### PR TITLE
[CINN] Optimize RS-layout configs for dynamic shape

### DIFF
--- a/paddle/cinn/ir/group_schedule/config/group_tile_config.cc
+++ b/paddle/cinn/ir/group_schedule/config/group_tile_config.cc
@@ -700,98 +700,63 @@ TileConfigMap BuildStaticSpatialConfig(
 TileConfigMap BuildStaticReduceConfig(
     const std::shared_ptr<ScheduleConfig::BaseInfo>& base_info,
     const common::Target& target) {
-  if (base_info->reduce_numel == 1) {
-    BucketInfo bucket_info__1_1023{/* sp_lower_bound = */ 1,
-                                   /* sp_upper_bound = */ 1023,
-                                   /* rb_lower_bound = */ 1,
-                                   /* rb_upper_bound = */ 1,
-                                   /* sp_is_dynamic = */ true,
-                                   /* rb_is_dynamic = */ false};
-    TileConfig tile_config__1_1023{/* warp_num = */ -1,
-                                   /* tree_reduce_num = */ 1,
-                                   /* grid_reduce_num = */ 1,
-                                   /* spatial_inner_num = */ 1,
-                                   /* vectorize_factor = */ 1,
-                                   /* reduce_inner_num = */ -1,
-                                   NoneReduceMethod()};
-    BucketInfo bucket_info__1024_INF{/* sp_lower_bound = */ 1024,
-                                     /* sp_upper_bound = */ kMaxNumel,
-                                     /* rb_lower_bound = */ 1,
-                                     /* rb_upper_bound = */ 1,
-                                     /* sp_is_dynamic = */ true,
-                                     /* rb_is_dynamic = */ false};
-    TileConfig tile_config__1024_INF{/* warp_num = */ 32,
-                                     /* tree_reduce_num = */ 1,
-                                     /* grid_reduce_num = */ 1,
-                                     /* spatial_inner_num = */ 4,
-                                     /* vectorize_factor = */ 1,
-                                     /* reduce_inner_num = */ -1,
-                                     NoneReduceMethod()};
-    return {{bucket_info__1_1023, tile_config__1_1023},
-            {bucket_info__1024_INF, tile_config__1024_INF}};
-  } else if (base_info->reduce_numel <= 256) {
-    BucketInfo bucket_info{/* sp_lower_bound = */ 1,
-                           /* sp_upper_bound = */ kMaxNumel,
-                           /* rb_lower_bound = */ 2,
-                           /* rb_upper_bound = */ 256,
-                           /* sp_is_dynamic = */ true,
-                           /* rb_is_dynamic = */ false};
-    TileConfig tile_config{
-        /* warp_num = */ 8,
-        /* tree_reduce_num = */ 32,
-        /* grid_reduce_num = */ 1,
-        /* spatial_inner_num = */ (256 / CeilPow2(base_info->reduce_numel)),
-        /* vectorize_factor = */ 1,
-        /* reduce_inner_num = */ -1,
-        WarpReduceMethod()};
-    return {{bucket_info, tile_config}};
-  } else if (base_info->reduce_numel <= 2048) {
-    int64_t reduce_block =
-        int64_t(std::ceil(base_info->reduce_numel * 1.0 / 256.0)) * 256;
-    int64_t warp_num = reduce_block / 256;
-    int64_t reduce_inner_num = 8;
-    int64_t tree_reduce_num = reduce_block / reduce_inner_num;
-    BucketInfo bucket_info{/* sp_lower_bound = */ 1,
-                           /* sp_upper_bound = */ kMaxNumel,
-                           /* rb_lower_bound = */ 257,
-                           /* rb_upper_bound = */ 2048,
-                           /* sp_is_dynamic = */ true,
-                           /* rb_is_dynamic = */ false};
-    TileConfig tile_config{warp_num,
-                           tree_reduce_num,
-                           /* grid_reduce_num = */ 1,
-                           /* spatial_inner_num */ 1,
-                           /* vectorize_factor = */ 1,
-                           /* reduce_inner_num = */ -1,
-                           BlockReduceMethod()};
-    return {{bucket_info, tile_config}};
-  } else {
-    BucketInfo bucket_info{/* sp_lower_bound = */ 1,
-                           /* sp_upper_bound = */ kMaxNumel,
-                           /* rb_lower_bound = */ 2049,
-                           /* rb_upper_bound = */ kMaxNumel,
-                           /* sp_is_dynamic = */ true,
-                           /* rb_is_dynamic = */ false};
-    TileConfig tile_config{/* warp_num = */ 32,
-                           /* tree_reduce_num = */ 1024,
-                           /* grid_reduce_num = */ 1,
-                           /* spatial_inner_num = */ 1,
-                           /* vectorize_factor = */ 1,
-                           /* reduce_inner_num = */ -1,
-                           BlockReduceMethod()};
-    return {{bucket_info, tile_config}};
+  const auto& last_dim = base_info->iter_space_type.back().first;
+
+  TileConfigCollector collector;
+  // { sp_lower, sp_upper, rd_lower, rd_upper },
+  // { warp, rd_thread, rd_block, sp_inner, vec_factor, rd_inner, rd_method }
+
+  if (last_dim == "R") {
+    if (base_info->reduce_numel <= 256) {
+      int64_t spatial_inner_num = 256 / CeilPow2(base_info->reduce_numel);
+      collector({1, kMaxNumel, 1, 256},
+                {8, 32, 1, spatial_inner_num, 1, -1, WarpReduceMethod()});
+    } else if (base_info->reduce_numel <= 2048) {
+      int64_t reduce_block = CeilDiv(base_info->reduce_numel, 256) * 256;
+      int64_t warp_num = reduce_block / 256;
+      int64_t reduce_inner_num = 8;
+      int64_t tree_reduce_num = reduce_block / reduce_inner_num;
+      collector({1, kMaxNumel, 257, 2048},
+                {warp_num, tree_reduce_num, 1, 1, 1, -1, BlockReduceMethod()});
+    } else {
+      collector({1, kMaxNumel, 2049, kMaxNumel},
+                {32, 1024, 1, 1, 1, -1, BlockReduceMethod()});
+    }
+  } else {  // last_dim == "S"
+    if (base_info->reduce_numel == 1) {
+      collector({1, 1023, 1, 1}, {-1, 1, 1, 1, 1, -1, NoneReduceMethod()});
+      collector({1024, kMaxNumel, 1, 1},
+                {32, 1, 1, 4, 1, -1, NoneReduceMethod()});
+    } else if (base_info->reduce_numel <= 16) {
+      collector({1, kMaxNumel, 1, 1}, {8, 1, 1, 1, 1, -1, NoneReduceMethod()});
+    } else {
+      collector({1, kMaxNumel, 1, 1},
+                {16, 16, 1, 1, 1, -1, DiscreteReduceMethod()});
+    }
   }
+
+  return collector.GetResult();
 }
 
 TileConfigMap BuildDynamicShapeConfig(
     const std::shared_ptr<ScheduleConfig::BaseInfo>& base_info,
     const common::Target& target) {
+  const auto& last_dim = base_info->iter_space_type.back().first;
+
   TileConfigCollector collector;
-  collector({1, kMaxNumel, 1, 256}, {8, 32, 1, 1, 1, 8, WarpReduceMethod()});
-  collector({1, kMaxNumel, 257, 2048},
-            {8, 256, 1, 1, 1, 8, BlockReduceMethod()});
-  collector({1, kMaxNumel, 2049, kMaxNumel},
-            {32, 1024, 1, 1, 1, -1, BlockReduceMethod()});
+  // { sp_lower, sp_upper, rd_lower, rd_upper },
+  // { warp, rd_thread, rd_block, sp_inner, vec_factor, rd_inner, rd_method }
+
+  if (last_dim == "R") {
+    collector({1, kMaxNumel, 1, 256}, {8, 32, 1, 1, 1, 8, WarpReduceMethod()});
+    collector({1, kMaxNumel, 257, 2048},
+              {8, 256, 1, 1, 1, 8, BlockReduceMethod()});
+    collector({1, kMaxNumel, 2049, kMaxNumel},
+              {32, 1024, 1, 1, 1, -1, BlockReduceMethod()});
+  } else {  // last_dim == "S"
+    collector({1, kMaxNumel, 1, kMaxNumel},
+              {16, 16, 1, 1, 1, -1, DiscreteReduceMethod()});
+  }
   return collector.GetResult();
 }
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
CINN


### PR Types
Performance


### Description
增加动态Shape下RS型Reduce的配置，并修复之前判断错SR/RS的bug

本PR内容：
1. `group_tile_util.cc`：之前在收集Load时用的是融合那边的接口，可能导致动态Shape下Layout判断错误，这里换成了自己实现的接口
2. `group_tile_config.cc`：为动态Shape增加了RS的配置，不然之前都是用SR的；我发现SR的配置也有点问题，不过考虑到PR的独立性没改，只是重构了一下
3. `tile_discrete_reduction_tactic.cc`：将原来固定的配置改成前面传过来的参数

<br>
Pcard-85711