### PR TITLE
[Dy2St] Support `element_size` method for value and breakgraph when access unknown tensor attr

### DIFF
--- a/paddle/fluid/pybind/pir.cc
+++ b/paddle/fluid/pybind/pir.cc
@@ -1556,6 +1556,8 @@ void BindValue(py::module *m) {
       .def("apply", &apply)
       .def("is_same", &Value::operator==)
       .def("hash", [](Value self) { return std::hash<pir::Value>{}(self); })
+      .def("element_size",
+           [](Value self) { return phi::SizeOf(pir::GetValueDtype(self)); })
       .def("_rename", &name_analysis::RenameValue)
       .def("_has_only_one_name",
            [](Value self) -> bool {

--- a/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
@@ -891,6 +891,7 @@ class OpcodeExecutorBase:
             if CALL_METHOD_LAYOUT_NULL_AFTER_VALUE:
                 self.stack.push(NullVariable())
 
+    @call_break_graph_decorator(push_n=2)
     def LOAD_METHOD(self, instr: Instruction):
         method_name = self.vframe.code.co_names[instr.arg]
         self.load_method(method_name)

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
@@ -48,7 +48,10 @@ from ....utils import (
     printable,
 )
 from ....utils.envs import ENV_SOT_BREAK_GRAPH_ON_GET_SYMBOLIC_VALUE
-from ....utils.exceptions import HasNoAttributeError, InnerError
+from ....utils.exceptions import (
+    InnerError,
+    UnsupportedPaddleAPIBreak,
+)
 from ..dispatch_functions import tensor_numel
 from ..guard import (
     FasterStringifiedExpression,
@@ -704,7 +707,9 @@ class TensorVariable(VariableBase):
             )
             return fn_var.bind(self, name)
         else:
-            raise HasNoAttributeError(f"Unknown Tensor attribute: {name}")
+            raise BreakGraphError(
+                UnsupportedPaddleAPIBreak(fn_name=f"Tensor.{name}")
+            )
 
     def setattr(self, key, val):
         # support tensor variable store attr, like:

--- a/test/dygraph_to_static/test_tensor_attr_consistency.py
+++ b/test/dygraph_to_static/test_tensor_attr_consistency.py
@@ -37,7 +37,6 @@ DYGRAPH_ONLY_TENSOR_ATTRS_ALLOW_LIST = OrderedSet(
         'data',
         'data_ptr',
         'detach_',
-        'element_size',
         'fill_',
         'fill_diagonal_',
         'fill_diagonal_tensor',

--- a/test/sot/test_18_tensor_method.py
+++ b/test/sot/test_18_tensor_method.py
@@ -57,6 +57,7 @@ def tensor_method_property_without_breakgraph(
         + a.ndim
         + a.dim()
         + a.rank(),
+        a.element_size(),
     )
 
 

--- a/test/sot/test_18_tensor_method.py
+++ b/test/sot/test_18_tensor_method.py
@@ -68,6 +68,7 @@ def tensor_method_property_with_breakgraph(a: paddle.Tensor, b: paddle.Tensor):
         a.tolist(),
         str(a.place),
         a.clear_gradient(),
+        a.is_dense(),
     )
 
 

--- a/test/sot/test_sot_exception.py
+++ b/test/sot/test_sot_exception.py
@@ -22,7 +22,7 @@ from paddle.jit.sot import symbolic_translate
 
 
 def case1(x):
-    return n  # noqa: F821
+    return undefined_var  # noqa: F821
 
 
 def case2(x):
@@ -31,7 +31,7 @@ def case2(x):
 
 
 def case3(x):
-    y = x.undefined_attr
+    y = undefined_var  # noqa: F821
     return y
 
 
@@ -39,7 +39,7 @@ def case4_inner(x):
     y = x * 2
     print()
     y = y + 1
-    return y.undefined_attr
+    return undefined_var  # noqa: F821
 
 
 def case4(x):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

静态图 `Value` 支持 `element_size` 方法，避免用户代码使用 `element_size` 时挂掉

为避免后续用户访问其他属性/方法时报错，将 `HasNoAttributeError` 改为 `UnsupportedPaddleAPIBreak`，以收紧正确性，如果真的发生了，后续能够从 PTS 上收集的打断类型感知到，以免用户用一个动静不统一的方法就报一个错