### PR TITLE
[PIR] fix full op logic  in ParseValueShape

### DIFF
--- a/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
@@ -3588,13 +3588,12 @@ std::vector<pir::Type> ExpandOp::InferMeta(
                            .dyn_cast<paddle::dialect::IntArrayAttribute>()
                            .data()
                            .GetData();
-      PADDLE_ENFORCE_LE(shape_vec.size(),
-                        1,
-                        common::errors::InvalidArgument(
-                            "The size of shape for Full op should be less than "
-                            "or equal to 1, but receive %d.",
-                            shape_vec.size()));
-      auto items = shape_vec.empty() ? 1 : shape_vec[0];
+      // TODO(ooooo): If can make sure shape_value's size is less than or equal
+      // to 1, can add a check here rather than product.
+      int64_t items = 1;
+      for (const auto &item : shape_vec) {
+        items *= item;
+      }
       vec_shape = std::vector<int64_t>(items, shape_item);
     } else if (shape.isa<pir::OpResult>() &&
                shape.defining_op()->isa<paddle::dialect::StackOp>()) {

--- a/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
@@ -3582,7 +3582,14 @@ std::vector<pir::Type> ExpandOp::InferMeta(
                             .dyn_cast<paddle::dialect::ScalarAttribute>()
                             .data()
                             .to<double>();
-      vec_shape = {static_cast<int64_t>(shape_item)};
+      auto items = shape.defining_op()
+                       ->dyn_cast<paddle::dialect::FullOp>()
+                       .attribute("shape")
+                       .dyn_cast<paddle::dialect::IntArrayAttribute>()
+                       .data()
+                       .GetData()
+                       .at(0);
+      vec_shape = std::vector<int64_t>(items, shape_item);
     } else if (shape.isa<pir::OpResult>() &&
                shape.defining_op()->isa<paddle::dialect::StackOp>()) {
       std::vector<pir::Value> inputs = shape.defining_op()

--- a/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
@@ -3582,13 +3582,13 @@ std::vector<pir::Type> ExpandOp::InferMeta(
                             .dyn_cast<paddle::dialect::ScalarAttribute>()
                             .data()
                             .to<double>();
-      auto items = shape.defining_op()
-                       ->dyn_cast<paddle::dialect::FullOp>()
-                       .attribute("shape")
-                       .dyn_cast<paddle::dialect::IntArrayAttribute>()
-                       .data()
-                       .GetData()
-                       .at(0);
+      auto shape_vec = shape.defining_op()
+                           ->dyn_cast<paddle::dialect::FullOp>()
+                           .attribute("shape")
+                           .dyn_cast<paddle::dialect::IntArrayAttribute>()
+                           .data()
+                           .GetData();
+      auto items = shape_vec.size() == 0 : 1 ? items[0];
       vec_shape = std::vector<int64_t>(items, shape_item);
     } else if (shape.isa<pir::OpResult>() &&
                shape.defining_op()->isa<paddle::dialect::StackOp>()) {

--- a/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
@@ -3588,7 +3588,7 @@ std::vector<pir::Type> ExpandOp::InferMeta(
                            .dyn_cast<paddle::dialect::IntArrayAttribute>()
                            .data()
                            .GetData();
-      auto items = shape_vec.size() == 0 : 1 ? items[0];
+      auto items = shape_vec.empty() ? 1 : shape_vec[0];
       vec_shape = std::vector<int64_t>(items, shape_item);
     } else if (shape.isa<pir::OpResult>() &&
                shape.defining_op()->isa<paddle::dialect::StackOp>()) {

--- a/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
@@ -3588,6 +3588,12 @@ std::vector<pir::Type> ExpandOp::InferMeta(
                            .dyn_cast<paddle::dialect::IntArrayAttribute>()
                            .data()
                            .GetData();
+      PADDLE_ENFORCE_LE(shape_vec.size(),
+                        1,
+                        common::errors::InvalidArgument(
+                            "The size of shape for Full op should be less than "
+                            "or equal to 1, but receive %d.",
+                            shape_vec.size()));
       auto items = shape_vec.empty() ? 1 : shape_vec[0];
       vec_shape = std::vector<int64_t>(items, shape_item);
     } else if (shape.isa<pir::OpResult>() &&

--- a/paddle/fluid/pir/dialect/operator/utils/utils.cc
+++ b/paddle/fluid/pir/dialect/operator/utils/utils.cc
@@ -426,7 +426,14 @@ std::vector<int64_t> ParseValueShape(const pir::Value& shape,
                           .dyn_cast<paddle::dialect::ScalarAttribute>()
                           .data()
                           .to<double>();
-    vec_shape = {static_cast<int64_t>(shape_item)};
+    auto items = shape.defining_op()
+                     ->dyn_cast<paddle::dialect::FullOp>()
+                     .attribute("shape")
+                     .dyn_cast<paddle::dialect::IntArrayAttribute>()
+                     .data()
+                     .GetData()
+                     .at(0);
+    vec_shape = std::vector<int64_t>(items, shape_item);
   } else if (shape.isa<pir::OpResult>() &&
              shape.defining_op()->isa<paddle::dialect::StackOp>()) {
     std::vector<pir::Value> inputs =

--- a/paddle/fluid/pir/dialect/operator/utils/utils.cc
+++ b/paddle/fluid/pir/dialect/operator/utils/utils.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <glog/logging.h>
+#include <cstdint>
 #include <sstream>
 #include <unordered_set>
 
@@ -432,13 +433,12 @@ std::vector<int64_t> ParseValueShape(const pir::Value& shape,
                          .dyn_cast<paddle::dialect::IntArrayAttribute>()
                          .data()
                          .GetData();
-    PADDLE_ENFORCE_LE(shape_vec.size(),
-                      1,
-                      common::errors::InvalidArgument(
-                          "The size of shape for Full op should be less than "
-                          "or equal to 1, but receive %d.",
-                          shape_vec.size()));
-    auto items = shape_vec.empty() ? 1 : shape_vec[0];
+    // TODO(ooooo): If can make sure shape_value's size is less than or equal
+    // to 1, can add a check here rather than product.
+    int64_t items = 1;
+    for (const auto& item : shape_vec) {
+      items *= item;
+    }
     vec_shape = std::vector<int64_t>(items, shape_item);
   } else if (shape.isa<pir::OpResult>() &&
              shape.defining_op()->isa<paddle::dialect::StackOp>()) {

--- a/paddle/fluid/pir/dialect/operator/utils/utils.cc
+++ b/paddle/fluid/pir/dialect/operator/utils/utils.cc
@@ -432,7 +432,7 @@ std::vector<int64_t> ParseValueShape(const pir::Value& shape,
                          .dyn_cast<paddle::dialect::IntArrayAttribute>()
                          .data()
                          .GetData();
-    auto items = shape_vec.size() == 0 : 1 ? items[0];
+    auto items = shape_vec.empty() ? 1 : shape_vec[0];
     vec_shape = std::vector<int64_t>(items, shape_item);
   } else if (shape.isa<pir::OpResult>() &&
              shape.defining_op()->isa<paddle::dialect::StackOp>()) {

--- a/paddle/fluid/pir/dialect/operator/utils/utils.cc
+++ b/paddle/fluid/pir/dialect/operator/utils/utils.cc
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <glog/logging.h>
-#include <cstdint>
 #include <sstream>
 #include <unordered_set>
 

--- a/paddle/fluid/pir/dialect/operator/utils/utils.cc
+++ b/paddle/fluid/pir/dialect/operator/utils/utils.cc
@@ -426,13 +426,13 @@ std::vector<int64_t> ParseValueShape(const pir::Value& shape,
                           .dyn_cast<paddle::dialect::ScalarAttribute>()
                           .data()
                           .to<double>();
-    auto items = shape.defining_op()
-                     ->dyn_cast<paddle::dialect::FullOp>()
-                     .attribute("shape")
-                     .dyn_cast<paddle::dialect::IntArrayAttribute>()
-                     .data()
-                     .GetData()
-                     .at(0);
+    auto shape_vec = shape.defining_op()
+                         ->dyn_cast<paddle::dialect::FullOp>()
+                         .attribute("shape")
+                         .dyn_cast<paddle::dialect::IntArrayAttribute>()
+                         .data()
+                         .GetData();
+    auto items = shape_vec.size() == 0 : 1 ? items[0];
     vec_shape = std::vector<int64_t>(items, shape_item);
   } else if (shape.isa<pir::OpResult>() &&
              shape.defining_op()->isa<paddle::dialect::StackOp>()) {

--- a/paddle/fluid/pir/dialect/operator/utils/utils.cc
+++ b/paddle/fluid/pir/dialect/operator/utils/utils.cc
@@ -432,6 +432,12 @@ std::vector<int64_t> ParseValueShape(const pir::Value& shape,
                          .dyn_cast<paddle::dialect::IntArrayAttribute>()
                          .data()
                          .GetData();
+    PADDLE_ENFORCE_LE(shape_vec.size(),
+                      1,
+                      common::errors::InvalidArgument(
+                          "The size of shape for Full op should be less than "
+                          "or equal to 1, but receive %d.",
+                          shape_vec.size()));
     auto items = shape_vec.empty() ? 1 : shape_vec[0];
     vec_shape = std::vector<int64_t>(items, shape_item);
   } else if (shape.isa<pir::OpResult>() &&


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Pcard-67164
- fix full op logic  in ParseValueShape
instance_norm 拆分之后出现的 Program，存在 full op 的shape 为 [2]，ParseValueShape解析出 reshape 的dims 是 [1,-1,1] ，实际上 rank 为 4

<img width="1121" alt="921619cd0374073b43cdea0148694e9c" src="https://github.com/user-attachments/assets/809ddd37-49a1-436b-aada-58349ef75383" />


