### PR TITLE
[Inference]Improve pir-trt performance Part-1

### DIFF
--- a/paddle/fluid/framework/new_executor/instruction/tensorrt_engine_instruction.h
+++ b/paddle/fluid/framework/new_executor/instruction/tensorrt_engine_instruction.h
@@ -42,7 +42,7 @@ class TensorRTEngineInstruction : public InstructionBase {
 
  private:
   std::string ReadBinaryFileToString(const std::string& filePath);
-  void PrepareDynamicShape();
+  void InputsCheck();
   void RunTrt();
   void BindInputTensor(const std::string& input_name,
                        const phi::DenseTensor& input_tensor,

--- a/paddle/fluid/pir/transforms/tensorrt/trt_op_marker_pass.cc
+++ b/paddle/fluid/pir/transforms/tensorrt/trt_op_marker_pass.cc
@@ -2374,13 +2374,7 @@ bool CheckSetValue(const pir::Operation *op, int starts_input_loc = 1) {
                "enter into trt.";
     return false;
   }
-  auto decrease_axes = op->attribute<pir::ArrayAttribute>("decrease_axes");
-  if (decrease_axes.size() != 0) {
-    VLOG(3) << "the set_value op doesn't support decrease_axes attribute "
-               "currently, it can not "
-               "enter into trt.";
-    return false;
-  }
+
   return true;
 }
 

--- a/paddle/fluid/pir/transforms/tensorrt/trt_op_marker_pass.cc
+++ b/paddle/fluid/pir/transforms/tensorrt/trt_op_marker_pass.cc
@@ -48,6 +48,7 @@ inline auto kCanRunTrtAttr = paddle::dialect::kCanRunTrtAttr;
   };
 
 DEFINE_GENERAL_PATTERN(Matmul, paddle::dialect::MatmulOp)
+DEFINE_GENERAL_PATTERN(Conv2d, paddle::dialect::Conv2dOp)
 DEFINE_GENERAL_PATTERN(BatchNorm, paddle::dialect::BatchNormOp)
 DEFINE_GENERAL_PATTERN(BatchNorm_, paddle::dialect::BatchNorm_Op)
 DEFINE_GENERAL_PATTERN(Softmax, paddle::dialect::SoftmaxOp)
@@ -453,22 +454,6 @@ class Pool2dOpPattern
                    "issues in TRT. Skip TRT conversion.";
         return false;
       }
-    }
-    op->set_attribute(kCanRunTrtAttr, rewriter.bool_attr(true));
-    return true;
-  }
-};
-
-class Conv2dOpPattern
-    : public pir::OpRewritePattern<paddle::dialect::Conv2dOp> {
- public:
-  using pir::OpRewritePattern<paddle::dialect::Conv2dOp>::OpRewritePattern;
-  bool MatchAndRewrite(paddle::dialect::Conv2dOp op,
-                       pir::PatternRewriter &rewriter) const override {
-    auto filter_define_op = pir::GetDefiningOpForInput(op, 1);
-    if (filter_define_op->name() != "builtin.parameter" &&
-        filter_define_op->name() != "builtin.constant") {
-      return false;
     }
     op->set_attribute(kCanRunTrtAttr, rewriter.bool_attr(true));
     return true;
@@ -3030,7 +3015,6 @@ class TrtOpMarkerPass : public pir::PatternRewritePass {
 #endif
 #undef ADD_PATTERN
     ps.Add(std::make_unique<Pool2dOpPattern>(context));
-    ps.Add(std::make_unique<Conv2dOpPattern>(context));
     ps.Add(std::make_unique<Conv2dTransposeOpPattern>(context));
     ps.Add(std::make_unique<DepthwiseConv2dTransposeOpPattern>(context));
     ps.Add(std::make_unique<DeformableConvOpPattern>(context));

--- a/python/paddle/tensorrt/converter_utils.py
+++ b/python/paddle/tensorrt/converter_utils.py
@@ -639,6 +639,11 @@ def convert_conv2d(network, paddle_op, inputs):
     pre_paddings = [0, 0]
     post_paddings = [0, 0]
 
+    if isinstance(filter, trt.Weights):
+        weight_filter = filter
+    else:
+        weight_filter = trt.Weights()
+
     if len(paddings) == 2:
         pre_paddings[0] = paddings[0]
         pre_paddings[1] = paddings[1]
@@ -661,7 +666,7 @@ def convert_conv2d(network, paddle_op, inputs):
             input=input_tensor,
             num_output_maps=n_output,
             kernel_shape=nv_ksize,
-            kernel=filter,
+            kernel=weight_filter,
             bias=bias,
         )
     elif (
@@ -672,10 +677,12 @@ def convert_conv2d(network, paddle_op, inputs):
             input=input_tensor,
             num_output_maps=n_input * groups,
             kernel_shape=nv_ksize,
-            kernel=filter,
+            kernel=weight_filter,
             bias=None,
         )
 
+    if isinstance(filter, trt.ITensor):
+        layer.set_input(1, filter)
     layer.stride_nd = nv_strides
     layer.pre_padding = pre_paddings
 

--- a/python/paddle/tensorrt/impls/others.py
+++ b/python/paddle/tensorrt/impls/others.py
@@ -32,6 +32,7 @@ from paddle.tensorrt.converter_utils import (
     trt_shape,
     trt_sub,
     trt_sum,
+    trt_unsqueeze,
 )
 from paddle.tensorrt.register import converter_registry
 
@@ -239,6 +240,15 @@ def set_value_converter(network, paddle_op, inputs):
         )
 
     _logger.info(f"Set_value_op: input's dimension is {input_dims}")
+
+    decrease_axes = paddle_op.attrs()["decrease_axes"]
+    if len(decrease_axes) > 0 and len(updates.shape) != len(x.shape):
+        updates = trt_unsqueeze(
+            network,
+            updates,
+            decrease_axes,
+            name=[paddle_op.name(), 'decrease_axes'],
+        )
 
     value_rank = len(updates.shape)
     input_rank = len(x.shape)

--- a/python/paddle/tensorrt/util.py
+++ b/python/paddle/tensorrt/util.py
@@ -282,7 +282,6 @@ def weight_to_tensor(network, paddle_value, trt_tensor, use_op_name):
     # the following op needn't cast trt.Weight to ITensor, because the layer need weight as input
     forbid_cast_op = [
         "pd_op.depthwise_conv2d",
-        "pd_op.conv2d",
         "pd_op.conv2d_transpose",
         "pd_op.conv3d",
         "pd_op.conv3d_transpose",


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->
card-71500

该PR做了如下工作：

- 简化TensorRTEngine Instruction中对输入预处理的冗余代码，减少copy操作
- 支持conv2d在filter为Itensor的场景系进入trt
- 支持set_value_with_tensor在decrease_axes存在场景下进入trt