### PR TITLE
[CINN]Enhance the symbol inference for control flow operations

### DIFF
--- a/paddle/fluid/pir/dialect/operator/ir/control_flow_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/control_flow_op.cc
@@ -458,7 +458,7 @@ bool IfOp::InferSymbolicShape(pir::InferSymbolicShapeContext *infer_context) {
   } else {
     PADDLE_THROW(
         common::errors::Unimplemented("IfOp::InferSymbolicShape: now only "
-                                      "support num_results() == 1."));
+                                      "support num_results() >= 1."));
   }
 }
 

--- a/paddle/fluid/pir/dialect/operator/ir/control_flow_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/control_flow_op.cc
@@ -340,59 +340,120 @@ bool IfOp::InferSymbolicShape(pir::InferSymbolicShapeContext *infer_context) {
   // infer false block
   pir::InferSymExprForBlock(false_block(), infer_context);
 
-  auto GetSymExprForBlockResult =
-      [infer_context](const pir::Operation &op,
-                      uint32_t idx) -> const std::vector<symbol::DimExpr> {
+  auto GetShapeDataForBlockResult = [infer_context](const pir::Operation &op,
+                                                    uint32_t idx) {
     const auto &operand_shape_data =
         infer_context->GetShapeOrDataForValue(op.operand_source(idx));
-    if (operand_shape_data.isa<symbol::NullShapeOrDataDimExpr>()) {
-      return {};
+    return operand_shape_data;
+  };
+
+  auto IsScalar = [](const symbol::ShapeOrDataDimExprs &shape_or_data) -> bool {
+    if (shape_or_data.isa<symbol::TensorShapeOrDataDimExprs>()) {
+      if (shape_or_data.data().has_value() && shape_or_data.shape().empty()) {
+        return true;
+      }
     }
-    return operand_shape_data.shape();
+    return false;
+  };
+
+  auto MergeShape =
+      [infer_context](const auto &true_dims,
+                      const auto &false_dims) -> std::vector<symbol::DimExpr> {
+    // merge shape for true and false block, new symbol will be assigned when
+    // the dims is not equal in true and false block, even if the dims are all
+    // constant, since we don't know which will be returned in compile time
+    // examples:
+    // true_block    false_block    return
+    // [1, 128]       [1, 256]      [1, S0]
+    // [1, S0]        [1, S1]       [1, S2]
+    // [1, S0]        [S1, S2]      [S1, S3]
+    // [1, S0]        [1, S0]       [1, S0]
+
+    std::vector<symbol::DimExpr> out_dims = true_dims;
+    if (false_dims.size() != 0) {
+      // now only support results of true and false block have same rank.
+      PADDLE_ENFORCE_EQ(true_dims.size(),
+                        false_dims.size(),
+                        common::errors::PreconditionNotMet(
+                            "The true and false block should have same rank, "
+                            "but got true_rank(%d) and false_rank(%d)",
+                            true_dims.size(),
+                            false_dims.size()));
+      for (size_t i = 0; i < true_dims.size(); i++) {
+        if (true_dims[i] != false_dims[i]) {
+          out_dims[i] = symbol::DimExpr{infer_context->GetNextSymName()};
+        }
+      }
+    }
+    return out_dims;
   };
 
   // TODO(lanxianghit): for llama, `if` op's result num always > 0, but
   // result_num == 0 should be supported in future
   if (num_results() > 0) {
     for (uint32_t rst_idx = 0; rst_idx < num_results(); rst_idx++) {
-      const auto &true_dims =
-          GetSymExprForBlockResult(true_block().back(), rst_idx);
-      const auto &false_dims =
-          GetSymExprForBlockResult(false_block().back(), rst_idx);
+      const auto &true_shape_data =
+          GetShapeDataForBlockResult(true_block().back(), rst_idx);
+      const auto &false_shape_data =
+          GetShapeDataForBlockResult(false_block().back(), rst_idx);
 
-      // merge shape for true and false block, new symbol will be assigned when
-      // the dims is not equal in true and false block, even if the dims are all
-      // constant, since we don't know which will be returned in compile time
-      // examples:
-      // true_block    false_block    return
-      // [1, 128]       [1, 256]      [1, S0]
-      // [1, S0]        [1, S1]       [1, S2]
-      // [1, S0]        [S1, S2]      [S1, S3]
-      // [1, S0]        [1, S0]       [1, S0]
-
-      std::vector<symbol::DimExpr> out_dims = true_dims;
-      if (false_dims.size() != 0) {
-        // now only support results of true and false block have same rank.
-        PADDLE_ENFORCE_EQ(true_dims.size(),
-                          false_dims.size(),
-                          common::errors::PreconditionNotMet(
-                              "The true and false block should have same rank, "
-                              "but got true_rank(%d) and false_rank(%d)",
-                              true_dims.size(),
-                              false_dims.size()));
-        for (size_t i = 0; i < true_dims.size(); i++) {
-          if (true_dims[i] != false_dims[i]) {
-            out_dims[i] = symbol::DimExpr{infer_context->GetNextSymName()};
-          }
+      if (true_shape_data.isa<symbol::TensorShapeOrDataDimExprs>() &&
+          false_shape_data.isa<symbol::TensorShapeOrDataDimExprs>()) {
+        // 0-D tensor
+        if (IsScalar(true_shape_data) && IsScalar(false_shape_data)) {
+          const auto &out_data = MergeShape(true_shape_data.data().value(),
+                                            false_shape_data.data().value());
+          infer_context->SetShapeOrDataForValue(
+              result(rst_idx),
+              symbol::ShapeOrDataDimExprs{
+                  symbol::TensorShapeOrDataDimExprs({}, out_data)});
         }
+
+        const auto &out_dims =
+            MergeShape(true_shape_data.shape(), false_shape_data.shape());
+        infer_context->SetShapeOrDataForValue(
+            result(rst_idx),
+            symbol::ShapeOrDataDimExprs{
+                symbol::TensorShapeOrDataDimExprs(out_dims)});
+      } else if (true_shape_data.isa<symbol::NullShapeOrDataDimExpr>() &&
+                 false_shape_data.isa<symbol::NullShapeOrDataDimExpr>()) {
+        infer_context->SetShapeOrDataForValue(
+            result(rst_idx),
+            symbol::ShapeOrDataDimExprs{symbol::NullShapeOrDataDimExpr()});
+      } else if (true_shape_data.isa<symbol::TensorListShapeOrDataDimExprs>() &&
+                 false_shape_data
+                     .isa<symbol::TensorListShapeOrDataDimExprs>()) {
+        const symbol::TensorListShapeOrDataDimExprs &true_list =
+            true_shape_data.dyn_cast<symbol::TensorListShapeOrDataDimExprs>();
+        const symbol::TensorListShapeOrDataDimExprs &false_list =
+            false_shape_data.dyn_cast<symbol::TensorListShapeOrDataDimExprs>();
+
+        PADDLE_ENFORCE_EQ(
+            true_list.size(),
+            false_list.size(),
+            common::errors::PreconditionNotMet(
+                "The result(%d) of true and false block should have same rank, "
+                "but got true_rank(%d) and false_rank(%d)",
+                rst_idx,
+                true_list.size(),
+                false_list.size()));
+        symbol::TensorListShapeOrDataDimExprs result_list(true_list.size());
+        for (int i = 0; i < true_list.size(); ++i) {
+          const auto &out_dims =
+              MergeShape(true_list[i].shape(), false_list[i].shape());
+          result_list[i] = symbol::TensorShapeOrDataDimExprs(out_dims);
+        }
+        infer_context->SetShapeOrDataForValue(
+            result(rst_idx), symbol::ShapeOrDataDimExprs{result_list});
+      } else {
+        PADDLE_THROW(common::errors::Unimplemented(
+            "IfOp::InferSymbolicShape: now only support "
+            "TensorShapeOrDataDimExprs, TensorListShapeOrDataDimExprs, "
+            "NullShapeOrDataDimExpr.Please check the type of %dth output of "
+            "true and false block.",
+            rst_idx));
       }
-
-      infer_context->SetShapeOrDataForValue(
-          result(rst_idx),
-          symbol::ShapeOrDataDimExprs{
-              symbol::TensorShapeOrDataDimExprs(out_dims)});
     }
-
     return true;
   } else {
     PADDLE_THROW(

--- a/paddle/fluid/pir/dialect/operator/ir/control_flow_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/control_flow_op.cc
@@ -438,7 +438,7 @@ bool IfOp::InferSymbolicShape(pir::InferSymbolicShapeContext *infer_context) {
                 true_list.size(),
                 false_list.size()));
         symbol::TensorListShapeOrDataDimExprs result_list(true_list.size());
-        for (int i = 0; i < true_list.size(); ++i) {
+        for (size_t i = 0; i < true_list.size(); ++i) {
           const auto &out_dims =
               MergeShape(true_list[i].shape(), false_list[i].shape());
           result_list[i] = symbol::TensorShapeOrDataDimExprs(out_dims);

--- a/paddle/fluid/pir/dialect/operator/ir/control_flow_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/control_flow_op.cc
@@ -342,9 +342,13 @@ bool IfOp::InferSymbolicShape(pir::InferSymbolicShapeContext *infer_context) {
 
   auto GetSymExprForBlockResult =
       [infer_context](const pir::Operation &op,
-                      uint32_t idx) -> const std::vector<symbol::DimExpr> & {
-    return infer_context->GetShapeOrDataForValue(op.operand_source(idx))
-        .shape();
+                      uint32_t idx) -> const std::vector<symbol::DimExpr> {
+    const auto &operand_shape_data =
+        infer_context->GetShapeOrDataForValue(op.operand_source(idx));
+    if (operand_shape_data.isa<symbol::NullShapeOrDataDimExpr>()) {
+      return {};
+    }
+    return operand_shape_data.shape();
   };
 
   // TODO(lanxianghit): for llama, `if` op's result num always > 0, but


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164
+ Process `Null Value` within the block of `IfOp`.