### PR TITLE
custom kernel modify ring_id

### DIFF
--- a/paddle/phi/kernels/custom/c_broadcast_kernel.cc
+++ b/paddle/phi/kernels/custom/c_broadcast_kernel.cc
@@ -28,24 +28,16 @@ namespace phi {
 template <typename T, typename Context>
 void CBroadcastKernel(const Context& dev_ctx,
                       const DenseTensor& x_in,
-                      int ring_id,
                       int root,
-                      bool use_calc_stream,
                       DenseTensor* out) {
   auto x = &x_in;
   const auto& place = dev_ctx.GetPlace();
   dev_ctx.template Alloc<T>(out);
-  int rid = ring_id;
   auto comm = reinterpret_cast<phi::distributed::XCCLCommContext*>(
-      phi::distributed::CommContextManager::GetInstance().Get(
-          std::to_string(rid)));
+      dev_ctx.GetCommContext());
 
   std::shared_ptr<phi::stream::Stream> stream;
-  if (use_calc_stream) {
-    stream = dev_ctx.GetStream();
-  } else {
-    stream = comm->GetStream();
-  }
+  stream = comm->GetStream();
 
   int numel = x->numel();
   auto dtype = x->dtype();

--- a/paddle/phi/kernels/custom/c_softmax_with_entropy_grad_kernel.cc
+++ b/paddle/phi/kernels/custom/c_softmax_with_entropy_grad_kernel.cc
@@ -31,7 +31,6 @@ void CSoftmaxWithEntropyGradKernel(const Context& dev_ctx,
                                    const DenseTensor& label_in,
                                    const DenseTensor& loss_grad_in,
                                    int64_t ignore_index,
-                                   int ring_id,
                                    int rank,
                                    int nranks,
                                    DenseTensor* logits_grad) {

--- a/paddle/phi/kernels/custom/global_gather_kernel.cc
+++ b/paddle/phi/kernels/custom/global_gather_kernel.cc
@@ -30,13 +30,10 @@ void GlobalGatherKernel(const Context& dev_ctx,
                         const DenseTensor& x_in,
                         const DenseTensor& local_count_in,
                         const DenseTensor& global_count_in,
-                        int ring_id,
-                        bool use_calc_stream,
                         DenseTensor* out) {
   auto x = &x_in;
   auto local_count = &local_count_in;
   auto global_count = &global_count_in;
-  const int rid = ring_id;
 
   auto place = dev_ctx.GetPlace();
 
@@ -69,158 +66,80 @@ void GlobalGatherKernel(const Context& dev_ctx,
     cpu_global_count_data = cpu_global_count.data<int64_t>();
   }
 
-  auto map = distributed::ProcessGroupMapFromGid::getInstance();
+  auto comm = reinterpret_cast<phi::distributed::XCCLCommContext*>(
+      dev_ctx.GetCommContext());
 
-  if (map->has(rid)) {
-    distributed::ProcessGroup* pg = map->get(rid);
-    auto stream =
-        reinterpret_cast<phi::CustomContext*>(pg->GetDeviceContext(place))
-            ->GetStream();
-    int nranks = pg->GetSize();
-    int rank = pg->GetRank();
-    auto in_feat = x->dims()[1];
-    auto n_expert = local_count->dims()[0] / nranks;
-    auto fwd_count = 0;
-    for (auto i = 0; i < local_count_len; ++i) {
-      fwd_count += cpu_local_count_data[i];
-    }
-    phi::DDim out_dims = common::make_ddim({fwd_count, in_feat});
-    int64_t* expert_ptr = new int64_t[n_expert * nranks];
-    expert_ptr[0] = 0;
-    auto tot_experts = n_expert * nranks;
-    for (auto i = 1; i < tot_experts; ++i) {
-      expert_ptr[i] = expert_ptr[i - 1] + cpu_local_count_data[i - 1];
-    }
-    auto send_ptr = 0;
-    out->Resize(out_dims);
-    dev_ctx.template Alloc<T>(out);
+  std::shared_ptr<phi::stream::Stream> stream;
+  stream = comm->GetStream();
 
-    for (auto i = 0; i < n_expert; ++i) {
-      for (auto j = 0; j < rank; ++j) {
-        int idx = i + j * n_expert;
-        if (cpu_local_count_data[idx]) {
-          pg->Recv(out,
-                   j,
-                   expert_ptr[idx] * in_feat,
-                   cpu_local_count_data[idx] * in_feat,
-                   /*sync_op*/ true);
-        }
-      }
-      for (auto j = 0; j < nranks; ++j) {
-        int idx = i + j * n_expert;
-        if (cpu_global_count_data[idx]) {
-          if (j != rank) {
-            phi::DenseTensor tmp = *x;
-            pg->Send(tmp,
-                     j,
-                     send_ptr * in_feat,
-                     cpu_global_count_data[idx] * in_feat,
-                     /*sync_op*/ true);
-          } else {
-            phi::DeviceManager::GetDeviceWithPlace(place)->MemoryCopyD2D(
-                reinterpret_cast<void*>(out->data<T>() +
-                                        expert_ptr[idx] * in_feat),
-                reinterpret_cast<const void*>(x->data<T>() +
-                                              send_ptr * in_feat),
-                (cpu_global_count_data[idx] * in_feat) *
-                    phi::SizeOf(x->dtype()),
-                stream.get());
-          }
-          send_ptr += cpu_global_count_data[idx];
-        }
-      }
-      for (auto j = rank + 1; j < nranks; ++j) {
-        int idx = i + j * n_expert;
-        if (cpu_local_count_data[idx]) {
-          pg->Recv(out,
-                   j,
-                   expert_ptr[idx] * in_feat,
-                   cpu_local_count_data[idx] * in_feat,
-                   /*sync_op*/ true);
-        }
+  int nranks = comm->GetSize();
+  int rank = comm->GetRank();
+  auto in_feat = x->dims()[1];
+  auto n_expert = local_count->dims()[0] / nranks;
+
+  auto fwd_count = 0;
+
+  for (auto i = 0; i < local_count_len; ++i) {
+    fwd_count += cpu_local_count_data[i];
+  }
+  phi::DDim out_dims = common::make_ddim({fwd_count, in_feat});
+  int64_t* expert_ptr = new int64_t[n_expert * nranks];
+  expert_ptr[0] = 0;
+  auto tot_experts = n_expert * nranks;
+  for (auto i = 1; i < tot_experts; ++i) {
+    expert_ptr[i] = expert_ptr[i - 1] + cpu_local_count_data[i - 1];
+  }
+  auto send_ptr = 0;
+  auto send_buf = x->data<T>();
+  out->Resize(out_dims);
+  auto recv_buf = dev_ctx.template Alloc<T>(out);
+
+  for (auto i = 0; i < n_expert; ++i) {
+    for (auto j = 0; j < rank + 1; ++j) {
+      int idx = i + j * n_expert;
+      if (cpu_local_count_data[idx]) {
+        phi::DeviceManager::CCLRecv(place.GetDeviceType(),
+                                    recv_buf + expert_ptr[idx] * in_feat,
+                                    cpu_local_count_data[idx] * in_feat,
+                                    x->dtype(),
+                                    j,
+                                    comm->GetXcclComm(),
+                                    *stream);
       }
     }
-  } else {
-    auto comm = reinterpret_cast<phi::distributed::XCCLCommContext*>(
-        phi::distributed::CommContextManager::GetInstance().Get(
-            std::to_string(rid)));
-
-    std::shared_ptr<phi::stream::Stream> stream;
-    if (use_calc_stream) {
-      stream = dev_ctx.GetStream();
-    } else {
-      stream = comm->GetStream();
-    }
-    int nranks = comm->GetSize();
-    int rank = comm->GetRank();
-    auto in_feat = x->dims()[1];
-    auto n_expert = local_count->dims()[0] / nranks;
-
-    auto fwd_count = 0;
-
-    for (auto i = 0; i < local_count_len; ++i) {
-      fwd_count += cpu_local_count_data[i];
-    }
-    phi::DDim out_dims = common::make_ddim({fwd_count, in_feat});
-    int64_t* expert_ptr = new int64_t[n_expert * nranks];
-    expert_ptr[0] = 0;
-    auto tot_experts = n_expert * nranks;
-    for (auto i = 1; i < tot_experts; ++i) {
-      expert_ptr[i] = expert_ptr[i - 1] + cpu_local_count_data[i - 1];
-    }
-    auto send_ptr = 0;
-    auto send_buf = x->data<T>();
-    out->Resize(out_dims);
-    auto recv_buf = dev_ctx.template Alloc<T>(out);
-
-    for (auto i = 0; i < n_expert; ++i) {
-      for (auto j = 0; j < rank + 1; ++j) {
-        int idx = i + j * n_expert;
-        if (cpu_local_count_data[idx]) {
-          phi::DeviceManager::CCLRecv(place.GetDeviceType(),
-                                      recv_buf + expert_ptr[idx] * in_feat,
-                                      cpu_local_count_data[idx] * in_feat,
-                                      x->dtype(),
-                                      j,
-                                      comm->GetXcclComm(),
-                                      *stream);
+    for (auto j = 0; j < nranks; ++j) {
+      int idx = i + j * n_expert;
+      if (cpu_global_count_data[idx]) {
+        if (j != rank) {
+          phi::DeviceManager::CCLSend(
+              place.GetDeviceType(),
+              const_cast<void*>(
+                  reinterpret_cast<const void*>(send_buf + send_ptr * in_feat)),
+              cpu_global_count_data[idx] * in_feat,
+              x->dtype(),
+              j,
+              comm->GetXcclComm(),
+              *stream);
+        } else {
+          phi::DeviceManager::GetDeviceWithPlace(place)->MemoryCopyD2D(
+              reinterpret_cast<void*>(recv_buf + expert_ptr[idx] * in_feat),
+              reinterpret_cast<const void*>(send_buf + send_ptr * in_feat),
+              (cpu_global_count_data[idx] * in_feat) * phi::SizeOf(x->dtype()),
+              stream.get());
         }
+        send_ptr += cpu_global_count_data[idx];
       }
-      for (auto j = 0; j < nranks; ++j) {
-        int idx = i + j * n_expert;
-        if (cpu_global_count_data[idx]) {
-          if (j != rank) {
-            phi::DeviceManager::CCLSend(
-                place.GetDeviceType(),
-                const_cast<void*>(reinterpret_cast<const void*>(
-                    send_buf + send_ptr * in_feat)),
-                cpu_global_count_data[idx] * in_feat,
-                x->dtype(),
-                j,
-                comm->GetXcclComm(),
-                *stream);
-          } else {
-            phi::DeviceManager::GetDeviceWithPlace(place)->MemoryCopyD2D(
-                reinterpret_cast<void*>(recv_buf + expert_ptr[idx] * in_feat),
-                reinterpret_cast<const void*>(send_buf + send_ptr * in_feat),
-                (cpu_global_count_data[idx] * in_feat) *
-                    phi::SizeOf(x->dtype()),
-                stream.get());
-          }
-          send_ptr += cpu_global_count_data[idx];
-        }
-      }
-      for (auto j = rank + 1; j < nranks; ++j) {
-        int idx = i + j * n_expert;
-        if (cpu_local_count_data[idx]) {
-          phi::DeviceManager::CCLRecv(place.GetDeviceType(),
-                                      recv_buf + expert_ptr[idx] * in_feat,
-                                      cpu_local_count_data[idx] * in_feat,
-                                      x->dtype(),
-                                      j,
-                                      comm->GetXcclComm(),
-                                      *stream);
-        }
+    }
+    for (auto j = rank + 1; j < nranks; ++j) {
+      int idx = i + j * n_expert;
+      if (cpu_local_count_data[idx]) {
+        phi::DeviceManager::CCLRecv(place.GetDeviceType(),
+                                    recv_buf + expert_ptr[idx] * in_feat,
+                                    cpu_local_count_data[idx] * in_feat,
+                                    x->dtype(),
+                                    j,
+                                    comm->GetXcclComm(),
+                                    *stream);
       }
     }
   }

--- a/paddle/phi/kernels/custom/mp_allreduce_sum_kernel.cc
+++ b/paddle/phi/kernels/custom/mp_allreduce_sum_kernel.cc
@@ -17,12 +17,8 @@ namespace phi {
 template <typename T, typename Context>
 void MpAllReduceSumKernel(const Context& dev_ctx,
                           const DenseTensor& x_in,
-                          int ring_id,
-                          bool use_calc_stream,
-                          bool use_model_parallel,
                           DenseTensor* out) {
-  CAllReduceKernel<T, Context, phi::ccl::CCLReduceOp::SUM>(
-      dev_ctx, x_in, ring_id, use_calc_stream, use_model_parallel, out);
+  AllReduceKernel<T, Context, phi::ccl::CCLReduceOp::SUM>(dev_ctx, x_in, out);
 }
 }  // namespace phi
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
https://github.com/PaddlePaddle/Paddle/issues/71631#issuecomment-2720742304
custom device部分通信库算子和GPU kernel中ring_id参数不一致，修改去掉ring_id参数，和GPU kernel保持一致
没有测试环境，需要提交后再找人测试

c_softmax_with_entropy 原有代码非ProcessGroup没有支持，修改为设置rid=0