### PR TITLE
[CINN] Fix buffer type assignment in Schedule

### DIFF
--- a/paddle/cinn/ir/group_schedule/tactic/tile_discrete_reduction_tactic.cc
+++ b/paddle/cinn/ir/group_schedule/tactic/tile_discrete_reduction_tactic.cc
@@ -234,22 +234,16 @@ void TileDiscreteReductionTactic::SplitReduceInner(
 
 void TileDiscreteReductionTactic::VariableTypeAssignment(
     ir::IRSchedule* sch, const std::string& block_id) {
-  const auto IsOutputTensor = [&](const std::string& tensor_name) -> bool {
-    return context_->output_names.count(tensor_name) > 0;
-  };
-  const auto HasConsumers = [&](const ir::Expr& block) -> bool {
-    return !ir::analyzer::GetConsumerSBlocks(block, sch->GetRootBlock(block))
-                .empty();
-  };
-
   auto block = sch->GetBlock(block_id);
-  if (!IsOutputTensor(block_id) && HasConsumers(block)) {
-    sch->SetBuffer(block, "local", false);
+  if (context_->output_names.count(block_id) > 0) {
+    sch->SetBuffer(block, "global");
+  } else {
+    sch->SetBuffer(block, "local");
   }
 
   if (map_rf_block_.count(block_id) > 0) {
     auto block = sch->GetBlock(map_rf_block_[block_id]);
-    sch->SetBuffer(block, "local", false);
+    sch->SetBuffer(block, "local");
   }
 }
 

--- a/paddle/cinn/ir/group_schedule/tactic/tile_first_general_tactic.cc
+++ b/paddle/cinn/ir/group_schedule/tactic/tile_first_general_tactic.cc
@@ -13,10 +13,6 @@
 // limitations under the License.
 
 #include "paddle/cinn/ir/group_schedule/tactic/tile_first_general_tactic.h"
-#include "paddle/cinn/adt/adt.h"
-#include "paddle/cinn/common/integer_set.h"
-#include "paddle/cinn/common/target.h"
-#include "paddle/cinn/ir/ir.h"
 #include "paddle/cinn/ir/ir_analyzer/ir_analyzer.h"
 #include "paddle/cinn/ir/schedule/ir_schedule_util.h"
 
@@ -277,22 +273,16 @@ void TileFirstGeneralTactic::MergeReduceAxis(ir::IRSchedule* sch,
 
 void TileFirstGeneralTactic::VariableTypeAssignment(
     ir::IRSchedule* sch, const std::string& block_id) {
-  const auto IsOutputTensor = [&](const std::string& tensor_name) -> bool {
-    return context_->output_names.count(tensor_name) > 0;
-  };
-  const auto HasConsumers = [&](const ir::Expr& block) -> bool {
-    return !ir::analyzer::GetConsumerSBlocks(block, sch->GetRootBlock(block))
-                .empty();
-  };
-
   auto block = sch->GetBlock(block_id);
-  if (!IsOutputTensor(block_id) && HasConsumers(block)) {
-    sch->SetBuffer(block, "local", false);
+  if (context_->output_names.count(block_id) > 0) {
+    sch->SetBuffer(block, "global");
+  } else {
+    sch->SetBuffer(block, "local");
   }
 
   if (map_rf_block_.count(block_id) > 0) {
     auto block = sch->GetBlock(map_rf_block_[block_id]);
-    sch->SetBuffer(block, "local", false);
+    sch->SetBuffer(block, "local");
   }
 }
 

--- a/paddle/cinn/ir/schedule/impl/storage.cc
+++ b/paddle/cinn/ir/schedule/impl/storage.cc
@@ -313,8 +313,10 @@ void DyScheduleImpl::SetBuffer(Expr& block,  // NOLINT
       }()));
 
   auto& tensor = (*find_tensor.begin()).As<ir::Store>()->tensor;
-  tensor.as_tensor_ref()->WithBuffer(
-      memory_type, "_" + tensor.as_tensor_ref()->name + "_temp_buffer");
+  if (memory_type == "local") {
+    tensor.as_tensor_ref()->WithBuffer(
+        memory_type, "_" + tensor.as_tensor_ref()->name + "_temp_buffer");
+  }
 
   auto exprs = this->GetModule().GetExprs();
   for (auto& it_expr : exprs) {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
CINN


### PR Types
Bug fixes


### Description
调度阶段原先对于全局变量是不设置buffer类型的，由于以前从Reduce到写回全局变量之间有一条`yield_store`作中继，所以不设置也没问题

但融合那边把`yield_store`去掉之后，不设置buffer类型会导致reduce_init没法和reduce本体绑定在一起，导致reduce_init丢失，因此现在改成显式设置global buffer

另外，tile_first_general和tile_discrete现在有一些重复代码，不过之后这两个文件应该会区别越来越大，所以就这样留着了，之后用新ir重构这两个文件的时候再统一把步骤优化下

<br>
Pcard-85711