### PR TITLE
[SOT][Dist] Add guard for dist tensor

### DIFF
--- a/paddle/fluid/pybind/eager_method.cc
+++ b/paddle/fluid/pybind/eager_method.cc
@@ -398,6 +398,31 @@ static PyObject* tensor_method_numpy(TensorObject* self,
                            dense_tensor->place(),
                            dense_tensor->Holder()->ptr(),
                            dense_tensor->Holder()->size());
+    } else if (self->tensor.is_dist_tensor()) {
+#ifdef PADDLE_WITH_DISTRIBUTE
+      VLOG(6) << "Getting DistTensor's numpy value";
+      auto* dist_tensor =
+          static_cast<phi::distributed::DistTensor*>(self->tensor.impl().get());
+      auto dense_tensor = ReshardXToReplicated(dist_tensor);
+
+      cpu_tensor.set_meta(dense_tensor.meta());
+      auto tmp_allocation_ptr =
+          memory::Alloc(cpu_place, dense_tensor.Holder()->size());
+      cpu_tensor.ResetHolder(std::shared_ptr<phi::Allocation>(
+          tmp_allocation_ptr.release(), tmp_allocation_ptr.get_deleter()));
+      paddle::memory::Copy(place,
+                           cpu_tensor.Holder()->ptr(),
+                           dense_tensor.place(),
+                           dense_tensor.Holder()->ptr(),
+                           dense_tensor.Holder()->size());
+#else
+      PADDLE_THROW(
+          common::errors::Unavailable("The `numpy()` method of (Dist)Tensor "
+                                      "is not supported in the current "
+                                      "PaddlePaddle, please recompile and "
+                                      "installPaddlePaddle with the option "
+                                      "of `WITH_DISTRIBUTE=ON`."));
+#endif
     } else {
       VLOG(6) << "Getting DenseTensor's numpy value";
       auto dense_tensor =

--- a/test/sot/test_sot_distribution.py
+++ b/test/sot/test_sot_distribution.py
@@ -29,15 +29,25 @@ def fn(x, y):
     return x + y
 
 
+@unittest.skipIf(
+    not paddle.is_compiled_with_distribute(),
+    reason='Not compiled with distribute.',
+)
 class TestGuardForDistInfo(TestCaseBase):
     def test_fn(self):
         x = paddle.ones([2, 2])
+        x.stop_gradient = False
         y = paddle.zeros([2, 2])
+        y.stop_gradient = False
         mesh1 = dist.ProcessMesh([0, 1], dim_names=['x'])
         mesh2 = dist.ProcessMesh([0, 1], dim_names=['y'])
         mesh3 = dist.ProcessMesh([0, 2], dim_names=['x'])
-        dist_x1 = dist.shard_tensor(x, mesh1, [dist.Replicate()])
-        dist_y1 = dist.shard_tensor(y, mesh1, [dist.Replicate()])
+        dist_x1 = dist.shard_tensor(
+            x, mesh1, [dist.Replicate()], stop_gradient=False
+        )
+        dist_y1 = dist.shard_tensor(
+            y, mesh1, [dist.Replicate()], stop_gradient=False
+        )
         dist_x2 = dist.shard_tensor(x, mesh2, [dist.Replicate()])
         dist_y2 = dist.shard_tensor(y, mesh2, [dist.Replicate()])
         dist_x3 = dist.shard_tensor(x, mesh3, [dist.Replicate()])

--- a/test/sot/test_sot_distribution.py
+++ b/test/sot/test_sot_distribution.py
@@ -24,17 +24,13 @@ import paddle.distributed as dist
 from paddle.jit.sot.psdb import check_no_breakgraph
 
 
-def apply_fn(fn, x, y):
-    return fn(x, y)
-
-
 @check_no_breakgraph
-def fn1(x, y):
+def fn(x, y):
     return x + y
 
 
-class TestApplyDifferentFunctions(TestCaseBase):
-    def test_apply_fn(self):
+class TestGuardForDistInfo(TestCaseBase):
+    def test_fn(self):
         x = paddle.ones([2, 2])
         y = paddle.zeros([2, 2])
         mesh1 = dist.ProcessMesh([0, 1], dim_names=['x'])
@@ -48,11 +44,11 @@ class TestApplyDifferentFunctions(TestCaseBase):
         dist_y3 = dist.shard_tensor(y, mesh3, [dist.Replicate()])
         with test_instruction_translator_cache_context() as ctx:
             self.assertEqual(ctx.translate_count, 0)
-            self.assert_results(apply_fn, fn1, dist_x1, dist_y1)
+            self.assert_results(fn, dist_x1, dist_y1)
             self.assertEqual(ctx.translate_count, 1)
-            self.assert_results(apply_fn, fn1, dist_x2, dist_y2)
+            self.assert_results(fn, dist_x2, dist_y2)
             self.assertEqual(ctx.translate_count, 1)
-            self.assert_results(apply_fn, fn1, dist_x3, dist_y3)
+            self.assert_results(fn, dist_x3, dist_y3)
             self.assertEqual(ctx.translate_count, 2)
 
 

--- a/test/sot/test_sot_distribution.py
+++ b/test/sot/test_sot_distribution.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from test_case_base import (
+    TestCaseBase,
+    test_instruction_translator_cache_context,
+)
+
+import paddle
+import paddle.distributed as dist
+from paddle.jit.sot.psdb import check_no_breakgraph
+
+
+def apply_fn(fn, x, y):
+    return fn(x, y)
+
+
+@check_no_breakgraph
+def fn1(x, y):
+    return x + y
+
+
+class TestApplyDifferentFunctions(TestCaseBase):
+    def test_apply_fn(self):
+        x = paddle.ones([2, 2])
+        y = paddle.zeros([2, 2])
+        mesh1 = dist.ProcessMesh([0, 1], dim_names=['x'])
+        mesh2 = dist.ProcessMesh([0, 1], dim_names=['y'])
+        mesh3 = dist.ProcessMesh([0, 2], dim_names=['x'])
+        dist_x1 = dist.shard_tensor(x, mesh1, [dist.Replicate()])
+        dist_y1 = dist.shard_tensor(y, mesh1, [dist.Replicate()])
+        dist_x2 = dist.shard_tensor(x, mesh2, [dist.Replicate()])
+        dist_y2 = dist.shard_tensor(y, mesh2, [dist.Replicate()])
+        dist_x3 = dist.shard_tensor(x, mesh3, [dist.Replicate()])
+        dist_y3 = dist.shard_tensor(y, mesh3, [dist.Replicate()])
+        with test_instruction_translator_cache_context() as ctx:
+            self.assertEqual(ctx.translate_count, 0)
+            self.assert_results(apply_fn, fn1, dist_x1, dist_y1)
+            self.assertEqual(ctx.translate_count, 1)
+            self.assert_results(apply_fn, fn1, dist_x2, dist_y2)
+            self.assertEqual(ctx.translate_count, 1)
+            self.assert_results(apply_fn, fn1, dist_x3, dist_y3)
+            self.assertEqual(ctx.translate_count, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
Pcard-67164
Support check distributed info of tensor in TensorVariable Guard

**Note**
- [ ] To deal with the scenario where the operand is a fake value in func `_complete_op_dist_attr`  of the `mix_to_dist_pass` in future. 

```python
def _complete_op_dist_attr(program, block=None):
    ...
    for op in block.ops:
      ...
            for operand in op.operands_source():
                tmp_attr = operand.dist_attr() 
                if tmp_attr is None:
                    operand_attrs.append(pir.Attribute())
                    value_mesh = None
                    tmp_op_dist_attr = operand.get_defining_op().dist_attr # error occurs when operand is a fake value
                    if tmp_op_dist_attr is not None:
                        value_mesh = tmp_op_dist_attr.process_mesh
                else:
                    operand_attrs.append(tmp_attr)
                    value_mesh = tmp_attr.process_mesh
                if value_mesh is not None and value_mesh not in meshes:
                    meshes.append(value_mesh)
            ...
```