### PR TITLE
[SOT] Re-format `ObjectVariable` in builtin dispatch pattern

### DIFF
--- a/python/paddle/jit/sot/utils/__init__.py
+++ b/python/paddle/jit/sot/utils/__init__.py
@@ -80,6 +80,7 @@ from .utils import (  # noqa: F401
     flatten_extend,
     get_api_fullname,
     get_numpy_ufuncs,
+    get_obj_stable_repr,
     get_unbound_method,
     hashable,
     in_paddle_module,

--- a/python/paddle/jit/sot/utils/utils.py
+++ b/python/paddle/jit/sot/utils/utils.py
@@ -416,3 +416,20 @@ def get_numpy_ufuncs():
     unary_ufuncs = filter(lambda ufunc: ufunc.nin == 1, ufuncs)
     binary_ufuncs = filter(lambda ufunc: ufunc.nin == 2, ufuncs)
     return list(unary_ufuncs), list(binary_ufuncs)
+
+
+def get_obj_stable_repr(obj) -> str:
+    if hasattr(obj, '__qualname__'):
+        return obj.__qualname__
+    if hasattr(obj, '__name__'):
+        return obj.__name__
+
+    class_name = obj.__class__.__name__
+
+    # If module is available and not __main__, include it
+    if hasattr(obj, "__class__") and hasattr(obj.__class__, "__module__"):
+        module = obj.__class__.__module__
+        if module not in ("__main__", "builtins"):
+            return f"{module}.{class_name}()"
+
+    return f"{class_name}()"


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->

之前统计的子图中，部分函数如 `values` 只能看到是 `ObjectVariable` 不支持，不能看到具体是哪一类不支持 `values`
```python
{'BuiltinFunctionBreak': {
'Not support builtin function: __bool__ with args: Args(ObjectVariable)': 50,
'Not support builtin function: get_device_id with args: Args(ObjectVariable)': 142,
'Not support builtin function: items with args: Args(ObjectVariable)': 31,
'Not support builtin function: load_op_meta_info_and_register_op with args: Args(ConstantVariable)': 8,
'Not support builtin function: super with args: Args(ClassVariable, UserDefinedLayerVariable)': 100,
'Not support builtin function: tolist with args: Args(NumpyArrayVariable)': 22,
'Not support builtin function: values with args: Args(ObjectVariable)': 198},
}
```

本PR修改其 format 形式，提高DEBUG日志的可读性