### PR TITLE
[Dy2St] Move `run_program` API to `_C_ops` namespace

### DIFF
--- a/paddle/fluid/eager/to_static/run_program_op_func.h
+++ b/paddle/fluid/eager/to_static/run_program_op_func.h
@@ -190,7 +190,7 @@ static std::vector<paddle::Tensor> Trans2ContiguousTensors(
   return res;
 }
 
-int64_t hash_with_seed(int64_t value, int64_t seed) {
+static int64_t hash_with_seed(int64_t value, int64_t seed) {
   return seed + 0x9e3779b9 + (value << 6) + (value >> 2);
 }
 

--- a/paddle/fluid/eager/to_static/run_program_op_node.h
+++ b/paddle/fluid/eager/to_static/run_program_op_node.h
@@ -494,13 +494,6 @@ inline void PirRunProgramAPI(
 
     details::print_collection(skip_names_set);
     interpreter_core->SetSkipGcVars(skip_names_set);
-
-    // std::set<std::string> input_vars;
-    // input_vars.insert(input_names.begin(), input_names.end());
-    // interpreter_core->SetJitInputVars(input_vars);
-
-    // cache.UpdateSkipEagerDeleteVars(
-    // program_id, global_inner_scope, false, skip_eager_delete_vars);
   } else {
     phi::RecordEvent record_event(
         "get_interpretercore_cache", phi::TracerEventType::UserDefined, 1);
@@ -516,13 +509,6 @@ inline void PirRunProgramAPI(
     details::ShareTensorsIntoScopeByValue(x, input_values, global_inner_scope);
     details::ShareTensorsIntoScopeByValue(
         params, param_values, global_inner_scope);
-    // TODO(xiongkun): new ir how to build scope.
-    // if (interpreter_core->GetVariableScope()->GetMutableScope() !=
-    // global_inner_scope) {
-    // details::BuildScopeByBlock(
-    // *interpreter_core.get(), *forward_global_block, global_inner_scope);
-    // interpreter_core->reset_scope(global_inner_scope);
-    //}
   }
 
   paddle::framework::RunFeedHooks(*forward_program, *global_inner_scope);
@@ -1071,9 +1057,6 @@ inline void PirRunProgramGradAPI(
 
     if (interpreter_core->GetVariableScope()->GetMutableScope() !=
         global_inner_scope) {
-      // update scope (TODO(xiongkun): do we need this??)
-      // details::BuildScopeByBlock(
-      // *interpreter_core.get(), *backward_global_block, global_inner_scope);
       interpreter_core->reset_scope(global_inner_scope);
     }
   }

--- a/paddle/fluid/pybind/eager_custom_python_api.h
+++ b/paddle/fluid/pybind/eager_custom_python_api.h
@@ -77,9 +77,9 @@ static PyObject *eager_api_linear(PyObject *self,
   }
 }
 
-static PyObject *pir_eager_api_run_program(PyObject *self,
-                                           PyObject *args,
-                                           PyObject *kwargs) {
+static PyObject *eager_api_run_program(PyObject *self,
+                                       PyObject *args,
+                                       PyObject *kwargs) {
   PyThreadState *tstate = nullptr;
   try {
     auto X = GetTensorListFromArgs("run_program", "X", args, 0, true);
@@ -130,7 +130,7 @@ static PyMethodDef CustomEagerFinalStateMethods[] = {
      METH_VARARGS | METH_KEYWORDS,
      "C++ interface function for linear."},
     {"run_program",
-     (PyCFunction)(void (*)(void))pir_eager_api_run_program,
+     (PyCFunction)(void (*)(void))eager_api_run_program,
      METH_VARARGS | METH_KEYWORDS,
      "C++ interface function for run_program in dygraph."},
     {nullptr, nullptr, 0, nullptr}};

--- a/paddle/fluid/pybind/eager_custom_python_api.h
+++ b/paddle/fluid/pybind/eager_custom_python_api.h
@@ -15,6 +15,7 @@
 
 #include <iostream>
 
+#include "paddle/fluid/eager/to_static/run_program_op_func.h"
 #include "paddle/fluid/eager/utils.h"
 #include "paddle/phi/core/enforce.h"
 
@@ -76,9 +77,60 @@ static PyObject *eager_api_linear(PyObject *self,
   }
 }
 
+static PyObject *pir_eager_api_run_program(PyObject *self,
+                                           PyObject *args,
+                                           PyObject *kwargs) {
+  PyThreadState *tstate = nullptr;
+  try {
+    auto X = GetTensorListFromArgs("run_program", "X", args, 0, true);
+    auto Params = GetTensorListFromArgs("run_program", "Params", args, 1, true);
+    auto Out = GetTensorPtrListFromArgs("run_program", "Out", args, 2, true);
+    auto OutScope =
+        GetScopePtrListFromArgs("run_program", "OutScope", args, 3, false);
+    const phi::distributed::ProcessMesh *mesh = nullptr;
+    if (InputsContainDistTensor(&mesh, X, Params, Out)) {
+      X = GetTensorListFromArgs("run_program", "X", args, 0, true, mesh);
+      Params =
+          GetTensorListFromArgs("run_program", "Params", args, 1, true, mesh);
+      Out = GetTensorPtrListFromArgs("run_program", "Out", args, 2, true, mesh);
+    }
+    framework::AttributeMap attrs;
+    VLOG(6) << "Start PIR ConstructAttrMapFromPyArgs";
+    ConstructAttrMapForRunProgram(
+        "run_program", args, 4, PyTuple_GET_SIZE(args), attrs);
+
+    VLOG(6) << "Finish Pir ConstructAttrMapFromPyArgs";
+    tstate = PyEval_SaveThread();
+    pir_run_program_ad_func(X, Params, Out, OutScope, attrs);
+    PyEval_RestoreThread(tstate);
+    tstate = nullptr;
+    Py_RETURN_NONE;
+  } catch (paddle::platform::EnforceNotMet &exception) {
+    if (tstate) {
+      PyEval_RestoreThread(tstate);
+    }
+    std::ostringstream sout;
+    sout << exception.what();
+    sout << "  [operator < run_program > error]";
+    exception.set_error_str(sout.str());
+    ThrowExceptionToPython(std::current_exception());
+    return nullptr;
+  } catch (...) {
+    if (tstate) {
+      PyEval_RestoreThread(tstate);
+    }
+    ThrowExceptionToPython(std::current_exception());
+    return nullptr;
+  }
+}
+
 static PyMethodDef CustomEagerFinalStateMethods[] = {
     {"linear",
      (PyCFunction)(void (*)(void))eager_api_linear,
+     METH_VARARGS | METH_KEYWORDS,
+     "C++ interface function for linear."},
+    {"run_program",
+     (PyCFunction)(void (*)(void))pir_eager_api_run_program,
      METH_VARARGS | METH_KEYWORDS,
      "C++ interface function for run_program in dygraph."},
     {nullptr, nullptr, 0, nullptr}};

--- a/paddle/fluid/pybind/eager_legacy_custom_python_api.h
+++ b/paddle/fluid/pybind/eager_legacy_custom_python_api.h
@@ -71,62 +71,9 @@ static PyObject *eager_api_run_program(PyObject *self,  // TOREMOVE
   }
 }
 
-static PyObject *pir_eager_api_run_program(PyObject *self,
-                                           PyObject *args,
-                                           PyObject *kwargs) {
-  PyThreadState *tstate = nullptr;
-  try {
-    auto X = GetTensorListFromArgs("run_program", "X", args, 0, true);
-    auto Params = GetTensorListFromArgs("run_program", "Params", args, 1, true);
-    auto Out = GetTensorPtrListFromArgs("run_program", "Out", args, 2, true);
-    auto OutScope =
-        GetScopePtrListFromArgs("run_program", "OutScope", args, 3, false);
-    const phi::distributed::ProcessMesh *mesh = nullptr;
-    if (InputsContainDistTensor(&mesh, X, Params, Out)) {
-      X = GetTensorListFromArgs("run_program", "X", args, 0, true, mesh);
-      Params =
-          GetTensorListFromArgs("run_program", "Params", args, 1, true, mesh);
-      Out = GetTensorPtrListFromArgs("run_program", "Out", args, 2, true, mesh);
-    }
-    framework::AttributeMap attrs;
-    // TODO(zengjinle): support CUDA Graph on eager mode
-    VLOG(6) << "Start Pir ConstructAttrMapFromPyArgs";
-
-    ConstructAttrMapForRunProgram(
-        "run_program", args, 5, PyTuple_GET_SIZE(args), attrs);
-
-    VLOG(6) << "Finish Pir ConstructAttrMapFromPyArgs";
-    tstate = PyEval_SaveThread();
-    pir_run_program_ad_func(X, Params, Out, OutScope, attrs);
-    PyEval_RestoreThread(tstate);
-    tstate = nullptr;
-    Py_RETURN_NONE;
-  } catch (paddle::platform::EnforceNotMet &exception) {
-    if (tstate) {
-      PyEval_RestoreThread(tstate);
-    }
-    std::ostringstream sout;
-    sout << exception.what();
-    sout << "  [operator < run_program > error]";
-    exception.set_error_str(sout.str());
-    ThrowExceptionToPython(std::current_exception());
-    return nullptr;
-  } catch (...) {
-    if (tstate) {
-      PyEval_RestoreThread(tstate);
-    }
-    ThrowExceptionToPython(std::current_exception());
-    return nullptr;
-  }
-}
-
 static PyMethodDef CustomEagerMethods[] = {
     {"run_program",
      (PyCFunction)(void (*)(void))eager_api_run_program,
-     METH_VARARGS | METH_KEYWORDS,
-     "C++ interface function for run_program in dygraph."},
-    {"pir_run_program",
-     (PyCFunction)(void (*)(void))pir_eager_api_run_program,
      METH_VARARGS | METH_KEYWORDS,
      "C++ interface function for run_program in dygraph."},
     {nullptr, nullptr, 0, nullptr}};

--- a/python/paddle/jit/dy2static/pir_partial_program.py
+++ b/python/paddle/jit/dy2static/pir_partial_program.py
@@ -22,7 +22,7 @@ import numpy as np
 
 import paddle
 import paddle.pir.core as ir_static
-from paddle import _legacy_C_ops
+from paddle import _C_ops
 from paddle.autograd.backward_utils import ValueDict
 from paddle.autograd.ir_backward import grad
 from paddle.base import core, framework
@@ -687,10 +687,6 @@ class PartialProgramLayer:
         if parameters is not None:
             parameters[0][:] = self._params
             parameters[1][:] = self._param_values
-        with paddle.base.framework._dygraph_guard(paddle.base.dygraph.Tracer()):
-            self._cuda_graph_vec = self._create_cuda_graph_vec()
-        self._cuda_graph_capture_mode = ""
-        self._cuda_graph_pool_id = 0
         # Set default mode to train
         self.training = True
         self._program_extra_info = {}
@@ -724,7 +720,7 @@ class PartialProgramLayer:
         out_vars = self._prepare_outputs()
         attrs = self._prepare_attributes(in_sot_mode=False)
         inputs = self._valid_vars(in_vars)
-        _legacy_C_ops.pir_run_program(
+        _C_ops.run_program(
             inputs,
             self._valid_vars(self._params),
             self._valid_vars(out_vars),
@@ -736,7 +732,6 @@ class PartialProgramLayer:
                 ),
                 use_scope_cache=True,
             ),
-            self._cuda_graph_vec,
             *attrs,
         )
         restored_nest_out = self._restore_out(out_vars)
@@ -749,7 +744,7 @@ class PartialProgramLayer:
         out_vars = self._prepare_outputs()
         attrs = self._prepare_attributes(in_sot_mode=True)
         inputs = self._valid_vars(inputs)
-        _legacy_C_ops.pir_run_program(
+        _C_ops.run_program(
             inputs,
             self._valid_vars(self._params),
             self._valid_vars(out_vars),
@@ -761,7 +756,6 @@ class PartialProgramLayer:
                 ),
                 use_scope_cache=True,
             ),
-            self._cuda_graph_vec,
             *attrs,
         )
         return self._outputs.quick_restore(out_vars)
@@ -847,7 +841,7 @@ class PartialProgramLayer:
                 pm = paddle.pir.PassManager(2)
                 pm.add_pass("auto_layout_pass", {})
                 pm.run(train_program.program)
-            train_program = self._append_backward_desc(train_program)
+            train_program = self._append_backward(train_program)
             # Note: Only set grad type once after initializing train program. So we put it here.
             self._set_grad_type(self._params, train_program)
 
@@ -978,7 +972,7 @@ class PartialProgramLayer:
         return main_program
 
     @switch_to_static_graph
-    def _append_backward_desc(
+    def _append_backward(
         self, train_runnable_program: RunnableProgram
     ) -> RunnableProgram:
         program = train_runnable_program.program
@@ -1141,16 +1135,6 @@ class PartialProgramLayer:
         for key, val in self.program.program_attr.items():
             attrs.append(key)
             attrs.append(val)
-
-        if self._cuda_graph_capture_mode:
-            attrs.extend(
-                (
-                    'cuda_graph_capture_mode',
-                    self._cuda_graph_capture_mode,
-                    'cuda_graph_pool_id',
-                    self._cuda_graph_pool_id,
-                )
-            )
         return attrs
 
     def _prepare_inputs(self, inputs):
@@ -1198,17 +1182,6 @@ class PartialProgramLayer:
             cache_key=cache_key, use_scope_cache=use_scope_cache
         )
         return [inner_scope]
-
-    def _create_cuda_graph_vec(self):
-        var = core.eager.Tensor(
-            core.VarDesc.VarType.FP32,
-            [],
-            "cuda_graph",
-            core.VarDesc.VarType.RAW,
-            True,
-        )
-        var.stop_gradient = True
-        return var
 
     def _restore_out(self, out_vars):
         """


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

将 `run_program` API 移到 `_C_ops` 下，并清理无用的 `cuda_graph_vec`

为 #71506 的拆分，那边还有些问题，这部分独立先拆出来