### PR TITLE
[SOT][Guard] `np.bool` conversion error in `NumpyVariable.format_dtype` in numpy `1.20.0+`

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
@@ -1221,6 +1221,11 @@ class NumpyVariable(VariableBase):
 
     @staticmethod
     def format_dtype(dtype: np.dtype):
+        if (
+            np.lib.NumpyVersion(np.__version__) >= "1.20.0"
+            and dtype == np.bool_
+        ):
+            return "np.bool_"
         return f"np.{dtype}"
 
     @staticmethod


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

修复 `Numpyvarial.format_dtype` 中的 `np.bool` 转换错误，参考 [numpy release](https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations) 还有一些可能也需要替换

* 已知使用 `dtype.type` 可以拿到 `<class 'numpy.bool_'>`
