### PR TITLE
[fixbugs] Adjusting the timeout of test_trt_convert_compare_logical

### DIFF
--- a/test/ir/inference/CMakeLists.txt
+++ b/test/ir/inference/CMakeLists.txt
@@ -170,11 +170,17 @@ if(WITH_GPU AND TENSORRT_FOUND)
 
   set_tests_properties(test_trt_ops_fp32_mix_precision PROPERTIES TIMEOUT 300)
   set_tests_properties(test_trt_convert_compare_and_logical PROPERTIES TIMEOUT
-                                                                       1000)
-  set_tests_properties(test_trt_convert_expand_v2 PROPERTIES TIMEOUT 1000)
+                                                                       600)
+  set_tests_properties(test_trt_convert_expand_v2 PROPERTIES TIMEOUT 600)
   set_tests_properties(test_trt_convert_unary PROPERTIES TIMEOUT 600)
   set_tests_properties(test_trt_convert_temporal_shift_deprecated
-                       PROPERTIES TIMEOUT 1000)
+                       PROPERTIES TIMEOUT 600)
+  set_tests_properties(test_trt_convert_index_select PROPERTIES TIMEOUT 600)
+  set_tests_properties(test_trt_convert_anchor_generator PROPERTIES TIMEOUT
+                                                                    600)
+  set_tests_properties(test_trt_convert_scale PROPERTIES TIMEOUT 600)
+  set_tests_properties(test_trt_convert_elementwise PROPERTIES TIMEOUT 600)
+  set_tests_properties(test_trt_convert_reduce PROPERTIES TIMEOUT 600)
   set_tests_properties(test_trt_convert_pool2d PROPERTIES TIMEOUT 600)
   set_tests_properties(test_trt_convert_slice PROPERTIES TIMEOUT 600)
 

--- a/test/ir/inference/CMakeLists.txt
+++ b/test/ir/inference/CMakeLists.txt
@@ -169,20 +169,14 @@ if(WITH_GPU AND TENSORRT_FOUND)
   #set_tests_properties(test_trt_multiclass_nms_op PROPERTIES TIMEOUT 200)
 
   set_tests_properties(test_trt_ops_fp32_mix_precision PROPERTIES TIMEOUT 300)
-  set_tests_properties(test_trt_convert_compare_and_logical PROPERTIES TIMEOUT
-                                                                       600)
   set_tests_properties(test_trt_convert_expand_v2 PROPERTIES TIMEOUT 600)
   set_tests_properties(test_trt_convert_unary PROPERTIES TIMEOUT 600)
   set_tests_properties(test_trt_convert_temporal_shift_deprecated
                        PROPERTIES TIMEOUT 600)
-  set_tests_properties(test_trt_convert_index_select PROPERTIES TIMEOUT 600)
-  set_tests_properties(test_trt_convert_anchor_generator PROPERTIES TIMEOUT
-                                                                    600)
-  set_tests_properties(test_trt_convert_scale PROPERTIES TIMEOUT 600)
-  set_tests_properties(test_trt_convert_elementwise PROPERTIES TIMEOUT 600)
-  set_tests_properties(test_trt_convert_reduce PROPERTIES TIMEOUT 600)
   set_tests_properties(test_trt_convert_pool2d PROPERTIES TIMEOUT 600)
   set_tests_properties(test_trt_convert_slice PROPERTIES TIMEOUT 600)
+  set_tests_properties(test_trt_convert_compare_and_logical PROPERTIES TIMEOUT
+                                                                       600)
 
   if(NOT WIN32)
 

--- a/test/ir/inference/CMakeLists.txt
+++ b/test/ir/inference/CMakeLists.txt
@@ -169,10 +169,10 @@ if(WITH_GPU AND TENSORRT_FOUND)
   #set_tests_properties(test_trt_multiclass_nms_op PROPERTIES TIMEOUT 200)
 
   set_tests_properties(test_trt_ops_fp32_mix_precision PROPERTIES TIMEOUT 300)
-  set_tests_properties(test_trt_convert_expand_v2 PROPERTIES TIMEOUT 600)
+  set_tests_properties(test_trt_convert_expand_v2 PROPERTIES TIMEOUT 1000)
   set_tests_properties(test_trt_convert_unary PROPERTIES TIMEOUT 600)
   set_tests_properties(test_trt_convert_temporal_shift_deprecated
-                       PROPERTIES TIMEOUT 600)
+                       PROPERTIES TIMEOUT 1000)
   set_tests_properties(test_trt_convert_pool2d PROPERTIES TIMEOUT 600)
   set_tests_properties(test_trt_convert_slice PROPERTIES TIMEOUT 600)
   set_tests_properties(test_trt_convert_compare_and_logical PROPERTIES TIMEOUT

--- a/test/ir/inference/CMakeLists.txt
+++ b/test/ir/inference/CMakeLists.txt
@@ -169,7 +169,8 @@ if(WITH_GPU AND TENSORRT_FOUND)
   #set_tests_properties(test_trt_multiclass_nms_op PROPERTIES TIMEOUT 200)
 
   set_tests_properties(test_trt_ops_fp32_mix_precision PROPERTIES TIMEOUT 300)
-  set_tests_properties(test_trt_convert_compare_and_logical PROPERTIES TIMEOUT 1000)
+  set_tests_properties(test_trt_convert_compare_and_logical PROPERTIES TIMEOUT
+                                                                       1000)
   set_tests_properties(test_trt_convert_expand_v2 PROPERTIES TIMEOUT 1000)
   set_tests_properties(test_trt_convert_unary PROPERTIES TIMEOUT 600)
   set_tests_properties(test_trt_convert_temporal_shift_deprecated

--- a/test/ir/inference/CMakeLists.txt
+++ b/test/ir/inference/CMakeLists.txt
@@ -169,6 +169,7 @@ if(WITH_GPU AND TENSORRT_FOUND)
   #set_tests_properties(test_trt_multiclass_nms_op PROPERTIES TIMEOUT 200)
 
   set_tests_properties(test_trt_ops_fp32_mix_precision PROPERTIES TIMEOUT 300)
+  set_tests_properties(test_trt_convert_compare_and_logical PROPERTIES TIMEOUT 1000)
   set_tests_properties(test_trt_convert_expand_v2 PROPERTIES TIMEOUT 1000)
   set_tests_properties(test_trt_convert_unary PROPERTIES TIMEOUT 600)
   set_tests_properties(test_trt_convert_temporal_shift_deprecated


### PR DESCRIPTION
### PR Category
User Experience

### PR Types
Others

### Description
card-71500
- Adjusting the timeout of test_trt_convert_compare_logical to 600