### PR TITLE
Allow to set stream for GPUEventTimer and get the comm_stream of deepep.

### DIFF
--- a/paddle/fluid/distributed/collective/deep_ep/deep_ep.cpp
+++ b/paddle/fluid/distributed/collective/deep_ep/deep_ep.cpp
@@ -208,6 +208,8 @@ int Buffer::get_root_rdma_rank(bool global) const {
 
 int Buffer::get_local_device_id() const { return device_id; }
 
+cudaStream_t Buffer::get_comm_stream() const { return comm_stream; }
+
 #ifndef PADDLE_NO_PYTHON
 pybind11::bytearray Buffer::get_local_ipc_handle() const {
   return {ipc_handles[nvl_rank].reserved, CUDA_IPC_HANDLE_SIZE};

--- a/paddle/fluid/distributed/collective/deep_ep/deep_ep.hpp
+++ b/paddle/fluid/distributed/collective/deep_ep/deep_ep.hpp
@@ -122,6 +122,8 @@ struct Buffer {
 
   int get_local_device_id() const;
 
+  cudaStream_t get_comm_stream() const;
+
 #ifndef PADDLE_NO_PYTHON
   pybind11::bytearray get_local_ipc_handle() const;
 

--- a/paddle/fluid/pybind/deep_ep_api.cc
+++ b/paddle/fluid/pybind/deep_ep_api.cc
@@ -59,6 +59,13 @@ void BindDeepEPApi(pybind11::module *m) {
       .def("get_rdma_rank", &deep_ep::Buffer::get_rdma_rank)
       .def("get_root_rdma_rank", &deep_ep::Buffer::get_root_rdma_rank)
       .def("get_local_device_id", &deep_ep::Buffer::get_local_device_id)
+      .def("get_comm_stream",
+           [](deep_ep::Buffer &self) {
+             int device_id = self.get_local_device_id();
+             cudaStream_t comm_stream = self.get_comm_stream();
+             auto s = phi::Stream(reinterpret_cast<phi::StreamId>(comm_stream));
+             return phi::CUDAStream(phi::GPUPlace(device_id), s);
+           })
       .def("get_local_ipc_handle", &deep_ep::Buffer::get_local_ipc_handle)
       .def("get_local_nvshmem_unique_id",
            &deep_ep::Buffer::get_local_nvshmem_unique_id)

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -2473,7 +2473,7 @@ All parameter, weight, gradient are variables in Paddle.
             if (stream == nullptr) {
               timer.Start();
             } else {
-              timer.Start(stream);
+              timer.Start(stream->raw_stream());
             }
           },
           py::arg("stream") = nullptr,
@@ -2484,7 +2484,7 @@ All parameter, weight, gradient are variables in Paddle.
             if (stream == nullptr) {
               timer.Stop();
             } else {
-              timer.Stop(stream);
+              timer.Stop(stream->raw_stream());
             }
           },
           py::arg("stream") = nullptr,

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -2469,11 +2469,25 @@ All parameter, weight, gradient are variables in Paddle.
       .def(py::init<phi::GPUPlace>(), py::arg("place"))
       .def(
           "start",
-          [](phi::GPUEventTimer &timer) { timer.Start(); },
+          [](phi::GPUEventTimer &timer, phi::CUDAStream *stream) {
+            if (stream == nullptr) {
+              timer.Start();
+            } else {
+              timer.Start(stream);
+            }
+          },
+          py::arg("stream") = nullptr,
           py::call_guard<py::gil_scoped_release>())
       .def(
           "stop",
-          [](phi::GPUEventTimer &timer) { timer.Stop(); },
+          [](phi::GPUEventTimer &timer, phi::CUDAStream *stream) {
+            if (stream == nullptr) {
+              timer.Stop();
+            } else {
+              timer.Stop(stream);
+            }
+          },
+          py::arg("stream") = nullptr,
           py::call_guard<py::gil_scoped_release>())
       .def("reset",
            &phi::GPUEventTimer::Reset,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Communication Library

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
pcard-67164

- `GPUEventTimer`计时接口添加`stream`参数，可以指定统计任意`stream`上的事件。
- deepep新增`get_comm_stream`接口，用户方便结合`GPUEventTimer`接口来计时分析。