### PR TITLE
support DeepEP alloc on comm stream

### DIFF
--- a/paddle/fluid/distributed/collective/deep_ep/deep_ep.cpp
+++ b/paddle/fluid/distributed/collective/deep_ep/deep_ep.cpp
@@ -38,14 +38,14 @@
 
 namespace deep_ep {
 
-namespace {
+namespace detail {
 void SetAllocatorStreamForGPUContext(cudaStream_t stream,
                                      phi::GPUContext* ctx) {
   ctx->SetAllocator(paddle::memory::allocation::AllocatorFacade::Instance()
                         .GetAllocator(ctx->GetPlace(), stream)
                         .get());
 }
-}  // namespace
+}  // namespace detail
 
 Buffer::Buffer(int rank,
                int num_ranks,
@@ -332,7 +332,7 @@ Buffer::get_dispatch_layout(const deep_ep::detail::Tensor& topk_idx,
   auto compute_stream = calc_ctx->stream();
   if (allocate_on_comm_stream) {
     EP_HOST_ASSERT(previous_event.has_value() && async);
-    SetAllocatorStreamForGPUContext(comm_stream, calc_ctx);
+    deep_ep::detail::SetAllocatorStreamForGPUContext(comm_stream, calc_ctx);
   }
 
   // Wait previous tasks to be finished
@@ -396,8 +396,9 @@ Buffer::get_dispatch_layout(const deep_ep::detail::Tensor& topk_idx,
   }
 
   // Switch back compute stream
-  if (allocate_on_comm_stream)
-    SetAllocatorStreamForGPUContext(compute_stream, calc_ctx);
+  if (allocate_on_comm_stream) {
+    deep_ep::detail::SetAllocatorStreamForGPUContext(compute_stream, calc_ctx);
+  }
 
   return {num_tokens_per_rank,
           num_tokens_per_rdma_rank,
@@ -530,7 +531,7 @@ Buffer::intranode_dispatch(
   auto compute_stream = calc_ctx->stream();
   if (allocate_on_comm_stream) {
     EP_HOST_ASSERT(previous_event.has_value() && async);
-    SetAllocatorStreamForGPUContext(comm_stream, calc_ctx);
+    deep_ep::detail::SetAllocatorStreamForGPUContext(comm_stream, calc_ctx);
   }
 
   // Wait previous tasks to be finished
@@ -759,8 +760,9 @@ Buffer::intranode_dispatch(
   }
 
   // Switch back compute stream
-  if (allocate_on_comm_stream)
-    SetAllocatorStreamForGPUContext(compute_stream, calc_ctx);
+  if (allocate_on_comm_stream) {
+    deep_ep::detail::SetAllocatorStreamForGPUContext(compute_stream, calc_ctx);
+  }
 
   // Return values
   return {recv_x,
@@ -824,7 +826,7 @@ Buffer::intranode_combine(
   auto compute_stream = calc_ctx->stream();
   if (allocate_on_comm_stream) {
     EP_HOST_ASSERT(previous_event.has_value() && async);
-    SetAllocatorStreamForGPUContext(comm_stream, calc_ctx);
+    deep_ep::detail::SetAllocatorStreamForGPUContext(comm_stream, calc_ctx);
   }
 
   // Wait previous tasks to be finished
@@ -927,8 +929,9 @@ Buffer::intranode_combine(
   }
 
   // Switch back compute stream
-  if (allocate_on_comm_stream)
-    SetAllocatorStreamForGPUContext(compute_stream, calc_ctx);
+  if (allocate_on_comm_stream) {
+    deep_ep::detail::SetAllocatorStreamForGPUContext(compute_stream, calc_ctx);
+  }
 
   return {recv_x, recv_topk_weights, event};
 }
@@ -1086,7 +1089,7 @@ Buffer::internode_dispatch(
   auto compute_stream = calc_ctx->stream();
   if (allocate_on_comm_stream) {
     EP_HOST_ASSERT(previous_event.has_value() && async);
-    SetAllocatorStreamForGPUContext(comm_stream, calc_ctx);
+    deep_ep::detail::SetAllocatorStreamForGPUContext(comm_stream, calc_ctx);
   }
 
   // Wait previous tasks to be finished
@@ -1366,8 +1369,9 @@ Buffer::internode_dispatch(
   }
 
   // Switch back compute stream
-  if (allocate_on_comm_stream)
-    SetAllocatorStreamForGPUContext(compute_stream, calc_ctx);
+  if (allocate_on_comm_stream) {
+    deep_ep::detail::SetAllocatorStreamForGPUContext(compute_stream, calc_ctx);
+  }
 
   // Return values
   return {recv_x,
@@ -1458,7 +1462,7 @@ Buffer::internode_combine(
   auto compute_stream = calc_ctx->stream();
   if (allocate_on_comm_stream) {
     EP_HOST_ASSERT(previous_event.has_value() && async);
-    SetAllocatorStreamForGPUContext(comm_stream, calc_ctx);
+    deep_ep::detail::SetAllocatorStreamForGPUContext(comm_stream, calc_ctx);
   }
 
   // Wait previous tasks to be finished
@@ -1576,8 +1580,9 @@ Buffer::internode_combine(
   }
 
   // Switch back compute stream
-  if (allocate_on_comm_stream)
-    SetAllocatorStreamForGPUContext(compute_stream, calc_ctx);
+  if (allocate_on_comm_stream) {
+    deep_ep::detail::SetAllocatorStreamForGPUContext(compute_stream, calc_ctx);
+  }
 
   // Return values
   return {combined_x, combined_topk_weights, event};

--- a/paddle/fluid/distributed/collective/deep_ep/include/CUDAStream.h
+++ b/paddle/fluid/distributed/collective/deep_ep/include/CUDAStream.h
@@ -57,10 +57,6 @@ inline CUDAStream getCurrentCUDAStream(DeviceIndex device_index = -1) {
   // return *(CUDAStream*)nullptr;
 }
 
-inline void setCurrentCUDAStream(cudaStream_t stream) {
-  LOG(FATAL) << "setCurrentCUDAStream is not implemented";
-}
-
 cudaStream_t GetCalcStreamFromGroup(int context_ring_id);
 
 cudaStream_t GetCommStreamFromGroup(int context_ring_id);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Communication Library

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
pcard-67164
This PR supports DeepEP alloc on comm stream, which is necessary for dualpipe overlap.