### PR TITLE
[CINN] Backend supports 0-size

### DIFF
--- a/paddle/cinn/optim/longlong2int_pass.cc
+++ b/paddle/cinn/optim/longlong2int_pass.cc
@@ -75,9 +75,10 @@ class CheckOverflow : public ir::stmt::StmtVisitor<> {
 
     if (is_overflow_) return;
 
+    int64_t prev_product = curr_product_;
     curr_product_ *= for_stmt->extent().as_int64();
     VisitBlock(for_stmt->body());
-    curr_product_ /= for_stmt->extent().as_int64();
+    curr_product_ = prev_product;
   }
 
   void VisitStmt(const Schedule& schedule_stmt) override {

--- a/test/ir/pir/cinn/test_cinn_0_size.py
+++ b/test/ir/pir/cinn/test_cinn_0_size.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy
+import utils
+
+import paddle
+
+
+class Test0Size(unittest.TestCase):
+    def eval(self, dy_compute, inputs):
+        dy_out = dy_compute(*inputs)
+
+        static_compute = utils.apply_to_static(dy_compute, use_cinn=True)
+        st_out = static_compute(*inputs)
+
+        for a, b in zip(
+            paddle.utils.flatten(dy_out), paddle.utils.flatten(st_out)
+        ):
+            numpy.testing.assert_allclose(a, b, atol=1e-6, rtol=1e-6)
+
+    def test_r_r0(self):
+        def func(x):
+            return x.sum()
+
+        x = paddle.uniform([128, 0])
+
+        self.eval(func, [x])
+
+    def test_s0_s(self):
+        def func(x, y):
+            return x + y
+
+        x = paddle.uniform([0, 128])
+        y = paddle.uniform([128])
+
+        self.eval(func, [x, y])
+
+    def test_s0_r(self):
+        def func(x):
+            return x.sum(axis=1)
+
+        x = paddle.uniform([0, 128])
+
+        self.eval(func, [x])
+
+    def test_r_r0_s(self):
+        def func(x):
+            return x.sum(axis=(0, 1))
+
+        x = paddle.uniform([32, 0, 128])
+
+        self.eval(func, [x])
+
+    def test_s_r_s0(self):
+        def func(x):
+            return x.sum(axis=1)
+
+        x = paddle.uniform([16, 32, 0])
+
+        self.eval(func, [x])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/ir/pir/cinn/test_cinn_0_size_dynshape.py
+++ b/test/ir/pir/cinn/test_cinn_0_size_dynshape.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy
+import utils
+
+import paddle
+from paddle.static import InputSpec
+
+
+class Test0SizeDynShape(unittest.TestCase):
+    def eval(self, dy_compute, inputs, input_spec=None):
+        dy_out = dy_compute(*inputs)
+
+        static_compute = utils.apply_to_static(
+            dy_compute, use_cinn=True, input_spec=input_spec
+        )
+        st_out = static_compute(*inputs)
+
+        for a, b in zip(
+            paddle.utils.flatten(dy_out), paddle.utils.flatten(st_out)
+        ):
+            numpy.testing.assert_allclose(a, b, atol=1e-6, rtol=1e-6)
+
+    def test_s0_s_dynshape(self):
+        def func(x, y):
+            return x + y
+
+        x = paddle.uniform([0, 128])
+        x_spec = InputSpec([None, 128])
+        y = paddle.uniform([1, 128])
+        y_spec = InputSpec([None, 128])
+
+        self.eval(func, [x, y], [x_spec, y_spec])
+
+    def test_s0_r_dynshape(self):
+        def func(x):
+            return x.sum(axis=1)
+
+        x = paddle.uniform([0, 128])
+        x_spec = InputSpec([0, None])
+
+        self.eval(func, [x], [x_spec])
+
+    def test_r0_s_dynshape(self):
+        def func(x):
+            return x.sum(axis=0)
+
+        x = paddle.uniform([0, 128])
+        x_spec = InputSpec([None, 128])
+
+        self.eval(func, [x], [x_spec])
+
+    def test_r_s_r0_dynshape(self):
+        def func(x):
+            return x.sum(axis=(0, 2))
+
+        x = paddle.uniform([16, 32, 0])
+        x_spec = InputSpec([16, None, 0])
+
+        self.eval(func, [x], [x_spec])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
CINN


### PR Types
Improvements


### Description
CINN后端增加对0-size的支持

0-size其实分为两种情况，即Spatial维为0和Reduce维为0，两者是不一样的，需要分情况讨论

#### Spatial维为0
此时输出一定为空，因此实际上我们不用进行任何操作

本PR对于Spatial维为0的情况会生成一个不可达的bucket，如下所示，虽然生成了CUDA Kernel，但在执行时不会被launch，也就不会产生launch成本
```cpp
function fn_bc_add_ (kernel_args, kernel_args_num, kernel_stream)
{
  if ((true and ((0ll >= 1ll) and (0ll <= 1ll)))) {  // 这个条件为false
    cinn_call_cuda_kernel(fn_add__kernel, kernel_args, kernel_args_num, 1ll, 1ll, 1ll, 256ll, 1ll, 1ll, 0, kernel_stream)
  }
}
function fn_bc_add__infer_shape (kernel_args, kernel_args_num, tensor_shape_args)
{
  infer_shape_set_value(0, 0, 0ll, tensor_shape_args)
  infer_shape_set_value(0, 1, 128ll, tensor_shape_args)
}
```

<b>说明：</b>当Spatial维为0时，block数必为0，而cuda launch即使是block=0也是有成本的（而且是bad practice），所以确实不应该发生实际的launch；其实我也试过连bucket都不分配，不生成kernel，这样也能跑通，不过要改的地方有点多，因为bucket lowering那套流程会假设至少有一个LoweredFunc，需要加很多特判；所以当前改法是兼顾了性能和简洁性的

#### Reduce维为0
此时输出未必为空，且还有特定的值，因此需要生成kernel并进行实际操作

PIR各Reduce API对于0-size的行为如下：
```python
x = paddle.randn([128, 0])
x.sum(axis=1)   # 返回shape=[128]的全0
x.any(axis=1)   # 返回shape=[128]的全False
x.all(axis=1)   # 返回shape=[128]的全True
x.prod(axis=1)  # _C_ops报错
x.min(axis=1)   # _C_ops报错
x.max(axis=1)   # _C_ops报错
```

本PR实现的CINN的行为如下：
```python
x = paddle.randn([128, 0])
x.sum(axis=1)   # 返回shape=[128]的全0
x.any(axis=1)   # 没进CINN，同PIR
x.all(axis=1)   # 没进CINN，同PIR
x.prod(axis=1)  # 返回shape=[128]的全1
x.min(axis=1)   # 返回shape=[128]的全3.40282347e+38f
x.max(axis=1)   # 返回shape=[128]的全-3.40282347e+38f
```

可以看到，至少对于PIR原本支持的API，CINN的行为是对齐的，不会破坏原有的兼容性

<br>
Pcard-85711