### PR TITLE
【custom】fix npu_cmake bug

### DIFF
--- a/paddle/fluid/primitive/codegen/decomp_rule_gen.py
+++ b/paddle/fluid/primitive/codegen/decomp_rule_gen.py
@@ -22,7 +22,8 @@ import yaml
 
 # fmt: off
 # import from paddle/fluid/operators/generator
-sys.path.append(
+sys.path.insert(
+    0,
     str(pathlib.Path(__file__).resolve().parents[2] / 'operators/generator')
 )
 import filters as op_gen_filters
@@ -32,7 +33,8 @@ from parse_utils import to_named_dict
 from type_mapping import output_type_map
 
 # import from paddle/fluid/pir/dialect/op_generator/api_gen.py
-sys.path.append(
+sys.path.insert(
+    0,
     str(pathlib.Path(__file__).resolve().parents[2] / 'pir/dialect/op_generator')
 )
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure
### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes 

### Description
<!-- Describe what you’ve done -->
pcard-67164
在npu 环境编译paddle , 遇到PATH 中也有op_gen 包，导致找包错误