### PR TITLE
[XPU] preserve symlink for xpu so

### DIFF
--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -14,7 +14,7 @@ import glob
 import shlex
 import ctypes
 
-from contextlib import contextmanager
+import contextlib
 from pathlib import Path
 from setuptools import Command
 from setuptools import setup, Distribution, Extension
@@ -1106,42 +1106,47 @@ if '${WITH_OPENVINO}' == 'ON':
         package_data['paddle.libs'] += ['openvino.dll', 'tbb.dll', 'openvino_paddle_frontend.dll', 'openvino_intel_cpu_plugin.dll']
 
 if '${WITH_XPU}' == 'ON':
-    shutil.copy('${XPU_API_LIB}', libs_path)
+    def copy_xpu_lib(src_path):
+        with contextlib.suppress(OSError):
+            os.remove(os.path.join(libs_path, os.basename(src_path)))
+        shutil.copy(src_path, libs_path, follow_symlinks=False)
+
+    copy_xpu_lib('${XPU_API_LIB}')
     package_data['paddle.libs']+=['${XPU_API_LIB_NAME}']
     xpu_rt_lib_list = glob.glob('${XPU_RT_LIB}*')
     for xpu_rt_lib_file in xpu_rt_lib_list:
-        shutil.copy(xpu_rt_lib_file, libs_path)
+        copy_xpu_lib(xpu_rt_lib_file)
         package_data['paddle.libs']+=[os.path.basename(xpu_rt_lib_file)]
     xpu_cuda_lib_list = glob.glob('${XPU_CUDA_LIB}*')
     for xpu_cuda_lib_file in xpu_cuda_lib_list:
-        shutil.copy(xpu_cuda_lib_file, libs_path)
+        copy_xpu_lib(xpu_cuda_lib_file)
         package_data['paddle.libs'] += [os.path.basename(xpu_cuda_lib_file)]
     if '${WITH_XPU_XRE5}' == 'ON':
         xpu_cuda_rt_lib_list = glob.glob('${XPU_CUDA_RT_LIB}*')
         for xpu_cuda_rt_lib_file in xpu_cuda_rt_lib_list:
-            shutil.copy(xpu_cuda_rt_lib_file, libs_path)
+            copy_xpu_lib(xpu_cuda_rt_lib_file)
             package_data['paddle.libs'] += [os.path.basename(xpu_cuda_rt_lib_file)]
         xpu_ml_lib_list = glob.glob('${XPU_ML_LIB}*')
         for xpu_ml_lib_file in xpu_ml_lib_list:
-            shutil.copy(xpu_ml_lib_file, libs_path)
+            copy_xpu_lib(xpu_ml_lib_file)
             package_data['paddle.libs'] += [os.path.basename(xpu_ml_lib_file)]
-        shutil.copy('${XPU_XBLAS_LIB}', libs_path)
+        copy_xpu_lib('${XPU_XBLAS_LIB}')
         package_data['paddle.libs'] += ['${XPU_XBLAS_LIB_NAME}']
-        shutil.copy('${XPU_XFA_LIB}', libs_path)
+        copy_xpu_lib('${XPU_XFA_LIB}')
         package_data['paddle.libs'] += ['${XPU_XFA_LIB_NAME}']
-        shutil.copy('${XPU_XPUDNN_LIB}', libs_path)
+        copy_xpu_lib('${XPU_XPUDNN_LIB}')
         package_data['paddle.libs'] += ['${XPU_XPUDNN_LIB_NAME}']
 
 if '${WITH_XPU_BKCL}' == 'ON':
-    shutil.copy('${XPU_BKCL_LIB}', libs_path)
+    copy_xpu_lib('${XPU_BKCL_LIB}')
     package_data['paddle.libs']+=['${XPU_BKCL_LIB_NAME}']
 
 if '${WITH_XPU_XFT}' == 'ON':
-    shutil.copy('${XPU_XFT_LIB}', libs_path)
+    copy_xpu_lib('${XPU_XFT_LIB}')
     package_data['paddle.libs']+=['${XPU_XFT_LIB_NAME}']
 
 if '${WITH_XPTI}' == 'ON':
-    shutil.copy('${XPU_XPTI_LIB}', libs_path)
+    copy_xpu_lib('${XPU_XPTI_LIB}')
     package_data['paddle.libs']+=['${XPU_XPTI_LIB_NAME}']
 
 # remove unused paddle/libs/__init__.py
@@ -1375,7 +1380,7 @@ class EggInfo(egg_info):
 
 # we redirect setuptools log for non-windows
 if sys.platform != 'win32':
-    @contextmanager
+    @contextlib.contextmanager
     def redirect_stdout():
         f_log = open('${SETUP_LOG_FILE}', 'w')
         origin_stdout = sys.stdout
@@ -1385,7 +1390,7 @@ if sys.platform != 'win32':
         sys.stdout = origin_stdout
         f_log.close()
 else:
-    @contextmanager
+    @contextlib.contextmanager
     def redirect_stdout():
         yield
 

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import ctypes
 import errno
 import fnmatch
@@ -27,7 +28,6 @@ import shutil
 import subprocess
 import sys
 import time
-from contextlib import contextmanager
 from pathlib import Path
 from subprocess import CalledProcessError
 
@@ -871,7 +871,7 @@ def find_files(pattern, root, recursive=False):
             break
 
 
-@contextmanager
+@contextlib.contextmanager
 def cd(path):
     if not os.path.isabs(path):
         raise RuntimeError(f'Can only cd to absolute path, got: {path}')
@@ -1560,48 +1560,55 @@ def get_package_data_and_package_dir():
             ]
 
     if env_dict.get("WITH_XPU") == 'ON':
-        shutil.copy(env_dict.get("XPU_API_LIB"), libs_path)
+
+        def copy_xpu_lib(src_path):
+            with contextlib.suppress(OSError):
+                os.remove(os.path.join(libs_path, os.basename(src_path)))
+            shutil.copy(src_path, libs_path, follow_symlinks=False)
+
+        copy_xpu_lib(env_dict.get("XPU_API_LIB"))
         package_data['paddle.libs'] += [env_dict.get("XPU_API_LIB_NAME")]
         xpu_rt_lib_list = glob.glob(env_dict.get("XPU_RT_LIB") + '*')
         for xpu_rt_lib_file in xpu_rt_lib_list:
-            shutil.copy(xpu_rt_lib_file, libs_path)
+            copy_xpu_lib(xpu_rt_lib_file)
             package_data['paddle.libs'] += [os.path.basename(xpu_rt_lib_file)]
         xpu_cuda_lib_list = glob.glob(env_dict.get("XPU_CUDA_LIB") + '*')
         for xpu_cuda_lib_file in xpu_cuda_lib_list:
-            shutil.copy(xpu_cuda_lib_file, libs_path)
+            copy_xpu_lib(xpu_cuda_lib_file)
             package_data['paddle.libs'] += [os.path.basename(xpu_cuda_lib_file)]
         if env_dict.get("WITH_XPU_XRE5") == 'ON':
             xpu_cuda_rt_lib_list = glob.glob(
                 env_dict.get("XPU_CUDA_RT_LIB") + '*'
             )
             for xpu_cuda_rt_lib_file in xpu_cuda_rt_lib_list:
-                shutil.copy(xpu_cuda_rt_lib_file, libs_path)
+                copy_xpu_lib(xpu_cuda_rt_lib_file)
                 package_data['paddle.libs'] += [
                     os.path.basename(xpu_cuda_rt_lib_file)
                 ]
             xpu_ml_lib_list = glob.glob(env_dict.get("XPU_ML_LIB") + '*')
             for xpu_ml_lib_file in xpu_ml_lib_list:
-                shutil.copy(xpu_ml_lib_file, libs_path)
+                copy_xpu_lib(xpu_ml_lib_file)
                 package_data['paddle.libs'] += [
                     os.path.basename(xpu_ml_lib_file)
                 ]
-            shutil.copy(env_dict.get("XPU_XBLAS_LIB"), libs_path)
+            copy_xpu_lib(env_dict.get("XPU_XBLAS_LIB"))
             package_data['paddle.libs'] += [env_dict.get("XPU_XBLAS_LIB_NAME")]
-            shutil.copy(env_dict.get("XPU_XFA_LIB"), libs_path)
+            copy_xpu_lib(env_dict.get("XPU_XFA_LIB"))
             package_data['paddle.libs'] += [env_dict.get("XPU_XFA_LIB_NAME")]
-            shutil.copy(env_dict.get("XPU_XPUDNN_LIB"), libs_path)
+            copy_xpu_lib(env_dict.get("XPU_XPUDNN_LIB"))
             package_data['paddle.libs'] += [env_dict.get("XPU_XPUDNN_LIB_NAME")]
 
     if env_dict.get("WITH_XPU_BKCL") == 'ON':
-        shutil.copy(env_dict.get("XPU_BKCL_LIB"), libs_path)
+        # shutil.copy(env_dict.get("XPU_BKCL_LIB"), libs_path, follow_symlinks=False)
+        copy_xpu_lib(env_dict.get("XPU_BKCL_LIB"))
         package_data['paddle.libs'] += [env_dict.get("XPU_BKCL_LIB_NAME")]
 
     if env_dict.get("WITH_XPU_XFT") == 'ON':
-        shutil.copy(env_dict.get("XPU_XFT_LIB"), libs_path)
+        copy_xpu_lib(env_dict.get("XPU_XFT_LIB"))
         package_data['paddle.libs'] += [env_dict.get("XPU_XFT_LIB_NAME")]
 
     if env_dict.get("WITH_XPTI") == 'ON':
-        shutil.copy(env_dict.get("XPU_XPTI_LIB"), libs_path)
+        copy_xpu_lib(env_dict.get("XPU_XPTI_LIB"))
         package_data['paddle.libs'] += [env_dict.get("XPU_XPTI_LIB_NAME")]
 
     # remove unused paddle/libs/__init__.py


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Custom Device

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
The XPU Runtime libs are ill-posed when the symlinks are broken during the generation of whl packages.
The PR fixes this problem by preserve the symlink in packaging.