### PR TITLE
[SOT][Faster Guard] clean `test_with_faster_guard`

### DIFF
--- a/test/sot/test_01_basic.py
+++ b/test/sot/test_01_basic.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-from test_case_base import TestCaseBase, test_with_faster_guard
+from test_case_base import TestCaseBase
 
 import paddle
 
@@ -24,7 +24,6 @@ def foo(x: int, y: paddle.Tensor):
 
 
 class TestBasic(TestCaseBase):
-    @test_with_faster_guard
     def test_simple(self):
         self.assert_results(foo, 1, paddle.to_tensor(2))
 

--- a/test/sot/test_04_list.py
+++ b/test/sot/test_04_list.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import unittest
 
-from test_case_base import TestCaseBase, test_with_faster_guard
+from test_case_base import TestCaseBase
 
 import paddle
 from paddle.jit.sot.psdb import check_no_breakgraph
@@ -368,7 +368,6 @@ class TestListMethods(TestCaseBase):
     def test_list_inplace_add(self):
         self.assert_results(list_inplace_add)
 
-    @test_with_faster_guard
     def test_list_extend_range(self):
         self.assert_results(list_extend_range, paddle.to_tensor([1, 2]))
 

--- a/test/sot/test_05_dict.py
+++ b/test/sot/test_05_dict.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-from test_case_base import TestCaseBase, test_with_faster_guard
+from test_case_base import TestCaseBase
 
 import paddle
 from paddle.jit.sot.psdb import check_no_breakgraph
@@ -253,7 +253,6 @@ class TestDictMethods(TestCaseBase):
     def test_dict_noargs(self):
         self.assert_results(dict_no_arguments)
 
-    @test_with_faster_guard
     def test_dict_fromkeys(self):
         self.assert_results(dict_test_fromkeys, (1, 2, 3, 4))
         self.assert_results(dict_test_fromkeys, [1, 2, 3, 4])

--- a/test/sot/test_07_unpack.py
+++ b/test/sot/test_07_unpack.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import unittest
 
-from test_case_base import TestCaseBase, test_with_faster_guard
+from test_case_base import TestCaseBase
 
 import paddle
 
@@ -56,7 +56,6 @@ class TestUnpack(TestCaseBase):
     def test_unpack_tensor(self):
         self.assert_results(unpack_tensor, paddle.to_tensor([2, 3]))
 
-    @test_with_faster_guard
     def test_unpack_ex_tuple(self):
         self.assert_results(unpack_ex_tuple, (1, 1, paddle.to_tensor(2)))
 

--- a/test/sot/test_12_for_loop.py
+++ b/test/sot/test_12_for_loop.py
@@ -22,7 +22,6 @@ import unittest
 from test_case_base import (
     TestCaseBase,
     test_instruction_translator_cache_context,
-    test_with_faster_guard,
 )
 
 import paddle
@@ -165,7 +164,6 @@ class TestForLoop(TestCaseBase):
         a = paddle.to_tensor(1)
         self.assert_results(for_list_1, a)
 
-    @test_with_faster_guard
     def test_list_with_fallback(self):
         a = paddle.to_tensor(1)
         self.assert_results(for_list_2, a)
@@ -195,7 +193,6 @@ class TestForLoop(TestCaseBase):
         paddle_output = for_break(a, gener())
         self.assert_nest_match(sym_output, paddle_output)
 
-    @test_with_faster_guard
     def test_for_continue(self):
         a = paddle.to_tensor(1)
         sym_output = symbolic_translate(for_continue)(a, gener())
@@ -207,7 +204,6 @@ class TestForLoop(TestCaseBase):
     #     a = [1, 2, 3]
     #     self.assert_results(for_enumerate_var_with_nested_range, a)
 
-    @test_with_faster_guard
     def test_create_var_in_loop(self):
         x = paddle.to_tensor(1, dtype="float32")
         a = [1, 2, 3]
@@ -220,7 +216,6 @@ class TestForLoop(TestCaseBase):
     def test_create_var_in_loop_with_same_name_as_global(self):
         self.assert_results(for_tmp_var_with_same_name_as_global_var)
 
-    @test_with_faster_guard
     def test_for_without_zero_iter(self):
         self_res_dict = {}
         output = paddle.to_tensor(2)
@@ -229,7 +224,6 @@ class TestForLoop(TestCaseBase):
     def test_reconstruct_range_iter(self):
         self.assert_results(for_reconstruct_range_iter)
 
-    @test_with_faster_guard
     def test_layer_list(self):
         layers = paddle.nn.LayerList()
         for i in range(5):
@@ -257,7 +251,6 @@ def for_enumerate_cache(func_list, x):
 
 
 class TestEnumerateCache(TestCaseBase):
-    @test_with_faster_guard
     def test_run(self):
         func_list = [
             paddle.nn.Linear(10, 10),
@@ -299,7 +292,6 @@ class TestUndefinedVarInRiskyCodes(TestCaseBase):
     def test_undefined_var_case_0(self):
         self.assert_results(undefined_var_case_0)
 
-    @test_with_faster_guard
     def test_undefined_var_case_1(self):
         self.assert_results(undefined_var_case_1)
 

--- a/test/sot/test_14_operators.py
+++ b/test/sot/test_14_operators.py
@@ -15,7 +15,7 @@
 import operator
 import unittest
 
-from test_case_base import TestCaseBase, test_with_faster_guard
+from test_case_base import TestCaseBase
 
 import paddle
 
@@ -328,7 +328,6 @@ class TestOperators(TestCaseBase):
         self.assert_results(inplace_or, b, g)
         self.assert_results(inplace_xor, b, g)
 
-    @test_with_faster_guard
     def test_operator_simple(self):
         self.assert_results(operator_add, 1, paddle.to_tensor(2))
         self.assert_results(operator_mul, 1, paddle.to_tensor(2))

--- a/test/sot/test_15_slice.py
+++ b/test/sot/test_15_slice.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import unittest
 
-from test_case_base import TestCaseBase, test_with_faster_guard
+from test_case_base import TestCaseBase
 
 import paddle
 from paddle.jit.sot.psdb import check_no_breakgraph
@@ -55,7 +55,6 @@ def tensor_subscript_tensor(x: paddle.Tensor):
 
 
 class TestSlice(TestCaseBase):
-    @test_with_faster_guard
     def test_simple(self):
         x = list(range(10))
         y = paddle.arange(10)
@@ -84,7 +83,6 @@ def layer_list_slice(layer, x):
 
 
 class TestLayerList(TestCaseBase):
-    @test_with_faster_guard
     def test_layer_list_slice(self):
         layer = MyLayer()
         x = paddle.randn([5, 10])
@@ -129,7 +127,6 @@ class LayerListNet(paddle.nn.Layer):
 
 
 class TestLayerListSlice(TestCaseBase):
-    @test_with_faster_guard
     def test_layer_list_slice(self):
         x = paddle.randn([2, 5])
         net = LayerListNet()

--- a/test/sot/test_17_paddle_layer.py
+++ b/test/sot/test_17_paddle_layer.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-from test_case_base import TestCaseBase, test_with_faster_guard
+from test_case_base import TestCaseBase
 
 import paddle
 
@@ -66,7 +66,6 @@ class SimpleNetWithSequenital(paddle.nn.Layer):
 
 
 class TestLayer(TestCaseBase):
-    @test_with_faster_guard
     def test_layer(self):
         x = paddle.rand((10,))
         y = paddle.rand((10, 10))
@@ -75,7 +74,6 @@ class TestLayer(TestCaseBase):
         self.assert_results(net_call, y, net)
         self.assert_results(net_call_passed_by_user, x, net.forward)
 
-    @test_with_faster_guard
     def test_layer_with_sequential(self):
         x = paddle.rand((10,))
         y = paddle.rand((10, 10))
@@ -84,7 +82,6 @@ class TestLayer(TestCaseBase):
         self.assert_results(net_call, y, net)
         self.assert_results(net_call_passed_by_user, x, net.forward)
 
-    @test_with_faster_guard
     def test_bound(self):
         x = paddle.rand((10,))
         y = paddle.rand((10, 10))

--- a/test/sot/test_18_tensor_method.py
+++ b/test/sot/test_18_tensor_method.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-from test_case_base import TestCaseBase, test_with_faster_guard
+from test_case_base import TestCaseBase
 
 import paddle
 from paddle.jit.sot.psdb import check_no_breakgraph
@@ -100,7 +100,6 @@ class TestTensorMethod(TestCaseBase):
         y = paddle.rand([42])
         self.assert_results(tensor_method_passed_by_user, x, y.add)
 
-    @test_with_faster_guard
     def test_tensor_method_property(self):
         x = paddle.rand([42, 24], dtype='float64')
         y = paddle.rand([42, 24], dtype='float32')

--- a/test/sot/test_builtin_bool.py
+++ b/test/sot/test_builtin_bool.py
@@ -17,7 +17,6 @@ import unittest
 from test_case_base import (
     TestCaseBase,
     test_instruction_translator_cache_context,
-    test_with_faster_guard,
 )
 
 import paddle
@@ -108,7 +107,6 @@ class TestBuiltinBool(TestCaseBase):
                 call_bool_by_operator_truth_no_breakgraph, layer
             )
 
-    @test_with_faster_guard
     def test_object_allow_breakgraph(self):
         with test_instruction_translator_cache_context():
             obj = TestObjectWithLen([1, 2, 3])

--- a/test/sot/test_builtin_dispatch.py
+++ b/test/sot/test_builtin_dispatch.py
@@ -22,7 +22,6 @@ import weakref
 from test_case_base import (
     TestCaseBase,
     test_instruction_translator_cache_context,
-    test_with_faster_guard,
 )
 
 import paddle
@@ -175,11 +174,9 @@ def test_builtin_type_check_eq():
 
 
 class TestBuiltinDispatch(TestCaseBase):
-    @test_with_faster_guard
     def test_dispatch_len(self):
         self.assert_results(dispatch_len, paddle.to_tensor([1, 2, 3]))
 
-    @test_with_faster_guard
     def test_dispatch_bool(self):
         self.assert_results(dispatch_bool, paddle.to_tensor([1, 2, 3]))
 
@@ -219,7 +216,6 @@ class TestBuiltinDispatch(TestCaseBase):
     def test_dispatch_float_floor(self):
         self.assert_results(dispatch_floor, 1.2)
 
-    @test_with_faster_guard
     def test_dispatch_sum(self):
         self.assert_results(test_sum_tuple, 1, 1)
         self.assert_results(test_sum_tuple, paddle.to_tensor(1), 1)

--- a/test/sot/test_builtin_map.py
+++ b/test/sot/test_builtin_map.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import unittest
 from typing import TYPE_CHECKING
 
-from test_case_base import TestCaseBase, test_with_faster_guard
+from test_case_base import TestCaseBase
 
 from paddle import Tensor, to_tensor
 from paddle.jit import sot
@@ -114,14 +114,12 @@ def test_map_with_zip_and_call_fn_ex(x: list[tuple[int, int]]):
 
 
 class TestMap(TestCaseBase):
-    @test_with_faster_guard
     def test_map(self):
         self.assert_results(test_map_list, [1, 2, 3, 4])
         self.assert_results(test_map_tuple, (1, 2, 3, 4))
         self.assert_results(test_map_range, range(5))
         self.assert_results(test_map_dict, {"a": 1, "b": 2, "c": 3})
 
-    @test_with_faster_guard
     def test_map_comprehension(self):
         self.assert_results(test_map_list_comprehension, [1, 2, 3, 4])
         self.assert_results(test_map_tuple_comprehension, (1, 2, 3, 4))
@@ -134,7 +132,6 @@ class TestMap(TestCaseBase):
         with strict_mode_guard(False):
             self.assert_results(test_map_list_with_breakgraph, [1, 2, 3, 4])
 
-    @test_with_faster_guard
     def test_map_unpack(self):
         self.assert_results(test_map_unpack, [1, 2, 3, 4])
         self.assert_results(
@@ -144,11 +141,9 @@ class TestMap(TestCaseBase):
             (2, 4, 6),
         )
 
-    @test_with_faster_guard
     def test_map_for_loop(self):
         self.assert_results(test_map_for_loop, [7, 8, 9, 10])
 
-    @test_with_faster_guard
     def test_map_with_zip_and_call_fn_ex(self):
         self.assert_results(
             test_map_with_zip_and_call_fn_ex, [(1, 2), (3, 4), (5, 6)]

--- a/test/sot/test_builtin_zip.py
+++ b/test/sot/test_builtin_zip.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-from test_case_base import TestCaseBase, test_with_faster_guard
+from test_case_base import TestCaseBase
 
 import paddle
 from paddle.jit.sot import psdb, symbolic_translate
@@ -77,7 +77,6 @@ def test_zip_8(iter_1, iter_2):
 
 
 class TestZip(TestCaseBase):
-    @test_with_faster_guard
     def test_simple_cases(self):
         x = 8
         y = 5
@@ -93,12 +92,10 @@ class TestZip(TestCaseBase):
         self.assert_results(test_zip_6, ty)
         self.assert_results(test_zip_7, layer_list, paddle.randn((10,)))
 
-    @test_with_faster_guard
     @min_graph_size_guard(0)
     def test_reconstruct(self):
         self.assert_results(test_zip_8, [1, 2, 3], [4, 5, 6])
 
-    @test_with_faster_guard
     @strict_mode_guard(False)
     @min_graph_size_guard(0)
     def test_zip_user_defined_iter(self):

--- a/test/sot/test_case_base.py
+++ b/test/sot/test_case_base.py
@@ -18,7 +18,6 @@ import contextlib
 import copy
 import types
 import unittest
-from functools import wraps
 
 import numpy as np
 
@@ -35,21 +34,6 @@ def test_instruction_translator_cache_context():
     cache.clear()
     yield cache
     cache.clear()
-
-
-FASTER_GUARD_CACHE_STATE = {
-    "cache": {},
-    "translate_count": 0,
-    "code_symbolic_inputs": {},
-}
-
-
-def test_with_faster_guard(func):
-    @wraps(func)
-    def impl(*args, **kwargs):
-        func(*args, **kwargs)
-
-    return impl
 
 
 class TestCaseBase(unittest.TestCase):

--- a/test/sot/test_dtype.py
+++ b/test/sot/test_dtype.py
@@ -17,7 +17,6 @@ import unittest
 from test_case_base import (
     TestCaseBase,
     test_instruction_translator_cache_context,
-    test_with_faster_guard,
 )
 
 import paddle
@@ -55,7 +54,6 @@ class TestTensorAstype(TestCaseBase):
 
 
 class TestTensorDtypeGuard(TestCaseBase):
-    @test_with_faster_guard
     def test_tensor_dtype_guard(self):
         x = paddle.ones([2, 3], dtype="float32")
         y = paddle.ones([2, 3], dtype="int32")
@@ -74,7 +72,6 @@ class TestDtypeReconstruct(TestCaseBase):
 
 
 class TestDtypeGuard(TestCaseBase):
-    @test_with_faster_guard
     def test_dtype_guard(self):
         dtype_map = {paddle.float32: paddle.float64}
         x = paddle.ones([2, 3], dtype="float32")

--- a/test/sot/test_guard_outputs.py
+++ b/test/sot/test_guard_outputs.py
@@ -19,7 +19,6 @@ import unittest
 from test_case_base import (
     TestCaseBase,
     test_instruction_translator_cache_context,
-    test_with_faster_guard,
 )
 
 import paddle
@@ -39,7 +38,6 @@ def guard_inputs(x: int, y: int, z: int):
 
 
 class TestGuardOutputs(TestCaseBase):
-    @test_with_faster_guard
     def test_non_operator_related_fn(self):
         with test_instruction_translator_cache_context() as ctx:
             self.assert_results(non_operator_related_fn, 1, 2)
@@ -47,7 +45,6 @@ class TestGuardOutputs(TestCaseBase):
             self.assert_results(non_operator_related_fn, 3, 4)
             self.assertEqual(ctx.translate_count, 2)
 
-    @test_with_faster_guard
     def test_partial_non_operator_related_fn(self):
         with test_instruction_translator_cache_context() as ctx:
             self.assert_results(
@@ -65,7 +62,6 @@ class TestGuardOutputs(TestCaseBase):
             )
             self.assertEqual(ctx.translate_count, 2)
 
-    @test_with_faster_guard
     def test_guard_inputs(self):
         with test_instruction_translator_cache_context() as ctx:
             self.assert_results(guard_inputs, 1, 2, 3)

--- a/test/sot/test_guard_user_defined_fn.py
+++ b/test/sot/test_guard_user_defined_fn.py
@@ -19,7 +19,6 @@ import unittest
 from test_case_base import (
     TestCaseBase,
     test_instruction_translator_cache_context,
-    test_with_faster_guard,
 )
 
 import paddle
@@ -33,7 +32,6 @@ def test_guard_fn(fn, inp):
 
 
 class TestGuardOutputs(TestCaseBase):
-    @test_with_faster_guard
     def test_non_operator_related_fn(self):
         with test_instruction_translator_cache_context() as ctx:
             self.assert_results(

--- a/test/sot/test_side_effects.py
+++ b/test/sot/test_side_effects.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import unittest
 
-from test_case_base import TestCaseBase, test_with_faster_guard
+from test_case_base import TestCaseBase
 
 import paddle
 from paddle.jit import sot
@@ -190,7 +190,6 @@ class TestDictSideEffect(TestCaseBase):
             dict_setitem, {0: paddle.to_tensor(1)}
         )
 
-    @test_with_faster_guard
     def test_dict_delitem(self):
         self.assert_results_with_side_effects(
             dict_delitem, {0: paddle.to_tensor(0), 1: paddle.to_tensor(1)}
@@ -204,7 +203,6 @@ class TestDictSideEffect(TestCaseBase):
             dict_delitem_getitem, {0: {0: 1, 1: 2}}
         )
 
-    @test_with_faster_guard
     def test_dict_nested_1(self):
         self.assert_results_with_side_effects(
             dict_nested_1, {0: {0: 1, 1: 2}, 1: {0: 1, 1: 2}}
@@ -213,7 +211,6 @@ class TestDictSideEffect(TestCaseBase):
             dict_nested_1, {0: {0: 123, 1: 2}, 1: {0: 1, 1: 2}}
         )
 
-    @test_with_faster_guard
     def test_dict_nested_2(self):
         self.assert_results_with_side_effects(
             dict_nested_2, {0: {0: 1, 1: 2}, 1: {0: 1, 1: 2}}
@@ -224,7 +221,6 @@ class TestDictSideEffect(TestCaseBase):
 
 
 class TestListSideEffect(TestCaseBase):
-    @test_with_faster_guard
     def test_list_append(self):
         self.assert_results_with_side_effects(
             list_append_int, paddle.to_tensor(1), [1, 2, 3]
@@ -233,71 +229,60 @@ class TestListSideEffect(TestCaseBase):
             list_append_tensor, paddle.to_tensor(2), [1, 2, 3]
         )
 
-    @test_with_faster_guard
     def test_list_delitem(self):
         self.assert_results_with_side_effects(list_delitem, [1, 2, 3])
 
-    @test_with_faster_guard
     def test_list_extend(self):
         self.assert_results_with_side_effects(
             list_extend, [1, 2, 3, 4, 5, 6, 7, 8, 9]
         )
 
-    @test_with_faster_guard
     def test_list_insert(self):
         self.assert_results_with_side_effects(list_insert, [1, 2, 3])
         self.assert_results_with_side_effects(
             list_insert, [-1, 2, -3, 4, -5, 6, -7, 8, -9]
         )
 
-    @test_with_faster_guard
     def test_list_remove(self):
         self.assert_results_with_side_effects(list_remove, [1, 1, 1])
         self.assert_results_with_side_effects(list_remove, [0, 1, 2])
         with self.assertRaises(InnerError):
             symbolic_translate(list_remove)([0, 2, 4])
 
-    @test_with_faster_guard
     def test_list_pop(self):
         self.assert_results_with_side_effects(list_pop, [1, 2, 3, 4, 5])
         self.assert_results_with_side_effects(
             list_pop, [-1, 2, -3, 4, -5, 6, -7, 8, -9]
         )
 
-    @test_with_faster_guard
     def test_list_clear(self):
         self.assert_results_with_side_effects(list_clear, [1, 2, 3, 4, 5])
         self.assert_results_with_side_effects(
             list_clear, [-1, 2, -3, 4, -5, 6, -7, 8, -9]
         )
 
-    @test_with_faster_guard
     def test_list_sort(self):
         self.assert_results_with_side_effects(list_sort, [2, 1, 7, 3, 4, 6])
         self.assert_results_with_side_effects(
             list_sort, [-1, 2, -3, 4, -5, 6, -7, 8, -9]
         )
 
-    @test_with_faster_guard
     def test_list_reverse(self):
         self.assert_results_with_side_effects(list_reverse, [1, 2, 3, 4, 5])
         self.assert_results_with_side_effects(
             list_reverse, [-1, 2, -3, 4, -5, 6, -7, 8, -9]
         )
 
-    @test_with_faster_guard
     def test_slice_in_for_loop(self):
         x = 2
         with strict_mode_guard(False):
             self.assert_results_with_side_effects(slice_in_for_loop, x)
 
-    @test_with_faster_guard
     def test_list_nested(self):
         self.assert_results_with_side_effects(list_nested, [1, 2, 3])
 
 
 class TestSliceAfterChange(TestCaseBase):
-    @test_with_faster_guard
     def test_slice_list_after_change(self):
         self.assert_results_with_side_effects(
             slice_list_after_change, [1, 2, 3, 4]


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->

在 #71239 中启用了一个新的 flag `SOT_ENABLE_STRICT_GUARD_CHECK` 用于对比两次 guard, 不再需要 `test_with_faster_guard`， 所以: 删！