### PR TITLE
[CINN] skip cache check for pd_op.sync_batch_norm_

### DIFF
--- a/paddle/pir/src/dialect/shape/transforms/shape_optimization_pass.cc
+++ b/paddle/pir/src/dialect/shape/transforms/shape_optimization_pass.cc
@@ -346,6 +346,7 @@ static const std::set<std::string> skip_cache_check_op_set = {
     "pd_op.data",
     "pd_op.arange",
     "pd_op.masked_select",
+    "pd_op.sync_batch_norm_",
     // unneeded to cache
     "cinn_op.generate_shape",
 };


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Pcard-67164
- skip cache check for pd_op.sync_batch_norm_ because of generate new symbol 