### PR TITLE
[SOT] Fix wrong type for tensor `numel`/`dim` and avoid break when access `size` and `len` in allow dynamic shape mode

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/dispatch_functions.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/dispatch_functions.py
@@ -53,7 +53,7 @@ def operator_is_not_none(val):
     pass
 
 
-def tensor_numel(x):
+def tensor_dim(x):
     pass
 
 

--- a/python/paddle/jit/sot/opcode_translator/executor/variable_dispatch.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variable_dispatch.py
@@ -46,7 +46,7 @@ from .dispatch_functions import (
     operator_is_none,
     operator_is_not_none,
     operator_not_in,
-    tensor_numel,
+    tensor_dim,
 )
 from .dispatcher import Dispatcher, optional
 from .tracker import ConstTracker, DanglingTracker, DummyTracker
@@ -891,7 +891,7 @@ Dispatcher.register(
     lambda var: var.is_floating_point(),
 )
 Dispatcher.register(
-    paddle.rank,
+    tensor_dim,
     ("TensorVariable",),
     lambda var: var.ndim,
 )
@@ -1037,8 +1037,6 @@ fallback_tensor_unary_method = {
     float,
     operator.truth,
 }
-
-Dispatcher.register(tensor_numel, ("TensorVariable",), lambda x: x.numel())
 
 for unary_fn in UNARY_OPS:
     if unary_fn in fallback_tensor_unary_method:

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
@@ -628,16 +628,15 @@ class TensorVariable(VariableBase):
         if len(self.meta.shape) == 0:
             raise InnerError("len() of a 0-D tensor is wrong")
         first_dim = self.meta.shape[0]
-        if isinstance(first_dim, SymbolicInt):
-            if not ENV_SOT_ALLOW_DYNAMIC_SHAPE.get():
-                raise BreakGraphError(
-                    DataDependencyDynamicShapeBreak(
-                        "Getting len() for a dynamic shape tensor causes graph break."
-                    )
+        if not isinstance(first_dim, SymbolicInt):
+            return ConstantVariable(first_dim, self.graph, DummyTracker([self]))
+        if not ENV_SOT_ALLOW_DYNAMIC_SHAPE.get():
+            raise BreakGraphError(
+                DataDependencyDynamicShapeBreak(
+                    "Getting len() for a dynamic shape tensor causes graph break."
                 )
-            return self.shape[0]
-
-        return ConstantVariable(first_dim, self.graph, DummyTracker([self]))
+            )
+        return self.shape[0]
 
     def is_tensor(self):
         return ConstantVariable(True, self.graph, DummyTracker([self]))

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
@@ -52,7 +52,7 @@ from ....utils.exceptions import (
     InnerError,
     UnsupportedPaddleAPIBreak,
 )
-from ..dispatch_functions import tensor_numel
+from ..dispatch_functions import tensor_dim
 from ..guard import (
     FasterStringifiedExpression,
     StringifiedExpression,
@@ -589,15 +589,24 @@ class TensorVariable(VariableBase):
         """
         Return a ConstantVariable object that represents the total number of elements in the wrapped value of this TensorVariable.
         """
-        # TODO: maybe break graph.
-        if self.meta.is_dynamic_shape():
+        from .callable import BuiltinVariable
+
+        if not self.meta.is_dynamic_shape():
+            n_elements = reduce(operator.mul, self.meta.shape, 1)
+            return ConstantVariable(
+                n_elements, self.graph, DummyTracker([self])
+            )
+        if not ENV_SOT_ALLOW_DYNAMIC_SHAPE.get():
             raise BreakGraphError(
                 DataDependencyDynamicShapeBreak(
                     f"Getting size for a dynamic shape tensor causes graph break. shape = {self.meta.shape}"
                 )
             )
-        elements = reduce(operator.mul, self.meta.shape, 1)
-        return ConstantVariable(elements, self.graph, DummyTracker([self]))
+        return reduce(
+            BuiltinVariable(operator.mul, self.graph, DanglingTracker()),
+            self.shape,
+            ConstantVariable.wrap_literal(1, self.graph),
+        )
 
     @tensor_property
     def shape(self):
@@ -615,19 +624,18 @@ class TensorVariable(VariableBase):
         tracker = GetAttrTracker(self, "shape")
         return ListVariable(self.meta.shape, self.graph, tracker=tracker)
 
-    def numel(self):
-        return self.size
-
     def len(self):
         if len(self.meta.shape) == 0:
             raise InnerError("len() of a 0-D tensor is wrong")
         first_dim = self.meta.shape[0]
         if isinstance(first_dim, SymbolicInt):
-            raise BreakGraphError(
-                DataDependencyDynamicShapeBreak(
-                    "Getting len() for a dynamic shape tensor causes graph break."
+            if not ENV_SOT_ALLOW_DYNAMIC_SHAPE.get():
+                raise BreakGraphError(
+                    DataDependencyDynamicShapeBreak(
+                        "Getting len() for a dynamic shape tensor causes graph break."
+                    )
                 )
-            )
+            return self.shape[0]
 
         return ConstantVariable(first_dim, self.graph, DummyTracker([self]))
 
@@ -661,9 +669,8 @@ class TensorVariable(VariableBase):
                 "default argument for getattr is not implemented"
             )
         method_name_to_builtin_fn = {
-            "dim": paddle.rank,
-            "numel": tensor_numel,
-            "ndimension": paddle.rank,
+            "dim": tensor_dim,
+            "ndimension": tensor_dim,
             "is_tensor": paddle.is_tensor,
             "is_complex": paddle.is_complex,
             "is_integer": paddle.is_integer,

--- a/test/dygraph_to_static/test_grad.py
+++ b/test/dygraph_to_static/test_grad.py
@@ -19,6 +19,7 @@ import unittest
 import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
+    test_ast_only,
     test_pir_only,
 )
 
@@ -209,6 +210,7 @@ def grad_with_if_case(x):
 
 class TestGradWithIf(Dy2StTestBase):
     @test_pir_only
+    @test_ast_only
     def test_grad_with_if(self):
         fn = grad_with_if_case
         static_fn = paddle.jit.to_static(fn)

--- a/test/sot/test_18_tensor_method.py
+++ b/test/sot/test_18_tensor_method.py
@@ -83,6 +83,21 @@ def middle_tensor_name(a: paddle.Tensor, b: paddle.Tensor):
     return c.name
 
 
+@check_no_breakgraph
+def tensor_numel(x: paddle.Tensor):
+    return x.numel(), x.size
+
+
+@check_no_breakgraph
+def tensor_dim(x: paddle.Tensor):
+    return x.dim(), x.ndimension(), x.ndim, x.rank()
+
+
+@check_no_breakgraph
+def tensor_len(x: paddle.Tensor):
+    return len(x)
+
+
 class TestTensorMethod(TestCaseBase):
     def test_tensor_method_1(self):
         x = paddle.rand([10])
@@ -118,6 +133,22 @@ class TestTensorMethod(TestCaseBase):
         y = paddle.rand([42, 24, 2, 3, 3, 2], dtype='float32')
         self.assert_results(tensor_method_property_mT, x)
         self.assert_results(tensor_method_property_mT, y)
+
+    def test_tensor_numel(self):
+        x = paddle.rand([2, 3], dtype='float32')
+        self.assert_results(tensor_numel, x)
+        x = paddle.rand([3, 3], dtype='float32')
+        self.assert_results(tensor_numel, x)  # test dynamic shape
+
+    def test_tensor_dim(self):
+        x = paddle.rand([2, 3], dtype='float32')
+        self.assert_results(tensor_dim, x)
+
+    def test_tensor_len(self):
+        x = paddle.rand([2, 3], dtype='float32')
+        self.assert_results(tensor_len, x)
+        x = paddle.rand([3, 3], dtype='float32')
+        self.assert_results(tensor_len, x)  # test dynamic shape
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Performance

### Description
<!-- Describe what you’ve done -->

修复 `numel` 本应返回 Tensor 却返回 int 的问题

修复 `size` 和 `len` 在动态 shape 模式完全可以避免打断但仍然发生了打断的问题