### PR TITLE
set scale

### DIFF
--- a/paddle/fluid/pir/transforms/general/auto_layout_pass.cc
+++ b/paddle/fluid/pir/transforms/general/auto_layout_pass.cc
@@ -112,13 +112,21 @@ class AutoLayoutPass : public pir::Pass {
     }
     VLOG(4) << "end IsNeedAllTranspose"
             << " conv_count_: " << conv_count_
-            << " transpose_count_: " << transpose_count_;
-    return conv_count_ > transpose_count_;
+            << " transpose_count_: " << transpose_count_
+            << " transpose_scale_ * transpose_count_: "
+            << transpose_scale_ * transpose_count_ << std::endl;
+
+    return conv_count_ > transpose_scale_ * transpose_count_;
   }
 
  private:
   int conv_count_ = 0;
   int transpose_count_ = 0;
+  // Due to the current transpose performance issues, our single explicit
+  // transpose does not perform better than cudnn, and there are interruptions
+  // in the network due to operators that do not support NHWC. So we set the
+  // scale to 1.2 temporarily.
+  float transpose_scale_ = 1.2;
 };
 }  // namespace
 namespace pir {

--- a/paddle/fluid/pir/transforms/general/auto_layout_pass.cc
+++ b/paddle/fluid/pir/transforms/general/auto_layout_pass.cc
@@ -125,8 +125,8 @@ class AutoLayoutPass : public pir::Pass {
   // Due to the current transpose performance issues, our single explicit
   // transpose does not perform better than cudnn, and there are interruptions
   // in the network due to operators that do not support NHWC. So we set the
-  // scale to 1.2 temporarily.
-  float transpose_scale_ = 1.2;
+  // scale to 1.3 temporarily.
+  float transpose_scale_ = 1.3;
 };
 }  // namespace
 namespace pir {

--- a/paddle/phi/ops/yaml/legacy/static_ops.yaml
+++ b/paddle/phi/ops/yaml/legacy/static_ops.yaml
@@ -61,7 +61,6 @@
   optional : x
   inplace : (x -> out)
   backward : assign_grad
-  interfaces: paddle::dialect::LayoutTransformationInterface
 
 - op : assign_value
   args : (int[] shape, DataType dtype, Scalar[] values = {})

--- a/paddle/phi/ops/yaml/ops.yaml
+++ b/paddle/phi/ops/yaml/ops.yaml
@@ -853,7 +853,7 @@
     data_type : x
   inplace: (x -> out)
   backward : cast_grad
-  interfaces : paddle::dialect::InferSymbolicShapeInterface
+  interfaces : paddle::dialect::InferSymbolicShapeInterface, paddle::dialect::LayoutTransformationInterface
 
 - op : ceil
   args : (Tensor x)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
1. set fallback scale to 1.3 and polish autolayoutpass code.
2. temporarily set the pool's layout transition strategy.
3. allow op has UnaryElementwiseTrait or BinaryElementwiseTrait but not have LayoutTransformationInterface change layout.
4. polish code

Pcard-67164