### PR TITLE
[CINN] Add second AnchorFusion after SplitRecompute

### DIFF
--- a/paddle/cinn/operator_fusion/pattern_graph.cc
+++ b/paddle/cinn/operator_fusion/pattern_graph.cc
@@ -49,12 +49,6 @@ std::vector<PatternNodePtr> PatternGraph::ClusterOps() {
   VLOG(4) << "[Group Cluster] After ReduceTree_Trivial_Fusion: ";
   PrintGraphInfo();
 
-  // All -> AnchorPattern
-  VLOG(4) << "[Group Cluster] Start LiftToAnchorPattern";
-  LiftToAnchorPattern();
-  VLOG(4) << "[Group Cluster] After LiftToAnchorPattern: ";
-  PrintGraphInfo();
-
   // AnchorPattern x AnchorPattern Fusion
   VLOG(4) << "[Group Cluster] Start AnchorFusion";
   AnchorFusion();
@@ -65,6 +59,12 @@ std::vector<PatternNodePtr> PatternGraph::ClusterOps() {
   VLOG(4) << "[Group Cluster] Start SplitRecomputePattern";
   SplitRecomputePattern();
   VLOG(4) << "[Group Cluster] After SplitRecomputePattern: ";
+  PrintGraphInfo();
+
+  // Second AnchorFusion after split recompute
+  VLOG(4) << "[Group Cluster] Start Second AnchorFusion";
+  AnchorFusion();
+  VLOG(4) << "[Group Cluster] After AnchorFusion: ";
   PrintGraphInfo();
 
   // Horizontal fusion.
@@ -192,16 +192,14 @@ void PatternGraph::ReduceTree_Trivial_Fusion() {
       MergeReduceTreeAndTrivialOperation>(this);
 }
 
-void PatternGraph::LiftToAnchorPattern() {
+void PatternGraph::AnchorFusion() {
   GraphTransformer<NodePattern,
                    Or<StmtPatternGraphMatcher<TrivialPattern>,
                       StmtPatternGraphMatcher<ReduceTreePlusTrivialPattern>,
                       StmtPatternGraphMatcher<ReducePattern>,
                       StmtPatternGraphMatcher<ReduceTreePattern>>,
                    LiftToAnchorPatternOperation>(this);
-}
 
-void PatternGraph::AnchorFusion() {
   GraphTransformer<ReverseTopoNodePairPattern,
                    And<CanAnchorFusionMatcher, InputOutputMaximumConstrain>,
                    AnchorFusionOperation>(this);

--- a/paddle/cinn/operator_fusion/pattern_graph.cc
+++ b/paddle/cinn/operator_fusion/pattern_graph.cc
@@ -237,9 +237,6 @@ void PatternGraph::ItersPermutationFusion() {
 void PatternGraph::SplitRecomputePattern() {
   GraphTransformer<NodePattern, RecomputeNodeMatcher, SplitRecomputeOperation>(
       this);
-  GraphTransformer<NodePattern,
-                   StmtPatternGraphMatcher<TrivialPattern>,
-                   LiftToAnchorPatternOperation>(this);
 }
 
 PatternGraph::PatternGraph(const std::vector<PatternContent>& contents,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
- 有些 case 可能会在第一次 AnchorFusion 不能进行融合，然后 SplitRecompute 对其中未融合的 Trivial 进行 inline 后，又可以用 AnchorFusion 进行融合了，因此该 PR 在 SplitRecompute 后又加了一次 AnchorFusion