### PR TITLE
[CINN] Fix template replacement of NoReduceMethod

### DIFF
--- a/paddle/cinn/ir/group_schedule/config/group_tile_config.cc
+++ b/paddle/cinn/ir/group_schedule/config/group_tile_config.cc
@@ -687,12 +687,12 @@ TileConfigMap BuildStaticSpatialConfig(
     if (rd_block_num > 1 && base_info->can_apply_grid_reduce) {
       int64_t rd_threshold = rd_block_num * min_loops * 16;
       collector({1, kMaxNumel, 1, rd_threshold},
-                {16, 16, 1, 1, 1, -1, BlockReduceMethod()});
+                {16, 16, 1, 1, 1, -1, DiscreteReduceMethod()});
       collector({1, kMaxNumel, rd_threshold + 1, kMaxNumel},
-                {16, 16, rd_block_num, 1, 1, -1, BlockReduceMethod()});
+                {16, 16, rd_block_num, 1, 1, -1, DiscreteReduceMethod()});
     } else {
       collector({1, kMaxNumel, 1, kMaxNumel},
-                {16, 16, 1, 1, 1, -1, BlockReduceMethod()});
+                {16, 16, 1, 1, 1, -1, DiscreteReduceMethod()});
     }
   }
 

--- a/paddle/cinn/ir/group_schedule/tactic/tile_discrete_reduction_tactic.cc
+++ b/paddle/cinn/ir/group_schedule/tactic/tile_discrete_reduction_tactic.cc
@@ -14,7 +14,6 @@
 
 #include "paddle/cinn/ir/group_schedule/tactic/tile_discrete_reduction_tactic.h"
 #include "paddle/cinn/ir/ir_analyzer/ir_analyzer.h"
-#include "paddle/cinn/ir/schedule/ir_schedule_util.h"
 
 namespace cinn {
 namespace ir {
@@ -43,8 +42,8 @@ class TileDiscreteReductionTactic final : public ScheduleTactic {
   void MergeReduceAxis(ir::IRSchedule* sch, const std::string& block_id);
   void SplitSptialInner(ir::IRSchedule* sch, const std::string& block_id);
   void SplitReduceInner(ir::IRSchedule* sch, const std::string& block_id);
-  void VariableTypeAssignment(ir::IRSchedule* sch, const std::string& block_id);
-  void SetDiscreteReduceType(ir::IRSchedule* sch, const std::string& block_id);
+  void SetBufferType(ir::IRSchedule* sch, const std::string& block_id);
+  void SetReduceType(ir::IRSchedule* sch, const std::string& block_id);
   void BindCudaInfo(ir::IRSchedule* sch, const std::string& block_id);
 
  private:
@@ -107,6 +106,7 @@ void TileDiscreteReductionTactic::Init(ScheduleContext* context,
   }
 
   map_rf_block_.clear();
+  map_global_rf_block_.clear();
 }
 
 void TileDiscreteReductionTactic::Apply(ir::IRSchedule* sch,
@@ -133,11 +133,8 @@ void TileDiscreteReductionTactic::Apply(ir::IRSchedule* sch,
   BindCudaInfo(sch, block_id);
   VLOG(6) << "After BindCudaInfo on block: [" << block_id << "], loop nest:\n"
           << sch->GetLoops(block_id)[0];
-  VariableTypeAssignment(sch, block_id);
-  VLOG(6) << "After VariableTypeAssignment on block: [" << block_id
-          << "], loop nest:\n"
-          << sch->GetLoops(block_id)[0];
-  SetDiscreteReduceType(sch, block_id);
+  SetBufferType(sch, block_id);
+  SetReduceType(sch, block_id);
 }
 
 void TileDiscreteReductionTactic::MergeDiscreteFlattenAxis(
@@ -202,8 +199,7 @@ void TileDiscreteReductionTactic::SplitReduceInner(
   sch->Reorder({loops[cur_reduce_axis + 1], loops[cur_reduce_axis]});
 
   loops = sch->GetLoops(block_id);
-  if (IsReductionSBlock(sch->GetBlock(block_id)) &&
-      ir::GetLoopExtent(loops[2]) != 1) {
+  if (IsReductionSBlock(sch->GetBlock(block_id))) {
     ir::Expr rf_tensor =
         sch->FactorizeReduction(loops[cur_reduce_axis],
                                 /* rf_axis = */ 0,
@@ -232,8 +228,8 @@ void TileDiscreteReductionTactic::SplitReduceInner(
   }
 }
 
-void TileDiscreteReductionTactic::VariableTypeAssignment(
-    ir::IRSchedule* sch, const std::string& block_id) {
+void TileDiscreteReductionTactic::SetBufferType(ir::IRSchedule* sch,
+                                                const std::string& block_id) {
   auto block = sch->GetBlock(block_id);
   if (context_->output_names.count(block_id) > 0) {
     sch->SetBuffer(block, "global");
@@ -247,19 +243,19 @@ void TileDiscreteReductionTactic::VariableTypeAssignment(
   }
 }
 
-void TileDiscreteReductionTactic::SetDiscreteReduceType(
-    ir::IRSchedule* sch, const std::string& block_id) {
+void TileDiscreteReductionTactic::SetReduceType(ir::IRSchedule* sch,
+                                                const std::string& block_id) {
   if (IsReductionSBlock(sch->GetBlock(block_id))) {
     auto block = sch->GetBlock(block_id)
                      .As<ir::ScheduleBlockRealize>()
                      ->schedule_block.As<ir::ScheduleBlock>();
-    block->reduce_method = cinn::ir::DiscreteReduceMethod();
+    block->reduce_method = context_->config.tile_config.reduce_method;
   }
   if (map_global_rf_block_.count(block_id) > 0) {
     auto block = sch->GetBlock(map_global_rf_block_[block_id])
                      .As<ir::ScheduleBlockRealize>()
                      ->schedule_block.As<ir::ScheduleBlock>();
-    block->reduce_method = cinn::ir::DiscreteReduceMethod();
+    block->reduce_method = context_->config.tile_config.reduce_method;
   }
 }
 

--- a/test/cpp/cinn/optim/replace_cross_thread_reduction_test.cc
+++ b/test/cpp/cinn/optim/replace_cross_thread_reduction_test.cc
@@ -52,6 +52,11 @@ TEST(CrossThreadReductionReplacer, basic) {
   ir_sch.Bind(ir_sch.GetLoops("B")[0], "blockIdx.x");
   ir_sch.Bind(ir_sch.GetLoops("B")[1], "threadIdx.x");
 
+  ir::Expr block = ir_sch.GetBlock("B");
+  block.As<ir::ScheduleBlockRealize>()
+      ->schedule_block.As<ir::ScheduleBlock>()
+      ->reduce_method = ir::BlockReduceMethod();
+
   ir::Expr func_body = ir_sch.GetModule().GetExprs()[0];
   std::vector<ir::Argument> args{
       ir::Argument(ir::Var("A"), ir::Argument::IO::kInput),


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
CINN


### PR Types
Bug fixes


### Description
规范Reduce直接写回memory的行为，修复reduce_method=NoRedceMethod时的一个错误

#### 规定
由于之前yield_store时有时无，Reduce是否能直接写回memory也没有规定，因此本PR规定如下：

1. 对于串行的Reduce，必须在寄存器上完成，否则会对中间变量读写很多次，造成性能下降
2. 对于并行的Reduce（cross-thread/block），可以在寄存器上或memory上完成，因为并行Reduce会被替换为模板，模板内有自己的中间变量，不会用memory当作中间变量

#### 代码修改
为了让串行Reduce不直接写回memory，本PR修改了调度的一些判定，即使在loop很小的情况下也进行RFactor操作，这样保证一定会创建一个中间变量用于Reduce

另外，由于串行Reduce不需要进行同步，调度器会将其标记为reduce_method=NoReduceMethod，NoReduce指的不是没有Reduce，而是不需要替换CUDA同步模板，只要自然写回就好；本PR也相应修改了后端Pass的替换逻辑

<br>
Pcard-85711