### PR TITLE
[Recompute] Use Flag to change recompute level

### DIFF
--- a/python/paddle/decomposition/recompute.py
+++ b/python/paddle/decomposition/recompute.py
@@ -156,8 +156,6 @@ COMPUTE_INTENSIVE_OPS: list[str] = [
 IGNORE_OPS: list[str] = [
     "cf.stack_create",
 ]
-
-RECOMPUTE_LEVEL = os.getenv("FLAGS_recompute_level")
 # Restricts the amount of computation recompute can do.
 MAX_DIST_FROM_BW = 3
 
@@ -503,7 +501,8 @@ def auto_recompute(
             return mem_sz * 2
 
     def _ban_recomputation(value_node):
-        if str(RECOMPUTE_LEVEL).upper() in ("AGGRESSIVE"):
+        recompute_level = os.getenv("FLAGS_recompute_level")
+        if str(recompute_level).upper() in ("AGGRESSIVE"):
             return value_node.get_defining_op().name() in unrecomputable_ops
         else:
             if value_node.get_defining_op().name() in tending_to_recompute_ops:

--- a/python/paddle/decomposition/recompute.py
+++ b/python/paddle/decomposition/recompute.py
@@ -503,6 +503,8 @@ def auto_recompute(
     def _ban_recomputation(value_node):
         recompute_level = os.getenv("FLAGS_recompute_level")
         if str(recompute_level).upper() in ("AGGRESSIVE"):
+            return value_node.get_defining_op().name() in random_ops
+        elif str(recompute_level).upper() in ("ENHANCED"):
             return value_node.get_defining_op().name() in unrecomputable_ops
         else:
             if value_node.get_defining_op().name() in tending_to_recompute_ops:

--- a/python/paddle/decomposition/recompute.py
+++ b/python/paddle/decomposition/recompute.py
@@ -157,7 +157,7 @@ IGNORE_OPS: list[str] = [
     "cf.stack_create",
 ]
 
-AGGRESSIVE_RECOMPUTATION = False
+RECOMPUTE_LEVEL = os.getenv("FLAGS_recompute_level")
 # Restricts the amount of computation recompute can do.
 MAX_DIST_FROM_BW = 3
 
@@ -503,7 +503,7 @@ def auto_recompute(
             return mem_sz * 2
 
     def _ban_recomputation(value_node):
-        if AGGRESSIVE_RECOMPUTATION:
+        if str(RECOMPUTE_LEVEL).upper() in ("AGGRESSIVE"):
             return value_node.get_defining_op().name() in unrecomputable_ops
         else:
             if value_node.get_defining_op().name() in tending_to_recompute_ops:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Devs

### Description
<!-- Describe what you’ve done -->
pcard-67164
Use Flag to change recompute level
Now we have 2 levels:
*AGGRESSIVE* : more ops will tend to be recomputed
normal: Consider balance between mem and ips