### PR TITLE
[Dy2St][CINN] Dont access cpp flag `FLAGS_use_cinn` via `os.getenv`

### DIFF
--- a/python/paddle/base/framework.py
+++ b/python/paddle/base/framework.py
@@ -444,6 +444,9 @@ def in_cinn_mode() -> bool:
 
     """
     CINN_FLAG_NAME = "FLAGS_use_cinn"
+    # NOTE: This flag only available when compiled with CINN
+    if not is_compiled_with_cinn():
+        return False
     return paddle.get_flags(CINN_FLAG_NAME)[CINN_FLAG_NAME]
 
 

--- a/python/paddle/jit/dy2static/utils.py
+++ b/python/paddle/jit/dy2static/utils.py
@@ -662,9 +662,7 @@ def cinn_is_enabled(build_strategy, backend):
         return True
     if build_strategy is not None and build_strategy.build_cinn_pass:
         return True
-
-    value = os.getenv('FLAGS_use_cinn')
-    if value is not None and value.lower() in ['true', '1']:
+    if paddle.base.framework.in_cinn_mode():
         return True
     return False
 

--- a/test/ir/pir/test_cse_pass.py
+++ b/test/ir/pir/test_cse_pass.py
@@ -16,6 +16,7 @@ import unittest
 from contextlib import contextmanager
 
 import paddle
+from paddle.base.framework import flag_guard
 
 paddle.enable_static()
 
@@ -29,16 +30,6 @@ def program_scope_guard():
     with paddle.static.scope_guard(new_scope):
         with paddle.static.program_guard(main_program):
             yield main_program
-
-
-@contextmanager
-def flag_guard(flag_name, flag_value):
-    old_value = paddle.get_flags(flag_name)[flag_name]
-    paddle.set_flags({flag_name: flag_value})
-    try:
-        yield
-    finally:
-        paddle.set_flags({flag_name: old_value})
 
 
 def walk_block(block, fn):
@@ -412,11 +403,11 @@ class TestCSECanNotReplace(unittest.TestCase, AssertOpCountEqualMixin):
     "This case only works when compiled with CINN",
 )
 class TestCSEDenyFullInCinn(unittest.TestCase, AssertOpCountEqualMixin):
-    CINN_FLAGS_NAME = "FLAGS_use_cinn"
+    CINN_FLAG_NAME = "FLAGS_use_cinn"
 
     def test_replace_full_without_cinn(self):
         with flag_guard(
-            self.CINN_FLAGS_NAME, False
+            self.CINN_FLAG_NAME, False
         ), program_scope_guard() as main_program:
             # Inputs
             x1 = paddle.full([2], 1.0, dtype="float32")
@@ -428,7 +419,7 @@ class TestCSEDenyFullInCinn(unittest.TestCase, AssertOpCountEqualMixin):
 
     def test_replace_full_with_cinn(self):
         with flag_guard(
-            self.CINN_FLAGS_NAME, True
+            self.CINN_FLAG_NAME, True
         ), program_scope_guard() as main_program:
             # Inputs
             x1 = paddle.full([2], 1.0, dtype="float32")

--- a/test/ir/pir/test_pir_executor_flag.py
+++ b/test/ir/pir/test_pir_executor_flag.py
@@ -15,6 +15,7 @@
 import os
 import unittest
 
+import paddle
 from paddle.base.framework import in_cinn_mode, in_pir_executor_mode
 
 
@@ -27,8 +28,12 @@ class TestPIRModeFlags(unittest.TestCase):
 
 class TestCinnModeFlags(unittest.TestCase):
     def test_cinn_mode_flags(self):
+        CINN_FLAG_NAME = "FLAGS_use_cinn"
+        if not paddle.is_compiled_with_cinn():
+            self.assertFalse(in_cinn_mode())
+            return
         self.assertFalse(in_cinn_mode())
-        os.environ["FLAGS_use_cinn"] = "true"
+        paddle.set_flags({CINN_FLAG_NAME: True})
         self.assertTrue(in_cinn_mode())
 
 

--- a/test/ir/pir/test_pir_executor_flag.py
+++ b/test/ir/pir/test_pir_executor_flag.py
@@ -16,7 +16,7 @@ import os
 import unittest
 
 import paddle
-from paddle.base.framework import in_cinn_mode, in_pir_executor_mode
+from paddle.base.framework import flag_guard, in_cinn_mode, in_pir_executor_mode
 
 
 class TestPIRModeFlags(unittest.TestCase):
@@ -33,8 +33,8 @@ class TestCinnModeFlags(unittest.TestCase):
             self.assertFalse(in_cinn_mode())
             return
         self.assertFalse(in_cinn_mode())
-        paddle.set_flags({CINN_FLAG_NAME: True})
-        self.assertTrue(in_cinn_mode())
+        with flag_guard(CINN_FLAG_NAME, True):
+            self.assertTrue(in_cinn_mode())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

确保所有 `FLAGS_use_cinn` 的设置与获取都使用单一数据来源，即 C++ 的 flag 状态，这个状态是 Python/C++ 统一的，**不应该在 `import paddle` 之后设置和访问对应的环境变量**，这往往会导致数据不同步，难以维护，**局部修改注意使用 guard 避免 side effect 意外扩散到后续操作**

C++ flag（即在 `flags.cc` 声明的，`FLAGS_` 开头的大多数是），此类主要用于需要 C++ 代码直接感知，应该统一使用以下 API（数据会存在 C++ 侧，不应该存在其他地方）

- 声明 `flags.cc`
- 设置 `paddle.set_flags`
- 获取 `paddle.get_flags`
- guard `paddle.base.framework.flag_guard`

而非 C++ flag，此类主要用于纯 Python 代码感知，应该使用以下 API（数据会存在环境变量中，不应该存在其他地方）

- 声明 创建 `python/paddle/utils/environments.py::EnvironmentVariable` 实例 `ENV_xxx`（如环境变量 `AAA_BBB_CCC` 应该对应 `ENV_AAA_BBB_CCC` 实例）
- 设置 `ENV_xxx.set`
- 获取 `ENV_xxx.get`
- guard `python/paddle/utils/environments.py::EnvironmentVariableGuard`