### PR TITLE
[Prim] add clip_grad vjp decomp

### DIFF
--- a/paddle/fluid/pir/dialect/op_generator/decomp_interface_gen_op_list.py
+++ b/paddle/fluid/pir/dialect/op_generator/decomp_interface_gen_op_list.py
@@ -97,6 +97,7 @@ GENERATE_IMPL_VJP = [
     'angle_grad',
     'bce_loss_grad',
     'cos_grad',
+    'clip_grad',
     'divide_grad',
     'elementwise_pow_grad',
     'erf_grad',

--- a/paddle/fluid/prim/api/composite_backward/composite_backward_api.h
+++ b/paddle/fluid/prim/api/composite_backward/composite_backward_api.h
@@ -112,7 +112,31 @@ void relu_grad(const Tensor& out, const Tensor& out_grad, Tensor* x_grad) {
     set_output<T>(res, x_grad);
   }
 }
-
+template <typename T>
+void clip_grad(const Tensor& x,
+               const Tensor& out_grad,
+               const Tensor& min,
+               const Tensor& max,
+               Tensor* x_grad) {
+  if (x_grad) {
+    Tensor min = reshape<T>(min, common::vectorize(x.dims()));
+    if (min.dtype() != x.dtype()) {
+      min = cast<T>(min, x.dtype());
+    }
+    auto mask_min = greater_than<T>(x, min);
+    Tensor max = reshape<T>(max, common::vectorize(x.dims()));
+    if (max.dtype() != x.dtype()) {
+      max = cast<T>(max, x.dtype());
+    }
+    auto mask_max = less_than<T>(x, max);
+    auto mask = mask_min + mask_max;
+    auto res = cast<T>(mask, out_grad.dtype()) * out_grad;
+    if (out_grad.dtype() != x.dtype()) {
+      res = cast<T>(res, x.dtype());
+    }
+    set_output<T>(res, x_grad);
+  }
+}
 template <typename T>
 void softmax_grad(const Tensor& out,
                   const Tensor& out_grad,

--- a/paddle/fluid/prim/api/composite_backward/composite_backward_api.h
+++ b/paddle/fluid/prim/api/composite_backward/composite_backward_api.h
@@ -112,31 +112,7 @@ void relu_grad(const Tensor& out, const Tensor& out_grad, Tensor* x_grad) {
     set_output<T>(res, x_grad);
   }
 }
-template <typename T>
-void clip_grad(const Tensor& x,
-               const Tensor& out_grad,
-               const Tensor& min,
-               const Tensor& max,
-               Tensor* x_grad) {
-  if (x_grad) {
-    Tensor min = reshape<T>(min, common::vectorize(x.dims()));
-    if (min.dtype() != x.dtype()) {
-      min = cast<T>(min, x.dtype());
-    }
-    auto mask_min = greater_than<T>(x, min);
-    Tensor max = reshape<T>(max, common::vectorize(x.dims()));
-    if (max.dtype() != x.dtype()) {
-      max = cast<T>(max, x.dtype());
-    }
-    auto mask_max = less_than<T>(x, max);
-    auto mask = mask_min + mask_max;
-    auto res = cast<T>(mask, out_grad.dtype()) * out_grad;
-    if (out_grad.dtype() != x.dtype()) {
-      res = cast<T>(res, x.dtype());
-    }
-    set_output<T>(res, x_grad);
-  }
-}
+
 template <typename T>
 void softmax_grad(const Tensor& out,
                   const Tensor& out_grad,

--- a/paddle/fluid/primitive/codegen/decomp_vjp_gen.py
+++ b/paddle/fluid/primitive/codegen/decomp_vjp_gen.py
@@ -158,6 +158,7 @@ CUSTOM_VJP = [
     'stack_grad',
     'swish_grad',
     'elu_grad',
+    'clip_grad',
     'swiglu_grad',
     'p_norm_grad',
 ]  # custom vjp list of composite op

--- a/paddle/fluid/primitive/decomp_rule/decomp_vjp/details.h
+++ b/paddle/fluid/primitive/decomp_rule/decomp_vjp/details.h
@@ -1331,22 +1331,15 @@ void relu_grad(const Tensor& out, const Tensor& out_grad, Tensor* x_grad) {
 template <typename T>
 void clip_grad(const Tensor& x,
                const Tensor& out_grad,
-               const Tensor& min,
-               const Tensor& max,
+               const Scalar& min,
+               const Scalar& max,
                Tensor* x_grad) {
   if (x_grad) {
-    Tensor mask_shape = shape64<T>(x);
-    Tensor min = reshape<T>(min, mask_shape);
-    if (min.dtype() != x.dtype()) {
-      min = cast<T>(min, x.dtype());
-    }
-    auto mask_min = greater_than<T>(x, min);
-    Tensor max = reshape<T>(max, mask_shape);
-    if (max.dtype() != x.dtype()) {
-      max = cast<T>(max, x.dtype());
-    }
-    auto mask_max = less_than<T>(x, max);
-    auto mask = mask_min + mask_max;
+    Tensor min_tensor = full_scalar<T>(min.to<double>(), x.dtype());
+    Tensor max_tensor = full_scalar<T>(max.to<double>(), x.dtype());
+    auto mask_gt = greater_than<T>(x, min_tensor);
+    auto mask_le = less_than<T>(x, max_tensor);
+    auto mask = backend::logical_and<T>(mask_gt, mask_le);
     auto res = cast<T>(mask, out_grad.dtype()) * out_grad;
     if (out_grad.dtype() != x.dtype()) {
       res = cast<T>(res, x.dtype());

--- a/python/paddle/autograd/backward_utils.py
+++ b/python/paddle/autograd/backward_utils.py
@@ -108,6 +108,7 @@ ALLOW_DYNAMIC_SHAPE_VJP_OPS = [
     "pd_op.where",
     "pd_op.p_norm",
     "pd_op.elu",
+    "pd_op.clip",
 ]
 
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Pcard-67164
- add clip_grad vjp decomp
- 自动生成的代码，只支持 full op 处理过的 Scalar
- 但是 clip 的前向拆解支持了 Value 的场景(手动的)，尝试支持的 pr https://github.com/PaddlePaddle/Paddle/pull/71836