### PR TITLE
[XPU] fix XPU linking error on Clang

### DIFF
--- a/paddle/phi/kernels/custom/c_embedding_grad_kernel.cc
+++ b/paddle/phi/kernels/custom/c_embedding_grad_kernel.cc
@@ -31,7 +31,7 @@ void CEmbeddingGradKernel(const Context& dev_ctx,
                           int64_t start_index,
                           DenseTensor* w_grad) {
   w_grad->Resize(w.dims());
-  dev_ctx.template Alloc(w_grad, w.dtype());
+  dev_ctx.Alloc(w_grad, w.dtype());
   const auto& index_type = ids.dtype();
   if (index_type == phi::DataType::INT32 ||
       index_type == phi::DataType::INT64) {

--- a/paddle/phi/kernels/xpu/c_concat_kernel.cc
+++ b/paddle/phi/kernels/xpu/c_concat_kernel.cc
@@ -58,7 +58,7 @@ void CConcatKernel(const Context& dev_ctx,
   phi::DDim temp_out_dims = x->dims();
   temp_out_dims[0] *= nranks;
   temp_out.Resize(temp_out_dims);
-  dev_ctx.template Alloc(&temp_out, x->dtype());
+  dev_ctx.Alloc(&temp_out, x->dtype());
 
   XPUStream stream = nullptr;
   phi::distributed::BKCLCommContext* comm_ctx = nullptr;
@@ -86,7 +86,7 @@ void CConcatKernel(const Context& dev_ctx,
 
   phi::funcs::ConcatFunctor<phi::XPUContext, T> functor;
   out->Resize(out_dims);
-  dev_ctx.template Alloc(out, x->dtype());
+  dev_ctx.Alloc(out, x->dtype());
   functor(dev_ctx, inputs, axis, out);
 #else
   PADDLE_THROW(common::errors::PreconditionNotMet(

--- a/paddle/phi/kernels/xpu/c_embedding_kernel_grad.cc
+++ b/paddle/phi/kernels/xpu/c_embedding_kernel_grad.cc
@@ -29,7 +29,7 @@ void CEmbeddingGradKernel(const Context& dev_ctx,
                           int64_t start_index,
                           DenseTensor* w_grad) {
   w_grad->Resize(w.dims());
-  dev_ctx.template Alloc(w_grad, w.dtype());
+  dev_ctx.Alloc(w_grad, w.dtype());
   T* table_grad_data = static_cast<T*>(w_grad->data());
   using XPUType = typename XPUTypeTrait<T>::Type;
 

--- a/paddle/phi/kernels/xpu/c_softmax_with_cross_entropy_kernel.cc
+++ b/paddle/phi/kernels/xpu/c_softmax_with_cross_entropy_kernel.cc
@@ -161,8 +161,8 @@ struct CSoftmaxWithCrossEntropyFunctor<phi::XPUContext, T> {
     stream = dev_ctx.stream();
 
     // allocate memory on device.
-    dev_ctx.template Alloc(softmax, logits->dtype());
-    dev_ctx.template Alloc(loss, logits->dtype());
+    dev_ctx.Alloc(softmax, logits->dtype());
+    dev_ctx.Alloc(loss, logits->dtype());
 
     const auto& logits_dims = logits->dims();
 

--- a/paddle/phi/kernels/xpu/c_split_kernel.cc
+++ b/paddle/phi/kernels/xpu/c_split_kernel.cc
@@ -59,7 +59,7 @@ void CSplitKernel(const Context& dev_ctx,
 
   dims[dims_size - 1] /= nranks;
   out->Resize(dims);
-  dev_ctx.template Alloc(out, x.dtype());
+  dev_ctx.Alloc(out, x.dtype());
 
   std::vector<XPUType*> output_list(nranks, nullptr);
   output_list.at(rank) = reinterpret_cast<XPUType*>(out->data<T>());

--- a/paddle/phi/kernels/xpu/embedding_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/embedding_grad_kernel.cc
@@ -93,8 +93,7 @@ void EmbeddingSparseGradKernel(const Context& ctx,
   std::vector<int64_t> ids;
   DenseTensor ids_cpu;
   ids_cpu.Resize(input.dims());
-  ctx.template HostAlloc(
-      &ids_cpu, input.dtype(), input.numel() * sizeof(int64_t));
+  ctx.HostAlloc(&ids_cpu, input.dtype(), input.numel() * sizeof(int64_t));
   if (input.dtype() == phi::DataType::INT64) {
     phi::Copy(ctx, input, CPUPlace(), false, &ids_cpu);
 

--- a/paddle/phi/kernels/xpu/reduce_sum_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/reduce_sum_grad_kernel.cc
@@ -33,7 +33,7 @@ void ReduceSumGradKernel(const Context& dev_ctx,
   using XPUType = typename XPUTypeTrait<T>::Type;
   reduce_all = recompute_reduce_all(x, dims_arr, reduce_all);
   auto dims = dims_arr.GetData();
-  dev_ctx.template Alloc(x_grad, x.dtype());
+  dev_ctx.Alloc(x_grad, x.dtype());
   auto* out_data = reinterpret_cast<const XPUType*>(out_grad.data());
   auto* x_grad_data = reinterpret_cast<XPUType*>(x_grad->data());
   const auto& input_dim_size = x.dims().size();


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Custom Device

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Some XPU Kernels use `dev_ctx.template Alloc` to call a no-template function, which would cause error in clang compiler.

![2b91bb20d9b47bc1f307ceaf234041b1](https://github.com/user-attachments/assets/99aa3b97-690f-4fe3-a10b-5390183f126c)
