### PR TITLE
add support_fp32_mix_precision for layer_norm and softmax

### DIFF
--- a/python/paddle/tensorrt/impls/activation.py
+++ b/python/paddle/tensorrt/impls/activation.py
@@ -75,6 +75,8 @@ def relu6_converter(network, paddle_op, inputs):
 
 @converter_registry.register("pd_op.softmax", trt_version="trt_version_ge=8.0")
 def softmax_converter(network, paddle_op, inputs):
+    from paddle.tensorrt.util import support_fp32_mix_precision
+
     input1 = inputs[0]
     input_shape = input1.shape
     input_dims = len(input_shape)
@@ -95,6 +97,7 @@ def softmax_converter(network, paddle_op, inputs):
 
     layer = network.add_softmax(input1)
     set_layer_name(layer, paddle_op)
+    support_fp32_mix_precision(paddle_op.name(), layer)
     axes = max(0, input_dims - 3)
 
     # Handle padded dimensions

--- a/python/paddle/tensorrt/impls/norm.py
+++ b/python/paddle/tensorrt/impls/norm.py
@@ -36,6 +36,8 @@ from paddle.tensorrt.register import converter_registry
     "pd_op.layer_norm", trt_version="trt_version_ge=8.6"
 )
 def layernorm_converter(network, paddle_op, inputs):
+    from paddle.tensorrt.util import support_fp32_mix_precision
+
     input_a, scale, bias = inputs
 
     begin_norm_axis = paddle_op.attrs().get("begin_norm_axis", 0)
@@ -75,7 +77,7 @@ def layernorm_converter(network, paddle_op, inputs):
     layer_norm.epsilon = epsilon
     layer_norm.compute_precision = trt.float32
     set_layer_name(layer_norm, paddle_op)
-
+    support_fp32_mix_precision(paddle_op.name(), layer_norm)
     return layer_norm.get_output(0)
 
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

New features

### Description
<!-- Describe what you’ve done -->
pcard-71501
add support_fp32_mix_precision for layer_norm and softmax pir-trt converter