### PR TITLE
refix core: auto growth allocator add release lock

### DIFF
--- a/paddle/phi/core/memory/allocation/auto_growth_best_fit_allocator.h
+++ b/paddle/phi/core/memory/allocation/auto_growth_best_fit_allocator.h
@@ -46,8 +46,7 @@ class AutoGrowthBestFitAllocator : public Allocator {
 
   // Release the memory block which is not used in pool.
   uint64_t ReleaseImpl(const phi::Place &place) override {
-    // TODO(vivienfanghuagood): the next line may cause the process to deadlock.
-    // std::lock_guard<SpinLock> guard(spinlock_);
+    std::lock_guard<SpinLock> guard(spinlock_);
     return FreeIdleChunks();
   }
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes


### Description
<!-- Describe what you’ve done -->
AutoGrowthBestFitAllocator作为默认的显存分配器，它是进程级的，在创建predictor时会调用ReleaseImpl释放空闲的chunks，但是ReleaseImpl不是线程安全的，如果此时其他predictor正在分配或者释放显存，会导致进程core或hang；
修复方式：参考FreeImpl和AllocateImpl接口实现，在ReleaseImpl中添加自旋锁，防止并发错误。
经过在多个不同模型中验证，加锁后core和hang的现象基本不会出现。
