### PR TITLE
fix bug when set PADDLE_CUDA_ARCH_LIST but extra_compile_args not given

### DIFF
--- a/python/paddle/utils/cpp_extension/extension_utils.py
+++ b/python/paddle/utils/cpp_extension/extension_utils.py
@@ -560,7 +560,7 @@ def normalize_extension_kwargs(kwargs, use_cuda=False):
     kwargs['library_dirs'] = library_dirs
 
     # append compile flags and check settings of compiler
-    extra_compile_args = kwargs.get('extra_compile_args', [])
+    extra_compile_args = kwargs.get('extra_compile_args', {})
     if isinstance(extra_compile_args, dict):
         for compiler in ['cxx', 'nvcc']:
             if compiler not in extra_compile_args:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-71500

修复当设置了环境变量PADDLE_CUDA_ARCH_LIST但是没有传extra_compile_args的时候报错的bug
