### PR TITLE
use slice to implement r2s of split_axis 

### DIFF
--- a/paddle/phi/core/distributed/auto_parallel/reshard/r_to_s_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/r_to_s_reshard_function.cc
@@ -69,8 +69,8 @@ void RToSReshardFunction::Eval(phi::DeviceContext* dev_ctx,
 
   DenseTensor dense_out;
   int64_t start = split_num_vec[0] * coord_in_mesh[mesh_axis];
-  int64_t end =
-      std::min(start + split_num_vec[0], in_physical_tensor_cur_rank.dims()[0]);
+  int64_t end = std::min(start + split_num_vec[0],
+                         in_physical_tensor_cur_rank.dims()[split_axis]);
   PADDLE_ENFORCE_LE(start,
                     end,
                     ::common::errors::InvalidArgument(

--- a/paddle/phi/core/distributed/auto_parallel/reshard/r_to_s_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/r_to_s_reshard_function.cc
@@ -63,7 +63,6 @@ void RToSReshardFunction::Eval(phi::DeviceContext* dev_ctx,
           << ". Split will use axis " << mesh_axis << " of process_mesh."
           << " There will have " << num_of_process
           << " process participate in.";
-
   std::vector<int64_t> split_num_vec =
       BalancedSplit(in.dims()[split_axis], num_of_process);
   auto dtype = in_physical_tensor_cur_rank.dtype();

--- a/paddle/phi/core/distributed/auto_parallel/reshard/r_to_s_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/r_to_s_reshard_function.cc
@@ -20,8 +20,8 @@
 #include "paddle/phi/core/distributed/auto_parallel/reshard/reshard_utils.h"
 #include "paddle/phi/core/distributed/auto_parallel/reshard/same_status_reshard_function.h"
 #include "paddle/phi/core/distributed/store/store_utils.h"
-#include "paddle/phi/kernels/split_kernel.h"
 #include "paddle/phi/kernels/slice_kernel.h"
+#include "paddle/phi/kernels/split_kernel.h"
 
 namespace phi::distributed {
 
@@ -75,7 +75,8 @@ void RToSReshardFunction::Eval(phi::DeviceContext* dev_ctx,
     DenseTensor dense_out;
     int64_t cur_rank_id = GetCurGlobalRank();
     int64_t start = split_num_vec[0] * cur_rank_id;
-    int64_t end = std::min(split_num_vec[0] * (cur_rank_id + 1), in_physical_tensor_cur_rank.dims()[split_axis]);
+    int64_t end = std::min(split_num_vec[0] * (cur_rank_id + 1),
+                           in_physical_tensor_cur_rank.dims()[split_axis]);
     RESHARD_FUNCTOR(dev_ctx,
                     Slice,
                     dtype,
@@ -96,7 +97,7 @@ void RToSReshardFunction::Eval(phi::DeviceContext* dev_ctx,
                     &split_out_vec);
     SetValue(out, split_out_vec[coord_in_mesh[mesh_axis]]);
     VLOG(3) << "The current process will remain the idx "
-          << coord_in_mesh[mesh_axis] << " piece of tensor";
+            << coord_in_mesh[mesh_axis] << " piece of tensor";
   }
   SetDistProps(out, in.dims(), out_dist_attr);
 }

--- a/paddle/phi/core/distributed/auto_parallel/reshard/r_to_s_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/r_to_s_reshard_function.cc
@@ -68,10 +68,16 @@ void RToSReshardFunction::Eval(phi::DeviceContext* dev_ctx,
   auto dtype = in_physical_tensor_cur_rank.dtype();
 
   DenseTensor dense_out;
-  int64_t cur_rank_id = GetCurGlobalRank();
-  int64_t start = split_num_vec[0] * cur_rank_id;
-  int64_t end = std::min(split_num_vec[0] * (cur_rank_id + 1),
-                         in_physical_tensor_cur_rank.dims()[split_axis]);
+  int64_t start = split_num_vec[0] * coord_in_mesh[mesh_axis];
+  int64_t end =
+      std::min(start + split_num_vec[0], in_physical_tensor_cur_rank.dims()[0]);
+  PADDLE_ENFORCE_LE(start,
+                    end,
+                    ::common::errors::InvalidArgument(
+                        "Slice Args 'start' should be less or qual to 'end', "
+                        "but got 'start' is %d, 'end' is %d.",
+                        start,
+                        end));
   RESHARD_FUNCTOR(dev_ctx,
                   Slice,
                   dtype,

--- a/paddle/phi/core/distributed/auto_parallel/reshard/r_to_s_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/r_to_s_reshard_function.cc
@@ -72,7 +72,7 @@ void RToSReshardFunction::Eval(phi::DeviceContext* dev_ctx,
   int64_t cur_rank_id = GetCurGlobalRank();
   int64_t start = split_num_vec[0] * cur_rank_id;
   int64_t end = std::min(split_num_vec[0] * (cur_rank_id + 1),
-                          in_physical_tensor_cur_rank.dims()[split_axis]);
+                         in_physical_tensor_cur_rank.dims()[split_axis]);
   RESHARD_FUNCTOR(dev_ctx,
                   Slice,
                   dtype,

--- a/paddle/phi/kernels/slice_kernel.h
+++ b/paddle/phi/kernels/slice_kernel.h
@@ -73,20 +73,20 @@ DenseTensor Slice(const Context& ctx,
 
 template <typename T, typename Context>
 void Slice(const Context& ctx,
-            const DenseTensor& input,
-            const std::vector<int64_t>& axes,
-            const IntArray& starts,
-            const IntArray& ends,
-            DenseTensor* out) {
-    MetaTensor meta_out(out);
-    std::vector<int64_t> infer_flags = {1};
-    std::vector<int64_t> decrease_axis = {};
-    SliceRawInferMeta(
-        input, axes, starts, ends, infer_flags, decrease_axis, &meta_out);
-    if (input.initialized()) {
-        SliceKernel<T, Context>(
-            ctx, input, axes, starts, ends, infer_flags, decrease_axis, out);
-    }
+           const DenseTensor& input,
+           const std::vector<int64_t>& axes,
+           const IntArray& starts,
+           const IntArray& ends,
+           DenseTensor* out) {
+  MetaTensor meta_out(out);
+  std::vector<int64_t> infer_flags = {1};
+  std::vector<int64_t> decrease_axis = {};
+  SliceRawInferMeta(
+      input, axes, starts, ends, infer_flags, decrease_axis, &meta_out);
+  if (input.initialized()) {
+    SliceKernel<T, Context>(
+        ctx, input, axes, starts, ends, infer_flags, decrease_axis, out);
+  }
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/slice_kernel.h
+++ b/paddle/phi/kernels/slice_kernel.h
@@ -71,4 +71,22 @@ DenseTensor Slice(const Context& ctx,
   return dense_out;
 }
 
+template <typename T, typename Context>
+void Slice(const Context& ctx,
+            const DenseTensor& input,
+            const std::vector<int64_t>& axes,
+            const IntArray& starts,
+            const IntArray& ends,
+            DenseTensor* out) {
+    MetaTensor meta_out(out);
+    std::vector<int64_t> infer_flags = {1};
+    std::vector<int64_t> decrease_axis = {};
+    SliceRawInferMeta(
+        input, axes, starts, ends, infer_flags, decrease_axis, &meta_out);
+    if (input.initialized()) {
+        SliceKernel<T, Context>(
+            ctx, input, axes, starts, ends, infer_flags, decrease_axis, out);
+    }
+}
+
 }  // namespace phi


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Auto Parallel 
### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Performance

### Description
<!-- Describe what you’ve done -->

r_2_s uses slice kernel
