### PR TITLE
[Fix] use `py_compile` for pyi file syntax check

### DIFF
--- a/tools/gen_pybind11_stub.py
+++ b/tools/gen_pybind11_stub.py
@@ -15,11 +15,11 @@
 from __future__ import annotations
 
 import argparse
-import ast
 import functools
 import keyword
 import logging
 import os
+import py_compile
 import re
 import shutil
 import tempfile
@@ -323,40 +323,25 @@ def insert_import_modules(filename: str):
         f.write(stub_file)
 
 
-def check_remove_syntax_error(filename, limit=1000):
+def check_remove_syntax_error(filename):
     """
     Args:
         filename: xxx.pyi
-        limit: check limit, or raise error
     """
     pattern_check = re.compile(
         rf"File.*{re.escape(filename)}.*line (?P<lineno>\d+)"
     )
 
-    while limit:
-        limit -= 1
+    while True:
 
-        # read file and check syntax error
+        # check syntax error
         err = ""
-        source = ""
-        source_lines = []
-        with open(filename, "r", encoding="utf-8") as f:
-            source_lines = f.readlines()
-            source = "".join(source_lines)
 
-            is_valid = True
-
-            try:
-                ast.parse(source, filename)
-            except SyntaxError:
-                is_valid = False
-                err = traceback.format_exc()
-
-            if is_valid:
-                break
-            else:
-                if limit <= 0:
-                    print(f">>> Syntax error detected in file: {filename}")
+        try:
+            py_compile.compile(filename, doraise=True)
+            break
+        except py_compile.PyCompileError as e:
+            err = traceback.format_exc()
 
         print(f">>> Syntax error: find syntax error in file: {filename}")
 
@@ -364,17 +349,24 @@ def check_remove_syntax_error(filename, limit=1000):
         match_obj = pattern_check.search(err)
         if match_obj is not None:
             line_no = int(match_obj.group("lineno"))
+
+            # read file
+            source_lines = []
+            with open(filename, "r", encoding="utf-8") as f:
+                source_lines = f.readlines()
+
+            del source_lines[line_no - 1]
+
+            # write new lines
+            with open(filename, "w", encoding="utf-8") as f:
+                f.writelines(source_lines)
+
             print(
                 f">>> Syntax error: remove the error line {line_no}, and continue to check ..."
             )
-            del source_lines[line_no - 1]
         else:
             print(">>> Syntax error: no match obj, just continue ...")
             break
-
-        # write new lines
-        with open(filename, "w", encoding="utf-8") as f:
-            f.writelines(source_lines)
 
 
 def post_process(output_dir: str):

--- a/tools/gen_pybind11_stub.py
+++ b/tools/gen_pybind11_stub.py
@@ -323,16 +323,19 @@ def insert_import_modules(filename: str):
         f.write(stub_file)
 
 
-def check_remove_syntax_error(filename):
+def check_remove_syntax_error(filename: str, limit: int = 10000):
     """
     Args:
         filename: xxx.pyi
+        limit: the max times try to check syntax error
     """
     pattern_check = re.compile(
         rf"File.*{re.escape(filename)}.*line (?P<lineno>\d+)"
     )
 
-    while True:
+    while limit > 0:
+
+        limit -= 1
 
         # check syntax error
         err = ""


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Use `py_compile` instead of `ast.parse` for pyi file syntax check. 

`ast.parse` at Python 3.9 can not guarantee raise `SyntaxError`.
- https://docs.python.org/3.8/library/ast.html#ast.parse
- https://docs.python.org/3.9/library/ast.html#ast.parse

@SigureMo 