### PR TITLE
[Dy2St][CINN] Explicit use phi backend in more CINN uts

### DIFF
--- a/test/ir/pir/cinn/sub_graphs/base.py
+++ b/test/ir/pir/cinn/sub_graphs/base.py
@@ -61,7 +61,10 @@ class TestBase(unittest.TestCase):
                 )
             else:
                 net = paddle.jit.to_static(
-                    net(), full_graph=True, input_spec=self.input_specs
+                    net(),
+                    backend=None,
+                    full_graph=True,
+                    input_spec=self.input_specs,
                 )
         if self.with_train:
             net.train()

--- a/test/ir/pir/cinn/symbolic/test_decomp_inference_predictor_run.py
+++ b/test/ir/pir/cinn/symbolic/test_decomp_inference_predictor_run.py
@@ -58,6 +58,7 @@ class TestPredictorRunWithTensor(unittest.TestCase):
                 ),
             ],
             full_graph=True,
+            backend=None,
         )
         paddle.jit.save(
             model,

--- a/test/ir/pir/cinn/symbolic/test_reshape_dyshape2stshape.py
+++ b/test/ir/pir/cinn/symbolic/test_reshape_dyshape2stshape.py
@@ -54,7 +54,11 @@ class TestSigmoid(unittest.TestCase):
                     full_graph=True,
                 )
             else:
-                net = paddle.jit.to_static(net, full_graph=True)
+                net = paddle.jit.to_static(
+                    net,
+                    backend=None,
+                    full_graph=True,
+                )
         paddle.seed(123)
         outs = net(*self.inputs)
         return outs

--- a/test/ir/pir/cinn/symbolic/test_sub_graph_flatten.py
+++ b/test/ir/pir/cinn/symbolic/test_sub_graph_flatten.py
@@ -51,7 +51,11 @@ class TestSigmoid(unittest.TestCase):
                     full_graph=True,
                 )
             else:
-                net = paddle.jit.to_static(net, full_graph=True)
+                net = paddle.jit.to_static(
+                    net,
+                    backend=None,
+                    full_graph=True,
+                )
         paddle.seed(123)
         outs = net(*self.inputs)
         return outs

--- a/test/legacy_test/test_stack_op.py
+++ b/test/legacy_test/test_stack_op.py
@@ -396,7 +396,11 @@ class TestStackListOfSingleTensor(unittest.TestCase):
     def test_list_single_tensor(self):
         expect = paddle.stack(self.x)
         paddle.base.core._set_prim_all_enabled(True)
-        st_model = paddle.jit.to_static(paddle.stack, full_graph=True)
+        st_model = paddle.jit.to_static(
+            paddle.stack,
+            backend=None,
+            full_graph=True,
+        )
         actual = st_model(self.x)
         np.testing.assert_allclose(expect, actual)
         paddle.enable_static()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

在一些漏掉的 case 中添加 `backend=None`

### Related links

CINN 切默认系列 PR

- [1/N] #71815
- [2/N] #71817
- [3/N] #71837
- [4/N] #71834
- [5/N] ➡️ #71896
- [6/N] #71838