### PR TITLE
[SOT][Faster Guard] support `NumpyDtypeMatchGuard`

### DIFF
--- a/paddle/fluid/pybind/CMakeLists.txt
+++ b/paddle/fluid/pybind/CMakeLists.txt
@@ -193,8 +193,7 @@ if(WITH_PYTHON)
     set(PYBIND_DEPS ${PYBIND_DEPS} process_group_custom)
   endif()
   if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.0)
-    set(DISTRIBUTE_COMPILE_FLAGS
-        "${DISTRIBUTE_COMPILE_FLAGS} -faligned-new -fvisibility=hidden")
+    set(DISTRIBUTE_COMPILE_FLAGS "${DISTRIBUTE_COMPILE_FLAGS} -faligned-new")
     set_source_files_properties(
       distributed_py.cc PROPERTIES COMPILE_FLAGS ${DISTRIBUTE_COMPILE_FLAGS})
   endif()

--- a/paddle/fluid/pybind/CMakeLists.txt
+++ b/paddle/fluid/pybind/CMakeLists.txt
@@ -193,7 +193,8 @@ if(WITH_PYTHON)
     set(PYBIND_DEPS ${PYBIND_DEPS} process_group_custom)
   endif()
   if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.0)
-    set(DISTRIBUTE_COMPILE_FLAGS "${DISTRIBUTE_COMPILE_FLAGS} -faligned-new")
+    set(DISTRIBUTE_COMPILE_FLAGS
+        "${DISTRIBUTE_COMPILE_FLAGS} -faligned-new -fvisibility=hidden")
     set_source_files_properties(
       distributed_py.cc PROPERTIES COMPILE_FLAGS ${DISTRIBUTE_COMPILE_FLAGS})
   endif()

--- a/paddle/fluid/pybind/jit.cc
+++ b/paddle/fluid/pybind/jit.cc
@@ -112,7 +112,7 @@ void BindGuard(pybind11::module *m) {
              GuardBase,
              std::shared_ptr<NumpyDtypeMatchGuard>>(
       *m, "NumpyDtypeMatchGuard", R"DOC(NumpyDtypeMatchGuard Class.)DOC")
-      .def(py::init<const py::dtype &>(), py::arg("dtype"));
+      .def(py::init<const py::object &>(), py::arg("dtype"));
 
   m->def(
       "merge_guard",

--- a/paddle/fluid/pybind/jit.cc
+++ b/paddle/fluid/pybind/jit.cc
@@ -108,6 +108,11 @@ void BindGuard(pybind11::module *m) {
              std::shared_ptr<InstanceCheckGuard>>(
       *m, "InstanceCheckGuard", R"DOC(InstanceCheckGuard Class.)DOC")
       .def(py::init<const py::object &>(), py::arg("isinstance_obj"));
+  py::class_<NumpyDtypeMatchGuard,
+             GuardBase,
+             std::shared_ptr<NumpyDtypeMatchGuard>>(
+      *m, "NumpyDtypeMatchGuard", R"DOC(NumpyDtypeMatchGuard Class.)DOC")
+      .def(py::init<const py::dtype &>(), py::arg("dtype"));
 
   m->def(
       "merge_guard",

--- a/paddle/fluid/pybind/sot/guards.cc
+++ b/paddle/fluid/pybind/sot/guards.cc
@@ -139,10 +139,10 @@ bool NumpyDtypeMatchGuard::check(PyObject* value) {
   }
 
   if (py::isinstance<py::array>(value)) {
-    return py::cast<py::array>(value).dtype().is(*expected_);
+    return py::cast<py::array>(value).dtype().is(expected_);
   }
 
-  return expected_->equal(py::handle(value).get_type());
+  return expected_.equal(py::handle(value).get_type());
 }
 
 #endif

--- a/paddle/fluid/pybind/sot/guards.cc
+++ b/paddle/fluid/pybind/sot/guards.cc
@@ -133,4 +133,16 @@ bool InstanceCheckGuard::check(PyObject* value) {
   return PyObject_IsInstance(value, expected_);
 }
 
+bool NumpyDtypeMatchGuard::check(PyObject* value) {
+  if (value == nullptr) {
+    return false;
+  }
+
+  if (py::isinstance<py::array>(value)) {
+    return py::cast<py::array>(value).dtype().is(expected_);
+  }
+
+  return expected_.equal(py::handle(value).get_type());
+}
+
 #endif

--- a/paddle/fluid/pybind/sot/guards.cc
+++ b/paddle/fluid/pybind/sot/guards.cc
@@ -139,10 +139,10 @@ bool NumpyDtypeMatchGuard::check(PyObject* value) {
   }
 
   if (py::isinstance<py::array>(value)) {
-    return py::cast<py::array>(value).dtype().is(expected_);
+    return py::cast<py::array>(value).dtype().is(*expected_);
   }
 
-  return expected_.equal(py::handle(value).get_type());
+  return expected_->equal(py::handle(value).get_type());
 }
 
 #endif

--- a/paddle/fluid/pybind/sot/guards.cc
+++ b/paddle/fluid/pybind/sot/guards.cc
@@ -138,6 +138,9 @@ bool NumpyDtypeMatchGuard::check(PyObject* value) {
   if (value == nullptr) {
     return false;
   }
+
+  // TODO(dev): encountered a compilation error: "declared with greater
+  // visibility than the type of its field", so had to put the conversion here
   py::dtype expected_dtype = py::cast<py::dtype>(expected_);
 
   if (py::isinstance<py::array>(value)) {

--- a/paddle/fluid/pybind/sot/guards.cc
+++ b/paddle/fluid/pybind/sot/guards.cc
@@ -19,6 +19,7 @@ limitations under the License. */
 
 #include <Python.h>
 #include <frameobject.h>
+#include "pybind11/numpy.h"
 
 #if !defined(PyObject_CallOneArg) && !PY_3_9_PLUS
 static inline PyObject* PyObject_CallOneArg(PyObject* func, PyObject* arg) {
@@ -137,12 +138,13 @@ bool NumpyDtypeMatchGuard::check(PyObject* value) {
   if (value == nullptr) {
     return false;
   }
+  py::dtype expected_dtype = py::cast<py::dtype>(expected_);
 
   if (py::isinstance<py::array>(value)) {
-    return py::cast<py::array>(value).dtype().is(expected_);
+    return py::cast<py::array>(value).dtype().is(expected_dtype);
   }
 
-  return expected_.equal(py::handle(value).get_type());
+  return expected_dtype.equal(py::handle(value).get_type());
 }
 
 #endif

--- a/paddle/fluid/pybind/sot/guards.h
+++ b/paddle/fluid/pybind/sot/guards.h
@@ -209,6 +209,8 @@ class NumpyDtypeMatchGuard : public GuardBase {
     Py_INCREF(expected_);
   }
 
+  ~NumpyDtypeMatchGuard() override { Py_DECREF(expected_); }
+
   bool check(PyObject* value) override;
 
  private:

--- a/paddle/fluid/pybind/sot/guards.h
+++ b/paddle/fluid/pybind/sot/guards.h
@@ -18,20 +18,11 @@ limitations under the License. */
 #include "paddle/fluid/pybind/sot/macros.h"
 #include "paddle/phi/core/utils/data_type.h"
 #include "paddle/utils/pybind.h"
-#include "pybind11/numpy.h"
 #include "pybind11/pybind11.h"
 
 namespace py = pybind11;
 #define PYBIND11_DETAILED_ERROR_MESSAGES
 #if SOT_IS_SUPPORTED
-
-// The visibility attribute is to avoid a warning about storing a field in the
-// struct that has a different visibility (from pybind) than the struct.
-#ifdef _WIN32
-#define VISIBILITY_HIDDEN
-#else
-#define VISIBILITY_HIDDEN __attribute__((visibility("hidden")))
-#endif
 
 class GuardBase {
  public:
@@ -213,12 +204,15 @@ class InstanceCheckGuard : public GuardBase {
 
 class NumpyDtypeMatchGuard : public GuardBase {
  public:
-  explicit NumpyDtypeMatchGuard(const py::dtype& dtype) : expected_(dtype) {}
+  explicit NumpyDtypeMatchGuard(const py::object& dtype)
+      : expected_(dtype.ptr()) {
+    Py_INCREF(expected_);
+  }
 
   bool check(PyObject* value) override;
 
  private:
-  py::dtype expected_;
+  PyObject* expected_;
 };
 
 #endif

--- a/paddle/fluid/pybind/sot/guards.h
+++ b/paddle/fluid/pybind/sot/guards.h
@@ -205,13 +205,12 @@ class InstanceCheckGuard : public GuardBase {
 
 class NumpyDtypeMatchGuard : public GuardBase {
  public:
-  explicit NumpyDtypeMatchGuard(const py::dtype& dtype)
-      : expected_(std::make_unique<py::dtype>(dtype)) {}
+  explicit NumpyDtypeMatchGuard(const py::dtype& dtype) : expected_(dtype) {}
 
   bool check(PyObject* value) override;
 
  private:
-  std::unique_ptr<py::dtype> expected_;
+  py::dtype expected_;
 };
 
 #endif

--- a/paddle/fluid/pybind/sot/guards.h
+++ b/paddle/fluid/pybind/sot/guards.h
@@ -205,12 +205,13 @@ class InstanceCheckGuard : public GuardBase {
 
 class NumpyDtypeMatchGuard : public GuardBase {
  public:
-  explicit NumpyDtypeMatchGuard(const py::dtype& dtype) : expected_(dtype) {}
+  explicit NumpyDtypeMatchGuard(const py::dtype& dtype)
+      : expected_(std::make_unique<py::dtype>(dtype)) {}
 
   bool check(PyObject* value) override;
 
  private:
-  py::dtype expected_;
+  std::unique_ptr<py::dtype> expected_;
 };
 
 #endif

--- a/paddle/fluid/pybind/sot/guards.h
+++ b/paddle/fluid/pybind/sot/guards.h
@@ -25,6 +25,14 @@ namespace py = pybind11;
 #define PYBIND11_DETAILED_ERROR_MESSAGES
 #if SOT_IS_SUPPORTED
 
+// The visibility attribute is to avoid a warning about storing a field in the
+// struct that has a different visibility (from pybind) than the struct.
+#ifdef _WIN32
+#define VISIBILITY_HIDDEN
+#else
+#define VISIBILITY_HIDDEN __attribute__((visibility("hidden")))
+#endif
+
 class GuardBase {
  public:
   GuardBase() = default;

--- a/paddle/fluid/pybind/sot/guards.h
+++ b/paddle/fluid/pybind/sot/guards.h
@@ -18,6 +18,7 @@ limitations under the License. */
 #include "paddle/fluid/pybind/sot/macros.h"
 #include "paddle/phi/core/utils/data_type.h"
 #include "paddle/utils/pybind.h"
+#include "pybind11/numpy.h"
 #include "pybind11/pybind11.h"
 
 namespace py = pybind11;
@@ -200,6 +201,16 @@ class InstanceCheckGuard : public GuardBase {
 
  private:
   PyObject* expected_;
+};
+
+class NumpyDtypeMatchGuard : public GuardBase {
+ public:
+  explicit NumpyDtypeMatchGuard(const py::dtype& dtype) : expected_(dtype) {}
+
+  bool check(PyObject* value) override;
+
+ private:
+  py::dtype expected_;
 };
 
 #endif

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
@@ -1331,16 +1331,20 @@ class NumpyNumberVariable(NumpyVariable):
     def make_stringified_guard(self) -> list[StringifiedExpression]:
         frame_value_tracer = self.tracker.trace_value_from_frame()
 
-        dtype_guard = StringifiedExpression(
+        dtype_guard = FasterStringifiedExpression(
             f"{{}}.dtype == {NumpyVariable.format_dtype(self.get_py_value().dtype)}",
+            paddle.framework.core.NumpyDtypeMatchGuard(
+                self.get_py_value().dtype
+            ),
             [frame_value_tracer],
             union_free_vars(frame_value_tracer.free_vars, {"np": np}),
         )
 
         return [
             dtype_guard,
-            StringifiedExpression(
+            FasterStringifiedExpression(
                 f"{{}} == {NumpyVariable.format_number(self.get_py_value())}",
+                paddle.framework.core.ValueMatchGuard(self.get_py_value()),
                 [frame_value_tracer],
                 union_free_vars(frame_value_tracer.free_vars, {"np": np}),
             ),

--- a/test/sot/test_faster_guard.py
+++ b/test/sot/test_faster_guard.py
@@ -137,6 +137,7 @@ class TestBasicFasterGuard(unittest.TestCase):
         self.assertTrue(guard_numpy_dtype.check(np.int32()))
         self.assertFalse(guard_numpy_dtype.check(np.array(1, dtype=np.int64)))
         self.assertFalse(guard_numpy_dtype.check(np.float32()))
+        self.assertFalse(guard_numpy_dtype.check(np.bool_()))
 
 
 class TestFasterGuardGroup(unittest.TestCase):

--- a/test/sot/test_faster_guard.py
+++ b/test/sot/test_faster_guard.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 import unittest
 from collections import OrderedDict
 
+import numpy as np
+
 import paddle
 
 
@@ -124,6 +126,17 @@ class TestBasicFasterGuard(unittest.TestCase):
         layer.eval()
         self.assertTrue(guard_id.check(layer))
         self.assertFalse(guard_id.check(paddle.nn.Linear(10, 10)))
+
+    def test_numpy_dtype_match_guard(self):
+        np_array = np.array(1, dtype=np.int32)
+        guard_numpy_dtype = paddle.framework.core.NumpyDtypeMatchGuard(
+            np_array.dtype
+        )
+        self.assertTrue(guard_numpy_dtype.check(np_array))
+        self.assertTrue(guard_numpy_dtype.check(np.array(1, dtype=np.int32)))
+        self.assertTrue(guard_numpy_dtype.check(np.int32()))
+        self.assertFalse(guard_numpy_dtype.check(np.array(1, dtype=np.int64)))
+        self.assertFalse(guard_numpy_dtype.check(np.float32()))
 
 
 class TestFasterGuardGroup(unittest.TestCase):

--- a/test/sot/test_faster_guard.py
+++ b/test/sot/test_faster_guard.py
@@ -139,6 +139,15 @@ class TestBasicFasterGuard(unittest.TestCase):
         self.assertFalse(guard_numpy_dtype.check(np.float32()))
         self.assertFalse(guard_numpy_dtype.check(np.bool_()))
 
+        np_bool = np.bool_(1)
+        guard_numpy_bool_dtype = paddle.framework.core.NumpyDtypeMatchGuard(
+            np_bool.dtype
+        )
+        self.assertTrue(guard_numpy_bool_dtype.check(np.bool_()))
+        self.assertTrue(
+            guard_numpy_bool_dtype.check(np.array(1, dtype=np.bool_))
+        )
+
 
 class TestFasterGuardGroup(unittest.TestCase):
     def test_guard_group(self):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->

* `NumpyDtypeMatchGuard` 支持，用于检查两个 numpy dtype 是否一致

