### PR TITLE
[XPU] update xhpc to solve flashmask error in some cases

### DIFF
--- a/cmake/external/xpu.cmake
+++ b/cmake/external/xpu.cmake
@@ -30,7 +30,7 @@ set(XPU_XFA_LIB_NAME "libxpu_flash_attention.so")
 set(XPU_XPUDNN_LIB_NAME "libxpu_dnn.so")
 
 if(NOT DEFINED XPU_XHPC_BASE_DATE)
-  set(XPU_XHPC_BASE_DATE "dev/20250318")
+  set(XPU_XHPC_BASE_DATE "dev/20250405")
 endif()
 set(XPU_XCCL_BASE_VERSION "3.0.2.5") # For XRE5
 if(NOT DEFINED XPU_XFT_BASE_VERSION)

--- a/paddle/phi/kernels/xpu/flash_attn_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/flash_attn_grad_kernel.cc
@@ -232,6 +232,8 @@ void FlashAttnGradKernelBase(
       is_flashmask ? flashmask_stream : nullptr);
   PADDLE_ENFORCE_XDNN_SUCCESS(r, "mha_varlen_bwd");
   if (is_flashmask && flashmask_stream != nullptr) {
+    r = xpu_wait(flashmask_stream);
+    PADDLE_ENFORCE_XPU_SUCCESS(r);
     xpu_stream_destroy(flashmask_stream);
   }
 }

--- a/paddle/phi/kernels/xpu/flash_attn_kernel.cc
+++ b/paddle/phi/kernels/xpu/flash_attn_kernel.cc
@@ -210,12 +210,15 @@ void FlashAttnKernelBase(
       (const int*)upstart_row_indices_data,       // upstart_row_indices_data
       (const int*)upend_row_indices_data,         // upend_row_indices_data
       is_flashmask ? startend_row_indices->dims()[1]
-                   : 0,                          // flash_mask_head_num
-      nullptr,                                   // flashmask_maxmin
-      is_flashmask ? flashmask_stream : nullptr  // side_stream
+                   : 0,                           // flash_mask_head_num
+      nullptr,                                    // flashmask_maxmin
+      is_flashmask ? flashmask_stream : nullptr,  // side_stream
+      0                                           // fixlen_batch_num
   );
   PADDLE_ENFORCE_XDNN_SUCCESS(r, "mha_varlen_fwd");
   if (is_flashmask && flashmask_stream != nullptr) {
+    r = xpu_wait(flashmask_stream);
+    PADDLE_ENFORCE_XPU_SUCCESS(r);
     xpu_stream_destroy(flashmask_stream);
   }
 }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Custom Device


### PR Types
Bug fixes


### Description

升级xhpc至0405，修复了flashmask算子hang的问题。

同时修复了flashmask可能存在的stream同步问题。


