### PR TITLE
[SOT] Use same list when create dynamic axes meta to ensure `SymbolicVariable` are same

### DIFF
--- a/python/paddle/jit/sot/infer_meta.py
+++ b/python/paddle/jit/sot/infer_meta.py
@@ -36,7 +36,13 @@ from paddle.distributed.auto_parallel.static.utils import (
 from paddle.framework import use_pir_api
 from paddle.utils import flatten, is_sequence
 
-from .utils import Cache, Singleton, map_if_extend, meta_str
+from .utils import (
+    Cache,
+    Singleton,
+    map_if_extend,
+    meta_str,
+    update_list_inplace,
+)
 
 DynamicSymbolT = TypeVar("DynamicSymbolT")
 SOT_INFER_META_INNER_VAR = "___SOT_INFER_META_INNER_VAR"
@@ -142,8 +148,7 @@ class MetaInfo:
         # NOTE(SigureMo): Ensure output meta.shape is same list object as
         # self.shape to avoid create two different data proxy for tensor.shape.
         # It will caused create a new SymbolicVariable when it's a dynamic dim.
-        self.shape.clear()
-        self.shape.extend(shape)
+        self.shape = update_list_inplace(self.shape, shape)
         return MetaInfo(
             self.shape,
             self.dtype,

--- a/python/paddle/jit/sot/infer_meta.py
+++ b/python/paddle/jit/sot/infer_meta.py
@@ -139,8 +139,13 @@ class MetaInfo:
             SymbolicInt() if i in dynamic_axes else dim
             for i, dim in enumerate(self.shape)
         ]
+        # NOTE(SigureMo): Ensure output meta.shape is same list object as
+        # self.shape to avoid create two different data proxy for tensor.shape.
+        # It will caused create a new SymbolicVariable when it's a dynamic dim.
+        self.shape.clear()
+        self.shape.extend(shape)
         return MetaInfo(
-            shape,
+            self.shape,
             self.dtype,
             self.stop_gradient,
             self.name,

--- a/python/paddle/jit/sot/opcode_translator/executor/dispatcher.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/dispatcher.py
@@ -105,7 +105,6 @@ class Parameter:
         return convert_annotation_to_type(self.annotation)
 
     def match_arg(self, arg: Any) -> bool:
-        # TODO: support VAR_KEYWORD
         if self.kind == inspect.Parameter.VAR_POSITIONAL:
             is_tuple = isinstance(arg, tuple)
             return is_tuple and all(isinstance(a, self.type) for a in arg)

--- a/python/paddle/jit/sot/utils/__init__.py
+++ b/python/paddle/jit/sot/utils/__init__.py
@@ -105,4 +105,5 @@ from .utils import (  # noqa: F401
     no_eval_frame,
     printable,
     switch_symbol_registry,
+    update_list_inplace,
 )

--- a/python/paddle/jit/sot/utils/utils.py
+++ b/python/paddle/jit/sot/utils/utils.py
@@ -430,6 +430,14 @@ def do_until_stop_iteration(fn: Callable[[], T]) -> list[T]:
     return res
 
 
+def update_list_inplace(
+    original_list: list[T], new_contents: list[T]
+) -> list[T]:
+    original_list.clear()
+    original_list.extend(new_contents)
+    return original_list
+
+
 def get_obj_stable_repr(obj) -> str:
     if hasattr(obj, '__qualname__'):
         return obj.__qualname__


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

应该是 #71771 暴露的新问题

对于动态 shape 场景，我们首先提前触发 `tensor.shape` 从 `meta.shape` 构造 shape 对应的 `ListVariable`，并 `shape_var.proxy.get_all()` 提前 finalize 所有值，以确保知道哪些是 `SymbolicVariable`，当发现 `SymbolicVariable` 时，反过来更新 `meta.shape`，但这里 `meta.shape` 的更新是非 inplace 的，是创建一个新的 meta，shape 也是全新的 list，这会导致下一次再次 `tensor.shape` 时，重新创建的 data proxy 也是全新的，会再次重新创建 `SymbolicVariable`，由于这次 `from_value` 传入的是 `SymbolicInt`，所以会创建一个新的 `SymbolicVariable`，会当成中间产生的符号变量来处理，产生错误的 tracker

最终导致在 symbolic fallback to constant 时 disable 该 Symbol 一直没 disable 成功，而且该 cache 还被丢弃了，cache 一直达不到 20，一直触发重复编译

因此本 PR 确保 `meta.shape` 保持是同一个对象，以免创建不同的 `SymbolicVariable`

<!-- PCard-66972 -->