### PR TITLE
[PIR][CSE] Skip replace inplace op in CSE

### DIFF
--- a/paddle/fluid/pir/transforms/general/common_subexpression_elimination_pass.cc
+++ b/paddle/fluid/pir/transforms/general/common_subexpression_elimination_pass.cc
@@ -284,6 +284,11 @@ struct Expression {
               << " has side effect";
       return false;
     }
+    if (op->HasTrait<paddle::dialect::InplaceTrait>()) {
+      VLOG(7) << "[CalcOperationCanBeSafeToReplace] " << op->name()
+              << " is an inplace op";
+      return false;
+    }
     for (auto& value : op->results()) {
       if (!IsDenseTensorOrVectorOfDenseTensorType(value)) {
         VLOG(7)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

CSE 之前考虑一个 OP 是否可以安全替换主要考虑的是

- 自身是否包含 side effect
- 其输出是否被 inplace op 所修改（即写语义）

但是如果其自身为 inplace op，那么自然满足第一个条件，即包含 side effect，因此，将自身为 inplace 的 op 标记为无法替换的，以免下面的 program 被替换错

```text
{
    (%0) = "pd_op.full" [id:32] () {dtype:float32,place:Place(undefined:0),shape:[1],stop_gradient:[true],value:0} : () -> tensor<1xf32>
    (%1) = "pd_op.increment_" [id:33] (%0) {stop_gradient:[true],value:2} : (tensor<1xf32>) -> tensor<1xf32>
    (%2) = "pd_op.increment_" [id:34] (%0) {stop_gradient:[true],value:2} : (tensor<1xf32>) -> tensor<1xf32>
    (%3) = "pd_op.increment_" [id:35] (%0) {stop_gradient:[true],value:2} : (tensor<1xf32>) -> tensor<1xf32>
    (%4) = "pd_op.increment_" [id:36] (%0) {stop_gradient:[true],value:2} : (tensor<1xf32>) -> tensor<1xf32>
    (%5) = "pd_op.increment_" [id:37] (%0) {stop_gradient:[true],value:2} : (tensor<1xf32>) -> tensor<1xf32>
    () = "builtin.shadow_output" [id:38] (%0) {output_name:"output_0"} : (tensor<1xf32>) -> 
}
```

### Related links

CINN 切默认系列 PR

- [1/N] #71815
- [2/N] #71817
- [3/N] #71837
- [4/N] #71834
- [5/N] #71896
- [6/N] ➡️ #71950
- [7/N] #71951
- [8/N] #71960
- [9/N] #71838

<!-- PCard-66972 -->