### PR TITLE
[Dy2St] Use `np.testing` module to get better error message and tolerance settings in `test_ifelse`

### DIFF
--- a/test/dygraph_to_static/test_ifelse.py
+++ b/test/dygraph_to_static/test_ifelse.py
@@ -95,7 +95,7 @@ class TestDygraphIfElse(Dy2StTestBase):
         return ret.numpy()
 
     def test_ast_to_func(self):
-        self.assertTrue((self._run_dygraph() == self._run_static()).all())
+        np.testing.assert_allclose(self._run_dygraph(), self._run_static())
 
 
 class TestDygraphIfElse2(TestDygraphIfElse):
@@ -106,7 +106,9 @@ class TestDygraphIfElse2(TestDygraphIfElse):
     # TODO(dev): fix AST mode
     @disable_test_case((ToStaticMode.AST, IrMode.PT))
     def test_ast_to_func(self):
-        self.assertTrue((self._run_dygraph() == self._run_static()).all())
+        np.testing.assert_allclose(
+            self._run_dygraph(), self._run_static(), atol=1e-7, rtol=1e-7
+        )
 
 
 class TestDygraphIfElse3(Dy2StTestBase):
@@ -126,7 +128,7 @@ class TestDygraphIfElse3(Dy2StTestBase):
         return ret.numpy()
 
     def test_ast_to_func(self):
-        self.assertTrue((self._run_dygraph() == self._run_static()).all())
+        np.testing.assert_allclose(self._run_dygraph(), self._run_static())
 
 
 class TestDygraphIfElse4(TestDygraphIfElse):
@@ -141,7 +143,7 @@ class TestDygraphIfElseWithListGenerator(TestDygraphIfElse):
         self.dyfunc = dyfunc_with_if_else_with_list_generator
 
     def test_ast_to_func(self):
-        self.assertTrue((self._run_dygraph() == self._run_static()).all())
+        np.testing.assert_allclose(self._run_dygraph(), self._run_static())
 
 
 class TestDygraphNestedIfElse(Dy2StTestBase):
@@ -161,7 +163,7 @@ class TestDygraphNestedIfElse(Dy2StTestBase):
         return ret.numpy()
 
     def test_ast_to_func(self):
-        self.assertTrue((self._run_dygraph() == self._run_static()).all())
+        np.testing.assert_allclose(self._run_dygraph(), self._run_static())
 
 
 class TestDygraphNestedIfElse2(TestDygraphIfElse):
@@ -170,7 +172,7 @@ class TestDygraphNestedIfElse2(TestDygraphIfElse):
         self.dyfunc = nested_if_else_2
 
     def test_ast_to_func(self):
-        self.assertTrue((self._run_dygraph() == self._run_static()).all())
+        np.testing.assert_allclose(self._run_dygraph(), self._run_static())
 
 
 class TestDygraphNestedIfElse3(Dy2StTestBase):
@@ -190,7 +192,7 @@ class TestDygraphNestedIfElse3(Dy2StTestBase):
         return ret.numpy()
 
     def test_ast_to_func(self):
-        self.assertTrue((self._run_dygraph() == self._run_static()).all())
+        np.testing.assert_allclose(self._run_dygraph(), self._run_static())
 
 
 def dyfunc_ifExp_with_while(x):
@@ -302,7 +304,7 @@ class TestDygraphIfTensor(Dy2StTestBase):
         return ret.numpy()
 
     def test_ast_to_func(self):
-        self.assertTrue((self._run_dygraph() == self._run_static()).all())
+        np.testing.assert_allclose(self._run_dygraph(), self._run_static())
 
 
 class TestDygraphIfElseNet(Dy2StTestBase):
@@ -329,7 +331,7 @@ class TestDygraphIfElseNet(Dy2StTestBase):
             return ret.numpy()
 
     def test_ast_to_func(self):
-        self.assertTrue((self._run_dygraph() == self._run_static()).all())
+        np.testing.assert_allclose(self._run_dygraph(), self._run_static())
 
 
 # Test to call function ahead caller.
@@ -381,7 +383,9 @@ class TestNetWithExternalFunc(TestDygraphIfElseNet):
         self.Net = NetWithExternalFunc
 
     def test_ast_to_func(self):
-        self.assertTrue((self._run_dygraph() == self._run_static()).all())
+        np.testing.assert_allclose(
+            self._run_dygraph(), self._run_static(), rtol=1e-7, atol=1e-8
+        )
 
 
 class DiffModeNet1(paddle.nn.Layer):
@@ -438,19 +442,15 @@ class TestDiffModeNet(Dy2StTestBase):
             return ret.numpy()
 
     def test_train_mode(self):
-        self.assertTrue(
-            (
-                self._run(mode='train', to_static=True)
-                == self._run(mode='train', to_static=False)
-            ).all()
+        np.testing.assert_allclose(
+            self._run(mode='train', to_static=True),
+            self._run(mode='train', to_static=False),
         )
 
     def test_infer_mode(self):
-        self.assertTrue(
-            (
-                self._run(mode='infer', to_static=True)
-                == self._run(mode='infer', to_static=False)
-            ).all()
+        np.testing.assert_allclose(
+            self._run(mode='infer', to_static=True),
+            self._run(mode='infer', to_static=False),
         )
 
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

动转静和动态图因为 kernel 完全一样能够做到完全对齐，但开编译器后会有些许 diff，因此统一修改为 `np.testing.assert_allclose` 以允许配置 `atol` 和 `rtol`，同时也能获得更好的报错提示

### Related links

CINN 切默认系列 PR

- [1/N] #71815
- [2/N] #71817
- [3/N] #71837
- [4/N] #71834
- [5/N] #71896
- [6/N] #71950
- [7/N] ➡️ #71951
- [8/N] #71960
- [9/N] #71838

<!-- PCard-66972 -->