### PR TITLE
[CINN] Add argmin/argmax op in frontend

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/ir/ops.yaml
+++ b/paddle/cinn/hlir/dialect/operator/ir/ops.yaml
@@ -1,3 +1,19 @@
+- op : argmax
+  args : (Tensor x, int64_t[] axis, bool keepdim=false, DataType dtype=DataType::INT64)
+  output : Tensor(out)
+  infer_meta :
+    func : ReduceSumInferMeta
+    param : [x, axis, keepdim, dtype]
+  interfaces : paddle::dialect::InferSymbolicShapeInterface
+
+- op : argmin
+  args : (Tensor x, int64_t[] axis, bool keepdim=false, DataType dtype=DataType::INT64)
+  output : Tensor(out)
+  infer_meta :
+    func : ReduceSumInferMeta
+    param : [x, axis, keepdim, dtype]
+  interfaces : paddle::dialect::InferSymbolicShapeInterface
+
 - op : broadcast
   args : (Tensor x, int64_t[] broadcast_axes,  int64_t[] out_shape)
   output : Tensor(out)

--- a/paddle/cinn/hlir/dialect/operator/transforms/pd_to_cinn_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/pd_to_cinn_pass.cc
@@ -170,6 +170,53 @@ class ReduceMinMaxOpPattern : public pir::OpRewritePattern<SOURCE_OP> {
   }
 };
 
+template <typename SOURCE_OP, typename TARGET_OP>
+class ArgMinMaxOpPattern : public pir::OpRewritePattern<SOURCE_OP> {
+ public:
+  using pir::OpRewritePattern<SOURCE_OP>::OpRewritePattern;
+
+  bool Match(SOURCE_OP op) const override {
+    const bool is_denied = CompatibleInfo::IsDeniedForCinn(*op.operation());
+    return !is_denied && IsDefinedBy<FullOp>(op, 1);
+  }
+
+  void Rewrite(SOURCE_OP op, pir::PatternRewriter &rewriter) const override {
+    const FullOp full_op = CastDefinedTo<FullOp>(op, 1);
+
+    const int64_t axis_value =
+        full_op.attribute("value")
+            .template dyn_cast<paddle::dialect::ScalarAttribute>()
+            .data()
+            .to<int64_t>();
+    const bool flatten = op.attribute("flatten")
+                             .template dyn_cast<::pir::BoolAttribute>()
+                             .data();
+    const bool keepdim = op.attribute("keepdims")
+                             .template dyn_cast<::pir::BoolAttribute>()
+                             .data();
+    const auto &dtype =
+        op.attribute("dtype")
+            .template dyn_cast<paddle::dialect::DataTypeAttribute>()
+            .data();
+
+    // The argmin/argmax has exactly one axis and is only effective when the
+    // `flatten` attr is false.
+    std::vector<int64_t> axis;
+    if (!flatten) {
+      axis = {axis_value};
+    }
+
+    auto cinn_op =
+        rewriter.Build<TARGET_OP>(op->operand_source(0), axis, keepdim, dtype);
+
+    rewriter.ReplaceAllUsesWith(op.result(0), cinn_op.result(0));
+    rewriter.EraseOp(op);
+    if (full_op->use_empty()) {
+      rewriter.EraseOp(full_op);
+    }
+  }
+};
+
 class ProdOpPattern : public pir::OpRewritePattern<paddle::dialect::ProdOp> {
  public:
   using pir::OpRewritePattern<paddle::dialect::ProdOp>::OpRewritePattern;
@@ -1328,6 +1375,12 @@ pir::RewritePatternSet PdOpToCinnOpPass::InitializePatterns(
                                cinn::dialect::ReduceMinOp>>(context);
   ps.Add<ReduceMinMaxOpPattern<paddle::dialect::MaxOp,
                                cinn::dialect::ReduceMaxOp>>(context);
+  ps.Add<
+      ArgMinMaxOpPattern<paddle::dialect::ArgminOp, cinn::dialect::ArgminOp>>(
+      context);
+  ps.Add<
+      ArgMinMaxOpPattern<paddle::dialect::ArgmaxOp, cinn::dialect::ArgmaxOp>>(
+      context);
   ps.Add<ProdOpPattern>(context);
   ps.Add<ReshapeOpPattern>(context);
   ps.Add<PowOpPattern>(context);

--- a/paddle/cinn/hlir/op/contrib/argmax.cc
+++ b/paddle/cinn/hlir/op/contrib/argmax.cc
@@ -107,7 +107,7 @@ std::shared_ptr<framework::OpStrategy> StrategyForArgmax(
     const framework::NodeAttr &attrs,
     const std::vector<Tensor> &inputs,
     const std::vector<Type> &out_type,
-    const std::vector<std::vector<int>> &output_shapes,
+    const std::vector<std::vector<ir::Dim>> &output_shapes,
     const Target &target) {
   int axis;
   bool keep_dims = false;
@@ -174,10 +174,10 @@ CINN_REGISTER_HELPER(argmax_ops) {
       .describe("This operator implements the op argmax.")
       .set_num_inputs(1)
       .set_num_outputs(1)
-      .set_attr<cinn::hlir::framework::StrategyFunction>(
-          "CINNStrategy", cinn::hlir::op::StrategyForArgmax)
+      .set_attr<cinn::hlir::framework::StrategyFunctionSymbolic>(
+          "CINNStrategySymbolic", cinn::hlir::op::StrategyForArgmax)
       .set_attr<cinn::hlir::framework::OpPatternKind>(
-          "OpPattern", cinn::hlir::framework::OpPatternKind::kNonFusible)
+          "OpPattern", cinn::hlir::framework::OpPatternKind::kReduction)
       .set_support_level(4);
 
   return true;

--- a/paddle/cinn/hlir/op/contrib/argmin.cc
+++ b/paddle/cinn/hlir/op/contrib/argmin.cc
@@ -103,7 +103,7 @@ std::shared_ptr<framework::OpStrategy> StrategyForArgmin(
     const framework::NodeAttr &attrs,
     const std::vector<Tensor> &inputs,
     const std::vector<Type> &out_type,
-    const std::vector<std::vector<int>> &output_shapes,
+    const std::vector<std::vector<ir::Dim>> &output_shapes,
     const Target &target) {
   int axis;
   bool keep_dims = false;
@@ -170,10 +170,10 @@ CINN_REGISTER_HELPER(argmin_ops) {
       .describe("This operator implements the op argmin.")
       .set_num_inputs(1)
       .set_num_outputs(1)
-      .set_attr<cinn::hlir::framework::StrategyFunction>(
-          "CINNStrategy", cinn::hlir::op::StrategyForArgmin)
+      .set_attr<cinn::hlir::framework::StrategyFunctionSymbolic>(
+          "CINNStrategySymbolic", cinn::hlir::op::StrategyForArgmin)
       .set_attr<cinn::hlir::framework::OpPatternKind>(
-          "OpPattern", cinn::hlir::framework::OpPatternKind::kNonFusible)
+          "OpPattern", cinn::hlir::framework::OpPatternKind::kReduction)
       .set_support_level(4);
 
   return true;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
CINN


### PR Types
New features


### Description
CINN前端定义 argmin/argmax op，并实现 pd_to_cinn、cinn_to_pd 的转换；目前暂未启用，等 [@Enigmatisms](https://github.com/Enigmatisms) 实现后端支持后再开启

#### 测试方法
在 paddle/cinn/hlir/framework/pir/utils.cc 中，将 default_deny_ops_ 的 "argmax" "argmin" 两处去掉，然后使用以下单测：
```python
import paddle

@paddle.jit.to_static(backend='CINN', full_graph=True)
def func(x, y):
    return x.argmax(axis=1) + y

x = paddle.randn([128, 256])
y = paddle.randint(0, 0xffff, [128])
func(x, y)
```
该单测可以正常进行前端各Pass与融合，关键阶段IR如下：

Before pd_to_cinn_pass pass:
```cpp
{
    (%0) = "pd_op.data" [id:27] () {dtype:float32,name:"_jst.0.x.0",place:Place(undefined:0),shape:[128,256],stop_gradient:[true]} : () -> tensor<128x256xf32>
    (%1) = "pd_op.data" [id:28] () {dtype:int64,name:"_jst.1.y.0",place:Place(undefined:0),shape:[128],stop_gradient:[true]} : () -> tensor<128xi64>
    (%2) = "pd_op.full" [id:29] () {dtype:int64,place:Place(cpu),shape:[1],stop_gradient:[true],value:1} : () -> tensor<1xi64>
    (%3) = "pd_op.argmax" [id:30] (%0, %2) {dtype:int64,flatten:false,keepdims:false,stop_gradient:[true]} : (tensor<128x256xf32>, tensor<1xi64>) -> tensor<128xi64>
    (%4) = "pd_op.add" [id:31] (%3, %1) {stop_gradient:[true]} : (tensor<128xi64>, tensor<128xi64>) -> tensor<128xi64>
    () = "builtin.shadow_output" [id:32] (%4) {output_name:"output_0"} : (tensor<128xi64>) -> 
}
```
After pd_to_cinn_pass pass:
```cpp
{
    (%0) = "pd_op.data" [id:27] () {dtype:float32,name:"_jst.0.x.0",place:Place(undefined:0),shape:[128,256],stop_gradient:[true]} : () -> tensor<128x256xf32>
    (%1) = "pd_op.data" [id:28] () {dtype:int64,name:"_jst.1.y.0",place:Place(undefined:0),shape:[128],stop_gradient:[true]} : () -> tensor<128xi64>
    (%2) = "cinn_op.argmax" [id:33] (%0) {axis:[1],dtype:int64,keepdim:false,stop_gradient:[true]} : (tensor<128x256xf32>) -> tensor<128xi64>
    (%3) = "pd_op.add" [id:31] (%2, %1) {stop_gradient:[true]} : (tensor<128xi64>, tensor<128xi64>) -> tensor<128xi64>
    () = "builtin.shadow_output" [id:32] (%3) {output_name:"output_0"} : (tensor<128xi64>) -> 
}
```
BucketLower Group:
```cpp
Group id: group_, func_name: fn_argmax_add_
(%0) = "cinn_op.argmax" [id:36] (%1) {axis:[1],dtype:int64,keepdim:false,stop_gradient:[true]} : (tensor<128x256xf32>) -> tensor<128xi64> {<shape[128, 256], data[NULL]>} -> {<shape[128], data[NULL]>}
(%2) = "pd_op.add" [id:37] (%0, %3) {stop_gradient:[true]} : (tensor<128xi64>, tensor<128xi64>) -> tensor<128xi64> {<shape[128], data[NULL]>,<shape[128], data[NULL]>} -> {<shape[128], data[NULL]>}
```

直至 Lowering 阶段 StrategyForArgmax 函数报错，这就需要后端进行支持了

#### 其他测试
* `axis=None`可以正确推导 Shape，直到 Lowering 阶段报错
* `FLAGS_enable_fusion_fallback=1`可以正常完整执行

<br>
Pcard-85711