### PR TITLE
[Prim][CINN] Restore insertion point after decomp

### DIFF
--- a/test/dygraph_to_static/test_slice.py
+++ b/test/dygraph_to_static/test_slice.py
@@ -205,7 +205,9 @@ class TestSetValueWithLayerAndSave(Dy2StTestBase):
 class TestSliceSupplementSpecialCase(Dy2StTestBase):
     # unittest for slice index which abs(step)>0. eg: x[::2]
     def test_static_slice_step(self):
-        with static_guard():
+        with static_guard(), paddle.static.program_guard(
+            paddle.static.Program()
+        ):
             array = np.arange(4**3).reshape((4, 4, 4)).astype('int64')
 
             x = paddle.static.data(name='x', shape=[4, 4, 4], dtype='int64')
@@ -253,18 +255,10 @@ class TestPaddleStridedSlice(Dy2StTestBase):
         stride1 = -2
         sl = paddle.strided_slice(
             pt,
-            axes=[
-                0,
-            ],
-            starts=[
-                s1,
-            ],
-            ends=[
-                e1,
-            ],
-            strides=[
-                stride1,
-            ],
+            axes=[0],
+            starts=[s1],
+            ends=[e1],
+            strides=[stride1],
         )
 
         self.assertTrue(array[s1:e1:stride1], sl)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

组合算子结束后恢复原来的 insertion point，避免副作用扩散到后续 case

该问题在 CINN 在动转静开默认后 `test_slice` 暴露，前一个动转静 case 因为跑了组合算子，导致后面没用 `program_guard` 的纯静态图插入点错误，并不是 `default_main_program`，因此跑（`exe.run`）了个寂寞（空 program）

通过删 backend 相关代码定位到 decomp 问题，加了插入点恢复逻辑

由于静态图单测实际上加 `program_guard` 会更安全些，因此也加了一下

### Related links

CINN 切默认系列 PR

- [1/N] #71815
- [2/N] #71817
- [3/N] #71837
- [4/N] #71834
- [5/N] #71896
- [6/N] #71950
- [7/N] #71951
- [8/N] ➡️ #71960
- [9/N] #71838

<!-- PCard-66972 -->