### PR TITLE
[Fix] remove the found_one = false to adapt sm=86

### DIFF
--- a/paddle/phi/kernels/fusion/cutlass/cutlass_kernels/fpA_intB_gemm/fpA_intB_gemm_template.cu
+++ b/paddle/phi/kernels/fusion/cutlass/cutlass_kernels/fpA_intB_gemm/fpA_intB_gemm_template.cu
@@ -681,7 +681,6 @@ void CutlassFpAIntBGemmRunner<T, WeightType>::run_gemm<EpilogueTag,
         VLOG(4) << "elapsed time: " << elapsed;
         VLOG(4) << "best_time: " << best_time;
       } catch (const std::exception& e) {
-        found_one = false;
         VLOG(4) << ii << ": Exception caught in main: " << e.what();
       }
     }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

sm=86场景下，fpa_int8_gemm会因为搜索不到合适的配置而导致异常退出。

https://github.com/PaddlePaddle/Paddle/issues/71944
https://github.com/PaddlePaddle/PaddleNLP/pull/10325