### PR TITLE
[SOT] Copy cached meta info to avoid got wrong symbol

### DIFF
--- a/python/paddle/jit/sot/utils/utils.py
+++ b/python/paddle/jit/sot/utils/utils.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import builtins
+import copy
 import inspect
 import sys
 import time
@@ -267,12 +268,13 @@ def count_if(*structures, pred):
 
 
 class Cache:
-    def __init__(self, weak=False):
+    def __init__(self, weak=False, copy=False):
         if not weak:
             self.cache = {}
         else:
             self.cache = WeakValueDictionary()
         self.hit_num = 0
+        self.copy = copy
 
     def __call__(self, *args, **kwargs):
         cache_key = self.key_fn(*args, **kwargs)
@@ -281,7 +283,10 @@ class Cache:
         if cache_key in self.cache:
             log(5, "cache hit: ", cache_key, "\n")
             self.hit_num += 1
-            return self.cache[cache_key]
+            cache_item = self.cache[cache_key]
+            if self.copy:
+                cache_item = copy.deepcopy(cache_item)
+            return cache_item
         value = self.value_fn(*args, **kwargs)
         self.cache[cache_key] = value
         return value


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

#71932 在 MetaInfo 处确保不 copy 新的 shape 来保证**同一个 `TensorVariable`** 中 shape 里的 `SymbolicVariable` 一定是 cache 住的，不会调两次 shape 创建的 `SymbolicVariable` 不同

但这暴露了另一个问题，因为我们 InferMeta 是有 cache 的，cache 后的 shape 一定是同一个对象，因此一旦两个 TensorVariable 因为 InferMetaCache 命中，那么就会共享同一个 `meta.shape` 了，这就导致这个 list 对应的 data proxy 是同一个，里面的 `SymbolicVariable` 也是同一个，就出现了**多个 `TensorVariable` 的 shape 使用同一个 `SymbolicVariable`** 的问题

比如

```python
x1 = Tensor(shape=[-1, -1]) # [S0, S1]
x2 = Tensor(shape=[-1, -1]) # [S2, S3]
y1 = api1(x1) # shape=[-1, -1] 对应符号 [S4, S5]
y2 = api1(x2) # 输入 meta 一致（只是 -1，不是 S2、S3，所以会命中），因此拿到 meta [-1, -1]，对应符号 [S4, S5]
```

这里从 cache 里拿到的符号就错了，其实应该是互不相关的 `[S6, S7]`

因此在 `InferMetaCache` 里加了 copy 参数，在输出前 `deepcopy` 一下，以免共享类似可变对象导致错误命中 cache 的问题

<!-- PCard-66972 -->