### PR TITLE
[CINN] Adapt to sub_iter_space in TileTransposeTactic

### DIFF
--- a/test/ir/pir/cinn/test_cinn_transpose.py
+++ b/test/ir/pir/cinn/test_cinn_transpose.py
@@ -100,6 +100,29 @@ class TestTranspose(unittest.TestCase):
 
         self.eval(func, [x])
 
+    def test_reshape_0312(self):
+        def func(x, y):
+            y = y.reshape([64, 14, 14, 128])
+            y = y.transpose([0, 3, 1, 2])
+            return x + y
+
+        x = paddle.uniform([64, 128, 14, 14])
+        y = paddle.uniform([64, 14 * 14, 128])
+
+        self.eval(func, [x, y])
+
+    def test_slice_reshape_021(self):
+        def func(x, y):
+            x = x[:, 64:192]
+            x = x.reshape([64, 128, 14 * 14])
+            x = x.transpose([0, 2, 1])
+            return x + y
+
+        x = paddle.uniform([64, 256, 14, 14])
+        y = paddle.uniform([64, 14 * 14, 128])
+
+        self.eval(func, [x, y])
+
     def test_small_0231_dynshape(self):
         def func(x):
             return x.transpose([0, 2, 3, 1]) + 1
@@ -118,9 +141,10 @@ class TestTranspose(unittest.TestCase):
 
         self.eval(func, [x], [x_spec])
 
-    def test_all_permuted_3210_dynshape(self):
+    def test_reshape_021_dynshape(self):
         def func(x):
-            x = x.transpose([3, 2, 1, 0])
+            x = x.reshape([0, -1, paddle.shape(x)[3]])
+            x = x.transpose([0, 2, 1])
             return x * (x + 1)
 
         x = paddle.uniform([32, 14, 14, 128])


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
CINN


### PR Types
Improvements


### Description
在 TileTransposeTactic 引入 <b>副迭代空间（Sub Iter Space）</b>的概念，替换掉原来的Common Permutation，本质上从关注具体的一个个transpose变为整体关注迭代空间的连续性，从而提高Tactic的通用性，并实现对Reshape和Slice的有限支持

<img src="https://github.com/user-attachments/assets/95f97ed5-ecce-44ed-8414-15182ec901f1" alt="图片 1" width="420"/>

如图，我们将for循环的顺序设为主迭代空间，与for循环顺序不同的则为副迭代空间，则：
* 对主迭代空间的读写均按自然顺序即可
* 对副迭代空间的读需要使用CacheRead，对副迭代空间的写需要使用CacheWrite（待实现）

#### 性能测试

模型 | 原ips/cost | 新ips/cost | 加速比
-- | --: | --: | --:
训练: PaddleSeg_segformer_b0_bs4_fp16 | 28.0 | 30.3 | 8.2%
推理: SegFormer-B0 fp32 | 6.68 | 6.40 | 4.4%

<br>
Pcard-85711
