### PR TITLE
[PIR]skip check if strides are not all 1

### DIFF
--- a/paddle/fluid/pybind/slice_utils.h
+++ b/paddle/fluid/pybind/slice_utils.h
@@ -65,6 +65,12 @@ inline T GetDenseTensorValue(const phi::DenseTensor* x) {
 template <typename T>
 inline void CheckTensorIndexValue(const phi::DenseTensor* x,
                                   const int64_t dim_len) {
+  // skip check if strides are not all 1
+  for (auto i = 0; i < x->strides().size(); i++) {
+    if (x->strides()[i] != 1) {
+      return;
+    }
+  }
   T value = static_cast<T>(0);
   int64_t x_numel = x->numel();
   if (!(x->place().GetType() == phi::AllocationType::CPU)) {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-67164
paddlenlp高级索引中出现stride不全为1的tensor index，暂时跳过此类索引的检查