### PR TITLE
[CINN] Fix nvrtc compile bug

### DIFF
--- a/paddle/cinn/backends/nvrtc/nvrtc_util.cc
+++ b/paddle/cinn/backends/nvrtc/nvrtc_util.cc
@@ -183,7 +183,14 @@ std::string Compiler::CompileCudaSource(const std::string& code,
       nvrtcCompileProgram(prog, param_cstrings.size(), param_cstrings.data());
 
   if (compile_res != NVRTC_SUCCESS) {
-    std::string new_code = CodeGenCudaDev::GetGeneralSourceHeader() + code;
+    std::string new_code = code;
+    std::string from = CodeGenCudaDev::GetSourceHeader();
+    size_t pos = new_code.find(from);
+    if (pos != std::string::npos) {
+      new_code.replace(
+          pos, from.length(), CodeGenCudaDev::GetGeneralSourceHeader());
+    }
+
     NVRTC_CALL(nvrtcCreateProgram(&prog,
                                   new_code.c_str(),
                                   nullptr,
@@ -193,6 +200,7 @@ std::string Compiler::CompileCudaSource(const std::string& code,
     compile_res =
         nvrtcCompileProgram(prog, param_cstrings.size(), param_cstrings.data());
   }
+
   {  // get log
     size_t log_size;
     NVRTC_CALL(nvrtcGetProgramLogSize(prog, &log_size));


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
 Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-67164
[pr71410](https://github.com/PaddlePaddle/Paddle/pull/71410) 引入了bug：编译出错后最后体现出来错误就不是之前的错误了，而是头文件重复定义。本PR修复这个错误.