### PR TITLE
【base】modiy Place.cc throw error 

### DIFF
--- a/paddle/fluid/pybind/place.cc
+++ b/paddle/fluid/pybind/place.cc
@@ -221,7 +221,8 @@ void BindPlace(pybind11::module &m) {  // NOLINT
                    "positive integer",
                    device_type,
                    dev_id);
-               std::exit(-1);
+                PADDLE_THROW(::common::errors::InvalidArgument(
+            "use wrong place, Please check."));
              }
 
              if (LIKELY(phi::DeviceManager::HasDeviceType(device_type) &&
@@ -234,7 +235,8 @@ void BindPlace(pybind11::module &m) {  // NOLINT
                               << " because there is no " << device_type
                               << " detected on your "
                                  "machine.";
-                   std::exit(-1);
+                    PADDLE_THROW(::common::errors::InvalidArgument(
+            "use wrong place, Please check."));
                  } else {
                    LOG(ERROR) << string::Sprintf(
                        "Invalid CustomPlace(%s, %d), dev_id must "
@@ -246,7 +248,8 @@ void BindPlace(pybind11::module &m) {  // NOLINT
                        dev_count,
                        device_type,
                        dev_count);
-                   std::exit(-1);
+                    PADDLE_THROW(::common::errors::InvalidArgument(
+            "use wrong place, Please check."));
                  }
                }
                new (&self) phi::CustomPlace(device_type, dev_id);
@@ -257,7 +260,8 @@ void BindPlace(pybind11::module &m) {  // NOLINT
                    "as a custom device.",
                    device_type,
                    dev_id);
-               std::exit(-1);
+                PADDLE_THROW(::common::errors::InvalidArgument(
+            "use wrong place, Please check."));
              }
 #else
              LOG(ERROR) << string::Sprintf(
@@ -269,7 +273,8 @@ void BindPlace(pybind11::module &m) {  // NOLINT
                  "If you only have CPU, please change "
                  "CustomPlace(%s, %d) to be CPUPlace().\n",
                  device_type, dev_id);
-             std::exit(-1);
+              PADDLE_THROW(::common::errors::InvalidArgument(
+            "use wrong place, Please check."));
 #endif
            })
       .def("_type", &PlaceIndex<phi::CustomPlace>)
@@ -313,7 +318,8 @@ void BindPlace(pybind11::module &m) {  // NOLINT
                    "Invalid CUDAPlace(%d), device id must be 0 or "
                    "positive integer",
                    dev_id);
-               std::exit(-1);
+                PADDLE_THROW(::common::errors::InvalidArgument(
+            "use wrong place, Please check."));
              }
 
              if (UNLIKELY(dev_id >= platform::GetGPUDeviceCount())) {
@@ -321,7 +327,8 @@ void BindPlace(pybind11::module &m) {  // NOLINT
                  LOG(ERROR) << "Cannot use GPU because there is no GPU "
                                "detected on your "
                                "machine.";
-                 std::exit(-1);
+                  PADDLE_THROW(::common::errors::InvalidArgument(
+            "use wrong place, Please check."));
                } else {
                  LOG(ERROR) << string::Sprintf(
                      "Invalid CUDAPlace(%d), must inside [0, %d), because GPU "
@@ -329,7 +336,8 @@ void BindPlace(pybind11::module &m) {  // NOLINT
                      dev_id,
                      platform::GetGPUDeviceCount(),
                      platform::GetGPUDeviceCount());
-                 std::exit(-1);
+                  PADDLE_THROW(::common::errors::InvalidArgument(
+            "use wrong place, Please check."));
                }
              }
 
@@ -343,7 +351,8 @@ void BindPlace(pybind11::module &m) {  // NOLINT
                  "If you only have CPU, please change CUDAPlace(%d) to be "
                  "CPUPlace().\n",
                  dev_id);
-             std::exit(-1);
+              PADDLE_THROW(::common::errors::InvalidArgument(
+            "use wrong place, Please check."));
 #endif
            })
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
@@ -398,14 +407,16 @@ void BindPlace(pybind11::module &m) {  // NOLINT
                    "Invalid XPUPlace(%d), device id must be 0 or "
                    "positive integer",
                    dev_id);
-               std::exit(-1);
+                PADDLE_THROW(::common::errors::InvalidArgument(
+            "use wrong place, Please check."));
              }
              if (UNLIKELY(dev_id >= platform::GetXPUDeviceCount())) {
                if (platform::GetXPUDeviceCount() == 0) {
                  LOG(ERROR) << "Cannot use XPU because there is no XPU "
                                "detected on your "
                                "machine.";
-                 std::exit(-1);
+                  PADDLE_THROW(::common::errors::InvalidArgument(
+            "use wrong place, Please check."));
                } else {
                  LOG(ERROR) << string::Sprintf(
                      "Invalid XPUPlace(%d), must inside [0, %d), because XPU "
@@ -413,7 +424,8 @@ void BindPlace(pybind11::module &m) {  // NOLINT
                      dev_id,
                      platform::GetXPUDeviceCount(),
                      platform::GetXPUDeviceCount());
-                 std::exit(-1);
+                  PADDLE_THROW(::common::errors::InvalidArgument(
+            "use wrong place, Please check."));
                }
              }
              new (&self) phi::XPUPlace(dev_id);
@@ -426,7 +438,8 @@ void BindPlace(pybind11::module &m) {  // NOLINT
                  "If you only have CPU, please change XPUPlace(%d) to be "
                  "CPUPlace().\n",
                  dev_id);
-             std::exit(-1);
+              PADDLE_THROW(::common::errors::InvalidArgument(
+            "use wrong place, Please check."));
 #endif
            })
 #ifdef PADDLE_WITH_XPU
@@ -569,7 +582,8 @@ void BindPlace(pybind11::module &m) {  // NOLINT
                LOG(ERROR) << "Cannot use IPU because there is no IPU "
                              "detected on your "
                              "machine.";
-               std::exit(-1);
+                PADDLE_THROW(::common::errors::InvalidArgument(
+            "use wrong place, Please check."));
              }
              // use ipu(0) to compile, while run with the number user configure
              // in sharding and pipeline.
@@ -582,7 +596,8 @@ void BindPlace(pybind11::module &m) {  // NOLINT
                  "PaddlePaddle by: pip install paddlepaddle*\n"
                  "If you only have CPU, please change IPUPlace to be "
                  "CPUPlace().\n");
-             std::exit(-1);
+              PADDLE_THROW(::common::errors::InvalidArgument(
+            "use wrong place, Please check."));
 #endif
            })
       .def("_type", &PlaceIndex<phi::IPUPlace>)

--- a/paddle/fluid/pybind/place.cc
+++ b/paddle/fluid/pybind/place.cc
@@ -221,8 +221,8 @@ void BindPlace(pybind11::module &m) {  // NOLINT
                    "positive integer",
                    device_type,
                    dev_id);
-                PADDLE_THROW(::common::errors::InvalidArgument(
-            "use wrong place, Please check."));
+               PADDLE_THROW(::common::errors::InvalidArgument(
+                   "use wrong place, Please check."));
              }
 
              if (LIKELY(phi::DeviceManager::HasDeviceType(device_type) &&
@@ -235,8 +235,8 @@ void BindPlace(pybind11::module &m) {  // NOLINT
                               << " because there is no " << device_type
                               << " detected on your "
                                  "machine.";
-                    PADDLE_THROW(::common::errors::InvalidArgument(
-            "use wrong place, Please check."));
+                   PADDLE_THROW(::common::errors::InvalidArgument(
+                       "use wrong place, Please check."));
                  } else {
                    LOG(ERROR) << string::Sprintf(
                        "Invalid CustomPlace(%s, %d), dev_id must "
@@ -248,8 +248,8 @@ void BindPlace(pybind11::module &m) {  // NOLINT
                        dev_count,
                        device_type,
                        dev_count);
-                    PADDLE_THROW(::common::errors::InvalidArgument(
-            "use wrong place, Please check."));
+                   PADDLE_THROW(::common::errors::InvalidArgument(
+                       "use wrong place, Please check."));
                  }
                }
                new (&self) phi::CustomPlace(device_type, dev_id);
@@ -260,8 +260,8 @@ void BindPlace(pybind11::module &m) {  // NOLINT
                    "as a custom device.",
                    device_type,
                    dev_id);
-                PADDLE_THROW(::common::errors::InvalidArgument(
-            "use wrong place, Please check."));
+               PADDLE_THROW(::common::errors::InvalidArgument(
+                   "use wrong place, Please check."));
              }
 #else
              LOG(ERROR) << string::Sprintf(
@@ -318,8 +318,8 @@ void BindPlace(pybind11::module &m) {  // NOLINT
                    "Invalid CUDAPlace(%d), device id must be 0 or "
                    "positive integer",
                    dev_id);
-                PADDLE_THROW(::common::errors::InvalidArgument(
-            "use wrong place, Please check."));
+               PADDLE_THROW(::common::errors::InvalidArgument(
+                   "use wrong place, Please check."));
              }
 
              if (UNLIKELY(dev_id >= platform::GetGPUDeviceCount())) {
@@ -327,8 +327,8 @@ void BindPlace(pybind11::module &m) {  // NOLINT
                  LOG(ERROR) << "Cannot use GPU because there is no GPU "
                                "detected on your "
                                "machine.";
-                  PADDLE_THROW(::common::errors::InvalidArgument(
-            "use wrong place, Please check."));
+                 PADDLE_THROW(::common::errors::InvalidArgument(
+                     "use wrong place, Please check."));
                } else {
                  LOG(ERROR) << string::Sprintf(
                      "Invalid CUDAPlace(%d), must inside [0, %d), because GPU "
@@ -336,8 +336,8 @@ void BindPlace(pybind11::module &m) {  // NOLINT
                      dev_id,
                      platform::GetGPUDeviceCount(),
                      platform::GetGPUDeviceCount());
-                  PADDLE_THROW(::common::errors::InvalidArgument(
-            "use wrong place, Please check."));
+                 PADDLE_THROW(::common::errors::InvalidArgument(
+                     "use wrong place, Please check."));
                }
              }
 
@@ -407,16 +407,16 @@ void BindPlace(pybind11::module &m) {  // NOLINT
                    "Invalid XPUPlace(%d), device id must be 0 or "
                    "positive integer",
                    dev_id);
-                PADDLE_THROW(::common::errors::InvalidArgument(
-            "use wrong place, Please check."));
+               PADDLE_THROW(::common::errors::InvalidArgument(
+                   "use wrong place, Please check."));
              }
              if (UNLIKELY(dev_id >= platform::GetXPUDeviceCount())) {
                if (platform::GetXPUDeviceCount() == 0) {
                  LOG(ERROR) << "Cannot use XPU because there is no XPU "
                                "detected on your "
                                "machine.";
-                  PADDLE_THROW(::common::errors::InvalidArgument(
-            "use wrong place, Please check."));
+                 PADDLE_THROW(::common::errors::InvalidArgument(
+                     "use wrong place, Please check."));
                } else {
                  LOG(ERROR) << string::Sprintf(
                      "Invalid XPUPlace(%d), must inside [0, %d), because XPU "
@@ -424,8 +424,8 @@ void BindPlace(pybind11::module &m) {  // NOLINT
                      dev_id,
                      platform::GetXPUDeviceCount(),
                      platform::GetXPUDeviceCount());
-                  PADDLE_THROW(::common::errors::InvalidArgument(
-            "use wrong place, Please check."));
+                 PADDLE_THROW(::common::errors::InvalidArgument(
+                     "use wrong place, Please check."));
                }
              }
              new (&self) phi::XPUPlace(dev_id);
@@ -438,6 +438,7 @@ void BindPlace(pybind11::module &m) {  // NOLINT
                  "If you only have CPU, please change XPUPlace(%d) to be "
                  "CPUPlace().\n",
                  dev_id);
+
               PADDLE_THROW(::common::errors::InvalidArgument(
             "use wrong place, Please check."));
 #endif
@@ -582,8 +583,8 @@ void BindPlace(pybind11::module &m) {  // NOLINT
                LOG(ERROR) << "Cannot use IPU because there is no IPU "
                              "detected on your "
                              "machine.";
-                PADDLE_THROW(::common::errors::InvalidArgument(
-            "use wrong place, Please check."));
+               PADDLE_THROW(::common::errors::InvalidArgument(
+                   "use wrong place, Please check."));
              }
              // use ipu(0) to compile, while run with the number user configure
              // in sharding and pipeline.


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
 Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-67164

修改place.cc 中的报错方式，不使用std::exit(-1) ,这样会导致程序无法显示python 端报错栈