### PR TITLE
[SOT] Non-break support for `paddle.get_device`

### DIFF
--- a/python/paddle/device/__init__.py
+++ b/python/paddle/device/__init__.py
@@ -342,7 +342,6 @@ def get_device() -> str:
     elif isinstance(place, core.IPUPlace):
         num_devices = core.get_ipu_device_count()
         device = f"ipus:{{0-{num_devices - 1}}}"
-        device = f"ipus:{{0-{num_devices - 1}}}"
     elif isinstance(place, core.CustomPlace):
         device_id = place.get_device_id()
         device_type = place.get_device_type()

--- a/python/paddle/jit/sot/opcode_translator/executor/dispatch_functions.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/dispatch_functions.py
@@ -61,5 +61,9 @@ def generator_send(x):
     pass
 
 
-def place_get_device_id(x):
+def place_get_device_id():
+    pass
+
+
+def place_get_device_type():
     pass

--- a/python/paddle/jit/sot/opcode_translator/executor/dispatch_functions.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/dispatch_functions.py
@@ -59,3 +59,7 @@ def tensor_dim(x):
 
 def generator_send(x):
     pass
+
+
+def place_get_device_id(x):
+    pass

--- a/python/paddle/jit/sot/opcode_translator/executor/variable_dispatch.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variable_dispatch.py
@@ -48,6 +48,7 @@ from .dispatch_functions import (
     operator_is_not_none,
     operator_not_in,
     place_get_device_id,
+    place_get_device_type,
     tensor_dim,
 )
 from .dispatcher import Dispatcher, optional
@@ -1593,4 +1594,9 @@ Dispatcher.register(
     place_get_device_id,
     ("PlaceVariable",),
     lambda var: var.get_device_id(),
+)
+Dispatcher.register(
+    place_get_device_type,
+    ("PlaceVariable",),
+    lambda var: var.get_device_type(),
 )

--- a/python/paddle/jit/sot/opcode_translator/executor/variable_dispatch.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variable_dispatch.py
@@ -47,6 +47,7 @@ from .dispatch_functions import (
     operator_is_none,
     operator_is_not_none,
     operator_not_in,
+    place_get_device_id,
     tensor_dim,
 )
 from .dispatcher import Dispatcher, optional
@@ -1586,3 +1587,10 @@ for ufunc in binary_ufuncs:
             ufunc,
         ),
     )
+
+# place
+Dispatcher.register(
+    place_get_device_id,
+    ("PlaceVariable",),
+    lambda var: var.get_device_id(),
+)

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/__init__.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/__init__.py
@@ -32,6 +32,7 @@ from .basic import (  # noqa: F401
     NumpyVariable,
     ObjectVariable,
     ParameterVariable,
+    PlaceVariable,
     SliceVariable,
     SuperVariable,
     SymbolicVariable,

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
@@ -1480,7 +1480,7 @@ class PlaceVariable(ObjectVariable):
                 "default argument for getattr is not implemented"
             )
         if name not in ["get_device_id"]:
-            super().getattr(name, default)
+            return super().getattr(name, default)
         if name == "get_device_id":
             from .callable import BuiltinVariable
 

--- a/test/sot/test_sot_place.py
+++ b/test/sot/test_sot_place.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import unittest
+from contextlib import contextmanager
+
+from test_case_base import (
+    TestCaseBase,
+    test_instruction_translator_cache_context,
+)
+
+import paddle
+from paddle.jit.sot.psdb import check_no_breakgraph
+
+
+@contextmanager
+def device_guard(place: str):
+    original_place = paddle.get_device()
+    try:
+        paddle.set_device(place)
+        yield
+    finally:
+        paddle.set_device(original_place)
+
+
+@check_no_breakgraph
+def run_diff_logic_by_check_expected_place(x: paddle.Tensor):
+    expected_place_str = paddle.get_device()
+    if "cpu" in expected_place_str:
+        return x + 1
+    elif "gpu" in expected_place_str:
+        return x + 2
+    elif "xpu" in expected_place_str:
+        return x + 3
+    elif "npu" in expected_place_str:
+        return x + 4
+    return x
+
+
+class TestCheckExpectedPlace(TestCaseBase):
+    def test_check_cpu(self):
+        x = paddle.to_tensor(0.0)
+        with device_guard("cpu"):
+            self.assert_results(run_diff_logic_by_check_expected_place, x.cpu())
+
+    @unittest.skipUnless(
+        paddle.is_compiled_with_cuda(),
+        "This test case need compiled with cuda",
+    )
+    def test_check_gpu(self):
+        x = paddle.to_tensor(0.0)
+        with device_guard("gpu"):
+            self.assert_results(
+                run_diff_logic_by_check_expected_place, x.cuda()
+            )
+
+    @unittest.skipUnless(
+        paddle.is_compiled_with_xpu(),
+        "This test case need compiled with xpu",
+    )
+    def test_check_xpu(self):
+        x = paddle.to_tensor(0.0)
+        with device_guard("xpu"):
+            self.assert_results(
+                run_diff_logic_by_check_expected_place, x.to("xpu")
+            )
+
+
+class TestExpectedPlaceGuard(TestCaseBase):
+    @unittest.skipUnless(
+        paddle.is_compiled_with_cuda(),
+        "This test case need compiled with cuda",
+    )
+    def test_expected_place_guard(self):
+        x = paddle.to_tensor(0.0)
+        with test_instruction_translator_cache_context() as ctx:
+            self.assertEqual(ctx.translate_count, 0)
+            with device_guard("cpu"):
+                self.assert_results(
+                    run_diff_logic_by_check_expected_place, x.cpu()
+                )
+            self.assertEqual(ctx.translate_count, 1)
+            with device_guard("gpu"):
+                self.assert_results(
+                    run_diff_logic_by_check_expected_place, x.cuda()
+                )
+            self.assertEqual(ctx.translate_count, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/sot/test_sot_place.py
+++ b/test/sot/test_sot_place.py
@@ -58,7 +58,7 @@ class TestCheckExpectedPlace(TestCaseBase):
 
     @unittest.skipUnless(
         paddle.is_compiled_with_cuda(),
-        "This test case need compiled with cuda",
+        "This test case needs to be compiled with CUDA",
     )
     def test_check_gpu(self):
         x = paddle.to_tensor(0.0)

--- a/test/sot/test_sot_place.py
+++ b/test/sot/test_sot_place.py
@@ -69,7 +69,7 @@ class TestCheckExpectedPlace(TestCaseBase):
 
     @unittest.skipUnless(
         paddle.is_compiled_with_xpu(),
-        "This test case need compiled with xpu",
+        "This test case needs to be compiled with XPU",
     )
     def test_check_xpu(self):
         x = paddle.to_tensor(0.0)

--- a/test/sot/test_sot_place.py
+++ b/test/sot/test_sot_place.py
@@ -82,7 +82,7 @@ class TestCheckExpectedPlace(TestCaseBase):
 class TestExpectedPlaceGuard(TestCaseBase):
     @unittest.skipUnless(
         paddle.is_compiled_with_cuda(),
-        "This test case need compiled with cuda",
+        "This test case needs to be compiled with cuda",
     )
     def test_expected_place_guard(self):
         x = paddle.to_tensor(0.0)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Performance

### Description
<!-- Describe what you’ve done -->

为 `paddle.get_device` 添加非打断支持，模拟的函数只有 `CUDAPlace.get_device_id` 不支持，添加 dispatch 后可以确保无打断，且 guard 能正常工作，切换 place 能重新触发组网

<!-- PCard-66972 -->