### PR TITLE
[XPU] fix all_to_all with unequal splits when input/output is empty

### DIFF
--- a/paddle/fluid/distributed/collective/process_group_bkcl.cc
+++ b/paddle/fluid/distributed/collective/process_group_bkcl.cc
@@ -466,74 +466,72 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupBKCL::AllToAll(
 
           int64_t nranks = size_;
 
-          if (in_row_size > 0 && out_row_size > 0) {
-            std::vector<int64_t> in_numel_vec(nranks);
-            std::vector<int64_t> in_offset_vec(nranks);
-            std::vector<int64_t> out_numel_vec(nranks);
-            std::vector<int64_t> out_offset_vec(nranks);
+          std::vector<int64_t> in_numel_vec(nranks);
+          std::vector<int64_t> in_offset_vec(nranks);
+          std::vector<int64_t> out_numel_vec(nranks);
+          std::vector<int64_t> out_offset_vec(nranks);
 
-            int64_t in_offset = 0;
-            int64_t out_offset = 0;
-            for (int64_t i = 0; i < nranks; i++) {
-              int64_t in_numel = in_split_sizes[i] * in_row_size;
-              int64_t out_numel = out_split_sizes[i] * out_row_size;
+          int64_t in_offset = 0;
+          int64_t out_offset = 0;
+          for (int64_t i = 0; i < nranks; i++) {
+            int64_t in_numel = in_split_sizes[i] * in_row_size;
+            int64_t out_numel = out_split_sizes[i] * out_row_size;
 
-              in_numel_vec[i] = in_numel;
-              in_offset_vec[i] = in_offset;
-              in_offset += in_numel;
+            in_numel_vec[i] = in_numel;
+            in_offset_vec[i] = in_offset;
+            in_offset += in_numel;
 
-              out_numel_vec[i] = out_numel;
-              out_offset_vec[i] = out_offset;
-              out_offset += out_numel;
-            }
-
-            PADDLE_ENFORCE_GE(
-                in_tensor.place().GetDeviceId(),
-                0,
-                common::errors::PreconditionNotMet(
-                    "The all_to_all device id must greater or equal than 0."));
-            phi::XPUPlace place = in_tensor.place();
-            auto allocator = std::unique_ptr<phi::Allocator>(
-                new paddle::experimental::DefaultAllocator(place));
-            phi::DenseTensorMeta meta(phi::DataType::INT64, phi::DDim{nranks});
-
-            phi::DenseTensor in_size_tensor = {allocator.get(), meta};
-            phi::DenseTensor in_offset_tensor = {allocator.get(), meta};
-            phi::DenseTensor out_size_tensor = {allocator.get(), meta};
-            phi::DenseTensor out_offset_tensor = {allocator.get(), meta};
-
-            memory::Copy(place,
-                         in_size_tensor.data(),
-                         phi::CPUPlace(),
-                         in_numel_vec.data(),
-                         in_size_tensor.numel() * sizeof(int64_t));
-
-            memory::Copy(place,
-                         in_offset_tensor.data(),
-                         phi::CPUPlace(),
-                         in_offset_vec.data(),
-                         in_offset_tensor.numel() * sizeof(int64_t));
-
-            memory::Copy(place,
-                         out_size_tensor.data(),
-                         phi::CPUPlace(),
-                         out_numel_vec.data(),
-                         out_size_tensor.numel() * sizeof(int64_t));
-
-            memory::Copy(place,
-                         out_offset_tensor.data(),
-                         phi::CPUPlace(),
-                         out_offset_vec.data(),
-                         out_offset_tensor.numel() * sizeof(int64_t));
-
-            comm_context->AllToAllUnequalSplit(out_tensor,
-                                               in_tensor,
-                                               out_size_tensor,
-                                               out_offset_tensor,
-                                               in_size_tensor,
-                                               in_offset_tensor,
-                                               stream);
+            out_numel_vec[i] = out_numel;
+            out_offset_vec[i] = out_offset;
+            out_offset += out_numel;
           }
+
+          PADDLE_ENFORCE_GE(
+              in_tensor.place().GetDeviceId(),
+              0,
+              common::errors::PreconditionNotMet(
+                  "The all_to_all device id must greater or equal than 0."));
+          phi::XPUPlace place = in_tensor.place();
+          auto allocator = std::unique_ptr<phi::Allocator>(
+              new paddle::experimental::DefaultAllocator(place));
+          phi::DenseTensorMeta meta(phi::DataType::INT64, phi::DDim{nranks});
+
+          phi::DenseTensor in_size_tensor = {allocator.get(), meta};
+          phi::DenseTensor in_offset_tensor = {allocator.get(), meta};
+          phi::DenseTensor out_size_tensor = {allocator.get(), meta};
+          phi::DenseTensor out_offset_tensor = {allocator.get(), meta};
+
+          memory::Copy(place,
+                       in_size_tensor.data(),
+                       phi::CPUPlace(),
+                       in_numel_vec.data(),
+                       in_size_tensor.numel() * sizeof(int64_t));
+
+          memory::Copy(place,
+                       in_offset_tensor.data(),
+                       phi::CPUPlace(),
+                       in_offset_vec.data(),
+                       in_offset_tensor.numel() * sizeof(int64_t));
+
+          memory::Copy(place,
+                       out_size_tensor.data(),
+                       phi::CPUPlace(),
+                       out_numel_vec.data(),
+                       out_size_tensor.numel() * sizeof(int64_t));
+
+          memory::Copy(place,
+                       out_offset_tensor.data(),
+                       phi::CPUPlace(),
+                       out_offset_vec.data(),
+                       out_offset_tensor.numel() * sizeof(int64_t));
+
+          comm_context->AllToAllUnequalSplit(out_tensor,
+                                             in_tensor,
+                                             out_size_tensor,
+                                             out_offset_tensor,
+                                             in_size_tensor,
+                                             in_offset_tensor,
+                                             stream);
         }
       },
       in_tensor,
@@ -614,95 +612,93 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupBKCL::AllToAll(
           out_numel_sum += (*out_tensors)[i].numel();
         }
 
-        if (in_numel_sum > 0 || out_numel_sum > 0) {
-          std::vector<int64_t> in_numel_vec(nranks);
-          std::vector<int64_t> in_offset_vec(nranks);
-          std::vector<int64_t> out_numel_vec(nranks);
-          std::vector<int64_t> out_offset_vec(nranks);
+        std::vector<int64_t> in_numel_vec(nranks);
+        std::vector<int64_t> in_offset_vec(nranks);
+        std::vector<int64_t> out_numel_vec(nranks);
+        std::vector<int64_t> out_offset_vec(nranks);
 
-          int64_t in_offset = 0;
-          int64_t out_offset = 0;
-          for (int64_t i = 0; i < nranks; i++) {
-            int64_t in_numel = in_tensors[i].numel();
-            int64_t out_numel = (*out_tensors)[i].numel();
+        int64_t in_offset = 0;
+        int64_t out_offset = 0;
+        for (int64_t i = 0; i < nranks; i++) {
+          int64_t in_numel = in_tensors[i].numel();
+          int64_t out_numel = (*out_tensors)[i].numel();
 
-            in_numel_vec[i] = in_numel;
-            in_offset_vec[i] = in_offset;
-            in_offset += in_numel;
+          in_numel_vec[i] = in_numel;
+          in_offset_vec[i] = in_offset;
+          in_offset += in_numel;
 
-            out_numel_vec[i] = out_numel;
-            out_offset_vec[i] = out_offset;
-            out_offset += out_numel;
-          }
+          out_numel_vec[i] = out_numel;
+          out_offset_vec[i] = out_offset;
+          out_offset += out_numel;
+        }
 
-          PADDLE_ENFORCE_GE(
-              in_tensors[0].place().GetDeviceId(),
-              0,
-              common::errors::PreconditionNotMet(
-                  "The all_to_all device id must greater or equal than 0."));
-          phi::XPUPlace place = in_tensors[0].place();
-          auto allocator = std::unique_ptr<phi::Allocator>(
-              new paddle::experimental::DefaultAllocator(place));
+        PADDLE_ENFORCE_GE(
+            in_tensors[0].place().GetDeviceId(),
+            0,
+            common::errors::PreconditionNotMet(
+                "The all_to_all device id must greater or equal than 0."));
+        phi::XPUPlace place = in_tensors[0].place();
+        auto allocator = std::unique_ptr<phi::Allocator>(
+            new paddle::experimental::DefaultAllocator(place));
 
-          phi::DenseTensorMeta concated_in_tensor_meta(in_tensors[0].dtype(),
-                                                       phi::DDim{in_numel_sum});
-          phi::DenseTensorMeta concated_out_tensor_meta(
-              (*out_tensors)[0].dtype(), phi::DDim{out_numel_sum});
-          phi::DenseTensorMeta split_meta(phi::DataType::INT64,
-                                          phi::DDim{nranks});
+        phi::DenseTensorMeta concated_in_tensor_meta(in_tensors[0].dtype(),
+                                                     phi::DDim{in_numel_sum});
+        phi::DenseTensorMeta concated_out_tensor_meta((*out_tensors)[0].dtype(),
+                                                      phi::DDim{out_numel_sum});
+        phi::DenseTensorMeta split_meta(phi::DataType::INT64,
+                                        phi::DDim{nranks});
 
-          phi::DenseTensor concated_in_tensor = {allocator.get(),
-                                                 concated_in_tensor_meta};
-          phi::DenseTensor concated_out_tensor = {allocator.get(),
-                                                  concated_out_tensor_meta};
-          phi::DenseTensor in_size_tensor = {allocator.get(), split_meta};
-          phi::DenseTensor in_offset_tensor = {allocator.get(), split_meta};
-          phi::DenseTensor out_size_tensor = {allocator.get(), split_meta};
-          phi::DenseTensor out_offset_tensor = {allocator.get(), split_meta};
+        phi::DenseTensor concated_in_tensor = {allocator.get(),
+                                               concated_in_tensor_meta};
+        phi::DenseTensor concated_out_tensor = {allocator.get(),
+                                                concated_out_tensor_meta};
+        phi::DenseTensor in_size_tensor = {allocator.get(), split_meta};
+        phi::DenseTensor in_offset_tensor = {allocator.get(), split_meta};
+        phi::DenseTensor out_size_tensor = {allocator.get(), split_meta};
+        phi::DenseTensor out_offset_tensor = {allocator.get(), split_meta};
 
-          if (in_numel_sum > 0) {
-            ConcatTensorByNumel(*GetDeviceContext(place, use_calc_stream),
-                                in_tensors,
-                                &concated_in_tensor);
-          }
+        if (in_numel_sum > 0) {
+          ConcatTensorByNumel(*GetDeviceContext(place, use_calc_stream),
+                              in_tensors,
+                              &concated_in_tensor);
+        }
 
-          memory::Copy(place,
-                       in_size_tensor.data(),
-                       phi::CPUPlace(),
-                       in_numel_vec.data(),
-                       in_size_tensor.numel() * sizeof(int64_t));
+        memory::Copy(place,
+                     in_size_tensor.data(),
+                     phi::CPUPlace(),
+                     in_numel_vec.data(),
+                     in_size_tensor.numel() * sizeof(int64_t));
 
-          memory::Copy(place,
-                       in_offset_tensor.data(),
-                       phi::CPUPlace(),
-                       in_offset_vec.data(),
-                       in_offset_tensor.numel() * sizeof(int64_t));
+        memory::Copy(place,
+                     in_offset_tensor.data(),
+                     phi::CPUPlace(),
+                     in_offset_vec.data(),
+                     in_offset_tensor.numel() * sizeof(int64_t));
 
-          memory::Copy(place,
-                       out_size_tensor.data(),
-                       phi::CPUPlace(),
-                       out_numel_vec.data(),
-                       out_size_tensor.numel() * sizeof(int64_t));
+        memory::Copy(place,
+                     out_size_tensor.data(),
+                     phi::CPUPlace(),
+                     out_numel_vec.data(),
+                     out_size_tensor.numel() * sizeof(int64_t));
 
-          memory::Copy(place,
-                       out_offset_tensor.data(),
-                       phi::CPUPlace(),
-                       out_offset_vec.data(),
-                       out_offset_tensor.numel() * sizeof(int64_t));
+        memory::Copy(place,
+                     out_offset_tensor.data(),
+                     phi::CPUPlace(),
+                     out_offset_vec.data(),
+                     out_offset_tensor.numel() * sizeof(int64_t));
 
-          comm_context->AllToAllUnequalSplit(&concated_out_tensor,
-                                             concated_in_tensor,
-                                             out_size_tensor,
-                                             out_offset_tensor,
-                                             in_size_tensor,
-                                             in_offset_tensor,
-                                             stream);
+        comm_context->AllToAllUnequalSplit(&concated_out_tensor,
+                                           concated_in_tensor,
+                                           out_size_tensor,
+                                           out_offset_tensor,
+                                           in_size_tensor,
+                                           in_offset_tensor,
+                                           stream);
 
-          if (out_numel_sum > 0) {
-            SplitTensorByNumel(*GetDeviceContext(place, use_calc_stream),
-                               concated_out_tensor,
-                               out_tensors);
-          }
+        if (out_numel_sum > 0) {
+          SplitTensorByNumel(*GetDeviceContext(place, use_calc_stream),
+                             concated_out_tensor,
+                             out_tensors);
         }
       },
       in_tensors,

--- a/paddle/fluid/distributed/collective/process_group_kernel_utils.h
+++ b/paddle/fluid/distributed/collective/process_group_kernel_utils.h
@@ -29,6 +29,10 @@ struct ConcatDenseTensorByNumel {
   void operator()(const DeviceContext &context,
                   const std::vector<phi::DenseTensor> &in,
                   phi::DenseTensor *out) {
+    if (out->numel() == 0) {
+      return;
+    }
+
     auto out_dims = common::vectorize(out->dims());
     auto flattened_out_dims = {out->numel()};
     std::vector<phi::DenseTensor> in_flatten;
@@ -39,11 +43,12 @@ struct ConcatDenseTensorByNumel {
 
     int64_t in_numel_sum = 0;
     for (auto &tensor : in) {
-      phi::DenseTensor tensor_flatten(tensor.Holder(), tensor.meta());
-      tensor_flatten.Resize({tensor.numel()});
-      in_flatten.push_back(tensor_flatten);
-
-      in_numel_sum += tensor.numel();
+      if (tensor.numel() > 0) {
+        phi::DenseTensor tensor_flatten(tensor.Holder(), tensor.meta());
+        tensor_flatten.Resize({tensor.numel()});
+        in_flatten.push_back(tensor_flatten);
+        in_numel_sum += tensor.numel();
+      }
     }
     PADDLE_ENFORCE_EQ(
         out->numel(),
@@ -105,6 +110,10 @@ struct SplitDenseTensorByNumel {
   void operator()(const DeviceContext &context,
                   const phi::DenseTensor &in,
                   std::vector<phi::DenseTensor> *out) {
+    if (in.numel() == 0) {
+      return;
+    }
+
     phi::DenseTensor in_flatten(in.Holder(), in.meta());
     in_flatten.Resize({in.numel()});
 
@@ -115,10 +124,12 @@ struct SplitDenseTensorByNumel {
     int64_t out_numel_sum = 0;
 
     for (auto &tensor : *out) {
-      phi::DenseTensor tensor_flatten(tensor.Holder(), tensor.meta());
-      tensor_flatten.Resize({tensor.numel()});
-      out_flatten.push_back(tensor_flatten);
-      out_numel_sum += tensor.numel();
+      if (tensor.numel() > 0) {
+        phi::DenseTensor tensor_flatten(tensor.Holder(), tensor.meta());
+        tensor_flatten.Resize({tensor.numel()});
+        out_flatten.push_back(tensor_flatten);
+        out_numel_sum += tensor.numel();
+      }
     }
     for (auto &tensor : out_flatten) {
       shape_refer.push_back(&tensor);

--- a/paddle/phi/core/distributed/check/bkcl_dynamic_check.cc
+++ b/paddle/phi/core/distributed/check/bkcl_dynamic_check.cc
@@ -41,6 +41,7 @@ void BKCLDynamicCheck::CheckDataType(const phi::DenseTensor& tensor,
   int64_t* dtype_device;
   PADDLE_ENFORCE_XPU_SUCCESS(
       xpu_malloc(reinterpret_cast<void**>(&dtype_device), kSize));
+  PADDLE_ENFORCE_XPU_SUCCESS(xpu_wait());
   PADDLE_ENFORCE_XPU_SUCCESS(xpu_memcpy(
       dtype_device, &dtype_host, kSize, XPUMemcpyKind::XPU_HOST_TO_DEVICE));
 
@@ -56,6 +57,7 @@ void BKCLDynamicCheck::CheckDataType(const phi::DenseTensor& tensor,
     VLOG(3) << "Dynamic check recv metadata, dtype: " << dtype_host;
     CheckDataType(tensor, dtype_host);
   }
+  PADDLE_ENFORCE_XPU_SUCCESS(xpu_wait());
   PADDLE_ENFORCE_XPU_SUCCESS(xpu_free(dtype_device));
 }
 
@@ -85,6 +87,7 @@ void BKCLDynamicCheck::CheckShape(const phi::DenseTensor& out_tensor,
     int64_t* in_shape_device;
     PADDLE_ENFORCE_XPU_SUCCESS(
         xpu_malloc(reinterpret_cast<void**>(&in_shape_device), kSize));
+    PADDLE_ENFORCE_XPU_SUCCESS(xpu_wait());
     PADDLE_ENFORCE_XPU_SUCCESS(xpu_memcpy(in_shape_device,
                                           &in_shape_host,
                                           kSize,
@@ -106,6 +109,7 @@ void BKCLDynamicCheck::CheckShape(const phi::DenseTensor& out_tensor,
       VLOG(3) << "Dynamic check recv metadata, shape: " << in_shape_host;
       CheckShape(out_tensor, in_shape_host);
     }
+    PADDLE_ENFORCE_XPU_SUCCESS(xpu_wait());
     PADDLE_ENFORCE_XPU_SUCCESS(xpu_free(in_shape_device));
   }
 }

--- a/test/xpu/collective_alltoall_api_unequal_split_empty_dygraph.py
+++ b/test/xpu/collective_alltoall_api_unequal_split_empty_dygraph.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import test_collective_api_base as test_base
+from op_test import convert_float_to_uint16, convert_uint16_to_float
+
+import paddle
+import paddle.distributed as dist
+from paddle import base
+
+
+class TestCollectiveAllToAllAPIUnequalSplitEmpty(
+    test_base.TestCollectiveAPIRunnerBase
+):
+    def __init__(self):
+        self.global_ring_id = 0
+
+    def get_model(self, main_prog, startup_program, rank, indata=None):
+        with base.program_guard(main_prog, startup_program):
+            none_shape = list(indata.shape)
+            none_shape[0] = 0
+
+            if rank == 0:
+                in_data_list = [
+                    np.empty(none_shape, dtype=indata.dtype) for _ in range(2)
+                ]
+                out_data_list = [
+                    np.empty(none_shape, dtype=indata.dtype),
+                    np.empty_like(indata),
+                ]
+            elif rank == 1:
+                in_data_list = [
+                    indata,
+                    np.empty(none_shape, dtype=indata.dtype),
+                ]
+                out_data_list = [
+                    np.empty(none_shape, dtype=indata.dtype) for _ in range(2)
+                ]
+            else:
+                raise ValueError(f"only support nranks==2, but got rank {rank}")
+
+            # NOTE: this is a hack relying on an undocumented behavior that `to_tensor` uses uint16 to replace bfloat16
+            if indata.dtype == "bfloat16":
+                tindata = [
+                    paddle.to_tensor(convert_float_to_uint16(data))
+                    for data in in_data_list
+                ]
+                toutdata = [
+                    paddle.to_tensor(convert_float_to_uint16(data))
+                    for data in out_data_list
+                ]
+                dist.alltoall(toutdata, tindata)
+                return [
+                    convert_uint16_to_float(data.numpy()) for data in toutdata
+                ]
+            else:
+                tindata = [paddle.to_tensor(data) for data in in_data_list]
+                toutdata = [paddle.to_tensor(data) for data in out_data_list]
+                dist.alltoall(toutdata, tindata)
+                return [data.numpy() for data in toutdata]
+
+
+if __name__ == "__main__":
+    test_base.runtime_main(
+        TestCollectiveAllToAllAPIUnequalSplitEmpty,
+        "alltoall_unequal_split_empty",
+    )

--- a/test/xpu/collective_alltoall_single_api_unequal_split_empty_dygraph.py
+++ b/test/xpu/collective_alltoall_single_api_unequal_split_empty_dygraph.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import test_collective_api_base as test_base
+from op_test import convert_float_to_uint16, convert_uint16_to_float
+
+import paddle
+import paddle.distributed as dist
+from paddle import base
+
+
+class TestCollectiveAllToAllSingleAPIUnequalSplitEmpty(
+    test_base.TestCollectiveAPIRunnerBase
+):
+    def __init__(self):
+        self.global_ring_id = 0
+
+    def get_model(self, main_prog, startup_program, rank, indata=None):
+        with base.program_guard(main_prog, startup_program):
+            if rank == 0:
+                in_split_sizes = [0, 0]
+                out_split_sizes = [0, 0]
+
+                none_shape = list(indata.shape)
+                none_shape[0] = 0
+
+                indata = np.empty(none_shape, dtype=indata.dtype)
+                out_shape = none_shape
+            elif rank == 1:
+                dim0 = indata.shape[0]
+                in_split_sizes = [0, dim0]
+                out_split_sizes = [0, dim0]
+                out_shape = indata.shape
+            else:
+                raise ValueError(f"only support nranks==2, but got rank {rank}")
+
+            if indata.dtype == "bfloat16":
+                indata = convert_float_to_uint16(indata)
+                tindata = paddle.to_tensor(indata)
+                toutdata = paddle.empty(out_shape, dtype=tindata.dtype)
+                dist.alltoall_single(
+                    toutdata,
+                    tindata,
+                    out_split_sizes=out_split_sizes,
+                    in_split_sizes=in_split_sizes,
+                )
+                return [convert_uint16_to_float(toutdata.numpy())]
+            else:
+                tindata = paddle.to_tensor(indata)
+                toutdata = paddle.empty(out_shape, dtype=tindata.dtype)
+                dist.alltoall_single(
+                    toutdata,
+                    tindata,
+                    out_split_sizes=out_split_sizes,
+                    in_split_sizes=in_split_sizes,
+                )
+                return [toutdata.numpy()]
+
+
+if __name__ == "__main__":
+    test_base.runtime_main(
+        TestCollectiveAllToAllSingleAPIUnequalSplitEmpty,
+        "alltoall_single_unequal_split_empty",
+    )

--- a/test/xpu/test_collective_alltoall_api_unequal_split.py
+++ b/test/xpu/test_collective_alltoall_api_unequal_split.py
@@ -45,6 +45,24 @@ class TestCollectiveAllToAllAPIUnequalSplit(TestDistBase):
                 dtype=dtype,
             )
 
+    @unittest.skipIf(
+        not core.is_compiled_with_xpu() or paddle.device.xpu.device_count() < 2,
+        "run test when having at least 2 XPUs.",
+    )
+    def test_alltoall_unequal_split_empty(self):
+        support_types = get_xpu_op_support_types('c_alltoall')
+        # split/concat not support float64
+        support_types = [
+            dtype for dtype in support_types if dtype not in ["float64", "bool"]
+        ]
+        for dtype in support_types:
+            self.check_with_place(
+                "collective_alltoall_api_unequal_split_empty_dygraph.py",
+                "alltoall_unequal_split_empty",
+                static_mode="0",
+                dtype=dtype,
+            )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/xpu/test_collective_alltoall_single_api_unequal_split.py
+++ b/test/xpu/test_collective_alltoall_single_api_unequal_split.py
@@ -41,6 +41,20 @@ class TestCollectiveAllToAllSingleUnequalSplitAPI(TestDistBase):
                 dtype=dtype,
             )
 
+    @unittest.skipIf(
+        not core.is_compiled_with_xpu() or paddle.device.xpu.device_count() < 2,
+        "run test when having at least 2 XPUs.",
+    )
+    def test_alltoall_single_unequal_split_empty(self):
+        support_types = get_xpu_op_support_types('c_alltoall')
+        for dtype in support_types:
+            self.check_with_place(
+                "collective_alltoall_single_api_unequal_split_empty_dygraph.py",
+                "alltoall_single_unequal_split_empty",
+                static_mode="0",
+                dtype=dtype,
+            )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/xpu/test_collective_api_base.py
+++ b/test/xpu/test_collective_api_base.py
@@ -582,7 +582,7 @@ class TestDistBase(unittest.TestCase):
                 tr1_out, need_result2, rtol=1e-05, atol=1e-05
             )
         elif col_type == "alltoall_unequal_split_empty":
-            none_shape = input1.shape
+            none_shape = list(input1.shape)
             none_shape[0] = 0
 
             need_result1 = input2

--- a/test/xpu/test_collective_api_base.py
+++ b/test/xpu/test_collective_api_base.py
@@ -542,6 +542,20 @@ class TestDistBase(unittest.TestCase):
             np.testing.assert_allclose(
                 tr1_out, need_result2, rtol=1e-05, atol=1e-05
             )
+        elif col_type == "alltoall_single_unequal_split_empty":
+            none_shape = list(input1.shape)
+            none_shape[0] = 0
+
+            need_result1 = np.empty(none_shape, dtype=input1.dtype)
+            need_result2 = input2
+            tr0_out = np.vstack(tr0_out)
+            tr1_out = np.vstack(tr1_out)
+            np.testing.assert_allclose(
+                tr0_out, need_result1, rtol=1e-05, atol=1e-05
+            )
+            np.testing.assert_allclose(
+                tr1_out, need_result2, rtol=1e-05, atol=1e-05
+            )
         elif col_type == "alltoall_unequal_split":
             half_dim0 = input1.shape[0] // 2
             half_dim1 = input1.shape[1] // 2
@@ -561,6 +575,20 @@ class TestDistBase(unittest.TestCase):
             )
             tr0_out = np.concatenate([out.flatten() for out in tr0_out])
             tr1_out = np.concatenate([out.flatten() for out in tr1_out])
+            np.testing.assert_allclose(
+                tr0_out, need_result1, rtol=1e-05, atol=1e-05
+            )
+            np.testing.assert_allclose(
+                tr1_out, need_result2, rtol=1e-05, atol=1e-05
+            )
+        elif col_type == "alltoall_unequal_split_empty":
+            none_shape = input1.shape
+            none_shape[0] = 0
+
+            need_result1 = input2
+            need_result2 = np.empty(none_shape, dtype=input1.dtype)
+            tr0_out = np.vstack(tr0_out)
+            tr1_out = np.vstack(tr1_out)
             np.testing.assert_allclose(
                 tr0_out, need_result1, rtol=1e-05, atol=1e-05
             )


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Custom Device 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
[XPU] fix all_to_all with unequal splits when input/output is empty

出错原因：之前的逻辑是输入输出全为0，就不调用all_to_all_v，导致有些卡调用，有些卡没调用