### PR TITLE
[fluid_ops]clean send_v2 TensorArray

### DIFF
--- a/paddle/fluid/operators/collective/recv_v2_op.cu.cc
+++ b/paddle/fluid/operators/collective/recv_v2_op.cu.cc
@@ -183,23 +183,6 @@ class RecvOpV2CUDAKernel : public framework::OpKernel<T> {
       // should ExecutionContext for calc stream.
       stream = ctx.cuda_device_context().stream();
     }
-    auto *out_var = ctx.OutputVar("Out");
-    if (out_var->IsType<phi::TensorArray>()) {
-      PADDLE_ENFORCE_EQ(
-          dynamic_shape,
-          false,
-          common::errors::InvalidArgument("Dynamic shape for send/recv not "
-                                          "support DenseTensorArray for now."));
-      auto out_array = out_var->GetMutable<phi::TensorArray>();
-      for (size_t idx = 0; idx < out_array->size(); ++idx) {
-        VLOG(3) << "DenseTensorArray: idx(" << idx << ")";
-        auto out = &out_array->at(idx);
-        ctx.cuda_device_context().Alloc<T>(out);
-        auto numel = out->numel();
-        comm_ctx->Recv(out, numel, peer, stream);
-      }
-      return;
-    }
 
     auto out_shape = ctx.Attr<std::vector<int>>("out_shape");
     auto out = ctx.Output<phi::DenseTensor>("Out");

--- a/paddle/fluid/operators/collective/send_v2_op.cu.cc
+++ b/paddle/fluid/operators/collective/send_v2_op.cu.cc
@@ -168,22 +168,6 @@ class SendOpV2CUDAKernel : public framework::OpKernel<T> {
       stream = ctx.cuda_device_context().stream();
     }
 
-    auto* x_var = ctx.InputVar("X");
-    if (x_var->IsType<phi::TensorArray>()) {
-      PADDLE_ENFORCE_EQ(
-          dynamic_shape,
-          false,
-          common::errors::InvalidArgument("Dynamic shape for send/recv not "
-                                          "support phi::TensorArray for now."));
-      auto& x_array = x_var->Get<phi::TensorArray>();
-      for (size_t idx = 0; idx < x_array.size(); idx++) {
-        VLOG(3) << "DenseTensorArray: idx(" << idx << ")";
-        auto& x = x_array.at(idx);
-        int numel = x.numel();
-        comm_ctx->Send(x, numel, peer, stream);
-      }
-      return;
-    }
     auto x = ctx.Input<phi::DenseTensor>("X");
     int numel = x->numel();
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
移除 send_v2, recv_v2 中 TensorArray 部分