### PR TITLE
[AutoParallel] Fix st save dy load in pir

### DIFF
--- a/python/paddle/nn/layer/layers.py
+++ b/python/paddle/nn/layer/layers.py
@@ -2225,8 +2225,6 @@ class Layer:
 
         matched_param_state = []
         for key, param in self._state_dict_impl(use_hook=False).items():
-            if isinstance(param, paddle.Tensor) and not param._is_initialized():
-                continue
             key_name = key if use_structured_name else param.name
             try:
                 match_res = _check_match(key_name, param)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Fix static save dynamic load bug in pir.
Remove redundant `_is_initialized` check that skips param_state matching.
The param becomes initialized after `param.set_value(state)` in the following lines.
Pcard-70448