### PR TITLE
[XPU] update StridedCopyKernel

### DIFF
--- a/paddle/phi/kernels/xpu/strided_copy_kernel.cc
+++ b/paddle/phi/kernels/xpu/strided_copy_kernel.cc
@@ -44,6 +44,17 @@ void StridedCopyKernel(const Context& dev_ctx,
                         input.numel(),
                         out->numel()));
 
+  if (input.numel() <= 0) {
+    return;
+  }
+
+  PADDLE_ENFORCE_NOT_NULL(out->data<T>(),
+                          common::errors::InvalidArgument(
+                              "StridedCopyKernel's out tensor must complete "
+                              "mutable data before call kernel."));
+
+  // 下述XPU算子有性能问题，因此暂时禁用掉，改成“先拷贝到CPU，按照CPU算子逻辑计算，再拷贝回XPU”的临时方案
+  /*
   // use XPUCopyTypeTrait to deal with double and int16_t copy instead of
   // XPUTypeTrait
   using XPUType = typename XPUCopyTypeTrait<T>::Type;
@@ -68,6 +79,63 @@ void StridedCopyKernel(const Context& dev_ctx,
                                    common::vectorize<int64_t>(out->strides()));
     PADDLE_ENFORCE_XDNN_SUCCESS(r, "strided_copy");
   }
+  */
+
+  // CPU buffer for input
+  char* input_on_cpu = new char[input.Holder()->size()];
+  memory_utils::Copy(CPUPlace(),
+                     static_cast<void*>(input_on_cpu),
+                     dev_ctx.GetPlace(),
+                     static_cast<const void*>(input.Holder()->ptr()),
+                     input.Holder()->size());
+
+  // CPU buffer for out
+  char* output_on_cpu = new char[out->Holder()->size()];
+  memory_utils::Copy(CPUPlace(),
+                     static_cast<void*>(output_on_cpu),
+                     dev_ctx.GetPlace(),
+                     static_cast<const void*>(out->Holder()->ptr()),
+                     out->Holder()->size());
+
+  // follow paddle/phi/kernels/cpu/strided_copy_kernel.cc
+  const T* input_data =
+      reinterpret_cast<T*>(input_on_cpu + input.meta().offset);
+  int input_rank = input.dims().size();
+  const int64_t* input_dims = input.dims().Get();
+  const int64_t* input_stride = input.strides().Get();
+
+  T* output_data = reinterpret_cast<T*>(output_on_cpu + offset);
+  int output_rank = meta.dims.size();
+  const int64_t* output_dims = meta.dims.Get();
+  const int64_t* output_stride = meta.strides.Get();
+
+  auto numel = input.numel();
+
+  for (int64_t i = 0; i < numel; i++) {
+    int64_t input_offset = 0;
+    int64_t index_tmp = i;
+    for (int dim = input_rank - 1; dim >= 0; --dim) {
+      input_offset += (index_tmp % input_dims[dim]) * input_stride[dim];
+      index_tmp = index_tmp / input_dims[dim];
+    }
+    int64_t output_offset = 0;
+    index_tmp = i;
+    for (int dim = output_rank - 1; dim >= 0; --dim) {
+      output_offset += (index_tmp % output_dims[dim]) * output_stride[dim];
+      index_tmp = index_tmp / output_dims[dim];
+    }
+    output_data[output_offset] = input_data[input_offset];
+  }
+
+  // copy out tensor, from cpu to xpu
+  memory_utils::Copy(dev_ctx.GetPlace(),
+                     static_cast<void*>(out->Holder()->ptr()),
+                     CPUPlace(),
+                     static_cast<const void*>(output_on_cpu),
+                     out->Holder()->size());
+
+  delete[] input_on_cpu;
+  delete[] output_on_cpu;
 }
 
 }  // namespace phi

--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -2449,6 +2449,7 @@ EOF
 }
 
 function parallel_test_base_xpu() {
+    unset FLAGS_use_stride_kernel
     mkdir -p ${PADDLE_ROOT}/build
     cd ${PADDLE_ROOT}/build
     if [ ${WITH_TESTING:-ON} == "ON" ] ; then

--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -2449,7 +2449,6 @@ EOF
 }
 
 function parallel_test_base_xpu() {
-    unset FLAGS_use_stride_kernel
     mkdir -p ${PADDLE_ROOT}/build
     cd ${PADDLE_ROOT}/build
     if [ ${WITH_TESTING:-ON} == "ON" ] ; then

--- a/test/indexing/CMakeLists.txt
+++ b/test/indexing/CMakeLists.txt
@@ -7,3 +7,6 @@ string(REPLACE ".py" "" TEST_OPS "${TEST_OPS}")
 foreach(TEST_OP ${TEST_OPS})
   py_test_modules(${TEST_OP} MODULES ${TEST_OP})
 endforeach()
+
+set_tests_properties(test_setitem_appendix
+                     PROPERTIES ENVIRONMENT "FLAGS_use_stride_kernel=1")

--- a/test/indexing/test_setitem_appendix.py
+++ b/test/indexing/test_setitem_appendix.py
@@ -194,10 +194,6 @@ class TestSetitemDygraphAdvancedIndex(unittest.TestCase):
         self.accuracy_check(x, y)
 
 
-@unittest.skipIf(
-    paddle.core.is_compiled_with_xpu(),
-    "There are some bugs on XPU.",
-)
 class TestSetitemDygraphCombinedIndex(unittest.TestCase):
     def accuracy_check(self, numpy_array, paddle_t):
         np.testing.assert_allclose(numpy_array, paddle_t.numpy())


### PR DESCRIPTION
### PR Category
Custom Device

### PR Types
Performance

### Description
目前`phi::StridedCopyKernel`的XPU实现中，会使用`xpu::strided_copy`函数。该函数有严重的性能问题，因此暂时禁用掉，改成“先拷贝到CPU，按照CPU算子逻辑计算，再拷贝回XPU”的临时方案。

由于有其它一批XPU下面的单测，仅能在`export FLAGS_use_stride_kernel=0`的时候通过，因此本PR先修改了`test_setitem_appendix`单个单测的运行时环境变量。