### PR TITLE
[XPU] adapt new interface for uniform kernel

### DIFF
--- a/paddle/phi/kernels/xpu/uniform_kernel.cc
+++ b/paddle/phi/kernels/xpu/uniform_kernel.cc
@@ -37,14 +37,19 @@ void UniformKernel(const Context &dev_ctx,
   using XPUType = typename XPUTypeTrait<T>::Type;
   int64_t real_seed = seed != 0 ? seed : dev_ctx.GetGenerator()->Random64();
 
-  // int random(Context* ctx, T* x, int64_t len, T min, T max, int64_t seed);
-  int r = xpu::random<XPUType>(dev_ctx.x_context(),
-                               reinterpret_cast<XPUType *>(data),
-                               out->numel(),
-                               static_cast<XPUType>(min.to<float>()),
-                               static_cast<XPUType>(max.to<float>()),
-                               real_seed);
-  PADDLE_ENFORCE_XDNN_SUCCESS(r, "random");
+  // algo:
+  //       0: philox4x32_10_pytorch
+  //       1: mt
+  //       2: philox4x32_10_curand
+  int algo = 0;
+  int r = xpu::uniform<XPUType>(dev_ctx.x_context(),
+                                reinterpret_cast<XPUType *>(data),
+                                out->numel(),
+                                static_cast<XPUType>(min.to<float>()),
+                                static_cast<XPUType>(max.to<float>()),
+                                real_seed,
+                                algo);
+  PADDLE_ENFORCE_XDNN_SUCCESS(r, "uniform");
 }
 
 }  // namespace phi

--- a/test/legacy_test/test_adamw_op.py
+++ b/test/legacy_test/test_adamw_op.py
@@ -1062,8 +1062,8 @@ class TestAdamWOpLayerwiseLR(TestAdamWOp):
             np.testing.assert_allclose(
                 linear1.weight.numpy(),
                 fc1_w,
-                atol=2e-9 if core.is_compiled_with_xpu() else 0,
-                rtol=1e-6,
+                atol=1e-8 if core.is_compiled_with_xpu() else 0,
+                rtol=1e-5,
             )
             np.testing.assert_allclose(linear1.bias.numpy(), fc1_b, rtol=1e-6)
             np.testing.assert_allclose(linear2.weight.numpy(), fc2_w, rtol=1e-6)
@@ -1700,8 +1700,8 @@ class TestAdamWOpLayerwiseLR(TestAdamWOp):
             np.testing.assert_allclose(
                 linear1.weight.numpy(),
                 fc1_w,
-                atol=2e-9 if core.is_compiled_with_xpu() else 0,
-                rtol=1e-6,
+                atol=1e-8 if core.is_compiled_with_xpu() else 0,
+                rtol=1e-5,
             )
             np.testing.assert_allclose(linear1.bias.numpy(), fc1_b, rtol=1e-6)
             np.testing.assert_allclose(linear2.weight.numpy(), fc2_w, rtol=1e-6)

--- a/test/legacy_test/test_adamw_op.py
+++ b/test/legacy_test/test_adamw_op.py
@@ -1062,7 +1062,7 @@ class TestAdamWOpLayerwiseLR(TestAdamWOp):
             np.testing.assert_allclose(
                 linear1.weight.numpy(),
                 fc1_w,
-                atol=2e-9 if core.is_compiled_with_xpu() else 0,
+                atol=1e-8 if core.is_compiled_with_xpu() else 0,
                 rtol=1e-6,
             )
             np.testing.assert_allclose(linear1.bias.numpy(), fc1_b, rtol=1e-6)
@@ -1700,7 +1700,7 @@ class TestAdamWOpLayerwiseLR(TestAdamWOp):
             np.testing.assert_allclose(
                 linear1.weight.numpy(),
                 fc1_w,
-                atol=2e-9 if core.is_compiled_with_xpu() else 0,
+                atol=1e-8 if core.is_compiled_with_xpu() else 0,
                 rtol=1e-6,
             )
             np.testing.assert_allclose(linear1.bias.numpy(), fc1_b, rtol=1e-6)

--- a/test/legacy_test/test_adamw_op.py
+++ b/test/legacy_test/test_adamw_op.py
@@ -1062,7 +1062,7 @@ class TestAdamWOpLayerwiseLR(TestAdamWOp):
             np.testing.assert_allclose(
                 linear1.weight.numpy(),
                 fc1_w,
-                atol=1e-8 if core.is_compiled_with_xpu() else 0,
+                atol=2e-9 if core.is_compiled_with_xpu() else 0,
                 rtol=1e-6,
             )
             np.testing.assert_allclose(linear1.bias.numpy(), fc1_b, rtol=1e-6)
@@ -1700,7 +1700,7 @@ class TestAdamWOpLayerwiseLR(TestAdamWOp):
             np.testing.assert_allclose(
                 linear1.weight.numpy(),
                 fc1_w,
-                atol=1e-8 if core.is_compiled_with_xpu() else 0,
+                atol=2e-9 if core.is_compiled_with_xpu() else 0,
                 rtol=1e-6,
             )
             np.testing.assert_allclose(linear1.bias.numpy(), fc1_b, rtol=1e-6)

--- a/test/xpu/parallel_api_xpu.py
+++ b/test/xpu/parallel_api_xpu.py
@@ -42,7 +42,7 @@ class TestParallelOnXPU(TestParallelAPI):
     def check_loss(self, loss):
         pretrained_loss = {}
         pretrained_loss['dp2mp1pp1'] = np.array(
-            [9.103161, 9.126399], dtype=np.float32
+            [9.080904, 9.06618], dtype=np.float32
         )
         pretrained_loss['dp1mp2pp1'] = np.array(
             [9.097355, 9.057393], dtype=np.float32

--- a/test/xpu/parallel_api_xpu.py
+++ b/test/xpu/parallel_api_xpu.py
@@ -45,7 +45,7 @@ class TestParallelOnXPU(TestParallelAPI):
             [9.103161, 9.126399], dtype=np.float32
         )
         pretrained_loss['dp1mp2pp1'] = np.array(
-            [9.101589, 9.133528], dtype=np.float32
+            [9.097355, 9.057393], dtype=np.float32
         )
         loss = np.array(loss, dtype=np.float32)
         if pretrained_loss.get(self.test_name) is not None:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Custom Device

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
adapt to use xpu::uniform for uniform_kernel
