### PR TITLE
[SOT][DynamicShape] Clarify symbolic operations and fix scatter infermeta

### DIFF
--- a/paddle/phi/infermeta/ternary.cc
+++ b/paddle/phi/infermeta/ternary.cc
@@ -1985,15 +1985,17 @@ void ScatterInferMeta(const MetaTensor& x,
             "Input(Updates)'s shape is %d.",
             ref_dims.size(),
             updates_dims.size()));
-    PADDLE_ENFORCE_LE(
-        index_dims[0],
-        updates_dims[0],
-        common::errors::InvalidArgument(
-            "The first dimension size of Input(Index) should be no greater "
-            "than Input(Updates), but received first dimension size of "
-            "Input(Index) is %d, Input(Updates) is  %d.",
-            index_dims[0],
-            updates_dims[0]));
+    if (index_dims[0] != -1 && updates_dims[0] != -1) {
+      PADDLE_ENFORCE_LE(
+          index_dims[0],
+          updates_dims[0],
+          common::errors::InvalidArgument(
+              "The first dimension size of Input(Index) should be no greater "
+              "than Input(Updates), but received first dimension size of "
+              "Input(Index) is %d, Input(Updates) is  %d.",
+              index_dims[0],
+              updates_dims[0]));
+    }
   } else {
     PADDLE_ENFORCE_EQ(
         (ref_dims.size() - 1 == updates_dims.size()),

--- a/python/paddle/jit/sot/opcode_translator/executor/dispatch_functions.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/dispatch_functions.py
@@ -14,6 +14,8 @@
 
 # This file stores the customized function that will be called by the dispatch mechanism.
 
+from __future__ import annotations
+
 from ...utils import BreakGraphError, BreakGraphReasonBase, FallbackError
 
 

--- a/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
@@ -224,6 +224,11 @@ def pop_jump_if_op_wrapper(fns: list[Callable[[Any], Any]]):
                 )(res)
 
             assert isinstance(res, (ConstantVariable, SymbolicVariable))
+            # NOTE(SigureMo): force to constant to trigger fallback to static dim
+            # to align with old behavior. In next PR we will support guard value
+            # with constraint.
+            if isinstance(res, SymbolicVariable):
+                res = res.to_constant()
             is_jump = res.get_py_value()
             assert isinstance(is_jump, bool)
             if is_jump:

--- a/python/paddle/jit/sot/opcode_translator/executor/tracker.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/tracker.py
@@ -28,6 +28,7 @@ from .guard import StringifiedExpression, stringify_pyobject, union_free_vars
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+    from ...utils.magic_methods import BinaryOp, UnaryOp
     from .pycode_generator import PyCodeGen
     from .variables import VariableBase
 
@@ -131,9 +132,9 @@ class SymbolicOperationTracker(Tracker):
         inputs (list[VariableBase]): The input variables associated with the generated variables.
     """
 
-    def __init__(self, inputs: Sequence[VariableBase], method_name: str):
+    def __init__(self, inputs: Sequence[VariableBase], op: UnaryOp | BinaryOp):
         super().__init__(inputs)
-        self.method_name = method_name
+        self.op = op
 
     def gen_instructions(self, codegen: PyCodeGen):
         raise InnerError("SymbolicOperationTracker has no instructions")

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
@@ -1086,7 +1086,6 @@ class SymbolicVariable(VariableBase):
         if not ENV_SOT_ALLOW_DYNAMIC_SHAPE.get():
             return None
         if isinstance(value, SymbolicInt):
-            # return SymbolicVariable(value, graph, tracker)
             tensor_shape_source_result = (
                 SymbolicVariable.find_tensor_shape_source(tracker)
             )
@@ -1104,7 +1103,6 @@ class SymbolicVariable(VariableBase):
                 tracker
                 if tensor_var.tracker.is_traceable()
                 else DummyTracker([tensor_dim_var])
-                # else tensor_dim_var.tracker
             )
             sym_var = SymbolicVariable(value, graph, sym_var_tracker)
             graph.add_alias(tensor_dim_var, sym_var)

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
@@ -878,7 +878,7 @@ class SymbolicVariable(VariableBase):
     SymbolicVariable is a subclass of VariableBase used to wrap a symbolic value.
 
     Args:
-        value_or_meta (int | SymbolicInt | MetaInfo): The symbolic value  to be wrapped or metadata.
+        value_or_meta (SymbolicInt | MetaInfo): The symbolic value  to be wrapped or metadata.
         graph (FunctionGraph): The FunctionGraph object that this variable is associated with.
         tracker (Tracker): The Tracker object that tracks the information of this variable.
     """
@@ -889,7 +889,7 @@ class SymbolicVariable(VariableBase):
 
     def __init__(
         self,
-        value_or_meta: int | SymbolicInt | MetaInfo,
+        value_or_meta: SymbolicInt | MetaInfo,
         graph: FunctionGraph,
         tracker: Tracker,
     ):

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/container.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/container.py
@@ -348,7 +348,7 @@ class ListVariable(ContainerVariable):
         permutation = list(range(self.proxy.length))
         permutation.sort(
             key=lambda x: key.get_py_value()(
-                Dispatcher.call(operator.getitem, self, x).value
+                Dispatcher.call(operator.getitem, self, x).get_py_value()
             ),
             reverse=reverse.get_py_value(),
         )

--- a/python/paddle/jit/sot/symbolic_shape.py
+++ b/python/paddle/jit/sot/symbolic_shape.py
@@ -1,0 +1,116 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import operator
+from typing import TYPE_CHECKING, Generic, TypeVar
+
+if TYPE_CHECKING:
+
+    from .utils.magic_methods import BinaryOp, UnaryOp
+
+_T = TypeVar("_T", "int", "float", "bool")
+
+
+def symbolic_to_bool(x):
+    # Unified api for python number and paddle Tensor
+    return x != 0
+
+
+def symbolic_not(x):
+    return x == 0
+
+
+# All symbolic operations need unified for python number and paddle Tensor
+SYMBOLIC_UNARY_MATH_OPS: list[UnaryOp] = [
+    # Basic
+    operator.neg,
+    # Bitwise
+    operator.invert,
+]
+SYMBOLIC_BINARY_MATH_OPS: list[BinaryOp] = [
+    # Basic
+    operator.add,
+    operator.sub,
+    operator.mul,
+    operator.truediv,
+    operator.floordiv,
+    operator.pow,
+    operator.mod,
+    # Bitwise
+    operator.lshift,
+    operator.rshift,
+    operator.and_,
+    operator.or_,
+    operator.xor,
+]
+SYMBOLIC_UNARY_LOGICAL_OPS: list[UnaryOp] = [
+    symbolic_to_bool,
+    symbolic_not,
+]
+SYMBOLIC_BINARY_LOGICAL_OPS: list[BinaryOp] = [
+    operator.eq,
+    operator.ne,
+    operator.lt,
+    operator.le,
+    operator.gt,
+    operator.ge,
+]
+SYMBOLIC_MATH_OPS = SYMBOLIC_UNARY_MATH_OPS + SYMBOLIC_BINARY_MATH_OPS
+SYMBOLIC_MATH_OPS = SYMBOLIC_UNARY_MATH_OPS + SYMBOLIC_BINARY_MATH_OPS
+SYMBOLIC_UNARY_OPS: list[UnaryOp] = (
+    SYMBOLIC_UNARY_MATH_OPS + SYMBOLIC_UNARY_LOGICAL_OPS
+)
+SYMBOLIC_BINARY_OPS: list[BinaryOp] = (
+    SYMBOLIC_BINARY_MATH_OPS + SYMBOLIC_BINARY_LOGICAL_OPS
+)
+
+
+class SymbolicValue(Generic[_T]):
+    example_value: _T | None
+
+    def __init__(self, example_value=None):
+        self.example_value = example_value
+
+    def __repr__(self) -> str:
+        if self.is_backed():
+            return f"{self.__class__.__name__}({self.example_value})"
+        return f"{self.__class__.__name__}()"
+
+    def get_static_type(self) -> type[_T]:
+        raise NotImplementedError("get_py_type is not implemented.")
+
+    def is_backed(self):
+        return self.example_value is not None
+
+    def get_example_value(self) -> _T:
+        if self.example_value is None:
+            raise ValueError(f"{self} is not backed by a value.")
+        return self.example_value
+
+
+class SymbolicBool(SymbolicValue):
+    def get_static_type(self) -> type[bool]:
+        return bool
+
+
+class SymbolicInt(SymbolicValue):
+    def get_static_type(self) -> type[int]:
+        return int
+
+
+class SymbolicFloat(SymbolicValue):
+    def get_static_type(self) -> type[float]:
+        return float

--- a/python/paddle/jit/sot/utils/magic_methods.py
+++ b/python/paddle/jit/sot/utils/magic_methods.py
@@ -78,7 +78,6 @@ UNARY_OPS_TO_MAGIC_NAMES: dict[UnaryOp, str] = {
     operator.abs: "__abs__",
     operator.index: "__index__",
     operator.inv: "__inv__",
-    operator.not_: "__not__",
     operator.truth: "__bool__",
     bool: "__bool__",
     abs: "__abs__",


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

重构和规范 SOT 动态 shape 符号化操作，确保操作在一个有限的子集内，且操作封闭（至少目前封闭在 `int`、`float`、`bool`）

```
- Math
   - Basic
     - Add
     - Sub
     - Mul
     - FloorDiv
     - TrueDiv (int -> maybe float)
     - Pow
     - Mod
   - Bitwise
     - LShift
     - RShift
     - BitAnd
     - BitOr
     - BitXor
     - BitNot <Unary> (invert?)
- Logic
  - Eq
  - Ne
  - Gt
  - Lt
  - Ge
  - Le
  - Not <Unary>
```

这里主要分为数学运算和逻辑运算，数学运算是 `int | float -> int | float`，而逻辑运算则是 `int | float -> bool`，因此最终约束节点总会落到逻辑运算节点上（`if number` 这种也会归结为 `Ne(number, 0)`）

> [!NOTE]
>
> 模型上还有点问题

<!-- PCard-66972 -->