### PR TITLE
[SOT][Faster Guard] support `object_equal_stringified_guard`

### DIFF
--- a/paddle/fluid/pybind/jit.cc
+++ b/paddle/fluid/pybind/jit.cc
@@ -110,10 +110,10 @@ void BindGuard(pybind11::module *m) {
              std::shared_ptr<InstanceCheckGuard>>(
       *m, "InstanceCheckGuard", R"DOC(InstanceCheckGuard Class.)DOC")
       .def(py::init<const py::object &>(), py::arg("isinstance_obj"));
-  py::class_<NumpyDtypeMatchGuard,
+  py::class_<NumPyDtypeMatchGuard,
              GuardBase,
-             std::shared_ptr<NumpyDtypeMatchGuard>>(
-      *m, "NumpyDtypeMatchGuard", R"DOC(NumpyDtypeMatchGuard Class.)DOC")
+             std::shared_ptr<NumPyDtypeMatchGuard>>(
+      *m, "NumPyDtypeMatchGuard", R"DOC(NumPyDtypeMatchGuard Class.)DOC")
       .def(py::init<const py::object &>(), py::arg("dtype"));
   py::class_<NumPyArrayValueMatchGuard,
              GuardBase,
@@ -122,6 +122,9 @@ void BindGuard(pybind11::module *m) {
       "NumPyArrayValueMatchGuard",
       R"DOC(NumPyArrayValueMatchGuard Class.)DOC")
       .def(py::init<const py::object &>(), py::arg("array"));
+  py::class_<PyObjMatchGuard, GuardBase, std::shared_ptr<PyObjMatchGuard>>(
+      *m, "PyObjMatchGuard", R"DOC(PyObjMatchGuard Class.)DOC")
+      .def(py::init<const py::object &>(), py::arg("func"));
 
   m->def(
       "merge_guard",

--- a/paddle/fluid/pybind/jit.cc
+++ b/paddle/fluid/pybind/jit.cc
@@ -122,8 +122,8 @@ void BindGuard(pybind11::module *m) {
       "NumPyArrayValueMatchGuard",
       R"DOC(NumPyArrayValueMatchGuard Class.)DOC")
       .def(py::init<const py::object &>(), py::arg("array"));
-  py::class_<PyObjMatchGuard, GuardBase, std::shared_ptr<PyObjMatchGuard>>(
-      *m, "PyObjMatchGuard", R"DOC(PyObjMatchGuard Class.)DOC")
+  py::class_<WeakRefMatchGuard, GuardBase, std::shared_ptr<WeakRefMatchGuard>>(
+      *m, "WeakRefMatchGuard", R"DOC(WeakRefMatchGuard Class.)DOC")
       .def(py::init<const py::object &>(), py::arg("func"));
 
   m->def(

--- a/paddle/fluid/pybind/sot/guards.cc
+++ b/paddle/fluid/pybind/sot/guards.cc
@@ -136,7 +136,7 @@ bool InstanceCheckGuard::check(PyObject* value) {
   return PyObject_IsInstance(value, expected_);
 }
 
-bool NumpyDtypeMatchGuard::check(PyObject* value) {
+bool NumPyDtypeMatchGuard::check(PyObject* value) {
   if (value == nullptr) {
     return false;
   }
@@ -162,6 +162,14 @@ bool NumPyArrayValueMatchGuard::check(PyObject* value) {
       .attr("__eq__")(py_value)
       .attr("all")()
       .cast<bool>();
+}
+
+bool PyObjMatchGuard::check(PyObject* value) {
+  if (value == nullptr || expected_ == nullptr || Py_IsNone(expected_)) {
+    return false;
+  }
+
+  return PyObject_Equal(expected_, value);
 }
 
 PyObject* ConstantExprNode::eval(FrameProxy* frame) { return value_ptr_; }

--- a/paddle/fluid/pybind/sot/guards.cc
+++ b/paddle/fluid/pybind/sot/guards.cc
@@ -29,6 +29,10 @@ static inline PyObject* PyObject_CallOneArg(PyObject* func, PyObject* arg) {
 }
 #endif
 
+#if !PY_3_10_PLUS
+#define Py_IsNone(x) ((x) == Py_None)
+#endif
+
 static inline bool PyObject_Equal(PyObject* a, PyObject* b) {
   if (a == b) {
     return true;

--- a/paddle/fluid/pybind/sot/guards.cc
+++ b/paddle/fluid/pybind/sot/guards.cc
@@ -168,14 +168,14 @@ bool NumPyArrayValueMatchGuard::check(PyObject* value) {
       .cast<bool>();
 }
 
-bool PyObjMatchGuard::check(PyObject* value) {
+bool WeakRefMatchGuard::check(PyObject* value) {
   if (value == nullptr || expected_ == nullptr || Py_IsNone(expected_)) {
     return false;
   }
 
 #if PY_3_13_PLUS
-  PyObject* referent = NULL;
-  int get_ref_result = PyWeakref_GetRef(expected_, &referent);
+  PyObject* ref = NULL;
+  int get_ref_result = PyWeakref_GetRef(expected_, &ref);
   if (get_ref_result == -1) {
     // error
     PyErr_Print();
@@ -185,8 +185,8 @@ bool PyObjMatchGuard::check(PyObject* value) {
     // is dead
     return false;
   }
-  bool res = PyObject_Equal(value, referent);
-  Py_DECREF(referent);
+  bool res = PyObject_Equal(value, ref);
+  Py_DECREF(ref);
   return res;
 #else
   return PyObject_Equal(value, PyWeakref_GetObject(expected_));

--- a/paddle/fluid/pybind/sot/guards.cc
+++ b/paddle/fluid/pybind/sot/guards.cc
@@ -173,7 +173,11 @@ bool PyObjMatchGuard::check(PyObject* value) {
     return false;
   }
 
-  return PyObject_Equal(expected_, value);
+#if PY_3_9_PLUS
+  return PyObject_Equal(PyObject_CallNoArgs(expected_), value);
+#else
+  return PyObject_Equal(PyObject_CallObject(expected_, NULL), value);
+#endif
 }
 
 PyObject* ConstantExprNode::eval(FrameProxy* frame) { return value_ptr_; }

--- a/paddle/fluid/pybind/sot/guards.cc
+++ b/paddle/fluid/pybind/sot/guards.cc
@@ -173,10 +173,23 @@ bool PyObjMatchGuard::check(PyObject* value) {
     return false;
   }
 
-#if PY_3_9_PLUS
-  return PyObject_Equal(PyObject_CallNoArgs(expected_), value);
+#if PY_3_13_PLUS
+  PyObject* referent = NULL;
+  int get_ref_result = PyWeakref_GetRef(expected_, &referent);
+  if (get_ref_result == -1) {
+    // error
+    PyErr_Print();
+    return false;
+  }
+  if (get_ref_result == 0) {
+    // is dead
+    return false;
+  }
+  bool res = PyObject_Equal(value, referent);
+  Py_DECREF(referent);
+  return res;
 #else
-  return PyObject_Equal(PyObject_CallObject(expected_, NULL), value);
+  return PyObject_Equal(value, PyWeakref_GetObject(expected_));
 #endif
 }
 

--- a/paddle/fluid/pybind/sot/guards.h
+++ b/paddle/fluid/pybind/sot/guards.h
@@ -206,14 +206,14 @@ class InstanceCheckGuard : public GuardBase {
   PyObject* expected_;
 };
 
-class NumpyDtypeMatchGuard : public GuardBase {
+class NumPyDtypeMatchGuard : public GuardBase {
  public:
-  explicit NumpyDtypeMatchGuard(const py::object& dtype)
+  explicit NumPyDtypeMatchGuard(const py::object& dtype)
       : expected_(dtype.ptr()) {
     Py_INCREF(expected_);
   }
 
-  ~NumpyDtypeMatchGuard() override { Py_DECREF(expected_); }
+  ~NumPyDtypeMatchGuard() override { Py_DECREF(expected_); }
 
   bool check(PyObject* value) override;
 
@@ -229,6 +229,20 @@ class NumPyArrayValueMatchGuard : public GuardBase {
   }
 
   ~NumPyArrayValueMatchGuard() override { Py_DECREF(expected_); }
+
+  bool check(PyObject* value) override;
+
+ private:
+  PyObject* expected_;
+};
+
+class PyObjMatchGuard : public GuardBase {
+ public:
+  explicit PyObjMatchGuard(const py::object& obj) : expected_(obj.ptr()) {
+    Py_INCREF(expected_);
+  }
+
+  ~PyObjMatchGuard() override { Py_DECREF(expected_); }
 
   bool check(PyObject* value) override;
 

--- a/paddle/fluid/pybind/sot/guards.h
+++ b/paddle/fluid/pybind/sot/guards.h
@@ -236,13 +236,13 @@ class NumPyArrayValueMatchGuard : public GuardBase {
   PyObject* expected_;
 };
 
-class PyObjMatchGuard : public GuardBase {
+class WeakRefMatchGuard : public GuardBase {
  public:
-  explicit PyObjMatchGuard(const py::object& obj) {
+  explicit WeakRefMatchGuard(const py::object& obj) {
     expected_ = PyWeakref_NewRef(obj.ptr(), nullptr);
   }
 
-  ~PyObjMatchGuard() override { PyObject_ClearWeakRefs(expected_); }
+  ~WeakRefMatchGuard() override { PyObject_ClearWeakRefs(expected_); }
 
   bool check(PyObject* value) override;
 

--- a/paddle/fluid/pybind/sot/guards.h
+++ b/paddle/fluid/pybind/sot/guards.h
@@ -238,11 +238,7 @@ class NumPyArrayValueMatchGuard : public GuardBase {
 
 class PyObjMatchGuard : public GuardBase {
  public:
-  explicit PyObjMatchGuard(const py::object& obj) : expected_(obj.ptr()) {
-    Py_INCREF(expected_);
-  }
-
-  ~PyObjMatchGuard() override { Py_DECREF(expected_); }
+  explicit PyObjMatchGuard(const py::object& obj) : expected_(obj.ptr()) {}
 
   bool check(PyObject* value) override;
 

--- a/paddle/fluid/pybind/sot/guards.h
+++ b/paddle/fluid/pybind/sot/guards.h
@@ -238,7 +238,11 @@ class NumPyArrayValueMatchGuard : public GuardBase {
 
 class PyObjMatchGuard : public GuardBase {
  public:
-  explicit PyObjMatchGuard(const py::object& obj) : expected_(obj.ptr()) {}
+  explicit PyObjMatchGuard(const py::object& obj) {
+    expected_ = PyWeakref_NewRef(obj.ptr(), nullptr);
+  }
+
+  ~PyObjMatchGuard() override { PyObject_ClearWeakRefs(expected_); }
 
   bool check(PyObject* value) override;
 

--- a/python/paddle/jit/sot/opcode_translator/executor/guard.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/guard.py
@@ -284,8 +284,9 @@ def object_equal_stringified_guard(self) -> list[StringifiedExpression]:
     if support_weak_ref(weak_ref_obj):
         weak_ref_obj = weakref.ref(self.get_py_value())
         return [
-            StringifiedExpression(
+            FasterStringifiedExpression(
                 f"{obj_free_var_name}() is not None and {{}} == {obj_free_var_name}()",
+                paddle.framework.core.PyObjMatchGuard(self.get_py_value()),
                 [frame_value_tracer],
                 union_free_vars(
                     frame_value_tracer.free_vars,

--- a/python/paddle/jit/sot/opcode_translator/executor/guard.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/guard.py
@@ -286,7 +286,7 @@ def object_equal_stringified_guard(self) -> list[StringifiedExpression]:
         return [
             FasterStringifiedExpression(
                 f"{obj_free_var_name}() is not None and {{}} == {obj_free_var_name}()",
-                paddle.framework.core.PyObjMatchGuard(self.get_py_value()),
+                paddle.framework.core.PyObjMatchGuard(weak_ref_obj),
                 [frame_value_tracer],
                 union_free_vars(
                     frame_value_tracer.free_vars,

--- a/python/paddle/jit/sot/opcode_translator/executor/guard.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/guard.py
@@ -286,7 +286,7 @@ def object_equal_stringified_guard(self) -> list[StringifiedExpression]:
         return [
             FasterStringifiedExpression(
                 f"{obj_free_var_name}() is not None and {{}} == {obj_free_var_name}()",
-                paddle.framework.core.PyObjMatchGuard(self.get_py_value()),
+                paddle.framework.core.WeakRefMatchGuard(self.get_py_value()),
                 [frame_value_tracer],
                 union_free_vars(
                     frame_value_tracer.free_vars,

--- a/python/paddle/jit/sot/opcode_translator/executor/guard.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/guard.py
@@ -286,7 +286,7 @@ def object_equal_stringified_guard(self) -> list[StringifiedExpression]:
         return [
             FasterStringifiedExpression(
                 f"{obj_free_var_name}() is not None and {{}} == {obj_free_var_name}()",
-                paddle.framework.core.PyObjMatchGuard(weak_ref_obj),
+                paddle.framework.core.PyObjMatchGuard(self.get_py_value()),
                 [frame_value_tracer],
                 union_free_vars(
                     frame_value_tracer.free_vars,

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
@@ -1458,7 +1458,7 @@ class NumpyNumberVariable(NumpyVariable):
 
         dtype_guard = FasterStringifiedExpression(
             f"{{}}.dtype == {NumpyVariable.format_dtype(self.get_py_value().dtype)}",
-            paddle.framework.core.NumpyDtypeMatchGuard(
+            paddle.framework.core.NumPyDtypeMatchGuard(
                 self.get_py_value().dtype
             ),
             [frame_value_tracer],
@@ -1498,7 +1498,7 @@ class NumpyArrayVariable(NumpyVariable):
 
         dtype_guard = FasterStringifiedExpression(
             f"{{}}.dtype == {NumpyVariable.format_dtype(self.get_py_value().dtype)}",
-            paddle.framework.core.NumpyDtypeMatchGuard(
+            paddle.framework.core.NumPyDtypeMatchGuard(
                 self.get_py_value().dtype
             ),
             [frame_value_tracer],

--- a/test/sot/test_faster_guard.py
+++ b/test/sot/test_faster_guard.py
@@ -129,7 +129,7 @@ class TestBasicFasterGuard(unittest.TestCase):
 
     def test_numpy_dtype_match_guard(self):
         np_array = np.array(1, dtype=np.int32)
-        guard_numpy_dtype = paddle.framework.core.NumpyDtypeMatchGuard(
+        guard_numpy_dtype = paddle.framework.core.NumPyDtypeMatchGuard(
             np_array.dtype
         )
         self.assertTrue(guard_numpy_dtype.check(np_array))
@@ -140,7 +140,7 @@ class TestBasicFasterGuard(unittest.TestCase):
         self.assertFalse(guard_numpy_dtype.check(np.bool_()))
 
         np_bool = np.bool_(1)
-        guard_numpy_bool_dtype = paddle.framework.core.NumpyDtypeMatchGuard(
+        guard_numpy_bool_dtype = paddle.framework.core.NumPyDtypeMatchGuard(
             np_bool.dtype
         )
         self.assertTrue(guard_numpy_bool_dtype.check(np.bool_()))
@@ -191,6 +191,22 @@ class TestBasicFasterGuard(unittest.TestCase):
         )
         self.assertFalse(np_bool_array_all_true.check(np.array([1, 2, 3])))
         self.assertTrue(np_bool_array_all_true.check(np.array([True, True, 1])))
+
+    def test_object_match_guard(self):
+        def test_func():
+            return 1 + 1
+
+        guard_object = paddle.framework.core.PyObjMatchGuard(test_func)
+        self.assertTrue(guard_object.check(test_func))
+        self.assertFalse(guard_object.check(lambda x: x == 1))
+        self.assertFalse(guard_object.check(1))
+        self.assertFalse(guard_object.check("1"))
+        del test_func
+
+        def test_func():
+            return 1 + 1
+
+        self.assertFalse(guard_object.check(test_func))
 
 
 class TestFasterGuardGroup(unittest.TestCase):

--- a/test/sot/test_faster_guard.py
+++ b/test/sot/test_faster_guard.py
@@ -196,7 +196,7 @@ class TestBasicFasterGuard(unittest.TestCase):
         def test_func():
             return 1 + 1
 
-        guard_object = paddle.framework.core.PyObjMatchGuard(test_func)
+        guard_object = paddle.framework.core.WeakRefMatchGuard(test_func)
         self.assertTrue(guard_object.check(test_func))
         self.assertFalse(guard_object.check(lambda x: x == 1))
         self.assertFalse(guard_object.check(1))

--- a/test/sot/test_faster_guard.py
+++ b/test/sot/test_faster_guard.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 
 import unittest
-import weakref
 from collections import OrderedDict
 
 import numpy as np
@@ -197,15 +196,11 @@ class TestBasicFasterGuard(unittest.TestCase):
         def test_func():
             return 1 + 1
 
-        weak_ref_obj = weakref.ref(test_func)
-
-        guard_object = paddle.framework.core.PyObjMatchGuard(weak_ref_obj)
+        guard_object = paddle.framework.core.PyObjMatchGuard(test_func)
         self.assertTrue(guard_object.check(test_func))
         self.assertFalse(guard_object.check(lambda x: x == 1))
         self.assertFalse(guard_object.check(1))
         self.assertFalse(guard_object.check("1"))
-        del weak_ref_obj
-        self.assertFalse(guard_object.check(test_func))
 
 
 class TestFasterGuardGroup(unittest.TestCase):

--- a/test/sot/test_faster_guard.py
+++ b/test/sot/test_faster_guard.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import unittest
+import weakref
 from collections import OrderedDict
 
 import numpy as np
@@ -196,16 +197,14 @@ class TestBasicFasterGuard(unittest.TestCase):
         def test_func():
             return 1 + 1
 
-        guard_object = paddle.framework.core.PyObjMatchGuard(test_func)
+        weak_ref_obj = weakref.ref(test_func)
+
+        guard_object = paddle.framework.core.PyObjMatchGuard(weak_ref_obj)
         self.assertTrue(guard_object.check(test_func))
         self.assertFalse(guard_object.check(lambda x: x == 1))
         self.assertFalse(guard_object.check(1))
         self.assertFalse(guard_object.check("1"))
-        del test_func
-
-        def test_func():
-            return 1 + 1
-
+        del weak_ref_obj
         self.assertFalse(guard_object.check(test_func))
 
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->

* `NumpyDtypeMatchGuard` -> `NumPyDtypeMatchGuard`
* 新增 `WeakRefMatchGuard` 用于对自身进行弱引用，在 check 的时候检查自身是否为 None，并且于传入值相等
