### PR TITLE
[Serde][Dy2St] Use cached `PartialProgramLayer` in `jit.load`

### DIFF
--- a/python/paddle/jit/pir_translated_layer.py
+++ b/python/paddle/jit/pir_translated_layer.py
@@ -321,7 +321,7 @@ def _construct_params_and_buffers(model_path, programs, params_filename=None):
         return var_dict
 
 
-def _run_dygraph(instance, input, program_holder):
+def _run_dygraph(instance, input, program_holder, method_name):
     # 1. prepare inputs, outputs, attrs
     input_tensors = []
     input_tensor_names = []
@@ -348,7 +348,7 @@ def _run_dygraph(instance, input, program_holder):
         input_tensor_names.append(tensor.name)
         input_tensors.append(tensor)
 
-    if not hasattr(instance, "layer"):
+    if instance._get_partial_program_layer(method_name) is None:
         persistable_tensors = []
         origin_persistable_var_name = [
             program_holder._suffix_varname_dict[var_name]
@@ -377,18 +377,19 @@ def _run_dygraph(instance, input, program_holder):
             outputs,
             parameters,
         )
-        instance.layer = layer
+        instance._set_partial_program_layer(method_name, layer)
+    layer = instance._get_partial_program_layer(method_name)
     if instance._is_test:
-        instance.layer.training = False
+        layer.training = False
     else:
         if not program_holder.support_train:
             raise ValueError(
                 "The model is not trainable, please check model_file of jit.save."
             )
         else:
-            instance.layer.training = True
+            layer.training = True
 
-    return instance.layer(input_tensors)
+    return layer(input_tensors)
 
 
 def _run_static_graph(inputs, program_holder, src_program):
@@ -590,6 +591,7 @@ class PirTranslatedLayer(layers.Layer):
 
         self._is_test = True
         self._input_args_names = None
+        self._partial_program_layers = {}
 
     @staticmethod
     @framework.dygraph_only
@@ -641,7 +643,7 @@ class PirTranslatedLayer(layers.Layer):
             # When using jit.save, it runs in static graph mode.
             # Run in dynamic graph mode when the model is inferring.
             if in_dynamic_mode():
-                return _run_dygraph(self, input, program_holder)
+                return _run_dygraph(self, input, program_holder, method_name)
             else:
                 return _run_static_graph(
                     input, program_holder, program_holder.infer_program
@@ -793,3 +795,9 @@ class PirTranslatedLayer(layers.Layer):
             output_spec.append(spec)
 
         return output_spec
+
+    def _get_partial_program_layer(self, method_name):
+        return self._partial_program_layers.get(method_name, None)
+
+    def _set_partial_program_layer(self, method_name, layer):
+        self._partial_program_layers[method_name] = layer

--- a/python/paddle/jit/pir_translated_layer.py
+++ b/python/paddle/jit/pir_translated_layer.py
@@ -348,44 +348,45 @@ def _run_dygraph(instance, input, program_holder):
         input_tensor_names.append(tensor.name)
         input_tensors.append(tensor)
 
-    persistable_tensors = []
-    origin_persistable_var_name = [
-        program_holder._suffix_varname_dict[var_name]
-        for var_name in program_holder.persistable_names
-    ]
-    for var_name in origin_persistable_var_name:
-        dy_var_name = instance._persistable_var_name_dict[var_name]
-        if dy_var_name in instance._parameters:
-            persistable_tensors.append(instance._parameters[dy_var_name])
-        elif dy_var_name in instance._buffers:
-            persistable_tensors.append(instance._buffers[dy_var_name])
-        else:
-            raise ValueError(
-                f"The persistable variable {var_name} does not exist in current PirTranslatedLayer."
-            )
+    if not hasattr(instance, "layer"):
+        persistable_tensors = []
+        origin_persistable_var_name = [
+            program_holder._suffix_varname_dict[var_name]
+            for var_name in program_holder.persistable_names
+        ]
+        for var_name in origin_persistable_var_name:
+            dy_var_name = instance._persistable_var_name_dict[var_name]
+            if dy_var_name in instance._parameters:
+                persistable_tensors.append(instance._parameters[dy_var_name])
+            elif dy_var_name in instance._buffers:
+                persistable_tensors.append(instance._buffers[dy_var_name])
+            else:
+                raise ValueError(
+                    f"The persistable variable {var_name} does not exist in current PirTranslatedLayer."
+                )
 
-    from paddle.jit.dy2static.pir_partial_program import PartialProgramLayer
+        from paddle.jit.dy2static.pir_partial_program import PartialProgramLayer
 
-    inputs = program_holder.input_vars
-    outputs = program_holder.output_vars
-    parameters = (persistable_tensors, program_holder.persistable_vars)
+        inputs = program_holder.input_vars
+        outputs = program_holder.output_vars
+        parameters = (persistable_tensors, program_holder.persistable_vars)
 
-    layer = PartialProgramLayer(
-        program_holder.infer_program,
-        inputs,
-        outputs,
-        parameters,
-    )
-    instance.layer = layer
+        layer = PartialProgramLayer(
+            program_holder.infer_program,
+            inputs,
+            outputs,
+            parameters,
+        )
+        instance.layer = layer
     if instance._is_test:
-        layer.training = False
+        instance.layer.training = False
     else:
         if not program_holder.support_train:
             raise ValueError(
                 "The model is not trainable, please check model_file of jit.save."
             )
         else:
-            layer.training = True
+            instance.layer.training = True
 
     return instance.layer(input_tensors)
 

--- a/test/legacy_test/test_jit_layer.py
+++ b/test/legacy_test/test_jit_layer.py
@@ -16,6 +16,7 @@ import os
 import sys
 import tempfile
 import unittest
+from pathlib import Path
 
 import numpy as np
 
@@ -24,7 +25,9 @@ from paddle.base.framework import _dygraph_place_guard
 from paddle.jit.layer import Layer
 from paddle.static import InputSpec
 
-sys.path.append("../dygraph_to_static")
+sys.path.append(
+    str(Path(__file__).resolve().parent.parent / "dygraph_to_static")
+)
 from dygraph_to_static_utils import enable_to_static_guard
 
 paddle.seed(1)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

`jit.load` 运行阶段，当 `PartialProgramLayer` 已经被构造后，不应该重新构造，应该直接复用，否则这会导致：

- `PartialProgramLayer` 构造阶段需要每次都重新跑，这包含了前反向拆分等诸多编译期逻辑，不应该在热启动链路执行
- `scope` 是在 `PartialProgramLayer` 上 cache 的，如果 `PartialProgramLayer` 每次重新构造，那么 `scope` 必然重新构造，这会导致执行器 cache 无法命中，每次都重新构造执行器，造成非常大的启动开销

同样代码（ResNet50），动转静直接跑 timeline 如下：

<img width="1020" alt="image" src="https://github.com/user-attachments/assets/97785a8c-b236-4e68-83f8-bd11b2c07909" />

`jit.save` 再 `jit.load` 本 PR 修复前 timeline 如下（慢了十几倍）：

<img width="987" alt="image" src="https://github.com/user-attachments/assets/00557012-6a88-486b-baf2-b9718fc30cd2" />

本 PR 修复后 timeline 如下（和动转静直接跑基本对齐了）：

<img width="1009" alt="image" src="https://github.com/user-attachments/assets/33f5bce3-f587-4902-89f6-baed14c10781" />

另外，因为有一个 `TranslatedLayer` load 多个 program 的情况，因此需要存多个 `PartialProgramLayer`，根据 `method_name` 存在 `_partial_program_layers` 中

<!-- PCard-66972 -->