### PR TITLE
add support_fp32_mix_precision for multiclass_nms3

### DIFF
--- a/paddle/fluid/inference/tensorrt/convert/multiclass_nms3_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/multiclass_nms3_op.cc
@@ -137,6 +137,10 @@ class MultiClassNMS3OpConverter : public OpConverter {
         nvinfer1::Weights{
             nvinfer1::DataType::kINT32, static_cast<void*>(index.data()), 1});
 
+    SupportFP32MixPrecision(rois_num_name, op_desc.Type(), batch_nms_layer);
+    SupportFP32MixPrecision(output_name, op_desc.Type(), nms_concat_layer);
+    SupportFP32MixPrecision(index_name, op_desc.Type(), constant_layer);
+
     ReplenishLayerAndOutput(
         batch_nms_layer, "multiclass_nms3", {rois_num_name}, test_mode);
     ReplenishLayerAndOutput(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
add SupportFP32MixPrecision for multiclass_nms3 in Paddle-TRT
