### PR TITLE
[CINN] Remove mark last op's result as output when no value used

### DIFF
--- a/paddle/fluid/pir/transforms/build_cinn_pass.cc
+++ b/paddle/fluid/pir/transforms/build_cinn_pass.cc
@@ -60,7 +60,7 @@ class BuildCinnPass : public pir::Pass {
         continue;
       }
       VLOG(4) << "current group_ops.size(): " << group_ops.size();
-      ::pir::ReplaceWithGroupOp(block, group_ops);
+      ::pir::ReplaceWithGroupOp(block, group_ops, false);
     }
     auto end_t = std::chrono::high_resolution_clock::now();
     auto duration =

--- a/paddle/fluid/pir/transforms/sub_graph_detector.cc
+++ b/paddle/fluid/pir/transforms/sub_graph_detector.cc
@@ -701,8 +701,8 @@ std::vector<GroupOpsVec> DetectSubGraphs(pir::Block* block,
   return subgraph_detector.BuildGroups();
 }
 
-std::vector<pir::Value> AnalysisOutputs(
-    const GroupOpsVec& group_ops) {  // NOLINT
+std::vector<pir::Value> AnalysisOutputs(const GroupOpsVec& group_ops,
+                                        bool at_least_one_output) {
   // Get output by ud chain
   std::unordered_set<pir::Operation*> op_set(group_ops.begin(),
                                              group_ops.end());
@@ -722,15 +722,13 @@ std::vector<pir::Value> AnalysisOutputs(
     }
   }
 
-#ifndef PADDLE_WITH_CINN
   // NOTE: If all value are not used outside, we mark last op's results
   // as outputs. But keep in mind that is risky.
-  if (outputs.size() == 0) {
+  if (at_least_one_output && outputs.size() == 0) {
     for (size_t i = 0; i < group_ops.back()->num_results(); ++i) {
       outputs.push_back(group_ops.back()->result(i));
     }
   }
-#endif
 
   return outputs;
 }
@@ -866,7 +864,8 @@ pir::Operation* FindInsertPoint(const GroupOpsVec& group_ops,
 }
 
 void ReplaceWithGroupOp(pir::Block* block,
-                        const GroupOpsVec& group_ops) {  // NOLINT
+                        const GroupOpsVec& group_ops,
+                        bool at_least_one_output) {  // NOLINT
   ::pir::IrContext* ctx = ::pir::IrContext::Instance();
 #ifdef PADDLE_WITH_CINN
   ctx->GetOrRegisterDialect<cinn::dialect::OperatorDialect>();
@@ -875,7 +874,8 @@ void ReplaceWithGroupOp(pir::Block* block,
   ctx->GetOrRegisterDialect<paddle::dialect::OneDNNOperatorDialect>();
 #endif
   ::pir::Builder builder = ::pir::Builder(ctx, block);
-  const std::vector<pir::Value> outputs = AnalysisOutputs(group_ops);
+  const std::vector<pir::Value> outputs =
+      AnalysisOutputs(group_ops, at_least_one_output);
 
   // step 1: Analysis and insert group op before insert_point.
   auto* insert_point = FindInsertPoint(group_ops, outputs);

--- a/paddle/fluid/pir/transforms/sub_graph_detector.cc
+++ b/paddle/fluid/pir/transforms/sub_graph_detector.cc
@@ -722,14 +722,6 @@ std::vector<pir::Value> AnalysisOutputs(
     }
   }
 
-  // NOTE: If all value are not used outside, we mark last op's results
-  // as outputs. But keep in mind that is risky.
-  if (outputs.size() == 0) {
-    for (size_t i = 0; i < group_ops.back()->num_results(); ++i) {
-      outputs.push_back(group_ops.back()->result(i));
-    }
-  }
-
   return outputs;
 }
 

--- a/paddle/fluid/pir/transforms/sub_graph_detector.cc
+++ b/paddle/fluid/pir/transforms/sub_graph_detector.cc
@@ -722,6 +722,16 @@ std::vector<pir::Value> AnalysisOutputs(
     }
   }
 
+#ifndef PADDLE_WITH_CINN
+  // NOTE: If all value are not used outside, we mark last op's results
+  // as outputs. But keep in mind that is risky.
+  if (outputs.size() == 0) {
+    for (size_t i = 0; i < group_ops.back()->num_results(); ++i) {
+      outputs.push_back(group_ops.back()->result(i));
+    }
+  }
+#endif
+
   return outputs;
 }
 

--- a/paddle/fluid/pir/transforms/sub_graph_detector.h
+++ b/paddle/fluid/pir/transforms/sub_graph_detector.h
@@ -36,7 +36,9 @@ std::vector<GroupOpsVec> DetectSubGraphs(pir::Block* block,
                                          const OpClassifier& classifier);
 
 std::vector<pir::Value> AnalysisOutputs(const GroupOpsVec& group_ops);
-void ReplaceWithGroupOp(pir::Block* block, const GroupOpsVec& group_ops);
+void ReplaceWithGroupOp(pir::Block* block,
+                        const GroupOpsVec& group_ops,
+                        bool at_least_one_output = true);
 
 pir::Operation* FindInsertPoint(const GroupOpsVec& group_ops,
                                 const std::vector<pir::Value>& outputs);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-76996

- Remove mark last op's result as output when no value used