### PR TITLE
[fluid_ops] remove use_calc_stream check

### DIFF
--- a/python/paddle/distributed/passes/auto_parallel_data_parallel_optimization.py
+++ b/python/paddle/distributed/passes/auto_parallel_data_parallel_optimization.py
@@ -280,7 +280,6 @@ class DataParallelOptimizationPass(PassBase):
         # comm wait calc to finish
         for idx, op in reversed(list(enumerate(block.ops))):
             if is_data_parallel_reduce_op(op):
-                assert op.has_attr('use_calc_stream')
                 assert op.has_attr('ring_id')
 
                 op._set_attr('use_calc_stream', False)

--- a/test/deprecated/auto_parallel/test_auto_parallel_data_parallel_optimization_pass_deprecated.py
+++ b/test/deprecated/auto_parallel/test_auto_parallel_data_parallel_optimization_pass_deprecated.py
@@ -164,7 +164,6 @@ class TestDataParallelPassWithStandaloneEXE(TestDataParallelPassWithScale1):
                     break
             assert allreduce_op_idx > 0
             allreduce_op = ops[allreduce_op_idx]
-            assert allreduce_op.attr('use_calc_stream') is True
             assert allreduce_op.dist_attr.execution_stream is not None
             assert ops[allreduce_op_idx - 1].type == "nop"
             assert ops[allreduce_op_idx + 1].type == "nop"


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
c_allreduce_sum切换all_reduce算子后没有use_calc_stream属性，不用检查