### PR TITLE
[fluid_ops] test_comm_cost.py modify c_allreduce_sum

### DIFF
--- a/test/auto_parallel/test_comm_cost.py
+++ b/test/auto_parallel/test_comm_cost.py
@@ -23,7 +23,7 @@ import paddle
 from paddle.distributed.auto_parallel.static.cluster import Cluster
 from paddle.distributed.auto_parallel.static.cost import (
     AllgatherOpCost,
-    AllreduceSumOpCost,
+    AllReduceOpCost,
     BroadcastOpCost,
     CommContext,
     IdentityOpCost,
@@ -58,12 +58,12 @@ class TestCommOpCost(unittest.TestCase):
 
         # Check AllreduceSumCost 128MB ring cost
         allreduce_sum_op_desc = build_comm_desc(
-            "c_allreduce_sum",
+            "all_reduce",
             [0, 1, 2, 3, 4, 5, 6, 7],
             paddle.float32,
             [1, 32 * (10**6)],
         )
-        allreduce_sum_op_cost = AllreduceSumOpCost(
+        allreduce_sum_op_cost = AllReduceOpCost(
             op_desc=allreduce_sum_op_desc, comm_context=comm_context
         )
 
@@ -138,12 +138,12 @@ class TestCommOpCost(unittest.TestCase):
 
         # Check AllreduceSumCost 128MB ring cost
         allreduce_sum_op_desc = build_comm_desc(
-            "c_allreduce_sum",
+            "all_reduce",
             [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
             paddle.float32,
             [1, 32 * (10**6)],
         )
-        allreduce_sum_op_cost = AllreduceSumOpCost(
+        allreduce_sum_op_cost = AllReduceOpCost(
             op_desc=allreduce_sum_op_desc, comm_context=comm_context
         )
 

--- a/test/auto_parallel/test_comm_cost.py
+++ b/test/auto_parallel/test_comm_cost.py
@@ -143,6 +143,7 @@ class TestCommOpCost(unittest.TestCase):
             [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
             paddle.float32,
             [1, 32 * (10**6)],
+            {"reduce_type": paddle.distributed.ReduceOp.SUM},
         )
         allreduce_sum_op_cost = AllReduceOpCost(
             op_desc=allreduce_sum_op_desc, comm_context=comm_context

--- a/test/auto_parallel/test_comm_cost.py
+++ b/test/auto_parallel/test_comm_cost.py
@@ -62,6 +62,7 @@ class TestCommOpCost(unittest.TestCase):
             [0, 1, 2, 3, 4, 5, 6, 7],
             paddle.float32,
             [1, 32 * (10**6)],
+            {"reduce_type": paddle.distributed.ReduceOp.SUM},
         )
         allreduce_sum_op_cost = AllReduceOpCost(
             op_desc=allreduce_sum_op_desc, comm_context=comm_context


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
test/auto_parallel/test_comm_cost.py 修改 c_allreduce_sum 为 all_reduce

框架cost已修改 https://github.com/PaddlePaddle/Paddle/pull/72077