### PR TITLE
[AMP]fix layer_norm dtype error in amp

### DIFF
--- a/paddle/fluid/eager/amp_auto_cast.h
+++ b/paddle/fluid/eager/amp_auto_cast.h
@@ -65,15 +65,8 @@ inline paddle::Tensor AmpAutoCast(const std::string& input_name,
                                   const paddle::Tensor& input,
                                   const phi::DataType& dst_dtype,
                                   std::string op_name) {
-  VLOG(6) << "AMP AmpAutoCasts:"
-          << " input(" << input_name << ") dst_dtype("
-          << phi::DataTypeToString(dst_dtype) << ").";
+  VLOG(1) << "AMP AmpAutoCasts:"<< op_name << " input(" << input_name << ") dst_dtype("<< phi::DataTypeToString(dst_dtype) << ").";
 
-  if ((op_name == "batch_norm" || op_name == "layer_norm" ||
-       op_name == "sync_batch_norm") &&
-      input_name != "X") {
-    return input;
-  }
   if (op_name == "fused_softmax_mask" && input_name == "Mask" &&
       input.dtype() == phi::DataType::FLOAT32) {
     return input;
@@ -89,12 +82,25 @@ inline paddle::Tensor AmpAutoCast(const std::string& input_name,
         return input;
       }
     }
+    if ((op_name == "batch_norm" || op_name == "layer_norm" ||
+         op_name == "sync_batch_norm" || op_name == "weight_only_linear") &&
+        input_name != "x") {
+      return input;
+    }
+  } else if (dst_dtype == phi::DataType::BFLOAT16) {
+    if ((op_name == "batch_norm" || op_name == "layer_norm" ||
+         op_name == "sync_batch_norm" || op_name == "weight_only_linear") &&
+        input_name != "x") {
+      return input;
+    }
   }
 
   if (NeedCast(input, dst_dtype)) {
     paddle::framework::AttributeMap cast_attrs = {
         {"in_dtype", paddle::framework::TransToProtoVarType(input.dtype())},
         {"out_dtype", paddle::framework::TransToProtoVarType(dst_dtype)}};
+      VLOG(1) <<" OP "<<op_name<< "AMP Cast input(" << input_name << ") to dtype("
+              << phi::DataTypeToString(dst_dtype) << ").";
     return cast_dygraph_function(input, cast_attrs);
   }
   return input;

--- a/paddle/fluid/eager/amp_auto_cast.h
+++ b/paddle/fluid/eager/amp_auto_cast.h
@@ -65,7 +65,9 @@ inline paddle::Tensor AmpAutoCast(const std::string& input_name,
                                   const paddle::Tensor& input,
                                   const phi::DataType& dst_dtype,
                                   std::string op_name) {
-  VLOG(1) << "AMP AmpAutoCasts:"<< op_name << " input(" << input_name << ") dst_dtype("<< phi::DataTypeToString(dst_dtype) << ").";
+  VLOG(6) << "AMP AmpAutoCasts:"
+          << " input(" << input_name << ") dst_dtype("
+          << phi::DataTypeToString(dst_dtype) << ").";
 
   if (op_name == "fused_softmax_mask" && input_name == "Mask" &&
       input.dtype() == phi::DataType::FLOAT32) {
@@ -99,8 +101,6 @@ inline paddle::Tensor AmpAutoCast(const std::string& input_name,
     paddle::framework::AttributeMap cast_attrs = {
         {"in_dtype", paddle::framework::TransToProtoVarType(input.dtype())},
         {"out_dtype", paddle::framework::TransToProtoVarType(dst_dtype)}};
-      VLOG(1) <<" OP "<<op_name<< "AMP Cast input(" << input_name << ") to dtype("
-              << phi::DataTypeToString(dst_dtype) << ").";
     return cast_dygraph_function(input, cast_attrs);
   }
   return input;

--- a/paddle/fluid/imperative/amp_utils.h
+++ b/paddle/fluid/imperative/amp_utils.h
@@ -282,14 +282,8 @@ inline T AmpAutoCast(const std::string& input_name,
                      const phi::DataType& dst_dtype,
                      const std::string& op_name,
                      bool trace_backward = true) {
-  VLOG(6) << "AMP AmpAutoCasts:"
-          << " input(" << input_name << ") dst_dtype("
-          << phi::DataTypeToString(dst_dtype) << ").";
-  if ((op_name == "batch_norm" || op_name == "layer_norm" ||
-       op_name == "sync_batch_norm" || op_name == "weight_only_linear") &&
-      input_name != "x") {
-    return input;
-  }
+  VLOG(1) << "AMP AmpAutoCasts: op_name(" << op_name << ")input(" << input_name
+          << ") dst_dtype(" << phi::DataTypeToString(dst_dtype) << ").";
 
   if (dst_dtype == phi::DataType::FLOAT16) {
     if (op_name == "run_program") {
@@ -308,9 +302,20 @@ inline T AmpAutoCast(const std::string& input_name,
         return input;
       }
     }
+    if ((op_name == "batch_norm" || op_name == "layer_norm" ||
+         op_name == "sync_batch_norm" || op_name == "weight_only_linear") &&
+        input_name != "x") {
+      return input;
+    }
+  } else if (dst_dtype == phi::DataType::BFLOAT16) {
+    if ((op_name == "batch_norm" || op_name == "layer_norm" ||
+         op_name == "sync_batch_norm" || op_name == "weight_only_linear") &&
+        input_name != "x") {
+      return input;
+    }
   }
   if (NeedCast(input, dst_dtype)) {
-    VLOG(6) << "Input : " << input.impl() << "NeedCast";
+    VLOG(1)<<op_name << " Input : " << input.impl() << "NeedCast "<< phi::DataTypeToString(dst_dtype);
     return Cast(input, dst_dtype, trace_backward);
   }
   return input;

--- a/paddle/fluid/imperative/amp_utils.h
+++ b/paddle/fluid/imperative/amp_utils.h
@@ -282,8 +282,9 @@ inline T AmpAutoCast(const std::string& input_name,
                      const phi::DataType& dst_dtype,
                      const std::string& op_name,
                      bool trace_backward = true) {
-  VLOG(1) << "AMP AmpAutoCasts: op_name(" << op_name << ")input(" << input_name
-          << ") dst_dtype(" << phi::DataTypeToString(dst_dtype) << ").";
+  VLOG(6) << "AMP AmpAutoCasts:"
+          << " input(" << input_name << ") dst_dtype("
+          << phi::DataTypeToString(dst_dtype) << ").";
 
   if (dst_dtype == phi::DataType::FLOAT16) {
     if (op_name == "run_program") {
@@ -315,7 +316,7 @@ inline T AmpAutoCast(const std::string& input_name,
     }
   }
   if (NeedCast(input, dst_dtype)) {
-    VLOG(1)<<op_name << " Input : " << input.impl() << "NeedCast "<< phi::DataTypeToString(dst_dtype);
+    VLOG(6) << "Input : " << input.impl() << "NeedCast";
     return Cast(input, dst_dtype, trace_backward);
   }
   return input;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes 

### Description
<!-- Describe what you’ve done -->
layer norm的input dtype fp32时，在amp下没有正确cast scale和bias的dtype