### PR TITLE
[Auto-parallel] fused comm for sharding stage1

### DIFF
--- a/python/paddle/distributed/auto_parallel/api.py
+++ b/python/paddle/distributed/auto_parallel/api.py
@@ -1388,6 +1388,108 @@ class _ShardOptimizer(Optimizer):
             param_and_grad = (param_and_grad[0], grad)
         return self._inner_opt._append_optimize_op(block, param_and_grad)
 
+    def _apply_optimize(
+        self, loss, startup_program, params_grads, param_group_idx=0
+    ):
+        fuse_allreduce_in_opt = False
+        fuse_reducescatter_in_opt = False
+        if os.getenv("FLAGS_fuse_allreduce_in_opt") in [
+            'True',
+            'true',
+            '1',
+        ]:
+            fuse_allreduce_in_opt = True
+        if os.getenv("FLAGS_fuse_reducescatter_in_opt") in [
+            'True',
+            'true',
+            '1',
+        ]:
+            fuse_reducescatter_in_opt = True
+
+        assert not (
+            fuse_allreduce_in_opt and fuse_reducescatter_in_opt
+        ), "The `FLAGS_fuse_allreduce_in_opt` switch and the `FLAGS_fuse_reducescatter_in_opt` switch cannot be turned on simultaneously."
+
+        # `FLAGS_fuse_allreduce_in_opt` = True
+        def fuse_allreduce_on_grad(p_and_g):
+            new_p_and_g = []
+            for p, g in p_and_g:
+                new_g = g
+                new_placements = copy.deepcopy(g.placements)
+                for idx, placement in enumerate(g.placements):
+                    if placement.is_partial():
+                        new_placements[idx] = dist.Replicate()
+
+                if g.placements != new_placements:
+                    new_g = dist.reshard(g, g.process_mesh, new_placements)
+                new_p_and_g.append((p, new_g))
+
+            return new_p_and_g
+
+        # `FLAGS_fuse_reducescatter_in_opt` = True
+        def get_shard_dim(len, shard_dims):
+            for idx in range(len):
+                if idx not in shard_dims:
+                    return idx
+            return -1
+
+        def fuse_reducescatter_on_grad(p_and_g):
+            new_p_and_g = []
+            for p, g in p_and_g:
+                new_placements = copy.deepcopy(g.placements)
+                new_g = g
+                shard_dims = {}
+
+                # Record shard dims
+                for placement in g.placements:
+                    if placement.is_shard():
+                        dim = placement.get_dim()
+                        shard_dims[dim] = 1
+
+                # Try to shard on sharding axis
+                dim = get_shard_dim(len(g._local_shape), shard_dims)
+                if dim != -1:
+                    shard_dims[dim] = 1
+                    new_placements[self._sharding_axis] = dist.Shard(dim)
+
+                # Try shard other dim
+                for idx, placement in enumerate(g.placements):
+                    if idx == self._sharding_axis:
+                        continue
+                    if placement.is_shard():
+                        continue
+                    dim = get_shard_dim(len(g._local_shape), shard_dims)
+                    if dim != -1:
+                        shard_dims[dim] = 1
+                        new_placements[idx] = dist.Shard(dim)
+                    else:
+                        new_placements[idx] = dist.Replicate()
+
+                if g.placements != new_placements:
+                    new_g = dist.reshard(g, g.process_mesh, new_placements)
+
+                new_p_and_g.append((p, new_g))
+
+            return new_p_and_g
+
+        if paddle.in_dynamic_mode():
+            if fuse_allreduce_in_opt:
+                with paddle.static.program_guard(
+                    paddle.static.default_main_program(),
+                    paddle.static.default_startup_program(),
+                ):
+                    params_grads = fuse_allreduce_on_grad(params_grads)
+            elif fuse_reducescatter_in_opt:
+                with paddle.static.program_guard(
+                    paddle.static.default_main_program(),
+                    paddle.static.default_startup_program(),
+                ):
+                    params_grads = fuse_reducescatter_on_grad(params_grads)
+
+        return super()._apply_optimize(
+            loss, startup_program, params_grads, param_group_idx=0
+        )
+
     def __getattr__(self, item):
         if "_inner_opt" in self.__dict__:
             if item == "_inner_opt":

--- a/python/paddle/distributed/auto_parallel/api.py
+++ b/python/paddle/distributed/auto_parallel/api.py
@@ -1392,14 +1392,15 @@ class _ShardOptimizer(Optimizer):
         '''
         In sharding dynamic mode, optimize grad clip on partial grads causes redundant allreduce.
         Below are 2 methods to modify grad partial state by fusing comms before optimize:
-            1) Fuse allreduce: Change all partial state in placements to replicate via `allreduce` comms,
+            1) FLAGS_fuse_reducescatter_in_opt: Change all partial state in placements to replicate
+               via `allreduce` comms,
                 e.g.
                     a) sharding_axis = 0, tensor rank = 2,
                        placements: [partial, shard(0), partial] -> [replicate, shard(0), replicate].
 
-            2) Fuse reduce_scatter: Keep shard states in placements unchanged, transform others to `shard(dim)`
-               states via `reduce_scatter` comms if possible, or replicate states otherwise. In particular,
-               the `placement[sharding_axis]` should be `shard(0)` if possible.
+            2) FLAGS_fuse_reducescatter_in_opt: Keep shard states in placements unchanged, transform others
+               to `shard(dim)` states via `reduce_scatter` comms if possible, or replicate states otherwise.
+               In particular, the `placement[sharding_axis]` should be `shard(0)` if possible.
                 e.g.
                     a) sharding_axis = 0, tensor rank = 2,
                        placements: [partial, partial, partial] -> [shard(0), shard(1), replicate]

--- a/python/paddle/distributed/auto_parallel/api.py
+++ b/python/paddle/distributed/auto_parallel/api.py
@@ -1388,43 +1388,27 @@ class _ShardOptimizer(Optimizer):
             param_and_grad = (param_and_grad[0], grad)
         return self._inner_opt._append_optimize_op(block, param_and_grad)
 
-    def _fused_comm_before_apply_optimize(self, params_grads):
+    def _fused_comm_before_apply_optimize(self, flags, params_grads):
         '''
         In sharding dynamic mode, optimize grad clip on partial grads causes redundant allreduce.
         Below are 2 methods to modify grad partial state by fusing comms before optimize:
-            1) FLAGS_fuse_reducescatter_in_opt: Change all partial state in placements to replicate
-               via `allreduce` comms,
+            1) fuse allreduce: Change all partial state in placements to replicate via `allreduce` comms,
                 e.g.
                     a) sharding_axis = 0, tensor rank = 2,
                        placements: [partial, shard(0), partial] -> [replicate, shard(0), replicate].
 
-            2) FLAGS_fuse_reducescatter_in_opt: Keep shard states in placements unchanged, transform others
-               to `shard(dim)` states via `reduce_scatter` comms if possible, or replicate states otherwise.
-               In particular, the `placement[sharding_axis]` should be `shard(0)` if possible.
+            2) fuse reduce_scatter: Keep shard states in placements unchanged, transform others to `shard(dim)`
+               states via `reduce_scatter` comms if possible, or replicate states otherwise. In particular,
+               the `placement[sharding_axis]` should be `shard(0)` if possible.
                 e.g.
                     a) sharding_axis = 0, tensor rank = 2,
                        placements: [partial, partial, partial] -> [shard(0), shard(1), replicate]
                     b) sharding_axis = 0, tensor rank = 2,
                        placements: [partial, shard(0), partial ] -> [shard(1), shard(0), replicate]
         '''
-
-        # Get fuse optimization flag.
-        def get_env(flag_name):
-            if os.getenv(flag_name) in ['True', 'true', '1']:
-                return True
-            return False
-
-        # TODO: This optimization hasn't been verified on a wide range of models. Currently,
-        # it's controlled by a flag switch and will be removed later.
-        fuse_allreduce_in_opt = get_env("FLAGS_fuse_allreduce_in_opt")
-        fuse_reducescatter_in_opt = get_env("FLAGS_fuse_reducescatter_in_opt")
-        assert not (
-            fuse_allreduce_in_opt and fuse_reducescatter_in_opt
-        ), "The `FLAGS_fuse_allreduce_in_opt` switch and the `FLAGS_fuse_reducescatter_in_opt` switch cannot be turned on simultaneously."
-
         new_params_grads = []
 
-        if fuse_allreduce_in_opt:
+        if flags["fuse_allreduce"]:
             for param, grad in params_grads:
                 new_grad = grad
                 new_placements = copy.deepcopy(grad.placements)
@@ -1440,7 +1424,7 @@ class _ShardOptimizer(Optimizer):
                     )
                 new_params_grads.append((param, new_grad))
 
-        if fuse_reducescatter_in_opt:
+        elif flags["fuse_reducescatter"]:
             # Get the first non-shard dim of tensor shape in ascending order.
             # `shard_dims_set` records if dim is marked as shard in placement.
             def get_first_can_shard_dim(tensor_shape, shard_dims_set):
@@ -1491,7 +1475,8 @@ class _ShardOptimizer(Optimizer):
                     )
 
                 new_params_grads.append((param, new_grad))
-
+        else:
+            new_params_grads = params_grads
         return new_params_grads
 
     def _apply_optimize(
@@ -1499,7 +1484,29 @@ class _ShardOptimizer(Optimizer):
     ):
         # Fuse the communication of gradients prior to the optimization operation in the dynamic mode.
         if paddle.in_dynamic_mode():
-            params_grads = self._fused_comm_before_apply_optimize(params_grads)
+            # Get fuse optimization flag.
+            def get_env(flag_name):
+                if os.getenv(flag_name) in ['True', 'true', '1']:
+                    return True
+                return False
+
+            # TODO: This optimization hasn't been verified on a wide range of models. Currently,
+            # it's controlled by a flag switch and will be removed later.
+            fuse_allreduce_in_opt = get_env("FLAGS_fuse_allreduce_in_opt")
+            fuse_reducescatter_in_opt = get_env(
+                "FLAGS_fuse_reducescatter_in_opt"
+            )
+            assert not (
+                fuse_allreduce_in_opt and fuse_reducescatter_in_opt
+            ), "The `FLAGS_fuse_allreduce_in_opt` switch and the `FLAGS_fuse_reducescatter_in_opt` switch cannot be turned on simultaneously."
+
+            if fuse_allreduce_in_opt or fuse_reducescatter_in_opt:
+                flags = {}
+                flags["fuse_allreduce"] = fuse_allreduce_in_opt
+                flags["fuse_reducescatter"] = fuse_reducescatter_in_opt
+                params_grads = self._fused_comm_before_apply_optimize(
+                    flags, params_grads
+                )
 
         return super()._apply_optimize(
             loss, startup_program, params_grads, param_group_idx

--- a/python/paddle/distributed/auto_parallel/api.py
+++ b/python/paddle/distributed/auto_parallel/api.py
@@ -1388,96 +1388,120 @@ class _ShardOptimizer(Optimizer):
             param_and_grad = (param_and_grad[0], grad)
         return self._inner_opt._append_optimize_op(block, param_and_grad)
 
-    def _apply_optimize(
-        self, loss, startup_program, params_grads, param_group_idx=0
-    ):
-        fuse_allreduce_in_opt = False
-        fuse_reducescatter_in_opt = False
-        if os.getenv("FLAGS_fuse_allreduce_in_opt") in [
-            'True',
-            'true',
-            '1',
-        ]:
-            fuse_allreduce_in_opt = True
-        if os.getenv("FLAGS_fuse_reducescatter_in_opt") in [
-            'True',
-            'true',
-            '1',
-        ]:
-            fuse_reducescatter_in_opt = True
+    def _fused_comm_before_apply_optimize(self, params_grads):
+        '''
+        In sharding dynamic mode, optimize grad clip on partial grads causes redundant allreduce.
+        Below are 2 methods to modify grad partial state by fusing comms before optimize:
+            1) Fuse allreduce: Change all partial state in placements to replicate via `allreduce` comms,
+                e.g.
+                    a) sharding_axis = 0, tensor rank = 2,
+                       placements: [partial, shard(0), partial] -> [replicate, shard(0), replicate].
 
+            2) Fuse reduce_scatter: Keep shard states in placements unchanged, transform others to `shard(dim)`
+               states via `reduce_scatter` comms if possible, or replicate states otherwise. In particular,
+               the `placement[sharding_axis]` should be `shard(0)` if possible.
+                e.g.
+                    a) sharding_axis = 0, tensor rank = 2,
+                       placements: [partial, partial, partial] -> [shard(0), shard(1), replicate]
+                    b) sharding_axis = 0, tensor rank = 2,
+                       placements: [partial, shard(0), partial ] -> [shard(1), shard(0), replicate]
+        '''
+
+        # Get fuse optimization flag.
+        def get_env(flag_name):
+            if os.getenv(flag_name) in ['True', 'true', '1']:
+                return True
+            return False
+
+        # TODO: This optimization hasn't been verified on a wide range of models. Currently,
+        # it's controlled by a flag switch and will be removed later.
+        fuse_allreduce_in_opt = get_env("FLAGS_fuse_allreduce_in_opt")
+        fuse_reducescatter_in_opt = get_env("FLAGS_fuse_reducescatter_in_opt")
         assert not (
             fuse_allreduce_in_opt and fuse_reducescatter_in_opt
         ), "The `FLAGS_fuse_allreduce_in_opt` switch and the `FLAGS_fuse_reducescatter_in_opt` switch cannot be turned on simultaneously."
 
-        # `FLAGS_fuse_allreduce_in_opt` = True
-        def fuse_allreduce_on_grad(p_and_g):
-            new_p_and_g = []
-            for p, g in p_and_g:
-                new_g = g
-                new_placements = copy.deepcopy(g.placements)
-                for idx, placement in enumerate(g.placements):
+        new_params_grads = []
+
+        if fuse_allreduce_in_opt:
+            for param, grad in params_grads:
+                new_grad = grad
+                new_placements = copy.deepcopy(grad.placements)
+                for mesh_axis, placement in enumerate(grad.placements):
+                    # 1. Convert all partial states to allreduce states.
                     if placement.is_partial():
-                        new_placements[idx] = dist.Replicate()
+                        new_placements[mesh_axis] = dist.Replicate()
 
-                if g.placements != new_placements:
-                    new_g = dist.reshard(g, g.process_mesh, new_placements)
-                new_p_and_g.append((p, new_g))
+                if grad.placements != new_placements:
+                    # 2. Add allreduce comms via reshard API.
+                    new_grad = dist.reshard(
+                        grad, grad.process_mesh, new_placements
+                    )
+                new_params_grads.append((param, new_grad))
 
-            return new_p_and_g
+        if fuse_reducescatter_in_opt:
+            # Get the first non-shard dim of tensor shape in ascending order.
+            # `shard_dims_set` records if dim is marked as shard in placement.
+            def get_first_can_shard_dim(tensor_shape, shard_dims_set):
+                for dim in range(len(tensor_shape)):
+                    if dim not in shard_dims_set:
+                        return dim
+                return -1
 
-        # `FLAGS_fuse_reducescatter_in_opt` = True
-        def get_shard_dim(len, shard_dims):
-            for idx in range(len):
-                if idx not in shard_dims:
-                    return idx
-            return -1
+            for param, grad in params_grads:
+                new_placements = copy.deepcopy(grad.placements)
+                new_grad = grad
+                tensor_shape = grad._local_shape
+                shard_dims_set = {}
 
-        def fuse_reducescatter_on_grad(p_and_g):
-            new_p_and_g = []
-            for p, g in p_and_g:
-                new_placements = copy.deepcopy(g.placements)
-                new_g = g
-                shard_dims = {}
-
-                # Record shard dims
-                for placement in g.placements:
+                # 1. `shard_dims_set` records dims marked as shard in placement.
+                for placement in grad.placements:
                     if placement.is_shard():
                         dim = placement.get_dim()
-                        shard_dims[dim] = 1
+                        shard_dims_set.add(dim)
 
-                # Try to shard on sharding axis
-                dim = get_shard_dim(len(g._local_shape), shard_dims)
+                # 2. Prioritize setting placement[sharding_axis] as shard (usually shard(0)), otherwise set as replicate.
+                dim = get_first_can_shard_dim(tensor_shape, shard_dims_set)
                 if dim != -1:
-                    shard_dims[dim] = 1
+                    shard_dims_set.add(dim)
                     new_placements[self._sharding_axis] = dist.Shard(dim)
+                else:
+                    new_placements[self._sharding_axis] = dist.Replicate()
 
-                # Try shard other dim
-                for idx, placement in enumerate(g.placements):
-                    if idx == self._sharding_axis or placement.is_shard():
+                for mesh_axis, placement in enumerate(grad.placements):
+                    if mesh_axis == self._sharding_axis:
                         continue
-                    dim = get_shard_dim(len(g._local_shape), shard_dims)
+                    # 3. Keep shard states in placements unchanged.
+                    if placement.is_shard():
+                        continue
+                    dim = get_first_can_shard_dim(tensor_shape, shard_dims_set)
                     if dim != -1:
-                        shard_dims[dim] = 1
-                        new_placements[idx] = dist.Shard(dim)
+                        # 4. Turn other placements into shard state if possible.
+                        shard_dims_set.add(dim)
+                        new_placements[mesh_axis] = dist.Shard(dim)
                     else:
-                        new_placements[idx] = dist.Replicate()
+                        # 5. When all tensor dims are in shard state, set remaining placements to replicate.
+                        new_placements[mesh_axis] = dist.Replicate()
 
-                if g.placements != new_placements:
-                    new_g = dist.reshard(g, g.process_mesh, new_placements)
+                if grad.placements != new_placements:
+                    # 6. Add reduce_scatter comms via reshard API.
+                    new_grad = dist.reshard(
+                        grad, grad.process_mesh, new_placements
+                    )
 
-                new_p_and_g.append((p, new_g))
+                new_params_grads.append((grad, new_grad))
 
-            return new_p_and_g
+        return new_params_grads
 
+    def _apply_optimize(
+        self, loss, startup_program, params_grads, param_group_idx=0
+    ):
+        # Fuse the communication of gradients prior to the optimization operation in the dynamic mode.
         if paddle.in_dynamic_mode():
-            if fuse_allreduce_in_opt:
-                params_grads = fuse_allreduce_on_grad(params_grads)
-            elif fuse_reducescatter_in_opt:
-                params_grads = fuse_reducescatter_on_grad(params_grads)
+            params_grads = self._fused_comm_before_apply_optimize(params_grads)
 
         return super()._apply_optimize(
-            loss, startup_program, params_grads, param_group_idx=0
+            loss, startup_program, params_grads, param_group_idx
         )
 
     def __getattr__(self, item):

--- a/python/paddle/distributed/auto_parallel/api.py
+++ b/python/paddle/distributed/auto_parallel/api.py
@@ -1453,7 +1453,7 @@ class _ShardOptimizer(Optimizer):
                 new_placements = copy.deepcopy(grad.placements)
                 new_grad = grad
                 tensor_shape = grad._local_shape
-                shard_dims_set = {}
+                shard_dims_set = set()
 
                 # 1. `shard_dims_set` records dims marked as shard in placement.
                 for placement in grad.placements:
@@ -1490,7 +1490,7 @@ class _ShardOptimizer(Optimizer):
                         grad, grad.process_mesh, new_placements
                     )
 
-                new_params_grads.append((grad, new_grad))
+                new_params_grads.append((param, new_grad))
 
         return new_params_grads
 

--- a/python/paddle/distributed/auto_parallel/api.py
+++ b/python/paddle/distributed/auto_parallel/api.py
@@ -1454,9 +1454,7 @@ class _ShardOptimizer(Optimizer):
 
                 # Try shard other dim
                 for idx, placement in enumerate(g.placements):
-                    if idx == self._sharding_axis:
-                        continue
-                    if placement.is_shard():
+                    if idx == self._sharding_axis or placement.is_shard():
                         continue
                     dim = get_shard_dim(len(g._local_shape), shard_dims)
                     if dim != -1:
@@ -1474,17 +1472,9 @@ class _ShardOptimizer(Optimizer):
 
         if paddle.in_dynamic_mode():
             if fuse_allreduce_in_opt:
-                with paddle.static.program_guard(
-                    paddle.static.default_main_program(),
-                    paddle.static.default_startup_program(),
-                ):
-                    params_grads = fuse_allreduce_on_grad(params_grads)
+                params_grads = fuse_allreduce_on_grad(params_grads)
             elif fuse_reducescatter_in_opt:
-                with paddle.static.program_guard(
-                    paddle.static.default_main_program(),
-                    paddle.static.default_startup_program(),
-                ):
-                    params_grads = fuse_reducescatter_on_grad(params_grads)
+                params_grads = fuse_reducescatter_on_grad(params_grads)
 
         return super()._apply_optimize(
             loss, startup_program, params_grads, param_group_idx=0

--- a/test/auto_parallel/semi_auto_parallel_sharding_stage_1.py
+++ b/test/auto_parallel/semi_auto_parallel_sharding_stage_1.py
@@ -48,6 +48,24 @@ class TestSemiAutoParallelShardingStage1:
         self.bias = linear.bias.numpy()
 
     def test_pure_sharding_stage_1(self):
+        paddle.distributed.auto_parallel.set_mesh(self._mesh)
+        paddle.seed(self._seed)
+        linear = paddle.nn.Linear(10, 10)
+        batch = paddle.rand(shape=[10, 10])
+        # shard the input by sharding degree
+        batch = dist.shard_tensor(batch, self._mesh, [dist.Shard(0)])
+        # shard optimizer with stage 1 fn
+        opt = paddle.optimizer.AdamW(parameters=linear.parameters())
+        opt = dist.shard_optimizer(opt, dist.ShardingStage1("dp", self._mesh))
+        for _ in range(5):
+            loss = linear(batch)
+            loss.backward()
+            opt.step()
+            opt.clear_grad()
+        self.check_tensor_eq(self.weight, linear.weight.numpy())
+        self.check_tensor_eq(self.bias, linear.bias.numpy())
+
+    def test_sharding_fuse_allreduce_in_opt(self):
         os.environ['FLAGS_fuse_reducescatter_in_opt'] = 'true'
         paddle.distributed.auto_parallel.set_mesh(self._mesh)
         paddle.seed(self._seed)
@@ -67,7 +85,7 @@ class TestSemiAutoParallelShardingStage1:
         self.check_tensor_eq(self.bias, linear.bias.numpy())
         os.environ['FLAGS_fuse_reducescatter_in_opt'] = 'false'
 
-    def test_sharding_fuse_allreduce_in_opt(self):
+    def test_sharding_fuse_reducescatter_in_opt(self):
         os.environ['FLAGS_fuse_reducescatter_in_opt'] = 'true'
         paddle.distributed.auto_parallel.set_mesh(self._mesh)
         paddle.seed(self._seed)

--- a/test/auto_parallel/semi_auto_parallel_sharding_stage_1.py
+++ b/test/auto_parallel/semi_auto_parallel_sharding_stage_1.py
@@ -48,6 +48,7 @@ class TestSemiAutoParallelShardingStage1:
         self.bias = linear.bias.numpy()
 
     def test_pure_sharding_stage_1(self):
+        os.environ['FLAGS_fuse_reducescatter_in_opt'] = 'true'
         paddle.distributed.auto_parallel.set_mesh(self._mesh)
         paddle.seed(self._seed)
         linear = paddle.nn.Linear(10, 10)
@@ -64,6 +65,27 @@ class TestSemiAutoParallelShardingStage1:
             opt.clear_grad()
         self.check_tensor_eq(self.weight, linear.weight.numpy())
         self.check_tensor_eq(self.bias, linear.bias.numpy())
+        os.environ['FLAGS_fuse_reducescatter_in_opt'] = 'false'
+
+    def test_sharding_fuse_allreduce_in_opt(self):
+        os.environ['FLAGS_fuse_reducescatter_in_opt'] = 'true'
+        paddle.distributed.auto_parallel.set_mesh(self._mesh)
+        paddle.seed(self._seed)
+        linear = paddle.nn.Linear(10, 10)
+        batch = paddle.rand(shape=[10, 10])
+        # shard the input by sharding degree
+        batch = dist.shard_tensor(batch, self._mesh, [dist.Shard(0)])
+        # shard optimizer with stage 1 fn
+        opt = paddle.optimizer.AdamW(parameters=linear.parameters())
+        opt = dist.shard_optimizer(opt, dist.ShardingStage1("dp", self._mesh))
+        for _ in range(5):
+            loss = linear(batch)
+            loss.backward()
+            opt.step()
+            opt.clear_grad()
+        self.check_tensor_eq(self.weight, linear.weight.numpy())
+        self.check_tensor_eq(self.bias, linear.bias.numpy())
+        os.environ['FLAGS_fuse_reducescatter_in_opt'] = 'false'
 
     def test_pure_sharding_multi_mesh_stage_1(self):
         paddle.distributed.auto_parallel.set_mesh(self._multi_dim_mesh)
@@ -143,6 +165,8 @@ class TestSemiAutoParallelShardingStage1:
 
         self.get_single_card_rst()
         self.test_pure_sharding_stage_1()
+        self.test_sharding_fuse_allreduce_in_opt()
+        self.test_sharding_fuse_reducescatter_in_opt()
         self.test_sharding_stage_1_to_static()
         self.test_pure_sharding_multi_mesh_stage_1()
         self.test_sharding_stage_1_overlap_to_static()

--- a/test/auto_parallel/semi_auto_parallel_sharding_stage_1.py
+++ b/test/auto_parallel/semi_auto_parallel_sharding_stage_1.py
@@ -66,7 +66,7 @@ class TestSemiAutoParallelShardingStage1:
         self.check_tensor_eq(self.bias, linear.bias.numpy())
 
     def test_sharding_fuse_allreduce_in_opt(self):
-        os.environ['FLAGS_fuse_reducescatter_in_opt'] = 'true'
+        os.environ['FLAGS_fuse_allreduce_in_opt'] = 'true'
         paddle.distributed.auto_parallel.set_mesh(self._mesh)
         paddle.seed(self._seed)
         linear = paddle.nn.Linear(10, 10)
@@ -83,7 +83,7 @@ class TestSemiAutoParallelShardingStage1:
             opt.clear_grad()
         self.check_tensor_eq(self.weight, linear.weight.numpy())
         self.check_tensor_eq(self.bias, linear.bias.numpy())
-        os.environ['FLAGS_fuse_reducescatter_in_opt'] = 'false'
+        os.environ['FLAGS_fuse_allreduce_in_opt'] = 'false'
 
     def test_sharding_fuse_reducescatter_in_opt(self):
         os.environ['FLAGS_fuse_reducescatter_in_opt'] = 'true'


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Performance Optimization


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Performance


### Description
<!-- Describe what you’ve done -->
**背景**
在动半 `sharding optmize` 时，反向计算的 grad 是 `partial` 状态的，在做 grad clip 会分别有：

1. `grad(partial) -> allreduce(replicate) -> l2_norm `
2. `grad(partial) -> allreduce(replicate) -> multiply`


**解决方法：**
在 grad clip 开始时需要融合冗余的 allreduce 通信：

1. 方法1 fuse:  修改 grad 是 `replicate` 的，先进行 `allreduce` 后再进入 `grad clip`，通过开关 `FLAGS_fuse_allreduce_in_opt` 控制
2. 方法2 fuse:  修改 grad 是 `shard` 的，通过 `reduce_scatter` 尽可能在 `sharding mesh`纬度切分，一般是 shard(0)，其他 `mesh` 纬度尽可能对 tensor 进行 `shard`，不能切分的保持`replicate`，通过开关 `FLAGS_fuse_reducescatter_in_opt` 控制


**验证：**
在 llama7B sd8 测试吞吐(tokens/s/card)情况：
base：6153.6
开启`FLAGS_fuse_allreduce_in_opt`：6909.8(+12.2%)
开启`FLAGS_fuse_reducescatter_in_opt`：7372.6(+19.7%)

PCard-90131