### PR TITLE
[fluid_ops] random_control_unittest_deprecated.py modify c_sync_calc_stream

### DIFF
--- a/test/deprecated/auto_parallel/random_control_unittest_deprecated.py
+++ b/test/deprecated/auto_parallel/random_control_unittest_deprecated.py
@@ -25,13 +25,13 @@ from get_gpt_model import FakeDataset, generate_model
 import paddle
 
 paddle.enable_static()
-from paddle import _legacy_C_ops
+from paddle import _C_ops
 from paddle.distributed.fleet import auto
 
 
 def dy_broadcast_helper(tensor):
     tensor = paddle._C_ops.broadcast(tensor, 0, 1)
-    _legacy_C_ops.c_sync_calc_stream(tensor, tensor)
+    _C_ops.sync_calc_stream(tensor)
     return tensor
 
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
test/deprecated/auto_parallel/random_control_unittest_deprecated.py 修改 c_sync_calc_stream 为 sync_calc_stream