### PR TITLE
[CINN] Fix dimexpr order check in SortOperands

### DIFF
--- a/paddle/pir/src/dialect/shape/utils/dim_expr_util.cc
+++ b/paddle/pir/src/dialect/shape/utils/dim_expr_util.cc
@@ -340,7 +340,7 @@ struct SortOperands {
         true,
         common::errors::InvalidArgument("input op is empty, please check!"));
     for (std::size_t i = 0; i < operands->size() - 1; ++i) {
-      if (IsLhsBeforeRhs(operands->at(i + 1), operands->at(i))) {
+      if (!IsLhsBeforeRhs(operands->at(i), operands->at(i + 1))) {
         return false;
       }
     }
@@ -1255,6 +1255,9 @@ void DoPass(bool* rewritten, DimExpr* expr) {
 }
 
 DimExpr Simplify(const DimExpr& expr) {
+  if (expr.isa<std::int64_t>() || expr.isa<std::string>()) {
+    return expr;
+  }
   DimExpr ret = expr;
   for (bool keep_rewrite = true; keep_rewrite;) {
     keep_rewrite = false;

--- a/paddle/pir/src/dialect/shape/utils/dim_expr_util.cc
+++ b/paddle/pir/src/dialect/shape/utils/dim_expr_util.cc
@@ -246,7 +246,7 @@ struct IsListLhsBeforeListRhsStruct {
       if (lhs_operands->at(i) == rhs_operands->at(i)) continue;
       return IsLhsBeforeRhs(lhs_operands->at(i), rhs_operands->at(i));
     }
-    return true;
+    return false;
   }
 };
 
@@ -340,7 +340,7 @@ struct SortOperands {
         true,
         common::errors::InvalidArgument("input op is empty, please check!"));
     for (std::size_t i = 0; i < operands->size() - 1; ++i) {
-      if (!IsLhsBeforeRhs(operands->at(i), operands->at(i + 1))) {
+      if (IsLhsBeforeRhs(operands->at(i + 1), operands->at(i))) {
         return false;
       }
     }

--- a/test/cpp/pir/shape_dialect/simplify_dim_expr_test.cc
+++ b/test/cpp/pir/shape_dialect/simplify_dim_expr_test.cc
@@ -290,4 +290,19 @@ TEST(Simplify, Case2) {
   ASSERT_TRUE((SimplifyDimExpr(dim_expr)) == expected);
 }
 
+TEST(Simplify, Case3) {
+  DimExpr S3{"S3"};
+  DimExpr S4{"S4"};
+  DimExpr S5{"S5"};
+  DimExpr S7{"S7"};
+  DimExpr S8{"S8"};
+  DimExpr dim_expr = Mul<DimExpr>{List<DimExpr>{
+      Div<DimExpr>{Mul<DimExpr>{List<DimExpr>{S3, S4, S5}},
+                   Mul<DimExpr>{List<DimExpr>{S7, S8}}},
+      Div<DimExpr>{Mul<DimExpr>{List<DimExpr>{S3, S4, S5}},
+                   Div<DimExpr>{Mul<DimExpr>{List<DimExpr>{S3, S4, S5}},
+                                Mul<DimExpr>{List<DimExpr>{S7, S8}}}}}};
+  ASSERT_TRUE((SimplifyDimExpr(dim_expr) == dim_expr));  // Need to simplify
+}
+
 }  // namespace symbol::test


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-76996

- Fix dimexpr order check in SortOperands