### PR TITLE
[fluid_ops] auto_parallel_fused_linear_promotion.py backward modify c_allreduce_sum

### DIFF
--- a/python/paddle/distributed/passes/auto_parallel_fused_linear_promotion.py
+++ b/python/paddle/distributed/passes/auto_parallel_fused_linear_promotion.py
@@ -53,14 +53,14 @@ _supported_optimizer_type = [
 FUSED_LINEAR_SOURCE_PATTERNS_LIST = [
     # amp_level == 'o2' or 'o3'
     {  # only MP
-        "forward": ["matmul_v2", "all_reduce", "elementwise_add"],
+        "forward": ["matmul_v2", "c_allreduce_sum", "elementwise_add"],
         "backward": ["elementwise_add_grad", "matmul_v2_grad"],
     },
     {  # MP + SP
         "forward": ["matmul_v2", "reduce_scatter", "elementwise_add"],
         "backward": [
             "elementwise_add_grad",
-            "c_allreduce_sum",
+            "all_reduce",
             "scale",
             "all_gather",
             "matmul_v2_grad",
@@ -68,10 +68,10 @@ FUSED_LINEAR_SOURCE_PATTERNS_LIST = [
         ],
     },
     {  # DP + MP
-        "forward": ["matmul_v2", "all_reduce", "elementwise_add"],
+        "forward": ["matmul_v2", "c_allreduce_sum", "elementwise_add"],
         "backward": [
             "elementwise_add_grad",
-            "c_allreduce_sum",
+            "all_reduce",
             "scale",
             "matmul_v2_grad",
         ],
@@ -80,9 +80,9 @@ FUSED_LINEAR_SOURCE_PATTERNS_LIST = [
         "forward": ["matmul_v2", "reduce_scatter", "elementwise_add"],
         "backward": [
             "elementwise_add_grad",
-            "c_allreduce_sum",
+            "all_reduce",
             "scale",
-            "c_allreduce_sum",
+            "all_reduce",
             "scale",
             "all_gather",
             "matmul_v2_grad",
@@ -91,14 +91,14 @@ FUSED_LINEAR_SOURCE_PATTERNS_LIST = [
     },
     # amp_level == 'o1'
     {
-        "forward": ["matmul_v2", "all_reduce", "cast", "elementwise_add"],
+        "forward": ["matmul_v2", "c_allreduce_sum", "cast", "elementwise_add"],
         "backward": ["elementwise_add_grad", "matmul_v2_grad"],
     },
     {
         "forward": ["matmul_v2", "reduce_scatter", "cast", "elementwise_add"],
         "backward": [
             "elementwise_add_grad",
-            "c_allreduce_sum",
+            "all_reduce",
             "scale",
             "all_gather",
             "all_gather",
@@ -106,10 +106,10 @@ FUSED_LINEAR_SOURCE_PATTERNS_LIST = [
         ],
     },
     {
-        "forward": ["matmul_v2", "all_reduce", "cast", "elementwise_add"],
+        "forward": ["matmul_v2", "c_allreduce_sum", "cast", "elementwise_add"],
         "backward": [
             "elementwise_add_grad",
-            "c_allreduce_sum",
+            "all_reduce",
             "scale",
             "matmul_v2_grad",
         ],
@@ -118,9 +118,9 @@ FUSED_LINEAR_SOURCE_PATTERNS_LIST = [
         "forward": ["matmul_v2", "reduce_scatter", "cast", "elementwise_add"],
         "backward": [
             "elementwise_add_grad",
-            "c_allreduce_sum",
+            "all_reduce",
             "scale",
-            "c_allreduce_sum",
+            "all_reduce",
             "scale",
             "all_gather",
             "matmul_v2_grad",


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
python/paddle/distributed/passes/auto_parallel_fused_linear_promotion.py 反向修改 c_allreduce_sum 为 all_reduce