### PR TITLE
[XPU] avoid using xpu-smi to query device info

### DIFF
--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -2940,6 +2940,10 @@ All parameter, weight, gradient are variables in Paddle.
 #ifdef PADDLE_WITH_XPU
   m.def("get_xpu_device_count", platform::GetXPUDeviceCount);
   m.def("xpu_empty_cache", platform::EmptyCache);
+  m.def("get_xpu_device_utilization_rate",
+        platform::GetXPUDeviceUtilizationRate);
+  m.def("get_xpu_device_total_memory", platform::GetXPUDeviceTotalMemory);
+  m.def("get_xpu_device_used_memory", platform::GetXPUDeviceUsedMemory);
 #endif
 
   py::enum_<platform::TracerOption>(m, "TracerOption", py::arithmetic())

--- a/paddle/phi/backends/xpu/enforce_xpu.h
+++ b/paddle/phi/backends/xpu/enforce_xpu.h
@@ -17,6 +17,7 @@ limitations under the License. */
 #ifdef PADDLE_WITH_XPU
 #include <cuda.h>
 #include <cuda_runtime.h>
+#include <xpu/xpuml.h>
 #endif
 
 #include "paddle/phi/backends/xpu/xpu_header.h"
@@ -126,6 +127,16 @@ DEFINE_EXTERNAL_API_TYPE(cudaError_t, cudaSuccess);
           common::errors::External("XPU Runtime Error: ", xre_msg); \
       __THROW_ERROR_INTERNAL__(__summary__);                        \
     }                                                               \
+  } while (0)
+
+// TODO(lijin23): support fine-grained error msg.
+#define PADDLE_ENFORCE_XPUML_SUCCESS(COND)                              \
+  do {                                                                  \
+    auto __cond__ = (COND);                                             \
+    PADDLE_ENFORCE_EQ(                                                  \
+        __cond__,                                                       \
+        XPUML_SUCCESS,                                                  \
+        common::errors::Fatal("XPUML Error, error_code=%d", __cond__)); \
   } while (0)
 
 }  // namespace xpu

--- a/paddle/phi/backends/xpu/xpu_info.cc
+++ b/paddle/phi/backends/xpu/xpu_info.cc
@@ -230,11 +230,10 @@ int GetXPUDeviceUtilizationRate(int dev_id) {
     dev_id = GetXPUCurrentDeviceId();
   }
   xpumlDevice_t dev_handle;
-  int ret = xpumlDeviceGetHandleByIndex(dev_id, &dev_handle);
-  printf("dev %d Get Index return %d\n", dev_id, ret);
+  PADDLE_ENFORCE_XPU_SUCCESS(xpumlDeviceGetHandleByIndex(dev_id, &dev_handle));
   xpumlUtilization_t dev_util;
-  ret = xpumlDeviceGetUtilizationRates(dev_handle, &dev_util);
-  printf("Get Utilization return %d\n", ret);
+  PADDLE_ENFORCE_XPU_SUCCESS(
+      xpumlDeviceGetUtilizationRates(dev_handle, &dev_util));
   return dev_util.xpu;
 }
 
@@ -245,9 +244,10 @@ int GetXPUDeviceTotalMemory(int dev_id) {
   }
 
   xpumlDevice_t dev_handle;
-  xpumlDeviceGetHandleByIndex(dev_id, &dev_handle);
+  PADDLE_ENFORCE_XPU_SUCCESS(xpumlDeviceGetHandleByIndex(dev_id, &dev_handle));
   xpumlMemory_t dev_mem_info;
-  xpumlDeviceGetMemoryInfo(dev_handle, &dev_mem_info);
+  PADDLE_ENFORCE_XPU_SUCCESS(
+      xpumlDeviceGetMemoryInfo(dev_handle, &dev_mem_info));
   return dev_mem_info.totalGlobalMemory / 1e6;  // MiB
 }
 
@@ -258,9 +258,10 @@ int GetXPUDeviceUsedMemory(int dev_id) {
   }
 
   xpumlDevice_t dev_handle;
-  xpumlDeviceGetHandleByIndex(dev_id, &dev_handle);
+  PADDLE_ENFORCE_XPU_SUCCESS(xpumlDeviceGetHandleByIndex(dev_id, &dev_handle));
   xpumlMemory_t dev_mem_info;
-  xpumlDeviceGetMemoryInfo(dev_handle, &dev_mem_info);
+  PADDLE_ENFORCE_XPU_SUCCESS(
+      xpumlDeviceGetMemoryInfo(dev_handle, &dev_mem_info));
   return dev_mem_info.usedGlobalMemory / 1e6;  // MiB
 }
 

--- a/paddle/phi/backends/xpu/xpu_info.cc
+++ b/paddle/phi/backends/xpu/xpu_info.cc
@@ -13,6 +13,7 @@ limitations under the License. */
 #ifdef PADDLE_WITH_XPU
 #include <cuda.h>
 #include <cuda_runtime.h>
+#include <xpu/xpuml.h>
 #endif
 
 #include <algorithm>
@@ -49,6 +50,8 @@ class XPUContext;
 
 namespace backends {
 namespace xpu {
+
+static std::once_flag xpuml_init_flag;
 
 /**************************** Version Management **************************/
 
@@ -220,6 +223,46 @@ void MemcpySyncD2D(void* dst,
 }
 
 /**************************** Others **************************/
+
+int GetXPUDeviceUtilizationRate(int dev_id) {
+  std::call_once(xpuml_init_flag, xpumlInit);
+  if (dev_id == -1) {
+    dev_id = GetXPUCurrentDeviceId();
+  }
+  xpumlDevice_t dev_handle;
+  int ret = xpumlDeviceGetHandleByIndex(dev_id, &dev_handle);
+  printf("dev %d Get Index return %d\n", dev_id, ret);
+  xpumlUtilization_t dev_util;
+  ret = xpumlDeviceGetUtilizationRates(dev_handle, &dev_util);
+  printf("Get Utilization return %d\n", ret);
+  return dev_util.xpu;
+}
+
+int GetXPUDeviceTotalMemory(int dev_id) {
+  std::call_once(xpuml_init_flag, xpumlInit);
+  if (dev_id == -1) {
+    dev_id = GetXPUCurrentDeviceId();
+  }
+
+  xpumlDevice_t dev_handle;
+  xpumlDeviceGetHandleByIndex(dev_id, &dev_handle);
+  xpumlMemory_t dev_mem_info;
+  xpumlDeviceGetMemoryInfo(dev_handle, &dev_mem_info);
+  return dev_mem_info.totalGlobalMemory / 1e6;  // MiB
+}
+
+int GetXPUDeviceUsedMemory(int dev_id) {
+  std::call_once(xpuml_init_flag, xpumlInit);
+  if (dev_id == -1) {
+    dev_id = GetXPUCurrentDeviceId();
+  }
+
+  xpumlDevice_t dev_handle;
+  xpumlDeviceGetHandleByIndex(dev_id, &dev_handle);
+  xpumlMemory_t dev_mem_info;
+  xpumlDeviceGetMemoryInfo(dev_handle, &dev_mem_info);
+  return dev_mem_info.usedGlobalMemory / 1e6;  // MiB
+}
 
 XPUVersion get_xpu_version(int dev_id) {
   if (dev_id == -1) {

--- a/paddle/phi/backends/xpu/xpu_info.cc
+++ b/paddle/phi/backends/xpu/xpu_info.cc
@@ -13,7 +13,6 @@ limitations under the License. */
 #ifdef PADDLE_WITH_XPU
 #include <cuda.h>
 #include <cuda_runtime.h>
-#include <xpu/xpuml.h>
 #endif
 
 #include <algorithm>
@@ -230,9 +229,10 @@ int GetXPUDeviceUtilizationRate(int dev_id) {
     dev_id = GetXPUCurrentDeviceId();
   }
   xpumlDevice_t dev_handle;
-  PADDLE_ENFORCE_XPU_SUCCESS(xpumlDeviceGetHandleByIndex(dev_id, &dev_handle));
+  PADDLE_ENFORCE_XPUML_SUCCESS(
+      xpumlDeviceGetHandleByIndex(dev_id, &dev_handle));
   xpumlUtilization_t dev_util;
-  PADDLE_ENFORCE_XPU_SUCCESS(
+  PADDLE_ENFORCE_XPUML_SUCCESS(
       xpumlDeviceGetUtilizationRates(dev_handle, &dev_util));
   return dev_util.xpu;
 }
@@ -244,9 +244,10 @@ int GetXPUDeviceTotalMemory(int dev_id) {
   }
 
   xpumlDevice_t dev_handle;
-  PADDLE_ENFORCE_XPU_SUCCESS(xpumlDeviceGetHandleByIndex(dev_id, &dev_handle));
+  PADDLE_ENFORCE_XPUML_SUCCESS(
+      xpumlDeviceGetHandleByIndex(dev_id, &dev_handle));
   xpumlMemory_t dev_mem_info;
-  PADDLE_ENFORCE_XPU_SUCCESS(
+  PADDLE_ENFORCE_XPUML_SUCCESS(
       xpumlDeviceGetMemoryInfo(dev_handle, &dev_mem_info));
   return dev_mem_info.totalGlobalMemory / 1024 / 1024;  // MB
 }
@@ -258,9 +259,10 @@ int GetXPUDeviceUsedMemory(int dev_id) {
   }
 
   xpumlDevice_t dev_handle;
-  PADDLE_ENFORCE_XPU_SUCCESS(xpumlDeviceGetHandleByIndex(dev_id, &dev_handle));
+  PADDLE_ENFORCE_XPUML_SUCCESS(
+      xpumlDeviceGetHandleByIndex(dev_id, &dev_handle));
   xpumlMemory_t dev_mem_info;
-  PADDLE_ENFORCE_XPU_SUCCESS(
+  PADDLE_ENFORCE_XPUML_SUCCESS(
       xpumlDeviceGetMemoryInfo(dev_handle, &dev_mem_info));
   return dev_mem_info.usedGlobalMemory / 1024 / 1024;  // MB
 }

--- a/paddle/phi/backends/xpu/xpu_info.cc
+++ b/paddle/phi/backends/xpu/xpu_info.cc
@@ -248,7 +248,7 @@ int GetXPUDeviceTotalMemory(int dev_id) {
   xpumlMemory_t dev_mem_info;
   PADDLE_ENFORCE_XPU_SUCCESS(
       xpumlDeviceGetMemoryInfo(dev_handle, &dev_mem_info));
-  return dev_mem_info.totalGlobalMemory / 1e6;  // MiB
+  return dev_mem_info.totalGlobalMemory / 1024 / 1024;  // MB
 }
 
 int GetXPUDeviceUsedMemory(int dev_id) {
@@ -262,7 +262,7 @@ int GetXPUDeviceUsedMemory(int dev_id) {
   xpumlMemory_t dev_mem_info;
   PADDLE_ENFORCE_XPU_SUCCESS(
       xpumlDeviceGetMemoryInfo(dev_handle, &dev_mem_info));
-  return dev_mem_info.usedGlobalMemory / 1e6;  // MiB
+  return dev_mem_info.usedGlobalMemory / 1024 / 1024;  // MB
 }
 
 XPUVersion get_xpu_version(int dev_id) {

--- a/paddle/phi/backends/xpu/xpu_info.h
+++ b/paddle/phi/backends/xpu/xpu_info.h
@@ -114,6 +114,9 @@ XPUVersion get_xpu_version(int dev_id);
 void set_xpu_debug_level(int level);
 
 int get_xpu_max_ptr_size(int dev_id);
+int GetXPUDeviceUtilizationRate(int dev_id);
+int GetXPUDeviceTotalMemory(int dev_id);
+int GetXPUDeviceUsedMemory(int dev_id);
 
 }  // namespace xpu
 }  // namespace backends

--- a/paddle/phi/core/platform/device/xpu/xpu_info.cc
+++ b/paddle/phi/core/platform/device/xpu/xpu_info.cc
@@ -119,6 +119,18 @@ void EmptyCache() {
   }
 }
 
+int GetXPUDeviceUtilizationRate(int dev_id) {
+  return phi::backends::xpu::GetXPUDeviceUtilizationRate(dev_id);
+}
+
+int GetXPUDeviceTotalMemory(int dev_id) {
+  return phi::backends::xpu::GetXPUDeviceTotalMemory(dev_id);
+}
+
+int GetXPUDeviceUsedMemory(int dev_id) {
+  return phi::backends::xpu::GetXPUDeviceUsedMemory(dev_id);
+}
+
 class RecordedXPUMallocHelper {
  private:
   explicit RecordedXPUMallocHelper(int dev_id, uint64_t limit_size = 0)

--- a/paddle/phi/core/platform/device/xpu/xpu_info.h
+++ b/paddle/phi/core/platform/device/xpu/xpu_info.h
@@ -94,6 +94,10 @@ bool IsXPUMallocRecorded(int dev_id);
 
 void EmptyCache(void);
 
+int GetXPUDeviceUtilizationRate(int dev_id);
+int GetXPUDeviceTotalMemory(int dev_id);
+int GetXPUDeviceUsedMemory(int dev_id);
+
 }  // namespace platform
 }  // namespace paddle
 #endif

--- a/test/xpu/test_query_xpu_device_info.py
+++ b/test/xpu/test_query_xpu_device_info.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import paddle
+from paddle.device import core
+
+
+class TestQueryXPUDeviceInfo(unittest.TestCase):
+    def test_dygraph(self):
+        if core.is_compiled_with_xpu():
+            paddle.disable_static()
+            dev_num = core.get_xpu_device_count()
+            self.assertGreater(
+                dev_num,
+                0,
+                "The environment you run this test does not have any xpu device.",
+            )
+            for dev_id in range(dev_num):
+                self.assertGreaterEqual(
+                    core.get_xpu_device_utilization_rate(dev_id), 0
+                )
+                self.assertGreater(core.get_xpu_device_total_memory(dev_id), 0)
+                self.assertGreaterEqual(
+                    core.get_xpu_device_used_memory(dev_id), 0
+                )
+            paddle.enable_static()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Custom Device

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->
Because the significant performance dropping on hygron CPU, we use xpuml calls to replace xpu-smi.