### PR TITLE
fix sumraw

### DIFF
--- a/paddle/phi/kernels/cpu/reduce_sum_kernel.cc
+++ b/paddle/phi/kernels/cpu/reduce_sum_kernel.cc
@@ -86,8 +86,7 @@ void SumRawKernel(const Context& dev_ctx,
     }
     out->Resize(phi::make_ddim(out_dims));
     dev_ctx.template Alloc<T>(out);
-    FullKernel<T, Context>(
-        dev_ctx, out_dims, 0, phi::CppTypeToDataType<T>::Type(), out);
+    FullKernel<T, Context>(dev_ctx, out_dims, 0, out_dtype, out);
     return;
   }
   phi::Reduce<CPUContext, T, phi::funcs::SumFunctor>(

--- a/paddle/phi/kernels/kps/reduce_kernel.cu
+++ b/paddle/phi/kernels/kps/reduce_kernel.cu
@@ -255,16 +255,8 @@ void SumRawKernel(const Context& dev_ctx,
       }
     }
     out->Resize(phi::make_ddim(out_dims));
-    if (x.dtype() == phi::DataType::BOOL || x.dtype() == phi::DataType::INT32) {
-      dev_ctx.template Alloc<int64_t>(out);
-      FullKernel<int64_t, Context>(
-          dev_ctx, out_dims, 0, phi::CppTypeToDataType<int64_t>::Type(), out);
-    } else {
-      dev_ctx.template Alloc<T>(out);
-      FullKernel<T, Context>(
-          dev_ctx, out_dims, 0, phi::CppTypeToDataType<T>::Type(), out);
-    }
-
+    dev_ctx.template Alloc<T>(out);
+    FullKernel<T, Context>(dev_ctx, out_dims, 0, out_dtype, out);
     return;
   }
   if (x.numel() > std::numeric_limits<int32_t>::max()) {

--- a/test/legacy_test/test_sum_op.py
+++ b/test/legacy_test/test_sum_op.py
@@ -561,8 +561,7 @@ class TestSumOpDtype(unittest.TestCase):
                     name='x', shape=self.shape, dtype=self.input_dtype
                 )
                 result = paddle.sum(x, axis=self.axis, dtype=self.output_dtype)
-
-        self.assertEqual(result[0].dtype, self.paddle_output_dtype)
+                self.assertEqual(result[0].dtype, self.paddle_output_dtype)
 
 
 class TestSumOpError(unittest.TestCase):

--- a/test/legacy_test/test_sum_op.py
+++ b/test/legacy_test/test_sum_op.py
@@ -22,6 +22,7 @@ import numpy as np
 from decorator_helper import prog_scope
 from op import Operator
 from op_test import OpTest, convert_float_to_uint16, convert_uint16_to_float
+from utils import dygraph_guard, static_guard
 
 import paddle
 import paddle.inference as paddle_infer
@@ -532,6 +533,36 @@ class TestRaiseSumsError(unittest.TestCase):
                 paddle.add_n(data1)
 
             self.assertRaises(TypeError, test_dtype1)
+
+
+class TestSumOpDtype(unittest.TestCase):
+    def setUp(self):
+        self.shape = [0, 1, 1]
+        self.axis = 0
+        self.input_dtype = 'int32'
+        self.output_dtype = 'int32'
+        self.paddle_output_dtype = paddle.int32
+
+    def test_dygraph(self):
+        with dygraph_guard():
+            x_paddle = paddle.zeros(shape=self.shape, dtype=self.input_dtype)
+            paddle_result = x_paddle.sum(
+                axis=self.axis, dtype=self.output_dtype
+            )
+
+        self.assertEqual(paddle_result.dtype, self.paddle_output_dtype)
+
+    def test_static(self):
+        with static_guard():
+            with paddle.static.program_guard(
+                paddle.static.Program(), paddle.static.Program()
+            ):
+                x = paddle.static.data(
+                    name='x', shape=self.shape, dtype=self.input_dtype
+                )
+                result = paddle.sum(x, axis=self.axis, dtype=self.output_dtype)
+
+        self.assertEqual(result[0].dtype, self.paddle_output_dtype)
 
 
 class TestSumOpError(unittest.TestCase):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修正sum输入为0-size时dtype不正确问题。
复现代码
```
import paddle
x1 = paddle.zeros(shape=[0，1, 1], dtype='int32')
x1.sum(axis=0,dtype=x1.dtype)
print(x1.dtype)
```

```
<DataType.INT64: 9>
```