### PR TITLE
[fluid_ops] test_variable_deprecated.py remove lod_level

### DIFF
--- a/test/deprecated/legacy_test/test_variable_deprecated.py
+++ b/test/deprecated/legacy_test/test_variable_deprecated.py
@@ -55,8 +55,6 @@ class TestVariable(unittest.TestCase):
         nw = w[:, :, :-1]
         self.assertEqual((784, 100, 99), nw.shape)
 
-        self.assertEqual(0, nw.lod_level)
-
         main = base.Program()
         with base.program_guard(main):
             exe = base.Executor(place)

--- a/test/deprecated/legacy_test/utils.py
+++ b/test/deprecated/legacy_test/utils.py
@@ -85,9 +85,6 @@ def _is_equal_program(prog1, prog2):
             if var1.dtype != var2.dtype:
                 return False
 
-            if var1.lod_level != var2.lod_level:
-                return False
-
             if var1.persistable != var2.persistable:
                 return False
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
test/deprecated/legacy_test/test_variable_deprecated.py 中删除lod_level判断