### PR TITLE
Fix SLANet infer error on MLU

### DIFF
--- a/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
+++ b/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
@@ -3049,6 +3049,7 @@ std::vector<pir::Value> BuildInputs(
         }
       }
     }
+    (*map_value_pair)[op_item->operand_source(i)] = new_in;
 
     vec_inputs.push_back(new_in);
   }
@@ -3459,7 +3460,7 @@ void ProcessBlock(
 
   for (auto iter = block->begin(); iter != block->end(); ++iter) {
     pir::Operation* op_item = &(*iter);
-    VLOG(6) << "op name " << op_item->name();
+    VLOG(6) << "op name " << op_item->name() << ", op id " << op_item->id();
     if ((op_item->isa<FeedOp>()) &&
         inputs_by_data_op.count(op_item->attributes()
                                     .at("name")
@@ -3619,7 +3620,6 @@ std::unique_ptr<pir::Program> PdOpLowerToKernelPass(pir::Program* prog,
 #endif
   std::unordered_map<pir::Operation*, pir::Operation*> map_op_pair;
   std::unordered_map<pir::Value, pir::Value> map_value_pair;
-
   ProcessBlock(
       place, block, program->block(), ctx, &map_op_pair, &map_value_pair);
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

### 问题描述
pcard-67164

有如下 IR before lowering to kernel：
```
%1 = pd.op1(%0)
%2 = pd.op2(%1)
```
在IR lowering过程中，当某个算子（如op1）在目标硬件上没有适配的kernel实现时，会退化为CPU实现，并自动插入数据拷贝kernel（host-to-device和device-to-host）。然而，后续引用该算子输出的其他算子（如op2）未能正确更新为拷贝后的输出：
```
%1 = d2h(%0)
%2 = pd.op1(%1)
%3 = h2d(%2)
%4 = pd.op2(%3)  // expected
%4 = pd.op2(%2)  // actual
```

原因是`map_value_pair`未及时更新，导致后续引用使用了错误的值。
