### PR TITLE
【CINN】Add broadcastable constraint in CINN backend

### DIFF
--- a/paddle/cinn/common/shape_constraint.cc
+++ b/paddle/cinn/common/shape_constraint.cc
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include "paddle/cinn/common/shape_constraint.h"
-#include "paddle/cinn/common/dim_expr_converter.h"
 #include "paddle/cinn/ir/ir_printer.h"
 #include "paddle/cinn/ir/utils/ir_compare.h"
 
@@ -23,6 +22,12 @@ ShapeConstraintManager& ShapeConstraintManager::Instance() {
   return instance;
 }
 void ShapeConstraintManager::Init(
+    const symbol::ConstraintsManager& constraint) {
+  InitEqualExprs(constraint.equals());
+  InitBroadCastableExprs(constraint.broadcastables());
+}
+
+void ShapeConstraintManager::InitEqualExprs(
     const ::common::UnionFindSet<symbol::DimExpr>& equal_dim_exprs) {
   equal_dim_exprs_ = equal_dim_exprs;
   // need to convert DimExpr to IndexExpr
@@ -42,7 +47,8 @@ void ShapeConstraintManager::Init(
       });
   equal_exprs_ = std::move(transfer_set);
 }
-void ShapeConstraintManager::Init(
+
+void ShapeConstraintManager::InitEqualExprs(
     const ::common::UnionFindSet<ir::IndexExpr, IndexExprDirectCompare>&
         equal_exprs) {
   equal_exprs_ = equal_exprs;
@@ -50,6 +56,68 @@ void ShapeConstraintManager::Init(
 bool ShapeConstraintManager::IsEqual(const ir::IndexExpr& lhs,
                                      const ir::IndexExpr& rhs) {
   return equal_exprs_.HasSameRoot(lhs, rhs);
+}
+
+bool ShapeConstraintManager::IsBroadCastable(const ir::IndexExpr& lhs,
+                                             const ir::IndexExpr& rhs) {
+  return broadcastable_exprs_.HasEdge(lhs, rhs);
+}
+
+bool ShapeConstraintManager::IsBroadCastable(
+    const std::vector<ir::IndexExpr>& vec) {
+  for (size_t i = 0; i < vec.size(); ++i) {
+    for (size_t j = i + 1; j < vec.size(); ++j) {
+      if (!IsBroadCastable(vec[i], vec[j])) return false;
+    }
+  }
+  return true;
+}
+
+void ShapeConstraintManager::InitBroadCastableExprs(
+    const std::unordered_set<symbol::Broadcastable<symbol::DimExpr>>&
+        broadcastable_dim_exprs) {
+  auto AddEdgesForOperands =
+      [this](const std::vector<symbol::DimExpr>& operands) {
+        for (size_t i = 0; i < operands.size(); ++i) {
+          for (size_t j = i + 1; j < operands.size(); ++j) {
+            broadcastable_exprs_.AddEdge(operands[i], operands[j]);
+          }
+        }
+      };
+  auto AddEdgesBetweenOperands =
+      [this](const std::vector<symbol::DimExpr>& lhs_operands,
+             const std::vector<symbol::DimExpr>& rhs_operands) {
+        for (auto& lhs_op : lhs_operands) {
+          for (auto& rhs_op : rhs_operands) {
+            broadcastable_exprs_.AddEdge(lhs_op, rhs_op);
+          }
+        }
+      };
+  for (auto& broadcastable_dim_expr : broadcastable_dim_exprs) {
+    auto [lhs, rhs] = *broadcastable_dim_expr;
+    if (lhs.isa<symbol::Broadcast<symbol::DimExpr>>() &&
+        rhs.isa<symbol::Broadcast<symbol::DimExpr>>()) {
+      auto lhs_operands =
+          lhs.dyn_cast<symbol::Broadcast<symbol::DimExpr>>().operands.vector();
+      auto rhs_operands =
+          rhs.dyn_cast<symbol::Broadcast<symbol::DimExpr>>().operands.vector();
+      AddEdgesForOperands(lhs_operands);
+      AddEdgesForOperands(rhs_operands);
+      AddEdgesBetweenOperands(lhs_operands, rhs_operands);
+    } else if (lhs.isa<symbol::Broadcast<symbol::DimExpr>>()) {
+      auto lhs_operands =
+          lhs.dyn_cast<symbol::Broadcast<symbol::DimExpr>>().operands.vector();
+      AddEdgesForOperands(lhs_operands);
+      AddEdgesBetweenOperands(lhs_operands, {rhs});
+    } else if (rhs.isa<symbol::Broadcast<symbol::DimExpr>>()) {
+      auto rhs_operands =
+          rhs.dyn_cast<symbol::Broadcast<symbol::DimExpr>>().operands.vector();
+      AddEdgesForOperands(rhs_operands);
+      AddEdgesBetweenOperands({lhs}, rhs_operands);
+    } else {
+      broadcastable_exprs_.AddEdge(lhs, rhs);
+    }
+  }
 }
 
 std::ostream& operator<<(std::ostream& stream,
@@ -72,6 +140,17 @@ std::ostream& operator<<(std::ostream& stream,
     stream << "  }" << std::endl;
   });
   stream << "--------------------------------------------------" << std::endl;
+  stream << "--------Broadcastable Constraints Exprs-----------" << std::endl;
+  for (auto& broadcastable_dim_expr :
+       constraints_manager.broadcastable_exprs_.GetBroadcastableExprs()) {
+    stream << broadcastable_dim_expr.first << " -> ";
+    for (auto& expr : broadcastable_dim_expr.second) {
+      stream << expr << ", ";
+    }
+    stream << std::endl;
+  }
+  stream << "--------------------------------------------------" << std::endl;
+
   return stream;
 }
 

--- a/paddle/cinn/common/shape_constraint.cc
+++ b/paddle/cinn/common/shape_constraint.cc
@@ -24,7 +24,7 @@ ShapeConstraintManager& ShapeConstraintManager::Instance() {
 void ShapeConstraintManager::Init(
     const symbol::ConstraintsManager& constraint) {
   InitEqualExprs(constraint.equals());
-  InitBroadCastableExprs(constraint.broadcastables());
+  InitBroadcastableExprs(constraint.broadcastables());
 }
 
 void ShapeConstraintManager::InitEqualExprs(
@@ -58,22 +58,22 @@ bool ShapeConstraintManager::IsEqual(const ir::IndexExpr& lhs,
   return equal_exprs_.HasSameRoot(lhs, rhs);
 }
 
-bool ShapeConstraintManager::IsBroadCastable(const ir::IndexExpr& lhs,
+bool ShapeConstraintManager::IsBroadcastable(const ir::IndexExpr& lhs,
                                              const ir::IndexExpr& rhs) {
   return broadcastable_exprs_.HasEdge(lhs, rhs);
 }
 
-bool ShapeConstraintManager::IsBroadCastable(
+bool ShapeConstraintManager::IsBroadcastable(
     const std::vector<ir::IndexExpr>& vec) {
   for (size_t i = 0; i < vec.size(); ++i) {
     for (size_t j = i + 1; j < vec.size(); ++j) {
-      if (!IsBroadCastable(vec[i], vec[j])) return false;
+      if (!IsBroadcastable(vec[i], vec[j])) return false;
     }
   }
   return true;
 }
 
-void ShapeConstraintManager::InitBroadCastableExprs(
+void ShapeConstraintManager::InitBroadcastableExprs(
     const std::unordered_set<symbol::Broadcastable<symbol::DimExpr>>&
         broadcastable_dim_exprs) {
   auto AddEdgesForOperands =

--- a/paddle/cinn/common/shape_constraint.h
+++ b/paddle/cinn/common/shape_constraint.h
@@ -71,13 +71,13 @@ class ShapeConstraintManager {
   //    {S0: {S1, S2},
   //     S1: {S0, S2},
   //     S2: {S0, S1}}
-  void InitBroadCastableExprs(
+  void InitBroadcastableExprs(
       const std::unordered_set<symbol::Broadcastable<symbol::DimExpr>>&
           broadcastable_dim_exprs);
   // Returns whether lhs and rhs are equal in the DimExpr UnionFindSet.
   bool IsEqual(const ir::IndexExpr& lhs, const ir::IndexExpr& rhs);
-  bool IsBroadCastable(const ir::IndexExpr& lhs, const ir::IndexExpr& rhs);
-  bool IsBroadCastable(const std::vector<ir::IndexExpr>& vec);
+  bool IsBroadcastable(const ir::IndexExpr& lhs, const ir::IndexExpr& rhs);
+  bool IsBroadcastable(const std::vector<ir::IndexExpr>& vec);
 
   friend std::ostream& operator<<(
       std::ostream& os, const ShapeConstraintManager& constraints_manager);
@@ -91,11 +91,11 @@ class ShapeConstraintManager {
   // indicates that the two nodes are broadcastable.
   class BroadcastMap {
    public:
-    void AddEdge(ir::IndexExpr lhs, ir::IndexExpr rhs) {
+    void AddEdge(const ir::IndexExpr& lhs, const ir::IndexExpr& rhs) {
       broadcastable_exprs_[lhs].insert(rhs);
       broadcastable_exprs_[rhs].insert(lhs);
     }
-    void AddEdge(symbol::DimExpr lhs, symbol::DimExpr rhs) {
+    void AddEdge(const symbol::DimExpr& lhs, const symbol::DimExpr& rhs) {
       DimExprConverter cvt;
       auto lhs_ = cvt.ConvertToIrExpr(lhs);
       auto rhs_ = cvt.ConvertToIrExpr(rhs);
@@ -106,7 +106,7 @@ class ShapeConstraintManager {
       return broadcastable_exprs_.count(lhs) &&
              broadcastable_exprs_.at(lhs).count(rhs);
     }
-    std::unordered_map<ir::IndexExpr, std::unordered_set<ir::IndexExpr>>
+    const std::unordered_map<ir::IndexExpr, std::unordered_set<ir::IndexExpr>>&
     GetBroadcastableExprs() const {
       return broadcastable_exprs_;
     }

--- a/paddle/cinn/common/shape_constraint.h
+++ b/paddle/cinn/common/shape_constraint.h
@@ -14,11 +14,13 @@
 #pragma once
 #include <unordered_set>
 #include <vector>
+#include "paddle/cinn/common/dim_expr_converter.h"
 #include "paddle/cinn/ir/ir.h"
 #include "paddle/cinn/ir/ir_base.h"
 #include "paddle/cinn/ir/utils/ir_compare.h"
 #include "paddle/common/union_find_set.h"
 #include "paddle/pir/include/dialect/shape/utils/dim_expr.h"
+#include "paddle/pir/include/dialect/shape/utils/shape_analysis.h"
 namespace cinn {
 namespace common {
 
@@ -40,13 +42,42 @@ class ShapeConstraintManager {
  public:
   // Returns a singleton object.
   static ShapeConstraintManager& Instance();
+  // Initialize the ShapeConstraintManager with CINN frontend
+  // ConstraintsManager.
+  void Init(const symbol::ConstraintsManager& constraint);
   // Initialize the ShapeConstraintManager with the DimExpr UnionFindSet.
-  void Init(const ::common::UnionFindSet<symbol::DimExpr>& equal_dim_exprs);
+  void InitEqualExprs(
+      const ::common::UnionFindSet<symbol::DimExpr>& equal_dim_exprs);
   // Initialize the ShapeConstraintManager with the IndexExpr UnionFindSet.
-  void Init(const ::common::UnionFindSet<ir::IndexExpr, IndexExprDirectCompare>&
-                equal_exprs);
+  void InitEqualExprs(
+      const ::common::UnionFindSet<ir::IndexExpr, IndexExprDirectCompare>&
+          equal_exprs);
+
+  // Broadcast DimExpr: All parameters need to build edges between each other.
+  // Other DimExpr: Only build edges between them.
+  // e.g.
+  //  1. Broadcastable[ Broadcast(S0, S1), Broadcast(S2, S3) ]
+  //   ===>
+  //    {S0: {S1, S2, S3},
+  //     S1: {S0, S2, S3},
+  //     S2: {S0, S1, S3},
+  //     S3: {S0, S1, S2}}
+  //  2. Broadcastable[ S0, S1 ]
+  //   ===>
+  //    {S0: {S1},
+  //     S1: {S0}}
+  //  3. Broadcastable[ S0, Broadcast(S1, S2) ]
+  //   ===>
+  //    {S0: {S1, S2},
+  //     S1: {S0, S2},
+  //     S2: {S0, S1}}
+  void InitBroadCastableExprs(
+      const std::unordered_set<symbol::Broadcastable<symbol::DimExpr>>&
+          broadcastable_dim_exprs);
   // Returns whether lhs and rhs are equal in the DimExpr UnionFindSet.
   bool IsEqual(const ir::IndexExpr& lhs, const ir::IndexExpr& rhs);
+  bool IsBroadCastable(const ir::IndexExpr& lhs, const ir::IndexExpr& rhs);
+  bool IsBroadCastable(const std::vector<ir::IndexExpr>& vec);
 
   friend std::ostream& operator<<(
       std::ostream& os, const ShapeConstraintManager& constraints_manager);
@@ -54,6 +85,37 @@ class ShapeConstraintManager {
  private:
   ::common::UnionFindSet<symbol::DimExpr> equal_dim_exprs_;
   ::common::UnionFindSet<ir::IndexExpr, IndexExprDirectCompare> equal_exprs_;
+
+  // Since broadcast relationships are not conductive, `Bidirectional Adjacency
+  // Map` are used to store broadcast relationships. The edge between nodes
+  // indicates that the two nodes are broadcastable.
+  class BroadcastMap {
+   public:
+    void AddEdge(ir::IndexExpr lhs, ir::IndexExpr rhs) {
+      broadcastable_exprs_[lhs].insert(rhs);
+      broadcastable_exprs_[rhs].insert(lhs);
+    }
+    void AddEdge(symbol::DimExpr lhs, symbol::DimExpr rhs) {
+      DimExprConverter cvt;
+      auto lhs_ = cvt.ConvertToIrExpr(lhs);
+      auto rhs_ = cvt.ConvertToIrExpr(rhs);
+      broadcastable_exprs_[lhs_].insert(rhs_);
+      broadcastable_exprs_[rhs_].insert(lhs_);
+    }
+    bool HasEdge(const ir::IndexExpr& lhs, const ir::IndexExpr& rhs) {
+      return broadcastable_exprs_.count(lhs) &&
+             broadcastable_exprs_.at(lhs).count(rhs);
+    }
+    std::unordered_map<ir::IndexExpr, std::unordered_set<ir::IndexExpr>>
+    GetBroadcastableExprs() const {
+      return broadcastable_exprs_;
+    }
+
+   private:
+    std::unordered_map<ir::IndexExpr, std::unordered_set<ir::IndexExpr>>
+        broadcastable_exprs_;
+  };
+  BroadcastMap broadcastable_exprs_;
   ShapeConstraintManager() = default;
   ~ShapeConstraintManager() = default;
   ShapeConstraintManager(const ShapeConstraintManager&) = delete;

--- a/paddle/cinn/hlir/framework/pir/op_lowering_impl.cc
+++ b/paddle/cinn/hlir/framework/pir/op_lowering_impl.cc
@@ -95,8 +95,6 @@ OpLowererImpl::OpLowererImpl(const Target& target) : target_(target) {
 BucketLoweredFuncsWrapper OpLowererImpl::BucketLower(
     const OpLoweringGroupPtr& group) {
   VLOG(4) << "BucketLower Group : \n" << *group;
-  std::cout << "cinn constraint manager: "
-            << cinn::common::ShapeConstraintManager::Instance() << std::endl;
   // 1.Do compute, lower and schedule for each op.
   const auto& ops = group->ops();
   auto X86Expr = LowerX86(group, ops, false);

--- a/paddle/cinn/hlir/framework/pir/op_lowering_impl.cc
+++ b/paddle/cinn/hlir/framework/pir/op_lowering_impl.cc
@@ -20,6 +20,7 @@
 #include "paddle/cinn/ast_gen_ius/tensor_group.h"
 #include "paddle/cinn/backends/codegen_device_util.h"
 #include "paddle/cinn/common/dim_expr_converter.h"
+#include "paddle/cinn/common/shape_constraint.h"
 #include "paddle/cinn/common/target.h"
 #include "paddle/cinn/hlir/dialect/operator/ir/manual_op.h"
 #include "paddle/cinn/hlir/dialect/operator/transforms/group_merge/op_with_group_merge_util.h"
@@ -38,6 +39,7 @@
 #include "paddle/cinn/operator_fusion/fusion_interface.h"
 #include "paddle/cinn/optim/check_tensor_buffer_map.h"
 #include "paddle/cinn/optim/eliminate_common_global_memory_read.h"
+#include "paddle/cinn/optim/ir_simplify.h"
 #include "paddle/cinn/optim/schedule_block_dce.h"
 #include "paddle/cinn/optim/transform_gpu_forloop.h"
 #include "paddle/cinn/pass/pass_manager.h"
@@ -93,6 +95,8 @@ OpLowererImpl::OpLowererImpl(const Target& target) : target_(target) {
 BucketLoweredFuncsWrapper OpLowererImpl::BucketLower(
     const OpLoweringGroupPtr& group) {
   VLOG(4) << "BucketLower Group : \n" << *group;
+  std::cout << "cinn constraint manager: "
+            << cinn::common::ShapeConstraintManager::Instance() << std::endl;
   // 1.Do compute, lower and schedule for each op.
   const auto& ops = group->ops();
   auto X86Expr = LowerX86(group, ops, false);
@@ -122,6 +126,10 @@ BucketLoweredFuncsWrapper OpLowererImpl::BucketLower(
                                 func_bodies,
                                 group->fusion_tracker_ptr,
                                 group->substitute_dimexpr_map());
+
+  std::for_each(func_bodies.begin(), func_bodies.end(), [](auto& expr) {
+    optim::SimplifyNoPureMath(&expr, ir::IndexExpr::OptLevel::kLevel4);
+  });
 
   std::unordered_set<std::string> fusion_group_args;
   for (auto value : group->GetInputOpValues()) {

--- a/paddle/cinn/hlir/framework/pir_compiler.cc
+++ b/paddle/cinn/hlir/framework/pir_compiler.cc
@@ -89,7 +89,7 @@ std::vector<pir::CINNKernelInfo> PirCompiler::Build(
           ::pir::ShapeAnalysisManager::Instance().Get(
               group_compilation_contexts[index].GetGroup()->GetParentProgram());
       cinn::common::ShapeConstraintManager::Instance().Init(
-          shape_analysis_manager.constraints_manager().equals());
+          shape_analysis_manager.constraints_manager());
       runtime::SetArchDevice(target_, device_id);
       compilation_results[index] = Compile(&group_compilation_contexts[index]);
     };
@@ -126,7 +126,7 @@ std::shared_ptr<pir::CompilationResult> PirCompiler::Compile(
             ::pir::ShapeAnalysisManager::Instance().Get(
                 switch_group_ctxs[index].GetGroup()->GetParentProgram());
         cinn::common::ShapeConstraintManager::Instance().Init(
-            shape_analysis_manager.constraints_manager().equals());
+            shape_analysis_manager.constraints_manager());
         CompilationTask lowering_task(&switch_group_ctxs[index]);
         lowering_task.Lowering();
       };

--- a/paddle/cinn/ir/ir_base.h
+++ b/paddle/cinn/ir/ir_base.h
@@ -557,6 +557,10 @@ struct IndexExpr : public IrNodeRef {
    * Level3: Simplify with boundary.
    *   e.g. x % S0 ==> x if x < S0
    *        x / S0 ==> 0 if x < S0
+   * Level4: Simplify with broadcast constraint.
+   *   e.g. x % cinn_max(cinn_max(cinn_max(S0, S10), S20), S30))
+   *          % cinn_max(S10, S30) ==> x % cinn_max(S10, S30),
+   *        if broadcastable(S0, S10, S20, S30).
    *
    * Note: Because IndexExpr is generated in order, Short operand is at the
    * end of the expression, so Level1 is usually used.
@@ -565,7 +569,8 @@ struct IndexExpr : public IrNodeRef {
     kLevel0 = 0,  // TODO(liujinnan): Only constant folding is performed
     kLevel1 = 1,
     kLevel2 = 2,
-    kLevel3 = 3  // Top level, simplify
+    kLevel3 = 3,
+    kLevel4 = 4
   };
 
   enum class IndexType {

--- a/paddle/cinn/optim/ir_simplify.h
+++ b/paddle/cinn/optim/ir_simplify.h
@@ -185,6 +185,12 @@ void SimplifyUnitBlock(Expr *expr);
 
 void SimplifyLogical(Expr *expr);
 
-Expr ArithSimplify(const Expr &u);
+void SimplifyNoPureMath(Expr *expr,
+                        const ir::IndexExpr::OptLevel &opt_level =
+                            ir::IndexExpr::OptLevel::kLevel1);
+
+Expr ArithSimplify(const Expr &u,
+                   const ir::IndexExpr::OptLevel &opt_level =
+                       ir::IndexExpr::OptLevel::kLevel1);
 }  // namespace optim
 }  // namespace cinn

--- a/paddle/cinn/optim/simplify_util.cc
+++ b/paddle/cinn/optim/simplify_util.cc
@@ -18,6 +18,7 @@
 #include <unordered_set>
 
 #include "paddle/cinn/common/const_fold.h"
+#include "paddle/cinn/common/shape_constraint.h"
 #include "paddle/cinn/common/simplify_special_pattern.h"
 #include "paddle/cinn/ir/ir_mutator.h"
 #include "paddle/cinn/ir/ir_printer.h"
@@ -685,6 +686,34 @@ ir::IndexExpr BoundSimplify(const ir::IndexExpr &expr) {
     }
   }
   return expr;
+}
+
+ir::IndexExpr BroadcastSimplify(const ir::IndexExpr &expr) {
+  // Two consecutive modular operations.
+  auto opt_map =
+      MatchPattern(expr,
+                   "f % a % b",
+                   [](const std::unordered_map<std::string, ir::IndexExpr> &m) {
+                     return m.at("a").node_type() == ir::IrNodeTy::Max;
+                   });
+  if (!opt_map) return expr;
+
+  auto &map = opt_map.value();
+  auto ll = map.at("f");
+  auto lr = map.at("a");
+  auto r = map.at("b");
+  auto lr_elems = GetFlattenExprs<ir::Max>(lr);
+  auto r_elems = GetFlattenExprs<ir::Max>(r);
+
+  // The second modulus is a subset of the first modulus.
+  for (auto &&r_elem : r_elems) {
+    if (std::find(lr_elems.begin(), lr_elems.end(), r_elem) == lr_elems.end())
+      return expr;
+  }
+
+  // The first modulus is broadcastable.
+  auto &constraint = cinn::common::ShapeConstraintManager::Instance();
+  return constraint.IsBroadCastable(lr_elems) ? ll % r : expr;
 }
 }  // namespace optim
 }  // namespace cinn

--- a/paddle/cinn/optim/simplify_util.cc
+++ b/paddle/cinn/optim/simplify_util.cc
@@ -713,7 +713,7 @@ ir::IndexExpr BroadcastSimplify(const ir::IndexExpr &expr) {
 
   // The first modulus is broadcastable.
   auto &constraint = cinn::common::ShapeConstraintManager::Instance();
-  return constraint.IsBroadCastable(lr_elems) ? ll % r : expr;
+  return constraint.IsBroadcastable(lr_elems) ? ll % r : expr;
 }
 }  // namespace optim
 }  // namespace cinn

--- a/paddle/cinn/optim/simplify_util.h
+++ b/paddle/cinn/optim/simplify_util.h
@@ -324,5 +324,21 @@ std::optional<std::unordered_map<std::string, ir::IndexExpr>> MatchPattern(
  * \return `IndexExpr` after simplification.
  */
 ir::IndexExpr BoundSimplify(const ir::IndexExpr &expr);
+
+/*!
+ * \brief Simplify IndexExpr with broadcastable information.
+ * For example:
+ *        x % cinn_max(cinn_max(cinn_max(S0, S10), S20), S30))
+ *          % cinn_max(S10, S30) ==> x % cinn_max(S10, S30),
+ *        if broadcastable(S0, S10, S20, S30).
+ * Note: The following conditions must be met:
+ * 1. Two consecutive modular operations.
+ * 2. The first modulus is broadcastable.
+ * 3. The second modulus is a subset of the first modulus.
+ *
+ * \param expr The `IndexExpr` to be simplified.
+ * \return `IndexExpr` after simplification.
+ */
+ir::IndexExpr BroadcastSimplify(const ir::IndexExpr &expr);
 }  // namespace optim
 }  // namespace cinn


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
1. CINN后端接入broadcast constraint，由于broadcastable不可传导性，因此使用双向邻接表存储图结构
2. 添加OptLevel4化简等级，其含义为使用 broadcast constraint 化简连续取模运算
Pcard-67164