### PR TITLE
[fluid_ops] _get_reduce_op remove func_name parameter

### DIFF
--- a/python/paddle/distributed/communication/reduce.py
+++ b/python/paddle/distributed/communication/reduce.py
@@ -68,7 +68,7 @@ class ReduceOp:
     AVG: ClassVar[Literal[4]] = 4
 
 
-def _get_reduce_op(reduce_op, func_name=""):
+def _get_reduce_op(reduce_op):
     if framework.in_dynamic_mode():
         if reduce_op == ReduceOp.SUM:
             return framework.core.ReduceOp.SUM
@@ -81,7 +81,7 @@ def _get_reduce_op(reduce_op, func_name=""):
         elif reduce_op == ReduceOp.AVG:
             return framework.core.ReduceOp.AVG
 
-    raise ValueError(f"Unknown reduce_op type for {func_name}.")
+    raise ValueError(f"Unknown reduce_op type for {reduce_op}.")
 
 
 def _to_inplace_op(op_name):

--- a/python/paddle/distributed/communication/reduce.py
+++ b/python/paddle/distributed/communication/reduce.py
@@ -68,7 +68,7 @@ class ReduceOp:
     AVG: ClassVar[Literal[4]] = 4
 
 
-def _get_reduce_op(reduce_op, func_name):
+def _get_reduce_op(reduce_op, func_name=""):
     if framework.in_dynamic_mode():
         if reduce_op == ReduceOp.SUM:
             return framework.core.ReduceOp.SUM
@@ -80,17 +80,6 @@ def _get_reduce_op(reduce_op, func_name):
             return framework.core.ReduceOp.PRODUCT
         elif reduce_op == ReduceOp.AVG:
             return framework.core.ReduceOp.AVG
-    else:
-        if reduce_op == ReduceOp.SUM:
-            return f'c_{func_name}_sum'
-        elif reduce_op == ReduceOp.MAX:
-            return f'c_{func_name}_max'
-        elif reduce_op == ReduceOp.MIN:
-            return f'c_{func_name}_min'
-        elif reduce_op == ReduceOp.PROD:
-            return f'c_{func_name}_prod'
-        else:
-            return f'c_{func_name}'
 
     raise ValueError(f"Unknown reduce_op type for {func_name}.")
 

--- a/python/paddle/distributed/communication/stream/all_reduce.py
+++ b/python/paddle/distributed/communication/stream/all_reduce.py
@@ -79,7 +79,7 @@ def _all_reduce_in_static_mode(
         'all_reduce',
     )
 
-    op_type = _get_reduce_op(op, "allreduce")
+    op_type = _get_reduce_op(op)
     ring_id = 0 if group is None else group.id
 
     if not isinstance(ring_id, int):

--- a/python/paddle/distributed/communication/stream/all_reduce.py
+++ b/python/paddle/distributed/communication/stream/all_reduce.py
@@ -43,7 +43,7 @@ def _all_reduce_in_dygraph(
     sync_op: bool,
     use_calc_stream: bool,
 ) -> task:
-    op_type = _get_reduce_op(op, "allreduce")
+    op_type = _get_reduce_op(op)
 
     if use_calc_stream:
         return group.process_group.all_reduce_on_calc_stream(tensor, op_type)

--- a/python/paddle/distributed/communication/stream/reduce.py
+++ b/python/paddle/distributed/communication/stream/reduce.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
 def _reduce_in_dygraph(
     tensor, dst_rank_in_group, op, group, sync_op, use_calc_stream
 ):
-    op_type = _get_reduce_op(op, "reduce")
+    op_type = _get_reduce_op(op)
     if use_calc_stream:
         return group.process_group.reduce_on_calc_stream(
             tensor, dst_rank_in_group, op_type

--- a/python/paddle/distributed/communication/stream/reduce_scatter.py
+++ b/python/paddle/distributed/communication/stream/reduce_scatter.py
@@ -44,7 +44,7 @@ def _reduce_scatter_tensor_in_dygraph(
     use_calc_stream,
     caller="reduce_scatter",
 ):
-    op_type = _get_reduce_op(op, caller)
+    op_type = _get_reduce_op(op)
 
     if use_calc_stream:
         return group.process_group.reduce_scatter_tensor_on_calc_stream(

--- a/python/paddle/distributed/communication/stream/reduce_scatter.py
+++ b/python/paddle/distributed/communication/stream/reduce_scatter.py
@@ -63,7 +63,7 @@ def _reduce_scatter_tensor_in_dygraph(
 def _reduce_scatter_in_dygraph(
     tensor, tensor_list, op, group, sync_op, use_calc_stream
 ):
-    op_type = _get_reduce_op(op, "reduce_scatter")
+    op_type = _get_reduce_op(op)
 
     if use_calc_stream:
         return group.process_group.reduce_scatter_on_calc_stream(

--- a/python/paddle/distributed/fleet/layers/mpu/mp_layers.py
+++ b/python/paddle/distributed/fleet/layers/mpu/mp_layers.py
@@ -227,7 +227,7 @@ class InnerOverlapLinear(paddle.autograd.PyLayer):
             dx = paddle.matmul(
                 dy, paddle.cast(weight, dtype=dy.dtype), transpose_y=True
             )
-        op_type = _get_reduce_op(ReduceOp.SUM, "_c_identity")
+        op_type = _get_reduce_op(ReduceOp.SUM)
         task = ctx.model_parallel_group.process_group.all_reduce(
             dx, op_type, sync_op=False
         )

--- a/python/paddle/distributed/fleet/layers/mpu/mp_ops.py
+++ b/python/paddle/distributed/fleet/layers/mpu/mp_ops.py
@@ -49,7 +49,7 @@ class c_identity_eager(PyLayer):
 
     @staticmethod
     def backward(ctx, dy):
-        op_type = _get_reduce_op(ReduceOp.SUM, "_c_identity")
+        op_type = _get_reduce_op(ReduceOp.SUM)
         ctx.group.process_group.all_reduce_on_calc_stream(dy, op_type)
         return dy
 
@@ -238,7 +238,7 @@ class mp_allreduce_eager(PyLayer):
         ctx.skip_c_identity_dynamic = skip_c_identity_dynamic
 
         if use_calc_stream:
-            op_type = _get_reduce_op(op, "_mp_allreduce")
+            op_type = _get_reduce_op(op)
             group.process_group.all_reduce_on_calc_stream(tensor, op_type)
             return tensor
         else:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
_get_reduce_op 参数 func_name 是转换为c_allreduce_xxx格式，c_allreduce_xxx 算子已修改为all_reduce，func_name 可以不用设置
