### PR TITLE
[CINN] Composite reduce pass horizontal fusion

### DIFF
--- a/test/ir/pir/cinn/test_cinn_argidx_reduce.py
+++ b/test/ir/pir/cinn/test_cinn_argidx_reduce.py
@@ -43,12 +43,14 @@ class TestArgIdxReduce(unittest.TestCase):
         x = paddle.randn([128, 256])
         self.eval(func, [x])
 
-    def test_argmax_discrete(self):
-        # discrete reduce
-        def func(x):
-            return x[x.argmax(axis=0, keepdim=True), paddle.arange(x.shape[-1])]
+    def test_argmax_discrete_hfuse(self):
+        # discrete reduce + horizontal fuse
+        bn = paddle.nn.BatchNorm(256)
 
-        x = paddle.randn([66, 256])
+        def func(x):
+            return bn(x), x.argmax(axis=0)
+
+        x = paddle.randn([128, 256])
         self.eval(func, [x])
 
     def test_argmin_all_bc(self):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
CINN


### PR Types
Bug fixes


### Description

Supports horizontal fusion for different types of composite reduce. For example:

```python
def test_argmax_discrete_hfuse(self):
    # discrete reduce + horizontal fuse
    bn = paddle.nn.BatchNorm(256)

    def func(x):
        return bn(x), x.argmax(axis=0)

    x = paddle.randn([128, 256])
    self.eval(func, [x])
```
Originally, the composite reduce pass in PR #72029 only supports vertical fusion for different ops. Basically, for one lowered-func, the `RealizeCompositeReducePass` assumes that there is only one unique `CompositeTypes`, which will lead to incorrect tensor buffer type deduction when the lowered-func contains different composite reduce types, and ultimately, replacing cross thread reduction will fail in these cases.

In this PR, we stopped using a shared `CompositeTypes` for all the store buffers. For each store buffer (related to composite reduce), we will try computing the correct composite type. For argidx, we might not be able to deduct the types for some of the buffers, so a second pass will be applied to resolve these types with *buffer-to-composite-type* map computed in the first pass.

Also, the unit test for composite reduce is renamed to `test_cinn_composite_reduce.py` and the horizontal fusion case is added.

Pcard-89620
