### PR TITLE
[CINN] Fix name duplication for TileTransposeTactic

### DIFF
--- a/paddle/cinn/ir/schedule/ir_schedule_util.cc
+++ b/paddle/cinn/ir/schedule/ir_schedule_util.cc
@@ -625,15 +625,6 @@ Expr GetNthAccessExpr(const Expr& block, int index, bool is_write) {
   }
 }
 
-Tensor MakeCacheTensor(const Tensor& tensor, const std::string& memory_type) {
-  auto cache_tensor = lang::Compute(
-      tensor->shape,
-      [=](const std::vector<Expr>& dims) { return tensor(dims); },
-      tensor->name + "_" + memory_type + "_temp_buffer");
-  cache_tensor->WithBuffer(memory_type);
-  return cache_tensor;
-}
-
 Expr MakeCacheBlock(const std::vector<IterRange>& buffer_ranges,
                     CacheBlockInfo* info,
                     const std::string& memory_type,

--- a/paddle/cinn/ir/schedule/ir_schedule_util.h
+++ b/paddle/cinn/ir/schedule/ir_schedule_util.h
@@ -191,14 +191,6 @@ std::vector<IterRange> CalculateTensorRegions(
 Expr GetNthAccessExpr(const Expr& block, int index, bool is_write);
 
 /**
- * Make a tensor's cache tensor.
- * @param tensor The original tensor.
- * @param memory_type The memory type of the cache tensor.
- * @return return The tensor's cache tensor.
- */
-Tensor MakeCacheTensor(const Tensor& tensor, const std::string& memory_type);
-
-/**
  * Make a the cache tensor's block.
  * @param buffer_region The accessed region of cache tensor.
  * @param info The information of cache block.

--- a/test/ir/pir/cinn/test_cinn_transpose.py
+++ b/test/ir/pir/cinn/test_cinn_transpose.py
@@ -111,6 +111,16 @@ class TestTranspose(unittest.TestCase):
 
         self.eval(func, [x, y])
 
+    def test_slice_021(self):
+        def func(x):
+            x1 = x[:, :48].transpose([0, 2, 1])
+            x2 = x.transpose([0, 2, 1])[:, :, 48:]
+            return x1 + x2
+
+        x = paddle.uniform([64, 96, 128])
+
+        self.eval(func, [x])
+
     def test_slice_reshape_021(self):
         def func(x, y):
             x = x[:, 64:192]


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
CINN


### PR Types
Bug fixes


### Description
之前TileTransposeTactic不支持slice的时候没注意这个问题，支持slice后会出现同名但不同下标的问题，因此需要用unique name来区分不同访存实例的cache tensor

Pcard-85711