### PR TITLE
[SOT][DynamicShape] Dont use static dim when dim hit count >= 5

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
@@ -120,8 +120,6 @@ DTYPE_ABBRS = {
     core.DataType.BOOL: "bool",
 }
 
-STATIC_DIM_FREQ_THRESHOLD = 5
-
 
 def method_to_reverse_method(method_name: str) -> str | None:
     if not method_name.startswith("__") or not method_name.endswith("__"):
@@ -1056,8 +1054,6 @@ class SymbolicVariable(VariableBase):
                 return False
             symbolic_input.setdefault(value, 0)
             symbolic_input[value] += 1
-            if symbolic_input[value] >= STATIC_DIM_FREQ_THRESHOLD:
-                return False
             if len(symbolic_input.keys()) > 1:
                 return True
             return False


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Performance

### Description
<!-- Describe what you’ve done -->

移除一旦某个维度 hit 次数超过 5 则使用静态 shape 的策略，目前该策略在无重复编译的情况没有效果，因为不会继续计数，在有重复编译的场景，大概率是动态 shape，而该策略会使得模型变回静态 shape，大幅增加编译时间，因此当前阶段移除掉，后续会考虑其他优化手段

<!-- PCard-66972 -->