### PR TITLE
[CINN] No need to consider cross-thread access in horizontal fusion

### DIFF
--- a/test/ir/pir/cinn/test_horizontal_fusion.py
+++ b/test/ir/pir/cinn/test_horizontal_fusion.py
@@ -166,6 +166,24 @@ class TestHorizontalFusion(unittest.TestCase):
 
         self.check_accuracy_and_kernel_num(init, func, kernel_num=1)
 
+    def test_slice_concat_with_shared_input(self):
+        def func(x):
+            res = []
+            for i in range(20):
+                a = x[i : i + 1] + 1
+                a = paddle.reshape(a, [1])
+                axis = paddle.full(shape=[1], fill_value=i, dtype='int64')
+                a = paddle.concat([a, axis], axis=0)
+                res.append(a)
+            return res
+
+        def init():
+            x = paddle.rand([20])
+            x = paddle.cast(x, dtype='int64')
+            return (x,)
+
+        self.check_accuracy_and_kernel_num(init, func, kernel_num=1)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-76996

No need to consider cross-thread access in horizontal fusion