### PR TITLE
[CINN] Prevent x86 kernel generation for composite reduce ops

### DIFF
--- a/paddle/cinn/hlir/framework/pir/op_lowering_impl.cc
+++ b/paddle/cinn/hlir/framework/pir/op_lowering_impl.cc
@@ -835,6 +835,12 @@ ir::LoweredFunc OpLowererImpl::GenerateInferShapeFunc(
       ir::ConvertExprBlockToStmtBlock(infer_shape_func->body);
   return infer_shape_func;
 }
+// TODO(heqianyue): support argidx and variance op on CPU
+bool IsOpDeniedOnCpu(::pir::Operation* op) {
+  static std::set<std::string> banned_ops = {
+      "cinn_op.argmax", "cinn_op.argmin", "pd_op.variance"};
+  return banned_ops.count(op->name());
+}
 ir::Expr OpLowererImpl::LowerX86(const OpLoweringGroupPtr& group,
                                  const std::vector<::pir::Operation*>& ops,
                                  bool apply_op_schedule) {
@@ -846,6 +852,9 @@ ir::Expr OpLowererImpl::LowerX86(const OpLoweringGroupPtr& group,
   std::vector<::pir::Value> vec_inputs;
   std::vector<::pir::Value> vec_outputs;
   for (auto* op : ops) {
+    if (IsOpDeniedOnCpu(op)) {
+      return ir::Expr(-1);
+    }
     for (size_t i = 0; i < op->num_operands(); ++i) {
       auto in = op->operand_source(i);
       if (!in || !in.type()) {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
CINN


### PR Types
Bug fixes


### Description
For small tensors, x86 kernels might get generated to infer dynamic shapes. For composite reduce (argmax/argmin/welford), the necessary support (llvm) is not currently available. This PR will prevent x86 kernel generation for these ops, so that CINN won't crash during LLVM codegen.

Pcard-89620
