### PR TITLE
[CINN] Only print log when `FLAGS_cinn_debug` is set

### DIFF
--- a/paddle/common/flags.cc
+++ b/paddle/common/flags.cc
@@ -1090,6 +1090,17 @@ PHI_DEFINE_EXPORTED_string(
     "",
     "File path of predefined input dynamic dimension specification.");
 
+/*
+ * CINN related FLAG
+ * Name: FLAGS_cinn_debug
+ * Since Version: 3.0
+ * Value Range: bool, default=false
+ * Example: FLAGS_cinn_debug=true would enable debug log for CINN.
+ */
+PHI_DEFINE_EXPORTED_bool(cinn_debug,
+                         false,
+                         "Whether to enable debug log for CINN.");
+
 #endif
 
 /*

--- a/paddle/fluid/pir/transforms/build_cinn_pass.cc
+++ b/paddle/fluid/pir/transforms/build_cinn_pass.cc
@@ -22,6 +22,8 @@
 #include "paddle/pir/include/pass/pass.h"
 #include "paddle/pir/include/pass/pass_registry.h"
 
+COMMON_DECLARE_bool(cinn_debug);
+
 namespace {
 using GroupOpsVec = std::vector<pir::Operation*>;
 using CompatibleInfo = cinn::hlir::framework::pir::CompatibleInfo;
@@ -63,10 +65,12 @@ class BuildCinnPass : public pir::Pass {
       ::pir::ReplaceWithGroupOp(block, group_ops, false);
     }
     auto end_t = std::chrono::high_resolution_clock::now();
-    auto duration =
-        std::chrono::duration_cast<std::chrono::milliseconds>(end_t - start_t);
-    LOG(INFO) << "Time of building group ops (size=" << num_ops
-              << "): " << FormatDuration(duration);
+    if (FLAGS_cinn_debug) {
+      auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(
+          end_t - start_t);
+      LOG(INFO) << "Time of building group ops (size=" << num_ops
+                << "): " << FormatDuration(duration);
+    }
   }
 };
 

--- a/python/paddle/base/framework.py
+++ b/python/paddle/base/framework.py
@@ -450,6 +450,14 @@ def in_cinn_mode() -> bool:
     return paddle.get_flags(CINN_FLAG_NAME)[CINN_FLAG_NAME]
 
 
+def in_cinn_debug_mode() -> bool:
+    CINN_DEBUG_FLAG_NAME = "FLAGS_cinn_debug"
+    # NOTE: This flag only available when compiled with CINN
+    if not is_compiled_with_cinn():
+        return False
+    return paddle.get_flags(CINN_DEBUG_FLAG_NAME)[CINN_DEBUG_FLAG_NAME]
+
+
 global_ipu_index = -1
 global_ipu_stage = -1
 ipu_index_attr_name = "ipu_index"

--- a/python/paddle/decomposition/recompute.py
+++ b/python/paddle/decomposition/recompute.py
@@ -24,6 +24,7 @@ import paddle
 from paddle import pir
 from paddle.autograd import backward_utils
 from paddle.base import core
+from paddle.base.framework import in_cinn_debug_mode
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -677,11 +678,12 @@ def auto_recompute(
     )
     DebugPrint("program after recompute:", program_after_recompute)
     end_time = time.time()
-    logger = logging.getLogger("auto-recompute")
-    logger.setLevel(logging.INFO)
-    logger.info(
-        f"Time of auto recompute program: ***** [ {end_time - start_time} ] ***** seconds."
-    )
+    if in_cinn_debug_mode():
+        logger = logging.getLogger("auto-recompute")
+        logger.setLevel(logging.INFO)
+        logger.info(
+            f"Time of auto recompute program: ***** [ {end_time - start_time} ] ***** seconds."
+        )
     return program_after_recompute, fwd_op_end_idx_after_recompute
 
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Improvements

### Description
<!-- Describe what you’ve done -->

由于 CINN 已经在动转静开默认，而 CINN 目前的 log 对于用户来说会有干扰效果，因此本 PR 修改为相关 log 仅在 `FLAGS_cinn_debug` 开启时才打印

<!-- PCard-66972 -->