### PR TITLE
【CINN】Add mutator for GetAddr

### DIFF
--- a/paddle/cinn/ir/ir_mutator.h
+++ b/paddle/cinn/ir/ir_mutator.h
@@ -313,6 +313,10 @@ void IRMutator<T>::Visit(const IntrinsicOp *expr, T op) {
         Visit(&expr, &expr);
       }
     } break;
+    case ir::IntrinsicKind::kGetAddr: {
+      auto *n = llvm::dyn_cast<intrinsics::GetAddr>(node);
+      Visit(&n->data, &n->data);
+    } break;
   }
 }
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
由向量化引入取地址运算，IRmutator 不会遍历到GetAddr intrinsic，因此注册
Pcard-67164