### PR TITLE
[CINN] Explicitly set block launch bound for grid reduce

### DIFF
--- a/paddle/cinn/backends/codegen_gpu_dev.cc
+++ b/paddle/cinn/backends/codegen_gpu_dev.cc
@@ -244,6 +244,15 @@ void CodeGenGpuDev::PrintFunctionDeclaration(const ir::_LoweredFunc_ *op) {
     if (!has_symbol_in_thread_num) {
       str_ += "__launch_bounds__(";
       str_ += std::to_string(thread_num);
+      // Explicitly set min_blocks_per_sm for grid reduce to prevent launch
+      // failure.
+      if (!op->temp_spaces.empty()) {
+        int min_blocks_per_sm = 1024 / thread_num;
+        if (min_blocks_per_sm > 1) {
+          str_ += ", ";
+          str_ += std::to_string(min_blocks_per_sm);
+        }
+      }
       str_ += ") ";
     }
   }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
CINN


### PR Types
Bug fixes


### Description
显式设置grid reduce的min_blocks_per_sm大小，避免编译器分配寄存器过多导致无法launch

<b>注：</b>nvrtc和nvcc的表现还不太一样，nvcc不设置也行，但是nvrtc报错了，所以还是设置一下

<b>TODO：</b>避免直接写1024这样的常数，但是这个要改的话需要从一开始的tile config就开始改，修改内容较多，所以之后再系统改

Pcard-85711