### PR TITLE
[SOT] Always use `dummy_guard` when fallback error occurred

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/executor_cache.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/executor_cache.py
@@ -292,21 +292,16 @@ def start_translate(
             raise InnerError(
                 f"{simulator.vframe.code.co_name} should not fallback, but got '{e}'"
             )
-        # if disable_eval_frame is True, it means we want fallback to speedup rather than error occurred
-        if is_strict_mode() and e.disable_eval_frame is False:
+        if is_strict_mode():
             raise
         log(
             2,
             f"Unsupported Frame is {frame.f_code}, error message is: \n"
             + "".join(traceback.format_exception(type(e), e, e.__traceback__)),
         )
-        # simulation not complete, not sure whether this code has sir, set disable_eval_frame = False
-        guard_fn = (
-            dummy_guard if e.disable_eval_frame is False else simulator.guard_fn
-        )
         return (
             CustomCode(None, e.disable_eval_frame),
-            guard_fn,
+            dummy_guard,
         )
     except Exception as e:
         raise InnerError(OpcodeExecutorBase.error_message_summary(e)) from e


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

这里针对 `disable_eval_frame = True` 逻辑不确定原因，可能是过去有别的场景，但目前代码是没有 `disable_eval_frame = True` 的，一旦真的 `disable_eval_frame = True` 会在外部首次 translate guard 不为 `None` 的检查处挂掉，所以这里应该是可以安全删掉的

<!-- PCard-66972 -->