### PR TITLE
[Dy2St] Reopen AST+legacy IR uts

### DIFF
--- a/test/dygraph_to_static/dygraph_to_static_utils.py
+++ b/test/dygraph_to_static/dygraph_to_static_utils.py
@@ -118,7 +118,8 @@ DEFAULT_TO_STATIC_MODE = (
 DEFAULT_IR_MODE = IrMode.PT | IrMode.PIR
 DEFAULT_BACKEND_MODE = BackendMode.PHI | BackendMode.CINN
 VALID_MODES = [
-    # For `.pd_model` export, we still need test AST+PT
+    # For `.pd_model` export, we still need test AST+PT / AST+LEGACY_IR
+    (ToStaticMode.AST, IrMode.LEGACY_IR, BackendMode.PHI),
     (ToStaticMode.AST, IrMode.PT, BackendMode.PHI),
     (ToStaticMode.AST, IrMode.PIR, BackendMode.PHI),
     (ToStaticMode.SOT, IrMode.PIR, BackendMode.PHI),

--- a/test/dygraph_to_static/test_ast_util.py
+++ b/test/dygraph_to_static/test_ast_util.py
@@ -21,7 +21,7 @@ from dygraph_to_static_utils import (
     Dy2StTestBase,
     static_guard,
     test_ast_only,
-    test_legacy_and_pir,
+    test_pir_only,
 )
 from ifelse_simple_func import (
     dyfunc_with_if_else,
@@ -49,7 +49,7 @@ class TestAST2Func(Dy2StTestBase):
         return transformed_func
 
     @test_ast_only
-    @test_legacy_and_pir
+    @test_pir_only
     def test_ast2func(self):
         def func(x, y):
             return x + y
@@ -58,7 +58,7 @@ class TestAST2Func(Dy2StTestBase):
         self.assertEqual(func(x, y), self._ast2func(func)(x, y))
 
     @test_ast_only
-    @test_legacy_and_pir
+    @test_pir_only
     def test_ast2func_dygraph(self):
         funcs = [dyfunc_with_if_else, dyfunc_with_if_else2, nested_if_else]
         x_data = np.random.random([10, 16]).astype('float32')
@@ -69,7 +69,7 @@ class TestAST2Func(Dy2StTestBase):
             self.assertTrue((true_ret == test_ret).all())
 
     @test_ast_only
-    @test_legacy_and_pir
+    @test_pir_only
     def test_ast2func_static(self):
         def func(x):
             y = F.relu(x)
@@ -88,7 +88,7 @@ class TestAST2Func(Dy2StTestBase):
                 self.assertTrue((ret[0] == ret[1]).all())
 
     @test_ast_only
-    @test_legacy_and_pir
+    @test_pir_only
     def test_ast2func_error(self):
         with self.assertRaises(Exception) as e:
             self.assertRaises(TypeError, ast_to_func("x = a + b", 'foo'))

--- a/test/dygraph_to_static/test_dygraph_to_static_utils.py
+++ b/test/dygraph_to_static/test_dygraph_to_static_utils.py
@@ -13,8 +13,12 @@
 # limitations under the License.
 
 import unittest
+from itertools import product
 
 from dygraph_to_static_utils import (
+    DEFAULT_BACKEND_MODE,
+    DEFAULT_IR_MODE,
+    DEFAULT_TO_STATIC_MODE,
     VALID_MODES,
     BackendMode,
     Dy2StTestBase,
@@ -27,6 +31,18 @@ from dygraph_to_static_utils import (
     set_ir_mode,
     set_to_static_mode,
 )
+
+ALL_MODES = list(product(ToStaticMode, IrMode, BackendMode))
+DEFAULT_MODES = [
+    (to_static_mode, ir_mode, backend_mode)
+    for (to_static_mode, ir_mode, backend_mode) in ALL_MODES
+    if (
+        (to_static_mode, ir_mode, backend_mode) in VALID_MODES
+        and to_static_mode & DEFAULT_TO_STATIC_MODE
+        and ir_mode & DEFAULT_IR_MODE
+        and backend_mode & DEFAULT_BACKEND_MODE
+    )
+]
 
 
 class CheckTestCaseExistsMixin:
@@ -89,14 +105,14 @@ class TestCheckTestCases(unittest.TestCase, CheckTestCaseExistsMixin):
         test_case = TestCaseBasic()
         case_name = "test_basic"
         self.assert_not_hasattr(test_case, case_name)
-        for mode_tuple in VALID_MODES:
+        for mode_tuple in DEFAULT_MODES:
             self.check_test_case_exists(test_case, case_name, mode_tuple)
 
     def test_check_test_case_disable_test_case(self):
         test_case = TestCaseDisableTestCase()
         case_name = "test_disable_one"
         self.assert_not_hasattr(test_case, case_name)
-        for mode_tuple in VALID_MODES:
+        for mode_tuple in DEFAULT_MODES:
             if mode_tuple == (ToStaticMode.SOT, IrMode.PIR, BackendMode.CINN):
                 self.check_test_case_not_exists(
                     test_case, case_name, mode_tuple
@@ -106,7 +122,7 @@ class TestCheckTestCases(unittest.TestCase, CheckTestCaseExistsMixin):
 
         case_name = "test_disable_multiple"
         self.assert_not_hasattr(test_case, case_name)
-        for mode_tuple in VALID_MODES:
+        for mode_tuple in DEFAULT_MODES:
             if mode_tuple in [
                 (ToStaticMode.SOT, IrMode.PIR, BackendMode.CINN),
                 (ToStaticMode.SOT, IrMode.PIR, BackendMode.PHI),
@@ -120,7 +136,7 @@ class TestCheckTestCases(unittest.TestCase, CheckTestCaseExistsMixin):
 
         case_name = "test_disable_multiple_with_or"
         self.assert_not_hasattr(test_case, case_name)
-        for mode_tuple in VALID_MODES:
+        for mode_tuple in DEFAULT_MODES:
             if mode_tuple in [
                 (ToStaticMode.SOT, IrMode.PIR, BackendMode.CINN),
                 (ToStaticMode.SOT, IrMode.PIR, BackendMode.PHI),
@@ -135,7 +151,7 @@ class TestCheckTestCases(unittest.TestCase, CheckTestCaseExistsMixin):
         test_case = TestCaseSetMode()
         case_name = "test_set_to_static_mode"
         self.assert_not_hasattr(test_case, case_name)
-        for mode_tuple in VALID_MODES:
+        for mode_tuple in DEFAULT_MODES:
             to_static_mode, _, _ = mode_tuple
             if to_static_mode == ToStaticMode.SOT:
                 self.check_test_case_exists(test_case, case_name, mode_tuple)
@@ -146,7 +162,7 @@ class TestCheckTestCases(unittest.TestCase, CheckTestCaseExistsMixin):
 
         case_name = "test_set_ir_mode"
         self.assert_not_hasattr(test_case, case_name)
-        for mode_tuple in VALID_MODES:
+        for mode_tuple in DEFAULT_MODES:
             _, ir_mode, _ = mode_tuple
             if ir_mode == IrMode.PIR:
                 self.check_test_case_exists(test_case, case_name, mode_tuple)
@@ -157,7 +173,7 @@ class TestCheckTestCases(unittest.TestCase, CheckTestCaseExistsMixin):
 
         case_name = "test_set_backend_mode"
         self.assert_not_hasattr(test_case, case_name)
-        for mode_tuple in VALID_MODES:
+        for mode_tuple in DEFAULT_MODES:
             _, _, backend_mode = mode_tuple
             if backend_mode == BackendMode.CINN:
                 self.check_test_case_exists(test_case, case_name, mode_tuple)
@@ -168,7 +184,7 @@ class TestCheckTestCases(unittest.TestCase, CheckTestCaseExistsMixin):
 
         case_name = "test_set_all"
         self.assert_not_hasattr(test_case, case_name)
-        for mode_tuple in VALID_MODES:
+        for mode_tuple in DEFAULT_MODES:
             if mode_tuple == (ToStaticMode.SOT, IrMode.PIR, BackendMode.CINN):
                 self.check_test_case_exists(test_case, case_name, mode_tuple)
             else:

--- a/test/dygraph_to_static/test_ifelse.py
+++ b/test/dygraph_to_static/test_ifelse.py
@@ -23,7 +23,6 @@ from dygraph_to_static_utils import (
     disable_test_case,
     enable_to_static_guard,
     test_ast_only,
-    test_legacy_and_pir,
     test_phi_only,
     test_pir_only,
 )
@@ -553,7 +552,7 @@ class IfElseNet(paddle.nn.Layer):
 
 
 class TestDy2StIfElseBackward(Dy2StTestBase):
-    @test_legacy_and_pir
+    @test_pir_only
     def test_run_backward(self):
         a = paddle.randn((4, 3), dtype='float32')
         a.stop_gradient = False

--- a/test/dygraph_to_static/test_incubate_jit_inference.py
+++ b/test/dygraph_to_static/test_incubate_jit_inference.py
@@ -18,8 +18,6 @@ import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
     test_ast_only,
-    test_legacy_and_pt,
-    test_legacy_and_pt_and_pir,
 )
 
 import paddle
@@ -63,7 +61,6 @@ class TestLayer2(paddle.nn.Layer):
 
 class TestToStaticInfenrenceModel(Dy2StTestBase):
     @test_ast_only
-    @test_legacy_and_pt_and_pir
     def test_dygraph_static_same_result(self):
         hidd = 1024
         batch = 4096
@@ -78,7 +75,6 @@ class TestToStaticInfenrenceModel(Dy2StTestBase):
 
 class TestToStaticInfenrenceTensorRTModel(Dy2StTestBase):
     @test_ast_only
-    @test_legacy_and_pt
     def test_dygraph_static_same_result(self):
         if paddle_infer.get_trt_compile_version()[0] == 0:
             return
@@ -95,7 +91,6 @@ class TestToStaticInfenrenceTensorRTModel(Dy2StTestBase):
 
 class TestToStaticInfenrenceFunc(Dy2StTestBase):
     @test_ast_only
-    @test_legacy_and_pt_and_pir
     def test_dygraph_static_same_result(self):
         hidd = 1024
         batch = 4096
@@ -118,7 +113,6 @@ class TestToStaticInfenrenceFunc(Dy2StTestBase):
 
 class TestToStaticInputListModel(Dy2StTestBase):
     @test_ast_only
-    @test_legacy_and_pt
     def test_dygraph_static_same_result(self):
         hidd = 1024
         batch = 4096

--- a/test/dygraph_to_static/test_len.py
+++ b/test/dygraph_to_static/test_len.py
@@ -19,8 +19,8 @@ from dygraph_to_static_utils import (
     Dy2StTestBase,
     static_guard,
     test_ast_only,
-    test_legacy_and_pt,
     test_pir_only,
+    test_pt_only,
 )
 
 import paddle
@@ -165,7 +165,7 @@ class TestLenWithSelectedRows(Dy2StTestBase):
         )
 
     @test_ast_only
-    @test_legacy_and_pt
+    @test_pt_only
     def test_len_legacy(self):
         with static_guard():
             (

--- a/test/dygraph_to_static/test_partial_program.py
+++ b/test/dygraph_to_static/test_partial_program.py
@@ -18,8 +18,8 @@ import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
     test_ast_only,
-    test_legacy_and_pt,
     test_pir_only,
+    test_pt_only,
 )
 from test_fetch_feed import Linear
 
@@ -132,7 +132,7 @@ class TestWithNestedOutput(Dy2StTestBase):
 
 class TestWithTrainAndEval(Dy2StTestBase):
     @test_ast_only
-    @test_legacy_and_pt
+    @test_pt_only
     def test_legacy_ir_switch_eval_and_train(self):
         # TODO(cleanup-legacy-ir): Remove this test case
         linear_net = Linear()
@@ -196,7 +196,7 @@ class TestWithTrainAndEval(Dy2StTestBase):
 
 class TestWithNoGrad(Dy2StTestBase):
     @test_ast_only
-    @test_legacy_and_pt
+    @test_pt_only
     def test_legacy_ir_with_no_grad(self):
         # TODO(cleanup-legacy-ir): Remove this test case
         linear_net = Linear()

--- a/test/dygraph_to_static/test_place.py
+++ b/test/dygraph_to_static/test_place.py
@@ -17,15 +17,15 @@ import warnings
 
 from dygraph_to_static_utils import (
     Dy2StTestBase,
-    test_legacy_and_pt,
     test_pir_only,
+    test_pt_only,
 )
 
 import paddle
 
 
 class TestPlace(Dy2StTestBase):
-    @test_legacy_and_pt
+    @test_pt_only
     def test_place_legacy(self):
         # TODO(cleanup-legacy-ir): remove this test case
         paddle.enable_static()

--- a/test/dygraph_to_static/test_typing.py
+++ b/test/dygraph_to_static/test_typing.py
@@ -18,7 +18,7 @@ import tempfile
 import unittest
 
 import numpy as np
-from dygraph_to_static_utils import Dy2StTestBase, test_legacy_and_pir
+from dygraph_to_static_utils import Dy2StTestBase, test_pir_only
 
 import paddle
 
@@ -94,7 +94,7 @@ class TestTyping(Dy2StTestBase):
         out, _ = self.net(self.x)
         return out
 
-    @test_legacy_and_pir
+    @test_pir_only
     def test_type(self):
         self.net = self.build_net()
         out = self.run_dy()

--- a/test/dygraph_to_static/test_utils.py
+++ b/test/dygraph_to_static/test_utils.py
@@ -15,14 +15,14 @@
 import types
 import unittest
 
-from dygraph_to_static_utils import Dy2StTestBase, test_legacy_and_pir
+from dygraph_to_static_utils import Dy2StTestBase, test_pir_only
 
 from paddle.jit.dy2static.transformers.utils import index_in_list
 from paddle.jit.dy2static.utils import is_paddle_func
 
 
 class TestIndexInList(Dy2StTestBase):
-    @test_legacy_and_pir
+    @test_pir_only
     def test_index_in_list(self):
         list_to_test = [1, 2, 3, 4, 5]
         self.assertEqual(index_in_list(list_to_test, 4), 3)
@@ -57,7 +57,7 @@ class TestIsPaddle(Dy2StTestBase):
     def fake_module(self):
         return types.ModuleType('paddlenlp')
 
-    @test_legacy_and_pir
+    @test_pir_only
     def test_func(self):
         m = self.fake_module()
         self.assertFalse(is_paddle_func(m))


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

#72165 开启了 SOT+PIR+CINN 的单测，但是同时限制了只有 5 种有效的模式，这会导致部分单测即便标记了 `@test_legacy_*` 也不再会跑老 IR，但对于部分 case 来说这还是有必要的，因为少数功能并没有 PT（pylayer），而老 IR 也不测的话就放弃测试老 IR 导出路径了，因此对于这些 case 还是需要测试老 IR 的，其他 case 则是直接删掉了 `@test_legacy_*` 之类的装饰器中的老 IR 部分

<!-- PCard-66972 -->