### PR TITLE
Fix bool_attrs to double_attrs

### DIFF
--- a/paddle/fluid/inference/tensorrt/convert/generic_and_custom_plugin_creater.cc
+++ b/paddle/fluid/inference/tensorrt/convert/generic_and_custom_plugin_creater.cc
@@ -62,7 +62,7 @@ class CustomPluginCreater : public OpConverter {
 
     std::list<int> int_attrs;
     std::list<float> float_attrs;
-    std::list<double> bool_attrs;
+    std::list<double> double_attrs;
     std::list<std::string> string_attrs;
     std::list<std::vector<int>> ints_attrs;
     std::list<std::vector<float>> floats_attrs;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
bool_attrs 类型 double ，应为 double_attrs