### PR TITLE
Fix SLANet infer error on MLU

### DIFF
--- a/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
+++ b/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
@@ -1593,7 +1593,8 @@ void HandleForWhileOp(
                &body_block,
                ctx,
                map_op_pair,
-               map_value_pair);
+               map_value_pair,
+               true);
 
   (*map_op_pair)[op_item] = new_while_op;
 
@@ -3049,7 +3050,7 @@ std::vector<pir::Value> BuildInputs(
         }
       }
     }
-
+    
     vec_inputs.push_back(new_in);
   }
   return vec_inputs;
@@ -3459,7 +3460,7 @@ void ProcessBlock(
 
   for (auto iter = block->begin(); iter != block->end(); ++iter) {
     pir::Operation* op_item = &(*iter);
-    VLOG(6) << "op name " << op_item->name();
+    VLOG(6) << "op name " << op_item->name() << ", op id " << op_item->id();
     if ((op_item->isa<FeedOp>()) &&
         inputs_by_data_op.count(op_item->attributes()
                                     .at("name")

--- a/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
+++ b/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
@@ -3050,7 +3050,7 @@ std::vector<pir::Value> BuildInputs(
         }
       }
     }
-    
+
     vec_inputs.push_back(new_in);
   }
   return vec_inputs;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-67164

while 中的 yield 在build inputs 时没有检查是否需要将 input 搬运到 arg 对应的设备上，从而导致 arg 在一轮循环后所在位置与预期不符。