### PR TITLE
[Infra][CINN] Add check for use `LOG(INFO)` in cinn dir

### DIFF
--- a/ci/check_approval.sh
+++ b/ci/check_approval.sh
@@ -137,6 +137,22 @@ if [[ ${IF_USE_FESETROUND} ]]; then
     check_approval 1 zyfncg SigureMo phlrain
 fi
 
+INFERMETA_FILES_ADDED_LINES=$(git diff -U0 upstream/$BRANCH -- 'paddle/phi/infermeta/' |grep "^+")
+IF_ADD_METACONFIG=`echo $INFERMETA_FILES_ADDED_LINES | grep -B5 --no-group-separator "MetaConfig" || true`
+HAS_MODIFIED_OP_BUILD_GEN_SCRIPT=`git diff --name-only upstream/$BRANCH -- 'paddle/fluid/pir/dialect/op_generator/op_build_gen.py'`
+if [ -n "${IF_ADD_METACONFIG}" ] && [ -z "${HAS_MODIFIED_OP_BUILD_GEN_SCRIPT}" ]; then
+    echo_line="If your added infermeta file contains MetaConfig, you must update _INFERMETA_NEED_META_CONFIG in op_build_gen.py synchronously.\n"
+    echo_line=${echo_line}"If you believe this is a false positive, please request one of the RD (SigureMo(Recommend), zyfncg, zhangbo9674) approval for the changes.\n"
+    check_approval 1 SigureMo zyfncg zhangbo9674
+fi
+
+CINN_FILES_ADDED_LINES=$(git diff -U0 upstream/$BRANCH -- 'paddle/cinn/' |grep "^+")
+IF_ADD_LOG_INFO=`echo $CINN_FILES_ADDED_LINES | grep -B5 --no-group-separator "LOG(INFO)" || true`
+if [[ ${IF_ADD_LOG_INFO} ]]; then
+    echo_line="You must have one RD (SigureMo(Recommend), zyfncg) approval for using LOG(INFO), which may make user confused. Recommend to move it under if (FLAGS_cinn_debug)\n"
+    check_approval 1 SigureMo zyfncg
+fi
+
 HAS_DEFINE_FLAG=`git diff -U0 upstream/$BRANCH |grep -o -m 1 "DEFINE_int32" |grep -o -m 1 "DEFINE_bool" | grep -o -m 1 "DEFINE_string" || true`
 if [ ${HAS_DEFINE_FLAG} ] && [ "${PR_ID}" != "" ]; then
     echo_line="You must have one RD zyfncg or zhangbo9674 or phlrain approval for the usage (either add or delete) of DEFINE_int32/DEFINE_bool/DEFINE_string flag.\n"

--- a/paddle/cinn/runtime/buffer.cc
+++ b/paddle/cinn/runtime/buffer.cc
@@ -32,7 +32,6 @@ void Shape::Resize(int ndim) {
   ndims_ = ndim;
   if (data_) delete data_;
   data_ = new value_type[ndim];
-  LOG(INFO) << "1111";
 }
 
 Shape::value_type &Shape::operator[](int i) {

--- a/paddle/cinn/runtime/buffer.cc
+++ b/paddle/cinn/runtime/buffer.cc
@@ -32,6 +32,7 @@ void Shape::Resize(int ndim) {
   ndims_ = ndim;
   if (data_) delete data_;
   data_ = new value_type[ndim];
+  LOG(INFO) << "1111";
 }
 
 Shape::value_type &Shape::operator[](int i) {

--- a/tools/check_file_diff_approvals.sh
+++ b/tools/check_file_diff_approvals.sh
@@ -147,6 +147,13 @@ if [ -n "${IF_ADD_METACONFIG}" ] && [ -z "${HAS_MODIFIED_OP_BUILD_GEN_SCRIPT}" ]
     check_approval 1 SigureMo zyfncg zhangbo9674
 fi
 
+CINN_FILES_ADDED_LINES=$(git diff -U0 upstream/$BRANCH -- 'paddle/cinn/' |grep "^+")
+IF_ADD_LOG_INFO=`echo $CINN_FILES_ADDED_LINES | grep -B5 --no-group-separator "LOG(INFO)" || true`
+if [[ ${IF_ADD_LOG_INFO} ]]; then
+    echo_line="You must have one RD (SigureMo(Recommend), zyfncg) approval for using LOG(INFO), which may make user confused. Recommend to move it under if (FLAGS_cinn_debug)\n"
+    check_approval 1 SigureMo zyfncg
+fi
+
 HAS_DEFINE_FLAG=`git diff -U0 upstream/$BRANCH |grep -o -m 1 "DEFINE_int32" |grep -o -m 1 "DEFINE_bool" | grep -o -m 1 "DEFINE_string" || true`
 if [ ${HAS_DEFINE_FLAG} ] && [ "${GIT_PR_ID}" != "" ]; then
     echo_line="You must have one RD zyfncg or zhangbo9674 or phlrain approval for the usage (either add or delete) of DEFINE_int32/DEFINE_bool/DEFINE_string flag.\n"


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

添加 cinn 目录 `LOG(INFO)` 使用的检查，避免默认打印太多信息，如需使用，请在 `if (FLAGS_cinn_debug)` 下使用

另外 #72059 添加的检查忘记在 GitHub Actions 版本的脚本里加了，这个 PR 补上，@swgu98 approval 流水线退场后可以尽快把原来的脚本删掉，不然大家可能会把检查加到错误的位置

<!-- PCard-66972 -->