### PR TITLE
[fluid_ops] remove fuse_with_relu in static/nn/common.py

### DIFF
--- a/python/paddle/static/nn/common.py
+++ b/python/paddle/static/nn/common.py
@@ -2624,8 +2624,6 @@ def batch_norm(
                 is_test,
                 'data_layout',
                 data_layout,
-                'fuse_with_relu',
-                False,
                 'use_global_stats',
                 use_global_stats,
             )
@@ -2637,8 +2635,6 @@ def batch_norm(
                 is_test,
                 'data_layout',
                 data_layout,
-                'fuse_with_relu',
-                False,
                 'use_global_stats',
                 use_global_stats,
             )


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
dygraph_ops.yaml 中batch_norm算子参数不包含 fuse_with_relu,  如果再转换到_C_ops调用时不加fuse_with_relu参数
paddle/phi/ops/yaml/inconsistent/dygraph_ops.yaml
![image](https://github.com/user-attachments/assets/047209df-f373-433c-b2ef-98fce9f7bdff)

fuse_with_relu 属性在onednn属性中设置，默认为False
paddle/phi/ops/yaml/inconsistent/onednn_ops_extra.yaml
![image](https://github.com/user-attachments/assets/3c92d098-c1da-40c4-80c0-b6843333b31f)


