### PR TITLE
update reshape strategy

### DIFF
--- a/paddle/fluid/pir/dialect/operator/interface/layout_transformation.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/layout_transformation.cc
@@ -239,7 +239,7 @@ bool CanBeModifiedImpl<ReshapeOp>(pir::Operation* op) {
     auto type = x.type().dyn_cast<paddle::dialect::DenseTensorType>();
     if (!type || type.dims().size() != 4) return false;
     auto x_shape = type.dims();
-    for (size_t i = 0; i < x_shape.size(); ++i) {
+    for (int i = 0; i < x_shape.size(); ++i) {
       if (x_shape.at(i) != value_int64.at(i)) return false;
     }
     return true;

--- a/paddle/fluid/pir/dialect/operator/interface/layout_transformation.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/layout_transformation.cc
@@ -211,19 +211,40 @@ bool CanBeModifiedImpl<ReshapeOp>(pir::Operation* op) {
   auto concrete_op = op->dyn_cast<ReshapeOp>();
   auto shape = concrete_op.shape();
   auto x = concrete_op.x();
-  if (!x || !(x.defining_op()->isa<pir::ParameterOp>())) return false;
-  if (!shape || !(shape.defining_op()->isa<FullIntArrayOp>())) return false;
-
-  auto full_int_op = shape.defining_op()->dyn_cast<FullIntArrayOp>();
-  auto value_attr =
-      full_int_op.attribute("value").dyn_cast<pir::ArrayAttribute>();
-
-  std::vector<int32_t> value_int32;
+  if (!x || !shape || !(shape.defining_op()->isa<FullIntArrayOp>()))
+    return false;
+  auto value_attr = shape.defining_op()
+                        ->dyn_cast<FullIntArrayOp>()
+                        .attribute("value")
+                        .dyn_cast<pir::ArrayAttribute>();
+  std::vector<int64_t> value_int64;
   for (size_t i = 0; i < value_attr.size(); ++i) {
     auto attr = value_attr.at(i);
-    value_int32.push_back(attr.dyn_cast<pir::Int64Attribute>().data());
+    value_int64.push_back(attr.dyn_cast<pir::Int64Attribute>().data());
   }
-  return value_int32 == std::vector<int32_t>{1, -1, 1, 1};
+  // reshape(builtin.parameter, [1, x, 1, 1]) can change layout.
+  bool IsParameterReshape = [&]() {
+    if (!(x.defining_op()->isa<pir::ParameterOp>())) return false;
+    if (value_attr.size() != 4) return false;
+    auto CheckShape = [&](std::vector<int64_t> value_int32) {
+      if (value_int32.at(0) != 1) return false;
+      if (value_int32.at(2) != 1) return false;
+      if (value_int32.at(3) != 1) return false;
+      return true;
+    };
+    return CheckShape(value_int64);
+  }();
+  // reshape(v, v.shape) can change layout.
+  bool IsUselessReshape = [&]() {
+    auto type = x.type().dyn_cast<paddle::dialect::DenseTensorType>();
+    if (!type || type.dims().size() != 4) return false;
+    auto x_shape = type.dims();
+    for (size_t i = 0; i < x_shape.size(); ++i) {
+      if (x_shape.at(i) != value_int64.at(i)) return false;
+    }
+    return true;
+  }();
+  return IsParameterReshape || IsUselessReshape;
 }
 
 template <>


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
升级reshape layout策略，现支持两类reshape改变layout:
1. out_shape = [1, C, 1, 1]
2. out_shape = inp_shape

Pcard-67164