### PR TITLE
[PHI] Optimize Gather kernel with vectorization

### DIFF
--- a/test/ir/inference/test_trt_convert_gather.py
+++ b/test/ir/inference/test_trt_convert_gather.py
@@ -49,59 +49,57 @@ class TrtConvertGatherTest(TrtLayerAutoScanTest):
             return np.array([axis]).astype(np.int32)
 
         for shape in [[32], [16, 64], [32, 16, 16], [32, 64, 16, 32]]:
-            for index in [[1, 4], [4, 8]]:
+            for index in [[0, 1]]:
                 for axis in [0, 1, 2, 3]:
-                    for overwrite in [True, False]:
-                        for input in [
-                            {"X": ["input_data"], "Index": ["index_data"]},
-                        ]:
-                            for index_type_int32 in [True, False]:
-                                self.shape = shape
-                                self.axis = axis
-                                self.input_num = len(input)
-                                self.index_type_int32 = index_type_int32
-                                dics = [{"overwrite": overwrite, "axis": axis}]
-                                ops_config = [
+                    for input in [
+                        {"X": ["input_data"], "Index": ["index_data"]},
+                    ]:
+                        for index_type_int32 in [True, False]:
+                            self.shape = shape
+                            self.axis = axis
+                            self.input_num = len(input)
+                            self.index_type_int32 = index_type_int32
+                            ops_config = [
+                                {
+                                    "op_type": "gather",
+                                    "op_inputs": input,
+                                    "op_outputs": {"Out": ["output_data"]},
+                                    "op_attrs": {"axis": axis},
+                                }
+                            ]
+                            ops = self.generate_op_config(ops_config)
+
+                            program_config = ProgramConfig(
+                                ops=ops,
+                                weights={},
+                                inputs=(
                                     {
-                                        "op_type": "gather",
-                                        "op_inputs": input,
-                                        "op_outputs": {"Out": ["output_data"]},
-                                        "op_attrs": dics[0],
+                                        "index_data": TensorConfig(
+                                            data_gen=partial(
+                                                (
+                                                    generate_input2
+                                                    if index_type_int32
+                                                    else generate_input4
+                                                ),
+                                                index,
+                                            )
+                                        ),
+                                        "input_data": TensorConfig(
+                                            data_gen=partial(
+                                                generate_input1, shape
+                                            )
+                                        ),
                                     }
-                                ]
-                                ops = self.generate_op_config(ops_config)
+                                ),
+                                outputs=["output_data"],
+                            )
 
-                                program_config = ProgramConfig(
-                                    ops=ops,
-                                    weights={},
-                                    inputs=(
-                                        {
-                                            "index_data": TensorConfig(
-                                                data_gen=partial(
-                                                    (
-                                                        generate_input2
-                                                        if index_type_int32
-                                                        else generate_input4
-                                                    ),
-                                                    index,
-                                                )
-                                            ),
-                                            "input_data": TensorConfig(
-                                                data_gen=partial(
-                                                    generate_input1, shape
-                                                )
-                                            ),
-                                        }
-                                    ),
-                                    outputs=["output_data"],
-                                )
-
-                                yield program_config
+                            yield program_config
 
     def generate_dynamic_shape(self):
         if len(self.shape) == 1:
             self.dynamic_shape.min_input_shape = {
-                "input_data": [1],
+                "input_data": [2],
                 "index_data": [2],
             }
             self.dynamic_shape.max_input_shape = {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Performance Optimization


### PR Types
Performance


### Description
使用向量化优化GatherGPUKernel的性能，并将原有的2种Gather实现合并为一个

<b>注：</b>原来的2种实现分别处理高维和低维，我发现没有必要，就合并成一个了，但仍然保留了2种调用接口，因为一些别的Kernel还依赖于被弃用的接口

#### 性能测试
A100，float16，假设index的长度和shape[axis]相同，用时单位为us

| shape | axis | 原用时 | 新用时 | 性能提升 | 说明 |
| --- | :-: | --: | --: | --: | --- |
[128, 1024*1024] | 0 | 1,466  | 459  | 219.6% | 2D高维，可4x向量化
[128, 1024*1024+2] | 0 | 1,472  | 834  | 76.5% | 2D高维，可2x向量化
[128, 1024*1024+1] | 0 | 1,471  | 1,394  | 5.5% | 2D高维，不可向量化
[262144, 256] | 1 | 793  | 694  | 14.2% | 2D低维，不可向量化
[16384, 4096] | 1 | 884  | 720  | 22.7% | 2D低维，不可向量化
[4096, 16384] | 1 | 1,151  | 963  | 19.6% | 2D低维，不可向量化
[128, 1024, 1024] | 1 | 1,700  | 478  | 255.5% | 3D中维，可4x向量化
[128, 1024, 1024+2] | 1 | 1,747  | 871  | 100.6% | 3D中维，可2x向量化
[128, 1024, 1024+1] | 1 | 1,695  | 1,409  | 20.3% | 3D中维，不可向量化

由测试结果可知，本PR主要在可向量化的场景下带来较大的性能提升；对于不可向量化的情况也有略微的提升，这是因为优化了下标的计算方式和增大了loop数量

另外，进行了千级的shape覆盖性测试，也检查了部分shape下float32的性能，均无问题

<br>
Pcard-85711
