### PR TITLE
[CINN] Clear OpInferSymbolicShapeCache when lowering subgraph

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/lowering_pass/collect_sym_expr.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/lowering_pass/collect_sym_expr.cc
@@ -234,6 +234,7 @@ CreateGroupShapeOrDataExprs(
 
   local_shape_analysis.RegisterSymbolConstraintFromShapeAnalysis(
       global_shape_analysis);
+  local_shape_analysis.ClearOpInferSymbolicShapeCache();
   for (const auto& item : dim_expr_map) {
     local_shape_analysis.AddEqualCstr(item.first, item.second);
   }

--- a/paddle/pir/include/dialect/shape/utils/shape_analysis.h
+++ b/paddle/pir/include/dialect/shape/utils/shape_analysis.h
@@ -136,6 +136,8 @@ class IR_API InferSymbolicShapeContext {
   std::optional<InferSymbolicShapeCacheValue> GetOpInferSymbolicShapeCache(
       const InferSymbolicShapeCacheKey& op_infer_cache_key) const;
 
+  void ClearOpInferSymbolicShapeCache();
+
   const symbol::ConstraintsManager& constraints_manager() const {
     return constraints_manager_;
   }
@@ -248,6 +250,10 @@ class IR_API ShapeConstraintIRAnalysis final
 
   const symbol::ConstraintsManager& constraints_manager() const {
     return context_.constraints_manager();
+  }
+
+  void ClearOpInferSymbolicShapeCache() {
+    context_.ClearOpInferSymbolicShapeCache();
   }
 
   void SetInputDynamicDimSpec(

--- a/paddle/pir/src/dialect/shape/utils/shape_analysis.cc
+++ b/paddle/pir/src/dialect/shape/utils/shape_analysis.cc
@@ -480,6 +480,10 @@ InferSymbolicShapeContext::GetOpInferSymbolicShapeCache(
   return std::nullopt;
 }
 
+void InferSymbolicShapeContext::ClearOpInferSymbolicShapeCache() {
+  infer_symbolic_shape_cache_.clear();
+}
+
 bool InferSymbolicShapeContext::HasPredefinedDimExprForInputName(
     const std::string& input_name) const {
   return predefined_dimexpr_map_for_inputs_.count(input_name) != 0;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->
Pcard-76996

- Clear OpInferSymbolicShapeCache when lowering subgraph for decreaing compiling time