### PR TITLE
Avoid NPU context null error by setting device when constructing Standalone Executor

### DIFF
--- a/paddle/fluid/framework/new_executor/standalone_executor.cc
+++ b/paddle/fluid/framework/new_executor/standalone_executor.cc
@@ -22,6 +22,7 @@
 #include "paddle/fluid/pir/dialect/operator/ir/pd_op.h"
 #include "paddle/fluid/pir/transforms/general/inplace_pass.h"
 #include "paddle/fluid/pir/transforms/pd_op_to_kernel_pass.h"
+#include "paddle/phi/backends/device_manager.h"
 #include "paddle/phi/core/platform/profiler/event_tracing.h"
 #include "paddle/pir/include/core/program.h"
 #include "paddle/pir/include/pass/pass.h"
@@ -113,6 +114,11 @@ StandaloneExecutor::StandaloneExecutor(const phi::Place& place,
         }
       }
 #if defined(PADDLE_WITH_CUSTOM_DEVICE)
+      std::string device_type = place_.GetDeviceType();
+      if(phi::DeviceManager::IsCustom(device_type)) {
+          phi::DeviceManager::SetDevice(place_);
+        }
+
       if (!FLAGS_enable_custom_engine.empty()) {
         std::string custom_engine_translate_pass = FLAGS_enable_custom_engine;
         std::istringstream ss(custom_engine_translate_pass);

--- a/paddle/fluid/framework/new_executor/standalone_executor.cc
+++ b/paddle/fluid/framework/new_executor/standalone_executor.cc
@@ -115,9 +115,9 @@ StandaloneExecutor::StandaloneExecutor(const phi::Place& place,
       }
 #if defined(PADDLE_WITH_CUSTOM_DEVICE)
       std::string device_type = place_.GetDeviceType();
-      if(phi::DeviceManager::IsCustom(device_type)) {
-          phi::DeviceManager::SetDevice(place_);
-        }
+      if (place_.GetType() == phi::AllocationType::CUSTOM) {
+        phi::DeviceManager::SetDevice(place_);
+      }
 
       if (!FLAGS_enable_custom_engine.empty()) {
         std::string custom_engine_translate_pass = FLAGS_enable_custom_engine;

--- a/paddle/fluid/framework/new_executor/standalone_executor.cc
+++ b/paddle/fluid/framework/new_executor/standalone_executor.cc
@@ -114,7 +114,6 @@ StandaloneExecutor::StandaloneExecutor(const phi::Place& place,
         }
       }
 #if defined(PADDLE_WITH_CUSTOM_DEVICE)
-      std::string device_type = place_.GetDeviceType();
       if (place_.GetType() == phi::AllocationType::CUSTOM) {
         phi::DeviceManager::SetDevice(place_);
       }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-67164

NPU 设备如果直接run main program，可能会报错 context 为null，需要先 run start_up program。

这是因为在 pd_op to kernel pass 中，为pd.data 添加 shadowFeed 时需要获取 device 信息，最终会调用runtime.getDevice，但此时没有调用过setDevice对 context 初始化。

每个 standalone Executor 都有个 place 属性，通过在构造执行器的时候执行一次 set_device 防止未初始化获取 device。