### PR TITLE
fix: install_gcc.sh typo to reduce image size

### DIFF
--- a/tools/dockerfile/build_scripts/install_gcc.sh
+++ b/tools/dockerfile/build_scripts/install_gcc.sh
@@ -71,7 +71,7 @@ elif [ "$1" == "gcc121" ]; then
   cd .. && mkdir temp_gcc121 && cd temp_gcc121 && \
   ../gcc-12.1.0/configure --prefix=/usr/local/gcc-12.1 --enable-checking=release --enable-languages=c,c++ --disable-multilib && \
   make -j8 && make install
-  cd .. && rm -rf temp_gcc122 gcc-12.1.0 gcc-12.1.0.tar.gz
+  cd .. && rm -rf temp_gcc121 gcc-12.1.0 gcc-12.1.0.tar.gz
   cp ${lib_so_6} ${lib_so_6}.bak  && rm -f ${lib_so_6} &&
   ln -s /usr/local/gcc-12.1/lib64/libstdc++.so.6 ${lib_so_6} && \
   cp /usr/local/gcc-12.1/lib64/libstdc++.so.6.0.30 ${lib_path}


### PR DESCRIPTION
### PR Category
Performance Optimization

### PR Types
Bug fixes

### Description

Fixed a typo in the cleanup step by changing `temp_gcc122` to `temp_gcc121`. This correction ensures the proper temporary build directory is removed, reducing the image size by approximately 6.6G.

**Changes Made:**
- Updated the directory name from `temp_gcc122` to `temp_gcc121` in the cleanup step.
- Ensured the correct temporary directory is deleted to prevent leftover files and optimize image size.

**Expected Impact:**
- Accurate cleanup post-build process.
- Reduced image size by around 6.6G, enhancing storage efficiency and transfer speed.

---