### PR TITLE
[SOT][Faster Guard] Implement more `make_faster_guard`

### DIFF
--- a/paddle/fluid/pybind/jit.cc
+++ b/paddle/fluid/pybind/jit.cc
@@ -180,7 +180,7 @@ void BindGuardTree(pybind11::module *m) {
             return self.lookup(reinterpret_cast<FrameProxy *>(frame.ptr()));
           },
           py::arg("frame"))
-      .def("stringify", &GuardNode::stringify);
+      .def("stringify", &GuardNode::stringify, py::arg("indent") = 0);
 
   py::class_<ExprNode, std::shared_ptr<ExprNode>>(
       *m, "ExprNode", R"DOC(ExprNode Class.)DOC")
@@ -190,7 +190,7 @@ void BindGuardTree(pybind11::module *m) {
             return self.eval(reinterpret_cast<FrameProxy *>(frame.ptr()));
           },
           py::arg("frame"))
-      .def("stringify", &ExprNode::stringify);
+      .def("stringify", &ExprNode::stringify, py::arg("indent") = 0);
 
   py::class_<ConstantExprNode, ExprNode, std::shared_ptr<ConstantExprNode>>(
       *m, "ConstantExprNode", R"DOC(ConstantExprNode Class.)DOC")

--- a/paddle/fluid/pybind/jit.cc
+++ b/paddle/fluid/pybind/jit.cc
@@ -144,7 +144,7 @@ void BindGuardTree(pybind11::module *m) {
       *m, "GuardTree", R"DOC(GuardTree Class.)DOC")
       .def(py::init<
                const std::vector<std::vector<std::shared_ptr<GuardNode>>> &>(),
-           py::arg("guard_nodes_list"))
+           py::arg("guard_chain_list"))
       .def(
           "lookup",
           [](GuardTree &self, py::object frame) {

--- a/paddle/fluid/pybind/sot/guards.cc
+++ b/paddle/fluid/pybind/sot/guards.cc
@@ -194,10 +194,12 @@ bool WeakRefMatchGuard::check(PyObject* value) {
 }
 
 PyObject* ConstantExprNode::eval(FrameProxy* frame) { return value_ptr_; }
-std::string ConstantExprNode::stringify() { return py::str(value_ptr_); }
+std::string ConstantExprNode::stringify(int indent) {
+  return py::str(value_ptr_);
+}
 
 PyObject* ExternVarExprNode::eval(FrameProxy* frame) { return value_ptr_; }
-std::string ExternVarExprNode::stringify() { return var_name_; }
+std::string ExternVarExprNode::stringify(int indent) { return var_name_; }
 
 PyObject* LocalVarExprNode::eval(FrameProxy* frame) {
 #if PY_3_13_PLUS
@@ -208,7 +210,7 @@ PyObject* LocalVarExprNode::eval(FrameProxy* frame) {
   return PyDict_GetItemString(frame->f_locals, var_name_.c_str());
 #endif
 }
-std::string LocalVarExprNode::stringify() {
+std::string LocalVarExprNode::stringify(int indent) {
   return "locals[" + var_name_ + "]";
 }
 
@@ -219,7 +221,7 @@ PyObject* GlobalVarExprNode::eval(FrameProxy* frame) {
   return PyDict_GetItemString(frame->f_globals, var_name_.c_str());
 #endif
 }
-std::string GlobalVarExprNode::stringify() {
+std::string GlobalVarExprNode::stringify(int indent) {
   return "globals[" + var_name_ + "]";
 }
 
@@ -227,7 +229,7 @@ PyObject* AttributeExprNode::eval(FrameProxy* frame) {
   PyObject* var = var_expr_->eval(frame);
   return PyObject_GetAttrString(var, attr_name_.c_str());
 }
-std::string AttributeExprNode::stringify() {
+std::string AttributeExprNode::stringify(int indent) {
   std::stringstream ss;
   ss << var_expr_->stringify() << "." << attr_name_;
   return ss.str();
@@ -238,7 +240,7 @@ PyObject* ItemExprNode::eval(FrameProxy* frame) {
   PyObject* key = key_expr_->eval(frame);
   return PyObject_GetItem(var, key);
 }
-std::string ItemExprNode::stringify() {
+std::string ItemExprNode::stringify(int indent) {
   std::stringstream ss;
   ss << var_expr_->stringify() << "[" << key_expr_->stringify() << "]";
   return ss.str();
@@ -261,10 +263,19 @@ std::optional<int> GuardNode::lookup(FrameProxy* frame) {
   }
   return std::nullopt;
 }
-std::string GuardNode::stringify() {
+std::string GuardNode::stringify(int indent) {
   std::stringstream ss;
-  ss << guard->get_guard_name();
+  // TODO(zrr1999): support multiple exprs
+  auto expr = exprs.back();
+  ss << std::string(indent, ' ') << guard->get_guard_name();
   ss << "(" << exprs.back()->stringify() << ")";
+  if (!next_guard_nodes.empty()) {
+    ss << " |" << std::endl;
+    for (auto& next_guard_node : next_guard_nodes) {
+      ss << std::string(indent + 2, ' ');
+      ss << next_guard_node->stringify(indent + 2) << std::endl;
+    }
+  }
   return ss.str();
 }
 
@@ -295,7 +306,7 @@ std::string GuardTree::stringify() {
   std::stringstream ss;
   for (size_t i = 0; i < guard_nodes_.size(); ++i) {
     if (i > 0) {
-      ss << " and ";
+      ss << std::endl << "and" << std::endl;
     }
     ss << guard_nodes_[i]->stringify();
   }

--- a/paddle/fluid/pybind/sot/guards.cc
+++ b/paddle/fluid/pybind/sot/guards.cc
@@ -84,6 +84,10 @@ bool TypeMatchGuard::check(PyObject* value) {
 bool IdMatchGuard::check(PyObject* value) { return value == expected_; }
 
 bool ValueMatchGuard::check(PyObject* value) {
+  if (value == NULL) {
+    PyErr_Clear();
+    return false;
+  }
   return PyObject_Equal(value, expected_value_);
 }
 
@@ -107,6 +111,10 @@ bool DtypeMatchGuard::check(PyObject* value) {
 }
 
 bool ShapeMatchGuard::check(PyObject* value) {
+  if (value == NULL) {
+    PyErr_Clear();
+    return false;
+  }
   auto tensor = GetTensorFromPyObject(value);
   if (!tensor) {
     return false;

--- a/paddle/fluid/pybind/sot/guards.cc
+++ b/paddle/fluid/pybind/sot/guards.cc
@@ -33,6 +33,12 @@ static inline PyObject* PyObject_CallOneArg(PyObject* func, PyObject* arg) {
 #define Py_IsNone(x) ((x) == Py_None)
 #endif
 
+#define HANDLE_NULL_VALUE(value) \
+  if ((value) == NULL) {         \
+    PyErr_Clear();               \
+    return false;                \
+  }
+
 static inline bool PyObject_Equal(PyObject* a, PyObject* b) {
   if (a == b) {
     return true;
@@ -84,10 +90,7 @@ bool TypeMatchGuard::check(PyObject* value) {
 bool IdMatchGuard::check(PyObject* value) { return value == expected_; }
 
 bool ValueMatchGuard::check(PyObject* value) {
-  if (value == NULL) {
-    PyErr_Clear();
-    return false;
-  }
+  HANDLE_NULL_VALUE(value);
   return PyObject_Equal(value, expected_value_);
 }
 
@@ -111,10 +114,7 @@ bool DtypeMatchGuard::check(PyObject* value) {
 }
 
 bool ShapeMatchGuard::check(PyObject* value) {
-  if (value == NULL) {
-    PyErr_Clear();
-    return false;
-  }
+  HANDLE_NULL_VALUE(value);
   auto tensor = GetTensorFromPyObject(value);
   if (!tensor) {
     return false;

--- a/paddle/fluid/pybind/sot/guards.h
+++ b/paddle/fluid/pybind/sot/guards.h
@@ -389,9 +389,9 @@ class GuardNode : public GuardTreeNode {
 class GuardTree {
  public:
   GuardTree(const std::vector<std::vector<std::shared_ptr<GuardNode>>>&
-                guard_nodes_list) {
-    for (size_t index = 0; index < guard_nodes_list.size(); ++index) {
-      add_guard_chain(guard_nodes_list[index]);
+                guard_chain_list) {
+    for (size_t index = 0; index < guard_chain_list.size(); ++index) {
+      add_guard_chain(guard_chain_list[index]);
     }
   }
   void add_guard_chain(

--- a/paddle/fluid/pybind/sot/guards.h
+++ b/paddle/fluid/pybind/sot/guards.h
@@ -275,7 +275,7 @@ class DummyGuard : public GuardBase {
 class GuardTreeNode {
  public:
   virtual ~GuardTreeNode() = default;
-  virtual std::string stringify() = 0;
+  virtual std::string stringify(int indent = 0) = 0;
 };
 
 class AttributeExprNode;
@@ -295,7 +295,7 @@ class ConstantExprNode : public ExprNode {
   }
   ~ConstantExprNode() { Py_DECREF(value_ptr_); }
   PyObject* eval(FrameProxy* frame) override;
-  std::string stringify() override;
+  std::string stringify(int indent = 0) override;
 
  private:
   PyObject* value_ptr_;
@@ -310,7 +310,7 @@ class ExternVarExprNode : public ExprNode {
 
   ~ExternVarExprNode() { Py_DECREF(value_ptr_); }
   PyObject* eval(FrameProxy* frame) override;
-  std::string stringify() override;
+  std::string stringify(int indent = 0) override;
 
  private:
   PyObject* value_ptr_;
@@ -323,7 +323,7 @@ class LocalVarExprNode : public ExprNode {
       : var_name_(var_name) {}
 
   PyObject* eval(FrameProxy* frame) override;
-  std::string stringify() override;
+  std::string stringify(int indent = 0) override;
 
  private:
   std::string var_name_;
@@ -334,7 +334,7 @@ class GlobalVarExprNode : public ExprNode {
       : var_name_(var_name) {}
 
   PyObject* eval(FrameProxy* frame) override;
-  std::string stringify() override;
+  std::string stringify(int indent = 0) override;
 
  private:
   std::string var_name_;
@@ -346,7 +346,7 @@ class AttributeExprNode : public ExprNode {
       : var_expr_(var_expr), attr_name_(attr_name) {}
 
   PyObject* eval(FrameProxy* frame) override;
-  std::string stringify() override;
+  std::string stringify(int indent = 0) override;
 
  private:
   std::shared_ptr<ExprNode> var_expr_;
@@ -359,7 +359,7 @@ class ItemExprNode : public ExprNode {
       : var_expr_(var_expr), key_expr_(key_expr) {}
 
   PyObject* eval(FrameProxy* frame) override;
-  std::string stringify() override;
+  std::string stringify(int indent = 0) override;
 
  private:
   std::shared_ptr<ExprNode> var_expr_;
@@ -381,8 +381,8 @@ class GuardNode : public GuardTreeNode {
         exprs(exprs),
         next_guard_nodes(next_guard_nodes),
         return_cache_index(return_cache_index) {}
-  std::string stringify() override;
   virtual ~GuardNode() = default;
+  std::string stringify(int indent = 0) override;
   std::optional<int> lookup(FrameProxy* frame);
 };
 

--- a/python/paddle/jit/sot/opcode_translator/executor/executor_cache.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/executor_cache.py
@@ -153,9 +153,20 @@ class OpcodeExecutorCache(metaclass=Singleton):
             log(4, f"[Cache] Guard tree is `{guard_tree.stringify()}`")
             cache_index = guard_tree.lookup(frame)
 
-        if not enable_strict_guard and cache_index is not None:
-            # TODO(zrr1999): add a mapping between custom_code and cache_index
-            return guarded_fns[cache_index][0]
+        if not enable_strict_guard:
+            if cache_index is not None:
+                # TODO(zrr1999): add a mapping between custom_code and cache_index
+                return guarded_fns[cache_index][0]
+            else:
+                log(2, "[Cache]: all guards missed (guard tree mode)\n")
+                new_custom_code, guard_fn, guard_chain = self.translate(
+                    frame, **kwargs
+                )
+                if guard_fn is not None:
+                    assert guard_chain is not None
+                    guarded_fns.append((new_custom_code, guard_fn))
+                    guard_tree.add_guard_chain(guard_chain)
+                return new_custom_code
 
         for index, (custom_code, guard_fn) in enumerate(guarded_fns):
             if enable_strict_guard:

--- a/python/paddle/jit/sot/opcode_translator/executor/executor_cache.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/executor_cache.py
@@ -150,10 +150,10 @@ class OpcodeExecutorCache(metaclass=Singleton):
 
         cache_index = None
         if enable_strict_guard or enable_guard_tree:
-            log(4, f"[Cache] Guard tree is `{guard_tree.stringify()}`")
+            log(4, f"[Cache] Guard tree: \n{guard_tree.stringify()}")
             cache_index = guard_tree.lookup(frame)
 
-        if not enable_strict_guard:
+        if not enable_strict_guard and enable_guard_tree:
             if cache_index is not None:
                 # TODO(zrr1999): add a mapping between custom_code and cache_index
                 return guarded_fns[cache_index][0]

--- a/python/paddle/jit/sot/opcode_translator/executor/guard.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/guard.py
@@ -294,6 +294,27 @@ def object_equal_stringified_guard(self) -> list[StringifiedExpression]:
     ]
 
 
+@check_faster_guard
+def object_equal_faster_guard(self) -> list[paddle.framework.core.GuardNode]:
+    expr_node = self.tracker.guard_tree_expr_node()
+
+    weak_ref_obj = self.get_py_value()
+    if support_weak_ref(weak_ref_obj):
+        weak_ref_obj = weakref.ref(self.get_py_value())
+        return [
+            paddle.framework.core.GuardNode(
+                paddle.framework.core.WeakRefMatchGuard(self.get_py_value()),
+                [expr_node],
+            )
+        ]
+    return [
+        paddle.framework.core.GuardNode(
+            paddle.framework.core.ValueMatchGuard(weak_ref_obj),
+            [expr_node],
+        )
+    ]
+
+
 def stringify_pyobject(obj: object) -> tuple[str, dict[str, Any]]:
     if isinstance(obj, paddle.core.VarDesc.VarType):
         return f"paddle.core.VarDesc.VarType({obj.value})", {"paddle": paddle}

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/base.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/base.py
@@ -347,11 +347,11 @@ class VariableBase:
 
     @check_faster_guard
     def make_faster_guard(self) -> list[paddle.framework.core.GuardNode]:
-        expr = self.tracker.guard_tree_expr_node()
+        expr_node = self.tracker.guard_tree_expr_node()
         return [
             paddle.framework.core.GuardNode(
                 paddle.framework.core.ValueMatchGuard(self.get_py_value()),
-                [expr],
+                [expr_node],
             )
         ]
 

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
@@ -98,6 +98,7 @@ from ..guard import (
     StringifiedExpression,
     check_faster_guard,
     check_guard,
+    object_equal_faster_guard,
     object_equal_stringified_guard,
     stringify_pyobject,
     union_free_vars,
@@ -1353,12 +1354,7 @@ class ObjectVariable(VariableBase):
     """
 
     make_stringified_guard = object_equal_stringified_guard
-
-    @check_faster_guard
-    def make_faster_guard(self) -> list[paddle.framework.core.GuardNode]:
-        raise NotImplementedError(
-            f"{self.__class__.__name__}.make_faster_guard is not implemented"
-        )
+    make_faster_guard = object_equal_faster_guard
 
     def __init__(self, obj, graph, tracker):
         super().__init__(graph, tracker)
@@ -1575,12 +1571,7 @@ class ModuleVariable(VariableBase):
 
     # Happened in a inline import statement.
     make_stringified_guard = object_equal_stringified_guard
-
-    @check_faster_guard
-    def make_faster_guard(self) -> list[paddle.framework.core.GuardNode]:
-        raise NotImplementedError(
-            f"{self.__class__.__name__}.make_faster_guard is not implemented"
-        )
+    make_faster_guard = object_equal_faster_guard
 
 
 class DygraphTracerVariable(VariableBase):

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
@@ -1199,7 +1199,18 @@ class SymbolicVariable(VariableBase):
     @check_faster_guard
     def make_faster_guard(self) -> list[paddle.framework.core.GuardNode]:
         assert ENV_SOT_ALLOW_DYNAMIC_SHAPE.get()
+        from ..executor_cache import OpcodeExecutorCache
+
+        expr_node = self.tracker.guard_tree_expr_node()
+        frame_value_tracer = self.tracker.trace_value_from_frame()
+        # TODO(zrr1999): symbolic_inputs need frame_value_tracer.inlined_expr
+        symbolic_inputs = OpcodeExecutorCache().get_symbolic_inputs(
+            self.graph.pycode_gen._origin_code
+        )
+        assert frame_value_tracer.inlined_expr in symbolic_inputs
+
         if self.need_guard_value:
+            log(3, f"Need guard value for {self} in {expr_node}\n")
             return super().make_faster_guard()
         raise NotImplementedError(
             f"{self.__class__.__name__}.make_faster_guard is not implemented"
@@ -1484,9 +1495,16 @@ class SliceVariable(VariableBase):
 
     @check_faster_guard
     def make_faster_guard(self) -> list[paddle.framework.core.GuardNode]:
-        raise NotImplementedError(
-            f"{self.__class__.__name__}.make_faster_guard is not implemented"
-        )
+        expr_node = self.tracker.guard_tree_expr_node()
+        return [
+            paddle.framework.core.GuardNode(
+                paddle.framework.core.TypeMatchGuard(slice),
+                [expr_node],
+            ),
+            *self.getattr("start").make_faster_guard(),
+            *self.getattr("stop").make_faster_guard(),
+            *self.getattr("step").make_faster_guard(),
+        ]
 
     @check_guard
     def make_stringified_guard(self) -> list[StringifiedExpression]:

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
@@ -1511,7 +1511,7 @@ class SliceVariable(VariableBase):
         frame_value_tracer = self.tracker.trace_value_from_frame()
         result = [
             FasterStringifiedExpression(
-                "id(type({{}})) == id(slice)",
+                f"id(type({{}})) == {id(slice)}",
                 paddle.framework.core.TypeMatchGuard(slice),
                 [frame_value_tracer],
                 frame_value_tracer.free_vars,

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
@@ -1585,9 +1585,7 @@ class DygraphTracerVariable(VariableBase):
 
     @check_faster_guard
     def make_faster_guard(self) -> list[paddle.framework.core.GuardNode]:
-        raise NotImplementedError(
-            f"{self.__class__.__name__}.make_faster_guard is not implemented"
-        )
+        return []
 
     @check_guard
     def make_stringified_guard(self) -> list[StringifiedExpression]:
@@ -1675,9 +1673,21 @@ class NumpyNumberVariable(NumpyVariable):
 
     @check_faster_guard
     def make_faster_guard(self) -> list[paddle.framework.core.GuardNode]:
-        raise NotImplementedError(
-            f"{self.__class__.__name__}.make_faster_guard is not implemented"
+        expr_node = self.tracker.guard_tree_expr_node()
+        dtype_guard = paddle.framework.core.GuardNode(
+            paddle.framework.core.NumPyDtypeMatchGuard(
+                self.get_py_value().dtype
+            ),
+            [expr_node],
         )
+
+        return [
+            dtype_guard,
+            paddle.framework.core.GuardNode(
+                paddle.framework.core.ValueMatchGuard(self.get_py_value()),
+                [expr_node],
+            ),
+        ]
 
     @check_guard
     def make_stringified_guard(self) -> list[StringifiedExpression]:
@@ -1720,9 +1730,21 @@ class NumpyBoolVariable(NumpyNumberVariable):
 class NumpyArrayVariable(NumpyVariable):
     @check_faster_guard
     def make_faster_guard(self) -> list[paddle.framework.core.GuardNode]:
-        raise NotImplementedError(
-            f"{self.__class__.__name__}.make_faster_guard is not implemented"
+        expr_node = self.tracker.guard_tree_expr_node()
+        dtype_guard = paddle.framework.core.GuardNode(
+            paddle.framework.core.NumPyDtypeMatchGuard(
+                self.get_py_value().dtype
+            ),
+            [expr_node],
         )
+        value_guard = paddle.framework.core.GuardNode(
+            paddle.framework.core.NumPyArrayValueMatchGuard(
+                self.get_py_value()
+            ),
+            [expr_node],
+        )
+
+        return [dtype_guard, value_guard]
 
     @check_guard
     def make_stringified_guard(self) -> list[StringifiedExpression]:

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/callable.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/callable.py
@@ -68,6 +68,7 @@ from ..guard import (
     StringifiedExpression,
     check_faster_guard,
     check_guard,
+    object_equal_faster_guard,
     object_equal_stringified_guard,
     union_free_vars,
 )
@@ -177,12 +178,7 @@ class FunctionVariable(CallableVariable):
         )
 
     make_stringified_guard = object_equal_stringified_guard
-
-    @check_faster_guard
-    def make_faster_guard(self) -> list[paddle.framework.core.GuardNode]:
-        raise NotImplementedError(
-            f"{self.__class__.__name__}.make_faster_guard is not implemented"
-        )
+    make_faster_guard = object_equal_faster_guard
 
 
 class UserDefinedFunctionVariable(FunctionVariable):
@@ -350,12 +346,7 @@ class PaddleApiVariable(FunctionVariable):
         }
 
     make_stringified_guard = object_equal_stringified_guard
-
-    @check_faster_guard
-    def make_faster_guard(self) -> list[paddle.framework.core.GuardNode]:
-        raise NotImplementedError(
-            f"{self.__class__.__name__}.make_faster_guard is not implemented"
-        )
+    make_faster_guard = object_equal_faster_guard
 
 
 class TensorFunctionVariable(FunctionVariable):
@@ -992,12 +983,7 @@ class ClassVariable(CallableVariable):
         return new_object_variable
 
     make_stringified_guard = object_equal_stringified_guard
-
-    @check_faster_guard
-    def make_faster_guard(self) -> list[paddle.framework.core.GuardNode]:
-        raise NotImplementedError(
-            f"{self.__class__.__name__}.make_faster_guard is not implemented"
-        )
+    make_faster_guard = object_equal_faster_guard
 
     @VariableFactory.register_from_value()
     def from_value(value: Any, graph: FunctionGraph, tracker: Tracker):

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/callable.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/callable.py
@@ -612,9 +612,22 @@ class ContainerLayerVariable(LayerVariable):
 
     @check_faster_guard
     def make_faster_guard(self) -> list[paddle.framework.core.GuardNode]:
-        raise NotImplementedError(
-            f"{self.__class__.__name__}.make_faster_guard is not implemented"
-        )
+        if isinstance(self.value, PD_SEQ_CONTAINERS):
+            expr_node = self.tracker.guard_tree_expr_node()
+            len_guard = paddle.framework.core.GuardNode(
+                paddle.framework.core.LengthMatchGuard(len(self.value)),
+                [expr_node],
+            )
+
+            guards: list[paddle.framework.core.GuardNode] = [len_guard]
+            for idx, layer in enumerate(self.value):
+                layer_variable = VariableFactory.from_value(
+                    layer, self.graph, GetItemTracker(self, idx)
+                )
+                guards.extend(layer_variable.make_faster_guard())
+            return guards
+        else:
+            return super().make_faster_guard()
 
     @property
     def main_info(self) -> dict[str, Any]:

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/callable.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/callable.py
@@ -536,9 +536,13 @@ class LayerVariable(CallableVariable):
 
     @check_faster_guard
     def make_faster_guard(self) -> list[paddle.framework.core.GuardNode]:
-        raise NotImplementedError(
-            f"{self.__class__.__name__}.make_faster_guard is not implemented"
-        )
+        expr_node = self.tracker.guard_tree_expr_node()
+        return [
+            paddle.framework.core.GuardNode(
+                paddle.framework.core.LayerMatchGuard(self.get_py_value()),
+                [expr_node],
+            )
+        ]
 
 
 class ContainerLayerVariable(LayerVariable):
@@ -664,9 +668,13 @@ class PaddleLayerVariable(LayerVariable):
 
     @check_faster_guard
     def make_faster_guard(self) -> list[paddle.framework.core.GuardNode]:
-        raise NotImplementedError(
-            f"{self.__class__.__name__}.make_faster_guard is not implemented"
-        )
+        if isinstance(self.tracker, CreateLayerTracker):
+            return reduce(
+                operator.add,
+                [var.make_faster_guard() for var in self.tracker.inputs],
+            )
+        else:
+            return super().make_faster_guard()
 
     @property
     def main_info(self) -> dict[str, Any]:

--- a/test/sot/test_15_slice.py
+++ b/test/sot/test_15_slice.py
@@ -144,5 +144,17 @@ class TestStringSlice(TestCaseBase):
         self.assert_results(string_slice, x)
 
 
+@check_no_breakgraph
+def tensor_slice_as_input(x: slice):
+    tensor = paddle.to_tensor([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+    return tensor[x]
+
+
+class TestSliceAsInput(TestCaseBase):
+    def test_slice_as_input(self):
+        x = slice(2, 7, 2)
+        self.assert_results(tensor_slice_as_input, x)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/sot/test_instruction_translator_cache.py
+++ b/test/sot/test_instruction_translator_cache.py
@@ -90,6 +90,8 @@ class GuardCode:
         self.func = lambda frame: recompile
         self.mirror_guard = self.func
         self.expr = f"lambda frame: {recompile}"
+        self.inlined_expr = f"lambda frame: {recompile}"
+        self.__globals__ = {}
 
     def __call__(self, *args, **kwargs):
         return self.func(*args, **kwargs)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Performance

### Description
<!-- Describe what you’ve done -->
当 STRICT_GUARD 没开启且GUARD_TREE开启时，如果guard tree没有命中，也就是cache_index为None之前会再找一次，fasterguard（pyguard），本PR把这个逻辑去掉了，guard tree没有命中则直接视为guard miss，不会再去其他guard模式找。

另外实现了下述make_faster_guard：
- ContainerVariable.make_faster_guard
- object_equal_faster_guard
- LayerVariable.make_faster_guard
- PaddleLayerVariable.make_faster_guard
- ContainerLayerVariable.make_faster_guard
- DygraphTracerVariable.make_faster_guard
- NumpyNumberVariable.make_faster_guard
- NumpyArrayVariable.make_faster_guard
- SliceVariable.make_faster_guard

目前还差2个：
- ~NumpyVariable，这个的 make_stringified_guard 也没有实现~
- SymbolicVariable