### PR TITLE
[XPU] adapt to new interface for normal

### DIFF
--- a/cmake/external/xpu.cmake
+++ b/cmake/external/xpu.cmake
@@ -30,7 +30,7 @@ set(XPU_XFA_LIB_NAME "libxpu_flash_attention.so")
 set(XPU_XPUDNN_LIB_NAME "libxpu_dnn.so")
 
 if(NOT DEFINED XPU_XHPC_BASE_DATE)
-  set(XPU_XHPC_BASE_DATE "dev/20250405")
+  set(XPU_XHPC_BASE_DATE "dev/20250412")
 endif()
 set(XPU_XCCL_BASE_VERSION "3.0.2.5") # For XRE5
 if(NOT DEFINED XPU_XFT_BASE_VERSION)

--- a/paddle/phi/kernels/xpu/gaussian_kernel.cc
+++ b/paddle/phi/kernels/xpu/gaussian_kernel.cc
@@ -39,12 +39,12 @@ void GaussianKernel(const Context& ctx,
   int64_t real_seed = seed != 0 ? seed : ctx.GetGenerator()->Random64();
 
   // int normal(Context* ctx, T* x, T mean, T std, int64_t len, int64_t seed);
-  int r = xpu::normal<XPUType>(ctx.x_context(),
-                               reinterpret_cast<XPUType*>(data),
-                               mean,
-                               std,
-                               out->numel(),
-                               real_seed);
+  int r = xpu::normal_<XPUType>(ctx.x_context(),
+                                reinterpret_cast<XPUType*>(data),
+                                mean,
+                                std,
+                                out->numel(),
+                                real_seed);
   PADDLE_ENFORCE_XDNN_SUCCESS(r, "normal");
 }
 

--- a/test/xpu/get_test_cover_info.py
+++ b/test/xpu/get_test_cover_info.py
@@ -366,8 +366,11 @@ def check_run_big_shape_test():
 @contextlib.contextmanager
 def xpu_matmul_quant_type_guard(dtype):
     # only fp32 is supported now
-    assert dtype == "float"
-    env_name = "XPU_PADDLE_FC_FLOAT"
+    assert dtype in ["float", "int16"]
+    if dtype == "float":
+        env_name = "XPU_PADDLE_FC_FLOAT"
+    elif dtype == "int16":
+        env_name = "XPU_PADDLE_FC_INT16"
     origin_env = os.getenv(env_name)
     os.environ[env_name] = "1"
     yield

--- a/test/xpu/test_fused_resnet_basic_block_op_xpu.py
+++ b/test/xpu/test_fused_resnet_basic_block_op_xpu.py
@@ -65,6 +65,7 @@ class XPUTestResNetBasicBlockOp(XPUOpTestWrapper):
             self.has_shortcut = False
 
         def Base(self):
+            # NOTE(lijin23): Because the fused_resnet_basic_block uses int16, we force the reference to use int16 too.
             with xpu_matmul_quant_type_guard("int16"):
                 conv1_weight = base.ParamAttr(
                     initializer=paddle.nn.initializer.XavierNormal(),

--- a/test/xpu/test_fused_resnet_basic_block_op_xpu.py
+++ b/test/xpu/test_fused_resnet_basic_block_op_xpu.py
@@ -65,7 +65,7 @@ class XPUTestResNetBasicBlockOp(XPUOpTestWrapper):
             self.has_shortcut = False
 
         def Base(self):
-            with xpu_matmul_quant_type_guard("float"):
+            with xpu_matmul_quant_type_guard("int16"):
                 conv1_weight = base.ParamAttr(
                     initializer=paddle.nn.initializer.XavierNormal(),
                     learning_rate=0.001,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Custom Device

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
normal kernel uses `xpu::normal_` , which is the nv-like version of XPU.