### PR TITLE
[BIT] fix unexpected inplace squeeze_ in paddle.signal.istft

### DIFF
--- a/python/paddle/signal.py
+++ b/python/paddle/signal.py
@@ -654,6 +654,6 @@ def istft(
     out = out / window_envelop
 
     if x_rank == 2:
-        out.squeeze_(0)
+        out = paddle.squeeze(out, axis=0)
 
     return out


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Operator Mechanism


### PR Types
Bug fixes

### Description
replace `out.squeeze_(0)` by `out = paddle.squeeze(out, axis=0)` in non-inplace operator `paddle.signal.istft`