### PR TITLE
[Dy2St] Use PHI backend in `jit.save` and use `backend_guard` when capture graph

### DIFF
--- a/python/paddle/jit/api.py
+++ b/python/paddle/jit/api.py
@@ -357,7 +357,7 @@ class _NotToStaticDecorator(Protocol):
 
 @overload
 def not_to_static(
-    func: Callable[_InputT, _RetT]
+    func: Callable[_InputT, _RetT],
 ) -> Callable[_InputT, _RetT]: ...
 
 
@@ -1236,6 +1236,7 @@ def save(
                     inner_layer.forward,
                     input_spec=inner_input_spec,
                     full_graph=True,
+                    backend=None,
                 )
 
                 concrete_program = (
@@ -1275,6 +1276,7 @@ def save(
                     static_func,
                     input_spec=inner_input_spec,
                     full_graph=True,
+                    backend=None,
                 )
                 concrete_program = static_function.concrete_program
 

--- a/python/paddle/jit/dy2static/program_translator.py
+++ b/python/paddle/jit/dy2static/program_translator.py
@@ -1246,6 +1246,7 @@ class ConcreteProgram:
             func_spec(FunctionSpec): A FunctionSpec instance for decorated function.
             input_spec(list[InputSpec]):
         """
+        backend = kwargs["backend"]
         # verify the instance is initialized in imperative mode.
         _verify_init_in_dynamic_mode(class_instance)
 
@@ -1294,7 +1295,11 @@ class ConcreteProgram:
                 # 2. Builds program only once and returns the output Variables.
                 with param_guard(
                     get_parameters(class_instance, True)
-                ), param_guard(get_buffers(class_instance, True)):
+                ), param_guard(
+                    get_buffers(class_instance, True)
+                ), backend_guard(
+                    backend
+                ):
                     try:
                         # only for jit.save, do nothing while train and eval process
                         inputs = hook_helper.apply_pre_hooks(static_inputs)

--- a/test/dygraph_to_static/test_gradname_parse.py
+++ b/test/dygraph_to_static/test_gradname_parse.py
@@ -18,7 +18,6 @@ import unittest
 import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
-    test_phi_only,
 )
 
 import paddle
@@ -45,8 +44,6 @@ class SimpleNet(paddle.nn.Layer):
 
 
 class TestGradNameParse(Dy2StTestBase):
-    # TODO(SigureMo): Fix this CINN case, it will raise segmentation fault
-    @test_phi_only
     def test_grad_name_parse(self):
         net = SimpleNet()
         opt = paddle.optimizer.Adam(

--- a/test/dygraph_to_static/test_ifelse.py
+++ b/test/dygraph_to_static/test_ifelse.py
@@ -23,7 +23,6 @@ from dygraph_to_static_utils import (
     disable_test_case,
     enable_to_static_guard,
     test_ast_only,
-    test_phi_only,
     test_pir_only,
 )
 from ifelse_simple_func import (
@@ -333,10 +332,10 @@ class TestDygraphIfElseNet(Dy2StTestBase):
             ret = net(x_v)
             return ret.numpy()
 
-    # TODO(SigureMo): Fix this CINN case, it will raise precision error
-    @test_phi_only
     def test_ast_to_func(self):
-        np.testing.assert_allclose(self._run_dygraph(), self._run_static())
+        np.testing.assert_allclose(
+            self._run_dygraph(), self._run_static(), rtol=1e-6, atol=1e-8
+        )
 
 
 # Test to call function ahead caller.


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

在前向组网过程中使用 `backend_guard` 以确保高阶微分场景前向组网中调用的 `paddle.grad` 也能走拆解逻辑

为避免默认情况 `backend="CINN"` 会对导出造成影响，在 `jit.save` 显式设置 `backend=None`

另外调整了下 `test_ifelse` tolerance，稍微放宽了下

<!-- PCard-66972 -->