### PR TITLE
[Prim] Fix `subtract_double_grad` bug

### DIFF
--- a/test/prim/prim/vjp/test_comp_high_grad.py
+++ b/test/prim/prim/vjp/test_comp_high_grad.py
@@ -164,7 +164,21 @@ class TestSubtractHighGradCheck(unittest.TestCase):
     def subtract_wrapper(self, x):
         return paddle.subtract(x[0], x[1])
 
-    @prog_scope()
+    def test_func_double_eager(self):
+        shape1 = self.shape1
+        shape2 = self.shape2
+        dtype = np.float64
+        x = paddle.randn(shape1, dtype=dtype)
+        x.stop_gradient = False
+        y = paddle.randn(shape2, dtype=dtype)
+        y.stop_gradient = False
+        out = paddle.subtract(x, y)
+        dout = paddle.randn(out.shape)
+        dout.stop_gradient = False
+        dy = paddle.grad([out], [y], dout, create_graph=True)[0]
+        ddout = paddle.grad(dy, dout)[0]
+        np.testing.assert_allclose(ddout.numpy(), np.full(ddout.shape, -1.0))
+
     def func_double(self, place):
         shape1 = self.shape1
         shape2 = self.shape2


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

Pcard-75624

#63697 引入了broadcast分支下的一个BUG，因此修复动态图组合算子`subtract_double_grad`部分分支结果缺少负号导致结果错误的问题