### PR TITLE
[Prim] Support `gather_double_grad` and `scatter_double_grad`

### DIFF
--- a/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
@@ -91,6 +91,7 @@ prim_white_list = [
     "take_along_axis_double_grad",
     "index_add_double_grad",
     "acos_double_grad",
+    "scatter_double_grad",
 ]
 
 # white ops list whose kernel can automatically do type promotion.

--- a/paddle/fluid/pir/dialect/op_generator/vjp_interface_black_list.py
+++ b/paddle/fluid/pir/dialect/op_generator/vjp_interface_black_list.py
@@ -38,4 +38,5 @@ vjp_interface_black_list = [
     'take_along_axis_grad',
     'index_add_grad',
     'acos_grad',
+    'scatter_grad',
 ]

--- a/paddle/fluid/prim/api/composite_backward/composite_backward_api.h
+++ b/paddle/fluid/prim/api/composite_backward/composite_backward_api.h
@@ -147,57 +147,6 @@ void cast_grad(const Tensor& x, const Tensor& out_grad, Tensor* x_grad) {
 }
 
 template <typename T>
-void gather_grad(const Tensor& x,
-                 const Tensor& index,
-                 const Tensor& out_grad,
-                 const Scalar& axis,
-                 Tensor* grad_x) {
-  auto zero_tensor =
-      full<T>(common::vectorize(x.dims()), 0.0, x.dtype(), x.place());
-  std::vector<int> tmp_perm;
-
-  // change axis to rank 0
-  int axis_value = axis.to<int>();
-  int rank = x.dims().size();
-  if (axis_value < 0) {
-    axis_value += rank;
-  }
-  tmp_perm.push_back(axis_value);
-  // make other ranks
-  for (int i = 0; i < rank; ++i) {
-    if (i != axis_value) {
-      tmp_perm.push_back(i);
-    }
-  }
-  std::vector<int> reverse_perm(tmp_perm);
-  // make origin ranks
-  for (int i = 0; i < static_cast<int>(tmp_perm.size()); ++i) {
-    if (tmp_perm[i] >= 0) {
-      reverse_perm[tmp_perm[i]] = i;
-    } else {
-      reverse_perm[tmp_perm[i] + tmp_perm.size()] = i;
-    }
-  }
-
-  // transpose out_grad and zero grad to target rank.
-  auto tmp_zero_x_grad = zero_tensor;
-  auto tmp_out_grad = out_grad;
-  if (zero_tensor.dims().size() > 0) {
-    tmp_zero_x_grad = transpose<T>(zero_tensor, tmp_perm);
-  }
-  if (out_grad.dims().size() > 0) {
-    tmp_out_grad = transpose<T>(out_grad, tmp_perm);
-  }
-  // scatter grad to grad_x
-  auto tmp_grad_x = scatter<T>(tmp_zero_x_grad, index, tmp_out_grad, false);
-  auto tmp_grad_x_transposed = tmp_grad_x;
-  if (tmp_grad_x.dims().size() > 0) {
-    tmp_grad_x_transposed = transpose<T>(tmp_grad_x, reverse_perm);
-  }
-  set_output<T>(tmp_grad_x_transposed, grad_x);
-}
-
-template <typename T>
 void tanh_grad(const Tensor& out, const Tensor& grad_out, Tensor* grad_x) {
   if (!grad_x) return;
   auto grad_x_tmp = grad_out * (1 - out * out);
@@ -1533,44 +1482,6 @@ template <typename T>
 void cos_grad(const Tensor& x, const Tensor& out_grad, Tensor* x_grad) {
   auto x_grad_tmp = -sin<T>(x) * out_grad;
   set_output<T>(x_grad_tmp, x_grad);
-}
-
-template <typename T>
-void scatter_grad(const Tensor& index,
-                  const Tensor& updates,
-                  const Tensor& out_grad,
-                  bool overwrite,
-                  Tensor* x_grad,
-                  Tensor* updates_grad) {
-  if (x_grad) {
-    auto zero_tensor = full<T>(common::vectorize(updates.dims()),
-                               0.0,
-                               updates.dtype(),
-                               updates.place());
-    auto tmp_grad = scatter<T>(out_grad, index, zero_tensor, false);
-    set_output<T>(tmp_grad, x_grad);
-  }
-
-  if (updates_grad) {
-    Scalar tmp_zero = 0;
-    auto tmp_updates_grad = gather<T>(out_grad, index, tmp_zero);
-
-    // NOTE: len(index) can be smaller than len(updates) when updates is not a
-    // scalar
-    auto updates_dims = common::vectorize(updates.dims());
-    auto index_dims = common::vectorize(index.dims());
-    if (updates_dims.size() > 0 && updates_dims[0] > index_dims[0]) {
-      // Pad zeros to the end of tmp_updates_grad to make its shape the same as
-      // updates.
-      decltype(updates_dims) padding_dims = updates_dims;
-      padding_dims[0] = updates_dims[0] - index_dims[0];
-      auto padding_zeros =
-          full<T>(padding_dims, 0, updates.dtype(), updates.place());
-      tmp_updates_grad =
-          concat<T>({tmp_updates_grad, std::move(padding_zeros)}, 0);
-    }
-    set_output<T>(tmp_updates_grad, updates_grad);
-  }
 }
 
 template <typename T>

--- a/paddle/fluid/prim/api/composite_backward/composite_double_backward_api.h
+++ b/paddle/fluid/prim/api/composite_backward/composite_double_backward_api.h
@@ -681,8 +681,13 @@ void scatter_double_grad(const Tensor& index,
       set_output<T>(ddy, grad_out_grad);
     } else if (grad_x_grad) {
       // only ddx
-      // ddy = ddx
-      by_pass<T>(grad_x_grad.get(), grad_out_grad);
+      // ddy = 0 + ddx
+      Tensor zero = full<T>(common::vectorize(out_grad.dims()),
+                            0,
+                            out_grad.dtype(),
+                            out_grad.place());
+      auto ddy = scatter<T>(grad_x_grad.get(), index, zero, true);
+      set_output<T>(ddy, grad_out_grad);
     } else if (grad_updates_grad) {
       // only ddv
       // ddy = scatter(0, index, ddv, overwrite)

--- a/paddle/fluid/prim/api/composite_backward/composite_double_backward_api.h
+++ b/paddle/fluid/prim/api/composite_backward/composite_double_backward_api.h
@@ -665,6 +665,38 @@ void silu_double_grad(const Tensor& x,
 }
 
 template <typename T>
+void scatter_double_grad(const Tensor& index,
+                         const Tensor& updates,
+                         const Tensor& out_grad,
+                         const paddle::optional<Tensor>& grad_x_grad,
+                         const paddle::optional<Tensor>& grad_updates_grad,
+                         bool overwrite,
+                         Tensor* grad_out_grad) {
+  if (grad_out_grad) {
+    if (grad_x_grad && grad_updates_grad) {
+      // ddx && ddv
+      // ddy = scatter(ddx, index, ddv, overwrite)
+      auto ddy = scatter<T>(
+          grad_x_grad.get(), index, grad_updates_grad.get(), overwrite);
+      set_output<T>(ddy, grad_out_grad);
+    } else if (grad_x_grad) {
+      // only ddx
+      // ddy = ddx
+      by_pass<T>(grad_x_grad.get(), grad_out_grad);
+    } else if (grad_updates_grad) {
+      // only ddv
+      // ddy = scatter(0, index, ddv, overwrite)
+      Tensor zero = full<T>(common::vectorize(out_grad.dims()),
+                            0,
+                            out_grad.dtype(),
+                            out_grad.place());
+      auto ddy = scatter<T>(zero, index, grad_updates_grad.get(), overwrite);
+      set_output<T>(ddy, grad_out_grad);
+    }
+  }
+}
+
+template <typename T>
 void multiply_double_grad(const Tensor& x,
                           const Tensor& y,
                           const Tensor& grad_out,

--- a/paddle/phi/ops/yaml/backward.yaml
+++ b/paddle/phi/ops/yaml/backward.yaml
@@ -1352,6 +1352,12 @@
   kernel :
     func : gammaln_grad
 
+- backward_op : gather_double_grad
+  forward : gather_grad(Tensor x, Tensor index, Tensor grad_out, Scalar axis) -> Tensor(grad_x)
+  args : (Tensor index, Tensor grad_x_grad, Scalar axis)
+  output : Tensor(grad_out_grad)
+  invoke: gather(grad_x_grad, index, axis)
+
 - backward_op : gather_grad
   forward : gather(Tensor x, Tensor index, Scalar axis=0) -> Tensor(out)
   args : (Tensor x, Tensor index, Tensor out_grad, Scalar axis=0)
@@ -1362,8 +1368,8 @@
   kernel :
     data_type: out_grad
     func : gather_grad
-  composite : gather_grad(x, index, out_grad, axis, x_grad)
   no_need_buffer : x
+  backward : gather_double_grad
 
 - backward_op : gather_nd_double_grad
   forward : gather_nd_grad (Tensor x, Tensor index, Tensor grad_out) -> Tensor(grad_x)
@@ -2820,6 +2826,17 @@
   output : Tensor(x_grad)
   invoke : scale(out_grad, scale, 0.0f, true)
 
+- backward_op : scatter_double_grad
+  forward : scatter_grad (Tensor index, Tensor updates, Tensor grad_out, bool overwrite) -> Tensor(grad_x), Tensor(grad_updates)
+  args : (Tensor index, Tensor updates, Tensor grad_out, Tensor grad_x_grad, Tensor grad_updates_grad, bool overwrite)
+  output : Tensor(grad_out_grad)
+  infer_meta :
+    func : UnchangedInferMeta
+    param : [grad_out]
+  no_need_buffer : updates, grad_out
+  composite: scatter_double_grad(index, updates, grad_out, grad_x_grad, grad_updates_grad, overwrite, grad_out_grad)
+  optional: grad_x_grad, grad_updates_grad
+
 - backward_op : scatter_grad
   forward : scatter (Tensor x, Tensor index, Tensor updates, bool overwrite=true) -> Tensor(out)
   args : (Tensor index, Tensor updates, Tensor out_grad, bool overwrite)
@@ -2831,7 +2848,8 @@
   kernel :
     func : scatter_grad
   no_need_buffer : updates
-  composite: scatter_grad(index, updates, out_grad, overwrite, x_grad, updates_grad)
+  backward : scatter_double_grad
+  # composite: scatter_grad(index, updates, out_grad, overwrite, x_grad, updates_grad)
 
 - backward_op : scatter_nd_add_grad
   forward : scatter_nd_add (Tensor x, Tensor index, Tensor updates) -> Tensor(out)

--- a/paddle/phi/ops/yaml/backward.yaml
+++ b/paddle/phi/ops/yaml/backward.yaml
@@ -2849,7 +2849,6 @@
     func : scatter_grad
   no_need_buffer : updates
   backward : scatter_double_grad
-  # composite: scatter_grad(index, updates, out_grad, overwrite, x_grad, updates_grad)
 
 - backward_op : scatter_nd_add_grad
   forward : scatter_nd_add (Tensor x, Tensor index, Tensor updates) -> Tensor(out)

--- a/paddle/phi/ops/yaml/op_compat.yaml
+++ b/paddle/phi/ops/yaml/op_compat.yaml
@@ -1810,7 +1810,7 @@
     out : Out
 
 - op : gather
-  backward : gather_grad
+  backward : gather_grad, gather_double_grad
   inputs :
     {x : X, index : Index}
   outputs :
@@ -3291,7 +3291,7 @@
     attrs : [bool use_mkldnn = false, str mkldnn_data_type = "float32"]
 
 - op : scatter
-  backward : scatter_grad
+  backward : scatter_grad, scatter_double_grad
   inputs :
     {x : X, index : Ids, updates : Updates}
   outputs :

--- a/test/legacy_test/test_gather_op.py
+++ b/test/legacy_test/test_gather_op.py
@@ -46,7 +46,7 @@ class TestGatherOp(OpTest):
 
     def test_check_grad(self):
         self.check_grad(
-            ['X'], 'Out', check_prim=True, check_pir=True, check_prim_pir=True
+            ['X'], 'Out', check_prim=False, check_pir=True, check_prim_pir=True
         )
 
     def config(self):
@@ -131,7 +131,7 @@ class TestGatherOpBFP16(TestGatherOp):
             paddle.CUDAPlace(0),
             ['X'],
             'Out',
-            check_prim=True,
+            check_prim=False,
             check_pir=True,
             check_prim_pir=True,
         )
@@ -703,7 +703,7 @@ class TestGatherOp5(TestGatherOp):
             ['X'],
             'Out',
             check_pir=True,
-            check_prim=True,
+            check_prim=False,
             check_prim_pir=True,
         )
 

--- a/test/legacy_test/test_scatter_op.py
+++ b/test/legacy_test/test_scatter_op.py
@@ -670,7 +670,7 @@ class TestScatterOp6(OpTest):
         self.check_grad(
             ["X", "Updates"],
             "Out",
-            check_prim=True,
+            check_prim=False,
             check_pir=True,
             check_prim_pir=True,
         )

--- a/test/legacy_test/test_scatter_op.py
+++ b/test/legacy_test/test_scatter_op.py
@@ -72,7 +72,7 @@ class TestScatterOp(OpTest):
         self.check_grad(
             ["X", "Updates"],
             "Out",
-            check_prim=True,
+            check_prim=False,
             check_pir=True,
             check_prim_pir=True,
             max_relative_error=0.008,
@@ -108,7 +108,7 @@ class TestScatterBF16Op(TestScatterOp):
                 place,
                 ['X', 'Updates'],
                 'Out',
-                check_prim=True,
+                check_prim=False,
                 check_pir=True,
                 check_prim_pir=True,
             )
@@ -149,7 +149,7 @@ class TestScatterOp0(OpTest):
         self.check_grad(
             ["X", "Updates"],
             "Out",
-            check_prim=True,
+            check_prim=False,
             check_pir=True,
             check_prim_pir=True,
         )
@@ -184,7 +184,7 @@ class TestScatterBF16Op0(TestScatterOp0):
                 place,
                 ['X', 'Updates'],
                 'Out',
-                check_prim=True,
+                check_prim=False,
                 check_pir=True,
                 check_prim_pir=True,
             )
@@ -228,7 +228,7 @@ class TestScatterOp1(OpTest):
         self.check_grad(
             ["X", "Updates"],
             "Out",
-            check_prim=True,
+            check_prim=False,
             check_pir=True,
             check_prim_pir=True,
         )
@@ -338,7 +338,7 @@ class TestScatterBF16Op1(TestScatterOp1):
                 place,
                 ['X', 'Updates'],
                 'Out',
-                check_prim=True,
+                check_prim=False,
                 check_pir=True,
                 check_prim_pir=True,
             )
@@ -388,7 +388,7 @@ class TestScatterOp2(OpTest):
                 place,
                 ['X', 'Updates'],
                 'Out',
-                check_prim=True,
+                check_prim=False,
                 check_pir=True,
                 check_prim_pir=True,
             )
@@ -463,7 +463,7 @@ class TestScatterOp3(OpTest):
                 place,
                 ['X', 'Updates'],
                 'Out',
-                check_prim=True,
+                check_prim=False,
                 check_pir=True,
                 check_prim_pir=True,
             )
@@ -524,7 +524,7 @@ class TestScatterOp4(OpTest):
         self.check_grad(
             ['X', 'Updates'],
             'Out',
-            check_prim=True,
+            check_prim=False,
             check_pir=True,
             check_prim_pir=True,
         )
@@ -559,7 +559,7 @@ class TestScatterBF16Op4(TestScatterOp4):
                 place,
                 ['X', 'Updates'],
                 'Out',
-                check_prim=True,
+                check_prim=False,
                 check_pir=True,
                 check_prim_pir=True,
             )
@@ -609,7 +609,7 @@ class TestScatterOp5(OpTest):
                 place,
                 ['X', 'Updates'],
                 'Out',
-                check_prim=True,
+                check_prim=False,
                 check_pir=True,
                 check_prim_pir=True,
             )
@@ -705,7 +705,7 @@ class TestScatterBF16Op6(TestScatterOp6):
                 place,
                 ['X', 'Updates'],
                 'Out',
-                check_prim=True,
+                check_prim=False,
                 check_pir=True,
                 check_prim_pir=True,
             )


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->

Pcard-75624

通过复用前向算子，动态图下支持`gather_double_grad` and `scatter_double_grad`，从而支持这两个算子的无限阶微分；同时移除了`gather_grad`和`scatter_grad`两个动态图组合算子，并关闭对应单测

推导公式如下

### `gather_double_grad`
0阶（前向）：y[k] = x[index[k]] 

1阶：dx[index[k]] = \sum dy[k] 
1阶：dx[q] = 0, q not in index

2阶：ddy[k] = ddx[index[k]]

### `scatter_double_grad`

1. 当`overwrite=True`时，x元素保留，但updates的行为为覆盖模式（出现重复覆盖时，理论上保留最后一次的覆盖结果，但实际CUDA并行计算可能存在随机性）
  
    0阶（前向）：y[index[k]] = v[k]
    0阶（前向）：y[q] = x[q], q not in index
    
    1阶：`dv[k] = dy[index[k]]`(index[k]有重复时，结果可能存在随机性)
    1阶：dx[q] = dy[q], q not in index, else 0
    
    2阶：ddy[index[k]] = ddv[k]
    2阶：ddy[q] = ddx[q], q not in index, else 0
    
    综上，当`overwrite=True`时，`ddy = scatter(maybe_zero(ddx), maybe_zero(ddv), index, overwrite=True)`

2. 当`overwrite=False`时，x元素中，被index覆盖的位置视为全0，updates的行为为累加模式，结果不存在随机性

    0阶（前向）：y[index[k]] = \sum v[k]
    0阶（前向）：y[q] = x[q], q not in index
    
    1阶：`dv[k] = dy[index[k]]`(index[k]有重复时，结果可能存在随机性)
    1阶：dx[q] = dy[q]，q not in index, else 0
    
    2阶：ddy[index[k]] = \sum ddv[k]
    2阶：ddy[q] = ddx[q], q not in index, else 0
    
    综上，当`overwrite=False`时，`ddy = scatter(ddx, ddv, index, overwrite=False)`


综上两种情况，`ddy = scatter(maybe_zero(ddx), maybe_zero(ddv), index, overwrite=overwrite)`


### 精度验证代码

<details><summary>scatter_double_grad</summary>
<p>

```py
def scatter_double_grad_check():
    # paddle.framework.core.set_prim_eager_enabled(True)

    x = paddle.randn([1024, 1024])
    x.stop_gradient = False
    index = paddle.randint(0, 1024, [1024])
    updates = paddle.randn([1024, 1024])
    updates.stop_gradient = False

    out = paddle.scatter(x, index, updates, overwrite=False)

    dout = paddle.randn(out.shape)
    dout.stop_gradient = False
    dx = paddle.grad(out, x, dout, create_graph=True)[0]
    dv = paddle.grad(out, updates, dout, create_graph=True)[0]

    ddx = paddle.randn(x.shape)
    ddv = paddle.randn(updates.shape)
    ddy = paddle.grad([dx], dout, [ddx])[0]
    # print('ddx', ddx.numpy())
    # print('paddle ddy', ddy.numpy())

    import torch
    x = torch.from_dlpack(x.detach())
    x.requires_grad = True
    index = torch.from_dlpack(index.detach())
    index = index.expand([index.shape[0], index.shape[0]]).T

    updates = torch.from_dlpack(updates.detach())
    updates.requires_grad = True

    out_ = torch.scatter_reduce(x, 0, index, updates, reduce='sum', include_self=False)
    dout = torch.from_dlpack(dout.detach())
    dout.requires_grad = True
    dx_ = torch.autograd.grad(out_, x, dout, create_graph=True)[0]
    dv_ = torch.autograd.grad(out_, updates, dout, create_graph=True)[0]

    ddx = torch.from_dlpack(ddx.detach())
    ddv = torch.from_dlpack(ddv.detach())
    ddy_ = torch.autograd.grad([dx_], dout, [ddx], create_graph=True)[0]
    # print('torch  ddy', ddy_.detach().cpu().numpy())

    np.testing.assert_allclose(out.numpy(), out_.detach().cpu().numpy(), 1e-6, 1e-6)
    np.testing.assert_allclose(dx.numpy(), dx_.detach().cpu().numpy(), 1e-6, 1e-6)
    np.testing.assert_allclose(dv.numpy(), dv_.detach().cpu().numpy(), 1e-6, 1e-6)
    np.testing.assert_allclose(ddy.numpy(), ddy_.detach().cpu().numpy(), 1e-6, 1e-6)

scatter_double_grad_check()

```

</p>
</details> 


<details><summary>gather_double_grad</summary>
<p>

```py
def gather_double_grad_check():
    x = paddle.randn([100, 100])
    x.stop_gradient = False
    index = paddle.randint(0, 100, [100])

    out = paddle.gather(x, index, axis=-1)

    dout = paddle.randn(out.shape)
    dout.stop_gradient = False
    dx = paddle.grad(out, x, dout, create_graph=True)[0]

    ddx = paddle.randn(x.shape)
    ddy = paddle.grad([dx], dout, [ddx])[0]

    import torch
    x = torch.from_dlpack(x.detach())
    x.requires_grad = True
    index = torch.from_dlpack(index.detach())

    out = torch.index_select(x, -1, index)
    dout = torch.from_dlpack(dout.detach())
    dout.requires_grad = True
    dx_ = torch.autograd.grad(out, x, dout, create_graph=True)[0]

    ddx = torch.from_dlpack(ddx.detach())
    ddy_ = torch.autograd.grad(dx_, dout, ddx, create_graph=True)[0]

    np.testing.assert_allclose(dx.numpy(), dx_.detach().cpu().numpy(), 1e-6 ,1e-6)
    np.testing.assert_allclose(ddy.numpy(), ddy_.detach().cpu().numpy(), 1e-6 ,1e-6)


gather_double_grad_check()
```

</p>
</details> 