### PR TITLE
[CINN]Add Type Support for Sigmoid and LogicalNot

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/pd_to_cinn_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/pd_to_cinn_pass.cc
@@ -1254,6 +1254,7 @@ class SigmoidOpPattern
             .dyn_cast<paddle::dialect::DenseTensorType>()
             .dtype());
 
+    auto one_type = input_dtype;
     auto in = op->operand_source(0);
     bool need_cast = (input_dtype == phi::DataType::FLOAT16 ||
                       input_dtype == phi::DataType::BFLOAT16 ||
@@ -1261,12 +1262,13 @@ class SigmoidOpPattern
     if (need_cast) {
       in = rewriter.Build<paddle::dialect::CastOp>(in, phi::DataType::FLOAT32)
                .result(0);
+      one_type = phi::DataType::FLOAT32;
     }
 
     // 1 / ( 1 + exp(-x))
     auto one = rewriter
                    .Build<paddle::dialect::FullOp>(
-                       std::vector<int64_t>({1}), 1.0, phi::DataType::FLOAT32)
+                       std::vector<int64_t>({1}), 1.0, one_type)
                    .result(0);
     auto minus_x =
         rewriter.Build<paddle::dialect::ScaleOp>(in, -1.0, 0.0).result(0);

--- a/paddle/cinn/lang/builtin.h
+++ b/paddle/cinn/lang/builtin.h
@@ -96,7 +96,7 @@ Expr Abs(Expr e);
 
 inline Expr Negative(Expr e) { return -e; }
 inline Expr Identity(Expr e) { return e; }
-inline Expr LogicalNot(Expr e) { return !e; }
+inline Expr LogicalNot(Expr e) { return !(ir::Cast::Make(common::Bool(), e)); }
 inline Expr BitwiseNot(Expr e) { return ~e; }
 inline Expr BitwiseAnd(Expr a, Expr b) { return a & b; }
 inline Expr BitwiseOr(Expr a, Expr b) { return a | b; }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
- Sigmoid(x) -> (1/1+exp(-x)),使1的类型与输入x匹配
- LogicalNot(x)->!(x) ===> LogicalNot(x)->!(bool(x))