### PR TITLE
【CPU】change Batch norm reserve_space dtype

### DIFF
--- a/paddle/phi/kernels/cpu/batch_norm_kernel.cc
+++ b/paddle/phi/kernels/cpu/batch_norm_kernel.cc
@@ -101,8 +101,8 @@ void BatchNormKernel(const Context& ctx,
         ctx.template Alloc<T>(saved_variance), C);
     saved_mean_e.setZero();
     saved_variance_e.setZero();
-    EigenVectorArrayMap<T> reserve_space_e(ctx.template Alloc<T>(reserve_space),
-                                           0);
+    EigenVectorArrayMap<uint8_t> reserve_space_e(
+        ctx.template Alloc<uint8_t>(reserve_space), 0);
     reserve_space_e.setZero();
 
     EigenVectorArrayMap<T> running_mean_arr(ctx.template Alloc<T>(mean_out), C);
@@ -222,4 +222,6 @@ void BatchNormKernel(const Context& ctx,
 }  // namespace phi
 
 PD_REGISTER_KERNEL(
-    batch_norm, CPU, ALL_LAYOUT, phi::BatchNormKernel, float, double) {}
+    batch_norm, CPU, ALL_LAYOUT, phi::BatchNormKernel, float, double) {
+  kernel->OutputAt(5).SetDataType(phi::DataType::UINT8);
+}

--- a/paddle/phi/kernels/xpu/batch_norm_kernel.cc
+++ b/paddle/phi/kernels/xpu/batch_norm_kernel.cc
@@ -98,7 +98,7 @@ void BatchNormKernel(const Context& dev_ctx,
   dev_ctx.template Alloc<float>(variance_out);
   dev_ctx.template Alloc<float>(saved_mean);
   dev_ctx.template Alloc<float>(saved_variance);
-
+  dev_ctx.template Alloc<uint8_t>(reserve_space);
   PADDLE_ENFORCE_LE(
       x_dims.size(),
       5,
@@ -164,4 +164,5 @@ PD_REGISTER_KERNEL(batch_norm,
   kernel->OutputAt(2).SetDataType(phi::DataType::FLOAT32);
   kernel->OutputAt(3).SetDataType(phi::DataType::FLOAT32);
   kernel->OutputAt(4).SetDataType(phi::DataType::FLOAT32);
+  kernel->OutputAt(5).SetDataType(phi::DataType::UINT8);
 }

--- a/paddle/phi/kernels/xpu/batch_norm_kernel.cc
+++ b/paddle/phi/kernels/xpu/batch_norm_kernel.cc
@@ -98,7 +98,6 @@ void BatchNormKernel(const Context& dev_ctx,
   dev_ctx.template Alloc<float>(variance_out);
   dev_ctx.template Alloc<float>(saved_mean);
   dev_ctx.template Alloc<float>(saved_variance);
-  dev_ctx.template Alloc<uint8_t>(reserve_space);
   PADDLE_ENFORCE_LE(
       x_dims.size(),
       5,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-67164

由于cpu/xpu kernel 没有对bacthnorm 的reserve_space 做正确的类型处理，导致传递的结果有误，在下一个cast kernel 中报类型不符的报错