### PR TITLE
Fix type promotion for op add

### DIFF
--- a/paddle/fluid/pir/dialect/operator/utils/utils.cc
+++ b/paddle/fluid/pir/dialect/operator/utils/utils.cc
@@ -612,6 +612,9 @@ bool CanGroupOpRunCpuKernel(const std::vector<::pir::Value>& vec_inputs,
     } else if (auto type_info =
                    tmp_in.type().dyn_cast<paddle::dialect::DenseTensorType>()) {
       in_dims = type_info.dims();
+      if (type_info.dtype().isa<::pir::BFloat16Type>()) {
+        return false;
+      }
     }
 
     // 1. dynamic shape not need lower x86

--- a/paddle/phi/common/type_promotion.h
+++ b/paddle/phi/common/type_promotion.h
@@ -205,23 +205,6 @@ inline bool NeedTypePromotion(
   // Tensor + Tensor type promotion only support calculations between
   // floating-point numbers and between complex and real numbers.
   if (x_dtype != y_dtype) {
-// TODO(Xi Zhao): we got special case for add now, should remove it in future.
-#ifdef PADDLE_WITH_CUDA
-    if ((op_name == "add" || op_name == "add_") &&
-        x_dtype == DataType::FLOAT32 &&
-        (y_dtype == phi::DataType::BFLOAT16 ||
-         y_dtype == phi::DataType::FLOAT16)) {
-      return false;
-    }
-#elif defined(PADDLE_WITH_XPU)
-    if ((op_name == "add" || op_name == "add_") &&
-        x_dtype == DataType::FLOAT32 &&
-        (y_dtype == phi::DataType::BFLOAT16 ||
-         y_dtype == phi::DataType::FLOAT16)) {
-      return false;
-    }
-#endif
-
     if ((is_support_float(x_dtype) && is_support_float(y_dtype)) ||
         (is_support_complex(x_dtype) || is_support_complex(y_dtype))) {
       return true;
@@ -244,19 +227,6 @@ inline bool NeedTypePromotionOldIr(const std::string& op_name,
   // Tensor + Tensor type promotion only support calculations between
   // floating-point numbers and between complex and real numbers.
   if (x != y) {
-// TODO(Xi Zhao): we got special case for add now, should remove it in future.
-#ifdef PADDLE_WITH_CUDA
-    if ((op_name == "add" || op_name == "add_") && x == DataType::FLOAT32 &&
-        (y == phi::DataType::BFLOAT16 || y == phi::DataType::FLOAT16)) {
-      return false;
-    }
-#elif defined(PADDLE_WITH_XPU)
-    if ((op_name == "add" || op_name == "add_") && x == DataType::FLOAT32 &&
-        (y == phi::DataType::BFLOAT16 || y == phi::DataType::FLOAT16)) {
-      return false;
-    }
-#endif
-
     if ((is_support_float(x) && is_support_float(y)) ||
         (is_support_complex(x) || is_support_complex(y))) {
       return true;

--- a/test/ir/pir/cinn/test_cinn_add_promotion.py
+++ b/test/ir/pir/cinn/test_cinn_add_promotion.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+import utils
+
+import paddle
+
+
+class TestAddPromotion(unittest.TestCase):
+    def setUp(self):
+        paddle.seed(2025)
+        self.prepare_info()
+
+    def prepare_info(self):
+        self.fn = paddle.add
+
+    def check_eval(self):
+        static_fn = utils.apply_to_static(self.fn, use_cinn=True)
+        cinn_out = static_fn(self.x, self.y)
+        dy_out = self.fn(self.x, self.y)
+        np.testing.assert_allclose(cinn_out.numpy(), dy_out.numpy(), atol=1e-8)
+
+    def test_bf16_fp32(self):
+        self.x = paddle.randn([3], dtype='bfloat16')
+        self.y = paddle.randn([3], dtype='float32')
+
+        self.check_eval()
+
+    def test_f16_fp32(self):
+        self.x = paddle.randn([3], dtype='float16')
+        self.y = paddle.randn([3], dtype='float32')
+
+        self.check_eval()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Fix error when add（bfloat16+float32）and（float16+float32）