### PR TITLE
[SOT][DynamicShape] Record `0` and `1` in symbolic dim count map

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
@@ -1247,9 +1247,6 @@ class SymbolicVariable(VariableBase):
         tracker: Tracker,
         symbolic_inputs: dict[str, dict[int, int] | None],
     ):
-        # The behavior specializes for 0 and 1, so we just ignore them here.
-        if value < 2:
-            return False
         tracker_expr = tracker.trace_value_from_frame().inlined_expr
         symbolic_inputs.setdefault(tracker_expr, {})
         if tracker_expr in symbolic_inputs:
@@ -1258,6 +1255,8 @@ class SymbolicVariable(VariableBase):
                 return False
             symbolic_input.setdefault(value, 0)
             symbolic_input[value] += 1
+            if value < 2:  # Specialize 0 and 1
+                return False
             if len(symbolic_input.keys()) > 1:
                 return True
             return False

--- a/test/sot/test_trace_list_arg.py
+++ b/test/sot/test_trace_list_arg.py
@@ -71,13 +71,13 @@ class TestTraceListArg(TestCaseBase):
             self.assert_results(bar, a, 2, 0)  # Cache miss
             self.assertEqual(cache.translate_count, 2)
             self.assert_results(bar, b, 2, 0)  # Cache hit
-            self.assertEqual(cache.translate_count, 2)
-            self.assert_results(bar, b, 2, 0)  # Cache hit
-            self.assertEqual(cache.translate_count, 2)
-            self.assert_results(bar, b, 1, 1)  # Cache hit
-            self.assertEqual(cache.translate_count, 2)
-            self.assert_results(bar, b, 0, 2)  # Cache miss
             self.assertEqual(cache.translate_count, 3)
+            self.assert_results(bar, b, 2, 0)  # Cache hit
+            self.assertEqual(cache.translate_count, 3)
+            self.assert_results(bar, b, 1, 1)  # Cache hit
+            self.assertEqual(cache.translate_count, 3)
+            self.assert_results(bar, b, 0, 2)  # Cache miss
+            self.assertEqual(cache.translate_count, 4)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Performance

### Description
<!-- Describe what you’ve done -->

0、1 特化后会导致动态 shape 触发变慢，比如

```
0 - static dim
1 - static dim
2 - static dim, start recored
3 - dynamic dim
```

因为 0 和 1 不会记录到 `symbolic_inputs` 里，因此仍然需要 2 这一个 step 启动，3 才会触发动态 shape

修改后由于 0、1 也会记录，因此到了 2 就可以触发动态 shape

暂时禁用掉 `int(sym)` 和 `float(sym)` 的 no break case，后续会考虑是否要支持

<!-- PCard-66972 -->