### PR TITLE
[Dy2St] Use `np.testing.assert_allclose` instead of equal check in dy2st uts

### DIFF
--- a/test/dygraph_to_static/test_ast_util.py
+++ b/test/dygraph_to_static/test_ast_util.py
@@ -66,7 +66,7 @@ class TestAST2Func(Dy2StTestBase):
             x_v = paddle.to_tensor(x_data)
             true_ret = func(x_v).numpy()
             test_ret = self._ast2func(func)(x_v).numpy()
-            self.assertTrue((true_ret == test_ret).all())
+            np.testing.assert_allclose(true_ret, test_ret)
 
     @test_ast_only
     @test_pir_only
@@ -85,7 +85,7 @@ class TestAST2Func(Dy2StTestBase):
                 test_ret = self._ast2func(func)(x_v)
                 exe = paddle.static.Executor(paddle.CPUPlace())
                 ret = exe.run(main_program, fetch_list=[true_ret, test_ret])
-                self.assertTrue((ret[0] == ret[1]).all())
+                np.testing.assert_allclose(ret[0], ret[1])
 
     @test_ast_only
     @test_pir_only

--- a/test/dygraph_to_static/test_dict.py
+++ b/test/dygraph_to_static/test_dict.py
@@ -139,7 +139,7 @@ class TestNetWithDict(Dy2StTestBase):
             return ret.numpy()
 
     def test_ast_to_func(self):
-        self.assertTrue((self._run_dygraph() == self._run_static()).all())
+        np.testing.assert_allclose(self._run_dygraph(), self._run_static())
 
 
 # Tests for dict pop
@@ -227,13 +227,7 @@ class TestDictPop3(TestNetWithDict):
             return ret.numpy()
 
     def test_ast_to_func(self):
-        dygraph_result = self._run_dygraph()
-        static_result = self._run_static()
-
-        self.assertTrue(
-            (dygraph_result == static_result).all(),
-            msg=f"dygraph result: {dygraph_result}\nstatic result: {static_result}",
-        )
+        np.testing.assert_allclose(self._run_dygraph(), self._run_static())
 
 
 class TestDictCmpInFor(Dy2StTestBase):

--- a/test/dygraph_to_static/test_lambda.py
+++ b/test/dygraph_to_static/test_lambda.py
@@ -99,23 +99,23 @@ class TestLambda(Dy2StTestBase):
 
     def test_call_lambda_as_func(self):
         fn = call_lambda_as_func
-        self.assertTrue((self.run_dygraph(fn) == self.run_static(fn)).all())
+        np.testing.assert_allclose(self.run_dygraph(fn), self.run_static(fn))
 
     def test_call_lambda_directly(self):
         fn = call_lambda_directly
-        self.assertTrue((self.run_dygraph(fn) == self.run_static(fn)).all())
+        np.testing.assert_allclose(self.run_dygraph(fn), self.run_static(fn))
 
     def test_call_lambda_in_func(self):
         fn = call_lambda_in_func
-        self.assertTrue((self.run_dygraph(fn) == self.run_static(fn)).all())
+        np.testing.assert_allclose(self.run_dygraph(fn), self.run_static(fn))
 
     def test_call_lambda_with_if_expr(self):
         fn = call_lambda_with_if_expr
-        self.assertTrue((self.run_dygraph(fn) == self.run_static(fn)).all())
+        np.testing.assert_allclose(self.run_dygraph(fn), self.run_static(fn))
 
     def test_call_lambda_with_if_expr2(self):
         fn = call_lambda_with_if_expr2
-        self.assertTrue((self.run_dygraph(fn) == self.run_static(fn)).all())
+        np.testing.assert_allclose(self.run_dygraph(fn), self.run_static(fn))
 
 
 if __name__ == '__main__':

--- a/test/dygraph_to_static/test_typing.py
+++ b/test/dygraph_to_static/test_typing.py
@@ -109,7 +109,7 @@ class TestTypingTuple(TestTyping):
 
     def run_dy(self):
         out, np_data = self.net(self.x)
-        self.assertTrue(np.equal(np_data, np.ones_like(np_data)).all())
+        np.testing.assert_allclose(np_data, np.ones_like(np_data))
         return out
 
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

使用 `np.testing.assert_allclose` 替代 `self.assertTrue((a == b).all())`，以避免过于严格的检查，并提供更加友好的报错提示，因为 CINN 下与动态图不能保证 kernel 一样，可能会有稍许合理的精度误差

<!-- PCard-66972 -->