### PR TITLE
[CINN] Fix crash in CheckTensorIsContinuous due to invalid as_var_ref…

### DIFF
--- a/paddle/cinn/ir/group_schedule/config/group_tile_util.cc
+++ b/paddle/cinn/ir/group_schedule/config/group_tile_util.cc
@@ -184,10 +184,10 @@ bool CheckBroadcastTensorIsContinuous(
     if (!iter_var2value.count(iter_var)) {
       return false;
     }
+
     ir::Expr iter_value = iter_var2value.at(iter_var);
 
-    if (!iter_value.as_var() && !iter_value.is_constant()) return false;
-
+    if (!iter_value.as_var()) return false;
     for (; loop_idx < for_iters.size(); ++loop_idx) {
       if (for_iters[loop_idx] == iter_value.as_var_ref()) {
         break;
@@ -212,14 +212,13 @@ bool CheckTensorIsContinuous(
   for (int i = 0; i < indices.size(); ++i) {
     ir::Expr index = indices[i];
     index = optim::ArithSimplify(index);
-    if (index.is_constant()) return false;
     if (!index.is_var()) return false;
     ir::Var iter_var = index.as_var_ref();
     if (!iter_var2value.count(iter_var)) {
       return false;
     }
     ir::Expr iter_value = iter_var2value.at(iter_var);
-    if (!iter_value.as_var() && !iter_value.is_constant()) return false;
+    if (!iter_value.as_var()) return false;
     if (for_iters[i] != iter_value.as_var_ref()) {
       return false;
     }


### PR DESCRIPTION

<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

Pcard-89071

当 iter_value 是一个常量时，常量不能被强制转换为 VarRef，调用 iter_value.as_var_ref() 会发生segmentation fault。
做了如下修复：
在调用 as_var_ref() 之前，先确认 iter_value 是一个变量类型（即 iter_value.as_var() 不为 null）。
iter_value为常量时，逻辑应于index一致
![b781e5b934694fd434862704ddaf218c](https://github.com/user-attachments/assets/654a94e5-092c-41da-ba75-e94792a9b377)


