### PR TITLE
Always link PYTHON_LIBRARIES to eager_generator

### DIFF
--- a/paddle/fluid/pybind/CMakeLists.txt
+++ b/paddle/fluid/pybind/CMakeLists.txt
@@ -361,9 +361,7 @@ if(WITH_PYTHON)
     target_link_libraries(eager_generator ${ROCM_HIPRTC_LIB})
   endif()
 
-  if(WITH_CINN)
-    target_link_libraries(eager_generator ${PYTHON_LIBRARIES})
-  endif()
+  target_link_libraries(eager_generator ${PYTHON_LIBRARIES})
 
   if(WIN32)
     set(EAGER_CODEGEN_DEPS eager_generator)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
在链接 eager_generator 时总是报错，已在多台设备上复现：
```
/usr/bin/ld: paddle/fluid/operators/libpy_func_op.a(py_func_op.cc.o): in function `pybind11::cast_error::set_error() const':
/work/PaddleCustomDevice/Paddle/build/third_party/pybind/src/extern_pybind/include/pybind11/detail/common.h:1040: undefined reference to `PyExc_RuntimeError'
/usr/bin/ld: /work/PaddleCustomDevice/Paddle/build/third_party/pybind/src/extern_pybind/include/pybind11/detail/common.h:1040: undefined reference to `PyExc_RuntimeError'
/usr/bin/ld: /work/PaddleCustomDevice/Paddle/build/third_party/pybind/src/extern_pybind/include/pybind11/detail/common.h:1040: undefined reference to `PyErr_SetString'
/usr/bin/ld: paddle/fluid/operators/libpy_func_op.a(py_func_op.cc.o): in function `pybind11::pybind11_fail(char const*)':
/work/PaddleCustomDevice/Paddle/build/third_party/pybind/src/extern_pybind/include/pybind11/detail/common.h:1046: undefined reference to `PyErr_Occurred'
/usr/bin/ld: paddle/fluid/operators/libpy_func_op.a(py_func_op.cc.o): in function `pybind11::pybind11_fail(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)':
```

使用的配置命令为：
```
cmake .. -GNinja -DPY_VERSION=3.10 -DWITH_GPU=OFF -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=1
```

排查是 eager_generator 仅在启用 CINN 时才链接到 PYTHON 库