### PR TITLE
【pir/custom】rm custom_black name change

### DIFF
--- a/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
+++ b/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
@@ -219,8 +219,7 @@ static bool NeedFallBackCpu(const pir::Operation* op,
   }
 
 #if defined(PADDLE_WITH_CUSTOM_DEVICE)
-  if (phi::backends::custom_device::is_in_custom_black_list(
-          phi::TransToFluidOpName(kernel))) {
+  if (phi::backends::custom_device::is_in_custom_black_list(kernel)) {
     phi::KernelKey copy_key = kernel_key;
     copy_key.set_backend(phi::Backend::CPU);
     if (phi::KernelFactory::Instance().HasKernel(kernel, copy_key)) {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
 Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-67164

custom_black_list 判断的是fluid 的name, 不符合使用习惯。 例如禁用transpose. 需要 填transpose2; 禁用add需要填elementwise_add