### PR TITLE
[CINN] Fixed TileBroadcast tactic matching conditions

### DIFF
--- a/paddle/cinn/ir/group_schedule/tactic/tile_broadcast_tactic.cc
+++ b/paddle/cinn/ir/group_schedule/tactic/tile_broadcast_tactic.cc
@@ -206,6 +206,7 @@ bool IsElementwiseOrBroadcast(const ir::Store& dst, const ir::Load& src) {
 
 bool CheckAllElementwiseOrBroadcast(ir::IRSchedule* sch) {
   for (auto& block : sch->GetAllBlocks()) {
+    if (ir::analyzer::IsReductionSBlock(block)) return false;
     ir::Expr store = ir::analyzer::GetStoreOfSBlock(block);
     auto* store_node = store.As<ir::Store>();
     for (auto& load : CollectLoads(store_node->value)) {
@@ -564,6 +565,7 @@ void TileBroadcastTactic::Apply(ir::IRSchedule* sch,
     block_size = CalcNumWarps(preserved_size_ >> 5);
     if (block_size == -1) {
       applied_layout_ = BroadcastLayout::Invalid;
+      return;
     }
     block_size = std::clamp(block_size << 5, 128, 1024);
   }

--- a/test/dygraph_to_static/test_pir_selectedrows.py
+++ b/test/dygraph_to_static/test_pir_selectedrows.py
@@ -17,7 +17,6 @@ import unittest
 
 from dygraph_to_static_utils import (
     Dy2StTestBase,
-    test_phi_only,
 )
 
 import paddle
@@ -74,7 +73,6 @@ def forward_static():
 
 
 class TestSimnet(Dy2StTestBase):
-    @test_phi_only
     def test_dygraph_static_same_loss(self):
         dygraph_value = forward_dygraph()
         static_value = forward_static()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
CINN

### PR Types
Bug fixes

### Description
Add one more rule that excludes reduce-related kernels for tilebroadcast tactic. Note that the old matching condition is well-crafted, the failed case should be caused by the following (yet unknown) PRs (unrelated to TileBroadcast Tactic), but anyway, we patch the potential flaw in this PR.

Pcard-89620