### PR TITLE
[spmd_rules] Add SPMD rules for ArgSort operator

### DIFF
--- a/paddle/phi/infermeta/spmd_rules/argsort.cc
+++ b/paddle/phi/infermeta/spmd_rules/argsort.cc
@@ -1,0 +1,195 @@
+/* Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include "paddle/phi/infermeta/spmd_rules/argsort.h"
+
+#include "glog/logging.h"
+
+#include "paddle/phi/core/distributed/auto_parallel/dist_attr.h"
+#include "paddle/phi/core/distributed/auto_parallel/inferspmd_utils.h"
+#include "paddle/phi/core/distributed/auto_parallel/utils.h"
+#include "paddle/phi/infermeta/spmd_rules/spmd_rule_macro_define.h"
+#include "paddle/phi/infermeta/spmd_rules/utils.h"
+
+namespace phi::distributed {
+
+SpmdInfo ArgSortInferSpmdBase(const DistMetaTensor& x,
+                              int axis,
+                              bool descending,
+                              bool stable) {
+  auto x_shape = common::vectorize(x.dims());
+  int x_ndim = static_cast<int>(x_shape.size());
+  auto x_dist_attr_src = x.dist_attr();
+  std::vector<int64_t> x_dims_mapping = x_dist_attr_src.dims_mapping();
+  PADDLE_ENFORCE_EQ(
+      x_ndim,
+      x_dims_mapping.size(),
+      errors::InvalidArgument(
+          "ArgSort input rank [%d] should be equal to dims_mapping size [%d].",
+          x_ndim,
+          x_dims_mapping.size()));
+
+  axis = axis < 0 ? axis + x_ndim : axis;
+
+  if (axis < 0 || axis >= x_ndim) {
+    PADDLE_ENFORCE(
+        false,
+        phi::errors::InvalidArgument(
+            "The axis of argsort should be in range [0, %d), but got %d.",
+            x_ndim,
+            axis));
+  }
+
+  std::vector<int64_t> x_dims_mapping_dst(x_dims_mapping);
+  x_dims_mapping_dst[axis] = -1;
+  std::vector<int64_t> y_dims_mapping_dst(x_dims_mapping_dst);
+  auto x_dist_attr_dst = CopyTensorDistAttrForOutput(x_dist_attr_src);
+  auto y_dist_attr_dst = CopyTensorDistAttrForOutput(x_dist_attr_src);
+  x_dist_attr_dst.set_dims_mapping(x_dims_mapping_dst);
+  y_dist_attr_dst.set_dims_mapping(y_dims_mapping_dst);
+
+  VLOG(4) << "ArgSortInferSpmdBase:" << std::endl;
+  VLOG(4) << "x_dist_attr_src: " << x_dist_attr_src.to_string()
+          << " x_dist_attr_dst: " << x_dist_attr_dst.to_string() << std::endl;
+  VLOG(4) << "y_dist_attr_dst: " << y_dist_attr_dst.to_string() << std::endl;
+
+  return {{x_dist_attr_dst}, {y_dist_attr_dst}};
+}
+
+SpmdInfo ArgSortGradInferSpmdBase(const DistMetaTensor& indices,
+                                  const DistMetaTensor& x,
+                                  const DistMetaTensor& out_grad,
+                                  int axis,
+                                  bool descending,
+                                  bool stable) {
+  // step 0: check invalidation of parameters
+  auto x_shape = common::vectorize(x.dims());
+  int x_ndim = static_cast<int>(x_shape.size());
+  auto x_dist_attr_src = x.dist_attr();
+  std::vector<int64_t> x_dims_mapping = x_dist_attr_src.dims_mapping();
+  PADDLE_ENFORCE_EQ(
+      x_ndim,
+      x_dims_mapping.size(),
+      errors::InvalidArgument("ArgSortGrad input x rank [%d] should be equal "
+                              "to dims_mapping size [%d].",
+                              x_ndim,
+                              x_dims_mapping.size()));
+
+  auto ind_shape = common::vectorize(indices.dims());
+  int ind_ndim = static_cast<int>(ind_shape.size());
+  auto ind_dist_attr_src = indices.dist_attr();
+  std::vector<int64_t> ind_dims_mapping = ind_dist_attr_src.dims_mapping();
+  PADDLE_ENFORCE_EQ(
+      ind_ndim,
+      ind_dims_mapping.size(),
+      errors::InvalidArgument("ArgSortGrad indices rank [%d] should be equal "
+                              "to dims_mapping size [%d].",
+                              ind_ndim,
+                              ind_dims_mapping.size()));
+
+  auto out_grad_shape = common::vectorize(out_grad.dims());
+  int out_grad_ndim = static_cast<int>(out_grad_shape.size());
+  auto out_grad_dist_attr_src = out_grad.dist_attr();
+  std::vector<int64_t> out_grad_dims_mapping =
+      out_grad_dist_attr_src.dims_mapping();
+  PADDLE_ENFORCE_EQ(
+      out_grad_ndim,
+      out_grad_dims_mapping.size(),
+      errors::InvalidArgument("ArgSortGrad out_grad rank [%d] should be equal "
+                              "to dims_mapping size [%d].",
+                              out_grad_ndim,
+                              out_grad_dims_mapping.size()));
+
+  PADDLE_ENFORCE_EQ(
+      x_ndim == ind_ndim && x_ndim == out_grad_ndim,
+      1,
+      errors::InvalidArgument("ArgSortGrad x rank [%d] should be equal to "
+                              "indices rank [%d] and out_grad rank [%d].",
+                              x_ndim,
+                              ind_ndim,
+                              out_grad_ndim));
+
+  for (int i = 0; i < x_ndim; ++i) {
+    PADDLE_ENFORCE_EQ(
+        x_dims_mapping[i] == ind_dims_mapping[i],
+        1,
+        errors::InvalidArgument("ArgSortGrad x dims_mapping[%d]=[%d] should be "
+                                "equal to indices dims_mapping[%d]=[%d].",
+                                i,
+                                x_dims_mapping[i],
+                                i,
+                                ind_dims_mapping[i]));
+  }
+
+  axis = axis < 0 ? axis + x_ndim : axis;
+
+  if (axis < 0 || axis >= x_ndim) {
+    PADDLE_ENFORCE(
+        false,
+        phi::errors::InvalidArgument(
+            "The axis of argsort should be in range [0, %d), but got %d.",
+            x_ndim,
+            axis));
+  }
+
+  // step 1: infer spmd info
+  std::vector<int64_t> x_dims_mapping_dst(x_dims_mapping);
+  x_dims_mapping_dst[axis] = -1;
+  std::vector<int64_t> out_grad_dims_mapping_dst(x_dims_mapping_dst);
+  std::vector<int64_t> indices_dims_mapping_dst(x_dims_mapping_dst);
+  std::vector<int64_t> x_grad_dims_mapping_dst(x_dims_mapping_dst);
+
+  auto x_dist_attr_dst = CopyTensorDistAttrForOutput(x_dist_attr_src);
+  auto out_grad_dist_attr_dst = CopyTensorDistAttrForOutput(x_dist_attr_src);
+  auto indices_dist_attr_dst = CopyTensorDistAttrForOutput(x_dist_attr_src);
+  auto x_grad_dist_attr_dst = CopyTensorDistAttrForOutput(x_dist_attr_src);
+
+  x_dist_attr_dst.set_dims_mapping(x_dims_mapping_dst);
+  out_grad_dist_attr_dst.set_dims_mapping(out_grad_dims_mapping_dst);
+  indices_dist_attr_dst.set_dims_mapping(indices_dims_mapping_dst);
+  x_grad_dist_attr_dst.set_dims_mapping(x_dims_mapping_dst);
+
+  VLOG(4) << "ArgSortGradInferSpmdBase:" << std::endl;
+  VLOG(4) << "indices_dist_attr_src: " << ind_dist_attr_src.to_string()
+          << " indices_dist_attr_dst: " << indices_dist_attr_dst.to_string()
+          << std::endl;
+  VLOG(4) << "x_dist_attr_src: " << x_dist_attr_src.to_string()
+          << " x_dist_attr_dst: " << x_dist_attr_dst.to_string() << std::endl;
+  VLOG(4) << "out_grad_dist_attr_src: " << out_grad_dist_attr_dst.to_string()
+          << " out_grad_dist_attr_dst: " << out_grad_dist_attr_dst.to_string()
+          << std::endl;
+  VLOG(4) << "x_grad_dist_attr_dst: " << x_grad_dist_attr_dst.to_string()
+          << std::endl;
+  return {{indices_dist_attr_dst, x_dist_attr_dst, out_grad_dist_attr_dst},
+          {x_grad_dist_attr_dst}};
+}
+
+SpmdInfo ArgSortInferSpmd(const DistMetaTensor& x,
+                          int axis,
+                          bool descending,
+                          bool stable) {
+  return ArgSortInferSpmdBase(x, axis, descending, stable);
+}
+
+SpmdInfo ArgSortGradInferSpmd(const DistMetaTensor& indices,
+                              const DistMetaTensor& x,
+                              const DistMetaTensor& out_grad,
+                              int axis,
+                              bool descending,
+                              bool stable) {
+  return ArgSortGradInferSpmdBase(
+      indices, x, out_grad, axis, descending, stable);
+}
+
+}  // namespace phi::distributed

--- a/paddle/phi/infermeta/spmd_rules/argsort.h
+++ b/paddle/phi/infermeta/spmd_rules/argsort.h
@@ -1,0 +1,49 @@
+/* Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#pragma once
+
+#include "paddle/phi/common/scalar.h"
+#include "paddle/phi/core/distributed/auto_parallel/dist_meta_tensor.h"
+#include "paddle/phi/core/distributed/type_defs.h"
+
+namespace phi {
+namespace distributed {
+
+SpmdInfo ArgSortInferSpmdBase(const DistMetaTensor& x,
+                              int axis,
+                              bool descending,
+                              bool stable);
+
+SpmdInfo ArgSortGradInferSpmdBase(const DistMetaTensor& indices,
+                                  const DistMetaTensor& x,
+                                  const DistMetaTensor& out_grad,
+                                  int axis,
+                                  bool descending,
+                                  bool stable);
+
+SpmdInfo ArgSortInferSpmd(const DistMetaTensor& x,
+                          int axis,
+                          bool descending,
+                          bool stable);
+
+SpmdInfo ArgSortGradInferSpmd(const DistMetaTensor& indices,
+                              const DistMetaTensor& x,
+                              const DistMetaTensor& out_grad,
+                              int axis,
+                              bool descending,
+                              bool stable);
+
+}  // namespace distributed
+}  // namespace phi

--- a/paddle/phi/infermeta/spmd_rules/rules.cc
+++ b/paddle/phi/infermeta/spmd_rules/rules.cc
@@ -733,4 +733,9 @@ PD_REGISTER_SPMD_RULE(nonzero,
 
 // add_n
 PD_REGISTER_SPMD_RULE(add_n, PD_INFER_SPMD(phi::distributed::AddNInferSpmd));
+
+// argsort
+PD_REGISTER_SPMD_RULE(argsort,
+                      PD_INFER_SPMD(phi::distributed::ArgSortInferSpmd),
+                      PD_INFER_SPMD(phi::distributed::ArgSortGradInferSpmd));
 }  // namespace phi::distributed

--- a/paddle/phi/infermeta/spmd_rules/rules.h
+++ b/paddle/phi/infermeta/spmd_rules/rules.h
@@ -17,6 +17,7 @@ limitations under the License. */
 #include "paddle/phi/infermeta/spmd_rules/add_n.h"
 #include "paddle/phi/infermeta/spmd_rules/amp_ops.h"
 #include "paddle/phi/infermeta/spmd_rules/argmax.h"
+#include "paddle/phi/infermeta/spmd_rules/argsort.h"
 #include "paddle/phi/infermeta/spmd_rules/c_embedding.h"
 #include "paddle/phi/infermeta/spmd_rules/c_softmax_with_cross_entropy.h"
 #include "paddle/phi/infermeta/spmd_rules/c_softmax_with_multi_label_cross_entropy.h"

--- a/paddle/phi/ops/yaml/backward.yaml
+++ b/paddle/phi/ops/yaml/backward.yaml
@@ -155,6 +155,7 @@
   infer_meta :
     func : UnchangedInferMeta
     param : [x]
+    spmd_rule: ArgSortGradInferSpmd
   kernel :
     func : argsort_grad
     data_type : out_grad

--- a/paddle/phi/ops/yaml/ops.yaml
+++ b/paddle/phi/ops/yaml/ops.yaml
@@ -316,6 +316,7 @@
   output : Tensor(out), Tensor(indices)
   infer_meta :
     func : ArgsortInferMeta
+    spmd_rule : ArgSortInferSpmd
   kernel :
     func : argsort
   backward : argsort_grad

--- a/test/auto_parallel/spmd_rules/test_argsort_rule.py
+++ b/test/auto_parallel/spmd_rules/test_argsort_rule.py
@@ -1,0 +1,178 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from collections import OrderedDict
+
+from paddle.distributed.auto_parallel.static.dist_attribute import (
+    DistTensorSpec,
+    TensorDistAttr,
+)
+from paddle.distributed.fleet import auto
+from paddle.framework import core
+
+
+class TestArgSortSPMDRule(unittest.TestCase):
+    """
+    Unit tests for argsort spmd rule.
+    """
+
+    def setUp(self):
+        x_shape = [64, 32, 48]
+        process_mesh = auto.ProcessMesh(mesh=[[0, 1, 2], [3, 4, 5]])
+
+        x_tensor_dist_attr = TensorDistAttr()
+        x_tensor_dist_attr.dims_mapping = [-1, -1, -1]
+        x_tensor_dist_attr.process_mesh = process_mesh
+        self.x_dist_tensor_spec = DistTensorSpec(x_shape, x_tensor_dist_attr)
+
+        indices_shape = list(x_shape)
+        indices_tensor_dist_attr = TensorDistAttr()
+        indices_tensor_dist_attr.dims_mapping = [-1, -1, -1]
+        indices_tensor_dist_attr.process_mesh = process_mesh
+        self.indices_dist_tensor_spec = DistTensorSpec(
+            indices_shape, indices_tensor_dist_attr
+        )
+
+        out_grad_shape = list(x_shape)
+        out_grad_tensor_dist_attr = TensorDistAttr()
+        out_grad_tensor_dist_attr.dims_mapping = [-1, -1, -1]
+        out_grad_tensor_dist_attr.process_mesh = process_mesh
+        self.out_grad_dist_tensor_spec = DistTensorSpec(
+            out_grad_shape, out_grad_tensor_dist_attr
+        )
+
+        self.rule = core.get_phi_spmd_rule("argsort")
+        self.attrs = OrderedDict(
+            {
+                'axis': -1,
+                'descending': False,
+                'stable': False,
+            }
+        )
+
+    def test_infer_spmd(self):
+        # axis = -1
+        # [0, -1, 1] --> [0, -1, -1]
+        self.attrs['axis'] = -1
+        self.x_dist_tensor_spec.set_dims_mapping([0, -1, 1])
+        dist_attr = self.rule.infer_forward(
+            self.x_dist_tensor_spec,
+            self.attrs['axis'],
+            self.attrs['descending'],
+            self.attrs['stable'],
+        )
+
+        x_tensor_dist_attr = dist_attr[0]
+        y_tensor_dist_attr = dist_attr[1]
+
+        self.assertEqual(len(dist_attr), 2)
+        self.assertEqual(len(x_tensor_dist_attr), 1)
+        self.assertEqual(len(y_tensor_dist_attr), 1)
+
+        self.assertEqual(x_tensor_dist_attr[0].dims_mapping, [0, -1, -1])
+        self.assertEqual(y_tensor_dist_attr[0].dims_mapping, [0, -1, -1])
+
+        # axis = -1
+        # [0, 1, -1] --> [0, 1, -1]
+        self.attrs['axis'] = -1
+        self.x_dist_tensor_spec.set_dims_mapping([0, 1, -1])
+        dist_attr = self.rule.infer_forward(
+            self.x_dist_tensor_spec,
+            self.attrs['axis'],
+            self.attrs['descending'],
+            self.attrs['stable'],
+        )
+
+        x_tensor_dist_attr = dist_attr[0]
+        y_tensor_dist_attr = dist_attr[1]
+
+        self.assertEqual(len(dist_attr), 2)
+        self.assertEqual(len(x_tensor_dist_attr), 1)
+        self.assertEqual(len(y_tensor_dist_attr), 1)
+
+        self.assertEqual(x_tensor_dist_attr[0].dims_mapping, [0, 1, -1])
+        self.assertEqual(y_tensor_dist_attr[0].dims_mapping, [0, 1, -1])
+
+        # axis = 1
+        # [0, 1, -1] --> [0, -1, -1]
+        self.attrs['axis'] = 1
+        self.x_dist_tensor_spec.set_dims_mapping([0, 1, -1])
+        dist_attr = self.rule.infer_forward(
+            self.x_dist_tensor_spec,
+            self.attrs['axis'],
+            self.attrs['descending'],
+            self.attrs['stable'],
+        )
+
+        x_tensor_dist_attr = dist_attr[0]
+        y_tensor_dist_attr = dist_attr[1]
+
+        self.assertEqual(len(dist_attr), 2)
+        self.assertEqual(len(x_tensor_dist_attr), 1)
+        self.assertEqual(len(y_tensor_dist_attr), 1)
+
+        self.assertEqual(x_tensor_dist_attr[0].dims_mapping, [0, -1, -1])
+        self.assertEqual(y_tensor_dist_attr[0].dims_mapping, [0, -1, -1])
+
+    def test_infer_grad_spmd(self):
+        # axis = -1
+        # [0, -1, 1] --> [0, -1, -1]
+        self.attrs['axis'] = -1
+        self.x_dist_tensor_spec.set_dims_mapping([0, -1, 1])
+        self.indices_dist_tensor_spec.set_dims_mapping([0, -1, 1])
+        self.out_grad_dist_tensor_spec.set_dims_mapping([0, -1, 1])
+        dist_attr = self.rule.infer_backward(
+            self.x_dist_tensor_spec,
+            self.indices_dist_tensor_spec,
+            self.out_grad_dist_tensor_spec,
+            self.attrs['axis'],
+            self.attrs['descending'],
+            self.attrs['stable'],
+        )
+
+        self.assertEqual(len(dist_attr), 2)
+        self.assertEqual(len(dist_attr[0]), 3)
+        self.assertEqual(len(dist_attr[1]), 1)
+        self.assertEqual(dist_attr[0][0].dims_mapping, [0, -1, -1])
+        self.assertEqual(dist_attr[0][1].dims_mapping, [0, -1, -1])
+        self.assertEqual(dist_attr[0][2].dims_mapping, [0, -1, -1])
+        self.assertEqual(dist_attr[1][0].dims_mapping, [0, -1, -1])
+
+        # axis = 1
+        # [0, 1, -1] --> [0, -1, -1]
+        self.attrs['axis'] = 1
+        self.x_dist_tensor_spec.set_dims_mapping([0, 1, -1])
+        self.indices_dist_tensor_spec.set_dims_mapping([0, 1, -1])
+        self.out_grad_dist_tensor_spec.set_dims_mapping([0, 1, -1])
+        dist_attr = self.rule.infer_backward(
+            self.x_dist_tensor_spec,
+            self.indices_dist_tensor_spec,
+            self.out_grad_dist_tensor_spec,
+            self.attrs['axis'],
+            self.attrs['descending'],
+            self.attrs['stable'],
+        )
+
+        self.assertEqual(len(dist_attr), 2)
+        self.assertEqual(len(dist_attr[0]), 3)
+        self.assertEqual(len(dist_attr[1]), 1)
+        self.assertEqual(dist_attr[0][0].dims_mapping, [0, -1, -1])
+        self.assertEqual(dist_attr[0][1].dims_mapping, [0, -1, -1])
+        self.assertEqual(dist_attr[0][2].dims_mapping, [0, -1, -1])
+        self.assertEqual(dist_attr[1][0].dims_mapping, [0, -1, -1])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
The version upon committing incorporates SPMD rules for the ArgSort operator, covering both the forward and backward passes.
The SPMD rules for both the forward and backward passes simply replicate the sorting axis across one worker mesh dimension. For example, dimension mapping [0, 1, -1], given sorting axis of 1, will be transformed into dimension mapping [0, -1, -1].
The rules that involve splitting the sorting axis are deeply coupled with the reduce communication mechanism. Specifically, merging sorted sequences during reduction is not currently supported and remains a topic for future work.
