### PR TITLE
Fix output inplace in c_softmax_with_cross_entropy_grad

### DIFF
--- a/paddle/phi/ops/yaml/backward.yaml
+++ b/paddle/phi/ops/yaml/backward.yaml
@@ -356,6 +356,7 @@
     func: c_softmax_with_cross_entropy_grad
     data_type: loss_grad
     param: [softmax, label, loss_grad, ignore_index, rank, nranks]
+  inplace : (softmax -> logits_grad)
 
 - backward_op : cast_grad
   forward : cast (Tensor x, DataType dtype) -> Tensor(out)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

- Fix output inplace in c_softmax_with_cross_entropy_grad.
- Avoid redundant memcpy in the grad kernel.

Pcard-70448