### PR TITLE
[SOT] Skip restore same stack arg when partial fallback

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
@@ -390,10 +390,15 @@ class FunctionGraph:
         self.pycode_gen.gen_enable_eval_frame()
 
         name_gen = NameGenerator("___graph_fn_saved_orig_")
+        stored_var_ids = set()
 
         # here is not update changed values, it just give names to stack vars
         # and want keep same interface as _build_compile_fn_with_name_store
         for var in stack_vars[::-1]:
+            if var.id in stored_var_ids:
+                self.pycode_gen.gen_pop_top()
+                continue
+            stored_var_ids.add(var.id)
             if not store_var_info.get(var.id, []):
                 name = name_gen.next()
                 store_var_info.setdefault(var.id, [])

--- a/test/sot/test_min_graph_size.py
+++ b/test/sot/test_min_graph_size.py
@@ -84,6 +84,15 @@ def get_arg_from_kwargs(x, **kwargs):
     return x, y
 
 
+def add_with_breakgraph(x, y):
+    sot.psdb.breakgraph()
+    return x + y
+
+
+def restore_same_arg_when_fallback(x):
+    return add_with_breakgraph(x, x)
+
+
 class TestMinGraphSize(TestCaseBase):
     @min_graph_size_guard(10)
     def test_cases(self):
@@ -115,6 +124,11 @@ class TestMinGraphSize(TestCaseBase):
     def test_get_arg_from_kwargs(self):
         self.assert_results(get_arg_from_kwargs, None)
         self.assert_results(get_arg_from_kwargs, None, y=1)
+
+    @min_graph_size_guard(10)
+    def test_restore_same_arg_when_fallback(self):
+        x = paddle.to_tensor(1)
+        self.assert_results(restore_same_arg_when_fallback, x)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

问题出现在子图大小低于 `MIN_GRAPH_SIZE` 的 partial fallback 处理处

与 `_build_compile_fn_with_name_store` 不同，这里传入的 `stack_vars` 是可能有重复的，因此当同一个变量在前面迭代分配了名字后并存到 `store_var_info` 后，后面迭代的时候就走到了 else 分支，就会走 `gen_store`，但这明明是 `___graph_fn_saved_orig_` 生成的，就无法在原来函数名字里找到，会挂掉，进而导致整个函数 fallback

因此，存过了就直接 `POP_TOP` 就好了

`_build_compile_fn_with_name_store` 不需要处理，因为不会重复

<!-- PCard-66972 -->