### PR TITLE
[CINN] CodeGenLLVM supports composite reduce

### DIFF
--- a/paddle/cinn/backends/llvm/codegen_llvm.h
+++ b/paddle/cinn/backends/llvm/codegen_llvm.h
@@ -262,6 +262,9 @@ class CodeGenLLVM : public LLVMIRVisitor, public IrBuilderMixin<CodeGenLLVM> {
   void Scalarize(const Expr &e,
                  std::function<void(int i, llvm::Value *v)> flambda);
 
+  llvm::Value *CastCompositeType(const ir::Expr &op_v);
+  void RegisterCustomizedPODStructType();
+
   llvm::Module *m_;
   llvm::IRBuilder<> *b_;
   // Current function


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
CINN


### PR Types
Improvements


### Description
The following PRs forms the support for x86 end composite reduce (Welford variance & argmin/argmax):

- #72368
- #72370
- #72371

This PR extends the codegen module, so that we can load our customized intrinsic functions and struct types needed in composite reduce:
- Composite reduce type LLVM explicit creation during construction of CodeGenLLVM instance.
- Automatically adapts LLVM arguments extracted from CINN IR to the requested function type of loaded intrinsic functions.

Pcard-89620
