### PR TITLE
[CINN] x86 runtime intrinsics for composite reduce

### DIFF
--- a/paddle/cinn/hlir/framework/pir/op_lowering_impl.cc
+++ b/paddle/cinn/hlir/framework/pir/op_lowering_impl.cc
@@ -845,10 +845,9 @@ ir::LoweredFunc OpLowererImpl::GenerateInferShapeFunc(
       ir::ConvertExprBlockToStmtBlock(infer_shape_func->body);
   return infer_shape_func;
 }
-// TODO(heqianyue): support argidx and variance op on CPU
 bool IsOpDeniedOnCpu(::pir::Operation* op) {
-  static std::set<std::string> banned_ops = {
-      "cinn_op.argmax", "cinn_op.argmin", "pd_op.variance"};
+  // no op is denied after the support for composite reduce on cpu
+  static std::set<std::string> banned_ops = {};
   return banned_ops.count(op->name());
 }
 ir::Expr OpLowererImpl::LowerX86(const OpLoweringGroupPtr& group,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
CINN


### PR Types
Improvements


### Description
The following PRs forms the support for x86 end composite reduce (Welford variance & argmin/argmax):

- #72368
- #72370
- #72371

This PR adds the intrinsic functions on the x86 end to support composite reduce ops. Note that, due to the ABI optimization of LLVM, functions defined in `cinn_runtime` basically do the same thing as those in `cinn_cuda_runtime_source`, but the function signatures differ a lot (on x86 end, most of the struct in/outputs are pointer-typed).

Also, we removed `pd_op.variance`, `cinn_op.argmax`, `cinn_op.argmin` from the denied ops on CPU. These kernels are now allowed to be generated on x86 end.

Pcard-89620
