### PR TITLE
[DRAFT 不 REVIEW]Support FakeTensorArray for Kernel Key and Backend Inference

### DIFF
--- a/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
+++ b/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
@@ -50,6 +50,7 @@
 #include "paddle/phi/common/type_traits.h"
 #include "paddle/phi/core/compat/convert_utils.h"
 #include "paddle/phi/core/kernel_factory.h"
+#include "paddle/phi/core/tensor_array.h"
 #include "paddle/pir/include/core/builtin_op.h"
 #include "paddle/pir/include/dialect/control_flow/ir/cf_op.h"
 
@@ -384,7 +385,7 @@ phi::DenseTensorMeta parse_tensor_meta<AllocatedSparseCsrTensorType>(
 }
 
 static std::vector<std::shared_ptr<phi::TensorBase>> PrepareFakeTensors(
-    pir::Value input) {
+    pir::Value input, bool build_array_item = false) {
   std::vector<std::shared_ptr<phi::TensorBase>> res;
   auto in_type = input.type();
 
@@ -427,16 +428,22 @@ static std::vector<std::shared_ptr<phi::TensorBase>> PrepareFakeTensors(
     return sr;
   };
 
-  auto fake_tensor_array = [](const AllocatedDenseTensorArrayType& type) {
-    auto ptr = new phi::Allocation(nullptr, 0, type.place());
-    std::shared_ptr<phi::Allocation> holder(ptr);
-    auto dtype = TransToPhiDataType(type.dtype());
-    phi::DenseTensorMeta meta(dtype, {});
-    phi::DenseTensor dt(holder, meta);
-    auto tensor_array = std::make_shared<phi::TensorArray>(0);
-    tensor_array->set_type(dtype);
-    return tensor_array;
-  };
+  auto fake_tensor_array =
+      [build_array_item](const AllocatedDenseTensorArrayType& type) {
+        auto tensor_array = std::make_shared<phi::TensorArray>(0);
+        auto dtype = TransToPhiDataType(type.dtype());
+        tensor_array->set_type(dtype);
+
+        if (build_array_item) {
+          auto ptr = new phi::Allocation(nullptr, 0, type.place());
+          std::shared_ptr<phi::Allocation> holder(ptr);
+          phi::DenseTensorMeta meta(dtype, {});
+          phi::DenseTensor dt(holder, meta);
+          tensor_array->push_back(dt);
+        }
+
+        return tensor_array;
+      };
 
   if (in_type.isa<AllocatedDenseTensorType>()) {
     res.push_back(fake_dt(in_type.dyn_cast<AllocatedDenseTensorType>()));
@@ -514,9 +521,17 @@ static pir::Value AddPlaceTransferOp(pir::Value in,
     if (src_place.GetType() == phi::AllocationType::CUSTOM) {
       paddle::experimental::detail::KernelKeyParser kernel_key_parser;
 
-      auto fake_tensors = PrepareFakeTensors(in);
+      auto fake_tensors = PrepareFakeTensors(in, true);
       for (auto& fake_tensor : fake_tensors) {
-        kernel_key_parser.AssignKernelKeySet(*fake_tensor);
+        if (phi::TensorArray::classof(fake_tensor.get())) {
+          // AssignKernelKeySet(const phi::TensorBase& tensor) cannot parse
+          // tensor array backend
+          const auto& tensor_array =
+              static_cast<phi::TensorArray&>(*fake_tensor);
+          kernel_key_parser.AssignKernelKeySet(tensor_array);
+        } else {
+          kernel_key_parser.AssignKernelKeySet(*fake_tensor);
+        }
       }
       auto kernel_key = kernel_key_parser.key_set.GetHighestPriorityKernelKey();
       copy_kernel_key.set_backend(kernel_key.backend());
@@ -1285,9 +1300,18 @@ phi::KernelKey GetKernelKey(
         continue;
       }
       auto new_input_tmp = map_value_pair.at(input_tmp);
-      auto fake_tensors = PrepareFakeTensors(new_input_tmp);
+
+      auto fake_tensors = PrepareFakeTensors(new_input_tmp, true);
       for (auto& fake_tensor : fake_tensors) {
-        kernel_key_parser.AssignKernelKeySet(*fake_tensor);
+        if (phi::TensorArray::classof(fake_tensor.get())) {
+          // AssignKernelKeySet(const phi::TensorBase& tensor) cannot parse
+          // tensor array backend
+          const auto& tensor_array =
+              static_cast<phi::TensorArray&>(*fake_tensor);
+          kernel_key_parser.AssignKernelKeySet(tensor_array);
+        } else {
+          kernel_key_parser.AssignKernelKeySet(*fake_tensor);
+        }
       }
 
       // Because we can't make sure the place when build data op

--- a/paddle/phi/api/lib/kernel_dispatch.cc
+++ b/paddle/phi/api/lib/kernel_dispatch.cc
@@ -29,7 +29,7 @@ limitations under the License. */
 namespace paddle::experimental::detail {
 
 // We need judge whether the allocation is nullptr,
-// whether the allocation is initialized, wo we need GetHolder method
+// whether the allocation is initialized, so we need GetHolder method
 bool HasAllocation(const phi::TensorBase& t) {
   if (phi::DenseTensor::classof(&t)) {
     return phi::DenseTensorUtils::GetHolder(

--- a/paddle/phi/api/lib/kernel_dispatch.h
+++ b/paddle/phi/api/lib/kernel_dispatch.h
@@ -31,6 +31,7 @@ limitations under the License. */
 
 // TODO(chenweihang): split Key, Kernel, Factory into diff files
 #include "paddle/phi/core/kernel_factory.h"
+#include "paddle/phi/core/tensor_array.h"
 
 namespace paddle {
 namespace experimental {
@@ -95,6 +96,12 @@ struct KernelKeyParser : ArgsIterator<KernelKeyParser> {
   // this dtype_set is used for cache multi-inputs dtype and used for
   // data_promote
   DataTypeSet dtype_set{DataType::UNDEFINED};
+
+  inline void AssignKernelKeySet(const phi::TensorArray& array) {
+    for (const auto& tensor : array) {
+      AssignKernelKeySet(tensor);
+    }
+  }
 
   inline void AssignKernelKeySet(const phi::TensorBase& tensor) {
     // assign Backend


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
在选 memcpy Kernel 和 根据操作数推导 place 时，如果 input 是 tensor array，无法解析其place 信息。

FIx：构建 FakeTensor 时支持构造出具有一个FakeTensor 的 FakeTensorArray，并添加对 FakeTensorArray 的place 解析方法。