### PR TITLE
Support FakeTensorArray for Backend Inference

### DIFF
--- a/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
@@ -2459,7 +2459,7 @@ OpInfoTuple TensorToArrayOp::GetOpInfo() {
 
   paddle::dialect::OpRunTimeInfo run_time_info =
       paddle::dialect::OpRunTimeInfo("TensorToArrayInferMeta",
-                                     {"x", "axis", "use_stack"},
+                                     {"x", "out_grad", "axis", "use_stack"},
                                      "tensor_to_array",
                                      {"x", "out_grad", "axis", "use_stack"},
                                      {"x"},

--- a/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
+++ b/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
@@ -50,6 +50,7 @@
 #include "paddle/phi/common/type_traits.h"
 #include "paddle/phi/core/compat/convert_utils.h"
 #include "paddle/phi/core/kernel_factory.h"
+#include "paddle/phi/core/tensor_array.h"
 #include "paddle/pir/include/core/builtin_op.h"
 #include "paddle/pir/include/dialect/control_flow/ir/cf_op.h"
 
@@ -435,6 +436,7 @@ static std::vector<std::shared_ptr<phi::TensorBase>> PrepareFakeTensors(
     phi::DenseTensor dt(holder, meta);
     auto tensor_array = std::make_shared<phi::TensorArray>(0);
     tensor_array->set_type(dtype);
+    tensor_array->push_back(dt);
     return tensor_array;
   };
 

--- a/paddle/phi/api/lib/kernel_dispatch.cc
+++ b/paddle/phi/api/lib/kernel_dispatch.cc
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 #include "paddle/phi/api/lib/kernel_dispatch.h"
 #include <glog/logging.h>
+#include "paddle/phi/core/tensor_array.h"
 #ifdef _MSC_VER
 #include <intrin.h>
 #endif
@@ -29,7 +30,7 @@ limitations under the License. */
 namespace paddle::experimental::detail {
 
 // We need judge whether the allocation is nullptr,
-// whether the allocation is initialized, wo we need GetHolder method
+// whether the allocation is initialized, so we need GetHolder method
 bool HasAllocation(const phi::TensorBase& t) {
   if (phi::DenseTensor::classof(&t)) {
     return phi::DenseTensorUtils::GetHolder(
@@ -50,6 +51,8 @@ bool HasAllocation(const phi::TensorBase& t) {
                static_cast<const phi::StringTensor&>(t)) != nullptr;
   } else if (phi::distributed::DistTensor::classof(&t)) {
     return static_cast<const phi::distributed::DistTensor&>(t).defined();
+  } else if (phi::TensorArray::classof(&t)) {
+    return t.has_allocation();
   } else {
     return false;
   }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
pcard-67164
为选 Memcpy 和 根据 operand 选 kernel backend 添加 input 为 tensorarray 的情况的支持。
具体 Fix:
1. TensorToArrayInferMeta 缺少 out_grad
2. prepare fake tensor 构造出的 tensorarray 没有元素
3. HasAllocation 缺少对 tensorarray的支持