### PR TITLE
[Dy2St] Decompose run program ad func with op maker

### DIFF
--- a/paddle/fluid/pybind/CMakeLists.txt
+++ b/paddle/fluid/pybind/CMakeLists.txt
@@ -44,7 +44,8 @@ set(PYBIND_DEPS
     prim_utils
     detail_op_handle
     type_info
-    auto_parallel)
+    auto_parallel
+    executor_cache)
 
 if(WITH_GPU)
   list(APPEND PYBIND_DEPS gpu_event_timer)

--- a/paddle/fluid/pybind/eager_legacy_custom_python_api.h
+++ b/paddle/fluid/pybind/eager_legacy_custom_python_api.h
@@ -43,8 +43,7 @@ static PyObject *eager_api_run_program(PyObject *self,  // TOREMOVE
       Out = GetTensorPtrListFromArgs("run_program", "Out", args, 2, true, mesh);
     }
     framework::AttributeMap attrs;
-    // TODO(zengjinle): support CUDA Graph on eager mode
-    ConstructAttrMapFromPyArgs(
+    ConstructAttrMapForLegacyRunProgram(
         "run_program", args, 5, PyTuple_GET_SIZE(args), attrs);
 
     tstate = PyEval_SaveThread();

--- a/paddle/fluid/pybind/op_function_common.cc
+++ b/paddle/fluid/pybind/op_function_common.cc
@@ -1268,9 +1268,10 @@ void ConstructAttrMapForRunProgram(
       it->second(obj, attrs, std::string(key_view), op_type, arg_pos);
     } else {
       PADDLE_THROW(common::errors::InvalidArgument(
-          "%.*s is not defined in this function.",
+          "Attribute key %.*s is not recognized for operator %s.",
           static_cast<int>(key_view.size()),
-          key_view.data()));  // NOLINT
+          key_view.data(),
+          op_type.c_str()));  // NOLINT
     }
   }
 }

--- a/paddle/fluid/pybind/op_function_common.cc
+++ b/paddle/fluid/pybind/op_function_common.cc
@@ -1196,9 +1196,10 @@ void ConstructAttrMapForLegacyRunProgram(
       it->second(obj, attrs, std::string(key_view), op_type, arg_pos);
     } else {
       PADDLE_THROW(common::errors::InvalidArgument(
-          "%.*s is not defined in this function.",
+          "Attribute key %.*s is not recognized for operator %s.",
           static_cast<int>(key_view.size()),
-          key_view.data()));  // NOLINT
+          key_view.data(),
+          op_type.c_str()));  // NOLINT
     }
   }
 }

--- a/paddle/fluid/pybind/op_function_common.cc
+++ b/paddle/fluid/pybind/op_function_common.cc
@@ -1135,6 +1135,74 @@ void ConstructAttrMapFromPyArgs(
   }
 }
 
+void ConstructAttrMapForLegacyRunProgram(
+    const std::string& op_type,
+    PyObject* args,
+    ssize_t attr_start,
+    ssize_t attr_end,
+    paddle::framework::AttributeMap& attrs) {  // NOLINT
+  PADDLE_ENFORCE_EQ((attr_end - attr_start) % 2,
+                    0,
+                    common::errors::InvalidArgument(
+                        "The number of arguments for attributes should be even "
+                        "but attr_start = %d, attr_end = %d.",
+                        attr_start,
+                        attr_end));
+  using CastFuncType = void (*)(PyObject*,
+                                paddle::framework::AttributeMap&,
+                                const std::string&,
+                                const std::string&,
+                                ssize_t);
+  // Static map from keys to casting function pointers
+  static const std::unordered_map<std::string, CastFuncType> kAttrFuncMap = {
+      {"forward_global_block", CastPyArg2AttrBlock},
+      {"backward_global_block", CastPyArg2AttrBlock},
+      {"is_test", CastPyArg2AttrBoolean},
+      {"program_id", CastPyArg2AttrLong},
+      {"param_grad_names", CastPyArg2AttrStrings},
+      {"x_names", CastPyArg2AttrStrings},
+      {"out_grad_names", CastPyArg2AttrStrings},
+      {"x_grad_names", CastPyArg2AttrStrings},
+      {"cuda_graph_capture_mode", CastPyArg2AttrString},
+      {"cuda_graph_pool_id", CastPyArg2AttrLong},
+      {"in_pir_pt_mode", CastPyArg2AttrBoolean},
+      {"use_interpretorcore", CastPyArg2AttrBoolean},
+      {"global_block", CastPyArg2AttrBlock},
+      {"start_op_index", CastPyArg2AttrLong},
+      {"end_op_index", CastPyArg2AttrLong},
+  };
+
+  PyObject* obj = nullptr;
+  for (ssize_t arg_pos = attr_start; arg_pos < attr_end; arg_pos += 2) {
+    VLOG(3) << "Start Process " << arg_pos;
+    Py_ssize_t key_len = 0;
+    const char* key_ptr = nullptr;
+    obj = PyTuple_GET_ITEM(args, arg_pos);
+    if (PyObject_CheckString(obj)) {
+      key_ptr = PyUnicode_AsUTF8AndSize(obj, &key_len);
+    } else {
+      PADDLE_THROW(common::errors::InvalidArgument(
+          "%s(): argument (position %d) must be str, but got %s",
+          op_type,
+          arg_pos,
+          ((PyTypeObject*)obj->ob_type)->tp_name));  // NOLINT
+    }
+    std::string_view key_view(key_ptr, static_cast<size_t>(key_len));
+    VLOG(3) << "Start Process " << key_view;
+    obj = PyTuple_GET_ITEM(args, arg_pos + 1);
+    auto it = kAttrFuncMap.find(std::string(key_view));
+    if (it != kAttrFuncMap.end()) {
+      // Call Cast function
+      it->second(obj, attrs, std::string(key_view), op_type, arg_pos);
+    } else {
+      PADDLE_THROW(common::errors::InvalidArgument(
+          "%.*s is not defined in this function.",
+          static_cast<int>(key_view.size()),
+          key_view.data()));  // NOLINT
+    }
+  }
+}
+
 void ConstructAttrMapForRunProgram(
     const std::string& op_type,
     PyObject* args,
@@ -1156,17 +1224,11 @@ void ConstructAttrMapForRunProgram(
                                 ssize_t);
   // Static map from keys to casting function pointers
   static const std::unordered_map<std::string, CastFuncType> kAttrFuncMap = {
-      {"cuda_graph_capture_mode", CastPyArg2AttrString},
-      {"global_block", CastPyArg2AttrIRBlock},
       {"forward_program", CastPyArg2AttrIRProgram},
       {"backward_program", CastPyArg2AttrIRProgram},
       {"is_test", CastPyArg2AttrBoolean},
-      {"use_interpretorcore", CastPyArg2AttrBoolean},
       {"in_sot_mode", CastPyArg2AttrBoolean},
-      {"start_op_index", CastPyArg2AttrLong},
-      {"end_op_index", CastPyArg2AttrLong},
       {"program_id", CastPyArg2AttrLong},
-      {"cuda_graph_pool_id", CastPyArg2AttrLong},
       {"fx", CastPyArg2AttrValues},
       {"fp", CastPyArg2AttrValues},
       {"fm", CastPyArg2AttrValues},
@@ -1178,7 +1240,8 @@ void ConstructAttrMapForRunProgram(
       {"bo_g", CastPyArg2AttrValues},
       {"bx_g", CastPyArg2AttrValues},
       {"bp_g", CastPyArg2AttrValues},
-      {"bo", CastPyArg2AttrValues}};
+      {"bo", CastPyArg2AttrValues},
+  };
 
   PyObject* obj = nullptr;
   for (ssize_t arg_pos = attr_start; arg_pos < attr_end; arg_pos += 2) {

--- a/paddle/fluid/pybind/op_function_common.h
+++ b/paddle/fluid/pybind/op_function_common.h
@@ -206,6 +206,13 @@ void ConstructAttrMapFromPyArgs(
     ssize_t attr_end,
     paddle::framework::AttributeMap& attrs);  // NOLINT
 
+void ConstructAttrMapForLegacyRunProgram(
+    const std::string& op_type,
+    PyObject* args,
+    ssize_t attr_start,
+    ssize_t attr_end,
+    paddle::framework::AttributeMap& attrs);  // NOLINT
+
 void ConstructAttrMapForRunProgram(
     const std::string& op_type,
     PyObject* args,

--- a/test/cpp/inference/tensorrt/CMakeLists.txt
+++ b/test/cpp/inference/tensorrt/CMakeLists.txt
@@ -10,6 +10,7 @@ if(${TENSORRT_VERSION_NUMBER} GREATER_EQUAL 85)
          phi
          common
          pir_save_load
+         pir_transforms
          pir_tensorrt_plugin)
   set_tests_properties(test_tensorrt_engine_instruction PROPERTIES TIMEOUT 120)
   if(WITH_ONNXRUNTIME AND WIN32)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

将 #72351 中踩坑的逻辑拆分出来单独提 PR，将 `run_program_ad_func` 与 `OpMaker`
 based `RunProgramOp` 彻底解耦（也是 #63226 的后续），本 PR 不移除 run program op，将来就算要删也很简单了

<!-- PCard-66972 -->