### PR TITLE
Do not overwrite root logger

### DIFF
--- a/python/paddle/distributed/auto_parallel/operators/dist_flash_attn.py
+++ b/python/paddle/distributed/auto_parallel/operators/dist_flash_attn.py
@@ -16,7 +16,7 @@ import logging
 
 from ...utils.log_utils import get_logger
 
-_logger = get_logger(logging.INFO)
+_logger = get_logger(logging.INFO, __name__)
 from ..random import determinate_rng, is_enable_auto_rand_ctrl
 from .common import (
     DistributedOperatorImplContainer,

--- a/python/paddle/distributed/auto_parallel/random.py
+++ b/python/paddle/distributed/auto_parallel/random.py
@@ -22,7 +22,7 @@ from ..utils.log_utils import get_logger
 from .process_mesh import retrieve_unique_id_for_process_mesh
 from .static.utils import _get_idx_in_axis
 
-_logger = get_logger(logging.INFO)
+_logger = get_logger(logging.INFO, __name__)
 
 _rng_name_to_seed = {}
 _rng_name_to_states = {}

--- a/python/paddle/distributed/auto_parallel/static/cluster.py
+++ b/python/paddle/distributed/auto_parallel/static/cluster.py
@@ -1230,7 +1230,7 @@ class Cluster:
         return self.__str__()
 
 
-logger = get_logger(logging.INFO)
+logger = get_logger(logging.INFO, __name__)
 
 
 def get_default_cluster(json_config=None, auto_config=None):

--- a/python/paddle/distributed/auto_parallel/static/converter.py
+++ b/python/paddle/distributed/auto_parallel/static/converter.py
@@ -44,7 +44,7 @@ class Converter:
         self._tensors_dict = self._check_tensor_dict(tensors_dict)
         self._pre_strategy = self._check_pre_strategy(pre_strategy)
         self._cur_strategy = self._check_cur_strategy(cur_strategy)
-        self._logger = get_logger(logging.INFO)
+        self._logger = get_logger(logging.INFO, __name__)
 
     def _check_tensor_dict(self, tensors_dict):
         if not tensors_dict:

--- a/python/paddle/distributed/auto_parallel/static/dist_saver.py
+++ b/python/paddle/distributed/auto_parallel/static/dist_saver.py
@@ -52,7 +52,7 @@ def _process_path(path):
 
 class DistributedSaver:
     def __init__(self):
-        self._logger = get_logger(logging.INFO)
+        self._logger = get_logger(logging.INFO, __name__)
 
     def save(self, path, serial_program, dist_main_program, dist_context):
         def _save_state(program, path, mode="param"):

--- a/python/paddle/distributed/auto_parallel/static/engine.py
+++ b/python/paddle/distributed/auto_parallel/static/engine.py
@@ -228,7 +228,7 @@ class Engine:
             )
         self._strategy = strategy or Strategy()
 
-        self._logger = get_logger(logging.INFO)
+        self._logger = get_logger(logging.INFO, __name__)
 
         # for compute cost
         # TODO: remove _fwd_main_progs and _orig_optimizer and _pir_main_progs

--- a/python/paddle/distributed/auto_parallel/static/parallelizer_v2.py
+++ b/python/paddle/distributed/auto_parallel/static/parallelizer_v2.py
@@ -51,7 +51,7 @@ class Parallelizer:
         assert self._dist_context._is_initialized
         self._pass_context = self._dist_context.pass_context
         self._strategy = self._dist_context.strategy
-        self._logger = get_logger(logging.INFO)
+        self._logger = get_logger(logging.INFO, __name__)
 
     @property
     def is_train(self):

--- a/python/paddle/distributed/auto_parallel/static/planner_v2.py
+++ b/python/paddle/distributed/auto_parallel/static/planner_v2.py
@@ -73,7 +73,7 @@ class Planner:
         return self._completer
 
     def plan(self):
-        logger = get_logger(logging.INFO)
+        logger = get_logger(logging.INFO, __name__)
         path = None
         if self._dist_context._json_config:
             try:

--- a/python/paddle/distributed/auto_parallel/static/tuner/rule_based_tuner.py
+++ b/python/paddle/distributed/auto_parallel/static/tuner/rule_based_tuner.py
@@ -1056,7 +1056,7 @@ class RuleBasedTuner:
         self._mode = mode
         assert level in ["o1", "o2"]
         self._level = level
-        self._logger = get_logger(logging.INFO)
+        self._logger = get_logger(logging.INFO, __name__)
         self._use_dp = False
 
         # forward sub program

--- a/python/paddle/distributed/fleet/meta_parallel/sharding/group_sharded_stage2.py
+++ b/python/paddle/distributed/fleet/meta_parallel/sharding/group_sharded_stage2.py
@@ -37,7 +37,7 @@ from .group_sharded_optimizer_stage2 import GroupShardedOptimizerStage2
 from .group_sharded_storage import GradStorage
 from .group_sharded_utils import Type, device_guard
 
-logger_ = get_logger(logging.WARNING)
+logger_ = get_logger(logging.WARNING, __name__)
 
 
 def _trainable(param):

--- a/python/paddle/distributed/passes/auto_parallel_recompute.py
+++ b/python/paddle/distributed/passes/auto_parallel_recompute.py
@@ -41,7 +41,7 @@ from ..auto_parallel.static.utils import (
 from ..utils.log_utils import get_logger
 from .pass_base import PassBase, register_pass
 
-logger = get_logger(logging.INFO)
+logger = get_logger(logging.INFO, __name__)
 
 
 class RecomputeState(ProgramStats):

--- a/python/paddle/distributed/passes/pipeline_scheduler_pass/pipeline_1f1b.py
+++ b/python/paddle/distributed/passes/pipeline_scheduler_pass/pipeline_1f1b.py
@@ -29,7 +29,7 @@ from ..pass_utils import (
 )
 from .pipeline_pass_base import PipelinePassBase
 
-logger = get_logger(logging.INFO)
+logger = get_logger(logging.INFO, __name__)
 
 
 @register_pass("pipeline_scheduler_1F1B")

--- a/python/paddle/distributed/passes/pipeline_scheduler_pass/pipeline_eager_1f1b.py
+++ b/python/paddle/distributed/passes/pipeline_scheduler_pass/pipeline_eager_1f1b.py
@@ -20,7 +20,7 @@ from ...utils.log_utils import get_logger
 from ..pass_base import register_pass
 from .pipeline_pass_base import PipelinePassBase
 
-logger = get_logger(logging.INFO)
+logger = get_logger(logging.INFO, __name__)
 
 
 @register_pass("pipeline_scheduler_Eager1F1B")

--- a/python/paddle/distributed/passes/pipeline_scheduler_pass/pipeline_fthenb.py
+++ b/python/paddle/distributed/passes/pipeline_scheduler_pass/pipeline_fthenb.py
@@ -23,7 +23,7 @@ from ..pass_utils import (
 )
 from .pipeline_pass_base import PipelinePassBase
 
-logger = get_logger(logging.INFO)
+logger = get_logger(logging.INFO, __name__)
 
 
 @register_pass("pipeline_scheduler_FThenB")

--- a/python/paddle/distributed/passes/pipeline_scheduler_pass/pipeline_pass_base.py
+++ b/python/paddle/distributed/passes/pipeline_scheduler_pass/pipeline_pass_base.py
@@ -23,7 +23,7 @@ from ..pass_utils import (
     set_skip_gc_vars,
 )
 
-logger = get_logger(logging.INFO)
+logger = get_logger(logging.INFO, __name__)
 
 
 class PipelinePassBase(PassBase):

--- a/python/paddle/distributed/passes/pipeline_scheduler_pass/pipeline_vpp.py
+++ b/python/paddle/distributed/passes/pipeline_scheduler_pass/pipeline_vpp.py
@@ -31,7 +31,7 @@ from ..pass_utils import (
 )
 from .pipeline_pass_base import PipelinePassBase
 
-logger = get_logger(logging.INFO)
+logger = get_logger(logging.INFO, __name__)
 
 
 @register_pass("pipeline_scheduler_VPP")

--- a/python/paddle/distributed/passes/pipeline_scheduler_pass/pipeline_zero_bubble.py
+++ b/python/paddle/distributed/passes/pipeline_scheduler_pass/pipeline_zero_bubble.py
@@ -21,7 +21,7 @@ from ...utils.log_utils import get_logger
 from ..pass_base import register_pass
 from .pipeline_pass_base import PipelinePassBase
 
-logger = get_logger(logging.INFO)
+logger = get_logger(logging.INFO, __name__)
 
 
 class PipelineZeroBubbleBase(PipelinePassBase):

--- a/python/paddle/distributed/sharding/group_sharded.py
+++ b/python/paddle/distributed/sharding/group_sharded.py
@@ -44,7 +44,7 @@ if TYPE_CHECKING:
     from paddle.distributed.communication.group import Group
     from paddle.nn import Layer
 
-logger_ = get_logger(logging.WARNING)
+logger_ = get_logger(logging.WARNING, __name__)
 
 
 def group_sharded_parallel(

--- a/python/paddle/distributed/utils/launch_utils.py
+++ b/python/paddle/distributed/utils/launch_utils.py
@@ -26,7 +26,7 @@ from paddle.utils import strtobool
 
 from ..utils.log_utils import get_logger
 
-logger = get_logger("INFO", "root")
+logger = get_logger("INFO", __name__)
 
 
 def get_cluster_from_args(args, selected_gpus):

--- a/python/paddle/distributed/utils/log_utils.py
+++ b/python/paddle/distributed/utils/log_utils.py
@@ -15,7 +15,7 @@
 import logging
 
 
-def get_logger(log_level, name="root"):
+def get_logger(log_level, name):
     logger = logging.getLogger(name)
 
     # Avoid printing multiple logs

--- a/python/paddle/distributed/utils/process_utils.py
+++ b/python/paddle/distributed/utils/process_utils.py
@@ -19,7 +19,7 @@ import subprocess
 import paddle
 from paddle.distributed.utils.log_utils import get_logger
 
-logger = get_logger("INFO", "root")
+logger = get_logger("INFO", __name__)
 
 SUCCESS_CODE = 0
 FAIL_CODE = 1


### PR DESCRIPTION
### PR Category
Others


### PR Types
APIs


### Description
I am using the ppdet API to edit configs. The current behaviour of the API overwrites the log level of the root Python logger. This overwrites the log level of all loggers, so the following code does not work.
```
import logging
logger = logging.getLogger(__name__)
logger.info('This prints to screen')
from ppdet.core.workspace import load_config, merge_config
logger.info('This does NOT print, because group_sharded_stage2.py sets the root logger to WARNING level')
```
This is line that causes this behaviour:
https://github.com/phlrain/Paddle/blob/e3fac43fd2f98bdeef0d58b03332aadae2e2aeb6/python/paddle/distributed/fleet/meta_parallel/sharding/group_sharded_stage2.py#L42
This is the PR where this was changed:
https://github.com/PaddlePaddle/Paddle/pull/45093/

This PR modifies the `get_logger` function to require `name` to be passed, so it will not overwrite the root logger. All calls have been changed to call with `name=__name__`, so that a logger for the local scope is used instead.