### PR TITLE
[SOT][Faster Guard] Implement `SymbolicVariable.make_faster_guard`

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/executor_cache.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/executor_cache.py
@@ -48,7 +48,7 @@ if TYPE_CHECKING:
 
 GuardedFunction = Tuple[CustomCode, Guard]
 GuardedFunctions = List[GuardedFunction]
-GuardChain = List[paddle.framework.core.GuardNode]
+GuardChain = List[paddle.framework.core.GuardNodeBase]
 GuardChainList = List[GuardChain]
 
 dummy_guard: Guard = lambda frame: True

--- a/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
@@ -318,13 +318,13 @@ class FunctionGraph:
 
     @property
     @event_register("guard_chain")
-    def guard_chain(self) -> list[paddle.framework.core.GuardNode]:
+    def guard_chain(self) -> list[paddle.framework.core.GuardNodeBase]:
         enable_strict_guard = ENV_SOT_ENABLE_STRICT_GUARD_CHECK.get()
         enable_guard_tree = ENV_SOT_ENABLE_GUARD_TREE.get()
 
         if not enable_strict_guard and not enable_guard_tree:
             return []
-        guard_chain: list[paddle.framework.core.GuardNode] = []
+        guard_chain: list[paddle.framework.core.GuardNodeBase] = []
 
         with EventGuard("guard_fn: find vars and make faster guard"):
             try:

--- a/python/paddle/jit/sot/opcode_translator/executor/guard.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/guard.py
@@ -241,11 +241,11 @@ def check_guard(
 
 
 def check_faster_guard(
-    fn: Callable[[CheckGuardInputT], list[paddle.framework.core.GuardNode]],
-) -> Callable[[CheckGuardInputT], list[paddle.framework.core.GuardNode]]:
+    fn: Callable[[CheckGuardInputT], list[paddle.framework.core.GuardNodeBase]],
+) -> Callable[[CheckGuardInputT], list[paddle.framework.core.GuardNodeBase]]:
     def wrapper(
         self: CheckGuardInputT,
-    ) -> list[paddle.framework.core.GuardNode]:
+    ) -> list[paddle.framework.core.GuardNodeBase]:
         assert (
             self.tracker.is_traceable()
         ), "Cannot make guard from a non-tracable guard variable."
@@ -295,7 +295,9 @@ def object_equal_stringified_guard(self) -> list[StringifiedExpression]:
 
 
 @check_faster_guard
-def object_equal_faster_guard(self) -> list[paddle.framework.core.GuardNode]:
+def object_equal_faster_guard(
+    self,
+) -> list[paddle.framework.core.GuardNodeBase]:
     expr_node = self.tracker.guard_tree_expr_node()
 
     weak_ref_obj = self.get_py_value()

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/base.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/base.py
@@ -346,7 +346,7 @@ class VariableBase:
         return hash(self.id)
 
     @check_faster_guard
-    def make_faster_guard(self) -> list[paddle.framework.core.GuardNode]:
+    def make_faster_guard(self) -> list[paddle.framework.core.GuardNodeBase]:
         expr_node = self.tracker.guard_tree_expr_node()
         return [
             paddle.framework.core.GuardNode(

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
@@ -332,7 +332,7 @@ class TensorDtypeVariable(DataVariable):
         super().__init__(value, graph, tracker)
 
     @check_faster_guard
-    def make_faster_guard(self) -> list[paddle.framework.core.GuardNode]:
+    def make_faster_guard(self) -> list[paddle.framework.core.GuardNodeBase]:
         raise NotImplementedError
 
     @check_guard
@@ -502,7 +502,7 @@ class TensorVariable(VariableBase):
         codegen.gen_load_fast(self.out_var_name)
 
     @check_faster_guard
-    def make_faster_guard(self) -> list[paddle.framework.core.GuardNode]:
+    def make_faster_guard(self) -> list[paddle.framework.core.GuardNodeBase]:
         assert paddle.framework.use_pir_api(), "Only support PIR"
         expr_node = self.tracker.guard_tree_expr_node()
         meta = self.origin_meta
@@ -1197,7 +1197,7 @@ class SymbolicVariable(VariableBase):
         codegen.gen_call_method(0)
 
     @check_faster_guard
-    def make_faster_guard(self) -> list[paddle.framework.core.GuardNode]:
+    def make_faster_guard(self) -> list[paddle.framework.core.GuardNodeBase]:
         assert ENV_SOT_ALLOW_DYNAMIC_SHAPE.get()
         from ..executor_cache import OpcodeExecutorCache
 
@@ -1212,9 +1212,26 @@ class SymbolicVariable(VariableBase):
         if self.need_guard_value:
             log(3, f"Need guard value for {self} in {expr_node}\n")
             return super().make_faster_guard()
-        raise NotImplementedError(
-            f"{self.__class__.__name__}.make_faster_guard is not implemented"
-        )
+        constraint_guards: list[paddle.framework.core.GuardNodeBase] = []
+        for constraint in self.constraints:
+            constraint_node, constraint_extern_vars = constraint
+            extern_vars = {
+                var_name: var.tracker.guard_tree_expr_node()
+                for var_name, var in constraint_extern_vars.items()
+            }
+            constraint_guards.append(
+                paddle.framework.core.ExprGuardNode(
+                    constraint_node.create_guard_node(extern_vars)
+                )
+            )
+        guards = [
+            paddle.framework.core.GuardNode(
+                paddle.core.TypeMatchGuard(self.get_py_type()),
+                [expr_node],
+            ),
+            *constraint_guards,
+        ]
+        return guards
 
     @check_guard
     def make_stringified_guard(self) -> list[StringifiedExpression]:
@@ -1248,7 +1265,7 @@ class SymbolicVariable(VariableBase):
                 [frame_value_tracer],
                 union_free_vars(frame_value_tracer.free_vars),
             ),
-            # TODO: replace it with FasterStringifiedExpression
+            # TODO(zrr1999): replace it with FasterStringifiedExpression
             *constraint_guards,
         ]
         return guards
@@ -1493,7 +1510,7 @@ class SliceVariable(VariableBase):
         )
 
     @check_faster_guard
-    def make_faster_guard(self) -> list[paddle.framework.core.GuardNode]:
+    def make_faster_guard(self) -> list[paddle.framework.core.GuardNodeBase]:
         expr_node = self.tracker.guard_tree_expr_node()
         return [
             paddle.framework.core.GuardNode(
@@ -1601,7 +1618,7 @@ class DygraphTracerVariable(VariableBase):
         return self.value
 
     @check_faster_guard
-    def make_faster_guard(self) -> list[paddle.framework.core.GuardNode]:
+    def make_faster_guard(self) -> list[paddle.framework.core.GuardNodeBase]:
         return []
 
     @check_guard
@@ -1656,7 +1673,7 @@ class NumpyVariable(VariableBase):
         return f"{NumpyVariable.format_dtype(number.dtype)}({number.item()})"
 
     @check_faster_guard
-    def make_faster_guard(self) -> list[paddle.framework.core.GuardNode]:
+    def make_faster_guard(self) -> list[paddle.framework.core.GuardNodeBase]:
         raise NotImplementedError(
             f"{self.__class__.__name__}.make_faster_guard is not implemented"
         )
@@ -1689,7 +1706,7 @@ class NumpyNumberVariable(NumpyVariable):
         ).bind(self, name)
 
     @check_faster_guard
-    def make_faster_guard(self) -> list[paddle.framework.core.GuardNode]:
+    def make_faster_guard(self) -> list[paddle.framework.core.GuardNodeBase]:
         expr_node = self.tracker.guard_tree_expr_node()
         dtype_guard = paddle.framework.core.GuardNode(
             paddle.framework.core.NumPyDtypeMatchGuard(
@@ -1746,7 +1763,7 @@ class NumpyBoolVariable(NumpyNumberVariable):
 
 class NumpyArrayVariable(NumpyVariable):
     @check_faster_guard
-    def make_faster_guard(self) -> list[paddle.framework.core.GuardNode]:
+    def make_faster_guard(self) -> list[paddle.framework.core.GuardNodeBase]:
         expr_node = self.tracker.guard_tree_expr_node()
         dtype_guard = paddle.framework.core.GuardNode(
             paddle.framework.core.NumPyDtypeMatchGuard(

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/callable.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/callable.py
@@ -548,7 +548,7 @@ class LayerVariable(CallableVariable):
         ]
 
     @check_faster_guard
-    def make_faster_guard(self) -> list[paddle.framework.core.GuardNode]:
+    def make_faster_guard(self) -> list[paddle.framework.core.GuardNodeBase]:
         expr_node = self.tracker.guard_tree_expr_node()
         return [
             paddle.framework.core.GuardNode(
@@ -624,7 +624,7 @@ class ContainerLayerVariable(LayerVariable):
             return super().make_stringified_guard()
 
     @check_faster_guard
-    def make_faster_guard(self) -> list[paddle.framework.core.GuardNode]:
+    def make_faster_guard(self) -> list[paddle.framework.core.GuardNodeBase]:
         if isinstance(self.value, PD_SEQ_CONTAINERS):
             expr_node = self.tracker.guard_tree_expr_node()
             len_guard = paddle.framework.core.GuardNode(
@@ -632,7 +632,7 @@ class ContainerLayerVariable(LayerVariable):
                 [expr_node],
             )
 
-            guards: list[paddle.framework.core.GuardNode] = [len_guard]
+            guards: list[paddle.framework.core.GuardNodeBase] = [len_guard]
             for idx, layer in enumerate(self.value):
                 layer_variable = VariableFactory.from_value(
                     layer, self.graph, GetItemTracker(self, idx)
@@ -693,7 +693,7 @@ class PaddleLayerVariable(LayerVariable):
             return super().make_stringified_guard()
 
     @check_faster_guard
-    def make_faster_guard(self) -> list[paddle.framework.core.GuardNode]:
+    def make_faster_guard(self) -> list[paddle.framework.core.GuardNodeBase]:
         if isinstance(self.tracker, CreateLayerTracker):
             return reduce(
                 operator.add,

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/container.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/container.py
@@ -129,7 +129,7 @@ class ContainerVariable(VariableBase):
         )
 
     @check_faster_guard
-    def make_faster_guard(self) -> list[paddle.framework.core.GuardNode]:
+    def make_faster_guard(self) -> list[paddle.framework.core.GuardNodeBase]:
         expr_node = self.tracker.guard_tree_expr_node()
 
         if self.get_py_type() is dict:
@@ -766,7 +766,7 @@ class RangeVariable(ContainerVariable):
         return None
 
     @check_faster_guard
-    def make_faster_guard(self) -> list[paddle.framework.core.GuardNode]:
+    def make_faster_guard(self) -> list[paddle.framework.core.GuardNodeBase]:
         frame_value_tracer = self.tracker.guard_tree_expr_node()
         return [
             paddle.framework.core.GuardNode(

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/iter.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/iter.py
@@ -103,7 +103,7 @@ class SequenceIterVariable(IterVariable):
         self.graph.side_effects.record_mutable_variable(self)
 
     @check_faster_guard
-    def make_faster_guard(self) -> list[paddle.framework.core.GuardNode]:
+    def make_faster_guard(self) -> list[paddle.framework.core.GuardNodeBase]:
         return [
             guard
             for holded in self.holds
@@ -452,7 +452,7 @@ class UserDefinedIterVariable(IterVariable):
         )
 
     @check_faster_guard
-    def make_faster_guard(self) -> list[paddle.framework.core.GuardNode]:
+    def make_faster_guard(self) -> list[paddle.framework.core.GuardNodeBase]:
         return [
             guard
             for holded in self.holds


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Performance

### Description
<!-- Describe what you’ve done -->
实现了 SymbolicVariable.make_faster_guard，主要通过下面几个工作实现：

- 实现了 BinaryExprNode 和 UnaryExprNode 节点
- 实现了 GuardNodeBase 和 ExprNodeBase（即原本的ExprNode改名）两个基类，父类都为 GuardTreeNodeBase
- 实现了 ExprGuardNode ，父类为 GuardNodeBase，原本的 ExprGuard 父类改为GuardNodeBase并移动了部分功能到父类。
- 给 ConstraintNode体系添加create_guard_node方法
- 实现了 SymbolicVariable.make_faster_guard