### PR TITLE
Support integer type promotion

### DIFF
--- a/paddle/phi/common/type_promotion.h
+++ b/paddle/phi/common/type_promotion.h
@@ -222,14 +222,15 @@ inline bool NeedTypePromotion(
     }
 #endif
 
-    if ((is_support_float(x_dtype) && is_support_float(y_dtype)) ||
+    if ((is_support_int(x_dtype) && is_support_int(y_dtype)) ||
+        (is_support_float(x_dtype) && is_support_float(y_dtype)) ||
         (is_support_complex(x_dtype) || is_support_complex(y_dtype))) {
       return true;
     } else {
       PADDLE_THROW(common::errors::InvalidType(
-          "Type promotion only support calculations between floating-point "
-          "numbers and between complex and real numbers. But got different "
-          "data type x: %s, y: %s.",
+          "Type promotion supports calculations between integers, between "
+          "floating-point numbers, and between complex and real numbers. But "
+          "got incompatible data type: x: %s, y: %s.",
           x_dtype,
           y_dtype));
     }


### PR DESCRIPTION
### PR Category

User Experience

### PR Types

Bug fixes

### Description
Pcard-75624

为整数类型添加了类型提升，允许进行整数类型之间的混合计算
```
import paddle

x = paddle.to_tensor([1], dtype='int32')
y = paddle.to_tensor([2], dtype='int64')
z = x + y

print(z)

# 修复前输出 
# ----------------------
# Error Message Summary:
# ----------------------
# InvalidTypeError: Type promotion only support calculations between floating-point numbers and between complex and real numbers. But got different data type x: int32, y: int64. (at /root/Paddle/paddle/phi/common/type_promotion.h:229)

# 修复后输出: 
# Tensor(shape=[1], dtype=int64, place=Place(gpu:0), stop_gradient=True, [3])
```