### PR TITLE
fix a bug, create_parameter not supprot paddle.bfloat16

### DIFF
--- a/python/paddle/base/layer_helper_base.py
+++ b/python/paddle/base/layer_helper_base.py
@@ -21,7 +21,6 @@ import numpy as np
 import paddle
 
 from . import core, unique_name
-from .data_feeder import convert_dtype
 from .framework import (
     Variable,
     _current_expected_place,
@@ -368,7 +367,7 @@ class LayerHelperBase:
         if not dtype:
             dtype = self.__dtype
         if isinstance(dtype, core.DataType):
-            dtype = convert_dtype(dtype)
+            dtype = paddle.pir.core.datatype_to_vartype[dtype]
         if is_bias:
             suffix = 'b'
             default_initializer = (

--- a/python/paddle/base/layer_helper_base.py
+++ b/python/paddle/base/layer_helper_base.py
@@ -448,6 +448,8 @@ class LayerHelperBase:
             )
         else:
             if in_pir_mode():
+                if isinstance(dtype, core.VarDesc.VarType):
+                    dtype = paddle.pir.core.vartype_to_datatype[dtype]
                 return paddle.pir.core.create_parameter(
                     dtype=dtype,
                     shape=shape,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
create_parameter只支持VarType和字符串类型。如果传入Dtype类型，早期是把他转为字符串类型。而为了适配numpy没有bfloat16的情况，convert_dtype将paddle.bfloat16转为了"uint16"。
修改create_parameter，如果为Dtype类型，则转为VarType类型。

修复后：

![1745479735174](https://github.com/user-attachments/assets/6c0c5668-416d-410d-ba83-08525ae71817)


Pcard-67164