### PR TITLE
【CINN】Fix bug of nvrtc compile

### DIFF
--- a/paddle/cinn/common/ir_util.cc
+++ b/paddle/cinn/common/ir_util.cc
@@ -512,16 +512,6 @@ void OpDataTypePromote(Expr *expr) {
       node->body = promote_args.at(1);
       IRMutator::Visit(op, expr);
     }
-
-    void Visit(const ir::For *op, ir::Expr *expr) {
-      auto node = expr->As<ir::For>();
-      auto promote_args = std::move(ir::TryElevateInt32ToInt64(
-          {node->loop_var, node->min, node->extent}));
-      node->loop_var = promote_args.at(0);
-      node->min = promote_args.at(1);
-      node->extent = promote_args.at(2);
-      IRMutator::Visit(op, expr);
-    }
   };
 
   TypePromote visitor;

--- a/paddle/cinn/ir/ir.cc
+++ b/paddle/cinn/ir/ir.cc
@@ -352,6 +352,11 @@ Expr Let::Make(Expr symbol, Expr body) {
   body = promote_args.at(1);
 
   n->symbol = symbol;
+
+  if (n->symbol.is_var()) {
+    n->symbol.as_var()->is_let_symbol = true;
+  }
+
   n->body = body;
   n->set_type(n->symbol->type());
   return Expr(n);
@@ -395,13 +400,15 @@ Expr _Var_::Make(Expr lower_bound,
                  const std::string &name,
                  bool is_reduce_axis,
                  bool is_symbolic_constant,
-                 bool is_keepdim) {
+                 bool is_keepdim,
+                 bool is_let_symbol) {
   auto *n = make_shared<_Var_>();
   n->lower_bound = lower_bound;
   n->upper_bound = upper_bound;
   n->is_reduce_axis = is_reduce_axis;
   n->is_keepdim = is_keepdim;
   n->is_symbolic_constant = is_symbolic_constant;
+  n->is_let_symbol = is_let_symbol;
   n->name = name;
   n->set_type(lower_bound.type());
   return Expr(n);
@@ -412,6 +419,8 @@ Expr _Var_::Copy() const {
   n->name = name;
   n->is_reduce_axis = is_reduce_axis;
   n->is_keepdim = is_keepdim;
+  n->is_symbolic_constant = is_symbolic_constant;
+  n->is_let_symbol = is_let_symbol;
   n->set_index(get_index());
   n->lower_bound = lower_bound;
   n->upper_bound = upper_bound;

--- a/paddle/cinn/ir/ir.h
+++ b/paddle/cinn/ir/ir.h
@@ -393,6 +393,7 @@ struct _Var_ : public ExprNode<_Var_> {
   bool is_reduce_axis{false};
   bool is_keepdim{false};
   bool is_symbolic_constant{false};
+  bool is_let_symbol{false};
   //! Lower bound and upper bound of a axis.
   // @{
   Expr lower_bound;
@@ -413,7 +414,8 @@ struct _Var_ : public ExprNode<_Var_> {
                    const std::string& name,
                    bool is_reduce,
                    bool is_symbolic_constant = false,
-                   bool is_keepdim = false);
+                   bool is_keepdim = false,
+                   bool is_let_symbol = false);
 
   void Verify() const override;
 

--- a/paddle/cinn/ir/ir_base.cc
+++ b/paddle/cinn/ir/ir_base.cc
@@ -641,6 +641,9 @@ void IrNode::convert_int32_to_int64() {
       }
     } else if (operand->node_type() == IrNodeTy::Load) {
       operand = ir::Cast::Make(type(), operand);
+    } else if (operand->node_type() == IrNodeTy::_Var_ &&
+               operand.as_var()->is_let_symbol) {
+      operand = ir::Cast::Make(type(), operand);
     }
   }
 }
@@ -675,6 +678,9 @@ void IrNode::convert_int64_to_int32() {
         operand->set_type(Int(32));
       }
     } else if (operand->node_type() == IrNodeTy::Load) {
+      operand = ir::Cast::Make(type(), operand);
+    } else if (operand->node_type() == IrNodeTy::_Var_ &&
+               operand.as_var()->is_let_symbol) {
       operand = ir::Cast::Make(type(), operand);
     }
   }
@@ -713,6 +719,9 @@ void TryElevateInt32ToInt64_(std::vector<Expr> &expr_vec) {  // NOLINT
         }
       } else if (expr->node_type() == IrNodeTy::Load) {
         expr = ir::Cast::Make(Int(64), expr);
+      } else if (expr->node_type() == IrNodeTy::_Var_ &&
+                 expr.as_var()->is_let_symbol) {
+        expr = ir::Cast::Make(Int(64), expr);
       }
     }
   }
@@ -747,6 +756,10 @@ void ElevateInt64ToInt32_(Expr &expr) {  // NOLINT
         expr->set_type(Int(32));
       }
     } else if (expr->node_type() == IrNodeTy::Load) {
+      expr = ir::Cast::Make(Int(32), expr);
+    } else if (expr->node_type() == IrNodeTy::_Var_ &&
+               expr.as_var()->is_let_symbol) {
+      // symbol of `let` op should be use cast to convert to int32.
       expr = ir::Cast::Make(Int(32), expr);
     }
   }

--- a/paddle/cinn/ir/utils/ir_copy.cc
+++ b/paddle/cinn/ir/utils/ir_copy.cc
@@ -200,6 +200,7 @@ struct IRCopyVisitor : public ir::IRVisitorRequireReImpl<Expr>,
     n->name = op->name;
     n->is_reduce_axis = op->is_reduce_axis;
     n->is_symbolic_constant = op->is_symbolic_constant;
+    n->is_let_symbol = op->is_let_symbol;
     n->set_type(op->type());
 
     if (op->lower_bound.defined()) {

--- a/paddle/cinn/optim/longlong2int_pass.cc
+++ b/paddle/cinn/optim/longlong2int_pass.cc
@@ -141,9 +141,10 @@ class CastLonglong2IntMutator : public ir::IRMutator<> {
     // min(min(S0, 1ll), 1ll) ==> min(min(S0, 1), 1)
     // min(V[S0, S1], 1ll)    ==> min(V[S0, S1], 1ll)
     // min(S0 + 1ll, 1ll)     ==> max(S0 + 1, 1)
-    // IndexType::kValid means expr only has +-*/%, Const, Symbol, Min, Max.
+    // min(V[0], S0)          ==> min((int32)V[0], S1)
+    // min(var_local, S0)     ==> min((int32)var_local, S0)
     // IsDynamic == true means expr has Symbol.
-    if (optim::VerifyIndex(*expr) == ir::IndexExpr::IndexType::kValid &&
+    if (optim::VerifyIndex(*expr) != ir::IndexExpr::IndexType::kInvalid &&
         expr->as_index().IsDynamic()) {
       ir::ElevateInt64ToInt32_((*expr)->operands);
     } else {
@@ -153,7 +154,7 @@ class CastLonglong2IntMutator : public ir::IRMutator<> {
   }
   void Visit(const ir::Max* op, Expr* expr) override {
     auto node = expr->As<ir::Max>();
-    if (optim::VerifyIndex(*expr) == ir::IndexExpr::IndexType::kValid &&
+    if (optim::VerifyIndex(*expr) != ir::IndexExpr::IndexType::kInvalid &&
         expr->as_index().IsDynamic()) {
       ir::ElevateInt64ToInt32_((*expr)->operands);
     } else {

--- a/paddle/cinn/optim/longlong2int_pass.cc
+++ b/paddle/cinn/optim/longlong2int_pass.cc
@@ -162,6 +162,20 @@ class CastLonglong2IntMutator : public ir::IRMutator<> {
       ir::IRMutator<>::Visit(&node->b(), &node->b());
     }
   }
+  void Visit(const ir::Call* op, Expr* expr) override {
+    auto node = expr->As<ir::Call>();
+    if (op->name == "CINN_ENTAIL_LOOP_CONDITION") {
+      // args of CINN_ENTAIL_LOOP_CONDITION is [loop_var, condition, stride],
+      // loop_var type is equal to stride type, so we only need to elevate
+      // condition and stride to int32.
+      ir::ElevateInt64ToInt32_(node->read_args[1]->operands);
+      ir::ElevateInt64ToInt32_(node->read_args[2]);
+    } else {
+      for (auto& expr : node->read_args) {
+        ir::IRMutator<>::Visit(&expr, &expr);
+      }
+    }
+  }
 };
 
 class LongLong2IntStmtPass : public StmtPass {

--- a/paddle/cinn/optim/simplify_util.cc
+++ b/paddle/cinn/optim/simplify_util.cc
@@ -224,7 +224,14 @@ bool IsNegatedIndexExpr(const ir::IndexExpr &candidate,
 
 ir::IndexExpr::IndexType VerifyIndex(const ir::Expr &expr) {
   switch (expr.node_type()) {
-    case ir::IrNodeTy::_Var_:
+    case ir::IrNodeTy::_Var_: {
+      if (expr.type().is_index_type()) {
+        return expr.as_var()->is_let_symbol ? ir::IndexExpr::IndexType::kLoad
+                                            : ir::IndexExpr::IndexType::kValid;
+      } else {
+        return ir::IndexExpr::IndexType::kInvalid;
+      }
+    }
     case ir::IrNodeTy::IntImm: {
       return expr.type().is_index_type() ? ir::IndexExpr::IndexType::kValid
                                          : ir::IndexExpr::IndexType::kInvalid;

--- a/paddle/cinn/pybind/ir/ir_api.cc
+++ b/paddle/cinn/pybind/ir/ir_api.cc
@@ -384,6 +384,7 @@ void BindIrIr(py::module *m) {
                                     const std::string &,
                                     bool,
                                     bool,
+                                    bool,
                                     bool>(&ir::_Var_::Make))
       .def("copy", &ir::_Var_::Copy);
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
1. 修复FastRcnn-tiny中nvrtc编译问题
  问题原因：Let op声明的Var具有固定type，不能在IR层面直接转换type，需要插入cast进行转换
  解决办法：Var 新增 is_let_symbol 字段进行区分
2. 修复dpa3中nvrtc编译问题
  问题原因：CINN_ENTAIL_LOOP_CONDITION 中存在min\max未转换
  解决办法：longlong2int 中新增 call CINN_ENTAIL_LOOP_CONDITION mutator
Pcard-67164