### PR TITLE
fix pack_unpack recompute stop_gradient error

### DIFF
--- a/python/paddle/distributed/fleet/recompute/recompute.py
+++ b/python/paddle/distributed/fleet/recompute/recompute.py
@@ -387,6 +387,7 @@ def _recompute_without_reentrant(
                         inner_x.persistable,
                     )
                 inner_x._unsafe_share_buffer_to(tmp_tensor)
+                tmp_tensor.stop_gradient = inner_x.stop_gradient
                 storage[holder_list[unpack_counter - 1]()] = tmp_tensor
                 return
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
unpack里返回tensor时丢失了原tensor的stop_gradient信息