### PR TITLE
[Update] test matrix exp tol for mac m4

### DIFF
--- a/test/legacy_test/test_linalg_matrix_exp.py
+++ b/test/legacy_test/test_linalg_matrix_exp.py
@@ -27,8 +27,8 @@ if sys.platform == 'win32':
     RTOL = {'float32': 1e-02, 'float64': 1e-04}
     ATOL = {'float32': 1e-02, 'float64': 1e-04}
 elif sys.platform == 'darwin':
-    RTOL = {'float32': 1e-06, 'float64': 1e-13}
-    ATOL = {'float32': 1e-06, 'float64': 1e-13}
+    RTOL = {'float32': 1e-06, 'float64': 1e-12}
+    ATOL = {'float32': 1e-06, 'float64': 1e-12}
 else:
     RTOL = {'float32': 1e-06, 'float64': 1e-15}
     ATOL = {'float32': 1e-06, 'float64': 1e-15}

--- a/test/legacy_test/test_linalg_matrix_exp.py
+++ b/test/legacy_test/test_linalg_matrix_exp.py
@@ -26,6 +26,9 @@ from paddle.base import core
 if sys.platform == 'win32':
     RTOL = {'float32': 1e-02, 'float64': 1e-04}
     ATOL = {'float32': 1e-02, 'float64': 1e-04}
+elif sys.platform == 'darwin':
+    RTOL = {'float32': 1e-06, 'float64': 1e-13}
+    ATOL = {'float32': 1e-06, 'float64': 1e-13}
 else:
     RTOL = {'float32': 1e-06, 'float64': 1e-15}
     ATOL = {'float32': 1e-06, 'float64': 1e-15}


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
修改 `matrix_exp` 在 mac 环境下的 rtol/atol ，从 `'float64': 1e-15` 改为 `'float64': 1e-12` 。

这个算子是纯 python 实现的，因此其精度基本上是由基础的底层算子决定。

当时添加这个算子的时候还没有 mac m4 ，但是应该在其他 mac 环境中测试过，是没啥问题的。

由此，https://github.com/PaddlePaddle/Paddle/issues/72468#issuecomment-2829244345 中提到的精度问题，有可能的原因：

- `matrix_exp` 添加至目前，底层的算子有改动，影响了精度，但是当时没有 m4 环境，所以当时也没有发现。
- 或者，底层依赖的 mac 基础算子，在 mac m4 上本身有精度变动导致。

这个算子涉及到的数值运算较多，对测试环境还是比较敏感的，如 win32 只能到 `'float64': 1e-04`  ~

个人感觉降低精度影响不大 ～ 看看降低精度要求是否可以通过 CI 测试，研发帮忙再评估一下影响看是否可以放行 ？ ～

关联 https://github.com/PaddlePaddle/Paddle/pull/59715 https://github.com/PaddlePaddle/Paddle/issues/72468#issuecomment-2829244345

@cxxly @tianshuo78520a @luotao1

