### PR TITLE
[Windows] Export symbols decorated by TEST_API or IR_API

### DIFF
--- a/paddle/utils/test_macros.h
+++ b/paddle/utils/test_macros.h
@@ -15,7 +15,7 @@
 #pragma once
 
 #define TEST_API
-#if defined(_WIN32) && defined(PADDLE_WITH_TESTING) && !defined(STATIC_PADDLE)
+#if defined(_WIN32) && !defined(STATIC_PADDLE)
 #ifdef PADDLE_DLL_EXPORT
 #define TEST_API __declspec(dllexport)
 #else


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
export symbols decorated by TEST_API or IR_API on Windows while `WITH_TESTING=OFF` 
pcard-67164