### PR TITLE
[SOT][FasterGuard] refactor GuardNode

### DIFF
--- a/paddle/fluid/pybind/sot/guards.cc
+++ b/paddle/fluid/pybind/sot/guards.cc
@@ -366,48 +366,6 @@ std::optional<int> GuardNodeBase::lookup_next(FrameProxy* frame) {
   return std::nullopt;
 }
 
-template <size_t N>
-std::optional<int> CheckGuardNode<N>::lookup(FrameProxy* frame) {
-  std::array<PyObject*, N> values = {};
-  for (size_t i = 0; i < N; ++i) {
-    values[i] = exprs[i]->eval(frame);
-    if (values[i]) {
-      Py_INCREF(values[i]);
-    }
-  }
-  std::optional<int> ret = std::nullopt;
-  if (check(values)) {
-    ret = lookup_next(frame);
-  }
-  for (size_t i = 0; i < N; ++i) {
-    if (values[i]) {
-      Py_DECREF(values[i]);
-    }
-  }
-  return ret;
-}
-template <size_t N>
-std::string CheckGuardNode<N>::stringify(int indent) {
-  std::stringstream ss;
-  ss << std::string(indent, ' ') << get_guard_name();
-  ss << "(";
-  for (size_t i = 0; i < N; ++i) {
-    if (i > 0) {
-      ss << " | ";
-    }
-    ss << exprs[i]->stringify();
-  }
-  ss << ")";
-  if (!next_guard_nodes.empty()) {
-    ss << " |" << std::endl;
-    for (auto& next_guard_node : next_guard_nodes) {
-      ss << std::string(indent + 2, ' ');
-      ss << next_guard_node->stringify(indent + 2) << std::endl;
-    }
-  }
-  return ss.str();
-}
-
 bool TensorDistMetaMatchGuardNode::check(std::array<PyObject*, 2> values) {
   PyObject* expr = values[0];
   HANDLE_NULL_VALUE(expr);

--- a/paddle/fluid/pybind/sot/guards.cc
+++ b/paddle/fluid/pybind/sot/guards.cc
@@ -218,60 +218,6 @@ bool WeakRefMatchGuard::check(PyObject* value) {
 #endif
 }
 
-bool TensorDistMetaMatchGuard::check(PyObject* value) {
-  HANDLE_NULL_VALUE(value);
-
-  PyObject* expr = PyTuple_GetItem(value, 0);
-  HANDLE_NULL_VALUE(expr);
-
-  auto tensor = GetTensorFromPyObject(expr);
-  HANDLE_NULL_TENSOR(tensor);
-
-  if (tensor->is_dist_tensor() == false && is_dist_ == false) return true;
-  if (tensor->is_dist_tensor() != is_dist_) {
-    return false;
-  }
-
-  PyObject* dist_info_from_tensor_func = PyTuple_GetItem(value, 1);
-  HANDLE_NULL_VALUE(dist_info_from_tensor_func);
-
-  PyObject* dist_info = PyObject_CallOneArg(dist_info_from_tensor_func, expr);
-  HANDLE_NULL_VALUE_DECREF(dist_info);
-
-  PyObject* mesh = PyObject_GetAttrString(dist_info, "mesh");
-  HANDLE_NULL_VALUE_DECREF(mesh);
-
-  PyObject* mesh_shape = PyObject_GetAttrString(mesh, "shape");
-  HANDLE_NULL_VALUE_DECREF(mesh_shape);
-  PyObject* process_ids = PyObject_GetAttrString(mesh, "process_ids");
-  HANDLE_NULL_VALUE_DECREF(process_ids);
-  PyObject* dims_mapping = PyObject_GetAttrString(dist_info, "dims_mapping");
-  HANDLE_NULL_VALUE_DECREF(dims_mapping);
-  PyObject* local_shape = PyObject_GetAttrString(dist_info, "local_shape");
-  HANDLE_NULL_VALUE_DECREF(local_shape);
-
-  if (py::handle(mesh_shape).cast<std::vector<int>>() != mesh_shape_expected_ ||
-      py::handle(process_ids).cast<std::vector<int>>() !=
-          mesh_process_ids_expected_.value() ||
-      !PyObject_Equal(dims_mapping, dims_mapping_expected_.value()) ||
-      !PyObject_Equal(local_shape, local_shape_expected_.value())) {
-    Py_DECREF(mesh);
-    Py_DECREF(mesh_shape);
-    Py_DECREF(process_ids);
-    Py_DECREF(dims_mapping);
-    Py_DECREF(local_shape);
-    PyErr_Clear();
-    return false;
-  }
-
-  Py_DECREF(mesh);
-  Py_DECREF(mesh_shape);
-  Py_DECREF(process_ids);
-  Py_DECREF(dims_mapping);
-  Py_DECREF(local_shape);
-  return true;
-}
-
 PyObject* ConstantExprNode::eval(FrameProxy* frame) { return value_ptr_; }
 std::string ConstantExprNode::stringify(int indent) {
   return py::str(value_ptr_);
@@ -407,54 +353,51 @@ std::string BinaryExprNode::stringify(int indent) {
   return ss.str();
 }
 
-std::optional<int> GuardNode::lookup(FrameProxy* frame) {
-  // TODO(zrr1999): support multiple exprs
-  PyObject* value = [this, frame]() {
-    if (exprs.size() == 1) {
-      PyObject* v = exprs.back()->eval(frame);
-      if (v) {
-        // TODO(dev): DECREF v.
-        Py_INCREF(v);
-      }
-      return v;
-    }
-    auto values = std::vector<PyObject*>(exprs.size());
-    for (size_t i = 0; i < exprs.size(); ++i) {
-      values[i] = exprs[i]->eval(frame);
-      if (values[i]) {
-        Py_INCREF(values[i]);
-      }
-    }
-    auto packed_value = PyTuple_New(exprs.size());
-    for (size_t i = 0; i < exprs.size(); ++i) {
-      PyTuple_SetItem(packed_value, i, values[i]);
-    }
-    return packed_value;
-  }();
-
-  if (guard->check(value)) {
-    // TODO(zrr1999): To extract the reusable code, we need to add a new method
-    // to GuardNodeBase<N>
-    if (return_cache_index.has_value()) {
-      Py_DECREF(value);
-      return return_cache_index.value();
-    }
-    for (auto& next_guard_node : next_guard_nodes) {
-      auto ret = next_guard_node->lookup(frame);
-      if (ret.has_value()) {
-        Py_DECREF(value);
-        return ret.value();
-      }
+std::optional<int> GuardNodeBase::lookup_next(FrameProxy* frame) {
+  if (return_cache_index.has_value()) {
+    return return_cache_index.value();
+  }
+  for (auto& next_guard_node : next_guard_nodes) {
+    auto ret = next_guard_node->lookup(frame);
+    if (ret.has_value()) {
+      return ret.value();
     }
   }
   return std::nullopt;
 }
-std::string GuardNode::stringify(int indent) {
+
+template <size_t N>
+std::optional<int> CheckGuardNode<N>::lookup(FrameProxy* frame) {
+  std::array<PyObject*, N> values = {};
+  for (size_t i = 0; i < N; ++i) {
+    values[i] = exprs[i]->eval(frame);
+    if (values[i]) {
+      Py_INCREF(values[i]);
+    }
+  }
+  std::optional<int> ret = std::nullopt;
+  if (check(values)) {
+    ret = lookup_next(frame);
+  }
+  for (size_t i = 0; i < N; ++i) {
+    if (values[i]) {
+      Py_DECREF(values[i]);
+    }
+  }
+  return ret;
+}
+template <size_t N>
+std::string CheckGuardNode<N>::stringify(int indent) {
   std::stringstream ss;
-  // TODO(zrr1999): support multiple exprs
-  auto expr = exprs.back();
-  ss << std::string(indent, ' ') << guard->get_guard_name();
-  ss << "(" << exprs.back()->stringify() << ")";
+  ss << std::string(indent, ' ') << get_guard_name();
+  ss << "(";
+  for (size_t i = 0; i < N; ++i) {
+    if (i > 0) {
+      ss << " | ";
+    }
+    ss << exprs[i]->stringify();
+  }
+  ss << ")";
   if (!next_guard_nodes.empty()) {
     ss << " |" << std::endl;
     for (auto& next_guard_node : next_guard_nodes) {
@@ -465,12 +408,68 @@ std::string GuardNode::stringify(int indent) {
   return ss.str();
 }
 
+bool TensorDistMetaMatchGuardNode::check(std::array<PyObject*, 2> values) {
+  PyObject* expr = values[0];
+  HANDLE_NULL_VALUE(expr);
+
+  auto tensor = GetTensorFromPyObject(expr);
+  HANDLE_NULL_TENSOR(tensor);
+
+  if (tensor->is_dist_tensor() == false && is_dist_ == false) return true;
+  if (tensor->is_dist_tensor() != is_dist_) {
+    return false;
+  }
+
+  PyObject* dist_info_from_tensor_func = values[1];
+  HANDLE_NULL_VALUE(dist_info_from_tensor_func);
+
+  PyObject* dist_info = PyObject_CallOneArg(dist_info_from_tensor_func, expr);
+  HANDLE_NULL_VALUE_DECREF(dist_info);
+
+  PyObject* mesh = PyObject_GetAttrString(dist_info, "mesh");
+  HANDLE_NULL_VALUE_DECREF(mesh);
+
+  PyObject* mesh_shape = PyObject_GetAttrString(mesh, "shape");
+  HANDLE_NULL_VALUE_DECREF(mesh_shape);
+  PyObject* process_ids = PyObject_GetAttrString(mesh, "process_ids");
+  HANDLE_NULL_VALUE_DECREF(process_ids);
+  PyObject* dims_mapping = PyObject_GetAttrString(dist_info, "dims_mapping");
+  HANDLE_NULL_VALUE_DECREF(dims_mapping);
+  PyObject* local_shape = PyObject_GetAttrString(dist_info, "local_shape");
+  HANDLE_NULL_VALUE_DECREF(local_shape);
+
+  if (py::handle(mesh_shape).cast<std::vector<int>>() != mesh_shape_expected_ ||
+      py::handle(process_ids).cast<std::vector<int>>() !=
+          mesh_process_ids_expected_.value() ||
+      !PyObject_Equal(dims_mapping, dims_mapping_expected_.value()) ||
+      !PyObject_Equal(local_shape, local_shape_expected_.value())) {
+    Py_DECREF(mesh);
+    Py_DECREF(mesh_shape);
+    Py_DECREF(process_ids);
+    Py_DECREF(dims_mapping);
+    Py_DECREF(local_shape);
+    PyErr_Clear();
+    return false;
+  }
+
+  Py_DECREF(mesh);
+  Py_DECREF(mesh_shape);
+  Py_DECREF(process_ids);
+  Py_DECREF(dims_mapping);
+  Py_DECREF(local_shape);
+  return true;
+}
+
+bool LegacyGuardNode::check(std::array<PyObject*, 1> values) {
+  // TODO(zrr1999): support multiple exprs
+  PyObject* value = values[0];
+  HANDLE_NULL_VALUE(value);
+  return guard->check(value);
+}
+
 std::optional<int> ExprGuardNode::lookup(FrameProxy* frame) {
-  auto expr = expr_;
   auto value = expr->eval(frame);
   if (PyObject_IsTrue(value)) {
-    // TODO(zrr1999): To extract the reusable code, we need to add a new method
-    // to GuardNodeBase<N>
     if (return_cache_index.has_value()) {
       return return_cache_index.value();
     }
@@ -486,7 +485,7 @@ std::optional<int> ExprGuardNode::lookup(FrameProxy* frame) {
 std::string ExprGuardNode::stringify(int indent) {
   std::stringstream ss;
   ss << std::string(indent, ' ');
-  ss << "(" << expr_->stringify() << ")";
+  ss << "(" << expr->stringify() << ")";
   if (!next_guard_nodes.empty()) {
     ss << " |" << std::endl;
     for (auto& next_guard_node : next_guard_nodes) {
@@ -499,17 +498,7 @@ std::string ExprGuardNode::stringify(int indent) {
 
 std::optional<int> DummyGuardNode::lookup(FrameProxy* frame) {
   if (return_true_) {
-    // TODO(zrr1999): To extract the reusable code, we need to add a new method
-    // to GuardNodeBase
-    if (return_cache_index.has_value()) {
-      return return_cache_index.value();
-    }
-    for (auto& next_guard_node : next_guard_nodes) {
-      auto ret = next_guard_node->lookup(frame);
-      if (ret.has_value()) {
-        return ret.value();
-      }
-    }
+    return lookup_next(frame);
   }
   return std::nullopt;
 }

--- a/paddle/fluid/pybind/sot/guards.cc
+++ b/paddle/fluid/pybind/sot/guards.cc
@@ -470,15 +470,7 @@ bool LegacyGuardNode::check(std::array<PyObject*, 1> values) {
 std::optional<int> ExprGuardNode::lookup(FrameProxy* frame) {
   auto value = expr->eval(frame);
   if (PyObject_IsTrue(value)) {
-    if (return_cache_index.has_value()) {
-      return return_cache_index.value();
-    }
-    for (auto& next_guard_node : next_guard_nodes) {
-      auto ret = next_guard_node->lookup(frame);
-      if (ret.has_value()) {
-        return ret.value();
-      }
-    }
+    return lookup_next(frame);
   }
   return std::nullopt;
 }

--- a/paddle/fluid/pybind/sot/guards.h
+++ b/paddle/fluid/pybind/sot/guards.h
@@ -268,48 +268,6 @@ class WeakRefMatchGuard : public GuardBase {
   PyObject* expected_;
 };
 
-class TensorDistMetaMatchGuard : public GuardBase {
- public:
-  explicit TensorDistMetaMatchGuard(const py::object& obj) {
-    if (obj != py::none()) {
-      mesh_shape_expected_ =
-          obj.attr("mesh").attr("shape").cast<std::vector<int>>();
-      mesh_process_ids_expected_ =
-          obj.attr("mesh").attr("process_ids").cast<std::vector<int>>();
-      dims_mapping_expected_ = obj.attr("dims_mapping").ptr();
-      local_shape_expected_ = obj.attr("local_shape").ptr();
-
-      is_dist_ = true;
-      Py_INCREF(dims_mapping_expected_.value());
-      Py_INCREF(local_shape_expected_.value());
-    }
-  }
-
-  ~TensorDistMetaMatchGuard() override {
-    if (is_dist_) {
-      Py_DECREF(dims_mapping_expected_.value());
-      Py_DECREF(local_shape_expected_.value());
-    }
-  }
-  bool check(PyObject* value) override;
-  std::string get_guard_name() const override {
-    return "TensorDistMetaMatchGuard";
-  }
-
- private:
-  bool is_dist_ = false;
-  std::optional<std::vector<int>> mesh_shape_expected_;
-  std::optional<std::vector<int>> mesh_process_ids_expected_;
-  std::optional<PyObject*> dims_mapping_expected_;
-  std::optional<PyObject*> local_shape_expected_;
-};
-
-class DummyGuard : public GuardBase {
- public:
-  bool check(PyObject* value) override { return true; }
-  std::string get_guard_name() const override { return "DummyGuard"; }
-};
-
 class GuardTreeNodeBase {
  public:
   virtual ~GuardTreeNodeBase() = default;
@@ -509,38 +467,7 @@ class GuardNodeBase : public GuardTreeNodeBase {
         return_cache_index(return_cache_index) {}
   virtual ~GuardNodeBase() = default;
   virtual std::optional<int> lookup(FrameProxy* frame) = 0;
-};
-
-class ExprGuardNode : public GuardNodeBase {
- public:
-  explicit ExprGuardNode(
-      std::shared_ptr<ExprNodeBase> expr,
-      std::vector<std::shared_ptr<GuardNodeBase>> next_guard_nodes,
-      std::optional<int> return_cache_index)
-      : GuardNodeBase(next_guard_nodes, return_cache_index), expr_(expr) {}
-
-  std::string stringify(int indent = 0) override;
-  std::optional<int> lookup(FrameProxy* frame) override;
-
- private:
-  std::shared_ptr<ExprNodeBase> expr_;
-};
-
-class GuardNode : public GuardNodeBase {
- public:
-  std::shared_ptr<GuardBase> guard;
-  std::vector<std::shared_ptr<ExprNodeBase>> exprs;
-  explicit GuardNode(
-      std::shared_ptr<GuardBase> guard,
-      std::vector<std::shared_ptr<ExprNodeBase>> exprs,
-      std::vector<std::shared_ptr<GuardNodeBase>> next_guard_nodes,
-      std::optional<int> return_cache_index)
-      : GuardNodeBase(next_guard_nodes, return_cache_index),
-        guard(guard),
-        exprs(exprs) {}
-  virtual ~GuardNode() = default;
-  std::string stringify(int indent = 0) override;
-  std::optional<int> lookup(FrameProxy* frame) override;
+  std::optional<int> lookup_next(FrameProxy* frame);
 };
 
 class DummyGuardNode : public GuardNodeBase {
@@ -557,6 +484,93 @@ class DummyGuardNode : public GuardNodeBase {
 
  private:
   bool return_true_;
+};
+
+class ExprGuardNode : public GuardNodeBase {
+ public:
+  std::shared_ptr<ExprNodeBase> expr;
+  explicit ExprGuardNode(
+      std::shared_ptr<ExprNodeBase> expr,
+      std::vector<std::shared_ptr<GuardNodeBase>> next_guard_nodes,
+      std::optional<int> return_cache_index)
+      : GuardNodeBase(next_guard_nodes, return_cache_index), expr(expr) {}
+
+  std::string stringify(int indent = 0) override;
+  std::optional<int> lookup(FrameProxy* frame) override;
+};
+
+template <size_t N>
+class CheckGuardNode : public GuardNodeBase {
+ public:
+  std::array<std::shared_ptr<ExprNodeBase>, N> exprs;
+  explicit CheckGuardNode(
+      std::array<std::shared_ptr<ExprNodeBase>, N> exprs,
+      std::vector<std::shared_ptr<GuardNodeBase>> next_guard_nodes,
+      std::optional<int> return_cache_index)
+      : GuardNodeBase(next_guard_nodes, return_cache_index), exprs(exprs) {}
+  virtual ~CheckGuardNode() = default;
+  virtual std::string get_guard_name() const = 0;
+  virtual bool check(std::array<PyObject*, N> values) = 0;
+  std::string stringify(int indent = 0) override;
+  std::optional<int> lookup(FrameProxy* frame) override;
+};
+
+class TensorDistMetaMatchGuardNode : public CheckGuardNode<2> {
+ public:
+  explicit TensorDistMetaMatchGuardNode(
+      const py::object& obj,
+      std::array<std::shared_ptr<ExprNodeBase>, 2> exprs,
+      std::vector<std::shared_ptr<GuardNodeBase>> next_guard_nodes,
+      std::optional<int> return_cache_index)
+      : CheckGuardNode<2>(exprs, next_guard_nodes, return_cache_index) {
+    if (obj != py::none()) {
+      mesh_shape_expected_ =
+          obj.attr("mesh").attr("shape").cast<std::vector<int>>();
+      mesh_process_ids_expected_ =
+          obj.attr("mesh").attr("process_ids").cast<std::vector<int>>();
+      dims_mapping_expected_ = obj.attr("dims_mapping").ptr();
+      local_shape_expected_ = obj.attr("local_shape").ptr();
+
+      is_dist_ = true;
+      Py_INCREF(dims_mapping_expected_.value());
+      Py_INCREF(local_shape_expected_.value());
+    }
+  }
+
+  ~TensorDistMetaMatchGuardNode() override {
+    if (is_dist_) {
+      Py_DECREF(dims_mapping_expected_.value());
+      Py_DECREF(local_shape_expected_.value());
+    }
+  }
+  bool check(std::array<PyObject*, 2> values) override;
+  std::string get_guard_name() const override {
+    return "TensorDistMetaMatchGuard";
+  }
+
+ private:
+  bool is_dist_ = false;
+  std::optional<std::vector<int>> mesh_shape_expected_;
+  std::optional<std::vector<int>> mesh_process_ids_expected_;
+  std::optional<PyObject*> dims_mapping_expected_;
+  std::optional<PyObject*> local_shape_expected_;
+};
+
+class LegacyGuardNode : public CheckGuardNode<1> {
+ public:
+  std::shared_ptr<GuardBase> guard;
+  explicit LegacyGuardNode(
+      std::shared_ptr<GuardBase> guard,
+      std::array<std::shared_ptr<ExprNodeBase>, 1> exprs,
+      std::vector<std::shared_ptr<GuardNodeBase>> next_guard_nodes,
+      std::optional<int> return_cache_index)
+      : CheckGuardNode<1>(exprs, next_guard_nodes, return_cache_index),
+        guard(guard) {}
+  virtual ~LegacyGuardNode() = default;
+  std::string get_guard_name() const override {
+    return guard->get_guard_name();
+  };
+  bool check(std::array<PyObject*, 1> values) override;
 };
 
 class GuardTree {

--- a/paddle/fluid/pybind/sot/guards.h
+++ b/paddle/fluid/pybind/sot/guards.h
@@ -511,8 +511,45 @@ class CheckGuardNode : public GuardNodeBase {
   virtual ~CheckGuardNode() = default;
   virtual std::string get_guard_name() const = 0;
   virtual bool check(std::array<PyObject*, N> values) = 0;
-  std::string stringify(int indent = 0) override;
-  std::optional<int> lookup(FrameProxy* frame) override;
+  std::string stringify(int indent = 0) override {
+    std::stringstream ss;
+    ss << std::string(indent, ' ') << get_guard_name();
+    ss << "(";
+    for (size_t i = 0; i < N; ++i) {
+      if (i > 0) {
+        ss << " | ";
+      }
+      ss << exprs[i]->stringify();
+    }
+    ss << ")";
+    if (!next_guard_nodes.empty()) {
+      ss << " |" << std::endl;
+      for (auto& next_guard_node : next_guard_nodes) {
+        ss << std::string(indent + 2, ' ');
+        ss << next_guard_node->stringify(indent + 2) << std::endl;
+      }
+    }
+    return ss.str();
+  }
+  std::optional<int> lookup(FrameProxy* frame) override {
+    std::array<PyObject*, N> values = {};
+    for (size_t i = 0; i < N; ++i) {
+      values[i] = exprs[i]->eval(frame);
+      if (values[i]) {
+        Py_INCREF(values[i]);
+      }
+    }
+    std::optional<int> ret = std::nullopt;
+    if (check(values)) {
+      ret = lookup_next(frame);
+    }
+    for (size_t i = 0; i < N; ++i) {
+      if (values[i]) {
+        Py_DECREF(values[i]);
+      }
+    }
+    return ret;
+  }
 };
 
 class TensorDistMetaMatchGuardNode : public CheckGuardNode<2> {

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
@@ -541,10 +541,8 @@ class TensorVariable(VariableBase):
                 ],
             ),
             # Check dist info
-            paddle.framework.core.GuardNode(
-                paddle.framework.core.TensorDistMetaMatchGuard(
-                    self.meta.dist_info
-                ),
+            paddle.framework.core.TensorDistMetaMatchGuardNode(
+                self.meta.dist_info,
                 [
                     expr_node,
                     paddle.framework.core.ExternVarExprNode(

--- a/test/sot/test_faster_guard.py
+++ b/test/sot/test_faster_guard.py
@@ -20,8 +20,6 @@ from collections import OrderedDict
 import numpy as np
 
 import paddle
-import paddle.distributed as dist
-from paddle.jit.sot.infer_meta import DistInfo
 
 
 class TestBasicFasterGuard(unittest.TestCase):
@@ -203,35 +201,6 @@ class TestBasicFasterGuard(unittest.TestCase):
         self.assertFalse(guard_object.check(lambda x: x == 1))
         self.assertFalse(guard_object.check(1))
         self.assertFalse(guard_object.check("1"))
-
-    @unittest.skipIf(
-        not paddle.is_compiled_with_distribute(),
-        reason='Not compiled with distribute.',
-    )
-    def test_tensor_dist_meta_guard(self):
-        x = paddle.ones([2, 2])
-        y = paddle.ones([1, 2])
-        x.stop_gradient = False
-        y.stop_gradient = False
-        mesh1 = dist.ProcessMesh([0, 1], dim_names=['x'])
-        mesh2 = dist.ProcessMesh([0, 1], dim_names=['y'])
-        dist_x1 = dist.shard_tensor(
-            x, mesh1, [dist.Replicate()], stop_gradient=False
-        )
-        dist_y1 = dist.shard_tensor(
-            y, mesh2, [dist.Replicate()], stop_gradient=False
-        )
-        guard_tensor_is_dist = paddle.framework.core.TensorDistMetaMatchGuard(
-            DistInfo.from_tensor(dist_x1)
-        )
-        self.assertTrue(
-            guard_tensor_is_dist.check((dist_x1, DistInfo.from_tensor))
-        )
-        self.assertFalse(
-            guard_tensor_is_dist.check((dist_y1, DistInfo.from_tensor))
-        )
-        self.assertFalse(guard_tensor_is_dist.check((x, DistInfo.from_tensor)))
-        self.assertFalse(guard_tensor_is_dist.check((y, DistInfo.from_tensor)))
 
 
 class TestFasterGuardGroup(unittest.TestCase):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Performance

### Description
<!-- Describe what you’ve done -->
- GuardNodeBase 新增 lookup_next 方法（后面可以放到Protected里）。
- ExprGuardNode 功能保持不变
- 新增 CheckGuardNode<N> 类（或许要改成CheckGuardNodeBase<N> ），LegacyGuardNode基于CheckGuardNode<1>，用来替代原本的老GuardNode。
- 移除TensorDistMetaMatchGuard，实现TensorDistMetaMatchGuardNode，基于CheckGuardNode<2>

#### TODO
- 需要找到一个方案，可以使用GuardNode 来替代原本的 GuardBase 。