### PR TITLE
[CINN] Update cinn jit data

### DIFF
--- a/paddle/fluid/framework/new_executor/instruction/cinn_jit_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/cinn_jit_instruction.cc
@@ -104,8 +104,8 @@ class CinnJitInstruction::FnPtrImpl {
     // Pass real tensor data to cinn_buffer_t func args placeholder
     for (size_t i = 0; i < kernel_tensor_args.size(); ++i) {
       if (!kernel_tensor_args[i]->has_allocation()) {
-        LOG(WARNING)
-            << "Access DenseTensor::data() without allocation, return nullptr!";
+        VLOG(2) << "WARNING! Access DenseTensor::data() without allocation, "
+                   "return nullptr!";
         cinn_pod_value_to_buffer_p(&(func_args_[i]))->memory = nullptr;
       } else {
         cinn_pod_value_to_buffer_p(&(func_args_[i]))->memory =

--- a/paddle/fluid/framework/new_executor/instruction/cinn_jit_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/cinn_jit_instruction.cc
@@ -103,8 +103,14 @@ class CinnJitInstruction::FnPtrImpl {
 
     // Pass real tensor data to cinn_buffer_t func args placeholder
     for (size_t i = 0; i < kernel_tensor_args.size(); ++i) {
-      cinn_pod_value_to_buffer_p(&(func_args_[i]))->memory =
-          reinterpret_cast<uint8_t*>(kernel_tensor_args[i]->data());
+      if (!kernel_tensor_args[i]->has_allocation()) {
+        LOG(WARNING)
+            << "Access DenseTensor::data() without allocation, return nullptr!";
+        cinn_pod_value_to_buffer_p(&(func_args_[i]))->memory = nullptr;
+      } else {
+        cinn_pod_value_to_buffer_p(&(func_args_[i]))->memory =
+            reinterpret_cast<uint8_t*>(kernel_tensor_args[i]->data());
+      }
     }
 
     // Launch host kernel
@@ -297,6 +303,7 @@ CinnJitInstruction::CinnJitInstruction(
     ir_dims_.push_back(
         result.type().dyn_cast<paddle::dialect::DenseTensorType>().dims());
     tensor_args_.push_back(tensor);
+    alloc_tensors_.push_back(tensor);
     auto alloc_tensor_type =
         result.type().dyn_cast<paddle::dialect::AllocatedDenseTensorType>();
     tensor->set_type(
@@ -321,6 +328,7 @@ CinnJitInstruction::CinnJitInstruction(
   }
   for (auto& tensor : temp_space_tensors_) {
     tensor_args_.push_back(&tensor);
+    alloc_tensors_.push_back(&tensor);
   }
   output_tensor_size += temp_space_tensors_.size();
 }
@@ -343,8 +351,8 @@ void CinnJitInstruction::Run() {
     fn_ptr_impl_->InferShape(
         tensor_args_, ir_dims_, input_tensor_size, output_tensor_size);
   }
-  for (size_t i = 0; i < tensor_args_.size(); ++i) {
-    dev_ctx_->Alloc(tensor_args_[i], tensor_args_[i]->dtype());
+  for (size_t i = 0; i < alloc_tensors_.size(); ++i) {
+    dev_ctx_->Alloc(alloc_tensors_[i], alloc_tensors_[i]->dtype());
   }
 
   // 2. execute kernel

--- a/paddle/fluid/framework/new_executor/instruction/cinn_jit_instruction.h
+++ b/paddle/fluid/framework/new_executor/instruction/cinn_jit_instruction.h
@@ -55,6 +55,7 @@ class CinnJitInstruction : public InstructionBase {
 
   bool need_update_shape{false};
   std::vector<phi::DenseTensor*> tensor_args_;
+  std::vector<phi::DenseTensor*> alloc_tensors_;
   std::vector<phi::DDim> ir_dims_;
 
   // Tensors that hold the temporary spaces used by the kernel. These tensors


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Performance

### Description
<!-- Describe what you’ve done -->

cinn_jit 目前会为 input 和 output tensor 均申请显存，但部分场景 generate shape 会引入额外的 input 参数，导致额外的开销，调度开销重的场景会影响效率。

![5b12c583ee8554d329c60c8ca7db6167](https://github.com/user-attachments/assets/defcdd60-8fb0-471b-910c-5c0498956cb2)


针对每个 cinn_jit，目前认为 input tensor 的显存均已经申请过，不再为其申请，generate shape 参数由于并不在 kernel 中实际使用，临时用 nullptr 代替，并输出 warning。

todo:
1. 修改 generate shape op 问题，并删除 warning。

pcard-67164
