### PR TITLE
[Dy2St][CINN] Remove `runtime_guards` around `run_program_op` call

### DIFF
--- a/python/paddle/jit/dy2static/pir_partial_program.py
+++ b/python/paddle/jit/dy2static/pir_partial_program.py
@@ -39,7 +39,6 @@ from .utils import (
     auto_layout_is_enabled,
     backend_guard,
     cse_is_enabled,
-    runtime_guards,
 )
 
 if TYPE_CHECKING:
@@ -735,22 +734,21 @@ class PartialProgramLayer:
         attrs = self._prepare_attributes(in_sot_mode=False)
         inputs = self._valid_vars(in_vars)
 
-        with runtime_guards(self._backend):
-            _C_ops.run_program(
-                inputs,
-                self._valid_vars(self._params),
-                self._valid_vars(out_vars),
-                self._create_scope_vec(
-                    cache_key=(
-                        hash_with_seed(
-                            self.program_id,
-                            self._calc_input_places_hash(inputs),
-                        )
-                    ),
-                    use_scope_cache=True,
+        _C_ops.run_program(
+            inputs,
+            self._valid_vars(self._params),
+            self._valid_vars(out_vars),
+            self._create_scope_vec(
+                cache_key=(
+                    hash_with_seed(
+                        self.program_id,
+                        self._calc_input_places_hash(inputs),
+                    )
                 ),
-                *attrs,
-            )
+                use_scope_cache=True,
+            ),
+            *attrs,
+        )
         restored_nest_out = self._restore_out(out_vars)
         return self._remove_no_value(restored_nest_out)
 
@@ -762,22 +760,21 @@ class PartialProgramLayer:
         attrs = self._prepare_attributes(in_sot_mode=True)
         inputs = self._valid_vars(inputs)
 
-        with runtime_guards(self._backend):
-            _C_ops.run_program(
-                inputs,
-                self._valid_vars(self._params),
-                self._valid_vars(out_vars),
-                self._create_scope_vec(
-                    cache_key=(
-                        hash_with_seed(
-                            self.program_id,
-                            self._calc_input_places_hash(inputs),
-                        )
-                    ),
-                    use_scope_cache=True,
+        _C_ops.run_program(
+            inputs,
+            self._valid_vars(self._params),
+            self._valid_vars(out_vars),
+            self._create_scope_vec(
+                cache_key=(
+                    hash_with_seed(
+                        self.program_id,
+                        self._calc_input_places_hash(inputs),
+                    )
                 ),
-                *attrs,
-            )
+                use_scope_cache=True,
+            ),
+            *attrs,
+        )
         return self._outputs.quick_restore(out_vars)
 
     @cached_property

--- a/python/paddle/jit/dy2static/utils.py
+++ b/python/paddle/jit/dy2static/utils.py
@@ -767,36 +767,6 @@ def is_api_in_module_helper(obj, module_prefix):
     return m is not None and m.__name__.startswith(module_prefix)
 
 
-def add_auto_layout_guard(backend, guard_creators):
-    # AutoLayoutPass may change layout of bn to NHWC, if not enable `FLAGS_cudnn_batchnorm_spatial_persistent`, it will revert to NCHW. So if the user does not set this Flag, we set it to True.
-    if (
-        auto_layout_is_enabled()
-        and backend.is_cinn()
-        and paddle.is_compiled_with_cuda()
-        and os.getenv("FLAGS_cudnn_batchnorm_spatial_persistent") is None
-    ):
-        guard_creators.append(
-            lambda: paddle.base.framework.flag_guard(
-                "FLAGS_cudnn_batchnorm_spatial_persistent",
-                True,
-            )
-        )
-
-
-@contextmanager
-def runtime_guards(backend):
-    """
-    runtime_guards is the guard method before program execution, which can integrate and add various guards.
-    """
-    guard_creators = []
-    # Add FLAGS_cudnn_batchnorm_spatial_persistent guard
-    add_auto_layout_guard(backend, guard_creators)
-    # add more guards here
-
-    with compose_guards(*guard_creators)():
-        yield
-
-
 def auto_layout_is_enabled():
     return paddle.get_flags(["FLAGS_enable_auto_layout_pass"])[
         "FLAGS_enable_auto_layout_pass"


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Performance

### Description
<!-- Describe what you’ve done -->

删掉 `run_program_op` 外的 `runtime_guards`，目前 `runtime_guards` 约占用了 50us

<!-- PCard-66972 -->