### PR TITLE
[SOT][DynamicShape] Mark `unfold` arguments not support dynamic dim

### DIFF
--- a/python/paddle/nn/functional/common.py
+++ b/python/paddle/nn/functional/common.py
@@ -30,6 +30,7 @@ from paddle.framework import (
 )
 from paddle.tensor.creation import full
 from paddle.utils import deprecated
+from paddle.utils.layers_utils import NotSupportedTensorArgumentError
 
 from ...base.data_feeder import (
     check_dtype,
@@ -158,25 +159,33 @@ def unfold(
     if isinstance(kernel_sizes, int):
         kernel_sizes = [kernel_sizes, kernel_sizes]
     else:
-        assert isinstance(kernel_sizes, (list, tuple)) and (
-            len(kernel_sizes) == 2
-        ), "kernel_sizes should either be an integer or a list/tuple of two integers"
+        if not (
+            isinstance(kernel_sizes, (list, tuple)) and (len(kernel_sizes) == 2)
+        ):
+            raise NotSupportedTensorArgumentError(
+                "kernel_sizes should either be an integer or a list/tuple of two integers",
+                "kernel_sizes",
+            )
         kernel_sizes = list(kernel_sizes)
 
     if isinstance(strides, int):
         strides = [strides, strides]
     else:
-        assert isinstance(strides, (list, tuple)) and (
-            len(strides) == 2
-        ), "strides should either be an integer or a list/tuple of two integers"
+        if not (isinstance(strides, (list, tuple)) and (len(strides) == 2)):
+            raise NotSupportedTensorArgumentError(
+                "strides should either be an integer or a list/tuple of two integers",
+                "strides",
+            )
         strides = list(strides)
 
     if isinstance(dilations, int):
         dilations = [dilations, dilations]
     else:
-        assert isinstance(dilations, (list, tuple)) and (
-            len(dilations) == 2
-        ), "dilations should either be an integer or a list/tuple of two integers"
+        if not (isinstance(dilations, (list, tuple)) and (len(dilations) == 2)):
+            raise NotSupportedTensorArgumentError(
+                "dilations should either be an integer or a list/tuple of two integers",
+                "dilations",
+            )
         dilations = list(dilations)
 
     if isinstance(paddings, int):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

为 `unfold` 标记为不支持动态 shape

<!-- PCard-66972 -->