### PR TITLE
[ThirdParty] Bump zlib to v1.3.1 to solve clang17 compile error

### DIFF
--- a/cmake/external/zlib.cmake
+++ b/cmake/external/zlib.cmake
@@ -22,7 +22,6 @@ set(ZLIB_ROOT
 set(ZLIB_INCLUDE_DIR
     "${ZLIB_INSTALL_DIR}/include"
     CACHE PATH "zlib include directory." FORCE)
-set(ZLIB_TAG v1.2.8)
 set(SOURCE_DIR ${PADDLE_SOURCE_DIR}/third_party/zlib)
 include_directories(${ZLIB_INCLUDE_DIR}
 )# For zlib code to include its own headers.

--- a/paddle/fluid/pir/drr/src/attr_type_uilts.h
+++ b/paddle/fluid/pir/drr/src/attr_type_uilts.h
@@ -53,7 +53,7 @@ PD_SPECIALIZE_CppTypeToIrAttribute(phi::IntArray,
 template <typename T>
 struct IrAttributeCreator {
   typename CppTypeToIrAttribute<T>::type operator()(T obj) const {
-    return CppTypeToIrAttribute<T>::type::template get(
+    return CppTypeToIrAttribute<T>::type::template get<T>(
         pir::IrContext::Instance(), obj);
   }
 };


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

尝试升级 zlib 到 v1.3.1 以解决 macOS 15.4 clang17 上的编译问题，问题同 ahrm/sioyek#1361，解决方案参考 google-ai-edge/mediapipe#5943

`paddle/fluid/pir/drr/src/attr_type_uilts.h` 修改也是 clang17 更加严格检查出来的编译问题

`ZLIB_TAG` 无用，所以删掉了

<!-- PCard-66972 -->