### PR TITLE
[PHI][CINN] Implement int64_t version of FastDivMod

### DIFF
--- a/paddle/phi/kernels/funcs/interpolate_function.h
+++ b/paddle/phi/kernels/funcs/interpolate_function.h
@@ -180,20 +180,19 @@ inline std::vector<T> get_new_data_from_tensor(
 }
 
 #if defined(__NVCC__) || defined(__HIPCC__)
-using phi::kps::details::FastDivMod;
 
 struct FastDivModForInterpolate {
  public:
-  FastDivMod channels_div;
-  FastDivMod output_w_div;
-  FastDivMod output_wc_div;
+  FastDivMod<int> channels_div;
+  FastDivMod<int> output_w_div;
+  FastDivMod<int> output_wc_div;
 
   explicit HOSTDEVICE FastDivModForInterpolate(const int channels,
                                                const int output_w,
                                                const int output_wc)
-      : channels_div(FastDivMod(channels)),
-        output_w_div(FastDivMod(output_w)),
-        output_wc_div(FastDivMod(output_wc)) {}
+      : channels_div(channels),
+        output_w_div(output_w),
+        output_wc_div(output_wc) {}
 };
 
 #endif

--- a/paddle/phi/kernels/funcs/pooling.cu
+++ b/paddle/phi/kernels/funcs/pooling.cu
@@ -24,73 +24,67 @@ limitations under the License. */
 #include "paddle/phi/backends/gpu/gpu_launch_config.h"
 #include "paddle/phi/backends/gpu/gpu_primitives.h"
 #include "paddle/phi/kernels/funcs/distribution_helper.h"
+#include "paddle/phi/kernels/funcs/fast_divmod.h"
 #include "paddle/phi/kernels/funcs/pooling.h"
 #include "paddle/phi/kernels/funcs/random.cuh"
 #include "paddle/phi/kernels/funcs/reduce_function.h"
-#include "paddle/phi/kernels/primitive/datamover_primitives.h"
 
 namespace phi {
 namespace funcs {
 
 struct FastDivModForPooling {
  public:
-  phi::kps::details::FastDivMod channel;
-  phi::kps::details::FastDivMod width;
-  phi::kps::details::FastDivMod height;
+  FastDivMod<int> channel;
+  FastDivMod<int> width;
+  FastDivMod<int> height;
 
   explicit HOSTDEVICE FastDivModForPooling(const int channels,
                                            const int output_width,
-                                           const int output_height) {
-    channel = phi::kps::details::FastDivMod(channels);
-    width = phi::kps::details::FastDivMod(output_width);
-    height = phi::kps::details::FastDivMod(output_height);
-  }
+                                           const int output_height)
+      : channel(channels), width(output_width), height(output_height) {}
 };
 
 struct FastDivModForPooling3D {
  public:
-  phi::kps::details::FastDivMod channel;
-  phi::kps::details::FastDivMod width;
-  phi::kps::details::FastDivMod height;
-  phi::kps::details::FastDivMod depth;
+  FastDivMod<int> channel;
+  FastDivMod<int> width;
+  FastDivMod<int> height;
+  FastDivMod<int> depth;
 
   explicit HOSTDEVICE FastDivModForPooling3D(const int channels,
                                              const int output_width,
                                              const int output_height,
-                                             const int output_depth) {
-    channel = phi::kps::details::FastDivMod(channels);
-    width = phi::kps::details::FastDivMod(output_width);
-    height = phi::kps::details::FastDivMod(output_height);
-    depth = phi::kps::details::FastDivMod(output_depth);
-  }
+                                             const int output_depth)
+      : channel(channels),
+        width(output_width),
+        height(output_height),
+        depth(output_depth) {}
 };
 
 struct FastDivModForPoolingWithMoreStaff {
  public:
-  phi::kps::details::FastDivMod channel;
-  phi::kps::details::FastDivMod width;
-  phi::kps::details::FastDivMod height;
-  phi::kps::details::FastDivMod ksize_w;
-  phi::kps::details::FastDivMod ksize_h;
-  phi::kps::details::FastDivMod stride_w;
-  phi::kps::details::FastDivMod stride_h;
+  FastDivMod<int> channel;
+  FastDivMod<int> width;
+  FastDivMod<int> height;
+  FastDivMod<int> ksize_w;
+  FastDivMod<int> ksize_h;
+  FastDivMod<int> stride_w;
+  FastDivMod<int> stride_h;
 
-  explicit HOSTDEVICE FastDivModForPoolingWithMoreStaff(
-      const int channels,
-      const int input_width,
-      const int input_height,
-      const int ksize_width,
-      const int ksize_height,
-      const int stride_width,
-      const int stride_height) {
-    channel = phi::kps::details::FastDivMod(channels);
-    width = phi::kps::details::FastDivMod(input_width);
-    height = phi::kps::details::FastDivMod(input_height);
-    ksize_w = phi::kps::details::FastDivMod(ksize_width);
-    ksize_h = phi::kps::details::FastDivMod(ksize_height);
-    stride_w = phi::kps::details::FastDivMod(stride_width);
-    stride_h = phi::kps::details::FastDivMod(stride_height);
-  }
+  explicit HOSTDEVICE FastDivModForPoolingWithMoreStaff(const int channels,
+                                                        const int input_width,
+                                                        const int input_height,
+                                                        const int ksize_width,
+                                                        const int ksize_height,
+                                                        const int stride_width,
+                                                        const int stride_height)
+      : channel(channels),
+        width(input_width),
+        height(input_height),
+        ksize_w(ksize_width),
+        ksize_h(ksize_height),
+        stride_w(stride_width),
+        stride_h(stride_height) {}
 };
 
 template <typename FastDivModForPooling>

--- a/paddle/phi/kernels/funcs/transpose_function.cu.h
+++ b/paddle/phi/kernels/funcs/transpose_function.cu.h
@@ -21,8 +21,8 @@ limitations under the License. */
 #include "paddle/phi/kernels/autotune/auto_tune_base.h"
 #include "paddle/phi/kernels/funcs/aligned_vector.h"
 #include "paddle/phi/kernels/funcs/dims_simplifier.h"
+#include "paddle/phi/kernels/funcs/fast_divmod.h"
 #include "paddle/phi/kernels/funcs/math_function.h"
-#include "paddle/phi/kernels/primitive/datamover_primitives.h"
 
 namespace phi {
 namespace funcs {
@@ -905,7 +905,7 @@ class IdxHelper<uint32_t, Rank> {
   explicit IdxHelper(const uint32_t* dims) {
     for (int i = Rank - 1; i >= 0; --i) {
       uint32_t value = i < (Rank - 1) ? dims[i + 1] * stride_[i + 1] : 1;
-      divmoder_[i] = phi::kps::details::FastDivMod(value);
+      divmoder_[i] = FastDivMod<int>(value);
       stride_[i] = value;
     }
   }
@@ -928,7 +928,7 @@ class IdxHelper<uint32_t, Rank> {
 
  private:
   uint32_t stride_[Rank];
-  phi::kps::details::FastDivMod divmoder_[Rank];
+  FastDivMod<int> divmoder_[Rank];
 };
 
 // Transform index between memory offset and shape coordinate.

--- a/paddle/phi/kernels/gpu/interpolate_kernel.cu
+++ b/paddle/phi/kernels/gpu/interpolate_kernel.cu
@@ -26,7 +26,6 @@
 #include "paddle/phi/kernels/primitive/datamover_primitives.h"
 
 namespace phi {
-using phi::kps::details::FastDivMod;
 
 template <typename T>
 __forceinline__ __device__ void PreCalculatorForLinearInterpInputIndex(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Operator Mechanism


### PR Types
Improvements


### Description
实现int64_t版本的FastDivMod，修复大tensor Reduce的部分问题

<b>核心修改：</b>`phi/kernels/funcs/fast_divmod.h` 模仿int版本实现了FastDivMod\<int64_t>类
注：实际上IndexType计算时使用的是uint32_t和uint64_t，但是为了和PHI原有的用法兼容，这里还是用int和int64_t作为模板参数

<b>其他使用了FastDivMod的文件修改：</b>
| 文件 | 原用法 | 新用法
| --- | --- | --- |
| datamover_primitives.h  | FastDivMod | FastDivMod\<int>（删掉了原来重复的实现）
| pooling.cu              | FastDivMod | FastDivMod\<int>
| stack_and_unstack.h     | GeneralDivMod\<IndexT> | <b>替换成FastDivMod\<IndexT></b>
| index_calculator.h      | FastDivMod | <b>升级成FastDivMod\<IndexType></b>
| transpose_function.cu.h | FastDivMod | FastDivMod\<int>
| interpolate_function.h  | FastDivMod | FastDivMod\<int>

说明：
* 大部分文件还是维持原来的用法，继续使用FastDivMod\<int>，因为FastDivMod\<int64_t>对性能有一定影响，需要评估才知道是否有必要升级，在此之前先维持现状
* `index_calculator.h`升级为FastDivMod\<IndexType>，这是本PR主要修复的问题
* `stack_and_unstack.h`本来已经用了GeneralDivMod\<IndexT>，所以在本PR里直接替换成FastDivMod\<IndexT>，GeneralDivMod是之前不支持int64_t所以用来fallback成普通除法的包装类，现在原生支持int64_t后就用不着了

<b>修复case示例：</b>
```python
paddle.sum(Tensor([2, 2, (1 << 30), 2], 'float16'), axis=(1, 3))      # 原来对，现在对
paddle.sum(Tensor([2, 2, (1 << 30) + 1, 2], 'float16'), axis=(1, 3))  # 原来错，现在对
```

<b>性能影响：</b>
确实对性能有影响，以`paddle.sum(Tensor([256, 1024, 192, 192], 'float16'), axis=(0, 2, 3))`为例，int版本用时28ms，int64_t版本用时46ms，直接增加60%（当然主要原因是IndexCalculator实现有问题，这个需要另外的PR来修），因此Kernel在调用FastDivMod时需要谨慎评估是否需要使用int64_t的版本

<br>
Pcard-85711
