### PR TITLE
[Bug fix] Fix the bug when setting sharding_check_comm_group in expert parallel communication group

### DIFF
--- a/python/paddle/distributed/fleet/base/topology.py
+++ b/python/paddle/distributed/fleet/base/topology.py
@@ -725,8 +725,10 @@ class EPHybridCommunicateGroup(HybridCommunicateGroup):
             "data", self._dense_topo
         )
         self.sharding_check_group, self.sharding_check_comm_group = (
-            "sharding",
-            self._dense_topo,
+            self._set_check_group(
+                "moe_sharding",
+                self._moe_topo,
+            )
         )
 
         # (


### PR DESCRIPTION
### PR Category
Distributed Strategy 

### PR Types
 Bug fixes 

### Description
Fix the bug when setting sharding_check_comm_group in expert parallel communication group
