### PR TITLE
[Auto Parallel] Add tensor_fusion and overlap in auto dy sharding

### DIFF
--- a/paddle/fluid/pybind/tensor.cc
+++ b/paddle/fluid/pybind/tensor.cc
@@ -1199,6 +1199,8 @@ void BindTensor(pybind11::module &m) {  // NOLINT
              self.unsafe_mutable_value()->ShareDataNoCheckWith(src.value());
              return self;
            })
+      .def("_numel",
+           [](DistTensor &self) -> int64_t { return self.value().numel(); })
       .def("_share_data_with",
            [](DistTensor &self, const DistTensor &src) {
              self.unsafe_set_dims(src.dims());

--- a/python/paddle/amp/auto_cast.py
+++ b/python/paddle/amp/auto_cast.py
@@ -693,7 +693,11 @@ def amp_guard(
                                     param.process_mesh
                                 ].append(param)
                     amp_global_state().already_classify_params_meshes = True
-                if not os.getenv("FLAGS_enable_tensor_fusion") == '1':
+                if os.getenv("FLAGS_enable_tensor_fusion") not in [
+                    "True",
+                    "true",
+                    "1",
+                ]:
                     if len(amp_global_state().mesh2params):
                         for _, params in amp_global_state().mesh2params.items():
                             core.eager.set_master_grads(params)
@@ -729,7 +733,7 @@ def amp_guard(
 
                 return param_hook
 
-            if os.getenv("FLAGS_enable_tensor_fusion") == '1':
+            if os.getenv("FLAGS_enable_tensor_fusion") in ["True", "true", "1"]:
                 for param in amp_global_state().model_parameters:
                     if not hasattr(param, "main_grad"):
                         param.main_grad = None

--- a/python/paddle/amp/auto_cast.py
+++ b/python/paddle/amp/auto_cast.py
@@ -14,6 +14,7 @@
 from __future__ import annotations
 
 import copy
+import os
 import warnings
 from typing import (
     TYPE_CHECKING,
@@ -655,6 +656,30 @@ def amp_guard(
             and not amp_global_state().already_register_final_backward_hook
         ):
 
+            def _dtensor_from_local(
+                local_tensor, mesh, placements, local_tensor_shape=None
+            ):
+                global_dims = list(local_tensor.shape)
+                if local_tensor_shape is not None:
+                    global_dims = local_tensor_shape
+                for idx, placement in enumerate(placements):
+                    if placement.is_shard():
+                        shard_dim = placement.get_dim()
+                        local_dim_size = global_dims[shard_dim]
+                        global_dims[shard_dim] = (
+                            local_dim_size * mesh.shape[idx]
+                        )
+                place = paddle.framework._current_expected_place()
+                place = paddle.framework._get_paddle_place(place)
+
+                return paddle.Tensor(
+                    local_tensor,
+                    dims=global_dims,
+                    process_mesh=mesh,
+                    placements=placements,
+                    place=place,
+                )
+
             def master_grad_hook():
                 # NOTE(lizhiyu): To support semi-auto of dygraph mode, we must
                 # classify the params of model into different classes according to their process_mesh.
@@ -674,16 +699,47 @@ def amp_guard(
                                     param.process_mesh
                                 ].append(param)
                     amp_global_state().already_classify_params_meshes = True
-
-                if len(amp_global_state().mesh2params):
-                    for _, params in amp_global_state().mesh2params.items():
-                        core.eager.set_master_grads(params)
-                else:
-                    core.eager.set_master_grads(
-                        amp_global_state().model_parameters
-                    )
+                if not os.getenv("FLAGS_enable_inplace_master_grad") == '1':
+                    if len(amp_global_state().mesh2params):
+                        for _, params in amp_global_state().mesh2params.items():
+                            core.eager.set_master_grads(params)
+                    else:
+                        core.eager.set_master_grads(
+                            amp_global_state().model_parameters
+                        )
 
                 amp_global_state().already_register_final_backward_hook = False
+
+            def _update_main_grad_hook(param):
+                @paddle.autograd.no_grad()
+                def param_hook(tmp_grad):
+                    if tmp_grad is not None and tmp_grad._is_initialized():
+                        if param.main_grad is None:
+                            tmp = core.eager.Tensor(
+                                value=tmp_grad._local_value()
+                                .cast(paddle.float32)
+                                .value(),
+                                place=tmp_grad.place,
+                                name="main_grad@" + param.name,
+                            )
+                            param.main_grad = _dtensor_from_local(
+                                tmp,
+                                tmp_grad.process_mesh,
+                                tmp_grad.placements,
+                            )
+                        else:
+                            param.main_grad._local_value().add_(
+                                tmp_grad._local_value()
+                            )
+                        tmp_grad._clear_data()
+
+                return param_hook
+
+            if os.getenv("FLAGS_enable_inplace_master_grad") == '1':
+                for param in amp_global_state().model_parameters:
+                    if not hasattr(param, "main_grad"):
+                        param.main_grad = None
+                        param._register_grad_hook(_update_main_grad_hook(param))
 
             core.eager._add_backward_final_hook(master_grad_hook)
             amp_global_state().already_register_final_backward_hook = True

--- a/python/paddle/amp/auto_cast.py
+++ b/python/paddle/amp/auto_cast.py
@@ -693,7 +693,7 @@ def amp_guard(
                                     param.process_mesh
                                 ].append(param)
                     amp_global_state().already_classify_params_meshes = True
-                if not os.getenv("FLAGS_enable_inplace_master_grad") == '1':
+                if not os.getenv("FLAGS_enable_tensor_fusion") == '1':
                     if len(amp_global_state().mesh2params):
                         for _, params in amp_global_state().mesh2params.items():
                             core.eager.set_master_grads(params)
@@ -729,7 +729,7 @@ def amp_guard(
 
                 return param_hook
 
-            if os.getenv("FLAGS_enable_inplace_master_grad") == '1':
+            if os.getenv("FLAGS_enable_tensor_fusion") == '1':
                 for param in amp_global_state().model_parameters:
                     if not hasattr(param, "main_grad"):
                         param.main_grad = None

--- a/python/paddle/amp/auto_cast.py
+++ b/python/paddle/amp/auto_cast.py
@@ -656,18 +656,12 @@ def amp_guard(
             and not amp_global_state().already_register_final_backward_hook
         ):
 
-            def _dtensor_from_local(
-                local_tensor, mesh, placements, local_tensor_shape=None
-            ):
+            def _dtensor_from_local(local_tensor, mesh, placements):
                 global_dims = list(local_tensor.shape)
-                if local_tensor_shape is not None:
-                    global_dims = local_tensor_shape
                 for idx, placement in enumerate(placements):
                     if placement.is_shard():
-                        shard_dim = placement.get_dim()
-                        local_dim_size = global_dims[shard_dim]
-                        global_dims[shard_dim] = (
-                            local_dim_size * mesh.shape[idx]
+                        global_dims[placement.get_dim()] = (
+                            global_dims[placement.get_dim()] * mesh.shape[idx]
                         )
                 place = paddle.framework._current_expected_place()
                 place = paddle.framework._get_paddle_place(place)

--- a/python/paddle/distributed/auto_parallel/api.py
+++ b/python/paddle/distributed/auto_parallel/api.py
@@ -1151,9 +1151,6 @@ class _ShardOptimizer(Optimizer):
         self.enable_tensor_fusion = (
             os.getenv("FLAGS_enable_tensor_fusion") == '1'
         )
-        self.enable_sharding_overlap = (
-            os.getenv("FLAGS_enable_sharding_overlap") == '1'
-        )
 
     def _set_and_check_sharding_prop_from_param(self):
         global_mesh = fleet.auto.get_mesh()
@@ -1286,19 +1283,18 @@ class _ShardOptimizer(Optimizer):
                 for grad_storage in self.grad_storage:
                     grad_storage.zero_()
                     grad_storage.check_in = 0
-            if not self.enable_sharding_overlap:
-                for i in range(len(self.fuse_param_view)):
-                    shard_size = (
-                        self.param_storage[i]._numel() // self.comm_group.nranks
-                    )
-                    begin = shard_size * max(self.comm_group.rank, 0)
-                    end = begin + shard_size
-                    slice_buffer = paddle._C_ops.view_slice(
-                        self.param_storage[i], begin, end
-                    )
-                    self.comm_group.process_group.all_gather(
-                        slice_buffer, self.param_storage[i]
-                    ).wait()
+            for i in range(len(self.fuse_param_view)):
+                shard_size = (
+                    self.param_storage[i]._numel() // self.comm_group.nranks
+                )
+                begin = shard_size * max(self.comm_group.rank, 0)
+                end = begin + shard_size
+                slice_buffer = paddle._C_ops.view_slice(
+                    self.param_storage[i], begin, end
+                )
+                self.comm_group.process_group.all_gather(
+                    slice_buffer, self.param_storage[i]
+                ).wait()
 
         else:
             if self.enable_inplace_master_grad:
@@ -1460,24 +1456,7 @@ class _ShardOptimizer(Optimizer):
                     grad, grad.shape, grad_mesh, [dist.Replicate()]
                 )
             param_and_grad = (param_and_grad[0], grad)
-        self._inner_opt._append_optimize_op(block, param_and_grad)
-        if self.enable_sharding_overlap:
-            # overlap all_gather with optimizer op
-            if hasattr(param_and_grad[0], 'last_idx'):
-                idx = param_and_grad[0].last_idx
-                shard_size = (
-                    self.param_storage[idx]._numel() // self.comm_group.nranks
-                )
-                begin = shard_size * max(self.comm_group.rank, 0)
-                end = begin + shard_size
-                slice_buffer = paddle._C_ops.view_slice(
-                    self.param_storage[idx], begin, end
-                )
-                task = paddle.distributed.all_gather(
-                    self.param_storage[idx],
-                    slice_buffer,
-                    sync_op=False,
-                )
+        return self._inner_opt._append_optimize_op(block, param_and_grad)
 
     def _reduce_scatter_gradients(self, grad_storage):
         shard_size = grad_storage._numel() // self.comm_group.nranks
@@ -1491,42 +1470,6 @@ class _ShardOptimizer(Optimizer):
             group=self.comm_group,
             sync_op=False,
         ).wait()
-
-    def _async_reduce_scatter(self):
-        for i in range(len(self.fuse_param_view)):
-            self._reduce_scatter_gradients(self.grad_storage[i])
-
-            def fuse_comm_hook_func(param_group_len, grad_storage, comm_group):
-                @paddle.autograd.no_grad()
-                def fuse_comm(*_):
-                    grad_storage.check_in += 1
-                    if grad_storage.check_in == param_group_len:
-                        shard_size = grad_storage._numel() // comm_group.nranks
-                        begin = shard_size * max(comm_group.rank, 0)
-                        end = begin + shard_size
-                        reduce_scattered = paddle._C_ops.view_slice(
-                            grad_storage, begin, end
-                        )
-                        task = paddle.distributed.reduce_scatter(
-                            reduce_scattered,
-                            grad_storage,
-                            op=paddle.distributed.ReduceOp.SUM,
-                            group=comm_group,
-                            sync_op=False,
-                        )
-                        grad_storage.comm_task = task
-
-                return fuse_comm
-
-            param_group_len = len(self.fuse_param_view[i])
-            for name, view in self.fuse_param_view[i].items():
-                view['param']._register_backward_hook(
-                    fuse_comm_hook_func(
-                        param_group_len,
-                        self.grad_storage[i],
-                        self.comm_group,
-                    )
-                )
 
     def _build_fuse_param_view(
         self,
@@ -1654,9 +1597,6 @@ class _ShardOptimizer(Optimizer):
                 self.param_storage.append(param_storage)
                 self.grad_storage.append(grad_storage)
 
-            if self.enable_sharding_overlap:
-                self._async_reduce_scatter()
-
             if self._inner_opt._grad_clip is not None:
                 self._inner_opt._grad_clip.should_comm_on_shard_dim = True
                 self._inner_opt._grad_clip.sharding_group = self.comm_group
@@ -1664,8 +1604,7 @@ class _ShardOptimizer(Optimizer):
         new_params = []
         new_grads = []
         for i in range(len(self.fuse_param_view)):
-            if not self.enable_sharding_overlap:
-                self._reduce_scatter_gradients(self.grad_storage[i])
+            self._reduce_scatter_gradients(self.grad_storage[i])
 
             for name, view in self.fuse_param_view[i].items():
                 param = view['param']
@@ -1708,12 +1647,6 @@ class _ShardOptimizer(Optimizer):
                     new_grad, param.process_mesh, [dist.Replicate()]
                 )
                 new_grads.append(new_grad)
-
-            if self.enable_sharding_overlap:
-                # last_idx marks the last param, start asyn comm
-                new_params[-1].last_idx = i
-                if self.grad_storage[i].comm_task is not None:
-                    self.grad_storage[i].comm_task.wait()
 
         new_params_grads = list(zip(new_params, new_grads))
 

--- a/python/paddle/distributed/auto_parallel/api.py
+++ b/python/paddle/distributed/auto_parallel/api.py
@@ -1469,6 +1469,7 @@ class _ShardOptimizer(Optimizer):
                 task = paddle.distributed.all_gather(
                     self.param_storage[idx],
                     slice_buffer,
+                    group=self.comm_group,
                     sync_op=False,
                 )
 
@@ -1527,7 +1528,7 @@ class _ShardOptimizer(Optimizer):
         sharding_degree,
     ):
         def get_padded_size(param):
-            size = np.prod(param.shape)
+            size = np.prod(param._local_shape)
             align_size = (
                 alignment[get_current_device_type()]
                 // align[param.dtype]
@@ -1574,7 +1575,7 @@ class _ShardOptimizer(Optimizer):
                 index,
                 index + param._numel(),
             )
-            tmp_param.get_tensor()._set_dims(param.shape)
+            tmp_param.get_tensor()._set_dims(param._local_shape)
             tmp_param = _dtensor_from_local(
                 tmp_param,
                 param.process_mesh,
@@ -1594,7 +1595,7 @@ class _ShardOptimizer(Optimizer):
                 index,
                 index + grad._local_value()._numel(),
             )
-            tmp_grad.get_tensor()._set_dims(grad.shape)
+            tmp_grad.get_tensor()._set_dims(grad._local_shape)
             tmp_grad = _dtensor_from_local(
                 tmp_grad,
                 grad.process_mesh,

--- a/python/paddle/distributed/auto_parallel/api.py
+++ b/python/paddle/distributed/auto_parallel/api.py
@@ -1145,9 +1145,6 @@ class _ShardOptimizer(Optimizer):
         self.comm_group = None
         self.do_tensor_fusion_once = True
         self._strategy = Strategy()
-        self.enable_inplace_master_grad = (
-            os.getenv("FLAGS_enable_inplace_master_grad") == '1'
-        )
         self.enable_tensor_fusion = (
             os.getenv("FLAGS_enable_tensor_fusion") == '1'
         )
@@ -1281,11 +1278,10 @@ class _ShardOptimizer(Optimizer):
     def _finish_update(self, block, parameters_and_grads):
         self._inner_opt._finish_update(block, parameters_and_grads)
         if self.enable_tensor_fusion:
-            if self.enable_inplace_master_grad:
-                # zero the grad storage for add_ op in inplace_master_grad
-                for grad_storage in self.grad_storage:
-                    grad_storage.zero_()
-                    grad_storage.check_in = 0
+            # zero the grad storage for add_ op in inplace_master_grad
+            for grad_storage in self.grad_storage:
+                grad_storage.zero_()
+                grad_storage.check_in = 0
             if not self.enable_sharding_overlap:
                 for i in range(len(self.fuse_param_view)):
                     shard_size = (
@@ -1301,9 +1297,6 @@ class _ShardOptimizer(Optimizer):
                     ).wait()
 
         else:
-            if self.enable_inplace_master_grad:
-                for param, _ in parameters_and_grads:
-                    param.main_grad._local_value().zero_()
             if isinstance(parameters_and_grads, list):
                 for p, _ in parameters_and_grads:
                     self._reset_placements(p)

--- a/python/paddle/distributed/auto_parallel/api.py
+++ b/python/paddle/distributed/auto_parallel/api.py
@@ -17,6 +17,7 @@ import copy
 import logging
 import os
 import warnings
+from collections import OrderedDict
 from types import MethodType
 from typing import TYPE_CHECKING, Any, Literal, TypedDict
 
@@ -58,6 +59,11 @@ from paddle.distributed.auto_parallel.static.utils import (
     split_param_func,
     to_list,
 )
+from paddle.distributed.fleet.utils.tensor_fusion_helper import (
+    align,
+    alignment,
+    get_current_device_type,
+)
 from paddle.framework import core
 from paddle.io.dataloader.batch_sampler import (
     DistributedBatchSampler,
@@ -68,6 +74,7 @@ from paddle.optimizer import Optimizer
 from .moe_utils import (
     _cal_local_shape,
     _dist_reshape,
+    _dtensor_from_local,
     _NdMeshAlltoAll,
     _reshard_mesh_shape,
     _specific_alltoall_dim,
@@ -79,7 +86,11 @@ from .placement_type import (
     to_placements,
 )
 from .random import determinate_rng, rng_state
-from .sharding import ShardingOptimizerStage1, get_placement_with_sharding
+from .sharding import (
+    ShardingOptimizerStage1,
+    get_mesh_comm_list,
+    get_placement_with_sharding,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
@@ -1128,6 +1139,22 @@ class _ShardOptimizer(Optimizer):
             for param in self._inner_opt._parameter_list:
                 self._shard_fn._shard_parameter(param)
 
+        self.fuse_param_view = []
+        self.param_storage = []
+        self.grad_storage = []
+        self.comm_group = None
+        self.do_tensor_fusion_once = True
+        self._strategy = Strategy()
+        self.enable_inplace_master_grad = (
+            os.getenv("FLAGS_enable_inplace_master_grad") == '1'
+        )
+        self.enable_tensor_fusion = (
+            os.getenv("FLAGS_enable_tensor_fusion") == '1'
+        )
+        self.enable_sharding_overlap = (
+            os.getenv("FLAGS_enable_sharding_overlap") == '1'
+        )
+
     def _set_and_check_sharding_prop_from_param(self):
         global_mesh = fleet.auto.get_mesh()
         if global_mesh:
@@ -1253,13 +1280,37 @@ class _ShardOptimizer(Optimizer):
 
     def _finish_update(self, block, parameters_and_grads):
         self._inner_opt._finish_update(block, parameters_and_grads)
-        if isinstance(parameters_and_grads, list):
-            for p, _ in parameters_and_grads:
-                self._reset_placements(p)
+        if self.enable_tensor_fusion:
+            if self.enable_inplace_master_grad:
+                # zero the grad storage for add_ op in inplace_master_grad
+                for grad_storage in self.grad_storage:
+                    grad_storage.zero_()
+                    grad_storage.check_in = 0
+            if not self.enable_sharding_overlap:
+                for i in range(len(self.fuse_param_view)):
+                    shard_size = (
+                        self.param_storage[i]._numel() // self.comm_group.nranks
+                    )
+                    begin = shard_size * max(self.comm_group.rank, 0)
+                    end = begin + shard_size
+                    slice_buffer = paddle._C_ops.view_slice(
+                        self.param_storage[i], begin, end
+                    )
+                    self.comm_group.process_group.all_gather(
+                        slice_buffer, self.param_storage[i]
+                    ).wait()
+
         else:
-            # reset the parameter and grad to right placements
-            for p, _ in parameters_and_grads['params']:
-                self._reset_placements(p)
+            if self.enable_inplace_master_grad:
+                for param, _ in parameters_and_grads:
+                    param.main_grad._local_value().zero_()
+            if isinstance(parameters_and_grads, list):
+                for p, _ in parameters_and_grads:
+                    self._reset_placements(p)
+            else:
+                # reset the parameter and grad to right placements
+                for p, _ in parameters_and_grads['params']:
+                    self._reset_placements(p)
 
     def apply_gradients(self, params_grads):
         new_params_grads = []
@@ -1409,7 +1460,264 @@ class _ShardOptimizer(Optimizer):
                     grad, grad.shape, grad_mesh, [dist.Replicate()]
                 )
             param_and_grad = (param_and_grad[0], grad)
-        return self._inner_opt._append_optimize_op(block, param_and_grad)
+        self._inner_opt._append_optimize_op(block, param_and_grad)
+        if self.enable_sharding_overlap:
+            # overlap all_gather with optimizer op
+            if hasattr(param_and_grad[0], 'last_idx'):
+                idx = param_and_grad[0].last_idx
+                shard_size = (
+                    self.param_storage[idx]._numel() // self.comm_group.nranks
+                )
+                begin = shard_size * max(self.comm_group.rank, 0)
+                end = begin + shard_size
+                slice_buffer = paddle._C_ops.view_slice(
+                    self.param_storage[idx], begin, end
+                )
+                task = paddle.distributed.all_gather(
+                    self.param_storage[idx],
+                    slice_buffer,
+                    sync_op=False,
+                )
+
+    def _reduce_scatter_gradients(self, grad_storage):
+        shard_size = grad_storage._numel() // self.comm_group.nranks
+        begin = shard_size * max(self.comm_group.rank, 0)
+        end = begin + shard_size
+        reduce_scattered = paddle._C_ops.view_slice(grad_storage, begin, end)
+        paddle.distributed.reduce_scatter(
+            reduce_scattered,
+            grad_storage,
+            op=paddle.distributed.ReduceOp.SUM,
+            group=self.comm_group,
+            sync_op=False,
+        ).wait()
+
+    def _async_reduce_scatter(self):
+        for i in range(len(self.fuse_param_view)):
+            self._reduce_scatter_gradients(self.grad_storage[i])
+
+            def fuse_comm_hook_func(param_group_len, grad_storage, comm_group):
+                @paddle.autograd.no_grad()
+                def fuse_comm(*_):
+                    grad_storage.check_in += 1
+                    if grad_storage.check_in == param_group_len:
+                        shard_size = grad_storage._numel() // comm_group.nranks
+                        begin = shard_size * max(comm_group.rank, 0)
+                        end = begin + shard_size
+                        reduce_scattered = paddle._C_ops.view_slice(
+                            grad_storage, begin, end
+                        )
+                        task = paddle.distributed.reduce_scatter(
+                            reduce_scattered,
+                            grad_storage,
+                            op=paddle.distributed.ReduceOp.SUM,
+                            group=comm_group,
+                            sync_op=False,
+                        )
+                        grad_storage.comm_task = task
+
+                return fuse_comm
+
+            param_group_len = len(self.fuse_param_view[i])
+            for name, view in self.fuse_param_view[i].items():
+                view['param']._register_backward_hook(
+                    fuse_comm_hook_func(
+                        param_group_len,
+                        self.grad_storage[i],
+                        self.comm_group,
+                    )
+                )
+
+    def _build_fuse_param_view(
+        self,
+        params_and_grads,
+        sharding_degree,
+    ):
+        def get_padded_size(param):
+            size = np.prod(param.shape)
+            align_size = (
+                alignment[get_current_device_type()]
+                // align[param.dtype]
+                * sharding_degree
+            )
+            return ((size + align_size - 1) // align_size) * align_size
+
+        total_buffer_size = 0
+        param2index = {}
+        for param, _ in params_and_grads:
+            param2index[param.name] = total_buffer_size
+            total_buffer_size += get_padded_size(param)
+        param_buffer = paddle.zeros(
+            shape=[total_buffer_size], dtype=params_and_grads[0][0].dtype
+        )
+        grad_dtype = paddle.float32
+        grad_buffer = paddle.zeros(shape=[total_buffer_size], dtype=grad_dtype)
+        grad_buffer.check_in = 0
+        grad_buffer.comm_task = None
+
+        views = {}
+        for param, grad in params_and_grads:
+            padded_size = get_padded_size(param)
+            views[param.name] = {
+                'param': param,
+                'index': param2index[param.name],
+            }
+
+            index = param2index[param.name]
+            param_shape = param.shape
+            stop_gradient = param.stop_gradient
+            param.stop_gradient = True
+            param._local_value().flatten_()
+            paddle.assign(
+                param._local_value(),
+                param_buffer._slice(
+                    index,
+                    index + param._numel(),
+                ),
+            )
+            param.stop_gradient = stop_gradient
+            tmp_param = paddle._C_ops.view_slice(
+                param_buffer,
+                index,
+                index + param._numel(),
+            )
+            tmp_param.get_tensor()._set_dims(param.shape)
+            tmp_param = _dtensor_from_local(
+                tmp_param,
+                param.process_mesh,
+                param.placements,
+            )
+            param.get_tensor()._share_data_with(tmp_param.get_tensor())
+
+            paddle.assign(
+                grad._local_value(),
+                grad_buffer._slice(
+                    index,
+                    index + grad._local_value()._numel(),
+                ),
+            )
+            tmp_grad = paddle._C_ops.view_slice(
+                grad_buffer,
+                index,
+                index + grad._local_value()._numel(),
+            )
+            tmp_grad.get_tensor()._set_dims(grad.shape)
+            tmp_grad = _dtensor_from_local(
+                tmp_grad,
+                grad.process_mesh,
+                grad.placements,
+            )
+            param.main_grad = tmp_grad
+            grad.get_tensor()._clear()
+            paddle.device.cuda.empty_cache()
+
+        return (views, param_buffer, grad_buffer)
+
+    def _tensor_fusion(self, params_grads):
+        if self.do_tensor_fusion_once:
+            mesh = dist.auto_parallel.get_mesh()
+            shard_groups = get_mesh_comm_list(mesh, "dp")
+            for group in shard_groups:
+                comm_group = dist.new_group(sorted(group))
+                if dist.get_rank() in group:
+                    self.comm_group = comm_group
+            self.do_tensor_fusion_once = False
+            parameters = [p_g[0] for p_g in params_grads]
+            comm_buffer_size_MB = self._strategy.sharding.comm_buffer_size_MB
+            if comm_buffer_size_MB < 0:
+                comm_buffer_size_MB = 256
+            group_size = comm_buffer_size_MB * 1024 * 1024
+            is_sparse_gradient = [False] * len(parameters)
+            shape_dict = {param.name: param.shape for param in parameters}
+            dense_params = [param._local_value() for param in parameters]
+
+            # group params according to comm_buffer_size_MB
+            group_indices = core.eager_assign_group_by_size(
+                dense_params, is_sparse_gradient, [group_size, group_size]
+            )
+            var_groups = OrderedDict()
+            for group_idx, indices in enumerate(group_indices):
+                for i in indices:
+                    var_groups.setdefault(group_idx, []).append(params_grads[i])
+
+            # create fuse_param_view, param_storage, grad_storage with groups
+            for group_idx, params_and_grads in var_groups.items():
+                (
+                    fuse_param_view,
+                    param_storage,
+                    grad_storage,
+                ) = self._build_fuse_param_view(
+                    params_and_grads,
+                    self.comm_group.nranks,
+                )
+                self.fuse_param_view.append(fuse_param_view)
+                self.param_storage.append(param_storage)
+                self.grad_storage.append(grad_storage)
+
+            if self.enable_sharding_overlap:
+                self._async_reduce_scatter()
+
+            if self._inner_opt._grad_clip is not None:
+                self._inner_opt._grad_clip.should_comm_on_shard_dim = True
+                self._inner_opt._grad_clip.sharding_group = self.comm_group
+
+        new_params = []
+        new_grads = []
+        for i in range(len(self.fuse_param_view)):
+            if not self.enable_sharding_overlap:
+                self._reduce_scatter_gradients(self.grad_storage[i])
+
+            for name, view in self.fuse_param_view[i].items():
+                param = view['param']
+                index = view['index']
+                shard_size = (
+                    self.param_storage[i]._numel() // self.comm_group.nranks
+                )
+                rank_begin = shard_size * max(self.comm_group.rank, 0)
+                rank_end = rank_begin + shard_size
+                param_begin = max(index, rank_begin)
+                param_end = min(index + param._numel(), rank_end)
+                if param_begin >= param_end:
+                    continue
+                # get new_param from param_storage
+                new_param = paddle._C_ops.view_slice(
+                    self.param_storage[i], param_begin, param_end
+                )
+                new_param = _dtensor_from_local(
+                    new_param,
+                    param.process_mesh,
+                    [dist.Replicate()],
+                )
+                new_param.name = name
+                new_param.stop_gradient = param.stop_gradient
+                new_param.need_clip = param.need_clip
+                new_param.persistable = True
+                new_param.trainable = param.trainable
+                new_param.stop_gradient = param.stop_gradient
+                new_param.optimize_attr = param.optimize_attr
+                new_param.regularizer = param.regularizer
+                new_param.do_model_average = param.do_model_average
+                new_param.is_distributed = param.is_distributed
+                new_params.append(new_param)
+
+                # get new_grad from grad_storage
+                new_grad = paddle._C_ops.view_slice(
+                    self.grad_storage[i], param_begin, param_end
+                )
+                new_grad = _dtensor_from_local(
+                    new_grad, param.process_mesh, [dist.Replicate()]
+                )
+                new_grads.append(new_grad)
+
+            if self.enable_sharding_overlap:
+                # last_idx marks the last param, start asyn comm
+                new_params[-1].last_idx = i
+                if self.grad_storage[i].comm_task is not None:
+                    self.grad_storage[i].comm_task.wait()
+
+        new_params_grads = list(zip(new_params, new_grads))
+
+        return new_params_grads
 
     def _fused_comm_before_apply_optimize(self, flags, params_grads):
         '''
@@ -1505,31 +1813,34 @@ class _ShardOptimizer(Optimizer):
     def _apply_optimize(
         self, loss, startup_program, params_grads, param_group_idx=0
     ):
-        # Fuse the communication of gradients prior to the optimization operation in the dynamic mode.
-        if paddle.in_dynamic_mode():
-            # Get fuse optimization flag.
-            def get_env(flag_name):
-                if os.getenv(flag_name) in ['True', 'true', '1']:
-                    return True
-                return False
+        if self.enable_tensor_fusion:
+            params_grads = self._tensor_fusion(params_grads)
+        else:
+            # Fuse the communication of gradients prior to the optimization operation in the dynamic mode.
+            if paddle.in_dynamic_mode():
+                # Get fuse optimization flag.
+                def get_env(flag_name):
+                    if os.getenv(flag_name) in ['True', 'true', '1']:
+                        return True
+                    return False
 
-            # TODO: This optimization hasn't been verified on a wide range of models. Currently,
-            # it's controlled by a flag switch and will be removed later.
-            fuse_allreduce_in_opt = get_env("FLAGS_fuse_allreduce_in_opt")
-            fuse_reducescatter_in_opt = get_env(
-                "FLAGS_fuse_reducescatter_in_opt"
-            )
-            assert not (
-                fuse_allreduce_in_opt and fuse_reducescatter_in_opt
-            ), "The `FLAGS_fuse_allreduce_in_opt` switch and the `FLAGS_fuse_reducescatter_in_opt` switch cannot be turned on simultaneously."
-
-            if fuse_allreduce_in_opt or fuse_reducescatter_in_opt:
-                flags = {}
-                flags["fuse_allreduce"] = fuse_allreduce_in_opt
-                flags["fuse_reducescatter"] = fuse_reducescatter_in_opt
-                params_grads = self._fused_comm_before_apply_optimize(
-                    flags, params_grads
+                # TODO: This optimization hasn't been verified on a wide range of models. Currently,
+                # it's controlled by a flag switch and will be removed later.
+                fuse_allreduce_in_opt = get_env("FLAGS_fuse_allreduce_in_opt")
+                fuse_reducescatter_in_opt = get_env(
+                    "FLAGS_fuse_reducescatter_in_opt"
                 )
+                assert not (
+                    fuse_allreduce_in_opt and fuse_reducescatter_in_opt
+                ), "The `FLAGS_fuse_allreduce_in_opt` switch and the `FLAGS_fuse_reducescatter_in_opt` switch cannot be turned on simultaneously."
+
+                if fuse_allreduce_in_opt or fuse_reducescatter_in_opt:
+                    flags = {}
+                    flags["fuse_allreduce"] = fuse_allreduce_in_opt
+                    flags["fuse_reducescatter"] = fuse_reducescatter_in_opt
+                    params_grads = self._fused_comm_before_apply_optimize(
+                        flags, params_grads
+                    )
 
         return super()._apply_optimize(
             loss, startup_program, params_grads, param_group_idx
@@ -1563,7 +1874,12 @@ class _ShardingStageBase:
         self, param: Tensor, master_weight: Tensor
     ) -> Tensor:
         if param.is_dist():
-            placements = get_placement_with_sharding(param, self._sharding_axis)
+            if os.getenv("FLAGS_enable_tensor_fusion") == '1':
+                placements = param.placements
+            else:
+                placements = get_placement_with_sharding(
+                    param, self._sharding_axis
+                )
             if isinstance(master_weight, pir.Value):
                 data_op = master_weight.get_defining_op()
                 assert (
@@ -1645,7 +1961,10 @@ class ShardingStage1(_ShardingStageBase):
     def __call__(self, key: str, param: Tensor, accumulator: Tensor) -> Tensor:
         if param.is_dist():
             # Only deal with momentum in optimizer, beta should be replicated cross param's mesh
-            if 'beta' not in key:
+            if (
+                not os.getenv("FLAGS_enable_tensor_fusion") == '1'
+                and 'beta' not in key
+            ):
                 placements = get_placement_with_sharding(
                     param, self._sharding_axis
                 )

--- a/python/paddle/distributed/auto_parallel/api.py
+++ b/python/paddle/distributed/auto_parallel/api.py
@@ -1151,6 +1151,9 @@ class _ShardOptimizer(Optimizer):
         self.enable_tensor_fusion = (
             os.getenv("FLAGS_enable_tensor_fusion") == '1'
         )
+        self.enable_sharding_overlap = (
+            os.getenv("FLAGS_enable_sharding_overlap") == '1'
+        )
 
     def _set_and_check_sharding_prop_from_param(self):
         global_mesh = fleet.auto.get_mesh()
@@ -1283,18 +1286,19 @@ class _ShardOptimizer(Optimizer):
                 for grad_storage in self.grad_storage:
                     grad_storage.zero_()
                     grad_storage.check_in = 0
-            for i in range(len(self.fuse_param_view)):
-                shard_size = (
-                    self.param_storage[i]._numel() // self.comm_group.nranks
-                )
-                begin = shard_size * max(self.comm_group.rank, 0)
-                end = begin + shard_size
-                slice_buffer = paddle._C_ops.view_slice(
-                    self.param_storage[i], begin, end
-                )
-                self.comm_group.process_group.all_gather(
-                    slice_buffer, self.param_storage[i]
-                ).wait()
+            if not self.enable_sharding_overlap:
+                for i in range(len(self.fuse_param_view)):
+                    shard_size = (
+                        self.param_storage[i]._numel() // self.comm_group.nranks
+                    )
+                    begin = shard_size * max(self.comm_group.rank, 0)
+                    end = begin + shard_size
+                    slice_buffer = paddle._C_ops.view_slice(
+                        self.param_storage[i], begin, end
+                    )
+                    self.comm_group.process_group.all_gather(
+                        slice_buffer, self.param_storage[i]
+                    ).wait()
 
         else:
             if self.enable_inplace_master_grad:
@@ -1456,7 +1460,24 @@ class _ShardOptimizer(Optimizer):
                     grad, grad.shape, grad_mesh, [dist.Replicate()]
                 )
             param_and_grad = (param_and_grad[0], grad)
-        return self._inner_opt._append_optimize_op(block, param_and_grad)
+        self._inner_opt._append_optimize_op(block, param_and_grad)
+        if self.enable_sharding_overlap:
+            # overlap all_gather with optimizer op
+            if hasattr(param_and_grad[0], 'last_idx'):
+                idx = param_and_grad[0].last_idx
+                shard_size = (
+                    self.param_storage[idx]._numel() // self.comm_group.nranks
+                )
+                begin = shard_size * max(self.comm_group.rank, 0)
+                end = begin + shard_size
+                slice_buffer = paddle._C_ops.view_slice(
+                    self.param_storage[idx], begin, end
+                )
+                task = paddle.distributed.all_gather(
+                    self.param_storage[idx],
+                    slice_buffer,
+                    sync_op=False,
+                )
 
     def _reduce_scatter_gradients(self, grad_storage):
         shard_size = grad_storage._numel() // self.comm_group.nranks
@@ -1470,6 +1491,42 @@ class _ShardOptimizer(Optimizer):
             group=self.comm_group,
             sync_op=False,
         ).wait()
+
+    def _async_reduce_scatter(self):
+        for i in range(len(self.fuse_param_view)):
+            self._reduce_scatter_gradients(self.grad_storage[i])
+
+            def fuse_comm_hook_func(param_group_len, grad_storage, comm_group):
+                @paddle.autograd.no_grad()
+                def fuse_comm(*_):
+                    grad_storage.check_in += 1
+                    if grad_storage.check_in == param_group_len:
+                        shard_size = grad_storage._numel() // comm_group.nranks
+                        begin = shard_size * max(comm_group.rank, 0)
+                        end = begin + shard_size
+                        reduce_scattered = paddle._C_ops.view_slice(
+                            grad_storage, begin, end
+                        )
+                        task = paddle.distributed.reduce_scatter(
+                            reduce_scattered,
+                            grad_storage,
+                            op=paddle.distributed.ReduceOp.SUM,
+                            group=comm_group,
+                            sync_op=False,
+                        )
+                        grad_storage.comm_task = task
+
+                return fuse_comm
+
+            param_group_len = len(self.fuse_param_view[i])
+            for name, view in self.fuse_param_view[i].items():
+                view['param']._register_backward_hook(
+                    fuse_comm_hook_func(
+                        param_group_len,
+                        self.grad_storage[i],
+                        self.comm_group,
+                    )
+                )
 
     def _build_fuse_param_view(
         self,
@@ -1597,6 +1654,9 @@ class _ShardOptimizer(Optimizer):
                 self.param_storage.append(param_storage)
                 self.grad_storage.append(grad_storage)
 
+            if self.enable_sharding_overlap:
+                self._async_reduce_scatter()
+
             if self._inner_opt._grad_clip is not None:
                 self._inner_opt._grad_clip.should_comm_on_shard_dim = True
                 self._inner_opt._grad_clip.sharding_group = self.comm_group
@@ -1604,7 +1664,8 @@ class _ShardOptimizer(Optimizer):
         new_params = []
         new_grads = []
         for i in range(len(self.fuse_param_view)):
-            self._reduce_scatter_gradients(self.grad_storage[i])
+            if not self.enable_sharding_overlap:
+                self._reduce_scatter_gradients(self.grad_storage[i])
 
             for name, view in self.fuse_param_view[i].items():
                 param = view['param']
@@ -1647,6 +1708,12 @@ class _ShardOptimizer(Optimizer):
                     new_grad, param.process_mesh, [dist.Replicate()]
                 )
                 new_grads.append(new_grad)
+
+            if self.enable_sharding_overlap:
+                # last_idx marks the last param, start asyn comm
+                new_params[-1].last_idx = i
+                if self.grad_storage[i].comm_task is not None:
+                    self.grad_storage[i].comm_task.wait()
 
         new_params_grads = list(zip(new_params, new_grads))
 

--- a/python/paddle/distributed/auto_parallel/api.py
+++ b/python/paddle/distributed/auto_parallel/api.py
@@ -1665,7 +1665,7 @@ class _ShardOptimizer(Optimizer):
             if self._inner_opt._grad_clip is not None:
                 self._inner_opt._grad_clip.should_comm_on_shard_dim = True
                 self._inner_opt._grad_clip.sharding_group = self._sharding_group
-                if self._mp_degree > 1:
+                if "mp" in mesh._dim_names and self._mp_degree > 1:
                     self._inner_opt._grad_clip.mp_group = self._mp_group
 
         new_params = []

--- a/python/paddle/distributed/auto_parallel/api.py
+++ b/python/paddle/distributed/auto_parallel/api.py
@@ -1142,7 +1142,8 @@ class _ShardOptimizer(Optimizer):
         self.fuse_param_view = []
         self.param_storage = []
         self.grad_storage = []
-        self.comm_group = None
+        self._sharding_group = None
+        self._mp_group = None
         self.do_tensor_fusion_once = True
         self._strategy = Strategy()
         self.enable_tensor_fusion = (
@@ -1285,14 +1286,15 @@ class _ShardOptimizer(Optimizer):
             if not self.enable_sharding_overlap:
                 for i in range(len(self.fuse_param_view)):
                     shard_size = (
-                        self.param_storage[i]._numel() // self.comm_group.nranks
+                        self.param_storage[i]._numel()
+                        // self._sharding_group.nranks
                     )
-                    begin = shard_size * max(self.comm_group.rank, 0)
+                    begin = shard_size * max(self._sharding_group.rank, 0)
                     end = begin + shard_size
                     slice_buffer = paddle._C_ops.view_slice(
                         self.param_storage[i], begin, end
                     )
-                    self.comm_group.process_group.all_gather(
+                    self._sharding_group.process_group.all_gather(
                         slice_buffer, self.param_storage[i]
                     ).wait()
 
@@ -1459,9 +1461,10 @@ class _ShardOptimizer(Optimizer):
             if hasattr(param_and_grad[0], 'last_idx'):
                 idx = param_and_grad[0].last_idx
                 shard_size = (
-                    self.param_storage[idx]._numel() // self.comm_group.nranks
+                    self.param_storage[idx]._numel()
+                    // self._sharding_group.nranks
                 )
-                begin = shard_size * max(self.comm_group.rank, 0)
+                begin = shard_size * max(self._sharding_group.rank, 0)
                 end = begin + shard_size
                 slice_buffer = paddle._C_ops.view_slice(
                     self.param_storage[idx], begin, end
@@ -1469,20 +1472,20 @@ class _ShardOptimizer(Optimizer):
                 task = paddle.distributed.all_gather(
                     self.param_storage[idx],
                     slice_buffer,
-                    group=self.comm_group,
+                    group=self._sharding_group,
                     sync_op=False,
                 )
 
     def _reduce_scatter_gradients(self, grad_storage):
-        shard_size = grad_storage._numel() // self.comm_group.nranks
-        begin = shard_size * max(self.comm_group.rank, 0)
+        shard_size = grad_storage._numel() // self._sharding_group.nranks
+        begin = shard_size * max(self._sharding_group.rank, 0)
         end = begin + shard_size
         reduce_scattered = paddle._C_ops.view_slice(grad_storage, begin, end)
         paddle.distributed.reduce_scatter(
             reduce_scattered,
             grad_storage,
             op=paddle.distributed.ReduceOp.SUM,
-            group=self.comm_group,
+            group=self._sharding_group,
             sync_op=False,
         ).wait()
 
@@ -1518,7 +1521,7 @@ class _ShardOptimizer(Optimizer):
                     fuse_comm_hook_func(
                         param_group_len,
                         self.grad_storage[i],
-                        self.comm_group,
+                        self._sharding_group,
                     )
                 )
 
@@ -1614,7 +1617,15 @@ class _ShardOptimizer(Optimizer):
             for group in shard_groups:
                 comm_group = dist.new_group(sorted(group))
                 if dist.get_rank() in group:
-                    self.comm_group = comm_group
+                    self._sharding_group = comm_group
+            if "mp" in mesh._dim_names:
+                mp_mesh_axis = mesh._dim_names.index("mp")
+                self._mp_degree = mesh._shape[mp_mesh_axis]
+                mp_groups = get_mesh_comm_list(mesh, "mp")
+                for group in mp_groups:
+                    comm_group = dist.new_group(sorted(group))
+                    if dist.get_rank() in group:
+                        self._mp_group = comm_group
             self.do_tensor_fusion_once = False
             parameters = [p_g[0] for p_g in params_grads]
             comm_buffer_size_MB = self._strategy.sharding.comm_buffer_size_MB
@@ -1642,7 +1653,7 @@ class _ShardOptimizer(Optimizer):
                     grad_storage,
                 ) = self._build_fuse_param_view(
                     params_and_grads,
-                    self.comm_group.nranks,
+                    self._sharding_group.nranks,
                 )
                 self.fuse_param_view.append(fuse_param_view)
                 self.param_storage.append(param_storage)
@@ -1653,7 +1664,9 @@ class _ShardOptimizer(Optimizer):
 
             if self._inner_opt._grad_clip is not None:
                 self._inner_opt._grad_clip.should_comm_on_shard_dim = True
-                self._inner_opt._grad_clip.sharding_group = self.comm_group
+                self._inner_opt._grad_clip.sharding_group = self._sharding_group
+                if self._mp_degree > 1:
+                    self._inner_opt._grad_clip.mp_group = self._mp_group
 
         new_params = []
         new_grads = []
@@ -1665,9 +1678,10 @@ class _ShardOptimizer(Optimizer):
                 param = view['param']
                 index = view['index']
                 shard_size = (
-                    self.param_storage[i]._numel() // self.comm_group.nranks
+                    self.param_storage[i]._numel()
+                    // self._sharding_group.nranks
                 )
-                rank_begin = shard_size * max(self.comm_group.rank, 0)
+                rank_begin = shard_size * max(self._sharding_group.rank, 0)
                 rank_end = rank_begin + shard_size
                 param_begin = max(index, rank_begin)
                 param_end = min(index + param._numel(), rank_end)

--- a/python/paddle/distributed/auto_parallel/api.py
+++ b/python/paddle/distributed/auto_parallel/api.py
@@ -1146,12 +1146,14 @@ class _ShardOptimizer(Optimizer):
         self._mp_group = None
         self.do_tensor_fusion_once = True
         self._strategy = Strategy()
-        self.enable_tensor_fusion = (
-            os.getenv("FLAGS_enable_tensor_fusion") == '1'
-        )
-        self.enable_sharding_overlap = (
-            os.getenv("FLAGS_enable_sharding_overlap") == '1'
-        )
+        self.enable_tensor_fusion = os.getenv("FLAGS_enable_tensor_fusion") in [
+            "True",
+            "true",
+            "1",
+        ]
+        self.enable_sharding_overlap = os.getenv(
+            "FLAGS_enable_sharding_overlap"
+        ) in ["True", "true", "1"]
 
     def _set_and_check_sharding_prop_from_param(self):
         global_mesh = fleet.auto.get_mesh()
@@ -1882,7 +1884,7 @@ class _ShardingStageBase:
         self, param: Tensor, master_weight: Tensor
     ) -> Tensor:
         if param.is_dist():
-            if os.getenv("FLAGS_enable_tensor_fusion") == '1':
+            if os.getenv("FLAGS_enable_tensor_fusion") in ["True", "true", "1"]:
                 placements = param.placements
             else:
                 placements = get_placement_with_sharding(
@@ -1970,7 +1972,8 @@ class ShardingStage1(_ShardingStageBase):
         if param.is_dist():
             # Only deal with momentum in optimizer, beta should be replicated cross param's mesh
             if (
-                not os.getenv("FLAGS_enable_tensor_fusion") == '1'
+                os.getenv("FLAGS_enable_tensor_fusion")
+                not in ["True", "true", "1"]
                 and 'beta' not in key
             ):
                 placements = get_placement_with_sharding(

--- a/python/paddle/nn/clip.py
+++ b/python/paddle/nn/clip.py
@@ -790,6 +790,12 @@ class ClipGradByGlobalNorm(ClipGradBase):
             global_norm_var.append(global_norm_var_fp64)
 
         global_norm_var = async_add_n(global_norm_var)
+
+        if self.should_comm_on_shard_dim and hasattr(self, 'sharding_group'):
+            paddle.distributed.all_reduce(
+                global_norm_var._local_value(), group=self.sharding_group
+            ).wait()
+
         global_norm_var = paddle.sqrt(global_norm_var)
         max_global_norm = paddle.full(
             shape=[1], dtype=sum_dtype, fill_value=self.clip_norm

--- a/python/paddle/nn/clip.py
+++ b/python/paddle/nn/clip.py
@@ -796,6 +796,11 @@ class ClipGradByGlobalNorm(ClipGradBase):
                 global_norm_var._local_value(), group=self.sharding_group
             ).wait()
 
+        if self.should_comm_on_shard_dim and hasattr(self, 'mp_group'):
+            paddle.distributed.all_reduce(
+                global_norm_var._local_value(), group=self.mp_group
+            ).wait()
+
         global_norm_var = paddle.sqrt(global_norm_var)
         max_global_norm = paddle.full(
             shape=[1], dtype=sum_dtype, fill_value=self.clip_norm

--- a/python/paddle/optimizer/optimizer.py
+++ b/python/paddle/optimizer/optimizer.py
@@ -2000,9 +2000,16 @@ class Optimizer:
             for param in self._param_groups:
                 if param.stop_gradient:
                     continue
-                if param._grad_ivar() is not None:
-                    grad_var = param._grad_ivar()
-                    params_grads.append((param, grad_var))
+                if os.getenv("FLAGS_enable_inplace_master_grad") == '1':
+                    if (
+                        hasattr(param, "main_grad")
+                        and param.main_grad is not None
+                    ):
+                        params_grads.append((param, param.main_grad))
+                else:
+                    if param._grad_ivar() is not None:
+                        grad_var = param._grad_ivar()
+                        params_grads.append((param, grad_var))
 
             self._apply_optimize(
                 loss=None,

--- a/python/paddle/optimizer/optimizer.py
+++ b/python/paddle/optimizer/optimizer.py
@@ -2000,7 +2000,7 @@ class Optimizer:
             for param in self._param_groups:
                 if param.stop_gradient:
                     continue
-                if os.getenv("FLAGS_enable_inplace_master_grad") == '1':
+                if os.getenv("FLAGS_enable_tensor_fusion") == '1':
                     if (
                         hasattr(param, "main_grad")
                         and param.main_grad is not None

--- a/python/paddle/optimizer/optimizer.py
+++ b/python/paddle/optimizer/optimizer.py
@@ -2000,7 +2000,11 @@ class Optimizer:
             for param in self._param_groups:
                 if param.stop_gradient:
                     continue
-                if os.getenv("FLAGS_enable_tensor_fusion") == '1':
+                if os.getenv("FLAGS_enable_tensor_fusion") in [
+                    "True",
+                    "true",
+                    "1",
+                ]:
                     if (
                         hasattr(param, "main_grad")
                         and param.main_grad is not None

--- a/test/auto_parallel/semi_auto_parallel_sharding_stage_1.py
+++ b/test/auto_parallel/semi_auto_parallel_sharding_stage_1.py
@@ -234,6 +234,34 @@ class TestSemiAutoParallelShardingStage1:
         loss_enable = run_sharding_test(enable_tensor_fusion=True)
         self.check_tensor_eq(loss_disable, loss_enable)
 
+    def test_pure_sharding_multi_mesh_stage_1_with_tensor_fusion_with_chip(
+        self,
+    ):
+        dist.init_parallel_env()
+        os.environ['FLAGS_enable_inplace_master_grad'] = '1'
+        os.environ['FLAGS_enable_tensor_fusion'] = '1'
+        paddle.distributed.auto_parallel.set_mesh(self._multi_dim_mesh)
+        paddle.seed(self._seed)
+        model = paddle.nn.Linear(10, 10)
+        batch = paddle.rand(shape=[10, 10])
+        batch = dist.shard_tensor(batch, self._mesh, [dist.Shard(0)])
+        clip = paddle.nn.ClipGradByGlobalNorm(1.0)
+        opt = paddle.optimizer.AdamW(
+            parameters=model.parameters(), grad_clip=clip
+        )
+        opt = dist.shard_optimizer(
+            opt, dist.ShardingStage1(sharding_mesh_dim="dp")
+        )
+        model, opt = paddle.amp.decorate(
+            model, optimizers=opt, level='O2', master_grad=True
+        )
+        for _ in range(5):
+            with paddle.amp.auto_cast(level='O2'):
+                loss = model(batch)
+                loss.backward()
+                opt.step()
+                opt.clear_grad()
+
     def test_pure_sharding_multi_mesh_stage_1_with_sharding_overlap(self):
         def run_sharding_test(enable_sharding_overlap):
             os.environ['FLAGS_enable_inplace_master_grad'] = '1'
@@ -283,6 +311,7 @@ class TestSemiAutoParallelShardingStage1:
         self.test_sharding_stage_1_overlap_to_static()
         self.test_pure_sharding_multi_mesh_stage_1_with_inplace_master_grad()
         self.test_pure_sharding_multi_mesh_stage_1_with_tensor_fusion()
+        self.test_pure_sharding_multi_mesh_stage_1_with_tensor_fusion_with_chip()
         self.test_pure_sharding_multi_mesh_stage_1_with_sharding_overlap()
 
 

--- a/test/auto_parallel/semi_auto_parallel_sharding_stage_1.py
+++ b/test/auto_parallel/semi_auto_parallel_sharding_stage_1.py
@@ -173,39 +173,8 @@ class TestSemiAutoParallelShardingStage1:
             for batch_id, (image, label) in enumerate(dist_loader()):
                 loss = dist_model(image, label)
 
-    def test_pure_sharding_multi_mesh_stage_1_with_inplace_master_grad(self):
-        def run_sharding_test(enable_inplace_master_grad):
-            os.environ['FLAGS_enable_inplace_master_grad'] = (
-                '1' if enable_inplace_master_grad else '0'
-            )
-            paddle.distributed.auto_parallel.set_mesh(self._multi_dim_mesh)
-            paddle.seed(self._seed)
-            model = paddle.nn.Linear(10, 10)
-            batch = paddle.rand(shape=[10, 10])
-            batch = dist.shard_tensor(batch, self._mesh, [dist.Shard(0)])
-            opt = paddle.optimizer.AdamW(parameters=model.parameters())
-            opt = dist.shard_optimizer(
-                opt, dist.ShardingStage1(sharding_mesh_dim="dp")
-            )
-            model, opt = paddle.amp.decorate(
-                model, optimizers=opt, level='O2', master_grad=True
-            )
-            for _ in range(5):
-                with paddle.amp.auto_cast(level='O2'):
-                    loss = model(batch)
-                    loss.backward()
-                    opt.step()
-                    opt.clear_grad()
-            return loss.numpy()
-
-        dist.init_parallel_env()
-        loss_disable = run_sharding_test(enable_inplace_master_grad=False)
-        loss_enable = run_sharding_test(enable_inplace_master_grad=True)
-        self.check_tensor_eq(loss_disable, loss_enable)
-
     def test_pure_sharding_multi_mesh_stage_1_with_tensor_fusion(self):
         def run_sharding_test(enable_tensor_fusion):
-            os.environ['FLAGS_enable_inplace_master_grad'] = '1'
             os.environ['FLAGS_enable_tensor_fusion'] = (
                 '1' if enable_tensor_fusion else '0'
             )
@@ -238,7 +207,6 @@ class TestSemiAutoParallelShardingStage1:
         self,
     ):
         dist.init_parallel_env()
-        os.environ['FLAGS_enable_inplace_master_grad'] = '1'
         os.environ['FLAGS_enable_tensor_fusion'] = '1'
         paddle.distributed.auto_parallel.set_mesh(self._multi_dim_mesh)
         paddle.seed(self._seed)
@@ -264,7 +232,6 @@ class TestSemiAutoParallelShardingStage1:
 
     def test_pure_sharding_multi_mesh_stage_1_with_sharding_overlap(self):
         def run_sharding_test(enable_sharding_overlap):
-            os.environ['FLAGS_enable_inplace_master_grad'] = '1'
             os.environ['FLAGS_enable_tensor_fusion'] = '1'
             os.environ['FLAGS_enable_sharding_overlap'] = (
                 '1' if enable_sharding_overlap else '0'
@@ -309,7 +276,6 @@ class TestSemiAutoParallelShardingStage1:
         self.test_sharding_stage_1_to_static()
         self.test_pure_sharding_multi_mesh_stage_1()
         self.test_sharding_stage_1_overlap_to_static()
-        self.test_pure_sharding_multi_mesh_stage_1_with_inplace_master_grad()
         self.test_pure_sharding_multi_mesh_stage_1_with_tensor_fusion()
         self.test_pure_sharding_multi_mesh_stage_1_with_tensor_fusion_with_chip()
         self.test_pure_sharding_multi_mesh_stage_1_with_sharding_overlap()

--- a/test/auto_parallel/semi_auto_parallel_sharding_stage_1.py
+++ b/test/auto_parallel/semi_auto_parallel_sharding_stage_1.py
@@ -173,6 +173,36 @@ class TestSemiAutoParallelShardingStage1:
             for batch_id, (image, label) in enumerate(dist_loader()):
                 loss = dist_model(image, label)
 
+    def test_pure_sharding_multi_mesh_stage_1_with_inplace_master_grad(self):
+        def run_sharding_test(enable_inplace_master_grad):
+            os.environ['FLAGS_enable_inplace_master_grad'] = (
+                '1' if enable_inplace_master_grad else '0'
+            )
+            paddle.distributed.auto_parallel.set_mesh(self._multi_dim_mesh)
+            paddle.seed(self._seed)
+            model = paddle.nn.Linear(10, 10)
+            batch = paddle.rand(shape=[10, 10])
+            batch = dist.shard_tensor(batch, self._mesh, [dist.Shard(0)])
+            opt = paddle.optimizer.AdamW(parameters=model.parameters())
+            opt = dist.shard_optimizer(
+                opt, dist.ShardingStage1(sharding_mesh_dim="dp")
+            )
+            model, opt = paddle.amp.decorate(
+                model, optimizers=opt, level='O2', master_grad=True
+            )
+            for _ in range(5):
+                with paddle.amp.auto_cast(level='O2'):
+                    loss = model(batch)
+                    loss.backward()
+                    opt.step()
+                    opt.clear_grad()
+            return loss.numpy()
+
+        dist.init_parallel_env()
+        loss_disable = run_sharding_test(enable_inplace_master_grad=False)
+        loss_enable = run_sharding_test(enable_inplace_master_grad=True)
+        self.check_tensor_eq(loss_disable, loss_enable)
+
     def test_pure_sharding_multi_mesh_stage_1_with_tensor_fusion(self):
         def run_sharding_test(enable_tensor_fusion):
             os.environ['FLAGS_enable_inplace_master_grad'] = '1'
@@ -181,24 +211,28 @@ class TestSemiAutoParallelShardingStage1:
             )
             paddle.distributed.auto_parallel.set_mesh(self._multi_dim_mesh)
             paddle.seed(self._seed)
-            linear = paddle.nn.Linear(10, 10)
+            model = paddle.nn.Linear(10, 10)
             batch = paddle.rand(shape=[10, 10])
             batch = dist.shard_tensor(batch, self._mesh, [dist.Shard(0)])
-            opt = paddle.optimizer.AdamW(parameters=linear.parameters())
+            opt = paddle.optimizer.AdamW(parameters=model.parameters())
             opt = dist.shard_optimizer(
                 opt, dist.ShardingStage1(sharding_mesh_dim="dp")
             )
+            model, opt = paddle.amp.decorate(
+                model, optimizers=opt, level='O2', master_grad=True
+            )
             for _ in range(5):
-                loss = linear(batch)
-                loss.backward()
-                opt.step()
-                opt.clear_grad()
+                with paddle.amp.auto_cast(level='O2'):
+                    loss = model(batch)
+                    loss.backward()
+                    opt.step()
+                    opt.clear_grad()
             return loss.numpy()
 
         dist.init_parallel_env()
-        loss_with_fusion = run_sharding_test(enable_tensor_fusion=True)
-        loss_without_fusion = run_sharding_test(enable_tensor_fusion=False)
-        self.check_tensor_eq(loss_with_fusion, loss_without_fusion)
+        loss_disable = run_sharding_test(enable_tensor_fusion=False)
+        loss_enable = run_sharding_test(enable_tensor_fusion=True)
+        self.check_tensor_eq(loss_disable, loss_enable)
 
     def test_pure_sharding_multi_mesh_stage_1_with_sharding_overlap(self):
         def run_sharding_test(enable_sharding_overlap):
@@ -209,27 +243,28 @@ class TestSemiAutoParallelShardingStage1:
             )
             paddle.distributed.auto_parallel.set_mesh(self._multi_dim_mesh)
             paddle.seed(self._seed)
-            linear = paddle.nn.Linear(10, 10)
+            model = paddle.nn.Linear(10, 10)
             batch = paddle.rand(shape=[10, 10])
             batch = dist.shard_tensor(batch, self._mesh, [dist.Shard(0)])
-            opt = paddle.optimizer.AdamW(
-                parameters=linear.parameters(),
-                grad_clip=paddle.nn.ClipGradByGlobalNorm(1.0),
-            )
+            opt = paddle.optimizer.AdamW(parameters=model.parameters())
             opt = dist.shard_optimizer(
                 opt, dist.ShardingStage1(sharding_mesh_dim="dp")
             )
+            model, opt = paddle.amp.decorate(
+                model, optimizers=opt, level='O2', master_grad=True
+            )
             for _ in range(5):
-                loss = linear(batch)
-                loss.backward()
-                opt.step()
-                opt.clear_grad()
+                with paddle.amp.auto_cast(level='O2'):
+                    loss = model(batch)
+                    loss.backward()
+                    opt.step()
+                    opt.clear_grad()
             return loss.numpy()
 
         dist.init_parallel_env()
-        loss_with_fusion = run_sharding_test(enable_sharding_overlap=True)
-        loss_without_fusion = run_sharding_test(enable_sharding_overlap=False)
-        self.check_tensor_eq(loss_with_fusion, loss_without_fusion)
+        loss_disable = run_sharding_test(enable_sharding_overlap=False)
+        loss_enable = run_sharding_test(enable_sharding_overlap=True)
+        self.check_tensor_eq(loss_disable, loss_enable)
 
     def run_test_case(self):
         if self._backend == "cpu":
@@ -246,6 +281,7 @@ class TestSemiAutoParallelShardingStage1:
         self.test_sharding_stage_1_to_static()
         self.test_pure_sharding_multi_mesh_stage_1()
         self.test_sharding_stage_1_overlap_to_static()
+        self.test_pure_sharding_multi_mesh_stage_1_with_inplace_master_grad()
         self.test_pure_sharding_multi_mesh_stage_1_with_tensor_fusion()
         self.test_pure_sharding_multi_mesh_stage_1_with_sharding_overlap()
 

--- a/test/auto_parallel/semi_auto_parallel_sharding_stage_1.py
+++ b/test/auto_parallel/semi_auto_parallel_sharding_stage_1.py
@@ -173,6 +173,64 @@ class TestSemiAutoParallelShardingStage1:
             for batch_id, (image, label) in enumerate(dist_loader()):
                 loss = dist_model(image, label)
 
+    def test_pure_sharding_multi_mesh_stage_1_with_tensor_fusion(self):
+        def run_sharding_test(enable_tensor_fusion):
+            os.environ['FLAGS_enable_inplace_master_grad'] = '1'
+            os.environ['FLAGS_enable_tensor_fusion'] = (
+                '1' if enable_tensor_fusion else '0'
+            )
+            paddle.distributed.auto_parallel.set_mesh(self._multi_dim_mesh)
+            paddle.seed(self._seed)
+            linear = paddle.nn.Linear(10, 10)
+            batch = paddle.rand(shape=[10, 10])
+            batch = dist.shard_tensor(batch, self._mesh, [dist.Shard(0)])
+            opt = paddle.optimizer.AdamW(parameters=linear.parameters())
+            opt = dist.shard_optimizer(
+                opt, dist.ShardingStage1(sharding_mesh_dim="dp")
+            )
+            for _ in range(5):
+                loss = linear(batch)
+                loss.backward()
+                opt.step()
+                opt.clear_grad()
+            return loss.numpy()
+
+        dist.init_parallel_env()
+        loss_with_fusion = run_sharding_test(enable_tensor_fusion=True)
+        loss_without_fusion = run_sharding_test(enable_tensor_fusion=False)
+        self.check_tensor_eq(loss_with_fusion, loss_without_fusion)
+
+    def test_pure_sharding_multi_mesh_stage_1_with_sharding_overlap(self):
+        def run_sharding_test(enable_sharding_overlap):
+            os.environ['FLAGS_enable_inplace_master_grad'] = '1'
+            os.environ['FLAGS_enable_tensor_fusion'] = '1'
+            os.environ['FLAGS_enable_sharding_overlap'] = (
+                '1' if enable_sharding_overlap else '0'
+            )
+            paddle.distributed.auto_parallel.set_mesh(self._multi_dim_mesh)
+            paddle.seed(self._seed)
+            linear = paddle.nn.Linear(10, 10)
+            batch = paddle.rand(shape=[10, 10])
+            batch = dist.shard_tensor(batch, self._mesh, [dist.Shard(0)])
+            opt = paddle.optimizer.AdamW(
+                parameters=linear.parameters(),
+                grad_clip=paddle.nn.ClipGradByGlobalNorm(1.0),
+            )
+            opt = dist.shard_optimizer(
+                opt, dist.ShardingStage1(sharding_mesh_dim="dp")
+            )
+            for _ in range(5):
+                loss = linear(batch)
+                loss.backward()
+                opt.step()
+                opt.clear_grad()
+            return loss.numpy()
+
+        dist.init_parallel_env()
+        loss_with_fusion = run_sharding_test(enable_sharding_overlap=True)
+        loss_without_fusion = run_sharding_test(enable_sharding_overlap=False)
+        self.check_tensor_eq(loss_with_fusion, loss_without_fusion)
+
     def run_test_case(self):
         if self._backend == "cpu":
             paddle.set_device("cpu")
@@ -188,6 +246,8 @@ class TestSemiAutoParallelShardingStage1:
         self.test_sharding_stage_1_to_static()
         self.test_pure_sharding_multi_mesh_stage_1()
         self.test_sharding_stage_1_overlap_to_static()
+        self.test_pure_sharding_multi_mesh_stage_1_with_tensor_fusion()
+        self.test_pure_sharding_multi_mesh_stage_1_with_sharding_overlap()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->

1. inplace_master_grad

- In-place `param.main_grad` replaces the old `master_grad` in auto dy.  
- `param.main_grad` will use inplace `add_` to save or cast grad to fp32 and store them in `param.main_grad`.  
- Enable by setting `export Flags_enable_inplace_master_grad=1`.  

2. tensor_fusion

- `tensor_fusion` groups params and grads into continuous `param_storage` and `grad_storage`.  
- `grad_storage` is used for grad's `reduce_scatter` comm.  
- `param_storage` is used for param's `all_gather` comm.  
- Supports non-uniform partitioning of params and grads across GPUs.  
- Each step requires get non-uniform params and grads from `param_storage` and `grad_storage` using `view_slice`.  
- Non-uniform `grad_chip` requires call `all_reduce` manually to collect `global_norm_var`.  
- Enable by setting `export FLAGS_enable_tensor_fusion=1`.  

3. sharding_overlap

- Overlap `reduce_scatter` comm for grads with grad computation in bwd.  
- Overlap `all_gather` comm for params with opt computation.  
- Enable by setting `export FLAGS_enable_tensor_fusion=1`.  

Note: non-uniform `tensor_fusion` changes the order of `add` in `grad_chip`, introducing some loss diff.  
Convergence results on llama7b, 1NC8, sharding8, 50,000 steps.

![loss_conver_50000](https://github.com/user-attachments/assets/13b6b9b5-508c-444e-9c88-7baca6b698e3)
![loss_diff_50000](https://github.com/user-attachments/assets/74efbb0d-2efb-4df2-ad9f-136e1b0ef42b)

【TODO】Add strategy config in auto-dy, like hand-dy (feelt.init(strategy)) and auto-static (to_static(strategy)).

Pcard-70448