### PR TITLE
[Infra][Dy2St] Remove manual unparse logic for Python 3.8 in check approval script

### DIFF
--- a/test/dygraph_to_static/check_approval.py
+++ b/test/dygraph_to_static/check_approval.py
@@ -53,33 +53,12 @@ class Location:
 
 
 def ast_to_source_code(node: ast.AST):
-    if sys.version_info >= (3, 9):
-        ast.fix_missing_locations(node)
-        return ast.unparse(node)
-
-    if isinstance(node, ast.Name):
-        return node.id
-    elif isinstance(node, ast.Attribute):
-        return f'{ast_to_source_code(node.value)}.{node.attr}'
-    elif isinstance(node, ast.Tuple):
-        return f'({", ".join(ast_to_source_code(elt) for elt in node.elts)})'
-    elif isinstance(node, ast.List):
-        return f'[{", ".join(ast_to_source_code(elt) for elt in node.elts)}]'
-    elif isinstance(node, ast.Set):
-        return f'{{{", ".join(ast_to_source_code(elt) for elt in node.elts)}}}'
-    elif isinstance(node, ast.Dict):
-        return f'{{{", ".join(f"{ast_to_source_code(k)}: {ast_to_source_code(v)}" for k, v in zip(node.keys, node.values))}}}'
-        return f'{ast_to_source_code(node.value)}[{ast_to_source_code(node.slice)}]'
-    elif isinstance(node, ast.Constant):
-        return repr(node.value)
-    elif isinstance(node, ast.Call):
-        unparsed_args = [ast_to_source_code(arg) for arg in node.args]
-        unparsed_keywords = [
-            f'{kw.arg}={ast_to_source_code(kw.value)}' for kw in node.keywords
-        ]
-        return f'{ast_to_source_code(node.func)}({", ".join(unparsed_args + unparsed_keywords)})'
-    else:
-        raise NotImplementedError(f'Unsupported node type: {type(node)}')
+    if sys.version_info < (3, 9):
+        raise NotImplementedError(
+            "ast.unparse is only available in Python 3.9 and later"
+        )
+    ast.fix_missing_locations(node)
+    return ast.unparse(node)
 
 
 class Diagnostic:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

清理掉 `test/dygraph_to_static/check_approval.py` 中的 Python 3.8 手写 unparse 逻辑，迁移到 GitHub Actions 后不会再遇到随机到 Python 3.8 的问题（#61540）

### Related links

- #59685

<!-- PCard-66972 -->