### PR TITLE
【Paddle Tensor 第二期 API支持 0-size Tensor】Fix frobenius_norm to support 0-size tensor

### DIFF
--- a/paddle/phi/kernels/gpu/frobenius_norm_kernel.cu
+++ b/paddle/phi/kernels/gpu/frobenius_norm_kernel.cu
@@ -16,6 +16,7 @@
 
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/activation_kernel.h"
+#include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/funcs/activation_functor.h"
 #include "paddle/phi/kernels/gpu/reduce.h"
 
@@ -28,6 +29,28 @@ void FrobeniusNormKernel(const Context& dev_ctx,
                          bool keep_dim,
                          bool reduce_all,
                          DenseTensor* out) {
+  if (x.numel() == 0) {
+    auto dim_x = x.dims();
+    std::set<int> axis_set;
+    for (auto ax : dims.GetData()) {
+      if (ax < 0) ax += dim_x.size();
+      axis_set.insert(ax);
+    }
+
+    std::vector<int64_t> out_dims_vec;
+    for (int i = 0; i < dim_x.size(); ++i) {
+      if (axis_set.count(i) == 0) {
+        out_dims_vec.push_back(dim_x[i]);
+      } else if (keep_dim) {
+        out_dims_vec.push_back(1);
+      }
+    }
+
+    // 正确调用 Full 初始化
+    phi::Full<T, Context>(
+        dev_ctx, phi::IntArray(out_dims_vec), static_cast<T>(0), out);
+    return;
+  }
   reduce_all = recompute_reduce_all(x, dims.GetData(), reduce_all);
   auto out_dtype = x.dtype();
   phi::Reduce<T, kps::AddFunctor, kps::SquareFunctor>(

--- a/paddle/phi/kernels/gpu/frobenius_norm_kernel.cu
+++ b/paddle/phi/kernels/gpu/frobenius_norm_kernel.cu
@@ -46,7 +46,6 @@ void FrobeniusNormKernel(const Context& dev_ctx,
       }
     }
 
-    // 正确调用 Full 初始化
     phi::Full<T, Context>(
         dev_ctx, phi::IntArray(out_dims_vec), static_cast<T>(0), out);
     return;

--- a/paddle/phi/kernels/gpu/frobenius_norm_kernel.cu
+++ b/paddle/phi/kernels/gpu/frobenius_norm_kernel.cu
@@ -16,7 +16,6 @@
 
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/activation_kernel.h"
-#include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/funcs/activation_functor.h"
 #include "paddle/phi/kernels/gpu/reduce.h"
 
@@ -30,24 +29,8 @@ void FrobeniusNormKernel(const Context& dev_ctx,
                          bool reduce_all,
                          DenseTensor* out) {
   if (x.numel() == 0) {
-    auto dim_x = x.dims();
-    std::set<int> axis_set;
-    for (auto ax : dims.GetData()) {
-      if (ax < 0) ax += dim_x.size();
-      axis_set.insert(ax);
-    }
-
-    std::vector<int64_t> out_dims_vec;
-    for (int i = 0; i < dim_x.size(); ++i) {
-      if (axis_set.count(i) == 0) {
-        out_dims_vec.push_back(dim_x[i]);
-      } else if (keep_dim) {
-        out_dims_vec.push_back(1);
-      }
-    }
-
-    phi::Full<T, Context>(
-        dev_ctx, phi::IntArray(out_dims_vec), static_cast<T>(0), out);
+    dev_ctx.template Alloc<T>(out);
+    phi::funcs::SetConstant<Context, T>()(dev_ctx, out, static_cast<T>(0));
     return;
   }
   reduce_all = recompute_reduce_all(x, dims.GetData(), reduce_all);

--- a/paddle/phi/kernels/impl/frobenius_norm_kernel_impl.h
+++ b/paddle/phi/kernels/impl/frobenius_norm_kernel_impl.h
@@ -27,6 +27,30 @@ void FrobeniusNormKernel(const Context& ctx,
                          bool keep_dim,
                          bool reduce_all,
                          DenseTensor* out) {
+  auto xdim = x.dims();
+
+  if (x.numel() == 0) {
+    std::set<int> axis_set;
+    for (int ax : axis.GetData()) {
+      if (ax < 0) {
+        ax += xdim.size();
+      }
+      axis_set.insert(ax);
+    }
+
+    std::vector<int64_t> out_dims_vec;
+    for (int i = 0; i < xdim.size(); ++i) {
+      if (axis_set.find(i) == axis_set.end()) {
+        out_dims_vec.push_back(xdim[i]);
+      } else if (keep_dim) {
+        out_dims_vec.push_back(1);
+      }
+    }
+    out->Resize(phi::make_ddim(out_dims_vec));
+    ctx.template Alloc<T>(out);
+    phi::funcs::SetConstant<Context, T>()(ctx, out, 0);
+    return;
+  }
   reduce_all = recompute_reduce_all(x, axis.GetData(), reduce_all);
   Reduce<Context, T, funcs::FrobeniusNormFunctor>(
       ctx, x, reduce_all, axis.GetData(), keep_dim, x.dtype(), out);

--- a/paddle/phi/kernels/impl/frobenius_norm_kernel_impl.h
+++ b/paddle/phi/kernels/impl/frobenius_norm_kernel_impl.h
@@ -27,26 +27,7 @@ void FrobeniusNormKernel(const Context& ctx,
                          bool keep_dim,
                          bool reduce_all,
                          DenseTensor* out) {
-  auto xdim = x.dims();
-
   if (x.numel() == 0) {
-    std::set<int> axis_set;
-    for (int ax : axis.GetData()) {
-      if (ax < 0) {
-        ax += xdim.size();
-      }
-      axis_set.insert(ax);
-    }
-
-    std::vector<int64_t> out_dims_vec;
-    for (int i = 0; i < xdim.size(); ++i) {
-      if (axis_set.find(i) == axis_set.end()) {
-        out_dims_vec.push_back(xdim[i]);
-      } else if (keep_dim) {
-        out_dims_vec.push_back(1);
-      }
-    }
-    out->Resize(phi::make_ddim(out_dims_vec));
     ctx.template Alloc<T>(out);
     phi::funcs::SetConstant<Context, T>()(ctx, out, 0);
     return;

--- a/test/legacy_test/test_norm_all.py
+++ b/test/legacy_test/test_norm_all.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import unittest
 
 import numpy as np
@@ -22,6 +21,8 @@ import paddle
 from paddle import _C_ops, base
 from paddle.base import core
 from paddle.base.framework import in_dygraph_mode
+
+from .utils import static_guard
 
 
 # hack method for test p_norm final state
@@ -734,365 +735,365 @@ def check_linalg_vector_dygraph(
 
 class API_NormTest(unittest.TestCase):
     def test_basic(self):
-        paddle.enable_static()
-        keep_dims = {False, True}
-        for keep in keep_dims:
-            check_fro_static(
-                self,
-                p='fro',
-                axis=[-2, -1],
-                shape_x=[2, 3, 4],
-                dtype="float32",
-                keep_dim=keep,
-            )
-            check_fro_static(
-                self,
-                p='fro',
-                axis=[0, 1],
-                shape_x=[2, 3, 4],
-                dtype="float64",
-                keep_dim=keep,
-                check_dim=True,
-            )
-            check_nuc_static(
-                self,
-                p='nuc',
-                axis=[0, 1],
-                shape_x=[2, 3, 4],
-                dtype='float64',
-                keep_dim=keep,
-                check_dim=True,
-            )
-            check_linalg_norm_static(
-                self,
-                p=2,
-                axis=None,
-                shape_x=[3, 4],
-                dtype="float32",
-                keep_dim=keep,
-            )
-            check_linalg_norm_static(
-                self,
-                p=2,
-                axis=1,
-                shape_x=[3, 4],
-                dtype="float64",
-                keep_dim=keep,
-                check_dim=True,
-            )
-            check_linalg_norm_static(
-                self,
-                p=np.inf,
-                axis=0,
-                shape_x=[2, 3, 4],
-                dtype="float32",
-                keep_dim=keep,
-                check_dim=True,
-            )
-            check_linalg_norm_static(
-                self,
-                p=np.inf,
-                axis=None,
-                shape_x=[2, 3, 4],
-                dtype="float32",
-                keep_dim=keep,
-            )
-            check_linalg_norm_static(
-                self,
-                p=-np.inf,
-                axis=0,
-                shape_x=[2, 3, 4],
-                dtype="float64",
-                keep_dim=keep,
-                check_dim=True,
-            )
-            check_linalg_norm_static(
-                self,
-                p=-np.inf,
-                axis=None,
-                shape_x=[2, 3, 4],
-                dtype="float64",
-                keep_dim=keep,
-            )
-            check_linalg_norm_static(
-                self,
-                p=0,
-                axis=1,
-                shape_x=[3, 4],
-                dtype="float64",
-                keep_dim=keep,
-                check_dim=True,
-            )
+        with static_guard():
+            keep_dims = {False, True}
+            for keep in keep_dims:
+                check_fro_static(
+                    self,
+                    p='fro',
+                    axis=[-2, -1],
+                    shape_x=[2, 3, 4],
+                    dtype="float32",
+                    keep_dim=keep,
+                )
+                check_fro_static(
+                    self,
+                    p='fro',
+                    axis=[0, 1],
+                    shape_x=[2, 3, 4],
+                    dtype="float64",
+                    keep_dim=keep,
+                    check_dim=True,
+                )
+                check_nuc_static(
+                    self,
+                    p='nuc',
+                    axis=[0, 1],
+                    shape_x=[2, 3, 4],
+                    dtype='float64',
+                    keep_dim=keep,
+                    check_dim=True,
+                )
+                check_linalg_norm_static(
+                    self,
+                    p=2,
+                    axis=None,
+                    shape_x=[3, 4],
+                    dtype="float32",
+                    keep_dim=keep,
+                )
+                check_linalg_norm_static(
+                    self,
+                    p=2,
+                    axis=1,
+                    shape_x=[3, 4],
+                    dtype="float64",
+                    keep_dim=keep,
+                    check_dim=True,
+                )
+                check_linalg_norm_static(
+                    self,
+                    p=np.inf,
+                    axis=0,
+                    shape_x=[2, 3, 4],
+                    dtype="float32",
+                    keep_dim=keep,
+                    check_dim=True,
+                )
+                check_linalg_norm_static(
+                    self,
+                    p=np.inf,
+                    axis=None,
+                    shape_x=[2, 3, 4],
+                    dtype="float32",
+                    keep_dim=keep,
+                )
+                check_linalg_norm_static(
+                    self,
+                    p=-np.inf,
+                    axis=0,
+                    shape_x=[2, 3, 4],
+                    dtype="float64",
+                    keep_dim=keep,
+                    check_dim=True,
+                )
+                check_linalg_norm_static(
+                    self,
+                    p=-np.inf,
+                    axis=None,
+                    shape_x=[2, 3, 4],
+                    dtype="float64",
+                    keep_dim=keep,
+                )
+                check_linalg_norm_static(
+                    self,
+                    p=0,
+                    axis=1,
+                    shape_x=[3, 4],
+                    dtype="float64",
+                    keep_dim=keep,
+                    check_dim=True,
+                )
 
-            check_linalg_norm_static(
-                self,
-                p=1,
-                axis=1,
-                shape_x=[3, 4],
-                dtype="float64",
-                keep_dim=keep,
-                check_dim=True,
-            )
-            check_linalg_norm_static(
-                self,
-                p=0,
-                axis=None,
-                shape_x=[3, 4],
-                dtype="float64",
-                keep_dim=keep,
-                check_dim=True,
-            )
-            check_linalg_norm_static(
-                self,
-                p=2,
-                axis=[0, 1],
-                shape_x=[2, 3, 4],
-                dtype="float64",
-                keep_dim=keep,
-                check_dim=True,
-            )
-            check_linalg_norm_static(
-                self,
-                p=2,
-                axis=-1,
-                shape_x=[2, 3, 4],
-                dtype="float64",
-                keep_dim=keep,
-                check_dim=True,
-            )
-            check_linalg_norm_static(
-                self,
-                p=1,
-                axis=[0, 1],
-                shape_x=[2, 3, 4],
-                dtype="float64",
-                keep_dim=keep,
-                check_dim=True,
-            )
-            check_linalg_norm_static(
-                self,
-                p=np.inf,
-                axis=[0, 1],
-                shape_x=[2, 3, 4],
-                dtype="float64",
-                keep_dim=keep,
-                check_dim=True,
-            )
-            check_linalg_norm_static(
-                self,
-                p=-np.inf,
-                axis=[0, 1],
-                shape_x=[2, 3, 4],
-                dtype="float64",
-                keep_dim=keep,
-                check_dim=True,
-            )
+                check_linalg_norm_static(
+                    self,
+                    p=1,
+                    axis=1,
+                    shape_x=[3, 4],
+                    dtype="float64",
+                    keep_dim=keep,
+                    check_dim=True,
+                )
+                check_linalg_norm_static(
+                    self,
+                    p=0,
+                    axis=None,
+                    shape_x=[3, 4],
+                    dtype="float64",
+                    keep_dim=keep,
+                    check_dim=True,
+                )
+                check_linalg_norm_static(
+                    self,
+                    p=2,
+                    axis=[0, 1],
+                    shape_x=[2, 3, 4],
+                    dtype="float64",
+                    keep_dim=keep,
+                    check_dim=True,
+                )
+                check_linalg_norm_static(
+                    self,
+                    p=2,
+                    axis=-1,
+                    shape_x=[2, 3, 4],
+                    dtype="float64",
+                    keep_dim=keep,
+                    check_dim=True,
+                )
+                check_linalg_norm_static(
+                    self,
+                    p=1,
+                    axis=[0, 1],
+                    shape_x=[2, 3, 4],
+                    dtype="float64",
+                    keep_dim=keep,
+                    check_dim=True,
+                )
+                check_linalg_norm_static(
+                    self,
+                    p=np.inf,
+                    axis=[0, 1],
+                    shape_x=[2, 3, 4],
+                    dtype="float64",
+                    keep_dim=keep,
+                    check_dim=True,
+                )
+                check_linalg_norm_static(
+                    self,
+                    p=-np.inf,
+                    axis=[0, 1],
+                    shape_x=[2, 3, 4],
+                    dtype="float64",
+                    keep_dim=keep,
+                    check_dim=True,
+                )
 
-            check_linalg_vector_static(
-                self,
-                p=2,
-                axis=None,
-                shape_x=[3, 4],
-                dtype="float32",
-                keep_dim=keep,
-            )
-            check_linalg_vector_static(
-                self,
-                p=4,
-                axis=1,
-                shape_x=[3, 4],
-                dtype="float64",
-                keep_dim=keep,
-                check_dim=True,
-            )
-            check_linalg_vector_static(
-                self,
-                p=np.inf,
-                axis=0,
-                shape_x=[2, 3, 4],
-                dtype="float32",
-                keep_dim=keep,
-                check_dim=True,
-            )
-            check_linalg_vector_static(
-                self,
-                p=np.inf,
-                axis=None,
-                shape_x=[2, 3, 4],
-                dtype="float32",
-                keep_dim=keep,
-            )
-            check_linalg_vector_static(
-                self,
-                p=-np.inf,
-                axis=0,
-                shape_x=[2, 3, 4],
-                dtype="float64",
-                keep_dim=keep,
-                check_dim=True,
-            )
-            check_linalg_vector_static(
-                self,
-                p=-np.inf,
-                axis=None,
-                shape_x=[2, 3, 4],
-                dtype="float64",
-                keep_dim=keep,
-            )
-            check_linalg_vector_static(
-                self,
-                p=0,
-                axis=1,
-                shape_x=[3, 4],
-                dtype="float64",
-                keep_dim=keep,
-                check_dim=True,
-            )
+                check_linalg_vector_static(
+                    self,
+                    p=2,
+                    axis=None,
+                    shape_x=[3, 4],
+                    dtype="float32",
+                    keep_dim=keep,
+                )
+                check_linalg_vector_static(
+                    self,
+                    p=4,
+                    axis=1,
+                    shape_x=[3, 4],
+                    dtype="float64",
+                    keep_dim=keep,
+                    check_dim=True,
+                )
+                check_linalg_vector_static(
+                    self,
+                    p=np.inf,
+                    axis=0,
+                    shape_x=[2, 3, 4],
+                    dtype="float32",
+                    keep_dim=keep,
+                    check_dim=True,
+                )
+                check_linalg_vector_static(
+                    self,
+                    p=np.inf,
+                    axis=None,
+                    shape_x=[2, 3, 4],
+                    dtype="float32",
+                    keep_dim=keep,
+                )
+                check_linalg_vector_static(
+                    self,
+                    p=-np.inf,
+                    axis=0,
+                    shape_x=[2, 3, 4],
+                    dtype="float64",
+                    keep_dim=keep,
+                    check_dim=True,
+                )
+                check_linalg_vector_static(
+                    self,
+                    p=-np.inf,
+                    axis=None,
+                    shape_x=[2, 3, 4],
+                    dtype="float64",
+                    keep_dim=keep,
+                )
+                check_linalg_vector_static(
+                    self,
+                    p=0,
+                    axis=1,
+                    shape_x=[3, 4],
+                    dtype="float64",
+                    keep_dim=keep,
+                    check_dim=True,
+                )
 
-            check_linalg_vector_static(
-                self,
-                p=1,
-                axis=1,
-                shape_x=[3, 4],
-                dtype="float64",
-                keep_dim=keep,
-                check_dim=True,
-            )
-            check_linalg_vector_static(
-                self,
-                p=0,
-                axis=None,
-                shape_x=[3, 4],
-                dtype="float64",
-                keep_dim=keep,
-                check_dim=True,
-            )
-            check_linalg_vector_static(
-                self,
-                p=2,
-                axis=[0, 1],
-                shape_x=[2, 3, 4],
-                dtype="float64",
-                keep_dim=keep,
-                check_dim=True,
-            )
-            check_linalg_vector_static(
-                self,
-                p=2,
-                axis=-1,
-                shape_x=[2, 3, 4],
-                dtype="float64",
-                keep_dim=keep,
-                check_dim=True,
-            )
-            check_linalg_vector_static(
-                self,
-                p=1,
-                axis=[0, 1],
-                shape_x=[2, 3, 4, 5],
-                dtype="float64",
-                keep_dim=keep,
-                check_dim=True,
-            )
-            check_linalg_vector_static(
-                self,
-                p=np.inf,
-                axis=[0, 1],
-                shape_x=[2, 3, 4],
-                dtype="float64",
-                keep_dim=keep,
-                check_dim=True,
-            )
-            check_linalg_vector_static(
-                self,
-                p=-np.inf,
-                axis=[0, 1, 2],
-                shape_x=[2, 3, 4],
-                dtype="float64",
-                keep_dim=keep,
-                check_dim=True,
-            )
-            check_linalg_vector_static(
-                self,
-                p=2,
-                axis=None,
-                shape_x=[],
-                dtype="float64",
-                keep_dim=keep,
-                check_dim=True,
-            )
-            check_linalg_vector_static(
-                self,
-                p=np.inf,
-                axis=None,
-                shape_x=[],
-                dtype="complex64",
-                keep_dim=keep,
-                check_dim=True,
-            )
-            check_linalg_vector_static(
-                self,
-                p=-np.inf,
-                axis=[0, 1, 2, 3],
-                shape_x=[1, 14, 5, 14],
-                dtype="complex128",
-                keep_dim=keep,
-                check_dim=True,
-            )
-            check_linalg_vector_static(
-                self,
-                p=np.inf,
-                axis=2,
-                shape_x=[1, 14, 5, 14],
-                dtype="complex128",
-                keep_dim=keep,
-                check_dim=True,
-            )
-            check_linalg_vector_static(
-                self,
-                p=0,
-                axis=[1, 3],
-                shape_x=[1, 14, 5, 14],
-                dtype="complex128",
-                keep_dim=keep,
-                check_dim=True,
-            )
-            check_linalg_matrix_static(
-                self,
-                p=-np.inf,
-                axis=[0, 1],
-                shape_x=[2, 3, 4],
-                dtype="float64",
-                keep_dim=keep,
-                check_dim=True,
-            )
-            check_linalg_matrix_static(
-                self,
-                p='fro',
-                axis=[0, 1],
-                shape_x=[2, 3, 4],
-                dtype="float64",
-                keep_dim=keep,
-                check_dim=True,
-            )
-            check_linalg_matrix_static(
-                self,
-                p='nuc',
-                axis=[0, 1],
-                shape_x=[2, 3, 4],
-                dtype="float64",
-                keep_dim=keep,
-                check_dim=True,
-            )
-            check_linalg_matrix_static(
-                self,
-                p=-2,
-                axis=[1, 2],
-                shape_x=[2, 3, 4, 5],
-                dtype="float64",
-                keep_dim=keep,
-                check_dim=True,
-            )
+                check_linalg_vector_static(
+                    self,
+                    p=1,
+                    axis=1,
+                    shape_x=[3, 4],
+                    dtype="float64",
+                    keep_dim=keep,
+                    check_dim=True,
+                )
+                check_linalg_vector_static(
+                    self,
+                    p=0,
+                    axis=None,
+                    shape_x=[3, 4],
+                    dtype="float64",
+                    keep_dim=keep,
+                    check_dim=True,
+                )
+                check_linalg_vector_static(
+                    self,
+                    p=2,
+                    axis=[0, 1],
+                    shape_x=[2, 3, 4],
+                    dtype="float64",
+                    keep_dim=keep,
+                    check_dim=True,
+                )
+                check_linalg_vector_static(
+                    self,
+                    p=2,
+                    axis=-1,
+                    shape_x=[2, 3, 4],
+                    dtype="float64",
+                    keep_dim=keep,
+                    check_dim=True,
+                )
+                check_linalg_vector_static(
+                    self,
+                    p=1,
+                    axis=[0, 1],
+                    shape_x=[2, 3, 4, 5],
+                    dtype="float64",
+                    keep_dim=keep,
+                    check_dim=True,
+                )
+                check_linalg_vector_static(
+                    self,
+                    p=np.inf,
+                    axis=[0, 1],
+                    shape_x=[2, 3, 4],
+                    dtype="float64",
+                    keep_dim=keep,
+                    check_dim=True,
+                )
+                check_linalg_vector_static(
+                    self,
+                    p=-np.inf,
+                    axis=[0, 1, 2],
+                    shape_x=[2, 3, 4],
+                    dtype="float64",
+                    keep_dim=keep,
+                    check_dim=True,
+                )
+                check_linalg_vector_static(
+                    self,
+                    p=2,
+                    axis=None,
+                    shape_x=[],
+                    dtype="float64",
+                    keep_dim=keep,
+                    check_dim=True,
+                )
+                check_linalg_vector_static(
+                    self,
+                    p=np.inf,
+                    axis=None,
+                    shape_x=[],
+                    dtype="complex64",
+                    keep_dim=keep,
+                    check_dim=True,
+                )
+                check_linalg_vector_static(
+                    self,
+                    p=-np.inf,
+                    axis=[0, 1, 2, 3],
+                    shape_x=[1, 14, 5, 14],
+                    dtype="complex128",
+                    keep_dim=keep,
+                    check_dim=True,
+                )
+                check_linalg_vector_static(
+                    self,
+                    p=np.inf,
+                    axis=2,
+                    shape_x=[1, 14, 5, 14],
+                    dtype="complex128",
+                    keep_dim=keep,
+                    check_dim=True,
+                )
+                check_linalg_vector_static(
+                    self,
+                    p=0,
+                    axis=[1, 3],
+                    shape_x=[1, 14, 5, 14],
+                    dtype="complex128",
+                    keep_dim=keep,
+                    check_dim=True,
+                )
+                check_linalg_matrix_static(
+                    self,
+                    p=-np.inf,
+                    axis=[0, 1],
+                    shape_x=[2, 3, 4],
+                    dtype="float64",
+                    keep_dim=keep,
+                    check_dim=True,
+                )
+                check_linalg_matrix_static(
+                    self,
+                    p='fro',
+                    axis=[0, 1],
+                    shape_x=[2, 3, 4],
+                    dtype="float64",
+                    keep_dim=keep,
+                    check_dim=True,
+                )
+                check_linalg_matrix_static(
+                    self,
+                    p='nuc',
+                    axis=[0, 1],
+                    shape_x=[2, 3, 4],
+                    dtype="float64",
+                    keep_dim=keep,
+                    check_dim=True,
+                )
+                check_linalg_matrix_static(
+                    self,
+                    p=-2,
+                    axis=[1, 2],
+                    shape_x=[2, 3, 4, 5],
+                    dtype="float64",
+                    keep_dim=keep,
+                    check_dim=True,
+                )
 
     def test_dygraph(self):
         paddle.disable_static()
@@ -1521,96 +1522,6 @@ class API_NormTest(unittest.TestCase):
             self.assertRaises(
                 ValueError, paddle.norm, data, p='unspport', axis=[-3, -2, -1]
             )
-
-
-class TestMatrixNormZeroSizeTensorTensor(unittest.TestCase):
-    def _get_places(self):
-        places = []
-        if (
-            os.environ.get('FLAGS_CI_both_cpu_and_gpu', 'False').lower()
-            in ['1', 'true', 'on']
-            or not paddle.is_compiled_with_cuda()
-        ):
-            places.append(base.CPUPlace())
-        if paddle.is_compiled_with_cuda():
-            places.append(base.CUDAPlace(0))
-        return places
-
-    def _test_matrix_norm_static(self, place):
-        with paddle.static.program_guard(
-            paddle.static.Program(), paddle.static.Program()
-        ):
-            x1 = paddle.static.data(name='x1', shape=[0, 0], dtype='float32')
-            x2 = paddle.static.data(name='x2', shape=[2, 2, 0], dtype='float32')
-            x3 = paddle.static.data(
-                name='x3', shape=[3, 0, 2, 0], dtype='float32'
-            )
-
-            y1_fro = paddle.linalg.matrix_norm(x1, p='fro')
-            y2_fro = paddle.linalg.matrix_norm(x2, p='fro')
-            y3_fro = paddle.linalg.matrix_norm(x3, p='fro', axis=[1, -1])
-
-            y2_p1 = paddle.linalg.matrix_norm(x2, p=1, axis=[0, 1])
-            y2_p2 = paddle.linalg.matrix_norm(x2, p=2, axis=[0, 1])
-            y2_pinf = paddle.linalg.matrix_norm(x2, p=np.inf, axis=[0, 1])
-            y2_pninf = paddle.linalg.matrix_norm(x2, p=-np.inf, axis=[0, 1])
-
-            exe = paddle.static.Executor(place)
-            fetch_list = [
-                y1_fro,
-                y2_fro,
-                y3_fro,
-                y2_p1,
-                y2_p2,
-                y2_pinf,
-                y2_pninf,
-            ]
-            res = exe.run(
-                feed={
-                    'x1': np.zeros((0, 0), dtype='float32'),
-                    'x2': np.ones((2, 2, 0), dtype='float32'),
-                    'x3': np.ones((3, 0, 2, 0), dtype='float32'),
-                },
-                fetch_list=fetch_list,
-            )
-
-            self.assertEqual(res[0].shape, ())  # y1_fro
-            self.assertEqual(res[1].shape, (2,))  # y2_fro
-            self.assertEqual(res[2].shape, (3, 2))  # y3_fro
-            for r in res[3:]:
-                self.assertEqual(r.shape, (0,))
-
-    def _test_matrix_norm_dynamic(self):
-        paddle.disable_static()
-        for place in self._get_places():
-            paddle.set_device(
-                'gpu' if isinstance(place, paddle.CUDAPlace) else 'cpu'
-            )
-
-            x1 = paddle.full((0, 0), 1.0, dtype='float32')
-            x2 = paddle.full((2, 2, 0), 1.0, dtype='float32')
-            x3 = paddle.full((3, 0, 2, 0), 1.0, dtype='float32')
-
-            y1_fro = paddle.linalg.matrix_norm(x1, p='fro')
-            y2_fro = paddle.linalg.matrix_norm(x2, p='fro')
-            y3_fro = paddle.linalg.matrix_norm(x3, p='fro', axis=[1, -1])
-
-            y2_p1 = paddle.linalg.matrix_norm(x2, p=1, axis=[0, 1])
-            y2_p2 = paddle.linalg.matrix_norm(x2, p=2, axis=[0, 1])
-            y2_pinf = paddle.linalg.matrix_norm(x2, p=np.inf, axis=[0, 1])
-            y2_pninf = paddle.linalg.matrix_norm(x2, p=-np.inf, axis=[0, 1])
-
-            self.assertEqual(y1_fro.shape, [])
-            self.assertEqual(y2_fro.shape, (2,))
-            self.assertEqual(y3_fro.shape, (3, 2))
-            for y in [y2_p1, y2_p2, y2_pinf, y2_pninf]:
-                self.assertEqual(y.shape, (0,))
-
-    def test_matrix_norm_zero_size(self):
-        for place in self._get_places():
-            self._test_matrix_norm_static(place)
-        self._test_matrix_norm_dynamic()
-        paddle.enable_static()
 
 
 if __name__ == '__main__':

--- a/test/legacy_test/test_norm_all.py
+++ b/test/legacy_test/test_norm_all.py
@@ -16,13 +16,12 @@ import unittest
 
 import numpy as np
 from op_test import OpTest, convert_float_to_uint16
+from utils import static_guard
 
 import paddle
 from paddle import _C_ops, base
 from paddle.base import core
 from paddle.base.framework import in_dygraph_mode
-
-from .utils import static_guard
 
 
 # hack method for test p_norm final state

--- a/test/legacy_test/test_norm_all.py
+++ b/test/legacy_test/test_norm_all.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import unittest
 
 import numpy as np
@@ -180,6 +181,49 @@ class TestFrobeniusNormOp2(TestFrobeniusNormOp):
 
     def test_check_grad(self):
         self.check_grad(['X'], 'Out', check_pir=True)
+
+
+class TestFrobeniusNormOpZeroSize(TestFrobeniusNormOp):
+    def init_test_case(self):
+        self.shape = [0, 20, 3]
+        self.axis = (1, 2)
+        self.keepdim = False
+
+    def init_dtype(self):
+        self.dtype = "float32"
+
+    def test_check_output(self):
+        places = (
+            [paddle.CPUPlace(), paddle.CUDAPlace(0)]
+            if core.is_compiled_with_cuda()
+            else [paddle.CPUPlace()]
+        )
+        for place in places:
+            self.check_output_with_place(place)
+
+    def test_check_grad(self):
+        pass
+
+
+class TestFrobeniusNormOpZeroSize2(TestFrobeniusNormOpZeroSize):
+    def init_test_case(self):
+        self.shape = [3, 0, 3]
+        self.axis = (1, 2)
+        self.keepdim = False
+
+
+class TestFrobeniusNormOpZeroSize3(TestFrobeniusNormOpZeroSize):
+    def init_test_case(self):
+        self.shape = [0, 20, 3]
+        self.axis = (0, 2)
+        self.keepdim = False
+
+
+class TestFrobeniusNormOpZeroSize4(TestFrobeniusNormOpZeroSize):
+    def init_test_case(self):
+        self.shape = [0, 20, 3]
+        self.axis = (0, -1)
+        self.keepdim = False
 
 
 class TestPnormOp(OpTest):
@@ -690,6 +734,7 @@ def check_linalg_vector_dygraph(
 
 class API_NormTest(unittest.TestCase):
     def test_basic(self):
+        paddle.enable_static()
         keep_dims = {False, True}
         for keep in keep_dims:
             check_fro_static(
@@ -1476,6 +1521,96 @@ class API_NormTest(unittest.TestCase):
             self.assertRaises(
                 ValueError, paddle.norm, data, p='unspport', axis=[-3, -2, -1]
             )
+
+
+class TestMatrixNormZeroSizeTensorTensor(unittest.TestCase):
+    def _get_places(self):
+        places = []
+        if (
+            os.environ.get('FLAGS_CI_both_cpu_and_gpu', 'False').lower()
+            in ['1', 'true', 'on']
+            or not paddle.is_compiled_with_cuda()
+        ):
+            places.append(base.CPUPlace())
+        if paddle.is_compiled_with_cuda():
+            places.append(base.CUDAPlace(0))
+        return places
+
+    def _test_matrix_norm_static(self, place):
+        with paddle.static.program_guard(
+            paddle.static.Program(), paddle.static.Program()
+        ):
+            x1 = paddle.static.data(name='x1', shape=[0, 0], dtype='float32')
+            x2 = paddle.static.data(name='x2', shape=[2, 2, 0], dtype='float32')
+            x3 = paddle.static.data(
+                name='x3', shape=[3, 0, 2, 0], dtype='float32'
+            )
+
+            y1_fro = paddle.linalg.matrix_norm(x1, p='fro')
+            y2_fro = paddle.linalg.matrix_norm(x2, p='fro')
+            y3_fro = paddle.linalg.matrix_norm(x3, p='fro', axis=[1, -1])
+
+            y2_p1 = paddle.linalg.matrix_norm(x2, p=1, axis=[0, 1])
+            y2_p2 = paddle.linalg.matrix_norm(x2, p=2, axis=[0, 1])
+            y2_pinf = paddle.linalg.matrix_norm(x2, p=np.inf, axis=[0, 1])
+            y2_pninf = paddle.linalg.matrix_norm(x2, p=-np.inf, axis=[0, 1])
+
+            exe = paddle.static.Executor(place)
+            fetch_list = [
+                y1_fro,
+                y2_fro,
+                y3_fro,
+                y2_p1,
+                y2_p2,
+                y2_pinf,
+                y2_pninf,
+            ]
+            res = exe.run(
+                feed={
+                    'x1': np.zeros((0, 0), dtype='float32'),
+                    'x2': np.ones((2, 2, 0), dtype='float32'),
+                    'x3': np.ones((3, 0, 2, 0), dtype='float32'),
+                },
+                fetch_list=fetch_list,
+            )
+
+            self.assertEqual(res[0].shape, ())  # y1_fro
+            self.assertEqual(res[1].shape, (2,))  # y2_fro
+            self.assertEqual(res[2].shape, (3, 2))  # y3_fro
+            for r in res[3:]:
+                self.assertEqual(r.shape, (0,))
+
+    def _test_matrix_norm_dynamic(self):
+        paddle.disable_static()
+        for place in self._get_places():
+            paddle.set_device(
+                'gpu' if isinstance(place, paddle.CUDAPlace) else 'cpu'
+            )
+
+            x1 = paddle.full((0, 0), 1.0, dtype='float32')
+            x2 = paddle.full((2, 2, 0), 1.0, dtype='float32')
+            x3 = paddle.full((3, 0, 2, 0), 1.0, dtype='float32')
+
+            y1_fro = paddle.linalg.matrix_norm(x1, p='fro')
+            y2_fro = paddle.linalg.matrix_norm(x2, p='fro')
+            y3_fro = paddle.linalg.matrix_norm(x3, p='fro', axis=[1, -1])
+
+            y2_p1 = paddle.linalg.matrix_norm(x2, p=1, axis=[0, 1])
+            y2_p2 = paddle.linalg.matrix_norm(x2, p=2, axis=[0, 1])
+            y2_pinf = paddle.linalg.matrix_norm(x2, p=np.inf, axis=[0, 1])
+            y2_pninf = paddle.linalg.matrix_norm(x2, p=-np.inf, axis=[0, 1])
+
+            self.assertEqual(y1_fro.shape, [])
+            self.assertEqual(y2_fro.shape, (2,))
+            self.assertEqual(y3_fro.shape, (3, 2))
+            for y in [y2_p1, y2_p2, y2_pinf, y2_pninf]:
+                self.assertEqual(y.shape, (0,))
+
+    def test_matrix_norm_zero_size(self):
+        for place in self._get_places():
+            self._test_matrix_norm_static(place)
+        self._test_matrix_norm_dynamic()
+        paddle.enable_static()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### PR Category
User Experience

### PR Types
Bug fixes

### Description
1. frobenius_norm支持0-size tensor;
2. 增加matrix_norm的OpTest；
3. fix paddle3.0.0下需要enable_static才能通过的单测

运行单元测试显示：
```
test/legacy_test/test_norm_all.py::TestFrobeniusNormOp::test_check_grad PASSED                         [  1%]
test/legacy_test/test_norm_all.py::TestFrobeniusNormOp::test_check_output PASSED                       [  3%]
test/legacy_test/test_norm_all.py::TestFrobeniusNormOp2::test_check_grad PASSED                        [  5%]
test/legacy_test/test_norm_all.py::TestFrobeniusNormOp2::test_check_output PASSED                      [  7%]
test/legacy_test/test_norm_all.py::TestFrobeniusNormOpZeroSize::test_check_grad PASSED                 [  9%]
test/legacy_test/test_norm_all.py::TestFrobeniusNormOpZeroSize::test_check_output PASSED               [ 11%]
test/legacy_test/test_norm_all.py::TestFrobeniusNormOpZeroSize2::test_check_grad PASSED                [ 13%]
test/legacy_test/test_norm_all.py::TestFrobeniusNormOpZeroSize2::test_check_output PASSED              [ 15%]
test/legacy_test/test_norm_all.py::TestFrobeniusNormOpZeroSize3::test_check_grad PASSED                [ 17%]
test/legacy_test/test_norm_all.py::TestFrobeniusNormOpZeroSize3::test_check_output PASSED              [ 19%]
test/legacy_test/test_norm_all.py::TestFrobeniusNormOpZeroSize4::test_check_grad PASSED                [ 21%]
test/legacy_test/test_norm_all.py::TestFrobeniusNormOpZeroSize4::test_check_output PASSED              [ 23%]
test/legacy_test/test_norm_all.py::TestPnormOp::test_check_grad PASSED                                 [ 25%]
test/legacy_test/test_norm_all.py::TestPnormOp::test_check_output PASSED                               [ 27%]
test/legacy_test/test_norm_all.py::TestPnormOp2::test_check_grad PASSED                                [ 29%]
test/legacy_test/test_norm_all.py::TestPnormOp2::test_check_output PASSED                              [ 31%]
test/legacy_test/test_norm_all.py::TestPnormOp3::test_check_grad PASSED                                [ 33%]
test/legacy_test/test_norm_all.py::TestPnormOp3::test_check_output PASSED                              [ 35%]
test/legacy_test/test_norm_all.py::TestPnormOp4::test_check_grad PASSED                                [ 37%]
test/legacy_test/test_norm_all.py::TestPnormOp4::test_check_output PASSED                              [ 39%]
test/legacy_test/test_norm_all.py::TestPnormOp5::test_check_grad PASSED                                [ 41%]
test/legacy_test/test_norm_all.py::TestPnormOp5::test_check_output PASSED                              [ 43%]
test/legacy_test/test_norm_all.py::TestPnormOp6::test_check_grad PASSED                                [ 45%]
test/legacy_test/test_norm_all.py::TestPnormOp6::test_check_output PASSED                              [ 47%]
test/legacy_test/test_norm_all.py::TestPnormOpZeroSize::test_check_grad PASSED                         [ 49%]
test/legacy_test/test_norm_all.py::TestPnormOpZeroSize::test_check_output PASSED                       [ 50%]
test/legacy_test/test_norm_all.py::TestPnormOpZeroSize2::test_check_grad PASSED                        [ 52%]
test/legacy_test/test_norm_all.py::TestPnormOpZeroSize2::test_check_output PASSED                      [ 54%]
test/legacy_test/test_norm_all.py::TestPnormOpZeroSize3::test_check_grad PASSED                        [ 56%]
test/legacy_test/test_norm_all.py::TestPnormOpZeroSize3::test_check_output PASSED                      [ 58%]
test/legacy_test/test_norm_all.py::TestPnormOpZeroSize4::test_check_grad PASSED                        [ 60%]
test/legacy_test/test_norm_all.py::TestPnormOpZeroSize4::test_check_output PASSED                      [ 62%]
test/legacy_test/test_norm_all.py::TestPnormOp_Fp16::test_check_grad PASSED                            [ 64%]
test/legacy_test/test_norm_all.py::TestPnormOp_Fp16::test_check_output PASSED                          [ 66%]
test/legacy_test/test_norm_all.py::TestPnormOp2_Fp16::test_check_grad PASSED                           [ 68%]
test/legacy_test/test_norm_all.py::TestPnormOp2_Fp16::test_check_output PASSED                         [ 70%]
test/legacy_test/test_norm_all.py::TestPnormOp3_Fp16::test_check_grad PASSED                           [ 72%]
test/legacy_test/test_norm_all.py::TestPnormOp3_Fp16::test_check_output PASSED                         [ 74%]
test/legacy_test/test_norm_all.py::TestPnormOp4_Fp16::test_check_grad PASSED                           [ 76%]
test/legacy_test/test_norm_all.py::TestPnormOp4_Fp16::test_check_output PASSED                         [ 78%]
test/legacy_test/test_norm_all.py::TestPnormOp5_Fp16::test_check_grad PASSED                           [ 80%]
test/legacy_test/test_norm_all.py::TestPnormOp5_Fp16::test_check_output PASSED                         [ 82%]
test/legacy_test/test_norm_all.py::TestPnormOp6_Fp16::test_check_grad PASSED                           [ 84%]
test/legacy_test/test_norm_all.py::TestPnormOp6_Fp16::test_check_output PASSED                         [ 86%]
test/legacy_test/test_norm_all.py::TestPnormBF16Op::test_check_grad PASSED                             [ 88%]
test/legacy_test/test_norm_all.py::TestPnormBF16Op::test_check_output PASSED                           [ 90%]
test/legacy_test/test_norm_all.py::API_NormTest::test_basic FAILED                                     [ 92%]
test/legacy_test/test_norm_all.py::API_NormTest::test_dygraph PASSED                                   [ 94%]
test/legacy_test/test_norm_all.py::API_NormTest::test_errors PASSED                                    [ 96%]
test/legacy_test/test_norm_all.py::API_NormTest::test_name PASSED                                      [ 98%]
py::TestMatrixNormZeroSizeTensorTensor::test_matrix_norm_zero_size FAILED [100%]

================================================== FAILURES ==================================================
__________________________________________ API_NormTest.test_basic ___________________________________________

self = <legacy_test.test_norm_all.API_NormTest testMethod=test_basic>

    def test_basic(self):
        keep_dims = {False, True}
        for keep in keep_dims:
>           check_fro_static(
                self,
                p='fro',
                axis=[-2, -1],
                shape_x=[2, 3, 4],
                dtype="float32",
                keep_dim=keep,
            )

test/legacy_test/test_norm_all.py:739: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
test/legacy_test/test_norm_all.py:576: in check_fro_static
    data = paddle.static.data(name="X", shape=shape_x, dtype=dtype)
../../miniconda3/envs/test_paddle/lib/python3.12/site-packages/decorator.py:235: in fun
    return caller(func, *(extras + args), **kw)
../../miniconda3/envs/test_paddle/lib/python3.12/site-packages/paddle/base/wrapped_decorator.py:40: in __impl__
    return wrapped_func(*args, **kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

args = ('X', [2, 3, 4], 'float32', 0), kwargs = {}

    def __impl__(*args: _InputT.args, **kwargs: _InputT.kwargs) -> _RetT:
        assert (
>           not in_dygraph_mode()
        ), f"In PaddlePaddle 2.x, we turn on dynamic graph mode by default, and '{func.__name__}()' is only supported in static graph mode. So if you want to use this api, please call 'paddle.enable_static()' before this api to enter static graph mode."
E       AssertionError: In PaddlePaddle 2.x, we turn on dynamic graph mode by default, and 'data()' is only supported in static graph mode. So if you want to use this api, please call 'paddle.enable_static()' before this api to enter static graph mode.

../../miniconda3/envs/test_paddle/lib/python3.12/site-packages/paddle/base/framework.py:748: AssertionError
```
目前给fro-norm写的单测都能通过，basic_test也能通过了
```
test/legacy_test/test_norm_all.py::TestPnormBF16Op::test_check_output PASSED                           [ 90%]
test/legacy_test/test_norm_all.py::API_NormTest::test_basic PASSED                                     [ 92%]
test/legacy_test/test_norm_all.py::API_NormTest::test_dygraph PASSED                                   [ 94%]
test/legacy_test/test_norm_all.py::API_NormTest::test_errors PASSED                                    [ 96%]
test/legacy_test/test_norm_all.py::API_NormTest::test_name PASSED  
```
剩下的报错都是nuclear-norm调用svd的错误，需要后续再调整svd以完整支持matrix-norm。

Issue: https://github.com/PaddlePaddle/Paddle/issues/69908

@HydrogenSulfate