### PR TITLE
[SOT][NumPy] Fix TypeError: unhashable type that occurs when attempting to construct a NumPyAPIVariable

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/variables/callable.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/callable.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-import collections
 import dis
 import functools
 import inspect
@@ -422,18 +421,17 @@ class NumpyApiVariable(FunctionVariable):
     @VariableFactory.register_from_value(successor="BuiltinVariable")
     def from_value(value: Any, graph: FunctionGraph, tracker: Tracker):
         # TODO(wangmingkai02): support other numpy api.
-        if (
-            ENV_SOT_TRACE_NUMPY.get()
-            and isinstance(value, collections.abc.Hashable)
-            and (
+        try:
+            if ENV_SOT_TRACE_NUMPY.get() and (
                 value in NUMPY_API_SUPPORTED_DICT
                 or any(
                     value in ufuncs
                     for ufuncs in NumpyApiVariable._get_numpy_ufuncs()
                 )
-            )
-        ):
-            return NumpyApiVariable(value, graph, tracker)
+            ):
+                return NumpyApiVariable(value, graph, tracker)
+        except Exception:
+            return None
         return None
 
     @property

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/callable.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/callable.py
@@ -41,6 +41,7 @@ from ....utils import (
     get_numpy_ufuncs,
     get_obj_stable_repr,
     get_static_function,
+    hashable,
     is_break_graph_api,
     is_break_graph_tensor_methods,
     is_builtin_fn,
@@ -421,17 +422,18 @@ class NumpyApiVariable(FunctionVariable):
     @VariableFactory.register_from_value(successor="BuiltinVariable")
     def from_value(value: Any, graph: FunctionGraph, tracker: Tracker):
         # TODO(wangmingkai02): support other numpy api.
-        try:
-            if ENV_SOT_TRACE_NUMPY.get() and (
+        if (
+            ENV_SOT_TRACE_NUMPY.get()
+            and hashable(value)
+            and (
                 value in NUMPY_API_SUPPORTED_DICT
                 or any(
                     value in ufuncs
                     for ufuncs in NumpyApiVariable._get_numpy_ufuncs()
                 )
-            ):
-                return NumpyApiVariable(value, graph, tracker)
-        except Exception:
-            return None
+            )
+        ):
+            return NumpyApiVariable(value, graph, tracker)
         return None
 
     @property


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修复哈希失败导致的异常问题：在`NumpyApiVariable` 的`from_value` 函数中，需要验证传入的`value` 是否在已支持的列表中，隐式地调用了`__hash__(value)`，当`value` 不支持哈希操作会导致SOT异常退出。
pcard-67164