### PR TITLE
【Inference】update moe ffn config

### DIFF
--- a/paddle/phi/kernels/fusion/cutlass/cutlass_extensions/ft_gemm_configs.h
+++ b/paddle/phi/kernels/fusion/cutlass/cutlass_extensions/ft_gemm_configs.h
@@ -48,16 +48,18 @@ enum class CutlassTileConfig {
   // Warp configs for M=16
   CtaShape16x128x64_WarpShape16x32x64,
   CtaShape16x256x64_WarpShape16x64x64,
-
+  CtaShape16x256x64_WarpShape64x16x128,
   // Warp configs for M=32
   CtaShape32x128x64_WarpShape32x32x64,
 
   // Warp configs for M=64
+  CtaShape64x64x64_WarpShape32x32x64,
   CtaShape64x128x64_WarpShape32x64x64,
   CtaShape64x128x64_WarpShape64x32x64,
   CtaShape64x128x64_WarpShape64x64x64,
 
   // Warp configs for M=128
+  CtaShape128x64x64_WarpShape64x32x64,
   CtaShape128x128x64_WarpShape64x32x64,
   CtaShape128x128x64_WarpShape64x64x64,
   CtaShape128x128x64_WarpShape128x32x64,

--- a/paddle/phi/kernels/fusion/cutlass/cutlass_kernels/cutlass_heuristic.h
+++ b/paddle/phi/kernels/fusion/cutlass/cutlass_kernels/cutlass_heuristic.h
@@ -60,9 +60,14 @@ static std::vector<CutlassTileConfig> get_candidate_tiles(
   };
   std::vector<CutlassTileConfig> quant_B_configs_sm80{
       CutlassTileConfig::CtaShape16x128x64_WarpShape16x32x64,
+      CutlassTileConfig::CtaShape16x256x64_WarpShape16x64x64,
       CutlassTileConfig::CtaShape32x128x64_WarpShape32x32x64,
+      CutlassTileConfig::CtaShape64x64x64_WarpShape32x32x64,
+      CutlassTileConfig::CtaShape64x128x64_WarpShape64x32x64,
       CutlassTileConfig::CtaShape64x128x64_WarpShape64x64x64,
+      CutlassTileConfig::CtaShape128x64x64_WarpShape64x32x64,
       CutlassTileConfig::CtaShape128x128x64_WarpShape64x64x64,
+      CutlassTileConfig::CtaShape128x128x64_WarpShape128x32x64,
       CutlassTileConfig::CtaShape128x256x64_WarpShape64x64x64,
   };
   if (is_moe) {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->
Pcard-71500
Add configuration to make the cutlass moe ffn operator choose better parameters