### PR TITLE
[PHI][CINN] Align linalg.solve kernel with torch

### DIFF
--- a/paddle/phi/kernels/funcs/matrix_solve.cu
+++ b/paddle/phi/kernels/funcs/matrix_solve.cu
@@ -17,9 +17,130 @@ limitations under the License. */
 #include "paddle/phi/core/tensor_utils.h"
 #include "paddle/phi/kernels/funcs/blas/blas.h"
 #include "paddle/phi/kernels/funcs/math_function.h"
+#include "paddle/phi/kernels/funcs/scatter.cu.h"
 
 namespace phi {
 namespace funcs {
+
+#ifndef PADDLE_WITH_HIP
+/**
+ * Transform pivot array to permutation by swapping perm[i] and perm[pivot[i]]
+ * from 0 to n-1, where pivot and perm have shape [batch_size, n].
+ * Example:
+ *    Input pivot = [[6, 7, 4, 5, 5, 7, 8, 8]]
+ *    Output perm = [[5, 6, 3, 4, 2, 1, 7, 0]]
+ */
+__global__ void UnpackPivot(const int* __restrict__ pivot,
+                            int* __restrict__ perm,
+                            int64_t batch_size,
+                            int64_t n) {
+  constexpr int warp_size = 32;
+  int warps_per_block = blockDim.x / warp_size;
+  int warp_id = threadIdx.x / warp_size;
+  int warp_offset = threadIdx.x % warp_size;
+  int64_t offset = static_cast<int64_t>(blockIdx.x) * warps_per_block + warp_id;
+  int64_t stride = static_cast<int64_t>(gridDim.x) * warps_per_block;
+
+  for (; offset < batch_size; offset += stride) {
+    // init perm[*, n] with 0...n-1
+    for (int64_t i = warp_offset; i < n; i += warp_size) {
+      perm[offset * n + i] = offset * n + i;
+    }
+    __syncwarp();
+
+    // Since the swapping makes entirely discrete access, we only use the first
+    // thread in each warp to avoid warp divergence.
+    if (warp_offset > 0) continue;
+
+    // Swap perm[i] and perm[pivot[i]] for i in 0...n-1
+    for (int64_t i = offset * n; i < offset * n + n; ++i) {
+      int64_t j = pivot[i] - 1 + offset * n;  // cublas use 1-index
+      int tmp = perm[i];
+      perm[i] = perm[j];
+      perm[j] = tmp;
+    }
+  }
+}
+
+/**
+ * Eliminate the L and U in equation:
+ *    (U^T @ L^T @ P) @ X = B  (the U^T @ L^T @ P is stored in A)
+ * by solving the inversion of L^T and U^T respectively. The result is:
+ *    P @ X = L^T^-1 @ U^T^-1 @ B
+ * and is stored in B.
+ */
+template <typename Context, typename T>
+void SolveLU(const phi::funcs::BlasT<Context, T>& blas,
+             int m,
+             int n,
+             const T* A,
+             T* B,
+             int batch_size) {
+  constexpr T alpha = 1.0;
+  for (int64_t i = 0; i < batch_size; ++i) {
+    // Before: U^T @ L^T @ P @ X = B
+    blas.TRSM(CblasRight,
+              CblasLower,
+              CblasTrans,
+              CblasNonUnit,
+              m,
+              n,
+              alpha,
+              A + i * n * n,
+              n,
+              B + i * m * n,
+              n);
+    // After: L^T @ P @ X = U^T^-1 @ B
+    blas.TRSM(CblasRight,
+              CblasUpper,
+              CblasTrans,
+              CblasUnit,
+              m,
+              n,
+              alpha,
+              A + i * n * n,
+              n,
+              B + i * m * n,
+              n);
+    // After: P @ X = L^T^-1 @ U^T^-1 @ B
+  }
+}
+
+// Batched version of SolveLU.
+template <typename Context, typename T>
+void BatchedSolveLU(const phi::funcs::BlasT<Context, T>& blas,
+                    int m,
+                    int n,
+                    const T** A,
+                    T** B,
+                    int batch_size) {
+  constexpr T alpha = 1.0;
+  blas.BatchedTRSM(CblasRight,
+                   CblasLower,
+                   CblasTrans,
+                   CblasNonUnit,
+                   m,
+                   n,
+                   alpha,
+                   A,
+                   n,
+                   B,
+                   n,
+                   batch_size);
+  blas.BatchedTRSM(CblasRight,
+                   CblasUpper,
+                   CblasTrans,
+                   CblasUnit,
+                   m,
+                   n,
+                   alpha,
+                   A,
+                   n,
+                   B,
+                   n,
+                   batch_size);
+}
+#endif
 
 template <typename Context, typename T>
 void MatrixSolveFunctor<Context, T>::operator()(const Context& context,
@@ -39,47 +160,38 @@ void MatrixSolveFunctor<Context, T>::operator()(const Context& context,
   const int a_rank = a_dims.size();
   int n = a_dims[a_rank - 1];
   int lda = n;
-  int batch_size = a_rank > 2 ? a.numel() / (n * n) : 1;
+  int64_t batch_size = a_rank > 2 ? a.numel() / (n * n) : 1;
 
   const auto& b_dims = b.dims();
   const int b_rank = b_dims.size();
   int nrhs = b_dims[b_rank - 1];
-  int ldb = b_dims[b_rank - 2];
+  int ldb = n;
 
-  // make sure the out dims is right
-  out->Resize(b_dims);
-
-  context.template Alloc<T>(out);
-
-  // copy input A to a temporary tensor tmp_a,
-  // LU factorization, written back to original matrix A, so in the beginning,
-  // it's necessary to create a temporary tensor tmp_a.
+  // 1. Copy input A to a temporary tensor tmp_a for LU factorization.
   DenseTensor tmp_a(a.dtype());
   tmp_a.Resize(a.dims());
-
   context.template Alloc<T>(&tmp_a);
   phi::Copy(context, a, context.GetPlace(), false, &tmp_a);
 
-  // copy input B to a temporary tensor tmp_b, and transpose tmp_b,
-  // because cuBlas assumes column-major while Paddle uses row-majar.
-  DenseTensor tmp_b(b.type());
-  const auto& new_dims_vec = getNewDimsVec(b_dims);
-  tmp_b.Resize(common::make_ddim(new_dims_vec));
-  context.template Alloc<T>(&tmp_b);
+  // 2. Transpose B and save it in out, because cuBlas assumes column-major
+  // while Paddle uses row-majar.
+  const auto& new_b_dims = getNewDimsVec(b_dims);
+  out->Resize(common::make_ddim(new_b_dims));
+  context.template Alloc<T>(out);
   phi::funcs::TransposeNormal<Context, T> trans;
   std::vector<int> new_axis = getNewAxis(b_rank);
-  trans(context, b, &tmp_b, new_axis);
+  trans(context, b, out, new_axis);
 
   const T* a_data_in_gpu = tmp_a.data<T>();
-  const T* b_data_in_gpu = tmp_b.data<T>();
+  T* b_data_in_gpu = out->data<T>();
 
   std::vector<const T*> cpu_ptrs(batch_size * 2);
-  for (int i = 0; i < batch_size; ++i) {
+  for (int64_t i = 0; i < batch_size; ++i) {
     cpu_ptrs[i] = a_data_in_gpu + i * n * n;
     cpu_ptrs[i + batch_size] = b_data_in_gpu + i * n * nrhs;
   }
 
-  // Copy the addresses of A and tmp_b from host to device.
+  // 3. Copy the addresses of A and B from host to device.
   phi::Allocator::AllocationPtr tmp_gpu_ptrs_data = phi::memory_utils::Alloc(
       context.GetPlace(),
       cpu_ptrs.size() * sizeof(T*),
@@ -94,8 +206,8 @@ void MatrixSolveFunctor<Context, T>::operator()(const Context& context,
   T** gpu_tmp_b_ptrs =
       reinterpret_cast<T**>(tmp_gpu_ptrs_data->ptr()) + batch_size;
 
-  // Allocate device memory for BatchedGETRF's info and pivots.
-  int num_ints = n < 32 ? batch_size : batch_size * (n + 1);
+  // 4. Allocate device memory for BatchedGETRF's info and pivots.
+  int64_t num_ints = batch_size * (n + 1);
   phi::Allocator::AllocationPtr tmp_gpu_info_data = phi::memory_utils::Alloc(
       context.GetPlace(),
       num_ints * sizeof(int),
@@ -111,14 +223,13 @@ void MatrixSolveFunctor<Context, T>::operator()(const Context& context,
   int* gpu_pivot_ptr =
       reinterpret_cast<int*>(tmp_gpu_info_data->ptr()) + batch_size;
 
-  // This function performs the LU factorization of each matrix A by the
-  // equation A = L * U. L and U are written back to original matrix A,
-  // and diagonal elements of L are discarded.
+  // 5. Performs LU factorization on A.
   blas.BatchedGETRF(n,
                     reinterpret_cast<T**>(tmp_gpu_ptrs_data->ptr()),
                     gpu_pivot_ptr,
                     gpu_info_ptr,
                     batch_size);
+  // After: P @ A^T = L @ U
 
   // check whether BatchedGETRF is executed successfully or not
   memory_utils::Copy(phi::CPUPlace(),
@@ -139,33 +250,47 @@ void MatrixSolveFunctor<Context, T>::operator()(const Context& context,
                           info[i]));
   }
 
-  // hold the result code from BatchedGETRS
-  int host_info = 0;
+  // 6. Solve L and U in equation Ax = B where A = U^T @ L^T @ P.
+  // The batched version is advantageous for small shapes, but has error for
+  // large shapes. In this case, we call the non-batched version for batch_size
+  // times instead.
+  // Ref: https://docs.nvidia.com/cuda/cublas/#cublas-t-trsmbatched
+  constexpr int max_batch_nrhs = 65535 * 8;  // max(gridDim.y) * 8
+  if (batch_size > 1 && nrhs <= max_batch_nrhs) {
+    BatchedSolveLU(blas,
+                   nrhs,
+                   n,
+                   reinterpret_cast<const T**>(tmp_gpu_ptrs_data->ptr()),
+                   gpu_tmp_b_ptrs,
+                   batch_size);
+  } else {
+    SolveLU(blas, nrhs, n, a_data_in_gpu, b_data_in_gpu, batch_size);
+  }
 
-  // to solve the equation after LU factorization
-  CBLAS_TRANSPOSE transA = CblasTrans;
-  blas.BatchedGETRS(transA,
-                    n,
-                    nrhs,
-                    reinterpret_cast<const T**>(tmp_gpu_ptrs_data->ptr()),
-                    lda,
-                    gpu_pivot_ptr,
-                    gpu_tmp_b_ptrs,
-                    ldb,
-                    &host_info,
-                    batch_size);
-
-  // check whether BatchedGETRS is executed successfully or not
-  PADDLE_ENFORCE_EQ(host_info,
-                    0,
-                    common::errors::InvalidArgument(
-                        "The [%d]'th argument to cublas*getrsBatched had "
-                        "an illegal value.",
-                        -host_info));
-
-  // transpose tmp_b to get the final result in row-major form.
+  // 7. Transpose B back to row-major form.
+  DenseTensor tmp_b(b.type());
+  tmp_b.Resize(b_dims);
+  context.template Alloc<T>(&tmp_b);
   phi::funcs::TransposeNormal<Context, T> trans2;
-  trans2(context, tmp_b, out, new_axis);
+  trans2(context, *out, &tmp_b, new_axis);
+
+  // 8. Permute B according to pivots to get the final result.
+  DenseTensor perm;
+  perm.Resize({batch_size * n});
+  context.template Alloc<int>(&perm);
+
+  auto config =
+      phi::backends::gpu::GetGpuLaunchConfig1D(context, batch_size * 32);
+  auto stream = context.stream();
+  UnpackPivot<<<config.block_per_grid, config.thread_per_block, 0, stream>>>(
+      gpu_pivot_ptr, perm.data<int>(), batch_size, n);
+
+  // fuse dims 0...n-2 because scatter only supports one index dim
+  tmp_b.Resize({batch_size * n, nrhs});
+  out->Resize({batch_size * n, nrhs});
+  GPUScatterAssign<T>(context, tmp_b, perm, out);
+  out->Resize(b_dims);
+  // After: X = P^T @ L^T^-1 @ U^T^-1 @ B
 
 #else
   compute_solve_eigen<Context, T>(context, a, b, out);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Operator Mechanism


### PR Types
Bug fixes


### Description
与torch对齐`paddle.linalg.solve`的调用逻辑，提升数百倍性能，并修复大Tensor下的报错

#### 简介
linalg.solve用于求解矩阵方程`A @ X = B`，其中A[batch_size, n, n]，X[batch_size, n, nrhs]，B[batch_size, n, nrhs]（batch_size可以没有或者是多维）

#### 求解方法
1. 首先对A做PLU分解，得到`P @ A = L @ U`；其中P是一个permutation矩阵（实际实现中使用pivot数组记录），L是一个对角线全为1的下三角矩阵，U是一个上三角矩阵

2. 然后将`P @ A = L @ U`做等价变换得到`A = P^T @ L @ U`，然后将A带入原来的方程`A @ X = B`中，得到`P^T @ L @ U @ X = B`

3. 接下来把P^T移到右边，得到`L @ U @ X = P @ B`，由于P是一个permutation矩阵，因此这步只需要scatter操作即可，不需要真的矩阵乘

4. 最后进行两次triangular求解，将L和U依次移动到右边，即`L @ U @ X = P @ B` ==第1次求解=> `U @ X = L^-1 @ P @ B` ==第2次求解=> `X = U^-1 @ L^-1 @ P @ B`

5. 此时`X = U^-1 @ L^-1 @ P @ B`即是方程的解

<b>注：</b>由于cublas使用列优先存储，而paddle使用行优先，出于性能考虑并没有对A在输入时进行转置（和torch保持一致），因此上述公式中A实际上是A^T，实际求解方程是`X = P^T @ L^T^-1 @ U^T^-1 @ B`，cublas调用方法大致相同，只是顺序不同

#### 执行过程
1. <b>PLU分解：</b>调用cublas getrfBatched
2. <b>triangular求解：</b>调用2次cublas trsm/trsmBatched，这是本PR的核心修改；原来用的是getrfBatched函数，这个函数把trsm和permutation结合在一起了，性能又差又不支持size稍微大一点的情况，因此必须换掉
3. <b>permutation：</b>首先调用自己写的UnpackPivot kernel把pivot数组转换为permutation index，然后调用phi scatter kernel进行重排序

参考torch实现：[lu_solve_kernel](https://github.com/pytorch/pytorch/blob/134179474539648ba7dee1317959529fbd0e7f89/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp#L2418)

#### 与torch对齐情况
1. batch_size<=16 且 m<=65535*8，或 batch_size<=2 时，和torch完全对齐（nsys trace相同）
2. batch_size>16 时，PLU分解这步torch会调用非cublas的函数，确实难以对齐，且有一定精度差别，因为PA=LU的P选取策略会影响分解结果，只能做到 atol=1e-3 rtol=1e-3 级别的对齐
3. batch_size>2 且 m>65535*8 时，torch 2.6.0竟然是错的！看trace是因为用了不支持的trsmBatched函数，见以下测试

```python
import paddle, torch, numpy as np

x = np.random.normal(size=[3, 16, 16]).astype(np.float32)
y = np.random.normal(size=[3, 16, 65535*8+1]).astype(np.float32)

a = paddle.linalg.solve(paddle.to_tensor(x), paddle.to_tensor(y))
b = torch.linalg.solve(torch.from_numpy(x).to('cuda'), torch.from_numpy(y).to('cuda')).cpu()
c = np.linalg.solve(x, y)

np.testing.assert_allclose(a, c, atol=1e-4, rtol=1e-4)  # OK
np.testing.assert_allclose(b, c, atol=1e-4, rtol=1e-4)  # Fail!
```

#### 关于int使用的说明

注意到，我在kernel中很多地方没有把int转成int64_t，包括n、nrhs，这是因为：
1. cublas的输入是int，我们在外面使用更大的类型也没有用
2. 而且n是矩阵的边长，边长不可能超过int（哪怕n^2也不可能超过int，不然数值不稳定解不出来）
3. 当然，batch_size * n * nrhs 可以超过int，所以我将batch_size定义为int64_t，这样定义只是为了乘的时候不用再cast，batch_size本身仍在int范围内
4. 我已经做到在数据类型上达到算子库的上限，包括我自己写的kernel也是支持int64_t，其他的只能看算子库了

<br>
Pcard-85711