### PR TITLE
fix result shape of `__ne__` and `__eq__` when comparing with complex scalar

### DIFF
--- a/paddle/fluid/pybind/eager_math_op_patch.cc
+++ b/paddle/fluid/pybind/eager_math_op_patch.cc
@@ -2070,7 +2070,7 @@ static PyObject* tensor__ne__method(TensorObject* self,
       if (PyComplex_Check(other_obj)) {
         eager_gil_scoped_release guard;
         other_tensor =
-            full_ad_func({1}, value, DataType::COMPLEX64, self_tensor.place());
+            full_ad_func({}, value, DataType::COMPLEX64, self_tensor.place());
       } else {
         eager_gil_scoped_release guard;
         other_tensor = full_ad_func(self_tensor.shape(),

--- a/paddle/fluid/pybind/eager_math_op_patch.cc
+++ b/paddle/fluid/pybind/eager_math_op_patch.cc
@@ -2163,7 +2163,7 @@ static PyObject* tensor__eq__method(TensorObject* self,
       if (PyComplex_Check(other_obj)) {
         eager_gil_scoped_release guard;
         other_tensor =
-            full_ad_func({1}, value, DataType::COMPLEX64, self_tensor.place());
+            full_ad_func({}, value, DataType::COMPLEX64, self_tensor.place());
       } else {
         eager_gil_scoped_release guard;
         other_tensor = full_ad_func(self_tensor.shape(),

--- a/test/legacy_test/test_math_op_patch_pir.py
+++ b/test/legacy_test/test_math_op_patch_pir.py
@@ -424,41 +424,54 @@ class TestMathOpPatchesPir(unittest.TestCase):
 
     # for logical compare
     def test_equal_and_nequal(self):
-        paddle.disable_static()
-        x_np = np.array([3, 4, 10, 14, 9, 18]).astype('float32')
-        y_np = np.array([3, 4, 11, 15, 8, 18]).astype('float32')
-        # TODO(gouzil): Open after deleting c++ logic
-        # res_np_b = x_np == y_np
-        # res_np_c = paddle.equal(paddle.to_tensor(x_np), paddle.to_tensor(y_np))
-        # res_np_d = x_np.__eq__(y_np)
-        res_np_e = x_np != y_np
-        res_np_f = paddle.not_equal(
-            paddle.to_tensor(x_np), paddle.to_tensor(y_np)
-        )
-        res_np_g = x_np.__ne__(y_np)
-        paddle.enable_static()
-        with paddle.pir_utils.IrGuard():
-            main_program, exe, program_guard = new_program()
-            with program_guard:
-                x = paddle.static.data(name="x", shape=[-1, 1], dtype='float32')
-                y = paddle.static.data(name="y", shape=[-1, 1], dtype='float32')
-                # b = x == y
-                # c = x.equal(y)
-                # d = x.__eq__(y)
-                e = x != y
-                f = x.not_equal(y)
-                g = x.__ne__(y)
-                (e_np, f_np, g_np) = exe.run(
-                    main_program,
-                    feed={"x": x_np, "y": y_np},
-                    fetch_list=[e, f, g],
-                )
-                # np.testing.assert_array_equal(res_np_b, b_np)
-                # np.testing.assert_array_equal(res_np_c, c_np)
-                # np.testing.assert_array_equal(res_np_d, d_np)
-                np.testing.assert_array_equal(res_np_e, e_np)
-                np.testing.assert_array_equal(res_np_f, f_np)
-                np.testing.assert_array_equal(res_np_g, g_np)
+
+        def _test(x_np, y_np, input_dtype):
+            paddle.disable_static()
+            # TODO(gouzil): Open after deleting c++ logic
+            # res_np_b = x_np == y_np
+            # res_np_c = paddle.equal(paddle.to_tensor(x_np), paddle.to_tensor(y_np))
+            # res_np_d = x_np.__eq__(y_np)
+            res_np_e = x_np != y_np
+            res_np_f = paddle.not_equal(
+                paddle.to_tensor(x_np), paddle.to_tensor(y_np)
+            )
+            res_np_g = x_np.__ne__(y_np)
+            paddle.enable_static()
+            with paddle.pir_utils.IrGuard():
+                main_program, exe, program_guard = new_program()
+                with program_guard:
+                    x = paddle.static.data(
+                        name="x", shape=[-1, 1], dtype=input_dtype
+                    )
+                    y = paddle.static.data(
+                        name="y", shape=[-1, 1], dtype=input_dtype
+                    )
+                    # b = x == y
+                    # c = x.equal(y)
+                    # d = x.__eq__(y)
+                    e = x != y
+                    f = x.not_equal(y)
+                    g = x.__ne__(y)
+                    (e_np, f_np, g_np) = exe.run(
+                        main_program,
+                        feed={"x": x_np, "y": y_np},
+                        fetch_list=[e, f, g],
+                    )
+                    # np.testing.assert_array_equal(res_np_b, b_np)
+                    # np.testing.assert_array_equal(res_np_c, c_np)
+                    # np.testing.assert_array_equal(res_np_d, d_np)
+                    np.testing.assert_array_equal(res_np_e, e_np)
+                    np.testing.assert_array_equal(res_np_f, f_np)
+                    np.testing.assert_array_equal(res_np_g, g_np)
+
+        x_np_1 = np.array([3, 4, 10, 14, 9, 18]).astype('float32')
+        y_np_2 = np.array([3, 4, 11, 15, 8, 18]).astype('float32')
+
+        x_np_3 = np.random.rand(0).astype("complex64")
+        y_np_4 = 4 + 5j
+
+        _test(x_np_1, y_np_2, 'float32')
+        _test(x_np_3, y_np_4, 'complex64')
 
     def test_less(self):
         paddle.disable_static()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
 Bug fixes

### Description
<!-- Describe what you’ve done -->
tensor(shape=[]) == complex scalar 时，返回的tensor形状期望为[]，但返回的是[1]
![114EE56DC7B6A9FF60E49AFD53A49E04](https://github.com/user-attachments/assets/1ab83de8-13a4-42ba-8f40-eae6d663a91b)
