### PR TITLE
optimize bool index logic && optimize set_tensor_value_op

### DIFF
--- a/paddle/fluid/pybind/eager_method.cc
+++ b/paddle/fluid/pybind/eager_method.cc
@@ -1452,6 +1452,15 @@ static PyObject* tensor__getitem_dygraph(TensorObject* self,
   PyObject* _index = PyTuple_GET_ITEM(args, 0);
   VLOG(4) << "Call new indexing strategy _getitem_dygraph";
 
+  PyObject* index_ptr =
+      !PyTuple_Check(_index) ? PyTuple_Pack(1, _index) : _index;
+  DEFINE_PADDLE_SCOPE_GUARD([index_ptr, &_index]() {
+    if (!PyTuple_Check(_index)) {
+      Py_DECREF(index_ptr);
+      VLOG(4) << "Call Py_DECREF";
+    }
+  });
+
   // Note(0x45f): Using defined() instead of initialized()
   // to support slice tensor which shape like [0, 0, 0].
   PADDLE_ENFORCE_EQ(
@@ -1476,7 +1485,7 @@ static PyObject* tensor__getitem_dygraph(TensorObject* self,
 
   // step1: parsing the index and recording them
   ParseIndex(tensor,
-             _index,
+             index_ptr,
              &slice_axes,
              &slice_starts,
              &slice_ends,
@@ -1748,6 +1757,7 @@ static PyObject* tensor__setitem_dygraph(TensorObject* self,
             tensor.name()));
   }
   const int rank = tensor.shape().size();
+  const int size = PyTuple_GET_SIZE(index_ptr);
   std::vector<int> slice_starts, slice_ends, slice_strides;
   std::vector<int64_t> slice_axes, decrease_axis, infer_flags, none_axes;
 
@@ -1760,7 +1770,7 @@ static PyObject* tensor__setitem_dygraph(TensorObject* self,
 
   // step1: parsing the index and recording them
   ParseIndex(tensor,
-             _index,
+             index_ptr,
              &slice_axes,
              &slice_starts,
              &slice_ends,
@@ -1808,14 +1818,18 @@ static PyObject* tensor__setitem_dygraph(TensorObject* self,
       if (InputsContainDistTensor(&mesh, self->tensor, value_tensor)) {
         ConvertAllInputsToDistTensor(mesh, self->tensor, value_tensor);
       }
-      self->tensor = set_value_with_tensor__ad_func(self->tensor,
-                                                    value_tensor,
-                                                    slice_starts,
-                                                    slice_ends,
-                                                    slice_strides,
-                                                    slice_axes,
-                                                    decrease_axis,
-                                                    none_axes);
+      if (size == 1 && PyTuple_GetItem(index_ptr, 0) == Py_False) {
+        // do nothing
+      } else {
+        self->tensor = set_value_with_tensor__ad_func(self->tensor,
+                                                      value_tensor,
+                                                      slice_starts,
+                                                      slice_ends,
+                                                      slice_strides,
+                                                      slice_axes,
+                                                      decrease_axis,
+                                                      none_axes);
+      }
       if (PyCheckTensor(value_obj)) {
         // pass the stop_gradient from value to tensor.
         // pass stop gradient should be done after CheckInplace in
@@ -1830,15 +1844,19 @@ static PyObject* tensor__setitem_dygraph(TensorObject* self,
       if (InputsContainDistTensor(&mesh, self->tensor)) {
         ConvertAllInputsToDistTensor(mesh, self->tensor);
       }
-      self->tensor = set_value__ad_func(self->tensor,
-                                        slice_starts,
-                                        slice_ends,
-                                        slice_strides,
-                                        slice_axes,
-                                        decrease_axis,
-                                        none_axes,
-                                        {1},
-                                        values);
+      if (size == 1 && PyTuple_GetItem(index_ptr, 0) == Py_False) {
+        // do nothing
+      } else {
+        self->tensor = set_value__ad_func(self->tensor,
+                                          slice_starts,
+                                          slice_ends,
+                                          slice_strides,
+                                          slice_axes,
+                                          decrease_axis,
+                                          none_axes,
+                                          {1},
+                                          values);
+      }
     }
   } else {
     // step3.2: Case for there are advanced indexing.

--- a/paddle/phi/kernels/impl/set_value_kernel_impl.h
+++ b/paddle/phi/kernels/impl/set_value_kernel_impl.h
@@ -86,6 +86,13 @@ void SetValueImpl(const Context& dev_ctx,
   std::vector<int64_t> starts_local = starts.GetData();
   std::vector<int64_t> ends_local = ends.GetData();
   std::vector<int64_t> steps_local = steps.GetData();
+  if (starts_local.empty() && ends_local.empty() && steps_local.empty() &&
+      axes.empty() && decrease_axes.empty() && none_axes.empty() &&
+      value.numel() == 1) {
+    ExpandKernel<T, Context>(
+        dev_ctx, value, IntArray{phi::vectorize<int64_t>(in.dims())}, out);
+    return;
+  }
   phi::funcs::CheckAndUpdateSliceAttrs(
       in_dims, axes, &starts_local, &ends_local, &steps_local);
   auto slice_dims = phi::funcs::GetSliceDims(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
pcard-67164

1. optimize bool index for case `x[True] = y` by add logic and optimize set_tensor_value_op
2. remove duplicate PyTuple_Pack in ParseIndex called by tensor__setitem_dygraph

**performance improvement**
| index | value | paddle/torch before | paddle/torch after|
| ------------- | ------------- | ------------- | ------------- |
| True | 0.5  | 17.28  |  1.06  | 
| False | 0.5  | 3.51  |  0.93  | 
| True | tensor f32  | 14.07  |  2.79->0.82  | 
| True | tensor f16 | 17.13  |  3.35->1.02  | 
| False | tensor f32   | 3.53  |  0.88  | 
| False | tensor f16   | 4.02  |  1.30  | 

tested on V100