### PR TITLE
[XPU] UpdatePadding has already modified the value of pad

### DIFF
--- a/paddle/phi/kernels/xpu/pool_kernel.cc
+++ b/paddle/phi/kernels/xpu/pool_kernel.cc
@@ -79,14 +79,6 @@ void Pool2dKernel(const Context& ctx,
                        strides,
                        kernel_size);
 
-  if (ceil_mode) {
-    int in_h_ceil = (out_h - 1) * strides[0] + kernel_size[0] - 2 * paddings[0];
-    int in_w_ceil = (out_w - 1) * strides[1] + kernel_size[1] - 2 * paddings[2];
-
-    paddings[1] += (in_h_ceil - in_h);
-    paddings[3] += (in_w_ceil - in_w);
-  }
-
   ctx.template Alloc<T>(out);
   int* index_data = nullptr;
   int r = xpu::Error_t::SUCCESS;


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Bug fixes

### Description
The UpdatePadding function has been designed to adjust the padding appropriately, regardless of whether ceil_mode is set to True or False in the Pool2D operation, however, the additional code that attempts to adjust the padding can lead to error, so remove this redundant part of the code.