### PR TITLE
[PHI] Optimize GatherNdCUDAKernel

### DIFF
--- a/paddle/phi/kernels/funcs/gather.cu.h
+++ b/paddle/phi/kernels/funcs/gather.cu.h
@@ -29,7 +29,7 @@ limitations under the License. */
 namespace phi {
 namespace funcs {
 
-template <typename T, typename IndexT = int>
+template <typename T, typename IndexT, int VecSize>
 __global__ void GatherNdCUDAKernel(const T* input,
                                    const Dim<DDim::kMaxRank> input_dims,
                                    const IndexT* indices,
@@ -37,11 +37,17 @@ __global__ void GatherNdCUDAKernel(const T* input,
                                    size_t remain_size,
                                    size_t slice_size,
                                    size_t end_size) {
-  CUDA_KERNEL_LOOP_TYPE(i, remain_size * slice_size, int64_t) {
-    int64_t indices_i = i / slice_size;
-    int64_t slice_i = i - indices_i * slice_size;  // offset inside the slice
+  int64_t total_size = remain_size * slice_size;
+  int64_t idx = (blockIdx.x * blockDim.x + threadIdx.x) * VecSize;
+  int64_t stride = blockDim.x * gridDim.x * VecSize;
+
+#pragma unroll
+  for (; idx < total_size; idx += stride) {
+    int64_t indices_i = idx / slice_size;
+    int64_t slice_i = idx % slice_size;
     int64_t gather_i = 0;
     int64_t temp = slice_size;
+#pragma unroll
     for (int64_t j = end_size - 1; j >= 0; --j) {
       auto index_value = indices[indices_i * end_size + j];
       PADDLE_ENFORCE(
@@ -61,7 +67,75 @@ __global__ void GatherNdCUDAKernel(const T* input,
       temp *= input_dims[j];
     }
     int64_t input_i = gather_i + slice_i;
-    *(output + i) = *(input + input_i);
+
+    using VecType = kps::details::VectorType<T, VecSize>;
+    const VecType* src = reinterpret_cast<const VecType*>(&input[input_i]);
+    VecType* dst = reinterpret_cast<VecType*>(&output[idx]);
+    *dst = *src;
+  }
+}
+
+template <typename T, typename IndexT, int VecSize>
+void DispatchGatherNdKernel(const phi::GPUContext& ctx,
+                            const T* p_input,
+                            const Dim<DDim::kMaxRank>& g_input_dims,
+                            const IndexT* p_index,
+                            T* p_output,
+                            int64_t remain_numel,
+                            int64_t slice_size,
+                            int64_t end_size,
+                            int vec_size,
+                            const phi::backends::gpu::GpuLaunchConfig& config) {
+  if (vec_size == VecSize) {
+    auto stream = ctx.stream();
+    GatherNdCUDAKernel<T, IndexT, VecSize>
+        <<<config.block_per_grid, config.thread_per_block, 0, stream>>>(
+            p_input,
+            g_input_dims,
+            p_index,
+            p_output,
+            remain_numel,
+            slice_size,
+            end_size);
+  } else {
+    DispatchGatherNdKernel<T, IndexT, VecSize / 2>(ctx,
+                                                   p_input,
+                                                   g_input_dims,
+                                                   p_index,
+                                                   p_output,
+                                                   remain_numel,
+                                                   slice_size,
+                                                   end_size,
+                                                   vec_size,
+                                                   config);
+  }
+}
+
+template <typename T, typename IndexT>
+void DispatchGatherNdKernel(const phi::GPUContext& ctx,
+                            const T* p_input,
+                            const Dim<DDim::kMaxRank>& g_input_dims,
+                            const IndexT* p_index,
+                            T* p_output,
+                            int64_t remain_numel,
+                            int64_t slice_size,
+                            int64_t end_size,
+                            int vec_size,
+                            const phi::backends::gpu::GpuLaunchConfig& config) {
+  if (vec_size == 1) {
+    auto stream = ctx.stream();
+    GatherNdCUDAKernel<T, IndexT, 1>
+        <<<config.block_per_grid, config.thread_per_block, 0, stream>>>(
+            p_input,
+            g_input_dims,
+            p_index,
+            p_output,
+            remain_numel,
+            slice_size,
+            end_size);
+  } else {
+    PADDLE_THROW(common::errors::Unimplemented(
+        "Unsupported vectorized size: %d", vec_size));
   }
 }
 
@@ -98,18 +172,27 @@ void GPUGatherNd(const phi::GPUContext& ctx,
     g_input_dims[i] = input_dims[i];
   }
 
-  int block = 512;
-  int64_t n = slice_size * remain_numel;
-  dim3 grid = dim3((n + block - 1) / block);
-  phi::backends::gpu::LimitGridDim(ctx, &grid);
+  int vec_size = 4;
+  vec_size = std::min(phi::GetVectorizedSize(p_input), vec_size);
+  vec_size = std::min(phi::GetVectorizedSize(p_output), vec_size);
+  while (vec_size > 1 && slice_size % vec_size != 0) {
+    vec_size /= 2;
+  }
 
-  GatherNdCUDAKernel<T, IndexT><<<grid, block, 0, ctx.stream()>>>(p_input,
-                                                                  g_input_dims,
-                                                                  p_index,
-                                                                  p_output,
-                                                                  remain_numel,
-                                                                  slice_size,
-                                                                  end_size);
+  constexpr int loop_count = 4;
+  auto config = phi::backends::gpu::GetGpuLaunchConfig1D(
+      ctx, remain_numel * slice_size, vec_size * loop_count);
+
+  DispatchGatherNdKernel<T, IndexT, 4>(ctx,
+                                       p_input,
+                                       g_input_dims,
+                                       p_index,
+                                       p_output,
+                                       remain_numel,
+                                       slice_size,
+                                       end_size,
+                                       vec_size,
+                                       config);
 }
 
 template <typename T, typename U, int VecSize>


### PR DESCRIPTION
### PR Category
Performance Optimization

### PR Types
Performance

### Description
使用向量化优化GatherNdCUDAKernel，通过GetGpuLaunchConfig1D优化kernel config。在测试中分别有17.22%(未向量化)到74.55%（4X向量化）的性能提升。

测试机器V100
<meta charset="UTF-8"><meta charset="UTF-8"><div class="mp-table-align"><div class="mp-table-wrapper"><div data-slate-node="element" style="padding-left:0px" class="mp-table-container">
输入形状 | 索引形状 | 非向量化kernel   (us) | 向量化kernel (us) | 性能提升（%）
-- | -- | -- | -- | --
(128, 1024) | (128, 1) | 34.91 | 22.59 | 35.29
(128, 1026) | (128, 1) | 34.71 | 22.99 | 33.77
(128, 1025) | (128, 1) | 35.24 | 23.44 | 33.48
(128, 1024, 1024) | (128, 1024, 2) | 8932.36 | 2273.65 | 74.55
(128, 1024, 1026) | (128, 1024, 2) | 8960.01 | 3033.86 | 66.14
(128, 1024, 1025) | (128, 1024, 2) | 8953.44 | 5079.28 | 43.27
(128, 1024, 1024, 4) | (128, 1024, 3) | 71.34 | 44.44 | 37.71
(128, 1024, 1024, 6) | (128, 1024, 3) | 91.81 | 60.87 | 33.70
(128, 1024, 1024, 5) | (128, 1024, 3) | 83.65 | 69.24 | 17.22
(128, 1024, 1024) | (128, 512, 2) | 4433.92 | 1136.21 | 74.38

</div><div class="mp-table-serialize-flag"><br/></div></div></div><span data-morpho-doc-data='{"token":"eyJhbGciOiJkaXIiLCJlbmMiOiJBMjU2R0NNIiwiYXBwSWQiOjEsInVpZCI6ImpOOUtVdDJjbHkiLCJkb2NJZCI6Il9GSW1pQUhiYnp5UHppIn0..RKpl6-X2YbWAIkGu.Nu6yKLgJu4en5a6JsZG9_TlIc4Vs_6ZQ9NBhOP9p1M9PsXQCcEGY67uERDWFPjhMRZn1tZfU3krhto-12LQUq5ITgwp2zgbggrJHvgdyqWCAiLeFamD0SxCAOq_dtZnoqdfgDF_E2P0QSsyurAemBd9ZgrznryJXGzQ97b56sg4TYVy9Hy1Jm3JaTyScTZi7sP31foiKaiqyO7PNAi0w-tkFQA.D8pIkTBoNDN_4Bw30qnMRQ","appId":"1"}' class='mp-morpho-clipboard-doc-data'>﻿</span>

Pcard-67164