### PR TITLE
Use gather to replace gather nd when the bool index is one-dimensional

### DIFF
--- a/paddle/fluid/pybind/slice_utils.h
+++ b/paddle/fluid/pybind/slice_utils.h
@@ -519,6 +519,12 @@ static paddle::Tensor getValueForBoolTensor(const paddle::Tensor& tensor,
   if (bool_index.shape().size() == tensor_shape.size()) {
     return masked_select_ad_func(tensor, bool_index);
   }
+
+  if (bool_index.shape().size() == 1) {
+    auto bool_2_idx = nonzero_ad_func(bool_index);
+    return gather_ad_func(tensor, bool_2_idx);
+  }
+
   auto bool_2_idx = nonzero_ad_func(bool_index);
   return gather_nd_ad_func(tensor, bool_2_idx);
 }


### PR DESCRIPTION
### PR Category
Performance Optimization

### PR Types
Performance

### Description
case:
```
out = a[ val == 1]
和
t1 = (val == 1).nonzero().flatten()
out = paddle.gather( a, t1)
```
bool index是一维的时候使用gather替换gather nd有更好的性能
测试机器V100
<meta charset="UTF-8"><meta charset="UTF-8"><div class="mp-table-align"><div class="mp-table-wrapper"><div data-slate-node="element" style="padding-left:0px" class="mp-table-container">
python api | shape, dtype | 平均单次运行时间 ms | 加速比
-- | -- | -- | --
paddle [] gather_nd未向量化 | [108, 64, 12288], [108]paddle.bfloat16, paddle.bool | 2201.24 |  
paddle [] gather_nd向量化 | [108, 64, 12288], [108]paddle.bfloat16, paddle.bool | 513.40 | 4.29
paddle [] gather | [108, 64, 12288], [108]paddle.bfloat16, paddle.bool | 289.12 | 7.61
paddle.gather | [108, 64, 12288], [108]paddle.bfloat16, paddle.int64 | 300.64 | 7.32
torch [] | [108, 64, 12288], [108]torch.bfloat16, torch.bool | 510.85 | 4.31

</div><div class="mp-table-serialize-flag"><br/></div></div></div><span data-morpho-doc-data='{"token":"eyJhbGciOiJkaXIiLCJlbmMiOiJBMjU2R0NNIiwiYXBwSWQiOjEsInVpZCI6ImpOOUtVdDJjbHkiLCJkb2NJZCI6IkNNZktkX2tpSDdDbzJuIn0..Y6LvW6NhWrvB4n2v.I0wu8HxzNx3WeYGqR-w_AvqZM06GVO6X_29K-ZlW4op-4Jz7OwRWHsL38tnf7dpaCud1sYeZvrSMHXkpzR4hrrI-QWIQjV5M1Uy6TeBhNuOW_jTeGD49cuZcBBsWeb-rjr9cy0ylpNLw9cMn-twn0nAHzQ9G5hzkkUC_fKlQ_Lgl7BFEQ85dn5liuN5EQZ0sXL_sOVi70Y4COHncohWFBhwDeQ.BWwx0obCo4IehKAMjwni-w","appId":"1"}' class='mp-morpho-clipboard-doc-data'>﻿</span>

对纯False的情况进行了测试，index为单值False的情况下比torch慢，其他情况下均有提升。
case：index =  False
get_item paddle_gpu: 82.50 us, torch_gpu: 34.36 us, Paddle/Torch GPU score: 2.40) 
get_item paddle_cpu: 100.40 us, torch_cpu: 47.92 us, Paddle/Torch CPU score: 2.10) 

纯False：index =  [False,False,False,...]
get_item paddle_gpu: 80.36 us, torch_gpu: 95.80 us, Paddle/Torch GPU score: 0.84) 
get_item paddle_cpu: 100.39 us, torch_cpu: 113.18 us, Paddle/Torch CPU score: 0.89) 

混合：index =  [False,True,False,False,Ture,....]  
get_item paddle_gpu: 479.26 us, torch_gpu: 587.41 us, Paddle/Torch GPU score: 0.82) 
get_item paddle_cpu: 497.92 us, torch_cpu: 598.02 us, Paddle/Torch CPU score: 0.83) 
Pcard-67164