### PR TITLE
[SOT][DynamicShape] Force break for symbolic variable when dispatch not found

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
@@ -626,7 +626,7 @@ class OpcodeExecutorBase:
             self._current_line = instr.starts_line
         if not hasattr(self, instr.opname):
             raise FallbackError(f"opcode: {instr.opname} is not supported.")
-        log_message = f"[Translate {self._name}] (line {self._current_line:>3}) {instr.opname:<12} {instr.argval}, stack is {self.stack}\n"
+        log_message = f"[Translate {self._name} {len(self.call_stack)}] (line {self._current_line:>3}) {instr.opname:<12} {instr.argval}, stack is {self.stack}\n"
         log(3, log_message)
         code_file = self.vframe.code.co_filename
         code_line = self._current_line

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
@@ -83,7 +83,6 @@ from ....utils import (
     log,
     printable,
 )
-from ....utils.envs import ENV_SOT_BREAK_GRAPH_ON_GET_SYMBOLIC_VALUE
 from ....utils.exceptions import (
     HasNoAttributeError,
     InnerError,
@@ -1010,8 +1009,9 @@ class SymbolicVariable(VariableBase):
                 return
 
             disabled_vars.add(var)
-            if var.tracker.is_traceable():
+            if var.tracker.is_traceable() and isinstance(var, SymbolicVariable):
                 tracker_expr = var.tracker.trace_value_from_frame().inlined_expr
+                var.need_guard_value = True
                 symbolic_inputs[tracker_expr] = None
                 return
             for input_var in var.tracker.inputs:
@@ -1021,36 +1021,13 @@ class SymbolicVariable(VariableBase):
         self.graph.need_cache = False
         log(3, f"Fallback {self} to ConstantVariable\n")
         return ConstantVariable(
-            self.get_py_value(), self.graph, DummyTracker([self])
+            self.get_example_value(), self.graph, DummyTracker([self])
         )
 
     def get_py_value(self, allow_tensor: bool = False) -> bool | int | float:
-        if ENV_SOT_BREAK_GRAPH_ON_GET_SYMBOLIC_VALUE.get():
-            raise BreakGraphError(
-                DataDependencyOperationBreak(
-                    "get_py_value from SymbolicVariable"
-                )
-            )
-        self.need_guard_value = True
-        log(
-            3,
-            f"get_py_value from SymbolicVariable {self} caused value need guard\n",
+        raise BreakGraphError(
+            DataDependencyOperationBreak("get_py_value from SymbolicVariable")
         )
-        if self.value.is_backed():
-            return self.value.get_example_value()
-        inputs = self.tracker.inputs
-        input_values = [x.get_py_value() for x in inputs]
-        if not isinstance(self.tracker, SymbolicOperationTracker):
-            raise BreakGraphError(
-                DataDependencyOperationBreak(
-                    f"SymbolicVariable.get_py_value() got {self.tracker}. May be a symbol from a inner tensor."
-                )
-            )
-        value = self.tracker.op(*input_values)
-        assert isinstance(
-            value, (bool, int, float)
-        ), f"SymbolicVariable.get_py_value() should return bool, int or float, but got {type(value)}"
-        return value
 
     def get_example_value(
         self, allow_tensor: bool = False

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/callable.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/callable.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 import dis
 import functools
 import inspect
-import itertools
 import operator
 import sys
 import types
@@ -34,7 +33,6 @@ from paddle.base.dygraph.base import _DecoratorContextManager
 from .... import psdb
 from ....profiler import EventGuard
 from ....utils import (
-    ENV_SOT_ALLOW_DYNAMIC_SHAPE,
     ENV_SOT_EXPORT,
     get_obj_stable_repr,
     get_static_function,
@@ -48,7 +46,6 @@ from ....utils import (
     log,
     log_do,
     magic_method_builtin_dispatch,
-    map_if,
 )
 from ....utils.exceptions import (
     BreakGraphError,
@@ -778,44 +775,12 @@ class BuiltinVariable(FunctionVariable):
         self.value = fn
 
     def call_function(self, /, *args, **kwargs):
-        from .basic import SymbolicVariable
 
         # Lookup the handler from dispatcher
         handler = Dispatcher.dispatch(self.value, *args, **kwargs)
 
         if handler is not None:
             return handler(*args, **kwargs)
-
-        if ENV_SOT_ALLOW_DYNAMIC_SHAPE.get() and any(
-            isinstance(var, SymbolicVariable)
-            for var in itertools.chain(args, kwargs.values())
-        ):
-            fake_args, fake_kwargs = map_if(
-                (args, kwargs),
-                pred=lambda x: isinstance(x, SymbolicVariable),
-                # this is a fake args, we don't need to care about the value of the args
-                true_fn=lambda x: ConstantVariable.wrap_literal(
-                    None, graph=self.graph
-                ),
-                false_fn=lambda x: x,
-            )
-            handler = Dispatcher.dispatch(self.value, *fake_args, **fake_kwargs)
-            if handler is not None:
-                from ..executor_cache import (
-                    OpcodeExecutorCache,
-                )
-
-                symbolic_inputs = OpcodeExecutorCache().get_symbolic_inputs(
-                    self.graph.pycode_gen._origin_code
-                )
-
-                args, kwargs = map_if(
-                    (args, kwargs),
-                    pred=lambda x: isinstance(x, SymbolicVariable),
-                    true_fn=lambda x: x.to_constant(),
-                    false_fn=lambda x: x,
-                )
-                return handler(*args, **kwargs)
 
         # If API can be directly called in simulation mode (e.g. user defined native code
         # without graph affect), we can directly call it.

--- a/python/paddle/jit/sot/utils/envs.py
+++ b/python/paddle/jit/sot/utils/envs.py
@@ -141,9 +141,6 @@ ENV_SOT_EVENT_LEVEL = IntegerEnvironmentVariable("SOT_EVENT_LEVEL", 0)
 ENV_ENABLE_SOT_STEP_PROFILER = BooleanEnvironmentVariable(
     "ENABLE_SOT_STEP_PROFILER", False
 )
-ENV_SOT_BREAK_GRAPH_ON_GET_SYMBOLIC_VALUE = BooleanEnvironmentVariable(
-    "SOT_BREAK_GRAPH_ON_GET_SYMBOLIC_VALUE", False
-)
 ENV_SOT_COLLECT_INFO = PEP508LikeEnvironmentVariable("SOT_COLLECT_INFO", {})
 ENV_SOT_SERIALIZE_INFO = BooleanEnvironmentVariable("SOT_SERIALIZE_INFO", False)
 ENV_SOT_CE_DEBUG_MODE = BooleanEnvironmentVariable("SOT_CE_DEBUG_MODE", False)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Performance

### Description
<!-- Describe what you’ve done -->

移除 symbolic variable 找不到 builtin dispatch 时候的回退静态逻辑，以免编译次数过多的问题

<!-- PCard-66972 -->