### PR TITLE
[PHI] Fixed paddle.var & paddle.std float16 overflow problem

### DIFF
--- a/python/paddle/tensor/stat.py
+++ b/python/paddle/tensor/stat.py
@@ -193,9 +193,11 @@ def var(
         )
 
     u = mean(x, axis, True, name)
-    out = paddle.sum(paddle.pow((x - u), 2), axis, keepdim=keepdim, name=name)
+    dtype = paddle.float32 if x.dtype == paddle.float16 else x.dtype
+    out = paddle.sum(
+        paddle.pow((x - u), 2), axis, keepdim=keepdim, name=name, dtype=dtype
+    )
 
-    dtype = x.dtype
     n = paddle.cast(paddle.numel(x), "int64") / paddle.cast(
         paddle.numel(out), "int64"
     )
@@ -205,6 +207,8 @@ def var(
         n = where(n > one_const, n - 1.0, one_const)
     n.stop_gradient = True
     out /= n
+    if out.dtype != x.dtype:
+        return out.astype(x.dtype)
     return out
 
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Operator Mechanism


### PR Types
Bug fixes


### Description
修复了 paddle.var, paddle.std 在 float16 情况下溢出的问题。实际上是因为 paddle 在处理 reduce_sum 算子时没有进行 type cast，导致shape较大情况下就会溢出。此问题不仅在大tensor上会出现，小tensor也可以观察到。

Pcard-89620