### PR TITLE
[Auto-parallel] fix custom op in dynamic mode

### DIFF
--- a/paddle/fluid/eager/accumulation/accumulation_node.cc
+++ b/paddle/fluid/eager/accumulation/accumulation_node.cc
@@ -35,7 +35,7 @@ static void CopyOrAddTensor(paddle::Tensor* tensor,
     VLOG(3) << "Move Tensor ptr: " << t.impl();
     *tensor = t;
   } else {
-    if (!tensor->defined() || !tensor->has_allocation()) {
+    if (!tensor->defined() || !tensor->initialized()) {
       // Simply copy tensor->impl
       VLOG(3) << "Move Tensor ptr: " << t.impl();
       *tensor = t;

--- a/paddle/fluid/eager/custom_operator/custom_operator_utils.cc
+++ b/paddle/fluid/eager/custom_operator/custom_operator_utils.cc
@@ -806,20 +806,22 @@ void run_custom_op_impl(const paddle::OpMetaInfo& op_info,
     std::vector<Tensor>* output_all = ctx.AllMutableOutput();
     for (size_t i = 0; i < output_all->size(); ++i) {
       auto& tensor = output_all->at(i);
-      phi::distributed::TensorDistAttr dist_attr;
-      if (!spmd_info.second.empty()) {
-        dist_attr = PADDLE_GET_CONST(phi::distributed::TensorDistAttr,
-                                     spmd_info.second[i]);
-      } else {
-        std::vector<int64_t> shape = common::vectorize(output_dims[i]);
-        dist_attr.set_default_dims_mapping(shape);
-        dist_attr.set_process_mesh(current_process_mesh);
+      if (tensor.initialized()) {
+        phi::distributed::TensorDistAttr dist_attr;
+        if (!spmd_info.second.empty()) {
+          dist_attr = PADDLE_GET_CONST(phi::distributed::TensorDistAttr,
+                                       spmd_info.second[i]);
+        } else {
+          std::vector<int64_t> shape = common::vectorize(output_dims[i]);
+          dist_attr.set_default_dims_mapping(shape);
+          dist_attr.set_process_mesh(current_process_mesh);
+        }
+        auto dist_t = std::make_shared<phi::distributed::DistTensor>(
+            std::dynamic_pointer_cast<phi::DenseTensor>(tensor.impl()),
+            output_dims[i],
+            dist_attr);
+        tensor.set_impl(dist_t);
       }
-      auto dist_t = std::make_shared<phi::distributed::DistTensor>(
-          std::dynamic_pointer_cast<phi::DenseTensor>(tensor.impl()),
-          output_dims[i],
-          dist_attr);
-      tensor.set_impl(dist_t);
     }
     return;
   }

--- a/paddle/fluid/eager/custom_operator/custom_operator_utils.cc
+++ b/paddle/fluid/eager/custom_operator/custom_operator_utils.cc
@@ -806,20 +806,20 @@ void run_custom_op_impl(const paddle::OpMetaInfo& op_info,
     std::vector<Tensor>* output_all = ctx.AllMutableOutput();
     for (size_t i = 0; i < output_all->size(); ++i) {
       auto& tensor = output_all->at(i);
-      if (tensor.initialized()) {
-        phi::distributed::TensorDistAttr dist_attr;
-        if (!spmd_info.second.empty()) {
-          dist_attr = PADDLE_GET_CONST(phi::distributed::TensorDistAttr,
-                                       spmd_info.second[i]);
-        } else {
-          std::vector<int64_t> shape = common::vectorize(output_dims[i]);
-          dist_attr.set_default_dims_mapping(shape);
-          dist_attr.set_process_mesh(current_process_mesh);
-        }
+      phi::distributed::TensorDistAttr dist_attr;
+      if (!spmd_info.second.empty()) {
+        dist_attr = PADDLE_GET_CONST(phi::distributed::TensorDistAttr,
+                                     spmd_info.second[i]);
+      } else {
+        std::vector<int64_t> shape = common::vectorize(output_dims[i]);
+        dist_attr.set_default_dims_mapping(shape);
+        dist_attr.set_process_mesh(current_process_mesh);
+      }
+      auto dense_tensor =
+          std::dynamic_pointer_cast<phi::DenseTensor>(tensor.impl());
+      if (dense_tensor != nullptr) {
         auto dist_t = std::make_shared<phi::distributed::DistTensor>(
-            std::dynamic_pointer_cast<phi::DenseTensor>(tensor.impl()),
-            output_dims[i],
-            dist_attr);
+            dense_tensor, output_dims[i], dist_attr);
         tensor.set_impl(dist_t);
       }
     }

--- a/paddle/fluid/eager/custom_operator/custom_operator_utils.cc
+++ b/paddle/fluid/eager/custom_operator/custom_operator_utils.cc
@@ -803,6 +803,24 @@ void run_custom_op_impl(const paddle::OpMetaInfo& op_info,
   phi::distributed::ProcessMesh current_process_mesh = std::get<2>(result);
   auto& spmd_info = std::get<3>(result);
   if (!rank_is_in_current_mesh) {
+    std::vector<Tensor>* output_all = ctx.AllMutableOutput();
+    for (size_t i = 0; i < output_all->size(); ++i) {
+      auto& tensor = output_all->at(i);
+      phi::distributed::TensorDistAttr dist_attr;
+      if (!spmd_info.second.empty()) {
+        dist_attr = PADDLE_GET_CONST(phi::distributed::TensorDistAttr,
+                                     spmd_info.second[i]);
+      } else {
+        std::vector<int64_t> shape = common::vectorize(output_dims[i]);
+        dist_attr.set_default_dims_mapping(shape);
+        dist_attr.set_process_mesh(current_process_mesh);
+      }
+      auto dist_t = std::make_shared<phi::distributed::DistTensor>(
+          std::dynamic_pointer_cast<phi::DenseTensor>(tensor.impl()),
+          output_dims[i],
+          dist_attr);
+      tensor.set_impl(dist_t);
+    }
     return;
   }
 #endif


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
动态图下，自定义算子在 pp 策略下跑不通，解决梯度累积下运行报错和精度不收敛问题，修复后精度 llama13b + 开关 fused_rms_norm 精度收敛情况如下：
（继承之前PR：https://github.com/PaddlePaddle/Paddle/pull/72730 ）
<img width="1035" alt="image" src="https://github.com/user-attachments/assets/5c39df01-3ff7-4f52-99b7-0ad4acf09b52" />

Pcard-90697