### PR TITLE
[CINN] Fixed arange float16 and bfloat16 support

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/pd_to_cinn_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/pd_to_cinn_pass.cc
@@ -554,6 +554,12 @@ class ArangeOpPattern
           case phi::DataType::INT32:
             input = phi::Scalar(input.to<int>());
             break;
+          case phi::DataType::FLOAT16:
+            input = phi::Scalar(input.to<float>());
+            break;
+          case phi::DataType::BFLOAT16:
+            input = phi::Scalar(input.to<float>());
+            break;
           default:
             input = phi::Scalar(input.to<int64_t>());
         }

--- a/paddle/cinn/hlir/op/elementwise.cc
+++ b/paddle/cinn/hlir/op/elementwise.cc
@@ -1310,8 +1310,20 @@ std::shared_ptr<framework::OpStrategy> StrategyForArangeSymbolic(
     EXPR_FROM_ATTR(int)
   } else if (dtype.is_int(64)) {
     EXPR_FROM_ATTR(int64_t)
+  } else if (dtype.is_bfloat16()) {
+    EXPR_FROM_ATTR(float)
+    start->set_type(cinn::common::BFloat16());
+    step->set_type(cinn::common::BFloat16());
+  } else if (dtype.is_float16()) {
+    EXPR_FROM_ATTR(float)
+    start->set_type(cinn::common::Float16());
+    step->set_type(cinn::common::Float16());
   } else {
-    CINN_NOT_IMPLEMENTED
+    PADDLE_ENFORCE_NOT_NULL(
+        nullptr,
+        ::common::errors::InvalidArgument(
+            "The dtype of arange op should be float32, float64, int32, int64, "
+            "bfloat16 or float16."));
   }
 
 #undef EXPR_FROM_ATTR

--- a/paddle/phi/infermeta/nullary.cc
+++ b/paddle/phi/infermeta/nullary.cc
@@ -57,6 +57,10 @@ void ArangeInferMeta(const Scalar& start,
         GET_SIZE_GIVEN_TYPE(double)
       case DataType::INT32:
         GET_SIZE_GIVEN_TYPE(int)
+      case DataType::FLOAT16:
+        GET_SIZE_GIVEN_TYPE(float)
+      case DataType::BFLOAT16:
+        GET_SIZE_GIVEN_TYPE(float)
       default:
         GET_SIZE_GIVEN_TYPE(int64_t)
     }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
CINN


### PR Types
Bug fixes


### Description
此前 #72598 中实现的 arange CINN 支持，没有支持 float16 和 bfloat16，本PR已经加上。如下两个简单的测试可以验证 (在`test_cinn_arange.py` 单测中)。内部计算 shape 时使用 float 计算。

```python
def test_arange_postfuse_float16(self):
    def func():
        return paddle.arange(0, 1024, 2.1, dtype="float16") * 0.2 + 1

    self.eval(func, [])

def test_arange_postfuse_bfloat16(self):
    def func():
        return paddle.arange(0, 128, 8, dtype="bfloat16") * 2 + 1

    self.eval(func, [])
```

Pcard-89620
