### PR TITLE
[PHI] Fixed logsumexp precision problem

### DIFF
--- a/paddle/phi/kernels/gpu/logsumexp_function.cu.h
+++ b/paddle/phi/kernels/gpu/logsumexp_function.cu.h
@@ -14,7 +14,6 @@
 #pragma once
 
 #include <assert.h>
-#include "glog/logging.h"
 #include "paddle/phi/kernels/funcs/aligned_vector.h"
 #include "paddle/phi/kernels/primitive/functor_primitives.h"
 
@@ -53,40 +52,6 @@ __inline__ __device__ T WarpAllReduce(T val) {
   }
   return val;
 }
-
-#if PADDLE_WITH_HIP
-inline void GetNumBlocks(int64_t block_size,
-                         int64_t max_blocks,
-                         int64_t waves,
-                         int* num_blocks) {
-  int dev;
-  PADDLE_ENFORCE_GPU_SUCCESS(hipGetDevice(&dev));
-  int sm_count;
-  PADDLE_ENFORCE_GPU_SUCCESS(hipDeviceGetAttribute(
-      &sm_count, hipDeviceAttributeMultiprocessorCount, dev));
-  int tpm;
-  PADDLE_ENFORCE_GPU_SUCCESS(hipDeviceGetAttribute(
-      &tpm, hipDeviceAttributeMaxThreadsPerMultiProcessor, dev));
-  *num_blocks = std::max<int>(
-      1, std::min<int64_t>(max_blocks, sm_count * tpm / block_size * waves));
-}
-#else
-inline void GetNumBlocks(int64_t block_size,
-                         int64_t max_blocks,
-                         int64_t waves,
-                         int* num_blocks) {
-  int dev;
-  PADDLE_ENFORCE_GPU_SUCCESS(cudaGetDevice(&dev));
-  int sm_count;
-  PADDLE_ENFORCE_GPU_SUCCESS(
-      cudaDeviceGetAttribute(&sm_count, cudaDevAttrMultiProcessorCount, dev));
-  int tpm;
-  PADDLE_ENFORCE_GPU_SUCCESS(cudaDeviceGetAttribute(
-      &tpm, cudaDevAttrMaxThreadsPerMultiProcessor, dev));
-  *num_blocks = std::max<int>(
-      1, std::min<int64_t>(max_blocks, sm_count * tpm / block_size * waves));
-}
-#endif
 
 template <typename T,
           typename SourceType,
@@ -209,25 +174,6 @@ inline cudaError_t LaunchLogsumexpWarp(const Context& dev_ctx,
   const int64_t num_blocks =
       (num_row / RowsPerThread + thread_groups_per_block - 1) /
       thread_groups_per_block;
-  int grid_dim_x = num_blocks;
-  { GetNumBlocks(block_size, num_blocks, waves, &grid_dim_x); }
-  VLOG(4) << "HQY number of blocks:" << grid_dim_x << ", r, c: " << num_row
-          << ", " << num_col << ", num blocks:" << num_blocks;
-  VLOG(4) << "HQY RowsPerThread: " << RowsPerThread
-          << ", ThreadGroupWidth: " << ThreadGroupWidth
-          << ", ColsPerThread: " << ColsPerThread << ", VecSize: " << VecSize;
-  int max_block_x, max_block_y, max_block_z, max_block_cnt, dev;
-  PADDLE_ENFORCE_GPU_SUCCESS(cudaGetDevice(&dev));
-  PADDLE_ENFORCE_GPU_SUCCESS(
-      cudaDeviceGetAttribute(&max_block_x, cudaDevAttrMaxGridDimX, dev));
-  PADDLE_ENFORCE_GPU_SUCCESS(
-      cudaDeviceGetAttribute(&max_block_y, cudaDevAttrMaxGridDimY, dev));
-  PADDLE_ENFORCE_GPU_SUCCESS(
-      cudaDeviceGetAttribute(&max_block_z, cudaDevAttrMaxGridDimZ, dev));
-  PADDLE_ENFORCE_GPU_SUCCESS(cudaDeviceGetAttribute(
-      &max_block_cnt, cudaDevAttrMaxThreadsPerMultiProcessor, dev));
-  VLOG(4) << "Limits: " << max_block_x << ", " << max_block_y << ", "
-          << max_block_z << ", " << max_block_cnt;
   LogsumexpWarpImpl<T,
                     SourceType,
                     Context,
@@ -236,7 +182,7 @@ inline cudaError_t LaunchLogsumexpWarp(const Context& dev_ctx,
                     RowsPerThread,
                     ThreadGroupWidth,
                     NeedPadding>
-      <<<grid_dim_x, block_dim, 0, dev_ctx.stream()>>>(
+      <<<num_blocks, block_dim, 0, dev_ctx.stream()>>>(
           dev_ctx, num_row, num_col, in, out);
 #if PADDLE_WITH_HIP
   return hipPeekAtLastError();

--- a/paddle/phi/kernels/gpu/logsumexp_function.cu.h
+++ b/paddle/phi/kernels/gpu/logsumexp_function.cu.h
@@ -53,6 +53,40 @@ __inline__ __device__ T WarpAllReduce(T val) {
   return val;
 }
 
+#if PADDLE_WITH_HIP
+inline void GetNumBlocks(int64_t block_size,
+                         int64_t max_blocks,
+                         int64_t waves,
+                         int* num_blocks) {
+  int dev;
+  PADDLE_ENFORCE_GPU_SUCCESS(hipGetDevice(&dev));
+  int sm_count;
+  PADDLE_ENFORCE_GPU_SUCCESS(hipDeviceGetAttribute(
+      &sm_count, hipDeviceAttributeMultiprocessorCount, dev));
+  int tpm;
+  PADDLE_ENFORCE_GPU_SUCCESS(hipDeviceGetAttribute(
+      &tpm, hipDeviceAttributeMaxThreadsPerMultiProcessor, dev));
+  *num_blocks = std::max<int>(
+      1, std::min<int64_t>(max_blocks, sm_count * tpm / block_size * waves));
+}
+#else
+inline void GetNumBlocks(int64_t block_size,
+                         int64_t max_blocks,
+                         int64_t waves,
+                         int* num_blocks) {
+  int dev;
+  PADDLE_ENFORCE_GPU_SUCCESS(cudaGetDevice(&dev));
+  int sm_count;
+  PADDLE_ENFORCE_GPU_SUCCESS(
+      cudaDeviceGetAttribute(&sm_count, cudaDevAttrMultiProcessorCount, dev));
+  int tpm;
+  PADDLE_ENFORCE_GPU_SUCCESS(cudaDeviceGetAttribute(
+      &tpm, cudaDevAttrMaxThreadsPerMultiProcessor, dev));
+  *num_blocks = std::max<int>(
+      1, std::min<int64_t>(max_blocks, sm_count * tpm / block_size * waves));
+}
+#endif
+
 template <typename T,
           typename SourceType,
           typename Context,
@@ -139,8 +173,7 @@ __global__ void LogsumexpWarpImpl(const Context& dev_ctx,
       store_vec[row_id] = static_cast<SourceType>(res + warp_max[row_id]);
     }
     if (thread_id == 0 && cur_row < num_row) {
-      phi::Store<SourceType, RowsPerThread>(store_vec,
-                                            out + group_id * RowsPerThread);
+      phi::Store<SourceType, RowsPerThread>(store_vec, out + cur_row);
     }
   }
 }
@@ -174,6 +207,8 @@ inline cudaError_t LaunchLogsumexpWarp(const Context& dev_ctx,
   const int64_t num_blocks =
       (num_row / RowsPerThread + thread_groups_per_block - 1) /
       thread_groups_per_block;
+  int grid_dim_x;
+  { GetNumBlocks(block_size, num_blocks, waves, &grid_dim_x); }
   LogsumexpWarpImpl<T,
                     SourceType,
                     Context,
@@ -182,7 +217,7 @@ inline cudaError_t LaunchLogsumexpWarp(const Context& dev_ctx,
                     RowsPerThread,
                     ThreadGroupWidth,
                     NeedPadding>
-      <<<num_blocks, block_dim, 0, dev_ctx.stream()>>>(
+      <<<grid_dim_x, block_dim, 0, dev_ctx.stream()>>>(
           dev_ctx, num_row, num_col, in, out);
 #if PADDLE_WITH_HIP
   return hipPeekAtLastError();

--- a/paddle/phi/kernels/gpu/logsumexp_function.cu.h
+++ b/paddle/phi/kernels/gpu/logsumexp_function.cu.h
@@ -14,6 +14,7 @@
 #pragma once
 
 #include <assert.h>
+#include "glog/logging.h"
 #include "paddle/phi/kernels/funcs/aligned_vector.h"
 #include "paddle/phi/kernels/primitive/functor_primitives.h"
 
@@ -208,8 +209,25 @@ inline cudaError_t LaunchLogsumexpWarp(const Context& dev_ctx,
   const int64_t num_blocks =
       (num_row / RowsPerThread + thread_groups_per_block - 1) /
       thread_groups_per_block;
-  int grid_dim_x;
+  int grid_dim_x = num_blocks;
   { GetNumBlocks(block_size, num_blocks, waves, &grid_dim_x); }
+  VLOG(4) << "HQY number of blocks:" << grid_dim_x << ", r, c: " << num_row
+          << ", " << num_col << ", num blocks:" << num_blocks;
+  VLOG(4) << "HQY RowsPerThread: " << RowsPerThread
+          << ", ThreadGroupWidth: " << ThreadGroupWidth
+          << ", ColsPerThread: " << ColsPerThread << ", VecSize: " << VecSize;
+  int max_block_x, max_block_y, max_block_z, max_block_cnt, dev;
+  PADDLE_ENFORCE_GPU_SUCCESS(cudaGetDevice(&dev));
+  PADDLE_ENFORCE_GPU_SUCCESS(
+      cudaDeviceGetAttribute(&max_block_x, cudaDevAttrMaxGridDimX, dev));
+  PADDLE_ENFORCE_GPU_SUCCESS(
+      cudaDeviceGetAttribute(&max_block_y, cudaDevAttrMaxGridDimY, dev));
+  PADDLE_ENFORCE_GPU_SUCCESS(
+      cudaDeviceGetAttribute(&max_block_z, cudaDevAttrMaxGridDimZ, dev));
+  PADDLE_ENFORCE_GPU_SUCCESS(cudaDeviceGetAttribute(
+      &max_block_cnt, cudaDevAttrMaxThreadsPerMultiProcessor, dev));
+  VLOG(4) << "Limits: " << max_block_x << ", " << max_block_y << ", "
+          << max_block_z << ", " << max_block_cnt;
   LogsumexpWarpImpl<T,
                     SourceType,
                     Context,

--- a/paddle/phi/kernels/gpu/logsumexp_kernel.cu
+++ b/paddle/phi/kernels/gpu/logsumexp_kernel.cu
@@ -15,6 +15,7 @@
 #include "paddle/phi/kernels/logsumexp_kernel.h"
 #include "paddle/phi/kernels/gpu/logsumexp_function.cu.h"
 
+#include "glog/logging.h"
 #include "paddle/phi/common/bfloat16.h"
 #include "paddle/phi/common/float16.h"
 #include "paddle/phi/core/kernel_registry.h"
@@ -115,6 +116,7 @@ void LogsumexpKernel(const Context& dev_ctx,
       axis_vec.push_back(i);
     }
   }
+  VLOG(4) << "Logsumexp type: " << typeid(T).name();
   for (size_t i = 0; i < xdim.size(); i++) {
     bool flag = false;
     for (auto v : axis_vec) {
@@ -138,6 +140,7 @@ void LogsumexpKernel(const Context& dev_ctx,
 
   auto outdim = common::make_ddim(outdim_vec);
   if (compute_size <= 1024) {
+    VLOG(4) << "Logsumexp compute_size: " << compute_size << ", if branch";
     if (perm.size() != xdim.size())
       perm.insert(perm.end(), axis_vec.begin(), axis_vec.end());
     for (auto i : axis_vec) transpose_shape.push_back(xdim[i]);
@@ -157,6 +160,8 @@ void LogsumexpKernel(const Context& dev_ctx,
         dev_ctx, num_row, num_col, transpose_x.data<T>(), out->data<T>());
     out->Resize(outdim);
   } else {
+    VLOG(4) << "Logsumexp compute_size: " << compute_size
+            << ", else fall back kernel";
     LogsumexpFallbackKernel<T, Context>(dev_ctx,
                                         x,
                                         axis_vec,

--- a/paddle/phi/kernels/gpu/logsumexp_kernel.cu
+++ b/paddle/phi/kernels/gpu/logsumexp_kernel.cu
@@ -15,7 +15,6 @@
 #include "paddle/phi/kernels/logsumexp_kernel.h"
 #include "paddle/phi/kernels/gpu/logsumexp_function.cu.h"
 
-#include "glog/logging.h"
 #include "paddle/phi/common/bfloat16.h"
 #include "paddle/phi/common/float16.h"
 #include "paddle/phi/core/kernel_registry.h"
@@ -116,7 +115,6 @@ void LogsumexpKernel(const Context& dev_ctx,
       axis_vec.push_back(i);
     }
   }
-  VLOG(4) << "Logsumexp type: " << typeid(T).name();
   for (size_t i = 0; i < xdim.size(); i++) {
     bool flag = false;
     for (auto v : axis_vec) {
@@ -140,7 +138,6 @@ void LogsumexpKernel(const Context& dev_ctx,
 
   auto outdim = common::make_ddim(outdim_vec);
   if (compute_size <= 1024) {
-    VLOG(4) << "Logsumexp compute_size: " << compute_size << ", if branch";
     if (perm.size() != xdim.size())
       perm.insert(perm.end(), axis_vec.begin(), axis_vec.end());
     for (auto i : axis_vec) transpose_shape.push_back(xdim[i]);
@@ -160,8 +157,6 @@ void LogsumexpKernel(const Context& dev_ctx,
         dev_ctx, num_row, num_col, transpose_x.data<T>(), out->data<T>());
     out->Resize(outdim);
   } else {
-    VLOG(4) << "Logsumexp compute_size: " << compute_size
-            << ", else fall back kernel";
     LogsumexpFallbackKernel<T, Context>(dev_ctx,
                                         x,
                                         axis_vec,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Operator Mechanism


### PR Types
Bug fixes


### Description
修复了 `paddle.logsumexp` 的精度问题，此精度问题甚至在tensor不算特别大的情况下存在。问题例子如下：

```python
def test_logsumexp(config):
    ts = paddle.randn(config[0], dtype = config[1])
    vp = paddle.logsumexp(ts, axis = config[2], keepdim = config[3])
    tst = torch.from_numpy(ts.numpy())

    keepdim = False if config[3] is None else config[3]
    np.testing.assert_allclose(
        torch.logsumexp(tst, axis = config[2], keepdim = keepdim).numpy(), vp.numpy(), rtol=1e-6, atol=1e-6)

def test_single():
    # 这里100%正确
    config = [[2, 131072, 4, 5],"float32", (-1,), False, ]
    test_logsumexp(config)
    
    # 这里会出精度错误（31.25%的值不对）
    config = [[2, 262144, 4, 5],"float32", (-1,), False, ]
    test_logsumexp(config)
```

测试发现：上述例子中，shape 为 131072 时 计算的 grid size 为 32768，但当 shape 变大一倍之后，grid size 没有变大一倍（非65536，而是55296）。实际收到了修改代码中的 `GetNumBlocks` 函数的影响，此函数基本就是在根据 GPU 所有SM中可用的线程数，计算最大block数量，有一定的性能考虑在内，但**在本算子内逻辑不正确**：tensor变大时，grid size没有成比例变大、thread内部没有通过 coarsening 做更多工作、block size也没有变化，导致实际上又部分tensor没参与计算。

- [Deprecated] 取消`GetNumBlocks` 函数，grid size 没有上限，依赖调度。可行，但是比较暴力。
- 目前：修正了函数中，grid size 过大情况下的bug（实际上，只需要修改一行）。

Pcard-89620
