### PR TITLE
[CINN] Denied arange op for x86 end codegen

### DIFF
--- a/paddle/cinn/hlir/framework/pir/op_lowering_impl.cc
+++ b/paddle/cinn/hlir/framework/pir/op_lowering_impl.cc
@@ -847,7 +847,7 @@ ir::LoweredFunc OpLowererImpl::GenerateInferShapeFunc(
 }
 bool IsOpDeniedOnCpu(::pir::Operation* op) {
   // no op is denied after the support for composite reduce on cpu
-  static std::set<std::string> banned_ops = {};
+  static std::set<std::string> banned_ops = {"cinn_op.arange"};
   return banned_ops.count(op->name());
 }
 ir::Expr OpLowererImpl::LowerX86(const OpLoweringGroupPtr& group,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
CINN


### PR Types
Bug fixes


### Description
目前，CodeGenLLVM 没有一套成熟通用的方法，可以在修改CINN算子之后立刻获得无错的x86版本（参考之前的 argidx reduce）。故暂且先禁止 arange 算子在 x86 端的代码生成（修复 #72598 x86 代码生成错误的问题）。

Pcard-89620
