### PR TITLE
[PHI] Remove enable unused var

### DIFF
--- a/.github/workflows/Coverage.yml
+++ b/.github/workflows/Coverage.yml
@@ -79,7 +79,6 @@ jobs:
           CCACHE_LIMIT_MULTIPLE: 0.8
           ON_INFER: "ON"
           PADDLE_CUDA_INSTALL_REQUIREMENTS: "ON"
-          FLAGS_enable_unused_var_check: 1
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           UT_RUN_TYPE_SETTING: WITHOUT_HYBRID
@@ -124,7 +123,6 @@ jobs:
             -e CCACHE_LIMIT_MULTIPLE \
             -e ON_INFER \
             -e PADDLE_CUDA_INSTALL_REQUIREMENTS \
-            -e FLAGS_enable_unused_var_check \
             -e GITHUB_TOKEN \
             -e GITHUB_API_TOKEN \
             -e UT_RUN_TYPE_SETTING \

--- a/paddle/fluid/framework/operator.h
+++ b/paddle/fluid/framework/operator.h
@@ -494,8 +494,6 @@ class ExecutionContext : public phi::KernelContext {
 
   virtual const std::vector<Variable*> MultiInputVar(
       const std::string& name) const {
-    LogVarUsageIfUnusedVarCheckEnabled(name);
-
     auto it = ctx_.inputs.find(name);
     if (it == ctx_.inputs.end()) {
       return {};
@@ -536,8 +534,6 @@ class ExecutionContext : public phi::KernelContext {
 
   template <typename T>
   const std::vector<const T*> MultiInput(const std::string& name) const {
-    LogVarUsageIfUnusedVarCheckEnabled(name);
-
     auto vars = MultiInputVar(name);
     if (vars.size() == 0) {
       return {};

--- a/paddle/fluid/framework/unused_var_check.cc
+++ b/paddle/fluid/framework/unused_var_check.cc
@@ -23,24 +23,12 @@ limitations under the License. */
 #include "paddle/fluid/framework/op_info.h"
 #include "paddle/fluid/framework/operator.h"
 #include "paddle/fluid/platform/enforce.h"
-PHI_DEFINE_EXPORTED_bool(
-    enable_unused_var_check,
-    false,
-    "Checking whether operator contains unused inputs, "
-    "especially for grad operator. It should be in unittest.");
 
 namespace paddle::framework {
 
 std::unordered_set<std::string> *GetThreadLocalUsedVarNameSet() {
   thread_local std::unordered_set<std::string> used_var_name_set;
   return &used_var_name_set;
-}
-
-void LogVarUsageIfUnusedVarCheckEnabled(const std::string &name) {
-  if (FLAGS_enable_unused_var_check) {
-    VLOG(6) << "Variable used:" << name;
-    GetThreadLocalUsedVarNameSet()->insert(name);
-  }
 }
 
 static const std::unordered_set<std::string> &GetOpWithUnusedVarAllowSet() {

--- a/paddle/fluid/framework/unused_var_check.h
+++ b/paddle/fluid/framework/unused_var_check.h
@@ -29,7 +29,6 @@ class Scope;
 
 std::unordered_set<std::string>* GetThreadLocalUsedVarNameSet();
 
-void LogVarUsageIfUnusedVarCheckEnabled(const std::string& name);
 void CheckUnusedVar(const OperatorBase& op, const Scope& scope);
 
 }  // namespace framework

--- a/paddle/phi/core/compat/op_utils.h
+++ b/paddle/phi/core/compat/op_utils.h
@@ -82,13 +82,9 @@ class OpUtilsMap {
     fluid_op_to_phi_kernel_.insert({op_type, base_kernel_name});
   }
   void InsertFluidOplName(std::string op_type, std::string base_kernel_name) {
-    PADDLE_ENFORCE_EQ(
-        phi_kernel_to_fluid_op_.count(base_kernel_name),
-        0UL,
-        common::errors::AlreadyExists(
-            "Operator (%s)'s kernel name (%s) has been registered.",
-            op_type,
-            base_kernel_name));
+    if (phi_kernel_to_fluid_op_.count(base_kernel_name)) {
+      return;
+    }
     phi_kernel_to_fluid_op_.insert({base_kernel_name, op_type});
   }
 
@@ -97,12 +93,9 @@ class OpUtilsMap {
   }
 
   void InsertArgumentMappingFn(std::string op_type, ArgumentMappingFn fn) {
-    PADDLE_ENFORCE_EQ(
-        arg_mapping_fn_map_.count(op_type),
-        0UL,
-        common::errors::AlreadyExists(
-            "Operator (%s)'s argument mapping function has been registered.",
-            op_type));
+    if (arg_mapping_fn_map_.count(op_type)) {
+      return;
+    }
     arg_mapping_fn_map_.insert({std::move(op_type), std::move(fn)});
   }
 

--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -3355,12 +3355,6 @@ function nv_test() {
 }
 
 
-function enable_unused_var_check() {
-    # NOTE(zhiqiu): Set FLAGS_enable_unused_var_check=1 here to enable unused_var_check,
-    # which checks if an operator has unused input variable(s).
-    # Currently, use it in coverage CI job.
-    export FLAGS_enable_unused_var_check=1
-}
 function check_coverage_added_ut() {
     # NOTE(risemeup1):The step of checking added test can be placed on the cpu machine to save gpu resources
     bash $PADDLE_ROOT/tools/check_added_ut.sh
@@ -4829,13 +4823,11 @@ function main() {
       cicheck)
         cmake_gen ${PYTHON_ABI:-""}
         build ${parallel_number}
-        enable_unused_var_check
         parallel_test
         ;;
       cicheck_coverage)
         check_diff_file_for_coverage
         run_setup ${PYTHON_ABI:-""} install ${parallel_number}
-        enable_unused_var_check
         parallel_test
         check_coverage
         ;;
@@ -4843,7 +4835,6 @@ function main() {
         check_diff_file_for_coverage
         export ON_INFER=ON PADDLE_CUDA_INSTALL_REQUIREMENTS=ON
         run_setup ${PYTHON_ABI:-""} bdist_wheel ${parallel_number}
-        enable_unused_var_check
         check_coverage_added_ut
         check_coverage_build
         clean_build_files

--- a/test/cpp/fluid/framework/operator_test.cc
+++ b/test/cpp/fluid/framework/operator_test.cc
@@ -610,28 +610,6 @@ REGISTER_OP_WITHOUT_GRADIENT(
 REGISTER_OP_CPU_KERNEL(op_without_unused_var,
                        paddle::framework::OpWithoutUnusedVarKernelTest<float>);
 
-// test with single input
-TEST(OpWithUnusedVar, all) {
-  paddle::framework::InitDevices();
-  paddle::framework::proto::OpDesc op_desc;
-  op_desc.set_type("op_with_unused_var");
-  BuildVar("X", {"X"}, op_desc.add_inputs());
-  BuildVar("Y", {"Y"}, op_desc.add_outputs());
-
-  phi::CPUPlace cpu_place;
-  paddle::framework::Scope scope;
-  auto* x = scope.Var("X")->GetMutable<phi::DenseTensor>();
-  auto* y = scope.Var("Y")->GetMutable<phi::DenseTensor>();
-  x->Resize({32, 64});
-  y->Resize({32, 64});
-  x->mutable_data<float>(cpu_place);
-  y->mutable_data<float>(cpu_place);
-
-  auto op = paddle::framework::OpRegistry::CreateOp(op_desc);
-  // should throw exception
-  ASSERT_THROW(op->Run(scope, cpu_place), paddle::platform::EnforceNotMet);
-}
-
 TEST(OpWithoutUnusedVar, all) {
   paddle::framework::InitDevices();
   paddle::framework::proto::OpDesc op_desc;

--- a/test/cpp/fluid/framework/operator_test.cc
+++ b/test/cpp/fluid/framework/operator_test.cc
@@ -19,8 +19,6 @@ limitations under the License. */
 #include "paddle/fluid/framework/op_registry.h"
 #include "paddle/fluid/platform/init.h"
 
-PD_DECLARE_bool(enable_unused_var_check);
-
 namespace paddle {
 namespace framework {
 
@@ -614,8 +612,6 @@ REGISTER_OP_CPU_KERNEL(op_without_unused_var,
 
 // test with single input
 TEST(OpWithUnusedVar, all) {
-  // enable the unused_var_check
-  FLAGS_enable_unused_var_check = true;
   paddle::framework::InitDevices();
   paddle::framework::proto::OpDesc op_desc;
   op_desc.set_type("op_with_unused_var");
@@ -634,13 +630,9 @@ TEST(OpWithUnusedVar, all) {
   auto op = paddle::framework::OpRegistry::CreateOp(op_desc);
   // should throw exception
   ASSERT_THROW(op->Run(scope, cpu_place), paddle::platform::EnforceNotMet);
-  FLAGS_enable_unused_var_check = false;
 }
 
 TEST(OpWithoutUnusedVar, all) {
-  // enable the unused_var_check
-  FLAGS_enable_unused_var_check = true;
-
   paddle::framework::InitDevices();
   paddle::framework::proto::OpDesc op_desc;
   op_desc.set_type("op_without_unused_var");
@@ -659,5 +651,4 @@ TEST(OpWithoutUnusedVar, all) {
   auto op = paddle::framework::OpRegistry::CreateOp(op_desc);
   // should not throw exception
   ASSERT_NO_THROW(op->Run(scope, cpu_place));
-  FLAGS_enable_unused_var_check = false;
 }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

Pcard-75624

1. 删除 `enable_unused_var` 相关的所有代码，避免推理开启CINN时找不到符号的问题
2. 添加op或者arg时，自动跳过已存在的键值对，而不是直接报错