### PR TITLE
sharding_optimzier support unused_param

### DIFF
--- a/python/paddle/distributed/fleet/meta_optimizers/dygraph_optimizer/dygraph_sharding_optimizer.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/dygraph_optimizer/dygraph_sharding_optimizer.py
@@ -727,7 +727,7 @@ class DygraphShardingOptimizerV2:
         if self._all_gather_overlap_forward:
             self._layers = layers
 
-    def marked_unused_param_and_add_fakegrad_to_buffer(self, unused_param):
+    def marked_unused_param_and_fake_add_grad_to_buffer(self, unused_param):
         # In sparse scenarios, some parameters may not have gradients at this step even if stop_gradient are true.
         # sharding optimzier will fake zero grad to fill the comm_buffer so that ensure gradient can cal reduce normally.
         if not self.comm_overlap:

--- a/python/paddle/distributed/fleet/meta_optimizers/dygraph_optimizer/dygraph_sharding_optimizer.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/dygraph_optimizer/dygraph_sharding_optimizer.py
@@ -727,7 +727,7 @@ class DygraphShardingOptimizerV2:
         if self._all_gather_overlap_forward:
             self._layers = layers
 
-    def marked_unused_param(self, unused_param):
+    def marked_unused_param_and_add_fakegrad_to_buffer(self, unused_param):
         # In sparse scenarios, some parameters may not have gradients at this step even if stop_gradient are true.
         # sharding optimzier will fake zero grad to fill the comm_buffer so that ensure gradient can cal reduce normally.
         if not self.comm_overlap:

--- a/python/paddle/distributed/fleet/meta_optimizers/dygraph_optimizer/dygraph_sharding_optimizer.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/dygraph_optimizer/dygraph_sharding_optimizer.py
@@ -727,6 +727,25 @@ class DygraphShardingOptimizerV2:
         if self._all_gather_overlap_forward:
             self._layers = layers
 
+    def marked_unused_param(self, unused_param):
+        # In sparse scenarios, some parameters may not have gradients at this step even if stop_gradient are true.
+        # sharding optimzier will fake zero grad to fill the comm_buffer so that ensure gradient can cal reduce normally.
+        if not self.comm_overlap:
+            return
+        unused_param_name = []
+        for param in unused_param:
+            unused_param_name.append(param.name)
+        for buffer in self._comm_buffer_list:
+            for param in buffer._params:
+                if param.name in unused_param_name:
+                    # NOTE(zhangwl): in acc . maybe param_a have grad_a in acc_1 , dnot have grad in acc_2,need support this scene.
+                    param_grad_is_none = True if param.grad is None else False
+                    buffer.add_grad(
+                        param,
+                        use_comm=True,
+                        param_grad_is_none=param_grad_is_none,
+                    )
+
     def register_reduce_overlap_hook(self, use_comm):
         # Register backward hooks for each parameter in the buffer
         for buffer in self._comm_buffer_list:

--- a/python/paddle/distributed/fleet/utils/tensor_fusion_helper.py
+++ b/python/paddle/distributed/fleet/utils/tensor_fusion_helper.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import itertools
 import os
 import weakref
@@ -558,7 +557,8 @@ class FusedCommBuffer:
         for p in self._params:
             self._params_step_dict[p.name] = 0
 
-    def _copy_grad_to_buffer(self, param):
+    def _copy_grad_to_buffer(self, param, param_grad_is_none=False):
+        # if param_grad is not None , skip record grad addr
         if self._params_step_dict[param.name] > 0:
             return
 
@@ -584,9 +584,18 @@ class FusedCommBuffer:
             )
 
         grad_var = param.main_grad if self.use_main_grad else param.grad
+
+        if param_grad_is_none:
+            # NOTE(zhangwl): in acc . maybe param_a have grad_a in acc_1 , dnot have grad in acc_2,need support this scene.
+            assert (
+                grad_var is None
+            ), f"The current parameter[{param.name}] has gradient, its stop_grdient is {param.stop_gradient} , but we excepte it^s grad is None ,  Here are some examples: user marked_unused_param incorrect ,like marked_unused_param when backward unfinished,marked_unused_param which param have grad"
+            return
+
         assert (
             grad_var is not None
         ), f"The current parameter[{param.name}] has no gradient, its stop_grdient is {param.stop_gradient}"
+
         grad_var.stop_gradient = True
         grad_var.flatten_()
 
@@ -620,12 +629,15 @@ class FusedCommBuffer:
             and len(self._params_step_dict) == 0
         )
 
-    def add_grad(self, param, use_comm=True):
+    def add_grad(self, param, use_comm=True, param_grad_is_none=False):
         assert param.name in self._params_step_dict
 
         if not self._release_grads or self._params_step_dict[param.name] > 0:
             current_ptr = get_grad_address(param, self.use_main_grad)
-            if self._grads_to_addr[param.name] != current_ptr:
+            if (
+                self._grads_to_addr[param.name] is not None
+                and self._grads_to_addr[param.name] != current_ptr
+            ):
                 error_message = f"The address of the grad/main_grad of param {param.name} has been changed during training, which is not allowed for dp/sharding overlap with pp. This may be caused by some non-inplace operations on the grad/main_grad. Here are some examples: 1. The grad/main_grad of the param is changed by other operations, such as: clear_grad; 2. Using non-inplace operations on the grad/main_grad, such as: add, sub, mul, div, etc."
                 logger.error(error_message)
                 raise ValueError(error_message)
@@ -633,7 +645,7 @@ class FusedCommBuffer:
             # When release_grads is enabled, fusing of gradients only happen
             # in the 0-th gradient accumulation step, and remain unchanged for
             # the following `acc_steps - 1` steps.
-            self._copy_grad_to_buffer(param)
+            self._copy_grad_to_buffer(param, param_grad_is_none)
 
         self._params_step_dict[param.name] += 1
 


### PR DESCRIPTION
**<!--** TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Distributed Strategy

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
当开启sharding_stage_overlap时，需要comm buffer填满才会触发reduce comm，当参数在一个step没梯度时，comm buffer永远不会触发，导致hang住。本pr支持用户mark_unused_param，标记没有梯度的param，optizmier会跳过等待mark的param，正常触发reduce comm。