### PR TITLE
[AP] Add manual op ap_op.add.

### DIFF
--- a/paddle/ap/include/paddle/hlir/manual_op.h
+++ b/paddle/ap/include/paddle/hlir/manual_op.h
@@ -42,6 +42,23 @@ class IR_API FacadeOp
   bool InferSymbolicShape(pir::InferSymbolicShapeContext *infer_context);
 };
 
+class IR_API AddOp
+    : public pir::Op<AddOp,
+                     pir::ImmutableLayoutTrait,
+                     ::paddle::dialect::InferSymbolicShapeInterface> {
+ public:
+  using Op::Op;
+  static const char *name() { return "ap_op.add"; }
+  static constexpr uint32_t attributes_num = 0;
+  static constexpr const char **attributes_name = nullptr;
+  static void Build(pir::Builder &builder,             // NOLINT
+                    pir::OperationArgument &argument,  // NOLINT
+                    pir::Value lhs,
+                    pir::Value rhs);
+  void VerifySig() const {}
+  bool InferSymbolicShape(pir::InferSymbolicShapeContext *infer_context);
+};
+
 class IR_API UpSpiderOp
     : public pir::Op<UpSpiderOp,
                      pir::SideEffectTrait,
@@ -152,6 +169,7 @@ class IR_API StoreToGlobalOp
 }  // namespace ap::dialect
 
 IR_EXPORT_DECLARE_EXPLICIT_TYPE_ID(ap::dialect::FacadeOp);
+IR_EXPORT_DECLARE_EXPLICIT_TYPE_ID(ap::dialect::AddOp);
 IR_EXPORT_DECLARE_EXPLICIT_TYPE_ID(ap::dialect::UpSpiderOp);
 IR_EXPORT_DECLARE_EXPLICIT_TYPE_ID(ap::dialect::DownSpiderOp);
 IR_EXPORT_DECLARE_EXPLICIT_TYPE_ID(ap::dialect::LoadFromRegisterOp);

--- a/paddle/ap/src/paddle/hlir/op_dialect.cc
+++ b/paddle/ap/src/paddle/hlir/op_dialect.cc
@@ -26,6 +26,7 @@ OperatorDialect::OperatorDialect(::pir::IrContext *context)
 
 void OperatorDialect::initialize() {
   RegisterOp<FacadeOp>();
+  RegisterOp<AddOp>();
   RegisterOp<UpSpiderOp>();
   RegisterOp<DownSpiderOp>();
   RegisterOp<LoadFromRegisterOp>();

--- a/paddle/ap/src/paddle/pass/op_factory.cc
+++ b/paddle/ap/src/paddle/pass/op_factory.cc
@@ -36,6 +36,17 @@ adt::Result<pir::Operation*> ConstructPdOpSum(
   return op;
 }
 
+adt::Result<pir::Operation*> ConstructAddOp(
+    pir::Builder* builder,
+    const std::vector<pir::Value>& inputs,
+    const pir::AttributeMap& attrs) {
+  ADT_CHECK(inputs.size() == 2) << adt::errors::TypeError{
+      std::string() + "'ap_op.add' op takes 2 arguments, but " +
+      std::to_string(inputs.size()) + " were given"};
+  auto op = builder->Build<ap::dialect::AddOp>(inputs.at(0), inputs.at(1));
+  return op;
+}
+
 adt::Result<pir::Operation*> ConstructUpSpiderOp(
     pir::Builder* builder,
     const std::vector<pir::Value>& inputs,
@@ -184,6 +195,10 @@ adt::Result<std::optional<pir::Operation*>> CreateOperation(
   }
   if (op_name == "builtin.shadow_output") {
     ADT_LET_CONST_REF(ret, ConstructShadowOutputOp(builder, inputs, attrs));
+    return ret;
+  }
+  if (op_name == "ap_op.add") {
+    ADT_LET_CONST_REF(ret, ConstructAddOp(builder, inputs, attrs));
     return ret;
   }
   if (op_name == "ap_op.up_spider") {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
pcard-76996

https://github.com/lixinqi/Paddle/pull/5 的部分修改，包括：
1. 新增ap_op.add