### PR TITLE
[SOT][DynamicShape][PHI] Fallback symbolic variable until success when infermeta and fix unfold infermeta

### DIFF
--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -5583,7 +5583,9 @@ void UnfoldInferMeta(const MetaTensor& x,
   std::vector<int> out_dims;
   out_dims.push_back(in_dims[0]);  // NOLINT
   int output_channels =
-      static_cast<int>(in_dims[1] * kernel_sizes[0] * kernel_sizes[1]);
+      in_dims[1] < 0
+          ? -1
+          : static_cast<int>(in_dims[1] * kernel_sizes[0] * kernel_sizes[1]);
   out_dims.push_back(output_channels);
 
   int output_height = phi::funcs::CalcOutputSize(static_cast<int>(in_dims[2]),

--- a/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
@@ -806,7 +806,7 @@ class FunctionGraph:
                 try_infer_meta_with_fallback_symbolic_to_constant(args, kwargs)
             )
         else:
-            out_metas = infer_meta(func, args, kwargs)
+            out_metas = infer_meta(args, kwargs)
 
         self.collect_input_variables(list(args))
         self.collect_input_variables(list(kwargs.values()))

--- a/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
@@ -738,7 +738,7 @@ class FunctionGraph:
                     # TODO(zrr1999): maybe we can continue to fallback to all args are constant.
                     raise BreakGraphError(
                         InferMetaBreak(
-                            f"InferMeta encount {type(err)}, but all args are not symbolic."
+                            f"InferMeta encountered {type(err)}, but all args are not symbolic."
                         )
                     )
 
@@ -764,7 +764,7 @@ class FunctionGraph:
                 ):
                     raise BreakGraphError(
                         InferMetaBreak(
-                            f"InferMeta encount {type(err)}, but all args are not symbolic."
+                            f"InferMeta encountered {type(err)}, but all args are not symbolic."
                         )
                     )
 

--- a/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
@@ -718,68 +718,81 @@ class FunctionGraph:
             func         : the logical function which will be represent as a stmt
         """
 
-        def try_infer_meta_fn(args, kwargs) -> Any:
-            try:
-                metas = convert_to_meta(args)
-                kwmetas = convert_to_meta(kwargs)
-                return args, kwargs, infer_meta_fn(func, *metas, **kwmetas)
-            except (NotSupportedTensorArgumentError, TypeError) as e:
-                bound_arguments = inspect.signature(func).bind(*args, **kwargs)
-                bound_arguments.apply_defaults()
-                if (
-                    isinstance(e, NotSupportedTensorArgumentError)
-                    and e.name in bound_arguments.arguments
+        def infer_meta(args, kwargs):
+            metas = convert_to_meta(args)
+            kwmetas = convert_to_meta(kwargs)
+            return infer_meta_fn(func, *metas, **kwmetas)
+
+        def fallback_symbolic_to_constant(args, kwargs, err):
+            bound_arguments = inspect.signature(func).bind(*args, **kwargs)
+            bound_arguments.apply_defaults()
+            if (
+                isinstance(err, NotSupportedTensorArgumentError)
+                and err.name in bound_arguments.arguments
+            ):
+                original_var = bound_arguments.arguments[err.name]
+                flatten_vars = original_var.flatten_inner_vars()
+                if not any(
+                    isinstance(arg, SymbolicVariable) for arg in flatten_vars
                 ):
-                    original_var = bound_arguments.arguments[e.name]
-                    flatten_vars = original_var.flatten_inner_vars()
-                    if not any(
-                        isinstance(arg, SymbolicVariable)
-                        for arg in flatten_vars
-                    ):
-                        # TODO(zrr1999): maybe we can continue to fallback to all args are constant.
-                        raise BreakGraphError(
-                            InferMetaBreak(
-                                f"InferMeta encount {type(e)}, but all args are not symbolic."
-                            )
+                    # TODO(zrr1999): maybe we can continue to fallback to all args are constant.
+                    raise BreakGraphError(
+                        InferMetaBreak(
+                            f"InferMeta encount {type(err)}, but all args are not symbolic."
                         )
-
-                    args, kwargs = map_if(
-                        (args, kwargs),
-                        pred=lambda x: x is original_var,
-                        true_fn=lambda x: replace_symbolic_var_with_constant_var(
-                            x
-                        ),
-                        false_fn=lambda x: x,
-                    )
-                else:
-                    flatten_vars = reduce(
-                        lambda x, y: (
-                            x + y.flatten_inner_vars()
-                            if isinstance(y, VariableBase)
-                            else x
-                        ),
-                        bound_arguments.arguments.values(),
-                        [],
                     )
 
-                    if not any(
-                        isinstance(arg, SymbolicVariable)
-                        for arg in flatten_vars
-                    ):
-                        raise BreakGraphError(
-                            InferMetaBreak(
-                                f"InferMeta encount {type(e)}, but all args are not symbolic."
-                            )
+                args, kwargs = map_if(
+                    (args, kwargs),
+                    pred=lambda x: x is original_var,
+                    true_fn=lambda x: replace_symbolic_var_with_constant_var(x),
+                    false_fn=lambda x: x,
+                )
+            else:
+                flatten_vars = reduce(
+                    lambda x, y: (
+                        x + y.flatten_inner_vars()
+                        if isinstance(y, VariableBase)
+                        else x
+                    ),
+                    bound_arguments.arguments.values(),
+                    [],
+                )
+
+                if not any(
+                    isinstance(arg, SymbolicVariable) for arg in flatten_vars
+                ):
+                    raise BreakGraphError(
+                        InferMetaBreak(
+                            f"InferMeta encount {type(err)}, but all args are not symbolic."
                         )
-
-                    args, kwargs = map_structure(
-                        replace_symbolic_var_with_constant_var, (args, kwargs)
                     )
 
-                metas = convert_to_meta(args)
-                kwmetas = convert_to_meta(kwargs)
-                return args, kwargs, infer_meta_fn(func, *metas, **kwmetas)
+                args, kwargs = map_structure(
+                    replace_symbolic_var_with_constant_var, (args, kwargs)
+                )
+            return args, kwargs
 
+        def try_infer_meta_with_fallback_symbolic_to_constant(
+            args, kwargs, max_retry_times=10
+        ):
+            try:
+                print("[INFERMETA]", func, args, kwargs)
+                return args, kwargs, infer_meta(args, kwargs)
+            except (NotSupportedTensorArgumentError, TypeError) as e:
+                err = e
+                retry_times = 0
+                while True:
+                    retry_times += 1
+                    if retry_times >= max_retry_times:
+                        raise err
+                    try:
+                        args, kwargs = fallback_symbolic_to_constant(
+                            args, kwargs, err
+                        )
+                        return args, kwargs, infer_meta(args, kwargs)
+                    except (NotSupportedTensorArgumentError, TypeError) as e:
+                        err = e
             except Exception as e:
                 if SotExtraInfo.from_exception(e).need_breakgraph:
                     raise BreakGraphError(
@@ -790,11 +803,11 @@ class FunctionGraph:
                 raise e
 
         if ENV_SOT_ALLOW_DYNAMIC_SHAPE.get():
-            args, kwargs, out_metas = try_infer_meta_fn(args, kwargs)
+            args, kwargs, out_metas = (
+                try_infer_meta_with_fallback_symbolic_to_constant(args, kwargs)
+            )
         else:
-            metas = convert_to_meta(args)
-            kwmetas = convert_to_meta(kwargs)
-            out_metas = infer_meta_fn(func, *metas, **kwmetas)
+            out_metas = infer_meta(func, args, kwargs)
 
         self.collect_input_variables(list(args))
         self.collect_input_variables(list(kwargs.values()))

--- a/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
@@ -777,7 +777,6 @@ class FunctionGraph:
             args, kwargs, max_retry_times=10
         ):
             try:
-                print("[INFERMETA]", func, args, kwargs)
                 return args, kwargs, infer_meta(args, kwargs)
             except (NotSupportedTensorArgumentError, TypeError) as e:
                 err = e

--- a/python/paddle/nn/functional/common.py
+++ b/python/paddle/nn/functional/common.py
@@ -201,9 +201,10 @@ def unfold(
                 "paddings should either be an integer or a list/tuple of 2 or 4 integers"
             )
     else:
-        raise ValueError(
-            "Unexpected type of paddings, it should be either an integer or a list/tuple"
-            "of 2 or 4 integers"
+        raise NotSupportedTensorArgumentError(
+            "Unexpected type of paddings, it should be either an integer or a list/tuple "
+            "of 2 or 4 integers",
+            "paddings",
         )
 
     if in_dynamic_or_pir_mode():


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

当 infermeta 会有多个不支持动态 dim 的参数时，会依次尝试 fallback，直到所有不支持的参数都 fallback 为止

另外修复了 `paddle.nn.functional.unfold` infermeta 在包含 -1 时候错误运算的问题（`in_dims[1]=-1, kernel_sizes[0]=3, kernel_sizes[1]=3` 算出来 `-9`），前序 PR #72522（unfold 问题真多）

<!-- PCard-66972 -->