### PR TITLE
[PHI][CINN] Fix paddle.where api for big tensor

### DIFF
--- a/paddle/phi/kernels/funcs/select_impl.cu.h
+++ b/paddle/phi/kernels/funcs/select_impl.cu.h
@@ -92,12 +92,13 @@ __global__ void GetBlockCountKernel(const InT *in,
                                     OutT *out,
                                     int64_t numel,
                                     int64_t main_offset) {
-  int64_t data_offset = BLOCK_ID_X * BLOCK_NUM_X * VecSize;
-  int64_t stride = BLOCK_NUM_X * GRID_NUM_X * VecSize;
+  int64_t size = static_cast<int64_t>(BLOCK_NUM_X) * VecSize;
+  int64_t data_offset = size * BLOCK_ID_X;
+  int64_t stride = size * GRID_NUM_X;
   int64_t repeat = 0;
   for (; data_offset < main_offset; data_offset += stride) {
     GetBlockCountImpl<InT, OutT, VecSize, false>(
-        in + data_offset, out, BLOCK_NUM_X * VecSize, repeat);
+        in + data_offset, out, size, repeat);
     repeat++;  // to get the real blockIdx
   }
 
@@ -155,12 +156,12 @@ __global__ void CumsumOneBlock(const InT *in,
                                int64_t numel,
                                int64_t main_offset,
                                Functor func) {
-  int64_t stride = BLOCK_NUM_X * VecSize;
+  int64_t stride = static_cast<int64_t>(BLOCK_NUM_X) * VecSize;
   int64_t offset = 0;
   OutT pre_cumsum = static_cast<OutT>(0);
   for (; offset < main_offset; offset += stride) {
     CumsumImpl<InT, OutT, Functor, VecSize, false>(
-        in + offset, out + offset, &pre_cumsum, BLOCK_NUM_X * VecSize, func);
+        in + offset, out + offset, &pre_cumsum, stride, func);
   }
 
   int64_t num = numel - offset;
@@ -265,7 +266,7 @@ __device__ void SelectKernelImpl(OutT *out,
                                  Functor func,
                                  int64_t num,
                                  int64_t data_offset,
-                                 int store_rank) {
+                                 int64_t store_rank) {
   const int kCVecSize = 2;
   // each thread cumsum 2 data
   using IdT = int64_t;
@@ -297,10 +298,9 @@ __device__ void SelectKernelImpl(OutT *out,
   // thread_fix
   kps::Cumsum<IdT, IdT, Add>(&cumsum_thread[0], &num_thread[0], Add());
   // get thread_fix
-  IdT thread_fix =
-      (static_cast<int>(cumsum_thread[0] - num_thread[0]) * store_rank);
+  IdT thread_fix = (cumsum_thread[0] - num_thread[0]) * store_rank;
   // get how many data need to store
-  IdT store_num = static_cast<int>(num_thread[0]) * store_rank;
+  IdT store_num = num_thread[0] * store_rank;
   // thread store num data, each thread may has different num
   // Get store data(index) according to mask_idt
   SelectCaller<OutT, MT, InT, Functor, VecSize, IsBoundary, MaskData> select;
@@ -321,11 +321,11 @@ __global__ void SelectKernel(OutT *out,
                              Functor func,
                              const int64_t numel,
                              int64_t main_offset,
-                             int store_rank) {
-  int64_t data_offset = BLOCK_ID_X * BLOCK_NUM_X * VecSize;
-  int64_t stride = BLOCK_NUM_X * GRID_NUM_X * VecSize;
+                             int64_t store_rank) {
+  int64_t size = static_cast<int64_t>(BLOCK_ID_X) * VecSize;
+  int64_t data_offset = size * BLOCK_NUM_X;
+  int64_t stride = static_cast<int64_t>(BLOCK_NUM_X) * GRID_NUM_X * VecSize;
   int64_t repeat = 0;
-  int64_t size = VecSize * BLOCK_ID_X;
   CT block_store_offset = 0;
   for (; data_offset < main_offset; data_offset += stride) {
     // Cumsum index

--- a/paddle/phi/kernels/funcs/select_impl.cu.h
+++ b/paddle/phi/kernels/funcs/select_impl.cu.h
@@ -121,7 +121,7 @@ template <typename InT,
           int VecSize,
           bool IsBoundary>
 __device__ void CumsumImpl(
-    const InT *in, OutT *out, OutT *pre_cumsum, int64_t num, Functor func) {
+    const InT *in, OutT *out, OutT *pre_cumsum, int num, Functor func) {
   __shared__ OutT max_thread_data;
   OutT temp[VecSize];
   InT arg[VecSize];
@@ -156,7 +156,7 @@ __global__ void CumsumOneBlock(const InT *in,
                                int64_t numel,
                                int64_t main_offset,
                                Functor func) {
-  int64_t stride = static_cast<int64_t>(BLOCK_NUM_X) * VecSize;
+  int64_t stride = BLOCK_NUM_X * VecSize;
   int64_t offset = 0;
   OutT pre_cumsum = static_cast<OutT>(0);
   for (; offset < main_offset; offset += stride) {
@@ -164,7 +164,7 @@ __global__ void CumsumOneBlock(const InT *in,
         in + offset, out + offset, &pre_cumsum, stride, func);
   }
 
-  int64_t num = numel - offset;
+  int num = numel - offset;
   if (num > 0) {
     CumsumImpl<InT, OutT, Functor, VecSize, true>(
         in + offset, out + offset, &pre_cumsum, num, func);

--- a/paddle/phi/kernels/funcs/select_impl.cu.h
+++ b/paddle/phi/kernels/funcs/select_impl.cu.h
@@ -59,14 +59,14 @@ struct NonZeroFunctor {
 template <typename InT, typename OutT, int VecSize, int IsBoundary>
 __device__ void GetBlockCountImpl(const InT *in,
                                   OutT *out,
-                                  int num,
-                                  int repeat) {
+                                  int64_t num,
+                                  int64_t repeat) {
   InT in_data[VecSize];
   OutT temp[VecSize];
   OutT result = static_cast<OutT>(0.0f);
   using Add = kps::AddFunctor<OutT>;
   using Cast = NonZeroFunctor<InT>;
-  int store_fix = BLOCK_ID_X + repeat * GRID_NUM_X;
+  int64_t store_fix = BLOCK_ID_X + repeat * GRID_NUM_X;
 
   kps::Init<InT, VecSize>(&in_data[0], static_cast<InT>(0.0f));
   kps::ReadData<InT, VecSize, 1, IsBoundary>(&in_data[0], in, num);
@@ -92,16 +92,16 @@ __global__ void GetBlockCountKernel(const InT *in,
                                     OutT *out,
                                     int64_t numel,
                                     int64_t main_offset) {
-  int data_offset = BLOCK_ID_X * BLOCK_NUM_X * VecSize;
-  int stride = BLOCK_NUM_X * GRID_NUM_X * VecSize;
-  int repeat = 0;
+  int64_t data_offset = BLOCK_ID_X * BLOCK_NUM_X * VecSize;
+  int64_t stride = BLOCK_NUM_X * GRID_NUM_X * VecSize;
+  int64_t repeat = 0;
   for (; data_offset < main_offset; data_offset += stride) {
     GetBlockCountImpl<InT, OutT, VecSize, false>(
         in + data_offset, out, BLOCK_NUM_X * VecSize, repeat);
     repeat++;  // to get the real blockIdx
   }
 
-  int num = numel - data_offset;
+  int64_t num = numel - data_offset;
   if (num > 0) {
     GetBlockCountImpl<InT, OutT, VecSize, true>(
         in + data_offset, out, num, repeat);
@@ -120,7 +120,7 @@ template <typename InT,
           int VecSize,
           bool IsBoundary>
 __device__ void CumsumImpl(
-    const InT *in, OutT *out, OutT *pre_cumsum, int num, Functor func) {
+    const InT *in, OutT *out, OutT *pre_cumsum, int64_t num, Functor func) {
   __shared__ OutT max_thread_data;
   OutT temp[VecSize];
   InT arg[VecSize];
@@ -150,17 +150,20 @@ __device__ void CumsumImpl(
 
 // Compute this store_offset of this block
 template <typename InT, typename OutT, typename Functor, int VecSize>
-__global__ void CumsumOneBlock(
-    const InT *in, OutT *out, int numel, int main_offset, Functor func) {
-  int stride = BLOCK_NUM_X * VecSize;
-  int offset = 0;
+__global__ void CumsumOneBlock(const InT *in,
+                               OutT *out,
+                               int64_t numel,
+                               int64_t main_offset,
+                               Functor func) {
+  int64_t stride = BLOCK_NUM_X * VecSize;
+  int64_t offset = 0;
   OutT pre_cumsum = static_cast<OutT>(0);
   for (; offset < main_offset; offset += stride) {
     CumsumImpl<InT, OutT, Functor, VecSize, false>(
         in + offset, out + offset, &pre_cumsum, BLOCK_NUM_X * VecSize, func);
   }
 
-  int num = numel - offset;
+  int64_t num = numel - offset;
   if (num > 0) {
     CumsumImpl<InT, OutT, Functor, VecSize, true>(
         in + offset, out + offset, &pre_cumsum, num, func);
@@ -180,10 +183,10 @@ struct SelectCaller {
                                     const MT *mask_data,
                                     const InT *in,
                                     Functor func,
-                                    int data_offset,
-                                    int store_num,
-                                    int thread_fix,
-                                    int num) {
+                                    int64_t data_offset,
+                                    int64_t store_num,
+                                    int64_t thread_fix,
+                                    int64_t num) {
     int64_t in_data[VecSize];
     OutT store_data[VecSize * phi::DDim::kMaxRank];
     // set index
@@ -260,8 +263,8 @@ __device__ void SelectKernelImpl(OutT *out,
                                  const MT *mask,
                                  const InT *in,
                                  Functor func,
-                                 int num,
-                                 int data_offset,
+                                 int64_t num,
+                                 int64_t data_offset,
                                  int store_rank) {
   const int kCVecSize = 2;
   // each thread cumsum 2 data
@@ -294,10 +297,10 @@ __device__ void SelectKernelImpl(OutT *out,
   // thread_fix
   kps::Cumsum<IdT, IdT, Add>(&cumsum_thread[0], &num_thread[0], Add());
   // get thread_fix
-  int thread_fix =
+  IdT thread_fix =
       (static_cast<int>(cumsum_thread[0] - num_thread[0]) * store_rank);
   // get how many data need to store
-  int store_num = static_cast<int>(num_thread[0]) * store_rank;
+  IdT store_num = static_cast<int>(num_thread[0]) * store_rank;
   // thread store num data, each thread may has different num
   // Get store data(index) according to mask_idt
   SelectCaller<OutT, MT, InT, Functor, VecSize, IsBoundary, MaskData> select;
@@ -319,17 +322,19 @@ __global__ void SelectKernel(OutT *out,
                              const int64_t numel,
                              int64_t main_offset,
                              int store_rank) {
-  int data_offset = BLOCK_ID_X * BLOCK_NUM_X * VecSize;
-  int stride = BLOCK_NUM_X * GRID_NUM_X * VecSize;
-  int repeat = 0;
-  int size = VecSize * BLOCK_ID_X;
+  int64_t data_offset = BLOCK_ID_X * BLOCK_NUM_X * VecSize;
+  int64_t stride = BLOCK_NUM_X * GRID_NUM_X * VecSize;
+  int64_t repeat = 0;
+  int64_t size = VecSize * BLOCK_ID_X;
   CT block_store_offset = 0;
   for (; data_offset < main_offset; data_offset += stride) {
     // Cumsum index
-    int idx_cumsum = repeat * GRID_NUM_X + BLOCK_ID_X;
+    int64_t idx_cumsum = repeat * GRID_NUM_X + BLOCK_ID_X;
     kps::details::ReadData<CT>(&block_store_offset, cumsum + idx_cumsum, 1);
-    int out_fix = MaskData < 2 ? block_store_offset * store_rank : data_offset;
-    int in_fix = MaskData < 2 ? data_offset : block_store_offset * store_rank;
+    int64_t out_fix =
+        MaskData < 2 ? block_store_offset * store_rank : data_offset;
+    int64_t in_fix =
+        MaskData < 2 ? data_offset : block_store_offset * store_rank;
     SelectKernelImpl<InT, MT, OutT, Functor, VecSize, MaskData, false>(
         out + out_fix,
         mask + data_offset,
@@ -341,13 +346,15 @@ __global__ void SelectKernel(OutT *out,
     repeat++;
   }
 
-  int num = numel - data_offset;
+  int64_t num = numel - data_offset;
   if (num > 0) {
     // Cumsum index
-    int idx_cumsum = repeat * GRID_NUM_X + BLOCK_ID_X;
+    int64_t idx_cumsum = repeat * GRID_NUM_X + BLOCK_ID_X;
     kps::details::ReadData<CT>(&block_store_offset, cumsum + idx_cumsum, 1);
-    int out_fix = MaskData < 2 ? block_store_offset * store_rank : data_offset;
-    int in_fix = MaskData < 2 ? data_offset : block_store_offset * store_rank;
+    int64_t out_fix =
+        MaskData < 2 ? block_store_offset * store_rank : data_offset;
+    int64_t in_fix =
+        MaskData < 2 ? data_offset : block_store_offset * store_rank;
     SelectKernelImpl<InT, MT, OutT, Functor, VecSize, MaskData, true>(
         out + out_fix,
         mask + data_offset,
@@ -398,19 +405,19 @@ void SelectKernel(const KPDevice &dev_ctx,
   int block = 64;
   auto stream = dev_ctx.x_context()->xpu_stream;
   const int num_per_block = kVecSize * block;
-  const int need_grids = (numel + num_per_block - 1) / num_per_block;
-  const int grid = std::min(need_grids, 8);
+  const int64_t need_grids = (numel + num_per_block - 1) / num_per_block;
+  const int64_t grid = std::min(need_grids, static_cast<int64_t>(8));
 #else
   const int block = 256;
   const int num_per_block = kVecSize * block;
-  const int need_grids = (numel + num_per_block - 1) / num_per_block;
-  const int grid = std::min(need_grids, 256);
+  const int64_t need_grids = (numel + num_per_block - 1) / num_per_block;
+  const int64_t grid = std::min(need_grids, static_cast<int64_t>(256));
   auto stream = dev_ctx.stream();
 #endif
   const int64_t main_offset = Floor(numel, num_per_block);
   // 1.2 alloc tmp data for CoutBlock
-  const int size_count_block = need_grids + 1;
-  std::vector<int> dims_vec = {size_count_block * 2};
+  const int64_t size_count_block = need_grids + 1;
+  std::vector<int64_t> dims_vec = {size_count_block * 2};
   IntArray dims_array(dims_vec);
   DenseTensor count_mem = phi::Empty<CT, KPDevice>(dev_ctx, dims_array);
   CT *count_data = count_mem.data<CT>();
@@ -424,7 +431,7 @@ void SelectKernel(const KPDevice &dev_ctx,
   CT total_true_num = static_cast<CT>(0);  // init
   const int kCumVesize = 2;
   const int block_c = 256;
-  const int main_offset_c = Floor(size_count_block, (kCumVesize * block_c));
+  const int64_t main_offset_c = Floor(size_count_block, (kCumVesize * block_c));
 
   using Add = kps::AddFunctor<CT>;
   CumsumOneBlock<CT, CT, Add, kCumVesize><<<1, block_c, 0, stream>>>(

--- a/paddle/phi/kernels/gpu/where_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/where_grad_kernel.cu
@@ -19,10 +19,10 @@
 
 namespace phi {
 
-template <typename T>
+template <typename T, typename IndexT>
 __global__ void WhereGradCUDAKernel(
-    const int64_t N, const T* dout, const bool* cond, T* dx, T* dy) {
-  int64_t idx = blockDim.x * blockIdx.x + threadIdx.x;
+    const IndexT N, const T* dout, const bool* cond, T* dx, T* dy) {
+  IndexT idx = blockDim.x * blockIdx.x + threadIdx.x;
   for (; idx < N; idx += blockDim.x * gridDim.x) {
     if (dx != nullptr) {
       dx[idx] = cond[idx] ? dout[idx] : static_cast<T>(0.);
@@ -50,9 +50,15 @@ void WhereGradKernel(const Context& ctx,
 
   auto stream = ctx.stream();
   auto config = backends::gpu::GetGpuLaunchConfig1D(ctx, numel);
-  WhereGradCUDAKernel<T>
-      <<<config.block_per_grid.x, config.thread_per_block.x, 0, stream>>>(
-          numel, dout, cond_data, dx, dy);
+  if (numel <= std::numeric_limits<int>::max()) {
+    WhereGradCUDAKernel<T, int>
+        <<<config.block_per_grid.x, config.thread_per_block.x, 0, stream>>>(
+            numel, dout, cond_data, dx, dy);
+  } else {
+    WhereGradCUDAKernel<T, int64_t>
+        <<<config.block_per_grid.x, config.thread_per_block.x, 0, stream>>>(
+            numel, dout, cond_data, dx, dy);
+  }
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/gpu/where_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/where_grad_kernel.cu
@@ -21,8 +21,8 @@ namespace phi {
 
 template <typename T>
 __global__ void WhereGradCUDAKernel(
-    const int N, const T* dout, const bool* cond, T* dx, T* dy) {
-  int idx = blockDim.x * blockIdx.x + threadIdx.x;
+    const int64_t N, const T* dout, const bool* cond, T* dx, T* dy) {
+  int64_t idx = blockDim.x * blockIdx.x + threadIdx.x;
   for (; idx < N; idx += blockDim.x * gridDim.x) {
     if (dx != nullptr) {
       dx[idx] = cond[idx] ? dout[idx] : static_cast<T>(0.);

--- a/paddle/phi/kernels/primitive/datamover_primitives.h
+++ b/paddle/phi/kernels/primitive/datamover_primitives.h
@@ -115,12 +115,12 @@ __device__ __forceinline__ void ReadData(T* dst,
 template <typename Tx, typename Ty, int NX, int NY, bool IsBoundary = false>
 __device__ __forceinline__ void ReadData(Ty* dst,
                                          const Tx* __restrict__ src,
-                                         int64_t size_nx,
-                                         int64_t size_ny,
-                                         int64_t stride_nx,
+                                         int size_nx,
+                                         int size_ny,
+                                         int stride_nx,
                                          int64_t stride_ny) {
-  int64_t thread_offset = static_cast<int64_t>(threadIdx.x);
-  int64_t left_size_nx = size_nx - thread_offset;
+  int thread_offset = threadIdx.x;
+  int left_size_nx = size_nx - thread_offset;
 
   // Each branch is added for better performance
   if (NX == 1 && NY == 1) {  // for NX == 1 and NY == 1
@@ -249,7 +249,7 @@ __device__ __forceinline__ void ReadData(T* dst,
                                          const T* __restrict__ src,
                                          int64_t num) {
   if (IsBoundary) {  // blockDim.x * NX > num
-    int64_t thread_offset = static_cast<int64_t>(threadIdx.x) * NX;
+    int64_t thread_offset = threadIdx.x * NX;
 #pragma unroll
     for (int idx = 0; idx < NX; ++idx) {
       if (idx + thread_offset < num) {
@@ -259,8 +259,7 @@ __device__ __forceinline__ void ReadData(T* dst,
   } else {  // blockDim,x * NX < num
     constexpr int kVectorSize = (NX % 4 == 0) ? 4 : (NX % 2 == 0) ? 2 : 1;
     constexpr int kVectorsPerThread = NX / kVectorSize;
-    int64_t thread_offset =
-        static_cast<int64_t>(threadIdx.x) * kVectorsPerThread;
+    int64_t thread_offset = threadIdx.x * kVectorsPerThread;
 
     using VecType = details::VectorType<T, kVectorSize>;
     const VecType* vec_input = reinterpret_cast<const VecType*>(src);
@@ -297,10 +296,10 @@ __device__ __forceinline__ void ReadData(T* dst,
 template <typename T, int NX, int NY, bool IsBoundary = false>
 __device__ __forceinline__ void ReadData(T* dst,
                                          const T* __restrict__ src,
-                                         int64_t num,
+                                         int num,
                                          int read_lens) {
   if (IsBoundary) {  // blockDim.x * NX > num
-    int64_t thread_offset = static_cast<int64_t>(threadIdx.x) * NX;
+    int thread_offset = threadIdx.x * NX;
 #pragma unroll
     for (int idx = 0; idx < NX; ++idx) {
       if (idx + thread_offset < num) {
@@ -310,8 +309,7 @@ __device__ __forceinline__ void ReadData(T* dst,
   } else {  // blockDim,x * NX < num
     constexpr int kVectorSize = (NX % 4 == 0) ? 4 : (NX % 2 == 0) ? 2 : 1;
     constexpr int kVectorsPerThread = NX / kVectorSize;
-    int64_t thread_offset =
-        static_cast<int64_t>(threadIdx.x) * kVectorsPerThread;
+    int thread_offset = threadIdx.x * kVectorsPerThread;
 
     using VecType = details::VectorType<T, kVectorSize>;
     const VecType* vec_input = reinterpret_cast<const VecType*>(src);
@@ -355,10 +353,10 @@ template <typename T,
           bool IsBoundary = false>
 __device__ __forceinline__ void ReadData(ArgsT* dst,
                                          const T* __restrict__ src,
-                                         int64_t num,
+                                         int num,
                                          int read_lens = 0) {
   if (IsBoundary) {  // blockDim.x * NX > num
-    int64_t thread_offset = static_cast<int64_t>(threadIdx.x) * NX;
+    int thread_offset = threadIdx.x * NX;
 #pragma unroll
     for (int idx = 0; idx < NX; ++idx) {
       if (idx + thread_offset < num) {
@@ -368,8 +366,7 @@ __device__ __forceinline__ void ReadData(ArgsT* dst,
   } else {  // blockDim,x * NX < num
     constexpr int kVectorSize = (NX % 4 == 0) ? 4 : (NX % 2 == 0) ? 2 : 1;
     constexpr int kVectorsPerThread = NX / kVectorSize;
-    int64_t thread_offset =
-        static_cast<int64_t>(threadIdx.x) * kVectorsPerThread;
+    int thread_offset = threadIdx.x * kVectorsPerThread;
 
     using VecType = details::VectorType<T, kVectorSize>;
     const VecType* vec_input = reinterpret_cast<const VecType*>(src);
@@ -560,7 +557,7 @@ __device__ __forceinline__ void WriteData(T* dst,
                                           T* __restrict__ src,
                                           int64_t num) {
   if (IsBoundary) {
-    int64_t thread_offset = static_cast<int64_t>(threadIdx.x) * NX;
+    int64_t thread_offset = threadIdx.x * NX;
 #pragma unroll
     for (int idx = 0; idx < NX; ++idx) {
       if ((thread_offset + idx) < num) {
@@ -572,8 +569,7 @@ __device__ __forceinline__ void WriteData(T* dst,
     constexpr int kVectorSize = (NX % 4 == 0) ? 4 : (NX % 2 == 0) ? 2 : 1;
     constexpr int kVectorsPerThread = NX / kVectorSize;
 
-    int64_t thread_offset =
-        static_cast<int64_t>(threadIdx.x) * kVectorsPerThread;
+    int64_t thread_offset = threadIdx.x * kVectorsPerThread;
     using VecType = details::VectorType<T, kVectorSize>;
     VecType* vec_dst = reinterpret_cast<VecType*>(dst);
     VecType vec_temp[kVectorsPerThread];
@@ -588,10 +584,10 @@ __device__ __forceinline__ void WriteData(T* dst,
 template <typename T, int NX, int NY, bool IsBoundary = false>
 __device__ __forceinline__ void WriteData(T* dst,
                                           T* __restrict__ src,
-                                          int64_t num,
+                                          int num,
                                           int read_lens) {
   if (IsBoundary) {
-    int64_t thread_offset = static_cast<int64_t>(threadIdx.x) * NX;
+    int thread_offset = threadIdx.x * NX;
 #pragma unroll
     for (int idx = 0; idx < NX; ++idx) {
       if ((thread_offset + idx) < num) {
@@ -603,8 +599,7 @@ __device__ __forceinline__ void WriteData(T* dst,
     constexpr int kVectorSize = (NX % 4 == 0) ? 4 : (NX % 2 == 0) ? 2 : 1;
     constexpr int kVectorsPerThread = NX / kVectorSize;
 
-    int64_t thread_offset =
-        static_cast<int64_t>(threadIdx.x) * kVectorsPerThread;
+    int thread_offset = threadIdx.x * kVectorsPerThread;
     using VecType = details::VectorType<T, kVectorSize>;
     VecType* vec_dst = reinterpret_cast<VecType*>(dst);
     VecType vec_temp[kVectorsPerThread];
@@ -645,10 +640,10 @@ template <typename Tx, typename Ty, int NX, int NY, bool IsBoundary = false>
 __device__ __forceinline__ void WriteData(Ty* dst,
                                           const Tx* __restrict__ src,
                                           int64_t size_nx,
-                                          int64_t size_ny,
-                                          int64_t stride_nx,
-                                          int64_t stride_ny) {
-  int64_t thread_offset = static_cast<int64_t>(threadIdx.x);
+                                          int size_ny,
+                                          int stride_nx,
+                                          int stride_ny) {
+  int thread_offset = threadIdx.x;
   int64_t left_size_nx = size_nx - thread_offset;
 
   // Each branch is added for better performance

--- a/paddle/phi/kernels/primitive/datamover_primitives.h
+++ b/paddle/phi/kernels/primitive/datamover_primitives.h
@@ -70,8 +70,8 @@ struct BroadcastConfig {
 template <typename T>
 __device__ __forceinline__ void WriteData(T* dst,
                                           T* __restrict__ src,
-                                          int num) {
-  for (int i = 0; i < num; i++) {
+                                          int64_t num) {
+  for (int64_t i = 0; i < num; i++) {
     dst[i] = src[i];
   }
 }
@@ -79,8 +79,8 @@ __device__ __forceinline__ void WriteData(T* dst,
 template <typename T>
 __device__ __forceinline__ void ReadData(T* dst,
                                          const T* __restrict__ src,
-                                         int num) {
-  for (int i = 0; i < num; i++) {
+                                         int64_t num) {
+  for (int64_t i = 0; i < num; i++) {
     dst[i] = src[i];
   }
 }
@@ -115,12 +115,12 @@ __device__ __forceinline__ void ReadData(T* dst,
 template <typename Tx, typename Ty, int NX, int NY, bool IsBoundary = false>
 __device__ __forceinline__ void ReadData(Ty* dst,
                                          const Tx* __restrict__ src,
-                                         int size_nx,
-                                         int size_ny,
-                                         int stride_nx,
+                                         int64_t size_nx,
+                                         int64_t size_ny,
+                                         int64_t stride_nx,
                                          int64_t stride_ny) {
-  int thread_offset = threadIdx.x;
-  int left_size_nx = size_nx - thread_offset;
+  int64_t thread_offset = static_cast<int64_t>(threadIdx.x);
+  int64_t left_size_nx = size_nx - thread_offset;
 
   // Each branch is added for better performance
   if (NX == 1 && NY == 1) {  // for NX == 1 and NY == 1
@@ -247,9 +247,9 @@ __device__ __forceinline__ void Init(ArgsT* dst, T init_data) {
 template <typename T, int NX, int NY, bool IsBoundary = false>
 __device__ __forceinline__ void ReadData(T* dst,
                                          const T* __restrict__ src,
-                                         int num) {
+                                         int64_t num) {
   if (IsBoundary) {  // blockDim.x * NX > num
-    int thread_offset = threadIdx.x * NX;
+    int64_t thread_offset = static_cast<int64_t>(threadIdx.x) * NX;
 #pragma unroll
     for (int idx = 0; idx < NX; ++idx) {
       if (idx + thread_offset < num) {
@@ -259,7 +259,8 @@ __device__ __forceinline__ void ReadData(T* dst,
   } else {  // blockDim,x * NX < num
     constexpr int kVectorSize = (NX % 4 == 0) ? 4 : (NX % 2 == 0) ? 2 : 1;
     constexpr int kVectorsPerThread = NX / kVectorSize;
-    int thread_offset = threadIdx.x * kVectorsPerThread;
+    int64_t thread_offset =
+        static_cast<int64_t>(threadIdx.x) * kVectorsPerThread;
 
     using VecType = details::VectorType<T, kVectorSize>;
     const VecType* vec_input = reinterpret_cast<const VecType*>(src);
@@ -296,10 +297,10 @@ __device__ __forceinline__ void ReadData(T* dst,
 template <typename T, int NX, int NY, bool IsBoundary = false>
 __device__ __forceinline__ void ReadData(T* dst,
                                          const T* __restrict__ src,
-                                         int num,
+                                         int64_t num,
                                          int read_lens) {
   if (IsBoundary) {  // blockDim.x * NX > num
-    int thread_offset = threadIdx.x * NX;
+    int64_t thread_offset = static_cast<int64_t>(threadIdx.x) * NX;
 #pragma unroll
     for (int idx = 0; idx < NX; ++idx) {
       if (idx + thread_offset < num) {
@@ -309,7 +310,8 @@ __device__ __forceinline__ void ReadData(T* dst,
   } else {  // blockDim,x * NX < num
     constexpr int kVectorSize = (NX % 4 == 0) ? 4 : (NX % 2 == 0) ? 2 : 1;
     constexpr int kVectorsPerThread = NX / kVectorSize;
-    int thread_offset = threadIdx.x * kVectorsPerThread;
+    int64_t thread_offset =
+        static_cast<int64_t>(threadIdx.x) * kVectorsPerThread;
 
     using VecType = details::VectorType<T, kVectorSize>;
     const VecType* vec_input = reinterpret_cast<const VecType*>(src);
@@ -353,10 +355,10 @@ template <typename T,
           bool IsBoundary = false>
 __device__ __forceinline__ void ReadData(ArgsT* dst,
                                          const T* __restrict__ src,
-                                         int num,
+                                         int64_t num,
                                          int read_lens = 0) {
   if (IsBoundary) {  // blockDim.x * NX > num
-    int thread_offset = threadIdx.x * NX;
+    int64_t thread_offset = static_cast<int64_t>(threadIdx.x) * NX;
 #pragma unroll
     for (int idx = 0; idx < NX; ++idx) {
       if (idx + thread_offset < num) {
@@ -366,7 +368,8 @@ __device__ __forceinline__ void ReadData(ArgsT* dst,
   } else {  // blockDim,x * NX < num
     constexpr int kVectorSize = (NX % 4 == 0) ? 4 : (NX % 2 == 0) ? 2 : 1;
     constexpr int kVectorsPerThread = NX / kVectorSize;
-    int thread_offset = threadIdx.x * kVectorsPerThread;
+    int64_t thread_offset =
+        static_cast<int64_t>(threadIdx.x) * kVectorsPerThread;
 
     using VecType = details::VectorType<T, kVectorSize>;
     const VecType* vec_input = reinterpret_cast<const VecType*>(src);
@@ -557,7 +560,7 @@ __device__ __forceinline__ void WriteData(T* dst,
                                           T* __restrict__ src,
                                           int64_t num) {
   if (IsBoundary) {
-    int64_t thread_offset = threadIdx.x * NX;
+    int64_t thread_offset = static_cast<int64_t>(threadIdx.x) * NX;
 #pragma unroll
     for (int idx = 0; idx < NX; ++idx) {
       if ((thread_offset + idx) < num) {
@@ -569,7 +572,8 @@ __device__ __forceinline__ void WriteData(T* dst,
     constexpr int kVectorSize = (NX % 4 == 0) ? 4 : (NX % 2 == 0) ? 2 : 1;
     constexpr int kVectorsPerThread = NX / kVectorSize;
 
-    int64_t thread_offset = threadIdx.x * kVectorsPerThread;
+    int64_t thread_offset =
+        static_cast<int64_t>(threadIdx.x) * kVectorsPerThread;
     using VecType = details::VectorType<T, kVectorSize>;
     VecType* vec_dst = reinterpret_cast<VecType*>(dst);
     VecType vec_temp[kVectorsPerThread];
@@ -584,10 +588,10 @@ __device__ __forceinline__ void WriteData(T* dst,
 template <typename T, int NX, int NY, bool IsBoundary = false>
 __device__ __forceinline__ void WriteData(T* dst,
                                           T* __restrict__ src,
-                                          int num,
+                                          int64_t num,
                                           int read_lens) {
   if (IsBoundary) {
-    int thread_offset = threadIdx.x * NX;
+    int64_t thread_offset = static_cast<int64_t>(threadIdx.x) * NX;
 #pragma unroll
     for (int idx = 0; idx < NX; ++idx) {
       if ((thread_offset + idx) < num) {
@@ -599,7 +603,8 @@ __device__ __forceinline__ void WriteData(T* dst,
     constexpr int kVectorSize = (NX % 4 == 0) ? 4 : (NX % 2 == 0) ? 2 : 1;
     constexpr int kVectorsPerThread = NX / kVectorSize;
 
-    int thread_offset = threadIdx.x * kVectorsPerThread;
+    int64_t thread_offset =
+        static_cast<int64_t>(threadIdx.x) * kVectorsPerThread;
     using VecType = details::VectorType<T, kVectorSize>;
     VecType* vec_dst = reinterpret_cast<VecType*>(dst);
     VecType vec_temp[kVectorsPerThread];
@@ -640,10 +645,10 @@ template <typename Tx, typename Ty, int NX, int NY, bool IsBoundary = false>
 __device__ __forceinline__ void WriteData(Ty* dst,
                                           const Tx* __restrict__ src,
                                           int64_t size_nx,
-                                          int size_ny,
-                                          int stride_nx,
-                                          int stride_ny) {
-  int thread_offset = threadIdx.x;
+                                          int64_t size_ny,
+                                          int64_t stride_nx,
+                                          int64_t stride_ny) {
+  int64_t thread_offset = static_cast<int64_t>(threadIdx.x);
   int64_t left_size_nx = size_nx - thread_offset;
 
   // Each branch is added for better performance
@@ -848,8 +853,9 @@ __device__ __forceinline__ void ReadDataBc(
  * init_data: The register pointer of init data, the size is NX.
  */
 template <typename T, int NX, int NY>
-__device__ __forceinline__ void InitWithDataIndex(T* dst, int block_offset) {
-  int thread_offset = block_offset + threadIdx.x * NX;
+__device__ __forceinline__ void InitWithDataIndex(T* dst,
+                                                  int64_t block_offset) {
+  int64_t thread_offset = block_offset + threadIdx.x * NX;
 #pragma unroll
   for (int nx = 0; nx < NX; ++nx) {
     dst[nx] = static_cast<T>(thread_offset + nx);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-85711

修复 paddle.where（底层涉及 SelectKernel 和 WhereGradCUDAKernel）访存下标 int 溢出问题

性能：SelectKernel int64 性能下降约 2% (未实现模版)，WhereGradCUDAKernel int64 性能下降约 10%（已实现模版）