### PR TITLE
[0-size Tensor No.27、290] Add 0-size Tensor support for broadcast_to API.

### DIFF
--- a/paddle/phi/kernels/gpu/expand_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/expand_grad_kernel.cu
@@ -17,6 +17,7 @@
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/funcs/reduce_function.h"
 #include "paddle/phi/kernels/reduce_sum_kernel.h"
 
@@ -29,6 +30,11 @@ void ExpandGradKernel(const Context& ctx,
                       const IntArray& shape,
                       DenseTensor* x_grad) {
   ctx.template Alloc<T>(x_grad);
+  if ((x_grad && x_grad->numel() == 0) || out_grad.numel() == 0) {
+    phi::Full<T, Context>(
+        ctx, phi::IntArray(common::vectorize(x_grad->dims())), 0, x_grad);
+    return;
+  }
   if (x_grad->dims() == out_grad.dims()) {
     phi::Copy(ctx, out_grad, ctx.GetPlace(), false, x_grad);
   } else {

--- a/paddle/phi/kernels/impl/expand_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/expand_grad_kernel_impl.h
@@ -55,10 +55,13 @@ void ExpandGradKernel(const Context& ctx,
                       DenseTensor* in_grad) {
   auto expand_shape = shape.GetData();
   auto x_dims = x.dims();
-  if (out_grad.numel() == 0 || (in_grad && in_grad->numel() == 0)) {
+  if (x.numel() == 0 || out_grad.numel() == 0 ||
+      (in_grad && in_grad->numel() == 0)) {
     ctx.template Alloc<T>(in_grad);
-    phi::Full<T, Context>(
-        ctx, phi::IntArray(common::vectorize(in_grad->dims())), 0, in_grad);
+    if (in_grad->numel() != 0) {
+      phi::Full<T, Context>(
+          ctx, phi::IntArray(common::vectorize(in_grad->dims())), 0, in_grad);
+    }
     return;
   }
 

--- a/paddle/phi/kernels/impl/expand_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/expand_grad_kernel_impl.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "paddle/phi/core/tensor_utils.h"
+#include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/funcs/eigen/common.h"
 #include "paddle/phi/kernels/funcs/eigen/eigen_function.h"
 #include "paddle/phi/kernels/impl/expand_kernel_impl.h"
@@ -54,6 +55,12 @@ void ExpandGradKernel(const Context& ctx,
                       DenseTensor* in_grad) {
   auto expand_shape = shape.GetData();
   auto x_dims = x.dims();
+  if (out_grad.numel() == 0 || (in_grad && in_grad->numel() == 0)) {
+    ctx.template Alloc<T>(in_grad);
+    phi::Full<T, Context>(
+        ctx, phi::IntArray(common::vectorize(in_grad->dims())), 0, in_grad);
+    return;
+  }
 
   if (in_grad->dims() == out_grad.dims()) {
     phi::Copy(ctx, out_grad, ctx.GetPlace(), false, in_grad);

--- a/paddle/phi/kernels/onednn/expand_kernel.cc
+++ b/paddle/phi/kernels/onednn/expand_kernel.cc
@@ -57,7 +57,7 @@ void ExpandKernel(const Context& dev_ctx,
             "The expanded size (%d) for non-existing dimensions must be "
             "positive for expand_v2 op.",
             out_new_dims[i]));
-            
+
     PADDLE_ENFORCE_GE(
         x_vec_dims[i],
         0,

--- a/paddle/phi/kernels/onednn/expand_kernel.cc
+++ b/paddle/phi/kernels/onednn/expand_kernel.cc
@@ -39,16 +39,51 @@ void ExpandKernel(const Context& dev_ctx,
   auto x_vec_dims = common::vectorize(x.dims());
 
   auto out_new_dims = shape.GetData();
+  bool has_zero_size = false;
 
   for (size_t i = 0; i < out_new_dims.size(); ++i) {
-    out_new_dims[i] = out_new_dims[i] > 0 ? out_new_dims[i] : x_vec_dims[i];
+    out_new_dims[i] = out_new_dims[i] >= 0 ? out_new_dims[i] : x_vec_dims[i];
   }
 
   if (x_vec_dims.size() != out_new_dims.size()) {
     x_vec_dims = GetExtendedXDims(x_vec_dims, out_new_dims.size());  // NOLINT
   }
 
+  for (size_t i = 0; i < x_vec_dims.size(); ++i) {
+    PADDLE_ENFORCE_GE(
+        out_new_dims[i],
+        0,
+        common::errors::InvalidArgument(
+            "The expanded size (%d) for non-existing dimensions must be "
+            "positive for expand_v2 op.",
+            out_new_dims[i]));
+            
+    PADDLE_ENFORCE_GE(
+        x_vec_dims[i],
+        0,
+        common::errors::InvalidArgument(
+            "The expanded size (%d) for non-existing dimensions must be "
+            "positive for expand_v2 op.",
+            x_vec_dims[i]));
+
+    PADDLE_ENFORCE_EQ(
+        x_vec_dims[i] == 1 || x_vec_dims[i] == out_new_dims[i],
+        true,
+        common::errors::InvalidArgument(
+            "The value (%d) of the non-singleton dimension does not match"
+            " the corresponding value (%d) in shape for expand_v2 op.",
+            x_vec_dims[i],
+            out_new_dims[i]));
+    if (out_new_dims[i] == 0) {
+      has_zero_size = true;
+    }
+  }
+
   out->Resize(common::make_ddim(out_new_dims));
+  if (has_zero_size) {
+    dev_ctx.template Alloc<T>(out);
+    return;
+  }
   funcs::BroadcastDataOneDNNHandler<T> handler(dnnl::algorithm::binary_add,
                                                onednn_engine,
                                                dev_ctx.GetPlace(),

--- a/test/legacy_test/test_expand_v2_op.py
+++ b/test/legacy_test/test_expand_v2_op.py
@@ -684,12 +684,18 @@ class TestExpandPirValueListShape(unittest.TestCase):
                 x = paddle.expand(x, shape=[shape1, 1, -1, -1])
                 np.testing.assert_equal(tuple(x.shape), (-1, 1, -1, -1))
 
+
 class TestExpandV2OneDNNOp(OpTest):
     def setUp(self):
         self.op_type = "expand_v2"
         self.init_data()
-        self.x = np.random.random(self.ori_shape).astype("float32")
-        self.attrs = {'shape': self.shape, 'use_mkldnn': True}
+        self.python_api = paddle.expand
+        self.x = np.zeros(self.ori_shape).astype("float32")
+        self.attrs = {
+            'shape': self.shape,
+            'use_mkldnn': True,
+            'dtype': int(paddle.float32),
+        }
         self.set_inputs()
         self.set_additional_inputs()
         output = np.zeros(self.expect_shape).astype("float32")
@@ -702,30 +708,90 @@ class TestExpandV2OneDNNOp(OpTest):
         pass
 
     def init_data(self):
-        self.ori_shape = [1, 1, 1, 140]
-        self.shape = [2, 3, 0, 140]
-        self.expect_shape = [2, 3, 0, 140]
+        self.ori_shape = [1, 0, 1, 140]
+        self.shape = [1, 0, 1, 140]
+        self.expect_shape = [1, 0, 1, 140]
 
     def test_check_output(self):
-        self.check_output_with_place(core.CPUPlace(), check_pir_onednn=True,check_dygraph=False)
-        
-    # def test_check_grad(self):
-    #     self.check_grad_with_place(
-    #         core.CPUPlace(), ["X"], "Out", check_pir_onednn=True, check_dygraph=False
-    #     )
+        self.check_output_with_place(
+            core.CPUPlace(), check_pir_onednn=True, check_dygraph=False
+        )
+
+    def test_check_grad(self):
+        self.check_grad_with_place(
+            core.CPUPlace(),
+            ["X"],
+            "Out",
+            check_pir_onednn=True,
+            check_dygraph=False,
+        )
+
+
 class TestExpandV2ZeroSizeOneDNNOp(TestExpandV2OneDNNOp):
 
     def init_data(self):
-        self.ori_shape = (1, 3)
-        self.shape = (0, 3)
-        self.expect_shape = (0, 3)
+        self.ori_shape = (0, 130)
+        self.shape = (4, 0, 130)
+        self.expect_shape = (4, 0, 130)
+
 
 class TestExpandV2ZeroSizeOneDNNOp2(TestExpandV2OneDNNOp):
 
     def init_data(self):
-        self.ori_shape = (1, 3)
-        self.shape = (1, 0, 3)
-        self.expect_shape = (1, 0, 3)
+        self.ori_shape = (0, 1, 8)
+        self.shape = (0, 8, 8)
+        self.expect_shape = (0, 8, 8)
+
+
+class TestExpandV2GPUOp(TestExpandV2OneDNNOp):
+    def test_check_output(self):
+        self.check_output_with_place(core.CUDAPlace(0), check_dygraph=True)
+
+    def test_check_grad(self):
+        if core.is_compiled_with_cuda():
+            self.check_grad_with_place(
+                core.CUDAPlace(0), ["X"], "Out", check_dygraph=True
+            )
+
+
+class TestExpandV2ZeroSizeGPUOp(TestExpandV2GPUOp):
+    def init_data(self):
+        self.ori_shape = (0, 130)
+        self.shape = (4, 0, 130)
+        self.expect_shape = (4, 0, 130)
+
+
+class TestExpandV2ZeroSizeGPUOp2(TestExpandV2GPUOp):
+    def init_data(self):
+        self.ori_shape = (0, 1)
+        self.shape = (0, 8)
+        self.expect_shape = (0, 8)
+
+
+class TestExpandV2CPUOp(TestExpandV2OneDNNOp):
+    def test_check_output(self):
+        self.check_output_with_place(core.CPUPlace(), check_dygraph=True)
+
+    def test_check_grad(self):
+        if core.is_compiled_with_cuda():
+            self.check_grad_with_place(
+                core.CPUPlace(), ["X"], "Out", check_dygraph=True
+            )
+
+
+class TestExpandV2CPUOp1(TestExpandV2CPUOp):
+    def init_data(self):
+        self.ori_shape = (0, 1)
+        self.shape = (0, 8)
+        self.expect_shape = (0, 8)
+
+
+class TestExpandV2CPUOp2(TestExpandV2CPUOp):
+    def init_data(self):
+        self.ori_shape = (0, 130)
+        self.shape = (4, 0, 130)
+        self.expect_shape = (4, 0, 130)
+
 
 if __name__ == "__main__":
     paddle.enable_static()

--- a/test/legacy_test/test_expand_v2_op.py
+++ b/test/legacy_test/test_expand_v2_op.py
@@ -685,20 +685,19 @@ class TestExpandPirValueListShape(unittest.TestCase):
                 np.testing.assert_equal(tuple(x.shape), (-1, 1, -1, -1))
 
 
-class TestExpandV2OneDNNOp(OpTest):
+class TestExpandV2ZeroSizeOp(OpTest):
     def setUp(self):
         self.op_type = "expand_v2"
         self.init_data()
+        self.init_place()
         self.python_api = paddle.expand
-        self.x = np.zeros(self.ori_shape).astype("float32")
+        self.x = np.zeros(self.ori_shape).astype("float64")
         self.attrs = {
             'shape': self.shape,
-            'use_mkldnn': True,
-            'dtype': int(paddle.float32),
         }
         self.set_inputs()
         self.set_additional_inputs()
-        output = np.zeros(self.expect_shape).astype("float32")
+        output = np.zeros(self.expect_shape).astype("float64")
         self.outputs = {'Out': output}
 
     def set_inputs(self):
@@ -712,85 +711,65 @@ class TestExpandV2OneDNNOp(OpTest):
         self.shape = [1, 0, 1, 140]
         self.expect_shape = [1, 0, 1, 140]
 
+    def init_place(self):
+        self.place = core.CPUPlace()
+
     def test_check_output(self):
-        self.check_output_with_place(
-            core.CPUPlace(), check_pir_onednn=True, check_dygraph=False
-        )
+        self.check_output_with_place(self.place, check_dygraph=False)
 
     def test_check_grad(self):
         self.check_grad_with_place(
-            core.CPUPlace(),
+            self.place,
             ["X"],
             "Out",
-            check_pir_onednn=True,
             check_dygraph=False,
         )
 
 
-class TestExpandV2ZeroSizeOneDNNOp(TestExpandV2OneDNNOp):
-
-    def init_data(self):
-        self.ori_shape = (0, 130)
-        self.shape = (4, 0, 130)
-        self.expect_shape = (4, 0, 130)
-
-
-class TestExpandV2ZeroSizeOneDNNOp2(TestExpandV2OneDNNOp):
-
-    def init_data(self):
-        self.ori_shape = (0, 1, 8)
-        self.shape = (0, 8, 8)
-        self.expect_shape = (0, 8, 8)
-
-
-class TestExpandV2GPUOp(TestExpandV2OneDNNOp):
-    def test_check_output(self):
-        self.check_output_with_place(core.CUDAPlace(0), check_dygraph=True)
-
-    def test_check_grad(self):
-        if core.is_compiled_with_cuda():
-            self.check_grad_with_place(
-                core.CUDAPlace(0), ["X"], "Out", check_dygraph=True
-            )
-
-
-class TestExpandV2ZeroSizeGPUOp(TestExpandV2GPUOp):
-    def init_data(self):
-        self.ori_shape = (0, 130)
-        self.shape = (4, 0, 130)
-        self.expect_shape = (4, 0, 130)
-
-
-class TestExpandV2ZeroSizeGPUOp2(TestExpandV2GPUOp):
+class TestExpandV2CPUOp1(TestExpandV2ZeroSizeOp):
     def init_data(self):
         self.ori_shape = (0, 1)
         self.shape = (0, 8)
         self.expect_shape = (0, 8)
 
 
-class TestExpandV2CPUOp(TestExpandV2OneDNNOp):
-    def test_check_output(self):
-        self.check_output_with_place(core.CPUPlace(), check_dygraph=True)
-
-    def test_check_grad(self):
-        if core.is_compiled_with_cuda():
-            self.check_grad_with_place(
-                core.CPUPlace(), ["X"], "Out", check_dygraph=True
-            )
-
-
-class TestExpandV2CPUOp1(TestExpandV2CPUOp):
-    def init_data(self):
-        self.ori_shape = (0, 1)
-        self.shape = (0, 8)
-        self.expect_shape = (0, 8)
-
-
-class TestExpandV2CPUOp2(TestExpandV2CPUOp):
+class TestExpandV2CPUOp2(TestExpandV2ZeroSizeOp):
     def init_data(self):
         self.ori_shape = (0, 130)
         self.shape = (4, 0, 130)
         self.expect_shape = (4, 0, 130)
+
+
+@unittest.skipIf(
+    not core.is_compiled_with_cuda(),
+    "core is not compiled with CUDA",
+)
+class TestExpandV2ZeroSizeGPUOp(TestExpandV2ZeroSizeOp):
+
+    def init_place(self):
+        self.place = core.CUDAPlace(0)
+
+
+@unittest.skipIf(
+    not core.is_compiled_with_cuda(),
+    "core is not compiled with CUDA",
+)
+class TestExpandV2ZeroSizeGPUOp1(TestExpandV2ZeroSizeGPUOp):
+    def init_data(self):
+        self.ori_shape = (0, 130)
+        self.shape = (4, 0, 130)
+        self.expect_shape = (4, 0, 130)
+
+
+@unittest.skipIf(
+    not core.is_compiled_with_cuda(),
+    "core is not compiled with CUDA",
+)
+class TestExpandV2ZeroSizeGPUOp2(TestExpandV2ZeroSizeGPUOp):
+    def init_data(self):
+        self.ori_shape = (0, 1)
+        self.shape = (0, 8)
+        self.expect_shape = (0, 8)
 
 
 if __name__ == "__main__":

--- a/test/legacy_test/test_expand_v2_op.py
+++ b/test/legacy_test/test_expand_v2_op.py
@@ -772,6 +772,61 @@ class TestExpandV2ZeroSizeGPUOp2(TestExpandV2ZeroSizeGPUOp):
         self.expect_shape = (0, 8)
 
 
+class TestExpandV2ZeroSizeOneDNNOp(TestExpandV2ZeroSizeOp):
+    def setUp(self):
+        self.op_type = "expand_v2"
+        self.init_data()
+        self.init_place()
+        self.python_api = paddle.expand
+        self.x = np.zeros(self.ori_shape).astype("float32")
+        self.attrs = {'shape': self.shape, 'use_mkldnn': True}
+        self.use_mkldnn = True
+        self.set_inputs()
+        self.set_additional_inputs()
+        output = np.zeros(self.expect_shape).astype("float32")
+        self.outputs = {'Out': output}
+
+    def init_data(self):
+        self.ori_shape = [1, 0, 1, 140]
+        self.shape = [1, 0, 1, 140]
+        self.expect_shape = [1, 0, 1, 140]
+
+    def init_place(self):
+        self.place = core.CPUPlace()
+
+    def test_check_output(self):
+        self.check_output_with_place(
+            self.place,
+            check_dygraph=False,
+            check_pir=True,
+            check_pir_onednn=True,
+        )
+
+    def test_check_grad(self):
+        self.check_grad_with_place(
+            self.place,
+            ["X"],
+            "Out",
+            check_dygraph=False,
+            check_pir=True,
+            check_pir_onednn=True,
+        )
+
+
+class TestExpandV2ZeroSizeOneDNNOp1(TestExpandV2ZeroSizeOneDNNOp):
+    def init_data(self):
+        self.ori_shape = (0, 130)
+        self.shape = (4, 0, 130)
+        self.expect_shape = (4, 0, 130)
+
+
+class TestExpandV2ZeroSizeOneDNNOp2(TestExpandV2ZeroSizeOneDNNOp):
+    def init_data(self):
+        self.ori_shape = (0, 1, 8)
+        self.shape = (0, 8, 8)
+        self.expect_shape = (0, 8, 8)
+
+
 if __name__ == "__main__":
     paddle.enable_static()
     unittest.main()

--- a/test/legacy_test/test_expand_v2_op.py
+++ b/test/legacy_test/test_expand_v2_op.py
@@ -684,6 +684,48 @@ class TestExpandPirValueListShape(unittest.TestCase):
                 x = paddle.expand(x, shape=[shape1, 1, -1, -1])
                 np.testing.assert_equal(tuple(x.shape), (-1, 1, -1, -1))
 
+class TestExpandV2OneDNNOp(OpTest):
+    def setUp(self):
+        self.op_type = "expand_v2"
+        self.init_data()
+        self.x = np.random.random(self.ori_shape).astype("float32")
+        self.attrs = {'shape': self.shape, 'use_mkldnn': True}
+        self.set_inputs()
+        self.set_additional_inputs()
+        output = np.zeros(self.expect_shape).astype("float32")
+        self.outputs = {'Out': output}
+
+    def set_inputs(self):
+        self.inputs = {'X': self.x}
+
+    def set_additional_inputs(self):
+        pass
+
+    def init_data(self):
+        self.ori_shape = [1, 1, 1, 140]
+        self.shape = [2, 3, 0, 140]
+        self.expect_shape = [2, 3, 0, 140]
+
+    def test_check_output(self):
+        self.check_output_with_place(core.CPUPlace(), check_pir_onednn=True,check_dygraph=False)
+        
+    # def test_check_grad(self):
+    #     self.check_grad_with_place(
+    #         core.CPUPlace(), ["X"], "Out", check_pir_onednn=True, check_dygraph=False
+    #     )
+class TestExpandV2ZeroSizeOneDNNOp(TestExpandV2OneDNNOp):
+
+    def init_data(self):
+        self.ori_shape = (1, 3)
+        self.shape = (0, 3)
+        self.expect_shape = (0, 3)
+
+class TestExpandV2ZeroSizeOneDNNOp2(TestExpandV2OneDNNOp):
+
+    def init_data(self):
+        self.ori_shape = (1, 3)
+        self.shape = (1, 0, 3)
+        self.expect_shape = (1, 0, 3)
 
 if __name__ == "__main__":
     paddle.enable_static()

--- a/test/legacy_test/test_expand_v2_op.py
+++ b/test/legacy_test/test_expand_v2_op.py
@@ -795,22 +795,28 @@ class TestExpandV2ZeroSizeOneDNNOp(TestExpandV2ZeroSizeOp):
         self.place = core.CPUPlace()
 
     def test_check_output(self):
+        flags_use_mkldnn = core.globals()["FLAGS_use_mkldnn"]
+        paddle.set_flags({'FLAGS_use_mkldnn': True})
         self.check_output_with_place(
             self.place,
             check_dygraph=False,
-            check_pir=True,
+            check_pir=False,
             check_pir_onednn=True,
         )
+        paddle.set_flags({'FLAGS_use_mkldnn': flags_use_mkldnn})
 
     def test_check_grad(self):
+        flags_use_mkldnn = core.globals()["FLAGS_use_mkldnn"]
+        paddle.set_flags({'FLAGS_use_mkldnn': True})
         self.check_grad_with_place(
             self.place,
             ["X"],
             "Out",
             check_dygraph=False,
-            check_pir=True,
+            check_pir=False,
             check_pir_onednn=True,
         )
+        paddle.set_flags({'FLAGS_use_mkldnn': flags_use_mkldnn})
 
 
 class TestExpandV2ZeroSizeOneDNNOp1(TestExpandV2ZeroSizeOneDNNOp):

--- a/test/mkldnn/test_expand_v2_mkldnn_op.py
+++ b/test/mkldnn/test_expand_v2_mkldnn_op.py
@@ -172,30 +172,6 @@ create_expand_v2_bf16_test_class(TestExpandV2ExpandShapesTensor2OneDNNOp)
 create_expand_v2_bf16_test_class(TestExpandV2ShapesTensorOneDNNOp)
 
 
-class TestExpandV2OneDNNOpZeroSize(TestExpandV2OneDNNOp):
-    def setUp(self):
-        self.op_type = "expand_v2"
-        self.init_data()
-        self.x = np.random.random(self.ori_shape).astype("float32")
-        self.attrs = {'shape': self.shape, 'use_mkldnn': True}
-        self.set_inputs()
-        output = np.zeros(self.expect_shape)
-        self.outputs = {'Out': output}
-
-    def init_data(self):
-        self.ori_shape = (0, 130)
-        self.shape = (4, 0, 130)
-        self.expect_shape = (4, 0, 130)
-
-
-class TestExpandV2OneDNNOpZeroSize1(TestExpandV2OneDNNOpZeroSize):
-
-    def init_data(self):
-        self.ori_shape = (0, 1, 8)
-        self.shape = (0, 8, 8)
-        self.expect_shape = (0, 8, 8)
-
-
 if __name__ == '__main__':
     paddle.enable_static()
     unittest.main()

--- a/test/mkldnn/test_expand_v2_mkldnn_op.py
+++ b/test/mkldnn/test_expand_v2_mkldnn_op.py
@@ -171,6 +171,31 @@ create_expand_v2_bf16_test_class(TestExpandV2ExpandShapesTensor1OneDNNOp)
 create_expand_v2_bf16_test_class(TestExpandV2ExpandShapesTensor2OneDNNOp)
 create_expand_v2_bf16_test_class(TestExpandV2ShapesTensorOneDNNOp)
 
+
+class TestExpandV2OneDNNOpZeroSize(TestExpandV2OneDNNOp):
+    def setUp(self):
+        self.op_type = "expand_v2"
+        self.init_data()
+        self.x = np.random.random(self.ori_shape).astype("float32")
+        self.attrs = {'shape': self.shape, 'use_mkldnn': True}
+        self.set_inputs()
+        output = np.zeros(self.expect_shape)
+        self.outputs = {'Out': output}
+
+    def init_data(self):
+        self.ori_shape = (0, 130)
+        self.shape = (4, 0, 130)
+        self.expect_shape = (4, 0, 130)
+
+
+class TestExpandV2OneDNNOpZeroSize1(TestExpandV2OneDNNOpZeroSize):
+
+    def init_data(self):
+        self.ori_shape = (0, 1, 8)
+        self.shape = (0, 8, 8)
+        self.expect_shape = (0, 8, 8)
+
+
 if __name__ == '__main__':
     paddle.enable_static()
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
对 https://github.com/PaddlePaddle/Paddle/pull/70125 的完善。
https://github.com/PaddlePaddle/Paddle/pull/70125 中未对OneDNN对应的kernel进行更改，而且OneDNN存在很明显的问题。
OneDNN中的expand kernel对shape中存在0的情况未进行处理。进而不支持如下几个case：
![image](https://github.com/user-attachments/assets/2311be55-bdc3-4652-ad0b-7e3a10ecedf9)
![image](https://github.com/user-attachments/assets/d8e8792e-849f-437a-afd4-e87b0878b5f5)
 这几个case在torch中能正常执行，但是在paddle broadcast_to OneDNN 版本中输出的shape和torch中的shape不一致。

**修复方法：**
- 在OneDNN 的ExpandKernel添加对shape中存在0这一情况的处理
- 添加OneDNN Expand的单测

Pcard-67164