### PR TITLE
XPU cudaHostAlloc use cudaHostAllocDefault flag

### DIFF
--- a/paddle/phi/core/memory/allocation/system_allocator.cc
+++ b/paddle/phi/core/memory/allocation/system_allocator.cc
@@ -324,6 +324,8 @@ void* XPUPinnedAllocator::Alloc(size_t* index, size_t size) {
   void* p = nullptr;
   VLOG(6) << "Calling cudaHostAlloc for " << size << " bytes";
   // PINNED memory is visible to all CUDA contexts.
+  // FIXME(yangjianbang): XPU does not support cudaHostAllocPortable with
+  // multiple cuda contexts yet.
   cudaError_t result = cudaHostAlloc(&p, size, cudaHostAllocDefault);
   VLOG(6) << "cudaHostAlloc returned: " << result;
 

--- a/paddle/phi/core/memory/allocation/system_allocator.cc
+++ b/paddle/phi/core/memory/allocation/system_allocator.cc
@@ -324,7 +324,7 @@ void* XPUPinnedAllocator::Alloc(size_t* index, size_t size) {
   void* p = nullptr;
   VLOG(6) << "Calling cudaHostAlloc for " << size << " bytes";
   // PINNED memory is visible to all CUDA contexts.
-  cudaError_t result = cudaHostAlloc(&p, size, cudaHostAllocPortable);
+  cudaError_t result = cudaHostAlloc(&p, size, cudaHostAllocDefault);
   VLOG(6) << "cudaHostAlloc returned: " << result;
 
   if (result == cudaSuccess) {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Custom Device

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
XPU cudaHostAlloc use cudaHostAllocDefault flag because cudaHostAllocPortable has bug.

#### 目前XPU runtime现状：
- 单进程单设备+portable = 不加portable
- 单进程多设备+portable 才会有特殊处理

因此单测里面使用`cudaHostAllocPortable`不会报错，而在模型里面由于使用了单进程多设备，cudaHostAlloc会失败，而实际上内存是够的：
<img width="1191" alt="53fcdb5b7ee86d4cde5d23e0b24f3096" src="https://github.com/user-attachments/assets/980df456-f7c7-4b1c-af16-b9487cbebd51" />

<img width="1527" alt="e12087574097c187cc50a9ce26f496e3" src="https://github.com/user-attachments/assets/203c6713-ca94-443f-b8da-17ad637f3c4e" />

<img width="1332" alt="e965601975d0133349b712c83788dad4" src="https://github.com/user-attachments/assets/a45534d7-0225-4f41-969e-1f4cddcde107" />

#### 临时使用`cudaHostAllocDefault` flag可能引发的问题：
- 如果cudaMemAllocHost只在cudaSetDevice的当前设备上用，就没有问题。如果后面Set了其他设备，又发起了Memcpy，就会有问题
- 跨Device/Context使用cudaMemAllocHost分配的内存的场景为DataLoader异步线程load，但是能够保证触发该case时memcpy runtime调用能够正确报错，不会触发隐式错误，因此该问题delay到之后fix