### PR TITLE
[CINN] Fixed arange nullary infer shape rounded division bug

### DIFF
--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/nullary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/nullary_infer_sym.cc
@@ -56,9 +56,9 @@ bool ArangeOpInferSymbolicShape(pir::Operation *op,
     const auto &end = end_shape_or_data.data()->at(0);
     const auto &step = step_shape_or_data.data()->at(0);
     std::vector<symbol::DimExpr> out_dims;
-    // TODO(lanxianghit, jiahy0825): here should be ceil((end - start) / step),
-    // but DimExpr doesn't support ceil and float now
-    out_dims.emplace_back((end - start) / step);
+    // Use ceiling div to avoid incorrect shape calculation
+    // introduced by rounded division
+    out_dims.emplace_back((end - start + step - 1) / step);
     return symbol::ShapeOrDataDimExprs{
         symbol::TensorShapeOrDataDimExprs(out_dims)};
   }();

--- a/test/ir/pir/cinn/symbolic/test_infer_sym_shape_nullary_op.py
+++ b/test/ir/pir/cinn/symbolic/test_infer_sym_shape_nullary_op.py
@@ -49,7 +49,7 @@ class ArangeOpInferSymbolicShapeTest(TestBase):
         self.start = paddle.full([1], 0, dtype='int32')
         self.end = paddle.full([1], 5, dtype='int32')
         self.step = paddle.full([1], 1, dtype='int32')
-        self.expected = ['shape[Div(Add(S1, -S0), S2)], data[NULL]']
+        self.expected = ['shape[Div(Add(S1, S2, -1, -S0), S2)], data[NULL]']
 
     def test_eval_symbolic(self):
         net = ArangeNet()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
CINN


### PR Types
Bug fixes


### Description
修复了 CINN 对 arange op支持中，`nullary shape infer` 的bug。nullary shape infer 中，对 shape 的计算实际上是：
```c++
(end - start) / step
```
在非整除情况下是向下取整的，本PR修改为：
```c++
(end - start + step - 1) / step
```
并且修改了 DimExpr 单测的参考结果（否则symbolic infer也是错的）。而nullary shape infer不影响`pd_op.arange`（即便计算的shape错，但tensor meta正确，结果就是正确的），但影响`cinn_op.arange`（与fusion输出的shape有关）。

Pcard-89620
