### PR TITLE
[SOT][PIR] Support optional tensor output

### DIFF
--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -1030,24 +1030,16 @@ void BindDecompRule(pybind11::module *m) {
          int start_index,
          int end_index) {
         VLOG(4) << "[Prim] Bind Decomp sinking_decomp begin.";
-        py::list res;
         auto original_insertion_point =
             paddle::dialect::ApiBuilder::Instance().GetCurrentInsertionPoint();
         DecompProgram decomp_object(
             program, src_vars, blacklist, whitelist, start_index, end_index);
         decomp_object.decomp_program();
         std::vector<pir::Value> tar_vars = decomp_object.get_dst_vars();
-        for (size_t i = 0; i < tar_vars.size(); ++i) {
-          if (!tar_vars[i]) {
-            res.append(nullptr);
-          } else {
-            res.append(tar_vars[i]);
-          }
-        }
         paddle::dialect::ApiBuilder::Instance().SetInsertionPoint(
             original_insertion_point);
         VLOG(4) << "[Prim] Bind Decomp sinking_decomp end.";
-        return res;
+        return tar_vars;
       });
 
   m->def("call_decomp_rule", [](pir::Operation &fwd_op) {

--- a/python/paddle/jit/sot/infer_meta.py
+++ b/python/paddle/jit/sot/infer_meta.py
@@ -14,7 +14,6 @@
 from __future__ import annotations
 
 import copy
-from abc import abstractmethod
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, TypeVar
 
@@ -48,6 +47,7 @@ from .utils import (
     map_if_extend,
     meta_str,
 )
+from .utils.exceptions import BreakGraphError, NullMetaBreak
 
 if TYPE_CHECKING:
     import numpy.typing as npt
@@ -98,38 +98,48 @@ class DistInfo:
         return f"DistInfo(mesh={self.mesh}, dims_mapping={self.dims_mapping}, local_shape={self.local_shape})"
 
 
-class MetaInfoBase:
-    @abstractmethod
-    def is_null(self):
-        raise NotImplementedError(
-            "MetaInfoBase is an abstract class, please implement is_null method."
-        )
+class MetaInfoOrNull:
+    def __init__(self, meta: MetaInfo | None):
+        self.meta = meta
 
-    @abstractmethod
+    @staticmethod
+    def null():
+        return MetaInfoOrNull(None)
+
+    def is_null(self):
+        return self.meta is None
+
+    def unwrap_or_breakgraph(self):
+        if self.meta is None:
+            raise BreakGraphError(NullMetaBreak())
+        return self.meta
+
+    def unwrap_unsafe(self):
+        if self.meta is None:
+            raise AssertionError("MetaInfo is None")
+        return self.meta
+
     def with_dynamic_axes(
         self, name: str, dynamic_axes: list[int]
-    ) -> MetaInfoBase:
-        raise NotImplementedError(
-            "MetaInfoBase is an abstract class, please implement with_dynamic_axes method."
-        )
+    ) -> MetaInfoOrNull:
+        if self.meta is None:
+            return MetaInfoOrNull.null()
+        return self.meta.with_dynamic_axes(name, dynamic_axes).wrap()
 
-    @abstractmethod
     def to_input_spec(self):
-        raise NotImplementedError(
-            "MetaInfoBase is an abstract class, please implement to_input_spec method."
-        )
+        if self.meta is None:
+            return None
+        return self.meta.to_input_spec()
 
-    @abstractmethod
     def guard_str(self):
-        raise NotImplementedError(
-            "MetaInfoBase is an abstract class, please implement guard_str method."
-        )
+        if self.meta is None:
+            return "(Null)"
+        return self.meta.guard_str()
 
-    @abstractmethod
     def __deepcopy__(self, memo):
-        raise NotImplementedError(
-            "MetaInfoBase is an abstract class, please implement __deepcopy__ method."
-        )
+        if self.meta is None:
+            return MetaInfoOrNull(None)
+        return MetaInfoOrNull(copy.deepcopy(self.meta))
 
     @staticmethod
     def _handle_legacy_ir_amp_dtype(dtype):
@@ -151,14 +161,14 @@ class MetaInfoBase:
     @staticmethod
     def from_tensor(
         tensor: paddle.Tensor, *, dynamic_axes: list[int] | None = None
-    ) -> MetaInfoBase:
-        if not tensor._is_initialized():
-            return NullInfo()
+    ) -> MetaInfoOrNull:
+        if not tensor._is_dense_tensor_hold_allocation():
+            return MetaInfoOrNull.null()
         assert isinstance(
             tensor, paddle.Tensor
         ), "Expect a Tensor, but got a Value."
 
-        dtype = MetaInfo._handle_legacy_ir_amp_dtype(tensor.dtype)
+        dtype = MetaInfoOrNull._handle_legacy_ir_amp_dtype(tensor.dtype)
         assert (
             -1 not in tensor.shape
         ), "Tensor shape should not contain -1, maybe you pass a Value to from_tensor"
@@ -181,12 +191,12 @@ class MetaInfoBase:
             tensor.place,
             None,
             dist_info=dist_info,
-        )
+        ).wrap()
 
     @staticmethod
     def from_numpy(
         nparray: npt.NDArray[Any], *, dynamic_axes: list[int] | None = None
-    ) -> MetaInfoBase:
+    ) -> MetaInfoOrNull:
         dtype = convert_np_dtype_to_dtype_(nparray.dtype)
         dynamic_axes = dynamic_axes or []
         shape = [
@@ -203,14 +213,14 @@ class MetaInfoBase:
             None,
             None,
             dist_info=None,
-        )
+        ).wrap()
 
     @staticmethod
-    def from_value(value) -> MetaInfoBase:
+    def from_value(value) -> MetaInfoOrNull:
         if is_fake_value(value):
-            return NullInfo()
+            return MetaInfoOrNull.null()
         name = SOT_INFER_META_INNER_VAR
-        dtype = MetaInfo._handle_legacy_ir_amp_dtype(value.dtype)
+        dtype = MetaInfoOrNull._handle_legacy_ir_amp_dtype(value.dtype)
         shape = [SymbolicInt() if dim == -1 else dim for dim in value.shape]
         if isinstance(value, paddle.pir.Value) and value.is_dist():
             dist_info = DistInfo.from_value(value)
@@ -226,29 +236,27 @@ class MetaInfoBase:
             None,  # We can't infer the right place in compile time.
             None,  # there's no spec_name specified when from_value.
             dist_info=dist_info,
-        )
+        ).wrap()
+
+    def __repr__(self):
+        if self.meta is None:
+            return "MetaInfoOrNull(None)"
+        return f"MetaInfoOrNull({self.meta})"
+
+    def __eq__(self, other):
+        if self.meta is None:
+            return other.meta is None
+        if other.meta is None:
+            return False
+        return self.meta == other.meta
+
+    def __hash__(self):
+        if self.meta is None:
+            return hash(None)
+        return hash(self.meta)
 
 
-class NullInfo(MetaInfoBase):
-    def is_null(self):
-        return True
-
-    def with_dynamic_axes(
-        self, name: str, dynamic_axes: list[int]
-    ) -> MetaInfoBase:
-        return NullInfo()
-
-    def to_input_spec(self):
-        return None
-
-    def guard_str(self):
-        return "(Null)"
-
-    def __deepcopy__(self, memo):
-        return NullInfo()
-
-
-class MetaInfo(MetaInfoBase):
+class MetaInfo:
     shape: list[int | SymbolicInt]
 
     def __init__(
@@ -276,8 +284,8 @@ class MetaInfo(MetaInfoBase):
         self.dist_info = dist_info
         self.spec_name = spec_name
 
-    def is_null(self):
-        return False
+    def wrap(self):
+        return MetaInfoOrNull(self)
 
     def shape_with_special_symbol(
         self, dynamic_symbol: DynamicSymbolT = -1
@@ -391,7 +399,10 @@ class VariableCreator(metaclass=Singleton):
         # self.startup_program = paddle.static.Program()
         self.var_name_generator = UniqueNameGenerator(SOT_INFER_META_INNER_VAR)
 
-    def gen_name(self, meta):
+    def gen_name(self, meta_or_null: MetaInfoOrNull):
+        if meta_or_null.is_null():
+            return "null"
+        meta = meta_or_null.unwrap_unsafe()
         name = f"{meta.dtype}_{meta.stop_gradient}_"
         name += "_".join(map(str, meta.shape))
         return name
@@ -435,10 +446,10 @@ class VariableCreator(metaclass=Singleton):
         else:
             return self.legacy_programs[1]
 
-    def create_var(self, meta: MetaInfoBase):
-        if meta.is_null():
+    def create_var(self, meta_or_null: MetaInfoOrNull):
+        if meta_or_null.is_null():
             return fake_value()
-        assert isinstance(meta, MetaInfo), "Expect a MetaInfo, but got {meta}."
+        meta = meta_or_null.unwrap_unsafe()
         shape = meta.shape_with_special_symbol(-1)
 
         if paddle.framework.use_pir_api():
@@ -446,7 +457,7 @@ class VariableCreator(metaclass=Singleton):
                 self.main_program, self.startup_program
             ):
                 var = paddle.static.input.data(
-                    name=self.gen_name(meta),
+                    name=self.gen_name(meta.wrap()),
                     shape=shape,
                     dtype=convert_dtype(meta.dtype),
                 )
@@ -470,7 +481,7 @@ class VariableCreator(metaclass=Singleton):
         ), "Expect a Variable, but got a Tensor."
         return var
 
-    def get_variable(self, meta, without_cache=False):
+    def get_variable(self, meta: MetaInfoOrNull, without_cache=False):
         var_feature_name = self.gen_name(meta)
         if without_cache:
             return self.create_var(meta)
@@ -508,7 +519,7 @@ class VariableCreator(metaclass=Singleton):
 def convert_meta_to_variable(args, without_cache=False):
     return map_if_extend(
         args,
-        pred=lambda x: isinstance(x, MetaInfoBase),
+        pred=lambda x: isinstance(x, MetaInfoOrNull),
         true_fn=lambda x: VariableCreator().get_variable(
             x, without_cache=without_cache
         ),
@@ -519,7 +530,7 @@ def convert_meta_to_variable(args, without_cache=False):
 def convert_meta_to_input_spec(args):
     return map_if_extend(
         args,
-        pred=lambda x: isinstance(x, MetaInfoBase),
+        pred=lambda x: isinstance(x, MetaInfoOrNull),
         true_fn=lambda x: x.to_input_spec(),
         # TODO(xiongkun): can x be tensor ?
         false_fn=lambda x: (
@@ -539,7 +550,7 @@ def convert_variable_to_meta_info(args):
     return map_if_extend(
         args,
         pred=lambda x: isinstance(x, static_variable_type),
-        true_fn=lambda x: MetaInfoBase.from_value(x),
+        true_fn=lambda x: MetaInfoOrNull.from_value(x),
         false_fn=lambda x: x,
     )
 
@@ -575,7 +586,7 @@ def infer_meta_for_layer(layer, *args, **kwargs):
             for x in paddle.utils.flatten(
                 convert_variable_to_meta_info(output_values)
             )
-            if isinstance(x, MetaInfoBase)
+            if isinstance(x, MetaInfoOrNull)
         ]
     )
     layer.forward.rollback()
@@ -596,7 +607,7 @@ def ast_infer_meta(static_function, *args, **kwargs):
             for x in paddle.utils.flatten(
                 convert_variable_to_meta_info(concrete_program.outputs)
             )
-            if isinstance(x, MetaInfoBase)
+            if isinstance(x, MetaInfoOrNull)
         ]
     )
 
@@ -661,7 +672,7 @@ class LayerInferMetaCache(Cache, metaclass=Singleton):
 
     def key_fn(self, layer, *args, **kwargs):
         params = [
-            MetaInfoBase.from_value(x)
+            MetaInfoOrNull.from_tensor(x)
             for x in layer.parameters(include_sublayers=True)
         ]
         return (

--- a/python/paddle/jit/sot/infer_meta.py
+++ b/python/paddle/jit/sot/infer_meta.py
@@ -14,6 +14,7 @@
 from __future__ import annotations
 
 import copy
+from abc import abstractmethod
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, TypeVar
 
@@ -36,6 +37,7 @@ from paddle.distributed.auto_parallel.static.utils import (
     convert_to_dims_mapping,
 )
 from paddle.framework import use_pir_api
+from paddle.pir import fake_value, is_fake_value
 from paddle.static import InputSpec
 from paddle.utils import flatten, is_sequence
 
@@ -96,7 +98,157 @@ class DistInfo:
         return f"DistInfo(mesh={self.mesh}, dims_mapping={self.dims_mapping}, local_shape={self.local_shape})"
 
 
-class MetaInfo:
+class MetaInfoBase:
+    @abstractmethod
+    def is_null(self):
+        raise NotImplementedError(
+            "MetaInfoBase is an abstract class, please implement is_null method."
+        )
+
+    @abstractmethod
+    def with_dynamic_axes(
+        self, name: str, dynamic_axes: list[int]
+    ) -> MetaInfoBase:
+        raise NotImplementedError(
+            "MetaInfoBase is an abstract class, please implement with_dynamic_axes method."
+        )
+
+    @abstractmethod
+    def to_input_spec(self):
+        raise NotImplementedError(
+            "MetaInfoBase is an abstract class, please implement to_input_spec method."
+        )
+
+    @abstractmethod
+    def guard_str(self):
+        raise NotImplementedError(
+            "MetaInfoBase is an abstract class, please implement guard_str method."
+        )
+
+    @abstractmethod
+    def __deepcopy__(self, memo):
+        raise NotImplementedError(
+            "MetaInfoBase is an abstract class, please implement __deepcopy__ method."
+        )
+
+    @staticmethod
+    def _handle_legacy_ir_amp_dtype(dtype):
+        # TODO(cleanup-legacy-ir) remove after pir become default state.
+        # We always use float32 in simulation if AMP is enabled.
+        if use_pir_api():
+            return dtype
+        assert isinstance(dtype, paddle.core.VarDesc.VarType)
+
+        current_amp_state = amp_state()
+        if (
+            dtype == paddle.float16
+            and current_amp_state is not None
+            and current_amp_state["dtype"] == "float16"
+        ):
+            dtype = paddle.float32
+        return dtype
+
+    @staticmethod
+    def from_tensor(
+        tensor: paddle.Tensor, *, dynamic_axes: list[int] | None = None
+    ) -> MetaInfoBase:
+        if not tensor._is_initialized():
+            return NullInfo()
+        assert isinstance(
+            tensor, paddle.Tensor
+        ), "Expect a Tensor, but got a Value."
+
+        dtype = MetaInfo._handle_legacy_ir_amp_dtype(tensor.dtype)
+        assert (
+            -1 not in tensor.shape
+        ), "Tensor shape should not contain -1, maybe you pass a Value to from_tensor"
+        dynamic_axes = dynamic_axes or []
+        shape = [
+            SymbolicInt() if i in dynamic_axes else dim
+            for i, dim in enumerate(tensor.shape)
+        ]
+        if tensor.is_dist():
+            dist_info = DistInfo.from_tensor(tensor)
+        else:
+            dist_info = None
+        return MetaInfo(
+            shape,
+            dtype,
+            tensor.stop_gradient,
+            tensor.name,
+            tensor.persistable,
+            tensor.type,
+            tensor.place,
+            None,
+            dist_info=dist_info,
+        )
+
+    @staticmethod
+    def from_numpy(
+        nparray: npt.NDArray[Any], *, dynamic_axes: list[int] | None = None
+    ) -> MetaInfoBase:
+        dtype = convert_np_dtype_to_dtype_(nparray.dtype)
+        dynamic_axes = dynamic_axes or []
+        shape = [
+            SymbolicInt() if i in dynamic_axes else dim
+            for i, dim in enumerate(nparray.shape)
+        ]
+        return MetaInfo(
+            shape,
+            dtype,
+            True,  # stop_gradient
+            None,
+            None,  # persistable
+            None,
+            None,
+            None,
+            dist_info=None,
+        )
+
+    @staticmethod
+    def from_value(value) -> MetaInfoBase:
+        if is_fake_value(value):
+            return NullInfo()
+        name = SOT_INFER_META_INNER_VAR
+        dtype = MetaInfo._handle_legacy_ir_amp_dtype(value.dtype)
+        shape = [SymbolicInt() if dim == -1 else dim for dim in value.shape]
+        if isinstance(value, paddle.pir.Value) and value.is_dist():
+            dist_info = DistInfo.from_value(value)
+        else:
+            dist_info = None
+        return MetaInfo(
+            shape,
+            dtype,
+            value.stop_gradient,
+            name,
+            value.persistable,
+            None,  # type is not a unified attribute in dygraph and static mode.
+            None,  # We can't infer the right place in compile time.
+            None,  # there's no spec_name specified when from_value.
+            dist_info=dist_info,
+        )
+
+
+class NullInfo(MetaInfoBase):
+    def is_null(self):
+        return True
+
+    def with_dynamic_axes(
+        self, name: str, dynamic_axes: list[int]
+    ) -> MetaInfoBase:
+        return NullInfo()
+
+    def to_input_spec(self):
+        return None
+
+    def guard_str(self):
+        return "(Null)"
+
+    def __deepcopy__(self, memo):
+        return NullInfo()
+
+
+class MetaInfo(MetaInfoBase):
     shape: list[int | SymbolicInt]
 
     def __init__(
@@ -123,6 +275,9 @@ class MetaInfo:
         self.stop_gradient = stop_gradient
         self.dist_info = dist_info
         self.spec_name = spec_name
+
+    def is_null(self):
+        return False
 
     def shape_with_special_symbol(
         self, dynamic_symbol: DynamicSymbolT = -1
@@ -159,99 +314,6 @@ class MetaInfo:
             if isinstance(dim, SymbolicInt)
         ]
 
-    @staticmethod
-    def _handle_legacy_ir_amp_dtype(dtype):
-        # TODO(cleanup-legacy-ir) remove after pir become default state.
-        # We always use float32 in simulation if AMP is enabled.
-        if use_pir_api():
-            return dtype
-        assert isinstance(dtype, paddle.core.VarDesc.VarType)
-
-        current_amp_state = amp_state()
-        if (
-            dtype == paddle.float16
-            and current_amp_state is not None
-            and current_amp_state["dtype"] == "float16"
-        ):
-            dtype = paddle.float32
-        return dtype
-
-    @staticmethod
-    def from_tensor(
-        tensor: paddle.Tensor, *, dynamic_axes: list[int] | None = None
-    ) -> MetaInfo:
-        assert isinstance(
-            tensor, paddle.Tensor
-        ), "Expect a Tensor, but got a Value."
-
-        dtype = MetaInfo._handle_legacy_ir_amp_dtype(tensor.dtype)
-        assert (
-            -1 not in tensor.shape
-        ), "Tensor shape should not contain -1, maybe you pass a Value to from_tensor"
-        dynamic_axes = dynamic_axes or []
-        shape = [
-            SymbolicInt() if i in dynamic_axes else dim
-            for i, dim in enumerate(tensor.shape)
-        ]
-        if tensor.is_dist():
-            dist_info = DistInfo.from_tensor(tensor)
-        else:
-            dist_info = None
-        return MetaInfo(
-            shape,
-            dtype,
-            tensor.stop_gradient,
-            tensor.name,
-            tensor.persistable,
-            tensor.type,
-            tensor.place,
-            None,
-            dist_info=dist_info,
-        )
-
-    @staticmethod
-    def from_value(value) -> MetaInfo:
-        name = SOT_INFER_META_INNER_VAR
-        dtype = MetaInfo._handle_legacy_ir_amp_dtype(value.dtype)
-        shape = [SymbolicInt() if dim == -1 else dim for dim in value.shape]
-        if isinstance(value, paddle.pir.Value) and value.is_dist():
-            dist_info = DistInfo.from_value(value)
-        else:
-            dist_info = None
-        return MetaInfo(
-            shape,
-            dtype,
-            value.stop_gradient,
-            name,
-            value.persistable,
-            None,  # type is not a unified attribute in dygraph and static mode.
-            None,  # We can't infer the right place in compile time.
-            None,  # there's no spec_name specified when from_value.
-            dist_info=dist_info,
-        )
-
-    @staticmethod
-    def from_numpy(
-        nparray: npt.NDArray[Any], *, dynamic_axes: list[int] | None = None
-    ):
-        dtype = convert_np_dtype_to_dtype_(nparray.dtype)
-        dynamic_axes = dynamic_axes or []
-        shape = [
-            SymbolicInt() if i in dynamic_axes else dim
-            for i, dim in enumerate(nparray.shape)
-        ]
-        return MetaInfo(
-            shape,
-            dtype,
-            True,  # stop_gradient
-            None,
-            None,  # persistable
-            None,
-            None,
-            None,
-            dist_info=None,
-        )
-
     def is_inner_var(self):
         return self.name == SOT_INFER_META_INNER_VAR
 
@@ -262,7 +324,7 @@ class MetaInfo:
         """
         return len(self.dynamic_axes) > 0
 
-    def to_input_spec(self):
+    def to_input_spec(self) -> DistributedInputSpec | ConstrainedInputSpec:
         shape = self.shape_with_special_symbol(None)
         if self.dist_info is not None:
             placements = to_placements(
@@ -373,7 +435,10 @@ class VariableCreator(metaclass=Singleton):
         else:
             return self.legacy_programs[1]
 
-    def create_var(self, meta: MetaInfo):
+    def create_var(self, meta: MetaInfoBase):
+        if meta.is_null():
+            return fake_value()
+        assert isinstance(meta, MetaInfo), "Expect a MetaInfo, but got {meta}."
         shape = meta.shape_with_special_symbol(-1)
 
         if paddle.framework.use_pir_api():
@@ -443,7 +508,7 @@ class VariableCreator(metaclass=Singleton):
 def convert_meta_to_variable(args, without_cache=False):
     return map_if_extend(
         args,
-        pred=lambda x: isinstance(x, MetaInfo),
+        pred=lambda x: isinstance(x, MetaInfoBase),
         true_fn=lambda x: VariableCreator().get_variable(
             x, without_cache=without_cache
         ),
@@ -454,7 +519,7 @@ def convert_meta_to_variable(args, without_cache=False):
 def convert_meta_to_input_spec(args):
     return map_if_extend(
         args,
-        pred=lambda x: isinstance(x, MetaInfo),
+        pred=lambda x: isinstance(x, MetaInfoBase),
         true_fn=lambda x: x.to_input_spec(),
         # TODO(xiongkun): can x be tensor ?
         false_fn=lambda x: (
@@ -474,7 +539,7 @@ def convert_variable_to_meta_info(args):
     return map_if_extend(
         args,
         pred=lambda x: isinstance(x, static_variable_type),
-        true_fn=lambda x: MetaInfo.from_value(x),
+        true_fn=lambda x: MetaInfoBase.from_value(x),
         false_fn=lambda x: x,
     )
 
@@ -510,7 +575,7 @@ def infer_meta_for_layer(layer, *args, **kwargs):
             for x in paddle.utils.flatten(
                 convert_variable_to_meta_info(output_values)
             )
-            if isinstance(x, MetaInfo)
+            if isinstance(x, MetaInfoBase)
         ]
     )
     layer.forward.rollback()
@@ -531,7 +596,7 @@ def ast_infer_meta(static_function, *args, **kwargs):
             for x in paddle.utils.flatten(
                 convert_variable_to_meta_info(concrete_program.outputs)
             )
-            if isinstance(x, MetaInfo)
+            if isinstance(x, MetaInfoBase)
         ]
     )
 
@@ -596,7 +661,7 @@ class LayerInferMetaCache(Cache, metaclass=Singleton):
 
     def key_fn(self, layer, *args, **kwargs):
         params = [
-            MetaInfo.from_value(x)
+            MetaInfoBase.from_value(x)
             for x in layer.parameters(include_sublayers=True)
         ]
         return (

--- a/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
@@ -35,7 +35,7 @@ from .....utils.layers_utils import NotSupportedTensorArgumentError
 from ...infer_meta import (
     InferMetaCache,
     LayerInferMetaCache,
-    MetaInfo,
+    MetaInfoBase,
     ast_infer_meta,
 )
 from ...profiler import EventGuard, event_register
@@ -833,7 +833,7 @@ class FunctionGraph:
             tracker = DummyTracker(list(args) + list(kwargs.values()))
         outputs = map_if(
             out_metas,
-            pred=lambda x: isinstance(x, MetaInfo),
+            pred=lambda x: isinstance(x, MetaInfoBase),
             true_fn=lambda x: var_cls(
                 x,
                 self,

--- a/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
@@ -35,7 +35,7 @@ from .....utils.layers_utils import NotSupportedTensorArgumentError
 from ...infer_meta import (
     InferMetaCache,
     LayerInferMetaCache,
-    MetaInfoBase,
+    MetaInfoOrNull,
     ast_infer_meta,
 )
 from ...profiler import EventGuard, event_register
@@ -833,7 +833,7 @@ class FunctionGraph:
             tracker = DummyTracker(list(args) + list(kwargs.values()))
         outputs = map_if(
             out_metas,
-            pred=lambda x: isinstance(x, MetaInfoBase),
+            pred=lambda x: isinstance(x, MetaInfoOrNull),
             true_fn=lambda x: var_cls(
                 x,
                 self,

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
@@ -30,6 +30,7 @@ from paddle.pir.core import _PADDLE_PIR_DTYPE_2_NUMPY_DTYPE
 from ....infer_meta import (
     DistInfo,
     MetaInfo,
+    MetaInfoBase,
 )
 from ....symbolic.statement_ir import Symbol
 from ....symbolic_shape.constraints import (
@@ -364,10 +365,10 @@ class TensorDtypeVariable(DataVariable):
             if not paddle.framework.use_pir_api():
                 return [
                     StringifiedExpression(
-                        f"MetaInfo.from_tensor({{}}).dtype == {dtype_str}",
+                        f"MetaInfoBase.from_tensor({{}}).dtype == {dtype_str}",
                         [tensor_value_tracer],
                         union_free_vars(
-                            {"MetaInfo": MetaInfo},
+                            {"MetaInfoBase": MetaInfoBase},
                             tensor_value_tracer.free_vars,
                             dtype_free_vars,
                         ),
@@ -417,7 +418,7 @@ class TensorVariable(VariableBase):
     TensorVariable is a subclass of VariableBase used to wrap a Variable of the tensor type.
 
     Args:
-        tensor (paddle.Tensor | MetaInfo): The tensor to be wrapped.
+        tensor (paddle.Tensor | MetaInfoBase): The tensor to be wrapped.
         graph (FunctionGraph): The FunctionGraph object that this variable is associated with.
         tracker (Tracker): The Tracker object that tracks the information of this variable.
     """
@@ -427,7 +428,7 @@ class TensorVariable(VariableBase):
 
     def __init__(
         self,
-        meta: MetaInfo,
+        meta: MetaInfoBase,
         graph: FunctionGraph,
         tracker: Tracker,
     ):
@@ -561,15 +562,15 @@ class TensorVariable(VariableBase):
         # TODO(cleanup-legacy-ir): Remove this branch after we remove legacy IR
         if not paddle.framework.use_pir_api():
             if ENV_SOT_ALLOW_DYNAMIC_SHAPE.get():
-                str_left_expr = f"MetaInfo.from_tensor({{}}, dynamic_axes={self.meta.dynamic_axes}).guard_str()"
+                str_left_expr = f"MetaInfoBase.from_tensor({{}}, dynamic_axes={self.meta.dynamic_axes}).guard_str()"
             else:
-                str_left_expr = "MetaInfo.from_tensor({}).guard_str()"
+                str_left_expr = "MetaInfoBase.from_tensor({}).guard_str()"
             return [
                 StringifiedExpression(
                     f"{str_left_expr} == '{self.origin_meta.guard_str()}'",
                     [frame_value_tracer],
                     union_free_vars(
-                        {"MetaInfo": MetaInfo},
+                        {"MetaInfoBase": MetaInfoBase},
                         frame_value_tracer.free_vars,
                     ),
                 )
@@ -898,9 +899,9 @@ class TensorVariable(VariableBase):
 
     @VariableFactory.register_from_value()
     def from_value(value: Any, graph: FunctionGraph, tracker: Tracker):
-        if isinstance(value, (paddle.Tensor, MetaInfo)):
+        if isinstance(value, (paddle.Tensor, MetaInfoBase)):
             value = (
-                MetaInfo.from_tensor(value)
+                MetaInfoBase.from_tensor(value)
                 if isinstance(value, paddle.Tensor)
                 else value
             )
@@ -908,7 +909,11 @@ class TensorVariable(VariableBase):
         return None
 
 
-def get_symbolic_from_meta(meta: MetaInfo) -> SymbolicValue:
+def get_symbolic_from_meta(meta: MetaInfoBase) -> SymbolicValue:
+    if not isinstance(meta, MetaInfo):
+        raise InnerError(
+            f"get_symbolic_from_meta() got {meta}. Only MetaInfo is supported."
+        )
     if meta.dtype in [paddle.bool]:
         value = SymbolicBool()
     elif meta.dtype in [
@@ -938,7 +943,7 @@ class SymbolicVariable(VariableBase):
     SymbolicVariable is a subclass of VariableBase used to wrap a symbolic value.
 
     Args:
-        value_or_meta (SymbolicInt | MetaInfo): The symbolic value  to be wrapped or metadata.
+        value_or_meta (SymbolicInt | MetaInfoBase): The symbolic value  to be wrapped or metadata.
         graph (FunctionGraph): The FunctionGraph object that this variable is associated with.
         tracker (Tracker): The Tracker object that tracks the information of this variable.
     """
@@ -949,13 +954,16 @@ class SymbolicVariable(VariableBase):
 
     def __init__(
         self,
-        value_or_meta: SymbolicInt | MetaInfo,
+        value_or_meta: SymbolicInt | MetaInfoBase,
         graph: FunctionGraph,
         tracker: Tracker,
     ):
         super().__init__(graph, tracker)
         self.var_name = self.var_name_generator.next()
-        if isinstance(value_or_meta, MetaInfo):
+        if isinstance(value_or_meta, MetaInfoBase):
+            assert isinstance(
+                value_or_meta, MetaInfo
+            ), "Only MetaInfo is supported"
             assert len(value_or_meta.shape) == 0
             self.value = get_symbolic_from_meta(value_or_meta)
             self.meta = value_or_meta
@@ -1407,7 +1415,7 @@ class SymbolicVariable(VariableBase):
 class ParameterVariable(TensorVariable):
     def __init__(
         self,
-        meta: MetaInfo,
+        meta: MetaInfoBase,
         graph: FunctionGraph,
         tracker: Tracker,
     ):
@@ -1416,7 +1424,7 @@ class ParameterVariable(TensorVariable):
     @VariableFactory.register_from_value(successor="TensorVariable")
     def from_value(value: Any, graph: FunctionGraph, tracker: Tracker):
         if isinstance(value, (paddle.base.framework.EagerParamBase)):
-            value = MetaInfo.from_tensor(value)
+            value = MetaInfoBase.from_tensor(value)
             return ParameterVariable(value, graph, tracker)
         return None
 
@@ -1813,7 +1821,7 @@ class NumPyArrayVariable(NumPyVariable):
 
     def __init__(
         self,
-        value_or_meta: npt.NDArray[Any] | MetaInfo,
+        value_or_meta: npt.NDArray[Any] | MetaInfoBase,
         graph: FunctionGraph,
         tracker: Tracker,
     ):
@@ -1821,13 +1829,13 @@ class NumPyArrayVariable(NumPyVariable):
         self.var_name = self.var_name_generator.next()
         self.graph.side_effects.record_mutable_variable(self)
 
-        if isinstance(value_or_meta, MetaInfo):
+        if isinstance(value_or_meta, MetaInfoBase):
             # TODO(wangmingkai02): self.value
             self.value = None
             self.meta = value_or_meta
         else:
             self.value = value_or_meta
-            self.meta = MetaInfo.from_numpy(self.value)
+            self.meta = MetaInfoBase.from_numpy(self.value)
 
     def __len__(self):
         if isinstance(self.meta.shape[0], SymbolicInt):

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
@@ -30,7 +30,7 @@ from paddle.pir.core import _PADDLE_PIR_DTYPE_2_NUMPY_DTYPE
 from ....infer_meta import (
     DistInfo,
     MetaInfo,
-    MetaInfoBase,
+    MetaInfoOrNull,
 )
 from ....symbolic.statement_ir import Symbol
 from ....symbolic_shape.constraints import (
@@ -365,10 +365,10 @@ class TensorDtypeVariable(DataVariable):
             if not paddle.framework.use_pir_api():
                 return [
                     StringifiedExpression(
-                        f"MetaInfoBase.from_tensor({{}}).dtype == {dtype_str}",
+                        f"MetaInfoOrNull.from_tensor({{}}).unwrap_unsafe().dtype == {dtype_str}",
                         [tensor_value_tracer],
                         union_free_vars(
-                            {"MetaInfoBase": MetaInfoBase},
+                            {"MetaInfoOrNull": MetaInfoOrNull},
                             tensor_value_tracer.free_vars,
                             dtype_free_vars,
                         ),
@@ -418,7 +418,7 @@ class TensorVariable(VariableBase):
     TensorVariable is a subclass of VariableBase used to wrap a Variable of the tensor type.
 
     Args:
-        tensor (paddle.Tensor | MetaInfoBase): The tensor to be wrapped.
+        tensor (paddle.Tensor | MetaInfoOrNull): The tensor to be wrapped.
         graph (FunctionGraph): The FunctionGraph object that this variable is associated with.
         tracker (Tracker): The Tracker object that tracks the information of this variable.
     """
@@ -428,7 +428,7 @@ class TensorVariable(VariableBase):
 
     def __init__(
         self,
-        meta: MetaInfoBase,
+        meta: MetaInfoOrNull,
         graph: FunctionGraph,
         tracker: Tracker,
     ):
@@ -473,13 +473,13 @@ class TensorVariable(VariableBase):
         return dynamic_axes
 
     def __len__(self):
-        if isinstance(self.meta.shape[0], SymbolicInt):
+        if isinstance(self.meta.unwrap_or_breakgraph().shape[0], SymbolicInt):
             raise BreakGraphError(
                 DataDependencyDynamicShapeBreak(
                     "length of tensor variable with first dimension is dynamic shape causes graph break."
                 )
             )
-        return self.meta.shape[0]
+        return self.meta.unwrap_or_breakgraph().shape[0]
 
     def get_py_value(self, allow_tensor=False):
         if allow_tensor:
@@ -523,6 +523,11 @@ class TensorVariable(VariableBase):
         assert paddle.framework.use_pir_api(), "Only support PIR"
         expr_node = self.tracker.guard_tree_expr_node()
         meta = self.origin_meta
+        if meta.is_null():
+            return [
+                # TODO: Implement uninitialized tensor guard
+            ]
+        meta = meta.unwrap_unsafe()
         return [
             # Check shape
             paddle.framework.core.GuardNode(
@@ -545,7 +550,7 @@ class TensorVariable(VariableBase):
             ),
             # Check dist info
             paddle.framework.core.TensorDistMetaMatchGuardNode(
-                self.meta.dist_info,
+                meta.dist_info,
                 [
                     expr_node,
                     paddle.framework.core.ExternVarExprNode(
@@ -561,16 +566,19 @@ class TensorVariable(VariableBase):
 
         # TODO(cleanup-legacy-ir): Remove this branch after we remove legacy IR
         if not paddle.framework.use_pir_api():
-            if ENV_SOT_ALLOW_DYNAMIC_SHAPE.get():
-                str_left_expr = f"MetaInfoBase.from_tensor({{}}, dynamic_axes={self.meta.dynamic_axes}).guard_str()"
+            if (
+                ENV_SOT_ALLOW_DYNAMIC_SHAPE.get()
+                and not self.origin_meta.is_null()
+            ):
+                str_left_expr = f"MetaInfoOrNull.from_tensor({{}}, dynamic_axes={self.meta.unwrap_unsafe().dynamic_axes}).guard_str()"
             else:
-                str_left_expr = "MetaInfoBase.from_tensor({}).guard_str()"
+                str_left_expr = "MetaInfoOrNull.from_tensor({}).guard_str()"
             return [
                 StringifiedExpression(
                     f"{str_left_expr} == '{self.origin_meta.guard_str()}'",
                     [frame_value_tracer],
                     union_free_vars(
-                        {"MetaInfoBase": MetaInfoBase},
+                        {"MetaInfoOrNull": MetaInfoOrNull},
                         frame_value_tracer.free_vars,
                     ),
                 )
@@ -578,6 +586,15 @@ class TensorVariable(VariableBase):
 
         # A quick check path for PIR, we don't need dtype conversion for AMP in PIR
         meta = self.origin_meta
+        if meta.is_null():
+            return [
+                StringifiedExpression(
+                    "not {}._is_dense_tensor_hold_allocation()",
+                    [frame_value_tracer],
+                    union_free_vars(frame_value_tracer.free_vars),
+                )
+            ]
+        meta = meta.unwrap_unsafe()
         dtype_str, dtype_free_vars = stringify_pyobject(meta.dtype)
         guards = [
             # Check rank
@@ -617,13 +634,13 @@ class TensorVariable(VariableBase):
             ),
             # Check whether this tensor is distributed
             StringifiedExpression(
-                f"{{}}.is_dist() is {(self.meta.dist_info is not None)!r}",
+                f"{{}}.is_dist() is {(meta.dist_info is not None)!r}",
                 [frame_value_tracer],
                 union_free_vars(frame_value_tracer.free_vars),
             ),
         ]
-        if self.meta.dist_info is not None:
-            tensor_dist_info = self.meta.dist_info
+        if meta.dist_info is not None:
+            tensor_dist_info = meta.dist_info
             guards.extend(
                 [
                     # check mesh shape
@@ -685,15 +702,20 @@ class TensorVariable(VariableBase):
 
     @property
     def main_info(self) -> dict[str, Any]:
-        dtype = self.meta.dtype
+        if self.meta.is_null():
+            return {
+                "meta": "null",
+            }
+        meta = self.meta.unwrap_unsafe()
+        dtype = meta.dtype
         if isinstance(dtype, paddle.core.VarDesc.VarType):
             dtype = paddle.pir.core.vartype_to_datatype[dtype]
         return {
-            "shape": self.meta.shape,
+            "shape": meta.shape,
             "dtype": DTYPE_ABBRS[dtype],
-            "stop_gradient": self.meta.stop_gradient,
+            "stop_gradient": meta.stop_gradient,
             "var_name": self.var_name,
-            "dist_info": self.meta.dist_info,
+            "dist_info": meta.dist_info,
         }
 
     def getitem(self, key):
@@ -717,7 +739,9 @@ class TensorVariable(VariableBase):
         """
         from .container import ListVariable
 
-        perm = list(range(len(self.meta.shape) - 1, -1, -1))
+        perm = list(
+            range(len(self.meta.unwrap_or_breakgraph().shape) - 1, -1, -1)
+        )
         perm_var = ListVariable(perm, self.graph, tracker=ConstTracker(perm))
         out = self.graph.call_paddle_api(paddle.transpose, self, perm_var)
         return out
@@ -729,12 +753,12 @@ class TensorVariable(VariableBase):
         """
         from .container import ListVariable
 
-        if len(self.meta.shape) < 2:
+        if len(self.meta.unwrap_or_breakgraph().shape) < 2:
             raise ValueError(
                 f"Variable.ndim({self.ndim}) is required to be greater than or equal to 2."
             )
 
-        perm = list(range(len(self.meta.shape)))
+        perm = list(range(len(self.meta.unwrap_or_breakgraph().shape)))
         perm[-1], perm[-2] = perm[-2], perm[-1]
         perm_var = ListVariable(perm, self.graph, tracker=DummyTracker([self]))
         out = self.graph.call_paddle_api(paddle.transpose, self, perm_var)
@@ -746,7 +770,9 @@ class TensorVariable(VariableBase):
         Return a ConstantVariable object that represents the number of dimensions of the wrapped value of this TensorVariable.
         """
         return ConstantVariable(
-            len(self.meta.shape), self.graph, DummyTracker([self])
+            len(self.meta.unwrap_or_breakgraph().shape),
+            self.graph,
+            DummyTracker([self]),
         )
 
     @tensor_property
@@ -756,15 +782,17 @@ class TensorVariable(VariableBase):
         """
         from .callable import BuiltinVariable
 
-        if not self.meta.is_dynamic_shape():
-            n_elements = reduce(operator.mul, self.meta.shape, 1)
+        meta = self.meta.unwrap_or_breakgraph()
+
+        if not meta.is_dynamic_shape():
+            n_elements = reduce(operator.mul, meta.shape, 1)
             return ConstantVariable(
                 n_elements, self.graph, DummyTracker([self])
             )
         if not ENV_SOT_ALLOW_DYNAMIC_SHAPE.get():
             raise BreakGraphError(
                 DataDependencyDynamicShapeBreak(
-                    f"Getting size for a dynamic shape tensor causes graph break. shape = {self.meta.shape}"
+                    f"Getting size for a dynamic shape tensor causes graph break. shape = {meta.shape}"
                 )
             )
         return reduce(
@@ -775,24 +803,23 @@ class TensorVariable(VariableBase):
 
     @tensor_property
     def shape(self):
-        if (
-            not ENV_SOT_ALLOW_DYNAMIC_SHAPE.get()
-            and self.meta.is_dynamic_shape()
-        ):
+        meta = self.meta.unwrap_or_breakgraph()
+        if not ENV_SOT_ALLOW_DYNAMIC_SHAPE.get() and meta.is_dynamic_shape():
             raise BreakGraphError(
                 DataDependencyDynamicShapeBreak(
-                    f"Getting shape for a dynamic shape tensor causes graph break. shape = {self.meta.shape}"
+                    f"Getting shape for a dynamic shape tensor causes graph break. shape = {meta.shape}"
                 )
             )
         from .container import ListVariable
 
         tracker = GetAttrTracker(self, "shape")
-        return ListVariable(self.meta.shape, self.graph, tracker=tracker)
+        return ListVariable(meta.shape, self.graph, tracker=tracker)
 
     def len(self):
-        if len(self.meta.shape) == 0:
+        meta = self.meta.unwrap_or_breakgraph()
+        if len(meta.shape) == 0:
             raise InnerError("len() of a 0-D tensor is wrong")
-        first_dim = self.meta.shape[0]
+        first_dim = meta.shape[0]
         if not isinstance(first_dim, SymbolicInt):
             return ConstantVariable(first_dim, self.graph, DummyTracker([self]))
         if not ENV_SOT_ALLOW_DYNAMIC_SHAPE.get():
@@ -807,21 +834,21 @@ class TensorVariable(VariableBase):
         return ConstantVariable(True, self.graph, DummyTracker([self]))
 
     def is_complex(self):
-        dtype = self.meta.dtype
+        dtype = self.meta.unwrap_or_breakgraph().dtype
         if isinstance(dtype, paddle.core.VarDesc.VarType):
             dtype = paddle.pir.core.vartype_to_datatype[dtype]
         is_cp_dtype = dtype in CP_DTYPE_ABBRS
         return ConstantVariable(is_cp_dtype, self.graph, DummyTracker([self]))
 
     def is_integer(self):
-        dtype = self.meta.dtype
+        dtype = self.meta.unwrap_or_breakgraph().dtype
         if isinstance(dtype, paddle.core.VarDesc.VarType):
             dtype = paddle.pir.core.vartype_to_datatype[dtype]
         is_int_dtype = dtype in INT_DTYPE_ABBRS
         return ConstantVariable(is_int_dtype, self.graph, DummyTracker([self]))
 
     def is_floating_point(self):
-        dtype = self.meta.dtype
+        dtype = self.meta.unwrap_or_breakgraph().dtype
         if isinstance(dtype, paddle.core.VarDesc.VarType):
             dtype = paddle.pir.core.vartype_to_datatype[dtype]
         is_fp_dtype = dtype in FP_DTYPE_ABBRS
@@ -840,10 +867,13 @@ class TensorVariable(VariableBase):
             "is_integer": paddle.is_integer,
             "is_floating_point": paddle.is_floating_point,
         }
-        if name in ["name", "place", "type"] and self.meta.is_inner_var():
+        if (
+            name in ["name", "place", "type"]
+            and self.meta.unwrap_or_breakgraph().is_inner_var()
+        ):
             raise BreakGraphError(
                 DataDependencyOperationBreak(
-                    f"{self.meta.name} is a middle tensor. Not support to get {name} property."
+                    f"{self.meta.unwrap_or_breakgraph().name} is a middle tensor. Not support to get {name} property."
                 )
             )
         if name in [
@@ -899,9 +929,9 @@ class TensorVariable(VariableBase):
 
     @VariableFactory.register_from_value()
     def from_value(value: Any, graph: FunctionGraph, tracker: Tracker):
-        if isinstance(value, (paddle.Tensor, MetaInfoBase)):
+        if isinstance(value, (paddle.Tensor, MetaInfoOrNull)):
             value = (
-                MetaInfoBase.from_tensor(value)
+                MetaInfoOrNull.from_tensor(value)
                 if isinstance(value, paddle.Tensor)
                 else value
             )
@@ -909,11 +939,12 @@ class TensorVariable(VariableBase):
         return None
 
 
-def get_symbolic_from_meta(meta: MetaInfoBase) -> SymbolicValue:
-    if not isinstance(meta, MetaInfo):
+def get_symbolic_from_meta(meta_or_null: MetaInfoOrNull) -> SymbolicValue:
+    if meta_or_null.is_null():
         raise InnerError(
-            f"get_symbolic_from_meta() got {meta}. Only MetaInfo is supported."
+            f"get_symbolic_from_meta() got {meta_or_null}. Only MetaInfo is supported."
         )
+    meta = meta_or_null.unwrap_unsafe()
     if meta.dtype in [paddle.bool]:
         value = SymbolicBool()
     elif meta.dtype in [
@@ -943,7 +974,7 @@ class SymbolicVariable(VariableBase):
     SymbolicVariable is a subclass of VariableBase used to wrap a symbolic value.
 
     Args:
-        value_or_meta (SymbolicInt | MetaInfoBase): The symbolic value  to be wrapped or metadata.
+        value_or_meta (SymbolicInt | MetaInfoOrNull): The symbolic value  to be wrapped or metadata.
         graph (FunctionGraph): The FunctionGraph object that this variable is associated with.
         tracker (Tracker): The Tracker object that tracks the information of this variable.
     """
@@ -954,17 +985,17 @@ class SymbolicVariable(VariableBase):
 
     def __init__(
         self,
-        value_or_meta: SymbolicInt | MetaInfoBase,
+        value_or_meta: SymbolicInt | MetaInfoOrNull,
         graph: FunctionGraph,
         tracker: Tracker,
     ):
         super().__init__(graph, tracker)
         self.var_name = self.var_name_generator.next()
-        if isinstance(value_or_meta, MetaInfoBase):
-            assert isinstance(
-                value_or_meta, MetaInfo
-            ), "Only MetaInfo is supported"
-            assert len(value_or_meta.shape) == 0
+        if isinstance(value_or_meta, MetaInfoOrNull):
+            assert (
+                not value_or_meta.is_null()
+            ), "MetaInfoOrNull should not be null"
+            assert len(value_or_meta.unwrap_unsafe().shape) == 0
             self.value = get_symbolic_from_meta(value_or_meta)
             self.meta = value_or_meta
         else:
@@ -974,7 +1005,7 @@ class SymbolicVariable(VariableBase):
             self.value = value_or_meta
             self.meta = MetaInfo(
                 [], paddle.int64, True, self.var_name, False, None, None
-            )
+            ).wrap()
         self.need_guard_value = False
         self.graph.side_effects.record_mutable_variable(self)
         self.constraints: list[SymbolicConstraint] = []
@@ -1415,7 +1446,7 @@ class SymbolicVariable(VariableBase):
 class ParameterVariable(TensorVariable):
     def __init__(
         self,
-        meta: MetaInfoBase,
+        meta: MetaInfoOrNull,
         graph: FunctionGraph,
         tracker: Tracker,
     ):
@@ -1424,7 +1455,7 @@ class ParameterVariable(TensorVariable):
     @VariableFactory.register_from_value(successor="TensorVariable")
     def from_value(value: Any, graph: FunctionGraph, tracker: Tracker):
         if isinstance(value, (paddle.base.framework.EagerParamBase)):
-            value = MetaInfoBase.from_tensor(value)
+            value = MetaInfoOrNull.from_tensor(value)
             return ParameterVariable(value, graph, tracker)
         return None
 
@@ -1821,7 +1852,7 @@ class NumPyArrayVariable(NumPyVariable):
 
     def __init__(
         self,
-        value_or_meta: npt.NDArray[Any] | MetaInfoBase,
+        value_or_meta: npt.NDArray[Any] | MetaInfoOrNull,
         graph: FunctionGraph,
         tracker: Tracker,
     ):
@@ -1829,22 +1860,23 @@ class NumPyArrayVariable(NumPyVariable):
         self.var_name = self.var_name_generator.next()
         self.graph.side_effects.record_mutable_variable(self)
 
-        if isinstance(value_or_meta, MetaInfoBase):
+        if isinstance(value_or_meta, MetaInfoOrNull):
             # TODO(wangmingkai02): self.value
             self.value = None
             self.meta = value_or_meta
         else:
             self.value = value_or_meta
-            self.meta = MetaInfoBase.from_numpy(self.value)
+            self.meta = MetaInfoOrNull.from_numpy(self.value)
 
     def __len__(self):
-        if isinstance(self.meta.shape[0], SymbolicInt):
+        meta = self.meta.unwrap_unsafe()
+        if isinstance(meta.shape[0], SymbolicInt):
             raise BreakGraphError(
                 DataDependencyDynamicShapeBreak(
                     "length of NumPy array Variable with first dimension is dynamic shape causes graph break."
                 )
             )
-        return self.meta.shape[0]
+        return meta.shape[0]
 
     def get_py_type(self):
         return np.ndarray
@@ -1881,6 +1913,7 @@ class NumPyArrayVariable(NumPyVariable):
 
     @check_faster_guard
     def make_faster_guard(self) -> list[paddle.framework.core.GuardNodeBase]:
+        meta = self.meta.unwrap_unsafe()
         expr_node = self.tracker.guard_tree_expr_node()
         type_guard = paddle.framework.core.GuardNode(
             paddle.framework.core.TypeMatchGuard(self.get_py_type()),
@@ -1888,12 +1921,12 @@ class NumPyArrayVariable(NumPyVariable):
         )
         dtype_guard = paddle.framework.core.GuardNode(
             paddle.framework.core.NumPyDtypeMatchGuard(
-                np.dtype(_PADDLE_PIR_DTYPE_2_NUMPY_DTYPE[self.meta.dtype])
+                np.dtype(_PADDLE_PIR_DTYPE_2_NUMPY_DTYPE[meta.dtype])
             ),
             [expr_node],
         )
         shape_guard = paddle.framework.core.GuardNode(
-            paddle.framework.core.NumPyArrayShapeMatchGuard(self.meta.shape),
+            paddle.framework.core.NumPyArrayShapeMatchGuard(meta.shape),
             [expr_node],
         )
         return [type_guard, dtype_guard, shape_guard]
@@ -1901,12 +1934,12 @@ class NumPyArrayVariable(NumPyVariable):
     @check_guard
     def make_stringified_guard(self) -> list[StringifiedExpression]:
         frame_value_tracer = self.tracker.trace_value_from_frame()
-        meta = self.meta
+        meta = self.meta.unwrap_unsafe()
 
         dtype_guard = FasterStringifiedExpression(
-            f"{{}}.dtype == {NumPyVariable.format_dtype(np.dtype(_PADDLE_PIR_DTYPE_2_NUMPY_DTYPE[self.meta.dtype]))}",
+            f"{{}}.dtype == {NumPyVariable.format_dtype(np.dtype(_PADDLE_PIR_DTYPE_2_NUMPY_DTYPE[meta.dtype]))}",
             paddle.framework.core.NumPyDtypeMatchGuard(
-                np.dtype(_PADDLE_PIR_DTYPE_2_NUMPY_DTYPE[self.meta.dtype])
+                np.dtype(_PADDLE_PIR_DTYPE_2_NUMPY_DTYPE[meta.dtype])
             ),
             [frame_value_tracer],
             union_free_vars(frame_value_tracer.free_vars, {"np": np}),

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
@@ -885,7 +885,7 @@ class TensorVariable(VariableBase):
             "place",
         ]:
             return VariableFactory.from_value(
-                getattr(self.meta, name),
+                getattr(self.meta.unwrap_or_breakgraph(), name),
                 self.graph,
                 tracker=GetAttrTracker(self, name),
             )

--- a/python/paddle/jit/sot/symbolic/builder.py
+++ b/python/paddle/jit/sot/symbolic/builder.py
@@ -173,7 +173,7 @@ class StatementIRBuilder:
         return DummyFunc()
 
     def compile_fn(
-        self, sir_name: str, input_spec: tuple[InputSpec, ...], **kwargs
+        self, sir_name: str, input_spec: tuple[InputSpec | None, ...], **kwargs
     ):
         """
         start compile and return the python function, which must can be to_static without errors.

--- a/python/paddle/jit/sot/symbolic/compile_cache.py
+++ b/python/paddle/jit/sot/symbolic/compile_cache.py
@@ -301,7 +301,7 @@ class CompileSIRCache(Cache, metaclass=Singleton):
         self,
         builder: StatementIRBuilder,
         sir_name: str,
-        input_spec: tuple[InputSpec, ...],
+        input_spec: tuple[InputSpec | None, ...],
         **kwargs,
     ):
         """
@@ -324,7 +324,7 @@ class CompileSIRCache(Cache, metaclass=Singleton):
         self,
         builder: StatementIRBuilder,
         sir_name: str,
-        input_spec: tuple[InputSpec, ...],
+        input_spec: tuple[InputSpec | None, ...],
         **kwargs,
     ):
         """

--- a/python/paddle/jit/sot/symbolic/export.py
+++ b/python/paddle/jit/sot/symbolic/export.py
@@ -174,7 +174,7 @@ class PyFileGen:
         init_fn.add_sub("super().__init__()")
 
         for param in self.SIR.param_symbol:
-            meta = self.SIR.symbol_meta_map[param]
+            meta = self.SIR.symbol_meta_map[param].unwrap_unsafe()
             init_fn.add_sub(
                 f"{self.name_gener(param)} = self.create_parameter(",
                 f"   shape={meta.shape},",
@@ -218,7 +218,7 @@ class PyFileGen:
 
         for inp in self.SIR.inputs:
             if inp in self.SIR.non_param_symbol:
-                meta = self.SIR.symbol_meta_map[inp.name]
+                meta = self.SIR.symbol_meta_map[inp.name].unwrap_unsafe()
                 shape_str = "[1]" if len(meta.shape) == 0 else str(meta.shape)
                 if meta.dtype in (
                     paddle.int8,

--- a/python/paddle/jit/sot/utils/exceptions.py
+++ b/python/paddle/jit/sot/utils/exceptions.py
@@ -192,6 +192,18 @@ class InferMetaBreak(BreakGraphReasonBase):
     pass
 
 
+class NullMetaBreak(BreakGraphReasonBase):
+    def __init__(
+        self,
+        *,
+        file_path="",
+        line_number=-1,
+    ):
+        super().__init__(
+            "Access attribute from null meta", file_path, line_number
+        )
+
+
 class SotErrorBase(Exception):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/test/dygraph_to_static/test_optional_tensor.py
+++ b/test/dygraph_to_static/test_optional_tensor.py
@@ -36,6 +36,8 @@ def call_fused_rms_norm(x, y):
 class TestOptionalTensorOutput(Dy2StTestBase):
     @test_pir_only
     def test_fused_rms_norm(self):
+        if not paddle.is_compiled_with_cuda():
+            return
         fn = call_fused_rms_norm
         static_fn = paddle.jit.to_static(fn)
 

--- a/test/dygraph_to_static/test_optional_tensor.py
+++ b/test/dygraph_to_static/test_optional_tensor.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+from dygraph_to_static_utils import (
+    Dy2StTestBase,
+    test_pir_only,
+)
+
+import paddle
+
+
+def call_fused_rms_norm(x, y):
+    return paddle.incubate.nn.functional.fused_rms_norm(
+        x,
+        y,
+        None,
+        1e-6,
+        begin_norm_axis=1,
+    )
+
+
+class TestOptionalTensorOutput(Dy2StTestBase):
+    @test_pir_only
+    def test_fused_rms_norm(self):
+        fn = call_fused_rms_norm
+        static_fn = paddle.jit.to_static(fn)
+
+        x = paddle.randn([1410, 5120], dtype='float32')
+        y = paddle.randn([5120], dtype='float32')
+        x.stop_gradient = False
+
+        out_1_dy, out_2_dy = fn(x, y)
+        out_1_st, out_2_st = static_fn(x, y)
+        np.testing.assert_equal(out_1_dy.numpy(), out_1_st.numpy())
+        self.assertFalse(out_2_dy._is_initialized())
+        self.assertFalse(out_2_st._is_initialized())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

LLM inference 暴露的问题（使用了 `fused_rms_norm`）

SOT 支持 `Optional[Tensor]` 输出，为确保类型安全，使用 `MetaInfoOrNull`（i.e. `Option<MetaInfo>` in rust，`MetaInfo | None` 在我们如此低程度的类型提示覆盖率下，难以做到完善）

为确保输出和动态图一致是 `Tensor(Not initialized)`，调整了 `CreateTensorFromValue` 适配 `Value(nullptr)` case，并移除了 `sinking_decomp` 里对 `Value(nullptr)` 转为 `None` 的特判逻辑

<!-- PCard-66972 -->