### PR TITLE
[Auto-parallel] Fix fusing comm optimize only in `stage1` shading strategy

### DIFF
--- a/python/paddle/distributed/auto_parallel/api.py
+++ b/python/paddle/distributed/auto_parallel/api.py
@@ -1827,7 +1827,9 @@ class _ShardOptimizer(Optimizer):
             params_grads = self._tensor_fusion(params_grads)
         else:
             # Fuse the communication of gradients prior to the optimization operation in the dynamic mode.
-            if paddle.in_dynamic_mode():
+            if paddle.in_dynamic_mode() and isinstance(
+                self._shard_fn, ShardingStage1
+            ):
                 # Get fuse optimization flag.
                 def get_env(flag_name):
                     if os.getenv(flag_name) in ['True', 'true', '1']:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
为 sharding fuse 通信优化执行 增加 `stage1` 前置检查
Pcard-90697 
