### PR TITLE
[CI] ignore Build docker in fork repo

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,6 +32,7 @@ on:
 
 jobs:
   build-docker-images:
+    if: github.repository_owner == 'PaddlePaddle'
     name: Build docker
     runs-on:
       group: Docker-build


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Devs

### Description
<!-- Describe what you’ve done -->

在 fork 仓库禁用 `Build docker` ci

<img width="1279" alt="截屏2025-05-16 下午2 43 48" src="https://github.com/user-attachments/assets/7e93a0a1-209f-4dbb-8902-2dba65a71ed0" />
