### PR TITLE
[XPU] Support complex and 0-size tensor for add

### DIFF
--- a/paddle/fluid/imperative/gradient_accumulator.cc
+++ b/paddle/fluid/imperative/gradient_accumulator.cc
@@ -187,7 +187,9 @@ void TensorAdd(const VarType& src, VarType* dst) {
     PADDLE_TENSOR_ADD(double, phi::XPUContext);
     PADDLE_TENSOR_ADD(phi::dtype::float16, phi::XPUContext);
     PADDLE_TENSOR_ADD(phi::dtype::bfloat16, phi::XPUContext);
+#ifdef PADDLE_WITH_XPU_FFT
     PADDLE_TENSOR_ADD(phi::dtype::complex<float>, phi::XPUContext);
+#endif
 #endif
   }
 

--- a/paddle/fluid/imperative/gradient_accumulator.cc
+++ b/paddle/fluid/imperative/gradient_accumulator.cc
@@ -187,6 +187,7 @@ void TensorAdd(const VarType& src, VarType* dst) {
     PADDLE_TENSOR_ADD(double, phi::XPUContext);
     PADDLE_TENSOR_ADD(phi::dtype::float16, phi::XPUContext);
     PADDLE_TENSOR_ADD(phi::dtype::bfloat16, phi::XPUContext);
+    PADDLE_TENSOR_ADD(phi::dtype::complex<float>, phi::XPUContext);
 #endif
   }
 

--- a/paddle/phi/backends/xpu/xpu3_op_list.cc
+++ b/paddle/phi/backends/xpu/xpu3_op_list.cc
@@ -407,6 +407,9 @@ XPUOpMap& get_kl3_ops() {
        XPUKernelSet({phi::DataType::FLOAT32,
                      phi::DataType::FLOAT16,
                      phi::DataType::BFLOAT16,
+#ifdef PADDLE_WITH_XPU_FFT
+                     phi::DataType::COMPLEX64,
+#endif
                      phi::DataType::INT64,
                      phi::DataType::INT32})},
       {"elementwise_add",
@@ -414,6 +417,9 @@ XPUOpMap& get_kl3_ops() {
                      phi::DataType::FLOAT32,
                      phi::DataType::FLOAT16,
                      phi::DataType::BFLOAT16,
+#ifdef PADDLE_WITH_XPU_FFT
+                     phi::DataType::COMPLEX64,
+#endif
                      phi::DataType::INT64,
                      phi::DataType::INT32})},
       {"elementwise_div_grad",

--- a/paddle/phi/kernels/xpu/elementwise_add_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/elementwise_add_grad_kernel.cc
@@ -23,6 +23,7 @@
 #include "paddle/phi/backends/xpu/xpu_info.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/core/tensor_utils.h"
+#include "paddle/phi/kernels/complex_kernel.h"
 #include "paddle/phi/kernels/funcs/elementwise_base.h"
 
 namespace phi {
@@ -97,6 +98,72 @@ void AddGradKernel(const Context& dev_ctx,
     }
   }
 }
+#ifdef PADDLE_WITH_XPU_FFT
+template <>
+void AddGradKernel<phi::dtype::complex<float>, XPUContext>(
+    const XPUContext& dev_ctx,
+    const DenseTensor& x,
+    const DenseTensor& y,
+    const DenseTensor& dout,
+    int axis,
+    DenseTensor* dx,
+    DenseTensor* dy) {
+  using T = phi::dtype::complex<float>;
+  const bool compute_dx = (dx != nullptr);
+  const bool compute_dy = (dy != nullptr);
+
+  DenseTensor x_real = Real<T, XPUContext>(dev_ctx, x);
+  DenseTensor x_imag = Imag<T, XPUContext>(dev_ctx, x);
+  DenseTensor y_real = Real<T, XPUContext>(dev_ctx, y);
+  DenseTensor y_imag = Imag<T, XPUContext>(dev_ctx, y);
+  DenseTensor dout_real = Real<T, XPUContext>(dev_ctx, dout);
+  DenseTensor dout_imag = Imag<T, XPUContext>(dev_ctx, dout);
+
+  if (compute_dx || compute_dy) {
+    DenseTensor dx_real, dx_imag, dy_real, dy_imag;
+
+    if (compute_dx) {
+      dx_real.Resize(x_real.dims());
+      dx_imag.Resize(x_imag.dims());
+      dev_ctx.template Alloc<float>(&dx_real);
+      dev_ctx.template Alloc<float>(&dx_imag);
+    }
+
+    if (compute_dy) {
+      dy_real.Resize(y_real.dims());
+      dy_imag.Resize(y_imag.dims());
+      dev_ctx.template Alloc<float>(&dy_real);
+      dev_ctx.template Alloc<float>(&dy_imag);
+    }
+
+    AddGradKernel<float, XPUContext>(dev_ctx,
+                                     x_real,
+                                     y_real,
+                                     dout_real,
+                                     axis,
+                                     compute_dx ? &dx_real : nullptr,
+                                     compute_dy ? &dy_real : nullptr);
+
+    AddGradKernel<float, XPUContext>(dev_ctx,
+                                     x_imag,
+                                     y_imag,
+                                     dout_imag,
+                                     axis,
+                                     compute_dx ? &dx_imag : nullptr,
+                                     compute_dy ? &dy_imag : nullptr);
+
+    if (compute_dx) {
+      dev_ctx.template Alloc<T>(dx);
+      phi::ComplexKernel<float>(dev_ctx, dx_real, dx_imag, dx);
+    }
+
+    if (compute_dy) {
+      dev_ctx.template Alloc<T>(dy);
+      phi::ComplexKernel<float>(dev_ctx, dy_real, dy_imag, dy);
+    }
+  }
+}
+#endif
 }  // namespace phi
 
 PD_REGISTER_KERNEL(add_grad,
@@ -105,6 +172,10 @@ PD_REGISTER_KERNEL(add_grad,
                    phi::AddGradKernel,
                    phi::dtype::float16,
                    phi::dtype::bfloat16,
+#ifdef PADDLE_WITH_XPU_FFT
+                   phi::dtype::complex<float>,
+#endif
                    float,
                    int,
-                   int64_t) {}
+                   int64_t) {
+}

--- a/paddle/phi/kernels/xpu/elementwise_add_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/elementwise_add_grad_kernel.cc
@@ -24,6 +24,7 @@
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/core/tensor_utils.h"
 #include "paddle/phi/kernels/complex_kernel.h"
+#include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/funcs/elementwise_base.h"
 
 namespace phi {
@@ -35,6 +36,25 @@ void AddGradKernel(const Context& dev_ctx,
                    int axis,
                    DenseTensor* dx,
                    DenseTensor* dy) {
+  if (dout.numel() == 0) {
+    if (dx) {
+      if (dx->numel() == 0) {
+        dev_ctx.template Alloc<T>(dx);
+      } else {
+        phi::Full<T, Context>(
+            dev_ctx, phi::IntArray(common::vectorize(dx->dims())), 0, dx);
+      }
+    }
+    if (dy) {
+      if (dy->numel() == 0) {
+        dev_ctx.template Alloc<T>(dy);
+      } else {
+        phi::Full<T, Context>(
+            dev_ctx, phi::IntArray(common::vectorize(dy->dims())), 0, dy);
+      }
+    }
+    return;
+  }
   using XPUType = typename XPUTypeTrait<T>::Type;
   funcs::ElementwiseGradPreProcess(dout, dx);
   auto* dz = &dout;
@@ -112,6 +132,9 @@ void AddGradKernel<phi::dtype::complex<float>, XPUContext>(
   const bool compute_dx = (dx != nullptr);
   const bool compute_dy = (dy != nullptr);
 
+  // The current complex number implementation uses separate real/imaginary
+  // parts,resulting in redundant operations and performance
+  // penalties.Optimization should address this in future iterations.
   DenseTensor x_real = Real<T, XPUContext>(dev_ctx, x);
   DenseTensor x_imag = Imag<T, XPUContext>(dev_ctx, x);
   DenseTensor y_real = Real<T, XPUContext>(dev_ctx, y);

--- a/paddle/phi/kernels/xpu/elementwise_add_kernel.cc
+++ b/paddle/phi/kernels/xpu/elementwise_add_kernel.cc
@@ -24,6 +24,7 @@
 #include "paddle/phi/backends/xpu/xpu_info.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/cast_kernel.h"
+#include "paddle/phi/kernels/complex_kernel.h"
 #include "paddle/phi/kernels/impl/elementwise_kernel_impl.h"
 #include "paddle/phi/kernels/xpu/elementwise.h"
 
@@ -111,14 +112,95 @@ void GradAddXPUKernel(const Context& dev_ctx,
   PADDLE_ENFORCE_XDNN_SUCCESS(r, "broadcast_add");
 }
 
+#ifdef PADDLE_WITH_XPU_FFT
+template <>
+void AddKernel<phi::dtype::complex<float>, XPUContext>(
+    const XPUContext& dev_ctx,
+    const DenseTensor& x,
+    const DenseTensor& y,
+    DenseTensor* out) {
+  using T = phi::dtype::complex<float>;
+
+  auto f = [](xpu::Context* ctx,
+              const float* x,
+              const float* y,
+              float* z,
+              const std::vector<int64_t>& xshape,
+              const std::vector<int64_t>& yshape) {
+    return xpu::broadcast_add<float>(ctx, x, y, z, xshape, yshape);
+  };
+  // The current complex number implementation uses separate real/imaginary
+  // parts,resulting in redundant operations and performance
+  // penalties.Optimization should address this in future iterations.
+  const DenseTensor x_real = Real<T, XPUContext>(dev_ctx, x);
+  const DenseTensor x_imag = Imag<T, XPUContext>(dev_ctx, x);
+  const DenseTensor y_real = Real<T, XPUContext>(dev_ctx, y);
+  const DenseTensor y_imag = Imag<T, XPUContext>(dev_ctx, y);
+  DenseTensor real_out, imag_out;
+  real_out.Resize(out->dims());
+  imag_out.Resize(out->dims());
+  dev_ctx.template Alloc<float>(&real_out);
+  dev_ctx.template Alloc<float>(&imag_out);
+
+  XPUElementwise<float, float>(dev_ctx, x_real, y_real, -1, &real_out, f);
+  XPUElementwise<float, float>(dev_ctx, x_imag, y_imag, -1, &imag_out, f);
+  phi::ComplexKernel<float>(dev_ctx, real_out, imag_out, out);
+}
+
+template <>
+void GradAddXPUKernel<phi::dtype::complex<float>, XPUContext>(
+    const XPUContext& dev_ctx,
+    const DenseTensor& x,
+    const DenseTensor& y,
+    DenseTensor* out) {
+  using T = phi::dtype::complex<float>;
+  dev_ctx.template Alloc<T>(out);
+  auto x_shape = common::vectorize<int64_t>(x.dims());
+  auto y_shape = common::vectorize<int64_t>(y.dims());
+
+  // The current complex number implementation uses separate real/imaginary
+  // parts,resulting in redundant operations and performance
+  // penalties.Optimization should address this in future iterations.
+  const DenseTensor x_real = Real<T, XPUContext>(dev_ctx, x);
+  const DenseTensor x_imag = Imag<T, XPUContext>(dev_ctx, x);
+  const DenseTensor y_real = Real<T, XPUContext>(dev_ctx, y);
+  const DenseTensor y_imag = Imag<T, XPUContext>(dev_ctx, y);
+  DenseTensor real_out, imag_out;
+  real_out.Resize(out->dims());
+  imag_out.Resize(out->dims());
+  dev_ctx.template Alloc<float>(&real_out);
+  dev_ctx.template Alloc<float>(&imag_out);
+
+  int r = xpu::broadcast_add(dev_ctx.x_context(),
+                             x_real.data<float>(),
+                             y_real.data<float>(),
+                             real_out.data<float>(),
+                             x_shape,
+                             y_shape);
+  PADDLE_ENFORCE_XDNN_SUCCESS(r, "broadcast_add");
+  r = xpu::broadcast_add(dev_ctx.x_context(),
+                         x_imag.data<float>(),
+                         y_imag.data<float>(),
+                         imag_out.data<float>(),
+                         x_shape,
+                         y_shape);
+  PADDLE_ENFORCE_XDNN_SUCCESS(r, "broadcast_add");
+  phi::ComplexKernel<float>(dev_ctx, real_out, imag_out, out);
+}
+#endif
+
 }  // namespace phi
 
 PD_REGISTER_KERNEL(grad_add,
                    XPU,
                    ALL_LAYOUT,
                    phi::GradAddXPUKernel,
+#ifdef PADDLE_WITH_XPU_FFT
+                   phi::dtype::complex<float>,
+#endif
                    phi::dtype::float16,
-                   float) {}
+                   float) {
+}
 
 PD_REGISTER_KERNEL(add,
                    XPU,
@@ -127,6 +209,10 @@ PD_REGISTER_KERNEL(add,
                    double,
                    phi::dtype::float16,
                    phi::dtype::bfloat16,
+#ifdef PADDLE_WITH_XPU_FFT
+                   phi::dtype::complex<float>,
+#endif
                    float,
                    int,
-                   int64_t) {}
+                   int64_t) {
+}

--- a/paddle/phi/kernels/xpu/elementwise_add_kernel.cc
+++ b/paddle/phi/kernels/xpu/elementwise_add_kernel.cc
@@ -35,6 +35,10 @@ void AddKernel(const Context& dev_ctx,
                const DenseTensor& x,
                const DenseTensor& y,
                DenseTensor* out) {
+  if (out->numel() == 0) {
+    dev_ctx.template Alloc<T>(out);
+    return;
+  }
   if (x.dtype() == phi::DataType::FLOAT32 &&
       (y.dtype() == phi::DataType::BFLOAT16 ||
        y.dtype() == phi::DataType::FLOAT16)) {
@@ -120,7 +124,10 @@ void AddKernel<phi::dtype::complex<float>, XPUContext>(
     const DenseTensor& y,
     DenseTensor* out) {
   using T = phi::dtype::complex<float>;
-
+  if (out->numel() == 0) {
+    dev_ctx.template Alloc<T>(out);
+    return;
+  }
   auto f = [](xpu::Context* ctx,
               const float* x,
               const float* y,
@@ -147,46 +154,6 @@ void AddKernel<phi::dtype::complex<float>, XPUContext>(
   phi::ComplexKernel<float>(dev_ctx, real_out, imag_out, out);
 }
 
-template <>
-void GradAddXPUKernel<phi::dtype::complex<float>, XPUContext>(
-    const XPUContext& dev_ctx,
-    const DenseTensor& x,
-    const DenseTensor& y,
-    DenseTensor* out) {
-  using T = phi::dtype::complex<float>;
-  dev_ctx.template Alloc<T>(out);
-  auto x_shape = common::vectorize<int64_t>(x.dims());
-  auto y_shape = common::vectorize<int64_t>(y.dims());
-
-  // The current complex number implementation uses separate real/imaginary
-  // parts,resulting in redundant operations and performance
-  // penalties.Optimization should address this in future iterations.
-  const DenseTensor x_real = Real<T, XPUContext>(dev_ctx, x);
-  const DenseTensor x_imag = Imag<T, XPUContext>(dev_ctx, x);
-  const DenseTensor y_real = Real<T, XPUContext>(dev_ctx, y);
-  const DenseTensor y_imag = Imag<T, XPUContext>(dev_ctx, y);
-  DenseTensor real_out, imag_out;
-  real_out.Resize(out->dims());
-  imag_out.Resize(out->dims());
-  dev_ctx.template Alloc<float>(&real_out);
-  dev_ctx.template Alloc<float>(&imag_out);
-
-  int r = xpu::broadcast_add(dev_ctx.x_context(),
-                             x_real.data<float>(),
-                             y_real.data<float>(),
-                             real_out.data<float>(),
-                             x_shape,
-                             y_shape);
-  PADDLE_ENFORCE_XDNN_SUCCESS(r, "broadcast_add");
-  r = xpu::broadcast_add(dev_ctx.x_context(),
-                         x_imag.data<float>(),
-                         y_imag.data<float>(),
-                         imag_out.data<float>(),
-                         x_shape,
-                         y_shape);
-  PADDLE_ENFORCE_XDNN_SUCCESS(r, "broadcast_add");
-  phi::ComplexKernel<float>(dev_ctx, real_out, imag_out, out);
-}
 #endif
 
 }  // namespace phi
@@ -195,12 +162,8 @@ PD_REGISTER_KERNEL(grad_add,
                    XPU,
                    ALL_LAYOUT,
                    phi::GradAddXPUKernel,
-#ifdef PADDLE_WITH_XPU_FFT
-                   phi::dtype::complex<float>,
-#endif
                    phi::dtype::float16,
-                   float) {
-}
+                   float) {}
 
 PD_REGISTER_KERNEL(add,
                    XPU,

--- a/test/xpu/test_conj_op_xpu.py
+++ b/test/xpu/test_conj_op_xpu.py
@@ -43,12 +43,10 @@ class XPUTestConjOp(XPUOpTestWrapper):
             self.outputs = {'Out': out}
 
         def init_dtype_type(self):
-            self.dtype = np.complex64
+            self.dtype = self.in_type
 
         def init_input(self):
-            self.x = (
-                np.random.random((12, 14)) + 1j * np.random.random((12, 14))
-            ).astype(self.dtype)
+            self.x = np.random.random([2, 2, 3]).astype(self.dtype)
 
         def test_check_output(self):
             if paddle.is_compiled_with_xpu():
@@ -66,45 +64,64 @@ class XPUTestConjOp(XPUOpTestWrapper):
 
     class TestConjOp1(TestConjOp):
         def init_input(self):
-            self.x = (
-                np.random.random([2, 20, 2, 3])
-                + 1j * np.random.random([2, 20, 2, 3])
-            ).astype(self.dtype)
+            self.x = np.random.random([2, 3]).astype(self.dtype)
 
     class TestConjOp2(TestConjOp):
         def init_input(self):
-            self.x = (
-                np.random.random([2, 2, 3]) + 1j * np.random.random([2, 2, 3])
-            ).astype(self.dtype)
-
-    class TestConjOp3(TestConjOp):
-        def init_input(self):
-            self.x = np.random.random([2, 2, 3]).astype(np.int32)
-
-    class TestConjOp4(TestConjOp):
-        def init_input(self):
-            self.x = np.random.random([2, 2, 3]).astype(np.int64)
-
-    class TestConjOp5(TestConjOp):
-        def init_input(self):
-            self.x = np.random.random([2, 2, 3]).astype(np.float16)
-
-    class TestConjOp6(TestConjOp):
-        def init_input(self):
-            self.x = np.random.random([2, 2, 3]).astype(np.uint16)
-
-    class TestConjOp7(TestConjOp):
-        def init_input(self):
-            self.x = np.random.random([2, 2, 3]).astype(np.float32)
-
-    class TestConjOp8(TestConjOp):
-        def init_input(self):
-            self.x = np.random.random([2, 2, 3]).astype(np.float64)
+            self.x = np.random.random([2, 20, 2, 3]).astype(self.dtype)
 
 
 support_types = get_xpu_op_support_types('conj')
 for stype in support_types:
     create_test_class(globals(), XPUTestConjOp, stype)
+
+
+class TestConjComplexOp(XPUOpTest):
+    def setUp(self):
+        self.op_type = "conj"
+        self.python_api = paddle.tensor.conj
+        self.init_dtype_type()
+        self.init_input()
+        self.inputs = {'X': self.x}
+        out = np.conj(self.x)
+        self.outputs = {'Out': out}
+
+    def init_dtype_type(self):
+        self.dtype = np.complex64
+
+    def init_input(self):
+        self.x = (
+            np.random.random((12, 14)) + 1j * np.random.random((12, 14))
+        ).astype(self.dtype)
+
+    def test_check_output(self):
+        if paddle.is_compiled_with_xpu():
+            place = paddle.XPUPlace(0)
+            self.check_output_with_place(place)
+
+    def test_check_grad(self):
+        if paddle.is_compiled_with_xpu():
+            place = paddle.XPUPlace(0)
+            self.check_grad_with_place(
+                place,
+                ['X'],
+                'Out',
+            )
+
+
+class TestConjComplexOp1(TestConjComplexOp):
+    def init_input(self):
+        self.x = (
+            np.random.random([2, 20, 2, 3])
+            + 1j * np.random.random([2, 20, 2, 3])
+        ).astype(self.dtype)
+
+
+class TestConjComplexOp2(TestConjComplexOp):
+    def init_input(self):
+        self.x = (
+            np.random.random([2, 2, 3]) + 1j * np.random.random([2, 2, 3])
+        ).astype(self.dtype)
 
 
 if __name__ == "__main__":

--- a/test/xpu/test_conj_op_xpu.py
+++ b/test/xpu/test_conj_op_xpu.py
@@ -43,10 +43,12 @@ class XPUTestConjOp(XPUOpTestWrapper):
             self.outputs = {'Out': out}
 
         def init_dtype_type(self):
-            self.dtype = self.in_type
+            self.dtype = np.complex64
 
         def init_input(self):
-            self.x = np.random.random([2, 2, 3]).astype(self.dtype)
+            self.x = (
+                np.random.random((12, 14)) + 1j * np.random.random((12, 14))
+            ).astype(self.dtype)
 
         def test_check_output(self):
             if paddle.is_compiled_with_xpu():
@@ -64,64 +66,45 @@ class XPUTestConjOp(XPUOpTestWrapper):
 
     class TestConjOp1(TestConjOp):
         def init_input(self):
-            self.x = np.random.random([2, 3]).astype(self.dtype)
+            self.x = (
+                np.random.random([2, 20, 2, 3])
+                + 1j * np.random.random([2, 20, 2, 3])
+            ).astype(self.dtype)
 
     class TestConjOp2(TestConjOp):
         def init_input(self):
-            self.x = np.random.random([2, 20, 2, 3]).astype(self.dtype)
+            self.x = (
+                np.random.random([2, 2, 3]) + 1j * np.random.random([2, 2, 3])
+            ).astype(self.dtype)
+
+    class TestConjOp3(TestConjOp):
+        def init_input(self):
+            self.x = np.random.random([2, 2, 3]).astype(np.int32)
+
+    class TestConjOp4(TestConjOp):
+        def init_input(self):
+            self.x = np.random.random([2, 2, 3]).astype(np.int64)
+
+    class TestConjOp5(TestConjOp):
+        def init_input(self):
+            self.x = np.random.random([2, 2, 3]).astype(np.float16)
+
+    class TestConjOp6(TestConjOp):
+        def init_input(self):
+            self.x = np.random.random([2, 2, 3]).astype(np.uint16)
+
+    class TestConjOp7(TestConjOp):
+        def init_input(self):
+            self.x = np.random.random([2, 2, 3]).astype(np.float32)
+
+    class TestConjOp8(TestConjOp):
+        def init_input(self):
+            self.x = np.random.random([2, 2, 3]).astype(np.float64)
 
 
 support_types = get_xpu_op_support_types('conj')
 for stype in support_types:
     create_test_class(globals(), XPUTestConjOp, stype)
-
-
-class TestConjComplexOp(XPUOpTest):
-    def setUp(self):
-        self.op_type = "conj"
-        self.python_api = paddle.tensor.conj
-        self.init_dtype_type()
-        self.init_input()
-        self.inputs = {'X': self.x}
-        out = np.conj(self.x)
-        self.outputs = {'Out': out}
-
-    def init_dtype_type(self):
-        self.dtype = np.complex64
-
-    def init_input(self):
-        self.x = (
-            np.random.random((12, 14)) + 1j * np.random.random((12, 14))
-        ).astype(self.dtype)
-
-    def test_check_output(self):
-        if paddle.is_compiled_with_xpu():
-            place = paddle.XPUPlace(0)
-            self.check_output_with_place(place)
-
-    def test_check_grad(self):
-        if paddle.is_compiled_with_xpu():
-            place = paddle.XPUPlace(0)
-            self.check_grad_with_place(
-                place,
-                ['X'],
-                'Out',
-            )
-
-
-class TestConjComplexOp1(TestConjComplexOp):
-    def init_input(self):
-        self.x = (
-            np.random.random([2, 20, 2, 3])
-            + 1j * np.random.random([2, 20, 2, 3])
-        ).astype(self.dtype)
-
-
-class TestConjComplexOp2(TestConjComplexOp):
-    def init_input(self):
-        self.x = (
-            np.random.random([2, 2, 3]) + 1j * np.random.random([2, 2, 3])
-        ).astype(self.dtype)
 
 
 if __name__ == "__main__":

--- a/test/xpu/test_elementwise_add_op_xpu.py
+++ b/test/xpu/test_elementwise_add_op_xpu.py
@@ -121,44 +121,29 @@ class XPUTestElementwiseAddOp(XPUOpTestWrapper):
             self.y = np.random.uniform(-1, 1, []).astype(self.dtype)
             self.out = self.x + self.y
 
-    class TestElementwiseAddOp_Complex1(TestElementwiseAddOp):
+    class TestElementwiseAddOp_ZeroSize1(TestElementwiseAddOp):
         def init_input_output(self):
-            self.x = (
-                np.random.rand(2, 3, 4) + 1j * np.random.rand(2, 3, 4)
-            ).astype(self.dtype)
-            self.y = (
-                np.random.rand(2, 3, 4) + 1j * np.random.rand(2, 3, 4)
-            ).astype(self.dtype)
+            self.x = np.random.rand(0, 3, 4).astype(self.dtype)
+            self.y = np.random.rand(1).astype(self.dtype)
             self.out = self.x + self.y
 
-        def init_dtype(self):
-            self.dtype = np.complex64
-
-    class TestElementwiseAddOp_Complex2(TestElementwiseAddOp):
+    class TestElementwiseAddOp_ZeroSize2(TestElementwiseAddOp):
         def init_input_output(self):
-            self.x = (
-                np.random.rand(2, 3, 4) + 1j * np.random.rand(2, 3, 4)
-            ).astype(self.dtype)
-            self.y = (np.random.rand(1, 1) + 1j * np.random.rand(1, 1)).astype(
-                self.dtype
-            )
+            self.x = np.random.rand(0, 3, 4).astype(self.dtype)
+            self.y = np.random.rand(0, 3, 4).astype(self.dtype)
             self.out = self.x + self.y
 
-        def init_dtype(self):
-            self.dtype = np.complex64
-
-    class TestElementwiseAddOp_Complex3(TestElementwiseAddOp):
+    class TestElementwiseAddOp_ZeroSize3(TestElementwiseAddOp):
         def init_input_output(self):
-            self.x = (
-                np.random.rand(100, 2, 3) + 1j * np.random.rand(100, 2, 3)
-            ).astype(self.dtype)
-            self.y = (np.random.rand(1, 1) + 1j * np.random.rand(1, 1)).astype(
-                self.dtype
-            )
+            self.x = np.random.rand(3, 0, 4).astype(self.dtype)
+            self.y = np.random.rand(1, 1, 4).astype(self.dtype)
             self.out = self.x + self.y
 
-        def init_dtype(self):
-            self.dtype = np.complex64
+    class TestElementwiseAddOp_ZeroSize4(TestElementwiseAddOp):
+        def init_input_output(self):
+            self.x = np.random.rand(3, 0, 4).astype(self.dtype)
+            self.y = np.random.rand(1, 0, 4).astype(self.dtype)
+            self.out = self.x + self.y
 
     @skip_check_grad_ci(
         reason="[skip shape check] Use y_shape(1) to test broadcast."
@@ -380,6 +365,98 @@ class XPUTestElementwiseAddOp(XPUOpTestWrapper):
 support_types = get_xpu_op_support_types('elementwise_add')
 for stype in support_types:
     create_test_class(globals(), XPUTestElementwiseAddOp, stype)
+
+
+class TestElementwiseAddOpComplex(XPUOpTest):
+    def setUp(self):
+        self.op_type = "elementwise_add"
+        self.init_dtype()
+        self.init_input_output()
+        self.init_axis()
+        self.init_max_relative_error()
+        self.inputs = {
+            'X': OpTest.np_dtype_to_base_dtype(self.x),
+            'Y': OpTest.np_dtype_to_base_dtype(self.y),
+        }
+        self.attrs = {'axis': self.axis, 'use_mkldnn': self.use_mkldnn}
+        self.outputs = {'Out': self.out}
+
+    def test_check_output(self):
+        if paddle.is_compiled_with_xpu():
+            place = paddle.XPUPlace(0)
+            self.check_output_with_place(place)
+
+    def test_check_grad_normal(self):
+        if paddle.is_compiled_with_xpu():
+            place = paddle.XPUPlace(0)
+            self.check_grad_with_place(
+                place,
+                ['X', 'Y'],
+                'Out',
+                max_relative_error=self.max_relative_error,
+            )
+
+    def test_check_grad_ignore_x(self):
+        if paddle.is_compiled_with_xpu():
+            place = paddle.XPUPlace(0)
+            self.check_grad_with_place(
+                place,
+                ['Y'],
+                'Out',
+                no_grad_set=set("X"),
+                max_relative_error=self.max_relative_error,
+            )
+
+    def test_check_grad_ignore_y(self):
+        if paddle.is_compiled_with_xpu():
+            place = paddle.XPUPlace(0)
+            self.check_grad_with_place(
+                place,
+                ['X'],
+                'Out',
+                no_grad_set=set("Y"),
+                max_relative_error=self.max_relative_error,
+            )
+
+    def init_input_output(self):
+        self.x = (
+            np.random.rand(2, 3, 4) + 1j * np.random.rand(2, 3, 4)
+        ).astype(self.dtype)
+        self.y = (
+            np.random.rand(2, 3, 4) + 1j * np.random.rand(2, 3, 4)
+        ).astype(self.dtype)
+        self.out = self.x + self.y
+
+    def init_dtype(self):
+        self.dtype = np.complex64
+
+    def init_axis(self):
+        self.axis = -1
+
+    def init_max_relative_error(self):
+        self.max_relative_error = 0.006
+
+
+class TestElementwiseAddOpComplex2(TestElementwiseAddOpComplex):
+    def init_input_output(self):
+        self.x = (
+            np.random.rand(2, 3, 4) + 1j * np.random.rand(2, 3, 4)
+        ).astype(self.dtype)
+        self.y = (np.random.rand(1, 1) + 1j * np.random.rand(1, 1)).astype(
+            self.dtype
+        )
+        self.out = self.x + self.y
+
+
+class TestElementwiseAddOpComplex3(TestElementwiseAddOpComplex):
+    def init_input_output(self):
+        self.x = (
+            np.random.rand(100, 2, 3) + 1j * np.random.rand(100, 2, 3)
+        ).astype(self.dtype)
+        self.y = (np.random.rand(1, 1) + 1j * np.random.rand(1, 1)).astype(
+            self.dtype
+        )
+        self.out = self.x + self.y
 
 
 @unittest.skipIf(

--- a/test/xpu/test_elementwise_add_op_xpu.py
+++ b/test/xpu/test_elementwise_add_op_xpu.py
@@ -373,7 +373,6 @@ class TestElementwiseAddOpComplex(XPUOpTest):
         self.init_dtype()
         self.init_input_output()
         self.init_axis()
-        self.init_max_relative_error()
         self.inputs = {
             'X': OpTest.np_dtype_to_base_dtype(self.x),
             'Y': OpTest.np_dtype_to_base_dtype(self.y),
@@ -393,7 +392,6 @@ class TestElementwiseAddOpComplex(XPUOpTest):
                 place,
                 ['X', 'Y'],
                 'Out',
-                max_relative_error=self.max_relative_error,
             )
 
     def test_check_grad_ignore_x(self):
@@ -404,7 +402,6 @@ class TestElementwiseAddOpComplex(XPUOpTest):
                 ['Y'],
                 'Out',
                 no_grad_set=set("X"),
-                max_relative_error=self.max_relative_error,
             )
 
     def test_check_grad_ignore_y(self):
@@ -415,7 +412,6 @@ class TestElementwiseAddOpComplex(XPUOpTest):
                 ['X'],
                 'Out',
                 no_grad_set=set("Y"),
-                max_relative_error=self.max_relative_error,
             )
 
     def init_input_output(self):
@@ -432,9 +428,6 @@ class TestElementwiseAddOpComplex(XPUOpTest):
 
     def init_axis(self):
         self.axis = -1
-
-    def init_max_relative_error(self):
-        self.max_relative_error = 0.006
 
 
 class TestElementwiseAddOpComplex2(TestElementwiseAddOpComplex):

--- a/test/xpu/test_elementwise_add_op_xpu.py
+++ b/test/xpu/test_elementwise_add_op_xpu.py
@@ -121,6 +121,45 @@ class XPUTestElementwiseAddOp(XPUOpTestWrapper):
             self.y = np.random.uniform(-1, 1, []).astype(self.dtype)
             self.out = self.x + self.y
 
+    class TestElementwiseAddOp_Complex1(TestElementwiseAddOp):
+        def init_input_output(self):
+            self.x = (
+                np.random.rand(2, 3, 4) + 1j * np.random.rand(2, 3, 4)
+            ).astype(self.dtype)
+            self.y = (
+                np.random.rand(2, 3, 4) + 1j * np.random.rand(2, 3, 4)
+            ).astype(self.dtype)
+            self.out = self.x + self.y
+
+        def init_dtype(self):
+            self.dtype = np.complex64
+
+    class TestElementwiseAddOp_Complex2(TestElementwiseAddOp):
+        def init_input_output(self):
+            self.x = (
+                np.random.rand(2, 3, 4) + 1j * np.random.rand(2, 3, 4)
+            ).astype(self.dtype)
+            self.y = (np.random.rand(1, 1) + 1j * np.random.rand(1, 1)).astype(
+                self.dtype
+            )
+            self.out = self.x + self.y
+
+        def init_dtype(self):
+            self.dtype = np.complex64
+
+    class TestElementwiseAddOp_Complex3(TestElementwiseAddOp):
+        def init_input_output(self):
+            self.x = (
+                np.random.rand(100, 2, 3) + 1j * np.random.rand(100, 2, 3)
+            ).astype(self.dtype)
+            self.y = (np.random.rand(1, 1) + 1j * np.random.rand(1, 1)).astype(
+                self.dtype
+            )
+            self.out = self.x + self.y
+
+        def init_dtype(self):
+            self.dtype = np.complex64
+
     @skip_check_grad_ci(
         reason="[skip shape check] Use y_shape(1) to test broadcast."
     )


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Custom Device

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
为XPU上的add添加complex64类型和对应单测，添加了0-size tensor支持，同时在梯度累计计算处加上complex64类型
因为fullkernel未支持complex，没有给complex64添加0-size-tensor支持

- [ ] complex支持0-size tensor

Pcard-75624