### PR TITLE
Fix expand_as and expand_as_grad kernel for big tensor

### DIFF
--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/binary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/binary_infer_sym.cc
@@ -777,8 +777,8 @@ bool SparseWeightEmbeddingOpInferSymbolicShape(
 
 bool ExpandAsOpInferSymbolicShape(
     pir::Operation *op, pir::InferSymbolicShapeContext *infer_context) {
-  std::vector<int> target_shape =
-      paddle::dialect::details::GetVectorAttr<int>(op, "target_shape");
+  std::vector<int64_t> target_shape =
+      paddle::dialect::details::GetVectorAttr<int64_t>(op, "target_shape");
   const std::vector<symbol::DimExpr> &output_dims = [&] {
     const auto &input_shape_or_data =
         infer_context->GetShapeOrDataForValue(op->operand_source(1));
@@ -787,7 +787,7 @@ bool ExpandAsOpInferSymbolicShape(
     }
     std::vector<symbol::DimExpr> output_dims;
     output_dims.reserve(target_shape.size());
-    for (int shape : target_shape) {
+    for (int64_t shape : target_shape) {
       output_dims.push_back(shape);
     }
     return output_dims;

--- a/paddle/fluid/pir/serialize_deserialize/patch/0.yaml
+++ b/paddle/fluid/pir/serialize_deserialize/patch/0.yaml
@@ -50,3 +50,10 @@ op_patches:
           - type: pir::Int64Attribute
           - type: pir::Int64Attribute
           - type: pir::Int64Attribute
+  - op_name : pd_op.expand_as
+    actions:
+      - action : modify_attr
+        object : target_shape
+        type : pir::ArrayAttribute
+        default :
+          - type: pir::Int64Attribute

--- a/paddle/phi/api/generator/dist_api_gen.py
+++ b/paddle/phi/api/generator/dist_api_gen.py
@@ -1612,7 +1612,7 @@ class DistForwardAPI(ForwardAPI):
     def get_shape_type(self, attr_info):
         shape_type = "int"
         for name, info in attr_info.items():
-            if "IntArray" in info[0]:
+            if "IntArray" in info[0] or "int64_t" in info[0]:
                 shape_type = "int64_t"
         return shape_type
 

--- a/paddle/phi/infermeta/binary.cc
+++ b/paddle/phi/infermeta/binary.cc
@@ -1816,7 +1816,7 @@ void CEmbeddingInferMeta(const MetaTensor& weight,
 
 void ExpandAsInferMeta(const MetaTensor& x,
                        const MetaTensor& y,
-                       const std::vector<int>& target_shape,
+                       const std::vector<int64_t>& target_shape,
                        MetaTensor* out) {
 #define MAX_RANK_SUPPORTED 8
   auto x_dims = x.dims();

--- a/paddle/phi/infermeta/binary.h
+++ b/paddle/phi/infermeta/binary.h
@@ -348,7 +348,7 @@ void CEmbeddingInferMeta(const MetaTensor& weight,
 
 void ExpandAsInferMeta(const MetaTensor& x,
                        const MetaTensor& y,
-                       const std::vector<int>& target_shape,
+                       const std::vector<int64_t>& target_shape,
                        MetaTensor* out);
 
 void FakeDequantizeMaxAbsInferMeta(const MetaTensor& x,

--- a/paddle/phi/kernels/expand_as_grad_kernel.h
+++ b/paddle/phi/kernels/expand_as_grad_kernel.h
@@ -22,7 +22,7 @@ template <typename T, typename Context>
 void ExpandAsGradKernel(const Context& ctx,
                         const DenseTensor& x,
                         const DenseTensor& out_grad,
-                        const std::vector<int>& target_shape,
+                        const std::vector<int64_t>& target_shape,
                         DenseTensor* in_grad);
 
 }  // namespace phi

--- a/paddle/phi/kernels/expand_as_kernel.h
+++ b/paddle/phi/kernels/expand_as_kernel.h
@@ -22,7 +22,7 @@ template <typename T, typename Context>
 void ExpandAsKernel(const Context& ctx,
                     const DenseTensor& x,
                     const paddle::optional<DenseTensor>& y,
-                    const std::vector<int>& target_shape,
+                    const std::vector<int64_t>& target_shape,
                     DenseTensor* out);
 
 }  // namespace phi

--- a/paddle/phi/kernels/gpu/expand_as_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/expand_as_grad_kernel.cu
@@ -26,7 +26,7 @@ template <typename T, typename Context>
 void ExpandAsGradKernel(const Context& context,
                         const DenseTensor& x,
                         const DenseTensor& out_grad,
-                        const std::vector<int>& target_shape,
+                        const std::vector<int64_t>& target_shape,
                         DenseTensor* in_grad) {
   auto in_dims = x.dims();
   auto out_dims = out_grad.dims();

--- a/paddle/phi/kernels/gpu/expand_as_kernel.cu
+++ b/paddle/phi/kernels/gpu/expand_as_kernel.cu
@@ -23,21 +23,21 @@
 
 namespace phi {
 
-template <typename T, typename Context, typename ShapeType>
-void ExpandAsKernelImpl(const Context& ctx,
-                        const DenseTensor& x,
-                        const paddle::optional<DenseTensor>& y,
-                        const std::vector<ShapeType>& target_shape_t,
-                        DenseTensor* out) {
-  std::vector<ShapeType> target_shape = target_shape_t;
+template <typename T, typename Context>
+void ExpandAsKernel(const Context& ctx,
+                    const DenseTensor& x,
+                    const paddle::optional<DenseTensor>& y,
+                    const std::vector<int64_t>& target_shape_t,
+                    DenseTensor* out) {
+  std::vector<int64_t> target_shape = target_shape_t;
 
   if (y.get_ptr()) {
-    target_shape = phi::vectorize<ShapeType>(y.get_ptr()->dims());
+    target_shape = phi::vectorize<int64_t>(y.get_ptr()->dims());
   }
 
   int rank = x.dims().size();
   int target_rank = static_cast<int>(target_shape.size());
-  auto vec_in_dims = common::vectorize<ShapeType>(x.dims());
+  auto vec_in_dims = common::vectorize<int64_t>(x.dims());
 
   unsigned int diff = target_rank - rank;
   vec_in_dims.insert(vec_in_dims.begin(), diff, 1);
@@ -78,34 +78,6 @@ void ExpandAsKernelImpl(const Context& ctx,
   }
 
   ExpandKernel<T, Context>(ctx, x, target_shape, out);
-}
-
-static inline std::vector<int> convert_to_int_vec(std::vector<int64_t> a) {
-  std::vector<int> ret;
-  for (size_t i = 0; i < a.size(); i++) {
-    ret.emplace_back(static_cast<int>(a[i]));
-  }
-
-  return ret;
-}
-
-template <typename T, typename Context>
-void ExpandAsKernel(const Context& ctx,
-                    const DenseTensor& x,
-                    const paddle::optional<DenseTensor>& y,
-                    const std::vector<int64_t>& target_shape_t,
-                    DenseTensor* out) {
-  bool use_int64 =
-      std::any_of(target_shape_t.begin(), target_shape_t.end(), [](int64_t v) {
-        return v > static_cast<int64_t>(std::numeric_limits<int32_t>::max());
-      });
-
-  if (use_int64) {
-    ExpandAsKernelImpl<T, Context, int64_t>(ctx, x, y, target_shape_t, out);
-  } else {
-    ExpandAsKernelImpl<T, Context, int32_t>(
-        ctx, x, y, convert_to_int_vec(target_shape_t), out);
-  }
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/gpu/expand_as_kernel.cu
+++ b/paddle/phi/kernels/gpu/expand_as_kernel.cu
@@ -23,21 +23,21 @@
 
 namespace phi {
 
-template <typename T, typename Context>
-void ExpandAsKernel(const Context& ctx,
-                    const DenseTensor& x,
-                    const paddle::optional<DenseTensor>& y,
-                    const std::vector<int>& target_shape_t,
-                    DenseTensor* out) {
-  std::vector<int> target_shape = target_shape_t;
+template <typename T, typename Context, typename ShapeType>
+void ExpandAsKernelImpl(const Context& ctx,
+                        const DenseTensor& x,
+                        const paddle::optional<DenseTensor>& y,
+                        const std::vector<ShapeType>& target_shape_t,
+                        DenseTensor* out) {
+  std::vector<ShapeType> target_shape = target_shape_t;
 
   if (y.get_ptr()) {
-    target_shape = phi::vectorize<int>(y.get_ptr()->dims());
+    target_shape = phi::vectorize<ShapeType>(y.get_ptr()->dims());
   }
 
   int rank = x.dims().size();
   int target_rank = static_cast<int>(target_shape.size());
-  auto vec_in_dims = common::vectorize<int>(x.dims());
+  auto vec_in_dims = common::vectorize<ShapeType>(x.dims());
 
   unsigned int diff = target_rank - rank;
   vec_in_dims.insert(vec_in_dims.begin(), diff, 1);
@@ -78,6 +78,34 @@ void ExpandAsKernel(const Context& ctx,
   }
 
   ExpandKernel<T, Context>(ctx, x, target_shape, out);
+}
+
+static inline std::vector<int> convert_to_int_vec(std::vector<int64_t> a) {
+  std::vector<int> ret;
+  for (size_t i = 0; i < a.size(); i++) {
+    ret.emplace_back(static_cast<int>(a[i]));
+  }
+
+  return ret;
+}
+
+template <typename T, typename Context>
+void ExpandAsKernel(const Context& ctx,
+                    const DenseTensor& x,
+                    const paddle::optional<DenseTensor>& y,
+                    const std::vector<int64_t>& target_shape_t,
+                    DenseTensor* out) {
+  bool use_int64 =
+      std::any_of(target_shape_t.begin(), target_shape_t.end(), [](int64_t v) {
+        return v > static_cast<int64_t>(std::numeric_limits<int32_t>::max());
+      });
+
+  if (use_int64) {
+    ExpandAsKernelImpl<T, Context, int64_t>(ctx, x, y, target_shape_t, out);
+  } else {
+    ExpandAsKernelImpl<T, Context, int32_t>(
+        ctx, x, y, convert_to_int_vec(target_shape_t), out);
+  }
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/impl/expand_as_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/expand_as_grad_kernel_impl.h
@@ -21,7 +21,7 @@ namespace phi {
 template <typename Context, typename T, int Dims>
 void ExpandAsBackward(const Context& ctx,
                       const DenseTensor& out_grad,
-                      const std::vector<int>& reshape_dims_vec,
+                      const std::vector<int64_t>& reshape_dims_vec,
                       const std::vector<int>& reduce_dims_vec,
                       DenseTensor* in_grad) {
   size_t reshape_size = reshape_dims_vec.size();
@@ -46,7 +46,7 @@ template <typename T, typename Context>
 void ExpandAsGradKernel(const Context& context,
                         const DenseTensor& x,
                         const DenseTensor& out_grad,
-                        const std::vector<int>& target_shape,
+                        const std::vector<int64_t>& target_shape,
                         DenseTensor* in_grad) {
   auto x_dims = x.dims();
 
@@ -55,14 +55,14 @@ void ExpandAsGradKernel(const Context& context,
     return;
   }
 
-  auto vec_in_dims = common::vectorize<int>(x_dims);
+  auto vec_in_dims = common::vectorize<int64_t>(x_dims);
   auto diff = target_shape.size() - vec_in_dims.size();
   vec_in_dims.insert(vec_in_dims.begin(), diff, 1);
-  std::vector<int> repeat_times(vec_in_dims.size());
+  std::vector<int64_t> repeat_times(vec_in_dims.size());
   for (size_t i = 0; i < vec_in_dims.size(); ++i) {
     repeat_times[i] = target_shape[i] / vec_in_dims[i];
   }
-  std::vector<int> reshape_dims_vec;
+  std::vector<int64_t> reshape_dims_vec;
   std::vector<int> reduce_dims_vec;
   for (size_t i = 0; i < repeat_times.size(); ++i) {
     reduce_dims_vec.push_back(reshape_dims_vec.size());

--- a/paddle/phi/kernels/impl/expand_as_kernel_impl.h
+++ b/paddle/phi/kernels/impl/expand_as_kernel_impl.h
@@ -27,13 +27,13 @@ namespace phi {
 template <typename Context, typename T, int Rank>
 void ExpandAs(const Context& context,
               const DenseTensor& x,
-              const std::vector<int>& target_shape,
+              const std::vector<int64_t>& target_shape,
               DenseTensor* out) {
   auto in_dims = x.dims();
   auto vec_in_dims = common::vectorize<int>(in_dims);
   auto diff = target_shape.size() - vec_in_dims.size();
   vec_in_dims.insert(vec_in_dims.begin(), diff, 1);
-  std::vector<int> repeat_times(vec_in_dims.size());
+  std::vector<int64_t> repeat_times(vec_in_dims.size());
   if (Rank == 0) {
     phi::Copy<Context>(context, x, context.GetPlace(), false, out);
     return;
@@ -98,7 +98,7 @@ template <typename T, typename Context>
 void ExpandAsKernel(const Context& ctx,
                     const DenseTensor& x,
                     const paddle::optional<DenseTensor>& y,
-                    const std::vector<int>& target_shape,
+                    const std::vector<int64_t>& target_shape,
                     DenseTensor* out) {
   auto rank = x.dims().size();
   auto target_rank = target_shape.size();
@@ -124,12 +124,12 @@ void ExpandAsKernel(const Context& ctx,
                         target_rank,
                         MAX_RANK_SUPPORTED));
 
-  std::vector<int> real_target_shape = target_shape;
+  std::vector<int64_t> real_target_shape = target_shape;
   for (size_t i = 0; i < target_shape.size(); ++i) {
     if (target_shape[i] == -1) {
       if (y) {
         if (y->IsInitialized()) {
-          real_target_shape = common::vectorize<int>(y->dims());
+          real_target_shape = common::vectorize<int64_t>(y->dims());
         }
       }
       break;

--- a/paddle/phi/kernels/impl/solve_kernel_impl.h
+++ b/paddle/phi/kernels/impl/solve_kernel_impl.h
@@ -76,15 +76,6 @@ static std::vector<int64_t> get_broadcast_batch_portion(
   return batchPortion;
 }
 
-static inline std::vector<int> convert_to_int_vec(std::vector<int64_t> a) {
-  std::vector<int> ret;
-  for (size_t i = 0; i < a.size(); i++) {
-    ret.emplace_back(static_cast<int>(a[i]));
-  }
-
-  return ret;
-}
-
 // broadcast the batch dimensions of tensor x and tensor y.
 static inline std::tuple<std::vector<int64_t>, std::vector<int64_t>>
 get_broadcast_dims(const Tensor& x, const Tensor& y) {
@@ -150,11 +141,11 @@ static void linalg_solve(const Context& dev_ctx,
   Tensor tmp_x_bc;
 
   phi::ExpandAsKernel<T, Context>(
-      dev_ctx, tmp_x, nullptr, convert_to_int_vec(x_broadcast_dims), &tmp_x_bc);
+      dev_ctx, tmp_x, nullptr, x_broadcast_dims, &tmp_x_bc);
 
   Tensor tmp_y_bc;
   phi::ExpandAsKernel<T, Context>(
-      dev_ctx, tmp_y, nullptr, convert_to_int_vec(y_broadcast_dims), &tmp_y_bc);
+      dev_ctx, tmp_y, nullptr, y_broadcast_dims, &tmp_y_bc);
 
   auto x_dim = x.dims();
   auto y_dim = y.dims();

--- a/paddle/phi/kernels/xpu/expand_as_kernel.cc
+++ b/paddle/phi/kernels/xpu/expand_as_kernel.cc
@@ -24,7 +24,7 @@ namespace phi {
 template <typename Context, typename T>
 void ExpandAs(const Context& context,
               const DenseTensor& x,
-              const std::vector<int>& target_shape_,
+              const std::vector<int64_t>& target_shape_,
               DenseTensor* out) {
   using XPUType = typename XPUTypeTrait<T>::Type;
   auto vec_in_dims = common::vectorize<int64_t>(x.dims());
@@ -87,7 +87,7 @@ template <typename T, typename Context>
 void ExpandAsKernel(const Context& ctx,
                     const DenseTensor& x,
                     const paddle::optional<DenseTensor>& y,
-                    const std::vector<int>& target_shape,
+                    const std::vector<int64_t>& target_shape,
                     DenseTensor* out) {
   auto rank = x.dims().size();
   auto target_rank = target_shape.size();

--- a/paddle/phi/ops/yaml/backward.yaml
+++ b/paddle/phi/ops/yaml/backward.yaml
@@ -990,8 +990,8 @@
   composite : exp_grad(out, out_grad, x_grad)
 
 - backward_op : expand_as_grad
-  forward : expand_as (Tensor x, Tensor y, int[] target_shape = {}) -> Tensor(out)
-  args : (Tensor x, Tensor out_grad, int[] target_shape)
+  forward : expand_as (Tensor x, Tensor y, int64_t[] target_shape = {}) -> Tensor(out)
+  args : (Tensor x, Tensor out_grad, int64_t[] target_shape)
   output : Tensor(x_grad)
   infer_meta :
     func : UnchangedInferMeta

--- a/paddle/phi/ops/yaml/legacy/backward_exclude.yaml
+++ b/paddle/phi/ops/yaml/legacy/backward_exclude.yaml
@@ -13,6 +13,7 @@
 - disable_check_model_nan_inf_grad
 - dropout_grad
 - enable_check_model_nan_inf_grad
+- expand_as_grad
 # FIXME(dev): Remove flatten_grad after deprecate flatten_contiguous_range in old IR system.
 # flatten_grad is alias name of flatten_contiguous_range_grad.
 - flatten_grad

--- a/paddle/phi/ops/yaml/legacy/ops_exclude.yaml
+++ b/paddle/phi/ops/yaml/legacy/ops_exclude.yaml
@@ -28,6 +28,7 @@
 - empty
 - empty_like
 - enable_check_model_nan_inf
+- expand_as
 - exponential_
 - eye
 # FIXME(dev): Remove flatten after deprecate flatten_contiguous_range in old IR system.

--- a/paddle/phi/ops/yaml/legacy/static_backward.yaml
+++ b/paddle/phi/ops/yaml/legacy/static_backward.yaml
@@ -112,6 +112,17 @@
     data_type : out_grad
   no_need_buffer : weight
 
+- backward_op : expand_as_grad
+  forward : expand_as (Tensor x, Tensor y, int[] target_shape = {}) -> Tensor(out)
+  args : (Tensor x, Tensor out_grad, int[] target_shape)
+  output : Tensor(x_grad)
+  infer_meta :
+    func : UnchangedInferMeta
+    param : [x]
+  kernel :
+    func : expand_as_grad
+  no_need_buffer : x
+
 - backward_op : exponential__grad
   forward : exponential_ (Tensor x, float lam=1.0f) -> Tensor(out)
   args : (Tensor out_grad)

--- a/paddle/phi/ops/yaml/legacy/static_ops.yaml
+++ b/paddle/phi/ops/yaml/legacy/static_ops.yaml
@@ -242,6 +242,19 @@
     force_backend : force_cpu
   traits : paddle::dialect::ForwardOnlyTrait
 
+- op : expand_as
+  args : (Tensor x, Tensor y, int[] target_shape = {})
+  output : Tensor(out)
+  infer_meta :
+    func : ExpandAsInferMeta
+    local_shape: out
+  kernel :
+    func : expand_as
+    data_type : x
+  optional : y
+  backward : expand_as_grad
+  interfaces : paddle::dialect::InferSymbolicShapeInterface
+
 - op : exponential_
   args : (Tensor x, float lam = 1.0f)
   output : Tensor(out)

--- a/paddle/phi/ops/yaml/ops.yaml
+++ b/paddle/phi/ops/yaml/ops.yaml
@@ -1779,7 +1779,7 @@
   backward : expand_grad
 
 - op : expand_as
-  args : (Tensor x, Tensor y, int[] target_shape = {})
+  args : (Tensor x, Tensor y, int64_t[] target_shape = {})
   output : Tensor(out)
   infer_meta :
     func : ExpandAsInferMeta

--- a/test/ir/pir/cinn/symbolic/test_infer_sym_shape_binary_op.py
+++ b/test/ir/pir/cinn/symbolic/test_infer_sym_shape_binary_op.py
@@ -67,6 +67,35 @@ class EmbeddingOpInferSymbolicShapeTest(TestBase):
         return out
 
 
+class ExpandAsNet(paddle.nn.Layer):
+    def forward(self, x, y):
+        return paddle.expand_as(x, y)
+
+
+class ExpandAsOpInferSymbolicShapeTest(TestBase):
+    def prepare_data(self):
+        self.x_shape = [2, 1]
+        self.y_shape = [2, 3]
+
+        self.x = paddle.ones(self.x_shape)
+        self.y = paddle.ones(self.y_shape)
+
+        self.expected = ['shape[S0, S1], data[NULL]']
+
+    def test_eval_symbolic(self):
+        net = ExpandAsNet()
+        input_spec = [
+            InputSpec(shape=[None, 1], dtype='float32'),  # x
+            InputSpec(shape=[None, None], dtype='float32'),  # y
+        ]
+        net = apply_to_static(net, False, input_spec)
+        net.eval()
+
+        check_infer_results(net, input_spec, 'pd_op.expand_as', self.expected)
+        out = net(self.x, self.y)
+        return out
+
+
 class KronNet(paddle.nn.Layer):
     def __init__(self):
         super().__init__()

--- a/test/ir/pir/cinn/symbolic/test_infer_sym_shape_binary_op.py
+++ b/test/ir/pir/cinn/symbolic/test_infer_sym_shape_binary_op.py
@@ -23,6 +23,7 @@ from test_infer_sym_shape_utils import (
 )
 
 import paddle
+from paddle import _C_ops
 from paddle.static import InputSpec
 
 sys.path.append(dirname(dirname(__file__)))
@@ -68,32 +69,32 @@ class EmbeddingOpInferSymbolicShapeTest(TestBase):
 
 
 class ExpandAsNet(paddle.nn.Layer):
-    def forward(self, x, y):
-        return paddle.expand_as(x, y)
+    def __init__(self, target_shape):
+        super().__init__()
+        self.target_shape = target_shape
+
+    def forward(self, x):
+        return _C_ops.expand_as(x, None, self.target_shape)
 
 
 class ExpandAsOpInferSymbolicShapeTest(TestBase):
     def prepare_data(self):
-        self.x_shape = [2, 1]
-        self.y_shape = [2, 3]
+        self.target_shape = [10, 3]
 
-        self.x = paddle.ones(self.x_shape)
-        self.y = paddle.ones(self.y_shape)
-
-        self.expected = ['shape[S1, S2], data[NULL]']
+        self.expected = ['shape[10, 3], data[NULL]']
 
     def test_eval_symbolic(self):
-        net = ExpandAsNet()
+        net = ExpandAsNet(self.target_shape)
         input_spec = [
             InputSpec(shape=[None, 1], dtype='float32'),  # x
-            InputSpec(shape=[None, None], dtype='float32'),  # y
         ]
         net = apply_to_static(net, False, input_spec)
         net.eval()
 
-        check_infer_results(net, input_spec, 'pd_op.expand_as', self.expected)
-        out = net(self.x, self.y)
-        return out
+        check_infer_results(
+            net, input_spec, 'builtin.shadow_output', self.expected
+        )
+        return True
 
 
 class KronNet(paddle.nn.Layer):

--- a/test/ir/pir/cinn/symbolic/test_infer_sym_shape_binary_op.py
+++ b/test/ir/pir/cinn/symbolic/test_infer_sym_shape_binary_op.py
@@ -80,7 +80,7 @@ class ExpandAsOpInferSymbolicShapeTest(TestBase):
         self.x = paddle.ones(self.x_shape)
         self.y = paddle.ones(self.y_shape)
 
-        self.expected = ['shape[S0, S1], data[NULL]']
+        self.expected = ['shape[S1, S2], data[NULL]']
 
     def test_eval_symbolic(self):
         net = ExpandAsNet()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修复expand_as的前向和反向大tensor推理问题，性能波动修复前后在1%以内。