### PR TITLE
[0-size Tensor] Add 0-size Tensor support for paddle.eigh、paddle.eigvalsh  API.

### DIFF
--- a/paddle/phi/kernels/impl/eigh_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/eigh_grad_kernel_impl.h
@@ -36,6 +36,9 @@ void EighGradKernel(const Context& dev_ctx,
                     const DenseTensor& dout_v,
                     DenseTensor* dx) {
   dev_ctx.template Alloc<T>(dx);
+  if (out_v.numel() == 0) {
+    return;
+  }
   auto& dims = out_v.dims();
   const int m = dims[dims.size() - 1];
   DenseTensor tV =

--- a/paddle/phi/kernels/impl/eigvalsh_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/eigvalsh_grad_kernel_impl.h
@@ -30,6 +30,10 @@ void EigvalshGradKernel(const Context& dev_ctx,
                         const std::string& uplo UNUSED,
                         bool is_test UNUSED,
                         DenseTensor* x_grad) {
+  if (x_grad->numel() == 0) {
+    dev_ctx.template Alloc<T>(x_grad);
+    return;
+  }
   auto tV = phi::TransposeLast2Dim<T>(dev_ctx, phi::Conj<T>(dev_ctx, out_v));
 
   x_grad->Resize(out_v.dims());


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->

**对 https://github.com/PaddlePaddle/Paddle/pull/70254 的补充修复**
存在的问题： https://github.com/PaddlePaddle/Paddle/pull/70254 修复了paddle.eigh、paddle.eigvalsh相关kernel的前向部分，但是并未修复其反向部分。
修复历程：
1. 检查eigh和eigvalsh 使用的InferMeta函数是否进行了正确推导。(涉及的EighInferMeta、EigvalsInferMeta、UnchangedInferMeta、EigvalshGradInferMeta 均不存在问题)
2. 检查kernel对0 size Tensor的处理，由于其前向过程已经修复，只修复了(EighGradKernel、EigvalshKernel)
3. 其他硬件并没有对应的kernel
4. 添加单测
5. PaddleAPITest无对应的报错信息

Pcard-67164