### PR TITLE
[XPU] Fix visit_type bug in fallback process

### DIFF
--- a/paddle/phi/core/visit_type.h
+++ b/paddle/phi/core/visit_type.h
@@ -394,6 +394,39 @@ namespace phi {
   }()
 #endif
 
+#define PD_VISIT_ALL_CPU_TYPES(TYPE, NAME, ...)                                \
+  [&] {                                                                        \
+    const auto& __dtype__ = TYPE;                                              \
+    switch (__dtype__) {                                                       \
+      PD_PRIVATE_CASE_TYPE(NAME, ::phi::DataType::BOOL, bool, __VA_ARGS__)     \
+      PD_PRIVATE_CASE_TYPE(NAME, ::phi::DataType::INT8, int8_t, __VA_ARGS__)   \
+      PD_PRIVATE_CASE_TYPE(NAME, ::phi::DataType::UINT8, uint8_t, __VA_ARGS__) \
+      PD_PRIVATE_CASE_TYPE(NAME, ::phi::DataType::INT16, int16_t, __VA_ARGS__) \
+      PD_PRIVATE_CASE_TYPE(NAME, ::phi::DataType::INT32, int32_t, __VA_ARGS__) \
+      PD_PRIVATE_CASE_TYPE(NAME, ::phi::DataType::INT64, int64_t, __VA_ARGS__) \
+      PD_PRIVATE_CASE_TYPE(                                                    \
+          NAME, ::phi::DataType::BFLOAT16, phi::bfloat16, __VA_ARGS__)         \
+      PD_PRIVATE_CASE_TYPE(                                                    \
+          NAME, ::phi::DataType::FLOAT16, phi::float16, __VA_ARGS__)           \
+      PD_PRIVATE_CASE_TYPE(NAME, ::phi::DataType::FLOAT32, float, __VA_ARGS__) \
+      PD_PRIVATE_CASE_TYPE(                                                    \
+          NAME, ::phi::DataType::FLOAT64, double, __VA_ARGS__)                 \
+      PD_PRIVATE_CASE_TYPE(                                                    \
+          NAME, ::phi::DataType::COMPLEX64, phi::complex64, __VA_ARGS__)       \
+      PD_PRIVATE_CASE_TYPE(                                                    \
+          NAME, ::phi::DataType::COMPLEX128, phi::complex128, __VA_ARGS__)     \
+      PD_PRIVATE_CASE_TYPE(NAME,                                               \
+                           ::phi::DataType::FLOAT8_E4M3FN,                     \
+                           phi::float8_e4m3fn,                                 \
+                           __VA_ARGS__)                                        \
+      PD_PRIVATE_CASE_TYPE(                                                    \
+          NAME, ::phi::DataType::FLOAT8_E5M2, phi::float8_e5m2, __VA_ARGS__)   \
+      default:                                                                 \
+        PADDLE_THROW(common::errors::InvalidArgument(                          \
+            "Invalid enum data type `%d`.", static_cast<int>(__dtype__)));     \
+    }                                                                          \
+  }()
+
 #define PD_VISIT_BOOL_AND_FLOATING_AND_COMPLEX_AND_4_TYPES(SPECIFIED_TYPE1,   \
                                                            SPECIFIED_TYPE2,   \
                                                            SPECIFIED_TYPE3,   \

--- a/paddle/phi/kernels/cpu/cast_kernel.cc
+++ b/paddle/phi/kernels/cpu/cast_kernel.cc
@@ -37,14 +37,15 @@ void CastKernel(const Context& dev_ctx,
   }
 
   if (out->IsSharedWith(x)) {
-    PD_VISIT_ALL_TYPES(out_dtype, "CastInplaceKernelImpl", ([&] {
-                         CastInplaceKernelImpl<T, data_t>(
-                             dev_ctx, x, out_dtype, out);
-                       }));
+    PD_VISIT_ALL_CPU_TYPES(out_dtype, "CastInplaceKernelImpl", ([&] {
+                             CastInplaceKernelImpl<T, data_t>(
+                                 dev_ctx, x, out_dtype, out);
+                           }));
   } else {
-    PD_VISIT_ALL_TYPES(out_dtype, "CastKernelImpl", ([&] {
-                         CastKernelImpl<T, data_t>(dev_ctx, x, out_dtype, out);
-                       }));
+    PD_VISIT_ALL_CPU_TYPES(out_dtype, "CastKernelImpl", ([&] {
+                             CastKernelImpl<T, data_t>(
+                                 dev_ctx, x, out_dtype, out);
+                           }));
   }
 }
 

--- a/paddle/phi/kernels/cpu/reduce.h
+++ b/paddle/phi/kernels/cpu/reduce.h
@@ -47,7 +47,7 @@ void Reduce(const DeviceContext& dev_ctx,
   // no need to cast dtype
   if (out_dtype == phi::DataType::UNDEFINED || out_dtype == x.dtype()) {
     // do reduce sum
-    PD_VISIT_ALL_TYPES(
+    PD_VISIT_CPU_ALL_TYPES(
         x.dtype(), "ReduceKernelImpl", ([&] {
           phi::funcs::ReduceKernelImpl<DeviceContext, T, data_t, Functor>(
               dev_ctx, x, out, dims, keep_dim, reduce_all);
@@ -58,7 +58,7 @@ void Reduce(const DeviceContext& dev_ctx,
     auto tmp_tensor = phi::Cast<T, DeviceContext>(dev_ctx, x, out_dtype);
 
     // do reduce sum
-    PD_VISIT_ALL_TYPES(
+    PD_VISIT_CPU_ALL_TYPES(
         out_dtype, "ReduceKernelImpl", ([&] {
           phi::funcs::ReduceKernelImpl<DeviceContext, T, data_t, Functor>(
               dev_ctx, tmp_tensor, out, dims, keep_dim, reduce_all);

--- a/paddle/phi/kernels/cpu/reduce.h
+++ b/paddle/phi/kernels/cpu/reduce.h
@@ -47,7 +47,7 @@ void Reduce(const DeviceContext& dev_ctx,
   // no need to cast dtype
   if (out_dtype == phi::DataType::UNDEFINED || out_dtype == x.dtype()) {
     // do reduce sum
-    PD_VISIT_CPU_ALL_TYPES(
+    PD_VISIT_ALL_CPU_TYPES(
         x.dtype(), "ReduceKernelImpl", ([&] {
           phi::funcs::ReduceKernelImpl<DeviceContext, T, data_t, Functor>(
               dev_ctx, x, out, dims, keep_dim, reduce_all);
@@ -58,7 +58,7 @@ void Reduce(const DeviceContext& dev_ctx,
     auto tmp_tensor = phi::Cast<T, DeviceContext>(dev_ctx, x, out_dtype);
 
     // do reduce sum
-    PD_VISIT_CPU_ALL_TYPES(
+    PD_VISIT_ALL_CPU_TYPES(
         out_dtype, "ReduceKernelImpl", ([&] {
           phi::funcs::ReduceKernelImpl<DeviceContext, T, data_t, Functor>(
               dev_ctx, tmp_tensor, out, dims, keep_dim, reduce_all);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
使用Paddle的时候，有很多算子的XPU端是未实现的，这时框架会自动fallback回CPU端
https://github.com/PaddlePaddle/Paddle/pull/55156 中把visit_type分为XPU和其他两类，会导致kernel在fallback回cpu端时使用了xpu相关的visit_type导致程序停止，并抛出一个不太明确的报错，如下图所示，使用了visit_type的有cast和reduce两种操作，有相关操作的kernel在fallback回cpu均会报错
![e0d04d7605138bddfbc018d91fd68c41](https://github.com/user-attachments/assets/b6ccb33b-63cb-4478-ba37-6731d19aa307)
本PR修复了新增了cpu相关的visit_type来避免触发上面的问题，让fallback回cpu的kernel可以正常运行
Pcard-75624
