### PR TITLE
[0-size Tensor No. 19,21,23,24,25,52,126,127,128] fix cpu elementwise compare op 0 size bug

### DIFF
--- a/paddle/phi/kernels/funcs/elementwise_base.h
+++ b/paddle/phi/kernels/funcs/elementwise_base.h
@@ -284,10 +284,10 @@ void CommonForwardBroadcastCPU(const DenseTensor &x,
   std::vector<int64_t> index_array(max_dim, 0);
   const T *x_data = x.data<T>();
   const T *y_data = y.data<T>();
-  PADDLE_ENFORCE_NOT_NULL(
-      x_data, errors::InvalidArgument("The input X should not be empty."));
-  PADDLE_ENFORCE_NOT_NULL(
-      y_data, errors::InvalidArgument("The input Y should not be empty."));
+  if (z && z->numel() == 0) {
+    ctx.Alloc<OutType>(z);
+    return;
+  }
   OutType *out_data = ctx.Alloc<OutType>(z);
 
   const int64_t out_size = std::accumulate(out_dims_array,

--- a/test/legacy_test/CMakeLists.txt
+++ b/test/legacy_test/CMakeLists.txt
@@ -170,6 +170,10 @@ if(APPLE OR WIN32)
   list(REMOVE_ITEM TEST_OPS test_multiprocess_dataloader_static)
 endif()
 
+if(APPLE)
+  list(REMOVE_ITEM TEST_OPS test_compare_op_0size)
+endif()
+
 list(REMOVE_ITEM TEST_OPS test_parallel_dygraph_hybrid_parallel)
 
 list(REMOVE_ITEM TEST_OPS test_parallel_dygraph_transformer_gloo)

--- a/test/legacy_test/test_compare_op_0size.py
+++ b/test/legacy_test/test_compare_op_0size.py
@@ -49,14 +49,15 @@ def create_test_class(op_type, dtype):
 
 
 create_test_class("equal", "float32")
-create_test_class("bitwise_left_shift", "int32")
-create_test_class("bitwise_right_shift", "int32")
 create_test_class("bitwise_or", "int32")
 create_test_class("bitwise_xor", "int32")
 create_test_class("bitwise_and", "int32")
 create_test_class("logical_or", "float32")
 create_test_class("logical_xor", "float32")
 create_test_class("logical_and", "float32")
+if not paddle.base.core.is_compiled_with_xpu():
+    create_test_class("bitwise_left_shift", "int32")
+    create_test_class("bitwise_right_shift", "int32")
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/legacy_test/test_compare_op_0size.py
+++ b/test/legacy_test/test_compare_op_0size.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy
+
+import paddle
+
+
+def create_test_class(op_type, dtype):
+    class Cls(unittest.TestCase):
+        def setUp(self):
+            pass
+
+        def test_0size(self):
+            numpy_tensor_x = numpy.ones([1]).astype(dtype)
+            paddle_x = paddle.to_tensor(numpy_tensor_x)
+            paddle_x.stop_gradient = False
+            numpy_tensor_x2 = numpy.ones([0]).astype(dtype)
+            paddle_x2 = paddle.to_tensor(numpy_tensor_x2)
+            paddle_x2.stop_gradient = False
+
+            paddle_api = eval(f"paddle.{op_type}")
+            paddle_out = paddle_api(paddle_x, paddle_x2)
+            numpy_api = eval(f"numpy.{op_type}")
+
+            numpy.testing.assert_allclose(
+                paddle_out.numpy(),
+                numpy_api(numpy_tensor_x, numpy_tensor_x2),
+                1e-2,
+                1e-2,
+            )
+
+    cls_name = f"{op_type}_0SizeTest"
+    Cls.__name__ = cls_name
+    globals()[cls_name] = Cls
+
+
+create_test_class("equal", "float32")
+create_test_class("bitwise_left_shift", "int32")
+create_test_class("bitwise_right_shift", "int32")
+create_test_class("bitwise_or", "int32")
+create_test_class("bitwise_xor", "int32")
+create_test_class("bitwise_and", "int32")
+create_test_class("logical_or", "float32")
+create_test_class("logical_xor", "float32")
+create_test_class("logical_and", "float32")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修复几个CPU elementwise compare op的0 Size问题并添加单测。
PaddleAPITest复测通过。

Pcard-67164