### PR TITLE
[0-size Tensor No.111] Add 0-size Tensor support for paddle.linalg.matrix_rank  API.

### DIFF
--- a/paddle/phi/kernels/cpu/matrix_rank_tol_kernel.cc
+++ b/paddle/phi/kernels/cpu/matrix_rank_tol_kernel.cc
@@ -30,7 +30,6 @@
 #include "paddle/phi/kernels/scale_kernel.h"
 #include "paddle/phi/kernels/transpose_kernel.h"
 #include "paddle/phi/kernels/where_kernel.h"
-
 namespace phi {
 
 template <typename T>
@@ -103,25 +102,14 @@ void MatrixRankTolKernel(const Context& dev_ctx,
   auto dim_out = out->dims();
   int rows = static_cast<int>(dim_x[dim_x.size() - 2]);
   int cols = static_cast<int>(dim_x[dim_x.size() - 1]);
-  PADDLE_ENFORCE_NE(
-      rows,
-      0,
-      errors::InvalidArgument("The input Tensor x's shape[-2] should not "
-                              "be 0, but received %s now.",
-                              dim_x));
-  PADDLE_ENFORCE_NE(
-      cols,
-      0,
-      errors::InvalidArgument("The input Tensor x's shape[-1] should not "
-                              "be 0, but received %s now.",
-                              dim_x));
+
   if (x.numel() == 0) {
-    std::vector<int64_t> out_dims_vec(dim_x.size() - 2);
-    for (int i = 0; i < dim_x.size() - 2; ++i) {
-      out_dims_vec[i] = dim_x[i];
-    }
-    out->Resize(phi::make_ddim(out_dims_vec));
+    out->Resize(dim_out);
     dev_ctx.template Alloc<int64_t>(out);
+    if (out && out->numel() != 0) {
+      phi::Full<int64_t, Context>(
+          dev_ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
+    }
     return;
   }
   int k = std::min(rows, cols);
@@ -223,28 +211,16 @@ void MatrixRankAtolRtolKernel(const Context& dev_ctx,
   auto dim_out = out->dims();
   int rows = static_cast<int>(dim_x[dim_x.size() - 2]);
   int cols = static_cast<int>(dim_x[dim_x.size() - 1]);
-  PADDLE_ENFORCE_NE(
-      rows,
-      0,
-      errors::InvalidArgument("The input Tensor x's shape[-2] should not "
-                              "be 0, but received %s now.",
-                              dim_x));
-  PADDLE_ENFORCE_NE(
-      cols,
-      0,
-      errors::InvalidArgument("The input Tensor x's shape[-1] should not "
-                              "be 0, but received %s now.",
-                              dim_x));
+
+  dev_ctx.template Alloc<int64_t>(out);
   if (x.numel() == 0) {
-    std::vector<int64_t> out_dims_vec(dim_x.size() - 2);
-    for (int i = 0; i < dim_x.size() - 2; ++i) {
-      out_dims_vec[i] = dim_x[i];
+    out->Resize(dim_out);
+    if (out && out->numel() != 0) {
+      phi::Full<int64_t, Context>(
+          dev_ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
     }
-    out->Resize(phi::make_ddim(out_dims_vec));
-    dev_ctx.template Alloc<int64_t>(out);
     return;
   }
-  dev_ctx.template Alloc<int64_t>(out);
   int k = std::min(rows, cols);
   int batches = static_cast<int>(x.numel() / (rows * cols));
 

--- a/paddle/phi/kernels/cpu/matrix_rank_tol_kernel.cc
+++ b/paddle/phi/kernels/cpu/matrix_rank_tol_kernel.cc
@@ -104,7 +104,6 @@ void MatrixRankTolKernel(const Context& dev_ctx,
   int cols = static_cast<int>(dim_x[dim_x.size() - 1]);
 
   if (x.numel() == 0) {
-    out->Resize(dim_out);
     dev_ctx.template Alloc<int64_t>(out);
     if (out && out->numel() != 0) {
       phi::Full<int64_t, Context>(
@@ -214,7 +213,6 @@ void MatrixRankAtolRtolKernel(const Context& dev_ctx,
 
   dev_ctx.template Alloc<int64_t>(out);
   if (x.numel() == 0) {
-    out->Resize(dim_out);
     if (out && out->numel() != 0) {
       phi::Full<int64_t, Context>(
           dev_ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);

--- a/paddle/phi/kernels/gpu/matrix_rank_tol_kernel.cu
+++ b/paddle/phi/kernels/gpu/matrix_rank_tol_kernel.cu
@@ -636,27 +636,17 @@ void MatrixRankTolKernel(const Context& dev_ctx,
   auto dim_out = out->dims();
   int rows = dim_x[dim_x.size() - 2];
   int cols = dim_x[dim_x.size() - 1];
-  PADDLE_ENFORCE_NE(rows,
-                    0,
-                    common::errors::InvalidArgument(
-                        "The input Tensor x's shape[-2] should not "
-                        "be 0, but received %s now.",
-                        dim_x));
-  PADDLE_ENFORCE_NE(cols,
-                    0,
-                    common::errors::InvalidArgument(
-                        "The input Tensor x's shape[-1] should not "
-                        "be 0, but received %s now.",
-                        dim_x));
+
   if (x.numel() == 0) {
-    std::vector<int64_t> out_dims_vec(dim_x.size() - 2);
-    for (int i = 0; i < dim_x.size() - 2; ++i) {
-      out_dims_vec[i] = dim_x[i];
-    }
-    out->Resize(phi::make_ddim(out_dims_vec));
+    out->Resize(dim_out);
     dev_ctx.template Alloc<int64_t>(out);
+    if (out && out->numel() != 0) {
+      phi::Full<int64_t, Context>(
+          dev_ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
+    }
     return;
   }
+
   int k = std::min(rows, cols);
   auto numel = x.numel();
   int batches = numel / (rows * cols);
@@ -772,28 +762,16 @@ void MatrixRankAtolRtolKernel(const Context& dev_ctx,
   auto dim_out = out->dims();
   int rows = dim_x[dim_x.size() - 2];
   int cols = dim_x[dim_x.size() - 1];
-  PADDLE_ENFORCE_NE(
-      rows,
-      0,
-      errors::InvalidArgument("The input Tensor x's shape[-2] should not "
-                              "be 0, but received %s now.",
-                              dim_x));
-  PADDLE_ENFORCE_NE(
-      cols,
-      0,
-      errors::InvalidArgument("The input Tensor x's shape[-1] should not "
-                              "be 0, but received %s now.",
-                              dim_x));
+
+  dev_ctx.template Alloc<int64_t>(out);
   if (x.numel() == 0) {
-    std::vector<int64_t> out_dims_vec(dim_x.size() - 2);
-    for (int i = 0; i < dim_x.size() - 2; ++i) {
-      out_dims_vec[i] = dim_x[i];
+    out->Resize(dim_out);
+    if (out && out->numel() != 0) {
+      phi::Full<int64_t, Context>(
+          dev_ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
     }
-    out->Resize(phi::make_ddim(out_dims_vec));
-    dev_ctx.template Alloc<int64_t>(out);
     return;
   }
-  dev_ctx.template Alloc<int64_t>(out);
   int k = std::min(rows, cols);
   auto numel = x.numel();
   int batches = numel / (rows * cols);

--- a/paddle/phi/kernels/gpu/matrix_rank_tol_kernel.cu
+++ b/paddle/phi/kernels/gpu/matrix_rank_tol_kernel.cu
@@ -638,7 +638,6 @@ void MatrixRankTolKernel(const Context& dev_ctx,
   int cols = dim_x[dim_x.size() - 1];
 
   if (x.numel() == 0) {
-    out->Resize(dim_out);
     dev_ctx.template Alloc<int64_t>(out);
     if (out && out->numel() != 0) {
       phi::Full<int64_t, Context>(

--- a/test/legacy_test/test_matrix_rank_atol_rtol_op.py
+++ b/test/legacy_test/test_matrix_rank_atol_rtol_op.py
@@ -610,7 +610,7 @@ class TestMatrixRankAtolRtolZeroSizeTensor(unittest.TestCase):
                 paddle.static.Program(), paddle.static.Program()
             ):
                 x_valid = paddle.static.data(
-                    name='x_valid', shape=[2, 0, 6, 6], dtype='float32'
+                    name='x_valid', shape=[2, 0, 6, 0], dtype='float32'
                 )
 
                 y_valid = paddle.linalg.matrix_rank(
@@ -619,7 +619,7 @@ class TestMatrixRankAtolRtolZeroSizeTensor(unittest.TestCase):
 
                 exe = paddle.static.Executor(place)
                 res_valid = exe.run(
-                    feed={'x_valid': np.zeros((2, 0, 6, 6), dtype='float32')},
+                    feed={'x_valid': np.zeros((2, 0, 6, 0), dtype='float32')},
                     fetch_list=[y_valid],
                 )
                 self.assertEqual(res_valid[0].shape, tuple(x_valid.shape[:-2]))
@@ -627,25 +627,21 @@ class TestMatrixRankAtolRtolZeroSizeTensor(unittest.TestCase):
     def _test_matrix_rank_dynamic(self, atol, rtol):
         with dygraph_guard():
             x_valid = paddle.full((2, 0, 6, 6), 1.0, dtype='float32')
-            x_invalid1 = paddle.full((0, 0), 1.0, dtype='float32')
-            x_invalid2 = paddle.full((2, 3, 0, 0), 1.0, dtype='float32')
-            self.assertRaises(
-                ValueError,
-                paddle.linalg.matrix_rank,
-                x_invalid1,
-                atol=atol,
-                rtol=rtol,
-            )
-            self.assertRaises(
-                ValueError,
-                paddle.linalg.matrix_rank,
-                x_invalid2,
-                atol=atol,
-                rtol=rtol,
-            )
+            x_valid1 = paddle.full((0, 0), 1.0, dtype='float32')
+            x_valid2 = paddle.full((2, 3, 0, 0), 1.0, dtype='float32')
 
             y_valid = paddle.linalg.matrix_rank(x_valid, atol=atol, rtol=rtol)
+            y_valid1 = paddle.linalg.matrix_rank(x_valid1, atol=atol, rtol=rtol)
+            y_valid2 = paddle.linalg.matrix_rank(x_valid2, atol=atol, rtol=rtol)
+
             self.assertEqual(y_valid.shape, x_valid.shape[:-2])
+            self.assertEqual(y_valid1.shape, x_valid1.shape[:-2])
+            self.assertEqual(y_valid2.shape, x_valid2.shape[:-2])
+
+            y_valid2_real = paddle.to_tensor(
+                np.zeros(x_valid2.shape[:-2]).astype(np.int64)
+            )
+            np.testing.assert_allclose(y_valid2, y_valid2_real, rtol=1e-05)
 
     def test_matrix_rank_tensor(self):
         atol = 0.2

--- a/test/legacy_test/test_matrix_rank_atol_rtol_op.py
+++ b/test/legacy_test/test_matrix_rank_atol_rtol_op.py
@@ -610,7 +610,7 @@ class TestMatrixRankAtolRtolZeroSizeTensor(unittest.TestCase):
                 paddle.static.Program(), paddle.static.Program()
             ):
                 x_valid = paddle.static.data(
-                    name='x_valid', shape=[2, 0, 6, 0], dtype='float32'
+                    name='x_valid', shape=[2, 1, 6, 0], dtype='float32'
                 )
 
                 y_valid = paddle.linalg.matrix_rank(
@@ -619,7 +619,7 @@ class TestMatrixRankAtolRtolZeroSizeTensor(unittest.TestCase):
 
                 exe = paddle.static.Executor(place)
                 res_valid = exe.run(
-                    feed={'x_valid': np.zeros((2, 0, 6, 0), dtype='float32')},
+                    feed={'x_valid': np.zeros((2, 1, 6, 0), dtype='float32')},
                     fetch_list=[y_valid],
                 )
                 self.assertEqual(res_valid[0].shape, tuple(x_valid.shape[:-2]))

--- a/test/legacy_test/test_matrix_rank_op.py
+++ b/test/legacy_test/test_matrix_rank_op.py
@@ -425,14 +425,14 @@ class TestMatrixRankZeroSizeTensor(unittest.TestCase):
                 paddle.static.Program(), paddle.static.Program()
             ):
                 x_valid = paddle.static.data(
-                    name='x_valid', shape=[2, 0, 6, 6], dtype='float32'
+                    name='x_valid', shape=[2, 0, 6, 0], dtype='float32'
                 )
 
                 y_valid = paddle.linalg.matrix_rank(x_valid)
 
                 exe = paddle.static.Executor(place)
                 res_valid = exe.run(
-                    feed={'x_valid': np.zeros((2, 0, 6, 6), dtype='float32')},
+                    feed={'x_valid': np.zeros((2, 0, 6, 0), dtype='float32')},
                     fetch_list=[y_valid],
                 )
                 self.assertEqual(res_valid[0].shape, tuple(x_valid.shape[:-2]))
@@ -441,24 +441,38 @@ class TestMatrixRankZeroSizeTensor(unittest.TestCase):
         with dygraph_guard():
             paddle.set_device("cpu")
             x_valid = paddle.full((2, 0, 6, 6), 1.0, dtype='float32')
-            x_invalid1 = paddle.full((0, 0), 1.0, dtype='float32')
-            x_invalid2 = paddle.full((2, 3, 0, 0), 1.0, dtype='float32')
-            self.assertRaises(ValueError, paddle.linalg.matrix_rank, x_invalid1)
-            self.assertRaises(ValueError, paddle.linalg.matrix_rank, x_invalid2)
+            x_valid1 = paddle.full((0, 0), 1.0, dtype='float32')
+            x_valid2 = paddle.full((2, 3, 8, 0), 1.0, dtype='float32')
 
             y_valid = paddle.linalg.matrix_rank(x_valid)
+            y_valid1 = paddle.linalg.matrix_rank(x_valid1)
+            y_valid2 = paddle.linalg.matrix_rank(x_valid2)
+
             self.assertEqual(y_valid.shape, x_valid.shape[:-2])
+            self.assertEqual(y_valid1.shape, x_valid1.shape[:-2])
+            self.assertEqual(y_valid2.shape, x_valid2.shape[:-2])
+            y_valid2_real = paddle.to_tensor(
+                np.zeros(x_valid2.shape[:-2]).astype(np.int64)
+            )
+            np.testing.assert_allclose(y_valid2, y_valid2_real, rtol=1e-05)
 
     def _test_matrix_rank_dynamic_gpu(self):
         with dygraph_guard():
             x_valid = paddle.full((2, 0, 6, 6), 1.0, dtype='float32')
-            x_invalid1 = paddle.full((0, 0), 1.0, dtype='float32')
-            x_invalid2 = paddle.full((2, 3, 0, 0), 1.0, dtype='float32')
-            self.assertRaises(ValueError, paddle.linalg.matrix_rank, x_invalid1)
-            self.assertRaises(ValueError, paddle.linalg.matrix_rank, x_invalid2)
+            x_valid1 = paddle.full((0, 0), 1.0, dtype='float32')
+            x_valid2 = paddle.full((2, 3, 0, 7), 1.0, dtype='float32')
 
             y_valid = paddle.linalg.matrix_rank(x_valid)
+            y_valid1 = paddle.linalg.matrix_rank(x_valid1)
+            y_valid2 = paddle.linalg.matrix_rank(x_valid2)
+
             self.assertEqual(y_valid.shape, x_valid.shape[:-2])
+            self.assertEqual(y_valid1.shape, x_valid1.shape[:-2])
+            self.assertEqual(y_valid2.shape, x_valid2.shape[:-2])
+            y_valid2_real = paddle.to_tensor(
+                np.zeros(x_valid2.shape[:-2]).astype(np.int64)
+            )
+            np.testing.assert_allclose(y_valid2, y_valid2_real, rtol=1e-05)
 
     def test_matrix_rank_tensor(self):
         for place in self._get_places():


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements


### Description
<!-- Describe what you’ve done -->
paddle.linalg.matrix_rank对0 size Tensor支持不够好，具体表现为PaddleAPITest报错。


这几个shape的Tensor在Torch中都是支持的。
![4c070b786cdcc8f75f3c03522d6186d3](https://github.com/user-attachments/assets/a62a74e4-4b73-4809-9df3-9306f0f47397)

但是Paddle中报参数错误，原因在于 https://github.com/PaddlePaddle/Paddle/pull/70130 对paddle.linalg.matrix_rank的修复过程添加了不必要的限制，导致矩阵的shape存在0时就报错。因此对paddle.linalg.matrix_rank进行了重新修复。

具体修复过程：
1.  检查infermeta推导（推导没问题）
2.  修复kernel
3.  检查其他device的kernel是否存在问题（只有cpu和gpu有对应的kernel）
4.  检查反向（这个api无反向的过程）
5.  添加单测以及使用PaddleAPITest 复测


<br class="Apple-interchange-newline">

Pcard-67164

