### PR TITLE
[0-size Tensor No.110] Add 0-size Tensor support for paddle.linalg.matrix_power API.

### DIFF
--- a/paddle/phi/kernels/impl/matrix_power_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/matrix_power_grad_kernel_impl.h
@@ -193,6 +193,11 @@ void MatrixPowerGradKernel(const Context& ctx,
   auto Out = &out;
   auto dOut = &out_grad;
   auto dX = x_grad;
+  if (x_grad && x_grad->numel() == 0) {
+    x_grad->Resize(x_grad.dims());
+    ctx.template Alloc<T>(x_grad);
+    return;
+  }
 
   MatrixPowerGradFunction<Context, T>(X, Out, dOut, n, dX, ctx);
 }

--- a/paddle/phi/kernels/impl/matrix_power_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/matrix_power_grad_kernel_impl.h
@@ -194,7 +194,6 @@ void MatrixPowerGradKernel(const Context& ctx,
   auto dOut = &out_grad;
   auto dX = x_grad;
   if (x_grad && x_grad->numel() == 0) {
-    x_grad->Resize(x_grad->dims());
     ctx.template Alloc<T>(x_grad);
     return;
   }

--- a/paddle/phi/kernels/impl/matrix_power_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/matrix_power_grad_kernel_impl.h
@@ -194,7 +194,7 @@ void MatrixPowerGradKernel(const Context& ctx,
   auto dOut = &out_grad;
   auto dX = x_grad;
   if (x_grad && x_grad->numel() == 0) {
-    x_grad->Resize(x_grad.dims());
+    x_grad->Resize(x_grad->dims());
     ctx.template Alloc<T>(x_grad);
     return;
   }

--- a/test/legacy_test/test_matrix_power_op.py
+++ b/test/legacy_test/test_matrix_power_op.py
@@ -216,6 +216,69 @@ class TestMatrixPowerOpLarge2(TestMatrixPowerOp):
         self.n = 32
 
 
+class TestMatrixPowerOpZeroSize(TestMatrixPowerOp):
+    def config(self):
+        self.matrix_shape = [0, 0]
+        self.dtype = "float32"
+        self.n = 32
+
+
+class TestMatrixPowerOpZeroSize1(TestMatrixPowerOp):
+    def config(self):
+        self.matrix_shape = [0, 0]
+        self.dtype = "float32"
+        self.n = 0
+
+
+class TestMatrixPowerOpZeroSize2(TestMatrixPowerOp):
+    def config(self):
+        self.matrix_shape = [0, 0]
+        self.dtype = "float32"
+        self.n = -1
+
+
+class TestMatrixPowerOpBatchedZeroSize1(TestMatrixPowerOp):
+    def config(self):
+        self.matrix_shape = [2, 0, 4, 4]
+        self.dtype = "float32"
+        self.n = 4
+
+
+class TestMatrixPowerOpBatchedZeroSize2(TestMatrixPowerOp):
+    def config(self):
+        self.matrix_shape = [2, 0, 4, 4]
+        self.dtype = "float32"
+        self.n = 0
+
+
+class TestMatrixPowerOpBatchedZeroSize3(TestMatrixPowerOp):
+    def config(self):
+        self.matrix_shape = [2, 0, 4, 4]
+        self.dtype = "float32"
+        self.n = -1
+
+
+class TestMatrixPowerOpBatchedZeroSize4(TestMatrixPowerOp):
+    def config(self):
+        self.matrix_shape = [2, 6, 0, 0]
+        self.dtype = "float32"
+        self.n = 1
+
+
+class TestMatrixPowerOpBatchedZeroSize5(TestMatrixPowerOp):
+    def config(self):
+        self.matrix_shape = [2, 6, 0, 0]
+        self.dtype = "float32"
+        self.n = 0
+
+
+class TestMatrixPowerOpBatchedZeroSize6(TestMatrixPowerOp):
+    def config(self):
+        self.matrix_shape = [2, 6, 0, 0]
+        self.dtype = "float32"
+        self.n = -1
+
+
 @unittest.skipIf(
     core.is_compiled_with_xpu(),
     "Skip complex due to lack of mean support",
@@ -563,7 +626,7 @@ class TestMatrixPowerEmptyTensor(unittest.TestCase):
                 self.assertEqual(res[0].shape, (0, 0))
                 self.assertEqual(res[1].shape, (2, 3, 0, 0))
 
-    def _test_matrix_power_empty_dynamtic(self):
+    def _test_matrix_power_empty_dynamic(self):
         with dygraph_guard():
             x2 = paddle.full((0, 6), 1.0, dtype='float32')
             x3 = paddle.full((6, 0), 1.0, dtype='float32')
@@ -581,7 +644,7 @@ class TestMatrixPowerEmptyTensor(unittest.TestCase):
     def test_matrix_power_empty_tensor(self):
         for place in self._get_places():
             self._test_matrix_power_empty_static(place)
-        self._test_matrix_power_empty_dynamtic()
+        self._test_matrix_power_empty_dynamic()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure 


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->

https://github.com/PaddlePaddle/Paddle/pull/70098 对paddle.linalg.matrix_power 的前向kernel进行了修复，但是其反向kernel仍然报错。在PaddleAPITest中的报错信息如下：
![8d49657c4b615ae0eedf9f65915c2394](https://github.com/user-attachments/assets/ee8ca82f-7121-4b63-8476-fb902b9b886e)

原因是MatrixPowerGradKernel遇到0 size Tensor时没有及时返回导致继续调用cublas进而报cublas error 7。
修复过程：
1. infermeta检查未发现错误。
2. 修复MatrixPowerGradKernel，cpu和gpu共用同一个MatrixPowerGradKernel，其他硬件没有对应的实现。
3. 添加单测
4. PaddleAPITest回测，回测结果：
![878362c37229ce0ee13f02d19ef265d1](https://github.com/user-attachments/assets/1c44a24d-b1e8-4374-8b59-f33a499e44e7)
所有失败的用例全部通过。



<br class="Apple-interchange-newline">


Pcard-67164

