### PR TITLE
[PHI] Improve chunk kernel for dim_size % num != 0

### DIFF
--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -4591,7 +4591,7 @@ void SplitWithNumInferMeta(const MetaTensor& x,
     std::vector<phi::DDim> out_dims;
     if (axis_value == -1) {  // NOLINT
       out_dims = std::vector<phi::DDim>(
-          num, common::make_ddim(std::vector<int>(x.dims().size(), -1)));
+          num, common::make_ddim(std::vector<int64_t>(x.dims().size(), -1)));
     } else {
       out_dims = std::vector<phi::DDim>(num, x.dims());
     }
@@ -4616,19 +4616,21 @@ void SplitWithNumInferMeta(const MetaTensor& x,
                       0,
                       common::errors::InvalidArgument(
                           "Attr(num_or_sections) should not be 0."));
-    PADDLE_ENFORCE_EQ(input_axis_dim % num,
-                      0,
-                      common::errors::InvalidArgument(
-                          "The input's size along the split dimension "
-                          "must be evenly divisible by Attr(num_or_sections). "
-                          "But received Attr(num_or_sections) "
-                          "= %d, input(X)'s shape = [%s], Attr(dim) = %d.",
-                          num,
-                          x.dims(),
-                          axis_value));
 
-    for (int i = 0; i < num; ++i) {
-      sections_vec.push_back(input_axis_dim / num);
+    if (input_axis_dim % num == 0) {
+      // paddle.arange(12).chunk(6)--->[2,2,2,2,2,2]
+      for (int i = 0; i < num; ++i) {
+        sections_vec.push_back(input_axis_dim / num);
+      }
+    } else {
+      // paddle.arange(13).chunk(6)--->[3,3,3,3,1]
+      // paddle.arange(11).chunk(6)--->[2,2,2,2,2,1]
+      auto base = input_axis_dim / num;
+      for (auto remaining = input_axis_dim; remaining > 0;
+           remaining -= sections_vec.back()) {
+        sections_vec.push_back((base + 1) <= remaining ? (base + 1)
+                                                       : remaining);
+      }
     }
     // setp2: fill out dims
     FillSplitOutDims(x, axis_value, sections_vec, &out);

--- a/paddle/phi/kernels/impl/split_kernel_impl.h
+++ b/paddle/phi/kernels/impl/split_kernel_impl.h
@@ -51,14 +51,8 @@ void SplitWithNumKernel(const Context& dev_ctx,
                         int num,
                         const Scalar& axis_scalar,
                         std::vector<DenseTensor*> outs) {
-  int axis_value = axis_scalar.to<int>();
-  auto input_axis_dim = x.dims().at(axis_value);
-  std::vector<int64_t> sections_vec;
-  for (int i = 0; i < num; ++i) {
-    sections_vec.push_back(input_axis_dim / num);
-  }
-  IntArray sections(sections_vec);
-  SplitKernel<T, Context>(dev_ctx, x, sections, axis_scalar, outs);
+  SplitKernel<T, Context>(
+      dev_ctx, x, CreateSplitSections(x, num, axis_scalar), axis_scalar, outs);
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/onednn/split_kernel.cc
+++ b/paddle/phi/kernels/onednn/split_kernel.cc
@@ -94,12 +94,8 @@ void SplitWithNumKernel(const Context& dev_ctx,
                         int num,
                         const Scalar& axis_scalar,
                         std::vector<DenseTensor*> outs) {
-  int axis_value = axis_scalar.to<int>();
-  auto input_axis_dim = x.dims().at(axis_value);
-  const std::vector<int64_t> sections_vec(num, input_axis_dim / num);
-
-  IntArray sections(sections_vec);
-  SplitKernel<T, Context>(dev_ctx, x, sections, axis_scalar, outs);
+  SplitKernel<T, Context>(
+      dev_ctx, x, CreateSplitSections(x, num, axis_scalar), axis_scalar, outs);
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/split_kernel.h
+++ b/paddle/phi/kernels/split_kernel.h
@@ -97,6 +97,7 @@ std::vector<DenseTensor> SplitWithNum(const Context& dev_ctx,
                                       const DenseTensor& x,
                                       int num,
                                       const Scalar& axis) {
+  // TODO(xiangmin): out_number is not always num
   size_t out_number = num;
 
   std::vector<MetaTensor> out_meta;
@@ -120,6 +121,28 @@ std::vector<DenseTensor> SplitWithNum(const Context& dev_ctx,
   SplitWithNumKernel<T, Context>(dev_ctx, x, num, axis, outs);
 
   return result;
+}
+
+inline IntArray CreateSplitSections(const DenseTensor& x,
+                                    int num,
+                                    const Scalar& axis_scalar) {
+  int axis_value = axis_scalar.to<int>();
+  auto input_axis_dim = x.dims().at(axis_value);
+  std::vector<int64_t> sections_vec;
+
+  if (input_axis_dim % num == 0) {
+    for (int i = 0; i < num; ++i) {
+      sections_vec.push_back(input_axis_dim / num);
+    }
+  } else {
+    auto base = input_axis_dim / num;
+    for (auto remaining = input_axis_dim; remaining > 0;
+         remaining -= sections_vec.back()) {
+      sections_vec.push_back((base + 1) <= remaining ? (base + 1) : remaining);
+    }
+  }
+
+  return IntArray(sections_vec);
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/stride/split_kernel.cc
+++ b/paddle/phi/kernels/stride/split_kernel.cc
@@ -66,15 +66,8 @@ void SplitWithNumStridedKernel(const Context& dev_ctx,
         "FLAGS_use_stride_kernel is closed. Strided kernel "
         "be called, something wrong has happened!"));
   }
-  int axis_value = axis_scalar.to<int>();
-  auto input_axis_dim = x.dims().at(axis_value);
-  std::vector<int64_t> sections_vec;
-  sections_vec.reserve(num);
-  for (int i = 0; i < num; ++i) {
-    sections_vec.push_back(input_axis_dim / num);
-  }
-  IntArray sections(sections_vec);
-  SplitStridedKernel<Context>(dev_ctx, x, sections, axis_scalar, outs);
+  SplitStridedKernel<Context>(
+      dev_ctx, x, CreateSplitSections(x, num, axis_scalar), axis_scalar, outs);
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/xpu/split_kernel.cc
+++ b/paddle/phi/kernels/xpu/split_kernel.cc
@@ -74,14 +74,8 @@ void SplitWithNumKernel(const Context& dev_ctx,
                         int num,
                         const Scalar& axis_scalar,
                         std::vector<DenseTensor*> outs) {
-  int axis_value = axis_scalar.to<int>();
-  int64_t input_axis_dim = x.dims().at(axis_value);
-  std::vector<int64_t> sections_vec;
-  for (int i = 0; i < num; ++i) {
-    sections_vec.push_back(input_axis_dim / static_cast<int64_t>(num));
-  }
-  IntArray sections(sections_vec);
-  SplitKernel<T, Context>(dev_ctx, x, sections, axis_scalar, outs);
+  SplitKernel<T, Context>(
+      dev_ctx, x, CreateSplitSections(x, num, axis_scalar), axis_scalar, outs);
 }
 
 }  // namespace phi

--- a/test/legacy_test/test_chunk_op.py
+++ b/test/legacy_test/test_chunk_op.py
@@ -136,6 +136,29 @@ class API_TestDygraphChunk(unittest.TestCase):
         np.testing.assert_allclose(ex_x1, x1_out, rtol=1e-05)
         np.testing.assert_allclose(ex_x2, x2_out, rtol=1e-05)
 
+    def test_out3(self):
+        with base.dygraph.guard():
+            input_1 = np.random.random([4, 10, 6]).astype("bool")
+            # input is a variable which shape is [4, 10, 6]
+            input = paddle.to_tensor(input_1)
+            x0, x1, x2 = paddle.chunk(input, chunks=3, axis=1)
+        # We only manually check the shape and do not compare it with numpy results
+        assert x0.shape == [
+            4,
+            4,
+            6,
+        ], f"x0.shape = {x0.shape}, expected [4, 4, 6]"
+        assert x1.shape == [
+            4,
+            4,
+            6,
+        ], f"x1.shape = {x1.shape}, expected [4, 4, 6]"
+        assert x2.shape == [
+            4,
+            2,
+            6,
+        ], f"x2.shape = {x2.shape}, expected [4, 2, 6]"
+
     def test_axis_tensor_input(self):
         with base.dygraph.guard():
             input_1 = np.random.random([4, 6, 6]).astype("int32")


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
- 之前：paddle.chunk(x, chunks, axis=0, name=None)，要求axis的维度大小能够整除chunks。
- 现在：与pytorch保持一致，

> - If the tensor size along the given dimension dim is divisible by chunks, all returned chunks will be the same size. If the tensor size along the given dimension dim is not divisible by chunks, all returned chunks will be the same size, except the last one. If such division is not possible, this function may return fewer than the specified number of chunks.

> ```
> > >>> torch.arange(13).chunk(6)
> > (tensor([0, 1, 2]),
> >  tensor([3, 4, 5]),
> >  tensor([6, 7, 8]),
> >  tensor([ 9, 10, 11]),
> >  tensor([12]))
> > >>> torch.arange(11).chunk(6)
> > (tensor([0, 1]),
> >  tensor([2, 3]),
> >  tensor([4, 5]),
> >  tensor([6, 7]),
> >  tensor([8, 9]),
> >  tensor([10]))
> ```

- TODO：
- 现在只修改了动态图模式下的推理机制，pir_mode和static_mode下的dim%num==0的断言仍然存在，见`manipulation.py` split定义部分。
- 当处理paddle.arange(13).chunk(6)这种情况时，output_size仍然为6，但是最后一个张量为空，需要修改输出长度。