### PR TITLE
[0-size Tensor No.134] Add 0-size Tensor support for paddle.meshgrid API.

### DIFF
--- a/test/legacy_test/test_meshgrid_op.py
+++ b/test/legacy_test/test_meshgrid_op.py
@@ -552,6 +552,24 @@ class TestMeshgridEmptyTensor2(TestMeshgridEmptyTensor):
         )
 
 
+class TestMeshgridZeroSizeGrad(unittest.TestCase):
+    def test_zero_size_grad_dynamic(self):
+        with base.dygraph.guard():
+            x = paddle.to_tensor(
+                np.ones([3]), dtype="float32", stop_gradient=False
+            )
+            y = paddle.to_tensor(
+                np.ones([0]), dtype="float32", stop_gradient=False
+            )
+            x_grid, y_grid = paddle.meshgrid(x, y)
+            z = paddle.sum(x_grid + y_grid)
+            z.backward()
+            x_grad_expacted = np.zeros([3])
+            y_grad_expacted = np.zeros([0])
+            np.testing.assert_array_equal(x.grad, x_grad_expacted)
+            np.testing.assert_array_equal(y.grad, y_grad_expacted)
+
+
 if __name__ == '__main__':
     paddle.enable_static()
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
 https://github.com/PaddlePaddle/Paddle/pull/70127 对paddle.meshgrid的前向过程进行了修复，然而反向的kernel在遇到0 size Tensor时仍然会报错。PaddleAPITest的报错信息如下：
![image](https://github.com/user-attachments/assets/56c362f4-acc3-4b78-97a0-b695ee7c37ea)

修复过程：
1.  infermeta没有发生推导错误
2.  修复反向kernel MeshgridGradKernel
3.  检查其他device有无出现此问题（CPU和GPU共享同一个模版）
4. 添加单测与PaddleAPI回测，回测结果
![image](https://github.com/user-attachments/assets/f65428ff-a9d2-4408-9ef2-d6356aa3f2dc)
之前失败的测试用例全部能pass



Pcard-67164

