### PR TITLE
[0-size Tensor No.9、10] Add 0-size Tensor support for paddle.argmin/max API

### DIFF
--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -321,6 +321,12 @@ void ArgMinMaxInferMeta(const MetaTensor& x,
                           int_axis));
   }
 
+  PADDLE_ENFORCE_NE(
+      x_dims[static_cast<int>((int_axis + x_rank) % x_rank)],
+      0,
+      common::errors::OutOfRange(
+          "Expected reduction axis(%d) to have non-zero size.", int_axis));
+
   if (int_axis < 0) int_axis += x_rank;
 
   if (config.is_runtime) {

--- a/paddle/phi/kernels/cpu/arg_min_max_kernel.cc
+++ b/paddle/phi/kernels/cpu/arg_min_max_kernel.cc
@@ -157,7 +157,7 @@ void ArgMinMaxKernel(const Context& dev_ctx,
       x.numel(),
       0,
       common::errors::InvalidArgument(
-          "argmin/argmax input numel must >= 0, bug got %d", x.numel()));
+          "argmin/argmax input numel must >= 0, but got %d", x.numel()));
   if (dtype == DataType::UNDEFINED) {
     phi::VisitDataTypeTiny(
         phi::DataType::INT64,

--- a/paddle/phi/kernels/cpu/arg_min_max_kernel.cc
+++ b/paddle/phi/kernels/cpu/arg_min_max_kernel.cc
@@ -153,11 +153,11 @@ void ArgMinMaxKernel(const Context& dev_ctx,
                      bool flatten,
                      DataType dtype,
                      DenseTensor* out) {
-  PADDLE_ENFORCE_GT(
+  PADDLE_ENFORCE_GE(
       x.numel(),
       0,
       common::errors::InvalidArgument(
-          "argmin/argmax input numel must > 0, bug got %d", x.numel()));
+          "argmin/argmax input numel must >= 0, bug got %d", x.numel()));
   if (dtype == DataType::UNDEFINED) {
     phi::VisitDataTypeTiny(
         phi::DataType::INT64,

--- a/paddle/phi/kernels/cpu/arg_min_max_kernel.cc
+++ b/paddle/phi/kernels/cpu/arg_min_max_kernel.cc
@@ -153,11 +153,6 @@ void ArgMinMaxKernel(const Context& dev_ctx,
                      bool flatten,
                      DataType dtype,
                      DenseTensor* out) {
-  PADDLE_ENFORCE_GE(
-      x.numel(),
-      0,
-      common::errors::InvalidArgument(
-          "argmin/argmax input numel must >= 0, but got %d", x.numel()));
   if (dtype == DataType::UNDEFINED) {
     phi::VisitDataTypeTiny(
         phi::DataType::INT64,

--- a/paddle/phi/kernels/gpu/arg_min_max_kernel.cu
+++ b/paddle/phi/kernels/gpu/arg_min_max_kernel.cu
@@ -223,11 +223,6 @@ void ArgMinMaxOpCUDAKernel(const Context& dev_ctx,
                            bool flatten,
                            DataType dtype,
                            DenseTensor* out) {
-  PADDLE_ENFORCE_GE(
-      x.numel(),
-      0,
-      common::errors::InvalidArgument(
-          "argmin/argmax input numel must >= 0, but got %d", x.numel()));
   if (dtype == DataType::UNDEFINED) {
     phi::VisitDataTypeTiny(
         phi::DataType::INT64,

--- a/paddle/phi/kernels/gpu/arg_min_max_kernel.cu
+++ b/paddle/phi/kernels/gpu/arg_min_max_kernel.cu
@@ -227,7 +227,7 @@ void ArgMinMaxOpCUDAKernel(const Context& dev_ctx,
       x.numel(),
       0,
       common::errors::InvalidArgument(
-          "argmin/argmax input numel must >= 0, bug got %d", x.numel()));
+          "argmin/argmax input numel must >= 0, but got %d", x.numel()));
   if (dtype == DataType::UNDEFINED) {
     phi::VisitDataTypeTiny(
         phi::DataType::INT64,

--- a/paddle/phi/kernels/gpu/arg_min_max_kernel.cu
+++ b/paddle/phi/kernels/gpu/arg_min_max_kernel.cu
@@ -223,11 +223,11 @@ void ArgMinMaxOpCUDAKernel(const Context& dev_ctx,
                            bool flatten,
                            DataType dtype,
                            DenseTensor* out) {
-  PADDLE_ENFORCE_GT(
+  PADDLE_ENFORCE_GE(
       x.numel(),
       0,
       common::errors::InvalidArgument(
-          "argmin/argmax input numel must > 0, bug got %d", x.numel()));
+          "argmin/argmax input numel must >= 0, bug got %d", x.numel()));
   if (dtype == DataType::UNDEFINED) {
     phi::VisitDataTypeTiny(
         phi::DataType::INT64,

--- a/paddle/phi/kernels/xpu/arg_min_max_kernel.cc
+++ b/paddle/phi/kernels/xpu/arg_min_max_kernel.cc
@@ -31,11 +31,6 @@ void ArgMaxKernel(const Context& dev_ctx,
                   bool flatten,
                   DataType dtype,
                   DenseTensor* out) {
-  PADDLE_ENFORCE_GE(
-      x.numel(),
-      0,
-      common::errors::InvalidArgument(
-          "argmin/argmax input numel must >= 0, but got %d", x.numel()));
   using XPUType = typename XPUTypeTrait<T>::Type;
   PADDLE_ENFORCE_EQ(
       (dtype == DataType::UNDEFINED || dtype == DataType::INT32 ||

--- a/paddle/phi/kernels/xpu/arg_min_max_kernel.cc
+++ b/paddle/phi/kernels/xpu/arg_min_max_kernel.cc
@@ -31,11 +31,11 @@ void ArgMaxKernel(const Context& dev_ctx,
                   bool flatten,
                   DataType dtype,
                   DenseTensor* out) {
-  PADDLE_ENFORCE_GT(
+  PADDLE_ENFORCE_GE(
       x.numel(),
       0,
       common::errors::InvalidArgument(
-          "argmin/argmax input numel must > 0, but got %d", x.numel()));
+          "argmin/argmax input numel must >= 0, but got %d", x.numel()));
   using XPUType = typename XPUTypeTrait<T>::Type;
   PADDLE_ENFORCE_EQ(
       (dtype == DataType::UNDEFINED || dtype == DataType::INT32 ||
@@ -112,11 +112,6 @@ void ArgMinKernel(const Context& dev_ctx,
                   bool flatten,
                   DataType dtype,
                   DenseTensor* out) {
-  PADDLE_ENFORCE_GT(
-      x.numel(),
-      0,
-      common::errors::InvalidArgument(
-          "argmin/argmax input numel must > 0, but got %d", x.numel()));
   using XPUType = typename XPUTypeTrait<T>::Type;
   PADDLE_ENFORCE_EQ(
       (dtype == DataType::UNDEFINED || dtype == DataType::INT32 ||

--- a/test/legacy_test/test_arg_min_max_op_0size.py
+++ b/test/legacy_test/test_arg_min_max_op_0size.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+
+import paddle
+
+
+class TestError(unittest.TestCase):
+    def test_exception(self):
+        exception_regular_expression = (
+            'Expected reduction axis(.)* to have non-zero size.'
+        )
+
+        self.assertRaisesRegex(
+            IndexError,
+            exception_regular_expression,
+            lambda: paddle.argmin(
+                paddle.zeros([1, 2, 3, 0], dtype='float32').argmin(3)
+            ),
+        )
+
+        self.assertRaisesRegex(
+            IndexError,
+            exception_regular_expression,
+            lambda: paddle.argmax(
+                paddle.zeros([1, 2, 3, 0], dtype='float32').argmax(3)
+            ),
+        )
+        self.assertRaisesRegex(
+            IndexError,
+            exception_regular_expression,
+            lambda: paddle.argmax(
+                paddle.zeros([1, 2, 3, 0], dtype='float32').argmax(-1)
+            ),
+        )
+        self.assertRaisesRegex(
+            IndexError,
+            exception_regular_expression,
+            lambda: paddle.argmax(
+                paddle.zeros([1, 2, 0, 3, 4], dtype='int32').argmax(2)
+            ),
+        )
+        self.assertRaisesRegex(
+            IndexError,
+            exception_regular_expression,
+            lambda: paddle.argmax(
+                paddle.zeros([1, 2, 0, 3, 4], dtype='int64').argmax(-3)
+            ),
+        )
+
+
+def create_test_class(op_type, dtype, shape, axis):
+    class TempCls(unittest.TestCase):
+        def test_zero_size(self):
+            numpy_tensor_1 = np.random.rand(*shape).astype(dtype)
+            paddle_x = paddle.to_tensor(numpy_tensor_1)
+            paddle_x.stop_gradient = False
+
+            paddle_api = eval(f"paddle.{op_type}")
+            paddle_out = paddle_api(paddle_x, axis=axis)
+            numpy_api = eval(f"np.{op_type}")
+            numpy_out = numpy_api(numpy_tensor_1, axis=axis)
+
+            np.testing.assert_allclose(
+                paddle_out.numpy(),
+                numpy_out,
+                1e-2,
+                1e-2,
+            )
+            np.testing.assert_allclose(
+                paddle_out.shape,
+                numpy_out.shape,
+                1e-2,
+                1e-2,
+            )
+
+    cls_name = f"{op_type}{dtype}ZeroSizeTest"
+    TempCls.__name__ = cls_name
+    globals()[cls_name] = TempCls
+
+
+create_test_class("argmax", "float32", [3, 4, 0], 0)
+create_test_class("argmax", "float64", [3, 4, 0, 3, 4], -2)
+create_test_class("argmax", "int32", [3, 4, 0], 0)
+create_test_class("argmax", "int64", [3, 4, 0, 3, 4], -1)
+create_test_class("argmin", "float32", [0, 3, 4], -2)
+create_test_class("argmin", "float64", [3, 0, 4], 2)
+create_test_class("argmin", "int32", [3, 4, 0, 3, 4], 1)
+create_test_class("argmin", "int64", [3, 4, 0, 3, 4], 0)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->

- `paddle/phi/ops/yaml/ops.yaml` 中找到 infer meta 函数为 `ArgMinMaxInferMeta`，删去输入为非 0 numel 的检查
- 添加单测

---
- https://github.com/PaddlePaddle/Paddle/issues/72637  Pcard-67164
