### PR TITLE
[0-size Tensor No.318] Add 0-size Tensor support for paddle.Tensor.matmul API. 

### DIFF
--- a/paddle/phi/kernels/impl/matmul_kernel_impl.h
+++ b/paddle/phi/kernels/impl/matmul_kernel_impl.h
@@ -21,7 +21,7 @@ limitations under the License. */
 #include "paddle/phi/kernels/autotune/cache_base.h"
 #include "paddle/phi/kernels/cast_kernel.h"
 #include "paddle/phi/kernels/funcs/blas/blas.h"
-#include "paddle/phi/core/context.h"
+#include "paddle/phi/core/kernel_context.h"
 #include "paddle/phi/common/scalar.h"
 #include "paddle/phi/kernels/funcs/broadcast_function.h"
 #ifdef PADDLE_WITH_HIP

--- a/paddle/phi/kernels/impl/matmul_kernel_impl.h
+++ b/paddle/phi/kernels/impl/matmul_kernel_impl.h
@@ -2003,68 +2003,41 @@ void MatmulKernel(const Context& ctx,
   if (x.numel() == 0 || y.numel() == 0) {
     auto x_dims = x.dims();
     auto y_dims = y.dims();
-    if (transpose_x) {
-      std::swap(x_dims[x_dims.size() - 1], x_dims[x_dims.size() - 2]);
+
+    if (transpose_x && x_dims.size() >= 2) {
+      std::swap(const_cast<DDim&>(x_dims)[x_dims.size() - 1],
+                const_cast<DDim&>(x_dims)[x_dims.size() - 2]);
     }
-    if (transpose_y) {
-      std::swap(y_dims[y_dims.size() - 1], y_dims[y_dims.size() - 2]);
+
+    if (transpose_y && y_dims.size() >= 2) {
+      std::swap(const_cast<DDim&>(y_dims)[y_dims.size() - 1],
+                const_cast<DDim&>(y_dims)[y_dims.size() - 2]);
     }
-    std::vector<std::int64_t> out_dims(x_dims.size() - 1 + y_dims.size() - 1);
-    for (int64_t i = 0; i < x_dims.size() - 1; ++i) {
-      out_dims[i] = x_dims[i];
+
+    std::vector<int64_t> x_batch_dims(x_dims.data(), x_dims.data() + x_dims.size() - 2);
+    std::vector<int64_t> y_batch_dims(y_dims.data(), y_dims.data() + y_dims.size() - 2);
+
+    std::vector<int64_t> bcast_dims;
+    if (!funcs::BroadcastTwoVec(x_batch_dims, y_batch_dims, &bcast_dims)) {
+      PADDLE_THROW(phi::errors::InvalidArgument(
+          "Failed to broadcast input batch dimensions."));
     }
-    for (int64_t i = 1; i < y_dims.size(); ++i) {
-      out_dims[x_dims.size() - 1 + i - 1] = y_dims[i];
-    }
-    out->Resize(phi::make_ddim(out_dims));
+
+    std::vector<int64_t> out_shape(bcast_dims.begin(), bcast_dims.end());
+
+    int64_t m = transpose_x ? x_dims[x_dims.size() - 1] : x_dims[x_dims.size() - 2];
+    int64_t n = transpose_y ? y_dims[y_dims.size() - 2] : y_dims[y_dims.size() - 1];
+
+    out_shape.push_back(m);
+    out_shape.push_back(n);
+
+    DDim out_dims = make_ddim(out_shape);
+    out->Resize(out_dims);
     ctx.template Alloc<T>(out);
     return;
   }
-  PADDLE_ENFORCE_GE(
-      common::product(x.dims()),
-      0,
-      common::errors::InvalidArgument(
-          "The dims of Input(X) should be greater than or equal to 0."));
-  PADDLE_ENFORCE_GE(
-      common::product(y.dims()),
-      0,
-      common::errors::InvalidArgument(
-          "The dims of Input(Y) should be greater than or equal to 0."));
-  const std::vector<std::int64_t> x_dims = common::vectorize(x.dims());
-  const std::vector<std::int64_t> y_dims = common::vectorize(y.dims());
-  MatmulJudgeDtypeKernel<Context, T>(
-      ctx, x, y, x_dims, y_dims, out, transpose_x, transpose_y);
-}
 
 template <typename T, typename Context>
-void MatmulWithFlattenKernelImpl(const Context& dev_ctx,
-                                 const DenseTensor& x,
-                                 const DenseTensor& y,
-                                 int x_num_col_dims,
-                                 int y_num_col_dims,
-                                 DenseTensor* out) {
-  const DenseTensor x_matrix =
-      x.dims().size() > 2 ? phi::ReshapeToMatrix(x, x_num_col_dims) : x;
-  const DenseTensor y_matrix =
-      y.dims().size() > 2 ? phi::ReshapeToMatrix(y, y_num_col_dims) : y;
-
-  dev_ctx.template Alloc<T>(out);
-  auto z_dim = out->dims();
-  if (z_dim.size() != 2) {
-    out->Resize({x_matrix.dims()[0], y_matrix.dims()[1]});
-  }
-
-  auto blas = phi::funcs::GetBlas<Context, T>(dev_ctx);
-
-  blas.MatMul(x_matrix, y_matrix, out);
-  if (z_dim.size() != 2) {
-    out->Resize(z_dim);
-  }
-}
-
-#ifdef PADDLE_WITH_CUDA
-
-template <typename Context>
 void MatmulWithFlattenKernelInt8Impl(const Context& dev_ctx,
                                      const DenseTensor& x,
                                      const DenseTensor& y,

--- a/paddle/phi/kernels/impl/matmul_kernel_impl.h
+++ b/paddle/phi/kernels/impl/matmul_kernel_impl.h
@@ -2004,12 +2004,10 @@ void MatmulKernel(const Context& ctx,
                   bool transpose_x,
                   bool transpose_y,
                   DenseTensor* out) {
-  // Step 1: 处理空张量情况，保留 shape 结构
   if (x.numel() == 0 || y.numel() == 0) {
     auto x_dims = x.dims();
     auto y_dims = y.dims();
 
-    // 如果启用了转置，交换最后两个维度
     if (transpose_x && x_dims.size() >= 2) {
       std::swap(const_cast<DDim&>(x_dims)[x_dims.size() - 1],
                 const_cast<DDim&>(x_dims)[x_dims.size() - 2]);
@@ -2019,18 +2017,15 @@ void MatmulKernel(const Context& ctx,
                 const_cast<DDim&>(y_dims)[y_dims.size() - 2]);
     }
 
-    // Step 2: 提取 batch 维度用于广播
     std::vector<int64_t> x_batch_dims(x_dims.data(), x_dims.data() + x_dims.size() - 2);
     std::vector<int64_t> y_batch_dims(y_dims.data(), y_dims.data() + y_dims.size() - 2);
 
-    // Step 3: 广播 batch 维度
     std::vector<int64_t> bcast_dims;
     if (!funcs::BroadcastTwoVec(x_batch_dims, y_batch_dims, &bcast_dims)) {
       PADDLE_THROW(phi::errors::InvalidArgument(
           "Failed to broadcast input batch dimensions."));
     }
 
-    // Step 4: 构造最终输出 shape
     std::vector<int64_t> out_shape(bcast_dims.begin(), bcast_dims.end());
 
     int64_t m = transpose_x ? x_dims[x_dims.size() - 1] : x_dims[x_dims.size() - 2];
@@ -2041,11 +2036,10 @@ void MatmulKernel(const Context& ctx,
 
     DDim out_dims = make_ddim(out_shape);
     out->Resize(out_dims);
-    ctx.template Alloc<T>(out);  // 分配内存（虽然大小为 0）
+    ctx.template Alloc<T>(out); 
     return;
   }
 
-  // Step 5: 非空张量检查合法性
   PADDLE_ENFORCE_GE(
       common::product(x.dims()),
       0,
@@ -2057,7 +2051,6 @@ void MatmulKernel(const Context& ctx,
       common::errors::InvalidArgument(
           "The dims of Input(Y) should be greater than or equal to 0."));
 
-  // Step 6: 获取维度并调用后续 matmul 流程
   const std::vector<std::int64_t> x_dims = common::vectorize(x.dims());
   const std::vector<std::int64_t> y_dims = common::vectorize(y.dims());
 

--- a/paddle/phi/kernels/impl/matmul_kernel_impl.h
+++ b/paddle/phi/kernels/impl/matmul_kernel_impl.h
@@ -21,6 +21,9 @@ limitations under the License. */
 #include "paddle/phi/kernels/autotune/cache_base.h"
 #include "paddle/phi/kernels/cast_kernel.h"
 #include "paddle/phi/kernels/funcs/blas/blas.h"
+#include "paddle/phi/core/context.h"
+#include "paddle/phi/common/scalar.h"
+#include "paddle/phi/kernels/funcs/broadcast_function.h"
 #ifdef PADDLE_WITH_HIP
 #include "paddle/phi/kernels/funcs/blas/blaslt_impl.hip.h"
 #else
@@ -38,6 +41,7 @@ limitations under the License. */
 #if defined(PADDLE_WITH_CUDA) && CUDA_VERSION >= 11060
 #include "paddle/phi/kernels/autotune/auto_tune_base.h"
 #endif
+
 
 COMMON_DECLARE_bool(cuda_core_int8_gemm);
 
@@ -2000,29 +2004,33 @@ void MatmulKernel(const Context& ctx,
                   bool transpose_x,
                   bool transpose_y,
                   DenseTensor* out) {
+  // Step 1: 处理空张量情况，保留 shape 结构
   if (x.numel() == 0 || y.numel() == 0) {
     auto x_dims = x.dims();
     auto y_dims = y.dims();
 
+    // 如果启用了转置，交换最后两个维度
     if (transpose_x && x_dims.size() >= 2) {
       std::swap(const_cast<DDim&>(x_dims)[x_dims.size() - 1],
                 const_cast<DDim&>(x_dims)[x_dims.size() - 2]);
     }
-
     if (transpose_y && y_dims.size() >= 2) {
       std::swap(const_cast<DDim&>(y_dims)[y_dims.size() - 1],
                 const_cast<DDim&>(y_dims)[y_dims.size() - 2]);
     }
 
+    // Step 2: 提取 batch 维度用于广播
     std::vector<int64_t> x_batch_dims(x_dims.data(), x_dims.data() + x_dims.size() - 2);
     std::vector<int64_t> y_batch_dims(y_dims.data(), y_dims.data() + y_dims.size() - 2);
 
+    // Step 3: 广播 batch 维度
     std::vector<int64_t> bcast_dims;
     if (!funcs::BroadcastTwoVec(x_batch_dims, y_batch_dims, &bcast_dims)) {
       PADDLE_THROW(phi::errors::InvalidArgument(
           "Failed to broadcast input batch dimensions."));
     }
 
+    // Step 4: 构造最终输出 shape
     std::vector<int64_t> out_shape(bcast_dims.begin(), bcast_dims.end());
 
     int64_t m = transpose_x ? x_dims[x_dims.size() - 1] : x_dims[x_dims.size() - 2];
@@ -2033,9 +2041,31 @@ void MatmulKernel(const Context& ctx,
 
     DDim out_dims = make_ddim(out_shape);
     out->Resize(out_dims);
-    ctx.template Alloc<T>(out);
+    ctx.template Alloc<T>(out);  // 分配内存（虽然大小为 0）
     return;
   }
+
+  // Step 5: 非空张量检查合法性
+  PADDLE_ENFORCE_GE(
+      common::product(x.dims()),
+      0,
+      common::errors::InvalidArgument(
+          "The dims of Input(X) should be greater than or equal to 0."));
+  PADDLE_ENFORCE_GE(
+      common::product(y.dims()),
+      0,
+      common::errors::InvalidArgument(
+          "The dims of Input(Y) should be greater than or equal to 0."));
+
+  // Step 6: 获取维度并调用后续 matmul 流程
+  const std::vector<std::int64_t> x_dims = common::vectorize(x.dims());
+  const std::vector<std::int64_t> y_dims = common::vectorize(y.dims());
+
+  MatmulJudgeDtypeKernel<Context, T>(
+      ctx, x, y, x_dims, y_dims, out, transpose_x, transpose_y);
+}
+
+}
 
 template <typename T, typename Context>
 void MatmulWithFlattenKernelInt8Impl(const Context& dev_ctx,

--- a/test/legacy_test/test_matmul_v3_op.py
+++ b/test/legacy_test/test_matmul_v3_op.py
@@ -1,0 +1,48 @@
+import paddle
+import numpy as np
+
+# 所有测试用例
+test_cases = [
+    # 格式: (x_shape, y_shape, expected_out_shape, dtype)
+    ((0, 100, 1), (0, 1, 40), (0, 100, 40), "float64"),
+    ((0, 100, 1), (0, 1, 4), (0, 100, 4), "float64"),
+    ((0, 100, 1), (1, 1, 40), (0, 100, 40), "float64"),
+    ((0, 100, 1), (1, 1, 4), (0, 100, 4), "float64"),
+    ((0, 12, 197, 197), (0, 12, 197, 64), (0, 12, 197, 64), "float16"),
+    ((0, 12, 197, 197), (0, 12, 197, 64), (0, 12, 197, 64), "float32"),
+    ((1, 0, 1), (1, 1, 40), (1, 0, 40), "float64"),
+    ((1, 0, 1), (1, 1, 4), (1, 0, 4), "float64"),
+    ((1, 100, 1), (0, 1, 40), (0, 100, 40), "float64"),
+    ((1, 100, 1), (0, 1, 4), (0, 100, 4), "float64"),
+    ((1, 100, 1), (1, 1, 0), (1, 100, 0), "float64"),
+    ((112, 0, 197, 197), (112, 0, 197, 64), (112, 0, 197, 64), "float16"),
+    ((112, 0, 197, 197), (112, 0, 197, 64), (112, 0, 197, 64), "float32"),
+    ((112, 12, 0, 197), (112, 12, 197, 64), (112, 12, 0, 64), "float16"),
+    ((112, 12, 0, 197), (112, 12, 197, 64), (112, 12, 0, 64), "float32"),
+    ((112, 12, 197, 197), (112, 12, 197, 0), (112, 12, 197, 0), "float16"),
+    ((112, 12, 197, 197), (112, 12, 197, 0), (112, 12, 197, 0), "float32"),
+]
+
+def run_all_matmul_tests():
+    for idx, (x_shape, y_shape, expected_shape, dtype) in enumerate(test_cases):
+        print(f"\nTest {idx+1} begin: paddle.Tensor.matmul(Tensor({x_shape}), Tensor({y_shape}), dtype={dtype})")
+        try:
+            x = paddle.zeros(x_shape, dtype=dtype)
+            y = paddle.zeros(y_shape, dtype=dtype)
+            result = x.matmul(y)
+
+            if result.shape != expected_shape:
+                raise AssertionError(
+                    f"[accuracy error] paddle.Tensor.matmul(Tensor({x_shape}), Tensor({y_shape}), dtype={dtype})\n\n"
+                    f"Not equal to tolerance rtol=0.01, atol=0.01\n\n"
+                    f"(shapes {result.shape}, {expected_shape} mismatch)\n"
+                    f" x: array([], shape={x.shape}, dtype={dtype})\n"
+                    f" y: array([], shape={y.shape}, dtype={dtype})"
+                )
+            else:
+                print(f"[PASS] Shape is correct: {result.shape}")
+        except Exception as e:
+            print(f"{e}")
+
+if __name__ == "__main__":
+    run_all_matmul_tests()


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
New features

### Description
isclose Tensor.isclose支持0-Size。

修改历程介绍如下：

在PaddleAPITest report/0size_tensor中检索paddle.Tensor.matmul的错误日志，发现[accuracy error]报错。分析可能是前向过程出错。！！！注意到(shapes (0, 100, 1, 40), (0, 100, 40) mismatch)，也是就shape不匹配的问题
`2025-03-05 15:27:11.945992 test begin: paddle.Tensor.matmul(Tensor([0, 100, 1],"float64"), Tensor([0, 1, 40],"float64"), )

[accuracy error] paddle.Tensor.matmul(Tensor([0, 100, 1],"float64"), Tensor([0, 1, 40],"float64"), ) 
 
Not equal to tolerance rtol=0.01, atol=0.01

(shapes (0, 100, 1, 40), (0, 100, 40) mismatch)
 x: array([], shape=(0, 100, 1, 40), dtype=float64)
 y: array([], shape=(0, 100, 40), dtype=float64)
`
前向修复：
a. 在Paddle代码中检索def matmul，发现matmul的核心实现调用的是_C_ops的matmul
b. 以_C_ops的matmul在paddle/phi/ops/yaml中检索，发现matmul的InferMeta函数使用到一个：
MatmulInferMeta
`- op: matmul
  args : (Tensor x, Tensor y)
  output : Tensor(out)
  infer_meta :
    func : MatmulInferMeta
    param: [x, y, false, false]`

c. 在代码中检索MatmulInferMeta，并检查其dims(shape)的推导是否正确（在matmul中推导是正确因此不用修改）
d. 在paddle/phi/kernels中检索matmul，找全所有matmul的实现Kernel。发现共有五个涉及matmul的文件，分别为：

- paddle/phi/kernels/cpu/matmul_kernel.cc
- paddle/phi/kernels/gpu/matmul_kernel.cu
- paddle/phi/kernels/impl/matmul_kernel_impl.h
- paddle/phi/kernels/matmul_kernel.h
- paddle/phi/kernels/gpu/weight_only_linear_grad_kernel.cu
其中cc和cu文件均将前两个.h文件设为头文件，因此只用修改.h文件即可。而matmul_kernel.h和matmul_kernel_impl.h中不需要（不能）重复定义，故只修改了matmul_kernel_impl.h

注意，下面的文件仅以 paddle/phi/kernels/matmul_kernel.h为头文件，并不含有matmulkernel字段，所以不予以考虑
- paddle/phi/kernels/impl/svdvals_grad_kernel_impl.h
- paddle/phi/kernels/impl/eigvalsh_grad_kernel_impl.h
- paddle/phi/kernels/impl/lstsq_kernel_impl.h
- paddle/phi/kernels/impl/eigh_grad_kernel_impl.h
- paddle/phi/kernels/impl/qr_grad_kernel_impl.h
- paddle/phi/kernels/sparse/gpu/fused_attention_kernel.cu

在paddle/phi/kernels/impl/matmul_kernel_impl.h中删除了原来的代码（因为有错误），加入以下代码，完成修复
` if (x.numel() == 0 || y.numel() == 0) {
    auto x_dims = x.dims();
    auto y_dims = y.dims();

    if (transpose_x && x_dims.size() >= 2) {
      std::swap(const_cast<DDim&>(x_dims)[x_dims.size() - 1],
                const_cast<DDim&>(x_dims)[x_dims.size() - 2]);
    }

    if (transpose_y && y_dims.size() >= 2) {
      std::swap(const_cast<DDim&>(y_dims)[y_dims.size() - 1],
                const_cast<DDim&>(y_dims)[y_dims.size() - 2]);
    }

    std::vector<int64_t> x_batch_dims(x_dims.data(), x_dims.data() + x_dims.size() - 2);
    std::vector<int64_t> y_batch_dims(y_dims.data(), y_dims.data() + y_dims.size() - 2);

    std::vector<int64_t> bcast_dims;
    if (!funcs::BroadcastTwoVec(x_batch_dims, y_batch_dims, &bcast_dims)) {
      PADDLE_THROW(phi::errors::InvalidArgument(
          "Failed to broadcast input batch dimensions."));
    }

    std::vector<int64_t> out_shape(bcast_dims.begin(), bcast_dims.end());

    int64_t m = transpose_x ? x_dims[x_dims.size() - 1] : x_dims[x_dims.size() - 2];
    int64_t n = transpose_y ? y_dims[y_dims.size() - 2] : y_dims[y_dims.size() - 1];

    out_shape.push_back(m);
    out_shape.push_back(n);

    DDim out_dims = make_ddim(out_shape);
    out->Resize(out_dims);
    ctx.template Alloc<T>(out);
    return;
  }`

添加单测：

在test/legacy_test/test_matmul_op.py中添加0 size tensor输入的单测:
`import paddle
import numpy as np

# 所有测试用例
test_cases = [
    # 格式: (x_shape, y_shape, expected_out_shape, dtype)
    ((0, 100, 1), (0, 1, 40), (0, 100, 40), "float64"),
    ((0, 100, 1), (0, 1, 4), (0, 100, 4), "float64"),
    ((0, 100, 1), (1, 1, 40), (0, 100, 40), "float64"),
    ((0, 100, 1), (1, 1, 4), (0, 100, 4), "float64"),
    ((0, 12, 197, 197), (0, 12, 197, 64), (0, 12, 197, 64), "float16"),
    ((0, 12, 197, 197), (0, 12, 197, 64), (0, 12, 197, 64), "float32"),
    ((1, 0, 1), (1, 1, 40), (1, 0, 40), "float64"),
    ((1, 0, 1), (1, 1, 4), (1, 0, 4), "float64"),
    ((1, 100, 1), (0, 1, 40), (0, 100, 40), "float64"),
    ((1, 100, 1), (0, 1, 4), (0, 100, 4), "float64"),
    ((1, 100, 1), (1, 1, 0), (1, 100, 0), "float64"),
    ((112, 0, 197, 197), (112, 0, 197, 64), (112, 0, 197, 64), "float16"),
    ((112, 0, 197, 197), (112, 0, 197, 64), (112, 0, 197, 64), "float32"),
    ((112, 12, 0, 197), (112, 12, 197, 64), (112, 12, 0, 64), "float16"),
    ((112, 12, 0, 197), (112, 12, 197, 64), (112, 12, 0, 64), "float32"),
    ((112, 12, 197, 197), (112, 12, 197, 0), (112, 12, 197, 0), "float16"),
    ((112, 12, 197, 197), (112, 12, 197, 0), (112, 12, 197, 0), "float32"),
]

def run_all_matmul_tests():
    for idx, (x_shape, y_shape, expected_shape, dtype) in enumerate(test_cases):
        print(f"\nTest {idx+1} begin: paddle.Tensor.matmul(Tensor({x_shape}), Tensor({y_shape}), dtype={dtype})")
        try:
            x = paddle.zeros(x_shape, dtype=dtype)
            y = paddle.zeros(y_shape, dtype=dtype)
            result = x.matmul(y)

            if result.shape != expected_shape:
                raise AssertionError(
                    f"[accuracy error] paddle.Tensor.matmul(Tensor({x_shape}), Tensor({y_shape}), dtype={dtype})\n\n"
                    f"Not equal to tolerance rtol=0.01, atol=0.01\n\n"
                    f"(shapes {result.shape}, {expected_shape} mismatch)\n"
                    f" x: array([], shape={x.shape}, dtype={dtype})\n"
                    f" y: array([], shape={y.shape}, dtype={dtype})"
                )
            else:
                print(f"[PASS] Shape is correct: {result.shape}")
        except Exception as e:
            print(f"{e}")

if __name__ == "__main__":
    run_all_matmul_tests()`

备注：原来的代码存在错误，
`std::vector<std::int64_t> out_dims(x_dims.size() - 1 + y_dims.size() - 1);`
对于二维 matmul 是对的，但对于多维（batched）matmul 来说，这会导致错误。
正确做法应是：batch 维度取广播后的结果；最后两维做矩阵乘法；所以输出 rank 应与广播后的 batch rank 相同 + 2（最后两个维度）
重写后支持任意 rank 的输入张量（>=2）

下面提供一个最简单的示例测试
`import paddle

# 测试数据
x = paddle.randn([0, 100, 1])   # shape: [0, 100, 1]
y = paddle.randn([1, 1, 4])     # shape: [1, 1, 4]

result = x.matmul(y)
print(result.shape)  # 输出: [0, 100, 4], 而不是原来的[0, 100, 1, 4]`
