### PR TITLE
[0-size Tensor No.41、125、296] Add 0-size Tensor support for cumsum

### DIFF
--- a/paddle/phi/kernels/cpu/cum_kernel.cc
+++ b/paddle/phi/kernels/cpu/cum_kernel.cc
@@ -57,6 +57,10 @@ void ScanKernel(const Context& dev_ctx,
                 bool reverse,
                 Reducer reducer,
                 DenseTensor* out) {
+  if (out && out->numel() == 0) {
+    dev_ctx.template Alloc<T>(out);
+    return;
+  }
   dev_ctx.template Alloc<T>(out);
 
   if (x.numel() == 1) {

--- a/paddle/phi/kernels/gpu/cum_kernel.cu
+++ b/paddle/phi/kernels/gpu/cum_kernel.cu
@@ -274,6 +274,10 @@ void ScanKernel(const Context& dev_ctx,
                 bool reverse,
                 Op op,
                 DenseTensor* out) {
+  if (out && out->numel() == 0) {
+    dev_ctx.template Alloc<T>(out);
+    return;
+  }
   T* out_data = dev_ctx.template Alloc<T>(out);
 
   // For 0D Tensor

--- a/paddle/phi/kernels/impl/logcumsumexp_grad_impl.h
+++ b/paddle/phi/kernels/impl/logcumsumexp_grad_impl.h
@@ -50,6 +50,10 @@ void LogcumsumexpGradKernel(const Context& dev_ctx,
                             bool exclusive,
                             bool reverse,
                             DenseTensor* d_x) {
+  if (d_x && d_x->numel() == 0) {
+    dev_ctx.template Alloc<T>(d_x);
+    return;
+  }
   reverse = !reverse;
   dev_ctx.template Alloc<T>(d_x);
 

--- a/paddle/phi/kernels/xpu/cum_kernel.cc
+++ b/paddle/phi/kernels/xpu/cum_kernel.cc
@@ -28,6 +28,10 @@ void CumsumKernel(const Context& dev_ctx,
                   bool reverse,
                   DenseTensor* out) {
   using XPUType = typename XPUTypeTrait<T>::Type;
+  if (out && out->numel() == 0) {
+    dev_ctx.template Alloc<T>(out);
+    return;
+  }
   dev_ctx.template Alloc<T>(out);
 
   if (x.numel() == 1) {

--- a/test/legacy_test/test_cumsum_op.py
+++ b/test/legacy_test/test_cumsum_op.py
@@ -750,6 +750,7 @@ class TestCumSumOpFp16(unittest.TestCase):
 def create_test_class(op_type, dtype, shape, axis):
     class Cls(unittest.TestCase):
         def test_zero_size(self):
+            paddle.disable_static()
             numpy_tensor_1 = np.random.rand(*shape).astype(dtype)
             paddle_x = paddle.to_tensor(numpy_tensor_1)
             paddle_x.stop_gradient = False

--- a/test/legacy_test/test_cumsum_op.py
+++ b/test/legacy_test/test_cumsum_op.py
@@ -747,5 +747,38 @@ class TestCumSumOpFp16(unittest.TestCase):
             paddle.disable_static()
 
 
+def create_test_class(op_type, dtype, shape, axis):
+    class Cls(unittest.TestCase):
+        def test_zero_size(self):
+            numpy_tensor_1 = np.random.rand(*shape).astype(dtype)
+            paddle_x = paddle.to_tensor(numpy_tensor_1)
+            paddle_x.stop_gradient = False
+
+            paddle_api = eval(f"paddle.{op_type}")
+            paddle_out = paddle_api(paddle_x, axis=axis)
+            numpy_api = eval(f"np.{op_type}")
+            numpy_out = numpy_api(numpy_tensor_1, axis=axis)
+
+            np.testing.assert_allclose(
+                paddle_out.numpy(),
+                numpy_out,
+                1e-2,
+                1e-2,
+            )
+            np.testing.assert_allclose(
+                paddle_out.shape,
+                numpy_out.shape,
+            )
+
+    cls_name = f"{op_type}{dtype}_0SizeTest"
+    Cls.__name__ = cls_name
+    globals()[cls_name] = Cls
+
+
+create_test_class("cumsum", "float32", [3, 4, 0], 0)
+create_test_class("cumsum", "float64", [3, 4, 0, 3, 4], -2)
+create_test_class("cumsum", "int32", [3, 4, 0], 0)
+create_test_class("cumsum", "int64", [3, 4, 0, 3, 4], -1)
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/legacy_test/test_logcumsumexp_op.py
+++ b/test/legacy_test/test_logcumsumexp_op.py
@@ -375,5 +375,39 @@ class TestLogcumsumexpBF16Op(OpTest):
         )
 
 
+def create_test_class(op_type, dtype, shape, axis):
+    class Cls(unittest.TestCase):
+        def test_zero_size(self):
+            numpy_tensor_1 = np.random.rand(*shape).astype(dtype)
+            paddle_x = paddle.to_tensor(numpy_tensor_1)
+            paddle_x.stop_gradient = False
+
+            paddle_api = eval(f"paddle.{op_type}")
+            paddle_out = paddle_api(paddle_x, axis=axis)
+            numpy_out = np.log(
+                np.cumsum(np.exp(numpy_tensor_1), axis=axis)
+            )  # Numpy does not have logcumsumexp
+
+            np.testing.assert_allclose(
+                paddle_out.numpy(),
+                numpy_out,
+                1e-2,
+                1e-2,
+            )
+            np.testing.assert_allclose(
+                paddle_out.shape,
+                numpy_out.shape,
+            )
+
+    cls_name = f"{op_type}{dtype}_0SizeTest"
+    Cls.__name__ = cls_name
+    globals()[cls_name] = Cls
+
+
+create_test_class("logcumsumexp", "float32", [3, 4, 0], 0)
+create_test_class("logcumsumexp", "float64", [3, 4, 0, 3, 4], -2)
+create_test_class("logcumsumexp", "int32", [3, 4, 0], 0)
+create_test_class("logcumsumexp", "int64", [3, 4, 0, 3, 4], -1)
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/legacy_test/test_logcumsumexp_op.py
+++ b/test/legacy_test/test_logcumsumexp_op.py
@@ -378,6 +378,7 @@ class TestLogcumsumexpBF16Op(OpTest):
 def create_test_class(op_type, dtype, shape, axis):
     class Cls(unittest.TestCase):
         def test_zero_size(self):
+            paddle.disable_static()
             numpy_tensor_1 = np.random.rand(*shape).astype(dtype)
             paddle_x = paddle.to_tensor(numpy_tensor_1)
             paddle_x.stop_gradient = False


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
[0-size Tensor No.41、125、296] Add 0-size Tensor support for cumsum
cumsum的反向使用cumsum正向kernel，所以不用修改
![image](https://github.com/user-attachments/assets/acfc4cb2-2539-4ad8-a5fc-d30927b31ad9)
infermeta shape推导正确不用修改
kernel修复修改cpu, gpu, xpu，不需要修改onednn sparse selectrows

logcumsumexp正向使用 cumsum，已修改反向
infermeta shape推导同cumsum不用修改
kernel修复修改cpu, gpu，其他不需要修改

PaddleAPITest 测试通过
![image](https://github.com/user-attachments/assets/85fd9db1-3cfc-44e8-a4af-662bf10d1091)

