### PR TITLE
[SOT] Stop test Python 3.8 on CI

### DIFF
--- a/.github/workflows/_SOT.yml
+++ b/.github/workflows/_SOT.yml
@@ -24,7 +24,7 @@ jobs:
     name: Check bypass for SOT
     uses: ./.github/workflows/check-bypass.yml
     with:
-      workflow-name: 'sot'
+      workflow-name: "sot"
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -128,34 +128,6 @@ jobs:
           bash ${ci_scripts}/determine_sot_ci_trigger.sh
           determine_excode=$?
           echo "determine_excode=$determine_excode" >> ${{ github.env }}
-          '
-
-      - name: Build with python3.8
-        env:
-          work_dir: ${{ github.workspace }}
-          PADDLE_ROOT: ${{ github.workspace }}
-        if: ${{ env.determine_excode == 0 }}
-        run: |
-          docker exec -t ${{ env.container_name }} /bin/bash -c '
-          export PY_VERSION=3.8
-          source ${{ github.workspace }}/../../../proxy
-          bash ${ci_scripts}/run_setup.sh bdist_wheel
-          EXCODE=$?
-          exit $EXCODE
-          '
-
-      - name: Test with python3.8
-        env:
-          work_dir: ${{ github.workspace }}
-          PADDLE_ROOT: ${{ github.workspace }}
-        if: ${{ env.determine_excode == 0 }}
-        run: |
-          docker exec -t ${{ env.container_name }} /bin/bash -c '
-          source ${{ github.workspace }}/../../../proxy
-          bash ${ci_scripts}/run_sot_test.sh 3.8
-          EXCODE=$?
-          rm -rf ${PADDLE_ROOT}/build/CMakeCache.txt
-          exit $EXCODE
           '
 
       - name: Build with python3.9

--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -4940,7 +4940,7 @@ function main() {
       cicheck_sot)
         check_run_sot_ci
         export WITH_SHARED_PHI=ON
-        PYTHON_VERSIONS=(3.13 3.8 3.9 3.10 3.11 3.12)
+        PYTHON_VERSIONS=(3.9 3.10 3.11 3.12 3.13)
         for PY_VERSION in ${PYTHON_VERSIONS[@]}; do
             ln -sf $(which python${PY_VERSION}) /usr/local/bin/python
             ln -sf $(which pip${PY_VERSION}) /usr/local/bin/pip


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Deprecations

### Description
<!-- Describe what you’ve done -->

CI 中移除 SOT Python 3.8 测试，后续不再支持 Python 3.8

<!-- PCard-66972 -->