### PR TITLE
[0-size Tensor No.92、94-97、309] Add 0-size Tensor support for isfinite/isinf/isnan

### DIFF
--- a/paddle/phi/kernels/impl/isfinite_kernel_impl.h
+++ b/paddle/phi/kernels/impl/isfinite_kernel_impl.h
@@ -481,18 +481,30 @@ template <typename T, typename Context>
 void IsfiniteKernel(const Context& dev_ctx,
                     const DenseTensor& x,
                     DenseTensor* out) {
+  if (out && out->numel() == 0) {
+    dev_ctx.template Alloc<bool>(out);
+    return;
+  }
   IsfiniteFunctor<Context, T>()(dev_ctx, x, out);
 }
 template <typename T, typename Context>
 void IsinfKernel(const Context& dev_ctx,
                  const DenseTensor& x,
                  DenseTensor* out) {
+  if (out && out->numel() == 0) {
+    dev_ctx.template Alloc<bool>(out);
+    return;
+  }
   IsinfFunctor<Context, T>()(dev_ctx, x, out);
 }
 template <typename T, typename Context>
 void IsnanKernel(const Context& dev_ctx,
                  const DenseTensor& x,
                  DenseTensor* out) {
+  if (out && out->numel() == 0) {
+    dev_ctx.template Alloc<bool>(out);
+    return;
+  }
   IsnanFunctor<Context, T>()(dev_ctx, x, out);
 }
 }  // namespace phi

--- a/paddle/phi/kernels/selected_rows/impl/isfinite_kernel_impl.h
+++ b/paddle/phi/kernels/selected_rows/impl/isfinite_kernel_impl.h
@@ -23,6 +23,10 @@ namespace phi {
   template <typename T, typename Context>                             \
   void isfinite##SR(                                                  \
       const Context& ctx, const SelectedRows& x, SelectedRows* out) { \
+    if (out && out->numel() == 0) {                                   \
+      ctx.template Alloc<bool>(out);                                  \
+      return;                                                         \
+    }                                                                 \
     ctx.template Alloc<bool>(out);                                    \
     Isinf##Kernel<T, Context>(ctx, x.value(), out->mutable_value());  \
   }

--- a/paddle/phi/kernels/xpu/isfinite_kernel.cc
+++ b/paddle/phi/kernels/xpu/isfinite_kernel.cc
@@ -23,6 +23,10 @@ namespace phi {
 template <typename T, typename Context>
 void IsnanKernel(const Context& ctx, const DenseTensor& x, DenseTensor* out) {
   using XPUType = typename XPUTypeTrait<T>::Type;
+  if (out && out->numel() == 0) {
+    ctx.template Alloc<bool>(out);
+    return;
+  }
   auto* out_data = ctx.template Alloc<bool>(out);
   int r = xpu::isnan<XPUType>(ctx.x_context(),
                               reinterpret_cast<const XPUType*>(x.data<T>()),
@@ -36,6 +40,10 @@ void IsfiniteKernel(const Context& ctx,
                     const DenseTensor& x,
                     DenseTensor* out) {
   using XPUType = typename XPUTypeTrait<T>::Type;
+  if (out && out->numel() == 0) {
+    ctx.template Alloc<bool>(out);
+    return;
+  }
   auto* out_data = ctx.template Alloc<bool>(out);
   int r = xpu::isfinite<XPUType>(ctx.x_context(),
                                  reinterpret_cast<const XPUType*>(x.data<T>()),
@@ -47,6 +55,10 @@ void IsfiniteKernel(const Context& ctx,
 template <typename T, typename Context>
 void IsinfKernel(const Context& ctx, const DenseTensor& x, DenseTensor* out) {
   using XPUType = typename XPUTypeTrait<T>::Type;
+  if (out && out->numel() == 0) {
+    ctx.template Alloc<bool>(out);
+    return;
+  }
   auto* out_data = ctx.template Alloc<bool>(out);
   int r = xpu::isinf<XPUType>(ctx.x_context(),
                               reinterpret_cast<const XPUType*>(x.data<T>()),

--- a/test/legacy_test/test_isfinite_v2_op.py
+++ b/test/legacy_test/test_isfinite_v2_op.py
@@ -352,6 +352,41 @@ class TestError(unittest.TestCase):
             self.assertRaises(TypeError, test_isneginf_bad_x)
 
 
+def create_test_class(op_type, dtype, shape):
+    class Cls(unittest.TestCase):
+        def test_zero_size(self):
+            numpy_tensor_1 = np.random.rand(*shape).astype(dtype)
+            paddle_x = paddle.to_tensor(numpy_tensor_1)
+            paddle_x.stop_gradient = False
+
+            paddle_api = eval(f"paddle.{op_type}")
+            paddle_out = paddle_api(paddle_x)
+            numpy_api = eval(f"np.{op_type}")
+            numpy_out = numpy_api(numpy_tensor_1)
+
+            np.testing.assert_allclose(
+                paddle_out.numpy(),
+                numpy_out,
+                1e-2,
+                1e-2,
+            )
+            np.testing.assert_allclose(
+                paddle_out.shape,
+                numpy_out.shape,
+            )
+
+    cls_name = f"{op_type}{dtype}_0SizeTest"
+    Cls.__name__ = cls_name
+    globals()[cls_name] = Cls
+
+
+op_list = ["isfinite", "isinf", "isnan"]
+for op in op_list:
+    create_test_class(op, "float32", [3, 4, 0])
+    create_test_class(op, "float64", [3, 4, 0, 3, 4])
+    create_test_class(op, "int32", [3, 4, 0])
+    create_test_class(op, "int64", [3, 4, 0, 3, 4])
+
 if __name__ == '__main__':
     paddle.enable_static()
     unittest.main()

--- a/test/legacy_test/test_isfinite_v2_op.py
+++ b/test/legacy_test/test_isfinite_v2_op.py
@@ -355,6 +355,7 @@ class TestError(unittest.TestCase):
 def create_test_class(op_type, dtype, shape):
     class Cls(unittest.TestCase):
         def test_zero_size(self):
+            paddle.disable_static()
             numpy_tensor_1 = np.random.rand(*shape).astype(dtype)
             paddle_x = paddle.to_tensor(numpy_tensor_1)
             paddle_x.stop_gradient = False


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
[0-size Tensor No.92、94-97] Add 0-size Tensor support for isfinite/isinf/isnan
isposinf, isneginf实际调用的为isinf
修改前向kernel，反向kernel没有
infermeta不用修改
kernel包含cpu/gpu/xpu

PaddleAPITest测试通过
![image](https://github.com/user-attachments/assets/1981478a-fc63-43bb-a335-7f8ea4eb2d81)
![image](https://github.com/user-attachments/assets/e0557d89-99ba-459d-82b6-7f2128491386)
![image](https://github.com/user-attachments/assets/f5831a61-6bed-49d4-86ef-ce4c41e56a85)