### PR TITLE
【cuda12.9】fix cuda12.9 compile bug

### DIFF
--- a/paddle/phi/CMakeLists.txt
+++ b/paddle/phi/CMakeLists.txt
@@ -190,6 +190,13 @@ else()
     DEPS ${PHI_DEPS})
 endif()
 
+set(NVTX3_PATH "${CUDA_INCLUDE_DIRS}/../targets/x86_64-linux/include/nvtx3/")
+get_filename_component(NVTX3_PATH "${NVTX3_PATH}" ABSOLUTE)
+
+if(EXISTS "${NVTX3_PATH}")
+  target_include_directories(phi_core PUBLIC "${NVTX3_PATH}")
+endif()
+
 # core/memory/allocation uses shm_unlink and requires the rt library
 if(UNIX AND NOT APPLE)
   target_link_libraries(phi_core rt)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修复cuda12.9编包镜像在cuda12.9下的编译错误，为phi_core增加搜索头文件路径，报错如下：
![97e35ce7d57f77ee1c5979aa1e3361fa](https://github.com/user-attachments/assets/80e5a58d-44fd-4368-b18d-03c25f2805d7)
pcard-67164