### PR TITLE
[CINN] Fix int type casting of Scale op

### DIFF
--- a/paddle/cinn/hlir/op/elementwise.cc
+++ b/paddle/cinn/hlir/op/elementwise.cc
@@ -326,10 +326,10 @@ std::shared_ptr<OpStrategy> StrategyForScaleSymbolic(
 
               Expr cast_scale = should_upscale_fp32
                                     ? Expr(scale)
-                                    : ir::Cast::Make(A->type(), Expr(scale));
+                                    : common::cast(Expr(scale), A->type());
               Expr cast_bias = should_upscale_fp32
                                    ? Expr(bias)
-                                   : ir::Cast::Make(A->type(), Expr(bias));
+                                   : common::cast(Expr(bias), A->type());
               Expr add_result;
               if (scale == 1.0f) {
                 if (bias == 0.0f) {

--- a/test/ir/pir/cinn/test_cinn_arange.py
+++ b/test/ir/pir/cinn/test_cinn_arange.py
@@ -65,7 +65,9 @@ class TestArange(unittest.TestCase):
 
     def test_broadcast_tensor(self):
         def func():
-            return paddle.arange(1, 2) + paddle.arange(end=32769)
+            a = paddle.arange(1, 2, dtype="int32")
+            b = paddle.arange(end=32769)
+            return (a * 3).astype("int64") + b
 
         self.eval(func, [])
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
CINN


### PR Types
Bug fixes


### Description
修复scale op在对int/int64类型进行scale时出现的cast报错

<b>说明：</b>scale默认是用float类型作为乘的参数，之前scale不会用于操作int类型的下标，都是操作浮点类型，所以没问题，而支持arange后出现了scale直接操作下标的场景，就发生类型冲突了

本PR使用common::cast接口替换Cast::Make，前者可以直接对常数进行eager cast，避免出现`int(5.0f)`这样矛盾的情况，这会导致后续convert_int32_to_int64报错

Pcard-85711