### PR TITLE
[Decomp] Optimize performance of decomp of gelu

### DIFF
--- a/paddle/fluid/primitive/decomp_rule/decomp_rule/composite.h
+++ b/paddle/fluid/primitive/decomp_rule/decomp_rule/composite.h
@@ -679,8 +679,7 @@ Tensor gelu_decomp(const Tensor& x, bool approximate) {
     auto kAlpha =
         full_scalar<T>(PM_2_SQRTPI * PM_SQRT1_2, org_dtype, x.place());
     auto GELU_CONSTANT = full_scalar<T>(0.044715, org_dtype, x.place());
-    auto x_pow3 =
-        elementwise_pow<T>(x, full_scalar<T>(3, org_dtype, x.place()));
+    auto x_pow3 = x * x * x;
     auto tanh_out = tanh<T>(kAlpha * (x + x_pow3 * GELU_CONSTANT));
 
     auto res = x * half * (one + tanh_out);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->
Pcard-67164

将gelu组合算子中的pow替换为mul连成，可有效提升在编译器场景下的kernel性能。