### PR TITLE
refine eager backward

### DIFF
--- a/paddle/fluid/eager/backward.cc
+++ b/paddle/fluid/eager/backward.cc
@@ -264,10 +264,6 @@ std::vector<paddle::Tensor> RunBackward(
     GradNodeBase* node = queue.front();
     VLOG(3) << "Preparing GradNode:" << node->name() << " addr:" << node;
     try {
-      if (queue.size() > 1 && node_in_degree_map[node] != 0) {
-        queue.pop_front();
-        continue;
-      }
       queue.pop_front();
 
       // Run node: This is where Hook happens

--- a/paddle/fluid/eager/backward.cc
+++ b/paddle/fluid/eager/backward.cc
@@ -225,6 +225,14 @@ std::vector<paddle::Tensor> RunBackward(
   std::unordered_map<GradNodeBase*, int> node_in_degree_map =
       getInDegreeMap(queue);
 
+  std::deque<GradNodeBase*> ready_queue;
+  for (GradNodeBase* item : queue) {
+    if (!node_in_degree_map.count(item)) {
+      ready_queue.push_back(item);
+    }
+  }
+  queue = ready_queue;
+
   std::list<GradNodeBase*> force_sequential_nodes_forward_queue =
       egr::Controller::Instance().GetForceSequentialNodes();
   std::deque<GradNodeBase*> force_sequential_nodes_queue;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->
Paddle 对于如下代码会报错：

```
import paddle

a = paddle.ones([100])
a.stop_gradient = False
b = paddle.ones([100])
b.stop_gradient = False

c = a + b
d = c + c
e = d + d
# paddle_out_grads = paddle.autograd.backward([e], [paddle.ones([100])]) # rigth
paddle_out_grads = paddle.autograd.backward([e,c,d], [paddle.ones([100]),paddle.ones([100]),paddle.ones([100])])
```

报错内容为：

```
Traceback (most recent call last):
  File "/host_home/wanghuan29/Paddle/test_grad.py", line 13, in <module>
    paddle_out_grads = paddle.autograd.backward([e,c,d], [paddle.ones([100]),paddle.ones([100]),paddle.ones([100])])
  File "/usr/local/lib/python3.9/dist-packages/decorator.py", line 232, in fun
    return caller(func, *(extras + args), **kw)
  File "/host_home/wanghuan29/Paddle2/build/python/paddle/base/wrapped_decorator.py", line 40, in __impl__
    return wrapped_func(*args, **kwargs)
  File "/host_home/wanghuan29/Paddle2/build/python/paddle/base/framework.py", line 726, in __impl__
    return func(*args, **kwargs)
  File "/host_home/wanghuan29/Paddle2/build/python/paddle/autograd/backward_mode.py", line 140, in backward
    core.eager.run_backward(tensors, grad_tensors, retain_graph)
SystemError: (Fatal) Unable to find next node in the GradTensorHolder 
Trying to run Node without configuring its GradTensorHolder.
  [Hint: Expected node_input_buffer_iter != node_input_buffers_dict.end(), but received node_input_buffer_iter == node_input_buffers_dict.end().] (at /host_home/wanghuan29/Paddle2/paddle/fluid/eager/backward.cc:272)
```
如下代码有同样的问题：
```
import paddle

a = paddle.ones([100])
a.stop_gradient = False
b = paddle.ones([100])
b.stop_gradient = False

c = a + b
d = c + c
e = d + d
f, g = paddle.split(e, num_or_sections=2, axis=0)
h = f + f

paddle_out_grads = paddle.autograd.backward([h,g], [paddle.ones([50]),paddle.ones([50])])
```
第一种情况，用户提供了c和d的梯度，那么通过反向回传获得的梯度该怎么办。实测torch.autograd.grad和paddle.grad都是将用户提供的梯度以及回传算出的梯度加和。因此，paddle.autograd.backward也有必要这么做。
第二种情况，是paddle.autograd.backward存在bug。

这两种错误在paddle.autograd.backward时会发生，在paddle.grad时不会发生，因为paddle.grad会走PreparedForGeneralGrad，对反向图做剪枝等优化。

Pcard-67164