### PR TITLE
[XPU] Support complex  for slice and cast

### DIFF
--- a/paddle/phi/backends/xpu/xpu3_op_list.cc
+++ b/paddle/phi/backends/xpu/xpu3_op_list.cc
@@ -270,6 +270,9 @@ XPUOpMap& get_kl3_ops() {
        XPUKernelSet({phi::DataType::FLOAT32,
                      phi::DataType::FLOAT16,
                      phi::DataType::BFLOAT16,
+#ifdef PADDLE_WITH_XPU_FFT
+                     phi::DataType::COMPLEX64,
+#endif
                      phi::DataType::FLOAT64,
                      phi::DataType::BOOL,
                      phi::DataType::INT8,

--- a/paddle/phi/backends/xpu/xpu3_op_list.cc
+++ b/paddle/phi/backends/xpu/xpu3_op_list.cc
@@ -1348,11 +1348,17 @@ XPUOpMap& get_kl3_ops() {
        XPUKernelSet({phi::DataType::FLOAT32,
                      phi::DataType::FLOAT16,
                      phi::DataType::BFLOAT16,
+#ifdef PADDLE_WITH_XPU_FFT
+                     phi::DataType::COMPLEX64,
+#endif
                      phi::DataType::INT32})},
       {"slice",
        XPUKernelSet({phi::DataType::FLOAT32,
                      phi::DataType::FLOAT16,
                      phi::DataType::BFLOAT16,
+#ifdef PADDLE_WITH_XPU_FFT
+                     phi::DataType::COMPLEX64,
+#endif
                      phi::DataType::FLOAT64,
                      phi::DataType::UINT8,
                      phi::DataType::INT8,

--- a/paddle/phi/kernels/xpu/cast_kernel.cc
+++ b/paddle/phi/kernels/xpu/cast_kernel.cc
@@ -150,6 +150,28 @@ void CastKernel(const Context& dev_ctx,
           "Not supported cast %d -> %d", x.dtype(), out_dtype));
   }
 }
+#ifdef PADDLE_WITH_XPU_FFT
+template <>
+void CastKernel<phi::dtype::complex<float>, XPUContext>(
+    const XPUContext& dev_ctx,
+    const DenseTensor& x,
+    DataType out_dtype,
+    DenseTensor* out) {
+  using T = phi::dtype::complex<float>;
+  if (x.dtype() == out_dtype) {
+    if (x.dims() == phi::make_ddim({-1})) {
+      *out = x;
+      return;
+    }
+    if (!out->IsSharedWith(x)) {
+      phi::Copy(dev_ctx, x, dev_ctx.GetPlace(), false, out);
+    }
+    return;
+  }
+  DenseTensor x_real = Real<T, XPUContext>(dev_ctx, x);
+  CastKernel<float, XPUContext>(dev_ctx, x_real, out_dtype, out);
+}
+#endif
 }  // namespace phi
 
 PD_REGISTER_KERNEL(cast,
@@ -161,6 +183,9 @@ PD_REGISTER_KERNEL(cast,
                    float,
                    phi::dtype::float16,
                    phi::dtype::bfloat16,
+#ifdef PADDLE_WITH_XPU_FFT
+                   phi::dtype::complex<float>,
+#endif
                    int64_t,
                    bool,
                    int8_t,

--- a/paddle/phi/kernels/xpu/cast_kernel.cc
+++ b/paddle/phi/kernels/xpu/cast_kernel.cc
@@ -16,8 +16,24 @@
 
 #include "paddle/phi/backends/xpu/enforce_xpu.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/complex_kernel.h"
+#include "paddle/phi/kernels/funcs/math_function.h"
 
 namespace phi {
+
+#ifdef PADDLE_WITH_XPU_FFT
+template <class T, class Context>
+static DenseTensor Fill(const Context& ctx,
+                        std::vector<int> shape,
+                        T fill_value) {
+  DenseTensor ret;
+  ret.Resize(common::make_ddim(shape));
+  ctx.template Alloc<T>(&ret);
+  funcs::SetConstant<Context, T>()(ctx, &ret, fill_value);
+  return ret;
+}
+#endif
+
 template <typename InT, typename OutT, typename Context>
 void CastXPUKernelImpl(const Context& dev_ctx,
                        const DenseTensor& x,
@@ -117,6 +133,18 @@ void CastKernel(const Context& dev_ctx,
     case DataType::INT16:
       CastXPUKernelImpl<T, int16_t, Context>(dev_ctx, x, out);
       break;
+#ifdef PADDLE_WITH_XPU_FFT
+    case DataType::COMPLEX64: {
+      DenseTensor real;
+      real.Resize(x.dims());
+      CastXPUKernelImpl<T, float, Context>(dev_ctx, x, &real);
+      dev_ctx.template Alloc<dtype::complex<float>>(out);
+      DenseTensor imag = Fill<float, Context>(
+          dev_ctx, common::vectorize<int>(x.dims()), static_cast<float>(0.0));
+      phi::ComplexKernel<float>(dev_ctx, real, imag, out);
+      break;
+    }
+#endif
     default:
       PADDLE_THROW(common::errors::Unavailable(
           "Not supported cast %d -> %d", x.dtype(), out_dtype));

--- a/paddle/phi/kernels/xpu/cast_kernel.cc
+++ b/paddle/phi/kernels/xpu/cast_kernel.cc
@@ -135,10 +135,14 @@ void CastKernel(const Context& dev_ctx,
       break;
 #ifdef PADDLE_WITH_XPU_FFT
     case DataType::COMPLEX64: {
+      if (x.numel() == 0) {
+        dev_ctx.template Alloc<T>(out);
+        return;
+      }
       DenseTensor real;
       real.Resize(x.dims());
       CastXPUKernelImpl<T, float, Context>(dev_ctx, x, &real);
-      dev_ctx.template Alloc<dtype::complex<float>>(out);
+      dev_ctx.template Alloc<T>(out);
       DenseTensor imag = Fill<float, Context>(
           dev_ctx, common::vectorize<int>(x.dims()), static_cast<float>(0.0));
       phi::ComplexKernel<float>(dev_ctx, real, imag, out);

--- a/paddle/phi/kernels/xpu/elementwise_add_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/elementwise_add_grad_kernel.cc
@@ -135,41 +135,33 @@ void AddGradKernel<phi::dtype::complex<float>, XPUContext>(
   // The current complex number implementation uses separate real/imaginary
   // parts,resulting in redundant operations and performance
   // penalties.Optimization should address this in future iterations.
-  DenseTensor x_real = Real<T, XPUContext>(dev_ctx, x);
-  DenseTensor x_imag = Imag<T, XPUContext>(dev_ctx, x);
-  DenseTensor y_real = Real<T, XPUContext>(dev_ctx, y);
-  DenseTensor y_imag = Imag<T, XPUContext>(dev_ctx, y);
   DenseTensor dout_real = Real<T, XPUContext>(dev_ctx, dout);
   DenseTensor dout_imag = Imag<T, XPUContext>(dev_ctx, dout);
 
   if (compute_dx || compute_dy) {
     DenseTensor dx_real, dx_imag, dy_real, dy_imag;
+    DenseTensor tmp_real, tmp_imag;
 
     if (compute_dx) {
-      dx_real.Resize(x_real.dims());
-      dx_imag.Resize(x_imag.dims());
-      dev_ctx.template Alloc<float>(&dx_real);
-      dev_ctx.template Alloc<float>(&dx_imag);
+      dx_real.Resize(dx->dims());
+      dx_imag.Resize(dx->dims());
     }
-
     if (compute_dy) {
-      dy_real.Resize(y_real.dims());
-      dy_imag.Resize(y_imag.dims());
-      dev_ctx.template Alloc<float>(&dy_real);
-      dev_ctx.template Alloc<float>(&dy_imag);
+      dy_real.Resize(dy->dims());
+      dy_imag.Resize(dy->dims());
     }
 
     AddGradKernel<float, XPUContext>(dev_ctx,
-                                     x_real,
-                                     y_real,
+                                     tmp_real,  // unused
+                                     tmp_imag,  // unused
                                      dout_real,
                                      axis,
                                      compute_dx ? &dx_real : nullptr,
                                      compute_dy ? &dy_real : nullptr);
 
     AddGradKernel<float, XPUContext>(dev_ctx,
-                                     x_imag,
-                                     y_imag,
+                                     tmp_real,  // unused
+                                     tmp_imag,  // unused
                                      dout_imag,
                                      axis,
                                      compute_dx ? &dx_imag : nullptr,
@@ -179,7 +171,6 @@ void AddGradKernel<phi::dtype::complex<float>, XPUContext>(
       dev_ctx.template Alloc<T>(dx);
       phi::ComplexKernel<float>(dev_ctx, dx_real, dx_imag, dx);
     }
-
     if (compute_dy) {
       dev_ctx.template Alloc<T>(dy);
       phi::ComplexKernel<float>(dev_ctx, dy_real, dy_imag, dy);

--- a/paddle/phi/kernels/xpu/slice_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/slice_grad_kernel.cc
@@ -16,6 +16,7 @@
 
 #include "paddle/phi/backends/xpu/enforce_xpu.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/complex_kernel.h"
 #include "paddle/phi/kernels/funcs/slice_utils.h"
 
 namespace phi {
@@ -77,6 +78,85 @@ void SliceGradKernel(const Context& ctx,
                         XPUType(0));
   PADDLE_ENFORCE_XDNN_SUCCESS(r, "pad");
 }
+
+#ifdef PADDLE_WITH_XPU_FFT
+template <>
+void SliceGradKernel<phi::dtype::complex<float>, XPUContext>(
+    const XPUContext& ctx,
+    const DenseTensor& input,
+    const DenseTensor& out_grad,
+    const std::vector<int64_t>& axes,
+    const IntArray& starts_t,
+    const IntArray& ends_t,
+    const std::vector<int64_t>& infer_flags,
+    const std::vector<int64_t>& decrease_axis,
+    DenseTensor* input_grad) {
+  using T = phi::dtype::complex<float>;
+  ctx.template Alloc<T>(input_grad);
+
+  // Get the accurate attribute value of starts and ends
+  std::vector<int64_t> starts = starts_t.GetData();
+  std::vector<int64_t> ends = ends_t.GetData();
+
+  const auto& in_dims = input.dims();
+  int rank = in_dims.size();
+
+  std::vector<int64_t> pad_left(rank);
+  std::vector<int64_t> out_dims(rank);
+  std::vector<int64_t> pad_right(rank);
+  int64_t cnt = 0;
+  for (int i = 0; i < in_dims.size(); ++i) {
+    int64_t start = 0;
+    int64_t end = in_dims[i];
+    int64_t axis = cnt < static_cast<int64_t>(axes.size()) ? axes[cnt] : -1;
+    if (axis == i) {
+      start = starts[cnt];
+      if (start < 0) {
+        start = (start + in_dims[i]);
+      }
+      start = std::max(start, static_cast<int64_t>(0));
+      end = ends[cnt];
+      if (end < 0) {
+        end = (end + in_dims[i]);
+      }
+      end = std::min(end, in_dims[i]);
+      cnt++;
+    }
+
+    pad_left[i] = start;
+    out_dims[i] = end - start;
+    pad_right[i] = in_dims[i] - out_dims[i] - pad_left[i];
+  }
+
+  // The current complex number implementation uses separate real/imaginary
+  // parts,resulting in redundant operations and performance
+  // penalties.Optimization should address this in future iterations.
+  const DenseTensor real = Real<T, XPUContext>(ctx, out_grad);
+  const DenseTensor imag = Imag<T, XPUContext>(ctx, out_grad);
+  DenseTensor real_out, imag_out;
+  real_out.Resize(input_grad->dims());
+  imag_out.Resize(input_grad->dims());
+  ctx.template Alloc<float>(&real_out);
+  ctx.template Alloc<float>(&imag_out);
+  int r = xpu::pad<float>(ctx.x_context(),
+                          real.data<float>(),
+                          real_out.data<float>(),
+                          out_dims,
+                          pad_left,
+                          pad_right,
+                          static_cast<float>(0));
+  PADDLE_ENFORCE_XDNN_SUCCESS(r, "pad");
+  r = xpu::pad<float>(ctx.x_context(),
+                      imag.data<float>(),
+                      imag_out.data<float>(),
+                      out_dims,
+                      pad_left,
+                      pad_right,
+                      static_cast<float>(0));
+  PADDLE_ENFORCE_XDNN_SUCCESS(r, "pad");
+  phi::ComplexKernel<float>(ctx, real_out, imag_out, input_grad);
+}
+#endif
 }  // namespace phi
 
 PD_REGISTER_KERNEL(slice_grad,
@@ -85,5 +165,9 @@ PD_REGISTER_KERNEL(slice_grad,
                    phi::SliceGradKernel,
                    float,
                    int,
+#ifdef PADDLE_WITH_XPU_FFT
+                   phi::dtype::complex<float>,
+#endif
                    phi::dtype::float16,
-                   phi::dtype::bfloat16) {}
+                   phi::dtype::bfloat16) {
+}

--- a/paddle/phi/kernels/xpu/slice_kernel.cc
+++ b/paddle/phi/kernels/xpu/slice_kernel.cc
@@ -16,6 +16,7 @@
 
 #include "paddle/phi/backends/xpu/enforce_xpu.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/complex_kernel.h"
 #include "paddle/phi/kernels/funcs/slice_utils.h"
 
 namespace phi {
@@ -126,6 +127,133 @@ void SliceKernel(const Context& ctx,
                               ends_extension);
   PADDLE_ENFORCE_XDNN_SUCCESS(r, "slice");
 }
+
+#ifdef PADDLE_WITH_XPU_FFT
+template <>
+void SliceKernel<phi::dtype::complex<float>, XPUContext>(
+    const XPUContext& ctx,
+    const DenseTensor& input,
+    const std::vector<int64_t>& axes,
+    const IntArray& starts_t,
+    const IntArray& ends_t,
+    const std::vector<int64_t>& infer_flags,
+    const std::vector<int64_t>& decrease_axis,
+    DenseTensor* out) {
+  using T = phi::dtype::complex<float>;
+  // Step 1: Get the accurate attribute value of starts and ends
+  std::vector<int64_t> starts = starts_t.GetData();
+  std::vector<int64_t> ends = ends_t.GetData();
+  PADDLE_ENFORCE_EQ(
+      starts.size(),
+      axes.size(),
+      common::errors::InvalidArgument(
+          "The size of starts must be equal to the size of axes."));
+  PADDLE_ENFORCE_EQ(ends.size(),
+                    axes.size(),
+                    common::errors::InvalidArgument(
+                        "The size of ends must be equal to the size of axes."));
+
+  // Step 2: Compute output
+  auto in_dims = input.dims();
+  auto out_dims = out->dims();
+  auto slice_dims = out_dims;
+  bool is_same = true;
+  if (in_dims.size() == out_dims.size()) {
+    for (int i = 0; i < in_dims.size(); i++) {
+      if (in_dims[i] != out_dims[i]) {
+        is_same = false;
+        break;
+      } else {
+        continue;
+      }
+    }
+    if (is_same) {
+      phi::Copy<XPUContext>(ctx, input, ctx.GetPlace(), false, out);
+      return;
+    }
+  }
+
+  // 2.1 Infer output dims
+  for (size_t i = 0; i < axes.size(); ++i) {
+    // when start == -1 && end == start+1
+    if (starts[i] == -1 && ends[i] == 0 && infer_flags[i] == -1) {
+      auto ret = std::find(decrease_axis.begin(), decrease_axis.end(), axes[i]);
+      if (ret != decrease_axis.end()) {
+        ends[i] = in_dims[axes[i]];
+      }
+    }
+  }
+
+  phi::funcs::CheckAndUpdateSliceAttrs(in_dims, axes, &starts, &ends);
+  slice_dims = funcs::GetSliceDims<int64_t>(
+      in_dims, axes, starts, ends, nullptr, nullptr);
+  out_dims = funcs::GetDecreasedDims(slice_dims, decrease_axis);
+
+  out->Resize(out_dims);
+
+  // 2.2 Get output
+  size_t shape_size = in_dims.size();
+  // the slice XPU kernel require that the length of `start`, `end` must be
+  // equal
+  // to the dims size of input tensor, therefore, if shape_size >
+  // axes.size(), the `starts_extension` and `ends_extension` is necessary.
+  std::vector<int64_t> starts_extension(shape_size, 0);
+  std::vector<int64_t> ends_extension(shape_size, 0);
+  if (shape_size > axes.size()) {
+    for (size_t i = 0; i < shape_size; ++i) {
+      ends_extension[i] = in_dims[i];
+    }
+    for (size_t i = 0; i < axes.size(); ++i) {
+      starts_extension[axes[i]] = starts[i];
+      ends_extension[axes[i]] = ends[i];
+    }
+  } else {
+    for (size_t i = 0; i < axes.size(); ++i) {
+      starts_extension[i] = starts[i];
+      ends_extension[i] = ends[i];
+    }
+  }
+
+  // prepare shape on XPU
+  std::vector<int64_t> shape(shape_size, 0);
+  for (size_t i = 0; i < shape_size; ++i) {
+    shape[i] = in_dims[i];
+  }
+
+  ctx.template Alloc<T>(out);
+  for (size_t i = 0; i < shape_size; ++i) {
+    if (starts_extension[i] == ends_extension[i] || shape[i] == 0) {
+      return;
+    }
+  }
+
+  // The current complex number implementation uses separate real/imaginary
+  // parts,resulting in redundant operations and performance
+  // penalties.Optimization should address this in future iterations.
+  const DenseTensor real = Real<T, XPUContext>(ctx, input);
+  const DenseTensor imag = Imag<T, XPUContext>(ctx, input);
+  DenseTensor real_out, imag_out;
+  real_out.Resize(out->dims());
+  imag_out.Resize(out->dims());
+  ctx.template Alloc<float>(&real_out);
+  ctx.template Alloc<float>(&imag_out);
+  int r = xpu::slice<float>(ctx.x_context(),
+                            real.data<float>(),
+                            real_out.data<float>(),
+                            shape,
+                            starts_extension,
+                            ends_extension);
+  PADDLE_ENFORCE_XDNN_SUCCESS(r, "slice");
+  r = xpu::slice<float>(ctx.x_context(),
+                        imag.data<float>(),
+                        imag_out.data<float>(),
+                        shape,
+                        starts_extension,
+                        ends_extension);
+  PADDLE_ENFORCE_XDNN_SUCCESS(r, "slice");
+  phi::ComplexKernel<float>(ctx, real_out, imag_out, out);
+}
+#endif
 }  // namespace phi
 
 PD_REGISTER_KERNEL(slice,
@@ -135,9 +263,13 @@ PD_REGISTER_KERNEL(slice,
                    float,
                    phi::dtype::float16,
                    phi::dtype::bfloat16,
+#ifdef PADDLE_WITH_XPU_FFT
+                   phi::dtype::complex<float>,
+#endif
                    double,
                    uint8_t,
                    int8_t,
                    int16_t,
                    int32_t,
-                   int64_t) {}
+                   int64_t) {
+}

--- a/test/xpu/test_conj_op_xpu.py
+++ b/test/xpu/test_conj_op_xpu.py
@@ -88,6 +88,8 @@ class XPUTestConjOp(XPUOpTestWrapper):
 
 
 support_types = get_xpu_op_support_types('conj')
+if 'complex64' in support_types:
+    support_types.remove('complex64')
 for stype in support_types:
     create_test_class(globals(), XPUTestConjOp, stype)
 

--- a/test/xpu/test_conj_op_xpu.py
+++ b/test/xpu/test_conj_op_xpu.py
@@ -88,58 +88,56 @@ class XPUTestConjOp(XPUOpTestWrapper):
 
 
 support_types = get_xpu_op_support_types('conj')
-if 'complex64' in support_types:
-    support_types.remove('complex64')
-for stype in support_types:
+real_types = [t for t in support_types if t != 'complex64']
+for stype in real_types:
     create_test_class(globals(), XPUTestConjOp, stype)
 
+if 'complex64' in support_types:
 
-class TestConjComplexOp(XPUOpTest):
-    def setUp(self):
-        self.op_type = "conj"
-        self.python_api = paddle.tensor.conj
-        self.init_dtype_type()
-        self.init_input()
-        self.inputs = {'X': self.x}
-        out = np.conj(self.x)
-        self.outputs = {'Out': out}
+    class TestConjComplexOp(XPUOpTest):
+        def setUp(self):
+            self.op_type = "conj"
+            self.python_api = paddle.tensor.conj
+            self.init_dtype_type()
+            self.init_input()
+            self.inputs = {'X': self.x}
+            out = np.conj(self.x)
+            self.outputs = {'Out': out}
 
-    def init_dtype_type(self):
-        self.dtype = np.complex64
+        def init_dtype_type(self):
+            self.dtype = np.complex64
 
-    def init_input(self):
-        self.x = (
-            np.random.random((12, 14)) + 1j * np.random.random((12, 14))
-        ).astype(self.dtype)
+        def init_input(self):
+            self.x = (
+                np.random.random((12, 14)) + 1j * np.random.random((12, 14))
+            ).astype(self.dtype)
 
-    def test_check_output(self):
-        if paddle.is_compiled_with_xpu():
-            place = paddle.XPUPlace(0)
-            self.check_output_with_place(place)
+        def test_check_output(self):
+            if paddle.is_compiled_with_xpu():
+                place = paddle.XPUPlace(0)
+                self.check_output_with_place(place)
 
-    def test_check_grad(self):
-        if paddle.is_compiled_with_xpu():
-            place = paddle.XPUPlace(0)
-            self.check_grad_with_place(
-                place,
-                ['X'],
-                'Out',
-            )
+        def test_check_grad(self):
+            if paddle.is_compiled_with_xpu():
+                place = paddle.XPUPlace(0)
+                self.check_grad_with_place(
+                    place,
+                    ['X'],
+                    'Out',
+                )
 
+    class TestConjComplexOp1(TestConjComplexOp):
+        def init_input(self):
+            self.x = (
+                np.random.random([2, 20, 2, 3])
+                + 1j * np.random.random([2, 20, 2, 3])
+            ).astype(self.dtype)
 
-class TestConjComplexOp1(TestConjComplexOp):
-    def init_input(self):
-        self.x = (
-            np.random.random([2, 20, 2, 3])
-            + 1j * np.random.random([2, 20, 2, 3])
-        ).astype(self.dtype)
-
-
-class TestConjComplexOp2(TestConjComplexOp):
-    def init_input(self):
-        self.x = (
-            np.random.random([2, 2, 3]) + 1j * np.random.random([2, 2, 3])
-        ).astype(self.dtype)
+    class TestConjComplexOp2(TestConjComplexOp):
+        def init_input(self):
+            self.x = (
+                np.random.random([2, 2, 3]) + 1j * np.random.random([2, 2, 3])
+            ).astype(self.dtype)
 
 
 if __name__ == "__main__":

--- a/test/xpu/test_elementwise_add_op_xpu.py
+++ b/test/xpu/test_elementwise_add_op_xpu.py
@@ -363,95 +363,93 @@ class XPUTestElementwiseAddOp(XPUOpTestWrapper):
 
 
 support_types = get_xpu_op_support_types('elementwise_add')
-if 'complex64' in support_types:
-    support_types.remove('complex64')
-for stype in support_types:
+real_types = [t for t in support_types if t != 'complex64']
+for stype in real_types:
     create_test_class(globals(), XPUTestElementwiseAddOp, stype)
 
+if 'complex64' in support_types:
 
-class TestElementwiseAddOpComplex(XPUOpTest):
-    def setUp(self):
-        self.op_type = "elementwise_add"
-        self.init_dtype()
-        self.init_input_output()
-        self.init_axis()
-        self.inputs = {
-            'X': OpTest.np_dtype_to_base_dtype(self.x),
-            'Y': OpTest.np_dtype_to_base_dtype(self.y),
-        }
-        self.attrs = {'axis': self.axis, 'use_mkldnn': self.use_mkldnn}
-        self.outputs = {'Out': self.out}
+    class TestElementwiseAddOpComplex(XPUOpTest):
+        def setUp(self):
+            self.op_type = "elementwise_add"
+            self.init_dtype()
+            self.init_input_output()
+            self.init_axis()
+            self.inputs = {
+                'X': OpTest.np_dtype_to_base_dtype(self.x),
+                'Y': OpTest.np_dtype_to_base_dtype(self.y),
+            }
+            self.attrs = {'axis': self.axis, 'use_mkldnn': self.use_mkldnn}
+            self.outputs = {'Out': self.out}
 
-    def test_check_output(self):
-        if paddle.is_compiled_with_xpu():
-            place = paddle.XPUPlace(0)
-            self.check_output_with_place(place)
+        def test_check_output(self):
+            if paddle.is_compiled_with_xpu():
+                place = paddle.XPUPlace(0)
+                self.check_output_with_place(place)
 
-    def test_check_grad_normal(self):
-        if paddle.is_compiled_with_xpu():
-            place = paddle.XPUPlace(0)
-            self.check_grad_with_place(
-                place,
-                ['X', 'Y'],
-                'Out',
+        def test_check_grad_normal(self):
+            if paddle.is_compiled_with_xpu():
+                place = paddle.XPUPlace(0)
+                self.check_grad_with_place(
+                    place,
+                    ['X', 'Y'],
+                    'Out',
+                )
+
+        def test_check_grad_ignore_x(self):
+            if paddle.is_compiled_with_xpu():
+                place = paddle.XPUPlace(0)
+                self.check_grad_with_place(
+                    place,
+                    ['Y'],
+                    'Out',
+                    no_grad_set=set("X"),
+                )
+
+        def test_check_grad_ignore_y(self):
+            if paddle.is_compiled_with_xpu():
+                place = paddle.XPUPlace(0)
+                self.check_grad_with_place(
+                    place,
+                    ['X'],
+                    'Out',
+                    no_grad_set=set("Y"),
+                )
+
+        def init_input_output(self):
+            self.x = (
+                np.random.rand(2, 3, 4) + 1j * np.random.rand(2, 3, 4)
+            ).astype(self.dtype)
+            self.y = (
+                np.random.rand(2, 3, 4) + 1j * np.random.rand(2, 3, 4)
+            ).astype(self.dtype)
+            self.out = self.x + self.y
+
+        def init_dtype(self):
+            self.dtype = np.complex64
+
+        def init_axis(self):
+            self.axis = -1
+
+    class TestElementwiseAddOpComplex2(TestElementwiseAddOpComplex):
+        def init_input_output(self):
+            self.x = (
+                np.random.rand(2, 3, 4) + 1j * np.random.rand(2, 3, 4)
+            ).astype(self.dtype)
+            self.y = (np.random.rand(1, 1) + 1j * np.random.rand(1, 1)).astype(
+                self.dtype
             )
+            self.out = self.x + self.y
 
-    def test_check_grad_ignore_x(self):
-        if paddle.is_compiled_with_xpu():
-            place = paddle.XPUPlace(0)
-            self.check_grad_with_place(
-                place,
-                ['Y'],
-                'Out',
-                no_grad_set=set("X"),
+    class TestElementwiseAddOpComplex3(TestElementwiseAddOpComplex):
+        def init_input_output(self):
+            self.x = (
+                np.random.rand(100, 2, 3) + 1j * np.random.rand(100, 2, 3)
+            ).astype(self.dtype)
+            self.y = (np.random.rand(1, 1) + 1j * np.random.rand(1, 1)).astype(
+                self.dtype
             )
-
-    def test_check_grad_ignore_y(self):
-        if paddle.is_compiled_with_xpu():
-            place = paddle.XPUPlace(0)
-            self.check_grad_with_place(
-                place,
-                ['X'],
-                'Out',
-                no_grad_set=set("Y"),
-            )
-
-    def init_input_output(self):
-        self.x = (
-            np.random.rand(2, 3, 4) + 1j * np.random.rand(2, 3, 4)
-        ).astype(self.dtype)
-        self.y = (
-            np.random.rand(2, 3, 4) + 1j * np.random.rand(2, 3, 4)
-        ).astype(self.dtype)
-        self.out = self.x + self.y
-
-    def init_dtype(self):
-        self.dtype = np.complex64
-
-    def init_axis(self):
-        self.axis = -1
-
-
-class TestElementwiseAddOpComplex2(TestElementwiseAddOpComplex):
-    def init_input_output(self):
-        self.x = (
-            np.random.rand(2, 3, 4) + 1j * np.random.rand(2, 3, 4)
-        ).astype(self.dtype)
-        self.y = (np.random.rand(1, 1) + 1j * np.random.rand(1, 1)).astype(
-            self.dtype
-        )
-        self.out = self.x + self.y
-
-
-class TestElementwiseAddOpComplex3(TestElementwiseAddOpComplex):
-    def init_input_output(self):
-        self.x = (
-            np.random.rand(100, 2, 3) + 1j * np.random.rand(100, 2, 3)
-        ).astype(self.dtype)
-        self.y = (np.random.rand(1, 1) + 1j * np.random.rand(1, 1)).astype(
-            self.dtype
-        )
-        self.out = self.x + self.y
+            self.out = self.x + self.y
 
 
 @unittest.skipIf(

--- a/test/xpu/test_elementwise_add_op_xpu.py
+++ b/test/xpu/test_elementwise_add_op_xpu.py
@@ -363,6 +363,8 @@ class XPUTestElementwiseAddOp(XPUOpTestWrapper):
 
 
 support_types = get_xpu_op_support_types('elementwise_add')
+if 'complex64' in support_types:
+    support_types.remove('complex64')
 for stype in support_types:
     create_test_class(globals(), XPUTestElementwiseAddOp, stype)
 

--- a/test/xpu/test_elementwise_add_op_xpu.py
+++ b/test/xpu/test_elementwise_add_op_xpu.py
@@ -369,9 +369,10 @@ for stype in real_types:
 
 if 'complex64' in support_types:
 
-    class TestElementwiseAddOpComplex(XPUOpTest):
+    class TestElementwiseAddOpComplex(OpTest):
         def setUp(self):
             self.op_type = "elementwise_add"
+            self.python_api = paddle.add
             self.init_dtype()
             self.init_input_output()
             self.init_axis()
@@ -379,7 +380,6 @@ if 'complex64' in support_types:
                 'X': OpTest.np_dtype_to_base_dtype(self.x),
                 'Y': OpTest.np_dtype_to_base_dtype(self.y),
             }
-            self.attrs = {'axis': self.axis, 'use_mkldnn': self.use_mkldnn}
             self.outputs = {'Out': self.out}
 
         def test_check_output(self):
@@ -444,7 +444,7 @@ if 'complex64' in support_types:
     class TestElementwiseAddOpComplex3(TestElementwiseAddOpComplex):
         def init_input_output(self):
             self.x = (
-                np.random.rand(100, 2, 3) + 1j * np.random.rand(100, 2, 3)
+                np.random.rand(10, 2, 3) + 1j * np.random.rand(10, 2, 3)
             ).astype(self.dtype)
             self.y = (np.random.rand(1, 1) + 1j * np.random.rand(1, 1)).astype(
                 self.dtype

--- a/test/xpu/test_slice_op_xpu.py
+++ b/test/xpu/test_slice_op_xpu.py
@@ -213,73 +213,71 @@ class XPUTestSliceOp_decs_dim(XPUOpTestWrapper):
 
 
 support_types = get_xpu_op_support_types('slice')
-if 'complex64' in support_types:
-    support_types.remove('complex64')
-for stype in support_types:
+real_types = [t for t in support_types if t != 'complex64']
+for stype in real_types:
     create_test_class(globals(), XPUTestSliceOp, stype)
     create_test_class(globals(), XPUTestSliceOp_decs_dim, stype)
 
+if 'complex64' in support_types:
 
-class TestSliceOpComplex(XPUOpTest):
-    def setUp(self):
-        self.dtype = np.float32
-        self.place = paddle.XPUPlace(0)
-        self.op_type = "slice"
-        self.config()
-        self.inputs = {'Input': self.input}
-        self.outputs = {'Out': self.out}
-        self.attrs = {
-            'axes': self.axes,
-            'starts': self.starts,
-            'ends': self.ends,
-            'infer_flags': self.infer_flags,
-            "use_xpu": True,
-        }
+    class TestSliceOpComplex(XPUOpTest):
+        def setUp(self):
+            self.dtype = np.float32
+            self.place = paddle.XPUPlace(0)
+            self.op_type = "slice"
+            self.config()
+            self.inputs = {'Input': self.input}
+            self.outputs = {'Out': self.out}
+            self.attrs = {
+                'axes': self.axes,
+                'starts': self.starts,
+                'ends': self.ends,
+                'infer_flags': self.infer_flags,
+                "use_xpu": True,
+            }
 
-    def config(self):
-        real_part = np.random.random([3, 4, 5, 6]).astype(self.dtype)
-        imag_part = np.random.random([3, 4, 5, 6]).astype(self.dtype)
-        self.input = real_part + 1j * imag_part
-        self.starts = [1, 0, 2]
-        self.ends = [3, 3, 4]
-        self.axes = [0, 1, 2]
-        self.infer_flags = [1, 1, 1]
-        self.out = self.input[1:3, 0:3, 2:4, :]
+        def config(self):
+            real_part = np.random.random([3, 4, 5, 6]).astype(self.dtype)
+            imag_part = np.random.random([3, 4, 5, 6]).astype(self.dtype)
+            self.input = real_part + 1j * imag_part
+            self.starts = [1, 0, 2]
+            self.ends = [3, 3, 4]
+            self.axes = [0, 1, 2]
+            self.infer_flags = [1, 1, 1]
+            self.out = self.input[1:3, 0:3, 2:4, :]
 
-    def test_check_grad_normal(self):
-        real_grad = np.random.random(self.out.shape).astype(self.dtype)
-        imag_grad = np.random.random(self.out.shape).astype(self.dtype)
-        user_defined_grad_outputs = real_grad + 1j * imag_grad
-        self.check_grad_with_place(
-            self.place,
-            ['Input'],
-            'Out',
-            user_defined_grad_outputs=user_defined_grad_outputs,
-        )
+        def test_check_grad_normal(self):
+            real_grad = np.random.random(self.out.shape).astype(self.dtype)
+            imag_grad = np.random.random(self.out.shape).astype(self.dtype)
+            user_defined_grad_outputs = real_grad + 1j * imag_grad
+            self.check_grad_with_place(
+                self.place,
+                ['Input'],
+                'Out',
+                user_defined_grad_outputs=user_defined_grad_outputs,
+            )
 
+    class TestCaseComplex1(TestSliceOpComplex):
+        def config(self):
+            real_part = np.random.random([3, 4, 5, 6]).astype(self.dtype)
+            imag_part = np.random.random([3, 4, 5, 6]).astype(self.dtype)
+            self.input = real_part + 1j * imag_part
+            self.starts = [-3, 0, 2]
+            self.ends = [3, 100, -1]
+            self.axes = [0, 1, 2]
+            self.infer_flags = [1, 1, 1]
+            self.out = self.input[-3:3, 0:100, 2:-1, :]
 
-class TestCaseComplex1(TestSliceOpComplex):
-    def config(self):
-        real_part = np.random.random([3, 4, 5, 6]).astype(self.dtype)
-        imag_part = np.random.random([3, 4, 5, 6]).astype(self.dtype)
-        self.input = real_part + 1j * imag_part
-        self.starts = [-3, 0, 2]
-        self.ends = [3, 100, -1]
-        self.axes = [0, 1, 2]
-        self.infer_flags = [1, 1, 1]
-        self.out = self.input[-3:3, 0:100, 2:-1, :]
-
-
-class TestCaseComplex2(TestSliceOpComplex):
-    def config(self):
-        real_part = np.random.random([3, 4, 5, 6]).astype(self.dtype)
-        imag_part = np.random.random([3, 4, 5, 6]).astype(self.dtype)
-        self.input = real_part + 1j * imag_part
-        self.starts = [-3, 0, 2]
-        self.ends = [3, 100, -1]
-        self.axes = [0, 1, 3]
-        self.infer_flags = [1, 1, 1]
-        self.out = self.input[-3:3, 0:100, :, 2:-1]
+    class TestCaseComplex2(TestSliceOpComplex):
+        def config(self):
+            real_part = np.random.random([3, 4, 5, 6]).astype(self.dtype)
+            imag_part = np.random.random([3, 4, 5, 6]).astype(self.dtype)
+            self.input = real_part + 1j * imag_part
+            self.starts = [-3, 0, 2]
+            self.ends = [3, 100, -1]
+            self.axes = [0, 1, 3]
+            self.infer_flags = [1, 1, 1]
+            self.out = self.input[-3:3, 0:100, :, 2:-1]
 
 
 if __name__ == '__main__':

--- a/test/xpu/test_slice_op_xpu.py
+++ b/test/xpu/test_slice_op_xpu.py
@@ -213,9 +213,74 @@ class XPUTestSliceOp_decs_dim(XPUOpTestWrapper):
 
 
 support_types = get_xpu_op_support_types('slice')
+if 'complex64' in support_types:
+    support_types.remove('complex64')
 for stype in support_types:
     create_test_class(globals(), XPUTestSliceOp, stype)
     create_test_class(globals(), XPUTestSliceOp_decs_dim, stype)
+
+
+class TestSliceOpComplex(XPUOpTest):
+    def setUp(self):
+        self.dtype = np.float32
+        self.place = paddle.XPUPlace(0)
+        self.op_type = "slice"
+        self.config()
+        self.inputs = {'Input': self.input}
+        self.outputs = {'Out': self.out}
+        self.attrs = {
+            'axes': self.axes,
+            'starts': self.starts,
+            'ends': self.ends,
+            'infer_flags': self.infer_flags,
+            "use_xpu": True,
+        }
+
+    def config(self):
+        real_part = np.random.random([3, 4, 5, 6]).astype(self.dtype)
+        imag_part = np.random.random([3, 4, 5, 6]).astype(self.dtype)
+        self.input = real_part + 1j * imag_part
+        self.starts = [1, 0, 2]
+        self.ends = [3, 3, 4]
+        self.axes = [0, 1, 2]
+        self.infer_flags = [1, 1, 1]
+        self.out = self.input[1:3, 0:3, 2:4, :]
+
+    def test_check_grad_normal(self):
+        real_grad = np.random.random(self.out.shape).astype(self.dtype)
+        imag_grad = np.random.random(self.out.shape).astype(self.dtype)
+        user_defined_grad_outputs = real_grad + 1j * imag_grad
+        self.check_grad_with_place(
+            self.place,
+            ['Input'],
+            'Out',
+            user_defined_grad_outputs=user_defined_grad_outputs,
+        )
+
+
+class TestCaseComplex1(TestSliceOpComplex):
+    def config(self):
+        real_part = np.random.random([3, 4, 5, 6]).astype(self.dtype)
+        imag_part = np.random.random([3, 4, 5, 6]).astype(self.dtype)
+        self.input = real_part + 1j * imag_part
+        self.starts = [-3, 0, 2]
+        self.ends = [3, 100, -1]
+        self.axes = [0, 1, 2]
+        self.infer_flags = [1, 1, 1]
+        self.out = self.input[-3:3, 0:100, 2:-1, :]
+
+
+class TestCaseComplex2(TestSliceOpComplex):
+    def config(self):
+        real_part = np.random.random([3, 4, 5, 6]).astype(self.dtype)
+        imag_part = np.random.random([3, 4, 5, 6]).astype(self.dtype)
+        self.input = real_part + 1j * imag_part
+        self.starts = [-3, 0, 2]
+        self.ends = [3, 100, -1]
+        self.axes = [0, 1, 3]
+        self.infer_flags = [1, 1, 1]
+        self.out = self.input[-3:3, 0:100, :, 2:-1]
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Custom Device 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
 New features

### Description
<!-- Describe what you’ve done -->
为xpu上的slice和cast算子添加对应complex64数据类型和对应单元测试，并修改了conj，add相关的单测逻辑，复数的单测只在由对应类型注册时再触发
修改了real，imag，add等算子的测试，由XPUoptest切换为optest
Pcard-75624