### PR TITLE
fix unique_consecutive bug test=develop

### DIFF
--- a/paddle/phi/kernels/gpu/unique_consecutive_functor.h
+++ b/paddle/phi/kernels/gpu/unique_consecutive_functor.h
@@ -272,6 +272,8 @@ struct BinaryNotEqual {
   }
 };
 
+
+
 // index_select() function for Tensor
 template <typename Context, typename InT, typename IndexT>
 void IndexSelect(const Context& context,
@@ -303,7 +305,6 @@ void IndexSelect(const Context& context,
   phi::TensorToVector(input, context, &input_vec);
   phi::TensorToVector(index, context, &index_vec);
   std::vector<InT> out_vec(output->numel());
-
   for (int i = 0; i < index_size; i++) {
     PADDLE_ENFORCE_GE(
         index_vec[i],
@@ -326,17 +327,16 @@ void IndexSelect(const Context& context,
             input_dim[dim],
             index_vec[i]));
   }
+  for (int64_t i = 0; i < outer_nums; i++) {
+    int64_t input_start_offset = i * input_width;
+    int64_t output_start_offset = i * output_width;
 
-  for (auto i = 0; i < outer_nums; i++) {
-    auto input_start_offset = i * input_width;
-    auto output_start_offset = i * output_width;
-
-    for (auto j = 0; j < index_size; j++) {
+    for (int64_t j = 0; j < index_size; j++) {
       IndexT index_value = index_vec[j];
       if (index_value < 0) {
         index_value += input_dim[dim];
       }
-      for (auto k = 0; k < slice_size; k++) {
+      for (int64_t k = 0; k < slice_size; k++) {
         out_vec[output_start_offset + j * slice_size + k] =
             input_vec[input_start_offset + index_value * slice_size + k];
       }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
修复了 `paddle.unique_consecutive` 大 Tensor 下的报错问题。

-   **算子简介**
    `paddle.unique_consecutive` 主要功能是去除张量中的连续重复元素，同时可以根据传入的 flag 值返回不同的元组。

-   **修改点**
    问题定位在 `unique_consecutive_functor.h` 中的以下代码段。怀疑是 `auto` 自动判定类型导致溢出，修改为 `int64_t` 后可以成功编译：

    ```cpp
    for (auto i = 0; i < outer_nums; i++) {
      auto input_start_offset = i * input_width;
      auto output_start_offset = i * output_width;

      for (auto j = 0; j < index_size; j++) {
        IndexT index_value = index_vec[j];
        if (index_value < 0) {
          index_value += input_dim[dim];
        }
        for (auto k = 0; k < slice_size; k++) {
          out_vec[output_start_offset + j * slice_size + k] =
              input_vec[input_start_offset + index_value * slice_size + k];
        }
      }
    }
    ```

-   **性能变化**
    性能下降了 2% 左右。
