### PR TITLE
[PHI] Fix full_like kernel for big tensor

### DIFF
--- a/paddle/phi/kernels/gpu/full_kernel.cu
+++ b/paddle/phi/kernels/gpu/full_kernel.cu
@@ -69,7 +69,7 @@ void FullLikeKernel(const Context& dev_ctx,
   // This function has no input, so the inputs.size() == 0. Use kUnary, but the
   // data will not be loaded in the kernel because the number of parameters in
   // the operator is 0
-  int numel = out->numel();
+  int64_t numel = out->numel();
 
   if (!std::is_same<T, phi::dtype::complex<float>>::value &&
       !std::is_same<T, phi::dtype::complex<double>>::value) {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Operator Mechanism


### PR Types
Bug fixes


### Description
修复full_like kernel的大Tensor问题（同时也修复了zeros_like和ones_like）

full_like是对ElementwiseKernel的包装，底层算子没问题，所以只要改一行即可

Pcard-85711