### PR TITLE
tensor support apply_backward_hook by user

### DIFF
--- a/paddle/fluid/pybind/eager_method.cc
+++ b/paddle/fluid/pybind/eager_method.cc
@@ -2107,12 +2107,14 @@ static PyObject* apply_backward_hook(TensorObject* self,
       !egr::EagerUtils::unsafe_autograd_meta(self->tensor)->StopGradient(),
       true,
       common::errors::InvalidArgument(
-          "Cannot register backward hook on a Tensor that stop "
+          "Cannot apply backward hook on a Tensor that stop "
           "gradient."));
-  PADDLE_ENFORCE(grad_node.get() != nullptr,
-                 common::errors::Fatal("Detected nullptr grad_node,"
-                                       "Leaf tensor should have had grad_node "
-                                       "with type: GradNodeAccumulation."));
+  PADDLE_ENFORCE_NE(
+      grad_node.get(),
+      nullptr,
+      common::errors::Fatal("Detected nullptr grad_node,"
+                            "Leaf tensor should have had grad_node "
+                            "with type: GradNodeAccumulation."));
 
   auto accumulation_grad_node =
       std::dynamic_pointer_cast<egr::GradNodeAccumulation>(grad_node);

--- a/paddle/fluid/pybind/eager_method.cc
+++ b/paddle/fluid/pybind/eager_method.cc
@@ -2096,6 +2096,34 @@ static PyObject* tensor_remove_grad_hook(TensorObject* self,
   EAGER_CATCH_AND_THROW_RETURN_NULL
 }
 
+static PyObject* apply_backward_hook(TensorObject* self,
+                                     PyObject* args,
+                                     PyObject* kwargs) {
+  EAGER_TRY
+  VLOG(6) << " Apply tensor hook for tensor: " << self->tensor.name();
+  std::shared_ptr<egr::GradNodeBase> grad_node =
+      egr::EagerUtils::grad_node(self->tensor);
+  PADDLE_ENFORCE_EQ(
+      !egr::EagerUtils::unsafe_autograd_meta(self->tensor)->StopGradient(),
+      true,
+      common::errors::InvalidArgument(
+          "Cannot register backward hook on a Tensor that stop "
+          "gradient."));
+  PADDLE_ENFORCE(grad_node.get() != nullptr,
+                 common::errors::Fatal("Detected nullptr grad_node,"
+                                       "Leaf tensor should have had grad_node "
+                                       "with type: GradNodeAccumulation."));
+
+  auto accumulation_grad_node =
+      std::dynamic_pointer_cast<egr::GradNodeAccumulation>(grad_node);
+
+  if (accumulation_grad_node->ReduceHooksRegistered()) {
+    accumulation_grad_node->ApplyReduceHooks();
+  }
+  RETURN_PY_NONE;
+  EAGER_CATCH_AND_THROW_RETURN_NULL
+}
+
 static PyObject* tensor_inplace_assign(TensorObject* self,
                                        PyObject* args,
                                        PyObject* kwargs) {
@@ -3661,6 +3689,10 @@ PyMethodDef variable_methods[] = {  // NOLINT
      nullptr},
     {"_remove_grad_hook",
      (PyCFunction)(void (*)())tensor_remove_grad_hook,
+     METH_VARARGS | METH_KEYWORDS,
+     nullptr},
+    {"_apply_backward_hook",
+     (PyCFunction)(void (*)())apply_backward_hook,
      METH_VARARGS | METH_KEYWORDS,
      nullptr},
     {"_register_backward_hook",


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
某些高性能场景下，用户希望手动对grad操作，绕过backward node机制。此时param的hook将不会被触发。此pr允许用户在上述场景下手动触发hook。