### PR TITLE
[PHI] Fix int32 overflow for some pool cuda kernel

### DIFF
--- a/paddle/phi/kernels/funcs/pooling.cc
+++ b/paddle/phi/kernels/funcs/pooling.cc
@@ -31,86 +31,9 @@ class Pool2dFunctor<CPUContext, PoolProcess, T> {
  public:
   void operator()(const CPUContext& context,
                   const DenseTensor& input,
-                  const std::vector<int>& ksize,
-                  const std::vector<int>& strides,
-                  const std::vector<int>& paddings,
-                  bool exclusive,
-                  bool adaptive,
-                  DenseTensor* output,
-                  PoolProcess pool_process) {
-    const int batch_size = static_cast<int>(input.dims()[0]);
-    const int input_height = static_cast<int>(input.dims()[2]);
-    const int input_width = static_cast<int>(input.dims()[3]);
-    const int output_channels = static_cast<int>(output->dims()[1]);
-    const int output_height = static_cast<int>(output->dims()[2]);
-    const int output_width = static_cast<int>(output->dims()[3]);
-    const int ksize_height = ksize[0];
-    const int ksize_width = ksize[1];
-    const int stride_height = strides[0];
-    const int stride_width = strides[1];
-    const int padding_height = paddings[0];
-    const int padding_width = paddings[1];
-
-    const int input_stride = input_height * input_width;
-    const int output_stride = output_height * output_width;
-
-    const T* input_data = input.data<T>();
-    T* output_data = context.template Alloc<T>(output);
-
-    int hstart = 0, hend = 1;
-    int wstart = 0, wend = 1;
-    for (int i = 0; i < batch_size; i++) {
-      for (int c = 0; c < output_channels; ++c) {
-        for (int ph = 0; ph < output_height; ++ph) {
-          if (adaptive) {
-            hstart = AdaptStartIndex(ph, input_height, output_height);
-            hend = AdaptEndIndex(ph, input_height, output_height);
-          }
-          for (int pw = 0; pw < output_width; ++pw) {
-            int pool_size = 1;
-            if (adaptive) {
-              wstart = AdaptStartIndex(pw, input_width, output_width);
-              wend = AdaptEndIndex(pw, input_width, output_width);
-            } else {
-              hstart = ph * stride_height - padding_height;
-              wstart = pw * stride_width - padding_width;
-              hend = std::min(hstart + ksize_height,
-                              input_height + padding_height);
-              wend =
-                  std::min(wstart + ksize_width, input_width + padding_width);
-              pool_size = (hend - hstart) * (wend - wstart);
-
-              wstart = std::max(wstart, 0);
-              hstart = std::max(hstart, 0);
-              hend = std::min(hend, input_height);
-              wend = std::min(wend, input_width);
-            }
-
-            T ele = pool_process.initial();
-            for (int h = hstart; h < hend; ++h) {
-              for (int w = wstart; w < wend; ++w) {
-                pool_process.compute(input_data[h * input_width + w], &ele);
-              }
-            }
-            if (exclusive || adaptive) {
-              pool_size = (hend - hstart) * (wend - wstart);
-            }
-
-            pool_process.finalize(static_cast<T>(pool_size), &ele);
-            output_data[ph * output_width + pw] = ele;
-          }
-        }
-        input_data += input_stride;
-        output_data += output_stride;
-      }
-    }
-  }
-
-  void operator()(const CPUContext& context,
-                  const DenseTensor& input,
-                  const std::vector<int>& ksize,
-                  const std::vector<int>& strides,
-                  const std::vector<int>& paddings,
+                  const std::vector<int64_t>& ksize,
+                  const std::vector<int64_t>& strides,
+                  const std::vector<int64_t>& paddings,
                   const std::string data_format,
                   bool exclusive,
                   bool adaptive,
@@ -118,47 +41,47 @@ class Pool2dFunctor<CPUContext, PoolProcess, T> {
                   PoolProcess pool_process) {
     bool channel_last = (data_format == "NHWC");
 
-    const int batch_size = static_cast<int>(input.dims()[0]);
-    const int input_channels =
-        static_cast<int>(channel_last ? input.dims()[3] : input.dims()[1]);
-    const int input_height =
-        static_cast<int>(channel_last ? input.dims()[1] : input.dims()[2]);
-    const int input_width =
-        static_cast<int>(channel_last ? input.dims()[2] : input.dims()[3]);
+    const int64_t batch_size = input.dims()[0];
+    const int64_t input_channels =
+        channel_last ? input.dims()[3] : input.dims()[1];
+    const int64_t input_height =
+        channel_last ? input.dims()[1] : input.dims()[2];
+    const int64_t input_width =
+        channel_last ? input.dims()[2] : input.dims()[3];
 
-    const int output_channels =
-        static_cast<int>(channel_last ? output->dims()[3] : output->dims()[1]);
-    const int output_height =
-        static_cast<int>(channel_last ? output->dims()[1] : output->dims()[2]);
-    const int output_width =
-        static_cast<int>(channel_last ? output->dims()[2] : output->dims()[3]);
+    const int64_t output_channels =
+        channel_last ? output->dims()[3] : output->dims()[1];
+    const int64_t output_height =
+        channel_last ? output->dims()[1] : output->dims()[2];
+    const int64_t output_width =
+        channel_last ? output->dims()[2] : output->dims()[3];
 
-    const int ksize_height = ksize[0];
-    const int ksize_width = ksize[1];
+    const int64_t ksize_height = ksize[0];
+    const int64_t ksize_width = ksize[1];
 
-    const int stride_height = strides[0];
-    const int stride_width = strides[1];
+    const int64_t stride_height = strides[0];
+    const int64_t stride_width = strides[1];
 
-    const int padding_height = paddings[0];
-    const int padding_width = paddings[1];
+    const int64_t padding_height = paddings[0];
+    const int64_t padding_width = paddings[1];
 
     const T* input_data = input.data<T>();
     T* output_data = context.template Alloc<T>(output);
 
-    int hstart = 0, hend = 1;
-    int wstart = 0, wend = 1;
+    int64_t hstart = 0, hend = 1;
+    int64_t wstart = 0, wend = 1;
     if (!channel_last) {
-      const int input_stride = input_height * input_width;
-      const int output_stride = output_height * output_width;
-      for (int i = 0; i < batch_size; i++) {
-        for (int c = 0; c < output_channels; ++c) {
-          for (int ph = 0; ph < output_height; ++ph) {
+      const int64_t input_stride = input_height * input_width;
+      const int64_t output_stride = output_height * output_width;
+      for (int64_t i = 0; i < batch_size; i++) {
+        for (int64_t c = 0; c < output_channels; ++c) {
+          for (int64_t ph = 0; ph < output_height; ++ph) {
             if (adaptive) {
               hstart = AdaptStartIndex(ph, input_height, output_height);
               hend = AdaptEndIndex(ph, input_height, output_height);
             }
-            for (int pw = 0; pw < output_width; ++pw) {
-              int pool_size = 1;
+            for (int64_t pw = 0; pw < output_width; ++pw) {
+              int64_t pool_size = 1;
               if (adaptive) {
                 wstart = AdaptStartIndex(pw, input_width, output_width);
                 wend = AdaptEndIndex(pw, input_width, output_width);
@@ -171,15 +94,15 @@ class Pool2dFunctor<CPUContext, PoolProcess, T> {
                     std::min(wstart + ksize_width, input_width + padding_width);
                 pool_size = (hend - hstart) * (wend - wstart);
 
-                wstart = std::max(wstart, 0);
-                hstart = std::max(hstart, 0);
+                wstart = std::max(wstart, static_cast<int64_t>(0));
+                hstart = std::max(hstart, static_cast<int64_t>(0));
                 hend = std::min(hend, input_height);
                 wend = std::min(wend, input_width);
               }
 
               T ele = pool_process.initial();
-              for (int h = hstart; h < hend; ++h) {
-                for (int w = wstart; w < wend; ++w) {
+              for (int64_t h = hstart; h < hend; ++h) {
+                for (int64_t w = wstart; w < wend; ++w) {
                   pool_process.compute(input_data[h * input_width + w], &ele);
                 }
               }
@@ -195,17 +118,18 @@ class Pool2dFunctor<CPUContext, PoolProcess, T> {
         }
       }
     } else {
-      const int input_stride = input_height * input_width * input_channels;
-      const int output_stride = output_height * output_width * output_channels;
-      for (int i = 0; i < batch_size; i++) {
-        for (int c = 0; c < output_channels; ++c) {
-          for (int ph = 0; ph < output_height; ++ph) {
+      const int64_t input_stride = input_height * input_width * input_channels;
+      const int64_t output_stride =
+          output_height * output_width * output_channels;
+      for (int64_t i = 0; i < batch_size; i++) {
+        for (int64_t c = 0; c < output_channels; ++c) {
+          for (int64_t ph = 0; ph < output_height; ++ph) {
             if (adaptive) {
               hstart = AdaptStartIndex(ph, input_height, output_height);
               hend = AdaptEndIndex(ph, input_height, output_height);
             }
-            for (int pw = 0; pw < output_width; ++pw) {
-              int pool_size = 1;
+            for (int64_t pw = 0; pw < output_width; ++pw) {
+              int64_t pool_size = 1;
               if (adaptive) {
                 wstart = AdaptStartIndex(pw, input_width, output_width);
                 wend = AdaptEndIndex(pw, input_width, output_width);
@@ -218,14 +142,14 @@ class Pool2dFunctor<CPUContext, PoolProcess, T> {
                     std::min(wstart + ksize_width, input_width + padding_width);
                 pool_size = (hend - hstart) * (wend - wstart);
 
-                wstart = std::max(wstart, 0);
-                hstart = std::max(hstart, 0);
+                wstart = std::max(wstart, static_cast<int64_t>(0));
+                hstart = std::max(hstart, static_cast<int64_t>(0));
                 hend = std::min(hend, input_height);
                 wend = std::min(wend, input_width);
               }
               T ele = pool_process.initial();
-              for (int h = hstart; h < hend; ++h) {
-                for (int w = wstart; w < wend; ++w) {
+              for (int64_t h = hstart; h < hend; ++h) {
+                for (int64_t w = wstart; w < wend; ++w) {
                   pool_process.compute(
                       input_data[h * input_width * input_channels +
                                  w * input_channels + c],
@@ -262,92 +186,9 @@ class Pool2dGradFunctor<CPUContext, PoolProcess, T> {
                   const DenseTensor& input,
                   const DenseTensor& output,
                   const DenseTensor& output_grad,
-                  const std::vector<int>& ksize,
-                  const std::vector<int>& strides,
-                  const std::vector<int>& paddings,
-                  bool exclusive,
-                  bool adaptive,
-                  DenseTensor* input_grad,
-                  PoolProcess pool_grad_process) {
-    const int batch_size = static_cast<int>(input.dims()[0]);
-    const int input_height = static_cast<int>(input.dims()[2]);
-    const int input_width = static_cast<int>(input.dims()[3]);
-    const int output_channels = static_cast<int>(output.dims()[1]);
-    const int output_height = static_cast<int>(output.dims()[2]);
-    const int output_width = static_cast<int>(output.dims()[3]);
-    const int ksize_height = ksize[0];
-    const int ksize_width = ksize[1];
-    const int stride_height = strides[0];
-    const int stride_width = strides[1];
-    const int padding_height = paddings[0];
-    const int padding_width = paddings[1];
-    const int input_stride = input_height * input_width;
-    const int output_stride = output_height * output_width;
-
-    const T* input_data = input.data<T>();
-    const T* output_data = output.data<T>();
-    const T* output_grad_data = output_grad.data<T>();
-    T* input_grad_data = context.template Alloc<T>(input_grad);
-
-    int hstart = 0, hend = 1;
-    int wstart = 0, wend = 1;
-    for (int i = 0; i < batch_size; i++) {
-      for (int c = 0; c < output_channels; ++c) {
-        for (int ph = 0; ph < output_height; ++ph) {
-          if (adaptive) {
-            hstart = AdaptStartIndex(ph, input_height, output_height);
-            hend = AdaptEndIndex(ph, input_height, output_height);
-          }
-          for (int pw = 0; pw < output_width; ++pw) {
-            int pool_size = 1;
-            if (adaptive) {
-              wstart = AdaptStartIndex(pw, input_width, output_width);
-              wend = AdaptEndIndex(pw, input_width, output_width);
-            } else {
-              hstart = ph * stride_height - padding_height;
-              wstart = pw * stride_width - padding_width;
-              hend = std::min(hstart + ksize_height,
-                              input_height + padding_height);
-              wend =
-                  std::min(wstart + ksize_width, input_width + padding_width);
-              pool_size = (hend - hstart) * (wend - wstart);
-
-              wstart = std::max(wstart, 0);
-              hstart = std::max(hstart, 0);
-              hend = std::min(hend, input_height);
-              wend = std::min(wend, input_width);
-            }
-            if (exclusive || adaptive) {
-              pool_size = (hend - hstart) * (wend - wstart);
-            }
-            float scale = 1.0f / static_cast<float>(pool_size);
-            for (int h = hstart; h < hend; ++h) {
-              for (int w = wstart; w < wend; ++w) {
-                pool_grad_process.compute(
-                    input_data[h * input_width + w],
-                    output_data[ph * output_width + pw],
-                    output_grad_data[ph * output_width + pw],
-                    static_cast<T>(scale),
-                    input_grad_data + h * input_width + w);
-              }
-            }
-          }
-        }
-        input_data += input_stride;
-        output_data += output_stride;
-        input_grad_data += input_stride;
-        output_grad_data += output_stride;
-      }
-    }
-  }
-
-  void operator()(const CPUContext& context,
-                  const DenseTensor& input,
-                  const DenseTensor& output,
-                  const DenseTensor& output_grad,
-                  const std::vector<int>& ksize,
-                  const std::vector<int>& strides,
-                  const std::vector<int>& paddings,
+                  const std::vector<int64_t>& ksize,
+                  const std::vector<int64_t>& strides,
+                  const std::vector<int64_t>& paddings,
                   const std::string data_format,
                   bool exclusive,
                   bool adaptive,
@@ -355,50 +196,50 @@ class Pool2dGradFunctor<CPUContext, PoolProcess, T> {
                   PoolProcess pool_grad_process) {
     bool channel_last = (data_format == "NHWC");
 
-    const int batch_size = static_cast<int>(input.dims()[0]);
+    const int64_t batch_size = input.dims()[0];
 
-    const int input_channels =
-        static_cast<int>(channel_last ? input.dims()[3] : input.dims()[1]);
-    const int input_height =
-        static_cast<int>(channel_last ? input.dims()[1] : input.dims()[2]);
-    const int input_width =
-        static_cast<int>(channel_last ? input.dims()[2] : input.dims()[3]);
+    const int64_t input_channels =
+        channel_last ? input.dims()[3] : input.dims()[1];
+    const int64_t input_height =
+        channel_last ? input.dims()[1] : input.dims()[2];
+    const int64_t input_width =
+        channel_last ? input.dims()[2] : input.dims()[3];
 
-    const int output_channels =
-        static_cast<int>(channel_last ? output.dims()[3] : output.dims()[1]);
-    const int output_height =
-        static_cast<int>(channel_last ? output.dims()[1] : output.dims()[2]);
-    const int output_width =
-        static_cast<int>(channel_last ? output.dims()[2] : output.dims()[3]);
+    const int64_t output_channels =
+        channel_last ? output.dims()[3] : output.dims()[1];
+    const int64_t output_height =
+        channel_last ? output.dims()[1] : output.dims()[2];
+    const int64_t output_width =
+        channel_last ? output.dims()[2] : output.dims()[3];
 
-    const int ksize_height = ksize[0];
-    const int ksize_width = ksize[1];
+    const int64_t ksize_height = ksize[0];
+    const int64_t ksize_width = ksize[1];
 
-    const int stride_height = strides[0];
-    const int stride_width = strides[1];
+    const int64_t stride_height = strides[0];
+    const int64_t stride_width = strides[1];
 
-    const int padding_height = paddings[0];
-    const int padding_width = paddings[1];
+    const int64_t padding_height = paddings[0];
+    const int64_t padding_width = paddings[1];
 
     const T* input_data = input.data<T>();
     const T* output_data = output.data<T>();
     const T* output_grad_data = output_grad.data<T>();
     T* input_grad_data = context.template Alloc<T>(input_grad);
 
-    int hstart = 0, hend = 1;
-    int wstart = 0, wend = 1;
+    int64_t hstart = 0, hend = 1;
+    int64_t wstart = 0, wend = 1;
     if (!channel_last) {
-      const int input_stride = input_height * input_width;
-      const int output_stride = output_height * output_width;
-      for (int i = 0; i < batch_size; i++) {
-        for (int c = 0; c < output_channels; ++c) {
-          for (int ph = 0; ph < output_height; ++ph) {
+      const int64_t input_stride = input_height * input_width;
+      const int64_t output_stride = output_height * output_width;
+      for (int64_t i = 0; i < batch_size; i++) {
+        for (int64_t c = 0; c < output_channels; ++c) {
+          for (int64_t ph = 0; ph < output_height; ++ph) {
             if (adaptive) {
               hstart = AdaptStartIndex(ph, input_height, output_height);
               hend = AdaptEndIndex(ph, input_height, output_height);
             }
-            for (int pw = 0; pw < output_width; ++pw) {
-              int pool_size = 1;
+            for (int64_t pw = 0; pw < output_width; ++pw) {
+              int64_t pool_size = 1;
               if (adaptive) {
                 wstart = AdaptStartIndex(pw, input_width, output_width);
                 wend = AdaptEndIndex(pw, input_width, output_width);
@@ -411,8 +252,8 @@ class Pool2dGradFunctor<CPUContext, PoolProcess, T> {
                     std::min(wstart + ksize_width, input_width + padding_width);
                 pool_size = (hend - hstart) * (wend - wstart);
 
-                wstart = std::max(wstart, 0);
-                hstart = std::max(hstart, 0);
+                wstart = std::max(wstart, static_cast<int64_t>(0));
+                hstart = std::max(hstart, static_cast<int64_t>(0));
                 hend = std::min(hend, input_height);
                 wend = std::min(wend, input_width);
               }
@@ -420,8 +261,8 @@ class Pool2dGradFunctor<CPUContext, PoolProcess, T> {
                 pool_size = (hend - hstart) * (wend - wstart);
               }
               float scale = 1.0f / static_cast<float>(pool_size);
-              for (int h = hstart; h < hend; ++h) {
-                for (int w = wstart; w < wend; ++w) {
+              for (int64_t h = hstart; h < hend; ++h) {
+                for (int64_t w = wstart; w < wend; ++w) {
                   pool_grad_process.compute(
                       input_data[h * input_width + w],
                       output_data[ph * output_width + pw],
@@ -439,17 +280,18 @@ class Pool2dGradFunctor<CPUContext, PoolProcess, T> {
         }
       }
     } else {
-      const int input_stride = input_height * input_width * input_channels;
-      const int output_stride = output_height * output_width * output_channels;
-      for (int i = 0; i < batch_size; i++) {
-        for (int c = 0; c < output_channels; ++c) {
-          for (int ph = 0; ph < output_height; ++ph) {
+      const int64_t input_stride = input_height * input_width * input_channels;
+      const int64_t output_stride =
+          output_height * output_width * output_channels;
+      for (int64_t i = 0; i < batch_size; i++) {
+        for (int64_t c = 0; c < output_channels; ++c) {
+          for (int64_t ph = 0; ph < output_height; ++ph) {
             if (adaptive) {
               hstart = AdaptStartIndex(ph, input_height, output_height);
               hend = AdaptEndIndex(ph, input_height, output_height);
             }
-            for (int pw = 0; pw < output_width; ++pw) {
-              int pool_size = 1;
+            for (int64_t pw = 0; pw < output_width; ++pw) {
+              int64_t pool_size = 1;
               if (adaptive) {
                 wstart = AdaptStartIndex(pw, input_width, output_width);
                 wend = AdaptEndIndex(pw, input_width, output_width);
@@ -462,8 +304,8 @@ class Pool2dGradFunctor<CPUContext, PoolProcess, T> {
                     std::min(wstart + ksize_width, input_width + padding_width);
                 pool_size = (hend - hstart) * (wend - wstart);
 
-                wstart = std::max(wstart, 0);
-                hstart = std::max(hstart, 0);
+                wstart = std::max(wstart, static_cast<int64_t>(0));
+                hstart = std::max(hstart, static_cast<int64_t>(0));
                 hend = std::min(hend, input_height);
                 wend = std::min(wend, input_width);
               }
@@ -471,8 +313,8 @@ class Pool2dGradFunctor<CPUContext, PoolProcess, T> {
                 pool_size = (hend - hstart) * (wend - wstart);
               }
               float scale = 1.0f / static_cast<float>(pool_size);
-              for (int h = hstart; h < hend; ++h) {
-                for (int w = wstart; w < wend; ++w) {
+              for (int64_t h = hstart; h < hend; ++h) {
+                for (int64_t w = wstart; w < wend; ++w) {
                   auto input_idx =
                       h * input_width * input_channels + w * input_channels + c;
                   auto output_idx = ph * output_width * output_channels +
@@ -510,97 +352,37 @@ class MaxPool2dGradFunctor<CPUContext, T> {
                   const DenseTensor& input,
                   const DenseTensor& output,
                   const DenseTensor& output_grad,
-                  const std::vector<int>& ksize,
-                  const std::vector<int>& strides,
-                  const std::vector<int>& paddings,
-                  DenseTensor* input_grad) {
-    const int batch_size = static_cast<int>(input.dims()[0]);
-    const int input_height = static_cast<int>(input.dims()[2]);
-    const int input_width = static_cast<int>(input.dims()[3]);
-    const int output_channels = static_cast<int>(output.dims()[1]);
-    const int output_height = static_cast<int>(output.dims()[2]);
-    const int output_width = static_cast<int>(output.dims()[3]);
-    const int ksize_height = ksize[0];
-    const int ksize_width = ksize[1];
-    const int stride_height = strides[0];
-    const int stride_width = strides[1];
-    const int padding_height = paddings[0];
-    const int padding_width = paddings[1];
-    const int input_stride = input_height * input_width;
-    const int output_stride = output_height * output_width;
-
-    const T* input_data = input.data<T>();
-    const T* output_data = output.data<T>();
-    const T* output_grad_data = output_grad.data<T>();
-    T* input_grad_data = context.template Alloc<T>(input_grad);
-
-    for (int i = 0; i < batch_size; i++) {
-      for (int c = 0; c < output_channels; ++c) {
-        for (int ph = 0; ph < output_height; ++ph) {
-          int hstart = ph * stride_height - padding_height;
-          int hend = std::min(hstart + ksize_height, input_height);
-          hstart = std::max(hstart, 0);
-          for (int pw = 0; pw < output_width; ++pw) {
-            int wstart = pw * stride_width - padding_width;
-            int wend = std::min(wstart + ksize_width, input_width);
-            wstart = std::max(wstart, 0);
-
-            bool stop = false;
-            for (int h = hstart; h < hend && !stop; ++h) {
-              for (int w = wstart; w < wend && !stop; ++w) {
-                int input_idx = h * input_width + w;
-                int output_idx = ph * output_width + pw;
-                if (input_data[input_idx] == output_data[output_idx]) {
-                  input_grad_data[input_idx] += output_grad_data[output_idx];
-                  stop = true;
-                }
-              }
-            }
-          }
-        }
-        input_data += input_stride;
-        output_data += output_stride;
-        input_grad_data += input_stride;
-        output_grad_data += output_stride;
-      }
-    }
-  }
-
-  void operator()(const CPUContext& context,
-                  const DenseTensor& input,
-                  const DenseTensor& output,
-                  const DenseTensor& output_grad,
-                  const std::vector<int>& ksize,
-                  const std::vector<int>& strides,
-                  const std::vector<int>& paddings,
+                  const std::vector<int64_t>& ksize,
+                  const std::vector<int64_t>& strides,
+                  const std::vector<int64_t>& paddings,
                   const std::string data_format,
                   DenseTensor* input_grad) {
     bool channel_last = (data_format == "NHWC");
 
-    const int batch_size = static_cast<int>(input.dims()[0]);
+    const int64_t batch_size = input.dims()[0];
 
-    const int input_channels =
-        static_cast<int>(channel_last ? input.dims()[3] : input.dims()[1]);
-    const int input_height =
-        static_cast<int>(channel_last ? input.dims()[1] : input.dims()[2]);
-    const int input_width =
-        static_cast<int>(channel_last ? input.dims()[2] : input.dims()[3]);
+    const int64_t input_channels =
+        channel_last ? input.dims()[3] : input.dims()[1];
+    const int64_t input_height =
+        channel_last ? input.dims()[1] : input.dims()[2];
+    const int64_t input_width =
+        channel_last ? input.dims()[2] : input.dims()[3];
 
-    const int output_channels =
-        static_cast<int>(channel_last ? output.dims()[3] : output.dims()[1]);
-    const int output_height =
-        static_cast<int>(channel_last ? output.dims()[1] : output.dims()[2]);
-    const int output_width =
-        static_cast<int>(channel_last ? output.dims()[2] : output.dims()[3]);
+    const int64_t output_channels =
+        channel_last ? output.dims()[3] : output.dims()[1];
+    const int64_t output_height =
+        channel_last ? output.dims()[1] : output.dims()[2];
+    const int64_t output_width =
+        channel_last ? output.dims()[2] : output.dims()[3];
 
-    const int ksize_height = ksize[0];
-    const int ksize_width = ksize[1];
+    const int64_t ksize_height = ksize[0];
+    const int64_t ksize_width = ksize[1];
 
-    const int stride_height = strides[0];
-    const int stride_width = strides[1];
+    const int64_t stride_height = strides[0];
+    const int64_t stride_width = strides[1];
 
-    const int padding_height = paddings[0];
-    const int padding_width = paddings[1];
+    const int64_t padding_height = paddings[0];
+    const int64_t padding_width = paddings[1];
 
     const T* input_data = input.data<T>();
     const T* output_data = output.data<T>();
@@ -608,24 +390,24 @@ class MaxPool2dGradFunctor<CPUContext, T> {
     T* input_grad_data = context.template Alloc<T>(input_grad);
 
     if (!channel_last) {
-      const int input_stride = input_height * input_width;
-      const int output_stride = output_height * output_width;
-      for (int i = 0; i < batch_size; i++) {
-        for (int c = 0; c < output_channels; ++c) {
-          for (int ph = 0; ph < output_height; ++ph) {
-            int hstart = ph * stride_height - padding_height;
-            int hend = std::min(hstart + ksize_height, input_height);
-            hstart = std::max(hstart, 0);
-            for (int pw = 0; pw < output_width; ++pw) {
-              int wstart = pw * stride_width - padding_width;
-              int wend = std::min(wstart + ksize_width, input_width);
-              wstart = std::max(wstart, 0);
+      const int64_t input_stride = input_height * input_width;
+      const int64_t output_stride = output_height * output_width;
+      for (int64_t i = 0; i < batch_size; i++) {
+        for (int64_t c = 0; c < output_channels; ++c) {
+          for (int64_t ph = 0; ph < output_height; ++ph) {
+            int64_t hstart = ph * stride_height - padding_height;
+            int64_t hend = std::min(hstart + ksize_height, input_height);
+            hstart = std::max(hstart, static_cast<int64_t>(0));
+            for (int64_t pw = 0; pw < output_width; ++pw) {
+              int64_t wstart = pw * stride_width - padding_width;
+              int64_t wend = std::min(wstart + ksize_width, input_width);
+              wstart = std::max(wstart, static_cast<int64_t>(0));
 
               bool stop = false;
-              for (int h = hstart; h < hend && !stop; ++h) {
-                for (int w = wstart; w < wend && !stop; ++w) {
-                  int input_idx = h * input_width + w;
-                  int output_idx = ph * output_width + pw;
+              for (int64_t h = hstart; h < hend && !stop; ++h) {
+                for (int64_t w = wstart; w < wend && !stop; ++w) {
+                  int64_t input_idx = h * input_width + w;
+                  int64_t output_idx = ph * output_width + pw;
                   if (input_data[input_idx] == output_data[output_idx]) {
                     input_grad_data[input_idx] += output_grad_data[output_idx];
                     stop = true;
@@ -641,26 +423,27 @@ class MaxPool2dGradFunctor<CPUContext, T> {
         }
       }
     } else {
-      const int input_stride = input_height * input_width * input_channels;
-      const int output_stride = output_height * output_width * output_channels;
-      for (int i = 0; i < batch_size; i++) {
-        for (int c = 0; c < output_channels; ++c) {
-          for (int ph = 0; ph < output_height; ++ph) {
-            int hstart = ph * stride_height - padding_height;
-            int hend = std::min(hstart + ksize_height, input_height);
-            hstart = std::max(hstart, 0);
-            for (int pw = 0; pw < output_width; ++pw) {
-              int wstart = pw * stride_width - padding_width;
-              int wend = std::min(wstart + ksize_width, input_width);
-              wstart = std::max(wstart, 0);
+      const int64_t input_stride = input_height * input_width * input_channels;
+      const int64_t output_stride =
+          output_height * output_width * output_channels;
+      for (int64_t i = 0; i < batch_size; i++) {
+        for (int64_t c = 0; c < output_channels; ++c) {
+          for (int64_t ph = 0; ph < output_height; ++ph) {
+            int64_t hstart = ph * stride_height - padding_height;
+            int64_t hend = std::min(hstart + ksize_height, input_height);
+            hstart = std::max(hstart, static_cast<int64_t>(0));
+            for (int64_t pw = 0; pw < output_width; ++pw) {
+              int64_t wstart = pw * stride_width - padding_width;
+              int64_t wend = std::min(wstart + ksize_width, input_width);
+              wstart = std::max(wstart, static_cast<int64_t>(0));
 
               bool stop = false;
-              for (int h = hstart; h < hend && !stop; ++h) {
-                for (int w = wstart; w < wend && !stop; ++w) {
-                  int input_idx =
+              for (int64_t h = hstart; h < hend && !stop; ++h) {
+                for (int64_t w = wstart; w < wend && !stop; ++w) {
+                  int64_t input_idx =
                       h * input_width * input_channels + w * input_channels + c;
-                  int output_idx = ph * output_width * output_channels +
-                                   pw * output_channels + c;
+                  int64_t output_idx = ph * output_width * output_channels +
+                                       pw * output_channels + c;
                   if (input_data[input_idx] == output_data[output_idx]) {
                     input_grad_data[input_idx] += output_grad_data[output_idx];
                     stop = true;
@@ -707,170 +490,72 @@ class Pool3dFunctor<CPUContext, PoolProcess, T> {
  public:
   void operator()(const CPUContext& context,
                   const DenseTensor& input,
-                  const std::vector<int>& ksize,
-                  const std::vector<int>& strides,
-                  const std::vector<int>& paddings,
-                  bool exclusive,
-                  bool adaptive,
-                  DenseTensor* output,
-                  PoolProcess pool_process) {
-    const int batch_size = static_cast<int>(input.dims()[0]);
-    const int input_depth = static_cast<int>(input.dims()[2]);
-    const int input_height = static_cast<int>(input.dims()[3]);
-    const int input_width = static_cast<int>(input.dims()[4]);
-    const int output_channels = static_cast<int>(output->dims()[1]);
-    const int output_depth = static_cast<int>(output->dims()[2]);
-    const int output_height = static_cast<int>(output->dims()[3]);
-    const int output_width = static_cast<int>(output->dims()[4]);
-    const int ksize_depth = ksize[0];
-    const int ksize_height = ksize[1];
-    const int ksize_width = ksize[2];
-    const int stride_depth = strides[0];
-    const int stride_height = strides[1];
-    const int stride_width = strides[2];
-    const int padding_depth = paddings[0];
-    const int padding_height = paddings[1];
-    const int padding_width = paddings[2];
-
-    const int input_stride = input_depth * input_height * input_width;
-    const int output_stride = output_depth * output_height * output_width;
-
-    const T* input_data = input.data<T>();
-    T* output_data = context.template Alloc<T>(output);
-
-    int dstart = 0, dend = 1;
-    int hstart = 0, hend = 1;
-    int wstart = 0, wend = 1;
-
-    for (int i = 0; i < batch_size; i++) {
-      for (int c = 0; c < output_channels; ++c) {
-        for (int pd = 0; pd < output_depth; ++pd) {
-          if (adaptive) {
-            dstart = AdaptStartIndex(pd, input_depth, output_depth);
-            dend = AdaptEndIndex(pd, input_depth, output_depth);
-          }
-
-          for (int ph = 0; ph < output_height; ++ph) {
-            if (adaptive) {
-              hstart = AdaptStartIndex(ph, input_height, output_height);
-              hend = AdaptEndIndex(ph, input_height, output_height);
-            }
-
-            for (int pw = 0; pw < output_width; ++pw) {
-              int pool_size = 1;
-              if (adaptive) {
-                wstart = AdaptStartIndex(pw, input_width, output_width);
-                wend = AdaptEndIndex(pw, input_width, output_width);
-              } else {
-                dstart = pd * stride_depth - padding_depth;
-                dend =
-                    std::min(dstart + ksize_depth, input_depth + padding_depth);
-                hstart = ph * stride_height - padding_height;
-                hend = std::min(hstart + ksize_height,
-                                input_height + padding_height);
-                wstart = pw * stride_width - padding_width;
-                wend =
-                    std::min(wstart + ksize_width, input_width + padding_width);
-                pool_size = (dend - dstart) * (hend - hstart) * (wend - wstart);
-                dstart = std::max(dstart, 0);
-                hstart = std::max(hstart, 0);
-                wstart = std::max(wstart, 0);
-                dend = std::min(dend, input_depth);
-                hend = std::min(hend, input_height);
-                wend = std::min(wend, input_width);
-              }
-              int output_idx = (pd * output_height + ph) * output_width + pw;
-              T ele = pool_process.initial();
-              for (int d = dstart; d < dend; ++d) {
-                for (int h = hstart; h < hend; ++h) {
-                  for (int w = wstart; w < wend; ++w) {
-                    pool_process.compute(
-                        input_data[(d * input_height + h) * input_width + w],
-                        &ele);
-                  }
-                }
-              }
-              if (exclusive || adaptive) {
-                pool_size = (dend - dstart) * (hend - hstart) * (wend - wstart);
-              }
-              pool_process.finalize(static_cast<T>(pool_size), &ele);
-              output_data[output_idx] = ele;
-            }
-          }
-        }
-        input_data += input_stride;
-        output_data += output_stride;
-      }
-    }
-  }
-  void operator()(const CPUContext& context,
-                  const DenseTensor& input,
-                  const std::vector<int>& ksize,
-                  const std::vector<int>& strides,
-                  const std::vector<int>& paddings,
+                  const std::vector<int64_t>& ksize,
+                  const std::vector<int64_t>& strides,
+                  const std::vector<int64_t>& paddings,
                   const std::string data_format,
                   bool exclusive,
                   bool adaptive,
                   DenseTensor* output,
                   PoolProcess pool_process) {
     bool channel_last = (data_format == "NDHWC");
-    const int batch_size = static_cast<int>(input.dims()[0]);
+    const int64_t batch_size = input.dims()[0];
 
-    const int input_channels =
-        static_cast<int>(channel_last ? input.dims()[4] : input.dims()[1]);
-    const int input_depth =
-        static_cast<int>(channel_last ? input.dims()[1] : input.dims()[2]);
-    const int input_height =
-        static_cast<int>(channel_last ? input.dims()[2] : input.dims()[3]);
-    const int input_width =
-        static_cast<int>(channel_last ? input.dims()[3] : input.dims()[4]);
+    const int64_t input_channels =
+        channel_last ? input.dims()[4] : input.dims()[1];
+    const int64_t input_depth =
+        channel_last ? input.dims()[1] : input.dims()[2];
+    const int64_t input_height =
+        channel_last ? input.dims()[2] : input.dims()[3];
+    const int64_t input_width =
+        channel_last ? input.dims()[3] : input.dims()[4];
 
-    const int output_channels =
-        static_cast<int>(channel_last ? output->dims()[4] : output->dims()[1]);
-    const int output_depth =
-        static_cast<int>(channel_last ? output->dims()[1] : output->dims()[2]);
-    const int output_height =
-        static_cast<int>(channel_last ? output->dims()[2] : output->dims()[3]);
-    const int output_width =
-        static_cast<int>(channel_last ? output->dims()[3] : output->dims()[4]);
+    const int64_t output_channels =
+        channel_last ? output->dims()[4] : output->dims()[1];
+    const int64_t output_depth =
+        channel_last ? output->dims()[1] : output->dims()[2];
+    const int64_t output_height =
+        channel_last ? output->dims()[2] : output->dims()[3];
+    const int64_t output_width =
+        channel_last ? output->dims()[3] : output->dims()[4];
 
-    const int ksize_depth = ksize[0];
-    const int ksize_height = ksize[1];
-    const int ksize_width = ksize[2];
+    const int64_t ksize_depth = ksize[0];
+    const int64_t ksize_height = ksize[1];
+    const int64_t ksize_width = ksize[2];
 
-    const int stride_depth = strides[0];
-    const int stride_height = strides[1];
-    const int stride_width = strides[2];
+    const int64_t stride_depth = strides[0];
+    const int64_t stride_height = strides[1];
+    const int64_t stride_width = strides[2];
 
-    const int padding_depth = paddings[0];
-    const int padding_height = paddings[1];
-    const int padding_width = paddings[2];
+    const int64_t padding_depth = paddings[0];
+    const int64_t padding_height = paddings[1];
+    const int64_t padding_width = paddings[2];
 
     const T* input_data = input.data<T>();
     T* output_data = context.template Alloc<T>(output);
 
-    int dstart = 0, dend = 1;
-    int hstart = 0, hend = 1;
-    int wstart = 0, wend = 1;
+    int64_t dstart = 0, dend = 1;
+    int64_t hstart = 0, hend = 1;
+    int64_t wstart = 0, wend = 1;
     if (!channel_last) {
-      const int input_stride = input_depth * input_height * input_width;
-      const int output_stride = output_depth * output_height * output_width;
-      for (int i = 0; i < batch_size; i++) {
-        for (int c = 0; c < output_channels; ++c) {
-          for (int pd = 0; pd < output_depth; ++pd) {
+      const int64_t input_stride = input_depth * input_height * input_width;
+      const int64_t output_stride = output_depth * output_height * output_width;
+      for (int64_t i = 0; i < batch_size; i++) {
+        for (int64_t c = 0; c < output_channels; ++c) {
+          for (int64_t pd = 0; pd < output_depth; ++pd) {
             if (adaptive) {
               dstart = AdaptStartIndex(pd, input_depth, output_depth);
               dend = AdaptEndIndex(pd, input_depth, output_depth);
             }
 
-            for (int ph = 0; ph < output_height; ++ph) {
+            for (int64_t ph = 0; ph < output_height; ++ph) {
               if (adaptive) {
                 hstart = AdaptStartIndex(ph, input_height, output_height);
                 hend = AdaptEndIndex(ph, input_height, output_height);
               }
 
-              for (int pw = 0; pw < output_width; ++pw) {
-                int pool_size = 1;
+              for (int64_t pw = 0; pw < output_width; ++pw) {
+                int64_t pool_size = 1;
                 if (adaptive) {
                   wstart = AdaptStartIndex(pw, input_width, output_width);
                   wend = AdaptEndIndex(pw, input_width, output_width);
@@ -887,19 +572,20 @@ class Pool3dFunctor<CPUContext, PoolProcess, T> {
 
                   pool_size =
                       (dend - dstart) * (hend - hstart) * (wend - wstart);
-                  dstart = std::max(dstart, 0);
-                  hstart = std::max(hstart, 0);
-                  wstart = std::max(wstart, 0);
+                  dstart = std::max(dstart, static_cast<int64_t>(0));
+                  hstart = std::max(hstart, static_cast<int64_t>(0));
+                  wstart = std::max(wstart, static_cast<int64_t>(0));
                   dend = std::min(dend, input_depth);
                   hend = std::min(hend, input_height);
                   wend = std::min(wend, input_width);
                 }
 
-                int output_idx = (pd * output_height + ph) * output_width + pw;
+                int64_t output_idx =
+                    (pd * output_height + ph) * output_width + pw;
                 T ele = pool_process.initial();
-                for (int d = dstart; d < dend; ++d) {
-                  for (int h = hstart; h < hend; ++h) {
-                    for (int w = wstart; w < wend; ++w) {
+                for (int64_t d = dstart; d < dend; ++d) {
+                  for (int64_t h = hstart; h < hend; ++h) {
+                    for (int64_t w = wstart; w < wend; ++w) {
                       pool_process.compute(
                           input_data[(d * input_height + h) * input_width + w],
                           &ele);
@@ -920,26 +606,26 @@ class Pool3dFunctor<CPUContext, PoolProcess, T> {
         }
       }
     } else {
-      const int input_stride =
+      const int64_t input_stride =
           input_depth * input_height * input_width * input_channels;
-      const int output_stride =
+      const int64_t output_stride =
           output_depth * output_height * output_width * output_channels;
-      for (int i = 0; i < batch_size; i++) {
-        for (int c = 0; c < output_channels; ++c) {
-          for (int pd = 0; pd < output_depth; ++pd) {
+      for (int64_t i = 0; i < batch_size; i++) {
+        for (int64_t c = 0; c < output_channels; ++c) {
+          for (int64_t pd = 0; pd < output_depth; ++pd) {
             if (adaptive) {
               dstart = AdaptStartIndex(pd, input_depth, output_depth);
               dend = AdaptEndIndex(pd, input_depth, output_depth);
             }
 
-            for (int ph = 0; ph < output_height; ++ph) {
+            for (int64_t ph = 0; ph < output_height; ++ph) {
               if (adaptive) {
                 hstart = AdaptStartIndex(ph, input_height, output_height);
                 hend = AdaptEndIndex(ph, input_height, output_height);
               }
 
-              for (int pw = 0; pw < output_width; ++pw) {
-                int pool_size = 1;
+              for (int64_t pw = 0; pw < output_width; ++pw) {
+                int64_t pool_size = 1;
                 if (adaptive) {
                   wstart = AdaptStartIndex(pw, input_width, output_width);
                   wend = AdaptEndIndex(pw, input_width, output_width);
@@ -956,19 +642,19 @@ class Pool3dFunctor<CPUContext, PoolProcess, T> {
 
                   pool_size =
                       (dend - dstart) * (hend - hstart) * (wend - wstart);
-                  dstart = std::max(dstart, 0);
-                  hstart = std::max(hstart, 0);
-                  wstart = std::max(wstart, 0);
+                  dstart = std::max(dstart, static_cast<int64_t>(0));
+                  hstart = std::max(hstart, static_cast<int64_t>(0));
+                  wstart = std::max(wstart, static_cast<int64_t>(0));
                   dend = std::min(dend, input_depth);
                   hend = std::min(hend, input_height);
                   wend = std::min(wend, input_width);
                 }
 
                 T ele = pool_process.initial();
-                for (int d = dstart; d < dend; ++d) {
-                  for (int h = hstart; h < hend; ++h) {
-                    for (int w = wstart; w < wend; ++w) {
-                      int input_idx =
+                for (int64_t d = dstart; d < dend; ++d) {
+                  for (int64_t h = hstart; h < hend; ++h) {
+                    for (int64_t w = wstart; w < wend; ++w) {
+                      int64_t input_idx =
                           ((d * input_height + h) * input_width + w) *
                               input_channels +
                           c;
@@ -981,7 +667,7 @@ class Pool3dFunctor<CPUContext, PoolProcess, T> {
                       (dend - dstart) * (hend - hstart) * (wend - wstart);
                 }
                 pool_process.finalize(static_cast<T>(pool_size), &ele);
-                int output_idx =
+                int64_t output_idx =
                     ((pd * output_height + ph) * output_width + pw) *
                         output_channels +
                     c;
@@ -1012,115 +698,9 @@ class Pool3dGradFunctor<CPUContext, PoolProcess, T> {
                   const DenseTensor& input,
                   const DenseTensor& output,
                   const DenseTensor& output_grad,
-                  const std::vector<int>& ksize,
-                  const std::vector<int>& strides,
-                  const std::vector<int>& paddings,
-                  bool exclusive,
-                  bool adaptive,
-                  DenseTensor* input_grad,
-                  PoolProcess pool_grad_process) {
-    const int batch_size = static_cast<int>(input.dims()[0]);
-    const int input_depth = static_cast<int>(input.dims()[2]);
-    const int input_height = static_cast<int>(input.dims()[3]);
-    const int input_width = static_cast<int>(input.dims()[4]);
-    const int output_channels = static_cast<int>(output.dims()[1]);
-    const int output_depth = static_cast<int>(output.dims()[2]);
-    const int output_height = static_cast<int>(output.dims()[3]);
-    const int output_width = static_cast<int>(output.dims()[4]);
-    const int ksize_depth = ksize[0];
-    const int ksize_height = ksize[1];
-    const int ksize_width = ksize[2];
-    const int stride_depth = strides[0];
-    const int stride_height = strides[1];
-    const int stride_width = strides[2];
-    const int padding_depth = paddings[0];
-    const int padding_height = paddings[1];
-    const int padding_width = paddings[2];
-    const int input_stride = input_depth * input_height * input_width;
-    const int output_stride = output_depth * output_height * output_width;
-
-    const T* input_data = input.data<T>();
-    const T* output_data = output.data<T>();
-    const T* output_grad_data = output_grad.data<T>();
-    T* input_grad_data = context.template Alloc<T>(input_grad);
-
-    int dstart = 0, dend = 1;
-    int hstart = 0, hend = 1;
-    int wstart = 0, wend = 1;
-    for (int i = 0; i < batch_size; i++) {
-      for (int c = 0; c < output_channels; ++c) {
-        for (int pd = 0; pd < output_depth; ++pd) {
-          if (adaptive) {
-            dstart = AdaptStartIndex(pd, input_depth, output_depth);
-            dend = AdaptEndIndex(pd, input_depth, output_depth);
-          }
-
-          for (int ph = 0; ph < output_height; ++ph) {
-            if (adaptive) {
-              hstart = AdaptStartIndex(ph, input_height, output_height);
-              hend = AdaptEndIndex(ph, input_height, output_height);
-            }
-
-            for (int pw = 0; pw < output_width; ++pw) {
-              int pool_size = 1;
-              if (adaptive) {
-                wstart = AdaptStartIndex(pw, input_width, output_width);
-                wend = AdaptEndIndex(pw, input_width, output_width);
-              } else {
-                dstart = pd * stride_depth - padding_depth;
-                dend =
-                    std::min(dstart + ksize_depth, input_depth + padding_depth);
-                hstart = ph * stride_height - padding_height;
-                hend = std::min(hstart + ksize_height,
-                                input_height + padding_height);
-                wstart = pw * stride_width - padding_width;
-                wend =
-                    std::min(wstart + ksize_width, input_width + padding_width);
-
-                pool_size = (dend - dstart) * (hend - hstart) * (wend - wstart);
-                dstart = std::max(dstart, 0);
-                hstart = std::max(hstart, 0);
-                wstart = std::max(wstart, 0);
-                dend = std::min(dend, input_depth);
-                hend = std::min(hend, input_height);
-                wend = std::min(wend, input_width);
-              }
-
-              if (exclusive || adaptive) {
-                pool_size = (dend - dstart) * (hend - hstart) * (wend - wstart);
-              }
-              float scale = 1.0f / static_cast<float>(pool_size);
-              for (int d = dstart; d < dend; ++d) {
-                for (int h = hstart; h < hend; ++h) {
-                  for (int w = wstart; w < wend; ++w) {
-                    int input_idx = (d * input_height + h) * input_width + w;
-                    int output_idx =
-                        (pd * output_height + ph) * output_width + pw;
-                    pool_grad_process.compute(input_data[input_idx],
-                                              output_data[output_idx],
-                                              output_grad_data[output_idx],
-                                              static_cast<T>(scale),
-                                              input_grad_data + input_idx);
-                  }
-                }
-              }
-            }
-          }
-        }
-        input_data += input_stride;
-        output_data += output_stride;
-        input_grad_data += input_stride;
-        output_grad_data += output_stride;
-      }
-    }
-  }
-  void operator()(const CPUContext& context,
-                  const DenseTensor& input,
-                  const DenseTensor& output,
-                  const DenseTensor& output_grad,
-                  const std::vector<int>& ksize,
-                  const std::vector<int>& strides,
-                  const std::vector<int>& paddings,
+                  const std::vector<int64_t>& ksize,
+                  const std::vector<int64_t>& strides,
+                  const std::vector<int64_t>& paddings,
                   const std::string data_format,
                   bool exclusive,
                   bool adaptive,
@@ -1128,64 +708,64 @@ class Pool3dGradFunctor<CPUContext, PoolProcess, T> {
                   PoolProcess pool_grad_process) {
     bool channel_last = (data_format == "NDHWC");
 
-    const int batch_size = static_cast<int>(input.dims()[0]);
-    const int input_channels =
-        static_cast<int>(channel_last ? input.dims()[4] : input.dims()[1]);
-    const int input_depth =
-        static_cast<int>(channel_last ? input.dims()[1] : input.dims()[2]);
-    const int input_height =
-        static_cast<int>(channel_last ? input.dims()[2] : input.dims()[3]);
-    const int input_width =
-        static_cast<int>(channel_last ? input.dims()[3] : input.dims()[4]);
+    const int64_t batch_size = input.dims()[0];
+    const int64_t input_channels =
+        channel_last ? input.dims()[4] : input.dims()[1];
+    const int64_t input_depth =
+        channel_last ? input.dims()[1] : input.dims()[2];
+    const int64_t input_height =
+        channel_last ? input.dims()[2] : input.dims()[3];
+    const int64_t input_width =
+        channel_last ? input.dims()[3] : input.dims()[4];
 
-    const int output_channels =
-        static_cast<int>(channel_last ? output.dims()[4] : output.dims()[1]);
-    const int output_depth =
-        static_cast<int>(channel_last ? output.dims()[1] : output.dims()[2]);
-    const int output_height =
-        static_cast<int>(channel_last ? output.dims()[2] : output.dims()[3]);
-    const int output_width =
-        static_cast<int>(channel_last ? output.dims()[3] : output.dims()[4]);
+    const int64_t output_channels =
+        channel_last ? output.dims()[4] : output.dims()[1];
+    const int64_t output_depth =
+        channel_last ? output.dims()[1] : output.dims()[2];
+    const int64_t output_height =
+        channel_last ? output.dims()[2] : output.dims()[3];
+    const int64_t output_width =
+        channel_last ? output.dims()[3] : output.dims()[4];
 
-    const int ksize_depth = ksize[0];
-    const int ksize_height = ksize[1];
-    const int ksize_width = ksize[2];
+    const int64_t ksize_depth = ksize[0];
+    const int64_t ksize_height = ksize[1];
+    const int64_t ksize_width = ksize[2];
 
-    const int stride_depth = strides[0];
-    const int stride_height = strides[1];
-    const int stride_width = strides[2];
+    const int64_t stride_depth = strides[0];
+    const int64_t stride_height = strides[1];
+    const int64_t stride_width = strides[2];
 
-    const int padding_depth = paddings[0];
-    const int padding_height = paddings[1];
-    const int padding_width = paddings[2];
+    const int64_t padding_depth = paddings[0];
+    const int64_t padding_height = paddings[1];
+    const int64_t padding_width = paddings[2];
 
     const T* input_data = input.data<T>();
     const T* output_data = output.data<T>();
     const T* output_grad_data = output_grad.data<T>();
     T* input_grad_data = context.template Alloc<T>(input_grad);
 
-    int dstart = 0, dend = 1;
-    int hstart = 0, hend = 1;
-    int wstart = 0, wend = 1;
+    int64_t dstart = 0, dend = 1;
+    int64_t hstart = 0, hend = 1;
+    int64_t wstart = 0, wend = 1;
     if (!channel_last) {
-      const int input_stride = input_depth * input_height * input_width;
-      const int output_stride = output_depth * output_height * output_width;
-      for (int i = 0; i < batch_size; i++) {
-        for (int c = 0; c < output_channels; ++c) {
-          for (int pd = 0; pd < output_depth; ++pd) {
+      const int64_t input_stride = input_depth * input_height * input_width;
+      const int64_t output_stride = output_depth * output_height * output_width;
+      for (int64_t i = 0; i < batch_size; i++) {
+        for (int64_t c = 0; c < output_channels; ++c) {
+          for (int64_t pd = 0; pd < output_depth; ++pd) {
             if (adaptive) {
               dstart = AdaptStartIndex(pd, input_depth, output_depth);
               dend = AdaptEndIndex(pd, input_depth, output_depth);
             }
 
-            for (int ph = 0; ph < output_height; ++ph) {
+            for (int64_t ph = 0; ph < output_height; ++ph) {
               if (adaptive) {
                 hstart = AdaptStartIndex(ph, input_height, output_height);
                 hend = AdaptEndIndex(ph, input_height, output_height);
               }
 
-              for (int pw = 0; pw < output_width; ++pw) {
-                int pool_size = 1;
+              for (int64_t pw = 0; pw < output_width; ++pw) {
+                int64_t pool_size = 1;
                 if (adaptive) {
                   wstart = AdaptStartIndex(pw, input_width, output_width);
                   wend = AdaptEndIndex(pw, input_width, output_width);
@@ -1202,9 +782,9 @@ class Pool3dGradFunctor<CPUContext, PoolProcess, T> {
 
                   pool_size =
                       (dend - dstart) * (hend - hstart) * (wend - wstart);
-                  dstart = std::max(dstart, 0);
-                  hstart = std::max(hstart, 0);
-                  wstart = std::max(wstart, 0);
+                  dstart = std::max(dstart, static_cast<int64_t>(0));
+                  hstart = std::max(hstart, static_cast<int64_t>(0));
+                  wstart = std::max(wstart, static_cast<int64_t>(0));
                   dend = std::min(dend, input_depth);
                   hend = std::min(hend, input_height);
                   wend = std::min(wend, input_width);
@@ -1215,11 +795,12 @@ class Pool3dGradFunctor<CPUContext, PoolProcess, T> {
                       (dend - dstart) * (hend - hstart) * (wend - wstart);
                 }
                 float scale = 1.0f / static_cast<float>(pool_size);
-                for (int d = dstart; d < dend; ++d) {
-                  for (int h = hstart; h < hend; ++h) {
-                    for (int w = wstart; w < wend; ++w) {
-                      int input_idx = (d * input_height + h) * input_width + w;
-                      int output_idx =
+                for (int64_t d = dstart; d < dend; ++d) {
+                  for (int64_t h = hstart; h < hend; ++h) {
+                    for (int64_t w = wstart; w < wend; ++w) {
+                      int64_t input_idx =
+                          (d * input_height + h) * input_width + w;
+                      int64_t output_idx =
                           (pd * output_height + ph) * output_width + pw;
                       pool_grad_process.compute(input_data[input_idx],
                                                 output_data[output_idx],
@@ -1239,26 +820,26 @@ class Pool3dGradFunctor<CPUContext, PoolProcess, T> {
         }
       }
     } else {
-      const int input_stride =
+      const int64_t input_stride =
           input_depth * input_height * input_width * input_channels;
-      const int output_stride =
+      const int64_t output_stride =
           output_depth * output_height * output_width * output_channels;
-      for (int i = 0; i < batch_size; i++) {
-        for (int c = 0; c < output_channels; ++c) {
-          for (int pd = 0; pd < output_depth; ++pd) {
+      for (int64_t i = 0; i < batch_size; i++) {
+        for (int64_t c = 0; c < output_channels; ++c) {
+          for (int64_t pd = 0; pd < output_depth; ++pd) {
             if (adaptive) {
               dstart = AdaptStartIndex(pd, input_depth, output_depth);
               dend = AdaptEndIndex(pd, input_depth, output_depth);
             }
 
-            for (int ph = 0; ph < output_height; ++ph) {
+            for (int64_t ph = 0; ph < output_height; ++ph) {
               if (adaptive) {
                 hstart = AdaptStartIndex(ph, input_height, output_height);
                 hend = AdaptEndIndex(ph, input_height, output_height);
               }
 
-              for (int pw = 0; pw < output_width; ++pw) {
-                int pool_size = 1;
+              for (int64_t pw = 0; pw < output_width; ++pw) {
+                int64_t pool_size = 1;
                 if (adaptive) {
                   wstart = AdaptStartIndex(pw, input_width, output_width);
                   wend = AdaptEndIndex(pw, input_width, output_width);
@@ -1275,9 +856,9 @@ class Pool3dGradFunctor<CPUContext, PoolProcess, T> {
 
                   pool_size =
                       (dend - dstart) * (hend - hstart) * (wend - wstart);
-                  dstart = std::max(dstart, 0);
-                  hstart = std::max(hstart, 0);
-                  wstart = std::max(wstart, 0);
+                  dstart = std::max(dstart, static_cast<int64_t>(0));
+                  hstart = std::max(hstart, static_cast<int64_t>(0));
+                  wstart = std::max(wstart, static_cast<int64_t>(0));
                   dend = std::min(dend, input_depth);
                   hend = std::min(hend, input_height);
                   wend = std::min(wend, input_width);
@@ -1288,14 +869,14 @@ class Pool3dGradFunctor<CPUContext, PoolProcess, T> {
                       (dend - dstart) * (hend - hstart) * (wend - wstart);
                 }
                 float scale = 1.0f / static_cast<float>(pool_size);
-                for (int d = dstart; d < dend; ++d) {
-                  for (int h = hstart; h < hend; ++h) {
-                    for (int w = wstart; w < wend; ++w) {
-                      int input_idx =
+                for (int64_t d = dstart; d < dend; ++d) {
+                  for (int64_t h = hstart; h < hend; ++h) {
+                    for (int64_t w = wstart; w < wend; ++w) {
+                      int64_t input_idx =
                           ((d * input_height + h) * input_width + w) *
                               input_channels +
                           c;
-                      int output_idx =
+                      int64_t output_idx =
                           ((pd * output_height + ph) * output_width + pw) *
                               output_channels +
                           c;
@@ -1335,116 +916,43 @@ class MaxPool3dGradFunctor<CPUContext, T> {
                   const DenseTensor& input,
                   const DenseTensor& output,
                   const DenseTensor& output_grad,
-                  const std::vector<int>& ksize,
-                  const std::vector<int>& strides,
-                  const std::vector<int>& paddings,
-                  DenseTensor* input_grad) {
-    const int batch_size = static_cast<int>(input.dims()[0]);
-    const int input_depth = static_cast<int>(input.dims()[2]);
-    const int input_height = static_cast<int>(input.dims()[3]);
-    const int input_width = static_cast<int>(input.dims()[4]);
-    const int output_channels = static_cast<int>(output.dims()[1]);
-    const int output_depth = static_cast<int>(output.dims()[2]);
-    const int output_height = static_cast<int>(output.dims()[3]);
-    const int output_width = static_cast<int>(output.dims()[4]);
-    const int ksize_depth = ksize[0];
-    const int ksize_height = ksize[1];
-    const int ksize_width = ksize[2];
-    const int stride_depth = strides[0];
-    const int stride_height = strides[1];
-    const int stride_width = strides[2];
-    const int padding_depth = paddings[0];
-    const int padding_height = paddings[1];
-    const int padding_width = paddings[2];
-    const int input_stride = input_depth * input_height * input_width;
-    const int output_stride = output_depth * output_height * output_width;
-
-    const T* input_data = input.data<T>();
-    const T* output_data = output.data<T>();
-    const T* output_grad_data = output_grad.data<T>();
-    T* input_grad_data = context.template Alloc<T>(input_grad);
-
-    for (int i = 0; i < batch_size; i++) {
-      for (int c = 0; c < output_channels; ++c) {
-        for (int pd = 0; pd < output_depth; ++pd) {
-          int dstart = pd * stride_depth - padding_depth;
-          int dend = std::min(dstart + ksize_depth, input_depth);
-          dstart = std::max(dstart, 0);
-          for (int ph = 0; ph < output_height; ++ph) {
-            int hstart = ph * stride_height - padding_height;
-            int hend = std::min(hstart + ksize_height, input_height);
-            hstart = std::max(hstart, 0);
-            for (int pw = 0; pw < output_width; ++pw) {
-              int wstart = pw * stride_width - padding_width;
-              int wend = std::min(wstart + ksize_width, input_width);
-              wstart = std::max(wstart, 0);
-              bool stop = false;
-              for (int d = dstart; d < dend && !stop; ++d) {
-                for (int h = hstart; h < hend && !stop; ++h) {
-                  for (int w = wstart; w < wend && !stop; ++w) {
-                    int input_idx = (d * input_height + h) * input_width + w;
-                    int output_idx =
-                        (pd * output_height + ph) * output_width + pw;
-
-                    if (input_data[input_idx] == output_data[output_idx]) {
-                      input_grad_data[input_idx] +=
-                          output_grad_data[output_idx];
-                      stop = true;
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-        input_data += input_stride;
-        output_data += output_stride;
-        input_grad_data += input_stride;
-        output_grad_data += output_stride;
-      }
-    }
-  }
-  void operator()(const CPUContext& context,
-                  const DenseTensor& input,
-                  const DenseTensor& output,
-                  const DenseTensor& output_grad,
-                  const std::vector<int>& ksize,
-                  const std::vector<int>& strides,
-                  const std::vector<int>& paddings,
+                  const std::vector<int64_t>& ksize,
+                  const std::vector<int64_t>& strides,
+                  const std::vector<int64_t>& paddings,
                   const std::string data_format,
                   DenseTensor* input_grad) {
     bool channel_last = (data_format == "NDHWC");
-    const int batch_size = static_cast<int>(input.dims()[0]);
+    const int64_t batch_size = input.dims()[0];
 
-    const int input_channels =
-        static_cast<int>(channel_last ? input.dims()[4] : input.dims()[1]);
-    const int input_depth =
-        static_cast<int>(channel_last ? input.dims()[1] : input.dims()[2]);
-    const int input_height =
-        static_cast<int>(channel_last ? input.dims()[2] : input.dims()[3]);
-    const int input_width =
-        static_cast<int>(channel_last ? input.dims()[3] : input.dims()[4]);
+    const int64_t input_channels =
+        channel_last ? input.dims()[4] : input.dims()[1];
+    const int64_t input_depth =
+        channel_last ? input.dims()[1] : input.dims()[2];
+    const int64_t input_height =
+        channel_last ? input.dims()[2] : input.dims()[3];
+    const int64_t input_width =
+        channel_last ? input.dims()[3] : input.dims()[4];
 
-    const int output_channels =
-        static_cast<int>(channel_last ? output.dims()[4] : output.dims()[1]);
-    const int output_depth =
-        static_cast<int>(channel_last ? output.dims()[1] : output.dims()[2]);
-    const int output_height =
-        static_cast<int>(channel_last ? output.dims()[2] : output.dims()[3]);
-    const int output_width =
-        static_cast<int>(channel_last ? output.dims()[3] : output.dims()[4]);
+    const int64_t output_channels =
+        channel_last ? output.dims()[4] : output.dims()[1];
+    const int64_t output_depth =
+        channel_last ? output.dims()[1] : output.dims()[2];
+    const int64_t output_height =
+        channel_last ? output.dims()[2] : output.dims()[3];
+    const int64_t output_width =
+        channel_last ? output.dims()[3] : output.dims()[4];
 
-    const int ksize_depth = ksize[0];
-    const int ksize_height = ksize[1];
-    const int ksize_width = ksize[2];
+    const int64_t ksize_depth = ksize[0];
+    const int64_t ksize_height = ksize[1];
+    const int64_t ksize_width = ksize[2];
 
-    const int stride_depth = strides[0];
-    const int stride_height = strides[1];
-    const int stride_width = strides[2];
+    const int64_t stride_depth = strides[0];
+    const int64_t stride_height = strides[1];
+    const int64_t stride_width = strides[2];
 
-    const int padding_depth = paddings[0];
-    const int padding_height = paddings[1];
-    const int padding_width = paddings[2];
+    const int64_t padding_depth = paddings[0];
+    const int64_t padding_height = paddings[1];
+    const int64_t padding_width = paddings[2];
 
     const T* input_data = input.data<T>();
     const T* output_data = output.data<T>();
@@ -1452,28 +960,29 @@ class MaxPool3dGradFunctor<CPUContext, T> {
     T* input_grad_data = context.template Alloc<T>(input_grad);
 
     if (!channel_last) {
-      const int input_stride = input_depth * input_height * input_width;
-      const int output_stride = output_depth * output_height * output_width;
-      for (int i = 0; i < batch_size; i++) {
-        for (int c = 0; c < output_channels; ++c) {
-          for (int pd = 0; pd < output_depth; ++pd) {
-            int dstart = pd * stride_depth - padding_depth;
-            int dend = std::min(dstart + ksize_depth, input_depth);
-            dstart = std::max(dstart, 0);
-            for (int ph = 0; ph < output_height; ++ph) {
-              int hstart = ph * stride_height - padding_height;
-              int hend = std::min(hstart + ksize_height, input_height);
-              hstart = std::max(hstart, 0);
-              for (int pw = 0; pw < output_width; ++pw) {
-                int wstart = pw * stride_width - padding_width;
-                int wend = std::min(wstart + ksize_width, input_width);
-                wstart = std::max(wstart, 0);
+      const int64_t input_stride = input_depth * input_height * input_width;
+      const int64_t output_stride = output_depth * output_height * output_width;
+      for (int64_t i = 0; i < batch_size; i++) {
+        for (int64_t c = 0; c < output_channels; ++c) {
+          for (int64_t pd = 0; pd < output_depth; ++pd) {
+            int64_t dstart = pd * stride_depth - padding_depth;
+            int64_t dend = std::min(dstart + ksize_depth, input_depth);
+            dstart = std::max(dstart, static_cast<int64_t>(0));
+            for (int64_t ph = 0; ph < output_height; ++ph) {
+              int64_t hstart = ph * stride_height - padding_height;
+              int64_t hend = std::min(hstart + ksize_height, input_height);
+              hstart = std::max(hstart, static_cast<int64_t>(0));
+              for (int64_t pw = 0; pw < output_width; ++pw) {
+                int64_t wstart = pw * stride_width - padding_width;
+                int64_t wend = std::min(wstart + ksize_width, input_width);
+                wstart = std::max(wstart, static_cast<int64_t>(0));
                 bool stop = false;
-                for (int d = dstart; d < dend && !stop; ++d) {
-                  for (int h = hstart; h < hend && !stop; ++h) {
-                    for (int w = wstart; w < wend && !stop; ++w) {
-                      int input_idx = (d * input_height + h) * input_width + w;
-                      int output_idx =
+                for (int64_t d = dstart; d < dend && !stop; ++d) {
+                  for (int64_t h = hstart; h < hend && !stop; ++h) {
+                    for (int64_t w = wstart; w < wend && !stop; ++w) {
+                      int64_t input_idx =
+                          (d * input_height + h) * input_width + w;
+                      int64_t output_idx =
                           (pd * output_height + ph) * output_width + pw;
 
                       if (input_data[input_idx] == output_data[output_idx]) {
@@ -1494,34 +1003,34 @@ class MaxPool3dGradFunctor<CPUContext, T> {
         }
       }
     } else {
-      const int input_stride =
+      const int64_t input_stride =
           input_depth * input_height * input_width * input_channels;
-      const int output_stride =
+      const int64_t output_stride =
           output_depth * output_height * output_width * output_channels;
-      for (int i = 0; i < batch_size; i++) {
-        for (int c = 0; c < output_channels; ++c) {
-          for (int pd = 0; pd < output_depth; ++pd) {
-            int dstart = pd * stride_depth - padding_depth;
-            int dend = std::min(dstart + ksize_depth, input_depth);
-            dstart = std::max(dstart, 0);
-            for (int ph = 0; ph < output_height; ++ph) {
-              int hstart = ph * stride_height - padding_height;
-              int hend = std::min(hstart + ksize_height, input_height);
-              hstart = std::max(hstart, 0);
-              for (int pw = 0; pw < output_width; ++pw) {
-                int wstart = pw * stride_width - padding_width;
-                int wend = std::min(wstart + ksize_width, input_width);
-                wstart = std::max(wstart, 0);
+      for (int64_t i = 0; i < batch_size; i++) {
+        for (int64_t c = 0; c < output_channels; ++c) {
+          for (int64_t pd = 0; pd < output_depth; ++pd) {
+            int64_t dstart = pd * stride_depth - padding_depth;
+            int64_t dend = std::min(dstart + ksize_depth, input_depth);
+            dstart = std::max(dstart, static_cast<int64_t>(0));
+            for (int64_t ph = 0; ph < output_height; ++ph) {
+              int64_t hstart = ph * stride_height - padding_height;
+              int64_t hend = std::min(hstart + ksize_height, input_height);
+              hstart = std::max(hstart, static_cast<int64_t>(0));
+              for (int64_t pw = 0; pw < output_width; ++pw) {
+                int64_t wstart = pw * stride_width - padding_width;
+                int64_t wend = std::min(wstart + ksize_width, input_width);
+                wstart = std::max(wstart, static_cast<int64_t>(0));
                 bool stop = false;
 
-                for (int d = dstart; d < dend && !stop; ++d) {
-                  for (int h = hstart; h < hend && !stop; ++h) {
-                    for (int w = wstart; w < wend && !stop; ++w) {
-                      int input_idx =
+                for (int64_t d = dstart; d < dend && !stop; ++d) {
+                  for (int64_t h = hstart; h < hend && !stop; ++h) {
+                    for (int64_t w = wstart; w < wend && !stop; ++w) {
+                      int64_t input_idx =
                           ((d * input_height + h) * input_width + w) *
                               input_channels +
                           c;
-                      int output_idx =
+                      int64_t output_idx =
                           ((pd * output_height + ph) * output_width + pw) *
                               output_channels +
                           c;

--- a/paddle/phi/kernels/funcs/pooling.cc
+++ b/paddle/phi/kernels/funcs/pooling.cc
@@ -41,47 +41,44 @@ class Pool2dFunctor<CPUContext, PoolProcess, T> {
                   PoolProcess pool_process) {
     bool channel_last = (data_format == "NHWC");
 
-    const int64_t batch_size = input.dims()[0];
-    const int64_t input_channels =
-        channel_last ? input.dims()[3] : input.dims()[1];
-    const int64_t input_height =
-        channel_last ? input.dims()[1] : input.dims()[2];
-    const int64_t input_width =
-        channel_last ? input.dims()[2] : input.dims()[3];
+    const int batch_size = input.dims()[0];
+    const int input_channels = channel_last ? input.dims()[3] : input.dims()[1];
+    const int input_height = channel_last ? input.dims()[1] : input.dims()[2];
+    const int input_width = channel_last ? input.dims()[2] : input.dims()[3];
 
-    const int64_t output_channels =
+    const int output_channels =
         channel_last ? output->dims()[3] : output->dims()[1];
-    const int64_t output_height =
+    const int output_height =
         channel_last ? output->dims()[1] : output->dims()[2];
-    const int64_t output_width =
+    const int output_width =
         channel_last ? output->dims()[2] : output->dims()[3];
 
-    const int64_t ksize_height = ksize[0];
-    const int64_t ksize_width = ksize[1];
+    const int ksize_height = ksize[0];
+    const int ksize_width = ksize[1];
 
-    const int64_t stride_height = strides[0];
-    const int64_t stride_width = strides[1];
+    const int stride_height = strides[0];
+    const int stride_width = strides[1];
 
-    const int64_t padding_height = paddings[0];
-    const int64_t padding_width = paddings[1];
+    const int padding_height = paddings[0];
+    const int padding_width = paddings[1];
 
     const T* input_data = input.data<T>();
     T* output_data = context.template Alloc<T>(output);
 
-    int64_t hstart = 0, hend = 1;
-    int64_t wstart = 0, wend = 1;
+    int hstart = 0, hend = 1;
+    int wstart = 0, wend = 1;
     if (!channel_last) {
-      const int64_t input_stride = input_height * input_width;
-      const int64_t output_stride = output_height * output_width;
-      for (int64_t i = 0; i < batch_size; i++) {
-        for (int64_t c = 0; c < output_channels; ++c) {
-          for (int64_t ph = 0; ph < output_height; ++ph) {
+      const int input_stride = input_height * input_width;
+      const int output_stride = output_height * output_width;
+      for (int i = 0; i < batch_size; i++) {
+        for (int c = 0; c < output_channels; ++c) {
+          for (int ph = 0; ph < output_height; ++ph) {
             if (adaptive) {
               hstart = AdaptStartIndex(ph, input_height, output_height);
               hend = AdaptEndIndex(ph, input_height, output_height);
             }
-            for (int64_t pw = 0; pw < output_width; ++pw) {
-              int64_t pool_size = 1;
+            for (int pw = 0; pw < output_width; ++pw) {
+              int pool_size = 1;
               if (adaptive) {
                 wstart = AdaptStartIndex(pw, input_width, output_width);
                 wend = AdaptEndIndex(pw, input_width, output_width);
@@ -94,15 +91,15 @@ class Pool2dFunctor<CPUContext, PoolProcess, T> {
                     std::min(wstart + ksize_width, input_width + padding_width);
                 pool_size = (hend - hstart) * (wend - wstart);
 
-                wstart = std::max(wstart, static_cast<int64_t>(0));
-                hstart = std::max(hstart, static_cast<int64_t>(0));
+                wstart = std::max(wstart, 0);
+                hstart = std::max(hstart, 0);
                 hend = std::min(hend, input_height);
                 wend = std::min(wend, input_width);
               }
 
               T ele = pool_process.initial();
-              for (int64_t h = hstart; h < hend; ++h) {
-                for (int64_t w = wstart; w < wend; ++w) {
+              for (int h = hstart; h < hend; ++h) {
+                for (int w = wstart; w < wend; ++w) {
                   pool_process.compute(input_data[h * input_width + w], &ele);
                 }
               }
@@ -118,18 +115,17 @@ class Pool2dFunctor<CPUContext, PoolProcess, T> {
         }
       }
     } else {
-      const int64_t input_stride = input_height * input_width * input_channels;
-      const int64_t output_stride =
-          output_height * output_width * output_channels;
-      for (int64_t i = 0; i < batch_size; i++) {
-        for (int64_t c = 0; c < output_channels; ++c) {
-          for (int64_t ph = 0; ph < output_height; ++ph) {
+      const int input_stride = input_height * input_width * input_channels;
+      const int output_stride = output_height * output_width * output_channels;
+      for (int i = 0; i < batch_size; i++) {
+        for (int c = 0; c < output_channels; ++c) {
+          for (int ph = 0; ph < output_height; ++ph) {
             if (adaptive) {
               hstart = AdaptStartIndex(ph, input_height, output_height);
               hend = AdaptEndIndex(ph, input_height, output_height);
             }
-            for (int64_t pw = 0; pw < output_width; ++pw) {
-              int64_t pool_size = 1;
+            for (int pw = 0; pw < output_width; ++pw) {
+              int pool_size = 1;
               if (adaptive) {
                 wstart = AdaptStartIndex(pw, input_width, output_width);
                 wend = AdaptEndIndex(pw, input_width, output_width);
@@ -142,14 +138,14 @@ class Pool2dFunctor<CPUContext, PoolProcess, T> {
                     std::min(wstart + ksize_width, input_width + padding_width);
                 pool_size = (hend - hstart) * (wend - wstart);
 
-                wstart = std::max(wstart, static_cast<int64_t>(0));
-                hstart = std::max(hstart, static_cast<int64_t>(0));
+                wstart = std::max(wstart, 0);
+                hstart = std::max(hstart, 0);
                 hend = std::min(hend, input_height);
                 wend = std::min(wend, input_width);
               }
               T ele = pool_process.initial();
-              for (int64_t h = hstart; h < hend; ++h) {
-                for (int64_t w = wstart; w < wend; ++w) {
+              for (int h = hstart; h < hend; ++h) {
+                for (int w = wstart; w < wend; ++w) {
                   pool_process.compute(
                       input_data[h * input_width * input_channels +
                                  w * input_channels + c],
@@ -196,50 +192,46 @@ class Pool2dGradFunctor<CPUContext, PoolProcess, T> {
                   PoolProcess pool_grad_process) {
     bool channel_last = (data_format == "NHWC");
 
-    const int64_t batch_size = input.dims()[0];
+    const int batch_size = input.dims()[0];
 
-    const int64_t input_channels =
-        channel_last ? input.dims()[3] : input.dims()[1];
-    const int64_t input_height =
-        channel_last ? input.dims()[1] : input.dims()[2];
-    const int64_t input_width =
-        channel_last ? input.dims()[2] : input.dims()[3];
+    const int input_channels = channel_last ? input.dims()[3] : input.dims()[1];
+    const int input_height = channel_last ? input.dims()[1] : input.dims()[2];
+    const int input_width = channel_last ? input.dims()[2] : input.dims()[3];
 
-    const int64_t output_channels =
+    const int output_channels =
         channel_last ? output.dims()[3] : output.dims()[1];
-    const int64_t output_height =
+    const int output_height =
         channel_last ? output.dims()[1] : output.dims()[2];
-    const int64_t output_width =
-        channel_last ? output.dims()[2] : output.dims()[3];
+    const int output_width = channel_last ? output.dims()[2] : output.dims()[3];
 
-    const int64_t ksize_height = ksize[0];
-    const int64_t ksize_width = ksize[1];
+    const int ksize_height = ksize[0];
+    const int ksize_width = ksize[1];
 
-    const int64_t stride_height = strides[0];
-    const int64_t stride_width = strides[1];
+    const int stride_height = strides[0];
+    const int stride_width = strides[1];
 
-    const int64_t padding_height = paddings[0];
-    const int64_t padding_width = paddings[1];
+    const int padding_height = paddings[0];
+    const int padding_width = paddings[1];
 
     const T* input_data = input.data<T>();
     const T* output_data = output.data<T>();
     const T* output_grad_data = output_grad.data<T>();
     T* input_grad_data = context.template Alloc<T>(input_grad);
 
-    int64_t hstart = 0, hend = 1;
-    int64_t wstart = 0, wend = 1;
+    int hstart = 0, hend = 1;
+    int wstart = 0, wend = 1;
     if (!channel_last) {
-      const int64_t input_stride = input_height * input_width;
-      const int64_t output_stride = output_height * output_width;
-      for (int64_t i = 0; i < batch_size; i++) {
-        for (int64_t c = 0; c < output_channels; ++c) {
-          for (int64_t ph = 0; ph < output_height; ++ph) {
+      const int input_stride = input_height * input_width;
+      const int output_stride = output_height * output_width;
+      for (int i = 0; i < batch_size; i++) {
+        for (int c = 0; c < output_channels; ++c) {
+          for (int ph = 0; ph < output_height; ++ph) {
             if (adaptive) {
               hstart = AdaptStartIndex(ph, input_height, output_height);
               hend = AdaptEndIndex(ph, input_height, output_height);
             }
-            for (int64_t pw = 0; pw < output_width; ++pw) {
-              int64_t pool_size = 1;
+            for (int pw = 0; pw < output_width; ++pw) {
+              int pool_size = 1;
               if (adaptive) {
                 wstart = AdaptStartIndex(pw, input_width, output_width);
                 wend = AdaptEndIndex(pw, input_width, output_width);
@@ -252,8 +244,8 @@ class Pool2dGradFunctor<CPUContext, PoolProcess, T> {
                     std::min(wstart + ksize_width, input_width + padding_width);
                 pool_size = (hend - hstart) * (wend - wstart);
 
-                wstart = std::max(wstart, static_cast<int64_t>(0));
-                hstart = std::max(hstart, static_cast<int64_t>(0));
+                wstart = std::max(wstart, 0);
+                hstart = std::max(hstart, 0);
                 hend = std::min(hend, input_height);
                 wend = std::min(wend, input_width);
               }
@@ -261,8 +253,8 @@ class Pool2dGradFunctor<CPUContext, PoolProcess, T> {
                 pool_size = (hend - hstart) * (wend - wstart);
               }
               float scale = 1.0f / static_cast<float>(pool_size);
-              for (int64_t h = hstart; h < hend; ++h) {
-                for (int64_t w = wstart; w < wend; ++w) {
+              for (int h = hstart; h < hend; ++h) {
+                for (int w = wstart; w < wend; ++w) {
                   pool_grad_process.compute(
                       input_data[h * input_width + w],
                       output_data[ph * output_width + pw],
@@ -280,18 +272,17 @@ class Pool2dGradFunctor<CPUContext, PoolProcess, T> {
         }
       }
     } else {
-      const int64_t input_stride = input_height * input_width * input_channels;
-      const int64_t output_stride =
-          output_height * output_width * output_channels;
-      for (int64_t i = 0; i < batch_size; i++) {
-        for (int64_t c = 0; c < output_channels; ++c) {
-          for (int64_t ph = 0; ph < output_height; ++ph) {
+      const int input_stride = input_height * input_width * input_channels;
+      const int output_stride = output_height * output_width * output_channels;
+      for (int i = 0; i < batch_size; i++) {
+        for (int c = 0; c < output_channels; ++c) {
+          for (int ph = 0; ph < output_height; ++ph) {
             if (adaptive) {
               hstart = AdaptStartIndex(ph, input_height, output_height);
               hend = AdaptEndIndex(ph, input_height, output_height);
             }
-            for (int64_t pw = 0; pw < output_width; ++pw) {
-              int64_t pool_size = 1;
+            for (int pw = 0; pw < output_width; ++pw) {
+              int pool_size = 1;
               if (adaptive) {
                 wstart = AdaptStartIndex(pw, input_width, output_width);
                 wend = AdaptEndIndex(pw, input_width, output_width);
@@ -304,8 +295,8 @@ class Pool2dGradFunctor<CPUContext, PoolProcess, T> {
                     std::min(wstart + ksize_width, input_width + padding_width);
                 pool_size = (hend - hstart) * (wend - wstart);
 
-                wstart = std::max(wstart, static_cast<int64_t>(0));
-                hstart = std::max(hstart, static_cast<int64_t>(0));
+                wstart = std::max(wstart, 0);
+                hstart = std::max(hstart, 0);
                 hend = std::min(hend, input_height);
                 wend = std::min(wend, input_width);
               }
@@ -313,8 +304,8 @@ class Pool2dGradFunctor<CPUContext, PoolProcess, T> {
                 pool_size = (hend - hstart) * (wend - wstart);
               }
               float scale = 1.0f / static_cast<float>(pool_size);
-              for (int64_t h = hstart; h < hend; ++h) {
-                for (int64_t w = wstart; w < wend; ++w) {
+              for (int h = hstart; h < hend; ++h) {
+                for (int w = wstart; w < wend; ++w) {
                   auto input_idx =
                       h * input_width * input_channels + w * input_channels + c;
                   auto output_idx = ph * output_width * output_channels +
@@ -359,30 +350,26 @@ class MaxPool2dGradFunctor<CPUContext, T> {
                   DenseTensor* input_grad) {
     bool channel_last = (data_format == "NHWC");
 
-    const int64_t batch_size = input.dims()[0];
+    const int batch_size = input.dims()[0];
 
-    const int64_t input_channels =
-        channel_last ? input.dims()[3] : input.dims()[1];
-    const int64_t input_height =
-        channel_last ? input.dims()[1] : input.dims()[2];
-    const int64_t input_width =
-        channel_last ? input.dims()[2] : input.dims()[3];
+    const int input_channels = channel_last ? input.dims()[3] : input.dims()[1];
+    const int input_height = channel_last ? input.dims()[1] : input.dims()[2];
+    const int input_width = channel_last ? input.dims()[2] : input.dims()[3];
 
-    const int64_t output_channels =
+    const int output_channels =
         channel_last ? output.dims()[3] : output.dims()[1];
-    const int64_t output_height =
+    const int output_height =
         channel_last ? output.dims()[1] : output.dims()[2];
-    const int64_t output_width =
-        channel_last ? output.dims()[2] : output.dims()[3];
+    const int output_width = channel_last ? output.dims()[2] : output.dims()[3];
 
-    const int64_t ksize_height = ksize[0];
-    const int64_t ksize_width = ksize[1];
+    const int ksize_height = ksize[0];
+    const int ksize_width = ksize[1];
 
-    const int64_t stride_height = strides[0];
-    const int64_t stride_width = strides[1];
+    const int stride_height = strides[0];
+    const int stride_width = strides[1];
 
-    const int64_t padding_height = paddings[0];
-    const int64_t padding_width = paddings[1];
+    const int padding_height = paddings[0];
+    const int padding_width = paddings[1];
 
     const T* input_data = input.data<T>();
     const T* output_data = output.data<T>();
@@ -390,24 +377,24 @@ class MaxPool2dGradFunctor<CPUContext, T> {
     T* input_grad_data = context.template Alloc<T>(input_grad);
 
     if (!channel_last) {
-      const int64_t input_stride = input_height * input_width;
-      const int64_t output_stride = output_height * output_width;
-      for (int64_t i = 0; i < batch_size; i++) {
-        for (int64_t c = 0; c < output_channels; ++c) {
-          for (int64_t ph = 0; ph < output_height; ++ph) {
-            int64_t hstart = ph * stride_height - padding_height;
-            int64_t hend = std::min(hstart + ksize_height, input_height);
-            hstart = std::max(hstart, static_cast<int64_t>(0));
-            for (int64_t pw = 0; pw < output_width; ++pw) {
-              int64_t wstart = pw * stride_width - padding_width;
-              int64_t wend = std::min(wstart + ksize_width, input_width);
-              wstart = std::max(wstart, static_cast<int64_t>(0));
+      const int input_stride = input_height * input_width;
+      const int output_stride = output_height * output_width;
+      for (int i = 0; i < batch_size; i++) {
+        for (int c = 0; c < output_channels; ++c) {
+          for (int ph = 0; ph < output_height; ++ph) {
+            int hstart = ph * stride_height - padding_height;
+            int hend = std::min(hstart + ksize_height, input_height);
+            hstart = std::max(hstart, 0);
+            for (int pw = 0; pw < output_width; ++pw) {
+              int wstart = pw * stride_width - padding_width;
+              int wend = std::min(wstart + ksize_width, input_width);
+              wstart = std::max(wstart, 0);
 
               bool stop = false;
-              for (int64_t h = hstart; h < hend && !stop; ++h) {
-                for (int64_t w = wstart; w < wend && !stop; ++w) {
-                  int64_t input_idx = h * input_width + w;
-                  int64_t output_idx = ph * output_width + pw;
+              for (int h = hstart; h < hend && !stop; ++h) {
+                for (int w = wstart; w < wend && !stop; ++w) {
+                  int input_idx = h * input_width + w;
+                  int output_idx = ph * output_width + pw;
                   if (input_data[input_idx] == output_data[output_idx]) {
                     input_grad_data[input_idx] += output_grad_data[output_idx];
                     stop = true;
@@ -423,27 +410,26 @@ class MaxPool2dGradFunctor<CPUContext, T> {
         }
       }
     } else {
-      const int64_t input_stride = input_height * input_width * input_channels;
-      const int64_t output_stride =
-          output_height * output_width * output_channels;
-      for (int64_t i = 0; i < batch_size; i++) {
-        for (int64_t c = 0; c < output_channels; ++c) {
-          for (int64_t ph = 0; ph < output_height; ++ph) {
-            int64_t hstart = ph * stride_height - padding_height;
-            int64_t hend = std::min(hstart + ksize_height, input_height);
-            hstart = std::max(hstart, static_cast<int64_t>(0));
-            for (int64_t pw = 0; pw < output_width; ++pw) {
-              int64_t wstart = pw * stride_width - padding_width;
-              int64_t wend = std::min(wstart + ksize_width, input_width);
-              wstart = std::max(wstart, static_cast<int64_t>(0));
+      const int input_stride = input_height * input_width * input_channels;
+      const int output_stride = output_height * output_width * output_channels;
+      for (int i = 0; i < batch_size; i++) {
+        for (int c = 0; c < output_channels; ++c) {
+          for (int ph = 0; ph < output_height; ++ph) {
+            int hstart = ph * stride_height - padding_height;
+            int hend = std::min(hstart + ksize_height, input_height);
+            hstart = std::max(hstart, 0);
+            for (int pw = 0; pw < output_width; ++pw) {
+              int wstart = pw * stride_width - padding_width;
+              int wend = std::min(wstart + ksize_width, input_width);
+              wstart = std::max(wstart, 0);
 
               bool stop = false;
-              for (int64_t h = hstart; h < hend && !stop; ++h) {
-                for (int64_t w = wstart; w < wend && !stop; ++w) {
-                  int64_t input_idx =
+              for (int h = hstart; h < hend && !stop; ++h) {
+                for (int w = wstart; w < wend && !stop; ++w) {
+                  int input_idx =
                       h * input_width * input_channels + w * input_channels + c;
-                  int64_t output_idx = ph * output_width * output_channels +
-                                       pw * output_channels + c;
+                  int output_idx = ph * output_width * output_channels +
+                                   pw * output_channels + c;
                   if (input_data[input_idx] == output_data[output_idx]) {
                     input_grad_data[input_idx] += output_grad_data[output_idx];
                     stop = true;
@@ -499,63 +485,59 @@ class Pool3dFunctor<CPUContext, PoolProcess, T> {
                   DenseTensor* output,
                   PoolProcess pool_process) {
     bool channel_last = (data_format == "NDHWC");
-    const int64_t batch_size = input.dims()[0];
+    const int batch_size = input.dims()[0];
 
-    const int64_t input_channels =
-        channel_last ? input.dims()[4] : input.dims()[1];
-    const int64_t input_depth =
-        channel_last ? input.dims()[1] : input.dims()[2];
-    const int64_t input_height =
-        channel_last ? input.dims()[2] : input.dims()[3];
-    const int64_t input_width =
-        channel_last ? input.dims()[3] : input.dims()[4];
+    const int input_channels = channel_last ? input.dims()[4] : input.dims()[1];
+    const int input_depth = channel_last ? input.dims()[1] : input.dims()[2];
+    const int input_height = channel_last ? input.dims()[2] : input.dims()[3];
+    const int input_width = channel_last ? input.dims()[3] : input.dims()[4];
 
-    const int64_t output_channels =
+    const int output_channels =
         channel_last ? output->dims()[4] : output->dims()[1];
-    const int64_t output_depth =
+    const int output_depth =
         channel_last ? output->dims()[1] : output->dims()[2];
-    const int64_t output_height =
+    const int output_height =
         channel_last ? output->dims()[2] : output->dims()[3];
-    const int64_t output_width =
+    const int output_width =
         channel_last ? output->dims()[3] : output->dims()[4];
 
-    const int64_t ksize_depth = ksize[0];
-    const int64_t ksize_height = ksize[1];
-    const int64_t ksize_width = ksize[2];
+    const int ksize_depth = ksize[0];
+    const int ksize_height = ksize[1];
+    const int ksize_width = ksize[2];
 
-    const int64_t stride_depth = strides[0];
-    const int64_t stride_height = strides[1];
-    const int64_t stride_width = strides[2];
+    const int stride_depth = strides[0];
+    const int stride_height = strides[1];
+    const int stride_width = strides[2];
 
-    const int64_t padding_depth = paddings[0];
-    const int64_t padding_height = paddings[1];
-    const int64_t padding_width = paddings[2];
+    const int padding_depth = paddings[0];
+    const int padding_height = paddings[1];
+    const int padding_width = paddings[2];
 
     const T* input_data = input.data<T>();
     T* output_data = context.template Alloc<T>(output);
 
-    int64_t dstart = 0, dend = 1;
-    int64_t hstart = 0, hend = 1;
-    int64_t wstart = 0, wend = 1;
+    int dstart = 0, dend = 1;
+    int hstart = 0, hend = 1;
+    int wstart = 0, wend = 1;
     if (!channel_last) {
-      const int64_t input_stride = input_depth * input_height * input_width;
-      const int64_t output_stride = output_depth * output_height * output_width;
-      for (int64_t i = 0; i < batch_size; i++) {
-        for (int64_t c = 0; c < output_channels; ++c) {
-          for (int64_t pd = 0; pd < output_depth; ++pd) {
+      const int input_stride = input_depth * input_height * input_width;
+      const int output_stride = output_depth * output_height * output_width;
+      for (int i = 0; i < batch_size; i++) {
+        for (int c = 0; c < output_channels; ++c) {
+          for (int pd = 0; pd < output_depth; ++pd) {
             if (adaptive) {
               dstart = AdaptStartIndex(pd, input_depth, output_depth);
               dend = AdaptEndIndex(pd, input_depth, output_depth);
             }
 
-            for (int64_t ph = 0; ph < output_height; ++ph) {
+            for (int ph = 0; ph < output_height; ++ph) {
               if (adaptive) {
                 hstart = AdaptStartIndex(ph, input_height, output_height);
                 hend = AdaptEndIndex(ph, input_height, output_height);
               }
 
-              for (int64_t pw = 0; pw < output_width; ++pw) {
-                int64_t pool_size = 1;
+              for (int pw = 0; pw < output_width; ++pw) {
+                int pool_size = 1;
                 if (adaptive) {
                   wstart = AdaptStartIndex(pw, input_width, output_width);
                   wend = AdaptEndIndex(pw, input_width, output_width);
@@ -572,20 +554,19 @@ class Pool3dFunctor<CPUContext, PoolProcess, T> {
 
                   pool_size =
                       (dend - dstart) * (hend - hstart) * (wend - wstart);
-                  dstart = std::max(dstart, static_cast<int64_t>(0));
-                  hstart = std::max(hstart, static_cast<int64_t>(0));
-                  wstart = std::max(wstart, static_cast<int64_t>(0));
+                  dstart = std::max(dstart, 0);
+                  hstart = std::max(hstart, 0);
+                  wstart = std::max(wstart, 0);
                   dend = std::min(dend, input_depth);
                   hend = std::min(hend, input_height);
                   wend = std::min(wend, input_width);
                 }
 
-                int64_t output_idx =
-                    (pd * output_height + ph) * output_width + pw;
+                int output_idx = (pd * output_height + ph) * output_width + pw;
                 T ele = pool_process.initial();
-                for (int64_t d = dstart; d < dend; ++d) {
-                  for (int64_t h = hstart; h < hend; ++h) {
-                    for (int64_t w = wstart; w < wend; ++w) {
+                for (int d = dstart; d < dend; ++d) {
+                  for (int h = hstart; h < hend; ++h) {
+                    for (int w = wstart; w < wend; ++w) {
                       pool_process.compute(
                           input_data[(d * input_height + h) * input_width + w],
                           &ele);
@@ -606,26 +587,26 @@ class Pool3dFunctor<CPUContext, PoolProcess, T> {
         }
       }
     } else {
-      const int64_t input_stride =
+      const int input_stride =
           input_depth * input_height * input_width * input_channels;
-      const int64_t output_stride =
+      const int output_stride =
           output_depth * output_height * output_width * output_channels;
-      for (int64_t i = 0; i < batch_size; i++) {
-        for (int64_t c = 0; c < output_channels; ++c) {
-          for (int64_t pd = 0; pd < output_depth; ++pd) {
+      for (int i = 0; i < batch_size; i++) {
+        for (int c = 0; c < output_channels; ++c) {
+          for (int pd = 0; pd < output_depth; ++pd) {
             if (adaptive) {
               dstart = AdaptStartIndex(pd, input_depth, output_depth);
               dend = AdaptEndIndex(pd, input_depth, output_depth);
             }
 
-            for (int64_t ph = 0; ph < output_height; ++ph) {
+            for (int ph = 0; ph < output_height; ++ph) {
               if (adaptive) {
                 hstart = AdaptStartIndex(ph, input_height, output_height);
                 hend = AdaptEndIndex(ph, input_height, output_height);
               }
 
-              for (int64_t pw = 0; pw < output_width; ++pw) {
-                int64_t pool_size = 1;
+              for (int pw = 0; pw < output_width; ++pw) {
+                int pool_size = 1;
                 if (adaptive) {
                   wstart = AdaptStartIndex(pw, input_width, output_width);
                   wend = AdaptEndIndex(pw, input_width, output_width);
@@ -642,19 +623,19 @@ class Pool3dFunctor<CPUContext, PoolProcess, T> {
 
                   pool_size =
                       (dend - dstart) * (hend - hstart) * (wend - wstart);
-                  dstart = std::max(dstart, static_cast<int64_t>(0));
-                  hstart = std::max(hstart, static_cast<int64_t>(0));
-                  wstart = std::max(wstart, static_cast<int64_t>(0));
+                  dstart = std::max(dstart, 0);
+                  hstart = std::max(hstart, 0);
+                  wstart = std::max(wstart, 0);
                   dend = std::min(dend, input_depth);
                   hend = std::min(hend, input_height);
                   wend = std::min(wend, input_width);
                 }
 
                 T ele = pool_process.initial();
-                for (int64_t d = dstart; d < dend; ++d) {
-                  for (int64_t h = hstart; h < hend; ++h) {
-                    for (int64_t w = wstart; w < wend; ++w) {
-                      int64_t input_idx =
+                for (int d = dstart; d < dend; ++d) {
+                  for (int h = hstart; h < hend; ++h) {
+                    for (int w = wstart; w < wend; ++w) {
+                      int input_idx =
                           ((d * input_height + h) * input_width + w) *
                               input_channels +
                           c;
@@ -667,7 +648,7 @@ class Pool3dFunctor<CPUContext, PoolProcess, T> {
                       (dend - dstart) * (hend - hstart) * (wend - wstart);
                 }
                 pool_process.finalize(static_cast<T>(pool_size), &ele);
-                int64_t output_idx =
+                int output_idx =
                     ((pd * output_height + ph) * output_width + pw) *
                         output_channels +
                     c;
@@ -708,64 +689,58 @@ class Pool3dGradFunctor<CPUContext, PoolProcess, T> {
                   PoolProcess pool_grad_process) {
     bool channel_last = (data_format == "NDHWC");
 
-    const int64_t batch_size = input.dims()[0];
-    const int64_t input_channels =
-        channel_last ? input.dims()[4] : input.dims()[1];
-    const int64_t input_depth =
-        channel_last ? input.dims()[1] : input.dims()[2];
-    const int64_t input_height =
-        channel_last ? input.dims()[2] : input.dims()[3];
-    const int64_t input_width =
-        channel_last ? input.dims()[3] : input.dims()[4];
+    const int batch_size = input.dims()[0];
+    const int input_channels = channel_last ? input.dims()[4] : input.dims()[1];
+    const int input_depth = channel_last ? input.dims()[1] : input.dims()[2];
+    const int input_height = channel_last ? input.dims()[2] : input.dims()[3];
+    const int input_width = channel_last ? input.dims()[3] : input.dims()[4];
 
-    const int64_t output_channels =
+    const int output_channels =
         channel_last ? output.dims()[4] : output.dims()[1];
-    const int64_t output_depth =
-        channel_last ? output.dims()[1] : output.dims()[2];
-    const int64_t output_height =
+    const int output_depth = channel_last ? output.dims()[1] : output.dims()[2];
+    const int output_height =
         channel_last ? output.dims()[2] : output.dims()[3];
-    const int64_t output_width =
-        channel_last ? output.dims()[3] : output.dims()[4];
+    const int output_width = channel_last ? output.dims()[3] : output.dims()[4];
 
-    const int64_t ksize_depth = ksize[0];
-    const int64_t ksize_height = ksize[1];
-    const int64_t ksize_width = ksize[2];
+    const int ksize_depth = ksize[0];
+    const int ksize_height = ksize[1];
+    const int ksize_width = ksize[2];
 
-    const int64_t stride_depth = strides[0];
-    const int64_t stride_height = strides[1];
-    const int64_t stride_width = strides[2];
+    const int stride_depth = strides[0];
+    const int stride_height = strides[1];
+    const int stride_width = strides[2];
 
-    const int64_t padding_depth = paddings[0];
-    const int64_t padding_height = paddings[1];
-    const int64_t padding_width = paddings[2];
+    const int padding_depth = paddings[0];
+    const int padding_height = paddings[1];
+    const int padding_width = paddings[2];
 
     const T* input_data = input.data<T>();
     const T* output_data = output.data<T>();
     const T* output_grad_data = output_grad.data<T>();
     T* input_grad_data = context.template Alloc<T>(input_grad);
 
-    int64_t dstart = 0, dend = 1;
-    int64_t hstart = 0, hend = 1;
-    int64_t wstart = 0, wend = 1;
+    int dstart = 0, dend = 1;
+    int hstart = 0, hend = 1;
+    int wstart = 0, wend = 1;
     if (!channel_last) {
-      const int64_t input_stride = input_depth * input_height * input_width;
-      const int64_t output_stride = output_depth * output_height * output_width;
-      for (int64_t i = 0; i < batch_size; i++) {
-        for (int64_t c = 0; c < output_channels; ++c) {
-          for (int64_t pd = 0; pd < output_depth; ++pd) {
+      const int input_stride = input_depth * input_height * input_width;
+      const int output_stride = output_depth * output_height * output_width;
+      for (int i = 0; i < batch_size; i++) {
+        for (int c = 0; c < output_channels; ++c) {
+          for (int pd = 0; pd < output_depth; ++pd) {
             if (adaptive) {
               dstart = AdaptStartIndex(pd, input_depth, output_depth);
               dend = AdaptEndIndex(pd, input_depth, output_depth);
             }
 
-            for (int64_t ph = 0; ph < output_height; ++ph) {
+            for (int ph = 0; ph < output_height; ++ph) {
               if (adaptive) {
                 hstart = AdaptStartIndex(ph, input_height, output_height);
                 hend = AdaptEndIndex(ph, input_height, output_height);
               }
 
-              for (int64_t pw = 0; pw < output_width; ++pw) {
-                int64_t pool_size = 1;
+              for (int pw = 0; pw < output_width; ++pw) {
+                int pool_size = 1;
                 if (adaptive) {
                   wstart = AdaptStartIndex(pw, input_width, output_width);
                   wend = AdaptEndIndex(pw, input_width, output_width);
@@ -782,9 +757,9 @@ class Pool3dGradFunctor<CPUContext, PoolProcess, T> {
 
                   pool_size =
                       (dend - dstart) * (hend - hstart) * (wend - wstart);
-                  dstart = std::max(dstart, static_cast<int64_t>(0));
-                  hstart = std::max(hstart, static_cast<int64_t>(0));
-                  wstart = std::max(wstart, static_cast<int64_t>(0));
+                  dstart = std::max(dstart, 0);
+                  hstart = std::max(hstart, 0);
+                  wstart = std::max(wstart, 0);
                   dend = std::min(dend, input_depth);
                   hend = std::min(hend, input_height);
                   wend = std::min(wend, input_width);
@@ -795,12 +770,11 @@ class Pool3dGradFunctor<CPUContext, PoolProcess, T> {
                       (dend - dstart) * (hend - hstart) * (wend - wstart);
                 }
                 float scale = 1.0f / static_cast<float>(pool_size);
-                for (int64_t d = dstart; d < dend; ++d) {
-                  for (int64_t h = hstart; h < hend; ++h) {
-                    for (int64_t w = wstart; w < wend; ++w) {
-                      int64_t input_idx =
-                          (d * input_height + h) * input_width + w;
-                      int64_t output_idx =
+                for (int d = dstart; d < dend; ++d) {
+                  for (int h = hstart; h < hend; ++h) {
+                    for (int w = wstart; w < wend; ++w) {
+                      int input_idx = (d * input_height + h) * input_width + w;
+                      int output_idx =
                           (pd * output_height + ph) * output_width + pw;
                       pool_grad_process.compute(input_data[input_idx],
                                                 output_data[output_idx],
@@ -820,26 +794,26 @@ class Pool3dGradFunctor<CPUContext, PoolProcess, T> {
         }
       }
     } else {
-      const int64_t input_stride =
+      const int input_stride =
           input_depth * input_height * input_width * input_channels;
-      const int64_t output_stride =
+      const int output_stride =
           output_depth * output_height * output_width * output_channels;
-      for (int64_t i = 0; i < batch_size; i++) {
-        for (int64_t c = 0; c < output_channels; ++c) {
-          for (int64_t pd = 0; pd < output_depth; ++pd) {
+      for (int i = 0; i < batch_size; i++) {
+        for (int c = 0; c < output_channels; ++c) {
+          for (int pd = 0; pd < output_depth; ++pd) {
             if (adaptive) {
               dstart = AdaptStartIndex(pd, input_depth, output_depth);
               dend = AdaptEndIndex(pd, input_depth, output_depth);
             }
 
-            for (int64_t ph = 0; ph < output_height; ++ph) {
+            for (int ph = 0; ph < output_height; ++ph) {
               if (adaptive) {
                 hstart = AdaptStartIndex(ph, input_height, output_height);
                 hend = AdaptEndIndex(ph, input_height, output_height);
               }
 
-              for (int64_t pw = 0; pw < output_width; ++pw) {
-                int64_t pool_size = 1;
+              for (int pw = 0; pw < output_width; ++pw) {
+                int pool_size = 1;
                 if (adaptive) {
                   wstart = AdaptStartIndex(pw, input_width, output_width);
                   wend = AdaptEndIndex(pw, input_width, output_width);
@@ -856,9 +830,9 @@ class Pool3dGradFunctor<CPUContext, PoolProcess, T> {
 
                   pool_size =
                       (dend - dstart) * (hend - hstart) * (wend - wstart);
-                  dstart = std::max(dstart, static_cast<int64_t>(0));
-                  hstart = std::max(hstart, static_cast<int64_t>(0));
-                  wstart = std::max(wstart, static_cast<int64_t>(0));
+                  dstart = std::max(dstart, 0);
+                  hstart = std::max(hstart, 0);
+                  wstart = std::max(wstart, 0);
                   dend = std::min(dend, input_depth);
                   hend = std::min(hend, input_height);
                   wend = std::min(wend, input_width);
@@ -869,14 +843,14 @@ class Pool3dGradFunctor<CPUContext, PoolProcess, T> {
                       (dend - dstart) * (hend - hstart) * (wend - wstart);
                 }
                 float scale = 1.0f / static_cast<float>(pool_size);
-                for (int64_t d = dstart; d < dend; ++d) {
-                  for (int64_t h = hstart; h < hend; ++h) {
-                    for (int64_t w = wstart; w < wend; ++w) {
-                      int64_t input_idx =
+                for (int d = dstart; d < dend; ++d) {
+                  for (int h = hstart; h < hend; ++h) {
+                    for (int w = wstart; w < wend; ++w) {
+                      int input_idx =
                           ((d * input_height + h) * input_width + w) *
                               input_channels +
                           c;
-                      int64_t output_idx =
+                      int output_idx =
                           ((pd * output_height + ph) * output_width + pw) *
                               output_channels +
                           c;
@@ -922,37 +896,31 @@ class MaxPool3dGradFunctor<CPUContext, T> {
                   const std::string data_format,
                   DenseTensor* input_grad) {
     bool channel_last = (data_format == "NDHWC");
-    const int64_t batch_size = input.dims()[0];
+    const int batch_size = input.dims()[0];
 
-    const int64_t input_channels =
-        channel_last ? input.dims()[4] : input.dims()[1];
-    const int64_t input_depth =
-        channel_last ? input.dims()[1] : input.dims()[2];
-    const int64_t input_height =
-        channel_last ? input.dims()[2] : input.dims()[3];
-    const int64_t input_width =
-        channel_last ? input.dims()[3] : input.dims()[4];
+    const int input_channels = channel_last ? input.dims()[4] : input.dims()[1];
+    const int input_depth = channel_last ? input.dims()[1] : input.dims()[2];
+    const int input_height = channel_last ? input.dims()[2] : input.dims()[3];
+    const int input_width = channel_last ? input.dims()[3] : input.dims()[4];
 
-    const int64_t output_channels =
+    const int output_channels =
         channel_last ? output.dims()[4] : output.dims()[1];
-    const int64_t output_depth =
-        channel_last ? output.dims()[1] : output.dims()[2];
-    const int64_t output_height =
+    const int output_depth = channel_last ? output.dims()[1] : output.dims()[2];
+    const int output_height =
         channel_last ? output.dims()[2] : output.dims()[3];
-    const int64_t output_width =
-        channel_last ? output.dims()[3] : output.dims()[4];
+    const int output_width = channel_last ? output.dims()[3] : output.dims()[4];
 
-    const int64_t ksize_depth = ksize[0];
-    const int64_t ksize_height = ksize[1];
-    const int64_t ksize_width = ksize[2];
+    const int ksize_depth = ksize[0];
+    const int ksize_height = ksize[1];
+    const int ksize_width = ksize[2];
 
-    const int64_t stride_depth = strides[0];
-    const int64_t stride_height = strides[1];
-    const int64_t stride_width = strides[2];
+    const int stride_depth = strides[0];
+    const int stride_height = strides[1];
+    const int stride_width = strides[2];
 
-    const int64_t padding_depth = paddings[0];
-    const int64_t padding_height = paddings[1];
-    const int64_t padding_width = paddings[2];
+    const int padding_depth = paddings[0];
+    const int padding_height = paddings[1];
+    const int padding_width = paddings[2];
 
     const T* input_data = input.data<T>();
     const T* output_data = output.data<T>();
@@ -960,29 +928,28 @@ class MaxPool3dGradFunctor<CPUContext, T> {
     T* input_grad_data = context.template Alloc<T>(input_grad);
 
     if (!channel_last) {
-      const int64_t input_stride = input_depth * input_height * input_width;
-      const int64_t output_stride = output_depth * output_height * output_width;
-      for (int64_t i = 0; i < batch_size; i++) {
-        for (int64_t c = 0; c < output_channels; ++c) {
-          for (int64_t pd = 0; pd < output_depth; ++pd) {
-            int64_t dstart = pd * stride_depth - padding_depth;
-            int64_t dend = std::min(dstart + ksize_depth, input_depth);
-            dstart = std::max(dstart, static_cast<int64_t>(0));
-            for (int64_t ph = 0; ph < output_height; ++ph) {
-              int64_t hstart = ph * stride_height - padding_height;
-              int64_t hend = std::min(hstart + ksize_height, input_height);
-              hstart = std::max(hstart, static_cast<int64_t>(0));
-              for (int64_t pw = 0; pw < output_width; ++pw) {
-                int64_t wstart = pw * stride_width - padding_width;
-                int64_t wend = std::min(wstart + ksize_width, input_width);
-                wstart = std::max(wstart, static_cast<int64_t>(0));
+      const int input_stride = input_depth * input_height * input_width;
+      const int output_stride = output_depth * output_height * output_width;
+      for (int i = 0; i < batch_size; i++) {
+        for (int c = 0; c < output_channels; ++c) {
+          for (int pd = 0; pd < output_depth; ++pd) {
+            int dstart = pd * stride_depth - padding_depth;
+            int dend = std::min(dstart + ksize_depth, input_depth);
+            dstart = std::max(dstart, 0);
+            for (int ph = 0; ph < output_height; ++ph) {
+              int hstart = ph * stride_height - padding_height;
+              int hend = std::min(hstart + ksize_height, input_height);
+              hstart = std::max(hstart, 0);
+              for (int pw = 0; pw < output_width; ++pw) {
+                int wstart = pw * stride_width - padding_width;
+                int wend = std::min(wstart + ksize_width, input_width);
+                wstart = std::max(wstart, 0);
                 bool stop = false;
-                for (int64_t d = dstart; d < dend && !stop; ++d) {
-                  for (int64_t h = hstart; h < hend && !stop; ++h) {
-                    for (int64_t w = wstart; w < wend && !stop; ++w) {
-                      int64_t input_idx =
-                          (d * input_height + h) * input_width + w;
-                      int64_t output_idx =
+                for (int d = dstart; d < dend && !stop; ++d) {
+                  for (int h = hstart; h < hend && !stop; ++h) {
+                    for (int w = wstart; w < wend && !stop; ++w) {
+                      int input_idx = (d * input_height + h) * input_width + w;
+                      int output_idx =
                           (pd * output_height + ph) * output_width + pw;
 
                       if (input_data[input_idx] == output_data[output_idx]) {
@@ -1003,34 +970,34 @@ class MaxPool3dGradFunctor<CPUContext, T> {
         }
       }
     } else {
-      const int64_t input_stride =
+      const int input_stride =
           input_depth * input_height * input_width * input_channels;
-      const int64_t output_stride =
+      const int output_stride =
           output_depth * output_height * output_width * output_channels;
-      for (int64_t i = 0; i < batch_size; i++) {
-        for (int64_t c = 0; c < output_channels; ++c) {
-          for (int64_t pd = 0; pd < output_depth; ++pd) {
-            int64_t dstart = pd * stride_depth - padding_depth;
-            int64_t dend = std::min(dstart + ksize_depth, input_depth);
-            dstart = std::max(dstart, static_cast<int64_t>(0));
-            for (int64_t ph = 0; ph < output_height; ++ph) {
-              int64_t hstart = ph * stride_height - padding_height;
-              int64_t hend = std::min(hstart + ksize_height, input_height);
-              hstart = std::max(hstart, static_cast<int64_t>(0));
-              for (int64_t pw = 0; pw < output_width; ++pw) {
-                int64_t wstart = pw * stride_width - padding_width;
-                int64_t wend = std::min(wstart + ksize_width, input_width);
-                wstart = std::max(wstart, static_cast<int64_t>(0));
+      for (int i = 0; i < batch_size; i++) {
+        for (int c = 0; c < output_channels; ++c) {
+          for (int pd = 0; pd < output_depth; ++pd) {
+            int dstart = pd * stride_depth - padding_depth;
+            int dend = std::min(dstart + ksize_depth, input_depth);
+            dstart = std::max(dstart, 0);
+            for (int ph = 0; ph < output_height; ++ph) {
+              int hstart = ph * stride_height - padding_height;
+              int hend = std::min(hstart + ksize_height, input_height);
+              hstart = std::max(hstart, 0);
+              for (int pw = 0; pw < output_width; ++pw) {
+                int wstart = pw * stride_width - padding_width;
+                int wend = std::min(wstart + ksize_width, input_width);
+                wstart = std::max(wstart, 0);
                 bool stop = false;
 
-                for (int64_t d = dstart; d < dend && !stop; ++d) {
-                  for (int64_t h = hstart; h < hend && !stop; ++h) {
-                    for (int64_t w = wstart; w < wend && !stop; ++w) {
-                      int64_t input_idx =
+                for (int d = dstart; d < dend && !stop; ++d) {
+                  for (int h = hstart; h < hend && !stop; ++h) {
+                    for (int w = wstart; w < wend && !stop; ++w) {
+                      int input_idx =
                           ((d * input_height + h) * input_width + w) *
                               input_channels +
                           c;
-                      int64_t output_idx =
+                      int output_idx =
                           ((pd * output_height + ph) * output_width + pw) *
                               output_channels +
                           c;

--- a/paddle/phi/kernels/funcs/pooling.cu
+++ b/paddle/phi/kernels/funcs/pooling.cu
@@ -656,7 +656,7 @@ class Pool2dFunctor<phi::GPUContext, PoolProcess, T> {
 #ifdef WITH_NV_JETSON
       backends::gpu::ChangeThreadNum(context, &thread_num);
 #endif
-      uint blocks = (nthreads + thread_num - 1) / thread_num;
+      int64_t blocks = (nthreads + thread_num - 1) / thread_num;
       dim3 threads(thread_num, 1);
       dim3 grid(blocks, 1);
       if (input.numel() <= std::numeric_limits<int>::max()) {
@@ -885,7 +885,7 @@ class MaxPool2dGradFunctor<phi::GPUContext, T> {
 
     int64_t nthreads =
         batch_size * output_channels * output_height * output_width;
-    uint blocks = (nthreads + 1024 - 1) / 1024;
+    int64_t blocks = (nthreads + 1024 - 1) / 1024;
     dim3 threads(1024, 1);
     dim3 grid(blocks, 1);
 
@@ -1450,7 +1450,7 @@ class Pool3dFunctor<phi::GPUContext, PoolProcess, T> {
 #ifdef WITH_NV_JETSON
     backends::gpu::ChangeThreadNum(context, &thread_num);
 #endif
-    uint blocks = (nthreads + thread_num - 1) / thread_num;
+    int64_t blocks = (nthreads + thread_num - 1) / thread_num;
     dim3 threads(thread_num, 1);
     dim3 grid(blocks, 1);
 
@@ -1571,7 +1571,7 @@ class Pool3dGradFunctor<phi::GPUContext, PoolProcess, T> {
 
     int64_t nthreads =
         batch_size * input_channels * input_depth * input_height * input_width;
-    uint blocks = (nthreads + 1024 - 1) / 1024;
+    int64_t blocks = (nthreads + 1024 - 1) / 1024;
     dim3 threads(1024, 1);
     dim3 grid(blocks, 1);
 
@@ -1696,7 +1696,7 @@ class MaxPool3dGradFunctor<phi::GPUContext, T> {
 
     int64_t nthreads = batch_size * output_channels * output_depth *
                        output_height * output_width;
-    uint blocks = (nthreads + 1024 - 1) / 1024;
+    int64_t blocks = (nthreads + 1024 - 1) / 1024;
     dim3 threads(1024, 1);
     dim3 grid(blocks, 1);
     if (input.numel() <= std::numeric_limits<int>::max() &&

--- a/paddle/phi/kernels/funcs/pooling.cu
+++ b/paddle/phi/kernels/funcs/pooling.cu
@@ -123,32 +123,32 @@ __device__ void OffsetPreparationFor4Dimension(IndexT index,
   }
 }
 
-template <typename PoolProcess, typename T>
-__global__ void KernelPool2D(const int64_t nthreads,
+template <typename PoolProcess, typename T, typename IndexT>
+__global__ void KernelPool2D(const IndexT nthreads,
                              const T* input_data,
-                             const int64_t channels,
-                             const int64_t input_height,
-                             const int64_t input_width,
-                             const int64_t output_height,
-                             const int64_t output_width,
-                             const int64_t ksize_height,
-                             const int64_t ksize_width,
-                             const int64_t stride_height,
-                             const int64_t stride_width,
-                             const int64_t padding_height,
-                             const int64_t padding_width,
-                             FastDivModForPooling<int64_t> divmods,
+                             const IndexT channels,
+                             const IndexT input_height,
+                             const IndexT input_width,
+                             const IndexT output_height,
+                             const IndexT output_width,
+                             const IndexT ksize_height,
+                             const IndexT ksize_width,
+                             const IndexT stride_height,
+                             const IndexT stride_width,
+                             const IndexT padding_height,
+                             const IndexT padding_width,
+                             FastDivModForPooling<IndexT> divmods,
                              PoolProcess pool_process,
                              bool exclusive,
                              T* output_data,
                              bool channel_last = false) {
-  const int64_t start_index =
-      static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
-  const int64_t step = static_cast<int64_t>(blockDim.x) * gridDim.x;
-  for (int64_t index = start_index; index < nthreads; index += step) {
-    int64_t hstart, hend, wstart, wend;
-    int64_t w_offset, h_offset, c_offset, input_offset;
-    OffsetPreparationFor4Dimension<FastDivModForPooling<int64_t>, int64_t>(
+  const IndexT start_index =
+      static_cast<IndexT>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const IndexT step = static_cast<IndexT>(blockDim.x) * gridDim.x;
+  for (IndexT index = start_index; index < nthreads; index += step) {
+    IndexT hstart, hend, wstart, wend;
+    IndexT w_offset, h_offset, c_offset, input_offset;
+    OffsetPreparationFor4Dimension<FastDivModForPooling<IndexT>, IndexT>(
         index,
         channel_last,
         divmods,
@@ -164,83 +164,82 @@ __global__ void KernelPool2D(const int64_t nthreads,
 
     hstart = h_offset * stride_height - padding_height;
     hend = min(hstart + ksize_height, input_height);
-    hstart = max(hstart, static_cast<int64_t>(0));
+    hstart = max(hstart, static_cast<IndexT>(0));
     wstart = w_offset * stride_width - padding_width;
     wend = min(wstart + ksize_width, input_width);
-    wstart = max(wstart, static_cast<int64_t>(0));
+    wstart = max(wstart, static_cast<IndexT>(0));
 
     T ele = pool_process.initial();
-    for (int64_t h = hstart; h < hend; ++h) {
-      for (int64_t w = wstart; w < wend; ++w) {
+    for (IndexT h = hstart; h < hend; ++h) {
+      for (IndexT w = wstart; w < wend; ++w) {
         auto input_idx = channel_last
                              ? (h * input_width + w) * channels + c_offset
                              : h * input_width + w;
         pool_process.compute(input_data[input_idx], &ele);
       }
     }
-    int64_t pool_size = exclusive ? (hend - hstart) * (wend - wstart)
-                                  : ksize_height * ksize_width;
+    IndexT pool_size = exclusive ? (hend - hstart) * (wend - wstart)
+                                 : ksize_height * ksize_width;
     pool_process.finalize(static_cast<T>(pool_size), &ele);
     output_data[index] = ele;
   }
 }
 
-template <typename PoolProcess, typename T>
-__global__ void AdaptiveKernelPool2D(const int64_t nthreads,
+template <typename PoolProcess, typename T, typename IndexT>
+__global__ void AdaptiveKernelPool2D(const IndexT nthreads,
                                      const T* input_data,
-                                     const int64_t channels,
-                                     const int64_t input_height,
-                                     const int64_t input_width,
-                                     const int64_t output_height,
-                                     const int64_t output_width,
-                                     const int64_t ksize_height,
-                                     const int64_t ksize_width,
-                                     const int64_t stride_height,
-                                     const int64_t stride_width,
-                                     const int64_t padding_height,
-                                     const int64_t padding_width,
-                                     FastDivModForPooling<int64_t> divmods,
+                                     const IndexT channels,
+                                     const IndexT input_height,
+                                     const IndexT input_width,
+                                     const IndexT output_height,
+                                     const IndexT output_width,
+                                     const IndexT ksize_height,
+                                     const IndexT ksize_width,
+                                     const IndexT stride_height,
+                                     const IndexT stride_width,
+                                     const IndexT padding_height,
+                                     const IndexT padding_width,
+                                     FastDivModForPooling<IndexT> divmods,
                                      PoolProcess pool_process,
                                      bool exclusive,
                                      T* output_data,
                                      bool channel_last = false) {
-  const int64_t n_offset = blockIdx.y;
-  const int64_t c_offset =
-      static_cast<int64_t>(blockIdx.x) * blockDim.y + threadIdx.y;
+  const IndexT n_offset = blockIdx.y;
+  const IndexT c_offset =
+      static_cast<IndexT>(blockIdx.x) * blockDim.y + threadIdx.y;
   if (c_offset >= channels) {
     return;
   }
-  int64_t hstart, hend, wstart, wend;
-  int64_t input_offset =
+  IndexT hstart, hend, wstart, wend;
+  IndexT input_offset =
       channel_last
           ? n_offset * input_height * input_width * channels
           : (n_offset * channels + c_offset) * input_height * input_width;
-  int64_t output_offset =
+  IndexT output_offset =
       channel_last
           ? n_offset * output_height * output_width * channels
           : (n_offset * channels + c_offset) * output_height * output_width;
-  for (int64_t hw_offset = threadIdx.x;
-       hw_offset < output_height * output_width;
+  for (IndexT hw_offset = threadIdx.x; hw_offset < output_height * output_width;
        hw_offset += blockDim.x) {
-    int64_t w_offset = hw_offset % output_width;
-    int64_t h_offset = hw_offset / output_width;
+    IndexT w_offset = hw_offset % output_width;
+    IndexT h_offset = hw_offset / output_width;
     hstart = AdaptStartIndex(h_offset, input_height, output_height);
     hend = AdaptEndIndex(h_offset, input_height, output_height);
     wstart = AdaptStartIndex(w_offset, input_width, output_width);
     wend = AdaptEndIndex(w_offset, input_width, output_width);
 
     T ele = pool_process.initial();
-    for (int64_t h = hstart; h < hend; ++h) {
-      for (int64_t w = wstart; w < wend; ++w) {
+    for (IndexT h = hstart; h < hend; ++h) {
+      for (IndexT w = wstart; w < wend; ++w) {
         auto input_idx = channel_last
                              ? (h * input_width + w) * channels + c_offset
                              : h * input_width + w;
         pool_process.compute(input_data[input_offset + input_idx], &ele);
       }
     }
-    int64_t pool_size = (hend - hstart) * (wend - wstart);
+    IndexT pool_size = (hend - hstart) * (wend - wstart);
     pool_process.finalize(static_cast<T>(pool_size), &ele);
-    int64_t output_idx =
+    IndexT output_idx =
         channel_last
             ? (h_offset * output_width + w_offset) * channels + c_offset
             : h_offset * output_width + w_offset;
@@ -248,51 +247,51 @@ __global__ void AdaptiveKernelPool2D(const int64_t nthreads,
   }
 }
 
-template <typename T, typename PoolProcess>
+template <typename T, typename PoolProcess, typename IndexT>
 __global__ void KernelPool2DGrad(
-    const int64_t nthreads,
+    const IndexT nthreads,
     const T* __restrict__ input_data,
     const T* __restrict__ output_data,
     const T* __restrict__ output_grad,
-    const int64_t output_width,
-    const int64_t output_height,
-    const int64_t input_width,
-    const int64_t input_height,
-    const int64_t ksize_width,
-    const int64_t ksize_height,
-    const int64_t stride_width,
-    const int64_t stride_height,
-    const int64_t padding_width,
-    const int64_t padding_height,
-    FastDivModForPoolingWithMoreStaff<int64_t> divmods,
+    const IndexT output_width,
+    const IndexT output_height,
+    const IndexT input_width,
+    const IndexT input_height,
+    const IndexT ksize_width,
+    const IndexT ksize_height,
+    const IndexT stride_width,
+    const IndexT stride_height,
+    const IndexT padding_width,
+    const IndexT padding_height,
+    FastDivModForPoolingWithMoreStaff<IndexT> divmods,
     PoolProcess pool_process,
     bool exclusive,
     bool adaptive,
     T* __restrict__ input_grad,
     bool channel_last = false) {
-  const int64_t start_index =
-      static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const IndexT start_index =
+      static_cast<IndexT>(blockIdx.x) * blockDim.x + threadIdx.x;
 
-  for (int64_t index =
-           static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  for (IndexT index =
+           static_cast<IndexT>(blockIdx.x) * blockDim.x + threadIdx.x;
        index < nthreads;
-       index += static_cast<int64_t>(blockDim.x) * gridDim.x) {
+       index += static_cast<IndexT>(blockDim.x) * gridDim.x) {
     T input = static_cast<T>(0);
     T input_grad_data = static_cast<T>(0);
-    int64_t phstart, phend, pwstart, pwend;
-    int64_t w_offset, h_offset, c_offset, output_offset;
-    OffsetPreparationFor4Dimension<FastDivModForPoolingWithMoreStaff<int64_t>,
-                                   int64_t>(index,
-                                            channel_last,
-                                            divmods,
-                                            padding_width,
-                                            padding_height,
-                                            output_width,
-                                            output_height,
-                                            &w_offset,
-                                            &h_offset,
-                                            &c_offset,
-                                            &output_offset);
+    IndexT phstart, phend, pwstart, pwend;
+    IndexT w_offset, h_offset, c_offset, output_offset;
+    OffsetPreparationFor4Dimension<FastDivModForPoolingWithMoreStaff<IndexT>,
+                                   IndexT>(index,
+                                           channel_last,
+                                           divmods,
+                                           padding_width,
+                                           padding_height,
+                                           output_width,
+                                           output_height,
+                                           &w_offset,
+                                           &h_offset,
+                                           &c_offset,
+                                           &output_offset);
     if (pool_process.use_x) {
       input = input_data[index];
       output_data += output_offset;
@@ -307,8 +306,8 @@ __global__ void KernelPool2DGrad(
       phend = tmp_phend.val[1] > 0 ? tmp_phend.val[0] + 1 : tmp_phend.val[0];
       pwend = tmp_pwend.val[1] > 0 ? tmp_pwend.val[0] + 1 : tmp_pwend.val[0];
 
-      for (int64_t ph = phstart; ph < phend; ++ph) {
-        for (int64_t pw = pwstart; pw < pwend; ++pw) {
+      for (IndexT ph = phstart; ph < phend; ++ph) {
+        for (IndexT pw = pwstart; pw < pwend; ++pw) {
           auto ksize_w_divmod = divmods.ksize_w.Divmod(input_width);
           auto ksize_h_divmod = divmods.ksize_h.Divmod(input_height);
           auto tmp_width = ksize_w_divmod.val[1] > 0 ? ksize_w_divmod.val[0] + 1
@@ -316,9 +315,9 @@ __global__ void KernelPool2DGrad(
           auto tmp_height = ksize_h_divmod.val[1] > 0
                                 ? ksize_h_divmod.val[0] + 1
                                 : ksize_h_divmod.val[0];
-          int64_t pool_size = tmp_height * tmp_width;
-          int64_t tmp_idx = ph * output_width + pw;
-          int64_t output_sub_idx =
+          IndexT pool_size = tmp_height * tmp_width;
+          IndexT tmp_idx = ph * output_width + pw;
+          IndexT output_sub_idx =
               channel_last ? tmp_idx * divmods.channel.divisor + c_offset
                            : tmp_idx;
           T output_value = pool_process.use_x ? output_data[output_sub_idx]
@@ -339,17 +338,17 @@ __global__ void KernelPool2DGrad(
       pwend = min(divmods.stride_w.Div(w_offset) + 1, output_width);
 
       if (exclusive) {
-        for (int64_t ph = phstart; ph < phend; ++ph) {
-          for (int64_t pw = pwstart; pw < pwend; ++pw) {
-            int64_t hstart = ph * stride_height - padding_height;
-            int64_t wstart = pw * stride_width - padding_width;
-            int64_t hend = min(hstart + ksize_height, input_height);
-            int64_t wend = min(wstart + ksize_width, input_width);
-            hstart = max(hstart, static_cast<int64_t>(0));
-            wstart = max(wstart, static_cast<int64_t>(0));
-            int64_t pool_size = (hend - hstart) * (wend - wstart);
-            int64_t tmp_idx = ph * output_width + pw;
-            int64_t output_sub_idx =
+        for (IndexT ph = phstart; ph < phend; ++ph) {
+          for (IndexT pw = pwstart; pw < pwend; ++pw) {
+            IndexT hstart = ph * stride_height - padding_height;
+            IndexT wstart = pw * stride_width - padding_width;
+            IndexT hend = min(hstart + ksize_height, input_height);
+            IndexT wend = min(wstart + ksize_width, input_width);
+            hstart = max(hstart, static_cast<IndexT>(0));
+            wstart = max(wstart, static_cast<IndexT>(0));
+            IndexT pool_size = (hend - hstart) * (wend - wstart);
+            IndexT tmp_idx = ph * output_width + pw;
+            IndexT output_sub_idx =
                 channel_last ? tmp_idx * divmods.channel.divisor + c_offset
                              : tmp_idx;
             T output_value = pool_process.use_x ? output_data[output_sub_idx]
@@ -362,11 +361,11 @@ __global__ void KernelPool2DGrad(
           }
         }
       } else {
-        for (int64_t ph = phstart; ph < phend; ++ph) {
-          for (int64_t pw = pwstart; pw < pwend; ++pw) {
-            int64_t pool_size = ksize_height * ksize_width;
-            int64_t tmp_idx = ph * output_width + pw;
-            int64_t output_sub_idx =
+        for (IndexT ph = phstart; ph < phend; ++ph) {
+          for (IndexT pw = pwstart; pw < pwend; ++pw) {
+            IndexT pool_size = ksize_height * ksize_width;
+            IndexT tmp_idx = ph * output_width + pw;
+            IndexT output_sub_idx =
                 channel_last ? tmp_idx * divmods.channel.divisor + c_offset
                              : tmp_idx;
             T output_value = pool_process.use_x ? output_data[output_sub_idx]
@@ -384,31 +383,31 @@ __global__ void KernelPool2DGrad(
   }
 }
 
-template <typename T>
-__global__ void KernelMaxPool2DGrad(const int64_t nthreads,
+template <typename T, typename IndexT>
+__global__ void KernelMaxPool2DGrad(const IndexT nthreads,
                                     const T* input_data,
                                     const T* output_data,
                                     const T* output_grad,
-                                    const int64_t channels,
-                                    const int64_t input_height,
-                                    const int64_t input_width,
-                                    const int64_t output_height,
-                                    const int64_t output_width,
-                                    const int64_t ksize_height,
-                                    const int64_t ksize_width,
-                                    const int64_t stride_height,
-                                    const int64_t stride_width,
-                                    const int64_t padding_height,
-                                    const int64_t padding_width,
+                                    const IndexT channels,
+                                    const IndexT input_height,
+                                    const IndexT input_width,
+                                    const IndexT output_height,
+                                    const IndexT output_width,
+                                    const IndexT ksize_height,
+                                    const IndexT ksize_width,
+                                    const IndexT stride_height,
+                                    const IndexT stride_width,
+                                    const IndexT padding_height,
+                                    const IndexT padding_width,
                                     T* input_grad,
-                                    FastDivModForPooling<int64_t> divmods,
+                                    FastDivModForPooling<IndexT> divmods,
                                     bool channel_last = false) {
-  const int64_t start_index =
-      static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
-  const int64_t step = static_cast<int64_t>(blockDim.x) * gridDim.x;
-  for (int64_t index = start_index; index < nthreads; index += step) {
-    int64_t w_offset, h_offset, c_offset, input_offset;
-    OffsetPreparationFor4Dimension<FastDivModForPooling<int64_t>, int64_t>(
+  const IndexT start_index =
+      static_cast<IndexT>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const IndexT step = static_cast<IndexT>(blockDim.x) * gridDim.x;
+  for (IndexT index = start_index; index < nthreads; index += step) {
+    IndexT w_offset, h_offset, c_offset, input_offset;
+    OffsetPreparationFor4Dimension<FastDivModForPooling<IndexT>, IndexT>(
         index,
         channel_last,
         divmods,
@@ -423,20 +422,20 @@ __global__ void KernelMaxPool2DGrad(const int64_t nthreads,
     input_data += input_offset;
     input_grad += input_offset;
 
-    int64_t hstart = h_offset * stride_height - padding_height;
-    int64_t hend = min(hstart + ksize_height, input_height);
-    hstart = max(hstart, static_cast<int64_t>(0));
+    IndexT hstart = h_offset * stride_height - padding_height;
+    IndexT hend = min(hstart + ksize_height, input_height);
+    hstart = max(hstart, static_cast<IndexT>(0));
 
-    int64_t wstart = w_offset * stride_width - padding_width;
-    int64_t wend = min(wstart + ksize_width, input_width);
-    wstart = max(wstart, static_cast<int64_t>(0));
+    IndexT wstart = w_offset * stride_width - padding_width;
+    IndexT wend = min(wstart + ksize_width, input_width);
+    wstart = max(wstart, static_cast<IndexT>(0));
 
     T ele = output_data[index];
-    int64_t maxIndex = -1;
+    IndexT maxIndex = -1;
     bool stop = false;
-    for (int64_t h = hstart; h < hend && !stop; ++h) {
-      for (int64_t w = wstart; w < wend && !stop; ++w) {
-        int64_t input_data_idx =
+    for (IndexT h = hstart; h < hend && !stop; ++h) {
+      for (IndexT w = wstart; w < wend && !stop; ++w) {
+        IndexT input_data_idx =
             channel_last ? (h * input_width + w) * channels + c_offset
                          : h * input_width + w;
         if (ele == input_data[input_data_idx]) {
@@ -481,8 +480,8 @@ void Pool2dDirectCUDAFunctor<PoolProcess, T>::operator()(
   const int padding_width = paddings[1];
   int64_t nthreads = static_cast<int64_t>(batch_size) * output_channels *
                      output_height * output_width;
-  auto pool_divmods = FastDivModForPooling<int64_t>(
-      input_channels, output_width, output_height);
+  auto pool_divmods =
+      FastDivModForPooling<int>(input_channels, output_width, output_height);
   if (adaptive) {
     int64_t max_threads = 512;
     int64_t thread_num =
@@ -495,7 +494,7 @@ void Pool2dDirectCUDAFunctor<PoolProcess, T>::operator()(
                        static_cast<int64_t>(1)),
               batch_size,
               1);
-    AdaptiveKernelPool2D<PoolProcess, T>
+    AdaptiveKernelPool2D<PoolProcess, T, int>
         <<<grid, threads, 0, stream>>>(nthreads,
                                        input,
                                        input_channels,
@@ -523,23 +522,24 @@ void Pool2dDirectCUDAFunctor<PoolProcess, T>::operator()(
     int blocks = (nthreads + thread_num - 1) / thread_num;
     dim3 threads(thread_num, 1);
     dim3 grid(blocks, 1);
-    KernelPool2D<PoolProcess, T><<<grid, threads, 0, stream>>>(nthreads,
-                                                               input,
-                                                               input_channels,
-                                                               input_height,
-                                                               input_width,
-                                                               output_height,
-                                                               output_width,
-                                                               ksize_height,
-                                                               ksize_width,
-                                                               stride_height,
-                                                               stride_width,
-                                                               padding_height,
-                                                               padding_width,
-                                                               pool_divmods,
-                                                               pool_compute,
-                                                               exclusive,
-                                                               output);
+    KernelPool2D<PoolProcess, T, int>
+        <<<grid, threads, 0, stream>>>(nthreads,
+                                       input,
+                                       input_channels,
+                                       input_height,
+                                       input_width,
+                                       output_height,
+                                       output_width,
+                                       ksize_height,
+                                       ksize_width,
+                                       stride_height,
+                                       stride_width,
+                                       padding_height,
+                                       padding_width,
+                                       pool_divmods,
+                                       pool_compute,
+                                       exclusive,
+                                       output);
   }
 }
 
@@ -594,8 +594,6 @@ class Pool2dFunctor<phi::GPUContext, PoolProcess, T> {
 
     int64_t nthreads =
         batch_size * output_channels * output_height * output_width;
-    auto pool_divmods = FastDivModForPooling<int64_t>(
-        input_channels, output_width, output_height);
     if (adaptive) {
       int64_t max_threads = 512;
       int64_t thread_num = std::min(
@@ -608,25 +606,51 @@ class Pool2dFunctor<phi::GPUContext, PoolProcess, T> {
                          static_cast<int64_t>(1)),
                 batch_size,
                 1);
-      AdaptiveKernelPool2D<PoolProcess, T>
-          <<<grid, threads, 0, context.stream()>>>(nthreads,
-                                                   input_data,
-                                                   input_channels,
-                                                   input_height,
-                                                   input_width,
-                                                   output_height,
-                                                   output_width,
-                                                   ksize_height,
-                                                   ksize_width,
-                                                   stride_height,
-                                                   stride_width,
-                                                   padding_height,
-                                                   padding_width,
-                                                   pool_divmods,
-                                                   pool_process,
-                                                   exclusive,
-                                                   output_data,
-                                                   channel_last);
+      if (input.numel() <= std::numeric_limits<int>::max()) {
+        auto pool_divmods = FastDivModForPooling<int>(
+            input_channels, output_width, output_height);
+        AdaptiveKernelPool2D<PoolProcess, T, int>
+            <<<grid, threads, 0, context.stream()>>>(nthreads,
+                                                     input_data,
+                                                     input_channels,
+                                                     input_height,
+                                                     input_width,
+                                                     output_height,
+                                                     output_width,
+                                                     ksize_height,
+                                                     ksize_width,
+                                                     stride_height,
+                                                     stride_width,
+                                                     padding_height,
+                                                     padding_width,
+                                                     pool_divmods,
+                                                     pool_process,
+                                                     exclusive,
+                                                     output_data,
+                                                     channel_last);
+      } else {
+        auto pool_divmods = FastDivModForPooling<int64_t>(
+            input_channels, output_width, output_height);
+        AdaptiveKernelPool2D<PoolProcess, T, int64_t>
+            <<<grid, threads, 0, context.stream()>>>(nthreads,
+                                                     input_data,
+                                                     input_channels,
+                                                     input_height,
+                                                     input_width,
+                                                     output_height,
+                                                     output_width,
+                                                     ksize_height,
+                                                     ksize_width,
+                                                     stride_height,
+                                                     stride_width,
+                                                     padding_height,
+                                                     padding_width,
+                                                     pool_divmods,
+                                                     pool_process,
+                                                     exclusive,
+                                                     output_data,
+                                                     channel_last);
+      }
     } else {
       int thread_num = 1024;
 #ifdef WITH_NV_JETSON
@@ -635,25 +659,51 @@ class Pool2dFunctor<phi::GPUContext, PoolProcess, T> {
       uint blocks = (nthreads + thread_num - 1) / thread_num;
       dim3 threads(thread_num, 1);
       dim3 grid(blocks, 1);
-      KernelPool2D<PoolProcess, T>
-          <<<grid, threads, 0, context.stream()>>>(nthreads,
-                                                   input_data,
-                                                   input_channels,
-                                                   input_height,
-                                                   input_width,
-                                                   output_height,
-                                                   output_width,
-                                                   ksize_height,
-                                                   ksize_width,
-                                                   stride_height,
-                                                   stride_width,
-                                                   padding_height,
-                                                   padding_width,
-                                                   pool_divmods,
-                                                   pool_process,
-                                                   exclusive,
-                                                   output_data,
-                                                   channel_last);
+      if (input.numel() <= std::numeric_limits<int>::max()) {
+        auto pool_divmods = FastDivModForPooling<int>(
+            input_channels, output_width, output_height);
+        KernelPool2D<PoolProcess, T, int>
+            <<<grid, threads, 0, context.stream()>>>(nthreads,
+                                                     input_data,
+                                                     input_channels,
+                                                     input_height,
+                                                     input_width,
+                                                     output_height,
+                                                     output_width,
+                                                     ksize_height,
+                                                     ksize_width,
+                                                     stride_height,
+                                                     stride_width,
+                                                     padding_height,
+                                                     padding_width,
+                                                     pool_divmods,
+                                                     pool_process,
+                                                     exclusive,
+                                                     output_data,
+                                                     channel_last);
+      } else {
+        auto pool_divmods = FastDivModForPooling<int64_t>(
+            input_channels, output_width, output_height);
+        KernelPool2D<PoolProcess, T, int64_t>
+            <<<grid, threads, 0, context.stream()>>>(nthreads,
+                                                     input_data,
+                                                     input_channels,
+                                                     input_height,
+                                                     input_width,
+                                                     output_height,
+                                                     output_width,
+                                                     ksize_height,
+                                                     ksize_width,
+                                                     stride_height,
+                                                     stride_width,
+                                                     padding_height,
+                                                     padding_width,
+                                                     pool_divmods,
+                                                     pool_process,
+                                                     exclusive,
+                                                     output_data,
+                                                     channel_last);
+      }
     }
   }
 };
@@ -711,38 +761,74 @@ class Pool2dGradFunctor<phi::GPUContext, PoolProcess, T> {
     T* input_grad_data = context.template Alloc<T>(input_grad);
 
     int64_t nthreads = batch_size * input_channels * input_height * input_width;
-    auto pool_divmods =
-        FastDivModForPoolingWithMoreStaff<int64_t>(input_channels,
-                                                   input_width,
-                                                   input_height,
-                                                   ksize_width,
-                                                   ksize_height,
-                                                   stride_width,
-                                                   stride_height);
     auto config = phi::backends::gpu::GetGpuLaunchConfig1D(context, nthreads);
-    KernelPool2DGrad<T, PoolProcess><<<config.block_per_grid,
-                                       config.thread_per_block,
-                                       0,
-                                       context.stream()>>>(nthreads,
-                                                           input_data,
-                                                           output_data,
-                                                           output_grad_data,
-                                                           output_width,
-                                                           output_height,
-                                                           input_width,
-                                                           input_height,
-                                                           ksize_width,
-                                                           ksize_height,
-                                                           stride_width,
-                                                           stride_height,
-                                                           padding_width,
-                                                           padding_height,
-                                                           pool_divmods,
-                                                           pool_process,
-                                                           exclusive,
-                                                           adaptive,
-                                                           input_grad_data,
-                                                           channel_last);
+    if (input.numel() <= std::numeric_limits<int>::max() &&
+        output.numel() <= std::numeric_limits<int>::max()) {
+      auto pool_divmods = FastDivModForPoolingWithMoreStaff<int>(input_channels,
+                                                                 input_width,
+                                                                 input_height,
+                                                                 ksize_width,
+                                                                 ksize_height,
+                                                                 stride_width,
+                                                                 stride_height);
+      KernelPool2DGrad<T, PoolProcess, int>
+          <<<config.block_per_grid,
+             config.thread_per_block,
+             0,
+             context.stream()>>>(nthreads,
+                                 input_data,
+                                 output_data,
+                                 output_grad_data,
+                                 output_width,
+                                 output_height,
+                                 input_width,
+                                 input_height,
+                                 ksize_width,
+                                 ksize_height,
+                                 stride_width,
+                                 stride_height,
+                                 padding_width,
+                                 padding_height,
+                                 pool_divmods,
+                                 pool_process,
+                                 exclusive,
+                                 adaptive,
+                                 input_grad_data,
+                                 channel_last);
+    } else {
+      auto pool_divmods =
+          FastDivModForPoolingWithMoreStaff<int64_t>(input_channels,
+                                                     input_width,
+                                                     input_height,
+                                                     ksize_width,
+                                                     ksize_height,
+                                                     stride_width,
+                                                     stride_height);
+      KernelPool2DGrad<T, PoolProcess, int64_t>
+          <<<config.block_per_grid,
+             config.thread_per_block,
+             0,
+             context.stream()>>>(nthreads,
+                                 input_data,
+                                 output_data,
+                                 output_grad_data,
+                                 output_width,
+                                 output_height,
+                                 input_width,
+                                 input_height,
+                                 ksize_width,
+                                 ksize_height,
+                                 stride_width,
+                                 stride_height,
+                                 padding_width,
+                                 padding_height,
+                                 pool_divmods,
+                                 pool_process,
+                                 exclusive,
+                                 adaptive,
+                                 input_grad_data,
+                                 channel_last);
+    }
   }
 };
 
@@ -803,28 +889,52 @@ class MaxPool2dGradFunctor<phi::GPUContext, T> {
     dim3 threads(1024, 1);
     dim3 grid(blocks, 1);
 
-    auto pool_divmods =
-        FastDivModForPooling(input_channels, output_width, output_height);
-
-    KernelMaxPool2DGrad<T>
-        <<<grid, threads, 0, context.stream()>>>(nthreads,
-                                                 input_data,
-                                                 output_data,
-                                                 output_grad_data,
-                                                 input_channels,
-                                                 input_height,
-                                                 input_width,
-                                                 output_height,
-                                                 output_width,
-                                                 ksize_height,
-                                                 ksize_width,
-                                                 stride_height,
-                                                 stride_width,
-                                                 padding_height,
-                                                 padding_width,
-                                                 input_grad_data,
-                                                 pool_divmods,
-                                                 channel_last);
+    if (input.numel() <= std::numeric_limits<int>::max() &&
+        output.numel() <= std::numeric_limits<int>::max()) {
+      auto pool_divmods = FastDivModForPooling<int>(
+          input_channels, output_width, output_height);
+      KernelMaxPool2DGrad<T, int>
+          <<<grid, threads, 0, context.stream()>>>(nthreads,
+                                                   input_data,
+                                                   output_data,
+                                                   output_grad_data,
+                                                   input_channels,
+                                                   input_height,
+                                                   input_width,
+                                                   output_height,
+                                                   output_width,
+                                                   ksize_height,
+                                                   ksize_width,
+                                                   stride_height,
+                                                   stride_width,
+                                                   padding_height,
+                                                   padding_width,
+                                                   input_grad_data,
+                                                   pool_divmods,
+                                                   channel_last);
+    } else {
+      auto pool_divmods = FastDivModForPooling<int64_t>(
+          input_channels, output_width, output_height);
+      KernelMaxPool2DGrad<T, int64_t>
+          <<<grid, threads, 0, context.stream()>>>(nthreads,
+                                                   input_data,
+                                                   output_data,
+                                                   output_grad_data,
+                                                   input_channels,
+                                                   input_height,
+                                                   input_width,
+                                                   output_height,
+                                                   output_width,
+                                                   ksize_height,
+                                                   ksize_width,
+                                                   stride_height,
+                                                   stride_width,
+                                                   padding_height,
+                                                   padding_width,
+                                                   input_grad_data,
+                                                   pool_divmods,
+                                                   channel_last);
+    }
   }
 };
 
@@ -886,35 +996,35 @@ template class Pool2dGradFunctor<phi::GPUContext,
                                  LPPoolGrad<dtype::bfloat16>,
                                  dtype::bfloat16>;
 
-template <typename PoolProcess, typename T>
-__global__ void KernelPool3D(const int64_t nthreads,
+template <typename PoolProcess, typename T, typename IndexT>
+__global__ void KernelPool3D(const IndexT nthreads,
                              const T* input_data,
-                             const int64_t channels,
-                             const int64_t input_depth,
-                             const int64_t input_height,
-                             const int64_t input_width,
-                             const int64_t output_depth,
-                             const int64_t output_height,
-                             const int64_t output_width,
-                             const int64_t ksize_depth,
-                             const int64_t ksize_height,
-                             const int64_t ksize_width,
-                             const int64_t stride_depth,
-                             const int64_t stride_height,
-                             const int64_t stride_width,
-                             const int64_t padding_depth,
-                             const int64_t padding_height,
-                             const int64_t padding_width,
+                             const IndexT channels,
+                             const IndexT input_depth,
+                             const IndexT input_height,
+                             const IndexT input_width,
+                             const IndexT output_depth,
+                             const IndexT output_height,
+                             const IndexT output_width,
+                             const IndexT ksize_depth,
+                             const IndexT ksize_height,
+                             const IndexT ksize_width,
+                             const IndexT stride_depth,
+                             const IndexT stride_height,
+                             const IndexT stride_width,
+                             const IndexT padding_depth,
+                             const IndexT padding_height,
+                             const IndexT padding_width,
                              PoolProcess pool_process,
                              bool exclusive,
                              bool adaptive,
                              T* output_data,
                              bool channel_last = false) {
-  const int64_t start_index =
-      static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
-  const int64_t step = static_cast<int64_t>(blockDim.x) * gridDim.x;
-  for (int64_t index = start_index; index < nthreads; index += step) {
-    int64_t pw, ph, pd, c, batch_idx;
+  const IndexT start_index =
+      static_cast<IndexT>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const IndexT step = static_cast<IndexT>(blockDim.x) * gridDim.x;
+  for (IndexT index = start_index; index < nthreads; index += step) {
+    IndexT pw, ph, pd, c, batch_idx;
     if (!channel_last) {
       pw = index % output_width;
       ph = (index / output_width) % output_height;
@@ -931,9 +1041,9 @@ __global__ void KernelPool3D(const int64_t nthreads,
           index / channels / output_width / output_height / output_depth;
     }
 
-    int64_t dstart, dend;
-    int64_t hstart, hend;
-    int64_t wstart, wend;
+    IndexT dstart, dend;
+    IndexT hstart, hend;
+    IndexT wstart, wend;
     if (adaptive) {
       dstart = AdaptStartIndex(pd, input_depth, output_depth);
       dend = AdaptEndIndex(pd, input_depth, output_depth);
@@ -950,12 +1060,12 @@ __global__ void KernelPool3D(const int64_t nthreads,
       dend = min(dstart + ksize_depth, input_depth);
       hend = min(hstart + ksize_height, input_height);
       wend = min(wstart + ksize_width, input_width);
-      dstart = max(dstart, static_cast<int64_t>(0));
-      hstart = max(hstart, static_cast<int64_t>(0));
-      wstart = max(wstart, static_cast<int64_t>(0));
+      dstart = max(dstart, static_cast<IndexT>(0));
+      hstart = max(hstart, static_cast<IndexT>(0));
+      wstart = max(wstart, static_cast<IndexT>(0));
     }
 
-    int64_t input_data_stride;
+    IndexT input_data_stride;
     if (!channel_last) { /* NCDHW */
       input_data_stride =
           (batch_idx * channels + c) * input_depth * input_height * input_width;
@@ -966,9 +1076,9 @@ __global__ void KernelPool3D(const int64_t nthreads,
     input_data += input_data_stride;
 
     T ele = pool_process.initial();
-    for (int64_t d = dstart; d < dend; ++d) {
-      for (int64_t h = hstart; h < hend; ++h) {
-        for (int64_t w = wstart; w < wend; ++w) {
+    for (IndexT d = dstart; d < dend; ++d) {
+      for (IndexT h = hstart; h < hend; ++h) {
+        for (IndexT w = wstart; w < wend; ++w) {
           auto input_data_idx =
               channel_last
                   ? ((d * input_height + h) * input_width + w) * channels + c
@@ -977,46 +1087,45 @@ __global__ void KernelPool3D(const int64_t nthreads,
         }
       }
     }
-    int64_t pool_size =
-        (exclusive || adaptive)
-            ? (dend - dstart) * (hend - hstart) * (wend - wstart)
-            : ksize_depth * ksize_height * ksize_width;
+    IndexT pool_size = (exclusive || adaptive)
+                           ? (dend - dstart) * (hend - hstart) * (wend - wstart)
+                           : ksize_depth * ksize_height * ksize_width;
     pool_process.finalize(static_cast<T>(pool_size), &ele);
     output_data[index] = ele;
   }
 }
 
-template <typename T, typename PoolProcess>
-__global__ void KernelPool3DGrad(const int64_t nthreads,
+template <typename T, typename PoolProcess, typename IndexT>
+__global__ void KernelPool3DGrad(const IndexT nthreads,
                                  const T* __restrict__ input_data,
                                  const T* __restrict__ output_data,
                                  const T* __restrict__ output_grad,
-                                 const int64_t channels,
-                                 const int64_t input_depth,
-                                 const int64_t input_height,
-                                 const int64_t input_width,
-                                 const int64_t output_depth,
-                                 const int64_t output_height,
-                                 const int64_t output_width,
-                                 const int64_t ksize_depth,
-                                 const int64_t ksize_height,
-                                 const int64_t ksize_width,
-                                 const int64_t stride_depth,
-                                 const int64_t stride_height,
-                                 const int64_t stride_width,
-                                 const int64_t padding_depth,
-                                 const int64_t padding_height,
-                                 const int64_t padding_width,
+                                 const IndexT channels,
+                                 const IndexT input_depth,
+                                 const IndexT input_height,
+                                 const IndexT input_width,
+                                 const IndexT output_depth,
+                                 const IndexT output_height,
+                                 const IndexT output_width,
+                                 const IndexT ksize_depth,
+                                 const IndexT ksize_height,
+                                 const IndexT ksize_width,
+                                 const IndexT stride_depth,
+                                 const IndexT stride_height,
+                                 const IndexT stride_width,
+                                 const IndexT padding_depth,
+                                 const IndexT padding_height,
+                                 const IndexT padding_width,
                                  PoolProcess pool_process,
                                  bool exclusive,
                                  bool adaptive,
                                  T* input_grad,
                                  bool channel_last = false) {
-  const int64_t start_index =
-      static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
-  const int64_t step = static_cast<int64_t>(blockDim.x) * gridDim.x;
-  for (int64_t index = start_index; index < nthreads; index += step) {
-    int64_t w_offset, h_offset, d_offset, c_offset, batch_idx, output_stride;
+  const IndexT start_index =
+      static_cast<IndexT>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const IndexT step = static_cast<IndexT>(blockDim.x) * gridDim.x;
+  for (IndexT index = start_index; index < nthreads; index += step) {
+    IndexT w_offset, h_offset, d_offset, c_offset, batch_idx, output_stride;
     T input = static_cast<T>(0);
     if (!channel_last) { /* "NCDHW" */
       w_offset = index % input_width + padding_width;
@@ -1039,9 +1148,9 @@ __global__ void KernelPool3DGrad(const int64_t nthreads,
           batch_idx * output_depth * output_height * output_width * channels;
     }
 
-    int64_t pdstart, pdend;
-    int64_t phstart, phend;
-    int64_t pwstart, pwend;
+    IndexT pdstart, pdend;
+    IndexT phstart, phend;
+    IndexT pwstart, pwend;
     if (adaptive) {
       pdstart = AdaptStartIndex(d_offset, output_depth, input_depth);
       pdend = AdaptEndIndex(d_offset, output_depth, input_depth);
@@ -1072,35 +1181,35 @@ __global__ void KernelPool3DGrad(const int64_t nthreads,
     output_grad += output_stride;
     T input_grad_data = static_cast<T>(0.0);
 
-    for (int64_t pd = pdstart; pd < pdend; ++pd) {
-      for (int64_t ph = phstart; ph < phend; ++ph) {
-        for (int64_t pw = pwstart; pw < pwend; ++pw) {
+    for (IndexT pd = pdstart; pd < pdend; ++pd) {
+      for (IndexT ph = phstart; ph < phend; ++ph) {
+        for (IndexT pw = pwstart; pw < pwend; ++pw) {
           // figure out the pooling size
-          int64_t pool_size;
+          IndexT pool_size;
           if (adaptive) {
             pool_size =
-                static_cast<int64_t>(
+                static_cast<IndexT>(
                     ceil(static_cast<double>(input_depth) / ksize_depth)) *
-                static_cast<int64_t>(
+                static_cast<IndexT>(
                     ceil(static_cast<double>(input_height) / ksize_height)) *
-                static_cast<int64_t>(
+                static_cast<IndexT>(
                     ceil(static_cast<double>(input_width) / ksize_width));
           } else {
-            int64_t dstart = pd * stride_depth - padding_depth;
-            int64_t hstart = ph * stride_height - padding_height;
-            int64_t wstart = pw * stride_width - padding_width;
-            int64_t dend = min(dstart + ksize_depth, input_depth);
-            int64_t hend = min(hstart + ksize_height, input_height);
-            int64_t wend = min(wstart + ksize_width, input_width);
-            dstart = max(dstart, static_cast<int64_t>(0));
-            hstart = max(hstart, static_cast<int64_t>(0));
-            wstart = max(wstart, static_cast<int64_t>(0));
+            IndexT dstart = pd * stride_depth - padding_depth;
+            IndexT hstart = ph * stride_height - padding_height;
+            IndexT wstart = pw * stride_width - padding_width;
+            IndexT dend = min(dstart + ksize_depth, input_depth);
+            IndexT hend = min(hstart + ksize_height, input_height);
+            IndexT wend = min(wstart + ksize_width, input_width);
+            dstart = max(dstart, static_cast<IndexT>(0));
+            hstart = max(hstart, static_cast<IndexT>(0));
+            wstart = max(wstart, static_cast<IndexT>(0));
             pool_size =
                 exclusive ? (dend - dstart) * (hend - hstart) * (wend - wstart)
                           : ksize_depth * ksize_height * ksize_width;
           }
 
-          int64_t output_sub_idx =
+          IndexT output_sub_idx =
               channel_last
                   ? ((pd * output_height + ph) * output_width + pw) * channels +
                         c_offset
@@ -1119,34 +1228,34 @@ __global__ void KernelPool3DGrad(const int64_t nthreads,
   }
 }
 
-template <typename T>
-__global__ void KernelMaxPool3DGrad(const int64_t nthreads,
+template <typename T, typename IndexT>
+__global__ void KernelMaxPool3DGrad(const IndexT nthreads,
                                     const T* input_data,
                                     const T* output_data,
                                     const T* output_grad,
-                                    const int64_t channels,
-                                    const int64_t input_depth,
-                                    const int64_t input_height,
-                                    const int64_t input_width,
-                                    const int64_t output_depth,
-                                    const int64_t output_height,
-                                    const int64_t output_width,
-                                    const int64_t ksize_depth,
-                                    const int64_t ksize_height,
-                                    const int64_t ksize_width,
-                                    const int64_t stride_depth,
-                                    const int64_t stride_height,
-                                    const int64_t stride_width,
-                                    const int64_t padding_depth,
-                                    const int64_t padding_height,
-                                    const int64_t padding_width,
+                                    const IndexT channels,
+                                    const IndexT input_depth,
+                                    const IndexT input_height,
+                                    const IndexT input_width,
+                                    const IndexT output_depth,
+                                    const IndexT output_height,
+                                    const IndexT output_width,
+                                    const IndexT ksize_depth,
+                                    const IndexT ksize_height,
+                                    const IndexT ksize_width,
+                                    const IndexT stride_depth,
+                                    const IndexT stride_height,
+                                    const IndexT stride_width,
+                                    const IndexT padding_depth,
+                                    const IndexT padding_height,
+                                    const IndexT padding_width,
                                     T* input_grad,
                                     bool channel_last = false) {
-  const int64_t start_index =
-      static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
-  const int64_t step = static_cast<int64_t>(blockDim.x) * gridDim.x;
-  for (int64_t index = start_index; index < nthreads; index += step) {
-    int64_t pw, ph, pd, c, batch_idx;
+  const IndexT start_index =
+      static_cast<IndexT>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const IndexT step = static_cast<IndexT>(blockDim.x) * gridDim.x;
+  for (IndexT index = start_index; index < nthreads; index += step) {
+    IndexT pw, ph, pd, c, batch_idx;
 
     if (!channel_last) { /*NCDHW*/
       pw = index % output_width;
@@ -1164,23 +1273,23 @@ __global__ void KernelMaxPool3DGrad(const int64_t nthreads,
           index / channels / output_width / output_height / output_depth;
     }
 
-    int64_t dstart = pd * stride_depth - padding_depth;
-    int64_t hstart = ph * stride_height - padding_height;
-    int64_t wstart = pw * stride_width - padding_width;
+    IndexT dstart = pd * stride_depth - padding_depth;
+    IndexT hstart = ph * stride_height - padding_height;
+    IndexT wstart = pw * stride_width - padding_width;
 
-    int64_t dend = min(dstart + ksize_depth, input_depth);
-    int64_t hend = min(hstart + ksize_height, input_height);
-    int64_t wend = min(wstart + ksize_width, input_width);
+    IndexT dend = min(dstart + ksize_depth, input_depth);
+    IndexT hend = min(hstart + ksize_height, input_height);
+    IndexT wend = min(wstart + ksize_width, input_width);
 
-    dstart = max(dstart, static_cast<int64_t>(0));
-    hstart = max(hstart, static_cast<int64_t>(0));
-    wstart = max(wstart, static_cast<int64_t>(0));
+    dstart = max(dstart, static_cast<IndexT>(0));
+    hstart = max(hstart, static_cast<IndexT>(0));
+    wstart = max(wstart, static_cast<IndexT>(0));
 
     T ele = output_data[index];
     bool stop = false;
-    int64_t maxIdx = -1;
+    IndexT maxIdx = -1;
 
-    int64_t input_stride;
+    IndexT input_stride;
     if (!channel_last) {
       input_stride =
           (batch_idx * channels + c) * input_depth * input_height * input_width;
@@ -1190,10 +1299,10 @@ __global__ void KernelMaxPool3DGrad(const int64_t nthreads,
     }
     input_data += input_stride;
     input_grad += input_stride;
-    for (int64_t d = dstart; d < dend && !stop; ++d) {
-      for (int64_t h = hstart; h < hend && !stop; ++h) {
-        for (int64_t w = wstart; w < wend && !stop; ++w) {
-          int64_t input_data_idx =
+    for (IndexT d = dstart; d < dend && !stop; ++d) {
+      for (IndexT h = hstart; h < hend && !stop; ++h) {
+        for (IndexT w = wstart; w < wend && !stop; ++w) {
+          IndexT input_data_idx =
               channel_last
                   ? ((d * input_height + h) * input_width + w) * channels + c
                   : (d * input_height + h) * input_width + w;
@@ -1253,28 +1362,29 @@ void Pool3dDirectCUDAFunctor<PoolProcess, T>::operator()(
   dim3 threads(thread_num, 1);
   dim3 grid(blocks, 1);
 
-  KernelPool3D<PoolProcess, T><<<grid, threads, 0, stream>>>(nthreads,
-                                                             input,
-                                                             input_channels,
-                                                             input_depth,
-                                                             input_height,
-                                                             input_width,
-                                                             output_depth,
-                                                             output_height,
-                                                             output_width,
-                                                             ksize_depth,
-                                                             ksize_height,
-                                                             ksize_width,
-                                                             stride_depth,
-                                                             stride_height,
-                                                             stride_width,
-                                                             padding_depth,
-                                                             padding_height,
-                                                             padding_width,
-                                                             pool_compute,
-                                                             exclusive,
-                                                             adaptive,
-                                                             output);
+  KernelPool3D<PoolProcess, T, int>
+      <<<grid, threads, 0, stream>>>(nthreads,
+                                     input,
+                                     input_channels,
+                                     input_depth,
+                                     input_height,
+                                     input_width,
+                                     output_depth,
+                                     output_height,
+                                     output_width,
+                                     ksize_depth,
+                                     ksize_height,
+                                     ksize_width,
+                                     stride_depth,
+                                     stride_height,
+                                     stride_width,
+                                     padding_depth,
+                                     padding_height,
+                                     padding_width,
+                                     pool_compute,
+                                     exclusive,
+                                     adaptive,
+                                     output);
 }
 
 /*
@@ -1344,30 +1454,57 @@ class Pool3dFunctor<phi::GPUContext, PoolProcess, T> {
     dim3 threads(thread_num, 1);
     dim3 grid(blocks, 1);
 
-    KernelPool3D<PoolProcess, T>
-        <<<grid, threads, 0, context.stream()>>>(nthreads,
-                                                 input_data,
-                                                 input_channels,
-                                                 input_depth,
-                                                 input_height,
-                                                 input_width,
-                                                 output_depth,
-                                                 output_height,
-                                                 output_width,
-                                                 ksize_depth,
-                                                 ksize_height,
-                                                 ksize_width,
-                                                 stride_depth,
-                                                 stride_height,
-                                                 stride_width,
-                                                 padding_depth,
-                                                 padding_height,
-                                                 padding_width,
-                                                 pool_process,
-                                                 exclusive,
-                                                 adaptive,
-                                                 output_data,
-                                                 channel_last);
+    if (input.numel() <= std::numeric_limits<int>::max()) {
+      KernelPool3D<PoolProcess, T, int>
+          <<<grid, threads, 0, context.stream()>>>(nthreads,
+                                                   input_data,
+                                                   input_channels,
+                                                   input_depth,
+                                                   input_height,
+                                                   input_width,
+                                                   output_depth,
+                                                   output_height,
+                                                   output_width,
+                                                   ksize_depth,
+                                                   ksize_height,
+                                                   ksize_width,
+                                                   stride_depth,
+                                                   stride_height,
+                                                   stride_width,
+                                                   padding_depth,
+                                                   padding_height,
+                                                   padding_width,
+                                                   pool_process,
+                                                   exclusive,
+                                                   adaptive,
+                                                   output_data,
+                                                   channel_last);
+    } else {
+      KernelPool3D<PoolProcess, T, int64_t>
+          <<<grid, threads, 0, context.stream()>>>(nthreads,
+                                                   input_data,
+                                                   input_channels,
+                                                   input_depth,
+                                                   input_height,
+                                                   input_width,
+                                                   output_depth,
+                                                   output_height,
+                                                   output_width,
+                                                   ksize_depth,
+                                                   ksize_height,
+                                                   ksize_width,
+                                                   stride_depth,
+                                                   stride_height,
+                                                   stride_width,
+                                                   padding_depth,
+                                                   padding_height,
+                                                   padding_width,
+                                                   pool_process,
+                                                   exclusive,
+                                                   adaptive,
+                                                   output_data,
+                                                   channel_last);
+    }
   }
 };
 
@@ -1438,32 +1575,64 @@ class Pool3dGradFunctor<phi::GPUContext, PoolProcess, T> {
     dim3 threads(1024, 1);
     dim3 grid(blocks, 1);
 
-    KernelPool3DGrad<T, PoolProcess><<<grid, threads, 0, context.stream()>>>(
-        nthreads,
-        input_data,
-        output_data,
-        output_grad_data,
-        input_channels,
-        input_depth,
-        input_height,
-        input_width,
-        output_depth,
-        output_height,
-        output_width,
-        ksize_depth,
-        ksize_height,
-        ksize_width,
-        stride_depth,
-        stride_height,
-        stride_width,
-        padding_depth,
-        padding_height,
-        padding_width,
-        pool_process,
-        exclusive,
-        adaptive,
-        input_grad_data,
-        channel_last);  // add channel_last
+    if (input.numel() <= std::numeric_limits<int>::max() &&
+        output.numel() <= std::numeric_limits<int>::max()) {
+      KernelPool3DGrad<T, PoolProcess, int>
+          <<<grid, threads, 0, context.stream()>>>(
+              nthreads,
+              input_data,
+              output_data,
+              output_grad_data,
+              input_channels,
+              input_depth,
+              input_height,
+              input_width,
+              output_depth,
+              output_height,
+              output_width,
+              ksize_depth,
+              ksize_height,
+              ksize_width,
+              stride_depth,
+              stride_height,
+              stride_width,
+              padding_depth,
+              padding_height,
+              padding_width,
+              pool_process,
+              exclusive,
+              adaptive,
+              input_grad_data,
+              channel_last);  // add channel_last
+    } else {
+      KernelPool3DGrad<T, PoolProcess, int64_t>
+          <<<grid, threads, 0, context.stream()>>>(
+              nthreads,
+              input_data,
+              output_data,
+              output_grad_data,
+              input_channels,
+              input_depth,
+              input_height,
+              input_width,
+              output_depth,
+              output_height,
+              output_width,
+              ksize_depth,
+              ksize_height,
+              ksize_width,
+              stride_depth,
+              stride_height,
+              stride_width,
+              padding_depth,
+              padding_height,
+              padding_width,
+              pool_process,
+              exclusive,
+              adaptive,
+              input_grad_data,
+              channel_last);  // add channel_last
+    }
   }
 };
 
@@ -1530,30 +1699,56 @@ class MaxPool3dGradFunctor<phi::GPUContext, T> {
     uint blocks = (nthreads + 1024 - 1) / 1024;
     dim3 threads(1024, 1);
     dim3 grid(blocks, 1);
-
-    KernelMaxPool3DGrad<T><<<grid, threads, 0, context.stream()>>>(
-        nthreads,
-        input_data,
-        output_data,
-        output_grad_data,
-        input_channels,
-        input_depth,
-        input_height,
-        input_width,
-        output_depth,
-        output_height,
-        output_width,
-        ksize_depth,
-        ksize_height,
-        ksize_width,
-        stride_depth,
-        stride_height,
-        stride_width,
-        padding_depth,
-        padding_height,
-        padding_width,
-        input_grad_data,
-        channel_last);  // add channel_last
+    if (input.numel() <= std::numeric_limits<int>::max() &&
+        output.numel() <= std::numeric_limits<int>::max()) {
+      KernelMaxPool3DGrad<T, int><<<grid, threads, 0, context.stream()>>>(
+          nthreads,
+          input_data,
+          output_data,
+          output_grad_data,
+          input_channels,
+          input_depth,
+          input_height,
+          input_width,
+          output_depth,
+          output_height,
+          output_width,
+          ksize_depth,
+          ksize_height,
+          ksize_width,
+          stride_depth,
+          stride_height,
+          stride_width,
+          padding_depth,
+          padding_height,
+          padding_width,
+          input_grad_data,
+          channel_last);  // add channel_last
+    } else {
+      KernelMaxPool3DGrad<T, int64_t><<<grid, threads, 0, context.stream()>>>(
+          nthreads,
+          input_data,
+          output_data,
+          output_grad_data,
+          input_channels,
+          input_depth,
+          input_height,
+          input_width,
+          output_depth,
+          output_height,
+          output_width,
+          ksize_depth,
+          ksize_height,
+          ksize_width,
+          stride_depth,
+          stride_height,
+          stride_width,
+          padding_depth,
+          padding_height,
+          padding_width,
+          input_grad_data,
+          channel_last);  // add channel_last
+    }
   }
 };
 

--- a/paddle/phi/kernels/funcs/pooling.cu
+++ b/paddle/phi/kernels/funcs/pooling.cu
@@ -32,15 +32,16 @@ limitations under the License. */
 namespace phi {
 namespace funcs {
 
+template <typename IndexT>
 struct FastDivModForPooling {
  public:
-  FastDivMod<int> channel;
-  FastDivMod<int> width;
-  FastDivMod<int> height;
+  FastDivMod<IndexT> channel;
+  FastDivMod<IndexT> width;
+  FastDivMod<IndexT> height;
 
-  explicit HOSTDEVICE FastDivModForPooling(const int channels,
-                                           const int output_width,
-                                           const int output_height)
+  explicit HOSTDEVICE FastDivModForPooling(const IndexT channels,
+                                           const IndexT output_width,
+                                           const IndexT output_height)
       : channel(channels), width(output_width), height(output_height) {}
 };
 
@@ -61,23 +62,25 @@ struct FastDivModForPooling3D {
         depth(output_depth) {}
 };
 
+template <typename IndexT>
 struct FastDivModForPoolingWithMoreStaff {
  public:
-  FastDivMod<int> channel;
-  FastDivMod<int> width;
-  FastDivMod<int> height;
-  FastDivMod<int> ksize_w;
-  FastDivMod<int> ksize_h;
-  FastDivMod<int> stride_w;
-  FastDivMod<int> stride_h;
+  FastDivMod<IndexT> channel;
+  FastDivMod<IndexT> width;
+  FastDivMod<IndexT> height;
+  FastDivMod<IndexT> ksize_w;
+  FastDivMod<IndexT> ksize_h;
+  FastDivMod<IndexT> stride_w;
+  FastDivMod<IndexT> stride_h;
 
-  explicit HOSTDEVICE FastDivModForPoolingWithMoreStaff(const int channels,
-                                                        const int input_width,
-                                                        const int input_height,
-                                                        const int ksize_width,
-                                                        const int ksize_height,
-                                                        const int stride_width,
-                                                        const int stride_height)
+  explicit HOSTDEVICE FastDivModForPoolingWithMoreStaff(
+      const IndexT channels,
+      const IndexT input_width,
+      const IndexT input_height,
+      const IndexT ksize_width,
+      const IndexT ksize_height,
+      const IndexT stride_width,
+      const IndexT stride_height)
       : channel(channels),
         width(input_width),
         height(input_height),
@@ -87,18 +90,18 @@ struct FastDivModForPoolingWithMoreStaff {
         stride_h(stride_height) {}
 };
 
-template <typename FastDivModForPooling>
-__device__ void OffsetPreparationFor4Dimension(int index,
+template <typename FastDivModForPooling, typename IndexT>
+__device__ void OffsetPreparationFor4Dimension(IndexT index,
                                                bool channel_last,
                                                FastDivModForPooling divmods,
-                                               const int pad_width,
-                                               const int pad_height,
-                                               const int aux_width,
-                                               const int aux_height,
-                                               int* w_offset,
-                                               int* h_offset,
-                                               int* c_offset,
-                                               int* stride) {
+                                               const IndexT pad_width,
+                                               const IndexT pad_height,
+                                               const IndexT aux_width,
+                                               const IndexT aux_height,
+                                               IndexT* w_offset,
+                                               IndexT* h_offset,
+                                               IndexT* c_offset,
+                                               IndexT* stride) {
   if (!channel_last) { /* NCHW */
     auto input_width_divmod = divmods.width.Divmod(index);
     auto input_height_divmod = divmods.height.Divmod(input_width_divmod.val[0]);
@@ -121,118 +124,123 @@ __device__ void OffsetPreparationFor4Dimension(int index,
 }
 
 template <typename PoolProcess, typename T>
-__global__ void KernelPool2D(const int nthreads,
+__global__ void KernelPool2D(const int64_t nthreads,
                              const T* input_data,
-                             const int channels,
-                             const int input_height,
-                             const int input_width,
-                             const int output_height,
-                             const int output_width,
-                             const int ksize_height,
-                             const int ksize_width,
-                             const int stride_height,
-                             const int stride_width,
-                             const int padding_height,
-                             const int padding_width,
-                             FastDivModForPooling divmods,
+                             const int64_t channels,
+                             const int64_t input_height,
+                             const int64_t input_width,
+                             const int64_t output_height,
+                             const int64_t output_width,
+                             const int64_t ksize_height,
+                             const int64_t ksize_width,
+                             const int64_t stride_height,
+                             const int64_t stride_width,
+                             const int64_t padding_height,
+                             const int64_t padding_width,
+                             FastDivModForPooling<int64_t> divmods,
                              PoolProcess pool_process,
                              bool exclusive,
                              T* output_data,
                              bool channel_last = false) {
-  for (int index = blockIdx.x * blockDim.x + threadIdx.x; index < nthreads;
-       index += blockDim.x * gridDim.x) {
-    int hstart, hend, wstart, wend;
-    int w_offset, h_offset, c_offset, input_offset;
-    OffsetPreparationFor4Dimension<FastDivModForPooling>(index,
-                                                         channel_last,
-                                                         divmods,
-                                                         0,
-                                                         0,
-                                                         input_width,
-                                                         input_height,
-                                                         &w_offset,
-                                                         &h_offset,
-                                                         &c_offset,
-                                                         &input_offset);
+  const int64_t start_index =
+      static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const int64_t step = static_cast<int64_t>(blockDim.x) * gridDim.x;
+  for (int64_t index = start_index; index < nthreads; index += step) {
+    int64_t hstart, hend, wstart, wend;
+    int64_t w_offset, h_offset, c_offset, input_offset;
+    OffsetPreparationFor4Dimension<FastDivModForPooling<int64_t>, int64_t>(
+        index,
+        channel_last,
+        divmods,
+        0,
+        0,
+        input_width,
+        input_height,
+        &w_offset,
+        &h_offset,
+        &c_offset,
+        &input_offset);
     input_data += input_offset;
 
     hstart = h_offset * stride_height - padding_height;
     hend = min(hstart + ksize_height, input_height);
-    hstart = max(hstart, 0);
+    hstart = max(hstart, static_cast<int64_t>(0));
     wstart = w_offset * stride_width - padding_width;
     wend = min(wstart + ksize_width, input_width);
-    wstart = max(wstart, 0);
+    wstart = max(wstart, static_cast<int64_t>(0));
 
     T ele = pool_process.initial();
-    for (int h = hstart; h < hend; ++h) {
-      for (int w = wstart; w < wend; ++w) {
+    for (int64_t h = hstart; h < hend; ++h) {
+      for (int64_t w = wstart; w < wend; ++w) {
         auto input_idx = channel_last
                              ? (h * input_width + w) * channels + c_offset
                              : h * input_width + w;
         pool_process.compute(input_data[input_idx], &ele);
       }
     }
-    int pool_size = exclusive ? (hend - hstart) * (wend - wstart)
-                              : ksize_height * ksize_width;
+    int64_t pool_size = exclusive ? (hend - hstart) * (wend - wstart)
+                                  : ksize_height * ksize_width;
     pool_process.finalize(static_cast<T>(pool_size), &ele);
     output_data[index] = ele;
   }
 }
 
 template <typename PoolProcess, typename T>
-__global__ void AdaptiveKernelPool2D(const int nthreads,
+__global__ void AdaptiveKernelPool2D(const int64_t nthreads,
                                      const T* input_data,
-                                     const int channels,
-                                     const int input_height,
-                                     const int input_width,
-                                     const int output_height,
-                                     const int output_width,
-                                     const int ksize_height,
-                                     const int ksize_width,
-                                     const int stride_height,
-                                     const int stride_width,
-                                     const int padding_height,
-                                     const int padding_width,
-                                     FastDivModForPooling divmods,
+                                     const int64_t channels,
+                                     const int64_t input_height,
+                                     const int64_t input_width,
+                                     const int64_t output_height,
+                                     const int64_t output_width,
+                                     const int64_t ksize_height,
+                                     const int64_t ksize_width,
+                                     const int64_t stride_height,
+                                     const int64_t stride_width,
+                                     const int64_t padding_height,
+                                     const int64_t padding_width,
+                                     FastDivModForPooling<int64_t> divmods,
                                      PoolProcess pool_process,
                                      bool exclusive,
                                      T* output_data,
                                      bool channel_last = false) {
-  const int n_offset = blockIdx.y;
-  const int c_offset = blockIdx.x * blockDim.y + threadIdx.y;
+  const int64_t n_offset = blockIdx.y;
+  const int64_t c_offset =
+      static_cast<int64_t>(blockIdx.x) * blockDim.y + threadIdx.y;
   if (c_offset >= channels) {
     return;
   }
-  int hstart, hend, wstart, wend;
-  int input_offset =
+  int64_t hstart, hend, wstart, wend;
+  int64_t input_offset =
       channel_last
           ? n_offset * input_height * input_width * channels
           : (n_offset * channels + c_offset) * input_height * input_width;
-  int output_offset =
+  int64_t output_offset =
       channel_last
           ? n_offset * output_height * output_width * channels
           : (n_offset * channels + c_offset) * output_height * output_width;
-  for (int hw_offset = threadIdx.x; hw_offset < output_height * output_width;
+  for (int64_t hw_offset = threadIdx.x;
+       hw_offset < output_height * output_width;
        hw_offset += blockDim.x) {
-    int w_offset = hw_offset % output_width;
-    int h_offset = hw_offset / output_width;
+    int64_t w_offset = hw_offset % output_width;
+    int64_t h_offset = hw_offset / output_width;
     hstart = AdaptStartIndex(h_offset, input_height, output_height);
     hend = AdaptEndIndex(h_offset, input_height, output_height);
     wstart = AdaptStartIndex(w_offset, input_width, output_width);
     wend = AdaptEndIndex(w_offset, input_width, output_width);
 
     T ele = pool_process.initial();
-    for (int h = hstart; h < hend; ++h) {
-      for (int w = wstart; w < wend; ++w) {
+    for (int64_t h = hstart; h < hend; ++h) {
+      for (int64_t w = wstart; w < wend; ++w) {
         auto input_idx = channel_last
                              ? (h * input_width + w) * channels + c_offset
                              : h * input_width + w;
         pool_process.compute(input_data[input_offset + input_idx], &ele);
       }
     }
-    int pool_size = (hend - hstart) * (wend - wstart);
+    int64_t pool_size = (hend - hstart) * (wend - wstart);
     pool_process.finalize(static_cast<T>(pool_size), &ele);
-    int output_idx =
+    int64_t output_idx =
         channel_last
             ? (h_offset * output_width + w_offset) * channels + c_offset
             : h_offset * output_width + w_offset;
@@ -241,43 +249,50 @@ __global__ void AdaptiveKernelPool2D(const int nthreads,
 }
 
 template <typename T, typename PoolProcess>
-__global__ void KernelPool2DGrad(const int nthreads,
-                                 const T* __restrict__ input_data,
-                                 const T* __restrict__ output_data,
-                                 const T* __restrict__ output_grad,
-                                 const int output_width,
-                                 const int output_height,
-                                 const int input_width,
-                                 const int input_height,
-                                 const int ksize_width,
-                                 const int ksize_height,
-                                 const int stride_width,
-                                 const int stride_height,
-                                 const int padding_width,
-                                 const int padding_height,
-                                 FastDivModForPoolingWithMoreStaff divmods,
-                                 PoolProcess pool_process,
-                                 bool exclusive,
-                                 bool adaptive,
-                                 T* __restrict__ input_grad,
-                                 bool channel_last = false) {
-  for (int index = blockIdx.x * blockDim.x + threadIdx.x; index < nthreads;
-       index += blockDim.x * gridDim.x) {
+__global__ void KernelPool2DGrad(
+    const int64_t nthreads,
+    const T* __restrict__ input_data,
+    const T* __restrict__ output_data,
+    const T* __restrict__ output_grad,
+    const int64_t output_width,
+    const int64_t output_height,
+    const int64_t input_width,
+    const int64_t input_height,
+    const int64_t ksize_width,
+    const int64_t ksize_height,
+    const int64_t stride_width,
+    const int64_t stride_height,
+    const int64_t padding_width,
+    const int64_t padding_height,
+    FastDivModForPoolingWithMoreStaff<int64_t> divmods,
+    PoolProcess pool_process,
+    bool exclusive,
+    bool adaptive,
+    T* __restrict__ input_grad,
+    bool channel_last = false) {
+  const int64_t start_index =
+      static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+
+  for (int64_t index =
+           static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+       index < nthreads;
+       index += static_cast<int64_t>(blockDim.x) * gridDim.x) {
     T input = static_cast<T>(0);
     T input_grad_data = static_cast<T>(0);
-    int phstart, phend, pwstart, pwend;
-    int w_offset, h_offset, c_offset, output_offset;
-    OffsetPreparationFor4Dimension<>(index,
-                                     channel_last,
-                                     divmods,
-                                     padding_width,
-                                     padding_height,
-                                     output_width,
-                                     output_height,
-                                     &w_offset,
-                                     &h_offset,
-                                     &c_offset,
-                                     &output_offset);
+    int64_t phstart, phend, pwstart, pwend;
+    int64_t w_offset, h_offset, c_offset, output_offset;
+    OffsetPreparationFor4Dimension<FastDivModForPoolingWithMoreStaff<int64_t>,
+                                   int64_t>(index,
+                                            channel_last,
+                                            divmods,
+                                            padding_width,
+                                            padding_height,
+                                            output_width,
+                                            output_height,
+                                            &w_offset,
+                                            &h_offset,
+                                            &c_offset,
+                                            &output_offset);
     if (pool_process.use_x) {
       input = input_data[index];
       output_data += output_offset;
@@ -292,8 +307,8 @@ __global__ void KernelPool2DGrad(const int nthreads,
       phend = tmp_phend.val[1] > 0 ? tmp_phend.val[0] + 1 : tmp_phend.val[0];
       pwend = tmp_pwend.val[1] > 0 ? tmp_pwend.val[0] + 1 : tmp_pwend.val[0];
 
-      for (int ph = phstart; ph < phend; ++ph) {
-        for (int pw = pwstart; pw < pwend; ++pw) {
+      for (int64_t ph = phstart; ph < phend; ++ph) {
+        for (int64_t pw = pwstart; pw < pwend; ++pw) {
           auto ksize_w_divmod = divmods.ksize_w.Divmod(input_width);
           auto ksize_h_divmod = divmods.ksize_h.Divmod(input_height);
           auto tmp_width = ksize_w_divmod.val[1] > 0 ? ksize_w_divmod.val[0] + 1
@@ -301,9 +316,9 @@ __global__ void KernelPool2DGrad(const int nthreads,
           auto tmp_height = ksize_h_divmod.val[1] > 0
                                 ? ksize_h_divmod.val[0] + 1
                                 : ksize_h_divmod.val[0];
-          int pool_size = tmp_height * tmp_width;
-          int tmp_idx = ph * output_width + pw;
-          int output_sub_idx =
+          int64_t pool_size = tmp_height * tmp_width;
+          int64_t tmp_idx = ph * output_width + pw;
+          int64_t output_sub_idx =
               channel_last ? tmp_idx * divmods.channel.divisor + c_offset
                            : tmp_idx;
           T output_value = pool_process.use_x ? output_data[output_sub_idx]
@@ -324,17 +339,17 @@ __global__ void KernelPool2DGrad(const int nthreads,
       pwend = min(divmods.stride_w.Div(w_offset) + 1, output_width);
 
       if (exclusive) {
-        for (int ph = phstart; ph < phend; ++ph) {
-          for (int pw = pwstart; pw < pwend; ++pw) {
-            int hstart = ph * stride_height - padding_height;
-            int wstart = pw * stride_width - padding_width;
-            int hend = min(hstart + ksize_height, input_height);
-            int wend = min(wstart + ksize_width, input_width);
-            hstart = max(hstart, 0);
-            wstart = max(wstart, 0);
-            int pool_size = (hend - hstart) * (wend - wstart);
-            int tmp_idx = ph * output_width + pw;
-            int output_sub_idx =
+        for (int64_t ph = phstart; ph < phend; ++ph) {
+          for (int64_t pw = pwstart; pw < pwend; ++pw) {
+            int64_t hstart = ph * stride_height - padding_height;
+            int64_t wstart = pw * stride_width - padding_width;
+            int64_t hend = min(hstart + ksize_height, input_height);
+            int64_t wend = min(wstart + ksize_width, input_width);
+            hstart = max(hstart, static_cast<int64_t>(0));
+            wstart = max(wstart, static_cast<int64_t>(0));
+            int64_t pool_size = (hend - hstart) * (wend - wstart);
+            int64_t tmp_idx = ph * output_width + pw;
+            int64_t output_sub_idx =
                 channel_last ? tmp_idx * divmods.channel.divisor + c_offset
                              : tmp_idx;
             T output_value = pool_process.use_x ? output_data[output_sub_idx]
@@ -347,11 +362,11 @@ __global__ void KernelPool2DGrad(const int nthreads,
           }
         }
       } else {
-        for (int ph = phstart; ph < phend; ++ph) {
-          for (int pw = pwstart; pw < pwend; ++pw) {
-            int pool_size = ksize_height * ksize_width;
-            int tmp_idx = ph * output_width + pw;
-            int output_sub_idx =
+        for (int64_t ph = phstart; ph < phend; ++ph) {
+          for (int64_t pw = pwstart; pw < pwend; ++pw) {
+            int64_t pool_size = ksize_height * ksize_width;
+            int64_t tmp_idx = ph * output_width + pw;
+            int64_t output_sub_idx =
                 channel_last ? tmp_idx * divmods.channel.divisor + c_offset
                              : tmp_idx;
             T output_value = pool_process.use_x ? output_data[output_sub_idx]
@@ -370,57 +385,60 @@ __global__ void KernelPool2DGrad(const int nthreads,
 }
 
 template <typename T>
-__global__ void KernelMaxPool2DGrad(const int nthreads,
+__global__ void KernelMaxPool2DGrad(const int64_t nthreads,
                                     const T* input_data,
                                     const T* output_data,
                                     const T* output_grad,
-                                    const int channels,
-                                    const int input_height,
-                                    const int input_width,
-                                    const int output_height,
-                                    const int output_width,
-                                    const int ksize_height,
-                                    const int ksize_width,
-                                    const int stride_height,
-                                    const int stride_width,
-                                    const int padding_height,
-                                    const int padding_width,
+                                    const int64_t channels,
+                                    const int64_t input_height,
+                                    const int64_t input_width,
+                                    const int64_t output_height,
+                                    const int64_t output_width,
+                                    const int64_t ksize_height,
+                                    const int64_t ksize_width,
+                                    const int64_t stride_height,
+                                    const int64_t stride_width,
+                                    const int64_t padding_height,
+                                    const int64_t padding_width,
                                     T* input_grad,
-                                    FastDivModForPooling divmods,
+                                    FastDivModForPooling<int64_t> divmods,
                                     bool channel_last = false) {
-  for (int index = blockIdx.x * blockDim.x + threadIdx.x; index < nthreads;
-       index += blockDim.x * gridDim.x) {
-    int w_offset, h_offset, c_offset, input_offset;
-    OffsetPreparationFor4Dimension<FastDivModForPooling>(index,
-                                                         channel_last,
-                                                         divmods,
-                                                         0,
-                                                         0,
-                                                         input_width,
-                                                         input_height,
-                                                         &w_offset,
-                                                         &h_offset,
-                                                         &c_offset,
-                                                         &input_offset);
+  const int64_t start_index =
+      static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const int64_t step = static_cast<int64_t>(blockDim.x) * gridDim.x;
+  for (int64_t index = start_index; index < nthreads; index += step) {
+    int64_t w_offset, h_offset, c_offset, input_offset;
+    OffsetPreparationFor4Dimension<FastDivModForPooling<int64_t>, int64_t>(
+        index,
+        channel_last,
+        divmods,
+        0,
+        0,
+        input_width,
+        input_height,
+        &w_offset,
+        &h_offset,
+        &c_offset,
+        &input_offset);
     input_data += input_offset;
     input_grad += input_offset;
 
-    int hstart = h_offset * stride_height - padding_height;
-    int hend = min(hstart + ksize_height, input_height);
-    hstart = max(hstart, 0);
+    int64_t hstart = h_offset * stride_height - padding_height;
+    int64_t hend = min(hstart + ksize_height, input_height);
+    hstart = max(hstart, static_cast<int64_t>(0));
 
-    int wstart = w_offset * stride_width - padding_width;
-    int wend = min(wstart + ksize_width, input_width);
-    wstart = max(wstart, 0);
+    int64_t wstart = w_offset * stride_width - padding_width;
+    int64_t wend = min(wstart + ksize_width, input_width);
+    wstart = max(wstart, static_cast<int64_t>(0));
 
     T ele = output_data[index];
-    int maxIndex = -1;
+    int64_t maxIndex = -1;
     bool stop = false;
-    for (int h = hstart; h < hend && !stop; ++h) {
-      for (int w = wstart; w < wend && !stop; ++w) {
-        int input_data_idx = channel_last
-                                 ? (h * input_width + w) * channels + c_offset
-                                 : h * input_width + w;
+    for (int64_t h = hstart; h < hend && !stop; ++h) {
+      for (int64_t w = wstart; w < wend && !stop; ++w) {
+        int64_t input_data_idx =
+            channel_last ? (h * input_width + w) * channels + c_offset
+                         : h * input_width + w;
         if (ele == input_data[input_data_idx]) {
           maxIndex = input_data_idx;
           stop = true;
@@ -463,8 +481,8 @@ void Pool2dDirectCUDAFunctor<PoolProcess, T>::operator()(
   const int padding_width = paddings[1];
   int64_t nthreads = static_cast<int64_t>(batch_size) * output_channels *
                      output_height * output_width;
-  auto pool_divmods =
-      FastDivModForPooling(input_channels, output_width, output_height);
+  auto pool_divmods = FastDivModForPooling<int64_t>(
+      input_channels, output_width, output_height);
   if (adaptive) {
     int64_t max_threads = 512;
     int64_t thread_num =
@@ -537,132 +555,47 @@ class Pool2dFunctor<phi::GPUContext, PoolProcess, T> {
  public:
   void operator()(const phi::GPUContext& context,
                   const DenseTensor& input,
-                  const std::vector<int>& ksize,
-                  const std::vector<int>& strides,
-                  const std::vector<int>& paddings,
-                  bool exclusive,
-                  bool adaptive,
-                  DenseTensor* output,
-                  PoolProcess pool_process) {
-    const int batch_size = input.dims()[0];
-    const int input_channels = input.dims()[1];
-    const int input_height = input.dims()[2];
-    const int input_width = input.dims()[3];
-    const int output_channels = output->dims()[1];
-    const int output_height = output->dims()[2];
-    const int output_width = output->dims()[3];
-    const int ksize_height = ksize[0];
-    const int ksize_width = ksize[1];
-    const int stride_height = strides[0];
-    const int stride_width = strides[1];
-    const int padding_height = paddings[0];
-    const int padding_width = paddings[1];
-
-    const T* input_data = input.data<T>();
-    T* output_data = context.template Alloc<T>(output);
-
-    int64_t nthreads = static_cast<int64_t>(batch_size) * output_channels *
-                       output_height * output_width;
-    auto pool_divmods =
-        FastDivModForPooling(input_channels, output_width, output_height);
-    if (adaptive) {
-      int64_t max_threads = 512;
-      int64_t thread_num = std::min(
-          phi::funcs::details::GetLastPow2(output_height * output_width),
-          max_threads);
-      int64_t blocks = std::min(max_threads / thread_num,
-                                static_cast<int64_t>(output_channels));
-      dim3 threads(thread_num, blocks, 1);
-      dim3 grid(std::max((output_channels + blocks - 1) / blocks,
-                         static_cast<int64_t>(1)),
-                batch_size,
-                1);
-      AdaptiveKernelPool2D<PoolProcess, T>
-          <<<grid, threads, 0, context.stream()>>>(nthreads,
-                                                   input_data,
-                                                   input_channels,
-                                                   input_height,
-                                                   input_width,
-                                                   output_height,
-                                                   output_width,
-                                                   ksize_height,
-                                                   ksize_width,
-                                                   stride_height,
-                                                   stride_width,
-                                                   padding_height,
-                                                   padding_width,
-                                                   pool_divmods,
-                                                   pool_process,
-                                                   exclusive,
-                                                   output_data);
-    } else {
-      int thread_num = 1024;
-#ifdef WITH_NV_JETSON
-      backends::gpu::ChangeThreadNum(context, &thread_num);
-#endif
-      int blocks = (nthreads + thread_num - 1) / thread_num;
-      dim3 threads(thread_num, 1);
-      dim3 grid(blocks, 1);
-      KernelPool2D<PoolProcess, T>
-          <<<grid, threads, 0, context.stream()>>>(nthreads,
-                                                   input_data,
-                                                   input_channels,
-                                                   input_height,
-                                                   input_width,
-                                                   output_height,
-                                                   output_width,
-                                                   ksize_height,
-                                                   ksize_width,
-                                                   stride_height,
-                                                   stride_width,
-                                                   padding_height,
-                                                   padding_width,
-                                                   pool_divmods,
-                                                   pool_process,
-                                                   exclusive,
-                                                   output_data);
-    }
-  }
-  void operator()(const phi::GPUContext& context,
-                  const DenseTensor& input,
-                  const std::vector<int>& ksize,
-                  const std::vector<int>& strides,
-                  const std::vector<int>& paddings,
+                  const std::vector<int64_t>& ksize,
+                  const std::vector<int64_t>& strides,
+                  const std::vector<int64_t>& paddings,
                   const std::string data_format,
                   bool exclusive,
                   bool adaptive,
                   DenseTensor* output,
                   PoolProcess pool_process) {
     bool channel_last = (data_format == "NHWC");
-    const int batch_size = input.dims()[0];
+    const int64_t batch_size = input.dims()[0];
 
-    const int input_channels = channel_last ? input.dims()[3] : input.dims()[1];
-    const int input_height = channel_last ? input.dims()[1] : input.dims()[2];
-    const int input_width = channel_last ? input.dims()[2] : input.dims()[3];
+    const int64_t input_channels =
+        channel_last ? input.dims()[3] : input.dims()[1];
+    const int64_t input_height =
+        channel_last ? input.dims()[1] : input.dims()[2];
+    const int64_t input_width =
+        channel_last ? input.dims()[2] : input.dims()[3];
 
-    const int output_channels =
+    const int64_t output_channels =
         channel_last ? output->dims()[3] : output->dims()[1];
-    const int output_height =
+    const int64_t output_height =
         channel_last ? output->dims()[1] : output->dims()[2];
-    const int output_width =
+    const int64_t output_width =
         channel_last ? output->dims()[2] : output->dims()[3];
 
-    const int ksize_height = ksize[0];
-    const int ksize_width = ksize[1];
+    const int64_t ksize_height = ksize[0];
+    const int64_t ksize_width = ksize[1];
 
-    const int stride_height = strides[0];
-    const int stride_width = strides[1];
+    const int64_t stride_height = strides[0];
+    const int64_t stride_width = strides[1];
 
-    const int padding_height = paddings[0];
-    const int padding_width = paddings[1];
+    const int64_t padding_height = paddings[0];
+    const int64_t padding_width = paddings[1];
 
     const T* input_data = input.data<T>();
     T* output_data = context.template Alloc<T>(output);
 
-    int64_t nthreads = static_cast<int64_t>(batch_size) * output_channels *
-                       output_height * output_width;
-    auto pool_divmods =
-        FastDivModForPooling(input_channels, output_width, output_height);
+    int64_t nthreads =
+        batch_size * output_channels * output_height * output_width;
+    auto pool_divmods = FastDivModForPooling<int64_t>(
+        input_channels, output_width, output_height);
     if (adaptive) {
       int64_t max_threads = 512;
       int64_t thread_num = std::min(
@@ -699,7 +632,7 @@ class Pool2dFunctor<phi::GPUContext, PoolProcess, T> {
 #ifdef WITH_NV_JETSON
       backends::gpu::ChangeThreadNum(context, &thread_num);
 #endif
-      int blocks = (nthreads + thread_num - 1) / thread_num;
+      uint blocks = (nthreads + thread_num - 1) / thread_num;
       dim3 threads(thread_num, 1);
       dim3 grid(blocks, 1);
       KernelPool2D<PoolProcess, T>
@@ -738,71 +671,9 @@ class Pool2dGradFunctor<phi::GPUContext, PoolProcess, T> {
                   const DenseTensor& input,
                   const DenseTensor& output,
                   const DenseTensor& output_grad,
-                  const std::vector<int>& ksize,
-                  const std::vector<int>& strides,
-                  const std::vector<int>& paddings,
-                  bool exclusive,
-                  bool adaptive,
-                  DenseTensor* input_grad,
-                  PoolProcess pool_process) {
-    const int batch_size = input.dims()[0];
-    const int input_channels = input.dims()[1];
-    const int input_height = input.dims()[2];
-    const int input_width = input.dims()[3];
-    const int output_height = output.dims()[2];
-    const int output_width = output.dims()[3];
-    const int ksize_height = ksize[0];
-    const int ksize_width = ksize[1];
-    const int stride_height = strides[0];
-    const int stride_width = strides[1];
-    const int padding_height = paddings[0];
-    const int padding_width = paddings[1];
-
-    const T* input_data = input.data<T>();
-    const T* output_data = output.data<T>();
-    const T* output_grad_data = output_grad.data<T>();
-    T* input_grad_data = context.template Alloc<T>(input_grad);
-
-    int nthreads = batch_size * input_channels * input_height * input_width;
-    auto pool_divmods = FastDivModForPoolingWithMoreStaff(input_channels,
-                                                          input_width,
-                                                          input_height,
-                                                          ksize_width,
-                                                          ksize_height,
-                                                          stride_width,
-                                                          stride_height);
-
-    auto config = phi::backends::gpu::GetGpuLaunchConfig1D(context, nthreads);
-    KernelPool2DGrad<T, PoolProcess><<<config.block_per_grid,
-                                       config.thread_per_block,
-                                       0,
-                                       context.stream()>>>(nthreads,
-                                                           input_data,
-                                                           output_data,
-                                                           output_grad_data,
-                                                           output_width,
-                                                           output_height,
-                                                           input_width,
-                                                           input_height,
-                                                           ksize_width,
-                                                           ksize_height,
-                                                           stride_width,
-                                                           stride_height,
-                                                           padding_width,
-                                                           padding_height,
-                                                           pool_divmods,
-                                                           pool_process,
-                                                           exclusive,
-                                                           adaptive,
-                                                           input_grad_data);
-  }
-  void operator()(const phi::GPUContext& context,
-                  const DenseTensor& input,
-                  const DenseTensor& output,
-                  const DenseTensor& output_grad,
-                  const std::vector<int>& ksize,
-                  const std::vector<int>& strides,
-                  const std::vector<int>& paddings,
+                  const std::vector<int64_t>& ksize,
+                  const std::vector<int64_t>& strides,
+                  const std::vector<int64_t>& paddings,
                   const std::string data_format,
                   bool exclusive,
                   bool adaptive,
@@ -810,40 +681,44 @@ class Pool2dGradFunctor<phi::GPUContext, PoolProcess, T> {
                   PoolProcess pool_process) {
     bool channel_last = (data_format == "NHWC");
 
-    const int batch_size = input.dims()[0];
-    const int input_channels = channel_last ? input.dims()[3] : input.dims()[1];
-    const int input_height = channel_last ? input.dims()[1] : input.dims()[2];
-    const int input_width = channel_last ? input.dims()[2] : input.dims()[3];
+    const int64_t batch_size = input.dims()[0];
+    const int64_t input_channels =
+        channel_last ? input.dims()[3] : input.dims()[1];
+    const int64_t input_height =
+        channel_last ? input.dims()[1] : input.dims()[2];
+    const int64_t input_width =
+        channel_last ? input.dims()[2] : input.dims()[3];
 
-    const int output_channels =
+    const int64_t output_channels =
         channel_last ? output.dims()[3] : output.dims()[1];
-    const int output_height =
+    const int64_t output_height =
         channel_last ? output.dims()[1] : output.dims()[2];
-    const int output_width = channel_last ? output.dims()[2] : output.dims()[3];
+    const int64_t output_width =
+        channel_last ? output.dims()[2] : output.dims()[3];
 
-    const int ksize_height = ksize[0];
-    const int ksize_width = ksize[1];
+    const int64_t ksize_height = ksize[0];
+    const int64_t ksize_width = ksize[1];
 
-    const int stride_height = strides[0];
-    const int stride_width = strides[1];
+    const int64_t stride_height = strides[0];
+    const int64_t stride_width = strides[1];
 
-    const int padding_height = paddings[0];
-    const int padding_width = paddings[1];
+    const int64_t padding_height = paddings[0];
+    const int64_t padding_width = paddings[1];
 
     const T* input_data = input.data<T>();
     const T* output_data = output.data<T>();
     const T* output_grad_data = output_grad.data<T>();
     T* input_grad_data = context.template Alloc<T>(input_grad);
 
-    int nthreads = batch_size * input_channels * input_height * input_width;
-    auto pool_divmods = FastDivModForPoolingWithMoreStaff(input_channels,
-                                                          input_width,
-                                                          input_height,
-                                                          ksize_width,
-                                                          ksize_height,
-                                                          stride_width,
-                                                          stride_height);
-
+    int64_t nthreads = batch_size * input_channels * input_height * input_width;
+    auto pool_divmods =
+        FastDivModForPoolingWithMoreStaff<int64_t>(input_channels,
+                                                   input_width,
+                                                   input_height,
+                                                   ksize_width,
+                                                   ksize_height,
+                                                   stride_width,
+                                                   stride_height);
     auto config = phi::backends::gpu::GetGpuLaunchConfig1D(context, nthreads);
     KernelPool2DGrad<T, PoolProcess><<<config.block_per_grid,
                                        config.thread_per_block,
@@ -885,94 +760,46 @@ class MaxPool2dGradFunctor<phi::GPUContext, T> {
                   const DenseTensor& input,
                   const DenseTensor& output,
                   const DenseTensor& output_grad,
-                  const std::vector<int>& ksize,
-                  const std::vector<int>& strides,
-                  const std::vector<int>& paddings,
-                  DenseTensor* input_grad) {
-    const int batch_size = input.dims()[0];
-    const int input_channels = input.dims()[1];
-    const int input_height = input.dims()[2];
-    const int input_width = input.dims()[3];
-    const int output_channels = output.dims()[1];
-    const int output_height = output.dims()[2];
-    const int output_width = output.dims()[3];
-    const int ksize_height = ksize[0];
-    const int ksize_width = ksize[1];
-    const int stride_height = strides[0];
-    const int stride_width = strides[1];
-    const int padding_height = paddings[0];
-    const int padding_width = paddings[1];
-
-    const T* input_data = input.data<T>();
-    const T* output_data = output.data<T>();
-    const T* output_grad_data = output_grad.data<T>();
-    T* input_grad_data = context.template Alloc<T>(input_grad);
-
-    int nthreads = batch_size * output_channels * output_height * output_width;
-    int blocks = (nthreads + 1024 - 1) / 1024;
-    dim3 threads(1024, 1);
-    dim3 grid(blocks, 1);
-
-    auto pool_divmods =
-        FastDivModForPooling(input_channels, output_width, output_height);
-    KernelMaxPool2DGrad<T>
-        <<<grid, threads, 0, context.stream()>>>(nthreads,
-                                                 input_data,
-                                                 output_data,
-                                                 output_grad_data,
-                                                 input_channels,
-                                                 input_height,
-                                                 input_width,
-                                                 output_height,
-                                                 output_width,
-                                                 ksize_height,
-                                                 ksize_width,
-                                                 stride_height,
-                                                 stride_width,
-                                                 padding_height,
-                                                 padding_width,
-                                                 input_grad_data,
-                                                 pool_divmods);
-  }
-  void operator()(const phi::GPUContext& context,
-                  const DenseTensor& input,
-                  const DenseTensor& output,
-                  const DenseTensor& output_grad,
-                  const std::vector<int>& ksize,
-                  const std::vector<int>& strides,
-                  const std::vector<int>& paddings,
+                  const std::vector<int64_t>& ksize,
+                  const std::vector<int64_t>& strides,
+                  const std::vector<int64_t>& paddings,
                   const std::string data_format,
                   DenseTensor* input_grad) {
     bool channel_last = (data_format == "NHWC");
 
-    const int batch_size = input.dims()[0];
+    const int64_t batch_size = input.dims()[0];
 
-    const int input_channels = channel_last ? input.dims()[3] : input.dims()[1];
-    const int input_height = channel_last ? input.dims()[1] : input.dims()[2];
-    const int input_width = channel_last ? input.dims()[2] : input.dims()[3];
+    const int64_t input_channels =
+        channel_last ? input.dims()[3] : input.dims()[1];
+    const int64_t input_height =
+        channel_last ? input.dims()[1] : input.dims()[2];
+    const int64_t input_width =
+        channel_last ? input.dims()[2] : input.dims()[3];
 
-    const int output_channels =
+    const int64_t output_channels =
         channel_last ? output.dims()[3] : output.dims()[1];
-    const int output_height =
+    const int64_t output_height =
         channel_last ? output.dims()[1] : output.dims()[2];
-    const int output_width = channel_last ? output.dims()[2] : output.dims()[3];
+    const int64_t output_width =
+        channel_last ? output.dims()[2] : output.dims()[3];
 
-    const int ksize_height = ksize[0];
-    const int ksize_width = ksize[1];
+    const int64_t ksize_height = ksize[0];
+    const int64_t ksize_width = ksize[1];
 
-    const int stride_height = strides[0];
-    const int stride_width = strides[1];
+    const int64_t stride_height = strides[0];
+    const int64_t stride_width = strides[1];
 
-    const int padding_height = paddings[0];
-    const int padding_width = paddings[1];
+    const int64_t padding_height = paddings[0];
+    const int64_t padding_width = paddings[1];
 
     const T* input_data = input.data<T>();
     const T* output_data = output.data<T>();
     const T* output_grad_data = output_grad.data<T>();
     T* input_grad_data = context.template Alloc<T>(input_grad);
 
-    int nthreads = batch_size * output_channels * output_height * output_width;
-    int blocks = (nthreads + 1024 - 1) / 1024;
+    int64_t nthreads =
+        batch_size * output_channels * output_height * output_width;
+    uint blocks = (nthreads + 1024 - 1) / 1024;
     dim3 threads(1024, 1);
     dim3 grid(blocks, 1);
 
@@ -1060,32 +887,34 @@ template class Pool2dGradFunctor<phi::GPUContext,
                                  dtype::bfloat16>;
 
 template <typename PoolProcess, typename T>
-__global__ void KernelPool3D(const int nthreads,
+__global__ void KernelPool3D(const int64_t nthreads,
                              const T* input_data,
-                             const int channels,
-                             const int input_depth,
-                             const int input_height,
-                             const int input_width,
-                             const int output_depth,
-                             const int output_height,
-                             const int output_width,
-                             const int ksize_depth,
-                             const int ksize_height,
-                             const int ksize_width,
-                             const int stride_depth,
-                             const int stride_height,
-                             const int stride_width,
-                             const int padding_depth,
-                             const int padding_height,
-                             const int padding_width,
+                             const int64_t channels,
+                             const int64_t input_depth,
+                             const int64_t input_height,
+                             const int64_t input_width,
+                             const int64_t output_depth,
+                             const int64_t output_height,
+                             const int64_t output_width,
+                             const int64_t ksize_depth,
+                             const int64_t ksize_height,
+                             const int64_t ksize_width,
+                             const int64_t stride_depth,
+                             const int64_t stride_height,
+                             const int64_t stride_width,
+                             const int64_t padding_depth,
+                             const int64_t padding_height,
+                             const int64_t padding_width,
                              PoolProcess pool_process,
                              bool exclusive,
                              bool adaptive,
                              T* output_data,
                              bool channel_last = false) {
-  for (int index = blockIdx.x * blockDim.x + threadIdx.x; index < nthreads;
-       index += blockDim.x * gridDim.x) {
-    int pw, ph, pd, c, batch_idx;
+  const int64_t start_index =
+      static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const int64_t step = static_cast<int64_t>(blockDim.x) * gridDim.x;
+  for (int64_t index = start_index; index < nthreads; index += step) {
+    int64_t pw, ph, pd, c, batch_idx;
     if (!channel_last) {
       pw = index % output_width;
       ph = (index / output_width) % output_height;
@@ -1102,9 +931,9 @@ __global__ void KernelPool3D(const int nthreads,
           index / channels / output_width / output_height / output_depth;
     }
 
-    int dstart, dend;
-    int hstart, hend;
-    int wstart, wend;
+    int64_t dstart, dend;
+    int64_t hstart, hend;
+    int64_t wstart, wend;
     if (adaptive) {
       dstart = AdaptStartIndex(pd, input_depth, output_depth);
       dend = AdaptEndIndex(pd, input_depth, output_depth);
@@ -1121,12 +950,12 @@ __global__ void KernelPool3D(const int nthreads,
       dend = min(dstart + ksize_depth, input_depth);
       hend = min(hstart + ksize_height, input_height);
       wend = min(wstart + ksize_width, input_width);
-      dstart = max(dstart, 0);
-      hstart = max(hstart, 0);
-      wstart = max(wstart, 0);
+      dstart = max(dstart, static_cast<int64_t>(0));
+      hstart = max(hstart, static_cast<int64_t>(0));
+      wstart = max(wstart, static_cast<int64_t>(0));
     }
 
-    int input_data_stride;
+    int64_t input_data_stride;
     if (!channel_last) { /* NCDHW */
       input_data_stride =
           (batch_idx * channels + c) * input_depth * input_height * input_width;
@@ -1137,9 +966,9 @@ __global__ void KernelPool3D(const int nthreads,
     input_data += input_data_stride;
 
     T ele = pool_process.initial();
-    for (int d = dstart; d < dend; ++d) {
-      for (int h = hstart; h < hend; ++h) {
-        for (int w = wstart; w < wend; ++w) {
+    for (int64_t d = dstart; d < dend; ++d) {
+      for (int64_t h = hstart; h < hend; ++h) {
+        for (int64_t w = wstart; w < wend; ++w) {
           auto input_data_idx =
               channel_last
                   ? ((d * input_height + h) * input_width + w) * channels + c
@@ -1148,43 +977,46 @@ __global__ void KernelPool3D(const int nthreads,
         }
       }
     }
-    int pool_size = (exclusive || adaptive)
-                        ? (dend - dstart) * (hend - hstart) * (wend - wstart)
-                        : ksize_depth * ksize_height * ksize_width;
+    int64_t pool_size =
+        (exclusive || adaptive)
+            ? (dend - dstart) * (hend - hstart) * (wend - wstart)
+            : ksize_depth * ksize_height * ksize_width;
     pool_process.finalize(static_cast<T>(pool_size), &ele);
     output_data[index] = ele;
   }
 }
 
 template <typename T, typename PoolProcess>
-__global__ void KernelPool3DGrad(const int nthreads,
+__global__ void KernelPool3DGrad(const int64_t nthreads,
                                  const T* __restrict__ input_data,
                                  const T* __restrict__ output_data,
                                  const T* __restrict__ output_grad,
-                                 const int channels,
-                                 const int input_depth,
-                                 const int input_height,
-                                 const int input_width,
-                                 const int output_depth,
-                                 const int output_height,
-                                 const int output_width,
-                                 const int ksize_depth,
-                                 const int ksize_height,
-                                 const int ksize_width,
-                                 const int stride_depth,
-                                 const int stride_height,
-                                 const int stride_width,
-                                 const int padding_depth,
-                                 const int padding_height,
-                                 const int padding_width,
+                                 const int64_t channels,
+                                 const int64_t input_depth,
+                                 const int64_t input_height,
+                                 const int64_t input_width,
+                                 const int64_t output_depth,
+                                 const int64_t output_height,
+                                 const int64_t output_width,
+                                 const int64_t ksize_depth,
+                                 const int64_t ksize_height,
+                                 const int64_t ksize_width,
+                                 const int64_t stride_depth,
+                                 const int64_t stride_height,
+                                 const int64_t stride_width,
+                                 const int64_t padding_depth,
+                                 const int64_t padding_height,
+                                 const int64_t padding_width,
                                  PoolProcess pool_process,
                                  bool exclusive,
                                  bool adaptive,
                                  T* input_grad,
                                  bool channel_last = false) {
-  for (int index = blockIdx.x * blockDim.x + threadIdx.x; index < nthreads;
-       index += blockDim.x * gridDim.x) {
-    int w_offset, h_offset, d_offset, c_offset, batch_idx, output_stride;
+  const int64_t start_index =
+      static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const int64_t step = static_cast<int64_t>(blockDim.x) * gridDim.x;
+  for (int64_t index = start_index; index < nthreads; index += step) {
+    int64_t w_offset, h_offset, d_offset, c_offset, batch_idx, output_stride;
     T input = static_cast<T>(0);
     if (!channel_last) { /* "NCDHW" */
       w_offset = index % input_width + padding_width;
@@ -1207,9 +1039,9 @@ __global__ void KernelPool3DGrad(const int nthreads,
           batch_idx * output_depth * output_height * output_width * channels;
     }
 
-    int pdstart, pdend;
-    int phstart, phend;
-    int pwstart, pwend;
+    int64_t pdstart, pdend;
+    int64_t phstart, phend;
+    int64_t pwstart, pwend;
     if (adaptive) {
       pdstart = AdaptStartIndex(d_offset, output_depth, input_depth);
       pdend = AdaptEndIndex(d_offset, output_depth, input_depth);
@@ -1240,35 +1072,35 @@ __global__ void KernelPool3DGrad(const int nthreads,
     output_grad += output_stride;
     T input_grad_data = static_cast<T>(0.0);
 
-    for (int pd = pdstart; pd < pdend; ++pd) {
-      for (int ph = phstart; ph < phend; ++ph) {
-        for (int pw = pwstart; pw < pwend; ++pw) {
+    for (int64_t pd = pdstart; pd < pdend; ++pd) {
+      for (int64_t ph = phstart; ph < phend; ++ph) {
+        for (int64_t pw = pwstart; pw < pwend; ++pw) {
           // figure out the pooling size
-          int pool_size;
+          int64_t pool_size;
           if (adaptive) {
             pool_size =
-                static_cast<int>(
+                static_cast<int64_t>(
                     ceil(static_cast<double>(input_depth) / ksize_depth)) *
-                static_cast<int>(
+                static_cast<int64_t>(
                     ceil(static_cast<double>(input_height) / ksize_height)) *
-                static_cast<int>(
+                static_cast<int64_t>(
                     ceil(static_cast<double>(input_width) / ksize_width));
           } else {
-            int dstart = pd * stride_depth - padding_depth;
-            int hstart = ph * stride_height - padding_height;
-            int wstart = pw * stride_width - padding_width;
-            int dend = min(dstart + ksize_depth, input_depth);
-            int hend = min(hstart + ksize_height, input_height);
-            int wend = min(wstart + ksize_width, input_width);
-            dstart = max(dstart, 0);
-            hstart = max(hstart, 0);
-            wstart = max(wstart, 0);
+            int64_t dstart = pd * stride_depth - padding_depth;
+            int64_t hstart = ph * stride_height - padding_height;
+            int64_t wstart = pw * stride_width - padding_width;
+            int64_t dend = min(dstart + ksize_depth, input_depth);
+            int64_t hend = min(hstart + ksize_height, input_height);
+            int64_t wend = min(wstart + ksize_width, input_width);
+            dstart = max(dstart, static_cast<int64_t>(0));
+            hstart = max(hstart, static_cast<int64_t>(0));
+            wstart = max(wstart, static_cast<int64_t>(0));
             pool_size =
                 exclusive ? (dend - dstart) * (hend - hstart) * (wend - wstart)
                           : ksize_depth * ksize_height * ksize_width;
           }
 
-          int output_sub_idx =
+          int64_t output_sub_idx =
               channel_last
                   ? ((pd * output_height + ph) * output_width + pw) * channels +
                         c_offset
@@ -1288,31 +1120,33 @@ __global__ void KernelPool3DGrad(const int nthreads,
 }
 
 template <typename T>
-__global__ void KernelMaxPool3DGrad(const int nthreads,
+__global__ void KernelMaxPool3DGrad(const int64_t nthreads,
                                     const T* input_data,
                                     const T* output_data,
                                     const T* output_grad,
-                                    const int channels,
-                                    const int input_depth,
-                                    const int input_height,
-                                    const int input_width,
-                                    const int output_depth,
-                                    const int output_height,
-                                    const int output_width,
-                                    const int ksize_depth,
-                                    const int ksize_height,
-                                    const int ksize_width,
-                                    const int stride_depth,
-                                    const int stride_height,
-                                    const int stride_width,
-                                    const int padding_depth,
-                                    const int padding_height,
-                                    const int padding_width,
+                                    const int64_t channels,
+                                    const int64_t input_depth,
+                                    const int64_t input_height,
+                                    const int64_t input_width,
+                                    const int64_t output_depth,
+                                    const int64_t output_height,
+                                    const int64_t output_width,
+                                    const int64_t ksize_depth,
+                                    const int64_t ksize_height,
+                                    const int64_t ksize_width,
+                                    const int64_t stride_depth,
+                                    const int64_t stride_height,
+                                    const int64_t stride_width,
+                                    const int64_t padding_depth,
+                                    const int64_t padding_height,
+                                    const int64_t padding_width,
                                     T* input_grad,
                                     bool channel_last = false) {
-  for (int index = blockIdx.x * blockDim.x + threadIdx.x; index < nthreads;
-       index += blockDim.x * gridDim.x) {
-    int pw, ph, pd, c, batch_idx;
+  const int64_t start_index =
+      static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const int64_t step = static_cast<int64_t>(blockDim.x) * gridDim.x;
+  for (int64_t index = start_index; index < nthreads; index += step) {
+    int64_t pw, ph, pd, c, batch_idx;
 
     if (!channel_last) { /*NCDHW*/
       pw = index % output_width;
@@ -1330,23 +1164,23 @@ __global__ void KernelMaxPool3DGrad(const int nthreads,
           index / channels / output_width / output_height / output_depth;
     }
 
-    int dstart = pd * stride_depth - padding_depth;
-    int hstart = ph * stride_height - padding_height;
-    int wstart = pw * stride_width - padding_width;
+    int64_t dstart = pd * stride_depth - padding_depth;
+    int64_t hstart = ph * stride_height - padding_height;
+    int64_t wstart = pw * stride_width - padding_width;
 
-    int dend = min(dstart + ksize_depth, input_depth);
-    int hend = min(hstart + ksize_height, input_height);
-    int wend = min(wstart + ksize_width, input_width);
+    int64_t dend = min(dstart + ksize_depth, input_depth);
+    int64_t hend = min(hstart + ksize_height, input_height);
+    int64_t wend = min(wstart + ksize_width, input_width);
 
-    dstart = max(dstart, 0);
-    hstart = max(hstart, 0);
-    wstart = max(wstart, 0);
+    dstart = max(dstart, static_cast<int64_t>(0));
+    hstart = max(hstart, static_cast<int64_t>(0));
+    wstart = max(wstart, static_cast<int64_t>(0));
 
     T ele = output_data[index];
     bool stop = false;
-    int maxIdx = -1;
+    int64_t maxIdx = -1;
 
-    int input_stride;
+    int64_t input_stride;
     if (!channel_last) {
       input_stride =
           (batch_idx * channels + c) * input_depth * input_height * input_width;
@@ -1356,10 +1190,10 @@ __global__ void KernelMaxPool3DGrad(const int nthreads,
     }
     input_data += input_stride;
     input_grad += input_stride;
-    for (int d = dstart; d < dend && !stop; ++d) {
-      for (int h = hstart; h < hend && !stop; ++h) {
-        for (int w = wstart; w < wend && !stop; ++w) {
-          int input_data_idx =
+    for (int64_t d = dstart; d < dend && !stop; ++d) {
+      for (int64_t h = hstart; h < hend && !stop; ++h) {
+        for (int64_t w = wstart; w < wend && !stop; ++w) {
+          int64_t input_data_idx =
               channel_last
                   ? ((d * input_height + h) * input_width + w) * channels + c
                   : (d * input_height + h) * input_width + w;
@@ -1456,118 +1290,57 @@ class Pool3dFunctor<phi::GPUContext, PoolProcess, T> {
  public:
   void operator()(const phi::GPUContext& context,
                   const DenseTensor& input,
-                  const std::vector<int>& ksize,
-                  const std::vector<int>& strides,
-                  const std::vector<int>& paddings,
-                  bool exclusive,
-                  bool adaptive,
-                  DenseTensor* output,
-                  PoolProcess pool_process) {
-    const int batch_size = input.dims()[0];
-    const int input_channels = input.dims()[1];
-    const int input_depth = input.dims()[2];
-    const int input_height = input.dims()[3];
-    const int input_width = input.dims()[4];
-    const int output_channels = output->dims()[1];
-    const int output_depth = output->dims()[2];
-    const int output_height = output->dims()[3];
-    const int output_width = output->dims()[4];
-    const int ksize_depth = ksize[0];
-    const int ksize_height = ksize[1];
-    const int ksize_width = ksize[2];
-    const int stride_depth = strides[0];
-    const int stride_height = strides[1];
-    const int stride_width = strides[2];
-    const int padding_depth = paddings[0];
-    const int padding_height = paddings[1];
-    const int padding_width = paddings[2];
-
-    const T* input_data = input.data<T>();
-    T* output_data = context.template Alloc<T>(output);
-
-    int nthreads = batch_size * output_channels * output_depth * output_height *
-                   output_width;
-    int thread_num = 1024;
-#ifdef WITH_NV_JETSON
-    backends::gpu::ChangeThreadNum(context, &thread_num);
-#endif
-    int blocks = (nthreads + thread_num - 1) / thread_num;
-    dim3 threads(thread_num, 1);
-    dim3 grid(blocks, 1);
-
-    KernelPool3D<PoolProcess, T>
-        <<<grid, threads, 0, context.stream()>>>(nthreads,
-                                                 input_data,
-                                                 input_channels,
-                                                 input_depth,
-                                                 input_height,
-                                                 input_width,
-                                                 output_depth,
-                                                 output_height,
-                                                 output_width,
-                                                 ksize_depth,
-                                                 ksize_height,
-                                                 ksize_width,
-                                                 stride_depth,
-                                                 stride_height,
-                                                 stride_width,
-                                                 padding_depth,
-                                                 padding_height,
-                                                 padding_width,
-                                                 pool_process,
-                                                 exclusive,
-                                                 adaptive,
-                                                 output_data);
-  }
-  void operator()(const phi::GPUContext& context,
-                  const DenseTensor& input,
-                  const std::vector<int>& ksize,
-                  const std::vector<int>& strides,
-                  const std::vector<int>& paddings,
+                  const std::vector<int64_t>& ksize,
+                  const std::vector<int64_t>& strides,
+                  const std::vector<int64_t>& paddings,
                   const std::string data_format,
                   bool exclusive,
                   bool adaptive,
                   DenseTensor* output,
                   PoolProcess pool_process) {
     bool channel_last = (data_format == "NDHWC");
-    const int batch_size = input.dims()[0];
+    const int64_t batch_size = input.dims()[0];
 
-    const int input_channels = channel_last ? input.dims()[4] : input.dims()[1];
-    const int input_depth = channel_last ? input.dims()[1] : input.dims()[2];
-    const int input_height = channel_last ? input.dims()[2] : input.dims()[3];
-    const int input_width = channel_last ? input.dims()[3] : input.dims()[4];
+    const int64_t input_channels =
+        channel_last ? input.dims()[4] : input.dims()[1];
+    const int64_t input_depth =
+        channel_last ? input.dims()[1] : input.dims()[2];
+    const int64_t input_height =
+        channel_last ? input.dims()[2] : input.dims()[3];
+    const int64_t input_width =
+        channel_last ? input.dims()[3] : input.dims()[4];
 
-    const int output_channels =
+    const int64_t output_channels =
         channel_last ? output->dims()[4] : output->dims()[1];
-    const int output_depth =
+    const int64_t output_depth =
         channel_last ? output->dims()[1] : output->dims()[2];
-    const int output_height =
+    const int64_t output_height =
         channel_last ? output->dims()[2] : output->dims()[3];
-    const int output_width =
+    const int64_t output_width =
         channel_last ? output->dims()[3] : output->dims()[4];
 
-    const int ksize_depth = ksize[0];
-    const int ksize_height = ksize[1];
-    const int ksize_width = ksize[2];
+    const int64_t ksize_depth = ksize[0];
+    const int64_t ksize_height = ksize[1];
+    const int64_t ksize_width = ksize[2];
 
-    const int stride_depth = strides[0];
-    const int stride_height = strides[1];
-    const int stride_width = strides[2];
+    const int64_t stride_depth = strides[0];
+    const int64_t stride_height = strides[1];
+    const int64_t stride_width = strides[2];
 
-    const int padding_depth = paddings[0];
-    const int padding_height = paddings[1];
-    const int padding_width = paddings[2];
+    const int64_t padding_depth = paddings[0];
+    const int64_t padding_height = paddings[1];
+    const int64_t padding_width = paddings[2];
 
     const T* input_data = input.data<T>();
     T* output_data = context.template Alloc<T>(output);
 
-    int nthreads = batch_size * output_channels * output_depth * output_height *
-                   output_width;
-    int thread_num = 1024;
+    int64_t nthreads = batch_size * output_channels * output_depth *
+                       output_height * output_width;
+    int64_t thread_num = 1024;
 #ifdef WITH_NV_JETSON
     backends::gpu::ChangeThreadNum(context, &thread_num);
 #endif
-    int blocks = (nthreads + thread_num - 1) / thread_num;
+    uint blocks = (nthreads + thread_num - 1) / thread_num;
     dim3 threads(thread_num, 1);
     dim3 grid(blocks, 1);
 
@@ -1613,76 +1386,9 @@ class Pool3dGradFunctor<phi::GPUContext, PoolProcess, T> {
                   const DenseTensor& input,
                   const DenseTensor& output,
                   const DenseTensor& output_grad,
-                  const std::vector<int>& ksize,
-                  const std::vector<int>& strides,
-                  const std::vector<int>& paddings,
-                  bool exclusive,
-                  bool adaptive,
-                  DenseTensor* input_grad,
-                  PoolProcess pool_process) {
-    const int batch_size = input.dims()[0];
-    const int input_channels = input.dims()[1];
-    const int input_depth = input.dims()[2];
-    const int input_height = input.dims()[3];
-    const int input_width = input.dims()[4];
-    const int output_channels = output.dims()[1];
-    const int output_depth = output.dims()[2];
-    const int output_height = output.dims()[3];
-    const int output_width = output.dims()[4];
-    const int ksize_depth = ksize[0];
-    const int ksize_height = ksize[1];
-    const int ksize_width = ksize[2];
-    const int stride_depth = strides[0];
-    const int stride_height = strides[1];
-    const int stride_width = strides[2];
-    const int padding_depth = paddings[0];
-    const int padding_height = paddings[1];
-    const int padding_width = paddings[2];
-
-    const T* input_data = input.data<T>();
-    const T* output_data = output.data<T>();
-    const T* output_grad_data = output_grad.data<T>();
-    T* input_grad_data = context.template Alloc<T>(input_grad);
-
-    int nthreads =
-        batch_size * input_channels * input_depth * input_height * input_width;
-    int blocks = (nthreads + 1024 - 1) / 1024;
-    dim3 threads(1024, 1);
-    dim3 grid(blocks, 1);
-
-    KernelPool3DGrad<T, PoolProcess>
-        <<<grid, threads, 0, context.stream()>>>(nthreads,
-                                                 input_data,
-                                                 output_data,
-                                                 output_grad_data,
-                                                 input_channels,
-                                                 input_depth,
-                                                 input_height,
-                                                 input_width,
-                                                 output_depth,
-                                                 output_height,
-                                                 output_width,
-                                                 ksize_depth,
-                                                 ksize_height,
-                                                 ksize_width,
-                                                 stride_depth,
-                                                 stride_height,
-                                                 stride_width,
-                                                 padding_depth,
-                                                 padding_height,
-                                                 padding_width,
-                                                 pool_process,
-                                                 exclusive,
-                                                 adaptive,
-                                                 input_grad_data);
-  }
-  void operator()(const phi::GPUContext& context,
-                  const DenseTensor& input,
-                  const DenseTensor& output,
-                  const DenseTensor& output_grad,
-                  const std::vector<int>& ksize,
-                  const std::vector<int>& strides,
-                  const std::vector<int>& paddings,
+                  const std::vector<int64_t>& ksize,
+                  const std::vector<int64_t>& strides,
+                  const std::vector<int64_t>& paddings,
                   const std::string data_format,
                   bool exclusive,
                   bool adaptive,
@@ -1690,39 +1396,45 @@ class Pool3dGradFunctor<phi::GPUContext, PoolProcess, T> {
                   PoolProcess pool_process) {
     bool channel_last = (data_format == "NDHWC");
 
-    const int batch_size = input.dims()[0];
-    const int input_channels = channel_last ? input.dims()[4] : input.dims()[1];
-    const int input_depth = channel_last ? input.dims()[1] : input.dims()[2];
-    const int input_height = channel_last ? input.dims()[2] : input.dims()[3];
-    const int input_width = channel_last ? input.dims()[3] : input.dims()[4];
+    const int64_t batch_size = input.dims()[0];
+    const int64_t input_channels =
+        channel_last ? input.dims()[4] : input.dims()[1];
+    const int64_t input_depth =
+        channel_last ? input.dims()[1] : input.dims()[2];
+    const int64_t input_height =
+        channel_last ? input.dims()[2] : input.dims()[3];
+    const int64_t input_width =
+        channel_last ? input.dims()[3] : input.dims()[4];
 
-    const int output_channels =
+    const int64_t output_channels =
         channel_last ? output.dims()[4] : output.dims()[1];
-    const int output_depth = channel_last ? output.dims()[1] : output.dims()[2];
-    const int output_height =
+    const int64_t output_depth =
+        channel_last ? output.dims()[1] : output.dims()[2];
+    const int64_t output_height =
         channel_last ? output.dims()[2] : output.dims()[3];
-    const int output_width = channel_last ? output.dims()[3] : output.dims()[4];
+    const int64_t output_width =
+        channel_last ? output.dims()[3] : output.dims()[4];
 
-    const int ksize_depth = ksize[0];
-    const int ksize_height = ksize[1];
-    const int ksize_width = ksize[2];
+    const int64_t ksize_depth = ksize[0];
+    const int64_t ksize_height = ksize[1];
+    const int64_t ksize_width = ksize[2];
 
-    const int stride_depth = strides[0];
-    const int stride_height = strides[1];
-    const int stride_width = strides[2];
+    const int64_t stride_depth = strides[0];
+    const int64_t stride_height = strides[1];
+    const int64_t stride_width = strides[2];
 
-    const int padding_depth = paddings[0];
-    const int padding_height = paddings[1];
-    const int padding_width = paddings[2];
+    const int64_t padding_depth = paddings[0];
+    const int64_t padding_height = paddings[1];
+    const int64_t padding_width = paddings[2];
 
     const T* input_data = input.data<T>();
     const T* output_data = output.data<T>();
     const T* output_grad_data = output_grad.data<T>();
     T* input_grad_data = context.template Alloc<T>(input_grad);
 
-    int nthreads =
+    int64_t nthreads =
         batch_size * input_channels * input_depth * input_height * input_width;
-    int blocks = (nthreads + 1024 - 1) / 1024;
+    uint blocks = (nthreads + 1024 - 1) / 1024;
     dim3 threads(1024, 1);
     dim3 grid(blocks, 1);
 
@@ -1770,107 +1482,52 @@ class MaxPool3dGradFunctor<phi::GPUContext, T> {
                   const DenseTensor& input,
                   const DenseTensor& output,
                   const DenseTensor& output_grad,
-                  const std::vector<int>& ksize,
-                  const std::vector<int>& strides,
-                  const std::vector<int>& paddings,
-                  DenseTensor* input_grad) {
-    const int batch_size = input.dims()[0];
-    const int input_channels = input.dims()[1];
-    const int input_depth = input.dims()[2];
-    const int input_height = input.dims()[3];
-    const int input_width = input.dims()[4];
-    const int output_channels = output.dims()[1];
-    const int output_depth = output.dims()[2];
-    const int output_height = output.dims()[3];
-    const int output_width = output.dims()[4];
-    const int ksize_depth = ksize[0];
-    const int ksize_height = ksize[1];
-    const int ksize_width = ksize[2];
-    const int stride_depth = strides[0];
-    const int stride_height = strides[1];
-    const int stride_width = strides[2];
-    const int padding_depth = paddings[0];
-    const int padding_height = paddings[1];
-    const int padding_width = paddings[2];
-
-    const T* input_data = input.data<T>();
-    const T* output_data = output.data<T>();
-    const T* output_grad_data = output_grad.data<T>();
-    T* input_grad_data = context.template Alloc<T>(input_grad);
-
-    int nthreads = batch_size * output_channels * output_depth * output_height *
-                   output_width;
-    int blocks = (nthreads + 1024 - 1) / 1024;
-    dim3 threads(1024, 1);
-    dim3 grid(blocks, 1);
-
-    KernelMaxPool3DGrad<T>
-        <<<grid, threads, 0, context.stream()>>>(nthreads,
-                                                 input_data,
-                                                 output_data,
-                                                 output_grad_data,
-                                                 input_channels,
-                                                 input_depth,
-                                                 input_height,
-                                                 input_width,
-                                                 output_depth,
-                                                 output_height,
-                                                 output_width,
-                                                 ksize_depth,
-                                                 ksize_height,
-                                                 ksize_width,
-                                                 stride_depth,
-                                                 stride_height,
-                                                 stride_width,
-                                                 padding_depth,
-                                                 padding_height,
-                                                 padding_width,
-                                                 input_grad_data);
-  }
-  void operator()(const phi::GPUContext& context,
-                  const DenseTensor& input,
-                  const DenseTensor& output,
-                  const DenseTensor& output_grad,
-                  const std::vector<int>& ksize,
-                  const std::vector<int>& strides,
-                  const std::vector<int>& paddings,
+                  const std::vector<int64_t>& ksize,
+                  const std::vector<int64_t>& strides,
+                  const std::vector<int64_t>& paddings,
                   const std::string data_format,
                   DenseTensor* input_grad) {
     bool channel_last = (data_format == "NDHWC");
-    const int batch_size = input.dims()[0];
+    const int64_t batch_size = input.dims()[0];
 
-    const int input_channels = channel_last ? input.dims()[4] : input.dims()[1];
-    const int input_depth = channel_last ? input.dims()[1] : input.dims()[2];
-    const int input_height = channel_last ? input.dims()[2] : input.dims()[3];
-    const int input_width = channel_last ? input.dims()[3] : input.dims()[4];
+    const int64_t input_channels =
+        channel_last ? input.dims()[4] : input.dims()[1];
+    const int64_t input_depth =
+        channel_last ? input.dims()[1] : input.dims()[2];
+    const int64_t input_height =
+        channel_last ? input.dims()[2] : input.dims()[3];
+    const int64_t input_width =
+        channel_last ? input.dims()[3] : input.dims()[4];
 
-    const int output_channels =
+    const int64_t output_channels =
         channel_last ? output.dims()[4] : output.dims()[1];
-    const int output_depth = channel_last ? output.dims()[1] : output.dims()[2];
-    const int output_height =
+    const int64_t output_depth =
+        channel_last ? output.dims()[1] : output.dims()[2];
+    const int64_t output_height =
         channel_last ? output.dims()[2] : output.dims()[3];
-    const int output_width = channel_last ? output.dims()[3] : output.dims()[4];
+    const int64_t output_width =
+        channel_last ? output.dims()[3] : output.dims()[4];
 
-    const int ksize_depth = ksize[0];
-    const int ksize_height = ksize[1];
-    const int ksize_width = ksize[2];
+    const int64_t ksize_depth = ksize[0];
+    const int64_t ksize_height = ksize[1];
+    const int64_t ksize_width = ksize[2];
 
-    const int stride_depth = strides[0];
-    const int stride_height = strides[1];
-    const int stride_width = strides[2];
+    const int64_t stride_depth = strides[0];
+    const int64_t stride_height = strides[1];
+    const int64_t stride_width = strides[2];
 
-    const int padding_depth = paddings[0];
-    const int padding_height = paddings[1];
-    const int padding_width = paddings[2];
+    const int64_t padding_depth = paddings[0];
+    const int64_t padding_height = paddings[1];
+    const int64_t padding_width = paddings[2];
 
     const T* input_data = input.data<T>();
     const T* output_data = output.data<T>();
     const T* output_grad_data = output_grad.data<T>();
     T* input_grad_data = context.template Alloc<T>(input_grad);
 
-    int nthreads = batch_size * output_channels * output_depth * output_height *
-                   output_width;
-    int blocks = (nthreads + 1024 - 1) / 1024;
+    int64_t nthreads = batch_size * output_channels * output_depth *
+                       output_height * output_width;
+    uint blocks = (nthreads + 1024 - 1) / 1024;
     dim3 threads(1024, 1);
     dim3 grid(blocks, 1);
 
@@ -1959,22 +1616,25 @@ __global__ void KernelMaxPool2dWithIdx(const int nthreads,
                                        bool adaptive,
                                        T1* output_data,
                                        T2* mask_data,
-                                       FastDivModForPooling divmods) {
-  for (int index = blockIdx.x * blockDim.x + threadIdx.x; index < nthreads;
-       index += blockDim.x * gridDim.x) {
+                                       FastDivModForPooling<int> divmods) {
+  const int64_t start_index =
+      static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const int64_t step = static_cast<int64_t>(blockDim.x) * gridDim.x;
+  for (int64_t index = start_index; index < nthreads; index += step) {
     int hstart, hend, wstart, wend;
     int w_offset, h_offset, c_offset, input_offset;
-    OffsetPreparationFor4Dimension<FastDivModForPooling>(index,
-                                                         false,
-                                                         divmods,
-                                                         0,
-                                                         0,
-                                                         input_width,
-                                                         input_height,
-                                                         &w_offset,
-                                                         &h_offset,
-                                                         &c_offset,
-                                                         &input_offset);
+    OffsetPreparationFor4Dimension<FastDivModForPooling<int>, int>(
+        index,
+        false,
+        divmods,
+        0,
+        0,
+        input_width,
+        input_height,
+        &w_offset,
+        &h_offset,
+        &c_offset,
+        &input_offset);
     input_data += input_offset;
 
     if (adaptive) {
@@ -2010,22 +1670,23 @@ __global__ void KernelMaxPool2dWithIdx(const int nthreads,
 }
 
 template <typename T1, typename T2>
-__global__ void AdaptiveKernelMaxPool2dWithIdx(const int nthreads,
-                                               const T1* input_data,
-                                               const int channels,
-                                               const int input_height,
-                                               const int input_width,
-                                               const int output_height,
-                                               const int output_width,
-                                               const int ksize_height,
-                                               const int ksize_width,
-                                               const int stride_height,
-                                               const int stride_width,
-                                               const int padding_height,
-                                               const int padding_width,
-                                               T1* output_data,
-                                               T2* mask_data,
-                                               FastDivModForPooling divmods) {
+__global__ void AdaptiveKernelMaxPool2dWithIdx(
+    const int nthreads,
+    const T1* input_data,
+    const int channels,
+    const int input_height,
+    const int input_width,
+    const int output_height,
+    const int output_width,
+    const int ksize_height,
+    const int ksize_width,
+    const int stride_height,
+    const int stride_width,
+    const int padding_height,
+    const int padding_width,
+    T1* output_data,
+    T2* mask_data,
+    FastDivModForPooling<int> divmods) {
   const int n_offset = blockIdx.y;
   const int c_offset = blockIdx.x * blockDim.y + threadIdx.y;
   if (c_offset >= channels) {
@@ -2079,22 +1740,23 @@ __global__ void KernelMaxPool2DWithIdxGrad(const int nthreads,
                                            const int padding_width,
                                            bool adaptive,
                                            T1* input_grad,
-                                           FastDivModForPooling divmods) {
+                                           FastDivModForPooling<int> divmods) {
   for (int index = blockIdx.x * blockDim.x + threadIdx.x; index < nthreads;
        index += blockDim.x * gridDim.x) {
     int phstart, phend, pwstart, pwend;
     int w_offset, h_offset, c_offset, output_offset;
-    OffsetPreparationFor4Dimension<FastDivModForPooling>(index,
-                                                         false,
-                                                         divmods,
-                                                         0,
-                                                         0,
-                                                         output_width,
-                                                         output_height,
-                                                         &w_offset,
-                                                         &h_offset,
-                                                         &c_offset,
-                                                         &output_offset);
+    OffsetPreparationFor4Dimension<FastDivModForPooling<int>, int>(
+        index,
+        false,
+        divmods,
+        0,
+        0,
+        output_width,
+        output_height,
+        &w_offset,
+        &h_offset,
+        &c_offset,
+        &output_offset);
     mask_data += output_offset;
     output_grad += output_offset;
 
@@ -2626,7 +2288,7 @@ __global__ void FractionalKernelMaxPool2d(const int ncd,
                                           uint64_t offset,
                                           T1* output_data,
                                           T2* mask_data,
-                                          FastDivModForPooling divmods) {
+                                          FastDivModForPooling<int> divmods) {
   float alpha_height = 0, alpha_width = 0;
   float u_height = 0, u_width = 0;
   float u = 0;
@@ -2705,21 +2367,22 @@ __global__ void FractionalKernelMaxPool2d(const int ncd,
 }
 
 template <typename T1, typename T2>
-__global__ void FractionalKernelMaxPool2dGrad(const int ncd,
-                                              const T1* output_grad,
-                                              const T2* mask_data,
-                                              const int channels,
-                                              const int input_height,
-                                              const int input_width,
-                                              const int output_height,
-                                              const int output_width,
-                                              const int pool_height,
-                                              const int pool_width,
-                                              float random_u,
-                                              uint64_t seed,
-                                              uint64_t offset,
-                                              T1* input_grad,
-                                              FastDivModForPooling divmods) {
+__global__ void FractionalKernelMaxPool2dGrad(
+    const int ncd,
+    const T1* output_grad,
+    const T2* mask_data,
+    const int channels,
+    const int input_height,
+    const int input_width,
+    const int output_height,
+    const int output_width,
+    const int pool_height,
+    const int pool_width,
+    float random_u,
+    uint64_t seed,
+    uint64_t offset,
+    T1* input_grad,
+    FastDivModForPooling<int> divmods) {
   int w_offset, h_offset, nc_offset;
 
   w_offset = blockIdx.x * blockDim.x + threadIdx.x;

--- a/paddle/phi/kernels/funcs/pooling.h
+++ b/paddle/phi/kernels/funcs/pooling.h
@@ -126,13 +126,15 @@ class LPPoolGrad {
 
 /* used for adaptive pool to calculate start and end index of each divided grid
  */
-HOSTDEVICE inline int AdaptStartIndex(int ph, int input_size, int output_size) {
-  return static_cast<int>(
+template <typename T = int>
+HOSTDEVICE inline T AdaptStartIndex(T ph, T input_size, T output_size) {
+  return static_cast<T>(
       floor(static_cast<float>(ph * input_size) / output_size));
 }
 
-HOSTDEVICE inline int AdaptEndIndex(int ph, int input_size, int output_size) {
-  return static_cast<int>(
+template <typename T = int>
+HOSTDEVICE inline T AdaptEndIndex(T ph, T input_size, T output_size) {
+  return static_cast<T>(
       ceil(static_cast<float>((ph + 1) * input_size) / output_size));
 }
 
@@ -213,20 +215,9 @@ class Pool2dFunctor {
  public:
   void operator()(const Context& context,
                   const DenseTensor& input,
-                  const std::vector<int>& ksize,
-                  const std::vector<int>& strides,
-                  const std::vector<int>& paddings,
-                  bool exclusive,
-                  bool adaptive,
-                  DenseTensor* output,
-                  PoolProcess pool_compute);
-
-  // overload operator() to support argument data_format
-  void operator()(const Context& context,
-                  const DenseTensor& input,
-                  const std::vector<int>& ksize,
-                  const std::vector<int>& strides,
-                  const std::vector<int>& paddings,
+                  const std::vector<int64_t>& ksize,
+                  const std::vector<int64_t>& strides,
+                  const std::vector<int64_t>& paddings,
                   const std::string data_format,
                   bool exclusive,
                   bool adaptive,
@@ -241,21 +232,9 @@ class Pool2dGradFunctor {
                   const DenseTensor& input,
                   const DenseTensor& output,
                   const DenseTensor& output_grad,
-                  const std::vector<int>& ksize,
-                  const std::vector<int>& strides,
-                  const std::vector<int>& paddings,
-                  bool exclusive,
-                  bool adaptive,
-                  DenseTensor* input_grad,
-                  PoolProcess pool_compute);
-  // overload operator() to support argument data_format
-  void operator()(const Context& context,
-                  const DenseTensor& input,
-                  const DenseTensor& output,
-                  const DenseTensor& output_grad,
-                  const std::vector<int>& ksize,
-                  const std::vector<int>& strides,
-                  const std::vector<int>& paddings,
+                  const std::vector<int64_t>& ksize,
+                  const std::vector<int64_t>& strides,
+                  const std::vector<int64_t>& paddings,
                   const std::string data_format,
                   bool exclusive,
                   bool adaptive,
@@ -270,18 +249,9 @@ class MaxPool2dGradFunctor {
                   const DenseTensor& input,
                   const DenseTensor& output,
                   const DenseTensor& output_grad,
-                  const std::vector<int>& ksize,
-                  const std::vector<int>& strides,
-                  const std::vector<int>& paddings,
-                  DenseTensor* input_grad);
-  // overload operator() to support argument data_format
-  void operator()(const Context& context,
-                  const DenseTensor& input,
-                  const DenseTensor& output,
-                  const DenseTensor& output_grad,
-                  const std::vector<int>& ksize,
-                  const std::vector<int>& strides,
-                  const std::vector<int>& paddings,
+                  const std::vector<int64_t>& ksize,
+                  const std::vector<int64_t>& strides,
+                  const std::vector<int64_t>& paddings,
                   const std::string data_format,
                   DenseTensor* input_grad);
 };
@@ -309,19 +279,9 @@ class Pool3dFunctor {
  public:
   void operator()(const Context& context,
                   const DenseTensor& input,
-                  const std::vector<int>& ksize,
-                  const std::vector<int>& strides,
-                  const std::vector<int>& paddings,
-                  bool exclusive,
-                  bool adaptive,
-                  DenseTensor* output,
-                  PoolProcess pool_compute);
-  // overload operator() to support argument data_format
-  void operator()(const Context& context,
-                  const DenseTensor& input,
-                  const std::vector<int>& ksize,
-                  const std::vector<int>& strides,
-                  const std::vector<int>& paddings,
+                  const std::vector<int64_t>& ksize,
+                  const std::vector<int64_t>& strides,
+                  const std::vector<int64_t>& paddings,
                   const std::string data_format,
                   bool exclusive,
                   bool adaptive,
@@ -336,21 +296,9 @@ class Pool3dGradFunctor {
                   const DenseTensor& input,
                   const DenseTensor& output,
                   const DenseTensor& output_grad,
-                  const std::vector<int>& ksize,
-                  const std::vector<int>& strides,
-                  const std::vector<int>& paddings,
-                  bool exclusive,
-                  bool adaptive,
-                  DenseTensor* input_grad,
-                  PoolProcess pool_compute);
-  // overload operator() to support argument data_format
-  void operator()(const Context& context,
-                  const DenseTensor& input,
-                  const DenseTensor& output,
-                  const DenseTensor& output_grad,
-                  const std::vector<int>& ksize,
-                  const std::vector<int>& strides,
-                  const std::vector<int>& paddings,
+                  const std::vector<int64_t>& ksize,
+                  const std::vector<int64_t>& strides,
+                  const std::vector<int64_t>& paddings,
                   const std::string data_format,
                   bool exclusive,
                   bool adaptive,
@@ -365,18 +313,9 @@ class MaxPool3dGradFunctor {
                   const DenseTensor& input,
                   const DenseTensor& output,
                   const DenseTensor& output_grad,
-                  const std::vector<int>& ksize,
-                  const std::vector<int>& strides,
-                  const std::vector<int>& paddings,
-                  DenseTensor* input_grad);
-  // overload operator() to support argument data_format
-  void operator()(const Context& context,
-                  const DenseTensor& input,
-                  const DenseTensor& output,
-                  const DenseTensor& output_grad,
-                  const std::vector<int>& ksize,
-                  const std::vector<int>& strides,
-                  const std::vector<int>& paddings,
+                  const std::vector<int64_t>& ksize,
+                  const std::vector<int64_t>& strides,
+                  const std::vector<int64_t>& paddings,
                   const std::string data_format,
                   DenseTensor* input_grad);
 };

--- a/paddle/phi/kernels/gpudnn/pool_grad_kernel.cu
+++ b/paddle/phi/kernels/gpudnn/pool_grad_kernel.cu
@@ -53,8 +53,9 @@ void PoolGradRawGPUDNNKernel(const Context& ctx,
   const DenseTensor* output = &out;
   const DenseTensor* output_grad = &dout;
   DenseTensor* input_grad = dx;
-  std::vector<int64_t> paddings_ = paddings;
-  std::vector<int64_t> kernel_size_ = kernel_size;
+  std::vector<int> strides_(strides.begin(), strides.end());
+  std::vector<int> paddings_(paddings.begin(), paddings.end());
+  std::vector<int> kernel_size_(kernel_size.begin(), kernel_size.end());
 
   const bool channel_last = (data_format == "NHWC" || data_format == "NDHWC");
 
@@ -66,7 +67,7 @@ void PoolGradRawGPUDNNKernel(const Context& ctx,
                                      dout,
                                      kernel_size,
                                      strides,
-                                     paddings_,
+                                     paddings,
                                      exclusive,
                                      data_format,
                                      pooling_type,
@@ -92,7 +93,7 @@ void PoolGradRawGPUDNNKernel(const Context& ctx,
                        adaptive,
                        padding_algorithm,
                        data_dims,
-                       strides,
+                       strides_,
                        kernel_size_);
   if (data_dims.size() * 2 == static_cast<int>(paddings_.size())) {
     for (int i = 0; i < data_dims.size(); ++i) {
@@ -238,10 +239,10 @@ void PoolGradRawGPUDNNKernel(const Context& ctx,
 
 #ifdef PADDLE_WITH_HIP
   miopenPoolingDescriptor_t cudnn_pool_desc =
-      pool_desc.descriptor(pooling_mode, kernel_size_, paddings_, strides);
+      pool_desc.descriptor(pooling_mode, kernel_size_, paddings_, strides_);
 #else
   cudnnPoolingDescriptor_t cudnn_pool_desc =
-      pool_desc.descriptor(pooling_mode, kernel_size_, paddings_, strides);
+      pool_desc.descriptor(pooling_mode, kernel_size_, paddings_, strides_);
 #endif
 
   // ------------------- cudnn pool algorithm ---------------------

--- a/paddle/phi/kernels/gpudnn/pool_grad_kernel.cu
+++ b/paddle/phi/kernels/gpudnn/pool_grad_kernel.cu
@@ -33,9 +33,9 @@ void PoolGradRawGPUDNNKernel(const Context& ctx,
                              const DenseTensor& x,
                              const DenseTensor& out,
                              const DenseTensor& dout,
-                             const std::vector<int>& kernel_size,
-                             const std::vector<int>& strides,
-                             const std::vector<int>& paddings,
+                             const std::vector<int64_t>& kernel_size,
+                             const std::vector<int64_t>& strides,
+                             const std::vector<int64_t>& paddings,
                              bool exclusive,
                              const std::string& data_format,
                              const std::string& pooling_type,
@@ -53,8 +53,8 @@ void PoolGradRawGPUDNNKernel(const Context& ctx,
   const DenseTensor* output = &out;
   const DenseTensor* output_grad = &dout;
   DenseTensor* input_grad = dx;
-  std::vector<int> paddings_ = paddings;
-  std::vector<int> kernel_size_ = kernel_size;
+  std::vector<int64_t> paddings_ = paddings;
+  std::vector<int64_t> kernel_size_ = kernel_size;
 
   const bool channel_last = (data_format == "NHWC" || data_format == "NDHWC");
 
@@ -317,17 +317,13 @@ void Pool2dGradGPUDNNKernel(const Context& ctx,
                             bool adaptive,
                             const std::string& padding_algorithm,
                             DenseTensor* dx) {
-  std::vector<int> kernel_size_val(kernel_size.GetData().begin(),
-                                   kernel_size.GetData().end());
-  std::vector<int> strides_val(strides.begin(), strides.end());
-  std::vector<int> paddings_val(paddings.begin(), paddings.end());
   PoolGradRawGPUDNNKernel<T, Context>(ctx,
                                       x,
                                       out,
                                       dout,
-                                      kernel_size_val,
-                                      strides_val,
-                                      paddings_val,
+                                      kernel_size.GetData(),
+                                      strides,
+                                      paddings,
                                       exclusive,
                                       data_format,
                                       pooling_type,
@@ -387,16 +383,13 @@ void Pool3dGradGPUDNNKernel(const Context& ctx,
                             bool adaptive,
                             const std::string& padding_algorithm,
                             DenseTensor* dx) {
-  std::vector<int> kernel_size_val(kernel_size.begin(), kernel_size.end());
-  std::vector<int> strides_val(strides.begin(), strides.end());
-  std::vector<int> paddings_val(paddings.begin(), paddings.end());
   PoolGradRawGPUDNNKernel<T, Context>(ctx,
                                       x,
                                       out,
                                       dout,
-                                      kernel_size_val,
-                                      strides_val,
-                                      paddings_val,
+                                      kernel_size,
+                                      strides,
+                                      paddings,
                                       exclusive,
                                       data_format,
                                       pooling_type,

--- a/paddle/phi/kernels/gpudnn/pool_kernel.cu
+++ b/paddle/phi/kernels/gpudnn/pool_kernel.cu
@@ -25,9 +25,9 @@ namespace phi {
 template <typename T, typename Context>
 void PoolRawGPUDNNKernel(const Context& ctx,
                          const DenseTensor& x,
-                         const std::vector<int>& kernel_size,
-                         const std::vector<int>& strides,
-                         const std::vector<int>& paddings,
+                         const std::vector<int64_t>& kernel_size,
+                         const std::vector<int64_t>& strides,
+                         const std::vector<int64_t>& paddings,
                          bool exclusive,
                          const std::string& data_format,
                          const std::string& pooling_type,
@@ -43,8 +43,8 @@ void PoolRawGPUDNNKernel(const Context& ctx,
 
   const DenseTensor* input = &x;
   DenseTensor* output = out;
-  std::vector<int> paddings_ = paddings;
-  std::vector<int> kernel_size_ = kernel_size;
+  std::vector<int64_t> paddings_ = paddings;
+  std::vector<int64_t> kernel_size_ = kernel_size;
 
   ctx.template Alloc<T>(output);
 
@@ -241,15 +241,11 @@ void Pool2dGPUDNNKernel(const Context& ctx,
                         bool adaptive,
                         const std::string& padding_algorithm,
                         DenseTensor* out) {
-  std::vector<int> kernel_size_val(kernel_size.GetData().begin(),
-                                   kernel_size.GetData().end());
-  std::vector<int> strides_val(strides.begin(), strides.end());
-  std::vector<int> paddings_val(paddings.begin(), paddings.end());
   PoolRawGPUDNNKernel<T, Context>(ctx,
                                   x,
-                                  kernel_size_val,
-                                  strides_val,
-                                  paddings_val,
+                                  kernel_size.GetData(),
+                                  strides,
+                                  paddings,
                                   exclusive,
                                   data_format,
                                   pooling_type,
@@ -273,14 +269,11 @@ void Pool3dGPUDNNKernel(const Context& ctx,
                         bool adaptive,
                         const std::string& padding_algorithm,
                         DenseTensor* out) {
-  std::vector<int> kernel_size_val(kernel_size.begin(), kernel_size.end());
-  std::vector<int> strides_val(strides.begin(), strides.end());
-  std::vector<int> paddings_val(paddings.begin(), paddings.end());
   PoolRawGPUDNNKernel<T, Context>(ctx,
                                   x,
-                                  kernel_size_val,
-                                  strides_val,
-                                  paddings_val,
+                                  kernel_size,
+                                  strides,
+                                  paddings,
                                   exclusive,
                                   data_format,
                                   pooling_type,

--- a/paddle/phi/kernels/gpudnn/pool_kernel.cu
+++ b/paddle/phi/kernels/gpudnn/pool_kernel.cu
@@ -25,9 +25,9 @@ namespace phi {
 template <typename T, typename Context>
 void PoolRawGPUDNNKernel(const Context& ctx,
                          const DenseTensor& x,
-                         const std::vector<int64_t>& kernel_size,
-                         const std::vector<int64_t>& strides,
-                         const std::vector<int64_t>& paddings,
+                         const std::vector<int>& kernel_size,
+                         const std::vector<int>& strides,
+                         const std::vector<int>& paddings,
                          bool exclusive,
                          const std::string& data_format,
                          const std::string& pooling_type,
@@ -43,8 +43,8 @@ void PoolRawGPUDNNKernel(const Context& ctx,
 
   const DenseTensor* input = &x;
   DenseTensor* output = out;
-  std::vector<int64_t> paddings_ = paddings;
-  std::vector<int64_t> kernel_size_ = kernel_size;
+  std::vector<int> paddings_ = paddings;
+  std::vector<int> kernel_size_ = kernel_size;
 
   ctx.template Alloc<T>(output);
 
@@ -241,11 +241,15 @@ void Pool2dGPUDNNKernel(const Context& ctx,
                         bool adaptive,
                         const std::string& padding_algorithm,
                         DenseTensor* out) {
+  std::vector<int> kernel_size_val(kernel_size.GetData().begin(),
+                                   kernel_size.GetData().end());
+  std::vector<int> strides_val(strides.begin(), strides.end());
+  std::vector<int> paddings_val(paddings.begin(), paddings.end());
   PoolRawGPUDNNKernel<T, Context>(ctx,
                                   x,
-                                  kernel_size.GetData(),
-                                  strides,
-                                  paddings,
+                                  kernel_size_val,
+                                  strides_val,
+                                  paddings_val,
                                   exclusive,
                                   data_format,
                                   pooling_type,
@@ -269,11 +273,14 @@ void Pool3dGPUDNNKernel(const Context& ctx,
                         bool adaptive,
                         const std::string& padding_algorithm,
                         DenseTensor* out) {
+  std::vector<int> kernel_size_val(kernel_size.begin(), kernel_size.end());
+  std::vector<int> strides_val(strides.begin(), strides.end());
+  std::vector<int> paddings_val(paddings.begin(), paddings.end());
   PoolRawGPUDNNKernel<T, Context>(ctx,
                                   x,
-                                  kernel_size,
-                                  strides,
-                                  paddings,
+                                  kernel_size_val,
+                                  strides_val,
+                                  paddings_val,
                                   exclusive,
                                   data_format,
                                   pooling_type,

--- a/paddle/phi/kernels/impl/pool_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/pool_grad_kernel_impl.h
@@ -28,9 +28,9 @@ void PoolGradRawKernel(const Context& ctx,
                        const DenseTensor& x,
                        const DenseTensor& out,
                        const DenseTensor& dout,
-                       const std::vector<int>& kernel_size,
-                       const std::vector<int>& strides,
-                       const std::vector<int>& paddings,
+                       const std::vector<int64_t>& kernel_size,
+                       const std::vector<int64_t>& strides,
+                       const std::vector<int64_t>& paddings,
                        bool exclusive,
                        const std::string& data_format,
                        const std::string& pooling_type,
@@ -40,8 +40,8 @@ void PoolGradRawKernel(const Context& ctx,
                        const float norm_type,
                        DenseTensor* dx) {
   const bool channel_last = (data_format == "NHWC" || data_format == "NDHWC");
-  std::vector<int> paddings_ = paddings;
-  std::vector<int> kernel_size_ = kernel_size;
+  std::vector<int64_t> paddings_ = paddings;
+  std::vector<int64_t> kernel_size_ = kernel_size;
 
   // update paddings
   auto x_dims = x.dims();
@@ -225,17 +225,13 @@ void Pool2dGradKernel(const Context& ctx,
                       bool adaptive,
                       const std::string& padding_algorithm,
                       DenseTensor* dx) {
-  std::vector<int> kernel_size_val(kernel_size.GetData().begin(),
-                                   kernel_size.GetData().end());
-  std::vector<int> strides_val(strides.begin(), strides.end());
-  std::vector<int> paddings_val(paddings.begin(), paddings.end());
   PoolGradRawKernel<T, Context>(ctx,
                                 x,
                                 out,
                                 dout,
-                                kernel_size_val,
-                                strides_val,
-                                paddings_val,
+                                kernel_size.GetData(),
+                                strides,
+                                paddings,
                                 exclusive,
                                 data_format,
                                 pooling_type,
@@ -263,17 +259,13 @@ void LPPool2dGradKernel(const Context& ctx,
                         const std::string& padding_algorithm,
                         const float norm_type,
                         DenseTensor* dx) {
-  std::vector<int> kernel_size_val(kernel_size.GetData().begin(),
-                                   kernel_size.GetData().end());
-  std::vector<int> strides_val(strides.begin(), strides.end());
-  std::vector<int> paddings_val(paddings.begin(), paddings.end());
   PoolGradRawKernel<T, Context>(ctx,
                                 x,
                                 out,
                                 dout,
-                                kernel_size_val,
-                                strides_val,
-                                paddings_val,
+                                kernel_size.GetData(),
+                                strides,
+                                paddings,
                                 exclusive,
                                 data_format,
                                 pooling_type,
@@ -358,16 +350,13 @@ void Pool3dGradKernel(const Context& ctx,
                       bool adaptive,
                       const std::string& padding_algorithm,
                       DenseTensor* dx) {
-  std::vector<int> kernel_size_val(kernel_size.begin(), kernel_size.end());
-  std::vector<int> strides_val(strides.begin(), strides.end());
-  std::vector<int> paddings_val(paddings.begin(), paddings.end());
   PoolGradRawKernel<T, Context>(ctx,
                                 x,
                                 out,
                                 dout,
-                                kernel_size_val,
-                                strides_val,
-                                paddings_val,
+                                kernel_size,
+                                strides,
+                                paddings,
                                 exclusive,
                                 data_format,
                                 pooling_type,

--- a/paddle/phi/kernels/impl/pool_kernel_impl.h
+++ b/paddle/phi/kernels/impl/pool_kernel_impl.h
@@ -52,9 +52,9 @@ inline int64_t GetReduceNum(const DenseTensor& input,
 template <typename T, typename Context>
 void PoolRawKernel(const Context& ctx,
                    const DenseTensor& x,
-                   const std::vector<int>& kernel_size,
-                   const std::vector<int>& strides,
-                   const std::vector<int>& paddings,
+                   const std::vector<int64_t>& kernel_size,
+                   const std::vector<int64_t>& strides,
+                   const std::vector<int64_t>& paddings,
                    bool exclusive,
                    const std::string& data_format,
                    const std::string& pooling_type,
@@ -64,8 +64,8 @@ void PoolRawKernel(const Context& ctx,
                    const float norm_type,
                    DenseTensor* out) {
   const bool channel_last = (data_format == "NHWC" || data_format == "NDHWC");
-  std::vector<int> paddings_ = paddings;
-  std::vector<int> kernel_size_ = kernel_size;
+  std::vector<int64_t> paddings_ = paddings;
+  std::vector<int64_t> kernel_size_ = kernel_size;
 
   // update paddings
   auto x_dims = x.dims();
@@ -263,15 +263,11 @@ void Pool2dKernel(const Context& ctx,
                   bool adaptive,
                   const std::string& padding_algorithm,
                   DenseTensor* out) {
-  std::vector<int> kernel_size_val(kernel_size.GetData().begin(),
-                                   kernel_size.GetData().end());
-  std::vector<int> strides_val(strides.begin(), strides.end());
-  std::vector<int> paddings_val(paddings.begin(), paddings.end());
   PoolRawKernel<T, Context>(ctx,
                             x,
-                            kernel_size_val,
-                            strides_val,
-                            paddings_val,
+                            kernel_size.GetData(),
+                            strides,
+                            paddings,
                             exclusive,
                             data_format,
                             pooling_type,
@@ -297,15 +293,11 @@ void LPPool2dKernel(const Context& ctx,
                     const std::string& padding_algorithm,
                     const float norm_type,
                     DenseTensor* out) {
-  std::vector<int> kernel_size_val(kernel_size.GetData().begin(),
-                                   kernel_size.GetData().end());
-  std::vector<int> strides_val(strides.begin(), strides.end());
-  std::vector<int> paddings_val(paddings.begin(), paddings.end());
   PoolRawKernel<T, Context>(ctx,
                             x,
-                            kernel_size_val,
-                            strides_val,
-                            paddings_val,
+                            kernel_size.GetData(),
+                            strides,
+                            paddings,
                             exclusive,
                             data_format,
                             pooling_type,
@@ -352,14 +344,11 @@ void Pool3dKernel(const Context& ctx,
                   bool adaptive,
                   const std::string& padding_algorithm,
                   DenseTensor* out) {
-  std::vector<int> kernel_size_val(kernel_size.begin(), kernel_size.end());
-  std::vector<int> strides_val(strides.begin(), strides.end());
-  std::vector<int> paddings_val(paddings.begin(), paddings.end());
   PoolRawKernel<T, Context>(ctx,
                             x,
-                            kernel_size_val,
-                            strides_val,
-                            paddings_val,
+                            kernel_size,
+                            strides,
+                            paddings,
                             exclusive,
                             data_format,
                             pooling_type,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-85711

- 修复 pool2d, pool3d, lp_pool2d 底层 kernel int 溢出问题 
- 测了 Pool2d 前反向 Kernel，性能下降严重，前向下降 5%，反向下降 90%，故都实现了模版
- 另外几个 Pool Functor 都实现了两个版本分别是否带 `data_format` 参数，但我看实际用法都带了 `data_format` 参数，因此把不带 `data_format` 参数的版本给删了，减少修改工作量
- 不确定是否需要把 cpu kernel 也改成 int64 版本，实现的话是否需要模版化，希望 Review 一下