### PR TITLE
[3.8] Remove Python 3.8 support speification in `setup.py`

### DIFF
--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -845,10 +845,10 @@ packages=['paddle',
           'paddle.vision.transforms',
           'paddle.vision.datasets',
           'paddle.audio',
-	        'paddle.audio.functional',
-	        'paddle.audio.features',
-	        'paddle.audio.datasets',
-	        'paddle.audio.backends',
+          'paddle.audio.functional',
+          'paddle.audio.features',
+          'paddle.audio.datasets',
+          'paddle.audio.backends',
           'paddle.text',
           'paddle.text.datasets',
           'paddle.incubate',
@@ -933,10 +933,10 @@ if '@WITH_TENSORRT@' =='ON':
 with open('@PADDLE_SOURCE_DIR@/python/requirements.txt') as f:
     setup_requires = f.read().splitlines()
 
-if sys.version_info < (3,8):
-    raise RuntimeError("Paddle only support Python version>=3.8 now")
+if sys.version_info < (3, 9):
+    raise RuntimeError("Paddle only support Python version>=3.9 now")
 
-if sys.version_info >= (3,8):
+if sys.version_info >= (3, 9):
     setup_requires_tmp = []
     for setup_requires_i in setup_requires:
         if (
@@ -947,6 +947,8 @@ if sys.version_info >= (3,8):
             or "<\"3.7\"" in setup_requires_i
             or "<=\"3.7\"" in setup_requires_i
             or "<\"3.8\"" in setup_requires_i
+            or '<="3.8"' in setup_requires_i
+            or '<"3.9"' in setup_requires_i
             or setup_requires_i.strip().endswith(
                 '[build]'
             )  # remove `[build]` requirements
@@ -1687,7 +1689,6 @@ with redirect_stdout():
             'Intended Audience :: Science/Research',
             'License :: OSI Approved :: Apache Software License',
             'Programming Language :: C++',
-            'Programming Language :: Python :: 3.8',
             'Programming Language :: Python :: 3.9',
             'Programming Language :: Python :: 3.10',
             'Programming Language :: Python :: 3.11',

--- a/setup.py
+++ b/setup.py
@@ -43,9 +43,9 @@ version_detail = sys.version_info
 version = str(version_detail[0]) + '.' + str(version_detail[1])
 env_version = os.getenv("PY_VERSION", None)
 
-if version_detail < (3, 8):
+if version_detail < (3, 9):
     raise RuntimeError(
-        f"Paddle only supports Python version >= 3.8 now,"
+        f"Paddle only supports Python version >= 3.9 now,"
         f"you are using Python {python_version}"
     )
 elif env_version is None:
@@ -1041,7 +1041,7 @@ def get_setup_requires():
         setup_requires = (
             f.read().splitlines()
         )  # Specify the dependencies to install
-    if sys.version_info >= (3, 8):
+    if sys.version_info >= (3, 9):
         setup_requires_tmp = []
         for setup_requires_i in setup_requires:
             if (
@@ -1052,6 +1052,8 @@ def get_setup_requires():
                 or '<"3.7"' in setup_requires_i
                 or '<="3.7"' in setup_requires_i
                 or '<"3.8"' in setup_requires_i
+                or '<="3.8"' in setup_requires_i
+                or '<"3.9"' in setup_requires_i
                 or setup_requires_i.strip().endswith('[build]')
             ):
                 continue
@@ -1061,7 +1063,7 @@ def get_setup_requires():
         return setup_requires
     else:
         raise RuntimeError(
-            "please check your python version,Paddle only support Python version>=3.8 now"
+            "please check your python version, Paddle only support Python version>=3.9 now"
         )
 
 
@@ -2643,7 +2645,6 @@ def main():
             'Intended Audience :: Science/Research',
             'License :: OSI Approved :: Apache Software License',
             'Programming Language :: C++',
-            'Programming Language :: Python :: 3.8',
             'Programming Language :: Python :: 3.9',
             'Programming Language :: Python :: 3.10',
             'Programming Language :: Python :: 3.11',


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Deprecations

### Description
<!-- Describe what you’ve done -->

清理 Python 3.8 支持声明，#72827 已经不再支持 Python 3.8 了，`setup.py` 应当同步清理

<!-- PCard-66972 -->