### PR TITLE
[Eager] Remove uncessary unwrapping

### DIFF
--- a/paddle/fluid/pybind/eager_utils.cc
+++ b/paddle/fluid/pybind/eager_utils.cc
@@ -1326,10 +1326,6 @@ static paddle::Tensor& GetTensorFromPyObject(const std::string& op_type,
                                              PyObject* obj,
                                              ssize_t arg_idx,
                                              bool dispensable) {
-  if (PyTuple_Check(obj)) {
-    obj = PyTuple_GET_ITEM(obj, 0);
-  }
-
   if (obj == nullptr || obj == Py_None) {
     if (!dispensable) {
       PADDLE_THROW(common::errors::InvalidArgument(

--- a/python/paddle/distributed/fleet/recompute/recompute.py
+++ b/python/paddle/distributed/fleet/recompute/recompute.py
@@ -793,4 +793,4 @@ def recompute_sequential(
             preserve_rng_state=preserve_rng_state,
             **kwargs,
         )
-    return _run_func(end + 1, len(functions) - 1, functions)(args)
+    return _run_func(end + 1, len(functions) - 1, functions)(*args)

--- a/test/legacy_test/test_mse_loss.py
+++ b/test/legacy_test/test_mse_loss.py
@@ -15,6 +15,7 @@
 import unittest
 
 import numpy as np
+from utils import dygraph_guard
 
 import paddle
 from paddle import base
@@ -78,6 +79,14 @@ class TestMseInvalidInput(unittest.TestCase):
             loss = paddle.nn.functional.mse_loss(input, label)
 
         self.assertRaises(TypeError, test_invalid_label)
+
+        def test_invalid_tuple_input():
+            with dygraph_guard():
+                input = paddle.randn(shape=[256, 3], dtype='float32')
+                label = [256, 3]
+                loss = paddle.nn.functional.mse_loss((input,), label)
+
+        self.assertRaises(ValueError, test_invalid_tuple_input)
 
 
 class TestNNMseLoss(unittest.TestCase):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

pcard-67164

> 原代码来自：<https://github.com/PaddlePaddle/Paddle/pull/37813>的<https://github.com/PaddlePaddle/Paddle/pull/37813/files#diff-816e3e61caad6341f966a51b9e3e7f308096b860019e5ab5a0647a4ac33e23e0R380>

删除动态图下`GetTensorFromPyObject`开头位置对tuple类型输入不必要的"取首元素"操作，否则如下代码不会触发预期的报错

``` py
loss = paddle.nn.functional.mse_loss((x, x), label)
```
