### PR TITLE
[SOT][3.8] Cleanup `eval_frame` python3.9- code

### DIFF
--- a/paddle/fluid/pybind/sot/eval_frame.c
+++ b/paddle/fluid/pybind/sot/eval_frame.c
@@ -22,11 +22,6 @@ limitations under the License. */
 
 #include <Python.h>
 
-#if PY_3_8_PLUS && !PY_3_9_PLUS
-#define Py_BUILD_CORE  // internal/pycore_pymem.h need this macro
-#include <internal/pycore_pystate.h>
-#undef Py_BUILD_CORE
-#endif
 #if !PY_3_11_PLUS
 #include <code.h>
 #endif
@@ -65,14 +60,10 @@ inline static void eval_frame_callback_set(PyObject *obj) {
 inline static PyObject *eval_frame_default(PyThreadState *tstate,
                                            FrameObject *frame,
                                            int throw_flag) {
-#if PY_3_9_PLUS
   if (tstate == NULL) {
     tstate = PyThreadState_GET();
   }
   return _PyEval_EvalFrameDefault(tstate, frame, throw_flag);
-#else
-  return _PyEval_EvalFrameDefault(frame, throw_flag);
-#endif
 }
 
 #if PY_3_11_PLUS
@@ -376,18 +367,11 @@ static PyObject *_custom_eval_frame_shim(PyThreadState *tstate,
   return _custom_eval_frame(tstate, frame, throw_flag, callback);
 }
 
-#if PY_3_9_PLUS
 static PyObject *custom_eval_frame_shim(PyThreadState *tstate,
                                         FrameObject *frame,
                                         int throw_flag) {
   return _custom_eval_frame_shim(tstate, frame, throw_flag);
 }
-#else
-static PyObject *custom_eval_frame_shim(FrameObject *frame, int throw_flag) {
-  PyThreadState *tstate = PyThreadState_GET();
-  return _custom_eval_frame_shim(tstate, frame, throw_flag);
-}
-#endif
 
 static PyObject *set_eval_frame(PyObject *new_callback, PyThreadState *tstate) {
   // Change the eval frame callback and return the old one
@@ -396,34 +380,21 @@ static PyObject *set_eval_frame(PyObject *new_callback, PyThreadState *tstate) {
   //  NOTE: Cache is not supported now
   PyObject *old_callback = eval_frame_callback_get();
 
-#if PY_3_9_PLUS
   _PyFrameEvalFunction old_eval_frame =
       _PyInterpreterState_GetEvalFrameFunc(tstate->interp);
-#else
-  // Function pointer.
-  _PyFrameEvalFunction old_eval_frame = tstate->interp->eval_frame;
-#endif
 
   // NOTE: multi-threading is not supported now
   if (old_callback != Py_None && new_callback == Py_None) {
     if (old_eval_frame != &_PyEval_EvalFrameDefault) {
       // VLOG(7) << "set _PyEval_EvalFrameDefault";
-#if PY_3_9_PLUS
       _PyInterpreterState_SetEvalFrameFunc(tstate->interp,
                                            &_PyEval_EvalFrameDefault);
-#else
-      tstate->interp->eval_frame = &_PyEval_EvalFrameDefault;
-#endif
     }
   } else if (old_callback == Py_None && new_callback != Py_None) {
     if (old_eval_frame != &custom_eval_frame_shim) {
       // VLOG(7) << "set custom_eval_frame_shim";
-#if PY_3_9_PLUS
       _PyInterpreterState_SetEvalFrameFunc(tstate->interp,
                                            &custom_eval_frame_shim);
-#else
-      tstate->interp->eval_frame = &custom_eval_frame_shim;
-#endif
     }
   }
 

--- a/paddle/fluid/pybind/sot/eval_frame.c
+++ b/paddle/fluid/pybind/sot/eval_frame.c
@@ -355,9 +355,9 @@ static PyObject *_custom_eval_frame(PyThreadState *tstate,
   return out;
 }
 
-static PyObject *_custom_eval_frame_shim(PyThreadState *tstate,
-                                         FrameObject *frame,
-                                         int throw_flag) {
+static PyObject *custom_eval_frame_shim(PyThreadState *tstate,
+                                        FrameObject *frame,
+                                        int throw_flag) {
   PyObject *callback = eval_frame_callback_get();
 
   if (callback == Py_None) {
@@ -365,12 +365,6 @@ static PyObject *_custom_eval_frame_shim(PyThreadState *tstate,
   }
 
   return _custom_eval_frame(tstate, frame, throw_flag, callback);
-}
-
-static PyObject *custom_eval_frame_shim(PyThreadState *tstate,
-                                        FrameObject *frame,
-                                        int throw_flag) {
-  return _custom_eval_frame_shim(tstate, frame, throw_flag);
 }
 
 static PyObject *set_eval_frame(PyObject *new_callback, PyThreadState *tstate) {

--- a/paddle/fluid/pybind/sot/guards.cc
+++ b/paddle/fluid/pybind/sot/guards.cc
@@ -23,12 +23,6 @@ limitations under the License. */
 #include <object.h>
 #include "pybind11/numpy.h"
 
-#if !defined(PyObject_CallOneArg) && !PY_3_9_PLUS
-static inline PyObject* PyObject_CallOneArg(PyObject* func, PyObject* arg) {
-  return PyObject_CallFunctionObjArgs(func, arg, NULL);
-}
-#endif
-
 #if !PY_3_10_PLUS
 #define Py_IsNone(x) ((x) == Py_None)
 #endif

--- a/paddle/fluid/pybind/sot/macros.h
+++ b/paddle/fluid/pybind/sot/macros.h
@@ -20,7 +20,6 @@ extern "C" {
 
 #include <Python.h>
 
-#define PY_3_8_0_HEX 0x03080000
 #define PY_3_9_0_HEX 0x03090000
 #define PY_3_10_0_HEX 0x030A0000
 #define PY_3_11_0_HEX 0x030B0000
@@ -28,7 +27,6 @@ extern "C" {
 #define PY_3_13_0_HEX 0x030D0000
 #define PY_3_14_0_HEX 0x030E0000
 
-#define PY_3_8_PLUS (PY_VERSION_HEX >= PY_3_8_0_HEX)
 #define PY_3_9_PLUS (PY_VERSION_HEX >= PY_3_9_0_HEX)
 #define PY_3_10_PLUS (PY_VERSION_HEX >= PY_3_10_0_HEX)
 #define PY_3_11_PLUS (PY_VERSION_HEX >= PY_3_11_0_HEX)

--- a/test/dygraph_to_static/test_eval_frame.py
+++ b/test/dygraph_to_static/test_eval_frame.py
@@ -28,8 +28,8 @@ class TestEvalFrame(unittest.TestCase):
         pass
 
     def test_eval_frame(self):
-        if not (sys.version_info >= (3, 8) and sys.version_info < (3, 14)):
-            # skip test_eval_frame, current only support 3.8 - 3.13
+        if not (sys.version_info >= (3, 9) and sys.version_info < (3, 14)):
+            # skip test_eval_frame, current only support 3.9 - 3.13
             return
 
         CustomCode = collections.namedtuple(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Deprecations

### Description
<!-- Describe what you’ve done -->

* 清理 `eval_frame` python3.9- 相关代码
