### PR TITLE
[3.8] Remove unused dependency `astor`

### DIFF
--- a/paddle/scripts/conda_build.py
+++ b/paddle/scripts/conda_build.py
@@ -57,7 +57,6 @@ requirements:
     - gast==0.3.3
     - Pillow
     - decorator
-    - astor
 """
 
         self.requirement_run_windows = r"""
@@ -68,7 +67,6 @@ requirements:
     - gast==0.3.3
     - Pillow
     - decorator
-    - astor
 """
         self.test = r"""
 test:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,6 +201,7 @@ show_column_numbers = true
 [[tool.mypy.overrides]]
 module = [
     "cv2",
+    "decorator",
     "scipy",
     "xlsxwriter"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,7 +200,6 @@ show_column_numbers = true
 
 [[tool.mypy.overrides]]
 module = [
-    "astor",
     "cv2",
     "scipy",
     "xlsxwriter"

--- a/python/paddle/jit/api.py
+++ b/python/paddle/jit/api.py
@@ -156,13 +156,13 @@ def ignore_module(modules: list[ModuleType]) -> None:
         .. code-block:: python
 
             >>> import scipy
-            >>> import torch
+            >>> import decorator
 
             >>> import paddle
             >>> from paddle.jit import ignore_module
             >>> modules = [
             ...     scipy,
-            ...     torch,
+            ...     decorator,
             ... ]
             >>> ignore_module(modules)
 

--- a/python/paddle/jit/api.py
+++ b/python/paddle/jit/api.py
@@ -156,13 +156,13 @@ def ignore_module(modules: list[ModuleType]) -> None:
         .. code-block:: python
 
             >>> import scipy
-            >>> import astor
+            >>> import torch
 
             >>> import paddle
             >>> from paddle.jit import ignore_module
             >>> modules = [
             ...     scipy,
-            ...     astor,
+            ...     torch,
             ... ]
             >>> ignore_module(modules)
 

--- a/python/paddle/jit/dy2static/ast_utils.py
+++ b/python/paddle/jit/dy2static/ast_utils.py
@@ -14,9 +14,6 @@
 
 
 import ast
-import sys
-
-import astor
 
 from paddle.utils import gast
 
@@ -32,13 +29,5 @@ def ast_to_source_code(ast_node):
     if isinstance(ast_node, gast.AST):
         ast_node = gast.gast_to_ast(ast_node)
 
-    if sys.version_info >= (3, 9):
-        ast.fix_missing_locations(ast_node)
-        return ast.unparse(ast_node)
-
-    # Do not wrap lines even if they are too long
-    def pretty_source(source):
-        return ''.join(source)
-
-    source_code = astor.to_source(ast_node, pretty_source=pretty_source)
-    return source_code
+    ast.fix_missing_locations(ast_node)
+    return ast.unparse(ast_node)

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -3,7 +3,6 @@ numpy>=1.21
 protobuf>=3.20.2
 Pillow
 decorator
-astor
 opt_einsum==3.3.0
 networkx
 typing_extensions

--- a/test/dygraph_to_static/test_program_translator.py
+++ b/test/dygraph_to_static/test_program_translator.py
@@ -12,11 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import inspect
-import textwrap
 import unittest
 
-import astor
 import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
@@ -31,7 +28,6 @@ from ifelse_simple_func import (
 import paddle
 import paddle.jit.dy2static as _jst
 from paddle.jit.dy2static.utils import func_to_source_code
-from paddle.utils import gast
 
 np.random.seed(0)
 
@@ -54,14 +50,6 @@ def decorated_simple_func(x, weight_numpy):
     y = paddle.matmul(x, w)
     z = paddle.mean(y)
     return z
-
-
-def get_source_code(func):
-    raw_code = inspect.getsource(func)
-    code = textwrap.dedent(raw_code)
-    root = gast.parse(code)
-    source_code = astor.to_source(gast.gast_to_ast(root))
-    return source_code
 
 
 class StaticCode1:

--- a/tools/cinn/docker/requirements.txt
+++ b/tools/cinn/docker/requirements.txt
@@ -8,5 +8,4 @@ gast==0.3.3 ; platform_system == "Windows"
 Pillow
 six
 decorator==4.4.2
-astor
 xgboost


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Deprecations

### Description
<!-- Describe what you’ve done -->

移除第三方库 `astor`，其仅用于 AST 动转静，但 AST 动转静很久之前就只在 3.9 及以上版本使用内置的 `ast.unparse` 替代 `astor` 了，而 python 3.8 已经退场，`astor` 已经彻底无用，故彻底移除

### Related links

- #59685