### PR TITLE
[Accuracy diff No.55-56、76-77] Fix accuracy diff for (`var,std`) API

### DIFF
--- a/test/legacy_test/test_zero_dim_sundry_dygraph_api.py
+++ b/test/legacy_test/test_zero_dim_sundry_dygraph_api.py
@@ -748,8 +748,8 @@ class TestSundryAPI(unittest.TestCase):
 
         self.assertEqual(out1.shape, [])
         self.assertEqual(out2.shape, [])
-        self.assertEqual(out1, 0)
-        self.assertEqual(out2, 0)
+        self.assertTrue(np.isnan(out1.numpy()))
+        self.assertTrue(np.isnan(out2.numpy()))
 
         self.assertEqual(x.grad.shape, [])
 
@@ -773,11 +773,11 @@ class TestSundryAPI(unittest.TestCase):
 
         self.assertEqual(out1.shape, [])
         self.assertEqual(out2.shape, [])
-        self.assertEqual(out1, 0)
-        self.assertEqual(out2, 0)
+        self.assertTrue(np.isnan(out1.numpy()))
+        self.assertTrue(np.isnan(out2.numpy()))
 
         self.assertEqual(x.grad.shape, [])
-        np.testing.assert_allclose(x.grad, 0)
+        self.assertTrue(np.isnan(x.grad.numpy()))
 
         # 2) x is ND
         x = paddle.rand([3, 5])

--- a/test/xpu/test_zero_dim_tensor_xpu.py
+++ b/test/xpu/test_zero_dim_tensor_xpu.py
@@ -1074,10 +1074,11 @@ class TestSundryAPI(unittest.TestCase):
 
         self.assertEqual(out1.shape, [])
         self.assertEqual(out2.shape, [])
-        self.assertEqual(out1, 0)
-        self.assertEqual(out2, 0)
+        self.assertTrue(np.isnan(out1.numpy()))
+        self.assertTrue(np.isnan(out2.numpy()))
 
         self.assertEqual(x.grad.shape, [])
+        self.assertTrue(np.isnan(x.grad.numpy()))
 
         # 2) x is ND
         x = paddle.rand([3, 5])
@@ -1099,11 +1100,11 @@ class TestSundryAPI(unittest.TestCase):
 
         self.assertEqual(out1.shape, [])
         self.assertEqual(out2.shape, [])
-        self.assertEqual(out1, 0)
-        self.assertEqual(out2, 0)
+        self.assertTrue(np.isnan(out1.numpy()))
+        self.assertTrue(np.isnan(out2.numpy()))
 
         self.assertEqual(x.grad.shape, [])
-        np.testing.assert_allclose(x.grad, 0)
+        self.assertTrue(np.isnan(x.grad.numpy()))
 
         # 2) x is ND
         x = paddle.rand([3, 5])


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
- https://github.com/PaddlePaddle/Paddle/issues/72667
- torch 和 numpy 一样当 unbiased 为 True 时，(N-1) 小于等于 0 的时候，给出 Warning  信息，最后还是会使用 （N-1）的值进行后续计算

`python engine.py --accuracy=True --api_config='paddle.var(Tensor([],"float32"), )' `
![图片](https://github.com/user-attachments/assets/abc2bf6f-7ebf-40ac-b93f-41f047292b19)
`python engine.py --accuracy=True --api_config='paddle.var(Tensor([],"float32"), list[], )'`
![图片](https://github.com/user-attachments/assets/0db6eeac-56d4-4962-b1ef-f37ef1198aae)
 