### PR TITLE
fix mem_eff_attn's compilation when arch > sm90

### DIFF
--- a/paddle/phi/kernels/fusion/cutlass/memory_efficient_attention/generate_kernels.py
+++ b/paddle/phi/kernels/fusion/cutlass/memory_efficient_attention/generate_kernels.py
@@ -40,6 +40,10 @@ assert sorted(DEFAULT_ARCH) == DEFAULT_ARCH
 
 
 def find_arch_range(min_arch, max_arch):
+    if (min_arch < DEFAULT_ARCH[0] or min_arch > MAX_ARCH) or (
+        max_arch < DEFAULT_ARCH[0] or max_arch > MAX_ARCH
+    ):
+        return [DEFAULT_ARCH[-1]]
     assert min_arch >= DEFAULT_ARCH[0] and min_arch <= MAX_ARCH
     assert max_arch >= DEFAULT_ARCH[0] and max_arch <= MAX_ARCH
     assert min_arch <= max_arch

--- a/paddle/phi/kernels/fusion/cutlass/memory_efficient_attention/generate_variable_forward_kernels.py
+++ b/paddle/phi/kernels/fusion/cutlass/memory_efficient_attention/generate_variable_forward_kernels.py
@@ -40,6 +40,10 @@ assert sorted(DEFAULT_ARCH) == DEFAULT_ARCH
 
 
 def find_arch_range(min_arch, max_arch):
+    if (min_arch < DEFAULT_ARCH[0] or min_arch > MAX_ARCH) or (
+        max_arch < DEFAULT_ARCH[0] or max_arch > MAX_ARCH
+    ):
+        return [DEFAULT_ARCH[-1]]
     assert min_arch >= DEFAULT_ARCH[0] and min_arch <= MAX_ARCH
     assert max_arch >= DEFAULT_ARCH[0] and max_arch <= MAX_ARCH
     assert min_arch <= max_arch


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
card-71500
fix mem_eff_attn's compilation when arch > sm90