### PR TITLE
[Auto Parallel] Add spmd rule No.18 for conv3d and conv3d_grad ops.

### DIFF
--- a/paddle/phi/infermeta/spmd_rules/conv3d.cc
+++ b/paddle/phi/infermeta/spmd_rules/conv3d.cc
@@ -1,0 +1,290 @@
+/* Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include "paddle/phi/infermeta/spmd_rules/conv3d.h"
+
+#include "glog/logging.h"
+
+#include "paddle/phi/core/distributed/auto_parallel/dist_attr.h"
+#include "paddle/phi/core/distributed/auto_parallel/inferspmd_utils.h"
+#include "paddle/phi/core/distributed/auto_parallel/utils.h"
+#include "paddle/phi/core/enforce.h"
+#include "paddle/phi/infermeta/spmd_rules/utils.h"
+
+namespace phi {
+namespace distributed {
+
+using phi::distributed::auto_parallel::str_join;
+
+SpmdInfo Conv3dInferSpmdBase(const DistMetaTensor& input,
+                             const DistMetaTensor& filter,
+                             const std::string& data_format) {
+  // Step0: verify input args based on conv3d logic
+  VLOG(4) << "step 0: verify input args based on conv3d logic";
+  auto original_input_shape = common::vectorize(input.dims());
+  auto original_filter_shape = common::vectorize(filter.dims());
+  int input_ndim = static_cast<int>(original_input_shape.size());
+  int filter_ndim = static_cast<int>(original_filter_shape.size());
+  const auto& input_dist_attr_src = input.dist_attr();
+  const auto& filter_dist_attr_src = filter.dist_attr();
+  std::vector<int64_t> input_dims_mapping = input_dist_attr_src.dims_mapping();
+  std::vector<int64_t> filter_dims_mapping =
+      filter_dist_attr_src.dims_mapping();
+
+  PADDLE_ENFORCE_EQ(
+      input_ndim,
+      5,
+      common::errors::InvalidArgument("The Tensor Input's rank must be 5 in "
+                                      "conv3d, for NCDHW or NDHWC format."
+                                      "But now it's [%d]",
+                                      input_ndim));
+
+  PADDLE_ENFORCE_EQ(
+      filter_ndim,
+      5,
+      common::errors::InvalidArgument(
+          "The Tensor Filter's rank must be 5 in conv3d, for MCDHW format."
+          "But now it's [%d]",
+          filter_ndim));
+
+  PADDLE_ENFORCE_EQ(input_ndim,
+                    input_dims_mapping.size(),
+                    common::errors::InvalidArgument(
+                        "The Tensor Input's rank [%d] and Input's "
+                        "dims_mapping size [%d] are not matched.",
+                        input_ndim,
+                        input_dims_mapping.size()));
+  PADDLE_ENFORCE_EQ(filter_ndim,
+                    filter_dims_mapping.size(),
+                    common::errors::InvalidArgument(
+                        "The Tensor Filter's rank [%d] and Filter's "
+                        "dims_mapping size [%d] are not matched.",
+                        filter_ndim,
+                        filter_dims_mapping.size()));
+  // todo: NCDHW or NDHWC check, check channel logic, input's channel
+  // dims_mapping must be equal to filter's channel dims_mapping
+  int inpput_channel_dim = (data_format == "NCDHW") ? 1 : 4;
+  int filter_channel_dim = 1;
+  PADDLE_ENFORCE_EQ(input_dims_mapping[inpput_channel_dim],
+                    filter_dims_mapping[filter_channel_dim],
+                    common::errors::InvalidArgument(
+                        "The Input channel's dims mapping must be equal to "
+                        "filter channel's dims mapping in conv3d. "
+                        "When shard channel dim to a mesh (multiple cards), "
+                        "each card will compute partial output, ",
+                        "otherwise, mark channel dim as replicate, each card "
+                        "will compute complete output.",
+                        "But now the Input channel's dims mapping is [%d], and "
+                        "the filter channel's dims mapping is [%d].",
+                        input_dims_mapping[inpput_channel_dim],
+                        filter_dims_mapping[filter_channel_dim]));
+
+  VLOG(6) << "Conv3D InferForward Inputs: "
+          << "Input shape: [" << str_join(original_input_shape)
+          << "], input_dims_mapping: [" << str_join(input_dims_mapping)
+          << "], Input data format: [" << data_format << "]; Filter shape: ["
+          << str_join(original_filter_shape) << "], filter_dims_mapping: ["
+          << str_join(filter_dims_mapping) << "]; ";
+
+  // Step1: build Einsum Notation
+  // todo: check output notation, how to deal with the "Input DHW, Filter DHW
+  // and Output DHW"...
+  VLOG(4) << "step 1: build Einsum Notation";
+  std::string input_axes = (data_format == "NCDHW") ? "ncdhw" : "ndhwc";
+  std::string filter_axes = "mcdhw";
+  std::string output_axes = "nmdhw";
+
+  // Step2: sharding propagation
+  VLOG(4) << "step 2: sharding propagation";
+  // Step2.1: merge input sharding
+  std::pair<std::string, std::vector<int64_t>> input_pair(input_axes,
+                                                          input_dims_mapping);
+  std::pair<std::string, std::vector<int64_t>> filter_pair(filter_axes,
+                                                           filter_dims_mapping);
+  auto axis_to_dim_map = ShardingMergeForTensors({input_pair, filter_pair});
+  // Step2.2: infer output dims mapping
+  TensorDistAttr output_dist_attr_dst =
+      CopyTensorDistAttrForOutput(input_dist_attr_src);
+  output_dist_attr_dst.set_dims_mapping(
+      GetDimsMappingForAxes(output_axes, axis_to_dim_map));
+
+  // Step2.3: update input dims mapping
+  TensorDistAttr input_dist_attr_dst =
+      CopyTensorDistAttrForOutput(input_dist_attr_src);
+  TensorDistAttr filter_dist_attr_dst =
+      CopyTensorDistAttrForOutput(filter_dist_attr_src);
+  input_dist_attr_dst.set_dims_mapping(
+      GetDimsMappingForAxes(input_axes, axis_to_dim_map));
+  filter_dist_attr_dst.set_dims_mapping(
+      GetDimsMappingForAxes(filter_axes, axis_to_dim_map));
+
+  // Step2.4: Handle Partial
+  // Step2.4.1 Output Partial
+  std::vector<int64_t> partial_on_dims =
+      ResoluteOutputPartialDimension(axis_to_dim_map, output_axes);
+  output_dist_attr_dst.set_partial_status(partial_on_dims);
+
+  VLOG(4) << "Conv3DSPMDRule InferForward: "
+          << "Einsum notation: [" << input_axes << "," << filter_axes << " --> "
+          << output_axes << "]. " << std::endl;
+  LogInputDistAttr(
+      "Input", original_input_shape, input_dist_attr_src, input_dist_attr_dst);
+  LogInputDistAttr("Filter",
+                   original_filter_shape,
+                   filter_dist_attr_src,
+                   filter_dist_attr_dst);
+  LogOutputDistAttr("Output", output_dist_attr_dst);
+  VLOG(4) << std::endl;
+
+  return {{input_dist_attr_dst, filter_dist_attr_dst}, {output_dist_attr_dst}};
+}
+
+SpmdInfo Conv3dGradInferSpmdBase(const DistMetaTensor& input,
+                                 const DistMetaTensor& filter,
+                                 const DistMetaTensor& output_grad,
+                                 const std::string& data_format) {
+  auto check_channel_dist_attr =
+      [&](const phi::distributed::TensorDistAttr& input_dist_attr,
+          const phi::distributed::TensorDistAttr& filter_dist_attr,
+          const phi::distributed::TensorDistAttr& output_grad_dist_attr) {
+        int inpput_channel_dim = (data_format == "NCDHW") ? 1 : 4;
+        int filter_channel_dim = 1;
+        if (output_grad_dist_attr.is_partial()) {
+          std::set<int64_t> partial_dims = output_grad_dist_attr.partial_dims();
+          PADDLE_ENFORCE_EQ(
+              partial_dims.size(),
+              1,
+              common::errors::InvalidArgument(
+                  "For conv3d output, only support partial on channel_dim for "
+                  "output, "
+                  "which means shard on channel_dim for input and filter."
+                  "But now the output is partial on [%d] dims.",
+                  partial_dims.size()));
+
+          int64_t partial_dim = *partial_dims.begin();
+          auto input_dims_mapping = input_dist_attr.dims_mapping();
+          auto filter_dims_mapping = filter_dist_attr.dims_mapping();
+          if (input_dims_mapping[inpput_channel_dim] == partial_dim &&
+              filter_dims_mapping[filter_channel_dim] == partial_dim) {
+            return true;
+          }
+        }
+
+        return false;
+      };
+
+  auto input_dist_attr_src = input.dist_attr();
+  auto filter_dist_attr_src = filter.dist_attr();
+  auto output_grad_dist_attr_src = output_grad.dist_attr();
+
+  std::string input_axes = (data_format == "NCDHW") ? "ncdhw" : "ndhwc";
+  std::string filter_axes = "mcdhw";
+  std::string output_axes = "nmdhw";
+
+  std::pair<std::string, std::vector<int64_t>> input_pair(
+      input_axes, input_dist_attr_src.dims_mapping());
+  std::pair<std::string, std::vector<int64_t>> filter_pair(
+      filter_axes, filter_dist_attr_src.dims_mapping());
+  std::pair<std::string, std::vector<int64_t>> output_grad_pair(
+      output_axes, output_grad_dist_attr_src.dims_mapping());
+
+  // input_grad_dist, copy n_dim and merge m_dim
+  auto axis_to_dim_map_1 =
+      ShardingMergeForTensors({filter_pair, output_grad_pair});
+  TensorDistAttr input_grad_dist_attr_dst =
+      GetReplicatedDistAttr(input_dist_attr_src);
+  input_grad_dist_attr_dst.set_dims_mapping(
+      GetDimsMappingForAxes(input_axes, axis_to_dim_map_1));
+  // handle partial for input_grad
+  std::vector<int64_t> partial_on_m_dim =
+      ResoluteOutputPartialDimension(axis_to_dim_map_1, input_axes);
+  input_grad_dist_attr_dst.set_partial_status(partial_on_m_dim);
+  TensorDistAttr filter_dist_attr_dst =
+      CopyTensorDistAttrForOutput(filter_dist_attr_src);
+  filter_dist_attr_dst.set_dims_mapping(
+      GetDimsMappingForAxes(filter_axes, axis_to_dim_map_1));
+
+  // filter_grad_dist, copy m_dim and merge n_dim
+  auto axis_to_dim_map_2 =
+      ShardingMergeForTensors({input_pair, output_grad_pair});
+  TensorDistAttr filter_grad_dist_attr_dst =
+      GetReplicatedDistAttr(filter_dist_attr_src);
+  filter_grad_dist_attr_dst.set_dims_mapping(
+      GetDimsMappingForAxes(filter_axes, axis_to_dim_map_2));
+  // handle partial for filter_grad
+  std::vector<int64_t> partial_on_n_dim =
+      ResoluteOutputPartialDimension(axis_to_dim_map_2, filter_axes);
+  filter_grad_dist_attr_dst.set_partial_status(partial_on_n_dim);
+  TensorDistAttr input_dist_attr_dst =
+      CopyTensorDistAttrForOutput(input_dist_attr_src);
+  input_dist_attr_dst.set_dims_mapping(
+      GetDimsMappingForAxes(input_axes, axis_to_dim_map_2));
+
+  // output_grad
+  auto axis_to_dim_map_3 =
+      ShardingMergeForTensors({input_pair, filter_pair, output_grad_pair});
+  TensorDistAttr output_grad_dist_attr_dst =
+      CopyTensorDistAttrForOutput(output_grad_dist_attr_src);
+  output_grad_dist_attr_dst.set_dims_mapping(
+      GetDimsMappingForAxes(output_axes, axis_to_dim_map_3));
+
+  // process channel_dim, handle partial
+  int inpput_channel_dim = (data_format == "NCDHW") ? 1 : 4;
+  int filter_channel_dim = 1;
+  if (check_channel_dist_attr(input_dist_attr_src,
+                              filter_dist_attr_src,
+                              output_grad_dist_attr_src)) {
+    int partial_mesh_dim = *output_grad_dist_attr_src.partial_dims().begin();
+    std::vector<int64_t> input_grad_dims_mapping_dst =
+        input_grad_dist_attr_dst.dims_mapping();
+    input_grad_dims_mapping_dst[inpput_channel_dim] = partial_mesh_dim;
+    input_grad_dist_attr_dst.set_dims_mapping(input_grad_dims_mapping_dst);
+    std::vector<int64_t> filter_grad_dims_mapping_dst =
+        filter_grad_dist_attr_dst.dims_mapping();
+    filter_grad_dims_mapping_dst[filter_channel_dim] = partial_mesh_dim;
+    filter_grad_dist_attr_dst.set_dims_mapping(filter_grad_dims_mapping_dst);
+    output_grad_dist_attr_dst.set_partial_status(
+        std::vector<int64_t>({partial_mesh_dim}));
+  }
+
+  return {
+      {input_dist_attr_dst, filter_dist_attr_dst, output_grad_dist_attr_dst},
+      {input_grad_dist_attr_dst, filter_grad_dist_attr_dst}};
+}
+
+SpmdInfo Conv3dInferSpmd(const DistMetaTensor& input,
+                         const DistMetaTensor& filter,
+                         const std::vector<int>& strides,
+                         const std::vector<int>& paddings,
+                         const std::string& padding_algorithm,
+                         int groups,
+                         const std::vector<int>& dilations,
+                         const std::string& data_format) {
+  return Conv3dInferSpmdBase(input, filter, data_format);
+}
+
+SpmdInfo Conv3dGradInferSpmd(const DistMetaTensor& input,
+                             const DistMetaTensor& filter,
+                             const DistMetaTensor& output_grad,
+                             const std::vector<int>& strides,
+                             const std::vector<int>& paddings,
+                             const std::string& padding_algorithm,
+                             int groups,
+                             const std::vector<int>& dilations,
+                             const std::string& data_format) {
+  return Conv3dGradInferSpmdBase(input, filter, output_grad, data_format);
+}
+
+}  // namespace distributed
+}  // namespace phi

--- a/paddle/phi/infermeta/spmd_rules/conv3d.cc
+++ b/paddle/phi/infermeta/spmd_rules/conv3d.cc
@@ -74,9 +74,9 @@ SpmdInfo Conv3dInferSpmdBase(const DistMetaTensor& input,
                         filter_dims_mapping.size()));
   // todo: NCDHW or NDHWC check, check channel logic, input's channel
   // dims_mapping must be equal to filter's channel dims_mapping
-  int inpput_channel_dim = (data_format == "NCDHW") ? 1 : 4;
+  int input_channel_dim = (data_format == "NCDHW") ? 1 : 4;
   int filter_channel_dim = 1;
-  PADDLE_ENFORCE_EQ(input_dims_mapping[inpput_channel_dim],
+  PADDLE_ENFORCE_EQ(input_dims_mapping[input_channel_dim],
                     filter_dims_mapping[filter_channel_dim],
                     common::errors::InvalidArgument(
                         "The Input channel's dims mapping must be equal to "
@@ -87,7 +87,7 @@ SpmdInfo Conv3dInferSpmdBase(const DistMetaTensor& input,
                         "will compute complete output.",
                         "But now the Input channel's dims mapping is [%d], and "
                         "the filter channel's dims mapping is [%d].",
-                        input_dims_mapping[inpput_channel_dim],
+                        input_dims_mapping[input_channel_dim],
                         filter_dims_mapping[filter_channel_dim]));
 
   VLOG(6) << "Conv3D InferForward Inputs: "
@@ -158,7 +158,7 @@ SpmdInfo Conv3dGradInferSpmdBase(const DistMetaTensor& input,
       [&](const phi::distributed::TensorDistAttr& input_dist_attr,
           const phi::distributed::TensorDistAttr& filter_dist_attr,
           const phi::distributed::TensorDistAttr& output_grad_dist_attr) {
-        int inpput_channel_dim = (data_format == "NCDHW") ? 1 : 4;
+        int input_channel_dim = (data_format == "NCDHW") ? 1 : 4;
         int filter_channel_dim = 1;
         if (output_grad_dist_attr.is_partial()) {
           std::set<int64_t> partial_dims = output_grad_dist_attr.partial_dims();
@@ -175,7 +175,7 @@ SpmdInfo Conv3dGradInferSpmdBase(const DistMetaTensor& input,
           int64_t partial_dim = *partial_dims.begin();
           auto input_dims_mapping = input_dist_attr.dims_mapping();
           auto filter_dims_mapping = filter_dist_attr.dims_mapping();
-          if (input_dims_mapping[inpput_channel_dim] == partial_dim &&
+          if (input_dims_mapping[input_channel_dim] == partial_dim &&
               filter_dims_mapping[filter_channel_dim] == partial_dim) {
             return true;
           }
@@ -240,7 +240,7 @@ SpmdInfo Conv3dGradInferSpmdBase(const DistMetaTensor& input,
       GetDimsMappingForAxes(output_axes, axis_to_dim_map_3));
 
   // process channel_dim, handle partial
-  int inpput_channel_dim = (data_format == "NCDHW") ? 1 : 4;
+  int input_channel_dim = (data_format == "NCDHW") ? 1 : 4;
   int filter_channel_dim = 1;
   if (check_channel_dist_attr(input_dist_attr_src,
                               filter_dist_attr_src,
@@ -248,7 +248,7 @@ SpmdInfo Conv3dGradInferSpmdBase(const DistMetaTensor& input,
     int partial_mesh_dim = *output_grad_dist_attr_src.partial_dims().begin();
     std::vector<int64_t> input_grad_dims_mapping_dst =
         input_grad_dist_attr_dst.dims_mapping();
-    input_grad_dims_mapping_dst[inpput_channel_dim] = partial_mesh_dim;
+    input_grad_dims_mapping_dst[input_channel_dim] = partial_mesh_dim;
     input_grad_dist_attr_dst.set_dims_mapping(input_grad_dims_mapping_dst);
     std::vector<int64_t> filter_grad_dims_mapping_dst =
         filter_grad_dist_attr_dst.dims_mapping();

--- a/paddle/phi/infermeta/spmd_rules/conv3d.h
+++ b/paddle/phi/infermeta/spmd_rules/conv3d.h
@@ -1,0 +1,55 @@
+/* Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "paddle/phi/core/distributed/auto_parallel/dist_meta_tensor.h"
+#include "paddle/phi/core/distributed/type_defs.h"
+
+namespace phi {
+namespace distributed {
+
+SpmdInfo Conv3dInferSpmdBase(const DistMetaTensor& input,
+                             const DistMetaTensor& filter,
+                             const std::string& data_format);
+
+SpmdInfo Conv3dGradInferSpmdBase(const DistMetaTensor& input,
+                                 const DistMetaTensor& filter,
+                                 const DistMetaTensor& output_grad,
+                                 const std::string& data_format);
+
+SpmdInfo Conv3dInferSpmd(const DistMetaTensor& input,
+                         const DistMetaTensor& filter,
+                         const std::vector<int>& strides = {1, 1, 1},
+                         const std::vector<int>& paddings = {0, 0, 0},
+                         const std::string& padding_algorithm = "EXPLICIT",
+                         int groups = 1,
+                         const std::vector<int>& dilations = {1, 1, 1},
+                         const std::string& data_format = "NCDHW");
+
+SpmdInfo Conv3dGradInferSpmd(const DistMetaTensor& input,
+                             const DistMetaTensor& filter,
+                             const DistMetaTensor& output_grad,
+                             const std::vector<int>& strides = {1, 1, 1},
+                             const std::vector<int>& paddings = {0, 0, 0},
+                             const std::string& padding_algorithm = "EXPLICIT",
+                             int groups = 1,
+                             const std::vector<int>& dilations = {1, 1, 1},
+                             const std::string& data_format = "NCDHW");
+
+}  // namespace distributed
+}  // namespace phi

--- a/paddle/phi/infermeta/spmd_rules/rules.cc
+++ b/paddle/phi/infermeta/spmd_rules/rules.cc
@@ -810,6 +810,7 @@ PD_REGISTER_SPMD_RULE(
     take_along_axis,
     PD_INFER_SPMD(phi::distributed::TakeAlongAxisInferSpmd),
     PD_INFER_SPMD(phi::distributed::TakeAlongAxisGradInferSpmd));
+
 // conv3d
 PD_REGISTER_SPMD_RULE(conv3d,
                       PD_INFER_SPMD(phi::distributed::Conv3dInferSpmd),

--- a/paddle/phi/infermeta/spmd_rules/rules.cc
+++ b/paddle/phi/infermeta/spmd_rules/rules.cc
@@ -810,4 +810,8 @@ PD_REGISTER_SPMD_RULE(
     take_along_axis,
     PD_INFER_SPMD(phi::distributed::TakeAlongAxisInferSpmd),
     PD_INFER_SPMD(phi::distributed::TakeAlongAxisGradInferSpmd));
+// conv3d
+PD_REGISTER_SPMD_RULE(conv3d,
+                      PD_INFER_SPMD(phi::distributed::Conv3dInferSpmd),
+                      PD_INFER_SPMD(phi::distributed::Conv3dGradInferSpmd));
 }  // namespace phi::distributed

--- a/paddle/phi/infermeta/spmd_rules/rules.h
+++ b/paddle/phi/infermeta/spmd_rules/rules.h
@@ -28,6 +28,7 @@ limitations under the License. */
 #include "paddle/phi/infermeta/spmd_rules/coalesce_tensor.h"
 #include "paddle/phi/infermeta/spmd_rules/concat.h"
 #include "paddle/phi/infermeta/spmd_rules/conv2d.h"
+#include "paddle/phi/infermeta/spmd_rules/conv3d.h"
 #include "paddle/phi/infermeta/spmd_rules/cross_entropy_with_softmax.h"
 #include "paddle/phi/infermeta/spmd_rules/cummax.h"
 #include "paddle/phi/infermeta/spmd_rules/cummin.h"

--- a/paddle/phi/ops/yaml/backward.yaml
+++ b/paddle/phi/ops/yaml/backward.yaml
@@ -570,6 +570,7 @@
   infer_meta :
     func : GeneralBinaryGradInferMeta
     param : [input, filter]
+    spmd_rule : Conv3dGradInferSpmd
   kernel :
     func : conv3d_grad
     data_type : input

--- a/paddle/phi/ops/yaml/ops.yaml
+++ b/paddle/phi/ops/yaml/ops.yaml
@@ -1145,6 +1145,7 @@
   output : Tensor
   infer_meta :
     func : Conv3DInferMeta
+    spmd_rule : Conv3dInferSpmd
   kernel :
     func : conv3d
     data_type : input

--- a/test/auto_parallel/spmd_rules/CMakeLists.txt
+++ b/test/auto_parallel/spmd_rules/CMakeLists.txt
@@ -62,6 +62,7 @@ if(WITH_DISTRIBUTE)
                     test_fused_gemm_epilogue_rule)
     py_test_modules(test_gelu_rule MODULES test_gelu_rule)
     py_test_modules(test_take_along_axis_rule MODULES test_take_along_axis_rule)
+    py_test_modules(test_conv3d_rule MODULES test_conv3d_rule)
   endif()
   # End of unittests WITH single card WITHOUT timeout
 

--- a/test/auto_parallel/spmd_rules/test_conv3d_rule.py
+++ b/test/auto_parallel/spmd_rules/test_conv3d_rule.py
@@ -331,7 +331,7 @@ class TestConv3dSPMDRule(unittest.TestCase):
     def test_conv3d_ncdhw_infer_backward(self):
         # backward setup
         input_shape = [2, 4, 8, 8, 8]
-        self.data_format = "NDHWC"
+        self.data_format = "NCDHW"
         filter_shape = [10, 4, 3, 3, 3]
         output_shape = [2, 10, 6, 6, 6]
         process_mesh = auto.ProcessMesh(
@@ -413,7 +413,7 @@ class TestConv3dSPMDRule(unittest.TestCase):
 
         # case 2:
         # Output: NMDoutHoutWout[0, 1, -1, -1, -1] partial_dim=[2]--->
-        # input: NCDinHinWin[0, -1, -1, -1, -1], filter: MCDkHkWk[1, -1, -1, -1, -1]
+        # input: NCDinHinWin[0, 2, -1, -1, -1], filter: MCDkHkWk[1, 2, -1, -1, -1]
         # input_grad: NCDinHinWin[0, 2, -1, -1, -1], filter_grad: MCDkHkWk[1, 2, -1, -1, -1]
         output_tensor_dist_attr._set_partial_dims([2])
         self.output_dist_tensor_spec = DistTensorSpec(

--- a/test/auto_parallel/spmd_rules/test_conv3d_rule.py
+++ b/test/auto_parallel/spmd_rules/test_conv3d_rule.py
@@ -1,0 +1,469 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from paddle.distributed.auto_parallel.static.dist_attribute import (
+    DistTensorSpec,
+    TensorDistAttr,
+)
+from paddle.distributed.fleet import auto
+from paddle.framework import core
+
+
+class TestConv3dSPMDRule(unittest.TestCase):
+    def setUp(self):
+        self.rule = core.get_phi_spmd_rule("conv3d")
+
+    def test_conv3d_ncdhw_infer_forward(self):
+        # forward setup
+        input_shape = [2, 4, 6, 8, 8]
+        self.data_format = "NCDHW"
+        filter_shape = [10, 4, 2, 3, 3]
+        process_mesh = auto.ProcessMesh(
+            mesh=[[[0, 1], [2, 3]], [[4, 5], [6, 7]]]
+        )
+
+        input_tensor_dist_attr = TensorDistAttr()
+        input_tensor_dist_attr.dims_mapping = [0, -1, -1, -1, -1]
+        input_tensor_dist_attr.process_mesh = process_mesh
+        self.input_dist_tensor_spec = DistTensorSpec(
+            input_shape, input_tensor_dist_attr
+        )
+
+        filter_tensor_dist_attr = TensorDistAttr()
+        filter_tensor_dist_attr.dims_mapping = [-1, -1, -1, -1, -1]
+        filter_tensor_dist_attr.process_mesh = process_mesh
+        self.filter_dist_tensor_spec = DistTensorSpec(
+            filter_shape, filter_tensor_dist_attr
+        )
+
+        self.strides = [1, 1, 1]
+        self.paddings = [0, 0, 0]
+        self.padding_algorithm = "EXPLICIT"
+        self.group = 1
+        self.dilations = [1, 1, 1]
+        # case 1
+        # input: NCDinHinWin[0, -1, -1, -1, -1], filter: MCDkHkWk[-1, -1, -1, -1, -1]
+        # ---> output: NMDoutHoutWout[0, -1, -1, -1, -1]
+        result_dist_attrs = self.rule.infer_forward(
+            self.input_dist_tensor_spec,
+            self.filter_dist_tensor_spec,
+            self.strides,
+            self.paddings,
+            self.padding_algorithm,
+            self.group,
+            self.dilations,
+            self.data_format,
+        )
+
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
+
+        self.assertEqual(len(result_dist_attrs), 2)
+        self.assertEqual(len(inferred_input_dist_attrs), 2)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
+
+        self.assertEqual(
+            inferred_input_dist_attrs[0].dims_mapping, [0, -1, -1, -1, -1]
+        )
+        self.assertEqual(
+            inferred_input_dist_attrs[1].dims_mapping, [-1, -1, -1, -1, -1]
+        )
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [0, -1, -1, -1, -1]
+        )
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), False)
+
+        # case 2
+        # input: NCDinHinWin[-1, -1, -1, -1, -1], filter: MCDkHkWk[0, -1, -1, -1, -1]
+        # ---> output: NMDoutHoutWout[-1, 0, -1, -1, -1]
+        self.input_dist_tensor_spec.set_dims_mapping([-1, -1, -1, -1, -1])
+        self.filter_dist_tensor_spec.set_dims_mapping([0, -1, -1, -1, -1])
+
+        result_dist_attrs = self.rule.infer_forward(
+            self.input_dist_tensor_spec,
+            self.filter_dist_tensor_spec,
+            self.strides,
+            self.paddings,
+            self.padding_algorithm,
+            self.group,
+            self.dilations,
+            self.data_format,
+        )
+
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
+
+        self.assertEqual(len(result_dist_attrs), 2)
+        self.assertEqual(len(inferred_input_dist_attrs), 2)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
+
+        self.assertEqual(
+            inferred_input_dist_attrs[0].dims_mapping, [-1, -1, -1, -1, -1]
+        )
+        self.assertEqual(
+            inferred_input_dist_attrs[1].dims_mapping, [0, -1, -1, -1, -1]
+        )
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [-1, 0, -1, -1, -1]
+        )
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), False)
+
+        # case 3
+        # input: NCDinHinWin[0, -1, -1, -1, -1], filter: MCDkHkWk[1, -1, -1, -1, -1] --->
+        # output: NMDoutHoutWout[0, 1, -1, -1, -1]
+        self.input_dist_tensor_spec.set_dims_mapping([0, -1, -1, -1, -1])
+        self.filter_dist_tensor_spec.set_dims_mapping([1, -1, -1, -1, -1])
+
+        result_dist_attrs = self.rule.infer_forward(
+            self.input_dist_tensor_spec,
+            self.filter_dist_tensor_spec,
+            self.strides,
+            self.paddings,
+            self.padding_algorithm,
+            self.group,
+            self.dilations,
+            self.data_format,
+        )
+
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
+
+        self.assertEqual(len(result_dist_attrs), 2)
+        self.assertEqual(len(inferred_input_dist_attrs), 2)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
+
+        self.assertEqual(
+            inferred_input_dist_attrs[0].dims_mapping, [0, -1, -1, -1, -1]
+        )
+        self.assertEqual(
+            inferred_input_dist_attrs[1].dims_mapping, [1, -1, -1, -1, -1]
+        )
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [0, 1, -1, -1, -1]
+        )
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), False)
+
+        # case 4
+        # input: NCDinHinWin[-1, 0, -1, -1, -1], filter: MCDkHkWk[-1, 0, -1, -1, -1] --->
+        # output: NMDoutHoutWout[-1, -1, -1, -1, -1]
+        self.input_dist_tensor_spec.set_dims_mapping([-1, 0, -1, -1, -1])
+        self.filter_dist_tensor_spec.set_dims_mapping([-1, 0, -1, -1, -1])
+
+        result_dist_attrs = self.rule.infer_forward(
+            self.input_dist_tensor_spec,
+            self.filter_dist_tensor_spec,
+            self.strides,
+            self.paddings,
+            self.padding_algorithm,
+            self.group,
+            self.dilations,
+            self.data_format,
+        )
+
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
+
+        self.assertEqual(len(result_dist_attrs), 2)
+        self.assertEqual(len(inferred_input_dist_attrs), 2)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
+
+        self.assertEqual(
+            inferred_input_dist_attrs[0].dims_mapping, [-1, 0, -1, -1, -1]
+        )
+        self.assertEqual(
+            inferred_input_dist_attrs[1].dims_mapping, [-1, 0, -1, -1, -1]
+        )
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [-1, -1, -1, -1, -1]
+        )
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), True)
+        self.assertEqual(inferred_output_dist_attrs[0]._partial_dims(), {0})
+
+        # case 5
+        # input: NCDinHinWin[0, 2, -1, -1, -1], filter: MCDkHkWk[1, 2, -1, -1, -1] --->
+        # output: NMDoutHoutWout[0, 1, -1, -1, -1]
+        self.input_dist_tensor_spec.set_dims_mapping([0, 2, -1, -1, -1])
+        self.filter_dist_tensor_spec.set_dims_mapping([1, 2, -1, -1, -1])
+
+        result_dist_attrs = self.rule.infer_forward(
+            self.input_dist_tensor_spec,
+            self.filter_dist_tensor_spec,
+            self.strides,
+            self.paddings,
+            self.padding_algorithm,
+            self.group,
+            self.dilations,
+            self.data_format,
+        )
+
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
+
+        self.assertEqual(len(result_dist_attrs), 2)
+        self.assertEqual(len(inferred_input_dist_attrs), 2)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
+
+        self.assertEqual(
+            inferred_input_dist_attrs[0].dims_mapping, [0, 2, -1, -1, -1]
+        )
+        self.assertEqual(
+            inferred_input_dist_attrs[1].dims_mapping, [1, 2, -1, -1, -1]
+        )
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [0, 1, -1, -1, -1]
+        )
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), True)
+        self.assertEqual(inferred_output_dist_attrs[0]._partial_dims(), {2})
+
+    def test_conv3d_ndhwc_infer_forward(self):
+        # forward setup
+        input_shape = [2, 6, 8, 8, 4]
+        self.data_format = "NDHWC"
+        filter_shape = [10, 4, 2, 3, 3]
+        process_mesh = auto.ProcessMesh(
+            mesh=[[[0, 1], [2, 3]], [[4, 5], [6, 7]]]
+        )
+
+        input_tensor_dist_attr = TensorDistAttr()
+        input_tensor_dist_attr.dims_mapping = [-1, -1, -1, -1, -1]
+        input_tensor_dist_attr.process_mesh = process_mesh
+        self.input_dist_tensor_spec = DistTensorSpec(
+            input_shape, input_tensor_dist_attr
+        )
+
+        filter_tensor_dist_attr = TensorDistAttr()
+        filter_tensor_dist_attr.dims_mapping = [-1, -1, -1, -1, -1]
+        filter_tensor_dist_attr.process_mesh = process_mesh
+        self.filter_dist_tensor_spec = DistTensorSpec(
+            filter_shape, filter_tensor_dist_attr
+        )
+
+        self.strides = [1, 1, 1]
+        self.paddings = [0, 0, 0]
+        self.padding_algorithm = "EXPLICIT"
+        self.group = 1
+        self.dilations = [1, 1, 1]
+        # case 6
+        # input: NDinHinWinC[-1, -1, -1, -1, 0], filter: MCDkHkWk[-1, 0, -1, -1, -1] --->
+        # output: NMDoutHoutWout[-1, -1, -1, -1, -1]
+        self.input_dist_tensor_spec.set_dims_mapping([-1, -1, -1, -1, 0])
+        self.filter_dist_tensor_spec.set_dims_mapping([-1, 0, -1, -1, -1])
+
+        result_dist_attrs = self.rule.infer_forward(
+            self.input_dist_tensor_spec,
+            self.filter_dist_tensor_spec,
+            self.strides,
+            self.paddings,
+            self.padding_algorithm,
+            self.group,
+            self.dilations,
+            self.data_format,
+        )
+
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
+
+        self.assertEqual(len(result_dist_attrs), 2)
+        self.assertEqual(len(inferred_input_dist_attrs), 2)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
+
+        self.assertEqual(
+            inferred_input_dist_attrs[0].dims_mapping, [-1, -1, -1, -1, 0]
+        )
+        self.assertEqual(
+            inferred_input_dist_attrs[1].dims_mapping, [-1, 0, -1, -1, -1]
+        )
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [-1, -1, -1, -1, -1]
+        )
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), True)
+        self.assertEqual(inferred_output_dist_attrs[0]._partial_dims(), {0})
+
+        # case 7
+        # input: NDinHinWinC[0, -1, -1, -1, 2], filter: MCDkHkWk[1, 2, -1, -1, -1] --->
+        # output: NMDoutHoutWout[0, 1, -1, -1, -1]
+        self.input_dist_tensor_spec.set_dims_mapping([0, -1, -1, -1, 2])
+        self.filter_dist_tensor_spec.set_dims_mapping([1, 2, -1, -1, -1])
+
+        result_dist_attrs = self.rule.infer_forward(
+            self.input_dist_tensor_spec,
+            self.filter_dist_tensor_spec,
+            self.strides,
+            self.paddings,
+            self.padding_algorithm,
+            self.group,
+            self.dilations,
+            self.data_format,
+        )
+
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
+
+        self.assertEqual(len(result_dist_attrs), 2)
+        self.assertEqual(len(inferred_input_dist_attrs), 2)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
+
+        self.assertEqual(
+            inferred_input_dist_attrs[0].dims_mapping, [0, -1, -1, -1, 2]
+        )
+        self.assertEqual(
+            inferred_input_dist_attrs[1].dims_mapping, [1, 2, -1, -1, -1]
+        )
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [0, 1, -1, -1, -1]
+        )
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), True)
+        self.assertEqual(inferred_output_dist_attrs[0]._partial_dims(), {2})
+
+    def test_conv3d_ncdhw_infer_backward(self):
+        # backward setup
+        input_shape = [2, 4, 8, 8, 8]
+        self.data_format = "NDHWC"
+        filter_shape = [10, 4, 3, 3, 3]
+        output_shape = [2, 10, 6, 6, 6]
+        process_mesh = auto.ProcessMesh(
+            mesh=[[[0, 1], [2, 3]], [[4, 5], [6, 7]]]
+        )
+
+        input_tensor_dist_attr = TensorDistAttr()
+        input_tensor_dist_attr.dims_mapping = [-1, -1, -1, -1, -1]
+        input_tensor_dist_attr.process_mesh = process_mesh
+        self.input_dist_tensor_spec = DistTensorSpec(
+            input_shape, input_tensor_dist_attr
+        )
+
+        filter_tensor_dist_attr = TensorDistAttr()
+        filter_tensor_dist_attr.dims_mapping = [-1, -1, -1, -1, -1]
+        filter_tensor_dist_attr.process_mesh = process_mesh
+        self.filter_dist_tensor_spec = DistTensorSpec(
+            filter_shape, filter_tensor_dist_attr
+        )
+
+        output_tensor_dist_attr = TensorDistAttr()
+        output_tensor_dist_attr.dims_mapping = [0, 1, -1, -1, -1]
+        output_tensor_dist_attr.process_mesh = process_mesh
+        self.output_dist_tensor_spec = DistTensorSpec(
+            output_shape, output_tensor_dist_attr
+        )
+
+        self.strides = [1, 1, 1]
+        self.paddings = [0, 0, 0]
+        self.padding_algorithm = "EXPLICIT"
+        self.group = 1
+        self.dilations = [1, 1, 1]
+
+        # case 1:
+        # Output: NMDoutHoutWout[0, 1, -1, -1, -1] --->
+        # input: NCDinHinWin[0, -1, -1, -1, -1], filter: MCDkHkWk[1, -1, -1, -1, -1]
+        # input_grad: NCDinHinWin[0, -1, -1, -1, -1], filter_grad: MCDkHkWk[1, -1, -1, -1, -1]
+        result_dist_attrs = self.rule.infer_backward(
+            self.input_dist_tensor_spec,
+            self.filter_dist_tensor_spec,
+            self.output_dist_tensor_spec,
+            self.strides,
+            self.paddings,
+            self.padding_algorithm,
+            self.group,
+            self.dilations,
+            self.data_format,
+        )
+
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
+
+        self.assertEqual(len(result_dist_attrs), 2)
+        self.assertEqual(len(inferred_input_dist_attrs), 3)
+        self.assertEqual(len(inferred_output_dist_attrs), 2)
+
+        self.assertEqual(
+            inferred_input_dist_attrs[0].dims_mapping, [0, -1, -1, -1, -1]
+        )
+        self.assertEqual(
+            inferred_input_dist_attrs[1].dims_mapping, [1, -1, -1, -1, -1]
+        )
+        self.assertEqual(
+            inferred_input_dist_attrs[2].dims_mapping, [0, 1, -1, -1, -1]
+        )
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [0, -1, -1, -1, -1]
+        )
+        self.assertEqual(
+            inferred_output_dist_attrs[1].dims_mapping, [1, -1, -1, -1, -1]
+        )
+        self.assertEqual(inferred_input_dist_attrs[0]._is_partial(), False)
+        self.assertEqual(inferred_input_dist_attrs[1]._is_partial(), False)
+        self.assertEqual(inferred_input_dist_attrs[2]._is_partial(), False)
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), True)
+        self.assertEqual(inferred_output_dist_attrs[0]._partial_dims(), {1})
+        self.assertEqual(inferred_output_dist_attrs[1]._is_partial(), True)
+        self.assertEqual(inferred_output_dist_attrs[1]._partial_dims(), {0})
+
+        # case 2:
+        # Output: NMDoutHoutWout[0, 1, -1, -1, -1] partial_dim=[2]--->
+        # input: NCDinHinWin[0, -1, -1, -1, -1], filter: MCDkHkWk[1, -1, -1, -1, -1]
+        # input_grad: NCDinHinWin[0, 2, -1, -1, -1], filter_grad: MCDkHkWk[1, 2, -1, -1, -1]
+        output_tensor_dist_attr._set_partial_dims([2])
+        self.output_dist_tensor_spec = DistTensorSpec(
+            output_shape, output_tensor_dist_attr
+        )
+        self.input_dist_tensor_spec.set_dims_mapping([0, 2, -1, -1, -1])
+        self.filter_dist_tensor_spec.set_dims_mapping([1, 2, -1, -1, -1])
+        result_dist_attrs = self.rule.infer_backward(
+            self.input_dist_tensor_spec,
+            self.filter_dist_tensor_spec,
+            self.output_dist_tensor_spec,
+            self.strides,
+            self.paddings,
+            self.padding_algorithm,
+            self.group,
+            self.dilations,
+            self.data_format,
+        )
+
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
+
+        self.assertEqual(len(result_dist_attrs), 2)
+        self.assertEqual(len(inferred_input_dist_attrs), 3)
+        self.assertEqual(len(inferred_output_dist_attrs), 2)
+
+        self.assertEqual(
+            inferred_input_dist_attrs[0].dims_mapping, [0, 2, -1, -1, -1]
+        )
+        self.assertEqual(
+            inferred_input_dist_attrs[1].dims_mapping, [1, 2, -1, -1, -1]
+        )
+        self.assertEqual(
+            inferred_input_dist_attrs[2].dims_mapping, [0, 1, -1, -1, -1]
+        )
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [0, 2, -1, -1, -1]
+        )
+        self.assertEqual(
+            inferred_output_dist_attrs[1].dims_mapping, [1, 2, -1, -1, -1]
+        )
+        self.assertEqual(inferred_input_dist_attrs[0]._is_partial(), False)
+        self.assertEqual(inferred_input_dist_attrs[1]._is_partial(), False)
+        self.assertEqual(inferred_input_dist_attrs[2]._is_partial(), True)
+        self.assertEqual(inferred_input_dist_attrs[2]._partial_dims(), {2})
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), True)
+        self.assertEqual(inferred_output_dist_attrs[0]._partial_dims(), {1})
+        self.assertEqual(inferred_output_dist_attrs[1]._is_partial(), True)
+        self.assertEqual(inferred_output_dist_attrs[1]._partial_dims(), {0})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
为 conv3d 和 conv3d_grad 算子增加切分推导规则。

- 规则与现有 conv2d 规则一致。