### PR TITLE
[PHI] Fix some pool kernel for big tensor in cpu and gpudnn context

### DIFF
--- a/paddle/phi/kernels/funcs/pooling.cc
+++ b/paddle/phi/kernels/funcs/pooling.cc
@@ -41,44 +41,47 @@ class Pool2dFunctor<CPUContext, PoolProcess, T> {
                   PoolProcess pool_process) {
     bool channel_last = (data_format == "NHWC");
 
-    const int batch_size = input.dims()[0];
-    const int input_channels = channel_last ? input.dims()[3] : input.dims()[1];
-    const int input_height = channel_last ? input.dims()[1] : input.dims()[2];
-    const int input_width = channel_last ? input.dims()[2] : input.dims()[3];
+    const int64_t batch_size = input.dims()[0];
+    const int64_t input_channels =
+        channel_last ? input.dims()[3] : input.dims()[1];
+    const int64_t input_height =
+        channel_last ? input.dims()[1] : input.dims()[2];
+    const int64_t input_width =
+        channel_last ? input.dims()[2] : input.dims()[3];
 
-    const int output_channels =
+    const int64_t output_channels =
         channel_last ? output->dims()[3] : output->dims()[1];
-    const int output_height =
+    const int64_t output_height =
         channel_last ? output->dims()[1] : output->dims()[2];
-    const int output_width =
+    const int64_t output_width =
         channel_last ? output->dims()[2] : output->dims()[3];
 
-    const int ksize_height = ksize[0];
-    const int ksize_width = ksize[1];
+    const int64_t ksize_height = ksize[0];
+    const int64_t ksize_width = ksize[1];
 
-    const int stride_height = strides[0];
-    const int stride_width = strides[1];
+    const int64_t stride_height = strides[0];
+    const int64_t stride_width = strides[1];
 
-    const int padding_height = paddings[0];
-    const int padding_width = paddings[1];
+    const int64_t padding_height = paddings[0];
+    const int64_t padding_width = paddings[1];
 
     const T* input_data = input.data<T>();
     T* output_data = context.template Alloc<T>(output);
 
-    int hstart = 0, hend = 1;
-    int wstart = 0, wend = 1;
+    int64_t hstart = 0, hend = 1;
+    int64_t wstart = 0, wend = 1;
     if (!channel_last) {
-      const int input_stride = input_height * input_width;
-      const int output_stride = output_height * output_width;
-      for (int i = 0; i < batch_size; i++) {
-        for (int c = 0; c < output_channels; ++c) {
-          for (int ph = 0; ph < output_height; ++ph) {
+      const int64_t input_stride = input_height * input_width;
+      const int64_t output_stride = output_height * output_width;
+      for (int64_t i = 0; i < batch_size; i++) {
+        for (int64_t c = 0; c < output_channels; ++c) {
+          for (int64_t ph = 0; ph < output_height; ++ph) {
             if (adaptive) {
               hstart = AdaptStartIndex(ph, input_height, output_height);
               hend = AdaptEndIndex(ph, input_height, output_height);
             }
-            for (int pw = 0; pw < output_width; ++pw) {
-              int pool_size = 1;
+            for (int64_t pw = 0; pw < output_width; ++pw) {
+              int64_t pool_size = 1;
               if (adaptive) {
                 wstart = AdaptStartIndex(pw, input_width, output_width);
                 wend = AdaptEndIndex(pw, input_width, output_width);
@@ -91,15 +94,15 @@ class Pool2dFunctor<CPUContext, PoolProcess, T> {
                     std::min(wstart + ksize_width, input_width + padding_width);
                 pool_size = (hend - hstart) * (wend - wstart);
 
-                wstart = std::max(wstart, 0);
-                hstart = std::max(hstart, 0);
+                wstart = std::max(wstart, static_cast<int64_t>(0));
+                hstart = std::max(hstart, static_cast<int64_t>(0));
                 hend = std::min(hend, input_height);
                 wend = std::min(wend, input_width);
               }
 
               T ele = pool_process.initial();
-              for (int h = hstart; h < hend; ++h) {
-                for (int w = wstart; w < wend; ++w) {
+              for (int64_t h = hstart; h < hend; ++h) {
+                for (int64_t w = wstart; w < wend; ++w) {
                   pool_process.compute(input_data[h * input_width + w], &ele);
                 }
               }
@@ -115,17 +118,18 @@ class Pool2dFunctor<CPUContext, PoolProcess, T> {
         }
       }
     } else {
-      const int input_stride = input_height * input_width * input_channels;
-      const int output_stride = output_height * output_width * output_channels;
-      for (int i = 0; i < batch_size; i++) {
-        for (int c = 0; c < output_channels; ++c) {
-          for (int ph = 0; ph < output_height; ++ph) {
+      const int64_t input_stride = input_height * input_width * input_channels;
+      const int64_t output_stride =
+          output_height * output_width * output_channels;
+      for (int64_t i = 0; i < batch_size; i++) {
+        for (int64_t c = 0; c < output_channels; ++c) {
+          for (int64_t ph = 0; ph < output_height; ++ph) {
             if (adaptive) {
               hstart = AdaptStartIndex(ph, input_height, output_height);
               hend = AdaptEndIndex(ph, input_height, output_height);
             }
-            for (int pw = 0; pw < output_width; ++pw) {
-              int pool_size = 1;
+            for (int64_t pw = 0; pw < output_width; ++pw) {
+              int64_t pool_size = 1;
               if (adaptive) {
                 wstart = AdaptStartIndex(pw, input_width, output_width);
                 wend = AdaptEndIndex(pw, input_width, output_width);
@@ -138,14 +142,14 @@ class Pool2dFunctor<CPUContext, PoolProcess, T> {
                     std::min(wstart + ksize_width, input_width + padding_width);
                 pool_size = (hend - hstart) * (wend - wstart);
 
-                wstart = std::max(wstart, 0);
-                hstart = std::max(hstart, 0);
+                wstart = std::max(wstart, static_cast<int64_t>(0));
+                hstart = std::max(hstart, static_cast<int64_t>(0));
                 hend = std::min(hend, input_height);
                 wend = std::min(wend, input_width);
               }
               T ele = pool_process.initial();
-              for (int h = hstart; h < hend; ++h) {
-                for (int w = wstart; w < wend; ++w) {
+              for (int64_t h = hstart; h < hend; ++h) {
+                for (int64_t w = wstart; w < wend; ++w) {
                   pool_process.compute(
                       input_data[h * input_width * input_channels +
                                  w * input_channels + c],
@@ -192,46 +196,50 @@ class Pool2dGradFunctor<CPUContext, PoolProcess, T> {
                   PoolProcess pool_grad_process) {
     bool channel_last = (data_format == "NHWC");
 
-    const int batch_size = input.dims()[0];
+    const int64_t batch_size = input.dims()[0];
 
-    const int input_channels = channel_last ? input.dims()[3] : input.dims()[1];
-    const int input_height = channel_last ? input.dims()[1] : input.dims()[2];
-    const int input_width = channel_last ? input.dims()[2] : input.dims()[3];
+    const int64_t input_channels =
+        channel_last ? input.dims()[3] : input.dims()[1];
+    const int64_t input_height =
+        channel_last ? input.dims()[1] : input.dims()[2];
+    const int64_t input_width =
+        channel_last ? input.dims()[2] : input.dims()[3];
 
-    const int output_channels =
+    const int64_t output_channels =
         channel_last ? output.dims()[3] : output.dims()[1];
-    const int output_height =
+    const int64_t output_height =
         channel_last ? output.dims()[1] : output.dims()[2];
-    const int output_width = channel_last ? output.dims()[2] : output.dims()[3];
+    const int64_t output_width =
+        channel_last ? output.dims()[2] : output.dims()[3];
 
-    const int ksize_height = ksize[0];
-    const int ksize_width = ksize[1];
+    const int64_t ksize_height = ksize[0];
+    const int64_t ksize_width = ksize[1];
 
-    const int stride_height = strides[0];
-    const int stride_width = strides[1];
+    const int64_t stride_height = strides[0];
+    const int64_t stride_width = strides[1];
 
-    const int padding_height = paddings[0];
-    const int padding_width = paddings[1];
+    const int64_t padding_height = paddings[0];
+    const int64_t padding_width = paddings[1];
 
     const T* input_data = input.data<T>();
     const T* output_data = output.data<T>();
     const T* output_grad_data = output_grad.data<T>();
     T* input_grad_data = context.template Alloc<T>(input_grad);
 
-    int hstart = 0, hend = 1;
-    int wstart = 0, wend = 1;
+    int64_t hstart = 0, hend = 1;
+    int64_t wstart = 0, wend = 1;
     if (!channel_last) {
-      const int input_stride = input_height * input_width;
-      const int output_stride = output_height * output_width;
-      for (int i = 0; i < batch_size; i++) {
-        for (int c = 0; c < output_channels; ++c) {
-          for (int ph = 0; ph < output_height; ++ph) {
+      const int64_t input_stride = input_height * input_width;
+      const int64_t output_stride = output_height * output_width;
+      for (int64_t i = 0; i < batch_size; i++) {
+        for (int64_t c = 0; c < output_channels; ++c) {
+          for (int64_t ph = 0; ph < output_height; ++ph) {
             if (adaptive) {
               hstart = AdaptStartIndex(ph, input_height, output_height);
               hend = AdaptEndIndex(ph, input_height, output_height);
             }
-            for (int pw = 0; pw < output_width; ++pw) {
-              int pool_size = 1;
+            for (int64_t pw = 0; pw < output_width; ++pw) {
+              int64_t pool_size = 1;
               if (adaptive) {
                 wstart = AdaptStartIndex(pw, input_width, output_width);
                 wend = AdaptEndIndex(pw, input_width, output_width);
@@ -244,8 +252,8 @@ class Pool2dGradFunctor<CPUContext, PoolProcess, T> {
                     std::min(wstart + ksize_width, input_width + padding_width);
                 pool_size = (hend - hstart) * (wend - wstart);
 
-                wstart = std::max(wstart, 0);
-                hstart = std::max(hstart, 0);
+                wstart = std::max(wstart, static_cast<int64_t>(0));
+                hstart = std::max(hstart, static_cast<int64_t>(0));
                 hend = std::min(hend, input_height);
                 wend = std::min(wend, input_width);
               }
@@ -253,8 +261,8 @@ class Pool2dGradFunctor<CPUContext, PoolProcess, T> {
                 pool_size = (hend - hstart) * (wend - wstart);
               }
               float scale = 1.0f / static_cast<float>(pool_size);
-              for (int h = hstart; h < hend; ++h) {
-                for (int w = wstart; w < wend; ++w) {
+              for (int64_t h = hstart; h < hend; ++h) {
+                for (int64_t w = wstart; w < wend; ++w) {
                   pool_grad_process.compute(
                       input_data[h * input_width + w],
                       output_data[ph * output_width + pw],
@@ -272,17 +280,18 @@ class Pool2dGradFunctor<CPUContext, PoolProcess, T> {
         }
       }
     } else {
-      const int input_stride = input_height * input_width * input_channels;
-      const int output_stride = output_height * output_width * output_channels;
-      for (int i = 0; i < batch_size; i++) {
-        for (int c = 0; c < output_channels; ++c) {
-          for (int ph = 0; ph < output_height; ++ph) {
+      const int64_t input_stride = input_height * input_width * input_channels;
+      const int64_t output_stride =
+          output_height * output_width * output_channels;
+      for (int64_t i = 0; i < batch_size; i++) {
+        for (int64_t c = 0; c < output_channels; ++c) {
+          for (int64_t ph = 0; ph < output_height; ++ph) {
             if (adaptive) {
               hstart = AdaptStartIndex(ph, input_height, output_height);
               hend = AdaptEndIndex(ph, input_height, output_height);
             }
-            for (int pw = 0; pw < output_width; ++pw) {
-              int pool_size = 1;
+            for (int64_t pw = 0; pw < output_width; ++pw) {
+              int64_t pool_size = 1;
               if (adaptive) {
                 wstart = AdaptStartIndex(pw, input_width, output_width);
                 wend = AdaptEndIndex(pw, input_width, output_width);
@@ -295,8 +304,8 @@ class Pool2dGradFunctor<CPUContext, PoolProcess, T> {
                     std::min(wstart + ksize_width, input_width + padding_width);
                 pool_size = (hend - hstart) * (wend - wstart);
 
-                wstart = std::max(wstart, 0);
-                hstart = std::max(hstart, 0);
+                wstart = std::max(wstart, static_cast<int64_t>(0));
+                hstart = std::max(hstart, static_cast<int64_t>(0));
                 hend = std::min(hend, input_height);
                 wend = std::min(wend, input_width);
               }
@@ -304,8 +313,8 @@ class Pool2dGradFunctor<CPUContext, PoolProcess, T> {
                 pool_size = (hend - hstart) * (wend - wstart);
               }
               float scale = 1.0f / static_cast<float>(pool_size);
-              for (int h = hstart; h < hend; ++h) {
-                for (int w = wstart; w < wend; ++w) {
+              for (int64_t h = hstart; h < hend; ++h) {
+                for (int64_t w = wstart; w < wend; ++w) {
                   auto input_idx =
                       h * input_width * input_channels + w * input_channels + c;
                   auto output_idx = ph * output_width * output_channels +
@@ -350,26 +359,30 @@ class MaxPool2dGradFunctor<CPUContext, T> {
                   DenseTensor* input_grad) {
     bool channel_last = (data_format == "NHWC");
 
-    const int batch_size = input.dims()[0];
+    const int64_t batch_size = input.dims()[0];
 
-    const int input_channels = channel_last ? input.dims()[3] : input.dims()[1];
-    const int input_height = channel_last ? input.dims()[1] : input.dims()[2];
-    const int input_width = channel_last ? input.dims()[2] : input.dims()[3];
+    const int64_t input_channels =
+        channel_last ? input.dims()[3] : input.dims()[1];
+    const int64_t input_height =
+        channel_last ? input.dims()[1] : input.dims()[2];
+    const int64_t input_width =
+        channel_last ? input.dims()[2] : input.dims()[3];
 
-    const int output_channels =
+    const int64_t output_channels =
         channel_last ? output.dims()[3] : output.dims()[1];
-    const int output_height =
+    const int64_t output_height =
         channel_last ? output.dims()[1] : output.dims()[2];
-    const int output_width = channel_last ? output.dims()[2] : output.dims()[3];
+    const int64_t output_width =
+        channel_last ? output.dims()[2] : output.dims()[3];
 
-    const int ksize_height = ksize[0];
-    const int ksize_width = ksize[1];
+    const int64_t ksize_height = ksize[0];
+    const int64_t ksize_width = ksize[1];
 
-    const int stride_height = strides[0];
-    const int stride_width = strides[1];
+    const int64_t stride_height = strides[0];
+    const int64_t stride_width = strides[1];
 
-    const int padding_height = paddings[0];
-    const int padding_width = paddings[1];
+    const int64_t padding_height = paddings[0];
+    const int64_t padding_width = paddings[1];
 
     const T* input_data = input.data<T>();
     const T* output_data = output.data<T>();
@@ -377,24 +390,24 @@ class MaxPool2dGradFunctor<CPUContext, T> {
     T* input_grad_data = context.template Alloc<T>(input_grad);
 
     if (!channel_last) {
-      const int input_stride = input_height * input_width;
-      const int output_stride = output_height * output_width;
-      for (int i = 0; i < batch_size; i++) {
-        for (int c = 0; c < output_channels; ++c) {
-          for (int ph = 0; ph < output_height; ++ph) {
-            int hstart = ph * stride_height - padding_height;
-            int hend = std::min(hstart + ksize_height, input_height);
-            hstart = std::max(hstart, 0);
-            for (int pw = 0; pw < output_width; ++pw) {
-              int wstart = pw * stride_width - padding_width;
-              int wend = std::min(wstart + ksize_width, input_width);
-              wstart = std::max(wstart, 0);
+      const int64_t input_stride = input_height * input_width;
+      const int64_t output_stride = output_height * output_width;
+      for (int64_t i = 0; i < batch_size; i++) {
+        for (int64_t c = 0; c < output_channels; ++c) {
+          for (int64_t ph = 0; ph < output_height; ++ph) {
+            int64_t hstart = ph * stride_height - padding_height;
+            int64_t hend = std::min(hstart + ksize_height, input_height);
+            hstart = std::max(hstart, static_cast<int64_t>(0));
+            for (int64_t pw = 0; pw < output_width; ++pw) {
+              int64_t wstart = pw * stride_width - padding_width;
+              int64_t wend = std::min(wstart + ksize_width, input_width);
+              wstart = std::max(wstart, static_cast<int64_t>(0));
 
               bool stop = false;
-              for (int h = hstart; h < hend && !stop; ++h) {
-                for (int w = wstart; w < wend && !stop; ++w) {
-                  int input_idx = h * input_width + w;
-                  int output_idx = ph * output_width + pw;
+              for (int64_t h = hstart; h < hend && !stop; ++h) {
+                for (int64_t w = wstart; w < wend && !stop; ++w) {
+                  int64_t input_idx = h * input_width + w;
+                  int64_t output_idx = ph * output_width + pw;
                   if (input_data[input_idx] == output_data[output_idx]) {
                     input_grad_data[input_idx] += output_grad_data[output_idx];
                     stop = true;
@@ -410,26 +423,27 @@ class MaxPool2dGradFunctor<CPUContext, T> {
         }
       }
     } else {
-      const int input_stride = input_height * input_width * input_channels;
-      const int output_stride = output_height * output_width * output_channels;
-      for (int i = 0; i < batch_size; i++) {
-        for (int c = 0; c < output_channels; ++c) {
-          for (int ph = 0; ph < output_height; ++ph) {
-            int hstart = ph * stride_height - padding_height;
-            int hend = std::min(hstart + ksize_height, input_height);
-            hstart = std::max(hstart, 0);
-            for (int pw = 0; pw < output_width; ++pw) {
-              int wstart = pw * stride_width - padding_width;
-              int wend = std::min(wstart + ksize_width, input_width);
-              wstart = std::max(wstart, 0);
+      const int64_t input_stride = input_height * input_width * input_channels;
+      const int64_t output_stride =
+          output_height * output_width * output_channels;
+      for (int64_t i = 0; i < batch_size; i++) {
+        for (int64_t c = 0; c < output_channels; ++c) {
+          for (int64_t ph = 0; ph < output_height; ++ph) {
+            int64_t hstart = ph * stride_height - padding_height;
+            int64_t hend = std::min(hstart + ksize_height, input_height);
+            hstart = std::max(hstart, static_cast<int64_t>(0));
+            for (int64_t pw = 0; pw < output_width; ++pw) {
+              int64_t wstart = pw * stride_width - padding_width;
+              int64_t wend = std::min(wstart + ksize_width, input_width);
+              wstart = std::max(wstart, static_cast<int64_t>(0));
 
               bool stop = false;
-              for (int h = hstart; h < hend && !stop; ++h) {
-                for (int w = wstart; w < wend && !stop; ++w) {
-                  int input_idx =
+              for (int64_t h = hstart; h < hend && !stop; ++h) {
+                for (int64_t w = wstart; w < wend && !stop; ++w) {
+                  int64_t input_idx =
                       h * input_width * input_channels + w * input_channels + c;
-                  int output_idx = ph * output_width * output_channels +
-                                   pw * output_channels + c;
+                  int64_t output_idx = ph * output_width * output_channels +
+                                       pw * output_channels + c;
                   if (input_data[input_idx] == output_data[output_idx]) {
                     input_grad_data[input_idx] += output_grad_data[output_idx];
                     stop = true;
@@ -485,59 +499,63 @@ class Pool3dFunctor<CPUContext, PoolProcess, T> {
                   DenseTensor* output,
                   PoolProcess pool_process) {
     bool channel_last = (data_format == "NDHWC");
-    const int batch_size = input.dims()[0];
+    const int64_t batch_size = input.dims()[0];
 
-    const int input_channels = channel_last ? input.dims()[4] : input.dims()[1];
-    const int input_depth = channel_last ? input.dims()[1] : input.dims()[2];
-    const int input_height = channel_last ? input.dims()[2] : input.dims()[3];
-    const int input_width = channel_last ? input.dims()[3] : input.dims()[4];
+    const int64_t input_channels =
+        channel_last ? input.dims()[4] : input.dims()[1];
+    const int64_t input_depth =
+        channel_last ? input.dims()[1] : input.dims()[2];
+    const int64_t input_height =
+        channel_last ? input.dims()[2] : input.dims()[3];
+    const int64_t input_width =
+        channel_last ? input.dims()[3] : input.dims()[4];
 
-    const int output_channels =
+    const int64_t output_channels =
         channel_last ? output->dims()[4] : output->dims()[1];
-    const int output_depth =
+    const int64_t output_depth =
         channel_last ? output->dims()[1] : output->dims()[2];
-    const int output_height =
+    const int64_t output_height =
         channel_last ? output->dims()[2] : output->dims()[3];
-    const int output_width =
+    const int64_t output_width =
         channel_last ? output->dims()[3] : output->dims()[4];
 
-    const int ksize_depth = ksize[0];
-    const int ksize_height = ksize[1];
-    const int ksize_width = ksize[2];
+    const int64_t ksize_depth = ksize[0];
+    const int64_t ksize_height = ksize[1];
+    const int64_t ksize_width = ksize[2];
 
-    const int stride_depth = strides[0];
-    const int stride_height = strides[1];
-    const int stride_width = strides[2];
+    const int64_t stride_depth = strides[0];
+    const int64_t stride_height = strides[1];
+    const int64_t stride_width = strides[2];
 
-    const int padding_depth = paddings[0];
-    const int padding_height = paddings[1];
-    const int padding_width = paddings[2];
+    const int64_t padding_depth = paddings[0];
+    const int64_t padding_height = paddings[1];
+    const int64_t padding_width = paddings[2];
 
     const T* input_data = input.data<T>();
     T* output_data = context.template Alloc<T>(output);
 
-    int dstart = 0, dend = 1;
-    int hstart = 0, hend = 1;
-    int wstart = 0, wend = 1;
+    int64_t dstart = 0, dend = 1;
+    int64_t hstart = 0, hend = 1;
+    int64_t wstart = 0, wend = 1;
     if (!channel_last) {
-      const int input_stride = input_depth * input_height * input_width;
-      const int output_stride = output_depth * output_height * output_width;
-      for (int i = 0; i < batch_size; i++) {
-        for (int c = 0; c < output_channels; ++c) {
-          for (int pd = 0; pd < output_depth; ++pd) {
+      const int64_t input_stride = input_depth * input_height * input_width;
+      const int64_t output_stride = output_depth * output_height * output_width;
+      for (int64_t i = 0; i < batch_size; i++) {
+        for (int64_t c = 0; c < output_channels; ++c) {
+          for (int64_t pd = 0; pd < output_depth; ++pd) {
             if (adaptive) {
               dstart = AdaptStartIndex(pd, input_depth, output_depth);
               dend = AdaptEndIndex(pd, input_depth, output_depth);
             }
 
-            for (int ph = 0; ph < output_height; ++ph) {
+            for (int64_t ph = 0; ph < output_height; ++ph) {
               if (adaptive) {
                 hstart = AdaptStartIndex(ph, input_height, output_height);
                 hend = AdaptEndIndex(ph, input_height, output_height);
               }
 
-              for (int pw = 0; pw < output_width; ++pw) {
-                int pool_size = 1;
+              for (int64_t pw = 0; pw < output_width; ++pw) {
+                int64_t pool_size = 1;
                 if (adaptive) {
                   wstart = AdaptStartIndex(pw, input_width, output_width);
                   wend = AdaptEndIndex(pw, input_width, output_width);
@@ -554,19 +572,20 @@ class Pool3dFunctor<CPUContext, PoolProcess, T> {
 
                   pool_size =
                       (dend - dstart) * (hend - hstart) * (wend - wstart);
-                  dstart = std::max(dstart, 0);
-                  hstart = std::max(hstart, 0);
-                  wstart = std::max(wstart, 0);
+                  dstart = std::max(dstart, static_cast<int64_t>(0));
+                  hstart = std::max(hstart, static_cast<int64_t>(0));
+                  wstart = std::max(wstart, static_cast<int64_t>(0));
                   dend = std::min(dend, input_depth);
                   hend = std::min(hend, input_height);
                   wend = std::min(wend, input_width);
                 }
 
-                int output_idx = (pd * output_height + ph) * output_width + pw;
+                int64_t output_idx =
+                    (pd * output_height + ph) * output_width + pw;
                 T ele = pool_process.initial();
-                for (int d = dstart; d < dend; ++d) {
-                  for (int h = hstart; h < hend; ++h) {
-                    for (int w = wstart; w < wend; ++w) {
+                for (int64_t d = dstart; d < dend; ++d) {
+                  for (int64_t h = hstart; h < hend; ++h) {
+                    for (int64_t w = wstart; w < wend; ++w) {
                       pool_process.compute(
                           input_data[(d * input_height + h) * input_width + w],
                           &ele);
@@ -587,26 +606,26 @@ class Pool3dFunctor<CPUContext, PoolProcess, T> {
         }
       }
     } else {
-      const int input_stride =
+      const int64_t input_stride =
           input_depth * input_height * input_width * input_channels;
-      const int output_stride =
+      const int64_t output_stride =
           output_depth * output_height * output_width * output_channels;
-      for (int i = 0; i < batch_size; i++) {
-        for (int c = 0; c < output_channels; ++c) {
-          for (int pd = 0; pd < output_depth; ++pd) {
+      for (int64_t i = 0; i < batch_size; i++) {
+        for (int64_t c = 0; c < output_channels; ++c) {
+          for (int64_t pd = 0; pd < output_depth; ++pd) {
             if (adaptive) {
               dstart = AdaptStartIndex(pd, input_depth, output_depth);
               dend = AdaptEndIndex(pd, input_depth, output_depth);
             }
 
-            for (int ph = 0; ph < output_height; ++ph) {
+            for (int64_t ph = 0; ph < output_height; ++ph) {
               if (adaptive) {
                 hstart = AdaptStartIndex(ph, input_height, output_height);
                 hend = AdaptEndIndex(ph, input_height, output_height);
               }
 
-              for (int pw = 0; pw < output_width; ++pw) {
-                int pool_size = 1;
+              for (int64_t pw = 0; pw < output_width; ++pw) {
+                int64_t pool_size = 1;
                 if (adaptive) {
                   wstart = AdaptStartIndex(pw, input_width, output_width);
                   wend = AdaptEndIndex(pw, input_width, output_width);
@@ -623,19 +642,19 @@ class Pool3dFunctor<CPUContext, PoolProcess, T> {
 
                   pool_size =
                       (dend - dstart) * (hend - hstart) * (wend - wstart);
-                  dstart = std::max(dstart, 0);
-                  hstart = std::max(hstart, 0);
-                  wstart = std::max(wstart, 0);
+                  dstart = std::max(dstart, static_cast<int64_t>(0));
+                  hstart = std::max(hstart, static_cast<int64_t>(0));
+                  wstart = std::max(wstart, static_cast<int64_t>(0));
                   dend = std::min(dend, input_depth);
                   hend = std::min(hend, input_height);
                   wend = std::min(wend, input_width);
                 }
 
                 T ele = pool_process.initial();
-                for (int d = dstart; d < dend; ++d) {
-                  for (int h = hstart; h < hend; ++h) {
-                    for (int w = wstart; w < wend; ++w) {
-                      int input_idx =
+                for (int64_t d = dstart; d < dend; ++d) {
+                  for (int64_t h = hstart; h < hend; ++h) {
+                    for (int64_t w = wstart; w < wend; ++w) {
+                      int64_t input_idx =
                           ((d * input_height + h) * input_width + w) *
                               input_channels +
                           c;
@@ -648,7 +667,7 @@ class Pool3dFunctor<CPUContext, PoolProcess, T> {
                       (dend - dstart) * (hend - hstart) * (wend - wstart);
                 }
                 pool_process.finalize(static_cast<T>(pool_size), &ele);
-                int output_idx =
+                int64_t output_idx =
                     ((pd * output_height + ph) * output_width + pw) *
                         output_channels +
                     c;
@@ -689,58 +708,64 @@ class Pool3dGradFunctor<CPUContext, PoolProcess, T> {
                   PoolProcess pool_grad_process) {
     bool channel_last = (data_format == "NDHWC");
 
-    const int batch_size = input.dims()[0];
-    const int input_channels = channel_last ? input.dims()[4] : input.dims()[1];
-    const int input_depth = channel_last ? input.dims()[1] : input.dims()[2];
-    const int input_height = channel_last ? input.dims()[2] : input.dims()[3];
-    const int input_width = channel_last ? input.dims()[3] : input.dims()[4];
+    const int64_t batch_size = input.dims()[0];
+    const int64_t input_channels =
+        channel_last ? input.dims()[4] : input.dims()[1];
+    const int64_t input_depth =
+        channel_last ? input.dims()[1] : input.dims()[2];
+    const int64_t input_height =
+        channel_last ? input.dims()[2] : input.dims()[3];
+    const int64_t input_width =
+        channel_last ? input.dims()[3] : input.dims()[4];
 
-    const int output_channels =
+    const int64_t output_channels =
         channel_last ? output.dims()[4] : output.dims()[1];
-    const int output_depth = channel_last ? output.dims()[1] : output.dims()[2];
-    const int output_height =
+    const int64_t output_depth =
+        channel_last ? output.dims()[1] : output.dims()[2];
+    const int64_t output_height =
         channel_last ? output.dims()[2] : output.dims()[3];
-    const int output_width = channel_last ? output.dims()[3] : output.dims()[4];
+    const int64_t output_width =
+        channel_last ? output.dims()[3] : output.dims()[4];
 
-    const int ksize_depth = ksize[0];
-    const int ksize_height = ksize[1];
-    const int ksize_width = ksize[2];
+    const int64_t ksize_depth = ksize[0];
+    const int64_t ksize_height = ksize[1];
+    const int64_t ksize_width = ksize[2];
 
-    const int stride_depth = strides[0];
-    const int stride_height = strides[1];
-    const int stride_width = strides[2];
+    const int64_t stride_depth = strides[0];
+    const int64_t stride_height = strides[1];
+    const int64_t stride_width = strides[2];
 
-    const int padding_depth = paddings[0];
-    const int padding_height = paddings[1];
-    const int padding_width = paddings[2];
+    const int64_t padding_depth = paddings[0];
+    const int64_t padding_height = paddings[1];
+    const int64_t padding_width = paddings[2];
 
     const T* input_data = input.data<T>();
     const T* output_data = output.data<T>();
     const T* output_grad_data = output_grad.data<T>();
     T* input_grad_data = context.template Alloc<T>(input_grad);
 
-    int dstart = 0, dend = 1;
-    int hstart = 0, hend = 1;
-    int wstart = 0, wend = 1;
+    int64_t dstart = 0, dend = 1;
+    int64_t hstart = 0, hend = 1;
+    int64_t wstart = 0, wend = 1;
     if (!channel_last) {
-      const int input_stride = input_depth * input_height * input_width;
-      const int output_stride = output_depth * output_height * output_width;
-      for (int i = 0; i < batch_size; i++) {
-        for (int c = 0; c < output_channels; ++c) {
-          for (int pd = 0; pd < output_depth; ++pd) {
+      const int64_t input_stride = input_depth * input_height * input_width;
+      const int64_t output_stride = output_depth * output_height * output_width;
+      for (int64_t i = 0; i < batch_size; i++) {
+        for (int64_t c = 0; c < output_channels; ++c) {
+          for (int64_t pd = 0; pd < output_depth; ++pd) {
             if (adaptive) {
               dstart = AdaptStartIndex(pd, input_depth, output_depth);
               dend = AdaptEndIndex(pd, input_depth, output_depth);
             }
 
-            for (int ph = 0; ph < output_height; ++ph) {
+            for (int64_t ph = 0; ph < output_height; ++ph) {
               if (adaptive) {
                 hstart = AdaptStartIndex(ph, input_height, output_height);
                 hend = AdaptEndIndex(ph, input_height, output_height);
               }
 
-              for (int pw = 0; pw < output_width; ++pw) {
-                int pool_size = 1;
+              for (int64_t pw = 0; pw < output_width; ++pw) {
+                int64_t pool_size = 1;
                 if (adaptive) {
                   wstart = AdaptStartIndex(pw, input_width, output_width);
                   wend = AdaptEndIndex(pw, input_width, output_width);
@@ -757,9 +782,9 @@ class Pool3dGradFunctor<CPUContext, PoolProcess, T> {
 
                   pool_size =
                       (dend - dstart) * (hend - hstart) * (wend - wstart);
-                  dstart = std::max(dstart, 0);
-                  hstart = std::max(hstart, 0);
-                  wstart = std::max(wstart, 0);
+                  dstart = std::max(dstart, static_cast<int64_t>(0));
+                  hstart = std::max(hstart, static_cast<int64_t>(0));
+                  wstart = std::max(wstart, static_cast<int64_t>(0));
                   dend = std::min(dend, input_depth);
                   hend = std::min(hend, input_height);
                   wend = std::min(wend, input_width);
@@ -770,11 +795,12 @@ class Pool3dGradFunctor<CPUContext, PoolProcess, T> {
                       (dend - dstart) * (hend - hstart) * (wend - wstart);
                 }
                 float scale = 1.0f / static_cast<float>(pool_size);
-                for (int d = dstart; d < dend; ++d) {
-                  for (int h = hstart; h < hend; ++h) {
-                    for (int w = wstart; w < wend; ++w) {
-                      int input_idx = (d * input_height + h) * input_width + w;
-                      int output_idx =
+                for (int64_t d = dstart; d < dend; ++d) {
+                  for (int64_t h = hstart; h < hend; ++h) {
+                    for (int64_t w = wstart; w < wend; ++w) {
+                      int64_t input_idx =
+                          (d * input_height + h) * input_width + w;
+                      int64_t output_idx =
                           (pd * output_height + ph) * output_width + pw;
                       pool_grad_process.compute(input_data[input_idx],
                                                 output_data[output_idx],
@@ -794,26 +820,26 @@ class Pool3dGradFunctor<CPUContext, PoolProcess, T> {
         }
       }
     } else {
-      const int input_stride =
+      const int64_t input_stride =
           input_depth * input_height * input_width * input_channels;
-      const int output_stride =
+      const int64_t output_stride =
           output_depth * output_height * output_width * output_channels;
-      for (int i = 0; i < batch_size; i++) {
-        for (int c = 0; c < output_channels; ++c) {
-          for (int pd = 0; pd < output_depth; ++pd) {
+      for (int64_t i = 0; i < batch_size; i++) {
+        for (int64_t c = 0; c < output_channels; ++c) {
+          for (int64_t pd = 0; pd < output_depth; ++pd) {
             if (adaptive) {
               dstart = AdaptStartIndex(pd, input_depth, output_depth);
               dend = AdaptEndIndex(pd, input_depth, output_depth);
             }
 
-            for (int ph = 0; ph < output_height; ++ph) {
+            for (int64_t ph = 0; ph < output_height; ++ph) {
               if (adaptive) {
                 hstart = AdaptStartIndex(ph, input_height, output_height);
                 hend = AdaptEndIndex(ph, input_height, output_height);
               }
 
-              for (int pw = 0; pw < output_width; ++pw) {
-                int pool_size = 1;
+              for (int64_t pw = 0; pw < output_width; ++pw) {
+                int64_t pool_size = 1;
                 if (adaptive) {
                   wstart = AdaptStartIndex(pw, input_width, output_width);
                   wend = AdaptEndIndex(pw, input_width, output_width);
@@ -830,9 +856,9 @@ class Pool3dGradFunctor<CPUContext, PoolProcess, T> {
 
                   pool_size =
                       (dend - dstart) * (hend - hstart) * (wend - wstart);
-                  dstart = std::max(dstart, 0);
-                  hstart = std::max(hstart, 0);
-                  wstart = std::max(wstart, 0);
+                  dstart = std::max(dstart, static_cast<int64_t>(0));
+                  hstart = std::max(hstart, static_cast<int64_t>(0));
+                  wstart = std::max(wstart, static_cast<int64_t>(0));
                   dend = std::min(dend, input_depth);
                   hend = std::min(hend, input_height);
                   wend = std::min(wend, input_width);
@@ -843,14 +869,14 @@ class Pool3dGradFunctor<CPUContext, PoolProcess, T> {
                       (dend - dstart) * (hend - hstart) * (wend - wstart);
                 }
                 float scale = 1.0f / static_cast<float>(pool_size);
-                for (int d = dstart; d < dend; ++d) {
-                  for (int h = hstart; h < hend; ++h) {
-                    for (int w = wstart; w < wend; ++w) {
-                      int input_idx =
+                for (int64_t d = dstart; d < dend; ++d) {
+                  for (int64_t h = hstart; h < hend; ++h) {
+                    for (int64_t w = wstart; w < wend; ++w) {
+                      int64_t input_idx =
                           ((d * input_height + h) * input_width + w) *
                               input_channels +
                           c;
-                      int output_idx =
+                      int64_t output_idx =
                           ((pd * output_height + ph) * output_width + pw) *
                               output_channels +
                           c;
@@ -896,31 +922,37 @@ class MaxPool3dGradFunctor<CPUContext, T> {
                   const std::string data_format,
                   DenseTensor* input_grad) {
     bool channel_last = (data_format == "NDHWC");
-    const int batch_size = input.dims()[0];
+    const int64_t batch_size = input.dims()[0];
 
-    const int input_channels = channel_last ? input.dims()[4] : input.dims()[1];
-    const int input_depth = channel_last ? input.dims()[1] : input.dims()[2];
-    const int input_height = channel_last ? input.dims()[2] : input.dims()[3];
-    const int input_width = channel_last ? input.dims()[3] : input.dims()[4];
+    const int64_t input_channels =
+        channel_last ? input.dims()[4] : input.dims()[1];
+    const int64_t input_depth =
+        channel_last ? input.dims()[1] : input.dims()[2];
+    const int64_t input_height =
+        channel_last ? input.dims()[2] : input.dims()[3];
+    const int64_t input_width =
+        channel_last ? input.dims()[3] : input.dims()[4];
 
-    const int output_channels =
+    const int64_t output_channels =
         channel_last ? output.dims()[4] : output.dims()[1];
-    const int output_depth = channel_last ? output.dims()[1] : output.dims()[2];
-    const int output_height =
+    const int64_t output_depth =
+        channel_last ? output.dims()[1] : output.dims()[2];
+    const int64_t output_height =
         channel_last ? output.dims()[2] : output.dims()[3];
-    const int output_width = channel_last ? output.dims()[3] : output.dims()[4];
+    const int64_t output_width =
+        channel_last ? output.dims()[3] : output.dims()[4];
 
-    const int ksize_depth = ksize[0];
-    const int ksize_height = ksize[1];
-    const int ksize_width = ksize[2];
+    const int64_t ksize_depth = ksize[0];
+    const int64_t ksize_height = ksize[1];
+    const int64_t ksize_width = ksize[2];
 
-    const int stride_depth = strides[0];
-    const int stride_height = strides[1];
-    const int stride_width = strides[2];
+    const int64_t stride_depth = strides[0];
+    const int64_t stride_height = strides[1];
+    const int64_t stride_width = strides[2];
 
-    const int padding_depth = paddings[0];
-    const int padding_height = paddings[1];
-    const int padding_width = paddings[2];
+    const int64_t padding_depth = paddings[0];
+    const int64_t padding_height = paddings[1];
+    const int64_t padding_width = paddings[2];
 
     const T* input_data = input.data<T>();
     const T* output_data = output.data<T>();
@@ -928,28 +960,29 @@ class MaxPool3dGradFunctor<CPUContext, T> {
     T* input_grad_data = context.template Alloc<T>(input_grad);
 
     if (!channel_last) {
-      const int input_stride = input_depth * input_height * input_width;
-      const int output_stride = output_depth * output_height * output_width;
-      for (int i = 0; i < batch_size; i++) {
-        for (int c = 0; c < output_channels; ++c) {
-          for (int pd = 0; pd < output_depth; ++pd) {
-            int dstart = pd * stride_depth - padding_depth;
-            int dend = std::min(dstart + ksize_depth, input_depth);
-            dstart = std::max(dstart, 0);
-            for (int ph = 0; ph < output_height; ++ph) {
-              int hstart = ph * stride_height - padding_height;
-              int hend = std::min(hstart + ksize_height, input_height);
-              hstart = std::max(hstart, 0);
-              for (int pw = 0; pw < output_width; ++pw) {
-                int wstart = pw * stride_width - padding_width;
-                int wend = std::min(wstart + ksize_width, input_width);
-                wstart = std::max(wstart, 0);
+      const int64_t input_stride = input_depth * input_height * input_width;
+      const int64_t output_stride = output_depth * output_height * output_width;
+      for (int64_t i = 0; i < batch_size; i++) {
+        for (int64_t c = 0; c < output_channels; ++c) {
+          for (int64_t pd = 0; pd < output_depth; ++pd) {
+            int64_t dstart = pd * stride_depth - padding_depth;
+            int64_t dend = std::min(dstart + ksize_depth, input_depth);
+            dstart = std::max(dstart, static_cast<int64_t>(0));
+            for (int64_t ph = 0; ph < output_height; ++ph) {
+              int64_t hstart = ph * stride_height - padding_height;
+              int64_t hend = std::min(hstart + ksize_height, input_height);
+              hstart = std::max(hstart, static_cast<int64_t>(0));
+              for (int64_t pw = 0; pw < output_width; ++pw) {
+                int64_t wstart = pw * stride_width - padding_width;
+                int64_t wend = std::min(wstart + ksize_width, input_width);
+                wstart = std::max(wstart, static_cast<int64_t>(0));
                 bool stop = false;
-                for (int d = dstart; d < dend && !stop; ++d) {
-                  for (int h = hstart; h < hend && !stop; ++h) {
-                    for (int w = wstart; w < wend && !stop; ++w) {
-                      int input_idx = (d * input_height + h) * input_width + w;
-                      int output_idx =
+                for (int64_t d = dstart; d < dend && !stop; ++d) {
+                  for (int64_t h = hstart; h < hend && !stop; ++h) {
+                    for (int64_t w = wstart; w < wend && !stop; ++w) {
+                      int64_t input_idx =
+                          (d * input_height + h) * input_width + w;
+                      int64_t output_idx =
                           (pd * output_height + ph) * output_width + pw;
 
                       if (input_data[input_idx] == output_data[output_idx]) {
@@ -970,34 +1003,34 @@ class MaxPool3dGradFunctor<CPUContext, T> {
         }
       }
     } else {
-      const int input_stride =
+      const int64_t input_stride =
           input_depth * input_height * input_width * input_channels;
-      const int output_stride =
+      const int64_t output_stride =
           output_depth * output_height * output_width * output_channels;
-      for (int i = 0; i < batch_size; i++) {
-        for (int c = 0; c < output_channels; ++c) {
-          for (int pd = 0; pd < output_depth; ++pd) {
-            int dstart = pd * stride_depth - padding_depth;
-            int dend = std::min(dstart + ksize_depth, input_depth);
-            dstart = std::max(dstart, 0);
-            for (int ph = 0; ph < output_height; ++ph) {
-              int hstart = ph * stride_height - padding_height;
-              int hend = std::min(hstart + ksize_height, input_height);
-              hstart = std::max(hstart, 0);
-              for (int pw = 0; pw < output_width; ++pw) {
-                int wstart = pw * stride_width - padding_width;
-                int wend = std::min(wstart + ksize_width, input_width);
-                wstart = std::max(wstart, 0);
+      for (int64_t i = 0; i < batch_size; i++) {
+        for (int64_t c = 0; c < output_channels; ++c) {
+          for (int64_t pd = 0; pd < output_depth; ++pd) {
+            int64_t dstart = pd * stride_depth - padding_depth;
+            int64_t dend = std::min(dstart + ksize_depth, input_depth);
+            dstart = std::max(dstart, static_cast<int64_t>(0));
+            for (int64_t ph = 0; ph < output_height; ++ph) {
+              int64_t hstart = ph * stride_height - padding_height;
+              int64_t hend = std::min(hstart + ksize_height, input_height);
+              hstart = std::max(hstart, static_cast<int64_t>(0));
+              for (int64_t pw = 0; pw < output_width; ++pw) {
+                int64_t wstart = pw * stride_width - padding_width;
+                int64_t wend = std::min(wstart + ksize_width, input_width);
+                wstart = std::max(wstart, static_cast<int64_t>(0));
                 bool stop = false;
 
-                for (int d = dstart; d < dend && !stop; ++d) {
-                  for (int h = hstart; h < hend && !stop; ++h) {
-                    for (int w = wstart; w < wend && !stop; ++w) {
-                      int input_idx =
+                for (int64_t d = dstart; d < dend && !stop; ++d) {
+                  for (int64_t h = hstart; h < hend && !stop; ++h) {
+                    for (int64_t w = wstart; w < wend && !stop; ++w) {
+                      int64_t input_idx =
                           ((d * input_height + h) * input_width + w) *
                               input_channels +
                           c;
-                      int output_idx =
+                      int64_t output_idx =
                           ((pd * output_height + ph) * output_width + pw) *
                               output_channels +
                           c;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-85711

- 将 pool2d, pool3d, lp_pool2d cpu kernel 改为 int64 版本
- 修复 pool 相关 op 报错 CUDNN(9)，主要还是 int 溢出，但我看 cudnn kernel 里调用的函数似乎只支持传 int，所以加上判断如果 int 溢出了 fallback 回普通的 gpu kernel 调用