### PR TITLE
Fix the error of not finding the corresponding CUDA version when WITH…

### DIFF
--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -712,8 +712,8 @@ def get_paddle_extra_install_requirements():
             cuda_major_version = match.group(1)
         except Exception as e:
             raise ValueError("CUDA not found")
-
-        paddle_cuda_requires = PADDLE_CUDA_INSTALL_REQUIREMENTS[cuda_major_version].split("|")
+        if cuda_major_version in PADDLE_CUDA_INSTALL_REQUIREMENTS:
+            paddle_cuda_requires = PADDLE_CUDA_INSTALL_REQUIREMENTS[cuda_major_version].split("|")
 
     if '@WITH_PIP_TENSORRT@' == 'ON':
         version_str = get_tensorrt_version()

--- a/setup.py
+++ b/setup.py
@@ -1224,9 +1224,10 @@ def get_paddle_extra_install_requirements():
         except Exception as e:
             raise ValueError("CUDA not found")
 
-        paddle_cuda_requires = PADDLE_CUDA_INSTALL_REQUIREMENTS[
-            cuda_major_version
-        ].split("|")
+        if cuda_major_version in PADDLE_CUDA_INSTALL_REQUIREMENTS:
+            paddle_cuda_requires = PADDLE_CUDA_INSTALL_REQUIREMENTS[
+                cuda_major_version
+            ].split("|")
 
     if env_dict.get("WITH_PIP_TENSORRT") == "ON":
         version_str = get_tensorrt_version()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Fix the error of not finding the corresponding CUDA version when WITH_PIP_CUDA_LIBRARIES=ON
![21f657db856a42e94020a68c74ce7688](https://github.com/user-attachments/assets/da5532ef-4d88-4dfa-9f6c-67c7c31ba48a)
