### PR TITLE
[CodeStyle][black] Bump black to 2025 style (`25.1.0`)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,7 +56,7 @@ repos:
         args: [--force-exclude]
   # For Python files
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.8.0
+    rev: 25.1.0
     hooks:
       - id: black
   - repo: https://github.com/astral-sh/ruff-pre-commit

--- a/ci/coverage_gcda_clean.py
+++ b/ci/coverage_gcda_clean.py
@@ -13,7 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-""" usage: gcda_clean.py pull_id. """
+"""usage: gcda_clean.py pull_id."""
 
 import os
 import sys

--- a/paddle/fluid/prim/api/auto_code_generated/static_gen.py
+++ b/paddle/fluid/prim/api/auto_code_generated/static_gen.py
@@ -20,7 +20,6 @@ import sys
 import jinja2
 import yaml
 
-# fmt: off
 # import from paddle/fluid/operators/generator
 sys.path.append(
     str(pathlib.Path(__file__).parents[3].joinpath('operators/generator'))

--- a/paddle/fluid/primitive/codegen/decomp_rule_gen.py
+++ b/paddle/fluid/primitive/codegen/decomp_rule_gen.py
@@ -20,11 +20,9 @@ import sys
 import jinja2
 import yaml
 
-# fmt: off
 # import from paddle/fluid/operators/generator
 sys.path.insert(
-    0,
-    str(pathlib.Path(__file__).resolve().parents[2] / 'operators/generator')
+    0, str(pathlib.Path(__file__).resolve().parents[2] / 'operators/generator')
 )
 import filters as op_gen_filters
 import tests_utils as op_gen_tests
@@ -35,7 +33,9 @@ from type_mapping import output_type_map
 # import from paddle/fluid/pir/dialect/op_generator/api_gen.py
 sys.path.insert(
     0,
-    str(pathlib.Path(__file__).resolve().parents[2] / 'pir/dialect/op_generator')
+    str(
+        pathlib.Path(__file__).resolve().parents[2] / 'pir/dialect/op_generator'
+    ),
 )
 
 from decomp_interface_gen_op_list import (

--- a/paddle/fluid/primitive/codegen/decomp_vjp_gen.py
+++ b/paddle/fluid/primitive/codegen/decomp_vjp_gen.py
@@ -20,7 +20,6 @@ import sys
 import jinja2
 import yaml
 
-# fmt: off
 # import from paddle/fluid/operators/generator
 sys.path.append(
     str(pathlib.Path(__file__).resolve().parents[2] / 'operators/generator')
@@ -31,7 +30,9 @@ from parse_utils import to_named_dict
 
 # import from paddle/fluid/pir/dialect/op_generator/api_gen.py
 sys.path.append(
-    str(pathlib.Path(__file__).resolve().parents[2] / 'pir/dialect/op_generator')
+    str(
+        pathlib.Path(__file__).resolve().parents[2] / 'pir/dialect/op_generator'
+    )
 )
 
 from decomp_interface_gen_op_list import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.black]
 line-length = 80
 skip-string-normalization = true
-target-version = ["py39", "py310", "py311", "py312"]
+target-version = ["py39", "py310", "py311", "py312", "py313"]
 extend-exclude = '''
 (
     third_party/.+      # Exclude third_party directory

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.black]
 line-length = 80
 skip-string-normalization = true
-target-version = ["py38", "py39", "py310", "py311", "py312"]
+target-version = ["py39", "py310", "py311", "py312"]
 extend-exclude = '''
 (
     third_party/.+      # Exclude third_party directory
@@ -178,7 +178,7 @@ known-first-party = ["paddle"]
 "test/dygraph_to_static/seq2seq_dygraph_model.py" = ["RUF005"]
 
 [tool.mypy]
-python_version = "3.8"
+python_version = "3.9"
 cache_dir = ".mypy_cache"
 # Miscellaneous strictness flags
 allow_redefinition = true

--- a/python/paddle/amp/debugging.py
+++ b/python/paddle/amp/debugging.py
@@ -76,7 +76,7 @@ class DebugMode(Enum):
 
 
 def check_layer_numerics(
-    func: Callable[_InputT, _RetT]
+    func: Callable[_InputT, _RetT],
 ) -> Callable[_InputT, _RetT]:
     """
     This decorator is used to check the numerical values of the layer's input and output data.

--- a/python/paddle/autograd/ir_backward.py
+++ b/python/paddle/autograd/ir_backward.py
@@ -1000,9 +1000,10 @@ def append_backward_ops(
                         # create grad_op
 
                         before_ops_num = len(bwd_block.ops)
-                        with dynamic_shape_prim_vjp_guard(
-                            op, inputs
-                        ), pir_op_name_guard(op.name() + '_grad'):
+                        with (
+                            dynamic_shape_prim_vjp_guard(op, inputs),
+                            pir_op_name_guard(op.name() + '_grad'),
+                        ):
                             input_grads = paddle.framework.core.call_vjp(
                                 op,
                                 inputs,

--- a/python/paddle/autograd/py_layer.py
+++ b/python/paddle/autograd/py_layer.py
@@ -417,7 +417,7 @@ class PyLayer(core.eager.PyLayer, PyLayerContext, metaclass=PyLayerMeta):
 
 
 def once_differentiable(
-    backward: Callable[Concatenate[PyLayerContext, ...], _RetT]
+    backward: Callable[Concatenate[PyLayerContext, ...], _RetT],
 ) -> Callable[Concatenate[PyLayerContext, ...], _RetT]:
     def wrapper(ctx: PyLayerContext, *args: Any) -> _RetT:
         with paddle.base.dygraph.no_grad():

--- a/python/paddle/base/core.py
+++ b/python/paddle/base/core.py
@@ -160,7 +160,7 @@ def avx_supported():
 
         # http://en.wikipedia.org/wiki/CPUID#EAX.3D1:_Processor_Info_and_Feature_Bits
         # mov eax,0x1; cpuid; mov cx, ax; ret
-        code_str = b"\xB8\x01\x00\x00\x00\x0f\xa2\x89\xC8\xC3"
+        code_str = b"\xb8\x01\x00\x00\x00\x0f\xa2\x89\xc8\xc3"
         avx_bit = 28
         retval = 0
         try:

--- a/python/paddle/base/framework.py
+++ b/python/paddle/base/framework.py
@@ -707,7 +707,7 @@ def require_version(min_version: str, max_version: str | None = None) -> None:
 
 
 def _dygraph_not_support_(
-    func: Callable[_InputT, _RetT]
+    func: Callable[_InputT, _RetT],
 ) -> Callable[_InputT, _RetT]:
     def __impl__(*args: _InputT.args, **kwargs: _InputT.kwargs) -> _RetT:
         assert (
@@ -729,7 +729,7 @@ def _dygraph_only_(func: Callable[_InputT, _RetT]) -> Callable[_InputT, _RetT]:
 
 
 def _non_static_only_(
-    func: Callable[_InputT, _RetT]
+    func: Callable[_InputT, _RetT],
 ) -> Callable[_InputT, _RetT]:
     def __impl__(*args: _InputT.args, **kwargs: _InputT.kwargs) -> _RetT:
         from .dygraph.base import in_to_static_mode
@@ -765,7 +765,7 @@ def _set_pipeline_stage(stage):
 # TODO(zhiqiu): We should make Tensor consistent with Variable in future, for example, by inheriting
 # same base class.
 def _fake_interface_only_(
-    func: Callable[_InputT, _RetT]
+    func: Callable[_InputT, _RetT],
 ) -> Callable[_InputT, _RetT]:
     def __impl__(*args: _InputT.args, **kwargs: _InputT.kwargs) -> _RetT:
         raise AssertionError(
@@ -784,7 +784,7 @@ def _fake_interface_only_(
 # NOTE(chenweihang): not using `wrap_decorator` here is because `wrap_decorator` will
 # move kwargs to args, which doesn't work in this decorate case
 def deprecate_stat_dict(
-    func: Callable[_InputT, _RetT]
+    func: Callable[_InputT, _RetT],
 ) -> Callable[_InputT, _RetT]:
     @functools.wraps(func)
     def wrapper(*args: _InputT.args, **kwargs: _InputT.kwargs) -> _RetT:

--- a/python/paddle/base/wrapped_decorator.py
+++ b/python/paddle/base/wrapped_decorator.py
@@ -28,7 +28,7 @@ __all__ = []
 def wrap_decorator(
     decorator_func: Callable[
         [Callable[_InputT, _RetT1]], Callable[_InputT, _RetT2]
-    ]
+    ],
 ) -> Callable[[Callable[_InputT, _RetT1]], Callable[_InputT, _RetT2]]:
     @decorator.decorator
     def __impl__(

--- a/python/paddle/dataset/conll05.py
+++ b/python/paddle/dataset/conll05.py
@@ -81,9 +81,10 @@ def corpus_reader(data_path, words_name, props_name):
         tf = tarfile.open(data_path)
         wf = tf.extractfile(words_name)
         pf = tf.extractfile(props_name)
-        with gzip.GzipFile(fileobj=wf) as words_file, gzip.GzipFile(
-            fileobj=pf
-        ) as props_file:
+        with (
+            gzip.GzipFile(fileobj=wf) as words_file,
+            gzip.GzipFile(fileobj=pf) as props_file,
+        ):
             sentences = []
             labels = []
             one_seg = []

--- a/python/paddle/decomposition/decomp.py
+++ b/python/paddle/decomposition/decomp.py
@@ -873,9 +873,11 @@ def decompose_dist_program(pir_program):
                 ) and _check_prim_dynamic(op):
                     skip_decomp = True
                 if not skip_decomp:
-                    with pir_op_name_guard(op.name()), pir_op_role_guard(
-                        op.op_role
-                    ), pir_chunk_id_guard(op.chunk_id):
+                    with (
+                        pir_op_name_guard(op.name()),
+                        pir_op_role_guard(op.op_role),
+                        pir_chunk_id_guard(op.chunk_id),
+                    ):
                         pir.set_insertion_point(op)
                         orig_outs = op.results()
 

--- a/python/paddle/distributed/auto_parallel/static/engine.py
+++ b/python/paddle/distributed/auto_parallel/static/engine.py
@@ -1133,9 +1133,10 @@ class Engine:
             serial_main_prog = self._orig_main_prog.clone()
             serial_startup_prog = self._orig_startup_prog.clone()
             if not self._skip_build:
-                with static.program_guard(
-                    serial_main_prog, serial_startup_prog
-                ), utils.unique_name.guard():
+                with (
+                    static.program_guard(serial_main_prog, serial_startup_prog),
+                    utils.unique_name.guard(),
+                ):
                     self._inputs = [
                         s._create_feed_layer() for s in self._inputs_spec
                     ]

--- a/python/paddle/distributed/auto_parallel/static/tuner/optimization_tuner.py
+++ b/python/paddle/distributed/auto_parallel/static/tuner/optimization_tuner.py
@@ -469,11 +469,14 @@ class OptimizationTuner:
         # TODO if any rank hang or fail, kill all processes
         self._logger.debug("Executing cmd:\n{} .".format(" ".join(cmd)))
         # new_process = subprocess.Popen(cmd, env=new_env)
-        with open(
-            os.path.join(trial_dir, "stdout.log" + str(self.rank)), "wb"
-        ) as out, open(
-            os.path.join(trial_dir, "stderr.log" + str(self.rank)), "wb"
-        ) as err:
+        with (
+            open(
+                os.path.join(trial_dir, "stdout.log" + str(self.rank)), "wb"
+            ) as out,
+            open(
+                os.path.join(trial_dir, "stderr.log" + str(self.rank)), "wb"
+            ) as err,
+        ):
             result = subprocess.Popen(cmd, stdout=out, stderr=err, env=new_env)
             result.wait()
             out.flush()

--- a/python/paddle/distributed/fleet/fleet.py
+++ b/python/paddle/distributed/fleet/fleet.py
@@ -111,7 +111,7 @@ def apply_ir_passes(
 
 
 def _inited_runtime_handler_(
-    func: Callable[_InputT, _RetT]
+    func: Callable[_InputT, _RetT],
 ) -> Callable[_InputT, _RetT]:
     def __impl__(*args: _InputT.args, **kwargs: _InputT.kwargs) -> _RetT:
         cls = args[0]
@@ -125,7 +125,7 @@ def _inited_runtime_handler_(
 
 
 def _is_non_distributed_check_(
-    func: Callable[_InputT, _RetT]
+    func: Callable[_InputT, _RetT],
 ) -> Callable[_InputT, _RetT]:
     def __impl__(*args: _InputT.args, **kwargs: _InputT.kwargs) -> _RetT:
         cls = args[0]

--- a/python/paddle/distributed/fleet/meta_optimizers/dgc_optimizer.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/dgc_optimizer.py
@@ -428,9 +428,10 @@ class DGCMomentumOptimizer(Optimizer):
         sgd_op = None
         if table_param is not None:
             param_and_grad = [table_param, table_grad]
-            with table_param.block.program._optimized_guard(
-                param_and_grad
-            ), framework.name_scope("optimizer"):
+            with (
+                table_param.block.program._optimized_guard(param_and_grad),
+                framework.name_scope("optimizer"),
+            ):
                 self._create_global_learning_rate()
                 # create the optimize op
                 sgd_op = global_block.append_op(

--- a/python/paddle/distributed/fleet/meta_optimizers/fp16_allreduce_optimizer.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/fp16_allreduce_optimizer.py
@@ -133,9 +133,10 @@ class FP16AllReduceOptimizer(MetaOptimizerBase):
                 stop_gradient=True,
             )
 
-            with block.program._optimized_guard(
-                [param, grad]
-            ), paddle.static.name_scope('fp16_allreduce'):
+            with (
+                block.program._optimized_guard([param, grad]),
+                paddle.static.name_scope('fp16_allreduce'),
+            ):
                 cast_op = block.append_op(
                     type="cast",
                     inputs={"X": grad},

--- a/python/paddle/distributed/fleet/recompute/recompute.py
+++ b/python/paddle/distributed/fleet/recompute/recompute.py
@@ -524,14 +524,18 @@ def _recompute_without_reentrant(
                             ):
                                 function(*args, **kwargs)
             else:
-                with paddle.set_grad_enabled(True), paddle.amp.auto_cast(
-                    enable=is_fw_autocast,
-                    custom_white_list=amp_white_list,
-                    custom_black_list=amp_black_list,
-                    level=amp_level,
-                    dtype=amp_dtype,
-                ), paddle.autograd.saved_tensors_hooks(
-                    inner_pack, inner_unpack
+                with (
+                    paddle.set_grad_enabled(True),
+                    paddle.amp.auto_cast(
+                        enable=is_fw_autocast,
+                        custom_white_list=amp_white_list,
+                        custom_black_list=amp_black_list,
+                        level=amp_level,
+                        dtype=amp_dtype,
+                    ),
+                    paddle.autograd.saved_tensors_hooks(
+                        inner_pack, inner_unpack
+                    ),
                 ):
                     function(*args, **kwargs)
 

--- a/python/paddle/incubate/optimizer/distributed_fused_lamb.py
+++ b/python/paddle/incubate/optimizer/distributed_fused_lamb.py
@@ -270,8 +270,9 @@ class DistributedFusedLamb(Optimizer):
         flattened = []
         for p, g in params_grads:
             flattened.extend([p, g])
-        with flattened[0].block.program._optimized_guard(flattened), name_scope(
-            "optimizer"
+        with (
+            flattened[0].block.program._optimized_guard(flattened),
+            name_scope("optimizer"),
         ):
             self._apply_gradients_impl(params_grads)
 

--- a/python/paddle/jit/dy2static/program_translator.py
+++ b/python/paddle/jit/dy2static/program_translator.py
@@ -1270,9 +1270,10 @@ class ConcreteProgram:
         )
 
         with ir_static.program_guard(main_program, startup_program):
-            with to_static_mode_guard(
-                is_to_static=True
-            ), static_op_arg_cast_guard(_convert_into_value):
+            with (
+                to_static_mode_guard(is_to_static=True),
+                static_op_arg_cast_guard(_convert_into_value),
+            ):
                 # 1. Adds `paddle.static.data` layers for input if needed
                 static_inputs, program_inputs = (
                     func_spec.pir_to_static_inputs_with_spec(
@@ -1293,12 +1294,10 @@ class ConcreteProgram:
                     )
 
                 # 2. Builds program only once and returns the output Variables.
-                with param_guard(
-                    get_parameters(class_instance, True)
-                ), param_guard(
-                    get_buffers(class_instance, True)
-                ), backend_guard(
-                    backend
+                with (
+                    param_guard(get_parameters(class_instance, True)),
+                    param_guard(get_buffers(class_instance, True)),
+                    backend_guard(backend),
                 ):
                     try:
                         # only for jit.save, do nothing while train and eval process
@@ -1404,9 +1403,10 @@ class ConcreteProgram:
                     )
 
                 # 2. Builds program only once and returns the output Variables.
-                with param_guard(
-                    get_parameters(class_instance, True)
-                ), param_guard(get_buffers(class_instance, True)):
+                with (
+                    param_guard(get_parameters(class_instance, True)),
+                    param_guard(get_buffers(class_instance, True)),
+                ):
                     try:
                         # only for jit.save, do nothing while train and eval process
                         inputs = hook_helper.apply_pre_hooks(static_inputs)

--- a/python/paddle/jit/sot/infer_meta.py
+++ b/python/paddle/jit/sot/infer_meta.py
@@ -490,8 +490,9 @@ class VariableCreator(metaclass=Singleton):
         return self.var_cache[var_feature_name]
 
     def infer_meta(self, func, *args, **kwargs):
-        with paddle.base.framework._dygraph_guard(None), UniqueNameGuard(
-            self.var_name_generator
+        with (
+            paddle.base.framework._dygraph_guard(None),
+            UniqueNameGuard(self.var_name_generator),
         ):
             if func is paddle.distributed.shard_tensor:
                 args, kwargs = (

--- a/python/paddle/jit/sot/opcode_translator/executor/mutable_data.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/mutable_data.py
@@ -112,7 +112,7 @@ class MutationPermutate(Mutation):
 
 
 def record_mutation(
-    mutation_fn: Callable[Concatenate[MutableDataT, P], Mutation]
+    mutation_fn: Callable[Concatenate[MutableDataT, P], Mutation],
 ) -> Callable[Concatenate[MutableDataT, P], None]:
     def wrapper(self, *args: P.args, **kwargs: P.kwargs):
         mutation = mutation_fn(self, *args, **kwargs)

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/base.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/base.py
@@ -675,8 +675,9 @@ def fn_bind_inputs(
     **kwargs: Any,
 ):
     # temparay clear the fn.__signature__ to avoid signature check error
-    with signature_clear_guard(fn, "__signature__"), signature_clear_guard(
-        fn, "__wrapped__"
+    with (
+        signature_clear_guard(fn, "__signature__"),
+        signature_clear_guard(fn, "__wrapped__"),
     ):
         sig = inspect.signature(fn)
         bound_args = sig.bind(*args, **kwargs)

--- a/python/paddle/nn/clip.py
+++ b/python/paddle/nn/clip.py
@@ -1491,8 +1491,9 @@ def append_gradient_clip_ops(param_grads):
     for p, g in param_grads:
         if g is None:
             continue
-        with p.block.program._optimized_guard([p, g]), framework.name_scope(
-            'gradient_clip'
+        with (
+            p.block.program._optimized_guard([p, g]),
+            framework.name_scope('gradient_clip'),
         ):
             clip_attr = getattr(p, 'gradient_clip_attr', None)
             if clip_attr is None:
@@ -1509,8 +1510,9 @@ def append_gradient_clip_ops(param_grads):
     for p, g in param_grads:
         if g is None:
             continue
-        with p.block.program._optimized_guard([p, g]), framework.name_scope(
-            'gradient_clip'
+        with (
+            p.block.program._optimized_guard([p, g]),
+            framework.name_scope('gradient_clip'),
         ):
             param, new_grad = clip_attr._create_operators(param=p, grad=g)
             param_new_grad_name_dict[param.name] = new_grad.name

--- a/python/paddle/nn/quant/stub.py
+++ b/python/paddle/nn/quant/stub.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" Define stub used in quantization."""
+"""Define stub used in quantization."""
 
 from __future__ import annotations
 

--- a/python/paddle/optimizer/adamax.py
+++ b/python/paddle/optimizer/adamax.py
@@ -338,9 +338,10 @@ class Adamax(Optimizer):
                         )
                         _C_ops.scale_(beta1_pow_acc, self._beta1, 0.0, True)
                 else:
-                    with param.block.program._optimized_guard(
-                        [param, grad]
-                    ), name_scope('adamax'):
+                    with (
+                        param.block.program._optimized_guard([param, grad]),
+                        name_scope('adamax'),
+                    ):
                         beta1_pow_acc = self._get_accumulator_master(
                             self._beta1_pow_acc_str, param
                         )
@@ -368,9 +369,10 @@ class Adamax(Optimizer):
                         )
                         beta1_pow_acc.copy_(tmp, False)
                 else:
-                    with param.block.program._optimized_guard(
-                        [param, grad]
-                    ), name_scope('adamax'):
+                    with (
+                        param.block.program._optimized_guard([param, grad]),
+                        name_scope('adamax'),
+                    ):
                         beta1_pow_acc = self._get_accumulator_master(
                             self._beta1_pow_acc_str, param
                         )

--- a/python/paddle/optimizer/optimizer.py
+++ b/python/paddle/optimizer/optimizer.py
@@ -882,10 +882,11 @@ class Optimizer:
                 if param_lr == 1.0:
                     return self._global_learning_rate()
                 else:
-                    with paddle.static.default_main_program()._lr_schedule_guard(
-                        is_with_opt=True
-                    ), framework.name_scope(
-                        'scale_with_param_lr'
+                    with (
+                        paddle.static.default_main_program()._lr_schedule_guard(
+                            is_with_opt=True
+                        ),
+                        framework.name_scope('scale_with_param_lr'),
                     ):
                         return self._global_learning_rate() * param_lr
         else:
@@ -1293,9 +1294,12 @@ class Optimizer:
                     ):
                         param_grad_list.append(param_and_grad[0])
                         param_grad_list.append(param_and_grad[1])
-                with param_grad_list[0].block.program._optimized_guard(
-                    param_grad_list
-                ), name_scope("optimizer"):
+                with (
+                    param_grad_list[0].block.program._optimized_guard(
+                        param_grad_list
+                    ),
+                    name_scope("optimizer"),
+                ):
                     device = self._get_device_for_param(param_grad_list[0].name)
                     with device_guard(device):
                         self._append_optimize_multi_tensor_op(
@@ -1387,9 +1391,12 @@ class Optimizer:
                 for param_and_grad in parameters_and_grads:
                     if param_and_grad[1] is None:
                         continue
-                    with param_and_grad[0].block.program._optimized_guard(
-                        param_and_grad
-                    ), name_scope("optimizer"):
+                    with (
+                        param_and_grad[0].block.program._optimized_guard(
+                            param_and_grad
+                        ),
+                        name_scope("optimizer"),
+                    ):
                         if param_and_grad[0].stop_gradient is False:
                             device = self._get_device_for_param(
                                 param_and_grad[0].name

--- a/python/paddle/static/nn/common.py
+++ b/python/paddle/static/nn/common.py
@@ -3943,8 +3943,9 @@ class ExponentialMovingAverage:
 
         self._ema_vars = {}
         for param, tmp in self._params_tmps:
-            with param.block.program._optimized_guard([param, tmp]), name_scope(
-                'moving_average'
+            with (
+                param.block.program._optimized_guard([param, tmp]),
+                name_scope('moving_average'),
             ):
                 self._ema_vars[param.name] = self._create_ema_vars(param)
 
@@ -4026,8 +4027,9 @@ class ExponentialMovingAverage:
         )
         param_master_emas = []
         for param, tmp in self._params_tmps:
-            with param.block.program._optimized_guard([param, tmp]), name_scope(
-                'moving_average'
+            with (
+                param.block.program._optimized_guard([param, tmp]),
+                name_scope('moving_average'),
             ):
                 param_ema = self._ema_vars[param.name]
                 if param.name + '.master' in self._ema_vars:

--- a/python/paddle/text/datasets/conll05.py
+++ b/python/paddle/text/datasets/conll05.py
@@ -232,9 +232,10 @@ class Conll05st(Dataset):
         self.sentences = []
         self.predicates = []
         self.labels = []
-        with gzip.GzipFile(fileobj=wf) as words_file, gzip.GzipFile(
-            fileobj=pf
-        ) as props_file:
+        with (
+            gzip.GzipFile(fileobj=wf) as words_file,
+            gzip.GzipFile(fileobj=pf) as props_file,
+        ):
             sentences = []
             labels = []
             one_seg = []

--- a/python/paddle/utils/inplace_utils.py
+++ b/python/paddle/utils/inplace_utils.py
@@ -53,7 +53,7 @@ def check_view_value(value: Value) -> bool:
 # NOTE(GGBond8488): Simply run the original version of the API under the static graph mode has a low
 # probability that the result is inconsistent with the dynamic graph.
 def _inplace_apis_in_dygraph_only_(
-    func: Callable[_InputT, _RetT]
+    func: Callable[_InputT, _RetT],
 ) -> Callable[_InputT, _RetT]:
     def __impl__(*args: _InputT.args, **kwargs: _InputT.kwargs) -> _RetT:
         if not in_dynamic_mode():

--- a/test/auto_parallel/test_static_gradient_sync.py
+++ b/test/auto_parallel/test_static_gradient_sync.py
@@ -110,9 +110,10 @@ class HybridParallelNet(nn.Layer):
 
 
 def get_hybrid_parallel_model(train_program, start_program):
-    with static.program_guard(
-        train_program, start_program
-    ), utils.unique_name.guard():
+    with (
+        static.program_guard(train_program, start_program),
+        utils.unique_name.guard(),
+    ):
         batch_size = BATCH_SIZE
         hidden_size = HIDDEN_SIZE
         sequence_len = SEQ_LEN

--- a/test/auto_parallel/test_static_sequence_parallel_pass.py
+++ b/test/auto_parallel/test_static_sequence_parallel_pass.py
@@ -109,9 +109,10 @@ class HybridParallelNet(nn.Layer):
 
 
 def get_hybrid_parallel_model(train_program, start_program):
-    with static.program_guard(
-        train_program, start_program
-    ), utils.unique_name.guard():
+    with (
+        static.program_guard(train_program, start_program),
+        utils.unique_name.guard(),
+    ):
         batch_size = BATCH_SIZE
         hidden_size = HIDDEN_SIZE
         sequence_len = SEQ_LEN

--- a/test/collective/fleet/test_rnn_dp.py
+++ b/test/collective/fleet/test_rnn_dp.py
@@ -104,9 +104,10 @@ class RNNModel(nn.Layer):
 
 
 def rnn_pretrain_forward(train_program, start_program, topo=None):
-    with static.program_guard(
-        train_program, start_program
-    ), paddle.utils.unique_name.guard():
+    with (
+        static.program_guard(train_program, start_program),
+        paddle.utils.unique_name.guard(),
+    ):
         batch_size = 1
         tokens = static.data(
             name="tokens", shape=[batch_size, -1], dtype="int64"
@@ -157,9 +158,10 @@ class TestFleetMetaOptimizer(unittest.TestCase):
             optimizer,
             data_holders,
         ) = rnn_pretrain_forward(train_program, start_program)
-        with paddle.static.program_guard(
-            train_program, start_program
-        ), paddle.utils.unique_name.guard():
+        with (
+            paddle.static.program_guard(train_program, start_program),
+            paddle.utils.unique_name.guard(),
+        ):
             strategy = fleet.DistributedStrategy()
             strategy.without_graph_optimization = True
             strategy.fuse_all_reduce_ops = True

--- a/test/deprecated/auto_parallel/auto_parallel_relaunch_model.py
+++ b/test/deprecated/auto_parallel/auto_parallel_relaunch_model.py
@@ -84,9 +84,10 @@ class MLPLayer(nn.Layer):
 
 
 def mlp_pretrain_forward(train_program, start_program):
-    with static.program_guard(
-        train_program, start_program
-    ), utils.unique_name.guard():
+    with (
+        static.program_guard(train_program, start_program),
+        utils.unique_name.guard(),
+    ):
         input = static.data(
             name="input",
             shape=[batch_size, sequence_len, hidden_size],

--- a/test/deprecated/auto_parallel/engine_api_deprecated.py
+++ b/test/deprecated/auto_parallel/engine_api_deprecated.py
@@ -241,9 +241,10 @@ def get_cost():
     )
     main_program = static.Program()
     startup_program = static.Program()
-    with static.program_guard(
-        main_program, startup_program
-    ), utils.unique_name.guard():
+    with (
+        static.program_guard(main_program, startup_program),
+        utils.unique_name.guard(),
+    ):
         input = static.data(
             name="input", shape=[batch_size, image_size], dtype='float32'
         )
@@ -295,9 +296,10 @@ def get_cost_by_default_program():
     )
     main_program = static.default_main_program()
     startup_program = static.default_startup_program()
-    with static.program_guard(
-        main_program, startup_program
-    ), utils.unique_name.guard():
+    with (
+        static.program_guard(main_program, startup_program),
+        utils.unique_name.guard(),
+    ):
         input = static.data(
             name="input", shape=[batch_size, image_size], dtype='float32'
         )

--- a/test/deprecated/auto_parallel/test_auto_parallel_fused_linear_promotion_pass_deprecated.py
+++ b/test/deprecated/auto_parallel/test_auto_parallel_fused_linear_promotion_pass_deprecated.py
@@ -121,9 +121,10 @@ class HybridParallelNet(nn.Layer):
 
 
 def get_hybrid_parallel_model(train_program, start_program, enable_sp=False):
-    with static.program_guard(
-        train_program, start_program
-    ), utils.unique_name.guard():
+    with (
+        static.program_guard(train_program, start_program),
+        utils.unique_name.guard(),
+    ):
         batch_size = BATCH_SIZE
         hidden_size = HIDDEN_SIZE
         sequence_len = SEQ_LEN

--- a/test/deprecated/auto_parallel/test_auto_parallel_gradient_merge_pass_deprecated.py
+++ b/test/deprecated/auto_parallel/test_auto_parallel_gradient_merge_pass_deprecated.py
@@ -163,9 +163,10 @@ class TestGradientMergePass(AutoParallelPassTestBase):
 
         train_program = static.Program()
         startup_program = static.Program()
-        with static.program_guard(
-            train_program, startup_program
-        ), utils.unique_name.guard():
+        with (
+            static.program_guard(train_program, startup_program),
+            utils.unique_name.guard(),
+        ):
             input = static.data(
                 name="input", shape=[batch_size, hidden_size], dtype='float32'
             )

--- a/test/deprecated/auto_parallel/test_base_cost_deprecated.py
+++ b/test/deprecated/auto_parallel/test_base_cost_deprecated.py
@@ -91,9 +91,10 @@ class MLPLayer(nn.Layer):
 
 
 def mlp_forward(train_program, start_program):
-    with static.program_guard(
-        train_program, start_program
-    ), utils.unique_name.guard():
+    with (
+        static.program_guard(train_program, start_program),
+        utils.unique_name.guard(),
+    ):
         batch_size = 4
         hidden_size = 1024
         sequence_len = 512

--- a/test/deprecated/auto_parallel/test_cost_interface_deprecated.py
+++ b/test/deprecated/auto_parallel/test_cost_interface_deprecated.py
@@ -79,9 +79,10 @@ class MLPLayer(nn.Layer):
 
 
 def mlp_forward(train_program, start_program):
-    with static.program_guard(
-        train_program, start_program
-    ), utils.unique_name.guard():
+    with (
+        static.program_guard(train_program, start_program),
+        utils.unique_name.guard(),
+    ):
         batch_size = 4
         hidden_size = 1024
         sequence_len = 512

--- a/test/deprecated/collective/fleet/auto_parallel_parallelizer_deprecated.py
+++ b/test/deprecated/collective/fleet/auto_parallel_parallelizer_deprecated.py
@@ -64,9 +64,10 @@ class MLPLayer(nn.Layer):
 
 
 def mlp_pretrain_forward(train_program, start_program):
-    with static.program_guard(
-        train_program, start_program
-    ), utils.unique_name.guard():
+    with (
+        static.program_guard(train_program, start_program),
+        utils.unique_name.guard(),
+    ):
         batch_size = 4
         hidden_size = 1024
         sequence_len = 512

--- a/test/deprecated/legacy_test/auto_parallel_autoconvert_deprecated.py
+++ b/test/deprecated/legacy_test/auto_parallel_autoconvert_deprecated.py
@@ -94,9 +94,10 @@ class MLPLayer(nn.Layer):
 
 
 def mlp_forward(train_program, start_program):
-    with static.program_guard(
-        train_program, start_program
-    ), utils.unique_name.guard():
+    with (
+        static.program_guard(train_program, start_program),
+        utils.unique_name.guard(),
+    ):
         batch_size = 4
         hidden_size = 64
         input = static.data(

--- a/test/deprecated/legacy_test/auto_parallel_save_load_deprecated.py
+++ b/test/deprecated/legacy_test/auto_parallel_save_load_deprecated.py
@@ -86,9 +86,10 @@ class MLPLayer(nn.Layer):
 
 
 def mlp_forward(train_program, start_program):
-    with static.program_guard(
-        train_program, start_program
-    ), utils.unique_name.guard():
+    with (
+        static.program_guard(train_program, start_program),
+        utils.unique_name.guard(),
+    ):
         batch_size = 4
         hidden_size = 64
         input = static.data(

--- a/test/deprecated/legacy_test/test_auto_parallel_completion_deprecated.py
+++ b/test/deprecated/legacy_test/test_auto_parallel_completion_deprecated.py
@@ -78,9 +78,10 @@ class MLPLayer(nn.Layer):
 
 
 def mlp_pretrain_forward(train_program, start_program):
-    with static.program_guard(
-        train_program, start_program
-    ), utils.unique_name.guard():
+    with (
+        static.program_guard(train_program, start_program),
+        utils.unique_name.guard(),
+    ):
         batch_size = 4
         hidden_size = 1024
         sequence_len = 512
@@ -334,9 +335,10 @@ class AttentionLayer(nn.Layer):
 
 
 def attn_pretrain_forward(train_program, start_program):
-    with static.program_guard(
-        train_program, start_program
-    ), utils.unique_name.guard():
+    with (
+        static.program_guard(train_program, start_program),
+        utils.unique_name.guard(),
+    ):
         batch_size = 4
         hidden_size = 1024
         sequence_len = 512
@@ -626,9 +628,10 @@ class DecoderLayer(nn.Layer):
 
 
 def decoder_pretrain_forward(train_program, start_program):
-    with static.program_guard(
-        train_program, start_program
-    ), utils.unique_name.guard():
+    with (
+        static.program_guard(train_program, start_program),
+        utils.unique_name.guard(),
+    ):
         batch_size = 4
         hidden_size = 1024
         sequence_len = 512

--- a/test/deprecated/legacy_test/test_auto_parallel_completion_gpt_deprecated.py
+++ b/test/deprecated/legacy_test/test_auto_parallel_completion_gpt_deprecated.py
@@ -727,9 +727,10 @@ class GPTPretrainingCriterion(nn.Layer):
 
 
 def gpt_pretrain_forward(train_program, start_program):
-    with static.program_guard(
-        train_program, start_program
-    ), utils.unique_name.guard():
+    with (
+        static.program_guard(train_program, start_program),
+        utils.unique_name.guard(),
+    ):
         batch_size = 16
         sequence_len = 512
         input_ids = static.data(

--- a/test/deprecated/legacy_test/test_auto_parallel_cost_model_deprecated.py
+++ b/test/deprecated/legacy_test/test_auto_parallel_cost_model_deprecated.py
@@ -105,9 +105,10 @@ def get_single_node_data():
 
 
 def mlp_forward(train_program, start_program, is_distributed=True):
-    with static.program_guard(
-        train_program, start_program
-    ), utils.unique_name.guard():
+    with (
+        static.program_guard(train_program, start_program),
+        utils.unique_name.guard(),
+    ):
         batch_size = 4
         hidden_size = 256
         sequence_len = 128

--- a/test/deprecated/legacy_test/test_auto_parallel_mapper_deprecated.py
+++ b/test/deprecated/legacy_test/test_auto_parallel_mapper_deprecated.py
@@ -433,9 +433,10 @@ class MLPLayer(nn.Layer):
 
 
 def mlp_forward(train_program, start_program):
-    with static.program_guard(
-        train_program, start_program
-    ), utils.unique_name.guard():
+    with (
+        static.program_guard(train_program, start_program),
+        utils.unique_name.guard(),
+    ):
         batch_size = 4
         hidden_size = 64
         input = static.data(

--- a/test/deprecated/legacy_test/test_auto_parallel_partitioner_deprecated.py
+++ b/test/deprecated/legacy_test/test_auto_parallel_partitioner_deprecated.py
@@ -321,9 +321,10 @@ class MLPLayer(nn.Layer):
 
 
 def mlp_pretrain_forward(train_program, start_program):
-    with static.program_guard(
-        train_program, start_program
-    ), utils.unique_name.guard():
+    with (
+        static.program_guard(train_program, start_program),
+        utils.unique_name.guard(),
+    ):
         batch_size = 4
         hidden_size = 1024
         sequence_len = 512
@@ -703,9 +704,10 @@ class AttentionLayer(nn.Layer):
 
 
 def attn_pretrain_forward(train_program, start_program):
-    with static.program_guard(
-        train_program, start_program
-    ), utils.unique_name.guard():
+    with (
+        static.program_guard(train_program, start_program),
+        utils.unique_name.guard(),
+    ):
         batch_size = 4
         hidden_size = 1024
         sequence_len = 512
@@ -1202,9 +1204,10 @@ class DecoderLayer(nn.Layer):
 
 
 def decoder_pretrain_forward(train_program, start_program):
-    with static.program_guard(
-        train_program, start_program
-    ), utils.unique_name.guard():
+    with (
+        static.program_guard(train_program, start_program),
+        utils.unique_name.guard(),
+    ):
         batch_size = 4
         hidden_size = 1024
         sequence_len = 512

--- a/test/deprecated/legacy_test/test_auto_parallel_partitioner_gpt_deprecated.py
+++ b/test/deprecated/legacy_test/test_auto_parallel_partitioner_gpt_deprecated.py
@@ -773,9 +773,10 @@ class GPTPretrainingCriterion(nn.Layer):
 
 
 def gpt_pretrain_forward(train_program, startup_program):
-    with static.program_guard(
-        train_program, startup_program
-    ), utils.unique_name.guard():
+    with (
+        static.program_guard(train_program, startup_program),
+        utils.unique_name.guard(),
+    ):
         batch_size = 16
         sequence_len = 512
         input_ids = static.data(

--- a/test/deprecated/legacy_test/test_auto_parallel_reshard_deprecated.py
+++ b/test/deprecated/legacy_test/test_auto_parallel_reshard_deprecated.py
@@ -84,9 +84,10 @@ class MLPLayer(nn.Layer):
 
 
 def mlp_forward(train_program, start_program):
-    with static.program_guard(
-        train_program, start_program
-    ), utils.unique_name.guard():
+    with (
+        static.program_guard(train_program, start_program),
+        utils.unique_name.guard(),
+    ):
         batch_size = 4
         hidden_size = 1024
         sequence_len = 512

--- a/test/deprecated/legacy_test/test_auto_parallel_reshard_dpmppp_deprecated.py
+++ b/test/deprecated/legacy_test/test_auto_parallel_reshard_dpmppp_deprecated.py
@@ -77,9 +77,10 @@ class MLPLayer(nn.Layer):
 
 
 def mlp_forward(train_program, start_program):
-    with static.program_guard(
-        train_program, start_program
-    ), utils.unique_name.guard():
+    with (
+        static.program_guard(train_program, start_program),
+        utils.unique_name.guard(),
+    ):
         batch_size = 4
         hidden_size = 1024
         sequence_len = 512

--- a/test/deprecated/legacy_test/test_auto_parallel_reshard_mppp_deprecated.py
+++ b/test/deprecated/legacy_test/test_auto_parallel_reshard_mppp_deprecated.py
@@ -93,9 +93,10 @@ class MLPLayer(nn.Layer):
 
 
 def mlp_forward(train_program, start_program):
-    with static.program_guard(
-        train_program, start_program
-    ), utils.unique_name.guard():
+    with (
+        static.program_guard(train_program, start_program),
+        utils.unique_name.guard(),
+    ):
         batch_size = 4
         hidden_size = 1024
         sequence_len = 512

--- a/test/deprecated/legacy_test/test_auto_parallel_reshard_serial_deprecated.py
+++ b/test/deprecated/legacy_test/test_auto_parallel_reshard_serial_deprecated.py
@@ -81,9 +81,10 @@ class MLPLayer(nn.Layer):
 
 def mlp_forward(train_program, start_program):
     print("mlp_forward outer", flush=True)
-    with static.program_guard(
-        train_program, start_program
-    ), utils.unique_name.guard():
+    with (
+        static.program_guard(train_program, start_program),
+        utils.unique_name.guard(),
+    ):
         batch_size = 4
         hidden_size = 1024
         sequence_len = 512

--- a/test/deprecated/legacy_test/test_auto_parallel_searcher_deprecated.py
+++ b/test/deprecated/legacy_test/test_auto_parallel_searcher_deprecated.py
@@ -68,9 +68,10 @@ class MLPLayer(nn.Layer):
 
 
 def mlp_forward(train_program, start_program):
-    with static.program_guard(
-        train_program, start_program
-    ), utils.unique_name.guard():
+    with (
+        static.program_guard(train_program, start_program),
+        utils.unique_name.guard(),
+    ):
         batch_size = 4
         hidden_size = 1024
         sequence_len = 512

--- a/test/deprecated/legacy_test/test_auto_search_dist_matmul_op_deprecated.py
+++ b/test/deprecated/legacy_test/test_auto_search_dist_matmul_op_deprecated.py
@@ -62,9 +62,10 @@ class MLPLayer(nn.Layer):
 
 
 def mlp_forward(train_program, start_program):
-    with static.program_guard(
-        train_program, start_program
-    ), utils.unique_name.guard():
+    with (
+        static.program_guard(train_program, start_program),
+        utils.unique_name.guard(),
+    ):
         batch_size = 4
         hidden_size = 1024
         sqrt_hidden_size = 32
@@ -107,9 +108,10 @@ class TestCompatible(unittest.TestCase):
         startup_program = paddle.static.Program()
         loss, program, start_program = mlp_forward(program, startup_program)
 
-        with static.program_guard(
-            program, start_program
-        ), utils.unique_name.guard():
+        with (
+            static.program_guard(program, start_program),
+            utils.unique_name.guard(),
+        ):
             matmulx3 = static.data(
                 name="matmulx3", shape=[6, 2, 6], dtype='float32'
             )
@@ -265,9 +267,10 @@ class TestCompatible(unittest.TestCase):
         program = paddle.static.Program()
         startup_program = paddle.static.Program()
         loss, program, start_program = mlp_forward(program, startup_program)
-        with static.program_guard(
-            program, start_program
-        ), utils.unique_name.guard():
+        with (
+            static.program_guard(program, start_program),
+            utils.unique_name.guard(),
+        ):
             matmulx3 = static.data(
                 name="matmulx3", shape=[6, 2, 6], dtype='float32'
             )
@@ -401,9 +404,10 @@ class TestCompatible(unittest.TestCase):
         program = paddle.static.Program()
         startup_program = paddle.static.Program()
         loss, program, start_program = mlp_forward(program, startup_program)
-        with static.program_guard(
-            program, start_program
-        ), utils.unique_name.guard():
+        with (
+            static.program_guard(program, start_program),
+            utils.unique_name.guard(),
+        ):
             matmulx3 = static.data(
                 name="matmulx3", shape=[6, 2, 6], dtype='float32'
             )

--- a/test/deprecated/legacy_test/test_auto_search_dist_op_deprecated.py
+++ b/test/deprecated/legacy_test/test_auto_search_dist_op_deprecated.py
@@ -62,9 +62,10 @@ class MLPLayer(nn.Layer):
 
 
 def mlp_forward(train_program, start_program):
-    with static.program_guard(
-        train_program, start_program
-    ), utils.unique_name.guard():
+    with (
+        static.program_guard(train_program, start_program),
+        utils.unique_name.guard(),
+    ):
         batch_size = 4
         hidden_size = 1024
         sqrt_hidden_size = 32

--- a/test/deprecated/legacy_test/test_dataset_dataloader_deprecated.py
+++ b/test/deprecated/legacy_test/test_dataset_dataloader_deprecated.py
@@ -213,13 +213,17 @@ class DatasetLoaderTestBase(unittest.TestCase):
     def test_batch_number_with_same_length_files(self):
         for p in self.get_all_places():
             with base.scope_guard(base.Scope()):
-                with paddle.pir_utils.OldIrGuard():  # if you need to test in pir mode ,delete this line
+                with (
+                    paddle.pir_utils.OldIrGuard()
+                ):  # if you need to test in pir mode ,delete this line
                     self.check_batch_number(place=p, randomize_batch_num=False)
 
     def test_batch_number_with_different_length_files(self):
         for p in self.get_all_places():
             with base.scope_guard(base.Scope()):
-                with paddle.pir_utils.OldIrGuard():  # if you need to test in pir mode ,delete this line
+                with (
+                    paddle.pir_utils.OldIrGuard()
+                ):  # if you need to test in pir mode ,delete this line
                     self.check_batch_number(place=p, randomize_batch_num=True)
 
 

--- a/test/deprecated/legacy_test/test_memory_reuse_exclude_feed_var_deprecated.py
+++ b/test/deprecated/legacy_test/test_memory_reuse_exclude_feed_var_deprecated.py
@@ -72,7 +72,9 @@ class TestMemoryReuseExcludeFeedVar(unittest.TestCase):
             with base.program_guard(base.Program(), base.Program()):
                 with base.unique_name.guard():
                     with base.scope_guard(base.Scope()):
-                        with paddle.pir_utils.OldIrGuard():  # if you need to test in pir mode ,delete this line
+                        with (
+                            paddle.pir_utils.OldIrGuard()
+                        ):  # if you need to test in pir mode ,delete this line
                             self.main_impl(p)
 
 

--- a/test/distribution/test_kl_static.py
+++ b/test/distribution/test_kl_static.py
@@ -152,9 +152,7 @@ class DummyDistribution(paddle.distribution.Distribution):
 
 
 @param.place(config.DEVICES)
-@param.param_cls(
-    (param.TEST_CASE_NAME, 'p', 'q'), [('test-dispatch-exception')]
-)
+@param.param_cls((param.TEST_CASE_NAME, 'p', 'q'), ['test-dispatch-exception'])
 class TestDispatch(unittest.TestCase):
     def setUp(self):
         self.mp = paddle.static.Program()

--- a/test/dygraph_to_static/test_slice.py
+++ b/test/dygraph_to_static/test_slice.py
@@ -205,8 +205,9 @@ class TestSetValueWithLayerAndSave(Dy2StTestBase):
 class TestSliceSupplementSpecialCase(Dy2StTestBase):
     # unittest for slice index which abs(step)>0. eg: x[::2]
     def test_static_slice_step(self):
-        with static_guard(), paddle.static.program_guard(
-            paddle.static.Program()
+        with (
+            static_guard(),
+            paddle.static.program_guard(paddle.static.Program()),
         ):
             array = np.arange(4**3).reshape((4, 4, 4)).astype('int64')
 

--- a/test/ir/pir/test_build_op.py
+++ b/test/ir/pir/test_build_op.py
@@ -42,8 +42,9 @@ class TestBuildOp(unittest.TestCase):
     def test_build_mean_op(self):
         pir_program = get_ir_program()
         tanh_out = pir_program.global_block().ops[-1].result(0)
-        with paddle.pir_utils.IrGuard(), paddle.pir.core.program_guard(
-            pir_program
+        with (
+            paddle.pir_utils.IrGuard(),
+            paddle.pir.core.program_guard(pir_program),
         ):
             out = paddle.mean(tanh_out)
             self.assertEqual(out.get_defining_op().name(), "pd_op.mean")
@@ -63,8 +64,9 @@ class TestBuildOp2(unittest.TestCase):
     def test_build_add_n_op(self):
         pir_program = get_ir_program()
         tanh_out = pir_program.global_block().ops[-1].result(0)
-        with paddle.pir_utils.IrGuard(), paddle.pir.core.program_guard(
-            pir_program
+        with (
+            paddle.pir_utils.IrGuard(),
+            paddle.pir.core.program_guard(pir_program),
         ):
             out1 = paddle.mean(tanh_out)
             out2 = paddle.mean(tanh_out)
@@ -109,8 +111,9 @@ class TestBuildOp4(unittest.TestCase):
     def test_build_concat_op(self):
         pir_program = get_ir_program()
         tanh_out = pir_program.global_block().ops[-1].result(0)
-        with paddle.pir_utils.IrGuard(), paddle.pir.core.program_guard(
-            pir_program
+        with (
+            paddle.pir_utils.IrGuard(),
+            paddle.pir.core.program_guard(pir_program),
         ):
             out = paddle.concat([tanh_out, tanh_out], 0)
             self.assertEqual(out.get_defining_op().name(), "pd_op.concat")
@@ -128,8 +131,9 @@ class TestBuildOp5(unittest.TestCase):
     def test_build_split_op(self):
         pir_program = get_ir_program()
         tanh_out = pir_program.global_block().ops[-1].result(0)
-        with paddle.pir_utils.IrGuard(), paddle.pir.core.program_guard(
-            pir_program
+        with (
+            paddle.pir_utils.IrGuard(),
+            paddle.pir.core.program_guard(pir_program),
         ):
             out = paddle.split(tanh_out, [2, 2], 0)
             self.assertEqual(out[0].get_defining_op().name(), "builtin.split")
@@ -148,8 +152,9 @@ class TestBuildOp6(unittest.TestCase):
     def test_build_tensorrt_engine_op(self):
         pir_program = get_ir_program()
         tanh_out = pir_program.global_block().ops[-1].result(0)
-        with paddle.pir_utils.IrGuard(), paddle.pir.core.program_guard(
-            pir_program
+        with (
+            paddle.pir_utils.IrGuard(),
+            paddle.pir.core.program_guard(pir_program),
         ):
             # create fake tensorrt op
             trt_params = paddle.base.libpaddle.TRTEngineParams()

--- a/test/ir/pir/test_cse_pass.py
+++ b/test/ir/pir/test_cse_pass.py
@@ -406,9 +406,10 @@ class TestCSEDenyFullInCinn(unittest.TestCase, AssertOpCountEqualMixin):
     CINN_FLAG_NAME = "FLAGS_use_cinn"
 
     def test_replace_full_without_cinn(self):
-        with flag_guard(
-            self.CINN_FLAG_NAME, False
-        ), program_scope_guard() as main_program:
+        with (
+            flag_guard(self.CINN_FLAG_NAME, False),
+            program_scope_guard() as main_program,
+        ):
             # Inputs
             x1 = paddle.full([2], 1.0, dtype="float32")
             x2 = paddle.full([2], 1.0, dtype="float32")
@@ -418,9 +419,10 @@ class TestCSEDenyFullInCinn(unittest.TestCase, AssertOpCountEqualMixin):
             self.assert_op_count_equal(main_program, {"pd_op.full": 1})
 
     def test_replace_full_with_cinn(self):
-        with flag_guard(
-            self.CINN_FLAG_NAME, True
-        ), program_scope_guard() as main_program:
+        with (
+            flag_guard(self.CINN_FLAG_NAME, True),
+            program_scope_guard() as main_program,
+        ):
             # Inputs
             x1 = paddle.full([2], 1.0, dtype="float32")
             x2 = paddle.full([2], 1.0, dtype="float32")

--- a/test/ir/pir/test_ir_backward.py
+++ b/test/ir/pir/test_ir_backward.py
@@ -45,8 +45,9 @@ class TesBackward_1(unittest.TestCase):
         pir_program = get_ir_program_0()
         input = pir_program.global_block().ops[-1].operand(0).source()
         tanh_out = pir_program.global_block().ops[-1].result(0)
-        with paddle.pir_utils.IrGuard(), paddle.pir.core.program_guard(
-            pir_program
+        with (
+            paddle.pir_utils.IrGuard(),
+            paddle.pir.core.program_guard(pir_program),
         ):
             out = paddle.mean(tanh_out)
             out2 = paddle.mean(tanh_out)
@@ -70,8 +71,9 @@ class TesBackward_1(unittest.TestCase):
         pir_program = get_ir_program_0()
         input = pir_program.global_block().ops[-1].operand(0).source()
         tanh_out = pir_program.global_block().ops[-1].result(0)
-        with paddle.pir_utils.IrGuard(), paddle.pir.core.program_guard(
-            pir_program
+        with (
+            paddle.pir_utils.IrGuard(),
+            paddle.pir.core.program_guard(pir_program),
         ):
             out = paddle.mean(tanh_out)
             input_grad = grad(out, input)
@@ -96,8 +98,9 @@ class TesBackward_1(unittest.TestCase):
         pir_program = get_ir_program_0()
         input = pir_program.global_block().ops[-1].operand(0).source()
         tanh_out = pir_program.global_block().ops[-1].result(0)
-        with paddle.pir_utils.IrGuard(), paddle.pir.core.program_guard(
-            pir_program
+        with (
+            paddle.pir_utils.IrGuard(),
+            paddle.pir.core.program_guard(pir_program),
         ):
             out = paddle.mean(tanh_out)
             input_grad = grad(out, input, no_grad_vars=[input])
@@ -110,8 +113,9 @@ class TesBackward_1(unittest.TestCase):
         pir_program = get_ir_program_0()
         input = pir_program.global_block().ops[-1].operand(0).source()
         tanh_out = pir_program.global_block().ops[-1].result(0)
-        with paddle.pir_utils.IrGuard(), paddle.pir.core.program_guard(
-            pir_program
+        with (
+            paddle.pir_utils.IrGuard(),
+            paddle.pir.core.program_guard(pir_program),
         ):
             out = paddle.split(tanh_out, [2, 2], 0)
             input_grad = grad(out, input)
@@ -159,8 +163,9 @@ class TesBackward_2(unittest.TestCase):
         input_x = pir_program.global_block().ops[-3].operand(0).source()
 
         add_out = pir_program.global_block().ops[-1].result(0)
-        with paddle.pir_utils.IrGuard(), paddle.pir.core.program_guard(
-            pir_program
+        with (
+            paddle.pir_utils.IrGuard(),
+            paddle.pir.core.program_guard(pir_program),
         ):
             out = paddle.mean(add_out)
             input_grad = grad(out, input_x)
@@ -180,8 +185,9 @@ class TesBackward_2(unittest.TestCase):
         input_x = pir_program.global_block().ops[-3].operand(0).source()
 
         add_out = pir_program.global_block().ops[-1].result(0)
-        with paddle.pir_utils.IrGuard(), paddle.pir.core.program_guard(
-            pir_program
+        with (
+            paddle.pir_utils.IrGuard(),
+            paddle.pir.core.program_guard(pir_program),
         ):
             out = paddle.concat([add_out, add_out])
             input_grad = grad(out, input_x)
@@ -231,8 +237,9 @@ class TestBackward_3(unittest.TestCase):
         pir_program = get_ir_program_2()
         x = pir_program.global_block().ops[-1].operand(0).source()
         sum_x = pir_program.global_block().ops[-1].result(0)
-        with paddle.pir_utils.IrGuard(), paddle.pir.core.program_guard(
-            pir_program
+        with (
+            paddle.pir_utils.IrGuard(),
+            paddle.pir.core.program_guard(pir_program),
         ):
             norm = paddle.tensor.fill_constant(
                 shape=[],

--- a/test/legacy_test/test_concat_op.py
+++ b/test/legacy_test/test_concat_op.py
@@ -1056,8 +1056,11 @@ class TestConcatOpErrorWithPir(unittest.TestCase):
             paddle.concat([])
 
     def test_empty_inputs_static(self):
-        with IrGuard(), paddle.base.program_guard(
-            paddle.base.Program(), paddle.base.Program()
+        with (
+            IrGuard(),
+            paddle.base.program_guard(
+                paddle.base.Program(), paddle.base.Program()
+            ),
         ):
             with self.assertRaisesRegex(ValueError, "but got empty list"):
                 paddle.concat([], axis=0)

--- a/test/legacy_test/test_dist_fleet_heter_base.py
+++ b/test/legacy_test/test_dist_fleet_heter_base.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-    high level unit test for distribute fleet.
+high level unit test for distribute fleet.
 """
 
 import argparse

--- a/test/legacy_test/test_dropout_op.py
+++ b/test/legacy_test/test_dropout_op.py
@@ -2146,8 +2146,10 @@ class TestPirCompositeDropout(unittest.TestCase):
         rev_actual = []
         mps = []
         for place in self.places:
-            with paddle.pir_utils.IrGuard(), static_guard(), scope_guard(
-                Scope()
+            with (
+                paddle.pir_utils.IrGuard(),
+                static_guard(),
+                scope_guard(Scope()),
             ):
                 core._set_prim_backward_enabled(True)
                 core._set_prim_forward_enabled(False)

--- a/test/legacy_test/test_fill_constant_op.py
+++ b/test/legacy_test/test_fill_constant_op.py
@@ -430,8 +430,11 @@ class TestFillConstantImperative(unittest.TestCase):
 class TestFillConstantOpError(unittest.TestCase):
 
     def test_errors1(self):
-        with paddle_static_guard(), paddle.static.program_guard(
-            paddle.static.Program(), paddle.static.Program()
+        with (
+            paddle_static_guard(),
+            paddle.static.program_guard(
+                paddle.static.Program(), paddle.static.Program()
+            ),
         ):
             # for ci coverage
             x1 = paddle.static.data(name='x1', shape=[-1, 1], dtype="int16")
@@ -463,8 +466,11 @@ class TestFillConstantOpError(unittest.TestCase):
             )
 
     def test_errors2(self):
-        with paddle_static_guard(), paddle.static.program_guard(
-            paddle.static.Program(), paddle.static.Program()
+        with (
+            paddle_static_guard(),
+            paddle.static.program_guard(
+                paddle.static.Program(), paddle.static.Program()
+            ),
         ):
             # The argument dtype of fill_constant_op must be one of bool, float16,
             # float32, float64, uint8, int16, int32 or int64

--- a/test/legacy_test/test_model.py
+++ b/test/legacy_test/test_model.py
@@ -722,7 +722,7 @@ class TestModelFunction(unittest.TestCase):
             print(params_info)
 
             model.summary(input_size=(20))
-            model.summary(input_size=[(20)])
+            model.summary(input_size=[20])
             model.summary(input_size=(20), dtype='float32')
 
     def test_summary_non_tensor(self):

--- a/test/legacy_test/test_slice_op.py
+++ b/test/legacy_test/test_slice_op.py
@@ -728,8 +728,9 @@ class TestSliceAPI(unittest.TestCase):
             np.testing.assert_array_equal(res_7, input[-1, 0:100, :, 2:-1])
 
     def test_pir(self):
-        with paddle.pir_utils.IrGuard(), paddle.static.program_guard(
-            paddle.static.Program()
+        with (
+            paddle.pir_utils.IrGuard(),
+            paddle.static.program_guard(paddle.static.Program()),
         ):
             input = np.random.random([3, 4, 5, 6]).astype("float64")
             minus_1 = paddle.tensor.fill_constant([], "int32", -1)
@@ -797,8 +798,9 @@ class TestSliceAPI(unittest.TestCase):
             np.testing.assert_array_equal(res, input[:, :, 2:3, :])
 
     def test_negative_axis_static(self):
-        with paddle_static_guard(), paddle.static.program_guard(
-            paddle.static.Program()
+        with (
+            paddle_static_guard(),
+            paddle.static.program_guard(paddle.static.Program()),
         ):
             input = np.random.random([3, 4, 5, 6]).astype("float64")
             x = paddle.static.data(
@@ -825,8 +827,9 @@ class TestSliceAPI(unittest.TestCase):
             np.testing.assert_array_equal(res, input[:, :, 2:3, :])
 
     def test_negative_axis_pir(self):
-        with paddle.pir_utils.IrGuard(), paddle.static.program_guard(
-            paddle.static.Program()
+        with (
+            paddle.pir_utils.IrGuard(),
+            paddle.static.program_guard(paddle.static.Program()),
         ):
             input = np.random.random([3, 4, 5, 6]).astype("float64")
             x = paddle.static.data(

--- a/test/legacy_test/test_sparse_elementwise_op.py
+++ b/test/legacy_test/test_sparse_elementwise_op.py
@@ -347,8 +347,8 @@ class TestSparseElementWiseAPIComplex(unittest.TestCase):
 
     def test_add_same_indices(self):
         indices_data = [[0, 1], [0, 3]]
-        values1_data = [[(1.0 + 0.2j)], [(2.0 + 0.3j)]]
-        values2_data = [[(1.0 + 0.2j)], [(2.0 - 0.3j)]]
+        values1_data = [[1.0 + 0.2j], [2.0 + 0.3j]]
+        values2_data = [[1.0 + 0.2j], [2.0 - 0.3j]]
         shape = [2, 4, 2]
 
         sp_a = paddle.sparse.sparse_coo_tensor(

--- a/test/legacy_test/test_where_op.py
+++ b/test/legacy_test/test_where_op.py
@@ -245,8 +245,11 @@ class TestWhereAPI(unittest.TestCase):
     def test_pir_api(self, use_cuda=False):
         for x_stop_gradient in [False, True]:
             for y_stop_gradient in [False, True]:
-                with paddle.pir_utils.IrGuard(), paddle.static.program_guard(
-                    paddle.static.Program(), paddle.static.Program()
+                with (
+                    paddle.pir_utils.IrGuard(),
+                    paddle.static.program_guard(
+                        paddle.static.Program(), paddle.static.Program()
+                    ),
                 ):
                     cond = paddle.static.data(
                         name='cond', shape=self.shape, dtype='bool'

--- a/test/legacy_test/test_where_op.py
+++ b/test/legacy_test/test_where_op.py
@@ -821,7 +821,7 @@ class TestWhereDygraphAPI(unittest.TestCase):
         np.testing.assert_allclose(expect_out, np.array(res), rtol=1e-05)
         data = np.array([True, True, False])
         with program_guard(Program(), Program()):
-            x = paddle.static.data(name='x', shape=[(-1)], dtype='bool')
+            x = paddle.static.data(name='x', shape=[-1], dtype='bool')
             if not paddle.framework.use_pir_api():
                 x.desc.set_need_check_feed(False)
             y = paddle.where(x)

--- a/test/prim/pir_prim/test_decompose_op.py
+++ b/test/prim/pir_prim/test_decompose_op.py
@@ -114,8 +114,9 @@ class TestDecomposeOp(unittest.TestCase):
                 pir_program, param_mapping, grad_var_to_var
             )
 
-        with paddle.pir_utils.IrGuard(), paddle.pir.core.program_guard(
-            pir_program
+        with (
+            paddle.pir_utils.IrGuard(),
+            paddle.pir.core.program_guard(pir_program),
         ):
             exe = paddle.static.Executor()
             outs = exe.run(

--- a/test/sot/test_sot_dynamic_shape.py
+++ b/test/sot/test_sot_dynamic_shape.py
@@ -106,9 +106,10 @@ def pool2d_fallback(x, kernel_size):
 
 class TestOpcodeExecutorDynamicShapeCache(TestCaseBase):
     def test_dynamic_int_input_cache_hit_case1(self):
-        with allow_dynamic_shape_guard(
-            True
-        ), test_instruction_translator_cache_context() as ctx:
+        with (
+            allow_dynamic_shape_guard(True),
+            test_instruction_translator_cache_context() as ctx,
+        ):
             self.assert_results(
                 dynamic_int_input_func1, paddle.randn([4, 5, 6]), 2
             )
@@ -120,9 +121,10 @@ class TestOpcodeExecutorDynamicShapeCache(TestCaseBase):
                 self.assertEqual(ctx.translate_count, 2)
 
     def test_dynamic_int_input_cache_hit_case2(self):
-        with allow_dynamic_shape_guard(
-            True
-        ), test_instruction_translator_cache_context() as ctx:
+        with (
+            allow_dynamic_shape_guard(True),
+            test_instruction_translator_cache_context() as ctx,
+        ):
             self.assert_results(
                 dynamic_int_input_func2, paddle.randn([4, 5, 6]), {1: 2}
             )
@@ -134,9 +136,10 @@ class TestOpcodeExecutorDynamicShapeCache(TestCaseBase):
                 self.assertEqual(ctx.translate_count, 2)
 
     def test_dynamic_int_input_cache_hit_case3(self):
-        with allow_dynamic_shape_guard(
-            True
-        ), test_instruction_translator_cache_context() as ctx:
+        with (
+            allow_dynamic_shape_guard(True),
+            test_instruction_translator_cache_context() as ctx,
+        ):
             translate_count_map = {
                 0: 1,
                 1: 2,  # 1 is dynamic dim
@@ -152,9 +155,10 @@ class TestOpcodeExecutorDynamicShapeCache(TestCaseBase):
                 self.assertEqual(ctx.translate_count, translate_count_map[i])
 
     def test_dynamic_shape_input_cache_hit_case1(self):
-        with allow_dynamic_shape_guard(
-            True
-        ), test_instruction_translator_cache_context() as ctx:
+        with (
+            allow_dynamic_shape_guard(True),
+            test_instruction_translator_cache_context() as ctx,
+        ):
             self.assert_results(
                 dynamic_shape_input_func1, paddle.randn([2, 4, 5])
             )
@@ -166,9 +170,10 @@ class TestOpcodeExecutorDynamicShapeCache(TestCaseBase):
                 self.assertEqual(ctx.translate_count, 2)
 
     def test_dynamic_shape_input_cache_hit_case2(self):
-        with allow_dynamic_shape_guard(
-            True
-        ), test_instruction_translator_cache_context() as ctx:
+        with (
+            allow_dynamic_shape_guard(True),
+            test_instruction_translator_cache_context() as ctx,
+        ):
             self.assert_results(
                 dynamic_shape_access_inner_var_shape, paddle.randn([2, 4, 5])
             )
@@ -181,9 +186,10 @@ class TestOpcodeExecutorDynamicShapeCache(TestCaseBase):
                 self.assertEqual(ctx.translate_count, 2)
 
     def test_dynamic_shape_cast(self):
-        with allow_dynamic_shape_guard(
-            True
-        ), test_instruction_translator_cache_context() as ctx:
+        with (
+            allow_dynamic_shape_guard(True),
+            test_instruction_translator_cache_context() as ctx,
+        ):
             func1 = check_no_breakgraph(lambda n: bool(n))
             # TODO(SigureMo): Open these cases
             # func2 = check_no_breakgraph(lambda n: int(n))
@@ -193,9 +199,10 @@ class TestOpcodeExecutorDynamicShapeCache(TestCaseBase):
                 self.assert_results(func, 2)
 
     def test_dynamic_shape_in_list(self):
-        with allow_dynamic_shape_guard(
-            True
-        ), test_instruction_translator_cache_context() as ctx:
+        with (
+            allow_dynamic_shape_guard(True),
+            test_instruction_translator_cache_context() as ctx,
+        ):
             self.assert_results(
                 dynamic_shape_in_list,
                 paddle.randn([2, 2, 5]),
@@ -211,27 +218,30 @@ class TestOpcodeExecutorDynamicShapeCache(TestCaseBase):
                 self.assertEqual(ctx.translate_count, 2)
 
     def test_conv_dynamic_shape_stride_fallback(self):
-        with allow_dynamic_shape_guard(
-            True
-        ), test_instruction_translator_cache_context() as ctx:
+        with (
+            allow_dynamic_shape_guard(True),
+            test_instruction_translator_cache_context() as ctx,
+        ):
             for i in range(1, 5):
                 conv = CustomConv(3, 3, 3, stride=i)
                 conv(paddle.randn([1, 3, 224, 224]))
                 self.assertEqual(ctx.translate_count, i)
 
     def test_conv_dynamic_shape_kernel_size_fallback(self):
-        with allow_dynamic_shape_guard(
-            True
-        ), test_instruction_translator_cache_context() as ctx:
+        with (
+            allow_dynamic_shape_guard(True),
+            test_instruction_translator_cache_context() as ctx,
+        ):
             for i in range(1, 5):
                 x = paddle.randn([1, 3, 224, 224])
                 self.assert_results(pool2d_fallback, x, i)
                 self.assertEqual(ctx.translate_count, i)
 
     def test_pad_dynamic_shape_fallback(self):
-        with allow_dynamic_shape_guard(
-            True
-        ), test_instruction_translator_cache_context() as ctx:
+        with (
+            allow_dynamic_shape_guard(True),
+            test_instruction_translator_cache_context() as ctx,
+        ):
             pad_func = check_no_breakgraph(
                 lambda x, n: paddle.nn.functional.pad(x, [0, n, 0, 0])
             )
@@ -240,16 +250,18 @@ class TestOpcodeExecutorDynamicShapeCache(TestCaseBase):
                 self.assertEqual(ctx.translate_count, i)
 
     def test_dynamic_shape_int_mul_float(self):
-        with allow_dynamic_shape_guard(
-            True
-        ), test_instruction_translator_cache_context() as ctx:
+        with (
+            allow_dynamic_shape_guard(True),
+            test_instruction_translator_cache_context() as ctx,
+        ):
             for i in range(1, 6):
                 self.assert_results(dynamic_shape_int_mul_float, i)
 
     def test_dynamic_shape_constraint(self):
-        with allow_dynamic_shape_guard(
-            True
-        ), test_instruction_translator_cache_context() as ctx:
+        with (
+            allow_dynamic_shape_guard(True),
+            test_instruction_translator_cache_context() as ctx,
+        ):
             const_dim = 6
             self.assert_results(
                 dynamic_shape_constraint, paddle.randn([1, 1, const_dim])
@@ -333,9 +345,10 @@ class TestOpcodeExecutorDynamicShapeCache(TestCaseBase):
                 )
 
     def test_mixed_dynamic_and_static(self):
-        with allow_dynamic_shape_guard(
-            True
-        ), test_instruction_translator_cache_context() as ctx:
+        with (
+            allow_dynamic_shape_guard(True),
+            test_instruction_translator_cache_context() as ctx,
+        ):
             a = paddle.randn([4, 5, 6])
             self.assert_results(dynamic_int_input_func1, a, 1)
             self.assertEqual(ctx.translate_count, 1)
@@ -346,9 +359,10 @@ class TestOpcodeExecutorDynamicShapeCache(TestCaseBase):
                 self.assertEqual(ctx.translate_count, 3)
 
     def test_mixed_static_after_dynamic(self):
-        with allow_dynamic_shape_guard(
-            True
-        ), test_instruction_translator_cache_context() as ctx:
+        with (
+            allow_dynamic_shape_guard(True),
+            test_instruction_translator_cache_context() as ctx,
+        ):
             a = paddle.randn([4, 5, 6])
             self.assert_results(dynamic_int_input_func1, a, 2)
             self.assertEqual(ctx.translate_count, 1)
@@ -361,9 +375,10 @@ class TestOpcodeExecutorDynamicShapeCache(TestCaseBase):
             self.assertEqual(ctx.translate_count, 3)
 
     def test_dynamic_shape_with_constraints(self):
-        with allow_dynamic_shape_guard(
-            True
-        ), test_instruction_translator_cache_context() as ctx:
+        with (
+            allow_dynamic_shape_guard(True),
+            test_instruction_translator_cache_context() as ctx,
+        ):
             self.assert_results(
                 dynamic_shape_with_constraints, paddle.randn([4, 5, 6]), 2
             )
@@ -468,9 +483,10 @@ def dynamic_shape_non_break_inplace_ops(x):
 
 class TestDynamicShapeNonBreakOps(TestCaseBase):
     def test_dynamic_shape_non_break_non_inplace_ops(self):
-        with allow_dynamic_shape_guard(
-            True
-        ), test_instruction_translator_cache_context() as ctx:
+        with (
+            allow_dynamic_shape_guard(True),
+            test_instruction_translator_cache_context() as ctx,
+        ):
             self.assert_results(
                 dynamic_shape_non_break_non_inplace_ops, paddle.randn([4, 5, 6])
             )
@@ -483,9 +499,10 @@ class TestDynamicShapeNonBreakOps(TestCaseBase):
                 self.assertEqual(ctx.translate_count, 2)
 
     def test_dynamic_shape_non_break_inplace_ops(self):
-        with allow_dynamic_shape_guard(
-            True
-        ), test_instruction_translator_cache_context() as ctx:
+        with (
+            allow_dynamic_shape_guard(True),
+            test_instruction_translator_cache_context() as ctx,
+        ):
             self.assert_results(
                 dynamic_shape_non_break_inplace_ops, paddle.randn([4, 5, 6])
             )

--- a/tools/check_only_change_python_files.py
+++ b/tools/check_only_change_python_files.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-""" For the PR that only modified the unit test, get cases in pull request. """
+"""For the PR that only modified the unit test, get cases in pull request."""
 
 import os
 import ssl

--- a/tools/check_ut.py
+++ b/tools/check_ut.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-""" Get pull requests. """
+"""Get pull requests."""
 
 import os
 import os.path

--- a/tools/coverage/cuda_clean.py
+++ b/tools/coverage/cuda_clean.py
@@ -13,7 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-""" usage: cuda_clean.py pull_id. """
+"""usage: cuda_clean.py pull_id."""
 
 import os
 import sys

--- a/tools/coverage/gcda_clean.py
+++ b/tools/coverage/gcda_clean.py
@@ -13,7 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-""" usage: gcda_clean.py pull_id. """
+"""usage: gcda_clean.py pull_id."""
 
 import os
 import sys

--- a/tools/get_pr_ut.py
+++ b/tools/get_pr_ut.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-""" For the PR that only modified the unit test, get cases in pull request. """
+"""For the PR that only modified the unit test, get cases in pull request."""
 
 import json
 import os

--- a/tools/windows/get_prec_ut_list.py
+++ b/tools/windows/get_prec_ut_list.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""To get a list of prec ut """
+"""To get a list of prec ut"""
 
 import os
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Improvements

### Description
<!-- Describe what you’ve done -->

- 升级 black 到 25.1.0，这包含了 2025 style，对全量代码格式化
- 移除 black `target-version` 中的 `py38`，添加 `py313`，同样全量格式化（with 多个 guard 的新形式好看多了，后面可以再引入 `SIM117`[^1]）
- 调整 mypy `python_version` 到 `3.9`
- 移除部分无必要的 `fmt: off`

<!-- PCard-66972 -->

[^1]: https://docs.astral.sh/ruff/rules/multiple-with-statements/