### PR TITLE
[0-size Tensor No.28、255] Add 0-size Tensor support for searchsorted

### DIFF
--- a/paddle/phi/kernels/impl/searchsorted_kernel_impl.h
+++ b/paddle/phi/kernels/impl/searchsorted_kernel_impl.h
@@ -240,12 +240,18 @@ void SearchsortedKernel(const Context& ctx,
                         DenseTensor* out) {
   if (out_int32) {
     ctx.template Alloc<int>(out);
+    if (out && out->numel() == 0) {
+      return;
+    }
     int* out_data = out->data<int>();
     SearchSortedFunctor<Context, T, int> functor(
         ctx, &sorted_sequence, &value, right, out_data);
     VisitDataTypeForSearchSorted(value.dtype(), functor);
   } else {
     ctx.template Alloc<int64_t>(out);
+    if (out && out->numel() == 0) {
+      return;
+    }
     int64_t* out_data = out->data<int64_t>();
     SearchSortedFunctor<Context, T, int64_t> functor(
         ctx, &sorted_sequence, &value, right, out_data);

--- a/test/legacy_test/test_searchsorted_op.py
+++ b/test/legacy_test/test_searchsorted_op.py
@@ -45,8 +45,17 @@ class TestSearchSorted(OpTest):
     def test_check_output(self):
         self.check_output(check_pir=True)
 
+    def init_shape(self):
+        self.shape = None
+
     def init_test_case(self):
-        self.sorted_sequence = np.array([1, 3, 5, 7, 9]).astype("float32")
+        self.init_shape()
+        if self.shape is None:
+            self.sorted_sequence = np.array([1, 3, 5, 7, 9]).astype("float32")
+        else:
+            self.sorted_sequence = np.random.randn(*self.shape).astype(
+                "float32"
+            )
         self.values = np.array([[3, 6, 9], [3, 6, 9]]).astype("float32")
         self.side = "left"
 
@@ -90,6 +99,11 @@ class TestSearchSortedOp5(TestSearchSorted):
             [[np.inf, np.inf, np.inf], [np.nan, np.nan, np.nan]]
         ).astype("float64")
         self.side = "right"
+
+
+class TestSearchSorted_ZeroSize(TestSearchSorted):
+    def init_shape(self):
+        self.shape = (0,)
 
 
 @unittest.skipIf(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
bucketize 使用 searchsorted kernel

searchsorted没有反向
infermeta没有问题
kernel支持cpu/gpu，共用impl

PaddleAPITest 测试通过
![image](https://github.com/user-attachments/assets/4e53c17d-a1d9-4807-b82b-45ef12113fd8)
