### PR TITLE
[0-size Tensor No.53、300] Add 0-size Tensor support for erfinv

### DIFF
--- a/paddle/phi/kernels/cpu/erfinv_kernel.cc
+++ b/paddle/phi/kernels/cpu/erfinv_kernel.cc
@@ -26,6 +26,9 @@ namespace phi {
 template <typename T, typename Context>
 void ErfinvKernel(const Context& ctx, const DenseTensor& x, DenseTensor* out) {
   ctx.template Alloc<T>(out);
+  if (out && out->numel() == 0) {
+    return;
+  }
   auto eigen_in = EigenVector<T>::Flatten(x);
   auto eigen_out = EigenVector<T>::Flatten(*out);
   auto& place = *ctx.eigen_device();

--- a/paddle/phi/kernels/gpu/erfinv_kernel.cu
+++ b/paddle/phi/kernels/gpu/erfinv_kernel.cu
@@ -41,6 +41,9 @@ struct ErfinvFunctor<bfloat16> {
 template <typename T, typename Context>
 void ErfinvKernel(const Context& ctx, const DenseTensor& x, DenseTensor* out) {
   ctx.template Alloc<T>(out);
+  if (out && out->numel() == 0) {
+    return;
+  }
   std::vector<const DenseTensor*> ins = {&x};
   std::vector<DenseTensor*> outs = {out};
   phi::funcs::ElementwiseKernel<T>(ctx, ins, &outs, ErfinvFunctor<T>());

--- a/paddle/phi/kernels/impl/erfinv_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/erfinv_grad_kernel_impl.h
@@ -25,6 +25,9 @@ void ErfinvGradKernel(const Context& ctx,
                       const DenseTensor& out_grad,
                       DenseTensor* x_grad) {
   ctx.template Alloc<T>(x_grad);
+  if (x_grad && x_grad->numel() == 0) {
+    return;
+  }
   auto eigen_out = EigenVector<T>::Flatten(out);
   auto eigen_dout = EigenVector<T>::Flatten(out_grad);
   auto eigen_dx = EigenVector<T>::Flatten(*x_grad);

--- a/test/legacy_test/test_erfinv_op.py
+++ b/test/legacy_test/test_erfinv_op.py
@@ -31,7 +31,7 @@ class TestErfinvOp(OpTest):
         self.op_type = "erfinv"
         self.python_api = paddle.erfinv
         self.init_dtype()
-        self.shape = [11, 17]
+        self.init_shape()
         self.x = np.random.uniform(-1, 1, size=self.shape).astype(self.dtype)
         self.res_ref = erfinv(self.x).astype(self.dtype)
         self.grad_out = np.ones(self.shape, self.dtype)
@@ -40,6 +40,9 @@ class TestErfinvOp(OpTest):
         )
         self.inputs = {'X': self.x}
         self.outputs = {'Out': self.res_ref}
+
+    def init_shape(self):
+        self.shape = [11, 17]
 
     def init_dtype(self):
         self.dtype = np.float64
@@ -60,6 +63,11 @@ class TestErfinvOp(OpTest):
 class TestErfinvFP64Op(TestErfinvOp):
     def init_dtype(self):
         self.dtype = np.float64
+
+
+class TestErfinvOp_ZeroSize(TestErfinvOp):
+    def init_shape(self):
+        self.shape = [0, 17]
 
 
 class TestErfinvAPIOp(unittest.TestCase):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->
erfinv 修改前向和反向
infermeta 不用修改
kernel 包含cpu/gpu

PaddleAPITest测试通过
![image](https://github.com/user-attachments/assets/ec4faf39-bb0a-4942-af74-7f3bf6d15f5b)
