### PR TITLE
[0-size Tensor No.207、208] Add 0-size Tensor support for pixel_shuffle/pixel_unshuffle

### DIFF
--- a/paddle/phi/kernels/impl/pixel_shuffle_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/pixel_shuffle_grad_kernel_impl.h
@@ -31,6 +31,9 @@ void PixelShuffleGradKernel(const Context& ctx,
   auto* dout = &out_grad;
   auto* dx = x_grad;
   ctx.template Alloc<T>(dx);
+  if (dx && dx->numel() == 0) {
+    return;
+  }
   int factor = upscale_factor;
   bool channel_last = (data_format == "NHWC");
   const auto& do_dims = dout->dims();

--- a/paddle/phi/kernels/impl/pixel_shuffle_kernel_impl.h
+++ b/paddle/phi/kernels/impl/pixel_shuffle_kernel_impl.h
@@ -30,6 +30,10 @@ void PixelShuffleKernel(const Context& ctx,
                         DenseTensor* out) {
   auto* in = &x;
   ctx.template Alloc<T>(out);
+  if (out && out->numel() == 0) {
+    return;
+  }
+
   int factor = upscale_factor;
   bool channel_last = (data_format == "NHWC");
   const auto& in_dims = in->dims();

--- a/paddle/phi/kernels/impl/pixel_unshuffle_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/pixel_unshuffle_grad_kernel_impl.h
@@ -31,6 +31,9 @@ void PixelUnshuffleGradKernel(const Context& dev_ctx,
   auto* dout = &out_grad;
   auto* dx = x_grad;
   dev_ctx.template Alloc<T>(dx);
+  if (dx && dx->numel() == 0) {
+    return;
+  }
   int factor = downscale_factor;
   bool channel_last = (data_format == "NHWC");
   const auto& do_dims = dout->dims();

--- a/paddle/phi/kernels/impl/pixel_unshuffle_kernel_impl.h
+++ b/paddle/phi/kernels/impl/pixel_unshuffle_kernel_impl.h
@@ -30,6 +30,9 @@ void PixelUnshuffleKernel(const Context& dev_ctx,
                           DenseTensor* out) {
   auto* in = &x;
   dev_ctx.template Alloc<T>(out);
+  if (out && out->numel() == 0) {
+    return;
+  }
   int factor = downscale_factor;
   bool channel_last = (data_format == "NHWC");
   const auto& in_dims = in->dims();

--- a/paddle/phi/kernels/xpu/pixel_shuffle_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/pixel_shuffle_grad_kernel.cc
@@ -28,6 +28,9 @@ void PixelShuffleGradKernel(const Context& ctx,
 
   const T* x_ptr = out_grad.data<T>();
   T* y_ptr = ctx.template Alloc<T>(x_grad);
+  if (x_grad && x_grad->numel() == 0) {
+    return;
+  }
 
   bool is_nchw = data_format == "NCHW";
 

--- a/paddle/phi/kernels/xpu/pixel_shuffle_kernel.cc
+++ b/paddle/phi/kernels/xpu/pixel_shuffle_kernel.cc
@@ -28,6 +28,9 @@ void PixelShuffleKernel(const Context& ctx,
 
   const T* x_ptr = x.data<T>();
   T* y_ptr = ctx.template Alloc<T>(out);
+  if (out && out->numel() == 0) {
+    return;
+  }
 
   bool is_nchw = data_format == "NCHW";
 

--- a/test/legacy_test/test_pixel_shuffle_op.py
+++ b/test/legacy_test/test_pixel_shuffle_op.py
@@ -64,8 +64,9 @@ class TestPixelShuffleOp(OpTest):
         self.op_type = "pixel_shuffle"
         self.python_api = paddle.nn.functional.pixel_shuffle
         self.init_dtype()
+        self.init_shape()
         self.init_data_format()
-        n, c, h, w = 2, 9, 4, 4
+        n, c, h, w = self.shape
 
         if self.format == "NCHW":
             shape = [n, c, h, w]
@@ -80,6 +81,9 @@ class TestPixelShuffleOp(OpTest):
         self.inputs = {'X': x}
         self.outputs = {'Out': npresult}
         self.attrs = {'upscale_factor': up_factor, "data_format": self.format}
+
+    def init_shape(self):
+        self.shape = [2, 9, 4, 4]
 
     def init_dtype(self):
         self.dtype = np.float64
@@ -106,6 +110,11 @@ class TestChannelLast(TestPixelShuffleOp):
 class TestPixelShuffleFP16Op(TestPixelShuffleOp):
     def init_dtype(self):
         self.dtype = np.float16
+
+
+class TestPixelShuffleOp_ZeroSize(TestPixelShuffleOp):
+    def init_shape(self):
+        self.shape = [2, 0, 0, 4]
 
 
 @unittest.skipIf(

--- a/test/legacy_test/test_pixel_unshuffle.py
+++ b/test/legacy_test/test_pixel_unshuffle.py
@@ -83,8 +83,9 @@ class TestPixelUnshuffleOp(OpTest):
         self.op_type = "pixel_unshuffle"
         self.python_api = pixel_unshuffle_wrapper
         self.init_dtype()
+        self.init_shape()
         self.init_data_format()
-        n, c, h, w = 2, 1, 12, 12
+        n, c, h, w = self.shape
 
         if self.format == "NCHW":
             shape = [n, c, h, w]
@@ -102,6 +103,9 @@ class TestPixelUnshuffleOp(OpTest):
             "downscale_factor": down_factor,
             "data_format": self.format,
         }
+
+    def init_shape(self):
+        self.shape = [2, 1, 12, 12]
 
     def init_dtype(self):
         self.dtype = np.float64
@@ -134,6 +138,11 @@ class TestChannelLast(TestPixelUnshuffleOp):
 class TestPixelUnshuffleFP16Op(TestPixelUnshuffleOp):
     def init_dtype(self):
         self.dtype = np.float16
+
+
+class TestPixelUnshuffleOp_ZeroSize(TestPixelUnshuffleOp):
+    def init_shape(self):
+        self.shape = [2, 0, 0, 12]
 
 
 @unittest.skipIf(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->
修改前向和反向
infermeta没有修改
kernel修改cpu/gpu

PaddleAPITest测试通过
pixel_shuffle
![image](https://github.com/user-attachments/assets/d945ede7-5a6b-4060-9e96-023ef5750242)

pixel_unshuffle
![image](https://github.com/user-attachments/assets/f71e27a8-5828-4970-a082-2860799af508)
