### PR TITLE
[0-size Tensor No.81、138、141] Add 0-size Tensor support for blha_get_max_len

### DIFF
--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.cc
@@ -2314,15 +2314,40 @@ bool NanmedianOpInferSymbolicShape(
   if (mode == "avg") {
     median_shape.emplace_back(2);
   }
-  infer_context->SetShapeOrDataForValue(
-      op->result(0),
-      symbol::ShapeOrDataDimExprs{
-          symbol::TensorShapeOrDataDimExprs(out_shape)});
-  infer_context->SetShapeOrDataForValue(
-      op->result(1),
-      symbol::ShapeOrDataDimExprs{
-          symbol::TensorShapeOrDataDimExprs(median_shape)});
 
+  const auto &IsZero = [&](const symbol::DimExpr &dim_expr) {
+    if (dim_expr.isa<int64_t>()) {
+      return dim_expr.dyn_cast<int64_t>() == static_cast<int64_t>(0);
+    }
+    return false;
+  };
+  bool size_0 = false;
+  for (int i = 0; i < x_shape.size(); i++) {
+    if (IsZero(x_shape.at(i))) {
+      size_0 = true;
+      break;
+    }
+  }
+  if (size_0) {
+    std::vector<symbol::DimExpr> x_numel_0_shape = {};
+    infer_context->SetShapeOrDataForValue(
+        op->result(0),
+        symbol::ShapeOrDataDimExprs{
+            symbol::TensorShapeOrDataDimExprs(x_numel_0_shape)});
+    infer_context->SetShapeOrDataForValue(
+        op->result(1),
+        symbol::ShapeOrDataDimExprs{
+            symbol::TensorShapeOrDataDimExprs(x_numel_0_shape)});
+  } else {
+    infer_context->SetShapeOrDataForValue(
+        op->result(0),
+        symbol::ShapeOrDataDimExprs{
+            symbol::TensorShapeOrDataDimExprs(out_shape)});
+    infer_context->SetShapeOrDataForValue(
+        op->result(1),
+        symbol::ShapeOrDataDimExprs{
+            symbol::TensorShapeOrDataDimExprs(median_shape)});
+  }
   return true;
 }
 

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.cc
@@ -2322,7 +2322,7 @@ bool NanmedianOpInferSymbolicShape(
     return false;
   };
   bool size_0 = false;
-  for (int i = 0; i < x_shape.size(); i++) {
+  for (size_t i = 0; i < x_shape.size(); i++) {
     if (IsZero(x_shape.at(i))) {
       size_0 = true;
       break;

--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -2854,6 +2854,11 @@ void NanmedianInferMeta(const MetaTensor& x,
   }
   median_index->set_dtype(DataType::INT64);
   median_index->set_dims(make_ddim(median_dim));
+
+  if (x.numel() == 0) {
+    out->set_dims(make_ddim({}));
+    median_index->set_dims(make_ddim({}));
+  }
 }
 
 void NMSInferMeta(const MetaTensor& x, float threshold, MetaTensor* out) {

--- a/paddle/phi/kernels/cpu/mv_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/mv_grad_kernel.cc
@@ -16,6 +16,7 @@
 
 #include "paddle/phi/backends/cpu/cpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/funcs/blas/blas.h"
 
 namespace phi {
@@ -30,6 +31,21 @@ void MvGradKernel(const Context& dev_ctx,
   auto dout = out_grad;
   auto dx = x_grad;
   auto dvec = vec_grad;
+  if (x.numel() == 0 || vec.numel() == 0) {
+    if (dx) {
+      phi::Full<T, Context>(dev_ctx,
+                            phi::IntArray(common::vectorize(dx->dims())),
+                            static_cast<T>(0),
+                            dx);
+    }
+    if (dvec) {
+      phi::Full<T, Context>(dev_ctx,
+                            phi::IntArray(common::vectorize(dvec->dims())),
+                            static_cast<T>(0),
+                            dvec);
+    }
+    return;
+  }
 
   const auto& dim_x = x.dims();
   int m = static_cast<int>(dim_x[0]);

--- a/paddle/phi/kernels/cpu/nanmedian_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/nanmedian_grad_kernel.cc
@@ -96,6 +96,10 @@ void NanmedianGradKernel(const Context& dev_ctx,
                          bool keepdim UNUSED,
                          const std::string& mode,
                          DenseTensor* x_grad) {
+  if (x_grad && x_grad->numel() == 0) {
+    dev_ctx.template Alloc<T>(x_grad);
+    return;
+  }
   DenseTensor tmp_x;
   auto rank = x.dims().size();
   if ((axes.size() == 0) || rank <= 1) {

--- a/paddle/phi/kernels/cpu/nanmedian_kernel.cc
+++ b/paddle/phi/kernels/cpu/nanmedian_kernel.cc
@@ -16,6 +16,7 @@
 
 #include "paddle/phi/backends/cpu/cpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/funcs/nanmedian_utils.h"
 #include "paddle/phi/kernels/top_k_kernel.h"
 
@@ -218,6 +219,16 @@ void NanmedianKernel(const Context& dev_ctx,
                      const std::string& mode,
                      DenseTensor* out,
                      DenseTensor* median_index) {
+  if (x.numel() == 0) {
+    phi::Full<T, Context>(
+        dev_ctx, phi::IntArray(common::vectorize(out->dims())), NAN, out);
+    phi::Full<int64_t, Context>(
+        dev_ctx,
+        phi::IntArray(common::vectorize(median_index->dims())),
+        0,
+        median_index);
+    return;
+  }
   DenseTensor tmp_x;
   auto rank = x.dims().size();
   if ((axes.size() == 0) || rank <= 1) {

--- a/paddle/phi/kernels/fusion/xpu/blha_get_max_len_kernel.cc
+++ b/paddle/phi/kernels/fusion/xpu/blha_get_max_len_kernel.cc
@@ -14,9 +14,11 @@
 
 #include <paddle/phi/backends/xpu/xpu_context.h>
 #include "glog/logging.h"
+#include "paddle/phi/backends/context_pool.h"
 #include "paddle/phi/backends/xpu/enforce_xpu.h"
 #include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/memcpy_kernel.h"
 #include "xpu/xdnn.h"
 
@@ -49,13 +51,33 @@ void BlhaGetMaxLenKernel(const Context& dev_ctx,
                          const phi::DenseTensor& batch_size,
                          DenseTensor* max_enc_len_this_time,
                          DenseTensor* max_dec_len_this_time) {
+  phi::DeviceContextPool& pool = phi::DeviceContextPool::Instance();
+  auto& dev_ctx_cpu = *pool.Get(phi::CPUPlace());
   // decoder
   max_dec_len_this_time->Resize({{1}});
-  GetMaxLenTensor(dev_ctx, seq_lens_decoder, batch_size, max_dec_len_this_time);
+  if (seq_lens_decoder.numel() > 0) {
+    GetMaxLenTensor(
+        dev_ctx, seq_lens_decoder, batch_size, max_dec_len_this_time);
+  } else {
+    phi::Full<int, phi::CPUContext>(
+        reinterpret_cast<const phi::CPUContext&>(dev_ctx_cpu),
+        phi::IntArray(common::vectorize(max_dec_len_this_time->dims())),
+        0,
+        max_dec_len_this_time);
+  }
 
   // encoder
   max_enc_len_this_time->Resize({{1}});
-  GetMaxLenTensor(dev_ctx, seq_lens_encoder, batch_size, max_enc_len_this_time);
+  if (seq_lens_encoder.numel() > 0) {
+    GetMaxLenTensor(
+        dev_ctx, seq_lens_encoder, batch_size, max_enc_len_this_time);
+  } else {
+    phi::Full<int, phi::CPUContext>(
+        reinterpret_cast<const phi::CPUContext&>(dev_ctx_cpu),
+        phi::IntArray(common::vectorize(max_enc_len_this_time->dims())),
+        0,
+        max_enc_len_this_time);
+  }
 }
 }  // namespace fusion
 }  // namespace phi

--- a/paddle/phi/kernels/gpu/mv_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/mv_grad_kernel.cu
@@ -16,6 +16,7 @@
 
 #include "paddle/phi/backends/gpu/gpu_launch_config.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/funcs/blas/blas.h"
 
 namespace phi {
@@ -41,6 +42,21 @@ void MvGradKernel(const Context &dev_ctx,
   auto dout = out_grad;
   auto dx = x_grad;
   auto dvec = vec_grad;
+  if (x.numel() == 0 || vec.numel() == 0) {
+    if (dx) {
+      phi::Full<T, Context>(dev_ctx,
+                            phi::IntArray(common::vectorize(dx->dims())),
+                            static_cast<T>(0),
+                            dx);
+    }
+    if (dvec) {
+      phi::Full<T, Context>(dev_ctx,
+                            phi::IntArray(common::vectorize(dvec->dims())),
+                            static_cast<T>(0),
+                            dvec);
+    }
+    return;
+  }
 
   auto dim_x = x.dims();
   int m = dim_x[0];

--- a/paddle/phi/kernels/gpu/nanmedian_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/nanmedian_grad_kernel.cu
@@ -111,6 +111,10 @@ void NanmedianGradKernel(const Context& dev_ctx,
                          bool keepdim UNUSED,
                          const std::string& mode,
                          DenseTensor* x_grad) {
+  if (x_grad && x_grad->numel() == 0) {
+    dev_ctx.template Alloc<T>(x_grad);
+    return;
+  }
   DenseTensor tmp_x;
   auto rank = x.dims().size();
   if ((axes.size() == 0) || rank <= 1) {

--- a/paddle/phi/kernels/gpu/nanmedian_kernel.cu
+++ b/paddle/phi/kernels/gpu/nanmedian_kernel.cu
@@ -356,6 +356,16 @@ void NanmedianKernel(const Context& dev_ctx,
                      const std::string& mode,
                      DenseTensor* out,
                      DenseTensor* median_index) {
+  if (x.numel() == 0) {
+    phi::Full<T, Context>(
+        dev_ctx, phi::IntArray(common::vectorize(out->dims())), NAN, out);
+    phi::Full<int64_t, Context>(
+        dev_ctx,
+        phi::IntArray(common::vectorize(median_index->dims())),
+        0,
+        median_index);
+    return;
+  }
   DenseTensor tmp_x;
   auto rank = x.dims().size();
   if ((axes.size() == 0) || rank <= 1) {

--- a/test/legacy_test/test_mv_op.py
+++ b/test/legacy_test/test_mv_op.py
@@ -39,6 +39,24 @@ class TestMVOp(OpTest):
         self.vec = np.random.random(100).astype("float64")
 
 
+class TestMVOp_ZeroSize1(TestMVOp):
+    def init_config(self):
+        self.x = np.random.random((0, 100)).astype("float64")
+        self.vec = np.random.random(100).astype("float64")
+
+
+class TestMVOp_ZeroSize2(TestMVOp):
+    def init_config(self):
+        self.x = np.random.random((100, 0)).astype("float64")
+        self.vec = np.random.random(0).astype("float64")
+
+
+class TestMVOp_ZeroSize3(TestMVOp):
+    def init_config(self):
+        self.x = np.random.random((0, 0)).astype("float64")
+        self.vec = np.random.random(0).astype("float64")
+
+
 class TestMVAPI(unittest.TestCase):
     def test_dygraph_api_out(self):
         paddle.disable_static()

--- a/test/legacy_test/test_nanmedian.py
+++ b/test/legacy_test/test_nanmedian.py
@@ -617,6 +617,23 @@ class TestNanmedianFP16Op(OpTest):
         self.check_grad(['X'], 'Out', check_pir=True)
 
 
+class TestNanmedianOp_ZeroSize(TestNanmedianFP16Op):
+    def setUp(self):
+        self.op_type = "nanmedian"
+        self.python_api = paddle.nanmedian
+        self.public_python_api = paddle.nanmedian
+        self.dtype = np.float64
+        self.python_out_sig = ["Out"]
+        X = np.random.random((100, 0)).astype('float64')
+        Out = np.nanmedian(X)
+        indices = np.zeros_like(Out, dtype='int64')
+        self.inputs = {'X': X}
+        self.outputs = {'Out': Out, 'MedianIndex': indices}
+
+    def test_check_output(self):
+        self.check_output(check_pir=True, equal_nan=True)
+
+
 @unittest.skipIf(
     not core.is_compiled_with_cuda()
     or not core.is_bfloat16_supported(core.CUDAPlace(0)),


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->
blha_get_max_len 调用了max ，numpy中max不支持0-size，所以没有增加单测，只是修改kernel支持PaddleAPITest 测试运行
修改包含前向，没有反向
infermeta没有修改
kernel修改gpu/xpu，返回结果为一个整数保存在cpu后端中

numpy中max不支持0-size
![image](https://github.com/user-attachments/assets/ca25b82f-e458-4803-b732-4fae023f264d)
PaddleAPITest 测试运行通过
![image](https://github.com/user-attachments/assets/ac3989d4-fd81-427f-b468-bbdd33d970b0)


mv 修改前向和反向
infermeta 不用修改
kernel 修改 cpu/gpu，前向共用impl实现
已修改测试用例, x末尾列需要和vec维度值相同，所以测试用例为
[0, 100], [100]
[100, 0], [0]
[0], [0]
PaddleAPITest 测试已修复cuda error, paddle, error, 错误为torch error
![image](https://github.com/user-attachments/assets/03cc9f5a-d845-423d-aca5-4672e41acddb)


nanmedian 修改前向和反向
infermeta修改设置维度
修改cpu/gpu kernel
返回值需要Resize，Out返回NAN，median_index返回0

PaddleAPITest测试通过
![image](https://github.com/user-attachments/assets/7c77ed42-9ac8-497e-8892-631bf9b48153)