### PR TITLE
[0-size Tensor No.249] Add 0-size Tensor support for paddle.reverse  API.

### DIFF
--- a/paddle/phi/kernels/cpu/flip_kernel.cc
+++ b/paddle/phi/kernels/cpu/flip_kernel.cc
@@ -42,6 +42,9 @@ void FlipKernel(const Context& dev_ctx,
   auto numel = x.numel();
   const T* x_data = x.data<T>();
   T* out_data = dev_ctx.template Alloc<T>(out);
+  if (out->numel() == 0) {
+    return;
+  }
 #ifdef PADDLE_WITH_MKLML
 #pragma omp parallel for
 #endif

--- a/paddle/phi/kernels/gpu/flip_kernel.cu
+++ b/paddle/phi/kernels/gpu/flip_kernel.cu
@@ -68,6 +68,9 @@ void FlipKernel(const Context& dev_ctx,
                 DenseTensor* out) {
   auto* in_data = x.data<T>();
   auto* out_data = dev_ctx.template Alloc<T>(out);
+  if (out->numel() == 0) {
+    return;
+  }
 
   auto x_dims = x.dims();
   const int rank = x_dims.size();

--- a/test/legacy_test/test_reverse_op.py
+++ b/test/legacy_test/test_reverse_op.py
@@ -91,6 +91,26 @@ class TestCase3_neg(TestReverseOp):
         self.axis = [-1, -2]
 
 
+class TestCase4(TestReverseOp):
+    def initTestCase(self):
+        self.x = np.random.random((3, 0, 10)).astype('float64')
+        self.axis = [1, 2]
+
+
+class TestCase5(TestReverseOp):
+    def initTestCase(self):
+        self.x = np.random.random((2, 0, 3)).astype('float32')
+        self.axis = [0]
+
+
+class TestCase6(TestReverseOp):
+    def initTestCase(self):
+        self.x = np.random.random((2, 0, 0)).astype('float32')
+        self.axis = [
+            0,
+        ]
+
+
 if __name__ == '__main__':
     paddle.enable_static()
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->

![image](https://github.com/user-attachments/assets/7e8a322b-3665-4a44-8b4e-77f18752c9c4)

通过执行时的debug log发现reverse底层的kernel并不是reversekernel而是调用的flip，因此需要修改flip。
无反向因此无需修改，前向kernel只有在cpu和gpu上有。
修改后paddleAPITest的回测结果。

![image](https://github.com/user-attachments/assets/6b8f6e7a-2b59-4835-8869-2504487c5b10)

pcard-67164