### PR TITLE
[Accuracy diff No.74、75] Fix accuracy diff for paddle.unique_consecutive API

### DIFF
--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -3509,7 +3509,7 @@ def unique_consecutive(
         )
         outs = [out]
         if return_inverse:
-            if inverse.shape != x.shape:
+            if inverse.shape != x.shape and inverse.numel() == x.numel():
                 inverse = inverse.reshape(x.shape)
             outs.append(inverse)
         if return_counts:
@@ -3548,7 +3548,7 @@ def unique_consecutive(
         outputs = {"Out": out, "Index": inverse, "Counts": counts}
         outs = [out]
         if return_inverse:
-            if inverse.shape != x.shape:
+            if inverse.shape != x.shape and inverse.numel() == x.numel():
                 inverse = inverse.reshape(x.shape)
             outs.append(inverse)
         if return_counts:

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -3509,6 +3509,8 @@ def unique_consecutive(
         )
         outs = [out]
         if return_inverse:
+            if inverse.shape != x.shape:
+                inverse = inverse.reshape(x.shape)
             outs.append(inverse)
         if return_counts:
             outs.append(counts)
@@ -3546,6 +3548,8 @@ def unique_consecutive(
         outputs = {"Out": out, "Index": inverse, "Counts": counts}
         outs = [out]
         if return_inverse:
+            if inverse.shape != x.shape:
+                inverse = inverse.reshape(x.shape)
             outs.append(inverse)
         if return_counts:
             outs.append(counts)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->

- #72667

修改历程：
根据ci_ce_cpu和ci_ce_gpu下的error log，发现导致accuracy error报错的原因是因为返回的inverse shape与torch不一致，torch返回的shape是与输入一致的。目前有两种修复方式：
1. 在框架中修改返回的inverse shape与torch保持一致。
2. 在PaddleAPITest中重写paddle.unique_consecutive的转换rule进行修复。
本PR采取前者进行修复。

测试结果:
![image](https://github.com/user-attachments/assets/310e0440-e628-4cda-98d2-19881872f2b8)
