### PR TITLE
[PHI] Fix int64 index selection for broadcast kernel

### DIFF
--- a/paddle/phi/kernels/funcs/broadcast_function.h
+++ b/paddle/phi/kernels/funcs/broadcast_function.h
@@ -739,12 +739,13 @@ void BroadcastKernelApply(const KPDevice &ctx,
                           int axis,
                           Functor func) {
 #ifndef PADDLE_WITH_XPU_KP
-  constexpr bool kEnabledInt64IndexKernel = (NumOuts == 1 && kArity <= 3);
-  // check whether need broadcast
   auto compute_size = std::numeric_limits<int32_t>::max();
-  bool use_int64_index_kernel =
-      kEnabledInt64IndexKernel && (*outs)[0]->numel() >= compute_size;
-
+  bool use_int64_index_kernel = false;
+  for (auto *out : *outs) {
+    if (out->numel() >= compute_size) {
+      use_int64_index_kernel = true;
+    }
+  }
   if (use_int64_index_kernel) {  // use_int64_index_kernel
     BroadcastKernelSplit<OutT, Functor, kArity, NumOuts>(
         ctx, ins, outs, axis, func, compute_size);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Operator Mechanism


### PR Types
Bug fixes


### Description
broadcast kernel本身是支持int64的，但是之前在判断是否使用int64时却有一个`(NumOuts == 1 && kArity <= 3)`的限制，原PR https://github.com/PaddlePaddle/Paddle/pull/57313 也没有说明原因；该限制会导致在计算反向的时候因为NumOuts不为1而无法使用int64，因此本PR删掉了这一限制，任何情况下均允许使用int64的index

经测试，`x[311412, 7168] * y[311412, 1]`的反向可以正确计算，精度与torch对齐

Pcard-85711