### PR TITLE
[Slice]Change deep_copy to share_buffer in eager backward

### DIFF
--- a/paddle/fluid/eager/backward.cc
+++ b/paddle/fluid/eager/backward.cc
@@ -179,8 +179,6 @@ std::vector<paddle::Tensor> RunBackward(
           std::make_unique<GradTensorHolder>(grad_node->InputMeta());
     }
 
-    // copy grad tensor since we should totally run grad without affect forward
-    // value
     if (!grad_tensors.empty() &&
         (grad_tensors[i].defined() && grad_tensors[i].has_allocation())) {
       PADDLE_ENFORCE(
@@ -192,9 +190,13 @@ std::vector<paddle::Tensor> RunBackward(
       // Feed given tensor if it's provided
       VLOG(3) << "Fill grad input tensor " << i << "with give grad tensor";
 
-      // Deep copy
-      node_input_buffers_dict[grad_node]->CopyValueFromTensor(
-          input_info.first, input_info.second, grad_tensors[i]);
+      // Share buffer with given grad_tensor
+      paddle::small_vector<std::vector<paddle::Tensor>, kSlotSmallVectorSize>
+          inputs_grad_tensors;
+      inputs_grad_tensors.push_back({grad_tensors[i]});
+      auto grad_holder = GradTensorHolder(std::move(inputs_grad_tensors));
+      node_input_buffers_dict[grad_node] =
+          std::make_unique<GradTensorHolder>(grad_holder);
     } else {
       VLOG(3) << "Fill grad input tensor " << i << " with 1.0";
       // Initialize tensor with 1.0

--- a/paddle/fluid/eager/backward.cc
+++ b/paddle/fluid/eager/backward.cc
@@ -179,6 +179,8 @@ std::vector<paddle::Tensor> RunBackward(
           std::make_unique<GradTensorHolder>(grad_node->InputMeta());
     }
 
+    // copy grad tensor since we should totally run grad without affect forward
+    // value
     if (!grad_tensors.empty() &&
         (grad_tensors[i].defined() && grad_tensors[i].has_allocation())) {
       PADDLE_ENFORCE(
@@ -190,13 +192,30 @@ std::vector<paddle::Tensor> RunBackward(
       // Feed given tensor if it's provided
       VLOG(3) << "Fill grad input tensor " << i << "with give grad tensor";
 
-      // Share buffer with given grad_tensor
-      paddle::small_vector<std::vector<paddle::Tensor>, kSlotSmallVectorSize>
-          inputs_grad_tensors;
-      inputs_grad_tensors.push_back({grad_tensors[i]});
-      auto grad_holder = GradTensorHolder(std::move(inputs_grad_tensors));
-      node_input_buffers_dict[grad_node] =
-          std::make_unique<GradTensorHolder>(grad_holder);
+      bool use_shared_buffer = false;
+      // Check if inputs and outputs are equal in size and share the same buffer
+      if (tensors.size() == inputs.size() &&
+          tensors[i].numel() == inputs[i].numel()) {
+        auto output_tensor =
+            std::dynamic_pointer_cast<phi::DenseTensor>(tensors[i].impl());
+        auto input_tensor =
+            std::dynamic_pointer_cast<phi::DenseTensor>(inputs[i].impl());
+        use_shared_buffer = output_tensor->IsSharedBufferWith(*input_tensor);
+      }
+
+      if (use_shared_buffer) {
+        // Share buffer with given grad_tensor
+        paddle::small_vector<std::vector<paddle::Tensor>, kSlotSmallVectorSize>
+            inputs_grad_tensors;
+        inputs_grad_tensors.push_back({grad_tensors[i]});
+        auto grad_holder = GradTensorHolder(std::move(inputs_grad_tensors));
+        node_input_buffers_dict[grad_node] =
+            std::make_unique<GradTensorHolder>(grad_holder);
+      } else {
+        // Deep copy
+        node_input_buffers_dict[grad_node]->CopyValueFromTensor(
+            input_info.first, input_info.second, grad_tensors[i]);
+      }
     } else {
       VLOG(3) << "Fill grad input tensor " << i << " with 1.0";
       // Initialize tensor with 1.0


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->
pcard-67164
Change deep_copy to share_buffer in eager backward
对于索引体系中单`Ellipsis,None,tuple()`的getitem 反向计算，由于前向结果与前向输出share buffer且numel一致，因此反向梯度也是与初始梯度numel一致数值一致的tensor，可以不用再进行gpu拷贝构造，使用share buffer进行加速。
该pr可以使这几种情况的加速比从10+降至1以内。