### PR TITLE
[0-size Tensor No.247、329] Add 0-size Tensor support for repeat_interleave

### DIFF
--- a/paddle/phi/kernels/cpu/repeat_interleave_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/repeat_interleave_grad_kernel.cc
@@ -79,6 +79,10 @@ void RepeatInterleaveGradKernel(const Context& ctx,
                                 int repeats,
                                 int dim,
                                 DenseTensor* x_grad) {
+  if (x_grad && x_grad->numel() == 0) {
+    ctx.template Alloc<T>(x_grad);
+    return;
+  }
   auto input_dim = x_grad->dims();
   if (dim < 0) {
     dim += input_dim.size();

--- a/paddle/phi/kernels/impl/repeat_interleave_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/repeat_interleave_grad_kernel_impl.h
@@ -164,6 +164,10 @@ void RepeatInterleaveGradKernel(const Context& ctx,
                                 int repeats,
                                 int dim,
                                 DenseTensor* x_grad) {
+  if (x_grad && x_grad->numel() == 0) {
+    ctx.template Alloc<T>(x_grad);
+    return;
+  }
   auto input_dim = x_grad->dims();
   if (dim < 0) {
     dim += input_dim.size();

--- a/paddle/phi/kernels/impl/repeat_interleave_kernel_impl.h
+++ b/paddle/phi/kernels/impl/repeat_interleave_kernel_impl.h
@@ -62,7 +62,10 @@ void RepeatInterleaveKernel(const Context& ctx,
                     0,
                     common::errors::InvalidArgument(
                         "repeats must grater than 0, but got %d", repeats));
-
+  if (out && out->numel() == 0) {
+    ctx.template Alloc<T>(out);
+    return;
+  }
   auto place = ctx.GetPlace();
   auto cpu_place = phi::CPUPlace();
 

--- a/paddle/phi/kernels/xpu/repeat_interleave_kernel.cc
+++ b/paddle/phi/kernels/xpu/repeat_interleave_kernel.cc
@@ -29,6 +29,10 @@ void RepeatInterleaveKernel(const Context& ctx,
                     0,
                     common::errors::InvalidArgument(
                         "repeats must grater than 0, but got %d", repeats));
+  if (out && out->numel() == 0) {
+    ctx.template Alloc<T>(out);
+    return;
+  }
   using XPUType = typename XPUTypeTrait<T>::Type;
 
   auto input_dim = x.dims();

--- a/test/legacy_test/test_repeat_interleave_op.py
+++ b/test/legacy_test/test_repeat_interleave_op.py
@@ -101,12 +101,11 @@ class TestRepeatInterleaveOp2(OpTest):
         self.check_grad(['X'], 'Out', check_pir=True)
 
 
-class TestRepeatInterleaveOp_ZeroSize(TestRepeatInterleaveOp):
+class TestRepeatInterleaveOp_ZeroSize(TestRepeatInterleaveOp2):
     def init_dtype_type(self):
         self.dim = 1
         self.x_type = np.float64
-        self.index_type = np.int64
-        self.x_shape = (0, 4, 5)
+        self.x_shape = (8, 0, 5)
         self.index_size = self.x_shape[self.dim]
 
 

--- a/test/legacy_test/test_repeat_interleave_op.py
+++ b/test/legacy_test/test_repeat_interleave_op.py
@@ -101,6 +101,15 @@ class TestRepeatInterleaveOp2(OpTest):
         self.check_grad(['X'], 'Out', check_pir=True)
 
 
+class TestRepeatInterleaveOp_ZeroSize(TestRepeatInterleaveOp):
+    def init_dtype_type(self):
+        self.dim = 1
+        self.x_type = np.float64
+        self.index_type = np.int64
+        self.x_shape = (0, 4, 5)
+        self.index_size = self.x_shape[self.dim]
+
+
 class TestIndexSelectAPI(unittest.TestCase):
     def input_data(self):
         self.data_zero_dim_x = np.array(0.5).astype('float32')


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->
[0-size Tensor No.247、329] Add 0-size Tensor support for repeat_interleave

修改前向和反向
infermeta没有修改
kernel 修改cpu/gpu/xpu

PaddleAPITest 测试通过
![image](https://github.com/user-attachments/assets/a900488f-cfaf-429c-8b83-7b2c81274cb2)
