### PR TITLE
[0-size Tensor No.20、22、54、56、242、301、186、212、178、226] Add 0-size Tensor support for polygamma/bitwise_not

### DIFF
--- a/test/legacy_test/test_activation_op_zero_size.py
+++ b/test/legacy_test/test_activation_op_zero_size.py
@@ -28,9 +28,13 @@ from test_activation_op import (
     TestExpFp32_Prim,
     TestExpm1,
     TestFloor,
+    TestHardSwish,
+    TestLeakyRelu,
     TestLogSigmoid,
     TestReciprocal,
     TestRelu,
+    TestRelu6,
+    TestRound,
     TestRsqrt,
     TestSigmoid,
     TestSilu,
@@ -39,6 +43,7 @@ from test_activation_op import (
     TestSoftsign,
     TestSqrt,
     TestSquare,
+    TestSwish,
     TestTan,
     TestTanh,
     TestTanhshrink,
@@ -100,6 +105,11 @@ create_test_zero_size_class(TestFloor)
 create_test_zero_size_class(TestCeil)
 create_test_zero_size_class(TestExpFp32_Prim)
 create_test_zero_size_class(TestExpm1)
+create_test_zero_size_class(TestLeakyRelu)
+create_test_zero_size_class(TestRelu6)
+create_test_zero_size_class(TestRound)
+create_test_zero_size_class(TestHardSwish)
+create_test_zero_size_class(TestSwish)
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/legacy_test/test_activation_op_zero_size.py
+++ b/test/legacy_test/test_activation_op_zero_size.py
@@ -34,7 +34,6 @@ from test_activation_op import (
     TestReciprocal,
     TestRelu,
     TestRelu6,
-    TestRound,
     TestRsqrt,
     TestSigmoid,
     TestSilu,
@@ -107,7 +106,6 @@ create_test_zero_size_class(TestExpFp32_Prim)
 create_test_zero_size_class(TestExpm1)
 create_test_zero_size_class(TestLeakyRelu)
 create_test_zero_size_class(TestRelu6)
-create_test_zero_size_class(TestRound)
 create_test_zero_size_class(TestHardSwish)
 create_test_zero_size_class(TestSwish)
 

--- a/test/legacy_test/test_activation_op_zero_size.py
+++ b/test/legacy_test/test_activation_op_zero_size.py
@@ -31,7 +31,6 @@ from test_activation_op import (
     TestLogSigmoid,
     TestReciprocal,
     TestRelu,
-    TestRelu6,
     TestRsqrt,
     TestSigmoid,
     TestSilu,
@@ -40,7 +39,6 @@ from test_activation_op import (
     TestSoftsign,
     TestSqrt,
     TestSquare,
-    TestSwish,
     TestTan,
     TestTanh,
     TestTanhshrink,
@@ -102,8 +100,6 @@ create_test_zero_size_class(TestFloor)
 create_test_zero_size_class(TestCeil)
 create_test_zero_size_class(TestExpFp32_Prim)
 create_test_zero_size_class(TestExpm1)
-create_test_zero_size_class(TestRelu6)
-create_test_zero_size_class(TestSwish)
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/legacy_test/test_activation_op_zero_size.py
+++ b/test/legacy_test/test_activation_op_zero_size.py
@@ -25,10 +25,13 @@ from test_activation_op import (
     TestCeil,
     TestCos,
     TestCosh,
+    TestExpFp32_Prim,
+    TestExpm1,
     TestFloor,
     TestLogSigmoid,
     TestReciprocal,
     TestRelu,
+    TestRelu6,
     TestRsqrt,
     TestSigmoid,
     TestSilu,
@@ -96,7 +99,9 @@ create_test_zero_size_class(TestSigmoid)
 create_test_zero_size_class(TestLogSigmoid)
 create_test_zero_size_class(TestFloor)
 create_test_zero_size_class(TestCeil)
-
+create_test_zero_size_class(TestExpFp32_Prim)
+create_test_zero_size_class(TestExpm1)
+create_test_zero_size_class(TestRelu6)
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/legacy_test/test_activation_op_zero_size.py
+++ b/test/legacy_test/test_activation_op_zero_size.py
@@ -40,6 +40,7 @@ from test_activation_op import (
     TestSoftsign,
     TestSqrt,
     TestSquare,
+    TestSwish,
     TestTan,
     TestTanh,
     TestTanhshrink,
@@ -102,6 +103,7 @@ create_test_zero_size_class(TestCeil)
 create_test_zero_size_class(TestExpFp32_Prim)
 create_test_zero_size_class(TestExpm1)
 create_test_zero_size_class(TestRelu6)
+create_test_zero_size_class(TestSwish)
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/legacy_test/test_bitwise_op.py
+++ b/test/legacy_test/test_bitwise_op.py
@@ -392,6 +392,11 @@ class TestBitwiseNot_ZeroDim(TestBitwiseNot):
         self.x_shape = []
 
 
+class TestBitwiseNot_ZeroSize(TestBitwiseNot):
+    def init_shape(self):
+        self.x_shape = [0, 3, 4, 5]
+
+
 class TestBitwiseNotUInt8(TestBitwiseNot):
     def init_dtype(self):
         self.dtype = np.uint8

--- a/test/legacy_test/test_polygamma_op.py
+++ b/test/legacy_test/test_polygamma_op.py
@@ -217,5 +217,25 @@ class TestPolygammaOp(OpTest):
         )
 
 
+class TestPolygammaOp_ZeroSize(TestPolygammaOp):
+
+    def init_config(self):
+        self.dtype = np.float64
+        self.order = 1
+        rand_case = np.random.randn(0).astype(self.dtype)
+        int_case = np.random.randint(low=1, high=100, size=0).astype(self.dtype)
+        self.case = np.concatenate([rand_case, int_case])
+        self.inputs = {'x': self.case}
+        self.attrs = {'n': self.order}
+        self.target = ref_polygamma(self.inputs['x'], self.order)
+
+    def test_check_grad(self):
+        self.check_grad(
+            ['x'],
+            'out',
+            check_pir=True,
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->
bitwise_invert 是 bitwise_not 别名
![image](https://github.com/user-attachments/assets/f02ae240-2e0c-4ed0-9a92-a9edbf55d508)

增加单测
bitwise_not 
polygamma 

复用test_activation_op_zero_size.py单测添加
expm1 
exp 
leaky_relu
relu6
hardswish
swish


PaddleAPITest 测试除round在cpu下不支持float16外，其他测试通过，增加单测
GPU测试
polygamma
![image](https://github.com/user-attachments/assets/f774d041-cf0a-46d7-9e8f-28434e94cec4)
bitwise_not
![image](https://github.com/user-attachments/assets/4f9a3215-2737-4ae6-9c1f-f47adacfc704)
expm1
![image](https://github.com/user-attachments/assets/4c585e97-6985-42da-bfa6-67988c52bfbc)
exp
![image](https://github.com/user-attachments/assets/69991c36-09a4-4c94-b8b2-0baa72bdd17b)
leaky_relu
![image](https://github.com/user-attachments/assets/35d9100e-528f-4a76-8e97-289ddce412ac)
relu6
![image](https://github.com/user-attachments/assets/493661fa-0d49-4953-becd-a77ebae4feb4)
hardswish
![image](https://github.com/user-attachments/assets/132081d4-8c8a-44ac-927c-20fb66aa4c9f)
swish
![image](https://github.com/user-attachments/assets/e17c162d-0c23-4ea1-a114-4cf93945b80d)

CPU测试
polygamma
![image](https://github.com/user-attachments/assets/08a14f25-44b6-4e6f-96ee-f1a45e0c5703)
bitwise_not
![image](https://github.com/user-attachments/assets/5e47a19e-9ff6-4872-934c-34c0a3ca3efc)
expm1
![image](https://github.com/user-attachments/assets/74de92ed-1fdf-4bdc-bf01-9551446c400b)
exp
![image](https://github.com/user-attachments/assets/80b4dc4f-a7ed-44c3-b650-b5d908b9f20e)
leaky_relu
![image](https://github.com/user-attachments/assets/af200fef-2532-448a-be54-5829c2ee806e)
relu6
![image](https://github.com/user-attachments/assets/40d75bab-744b-4ec0-8e43-c1fb45a32ac7)
hardswish
![image](https://github.com/user-attachments/assets/0a07fa20-7bfc-4727-8b26-906260c46b18)
swish
![image](https://github.com/user-attachments/assets/8e0b9549-0c1b-4574-887b-7ab562b77e68)

