### PR TITLE
[XPU]Support complex for multiply

### DIFF
--- a/paddle/phi/backends/xpu/xpu3_op_list.cc
+++ b/paddle/phi/backends/xpu/xpu3_op_list.cc
@@ -460,11 +460,17 @@ XPUOpMap& get_kl3_ops() {
       {"elementwise_mul_grad",
        XPUKernelSet({phi::DataType::FLOAT32,
                      phi::DataType::FLOAT16,
+#ifdef PADDLE_WITH_XPU_FFT
+                     phi::DataType::COMPLEX64,
+#endif
                      phi::DataType::BFLOAT16})},
       {"elementwise_mul",
        XPUKernelSet({phi::DataType::FLOAT32,
                      phi::DataType::FLOAT16,
                      phi::DataType::BFLOAT16,
+#ifdef PADDLE_WITH_XPU_FFT
+                     phi::DataType::COMPLEX64,
+#endif
                      phi::DataType::INT32,
                      phi::DataType::INT64})},
       {"elementwise_pow",

--- a/paddle/phi/kernels/xpu/elementwise_multiply_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/elementwise_multiply_grad_kernel.cc
@@ -19,6 +19,11 @@
 
 #include "paddle/phi/backends/xpu/xpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/complex_kernel.h"
+#include "paddle/phi/kernels/elementwise_add_kernel.h"
+#include "paddle/phi/kernels/elementwise_multiply_kernel.h"
+#include "paddle/phi/kernels/elementwise_subtract_kernel.h"
+#include "paddle/phi/kernels/expand_grad_kernel.h"
 #include "paddle/phi/kernels/funcs/elementwise_base.h"
 #include "paddle/phi/kernels/xpu/elementwise.h"
 
@@ -50,6 +55,94 @@ void MultiplyGradKernel(const Context& dev_ctx,
   XPUElementwiseGrad<T, XPUType>(dev_ctx, x, y, dout, axis, dx, dy, f, true);
 }
 
+#ifdef PADDLE_WITH_XPU_FFT
+template <>
+void MultiplyGradKernel<phi::dtype::complex<float>, XPUContext>(
+    const XPUContext& dev_ctx,
+    const DenseTensor& x,
+    const DenseTensor& y,
+    const DenseTensor& dout,
+    int axis,
+    DenseTensor* dx,
+    DenseTensor* dy) {
+  using T = phi::dtype::complex<float>;
+  funcs::ElementwiseGradPreProcess(dout, dx);
+  // The current complex number implementation uses separate real/imaginary
+  // parts,resulting in redundant operations and performance
+  // penalties.Optimization should address this in future iterations.
+  DenseTensor dout_real = Real<T, XPUContext>(dev_ctx, dout);
+  DenseTensor dout_imag = Imag<T, XPUContext>(dev_ctx, dout);
+
+  if (dx) {
+    DenseTensor y_real = Real<T, XPUContext>(dev_ctx, y);
+    DenseTensor y_imag = Imag<T, XPUContext>(dev_ctx, y);
+    DenseTensor dx_real = Add<float, XPUContext>(
+        dev_ctx,
+        Multiply<float, XPUContext>(dev_ctx, dout_real, y_real),
+        Multiply<float, XPUContext>(dev_ctx, dout_imag, y_imag));
+    DenseTensor dx_imag = Subtract<float, XPUContext>(
+        dev_ctx,
+        Multiply<float, XPUContext>(dev_ctx, dout_imag, y_real),
+        Multiply<float, XPUContext>(dev_ctx, dout_real, y_imag));
+    dev_ctx.template Alloc<T>(dx);
+    if (x.dims() == dout.dims()) {
+      phi::ComplexKernel<float>(dev_ctx, dx_real, dx_imag, dx);
+    } else {
+      DenseTensor dx_real_expanded, dx_imag_expanded;
+      dx_real_expanded.Resize(dx->dims());
+      dx_imag_expanded.Resize(dx->dims());
+      ExpandGradKernel<float, XPUContext>(
+          dev_ctx,
+          x,
+          dx_real,
+          phi::IntArray(phi::vectorize(x.dims())),
+          &dx_real_expanded);
+      ExpandGradKernel<float, XPUContext>(
+          dev_ctx,
+          x,
+          dx_imag,
+          phi::IntArray(phi::vectorize(x.dims())),
+          &dx_imag_expanded);
+      phi::ComplexKernel<float>(
+          dev_ctx, dx_real_expanded, dx_imag_expanded, dx);
+    }
+  }
+  if (dy) {
+    DenseTensor x_real = Real<T, XPUContext>(dev_ctx, x);
+    DenseTensor x_imag = Imag<T, XPUContext>(dev_ctx, x);
+    DenseTensor dy_real = Add<float, XPUContext>(
+        dev_ctx,
+        Multiply<float, XPUContext>(dev_ctx, dout_real, x_real),
+        Multiply<float, XPUContext>(dev_ctx, dout_imag, x_imag));
+    DenseTensor dy_imag = Subtract<float, XPUContext>(
+        dev_ctx,
+        Multiply<float, XPUContext>(dev_ctx, dout_imag, x_real),
+        Multiply<float, XPUContext>(dev_ctx, dout_real, x_imag));
+    dev_ctx.template Alloc<T>(dy);
+    if (y.dims() == dout.dims()) {
+      phi::ComplexKernel<float>(dev_ctx, dy_real, dy_imag, dy);
+    } else {
+      DenseTensor dy_real_expanded, dy_imag_expanded;
+      dy_real_expanded.Resize(dy->dims());
+      dy_imag_expanded.Resize(dy->dims());
+      ExpandGradKernel<float, XPUContext>(
+          dev_ctx,
+          y,
+          dy_real,
+          phi::IntArray(phi::vectorize(y.dims())),
+          &dy_real_expanded);
+      ExpandGradKernel<float, XPUContext>(
+          dev_ctx,
+          y,
+          dy_imag,
+          phi::IntArray(phi::vectorize(y.dims())),
+          &dy_imag_expanded);
+      phi::ComplexKernel<float>(
+          dev_ctx, dy_real_expanded, dy_imag_expanded, dy);
+    }
+  }
+}
+#endif
 }  // namespace phi
 
 PD_REGISTER_KERNEL(multiply_grad,
@@ -58,4 +151,8 @@ PD_REGISTER_KERNEL(multiply_grad,
                    phi::MultiplyGradKernel,
                    phi::dtype::float16,
                    phi::dtype::bfloat16,
-                   float) {}
+#ifdef PADDLE_WITH_XPU_FFT
+                   phi::dtype::complex<float>,
+#endif
+                   float) {
+}

--- a/paddle/phi/kernels/xpu/elementwise_multiply_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/elementwise_multiply_grad_kernel.cc
@@ -24,6 +24,7 @@
 #include "paddle/phi/kernels/elementwise_multiply_kernel.h"
 #include "paddle/phi/kernels/elementwise_subtract_kernel.h"
 #include "paddle/phi/kernels/expand_grad_kernel.h"
+#include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/funcs/elementwise_base.h"
 #include "paddle/phi/kernels/xpu/elementwise.h"
 
@@ -38,6 +39,25 @@ void MultiplyGradKernel(const Context& dev_ctx,
                         DenseTensor* dx,
                         DenseTensor* dy) {
   using XPUType = typename XPUTypeTrait<T>::Type;
+  if (dout.numel() == 0) {
+    if (dx) {
+      if (dx->numel() == 0) {
+        dev_ctx.template Alloc<T>(dx);
+      } else {
+        phi::Full<T, Context>(
+            dev_ctx, phi::IntArray(common::vectorize(dx->dims())), 0, dx);
+      }
+    }
+    if (dy) {
+      if (dy->numel() == 0) {
+        dev_ctx.template Alloc<T>(dy);
+      } else {
+        phi::Full<T, Context>(
+            dev_ctx, phi::IntArray(common::vectorize(dy->dims())), 0, dy);
+      }
+    }
+    return;
+  }
   funcs::ElementwiseGradPreProcess(dout, dx);
   auto f = [](xpu::Context* ctx,
               const XPUType* x,
@@ -66,6 +86,25 @@ void MultiplyGradKernel<phi::dtype::complex<float>, XPUContext>(
     DenseTensor* dx,
     DenseTensor* dy) {
   using T = phi::dtype::complex<float>;
+  if (dout.numel() == 0) {
+    if (dx) {
+      if (dx->numel() == 0) {
+        dev_ctx.template Alloc<T>(dx);
+      } else {
+        phi::Full<T, XPUContext>(
+            dev_ctx, phi::IntArray(common::vectorize(dx->dims())), T(0), dx);
+      }
+    }
+    if (dy) {
+      if (dy->numel() == 0) {
+        dev_ctx.template Alloc<T>(dy);
+      } else {
+        phi::Full<T, XPUContext>(
+            dev_ctx, phi::IntArray(common::vectorize(dy->dims())), T(0), dy);
+      }
+    }
+    return;
+  }
   funcs::ElementwiseGradPreProcess(dout, dx);
   // The current complex number implementation uses separate real/imaginary
   // parts,resulting in redundant operations and performance

--- a/paddle/phi/kernels/xpu/elementwise_multiply_kernel.cc
+++ b/paddle/phi/kernels/xpu/elementwise_multiply_kernel.cc
@@ -19,6 +19,9 @@
 
 #include "paddle/phi/backends/xpu/xpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/complex_kernel.h"
+#include "paddle/phi/kernels/elementwise_add_kernel.h"
+#include "paddle/phi/kernels/elementwise_subtract_kernel.h"
 #include "paddle/phi/kernels/funcs/elementwise_base.h"
 #include "paddle/phi/kernels/xpu/elementwise.h"
 
@@ -42,6 +45,33 @@ void MultiplyKernel(const Context& dev_ctx,
   XPUElementwise<T, XPUType>(dev_ctx, x, y, -1, out, f);
 }
 
+#ifdef PADDLE_WITH_XPU_FFT
+template <>
+void MultiplyKernel<phi::dtype::complex<float>, XPUContext>(
+    const XPUContext& dev_ctx,
+    const DenseTensor& x,
+    const DenseTensor& y,
+    DenseTensor* out) {
+  using T = phi::dtype::complex<float>;
+  // The current complex number implementation uses separate real/imaginary
+  // parts,resulting in redundant operations and performance
+  // penalties.Optimization should address this in future iterations.
+  const DenseTensor x_real = Real<T, XPUContext>(dev_ctx, x);
+  const DenseTensor x_imag = Imag<T, XPUContext>(dev_ctx, x);
+  const DenseTensor y_real = Real<T, XPUContext>(dev_ctx, y);
+  const DenseTensor y_imag = Imag<T, XPUContext>(dev_ctx, y);
+  DenseTensor real_out = Subtract<float, XPUContext>(
+      dev_ctx,
+      Multiply<float, XPUContext>(dev_ctx, x_real, y_real),
+      Multiply<float, XPUContext>(dev_ctx, x_imag, y_imag));
+  DenseTensor imag_out = Add<float, XPUContext>(
+      dev_ctx,
+      Multiply<float, XPUContext>(dev_ctx, x_real, y_imag),
+      Multiply<float, XPUContext>(dev_ctx, x_imag, y_real));
+  phi::ComplexKernel<float>(dev_ctx, real_out, imag_out, out);
+}
+#endif
+
 }  // namespace phi
 
 PD_REGISTER_KERNEL(multiply,
@@ -50,6 +80,10 @@ PD_REGISTER_KERNEL(multiply,
                    phi::MultiplyKernel,
                    phi::dtype::float16,
                    phi::dtype::bfloat16,
+#ifdef PADDLE_WITH_XPU_FFT
+                   phi::dtype::complex<float>,
+#endif
                    float,
                    int,
-                   int64_t) {}
+                   int64_t) {
+}

--- a/paddle/phi/kernels/xpu/elementwise_multiply_kernel.cc
+++ b/paddle/phi/kernels/xpu/elementwise_multiply_kernel.cc
@@ -33,6 +33,10 @@ void MultiplyKernel(const Context& dev_ctx,
                     const DenseTensor& y,
                     DenseTensor* out) {
   using XPUType = typename XPUTypeTrait<T>::Type;
+  if (out->numel() == 0) {
+    dev_ctx.template Alloc<T>(out);
+    return;
+  }
   auto f = [](xpu::Context* ctx,
               const XPUType* x,
               const XPUType* y,
@@ -53,6 +57,10 @@ void MultiplyKernel<phi::dtype::complex<float>, XPUContext>(
     const DenseTensor& y,
     DenseTensor* out) {
   using T = phi::dtype::complex<float>;
+  if (out->numel() == 0) {
+    dev_ctx.template Alloc<T>(out);
+    return;
+  }
   // The current complex number implementation uses separate real/imaginary
   // parts,resulting in redundant operations and performance
   // penalties.Optimization should address this in future iterations.

--- a/test/xpu/test_elementwise_mul_op_xpu.py
+++ b/test/xpu/test_elementwise_mul_op_xpu.py
@@ -206,6 +206,21 @@ class XPUTestElementwiseMulOp(XPUOpTestWrapper):
             self.x = self.gen_data_depend_on_dtype([30, 3, 1, 5])
             self.y = self.gen_data_depend_on_dtype([30, 1, 4, 1])
 
+    class TestElementwiseMulComplexOpZeroSize1(ElementwiseMulOp):
+        def init_data(self):
+            self.x = self.gen_data_depend_on_dtype([0, 2, 3])
+            self.y = self.gen_data_depend_on_dtype([0, 1, 1])
+
+    class TestElementwiseMulComplexOpZeroSize2(ElementwiseMulOp):
+        def init_data(self):
+            self.x = self.gen_data_depend_on_dtype([2, 0, 3])
+            self.y = self.gen_data_depend_on_dtype([1, 0, 1])
+
+    class TestElementwiseMulComplexOpZeroSize3(ElementwiseMulOp):
+        def init_data(self):
+            self.x = self.gen_data_depend_on_dtype([2, 0, 0])
+            self.y = self.gen_data_depend_on_dtype([1, 0, 0])
+
     class TestElementwiseMulOp_xsize_lessthan_ysize(ElementwiseMulOp):
         def init_data(self):
             self.x = self.gen_data_depend_on_dtype([10, 10])
@@ -234,8 +249,153 @@ class XPUTestElementwiseMulOp(XPUOpTestWrapper):
 
 
 support_types = get_xpu_op_support_types('elementwise_mul')
-for stype in support_types:
+real_types = [t for t in support_types if t != 'complex64']
+for stype in real_types:
     create_test_class(globals(), XPUTestElementwiseMulOp, stype)
+
+if 'complex64' in support_types:
+
+    class ElementwiseMulComplexOp(XPUTestElementwiseMulOp.ElementwiseMulOp):
+        def init_kernel_type(self):
+            self.use_mkldnn = False
+
+        def setUp(self):
+            self.op_type = 'elementwise_mul'
+            self.use_xpu = True
+            self.cal_x = None
+            self.cal_y = None
+            self.dtype = np.complex64
+            self.axis = -1
+            self.init_data()
+            self.gen_output()
+            self.init_input_output()
+            self.init_kernel_type()
+            self.init_axis()
+
+        def init_input_output(self):
+            self.x = self.x.astype(self.dtype)
+            self.y = self.y.astype(self.dtype)
+
+            self.inputs = {
+                'X': self.x,
+                'Y': self.y,
+            }
+            self.outputs = {'Out': self.out}
+            self.attrs = {'axis': self.axis, 'use_mkldnn': self.use_mkldnn}
+
+        def gen_output(self):
+            if self.cal_x is None:
+                self.cal_x = self.x
+            if self.cal_y is None:
+                self.cal_y = self.y
+            self.out = np.multiply(
+                self.cal_x.astype(self.dtype), self.cal_y.astype(self.dtype)
+            )
+
+        def gen_data_depend_on_dtype(self, shape):
+            real_part = np.random.uniform(0.1, 1, size=shape)
+            imag_part = np.random.uniform(0.1, 1, size=shape)
+            return real_part + 1j * imag_part
+
+        def test_check_output(self):
+            if paddle.is_compiled_with_xpu():
+                place = paddle.XPUPlace(0)
+                self.check_output_with_place(place, check_dygraph=False)
+
+        def test_check_grad_normal(self):
+            if paddle.is_compiled_with_xpu():
+                place = paddle.XPUPlace(0)
+                self.check_grad_with_place(
+                    place,
+                    ['X', 'Y'],
+                    'Out',
+                    check_dygraph=False,
+                )
+
+        def test_check_grad_ignore_x(self):
+            if paddle.is_compiled_with_xpu():
+                place = paddle.XPUPlace(0)
+                self.check_grad_with_place(
+                    place,
+                    ['Y'],
+                    'Out',
+                    no_grad_set=set("X"),
+                    check_dygraph=False,
+                )
+
+        def test_check_grad_ignore_y(self):
+            if paddle.is_compiled_with_xpu():
+                place = paddle.XPUPlace(0)
+                self.check_grad_with_place(
+                    place,
+                    ['X'],
+                    'Out',
+                    no_grad_set=set('Y'),
+                    check_dygraph=False,
+                )
+
+    class TestElementwiseMulComplexOp_broadcast_0(ElementwiseMulComplexOp):
+        def init_data(self):
+            self.x = self.gen_data_depend_on_dtype([5, 2, 3])
+            self.y = self.gen_data_depend_on_dtype([5, 1, 1])
+
+    class TestElementwiseMulComplexOp_broadcast_1(ElementwiseMulComplexOp):
+        def init_data(self):
+            self.x = self.gen_data_depend_on_dtype([2, 100, 3])
+            self.y = self.gen_data_depend_on_dtype([1, 100, 1])
+
+    class TestElementwiseMulComplexOp_broadcast_2(ElementwiseMulComplexOp):
+        def init_data(self):
+            self.x = self.gen_data_depend_on_dtype([2, 3, 100])
+            self.y = self.gen_data_depend_on_dtype([1, 1, 100])
+
+    class TestElementwiseMulComplexOp_broadcast_3(ElementwiseMulComplexOp):
+        def init_data(self):
+            self.x = self.gen_data_depend_on_dtype([2, 10, 12, 3])
+            self.y = self.gen_data_depend_on_dtype([1, 10, 12, 1])
+
+    class TestElementwiseMulComplexOp_broadcast_4(ElementwiseMulComplexOp):
+        def init_data(self):
+            self.x = self.gen_data_depend_on_dtype([10, 2, 11])
+            self.y = self.gen_data_depend_on_dtype([10, 1, 11])
+
+    class TestElementwiseMulComplexOp_broadcast_5(ElementwiseMulComplexOp):
+        def init_data(self):
+            self.x = self.gen_data_depend_on_dtype([10, 4, 2, 3])
+            self.y = self.gen_data_depend_on_dtype([10, 4, 1, 3])
+
+    class TestElementwiseMulComplexOp_commonuse_1(ElementwiseMulComplexOp):
+        def init_data(self):
+            self.x = self.gen_data_depend_on_dtype([2, 3, 100])
+            self.y = self.gen_data_depend_on_dtype([1, 1, 100])
+
+    class TestElementwiseMulComplexOp_commonuse_2(ElementwiseMulComplexOp):
+        def init_data(self):
+            self.x = self.gen_data_depend_on_dtype([30, 3, 1, 5])
+            self.y = self.gen_data_depend_on_dtype([30, 1, 4, 1])
+
+    class TestElementwiseMulComplexOpZeroSize1(ElementwiseMulComplexOp):
+        def init_data(self):
+            self.x = self.gen_data_depend_on_dtype([0, 2, 3])
+            self.y = self.gen_data_depend_on_dtype([0, 1, 1])
+
+    class TestElementwiseMulComplexOpZeroSize2(ElementwiseMulComplexOp):
+        def init_data(self):
+            self.x = self.gen_data_depend_on_dtype([2, 0, 3])
+            self.y = self.gen_data_depend_on_dtype([1, 0, 1])
+
+    class TestElementwiseMulComplexOpZeroSize3(ElementwiseMulComplexOp):
+        def init_data(self):
+            self.x = self.gen_data_depend_on_dtype([2, 0, 0])
+            self.y = self.gen_data_depend_on_dtype([1, 0, 0])
+
+    class TestElementwiseMulComplexOp_xsize_lessthan_ysize(
+        ElementwiseMulComplexOp
+    ):
+        def init_data(self):
+            self.x = self.gen_data_depend_on_dtype([10, 10])
+            self.y = self.gen_data_depend_on_dtype([2, 2, 10, 10])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/xpu/test_elementwise_mul_op_xpu.py
+++ b/test/xpu/test_elementwise_mul_op_xpu.py
@@ -114,7 +114,7 @@ class XPUTestElementwiseMulOp(XPUOpTestWrapper):
             self.y = self.gen_data_depend_on_dtype([13, 17])
 
         def init_input_output(self):
-            if self.dtype == np.uint16:
+            if self.dtype == np.uint16 and self.x.size > 0 and self.y.size > 0:
                 self.x = convert_float_to_uint16(self.x)
                 self.y = convert_float_to_uint16(self.y)
             else:
@@ -206,17 +206,17 @@ class XPUTestElementwiseMulOp(XPUOpTestWrapper):
             self.x = self.gen_data_depend_on_dtype([30, 3, 1, 5])
             self.y = self.gen_data_depend_on_dtype([30, 1, 4, 1])
 
-    class TestElementwiseMulComplexOpZeroSize1(ElementwiseMulOp):
+    class TestElementwiseMulZeroSize1(ElementwiseMulOp):
         def init_data(self):
             self.x = self.gen_data_depend_on_dtype([0, 2, 3])
             self.y = self.gen_data_depend_on_dtype([0, 1, 1])
 
-    class TestElementwiseMulComplexOpZeroSize2(ElementwiseMulOp):
+    class TestElementwiseMulZeroSize2(ElementwiseMulOp):
         def init_data(self):
             self.x = self.gen_data_depend_on_dtype([2, 0, 3])
             self.y = self.gen_data_depend_on_dtype([1, 0, 1])
 
-    class TestElementwiseMulComplexOpZeroSize3(ElementwiseMulOp):
+    class TestElementwiseMulZeroSize3(ElementwiseMulOp):
         def init_data(self):
             self.x = self.gen_data_depend_on_dtype([2, 0, 0])
             self.y = self.gen_data_depend_on_dtype([1, 0, 0])
@@ -300,7 +300,7 @@ if 'complex64' in support_types:
         def test_check_output(self):
             if paddle.is_compiled_with_xpu():
                 place = paddle.XPUPlace(0)
-                self.check_output_with_place(place, check_dygraph=False)
+                self.check_output_with_place(place)
 
         def test_check_grad_normal(self):
             if paddle.is_compiled_with_xpu():
@@ -309,7 +309,6 @@ if 'complex64' in support_types:
                     place,
                     ['X', 'Y'],
                     'Out',
-                    check_dygraph=False,
                 )
 
         def test_check_grad_ignore_x(self):
@@ -320,7 +319,6 @@ if 'complex64' in support_types:
                     ['Y'],
                     'Out',
                     no_grad_set=set("X"),
-                    check_dygraph=False,
                 )
 
         def test_check_grad_ignore_y(self):
@@ -331,7 +329,6 @@ if 'complex64' in support_types:
                     ['X'],
                     'Out',
                     no_grad_set=set('Y'),
-                    check_dygraph=False,
                 )
 
     class TestElementwiseMulComplexOp_broadcast_0(ElementwiseMulComplexOp):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Custom Device 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
为XPU端multiply算子添加complex64类型，支持自动广播 
复数乘法为(a + bi)(c + di) = (ac - bd) + (ad + bc)i 
前向计算为 z₁ * z₂ =  c
反向计算为 dz₁ = dc * z₂    dz₂ = dc * z₁

Pcard-75624