### PR TITLE
[0-size Tensor] Add 0-size Tensor support for paddle.multiply、paddle.__mul___

### DIFF
--- a/paddle/phi/kernels/xpu/elementwise.h
+++ b/paddle/phi/kernels/xpu/elementwise.h
@@ -198,9 +198,9 @@ void XPUElementwiseGrad(const XPUContext& dev_ctx,
     dy_data = dev_ctx.template Alloc<T>(dy);
   }
   if (dz.numel() == 0) {
-    phi::Full<T, Context>(
+    phi::Full<T, XPUContext>(
         dev_ctx, phi::IntArray(common::vectorize(dx->dims())), 0, dx);
-    phi::Full<T, Context>(
+    phi::Full<T, XPUContext>(
         dev_ctx, phi::IntArray(common::vectorize(dy->dims())), 0, dy);
     return;
   }

--- a/paddle/phi/kernels/xpu/elementwise.h
+++ b/paddle/phi/kernels/xpu/elementwise.h
@@ -22,8 +22,8 @@ limitations under the License. */
 #include "paddle/phi/backends/xpu/xpu_context.h"
 #include "paddle/phi/common/place.h"
 #include "paddle/phi/core/dense_tensor.h"
+#include "paddle/phi/kernels/full_kernel.h"
 #include "xpu/refactor/math.h"
-
 namespace phi {
 
 template <typename T, typename XPUType>
@@ -112,6 +112,9 @@ void XPUElementwise(const XPUContext& dev_ctx,
                                       const std::vector<int64_t>&,
                                       const std::vector<int64_t>&)> func) {
   dev_ctx.template Alloc<T>(z);
+  if (z->numel() == 0) {
+    return;
+  }
   const DDim& x_dims = x.dims();
   const DDim& y_dims = y.dims();
 
@@ -193,6 +196,13 @@ void XPUElementwiseGrad(const XPUContext& dev_ctx,
   }
   if (dy) {
     dy_data = dev_ctx.template Alloc<T>(dy);
+  }
+  if (dz.numel() == 0) {
+    phi::Full<T, Context>(
+        dev_ctx, phi::IntArray(common::vectorize(dx->dims())), 0, dx);
+    phi::Full<T, Context>(
+        dev_ctx, phi::IntArray(common::vectorize(dy->dims())), 0, dy);
+    return;
   }
 
   // use [1] to replace [], because xpu not support []


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
#### 存在的问题
- 问题1 
![image](https://github.com/user-attachments/assets/9e14a360-024f-4941-9fb0-45bbd665d17a)
遇到0-size Tensor时，y 反向梯度shape错误。原因是ElementwiseMulGrad   -->GetGradXAndYOut -->SumRawKernel,  但是https://github.com/PaddlePaddle/Paddle/pull/70379 对SumRawKernel进行了修改，让SumRawKernel重新对out Tensor的shape进行了推导和resize，进而导致了输出的维度被错误的reduce掉一个维度。

- 问题2
![6dc6dcdb904835da83327fc128bbec68](https://github.com/user-attachments/assets/2f8d43f4-e1df-424b-aff2-19e47443981a)
 
y为0 size Tensor，x为非0 size Tensor，x 的梯度存在错误。应该全是0。

- 问题3 
![image](https://github.com/user-attachments/assets/a53df00f-0d67-4045-b227-260132a82114)

xpu kernel 前向报错

##### 检查与修复
- paddle.multiply前向和反向的infermeta shape推导都正确
- 出现问题的只有gpu，cpu测试未发现上述问题
- 修复gpu multiply的反向kernel
- 添加单测
- paddleAPITest回测结果
![image](https://github.com/user-attachments/assets/f7cd7075-eccc-43cb-a4de-f57b0025698b)
除了一些非法参数输入，其余均通过。

pcard-67164
