### PR TITLE
[Custom] Support double dtype static_api_run_custom_op

### DIFF
--- a/paddle/fluid/pybind/manual_static_op_function.h
+++ b/paddle/fluid/pybind/manual_static_op_function.h
@@ -694,6 +694,12 @@ static PyObject *static_api_run_custom_op(PyObject *self,
       argument.AddAttribute(
           attr_name_and_type[0],
           pir::FloatAttribute::get(pir::IrContext::Instance(), float_attr));
+    } else if (attr_type_str == "double") {
+      double double_attr = CastPyArg2AttrDouble(obj, attr_start_idx + i);
+      custom_attrs.push_back(double_attr);  // NOLINT
+      argument.AddAttribute(
+          attr_name_and_type[0],
+          pir::DoubleAttribute::get(pir::IrContext::Instance(), double_attr));
     } else if (attr_type_str == "int64_t") {
       int64_t long_attr = CastPyArg2AttrLong(obj, attr_start_idx + i);
       custom_attrs.push_back(long_attr);  // NOLINT
@@ -761,7 +767,7 @@ static PyObject *static_api_run_custom_op(PyObject *self,
     } else {
       PADDLE_THROW(common::errors::Unimplemented(
           "Unsupported `%s` type value as custom attribute now. "
-          "Supported data types include `bool`, `int`, `float`, "
+          "Supported data types include `bool`, `int`, `float`, `double`, "
           "`int64_t`, `std::string`, `std::vector<int>`, "
           "`std::vector<float>`, `std::vector<int64_t>`, "
           "`std::vector<std::string>`, Please check whether "


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->
pcard-67164

模型导出时，支持自定义算子含有double类型的attribute，如下所示

<https://github.com/PFCCLab/Open3D/blob/fdefb248b975963bcbb670f385d4fe6b4820b2e4/cpp/open3d/ml/paddle/misc/FixedRadiusSearchOps.cpp#L57>