### PR TITLE
[0-size Tensor No.99、310] Add 0-size Tensor support for kthvalue

### DIFF
--- a/paddle/phi/kernels/cpu/kthvalue_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/kthvalue_grad_kernel.cc
@@ -56,6 +56,9 @@ void KthvalueGradKernel(const Context& dev_ctx,
   auto in_dims = x.dims();
   auto out_dims = indices.dims();
   T* x_grad_data = dev_ctx.template Alloc<T>(d_x);
+  if (d_x && d_x->numel() == 0) {
+    return;
+  }
 
   // For 0D Tensor
   if (in_dims.size() == 0) {

--- a/paddle/phi/kernels/cpu/kthvalue_kernel.cc
+++ b/paddle/phi/kernels/cpu/kthvalue_kernel.cc
@@ -85,6 +85,7 @@ void KthvalueKernel(const Context& dev_ctx,
         dev_ctx, phi::IntArray(common::vectorize(output->dims())), NAN, output);
     phi::Full<int64_t, Context>(
         dev_ctx, phi::IntArray(common::vectorize(indices->dims())), 0, indices);
+    return;
   }
   const auto& in_dims = x.dims();
   if (axis < 0) axis += in_dims.size();

--- a/paddle/phi/kernels/cpu/kthvalue_kernel.cc
+++ b/paddle/phi/kernels/cpu/kthvalue_kernel.cc
@@ -16,9 +16,9 @@
 
 #include "paddle/phi/backends/cpu/cpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/funcs/eigen/common.h"
 #include "paddle/phi/kernels/funcs/math_function.h"
-
 namespace phi {
 template <typename T, typename Type>
 static void getKthvalue(Type input_height,
@@ -80,6 +80,12 @@ void KthvalueKernel(const Context& dev_ctx,
                     bool keepdim,
                     DenseTensor* output,
                     DenseTensor* indices) {
+  if (x.numel() == 0) {
+    phi::Full<T, Context>(
+        ctx, phi::IntArray(common::vectorize(output->dims())), NAN, output);
+    phi::Full<int64_t, Context>(
+        ctx, phi::IntArray(common::vectorize(output->dims())), 0, output);
+  }
   const auto& in_dims = x.dims();
   if (axis < 0) axis += in_dims.size();
 

--- a/paddle/phi/kernels/cpu/kthvalue_kernel.cc
+++ b/paddle/phi/kernels/cpu/kthvalue_kernel.cc
@@ -82,9 +82,9 @@ void KthvalueKernel(const Context& dev_ctx,
                     DenseTensor* indices) {
   if (x.numel() == 0) {
     phi::Full<T, Context>(
-        ctx, phi::IntArray(common::vectorize(output->dims())), NAN, output);
+        dev_ctx, phi::IntArray(common::vectorize(output->dims())), NAN, output);
     phi::Full<int64_t, Context>(
-        ctx, phi::IntArray(common::vectorize(output->dims())), 0, output);
+        dev_ctx, phi::IntArray(common::vectorize(indices->dims())), 0, indices);
   }
   const auto& in_dims = x.dims();
   if (axis < 0) axis += in_dims.size();

--- a/paddle/phi/kernels/gpu/kthvalue_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/kthvalue_grad_kernel.cu
@@ -44,6 +44,10 @@ void KthvalueGradKernel(const Context& dev_ctx,
   const auto& in_dims = x.dims();
   auto out_dims = indices.dims();
   T* x_grad_data = dev_ctx.template Alloc<T>(d_x);
+  if (d_x && d_x->numel() == 0) {
+    return;
+  }
+
   // For 0D Tensor
   if (in_dims.size() == 0) {
     phi::funcs::set_constant(dev_ctx, d_x, static_cast<T>(1.0));

--- a/paddle/phi/kernels/gpu/kthvalue_kernel.cu
+++ b/paddle/phi/kernels/gpu/kthvalue_kernel.cu
@@ -166,6 +166,7 @@ void KthvalueKernel(const Context& dev_ctx,
         dev_ctx, phi::IntArray(common::vectorize(output->dims())), NAN, output);
     phi::Full<int64_t, Context>(
         dev_ctx, phi::IntArray(common::vectorize(indices->dims())), 0, indices);
+    return;
   }
 
   const auto& in_dims = x.dims();

--- a/paddle/phi/kernels/gpu/kthvalue_kernel.cu
+++ b/paddle/phi/kernels/gpu/kthvalue_kernel.cu
@@ -160,6 +160,13 @@ void KthvalueKernel(const Context& dev_ctx,
                     bool keepdim,
                     DenseTensor* output,
                     DenseTensor* indices) {
+  if (x.numel() == 0) {
+    phi::Full<T, Context>(
+        ctx, phi::IntArray(common::vectorize(output->dims())), NAN, output);
+    phi::Full<int64_t, Context>(
+        ctx, phi::IntArray(common::vectorize(output->dims())), 0, output);
+  }
+
   const auto& in_dims = x.dims();
   if (axis < 0) axis += in_dims.size();
   auto out_dims = output->dims();

--- a/paddle/phi/kernels/gpu/kthvalue_kernel.cu
+++ b/paddle/phi/kernels/gpu/kthvalue_kernel.cu
@@ -162,9 +162,9 @@ void KthvalueKernel(const Context& dev_ctx,
                     DenseTensor* indices) {
   if (x.numel() == 0) {
     phi::Full<T, Context>(
-        ctx, phi::IntArray(common::vectorize(output->dims())), NAN, output);
+        dev_ctx, phi::IntArray(common::vectorize(output->dims())), NAN, output);
     phi::Full<int64_t, Context>(
-        ctx, phi::IntArray(common::vectorize(output->dims())), 0, output);
+        dev_ctx, phi::IntArray(common::vectorize(indices->dims())), 0, indices);
   }
 
   const auto& in_dims = x.dims();

--- a/paddle/phi/kernels/gpu/kthvalue_kernel.cu
+++ b/paddle/phi/kernels/gpu/kthvalue_kernel.cu
@@ -16,6 +16,7 @@
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/common/amp_type_traits.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/funcs/eigen/common.h"
 #include "paddle/phi/kernels/funcs/eigen/eigen_function.h"
 #include "paddle/phi/kernels/funcs/math_function.h"

--- a/test/legacy_test/test_kthvalue_op.py
+++ b/test/legacy_test/test_kthvalue_op.py
@@ -43,13 +43,17 @@ class TestKthvalueOp(OpTest):
     def init_dtype(self):
         self.dtype = np.float64
 
+    def init_shape(self):
+        self.shape = [2, 1, 2, 4, 10]
+
     def setUp(self):
         self.op_type = "kthvalue"
         self.prim_op_type = "prim"
         self.python_api = paddle.kthvalue
         self.public_python_api = paddle.kthvalue
         self.init_dtype()
-        self.input_data = np.random.random([2, 1, 2, 4, 10]).astype(self.dtype)
+        self.init_shape()
+        self.input_data = np.random.random(self.shape).astype(self.dtype)
         self.init_args()
         self.inputs = {'X': self.input_data}
         self.attrs = {'k': self.k, 'axis': self.axis}
@@ -75,6 +79,11 @@ class TestKthvalueOp(OpTest):
 class TestKthvalueOpFp16(TestKthvalueOp):
     def init_dtype(self):
         self.dtype = np.float16
+
+
+class TestKthvalueOp_ZeroSize(TestKthvalueOp):
+    def init_shape(self):
+        self.shape = [2, 1, 0, 4, 10]
 
 
 class TestKthvalueOpWithKeepdim(OpTest):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->
修改前向和反向
infermeta中有axis维度不能为0的检查，和torch检查相同，没有修改
kernel 修改cpu/gpu

PaddleAPITest 已修改cuda error
![image](https://github.com/user-attachments/assets/36f6b47e-950b-4efa-ac44-fcd3e365140c)

torch axis维度检查
```
python engine.py --accuracy=True --api_config='paddle.kthvalue(Tensor([0],"float32"), 1, )'
```
![image](https://github.com/user-attachments/assets/c2ef8e66-9252-4b4b-98d7-133c2921e066)
