### PR TITLE
[0-size Tensor No.100] Add 0-size Tensor support for ldexp 

### DIFF
--- a/test/legacy_test/test_ldexp.py
+++ b/test/legacy_test/test_ldexp.py
@@ -130,6 +130,21 @@ class TestLdexpAPIWithDynamic(unittest.TestCase):
             check_dtype(res, np.float32)
             np.testing.assert_allclose(res, np.ldexp(x, y))
 
+            # test 0-d
+            dims = (np.random.randint(10),)
+            x = (np.random.rand(*dims) * 10).astype(np.float64)
+            y = (np.random.randint(-10, 10, dims)).astype(np.int32)
+            res = _run_ldexp_dynamic(x, y, place)
+            check_dtype(res, np.float64)
+            np.testing.assert_allclose(res, np.ldexp(x, y))
+
+            dims = (np.random.randint(10),)
+            x = (np.random.randint(-10, 10, dims)).astype(np.int32)
+            y = (np.random.randint(-10, 10, dims)).astype(np.int32)
+            res = _run_ldexp_dynamic(x, y, place)
+            check_dtype(res, np.float32)
+            np.testing.assert_allclose(res, np.ldexp(x, y))
+
             # test broadcast
             dims = (
                 np.random.randint(1, 10),


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
在 PaddleAPITest中，运行报错。
但是用代码直接运行，是可以的。
如下：
```python
import paddle

paddle.device.set_device("gpu")
x = paddle.to_tensor(0, dtype='float32')
y = paddle.to_tensor(0, dtype='int32')
res = paddle.ldexp(x, y)
print(res)
```
结果：
```bash
W0529 03:50:15.910976 10840 gpu_resources.cc:114] Please NOTE: device: 0, GPU Compute Capability: 7.0, Driver API Version: 12.0, Runtime API Version: 11.8
Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
       0.)
```


```python
import paddle

paddle.device.set_device("gpu")
x = paddle.to_tensor([0], dtype='float32')
y = paddle.to_tensor([0], dtype='int32')
res = paddle.ldexp(x, y)
print(res)
```
结果：
```bash
W0529 03:56:33.115897 12246 gpu_resources.cc:114] Please NOTE: device: 0, GPU Compute Capability: 7.0, Driver API Version: 12.0, Runtime API Version: 11.8
Tensor(shape=[1], dtype=float32, place=Place(gpu:0), stop_gradient=True,
       [0.])
```
故添加单测。