### PR TITLE
[0-size Tensor No.98、246、247、329] Add 0-size Tensor support for renorm/kron/repeat_interleave

### DIFF
--- a/paddle/phi/kernels/cpu/repeat_interleave_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/repeat_interleave_grad_kernel.cc
@@ -79,6 +79,10 @@ void RepeatInterleaveGradKernel(const Context& ctx,
                                 int repeats,
                                 int dim,
                                 DenseTensor* x_grad) {
+  if (x_grad && x_grad->numel() == 0) {
+    ctx.template Alloc<T>(x_grad);
+    return;
+  }
   auto input_dim = x_grad->dims();
   if (dim < 0) {
     dim += input_dim.size();

--- a/paddle/phi/kernels/impl/kron_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/kron_grad_kernel_impl.h
@@ -14,9 +14,9 @@
 
 #pragma once
 
+#include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/impl/kron_kernel_impl.h"
 #include "paddle/phi/kernels/reduce_sum_kernel.h"
-
 namespace phi {
 
 template <typename T>
@@ -266,6 +266,17 @@ void KronGradKernel(const Context &ctx,
                     const DenseTensor &out_grad,
                     DenseTensor *x_grad,
                     DenseTensor *y_grad) {
+  if (out_grad.numel() == 0) {
+    if (x_grad) {
+      phi::Full<T, Context>(
+          ctx, phi::IntArray(common::vectorize(x_grad->dims())), 0, x_grad);
+    }
+    if (y_grad) {
+      phi::Full<T, Context>(
+          ctx, phi::IntArray(common::vectorize(y_grad->dims())), 0, y_grad);
+    }
+    return;
+  }
   if (x_grad) {
     ctx.template Alloc<T>(x_grad);
   }

--- a/paddle/phi/kernels/impl/kron_kernel_impl.h
+++ b/paddle/phi/kernels/impl/kron_kernel_impl.h
@@ -158,6 +158,9 @@ void KronKernel(const Context &ctx,
                 const DenseTensor &y,
                 DenseTensor *out) {
   ctx.template Alloc<T>(out);
+  if (out && out->numel() == 0) {
+    return;
+  }
 
   int ndims = out->dims().size();
   DenseTensor xx = UnsqueezeTo(x, ndims);

--- a/paddle/phi/kernels/impl/renorm_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/renorm_grad_kernel_impl.h
@@ -37,6 +37,9 @@ void RenormGradKernel(const Context& dev_ctx,
   auto dimension_each = input_dims[dim];
   dx->Resize(x.dims());
   dev_ctx.template Alloc<T>(dx);
+  if (dx && dx->numel() == 0) {
+    return;
+  }
   phi::funcs::RenormGradFunc(dev_ctx,
                              x_data,
                              dout_data,

--- a/paddle/phi/kernels/impl/renorm_kernel_impl.h
+++ b/paddle/phi/kernels/impl/renorm_kernel_impl.h
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#pragma once
 
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/kernels/funcs/eigen/common.h"
@@ -28,6 +29,9 @@ void RenormKernel(const Context& dev_ctx,
                   DenseTensor* out) {
   out->Resize(x.dims());
   dev_ctx.template Alloc<T>(out);
+  if (out && out->numel() == 0) {
+    return;
+  }
   auto x_ptr = x.template data<T>();
   auto numel = x.numel();
   int dim = axis;

--- a/paddle/phi/kernels/impl/repeat_interleave_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/repeat_interleave_grad_kernel_impl.h
@@ -164,6 +164,10 @@ void RepeatInterleaveGradKernel(const Context& ctx,
                                 int repeats,
                                 int dim,
                                 DenseTensor* x_grad) {
+  if (x_grad && x_grad->numel() == 0) {
+    ctx.template Alloc<T>(x_grad);
+    return;
+  }
   auto input_dim = x_grad->dims();
   if (dim < 0) {
     dim += input_dim.size();

--- a/paddle/phi/kernels/impl/repeat_interleave_kernel_impl.h
+++ b/paddle/phi/kernels/impl/repeat_interleave_kernel_impl.h
@@ -62,7 +62,10 @@ void RepeatInterleaveKernel(const Context& ctx,
                     0,
                     common::errors::InvalidArgument(
                         "repeats must grater than 0, but got %d", repeats));
-
+  if (out && out->numel() == 0) {
+    ctx.template Alloc<T>(out);
+    return;
+  }
   auto place = ctx.GetPlace();
   auto cpu_place = phi::CPUPlace();
 

--- a/paddle/phi/kernels/xpu/repeat_interleave_kernel.cc
+++ b/paddle/phi/kernels/xpu/repeat_interleave_kernel.cc
@@ -29,6 +29,10 @@ void RepeatInterleaveKernel(const Context& ctx,
                     0,
                     common::errors::InvalidArgument(
                         "repeats must grater than 0, but got %d", repeats));
+  if (out && out->numel() == 0) {
+    ctx.template Alloc<T>(out);
+    return;
+  }
   using XPUType = typename XPUTypeTrait<T>::Type;
 
   auto input_dim = x.dims();

--- a/test/legacy_test/test_kron_op.py
+++ b/test/legacy_test/test_kron_op.py
@@ -144,6 +144,33 @@ class TestKronFP16Op(TestKronOp):
         return "float16"
 
 
+class TestKronOp_ZeroSize(OpTest):
+    def setUp(self):
+        self.op_type = "kron"
+        self.prim_op_type = "prim"
+        self.python_api = paddle.kron
+        self.public_python_api = paddle.kron
+        self.dtype = self._init_dtype()
+        x = np.random.uniform(size=(10, 0, 2)).astype(self.dtype)
+        y = np.random.uniform(size=(2, 3, 4, 3, 2)).astype(self.dtype)
+        out_ref = np.kron(x, y)
+        self.inputs = {'X': x, 'Y': y}
+        self.outputs = {'Out': out_ref}
+
+    def _init_dtype(self):
+        return "float64"
+
+    def test_check_output(self):
+        self.check_output(check_pir=True)
+
+    def test_check_grad(self):
+        self.check_grad(
+            ['X', 'Y'],
+            'Out',
+            check_pir=True,
+        )
+
+
 @unittest.skipIf(
     not core.is_compiled_with_cuda()
     or not core.is_bfloat16_supported(core.CUDAPlace(0)),

--- a/test/legacy_test/test_repeat_interleave_op.py
+++ b/test/legacy_test/test_repeat_interleave_op.py
@@ -101,12 +101,11 @@ class TestRepeatInterleaveOp2(OpTest):
         self.check_grad(['X'], 'Out', check_pir=True)
 
 
-class TestRepeatInterleaveOp_ZeroSize(TestRepeatInterleaveOp):
+class TestRepeatInterleaveOp_ZeroSize(TestRepeatInterleaveOp2):
     def init_dtype_type(self):
         self.dim = 1
         self.x_type = np.float64
-        self.index_type = np.int64
-        self.x_shape = (0, 4, 5)
+        self.x_shape = (8, 0, 5)
         self.index_size = self.x_shape[self.dim]
 
 

--- a/test/legacy_test/test_repeat_interleave_op.py
+++ b/test/legacy_test/test_repeat_interleave_op.py
@@ -101,6 +101,15 @@ class TestRepeatInterleaveOp2(OpTest):
         self.check_grad(['X'], 'Out', check_pir=True)
 
 
+class TestRepeatInterleaveOp_ZeroSize(TestRepeatInterleaveOp):
+    def init_dtype_type(self):
+        self.dim = 1
+        self.x_type = np.float64
+        self.index_type = np.int64
+        self.x_shape = (0, 4, 5)
+        self.index_size = self.x_shape[self.dim]
+
+
 class TestIndexSelectAPI(unittest.TestCase):
     def input_data(self):
         self.data_zero_dim_x = np.array(0.5).astype('float32')


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->
renorm
修改前向和反向
infermeta没有修改
kernel修改cpu/gpu，共用impl

PaddleAPITest测试通过
![image](https://github.com/user-attachments/assets/4d8f3072-a8b5-43f9-8ee6-5b0dd79ce9e1)

kron
修改前向和反向
infermeta没有修改
kernel 修改cpu/gpu，共用impl

PaddleAPITest 测试通过
![image](https://github.com/user-attachments/assets/0dbd1251-60b5-4ca4-8326-b26ad552db82)

repeat_interleave

修改前向和反向
infermeta没有修改
kernel 修改cpu/gpu/xpu

PaddleAPITest 测试通过
![image](https://github.com/user-attachments/assets/a900488f-cfaf-429c-8b83-7b2c81274cb2)
