### PR TITLE
[Accuracy diff No.57、69] Fix accuracy diff for sum API

### DIFF
--- a/test/legacy_test/test_reduce_op.py
+++ b/test/legacy_test/test_reduce_op.py
@@ -207,6 +207,24 @@ def create_test_fp16_class(parent):
             )
 
 
+def create_test_fp16_class_cpu(parent):
+    class TestSumOpFp16CPU(parent):
+        def init_dtype(self):
+            self.dtype = np.float16
+
+        def test_check_output(self):
+            self.check_output(check_pir=True, rtol=1e-2, atol=1e-2)
+
+        def test_check_grad(self):
+            self.check_grad(
+                ['X'],
+                'Out',
+                check_prim=True,
+                check_prim_pir=True,
+                check_pir=True,
+            )
+
+
 class TestSumOp3D0size(TestSumOp3Dim):
 
     def test_check_output(self):
@@ -260,6 +278,14 @@ create_test_fp16_class(TestSumOp6D)
 create_test_fp16_class(TestSumOp8D)
 create_test_fp16_class(TestSumOp_withInt)
 create_test_fp16_class(TestSumOp3Dim)
+
+create_test_fp16_class_cpu(TestSumOp)
+create_test_fp16_class_cpu(TestSumOp_ZeroDim)
+create_test_fp16_class_cpu(TestSumOp5D)
+create_test_fp16_class_cpu(TestSumOp6D)
+create_test_fp16_class_cpu(TestSumOp8D)
+create_test_fp16_class_cpu(TestSumOp_withInt)
+create_test_fp16_class_cpu(TestSumOp3Dim)
 
 
 def create_test_bf16_class(parent):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->

https://github.com/pytorch/pytorch/blob/3c74a72ea08a7a7e50c586c22eb6d75e6fed54f3/aten/src/ATen/native/cpu/SumKernel.cpp#L625C1-L629C2

Torch 为了精度float16和bfloat16也是会进行 float32 的计算，为了精度采用 pytorch 的处理方式，进行计算时也采用 float32，比 cast的优先级高 
PaddleAPTTest 测试通过
![图片](https://github.com/user-attachments/assets/003005a7-1055-4ee3-bbc7-9e2033e8e78b)
