### PR TITLE
[0-size Tensor No.360] Add 0-size Tensor support for yolo_box

### DIFF
--- a/paddle/phi/kernels/cpu/yolo_box_kernel.cc
+++ b/paddle/phi/kernels/cpu/yolo_box_kernel.cc
@@ -35,6 +35,12 @@ void YoloBoxKernel(const Context& dev_ctx,
                    float iou_aware_factor,
                    DenseTensor* boxes,
                    DenseTensor* scores) {
+  if (x.numel() == 0 || img_size.numel() == 0) {
+    phi::Full<T, Context>(
+        dev_ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
+    return;
+  }
+
   auto* input = &x;
   auto* imgsize = &img_size;
   float scale = scale_x_y;

--- a/paddle/phi/kernels/cpu/yolo_box_kernel.cc
+++ b/paddle/phi/kernels/cpu/yolo_box_kernel.cc
@@ -37,7 +37,9 @@ void YoloBoxKernel(const Context& dev_ctx,
                    DenseTensor* scores) {
   if (x.numel() == 0 || img_size.numel() == 0) {
     phi::Full<T, Context>(
-        dev_ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
+        dev_ctx, phi::IntArray(common::vectorize(boxes->dims())), 0, boxes);
+    phi::Full<T, Context>(
+        dev_ctx, phi::IntArray(common::vectorize(scores->dims())), 0, scores);
     return;
   }
 

--- a/paddle/phi/kernels/cpu/yolo_box_kernel.cc
+++ b/paddle/phi/kernels/cpu/yolo_box_kernel.cc
@@ -17,6 +17,7 @@
 
 #include "paddle/phi/backends/cpu/cpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/funcs/yolo_box_util.h"
 
 namespace phi {

--- a/paddle/phi/kernels/gpu/yolo_box_kernel.cu
+++ b/paddle/phi/kernels/gpu/yolo_box_kernel.cu
@@ -117,7 +117,9 @@ void YoloBoxKernel(const Context& dev_ctx,
                    DenseTensor* scores) {
   if (x.numel() == 0 || img_size.numel() == 0) {
     phi::Full<T, Context>(
-        dev_ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
+        dev_ctx, phi::IntArray(common::vectorize(boxes->dims())), 0, boxes);
+    phi::Full<T, Context>(
+        dev_ctx, phi::IntArray(common::vectorize(scores->dims())), 0, scores);
     return;
   }
 

--- a/paddle/phi/kernels/gpu/yolo_box_kernel.cu
+++ b/paddle/phi/kernels/gpu/yolo_box_kernel.cu
@@ -115,6 +115,12 @@ void YoloBoxKernel(const Context& dev_ctx,
                    float iou_aware_factor,
                    DenseTensor* boxes,
                    DenseTensor* scores) {
+  if (x.numel() == 0 || img_size.numel() == 0) {
+    phi::Full<T, Context>(
+        dev_ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
+    return;
+  }
+
   auto* input = &x;
   float scale = scale_x_y;
   float bias = -0.5 * (scale - 1.);

--- a/paddle/phi/kernels/gpu/yolo_box_kernel.cu
+++ b/paddle/phi/kernels/gpu/yolo_box_kernel.cu
@@ -18,6 +18,7 @@
 #include "paddle/phi/backends/gpu/gpu_launch_config.h"
 #include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/funcs/math_function.h"
 #include "paddle/phi/kernels/funcs/yolo_box_util.h"
 

--- a/paddle/phi/kernels/xpu/yolo_box_kernel.cc
+++ b/paddle/phi/kernels/xpu/yolo_box_kernel.cc
@@ -37,7 +37,9 @@ void YoloBoxKernel(const Context& dev_ctx,
                    DenseTensor* scores) {
   if (x.numel() == 0 || img_size.numel() == 0) {
     phi::Full<T, Context>(
-        dev_ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
+        dev_ctx, phi::IntArray(common::vectorize(boxes->dims())), 0, boxes);
+    phi::Full<T, Context>(
+        dev_ctx, phi::IntArray(common::vectorize(scores->dims())), 0, scores);
     return;
   }
 

--- a/paddle/phi/kernels/xpu/yolo_box_kernel.cc
+++ b/paddle/phi/kernels/xpu/yolo_box_kernel.cc
@@ -16,6 +16,7 @@
 
 #include "paddle/phi/backends/xpu/enforce_xpu.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/funcs/yolo_box_util.h"
 
 namespace phi {
@@ -34,6 +35,12 @@ void YoloBoxKernel(const Context& dev_ctx,
                    float iou_aware_factor,
                    DenseTensor* boxes,
                    DenseTensor* scores) {
+  if (x.numel() == 0 || img_size.numel() == 0) {
+    phi::Full<T, Context>(
+        dev_ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
+    return;
+  }
+
   using XPUType = typename XPUTypeTrait<T>::Type;
   int r = 0;
   auto* input = &x;

--- a/test/legacy_test/test_yolo_box_op.py
+++ b/test/legacy_test/test_yolo_box_op.py
@@ -56,7 +56,13 @@ def YoloBox(x, img_size, attrs):
         (anchors[i], anchors[(i + 1)]) for i in range(0, len(anchors), 2)
     ]
     anchors_s = np.array(
-        [((an_w / input_w), (an_h / input_h)) for (an_w, an_h) in anchors]
+        [
+            (
+                (an_w / input_w if input_w > 0 else 0),
+                (an_h / input_h if input_h > 0 else 0),
+            )
+            for (an_w, an_h) in anchors
+        ]
     )
     anchor_w = anchors_s[:, 0:1].reshape((1, an_num, 1, 1))
     anchor_h = anchors_s[:, 1:2].reshape((1, an_num, 1, 1))
@@ -303,6 +309,23 @@ class TestYoloBoxOpHW(TestYoloBoxOp):
         self.downsample = 32
         self.clip_bbox = False
         self.x_shape = (self.batch_size, (an_num * (5 + self.class_num)), 13, 9)
+        self.imgsize_shape = (self.batch_size, 2)
+        self.scale_x_y = 1.0
+        self.iou_aware = False
+        self.iou_aware_factor = 0.5
+
+
+class TestYoloBoxOp_ZeroSize(TestYoloBoxOp):
+    def initTestCase(self):
+        self.__class__.op_type = "yolo_box"
+        self.anchors = [10, 13, 16, 30, 33, 23]
+        an_num = int(len(self.anchors) // 2)
+        self.batch_size = 32
+        self.class_num = 2
+        self.conf_thresh = 0.5
+        self.downsample = 32
+        self.clip_bbox = False
+        self.x_shape = (self.batch_size, (an_num * (5 + self.class_num)), 13, 0)
         self.imgsize_shape = (self.batch_size, 2)
         self.scale_x_y = 1.0
         self.iou_aware = False


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->
修改前向
infermeta 不用修改
kernel 修改 cpu/gpu/xpu

PaddleAPITest 测试已修复cuda error
```
python engine.py --paddle_only=True --api_config='paddle.vision.ops.yolo_box(Tensor([2, 16, 8, 0],"float32"), img_size=Tensor([2, 2],"int32"), anchors=list[10,13,16,30,], class_num=2, conf_thresh=0.01, downsample_ratio=8, clip_bbox=True, scale_x_y=1.0, iou_aware=True, iou_aware_factor=0.5, )'
```
![image](https://github.com/user-attachments/assets/de61b26b-2871-4192-b33b-699092df07c2)

paddle error 是已有的逻辑判断, torch中没有相应接口
![image](https://github.com/user-attachments/assets/48994a09-faa5-403b-9f94-0b72f7a79704)
