### PR TITLE
[0-size Tensor No.359] Add 0-size Tensor support for prior_box

### DIFF
--- a/paddle/phi/kernels/cpu/prior_box_kernel.cc
+++ b/paddle/phi/kernels/cpu/prior_box_kernel.cc
@@ -37,9 +37,9 @@ void PriorBoxKernel(const Context& ctx,
                     DenseTensor* var) {
   if (input.numel() == 0 || image.numel() == 0) {
     phi::Full<T, Context>(
-        dev_ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
+        ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
     phi::Full<T, Context>(
-        dev_ctx, phi::IntArray(common::vectorize(var->dims())), 0, var);
+        ctx, phi::IntArray(common::vectorize(var->dims())), 0, var);
     return;
   }
 

--- a/paddle/phi/kernels/cpu/prior_box_kernel.cc
+++ b/paddle/phi/kernels/cpu/prior_box_kernel.cc
@@ -15,8 +15,8 @@
 #include "paddle/phi/kernels/prior_box_kernel.h"
 
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/funcs/eigen/common.h"
-
 namespace phi {
 
 template <typename T, typename Context>
@@ -35,6 +35,14 @@ void PriorBoxKernel(const Context& ctx,
                     bool min_max_aspect_ratios_order,
                     DenseTensor* out,
                     DenseTensor* var) {
+  if (input.numel() == 0 || image.numel() == 0) {
+    phi::Full<T, Context>(
+        dev_ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
+    phi::Full<T, Context>(
+        dev_ctx, phi::IntArray(common::vectorize(var->dims())), 0, var);
+    return;
+  }
+
   std::vector<float> new_aspect_ratios;
   ExpandAspectRatios(aspect_ratios, flip, &new_aspect_ratios);
 

--- a/paddle/phi/kernels/gpu/prior_box_kernel.cu
+++ b/paddle/phi/kernels/gpu/prior_box_kernel.cu
@@ -21,6 +21,7 @@
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/core/tensor_utils.h"
+#include "paddle/phi/kernels/full_kernel.h"
 
 namespace phi {
 
@@ -122,6 +123,14 @@ void PriorBoxKernel(const Context& ctx,
                     bool min_max_aspect_ratios_order,
                     DenseTensor* out,
                     DenseTensor* var) {
+  if (input.numel() == 0 || image.numel() == 0) {
+    phi::Full<T, Context>(
+        dev_ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
+    phi::Full<T, Context>(
+        dev_ctx, phi::IntArray(common::vectorize(var->dims())), 0, var);
+    return;
+  }
+
   std::vector<float> new_aspect_ratios;
   ExpandAspectRatios(aspect_ratios, flip, &new_aspect_ratios);
 

--- a/paddle/phi/kernels/gpu/prior_box_kernel.cu
+++ b/paddle/phi/kernels/gpu/prior_box_kernel.cu
@@ -125,9 +125,9 @@ void PriorBoxKernel(const Context& ctx,
                     DenseTensor* var) {
   if (input.numel() == 0 || image.numel() == 0) {
     phi::Full<T, Context>(
-        dev_ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
+        ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
     phi::Full<T, Context>(
-        dev_ctx, phi::IntArray(common::vectorize(var->dims())), 0, var);
+        ctx, phi::IntArray(common::vectorize(var->dims())), 0, var);
     return;
   }
 

--- a/paddle/phi/kernels/xpu/prior_box_kernel.cc
+++ b/paddle/phi/kernels/xpu/prior_box_kernel.cc
@@ -16,6 +16,7 @@
 
 #include "paddle/phi/backends/xpu/enforce_xpu.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/funcs/eigen/common.h"
 
 namespace phi {
@@ -36,6 +37,14 @@ void PriorBoxKernel(const Context& ctx,
                     bool min_max_aspect_ratios_order,
                     DenseTensor* out,
                     DenseTensor* var) {
+  if (input.numel() == 0 || image.numel() == 0) {
+    phi::Full<T, Context>(
+        dev_ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
+    phi::Full<T, Context>(
+        dev_ctx, phi::IntArray(common::vectorize(var->dims())), 0, var);
+    return;
+  }
+
   std::vector<float> new_aspect_ratios;
   ExpandAspectRatios(aspect_ratios, flip, &new_aspect_ratios);
 

--- a/paddle/phi/kernels/xpu/prior_box_kernel.cc
+++ b/paddle/phi/kernels/xpu/prior_box_kernel.cc
@@ -39,9 +39,9 @@ void PriorBoxKernel(const Context& ctx,
                     DenseTensor* var) {
   if (input.numel() == 0 || image.numel() == 0) {
     phi::Full<T, Context>(
-        dev_ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
+        ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
     phi::Full<T, Context>(
-        dev_ctx, phi::IntArray(common::vectorize(var->dims())), 0, var);
+        ctx, phi::IntArray(common::vectorize(var->dims())), 0, var);
     return;
   }
 

--- a/test/legacy_test/test_prior_box_op.py
+++ b/test/legacy_test/test_prior_box_op.py
@@ -224,6 +224,43 @@ class TestPriorBoxOpWithSpecifiedOutOrder(TestPriorBoxOp):
         self.min_max_aspect_ratios_order = True
 
 
+class TestPriorBoxOp_ZeroSize(TestPriorBoxOp):
+    def init_test_params(self):
+        self.__class__.op_type = "prior_box"
+        self.layer_w = 0
+        self.layer_h = 0
+
+        self.image_w = 40
+        self.image_h = 40
+
+        self.step_w = (
+            float(self.image_w) / float(self.layer_w) if self.layer_w > 0 else 0
+        )
+        self.step_h = (
+            float(self.image_h) / float(self.layer_h) if self.layer_h > 0 else 0
+        )
+
+        self.input_channels = 2
+        self.image_channels = 3
+        self.batch_size = 10
+
+        self.min_sizes = [2, 4]
+        self.min_sizes = np.array(self.min_sizes).astype('float32').tolist()
+        self.set_max_sizes()
+        self.aspect_ratios = [2.0, 3.0]
+        self.flip = True
+        self.set_min_max_aspect_ratios_order()
+        self.real_aspect_ratios = [1, 2.0, 1.0 / 2.0, 3.0, 1.0 / 3.0]
+        self.variances = [0.1, 0.1, 0.2, 0.2]
+        self.variances = np.array(self.variances, dtype=np.float64).flatten()
+
+        self.clip = True
+        self.num_priors = len(self.real_aspect_ratios) * len(self.min_sizes)
+        if len(self.max_sizes) > 0:
+            self.num_priors += len(self.max_sizes)
+        self.offset = 0.5
+
+
 class TestPriorBoxAPI(unittest.TestCase):
     def setUp(self):
         np.random.seed(678)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->
修改前向
infermeta 不用修改
kernel 修改 cpu/gpu/xpu

PaddleAPITest 测试通过
![image](https://github.com/user-attachments/assets/aaaa04c7-1ebe-487a-91c1-3147400cee8e)
