### PR TITLE
[0-size Tensor No.357、359、360、98、246、247、329] Add 0-size Tensor support for box_coder/yolo_box/prior_box/renorm/kron/repeat_interleave

### DIFF
--- a/paddle/phi/kernels/cpu/prior_box_kernel.cc
+++ b/paddle/phi/kernels/cpu/prior_box_kernel.cc
@@ -15,8 +15,8 @@
 #include "paddle/phi/kernels/prior_box_kernel.h"
 
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/funcs/eigen/common.h"
-
 namespace phi {
 
 template <typename T, typename Context>
@@ -35,6 +35,14 @@ void PriorBoxKernel(const Context& ctx,
                     bool min_max_aspect_ratios_order,
                     DenseTensor* out,
                     DenseTensor* var) {
+  if (input.numel() == 0 || image.numel() == 0) {
+    phi::Full<T, Context>(
+        ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
+    phi::Full<T, Context>(
+        ctx, phi::IntArray(common::vectorize(var->dims())), 0, var);
+    return;
+  }
+
   std::vector<float> new_aspect_ratios;
   ExpandAspectRatios(aspect_ratios, flip, &new_aspect_ratios);
 

--- a/paddle/phi/kernels/cpu/repeat_interleave_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/repeat_interleave_grad_kernel.cc
@@ -79,6 +79,10 @@ void RepeatInterleaveGradKernel(const Context& ctx,
                                 int repeats,
                                 int dim,
                                 DenseTensor* x_grad) {
+  if (x_grad && x_grad->numel() == 0) {
+    ctx.template Alloc<T>(x_grad);
+    return;
+  }
   auto input_dim = x_grad->dims();
   if (dim < 0) {
     dim += input_dim.size();

--- a/paddle/phi/kernels/cpu/yolo_box_kernel.cc
+++ b/paddle/phi/kernels/cpu/yolo_box_kernel.cc
@@ -17,6 +17,7 @@
 
 #include "paddle/phi/backends/cpu/cpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/funcs/yolo_box_util.h"
 
 namespace phi {
@@ -35,6 +36,14 @@ void YoloBoxKernel(const Context& dev_ctx,
                    float iou_aware_factor,
                    DenseTensor* boxes,
                    DenseTensor* scores) {
+  if (x.numel() == 0 || img_size.numel() == 0) {
+    phi::Full<T, Context>(
+        dev_ctx, phi::IntArray(common::vectorize(boxes->dims())), 0, boxes);
+    phi::Full<T, Context>(
+        dev_ctx, phi::IntArray(common::vectorize(scores->dims())), 0, scores);
+    return;
+  }
+
   auto* input = &x;
   auto* imgsize = &img_size;
   float scale = scale_x_y;

--- a/paddle/phi/kernels/gpu/prior_box_kernel.cu
+++ b/paddle/phi/kernels/gpu/prior_box_kernel.cu
@@ -21,6 +21,7 @@
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/core/tensor_utils.h"
+#include "paddle/phi/kernels/full_kernel.h"
 
 namespace phi {
 
@@ -122,6 +123,14 @@ void PriorBoxKernel(const Context& ctx,
                     bool min_max_aspect_ratios_order,
                     DenseTensor* out,
                     DenseTensor* var) {
+  if (input.numel() == 0 || image.numel() == 0) {
+    phi::Full<T, Context>(
+        ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
+    phi::Full<T, Context>(
+        ctx, phi::IntArray(common::vectorize(var->dims())), 0, var);
+    return;
+  }
+
   std::vector<float> new_aspect_ratios;
   ExpandAspectRatios(aspect_ratios, flip, &new_aspect_ratios);
 

--- a/paddle/phi/kernels/gpu/yolo_box_kernel.cu
+++ b/paddle/phi/kernels/gpu/yolo_box_kernel.cu
@@ -18,6 +18,7 @@
 #include "paddle/phi/backends/gpu/gpu_launch_config.h"
 #include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/funcs/math_function.h"
 #include "paddle/phi/kernels/funcs/yolo_box_util.h"
 
@@ -115,6 +116,14 @@ void YoloBoxKernel(const Context& dev_ctx,
                    float iou_aware_factor,
                    DenseTensor* boxes,
                    DenseTensor* scores) {
+  if (x.numel() == 0 || img_size.numel() == 0) {
+    phi::Full<T, Context>(
+        dev_ctx, phi::IntArray(common::vectorize(boxes->dims())), 0, boxes);
+    phi::Full<T, Context>(
+        dev_ctx, phi::IntArray(common::vectorize(scores->dims())), 0, scores);
+    return;
+  }
+
   auto* input = &x;
   float scale = scale_x_y;
   float bias = -0.5 * (scale - 1.);

--- a/paddle/phi/kernels/impl/kron_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/kron_grad_kernel_impl.h
@@ -14,9 +14,9 @@
 
 #pragma once
 
+#include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/impl/kron_kernel_impl.h"
 #include "paddle/phi/kernels/reduce_sum_kernel.h"
-
 namespace phi {
 
 template <typename T>
@@ -266,6 +266,17 @@ void KronGradKernel(const Context &ctx,
                     const DenseTensor &out_grad,
                     DenseTensor *x_grad,
                     DenseTensor *y_grad) {
+  if (out_grad.numel() == 0) {
+    if (x_grad) {
+      phi::Full<T, Context>(
+          ctx, phi::IntArray(common::vectorize(x_grad->dims())), 0, x_grad);
+    }
+    if (y_grad) {
+      phi::Full<T, Context>(
+          ctx, phi::IntArray(common::vectorize(y_grad->dims())), 0, y_grad);
+    }
+    return;
+  }
   if (x_grad) {
     ctx.template Alloc<T>(x_grad);
   }

--- a/paddle/phi/kernels/impl/kron_kernel_impl.h
+++ b/paddle/phi/kernels/impl/kron_kernel_impl.h
@@ -158,6 +158,9 @@ void KronKernel(const Context &ctx,
                 const DenseTensor &y,
                 DenseTensor *out) {
   ctx.template Alloc<T>(out);
+  if (out && out->numel() == 0) {
+    return;
+  }
 
   int ndims = out->dims().size();
   DenseTensor xx = UnsqueezeTo(x, ndims);

--- a/paddle/phi/kernels/impl/renorm_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/renorm_grad_kernel_impl.h
@@ -37,6 +37,9 @@ void RenormGradKernel(const Context& dev_ctx,
   auto dimension_each = input_dims[dim];
   dx->Resize(x.dims());
   dev_ctx.template Alloc<T>(dx);
+  if (dx && dx->numel() == 0) {
+    return;
+  }
   phi::funcs::RenormGradFunc(dev_ctx,
                              x_data,
                              dout_data,

--- a/paddle/phi/kernels/impl/renorm_kernel_impl.h
+++ b/paddle/phi/kernels/impl/renorm_kernel_impl.h
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#pragma once
 
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/kernels/funcs/eigen/common.h"
@@ -28,6 +29,9 @@ void RenormKernel(const Context& dev_ctx,
                   DenseTensor* out) {
   out->Resize(x.dims());
   dev_ctx.template Alloc<T>(out);
+  if (out && out->numel() == 0) {
+    return;
+  }
   auto x_ptr = x.template data<T>();
   auto numel = x.numel();
   int dim = axis;

--- a/paddle/phi/kernels/impl/repeat_interleave_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/repeat_interleave_grad_kernel_impl.h
@@ -164,6 +164,10 @@ void RepeatInterleaveGradKernel(const Context& ctx,
                                 int repeats,
                                 int dim,
                                 DenseTensor* x_grad) {
+  if (x_grad && x_grad->numel() == 0) {
+    ctx.template Alloc<T>(x_grad);
+    return;
+  }
   auto input_dim = x_grad->dims();
   if (dim < 0) {
     dim += input_dim.size();

--- a/paddle/phi/kernels/impl/repeat_interleave_kernel_impl.h
+++ b/paddle/phi/kernels/impl/repeat_interleave_kernel_impl.h
@@ -62,7 +62,10 @@ void RepeatInterleaveKernel(const Context& ctx,
                     0,
                     common::errors::InvalidArgument(
                         "repeats must grater than 0, but got %d", repeats));
-
+  if (out && out->numel() == 0) {
+    ctx.template Alloc<T>(out);
+    return;
+  }
   auto place = ctx.GetPlace();
   auto cpu_place = phi::CPUPlace();
 

--- a/paddle/phi/kernels/xpu/prior_box_kernel.cc
+++ b/paddle/phi/kernels/xpu/prior_box_kernel.cc
@@ -16,6 +16,7 @@
 
 #include "paddle/phi/backends/xpu/enforce_xpu.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/funcs/eigen/common.h"
 
 namespace phi {
@@ -36,6 +37,14 @@ void PriorBoxKernel(const Context& ctx,
                     bool min_max_aspect_ratios_order,
                     DenseTensor* out,
                     DenseTensor* var) {
+  if (input.numel() == 0 || image.numel() == 0) {
+    phi::Full<T, Context>(
+        ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
+    phi::Full<T, Context>(
+        ctx, phi::IntArray(common::vectorize(var->dims())), 0, var);
+    return;
+  }
+
   std::vector<float> new_aspect_ratios;
   ExpandAspectRatios(aspect_ratios, flip, &new_aspect_ratios);
 

--- a/paddle/phi/kernels/xpu/repeat_interleave_kernel.cc
+++ b/paddle/phi/kernels/xpu/repeat_interleave_kernel.cc
@@ -29,6 +29,10 @@ void RepeatInterleaveKernel(const Context& ctx,
                     0,
                     common::errors::InvalidArgument(
                         "repeats must grater than 0, but got %d", repeats));
+  if (out && out->numel() == 0) {
+    ctx.template Alloc<T>(out);
+    return;
+  }
   using XPUType = typename XPUTypeTrait<T>::Type;
 
   auto input_dim = x.dims();

--- a/paddle/phi/kernels/xpu/yolo_box_kernel.cc
+++ b/paddle/phi/kernels/xpu/yolo_box_kernel.cc
@@ -16,6 +16,7 @@
 
 #include "paddle/phi/backends/xpu/enforce_xpu.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/funcs/yolo_box_util.h"
 
 namespace phi {
@@ -34,6 +35,14 @@ void YoloBoxKernel(const Context& dev_ctx,
                    float iou_aware_factor,
                    DenseTensor* boxes,
                    DenseTensor* scores) {
+  if (x.numel() == 0 || img_size.numel() == 0) {
+    phi::Full<T, Context>(
+        dev_ctx, phi::IntArray(common::vectorize(boxes->dims())), 0, boxes);
+    phi::Full<T, Context>(
+        dev_ctx, phi::IntArray(common::vectorize(scores->dims())), 0, scores);
+    return;
+  }
+
   using XPUType = typename XPUTypeTrait<T>::Type;
   int r = 0;
   auto* input = &x;

--- a/test/legacy_test/test_box_coder_op.py
+++ b/test/legacy_test/test_box_coder_op.py
@@ -482,6 +482,39 @@ class TestBoxCoderSupporttuple(unittest.TestCase):
         paddle.enable_static()
 
 
+class TestBoxCoderOp_ZeroSize(OpTest):
+    def test_check_output(self):
+        self.check_output(check_pir=True)
+
+    def setUp(self):
+        self.op_type = "box_coder"
+        self.python_api = paddle.vision.ops.box_coder
+        lod = [[1, 1, 1, 1, 1]]
+        prior_box = np.random.random((81, 4)).astype('float32')
+        prior_box_var = np.random.random((81, 4)).astype('float32')
+        target_box = np.random.random((0, 81, 4)).astype('float32')
+        code_type = "DecodeCenterSize"
+        box_normalized = False
+        output_box = batch_box_coder(
+            prior_box,
+            prior_box_var,
+            target_box,
+            lod[0],
+            code_type,
+            box_normalized,
+        )
+        self.inputs = {
+            'PriorBox': prior_box,
+            'PriorBoxVar': prior_box_var,
+            'TargetBox': target_box,
+        }
+        self.attrs = {
+            'code_type': 'decode_center_size',
+            'box_normalized': False,
+        }
+        self.outputs = {'OutputBox': output_box}
+
+
 if __name__ == '__main__':
     paddle.enable_static()
     unittest.main()

--- a/test/legacy_test/test_kron_op.py
+++ b/test/legacy_test/test_kron_op.py
@@ -144,6 +144,33 @@ class TestKronFP16Op(TestKronOp):
         return "float16"
 
 
+class TestKronOp_ZeroSize(OpTest):
+    def setUp(self):
+        self.op_type = "kron"
+        self.prim_op_type = "prim"
+        self.python_api = paddle.kron
+        self.public_python_api = paddle.kron
+        self.dtype = self._init_dtype()
+        x = np.random.uniform(size=(10, 0, 2)).astype(self.dtype)
+        y = np.random.uniform(size=(2, 3, 4, 3, 2)).astype(self.dtype)
+        out_ref = np.kron(x, y)
+        self.inputs = {'X': x, 'Y': y}
+        self.outputs = {'Out': out_ref}
+
+    def _init_dtype(self):
+        return "float64"
+
+    def test_check_output(self):
+        self.check_output(check_pir=True)
+
+    def test_check_grad(self):
+        self.check_grad(
+            ['X', 'Y'],
+            'Out',
+            check_pir=True,
+        )
+
+
 @unittest.skipIf(
     not core.is_compiled_with_cuda()
     or not core.is_bfloat16_supported(core.CUDAPlace(0)),

--- a/test/legacy_test/test_prior_box_op.py
+++ b/test/legacy_test/test_prior_box_op.py
@@ -224,6 +224,43 @@ class TestPriorBoxOpWithSpecifiedOutOrder(TestPriorBoxOp):
         self.min_max_aspect_ratios_order = True
 
 
+class TestPriorBoxOp_ZeroSize(TestPriorBoxOp):
+    def init_test_params(self):
+        self.__class__.op_type = "prior_box"
+        self.layer_w = 0
+        self.layer_h = 0
+
+        self.image_w = 40
+        self.image_h = 40
+
+        self.step_w = (
+            float(self.image_w) / float(self.layer_w) if self.layer_w > 0 else 0
+        )
+        self.step_h = (
+            float(self.image_h) / float(self.layer_h) if self.layer_h > 0 else 0
+        )
+
+        self.input_channels = 2
+        self.image_channels = 3
+        self.batch_size = 10
+
+        self.min_sizes = [2, 4]
+        self.min_sizes = np.array(self.min_sizes).astype('float32').tolist()
+        self.set_max_sizes()
+        self.aspect_ratios = [2.0, 3.0]
+        self.flip = True
+        self.set_min_max_aspect_ratios_order()
+        self.real_aspect_ratios = [1, 2.0, 1.0 / 2.0, 3.0, 1.0 / 3.0]
+        self.variances = [0.1, 0.1, 0.2, 0.2]
+        self.variances = np.array(self.variances, dtype=np.float64).flatten()
+
+        self.clip = True
+        self.num_priors = len(self.real_aspect_ratios) * len(self.min_sizes)
+        if len(self.max_sizes) > 0:
+            self.num_priors += len(self.max_sizes)
+        self.offset = 0.5
+
+
 class TestPriorBoxAPI(unittest.TestCase):
     def setUp(self):
         np.random.seed(678)

--- a/test/legacy_test/test_repeat_interleave_op.py
+++ b/test/legacy_test/test_repeat_interleave_op.py
@@ -101,6 +101,14 @@ class TestRepeatInterleaveOp2(OpTest):
         self.check_grad(['X'], 'Out', check_pir=True)
 
 
+class TestRepeatInterleaveOp_ZeroSize(TestRepeatInterleaveOp2):
+    def init_dtype_type(self):
+        self.dim = 1
+        self.x_type = np.float64
+        self.x_shape = (8, 0, 5)
+        self.index_size = self.x_shape[self.dim]
+
+
 class TestIndexSelectAPI(unittest.TestCase):
     def input_data(self):
         self.data_zero_dim_x = np.array(0.5).astype('float32')

--- a/test/legacy_test/test_yolo_box_op.py
+++ b/test/legacy_test/test_yolo_box_op.py
@@ -56,7 +56,13 @@ def YoloBox(x, img_size, attrs):
         (anchors[i], anchors[(i + 1)]) for i in range(0, len(anchors), 2)
     ]
     anchors_s = np.array(
-        [((an_w / input_w), (an_h / input_h)) for (an_w, an_h) in anchors]
+        [
+            (
+                (an_w / input_w if input_w > 0 else 0),
+                (an_h / input_h if input_h > 0 else 0),
+            )
+            for (an_w, an_h) in anchors
+        ]
     )
     anchor_w = anchors_s[:, 0:1].reshape((1, an_num, 1, 1))
     anchor_h = anchors_s[:, 1:2].reshape((1, an_num, 1, 1))
@@ -303,6 +309,23 @@ class TestYoloBoxOpHW(TestYoloBoxOp):
         self.downsample = 32
         self.clip_bbox = False
         self.x_shape = (self.batch_size, (an_num * (5 + self.class_num)), 13, 9)
+        self.imgsize_shape = (self.batch_size, 2)
+        self.scale_x_y = 1.0
+        self.iou_aware = False
+        self.iou_aware_factor = 0.5
+
+
+class TestYoloBoxOp_ZeroSize(TestYoloBoxOp):
+    def initTestCase(self):
+        self.__class__.op_type = "yolo_box"
+        self.anchors = [10, 13, 16, 30, 33, 23]
+        an_num = int(len(self.anchors) // 2)
+        self.batch_size = 32
+        self.class_num = 2
+        self.conf_thresh = 0.5
+        self.downsample = 32
+        self.clip_bbox = False
+        self.x_shape = (self.batch_size, (an_num * (5 + self.class_num)), 13, 0)
         self.imgsize_shape = (self.batch_size, 2)
         self.scale_x_y = 1.0
         self.iou_aware = False


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->
yolo_box
修改前向
infermeta 不用修改
kernel 修改 cpu/gpu/xpu

PaddleAPITest 测试已修复cuda error
```
python engine.py --paddle_only=True --api_config='paddle.vision.ops.yolo_box(Tensor([2, 16, 8, 0],"float32"), img_size=Tensor([2, 2],"int32"), anchors=list[10,13,16,30,], class_num=2, conf_thresh=0.01, downsample_ratio=8, clip_bbox=True, scale_x_y=1.0, iou_aware=True, iou_aware_factor=0.5, )'
```
![image](https://github.com/user-attachments/assets/de61b26b-2871-4192-b33b-699092df07c2)

paddle error 是已有的逻辑判断, torch中没有相应接口
![image](https://github.com/user-attachments/assets/48994a09-faa5-403b-9f94-0b72f7a79704)


prior_box
修改前向
infermeta 不用修改
kernel 修改 cpu/gpu/xpu

PaddleAPITest 测试通过
![image](https://github.com/user-attachments/assets/aaaa04c7-1ebe-487a-91c1-3147400cee8e)


box_coder 
修改前向
infermeta 不用修改
kernel 修改 cpu/gpu

PaddleAPITest 测试已修复cuda error, paddle error 为已有的判断维度逻辑
![image](https://github.com/user-attachments/assets/6f4423c9-9576-41de-8de8-f0a1985f49f5)

renorm
修改前向和反向
infermeta没有修改
kernel修改cpu/gpu，共用impl

PaddleAPITest测试通过
![image](https://github.com/user-attachments/assets/4d8f3072-a8b5-43f9-8ee6-5b0dd79ce9e1)

kron
修改前向和反向
infermeta没有修改
kernel 修改cpu/gpu，共用impl

PaddleAPITest 测试通过
![image](https://github.com/user-attachments/assets/0dbd1251-60b5-4ca4-8326-b26ad552db82)

repeat_interleave

修改前向和反向
infermeta没有修改
kernel 修改cpu/gpu/xpu

PaddleAPITest 测试通过
![image](https://github.com/user-attachments/assets/a900488f-cfaf-429c-8b83-7b2c81274cb2)