### PR TITLE
[Accuracy diff No.72] Fix accuracy diff for trace API

### DIFF
--- a/paddle/phi/kernels/funcs/diagonal.h
+++ b/paddle/phi/kernels/funcs/diagonal.h
@@ -73,10 +73,10 @@ DenseTensor Diagonal(const DeviceContext& context,
   auto input_stride = common::stride(input_dims);
   auto dim1_ = dim1 < 0 ? input_dims.size() + dim1 : dim1;
   auto dim2_ = dim2 < 0 ? input_dims.size() + dim2 : dim2;
-  auto len1 = input_dims[std::min(dim1_, dim2_)];
-  auto len2 = input_dims[std::max(dim1_, dim2_)];
-  auto stride1 = input_stride[std::min(dim1_, dim2_)];
-  auto stride2 = input_stride[std::max(dim1_, dim2_)];
+  auto len1 = input_dims[dim1_];
+  auto len2 = input_dims[dim2_];
+  auto stride1 = input_stride[dim1_];
+  auto stride2 = input_stride[dim2_];
 
   int offset_stride = 0;
   if (offset >= 0) {

--- a/paddle/phi/kernels/impl/trace_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/trace_grad_kernel_impl.h
@@ -108,10 +108,10 @@ void TraceGradKernel(const Context& ctx,
   auto dim2 = axis2;
   auto dim1_ = dim1 < 0 ? input_dims.size() + dim1 : dim1;
   auto dim2_ = dim2 < 0 ? input_dims.size() + dim2 : dim2;
-  auto len1 = input_dims[std::min(dim1_, dim2_)];
-  auto len2 = input_dims[std::max(dim1_, dim2_)];
-  auto stride1 = input_stride[std::min(dim1_, dim2_)];
-  auto stride2 = input_stride[std::max(dim1_, dim2_)];
+  auto len1 = input_dims[dim1_];
+  auto len2 = input_dims[dim2_];
+  auto stride1 = input_stride[dim1_];
+  auto stride2 = input_stride[dim2_];
 
   int offset_stride = 0;
   if (offset >= 0) {

--- a/test/legacy_test/test_trace_op.py
+++ b/test/legacy_test/test_trace_op.py
@@ -82,6 +82,19 @@ class TestTraceOpCase3(TestTraceOp):
         )
 
 
+class TestTraceOpCase4(TestTraceOp):
+    def init_config(self):
+        self.case = np.random.randn(2, 3, 2).astype('float64')
+        self.inputs = {'Input': self.case}
+        self.attrs = {'offset': -1, 'axis1': 2, 'axis2': -2}
+        self.target = np.trace(
+            self.inputs['Input'],
+            offset=self.attrs['offset'],
+            axis1=self.attrs['axis1'],
+            axis2=self.attrs['axis2'],
+        )
+
+
 class TestTraceFP16Op1(TestTraceOp):
     def init_config(self):
         self.dtype = np.float16

--- a/test/legacy_test/test_trace_op.py
+++ b/test/legacy_test/test_trace_op.py
@@ -84,7 +84,7 @@ class TestTraceOpCase3(TestTraceOp):
 
 class TestTraceOpCase4(TestTraceOp):
     def init_config(self):
-        self.case = np.random.randn(2, 3, 2).astype('float64')
+        self.case = np.random.randn(2, 30, 3).astype('float64')
         self.inputs = {'Input': self.case}
         self.attrs = {'offset': -1, 'axis1': 2, 'axis2': -2}
         self.target = np.trace(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
- https://github.com/PaddlePaddle/Paddle/issues/72667
- trace 的 dims1 就是所对角线的二维平面的第一维,dim2 是第二维，有明确的位置关系，所以修改 kernel 中根据 dim 所处位置选择的 bug
- 关联 PaddleTest repo　修改　https://github.com/PaddlePaddle/PaddleTest/pull/3080
- PaddleAPITest 测试通过
![图片](https://github.com/user-attachments/assets/f90e5137-0d05-4b41-b47a-d56de00b673d)

