### PR TITLE
[0-size Tensor No.124] Add 0-size Tensor support for logaddexp

### DIFF
--- a/test/legacy_test/test_logaddexp.py
+++ b/test/legacy_test/test_logaddexp.py
@@ -79,5 +79,37 @@ class TestLogsumexpAPI(unittest.TestCase):
         self.api_case()
 
 
+class TestLogsumexpAPI_ZeroSize(unittest.TestCase):
+    def setUp(self):
+        self.place = (
+            paddle.CUDAPlace(0)
+            if paddle.base.core.is_compiled_with_cuda()
+            else paddle.CPUPlace()
+        )
+
+    def api_case(self):
+        self.x = np.random.uniform(-1, 1, self.xshape).astype(self.dtype)
+        self.y = np.random.uniform(-1, 1, self.yshape).astype(self.dtype)
+        out_ref = ref_logaddexp(self.x, self.y)
+
+        # paddle.disable_static(self.place)
+        x = paddle.to_tensor(self.x)
+        y = paddle.to_tensor(self.y)
+        x.stop_gradient = False
+        y.stop_gradient = False
+        out = paddle.logaddexp(x, y)
+        np.testing.assert_allclose(out.numpy(), out_ref, atol=1e-06)
+
+        loss = paddle.sum(out)
+        loss.backward()
+        np.testing.assert_allclose(x.grad.shape, x.shape)
+
+    def test_api(self):
+        self.xshape = [1, 2, 3, 0]
+        self.yshape = [1, 2, 3, 1]
+        self.dtype = np.float32
+        self.api_case()
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/legacy_test/test_logaddexp.py
+++ b/test/legacy_test/test_logaddexp.py
@@ -92,7 +92,7 @@ class TestLogsumexpAPI_ZeroSize(unittest.TestCase):
         self.y = np.random.uniform(-1, 1, self.yshape).astype(self.dtype)
         out_ref = ref_logaddexp(self.x, self.y)
 
-        # paddle.disable_static(self.place)
+        paddle.disable_static(self.place)
         x = paddle.to_tensor(self.x)
         y = paddle.to_tensor(self.y)
         x.stop_gradient = False


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->
logaddexp 是python端算子，原有错误为subtract算子错误，subtract已修复，
当前PR是增加单测

PaddleAPITest 测试没有cuda error，paddle error 为测试用例形状 broadcast 错误，x, y为0的维度对应的其他值不能大于1
![image](https://github.com/user-attachments/assets/fd0733ba-a6b0-40cb-931a-9b0aa919a254)

