### PR TITLE
[Slice]Fix set_value output_offset out_of_range bug

### DIFF
--- a/paddle/phi/kernels/gpu/set_value_kernel.cu
+++ b/paddle/phi/kernels/gpu/set_value_kernel.cu
@@ -62,8 +62,8 @@ void SetTensorValueKernelV2(const Context& dev_ctx,
 
     auto out_dim =
         (std::abs(ends_local[i] - starts_local[i]) + step_size - 1) / step_size;
-    output_offset += static_cast<int>(starts_local[i] * output_stride[axes[i]] *
-                                      SizeOf(out->dtype()));
+    output_offset += static_cast<int64_t>(
+        starts_local[i] * output_stride[axes[i]] * SizeOf(out->dtype()));
     output_dims[axes[i]] = out_dim;
     output_stride[axes[i]] *= steps_local[i];
   }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-67164
Fix set_value output_offset out_of_range bug:
修复set_value_kernel.cu中output_offset类型转换bug，应统一为int64。
解决了在大tensor上cuda700的报错。