### PR TITLE
[Auto Parallel] remove redundant reshard when mesh==1

### DIFF
--- a/paddle/phi/core/distributed/auto_parallel/reshard/p_to_r_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/p_to_r_reshard_function.cc
@@ -51,7 +51,7 @@ void PToRReshardFunction::Eval(DeviceContext* dev_ctx,
   const auto& in_process_mesh = in_dist_attr.process_mesh();
   const auto& in_process_ids = in_process_mesh.process_ids();
   if (in_process_ids.size() == 1) {
-    *out = in;
+    SetValue(out, in.value());
     return;
   }
   const auto& in_partial_status = in_dist_attr.partial_status();

--- a/paddle/phi/core/distributed/auto_parallel/reshard/p_to_r_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/p_to_r_reshard_function.cc
@@ -50,6 +50,10 @@ void PToRReshardFunction::Eval(DeviceContext* dev_ctx,
   const auto& in_dist_attr = in.dist_attr();
   const auto& in_process_mesh = in_dist_attr.process_mesh();
   const auto& in_process_ids = in_process_mesh.process_ids();
+  if (in_process_ids.size() == 1) {
+    *out = in;
+    return;
+  }
   const auto& in_partial_status = in_dist_attr.partial_status();
   auto in_reduce_type = in_partial_status.at(0);
   bool reduce_mean = false;

--- a/paddle/phi/core/distributed/auto_parallel/reshard/p_to_r_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/p_to_r_reshard_function.cc
@@ -52,6 +52,7 @@ void PToRReshardFunction::Eval(DeviceContext* dev_ctx,
   const auto& in_process_ids = in_process_mesh.process_ids();
   if (in_process_ids.size() == 1) {
     SetValue(out, in.value());
+    SetDistProps(out, in.dims(), out_dist_attr);
     return;
   }
   const auto& in_partial_status = in_dist_attr.partial_status();

--- a/paddle/phi/core/distributed/auto_parallel/reshard/p_to_s_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/p_to_s_reshard_function.cc
@@ -123,6 +123,7 @@ void PToSReshardFunction::Eval(DeviceContext* dev_ctx,
   int64_t num_of_process = in_process_mesh.size();
   if (num_of_process == 1) {
     SetValue(out, in.value());
+    SetDistProps(out, in.dims(), out_dist_attr);
     return;
   }
   int64_t num_of_padding = in.dims()[out_split_axis] % num_of_process;

--- a/paddle/phi/core/distributed/auto_parallel/reshard/p_to_s_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/p_to_s_reshard_function.cc
@@ -121,6 +121,10 @@ void PToSReshardFunction::Eval(DeviceContext* dev_ctx,
   int out_split_axis =
       GetSplitAxisWithDimsMapping(out_dist_attr.dims_mapping()).begin()->first;
   int64_t num_of_process = in_process_mesh.size();
+  if (num_of_process == 1) {
+    *out = in;
+    return;
+  }
   int64_t num_of_padding = in.dims()[out_split_axis] % num_of_process;
   bool is_balanced_split = (num_of_padding == 0);
 

--- a/paddle/phi/core/distributed/auto_parallel/reshard/p_to_s_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/p_to_s_reshard_function.cc
@@ -122,7 +122,7 @@ void PToSReshardFunction::Eval(DeviceContext* dev_ctx,
       GetSplitAxisWithDimsMapping(out_dist_attr.dims_mapping()).begin()->first;
   int64_t num_of_process = in_process_mesh.size();
   if (num_of_process == 1) {
-    *out = in;
+    SetValue(out, in.value());
     return;
   }
   int64_t num_of_padding = in.dims()[out_split_axis] % num_of_process;

--- a/paddle/phi/core/distributed/auto_parallel/reshard/r_to_p_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/r_to_p_reshard_function.cc
@@ -50,7 +50,7 @@ void RToPReshardFunction::Eval(phi::DeviceContext* dev_ctx,
   VLOG(3) << "Call " << Name();
   const auto& in_process_ids = in.dist_attr().process_mesh().process_ids();
   if (in_process_ids.size() == 1) {
-    *out = in;
+    SetValue(out, in.value());
     return;
   }
   const auto& out_process_mesh = out_dist_attr.process_mesh();

--- a/paddle/phi/core/distributed/auto_parallel/reshard/r_to_p_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/r_to_p_reshard_function.cc
@@ -51,6 +51,7 @@ void RToPReshardFunction::Eval(phi::DeviceContext* dev_ctx,
   const auto& in_process_ids = in.dist_attr().process_mesh().process_ids();
   if (in_process_ids.size() == 1) {
     SetValue(out, in.value());
+    SetDistProps(out, in.dims(), out_dist_attr);
     return;
   }
   const auto& out_process_mesh = out_dist_attr.process_mesh();

--- a/paddle/phi/core/distributed/auto_parallel/reshard/r_to_p_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/r_to_p_reshard_function.cc
@@ -48,6 +48,11 @@ void RToPReshardFunction::Eval(phi::DeviceContext* dev_ctx,
                                const TensorDistAttr& out_dist_attr,
                                DistTensor* out) {
   VLOG(3) << "Call " << Name();
+  const auto& in_process_ids = in.dist_attr().process_mesh().process_ids();
+  if (in_process_ids.size() == 1) {
+    *out = in;
+    return;
+  }
   const auto& out_process_mesh = out_dist_attr.process_mesh();
   int64_t local_rank = GetCurRankCoordInMesh(out_process_mesh)[0];
   const auto& in_reduce_type = out_dist_attr.partial_status().at(0);

--- a/paddle/phi/core/distributed/auto_parallel/reshard/r_to_s_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/r_to_s_reshard_function.cc
@@ -59,6 +59,10 @@ void RToSReshardFunction::Eval(phi::DeviceContext* dev_ctx,
   int64_t mesh_axis = split_axis_to_mesh_axis.begin()->second;
 
   int64_t num_of_process = out_process_mesh.shape()[mesh_axis];
+  if (num_of_process == 1) {
+    *out = in;
+    return;
+  }
   VLOG(3) << "RToSReshard: Tensor will be split on axis " << split_axis
           << ". Split will use axis " << mesh_axis << " of process_mesh."
           << " There will have " << num_of_process

--- a/paddle/phi/core/distributed/auto_parallel/reshard/r_to_s_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/r_to_s_reshard_function.cc
@@ -60,7 +60,7 @@ void RToSReshardFunction::Eval(phi::DeviceContext* dev_ctx,
 
   int64_t num_of_process = out_process_mesh.shape()[mesh_axis];
   if (num_of_process == 1) {
-    *out = in;
+    SetValue(out, in.value());
     return;
   }
   VLOG(3) << "RToSReshard: Tensor will be split on axis " << split_axis

--- a/paddle/phi/core/distributed/auto_parallel/reshard/r_to_s_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/r_to_s_reshard_function.cc
@@ -61,6 +61,7 @@ void RToSReshardFunction::Eval(phi::DeviceContext* dev_ctx,
   int64_t num_of_process = out_process_mesh.shape()[mesh_axis];
   if (num_of_process == 1) {
     SetValue(out, in.value());
+    SetDistProps(out, in.dims(), out_dist_attr);
     return;
   }
   VLOG(3) << "RToSReshard: Tensor will be split on axis " << split_axis

--- a/paddle/phi/core/distributed/auto_parallel/reshard/s_to_r_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/s_to_r_reshard_function.cc
@@ -37,10 +37,6 @@ void ReshardSToRWithPadding(DeviceContext* dev_ctx,
                             int64_t padding_nums,
                             DenseTensor* out) {
   int64_t num_of_process = process_ids.size();
-  if (num_of_process == 1) {
-    *out = in;
-    return;
-  }
   auto dtype = in.dtype();
 
   // For balanced split to replicate, we need to do all gather first.
@@ -115,6 +111,7 @@ void SToRReshardFunction::Eval(DeviceContext* dev_ctx,
   const auto& in_process_ids = in_process_mesh.process_ids();
   if (in_process_ids.size() == 1) {
     SetValue(out, in.value());
+    SetDistProps(out, in.dims(), out_dist_attr);
     return;
   }
 

--- a/paddle/phi/core/distributed/auto_parallel/reshard/s_to_r_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/s_to_r_reshard_function.cc
@@ -37,6 +37,10 @@ void ReshardSToRWithPadding(DeviceContext* dev_ctx,
                             int64_t padding_nums,
                             DenseTensor* out) {
   int64_t num_of_process = process_ids.size();
+  if (num_of_process == 1) {
+    *out = in;
+    return;
+  }
   auto dtype = in.dtype();
 
   // For balanced split to replicate, we need to do all gather first.
@@ -109,7 +113,10 @@ void SToRReshardFunction::Eval(DeviceContext* dev_ctx,
   const auto& in_dims_mapping = in_dist_attr.dims_mapping();
   const auto& in_process_mesh = in_dist_attr.process_mesh();
   const auto& in_process_ids = in_process_mesh.process_ids();
-
+  if (in_process_ids.size() == 1) {
+    *out = in;
+    return;
+  }
   int split_axis = GetSplitAxisWithDimsMapping(in_dims_mapping).begin()->first;
   int64_t num_of_process = in_process_mesh.size();
   int64_t num_of_padding = in.dims()[split_axis] % num_of_process;

--- a/paddle/phi/core/distributed/auto_parallel/reshard/s_to_r_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/s_to_r_reshard_function.cc
@@ -114,9 +114,10 @@ void SToRReshardFunction::Eval(DeviceContext* dev_ctx,
   const auto& in_process_mesh = in_dist_attr.process_mesh();
   const auto& in_process_ids = in_process_mesh.process_ids();
   if (in_process_ids.size() == 1) {
-    *out = in;
+    SetValue(out, in.value());
     return;
   }
+
   int split_axis = GetSplitAxisWithDimsMapping(in_dims_mapping).begin()->first;
   int64_t num_of_process = in_process_mesh.size();
   int64_t num_of_padding = in.dims()[split_axis] % num_of_process;

--- a/paddle/phi/core/distributed/auto_parallel/reshard/s_to_s_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/s_to_s_reshard_function.cc
@@ -54,6 +54,10 @@ void SToSReshardFunction::Eval(phi::DeviceContext* dev_ctx,
   VLOG(3) << "Call " << Name();
   const auto& in_process_mesh = in.dist_attr().process_mesh();
   const auto& in_process_ids = in_process_mesh.process_ids();
+  if (in_process_ids.size() == 1) {
+    *out = in;
+    return;
+  }
   auto dtype = in.dtype();
   const auto& logical_ddim = in.dims();
   int64_t nranks = static_cast<int64_t>(in_process_ids.size());

--- a/paddle/phi/core/distributed/auto_parallel/reshard/s_to_s_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/s_to_s_reshard_function.cc
@@ -55,7 +55,7 @@ void SToSReshardFunction::Eval(phi::DeviceContext* dev_ctx,
   const auto& in_process_mesh = in.dist_attr().process_mesh();
   const auto& in_process_ids = in_process_mesh.process_ids();
   if (in_process_ids.size() == 1) {
-    *out = in;
+    SetValue(out, in.value());
     return;
   }
   auto dtype = in.dtype();

--- a/paddle/phi/core/distributed/auto_parallel/reshard/s_to_s_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/s_to_s_reshard_function.cc
@@ -56,6 +56,7 @@ void SToSReshardFunction::Eval(phi::DeviceContext* dev_ctx,
   const auto& in_process_ids = in_process_mesh.process_ids();
   if (in_process_ids.size() == 1) {
     SetValue(out, in.value());
+    SetDistProps(out, in.dims(), out_dist_attr);
     return;
   }
   auto dtype = in.dtype();


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

- remove redundant reshard when mesh==1

Pcard-70448