### PR TITLE
[SOT][Exception] Fix zerodiv not raising

### DIFF
--- a/python/paddle/jit/sot/symbolic_shape/operators.py
+++ b/python/paddle/jit/sot/symbolic_shape/operators.py
@@ -18,7 +18,6 @@ import operator
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-
     from ..utils.magic_methods import BinaryOp, UnaryOp
 
 

--- a/python/paddle/jit/sot/utils/magic_methods.py
+++ b/python/paddle/jit/sot/utils/magic_methods.py
@@ -95,7 +95,8 @@ BINARY_OPS = INPLACE_BINARY_OPS | NON_INPLACE_BINARY_OPS
 UNARY_OPS = set(UNARY_OPS_TO_MAGIC_NAMES.keys())
 
 
-# operator.pow operator.ipow, 当底数为0且指数为负数时，会引发ZeroDivisionError
+# NOTE: Both operator.pow and operator.ipow should be considered for inclusion in this list,
+# as they raise ZeroDivisionError when evaluating 0^n where n < 0 (division by zero).
 NEED_GUARD_ZERO_DIVISION_ERROR_OPS: list[BinaryOp] = [
     operator.floordiv,
     operator.truediv,

--- a/python/paddle/jit/sot/utils/magic_methods.py
+++ b/python/paddle/jit/sot/utils/magic_methods.py
@@ -95,6 +95,17 @@ BINARY_OPS = INPLACE_BINARY_OPS | NON_INPLACE_BINARY_OPS
 UNARY_OPS = set(UNARY_OPS_TO_MAGIC_NAMES.keys())
 
 
+# operator.pow operator.ipow, 当底数为0且指数为负数时，会引发ZeroDivisionError
+NEED_GUARD_ZERO_DIVISION_ERROR_OPS: list[BinaryOp] = [
+    operator.floordiv,
+    operator.truediv,
+    operator.mod,
+    operator.ifloordiv,
+    operator.itruediv,
+    operator.imod,
+]
+
+
 @dataclass
 class MagicMethod:
     name: str

--- a/test/sot/test_24_exceptions.py
+++ b/test/sot/test_24_exceptions.py
@@ -944,5 +944,29 @@ class TestGuard(TestCaseBase):
         self.assert_results(fn)
 
 
+class TestBuiltinFunctionRaiseExceptionGuard(TestCaseBase):
+    def test_guard_run(self):
+        def foo_floordiv(x):
+            1 / x
+
+        def foo_mod(x):
+            2 % x
+
+        self.assert_results(foo_floordiv, 1)
+        self.assert_exceptions(
+            ZeroDivisionError,
+            "division by zero",
+            foo_floordiv,
+            0,
+        )
+        self.assert_results(foo_mod, 10)
+        self.assert_exceptions(
+            ZeroDivisionError,
+            "integer division or modulo by zero",
+            foo_mod,
+            0,
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/sot/test_24_exceptions.py
+++ b/test/sot/test_24_exceptions.py
@@ -962,7 +962,7 @@ class TestBuiltinFunctionRaiseExceptionGuard(TestCaseBase):
         self.assert_results(foo_mod, 10)
         self.assert_exceptions(
             ZeroDivisionError,
-            "integer (.)* modulo by zero",
+            "integer (.)*modulo by zero",
             foo_mod,
             0,
         )

--- a/test/sot/test_24_exceptions.py
+++ b/test/sot/test_24_exceptions.py
@@ -962,7 +962,7 @@ class TestBuiltinFunctionRaiseExceptionGuard(TestCaseBase):
         self.assert_results(foo_mod, 10)
         self.assert_exceptions(
             ZeroDivisionError,
-            "integer division or modulo by zero",
+            "integer (.)* modulo by zero",
             foo_mod,
             0,
         )


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

执行 `fn`:
```
def fn(x):
	1 / x
```
先执行 `x=1` ，之后执行 `x=0`，并不会报错

这个PR将**除数**是否为0添加到 guard 中

PCard-66972
之前PR https://github.com/PaddlePaddle/Paddle/pull/72784#issuecomment-2900339966 的遗留问题