### PR TITLE
[Prim][CINN] Fix group_norm_grad decomp sum dtype

### DIFF
--- a/paddle/fluid/primitive/decomp_rule/decomp_vjp/details.h
+++ b/paddle/fluid/primitive/decomp_rule/decomp_vjp/details.h
@@ -2307,7 +2307,9 @@ void group_norm_grad(const Tensor& x,
       auto tmp1 = out_grad_data * (x_data - mean_new) * sqrt_var_1;
 
       auto scale_grad_tmp = reshape<T>(
-          tmp1.sum(reduce_axis_except_channel, scale->dtype(), false), {-1});
+          tmp1.sum(reduce_axis_except_channel, x_data.dtype(), false), {-1});
+      scale_grad_tmp = ConvertToOrig<T>(scale_grad_tmp, scale->dtype());
+
       set_output<T>(scale_grad_tmp, scale_grad);
     }
   }
@@ -2315,7 +2317,8 @@ void group_norm_grad(const Tensor& x,
   if (bias_grad) {
     if (bias) {
       auto bias_grad_tmp =
-          out_grad_data.sum(reduce_axis_except_channel, bias->dtype(), false);
+          out_grad_data.sum(reduce_axis_except_channel, x_data.dtype(), false);
+      bias_grad_tmp = ConvertToOrig<T>(bias_grad_tmp, bias->dtype());
 
       set_output<T>(reshape<T>(bias_grad_tmp, {-1}), bias_grad);
     }

--- a/test/deprecated/legacy_test/test_group_norm_op_deprecated.py
+++ b/test/deprecated/legacy_test/test_group_norm_op_deprecated.py
@@ -586,6 +586,7 @@ class TestGroupNormBF16Op_With_NHWC(TestGroupNormBF16Op):
         self.python_out_sig = ["Y"]
         self.data_format = "NHWC"
         self.prim_op_type = "comp"
+        self.channel_last = True
 
         self.dtype = np.uint16
         self.shape = (1, 3, 5, 512)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Operator Mechanism


### PR Types
Bug fixes


### Description
修复`group_norm_grad`组合算子拆解中sum的dtype设置错误的问题，即半精度下应当基于float类型进行sum，解决`test_group_norm_op_deprecated`单测的精度问题（这个单测在CI里不跑，只能手动验证）

参考layer_norm_grad：https://github.com/PaddlePaddle/Paddle/blob/4f9d17aea576ea7bf5065d020b1e6eb28d123a6f/paddle/fluid/primitive/decomp_rule/decomp_vjp/details.h#L896-L901

检查了下另外几个batch_norm/layer_norm/instance_norm的反向都是对的，为啥只有group_norm_grad是错的

Pcard-85711