### PR TITLE
[SOT][Exception] breakgraph when using `random.*`

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/variables/callable.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/callable.py
@@ -19,6 +19,7 @@ import functools
 import inspect
 import itertools
 import operator
+import random
 import sys
 import types
 from functools import partial, reduce
@@ -325,8 +326,6 @@ class UserDefinedFunctionVariable(FunctionVariable):
 
     @staticmethod
     def __is_random_function(value) -> bool:
-        import random
-
         return value.__qualname__ in [
             f"{random._inst.__class__.__name__}.{name}"
             for name in dir(random._inst)

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/callable.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/callable.py
@@ -70,6 +70,7 @@ from ....utils.exceptions import (
     UnsupportedNumPyAPIBreak,
     UnsupportedOperationBreak,
     UnsupportedPaddleAPIBreak,
+    UnsupportedRandomAPIBreak,
 )
 from ..dispatcher import Dispatcher
 from ..guard import (
@@ -250,6 +251,10 @@ class UserDefinedFunctionVariable(FunctionVariable):
         return None
 
     def call_function(self, /, *args, **kwargs) -> VariableBase:
+        if UserDefinedFunctionVariable.__is_random_function(self.value):
+            raise BreakGraphError(
+                UnsupportedRandomAPIBreak(fn_name=self.value.__name__)
+            )
         from ..opcode_inline_executor import OpcodeInlineExecutor
 
         result = self.handle_psdb_function(*args, **kwargs)
@@ -317,6 +322,15 @@ class UserDefinedFunctionVariable(FunctionVariable):
         return {
             "name": self.value.__name__,
         }
+
+    @staticmethod
+    def __is_random_function(value) -> bool:
+        import random
+
+        return value.__qualname__ in [
+            f"{random._inst.__class__.__name__}.{name}"
+            for name in dir(random._inst)
+        ]
 
 
 class UserCodeVariable(FunctionVariable):

--- a/python/paddle/jit/sot/utils/exceptions.py
+++ b/python/paddle/jit/sot/utils/exceptions.py
@@ -125,6 +125,25 @@ class UnsupportedNumPyAPIBreak(UnsupportedOperationBreak):
         )
 
 
+class UnsupportedRandomAPIBreak(UnsupportedOperationBreak):
+    def __init__(
+        self,
+        *,
+        fn_name=None,
+        reason_str=None,
+        file_path="",
+        line_number=-1,
+    ):
+        if reason_str is None:
+            reason_str = f"Random function {fn_name} is not supported."
+
+        super().__init__(
+            reason_str=reason_str,
+            file_path=file_path,
+            line_number=line_number,
+        )
+
+
 class BuiltinFunctionBreak(UnsupportedOperationBreak):
     """Break reason for unsupported built-in function calls.
 

--- a/test/sot/test_force_breakgraph_api.py
+++ b/test/sot/test_force_breakgraph_api.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import random
+import unittest
+
+from test_case_base import TestCaseBase
+
+import paddle
+from paddle.jit.sot import symbolic_translate
+
+
+def fn_randint(x):
+    x = x + 1
+    x = random.randint(0, 100)
+    x = x + 2
+    return x
+
+
+def fn_random(x):
+    x = x + 3
+    x = random.random()
+    x = x + 4
+    return x
+
+
+class TestRandom(TestCaseBase):
+    def test_random_randint(self):
+        x = paddle.to_tensor(2024)
+
+        random.seed(2025)
+        sym_output = symbolic_translate(fn_randint)(x)
+        random.seed(2025)
+        paddle_output = fn_randint(x)
+
+        self.assertEqual(sym_output, paddle_output)
+
+    def test_random_random(self):
+        x = paddle.to_tensor(2025)
+
+        random.seed(2025)
+        sym_output = symbolic_translate(fn_random)(x)
+        random.seed(2025)
+        paddle_output = fn_random(x)
+
+        self.assertEqual(sym_output, paddle_output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/sot/test_force_breakgraph_api.py
+++ b/test/sot/test_force_breakgraph_api.py
@@ -25,14 +25,14 @@ from paddle.jit.sot import symbolic_translate
 
 def fn_randint(x):
     x = x + 1
-    x = random.randint(0, 100)
+    x = x + random.randint(0, 100)
     x = x + 2
     return x
 
 
 def fn_random(x):
     x = x + 3
-    x = random.random()
+    x = x + random.random()
     x = x + 4
     return x
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
之前在`import random`之后，由于存在 `try ... except ...`，所以导入 random 会 fallback
现在SOT异常支持后，在模拟 random 中的函数导入，由于random的部分函数，都是实例 `_inst = Random()` 的方法

```
# Py3.10 Random 库源码中的一部分
_inst = Random()
seed = _inst.seed
random = _inst.random
uniform = _inst.uniform
triangular = _inst.triangular
randint = _inst.randint
choice = _inst.choice
randrange = _inst.randrange
sample = _inst.sample
shuffle = _inst.shuffle
choices = _inst.choices
```

所以此时使用 random 中的函数会报:
```
  File "/workspace/paddle/build/python/paddle/jit/sot/opcode_translator/executor/variables/base.py", line 518, in getattr
    raise HasNoAttributeError(
paddle.jit.sot.utils.exceptions.HasNoAttributeError: ModuleVariable ModuleVariable(<module 'random' from '/usr/lib/python3.10/random.py'>, object_176, random) has no attribute _randbelow
```

在执行：

```python
>>> import random
>>> random._inst.seed
<bound method Random.seed of <random.Random object at 0x12f00e810>>
```

> `inst.seed` 理应是 `Random.seed.__get__(Random())`
> 但现在是 `Random.seed.__get__(random)`
> 注意 `random` 是 `ModuleType`，`Random()` 是 `Random`

所以目前现将 `random.*` 函数全部打断



cc @SigureMo
PCard-66972