### PR TITLE
[0-size Tensor No.345、356] Add 0-size Tensor support for paddle.var

### DIFF
--- a/python/paddle/tensor/stat.py
+++ b/python/paddle/tensor/stat.py
@@ -210,7 +210,9 @@ def var(
     n.stop_gradient = True
     out /= n
     if x.numel() == 0:
-        out = paddle.full(out.shape, paddle.nan, dtype=out.dtype)
+        out_nan = paddle.full_like(out, paddle.nan)
+        out_nan.stop_gradient = out.stop_gradient
+        out = out_nan
     if out.dtype != x.dtype:
         return out.astype(x.dtype)
     return out

--- a/python/paddle/tensor/stat.py
+++ b/python/paddle/tensor/stat.py
@@ -209,7 +209,7 @@ def var(
         n = n - 1.0
     n.stop_gradient = True
     out /= n
-    if x.numel() == 0:
+    if paddle.numel(x) == 0:
         out_nan = paddle.full_like(out, paddle.nan)
         out_nan.stop_gradient = out.stop_gradient
         out = out_nan

--- a/python/paddle/tensor/stat.py
+++ b/python/paddle/tensor/stat.py
@@ -209,6 +209,8 @@ def var(
         n = n - 1.0
     n.stop_gradient = True
     out /= n
+    if x.numel() == 0:
+        out = paddle.full(out.shape, paddle.nan, dtype=out.dtype)
     if out.dtype != x.dtype:
         return out.astype(x.dtype)
     return out

--- a/python/paddle/tensor/stat.py
+++ b/python/paddle/tensor/stat.py
@@ -210,7 +210,9 @@ def var(
     n.stop_gradient = True
     out /= n
     if x.numel() == 0:
-        out = paddle.full_like(out, paddle.nan)
+        out_nan = paddle.full_like(out, paddle.nan)
+        out_nan.stop_gradient = out.stop_gradient
+        out = out_nan
     if out.dtype != x.dtype:
         return out.astype(x.dtype)
     return out

--- a/python/paddle/tensor/stat.py
+++ b/python/paddle/tensor/stat.py
@@ -209,7 +209,7 @@ def var(
         n = n - 1.0
     n.stop_gradient = True
     out /= n
-    if paddle.numel(x) == 0:
+    if paddle.numel(x).item() == 0:
         out_nan = paddle.full_like(out, paddle.nan)
         out_nan.stop_gradient = out.stop_gradient
         out = out_nan

--- a/python/paddle/tensor/stat.py
+++ b/python/paddle/tensor/stat.py
@@ -209,10 +209,18 @@ def var(
         n = n - 1.0
     n.stop_gradient = True
     out /= n
-    if paddle.in_dynamic_mode() and paddle.numel(x) == 0:
+
+    def _replace_nan(out):
         out_nan = paddle.full_like(out, paddle.nan)
         out_nan.stop_gradient = out.stop_gradient
-        out = out_nan
+        return out_nan
+
+    if paddle.in_dynamic_mode() and paddle.numel(x) == 0:
+        out = _replace_nan(out)
+    if not paddle.in_dynamic_mode():
+        out = paddle.static.nn.cond(
+            paddle.numel(x) == 0, lambda: _replace_nan(out), lambda: out
+        )
     if out.dtype != x.dtype:
         return out.astype(x.dtype)
     return out

--- a/python/paddle/tensor/stat.py
+++ b/python/paddle/tensor/stat.py
@@ -210,9 +210,7 @@ def var(
     n.stop_gradient = True
     out /= n
     if x.numel() == 0:
-        out_nan = paddle.full_like(out, paddle.nan)
-        out_nan.stop_gradient = out.stop_gradient
-        out = out_nan
+        out = paddle.full_like(out, paddle.nan)
     if out.dtype != x.dtype:
         return out.astype(x.dtype)
     return out

--- a/python/paddle/tensor/stat.py
+++ b/python/paddle/tensor/stat.py
@@ -209,7 +209,7 @@ def var(
         n = n - 1.0
     n.stop_gradient = True
     out /= n
-    if paddle.numel(x).item() == 0:
+    if paddle.in_dynamic_mode() and paddle.numel(x) == 0:
         out_nan = paddle.full_like(out, paddle.nan)
         out_nan.stop_gradient = out.stop_gradient
         out = out_nan

--- a/test/legacy_test/test_variance_layer.py
+++ b/test/legacy_test/test_variance_layer.py
@@ -126,5 +126,15 @@ class TestVarError(unittest.TestCase):
             self.assertRaises(TypeError, paddle.var, x)
 
 
+class TestVarAPI_ZeroSize(unittest.TestCase):
+    def test_zerosize(self):
+        paddle.disable_static()
+        x = paddle.to_tensor(np.random.random([10, 0]))
+        out1 = paddle.var(x).numpy()
+        out2 = np.var(x.numpy())
+        np.testing.assert_allclose(out1, out2, equal_nan=True)
+        paddle.enable_static()
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->
paddle.var 在python中实现，没有反向
增加单测

PaddleAPITest测试通过，not compare grad是反向没有测试
![image](https://github.com/user-attachments/assets/a6c785c6-b8ff-43ff-84e7-9069482288c3)
