### PR TITLE
[0-size Tensor No.57-58、60-61、63-66] Add 0-size Tensor support for fft2

### DIFF
--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -1470,7 +1470,7 @@ void FFTC2CInferMeta(const MetaTensor& x,
   if (config.is_runtime) {
     const phi::DDim x_dim = x.dims();
     for (auto axis : axes) {
-      PADDLE_ENFORCE_GT(x_dim[axis],
+      PADDLE_ENFORCE_GE(x_dim[axis],
                         0,
                         common::errors::InvalidArgument(
                             "Invalid fft n-point (%d).", x_dim[axis]));
@@ -1497,7 +1497,7 @@ void FFTC2RInferMeta(const MetaTensor& x,
   if (config.is_runtime) {
     size_t signal_dims = axes.size();
     for (size_t i = 0; i < signal_dims - 1; i++) {
-      PADDLE_ENFORCE_GT(x_dim[axes[i]],
+      PADDLE_ENFORCE_GE(x_dim[axes[i]],
                         0,
                         common::errors::InvalidArgument(
                             "Invalid fft n-point (%d).", x_dim[axes[i]]));
@@ -1513,7 +1513,7 @@ void FFTC2RInferMeta(const MetaTensor& x,
   } else if (config.is_runtime) {
     const int64_t input_last_dim_size = x_dim[last_fft_axis];
     const int64_t fft_n_point = (input_last_dim_size - 1) * 2;
-    PADDLE_ENFORCE_GT(fft_n_point,
+    PADDLE_ENFORCE_GE(fft_n_point,
                       0,
                       common::errors::InvalidArgument(
                           "Invalid fft n-point (%d).", fft_n_point));
@@ -1542,7 +1542,7 @@ void FFTR2CInferMeta(const MetaTensor& x,
   // they might be -1 to indicate unknown size ar compile time
   if (config.is_runtime) {
     for (auto axis : axes) {
-      PADDLE_ENFORCE_GT(x_dim[axis],
+      PADDLE_ENFORCE_GE(x_dim[axis],
                         0,
                         common::errors::InvalidArgument(
                             "Invalid fft n-point (%d).", x_dim[axis]));

--- a/paddle/phi/kernels/impl/fft_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/fft_grad_kernel_impl.h
@@ -38,6 +38,9 @@ void FFTC2CGradKernel(const Context& ctx,
                       bool forward,
                       DenseTensor* x_grad) {
   ctx.template Alloc<T>(x_grad);
+  if (x_grad && x_grad->numel() == 0) {
+    return;
+  }
   auto norm_type = funcs::get_norm_from_string(normalization, forward);
   funcs::FFTC2CFunctor<Context, T, T> fft_c2c_func;
   fft_c2c_func(ctx, out_grad, x_grad, axes, norm_type, !forward);
@@ -55,6 +58,10 @@ void FFTR2CGradKernel(const Context& ctx,
   using R = typename T::value_type;
   DenseTensor complex_x_grad = EmptyLike<T>(ctx, x);
   ctx.template Alloc<R>(x_grad);
+  if (x_grad && x_grad->numel() == 0) {
+    return;
+  }
+
   auto norm_type = funcs::get_norm_from_string(normalization, forward);
   funcs::FFTC2CFunctor<Context, T, T> fft_c2c_func;
 
@@ -85,6 +92,10 @@ void FFTC2RGradKernel(const Context& ctx,
                       DenseTensor* x_grad) {
   using C = phi::dtype::complex<T>;
   ctx.template Alloc<C>(x_grad);
+  if (x_grad && x_grad->numel() == 0) {
+    return;
+  }
+
   auto norm_type = funcs::get_norm_from_string(normalization, forward);
 
   funcs::FFTR2CFunctor<Context, T, C> fft_r2c_func;

--- a/paddle/phi/kernels/impl/fft_kernel_impl.h
+++ b/paddle/phi/kernels/impl/fft_kernel_impl.h
@@ -21,9 +21,9 @@
 #include "paddle/common/ddim.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/empty_kernel.h"
+#include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/funcs/fft.h"
 #include "paddle/phi/kernels/funcs/fft_fill_conj.h"
-
 namespace phi {
 template <typename T, typename Context>
 void FFTC2CKernel(const Context& ctx,
@@ -33,6 +33,11 @@ void FFTC2CKernel(const Context& ctx,
                   bool forward,
                   DenseTensor* out) {
   ctx.template Alloc<T>(out);
+  if (x.numel() == 0) {
+    phi::Full<T, Context>(
+        dev_ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
+    return;
+  }
   const auto norm_type = funcs::get_norm_from_string(normalization, forward);
   funcs::FFTC2CFunctor<Context, T, T> fft_c2c_func;
   fft_c2c_func(ctx, x, out, axes, norm_type, forward);
@@ -48,6 +53,11 @@ void FFTC2RKernel(const Context& ctx,
                   DenseTensor* out) {
   using R = typename T::value_type;  // get real type
   ctx.template Alloc<R>(out);
+  if (x.numel() == 0) {
+    phi::Full<R, Context>(
+        dev_ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
+    return;
+  }
   const auto norm_type = funcs::get_norm_from_string(normalization, forward);
   funcs::FFTC2RFunctor<Context, T, R> fft_c2r_func;
   fft_c2r_func(ctx, x, out, axes, norm_type, forward);
@@ -63,6 +73,11 @@ void FFTR2CKernel(const Context& ctx,
                   DenseTensor* out) {
   using C = phi::dtype::complex<T>;
   ctx.template Alloc<C>(out);
+  if (x.numel() == 0) {
+    phi::Full<C, Context>(
+        dev_ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
+    return;
+  }
   auto norm_type = funcs::get_norm_from_string(normalization, forward);
   funcs::FFTR2CFunctor<Context, T, C> fft_r2c_func;
 

--- a/paddle/phi/kernels/impl/fft_kernel_impl.h
+++ b/paddle/phi/kernels/impl/fft_kernel_impl.h
@@ -37,8 +37,8 @@ void FFTC2CKernel(const Context& ctx,
     /*
     This will return 0:
     >>> scipy.fft.fft2(np.random.random([3, 0, 1, 2]), s=(1, 2), axes=(0, 1),
-norm='backward') array([[[[0.-0.j, 0.-0.j]],
-
+norm='backward')
+    array([[[[0.-0.j, 0.-0.j]],
         [[0.-0.j, 0.-0.j]]]])
     */
     phi::Full<T, Context>(

--- a/paddle/phi/kernels/impl/fft_kernel_impl.h
+++ b/paddle/phi/kernels/impl/fft_kernel_impl.h
@@ -34,6 +34,13 @@ void FFTC2CKernel(const Context& ctx,
                   DenseTensor* out) {
   ctx.template Alloc<T>(out);
   if (x.numel() == 0) {
+    /*
+    This will return 0:
+    >>> scipy.fft.fft2(np.random.random([3, 0, 1, 2]), s=(1, 2), axes=(0, 1),
+norm='backward') array([[[[0.-0.j, 0.-0.j]],
+
+        [[0.-0.j, 0.-0.j]]]])
+    */
     phi::Full<T, Context>(
         ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
     return;

--- a/paddle/phi/kernels/impl/fft_kernel_impl.h
+++ b/paddle/phi/kernels/impl/fft_kernel_impl.h
@@ -35,7 +35,7 @@ void FFTC2CKernel(const Context& ctx,
   ctx.template Alloc<T>(out);
   if (x.numel() == 0) {
     phi::Full<T, Context>(
-        dev_ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
+        ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
     return;
   }
   const auto norm_type = funcs::get_norm_from_string(normalization, forward);
@@ -55,7 +55,7 @@ void FFTC2RKernel(const Context& ctx,
   ctx.template Alloc<R>(out);
   if (x.numel() == 0) {
     phi::Full<R, Context>(
-        dev_ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
+        ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
     return;
   }
   const auto norm_type = funcs::get_norm_from_string(normalization, forward);
@@ -75,7 +75,7 @@ void FFTR2CKernel(const Context& ctx,
   ctx.template Alloc<C>(out);
   if (x.numel() == 0) {
     phi::Full<C, Context>(
-        dev_ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
+        ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
     return;
   }
   auto norm_type = funcs::get_norm_from_string(normalization, forward);

--- a/test/fft/test_fft.py
+++ b/test/fft/test_fft.py
@@ -2009,5 +2009,245 @@ class TestIfftShift_ZeroSize(unittest.TestCase):
             )
 
 
+@place(DEVICES)
+@parameterize(
+    (TEST_CASE_NAME, 'x', 'n', 'axis', 'norm'),
+    [
+        ('test_x', np.random.randn(3, 3, 0, 2), (1, 2), (0, 1), 'backward'),
+    ],
+)
+class TestFft2_ZeroSize(unittest.TestCase):
+    def test_fft2(self):
+        with paddle.base.dygraph.guard(self.place):
+            np.testing.assert_allclose(
+                scipy.fft.fft2(self.x, self.n, self.axis, self.norm),
+                paddle.fft.fft2(
+                    paddle.to_tensor(self.x), self.n, self.axis, self.norm
+                ),
+                rtol=RTOL.get(str(self.x.dtype)),
+                atol=ATOL.get(str(self.x.dtype)),
+            )
+
+    def test_grad_shape(self):
+        with paddle.base.dygraph.guard(self.place):
+            x = paddle.to_tensor(self.x, stop_gradient=False)
+            y = paddle.fft.fft2(x, self.n, self.axis, self.norm)
+            loss = paddle.sum(y)
+            loss.backward()
+            np.testing.assert_equal(
+                x.grad.shape, self.x.shape, "Grad shape mismatch"
+            )
+
+
+@place(DEVICES)
+@parameterize(
+    (TEST_CASE_NAME, 'x', 'n', 'axis', 'norm'),
+    [
+        ('test_x', np.random.randn(4, 0, 6), (2, 4), None, 'backward'),
+    ],
+)
+class TestFftn_ZeroSize(unittest.TestCase):
+    def test_fftn(self):
+        with paddle.base.dygraph.guard(self.place):
+            np.testing.assert_allclose(
+                scipy.fft.fftn(self.x, self.n, self.axis, self.norm),
+                paddle.fft.fftn(
+                    paddle.to_tensor(self.x), self.n, self.axis, self.norm
+                ),
+                rtol=RTOL.get(str(self.x.dtype)),
+                atol=ATOL.get(str(self.x.dtype)),
+            )
+
+    def test_grad_shape(self):
+        with paddle.base.dygraph.guard(self.place):
+            x = paddle.to_tensor(self.x, stop_gradient=False)
+            y = paddle.fft.fftn(x, self.n, self.axis, self.norm)
+            loss = paddle.sum(y)
+            loss.backward()
+            np.testing.assert_equal(
+                x.grad.shape, self.x.shape, "Grad shape mismatch"
+            )
+
+
+@place(DEVICES)
+@parameterize(
+    (TEST_CASE_NAME, 'x', 'n', 'axis', 'norm'),
+    [
+        ('test_x', np.random.randn(3, 3, 0, 2), (1, 2), (0, 1), 'backward'),
+    ],
+)
+class TestIfft2_ZeroSize(unittest.TestCase):
+    def test_ifft2(self):
+        with paddle.base.dygraph.guard(self.place):
+            np.testing.assert_allclose(
+                scipy.fft.ifft2(self.x, self.n, self.axis, self.norm),
+                paddle.fft.ifft2(
+                    paddle.to_tensor(self.x), self.n, self.axis, self.norm
+                ),
+                rtol=RTOL.get(str(self.x.dtype)),
+                atol=ATOL.get(str(self.x.dtype)),
+            )
+
+    def test_grad_shape(self):
+        with paddle.base.dygraph.guard(self.place):
+            x = paddle.to_tensor(self.x, stop_gradient=False)
+            y = paddle.fft.ifft2(x, self.n, self.axis, self.norm)
+            loss = paddle.sum(y)
+            loss.backward()
+            np.testing.assert_equal(
+                x.grad.shape, self.x.shape, "Grad shape mismatch"
+            )
+
+
+@place(DEVICES)
+@parameterize(
+    (TEST_CASE_NAME, 'x', 'n', 'axis', 'norm'),
+    [
+        ('test_x', np.random.randn(4, 0, 6), (2, 4), None, 'backward'),
+    ],
+)
+class TestIfftn_ZeroSize(unittest.TestCase):
+    def test_ifftn(self):
+        with paddle.base.dygraph.guard(self.place):
+            np.testing.assert_allclose(
+                scipy.fft.ifftn(self.x, self.n, self.axis, self.norm),
+                paddle.fft.ifftn(
+                    paddle.to_tensor(self.x), self.n, self.axis, self.norm
+                ),
+                rtol=RTOL.get(str(self.x.dtype)),
+                atol=ATOL.get(str(self.x.dtype)),
+            )
+
+    def test_grad_shape(self):
+        with paddle.base.dygraph.guard(self.place):
+            x = paddle.to_tensor(self.x, stop_gradient=False)
+            y = paddle.fft.ifftn(x, self.n, self.axis, self.norm)
+            loss = paddle.sum(y)
+            loss.backward()
+            np.testing.assert_equal(
+                x.grad.shape, self.x.shape, "Grad shape mismatch"
+            )
+
+
+@place(DEVICES)
+@parameterize(
+    (TEST_CASE_NAME, 'x', 'n', 'axis', 'norm'),
+    [
+        ('test_x', np.random.randn(3, 3, 0, 2), None, (0, 1), 'backward'),
+    ],
+)
+class TestIhfft2_ZeroSize(unittest.TestCase):
+    def test_ihfft2(self):
+        with paddle.base.dygraph.guard(self.place):
+            np.testing.assert_allclose(
+                scipy.fft.ihfft2(self.x, self.n, self.axis, self.norm),
+                paddle.fft.ihfft2(
+                    paddle.to_tensor(self.x), self.n, self.axis, self.norm
+                ),
+                rtol=RTOL.get(str(self.x.dtype)),
+                atol=ATOL.get(str(self.x.dtype)),
+            )
+
+    def test_grad_shape(self):
+        with paddle.base.dygraph.guard(self.place):
+            x = paddle.to_tensor(self.x, stop_gradient=False)
+            y = paddle.fft.ihfft2(x, self.n, self.axis, self.norm)
+            loss = paddle.sum(y)
+            loss.backward()
+            np.testing.assert_equal(
+                x.grad.shape, self.x.shape, "Grad shape mismatch"
+            )
+
+
+@place(DEVICES)
+@parameterize(
+    (TEST_CASE_NAME, 'x', 'n', 'axis', 'norm'),
+    [
+        ('test_x', np.random.randn(4, 0, 6), (2, 4), None, 'backward'),
+    ],
+)
+class TestIhfftn_ZeroSize(unittest.TestCase):
+    def test_ihfftn(self):
+        with paddle.base.dygraph.guard(self.place):
+            np.testing.assert_allclose(
+                scipy.fft.ihfftn(self.x, self.n, self.axis, self.norm),
+                paddle.fft.ihfftn(
+                    paddle.to_tensor(self.x), self.n, self.axis, self.norm
+                ),
+                rtol=RTOL.get(str(self.x.dtype)),
+                atol=ATOL.get(str(self.x.dtype)),
+            )
+
+    def test_grad_shape(self):
+        with paddle.base.dygraph.guard(self.place):
+            x = paddle.to_tensor(self.x, stop_gradient=False)
+            y = paddle.fft.ihfftn(x, self.n, self.axis, self.norm)
+            loss = paddle.sum(y)
+            loss.backward()
+            np.testing.assert_equal(
+                x.grad.shape, self.x.shape, "Grad shape mismatch"
+            )
+
+
+@place(DEVICES)
+@parameterize(
+    (TEST_CASE_NAME, 'x', 'n', 'axis', 'norm'),
+    [
+        ('test_x', np.random.randn(3, 3, 0, 2), None, (0, 1), 'backward'),
+    ],
+)
+class TestRfft2_ZeroSize(unittest.TestCase):
+    def test_rfft2(self):
+        with paddle.base.dygraph.guard(self.place):
+            np.testing.assert_allclose(
+                scipy.fft.rfft2(self.x, self.n, self.axis, self.norm),
+                paddle.fft.rfft2(
+                    paddle.to_tensor(self.x), self.n, self.axis, self.norm
+                ),
+                rtol=RTOL.get(str(self.x.dtype)),
+                atol=ATOL.get(str(self.x.dtype)),
+            )
+
+    def test_grad_shape(self):
+        with paddle.base.dygraph.guard(self.place):
+            x = paddle.to_tensor(self.x, stop_gradient=False)
+            y = paddle.fft.rfft2(x, self.n, self.axis, self.norm)
+            loss = paddle.sum(y)
+            loss.backward()
+            np.testing.assert_equal(
+                x.grad.shape, self.x.shape, "Grad shape mismatch"
+            )
+
+
+@place(DEVICES)
+@parameterize(
+    (TEST_CASE_NAME, 'x', 'n', 'axis', 'norm'),
+    [
+        ('test_x', np.random.randn(4, 0, 6), (2, 4), None, 'backward'),
+    ],
+)
+class TestRfftn_ZeroSize(unittest.TestCase):
+    def test_rfftn(self):
+        with paddle.base.dygraph.guard(self.place):
+            np.testing.assert_allclose(
+                scipy.fft.rfftn(self.x, self.n, self.axis, self.norm),
+                paddle.fft.rfftn(
+                    paddle.to_tensor(self.x), self.n, self.axis, self.norm
+                ),
+                rtol=RTOL.get(str(self.x.dtype)),
+                atol=ATOL.get(str(self.x.dtype)),
+            )
+
+    def test_grad_shape(self):
+        with paddle.base.dygraph.guard(self.place):
+            x = paddle.to_tensor(self.x, stop_gradient=False)
+            y = paddle.fft.rfftn(x, self.n, self.axis, self.norm)
+            loss = paddle.sum(y)
+            loss.backward()
+            np.testing.assert_equal(
+                x.grad.shape, self.x.shape, "Grad shape mismatch"
+            )
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/fft/test_fft.py
+++ b/test/fft/test_fft.py
@@ -1029,14 +1029,6 @@ class TestHfft2Exception(unittest.TestCase):
             ValueError,
         ),
         (
-            'test_zero_point',
-            np.random.randn(4, 4, 1) + 1j * np.random.randn(4, 4, 1),
-            None,
-            (-2, -1),
-            "backward",
-            ValueError,
-        ),
-        (
             'test_n_zero',
             np.random.randn(4, 4, 4) + 1j * np.random.randn(4, 4, 4),
             (0, 0),


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->
[0-size Tensor No.57-58、60-61、63-66] Add 0-size Tensor support for fft2

修改前向和反向
paddle/phi/infermeta/unary.cc 修改等于0判断
symbolic_shape 没有对应代码，查找 FftC2cOpInferSymbolicShape FftC2rOpInferSymbolicShape FftR2cOpInferSymbolicShape
https://github.com/PaddlePaddle/Paddle/blob/6c675da309b004e0889aa31c46f2d9d6c7721c85/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.cc#L1348
cpu/gpu kernel共用impl实现

PaddleAPITest 测试已修复cuda error , paddle error，存在错误为torch error
fft2
![image](https://github.com/user-attachments/assets/3c30f21a-91c6-45ff-b39e-e1965d29e55d)

fftn
![image](https://github.com/user-attachments/assets/ff7b7496-2d98-48bc-abd9-f45904950cf7)

ifft2
![image](https://github.com/user-attachments/assets/f0f2d73f-78ed-4a95-a6db-07fe5f8cd970)

ifftn
![image](https://github.com/user-attachments/assets/e83bf14a-884a-43f2-887b-b86e939f8deb)

ihfft2
![image](https://github.com/user-attachments/assets/aab3978f-a41b-47a3-acfd-080e95b11beb)

ihfftn
![image](https://github.com/user-attachments/assets/c259527a-8158-43a4-996b-656428feace5)

rfft2
![image](https://github.com/user-attachments/assets/1f7c4f30-188b-4283-9a35-54357c5ec97f)

rfftn
![image](https://github.com/user-attachments/assets/4baa598b-4881-4324-afd7-da75599f1f0f)

单测中取消 test_zero_point 中检查错误的判断，这样 irfft2 中 s=None 可以