### PR TITLE
[0-size Tensor No.200、210、345、356、267、338] Add 0-size Tensor support for prelu/maxout/var

### DIFF
--- a/paddle/phi/kernels/cpu/prelu_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/prelu_grad_kernel.cc
@@ -16,7 +16,7 @@
 
 #include "paddle/phi/backends/cpu/cpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
-
+#include "paddle/phi/kernels/full_kernel.h"
 namespace phi {
 
 template <typename T, typename Context>
@@ -28,6 +28,17 @@ void PReluGradKernel(const Context& dev_ctx,
                      const std::string& mode,
                      DenseTensor* x_grad,
                      DenseTensor* alpha_grad) {
+  if (x_grad->numel() == 0) {
+    dev_ctx.template Alloc<T>(x_grad);
+    if (alpha_grad) {
+      phi::Full<T, Context>(
+          dev_ctx,
+          phi::IntArray(common::vectorize(alpha_grad->dims())),
+          0,
+          alpha_grad);
+    }
+    return;
+  }
   const T* alpha_ptr = alpha.data<T>();
   const T* x_ptr = x.data<T>();
   const T* out_grad_ptr = out_grad.data<T>();

--- a/paddle/phi/kernels/cpu/prelu_kernel.cc
+++ b/paddle/phi/kernels/cpu/prelu_kernel.cc
@@ -29,6 +29,9 @@ void PReluKernel(const Context& dev_ctx,
   const T* x_ptr = x.data<T>();
   const T* alpha_ptr = alpha.data<T>();
   T* o_ptr = dev_ctx.template Alloc<T>(out);
+  if (out && out->numel() == 0) {
+    return;
+  }
 
   int numel = static_cast<int>(x.numel());
   auto dim = x.dims();

--- a/paddle/phi/kernels/gpu/prelu_kernel.cu
+++ b/paddle/phi/kernels/gpu/prelu_kernel.cu
@@ -32,6 +32,9 @@ void PReluKernel(const Context& dev_ctx,
                  const std::string& mode,
                  DenseTensor* out) {
   dev_ctx.template Alloc<T>(out);
+  if (out && out->numel() == 0) {
+    return;
+  }
   const T* x_ptr = x.data<T>();
   const T* alpha_ptr = alpha.data<T>();
 

--- a/paddle/phi/kernels/impl/maxout_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/maxout_grad_kernel_impl.h
@@ -28,6 +28,10 @@ void MaxOutGradKernel(const Context& dev_ctx,
                       int groups,
                       int axis,
                       DenseTensor* x_grad) {
+  if (x_grad && x_grad->numel() == 0) {
+    dev_ctx.template Alloc<T>(x_grad);
+    return;
+  }
   if (axis < 0) {
     axis += x.dims().size();
   }

--- a/paddle/phi/kernels/impl/maxout_kernel_impl.h
+++ b/paddle/phi/kernels/impl/maxout_kernel_impl.h
@@ -25,6 +25,10 @@ void MaxOutKernel(const Context& dev_ctx,
                   int groups,
                   int axis,
                   DenseTensor* out) {
+  if (out && out->numel() == 0) {
+    dev_ctx.template Alloc<T>(out);
+    return;
+  }
   if (axis < 0) {
     axis += x.dims().size();
   }

--- a/paddle/phi/kernels/onednn/prelu_grad_kernel.cc
+++ b/paddle/phi/kernels/onednn/prelu_grad_kernel.cc
@@ -16,7 +16,7 @@
 
 #include "paddle/phi/backends/onednn/onednn_reuse.h"
 #include "paddle/phi/core/kernel_registry.h"
-
+#include "paddle/phi/kernels/full_kernel.h"
 namespace phi {
 
 template <typename T, typename Context>
@@ -28,6 +28,16 @@ void PReluGradKernel(const Context& dev_ctx,
                      const std::string& mode,
                      DenseTensor* x_grad,
                      DenseTensor* alpha_grad) {
+  if (x_grad->numel() == 0) {
+    dev_ctx.template Alloc<T>(x_grad);
+    if (alpha_grad) {
+      phi::Full<T, Context>(
+          dev_ctx,
+          phi::IntArray(common::vectorize(alpha_grad->dims())),
+          0,
+          alpha_grad);
+    }
+  }
   bool is_test = dev_ctx.HasDnnAttr("is_test")
                      ? PADDLE_GET_CONST(bool, dev_ctx.GetDnnAttr("is_test"))
                      : false;

--- a/paddle/phi/kernels/onednn/prelu_kernel.cc
+++ b/paddle/phi/kernels/onednn/prelu_kernel.cc
@@ -29,6 +29,10 @@ void PReluKernel(const Context& dev_ctx,
                     AllocationType::CPU,
                     common::errors::PreconditionNotMet(
                         "Operator oneDNN PReLU must use CPUPlace"));
+  if (out && out->numel() == 0) {
+    dev_ctx.template Alloc<T>(out);
+    return;
+  }
 
   bool is_test = dev_ctx.HasDnnAttr("is_test")
                      ? PADDLE_GET_CONST(bool, dev_ctx.GetDnnAttr("is_test"))

--- a/paddle/phi/kernels/xpu/prelu_kernel.cc
+++ b/paddle/phi/kernels/xpu/prelu_kernel.cc
@@ -31,6 +31,9 @@ void PReluKernel(const Context& dev_ctx,
   const T* alpha_ptr = alpha.data<T>();
 
   T* y_ptr = dev_ctx.template Alloc<T>(out);
+  if (out && out->numel() == 0) {
+    return;
+  }
 
   auto x_dim = x.dims();
   auto x_rank = x_dim.size();

--- a/python/paddle/tensor/stat.py
+++ b/python/paddle/tensor/stat.py
@@ -209,6 +209,18 @@ def var(
         n = n - 1.0
     n.stop_gradient = True
     out /= n
+
+    def _replace_nan(out):
+        out_nan = paddle.full_like(out, paddle.nan)
+        out_nan.stop_gradient = out.stop_gradient
+        return out_nan
+
+    if paddle.in_dynamic_mode() and paddle.numel(x) == 0:
+        out = _replace_nan(out)
+    if not paddle.in_dynamic_mode():
+        out = paddle.static.nn.cond(
+            paddle.numel(x) == 0, lambda: _replace_nan(out), lambda: out
+        )
     if out.dtype != x.dtype:
         return out.astype(x.dtype)
     return out

--- a/python/paddle/tensor/stat.py
+++ b/python/paddle/tensor/stat.py
@@ -215,12 +215,8 @@ def var(
         out_nan.stop_gradient = out.stop_gradient
         return out_nan
 
-    if paddle.in_dynamic_mode() and paddle.numel(x) == 0:
+    if 0 in x.shape:
         out = _replace_nan(out)
-    if not paddle.in_dynamic_mode():
-        out = paddle.static.nn.cond(
-            paddle.numel(x) == 0, lambda: _replace_nan(out), lambda: out
-        )
     if out.dtype != x.dtype:
         return out.astype(x.dtype)
     return out

--- a/test/legacy_test/test_maxout_op.py
+++ b/test/legacy_test/test_maxout_op.py
@@ -83,6 +83,11 @@ class TestMaxOutOpGroups(TestMaxOutOp):
         self.groups = 3
 
 
+class TestMaxOutOp_ZeroSize(TestMaxOutOp):
+    def set_attrs(self):
+        self.shape = [3, 0, 2, 4]
+
+
 class TestMaxoutAPI(unittest.TestCase):
     # test paddle.nn.Maxout, paddle.nn.functional.maxout
     def setUp(self):

--- a/test/legacy_test/test_prelu_op.py
+++ b/test/legacy_test/test_prelu_op.py
@@ -379,6 +379,11 @@ class TestModeElementRank6NHWC(PReluTest):
         self.attrs = {'mode': "element", "data_format": "NHWC"}
 
 
+class TestModeElt_ZeroSize(PReluTest):
+    def init_input_shape(self):
+        self.x_shape = [3, 0, 5, 10]
+
+
 def create_test_fp16_class(
     parent, check_grad=True, atol=1e-3, max_relative_error=0.05
 ):

--- a/test/legacy_test/test_variance_layer.py
+++ b/test/legacy_test/test_variance_layer.py
@@ -126,5 +126,15 @@ class TestVarError(unittest.TestCase):
             self.assertRaises(TypeError, paddle.var, x)
 
 
+class TestVarAPI_ZeroSize(unittest.TestCase):
+    def test_zerosize(self):
+        paddle.disable_static()
+        x = paddle.to_tensor(np.random.random([10, 0]))
+        out1 = paddle.var(x).numpy()
+        out2 = np.var(x.numpy())
+        np.testing.assert_allclose(out1, out2, equal_nan=True)
+        paddle.enable_static()
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->
paddle.nn.functional.prelu
修改前向和反向
infermeta 判断weight numel为1没有修改
kernel 修改cpu/gpu/xpu/onednn

PaddleAPITest已修复cuda error, paddle error 为weight numel的判断，需要为1
![image](https://github.com/user-attachments/assets/2f5e8a21-1799-4036-b70f-43af763a5d04)


paddle.nn.functional.maxout
修改前向和反向
infermeta 没有修改
kernel 修改cpu/gpu，共用 impl 调用

PaddleAPITest 测试通过
![image](https://github.com/user-attachments/assets/61d3f372-41ae-4669-b6d5-44cd1727ac22)

 
paddle.var 在python中实现，没有反向
增加单测
PaddleAPITest测试通过，not compare grad是反向没有测试
![image](https://github.com/user-attachments/assets/a6c785c6-b8ff-43ff-84e7-9069482288c3)

paddle.std 调用的是paddle.var ，修改paddle.var即可
PaddleAPITest 测试
![image](https://github.com/user-attachments/assets/ddbbc836-0374-46ce-8a94-550a45ac0a4f)
