### PR TITLE
优化to_tensor函数中的bf16转换

### DIFF
--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -763,7 +763,11 @@ def _to_tensor_non_static(
                 data = data.astype("int64")
 
     if dtype:
-        if convert_dtype(dtype) == 'uint16' and 'bfloat16' in str(dtype):
+        if (
+            convert_dtype(dtype) == 'uint16'
+            and 'bfloat16' in str(dtype)
+            and isinstance(data, np.ndarray)
+        ):
             tensor = core.eager.Tensor(
                 value=data,
                 place=place,
@@ -772,7 +776,9 @@ def _to_tensor_non_static(
                 name=None,
                 stop_gradient=stop_gradient,
             )
-            return tensor.astype(dtype)
+            tensor = tensor.detach().astype(dtype)
+            tensor.stop_gradient = stop_gradient
+            return tensor
         else:
             data = _handle_np_dtype(data, dtype)
 

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -763,7 +763,18 @@ def _to_tensor_non_static(
                 data = data.astype("int64")
 
     if dtype:
-        data = _handle_np_dtype(data, dtype)
+        if convert_dtype(dtype) == 'uint16' and 'bfloat16' in str(dtype):
+            tensor = core.eager.Tensor(
+                value=data,
+                place=place,
+                persistable=False,
+                zero_copy=False,
+                name=None,
+                stop_gradient=stop_gradient,
+            )
+            return tensor.astype(dtype)
+        else:
+            data = _handle_np_dtype(data, dtype)
 
     if isinstance(data, np.ndarray):
         return core.eager.Tensor(

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -18,10 +18,9 @@ import builtins
 import math
 import re
 import warnings
-from typing import TYPE_CHECKING, Any, overload
+from typing import TYPE_CHECKING, overload
 
 import numpy as np
-import numpy.typing as npt
 
 import paddle
 from paddle import _C_ops
@@ -32,7 +31,6 @@ from ..base.data_feeder import (
     check_type,
     check_variable_and_dtype,
     convert_dtype,
-    convert_float_to_uint16,
 )
 from ..base.framework import Variable, device_guard
 from ..base.param_attr import ParamAttr
@@ -699,19 +697,6 @@ def _to_tensor_non_static(
                 return tensor.astype(convert_dtype(dtype))
         return tensor
 
-    def _handle_np_dtype(
-        ndarray: npt.NDArray[Any], dtype: DTypeLike
-    ) -> npt.NDArray[Any]:
-        if dtype:
-            if convert_dtype(dtype) != convert_dtype(ndarray.dtype):
-                # should not ndarray.astype('uint16') directly, data bits is wrong
-                if convert_dtype(dtype) in ['uint16']:
-                    return convert_float_to_uint16(ndarray.astype('float32'))
-                else:
-                    return ndarray.astype(convert_dtype(dtype))
-
-        return ndarray
-
     if isinstance(data, np.number):  # Special case for numpy scalars
         data = np.array(data)
 
@@ -757,7 +742,11 @@ def _to_tensor_non_static(
                         if default_type in ['float16', 'float32']
                         else 'complex128'
                     )
-                data = _handle_np_dtype(data, default_type)
+                if convert_dtype(default_type) != convert_dtype(data.dtype):
+                    if convert_dtype(default_type) in ['uint16']:
+                        dtype = 'bfloat16'
+                    else:
+                        data = data.astype(convert_dtype(default_type))
             # Windows default type is 'int32', while Linux/Mac is 'int64'. Unify they.
             if data.dtype in ['int32']:
                 data = data.astype("int64")
@@ -780,7 +769,8 @@ def _to_tensor_non_static(
             tensor.stop_gradient = stop_gradient
             return tensor
         else:
-            data = _handle_np_dtype(data, dtype)
+            if convert_dtype(dtype) != convert_dtype(data.dtype):
+                data = data.astype(convert_dtype(dtype))
 
     if isinstance(data, np.ndarray):
         return core.eager.Tensor(

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -743,20 +743,13 @@ def _to_tensor_non_static(
                         else 'complex128'
                     )
                 if convert_dtype(default_type) != convert_dtype(data.dtype):
-                    if convert_dtype(default_type) in ['uint16']:
-                        dtype = 'bfloat16'
-                    else:
-                        data = data.astype(convert_dtype(default_type))
+                    dtype = default_type
             # Windows default type is 'int32', while Linux/Mac is 'int64'. Unify they.
             if data.dtype in ['int32']:
                 data = data.astype("int64")
 
-    if dtype:
-        if (
-            convert_dtype(dtype) == 'uint16'
-            and 'bfloat16' in str(dtype)
-            and isinstance(data, np.ndarray)
-        ):
+    if dtype and convert_dtype(dtype) != convert_dtype(data.dtype):
+        if convert_dtype(dtype) == 'uint16':
             tensor = core.eager.Tensor(
                 value=data,
                 place=place,
@@ -769,8 +762,7 @@ def _to_tensor_non_static(
             tensor.stop_gradient = stop_gradient
             return tensor
         else:
-            if convert_dtype(dtype) != convert_dtype(data.dtype):
-                data = data.astype(convert_dtype(dtype))
+            data = data.astype(convert_dtype(dtype))
 
     if isinstance(data, np.ndarray):
         return core.eager.Tensor(

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -774,9 +774,9 @@ def _to_tensor_non_static(
                 persistable=False,
                 zero_copy=False,
                 name=None,
-                stop_gradient=stop_gradient,
+                stop_gradient=True,
             )
-            tensor = tensor.detach().astype(dtype)
+            tensor = tensor.astype(dtype)
             tensor.stop_gradient = stop_gradient
             return tensor
         else:

--- a/test/dygraph_to_static/test_to_tensor.py
+++ b/test/dygraph_to_static/test_to_tensor.py
@@ -104,19 +104,6 @@ def case8(x):
     return a
 
 
-@unittest.skipIf(
-    not paddle.is_compiled_with_cuda(),
-    "CUDA is not available, this test requires GPU support.",
-)
-def case9():
-    data = np.array([[1.0, 2.0], [3.0, 4.0]], dtype="float32")
-    place = paddle.CUDAPlace(0)
-
-    x = paddle.to_tensor(data, dtype="bfloat16", place=place)
-
-    assert x.dtype == paddle.bfloat16
-
-
 def case_to_tensor_default_dtype():
     return paddle.to_tensor(1)
 

--- a/test/dygraph_to_static/test_to_tensor.py
+++ b/test/dygraph_to_static/test_to_tensor.py
@@ -104,6 +104,19 @@ def case8(x):
     return a
 
 
+@unittest.skipIf(
+    not paddle.is_compiled_with_cuda(),
+    "CUDA is not available, this test requires GPU support.",
+)
+def case9():
+    data = np.array([[1.0, 2.0], [3.0, 4.0]], dtype="float32")
+    place = paddle.CUDAPlace(0)
+
+    x = paddle.to_tensor(data, dtype="bfloat16", place=place)
+
+    assert x.dtype == paddle.bfloat16
+
+
 def case_to_tensor_default_dtype():
     return paddle.to_tensor(1)
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Improvements

### Description
<!-- Describe what you’ve done -->

resolve https://github.com/PaddlePaddle/Paddle/issues/72484

需求：

> 1.  保持原numpy类型不变，直接转为一个paddle.Tensor
> 2.  返回paddle.Tensor，astype为bfloat16

测试代码

```python
import numpy as np
import paddle
import time

x = np.random.randn(100000).astype(np.float32)
tensor_bfloat16 = paddle.to_tensor(x, dtype=paddle.bfloat16)


num_runs = 1000
total_time = 0

for _ in range(num_runs):
    start_time = time.time()
    tensor_bfloat16 = paddle.to_tensor(x, dtype=paddle.bfloat16)
    paddle.device.synchronize()
    end_time = time.time()
    total_time += (end_time - start_time)

avg_time = total_time / num_runs

print(f"avg time ({num_runs} runs): {avg_time * 1000:.4f} ms")
```

原本方式平均耗时为 40.4780 ms， 修改后平均耗时为 0.2655 ms。