### PR TITLE
[AutoParallel] fused_rms_norm SPMD adapt partial status

### DIFF
--- a/paddle/phi/infermeta/spmd_rules/rms_norm.cc
+++ b/paddle/phi/infermeta/spmd_rules/rms_norm.cc
@@ -167,8 +167,9 @@ SpmdInfo RmsNormGradInferSpmd(const DistMetaTensor& x,
   std::string align_annotation;
   std::tie(annotations, align_annotation) =
       BuildRmsNormGradEinsum(x_shape.size());
+  // Don't align on mp mesh.
   AlignDimsSharding(
-      &dist_attrs, shapes, annotations, {}, align_annotation, false);
+      &dist_attrs, shapes, annotations, {1}, align_annotation, true);
   auto x_dist_attr_dst = dist_attrs[0];
   auto invvar_dist_attr_dst = dist_attrs[1];
   auto out_grad_dist_attr_dst = dist_attrs[2];

--- a/paddle/phi/infermeta/spmd_rules/rms_norm.cc
+++ b/paddle/phi/infermeta/spmd_rules/rms_norm.cc
@@ -96,8 +96,6 @@ SpmdInfo RmsNormInferSpmdReverse(const DistMetaTensor& x,
     x_axes[i] = alphabet[i];
     variance_axes[i] = alphabet[i];
   }
-  x_axes[1] = '1';
-  variance_axes[1] = '1';
   auto out_axes = x_axes;
   std::string scale_axes(1, x_axes[x_ndim - 1]);
 
@@ -137,10 +135,6 @@ std::tuple<std::vector<std::string>, std::string> BuildRmsNormGradEinsum(
   std::string x_notation = alphabet.substr(0, input_rank);
   std::string variance_notation = x_notation.substr(0, input_rank - 1);
   std::string align_notation = x_notation.substr(0, input_rank - 1);
-  x_notation[1] = '1';
-  variance_notation[1] = '1';
-  align_notation =
-      align_notation.substr(0, 1) + align_notation.substr(2, input_rank - 1);
   return {{x_notation, variance_notation, x_notation}, align_notation};
 }
 
@@ -173,6 +167,10 @@ SpmdInfo RmsNormGradInferSpmd(const DistMetaTensor& x,
   std::string align_annotation;
   std::tie(annotations, align_annotation) =
       BuildRmsNormGradEinsum(x_shape.size());
+  // Partial status is not supported.
+  for (auto& dist_attr : dist_attrs) {
+    dist_attr.clean_partial_status();
+  }
   AlignDimsSharding(
       &dist_attrs, shapes, annotations, {}, align_annotation, false);
   auto x_dist_attr_dst = dist_attrs[0];

--- a/paddle/phi/infermeta/spmd_rules/rms_norm.cc
+++ b/paddle/phi/infermeta/spmd_rules/rms_norm.cc
@@ -96,6 +96,8 @@ SpmdInfo RmsNormInferSpmdReverse(const DistMetaTensor& x,
     x_axes[i] = alphabet[i];
     variance_axes[i] = alphabet[i];
   }
+  x_axes[1] = '1';
+  variance_axes[1] = '1';
   auto out_axes = x_axes;
   std::string scale_axes(1, x_axes[x_ndim - 1]);
 
@@ -135,6 +137,10 @@ std::tuple<std::vector<std::string>, std::string> BuildRmsNormGradEinsum(
   std::string x_notation = alphabet.substr(0, input_rank);
   std::string variance_notation = x_notation.substr(0, input_rank - 1);
   std::string align_notation = x_notation.substr(0, input_rank - 1);
+  x_notation[1] = '1';
+  variance_notation[1] = '1';
+  align_notation =
+      align_notation.substr(0, 1) + align_notation.substr(2, input_rank - 1);
   return {{x_notation, variance_notation, x_notation}, align_notation};
 }
 
@@ -167,9 +173,8 @@ SpmdInfo RmsNormGradInferSpmd(const DistMetaTensor& x,
   std::string align_annotation;
   std::tie(annotations, align_annotation) =
       BuildRmsNormGradEinsum(x_shape.size());
-  // Don't align on mp mesh.
   AlignDimsSharding(
-      &dist_attrs, shapes, annotations, {1}, align_annotation, false);
+      &dist_attrs, shapes, annotations, {}, align_annotation, false);
   auto x_dist_attr_dst = dist_attrs[0];
   auto invvar_dist_attr_dst = dist_attrs[1];
   auto out_grad_dist_attr_dst = dist_attrs[2];

--- a/paddle/phi/infermeta/spmd_rules/rms_norm.cc
+++ b/paddle/phi/infermeta/spmd_rules/rms_norm.cc
@@ -169,7 +169,7 @@ SpmdInfo RmsNormGradInferSpmd(const DistMetaTensor& x,
       BuildRmsNormGradEinsum(x_shape.size());
   // Don't align on mp mesh.
   AlignDimsSharding(
-      &dist_attrs, shapes, annotations, {1}, align_annotation, true);
+      &dist_attrs, shapes, annotations, {1}, align_annotation, false);
   auto x_dist_attr_dst = dist_attrs[0];
   auto invvar_dist_attr_dst = dist_attrs[1];
   auto out_grad_dist_attr_dst = dist_attrs[2];


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
**背景：**
    动半下自定义算子 `fused_rms_norm` 的 SPMD 在遇到输入存在 `partial` 状态输入时，会转化为 `shard` 状态，其他 replicate 状态的输入也要转化为 `shard` 状态，这会导致较多通信时间。

**解决方法：**
    这里修改 SPMD 将该输入的 `partial` 状态转为 `replicate` 状态，其他输入还可以继续保持 `replicate` 状态，减少其他输入状态的改变，可以减少通信时长，提高性能


**验证：**
qwen-13b H800 N4C32 吞吐(token/s/card)
修复前：4143.43
修复后：4344.84(+4.86%)


Pcard-91035