### PR TITLE
[Prim&Comp] Support `repeat_interleave double grad`

### DIFF
--- a/paddle/phi/ops/yaml/backward.yaml
+++ b/paddle/phi/ops/yaml/backward.yaml
@@ -2103,16 +2103,6 @@
     data_type : softmax
   inplace : (softmax -> logits_grad)
 
-- backward_op : masked_fill_double_grad
-  forward : masked_fill_grad (Tensor x, Tensor mask, Tensor value, Tensor grad_out) -> Tensor(grad_x), Tensor(grad_value)
-  args : (Tensor mask, Tensor grad_x_grad, Tensor grad_value_grad)
-  output : Tensor(grad_out_grad)
-  infer_meta :
-    func : UnchangedInferMeta
-    param : [grad_x_grad]
-  optional: grad_x_grad, grad_value_grad
-  composite : masked_fill_double_grad(mask, grad_x_grad, grad_value_grad, grad_out_grad)
-
 - backward_op : masked_fill_grad
   forward : masked_fill (Tensor x, Tensor mask, Tensor value) -> Tensor(out)
   args : (Tensor x, Tensor mask, Tensor value, Tensor out_grad)
@@ -2124,7 +2114,7 @@
     func : masked_fill_grad
     param: [x, mask, value, out_grad]
   inplace : (out_grad -> x_grad)
-  backward: masked_fill_double_grad
+  composite : masked_fill_grad(x, mask, value, out_grad, x_grad, value_grad)
 
 - backward_op : masked_select_grad
   forward : masked_select (Tensor x, Tensor mask) -> Tensor(out)

--- a/paddle/phi/ops/yaml/backward.yaml
+++ b/paddle/phi/ops/yaml/backward.yaml
@@ -2103,6 +2103,16 @@
     data_type : softmax
   inplace : (softmax -> logits_grad)
 
+- backward_op : masked_fill_double_grad
+  forward : masked_fill_grad (Tensor x, Tensor mask, Tensor value, Tensor grad_out) -> Tensor(grad_x), Tensor(grad_value)
+  args : (Tensor mask, Tensor grad_x_grad, Tensor grad_value_grad)
+  output : Tensor(grad_out_grad)
+  infer_meta :
+    func : UnchangedInferMeta
+    param : [grad_x_grad]
+  optional: grad_x_grad, grad_value_grad
+  composite : masked_fill_double_grad(mask, grad_x_grad, grad_value_grad, grad_out_grad)
+
 - backward_op : masked_fill_grad
   forward : masked_fill (Tensor x, Tensor mask, Tensor value) -> Tensor(out)
   args : (Tensor x, Tensor mask, Tensor value, Tensor out_grad)
@@ -2114,7 +2124,7 @@
     func : masked_fill_grad
     param: [x, mask, value, out_grad]
   inplace : (out_grad -> x_grad)
-  composite : masked_fill_grad(x, mask, value, out_grad, x_grad, value_grad)
+  backward: masked_fill_double_grad
 
 - backward_op : masked_select_grad
   forward : masked_select (Tensor x, Tensor mask) -> Tensor(out)
@@ -2704,6 +2714,12 @@
   kernel :
     func : renorm_grad
 
+- backward_op : repeat_interleave_double_grad
+  forward : repeat_interleave_grad(Tensor x, Tensor grad_out, int repeats, int axis) -> Tensor(grad_x)
+  args : (Tensor grad_x_grad, int repeats, int axis)
+  output : Tensor(grad_out_grad)
+  invoke: repeat_interleave(grad_x_grad, repeats, axis)
+
 - backward_op : repeat_interleave_grad
   forward : repeat_interleave(Tensor x, int repeats, int axis) -> Tensor(out)
   args : (Tensor x, Tensor out_grad, int repeats, int axis)
@@ -2713,6 +2729,13 @@
     param : [x]
   kernel :
     func : repeat_interleave_grad
+  backward: repeat_interleave_double_grad
+
+- backward_op : repeat_interleave_with_tensor_index_double_grad
+  forward : repeat_interleave_with_tensor_index_grad(Tensor x, Tensor repeats, Tensor grad_out, int axis) -> Tensor(grad_x)
+  args : (Tensor repeats, Tensor grad_x_grad, int axis)
+  output : Tensor(grad_out_grad)
+  invoke: repeat_interleave_with_tensor_index(grad_x_grad, repeats, axis)
 
 - backward_op : repeat_interleave_with_tensor_index_grad
   forward : repeat_interleave_with_tensor_index(Tensor x, Tensor repeats, int axis) -> Tensor(out)
@@ -2724,6 +2747,7 @@
   kernel :
     func : repeat_interleave_with_tensor_index_grad
     data_type : x
+  backward: repeat_interleave_with_tensor_index_double_grad
 
 - backward_op : reshape_double_grad
   forward : reshape_grad (Tensor x, Tensor grad_out) -> Tensor(grad_x)

--- a/paddle/phi/ops/yaml/op_compat.yaml
+++ b/paddle/phi/ops/yaml/op_compat.yaml
@@ -2442,13 +2442,6 @@
   outputs:
     {softmax : Softmax, loss : Loss}
 
-- op : masked_fill
-  backward : masked_fill_grad, masked_fill_double_grad
-  inputs :
-    {x : X, mask : Mask, v: Value}
-  outputs :
-    out : Y
-
 - op : masked_select
   inputs :
     {x : X, mask : Mask}

--- a/paddle/phi/ops/yaml/op_compat.yaml
+++ b/paddle/phi/ops/yaml/op_compat.yaml
@@ -2442,6 +2442,13 @@
   outputs:
     {softmax : Softmax, loss : Loss}
 
+- op : masked_fill
+  backward : masked_fill_grad, masked_fill_double_grad
+  inputs :
+    {x : X, mask : Mask, v: Value}
+  outputs :
+    out : Y
+
 - op : masked_select
   inputs :
     {x : X, mask : Mask}
@@ -3133,7 +3140,7 @@
     repeats : Repeats
 
 - op : repeat_interleave
-  backward : repeat_interleave_grad
+  backward : repeat_interleave_grad, repeat_interleave_double_grad
   inputs :
     x : X
   outputs :
@@ -3142,7 +3149,7 @@
     {repeats : Repeats, axis : dim}
 
 - op : repeat_interleave_with_tensor_index
-  backward : repeat_interleave_with_tensor_index_grad
+  backward : repeat_interleave_with_tensor_index_grad, repeat_interleave_with_tensor_index_double_grad
   inputs :
     {x : X, repeats: RepeatTensor}
   outputs:

--- a/test/legacy_test/test_repeat_interleave_op.py
+++ b/test/legacy_test/test_repeat_interleave_op.py
@@ -316,6 +316,50 @@ class TestIndexSelectAPI(unittest.TestCase):
         )
         np.testing.assert_allclose(expect_out, np_z, rtol=1e-05)
 
+        # case 5 repeat_interleave_with_tensor_double_grad
+        with base.dygraph.guard():
+            x_pd = paddle.randn([40, 50])
+            x_pd.stop_gradient = False
+            axis = 1
+            repeats_pd = paddle.randint(1, 50, [x_pd.shape[axis]])
+
+            y_pd = paddle.repeat_interleave(x_pd, repeats_pd, axis)
+            dy_pd = paddle.randn_like(y_pd)
+            dy_pd.stop_gradient = False
+            g_pd = paddle.grad(y_pd, x_pd, dy_pd, create_graph=True)[0]
+
+            ddx_pd = paddle.randn_like(x_pd)
+            gg_pd = paddle.grad(g_pd, dy_pd, ddx_pd)[0]
+
+            np.testing.assert_allclose(
+                gg_pd.numpy(),
+                paddle.repeat_interleave(ddx_pd, repeats_pd, axis).numpy(),
+                1e-5,
+                1e-5,
+            )
+
+        # case 6 repeat_interleave_double_grad
+        with base.dygraph.guard():
+            x_pd = paddle.randn([40, 50])
+            x_pd.stop_gradient = False
+            axis = 1
+            repeats_pd = 4
+
+            y_pd = paddle.repeat_interleave(x_pd, repeats_pd, axis)
+            dy_pd = paddle.randn_like(y_pd)
+            dy_pd.stop_gradient = False
+            g_pd = paddle.grad(y_pd, x_pd, dy_pd, create_graph=True)[0]
+
+            ddx_pd = paddle.randn_like(x_pd)
+            gg_pd = paddle.grad(g_pd, dy_pd, ddx_pd)[0]
+
+            np.testing.assert_allclose(
+                gg_pd.numpy(),
+                paddle.repeat_interleave(ddx_pd, repeats_pd, axis).numpy(),
+                1e-5,
+                1e-5,
+            )
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->

Pcard-75624

支持动态图和静态图下的`repeat_interleave_with_tensor_index`和`repeat_interleave`两个算子的二阶反向组合算子

相关PR：<https://github.com/PaddlePaddle/PaddleScience/pull/1160> @BeingGod 

<details><summary>torch精度对比测试代码</summary>
<p>

``` py
import paddle
import torch
import numpy as np


# paddle
x_pd = paddle.randn([40, 50])
x_pd.stop_gradient = False
axis = 0
repeats_pd = paddle.randint(1, 50, [x_pd.shape[axis]])

y_pd = paddle.repeat_interleave(x_pd, repeats_pd, axis)
dy_pd = paddle.randn_like(y_pd)
dy_pd.stop_gradient = False
g_pd = paddle.grad(y_pd, x_pd, dy_pd, create_graph=True)[0]

ddx_pd = paddle.randn_like(x_pd)
gg_pd = paddle.grad(g_pd, dy_pd, ddx_pd)[0]

# torch
x_pt = torch.from_dlpack(x_pd.detach())
x_pt.requires_grad = True
repeats_pt = torch.from_dlpack(repeats_pd.detach())

y_pt = torch.repeat_interleave(x_pt, repeats_pt, axis)
np.testing.assert_allclose(y_pd.numpy(), y_pt.detach().cpu().numpy(), 1e-6, 1e-6)

dy_pt = torch.from_dlpack(dy_pd.detach())
dy_pt.requires_grad = True
g_pt = torch.autograd.grad(y_pt, x_pt, dy_pt, create_graph=True)[0]
np.testing.assert_allclose(g_pd.numpy(), g_pt.detach().cpu().numpy(), 1e-5, 1e-5)

ddx_pt = torch.from_dlpack(ddx_pd.detach())
gg_pt = torch.autograd.grad(g_pt, dy_pt, ddx_pt, create_graph=True)[0]

np.testing.assert_allclose(gg_pd.numpy(), gg_pt.detach().cpu().numpy(), 1e-5, 1e-5)

```

</p>
</details> 