### PR TITLE
[SOT] Add internal API `paddle.jit.marker.force_dynamic` to ensure function or layer run under dynamic mode

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/variables/callable.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/callable.py
@@ -43,7 +43,6 @@ from ....utils import (
     get_obj_stable_repr,
     get_static_function,
     hashable,
-    is_break_graph_api,
     is_break_graph_tensor_methods,
     is_builtin_fn,
     is_directly_run_api,
@@ -61,6 +60,7 @@ from ....utils.exceptions import (
     DataDependencyOperationBreak,
     FallbackError,
     FallbackInlineCallBreak,
+    ForceBreak,
     InnerError,
     OtherInlineCallBreak,
     PsdbBreakReason,
@@ -69,7 +69,6 @@ from ....utils.exceptions import (
     SotErrorBase,
     UnsupportedNumPyAPIBreak,
     UnsupportedOperationBreak,
-    UnsupportedPaddleAPIBreak,
 )
 from ....utils.paddle_api_config import (
     break_graph_functions,
@@ -149,15 +148,12 @@ class CallableVariable(VariableBase):
 
 
 class ForceBreakCallableVariable(CallableVariable):
-    def __init__(self, callable, graph: FunctionGraph, tracker: Tracker):
+    def __init__(self, name: str, graph: FunctionGraph, tracker: Tracker):
         super().__init__(graph, tracker)
+        self.name = name
 
     def call_function(self, /, *args, **kwargs) -> VariableBase:
-        raise BreakGraphError(
-            UnsupportedOperationBreak(
-                reason_str="ForceBreakCallableVariable is called."
-            )
-        )
+        raise BreakGraphError(ForceBreak(reason_str=f"Force run {self.name}"))
 
     def get_py_value(self, allow_tensor=False):
         return self.value
@@ -168,9 +164,13 @@ class ForceBreakCallableVariable(CallableVariable):
             isinstance(value, paddle.nn.Layer)
             and value.__class__ in break_graph_layer_classes
         ):
-            return ForceBreakCallableVariable(value, graph, tracker)
+            return ForceBreakCallableVariable(
+                f"Layer({value.__class__.__name__})", graph, tracker
+            )
         elif hashable(value) and value in break_graph_functions:
-            return ForceBreakCallableVariable(value, graph, tracker)
+            return ForceBreakCallableVariable(
+                get_obj_stable_repr(value), graph, tracker
+            )
         return None
 
 
@@ -381,10 +381,6 @@ class PaddleApiVariable(FunctionVariable):
         super().__init__(fn, graph, tracker)
 
     def call_function(self, /, *args, **kwargs):
-        if is_break_graph_api(self.value):
-            raise BreakGraphError(
-                UnsupportedPaddleAPIBreak(fn_name=self.value.__name__)
-            )
         return self.graph.call_paddle_api(self.value, *args, **kwargs)
 
     @VariableFactory.register_from_value(

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/callable.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/callable.py
@@ -71,6 +71,10 @@ from ....utils.exceptions import (
     UnsupportedOperationBreak,
     UnsupportedPaddleAPIBreak,
 )
+from ....utils.paddle_api_config import (
+    break_graph_functions,
+    break_graph_layer_classes,
+)
 from ..dispatcher import Dispatcher
 from ..guard import (
     FasterStringifiedExpression,
@@ -142,6 +146,32 @@ class CallableVariable(VariableBase):
 
     def call_function(self, /, *args, **kwargs):
         raise NotImplementedError("call_function is not implemented.")
+
+
+class ForceBreakCallableVariable(CallableVariable):
+    def __init__(self, callable, graph: FunctionGraph, tracker: Tracker):
+        super().__init__(graph, tracker)
+
+    def call_function(self, /, *args, **kwargs) -> VariableBase:
+        raise BreakGraphError(
+            UnsupportedOperationBreak(
+                reason_str="ForceBreakCallableVariable is called."
+            )
+        )
+
+    def get_py_value(self, allow_tensor=False):
+        return self.value
+
+    @VariableFactory.register_from_value()
+    def from_value(value: Any, graph: FunctionGraph, tracker: Tracker):
+        if (
+            isinstance(value, paddle.nn.Layer)
+            and value.__class__ in break_graph_layer_classes
+        ):
+            return ForceBreakCallableVariable(value, graph, tracker)
+        elif hashable(value) and value in break_graph_functions:
+            return ForceBreakCallableVariable(value, graph, tracker)
+        return None
 
 
 class FunctionVariable(CallableVariable):

--- a/python/paddle/jit/sot/utils/exceptions.py
+++ b/python/paddle/jit/sot/utils/exceptions.py
@@ -125,6 +125,24 @@ class UnsupportedNumPyAPIBreak(UnsupportedOperationBreak):
         )
 
 
+class ForceBreak(UnsupportedOperationBreak):
+    def __init__(
+        self,
+        *,
+        reason_str=None,
+        file_path="",
+        line_number=-1,
+    ):
+        if reason_str is None:
+            reason_str = "Force break graph execution"
+
+        super().__init__(
+            reason_str=reason_str,
+            file_path=file_path,
+            line_number=line_number,
+        )
+
+
 class BuiltinFunctionBreak(UnsupportedOperationBreak):
     """Break reason for unsupported built-in function calls.
 

--- a/python/paddle/jit/sot/utils/paddle_api_config.py
+++ b/python/paddle/jit/sot/utils/paddle_api_config.py
@@ -116,9 +116,8 @@ paddle_api_module_prefix = {
     "paddle.nn.functional",
 }
 
-break_graph_set = set()
-
-
+break_graph_functions = set()
+break_graph_layer_classes = set()
 break_graph_tensor_method = {
     'register_hook',
     'numpy',
@@ -139,8 +138,12 @@ def is_break_graph_tensor_methods(method_name):
     return method_name in break_graph_tensor_method
 
 
-def add_break_graph_apis(apis: list):
-    break_graph_set.update(apis)
+def add_break_graph_function(fn):
+    break_graph_functions.add(fn)
+
+
+def add_break_graph_layer_class(layer_class: type[paddle.nn.Layer]):
+    break_graph_layer_classes.add(layer_class)
 
 
 def is_directly_run_api(api):

--- a/python/paddle/jit/sot/utils/utils.py
+++ b/python/paddle/jit/sot/utils/utils.py
@@ -38,7 +38,7 @@ from .envs import (
     ENV_STRICT_MODE,
 )
 from .paddle_api_config import (
-    break_graph_set,
+    break_graph_functions,
     paddle_api_list,
     paddle_api_module_prefix,
 )
@@ -237,7 +237,7 @@ def in_paddle_module(func):
 
 
 def is_break_graph_api(func):
-    return func in break_graph_set
+    return func in break_graph_functions
 
 
 def is_namedtuple_class(cls):

--- a/test/sot/test_break_graph.py
+++ b/test/sot/test_break_graph.py
@@ -18,7 +18,7 @@ import numpy as np
 from test_case_base import TestCaseBase
 
 import paddle
-from paddle.jit.sot.utils.paddle_api_config import add_break_graph_apis
+from paddle.jit.sot.utils.paddle_api_config import add_break_graph_function
 
 
 def ifelse_func(x, y):
@@ -74,7 +74,7 @@ def to_tensor_break_graph(x, y):
 
 class TestToTensor(TestCaseBase):
     def test_simple(self):
-        add_break_graph_apis([paddle.to_tensor])
+        add_break_graph_function(paddle.to_tensor)
         x = paddle.to_tensor(2)
         y = paddle.to_tensor(3)
         self.assert_results(to_tensor_break_graph, x, y)

--- a/test/sot/test_force_dynamic.py
+++ b/test/sot/test_force_dynamic.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from test_case_base import (
+    TestCaseBase,
+    test_instruction_translator_cache_context,
+)
+
+import paddle
+from paddle.jit import sot
+
+
+class EmbeddingLayer(paddle.nn.Layer):
+    def __init__(self):
+        super().__init__()
+        self.embedding = paddle.nn.Embedding(10, 10)
+
+    def forward(self, x):
+        x = x + 1 - 1
+        x = self.embedding(x)
+        return x + 1
+
+
+def call_embedding_layer(x: paddle.Tensor, layer: paddle.nn.Layer):
+    return layer(x)
+
+
+def call_functional_embedding(x: paddle.Tensor, weight: paddle.Tensor):
+    x = x + 1 - 1
+    x = paddle.nn.functional.embedding(x, weight)
+    return x + 1
+
+
+class TestForceDynamic(TestCaseBase):
+    def test_embedding_layer(self):
+        paddle.jit.marker.force_dynamic(paddle.nn.Embedding)
+
+        layer = EmbeddingLayer()
+        with test_instruction_translator_cache_context() as ctx:
+            self.assertEqual(ctx.translate_count, 0)
+            self.assert_results(
+                call_embedding_layer,
+                paddle.randint(0, 10, [1, 3, 224, 224], dtype='int64'),
+                layer,
+            )
+            self.assertGreater(ctx.translate_count, 1)
+
+        sot.utils.paddle_api_config.break_graph_layer_classes.clear()
+
+    def test_functional_embedding(self):
+        paddle.jit.marker.force_dynamic(paddle.nn.functional.embedding)
+
+        weight = paddle.randn([10, 10])
+        x = paddle.randint(0, 10, [1, 3, 224, 224], dtype='int64')
+        with test_instruction_translator_cache_context() as ctx:
+            self.assertEqual(ctx.translate_count, 0)
+            self.assert_results(call_functional_embedding, x, weight)
+            self.assertGreater(ctx.translate_count, 1)
+
+        sot.utils.paddle_api_config.break_graph_functions.clear()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

添加新的 internal API `paddle.jit.marker.force_dynamic` 用于标记一个函数 or layer 一定会跑在动态图，实现为在该处打断

### Example usage

```python
class MyLayer(paddle.nn.Layer):
    def __init__(self):
        self.emb = paddle.nn.Embedding(10, 10)

    def forward(self, x: paddle.Tensor):
        return self.emb(x)

layer = MyLayer()
layer = paddle.jit.to_static(layer)

paddle.jit.marker.force_dynamic(paddle.nn.Embedding) # 确保 paddle.nn.Embedding 回到动态图，不会走 call_layer
paddle.jit.marker.force_dynamic(paddle.nn.functional.embedding) # 确保自定义 layer 内部调用的 functional API 不会走 call_function
```

比如这里如果想要禁掉 `embedding`，建议 layer 和 functional 都禁掉，具体应该调用哪个实际上取决于模型中的使用方式

<!-- PCard-66972 -->