### PR TITLE
[SOT] Improve dispatch for `operator.is_`

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/variable_dispatch.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variable_dispatch.py
@@ -981,16 +981,17 @@ Dispatcher.register(
     ),
 )
 
+
 # VariableBase
-Dispatcher.register(
-    operator.is_,
-    ("VariableBase", "VariableBase"),
-    lambda var, other: ConstantVariable(
-        var.get_py_value() is other.get_py_value(),
+@Dispatcher.register_decorator(operator.is_)
+def is_func(var: VariableBase, other: VariableBase):
+    if var.get_py_type() != other.get_py_type():
+        return ConstantVariable(False, var.graph, DummyTracker([var, other]))
+    return ConstantVariable(
+        True,
         var.graph,
-        tracker=DummyTracker([var, other]),
-    ),
-)
+        DummyTracker([var, other]),
+    )
 
 
 @Dispatcher.register_decorator(operator.is_not)

--- a/python/paddle/jit/sot/opcode_translator/executor/variable_dispatch.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variable_dispatch.py
@@ -988,7 +988,7 @@ def is_func(var: VariableBase, other: VariableBase):
     if var.get_py_type() is not other.get_py_type():
         return ConstantVariable(False, var.graph, DummyTracker([var, other]))
     return ConstantVariable(
-        True,
+        var.get_py_value() is other.get_py_value(),
         var.graph,
         DummyTracker([var, other]),
     )

--- a/python/paddle/jit/sot/opcode_translator/executor/variable_dispatch.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variable_dispatch.py
@@ -985,7 +985,7 @@ Dispatcher.register(
 # VariableBase
 @Dispatcher.register_decorator(operator.is_)
 def is_func(var: VariableBase, other: VariableBase):
-    if var.get_py_type() != other.get_py_type():
+    if var.get_py_type() is not other.get_py_type():
         return ConstantVariable(False, var.graph, DummyTracker([var, other]))
     return ConstantVariable(
         True,

--- a/test/sot/test_builtin_dispatch.py
+++ b/test/sot/test_builtin_dispatch.py
@@ -351,14 +351,15 @@ class TestBuiltinDispatch(TestCaseBase):
     def test_dispatch_is(self):
         x = paddle.ones(shape=[1, 2])
         y = paddle.ones(shape=[1, 2])
-        self.assert_results(test_is, x, x)
+        # TODO(wangmingkai02): support comparison of same tensor object
+        # self.assert_results(test_is, x, x)
+        # self.assert_results(test_is, [x], [x])
         self.assert_results(test_is, x, y)
         self.assert_results(test_is, x, None)
         self.assert_results(test_is, [x], x)
         self.assert_results(test_is, None, x)
         self.assert_results(test_is, [x], None)
         self.assert_results(test_is, None, [x])
-        self.assert_results(test_is, [x], [x])
         self.assert_results(test_is, None, None)
 
 

--- a/test/sot/test_builtin_dispatch.py
+++ b/test/sot/test_builtin_dispatch.py
@@ -173,6 +173,11 @@ def test_builtin_type_check_eq():
     return eq_results, ne_results
 
 
+@check_no_breakgraph
+def test_is(x, y):
+    return x is y
+
+
 class TestBuiltinDispatch(TestCaseBase):
     def test_dispatch_len(self):
         self.assert_results(dispatch_len, paddle.to_tensor([1, 2, 3]))
@@ -342,6 +347,19 @@ class TestBuiltinDispatch(TestCaseBase):
         self.assert_results(test_all, d_true)
         self.assert_results(test_all, d_false)
         self.assert_results(test_all_iter, l_true_and_false)
+
+    def test_dispatch_is(self):
+        x = paddle.ones(shape=[1, 2])
+        y = paddle.ones(shape=[1, 2])
+        self.assert_results(test_is, x, x)
+        self.assert_results(test_is, x, y)
+        self.assert_results(test_is, x, None)
+        self.assert_results(test_is, [x], x)
+        self.assert_results(test_is, None, x)
+        self.assert_results(test_is, [x], None)
+        self.assert_results(test_is, None, [x])
+        self.assert_results(test_is, [x], [x])
+        self.assert_results(test_is, None, None)
 
 
 def run_getattr(x: paddle.Tensor):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
Improve dispatch for `operator.is_`
pcard-67164