### PR TITLE
[SOT] Skip analyse dynamic shape on null meta and use `None` for null infer meta

### DIFF
--- a/python/paddle/jit/sot/infer_meta.py
+++ b/python/paddle/jit/sot/infer_meta.py
@@ -36,7 +36,7 @@ from paddle.distributed.auto_parallel.static.utils import (
     convert_to_dims_mapping,
 )
 from paddle.framework import use_pir_api
-from paddle.pir import fake_value, is_fake_value
+from paddle.pir import is_fake_value
 from paddle.static import InputSpec
 from paddle.utils import flatten, is_sequence
 
@@ -448,7 +448,7 @@ class VariableCreator(metaclass=Singleton):
 
     def create_var(self, meta_or_null: MetaInfoOrNull):
         if meta_or_null.is_null():
-            return fake_value()
+            return None
         meta = meta_or_null.unwrap_unsafe()
         shape = meta.shape_with_special_symbol(-1)
 

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
@@ -437,7 +437,11 @@ class TensorVariable(VariableBase):
         self.value = None
         self.meta = meta
         dynamic_axes: list[int] = []
-        if ENV_SOT_ALLOW_DYNAMIC_SHAPE.get() and self.tracker.is_traceable():
+        if (
+            ENV_SOT_ALLOW_DYNAMIC_SHAPE.get()
+            and self.tracker.is_traceable()
+            and not self.meta.is_null()
+        ):
             dynamic_axes = self.analyse_dynamic_axes(tracker)
         self.var_name = TensorVariable.var_name_generator.next()
         self.graph.side_effects.record_mutable_variable(self)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

- 跳过 null meta 时的 dynamic shape 分析
- infermeta 时对于 null meta 使用 `None` 而不是 `fake_value`

<!-- PCard-66972 -->