### PR TITLE
[PHI] Fix paddle.digamma logic on zero input

### DIFF
--- a/paddle/phi/kernels/impl/digamma_kernel_impl.h
+++ b/paddle/phi/kernels/impl/digamma_kernel_impl.h
@@ -30,7 +30,11 @@ struct DigammaFunctor {
   HOSTDEVICE void operator()(int64_t idx) const {
     using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
     const MPType mp_input = static_cast<MPType>(input_[idx]);
-    output_[idx] = static_cast<T>(Eigen::numext::digamma(mp_input));
+    MPType eigen_out = Eigen::numext::digamma(mp_input);
+    constexpr MPType mp_inf = std::numeric_limits<MPType>::infinity();
+    MPType mp_out =
+        mp_input == 0 ? (std::signbit(mp_input) ? mp_inf : -mp_inf) : eigen_out;
+    output_[idx] = static_cast<T>(mp_out);
   }
 
  private:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Operator Mechanism


### PR Types
Bug fixes


### Description
`paddle.digamma`和torch在输入为+0.0/-0.0时的行为不同，torch是返回-inf/+inf，paddle是返回nan，本PR将paddle与torch对齐

由于digamma函数非常复杂（多步拟合），我没法改Eigen里面的实现，所以就在外面套了一层处理，这种写法经compiler explorer验证是指令最少的写法，且性能测试也无明显变化

测试：
```python
>>> import paddle
>>> paddle.device.set_device('cpu')
>>> paddle.digamma(paddle.to_tensor([float('0.0'), float('-0.0')]))
# Tensor(shape=[2], dtype=float32, place=Place(cpu), stop_gradient=True,
#        [-inf.,  inf.])
>>> paddle.device.set_device('gpu')
>>> paddle.digamma(paddle.to_tensor([float('0.0'), float('-0.0')]))
# Tensor(shape=[2], dtype=float32, place=Place(gpu:0), stop_gradient=True,
#        [-inf.,  inf.])
```

<br>
Pcard-85711