### PR TITLE
[0-size Tensor No.46、139、140、142、143、173、323] Add 0-size Tensor support for diff/nan_to_num

### DIFF
--- a/test/legacy_test/test_diff_op.py
+++ b/test/legacy_test/test_diff_op.py
@@ -353,6 +353,15 @@ class TestDiffOpFp16(TestDiffOp):
         paddle.disable_static()
 
 
+class TestDiffOp_ZeroSize(TestDiffOp):
+    def set_args(self):
+        self.input = np.array([1, 0, 5, 2]).astype('float32')
+        self.n = 2
+        self.axis = 0
+        self.prepend = None
+        self.append = None
+
+
 if __name__ == '__main__':
     paddle.enable_static()
     unittest.main()

--- a/test/legacy_test/test_nansum_api.py
+++ b/test/legacy_test/test_nansum_api.py
@@ -145,5 +145,26 @@ class API_Test_Nansum(unittest.TestCase):
             )
 
 
+class API_Test_Nansum_ZeroSize(unittest.TestCase):
+
+    def test_dygraph(self):
+        x = np.random.random([2, 0, 3]).astype(np.float32)
+        with base.dygraph.guard():
+            inputs = paddle.to_tensor(x)
+            inputs.stop_gradient = False
+            out = paddle.nansum(inputs)
+            out_ref = np.nansum(x).astype(np.float32)
+
+            self.assertTrue(
+                (out.numpy() == out_ref).all(),
+                msg='nansum output is wrong, out =' + str(out.numpy()),
+            )
+
+            # check grad shape
+            loss = paddle.sum(out)
+            loss.backward()
+            np.testing.assert_allclose(inputs.grad.shape, inputs.shape)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/legacy_test/test_quantile_and_nanquantile.py
+++ b/test/legacy_test/test_quantile_and_nanquantile.py
@@ -207,6 +207,20 @@ class TestQuantileAndNanquantile(unittest.TestCase):
             [(paddle.nanquantile, None)],
         )
 
+    def test_nanquantile_ZeroSize(self):
+        input_data = np.full(shape=[2, 0, 3], fill_value=np.nan)
+        x = paddle.to_tensor(input_data)
+        x.stop_gradient = False
+        paddle_res = paddle.nanquantile(x, q=0.35, axis=0)
+        np_res = np.nanquantile(input_data, q=0.35, axis=0)
+        np.testing.assert_allclose(
+            paddle_res.numpy(), np_res, rtol=1e-05, equal_nan=True
+        )
+
+        loss = paddle.sum(paddle_res)
+        loss.backward()
+        np.testing.assert_allclose(x.grad.shape, x.shape)
+
 
 class TestMuitlpleQ(unittest.TestCase):
     """


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->
PaddleAPITest 测试错误是torch error，没有cuda error， 增加单测
46 paddle.diff  错误是torch error
CPU
![image](https://github.com/user-attachments/assets/f3a1c50f-ec9e-445d-822b-72bb4e4893df)
GPU
![image](https://github.com/user-attachments/assets/65133978-b9ce-4605-a50e-2558a4c2af0f)

139 paddle.nan_to_num
CPU
![image](https://github.com/user-attachments/assets/970dabd5-1749-4e84-9fdd-53e3f4cbcb91)
GPU
![image](https://github.com/user-attachments/assets/7fc3bf55-aac5-4765-b5f0-bb4d9a82e080)

140 paddle.nanmean
CPU
![image](https://github.com/user-attachments/assets/addf5a48-ffcf-4153-bf32-44c141992f27)
GPU
![image](https://github.com/user-attachments/assets/6067f56b-3a58-41d0-abf7-50d6a4928c7d)

142 paddle.nanquantile 错误为torch error
CPU
![image](https://github.com/user-attachments/assets/215f9efc-7bf7-4962-b555-43d6453ecbe7)
GPU
![image](https://github.com/user-attachments/assets/dddcdb07-b849-4e5d-b524-64e78c56536f)
![image](https://github.com/user-attachments/assets/12fc751f-c268-4f2c-bb4f-91b2af635032)

143 paddle.nansum
CPU
![image](https://github.com/user-attachments/assets/b69df47b-9dc4-489f-8f15-cf4d3f31484e)
GPU
![image](https://github.com/user-attachments/assets/9be185a6-d444-4348-8e2a-e6bdb1f0d5bf)

173 paddle.nn.functional.glu
CPU
![image](https://github.com/user-attachments/assets/72806fc2-6382-4937-bb7e-2b4076fec192)
GPU
![image](https://github.com/user-attachments/assets/2296be37-e2c8-403e-970e-ad3257ea2b4a)
