### PR TITLE
[0-size Tensor No.100、100] Add 0-size Tensor support for ldexp

### DIFF
--- a/paddle/phi/kernels/impl/elementwise_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/elementwise_grad_kernel_impl.h
@@ -1522,6 +1522,21 @@ void ElementwisePowGradKernel(const Context& dev_ctx,
                               const DenseTensor& dout,
                               DenseTensor* dx,
                               DenseTensor* dy) {
+  if (dout.numel() == 0) {
+    if (dx) {
+      phi::Full<T, Context>(dev_ctx,
+                            phi::IntArray(common::vectorize(x.dims())),
+                            static_cast<T>(0),
+                            dx);
+    }
+    if (dy) {
+      phi::Full<T, Context>(dev_ctx,
+                            phi::IntArray(common::vectorize(y.dims())),
+                            static_cast<T>(0),
+                            dy);
+    }
+    return;
+  }
   funcs::ElementwiseGradPreProcess(dout, dx);
   int axis = -1;
   phi::funcs::ElemwiseGradCompute<Context, T, PowGradDX<T>, PowGradDY<T>>(

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -7900,8 +7900,8 @@ def ldexp(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
         out_dtype = DataType.FLOAT64
     else:
         out_dtype = paddle.get_default_dtype()
-    x = paddle.cast(x, dtype=out_dtype)
-    y = paddle.cast(y, dtype=out_dtype)
+    x = x.astype(dtype=out_dtype)
+    y = y.astype(dtype=out_dtype)
     two = paddle.to_tensor(2, dtype=out_dtype)
     return paddle.multiply(x, paddle.pow(two, y))
 

--- a/test/legacy_test/test_ldexp.py
+++ b/test/legacy_test/test_ldexp.py
@@ -220,5 +220,35 @@ class TestLdexpError(unittest.TestCase):
         self.assertRaises(TypeError, paddle.ldexp, paddle.to_tensor(x), y)
 
 
+class TestLdexpAPI_ZeroSize(unittest.TestCase):
+    def setUp(self):
+        self.places = []
+        if (
+            os.environ.get('FLAGS_CI_both_cpu_and_gpu', 'False').lower()
+            in ['1', 'true', 'on']
+            or not core.is_compiled_with_cuda()
+        ):
+            self.places.append(paddle.CPUPlace())
+        if core.is_compiled_with_cuda():
+            self.places.append(paddle.CUDAPlace(0))
+
+    def test_ldexp_dynamic(self):
+        for place in self.places:
+            with paddle.base.dygraph.guard(place):
+                dims = [2, 0]
+                x = np.random.rand(*dims) * 10
+                y = (np.random.randint(-10, 10, dims)).astype(np.int32)
+                x_ = paddle.to_tensor(x)
+                y_ = paddle.to_tensor(y)
+                x_.stop_gradient = False
+                y_.stop_gradient = False
+                res = paddle.ldexp(x_, y_)
+                np.testing.assert_allclose(res, np.ldexp(x, y))
+
+                loss = res
+                loss.backward()
+                np.testing.assert_allclose(x_.grad.shape, x_.shape)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/legacy_test/test_ldexp.py
+++ b/test/legacy_test/test_ldexp.py
@@ -245,7 +245,7 @@ class TestLdexpAPI_ZeroSize(unittest.TestCase):
                 res = paddle.ldexp(x_, y_)
                 np.testing.assert_allclose(res, np.ldexp(x, y))
 
-                loss = res
+                loss = paddle.sum(res)
                 loss.backward()
                 np.testing.assert_allclose(x_.grad.shape, x_.shape)
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->
ldexp 是python算子，测试中cuda error是paddle.pow的反向产生，修改了pow的反向，
因为paddle.pow没有在PaddleAPITest测试列表中，没有测试修改paddle.pow其他模块
ldexp 中使用的paddle.cast，在backward时会没有grad信息，所以修改为astype
增加单测
PaddleAPITest 测试是torch error
![image](https://github.com/user-attachments/assets/5c8748b4-25d2-473a-8b55-b2111c44be30)

修改前产生cuda error的命令，需要使用paddle_only, accuracy下没有错误
```
python engine.py --paddle_only=True --api_config='paddle.ldexp(Tensor([10, 20, 1],"float32"), Tensor([0],"int32"), )'
```