### PR TITLE
[0-size Tensor No.133、318、277、136、320、239、325、279] Add 0-size Tensor support for matmul

### DIFF
--- a/paddle/phi/infermeta/binary.cc
+++ b/paddle/phi/infermeta/binary.cc
@@ -2992,7 +2992,12 @@ void MatmulInferMeta(const MetaTensor& x,
   } else {
     new_dims.reserve(ndims_x);
     for (size_t i = 0; i < ndims_x - 2; ++i) {
-      new_dims.push_back(std::max(dims_x[i], dims_y[i]));
+      // If one of them is 0, choose 0.
+      if (dims_x[i] == 0 || dims_y[i] == 0) {
+        new_dims.push_back(0);
+      } else {
+        new_dims.push_back(std::max(dims_x[i], dims_y[i]));
+      }
     }
   }
   if (!x_broadcasted) {

--- a/paddle/phi/kernels/impl/matmul_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/matmul_grad_kernel_impl.h
@@ -230,11 +230,15 @@ void MatmulGradKernel(const Context& dev_ctx,
                       DenseTensor* dx,
                       DenseTensor* dy) {
   if (x.numel() == 0) {
-    if (dy != nullptr) {
-      dev_ctx.template Alloc<T>(dx);
-      phi::FullKernel<T>(
-          dev_ctx, common::vectorize(y.dims()), 0.0, y.dtype(), dy);
-    }
+    dev_ctx.template Alloc<T>(dx);
+    phi::Full<T, Context>(
+        dev_ctx, phi::IntArray(common::vectorize(y.dims())), 0, dy);
+    return;
+  }
+  if (y.numel() == 0) {
+    dev_ctx.template Alloc<T>(dy);
+    phi::Full<T, Context>(
+        dev_ctx, phi::IntArray(common::vectorize(x.dims())), 0, dx);
     return;
   }
   // get dims

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -2942,8 +2942,16 @@ def outer(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
 
 
     """
-    nx = x.reshape((-1, 1))
-    ny = y.reshape((1, -1))
+    xshape = x.shape
+    yshape = y.shape
+    if math.prod(xshape) == 0:  # If the size is 0
+        nx = x.reshape((0, 0))
+    else:
+        nx = x.reshape((-1, 1))
+    if math.prod(yshape) == 0:  # If the size is 0
+        ny = y.reshape((0, 0))
+    else:
+        ny = y.reshape((1, -1))
 
     if in_dynamic_mode():
         return _C_ops.matmul(nx, ny, False, False)

--- a/test/legacy_test/test_matmul_v2_op.py
+++ b/test/legacy_test/test_matmul_v2_op.py
@@ -943,6 +943,41 @@ class TestMatmulop(unittest.TestCase):
         paddle.enable_static()
 
 
+class TestMatMulOp_ZeroSize(OpTest):
+    def setUp(self):
+        self.op_type = "matmul_v2"
+        self.python_api = paddle.matmul
+        self.init_input_output()
+
+        self.inputs = {
+            'X': OpTest.np_dtype_to_base_dtype(self.x),
+            'Y': OpTest.np_dtype_to_base_dtype(self.y),
+        }
+        self.out = np.matmul(self.x, self.y)
+        self.attrs = {'axis': -1, 'use_mkldnn': False}
+        self.outputs = {'Out': self.out}
+
+    def init_input_output(self):
+        self.x = np.random.random((1, 1, 2, 3))
+        self.y = np.random.random((1, 0, 3, 2))
+
+    def test_check_output(self):
+        self.check_output(check_pir=True)
+
+    def test_check_grad(self):
+        self.check_grad(
+            ['X', 'Y'],
+            'Out',
+            check_pir=True,
+        )
+
+
+class TestMatMulOp_ZeroSize2(TestMatMulOp_ZeroSize):
+    def init_input_output(self):
+        self.x = np.random.random((0, 3, 2, 3))
+        self.y = np.random.random((1, 3, 3, 2))
+
+
 if __name__ == "__main__":
     paddle.enable_static()
     unittest.main()

--- a/test/legacy_test/test_outer.py
+++ b/test/legacy_test/test_outer.py
@@ -172,5 +172,23 @@ class TestMultiplyError(unittest.TestCase):
         self.assertRaises(Exception, paddle.outer, x_data, y_data)
 
 
+class TestMultiplyApi_ZeroSize(unittest.TestCase):
+    def test_multiply_dynamic(self):
+        x_data = np.random.rand(5, 10, 0).astype(np.float64)
+        y_data = np.random.rand(0, 10).astype(np.float64)
+        paddle.disable_static()
+        x = paddle.to_tensor(x_data)
+        y = paddle.to_tensor(y_data)
+        x.stop_gradient = False
+        y.stop_gradient = False
+        res = paddle.outer(x, y)
+        np.testing.assert_allclose(
+            res.numpy(), np.outer(x_data, y_data), rtol=1e-05
+        )
+        loss = paddle.sum(res)
+        loss.backward()
+        np.testing.assert_allclose(x.grad.shape, x.shape)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->
[0-size Tensor No.133、318、277、136、320、239、325] Add 0-size Tensor support for matmul
matmul关联算子修改
```
133、paddle.matmul
318、paddle.Tensor.matmul
277、paddle.Tensor.__matmul__
136、paddle.mm
320、paddle.Tensor.mm
239、paddle.outer
325  paddle.Tensor.outer
279 paddle.Tensor.__rmatmul__
```

matmul 前向中原有逻辑有问题，已删除原有逻辑修改
修改infermeta，如果维度为0时，结果维度不是取x,y中最大值，而是取0, symbolic shape没有对应代码
https://github.com/PaddlePaddle/Paddle/blob/814a16b6092fe49f1ea68250a4d1697dc362569f/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/binary_infer_sym.cc#L1443
cpu/gpu/xpu使用impl接口

paddle.mm 调用和matmul相同，没有修改
paddle.inner, paddle.outer 是对输入reshape后调用matmul，修改python中逻辑支持0-size，增加单测

PaddleAPITest测试
matmul，错误为torch error
![image](https://github.com/user-attachments/assets/bec6d6fa-135d-4c28-86e8-ee12699a6a29)
![image](https://github.com/user-attachments/assets/7f8a86f3-274a-4a98-b60e-daa8f99da333)

mm，错误为torch error
![image](https://github.com/user-attachments/assets/acc65223-7f32-49fd-9562-210f6887af35)

paddle.outer 测试通过
![image](https://github.com/user-attachments/assets/e9d2a8ec-511b-486c-81ee-e5335441fb49)

279 paddle.Tensor.__rmatmul__
PaddleAPITest 测试通过， 使用paddle_only=True
![image](https://github.com/user-attachments/assets/3bdadf34-340e-46c5-ad36-aadcaec595a4)