### PR TITLE
[SOT] Mark API in `paddle.nn.quant` module as unified in dynamic and static mode

### DIFF
--- a/python/paddle/jit/sot/utils/paddle_api_config.py
+++ b/python/paddle/jit/sot/utils/paddle_api_config.py
@@ -42,6 +42,7 @@ def get_paddle_api():
     modules = [
         paddle,
         paddle.nn.functional,
+        paddle.nn.quant,
         paddle.incubate.nn.functional,
         paddle.linalg,
         paddle.signal,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
Add unified marker for `paddle.nn.quant` module
pcard-67164
