### PR TITLE
Fix segment fault bug of allocator with cuda graph

### DIFF
--- a/paddle/phi/core/memory/allocation/auto_growth_best_fit_allocator.cc
+++ b/paddle/phi/core/memory/allocation/auto_growth_best_fit_allocator.cc
@@ -200,7 +200,8 @@ void AutoGrowthBestFitAllocator::FreeImpl(phi::Allocation *allocation) {
   auto next_it = block_it;
   ++next_it;
 
-  if (next_it != blocks.end() && next_it->is_free_) {
+  // It's weird that using `next_it == blocks.end()` will cause a judgment fail.
+  if (block_it != (--blocks.end()) && next_it->is_free_) {
     free_blocks_.erase(std::make_pair(next_it->size_, next_it->ptr_));
     block_it->size_ += next_it->size_;
     blocks.erase(next_it);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164

临时修复使用cuda graph 时 allocator 的 segment fault问题。