### PR TITLE
Fix nvtx.h deprecation warning

### DIFF
--- a/paddle/phi/backends/dynload/nvtx.h
+++ b/paddle/phi/backends/dynload/nvtx.h
@@ -14,6 +14,9 @@ limitations under the License. */
 #pragma once
 #ifndef _WIN32
 #include <cuda.h>
+#ifndef NVTX_SUPPRESS_V2_DEPRECATION_WARNING
+#define NVTX_SUPPRESS_V2_DEPRECATION_WARNING
+#endif
 #include <nvToolsExt.h>
 
 #include <mutex>  // NOLINT


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
使用CUDA 12.8编译，有提示信息，推荐使用NVTX_3，如果使用NVTX_V2会显示提示信息，需要定义NVTX_V2_DEPRECATION_WARNING_MESSAGE，
检查判断在/usr/local/cuda/targets/x86_64-linux/include/nvToolsExt.h中
修改增加NVTX_V2_DEPRECATION_WARNING_MESSAGE定义
```
/usr/local/cuda/targets/x86_64-linux/include/nvToolsExt.h:47:45: note: in definition of macro ‘NVTX_V2_DEPRECATION_WARNING_MESSAGE’
   47 | #define NVTX_V2_DEPRECATION_WARNING_MESSAGE "DEPRECATION NOTICE:  NVTX 2 is deprecated and will be removed from toolkits that distribute it in their next major version (CUDA 12.9).  Please use NVTX 3 instead.  All NVTX 2 API functions are supported in version 3.  The implementation is now header-only, so you no longer need to link with and distribute a dynamic library to use NVTX.  Ensure you are explicitly using NVTX 3 by writing #include <nvtx3/nvToolsExt.h> instead of #include <nvToolsExt.h>.  Remove nvToolsExt from your link command and linker search paths, and stop deploying libnvToolsExt.so or nvToolsExt64_1.dll -- these binary libraries will not be shipped with NVTX 3 for C/C++ usage.  A new library called 'libnvtx3interop.so' or 'nvtx3interop.dll' will be provided for interop with other languages.  This message can be suppressed by defining NVTX_SUPPRESS_V2_DEPRECATION_WARNING before including the NVTX 2 headers."
      |                                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

