### PR TITLE
[BIT] cummax cummin support big tensor

### DIFF
--- a/paddle/phi/kernels/gpu/cum_maxmin_kernel.cu
+++ b/paddle/phi/kernels/gpu/cum_maxmin_kernel.cu
@@ -93,8 +93,8 @@ template <typename T1,
 __global__ void KernelScanInnerWithIndices(const T1* x_data,
                                            T1* values_data,
                                            T2* indices_data,
-                                           int num_rows,
-                                           int row_size,
+                                           int64_t num_rows,
+                                           int64_t row_size,
                                            T1 init,
                                            BinaryFunction binary_op) {
   __shared__ T1 vbuf[num_threads_y][2 * num_threads_x];
@@ -102,9 +102,9 @@ __global__ void KernelScanInnerWithIndices(const T1* x_data,
   T1* row_buf = vbuf[threadIdx.y];
   T2* row_idx_buf = ibuf[threadIdx.y];
 
-  for (int block_row = blockIdx.x * blockDim.y; block_row < num_rows;
+  for (int64_t block_row = blockIdx.x * blockDim.y; block_row < num_rows;
        block_row += blockDim.y * gridDim.x) {
-    int row = block_row + threadIdx.y;
+    int64_t row = block_row + threadIdx.y;
     const T1* row_self = x_data + row * row_size;
     T1* row_values = values_data + row * row_size;
     T2* row_indices = indices_data + row * row_size;
@@ -112,11 +112,11 @@ __global__ void KernelScanInnerWithIndices(const T1* x_data,
     T2 block_idx_final = 0;
     // Perform scan on one block at a time, keeping track of the total value of
     // all blocks processed so far.
-    for (int block_col = 0; block_col < row_size;
+    for (int64_t block_col = 0; block_col < row_size;
          block_col += 2 * num_threads_x) {
       // Load data into shared memory (two values per thread).
-      int col1 = block_col + threadIdx.x;
-      int col2 = block_col + num_threads_x + threadIdx.x;
+      int64_t col1 = block_col + threadIdx.x;
+      int64_t col2 = block_col + num_threads_x + threadIdx.x;
       if (row < num_rows) {
         if (col1 < row_size) {
           row_buf[threadIdx.x] = *reinterpret_cast<const T1*>(&row_self[col1]);


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Bug fixes

### Description
cummax/cummin 在 input 为大 tensor 时出现 CUDA error(700)，本 PR 修复此问题。

由于出错配置（[100, 42949673]）所需要的显存太大，无法使用apitest运行accuracy测试。修改之后运行paddle_only不会报错。

为了运行accuracy，将配置稍微改小为[100, 22949673]，accuracy运行反馈为torch报错（修复前是paddle_only报错）。经验证，torch对这种超过int32范围的cummin和cummax不支持。

修改之前的paddle内核报错：
![image](https://github.com/user-attachments/assets/e8920d53-1147-4b4b-86db-33ba682b0979)
修改之后的torch报错：
![image](https://github.com/user-attachments/assets/9a818cb4-05fd-4677-b393-8a77aacfdb3c)



