### PR TITLE
Restore allocator_facade

### DIFF
--- a/paddle/phi/core/memory/allocation/allocator_facade.cc
+++ b/paddle/phi/core/memory/allocation/allocator_facade.cc
@@ -1798,17 +1798,11 @@ AllocationPtr AllocatorFacade::Alloc(const phi::Place& place,
 bool AllocatorFacade::InSameStream(
     const std::shared_ptr<phi::Allocation>& allocation,
     const phi::Stream& stream) {
-#if (defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)) && \
-    !defined(PADDLE_WITH_CUSTOM_DEVICE)
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
   gpuStream_t s = reinterpret_cast<gpuStream_t>(stream.id());  // NOLINT
   return s == GetStream(allocation);
-#elif defined(PADDLE_WITH_CUSTOM_DEVICE)
-  phi::stream::stream_t s =
-      reinterpret_cast<phi::stream::stream_t>(stream.id());  // NOLINT
-  return s == GetStream(allocation);
 #else
-  PADDLE_THROW(common::errors::PreconditionNotMet(
-      "Not compiled with GPU or CUDA backend."));
+  PADDLE_THROW(common::errors::PreconditionNotMet("Not compiled with GPU."));
 #endif
 }
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Custom Device

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-67164
Restore allocator_facade.cc due to an error in fast_deploy for an unknown reason.
