### PR TITLE
在fused_rms_norm函数中加入begin_norm_axis的默认值和维度检查

### DIFF
--- a/python/paddle/incubate/nn/functional/fused_rms_norm.py
+++ b/python/paddle/incubate/nn/functional/fused_rms_norm.py
@@ -61,7 +61,7 @@ def fused_rms_norm(
     norm_weight,
     norm_bias,
     epsilon,
-    begin_norm_axis,
+    begin_norm_axis=1,
     bias=None,
     residual=None,
     quant_scale=-1,
@@ -102,6 +102,21 @@ def fused_rms_norm(
             >>> epsilon = 1e-6
             >>> paddle_rmsnorm = paddle.incubate.nn.functional.fused_rms_norm(paddle_x, paddle_weight, paddle_bias, epsilon, 1)
     """
+    input_rank = len(x.shape)
+    if begin_norm_axis < 0:
+        begin_norm_axis += input_rank
+
+    if begin_norm_axis < 0 or begin_norm_axis >= input_rank:
+        raise ValueError(
+            f"begin_norm_axis must be in range [0, {input_rank}), "
+            f"but got {begin_norm_axis}"
+            + (
+                f" (originally {begin_norm_axis - input_rank})"
+                if begin_norm_axis < 0
+                else ""
+            )
+        )
+
     if in_dynamic_or_pir_mode():
         return _C_ops.rms_norm(
             x,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Improvements

### Description
<!-- Describe what you’ve done -->

1. 按文档中描述，begin_norm_axis的默认值设置为1
2. 加入begin_norm_axis的维度检查