### PR TITLE
[Accuracy diff No.52] Fix accuracy diff for reciprocal API

### DIFF
--- a/paddle/phi/kernels/funcs/activation_functor.h
+++ b/paddle/phi/kernels/funcs/activation_functor.h
@@ -3589,9 +3589,13 @@ struct CudaReciprocalFunctor : public BaseActivationFunctor<T> {
 
 template <typename T>
 struct CudaReciprocalGradFunctor : public BaseActivationFunctor<T> {
+  using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
+
   // dx = -dout * out^2
   __device__ __forceinline__ T operator()(const T dout, const T out) const {
-    return -dout * out * out;
+    MPType dout = static_cast<MPType>(dout);
+    MPType out = static_cast<MPType>(out);
+    return static_cast<T>(-dout * out * out);
   }
 
   static constexpr ActBwdOpFwdDeps FwdDeps() {

--- a/paddle/phi/kernels/funcs/activation_functor.h
+++ b/paddle/phi/kernels/funcs/activation_functor.h
@@ -3596,7 +3596,8 @@ struct CudaReciprocalGradFunctor : public BaseActivationFunctor<T> {
                                           const T arg_out) const {
     MPType dout = static_cast<MPType>(arg_dout);
     MPType out = static_cast<MPType>(arg_out);
-    return static_cast<T>(-dout * out * out);
+    return static_cast<T>(-dout *
+                          static_cast<MPType>(static_cast<T>(out * out)));
   }
 
   static constexpr ActBwdOpFwdDeps FwdDeps() {

--- a/paddle/phi/kernels/funcs/activation_functor.h
+++ b/paddle/phi/kernels/funcs/activation_functor.h
@@ -3592,9 +3592,10 @@ struct CudaReciprocalGradFunctor : public BaseActivationFunctor<T> {
   using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
 
   // dx = -dout * out^2
-  __device__ __forceinline__ T operator()(const T dout, const T out) const {
-    MPType dout = static_cast<MPType>(dout);
-    MPType out = static_cast<MPType>(out);
+  __device__ __forceinline__ T operator()(const T arg_dout,
+                                          const T arg_out) const {
+    MPType dout = static_cast<MPType>(arg_dout);
+    MPType out = static_cast<MPType>(arg_out);
     return static_cast<T>(-dout * out * out);
   }
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
日志显示反向精度问题，都出现在 torch 包含 inf 中，torch 的自动求导是 `-grad * (result * result).conj()`，先进行了 output 的相乘，如果出现 inf ，就会传递下去，paddle中按顺序 -grad*result，就导致不会出现 inf。对齐 torch 的行为，感觉在数学上也更加合理。（这里加了一个精度提升，主要是看见 torch 的mul算子有这个行为，但是没加 PaddleAPITest 也能通过

- PaddleAPITest 测试通过
![图片](https://github.com/user-attachments/assets/9b83a27c-7b0b-4ef3-86db-5f38ed9dce42)
