### PR TITLE
[PHI] Update the MAX_ARCH of cutlass attention to support sm90

### DIFF
--- a/paddle/phi/kernels/fusion/cutlass/memory_efficient_attention/generate_kernels.py
+++ b/paddle/phi/kernels/fusion/cutlass/memory_efficient_attention/generate_kernels.py
@@ -33,7 +33,7 @@ from pathlib import Path
 from typing import TypeVar
 
 DEFAULT_ARCH = [50, 70, 75, 80]
-MAX_ARCH = 90
+MAX_ARCH = 100
 ENABLE_MACRO = "PADDLE_WITH_MEMORY_EFFICIENT_ATTENTION"
 
 assert sorted(DEFAULT_ARCH) == DEFAULT_ARCH

--- a/paddle/phi/kernels/fusion/cutlass/memory_efficient_attention/generate_variable_forward_kernels.py
+++ b/paddle/phi/kernels/fusion/cutlass/memory_efficient_attention/generate_variable_forward_kernels.py
@@ -33,7 +33,7 @@ from pathlib import Path
 from typing import TypeVar
 
 DEFAULT_ARCH = [50, 70, 75, 80]
-MAX_ARCH = 90
+MAX_ARCH = 100
 ENABLE_MACRO = "PADDLE_WITH_MEMORY_EFFICIENT_ATTENTION"
 
 assert sorted(DEFAULT_ARCH) == DEFAULT_ARCH


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Operator Mechanism


### PR Types
Bug fixes


### Description
将cutlass的`memory_efficient_attention`的架构上限调整为100，以支持sm90系显卡的运行

其实我本来是想在80和100之间再隔入一个90的：
```python
DEFAULT_ARCH = [50, 70, 75, 80, 90]
MAX_ARCH = 100
```
但是这样会编译失败，究其原因，是因为cutlass虽然定义了Sm90这个架构：https://github.com/NVIDIA/cutlass/blob/66d9cddc832c1cdc2b30a8755274f7f74640cfe6/include/cutlass/arch/arch.h#L90-L92
但在gemm的配置中对于Sm90只支持double和complex\<double>：https://github.com/NVIDIA/cutlass/blob/66d9cddc832c1cdc2b30a8755274f7f74640cfe6/include/cutlass/gemm/device/default_gemm_configuration.h#L771
而memory_efficient_attention是半精度操作，没法用这两个配置，也就是区分Sm90没有什么作用，因此我直接就从80跳到100了

经过测试，可以修复test_block_multihead_attention、test_block_multihead_attention_gqa单测在H卡上报错的问题，但是注意nvcc版本和驱动版本要匹配，如果用高版本的nvcc编译（如12.9），但驱动是低版本（如12.4），就会出现精度问题，这并非Paddle的问题

Pcard-85711