### PR TITLE
[Auto Parallel] Add spmd rule No.16 for depthwise_conv2d and depthwise_conv2d_grad ops.

### DIFF
--- a/paddle/phi/infermeta/spmd_rules/depthwise_conv2d.cc
+++ b/paddle/phi/infermeta/spmd_rules/depthwise_conv2d.cc
@@ -1,0 +1,215 @@
+/* Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include "paddle/phi/infermeta/spmd_rules/depthwise_conv2d.h"
+
+#include "glog/logging.h"
+
+#include "paddle/phi/core/distributed/auto_parallel/dist_attr.h"
+#include "paddle/phi/core/distributed/auto_parallel/inferspmd_utils.h"
+#include "paddle/phi/core/distributed/auto_parallel/utils.h"
+#include "paddle/phi/core/enforce.h"
+#include "paddle/phi/infermeta/spmd_rules/utils.h"
+
+namespace phi {
+namespace distributed {
+
+using phi::distributed::auto_parallel::str_join;
+
+SpmdInfo DepthwiseConv2dInferSpmd(const DistMetaTensor& input,
+                                  const DistMetaTensor& filter,
+                                  const std::vector<int>& strides,
+                                  const std::vector<int>& paddings,
+                                  const std::string& padding_algorithm,
+                                  const std::vector<int>& dilations,
+                                  int groups,
+                                  const std::string& data_format) {
+  // Step0: verify input args based on depthwise_conv2d logic
+  // input_dim: NCHinWin, filter_dim: M1HfWf, C = groups, M % groups == 0
+  // output_dim: NMHoutWout
+  VLOG(4) << "step 0: verify input args based on depthwise_conv2d logic";
+  auto original_input_shape = common::vectorize(input.dims());
+  auto original_filter_shape = common::vectorize(filter.dims());
+  int input_ndim = static_cast<int>(original_input_shape.size());
+  int filter_ndim = static_cast<int>(original_filter_shape.size());
+  const auto& input_dist_attr_src = input.dist_attr();
+  const auto& filter_dist_attr_src = filter.dist_attr();
+  std::vector<int64_t> input_dims_mapping = input_dist_attr_src.dims_mapping();
+  std::vector<int64_t> filter_dims_mapping =
+      filter_dist_attr_src.dims_mapping();
+
+  PADDLE_ENFORCE_EQ(input_ndim,
+                    4,
+                    common::errors::InvalidArgument(
+                        "The Tensor Input's rank must be 4 in "
+                        "depthwise_conv2d, for NCHW or NHWC format."
+                        "But now it's [%d]",
+                        input_ndim));
+
+  PADDLE_ENFORCE_EQ(
+      filter_ndim,
+      4,
+      common::errors::InvalidArgument("The Tensor Filter's rank must be 4 in "
+                                      "depthwise_conv2d, for MCHW format."
+                                      "But now it's [%d]",
+                                      filter_ndim));
+
+  PADDLE_ENFORCE_EQ(input_ndim,
+                    input_dims_mapping.size(),
+                    common::errors::InvalidArgument(
+                        "The Tensor Input's rank [%d] and Input's "
+                        "dims_mapping size [%d] are not matched.",
+                        input_ndim,
+                        input_dims_mapping.size()));
+  PADDLE_ENFORCE_EQ(filter_ndim,
+                    filter_dims_mapping.size(),
+                    common::errors::InvalidArgument(
+                        "The Tensor Filter's rank [%d] and Filter's "
+                        "dims_mapping size [%d] are not matched.",
+                        filter_ndim,
+                        filter_dims_mapping.size()));
+  PADDLE_ENFORCE_EQ(filter_dims_mapping[1],
+                    -1,
+                    common::errors::InvalidArgument(
+                        "The Tensor Filter's dims_mapping on channel dim "
+                        "should always be -1.",
+                        "But now it's [%d]",
+                        filter_dims_mapping[1]));
+
+  VLOG(6) << "DepthwiseConv2D InferForward Inputs: "
+          << "Input shape: [" << str_join(original_input_shape)
+          << "], input_dims_mapping: [" << str_join(input_dims_mapping)
+          << "]; Filter shape: [" << str_join(original_filter_shape)
+          << "], filter_dims_mapping: [" << str_join(filter_dims_mapping)
+          << "]; ";
+
+  // Step1: build Einsum Notation
+  // todo: check output notation, how to deal with the "Input HW, Filter HW and
+  // Output HW"...
+  // todo: if shard channel_dim, attribute group should also be changed on each
+  // device, which is not supported, so channel_dim currently should not be
+  // sharded.
+  VLOG(4) << "step 1: build Einsum Notation";
+  std::string input_axes = (data_format == "NCHW") ? "n1hw" : "nhw1";
+  std::string filter_axes = "m1hw";
+  std::string output_axes = "nmhw";
+
+  if (data_format == "NCHW")
+    input_dims_mapping[1] == -1;
+  else
+    input_dims_mapping[3] == -1;
+  filter_dims_mapping[1] == -1;
+
+  // Step2: sharding propagation
+  VLOG(4) << "step 2: sharding propagation";
+  // Step2.1: merge input sharding
+  std::pair<std::string, std::vector<int64_t>> input_pair(input_axes,
+                                                          input_dims_mapping);
+  std::pair<std::string, std::vector<int64_t>> filter_pair(filter_axes,
+                                                           filter_dims_mapping);
+  auto axis_to_dim_map = ShardingMergeForTensors({input_pair, filter_pair});
+  // Step2.2: infer output dims mapping
+  TensorDistAttr output_dist_attr_dst =
+      CopyTensorDistAttrForOutput(input_dist_attr_src);
+  output_dist_attr_dst.set_dims_mapping(
+      GetDimsMappingForAxes(output_axes, axis_to_dim_map));
+
+  // Step2.3: update input dims mapping
+  TensorDistAttr input_dist_attr_dst =
+      CopyTensorDistAttrForOutput(input_dist_attr_src);
+  TensorDistAttr filter_dist_attr_dst =
+      CopyTensorDistAttrForOutput(filter_dist_attr_src);
+  input_dist_attr_dst.set_dims_mapping(
+      GetDimsMappingForAxes(input_axes, axis_to_dim_map));
+  filter_dist_attr_dst.set_dims_mapping(
+      GetDimsMappingForAxes(filter_axes, axis_to_dim_map));
+
+  VLOG(4) << "DepthwiseConv2DSPMDRule InferForward: "
+          << "Einsum notation: [" << input_axes << "," << filter_axes << " --> "
+          << output_axes << "]. " << std::endl;
+  LogInputDistAttr(
+      "Input", original_input_shape, input_dist_attr_src, input_dist_attr_dst);
+  LogInputDistAttr("Filter",
+                   original_filter_shape,
+                   filter_dist_attr_src,
+                   filter_dist_attr_dst);
+  LogOutputDistAttr("Output", output_dist_attr_dst);
+  VLOG(4) << std::endl;
+
+  return {{input_dist_attr_dst, filter_dist_attr_dst}, {output_dist_attr_dst}};
+}
+
+SpmdInfo DepthwiseConv2dGradInferSpmd(const DistMetaTensor& input,
+                                      const DistMetaTensor& filter,
+                                      const DistMetaTensor& output_grad,
+                                      const std::vector<int>& strides,
+                                      const std::vector<int>& paddings,
+                                      const std::string& padding_algorithm,
+                                      const std::vector<int>& dilations,
+                                      int groups,
+                                      const std::string& data_format) {
+  auto input_dist_attr_src = input.dist_attr();
+  auto filter_dist_attr_src = filter.dist_attr();
+  auto output_grad_dist_attr_src = output_grad.dist_attr();
+
+  std::string input_axes = (data_format == "NCHW") ? "n1hw" : "nhw1";
+  std::string filter_axes = "m1hw";
+  std::string output_axes = "nmhw";
+
+  std::pair<std::string, std::vector<int64_t>> input_pair(
+      input_axes, input_dist_attr_src.dims_mapping());
+  std::pair<std::string, std::vector<int64_t>> filter_pair(
+      filter_axes, filter_dist_attr_src.dims_mapping());
+  std::pair<std::string, std::vector<int64_t>> output_grad_pair(
+      output_axes, output_grad_dist_attr_src.dims_mapping());
+
+  // input_grad_dist, copy n_dim and merge m_dim
+  auto axis_to_dim_map_1 =
+      ShardingMergeForTensors({filter_pair, output_grad_pair});
+  TensorDistAttr input_grad_dist_attr_dst =
+      GetReplicatedDistAttr(input_dist_attr_src);
+  input_grad_dist_attr_dst.set_dims_mapping(
+      GetDimsMappingForAxes(input_axes, axis_to_dim_map_1));
+  TensorDistAttr filter_dist_attr_dst =
+      CopyTensorDistAttrForOutput(filter_dist_attr_src);
+  filter_dist_attr_dst.set_dims_mapping(
+      GetDimsMappingForAxes(filter_axes, axis_to_dim_map_1));
+
+  // filter_grad_dist, copy m_dim and merge n_dim
+  auto axis_to_dim_map_2 =
+      ShardingMergeForTensors({input_pair, output_grad_pair});
+  TensorDistAttr filter_grad_dist_attr_dst =
+      GetReplicatedDistAttr(filter_dist_attr_src);
+  filter_grad_dist_attr_dst.set_dims_mapping(
+      GetDimsMappingForAxes(filter_axes, axis_to_dim_map_2));
+  TensorDistAttr input_dist_attr_dst =
+      CopyTensorDistAttrForOutput(input_dist_attr_src);
+  input_dist_attr_dst.set_dims_mapping(
+      GetDimsMappingForAxes(input_axes, axis_to_dim_map_2));
+
+  // output_grad
+  auto axis_to_dim_map_3 =
+      ShardingMergeForTensors({input_pair, filter_pair, output_grad_pair});
+  TensorDistAttr output_grad_dist_attr_dst =
+      CopyTensorDistAttrForOutput(output_grad_dist_attr_src);
+  output_grad_dist_attr_dst.set_dims_mapping(
+      GetDimsMappingForAxes(output_axes, axis_to_dim_map_3));
+
+  return {
+      {input_dist_attr_dst, filter_dist_attr_dst, output_grad_dist_attr_dst},
+      {input_grad_dist_attr_dst, filter_grad_dist_attr_dst}};
+}
+
+}  // namespace distributed
+}  // namespace phi

--- a/paddle/phi/infermeta/spmd_rules/depthwise_conv2d.cc
+++ b/paddle/phi/infermeta/spmd_rules/depthwise_conv2d.cc
@@ -32,8 +32,8 @@ SpmdInfo DepthwiseConv2dInferSpmd(const DistMetaTensor& input,
                                   const std::vector<int>& strides,
                                   const std::vector<int>& paddings,
                                   const std::string& padding_algorithm,
-                                  const std::vector<int>& dilations,
                                   int groups,
+                                  const std::vector<int>& dilations,
                                   const std::string& data_format) {
   // Step0: verify input args based on depthwise_conv2d logic
   // input_dim: NCHinWin, filter_dim: M1HfWf, C = groups, M % groups == 0
@@ -109,7 +109,6 @@ SpmdInfo DepthwiseConv2dInferSpmd(const DistMetaTensor& input,
     input_dims_mapping[1] == -1;
   else
     input_dims_mapping[3] == -1;
-  filter_dims_mapping[1] == -1;
 
   // Step2: sharding propagation
   VLOG(4) << "step 2: sharding propagation";
@@ -156,8 +155,8 @@ SpmdInfo DepthwiseConv2dGradInferSpmd(const DistMetaTensor& input,
                                       const std::vector<int>& strides,
                                       const std::vector<int>& paddings,
                                       const std::string& padding_algorithm,
-                                      const std::vector<int>& dilations,
                                       int groups,
+                                      const std::vector<int>& dilations,
                                       const std::string& data_format) {
   auto input_dist_attr_src = input.dist_attr();
   auto filter_dist_attr_src = filter.dist_attr();

--- a/paddle/phi/infermeta/spmd_rules/depthwise_conv2d.cc
+++ b/paddle/phi/infermeta/spmd_rules/depthwise_conv2d.cc
@@ -106,9 +106,9 @@ SpmdInfo DepthwiseConv2dInferSpmd(const DistMetaTensor& input,
   std::string output_axes = "nmhw";
 
   if (data_format == "NCHW")
-    input_dims_mapping[1] == -1;
+    input_dims_mapping[1] = -1;
   else
-    input_dims_mapping[3] == -1;
+    input_dims_mapping[3] = -1;
 
   // Step2: sharding propagation
   VLOG(4) << "step 2: sharding propagation";
@@ -134,6 +134,7 @@ SpmdInfo DepthwiseConv2dInferSpmd(const DistMetaTensor& input,
   filter_dist_attr_dst.set_dims_mapping(
       GetDimsMappingForAxes(filter_axes, axis_to_dim_map));
 
+  // Step3: Handle Partial
   VLOG(4) << "DepthwiseConv2DSPMDRule InferForward: "
           << "Einsum notation: [" << input_axes << "," << filter_axes << " --> "
           << output_axes << "]. " << std::endl;

--- a/paddle/phi/infermeta/spmd_rules/depthwise_conv2d.h
+++ b/paddle/phi/infermeta/spmd_rules/depthwise_conv2d.h
@@ -29,8 +29,8 @@ SpmdInfo DepthwiseConv2dInferSpmd(
     const std::vector<int>& strides = {1, 1},
     const std::vector<int>& paddings = {0, 0},
     const std::string& padding_algorithm = "EXPLICIT",
-    const std::vector<int>& dilations = {1, 1},
     int groups = 1,
+    const std::vector<int>& dilations = {1, 1},
     const std::string& data_format = "NCHW");
 
 SpmdInfo DepthwiseConv2dGradInferSpmd(
@@ -40,8 +40,8 @@ SpmdInfo DepthwiseConv2dGradInferSpmd(
     const std::vector<int>& strides = {1, 1},
     const std::vector<int>& paddings = {0, 0},
     const std::string& padding_algorithm = "EXPLICIT",
-    const std::vector<int>& dilations = {1, 1},
     int groups = 1,
+    const std::vector<int>& dilations = {1, 1},
     const std::string& data_format = "NCHW");
 
 }  // namespace distributed

--- a/paddle/phi/infermeta/spmd_rules/depthwise_conv2d.h
+++ b/paddle/phi/infermeta/spmd_rules/depthwise_conv2d.h
@@ -1,0 +1,48 @@
+/* Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "paddle/phi/core/distributed/auto_parallel/dist_meta_tensor.h"
+#include "paddle/phi/core/distributed/type_defs.h"
+
+namespace phi {
+namespace distributed {
+
+SpmdInfo DepthwiseConv2dInferSpmd(
+    const DistMetaTensor& input,
+    const DistMetaTensor& filter,
+    const std::vector<int>& strides = {1, 1},
+    const std::vector<int>& paddings = {0, 0},
+    const std::string& padding_algorithm = "EXPLICIT",
+    const std::vector<int>& dilations = {1, 1},
+    int groups = 1,
+    const std::string& data_format = "NCHW");
+
+SpmdInfo DepthwiseConv2dGradInferSpmd(
+    const DistMetaTensor& input,
+    const DistMetaTensor& filter,
+    const DistMetaTensor& output_grad,
+    const std::vector<int>& strides = {1, 1},
+    const std::vector<int>& paddings = {0, 0},
+    const std::string& padding_algorithm = "EXPLICIT",
+    const std::vector<int>& dilations = {1, 1},
+    int groups = 1,
+    const std::string& data_format = "NCHW");
+
+}  // namespace distributed
+}  // namespace phi

--- a/paddle/phi/infermeta/spmd_rules/rules.cc
+++ b/paddle/phi/infermeta/spmd_rules/rules.cc
@@ -818,4 +818,10 @@ PD_REGISTER_SPMD_RULE(
 PD_REGISTER_SPMD_RULE(conv3d,
                       PD_INFER_SPMD(phi::distributed::Conv3dInferSpmd),
                       PD_INFER_SPMD(phi::distributed::Conv3dGradInferSpmd));
+
+// depthwise_conv2d
+PD_REGISTER_SPMD_RULE(
+    depthwise_conv2d,
+    PD_INFER_SPMD(phi::distributed::DepthwiseConv2dInferSpmd),
+    PD_INFER_SPMD(phi::distributed::DepthwiseConv2dGradInferSpmd));
 }  // namespace phi::distributed

--- a/paddle/phi/infermeta/spmd_rules/rules.h
+++ b/paddle/phi/infermeta/spmd_rules/rules.h
@@ -34,6 +34,7 @@ limitations under the License. */
 #include "paddle/phi/infermeta/spmd_rules/cummin.h"
 #include "paddle/phi/infermeta/spmd_rules/cumsum.h"
 #include "paddle/phi/infermeta/spmd_rules/default_data_parallel.h"
+#include "paddle/phi/infermeta/spmd_rules/depthwise_conv2d.h"
 #include "paddle/phi/infermeta/spmd_rules/dropout.h"
 #include "paddle/phi/infermeta/spmd_rules/elementwise.h"
 #include "paddle/phi/infermeta/spmd_rules/embedding.h"

--- a/paddle/phi/ops/yaml/backward.yaml
+++ b/paddle/phi/ops/yaml/backward.yaml
@@ -792,6 +792,7 @@
   infer_meta :
     func : GeneralBinaryGradInferMeta
     param : [input, filter]
+    spmd_rule : DepthwiseConv2dGradInferSpmd
   kernel :
     func : depthwise_conv2d_grad
     data_type : input

--- a/paddle/phi/ops/yaml/ops.yaml
+++ b/paddle/phi/ops/yaml/ops.yaml
@@ -1419,6 +1419,7 @@
   output : Tensor(out)
   infer_meta :
     func : DepthwiseConvInferMeta
+    spmd_rule : DepthwiseConv2dInferSpmd
   kernel :
     func : depthwise_conv2d
     data_type : input

--- a/test/auto_parallel/spmd_rules/CMakeLists.txt
+++ b/test/auto_parallel/spmd_rules/CMakeLists.txt
@@ -63,6 +63,8 @@ if(WITH_DISTRIBUTE)
     py_test_modules(test_gelu_rule MODULES test_gelu_rule)
     py_test_modules(test_take_along_axis_rule MODULES test_take_along_axis_rule)
     py_test_modules(test_conv3d_rule MODULES test_conv3d_rule)
+    py_test_modules(test_depthwise_conv2d_rule MODULES
+                    test_depthwise_conv2d_rule)
   endif()
   # End of unittests WITH single card WITHOUT timeout
 

--- a/test/auto_parallel/spmd_rules/test_depthwise_conv2d_rule.py
+++ b/test/auto_parallel/spmd_rules/test_depthwise_conv2d_rule.py
@@ -1,0 +1,453 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from paddle.distributed.auto_parallel.static.dist_attribute import (
+    DistTensorSpec,
+    TensorDistAttr,
+)
+from paddle.distributed.fleet import auto
+from paddle.framework import core
+
+
+class TestDepthwiseConv2dSPMDRule(unittest.TestCase):
+    def setUp(self):
+        self.rule = core.get_phi_spmd_rule("depthwise_conv2d")
+
+    def test_depthwise_conv2d_nchw_infer_forward(self):
+        # forward setup
+        input_shape = [2, 4, 8, 8]
+        self.data_format = "NCHW"
+        filter_shape = [8, 1, 3, 3]
+        process_mesh = auto.ProcessMesh(
+            mesh=[[[0, 1], [2, 3]], [[4, 5], [6, 7]]]
+        )
+
+        input_tensor_dist_attr = TensorDistAttr()
+        input_tensor_dist_attr.dims_mapping = [0, -1, -1, -1]
+        input_tensor_dist_attr.process_mesh = process_mesh
+        self.input_dist_tensor_spec = DistTensorSpec(
+            input_shape, input_tensor_dist_attr
+        )
+
+        filter_tensor_dist_attr = TensorDistAttr()
+        filter_tensor_dist_attr.dims_mapping = [-1, -1, -1, -1]
+        filter_tensor_dist_attr.process_mesh = process_mesh
+        self.filter_dist_tensor_spec = DistTensorSpec(
+            filter_shape, filter_tensor_dist_attr
+        )
+
+        self.strides = [1, 1]
+        self.paddings = [0, 0]
+        self.padding_algorithm = "EXPLICIT"
+        self.group = 4
+        self.dilations = [1, 1]
+        # case 1
+        # input: NCHinWin[0, -1, -1, -1], filter: MCHkWk[-1, -1, -1, -1] ---> output: NMHoutWout[0, -1, -1, -1]
+        result_dist_attrs = self.rule.infer_forward(
+            self.input_dist_tensor_spec,
+            self.filter_dist_tensor_spec,
+            self.strides,
+            self.paddings,
+            self.padding_algorithm,
+            self.group,
+            self.dilations,
+            self.data_format,
+        )
+
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
+
+        self.assertEqual(len(result_dist_attrs), 2)
+        self.assertEqual(len(inferred_input_dist_attrs), 2)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
+
+        self.assertEqual(
+            inferred_input_dist_attrs[0].dims_mapping, [0, -1, -1, -1]
+        )
+        self.assertEqual(
+            inferred_input_dist_attrs[1].dims_mapping, [-1, -1, -1, -1]
+        )
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [0, -1, -1, -1]
+        )
+
+        # case 2
+        # input: NCHinWin[-1, -1, -1, -1], filter: MCHkWk[0, -1, -1, -1] ---> output: NMHoutWout[-1, 0, -1, -1]
+        self.input_dist_tensor_spec.set_dims_mapping([-1, -1, -1, -1])
+        self.filter_dist_tensor_spec.set_dims_mapping([0, -1, -1, -1])
+
+        result_dist_attrs = self.rule.infer_forward(
+            self.input_dist_tensor_spec,
+            self.filter_dist_tensor_spec,
+            self.strides,
+            self.paddings,
+            self.padding_algorithm,
+            self.group,
+            self.dilations,
+            self.data_format,
+        )
+
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
+
+        self.assertEqual(len(result_dist_attrs), 2)
+        self.assertEqual(len(inferred_input_dist_attrs), 2)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
+
+        self.assertEqual(
+            inferred_input_dist_attrs[0].dims_mapping, [-1, -1, -1, -1]
+        )
+        self.assertEqual(
+            inferred_input_dist_attrs[1].dims_mapping, [0, -1, -1, -1]
+        )
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [-1, 0, -1, -1]
+        )
+
+        # case 3
+        # input: NCHinWin[0, -1, -1, -1], filter: MCHkWk[1, -1, -1, -1] ---> output: NMHoutWout[0, 1, -1, -1]
+        self.input_dist_tensor_spec.set_dims_mapping([0, -1, -1, -1])
+        self.filter_dist_tensor_spec.set_dims_mapping([1, -1, -1, -1])
+
+        result_dist_attrs = self.rule.infer_forward(
+            self.input_dist_tensor_spec,
+            self.filter_dist_tensor_spec,
+            self.strides,
+            self.paddings,
+            self.padding_algorithm,
+            self.group,
+            self.dilations,
+            self.data_format,
+        )
+
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
+
+        self.assertEqual(len(result_dist_attrs), 2)
+        self.assertEqual(len(inferred_input_dist_attrs), 2)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
+
+        self.assertEqual(
+            inferred_input_dist_attrs[0].dims_mapping, [0, -1, -1, -1]
+        )
+        self.assertEqual(
+            inferred_input_dist_attrs[1].dims_mapping, [1, -1, -1, -1]
+        )
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [0, 1, -1, -1]
+        )
+
+        # case 4
+        # input: NCHinWin[-1, 0, -1, -1], filter: MCHkWk[-1, -1, -1, -1] ---> output: NMHoutWout[-1, -1, -1, -1]
+        self.input_dist_tensor_spec.set_dims_mapping([-1, 0, -1, -1])
+        self.filter_dist_tensor_spec.set_dims_mapping([-1, -1, -1, -1])
+
+        result_dist_attrs = self.rule.infer_forward(
+            self.input_dist_tensor_spec,
+            self.filter_dist_tensor_spec,
+            self.strides,
+            self.paddings,
+            self.padding_algorithm,
+            self.group,
+            self.dilations,
+            self.data_format,
+        )
+
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
+
+        self.assertEqual(len(result_dist_attrs), 2)
+        self.assertEqual(len(inferred_input_dist_attrs), 2)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
+
+        self.assertEqual(
+            inferred_input_dist_attrs[0].dims_mapping, [-1, -1, -1, -1]
+        )
+        self.assertEqual(
+            inferred_input_dist_attrs[1].dims_mapping, [-1, -1, -1, -1]
+        )
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [-1, -1, -1, -1]
+        )
+
+        # case 5
+        # input: NCHinWin[0, 2, -1, -1], filter: MCHkWk[1, -1, -1, -1] ---> output: NMHoutWout[0, 1, -1, -1]
+        self.input_dist_tensor_spec.set_dims_mapping([0, 2, -1, -1])
+        self.filter_dist_tensor_spec.set_dims_mapping([1, -1, -1, -1])
+
+        result_dist_attrs = self.rule.infer_forward(
+            self.input_dist_tensor_spec,
+            self.filter_dist_tensor_spec,
+            self.strides,
+            self.paddings,
+            self.padding_algorithm,
+            self.group,
+            self.dilations,
+            self.data_format,
+        )
+
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
+
+        self.assertEqual(len(result_dist_attrs), 2)
+        self.assertEqual(len(inferred_input_dist_attrs), 2)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
+
+        self.assertEqual(
+            inferred_input_dist_attrs[0].dims_mapping, [0, -1, -1, -1]
+        )
+        self.assertEqual(
+            inferred_input_dist_attrs[1].dims_mapping, [1, -1, -1, -1]
+        )
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [0, 1, -1, -1]
+        )
+
+    def test_depthwise_conv2d_nhwc_infer_forward(self):
+        # forward setup
+        input_shape = [2, 8, 8, 4]
+        self.data_format = "NHWC"
+        filter_shape = [8, 1, 3, 3]
+        process_mesh = auto.ProcessMesh(
+            mesh=[[[0, 1], [2, 3]], [[4, 5], [6, 7]]]
+        )
+
+        input_tensor_dist_attr = TensorDistAttr()
+        input_tensor_dist_attr.dims_mapping = [0, -1, -1, -1]
+        input_tensor_dist_attr.process_mesh = process_mesh
+        self.input_dist_tensor_spec = DistTensorSpec(
+            input_shape, input_tensor_dist_attr
+        )
+
+        filter_tensor_dist_attr = TensorDistAttr()
+        filter_tensor_dist_attr.dims_mapping = [-1, -1, -1, -1]
+        filter_tensor_dist_attr.process_mesh = process_mesh
+        self.filter_dist_tensor_spec = DistTensorSpec(
+            filter_shape, filter_tensor_dist_attr
+        )
+
+        self.strides = [1, 1]
+        self.paddings = [0, 0]
+        self.padding_algorithm = "EXPLICIT"
+        self.group = 4
+        self.dilations = [1, 1]
+        # case 1
+        # input: NHinWinC[0, -1, -1, -1], filter: MCHkWk[-1, -1, -1, -1] ---> output: NMHoutWout[0, -1, -1, -1]
+        result_dist_attrs = self.rule.infer_forward(
+            self.input_dist_tensor_spec,
+            self.filter_dist_tensor_spec,
+            self.strides,
+            self.paddings,
+            self.padding_algorithm,
+            self.group,
+            self.dilations,
+            self.data_format,
+        )
+
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
+
+        self.assertEqual(len(result_dist_attrs), 2)
+        self.assertEqual(len(inferred_input_dist_attrs), 2)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
+
+        self.assertEqual(
+            inferred_input_dist_attrs[0].dims_mapping, [0, -1, -1, -1]
+        )
+        self.assertEqual(
+            inferred_input_dist_attrs[1].dims_mapping, [-1, -1, -1, -1]
+        )
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [0, -1, -1, -1]
+        )
+
+        # case 2
+        # input: NHinWinC[-1, -1, -1, -1], filter: MCHkWk[0, -1, -1, -1] ---> output: NMHoutWout[-1, 0, -1, -1]
+        self.input_dist_tensor_spec.set_dims_mapping([-1, -1, -1, -1])
+        self.filter_dist_tensor_spec.set_dims_mapping([0, -1, -1, -1])
+
+        result_dist_attrs = self.rule.infer_forward(
+            self.input_dist_tensor_spec,
+            self.filter_dist_tensor_spec,
+            self.strides,
+            self.paddings,
+            self.padding_algorithm,
+            self.group,
+            self.dilations,
+            self.data_format,
+        )
+
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
+
+        self.assertEqual(len(result_dist_attrs), 2)
+        self.assertEqual(len(inferred_input_dist_attrs), 2)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
+
+        self.assertEqual(
+            inferred_input_dist_attrs[0].dims_mapping, [-1, -1, -1, -1]
+        )
+        self.assertEqual(
+            inferred_input_dist_attrs[1].dims_mapping, [0, -1, -1, -1]
+        )
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [-1, 0, -1, -1]
+        )
+
+        # case 3
+        # input: NHinWinC[0, -1, -1, -1], filter: MCHkWk[1, -1, -1, -1] ---> output: NMHoutWout[0, 1, -1, -1]
+        self.input_dist_tensor_spec.set_dims_mapping([0, -1, -1, -1])
+        self.filter_dist_tensor_spec.set_dims_mapping([1, -1, -1, -1])
+
+        result_dist_attrs = self.rule.infer_forward(
+            self.input_dist_tensor_spec,
+            self.filter_dist_tensor_spec,
+            self.strides,
+            self.paddings,
+            self.padding_algorithm,
+            self.group,
+            self.dilations,
+            self.data_format,
+        )
+
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
+
+        self.assertEqual(len(result_dist_attrs), 2)
+        self.assertEqual(len(inferred_input_dist_attrs), 2)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
+
+        self.assertEqual(
+            inferred_input_dist_attrs[0].dims_mapping, [0, -1, -1, -1]
+        )
+        self.assertEqual(
+            inferred_input_dist_attrs[1].dims_mapping, [1, -1, -1, -1]
+        )
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [0, 1, -1, -1]
+        )
+
+        # case 4
+        # input: NHinWinC[-1, -1, -1, 0], filter: MCHkWk[-1, -1, -1, -1] ---> output: NMHoutWout[-1, -1, -1, -1]
+        self.input_dist_tensor_spec.set_dims_mapping([-1, -1, -1, 0])
+        self.filter_dist_tensor_spec.set_dims_mapping([-1, -1, -1, -1])
+
+        result_dist_attrs = self.rule.infer_forward(
+            self.input_dist_tensor_spec,
+            self.filter_dist_tensor_spec,
+            self.strides,
+            self.paddings,
+            self.padding_algorithm,
+            self.group,
+            self.dilations,
+            self.data_format,
+        )
+
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
+
+        self.assertEqual(len(result_dist_attrs), 2)
+        self.assertEqual(len(inferred_input_dist_attrs), 2)
+        self.assertEqual(len(inferred_output_dist_attrs), 1)
+
+        self.assertEqual(
+            inferred_input_dist_attrs[0].dims_mapping, [-1, -1, -1, -1]
+        )
+        self.assertEqual(
+            inferred_input_dist_attrs[1].dims_mapping, [-1, -1, -1, -1]
+        )
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [-1, -1, -1, -1]
+        )
+
+    def test_depthwise_conv2d_infer_backward(self):
+        # backward setup
+        input_shape = [2, 4, 8, 8]
+        self.data_format = "NCHW"
+        filter_shape = [8, 1, 3, 3]
+        output_shape = [2, 8, 6, 6]
+        process_mesh = auto.ProcessMesh(
+            mesh=[[[0, 1], [2, 3]], [[4, 5], [6, 7]]]
+        )
+
+        input_tensor_dist_attr = TensorDistAttr()
+        input_tensor_dist_attr.dims_mapping = [-1, -1, -1, -1]
+        input_tensor_dist_attr.process_mesh = process_mesh
+        self.input_dist_tensor_spec = DistTensorSpec(
+            input_shape, input_tensor_dist_attr
+        )
+
+        filter_tensor_dist_attr = TensorDistAttr()
+        filter_tensor_dist_attr.dims_mapping = [-1, -1, -1, -1]
+        filter_tensor_dist_attr.process_mesh = process_mesh
+        self.filter_dist_tensor_spec = DistTensorSpec(
+            filter_shape, filter_tensor_dist_attr
+        )
+
+        output_tensor_dist_attr = TensorDistAttr()
+        output_tensor_dist_attr.dims_mapping = [0, 1, -1, -1]
+        output_tensor_dist_attr.process_mesh = process_mesh
+        self.output_dist_tensor_spec = DistTensorSpec(
+            output_shape, output_tensor_dist_attr
+        )
+
+        self.strides = [1, 1]
+        self.paddings = [0, 0]
+        self.padding_algorithm = "EXPLICIT"
+        self.group = 4
+        self.dilations = [1, 1]
+
+        # case 1:
+        # Output: NMHoutWout[0, 1, -1, -1] ---> input: NCHinWin[0, -1, -1, -1], filter: MCHkWk[1, -1, -1, -1]
+        # input_grad: NCHinWin[0, -1, -1, -1], filter_grad: MCHkWk[1, -1, -1, -1]
+        result_dist_attrs = self.rule.infer_backward(
+            self.input_dist_tensor_spec,
+            self.filter_dist_tensor_spec,
+            self.output_dist_tensor_spec,
+            self.strides,
+            self.paddings,
+            self.padding_algorithm,
+            self.group,
+            self.dilations,
+            self.data_format,
+        )
+
+        inferred_input_dist_attrs = result_dist_attrs[0]
+        inferred_output_dist_attrs = result_dist_attrs[1]
+
+        self.assertEqual(len(result_dist_attrs), 2)
+        self.assertEqual(len(inferred_input_dist_attrs), 3)
+        self.assertEqual(len(inferred_output_dist_attrs), 2)
+
+        self.assertEqual(
+            inferred_input_dist_attrs[0].dims_mapping, [0, -1, -1, -1]
+        )
+        self.assertEqual(
+            inferred_input_dist_attrs[1].dims_mapping, [1, -1, -1, -1]
+        )
+        self.assertEqual(
+            inferred_input_dist_attrs[2].dims_mapping, [0, 1, -1, -1]
+        )
+        self.assertEqual(
+            inferred_output_dist_attrs[0].dims_mapping, [0, -1, -1, -1]
+        )
+        self.assertEqual(
+            inferred_output_dist_attrs[1].dims_mapping, [1, -1, -1, -1]
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/auto_parallel/spmd_rules/test_depthwise_conv2d_rule.py
+++ b/test/auto_parallel/spmd_rules/test_depthwise_conv2d_rule.py
@@ -152,6 +152,7 @@ class TestDepthwiseConv2dSPMDRule(unittest.TestCase):
 
         # case 4
         # input: NCHinWin[-1, 0, -1, -1], filter: MCHkWk[-1, -1, -1, -1] ---> output: NMHoutWout[-1, -1, -1, -1]
+        # Automatically reset dim "C" to -1
         self.input_dist_tensor_spec.set_dims_mapping([-1, 0, -1, -1])
         self.filter_dist_tensor_spec.set_dims_mapping([-1, -1, -1, -1])
 
@@ -185,6 +186,7 @@ class TestDepthwiseConv2dSPMDRule(unittest.TestCase):
 
         # case 5
         # input: NCHinWin[0, 2, -1, -1], filter: MCHkWk[1, -1, -1, -1] ---> output: NMHoutWout[0, 1, -1, -1]
+        # Automatically reset dim "C" to -1
         self.input_dist_tensor_spec.set_dims_mapping([0, 2, -1, -1])
         self.filter_dist_tensor_spec.set_dims_mapping([1, -1, -1, -1])
 
@@ -342,6 +344,7 @@ class TestDepthwiseConv2dSPMDRule(unittest.TestCase):
 
         # case 4
         # input: NHinWinC[-1, -1, -1, 0], filter: MCHkWk[-1, -1, -1, -1] ---> output: NMHoutWout[-1, -1, -1, -1]
+        # Automatically reset dim "C" to -1
         self.input_dist_tensor_spec.set_dims_mapping([-1, -1, -1, 0])
         self.filter_dist_tensor_spec.set_dims_mapping([-1, -1, -1, -1])
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
为 depthwise_conv2d 和 depthwise_conv2d_grad 算子增加切分推导规则。

- input 和 filter 的 channel 维不进行切分：filter 的 channel 维大小总是 1，若将 input 的 channel 维切分到不同设备，则在不同设备上需要将 group 参数也改为对应的大小才能正确计算，所以暂时对 channel 维不做切分。
- 其他规则与 conv2d, conv3d 一致