### PR TITLE
[Prim] Support `masked_fill_double_grad` for eager mode

### DIFF
--- a/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
@@ -92,6 +92,7 @@ prim_white_list = [
     "index_add_double_grad",
     "acos_double_grad",
     "put_along_axis_double_grad",
+    "masked_fill_double_grad",
 ]
 
 # white ops list whose kernel can automatically do type promotion.

--- a/paddle/fluid/pir/dialect/op_generator/vjp_interface_black_list.py
+++ b/paddle/fluid/pir/dialect/op_generator/vjp_interface_black_list.py
@@ -39,4 +39,5 @@ vjp_interface_black_list = [
     'index_add_grad',
     'acos_grad',
     'put_along_axis_grad',
+    'masked_fill_grad',
 ]

--- a/paddle/fluid/prim/api/api.yaml
+++ b/paddle/fluid/prim/api/api.yaml
@@ -57,3 +57,4 @@
 - isfinite
 - take_along_axis
 - variance
+- masked_fill

--- a/paddle/fluid/prim/api/composite_backward/composite_double_backward_api.h
+++ b/paddle/fluid/prim/api/composite_backward/composite_double_backward_api.h
@@ -172,13 +172,8 @@ void masked_fill_double_grad(const Tensor& mask,
           mask,
           full<T>({}, 0, grad_x_grad.get().dtype(), grad_x_grad.get().place()));
     } else if (grad_value_grad) {
-      grad_out_grad_tmp =
-          masked_fill<T>(common::vectorize(grad_x_grad.get().dims()),
-                         0,
-                         grad_x_grad.get().dtype(),
-                         grad_x_grad.get().place(),
-                         mask,
-                         grad_value_grad.get());
+      PADDLE_THROW(common::errors::InvalidArgument(
+          "grad_x_grad can not be null in 'masked_fill_double_grad'"));
     }
     set_output<T>(grad_out_grad_tmp, grad_out_grad);
   }

--- a/paddle/fluid/prim/api/composite_backward/composite_double_backward_api.h
+++ b/paddle/fluid/prim/api/composite_backward/composite_double_backward_api.h
@@ -157,6 +157,34 @@ void pow_double_grad(const Tensor& x,
 }
 
 template <typename T>
+void masked_fill_double_grad(const Tensor& mask,
+                             const paddle::optional<Tensor>& grad_x_grad,
+                             const paddle::optional<Tensor>& grad_value_grad,
+                             Tensor* grad_out_grad) {
+  if (grad_out_grad) {
+    Tensor grad_out_grad_tmp;
+    if (grad_x_grad && grad_value_grad) {
+      grad_out_grad_tmp =
+          masked_fill<T>(grad_x_grad.get(), mask, grad_value_grad.get());
+    } else if (grad_x_grad) {
+      grad_out_grad_tmp = masked_fill<T>(
+          grad_x_grad.get(),
+          mask,
+          full<T>({}, 0, grad_x_grad.get().dtype(), grad_x_grad.get().place()));
+    } else if (grad_value_grad) {
+      grad_out_grad_tmp =
+          masked_fill<T>(common::vectorize(grad_x_grad.get().dims()),
+                         0,
+                         grad_x_grad.get().dtype(),
+                         grad_x_grad.get().place(),
+                         mask,
+                         grad_value_grad.get());
+    }
+    set_output<T>(grad_out_grad_tmp, grad_out_grad);
+  }
+}
+
+template <typename T>
 void maximum_double_grad(const Tensor& x,
                          const Tensor& y,
                          const paddle::optional<Tensor>& grad_x_grad,

--- a/paddle/fluid/primitive/codegen/decomp_vjp_gen.py
+++ b/paddle/fluid/primitive/codegen/decomp_vjp_gen.py
@@ -128,7 +128,6 @@ PRIM_VJP = [
     'subtract_grad',
     'sum_grad',
     'take_along_axis_grad',
-    'put_along_axis_grad',
     'tanh_grad',
     'tile_grad',
     'topk_grad',

--- a/paddle/phi/kernels/xpu/p_send_kernel.cc
+++ b/paddle/phi/kernels/xpu/p_send_kernel.cc
@@ -60,7 +60,6 @@ void PSendArrayKernel(const Context& dev_ctx,
   for (size_t idx = 0; idx < x_array.size(); idx++) {
     VLOG(3) << "DenseTensorArray: idx(" << idx << ")";
     auto x = x_array.at(idx);
-    bkclDataType_t dtype = ToBKCLDataType(x.type());
     comm_ctx->Send(x, x.numel(), peer, stream);
     VLOG(3) << "rank " << comm_ctx->GetRank() << " send "
             << common::product(x.dims()) << " to " << peer;

--- a/paddle/phi/ops/yaml/backward.yaml
+++ b/paddle/phi/ops/yaml/backward.yaml
@@ -2124,6 +2124,16 @@
     data_type : softmax
   inplace : (softmax -> logits_grad)
 
+- backward_op : masked_fill_double_grad
+  forward : masked_fill_grad (Tensor x, Tensor mask, Tensor value, Tensor grad_out) -> Tensor(grad_x), Tensor(grad_value)
+  args : (Tensor mask, Tensor grad_x_grad, Tensor grad_value_grad)
+  output : Tensor(grad_out_grad)
+  infer_meta :
+    func : UnchangedInferMeta
+    param : [grad_x_grad]
+  optional: grad_x_grad, grad_value_grad
+  composite : masked_fill_double_grad(mask, grad_x_grad, grad_value_grad, grad_out_grad)
+
 - backward_op : masked_fill_grad
   forward : masked_fill (Tensor x, Tensor mask, Tensor value) -> Tensor(out)
   args : (Tensor x, Tensor mask, Tensor value, Tensor out_grad)
@@ -2135,7 +2145,7 @@
     func : masked_fill_grad
     param: [x, mask, value, out_grad]
   inplace : (out_grad -> x_grad)
-  composite : masked_fill_grad(x, mask, value, out_grad, x_grad, value_grad)
+  backward: masked_fill_double_grad
 
 - backward_op : masked_select_grad
   forward : masked_select (Tensor x, Tensor mask) -> Tensor(out)

--- a/paddle/phi/ops/yaml/op_compat.yaml
+++ b/paddle/phi/ops/yaml/op_compat.yaml
@@ -2442,6 +2442,13 @@
   outputs:
     {softmax : Softmax, loss : Loss}
 
+- op : masked_fill
+  backward : masked_fill_grad, masked_fill_double_grad
+  inputs :
+    {x : X, mask : Mask}
+  outputs :
+    out : Y
+
 - op : masked_select
   inputs :
     {x : X, mask : Mask}

--- a/paddle/phi/ops/yaml/op_compat.yaml
+++ b/paddle/phi/ops/yaml/op_compat.yaml
@@ -2442,13 +2442,6 @@
   outputs:
     {softmax : Softmax, loss : Loss}
 
-- op : masked_fill
-  backward : masked_fill_grad, masked_fill_double_grad
-  inputs :
-    {x : X, mask : Mask}
-  outputs :
-    out : Y
-
 - op : masked_select
   inputs :
     {x : X, mask : Mask}


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

Pcard-75624

添加 `masked_fill_double_grad` 动态图组合