### PR TITLE
[Auto Parallel] Fix pp_degree > 1 bug for sharding overlap in auto dy

### DIFF
--- a/python/paddle/distributed/auto_parallel/api.py
+++ b/python/paddle/distributed/auto_parallel/api.py
@@ -1537,6 +1537,10 @@ class _ShardOptimizer(Optimizer):
             param_group_len = (
                 len(self.fuse_param_view[i]) * self.gradient_accumulation_steps
             )
+            if "pp" in fleet.auto.get_mesh().dim_names:
+                param_group_len = (
+                    param_group_len * fleet.auto.get_mesh().get_dim_size("pp")
+                )
             for name, view in self.fuse_param_view[i].items():
                 view['param']._register_backward_hook(
                     fuse_comm_hook_func(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

- Fix pp_degree > 1 bug for sharding overlap in auto dy.
- Accuracy alignment for `FLAGS_enable_sharding_overlap = true/false` in pp_degree > 1.
- [TODO] Add ut to check sharding overlap always occurs at the last backward of each step.

Pcard-70448