### PR TITLE
[0-size Tensor No.175] Add 0-size Tensor support for group_norm

### DIFF
--- a/paddle/phi/kernels/gpu/group_norm_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/group_norm_grad_kernel.cu
@@ -17,9 +17,9 @@
 #include "paddle/common/layout.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/funcs/math_function.h"
 #include "paddle/phi/kernels/gpu/group_norm_utils.h"
-
 namespace phi {
 
 template <typename T, typename AccT, int flags>
@@ -279,6 +279,29 @@ void GroupNormGradKernel(const Context& dev_ctx,
                          DenseTensor* d_x,
                          DenseTensor* d_scale,
                          DenseTensor* d_bias) {
+  if (x.numel() == 0) {
+    dev_ctx.template Alloc<T>(d_x);
+    if (d_scale) {
+      // If batch dim is 0, we should set d_scale to zero, or else NAN
+      if (x.dims().size() > 0 && x.dims()[0] == 0) {
+        phi::Full<T, Context>(dev_ctx,
+                              phi::IntArray(common::vectorize(d_scale->dims())),
+                              0,
+                              d_scale);
+
+      } else {
+        phi::Full<T, Context>(dev_ctx,
+                              phi::IntArray(common::vectorize(d_scale->dims())),
+                              NAN,
+                              d_scale);
+      }
+    }
+    if (d_bias) {
+      phi::Full<T, Context>(
+          dev_ctx, phi::IntArray(common::vectorize(d_bias->dims())), 0, d_bias);
+    }
+    return;
+  }
   using AccT = typename phi::dtype::MPTypeTrait<T>::Type;
   const DataLayout data_layout = common::StringToDataLayout(data_layout_str);
   const auto scale_ptr = scale.get_ptr();

--- a/test/legacy_test/test_group_norm_op_v2.py
+++ b/test/legacy_test/test_group_norm_op_v2.py
@@ -647,8 +647,8 @@ class TestGroupNormAPIV2_ZeroSize(unittest.TestCase):
                     weight=scale_,
                     bias=bias_,
                 )
-                self.assertTrue(
-                    np.allclose(result1.numpy(), expect_res1, atol=1e-5)
+                np.testing.assert_allclose(
+                    result1.numpy(), expect_res1, atol=1e-5
                 )
 
                 loss = paddle.sum(result1)

--- a/test/legacy_test/test_group_norm_op_v2.py
+++ b/test/legacy_test/test_group_norm_op_v2.py
@@ -35,7 +35,11 @@ def group_norm_naive_for_general_dimension(
     input_shape = x.shape
     N, C = x.shape[0], x.shape[1]
     G = groups
-    x = x.reshape((N * G, -1))
+    if 0 in x.shape:
+        # output will reshape to input_shape
+        x = x.reshape((N * G, 0))
+    else:
+        x = x.reshape((N * G, -1))
     mean = np.mean(x, axis=1, keepdims=True)
     var = np.var(x, axis=1, keepdims=True)
     output = (x - mean) / np.sqrt(var + epsilon)
@@ -592,6 +596,76 @@ class TestGroupNormAPIV2_With_NDHWC_fp16(unittest.TestCase):
             np.testing.assert_allclose(
                 result2, expect_res2, rtol=1e-2, atol=1e-2
             )
+
+
+class TestGroupNormAPIV2_ZeroSize(unittest.TestCase):
+    def test_numerical_accuracy(self):
+        paddle.disable_static()
+        shape_groups = [
+            [(2, 4, 3, 2, 0), 4],
+            [(0, 1, 0, 0, 1), 1],
+        ]
+        np.random.seed(10)
+        places = []
+        if (
+            os.environ.get('FLAGS_CI_both_cpu_and_gpu', 'False').lower()
+            in ['1', 'true', 'on']
+            or not core.is_compiled_with_cuda()
+        ):
+            places.append(base.CPUPlace())
+        if core.is_compiled_with_cuda() and core.op_support_gpu("group_norm"):
+            places.append(base.CUDAPlace(0))
+
+        for place in places:
+            paddle.disable_static(place)
+            for shape_group in shape_groups:
+                shape = shape_group[0]
+                group = shape_group[1]
+                scale = np.array([1]).astype("float32")
+                bias = np.array([0]).astype("float32")
+                data = np.random.random(shape).astype("float32")
+                expect_res1 = group_norm_naive_for_general_dimension(
+                    data,
+                    scale,
+                    bias,
+                    epsilon=1e-5,
+                    groups=group,
+                )
+
+                data_pd = paddle.to_tensor(data)
+                data_pd.stop_gradient = False
+                scale_ = paddle.ones(
+                    shape[1]
+                )  # shape[1] is the number of channels
+                scale_.stop_gradient = False
+                bias_ = paddle.zeros(shape[1])
+                bias_.stop_gradient = False
+                result1 = paddle.nn.functional.group_norm(
+                    data_pd,
+                    group,
+                    data_format='NCDHW',
+                    weight=scale_,
+                    bias=bias_,
+                )
+                self.assertTrue(
+                    np.allclose(result1.numpy(), expect_res1, atol=1e-5)
+                )
+
+                loss = paddle.sum(result1)
+                loss.backward()
+                np.testing.assert_allclose(
+                    data_pd.grad.shape,
+                    data_pd.shape,
+                )
+                # If batch is 0, scale grad is 0, or else nan.
+                if data_pd.shape[0] == 0:
+                    scale2 = paddle.zeros(scale_.shape)
+                else:
+                    scale2 = paddle.full(scale_.shape, paddle.nan)
+                np.testing.assert_allclose(scale_.grad.numpy(), scale2.numpy())
+                np.testing.assert_allclose(
+                    bias_.grad.numpy(), paddle.zeros(bias_.shape).numpy()
+                )
 
 
 class TestGroupNormDimException(unittest.TestCase):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->

待修改 

[0-size Tensor No.175] Add 0-size Tensor support for group_norm

修改前向和反向
infermeta没有修改
kernel修改cpu/gpu/xpu

group和channel维度需要一致并大于0

PaddleAPITest 测试通过
![image](https://github.com/user-attachments/assets/4f34031a-86ec-47c8-b5a2-f3f32ce09d05)
