### PR TITLE
[Auto Parallel] add more tests for expand spmd

### DIFF
--- a/paddle/phi/infermeta/spmd_rules/expand.cc
+++ b/paddle/phi/infermeta/spmd_rules/expand.cc
@@ -41,24 +41,27 @@ SpmdInfo ExpandGradInferSpmd(const DistMetaTensor& x,
                              const IntArray& shape) {
   EXTRACT_SHAPE_AND_DIST_ATTR(x);
   EXTRACT_SHAPE_AND_DIST_ATTR(out_grad);
-  if (x_shape.size() == out_grad_shape.size()) {
-    return {{x_dist_attr_src, out_grad_dist_attr_src}, {x_dist_attr_src}};
-  }
   size_t axis =
       std::abs(static_cast<int>(out_grad.dims().size() - x.dims().size()));
-  std::vector<int64_t> x_grad_dims_mapping;
-  // std::vector<int64_t> x_grad_dims_mapping(x_ndim, -1);
+  std::vector<int64_t> x_grad_dims_mapping(x_ndim, -1);
+  std::vector<int64_t> partial_dims;
   for (size_t i = 0; i < out_grad_dims_mapping_src.size(); ++i) {
     if (i < axis || i >= axis + x.dims().size() ||
         out_grad.dims()[i] != x.dims()[i - axis]) {
+      if (out_grad_dims_mapping_src[i] >= 0) {
+        partial_dims.push_back(out_grad_dims_mapping_src[i]);
+      }
       continue;
     }
-    x_grad_dims_mapping.push_back(out_grad_dims_mapping_src[i]);
+    x_grad_dims_mapping[i - axis] = out_grad_dims_mapping_src[i];
   }
   TensorDistAttr x_grad_dist_attr =
       CopyTensorDistAttrForOutput(x_dist_attr_src);
+  TensorDistAttr x_dist_attr = x_grad_dist_attr;
+  x_dist_attr.set_dims_mapping(x_grad_dims_mapping);
   x_grad_dist_attr.set_dims_mapping(x_grad_dims_mapping);
-  return {{x_dist_attr_src, out_grad_dist_attr_src}, {x_grad_dist_attr}};
+  x_grad_dist_attr.set_partial_status(partial_dims);
+  return {{x_dist_attr, out_grad_dist_attr_src}, {x_grad_dist_attr}};
 }
 
 }  // namespace phi::distributed

--- a/paddle/phi/infermeta/spmd_rules/expand.cc
+++ b/paddle/phi/infermeta/spmd_rules/expand.cc
@@ -47,6 +47,7 @@ SpmdInfo ExpandGradInferSpmd(const DistMetaTensor& x,
   size_t axis =
       std::abs(static_cast<int>(out_grad.dims().size() - x.dims().size()));
   std::vector<int64_t> x_grad_dims_mapping;
+  // std::vector<int64_t> x_grad_dims_mapping(x_ndim, -1);
   for (size_t i = 0; i < out_grad_dims_mapping_src.size(); ++i) {
     if (i < axis || i >= axis + x.dims().size() ||
         out_grad.dims()[i] != x.dims()[i - axis]) {

--- a/test/cpp/auto_parallel/expand_spmd_rule_test.cc
+++ b/test/cpp/auto_parallel/expand_spmd_rule_test.cc
@@ -73,6 +73,18 @@ TEST(ExpandInferSpmd, Ctor) {
   EXPECT_EQ(get_dims_mapping(spmdinfo3.first[1]),
             std::vector<int64_t>({-1, 1}));
   EXPECT_EQ(get_dims_mapping(spmdinfo3.second[0]), std::vector<int64_t>({1}));
+
+  // Test case backward 2: ExpandGrad with shape {2, 2, -1}
+  auto x4 = CreateDistMetaTensor({1, 8}, {-1, 1}, process_mesh);
+  auto out4 = CreateDistMetaTensor({2, 2, 8}, {-1, -1, 1}, process_mesh);
+  phi::IntArray shape4 = {2, 2, -1};
+  auto spmdinfo4 = ExpandGradInferSpmd(x4, out4, shape4);
+  EXPECT_EQ(get_dims_mapping(spmdinfo4.first[0]),
+            std::vector<int64_t>({-1, 1}));
+  EXPECT_EQ(get_dims_mapping(spmdinfo4.first[1]),
+            std::vector<int64_t>({-1, -1, 1}));
+  EXPECT_EQ(get_dims_mapping(spmdinfo4.second[0]),
+            std::vector<int64_t>({-1, -1, 1}));
 }
 
 }  // namespace auto_parallel

--- a/test/cpp/auto_parallel/expand_spmd_rule_test.cc
+++ b/test/cpp/auto_parallel/expand_spmd_rule_test.cc
@@ -97,7 +97,7 @@ TEST(ExpandInferSpmd, Ctor) {
             std::vector<int64_t>({-1, 0, 1}));
   EXPECT_EQ(get_dims_mapping(spmdinfo5.second[0]),
             std::vector<int64_t>({-1, 1}));
-  EXPECT_EQ(get_partial_dims(spmdinfo5.second[0]), std::vector<int64_t>({0}));
+  EXPECT_EQ(get_partial_dims(spmdinfo5.second[0]), std::set<int64_t>({0}));
 }
 
 }  // namespace auto_parallel

--- a/test/cpp/auto_parallel/expand_spmd_rule_test.cc
+++ b/test/cpp/auto_parallel/expand_spmd_rule_test.cc
@@ -84,7 +84,20 @@ TEST(ExpandInferSpmd, Ctor) {
   EXPECT_EQ(get_dims_mapping(spmdinfo4.first[1]),
             std::vector<int64_t>({-1, -1, 1}));
   EXPECT_EQ(get_dims_mapping(spmdinfo4.second[0]),
-            std::vector<int64_t>({-1, -1, 1}));
+            std::vector<int64_t>({-1, 1}));
+
+  // Test case backward 3: ExpandGrad with shape {2, 2, -1}
+  auto x5 = CreateDistMetaTensor({1, 8}, {-1, 1}, process_mesh);
+  auto out5 = CreateDistMetaTensor({2, 2, 8}, {-1, 0, 1}, process_mesh);
+  phi::IntArray shape5 = {2, 2, -1};
+  auto spmdinfo5 = ExpandGradInferSpmd(x5, out5, shape5);
+  EXPECT_EQ(get_dims_mapping(spmdinfo5.first[0]),
+            std::vector<int64_t>({-1, 1}));
+  EXPECT_EQ(get_dims_mapping(spmdinfo5.first[1]),
+            std::vector<int64_t>({-1, 0, 1}));
+  EXPECT_EQ(get_dims_mapping(spmdinfo5.second[0]),
+            std::vector<int64_t>({-1, 1}));
+  EXPECT_EQ(get_partial_dims(spmdinfo5.second[0]), std::vector<int64_t>({0}));
 }
 
 }  // namespace auto_parallel


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
```python
# 测试1对应新加的 Test case backward 2
import numpy as np
import paddle
import paddle.distributed as dist

mesh = dist.ProcessMesh([0, 1], dim_names=["x"])

class SimpleNet(paddle.nn.Layer):
    def __init__(self, x):
        super(SimpleNet,self).__init__()
        self.x = dist.shard_tensor(x,mesh,[dist.Shard(1)])

    def forward(self):
        y = paddle.expand(self.x, [3,2,4])
        return y

x = paddle.to_tensor(np.random.random([1,4]))
x.stop_gradient=False
with paddle.LazyGuard():
    model = SimpleNet(x)

out = model()
loss = out.sum()
loss.backward()
print(out)
print(model.x.grad)
# 直接报错，x_grad 的 dim_mapping = {0}，和 rank 就不符合，计算 local_shape 时报错

# 测试2 对应新加的 Test case backward 3
import numpy as np
import paddle
import paddle.distributed as dist

mesh = dist.ProcessMesh([0, 1], dim_names=["x"])
x = paddle.to_tensor(np.random.random([1,4]))
x.stop_gradient=False
x = dist.shard_tensor(x, mesh, [dist.Replicate()])
out = paddle.expand(x, [3, 2, 4])
grad_out = dist.shard_tensor(paddle.ones([3, 2, 4]), mesh, [dist.Shard(1)])
r = paddle.grad(out, x,grad_out)
print(r)
# [[3, 3, 3, 3]] 实际上是 [[6, 6, 6, 6]]
```