### PR TITLE
[0-size Tensor No.248] Add 0-size Tensor support for reshape

### DIFF
--- a/paddle/phi/kernels/reshape_grad_kernel.cc
+++ b/paddle/phi/kernels/reshape_grad_kernel.cc
@@ -28,6 +28,10 @@ void ReshapeGradKernel(const Context& dev_ctx,
                        const DenseTensor& x,
                        const DenseTensor& out_grad,
                        DenseTensor* x_grad) {
+  if (x_grad->numel() == 0) {
+    dev_ctx.Alloc(x_grad, x_grad->dtype());
+    return;
+  }
   // NOTE: [Why not to use x.dims() ?]
   // Because inplace strategy is different between old IR and PIR,
   // we need fix it into x.dims() after cleaning old IR system.

--- a/paddle/phi/kernels/reshape_kernel.cc
+++ b/paddle/phi/kernels/reshape_kernel.cc
@@ -35,6 +35,8 @@ void ReshapeKernel(const Context& dev_ctx,
     return;
   }
   dev_ctx.Alloc(out, x.dtype());
+  if (out->numel() == 0) return;
+
   // TODO(chenweihang): the output dims are overwrite after copying,
   // here we need to use copy method that only copy data
   auto dims = out->dims();

--- a/test/legacy_test/test_reshape_op.py
+++ b/test/legacy_test/test_reshape_op.py
@@ -92,6 +92,35 @@ class TestReshapeOp_ZeroDim3(OpTest):
         self.inferred_shape = ()
 
 
+class TestReshapeOp_ZeroSize(OpTest):
+    def init_data(self):
+        self.ori_shape = (0, 2)
+        self.new_shape = (2, 0)
+        self.inferred_shape = (2, 0)
+
+    def setUp(self):
+        self.init_data()
+        self.op_type = "reshape2"
+        self.python_api = paddle.tensor.reshape
+        self.public_python_api = paddle.tensor.reshape
+        self.python_out_sig = ['Out']
+        self.inputs = {"X": np.random.random(self.ori_shape).astype("float32")}
+        self.attrs = {"shape": self.new_shape}
+        self.outputs = {
+            "Out": self.inputs["X"].reshape(self.inferred_shape),
+            'XShape': np.random.random(self.ori_shape).astype("float32"),
+        }
+
+    def test_check_output(self):
+        self.check_output(no_check_set=['XShape'])
+
+    def test_check_grad(self):
+        self.check_grad(
+            ["X"],
+            "Out",
+        )
+
+
 @unittest.skipIf(
     not paddle.is_compiled_with_cuda() or paddle.is_compiled_with_rocm(),
     "BFP16 test runs only on CUDA",


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->
[0-size Tensor No.248] Add 0-size Tensor support for reshape

paddle/phi/kernels/reshape_grad_kernel.cc 中对所有backend注册
![image](https://github.com/user-attachments/assets/7243220f-d515-4441-bb87-46bee9945dc9)

PaddleAPITest 测试没有cuda error, torch 和 paddle都有shape检查
![image](https://github.com/user-attachments/assets/dabf70ea-6e15-4183-8a5a-4d80ad9e2905)

如果x numel为0，shape numel不为0，torch没有错误，这是因为PaddleAPITest有修改torch规则配置，返回为全0
https://github.com/PFCCLab/PaddleAPITest/blob/480b501e1fd3c480e173284c8a94d15a5c42546e/tester/paddle_to_torch/rules.py#L4641

![image](https://github.com/user-attachments/assets/4aa30ba0-08b9-4db9-bfdc-d382612201c2)
