### PR TITLE
[Auto Parallel] add spmd rule for pd_op.empty_like

### DIFF
--- a/paddle/phi/infermeta/spmd_rules/full_like.cc
+++ b/paddle/phi/infermeta/spmd_rules/full_like.cc
@@ -16,11 +16,20 @@ limitations under the License. */
 #include "paddle/phi/infermeta/spmd_rules/elementwise.h"
 
 namespace phi::distributed {
-SpmdInfo FullLikeInferSpmd(const DistMetaTensor& x,
-                           const Scalar& y,
-                           phi::DataType dtype) {
+
+SpmdInfo CreateLikeInferSpmd(const DistMetaTensor& x) {
   TensorDistAttr out_dist_attr = x.dist_attr();
   out_dist_attr.clean_partial_status();
   return {{x.dist_attr()}, {out_dist_attr}};
+}
+
+SpmdInfo FullLikeInferSpmd(const DistMetaTensor& x,
+                           const Scalar& y,
+                           phi::DataType dtype) {
+  return CreateLikeInferSpmd(x);
+}
+
+SpmdInfo EmptyLikeInferSpmd(const DistMetaTensor& x, phi::DataType dtype) {
+  return CreateLikeInferSpmd(x);
 }
 }  // namespace phi::distributed

--- a/paddle/phi/infermeta/spmd_rules/full_like.h
+++ b/paddle/phi/infermeta/spmd_rules/full_like.h
@@ -22,8 +22,11 @@ limitations under the License. */
 
 namespace phi {
 namespace distributed {
+SpmdInfo CreateLikeInferSpmd(const DistMetaTensor& x);
+
 SpmdInfo FullLikeInferSpmd(const DistMetaTensor& x,
                            const Scalar& y,
                            phi::DataType dtype);
-}
+SpmdInfo EmptyLikeInferSpmd(const DistMetaTensor& x, phi::DataType dtype);
+}  // namespace distributed
 }  // namespace phi

--- a/paddle/phi/ops/yaml/ops.yaml
+++ b/paddle/phi/ops/yaml/ops.yaml
@@ -1719,6 +1719,7 @@
   infer_meta :
     func : CreateLikeInferMeta
     param : [x, dtype]
+    spmd_rule : EmptyLikeInferSpmd
   kernel :
     func : empty_like
     param : [x, dtype]

--- a/test/cpp/auto_parallel/spmd_rule_test.cc
+++ b/test/cpp/auto_parallel/spmd_rule_test.cc
@@ -1507,7 +1507,12 @@ TEST(ElementwiseUnaryLike, Ctor) {
   inferred_dist_attrs =
       phi::distributed::FullLikeInferSpmd(input, 1.0, phi::DataType::FLOAT32);
   check_element_unary_like(inferred_dist_attrs);
-
+  // empty like
+  input =
+      phi::distributed::DistMetaTensor(common::make_ddim(shape), t_dist_attr);
+  inferred_dist_attrs =
+      phi::distributed::EmptyLikeInferSpmd(input, phi::DataType::FLOAT32);
+  check_element_unary_like(inferred_dist_attrs);
   // pow
   input =
       phi::distributed::DistMetaTensor(common::make_ddim(shape), t_dist_attr);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
为 empty_like 算子添加切分推导规则，同 full_like，提取 CreateLikeInferSpmd 公共函数