### PR TITLE
[0-size Tensor No.4] Add 0-size Tensor support for addmm

### DIFF
--- a/paddle/phi/infermeta/ternary.cc
+++ b/paddle/phi/infermeta/ternary.cc
@@ -98,29 +98,6 @@ void AddmmInferMeta(const MetaTensor& input,
           << " alpha=" << alpha << " ndim_input=" << ndim_input
           << " ndim_x=" << ndim_x << " ndim_y=" << ndim_y;
 
-  PADDLE_ENFORCE_NE(
-      product(input_dims),
-      0,
-      errors::PreconditionNotMet("The Input variable 'input' has not "
-                                 "been initialized. You may need to confirm "
-                                 "if you put exe.run(startup_program) "
-                                 "after optimizer.minimize function."));
-
-  PADDLE_ENFORCE_NE(
-      product(x_dims),
-      0,
-      errors::PreconditionNotMet("The Input variable 'x' has not "
-                                 "been initialized. You may need to confirm "
-                                 "if you put exe.run(startup_program) "
-                                 "after optimizer.minimize function."));
-
-  PADDLE_ENFORCE_NE(
-      product(y_dims),
-      0,
-      errors::PreconditionNotMet("The Input variable 'y' has not "
-                                 "been initialized. You may need to confirm "
-                                 "if you put exe.run(startup_program) "
-                                 "after optimizer.minimize function."));
   // dim check
   PADDLE_ENFORCE_EQ(ndim_input == 2 || ndim_input == 1,
                     true,

--- a/paddle/phi/kernels/xpu/addmm_kernel.cc
+++ b/paddle/phi/kernels/xpu/addmm_kernel.cc
@@ -60,13 +60,16 @@ void AddmmKernel(const Context& dev_ctx,
                         input_dims));
 
   dev_ctx.template Alloc<T>(out);
+  if (out->numel() == 0) return;
+
   const XPUType* x_ptr = reinterpret_cast<const XPUType*>(x.data<T>());
   const XPUType* y_ptr = reinterpret_cast<const XPUType*>(y.data<T>());
   const XPUType* input_ptr = reinterpret_cast<const XPUType*>(input.data<T>());
   XPUType* out_ptr = reinterpret_cast<XPUType*>(out->data<T>());
 
   int r;
-  if (alpha == 0.f) {
+  // If x.numel or y.numel is 0, we just need to do a broadcast mul.
+  if (alpha == 0.f || x.numel() == 0 || y.numel() == 0) {
     if (beta == 0.f) {
       r = xpu::constant(dev_ctx.x_context(),
                         out_ptr,

--- a/test/legacy_test/test_addmm_op.py
+++ b/test/legacy_test/test_addmm_op.py
@@ -513,6 +513,60 @@ class TestAddMMAPI(unittest.TestCase):
         paddle.enable_static()
 
 
+class TestAddmmOp_ZeroSize(OpTest):
+    def setUp(self):
+        self.op_type = "addmm"
+        self.python_api = paddle.addmm
+        self.public_python_api = paddle.addmm
+        self.init_dtype_type()
+        self.init_input()
+        self.attrs = {
+            'Alpha': 0.5,
+            'Beta': 2.0,
+        }
+        self.outputs = {
+            'Out': self.attrs['Beta'] * self.inputs['Input']
+            + self.attrs['Alpha'] * np.dot(self.inputs['X'], self.inputs['Y'])
+        }
+
+    def init_input(self):
+        # result shape: [20, 100]
+        self.inputs = {
+            'Input': np.random.random(100).astype(self.dtype),
+            'X': np.random.random((20, 0)).astype(self.dtype),
+            'Y': np.random.random((0, 100)).astype(self.dtype),
+        }
+
+    def init_dtype_type(self):
+        self.dtype = np.float64
+
+    def test_check_output(self):
+        self.check_output(check_pir=True)
+
+    def test_check_grad_normal(self):
+        self.check_grad(['Input', 'X', 'Y'], 'Out', check_pir=True)
+
+
+class TestAddmmOp_ZeroSize2(TestAddmmOp_ZeroSize):
+    def init_input(self):
+        # result shape: [20, 0]
+        self.inputs = {
+            'Input': np.random.random(0).astype(self.dtype),
+            'X': np.random.random((20, 100)).astype(self.dtype),
+            'Y': np.random.random((100, 0)).astype(self.dtype),
+        }
+
+
+class TestAddmmOp_ZeroSize3(TestAddmmOp_ZeroSize):
+    def init_input(self):
+        # result shape: [0, 0]
+        self.inputs = {
+            'Input': np.random.random(0).astype(self.dtype),
+            'X': np.random.random((0, 100)).astype(self.dtype),
+            'Y': np.random.random((100, 0)).astype(self.dtype),
+        }
+
+
 if __name__ == "__main__":
     paddle.enable_static()
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->
[0-size Tensor No.4] Add 0-size Tensor support for addmm

修改infermeta中判断numel为0，symbolic_shape没有对应代码
https://github.com/PaddlePaddle/Paddle/blob/275e2db9f60595542507a8a96c01325e158b2271/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/multiary_infer_sym.cc#L105

kernel 修改impl中实现和xpu实现

PaddleAPITest 测试没有cuda error，其他为shape判断，和torch相同
![image](https://github.com/user-attachments/assets/ac3a4975-38c8-4679-97d8-8ec31df35219)

![image](https://github.com/user-attachments/assets/f446e55f-56e6-41f6-8b8b-35820167bec5)
