### PR TITLE
[0-size Tensor No.113、119、206] Add 0-size Tensor support for linalg.norm/vector_norm

### DIFF
--- a/paddle/phi/kernels/xpu/p_norm_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/p_norm_grad_kernel.cc
@@ -47,6 +47,7 @@ void PNormGradKernel(const Context& dev_ctx,
                      DenseTensor* x_grad) {
   using XPUType = typename XPUTypeTrait<T>::Type;
   dev_ctx.template Alloc<T>(x_grad);
+  if (x.numel() == 0) return;
   auto xdim = x.dims();
   axis = axis < 0 ? xdim.size() + axis : axis;
   int m, t, n;

--- a/paddle/phi/kernels/xpu/p_norm_kernel.cc
+++ b/paddle/phi/kernels/xpu/p_norm_kernel.cc
@@ -15,7 +15,7 @@
 #include "paddle/phi/kernels/p_norm_kernel.h"
 #include "paddle/phi/backends/xpu/enforce_xpu.h"
 #include "paddle/phi/core/kernel_registry.h"
-
+#include "paddle/phi/kernels/full_kernel.h"
 namespace phi {
 
 inline void GetDims(const phi::DDim& dim,
@@ -50,6 +50,11 @@ void PNormKernel(const Context& dev_ctx,
                  DenseTensor* out) {
   using XPUType = typename XPUTypeTrait<T>::Type;
   dev_ctx.template Alloc<T>(out);
+  if (x.numel() == 0) {
+    phi::Full<T, Context>(
+        dev_ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
+    return;
+  }
   auto xdim = x.dims();
   if (axis < 0) axis = xdim.size() + axis;
   std::vector<int64_t> r_dim;

--- a/test/legacy_test/test_norm_all.py
+++ b/test/legacy_test/test_norm_all.py
@@ -1546,6 +1546,28 @@ class API_NormTest_ZeroSize(unittest.TestCase):
         loss.backward()
         np.testing.assert_equal(x_paddle.grad.shape, x_paddle.shape)
 
+    def check_linalg_vector_dygraph_and_grad(
+        self, p, axis, shape_x, dtype, keep_dim, check_dim=False
+    ):
+        x_numpy = np.array(np.random.random(shape_x) + 1.0).astype(dtype)
+        expected_result = np_linalg_vector_norm(
+            x_numpy, porder=p, axis=axis, keepdims=keep_dim
+        )
+        x_paddle = paddle.to_tensor(x_numpy)
+        x_paddle.stop_gradient = False
+        result1 = paddle.linalg.vector_norm(
+            x=x_paddle, p=p, axis=axis, keepdim=keep_dim
+        )
+        result = result1.numpy()
+        np.testing.assert_allclose(
+            result, expected_result, rtol=1e-6, atol=1e-8
+        )
+        if keep_dim and check_dim:
+            np.testing.assert_equal(result.shape, expected_result.shape)
+        loss = paddle.sum(result1)
+        loss.backward()
+        np.testing.assert_equal(x_paddle.grad.shape, x_paddle.shape)
+
     def test_dygraph(self):
         paddle.disable_static()
         keep_dims = {False, True}
@@ -1557,6 +1579,14 @@ class API_NormTest_ZeroSize(unittest.TestCase):
                 dtype="float64",
                 keep_dim=keep,
                 check_dim=True,
+            )
+
+            self.check_linalg_vector_dygraph_and_grad(
+                p=np.inf,
+                axis=[1],
+                shape_x=[0, 3, 4],
+                dtype="float32",
+                keep_dim=keep,
             )
 
 

--- a/test/legacy_test/test_norm_all.py
+++ b/test/legacy_test/test_norm_all.py
@@ -1523,6 +1523,43 @@ class API_NormTest(unittest.TestCase):
             )
 
 
+class API_NormTest_ZeroSize(unittest.TestCase):
+    def check_linalg_norm_dygraph_and_grad(
+        self, p, axis, shape_x, dtype, keep_dim, check_dim=False
+    ):
+        x_numpy = (np.random.random(shape_x) + 1.0).astype(dtype)
+        expected_result = np_linalg_norm(
+            x_numpy, porder=p, axis=axis, keepdims=keep_dim
+        )
+        x_paddle = paddle.to_tensor(x_numpy)
+        x_paddle.stop_gradient = False
+        result1 = paddle.linalg.norm(
+            x=x_paddle, p=p, axis=axis, keepdim=keep_dim
+        )
+        result = result1.numpy()
+        np.testing.assert_allclose(
+            result, expected_result, rtol=1e-6, atol=1e-8
+        )
+        if keep_dim and check_dim:
+            np.testing.assert_equal(result.shape, expected_result.shape)
+        loss = paddle.sum(result1)
+        loss.backward()
+        np.testing.assert_equal(x_paddle.grad.shape, x_paddle.shape)
+
+    def test_dygraph(self):
+        paddle.disable_static()
+        keep_dims = {False, True}
+        for keep in keep_dims:
+            self.check_linalg_norm_dygraph_and_grad(
+                p=1,
+                axis=[0, 1],
+                shape_x=[0, 3, 4],
+                dtype="float64",
+                keep_dim=keep,
+                check_dim=True,
+            )
+
+
 if __name__ == '__main__':
     paddle.enable_static()
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->
单测使用到p_norm，修改p_norm kernel

113 paddle.linalg.norm
PaddleAPITest 测试cuda error通过，增加单测
GPU
![image](https://github.com/user-attachments/assets/20c8cf06-dc91-4406-9b83-ba824b8013b7)

CPU，错误为torch error
![image](https://github.com/user-attachments/assets/019f3497-0967-409c-b5c6-8ef0a9bc21ff)

119 paddle.linalg.vector_norm
PaddleAPITest 测试cuda error通过，增加单测
GPU，错误为 torch error
![image](https://github.com/user-attachments/assets/38c84eb5-ba32-4940-ab1c-5b4490e47dae)

CPU，错误为 torch error
![image](https://github.com/user-attachments/assets/cd3c9783-b1b6-4595-9ef0-de5db426af2c)

206 paddle.nn.functional.pairwise_distance
GPU 测试通过
![image](https://github.com/user-attachments/assets/d537f3ad-be99-43de-bcb5-267dfa4ba14a)
CPU 测试通过
![image](https://github.com/user-attachments/assets/6f6dbe3e-d214-42be-a009-aa3c10691347)
