### PR TITLE
[0-size Tensor No.180、182-183] Add 0-size Tensor support for hinge_embedding_loss

### DIFF
--- a/paddle/phi/kernels/impl/kldiv_loss_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/kldiv_loss_grad_kernel_impl.h
@@ -48,6 +48,11 @@ void KLDivLossGradKernel(const Context& dev_ctx,
                          const std::string& reduction,
                          bool log_target,
                          DenseTensor* d_x) {
+  if (d_x->numel() == 0) {
+    dev_ctx.template Alloc<T>(d_x);
+    return;
+  }
+
   auto& place = *dev_ctx.eigen_device();
   auto* target = &label;
   auto* input_grad = d_x;

--- a/paddle/phi/kernels/impl/kldiv_loss_kernel_impl.h
+++ b/paddle/phi/kernels/impl/kldiv_loss_kernel_impl.h
@@ -18,8 +18,8 @@
 #include "paddle/common/hostdevice.h"
 #include "paddle/phi/backends/cpu/cpu_context.h"
 #include "paddle/phi/core/dense_tensor.h"
+#include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/funcs/eigen/common.h"
-
 namespace phi {
 using Array1 = Eigen::DSizes<int64_t, 1>;
 template <typename T>
@@ -48,6 +48,11 @@ void KLDivLossKernel(const Context& dev_ctx,
                      const std::string& reduction,
                      bool log_target,
                      DenseTensor* out) {
+  if (x.numel() == 0) {
+    phi::Full<T, Context>(
+        dev_ctx, phi::IntArray(common::vectorize(out->dims())), NAN, out);
+    return;
+  }
   auto& place = *(dev_ctx.eigen_device());
   auto* input = &x;
   auto* target = &label;

--- a/paddle/phi/kernels/xpu/kldiv_loss_kernel.cc
+++ b/paddle/phi/kernels/xpu/kldiv_loss_kernel.cc
@@ -15,8 +15,8 @@ limitations under the License. */
 #include "paddle/phi/backends/xpu/enforce_xpu.h"
 #include "paddle/phi/core/enforce.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/softmax_kernel.h"
-
 namespace phi {
 
 template <typename T, typename Context>
@@ -29,6 +29,11 @@ void KLDivLossKernel(const Context& dev_ctx,
   using XPUType = typename XPUTypeTrait<T>::Type;
   dev_ctx.template Alloc<T>(out);
   if (out->numel() == 0) {
+    return;
+  }
+  if (x.numel() == 0) {
+    phi::Full<T, Context>(
+        dev_ctx, phi::IntArray(common::vectorize(out->dims())), NAN, out);
     return;
   }
 

--- a/test/legacy_test/test_kldiv_loss_op.py
+++ b/test/legacy_test/test_kldiv_loss_op.py
@@ -115,6 +115,52 @@ class TestKLDivLossOp6(TestKLDivLossOp):
         self.log_target = True
 
 
+class TestKLDivLossOp_ZeroSize1(TestKLDivLossOp):
+    def setUp(self):
+        self.initTestCase()
+        self.op_type = 'kldiv_loss'
+        self.python_api = kl_div
+        self.public_python_api = paddle.nn.functional.kl_div
+        x = np.random.uniform(-10, 10, self.x_shape).astype('float64')
+        target = np.random.uniform(-10, 10, self.x_shape).astype('float64')
+
+        self.attrs = {
+            "reduction": self.reduction,
+            "log_target": self.log_target,
+        }
+
+        self.inputs = {
+            'X': x,
+            'Target': target,
+        }
+        loss = kldiv_loss(x, target, self.reduction, self.log_target)
+        self.outputs = {'Loss': loss.astype('float64')}
+
+    def initTestCase(self):
+        # return NAN
+        self.x_shape = (0, 2, 7, 7)
+        self.reduction = 'mean'
+        self.log_target = False
+
+    def test_check_output(self):
+        self.check_output(check_pir=True, equal_nan=True)
+
+    def test_check_grad(self):
+        self.check_grad(
+            ['X'],
+            'Loss',
+            no_grad_set={"Target"},
+            check_pir=True,
+        )
+
+
+class TestKLDivLossOp_ZeroSize2(TestKLDivLossOp_ZeroSize1):
+    def initTestCase(self):
+        self.x_shape = (0, 2, 7, 7)
+        self.reduction = 'none'
+        self.log_target = False
+
+
 class TestKLDivLossDygraph(unittest.TestCase):
     def run_kl_loss(self, reduction, shape=(5, 20), log_target=False):
         x = np.random.uniform(-10, 10, shape).astype('float64')


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->
180 paddle.nn.functional.hinge_embedding_loss 
GPU 测试通过
CPU 测试通过
182 paddle.nn.functional.kl_div 
GPU 测试通过
![image](https://github.com/user-attachments/assets/5cc44601-4920-455d-b060-990fe0b14e75)
CPU 测试通过
![image](https://github.com/user-attachments/assets/67caadf8-f73e-43d1-a142-e81e7db7adec)

183 paddle.nn.functional.l1_loss
GPU 测试通过
CPU 测试通过

paddle.nn.functional.kl_div 
kernel 修改 impl和xpu调用
前向reduction不为none时，返回填充NAN
infermeta没有修改

