### PR TITLE
[0-size Tensor No.132、236、240、241、259] Add 0-size Tensor support for masked_select

### DIFF
--- a/paddle/phi/kernels/gpu/masked_select_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/masked_select_grad_kernel.cu
@@ -56,6 +56,7 @@ void MaskedSelectGradKernel(const Context& dev_ctx,
                             const DenseTensor& out_grad,
                             DenseTensor* x_grad) {
   if (out_grad.numel() == 0 && x_grad) {
+    // x = [1, 2], mask = [False, False], out = []
     phi::Full<T, Context>(
         dev_ctx, phi::IntArray(common::vectorize(x_grad->dims())), 0, x_grad);
     return;

--- a/paddle/phi/kernels/gpu/masked_select_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/masked_select_grad_kernel.cu
@@ -56,7 +56,7 @@ void MaskedSelectGradKernel(const Context& dev_ctx,
                             const DenseTensor& out_grad,
                             DenseTensor* x_grad) {
   if (out_grad.numel() == 0 && x_grad) {
-    // x = [1, 2], mask = [False, False], out = []
+    // x = [1, 2], mask = [False, False], out = [], x_grad = [0, 0]
     phi::Full<T, Context>(
         dev_ctx, phi::IntArray(common::vectorize(x_grad->dims())), 0, x_grad);
     return;

--- a/paddle/phi/kernels/gpu/masked_select_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/masked_select_grad_kernel.cu
@@ -24,10 +24,10 @@
 #include "paddle/phi/kernels/empty_kernel.h"
 #include "paddle/phi/kernels/expand_grad_kernel.h"
 #include "paddle/phi/kernels/expand_kernel.h"
+#include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/funcs/common_shape.h"
 #include "paddle/phi/kernels/funcs/reduce_function.h"
 #include "paddle/phi/kernels/funcs/select_impl.cu.h"
-
 namespace phi {
 
 template <typename MT, typename InT, typename OutT>
@@ -55,6 +55,11 @@ void MaskedSelectGradKernel(const Context& dev_ctx,
                             const DenseTensor& mask,
                             const DenseTensor& out_grad,
                             DenseTensor* x_grad) {
+  if (out_grad.numel() == 0 && x_grad) {
+    phi::Full<T, Context>(
+        dev_ctx, phi::IntArray(common::vectorize(x_grad->dims())), 0, x_grad);
+    return;
+  }
   // x_grad.size() == x.size()
   // x.size() == mask.size(), no broadcast, expand_mask = false, expand_x =
   // false x.size() < mask.size(), x broadcast to mask, expand_mask = false,

--- a/test/legacy_test/test_masked_select_op.py
+++ b/test/legacy_test/test_masked_select_op.py
@@ -24,9 +24,10 @@ from paddle.base import core
 def np_masked_select(x, mask):
     result = np.empty(shape=(0), dtype=x.dtype)
     x, mask = np.broadcast_arrays(x, mask)
-    for ele, ma in zip(np.nditer(x), np.nditer(mask)):
-        if ma:
-            result = np.append(result, ele)
+    if x.size != 0:
+        for ele, ma in zip(np.nditer(x), np.nditer(mask)):
+            if ma:
+                result = np.append(result, ele)
     return result.flatten()
 
 
@@ -278,6 +279,18 @@ class TestMaskedSelectOpBroadcast4(TestMaskedSelectOp):
     def init(self):
         self.shape = (300, 40)
         self.mask_shape = 40
+
+
+class TestMaskedSelectOpBroadcast_ZeroSize(TestMaskedSelectOp):
+    def init(self):
+        self.shape = (0, 40)
+        self.mask_shape = 40
+
+
+class TestMaskedSelectOpBroadcast_ZeroSize2(TestMaskedSelectOp):
+    def init(self):
+        self.shape = (0, 0)
+        self.mask_shape = 0
 
 
 if __name__ == '__main__':

--- a/test/legacy_test/test_masked_select_op.py
+++ b/test/legacy_test/test_masked_select_op.py
@@ -293,6 +293,20 @@ class TestMaskedSelectOpBroadcast_ZeroSize2(TestMaskedSelectOp):
         self.mask_shape = 0
 
 
+class TestMaskedSelectOp_ZeroSize3(unittest.TestCase):
+    def setUp(self):
+        paddle.disable_static()
+
+    def test_out_0size(self):
+        x = paddle.to_tensor([1, 2], dtype='float32')
+        x.stop_gradient = False
+        y = paddle.to_tensor([False, False], dtype='bool')
+        z = x.masked_select(y)
+        np.testing.assert_allclose(z.shape, [0])
+        z.sum().backward()
+        np.testing.assert_allclose(x.grad.numpy(), [0, 0])
+
+
 if __name__ == '__main__':
     paddle.enable_static()
     unittest.main()

--- a/test/legacy_test/test_masked_select_op.py
+++ b/test/legacy_test/test_masked_select_op.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import unittest
 
 import numpy as np
@@ -295,9 +296,18 @@ class TestMaskedSelectOpBroadcast_ZeroSize2(TestMaskedSelectOp):
 
 class TestMaskedSelectOp_ZeroSize3(unittest.TestCase):
     def setUp(self):
-        paddle.disable_static()
+        self.place = []
+        if (
+            os.environ.get('FLAGS_CI_both_cpu_and_gpu', 'False').lower()
+            in ['1', 'true', 'on']
+            or not core.is_compiled_with_cuda()
+        ):
+            self.place.append(paddle.CPUPlace())
+        if core.is_compiled_with_cuda():
+            self.place.append(paddle.CUDAPlace(0))
 
-    def test_out_0size(self):
+    def _test_out_0size(self, place):
+        paddle.disable_static(place)
         x = paddle.to_tensor([1, 2], dtype='float32')
         x.stop_gradient = False
         y = paddle.to_tensor([False, False], dtype='bool')
@@ -305,6 +315,11 @@ class TestMaskedSelectOp_ZeroSize3(unittest.TestCase):
         np.testing.assert_allclose(z.shape, [0])
         z.sum().backward()
         np.testing.assert_allclose(x.grad.numpy(), [0, 0])
+        paddle.enable_static()
+
+    def test_out_0size(self):
+        for place in self.place:
+            self._test_out_0size(place)
 
 
 if __name__ == '__main__':

--- a/test/legacy_test/test_parameter.py
+++ b/test/legacy_test/test_parameter.py
@@ -136,6 +136,19 @@ class ParameterChecks(unittest.TestCase):
             self.assertTrue(linear2.weight.is_leaf, True)
             self.assertTrue(linear2.bias.is_leaf, True)
 
+    def test_parambase_to_vector_zero(self):
+        with guard():
+            initializer = paddle.ParamAttr(
+                initializer=paddle.nn.initializer.Constant(3.0)
+            )
+            linear1 = paddle.nn.Linear(0, 15, initializer)
+
+            vec = paddle.nn.utils.parameters_to_vector(linear1.parameters())
+            self.assertEqual(linear1.weight.shape, [0, 15])
+            self.assertEqual(linear1.bias.shape, [15])
+            self.assertTrue(isinstance(vec, Variable))
+            self.assertEqual(vec.shape, [15])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->
132 paddle.masked_select
236 paddle.nn.utils.parameters_to_vector
240 paddle.pdist
241 paddle.polar
259 paddle.sinc

增加单测

paddle.masked_select, paddle.polar 在 report/0size_tensor_gpu/test_history/20250528/accuracy/error_config.txt 中没有配置，应该是没有错误
![image](https://github.com/user-attachments/assets/78775cff-66b9-47f2-8c34-f5e24c336a96)

paddle.nn.utils.parameter_to_vector 是PaddleAPITest错误，没有其他错误
![image](https://github.com/user-attachments/assets/203a16ac-a0bc-40d7-a094-be7c50fc8ded)

paddle.pdist GPU/CPU测试都通过
paddle.sinc GPU/CPU测试都通过
