### PR TITLE
[slice] Updating the computation of the index_elementwise output dim

### DIFF
--- a/paddle/phi/infermeta/binary.cc
+++ b/paddle/phi/infermeta/binary.cc
@@ -2133,51 +2133,6 @@ void GatherNdInferMeta(const MetaTensor& x,
   out->set_dtype(x.dtype());
 }
 
-void IndexElementwisePutInferMeta(const MetaTensor& x,
-                                  const std::vector<const MetaTensor*>& index,
-                                  const MetaTensor& value,
-                                  const std::vector<int64_t>& input_dims,
-                                  const std::vector<int64_t>& input_strides,
-                                  const std::vector<int64_t>& index_dims,
-                                  const std::vector<int64_t>& index_strides,
-                                  MetaTensor* out) {
-  out->set_dims(x.dims());
-  out->set_dtype(x.dtype());
-}
-
-void IndexElementwiseGetInferMeta(const MetaTensor& x,
-                                  const std::vector<const MetaTensor*>& index,
-                                  const std::vector<int64_t>& input_dims,
-                                  const std::vector<int64_t>& input_strides,
-                                  const std::vector<int64_t>& index_dims,
-                                  const std::vector<int64_t>& index_stride,
-                                  MetaTensor* out) {
-  const auto& x_dims = x.dims();
-
-  PADDLE_ENFORCE_LE(
-      index_dims.size(),
-      x_dims.size(),
-      common::errors::InvalidArgument(
-          "Input(index).rank should be less than or equal to Input(x).rank"));
-
-  for (size_t i = 0; i < index_dims.size(); ++i) {
-    PADDLE_ENFORCE_EQ(index_dims[i],
-                      x_dims[i],
-                      common::errors::InvalidArgument(
-                          "Input(index).shape should match the first k "
-                          "dimensions of Input(x).shape"));
-  }
-  std::vector<int64_t> result_dims;
-  result_dims.push_back(-1);
-
-  int64_t k = index_dims.size();
-  for (int64_t i = k; i < static_cast<int64_t>(x_dims.size()); ++i) {
-    result_dims.push_back(x_dims[i]);
-  }
-  out->set_dims(common::make_ddim(result_dims));
-  out->set_dtype(x.dtype());
-}
-
 void GatherTreeMeta(const MetaTensor& ids,
                     const MetaTensor& parents,
                     MetaTensor* out) {
@@ -2589,6 +2544,51 @@ void IndexAddInferMeta(const MetaTensor& x,
   output->set_dtype(x.dtype());
   output->set_layout(x.layout());
   output->share_lod(x);
+}
+
+void IndexElementwisePutInferMeta(const MetaTensor& x,
+                                  const std::vector<const MetaTensor*>& index,
+                                  const MetaTensor& value,
+                                  const std::vector<int64_t>& input_dims,
+                                  const std::vector<int64_t>& input_strides,
+                                  const std::vector<int64_t>& index_dims,
+                                  const std::vector<int64_t>& index_strides,
+                                  MetaTensor* out) {
+  out->set_dims(x.dims());
+  out->set_dtype(x.dtype());
+}
+
+void IndexElementwiseGetInferMeta(const MetaTensor& x,
+                                  const std::vector<const MetaTensor*>& index,
+                                  const std::vector<int64_t>& input_dims,
+                                  const std::vector<int64_t>& input_strides,
+                                  const std::vector<int64_t>& index_dims,
+                                  const std::vector<int64_t>& index_stride,
+                                  MetaTensor* out) {
+  const auto& x_dims = x.dims();
+
+  PADDLE_ENFORCE_LE(
+      index_dims.size(),
+      x_dims.size(),
+      common::errors::InvalidArgument(
+          "Input(index).rank should be less than or equal to Input(x).rank"));
+
+  for (size_t i = 0; i < index_dims.size(); ++i) {
+    PADDLE_ENFORCE_EQ(index_dims[i],
+                      x_dims[i],
+                      common::errors::InvalidArgument(
+                          "Input(index).shape should match the first k "
+                          "dimensions of Input(x).shape"));
+  }
+  std::vector<int64_t> result_dims;
+  result_dims.push_back(-1);
+
+  int64_t k = index_dims.size();
+  for (int64_t i = k; i < static_cast<int64_t>(x_dims.size()); ++i) {
+    result_dims.push_back(x_dims[i]);
+  }
+  out->set_dims(common::make_ddim(result_dims));
+  out->set_dtype(x.dtype());
 }
 
 void KronInferMeta(const MetaTensor& x, const MetaTensor& y, MetaTensor* out) {

--- a/paddle/phi/infermeta/binary.h
+++ b/paddle/phi/infermeta/binary.h
@@ -401,23 +401,6 @@ void GatherNdInferMeta(const MetaTensor& x,
                        const MetaTensor& index,
                        MetaTensor* out);
 
-void IndexElementwisePutInferMeta(const MetaTensor& x,
-                                  const std::vector<const MetaTensor*>& index,
-                                  const MetaTensor& value,
-                                  const std::vector<int64_t>& input_dims,
-                                  const std::vector<int64_t>& input_strides,
-                                  const std::vector<int64_t>& index_dims,
-                                  const std::vector<int64_t>& index_strides,
-                                  MetaTensor* out);
-
-void IndexElementwiseGetInferMeta(const MetaTensor& x,
-                                  const std::vector<const MetaTensor*>& index,
-                                  const std::vector<int64_t>& input_dims,
-                                  const std::vector<int64_t>& input_strides,
-                                  const std::vector<int64_t>& index_dims,
-                                  const std::vector<int64_t>& index_stride,
-                                  MetaTensor* out);
-
 void GatherTreeMeta(const MetaTensor& ids,
                     const MetaTensor& parents,
                     MetaTensor* out);
@@ -480,6 +463,23 @@ void IndexAddInferMeta(const MetaTensor& x,
                        const MetaTensor& add_value,
                        int axis,
                        MetaTensor* output);
+
+void IndexElementwisePutInferMeta(const MetaTensor& x,
+                                  const std::vector<const MetaTensor*>& index,
+                                  const MetaTensor& value,
+                                  const std::vector<int64_t>& input_dims,
+                                  const std::vector<int64_t>& input_strides,
+                                  const std::vector<int64_t>& index_dims,
+                                  const std::vector<int64_t>& index_strides,
+                                  MetaTensor* out);
+
+void IndexElementwiseGetInferMeta(const MetaTensor& x,
+                                  const std::vector<const MetaTensor*>& index,
+                                  const std::vector<int64_t>& input_dims,
+                                  const std::vector<int64_t>& input_strides,
+                                  const std::vector<int64_t>& index_dims,
+                                  const std::vector<int64_t>& index_stride,
+                                  MetaTensor* out);
 
 void KronInferMeta(const MetaTensor& x, const MetaTensor& y, MetaTensor* out);
 


### PR DESCRIPTION
### PR Category
Performance Optimization

### PR Types
Improvements

### Description
1.  修改index_elementwise算子中output dim的计算方式，可以直接通过AdvancedIndex src_sizes来设置。
2.  IndexElementwiseGetInferMeta IndexElementwisePutInferMeta按照字母序排序
3.  规范PADDLE_ENFORCE
pcard-67164