### PR TITLE
【load】move tensor dict to Avoid the inability to release memory

### DIFF
--- a/python/paddle/framework/io.py
+++ b/python/paddle/framework/io.py
@@ -1242,8 +1242,9 @@ def load(path: str | BytesIO, **configs: Unpack[_LoadOptions]) -> Any:
                     else:
                         for key, value in tensor_load_result.items():
                             if _transformed_from_varbase(value):
-                                value[1].name = value[0]
-                                tensor_load_result[key] = value[1]
+                                temp_value = paddle.to_tensor(value[1])
+                                temp_value.name = value[0]
+                                tensor_load_result[key] = temp_value
 
                     return tensor_load_result
                 else:

--- a/python/paddle/framework/io.py
+++ b/python/paddle/framework/io.py
@@ -576,7 +576,7 @@ def _to_LodTensor(ndarray):
 
 def _tuple_to_tensor(obj, return_numpy):
     if return_numpy:
-        return obj[1]
+        return obj
     if in_dygraph_mode():
         t = paddle.to_tensor(obj[1])
         # This function does modify the name of return value.
@@ -1198,36 +1198,51 @@ def load(path: str | BytesIO, **configs: Unpack[_LoadOptions]) -> Any:
                 # TODO(weixin):If `obj` is any object, the judgment condition should be more precise.
                 if isinstance(load_result, dict):
                     load_result = _pack_loaded_dict(load_result)
+
+                    if "StructuredToParameterName@@" not in load_result:
+                        # paddle2.1 static.save/load
+                        load_result = _parse_load_result(load_result, True)
+
+                else:
+                    load_result = _parse_load_result(load_result, True)
+
+                if not config.return_numpy:
+                    tensor_load_result = {}
+                    for key, value in load_result.items():
+                        if isinstance(value, np.ndarray):
+                            tensor_load_result[key] = _ndarray_to_tensor(
+                                value, False
+                            )
+                        else:
+                            tensor_load_result[key] = value
+
                     # paddle2.0: paddle.save/load
                     if "StructuredToParameterName@@" in load_result:
                         for key, name in load_result[
                             "StructuredToParameterName@@"
                         ].items():
-                            if isinstance(load_result[key], np.ndarray):
-                                load_result[key] = _ndarray_to_tensor(
-                                    load_result[key], config.return_numpy
-                                )
-                                # default name is "generatedxxx" which is set in Tensor init, if not set
-                                if not config.return_numpy and getattr(
-                                    load_result[key], "name", ""
-                                ):
-                                    load_result[key].name = name
+                            # default name is "generatedxxx" which is set in Tensor init, if not set
+                            tensor_load_result[key].name = name
 
                         if (
                             not config.keep_name_table
-                            and "StructuredToParameterName@@" in load_result
+                            and "StructuredToParameterName@@"
+                            in tensor_load_result
                         ):
-                            del load_result["StructuredToParameterName@@"]
-                    else:
-                        # paddle2.1 static.save/load
-                        load_result = _parse_load_result(
-                            load_result, config.return_numpy
-                        )
+                            del tensor_load_result[
+                                "StructuredToParameterName@@"
+                            ]
 
+                    else:
+                        for key, value in tensor_load_result.items:
+                            if _transformed_from_varbase(value):
+                                value[1].name = value[0]
+                                tensor_load_result[key] = value[1]
+
+                    del load_result
+                    return tensor_load_result
                 else:
-                    load_result = _parse_load_result(
-                        load_result, config.return_numpy
-                    )
+                    return load_result
 
         except exception_type as msg_pickle:
             try:

--- a/python/paddle/framework/io.py
+++ b/python/paddle/framework/io.py
@@ -1208,21 +1208,27 @@ def load(path: str | BytesIO, **configs: Unpack[_LoadOptions]) -> Any:
 
                 if not config.return_numpy:
                     tensor_load_result = {}
-                    for key, value in load_result.items():
+                    for key in list(load_result.keys()):
+                        value = load_result[key]
                         if isinstance(value, np.ndarray):
                             tensor_load_result[key] = _ndarray_to_tensor(
                                 value, False
                             )
                         else:
                             tensor_load_result[key] = value
-
+                        # add this can decrease load memory but can't fix the bug
+                        # del load_result[key]
+                    del load_result
                     # paddle2.0: paddle.save/load
-                    if "StructuredToParameterName@@" in load_result:
-                        for key, name in load_result[
+                    if "StructuredToParameterName@@" in tensor_load_result:
+                        for key, name in tensor_load_result[
                             "StructuredToParameterName@@"
                         ].items():
                             # default name is "generatedxxx" which is set in Tensor init, if not set
-                            tensor_load_result[key].name = name
+                            if isinstance(
+                                tensor_load_result[key], paddle.Tensor
+                            ):
+                                tensor_load_result[key].name = name
 
                         if (
                             not config.keep_name_table
@@ -1239,7 +1245,6 @@ def load(path: str | BytesIO, **configs: Unpack[_LoadOptions]) -> Any:
                                 value[1].name = value[0]
                                 tensor_load_result[key] = value[1]
 
-                    del load_result
                     return tensor_load_result
                 else:
                     return load_result

--- a/python/paddle/framework/io.py
+++ b/python/paddle/framework/io.py
@@ -1234,7 +1234,7 @@ def load(path: str | BytesIO, **configs: Unpack[_LoadOptions]) -> Any:
                             ]
 
                     else:
-                        for key, value in tensor_load_result.items:
+                        for key, value in tensor_load_result.items():
                             if _transformed_from_varbase(value):
                                 value[1].name = value[0]
                                 tensor_load_result[key] = value[1]


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-67164

由于paddle.load 在load 参数时，会对pickle 得到的内容进行处理，将narray 转换为tensor，并修改好对应的名字，但原始的写法如果在调用之后希望通过del 删除load_result 时，无法正常删除，原因可能是tensor被其他数据结构hold。 当改为先构造narray 的dict, 再统一构造tensordict 后，可以使用del 正常删除。

测试代码如下,修复前后内存测试结果如图
<img width="292" alt="截屏2025-06-09 15 25 51" src="https://github.com/user-attachments/assets/5bc26d3d-2b47-4117-bdf2-e0820ad97fe2" />



```import paddle
import numpy as np
import gc
import psutil, os
import weakref
from collections import defaultdict
process = psutil.Process(os.getpid())
print("paddle__file__ ", paddle.__file__)
paddle.set_device("cpu")

def fn():
    print(f"VMS4ooooo内存: {process.memory_info().vms/1024**2:.2f}MB")  # 虚拟内存:ml-citation{ref="3,10" data="citationList"}
    # with open("./oooo/model_state.tp00.pdparams", "rb") as f:
    #     aaa = f.read()
    # breakpoint()
    aaa = paddle.load("./model_state.tp00.pdparams")

    print(f"RSS4ooooo内存: {process.memory_info().rss/1024**2:.2f}MB")  # 实际物理内存
    print(f"VMS4ooooo内存: {process.memory_info().vms/1024**2:.2f}MB")  # 虚拟内存:ml-citation{ref="3,10" data="citationList"}
    print(len(aaa.keys()))  
    chunk_size = 100  # 每次删除的项数
    keys = list(aaa.keys())
    for i in range(0, 101, chunk_size):
        chunk = keys[i:i + chunk_size]
        for key in chunk:
            print(key, " Tensor占用的内存大小:", aaa[key].numpy().nbytes / (1024 * 1024), "MB")
            gc.collect()
    gc.collect()
    print(f"before del aaa VMS4ooooo内存: {process.memory_info().vms/1024**2:.2f}MB")  # 虚拟内存:ml-citation{ref="3,10" data="citationList"}
    del aaa    
    gc.collect()
    print(f"after del aaaVMS4ooooo内存: {process.memory_info().vms/1024**2:.2f}MB")  # 虚拟内存:ml-citation{ref="3,10" data="citationList"}
    
```