### PR TITLE
[PHI]add check for cudnn big tensor

### DIFF
--- a/paddle/phi/backends/gpu/cuda/cudnn_workspace_helper.h
+++ b/paddle/phi/backends/gpu/cuda/cudnn_workspace_helper.h
@@ -18,6 +18,18 @@ namespace phi {
 namespace backends {
 namespace gpu {
 
+#define CUDNN_ENFORCE_TENSOR_SIZE_SUPPORTED(tensor)                            \
+  do {                                                                         \
+    int64_t largest = (1LL << 31) - 1;                                         \
+    PADDLE_ENFORCE_LE(                                                         \
+        tensor.numel(),                                                        \
+        largest,                                                               \
+        ::common::errors::PreconditionNotMet(                                  \
+            "The element size of " #tensor " should be <= INT_MAX(2147483647)" \
+            ", but got %lld",                                                  \
+            tensor.numel()));                                                  \
+  } while (0)
+
 static constexpr int kDefaultConvWorkspaceSizeLimitMB = 512;
 
 int GetDefaultConvWorkspaceSizeLimitMB();

--- a/paddle/phi/kernels/gpudnn/conv_grad_kernel.cu
+++ b/paddle/phi/kernels/gpudnn/conv_grad_kernel.cu
@@ -635,6 +635,9 @@ void ConvCudnnGradKernel(const Context& ctx,
                  ? phi::backends::gpu::DataLayout::kNDHWC
                  : phi::backends::gpu::DataLayout::kNCDHW;
   }
+  CUDNN_ENFORCE_TENSOR_SIZE_SUPPORTED(transformed_input);
+  CUDNN_ENFORCE_TENSOR_SIZE_SUPPORTED(transformed_filter_channel);
+  CUDNN_ENFORCE_TENSOR_SIZE_SUPPORTED(transformed_output_grad_channel);
 
 #ifdef PADDLE_WITH_CUDNN_FRONTEND
   if (dynload::IsCudnnFrontendEnabled() && (groups == 1))

--- a/paddle/phi/kernels/gpudnn/conv_kernel.cu
+++ b/paddle/phi/kernels/gpudnn/conv_kernel.cu
@@ -490,6 +490,9 @@ void ConvCudnnKernel(const Context& ctx,
                  : phi::backends::gpu::DataLayout::kNCDHW;
   }
 
+  CUDNN_ENFORCE_TENSOR_SIZE_SUPPORTED(transformed_input);
+  CUDNN_ENFORCE_TENSOR_SIZE_SUPPORTED(transformed_filter_channel);
+  CUDNN_ENFORCE_TENSOR_SIZE_SUPPORTED(transformed_output);
 #ifdef PADDLE_WITH_CUDNN_FRONTEND
   if (dynload::IsCudnnFrontendEnabled() && (groups == 1))
     ConvCudnnKernelImplV8<T>(&transformed_input,

--- a/paddle/phi/kernels/gpudnn/conv_transpose_grad_kernel.cu
+++ b/paddle/phi/kernels/gpudnn/conv_transpose_grad_kernel.cu
@@ -177,9 +177,6 @@ void ConvTransposeGradRawGPUDNNKernel(const Context& ctx,
   auto dtype = phi::backends::gpu::CudnnDataType<T>::type;
   auto handle = ctx.cudnn_handle();
 
-  CUDNN_ENFORCE_TENSOR_SIZE_SUPPORTED(transformed_dout);
-  CUDNN_ENFORCE_TENSOR_SIZE_SUPPORTED(filter);
-  CUDNN_ENFORCE_TENSOR_SIZE_SUPPORTED(x_transpose);
   ConvArgs args1{handle,
                  &transformed_dout,
                  &filter,
@@ -205,6 +202,9 @@ void ConvTransposeGradRawGPUDNNKernel(const Context& ctx,
   SearchResult<miopenConvFwdAlgorithm_t> fwd_result;
   SearchResult<miopenConvBwdWeightsAlgorithm_t> filter_result;
 #else
+  CUDNN_ENFORCE_TENSOR_SIZE_SUPPORTED(transformed_dout);
+  CUDNN_ENFORCE_TENSOR_SIZE_SUPPORTED(filter);
+  CUDNN_ENFORCE_TENSOR_SIZE_SUPPORTED(x_transpose);
   SearchResult<cudnnConvolutionFwdAlgo_t> fwd_result;
   SearchResult<cudnnConvolutionBwdFilterAlgo_t> filter_result;
 #endif

--- a/paddle/phi/kernels/gpudnn/conv_transpose_grad_kernel.cu
+++ b/paddle/phi/kernels/gpudnn/conv_transpose_grad_kernel.cu
@@ -34,6 +34,7 @@ limitations under the License. */
 #include "paddle/phi/kernels/gpudnn/conv_miopen_helper.h"
 #else
 #include "paddle/phi/backends/gpu/cuda/cudnn_helper.h"
+#include "paddle/phi/backends/gpu/cuda/cudnn_workspace_helper.h"
 #include "paddle/phi/kernels/gpudnn/conv_cudnn_v7.h"
 #endif
 
@@ -176,6 +177,9 @@ void ConvTransposeGradRawGPUDNNKernel(const Context& ctx,
   auto dtype = phi::backends::gpu::CudnnDataType<T>::type;
   auto handle = ctx.cudnn_handle();
 
+  CUDNN_ENFORCE_TENSOR_SIZE_SUPPORTED(transformed_dout);
+  CUDNN_ENFORCE_TENSOR_SIZE_SUPPORTED(filter);
+  CUDNN_ENFORCE_TENSOR_SIZE_SUPPORTED(x_transpose);
   ConvArgs args1{handle,
                  &transformed_dout,
                  &filter,

--- a/paddle/phi/kernels/gpudnn/conv_transpose_kernel.cu
+++ b/paddle/phi/kernels/gpudnn/conv_transpose_kernel.cu
@@ -32,6 +32,7 @@ limitations under the License. */
 #include "paddle/phi/kernels/gpudnn/conv_miopen_helper.h"
 #else
 #include "paddle/phi/backends/gpu/cuda/cudnn_helper.h"
+#include "paddle/phi/backends/gpu/cuda/cudnn_workspace_helper.h"
 #include "paddle/phi/kernels/gpudnn/conv_cudnn_v7.h"
 #endif
 
@@ -200,6 +201,9 @@ void ConvTransposeRawGPUDNNKernel(const Context& ctx,
   bool deterministic = FLAGS_cudnn_deterministic;
 
   auto dtype = phi::backends::gpu::CudnnDataType<T>::type;
+  CUDNN_ENFORCE_TENSOR_SIZE_SUPPORTED(transformed_x);
+  CUDNN_ENFORCE_TENSOR_SIZE_SUPPORTED(filter);
+  CUDNN_ENFORCE_TENSOR_SIZE_SUPPORTED(transformed_out);
   // ------------------- cudnn descriptors ---------------------
   ConvArgs args{handle,
                 &transformed_out,

--- a/paddle/phi/kernels/gpudnn/conv_transpose_kernel.cu
+++ b/paddle/phi/kernels/gpudnn/conv_transpose_kernel.cu
@@ -201,9 +201,6 @@ void ConvTransposeRawGPUDNNKernel(const Context& ctx,
   bool deterministic = FLAGS_cudnn_deterministic;
 
   auto dtype = phi::backends::gpu::CudnnDataType<T>::type;
-  CUDNN_ENFORCE_TENSOR_SIZE_SUPPORTED(transformed_x);
-  CUDNN_ENFORCE_TENSOR_SIZE_SUPPORTED(filter);
-  CUDNN_ENFORCE_TENSOR_SIZE_SUPPORTED(transformed_out);
   // ------------------- cudnn descriptors ---------------------
   ConvArgs args{handle,
                 &transformed_out,
@@ -232,6 +229,9 @@ void ConvTransposeRawGPUDNNKernel(const Context& ctx,
   bwd_result.algo =
       search::Find<T>(args, false, deterministic, workspace_size, ctx);
 #else
+  CUDNN_ENFORCE_TENSOR_SIZE_SUPPORTED(transformed_x);
+  CUDNN_ENFORCE_TENSOR_SIZE_SUPPORTED(filter);
+  CUDNN_ENFORCE_TENSOR_SIZE_SUPPORTED(transformed_out);
   SearchResult<cudnnConvolutionBwdDataAlgo_t> bwd_result;
   using search = SearchAlgorithm<ConvKind::kBackwardData>;
   bwd_result = search::Find<T>(ctx, args, false, deterministic, false);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
pcard-67164
经测试，cudnn V7和V8在处理数据超过INT_MAX(2147483647)时会出现CUDNN error(9)或者CUDA访问越界的问题，可能加速库内部未使用int64索引导致。此PR先针对该大tensor情况进行识别抛异常，以精准区分定位出访问越界问题。
对cudnn的使用属于历史遗留问题，可能存在性能下降等系列隐患，故这方面的改进放到后续PR。