### PR TITLE
[0-size Tensor No.321] Add 0-size Tensor support for mode

### DIFF
--- a/paddle/phi/kernels/cpu/mode_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/mode_grad_kernel.cc
@@ -34,6 +34,9 @@ void ModeGradKernel(const Context& dev_ctx,
   auto out_dims = indices.dims();
 
   T* x_grad_data = dev_ctx.template Alloc<T>(x_grad);
+  if (x_grad && x_grad->numel() == 0) {
+    return;
+  }
 
   // axis < 0, get the real axis
   axis = (axis < 0) ? (in_dims.size() + axis) : axis;

--- a/paddle/phi/kernels/cpu/mode_kernel.cc
+++ b/paddle/phi/kernels/cpu/mode_kernel.cc
@@ -16,9 +16,9 @@
 
 #include "paddle/phi/backends/cpu/cpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/funcs/math_function.h"
 #include "paddle/phi/kernels/funcs/mode.h"
-
 namespace phi {
 
 template <typename T, typename Context>
@@ -30,17 +30,29 @@ void ModeKernel(const Context& dev_ctx,
                 DenseTensor* indices) {
   const auto& in_dims = x.dims();
   for (int i = 0; i < in_dims.size(); i++) {
-    PADDLE_ENFORCE_LT(0,
-                      in_dims[i],
-                      errors::InvalidArgument(
-                          "The dims of Input(X) should be greater than 0."));
+    PADDLE_ENFORCE_LE(
+        0,
+        in_dims[i],
+        errors::InvalidArgument(
+            "The dims of Input(X) should be greater than or equal to 0."));
   }
   auto out_dims = out->dims();
   // axis < 0, calculate the real axis
   if (axis < 0) axis += in_dims.size();
+  if (keepdim) {
+    PADDLE_ENFORCE_GT(
+        in_dims[axis],
+        0,
+        errors::InvalidArgument(
+            "If keepdim is True, in_dims[axis] should be greater than 0."));
+  }
 
   T* output_data = dev_ctx.template Alloc<T>(out);
   int64_t* indices_data = dev_ctx.template Alloc<int64_t>(indices);
+  // out and indices have the same numel.
+  if (out->numel() == 0) {
+    return;
+  }
 
   if (in_dims.size() == 0) {
     phi::Copy<Context>(dev_ctx, x, dev_ctx.GetPlace(), false, out);

--- a/paddle/phi/kernels/gpu/mode_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/mode_grad_kernel.cu
@@ -63,6 +63,9 @@ void ModeGradKernel(const Context& dev_ctx,
   T* x_grad_data = dev_ctx.template Alloc<T>(x_grad);
   const T* out_grad_data = out_grad.data<T>();
   const int64_t* indices_data = indices.data<int64_t>();
+  if (x_grad && x_grad->numel() == 0) {
+    return;
+  }
 
   // For 0D Tensor
   if (in_dims.size() == 0) {

--- a/test/legacy_test/test_mode_op.py
+++ b/test/legacy_test/test_mode_op.py
@@ -268,7 +268,7 @@ class TestModeZeroError(unittest.TestCase):
             def test_0_size():
                 array = np.array([], dtype=np.float32)
                 x = paddle.to_tensor(np.reshape(array, [0, 0]), dtype='float32')
-                paddle.mode(x, axis=0)
+                paddle.mode(x, axis=0, keepdim=True)
 
             self.assertRaises(ValueError, test_0_size)
 

--- a/test/legacy_test/test_mode_op.py
+++ b/test/legacy_test/test_mode_op.py
@@ -273,5 +273,34 @@ class TestModeZeroError(unittest.TestCase):
             self.assertRaises(ValueError, test_0_size)
 
 
+class TestModeOp_ZeroSize(OpTest):
+    def init_args(self):
+        self.axis = 1
+        self.input_shape = (0, 2, 3)
+
+    def init_input_data(self):
+        self.input_data = np.random.rand(*self.input_shape).astype(self.dtype)
+        self.inputs = {'X': self.input_data}
+
+    def init_dtype(self):
+        self.dtype = np.float64
+
+    def setUp(self):
+        self.op_type = "mode"
+        self.python_api = paddle.mode
+        self.init_dtype()
+        self.init_args()
+        self.init_input_data()
+        self.attrs = {'axis': self.axis}
+        output, indices = cal_mode(self.input_data, axis=self.axis)
+        self.outputs = {'Out': output, 'Indices': indices}
+
+    def test_check_output(self):
+        self.check_output(check_pir=True)
+
+    def test_check_grad(self):
+        self.check_grad({'X'}, 'Out', check_pir=True)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->
321 paddle.Tensor.mode

修改ModeKernel中判断是否包含0的部分
增加keepdim为True时, axis指定维度不能为0，torch中有同样判断
![image](https://github.com/user-attachments/assets/feabbfa9-7d2a-4c9c-81ca-bdfa7777e4c6)
增加单测

PaddleAPITest错误为torch error
![image](https://github.com/user-attachments/assets/620cbc40-4c79-4c82-9de4-bb6ef993d03e)
