### PR TITLE
[Dy2St] Accept `dataclass` as input argument

### DIFF
--- a/python/paddle/jit/dy2static/utils.py
+++ b/python/paddle/jit/dy2static/utils.py
@@ -29,6 +29,7 @@ import time
 import types
 import warnings
 from contextlib import contextmanager
+from dataclasses import is_dataclass
 from enum import Enum, Flag, auto
 from importlib.machinery import SourceFileLoader
 from typing import TYPE_CHECKING, Any
@@ -286,6 +287,13 @@ def type_name(v):
     return type(v).__name__
 
 
+def _is_dataclass_instance(obj):
+    """Check if the object is an instance of a dataclass.
+    Refer to https://docs.python.org/3/library/dataclasses.html#dataclasses.is_dataclass
+    """
+    return is_dataclass(obj) and not isinstance(obj, type)
+
+
 def make_hashable(x, error_msg=None):
     """
     Makes input `x` hashable.
@@ -294,6 +302,17 @@ def make_hashable(x, error_msg=None):
     """
     if isinstance(x, (tuple, list, set)):
         return tuple(map(make_hashable, x))
+
+    if _is_dataclass_instance(x):
+        return tuple(
+            map(
+                make_hashable,
+                [
+                    getattr(x, field_name)
+                    for field_name in x.__dataclass_fields__
+                ],
+            )
+        )
 
     try:
         hash(x)

--- a/python/paddle/jit/dy2static/utils.py
+++ b/python/paddle/jit/dy2static/utils.py
@@ -29,7 +29,7 @@ import time
 import types
 import warnings
 from contextlib import contextmanager
-from dataclasses import is_dataclass
+from dataclasses import fields, is_dataclass
 from enum import Enum, Flag, auto
 from importlib.machinery import SourceFileLoader
 from typing import TYPE_CHECKING, Any
@@ -304,14 +304,12 @@ def make_hashable(x, error_msg=None):
         return tuple(map(make_hashable, x))
 
     if _is_dataclass_instance(x):
-        return tuple(
-            map(
+        return (
+            type(x).__name__,
+            *map(
                 make_hashable,
-                [
-                    getattr(x, field_name)
-                    for field_name in x.__dataclass_fields__
-                ],
-            )
+                [getattr(x, field.name) for field in fields(x)],
+            ),
         )
 
     try:

--- a/test/dygraph_to_static/test_dataclass_as_input.py
+++ b/test/dygraph_to_static/test_dataclass_as_input.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from dataclasses import dataclass
+
+import numpy as np
+from dygraph_to_static_utils import (
+    Dy2StTestBase,
+)
+
+import paddle
+
+
+@dataclass
+class Data:
+    x: paddle.Tensor
+
+
+def accept_dataclass_as_input(data: Data):
+    return data.x + 1
+
+
+class TestDataclassAsInput(Dy2StTestBase):
+    def test_dataclass_as_input(self):
+        x = paddle.to_tensor(np.random.rand(3, 4).astype('float32'))
+        data = Data(x)
+        dy_out = accept_dataclass_as_input(data)
+        static_fn = paddle.jit.to_static(accept_dataclass_as_input)
+        st_out = static_fn(data)
+        np.testing.assert_allclose(
+            dy_out.numpy(),
+            st_out.numpy(),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

在此之前，AST 动转静在根据输入计算 hash 时会依次对输入进行 hash，而 `dataclass` 本身是 `unhashable` 的，因此需要单独写一下 hash 的方式

当然，SOT 是没有这个问题的，但 SOT 有其他的问题（无法识别内部数据，会 hold 内部的 Tensor，有 OOM 的隐患）

<!-- PCard-66972 -->