### PR TITLE
1st-batch-50-Fix opendir_check bug

### DIFF
--- a/test/cpp/inference/api/trt_test_helper.h
+++ b/test/cpp/inference/api/trt_test_helper.h
@@ -170,6 +170,7 @@ void delete_cache_files(std::string path) {
       remove(file_rm.c_str());
     }
   }
+  closedir(dir);
   remove(path.c_str());
 }
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修复opendir未close的bug共1处
在文件(trt_test_helper.h)调用函数[opendir]打开目录，将分配的资源赋给指针变量[dir]。在一定条件下未正确释放，可能导致资源泄漏