### PR TITLE
1st-batch-46-Fix openfile_check bug

### DIFF
--- a/paddle/fluid/inference/utils/io_utils.cc
+++ b/paddle/fluid/inference/utils/io_utils.cc
@@ -174,6 +174,9 @@ void SerializeShapeRangeInfo(
     const std::string &path,
     const paddle::inference::proto::ShapeRangeInfos &info) {
   int out_fd = open(path.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0644);
+  if (out_fd == -1) {
+    PADDLE_THROW(common::errors::NotFound("File [%s] is not found.", path));
+  }
   google::protobuf::io::FileOutputStream *os =
       new google::protobuf::io::FileOutputStream(out_fd);
   google::protobuf::TextFormat::Print(info, os);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修复openfile未检查的bug共1处
调用函数[open]打开资源，赋值给[out_fd]，未判断资源[out_fd]状态是否可用的情况下就调用函数[close]关闭资源[out_fd]，可能造成系统错误。