### PR TITLE
[0-size Tensor support] fix std in some 0-size case

### DIFF
--- a/python/paddle/tensor/stat.py
+++ b/python/paddle/tensor/stat.py
@@ -215,8 +215,10 @@ def var(
         out_nan.stop_gradient = out.stop_gradient
         return out_nan
 
-    if (0 in x.shape) or (len(x.shape) == 0 and unbiased):
+    if 0 in x.shape:
         out = _replace_nan(out)
+    if len(x.shape) == 0 and not unbiased:
+        out = paddle.to_tensor(0, stop_gradient=out.stop_gradient)
     if out.dtype != x.dtype:
         return out.astype(x.dtype)
     return out

--- a/python/paddle/tensor/stat.py
+++ b/python/paddle/tensor/stat.py
@@ -215,7 +215,7 @@ def var(
         out_nan.stop_gradient = out.stop_gradient
         return out_nan
 
-    if 0 in x.shape:
+    if (0 in x.shape) or (len(x.shape) == 0 and unbiased):
         out = _replace_nan(out)
     if out.dtype != x.dtype:
         return out.astype(x.dtype)

--- a/test/legacy_test/test_std_layer.py
+++ b/test/legacy_test/test_std_layer.py
@@ -146,5 +146,53 @@ class Testfp16Std(unittest.TestCase):
                 )
 
 
+class TestStdAPI_ZeroSize1(unittest.TestCase):
+    def init_data(self):
+        self.x_shape = []
+        # x = torch.tensor([])
+        # res= torch.std(x)     Here, res is nan
+        self.expact_out = np.nan
+
+    def test_zerosize(self):
+        self.init_data()
+        paddle.disable_static()
+        x = paddle.to_tensor(np.random.random(self.x_shape))
+        out1 = paddle.std(x).numpy()
+        np.testing.assert_allclose(out1, self.expact_out, equal_nan=True)
+        paddle.enable_static()
+
+
+class TestStdAPI_UnBiased1(unittest.TestCase):
+    def init_data(self):
+        self.x_shape = [1]
+        # x = torch.randn([1])
+        # res= torch.std(x,correction=0)     Here, res is 0.
+        self.expact_out = 0.0
+
+    def test_api(self):
+        self.init_data()
+        paddle.disable_static()
+        x = paddle.to_tensor(np.random.random(self.x_shape))
+        out1 = paddle.std(x, unbiased=False).numpy()
+        np.testing.assert_allclose(out1, self.expact_out, equal_nan=True)
+        paddle.enable_static()
+
+
+class TestStdAPI_UnBiased2(unittest.TestCase):
+    def init_data(self):
+        self.x_shape = [1]
+        # x = torch.randn([1])
+        # res= torch.std(x,correction=1)     Here, res is 0.
+        self.expact_out = np.nan
+
+    def test_api(self):
+        self.init_data()
+        paddle.disable_static()
+        x = paddle.to_tensor(np.random.random(self.x_shape))
+        out1 = paddle.std(x, unbiased=True).numpy()
+        np.testing.assert_allclose(out1, self.expact_out, equal_nan=True)
+        paddle.enable_static()
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/legacy_test/test_variance_layer.py
+++ b/test/legacy_test/test_variance_layer.py
@@ -127,12 +127,64 @@ class TestVarError(unittest.TestCase):
 
 
 class TestVarAPI_ZeroSize(unittest.TestCase):
+    def init_data(self):
+        self.x_shape = [10, 0]
+
     def test_zerosize(self):
+        self.init_data()
         paddle.disable_static()
-        x = paddle.to_tensor(np.random.random([10, 0]))
+        x = paddle.to_tensor(np.random.random(self.x_shape))
         out1 = paddle.var(x).numpy()
         out2 = np.var(x.numpy())
         np.testing.assert_allclose(out1, out2, equal_nan=True)
+        paddle.enable_static()
+
+
+class TestVarAPI_ZeroSize1(unittest.TestCase):
+    def init_data(self):
+        self.x_shape = []
+        # x = torch.tensor([])
+        # res= torch.var(x)     Here, res is nan
+        self.expact_out = np.nan
+
+    def test_zerosize(self):
+        self.init_data()
+        paddle.disable_static()
+        x = paddle.to_tensor(np.random.random(self.x_shape))
+        out1 = paddle.var(x).numpy()
+        np.testing.assert_allclose(out1, self.expact_out, equal_nan=True)
+        paddle.enable_static()
+
+
+class TestVarAPI_UnBiased1(unittest.TestCase):
+    def init_data(self):
+        self.x_shape = [1]
+        # x = torch.randn([1])
+        # res= torch.var(x,correction=0)     Here, res is 0.
+        self.expact_out = 0.0
+
+    def test_api(self):
+        self.init_data()
+        paddle.disable_static()
+        x = paddle.to_tensor(np.random.random(self.x_shape))
+        out1 = paddle.var(x, unbiased=False).numpy()
+        np.testing.assert_allclose(out1, self.expact_out, equal_nan=True)
+        paddle.enable_static()
+
+
+class TestVarAPI_UnBiased2(unittest.TestCase):
+    def init_data(self):
+        self.x_shape = [1]
+        # x = torch.randn([1])
+        # res= torch.var(x,correction=1)     Here, res is 0.
+        self.expact_out = np.nan
+
+    def test_api(self):
+        self.init_data()
+        paddle.disable_static()
+        x = paddle.to_tensor(np.random.random(self.x_shape))
+        out1 = paddle.var(x, unbiased=True).numpy()
+        np.testing.assert_allclose(out1, self.expact_out, equal_nan=True)
         paddle.enable_static()
 
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes 

### Description
<!-- Describe what you’ve done -->
从PaddleAPITest报错：
```
2025-06-08 12:06:59.072995 GPU 3 63652 test begin: paddle.std(Tensor([],"float32"), )
W0608 12:06:59.222908 63652 dygraph_functions.cc:87666] got different data type, run type promotion automatically, this may cause data type been changed.
/root/miniconda3/envs/paddle/lib/python3.12/site-packages/paddle/tensor/stat.py:285: UserWarning: Degrees of freedom is <= 0.
  out = var(**locals())
[accuracy error] paddle.std(Tensor([],"float32"), ) 
 Not equal to tolerance rtol=0.01, atol=0.01
Scalars are not close!

Expected 0.0 but got nan.
Absolute difference: nan (up to 0.01 allowed)
Relative difference: inf (up to 0.01 allowed)
ACTUAL: (shape=torch.Size([]), dtype=torch.float32)
nan
DESIRED: (shape=torch.Size([]), dtype=torch.float32)
0.0

2025-06-08 12:06:59.102253 GPU 4 63646 test begin: paddle.std(Tensor([],"float32"), list[], )
W0608 12:06:59.242542 63646 dygraph_functions.cc:87666] got different data type, run type promotion automatically, this may cause data type been changed.
/root/miniconda3/envs/paddle/lib/python3.12/site-packages/paddle/tensor/stat.py:285: UserWarning: Degrees of freedom is <= 0.
  out = var(**locals())
[accuracy error] paddle.std(Tensor([],"float32"), list[], ) 
 Not equal to tolerance rtol=0.01, atol=0.01
Scalars are not close!

Expected 0.0 but got nan.
Absolute difference: nan (up to 0.01 allowed)
Relative difference: inf (up to 0.01 allowed)
ACTUAL: (shape=torch.Size([]), dtype=torch.float32)
nan
DESIRED: (shape=torch.Size([]), dtype=torch.float32)
0.0
```
上述错误中torch的返回结果为0.0，paddle的返回结果为nan。但是通过
```python
import torch
import numpy as np

shape1 = []  

tensor1 = torch.tensor([])

print("Torch Tensor 1 shape:", tensor1.shape)
torch_result = torch.std(tensor1)

print("Torch Result shape :", torch_result.shape)
print("Torch Result :", torch_result)

import paddle
tensor1 = paddle.to_tensor([], dtype='float32')
paddle_result = paddle.std(tensor1)

print("paddle Result shape :", paddle_result.shape)
print("paddle Result  :", paddle_result)
np.testing.assert_allclose(torch_result.detach().numpy(), paddle_result.numpy(), rtol=1e-05)
```

```
# outputs
Torch Result shape : torch.Size([])
Torch Result : tensor(nan)

paddle Result shape : []
paddle Result  : Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
       nan)
```
测试输出都是正常的。
- 仅发现当输入为一个标量tensor(0-dim)并且unbiased（torch为correction）参数为False时，torch返回0，paddle返回nan。修复了上述问题。
- 修复后上述程序可以通过，PaddleAPITest仍然报错。
- 添加了var和std的单测case
pcard-67164
