### PR TITLE
[Comp] Support `masked_fill_decomp`

### DIFF
--- a/paddle/fluid/pir/dialect/op_generator/decomp_interface_gen_op_list.py
+++ b/paddle/fluid/pir/dialect/op_generator/decomp_interface_gen_op_list.py
@@ -78,6 +78,7 @@ GENERATE_IMPL_DECOMP = [
     "unbind",
     "unsqueeze",
     "unstack",
+    "masked_fill",
 ]
 decomp_rule_interface_declare_gen_op_list = (
     GENERATE_IMPL_DECOMP + MANUAL_IMPL_DECOMP

--- a/paddle/fluid/primitive/decomp_rule/decomp_rule/composite.h
+++ b/paddle/fluid/primitive/decomp_rule/decomp_rule/composite.h
@@ -601,6 +601,40 @@ Tensor full_like_decomp(const Tensor& x,
 }
 
 template <typename T>
+Tensor masked_fill_decomp(const Tensor& x,
+                          const Tensor& mask,
+                          const Tensor& v) {
+  if (has_dynamic_shape(x.shape()) || has_dynamic_shape(mask.shape())) {
+    // NOTE: use add operator to get broadcast shape implicitly,
+    // which is not efficient yet, should be improved in the future.
+    Tensor dummy_x =
+        backend::full_with_tensor<T>(shape64<T>(x), 0.0, x.dtype());
+    Tensor dummy_y =
+        backend::full_with_tensor<T>(shape64<T>(mask), 0.0, x.dtype());
+    dummy = dummy_x + dummy_y;
+    Tensor mask_expanded = expand<T>(mask, shape64<T>(dummy));
+    Tensor v_expanded = expand<T>(v, shape64<T>(dummy));
+    return where<T>(mask_expanded, v_expanded, x);
+
+  } else {
+    auto out_dims = phi::funcs::BroadcastTwoDims(x.dims(), mask.dims());
+    Tensor x_expanded = x;
+    if (x.dims() != out_dims) {
+      x_expanded = expand<T>(x_expanded, out_dims);
+    }
+
+    Tensor mask_expanded = mask;
+    if (mask.dims() != out_dims) {
+      mask_expanded = expand<T>(mask, out_dims);
+    }
+
+    Tensor v_expanded = expand<T>(v, out_dims);
+
+    return where<T>(mask_expanded, v_expanded, x_expanded);
+  }
+}
+
+template <typename T>
 std::tuple<Tensor, Tensor> dropout_decomp(
     const Tensor& x,
     const paddle::optional<Tensor>& seed_tensor,

--- a/paddle/fluid/primitive/decomp_rule/decomp_rule/composite.h
+++ b/paddle/fluid/primitive/decomp_rule/decomp_rule/composite.h
@@ -608,28 +608,26 @@ Tensor masked_fill_decomp(const Tensor& x,
     // NOTE: use add operator to get broadcast shape implicitly,
     // which is not efficient yet, should be improved in the future.
     Tensor dummy_x =
-        backend::full_with_tensor<T>(shape64<T>(x), 0.0, x.dtype());
-    Tensor dummy_y =
-        backend::full_with_tensor<T>(shape64<T>(mask), 0.0, x.dtype());
-    dummy = dummy_x + dummy_y;
-    Tensor mask_expanded = expand<T>(mask, shape64<T>(dummy));
-    Tensor v_expanded = expand<T>(v, shape64<T>(dummy));
+        backend::full_with_tensor<T>(shape64<T>(x), 0.0, x.dtype(), x.place());
+    Tensor dummy_y = backend::full_with_tensor<T>(
+        shape64<T>(mask), 0.0, x.dtype(), x.place());
+    Tensor dummy = dummy_x + dummy_y;
+    Tensor mask_expanded = backend::expand<T>(mask, shape64<T>(dummy));
+    Tensor v_expanded = backend::expand<T>(v, shape64<T>(dummy));
     return where<T>(mask_expanded, v_expanded, x);
 
   } else {
     auto out_dims = phi::funcs::BroadcastTwoDims(x.dims(), mask.dims());
+    std::vector<int64_t> out_shape = common::vectorize(out_dims);
     Tensor x_expanded = x;
     if (x.dims() != out_dims) {
-      x_expanded = expand<T>(x_expanded, out_dims);
+      x_expanded = expand<T>(x_expanded, out_shape);
     }
-
     Tensor mask_expanded = mask;
     if (mask.dims() != out_dims) {
-      mask_expanded = expand<T>(mask, out_dims);
+      mask_expanded = expand<T>(mask, out_shape);
     }
-
-    Tensor v_expanded = expand<T>(v, out_dims);
-
+    Tensor v_expanded = expand<T>(v, out_shape);
     return where<T>(mask_expanded, v_expanded, x_expanded);
   }
 }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->

Pcard-75624

添加`masked_fill`的静态图前向组合算子

<details><summary>动转静反向精度验证代码</summary>
<p>

``` py
import paddle
import numpy as np
import torch


paddle.framework.core._set_prim_all_enabled(True)
# paddle.framework.core.set_prim_eager_enabled(True)

x_pd = paddle.randn([300, 400])
x_pd.stop_gradient = False

mask_pd = paddle.randint_like(x_pd, 0, 2).astype("bool")
# mask_pd = paddle.randint(0, 2, [10]).astype("bool")

value_pd = paddle.randn([])
value_pd.stop_gradient = False

dy_pd = paddle.randn_like(x_pd)

def grad_func(x, mask, v, dy):
    y = paddle.masked_fill(x, mask, v)
    return paddle.grad(y, [x, v], dy, create_graph=False)

grad_func = paddle.jit.to_static(grad_func, full_graph=True)
# print(dy_pd)
# print(mask_pd)
dx_pd, dv_pd = grad_func(x_pd, mask_pd, value_pd, dy_pd)
# print(dv_pd)
# exit()
# print(dv_pd.item())

x_pt = torch.from_dlpack(x_pd.detach())
x_pt.requires_grad = True

mask_pt = torch.from_dlpack(mask_pd.detach())

value_pt = torch.from_dlpack(value_pd.detach())
value_pt.requires_grad = True

dy_pt = torch.from_dlpack(dy_pd.detach())
# print(mask_pd.to("float32").sum().item())
# print(dy_pd.sum().item())
# print((dy_pd * mask_pd.astype(dy_pd.dtype)).sum().item())

def torch_masked_fill(x, mask, v):
    y = x.clone()
    y[mask] = v
    return y

y_pt = torch_masked_fill(x_pt, mask_pt, value_pt)

dx_pt, dv_pt = torch.autograd.grad(y_pt, [x_pt, value_pt], dy_pt, create_graph=True)

np.testing.assert_allclose(dx_pd.numpy(), dx_pt.cpu().numpy(), rtol=1e-5, atol=1e-7)
np.testing.assert_allclose(dv_pd.numpy(), dv_pt.cpu().numpy(), rtol=1e-5, atol=1e-7)
print(dv_pd.item(), dv_pt.item())
```

</p>
</details> 
