### PR TITLE
[Accuracy diff No.105、100] Fix accuracy diff for max,amax,min,amin,linalg.cond api

### DIFF
--- a/paddle/phi/kernels/funcs/reduce_functor.h
+++ b/paddle/phi/kernels/funcs/reduce_functor.h
@@ -308,6 +308,12 @@ struct AMaxOrAMinGradFunctor {
           mask.sum(axis).reshape(dy->dimensions()).broadcast(dim);
       return;
     }
+
+    if (rank == 0) {
+      dx->device(place) = dy->broadcast(dim) * mask;
+      return;
+    }
+
     // axis is list, HANDLE_AXIS_DIM(broadcast_dim_size, rank)
     HANDLE_AXIS_DIM(3, 2);
     HANDLE_AXIS_DIM(4, 2);

--- a/test/legacy_test/test_max_min_amax_amin_op.py
+++ b/test/legacy_test/test_max_min_amax_amin_op.py
@@ -162,7 +162,7 @@ class TestMaxMinAmaxAminAPI_AxisWithOne3(TestMaxMinAmaxAminAPI):
         self.x_np = np.random.randn(1, 1, 10).astype(np.float32)
         self.shape = [1, 1, 10]
         self.dtype = 'float32'
-        self.axis = [0, 1]
+        self.axis = (0, 1)
         self.keepdim = False
 
 

--- a/test/legacy_test/test_max_min_amax_amin_op.py
+++ b/test/legacy_test/test_max_min_amax_amin_op.py
@@ -139,6 +139,33 @@ class TestMaxMinAmaxAminAPI(unittest.TestCase):
     # test two minimum or maximum elements
 
 
+class TestMaxMinAmaxAminAPI_AxisWithOne1(TestMaxMinAmaxAminAPI):
+    def init_case(self):
+        self.x_np = np.random.randn(1, 5, 10).astype(np.float32)
+        self.shape = [1, 5, 10]
+        self.dtype = 'float32'
+        self.axis = 0
+        self.keepdim = False
+
+
+class TestMaxMinAmaxAminAPI_AxisWithOne2(TestMaxMinAmaxAminAPI):
+    def init_case(self):
+        self.x_np = np.random.randn(1, 5, 10).astype(np.float32)
+        self.shape = [1, 5, 10]
+        self.dtype = 'float32'
+        self.axis = 0
+        self.keepdim = True
+
+
+class TestMaxMinAmaxAminAPI_AxisWithOne3(TestMaxMinAmaxAminAPI):
+    def init_case(self):
+        self.x_np = np.random.randn(1, 1, 10).astype(np.float32)
+        self.shape = [1, 1, 10]
+        self.dtype = 'float32'
+        self.axis = [0, 1]
+        self.keepdim = False
+
+
 class TestMaxMinAmaxAminAPI_ZeroDim(TestMaxMinAmaxAminAPI):
     def init_case(self):
         self.x_np = np.array(0.5)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
添加处理所有规约的轴本身大小为 1 的情况，省略了➗1的写法