### PR TITLE
[AutoParallel] Fix reshard_grad with partial

### DIFF
--- a/paddle/fluid/eager/api/manual/eager_manual/nodes/reshard_node.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/nodes/reshard_node.cc
@@ -46,9 +46,10 @@ ReshardGradNode::operator()(
 
   // Collect GradIn Tensors, Attrs and Recovered TensorWrappers
   auto input = egr::EagerUtils::RecoverTensorWrapper(&this->input_);
-  const auto& dist_attr =
+  auto dist_attr =
       std::static_pointer_cast<phi::distributed::DistTensor>(input.impl())
           ->dist_attr();
+  dist_attr.clean_partial_status();
   auto& grad_out = hooked_grad[0][0];
   // Prepare Grad function call
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

- Fix reshard_grad bug, clean partial status in reshard_grad for the target dist_attr.
- The forward P_To_S `reshard` implements a `reduce_scatter`, with its backward `reshard_grad` is `all_gather` (equivalent to S_To_R).
- The forward P_to_R `reshard` implements a `all_reduce`, with its backward `reshard_grad` is `identity` (equivalent to R_To_R).
- Add ut to check reshard_grad with partial.

Pcard-70448