### PR TITLE
[0-size Tensor Retest No.1、3] fix output type error for paddle.imag and paddle.real api.

### DIFF
--- a/paddle/phi/kernels/impl/complex_kernel_impl.h
+++ b/paddle/phi/kernels/impl/complex_kernel_impl.h
@@ -44,7 +44,7 @@ void RealKernel(const Context& dev_ctx,
                 const DenseTensor& x,
                 DenseTensor* out) {
   if (out->numel() == 0) {
-    dev_ctx.template Alloc<T>(out);
+    dev_ctx.template Alloc<phi::dtype::Real<T>>(out);
     return;
   }
   auto numel = x.numel();
@@ -62,7 +62,7 @@ void ImagKernel(const Context& dev_ctx,
                 const DenseTensor& x,
                 DenseTensor* out) {
   if (out->numel() == 0) {
-    dev_ctx.template Alloc<T>(out);
+    dev_ctx.template Alloc<phi::dtype::Real<T>>(out);
     return;
   }
   auto numel = x.numel();

--- a/paddle/phi/kernels/stride/complex_kernel.cc
+++ b/paddle/phi/kernels/stride/complex_kernel.cc
@@ -26,7 +26,7 @@ void RealStridedKernel(const Context& dev_ctx,
                        const DenseTensor& x,
                        DenseTensor* out) {
   if (out->numel() == 0) {
-    dev_ctx.template Alloc<T>(out);
+    dev_ctx.template Alloc<phi::dtype::Real<T>>(out);
     return;
   }
   if (!FLAGS_use_stride_kernel) {
@@ -55,7 +55,7 @@ void ImagStridedKernel(const Context& dev_ctx,
                        const DenseTensor& x,
                        DenseTensor* out) {
   if (out->numel() == 0) {
-    dev_ctx.template Alloc<T>(out);
+    dev_ctx.template Alloc<phi::dtype::Real<T>>(out);
     return;
   }
   if (!FLAGS_use_stride_kernel) {

--- a/test/legacy_test/test_real_imag_op.py
+++ b/test/legacy_test/test_real_imag_op.py
@@ -296,5 +296,44 @@ class TestImagAPIZeroSize2(TestImagAPI):
         self._shape = [0, 0, 0, 0]
 
 
+class TestImagAPIZeroDtype(unittest.TestCase):
+    def init_data(self):
+        self.shape = [8, 0, 8]
+        self.dtype = 'float32'
+        self.expact_dtype = paddle.float32
+
+    def test_dtype(self):
+        with paddle.base.dygraph.guard():
+            self.init_data()
+            real_part = paddle.rand(self.shape, dtype=self.dtype)
+            imag_part = paddle.rand(self.shape, dtype=self.dtype)
+            complex_matrix = paddle.complex(real_part, imag_part)
+            imag = paddle.imag(complex_matrix)
+            self.assertTrue(imag.dtype == self.expact_dtype)
+
+
+class TestImagAPIZeroDtype1(TestImagAPIZeroDtype):
+    def init_shape(self):
+        self.shape = [8, 0, 8]
+        self.dtype = 'float64'
+        self.expact_dtype = paddle.float64
+
+
+class TestRealAPIZeroDtype(unittest.TestCase):
+    def init_data(self):
+        self.shape = [8, 0, 8]
+        self.dtype = 'float32'
+        self.expact_dtype = paddle.float32
+
+    def test_dtype(self):
+        with paddle.base.dygraph.guard():
+            self.init_data()
+            real_part = paddle.rand(self.shape, dtype=self.dtype)
+            imag_part = paddle.rand(self.shape, dtype=self.dtype)
+            complex_matrix = paddle.complex(real_part, imag_part)
+            real = paddle.real(complex_matrix)
+            self.assertTrue(real.dtype == self.expact_dtype)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
 Bug fixes

### Description
<!-- Describe what you’ve done -->

![image](https://github.com/user-attachments/assets/3d41f06d-ba14-40e5-9bf6-e522d3c62444)
- 复测发现的问题是0 size输入对应的输出的type出错。Real和Imag都有同样的错误。
- 修复alloc部分使用的数据类型，0-size调用的是```ImagStridedKernel```
- 修复后添加单测和paddleAPITest回测，回测结果：


GPU：
![image](https://github.com/user-attachments/assets/5643abd1-f5f5-460f-bba8-7a3f6cbf688f)
CPU：
![image](https://github.com/user-attachments/assets/a925c8f0-35fb-4a70-a680-9d5baa7b0028)

pcard-67164
