### PR TITLE
propagates NaNs for paddle.angle

### DIFF
--- a/paddle/phi/kernels/funcs/complex_functors.h
+++ b/paddle/phi/kernels/funcs/complex_functors.h
@@ -355,6 +355,15 @@ struct ConjFunctor<T, DisableComplex<T>> {
 template <typename T, typename Enable = void>
 struct AngleFunctor;
 
+template <typename T>
+HOSTDEVICE bool is_nan(const T& value) {
+  if constexpr (std::is_same_v<T, double> || std::is_same_v<T, float>) {
+    return std::isnan(value);
+  } else {
+    return phi::dtype::isnan(value);
+  }
+}
+
 // angel function for complex
 template <typename T>
 struct AngleFunctor<T, phi::funcs::Complex<T, dtype::Real<T>>> {
@@ -377,7 +386,7 @@ struct AngleFunctor<T, phi::funcs::NoComplex<T, dtype::Real<T>>> {
       : input_(input), output_(output), numel_(numel) {}
 
   HOSTDEVICE void operator()(int64_t idx) const {
-    if (std::isnan(input_[idx])) {
+    if (is_nan(input_[idx])) {
       output_[idx] = input_[idx];
       return;
     }

--- a/paddle/phi/kernels/funcs/complex_functors.h
+++ b/paddle/phi/kernels/funcs/complex_functors.h
@@ -386,7 +386,7 @@ struct AngleFunctor<T, phi::funcs::NoComplex<T, dtype::Real<T>>> {
       : input_(input), output_(output), numel_(numel) {}
 
   HOSTDEVICE void operator()(int64_t idx) const {
-    if (is_nan(input_[idx])) {
+    if (is_nan<T>(input_[idx])) {
       output_[idx] = input_[idx];
       return;
     }

--- a/paddle/phi/kernels/funcs/complex_functors.h
+++ b/paddle/phi/kernels/funcs/complex_functors.h
@@ -377,6 +377,10 @@ struct AngleFunctor<T, phi::funcs::NoComplex<T, dtype::Real<T>>> {
       : input_(input), output_(output), numel_(numel) {}
 
   HOSTDEVICE void operator()(int64_t idx) const {
+    if (std::isnan(input_[idx])) {
+      output_[idx] = input_[idx];
+      return;
+    }
     output_[idx] = input_[idx] < static_cast<T>(0) ? M_PI : 0;
   }
 

--- a/paddle/phi/kernels/funcs/complex_functors.h
+++ b/paddle/phi/kernels/funcs/complex_functors.h
@@ -377,7 +377,13 @@ struct AngleFunctor<T, phi::funcs::NoComplex<T, dtype::Real<T>>> {
       : input_(input), output_(output), numel_(numel) {}
 
   HOSTDEVICE void operator()(int64_t idx) const {
-    if constexpr (std::is_floating_point_v<T>) {
+    if constexpr (std::is_same_v<T, phi::dtype::bfloat16> ||
+                  std::is_same_v<T, phi::dtype::float16>) {
+      if (phi::dtype::isnan(input_[idx])) {
+        output_[idx] = input_[idx];
+        return;
+      }
+    } else if constexpr (std::is_floating_point_v<T>) {
 #if defined(__CUDACC__) || defined(__HIPCC__)
       if (::isnan(input_[idx])) {
         output_[idx] = input_[idx];
@@ -389,16 +395,7 @@ struct AngleFunctor<T, phi::funcs::NoComplex<T, dtype::Real<T>>> {
         return;
       }
 #endif
-    } else {
-      if constexpr (std::is_same_v<T, phi::dtype::bfloat16> ||
-                    std::is_same_v<T, phi::dtype::float16>) {
-        if (phi::dtype::isnan(input_[idx])) {
-          output_[idx] = input_[idx];
-          return;
-        }
-      }
     }
-
     output_[idx] = input_[idx] < static_cast<T>(0) ? M_PI : 0;
   }
 

--- a/paddle/phi/kernels/funcs/complex_functors.h
+++ b/paddle/phi/kernels/funcs/complex_functors.h
@@ -355,15 +355,6 @@ struct ConjFunctor<T, DisableComplex<T>> {
 template <typename T, typename Enable = void>
 struct AngleFunctor;
 
-template <typename T>
-HOSTDEVICE bool is_nan(const T& value) {
-  if constexpr (std::is_same_v<T, double> || std::is_same_v<T, float>) {
-    return std::isnan(value);
-  } else {
-    return phi::dtype::isnan(value);
-  }
-}
-
 // angel function for complex
 template <typename T>
 struct AngleFunctor<T, phi::funcs::Complex<T, dtype::Real<T>>> {
@@ -386,10 +377,28 @@ struct AngleFunctor<T, phi::funcs::NoComplex<T, dtype::Real<T>>> {
       : input_(input), output_(output), numel_(numel) {}
 
   HOSTDEVICE void operator()(int64_t idx) const {
-    if (is_nan<T>(input_[idx])) {
-      output_[idx] = input_[idx];
-      return;
+    if constexpr (std::is_floating_point_v<T>) {
+#if defined(__CUDACC__) || defined(__HIPCC__)
+      if (::isnan(input_[idx])) {
+        output_[idx] = input_[idx];
+        return;
+      }
+#else
+      if (std::isnan(input_[idx])) {
+        output_[idx] = input_[idx];
+        return;
+      }
+#endif
+    } else {
+      if constexpr (std::is_same_v<T, phi::dtype::bfloat16> ||
+                    std::is_same_v<T, phi::dtype::float16>) {
+        if (phi::dtype::isnan(input_[idx])) {
+          output_[idx] = input_[idx];
+          return;
+        }
+      }
     }
+
     output_[idx] = input_[idx] < static_cast<T>(0) ? M_PI : 0;
   }
 

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -6800,7 +6800,7 @@ def diff(
 def angle(x: Tensor, name: str | None = None) -> Tensor:
     r"""
     Element-wise angle of complex numbers. For non-negative real numbers, the angle is 0 while
-    for negative real numbers, the angle is :math:`\pi`.
+    for negative real numbers, the angle is :math:`\pi`, and NaNs are propagated..
 
     Equation:
         .. math::

--- a/test/legacy_test/test_angle_op.py
+++ b/test/legacy_test/test_angle_op.py
@@ -148,6 +148,7 @@ class TestAngleAPI(unittest.TestCase):
     def setUp(self):
         self.x = np.random.randn(2, 3) + 1j * np.random.randn(2, 3)
         self.out = np.angle(self.x)
+        self.dtype = "complex128"
 
     def test_dygraph(self):
         with dygraph.guard():
@@ -158,7 +159,7 @@ class TestAngleAPI(unittest.TestCase):
     def test_static(self):
         mp, sp = static.Program(), static.Program()
         with static.program_guard(mp, sp):
-            x = static.data("x", shape=[2, 3], dtype="complex128")
+            x = static.data("x", shape=[2, 3], dtype=self.dtype)
             out = paddle.angle(x)
 
         exe = static.Executor()
@@ -171,6 +172,7 @@ class TestAngleAPIWithNan(TestAngleAPI):
     def setUp(self):
         self.x = np.array([np.nan, -1, 1], dtype=np.float64)
         self.out = np.angle(self.x)
+        self.dtype = "float64"
 
 
 class TestZeroSize(unittest.TestCase):

--- a/test/legacy_test/test_angle_op.py
+++ b/test/legacy_test/test_angle_op.py
@@ -167,6 +167,12 @@ class TestAngleAPI(unittest.TestCase):
         np.testing.assert_allclose(self.out, out_np, rtol=1e-05)
 
 
+class TestAngleAPIWithNan(TestAngleAPI):
+    def setUp(self):
+        self.x = np.array([np.nan, 1j * np.inf, np.inf, 1j * np.nan, 1])
+        self.out = np.angle(self.x)
+
+
 class TestZeroSize(unittest.TestCase):
     def setUp(self):
         self.x = np.random.randn(2, 0) + 1j * np.random.randn(2, 0)

--- a/test/legacy_test/test_angle_op.py
+++ b/test/legacy_test/test_angle_op.py
@@ -169,7 +169,7 @@ class TestAngleAPI(unittest.TestCase):
 
 class TestAngleAPIWithNan(TestAngleAPI):
     def setUp(self):
-        self.x = np.array([np.nan, 1j * np.inf, np.inf, 1j * np.nan, 1])
+        self.x = np.array([np.nan, -1, 1], dtype=np.float64)
         self.out = np.angle(self.x)
 
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
fix:
- https://github.com/PaddlePaddle/Paddle/issues/73199

propagates NaNs for paddle.angle, which is same as numpy and torch. Also a clear way to deal with nan.

#### TODO
- [x] update the docstring
- [ ] update the cn docs
- [x] pass ci tests