### PR TITLE
优化scaled_dot_product_attention的head_size检查

### DIFF
--- a/python/paddle/nn/functional/flash_attention.py
+++ b/python/paddle/nn/functional/flash_attention.py
@@ -113,7 +113,7 @@ def can_use_flash_attn(query, key, attn_mask, dropout, is_causal) -> bool:
         return False
     if query.ndim != 4:
         return False
-    if query.shape[-1] >= 256:
+    if query.shape[-1] > 256:
         return False
     if _get_arch_info() < 80:
         return False

--- a/test/legacy_test/test_scaled_dot_product_attention.py
+++ b/test/legacy_test/test_scaled_dot_product_attention.py
@@ -137,7 +137,7 @@ class TestAttentionWithBoolMask(unittest.TestCase):
     def test_dot_scale_product_float_mask(self):
         # test with mask=float
         paddle.disable_static()
-        self.shape = (1, 1, 8, 512)
+        self.shape = (1, 1, 8, 256)
         query = np.random.random(self.shape)
         key = np.random.random(self.shape)
         value = np.random.random(self.shape)

--- a/test/legacy_test/test_scaled_dot_product_attention.py
+++ b/test/legacy_test/test_scaled_dot_product_attention.py
@@ -137,7 +137,7 @@ class TestAttentionWithBoolMask(unittest.TestCase):
     def test_dot_scale_product_float_mask(self):
         # test with mask=float
         paddle.disable_static()
-        self.shape = (1, 1, 8, 256)
+
         query = np.random.random(self.shape)
         key = np.random.random(self.shape)
         value = np.random.random(self.shape)
@@ -169,7 +169,7 @@ class TestAttentionWithBoolMask(unittest.TestCase):
         )
 
         with sdp_kernel(
-            enable_math=None, enable_flash=None, enable_mem_efficient=None
+            enable_math=True, enable_flash=False, enable_mem_efficient=False
         ):
             out = scaled_dot_product_attention(
                 q, k, v, m, self.dropout, self.causal

--- a/test/legacy_test/test_scaled_dot_product_attention.py
+++ b/test/legacy_test/test_scaled_dot_product_attention.py
@@ -137,7 +137,7 @@ class TestAttentionWithBoolMask(unittest.TestCase):
     def test_dot_scale_product_float_mask(self):
         # test with mask=float
         paddle.disable_static()
-
+        self.shape = (1, 1, 8, 512)
         query = np.random.random(self.shape)
         key = np.random.random(self.shape)
         value = np.random.random(self.shape)
@@ -169,7 +169,7 @@ class TestAttentionWithBoolMask(unittest.TestCase):
         )
 
         with sdp_kernel(
-            enable_math=True, enable_flash=False, enable_mem_efficient=False
+            enable_math=None, enable_flash=None, enable_mem_efficient=None
         ):
             out = scaled_dot_product_attention(
                 q, k, v, m, self.dropout, self.causal


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

head_size的检查为head_size <= 256即可  
```cpp
#define CHECK_FWD_EXECTUABLE(__seqlen_q, __seqlen_k)                     \
      auto dprops = at::cuda::getCurrentDeviceProperties();              \
      const bool is_sm8x = dprops->major == 8 && dprops->minor >= 0;     \
      const bool is_sm90 = dprops->major == 9 && dprops->minor == 0;     \
      ASSERT_CHECK(is_sm8x || is_sm90);                                  \
      ASSERT_CHECK(batch_size > 0);                                      \
      ASSERT_CHECK(head_size % 8 == 0);                                  \
      ASSERT_CHECK(head_size <= 256);                                    \
      ASSERT_CHECK(num_heads % num_heads_k == 0);                        \
      if (attn_mask) {                                                   \
          ASSERT_CHECK(mask_dims[0] == batch_size);                      \
          ASSERT_CHECK(mask_dims[1] == 1 || mask_dims[1] == num_heads);  \
          ASSERT_CHECK(mask_dims[2] == 1 || mask_dims[2] == __seqlen_q); \
          ASSERT_CHECK(mask_dims[3] == __seqlen_k);                      \
      }
```
[相关pr](https://github.com/PaddlePaddle/Paddle/pull/73157)  