### PR TITLE
[PHI] Fix test_linalg_matrix_exp accuracy issue

### DIFF
--- a/test/legacy_test/test_linalg_matrix_exp.py
+++ b/test/legacy_test/test_linalg_matrix_exp.py
@@ -23,15 +23,20 @@ import paddle
 from paddle import base
 from paddle.base import core
 
+os.environ['NVIDIA_TF32_OVERRIDE'] = '0'
+
 if sys.platform == 'win32':
     RTOL = {'float32': 1e-02, 'float64': 1e-04}
     ATOL = {'float32': 1e-02, 'float64': 1e-04}
 elif sys.platform == 'darwin':
     RTOL = {'float32': 1e-06, 'float64': 1e-12}
     ATOL = {'float32': 1e-06, 'float64': 1e-12}
-else:
+elif scipy.__version__ < '1.15':
     RTOL = {'float32': 1e-06, 'float64': 1e-15}
     ATOL = {'float32': 1e-06, 'float64': 1e-15}
+else:
+    RTOL = {'float32': 1e-06, 'float64': 1e-13}
+    ATOL = {'float32': 1e-06, 'float64': 1e-13}
 
 
 class MatrixExpTestCase(unittest.TestCase):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Operator Mechanism


### PR Types
Bug fixes


### Description
修复`test_linalg_matrix_exp`单测在A卡和H卡上的精度问题，包括2点：
* 设置`NVIDIA_TF32_OVERRIDE=0`，禁止算子库在A卡及以上的架构使用TF32类型，保证精度
* scipy从1.15.0版本开始，其`scipy.linalg.expm`API的精度自己就发生了变化，因此需要适当放宽float64下的精度阈值


Pcard-85711