### PR TITLE
修改tensor.data的返回，返回的张量不包含梯度信息

### DIFF
--- a/paddle/fluid/pybind/eager_properties.cc
+++ b/paddle/fluid/pybind/eager_properties.cc
@@ -230,11 +230,6 @@ Examples:
 PyObject* tensor_properties_get_data(TensorObject* self, void* closure) {
   EAGER_TRY
   paddle::Tensor new_tensor(self->tensor.impl());
-
-  auto meta = std::make_shared<egr::AutogradMeta>();
-  meta->SetStopGradient(true);
-  new_tensor.set_autograd_meta(meta);
-
   return ToPyObject(new_tensor);
   EAGER_CATCH_AND_THROW_RETURN_NULL
 }

--- a/paddle/fluid/pybind/eager_properties.cc
+++ b/paddle/fluid/pybind/eager_properties.cc
@@ -229,8 +229,13 @@ Examples:
 )DOC");
 PyObject* tensor_properties_get_data(TensorObject* self, void* closure) {
   EAGER_TRY
-  Py_INCREF(self);
-  return reinterpret_cast<PyObject*>(self);
+  paddle::Tensor new_tensor(self->tensor.impl());
+
+  auto meta = std::make_shared<egr::AutogradMeta>();
+  meta->SetStopGradient(true);
+  new_tensor.set_autograd_meta(meta);
+
+  return ToPyObject(new_tensor);
   EAGER_CATCH_AND_THROW_RETURN_NULL
 }
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Improvements

### Description
<!-- Describe what you’ve done -->

tensor.data功能和pytorch对齐，返回不包含梯度信息的tensor  
测试代码：
```python
import numpy as np
import paddle
import torch

np_data = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=np.float32)
paddle_tensor = paddle.to_tensor(np_data, stop_gradient=False)
paddle_tensor_data = paddle_tensor.data
print(paddle_tensor_data)

np_data = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=np.float32)
torch_tensor = torch.tensor(np_data, requires_grad=True)
torch_tensor_data = torch_tensor.data
print(torch_tensor_data)
```