### PR TITLE
【Cherry-pick】fix 0size in matmul grad kernel (#73090)

### DIFF
--- a/paddle/phi/kernels/impl/matmul_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/matmul_grad_kernel_impl.h
@@ -230,10 +230,11 @@ void MatmulGradKernel(const Context& dev_ctx,
                       DenseTensor* dx,
                       DenseTensor* dy) {
   if (x.numel() == 0) {
-    dev_ctx.template Alloc<T>(dx);
-    phi::FullKernel<T>(
-        dev_ctx, common::vectorize(y.dims()), 0.0, y.dtype(), dy);
-
+    if (dy != nullptr) {
+      dev_ctx.template Alloc<T>(dx);
+      phi::FullKernel<T>(
+          dev_ctx, common::vectorize(y.dims()), 0.0, y.dtype(), dy);
+    }
     return;
   }
   // get dims


### PR DESCRIPTION
### PR Category
Operator Mechanism


### PR Types
Bug fixes


### Description
y是stop_gradient的时候，matmul_grad_kernel遇到0size tensor会coredump，这里修复这种情况
