### PR TITLE
[PHI] Fix fast_ln_fwd_kernel for big tensor

### DIFF
--- a/paddle/phi/kernels/funcs/layer_norm_impl.cu.h
+++ b/paddle/phi/kernels/funcs/layer_norm_impl.cu.h
@@ -233,8 +233,9 @@ __global__ __launch_bounds__(THREADS_PER_CTA) void fast_ln_fwd_kernel(
 #pragma unroll
     for (int it = 0, col = c; it < LDGS; it++) {
       if (col < cols) {
-        phi::Load<T, VecSize>(x_ptr + row * ELTS_PER_ROW + col * VecSize,
-                              &x[it]);
+        phi::Load<T, VecSize>(
+            x_ptr + static_cast<int64_t>(row) * ELTS_PER_ROW + col * VecSize,
+            &x[it]);
       } else {
         x[it] = Vec{};
       }
@@ -344,8 +345,9 @@ __global__ __launch_bounds__(THREADS_PER_CTA) void fast_ln_fwd_kernel(
 #pragma unroll
     for (int it = 0, col = c; it < LDGS; it++) {
       if (col < cols) {
-        phi::Store<T, VecSize>(x[it],
-                               y_ptr + row * ELTS_PER_ROW + col * VecSize);
+        phi::Store<T, VecSize>(
+            x[it],
+            y_ptr + static_cast<int64_t>(row) * ELTS_PER_ROW + col * VecSize);
       }
       col += THREADS_PER_ROW;
     }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Operator Mechanism


### PR Types
Bug fixes


### Description
LayerNorm前向一共涉及以下3个CUDA Kernel：

| CUDA Kernel | 分发条件 | 修复情况 |
| --- | --- | --- |
| fast_ln_fwd_kernel | feature_size在[768, 4096]之间且是256的倍数 | 本PR修复
| LayerNormFwdWithWelford | feature_size <= 1024 | 之前已修复
| LayerNormForward | 其余情况 | 之前已修复

事实上，本PR只需把两处运算从int改成int64，因为fast_ln_fwd_kernel对输入大小有限制，row和col单独都不会超过int，只有乘在一起的时候会超过，因此只要在乘在一起的时候转成int64即可，其他地方都保留int，改动很小，实测对性能无任何影响

经验证，可以通过error_log里全部34个case

Pcard-85711