### PR TITLE
[0-size Tensor Retest No.4] fix shape diff for matrix_rank when input is 0-size tensor

### DIFF
--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/binary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/binary_infer_sym.cc
@@ -1361,16 +1361,14 @@ bool MatrixRankTolOpInferSymbolicShape(
                     common::errors::InvalidArgument(
                         "The dims of input must be greater than 2"));
   bool hermitian = GetBoolAttr(op, "hermitian");
-  const auto &GetProduct = [&](const auto &dim_exprs, const auto &Filter) {
+  const auto &GetProduct = [&](const auto &dim_exprs) {
     symbol::DimExpr product{1};
     for (const auto &dim_expr : dim_exprs) {
-      if (Filter(dim_expr)) {
-        product = product * dim_expr;
-      }
+      product = product * dim_expr;
     }
     return product;
   };
-  const auto &x_numel = GetProduct(x_shape, [](const auto &) { return true; });
+  const auto &x_numel = GetProduct(x_shape);
 
   if (hermitian && x_numel != 0) {
     infer_context->AddEqualCstr(x_shape[x_rank - 2], x_shape[x_rank - 1]);

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/binary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/binary_infer_sym.cc
@@ -1361,7 +1361,18 @@ bool MatrixRankTolOpInferSymbolicShape(
                     common::errors::InvalidArgument(
                         "The dims of input must be greater than 2"));
   bool hermitian = GetBoolAttr(op, "hermitian");
-  if (hermitian) {
+  const auto &GetProduct = [&](const auto &dim_exprs, const auto &Filter) {
+    symbol::DimExpr product{1};
+    for (const auto &dim_expr : dim_exprs) {
+      if (Filter(dim_expr)) {
+        product = product * dim_expr;
+      }
+    }
+    return product;
+  };
+  const auto &x_numel = GetProduct(x_shape, [](const auto &) { return true; });
+
+  if (hermitian && x_numel != 0) {
     infer_context->AddEqualCstr(x_shape[x_rank - 2], x_shape[x_rank - 1]);
   }
   std::vector<symbol::DimExpr> x_shape_batch = [&] {
@@ -1385,6 +1396,12 @@ bool MatrixRankTolOpInferSymbolicShape(
 
   const std::vector<symbol::DimExpr> shapes = [&] {
     std::vector<symbol::DimExpr> shapes;
+    if (x_numel == 0) {
+      if (x_rank == 2)
+        return shapes;  // return empty shape
+      else
+        return x_shape_batch;  // return x_shape[:-2]
+    }
     symbol::DimExprBuilder builder;
     for (size_t i = 0; i < x_shape_batch.size(); i++) {
       if (x_shape_batch[i] == tol_shape[i]) {

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.cc
@@ -2168,6 +2168,17 @@ bool MatrixRankOpInferSymbolicShape(
       infer_context->GetShapeOrDataForValue(op->operand_source(0));
   const std::vector<symbol::DimExpr> &x_shape = x_shape_or_data.shape();
 
+  const auto &GetProduct = [&](const auto &dim_exprs, const auto &Filter) {
+    symbol::DimExpr product{1};
+    for (const auto &dim_expr : dim_exprs) {
+      if (Filter(dim_expr)) {
+        product = product * dim_expr;
+      }
+    }
+    return product;
+  };
+  const auto &x_numel = GetProduct(x_shape, [](const auto &) { return true; });
+
   // 确保输入x的维度大于等于2
   PADDLE_ENFORCE_GE(x_shape.size(),
                     2,
@@ -2177,8 +2188,8 @@ bool MatrixRankOpInferSymbolicShape(
   // 获取Hermitian属性
   bool hermitian = op->attribute<pir::BoolAttribute>("hermitian").data();
 
-  // 如果hermitian为true，确保输入x是方阵
-  if (hermitian) {
+  // 如果hermitian为true，确保输入x是方阵,0-size Tensor不需要此检查
+  if (hermitian && x_numel != 0) {
     infer_context->AddEqualCstr(x_shape[x_shape.size() - 2],
                                 x_shape[x_shape.size() - 1]);
   }

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.cc
@@ -2168,16 +2168,14 @@ bool MatrixRankOpInferSymbolicShape(
       infer_context->GetShapeOrDataForValue(op->operand_source(0));
   const std::vector<symbol::DimExpr> &x_shape = x_shape_or_data.shape();
 
-  const auto &GetProduct = [&](const auto &dim_exprs, const auto &Filter) {
+  const auto &GetProduct = [&](const auto &dim_exprs) {
     symbol::DimExpr product{1};
     for (const auto &dim_expr : dim_exprs) {
-      if (Filter(dim_expr)) {
-        product = product * dim_expr;
-      }
+      product = product * dim_expr;
     }
     return product;
   };
-  const auto &x_numel = GetProduct(x_shape, [](const auto &) { return true; });
+  const auto &x_numel = GetProduct(x_shape);
 
   // 确保输入x的维度大于等于2
   PADDLE_ENFORCE_GE(x_shape.size(),

--- a/paddle/phi/infermeta/binary.cc
+++ b/paddle/phi/infermeta/binary.cc
@@ -3177,9 +3177,10 @@ void MatrixRankTolInferMeta(const MetaTensor& x,
                     common::errors::InvalidArgument(
                         "The dims of input must be greater than 2"));
 
-  if (hermitian) {
+  if (hermitian && x.numel() != 0) {
     int64_t rows = static_cast<int64_t>(dim_x[dim_x.size() - 2]);
     int64_t cols = static_cast<int64_t>(dim_x[dim_x.size() - 1]);
+    // if x is 0 size tensor,ignore rows == cols check.
     PADDLE_ENFORCE_EQ(rows,
                       cols,
                       common::errors::InvalidArgument(
@@ -3187,7 +3188,13 @@ void MatrixRankTolInferMeta(const MetaTensor& x,
   }
   DDim dim_x_batch = detail::CheckAndGetOutputDim(dim_x);
   auto dim_tol = atol_tensor.dims();
-  if (dim_x_batch == dim_tol) {
+  if (x.numel() == 0) {
+    if (dim_x.size() == 2) {
+      out->set_dims(common::make_ddim({}));
+    } else {
+      out->set_dims(dim_x_batch);
+    }
+  } else if (dim_x_batch == dim_tol) {
     out->set_dims(dim_x_batch);
   } else {
     int max_dim = std::max(dim_x_batch.size(), dim_tol.size());

--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -2534,9 +2534,10 @@ void MatrixRankInferMeta(const MetaTensor& x,
                     common::errors::InvalidArgument(
                         "The dims of input must be greater than 2."));
 
-  if (hermitian) {
+  if (hermitian && x.numel() != 0) {
     int rows = static_cast<int>(dim_x[dim_x.size() - 2]);
     int cols = static_cast<int>(dim_x[dim_x.size() - 1]);
+    // if x is 0-size Tensor,ignore rows == cols check.
     PADDLE_ENFORCE_EQ(rows,
                       cols,
                       common::errors::InvalidArgument(

--- a/test/legacy_test/test_matrix_rank_op.py
+++ b/test/legacy_test/test_matrix_rank_op.py
@@ -474,6 +474,21 @@ class TestMatrixRankZeroSizeTensor(unittest.TestCase):
             )
             np.testing.assert_allclose(y_valid2, y_valid2_real, rtol=1e-05)
 
+            x_valid3 = paddle.full((2, 0, 7, 7), 1.0, dtype='float64')
+            tol = paddle.full((2, 0), 1.0, dtype='float32')
+            y_valid3 = paddle.linalg.matrix_rank(x_valid3, tol)
+            self.assertEqual(y_valid3.shape, x_valid3.shape[:-2])
+
+            x_valid4 = paddle.full((2, 0, 7, 7), 1.0, dtype='float64')
+            atol = paddle.full((2, 0), 1.0, dtype='float32')
+            y_valid4 = paddle.linalg.matrix_rank(x_valid4, atol=atol)
+            self.assertEqual(y_valid4.shape, x_valid4.shape[:-2])
+
+            x_valid5 = paddle.full((0, 7), 1.0, dtype='float64')
+            tol = paddle.full((1), 1.0, dtype='float32')
+            y_valid5 = paddle.linalg.matrix_rank(x_valid5, tol)
+            self.assertEqual(y_valid5.shape, y_valid5.shape[:-2])
+
     def test_matrix_rank_tensor(self):
         for place in self._get_places():
             self._test_matrix_rank_static(place)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修复了当输入为0 size Tensor时，输出的shape和torch不对齐的error。
### 回测问题
![image](https://github.com/user-attachments/assets/faa1ed11-1335-44e4-bc19-c52b5cb3db7b)
- 非法参数。输入的最后两个维度不等的检查没过
- 一些情况输出shape不对

### 修复方法
通过和torch进行对比，采用的修复方法如下：
- 如果输入是0-size Tensor即使hermitian=True 也无需检查矩阵是否是方阵。
- 如果输入是0-size且为二维矩阵则输出shape为[] ，0-dim
- 如果tol或者atol或者rtol不为None，则输出的shape为x.dims()[:-2],即输入shape删掉最后两个dim
- atol或者rtol不为None时调用的是_C_ops.matrix_rank_atol_rtol，已经修改infermeta，无对应的infer_symbolic_shape函数
- tol不为None时调用的是_C_ops.matrix_rank_tol，已经同步修改infermeta和infer_symbolic_shape函数
- 其他调用_C_ops.matrix_rank，已经同步修改infermeta和infer_symbolic_shape函数

### PaddleAPITest 回测

CPU
![image](https://github.com/user-attachments/assets/b6af8499-c41f-47c8-ac6d-ab7e6f37aa05)


GPU

![image](https://github.com/user-attachments/assets/5377097d-9538-42b8-bc85-5bdaffb2fad4)

pcard-67164
