### PR TITLE
[0-size Tensor Retest No.5] fix output shape diff for paddle.nanmedian	

### DIFF
--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.cc
@@ -2315,39 +2315,14 @@ bool NanmedianOpInferSymbolicShape(
     median_shape.emplace_back(2);
   }
 
-  const auto &IsZero = [&](const symbol::DimExpr &dim_expr) {
-    if (dim_expr.isa<int64_t>()) {
-      return dim_expr.dyn_cast<int64_t>() == static_cast<int64_t>(0);
-    }
-    return false;
-  };
-  bool size_0 = false;
-  for (size_t i = 0; i < x_shape.size(); i++) {
-    if (IsZero(x_shape.at(i))) {
-      size_0 = true;
-      break;
-    }
-  }
-  if (size_0) {
-    std::vector<symbol::DimExpr> x_numel_0_shape = {};
-    infer_context->SetShapeOrDataForValue(
-        op->result(0),
-        symbol::ShapeOrDataDimExprs{
-            symbol::TensorShapeOrDataDimExprs(x_numel_0_shape)});
-    infer_context->SetShapeOrDataForValue(
-        op->result(1),
-        symbol::ShapeOrDataDimExprs{
-            symbol::TensorShapeOrDataDimExprs(x_numel_0_shape)});
-  } else {
-    infer_context->SetShapeOrDataForValue(
-        op->result(0),
-        symbol::ShapeOrDataDimExprs{
-            symbol::TensorShapeOrDataDimExprs(out_shape)});
-    infer_context->SetShapeOrDataForValue(
-        op->result(1),
-        symbol::ShapeOrDataDimExprs{
-            symbol::TensorShapeOrDataDimExprs(median_shape)});
-  }
+  infer_context->SetShapeOrDataForValue(
+      op->result(0),
+      symbol::ShapeOrDataDimExprs{
+          symbol::TensorShapeOrDataDimExprs(out_shape)});
+  infer_context->SetShapeOrDataForValue(
+      op->result(1),
+      symbol::ShapeOrDataDimExprs{
+          symbol::TensorShapeOrDataDimExprs(median_shape)});
   return true;
 }
 

--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -2884,11 +2884,6 @@ void NanmedianInferMeta(const MetaTensor& x,
   }
   median_index->set_dtype(DataType::INT64);
   median_index->set_dims(make_ddim(median_dim));
-
-  if (x.numel() == 0) {
-    out->set_dims(make_ddim({}));
-    median_index->set_dims(make_ddim({}));
-  }
 }
 
 void NMSInferMeta(const MetaTensor& x, float threshold, MetaTensor* out) {

--- a/test/legacy_test/test_nanmedian.py
+++ b/test/legacy_test/test_nanmedian.py
@@ -617,21 +617,26 @@ class TestNanmedianFP16Op(OpTest):
         self.check_grad(['X'], 'Out', check_pir=True)
 
 
-class TestNanmedianOp_ZeroSize(TestNanmedianFP16Op):
-    def setUp(self):
-        self.op_type = "nanmedian"
-        self.python_api = paddle.nanmedian
-        self.public_python_api = paddle.nanmedian
-        self.dtype = np.float64
-        self.python_out_sig = ["Out"]
-        X = np.random.random((100, 0)).astype('float64')
-        Out = np.nanmedian(X)
-        indices = np.zeros_like(Out, dtype='int64')
-        self.inputs = {'X': X}
-        self.outputs = {'Out': Out, 'MedianIndex': indices}
+class TestNanmedianZeroSize(unittest.TestCase):
+    def init_data(self):
+        self.x_shape = [100, 0]
+        self.expect_out = np.array(np.nan, dtype='float32')
+        self.axis = None
 
-    def test_check_output(self):
-        self.check_output(check_pir=True, equal_nan=True)
+    def test_zero(self):
+        self.init_data()
+        x = paddle.randn(self.x_shape)
+        out = paddle.nanmedian(x, axis=self.axis)
+        np.testing.assert_allclose(
+            out.numpy(), self.expect_out, rtol=1e-05, equal_nan=True
+        )
+
+
+class TestNanmedianZeroSize1(TestNanmedianZeroSize):
+    def init_data(self):
+        self.x_shape = [100, 0, 100]
+        self.expect_out = np.zeros(self.x_shape[:-1], dtype='float32')
+        self.axis = -1
 
 
 @unittest.skipIf(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure 
### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
### 复测报错：
![image](https://github.com/user-attachments/assets/f5761076-f634-4f66-a9ae-5aa3a2c28e47)

### 问题分析：
https://github.com/PaddlePaddle/Paddle/pull/72937 的修复存在问题，由于其对比的对象是numpy的nanmedia，在遇到0-size Tensor时与Torch的行为有区别，进而导致一些复测case出错。

### 修复方法：
删除https://github.com/PaddlePaddle/Paddle/pull/72937 对shape推导部分的修改，只保留其对kernel部分的修改。添加单测，单测的结果应该是torch的输出。

PaddleAPITest回测：
- CPU
![image](https://github.com/user-attachments/assets/5fbda7bd-7913-41a2-b9eb-68f3aeb86af9)
 
- GPU
![image](https://github.com/user-attachments/assets/76c1282d-51af-4554-8724-f1502c31c12d)


pcard-67164
