### PR TITLE
修改bernoulli的inplace实现（p为随机值为1的概率）

### DIFF
--- a/python/paddle/tensor/random.py
+++ b/python/paddle/tensor/random.py
@@ -172,8 +172,8 @@ def bernoulli_(
              [0., 0., 0., 0.]])
     """
     x.uniform_(0.0, 1.0)
-    ones_mask = x > p
-    zeros_mask = x < p
+    ones_mask = x < p
+    zeros_mask = x > p
     x.masked_fill_(ones_mask, 1.0)
     x.masked_fill_(zeros_mask, 0.0)
     return x


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

之前Bernoulli的inplace实现有bug，p实现成了随机值为0的概率：与非inplace版本的paddle.bernoulli、pytorch实现均不同。

现在修改成p是随机值为1的概率，与非inplace版本以及Pytorch均对齐了。

测试代码：
```python
import paddle
import torch
import numpy as np

np.random.seed(23)
paddle.seed(23)
torch.manual_seed(23)

probs_np = np.random.rand(3, 3).astype(np.float32)

probs_paddle = paddle.to_tensor(probs_np)
probs_torch = torch.tensor(probs_np)

print("\n概率值 (输入):")
print(probs_paddle)
probs_paddle.bernoulli_(p=0.99)
print("\nPaddle bernoulli_ 结果:")
print(probs_paddle)

print("\n概率值 (输入):")
print(probs_torch)
probs_torch.bernoulli_(p=0.99)
print("\nPyTorch bernoulli_ 结果:")
print(probs_torch)
```

```bash
概率值 (输入):
Tensor(shape=[3, 3], dtype=float32, place=Place(gpu:0), stop_gradient=True,
       [[0.51729786, 0.94696259, 0.76545978],
        [0.28239584, 0.22104536, 0.68622208],
        [0.16713920, 0.39244246, 0.61805236]])

Paddle bernoulli_ 结果:
Tensor(shape=[3, 3], dtype=float32, place=Place(gpu:0), stop_gradient=True,
       [[1., 1., 1.],
        [1., 1., 1.],
        [1., 1., 1.]])

概率值 (输入):
tensor([[0.5173, 0.9470, 0.7655],
        [0.2824, 0.2210, 0.6862],
        [0.1671, 0.3924, 0.6181]])

PyTorch bernoulli_ 结果:
tensor([[1., 1., 1.],
        [1., 1., 1.],
        [1., 1., 1.]])
```
