### PR TITLE
Add the acquisition method of cudastream in CustomDevice

### DIFF
--- a/paddle/fluid/pybind/cuda_streams_py.cc
+++ b/paddle/fluid/pybind/cuda_streams_py.cc
@@ -95,7 +95,7 @@ void BindCudaStream(py::module *m_ptr) {
       },
       py::return_value_policy::reference);
 
-#elif defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+#else
   m.def(
       "_get_current_stream",
       [](int deviceId) {

--- a/paddle/fluid/pybind/cuda_streams_py.cc
+++ b/paddle/fluid/pybind/cuda_streams_py.cc
@@ -25,7 +25,7 @@ namespace py = pybind11;
 namespace paddle {
 namespace platform {
 #if defined(PADDLE_WITH_CUSTOM_DEVICE)
-phi::stream::Stream *get_current_stream(int device_id) {
+STREAM_TYPE get_current_stream(int device_id) {
   auto dev_types = phi::DeviceManager::GetAllCustomDeviceTypes();
   if (device_id == -1) {
     device_id = phi::DeviceManager::GetDevice(dev_types[0]);
@@ -36,7 +36,7 @@ phi::stream::Stream *get_current_stream(int device_id) {
   return custom_context->GetStream().get();
 }
 
-phi::stream::Stream *set_current_stream(phi::stream::Stream *stream) {
+STREAM_TYPE set_current_stream(STREAM_TYPE stream) {
   auto *original_stream = get_current_stream(stream->GetPlace().GetDeviceId());
   auto *custom_context = static_cast<phi::CustomContext *>(
       DeviceContextPool::Instance().Get(stream->GetPlace()));
@@ -45,7 +45,7 @@ phi::stream::Stream *set_current_stream(phi::stream::Stream *stream) {
 }
 
 #elif defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
-phi::CUDAStream *get_current_stream(int device_id) {
+STREAM_TYPE get_current_stream(int device_id) {
   if (device_id == -1) {
     device_id = phi::backends::gpu::GetCurrentDeviceId();
   }
@@ -54,7 +54,7 @@ phi::CUDAStream *get_current_stream(int device_id) {
   return gpu_context->cuda_stream();
 }
 
-phi::CUDAStream *set_current_stream(phi::CUDAStream *stream) {
+STREAM_TYPE set_current_stream(STREAM_TYPE stream) {
   auto *original_stream = get_current_stream(stream->place().GetDeviceId());
   auto *gpu_context = static_cast<phi::GPUContext *>(
       DeviceContextPool::Instance().Get(stream->place()));
@@ -68,15 +68,15 @@ void BindCudaStream(py::module *m_ptr) {
   auto &m = *m_ptr;
 
   // Bind Methods
-#if defined(PADDLE_WITH_CUSTOM_DEVICE)
   m.def(
       "_get_current_stream",
       [](int deviceId) {
-#if defined(PADDLE_WITH_CUSTOM_DEVICE)
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP) || \
+    defined(PADDLE_WITH_CUSTOM_DEVICE)
         return paddle::platform::get_current_stream(deviceId);
 #else
         PADDLE_THROW(common::errors::Unavailable(
-            "Paddle is not compiled with CUSTOM_DEVICE. "
+            "Paddle do not support _get_current_stream "
             "Cannot visit device synchronize."));
 #endif
       },
@@ -84,44 +84,17 @@ void BindCudaStream(py::module *m_ptr) {
 
   m.def(
       "_set_current_stream",
-      [](phi::stream::Stream *stream) {
-#if defined(PADDLE_WITH_CUSTOM_DEVICE)
+      [](STREAM_TYPE stream) {
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP) || \
+    defined(PADDLE_WITH_CUSTOM_DEVICE)
         return paddle::platform::set_current_stream(stream);
 #else
         PADDLE_THROW(common::errors::Unavailable(
-            "Paddle is not compiled with CUSTOM_DEVICE. "
+            "Paddle do not support _set_current_stream "
             "Cannot visit device synchronize."));
 #endif
       },
       py::return_value_policy::reference);
-
-#else
-  m.def(
-      "_get_current_stream",
-      [](int deviceId) {
-#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
-        return platform::get_current_stream(deviceId);
-#else
-        PADDLE_THROW(
-            common::errors::Unavailable("Paddle is not compiled with CUDA. "
-                                        "Cannot visit device synchronize."));
-#endif
-      },
-      py::return_value_policy::reference);
-
-  m.def(
-      "_set_current_stream",
-      [](phi::CUDAStream *stream) {
-#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
-        return platform::set_current_stream(stream);
-#else
-        PADDLE_THROW(
-            common::errors::Unavailable("Paddle is not compiled with CUDA. "
-                                        "Cannot visit device synchronize."));
-#endif
-      },
-      py::return_value_policy::reference);
-#endif
 
   m.def("_device_synchronize", [](int device_id) {
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
@@ -287,6 +260,28 @@ void BindCudaStream(py::module *m_ptr) {
                   >>> print(cuda_stream)
 
                   >>> ptr = ctypes.c_void_p(cuda_stream)  # convert back to void*
+                  >>> print(ptr)
+
+          )DOC")
+      .def_property_readonly(
+          "raw_stream",
+          [](phi::CUDAStream &self) {
+            VLOG(10) << self.raw_stream();
+            return reinterpret_cast<std::uintptr_t>(self.raw_stream());
+          },
+          R"DOC(
+          return the raw cuda stream of type cudaStream_t as type int.
+
+          Examples:
+              .. code-block:: python
+
+                  >>> # doctest: +REQUIRES(env:GPU)
+                  >>> import paddle
+                  >>> import ctypes
+                  >>> raw_stream = paddle.device.cuda.current_stream().raw_stream
+                  >>> print(raw_stream)
+
+                  >>> ptr = ctypes.c_void_p(raw_stream)  # convert back to void*
                   >>> print(ptr)
 
           )DOC")

--- a/paddle/fluid/pybind/cuda_streams_py.cc
+++ b/paddle/fluid/pybind/cuda_streams_py.cc
@@ -24,7 +24,26 @@ namespace py = pybind11;
 
 namespace paddle {
 namespace platform {
-#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+#if defined(PADDLE_WITH_CUSTOM_DEVICE)
+phi::stream::Stream *get_current_stream(int device_id) {
+  auto dev_types = phi::DeviceManager::GetAllCustomDeviceTypes();
+  if (device_id == -1) {
+    device_id = phi::DeviceManager::GetDevice(dev_types[0]);
+  }
+  auto *custom_context = static_cast<const phi::CustomContext *>(
+      DeviceContextPool::Instance().Get(phi::CustomPlace(dev_types[0], device_id)));
+  return custom_context->GetStream().get();
+}
+
+phi::stream::Stream *set_current_stream(phi::stream::Stream *stream) {
+    auto *original_stream = get_current_stream(stream->GetPlace().GetDeviceId());
+    auto *custom_context = static_cast<phi::CustomContext *>(
+        DeviceContextPool::Instance().Get(stream->GetPlace()));
+    custom_context->SetStream(std::shared_ptr<phi::stream::Stream>(stream));
+    return original_stream;
+  }
+
+#elif defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
 phi::CUDAStream *get_current_stream(int device_id) {
   if (device_id == -1) {
     device_id = phi::backends::gpu::GetCurrentDeviceId();
@@ -48,6 +67,34 @@ void BindCudaStream(py::module *m_ptr) {
   auto &m = *m_ptr;
 
   // Bind Methods
+#if defined(PADDLE_WITH_CUSTOM_DEVICE)
+  m.def(
+      "_get_current_stream",
+      [](int deviceId) {
+#if defined(PADDLE_WITH_CUSTOM_DEVICE)
+        return paddle::platform::get_current_stream(deviceId);
+#else
+        PADDLE_THROW(
+            common::errors::Unavailable("Paddle is not compiled with CUSTOM_DEVICE. "
+                                        "Cannot visit device synchronize."));
+#endif
+      },
+      py::return_value_policy::reference);
+
+  m.def(
+      "_set_current_stream",
+      [](phi::stream::Stream *stream) {
+#if defined(PADDLE_WITH_CUSTOM_DEVICE)
+        return paddle::platform::set_current_stream(stream);
+#else
+        PADDLE_THROW(
+            common::errors::Unavailable("Paddle is not compiled with CUSTOM_DEVICE. "
+                                        "Cannot visit device synchronize."));
+#endif
+      },
+      py::return_value_policy::reference);
+
+#elif defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
   m.def(
       "_get_current_stream",
       [](int deviceId) {
@@ -73,6 +120,7 @@ void BindCudaStream(py::module *m_ptr) {
 #endif
       },
       py::return_value_policy::reference);
+#endif
 
   m.def("_device_synchronize", [](int device_id) {
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)

--- a/paddle/fluid/pybind/cuda_streams_py.cc
+++ b/paddle/fluid/pybind/cuda_streams_py.cc
@@ -30,18 +30,19 @@ phi::stream::Stream *get_current_stream(int device_id) {
   if (device_id == -1) {
     device_id = phi::DeviceManager::GetDevice(dev_types[0]);
   }
-  auto *custom_context = static_cast<const phi::CustomContext *>(
-      DeviceContextPool::Instance().Get(phi::CustomPlace(dev_types[0], device_id)));
+  auto *custom_context =
+      static_cast<const phi::CustomContext *>(DeviceContextPool::Instance().Get(
+          phi::CustomPlace(dev_types[0], device_id)));
   return custom_context->GetStream().get();
 }
 
 phi::stream::Stream *set_current_stream(phi::stream::Stream *stream) {
-    auto *original_stream = get_current_stream(stream->GetPlace().GetDeviceId());
-    auto *custom_context = static_cast<phi::CustomContext *>(
-        DeviceContextPool::Instance().Get(stream->GetPlace()));
-    custom_context->SetStream(std::shared_ptr<phi::stream::Stream>(stream));
-    return original_stream;
-  }
+  auto *original_stream = get_current_stream(stream->GetPlace().GetDeviceId());
+  auto *custom_context = static_cast<phi::CustomContext *>(
+      DeviceContextPool::Instance().Get(stream->GetPlace()));
+  custom_context->SetStream(std::shared_ptr<phi::stream::Stream>(stream));
+  return original_stream;
+}
 
 #elif defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
 phi::CUDAStream *get_current_stream(int device_id) {
@@ -74,9 +75,9 @@ void BindCudaStream(py::module *m_ptr) {
 #if defined(PADDLE_WITH_CUSTOM_DEVICE)
         return paddle::platform::get_current_stream(deviceId);
 #else
-        PADDLE_THROW(
-            common::errors::Unavailable("Paddle is not compiled with CUSTOM_DEVICE. "
-                                        "Cannot visit device synchronize."));
+        PADDLE_THROW(common::errors::Unavailable(
+            "Paddle is not compiled with CUSTOM_DEVICE. "
+            "Cannot visit device synchronize."));
 #endif
       },
       py::return_value_policy::reference);
@@ -87,9 +88,9 @@ void BindCudaStream(py::module *m_ptr) {
 #if defined(PADDLE_WITH_CUSTOM_DEVICE)
         return paddle::platform::set_current_stream(stream);
 #else
-        PADDLE_THROW(
-            common::errors::Unavailable("Paddle is not compiled with CUSTOM_DEVICE. "
-                                        "Cannot visit device synchronize."));
+        PADDLE_THROW(common::errors::Unavailable(
+            "Paddle is not compiled with CUSTOM_DEVICE. "
+            "Cannot visit device synchronize."));
 #endif
       },
       py::return_value_policy::reference);

--- a/paddle/fluid/pybind/cuda_streams_py.cc
+++ b/paddle/fluid/pybind/cuda_streams_py.cc
@@ -25,7 +25,7 @@ namespace py = pybind11;
 namespace paddle {
 namespace platform {
 #if defined(PADDLE_WITH_CUSTOM_DEVICE)
-STREAM_TYPE get_current_stream(int device_id) {
+PY_STREAM_TYPE get_current_stream(int device_id) {
   auto dev_types = phi::DeviceManager::GetAllCustomDeviceTypes();
   if (device_id == -1) {
     device_id = phi::DeviceManager::GetDevice(dev_types[0]);
@@ -36,7 +36,7 @@ STREAM_TYPE get_current_stream(int device_id) {
   return custom_context->GetStream().get();
 }
 
-STREAM_TYPE set_current_stream(STREAM_TYPE stream) {
+PY_STREAM_TYPE set_current_stream(PY_STREAM_TYPE stream) {
   auto *original_stream = get_current_stream(stream->GetPlace().GetDeviceId());
   auto *custom_context = static_cast<phi::CustomContext *>(
       DeviceContextPool::Instance().Get(stream->GetPlace()));
@@ -45,7 +45,7 @@ STREAM_TYPE set_current_stream(STREAM_TYPE stream) {
 }
 
 #elif defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
-STREAM_TYPE get_current_stream(int device_id) {
+PY_STREAM_TYPE get_current_stream(int device_id) {
   if (device_id == -1) {
     device_id = phi::backends::gpu::GetCurrentDeviceId();
   }
@@ -54,7 +54,7 @@ STREAM_TYPE get_current_stream(int device_id) {
   return gpu_context->cuda_stream();
 }
 
-STREAM_TYPE set_current_stream(STREAM_TYPE stream) {
+PY_STREAM_TYPE set_current_stream(PY_STREAM_TYPE stream) {
   auto *original_stream = get_current_stream(stream->place().GetDeviceId());
   auto *gpu_context = static_cast<phi::GPUContext *>(
       DeviceContextPool::Instance().Get(stream->place()));
@@ -73,7 +73,7 @@ void BindCudaStream(py::module *m_ptr) {
       [](int deviceId) {
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP) || \
     defined(PADDLE_WITH_CUSTOM_DEVICE)
-        return paddle::platform::get_current_stream(deviceId);
+        return platform::get_current_stream(deviceId);
 #else
         PADDLE_THROW(common::errors::Unavailable(
             "Paddle do not support _get_current_stream "
@@ -84,10 +84,10 @@ void BindCudaStream(py::module *m_ptr) {
 
   m.def(
       "_set_current_stream",
-      [](STREAM_TYPE stream) {
+      [](PY_STREAM_TYPE stream) {
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP) || \
     defined(PADDLE_WITH_CUSTOM_DEVICE)
-        return paddle::platform::set_current_stream(stream);
+        return platform::set_current_stream(stream);
 #else
         PADDLE_THROW(common::errors::Unavailable(
             "Paddle do not support _set_current_stream "

--- a/paddle/fluid/pybind/cuda_streams_py.h
+++ b/paddle/fluid/pybind/cuda_streams_py.h
@@ -30,7 +30,7 @@ class CUDAStream {};
 
 #if defined(PADDLE_WITH_CUSTOM_DEVICE)
 #define PY_STREAM_TYPE phi::stream::Stream*
-#elif defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+#else
 #define PY_STREAM_TYPE phi::CUDAStream*
 #endif
 

--- a/paddle/fluid/pybind/cuda_streams_py.h
+++ b/paddle/fluid/pybind/cuda_streams_py.h
@@ -28,16 +28,20 @@ class CUDAStream {};
 }  // namespace phi
 #endif
 
+#if defined(PADDLE_WITH_CUSTOM_DEVICE)
+#define STREAM_TYPE phi::stream::Stream*
+#elif defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+#define STREAM_TYPE phi::CUDAStream*
+#endif
+
 namespace py = pybind11;
 
 namespace paddle {
 namespace platform {
-#if defined(PADDLE_WITH_CUSTOM_DEVICE)
-phi::stream::Stream* get_current_stream(int device_id = -1);
-phi::stream::Stream* set_current_stream(phi::stream::Stream* stream);
-#elif defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
-phi::CUDAStream* get_current_stream(int device_id = -1);
-phi::CUDAStream* set_current_stream(phi::CUDAStream* stream);
+#if || defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP) || \
+    defined(PADDLE_WITH_CUSTOM_DEVICE)
+STREAM_TYPE get_current_stream(int device_id = -1);
+STREAM_TYPE set_current_stream(STREAM_TYPE stream);
 #endif
 }  // namespace platform
 namespace pybind {

--- a/paddle/fluid/pybind/cuda_streams_py.h
+++ b/paddle/fluid/pybind/cuda_streams_py.h
@@ -17,6 +17,9 @@
 #include "pybind11/pybind11.h"
 #include "pybind11/stl.h"
 
+#if defined(PADDLE_WITH_CUSTOM_DEVICE)
+#include "paddle/phi/backends/stream.h"
+#endif
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
 #include "paddle/phi/core/cuda_stream.h"
 #else
@@ -29,7 +32,10 @@ namespace py = pybind11;
 
 namespace paddle {
 namespace platform {
-#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+#if defined(PADDLE_WITH_CUSTOM_DEVICE)
+phi::stream::Stream* get_current_stream(int device_id = -1);
+phi::stream::Stream* set_current_stream(phi::stream::Stream* stream);
+#elif defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
 phi::CUDAStream* get_current_stream(int device_id = -1);
 phi::CUDAStream* set_current_stream(phi::CUDAStream* stream);
 #endif

--- a/paddle/fluid/pybind/cuda_streams_py.h
+++ b/paddle/fluid/pybind/cuda_streams_py.h
@@ -29,19 +29,19 @@ class CUDAStream {};
 #endif
 
 #if defined(PADDLE_WITH_CUSTOM_DEVICE)
-#define STREAM_TYPE phi::stream::Stream*
+#define PY_STREAM_TYPE phi::stream::Stream*
 #elif defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
-#define STREAM_TYPE phi::CUDAStream*
+#define PY_STREAM_TYPE phi::CUDAStream*
 #endif
 
 namespace py = pybind11;
 
 namespace paddle {
 namespace platform {
-#if || defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP) || \
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP) || \
     defined(PADDLE_WITH_CUSTOM_DEVICE)
-STREAM_TYPE get_current_stream(int device_id = -1);
-STREAM_TYPE set_current_stream(STREAM_TYPE stream);
+PY_STREAM_TYPE get_current_stream(int device_id = -1);
+PY_STREAM_TYPE set_current_stream(PY_STREAM_TYPE stream);
 #endif
 }  // namespace platform
 namespace pybind {

--- a/paddle/fluid/pybind/custom_device_py.cc
+++ b/paddle/fluid/pybind/custom_device_py.cc
@@ -355,6 +355,34 @@ void BindCustomDevicePy(py::module *m_ptr) {
                 >>> print(ptr)
 
           )DOC")
+      .def_property_readonly(
+          "cuda_stream",
+          [](const phi::stream::Stream &self) {
+#ifdef PADDLE_WITH_CUSTOM_DEVICE
+            VLOG(10) << self.raw_stream();
+            return reinterpret_cast<std::uintptr_t>(self.raw_stream());
+#else
+        PADDLE_THROW(common::errors::Unavailable(
+            "Paddle is not compiled with CustomDevice. "
+            "Cannot visit CustomDeviceStream."));
+#endif
+          },
+          R"DOC(
+          return the raw stream of type CustomDeviceStream as type int.
+
+          Examples:
+            .. code-block:: python
+
+                >>> # doctest: +REQUIRES(env:CUSTOM_DEVICE)
+                >>> import paddle
+                >>> import ctypes
+                >>> stream  = paddle.device.custom.current_stream().cuda_stream
+                >>> print(stream)
+
+                >>> ptr = ctypes.c_void_p(stream)  # convert back to void*
+                >>> print(ptr)
+
+          )DOC")
       .def_property_readonly("place", [](const phi::stream::Stream &self) {
 #ifdef PADDLE_WITH_CUSTOM_DEVICE
         return reinterpret_cast<const phi::CustomPlace &>(self.GetPlace());

--- a/paddle/fluid/pybind/custom_device_py.cc
+++ b/paddle/fluid/pybind/custom_device_py.cc
@@ -355,34 +355,6 @@ void BindCustomDevicePy(py::module *m_ptr) {
                 >>> print(ptr)
 
           )DOC")
-      .def_property_readonly(
-          "cuda_stream",
-          [](const phi::stream::Stream &self) {
-#ifdef PADDLE_WITH_CUSTOM_DEVICE
-            VLOG(10) << self.raw_stream();
-            return reinterpret_cast<std::uintptr_t>(self.raw_stream());
-#else
-        PADDLE_THROW(common::errors::Unavailable(
-            "Paddle is not compiled with CustomDevice. "
-            "Cannot visit CustomDeviceStream."));
-#endif
-          },
-          R"DOC(
-          return the raw stream of type CustomDeviceStream as type int.
-
-          Examples:
-            .. code-block:: python
-
-                >>> # doctest: +REQUIRES(env:CUSTOM_DEVICE)
-                >>> import paddle
-                >>> import ctypes
-                >>> stream  = paddle.device.custom.current_stream().cuda_stream
-                >>> print(stream)
-
-                >>> ptr = ctypes.c_void_p(stream)  # convert back to void*
-                >>> print(ptr)
-
-          )DOC")
       .def_property_readonly("place", [](const phi::stream::Stream &self) {
 #ifdef PADDLE_WITH_CUSTOM_DEVICE
         return reinterpret_cast<const phi::CustomPlace &>(self.GetPlace());


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Custom Device

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-67164
Add the acquisition method of cudastream in CustomDevice