### PR TITLE
[Accuracy diff No.133] Fix accuracy diff for pow API

### DIFF
--- a/paddle/phi/kernels/funcs/elementwise_functor.h
+++ b/paddle/phi/kernels/funcs/elementwise_functor.h
@@ -1045,6 +1045,10 @@ compute_pow(const T a, const T b) {
   // it will return a float number like 2.99... , which floor to 2
   // when cast to int by default and it is wrong.
   // Use llrint to cast it to the nearest integer, which is 3.
+  T zero = static_cast<T>(0);
+  if (a == zero && b < zero) {
+    return zero;
+  }
   return llrint(pow(static_cast<double>(a), static_cast<double>(b)));
 }
 template <typename T, typename MPType>
@@ -1057,6 +1061,11 @@ compute_pow(const T a, const T b) {
 #else
 template <typename T, typename MPType>
 inline HOSTDEVICE T compute_pow(const T a, const T b) {
+  if constexpr (std::is_integral<T>::value) {
+    if (a == static_cast<T>(0) && b < static_cast<T>(0)) {
+      return static_cast<T>(0);
+    }
+  }
   MPType a_val = static_cast<MPType>(a);
   MPType b_val = static_cast<MPType>(b);
 #ifdef PADDLE_WITH_XPU_KP

--- a/paddle/phi/kernels/gpu/activation_kernel.cu
+++ b/paddle/phi/kernels/gpu/activation_kernel.cu
@@ -208,7 +208,7 @@ void PowKernel(const Context& dev_ctx,
                const DenseTensor& x,
                const Scalar& factor,
                DenseTensor* out) {
-  if (std::is_integral<T>::value) {
+  if constexpr (std::is_integral<T>::value) {
     PADDLE_ENFORCE_GE(
         factor.to<float>(),
         0,

--- a/paddle/phi/kernels/gpu/activation_kernel.cu
+++ b/paddle/phi/kernels/gpu/activation_kernel.cu
@@ -208,6 +208,13 @@ void PowKernel(const Context& dev_ctx,
                const DenseTensor& x,
                const Scalar& factor,
                DenseTensor* out) {
+  if (std::is_integral<T>::value) {
+    PADDLE_ENFORCE_GE(
+        factor.to<float>(),
+        0,
+        common::errors::InvalidArgument(
+            "Integers to negative integer powers are not allowed."));
+  }
   if (factor.to<float>() == 0) {
     std::vector<int64_t> vec_dims = common::vectorize(out->dims());
     phi::Full<T, Context>(

--- a/test/legacy_test/test_elementwise_pow_op.py
+++ b/test/legacy_test/test_elementwise_pow_op.py
@@ -62,6 +62,57 @@ class TestElementwisePowOp(OpTest):
             )
 
 
+class TestElementwisePowOp_ZeroBaseNumber1(TestElementwisePowOp):
+    def setUp(self):
+        self.op_type = "elementwise_pow"
+        self.python_api = paddle.pow
+        self.public_python_api = paddle.pow
+        self.prim_op_type = "prim"
+
+        self.inputs = {
+            'X': np.random.randint(-100, -1, size=[20, 5]).astype("int32"),
+            'Y': np.random.randint(-200, 0, size=[20, 5], dtype="int32"),
+        }
+        self.outputs = {'Out': np.zeros([20, 5]).astype("int32")}
+
+    def test_check_grad_normal(self):
+        pass
+
+
+class TestElementwisePowOp_ZeroBaseNumber2(TestElementwisePowOp):
+    def setUp(self):
+        self.op_type = "elementwise_pow"
+        self.python_api = paddle.pow
+        self.public_python_api = paddle.pow
+        self.prim_op_type = "prim"
+
+        self.inputs = {
+            'X': np.random.randint(2, 100, size=[20, 5]).astype("int32"),
+            'Y': np.random.randint(-200, 0, size=[20, 5], dtype="int32"),
+        }
+        self.outputs = {'Out': np.zeros([20, 5]).astype("int32")}
+
+    def test_check_grad_normal(self):
+        pass
+
+
+class TestElementwisePowOp_ZeroBaseNumber3(TestElementwisePowOp):
+    def setUp(self):
+        self.op_type = "elementwise_pow"
+        self.python_api = paddle.pow
+        self.public_python_api = paddle.pow
+        self.prim_op_type = "prim"
+
+        self.inputs = {
+            'X': np.asarray([-1, 0, 1]),
+            'Y': np.asarray([-1, -1, -1]),
+        }
+        self.outputs = {'Out': np.asarray([-1, 0, 1])}
+
+    def test_check_grad_normal(self):
+        pass
+
+
 class TestElementwisePowOp_ZeroDim1(TestElementwisePowOp):
     def setUp(self):
         self.op_type = "elementwise_pow"


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
跟torch对齐
- 当指数为向量 且为 整数 且为 负数时
a） 底数为 0 时 输出0
b） 底数为1和-1时 输出1和-1
c） 底数为其他整数时 输出0
- 当指数为标量 且为 整数 且为 负数时
a） 输出报错 不允许负数

![截屏2025-06-11 12 23 27](https://github.com/user-attachments/assets/fac561a2-cce9-4750-8599-f425ce1220a4)