### PR TITLE
[0-size Tensor Retest No.2、7、8、10]Fix Output accuracy error for max_pool1d for 0 size Input

### DIFF
--- a/paddle/phi/kernels/gpudnn/pool_kernel.cu
+++ b/paddle/phi/kernels/gpudnn/pool_kernel.cu
@@ -266,9 +266,14 @@ void Pool2dGPUDNNKernel(const Context& dev_ctx,
                         bool adaptive,
                         const std::string& padding_algorithm,
                         DenseTensor* out) {
-  if (x.numel() == 0 && out->numel() != 0 && pooling_type == "max") {
-    phi::Full<T, Context>(
-        dev_ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
+  if (x.numel() == 0) {
+    if (pooling_type == "max") {
+      phi::Full<T, Context>(
+          dev_ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
+    } else {  // for pooling_type == "avg"
+      phi::Full<T, Context>(
+          dev_ctx, phi::IntArray(common::vectorize(out->dims())), NAN, out);
+    }
     return;
   }
   PoolRawGPUDNNKernel<T, Context>(dev_ctx,

--- a/paddle/phi/kernels/gpudnn/pool_kernel.cu
+++ b/paddle/phi/kernels/gpudnn/pool_kernel.cu
@@ -266,6 +266,11 @@ void Pool2dGPUDNNKernel(const Context& dev_ctx,
                         bool adaptive,
                         const std::string& padding_algorithm,
                         DenseTensor* out) {
+  if (x.numel() == 0 && out->numel() != 0 && pooling_type == "max") {
+    phi::Full<T, Context>(
+        dev_ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
+    return;
+  }
   PoolRawGPUDNNKernel<T, Context>(dev_ctx,
                                   x,
                                   kernel_size.GetData(),

--- a/paddle/phi/kernels/impl/pool_kernel_impl.h
+++ b/paddle/phi/kernels/impl/pool_kernel_impl.h
@@ -281,6 +281,11 @@ void Pool2dKernel(const Context& dev_ctx,
                   bool adaptive,
                   const std::string& padding_algorithm,
                   DenseTensor* out) {
+  if (x.numel() == 0 && out->numel() != 0 && pooling_type == "max") {
+    phi::Full<T, Context>(
+        dev_ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
+    return;
+  }
   PoolRawKernel<T, Context>(dev_ctx,
                             x,
                             kernel_size.GetData(),

--- a/paddle/phi/kernels/impl/pool_kernel_impl.h
+++ b/paddle/phi/kernels/impl/pool_kernel_impl.h
@@ -281,9 +281,14 @@ void Pool2dKernel(const Context& dev_ctx,
                   bool adaptive,
                   const std::string& padding_algorithm,
                   DenseTensor* out) {
-  if (x.numel() == 0 && out->numel() != 0 && pooling_type == "max") {
-    phi::Full<T, Context>(
-        dev_ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
+  if (x.numel() == 0) {
+    if (pooling_type == "max") {
+      phi::Full<T, Context>(
+          dev_ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
+    } else {  // for pooling_type == "avg"
+      phi::Full<T, Context>(
+          dev_ctx, phi::IntArray(common::vectorize(out->dims())), NAN, out);
+    }
     return;
   }
   PoolRawKernel<T, Context>(dev_ctx,

--- a/paddle/phi/kernels/xpu/pool_kernel.cc
+++ b/paddle/phi/kernels/xpu/pool_kernel.cc
@@ -35,8 +35,13 @@ void Pool2dKernel(const Context& dev_ctx,
                   const std::string& padding_algorithm,
                   DenseTensor* out) {
   if (x.numel() == 0) {
-    phi::Full<T, Context>(
-        dev_ctx, phi::IntArray(common::vectorize(out->dims())), NAN, out);
+    if (pooling_type == "max") {
+      phi::Full<T, Context>(
+          dev_ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
+    } else {
+      phi::Full<T, Context>(
+          dev_ctx, phi::IntArray(common::vectorize(out->dims())), NAN, out);
+    }
     return;
   }
   using XPUType = typename XPUTypeTrait<T>::Type;

--- a/test/legacy_test/test_pool1d_api.py
+++ b/test/legacy_test/test_pool1d_api.py
@@ -855,6 +855,7 @@ class TestPool1D_API_ZeroSize(unittest.TestCase):
 
     def check_max_dygraph_results(self, place):
         with base.dygraph.guard(place):
+            # test1
             input_np = np.random.random([2, 0, 3]).astype("float32")
             input = paddle.to_tensor(input_np)
             input.stop_gradient = False
@@ -866,6 +867,19 @@ class TestPool1D_API_ZeroSize(unittest.TestCase):
             loss = paddle.sum(result)
             loss.backward()
             np.testing.assert_allclose(input.grad.shape, input.shape)
+            # test2
+            input_np2 = np.random.random([2, 3, 0]).astype("float64")
+            input2 = paddle.to_tensor(input_np2)
+            input2.stop_gradient = False
+            result2 = F.max_pool1d(
+                input2, kernel_size=2, stride=1, padding=[1, 1]
+            )
+            # Torch result is 0.0
+            result_np2 = np.zeros([2, 3, 1], dtype=np.float64)
+            np.testing.assert_allclose(result2.numpy(), result_np2, rtol=1e-05)
+            loss2 = paddle.sum(result2)
+            loss2.backward()
+            np.testing.assert_allclose(input2.grad.shape, input2.shape)
 
     def check_lp_dygraph_results(self, place):
         with base.dygraph.guard(place):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes
### Description
<!-- Describe what you’ve done -->

- paddle.clip 、paddle.nn.functional.max_unpool2d、paddle.allclose 为PaddleAPITest的bug导致的报错。
- 主要修复paddle.nn.functional.max_pool1d 输出时精度和torch对不上的问题。
```paddle.nn.functional.max_pool1d(x=Tensor([2, 3, 0],"float64"), kernel_size=2, stride=1, padding=list[1,1,])```
这个测试case，paddle输出为全nan，torch输出为全0.0

- 由于Pool2dKernel被多个api调用，因此需要通过pooling_type区分是max还是avg，二者初始化的值不同。
- PaddleAPITest回测结果：
![image](https://github.com/user-attachments/assets/21dedda5-1213-4480-9727-647606421a45)

pcard-67164
<br class="Apple-interchange-newline">


<br class="Apple-interchange-newline">


<br class="Apple-interchange-newline">

<br class="Apple-interchange-newline">

