### PR TITLE
[SOT] Mark more APIs as unified (`all_reduce`, `top_p_sampling`, etc.)

### DIFF
--- a/python/paddle/distributed/fleet/layers/mpu/mp_ops.py
+++ b/python/paddle/distributed/fleet/layers/mpu/mp_ops.py
@@ -28,10 +28,10 @@ from paddle.framework import (
     in_dynamic_or_pir_mode,
     in_pir_mode,
 )
+from paddle.jit.marker import unified
 from paddle.nn import Layer
 from paddle.nn.utils import dygraph_utils
 
-from .....jit.marker import unified
 from ....communication.reduce import ReduceOp, _get_reduce_op
 
 if TYPE_CHECKING:

--- a/python/paddle/jit/sot/opcode_translator/executor/pycode_generator.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/pycode_generator.py
@@ -1034,7 +1034,9 @@ class ResumeFunctionCreator:
     @staticmethod
     def validate_code(code):
         if len(code.co_freevars) + len(code.co_cellvars) > 0:
-            raise FallbackError("Break graph in closure is not support.")
+            raise FallbackError(
+                f"Break graph in closure is not support.\n`co_freevars`: {code.co_freevars}\n`co_cellvars`: {code.co_cellvars}"
+            )
 
     def lookup(self, cache_key):
         if cache_key in self.CODE_CACHE:

--- a/python/paddle/jit/sot/utils/paddle_api_config.py
+++ b/python/paddle/jit/sot/utils/paddle_api_config.py
@@ -52,6 +52,7 @@ def get_paddle_api():
         paddle.geometric,
     ]
     distributed_apis = [
+        paddle.distributed.all_reduce,
         paddle.distributed.shard_tensor,
         paddle.distributed.reshard,
         paddle.distributed.all_gather,

--- a/python/paddle/jit/sot/utils/paddle_api_config.py
+++ b/python/paddle/jit/sot/utils/paddle_api_config.py
@@ -54,13 +54,22 @@ def get_paddle_api():
     distributed_apis = [
         paddle.distributed.shard_tensor,
         paddle.distributed.reshard,
+        paddle.distributed.all_gather,
+        paddle.distributed.alltoall,
+        paddle.distributed.barrier,
+        paddle.distributed.recv,
+        paddle.distributed.send,
+        paddle.distributed.broadcast,
         paddle.distributed.unshard_dtensor,
         paddle.distributed.auto_parallel.api.dtensor_to_local,
         paddle.distributed.auto_parallel.api.dtensor_from_local,
         paddle.distributed.auto_parallel.api.moe_global_mesh_tensor,
         paddle.distributed.auto_parallel.api.moe_sub_mesh_tensors,
     ]
-    special_paddle_apis = [paddle.tensor.fill_constant]
+    special_paddle_apis = [
+        paddle.tensor.fill_constant,
+        paddle.tensor.top_p_sampling,
+    ]
     non_operator_related_apis = [
         paddle.in_dynamic_mode,
         paddle.save,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
开启SOT转静，能使减少通信 `all_reduce` 的调度时间，在 SOT 中将 `all_reduce` 转换为 `PaddleApiVariable`

cc @SigureMo
PCard-66972