### PR TITLE
[PHI] Fix masked_fill & masked_fill_grad kernel for big tensor

### DIFF
--- a/paddle/phi/kernels/gpu/masked_fill_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/masked_fill_grad_kernel.cu
@@ -40,7 +40,7 @@ __global__ void GPUMaskedFillGradKernel(const T* out_grad,
                                         const int64_t input_len,
                                         const int64_t batch_size,
                                         T* x_grad) {
-  int64_t idx = (blockIdx.x * blockDim.x + threadIdx.x);
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
 
   if (idx >= (input_len / VecSize)) {
     return;

--- a/paddle/phi/kernels/gpu/masked_fill_kernel.cu
+++ b/paddle/phi/kernels/gpu/masked_fill_kernel.cu
@@ -37,7 +37,7 @@ __global__ void GPUMaskedFillKernel(const T* input,
                                     const int64_t input_len,
                                     const int64_t batch_size,
                                     T* output) {
-  int64_t idx = (blockIdx.x * blockDim.x + threadIdx.x);
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
 
   if (idx >= (input_len / VecSize)) {
     return;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Operator Mechanism


### PR Types
Bug fixes


### Description
修复`masked_fill`和`masked_fill_grad`Kernel的大Tensor问题

这两个Kernel竟然是3周前 https://github.com/PaddlePaddle/Paddle/pull/72788 才实现的，还出现乘法没有提前cast的错误，我们写Kernel的时候还是要注意一些

可通过error_log里全部11个case

Pcard-85711
