### PR TITLE
[Accuracy diff No.68, 147] Fix accuracy diff for paddle.Tensor.set_ API

### DIFF
--- a/paddle/phi/kernels/set_kernel.cc
+++ b/paddle/phi/kernels/set_kernel.cc
@@ -32,9 +32,6 @@ void SetKernel(const Context& dev_ctx,
   if (x.IsSharedWith(source)) {
     out->set_meta(meta);
   } else {
-    // // reset holder to nullptr
-    // out->clear();
-    // *out = DenseTensor{source.Holder(), meta};
     phi::Full<T, Context>(dev_ctx, phi::IntArray(dims), 0, out);
     out->ResetHolder(source.Holder());
     out->set_meta(meta);

--- a/paddle/phi/kernels/set_kernel.cc
+++ b/paddle/phi/kernels/set_kernel.cc
@@ -29,13 +29,11 @@ void SetKernel(const Context& dev_ctx,
   meta.dims = DDim(dims.data(), static_cast<int>(dims.size()));
   meta.strides = DDim(stride.data(), static_cast<int>(stride.size()));
   meta.offset = offset;
-  if (x.IsSharedWith(source)) {
-    out->set_meta(meta);
-  } else {
+  if (!x.IsSharedWith(source)) {
     phi::Full<T, Context>(dev_ctx, phi::IntArray(dims), 0, out);
     out->ResetHolder(source.Holder());
-    out->set_meta(meta);
   }
+  out->set_meta(meta);
   out->ShareInplaceVersionCounterWith(x);
 }
 

--- a/paddle/phi/kernels/set_kernel.cc
+++ b/paddle/phi/kernels/set_kernel.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 #include "paddle/phi/kernels/set_kernel.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/full_kernel.h"
 
 namespace phi {
 
@@ -31,9 +32,12 @@ void SetKernel(const Context& dev_ctx,
   if (x.IsSharedWith(source)) {
     out->set_meta(meta);
   } else {
-    // reset holder to nullptr
-    out->clear();
-    *out = DenseTensor{source.Holder(), meta};
+    // // reset holder to nullptr
+    // out->clear();
+    // *out = DenseTensor{source.Holder(), meta};
+    phi::Full<T, Context>(dev_ctx, phi::IntArray(dims), 0, out);
+    out->ResetHolder(source.Holder());
+    out->set_meta(meta);
   }
   out->ShareInplaceVersionCounterWith(x);
 }

--- a/test/legacy_test/test_inplace.py
+++ b/test/legacy_test/test_inplace.py
@@ -2222,6 +2222,15 @@ class TestDygraphInplaceSet(unittest.TestCase):
 
             self.assertRaises(ValueError, leaf_inplace_error)
 
+    def test_api_accuracy(self):
+        for dtype in self.support_dtypes:
+            for place in self.places:
+                with paddle.base.dygraph.guard():
+                    x = paddle.randn([3, 8], dtype=dtype)
+                    src = paddle.randn([6, 3], dtype=dtype)
+                    x.set_(src, [3, 8], [2, 2], 0)
+                    self.assertEqual(x.numpy()[2, 7], 0.0)
+
 
 @unittest.skipIf(
     not paddle.base.core.is_compiled_with_cuda()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
```
![image](https://github.com/user-attachments/assets/9ef0cce9-8a84-489a-96ee-565903aa241d)
![image](https://github.com/user-attachments/assets/623742f8-cb88-40f5-b81a-518b0b216e46)
精度差异的原因应该是原kernel的实现导致内存重叠了，修改了一下实现方法。

回测结果：
![image](https://github.com/user-attachments/assets/1b4166ff-84d0-42e0-94fb-9691980525a3)
```
update:
aistudio 复现 PaddleAPITest 的问题原因是 torch.Tensor.set_ 会有内存重叠的问题，paddle.Tensor.set_ 不会：
![image](https://github.com/user-attachments/assets/1b9c06d7-8e1d-4776-b9dd-1e6bded51a8f)

但在本机(windows)上发现 torch.Tensor.set_ **不会产生**内存重叠的问题
![image](https://github.com/user-attachments/assets/60f3b7bc-6ec3-4eeb-b0df-52d2757ef04a)

本机 gpu 上 paddle.Tensor.set_ **不会产生**
![image](https://github.com/user-attachments/assets/0ed221a8-f494-4d04-850e-c174b0fcf071)

本机 cpu 上 paddle.Tensor.set_ **会产生**
![image](https://github.com/user-attachments/assets/a1ba82a7-ea29-42d2-a59e-3117b3ce4d26)

不知道这个问题和系统是否有关
