### PR TITLE
[Accuracy diff No.103] Fix accuracy diff for paddle.linalg.matrix_rank API

### DIFF
--- a/paddle/phi/kernels/cpu/matrix_rank_tol_kernel.cc
+++ b/paddle/phi/kernels/cpu/matrix_rank_tol_kernel.cc
@@ -172,7 +172,7 @@ void MatrixRankTolKernel(const Context& dev_ctx,
   if (eigenvalue_tensor.dims().size() >= tol_tensor.dims().size()) {
     funcs::ElementwiseCompute<funcs::GreaterThanFunctor<RealType, int64_t>,
                               RealType,
-                              int>(
+                              int64_t>(
         dev_ctx,
         eigenvalue_tensor,
         tol_tensor,
@@ -182,12 +182,13 @@ void MatrixRankTolKernel(const Context& dev_ctx,
   } else {
     funcs::ElementwiseCompute<funcs::LessThanFunctor<RealType, int64_t>,
                               RealType,
-                              int>(dev_ctx,
-                                   eigenvalue_tensor,
-                                   tol_tensor,
-                                   funcs::LessThanFunctor<RealType, int64_t>(),
-                                   &compare_result,
-                                   axis);
+                              int64_t>(
+        dev_ctx,
+        eigenvalue_tensor,
+        tol_tensor,
+        funcs::LessThanFunctor<RealType, int64_t>(),
+        &compare_result,
+        axis);
   }
 
   phi::SumKernel<int64_t>(dev_ctx,
@@ -315,7 +316,7 @@ void MatrixRankAtolRtolKernel(const Context& dev_ctx,
   if (eigenvalue_tensor.dims().size() >= tol_tensor.dims().size()) {
     funcs::ElementwiseCompute<funcs::GreaterThanFunctor<RealType, int64_t>,
                               RealType,
-                              int>(
+                              int64_t>(
         dev_ctx,
         eigenvalue_tensor,
         tol_tensor,
@@ -325,12 +326,13 @@ void MatrixRankAtolRtolKernel(const Context& dev_ctx,
   } else {
     funcs::ElementwiseCompute<funcs::LessThanFunctor<RealType, int64_t>,
                               RealType,
-                              int>(dev_ctx,
-                                   eigenvalue_tensor,
-                                   tol_tensor,
-                                   funcs::LessThanFunctor<RealType, int64_t>(),
-                                   &compare_result,
-                                   axis);
+                              int64_t>(
+        dev_ctx,
+        eigenvalue_tensor,
+        tol_tensor,
+        funcs::LessThanFunctor<RealType, int64_t>(),
+        &compare_result,
+        axis);
   }
 
   phi::SumKernel<int64_t>(dev_ctx,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
set matrix_rank output dtype to int64(default integer data type)
same as torch and numpy and [array-api](https://data-apis.org/array-api/2024.12/extensions/generated/array_api.linalg.matrix_rank.html#matrix-rank)

PaddleAPITest 测试通过
![图片](https://github.com/user-attachments/assets/9371145d-0f03-4e87-8a85-6d3bb847307c)
