### PR TITLE
[0-size Tensor Job2 No.6] Add 0-size Tensor support for crop

### DIFF
--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.cc
@@ -795,7 +795,9 @@ bool CropOpInferSymbolicShape(pir::Operation *op,
 
   for (size_t i = 0; i < in_shape.size(); ++i) {
     if (in_shape[i].isa<int64_t>()) {
-      if (in_shape[i].Get<int64_t>() == -1) {
+      if (x_shape[i].Get<int64_t>() == 0) {  // x is 0-size
+        out_dims.push_back(symbol::DimExpr(x_shape[i]));
+      } else if (in_shape[i].Get<int64_t>() == -1) {
         out_dims.push_back(symbol::DimExpr(x_shape[i] - offsets[i]));
       } else {
         out_dims.push_back(symbol::DimExpr(in_shape[i]));

--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -784,7 +784,9 @@ void CropInferMeta(const MetaTensor& x,
 
   auto out_dims = std::vector<int64_t>(shape.size(), -1);
   for (int i = 0; i < static_cast<int>(shape_dims.size()); ++i) {
-    if (shape_dims[i] > 0) {
+    if (x_dim[i] == 0) {
+      out_dims[i] = static_cast<int64_t>(x_dim[i]);
+    } else if (shape_dims[i] >= 0) {
       out_dims[i] = static_cast<int64_t>(shape_dims[i]);
     }
   }

--- a/paddle/phi/kernels/impl/crop_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/crop_grad_kernel_impl.h
@@ -20,9 +20,9 @@
 #include <vector>
 
 #include "paddle/phi/core/tensor_utils.h"
+#include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/funcs/eigen/common.h"
 #include "paddle/phi/kernels/funcs/eigen/eigen_function.h"
-
 namespace phi {
 
 template <typename Context, typename T, size_t D>
@@ -57,6 +57,12 @@ void CropGradKernel(const Context& dev_ctx,
                     const DenseTensor& x,
                     const IntArray& offsets,
                     DenseTensor* x_grad) {
+  // x[3, 5], shape[2, 0], out[2, 0]
+  if (out_grad.numel() == 0 && x_grad != nullptr) {
+    phi::Full<T, Context>(
+        dev_ctx, phi::IntArray(common::vectorize(x_grad->dims())), 0, x_grad);
+    return;
+  }
   size_t rank = out_grad.dims().size();
   PADDLE_ENFORCE_GE(
       rank,

--- a/paddle/phi/kernels/impl/crop_kernel_impl.h
+++ b/paddle/phi/kernels/impl/crop_kernel_impl.h
@@ -142,6 +142,10 @@ void CropKernel(const Context& dev_ctx,
                 const IntArray& shape,
                 const IntArray& offsets,
                 DenseTensor* out) {
+  if (out && out->numel() == 0) {
+    dev_ctx.template Alloc<T>(out);
+    return;
+  }
   int rank = x.dims().size();
   PADDLE_ENFORCE_GE(
       rank,

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -907,10 +907,6 @@ def crop(
             raise TypeError(
                 f"Attr(shape)'s dtype of Op(crop_tensor) should be int32, but received: {type(shape_val)}."
             )
-        if shape_val == 0:
-            raise ValueError(
-                f"Attr(shape) of Op(crop_tensor) should not be zero, but received: {shape_val}."
-            )
         if shape_val < -1:
             raise ValueError(
                 f"When the element in Attr(shape) of Op(crop_tensor) is negative, only -1 is supported, but received: {shape_val}."

--- a/test/legacy_test/test_crop_tensor_op.py
+++ b/test/legacy_test/test_crop_tensor_op.py
@@ -57,17 +57,18 @@ class TestCropTensorOp(OpTest):
         self.unk_dim_idx = -1
         self.attrs = {}
         self.python_api = paddle.crop
+        self.dtype = "float64"
         self.initTestCase()
 
         if self.shape_by_input:
             self.inputs = {
-                'X': np.random.random(self.x_shape).astype("float64"),
+                'X': np.random.random(self.x_shape).astype(self.dtype),
                 'Shape': np.array(self.crop_shape).astype("int32"),
             }
         else:
             self.attrs['shape'] = self.crop_shape
             self.inputs = {
-                'X': np.random.random(self.x_shape).astype("float64"),
+                'X': np.random.random(self.x_shape).astype(self.dtype),
             }
         if self.offset_by_input:
             self.inputs['Offsets'] = np.array(self.offsets).astype('int32')
@@ -150,6 +151,7 @@ class TestCase6(TestCropTensorOp):
 
 class TestCase_ZeroSize(TestCropTensorOp):
     def initTestCase(self):
+        self.__class__.exist_fp64_check_grad = True
         self.x_shape = (0, 0, 5, 8, 8)
         self.crop_shape = [1, 1, 2, 4, 4]
         self.offsets = [1, 0, 0, 2, 2]
@@ -158,10 +160,17 @@ class TestCase_ZeroSize(TestCropTensorOp):
 
 class TestCase_ZeroSize2(TestCropTensorOp):
     def initTestCase(self):
+        self.__class__.exist_fp64_check_grad = True
+        # x_grad return NAN
         self.x_shape = (2, 4, 5, 8, 8)
         self.crop_shape = [0, 0, 2, 4, 4]
         self.offsets = [1, 0, 0, 2, 2]
         self.offset_by_input = True
+        self.dtype = "float32"
+
+    def test_check_grad_normal(self):
+        grad = paddle.zeros(self.x_shape).numpy()
+        self.check_grad(['X'], 'Out', user_defined_grads=[grad], check_pir=True)
 
 
 class TestCropTensorOpTensorAttr(OpTest):
@@ -263,6 +272,7 @@ class TestCropTensorOpTensorAttrCase4(TestCropTensorOpTensorAttr):
 class TestCropTensorException(unittest.TestCase):
 
     def test_exception(self):
+        paddle.enable_static()
         input1 = paddle.static.data(
             name="input1", shape=[2, 3, 6, 6], dtype="float32"
         )
@@ -280,9 +290,6 @@ class TestCropTensorException(unittest.TestCase):
 
         def attr_shape_value1():
             out = paddle.crop(input1, shape=[2, -2, dim, 3])
-
-        def attr_shape_value2():
-            out = paddle.crop(input1, shape=[2, 0, dim, 3])
 
         def attr_offsets_type():
             out = paddle.crop(input1, shape=[2, 2, 3, 3], offsets=0)
@@ -303,7 +310,6 @@ class TestCropTensorException(unittest.TestCase):
         self.assertRaises(TypeError, attr_shape_type)
         self.assertRaises(TypeError, attr_shape_dtype)
         self.assertRaises(ValueError, attr_shape_value1)
-        self.assertRaises(ValueError, attr_shape_value2)
         self.assertRaises(TypeError, attr_offsets_type)
         self.assertRaises(TypeError, attr_offsets_dtype)
         self.assertRaises(ValueError, attr_offsets_value)
@@ -312,6 +318,7 @@ class TestCropTensorException(unittest.TestCase):
 
 class TestCropWithUnknownShape(unittest.TestCase):
     def test_crop_with_unknown_shape(self):
+        paddle.enable_static()
         main_program = paddle.static.Program()
         with paddle.static.program_guard(main_program):
             x = paddle.static.data(name='x', shape=[-1, 4, 4], dtype='float32')
@@ -323,7 +330,7 @@ class TestCropWithUnknownShape(unittest.TestCase):
             (out_np,) = exe.run(
                 feed={'x': x_np, 'shape': shape_np}, fetch_list=[out]
             )
-            self.assertEqual(out.shape, [-1, -1, -1])
+            self.assertEqual(tuple(out.shape), (-1, -1, -1))
             self.assertEqual(out_np.shape, (2, 2, 2))
 
 

--- a/test/legacy_test/test_crop_tensor_op.py
+++ b/test/legacy_test/test_crop_tensor_op.py
@@ -41,6 +41,11 @@ def crop(data, offsets, crop_shape):
                 )
             if selected:
                 result.append(value)
+    # data 0-size
+    if 0 in data.shape:
+        for i, value in enumerate(data.shape):
+            if value == 0:
+                crop_shape[i] = 0
     return np.array(result).reshape(crop_shape)
 
 
@@ -141,6 +146,22 @@ class TestCase6(TestCropTensorOp):
 
     def test_check_output(self):
         self.check_output(check_pir=True, check_symbol_infer=False)
+
+
+class TestCase_ZeroSize(TestCropTensorOp):
+    def initTestCase(self):
+        self.x_shape = (0, 0, 5, 8, 8)
+        self.crop_shape = [1, 1, 2, 4, 4]
+        self.offsets = [1, 0, 0, 2, 2]
+        self.offset_by_input = True
+
+
+class TestCase_ZeroSize2(TestCropTensorOp):
+    def initTestCase(self):
+        self.x_shape = (2, 4, 5, 8, 8)
+        self.crop_shape = [0, 0, 2, 4, 4]
+        self.offsets = [1, 0, 0, 2, 2]
+        self.offset_by_input = True
 
 
 class TestCropTensorOpTensorAttr(OpTest):

--- a/test/legacy_test/test_crop_tensor_op.py
+++ b/test/legacy_test/test_crop_tensor_op.py
@@ -160,6 +160,7 @@ class TestCase_ZeroSize(TestCropTensorOp):
 
 class TestCase_ZeroSize2(TestCropTensorOp):
     def initTestCase(self):
+        paddle.disable_static()
         self.__class__.exist_fp64_check_grad = True
         # x_grad return NAN
         self.x_shape = (2, 4, 5, 8, 8)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->

[0-size Tensor Job2 No.6] Add 0-size Tensor support for crop
修改infermeta，symbolic 符号推导，如果输入维度为0，输出维度设置为0，而不是和参数shape相同
单测中去掉原有0维度抛异常的单测
因为torch中没有对应torch.crop比较，反向使用自定义全0测试

PaddleAPITest 测试

CPU测试通过
![image](https://github.com/user-attachments/assets/f66f1413-5e30-430d-af3f-0c324972486d)
GPU测试通过
![image](https://github.com/user-attachments/assets/6fb60961-9006-4211-a689-3239c568a7c2)
