### PR TITLE
add feature _only_reshard_mesh_shape and get_local_slice

### DIFF
--- a/python/paddle/distributed/auto_parallel/api.py
+++ b/python/paddle/distributed/auto_parallel/api.py
@@ -81,6 +81,7 @@ from .moe_utils import (
     _dist_reshape,
     _dtensor_from_local,
     _NdMeshAlltoAll,
+    _only_reshard_mesh_shape,
     _reshard_mesh_shape,
     _specific_alltoall_dim,
 )
@@ -850,6 +851,8 @@ def reshard(
             >>> print(out_d_tensor)
 
     """
+    if _only_reshard_mesh_shape(dist_tensor, mesh, placements):
+        return _reshard_mesh_shape(dist_tensor, mesh, placements)
 
     if paddle.framework.in_dynamic_mode():
         # TODO(LiYuRio): static logic here, reshard should be changed for dygraph logic

--- a/python/paddle/distributed/auto_parallel/moe_utils.py
+++ b/python/paddle/distributed/auto_parallel/moe_utils.py
@@ -358,6 +358,126 @@ def _dist_reshape(
         )
 
 
+def get_sub_meshes_for_shard(mesh, mesh_dim):
+    process_ids = np.array(mesh.process_ids).reshape(mesh.shape)
+    num_shards = mesh.shape[mesh_dim]
+
+    sub_meshes = []
+    for i in range(num_shards):
+        coords = [slice(None)] * len(mesh.shape)
+        coords[mesh_dim] = i
+        sub_process_ids = process_ids[tuple(coords)].flatten().tolist()
+        new_shape = list(mesh.shape)
+        new_shape[mesh_dim] = 1
+        sub_mesh = dist.ProcessMesh(
+            shape=new_shape,
+            process_ids=sub_process_ids,
+            dim_names=mesh.dim_names,
+        )
+        sub_meshes.append(sub_mesh)
+    return sub_meshes
+
+
+def shard_submesh_and_slice(mesh, tensor_slice, tensor_dim, mesh_dim):
+    new_sub_meshes = get_sub_meshes_for_shard(mesh, mesh_dim)
+    num_shards = len(new_sub_meshes)
+
+    total_size = tensor_slice[tensor_dim][1] - tensor_slice[tensor_dim][0]
+    shard_size = (total_size + num_shards - 1) // num_shards
+    effective_size = shard_size * (num_shards - 1)
+    last_shard_size = total_size - effective_size
+
+    new_slices = []
+    for i in range(num_shards):
+        start = tensor_slice[tensor_dim][0] + i * shard_size
+        if i == num_shards - 1:
+            end = min(start + last_shard_size, tensor_slice[tensor_dim][1])
+        else:
+            end = min(start + shard_size, tensor_slice[tensor_dim][1])
+        new_slice = list(tensor_slice)
+        new_slice[tensor_dim] = (start, end)
+        new_slices.append(tuple(new_slice))
+    return new_sub_meshes, new_slices
+
+
+def get_rank2tensor_indices(sub_mesh2tensor_indices):
+    rank2tensor_indices = {}
+    for sub_mesh, info in sub_mesh2tensor_indices.items():
+        for rank in sub_mesh.process_ids:
+            rank2tensor_indices[rank] = {
+                'slice': info['slice'],
+                'partial': info['partial'],
+            }
+    return rank2tensor_indices
+
+
+def get_local_slices(tensor, mesh, placements):
+    if len(mesh.shape) != len(placements):
+        raise ValueError(
+            f"placements nums ({len(placements)}) must equal mesh_shape({len(mesh.shape)})"
+        )
+
+    sub_mesh2tensor_indices = {
+        mesh: {'slice': [(0, s) for s in tensor.shape], 'partial': {}}
+    }
+    for mesh_dim, placement in enumerate(placements):
+        new_sub_mesh2tensor_indices = {}
+
+        if placement.is_shard():
+            tensor_dim = placement.get_dim()
+
+            for sub_mesh, info in sub_mesh2tensor_indices.items():
+                new_sub_meshes, new_slices = shard_submesh_and_slice(
+                    sub_mesh, info['slice'], tensor_dim, mesh_dim
+                )
+                for new_sub_mesh, new_slice in zip(new_sub_meshes, new_slices):
+                    new_sub_mesh2tensor_indices[new_sub_mesh] = {
+                        'slice': new_slice,
+                        'partial': info['partial'].copy(),
+                    }
+        elif hasattr(placement, 'is_partial') and placement.is_partial():
+            for sub_mesh, info in sub_mesh2tensor_indices.items():
+                new_partial = info['partial'].copy()
+                new_partial[mesh_dim] = placement.reduce_type()
+                new_sub_mesh2tensor_indices[sub_mesh] = {
+                    'slice': info['slice'],
+                    'partial': new_partial,
+                }
+        else:
+            for sub_mesh, info in sub_mesh2tensor_indices.items():
+                new_sub_mesh2tensor_indices[sub_mesh] = info.copy()
+
+        sub_mesh2tensor_indices = new_sub_mesh2tensor_indices
+    return get_rank2tensor_indices(sub_mesh2tensor_indices)
+
+
+def _only_reshard_mesh_shape(
+    dist_tensor: Tensor, mesh: ProcessMesh, placements: list[Placement]
+):
+    if not os.getenv("FLAGS_enable_moe_utils") == "true":
+        return False
+
+    if paddle.in_dynamic_mode():
+        src_placements = dist_tensor.placements
+        src_mesh = dist_tensor.process_mesh
+    elif paddle.framework.in_pir_mode():
+        src_placements = dist_tensor.dist_attr().placements_attr
+        src_mesh = dist_tensor.dist_attr().process_mesh
+    else:
+        raise NotImplementedError(
+            "_only_reshard_mesh_shape is only supported in dynamic and pir mode."
+        )
+    if src_mesh == mesh or src_mesh.process_ids != mesh.process_ids:
+        return False
+    src_rank2tensor_indices = get_local_slices(
+        dist_tensor, src_mesh, src_placements
+    )
+    dst_rank2tensor_indices = get_local_slices(dist_tensor, mesh, placements)
+    if src_rank2tensor_indices != dst_rank2tensor_indices:
+        return False
+    return True
+
+
 def _reshard_mesh_shape(
     dist_tensor: Tensor, mesh: ProcessMesh, placements: list[Placement]
 ):

--- a/test/auto_parallel/semi_auto_parallel_moe_utils.py
+++ b/test/auto_parallel/semi_auto_parallel_moe_utils.py
@@ -119,10 +119,33 @@ class TestMoEUtils:
             dist_y._local_value().numpy(), dist_x._local_value().numpy()
         )
 
+    def test_get_local_slices(self):
+        (h, w) = (4, 4)
+        src_shape = [h, w]
+        x = paddle.arange(0, h * w).reshape(src_shape)
+        placements = [dist.Shard(0), dist.Partial()]
+        dist_x = dist.shard_tensor(x, self._mesh0, placements)
+        dist_x_local_slices = dist.auto_parallel.moe_utils.get_local_slices(
+            x, self._mesh0, placements
+        )
+        if dist.get_rank() == 0:
+            assert dist_x_local_slices[0]['slice'] == ((0, 2), (0, 4))
+            assert (
+                dist_x_local_slices[0]['partial'][1]
+                == dist_x.placements[1].reduce_type()
+            )
+        if dist.get_rank() == 1:
+            assert dist_x_local_slices[1]['slice'] == ((2, 4), (0, 4))
+            assert (
+                dist_x_local_slices[1]['partial'][1]
+                == dist_x.placements[1].reduce_type()
+            )
+
     def run_test_case(self):
         self.test_local_reshape()
         self.test_nd_mesh_alltoall()
         self.test_reshard_mesh_shape()
+        self.test_get_local_slices()
 
 
 if __name__ == '__main__':

--- a/test/auto_parallel/semi_auto_parallel_moe_utils.py
+++ b/test/auto_parallel/semi_auto_parallel_moe_utils.py
@@ -1,34 +1,32 @@
-# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 import os
 import unittest
-
 import numpy as np
-
 import paddle
 import paddle.distributed as dist
+from paddle.distributed.auto_parallel.moe_utils import (
+    get_sub_meshes_for_shard,
+    shard_submesh_and_slice,
+    get_rank2tensor_indices,
+    get_local_slices,
+    _only_reshard_mesh_shape,
+)
 
+class TestMoEUtils(unittest.TestCase):
+    def __init__(self, methodName='runTest'):
+        super().__init__(methodName)
+        self._dtype = os.getenv("dtype", "float32")
+        self._seed = eval(os.getenv("seed", "2024"))
+        self._backend = os.getenv("backend", "gpu")
+        self._mesh0 = dist.ProcessMesh([[0], [1]], dim_names=["x", "y"])  # 2x1
+        self._mesh1 = dist.ProcessMesh([[0, 1]], dim_names=["x", "y"])   # 1x2
+        self._mesh2 = dist.ProcessMesh([0, 1], dim_names=["x"])          # 1D mesh with 2 processes
+        paddle.seed(self._seed)
 
-class TestMoEUtils:
-    def __init__(self):
-        self._dtype = os.getenv("dtype")
-        self._seed = eval(os.getenv("seed"))
-        self._backend = os.getenv("backend")
-        self._mesh0 = dist.ProcessMesh([[0], [1]], dim_names=["x", "y"])
-        self._mesh1 = dist.ProcessMesh([[0, 1]], dim_names=["x", "y"])
+    def setUp(self):
+        # Ensure the environment flag is set for _only_reshard_mesh_shape
+        os.environ["FLAGS_enable_moe_utils"] = "true"
 
+    # Existing tests (unchanged)
     def test_local_reshape(self):
         (h, w) = (4, 4)
         src_shape = [h, w]
@@ -44,11 +42,11 @@ class TestMoEUtils:
             dist_x, [-1, w * 2], self._mesh0, [dist.Shard(1), dist.Replicate()]
         )
 
-        split_np_x = np.split(np_x, 2, axis=1)
-        for i in range(len(split_np_x)):
-            split_np_x[i] = split_np_x[i].reshape([h // 2, w])
+        splitted_np_x = np.split(np_x, 2, axis=1)
+        for i in range(len(splitted_np_x)):
+            splitted_np_x[i] = splitted_np_x[i].reshape([h // 2, w])
         np.testing.assert_array_equal(
-            split_np_x[dist.get_rank()], dist_y._local_value().numpy()
+            splitted_np_x[dist.get_rank()], dist_y._local_value().numpy()
         )
 
         label = paddle.ones(tgt_shape, dtype=paddle.int64)
@@ -60,13 +58,13 @@ class TestMoEUtils:
         loss.backward()
 
         np_grad = np.ones(src_shape, dtype="int64")
-        split_np_grad = np.split(np_grad, 2, axis=1)
+        splitted_np_grad = np.split(np_grad, 2, axis=1)
         np.testing.assert_array_equal(
-            split_np_grad[dist.get_rank()],
+            splitted_np_grad[dist.get_rank()],
             dist_x.grad._local_value().numpy(),
         )
 
-        with unittest.TestCase().assertRaises(AssertionError):
+        with self.assertRaises(AssertionError):
             dist_z = dist.auto_parallel.moe_utils._dist_reshape(
                 dist_x,
                 dist_x.shape,
@@ -74,7 +72,6 @@ class TestMoEUtils:
                 [dist.Replicate(), dist.Replicate()],
             )
 
-        # test the warning log message
         dist_z = dist.auto_parallel.moe_utils._dist_reshape(
             dist_x, dist_x.shape, self._mesh0, [dist.Shard(1), dist.Shard(1)]
         )
@@ -93,12 +90,12 @@ class TestMoEUtils:
         )
         dist_y.backward()
 
-        assert dist_y.placements == [dist.Shard(0), dist.Replicate()]
-        assert dist_x.grad.placements == [dist.Shard(1), dist.Replicate()]
+        self.assertEqual(dist_y.placements, [dist.Shard(0), dist.Replicate()])
+        self.assertEqual(dist_x.grad.placements, [dist.Shard(1), dist.Replicate()])
         np_grad = np.ones(src_shape, dtype="int64")
-        split_np_grad = np.split(np_grad, 2, axis=1)
+        splitted_np_grad = np.split(np_grad, 2, axis=1)
         np.testing.assert_array_equal(
-            split_np_grad[dist.get_rank()],
+            splitted_np_grad[dist.get_rank()],
             dist_x.grad._local_value().numpy(),
         )
 
@@ -114,7 +111,7 @@ class TestMoEUtils:
             dist_x, self._mesh1, [dist.Replicate(), dist.Replicate()]
         )
 
-        assert dist_y.process_mesh == self._mesh1
+        self.assertEqual(dist_y.process_mesh, self._mesh1)
         np.testing.assert_array_equal(
             dist_y._local_value().numpy(), dist_x._local_value().numpy()
         )
@@ -124,29 +121,139 @@ class TestMoEUtils:
         src_shape = [h, w]
         x = paddle.arange(0, h * w).reshape(src_shape)
         placements = [dist.Shard(0), dist.Partial()]
-        dist_x = dist.shard_tensor(x, self._mesh0, placements)
-        dist_x_local_slices = dist.auto_parallel.moe_utils.get_local_slices(
+        dist_x = dist.shard_tensor(
             x, self._mesh0, placements
         )
+        dist_x_local_slices = get_local_slices(x, self._mesh0, placements)
         if dist.get_rank() == 0:
-            assert dist_x_local_slices[0]['slice'] == ((0, 2), (0, 4))
-            assert (
-                dist_x_local_slices[0]['partial'][1]
-                == dist_x.placements[1].reduce_type()
-            )
+            self.assertEqual(dist_x_local_slices[0]['slice'], ((0, 2), (0, 4)))
+            self.assertEqual(dist_x_local_slices[0]['partial'][1], dist_x.placements[1].reduce_type())
         if dist.get_rank() == 1:
-            assert dist_x_local_slices[1]['slice'] == ((2, 4), (0, 4))
-            assert (
-                dist_x_local_slices[1]['partial'][1]
-                == dist_x.placements[1].reduce_type()
-            )
+            self.assertEqual(dist_x_local_slices[1]['slice'], ((2, 4), (0, 4)))
+            self.assertEqual(dist_x_local_slices[1]['partial'][1], dist_x.placements[1].reduce_type())
+
+    # New tests to increase coverage
+    def test_reshard_general_case(self):
+        """Test reshard when _only_reshard_mesh_shape returns False."""
+        (h, w) = (4, 4)
+        x = paddle.arange(0, h * w, dtype=self._dtype).reshape([h, w])
+        dist_x = dist.shard_tensor(x, self._mesh0, [dist.Shard(0), dist.Replicate()])
+        dist_y = dist.reshard(dist_x, self._mesh1, [dist.Replicate(), dist.Shard(1)])
+        
+        if dist.get_rank() == 0:
+            expected_y = x[:, :2]  # Process 0 gets first half of axis 1
+            np.testing.assert_array_equal(dist_y._local_value().numpy(), expected_y.numpy())
+        elif dist.get_rank() == 1:
+            expected_y = x[:, 2:]  # Process 1 gets second half of axis 1
+            np.testing.assert_array_equal(dist_y._local_value().numpy(), expected_y.numpy())
+
+    def test_get_sub_meshes_for_shard(self):
+        """Test get_sub_meshes_for_shard with a 2x2 mesh."""
+        mesh = dist.ProcessMesh([[0, 1], [2, 3]], dim_names=["x", "y"])  # 2x2 mesh
+        # Shard along dim 0
+        sub_meshes = get_sub_meshes_for_shard(mesh, 0)
+        self.assertEqual(len(sub_meshes), 2)
+        self.assertEqual(sub_meshes[0].process_ids, [0, 1])
+        self.assertEqual(sub_meshes[0].shape, [1, 2])
+        self.assertEqual(sub_meshes[1].process_ids, [2, 3])
+        self.assertEqual(sub_meshes[1].shape, [1, 2])
+        # Shard along dim 1
+        sub_meshes = get_sub_meshes_for_shard(mesh, 1)
+        self.assertEqual(len(sub_meshes), 2)
+        self.assertEqual(sub_meshes[0].process_ids, [0, 2])
+        self.assertEqual(sub_meshes[0].shape, [2, 1])
+        self.assertEqual(sub_meshes[1].process_ids, [1, 3])
+        self.assertEqual(sub_meshes[1].shape, [2, 1])
+
+    def test_shard_submesh_and_slice(self):
+        """Test shard_submesh_and_slice with even and uneven tensor sizes."""
+        mesh = dist.ProcessMesh([[0, 1]], dim_names=["x", "y"])  # 1x2 mesh
+        tensor_slice = [(0, 4), (0, 4)]
+        tensor_dim = 0
+        mesh_dim = 1
+        new_sub_meshes, new_slices = shard_submesh_and_slice(mesh, tensor_slice, tensor_dim, mesh_dim)
+        self.assertEqual(len(new_sub_meshes), 2)
+        self.assertEqual(new_sub_meshes[0].process_ids, [0])
+        self.assertEqual(new_sub_meshes[1].process_ids, [1])
+        self.assertEqual(new_slices[0], [(0, 2), (0, 4)])
+        self.assertEqual(new_slices[1], [(2, 4), (0, 4)])
+
+        # Uneven size
+        tensor_slice = [(0, 5), (0, 4)]
+        new_sub_meshes, new_slices = shard_submesh_and_slice(mesh, tensor_slice, tensor_dim, mesh_dim)
+        self.assertEqual(new_slices[0], [(0, 3), (0, 4)])  # First shard: 3 elements
+        self.assertEqual(new_slices[1], [(3, 5), (0, 4)])  # Last shard: 2 elements
+
+    def test_get_rank2tensor_indices(self):
+        """Test get_rank2tensor_indices mapping."""
+        sub_mesh2tensor_indices = {
+            dist.ProcessMesh([0]): {'slice': [(0, 2), (0, 4)], 'partial': {}},
+            dist.ProcessMesh([1]): {'slice': [(2, 4), (0, 4)], 'partial': {}},
+        }
+        rank2tensor_indices = get_rank2tensor_indices(sub_mesh2tensor_indices)
+        self.assertEqual(rank2tensor_indices[0], {'slice': [(0, 2), (0, 4)], 'partial': {}})
+        self.assertEqual(rank2tensor_indices[1], {'slice': [(2, 4), (0, 4)], 'partial': {}})
+
+    def test_get_local_slices_additional(self):
+        """Test get_local_slices with different placements."""
+        (h, w) = (4, 4)
+        x = paddle.arange(0, h * w, dtype=self._dtype).reshape([h, w])
+        
+        # Test with [Replicate(), Replicate()]
+        placements = [dist.Replicate(), dist.Replicate()]
+        slices = get_local_slices(x, self._mesh0, placements)
+        for rank in [0, 1]:
+            self.assertEqual(slices[rank]['slice'], [(0, 4), (0, 4)])
+            self.assertEqual(slices[rank]['partial'], {})
+
+        # Test with [Shard(1), Replicate()] on mesh1
+        placements = [dist.Replicate(), dist.Shard(1)]
+        slices = get_local_slices(x, self._mesh1, placements)
+        self.assertEqual(slices[0]['slice'], [(0, 4), (0, 2)])
+        self.assertEqual(slices[1]['slice'], [(0, 4), (2, 4)])
+
+    def test_only_reshard_mesh_shape(self):
+        """Test _only_reshard_mesh_shape conditions."""
+        (h, w) = (4, 4)
+        x = paddle.arange(0, h * w, dtype=self._dtype).reshape([h, w])
+        
+        # Case 1: Same mesh, should return False
+        dist_x = dist.shard_tensor(x, self._mesh0, [dist.Replicate(), dist.Replicate()])
+        result = _only_reshard_mesh_shape(dist_x, self._mesh0, [dist.Replicate(), dist.Replicate()])
+        self.assertFalse(result)
+
+        # Case 2: Different process IDs, should return False
+        mesh_diff = dist.ProcessMesh([[2], [3]], dim_names=["x", "y"])
+        result = _only_reshard_mesh_shape(dist_x, mesh_diff, [dist.Replicate(), dist.Replicate()])
+        self.assertFalse(result)
+
+        # Case 3: Same process IDs, different slices
+        dist_x = dist.shard_tensor(x, self._mesh0, [dist.Shard(0), dist.Replicate()])
+        result = _only_reshard_mesh_shape(dist_x, self._mesh1, [dist.Replicate(), dist.Shard(1)])
+        self.assertFalse(result)
+
+        # Case 4: Same process IDs, same slices
+        dist_x = dist.shard_tensor(x, self._mesh0, [dist.Replicate(), dist.Replicate()])
+        result = _only_reshard_mesh_shape(dist_x, self._mesh1, [dist.Replicate(), dist.Replicate()])
+        self.assertTrue(result)
+
+        # Case 5: Flag disabled
+        os.environ["FLAGS_enable_moe_utils"] = "false"
+        result = _only_reshard_mesh_shape(dist_x, self._mesh1, [dist.Replicate(), dist.Replicate()])
+        self.assertFalse(result)
+        os.environ["FLAGS_enable_moe_utils"] = "true"  # Reset
 
     def run_test_case(self):
         self.test_local_reshape()
         self.test_nd_mesh_alltoall()
         self.test_reshard_mesh_shape()
         self.test_get_local_slices()
-
+        self.test_reshard_general_case()
+        self.test_get_sub_meshes_for_shard()
+        self.test_shard_submesh_and_slice()
+        self.test_get_rank2tensor_indices()
+        self.test_get_local_slices_additional()
+        self.test_only_reshard_mesh_shape()
 
 if __name__ == '__main__':
-    TestMoEUtils().run_test_case()
+    unittest.main()


### PR DESCRIPTION
### PR Category
Auto Parallel

### PR Types
New features

### Description
添加了 feature _only_reshard_mesh_shape 和 get_local_slice的功能，实现在不进行实际切分张量的情况下，用迭代模拟的方式得到了理论上每张GPU切分后的local_slice，支持shard,replicate和partail三种齐全的placements，并且支持不均匀切分和多重切分的情况。
