### PR TITLE
[Accuracy diff No.80、150] Fix accuracy diff for `cumulative_trapezoid, trapezoid`API

### DIFF
--- a/paddle/phi/kernels/funcs/gather.h
+++ b/paddle/phi/kernels/funcs/gather.h
@@ -265,12 +265,14 @@ void GatherV2GradFunction(const phi::CPUContext& ctx,
   for (int64_t i = 0; i < inner_dim_size; i++) {
     for (int64_t j = 0; j < input_index_dim_size; j++) {
       const int64_t index_data_j =
-          (index_data[j] < 0 ? index_data[j] + input_index_dim_size
+          (index_data[j] < 0 ? index_data[j] + out_index_dim_size
                              : index_data[j]);
       for (int64_t k = 0; k < outer_dim_size; k++) {
         int64_t index = k + index_data_j * outer_dim_size +
                         i * outer_dim_size * out_index_dim_size;
-        out_data[index] += input_data[j * outer_dim_size + k];
+        out_data[index] +=
+            input_data[i * input_index_dim_size * outer_dim_size +
+                       j * outer_dim_size + k];
       }
     }
   }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
定位到 gather cpu kerenl 的反向问题
1. 反向索引的是 out 张量，应该使用 out_index_dim_size
2. input 张量索引计算错误，缺少外层循环 i，重复读取input张量的第一个切片

- PaddleAPITest 通过测试
![图片](https://github.com/user-attachments/assets/e0fd2d4d-f650-42ae-bce8-d8585de6c840)
