### PR TITLE
[PHI] fix paddle.assign for big tensor

### DIFF
--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -2801,7 +2801,8 @@ def assign(x: TensorLike, output: paddle.Tensor | None = None) -> paddle.Tensor:
         )
         value_name = "values"
         values = input.ravel().tolist()
-        if input.size > 1024 * 1024:
+        max_element_num = 17179869184  # 17179869184 = 2**34
+        if input.size > max_element_num:
             from paddle.jit.sot.utils.exceptions import SotExtraInfo
 
             sot_extra_info = SotExtraInfo(need_breakgraph=True)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes
### Description
<!-- Describe what you’ve done -->
**报错：**
![image](https://github.com/user-attachments/assets/2f8da931-565b-48bc-8bf6-0918dc0b60f2)

报错是因为assign里面limit设置的太小了

**PaddleAPITest回测结果：**
![image](https://github.com/user-attachments/assets/3b24575f-0b60-4acc-8f70-b4d5ee4191ff)

pcard-67164
