### PR TITLE
add a tool to get layer of pp info

### DIFF
--- a/python/paddle/distributed/auto_parallel/pipelining/utils.py
+++ b/python/paddle/distributed/auto_parallel/pipelining/utils.py
@@ -18,7 +18,7 @@ import logging
 from typing import Any, Callable, Union
 
 import paddle
-from paddle.distributed import fleet
+from paddle.distributed import ProcessMesh, fleet
 from paddle.distributed.auto_parallel.api import (
     dtensor_from_local,
 )
@@ -172,3 +172,122 @@ def _map_debug_info(a):
     `a` may be a list, tuple, or dict.
     """
     return map_structure(_friendly_debug_info, a)
+
+
+class GET_PP_INFO_OF_LAYER:
+    """Class for getting Pipeline Parallel information of model layers
+    Args:
+        hidden_layer_num (int): Number of model layers
+        mesh (ProcessMesh): Device mesh information
+        pp_schedule (str, optional): Pipeline parallel scheduling strategy. Defaults to "1F1B", representing the common model allocation strategy.
+        vpp_degree (int | None, optional): VPP parallel degree. Defaults to None, indicating VPP strategy is not used.
+    """
+
+    def __init__(
+        self,
+        hidden_layer_num: int,
+        mesh: ProcessMesh,
+        pp_schedule: str = "1F1B",
+        vpp_degree: int | None = None,
+    ):
+        self.mesh = mesh
+        if "pp" in self.mesh.dim_names:
+            self.pp_degree = mesh.get_dim_size("pp")
+        else:
+            raise ValueError("mesh must have 'pp' dimension")
+
+        self.pp_schedule = pp_schedule.upper()
+        # Check if schedule is supported
+        if self.pp_schedule not in ["VPP", "1F1B", "GPIPE"]:
+            raise ValueError(
+                f"The pipeline schedule {self.pp_schedule} is not supported currently"
+            )
+        self.hidden_layer_num = hidden_layer_num
+        self.vpp_degree = vpp_degree
+
+        # Initialize VPP mode parameters
+        if self.pp_schedule == "VPP":
+            if self.vpp_degree is None:
+                raise ValueError("VPP mode requires vpp_degree to be specified")
+            self.real_pp_degree = self.vpp_degree * self.pp_degree
+            if self.hidden_layer_num < self.real_pp_degree:
+                raise ValueError(
+                    f"In VPP mode, number of layers must be >= vpp_degree * pp_degree, "
+                    f"but got {hidden_layer_num} layers with {self.real_pp_degree} stages "
+                    f"(vpp_degree={vpp_degree}, pp_degree={self.pp_degree})"
+                )
+
+        # Calculate base layers per stage and remaining layers
+        if pp_schedule == "VPP":
+            self.base_layers = hidden_layer_num // self.real_pp_degree
+            self.remaining_layers = hidden_layer_num % self.real_pp_degree
+        else:
+            self.base_layers = hidden_layer_num // self.pp_degree
+            self.remaining_layers = hidden_layer_num % self.pp_degree
+
+    def __getitem__(self, layer_idx: int) -> ProcessMesh:
+        """Get device mesh information for specified layer through index access
+        Args:
+            layer_idx (int): Layer index
+        Returns:
+            ProcessMesh: Corresponding device mesh information
+        """
+        return self.get_info_by_index(layer_idx)
+
+    def get_info_by_index(self, layer_idx: int) -> ProcessMesh:
+        """Get device mesh information for specified layer
+        Args:
+            layer_idx (int): Layer index
+        Returns:
+            ProcessMesh: Corresponding device mesh information
+        """
+        if layer_idx >= self.hidden_layer_num:
+            raise ValueError(
+                f"layer_idx {layer_idx} exceeds total number of layers {self.hidden_layer_num}"
+            )
+
+        if self.pp_schedule == "VPP":
+            # Calculate logical stage index (0 to real_pp_degree-1)
+            if layer_idx < self.remaining_layers * (self.base_layers + 1):
+                logical_stage_idx = layer_idx // (self.base_layers + 1)
+            else:
+                layers_not_remaining = layer_idx - self.remaining_layers * (
+                    self.base_layers + 1
+                )
+                logical_stage_idx = (
+                    self.remaining_layers
+                    + layers_not_remaining // self.base_layers
+                )
+
+            # Map logical stage to physical device (0 to pp_degree-1)
+            physical_device_idx = logical_stage_idx % self.pp_degree
+            return self.mesh.get_mesh_with_dim("pp", physical_device_idx)
+        elif (
+            self.pp_schedule == "1F1B" or self.pp_schedule == "GPIPE"
+        ):  # "1F1B" or "Gpipe"
+            if layer_idx < self.remaining_layers * (self.base_layers + 1):
+                stage_idx = layer_idx // (self.base_layers + 1)
+            else:
+                layers_not_remaining = layer_idx - self.remaining_layers * (
+                    self.base_layers + 1
+                )
+                stage_idx = (
+                    self.remaining_layers
+                    + layers_not_remaining // self.base_layers
+                )
+
+            return self.mesh.get_mesh_with_dim("pp", stage_idx)
+        else:
+            raise ValueError(
+                f"The pipeline schedule {self.pp_schedule} is not supported currently"
+            )
+
+    def get_info_mapping(self) -> dict[int, ProcessMesh]:
+        """Get device mesh information mapping for all layers
+        Returns:
+            dict[int, ProcessMesh]: key is layer_index (starting from 0), value is the corresponding device group mesh
+        """
+        return {
+            layer_idx: self.get_info_by_index(layer_idx)
+            for layer_idx in range(self.hidden_layer_num)
+        }

--- a/test/auto_parallel/CMakeLists.txt
+++ b/test/auto_parallel/CMakeLists.txt
@@ -191,6 +191,7 @@ if(WITH_DISTRIBUTE AND WITH_GPU)
     FLAGS_cudnn_deterministic=1
     FLAGS_embedding_deterministic=1
     NVIDIA_TF32_OVERRIDE=0)
+  py_test_modules(test_get_pp_info_of_layer MODULES test_get_pp_info_of_layer)
   # End of unittests WITH single card WITHOUT timeout
 
 endif()

--- a/test/auto_parallel/test_get_pp_info_of_layer.py
+++ b/test/auto_parallel/test_get_pp_info_of_layer.py
@@ -1,0 +1,166 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from paddle.distributed import ProcessMesh
+from paddle.distributed.auto_parallel.pipelining.utils import (
+    GET_PP_INFO_OF_LAYER,
+)
+
+
+class TestGetPPInfoOfLayer(unittest.TestCase):
+    def test_error_cases(self):
+        # Test mesh dimension name error
+        mesh = ProcessMesh([0, 1, 2, 3], dim_names=["dp"])
+        with self.assertRaises(ValueError):
+            GET_PP_INFO_OF_LAYER(
+                hidden_layer_num=8, mesh=mesh, pp_schedule="1F1B"
+            )
+
+        # Test VPP without vpp_degree
+        mesh = ProcessMesh([0, 1, 2, 3], dim_names=["pp"])
+        with self.assertRaises(ValueError):
+            GET_PP_INFO_OF_LAYER(
+                hidden_layer_num=8, mesh=mesh, pp_schedule="VPP"
+            )
+
+        # Test insufficient layers for VPP
+        with self.assertRaises(ValueError):
+            GET_PP_INFO_OF_LAYER(
+                hidden_layer_num=7, mesh=mesh, pp_schedule="VPP", vpp_degree=2
+            )
+
+        # Test unsupported schedule
+        with self.assertRaises(ValueError):
+            GET_PP_INFO_OF_LAYER(
+                hidden_layer_num=8,
+                mesh=mesh,
+                pp_schedule="VPP_ZERO",
+                vpp_degree=2,
+            )
+
+        # Test layer index out of range
+        with self.assertRaises(ValueError):
+            pp_info = GET_PP_INFO_OF_LAYER(
+                hidden_layer_num=8, mesh=mesh, pp_schedule="1F1B", vpp_degree=2
+            )
+            pp_info[9]
+
+    def test_1F1B_and_GPipe(self):
+        # Test 1D mesh
+        mesh = ProcessMesh([0, 1, 2, 3], dim_names=["pp"])
+        pp_info_1F1B = GET_PP_INFO_OF_LAYER(
+            hidden_layer_num=8, mesh=mesh, pp_schedule="1f1B"
+        )
+        pp_info_Gpipe = GET_PP_INFO_OF_LAYER(
+            hidden_layer_num=8, mesh=mesh, pp_schedule="Gpipe"
+        )
+
+        self.assertEqual(pp_info_1F1B[3].process_ids, [1])
+        self.assertEqual(
+            pp_info_Gpipe[3].process_ids, pp_info_1F1B[3].process_ids
+        )
+
+        # Test 2D mesh
+        mesh = ProcessMesh([[0, 1], [2, 3]], dim_names=["pp", "dp"])
+        pp_info_1F1B = GET_PP_INFO_OF_LAYER(
+            hidden_layer_num=8, mesh=mesh, pp_schedule="1F1B"
+        )
+        pp_info_Gpipe = GET_PP_INFO_OF_LAYER(
+            hidden_layer_num=8, mesh=mesh, pp_schedule="Gpipe"
+        )
+
+        self.assertEqual(pp_info_1F1B[3].process_ids, [0, 1])
+        self.assertEqual(
+            pp_info_Gpipe[3].process_ids, pp_info_1F1B[3].process_ids
+        )
+
+        # Test 3D mesh
+        mesh = ProcessMesh(
+            [[[0, 1], [2, 3]], [[4, 5], [6, 7]]], dim_names=["pp", "dp", "mp"]
+        )
+        pp_info_1F1B = GET_PP_INFO_OF_LAYER(
+            hidden_layer_num=8, mesh=mesh, pp_schedule="1F1B"
+        )
+        pp_info_Gpipe = GET_PP_INFO_OF_LAYER(
+            hidden_layer_num=8, mesh=mesh, pp_schedule="Gpipe"
+        )
+
+        self.assertEqual(pp_info_1F1B[3].process_ids, [0, 1, 2, 3])
+        self.assertEqual(
+            pp_info_Gpipe[3].process_ids, pp_info_1F1B[3].process_ids
+        )
+
+    def test_VPP(self):
+        # Test 1D mesh
+        mesh = ProcessMesh([0, 1, 2, 3], dim_names=["pp"])
+        pp_info = GET_PP_INFO_OF_LAYER(
+            hidden_layer_num=8, mesh=mesh, pp_schedule="VPP", vpp_degree=2
+        )
+        self.assertEqual(pp_info[3].process_ids, [3])
+
+        # Test 2D mesh
+        mesh = ProcessMesh([[0, 1], [2, 3]], dim_names=["pp", "dp"])
+        pp_info = GET_PP_INFO_OF_LAYER(
+            hidden_layer_num=8, mesh=mesh, pp_schedule="VPP", vpp_degree=2
+        )
+        self.assertEqual(pp_info[2].process_ids, [2, 3])
+
+        # Test 3D mesh
+        mesh = ProcessMesh(
+            [[[0, 1], [2, 3]], [[4, 5], [6, 7]]], dim_names=["pp", "dp", "mp"]
+        )
+        pp_info = GET_PP_INFO_OF_LAYER(
+            hidden_layer_num=8, mesh=mesh, pp_schedule="VPP", vpp_degree=2
+        )
+        self.assertEqual(pp_info[3].process_ids, [4, 5, 6, 7])
+
+    def test_uneven_distribution(self):
+        # Test 1F1B with uneven layers
+        mesh = ProcessMesh([0, 1, 2, 3], dim_names=["pp"])
+        pp_info = GET_PP_INFO_OF_LAYER(
+            hidden_layer_num=7, mesh=mesh, pp_schedule="1F1B"
+        )
+        self.assertEqual(pp_info[5].process_ids, [2])
+        self.assertEqual(pp_info[6].process_ids, [3])
+
+        # Test VPP with uneven layers
+        pp_info = GET_PP_INFO_OF_LAYER(
+            hidden_layer_num=9, mesh=mesh, pp_schedule="VPP", vpp_degree=2
+        )
+        self.assertEqual(pp_info[8].process_ids, [3])
+
+    def test_info_mapping(self):
+        mesh = ProcessMesh([0, 1, 2, 3], dim_names=["pp"])
+
+        # Test 1F1B mapping
+        pp_info = GET_PP_INFO_OF_LAYER(
+            hidden_layer_num=8, mesh=mesh, pp_schedule="1F1B"
+        )
+        layer_mesh_of_pp = pp_info.get_info_mapping()
+        for layer_idx, submesh in layer_mesh_of_pp.items():
+            self.assertEqual(layer_idx // 2, submesh.process_ids[0])
+
+        # Test VPP mapping
+        pp_info = GET_PP_INFO_OF_LAYER(
+            hidden_layer_num=8, mesh=mesh, pp_schedule="VPP", vpp_degree=2
+        )
+        layer_mesh_of_pp = pp_info.get_info_mapping()
+        for layer_idx, submesh in layer_mesh_of_pp.items():
+            self.assertEqual(layer_idx % 4, submesh.process_ids[0])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Auto Parallel


### PR Types
New features


### Description
为了让用户在使用pp策略时，正确切分模型到对应的mesh上，开发此工具。将根据 hidden_layer_num,mesh,pp_schedule,vpp_degree，来处理模型切分，并根据 layer_index,返回对应的mesh信息，也可一次返回全部layer的mesh信息。
- 如下是使用不同pp策略时，hidden_layer的分布状态：
![image](https://github.com/user-attachments/assets/3b42f8cb-2758-4c5e-b70a-690555306a6f)


