### PR TITLE
[Accuracy diff No.132] Fix accuracy diff for paddle.outer API

### DIFF
--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -2953,6 +2953,16 @@ def outer(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
     else:
         ny = y.reshape((1, -1))
 
+    if x.dtype in [
+        paddle.int32,
+        paddle.int64,
+        DataType.INT32,
+        DataType.INT64,
+        VarDesc.VarType.INT32,
+        VarDesc.VarType.INT64,
+    ]:
+        return nx * ny
+
     if in_dynamic_mode():
         return _C_ops.matmul(nx, ny, False, False)
 

--- a/test/legacy_test/test_outer.py
+++ b/test/legacy_test/test_outer.py
@@ -87,6 +87,18 @@ class TestMultiplyApi(unittest.TestCase):
         res = self._run_static_graph_case(x_data, y_data)
         np.testing.assert_allclose(res, np.outer(x_data, y_data), rtol=1e-05)
 
+        # test static computation graph: 3-d int32 big array
+        x_data = np.random.randint(-80000, 80000, [5, 10, 10]).astype(np.int32)
+        y_data = np.random.randint(-80000, 80000, [2, 10]).astype(np.int32)
+        res = self._run_static_graph_case(x_data, y_data)
+        np.testing.assert_allclose(res, np.outer(x_data, y_data), rtol=1e-05)
+
+        # test static computation graph: 3-d int64 big array
+        x_data = np.random.randint(-80000, 80000, [5, 10, 10]).astype(np.int64)
+        y_data = np.random.randint(-80000, 80000, [2, 10]).astype(np.int64)
+        res = self._run_static_graph_case(x_data, y_data)
+        np.testing.assert_allclose(res, np.outer(x_data, y_data), rtol=1e-05)
+
     def test_multiply_dynamic(self):
         # test dynamic computation graph: 3-d array
         x_data = np.random.rand(5, 10, 10).astype(np.float64)
@@ -135,6 +147,18 @@ class TestMultiplyApi(unittest.TestCase):
         # test dynamic computation graph: 3-d int64 array
         x_data = np.random.rand(5, 10, 10).astype(np.int64)
         y_data = np.random.rand(2, 10).astype(np.int64)
+        res = self._run_dynamic_graph_case(x_data, y_data)
+        np.testing.assert_allclose(res, np.outer(x_data, y_data), rtol=1e-05)
+
+        # test dynamic computation graph: 3-d int32 big array
+        x_data = np.random.randint(-80000, 80000, [5, 10, 10]).astype(np.int32)
+        y_data = np.random.randint(-80000, 80000, [2, 10]).astype(np.int32)
+        res = self._run_dynamic_graph_case(x_data, y_data)
+        np.testing.assert_allclose(res, np.outer(x_data, y_data), rtol=1e-05)
+
+        # test dynamic computation graph: 3-d int64 big array
+        x_data = np.random.randint(-80000, 80000, [5, 10, 10]).astype(np.int64)
+        y_data = np.random.randint(-80000, 80000, [2, 10]).astype(np.int64)
         res = self._run_dynamic_graph_case(x_data, y_data)
         np.testing.assert_allclose(res, np.outer(x_data, y_data), rtol=1e-05)
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
排查发现是 matmul kernel 中整数类型在运算时先cast为float32进行计算再cast回整数类型（底层使用的是 blas 等库的接口），大整数相乘会产生溢出，而 `Tensor.__multiply__` 可以正确计算，所以在 python 端进行修改。

回测结果：
![image](https://github.com/user-attachments/assets/b4e59b50-c75a-4d95-b13b-95f84558b193)
