### PR TITLE
Rename dev_ctx.x_context() ctx

### DIFF
--- a/paddle/phi/kernels/xpu/activation_kernel.cc
+++ b/paddle/phi/kernels/xpu/activation_kernel.cc
@@ -442,8 +442,9 @@ void EluKernel(const Context& dev_ctx,
   if (out->numel() == 0) {
     return;
   }
-  // template<typename T> int elu(Context* ctx, const T* x, T* y, int64_t len,
-  // float alpha = 1.0f, const float* max_x = nullptr, float* max_y = nullptr)
+  // template<typename T> int elu(Context* xpu_ctx, const T* x, T* y, int64_t
+  // len, float alpha = 1.0f, const float* max_x = nullptr, float* max_y =
+  // nullptr)
   int r = xpu::elu(dev_ctx.x_context(),
                    reinterpret_cast<const XPUType*>(x.data<T>()),
                    reinterpret_cast<XPUType*>(out->data<T>()),

--- a/paddle/phi/kernels/xpu/add_n_kernel.cc
+++ b/paddle/phi/kernels/xpu/add_n_kernel.cc
@@ -146,7 +146,7 @@ void AddNArrayKernel(const Context& dev_ctx,
           ptrs.push_back(
               reinterpret_cast<const XPUType*>(out->at(j).data<T>()));
 
-          // int sum(Context* ctx, const std::vector<const T*>& x_list, T*
+          // int sum(Context* xpu_ctx, const std::vector<const T*>& x_list, T*
           // y, int64_t len);
           int r = xpu::sum(dev_ctx.x_context(),
                            ptrs,

--- a/paddle/phi/kernels/xpu/batch_norm_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/batch_norm_grad_kernel.cc
@@ -22,7 +22,7 @@
 namespace phi {
 
 template <typename T>
-static int CalculateInvBNY(xpu::Context *ctx,
+static int CalculateInvBNY(xpu::Context *xpu_ctx,
                            T *x,
                            const T *scale,
                            const T *bias,
@@ -39,34 +39,34 @@ static int CalculateInvBNY(xpu::Context *ctx,
   std::vector<int64_t> tensor_shape_vec({N, C, M});
   std::vector<int64_t> array_shape_vec({1, C, 1});
   // y - bias
-  int r1 =
-      xpu::broadcast_sub<T>(ctx, bias, y, x, array_shape_vec, tensor_shape_vec);
+  int r1 = xpu::broadcast_sub<T>(
+      xpu_ctx, bias, y, x, array_shape_vec, tensor_shape_vec);
   // (y - bias) / scale
   int r2 = xpu::broadcast_div<T>(
-      ctx, scale, x, x, array_shape_vec, tensor_shape_vec);
+      xpu_ctx, scale, x, x, array_shape_vec, tensor_shape_vec);
   // (y - bias) / scale / variance
   int r3 = xpu::broadcast_div<T>(
-      ctx, variance, x, x, array_shape_vec, tensor_shape_vec);
+      xpu_ctx, variance, x, x, array_shape_vec, tensor_shape_vec);
   // (y - bias) / scale / variance + mean
-  int r4 =
-      xpu::broadcast_add<T>(ctx, mean, x, x, array_shape_vec, tensor_shape_vec);
+  int r4 = xpu::broadcast_add<T>(
+      xpu_ctx, mean, x, x, array_shape_vec, tensor_shape_vec);
 
   return r1 + r2 + r3 + r4;
 }
 
 template <typename T>
-static int CalculateInvVar(xpu::Context *ctx,
+static int CalculateInvVar(xpu::Context *xpu_ctx,
                            const T *var,
                            const T epsilon,
                            const int64_t C,
                            T *epsilon_data,
                            T *inv_var) {
-  int r1 = constant(ctx, epsilon_data, 1, epsilon);
+  int r1 = constant(xpu_ctx, epsilon_data, 1, epsilon);
   std::vector<int64_t> tensor_shape_vec({C});
   std::vector<int64_t> array_shape_vec({1});
   int r2 = xpu::broadcast_add<T>(
-      ctx, epsilon_data, var, inv_var, array_shape_vec, tensor_shape_vec);
-  int r3 = xpu::rsqrt<T>(ctx, inv_var, inv_var, C);
+      xpu_ctx, epsilon_data, var, inv_var, array_shape_vec, tensor_shape_vec);
+  int r3 = xpu::rsqrt<T>(xpu_ctx, inv_var, inv_var, C);
   return r1 + r2 + r3;
 }
 

--- a/paddle/phi/kernels/xpu/compare_kernel.cc
+++ b/paddle/phi/kernels/xpu/compare_kernel.cc
@@ -64,13 +64,13 @@ void XPUCompareKernelImpl(
                     const DenseTensor& y,                             \
                     DenseTensor* out) {                               \
     using XPUType = typename XPUTypeTrait<T>::Type;                   \
-    auto f = [](xpu::Context* ctx,                                    \
+    auto f = [](xpu::Context* xpu_ctx,                                \
                 const XPUType* x,                                     \
                 const XPUType* y,                                     \
                 bool* z,                                              \
                 const std::vector<int64_t>& xshape,                   \
                 const std::vector<int64_t>& yshape) {                 \
-      return functor(ctx, x, y, z, xshape, yshape);                   \
+      return functor(xpu_ctx, x, y, z, xshape, yshape);               \
     };                                                                \
     XPUCompareKernelImpl<T, XPUType, Context>(dev_ctx, x, y, out, f); \
   }

--- a/paddle/phi/kernels/xpu/concat_and_split_functor.cc
+++ b/paddle/phi/kernels/xpu/concat_and_split_functor.cc
@@ -119,9 +119,9 @@ class SplitFunctor<XPUContext, T> {
       context.template Alloc<T>(&tmp_data);
     }
 
-    // int split(Context* ctx, const T* x, const std::vector<T*>& y_list, const
-    // std::vector<int64_t>& xshape, const std::vector<int64_t>& split_list,
-    // int64_t axis);
+    // int split(Context* xpu_ctx, const T* x, const std::vector<T*>& y_list,
+    // const std::vector<int64_t>& xshape, const std::vector<int64_t>&
+    // split_list, int64_t axis);
     auto r = xpu::split<XPUType>(
         context.x_context(),
         reinterpret_cast<const XPUType*>(tmp_data.data<T>()),

--- a/paddle/phi/kernels/xpu/cum_kernel.cc
+++ b/paddle/phi/kernels/xpu/cum_kernel.cc
@@ -70,7 +70,7 @@ void CumsumKernel(const Context& dev_ctx,
     }
   }
 
-  // template<typename T> DLL_EXPORT int cumsum(Context* ctx, const T* x, T*
+  // template<typename T> DLL_EXPORT int cumsum(Context* xpu_ctx, const T* x, T*
   // y, const std::vector<int>& xshape, bool reverse, bool exclusive, int
   // axis);
   int r = xpu::cumsum<XPUType>(dev_ctx.x_context(),

--- a/paddle/phi/kernels/xpu/dropout_kernel.cc
+++ b/paddle/phi/kernels/xpu/dropout_kernel.cc
@@ -81,7 +81,7 @@ void DropoutRawKernel(const Context& dev_ctx,
       return;
     }
     if (dev_version == phi::backends::xpu::XPUVersion::XPU3) {
-      // int dropout_v3(Context* ctx, const T* input, T* res, uint8_t* mask,
+      // int dropout_v3(Context* xpu_ctx, const T* input, T* res, uint8_t* mask,
       // unsigned int seed, int64_t n, bool is_upscale, float dropout_prob);
       int r = xpu::dropout_v3(dev_ctx.x_context(),
                               reinterpret_cast<const XPUType*>(x_data),
@@ -95,8 +95,8 @@ void DropoutRawKernel(const Context& dev_ctx,
     } else {
       XPUType* mask_tmp_data =
           RAII_GUARD.alloc_l3_or_gm<XPUType>(mask->numel());
-      // int dropout(Context* ctx, const T* input, T* res, T* mask, unsigned int
-      // seed, int64_t n, bool is_upscale, float dropout_prob);
+      // int dropout(Context* xpu_ctx, const T* input, T* res, T* mask, unsigned
+      // int seed, int64_t n, bool is_upscale, float dropout_prob);
       int r = xpu::dropout(dev_ctx.x_context(),
                            reinterpret_cast<const XPUType*>(x_data),
                            reinterpret_cast<XPUType*>(y_data),

--- a/paddle/phi/kernels/xpu/elementwise_add_kernel.cc
+++ b/paddle/phi/kernels/xpu/elementwise_add_kernel.cc
@@ -70,13 +70,13 @@ void AddKernel(const Context& dev_ctx,
     } else {
       using Type = DataTypeToCppType<phi::DataType::FLOAT32>::type;
       using XPUType = typename XPUTypeTrait<Type>::Type;
-      auto f = [](xpu::Context* ctx,
+      auto f = [](xpu::Context* xpu_ctx,
                   const XPUType* x,
                   const XPUType* y,
                   XPUType* z,
                   const std::vector<int64_t>& xshape,
                   const std::vector<int64_t>& yshape) {
-        return xpu::broadcast_add<XPUType>(ctx, x, y, z, xshape, yshape);
+        return xpu::broadcast_add<XPUType>(xpu_ctx, x, y, z, xshape, yshape);
       };
       auto casted_y = phi::Cast<T>(dev_ctx, y, phi::DataType::FLOAT32);
       XPUElementwise<Type, XPUType>(dev_ctx, x, casted_y, -1, out, f);
@@ -84,13 +84,13 @@ void AddKernel(const Context& dev_ctx,
   } else {
     using XPUType = typename XPUTypeTrait<T>::Type;
 
-    auto f = [](xpu::Context* ctx,
+    auto f = [](xpu::Context* xpu_ctx,
                 const XPUType* x,
                 const XPUType* y,
                 XPUType* z,
                 const std::vector<int64_t>& xshape,
                 const std::vector<int64_t>& yshape) {
-      return xpu::broadcast_add<XPUType>(ctx, x, y, z, xshape, yshape);
+      return xpu::broadcast_add<XPUType>(xpu_ctx, x, y, z, xshape, yshape);
     };
 
     XPUElementwise<T, XPUType>(dev_ctx, x, y, -1, out, f);
@@ -128,13 +128,13 @@ void AddKernel<phi::dtype::complex<float>, XPUContext>(
     dev_ctx.template Alloc<T>(out);
     return;
   }
-  auto f = [](xpu::Context* ctx,
+  auto f = [](xpu::Context* xpu_ctx,
               const float* x,
               const float* y,
               float* z,
               const std::vector<int64_t>& xshape,
               const std::vector<int64_t>& yshape) {
-    return xpu::broadcast_add<float>(ctx, x, y, z, xshape, yshape);
+    return xpu::broadcast_add<float>(xpu_ctx, x, y, z, xshape, yshape);
   };
   // The current complex number implementation uses separate real/imaginary
   // parts,resulting in redundant operations and performance

--- a/paddle/phi/kernels/xpu/elementwise_divide_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/elementwise_divide_grad_kernel.cc
@@ -36,7 +36,7 @@ void DivideGradKernel(const Context& dev_ctx,
   using XPUType = typename XPUTypeTrait<T>::Type;
   funcs::ElementwiseGradPreProcess(dout, dx);
 
-  auto f = [](xpu::Context* ctx,
+  auto f = [](xpu::Context* xpu_ctx,
               const XPUType* x,
               const XPUType* y,
               const XPUType* z,
@@ -46,7 +46,7 @@ void DivideGradKernel(const Context& dev_ctx,
               const std::vector<int64_t>& xshape,
               const std::vector<int64_t>& yshape) {
     return xpu::broadcast_div_grad<XPUType>(
-        ctx, x, y, z, dz, dy, dx, xshape, yshape);
+        xpu_ctx, x, y, z, dz, dy, dx, xshape, yshape);
   };
 
   XPUElementwiseGrad<T, XPUType>(dev_ctx, x, y, dout, axis, dx, dy, f, true);

--- a/paddle/phi/kernels/xpu/elementwise_divide_kernel.cc
+++ b/paddle/phi/kernels/xpu/elementwise_divide_kernel.cc
@@ -30,13 +30,13 @@ void DivideKernel(const Context& dev_ctx,
                   const DenseTensor& y,
                   DenseTensor* out) {
   using XPUType = typename XPUTypeTrait<T>::Type;
-  auto f = [](xpu::Context* ctx,
+  auto f = [](xpu::Context* xpu_ctx,
               const XPUType* x,
               const XPUType* y,
               XPUType* z,
               const std::vector<int64_t>& xshape,
               const std::vector<int64_t>& yshape) {
-    return xpu::broadcast_div<XPUType>(ctx, x, y, z, xshape, yshape);
+    return xpu::broadcast_div<XPUType>(xpu_ctx, x, y, z, xshape, yshape);
   };
 
   XPUElementwise<T, XPUType>(dev_ctx, x, y, -1, out, f);

--- a/paddle/phi/kernels/xpu/elementwise_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/elementwise_grad_kernel.cc
@@ -50,7 +50,7 @@ void MaximumGradKernel(const Context& dev_ctx,
 
   using XPUType = typename XPUTypeTrait<T>::Type;
   int axis = -1;
-  auto f = [](xpu::Context* ctx,
+  auto f = [](xpu::Context* xpu_ctx,
               const XPUType* x,
               const XPUType* y,
               const XPUType* z,
@@ -60,7 +60,7 @@ void MaximumGradKernel(const Context& dev_ctx,
               const std::vector<int64_t>& xshape,
               const std::vector<int64_t>& yshape) {
     return xpu::broadcast_max_grad<XPUType>(
-        ctx, x, y, z, dz, dy, dx, xshape, yshape);
+        xpu_ctx, x, y, z, dz, dy, dx, xshape, yshape);
   };
 
   XPUElementwiseGrad<T, XPUType>(dev_ctx, x, y, dout, axis, dx, dy, f, true);
@@ -94,7 +94,7 @@ void MinimumGradKernel(const Context& dev_ctx,
   }
   using XPUType = typename XPUTypeTrait<T>::Type;
   int axis = -1;
-  auto f = [](xpu::Context* ctx,
+  auto f = [](xpu::Context* xpu_ctx,
               const XPUType* x,
               const XPUType* y,
               const XPUType* z,
@@ -104,7 +104,7 @@ void MinimumGradKernel(const Context& dev_ctx,
               const std::vector<int64_t>& xshape,
               const std::vector<int64_t>& yshape) {
     return xpu::broadcast_min_grad<XPUType>(
-        ctx, x, y, z, dz, dy, dx, xshape, yshape);
+        xpu_ctx, x, y, z, dz, dy, dx, xshape, yshape);
   };
 
   XPUElementwiseGrad<T, XPUType>(dev_ctx, x, y, dout, axis, dx, dy, f, true);

--- a/paddle/phi/kernels/xpu/elementwise_kernel.cc
+++ b/paddle/phi/kernels/xpu/elementwise_kernel.cc
@@ -54,13 +54,13 @@ void RemainderKernel(const Context& dev_ctx,
                      const DenseTensor& y,
                      DenseTensor* out) {
   using XPUType = typename XPUTypeTrait<T>::Type;
-  auto f = [](xpu::Context* ctx,
+  auto f = [](xpu::Context* xpu_ctx,
               const XPUType* x,
               const XPUType* y,
               XPUType* z,
               const std::vector<int64_t>& xshape,
               const std::vector<int64_t>& yshape) {
-    return xpu::broadcast_mod<XPUType>(ctx, x, y, z, xshape, yshape);
+    return xpu::broadcast_mod<XPUType>(xpu_ctx, x, y, z, xshape, yshape);
   };
 
   XPUElementwise<T, XPUType>(dev_ctx, x, y, -1, out, f);

--- a/paddle/phi/kernels/xpu/elementwise_multiply_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/elementwise_multiply_grad_kernel.cc
@@ -59,7 +59,7 @@ void MultiplyGradKernel(const Context& dev_ctx,
     return;
   }
   funcs::ElementwiseGradPreProcess(dout, dx);
-  auto f = [](xpu::Context* ctx,
+  auto f = [](xpu::Context* xpu_ctx,
               const XPUType* x,
               const XPUType* y,
               const XPUType* z,
@@ -69,7 +69,7 @@ void MultiplyGradKernel(const Context& dev_ctx,
               const std::vector<int64_t>& xshape,
               const std::vector<int64_t>& yshape) {
     return xpu::broadcast_mul_grad<XPUType>(
-        ctx, x, y, z, dz, dy, dx, xshape, yshape);
+        xpu_ctx, x, y, z, dz, dy, dx, xshape, yshape);
   };
 
   XPUElementwiseGrad<T, XPUType>(dev_ctx, x, y, dout, axis, dx, dy, f, true);

--- a/paddle/phi/kernels/xpu/elementwise_multiply_kernel.cc
+++ b/paddle/phi/kernels/xpu/elementwise_multiply_kernel.cc
@@ -37,13 +37,13 @@ void MultiplyKernel(const Context& dev_ctx,
     dev_ctx.template Alloc<T>(out);
     return;
   }
-  auto f = [](xpu::Context* ctx,
+  auto f = [](xpu::Context* xpu_ctx,
               const XPUType* x,
               const XPUType* y,
               XPUType* z,
               const std::vector<int64_t>& xshape,
               const std::vector<int64_t>& yshape) {
-    return xpu::broadcast_mul<XPUType>(ctx, x, y, z, xshape, yshape);
+    return xpu::broadcast_mul<XPUType>(xpu_ctx, x, y, z, xshape, yshape);
   };
 
   XPUElementwise<T, XPUType>(dev_ctx, x, y, -1, out, f);

--- a/paddle/phi/kernels/xpu/elementwise_subtract_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/elementwise_subtract_grad_kernel.cc
@@ -48,7 +48,7 @@ void SubtractGradKernel(const Context& dev_ctx,
     return;
   }
 
-  auto f = [](xpu::Context* ctx,
+  auto f = [](xpu::Context* xpu_ctx,
               const XPUType* x,
               const XPUType* y,
               const XPUType* z,
@@ -58,7 +58,7 @@ void SubtractGradKernel(const Context& dev_ctx,
               const std::vector<int64_t>& xshape,
               const std::vector<int64_t>& yshape) {
     return xpu::broadcast_sub_grad<XPUType>(
-        ctx, x, y, z, dz, dy, dx, xshape, yshape);
+        xpu_ctx, x, y, z, dz, dy, dx, xshape, yshape);
   };
 
   phi::XPUElementwiseGrad<T, XPUType>(

--- a/paddle/phi/kernels/xpu/elementwise_subtract_kernel.cc
+++ b/paddle/phi/kernels/xpu/elementwise_subtract_kernel.cc
@@ -29,13 +29,13 @@ void SubtractKernel(const Context& dev_ctx,
     return;
   }
   using XPUType = typename XPUTypeTrait<T>::Type;
-  auto f = [](xpu::Context* ctx,
+  auto f = [](xpu::Context* xpu_ctx,
               const XPUType* x,
               const XPUType* y,
               XPUType* z,
               const std::vector<int64_t>& xshape,
               const std::vector<int64_t>& yshape) {
-    return xpu::broadcast_sub<XPUType>(ctx, x, y, z, xshape, yshape);
+    return xpu::broadcast_sub<XPUType>(xpu_ctx, x, y, z, xshape, yshape);
   };
 
   phi::XPUElementwise<T, XPUType>(dev_ctx, x, y, -1, out, f);

--- a/paddle/phi/kernels/xpu/flash_attn_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/flash_attn_grad_kernel.cc
@@ -161,8 +161,8 @@ void FlashAttnGradKernelBase(
         baidu::xpu::xfa::mha_varlen_bwd<XPUType, float, XPUTypeFP16, int>;
   }
   // template<typename T, typename TACCUM, typename TGEMM, typename TID = int>
-  // int mha_varlen_bwd(xdnn::Context* ctx, const T* dout, const T* q, const T*
-  // k, const T* v, const T* out, const TACCUM* softmax_lse, T* dq, T* dk, T*
+  // int mha_varlen_bwd(xdnn::Context* xpu_ctx, const T* dout, const T* q, const
+  // T* k, const T* v, const T* out, const TACCUM* softmax_lse, T* dq, T* dk, T*
   // dv, const xdnn::VectorParam<TID>& lod_seqlens_q, const
   // xdnn::VectorParam<TID>& lod_seqlens_k, int64_t max_seqlen_q, int64_t
   // max_seqlen_k, int64_t head_num, int64_t head_num_k, int64_t head_dim, const

--- a/paddle/phi/kernels/xpu/flip_kernel.cc
+++ b/paddle/phi/kernels/xpu/flip_kernel.cc
@@ -48,7 +48,7 @@ void FlipKernel(const Context& dev_ctx,
     return;
   }
   int r = xpu::flip<XPUInTDType>(
-      /* Context* ctx */ dev_ctx.x_context(),
+      /* Context* xpu_ctx */ dev_ctx.x_context(),
       /* const T* x */ x_data,
       /* T* y */ out_data,
       /* const std::vector<int64_t>& xshape */ x_shape,

--- a/paddle/phi/kernels/xpu/gather_nd_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/gather_nd_grad_kernel.cc
@@ -63,8 +63,8 @@ void GatherNdGradKernel(const Context &dev_ctx,
             remain_numel,
             out_grad_numel));
 
-    // int reduce_sum(Context* ctx, const T* x, T* y, const std::vector<int>&
-    // xshape, const std::vector<int>& rdims)
+    // int reduce_sum(Context* xpu_ctx, const T* x, T* y, const
+    // std::vector<int>& xshape, const std::vector<int>& rdims)
     int r =
         xpu::reduce_sum(dev_ctx.x_context(),
                         reinterpret_cast<const XPUType *>(out_grad.data<T>()),

--- a/paddle/phi/kernels/xpu/gaussian_kernel.cc
+++ b/paddle/phi/kernels/xpu/gaussian_kernel.cc
@@ -38,7 +38,8 @@ void GaussianKernel(const Context& dev_ctx,
   using XPUType = typename XPUTypeTrait<T>::Type;
   int64_t real_seed = seed != 0 ? seed : dev_ctx.GetGenerator()->Random64();
 
-  // int normal(Context* ctx, T* x, T mean, T std, int64_t len, int64_t seed);
+  // int normal(Context* xpu_ctx, T* x, T mean, T std, int64_t len, int64_t
+  // seed);
   int r = xpu::normal_<XPUType>(dev_ctx.x_context(),
                                 reinterpret_cast<XPUType*>(data),
                                 mean,

--- a/paddle/phi/kernels/xpu/increment_kernel.cc
+++ b/paddle/phi/kernels/xpu/increment_kernel.cc
@@ -44,7 +44,7 @@ void IncrementKernel(const Context& dev_ctx,
                      reinterpret_cast<void*>(&value_as_t),
                      sizeof(T));
 
-  // int add(Context* ctx, const T* x, const T* y, T* z, int64_t len);
+  // int add(Context* xpu_ctx, const T* x, const T* y, T* z, int64_t len);
   int ret = xpu::add(dev_ctx.x_context(), x_data, value_xpu, out_data, 1);
   PADDLE_ENFORCE_XDNN_SUCCESS(ret, "add");
 }

--- a/paddle/phi/kernels/xpu/index_sample_kernel.cc
+++ b/paddle/phi/kernels/xpu/index_sample_kernel.cc
@@ -48,7 +48,7 @@ void IndexSampleKernel(const Context& dev_ctx,
   T* out_data = dev_ctx.template Alloc<T>(out);
 
   // template<typename T, typename TID> DLL_EXPORT int gather_element(Context*
-  // ctx, const T* x, const TID* index, T* y, const std::vector<int64_t>&
+  // xpu_ctx, const T* x, const TID* index, T* y, const std::vector<int64_t>&
   // xshape, const std::vector<int64_t>& idxshape, int64_t axis);
 
   if (index_type == DataType::INT64) {

--- a/paddle/phi/kernels/xpu/logical_kernel.cc
+++ b/paddle/phi/kernels/xpu/logical_kernel.cc
@@ -20,12 +20,12 @@
 namespace phi {
 
 template <typename T, typename Context>
-void LogicalNotKernel(const Context& xpu_ctx,
+void LogicalNotKernel(const Context& dev_ctx,
                       const DenseTensor& x,
                       DenseTensor* out) {
-  xpu_ctx.template Alloc<bool>(out);
+  dev_ctx.template Alloc<bool>(out);
   int r = xpu::logical_not(
-      xpu_ctx.x_context(), x.data<T>(), out->data<T>(), x.numel());
+      dev_ctx.x_context(), x.data<T>(), out->data<T>(), x.numel());
   PADDLE_ENFORCE_XDNN_SUCCESS(r, "logical_not");
 }
 

--- a/paddle/phi/kernels/xpu/logical_kernel.cc
+++ b/paddle/phi/kernels/xpu/logical_kernel.cc
@@ -20,12 +20,12 @@
 namespace phi {
 
 template <typename T, typename Context>
-void LogicalNotKernel(const Context& ctx,
+void LogicalNotKernel(const Context& xpu_ctx,
                       const DenseTensor& x,
                       DenseTensor* out) {
-  ctx.template Alloc<bool>(out);
-  int r =
-      xpu::logical_not(ctx.x_context(), x.data<T>(), out->data<T>(), x.numel());
+  xpu_ctx.template Alloc<bool>(out);
+  int r = xpu::logical_not(
+      xpu_ctx.x_context(), x.data<T>(), out->data<T>(), x.numel());
   PADDLE_ENFORCE_XDNN_SUCCESS(r, "logical_not");
 }
 

--- a/paddle/phi/kernels/xpu/momentum_kernel.cc
+++ b/paddle/phi/kernels/xpu/momentum_kernel.cc
@@ -46,7 +46,7 @@ void MomentumDenseKernel(const Context& dev_ctx,
     regularization_coeff = 0.0f;
   }
 
-  // int momentum(Context* ctx, const T* param, const T* velocity, const T*
+  // int momentum(Context* xpu_ctx, const T* param, const T* velocity, const T*
   // grad, T* param_out, T* velocity_out, int len, const float* lr, int
   // use_nesterov, float mu, float l2_weight_decay);
   int r = xpu::momentum(dev_ctx.x_context(),

--- a/paddle/phi/kernels/xpu/multinomial_kernel.cc
+++ b/paddle/phi/kernels/xpu/multinomial_kernel.cc
@@ -58,7 +58,7 @@ void MultinomialKernel(const Context& dev_ctx,
     in_data = reinterpret_cast<const float*>(x.data<T>());
   }
 
-  // int multinomial(Context* ctx, const T* x, TID* y, int64_t num_samples,
+  // int multinomial(Context* xpu_ctx, const T* x, TID* y, int64_t num_samples,
   // int64_t num_categories, int64_t num_distributions, bool replacement,
   // int64_t seed);
   int r = xpu::multinomial<float, int64_t>(dev_ctx.x_context(),

--- a/paddle/phi/kernels/xpu/prod_kernel.cc
+++ b/paddle/phi/kernels/xpu/prod_kernel.cc
@@ -31,12 +31,12 @@ void ProdKernel(const Context& dev_ctx,
   reduce_all = recompute_reduce_all(x, dims, reduce_all);
   using XPUType = typename XPUTypeTrait<T>::Type;
 
-  auto f = [](xpu::Context* ctx,
+  auto f = [](xpu::Context* xpu_ctx,
               const T* x,
               T* y,
               const std::vector<int64_t>& xdims,
               const std::vector<int64_t>& reduce_dims) {
-    return xpu::reduce_prod<XPUType>(ctx,
+    return xpu::reduce_prod<XPUType>(xpu_ctx,
                                      reinterpret_cast<const XPUType*>(x),
                                      reinterpret_cast<XPUType*>(y),
                                      xdims,

--- a/paddle/phi/kernels/xpu/quantize_linear_kernel.cc
+++ b/paddle/phi/kernels/xpu/quantize_linear_kernel.cc
@@ -53,7 +53,7 @@ void DeQuantizeLinearKernel(const Context& dev_ctx,
 
   if (quant_axis == -1) {
     // step1: out = x * scale
-    // int broadcast_mul(Context* ctx, const T* x, const T* y, T* z, const
+    // int broadcast_mul(Context* xpu_ctx, const T* x, const T* y, T* z, const
     // std::vector<int64_t>& xshape, const std::vector<int64_t>& yshape);
     auto x_dims = x.dims();
     std::vector<int64_t> xshape = common::vectorize<int64_t>(x_dims);
@@ -72,7 +72,7 @@ void DeQuantizeLinearKernel(const Context& dev_ctx,
                        sizeof(float));
 
     // step3: out = out / qmax_as_float_xpu
-    // int broadcast_div(Context* ctx, const T* x, const T* y, T* z, const
+    // int broadcast_div(Context* xpu_ctx, const T* x, const T* y, T* z, const
     // std::vector<int64_t>& xshape, const std::vector<int64_t>& yshape);
     r = xpu::broadcast_div(dev_ctx.x_context(),
                            out_data,
@@ -85,8 +85,8 @@ void DeQuantizeLinearKernel(const Context& dev_ctx,
     auto x_dims = x.dims();
     const int64_t channel = x_dims[quant_axis];
     const int64_t channel_size = x.numel() / channel;
-    // int paddle_clip_dequant_channel(Context* ctx, const T* x, const T* scale,
-    // T* y, int qmax, int64_t channel, int64_t channel_size);
+    // int paddle_clip_dequant_channel(Context* xpu_ctx, const T* x, const T*
+    // scale, T* y, int qmax, int64_t channel, int64_t channel_size);
     int r = xpu::paddle_clip_dequant_channel<T>(dev_ctx.x_context(),
                                                 x_data,
                                                 scale_data,
@@ -112,8 +112,8 @@ void DeQuantizeLinearKernel(const Context& dev_ctx,
     T* buffer = RAII_GUARD.alloc_l3_or_gm<T>(x.numel());
     PADDLE_ENFORCE_XDNN_NOT_NULL(buffer);
 
-    // int transpose(Context* ctx, const T* x, T* y, const std::vector<int64_t>&
-    // xshape,    const std::vector<int64_t>& permute);
+    // int transpose(Context* xpu_ctx, const T* x, T* y, const
+    // std::vector<int64_t>& xshape,    const std::vector<int64_t>& permute);
     int r = xpu::transpose<T>(
         dev_ctx.x_context(), x_data, buffer, xshape, trans_axes);
     PADDLE_ENFORCE_XDNN_SUCCESS(r, "transpose");
@@ -121,8 +121,8 @@ void DeQuantizeLinearKernel(const Context& dev_ctx,
     // 按照axis=0时候的情况进行计算
     const int64_t channel = x_dims[quant_axis];
     const int64_t channel_size = x.numel() / channel;
-    // int paddle_clip_dequant_channel(Context* ctx, const T* x, const T* scale,
-    // T* y, int qmax, int64_t channel, int64_t channel_size);
+    // int paddle_clip_dequant_channel(Context* xpu_ctx, const T* x, const T*
+    // scale, T* y, int qmax, int64_t channel, int64_t channel_size);
     r = xpu::paddle_clip_dequant_channel<T>(dev_ctx.x_context(),
                                             buffer,
                                             scale_data,
@@ -164,8 +164,8 @@ void QuantizeLinearInferKernel(const Context& dev_ctx,
   T* out_data = dev_ctx.template Alloc<T>(out);
 
   if (quant_axis == -1) {
-    // int paddle_clip_quant(Context* ctx, const T* x, const T* scale, T* y, int
-    // qmax, int64_t n);
+    // int paddle_clip_quant(Context* xpu_ctx, const T* x, const T* scale, T* y,
+    // int qmax, int64_t n);
     int r = xpu::paddle_clip_quant<T>(
         dev_ctx.x_context(), x_data, scale_data, out_data, qmax, x.numel());
     PADDLE_ENFORCE_XDNN_SUCCESS(r, "paddle_clip_quant");
@@ -173,8 +173,8 @@ void QuantizeLinearInferKernel(const Context& dev_ctx,
     auto x_dims = x.dims();
     const int64_t channel = x_dims[quant_axis];
     const int64_t channel_size = x.numel() / channel;
-    // int paddle_clip_quant_channel(Context* ctx, const T* x, const T* scale,
-    // T* y, int qmax, int64_t channel, int64_t channel_size);
+    // int paddle_clip_quant_channel(Context* xpu_ctx, const T* x, const T*
+    // scale, T* y, int qmax, int64_t channel, int64_t channel_size);
     int r = xpu::paddle_clip_quant_channel<T>(dev_ctx.x_context(),
                                               x_data,
                                               scale_data,
@@ -200,8 +200,8 @@ void QuantizeLinearInferKernel(const Context& dev_ctx,
     T* buffer = RAII_GUARD.alloc_l3_or_gm<T>(x.numel());
     PADDLE_ENFORCE_XDNN_NOT_NULL(buffer);
 
-    // int transpose(Context* ctx, const T* x, T* y, const std::vector<int64_t>&
-    // xshape,    const std::vector<int64_t>& permute);
+    // int transpose(Context* xpu_ctx, const T* x, T* y, const
+    // std::vector<int64_t>& xshape,    const std::vector<int64_t>& permute);
     int r = xpu::transpose<T>(
         dev_ctx.x_context(), x_data, buffer, xshape, trans_axes);
     PADDLE_ENFORCE_XDNN_SUCCESS(r, "transpose");
@@ -209,8 +209,8 @@ void QuantizeLinearInferKernel(const Context& dev_ctx,
     // 按照axis=0时候的情况进行计算
     const int64_t channel = x_dims[quant_axis];
     const int64_t channel_size = x.numel() / channel;
-    // int paddle_clip_quant_channel(Context* ctx, const T* x, const T* scale,
-    // T* y, int qmax, int64_t channel, int64_t channel_size);
+    // int paddle_clip_quant_channel(Context* xpu_ctx, const T* x, const T*
+    // scale, T* y, int qmax, int64_t channel, int64_t channel_size);
     r = xpu::paddle_clip_quant_channel<T>(dev_ctx.x_context(),
                                           buffer,
                                           scale_data,

--- a/paddle/phi/kernels/xpu/reduce_all_kernel.cc
+++ b/paddle/phi/kernels/xpu/reduce_all_kernel.cc
@@ -30,12 +30,12 @@ void AllRawKernel(const Context& dev_ctx,
                   DenseTensor* out) {
   reduce_all = recompute_reduce_all(x, dims);
   using XPUType = typename XPUTypeTrait<T>::Type;
-  auto f = [](xpu::Context* ctx,
+  auto f = [](xpu::Context* xpu_ctx,
               const T* x,
               T* y,
               const std::vector<int64_t>& xdims,
               const std::vector<int64_t>& reduce_dims) {
-    return xpu::reduce_all<XPUType>(ctx,
+    return xpu::reduce_all<XPUType>(xpu_ctx,
                                     reinterpret_cast<const XPUType*>(x),
                                     reinterpret_cast<XPUType*>(y),
                                     xdims,

--- a/paddle/phi/kernels/xpu/reduce_any_kernel.cc
+++ b/paddle/phi/kernels/xpu/reduce_any_kernel.cc
@@ -30,12 +30,12 @@ void AnyRawKernel(const Context& dev_ctx,
                   DenseTensor* out) {
   reduce_all = recompute_reduce_all(x, dims, reduce_all);
   using XPUType = typename XPUTypeTrait<T>::Type;
-  auto f = [](xpu::Context* ctx,
+  auto f = [](xpu::Context* xpu_ctx,
               const T* x,
               T* y,
               const std::vector<int64_t>& xdims,
               const std::vector<int64_t>& reduce_dims) {
-    return xpu::reduce_any<XPUType>(ctx,
+    return xpu::reduce_any<XPUType>(xpu_ctx,
                                     reinterpret_cast<const XPUType*>(x),
                                     reinterpret_cast<XPUType*>(y),
                                     xdims,

--- a/paddle/phi/kernels/xpu/reduce_max_kernel.cc
+++ b/paddle/phi/kernels/xpu/reduce_max_kernel.cc
@@ -33,20 +33,20 @@ void MaxKernel(const Context& dev_ctx,
   }
   bool reduce_all = recompute_reduce_all(x, dims);
   using XPUType = typename XPUTypeTrait<T>::Type;
-  auto f = [](xpu::Context* ctx,
+  auto f = [](xpu::Context* xpu_ctx,
               const T* x,
               T* y,
               const std::vector<int64_t>& xdims,
               const std::vector<int64_t>& reduce_dims) {
 #ifndef PADDLE_WITH_XPU_PLUGIN
-    return xpu::reduce_max<XPUType>(ctx,
+    return xpu::reduce_max<XPUType>(xpu_ctx,
                                     reinterpret_cast<const XPUType*>(x),
                                     reinterpret_cast<XPUType*>(y),
                                     xdims,
                                     reduce_dims);
 #else
     return xpu::plugin::fast_reduce_max<XPUType>(
-        ctx,
+        xpu_ctx,
         reinterpret_cast<const XPUType*>(x),
         reinterpret_cast<XPUType*>(y),
         std::vector<int>(xdims.begin(), xdims.end()),

--- a/paddle/phi/kernels/xpu/reduce_mean_kernel.cc
+++ b/paddle/phi/kernels/xpu/reduce_mean_kernel.cc
@@ -37,20 +37,20 @@ void MeanRawKernel(const Context& dev_ctx,
 
   reduce_all = recompute_reduce_all(x, dims, reduce_all);
   using XPUType = typename XPUTypeTrait<T>::Type;
-  auto f = [](xpu::Context* ctx,
+  auto f = [](xpu::Context* xpu_ctx,
               const T* x,
               T* y,
               const std::vector<int64_t>& xdims,
               const std::vector<int64_t>& reduce_dims) {
 #ifndef PADDLE_WITH_XPU_PLUGIN
-    return xpu::reduce_mean<XPUType>(ctx,
+    return xpu::reduce_mean<XPUType>(xpu_ctx,
                                      reinterpret_cast<const XPUType*>(x),
                                      reinterpret_cast<XPUType*>(y),
                                      xdims,
                                      reduce_dims);
 #else
     return xpu::plugin::fast_reduce_mean<XPUType>(
-        ctx,
+        xpu_ctx,
         reinterpret_cast<const XPUType*>(x),
         reinterpret_cast<XPUType*>(y),
         std::vector<int>(xdims.begin(), xdims.end()),

--- a/paddle/phi/kernels/xpu/reduce_min_kernel.cc
+++ b/paddle/phi/kernels/xpu/reduce_min_kernel.cc
@@ -31,20 +31,20 @@ void MinRawKernel(const Context& dev_ctx,
   reduce_all = recompute_reduce_all(x, dims, reduce_all);
   using XPUType = typename XPUTypeTrait<T>::Type;
 
-  auto f = [](xpu::Context* ctx,
+  auto f = [](xpu::Context* xpu_ctx,
               const T* x,
               T* y,
               const std::vector<int64_t>& xdims,
               const std::vector<int64_t>& reduce_dims) {
 #ifndef PADDLE_WITH_XPU_PLUGIN
-    return xpu::reduce_min<XPUType>(ctx,
+    return xpu::reduce_min<XPUType>(xpu_ctx,
                                     reinterpret_cast<const XPUType*>(x),
                                     reinterpret_cast<XPUType*>(y),
                                     xdims,
                                     reduce_dims);
 #else
     return xpu::plugin::fast_reduce_min<XPUType>(
-        ctx,
+        xpu_ctx,
         reinterpret_cast<const XPUType*>(x),
         reinterpret_cast<XPUType*>(y),
         std::vector<int>(xdims.begin(), xdims.end()),

--- a/paddle/phi/kernels/xpu/reduce_util.h
+++ b/paddle/phi/kernels/xpu/reduce_util.h
@@ -22,14 +22,14 @@ namespace phi {
 //////// Sum Functor ///////
 struct SumFunctor {
   template <typename DeviceContext, typename X, typename Y>
-  void operator()(const DeviceContext& ctx,
+  void operator()(const DeviceContext& xpu_ctx,
                   const X* x,
                   Y* y,
                   const std::vector<int64_t>& xdims,
                   const std::vector<int64_t>& reduce_dims) {
     using XPUType = typename XPUTypeTrait<X>::Type;
 #ifndef PADDLE_WITH_XPU_PLUGIN
-    int r = xpu::reduce_sum<XPUType>(ctx,
+    int r = xpu::reduce_sum<XPUType>(xpu_ctx,
                                      reinterpret_cast<const XPUType*>(x),
                                      reinterpret_cast<XPUType*>(y),
                                      xdims,
@@ -37,7 +37,7 @@ struct SumFunctor {
     PADDLE_ENFORCE_XDNN_SUCCESS(r, "reduce_sum");
 #else
     int r = xpu::plugin::fast_reduce_sum<XPUType>(
-        ctx,
+        xpu_ctx,
         reinterpret_cast<const XPUType*>(x),
         reinterpret_cast<XPUType*>(y),
         std::vector<int>(xdims.begin(), xdims.end()),

--- a/paddle/phi/kernels/xpu/set_value_kernel.cc
+++ b/paddle/phi/kernels/xpu/set_value_kernel.cc
@@ -194,13 +194,13 @@ void SetValueImpl(const Context& dev_ctx,
   CheckIsDimsMatch(slice_dims_for_assign, new_value_dims);
 
   // do broadcasting
-  auto f = [](xpu::Context* ctx,
+  auto f = [](xpu::Context* xpu_ctx,
               const XPUType* x,
               const XPUType* y, /*unused*/
               XPUType* z,
               const std::vector<int64_t>& xshape,
               const std::vector<int64_t>& zshape) {
-    return xpu::broadcast<XPUType>(ctx, x, z, xshape, zshape);
+    return xpu::broadcast<XPUType>(xpu_ctx, x, z, xshape, zshape);
   };
 
   XPUElementwise<T, XPUType>(dev_ctx,

--- a/paddle/phi/kernels/xpu/sigmoid_cross_entropy_with_logits_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/sigmoid_cross_entropy_with_logits_grad_kernel.cc
@@ -47,9 +47,9 @@ void SigmoidCrossEntropyWithLogitsGradKernel(
   auto pos_weight_data =
       (pos_weight.get_ptr() == nullptr ? nullptr
                                        : pos_weight.get_ptr()->data<T>());
-  // int paddle_sigmoid_cross_entropy_with_logits_grad(Context* ctx, const T* x,
-  // const T* label, const T* pos_weight, const T* dy, T* dx, int* hit, int
-  // ignore_index, int64_t n);
+  // int paddle_sigmoid_cross_entropy_with_logits_grad(Context* xpu_ctx, const
+  // T* x, const T* label, const T* pos_weight, const T* dy, T* dx, int* hit,
+  // int ignore_index, int64_t n);
   int r = xpu::paddle_sigmoid_cross_entropy_with_logits_grad(
       dev_ctx.x_context(),
       reinterpret_cast<const XPUType*>(x.data<T>()),

--- a/paddle/phi/kernels/xpu/sigmoid_cross_entropy_with_logits_kernel.cc
+++ b/paddle/phi/kernels/xpu/sigmoid_cross_entropy_with_logits_kernel.cc
@@ -45,7 +45,7 @@ void SigmoidCrossEntropyWithLogitsKernel(
   auto pos_weight_data =
       (pos_weight.get_ptr() == nullptr ? nullptr
                                        : pos_weight.get_ptr()->data<T>());
-  // int paddle_sigmoid_cross_entropy_with_logits(Context* ctx, const T* x,
+  // int paddle_sigmoid_cross_entropy_with_logits(Context* xpu_ctx, const T* x,
   // const T* label, const T* pos_weight, T* y, int* hit, int ignore_index,
   // int64_t n);
   int r = xpu::paddle_sigmoid_cross_entropy_with_logits(

--- a/paddle/phi/kernels/xpu/squared_l2_norm_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/squared_l2_norm_grad_kernel.cc
@@ -45,7 +45,7 @@ void SquaredL2NormGradKernel(const Context& dev_ctx,
 
   // squared_l2_norm_grad: dx = dout(it is a scalar value!) * x * 2.0
 
-  // int scale(Context* ctx, const T* x, T* y, int64_t len, bool
+  // int scale(Context* xpu_ctx, const T* x, T* y, int64_t len, bool
   // bias_after_scale, float _scale, float _bias);
   int r = xpu::scale(dev_ctx.x_context(),
                      reinterpret_cast<const XPUType*>(x.data<T>()),

--- a/paddle/phi/kernels/xpu/squared_l2_norm_kernel.cc
+++ b/paddle/phi/kernels/xpu/squared_l2_norm_kernel.cc
@@ -34,8 +34,8 @@ void SquaredL2NormKernel(const Context& dev_ctx,
     y_for_xdnn = RAII_GUARD.alloc_l3_or_gm<float>(1);
   }
 
-  // int square_reduce_sum(Context* ctx, const T* x, float* y, int64_t len, bool
-  // is_sqrt=false);
+  // int square_reduce_sum(Context* xpu_ctx, const T* x, float* y, int64_t len,
+  // bool is_sqrt=false);
   int r = xpu::square_reduce_sum<XPUType>(
       dev_ctx.x_context(),
       reinterpret_cast<const XPUType*>(x.data<T>()),
@@ -45,7 +45,7 @@ void SquaredL2NormKernel(const Context& dev_ctx,
   PADDLE_ENFORCE_XDNN_SUCCESS(r, "square_reduce_sum");
 
   if (!std::is_same<T, float>::value) {
-    // int cast(Context* ctx, const TX* x, TY* y, int64_t len);
+    // int cast(Context* xpu_ctx, const TX* x, TY* y, int64_t len);
     int r = xpu::cast<float, XPUType>(
         dev_ctx.x_context(), y_for_xdnn, reinterpret_cast<XPUType*>(data), 1);
     PADDLE_ENFORCE_XDNN_SUCCESS(r, "cast");

--- a/paddle/phi/kernels/xpu/stride_slice_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/stride_slice_grad_kernel.cc
@@ -102,7 +102,7 @@ void StridedSliceRawGradKernel(const Context& dev_ctx,
 
     // step 1: set all value to 0
 
-    // int constant(Context* ctx, T* x, int64_t len, T val)
+    // int constant(Context* xpu_ctx, T* x, int64_t len, T val)
     int r = xpu::constant(
         dev_ctx.x_context(), x_transpose, x.numel(), static_cast<XPUType>(0));
     PADDLE_ENFORCE_XDNN_SUCCESS(r, "constant");
@@ -116,7 +116,7 @@ void StridedSliceRawGradKernel(const Context& dev_ctx,
     if (starts_in.back() == 1) {
       offset = x.numel() / 2;
     }
-    // int copy(Context* ctx, const T* x, T* y, int64_t len)
+    // int copy(Context* xpu_ctx, const T* x, T* y, int64_t len)
     r = xpu::copy<XPUType>(dev_ctx.x_context(),
                            reinterpret_cast<const XPUType*>(out_grad.data<T>()),
                            x_transpose + offset,

--- a/paddle/phi/kernels/xpu/stride_slice_kernel.cc
+++ b/paddle/phi/kernels/xpu/stride_slice_kernel.cc
@@ -120,8 +120,8 @@ void StridedSliceRawKernel(const Context& dev_ctx,
      * [1 3 5 7 9
      *  2 4 6 8 10]
      */
-    // int transpose(Context* ctx, const T* x, T* y, const std::vector<int64_t>&
-    // xshape, const std::vector<int64_t>& permute)
+    // int transpose(Context* xpu_ctx, const T* x, T* y, const
+    // std::vector<int64_t>& xshape, const std::vector<int64_t>& permute)
     int r =
         xpu::transpose<XPUType>(dev_ctx.x_context(),
                                 reinterpret_cast<const XPUType*>(x.data<T>()),
@@ -135,7 +135,7 @@ void StridedSliceRawKernel(const Context& dev_ctx,
     if (starts_in.back() == 1) {
       offset = x.numel() / 2;
     }
-    // int copy(Context* ctx, const T* x, T* y, int64_t len)
+    // int copy(Context* xpu_ctx, const T* x, T* y, int64_t len)
     r = xpu::copy<XPUType>(dev_ctx.x_context(),
                            x_transpose + offset,
                            reinterpret_cast<XPUType*>(out->data<T>()),

--- a/paddle/phi/kernels/xpu/tile_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/tile_grad_kernel.cc
@@ -81,7 +81,7 @@ void TileGradKernel(const Context& dev_ctx,
                           dims));
 
     using XPUType = typename XPUTypeTrait<T>::Type;
-    // int reduce_sum(Context* ctx, const T* x, T* y, const
+    // int reduce_sum(Context* xpu_ctx, const T* x, T* y, const
     // std::vector<int64_t>& xshape, const std::vector<int64_t>& rdims)
     const auto* out_data = reinterpret_cast<const XPUType*>(out_grad.data<T>());
     auto* x_grad_data = reinterpret_cast<XPUType*>(x_grad->data<T>());


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->
kernels/xpu目录下使用 dev_ctx.x_context() 获取的 ctx 重命名xpu_ctx，这样容易识别