### PR TITLE
[SOT] Handle `in_sot_simulation_mode` same as psdb functions

### DIFF
--- a/python/paddle/base/dygraph/base.py
+++ b/python/paddle/base/dygraph/base.py
@@ -66,10 +66,17 @@ def in_to_static_mode() -> bool:
 
 def in_sot_simulation_mode() -> bool:
     """
-    Return a bool value that indicates whether running code under SOT simulation context.
+    Returns whether the code is running under the SOT simulation context.
 
+    NOTE: Always returns False because if this function is called directly from native Python,
+    it is not within the SOT simulation process. In that case, returning False is correct.
+    If the code is running within the SOT simulation process, the function will be represented
+    by UserDefinedFunctionVariable, which is specially handled in its `call_function` method
+    to return True when this function is called.
+
+    This design avoids introducing `global_var` into the guard logic.
     """
-    return global_var._in_sot_simulation_mode_
+    return False
 
 
 # TODO(Aurelius84): Need to remove this alias after clean usage in PaddleX
@@ -117,19 +124,6 @@ def to_static_mode_guard(
         yield
     finally:
         global_var._in_to_static_mode_ = original_val
-
-
-@signature_safe_contextmanager
-def sot_simulation_mode_guard(
-    is_sot_simulation: bool = True,
-) -> Generator[None, None, None]:
-    global global_var
-    original_val = global_var._in_sot_simulation_mode_
-    global_var._in_sot_simulation_mode_ = is_sot_simulation
-    try:
-        yield
-    finally:
-        global_var._in_sot_simulation_mode_ = original_val
 
 
 @signature_safe_contextmanager

--- a/python/paddle/base/framework.py
+++ b/python/paddle/base/framework.py
@@ -220,7 +220,6 @@ class GlobalThreadLocal(threading.local):
         """
         global _dygraph_tracer_
         self._in_to_static_mode_ = False
-        self._in_sot_simulation_mode_ = False
         self._functional_dygraph_context_manager = None
         self._dygraph_tracer_ = _dygraph_tracer_
         env_pir_enabled = os.environ.get("FLAGS_enable_pir_api")
@@ -242,9 +241,6 @@ class GlobalThreadLocal(threading.local):
     def __str__(self):
         strings = []
         strings.append("_in_to_static_mode_:" + str(self._in_to_static_mode_))
-        strings.append(
-            "_in_sot_simulation_mode_:" + str(self._in_sot_simulation_mode_)
-        )
         strings.append(
             "_functional_dygraph_context_manager:"
             + str(self._functional_dygraph_context_manager)

--- a/python/paddle/jit/sot/opcode_translator/executor/executor_cache.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/executor_cache.py
@@ -19,7 +19,6 @@ import traceback
 from typing import TYPE_CHECKING
 
 import paddle
-from paddle.base.dygraph.base import sot_simulation_mode_guard
 
 from ...profiler import EventGuard, event_register
 from ...psdb import NO_FALLBACK_CODES
@@ -363,11 +362,12 @@ def start_translate(
         simulator = OpcodeExecutor(vframe, graph)
         simulator.check_code_simulatable()
         InfoCollector().attach(CompileCountInfo, frame.f_code)
-        with sot_simulation_mode_guard(True):
-            new_custom_code, guard_fn = simulator.transform(frame)
-            if ENV_SOT_ENABLE_STRICT_GUARD_CHECK.get():
-                assert guard_fn(frame)
-                assert guard_fn.mirror_guard(frame)
+
+        new_custom_code, guard_fn = simulator.transform(frame)
+        if ENV_SOT_ENABLE_STRICT_GUARD_CHECK.get():
+            assert guard_fn(frame)
+            assert guard_fn.mirror_guard(frame)
+
         if not simulator._graph.need_cache:
             return (
                 CustomCode(None, True),

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/callable.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/callable.py
@@ -30,7 +30,10 @@ from typing import (
 )
 
 import paddle
-from paddle.base.dygraph.base import _DecoratorContextManager
+from paddle.base.dygraph.base import (
+    _DecoratorContextManager,
+    in_sot_simulation_mode,
+)
 
 from .... import psdb
 from ....profiler import EventGuard
@@ -277,7 +280,7 @@ class UserDefinedFunctionVariable(FunctionVariable):
                 f"Fallback by psdb.fallback (recursive={recursive_var.get_py_value()})",
                 disable_eval_frame=recursive_var.get_py_value(),
             )
-        elif self.value is psdb.in_sot:
+        elif self.value in {psdb.in_sot, in_sot_simulation_mode}:
             return ConstantVariable.wrap_literal(True, self.graph)
         return None
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->

原有的 guard `sot_simulation_mode_guard` 主要是用来记录是否在进行SOT模拟这个状态

```python
def in_sot_simulation_mode() -> bool:
	return global_var._in_sot_simulation_mode_
```

`sot_simulation_mode_guard` 和 `in_sot_simulation_mode` 其实都通过访问 `global_var` 这个全局变量来进行状态的读写

但在 `nn.Layer` 的 `__call__` 中：

```python
    def __call__(self, *inputs: Any, **kwargs: Any) -> Any:
        if (
            (not in_to_static_mode())
            and (not self._forward_pre_hooks)
            and (not self._forward_post_hooks)
            and (self.__class__._build_once is Layer._build_once or self._built)
            and in_dygraph_mode()
            and (not in_profiler_mode() or in_sot_simulation_mode())
        ):
            return self.forward(*inputs, **kwargs)
        else:
            return self._dygraph_call_func(*inputs, **kwargs)
```

在模拟执行过程中，开启 profile 时，`in_sot_simulation_mode` 会被加入 guard 中，导致 Guard miss 多次后，自动回退到动态图执行

```
[Cache] missed at frame.f_locals['self'].embeddings.__call__.__globals__['in_to_static_mode'].__globals__['global_var']._in_sot_simulation_mode_ == True
```

这里我们直接移除 `global_var._in_sot_simulation_mode_` 来避免被加到 guard 中

同时 `in_sot_simulation_mode` 直接返回 False

```python
def in_sot_simulation_mode() -> bool:
	return False
```

在非SOT模拟过程中，这里原生Python执行，直接返回 False，没毛病
在 SOT 模拟时，`in_sot_simulation_mode` 是 `UserDefinedFunctionVariable` 只需要在这里特判一下，让其返回 True 即可


cc @SigureMo
PCard-66972