### PR TITLE
[0-size Tensor No.6、7、284、285]Add 0-size Tensor support for amin

### DIFF
--- a/paddle/phi/kernels/cpu/reduce_amax_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/reduce_amax_grad_kernel.cc
@@ -28,6 +28,10 @@ void ReduceAMaxGradKernel(const Context& dev_ctx,
                           bool keep_dim,
                           bool reduce_all,
                           DenseTensor* x_grad) {
+  if (x_grad && x_grad->numel() == 0) {
+    dev_ctx.template Alloc<T>(x_grad);
+    return;
+  }
   reduce_all = recompute_reduce_all(x, dims, reduce_all);
   ReduceGradKernel<Context, T, funcs::AMaxOrAMinGradFunctor>(
       dev_ctx, x, out, out_grad, dims, keep_dim, reduce_all, x_grad);

--- a/paddle/phi/kernels/cpu/reduce_amin_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/reduce_amin_grad_kernel.cc
@@ -28,6 +28,10 @@ void ReduceAMinGradKernel(const Context& dev_ctx,
                           bool keep_dim,
                           bool reduce_all,
                           DenseTensor* x_grad) {
+  if (x_grad && x_grad->numel() == 0) {
+    dev_ctx.template Alloc<T>(x_grad);
+    return;
+  }
   reduce_all = recompute_reduce_all(x, dims, reduce_all);
   ReduceGradKernel<Context, T, funcs::AMaxOrAMinGradFunctor>(
       dev_ctx, x, out, out_grad, dims, keep_dim, reduce_all, x_grad);

--- a/paddle/phi/kernels/funcs/reduce_function.h
+++ b/paddle/phi/kernels/funcs/reduce_function.h
@@ -1460,16 +1460,10 @@ void ReduceKernelImpl(const Context& dev_ctx,
                       const std::vector<int64_t>& dims,
                       bool keep_dim,
                       bool reduce_all) {
+  dev_ctx.template Alloc<OutT>(output);
   if (input.numel() == 0) {
-    dev_ctx.template Alloc<OutT>(output);
     return;
   }
-  PADDLE_ENFORCE_GT(input.numel(),
-                    0,
-                    common::errors::InvalidArgument(
-                        "Tensor need be reduced must not empty."));
-
-  dev_ctx.template Alloc<OutT>(output);
 
   if (reduce_all) {
     // Flatten and reduce 1-D tensor

--- a/paddle/phi/kernels/funcs/reduce_function.h
+++ b/paddle/phi/kernels/funcs/reduce_function.h
@@ -1460,6 +1460,10 @@ void ReduceKernelImpl(const Context& dev_ctx,
                       const std::vector<int64_t>& dims,
                       bool keep_dim,
                       bool reduce_all) {
+  if (input.numel() == 0) {
+    dev_ctx.template Alloc<OutT>(output);
+    return;
+  }
   PADDLE_ENFORCE_GT(input.numel(),
                     0,
                     common::errors::InvalidArgument(

--- a/paddle/phi/kernels/xpu/reduce_max_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/reduce_max_grad_kernel.cc
@@ -31,6 +31,10 @@ void ReduceMaxGradKernel(const Context& dev_ctx,
                          bool keep_dim,
                          bool reduce_all,
                          DenseTensor* x_grad) {
+  if (x_grad && x_grad->numel() == 0) {
+    dev_ctx.template Alloc<T>(x_grad);
+    return;
+  }
   using XPUDataType = typename XPUTypeTrait<T>::Type;
   reduce_all = recompute_reduce_all(x, dims_arr, reduce_all);
   auto dims = dims_arr.GetData();

--- a/paddle/phi/kernels/xpu/reduce_min_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/reduce_min_grad_kernel.cc
@@ -31,6 +31,10 @@ void ReduceMinGradKernel(const Context& dev_ctx,
                          bool keep_dim,
                          bool reduce_all,
                          DenseTensor* x_grad) {
+  if (x_grad && x_grad->numel() == 0) {
+    dev_ctx.template Alloc<T>(x_grad);
+    return;
+  }
   reduce_all = recompute_reduce_all(x, dims_arr, reduce_all);
   auto dims = dims_arr.GetData();
 

--- a/test/legacy_test/test_max_min_amax_amin_op.py
+++ b/test/legacy_test/test_max_min_amax_amin_op.py
@@ -264,5 +264,23 @@ class TestMaxMinAmaxAminAPI7(TestMaxMinAmaxAminAPI):
         _test_dygraph('min')
 
 
+class TestMaxMinAmaxAminAPI_ZeroSize(TestMaxMinAmaxAminAPI):
+    def init_case(self):
+        self.x_np = np.random.randn(1, 0, 10).astype(np.float32)
+        self.shape = [1, 0, 10]
+        self.dtype = 'float32'
+        self.axis = 0
+        self.keepdim = False
+
+
+class TestMaxMinAmaxAminAPI_ZeroSize2(TestMaxMinAmaxAminAPI):
+    def init_case(self):
+        self.x_np = np.random.randn(1, 0, 10).astype(np.float32)
+        self.shape = [1, 0, 10]
+        self.dtype = 'float32'
+        self.axis = -1
+        self.keepdim = True
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/legacy_test/test_max_min_amax_amin_op.py
+++ b/test/legacy_test/test_max_min_amax_amin_op.py
@@ -92,6 +92,7 @@ class TestMaxMinAmaxAminAPI(unittest.TestCase):
 
     def test_static_graph(self):
         def _test_static_graph(func):
+            paddle.enable_static()
             startup_program = base.Program()
             train_program = base.Program()
             with base.program_guard(startup_program, train_program):
@@ -107,6 +108,7 @@ class TestMaxMinAmaxAminAPI(unittest.TestCase):
                     fetch_list=[out],
                 )
                 self.assertTrue((np.array(res[0]) == self.np_out[func]).all())
+            paddle.disable_static()
 
         _test_static_graph('amax')
         _test_static_graph('amin')


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->
[0-size Tensor No.6、7、284、285]

paddle.amax
paddle.amin
paddle.Tensor.amax
paddle.Tensor.amin

[0-size Tensor Job2 No.47、49、88、90]
任务二中在同一个单测文件
paddle.max
paddle.min
paddle.Tensor.max
paddle.Tensor.min

修改 paddle/phi/kernels/funcs/reduce_function.h 中检查
修改 amax, amin CPU 反向, max, min 使用的是amax, amin，修改 max,min XPU 反向，以解决CI中报错
infermeta 不用修改

PaddleAPITest 测试 
amax
GPU 测试通过
![image](https://github.com/user-attachments/assets/7df96810-7070-4bc8-baa7-14bbe5eeaf59)
CPU 测试通过
![image](https://github.com/user-attachments/assets/3629d1de-18fd-4ad3-8286-fe0f9973b509)

amin
GPU 测试通过
![image](https://github.com/user-attachments/assets/63a26576-d142-48a2-8914-a78f36739445)
CPU 测试通过
![image](https://github.com/user-attachments/assets/1631d317-5f8f-4e65-94b6-7d8c224b9c4a)

max
GPU 测试通过
![image](https://github.com/user-attachments/assets/2d704086-8818-4179-a9ee-279bccd1cfc3)
CPU 错误为torch error
![image](https://github.com/user-attachments/assets/0efe39c7-a0ce-4d0c-9f89-a244c1823882)

min
GPU 错误为torch error
![image](https://github.com/user-attachments/assets/7ac5555d-5e1a-48b6-bfba-d0a145b38133)
CPU 错误为numpy error
![image](https://github.com/user-attachments/assets/4d443589-eb3e-429e-b05d-ac8c7d83c3b5)
