### PR TITLE
[Dy2St] Remove `ShadowFeedOp` for `DataOp` downstream

### DIFF
--- a/paddle/fluid/eager/to_static/run_program_op_node.h
+++ b/paddle/fluid/eager/to_static/run_program_op_node.h
@@ -468,6 +468,9 @@ inline void PirRunProgramAPI(
     // Step 3. create new interpretercore
     auto passed_kernel_program = paddle::framework::ApplyIrPass(
         forward_program.get(), place, no_need_buffer_name_set);
+    const auto &new_block = passed_kernel_program->block();
+    passed_kernel_program = paddle::framework::ApplyRemoveShadowFeedPass(
+        std::move(passed_kernel_program), new_block, place, global_inner_scope);
     interpreter_core = paddle::framework::CreatePirInterpreterCoreInfoToCache(
         std::move(passed_kernel_program),
         place,

--- a/paddle/fluid/pir/transforms/general/remove_shadow_feed_pass.cc
+++ b/paddle/fluid/pir/transforms/general/remove_shadow_feed_pass.cc
@@ -78,11 +78,24 @@ class RemoveShadowFeedPattern
   bool IsSamePlaceShadowFeed(paddle::dialect::PhiKernelOp op) const {
     if (op.op_name() == "pd_op.shadow_feed") {
       auto in = op.operand_source(0);
-      if (!kwargs_map_.count(in)) {
-        return false;
-      }
-      auto in_name = kwargs_map_.at(in);
-      auto *var = scope_->FindVar(in_name);
+      auto *var = [&] -> paddle::framework::Variable * {
+        auto *defined_op = in.defining_op();
+        if (defined_op && defined_op->isa<paddle::dialect::PhiKernelOp>()) {
+          if (defined_op->dyn_cast<paddle::dialect::PhiKernelOp>()
+                  .kernel_name() != "data")
+            return nullptr;
+          const auto &name = defined_op->attributes()
+                                 .at("name")
+                                 .dyn_cast<pir::StrAttribute>()
+                                 .AsString();
+          return scope_->FindVar(name);
+        }
+        if (kwargs_map_.count(in)) {
+          const auto &name = kwargs_map_.at(in);
+          return scope_->FindVar(name);
+        }
+        return nullptr;
+      }();
       if (!var) {
         return false;
       }

--- a/paddle/fluid/pir/transforms/general/remove_shadow_feed_pass.cc
+++ b/paddle/fluid/pir/transforms/general/remove_shadow_feed_pass.cc
@@ -78,7 +78,7 @@ class RemoveShadowFeedPattern
   bool IsSamePlaceShadowFeed(paddle::dialect::PhiKernelOp op) const {
     if (op.op_name() == "pd_op.shadow_feed") {
       auto in = op.operand_source(0);
-      auto *var = [&] -> paddle::framework::Variable * {
+      auto *var = [&]() -> paddle::framework::Variable * {
         auto *defined_op = in.defining_op();
         if (defined_op && defined_op->isa<paddle::dialect::PhiKernelOp>()) {
           if (defined_op->dyn_cast<paddle::dialect::PhiKernelOp>()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
 Improve remove_shadow_feed_pass

cc @SigureMo 
pcard-67164