### PR TITLE
[0-size Tensor Job2 No.17-20、31-34] Add 0-size Tensor support for segment_max

### DIFF
--- a/paddle/phi/kernels/impl/segment_pool_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/segment_pool_grad_kernel_impl.h
@@ -34,6 +34,10 @@ void SegmentPoolGradKernel(const Context& dev_ctx,
   dev_ctx.template Alloc<T>(x_grad);
   phi::funcs::SetConstant<Context, T> set_zero;
   set_zero(dev_ctx, x_grad, static_cast<T>(0));
+  // return after allocation if x_grad is empty.
+  if (x_grad && x_grad->numel() == 0) {
+    return;
+  }
 
   auto index_type = segment_ids.type();
   if (index_type == DataType::INT32) {

--- a/paddle/phi/kernels/impl/segment_pool_kernel_impl.h
+++ b/paddle/phi/kernels/impl/segment_pool_kernel_impl.h
@@ -42,10 +42,6 @@ void SegmentKernelLaunchHelper(const Context& dev_ctx,
                         "dimension size is 1. Segment_ids's shape is: [%s].",
                         segment_ids.dims()));
 
-  if (x.numel() == 0 || segment_ids.numel() == 0) {
-    return;
-  }
-
   bool cpu_place = dev_ctx.GetPlace().GetType() == phi::AllocationType::CPU;
   if (cpu_place) {
     auto dims = x.dims();
@@ -112,6 +108,10 @@ void SegmentKernelLaunchHelper(const Context& dev_ctx,
     }
   }
 #endif
+  // return after allocation, if x or segment_ids is empty tensor.
+  if (x.numel() == 0 || segment_ids.numel() == 0) {
+    return;
+  }
 
   phi::funcs::SegmentPoolFunctor<Context, T, IndexT> pool;
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->
17	paddle.geometric.segment_max
18	paddle.geometric.segment_mean
19	paddle.geometric.segment_min	
20	paddle.geometric.segment_sum

31	paddle.incubate.segment_max		
32	paddle.incubate.segment_mean		
33	paddle.incubate.segment_min		
34	paddle.incubate.segment_sum
paddle.incubate.* 算子和paddle.geometric.*相同

修改前向和反向，CPU/GPU 都使用impl
infermeta 没有修改

PaddleAPITest 测试numpy error, 其他通过
paddle.geometric.segment_max
GPU
![image](https://github.com/user-attachments/assets/3cdd7453-134a-4bf5-87a5-d814e8d7ea9c)
CPU
![image](https://github.com/user-attachments/assets/8c96c5c9-da42-4a9b-bf87-b6a87aca3645)

其他算子相同

paddle.incubate.* 算子和paddle.geometric.*相同，只是增加deprecation 提示
![image](https://github.com/user-attachments/assets/e0735093-0317-403d-96fe-b5f38120de33)
python/paddle/incubate/tensor/math.py
![image](https://github.com/user-attachments/assets/af75106d-4c73-4187-a8f6-5790f66174fc)
