### PR TITLE
[Accuracy diff No.86] Fix accuracy diff for paddle.gammaln API

### DIFF
--- a/test/legacy_test/test_gammaln_op.py
+++ b/test/legacy_test/test_gammaln_op.py
@@ -110,6 +110,36 @@ class TestGammalnBigNumberOp(TestGammalnOp):
         )
 
 
+class TestGammalnNegativeInputFP64Op(TestGammalnOp):
+    def setUp(self):
+        self.op_type = 'gammaln'
+        self.python_api = paddle.gammaln
+        self.init_dtype_type()
+        self.init_shape()
+        self.x = np.random.random(self.shape).astype(self.dtype) - 1
+        self.inputs = {'x': self.x}
+        out = ref_gammaln(self.x)
+        self.outputs = {'out': out}
+
+    def init_dtype_type(self):
+        self.dtype = np.float64
+
+    def test_check_grad(self):
+        d_out = self.outputs['out']
+        d_x = ref_gammaln_grad(self.x, d_out)
+        self.check_grad(
+            ['x'],
+            'out',
+            user_defined_grads=[
+                d_x,
+            ],
+            user_defined_grad_outputs=[
+                d_out,
+            ],
+            check_pir=True,
+        )
+
+
 @unittest.skipIf(
     not core.is_compiled_with_cuda()
     or not core.is_bfloat16_supported(core.CUDAPlace(0)),


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
原问题是输入小于等于0时 gammaln 的梯度会直接返回 0，参照 torch 的实现对 gammaln_grad kernel 进行了修改

回测结果：
![image](https://github.com/user-attachments/assets/f1b268e4-5385-4718-a082-ab30af3e2dcf)
