### PR TITLE
在KaimingNormal/Uniform中增加mode参数

### DIFF
--- a/python/paddle/nn/initializer/kaiming.py
+++ b/python/paddle/nn/initializer/kaiming.py
@@ -343,6 +343,7 @@ class KaimingUniform(MSRAInitializer):
         fan_in (float32|None, optional): fan_in (in_features) of trainable Tensor, If None, it will be inferred automatically. If you don't want to use in_features of the Tensor, you can set the value of 'fan_in' smartly by yourself. Default is None.
         negative_slope (float, optional): negative_slope (only used with leaky_relu). Default is 0.0.
         nonlinearity(str, optional): the non-linear function. Default is relu.
+        mode(str, optional): the mode of initialization, can be 'fan_in' or 'fan_out'. When set to 'fan_in', the fan_in parameter is used for initialization. When set to 'fan_out', the out_features of trainable Tensor will be used. Default is 'fan_in'.
 
     Note:
         It is recommended to set fan_in to None for most cases.
@@ -364,6 +365,7 @@ class KaimingUniform(MSRAInitializer):
         fan_in: float | None = None,
         negative_slope: float = 0.0,
         nonlinearity: str = 'relu',
+        mode: str = 'fan_in',
     ) -> None:
         super().__init__(
             uniform=True,
@@ -371,4 +373,5 @@ class KaimingUniform(MSRAInitializer):
             seed=0,
             negative_slope=negative_slope,
             nonlinearity=nonlinearity,
+            mode=mode,
         )

--- a/python/paddle/nn/initializer/kaiming.py
+++ b/python/paddle/nn/initializer/kaiming.py
@@ -90,12 +90,12 @@ class MSRAInitializer(Initializer):
         self._mode = mode
         if self._mode not in ['fan_in', 'fan_out']:
             raise ValueError(
-                "The mode of MSRAInitializer should be 'fan_in' or 'fan_out', "
+                "The mode of KaimingNormal/KaimingUniform should be 'fan_in' or 'fan_out', "
                 f"but received {self._mode}."
             )
         if self._mode == 'fan_out' and self._fan_in is not None:
             raise ValueError(
-                "The mode of MSRAInitializer is 'fan_out', "
+                "The mode of KaimingNormal/KaimingUniform is 'fan_out', "
                 "but fan_in is set. Please set fan_in to None."
             )
 

--- a/python/paddle/nn/initializer/kaiming.py
+++ b/python/paddle/nn/initializer/kaiming.py
@@ -62,6 +62,7 @@ class MSRAInitializer(Initializer):
         seed (int32, optional): random seed. Default is 0.
         negative_slope (float, optional): negative_slope (only used with leaky_relu). Default is 0.0.
         nonlinearity(str, optional): the non-linear function. Default is relu.
+        mode(str, optional): the mode of initialization, can be 'fan_in' or 'fan_out'. When set to 'fan_in', the fan_in parameter is used for initialization. When set to 'fan_out', the out_features of trainable Tensor will be used. Default is 'fan_in'.
 
     Note:
         It is recommended to set fan_in to None for most cases.
@@ -75,6 +76,7 @@ class MSRAInitializer(Initializer):
         seed: int = 0,
         negative_slope: float = 0,
         nonlinearity: _NonLinearity = 'relu',
+        mode: str = 'fan_in',
     ) -> None:
         """Constructor for MSRAInitializer"""
         assert uniform is not None
@@ -85,6 +87,17 @@ class MSRAInitializer(Initializer):
         self._seed = seed
         self._negative_slope = negative_slope
         self._nonlinearity = nonlinearity
+        self._mode = mode
+        if self._mode not in ['fan_in', 'fan_out']:
+            raise ValueError(
+                "The mode of MSRAInitializer should be 'fan_in' or 'fan_out', "
+                f"but received {self._mode}."
+            )
+        if self._mode == 'fan_out' and self._fan_in is not None:
+            raise ValueError(
+                "The mode of MSRAInitializer is 'fan_out', "
+                "but fan_in is set. Please set fan_in to None."
+            )
 
     def forward(
         self, var: paddle.Tensor, block: paddle.pir.Block | None = None
@@ -110,7 +123,10 @@ class MSRAInitializer(Initializer):
         f_in, f_out = self._compute_fans(var)
 
         # If fan_in is passed, use it
-        fan_in = f_in if self._fan_in is None else self._fan_in
+        if self._mode == 'fan_in':
+            fan_in = f_in if self._fan_in is None else self._fan_in
+        if self._mode == 'fan_out':
+            fan_in = f_out
 
         if self._seed == 0:
             self._seed = block.program.random_seed
@@ -273,6 +289,7 @@ class KaimingNormal(MSRAInitializer):
         fan_in (float32|None, optional): fan_in (in_features) of trainable Tensor, If None, it will be inferred automatically. If you don't want to use in_features of the Tensor, you can set the value of 'fan_in' smartly by yourself. Default is None.
         negative_slope (float, optional): negative_slope (only used with leaky_relu). Default is 0.0.
         nonlinearity(str, optional): the non-linear function. Default is relu.
+        mode(str, optional): the mode of initialization, can be 'fan_in' or 'fan_out'. When set to 'fan_in', the fan_in parameter is used for initialization. When set to 'fan_out', the out_features of trainable Tensor will be used. Default is 'fan_in'.
 
     Note:
         It is recommended to set fan_in to None for most cases.
@@ -294,6 +311,7 @@ class KaimingNormal(MSRAInitializer):
         fan_in: float | None = None,
         negative_slope: float = 0.0,
         nonlinearity: str = 'relu',
+        mode: str = 'fan_in',
     ) -> None:
         super().__init__(
             uniform=False,
@@ -301,6 +319,7 @@ class KaimingNormal(MSRAInitializer):
             seed=0,
             negative_slope=negative_slope,
             nonlinearity=nonlinearity,
+            mode=mode,
         )
 
 

--- a/test/legacy_test/test_initializer.py
+++ b/test/legacy_test/test_initializer.py
@@ -1712,6 +1712,26 @@ class TestMSRAInitializerFanoutDygraph(unittest.TestCase):
             )
             msra_(tensor)
 
+    def test_msra_uniform_fanout_initializer(self, dtype="float32"):
+        paddle.disable_static()
+
+        tensor = paddle.zeros([16, 1024])
+        tensor.stop_gradient = False
+
+        msra_ = paddle.nn.initializer.KaimingUniform(mode='fan_out')
+        msra_(tensor)
+
+        hist, _ = output_hist(tensor.numpy())
+
+        fan_out = tensor.shape[1]
+        limit = np.sqrt(6.0 / fan_out)
+        theory_data = np.random.uniform(-limit, limit, [16, 1024])
+
+        hist2, _ = output_hist(theory_data)
+
+        np.testing.assert_allclose(hist, hist2, rtol=0, atol=0.01)
+        paddle.enable_static()
+
 
 class TestConsistencyOfDynamicAndStaticGraph(unittest.TestCase):
     def test_order(self):

--- a/test/legacy_test/test_initializer.py
+++ b/test/legacy_test/test_initializer.py
@@ -1671,6 +1671,48 @@ class TestMSRAInitializerDygraph(unittest.TestCase):
         paddle.enable_static()
 
 
+class TestMSRAInitializerFanoutDygraph(unittest.TestCase):
+    def test_msra_fanout_initializer(self, dtype="float32"):
+        """
+        In dygraph mode, we can use initializer directly to initialize a tensor.
+        """
+        paddle.disable_static()
+
+        tensor = paddle.zeros([16, 1024])
+        tensor.stop_gradient = False
+
+        msra_ = paddle.nn.initializer.KaimingNormal(mode='fan_out')
+        msra_(tensor)
+
+        hist, _ = output_hist(tensor.numpy())
+
+        hist2, _ = output_hist(
+            np.random.normal(0, np.sqrt(2.0 / (1024)), [16, 1024])
+        )
+
+        np.testing.assert_allclose(hist, hist2, rtol=0, atol=0.01)
+        paddle.enable_static()
+
+    def test_msra_invalid_fanout_initializer(self, dtype="float32"):
+        """
+        In dygraph mode, we can use initializer directly to initialize a tensor.
+        """
+        paddle.disable_static()
+
+        tensor = paddle.zeros([16, 1024])
+        tensor.stop_gradient = False
+
+        with self.assertRaises(ValueError):
+            msra_ = paddle.nn.initializer.KaimingNormal(mode='fan')
+            msra_(tensor)
+
+        with self.assertRaises(ValueError):
+            msra_ = paddle.nn.initializer.KaimingNormal(
+                fan_in=1, mode='fan_out'
+            )
+            msra_(tensor)
+
+
 class TestConsistencyOfDynamicAndStaticGraph(unittest.TestCase):
     def test_order(self):
         paddle.set_device('cpu')


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Improvements

### Description
<!-- Describe what you’ve done -->

**当前问题**  
paddle.nn.initializer.KaimingNormal目前只fan_in模式，不支持fan_out模式，fan_out需要自己计算out_feature值后填入fan_in参数  

**解决方案**  
paddle.nn.initializer.KaimingNormal中增加一个mode参数：
- mode参数可以设置为'fan_in'或者'fan_out'
- 在mode='fan_in'时，fan_in参数才会生效
- 在mode='fan_out'时，会自动计算out feature值用于计算