### PR TITLE
[0-size Tensor Job2 No.35] Add 0-size Tensor support for softmax_mask_fuse_upper_triangle

### DIFF
--- a/paddle/phi/kernels/fusion/gpu/fused_softmax_mask_upper_triangle_grad_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/fused_softmax_mask_upper_triangle_grad_kernel.cu
@@ -154,6 +154,9 @@ void FusedSoftmaxMaskFuseUpperTriangleGradKernel(const Context& dev_ctx,
   auto* softmax_rst = &out;
 
   auto* x_grad_data = dev_ctx.template Alloc<T>(x_grad);
+  if (x_grad && x_grad->numel() == 0) {
+    return;
+  }
 
   auto* grad_y_data = grad_y->data<T>();
   auto* softmax_rst_data = softmax_rst->data<T>();

--- a/paddle/phi/kernels/fusion/gpu/fused_softmax_mask_upper_triangle_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/fused_softmax_mask_upper_triangle_kernel.cu
@@ -155,6 +155,9 @@ void FusedSoftmaxMaskFuseUpperTriangleKernel(const Context& dev_ctx,
 
   auto* x_data = x_ptr->data<T>();
   auto* y_data = dev_ctx.template Alloc<T>(out);
+  if (out && out->numel() == 0) {
+    return;
+  }
 
   auto x_dim = x_ptr->dims();
   auto batches = x_dim[0];

--- a/test/legacy_test/test_softmax_mask_fuse_upper_triangle_op.py
+++ b/test/legacy_test/test_softmax_mask_fuse_upper_triangle_op.py
@@ -63,6 +63,19 @@ class TestSoftmaxMaskFuseOp(OpTest):
 @unittest.skipIf(
     not core.is_compiled_with_cuda(), "core is not compiled with CUDA"
 )
+class TestSoftmaxMaskFuseOp_ZeroSize(TestSoftmaxMaskFuseOp):
+    def setUp(self):
+        self.op_type = "fused_softmax_mask_upper_triangle"
+        self.python_api = paddle.incubate.softmax_mask_fuse_upper_triangle
+        x = np.random.random((1, 1, 0, 32)).astype("float16")
+        self.inputs = {'X': x}
+        rst = _get_softmax_upper(x)
+        self.outputs = {'Out': rst}
+
+
+@unittest.skipIf(
+    not core.is_compiled_with_cuda(), "core is not compiled with CUDA"
+)
 class TestSoftmaxMaskFuseOp1(OpTest):
     def setUp(self):
         self.op_type = "fused_softmax_mask_upper_triangle"


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->
35 paddle.incubate.softmax_mask_fuse_upper_triangle
修改GPU 前向和反向
infermeta 没有修改

PaddleAPITest测试通过
![image](https://github.com/user-attachments/assets/3aacb778-1cd8-4b60-a0e6-9fe69c4e568c)
