### PR TITLE
Rename the conflicting variables

### DIFF
--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -2937,9 +2937,9 @@ All parameter, weight, gradient are variables in Paddle.
       .def_property_readonly(
           "name", [](const phi::DeviceProp &prop) { return prop.name; })
       .def_property_readonly(
-          "major", [](const phi::DeviceProp &prop) { return prop.DeviceMajor; })
+          "major", [](const phi::DeviceProp &prop) { return prop.deviceMajor; })
       .def_property_readonly(
-          "minor", [](const phi::DeviceProp &prop) { return prop.DeviceMinor; })
+          "minor", [](const phi::DeviceProp &prop) { return prop.deviceMinor; })
       .def_property_readonly(
           "total_memory",
           [](const phi::DeviceProp &prop) { return prop.totalGlobalMem; })
@@ -2955,8 +2955,8 @@ All parameter, weight, gradient are variables in Paddle.
       .def("__repr__", [](const phi::DeviceProp &prop) {
         std::stringstream ostr;
         ostr << "_customDeviceProperties(name='" << prop.name
-             << "', major=" << prop.DeviceMajor
-             << ", minor=" << prop.DeviceMinor
+             << "', major=" << prop.deviceMajor
+             << ", minor=" << prop.deviceMinor
              << ", total_memory=" << prop.totalGlobalMem / (1024 * 1024)
              << "MB, multi_processor_count=" << prop.multiProcessorCount << ")";
         return ostr.str();

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -2937,9 +2937,9 @@ All parameter, weight, gradient are variables in Paddle.
       .def_property_readonly(
           "name", [](const phi::DeviceProp &prop) { return prop.name; })
       .def_property_readonly(
-          "major", [](const phi::DeviceProp &prop) { return prop.major; })
+          "major", [](const phi::DeviceProp &prop) { return prop.DeviceMajor; })
       .def_property_readonly(
-          "minor", [](const phi::DeviceProp &prop) { return prop.minor; })
+          "minor", [](const phi::DeviceProp &prop) { return prop.DeviceMinor; })
       .def_property_readonly(
           "total_memory",
           [](const phi::DeviceProp &prop) { return prop.totalGlobalMem; })
@@ -2955,7 +2955,8 @@ All parameter, weight, gradient are variables in Paddle.
       .def("__repr__", [](const phi::DeviceProp &prop) {
         std::stringstream ostr;
         ostr << "_customDeviceProperties(name='" << prop.name
-             << "', major=" << prop.major << ", minor=" << prop.minor
+             << "', major=" << prop.DeviceMajor
+             << ", minor=" << prop.DeviceMinor
              << ", total_memory=" << prop.totalGlobalMem / (1024 * 1024)
              << "MB, multi_processor_count=" << prop.multiProcessorCount << ")";
         return ostr.str();

--- a/paddle/phi/backends/custom/custom_device.cc
+++ b/paddle/phi/backends/custom/custom_device.cc
@@ -559,8 +559,8 @@ class CustomDevice : public DeviceInterface {
     }
     VLOG(10) << Type() << " get device properties"
              << "DeviceProperties(name='" << prop.name
-             << "', major=" << prop.DeviceMajor
-             << ", minor=" << prop.DeviceMinor
+             << "', major=" << prop.deviceMajor
+             << ", minor=" << prop.deviceMajor
              << ", total_memory=" << prop.totalGlobalMem / (1024 * 1024)
              << "MB, multi_processor_count=" << prop.multiProcessorCount << ")";
     return prop;

--- a/paddle/phi/backends/custom/custom_device.cc
+++ b/paddle/phi/backends/custom/custom_device.cc
@@ -559,7 +559,8 @@ class CustomDevice : public DeviceInterface {
     }
     VLOG(10) << Type() << " get device properties"
              << "DeviceProperties(name='" << prop.name
-             << "', major=" << prop.major << ", minor=" << prop.minor
+             << "', major=" << prop.DeviceMajor
+             << ", minor=" << prop.DeviceMinor
              << ", total_memory=" << prop.totalGlobalMem / (1024 * 1024)
              << "MB, multi_processor_count=" << prop.multiProcessorCount << ")";
     return prop;

--- a/paddle/phi/backends/device_base.h
+++ b/paddle/phi/backends/device_base.h
@@ -25,8 +25,8 @@ namespace phi {
 
 struct DeviceProp {
   std::string name;
-  int major = 0;
-  int minor = 0;
+  int DeviceMajor = 0;
+  int DeviceMinor = 0;
   size_t totalGlobalMem = 0;
   int multiProcessorCount = 0;
   bool isMultiGpuBoard = false;
@@ -35,15 +35,15 @@ struct DeviceProp {
   DeviceProp() = default;
 
   DeviceProp(const std::string& name_,
-             int major_,
-             int minor_,
+             int DeviceMajor_,
+             int DeviceMinor_,
              size_t totalGlobalMem_,
              int multiProcessorCount_,
              bool isMultiGpuBoard_,
              bool integrated_)
       : name(name_),
-        major(major_),
-        minor(minor_),
+        DeviceMajor(DeviceMajor_),
+        DeviceMinor(DeviceMinor_),
         totalGlobalMem(totalGlobalMem_),
         multiProcessorCount(multiProcessorCount_),
         isMultiGpuBoard(isMultiGpuBoard_),

--- a/paddle/phi/backends/device_base.h
+++ b/paddle/phi/backends/device_base.h
@@ -25,8 +25,8 @@ namespace phi {
 
 struct DeviceProp {
   std::string name;
-  int DeviceMajor = 0;
-  int DeviceMinor = 0;
+  int deviceMajor = 0;
+  int deviceMinor = 0;
   size_t totalGlobalMem = 0;
   int multiProcessorCount = 0;
   bool isMultiGpuBoard = false;
@@ -35,15 +35,15 @@ struct DeviceProp {
   DeviceProp() = default;
 
   DeviceProp(const std::string& name_,
-             int DeviceMajor_,
-             int DeviceMinor_,
+             int deviceMajor_,
+             int deviceMinor_,
              size_t totalGlobalMem_,
              int multiProcessorCount_,
              bool isMultiGpuBoard_,
              bool integrated_)
       : name(name_),
-        DeviceMajor(DeviceMajor_),
-        DeviceMinor(DeviceMinor_),
+        deviceMajor(deviceMajor_),
+        deviceMinor(deviceMinor_),
         totalGlobalMem(totalGlobalMem_),
         multiProcessorCount(multiProcessorCount_),
         isMultiGpuBoard(isMultiGpuBoard_),


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Custom Device

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-67164
Rename the conflicting variables to avoid collision with the system macro defined in some environment.