### PR TITLE
[0-size Tensor Job2 No.105] Add 0-size Tensor support for roi_align

### DIFF
--- a/paddle/phi/kernels/cpu/roi_align_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/roi_align_grad_kernel.cc
@@ -17,6 +17,7 @@
 #include "paddle/phi/backends/cpu/cpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/empty_kernel.h"
+#include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/funcs/math_function.h"
 
 namespace phi {
@@ -90,7 +91,11 @@ void RoiAlignGradKernel(const Context& dev_ctx,
   if (!dx) {
     return;
   }
-
+  if (x.numel() == 0 || boxes.numel() == 0) {
+    phi::Full<T, Context>(
+        dev_ctx, phi::IntArray(common::vectorize(dx->dims())), 0, dx);
+    return;
+  }
   DenseTensor roi_batch_id_list = Empty<int>(dev_ctx, {rois_num});
   int* box_batch_id_data = roi_batch_id_list.data<int>();
 

--- a/paddle/phi/kernels/cpu/roi_align_kernel.cc
+++ b/paddle/phi/kernels/cpu/roi_align_kernel.cc
@@ -17,6 +17,7 @@
 #include "paddle/phi/backends/cpu/cpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/empty_kernel.h"
+#include "paddle/phi/kernels/full_kernel.h"
 
 namespace phi {
 
@@ -193,8 +194,9 @@ void RoiAlignKernel(const Context& dev_ctx,
   int width = static_cast<int>(in_dims[3]);
   int rois_num = static_cast<int>(boxes.dims()[0]);
 
-  if (rois_num == 0) {
-    dev_ctx.template Alloc<T>(out);
+  if (x.numel() == 0 || boxes.numel() == 0) {
+    phi::Full<T, Context>(
+        dev_ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
     return;
   }
 

--- a/paddle/phi/kernels/gpu/roi_align_kernel.cu
+++ b/paddle/phi/kernels/gpu/roi_align_kernel.cu
@@ -19,6 +19,7 @@
 #include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/common/place.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/full_kernel.h"
 
 namespace phi {
 
@@ -147,6 +148,11 @@ void RoiAlignKernel(const Context& dev_ctx,
                     DenseTensor* out) {
   if (out->numel() == 0) {
     dev_ctx.template Alloc<T>(out);
+    return;
+  }
+  if (x.numel() == 0) {
+    phi::Full<T, Context>(
+        dev_ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
     return;
   }
   auto in_dims = x.dims();

--- a/paddle/phi/kernels/xpu/roi_align_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/roi_align_grad_kernel.cc
@@ -18,6 +18,7 @@
 #include "paddle/phi/backends/xpu/xpu_context.h"
 #include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/full_kernel.h"
 
 namespace phi {
 
@@ -39,6 +40,11 @@ void RoiAlignGradKernel(const Context& dev_ctx,
   int width = x.dims()[3];
 
   if (!dx) {
+    return;
+  }
+  if (x.numel() == 0 || boxes.numel() == 0) {
+    phi::Full<T, Context>(
+        dev_ctx, phi::IntArray(common::vectorize(dx->dims())), 0, dx);
     return;
   }
   DenseTensor roi_batch_id_list;

--- a/paddle/phi/kernels/xpu/roi_align_kernel.cc
+++ b/paddle/phi/kernels/xpu/roi_align_kernel.cc
@@ -18,7 +18,7 @@
 #include "paddle/phi/backends/xpu/xpu_context.h"
 #include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/core/kernel_registry.h"
-
+#include "paddle/phi/kernels/full_kernel.h"
 namespace phi {
 
 template <typename T, typename Context>
@@ -40,8 +40,9 @@ void RoiAlignKernel(const Context& dev_ctx,
 
   int rois_num = boxes.dims()[0];
 
-  if (rois_num == 0) {
-    dev_ctx.template Alloc<T>(out);
+  if (x.numel() == 0 || boxes.numel() == 0) {
+    phi::Full<T, Context>(
+        dev_ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
     return;
   }
 

--- a/test/legacy_test/test_roi_align_op.py
+++ b/test/legacy_test/test_roi_align_op.py
@@ -283,5 +283,57 @@ class TestROIAlignOpWithAligned(TestROIAlignOp):
         self.x = np.random.random(self.x_dim).astype('float64')
 
 
+class TestROIAlignOp_ZeroSize(TestROIAlignOp):
+    def init_test_case(self):
+        self.batch_size = 3
+        self.channels = 3
+        self.height = 0
+        self.width = 6
+
+        # n, c, h, w
+        self.x_dim = (self.batch_size, self.channels, self.height, self.width)
+
+        self.spatial_scale = 1.0 / 2.0
+        self.pooled_height = 2
+        self.pooled_width = 2
+        self.sampling_ratio = -1
+        self.aligned = False
+
+        self.x = np.random.random(self.x_dim).astype('float64')
+
+    def make_rois(self):
+        rois = []
+        self.rois_lod = [[]]
+        for bno in range(self.batch_size):
+            self.rois_lod[0].append(bno + 1)
+            for i in range(bno + 1):
+                x1 = np.random.random_integers(
+                    0, self.width // self.spatial_scale - self.pooled_width
+                )
+                x2 = np.random.random_integers(
+                    x1 + self.pooled_width, self.width // self.spatial_scale
+                )
+                if self.height == 0:
+                    y1 = 0
+                    y2 = 0
+                else:
+                    y1 = np.random.random_integers(
+                        0,
+                        self.height // self.spatial_scale - self.pooled_height,
+                    )
+                    y2 = np.random.random_integers(
+                        y1 + self.pooled_height,
+                        self.height // self.spatial_scale,
+                    )
+
+                roi = [bno, x1, y1, x2, y2]
+                rois.append(roi)
+        self.rois_num = len(rois)
+        self.rois = np.array(rois).astype("float64")
+        self.boxes_num = np.array(
+            [bno + 1 for bno in range(self.batch_size)]
+        ).astype('int32')
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->
[0-size Tensor Job2 No.105] Add 0-size Tensor support for roi_align

输出的shape为 [box[0], input[1], pooled_height, pooled_width]，pooled_height, pooled_width 是都要大于0，所以判断input和box的numel

PaddleAPITest 测试，
使用--accuracy 选项，是torch error异常退出
![image](https://github.com/user-attachments/assets/a3be4448-bc3a-4c43-9b93-d15fdd7477b0)

使用--paddle_only 选项测试通过，错误为numpy error
![image](https://github.com/user-attachments/assets/68f4f9ab-9ea5-4073-8d08-3f49cef646cf)
