### PR TITLE
[SOT] Add unsafe cache fast path

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/executor_cache.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/executor_cache.py
@@ -74,21 +74,23 @@ class OpcodeExecutorCache(metaclass=Singleton):
     MAX_CACHE_SIZE = 20
     MAX_COMPILE_TIME_PER_CODE = 40
     MAX_COMPILE_TIME_TOTAL = 15 * 60
-    CACHE_HIT_THRESHOLD = 32
+    CACHE_HIT_FASTPATH_THRESHOLD = 32
     cache: dict[
         types.CodeType, tuple[GuardedFunctions, paddle.framework.core.GuardTree]
     ]
     translate_count: int
     code_symbolic_inputs: dict[types.CodeType, dict[str, None | dict[int, int]]]
     compile_time_stats: dict[types.CodeType, float]
+    consecutive_cache_hit_count: dict[types.CodeType, int]
+    last_cache_index: dict[types.CodeType, int | None]
 
     def __init__(self):
         self.cache = {}
         self.translate_count = 0
         self.code_symbolic_inputs = {}
         self.compile_time_stats = {}
-        self.cache_hit_num = 0
-        self.last_cache_index = None
+        self.consecutive_cache_hit_count = {}
+        self.last_cache_index = {}
 
     def get_symbolic_inputs(
         self, code: types.CodeType
@@ -165,6 +167,7 @@ class OpcodeExecutorCache(metaclass=Singleton):
         Returns:
             CustomCode: The custom code object if a matching guard function is found, otherwise None.
         """
+        code: types.CodeType = frame.f_code
 
         if len(guarded_fns) >= self.MAX_CACHE_SIZE:
             log(2, "[Cache] Exceed max cache size, skip it\n")
@@ -174,12 +177,12 @@ class OpcodeExecutorCache(metaclass=Singleton):
         enable_guard_tree = ENV_SOT_ENABLE_GUARD_TREE.get()
         enable_unsafe_cache_fastpath = ENV_SOT_UNSAFE_CACHE_FASTPATH.get()
 
-        if (
-            enable_unsafe_cache_fastpath
-            and self.cache_hit_num > self.CACHE_HIT_THRESHOLD
+        if enable_unsafe_cache_fastpath and (
+            self.consecutive_cache_hit_count[code]
+            > self.CACHE_HIT_FASTPATH_THRESHOLD
         ):
             # NOTE: In inference scenarios, cache misses are generally rare, so we can enable this short path.
-            return guarded_fns[self.last_cache_index][0]
+            return guarded_fns[self.last_cache_index[code]][0]
 
         cache_index = None
         if enable_strict_guard or enable_guard_tree:
@@ -245,11 +248,11 @@ class OpcodeExecutorCache(metaclass=Singleton):
                         cache_index is None or index == cache_index
                     ), f"cache_index({cache_index}) is not equal to index({index})"
 
-                    if self.last_cache_index == index:
-                        self.cache_hit_num += 1
+                    if self.last_cache_index[code] == index:
+                        self.consecutive_cache_hit_count[code] += 1
                     else:
-                        self.last_cache_index = index
-                        self.cache_hit_num = 0
+                        self.last_cache_index[code] = index
+                        self.consecutive_cache_hit_count[code] = 0
 
                     return custom_code
                 else:

--- a/python/paddle/jit/sot/opcode_translator/executor/executor_cache.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/executor_cache.py
@@ -26,6 +26,7 @@ from ...utils import (
     ENV_SOT_ALLOW_DYNAMIC_SHAPE,
     ENV_SOT_ENABLE_GUARD_TREE,
     ENV_SOT_ENABLE_STRICT_GUARD_CHECK,
+    ENV_SOT_UNSAFE_CACHE_FASTPATH,
     BreakGraphError,
     CompileCountInfo,
     ConditionalFallbackError,
@@ -73,6 +74,7 @@ class OpcodeExecutorCache(metaclass=Singleton):
     MAX_CACHE_SIZE = 20
     MAX_COMPILE_TIME_PER_CODE = 40
     MAX_COMPILE_TIME_TOTAL = 15 * 60
+    CACHE_HIT_THRESHOLD = 32
     cache: dict[
         types.CodeType, tuple[GuardedFunctions, paddle.framework.core.GuardTree]
     ]
@@ -85,6 +87,8 @@ class OpcodeExecutorCache(metaclass=Singleton):
         self.translate_count = 0
         self.code_symbolic_inputs = {}
         self.compile_time_stats = {}
+        self.cache_hit_num = 0
+        self.last_cache_index = None
 
     def get_symbolic_inputs(
         self, code: types.CodeType
@@ -168,6 +172,14 @@ class OpcodeExecutorCache(metaclass=Singleton):
 
         enable_strict_guard = ENV_SOT_ENABLE_STRICT_GUARD_CHECK.get()
         enable_guard_tree = ENV_SOT_ENABLE_GUARD_TREE.get()
+        enable_unsafe_cache_fastpath = ENV_SOT_UNSAFE_CACHE_FASTPATH.get()
+
+        if (
+            enable_unsafe_cache_fastpath
+            and self.cache_hit_num > self.CACHE_HIT_THRESHOLD
+        ):
+            # NOTE: In inference scenarios, cache misses are generally rare, so we can enable this short path.
+            return guarded_fns[self.last_cache_index][0]
 
         cache_index = None
         if enable_strict_guard or enable_guard_tree:
@@ -232,6 +244,13 @@ class OpcodeExecutorCache(metaclass=Singleton):
                     assert (
                         cache_index is None or index == cache_index
                     ), f"cache_index({cache_index}) is not equal to index({index})"
+
+                    if self.last_cache_index == index:
+                        self.cache_hit_num += 1
+                    else:
+                        self.last_cache_index = index
+                        self.cache_hit_num = 0
+
                     return custom_code
                 else:
                     log_do(

--- a/python/paddle/jit/sot/opcode_translator/executor/executor_cache.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/executor_cache.py
@@ -82,7 +82,7 @@ class OpcodeExecutorCache(metaclass=Singleton):
     code_symbolic_inputs: dict[types.CodeType, dict[str, None | dict[int, int]]]
     compile_time_stats: dict[types.CodeType, float]
     consecutive_cache_hit_count: dict[types.CodeType, int]
-    last_cache_index: dict[types.CodeType, int | None]
+    last_cache_index: dict[types.CodeType, int]
 
     def __init__(self):
         self.cache = {}
@@ -147,6 +147,14 @@ class OpcodeExecutorCache(metaclass=Singleton):
             **kwargs,
         )
 
+    def is_fastpath_threshold_reached(self, code):
+        # Returns True if the number of consecutive cache hits for the given code
+        # exceeds the UNSAFE_CACHE_FASTPATH threshold.
+        return (
+            self.consecutive_cache_hit_count.get(code, 0)
+            >= self.CACHE_HIT_FASTPATH_THRESHOLD
+        )
+
     @event_register("lookup")
     def lookup(
         self,
@@ -178,8 +186,7 @@ class OpcodeExecutorCache(metaclass=Singleton):
         enable_unsafe_cache_fastpath = ENV_SOT_UNSAFE_CACHE_FASTPATH.get()
 
         if enable_unsafe_cache_fastpath and (
-            self.consecutive_cache_hit_count.get(code, 0)
-            > self.CACHE_HIT_FASTPATH_THRESHOLD
+            self.is_fastpath_threshold_reached(code)
         ):
             # NOTE: In inference scenarios, cache misses are generally rare, so we can enable this short path.
             return guarded_fns[self.last_cache_index[code]][0]
@@ -252,7 +259,7 @@ class OpcodeExecutorCache(metaclass=Singleton):
                         self.consecutive_cache_hit_count[code] += 1
                     else:
                         self.last_cache_index[code] = index
-                        self.consecutive_cache_hit_count[code] = 0
+                        self.consecutive_cache_hit_count[code] = 1
 
                     return custom_code
                 else:

--- a/python/paddle/jit/sot/opcode_translator/executor/executor_cache.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/executor_cache.py
@@ -178,7 +178,7 @@ class OpcodeExecutorCache(metaclass=Singleton):
         enable_unsafe_cache_fastpath = ENV_SOT_UNSAFE_CACHE_FASTPATH.get()
 
         if enable_unsafe_cache_fastpath and (
-            self.consecutive_cache_hit_count[code]
+            self.consecutive_cache_hit_count.get(code, 0)
             > self.CACHE_HIT_FASTPATH_THRESHOLD
         ):
             # NOTE: In inference scenarios, cache misses are generally rare, so we can enable this short path.
@@ -248,7 +248,7 @@ class OpcodeExecutorCache(metaclass=Singleton):
                         cache_index is None or index == cache_index
                     ), f"cache_index({cache_index}) is not equal to index({index})"
 
-                    if self.last_cache_index[code] == index:
+                    if self.last_cache_index.get(code, None) == index:
                         self.consecutive_cache_hit_count[code] += 1
                     else:
                         self.last_cache_index[code] = index

--- a/python/paddle/jit/sot/utils/__init__.py
+++ b/python/paddle/jit/sot/utils/__init__.py
@@ -26,6 +26,7 @@ from .envs import (  # noqa: F401
     ENV_SOT_LOG_LEVEL,
     ENV_SOT_SERIALIZE_INFO,
     ENV_SOT_TRACE_NUMPY,
+    ENV_SOT_UNSAFE_CACHE_FASTPATH,
     ENV_SOT_WITH_CONTROL_FLOW,
     ENV_STRICT_MODE,
     PEP508LikeEnvironmentVariable,

--- a/python/paddle/jit/sot/utils/envs.py
+++ b/python/paddle/jit/sot/utils/envs.py
@@ -150,6 +150,9 @@ ENV_SOT_FORCE_FALLBACK_SIR_IDS = StringEnvironmentVariable(
     "SOT_FORCE_FALLBACK_SIR_IDS", ""
 )
 ENV_SOT_TRACE_NUMPY = BooleanEnvironmentVariable("ENV_SOT_TRACE_NUMPY", True)
+ENV_SOT_UNSAFE_CACHE_FASTPATH = BooleanEnvironmentVariable(
+    "SOT_UNSAFE_CACHE_FASTPATH", False
+)
 
 
 def update_ce_flags():

--- a/test/sot/test_guard_fastpath_strategy.py
+++ b/test/sot/test_guard_fastpath_strategy.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import unittest
+
+from test_case_base import (
+    TestCaseBase,
+)
+
+import paddle
+from paddle.jit.sot.utils import ENV_SOT_UNSAFE_CACHE_FASTPATH
+from paddle.utils.environments import (
+    EnvironmentVariableGuard,
+)
+
+
+def add(x, y):
+    return x + y
+
+
+class TestGuardOutputs(TestCaseBase):
+    def test_guard_inputs(self):
+        # NOTE: When UNSAFE CACHE FASTPATH is enabled, if the same cache entry is hit consecutively
+        # for 32 times (this threshold is configurable), the cache is considered stable and
+        # subsequent guard checks will be skipped to improve performance.
+        # The related logic is implemented in the OpcodeExecutorCache class.
+        with EnvironmentVariableGuard(ENV_SOT_UNSAFE_CACHE_FASTPATH, True):
+            self.assertTrue(ENV_SOT_UNSAFE_CACHE_FASTPATH.get())
+            for _ in range(50):
+                self.assert_results(add, 1, paddle.ones([4]))
+
+        with EnvironmentVariableGuard(ENV_SOT_UNSAFE_CACHE_FASTPATH, False):
+            self.assertFalse(ENV_SOT_UNSAFE_CACHE_FASTPATH.get())
+            for _ in range(1000):
+                self.assert_results(add, 1, 2)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/sot/test_guard_fastpath_strategy.py
+++ b/test/sot/test_guard_fastpath_strategy.py
@@ -21,6 +21,9 @@ from test_case_base import (
 )
 
 import paddle
+from paddle.jit.sot.opcode_translator.executor.executor_cache import (
+    OpcodeExecutorCache,
+)
 from paddle.jit.sot.utils import ENV_SOT_UNSAFE_CACHE_FASTPATH
 from paddle.utils.environments import (
     EnvironmentVariableGuard,
@@ -31,21 +34,52 @@ def add(x, y):
     return x + y
 
 
-class TestGuardOutputs(TestCaseBase):
-    def test_guard_inputs(self):
+def subtract(x, y):
+    return x - y
+
+
+class TestUnsafeCacheFastPath(TestCaseBase):
+    def test_guard(self):
         # NOTE: When UNSAFE CACHE FASTPATH is enabled, if the same cache entry is hit consecutively
         # for 32 times (this threshold is configurable), the cache is considered stable and
         # subsequent guard checks will be skipped to improve performance.
         # The related logic is implemented in the OpcodeExecutorCache class.
         with EnvironmentVariableGuard(ENV_SOT_UNSAFE_CACHE_FASTPATH, True):
+
             self.assertTrue(ENV_SOT_UNSAFE_CACHE_FASTPATH.get())
-            for _ in range(50):
+
+            self.assertFalse(
+                OpcodeExecutorCache().is_fastpath_threshold_reached(
+                    add.__code__
+                )
+            )
+            for _ in range(33):
                 self.assert_results(add, 1, paddle.ones([4]))
+            self.assertTrue(
+                OpcodeExecutorCache().is_fastpath_threshold_reached(
+                    add.__code__
+                )
+            )
+            self.assertFalse(
+                OpcodeExecutorCache().is_fastpath_threshold_reached(
+                    subtract.__code__
+                )
+            )
 
         with EnvironmentVariableGuard(ENV_SOT_UNSAFE_CACHE_FASTPATH, False):
             self.assertFalse(ENV_SOT_UNSAFE_CACHE_FASTPATH.get())
-            for _ in range(1000):
+            self.assertFalse(
+                OpcodeExecutorCache().is_fastpath_threshold_reached(
+                    subtract.__code__
+                )
+            )
+            for _ in range(35):
                 self.assert_results(add, 1, 2)
+            self.assertFalse(
+                OpcodeExecutorCache().is_fastpath_threshold_reached(
+                    subtract.__code__
+                )
+            )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->

在推理场景下，通常只会命中同一个 cache，但目前每次都需要重新执行 guard 检查，这其实没有必要。因此，我们可以启用一种**不安全**的优化策略：如果同一个 cache 被连续命中超过一定次数（例如 32 次），则可以认为输入数据没有发生变化，直接返回该 cache，跳过 guard 检查，以提升推理效率。

<img width="1253" alt="image" src="https://github.com/user-attachments/assets/d6c81227-0ed9-4805-bbac-b2c5e0126680" />

这个策略通过环境变量 `SOT_UNSAFE_CACHE_FASTPATH` 开启

收益：（**稳定后**）某模型单Token时间从 35.9ms -> 29.8ms

<img width="1021" alt="8441801dc95c094dfc213c5f8a814786" src="https://github.com/user-attachments/assets/08df2736-bb4f-4c47-a28e-a71a04e4a4c1" />
<img width="905" alt="5415343087b48a7aa1ce27141ce1caa2" src="https://github.com/user-attachments/assets/4bee04f8-9586-4520-96fb-2990d2fa9a00" />


cc @SigureMo
PCard-66972