### PR TITLE
[0-size Tensor Job2 No.24] Add 0-size Tensor support for histogram

### DIFF
--- a/paddle/phi/kernels/cpu/histogram_kernel.cc
+++ b/paddle/phi/kernels/cpu/histogram_kernel.cc
@@ -16,6 +16,7 @@
 
 #include "paddle/phi/backends/cpu/cpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/funcs/math_function.h"
 #include "paddle/phi/kernels/reduce_sum_kernel.h"
 #include "paddle/utils/optional.h"
@@ -37,6 +38,11 @@ void HistogramKernel(const Context& dev_ctx,
   const T* input_data = input.data<T>();
   auto weight_data = weight.get_ptr() ? weight.get_ptr()->data<T>() : nullptr;
   auto input_numel = input.numel();
+  if (input_numel == 0) {
+    phi::Full<T, Context>(
+        dev_ctx, phi::IntArray(common::vectorize(output->dims())), 0, output);
+    return;
+  }
 
   if (input_data == nullptr) return;
 

--- a/paddle/phi/kernels/gpu/histogram_kernel.cu
+++ b/paddle/phi/kernels/gpu/histogram_kernel.cu
@@ -18,6 +18,7 @@
 #include "paddle/phi/backends/gpu/gpu_primitives.h"
 #include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/funcs/elementwise_base.h"
 #include "paddle/phi/kernels/funcs/functors.h"
 #include "paddle/phi/kernels/funcs/math_cuda_utils.h"
@@ -147,6 +148,11 @@ void HistogramKernel(const Context& dev_ctx,
   const T* input_data = input.data<T>();
   const int64_t input_numel = input.numel();
   auto weight_data = weight.get_ptr() ? weight.get_ptr()->data<T>() : nullptr;
+  if (input_numel == 0) {
+    phi::Full<T, Context>(
+        dev_ctx, phi::IntArray(common::vectorize(output->dims())), 0, output);
+    return;
+  }
 
   if (input_data == nullptr) return;
 

--- a/test/legacy_test/test_histogram_op.py
+++ b/test/legacy_test/test_histogram_op.py
@@ -312,6 +312,54 @@ class TestHistogramOpAPIWithFloatminMax(TestHistogram):
         self.is_weight = False
 
 
+class TestHistogram_ZeroSize(unittest.TestCase):
+    def setUp(self):
+        self.init_test_case()
+        self.input_np = np.random.uniform(
+            low=0.0, high=20.0, size=self.in_shape
+        ).astype(np.float32)
+        self.weight_np = np.random.uniform(
+            low=0.0, high=1.0, size=self.in_shape
+        ).astype(np.float32)
+
+    def init_test_case(self):
+        self.in_shape = (0, 12)
+        self.bins = 5
+        self.min = 1
+        self.max = 5
+        self.density = False
+        self.is_weight = True
+
+    def test_dygraph(self):
+        with base.dygraph.guard():
+            inputs_np = np.random.uniform(
+                low=0.0, high=20.0, size=self.in_shape
+            ).astype(np.float32)
+            inputs = paddle.to_tensor(inputs_np)
+            weight_np = np.random.uniform(
+                low=0.0, high=1.0, size=self.in_shape
+            ).astype(np.float32)
+            weight = paddle.to_tensor(weight_np)
+            actual = paddle.histogram(
+                inputs,
+                bins=5,
+                min=1,
+                max=5,
+                weight=weight if self.is_weight else None,
+                density=self.density,
+            )
+            Out, _ = np.histogram(
+                inputs_np,
+                bins=5,
+                range=(1, 5),
+                weights=weight_np if self.is_weight else None,
+                density=self.density,
+            )
+            np.testing.assert_allclose(
+                actual.numpy(), Out, rtol=1e-58, atol=1e-5
+            )
+
+
 if __name__ == "__main__":
     paddle.enable_static()
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->
[0-size Tensor Job2 No.24] Add 0-size Tensor support for histogram

histogram 修改CPU/GPU，没有反向
增加单测

PaddleAPITest 测试通过
![image](https://github.com/user-attachments/assets/d83cee16-a85e-454a-9066-9b318c691070)
