### PR TITLE
[0-size Tensor Job2 No.42] Add 0-size Tensor support for eigvals

### DIFF
--- a/paddle/phi/kernels/cpu/eigvals_kernel.cc
+++ b/paddle/phi/kernels/cpu/eigvals_kernel.cc
@@ -206,6 +206,9 @@ void EigvalsKernel(const Context& dev_ctx,
                    const DenseTensor& x,
                    DenseTensor* out) {
   dev_ctx.template Alloc<PaddleCType<T>>(out);
+  if (out && out->numel() == 0) {
+    return;
+  }
 
   std::vector<DenseTensor> x_matrices;
   SpiltBatchSquareMatrix(x, /*->*/ &x_matrices);

--- a/test/legacy_test/test_eigvals_op.py
+++ b/test/legacy_test/test_eigvals_op.py
@@ -169,6 +169,16 @@ class TestEigvalsOpBatch3(TestEigvalsOp):
         self.input_dims = (6, 2, 9, 6, 6)
 
 
+class TestEigvalsOp_ZeroSize(TestEigvalsOp):
+    def set_input_dims(self):
+        self.input_dims = (6, 0, 2, 2)
+
+
+class TestEigvalsOp_ZeroSize2(TestEigvalsOp):
+    def set_input_dims(self):
+        self.input_dims = (6, 2, 0, 0)
+
+
 class TestEigvalsAPI(unittest.TestCase):
     def setUp(self):
         np.random.seed(0)

--- a/test/legacy_test/test_eigvals_op.py
+++ b/test/legacy_test/test_eigvals_op.py
@@ -178,6 +178,21 @@ class TestEigvalsOp_ZeroSize2(TestEigvalsOp):
     def set_input_dims(self):
         self.input_dims = (6, 2, 0, 0)
 
+    def verify_output(self, outs):
+        actual_outs = np.sort(np.array(outs[0]))
+        expect_outs = np.sort(np.array(self.outputs['Out']))
+        self.assertTrue(
+            actual_outs.shape == expect_outs.shape,
+            "Output shape has diff.\n"
+            "Expect shape "
+            + str(expect_outs.shape)
+            + "\n"
+            + "But Got"
+            + str(actual_outs.shape)
+            + " in class "
+            + self.__class__.__name__,
+        )
+
 
 class TestEigvalsAPI(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->
42 paddle.linalg.eigvals 
修改CPU 前向，没有反向和其他kernel
infermeta 没有修改

PaddleAPITest测试通过
![image](https://github.com/user-attachments/assets/a6201653-efe4-4b25-95fa-718f81f4d843)
