### PR TITLE
[0-size Tensor Job2 No.42、45] Add 0-size Tensor support for paddle.linalg.svdvals

### DIFF
--- a/paddle/phi/kernels/cpu/eigvals_kernel.cc
+++ b/paddle/phi/kernels/cpu/eigvals_kernel.cc
@@ -206,6 +206,9 @@ void EigvalsKernel(const Context& dev_ctx,
                    const DenseTensor& x,
                    DenseTensor* out) {
   dev_ctx.template Alloc<PaddleCType<T>>(out);
+  if (out && out->numel() == 0) {
+    return;
+  }
 
   std::vector<DenseTensor> x_matrices;
   SpiltBatchSquareMatrix(x, /*->*/ &x_matrices);

--- a/paddle/phi/kernels/cpu/svdvals_kernel.cc
+++ b/paddle/phi/kernels/cpu/svdvals_kernel.cc
@@ -90,6 +90,10 @@ template <typename T, typename Context>
 void SvdvalsKernel(const Context& dev_ctx,
                    const DenseTensor& X,
                    DenseTensor* S) {
+  if (S && S->numel() == 0) {
+    dev_ctx.template Alloc<phi::dtype::Real<T>>(S);
+    return;
+  }
   auto x_dims = X.dims();
   int rows = static_cast<int>(x_dims[x_dims.size() - 2]);
   int cols = static_cast<int>(x_dims[x_dims.size() - 1]);

--- a/paddle/phi/kernels/impl/svdvals_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/svdvals_grad_kernel_impl.h
@@ -34,6 +34,10 @@ void SvdvalsGradKernel(const Context& dev_ctx,
                        const DenseTensor& x,
                        const DenseTensor& s_grad,
                        DenseTensor* x_grad) {
+  if (x_grad && x_grad->numel() == 0) {
+    dev_ctx.template Alloc<T>(x_grad);
+    return;
+  }
   auto x_dims = x.dims();
   int rows = static_cast<int>(x_dims[x_dims.size() - 2]);
   int cols = static_cast<int>(x_dims[x_dims.size() - 1]);

--- a/test/legacy_test/test_eigvals_op.py
+++ b/test/legacy_test/test_eigvals_op.py
@@ -169,6 +169,16 @@ class TestEigvalsOpBatch3(TestEigvalsOp):
         self.input_dims = (6, 2, 9, 6, 6)
 
 
+class TestEigvalsOp_ZeroSize(TestEigvalsOp):
+    def set_input_dims(self):
+        self.input_dims = (6, 0, 2, 2)
+
+
+class TestEigvalsOp_ZeroSize2(TestEigvalsOp):
+    def set_input_dims(self):
+        self.input_dims = (6, 2, 0, 0)
+
+
 class TestEigvalsAPI(unittest.TestCase):
     def setUp(self):
         np.random.seed(0)

--- a/test/legacy_test/test_eigvals_op.py
+++ b/test/legacy_test/test_eigvals_op.py
@@ -178,6 +178,21 @@ class TestEigvalsOp_ZeroSize2(TestEigvalsOp):
     def set_input_dims(self):
         self.input_dims = (6, 2, 0, 0)
 
+    def verify_output(self, outs):
+        actual_outs = np.sort(np.array(outs[0]))
+        expect_outs = np.sort(np.array(self.outputs['Out']))
+        self.assertTrue(
+            actual_outs.shape == expect_outs.shape,
+            "Output shape has diff.\n"
+            "Expect shape "
+            + str(expect_outs.shape)
+            + "\n"
+            + "But Got"
+            + str(actual_outs.shape)
+            + " in class "
+            + self.__class__.__name__,
+        )
+
 
 class TestEigvalsAPI(unittest.TestCase):
     def setUp(self):

--- a/test/legacy_test/test_svdvals_op.py
+++ b/test/legacy_test/test_svdvals_op.py
@@ -158,5 +158,30 @@ class TestSvdvalsAPI(unittest.TestCase):
             self.assertRaises(ValueError, test_empty_tensor)
 
 
+class TestSvdvalsOp_ZeroSize(OpTest):
+    def setUp(self):
+        self.op_type = "svdvals"
+        self.python_api = paddle.linalg.svdvals
+        self.init_data()
+
+    def init_shape(self):
+        self._input_shape = (1, 0)
+
+    def init_data(self):
+        self.init_shape()
+        self._input_data = np.random.random(self._input_shape).astype("float64")
+        self._output_data = np.linalg.svd(
+            self._input_data, compute_uv=False, hermitian=False
+        )
+        self.inputs = {'x': self._input_data}
+        self.outputs = {'s': self._output_data}
+
+    def test_check_output(self):
+        self.check_output(check_pir=True)
+
+    def test_check_grad(self):
+        self.check_grad(['x'], ['s'], numeric_grad_delta=0.001, check_pir=True)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/legacy_test/test_svdvals_op.py
+++ b/test/legacy_test/test_svdvals_op.py
@@ -148,14 +148,7 @@ class TestSvdvalsAPI(unittest.TestCase):
                 x_invalid_shape = paddle.to_tensor(x_np_invalid_shape)
                 paddle.linalg.svdvals(x_invalid_shape)
 
-            def test_empty_tensor():
-                """Test empty tensor"""
-                x_np_empty = np.empty([0, 10], dtype='float32')
-                x_empty = paddle.to_tensor(x_np_empty)
-                paddle.linalg.svdvals(x_empty)
-
             self.assertRaises(ValueError, test_invalid_shape)
-            self.assertRaises(ValueError, test_empty_tensor)
 
 
 class TestSvdvalsOp_ZeroSize(OpTest):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->
45 paddle.linalg.svdvals
修改CPU前向和反向
infermeta没有修改
增加单测

PaddleAPITest 测试通过
![image](https://github.com/user-attachments/assets/3e44fdcb-7c8f-46fe-afe0-f0920d2f064b)

42 paddle.linalg.eigvals 
修改CPU 前向，没有反向和其他kernel
infermeta 没有修改

PaddleAPITest测试通过
![image](https://github.com/user-attachments/assets/a6201653-efe4-4b25-95fa-718f81f4d843)
