### PR TITLE
[0-size Tensor Job2 No.7、64、83] Add 0-size Tensor support for one_hot

### DIFF
--- a/paddle/phi/kernels/gpu/cumprod_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/cumprod_grad_kernel.cu
@@ -159,6 +159,11 @@ void CumprodGradKernel(const Context &dev_ctx,
   const auto *y = &out;
   const auto *dy = &dout;
 
+  if (dx && dx->numel() == 0) {
+    dev_ctx.template Alloc<T>(dx);
+    return;
+  }
+
   size_t outer_dim, mid_dim, inner_dim;
   GetCumprodDimInfo(x.dims(), dim, &outer_dim, &mid_dim, &inner_dim);
   if (x.dims().size() == 0) {

--- a/paddle/phi/kernels/gpu/one_hot_kernel.cu
+++ b/paddle/phi/kernels/gpu/one_hot_kernel.cu
@@ -57,6 +57,7 @@ void OneHotKernel(const Context& dev_ctx,
   auto* p_out_data = dev_ctx.template Alloc<float>(out);
   auto stream = dev_ctx.stream();
   funcs::set_constant(dev_ctx, out, static_cast<float>(0.0));
+  if (numel == 0) return;
 
   auto config = phi::backends::gpu::GetGpuLaunchConfig1D(dev_ctx, numel);
 

--- a/paddle/phi/kernels/xpu/one_hot_kernel.cc
+++ b/paddle/phi/kernels/xpu/one_hot_kernel.cc
@@ -33,6 +33,7 @@ void OneHotKernel(const Context& dev_ctx,
   auto* p_in_data = x.data<T>();
   auto numel = x.numel();
   auto* p_out_data = dev_ctx.template Alloc<float>(out);
+  if (numel == 0) return;
   int r = xpu::one_hot<T>(
       dev_ctx.x_context(), p_in_data, p_out_data, numel, depth_v, 1.0, 0.0);
   PADDLE_ENFORCE_XDNN_SUCCESS(r, "one_hot");

--- a/test/legacy_test/test_one_hot_v2_op.py
+++ b/test/legacy_test/test_one_hot_v2_op.py
@@ -254,6 +254,36 @@ class BadInputTestOnehotV2(unittest.TestCase):
             self.assertRaises(TypeError, test_bad_x)
 
 
+class TestOneHotOp_ZeroSize(OpTest):
+    def setUp(self):
+        self.op_type = 'one_hot_v2'
+        self.python_api = one_hot_wrapper
+        self.public_python_api = one_hot_wrapper
+        self.python_out_sig = ['Out']
+        depth = 10
+        depth_np = np.array(10).astype('int32')
+        x_shape = [0, 10, 7, 3]
+        x = [np.random.randint(0, depth - 1) for i in range(np.prod(x_shape))]
+        x = np.array(x).astype('int32').reshape(x_shape)
+
+        out = np.zeros(shape=(np.prod(x.shape), depth)).astype('float32')
+
+        r_x = np.reshape(x, np.prod(x.shape))
+        for i in range(np.prod(x.shape)):
+            out[i, r_x[i]] = 1.0
+
+        shape_np = list(x.shape)
+        shape_np.append(depth)
+        out = np.reshape(out, shape_np)
+
+        self.inputs = {'X': x, 'depth_tensor': depth_np}
+        self.attrs = {'dtype': int(core.VarDesc.VarType.FP32)}
+        self.outputs = {'Out': out}
+
+    def test_check_output(self):
+        self.check_output()
+
+
 if __name__ == '__main__':
     paddle.enable_static()
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->
64 one_hot
修改前向
infermeta没有修改
kernel修改GPU/XPU

PaddleAPITest 测试通过
![image](https://github.com/user-attachments/assets/ca317560-3143-4cc0-994a-602d65b0de24)

7 paddle.cumprod
83 paddle.Tensor.cumprod
测试GPU错误为 not compare grad，反向返回没有初始化
修改GPU反向返回

修改后PaddleAPITest 测试通过
![image](https://github.com/user-attachments/assets/0ff12af3-f1a9-476b-9a1d-a5b9644141e9)

paddle.Tensor.cumprod
![image](https://github.com/user-attachments/assets/e9fe28d1-228b-4d95-b9c5-e196eb134410)
