### PR TITLE
fix deepep with_nvshmem compile on multi arch target

### DIFF
--- a/paddle/fluid/distributed/collective/deep_ep/CMakeLists.txt
+++ b/paddle/fluid/distributed/collective/deep_ep/CMakeLists.txt
@@ -3,8 +3,8 @@ if(WITH_NVSHMEM)
   set(CMAKE_CUDA_FLAGS
       "${CMAKE_CUDA_FLAGS} -rdc=true --ptxas-options=--register-usage-level=10,--warn-on-local-memory-usage"
   )
-  string(REPLACE "-gencode arch=compute_80,code=sm_80" "" CMAKE_CUDA_FLAGS
-                 "${CMAKE_CUDA_FLAGS}")
+  string(REGEX REPLACE "-gencode arch=compute_[0-8][0-9],code=sm_[0-8][0-9]" ""
+                       CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS}")
 
   set(DEEPEP_KERNEL_SRCS kernels/intranode.cu kernels/runtime.cu
                          kernels/internode.cu kernels/internode_ll.cu)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Communication Library

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-67164
This PR fixes deepep with_nvshmem compile on multi arch target.