### PR TITLE
[Big tensor] check arg type for mean op

### DIFF
--- a/paddle/phi/kernels/cpu/reduce_mean_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/reduce_mean_grad_kernel.cc
@@ -49,10 +49,7 @@ PD_REGISTER_KERNEL(mean_grad,
                    CPU,
                    ALL_LAYOUT,
                    phi::ReduceMeanGradKernel,
-                   bool,
                    float,
                    double,
                    phi::dtype::complex<float>,
-                   phi::dtype::complex<double>,
-                   int,
-                   int64_t) {}
+                   phi::dtype::complex<double>) {}

--- a/paddle/phi/kernels/gpu/reduce_kernel.cu
+++ b/paddle/phi/kernels/gpu/reduce_kernel.cu
@@ -288,15 +288,12 @@ PD_REGISTER_KERNEL(mean_grad,
                    GPU,
                    ALL_LAYOUT,
                    phi::ReduceMeanGradKernel,
-                   bool,
                    float,
                    double,
                    phi::dtype::float16,
                    phi::dtype::bfloat16,
                    phi::dtype::complex<float>,
-                   phi::dtype::complex<double>,
-                   int,
-                   int64_t) {}
+                   phi::dtype::complex<double>) {}
 
 PD_REGISTER_KERNEL(min_grad,
                    GPU,

--- a/paddle/phi/kernels/reduce_mean_kernel.cc
+++ b/paddle/phi/kernels/reduce_mean_kernel.cc
@@ -27,6 +27,17 @@ void MeanKernel(const Context& dev_ctx,
                 const IntArray& dims,
                 bool keep_dim,
                 DenseTensor* out) {
+  bool valid_arg =
+      x.dtype() == DataType::FLOAT16 || x.dtype() == DataType::FLOAT32 ||
+      x.dtype() == DataType::FLOAT64 || x.dtype() == DataType::COMPLEX64 ||
+      x.dtype() == DataType::COMPLEX128 || x.dtype() == DataType::BFLOAT16;
+  PADDLE_ENFORCE_EQ(
+      valid_arg,
+      true,
+      phi::errors::InvalidArgument(
+          "The DataType of mean Op must be either a floating point "
+          "or complex dtype. But got: %s",
+          DataTypeToString(x.dtype())));
   bool reduce_all = recompute_reduce_all(x, dims);
   if (std::is_same<T, int>::value || std::is_same<T, int64_t>::value ||
       std::is_same<T, bool>::value) {
@@ -56,9 +67,6 @@ PD_REGISTER_KERNEL(mean,
                    phi::MeanKernel,
                    float,
                    double,
-                   bool,
-                   int,
-                   int64_t,
                    phi::dtype::complex<float>,
                    phi::dtype::complex<double>) {}
 
@@ -69,9 +77,6 @@ PD_REGISTER_KERNEL(mean,
                    phi::MeanKernel,
                    float,
                    double,
-                   bool,
-                   int,
-                   int64_t,
                    phi::dtype::float16,
                    phi::dtype::bfloat16,
                    phi::dtype::complex<float>,

--- a/test/legacy_test/op_test.py
+++ b/test/legacy_test/op_test.py
@@ -3658,7 +3658,7 @@ class OpTest(unittest.TestCase):
                                 outputs_valid[cur_loss][0].astype("float64")
                             )
                         else:
-                            cur_avg_lossloss = paddle.mean(
+                            cur_avg_loss = paddle.mean(
                                 outputs_valid[cur_loss][0]
                             )
                         avg_sum.append(cur_avg_loss)

--- a/test/legacy_test/op_test.py
+++ b/test/legacy_test/op_test.py
@@ -3632,7 +3632,9 @@ class OpTest(unittest.TestCase):
             if user_defined_grad_outputs is None:
                 if len(outputs_valid) == 1:
                     for outputs_valid_key in outputs_valid:
-                        loss = paddle.mean(outputs_valid[outputs_valid_key][0])
+                        loss = paddle.mean(
+                            outputs_valid[outputs_valid_key][0].cast('float32')
+                        )
                 else:
                     avg_sum = []
                     for cur_loss in outputs_valid:

--- a/test/legacy_test/op_test.py
+++ b/test/legacy_test/op_test.py
@@ -3633,7 +3633,9 @@ class OpTest(unittest.TestCase):
                 if len(outputs_valid) == 1:
                     for outputs_valid_key in outputs_valid:
                         loss = paddle.mean(
-                            outputs_valid[outputs_valid_key][0].cast('float32')
+                            outputs_valid[outputs_valid_key][0].astype(
+                                "float32"
+                            )
                         )
                 else:
                     avg_sum = []

--- a/test/legacy_test/op_test.py
+++ b/test/legacy_test/op_test.py
@@ -3632,15 +3632,35 @@ class OpTest(unittest.TestCase):
             if user_defined_grad_outputs is None:
                 if len(outputs_valid) == 1:
                     for outputs_valid_key in outputs_valid:
-                        loss = paddle.mean(
-                            outputs_valid[outputs_valid_key][0].astype(
-                                "float32"
+                        if outputs_valid[outputs_valid_key][0].dtype in [
+                            paddle.int32,
+                            paddle.int64,
+                            paddle.bool,
+                        ]:
+                            loss = paddle.mean(
+                                outputs_valid[outputs_valid_key][0].astype(
+                                    "float64"
+                                )
                             )
-                        )
+                        else:
+                            loss = paddle.mean(
+                                outputs_valid[outputs_valid_key][0]
+                            )
                 else:
                     avg_sum = []
                     for cur_loss in outputs_valid:
-                        cur_avg_loss = paddle.mean(outputs_valid[cur_loss][0])
+                        if outputs_valid[cur_loss][0].dtype in [
+                            paddle.int32,
+                            paddle.int64,
+                            paddle.bool,
+                        ]:
+                            cur_avg_loss = paddle.mean(
+                                outputs_valid[cur_loss][0].astype("float64")
+                            )
+                        else:
+                            cur_avg_lossloss = paddle.mean(
+                                outputs_valid[cur_loss][0]
+                            )
                         avg_sum.append(cur_avg_loss)
                     loss_sum = paddle.add_n(avg_sum)
                     loss = paddle.scale(
@@ -4050,11 +4070,35 @@ class OpTest(unittest.TestCase):
             if user_defined_grad_outputs is None:
                 if len(outputs_valid) == 1:
                     for outputs_valid_key in outputs_valid:
-                        loss = paddle.mean(outputs_valid[outputs_valid_key][0])
+                        if outputs_valid[outputs_valid_key][0].dtype in [
+                            paddle.int32,
+                            paddle.int64,
+                            paddle.bool,
+                        ]:
+                            loss = paddle.mean(
+                                outputs_valid[outputs_valid_key][0].astype(
+                                    "float64"
+                                )
+                            )
+                        else:
+                            loss = paddle.mean(
+                                outputs_valid[outputs_valid_key][0]
+                            )
                 else:
                     avg_sum = []
                     for cur_loss in outputs_valid:
-                        cur_avg_loss = paddle.mean(outputs_valid[cur_loss][0])
+                        if outputs_valid[cur_loss][0].dtype in [
+                            paddle.int32,
+                            paddle.int64,
+                            paddle.bool,
+                        ]:
+                            cur_avg_loss = paddle.mean(
+                                outputs_valid[cur_loss][0].astype("float64")
+                            )
+                        else:
+                            cur_avg_loss = paddle.mean(
+                                outputs_valid[cur_loss][0]
+                            )
                         avg_sum.append(cur_avg_loss)
                     loss_sum = paddle.add_n(avg_sum)
                     loss = paddle.scale(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164
参考paddle文档，mean算子仅要支持  float类型。之前注册了对int, bool 的接口，但缺乏这些类型的实现。目前对int类型做mean的计算结果也是错误的。Pytoch也仅支持对float数据mean操作。
因此对该算子 的输入进行类型检查，排除计算错误的类型（如int, bool）。