### PR TITLE
Fix self.assertTrue(np.allclose())

### DIFF
--- a/test/legacy_test/test_group_norm_op_v2.py
+++ b/test/legacy_test/test_group_norm_op_v2.py
@@ -87,8 +87,8 @@ class TestGroupNormAPIV2_With_General_Dimensions(unittest.TestCase):
                 data_pd = paddle.to_tensor(data)
                 result1 = gn1(data_pd).numpy()
                 result2 = gn2(data_pd).numpy()
-                self.assertTrue(np.allclose(result1, expect_res1, atol=1e-5))
-                self.assertTrue(np.allclose(result2, expect_res2, atol=1e-5))
+                np.testing.assert_allclose(result1, expect_res1, atol=1e-5)
+                np.testing.assert_allclose(result2, expect_res2, atol=1e-5)
 
 
 class TestGroupNormAPIV2_With_NCL(unittest.TestCase):

--- a/test/legacy_test/test_stride.py
+++ b/test/legacy_test/test_stride.py
@@ -33,32 +33,32 @@ class TestStride(unittest.TestCase):
     def call_transpose(self):
         x_np = np.random.random(size=[2, 3, 4]).astype('float32')
         x = paddle.to_tensor(x_np)
-        self.assertTrue(np.allclose(x.numpy(), x_np))
+        np.testing.assert_allclose(x.numpy(), x_np)
 
         x_transposed1 = paddle.transpose(x, perm=[1, 0, 2])
         x_np_transposed1 = x_np.transpose(1, 0, 2)
-        self.assertTrue(np.allclose(x_transposed1.numpy(), x_np_transposed1))
+        np.testing.assert_allclose(x_transposed1.numpy(), x_np_transposed1)
         self.assertFalse(x_transposed1.is_contiguous())
         self.assertTrue(x._is_shared_buffer_with(x_transposed1))
 
         x_c = x_transposed1.contiguous()
-        self.assertTrue(np.allclose(x_c.numpy(), x_np_transposed1))
+        np.testing.assert_allclose(x_c.numpy(), x_np_transposed1)
 
         x_transposed2 = paddle.transpose(x_transposed1, perm=[2, 0, 1])
         x_np_transposed2 = x_np_transposed1.transpose(2, 0, 1)
-        self.assertTrue(np.allclose(x_transposed2.numpy(), x_np_transposed2))
+        np.testing.assert_allclose(x_transposed2.numpy(), x_np_transposed2)
         self.assertFalse(x_transposed2.is_contiguous())
 
         y = x_transposed2 + 2
         y_np = x_np_transposed2 + 2
-        self.assertTrue(np.allclose(y.numpy(), y_np))
+        np.testing.assert_allclose(y.numpy(), y_np)
         self.assertTrue(y.is_contiguous())
         self.assertFalse(x._is_shared_buffer_with(y))
 
     def call_diagonal(self):
         x_np = np.random.random(size=[2, 3, 4]).astype('float32')
         x = paddle.to_tensor(x_np)
-        self.assertTrue(np.allclose(x.numpy(), x_np))
+        np.testing.assert_allclose(x.numpy(), x_np)
 
         out = paddle.diagonal(x)
         out2 = paddle.diagonal(x, offset=0, axis1=2, axis2=1)
@@ -70,10 +70,10 @@ class TestStride(unittest.TestCase):
         np_out3 = np.diagonal(x_np, offset=1, axis1=0, axis2=1)
         np_out4 = np.diagonal(x_np, offset=0, axis1=1, axis2=2)
 
-        self.assertTrue(np.allclose(out.numpy(), np_out))
-        self.assertTrue(np.allclose(out2.numpy(), np_out2))
-        self.assertTrue(np.allclose(out3.numpy(), np_out3))
-        self.assertTrue(np.allclose(out4.numpy(), np_out4))
+        np.testing.assert_allclose(out.numpy(), np_out)
+        np.testing.assert_allclose(out2.numpy(), np_out2)
+        np.testing.assert_allclose(out3.numpy(), np_out3)
+        np.testing.assert_allclose(out4.numpy(), np_out4)
 
         self.assertFalse(out.is_contiguous())
         self.assertFalse(out2.is_contiguous())
@@ -90,21 +90,21 @@ class TestStride(unittest.TestCase):
         out3_c = out3.contiguous()
         out4_c = out4.contiguous()
 
-        self.assertTrue(np.allclose(out_c.numpy(), np_out))
-        self.assertTrue(np.allclose(out2_c.numpy(), np_out2))
-        self.assertTrue(np.allclose(out3_c.numpy(), np_out3))
-        self.assertTrue(np.allclose(out4_c.numpy(), np_out4))
+        np.testing.assert_allclose(out_c.numpy(), np_out)
+        np.testing.assert_allclose(out2_c.numpy(), np_out2)
+        np.testing.assert_allclose(out3_c.numpy(), np_out3)
+        np.testing.assert_allclose(out4_c.numpy(), np_out4)
 
     def call_slice(self):
         x_np = np.random.random(size=[10, 10, 10, 20]).astype('float32')
         x = paddle.to_tensor(x_np)
-        self.assertTrue(np.allclose(x.numpy(), x_np))
+        np.testing.assert_allclose(x.numpy(), x_np)
 
         out = x[1:10, 0:10, 0:10, 0:20]
 
         np_out = x_np[1:10, 0:10, 0:10, 0:20]
 
-        self.assertTrue(np.allclose(out.numpy(), np_out))
+        np.testing.assert_allclose(out.numpy(), np_out)
 
         self.assertTrue(out.is_contiguous())
 
@@ -112,20 +112,20 @@ class TestStride(unittest.TestCase):
 
         out_c = out.contiguous()
 
-        self.assertTrue(np.allclose(out_c.numpy(), np_out))
+        np.testing.assert_allclose(out_c.numpy(), np_out)
 
         self.assertTrue(out_c._is_shared_buffer_with(out))
 
     def call_strided_slice(self):
         x_np = np.random.random(size=[10, 10, 10, 20]).astype('float32')
         x = paddle.to_tensor(x_np)
-        self.assertTrue(np.allclose(x.numpy(), x_np))
+        np.testing.assert_allclose(x.numpy(), x_np)
 
         out = x[1:10:2, 0:10:2, 0:10:2, 0:20:2]
 
         np_out = x_np[1:10:2, 0:10:2, 0:10:2, 0:20:2]
 
-        self.assertTrue(np.allclose(out.numpy(), np_out))
+        np.testing.assert_allclose(out.numpy(), np_out)
 
         self.assertFalse(out.is_contiguous())
 
@@ -133,17 +133,17 @@ class TestStride(unittest.TestCase):
 
         out_c = out.contiguous()
 
-        self.assertTrue(np.allclose(out_c.numpy(), np_out))
+        np.testing.assert_allclose(out_c.numpy(), np_out)
 
     def call_index_select(self):
         x_np = np.random.random(size=[10, 10, 10, 20]).astype('float32')
         x = paddle.to_tensor(x_np)
-        self.assertTrue(np.allclose(x.numpy(), x_np))
+        np.testing.assert_allclose(x.numpy(), x_np)
 
         out = x[:, :, :, 5]
         np_out = x_np[:, :, :, 5]
 
-        self.assertTrue(np.allclose(out.numpy(), np_out))
+        np.testing.assert_allclose(out.numpy(), np_out)
 
         self.assertFalse(out.is_contiguous())
 
@@ -151,17 +151,17 @@ class TestStride(unittest.TestCase):
 
         out_c = out.contiguous()
 
-        self.assertTrue(np.allclose(out_c.numpy(), np_out))
+        np.testing.assert_allclose(out_c.numpy(), np_out)
 
     def call_reshape(self):
         x_np = np.random.random(size=[10, 10, 10, 20]).astype('float32')
         x = paddle.to_tensor(x_np)
-        self.assertTrue(np.allclose(x.numpy(), x_np))
+        np.testing.assert_allclose(x.numpy(), x_np)
 
         out = paddle.reshape(x, [10, 100, 20])
         np_out = x_np.reshape(10, 100, 20)
 
-        self.assertTrue(np.allclose(out.numpy(), np_out))
+        np.testing.assert_allclose(out.numpy(), np_out)
 
         self.assertTrue(out.is_contiguous())
 
@@ -169,19 +169,19 @@ class TestStride(unittest.TestCase):
 
         out_c = out.contiguous()
 
-        self.assertTrue(np.allclose(out_c.numpy(), np_out))
+        np.testing.assert_allclose(out_c.numpy(), np_out)
 
         self.assertTrue(out_c._is_shared_buffer_with(out))
 
     def call_real(self):
         x_np = np.random.random(size=[10, 10, 10, 20]).astype('complex64')
         x = paddle.to_tensor(x_np)
-        self.assertTrue(np.allclose(x.numpy(), x_np))
+        np.testing.assert_allclose(x.numpy(), x_np)
 
         out = paddle.real(x)
         np_out = np.real(x_np)
 
-        self.assertTrue(np.allclose(out.numpy(), np_out))
+        np.testing.assert_allclose(out.numpy(), np_out)
 
         self.assertFalse(out.is_contiguous())
 
@@ -189,17 +189,17 @@ class TestStride(unittest.TestCase):
 
         out_c = out.contiguous()
 
-        self.assertTrue(np.allclose(out_c.numpy(), np_out))
+        np.testing.assert_allclose(out_c.numpy(), np_out)
 
     def call_imag(self):
         x_np = np.random.random(size=[10, 10, 10, 20]).astype('complex128')
         x = paddle.to_tensor(x_np)
-        self.assertTrue(np.allclose(x.numpy(), x_np))
+        np.testing.assert_allclose(x.numpy(), x_np)
 
         out = paddle.imag(x)
         np_out = np.imag(x_np)
 
-        self.assertTrue(np.allclose(out.numpy(), np_out))
+        np.testing.assert_allclose(out.numpy(), np_out)
 
         self.assertFalse(out.is_contiguous())
 
@@ -207,17 +207,17 @@ class TestStride(unittest.TestCase):
 
         out_c = out.contiguous()
 
-        self.assertTrue(np.allclose(out_c.numpy(), np_out))
+        np.testing.assert_allclose(out_c.numpy(), np_out)
 
     def call_as_real(self):
         x_np = np.random.random(size=[10, 10, 10, 20]).astype('complex128')
         x = paddle.to_tensor(x_np)
-        self.assertTrue(np.allclose(x.numpy(), x_np))
+        np.testing.assert_allclose(x.numpy(), x_np)
 
         out = paddle.as_real(x)
         np_out = ref_view_as_real(x_np)
 
-        self.assertTrue(np.allclose(out.numpy(), np_out))
+        np.testing.assert_allclose(out.numpy(), np_out)
 
         self.assertTrue(out.is_contiguous())
 
@@ -225,19 +225,19 @@ class TestStride(unittest.TestCase):
 
         out_c = out.contiguous()
 
-        self.assertTrue(np.allclose(out_c.numpy(), np_out))
+        np.testing.assert_allclose(out_c.numpy(), np_out)
 
         self.assertTrue(out_c._is_shared_buffer_with(out))
 
     def call_as_complex(self):
         x_np = np.random.random(size=[10, 10, 10, 2]).astype('float32')
         x = paddle.to_tensor(x_np)
-        self.assertTrue(np.allclose(x.numpy(), x_np))
+        np.testing.assert_allclose(x.numpy(), x_np)
 
         out = paddle.as_complex(x)
         np_out = ref_view_as_complex(x_np)
 
-        self.assertTrue(np.allclose(out.numpy(), np_out))
+        np.testing.assert_allclose(out.numpy(), np_out)
 
         self.assertTrue(out.is_contiguous())
 
@@ -245,19 +245,19 @@ class TestStride(unittest.TestCase):
 
         out_c = out.contiguous()
 
-        self.assertTrue(np.allclose(out_c.numpy(), np_out))
+        np.testing.assert_allclose(out_c.numpy(), np_out)
 
         self.assertTrue(out_c._is_shared_buffer_with(out))
 
     def call_flatten(self):
         x_np = np.random.random(size=[2, 3, 4, 4]).astype('float32')
         x = paddle.to_tensor(x_np)
-        self.assertTrue(np.allclose(x.numpy(), x_np))
+        np.testing.assert_allclose(x.numpy(), x_np)
 
         out = paddle.flatten(x, start_axis=1, stop_axis=2)
         np_out = x_np.reshape(2, 12, 4)
 
-        self.assertTrue(np.allclose(out.numpy(), np_out))
+        np.testing.assert_allclose(out.numpy(), np_out)
 
         self.assertTrue(out.is_contiguous())
 
@@ -265,19 +265,19 @@ class TestStride(unittest.TestCase):
 
         out_c = out.contiguous()
 
-        self.assertTrue(np.allclose(out_c.numpy(), np_out))
+        np.testing.assert_allclose(out_c.numpy(), np_out)
 
         self.assertTrue(out_c._is_shared_buffer_with(out))
 
     def call_squeeze(self):
         x_np = np.random.random(size=[5, 1, 10]).astype('float32')
         x = paddle.to_tensor(x_np)
-        self.assertTrue(np.allclose(x.numpy(), x_np))
+        np.testing.assert_allclose(x.numpy(), x_np)
 
         out = paddle.squeeze(x, axis=1)
         np_out = x_np.reshape(5, 10)
 
-        self.assertTrue(np.allclose(out.numpy(), np_out))
+        np.testing.assert_allclose(out.numpy(), np_out)
 
         self.assertTrue(out.is_contiguous())
 
@@ -285,19 +285,19 @@ class TestStride(unittest.TestCase):
 
         out_c = out.contiguous()
 
-        self.assertTrue(np.allclose(out_c.numpy(), np_out))
+        np.testing.assert_allclose(out_c.numpy(), np_out)
 
         self.assertTrue(out_c._is_shared_buffer_with(out))
 
     def call_unsqueeze(self):
         x_np = np.random.random(size=[5, 10]).astype('float32')
         x = paddle.to_tensor(x_np)
-        self.assertTrue(np.allclose(x.numpy(), x_np))
+        np.testing.assert_allclose(x.numpy(), x_np)
 
         out = paddle.unsqueeze(x, axis=0)
         np_out = x_np.reshape(1, 5, 10)
 
-        self.assertTrue(np.allclose(out.numpy(), np_out))
+        np.testing.assert_allclose(out.numpy(), np_out)
 
         self.assertTrue(out.is_contiguous())
 
@@ -305,21 +305,21 @@ class TestStride(unittest.TestCase):
 
         out_c = out.contiguous()
 
-        self.assertTrue(np.allclose(out_c.numpy(), np_out))
+        np.testing.assert_allclose(out_c.numpy(), np_out)
 
         self.assertTrue(out_c._is_shared_buffer_with(out))
 
     def call_split(self):
         x_np = np.random.random(size=[3, 9, 5]).astype('float32')
         x = paddle.to_tensor(x_np)
-        self.assertTrue(np.allclose(x.numpy(), x_np))
+        np.testing.assert_allclose(x.numpy(), x_np)
 
         out0, out1, out2 = paddle.split(x, num_or_sections=3, axis=1)
         np_out0, np_out1, np_out2 = np.split(x_np, 3, 1)
 
-        self.assertTrue(np.allclose(out0.numpy(), np_out0))
-        self.assertTrue(np.allclose(out1.numpy(), np_out1))
-        self.assertTrue(np.allclose(out2.numpy(), np_out2))
+        np.testing.assert_allclose(out0.numpy(), np_out0)
+        np.testing.assert_allclose(out1.numpy(), np_out1)
+        np.testing.assert_allclose(out2.numpy(), np_out2)
 
         self.assertFalse(out0.is_contiguous())
         self.assertFalse(out1.is_contiguous())
@@ -333,14 +333,14 @@ class TestStride(unittest.TestCase):
         out1_c = out1.contiguous()
         out2_c = out2.contiguous()
 
-        self.assertTrue(np.allclose(out0_c.numpy(), np_out0))
-        self.assertTrue(np.allclose(out1_c.numpy(), np_out1))
-        self.assertTrue(np.allclose(out2_c.numpy(), np_out2))
+        np.testing.assert_allclose(out0_c.numpy(), np_out0)
+        np.testing.assert_allclose(out1_c.numpy(), np_out1)
+        np.testing.assert_allclose(out2_c.numpy(), np_out2)
 
     def call_split2(self):
         x_np = np.random.random(size=[3, 9, 5]).astype('float32')
         x = paddle.to_tensor(x_np)
-        self.assertTrue(np.allclose(x.numpy(), x_np))
+        np.testing.assert_allclose(x.numpy(), x_np)
 
         out0, out1, out2 = paddle.split(x, num_or_sections=[2, 3, 4], axis=1)
         out = np.split(x_np, [2, 5], 1)
@@ -348,9 +348,9 @@ class TestStride(unittest.TestCase):
         np_out1 = out[1]
         np_out2 = out[2]
 
-        self.assertTrue(np.allclose(out0.numpy(), np_out0))
-        self.assertTrue(np.allclose(out1.numpy(), np_out1))
-        self.assertTrue(np.allclose(out2.numpy(), np_out2))
+        np.testing.assert_allclose(out0.numpy(), np_out0)
+        np.testing.assert_allclose(out1.numpy(), np_out1)
+        np.testing.assert_allclose(out2.numpy(), np_out2)
 
         self.assertFalse(out0.is_contiguous())
         self.assertFalse(out1.is_contiguous())
@@ -364,21 +364,21 @@ class TestStride(unittest.TestCase):
         out1_c = out1.contiguous()
         out2_c = out2.contiguous()
 
-        self.assertTrue(np.allclose(out0_c.numpy(), np_out0))
-        self.assertTrue(np.allclose(out1_c.numpy(), np_out1))
-        self.assertTrue(np.allclose(out2_c.numpy(), np_out2))
+        np.testing.assert_allclose(out0_c.numpy(), np_out0)
+        np.testing.assert_allclose(out1_c.numpy(), np_out1)
+        np.testing.assert_allclose(out2_c.numpy(), np_out2)
 
     def call_split3(self):
         x_np = np.random.random(size=[9, 3, 5]).astype('float32')
         x = paddle.to_tensor(x_np)
-        self.assertTrue(np.allclose(x.numpy(), x_np))
+        np.testing.assert_allclose(x.numpy(), x_np)
 
         out0, out1, out2 = paddle.split(x, num_or_sections=3, axis=0)
         np_out0, np_out1, np_out2 = np.split(x_np, 3, 0)
 
-        self.assertTrue(np.allclose(out0.numpy(), np_out0))
-        self.assertTrue(np.allclose(out1.numpy(), np_out1))
-        self.assertTrue(np.allclose(out2.numpy(), np_out2))
+        np.testing.assert_allclose(out0.numpy(), np_out0)
+        np.testing.assert_allclose(out1.numpy(), np_out1)
+        np.testing.assert_allclose(out2.numpy(), np_out2)
 
         self.assertTrue(out0.is_contiguous())
         self.assertTrue(out1.is_contiguous())
@@ -392,9 +392,9 @@ class TestStride(unittest.TestCase):
         out1_c = out1.contiguous()
         out2_c = out2.contiguous()
 
-        self.assertTrue(np.allclose(out0_c.numpy(), np_out0))
-        self.assertTrue(np.allclose(out1_c.numpy(), np_out1))
-        self.assertTrue(np.allclose(out2_c.numpy(), np_out2))
+        np.testing.assert_allclose(out0_c.numpy(), np_out0)
+        np.testing.assert_allclose(out1_c.numpy(), np_out1)
+        np.testing.assert_allclose(out2_c.numpy(), np_out2)
 
         self.assertTrue(out0_c._is_shared_buffer_with(out0))
         self.assertTrue(out1_c._is_shared_buffer_with(out1))
@@ -403,7 +403,7 @@ class TestStride(unittest.TestCase):
     def call_split4(self):
         x_np = np.random.random(size=[9, 3, 5]).astype('float32')
         x = paddle.to_tensor(x_np)
-        self.assertTrue(np.allclose(x.numpy(), x_np))
+        np.testing.assert_allclose(x.numpy(), x_np)
 
         out0, out1, out2 = paddle.split(x, num_or_sections=[2, 3, 4], axis=0)
         out = np.split(x_np, [2, 5], 0)
@@ -411,9 +411,9 @@ class TestStride(unittest.TestCase):
         np_out1 = out[1]
         np_out2 = out[2]
 
-        self.assertTrue(np.allclose(out0.numpy(), np_out0))
-        self.assertTrue(np.allclose(out1.numpy(), np_out1))
-        self.assertTrue(np.allclose(out2.numpy(), np_out2))
+        np.testing.assert_allclose(out0.numpy(), np_out0)
+        np.testing.assert_allclose(out1.numpy(), np_out1)
+        np.testing.assert_allclose(out2.numpy(), np_out2)
 
         self.assertTrue(out0.is_contiguous())
         self.assertTrue(out1.is_contiguous())
@@ -427,9 +427,9 @@ class TestStride(unittest.TestCase):
         out1_c = out1.contiguous()
         out2_c = out2.contiguous()
 
-        self.assertTrue(np.allclose(out0_c.numpy(), np_out0))
-        self.assertTrue(np.allclose(out1_c.numpy(), np_out1))
-        self.assertTrue(np.allclose(out2_c.numpy(), np_out2))
+        np.testing.assert_allclose(out0_c.numpy(), np_out0)
+        np.testing.assert_allclose(out1_c.numpy(), np_out1)
+        np.testing.assert_allclose(out2_c.numpy(), np_out2)
 
         self.assertTrue(out0_c._is_shared_buffer_with(out0))
         self.assertTrue(out1_c._is_shared_buffer_with(out1))
@@ -438,14 +438,14 @@ class TestStride(unittest.TestCase):
     def call_chunk(self):
         x_np = np.random.random(size=[3, 9, 5]).astype('float32')
         x = paddle.to_tensor(x_np)
-        self.assertTrue(np.allclose(x.numpy(), x_np))
+        np.testing.assert_allclose(x.numpy(), x_np)
 
         out0, out1, out2 = paddle.chunk(x, chunks=3, axis=1)
         np_out0, np_out1, np_out2 = np.split(x_np, 3, 1)
 
-        self.assertTrue(np.allclose(out0.numpy(), np_out0))
-        self.assertTrue(np.allclose(out1.numpy(), np_out1))
-        self.assertTrue(np.allclose(out2.numpy(), np_out2))
+        np.testing.assert_allclose(out0.numpy(), np_out0)
+        np.testing.assert_allclose(out1.numpy(), np_out1)
+        np.testing.assert_allclose(out2.numpy(), np_out2)
 
         self.assertFalse(out0.is_contiguous())
         self.assertFalse(out1.is_contiguous())
@@ -459,23 +459,23 @@ class TestStride(unittest.TestCase):
         out1_c = out1.contiguous()
         out2_c = out2.contiguous()
 
-        self.assertTrue(np.allclose(out0_c.numpy(), np_out0))
-        self.assertTrue(np.allclose(out1_c.numpy(), np_out1))
-        self.assertTrue(np.allclose(out2_c.numpy(), np_out2))
+        np.testing.assert_allclose(out0_c.numpy(), np_out0)
+        np.testing.assert_allclose(out1_c.numpy(), np_out1)
+        np.testing.assert_allclose(out2_c.numpy(), np_out2)
 
     def call_unbind(self):
         x_np = np.random.random(size=[3, 9, 5]).astype('float32')
         x = paddle.to_tensor(x_np)
-        self.assertTrue(np.allclose(x.numpy(), x_np))
+        np.testing.assert_allclose(x.numpy(), x_np)
 
         out0, out1, out2 = paddle.unbind(x, axis=0)
         np_out0 = x_np[0, 0:100, 0:100]
         np_out1 = x_np[1, 0:100, 0:100]
         np_out2 = x_np[2, 0:100, 0:100]
 
-        self.assertTrue(np.allclose(out0.numpy(), np_out0))
-        self.assertTrue(np.allclose(out1.numpy(), np_out1))
-        self.assertTrue(np.allclose(out2.numpy(), np_out2))
+        np.testing.assert_allclose(out0.numpy(), np_out0)
+        np.testing.assert_allclose(out1.numpy(), np_out1)
+        np.testing.assert_allclose(out2.numpy(), np_out2)
 
         self.assertTrue(out0.is_contiguous())
         self.assertTrue(out1.is_contiguous())
@@ -489,9 +489,9 @@ class TestStride(unittest.TestCase):
         out1_c = out1.contiguous()
         out2_c = out2.contiguous()
 
-        self.assertTrue(np.allclose(out0_c.numpy(), np_out0))
-        self.assertTrue(np.allclose(out1_c.numpy(), np_out1))
-        self.assertTrue(np.allclose(out2_c.numpy(), np_out2))
+        np.testing.assert_allclose(out0_c.numpy(), np_out0)
+        np.testing.assert_allclose(out1_c.numpy(), np_out1)
+        np.testing.assert_allclose(out2_c.numpy(), np_out2)
 
         self.assertTrue(out0_c._is_shared_buffer_with(out0))
         self.assertTrue(out1_c._is_shared_buffer_with(out1))
@@ -500,12 +500,12 @@ class TestStride(unittest.TestCase):
     def call_as_strided(self):
         x_np = np.random.random(size=[2, 4, 6]).astype('float32')
         x = paddle.to_tensor(x_np)
-        self.assertTrue(np.allclose(x.numpy(), x_np))
+        np.testing.assert_allclose(x.numpy(), x_np)
 
         out = paddle.as_strided(x, [8, 6], [6, 1])
         np_out = x_np.reshape(8, 6)
 
-        self.assertTrue(np.allclose(out.numpy(), np_out))
+        np.testing.assert_allclose(out.numpy(), np_out)
 
         self.assertTrue(out.is_contiguous())
 
@@ -513,19 +513,19 @@ class TestStride(unittest.TestCase):
 
         out_c = out.contiguous()
 
-        self.assertTrue(np.allclose(out_c.numpy(), np_out))
+        np.testing.assert_allclose(out_c.numpy(), np_out)
 
         self.assertTrue(out_c._is_shared_buffer_with(out))
 
     def call_view(self):
         x_np = np.random.random(size=[10, 10, 10, 20]).astype('float32')
         x = paddle.to_tensor(x_np)
-        self.assertTrue(np.allclose(x.numpy(), x_np))
+        np.testing.assert_allclose(x.numpy(), x_np)
 
         out = paddle.view(x, [10, 100, 20])
         np_out = x_np.reshape(10, 100, 20)
 
-        self.assertTrue(np.allclose(out.numpy(), np_out))
+        np.testing.assert_allclose(out.numpy(), np_out)
 
         self.assertTrue(out.is_contiguous())
 
@@ -533,19 +533,19 @@ class TestStride(unittest.TestCase):
 
         out_c = out.contiguous()
 
-        self.assertTrue(np.allclose(out_c.numpy(), np_out))
+        np.testing.assert_allclose(out_c.numpy(), np_out)
 
         self.assertTrue(out_c._is_shared_buffer_with(out))
 
     def call_view2(self):
         x_np = np.random.random(size=[10, 10, 10, 20]).astype('float32')
         x = paddle.to_tensor(x_np)
-        self.assertTrue(np.allclose(x.numpy(), x_np))
+        np.testing.assert_allclose(x.numpy(), x_np)
 
         out = paddle.view(x, "uint8")
         np_out = x_np.view(np.uint8)
 
-        self.assertTrue(np.allclose(out.numpy(), np_out))
+        np.testing.assert_allclose(out.numpy(), np_out)
 
         self.assertTrue(out.is_contiguous())
 
@@ -553,7 +553,7 @@ class TestStride(unittest.TestCase):
 
         out_c = out.contiguous()
 
-        self.assertTrue(np.allclose(out_c.numpy(), np_out))
+        np.testing.assert_allclose(out_c.numpy(), np_out)
 
         self.assertTrue(out_c._is_shared_buffer_with(out))
 
@@ -694,13 +694,13 @@ class TestStride(unittest.TestCase):
     def call_view_as(self):
         x_np = np.random.random(size=[10, 10, 10, 20]).astype('float32')
         x = paddle.to_tensor(x_np)
-        self.assertTrue(np.allclose(x.numpy(), x_np))
+        np.testing.assert_allclose(x.numpy(), x_np)
 
         np_out = x_np.reshape(10, 100, 20)
         tmp = paddle.to_tensor(np_out)
         out = paddle.view_as(x, tmp)
 
-        self.assertTrue(np.allclose(out.numpy(), np_out))
+        np.testing.assert_allclose(out.numpy(), np_out)
 
         self.assertTrue(out.is_contiguous())
 
@@ -708,19 +708,19 @@ class TestStride(unittest.TestCase):
 
         out_c = out.contiguous()
 
-        self.assertTrue(np.allclose(out_c.numpy(), np_out))
+        np.testing.assert_allclose(out_c.numpy(), np_out)
 
         self.assertTrue(out_c._is_shared_buffer_with(out))
 
     def call_unfold(self):
         x_np = np.random.random(size=[9]).astype('float32')
         x = paddle.to_tensor(x_np)
-        self.assertTrue(np.allclose(x.numpy(), x_np))
+        np.testing.assert_allclose(x.numpy(), x_np)
 
         out = paddle.unfold(x, 0, 2, 4)
         np_out = np.stack((x_np[0:2], x_np[4:6]))
 
-        self.assertTrue(np.allclose(out.numpy(), np_out))
+        np.testing.assert_allclose(out.numpy(), np_out)
 
         self.assertFalse(out.is_contiguous())
 
@@ -728,7 +728,7 @@ class TestStride(unittest.TestCase):
 
         out_c = out.contiguous()
 
-        self.assertTrue(np.allclose(out_c.numpy(), np_out))
+        np.testing.assert_allclose(out_c.numpy(), np_out)
 
     def call_stride(self):
         self.call_transpose()

--- a/test/legacy_test/test_unfold_op.py
+++ b/test/legacy_test/test_unfold_op.py
@@ -153,7 +153,7 @@ class TestUnfoldOp(OpTest):
         paddle.nn.functional.unfold(x, 3, 1, 1, (1, 1))
         out1 = paddle.nn.functional.unfold(x, 3, (1, 1), (1, 1), (1, 1))
         out2 = paddle.nn.functional.unfold(x, (3, 3), (1, 1), (1, 1), (1, 1))
-        self.assertTrue(np.allclose(out1.numpy(), out2.numpy()))
+        np.testing.assert_allclose(out1.numpy(), out2.numpy())
         paddle.enable_static()
 
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
self.assertTrue(np.allclose( 修改为 np.testing.assert_allclose( 形式，CI有验证