### PR TITLE
[PHI]Fix paddle.index_sample to support big Tensor

### DIFF
--- a/paddle/phi/kernels/cpu/index_sample_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_sample_grad_kernel.cc
@@ -35,12 +35,12 @@ void IndexSampleGradInner(const Context& context,
 
   auto value_length = x_grad_dims[1];
   auto index_length = index_dims[1];
-  int index_ids_num = static_cast<int>(index.numel());
+  int64_t index_ids_num = index.numel();
 
   std::vector<T> x_grad_vec(x_grad->numel(), 0);
 
-  for (int i = 0; i < index_ids_num; i++) {
-    int b = floor(i / index_length);
+  for (int64_t i = 0; i < index_ids_num; i++) {
+    int64_t b = floor(i / index_length);
     PADDLE_ENFORCE_GE(
         index_vec[i],
         0,
@@ -59,7 +59,7 @@ void IndexSampleGradInner(const Context& context,
             "value.",
             value_length,
             index_vec[i]));
-    int v_i = b * value_length + static_cast<int>(index_vec[i]);
+    int64_t v_i = b * value_length + static_cast<int64_t>(index_vec[i]);
     x_grad_vec[v_i] += out_grad_vec[i];
   }
   context.template Alloc<T>(x_grad);

--- a/paddle/phi/kernels/cpu/index_sample_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_sample_kernel.cc
@@ -37,10 +37,10 @@ void IndexSampleInner(const Context &context,
   auto input_dims = input.dims();
   auto index_dims = index.dims();
 
-  int batch_size = static_cast<int>(input_dims[0]);
+  int64_t batch_size = input_dims[0];
   auto value_length = input_dims[1];
   auto index_length = index_dims[1];
-  int index_ids_num = static_cast<int>(index.numel());
+  int64_t index_ids_num = index.numel();
 
   std::vector<T> input_vec;
   std::vector<IndexT> index_vec;
@@ -48,8 +48,8 @@ void IndexSampleInner(const Context &context,
   phi::TensorToVector<IndexT>(index, context, &index_vec);
 
   std::vector<T> res(index_ids_num);
-  for (int i = 0; i < index_ids_num; i++) {
-    int b = floor(i / index_length);
+  for (int64_t i = 0; i < index_ids_num; i++) {
+    int64_t b = floor(i / index_length);
     PADDLE_ENFORCE_GE(
         index_vec[i],
         0,
@@ -69,7 +69,7 @@ void IndexSampleInner(const Context &context,
             value_length,
             index_vec[i]));
 
-    int v_i = b * value_length + static_cast<int>(index_vec[i]);
+    int64_t v_i = b * value_length + static_cast<int64_t>(index_vec[i]);
     T v = input_vec[v_i];
     VLOG(4) << "Index Sample: batch = " << b << " index = " << v_i
             << " value = " << v;

--- a/paddle/phi/kernels/gpu/index_sample_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_sample_grad_kernel.cu
@@ -30,25 +30,27 @@ namespace {
 #define PREDEFINED_BLOCK_SIZE_X 512
 #define PREDEFINED_BLOCK_SIZE 1024
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
+#define UINT32_MAX std::numeric_limits<uint32_t>::max()
+
 }  // namespace
 
-template <typename T, typename IndexT = int>
-__global__ void IndexSampleGrad(const IndexT* index,
+template <typename T, typename SampleIndexT = int, typename ElementIndexT>
+__global__ void IndexSampleGrad(const SampleIndexT* index,
                                 T* in_grad,
                                 const T* out_grad,
                                 size_t index_length,
                                 size_t input_length,
                                 size_t batch_size,
                                 bool same_data_in_row = true) {
-  unsigned int index_i = blockDim.x * blockIdx.x + threadIdx.x;
-  unsigned int index_j = blockDim.y * blockIdx.y + threadIdx.y;
+  ElementIndexT index_i = blockDim.x * blockIdx.x + threadIdx.x;
+  ElementIndexT index_j = blockDim.y * blockIdx.y + threadIdx.y;
 
   for (; index_j < batch_size; index_j += blockDim.y * gridDim.y) {
     index_i = blockDim.x * blockIdx.x + threadIdx.x;
     for (; index_i < index_length; index_i += blockDim.x * gridDim.x) {
-      unsigned int index_idx = index_j * index_length + index_i;
-      unsigned int in_idx = index_j * input_length + index_i;
-      IndexT sample_idx = index[index_idx];
+      ElementIndexT index_idx = index_j * index_length + index_i;
+      ElementIndexT in_idx = index_j * input_length + index_i;
+      SampleIndexT sample_idx = index[index_idx];
       if (same_data_in_row) {
         phi::CudaAtomicAdd(&(in_grad[in_idx - index_i + sample_idx]),
                            out_grad[sample_idx]);
@@ -101,27 +103,56 @@ void IndexSampleGradKernel(const Context& dev_ctx,
 
   phi::funcs::SetConstant<Context, T> set_zero;
   set_zero(dev_ctx, x_grad, static_cast<T>(0));
+  bool use_int32 = true;
+  if (out_grad.numel() > UINT32_MAX || x_grad->numel() > UINT32_MAX) {
+    use_int32 = false;
+  }
 
   if (index_type == DataType::INT64) {
     const int64_t* index_data = index.data<int64_t>();
-    IndexSampleGrad<T, int64_t>
-        <<<grid_dim, block_dim, 0, stream>>>(index_data,
-                                             input_grad_data,
-                                             output_grad_data,
-                                             index_length,
-                                             input_length,
-                                             batch_size,
-                                             same_data_in_index_row);
+    if (use_int32) {
+      IndexSampleGrad<T, int64_t, uint32_t>
+          <<<grid_dim, block_dim, 0, stream>>>(index_data,
+                                               input_grad_data,
+                                               output_grad_data,
+                                               index_length,
+                                               input_length,
+                                               batch_size,
+                                               same_data_in_index_row);
+
+    } else {
+      IndexSampleGrad<T, int64_t, int64_t>
+          <<<grid_dim, block_dim, 0, stream>>>(index_data,
+                                               input_grad_data,
+                                               output_grad_data,
+                                               index_length,
+                                               input_length,
+                                               batch_size,
+                                               same_data_in_index_row);
+    }
+
   } else if (index_type == DataType::INT32) {
     const int* index_data = index.data<int>();
-    IndexSampleGrad<T, int>
-        <<<grid_dim, block_dim, 0, stream>>>(index_data,
-                                             input_grad_data,
-                                             output_grad_data,
-                                             index_length,
-                                             input_length,
-                                             batch_size,
-                                             same_data_in_index_row);
+    if (use_int32) {
+      IndexSampleGrad<T, int, uint32_t>
+          <<<grid_dim, block_dim, 0, stream>>>(index_data,
+                                               input_grad_data,
+                                               output_grad_data,
+                                               index_length,
+                                               input_length,
+                                               batch_size,
+                                               same_data_in_index_row);
+
+    } else {
+      IndexSampleGrad<T, int, int64_t>
+          <<<grid_dim, block_dim, 0, stream>>>(index_data,
+                                               input_grad_data,
+                                               output_grad_data,
+                                               index_length,
+                                               input_length,
+                                               batch_size,
+                                               same_data_in_index_row);
+    }
   }
 }
 }  // namespace phi

--- a/paddle/phi/kernels/gpu/index_sample_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_sample_kernel.cu
@@ -29,23 +29,25 @@ namespace {
 #define PREDEFINED_BLOCK_SIZE_X 512
 #define PREDEFINED_BLOCK_SIZE 1024
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
+#define UINT32_MAX std::numeric_limits<uint32_t>::max()
+
 }  // namespace
 
-template <typename T, typename IndexT = int>
-__global__ void IndexSampleForward(const IndexT* index,
+template <typename T, typename SampleIndexT = int, typename ElementIndexT>
+__global__ void IndexSampleForward(const SampleIndexT* index,
                                    const T* in_data,
                                    T* out_data,
                                    size_t index_length,
                                    size_t input_length,
                                    size_t batch_size) {
-  unsigned int index_i = blockDim.x * blockIdx.x + threadIdx.x;
-  unsigned int index_j = blockDim.y * blockIdx.y + threadIdx.y;
+  ElementIndexT index_i = blockDim.x * blockIdx.x + threadIdx.x;
+  ElementIndexT index_j = blockDim.y * blockIdx.y + threadIdx.y;
   for (; index_j < batch_size; index_j += blockDim.y * gridDim.y) {
     index_i = blockDim.x * blockIdx.x + threadIdx.x;
     for (; index_i < index_length; index_i += blockDim.x * gridDim.x) {
-      unsigned int index_idx = index_j * index_length + index_i;
-      unsigned int in_idx = index_j * input_length + index_i;
-      IndexT sample_idx = index[index_idx];
+      ElementIndexT index_idx = index_j * index_length + index_i;
+      ElementIndexT in_idx = index_j * input_length + index_i;
+      SampleIndexT sample_idx = index[index_idx];
       out_data[index_idx] = in_data[in_idx - index_i + sample_idx];
     }
   }
@@ -86,15 +88,51 @@ void IndexSampleKernel(const Context& dev_ctx,
   dim3 grid_dim((index_length + block_dim.x - 1) / block_dim.x,
                 (batch_size + block_dim.y - 1) / block_dim.y);
   phi::backends::gpu::LimitGridDim(dev_ctx, &grid_dim);
+  // choose the element index type ; uint32 or int64 based on the tensor size
+  bool use_uint32 = true;
+  if (x.numel() > UINT32_MAX || out->numel() > UINT32_MAX) {
+    use_uint32 = false;
+  }
 
   if (index_type == DataType::INT64) {
     const int64_t* index_data = index.data<int64_t>();
-    IndexSampleForward<T, int64_t><<<grid_dim, block_dim, 0, stream>>>(
-        index_data, in_data, out_data, index_length, input_length, batch_size);
+    if (use_uint32) {
+      IndexSampleForward<T, int64_t, uint32_t>
+          <<<grid_dim, block_dim, 0, stream>>>(index_data,
+                                               in_data,
+                                               out_data,
+                                               index_length,
+                                               input_length,
+                                               batch_size);
+    } else {
+      IndexSampleForward<T, int64_t, int64_t>
+          <<<grid_dim, block_dim, 0, stream>>>(index_data,
+                                               in_data,
+                                               out_data,
+                                               index_length,
+                                               input_length,
+                                               batch_size);
+    }
+
   } else if (index_type == DataType::INT32) {
     const int* index_data = index.data<int>();
-    IndexSampleForward<T, int><<<grid_dim, block_dim, 0, stream>>>(
-        index_data, in_data, out_data, index_length, input_length, batch_size);
+    if (use_uint32) {
+      IndexSampleForward<T, int, uint32_t>
+          <<<grid_dim, block_dim, 0, stream>>>(index_data,
+                                               in_data,
+                                               out_data,
+                                               index_length,
+                                               input_length,
+                                               batch_size);
+    } else {
+      IndexSampleForward<T, int, int64_t>
+          <<<grid_dim, block_dim, 0, stream>>>(index_data,
+                                               in_data,
+                                               out_data,
+                                               index_length,
+                                               input_length,
+                                               batch_size);
+    }
   }
 }
 }  // namespace phi


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修复了 paddle.index_sample 由于大Tensor引起的精度问题。修复了CPU和GPU的前向和反向的实现。
- GPU的原来版本的kernel中使用了uint32 作为访问数据的索引，当元素数量超过2^32时会访问不到超出的部分。GPU新增了typename ElementIndexT 并和原来的sample的参数类型IndexT保持区分。
- CPU的kernel也会存在此问题，尽管目前没有报错日志，仍然修复了它。CPU的修复中没有采用创建IndexType模版的方法，而是直接将kernel中int替换为int64_t ,因为对64位CPU而言int64和int32运算耗时差距很小，而且index sample为访问密集型算子，直接替换为int64影响应该不大.

PaddleAPITest回测结果：
![image](https://github.com/user-attachments/assets/fd22b32f-4c75-448b-ab89-cc3c8026b770)
有两个非法case（paddle要求x和index的dim[0]必须相同 ），其余全部pass。
pcard-67164 
