### PR TITLE
[Dy2St] Add `FLAGS_specialize_device_in_dy2st` to set PlaceAttribute for DataOp based on input tensor's place before lowering

### DIFF
--- a/paddle/common/flags.cc
+++ b/paddle/common/flags.cc
@@ -1884,6 +1884,19 @@ PHI_DEFINE_EXPORTED_bool(enable_cse_in_dy2st,
                          "Apply CSE optimize pass in Dy2St");
 
 /**
+ * Run Dy2St in specialized device
+ * Name: specialize_device_in_dy2st
+ * Since Version: 3.1.0 Beta
+ * Value Range: bool, default=false
+ * Example:
+ * Note: If True, will specialize device for DataOp's place based on input
+ * tensor's place before lowering.
+ */
+PHI_DEFINE_EXPORTED_bool(specialize_device_in_dy2st,
+                         false,
+                         "Run Dy2St in specialized device");
+
+/**
  * Max count of eliminate redundant computation in CSE, for debug usage
  * Name: cse_max_count
  * Since Version: 3.0.0

--- a/python/paddle/jit/dy2static/pir_partial_program.py
+++ b/python/paddle/jit/dy2static/pir_partial_program.py
@@ -40,6 +40,7 @@ from .utils import (
     auto_layout_is_enabled,
     backend_guard,
     cse_is_enabled,
+    is_specialize_device,
 )
 
 if TYPE_CHECKING:
@@ -1244,10 +1245,9 @@ class PartialProgramLayer:
                 )
             elif isinstance(value, core.eager.Tensor):
                 # NOTE(Aurelius84): If var is on CPUPlace, it will be transformed multi times
-                # into CUDAPlace when it's as input of multi Ops. so we move it in advance
-                # to avoid this problem.
+                # into CUDAPlace when it's as input of multi Ops. so we move it in advance to avoid this problem.
                 if value.stop_gradient and not value.place._equals(
-                    expected_place
+                    expected_place and not is_specialize_device()
                 ):
                     var = value._copy_to(expected_place, False)
                     var.stop_gradient = True

--- a/python/paddle/jit/dy2static/pir_partial_program.py
+++ b/python/paddle/jit/dy2static/pir_partial_program.py
@@ -40,7 +40,7 @@ from .utils import (
     auto_layout_is_enabled,
     backend_guard,
     cse_is_enabled,
-    is_specialize_device,
+    use_specialized_device,
 )
 
 if TYPE_CHECKING:
@@ -1246,8 +1246,10 @@ class PartialProgramLayer:
             elif isinstance(value, core.eager.Tensor):
                 # NOTE(Aurelius84): If var is on CPUPlace, it will be transformed multi times
                 # into CUDAPlace when it's as input of multi Ops. so we move it in advance to avoid this problem.
-                if value.stop_gradient and not value.place._equals(
-                    expected_place and not is_specialize_device()
+                if (
+                    value.stop_gradient
+                    and not value.place._equals(expected_place)
+                    and not use_specialized_device()
                 ):
                     var = value._copy_to(expected_place, False)
                     var.stop_gradient = True

--- a/python/paddle/jit/dy2static/utils.py
+++ b/python/paddle/jit/dy2static/utils.py
@@ -819,7 +819,7 @@ def cse_is_enabled():
     ]
 
 
-def is_specialize_device():
+def use_specialized_device():
     return paddle.get_flags(["FLAGS_specialize_device_in_dy2st"])[
         "FLAGS_specialize_device_in_dy2st"
     ]

--- a/python/paddle/jit/dy2static/utils.py
+++ b/python/paddle/jit/dy2static/utils.py
@@ -819,6 +819,12 @@ def cse_is_enabled():
     ]
 
 
+def is_specialize_device():
+    return paddle.get_flags(["FLAGS_specialize_device_in_dy2st"])[
+        "FLAGS_specialize_device_in_dy2st"
+    ]
+
+
 def prim_is_enabled():
     return core._is_bwd_prim_enabled() or core._is_fwd_prim_enabled()
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
Add `FLAGS_specialize_device_in_dy2st`, default value is `False`. It will set PlaceAttribute for DataOp based on input tensor's place before lowering when `FLAGS_specialize_device_in_dy2st=1` 

**NOTE:**
Performance may decrease when a CPU Tensor is copied to a device multiple times.
Consider applying CSE to solve this problem.

pcard-67164