### PR TITLE
[SOT] Avoid deep copy  while creating `MutableDictLikeData` for `DataClassInstanceVariable`

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
@@ -18,7 +18,7 @@ import dataclasses
 import operator
 import sys
 import types
-from dataclasses import asdict, is_dataclass
+from dataclasses import is_dataclass
 from enum import Enum
 from functools import cached_property, reduce
 from typing import TYPE_CHECKING, Any
@@ -2563,6 +2563,10 @@ class DataClassInstanceVariable(VariableBase):
             for fd in dataclasses.fields(self.get_py_type())
         ]
 
+    @classmethod
+    def _custom_asdict(cls, obj):
+        return {f.name: getattr(obj, f.name) for f in dataclasses.fields(obj)}
+
     @VariableFactory.register_from_value()
     def from_value(value: object, graph: FunctionGraph, tracker: Tracker):
         if is_dataclass(value) and not isinstance(value, type):
@@ -2570,7 +2574,7 @@ class DataClassInstanceVariable(VariableBase):
                 type(value), graph, DanglingTracker()
             )
             var = DataClassInstanceVariable(
-                asdict(value),
+                DataClassInstanceVariable._custom_asdict(value),
                 class_var,
                 id(value),
                 graph=graph,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
Use a custom asdict function to avoid deep copy for data in dataclass instance.

Introduction of dataclasses.asdict funtion
> dataclasses.asdict(obj, *, dict_factory=dict)
Converts the dataclass obj to a dict (by using the factory function dict_factory). Each dataclass is converted to a dict of its fields, as name: value pairs. dataclasses, dicts, lists, and tuples are recursed into. Other objects are copied with [copy.deepcopy()](https://docs.python.org/3.13/library/copy.html#copy.deepcopy).

The default behavior above may lead to out of memory error.

pcard-67164