### PR TITLE
[Auto Parallel] add FLAGS_enable_main_grad

### DIFF
--- a/python/paddle/amp/auto_cast.py
+++ b/python/paddle/amp/auto_cast.py
@@ -695,6 +695,10 @@ def amp_guard(
                     "True",
                     "true",
                     "1",
+                ] and os.getenv("FLAGS_enable_main_grad") not in [
+                    "True",
+                    "true",
+                    "1",
                 ]:
                     if len(amp_global_state().mesh2params):
                         for _, params in amp_global_state().mesh2params.items():
@@ -731,7 +735,15 @@ def amp_guard(
 
                 return param_hook
 
-            if os.getenv("FLAGS_enable_tensor_fusion") in ["True", "true", "1"]:
+            if os.getenv("FLAGS_enable_tensor_fusion") in [
+                "True",
+                "true",
+                "1",
+            ] or os.getenv("FLAGS_enable_main_grad") in [
+                "True",
+                "true",
+                "1",
+            ]:
                 for param in amp_global_state().model_parameters:
                     if not hasattr(param, "main_grad"):
                         param.main_grad = None

--- a/python/paddle/optimizer/optimizer.py
+++ b/python/paddle/optimizer/optimizer.py
@@ -2020,6 +2020,10 @@ class Optimizer:
                     "True",
                     "true",
                     "1",
+                ] or os.getenv("FLAGS_enable_main_grad") in [
+                    "True",
+                    "true",
+                    "1",
                 ]:
                     if (
                         hasattr(param, "main_grad")


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Auto Parallel


### PR Types
New features


### Description
在动半中初始化main_grad，未使用MixPrecisionLayer而使用FLAG控制原因如下：

1. 动手中的trainer.py应该已经弃用master_grad，统一使用main_grad。因此原本控制master_grad的config:amp_master_grad被修改用来控制main_grad初始化；
2. 动半中有部分组件仍然在用master_grad（这些组件同时兼容没有master_grad的情况），因此amp_master_grad仍然需要控制master_grad，且master_grad与main_grad应该为二选一的关系，在除非必须开启main_grad的情况下，应尽可能不影响这些仍然需使用master_grad的组件，因此通过FLAGS控制main_grad能最小化对于其他组件的影响

TODO:后续需梳理动半中使用了master_grad的组件，与动手统一使用amp_master_grad在auto_trainer.py中处理main_grad的初始化
