### PR TITLE
[SOT] Adapt `unified` for `paddle.nn.Layer`

### DIFF
--- a/python/paddle/jit/dy2static/utils.py
+++ b/python/paddle/jit/dy2static/utils.py
@@ -135,7 +135,7 @@ class TransformOptions:
         if inspect.ismethod(fn):
             fn = fn.__func__
 
-        if inspect.isfunction(fn):
+        if inspect.isfunction(fn) or issubclass(fn, paddle.nn.Layer):
             setattr(fn, TransformOptions.TRANSFORM_OPTIONS_ATTR_NAME, self)
         else:
             warnings.warn(

--- a/python/paddle/jit/marker.py
+++ b/python/paddle/jit/marker.py
@@ -96,7 +96,7 @@ def not_to_static(func=None):
 
 
 def unified(
-    fn: Callable[_InputT, _RetT] | None = None,
+    fn: Callable[_InputT, _RetT] | None | type[paddle.nn.Layer] = None,
     *,
     for_sot: bool = True,
     for_ast: bool = True,

--- a/python/paddle/jit/marker.py
+++ b/python/paddle/jit/marker.py
@@ -96,7 +96,7 @@ def not_to_static(func=None):
 
 
 def unified(
-    fn: Callable[_InputT, _RetT] | None | type[paddle.nn.Layer] = None,
+    fn: Callable[_InputT, _RetT] | type[paddle.nn.Layer] | None = None,
     *,
     for_sot: bool = True,
     for_ast: bool = True,

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/callable.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/callable.py
@@ -894,11 +894,7 @@ class UserDefinedLayerVariable(LayerVariable):
 
     @VariableFactory.register_from_value(successor="PaddleApiVariable")
     def from_value(value: Any, graph: FunctionGraph, tracker: Tracker):
-        if isinstance(
-            value, paddle.nn.Layer
-        ) and TransformOptions.check_fn_need_transform(
-            value.__class__, TransformOptions.ToStaticMode.SOT
-        ):
+        if isinstance(value, paddle.nn.Layer):
             return UserDefinedLayerVariable(value, graph, tracker)
         return None
 

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/callable.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/callable.py
@@ -36,6 +36,7 @@ from paddle.base.dygraph.base import (
     _DecoratorContextManager,
     in_sot_simulation_mode,
 )
+from paddle.jit.dy2static.utils import TransformOptions
 
 from .... import psdb
 from ....profiler import EventGuard
@@ -861,7 +862,11 @@ class PaddleLayerVariable(LayerVariable):
                 or is_not_supported_paddle_layer(type(value))
             ):
                 return None
-            if value.__module__.startswith("paddle.nn."):
+            if value.__module__.startswith("paddle.nn.") or (
+                not TransformOptions.check_fn_need_transform(
+                    value.__class__, TransformOptions.ToStaticMode.SOT
+                )
+            ):
                 return PaddleLayerVariable(value, graph, tracker)
         return None
 
@@ -889,7 +894,11 @@ class UserDefinedLayerVariable(LayerVariable):
 
     @VariableFactory.register_from_value(successor="PaddleApiVariable")
     def from_value(value: Any, graph: FunctionGraph, tracker: Tracker):
-        if isinstance(value, paddle.nn.Layer):
+        if isinstance(
+            value, paddle.nn.Layer
+        ) and TransformOptions.check_fn_need_transform(
+            value.__class__, TransformOptions.ToStaticMode.SOT
+        ):
             return UserDefinedLayerVariable(value, graph, tracker)
         return None
 

--- a/test/dygraph_to_static/test_convert_call.py
+++ b/test/dygraph_to_static/test_convert_call.py
@@ -450,6 +450,75 @@ class TestMarkerUnified(Dy2StTestBase):
             )
         )
 
+    def test_nn_layer_subclass_skip_sot_only(self):
+        @paddle.jit.marker.unified(for_sot=True, for_ast=False)
+        class MyLayer(paddle.nn.Layer):
+
+            def __init__(self):
+                super().__init__()
+                self.w = paddle.create_parameter(shape=[1], dtype='float32')
+
+            def forward(self, x):
+                return x * self.w
+
+        self.assertFalse(
+            TransformOptions.check_fn_need_transform(
+                MyLayer(), TransformOptions.ToStaticMode.SOT
+            )
+        )
+
+        self.assertTrue(
+            TransformOptions.check_fn_need_transform(
+                MyLayer(), TransformOptions.ToStaticMode.AST
+            )
+        )
+
+    def test_nn_layer_subclass_skip_ast_only(self):
+        @paddle.jit.marker.unified(for_sot=False, for_ast=True)
+        class MyLayer(paddle.nn.Layer):
+
+            def __init__(self):
+                super().__init__()
+                self.w = paddle.create_parameter(shape=[1], dtype='float32')
+
+            def forward(self, x):
+                return x * self.w
+
+        self.assertTrue(
+            TransformOptions.check_fn_need_transform(
+                MyLayer(), TransformOptions.ToStaticMode.SOT
+            )
+        )
+
+        self.assertFalse(
+            TransformOptions.check_fn_need_transform(
+                MyLayer(), TransformOptions.ToStaticMode.AST
+            )
+        )
+
+    def test_nn_layer_subclass_skip_ast_and_sot(self):
+        @paddle.jit.marker.unified()
+        class MyLayer(paddle.nn.Layer):
+
+            def __init__(self):
+                super().__init__()
+                self.w = paddle.create_parameter(shape=[1], dtype='float32')
+
+            def forward(self, x):
+                return x * self.w
+
+        self.assertFalse(
+            TransformOptions.check_fn_need_transform(
+                MyLayer(), TransformOptions.ToStaticMode.SOT
+            )
+        )
+
+        self.assertFalse(
+            TransformOptions.check_fn_need_transform(
+                MyLayer(), TransformOptions.ToStaticMode.AST
+            )
+        )
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->

目前自定义 `Layer` ，在SOT中被映射为 `UserDefinedLayerVariable`，这样模型的参数会被视为 **外部输入**，相比于 `PaddleLayerVariable` ，存在额外的载入参数开销

于是类似 https://github.com/PaddlePaddle/Paddle/pull/72466 给 `nn.Layer` 的子类加上装饰器 `unified`

这样参数就不会被视为**外部输入**

以下是 参考代码：

```python
from __future__ import annotations

from typing import TYPE_CHECKING

import paddle
from paddle.nn import Linear
import paddle.nn.functional as F
from paddle.jit.marker import unified
from paddle.jit import to_static
if TYPE_CHECKING:

    from paddle import Tensor
    from paddle._typing import (
        ParamAttrLike,
    )

@unified
class MyLinear(paddle.nn.Layer):

    weight: Tensor
    bias: Tensor
    name: str | None

    def __init__(
        self,
        in_features: int,
        out_features: int,
        weight_attr: ParamAttrLike | None = None,
        bias_attr: ParamAttrLike | None = None,
        name: str | None = None,
    ) -> None:
        super().__init__()
        self._dtype = self._helper.get_default_dtype()
        self._weight_attr = weight_attr
        self._bias_attr = bias_attr
        self.weight = self.create_parameter(
            shape=[in_features, out_features],
            attr=self._weight_attr,
            dtype=self._dtype,
            is_bias=False,
        )
        self.bias = self.create_parameter(
            shape=[out_features],
            attr=self._bias_attr,
            dtype=self._dtype,
            is_bias=True,
        )
        self.name = name

    def forward(self, input: Tensor) -> Tensor:
        out = F.linear(
            x=input, weight=self.weight, bias=self.bias, name=self.name
        )
        return out

def call_linear(x, linear):
    return linear(x)

if __name__ == "__main__":
    linear = MyLinear(32, 10)
    static_fn = to_static(call_linear)
    x = paddle.randn([4, 32])
    y = static_fn(x, linear)

    print(type(linear.weight), linear.weight.shape)
    print(type(linear.bias), linear.weight.shape)

    print(y.shape)
```

这是之前的，将参数视为外部输入的 IR
```shell
StatementIR: SIR_0
  inputs: ['var_0', 'var_2', 'var_3']
  outputs: ['var_4']
  statements: 
    api        || var_4 = paddle.nn.functional.common.linear (var_3, None, var_2, var_0)  
```

这是之后的，将外部输入不再包含参数做输入：
```shell
StatementIR: SIR_0
  inputs: ['var_0']
  outputs: ['var_1']
  statements: 
    layer      || var_1 = MyLinear (var_0)  
```
cc @SigureMo
PCard-66972