### PR TITLE
[PHI]Fix paddle.stack to support big Tensor

### DIFF
--- a/paddle/phi/infermeta/backward.cc
+++ b/paddle/phi/infermeta/backward.cc
@@ -1750,7 +1750,7 @@ void StackGradInferMeta(const MetaTensor& out_grad,
           x_grad.size(),
           static_cast<size_t>(dy_dim[axis])));
 
-  auto vec = common::vectorize<int>(dy_dim);
+  auto vec = common::vectorize<int64_t>(dy_dim);
   vec.erase(vec.begin() + axis);
 
   for (auto& grad : x_grad) {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure
### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
**PaddleAPITest报错日志**
![image](https://github.com/user-attachments/assets/8415aa76-66c8-48bb-bac4-6ca767e39dd2)
PaddleAPITest报错日志中 cuda error 9 已经被修复了，但是目前还存在paddle.stack 的反向输出为none的问题。
而CPU直接报如下错误：
![50939c749553a07b7be0c50cef22fc44](https://github.com/user-attachments/assets/56a506ff-e624-45e6-a6e6-df543aabd713)
经过排查发现是infermeta的时候使用int作为了dim的数据类型因此会报错。
paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/* 中未找到对应的符号推导，因此只修复infermeta。
**修复后的PaddleAPITest复测结果：**
![image](https://github.com/user-attachments/assets/d3dade03-b039-4be6-a14e-8258243ea425)
全部pass



pcard-67164
