### PR TITLE
[XPU]add complex64 for visit_type

### DIFF
--- a/paddle/phi/core/visit_type.h
+++ b/paddle/phi/core/visit_type.h
@@ -336,6 +336,15 @@ namespace phi {
                  "`");                                                        \
     }                                                                         \
   }()
+
+#ifdef PADDLE_WITH_XPU_FFT
+#define PD_XPU_COMPLEX64_CASE(NAME, ...) \
+  PD_PRIVATE_CASE_TYPE(                  \
+      NAME, ::phi::DataType::COMPLEX64, phi::complex64, __VA_ARGS__)
+#else
+#define PD_XPU_COMPLEX64_CASE(NAME, ...)
+#endif
+
 #if defined(PADDLE_WITH_XPU)
 #define PD_VISIT_ALL_TYPES(TYPE, NAME, ...)                                    \
   [&] {                                                                        \
@@ -354,6 +363,7 @@ namespace phi {
       PD_PRIVATE_CASE_TYPE(NAME, ::phi::DataType::FLOAT32, float, __VA_ARGS__) \
       PD_PRIVATE_CASE_TYPE(                                                    \
           NAME, ::phi::DataType::FLOAT64, double, __VA_ARGS__)                 \
+      PD_XPU_COMPLEX64_CASE(NAME, __VA_ARGS__)                                 \
       default:                                                                 \
         PADDLE_THROW(common::errors::InvalidArgument(                          \
             "Invalid enum data type `%d`.", static_cast<int>(__dtype__)));     \


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Custom Device

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
为XPU下的PD_VISIT_ALL_TYPES添加complex64类型，避免出现(InvalidArgument)Invalid enum data type`12`这类报错
Pcard-75624