### PR TITLE
在smooth_l1_loss函数中加入is_huber参数

### DIFF
--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -1105,6 +1105,7 @@ def smooth_l1_loss(
     label: Tensor,
     reduction: _ReduceMode = 'mean',
     delta: float = 1.0,
+    is_huber: bool = True,
     name: str | None = None,
 ) -> Tensor:
     r"""
@@ -1143,6 +1144,7 @@ def smooth_l1_loss(
             The value determines how large the errors need to be to use L1. Errors
             smaller than delta are minimized with L2. Parameter is ignored for
             negative/zero values. Default = 1.0
+        is_huber (bool, optional): If True, use the Huber loss, otherwise use a modified version where the Huber loss is divided by delta. Default is True.
         name (str|None, optional): For details, please refer to :ref:`api_guide_Name`. Generally, no setting is required. Default: None.
 
     Returns:
@@ -1191,6 +1193,9 @@ def smooth_l1_loss(
             outputs={'Out': out, 'Residual': residual},
             attrs={'delta': delta},
         )
+
+    if not is_huber:
+        out = out / delta
 
     if reduction not in ['sum', 'mean', 'none']:
         raise ValueError(

--- a/python/paddle/nn/layer/loss.py
+++ b/python/paddle/nn/layer/loss.py
@@ -1481,6 +1481,7 @@ class SmoothL1Loss(Layer):
             The value determines how large the errors need to be to use L1. Errors
             smaller than delta are minimized with L2. Parameter is ignored for
             negative/zero values. Default value is :math:`1.0`.
+        is_huber (bool, optional): If True, use the Huber loss, otherwise use a modified version where the Huber loss is divided by delta. Default is True.
         name (str|None, optional): For details, please refer to :ref:`api_guide_Name`. Generally, no setting is required. Default: None.
 
     Call Parameters:
@@ -1517,11 +1518,13 @@ class SmoothL1Loss(Layer):
         self,
         reduction: _ReduceMode = 'mean',
         delta: float = 1.0,
+        is_huber: bool = True,
         name: str | None = None,
     ) -> None:
         super().__init__()
         self.reduction = reduction
         self.delta = delta
+        self.is_huber = is_huber
         self.name = name
 
     def forward(self, input: Tensor, label: Tensor) -> Tensor:
@@ -1530,6 +1533,7 @@ class SmoothL1Loss(Layer):
             label,
             reduction=self.reduction,
             delta=self.delta,
+            is_huber=self.is_huber,
             name=self.name,
         )
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Improvements

### Description
<!-- Describe what you’ve done -->

**当前问题**：paddle.nn.SmoothL1Loss和torch.nn.SmoothL1Loss功能不一致。paddle.nn.SmoothL1Loss当前的实现与torch.nn.HuberLoss是一致的。

**修改方案**：
由于目前paddle的SmoothL1Loss与torch的HuberLoss是一致的，因此无法再增加一个HuberLoss来对应SmoothL1Loss，只能在现有基础上改造，增加is_huber参数：
1. is_huber=True时，与torch.nn.HuberLoss对应。
2. is_huber=False时，与torch.nn.SmoothL1Loss对应。

默认is_huber=True，保持兼容性升级。