### PR TITLE
将signal.stft的onsided的默认参数值从True改为None

### DIFF
--- a/python/paddle/signal.py
+++ b/python/paddle/signal.py
@@ -420,7 +420,7 @@ def stft(
     norm = 'ortho' if normalized else 'backward'
 
     if onesided is None:
-        onesided = not is_complex(x)
+        onesided = not is_complex(x_frames)
 
     if is_complex(x_frames):
         assert (

--- a/python/paddle/signal.py
+++ b/python/paddle/signal.py
@@ -278,7 +278,7 @@ def stft(
     center: bool = True,
     pad_mode: Literal["reflect", "constant"] = "reflect",
     normalized: bool = False,
-    onesided: bool = True,
+    onesided: bool | None = None,
     name: str | None = None,
 ) -> Tensor:
     r"""
@@ -317,7 +317,7 @@ def stft(
             Default: `False`
         onesided (bool, optional): Control whether to return half of the Fourier transform
             output that satisfies the conjugate symmetry condition when input is a real-valued
-            tensor. It can not be `True` if input is a complex tensor. Default: `True`
+            tensor. It can not be `True` if input is a complex tensor. Default: `None`
         name (str|None, optional): The default value is None. Normally there is no need for user
             to set this property. For more information, please refer to :ref:`api_guide_Name`.
 
@@ -418,6 +418,10 @@ def stft(
     x_frames = paddle.multiply(x_frames, window)
 
     norm = 'ortho' if normalized else 'backward'
+
+    if onesided is None:
+        onesided = not is_complex(x)
+
     if is_complex(x_frames):
         assert (
             not onesided


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Improvements

### Description
<!-- Describe what you’ve done -->

默认值改为None，会自动根据输入判断是否返回一半的频点值。当输入为复数时，不需要每次手动输入onsided=False。

相关pytorch代码：
```cpp
  const bool complex_fft = input.is_complex();
  const auto onesided = onesidedOpt.value_or(!complex_fft);
```