### PR TITLE
Fix paddle.unfold for big tensor

### DIFF
--- a/paddle/phi/backends/device_base.h
+++ b/paddle/phi/backends/device_base.h
@@ -34,6 +34,13 @@ struct DeviceProp {
 
   DeviceProp() = default;
 
+#ifdef major
+#undef major
+#endif
+#ifdef minor
+#undef minor
+#endif
+
   DeviceProp(const std::string& name_,
              int major_,
              int minor_,

--- a/paddle/phi/kernels/funcs/strided_copy_kernel.cu.h
+++ b/paddle/phi/kernels/funcs/strided_copy_kernel.cu.h
@@ -34,7 +34,7 @@ __global__ void Contiguous2StridedCaseOneFunc(
     phi::Array<int64_t, phi::DDim::kMaxRank + 1> output_stride,
     phi::Array<int64_t, 6> dims,
     const int64_t x_max) {
-  int64_t x = blockIdx.x * blockDim.x + threadIdx.x;
+  int64_t x = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   if (x < x_max) {
     int64_t input_offset = (blockIdx.z * gridDim.y + blockIdx.y) * x_max + x;
     int64_t output_offset = 0;
@@ -714,7 +714,7 @@ void StrideCopyDiffDimKernel(
     const phi::Array<int64_t, phi::DDim::kMaxRank + 1>& output_stride,
     const phi::Array<int64_t, phi::DDim::kMaxRank + 1>& output_dims,
     int rank,
-    int numel) {
+    int64_t numel) {
   if (LaunchContiguous2StridedCaseZeroKernel<T, Context>(dev_ctx,
                                                          input_data,
                                                          output_data,

--- a/paddle/phi/kernels/gpu/gather_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/gather_grad_kernel.cu
@@ -34,7 +34,6 @@ void GatherGradKernel(const Context& dev_ctx,
   if (axis_v < 0) {
     axis_v += static_cast<int>(x.dims().size());
   }
-
   if (axis_v != 0) {
     if (index_type == DataType::INT32) {
       phi::funcs::GatherV2GradCUDAFunction<T, int32_t>(
@@ -45,7 +44,6 @@ void GatherGradKernel(const Context& dev_ctx,
     }
     return;
   }
-
   dev_ctx.template Alloc<T>(x_grad);
   auto dxt = EigenVector<T>::Flatten(*x_grad);
   auto& place = *dev_ctx.eigen_device();

--- a/paddle/phi/kernels/gpu/gather_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/gather_grad_kernel.cu
@@ -34,6 +34,7 @@ void GatherGradKernel(const Context& dev_ctx,
   if (axis_v < 0) {
     axis_v += static_cast<int>(x.dims().size());
   }
+
   if (axis_v != 0) {
     if (index_type == DataType::INT32) {
       phi::funcs::GatherV2GradCUDAFunction<T, int32_t>(
@@ -44,6 +45,7 @@ void GatherGradKernel(const Context& dev_ctx,
     }
     return;
   }
+
   dev_ctx.template Alloc<T>(x_grad);
   auto dxt = EigenVector<T>::Flatten(*x_grad);
   auto& place = *dev_ctx.eigen_device();

--- a/paddle/phi/kernels/gpu/strided_copy_kernel.cu
+++ b/paddle/phi/kernels/gpu/strided_copy_kernel.cu
@@ -719,7 +719,7 @@ void StridedCopyKernel(const Context& dev_ctx,
   meta.offset = offset;
   out->set_meta(meta);
   int rank = out->dims().size();
-  auto numel = out->numel();
+  int64_t numel = out->numel();
   T* output_data = out->data<T>();
   PADDLE_ENFORCE_NOT_NULL(output_data,
                           common::errors::InvalidArgument(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes


### Description
<!-- Describe what you’ve done -->
- unfold的错误是最后发生在最后4个元素，再结合[5, 8589934560]的特殊性，这基本确定了是int溢出的问题
- device_base.h文件中的修改是为了避免与系统宏定义的冲突
