### PR TITLE
[Accuracy diff No.127] Fix accuracy diff for paddle.nn.functional.sigmoid_focal_loss API

### DIFF
--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -3358,81 +3358,28 @@ def sigmoid_focal_loss(
                 f"Expected zero or one dimension of normalizer in sigmoid_focal_loss but got {normalizer_dims}."
             )
 
-    if in_dynamic_or_pir_mode():
-        place = _current_expected_place()
-        one = _C_ops.full(paddle.shape(logit), 1.0, logit.dtype, place)
+    pred = paddle.nn.functional.sigmoid(logit)
 
-        loss = _C_ops.sigmoid_cross_entropy_with_logits(
-            logit, label, None, False, -100
-        )
+    positive_loss = (
+        -label * alpha * (paddle.pow(1.0 - pred, gamma)) * paddle.log(pred)
+    )
+    negative_loss = (
+        -(1.0 - label)
+        * (1.0 - alpha)
+        * paddle.pow(pred, gamma)
+        * paddle.log(1 - pred)
+    )
+    loss = positive_loss + negative_loss
 
-        pred = _C_ops.sigmoid(logit)
+    if normalizer is not None:
+        loss = paddle.divide(loss, normalizer)
 
-        p_t = _C_ops.add(
-            _C_ops.multiply(pred, label),
-            _C_ops.multiply(
-                _C_ops.subtract(one, pred), _C_ops.subtract(one, label)
-            ),
-        )
+    if reduction == "sum":
+        return paddle.sum(loss)
+    elif reduction == "mean":
+        return paddle.mean(loss)
 
-        alpha = paddle.to_tensor(alpha, dtype=loss.dtype)
-        alpha_t = _C_ops.add(
-            _C_ops.multiply(alpha, label),
-            _C_ops.multiply(
-                _C_ops.subtract(one, alpha), _C_ops.subtract(one, label)
-            ),
-        )
-        loss = _C_ops.multiply(alpha_t, loss)
-
-        if in_dynamic_mode():
-            gamma = paddle.to_tensor(gamma, dtype=loss.dtype)
-        gamma_t = _C_ops.pow(_C_ops.subtract(one, p_t), gamma)
-        loss = _C_ops.multiply(gamma_t, loss)
-
-        if normalizer is not None:
-            loss = _C_ops.divide(loss, normalizer)
-
-        if reduction == "sum":
-            return _C_ops.sum(loss, [], None, False)
-        elif reduction == "mean":
-            return _C_ops.mean_all(loss)
-
-        return loss
-
-    else:
-        check_variable_and_dtype(
-            logit, 'logit', ['float32', 'float64'], 'sigmoid_focal_loss'
-        )
-        check_variable_and_dtype(
-            label, 'label', ['float32', 'float64'], 'sigmoid_focal_loss'
-        )
-
-        bce_name = None
-        if reduction == 'none' and normalizer is None:
-            bce_name = name
-        loss = paddle.nn.functional.binary_cross_entropy_with_logits(
-            logit, label, None, reduction='none', name=bce_name
-        )
-
-        pred = paddle.nn.functional.sigmoid(logit)
-        p_t = pred * label + (1 - pred) * (1 - label)
-
-        alpha_t = alpha * label + (1 - alpha) * (1 - label)
-        loss = paddle.multiply(alpha_t, loss)
-
-        gamma_t = paddle.pow((1 - p_t), gamma)
-        loss = paddle.multiply(gamma_t, loss)
-
-        if normalizer is not None:
-            normalizer_name = name if reduction == 'none' else None
-            loss = paddle.divide(loss, normalizer, name=normalizer_name)
-
-        if reduction == 'mean':
-            loss = paddle.mean(loss, name=name)
-        elif reduction == 'sum':
-            loss = paddle.sum(loss, name=name)
-
-        return loss
+    return loss
 
 
 def multi_label_soft_margin_loss(

--- a/test/legacy_test/test_sigmoid_focal_loss.py
+++ b/test/legacy_test/test_sigmoid_focal_loss.py
@@ -92,21 +92,13 @@ def test_dygraph(
 def calc_sigmoid_focal_loss(
     logit_np, label_np, normalizer_np, alpha=0.25, gamma=2.0, reduction='sum'
 ):
-    loss = (
-        np.maximum(logit_np, 0)
-        - logit_np * label_np
-        + np.log(1 + np.exp(-np.abs(logit_np)))
-    )
-
     pred = 1 / (1 + np.exp(-logit_np))
-    p_t = pred * label_np + (1 - pred) * (1 - label_np)
 
-    if alpha is not None:
-        alpha_t = alpha * label_np + (1 - alpha) * (1 - label_np)
-        loss = alpha_t * loss
-
-    if gamma is not None:
-        loss = loss * ((1 - p_t) ** gamma)
+    positive_loss = -label_np * alpha * ((1.0 - pred) ** gamma) * np.log(pred)
+    negative_loss = (
+        -(1.0 - label_np) * (1.0 - alpha) * (pred**gamma) * np.log(1 - pred)
+    )
+    loss = positive_loss + negative_loss
 
     if normalizer_np is not None:
         loss = loss / normalizer_np
@@ -198,6 +190,73 @@ class TestSigmoidFocalLoss(unittest.TestCase):
             reduction="unsupported reduction",
         )
         paddle.enable_static()
+
+
+class TestSigmoidFocalLossFloatLabel(unittest.TestCase):
+
+    def test_SigmoidFocalLoss(self):
+        logit_np = np.random.uniform(0.1, 0.8, size=(2, 3, 4, 10)).astype(
+            np.float64
+        )
+        label_np = np.random.uniform(0, 1, size=(2, 3, 4, 10)).astype(
+            np.float64
+        )
+        normalizer_nps = [
+            np.asarray([np.sum(label_np > 0)], dtype=label_np.dtype),
+            None,
+        ]
+        places = []
+        if (
+            os.environ.get('FLAGS_CI_both_cpu_and_gpu', 'False').lower()
+            in ['1', 'true', 'on']
+            or not base.core.is_compiled_with_cuda()
+        ):
+            places.append(base.CPUPlace())
+        if base.core.is_compiled_with_cuda():
+            places.append(base.CUDAPlace(0))
+        reductions = ['sum', 'mean', 'none']
+        alphas = [0.25, 0.5]
+        gammas = [3, 0.0]
+        for place in places:
+            for reduction in reductions:
+                for alpha in alphas:
+                    for gamma in gammas:
+                        for normalizer_np in normalizer_nps:
+                            (static_result,) = test_static(
+                                place,
+                                logit_np,
+                                label_np,
+                                normalizer_np,
+                                alpha,
+                                gamma,
+                                reduction,
+                            )
+                            dy_result = test_dygraph(
+                                place,
+                                logit_np,
+                                label_np,
+                                normalizer_np,
+                                alpha,
+                                gamma,
+                                reduction,
+                            )
+                            expected = calc_sigmoid_focal_loss(
+                                logit_np,
+                                label_np,
+                                normalizer_np,
+                                alpha,
+                                gamma,
+                                reduction,
+                            )
+                            np.testing.assert_allclose(
+                                static_result, expected, rtol=1e-05
+                            )
+                            np.testing.assert_allclose(
+                                static_result, dy_result, rtol=1e-05
+                            )
+                            np.testing.assert_allclose(
+                                dy_result, expected, rtol=1e-05
+                            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
经检查原来的focal loss实现默认了 label 取值为 0.0 或 1.0，而 api 文档中描述 label 的取值范围是 0 到 1，所以按照 PaddelAPITest 中的 torch 转化代码修改 focal loss 的实现，以支持取值在 0~1 之间的 label 输入。

同时需要将 PaddelAPITest 的 SigmoidFocalLossRule 中 reduction 参数默认值改为 sum。

回测结果：
![image](https://github.com/user-attachments/assets/ab8ef9b5-fd51-4be2-b316-393785894a42)
