### PR TITLE
[0-size Tensor No.355] Add 0-size Tensor support for unique_consecutive

### DIFF
--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.cc
@@ -4351,14 +4351,39 @@ bool UniqueConsecutiveOpInferSymbolicShape(
     return inverse_dims;
   }();
 
-  infer_context->SetShapeOrDataForValue(
-      op->result(0), symbol::TensorShapeOrDataDimExprs{out_dims});
-  infer_context->SetShapeOrDataForValue(
-      op->result(1),
-      return_inverse ? symbol::TensorShapeOrDataDimExprs{inverse_dims} : empty);
-  infer_context->SetShapeOrDataForValue(
-      op->result(2),
-      return_counts ? symbol::TensorShapeOrDataDimExprs{counts_dims} : empty);
+  const auto &IsZero = [&](const symbol::DimExpr &dim_expr) {
+    if (dim_expr.isa<int64_t>()) {
+      return dim_expr.dyn_cast<int64_t>() == static_cast<int64_t>(0);
+    }
+    return false;
+  };
+  bool size_0 = false;
+  for (size_t i = 0; i < x_dims_sym.size(); i++) {
+    if (IsZero(x_dims_sym.at(i))) {
+      size_0 = true;
+      break;
+    }
+  }
+
+  if (size_0) {
+    infer_context->SetShapeOrDataForValue(
+        op->result(0), symbol::TensorShapeOrDataDimExprs{x_dims_sym});
+    infer_context->SetShapeOrDataForValue(
+        op->result(1),
+        return_inverse ? symbol::TensorShapeOrDataDimExprs{} : empty);
+    infer_context->SetShapeOrDataForValue(
+        op->result(2),
+        return_counts ? symbol::TensorShapeOrDataDimExprs{} : empty);
+  } else {
+    infer_context->SetShapeOrDataForValue(
+        op->result(0), symbol::TensorShapeOrDataDimExprs{out_dims});
+    infer_context->SetShapeOrDataForValue(
+        op->result(1),
+        return_inverse ? symbol::TensorShapeOrDataDimExprs{inverse_dims} : empty);
+    infer_context->SetShapeOrDataForValue(
+        op->result(2),
+        return_counts ? symbol::TensorShapeOrDataDimExprs{counts_dims} : empty);
+  }
 
   return true;
 }

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.cc
@@ -4379,7 +4379,8 @@ bool UniqueConsecutiveOpInferSymbolicShape(
         op->result(0), symbol::TensorShapeOrDataDimExprs{out_dims});
     infer_context->SetShapeOrDataForValue(
         op->result(1),
-        return_inverse ? symbol::TensorShapeOrDataDimExprs{inverse_dims} : empty);
+        return_inverse ? symbol::TensorShapeOrDataDimExprs{inverse_dims}
+                       : empty);
     infer_context->SetShapeOrDataForValue(
         op->result(2),
         return_counts ? symbol::TensorShapeOrDataDimExprs{counts_dims} : empty);

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.cc
@@ -4366,11 +4366,20 @@ bool UniqueConsecutiveOpInferSymbolicShape(
   }
 
   if (size_0) {
-    infer_context->SetShapeOrDataForValue(
-        op->result(0), symbol::TensorShapeOrDataDimExprs{x_dims_sym});
-    infer_context->SetShapeOrDataForValue(
-        op->result(1),
-        return_inverse ? symbol::TensorShapeOrDataDimExprs{} : empty);
+    if (axes.empty()) {
+      infer_context->SetShapeOrDataForValue(
+          op->result(0), symbol::TensorShapeOrDataDimExprs{});
+      infer_context->SetShapeOrDataForValue(
+          op->result(1),
+          return_inverse ? symbol::TensorShapeOrDataDimExprs{inverse_dims}
+                         : empty);
+    } else {
+      infer_context->SetShapeOrDataForValue(
+          op->result(0), symbol::TensorShapeOrDataDimExprs{x_dims_sym});
+      infer_context->SetShapeOrDataForValue(
+          op->result(1),
+          return_inverse ? symbol::TensorShapeOrDataDimExprs{} : empty);
+    }
     infer_context->SetShapeOrDataForValue(
         op->result(2),
         return_counts ? symbol::TensorShapeOrDataDimExprs{} : empty);

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.cc
@@ -4371,7 +4371,7 @@ bool UniqueConsecutiveOpInferSymbolicShape(
           op->result(0), symbol::TensorShapeOrDataDimExprs{});
       infer_context->SetShapeOrDataForValue(
           op->result(1),
-          return_inverse ? symbol::TensorShapeOrDataDimExprs{inverse_dims}
+          return_inverse ? symbol::TensorShapeOrDataDimExprs{x_dims_sym}
                          : empty);
     } else {
       infer_context->SetShapeOrDataForValue(

--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -5918,6 +5918,15 @@ void UniqueConsecutiveInferMeta(const MetaTensor& x,
   if (return_counts) {
     counts->set_dims({-1});
   }
+  if (x.numel() == 0) {
+    out->set_dims(in_dims);
+    if (return_inverse) {
+      index->set_dims({0});
+    }
+    if (return_counts) {
+      counts->set_dims({0});
+    }
+  }
 }
 
 void UniqueInferMeta(const MetaTensor& x,

--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -5919,9 +5919,16 @@ void UniqueConsecutiveInferMeta(const MetaTensor& x,
     counts->set_dims({-1});
   }
   if (x.numel() == 0) {
-    out->set_dims(in_dims);
-    if (return_inverse) {
-      index->set_dims({0});
+    if (axis.empty()) {
+      out->set_dims({0});
+      if (return_inverse) {
+        index->set_dims(in_dims);
+      }
+    } else {
+      out->set_dims(in_dims);
+      if (return_inverse) {
+        index->set_dims({0});
+      }
     }
     if (return_counts) {
       counts->set_dims({0});

--- a/paddle/phi/kernels/cpu/unique_consecutive_kernel.cc
+++ b/paddle/phi/kernels/cpu/unique_consecutive_kernel.cc
@@ -34,6 +34,16 @@ void UniqueConsecutiveKernel(const Context& dev_ctx,
                              DenseTensor* out,
                              DenseTensor* index,
                              DenseTensor* counts) {
+  if (out && out->numel() == 0) {
+    dev_ctx.template Alloc<T>(out);
+    if (return_inverse) {
+      dev_ctx.Alloc(index, dtype);
+    }
+    if (return_counts) {
+      dev_ctx.Alloc(counts, dtype);
+    }
+    return;
+  }
   if (dtype == phi::DataType::INT32) {
     PADDLE_ENFORCE_LE(
         x.numel(),

--- a/paddle/phi/kernels/cpu/unique_consecutive_kernel.cc
+++ b/paddle/phi/kernels/cpu/unique_consecutive_kernel.cc
@@ -42,6 +42,7 @@ void UniqueConsecutiveKernel(const Context& dev_ctx,
     if (return_counts) {
       dev_ctx.Alloc(counts, dtype);
     }
+
     return;
   }
   if (dtype == phi::DataType::INT32) {

--- a/paddle/phi/kernels/gpu/unique_consecutive_kernel.cu
+++ b/paddle/phi/kernels/gpu/unique_consecutive_kernel.cu
@@ -33,6 +33,16 @@ void UniqueConsecutiveKernel(const Context& dev_ctx,
                              DenseTensor* out,
                              DenseTensor* index,
                              DenseTensor* counts) {
+  if (out && out->numel() == 0) {
+    dev_ctx.template Alloc<T>(out);
+    if (return_inverse) {
+      dev_ctx.Alloc(index, dtype);
+    }
+    if (return_counts) {
+      dev_ctx.Alloc(counts, dtype);
+    }
+    return;
+  }
   if (dtype == phi::DataType::INT32) {
     PADDLE_ENFORCE_LE(
         x.numel() + 1,

--- a/paddle/phi/kernels/gpu/unique_consecutive_kernel.cu
+++ b/paddle/phi/kernels/gpu/unique_consecutive_kernel.cu
@@ -41,6 +41,7 @@ void UniqueConsecutiveKernel(const Context& dev_ctx,
     if (return_counts) {
       dev_ctx.Alloc(counts, dtype);
     }
+
     return;
   }
   if (dtype == phi::DataType::INT32) {

--- a/test/legacy_test/test_unique_consecutive_op.py
+++ b/test/legacy_test/test_unique_consecutive_op.py
@@ -371,6 +371,37 @@ class TestUniqueConsecutiveEmptyInput(OpTest):
     def test_check_output(self):
         self.check_output(check_pir=True, check_symbol_infer=False)
 
+class TestUniqueConsecutiveZeroSize(TestUniqueConsecutiveOp):
+    """ZeroSize input"""
+
+    def config(self):
+        self.x_size = (0, 2, 4)
+        self.x_range = 20
+        self.return_inverse = True
+        self.return_counts = True
+        self.python_api = paddle.unique_consecutive
+
+    def setUp(self):
+        self.init_kernel_type()
+        self.config()
+        self.op_type = "unique_consecutive"
+        x = np.random.randint(self.x_range, size=self.x_size).astype(self.dtype)
+        result, inverse, counts = reference_unique_consecutive(
+            x, self.return_inverse, self.return_counts
+        )
+        result = np.array(result).astype(self.dtype).reshape(x.shape)
+        inverse = inverse.astype(self.dtype)
+        counts = counts.astype(self.dtype)
+        self.inputs = {
+            'X': x,
+        }
+        self.attrs = {
+            'return_inverse': self.return_inverse,
+            'return_counts': self.return_counts,
+            'dtype': paddle.int32,
+        }
+        self.python_out_sig = ["Out", "Index", "Counts"]
+        self.outputs = {'Out': result, 'Index': inverse, 'Counts': counts}
 
 if __name__ == "__main__":
     paddle.enable_static()

--- a/test/legacy_test/test_unique_consecutive_op.py
+++ b/test/legacy_test/test_unique_consecutive_op.py
@@ -371,6 +371,7 @@ class TestUniqueConsecutiveEmptyInput(OpTest):
     def test_check_output(self):
         self.check_output(check_pir=True, check_symbol_infer=False)
 
+
 class TestUniqueConsecutiveZeroSize(TestUniqueConsecutiveOp):
     """ZeroSize input"""
 
@@ -402,6 +403,7 @@ class TestUniqueConsecutiveZeroSize(TestUniqueConsecutiveOp):
         }
         self.python_out_sig = ["Out", "Index", "Counts"]
         self.outputs = {'Out': result, 'Index': inverse, 'Counts': counts}
+
 
 if __name__ == "__main__":
     paddle.enable_static()

--- a/test/legacy_test/test_unique_consecutive_op.py
+++ b/test/legacy_test/test_unique_consecutive_op.py
@@ -390,8 +390,8 @@ class TestUniqueConsecutiveZeroSize(TestUniqueConsecutiveOp):
         result, inverse, counts = reference_unique_consecutive(
             x, self.return_inverse, self.return_counts
         )
-        result = np.array(result).astype(self.dtype).reshape(x.shape)
-        inverse = inverse.astype(self.dtype)
+        result = np.array(result).astype(self.dtype)
+        inverse = inverse.astype(self.dtype).reshape(x.shape)
         counts = counts.astype(self.dtype)
         self.inputs = {
             'X': x,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
infermeta修改设置维度
修改cpu/gpu kernel
当0-size Tensor时， out tensor的shape与输入保持一致（与torch保持一致）

PaddleAPITest测试通过
![image](https://github.com/user-attachments/assets/beed459a-2d20-47a4-917b-a6ebb48e8b77)
