### PR TITLE
[0-size Tensor Job2 No.9] Add 0-size Tensor support for paddle.dot

### DIFF
--- a/paddle/phi/kernels/cpu/dot_kernel.cc
+++ b/paddle/phi/kernels/cpu/dot_kernel.cc
@@ -18,6 +18,7 @@
 #include "paddle/phi/core/kernel_registry.h"
 
 #include "paddle/phi/common/complex.h"
+#include "paddle/phi/kernels/full_kernel.h"
 
 namespace phi {
 
@@ -26,6 +27,12 @@ void DotKernel(const Context& dev_ctx,
                const DenseTensor& x,
                const DenseTensor& y,
                DenseTensor* out) {
+  if (x.numel() == 0 || y.numel() == 0) {
+    // x[2, 1], y[2, 0], out[2]
+    phi::Full<T, Context>(
+        dev_ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
+    return;
+  }
   if (out->numel() <= 0) {
     return;
   }

--- a/paddle/phi/kernels/gpu/dot_kernel.cu
+++ b/paddle/phi/kernels/gpu/dot_kernel.cu
@@ -21,8 +21,8 @@
 #include "paddle/phi/kernels/funcs/eigen/common.h"
 
 #include "paddle/phi/common/complex.h"
+#include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/funcs/eigen/eigen_function.h"
-
 namespace phi {
 
 template <typename T, typename Context>
@@ -30,6 +30,12 @@ void DotKernel(const Context& dev_ctx,
                const DenseTensor& x,
                const DenseTensor& y,
                DenseTensor* out) {
+  if (x.numel() == 0 || y.numel() == 0) {
+    // x[2, 1], y[2, 0], out[2]
+    phi::Full<T, Context>(
+        dev_ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
+    return;
+  }
   if (out->numel() <= 0) {
     return;
   }

--- a/paddle/phi/kernels/impl/dot_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/dot_grad_kernel_impl.h
@@ -23,7 +23,6 @@ limitations under the License. */
 #include "paddle/phi/kernels/funcs/complex_functors.h"
 #include "paddle/phi/kernels/funcs/eigen/common.h"
 #include "paddle/phi/kernels/funcs/eigen/eigen_function.h"
-
 namespace phi {
 
 template <typename DeviceContext, typename T, typename Enable = void>
@@ -1381,9 +1380,19 @@ void DotGradKernel(const Context& dev_ctx,
                    DenseTensor* dy) {
   if (dx) {
     dev_ctx.template Alloc<T>(dx);
+    if (dx->numel() == 0) {
+      phi::Full<T, Context>(
+          dev_ctx, phi::IntArray(common::vectorize(y.dims())), 0, dy);
+      return;
+    }
   }
   if (dy) {
     dev_ctx.template Alloc<T>(dy);
+    if (dy->numel() == 0) {
+      phi::Full<T, Context>(
+          dev_ctx, phi::IntArray(common::vectorize(x.dims())), 0, dx);
+      return;
+    }
   }
   DotGradFunction<Context, T>()(dev_ctx, &x, &y, &dout, dx, dy);
 }

--- a/test/legacy_test/test_dot_op.py
+++ b/test/legacy_test/test_dot_op.py
@@ -450,6 +450,41 @@ class DotBF16OpBatch(TestDotBF16Op):
                 )
 
 
+class DotOp_ZeroSize(OpTest):
+    def setUp(self):
+        self.op_type = "dot"
+        self.python_api = paddle.dot
+        self.public_python_api = paddle.dot
+        self.init_shape()
+        self.init_dtype()
+        self.init_input_output()
+
+        self.inputs = {
+            'X': OpTest.np_dtype_to_base_dtype(self.x),
+            'Y': OpTest.np_dtype_to_base_dtype(self.y),
+        }
+        self.outputs = {'Out': self.out}
+        self.attrs = {}
+
+    def test_check_output(self):
+        self.check_output(check_pir=True)
+
+    def test_check_grad_normal(self):
+        self.check_grad(['X', 'Y'], 'Out', check_pir=True)
+
+    def init_input_output(self):
+        self.x = np.random.uniform(0.1, 1, self.shape).astype(self.dtype)
+        self.y = np.random.uniform(1, 3, self.shape).astype(self.dtype)
+        self.out = np.dot(self.x, self.y).astype(self.dtype)
+
+    def init_dtype(self):
+        self.dtype = np.float64
+
+    def init_shape(self):
+        # return shape []
+        self.shape = [0]
+
+
 if __name__ == '__main__':
     paddle.enable_static()
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->
修改Infermeta，符号推导，输出维度为x_dims去掉结尾一维，如果维度为0跳过检查，如果输入y[0]维度为0，out[0]同样设置为0

单测中没有使用2-D和numpy比较
https://docs.scipy.org/doc/numpy-1.15.0/reference/generated/numpy.dot.html
numpy 中1-D 2-D计算不同， 2-D是矩阵计算，PaddleAPITest 是自定义算法
![image](https://github.com/user-attachments/assets/0c75930a-0edf-4eca-96dd-ca6f27040c51)

https://github.com/PFCCLab/PaddleAPITest/blob/8cd041a339b55bacb2ec45049905015c4f3adb39/tester/paddle_to_torch/rules.py#L1295
![image](https://github.com/user-attachments/assets/4b82429d-2a21-49be-b4a1-019070573467)

PaddleAPITest测试通过
![image](https://github.com/user-attachments/assets/b73318a8-0d15-4feb-a5aa-0a717451c210)
