### PR TITLE
Module.train和Module.eval加入返回值

### DIFF
--- a/python/paddle/nn/layer/layers.py
+++ b/python/paddle/nn/layer/layers.py
@@ -462,14 +462,14 @@ class Layer:
         # Records original functions after @to_static to support to rollback
         self._original_funcs = OrderedDict()
 
-    def train(self) -> None:
+    def train(self) -> Self:
         """
 
         Sets this Layer and all its sublayers to training mode.
         This only effects certain modules like `Dropout` and `BatchNorm`.
 
         Returns:
-            None
+            Layer: self
 
         Examples:
             .. code-block:: python
@@ -518,13 +518,15 @@ class Layer:
         for layer in self.sublayers():
             layer.training = True
 
-    def eval(self) -> None:
+        return self
+
+    def eval(self) -> Self:
         """
         Sets this Layer and all its sublayers to evaluation mode.
         This only effects certain modules like `Dropout` and `BatchNorm`.
 
         Returns:
-            None
+            Layer: self
 
         Examples:
             .. code-block:: python
@@ -569,6 +571,8 @@ class Layer:
         self.training = False
         for layer in self.sublayers():
             layer.training = False
+
+        return self
 
     def apply(self, fn: Callable[[Self], None]) -> Self:
         """


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Improvements

### Description
<!-- Describe what you’ve done -->

**当前问题**
train/eval无返回值，导致paddle不支持model.eval()(input)、model.eval().set_state_dict(state_dict)之类的写法，写法不够灵活，限制了写法，

**解决方案**
在Module.train和Module.eval函数中加入了返回值，支持与竞品相同的写法，写法更灵活。