### PR TITLE
refix core: auto growth allocator add release lock

### DIFF
--- a/paddle/common/flags.cc
+++ b/paddle/common/flags.cc
@@ -2079,6 +2079,11 @@ PHI_DEFINE_EXPORTED_bool(save_cf_stack_op,
                          false,
                          "Save cf stack op for higher-order derivatives.");
 
+PHI_DEFINE_EXPORTED_bool(
+    enable_auto_growth_allocator_add_lock,
+    false,
+    "Enable add lock when call AutoGrowthBestFitAllocator::ReleaseImpl");
+
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
 /**
  * FlashAttention related FLAG


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Inference


### PR Types
Bug fixes


### Description
AutoGrowthBestFitAllocator作为默认的显存分配器，它是进程级的，在创建predictor时会调用ReleaseImpl释放空闲的chunks，但是ReleaseImpl不是线程安全的，如果此时其他predictor正在分配或者释放显存，会导致进程core或hang；
修复方式：参考FreeImpl和AllocateImpl接口实现，在ReleaseImpl中添加自旋锁，防止并发错误。
经过在多个不同模型中验证，加锁后core和hang的现象基本不会出现。
