### PR TITLE
[SOT] Explicit access layer attribute from `_parameters`/`_sub_layers`/`_buffers` to avoid `__getattr__` overhead and move dataclass utilities to `utils.py`

### DIFF
--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -127,6 +127,7 @@ from . import (
     linalg as linalg,
     signal as signal,
     tensor as tensor,
+    utils as utils,
 )
 from .autograd import (
     enable_grad,

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/base.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/base.py
@@ -23,6 +23,9 @@ from queue import Queue
 from typing import TYPE_CHECKING, Any, Callable, Optional
 
 import paddle
+from paddle.jit.dy2static.utils import (
+    dataclass_from_dict,
+)
 
 from ....profiler import event_register
 from ....utils import (
@@ -157,7 +160,7 @@ def map_variables(
     def _map_dataclass_variable(variable: VariableBase | object):
         if not isinstance(variable, DataClassInstanceVariable):
             return variable
-        new_dataclass = DataClassInstanceVariable._dataclass_from_dict(
+        new_dataclass = dataclass_from_dict(
             variable.get_py_type(),
             {
                 fd.name: map_func(variable.getattr(fd.name))

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
@@ -18,7 +18,6 @@ import dataclasses
 import operator
 import sys
 import types
-from dataclasses import is_dataclass
 from enum import Enum
 from functools import cached_property, reduce
 from typing import TYPE_CHECKING, Any
@@ -28,6 +27,11 @@ import numpy as np
 import paddle
 from paddle._typing import unreached
 from paddle.framework import core
+from paddle.jit.dy2static.utils import (
+    dataclass_as_dict,
+    dataclass_from_dict,
+    is_dataclass_instance,
+)
 from paddle.jit.sot.opcode_translator.executor.pycode_generator import PyCodeGen
 from paddle.pir.core import _PADDLE_PIR_DTYPE_2_NUMPY_DTYPE
 
@@ -452,7 +456,7 @@ class TensorVariable(VariableBase):
             and not self.meta.is_null()
         ):
             dynamic_axes = self.analyse_dynamic_axes(tracker)
-        self.var_name = TensorVariable.var_name_generator.next()
+        self.var_name = self.var_name_generator.next()
         self.graph.side_effects.record_mutable_variable(self)
         self.meta = self.meta.with_dynamic_axes(self.var_name, dynamic_axes)
         self.origin_meta = self.meta
@@ -1461,6 +1465,8 @@ class SymbolicVariable(VariableBase):
 
 
 class ParameterVariable(TensorVariable):
+    var_name_generator = NameGenerator("param_")
+
     def __init__(
         self,
         meta: MetaInfoOrNull,
@@ -2426,18 +2432,9 @@ class DataClassInstanceVariable(VariableBase):
             id_getter=lambda _: data_id or id(data_dict),
         )
 
-    @staticmethod
-    def _dataclass_from_dict(dataclass_type: type[Any], data: dict[str, Any]):
-        # NOTE(SigureMo): Create dataclass without __post_init__,
-        # because __post_init__ has been run in simulation
-        instance = dataclass_type.__new__(dataclass_type, **data)
-        for fd in dataclasses.fields(dataclass_type):
-            setattr(instance, fd.name, data[fd.name])
-        return instance
-
     def _reconstruct(self, codegen: PyCodeGen) -> None:
         codegen.gen_load_object(
-            DataClassInstanceVariable._dataclass_from_dict,
+            dataclass_from_dict,
             "___dataclass_from_dict",
         )
         self.getattr("__class__").reconstruct(codegen)
@@ -2481,7 +2478,7 @@ class DataClassInstanceVariable(VariableBase):
         return self.class_var.get_py_value()
 
     def get_py_value(self, allow_tensor=False):
-        return DataClassInstanceVariable._dataclass_from_dict(
+        return dataclass_from_dict(
             self.get_py_type(),
             {
                 key: value.get_py_value(allow_tensor)
@@ -2563,18 +2560,14 @@ class DataClassInstanceVariable(VariableBase):
             for fd in dataclasses.fields(self.get_py_type())
         ]
 
-    @classmethod
-    def _custom_asdict(cls, obj):
-        return {f.name: getattr(obj, f.name) for f in dataclasses.fields(obj)}
-
     @VariableFactory.register_from_value()
     def from_value(value: object, graph: FunctionGraph, tracker: Tracker):
-        if is_dataclass(value) and not isinstance(value, type):
+        if is_dataclass_instance(value):
             class_var = VariableFactory.from_value(
                 type(value), graph, DanglingTracker()
             )
             var = DataClassInstanceVariable(
-                DataClassInstanceVariable._custom_asdict(value),
+                dataclass_as_dict(value),
                 class_var,
                 id(value),
                 graph=graph,

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/callable.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/callable.py
@@ -23,7 +23,7 @@ import operator
 import random
 import sys
 import types
-from dataclasses import fields, is_dataclass
+from dataclasses import fields
 from functools import partial, reduce
 from typing import (
     TYPE_CHECKING,
@@ -36,7 +36,7 @@ from paddle.base.dygraph.base import (
     _DecoratorContextManager,
     in_sot_simulation_mode,
 )
-from paddle.jit.dy2static.utils import TransformOptions
+from paddle.jit.dy2static.utils import TransformOptions, is_dataclass_type
 
 from .... import psdb
 from ....profiler import EventGuard
@@ -658,6 +658,31 @@ class LayerVariable(CallableVariable):
     ):
         super().__init__(graph, tracker)
         self.value = layer
+
+    def getattr(self, name: str, default=None):
+        # TODO(SigureMo): Use more common logic to handle this case,
+        # e.g. call Layer's __getattr__
+        layer = self.value
+        if (
+            '_parameters' in layer.__dict__
+            and name in layer.__dict__["_parameters"]
+        ):
+            return self.getattr("_parameters").getitem(
+                ConstantVariable.wrap_literal(name, self.graph)
+            )
+        if (
+            '_sub_layers' in layer.__dict__
+            and name in layer.__dict__["_sub_layers"]
+        ):
+            out = self.getattr("_sub_layers").getitem(
+                ConstantVariable.wrap_literal(name, self.graph)
+            )
+            return out
+        if '_buffers' in layer.__dict__ and name in layer.__dict__["_buffers"]:
+            return self.getattr("_buffers").getitem(
+                ConstantVariable.wrap_literal(name, self.graph)
+            )
+        return super().getattr(name, default)
 
     def get_py_value(self, allow_tensor=False):
         return self.value
@@ -1311,7 +1336,7 @@ class DataClassVariable(ClassVariable):
 
     @VariableFactory.register_from_value(successor="ClassVariable")
     def from_value(value: object, graph: FunctionGraph, tracker: Tracker):
-        if is_dataclass(value) and isinstance(value, type):
+        if is_dataclass_type(value):
             var = DataClassVariable(value, graph=graph, tracker=tracker)
             return var
         return None

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/callable.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/callable.py
@@ -684,6 +684,22 @@ class LayerVariable(CallableVariable):
             )
         return super().getattr(name, default)
 
+    def setattr(self, name: str, value):
+        layer = self.value
+        if (
+            '_parameters' in layer.__dict__
+            and name in layer.__dict__["_parameters"]
+        ):
+            return self.getattr("_parameters").setitem(name, value)
+        if (
+            '_sub_layers' in layer.__dict__
+            and name in layer.__dict__["_sub_layers"]
+        ):
+            return self.getattr("_sub_layers").setitem(name, value)
+        if '_buffers' in layer.__dict__ and name in layer.__dict__["_buffers"]:
+            return self.getattr("_buffers").setitem(name, value)
+        return super().setattr(name, value)
+
     def get_py_value(self, allow_tensor=False):
         return self.value
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Performance

### Description
<!-- Describe what you’ve done -->

SOT 目前对于 layer 的参数/sublayer 的加载是直接走的 `layer.weight` 的这种方式，这样是会走 `Layer.__getattr__` 的 dispatch 的，因为 `layer.weight` 实际上会存在 `layer._parameters["weight"]` 上，因为不在 `layer.__dict__` 里，所以一定会 dispatch，但我们完全可以生成 `layer._parameters["weight"]` 这样的加载方式，以消除掉 `__getattr__` 的开销，这是通过构建 tracker 的方式实现的（同理，guard 开销也会降低）

经过测试，`layer._parameters["weight"]` 会比 `layer.weight` 快 10 多倍，这对 guard 开销和加载参数开销都会有大幅降低

当然，我们后面也可以在 `VariableBase` 上直接实现 `__getattr__` 的 inline call，以避免每次都要重新实现类似逻辑，现在的实现是不够通用的

另外顺带优化了下 `dataclass` 的 utilities

<!-- PCard-66972 -->