### PR TITLE
[Dy2St] Skip move `CUDAPinned` tensors to expected place in specialize device mode

### DIFF
--- a/python/paddle/jit/dy2static/program_translator.py
+++ b/python/paddle/jit/dy2static/program_translator.py
@@ -71,6 +71,7 @@ from .utils import (
     make_hashable,
     prim_or_cinn_is_enabled,
     type_name,
+    use_specialized_device,
 )
 
 if TYPE_CHECKING:
@@ -765,7 +766,8 @@ class SymbolicStaticFunction(StaticFunction):
         from ..sot import symbolic_translate
 
         args, kwargs = self._function_spec.unified_args_and_kwargs(args, kwargs)
-        cuda_pinned_tensors_move_to_excepted_place(args)
+        if not use_specialized_device():
+            cuda_pinned_tensors_move_to_excepted_place(args)
 
         (
             input_args_with_spec,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Performance

### Description
<!-- Describe what you’ve done -->

同 #73405，用于推理加速，在 specialized device 模式下跳过 cuda pinned move 到 expected place 的操作
<!-- PCard-66972 -->