### PR TITLE
[0-size Tensor No.319] Add 0-size Tensor support for paddle.median

### DIFF
--- a/python/paddle/tensor/stat.py
+++ b/python/paddle/tensor/stat.py
@@ -598,10 +598,6 @@ def median(
     if not isinstance(x, (Variable, paddle.pir.Value)):
         raise TypeError("In median, the input x should be a Tensor.")
 
-    if in_dynamic_mode() and x.size == 0:
-        # TODO: Currently, `__eq__` don't support arguments (`pir.Value` & `int`)
-        raise ValueError("In median, the size of input x should not be 0.")
-
     is_flatten = False
     dims = len(x.shape)
     if dims == 0:
@@ -658,7 +654,7 @@ def median(
             keepdim=True,
         )
     else:  # mode == 'min'
-        if sz & 1 == 0:
+        if sz & 1 == 0 and kth != 0:
             out_tensor = paddle.slice(
                 tensor_topk, axes=[axis], starts=[kth - 1], ends=[kth]
             )


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->
[0-size Tensor No.319] Add 0-size Tensor support for paddle.Tensor.median
[0-size Tensor Job2 No.48] Add 0-size Tensor support for paddle.median

去掉 python/paddle/tensor/stat.py 中判断size=0
修改 topk kernel，topk kernel 在infermeta 时设置为-1，需要在kernel中Resize后再判断x.numel

PaddleAPITest测试通过
![image](https://github.com/user-attachments/assets/866c1384-9801-49e2-972a-96e0a1ae5d72)

