### PR TITLE
[PHI] Remove CUDA error checking of fused_transpose_split_quant kernel

### DIFF
--- a/paddle/phi/kernels/fusion/gpu/fused_transpose_split_quant_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/fused_transpose_split_quant_kernel.cu
@@ -293,8 +293,6 @@ void FusedTransposeSplitQuantKernel(
 
 #undef LAUNCH_KERNEL_PARTIAL
 #undef LAUNCH_KERNEL
-
-  PADDLE_ENFORCE_GPU_SUCCESS(cudaGetLastError());
 }
 
 }  // namespace phi


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Operator Mechanism


### PR Types
Bug fixes


### Description
移除`fused_transpose_split_quant`算子里面的CUDA error检查，因为phi算子库的算子一般都不自己检查错误，这个是之前从PaddleNLP迁移过来时的遗留语句

Pcard-85711