### PR TITLE
[Accuracy diff No.11、144] Fix accuracy diff for paddle.clip API

### DIFF
--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -4012,6 +4012,9 @@ def clip(
     elif x_dtype == 'paddle.float16':
         min_ = float(np.finfo(np.float16).min)
         max_ = float(np.finfo(np.float16).max)
+    elif x_dtype == 'paddle.float64':
+        min_ = float(np.finfo(np.float64).min)
+        max_ = float(np.finfo(np.float64).max)
     else:
         min_ = float(np.finfo(np.float32).min)
         max_ = float(np.finfo(np.float32).max)

--- a/test/legacy_test/test_clip_op.py
+++ b/test/legacy_test/test_clip_op.py
@@ -525,5 +525,33 @@ class TestInplaceClipAPI(TestClipAPI):
         return x.clip_(min, max)
 
 
+class TestClipOp_FP64(OpTest):
+    def setUp(self):
+        self.python_api = paddle.clip
+        self.public_python_api = paddle.clip
+
+        self.inputs = {}
+        self.dtype = np.float64
+        self.shape = (8, 16, 8)
+        self.max = float(np.finfo(np.float64).max)
+        self.min = float(np.finfo(np.float64).min)
+
+        self.op_type = "clip"
+        self.attrs = {}
+        self.attrs['min'] = self.min
+        self.attrs['max'] = self.max
+
+        self.inputs['X'] = np.random.random(self.shape).astype(self.dtype)
+        self.outputs = {'Out': np.clip(self.inputs['X'], self.min, self.max)}
+
+    def test_check_output(self):
+        self.check_output(
+            check_pir=True,
+        )
+
+    def test_check_grad_normal(self):
+        self.check_grad(['X'], 'Out', check_pir=True)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->
11 paddle.cli
144 paddle.Tensor.clip
paddle.clip float64是按float32获取的max, min，应按float64类型获取

PaddleAPITest 测试通过
![image](https://github.com/user-attachments/assets/8239d770-ceaa-4f1b-84fa-5d7dd2386f48)
