### PR TITLE
[Auto Paralle] update fused_gemm_epilogue_rule partial rule

### DIFF
--- a/paddle/phi/infermeta/spmd_rules/utils.cc
+++ b/paddle/phi/infermeta/spmd_rules/utils.cc
@@ -215,6 +215,21 @@ bool PlacementEqual(const std::shared_ptr<PlacementStatus>& a,
   return a_shard->get_axis() == b_shard->get_axis();
 }
 
+bool IsPartialLegal(const TensorDistAttr& dist_attr) {
+  if (dist_attr.is_partial()) {
+    const std::vector<int64_t> dims_mapping = dist_attr.dims_mapping();
+    const std::set<int64_t> partial_on_dims = dist_attr.partial_dims();
+    for (const int64_t& dim : dims_mapping) {
+      if (dim != -1 && partial_on_dims.count(dim) != 0) {
+        return false;
+      }
+    }
+    return true;
+  } else {
+    return true;
+  }
+}
+
 void AlignDimsSharding(std::vector<TensorDistAttr>* input_attrs_ptr,
                        const std::vector<std::vector<int64_t>>& tensor_shapes,
                        const std::vector<std::string>& axis_names,

--- a/paddle/phi/infermeta/spmd_rules/utils.cc
+++ b/paddle/phi/infermeta/spmd_rules/utils.cc
@@ -221,6 +221,7 @@ bool IsPartialLegal(const TensorDistAttr& dist_attr) {
     const std::set<int64_t> partial_on_dims = dist_attr.partial_dims();
     for (const int64_t& dim : dims_mapping) {
       if (dim != -1 && partial_on_dims.count(dim) != 0) {
+        VLOG(4) << "Partial on dim [" << dim << "] but dim is sharded";
         return false;
       }
     }

--- a/paddle/phi/infermeta/spmd_rules/utils.h
+++ b/paddle/phi/infermeta/spmd_rules/utils.h
@@ -98,6 +98,8 @@ TensorDistAttr UnShardTensorDim(const TensorDistAttr& dist_attr, int dim);
 bool PlacementEqual(const std::shared_ptr<PlacementStatus>& a,
                     const std::shared_ptr<PlacementStatus>& b);
 
+bool IsPartialLegal(const TensorDistAttr& dist_attr);
+
 void AlignDimsSharding(std::vector<TensorDistAttr>* input_attrs,
                        const std::vector<std::vector<int64_t>>& tensor_shapes,
                        const std::vector<std::string>& axis_names,

--- a/test/auto_parallel/spmd_rules/test_fused_gemm_epilogue_rule.py
+++ b/test/auto_parallel/spmd_rules/test_fused_gemm_epilogue_rule.py
@@ -23,7 +23,7 @@ from paddle.distributed.fleet import auto
 from paddle.framework import core
 
 
-class TestMatmulSPMDRule(unittest.TestCase):
+class TestFusedGemmEpilogueSPMDRule(unittest.TestCase):
     def setUp(self):
         # After replaced all spmd rules by phi impl, we can recover the
         # api name to `get_spmd_rule`
@@ -52,7 +52,7 @@ class TestMatmulSPMDRule(unittest.TestCase):
         )
         self.bias_dist_tensor_spec.set_dims_mapping([-1])
 
-        # has partial,force to replicate test partial: mk[1, 0],kn[0, -1],bias[-1] --> mk[1, 0],kn[0, -1],bias[-1] = nm[1, -1]
+        # mk[1, 0],kn[0, -1],bias[-1] --> mk[1, 0],kn[0, -1],bias[-1]partial[0] = nm[1, -1]partial[0]
         self.x_dist_tensor_spec.set_dims_mapping([1, 0])
         self.y_dist_tensor_spec.set_dims_mapping([0, -1])
 
@@ -71,11 +71,15 @@ class TestMatmulSPMDRule(unittest.TestCase):
         self.assertEqual(len(inferred_input_dist_attrs), 3)
         self.assertEqual(len(inferred_output_dist_attrs), 2)
 
-        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1, -1])
-        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [-1, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [1, 0])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [0, -1])
         self.assertEqual(inferred_input_dist_attrs[2].dims_mapping, [-1])
-        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1, -1])
-        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), False)
+        self.assertEqual(inferred_input_dist_attrs[2]._is_partial(), True)
+        self.assertEqual(inferred_input_dist_attrs[2]._partial_dims(), {0})
+
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [1, -1])
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), True)
+        self.assertEqual(inferred_output_dist_attrs[0]._partial_dims(), {0})
 
         # test row parallel: mk[1, -1],kn[-1, -1],bias[-1] --> mk[1, -1],kn[-1, -1],bias[-1] = nm[1, -1]
         self.x_dist_tensor_spec.set_dims_mapping([1, -1])
@@ -119,7 +123,7 @@ class TestMatmulSPMDRule(unittest.TestCase):
         self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1, 0])
         self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), False)
 
-        # has partial,force to replicate test partial with propagation: mk[1, 0],kn[-1,-1],bias[-1] --> mk[1, 0],kn[0, -1],bias[-1] = nm[1, -1]
+        # mk[1, 0],kn[-1,-1],bias[-1] --> mk[1, 0],kn[0, -1],bias[-1]partial[0] = nm[1, -1]partial[0]
         self.x_dist_tensor_spec.set_dims_mapping([1, 0])
         self.y_dist_tensor_spec.set_dims_mapping([-1, -1])
         self.bias_dist_tensor_spec.set_dims_mapping([-1])
@@ -135,13 +139,17 @@ class TestMatmulSPMDRule(unittest.TestCase):
         inferred_input_dist_attrs = result_dist_attrs[0]
         inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1, -1])
-        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [-1, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [1, 0])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [0, -1])
         self.assertEqual(inferred_input_dist_attrs[2].dims_mapping, [-1])
-        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1, -1])
-        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), False)
+        self.assertEqual(inferred_input_dist_attrs[2]._is_partial(), True)
+        self.assertEqual(inferred_input_dist_attrs[2]._partial_dims(), {0})
 
-        # has partial,force to replicate mk[-1,-1],kn[1,0],bias[-1] --> mk[-1, 1],kn[1, 0],bias[0] = nm[-1, 0]
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [1, -1])
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), True)
+        self.assertEqual(inferred_output_dist_attrs[0]._partial_dims(), {0})
+
+        # mk[-1,-1],kn[1,0],bias[-1] --> mk[-1, 1],kn[1, 0],bias[0]partial[1] = nm[-1, 0]partial[1]
         self.x_dist_tensor_spec.set_dims_mapping([-1, -1])
         self.y_dist_tensor_spec.set_dims_mapping([1, 0])
         self.bias_dist_tensor_spec.set_dims_mapping([-1])
@@ -157,11 +165,15 @@ class TestMatmulSPMDRule(unittest.TestCase):
         inferred_input_dist_attrs = result_dist_attrs[0]
         inferred_output_dist_attrs = result_dist_attrs[1]
 
-        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1, -1])
-        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [-1, -1])
-        self.assertEqual(inferred_input_dist_attrs[2].dims_mapping, [-1])
-        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1, -1])
-        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), False)
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1, 1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [1, 0])
+        self.assertEqual(inferred_input_dist_attrs[2].dims_mapping, [0])
+        self.assertEqual(inferred_input_dist_attrs[2]._is_partial(), True)
+        self.assertEqual(inferred_input_dist_attrs[2]._partial_dims(), {1})
+
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1, 0])
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), True)
+        self.assertEqual(inferred_output_dist_attrs[0]._partial_dims(), {1})
 
         # abcmk[1, 0, -1, -1],kn[-1, -1],bias[-1] --> abcmk[1, 0, -1, -1],kn[-1, -1],bias[-1] = abcmn[1, 0, -1, -1]
         self.x_dist_tensor_spec.shape = [512, 48, 64, 32]
@@ -187,7 +199,7 @@ class TestMatmulSPMDRule(unittest.TestCase):
         )
         self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), False)
 
-        # has partial,force to replicate abcmk[1, -1, -1, 0],kn[-1, -1],bias[-1] --> abcmk[1, -1, -1, 0],kn[0, -1],bias[-1] = abcmn[1,-1, -1, -1]
+        # abcmk[1, -1, -1, 0],kn[-1, -1],bias[-1] --> abcmk[1, -1, -1, 0],kn[0, -1],bias[-1]partial[0] = abcmn[1,-1, -1, -1]partial[0]
         self.x_dist_tensor_spec.set_dims_mapping([1, -1, -1, 0])
         self.y_dist_tensor_spec.set_dims_mapping([-1, -1])
 
@@ -202,14 +214,17 @@ class TestMatmulSPMDRule(unittest.TestCase):
         inferred_input_dist_attrs = result_dist_attrs[0]
         inferred_output_dist_attrs = result_dist_attrs[1]
         self.assertEqual(
-            inferred_input_dist_attrs[0].dims_mapping, [1, -1, -1, -1]
+            inferred_input_dist_attrs[0].dims_mapping, [1, -1, -1, 0]
         )
-        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [-1, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [0, -1])
         self.assertEqual(inferred_input_dist_attrs[2].dims_mapping, [-1])
+        self.assertEqual(inferred_input_dist_attrs[2]._is_partial(), True)
+        self.assertEqual(inferred_input_dist_attrs[2]._partial_dims(), {0})
         self.assertEqual(
             inferred_output_dist_attrs[0].dims_mapping, [1, -1, -1, -1]
         )
-        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), False)
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), True)
+        self.assertEqual(inferred_output_dist_attrs[0]._partial_dims(), {0})
 
         # trans_x = True, abcmk[1, -1, -1, 0], kn[-1, -1],bias[-1] --> abcmk[1, -1, -1, 0],kn[-1, -1],bias[-1] = abcmn[1, -1, 0, -1]
         self.x_dist_tensor_spec.set_dims_mapping([1, -1, -1, 0])
@@ -230,12 +245,13 @@ class TestMatmulSPMDRule(unittest.TestCase):
         )
         self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [-1, -1])
         self.assertEqual(inferred_input_dist_attrs[2].dims_mapping, [-1])
+        self.assertEqual(inferred_input_dist_attrs[2]._is_partial(), False)
         self.assertEqual(
             inferred_output_dist_attrs[0].dims_mapping, [1, -1, 0, -1]
         )
         self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), False)
 
-        # has partial,force to replicate trans_y = True, abcmk[-1, -1, -1, -1], kn[1, 0],bias[-1] --> abcmk[-1, -1, -1, 0],kn[1, 0],bias[1] = abcmn[-1, -1, -1, 1] partial[0]: done
+        # trans_y = True, abcmk[-1, -1, -1, -1], kn[1, 0],bias[-1] --> abcmk[-1, -1, -1, 0],kn[1, 0],bias[1]partial[0] = abcmn[-1, -1, -1, 1]partial[0]
         self.x_dist_tensor_spec.set_dims_mapping([-1, -1, -1, -1])
         self.y_dist_tensor_spec.set_dims_mapping([1, 0])
 
@@ -250,16 +266,19 @@ class TestMatmulSPMDRule(unittest.TestCase):
         inferred_input_dist_attrs = result_dist_attrs[0]
         inferred_output_dist_attrs = result_dist_attrs[1]
         self.assertEqual(
-            inferred_input_dist_attrs[0].dims_mapping, [-1, -1, -1, -1]
+            inferred_input_dist_attrs[0].dims_mapping, [-1, -1, -1, 0]
         )
-        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [-1, -1])
-        self.assertEqual(inferred_input_dist_attrs[2].dims_mapping, [-1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [1, 0])
+        self.assertEqual(inferred_input_dist_attrs[2].dims_mapping, [1])
+        self.assertEqual(inferred_input_dist_attrs[2]._is_partial(), True)
+        self.assertEqual(inferred_input_dist_attrs[2]._partial_dims(), {0})
         self.assertEqual(
-            inferred_output_dist_attrs[0].dims_mapping, [-1, -1, -1, -1]
+            inferred_output_dist_attrs[0].dims_mapping, [-1, -1, -1, 1]
         )
-        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), False)
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), True)
+        self.assertEqual(inferred_output_dist_attrs[0]._partial_dims(), {0})
 
-        # has partial,force to replicate trans_y = True, trans_x = True, abcmk[-1, -1, 0, 1], kn[1, 0],bias[-1] --> abcmk[-1, -1, 0, 1]],kn[-1, 0],bias[-1] = abcmn[-1, -1, 1, -1]
+        # trans_y = True, trans_x = True, abcmk[-1, -1, 0, 1], kn[1, 0],bias[-1] --> abcmk[-1, -1, 0, 1],kn[-1, 0],bias[-1]partial[0] = abcmn[-1, -1, 1, -1]partial[0]
         # multiple mesh dim shard same tensor axis
         self.x_dist_tensor_spec.set_dims_mapping([-1, -1, 0, 1])
         self.y_dist_tensor_spec.set_dims_mapping([1, 0])
@@ -275,14 +294,18 @@ class TestMatmulSPMDRule(unittest.TestCase):
         inferred_input_dist_attrs = result_dist_attrs[0]
         inferred_output_dist_attrs = result_dist_attrs[1]
         self.assertEqual(
-            inferred_input_dist_attrs[0].dims_mapping, [-1, -1, -1, -1]
+            inferred_input_dist_attrs[0].dims_mapping, [-1, -1, 0, 1]
         )
-        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [-1, -1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [-1, 0])
         self.assertEqual(inferred_input_dist_attrs[2].dims_mapping, [-1])
+        self.assertEqual(inferred_input_dist_attrs[2]._is_partial(), True)
+        self.assertEqual(inferred_input_dist_attrs[2]._partial_dims(), {0})
         self.assertEqual(
-            inferred_output_dist_attrs[0].dims_mapping, [-1, -1, -1, -1]
+            inferred_output_dist_attrs[0].dims_mapping, [-1, -1, 1, -1]
         )
         self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), False)
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), True)
+        self.assertEqual(inferred_output_dist_attrs[0]._partial_dims(), {0})
 
         # has partial,force to replicate mk[-1,1],k[1],bias[1] --> mk[-1,-1],k[-1],bias[-1] = m[-1]
         x_shape = [64, 32]

--- a/test/auto_parallel/spmd_rules/test_fused_gemm_epilogue_rule.py
+++ b/test/auto_parallel/spmd_rules/test_fused_gemm_epilogue_rule.py
@@ -303,11 +303,10 @@ class TestFusedGemmEpilogueSPMDRule(unittest.TestCase):
         self.assertEqual(
             inferred_output_dist_attrs[0].dims_mapping, [-1, -1, 1, -1]
         )
-        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), False)
         self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), True)
         self.assertEqual(inferred_output_dist_attrs[0]._partial_dims(), {0})
 
-        # has partial,force to replicate mk[-1,1],k[1],bias[1] --> mk[-1,-1],k[-1],bias[-1] = m[-1]
+        # mk[-1,1],k[1],bias[1] --> mk[-1,1],k[1],bias[-1]partial[1] = m[-1]partial[1]
         x_shape = [64, 32]
         y_shape = [32]
         bias_shape = [32]
@@ -339,13 +338,17 @@ class TestFusedGemmEpilogueSPMDRule(unittest.TestCase):
 
         inferred_input_dist_attrs = result_dist_attrs[0]
         inferred_output_dist_attrs = result_dist_attrs[1]
-        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1, -1])
-        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [-1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1, 1])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [1])
         self.assertEqual(inferred_input_dist_attrs[2].dims_mapping, [-1])
-        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1])
-        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), False)
+        self.assertEqual(inferred_input_dist_attrs[2]._is_partial(), True)
+        self.assertEqual(inferred_input_dist_attrs[2]._partial_dims(), {1})
 
-        # has partial,force to replicate k[-1],kn[-1,1],bias[-1] --> k[-1],kn[-1,1],bias[1] = n[1]
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1])
+        self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), True)
+        self.assertEqual(inferred_output_dist_attrs[0]._partial_dims(), {1})
+
+        # k[-1],kn[-1,1],bias[-1] --> k[-1],kn[-1,1],bias[1] = n[1]
         x_shape = [32]
         y_shape = [32, 64]
         bias_shape = [64]
@@ -380,6 +383,7 @@ class TestFusedGemmEpilogueSPMDRule(unittest.TestCase):
         self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1])
         self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [-1, 1])
         self.assertEqual(inferred_input_dist_attrs[2].dims_mapping, [1])
+        self.assertEqual(inferred_input_dist_attrs[2]._is_partial(), False)
         self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [1])
         self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), False)
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Auto Parallel


### PR Types
New features


### Description
<!-- Describe what you’ve done -->
原先的fused_gemm不允许partial状态，会全部重置为replicated，在运行部分模型（如gpt3）时会触发大量reshard带来多余通信开销。

本pr通过将bias同步为matmul output的partial状态避免partial output被重置为replicated，同时添加partial状态检查保证输出合法，从而兼容大多数partial情况。

pcard-86802