### PR TITLE
Adding 0size support and expert_num enforcement to moe_permute & unpermute op.

### DIFF
--- a/paddle/phi/kernels/gpu/moe_permute_kernel.cu
+++ b/paddle/phi/kernels/gpu/moe_permute_kernel.cu
@@ -230,6 +230,16 @@ void MoePermuteKernel(const Context &dev_ctx,
                       DenseTensor *XScale_unzipped) {
   const int rows = X.dims()[0];
   const int cols = X.dims()[1];
+  PADDLE_ENFORCE_LE(
+      num_experts,
+      MAX_NUM_EXPERTS,
+      common::errors::InvalidArgument(
+          "Currently we support no more than (%ld), received num_expert: "
+          "(%ld). Please check input "
+          "value.",
+          MAX_NUM_EXPERTS,
+          num_experts));
+  if (rows == 0) return;
   const int quanted_cols = (XScale) ? XScale.get_ptr()->dims()[1] : 0;
   expert_base_offset expert_offset;
   int tokens_cumulated = 0;

--- a/paddle/phi/kernels/gpu/moe_permute_kernel.cu
+++ b/paddle/phi/kernels/gpu/moe_permute_kernel.cu
@@ -239,7 +239,13 @@ void MoePermuteKernel(const Context &dev_ctx,
           "value.",
           MAX_NUM_EXPERTS,
           num_experts));
-  if (rows == 0) return;
+  if (X.numel() == 0) {
+    dev_ctx.template Alloc<float>(XScale_unzipped);
+    dev_ctx.template Alloc<int>(zipped_expertwise_rowmap);
+    dev_ctx.template Alloc<T>(X_unzipped);
+    dev_ctx.template Alloc<float>(token_prob_unzipped);
+    return;
+  }
   const int quanted_cols = (XScale) ? XScale.get_ptr()->dims()[1] : 0;
   expert_base_offset expert_offset;
   int tokens_cumulated = 0;

--- a/paddle/phi/kernels/gpu/moe_unpermute_kernel.cu
+++ b/paddle/phi/kernels/gpu/moe_unpermute_kernel.cu
@@ -230,7 +230,7 @@ void MoeUnpermuteKernel(const Context &dev_ctx,
   const int topk = expert_routemap_topk.dims()[1];
   dev_ctx.template Alloc<T>(zipped_tokens);
   dev_ctx.template Alloc<float>(zipped_probs_topk);
-  if (unzipped_tokens->numel() == 0) return;  // 0-size tensor
+  if (unzipped_tokens.numel() == 0) return;  // 0-size tensor
   void *zipped_probs_topk_ptr =
       reinterpret_cast<void *>(zipped_probs_topk->data<float>());
   cudaMemsetAsync(zipped_probs_topk_ptr,

--- a/paddle/phi/kernels/gpu/moe_unpermute_kernel.cu
+++ b/paddle/phi/kernels/gpu/moe_unpermute_kernel.cu
@@ -227,10 +227,10 @@ void MoeUnpermuteKernel(const Context &dev_ctx,
           "value.",
           MAX_NUM_EXPERTS,
           num_experts));
-  if (rows == 0) return;
   const int topk = expert_routemap_topk.dims()[1];
   dev_ctx.template Alloc<T>(zipped_tokens);
   dev_ctx.template Alloc<float>(zipped_probs_topk);
+  if (unzipped_tokens->numel() == 0) return;  // 0-size tensor
   void *zipped_probs_topk_ptr =
       reinterpret_cast<void *>(zipped_probs_topk->data<float>());
   cudaMemsetAsync(zipped_probs_topk_ptr,

--- a/paddle/phi/kernels/gpu/moe_unpermute_kernel.cu
+++ b/paddle/phi/kernels/gpu/moe_unpermute_kernel.cu
@@ -218,6 +218,16 @@ void MoeUnpermuteKernel(const Context &dev_ctx,
                         DenseTensor *zipped_probs_topk) {
   const int rows = unzipped_tokens.dims()[0];
   const int cols = unzipped_tokens.dims()[1];
+  PADDLE_ENFORCE_LE(
+      num_experts,
+      MAX_NUM_EXPERTS,
+      common::errors::InvalidArgument(
+          "Currently we support no more than (%ld), received num_expert: "
+          "(%ld). Please check input "
+          "value.",
+          MAX_NUM_EXPERTS,
+          num_experts));
+  if (rows == 0) return;
   const int topk = expert_routemap_topk.dims()[1];
   dev_ctx.template Alloc<T>(zipped_tokens);
   dev_ctx.template Alloc<float>(zipped_probs_topk);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
Adding 0size support and expert_num enforcement to moe_permute & unpermute op.

pcard-91067
