### PR TITLE
[0-size Tensor No.72、306] Add 0-size Tensor support for frexp

### DIFF
--- a/test/legacy_test/test_frexp_api.py
+++ b/test/legacy_test/test_frexp_api.py
@@ -96,5 +96,30 @@ class TestSplitsFloat64Case2(TestFrexpAPI):
         self.x_np = np.random.uniform(-1, 1, [4, 5, 2]).astype('float64')
 
 
+class TestFrexpAPI_ZeroSize(unittest.TestCase):
+    def setUp(self):
+        self.place = (
+            paddle.CUDAPlace(0)
+            if paddle.is_compiled_with_cuda()
+            else paddle.CPUPlace()
+        )
+        self.set_input()
+
+    def set_input(self):
+        self.x_np = np.random.uniform(-3, 3, [0, 12]).astype('float32')
+
+    def test_dygraph_api(self):
+        paddle.disable_static(self.place)
+        input_num = paddle.to_tensor(self.x_np)
+        input_num.stop_gradient = False
+        out1 = np.frexp(self.x_np)
+        out2 = paddle.frexp(input_num)
+        np.testing.assert_allclose(out1, out2)
+
+        paddle.sum(out2[0]).backward()
+        np.testing.assert_allclose(input_num.grad.shape, input_num.shape)
+        paddle.enable_static()
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->
72 paddle.frexp
306 paddle.Tensor.frexp

PaddleAPITest 测试通过增加单测
GPU
![image](https://github.com/user-attachments/assets/c71999be-85d3-4e54-b452-7fcefddcd727)

![image](https://github.com/user-attachments/assets/31c6914d-1189-43dd-b1be-e2301ef57787)

CPU
![image](https://github.com/user-attachments/assets/f5219203-9c0f-405a-b39d-b9d0e8360472)

![image](https://github.com/user-attachments/assets/8a4d583c-efd5-41f4-a471-7046e177afec)
