### PR TITLE
[SOT] Support user specified dynamic dims

### DIFF
--- a/python/paddle/jit/dy2static/utils.py
+++ b/python/paddle/jit/dy2static/utils.py
@@ -87,6 +87,8 @@ ENV_ENABLE_CINN_IN_DY2ST = BooleanEnvironmentVariable(
     "ENABLE_CINN_IN_DY2ST", True
 )
 
+DYNAMIC_DIMS_ATTR_NAME = "__sot_dynamic_dims"
+
 
 class Backend(Enum):
     CINN = auto()
@@ -1012,3 +1014,26 @@ def patch_method_guard(
         yield
     finally:
         restorer(instance)
+
+
+def extract_tensor_dynamic_dims(
+    tensor: paddle.Tensor,
+) -> tuple[int]:
+    """
+    Extract dynamic dimensions from a paddle.Tensor.
+    Returns a list of dynamic dimensions or None if no dynamic dimensions exist.
+    """
+    if not isinstance(tensor, paddle.Tensor):
+        raise TypeError(
+            f"Expected a paddle.Tensor, but got {type(tensor).__name__}"
+        )
+
+    if not hasattr(tensor, DYNAMIC_DIMS_ATTR_NAME):
+        return []
+
+    dynamic_dims = getattr(tensor, DYNAMIC_DIMS_ATTR_NAME)
+    if not isinstance(dynamic_dims, tuple):
+        raise TypeError(
+            f"Expected {DYNAMIC_DIMS_ATTR_NAME} to be a tuple, but got {type(dynamic_dims).__name__}"
+        )
+    return dynamic_dims

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
@@ -1412,6 +1412,8 @@ class SymbolicVariable(VariableBase):
         if not ENV_SOT_ALLOW_DYNAMIC_SHAPE.get():
             return None
         if isinstance(value, SymbolicInt):
+            if value.is_backed():
+                return SymbolicVariable(value, graph, tracker)
             tensor_shape_source_result = (
                 SymbolicVariable.find_tensor_shape_source(tracker)
             )

--- a/test/sot/test_user_specified_dynamic_dims.py
+++ b/test/sot/test_user_specified_dynamic_dims.py
@@ -1,0 +1,120 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import unittest
+
+from test_case_base import (
+    TestCaseBase,
+    test_instruction_translator_cache_context,
+)
+
+import paddle
+from paddle.jit.sot.psdb import check_no_breakgraph
+
+
+@check_no_breakgraph
+def tensor_with_marked_dynamic_dims(tensor):
+    return tensor + 1
+
+
+@check_no_breakgraph
+def multiple_tensors_with_marked_dynamic_dims(tensor1, tensor2):
+    return tensor1.sum() + tensor2.sum()
+
+
+class TestUserSpecifiedDynamicDims(TestCaseBase):
+    def test_auto_inferred_dynamic_dims(self):
+        with test_instruction_translator_cache_context() as ctx:
+            self.assertEqual(ctx.translate_count, 0)
+            x1 = paddle.rand([5, 6], dtype='float32')
+            self.assert_results(tensor_with_marked_dynamic_dims, x1)
+            self.assertEqual(ctx.translate_count, 1)
+            x2 = paddle.rand([4, 6], dtype='float32')
+            self.assert_results(tensor_with_marked_dynamic_dims, x2)
+            self.assertEqual(ctx.translate_count, 2)
+            x3 = paddle.rand([3, 6], dtype='float32')
+            self.assert_results(tensor_with_marked_dynamic_dims, x3)
+            self.assertEqual(ctx.translate_count, 2)
+
+    def test_user_specified_dynamic_dims(self):
+        with test_instruction_translator_cache_context() as ctx:
+            self.assertEqual(ctx.translate_count, 0)
+            x1 = paddle.rand([5, 6], dtype='float32')
+            paddle.jit.marker.dynamic_dims(x1, [0])
+            self.assert_results(tensor_with_marked_dynamic_dims, x1)
+            self.assertEqual(ctx.translate_count, 1)
+            x2 = paddle.rand([4, 6], dtype='float32')
+            self.assert_results(tensor_with_marked_dynamic_dims, x2)
+            self.assertEqual(ctx.translate_count, 1)
+            x3 = paddle.rand([3, 6], dtype='float32')
+            self.assert_results(tensor_with_marked_dynamic_dims, x3)
+            self.assertEqual(ctx.translate_count, 1)
+
+    def test_user_specified_multiple_dynamic_dims(self):
+        with test_instruction_translator_cache_context() as ctx:
+            self.assertEqual(ctx.translate_count, 0)
+            x1 = paddle.rand([5, 6], dtype='float32')
+            paddle.jit.marker.dynamic_dims(x1, [0, 1])
+            self.assert_results(tensor_with_marked_dynamic_dims, x1)
+            self.assertEqual(ctx.translate_count, 1)
+            x2 = paddle.rand([4, 6], dtype='float32')
+            self.assert_results(tensor_with_marked_dynamic_dims, x2)
+            self.assertEqual(ctx.translate_count, 1)
+            x3 = paddle.rand([3, 7], dtype='float32')
+            self.assert_results(tensor_with_marked_dynamic_dims, x3)
+            self.assertEqual(ctx.translate_count, 1)
+
+    def test_multiple_tensors_with_marked_dynamic_dims(self):
+        with test_instruction_translator_cache_context() as ctx:
+            self.assertEqual(ctx.translate_count, 0)
+            x1 = paddle.rand([5, 6], dtype='float32')
+            x2 = paddle.rand([5, 6], dtype='float32')
+            paddle.jit.marker.dynamic_dims(x1, [0])
+            paddle.jit.marker.dynamic_dims(x2, [0])
+            self.assert_results(
+                multiple_tensors_with_marked_dynamic_dims, x1, x2
+            )
+            self.assertEqual(ctx.translate_count, 1)
+            x3 = paddle.rand([4, 6], dtype='float32')
+            x4 = paddle.rand([5, 6], dtype='float32')
+            self.assert_results(
+                multiple_tensors_with_marked_dynamic_dims, x3, x4
+            )
+            self.assertEqual(ctx.translate_count, 1)
+            x5 = paddle.rand([4, 6], dtype='float32')
+            x6 = paddle.rand([4, 6], dtype='float32')
+            self.assert_results(
+                multiple_tensors_with_marked_dynamic_dims, x5, x6
+            )
+            self.assertEqual(ctx.translate_count, 1)
+
+    def test_mix_auto_inferred_and_specified_dynamic_dims(self):
+        with test_instruction_translator_cache_context() as ctx:
+            self.assertEqual(ctx.translate_count, 0)
+            x1 = paddle.rand([5, 6], dtype='float32')
+            paddle.jit.marker.dynamic_dims(x1, [0])
+            self.assert_results(tensor_with_marked_dynamic_dims, x1)
+            self.assertEqual(ctx.translate_count, 1)
+            x2 = paddle.rand([4, 6], dtype='float32')
+            self.assert_results(tensor_with_marked_dynamic_dims, x2)
+            self.assertEqual(ctx.translate_count, 1)
+            x3 = paddle.rand([3, 7], dtype='float32')
+            self.assert_results(tensor_with_marked_dynamic_dims, x3)
+            self.assertEqual(ctx.translate_count, 2)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

New features

### Description
<!-- Describe what you’ve done -->

支持通过 `paddle.jit.marker.dynamic_dims` 来标记输入 Tensor 的某些维度是动态的，以减少静态 shape warmup 所需的开销

从实现上来讲，这会为 Tensor patch 一个属性，以确保 SOT 能够感知

<!-- PCard-66972 -->