### PR TITLE
[0-size Tensor Job2 No.37] Add 0-size Tensor support for index_put

### DIFF
--- a/paddle/phi/kernels/cpu/index_put_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_put_grad_kernel.cc
@@ -182,6 +182,18 @@ void IndexPutGradKernel(const Context& dev_ctx,
                         bool accumulate,
                         DenseTensor* x_grad,
                         DenseTensor* value_grad) {
+  if (out_grad.numel() == 0) {
+    dev_ctx.template Alloc<T>(x_grad);
+    // Fill value_grad with 0.
+    if (value_grad) {
+      phi::Full<T, Context>(
+          dev_ctx,
+          phi::IntArray(common::vectorize(value_grad->dims())),
+          0,
+          value_grad);
+    }
+    return;
+  }
   PADDLE_ENFORCE_EQ(
       x.dtype(),
       value.dtype(),

--- a/paddle/phi/kernels/cpu/index_put_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_put_kernel.cc
@@ -105,6 +105,10 @@ void IndexPutKernel(const Context& dev_ctx,
                     const DenseTensor& value,
                     bool accumulate,
                     DenseTensor* out) {
+  if (out && out->numel() == 0) {
+    dev_ctx.template Alloc<T>(out);
+    return;
+  }
   PADDLE_ENFORCE_EQ(
       x.dtype(),
       value.dtype(),

--- a/paddle/phi/kernels/gpu/index_put_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_put_grad_kernel.cu
@@ -231,6 +231,19 @@ void IndexPutGradKernel(const Context& dev_ctx,
                         bool accumulate,
                         DenseTensor* x_grad,
                         DenseTensor* value_grad) {
+  if (out_grad.numel() == 0) {
+    dev_ctx.template Alloc<T>(x_grad);
+    // Fill value_grad with 0.
+    if (value_grad) {
+      phi::Full<T, Context>(
+          dev_ctx,
+          phi::IntArray(common::vectorize(value_grad->dims())),
+          0,
+          value_grad);
+    }
+    return;
+  }
+
   PADDLE_ENFORCE_EQ(
       x.dtype(),
       value.dtype(),

--- a/paddle/phi/kernels/gpu/index_put_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_put_kernel.cu
@@ -116,6 +116,10 @@ void IndexPutKernel(const Context& dev_ctx,
                     const DenseTensor& value,
                     bool accumulate,
                     DenseTensor* out) {
+  if (out && out->numel() == 0) {
+    dev_ctx.template Alloc<T>(out);
+    return;
+  }
   PADDLE_ENFORCE_EQ(
       x.dtype(),
       value.dtype(),

--- a/paddle/phi/kernels/xpu/index_put_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/index_put_grad_kernel.cc
@@ -31,6 +31,18 @@ void IndexPutGradKernel(const Context& dev_ctx,
                         bool accumulate,
                         DenseTensor* x_grad,
                         DenseTensor* value_grad) {
+  if (out_grad.numel() == 0) {
+    dev_ctx.template Alloc<T>(x_grad);
+    // Fill value_grad with 0.
+    if (value_grad) {
+      phi::Full<T, Context>(
+          dev_ctx,
+          phi::IntArray(common::vectorize(value_grad->dims())),
+          0,
+          value_grad);
+    }
+    return;
+  }
   PADDLE_ENFORCE_EQ(
       x.dtype(),
       value.dtype(),

--- a/paddle/phi/kernels/xpu/index_put_kernel.cc
+++ b/paddle/phi/kernels/xpu/index_put_kernel.cc
@@ -28,6 +28,10 @@ void IndexPutKernel(const Context& dev_ctx,
                     const DenseTensor& value,
                     bool accumulate,
                     DenseTensor* out) {
+  if (out && out->numel() == 0) {
+    dev_ctx.template Alloc<T>(out);
+    return;
+  }
   PADDLE_ENFORCE_EQ(
       x.dtype(),
       value.dtype(),

--- a/test/legacy_test/test_index_put_op.py
+++ b/test/legacy_test/test_index_put_op.py
@@ -1030,34 +1030,8 @@ class TestIndexPutAPIMixedIndices1(TestIndexPutAPIBase):
 
 class TestIndexPutAPI_ZeroSize(unittest.TestCase):
     def setUp(self):
-        self.mixed_indices = False
-        self.is_all_false = False
         self.init_dtype_type()
         self.setPlace()
-
-        if self.mixed_indices:
-            tmp_indices_np1 = gen_indices_np(
-                self.x_shape,
-                self.indices_shapes,
-                self.index_type_np,
-                self.is_all_false,
-            )
-            tmp_indices_np2 = gen_indices_np(
-                self.x_shape,
-                self.indices_shapes1,
-                self.index_type_np1,
-                self.is_all_false,
-            )
-            self.indices_np = tuple(
-                list(tmp_indices_np1) + list(tmp_indices_np2)
-            )
-        else:
-            self.indices_np = gen_indices_np(
-                self.x_shape,
-                self.indices_shapes,
-                self.index_type_np,
-                self.is_all_false,
-            )
 
     def init_dtype_type(self):
         self.dtype_np = np.float32

--- a/test/legacy_test/test_index_put_op.py
+++ b/test/legacy_test/test_index_put_op.py
@@ -1028,5 +1028,89 @@ class TestIndexPutAPIMixedIndices1(TestIndexPutAPIBase):
         self.index_type_pd1 = "bool"
 
 
+class TestIndexPutAPI_ZeroSize(unittest.TestCase):
+    def setUp(self):
+        self.mixed_indices = False
+        self.is_all_false = False
+        self.init_dtype_type()
+        self.setPlace()
+
+        if self.mixed_indices:
+            tmp_indices_np1 = gen_indices_np(
+                self.x_shape,
+                self.indices_shapes,
+                self.index_type_np,
+                self.is_all_false,
+            )
+            tmp_indices_np2 = gen_indices_np(
+                self.x_shape,
+                self.indices_shapes1,
+                self.index_type_np1,
+                self.is_all_false,
+            )
+            self.indices_np = tuple(
+                list(tmp_indices_np1) + list(tmp_indices_np2)
+            )
+        else:
+            self.indices_np = gen_indices_np(
+                self.x_shape,
+                self.indices_shapes,
+                self.index_type_np,
+                self.is_all_false,
+            )
+
+    def init_dtype_type(self):
+        self.dtype_np = np.float32
+        self.index_type_np = np.int64
+        self.x_shape = (10, 0)
+        self.indices_shapes = [[10]]
+        self.value_shape = [1, 1]
+        self.dtype_pd = paddle.float32
+        self.index_type_pd = paddle.int64
+
+    def setPlace(self):
+        self.place = []
+        if (
+            os.environ.get('FLAGS_CI_both_cpu_and_gpu', 'False').lower()
+            in ['1', 'true', 'on']
+            or not paddle.is_compiled_with_cuda()
+        ):
+            self.place.append('cpu')
+        if self.dtype_np is np.float16:
+            self.place = []
+        if paddle.is_compiled_with_cuda():
+            self.place.append('gpu')
+
+    def test_dygraph_forward(self):
+        paddle.disable_static()
+        for place in self.place:
+            paddle.device.set_device(place)
+            x_pd = paddle.randn(self.x_shape, dtype=self.dtype_pd)
+            x_np = x_pd.numpy()
+            value_pd = paddle.randn(self.value_shape, dtype=self.dtype_pd)
+            value_np = value_pd.numpy()
+            x_pd.stop_gradient = False
+            value_pd.stop_gradient = False
+            indices_pd = [
+                paddle.randn(indices_shape).astype(dtype=self.index_type_pd)
+                for indices_shape in self.indices_shapes
+            ]
+            indices_np = [item.numpy() for item in indices_pd]
+            indices_pd = tuple(indices_pd)
+            accumulate = False
+            ref_res = compute_index_put_ref(
+                x_np, indices_np, value_np, accumulate
+            )
+            pd_res = paddle.index_put(x_pd, indices_pd, value_pd, accumulate)
+            np.testing.assert_allclose(ref_res, pd_res.numpy(), atol=1e-7)
+
+            # check grad
+            pd_res.sum().backward()
+            np.testing.assert_allclose(x_pd.grad.shape, x_pd.shape)
+            np.testing.assert_allclose(
+                value_pd.grad.numpy(), np.zeros(value_pd.shape)
+            )
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->
index_put 输出维度和输入维度相同，反向 value 参数填充0, x numel为0不填充
torch 测试反向
```
args = []
# x
args.append(paddle.randn([10, 0]))
# index
args.append([paddle.to_tensor([-4, -9, -7, -3, -8, -8,  0, -1, -6,  2], dtype=paddle.int64)])
# value
args.append(paddle.randn([1, 1]))
args.append(False)
args[2].stop_gradient=False
args[0].stop_gradient=False
result = paddle.index_put(*args)
result.sum().backward()
print(args[2].grad)

Tensor(shape=[1, 1], dtype=float32, place=Place(gpu:0), stop_gradient=False,
       [[0.]])
```

PaddleAPITest 测试numpy error，其他通过
![image](https://github.com/user-attachments/assets/a3519f77-8f2f-47c6-9daf-373d4780dc2f)
