### PR TITLE
[SOT] Check without graph for fallback code only

### DIFF
--- a/paddle/fluid/pybind/sot/eval_frame.c
+++ b/paddle/fluid/pybind/sot/eval_frame.c
@@ -321,14 +321,10 @@ static PyObject *_custom_eval_frame(PyThreadState *tstate,
 #endif
 
   // code status
-  if (is_code_without_graph(code == Py_None ? PyFrame_GET_CODE(frame)
-                                            : (PyCodeObject *)code) &&
-      disable_eval_frame == Py_False) {
-    out = eval_frame_default(tstate, frame, throw_flag);
-    eval_frame_callback_set(callback);
-    Py_DECREF(code);
+  if (code == Py_None && is_code_without_graph(PyFrame_GET_CODE(frame))) {
     Py_DECREF(disable_eval_frame);
-    return out;
+    disable_eval_frame = Py_True;
+    Py_INCREF(disable_eval_frame);
   }
 
   // run code


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

我们目前有一个策略，就是针对一个 code，如果连续多次都没有感知到其内有 graph，就直接回退到动态图，这个目前主要针对的应该是有 fallback 的场景，而对于非 fallback，也就是生成了 code 的场景，一般不会没有 graph，就算没有，也应该是在新的 code 里处理而不是在这里

目前处理方式是有问题的，`StepInfoManager` 是为每个 original code 来记录 step count，但实际记录的分别如下：

- 对于 fallback 场景，当然会为 original code 标记是否有 graph，因为 fallback 回 original code 了，其内的函数会去标记这件事
- 对于非 fallback 场景，**是会为生成的 code 标记是否有 graph**，因为实际执行的是这个，而不是 original code

这里两者 step 记录的不匹配导致出现如下问题

- original code 在第一轮编译了一个 new code 1，之后跑了 20 次，new code 1 在第一轮就被标记为有图了
- 接着 original code 在第 21 轮编译了一个 new code 2，由于 original code 已经跑了 20 轮，所以不会再记录是否有图，new code 2 没有机会再记录为有图，10 轮后直接 fallback 回动态图

这里问题只出现在非 fallback 的情况，fallback 的情况因为记录的 code 是统一的，因此不会出问题

而非 fallback 的情况已经生成 code 了，一般不会没有 graph，因此本 PR 移除对该 case 的处理，仅针对 fallback case

<!-- PCard-66972 -->