### PR TITLE
[0-size Tensor Job2 No.69、93] Add 0-size Tensor support for prod

### DIFF
--- a/paddle/phi/kernels/cpu/prod_kernel.cc
+++ b/paddle/phi/kernels/cpu/prod_kernel.cc
@@ -17,6 +17,7 @@
 #include "paddle/phi/common/complex.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/cpu/reduce.h"
+#include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/funcs/reduce_functor.h"
 
 namespace phi {
@@ -28,6 +29,13 @@ void ProdKernel(const Context& dev_ctx,
                 bool keep_dim,
                 bool reduce_all,
                 DenseTensor* out) {
+  if (x.numel() == 0) {
+    // fill with 1.
+    phi::Full<T, Context>(
+        dev_ctx, phi::IntArray(common::vectorize(out->dims())), 1, out);
+    return;
+  }
+
   reduce_all = recompute_reduce_all(x, dims, reduce_all);
   auto out_dtype = x.dtype();
   phi::Reduce<CPUContext, T, phi::funcs::ProdFunctor>(

--- a/paddle/phi/kernels/impl/prod_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/prod_grad_kernel_impl.h
@@ -30,6 +30,10 @@ void ProdGradKernel(const Context& dev_ctx,
                     bool keep_dim,
                     bool reduce_all,
                     DenseTensor* x_grad) {
+  if (x_grad && x_grad->numel() == 0) {
+    dev_ctx.template Alloc<T>(x_grad);
+    return;
+  }
   reduce_all = recompute_reduce_all(x, dims, reduce_all);
   ReduceGradKernel<Context, T, funcs::ProdGradFunctor>(
       dev_ctx, x, out, out_grad, dims.GetData(), keep_dim, reduce_all, x_grad);

--- a/paddle/phi/kernels/kps/reduce_kernel.cu
+++ b/paddle/phi/kernels/kps/reduce_kernel.cu
@@ -45,6 +45,13 @@ void ProdKernel(const Context& dev_ctx,
                 bool keep_dim,
                 bool reduce_all,
                 DenseTensor* out) {
+  if (x.numel() == 0) {
+    // fill with 1.
+    phi::Full<T, Context>(
+        dev_ctx, phi::IntArray(common::vectorize(out->dims())), 1, out);
+    return;
+  }
+
   reduce_all = recompute_reduce_all(x, dims, reduce_all);
   auto out_dtype = x.dtype();
   phi::Reduce<T, kps::MulFunctor, kps::IdentityFunctor>(

--- a/paddle/phi/kernels/xpu/prod_kernel.cc
+++ b/paddle/phi/kernels/xpu/prod_kernel.cc
@@ -17,6 +17,7 @@
 #include "paddle/phi/backends/xpu/enforce_xpu.h"
 #include "paddle/phi/backends/xpu/xpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/xpu/reduce.h"
 
 namespace phi {
@@ -28,6 +29,12 @@ void ProdKernel(const Context& dev_ctx,
                 bool keep_dim,
                 bool reduce_all,
                 DenseTensor* out) {
+  if (x.numel() == 0) {
+    phi::Full<T, Context>(
+        dev_ctx, phi::IntArray(common::vectorize(out->dims())), 1, out);
+    return;
+  }
+
   reduce_all = recompute_reduce_all(x, dims, reduce_all);
   using XPUType = typename XPUTypeTrait<T>::Type;
 

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -5012,6 +5012,10 @@ def prod(
         if x.dtype != convert_np_dtype_to_dtype_(dtype):
             x = cast(x, dtype)
 
+    # axis is 0-size tensor.
+    if paddle.is_tensor(axis) and axis.shape == [0]:
+        return x
+
     reduce_all, axis = _get_reduce_axis_with_tensor(axis, x)
     if in_dynamic_or_pir_mode():
         return _C_ops.prod(x, axis, keepdim, reduce_all)

--- a/test/legacy_test/test_prod_op.py
+++ b/test/legacy_test/test_prod_op.py
@@ -277,5 +277,39 @@ class TestProdWithTensorAxis2(TestReduceOPTensorAxisBase):
         ]
 
 
+class TestProdOp_ZeroSize(unittest.TestCase):
+    def setUp(self):
+        self.input = np.random.random(size=(10, 0, 5)).astype(np.float32)
+
+    def run_imperative(self, place):
+        input = paddle.to_tensor(self.input, place=place)
+        input.stop_gradient = False
+        out = paddle.prod(input)
+        expected_result = np.prod(self.input)
+        np.testing.assert_allclose(out.numpy(), expected_result, rtol=1e-05)
+        out.sum().backward()
+        np.testing.assert_allclose(input.grad.numpy(), expected_result)
+
+    def test_cpu(self):
+        with dygraph_guard():
+            self.run_imperative(place=paddle.CPUPlace())
+
+    def test_gpu(self):
+        if not paddle.base.core.is_compiled_with_cuda():
+            return
+        with dygraph_guard():
+            self.run_imperative(place=paddle.CUDAPlace(0))
+
+
+class TestProdOp_ZeroSize2(TestProdOp_ZeroSize):
+    def setUp(self):
+        self.input = np.random.random(size=(10, 1, 5)).astype(np.float32)
+
+    def run_imperative(self, place):
+        input = paddle.to_tensor(self.input, place=place)
+        out = paddle.prod(input, paddle.randn([0]).astype(paddle.int32))
+        np.testing.assert_allclose(out.numpy(), input.numpy())
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/legacy_test/test_prod_op.py
+++ b/test/legacy_test/test_prod_op.py
@@ -288,7 +288,7 @@ class TestProdOp_ZeroSize(unittest.TestCase):
         expected_result = np.prod(self.input)
         np.testing.assert_allclose(out.numpy(), expected_result, rtol=1e-05)
         out.sum().backward()
-        np.testing.assert_allclose(input.grad.numpy(), expected_result)
+        np.testing.assert_allclose(input.grad.shape, input.shape)
 
     def test_cpu(self):
         with dygraph_guard():


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->
torch 返回使用1填充
```
import torch
out = torch.prod(torch.randn([2,0,3]))
print(out)

tensor(1.)
```

python/paddle/tensor/math.py 修改判断axis如果为Tensor并且shape为[0]，返回x，PaddleAPITest中是循环axis计算，返回实际也是x
https://github.com/PFCCLab/PaddleAPITest/blob/8211bf81028e55b5294b44f097d0a6ea39829bee/tester/paddle_to_torch/rules.py#L4288
![image](https://github.com/user-attachments/assets/54dce341-20e0-41d2-b4e4-4f5a11dc2292)
![image](https://github.com/user-attachments/assets/bc0c3de5-eed3-4a83-bd4b-a829892e7701)

PaddleAPITest测试通过
![image](https://github.com/user-attachments/assets/8a03dba3-27d0-41ab-bae1-50a9a4912595)
