### PR TITLE
[Accuracy diff No.112] Fix accuracy diff for paddle.nn.functional.conv1d API

### DIFF
--- a/test/legacy_test/test_functional_conv1d.py
+++ b/test/legacy_test/test_functional_conv1d.py
@@ -82,5 +82,31 @@ class TestFunctionalConv1DErrorCase2(TestFunctionalConv1DError):
         self.data_format = "NCL"
 
 
+class TestFunctionalConv1D_CPU_FP16(TestCase):
+    def setUp(self):
+        self.padding = 0
+        self.stride = 1
+        self.dilation = 1
+        self.groups = 1
+        self.data_format = "NCL"
+
+    def test_cpu_fp16(self):
+        with dg.guard(paddle.CPUPlace()):
+            x = paddle.ones([1, 1, 1])
+            w = paddle.ones([1, 1, 1]).astype(paddle.float16)
+            b = paddle.ones([1]).astype(paddle.float16)
+            y = F.conv1d(
+                x,
+                w,
+                b,
+                padding=self.padding,
+                stride=self.stride,
+                dilation=self.dilation,
+                groups=self.groups,
+                data_format=self.data_format,
+            )
+            np.testing.assert_allclose(y.numpy(), [[[2]]])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->

https://github.com/PFCCLab/PaddleAPITest/pull/306

PaddleAPITest 测试
```
paddle.nn.functional.conv1d(Tensor([8, 400, 100],"float32"), Tensor([256, 100, 3],"float16"), bias=Tensor([256],"float16"), padding=1, stride=list[1,], dilation=list[1,], groups=4, data_format="NCL", )
```
paddle.nn.functional.conv1d CPU 不支持float16，需要转换weight bias 类型float16 到float32 ，同时结果类型为float16

