### PR TITLE
[CINN] Fix bug of test_trilinear_interp_v2_op unittest 

### DIFF
--- a/test/legacy_test/test_trilinear_interp_v2_op.py
+++ b/test/legacy_test/test_trilinear_interp_v2_op.py
@@ -595,7 +595,9 @@ class TestNearestInterpOpBF16(OpTest):
         self.outputs = {'Out': convert_float_to_uint16(output_np)}
 
     def test_check_output(self):
-        self.check_output(check_pir=True)
+        self.check_output(
+            check_pir=True, check_symbol_infer=(self.out_size is None)
+        )
 
     def test_check_grad(self):
         self.check_grad(['X'], 'Out', in_place=True, check_pir=True)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164

修复`test_trilinear_interp_v2_op` 如下报错：

![image](https://github.com/user-attachments/assets/fcbede24-651f-44d1-8f14-9b3c7c6e57c7)
