### PR TITLE
Fix bug in bit_count and moe_gate_permute.

### DIFF
--- a/paddle/phi/infermeta/ternary.cc
+++ b/paddle/phi/infermeta/ternary.cc
@@ -1818,16 +1818,6 @@ void MoeGateDispatchPermuteInferMeta(const MetaTensor& x,
             "dimensions of Input(corr_bias) is [%d]",
             corr_bias_dims.size()));
     PADDLE_ENFORCE_EQ(
-        corr_bias_dims[0],
-        x_dims[0],
-        common::errors::InvalidArgument(
-            "The dimensions of Input(corr_bias) must be equal to the first "
-            "dimension of Input(x), but received Input(corr_bias) first "
-            "dimension is [%d],"
-            "Input(x) first dimension is [%d]",
-            corr_bias_dims[0],
-            x_dims[0]));
-    PADDLE_ENFORCE_EQ(
         corr_bias.dtype(),
         paddle::DataType::FLOAT32,
         common::errors::InvalidArgument(

--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -6376,17 +6376,11 @@ void IntBincountInferMeta(const MetaTensor& x,
                           int64_t high,
                           int64_t dtype,
                           MetaTensor* out) {
-  PADDLE_ENFORCE_EQ(
-      x.dims().size(),
-      1,
-      errors::InvalidArgument(
-          "The input 'x' of int_bincount must be a 1-D Tensor, but got %u-D.",
-          x.dims().size()));
   PADDLE_ENFORCE_GT(
       high,
       low,
       errors::InvalidArgument("Attr high (%d) must be > low (%d).", high, low));
-  int64_t bin_count = high - low + 1;
+  int64_t bin_count = high - low;
 
   out->set_dims(phi::make_ddim({bin_count}));
   out->set_dtype(x.dtype());


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修复bit_count和moe_gate_dispatch_permute问题：
**1. bit_count 相关问题:**
- 输入x可以是二维情况，paddle infermeta中添加了额外的约束：x只能为1维，导致模型运行错误：<img width="1260" alt="image" src="https://github.com/user-attachments/assets/019f130b-057b-4761-a2c9-c2fc45397d29" />

- 输出形状信息推导存在错误，导致后续算子infermeta出错，这里对齐eb中自定义算子shape推导信息：<img width="424" alt="image" src="https://github.com/user-attachments/assets/49a05b6b-2b53-4931-a496-82bb6c1a6c66" />

**2. moe_gate_dispatch_permute 问题：**
- inferMeta中存在错误约束，当存在可选输入corr_bias时，其shape[0]应对齐**专家数**即gate_logits.shape[1]，而不是x_dims[0]，因此导致模型报错：<img width="1442" alt="image" src="https://github.com/user-attachments/assets/00cd0497-d309-42c7-ae11-e9611440327e" />

- TODO：模型输出类型并未对齐eb算子（应对齐输入x类型输出bf16，实际输出fp32，导致后续算子infermeta出错），未在infermeta中发现错误，暂时在组网中添加cast绕过：<img width="794" alt="image" src="https://github.com/user-attachments/assets/6c5bf253-4ebf-480e-a6f7-b2233e7f7360" />

pcard-67164