### PR TITLE
[SOT] Add fine gate side effects changed check for dict like proxy data

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
@@ -2475,7 +2475,7 @@ class DataClassInstanceVariable(VariableBase):
         return VariableFactory.from_value(
             proxy.original_data[key],
             self.graph,
-            tracker=GetAttrTracker(self, key, changed=proxy.has_changed),
+            tracker=GetAttrTracker(self, key, changed=proxy.check_changed(key)),
         )
 
     def get_py_type(self):

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/container.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/container.py
@@ -199,7 +199,7 @@ class ListVariable(ContainerVariable):
         return VariableFactory.from_value(
             proxy.original_data[key],
             self.graph,
-            tracker=GetItemTracker(self, key, changed=proxy.has_changed),
+            tracker=GetItemTracker(self, key, changed=proxy.check_changed(key)),
         )
 
     def get_py_value(self, allow_tensor=False):
@@ -249,7 +249,7 @@ class ListVariable(ContainerVariable):
                 items[key],
                 self.graph,
                 tracker=GetItemTracker(
-                    self, key, changed=self.proxy.has_changed
+                    self, key, changed=self.proxy.check_changed(key)
                 ),
             )
         else:
@@ -870,7 +870,7 @@ class DictVariable(ContainerVariable):
         return VariableFactory.from_value(
             proxy.original_data[key],
             self.graph,
-            tracker=GetItemTracker(self, key, changed=proxy.has_changed),
+            tracker=GetItemTracker(self, key, changed=proxy.check_changed(key)),
         )
 
     def get_py_value(self, allow_tensor=False):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

#73469 修改 `parameters`/`buffers`/`sub_layers` 从原来直接访问 attribute 变成了从 `_parameters` 等 dict 上访问，这导致了部分模型生成的 side effect 恢复代码出问题：

```python

class ReadBufferAfterChanged(paddle.nn.Layer):
    def __init__(self):
        super().__init__()
        self.buffer1 = paddle.to_tensor(1)
        self.buffer2 = paddle.to_tensor(2)

    def forward(self, x):
        self.buffer1 += 1
        return x + self.buffer1 + self.buffer2

    def __eq__(self, other):
        if not isinstance(other, ReadBufferAfterChanged):
            return False
        return paddle.equal(self.buffer1, other.buffer1) and paddle.equal(
            self.buffer2, other.buffer2
        )
```

以单测中的 case 为例，这里对 `self._buffers["buffer1"]` 修改后使得 `self._buffers` 处于 `changed` 的状态（PaddlePaddle/PaddleSOT#274 引入），因此后续读取的 `self._buffers["buffer2"]` tracker 将会是不可信的，会变成不可 traceable 的

这导致了在最终生成的 side effect 代码中，认为 buffer2 non-traceable，因此会**从图上根据 `___SIR_out_xxx` 来 load**，而它的 tracker 又不是 `DummyTracker`，又不会当成子图输出 store 到 `___SIR_out_xxx`，结果就出错了

这里实际上 buffer2 并没有改过，它应该是 traceable 的，但是因为我们现在判断 changed 粒度不够细，导致了这个问题

对于 `DictLikeMutableData` 来说，每个 key 都是独立的容器，我们完全可以感知到哪个 key 发生了变动，如果该 key 没有发生变动，那么就不需要认为是 changed，本 PR 实现了这一点

而 `ListLikeMutableData` 则会复杂些，本 PR 并没有修改，仍然会是粗粒度的感知，这可能会导致后续仍然会有问题，后续仍然需要优化

<!-- PCard-66972 -->