### PR TITLE
[0-size Tensor Job2 No.12] Add 0-size Tensor support for paddle.full

### DIFF
--- a/python/paddle/utils/layers_utils.py
+++ b/python/paddle/utils/layers_utils.py
@@ -483,7 +483,15 @@ def convert_shape_to_list(shape):
     Convert shape(list, tuple, variable) to list in imperative mode
     """
     if isinstance(shape, (list, tuple)):
-        shape = [x.item(0) if isinstance(x, Variable) else x for x in shape]
+        shape_out = []
+        for x in shape:
+            if isinstance(x, Variable):
+                # skip item if size = 0
+                if x.size > 0:
+                    shape_out.append(x.item(0))
+            else:
+                shape_out.append(x)
+        shape = shape_out
     else:
         if in_dygraph_mode():
             shape = shape.astype(int).tolist()

--- a/test/legacy_test/test_fill_constant_op.py
+++ b/test/legacy_test/test_fill_constant_op.py
@@ -553,6 +553,21 @@ class TestFillConstantOp_ValueTensorBf16(OpTest):
         )
 
 
+class TestFillConstantOp_ZeroSize(unittest.TestCase):
+
+    def test_shape(self):
+        out = paddle.full(
+            shape=[
+                paddle.to_tensor([1]),
+                paddle.to_tensor([1]),
+                paddle.to_tensor([]),
+            ],
+            fill_value=1.0,
+        )
+        out_np = out.numpy()
+        np.testing.assert_allclose(out_np, np.ones([1, 1]).astype(out_np.dtype))
+
+
 if __name__ == "__main__":
     paddle.enable_static()
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->
paddle.full 如果输入shape为Tensor包含0-size，需要在python端转换时忽略
修改 convert_shape_to_list 函数，kernel不用修改

PaddleAPITest 测试通过
![image](https://github.com/user-attachments/assets/1e3f8e80-6166-400c-a30a-9f2c77b100dc)

PaddleAPITest配置文件
report/0size_tensor_gpu/error_config.txt
report/0size_tensor_cpu/error_config.txt
