### PR TITLE
Dygraph PIR check cuda error

### DIFF
--- a/paddle/common/flags.cc
+++ b/paddle/common/flags.cc
@@ -2132,3 +2132,14 @@ PHI_DEFINE_EXPORTED_int32(
     "Version 2 requires Ampere architecture or higher, "
     "while version 3 requires Hopper architecture.");
 #endif
+
+/**
+ * Operator related FLAG
+ * Name: FLAGS_check_cuda_error
+ * Value Range: bool, default=false
+ * Example:
+ * Note: Used to debug. Checking whether CUDA error occurred or not.
+ */
+PHI_DEFINE_EXPORTED_bool(check_cuda_error,
+                         false,
+                         "Checking whether CUDA error occurred or not.");

--- a/paddle/fluid/eager/api/manual/eager_manual/forwards/add_n_fwd_func.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/forwards/add_n_fwd_func.cc
@@ -26,7 +26,7 @@ COMMON_DECLARE_bool(check_cuda_error);
 paddle::Tensor add_n_ad_func(const std::vector<paddle::Tensor>& x) {
   VLOG(3) << "Running AD API: "
           << "add_n";
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     egr::CUDAErrorCheck("add_n_ad_func begin");
   }
   // Dygraph Record Event
@@ -113,7 +113,7 @@ paddle::Tensor add_n_ad_func(const std::vector<paddle::Tensor>& x) {
     // Set TensorWrappers for Forward Outputs if needed
   }
 
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     egr::CUDAErrorCheck("add_n_ad_func finish");
   }
 

--- a/paddle/fluid/eager/api/manual/eager_manual/forwards/add_n_fwd_func.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/forwards/add_n_fwd_func.cc
@@ -21,8 +21,14 @@
 #include "paddle/phi/core/platform/profiler/event_tracing.h"
 
 COMMON_DECLARE_bool(check_nan_inf);
+COMMON_DECLARE_bool(check_cuda_error);
 
 paddle::Tensor add_n_ad_func(const std::vector<paddle::Tensor>& x) {
+  VLOG(3) << "Running AD API: "
+          << "add_n";
+  if (FLAGS_check_cuda_error) {
+    egr::CUDAErrorCheck("add_n_ad_func begin");
+  }
   // Dygraph Record Event
   phi::RecordEvent dygraph_entrance_record_event(
       "add_n dygraph", phi::TracerEventType::Operator, 1);
@@ -105,6 +111,10 @@ paddle::Tensor add_n_ad_func(const std::vector<paddle::Tensor>& x) {
     }
     grad_node->SetGradInMeta(out, 0);
     // Set TensorWrappers for Forward Outputs if needed
+  }
+
+  if (FLAGS_check_cuda_error) {
+    egr::CUDAErrorCheck("add_n_ad_func finish");
   }
 
   // Returns

--- a/paddle/fluid/eager/api/manual/eager_manual/forwards/conv2d_fwd_function.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/forwards/conv2d_fwd_function.cc
@@ -34,7 +34,7 @@ paddle::Tensor conv2d_ad_func(const paddle::Tensor& input,
                               std::string data_format) {
   VLOG(3) << "Running AD API: "
           << "conv2d";
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     egr::CUDAErrorCheck("conv2d_ad_func begin");
   }
   // Dygraph Record Event
@@ -173,7 +173,7 @@ paddle::Tensor conv2d_ad_func(const paddle::Tensor& input,
     // Set TensorWrappers for Forward Outputs if needed
   }
 
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     egr::CUDAErrorCheck("conv2d_ad_func finish");
   }
   // Returns

--- a/paddle/fluid/eager/api/manual/eager_manual/forwards/conv2d_fwd_function.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/forwards/conv2d_fwd_function.cc
@@ -22,6 +22,7 @@
 #include "paddle/phi/core/platform/profiler/event_tracing.h"
 
 COMMON_DECLARE_bool(check_nan_inf);
+COMMON_DECLARE_bool(check_cuda_error);
 
 paddle::Tensor conv2d_ad_func(const paddle::Tensor& input,
                               const paddle::Tensor& filter,
@@ -31,6 +32,11 @@ paddle::Tensor conv2d_ad_func(const paddle::Tensor& input,
                               std::vector<int> dilations,
                               int groups,
                               std::string data_format) {
+  VLOG(3) << "Running AD API: "
+          << "conv2d";
+  if (FLAGS_check_cuda_error) {
+    egr::CUDAErrorCheck("conv2d_ad_func begin");
+  }
   // Dygraph Record Event
   phi::RecordEvent dygraph_entrance_record_event(
       "conv2d dygraph", phi::TracerEventType::Operator, 1);
@@ -167,6 +173,9 @@ paddle::Tensor conv2d_ad_func(const paddle::Tensor& input,
     // Set TensorWrappers for Forward Outputs if needed
   }
 
+  if (FLAGS_check_cuda_error) {
+    egr::CUDAErrorCheck("conv2d_ad_func finish");
+  }
   // Returns
   return out;
 }

--- a/paddle/fluid/eager/api/manual/eager_manual/forwards/dtensor_from_local_fwd_func.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/forwards/dtensor_from_local_fwd_func.cc
@@ -29,7 +29,7 @@ paddle::Tensor dtensor_from_local_ad_function(
 #ifdef PADDLE_WITH_DISTRIBUTE
   VLOG(3) << "Running AD API: "
           << "dtensor_from_local dygraph";
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     egr::CUDAErrorCheck("dtensor_from_local_ad_function begin");
   }
 
@@ -105,7 +105,7 @@ paddle::Tensor dtensor_from_local_ad_function(
     grad_node->SetGradInMeta(out, 0);
     grad_node->SetTensorWrapperNoNeedBuffer_Output(out);
   }
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     egr::CUDAErrorCheck("dtensor_from_local_ad_function finish");
   }
   return out;

--- a/paddle/fluid/eager/api/manual/eager_manual/forwards/dtensor_from_local_fwd_func.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/forwards/dtensor_from_local_fwd_func.cc
@@ -20,6 +20,8 @@
 #include "paddle/phi/core/distributed/auto_parallel/reshard/reshard_utils.h"
 #include "paddle/phi/core/platform/profiler/event_tracing.h"
 
+COMMON_DECLARE_bool(check_cuda_error);
+
 paddle::Tensor dtensor_from_local_ad_function(
     const paddle::Tensor& input,
     const phi::distributed::ProcessMesh& process_mesh,
@@ -27,6 +29,10 @@ paddle::Tensor dtensor_from_local_ad_function(
 #ifdef PADDLE_WITH_DISTRIBUTE
   VLOG(3) << "Running AD API: "
           << "dtensor_from_local dygraph";
+  if (FLAGS_check_cuda_error) {
+    egr::CUDAErrorCheck("dtensor_from_local_ad_function begin");
+  }
+
   if (input.is_dist_tensor()) {
     VLOG(3) << "Input is a distributed tensor, no need to convert.";
     return input;
@@ -99,7 +105,9 @@ paddle::Tensor dtensor_from_local_ad_function(
     grad_node->SetGradInMeta(out, 0);
     grad_node->SetTensorWrapperNoNeedBuffer_Output(out);
   }
-
+  if (FLAGS_check_cuda_error) {
+    egr::CUDAErrorCheck("dtensor_from_local_ad_function finish");
+  }
   return out;
 #else
   PADDLE_THROW(common::errors::Unavailable(

--- a/paddle/fluid/eager/api/manual/eager_manual/forwards/dtensor_to_local_fwd_func.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/forwards/dtensor_to_local_fwd_func.cc
@@ -27,7 +27,7 @@ paddle::Tensor dtensor_to_local_ad_function(
 #ifdef PADDLE_WITH_DISTRIBUTE
   VLOG(3) << "Running AD API: "
           << "dtensor_to_local dygraph";
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     egr::CUDAErrorCheck("dtensor_to_local_ad_function begin");
   }
   bool rank_is_in_current_mesh = phi::distributed::IsCurRankInMesh(
@@ -127,7 +127,7 @@ paddle::Tensor dtensor_to_local_ad_function(
     }
     grad_node->SetGradInMeta(out, 0);
   }
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     egr::CUDAErrorCheck("dtensor_to_local_ad_function finish");
   }
   return out;

--- a/paddle/fluid/eager/api/manual/eager_manual/forwards/dtensor_to_local_fwd_func.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/forwards/dtensor_to_local_fwd_func.cc
@@ -18,6 +18,8 @@
 #include "paddle/fluid/eager/api/utils/global_utils.h"
 #include "paddle/phi/core/platform/profiler/event_tracing.h"
 
+COMMON_DECLARE_bool(check_cuda_error);
+
 paddle::Tensor dtensor_to_local_ad_function(
     const paddle::Tensor& input,
     const phi::distributed::ProcessMesh& process_mesh,
@@ -25,6 +27,9 @@ paddle::Tensor dtensor_to_local_ad_function(
 #ifdef PADDLE_WITH_DISTRIBUTE
   VLOG(3) << "Running AD API: "
           << "dtensor_to_local dygraph";
+  if (FLAGS_check_cuda_error) {
+    egr::CUDAErrorCheck("dtensor_to_local_ad_function begin");
+  }
   bool rank_is_in_current_mesh = phi::distributed::IsCurRankInMesh(
       static_cast<phi::distributed::DistTensor*>(input.impl().get())
           ->process_mesh());
@@ -122,7 +127,9 @@ paddle::Tensor dtensor_to_local_ad_function(
     }
     grad_node->SetGradInMeta(out, 0);
   }
-
+  if (FLAGS_check_cuda_error) {
+    egr::CUDAErrorCheck("dtensor_to_local_ad_function finish");
+  }
   return out;
 #else
   PADDLE_THROW(common::errors::Unavailable(

--- a/paddle/fluid/eager/api/manual/eager_manual/forwards/multiply_fwd_func.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/forwards/multiply_fwd_func.cc
@@ -26,6 +26,7 @@
 #include "paddle/phi/core/platform/profiler/event_tracing.h"
 
 COMMON_DECLARE_bool(check_nan_inf);
+COMMON_DECLARE_bool(check_cuda_error);
 
 bool check_if_support_elementwise_mul_mem_opt(const std::string& device_type) {
   // TODO(@gexiao): replace this function with api implemented at custom repo
@@ -41,6 +42,9 @@ paddle::Tensor multiply_ad_func(const paddle::Tensor& x,
   FLAGS_tensor_operants_mode = "eager";
   VLOG(3) << "Running AD API: "
           << "multiply";
+  if (FLAGS_check_cuda_error) {
+    egr::CUDAErrorCheck("multiply_ad_func begin");
+  }
   // Dygraph Record Event
   phi::RecordEvent dygraph_entrance_record_event(
       "multiply dygraph", phi::TracerEventType::Operator, 1);
@@ -229,7 +233,9 @@ paddle::Tensor multiply_ad_func(const paddle::Tensor& x,
     VLOG(4) << paddle::string::Sprintf(
         INPUT_PRINT_TEMPLATE, input_str, output_str);
   }
-
+  if (FLAGS_check_cuda_error) {
+    egr::CUDAErrorCheck("multiply_ad_func finish");
+  }
   // Returns
   return out;
 }
@@ -239,6 +245,9 @@ paddle::Tensor& multiply__ad_func(paddle::Tensor& x,  // NOLINT
   FLAGS_tensor_operants_mode = "eager";
   VLOG(3) << "Running AD API: "
           << "multiply_";
+  if (FLAGS_check_cuda_error) {
+    egr::CUDAErrorCheck("multiply__ad_func begin");
+  }
   // Dygraph Record Event
   phi::RecordEvent dygraph_entrance_record_event(
       "multiply_ dygraph", phi::TracerEventType::Operator, 1);
@@ -400,6 +409,9 @@ paddle::Tensor& multiply__ad_func(paddle::Tensor& x,  // NOLINT
         INPUT_PRINT_TEMPLATE, input_str, output_str);
   }
 
+  if (FLAGS_check_cuda_error) {
+    egr::CUDAErrorCheck("multiply__ad_func finish");
+  }
   // Returns
   return out;
 }
@@ -411,6 +423,9 @@ paddle::Tensor multiply_ad_func(const paddle::Tensor& x,
   FLAGS_tensor_operants_mode = "eager";
   VLOG(3) << "Running AD API: "
           << "multiply";
+  if (FLAGS_check_cuda_error) {
+    egr::CUDAErrorCheck("sparse::multiply_ad_func begin");
+  }
   // Dygraph Record Event
   phi::RecordEvent dygraph_entrance_record_event(
       "multiply dygraph", phi::TracerEventType::Operator, 1);
@@ -578,7 +593,9 @@ paddle::Tensor multiply_ad_func(const paddle::Tensor& x,
     VLOG(4) << paddle::string::Sprintf(
         INPUT_PRINT_TEMPLATE, input_str, output_str);
   }
-
+  if (FLAGS_check_cuda_error) {
+    egr::CUDAErrorCheck("sparse::multiply_ad_func finish");
+  }
   // Returns
   return out;
 }

--- a/paddle/fluid/eager/api/manual/eager_manual/forwards/multiply_fwd_func.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/forwards/multiply_fwd_func.cc
@@ -42,7 +42,7 @@ paddle::Tensor multiply_ad_func(const paddle::Tensor& x,
   FLAGS_tensor_operants_mode = "eager";
   VLOG(3) << "Running AD API: "
           << "multiply";
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     egr::CUDAErrorCheck("multiply_ad_func begin");
   }
   // Dygraph Record Event
@@ -233,7 +233,7 @@ paddle::Tensor multiply_ad_func(const paddle::Tensor& x,
     VLOG(4) << paddle::string::Sprintf(
         INPUT_PRINT_TEMPLATE, input_str, output_str);
   }
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     egr::CUDAErrorCheck("multiply_ad_func finish");
   }
   // Returns
@@ -245,7 +245,7 @@ paddle::Tensor& multiply__ad_func(paddle::Tensor& x,  // NOLINT
   FLAGS_tensor_operants_mode = "eager";
   VLOG(3) << "Running AD API: "
           << "multiply_";
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     egr::CUDAErrorCheck("multiply__ad_func begin");
   }
   // Dygraph Record Event
@@ -409,7 +409,7 @@ paddle::Tensor& multiply__ad_func(paddle::Tensor& x,  // NOLINT
         INPUT_PRINT_TEMPLATE, input_str, output_str);
   }
 
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     egr::CUDAErrorCheck("multiply__ad_func finish");
   }
   // Returns
@@ -423,7 +423,7 @@ paddle::Tensor multiply_ad_func(const paddle::Tensor& x,
   FLAGS_tensor_operants_mode = "eager";
   VLOG(3) << "Running AD API: "
           << "multiply";
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     egr::CUDAErrorCheck("sparse::multiply_ad_func begin");
   }
   // Dygraph Record Event
@@ -593,7 +593,7 @@ paddle::Tensor multiply_ad_func(const paddle::Tensor& x,
     VLOG(4) << paddle::string::Sprintf(
         INPUT_PRINT_TEMPLATE, input_str, output_str);
   }
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     egr::CUDAErrorCheck("sparse::multiply_ad_func finish");
   }
   // Returns

--- a/paddle/fluid/eager/api/manual/eager_manual/forwards/reshard_fwd_func.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/forwards/reshard_fwd_func.cc
@@ -18,12 +18,17 @@
 #include "paddle/fluid/eager/api/utils/global_utils.h"
 #include "paddle/phi/core/platform/profiler/event_tracing.h"
 
+COMMON_DECLARE_bool(check_cuda_error);
+
 paddle::Tensor reshard_ad_function(
     const paddle::Tensor& input,
     const phi::distributed::TensorDistAttr dist_attr) {
 #ifdef PADDLE_WITH_DISTRIBUTE
   VLOG(3) << "Running AD API: "
           << "reshard dygraph";
+  if (FLAGS_check_cuda_error) {
+    egr::CUDAErrorCheck("reshard_ad_function begin");
+  }
   // Dygraph Record Event
   phi::RecordEvent dygraph_entrance_record_event(
       "reshard dygraph", phi::TracerEventType::Communication, 1);
@@ -75,7 +80,9 @@ paddle::Tensor reshard_ad_function(
     }
     grad_node->SetGradInMeta(out, 0);
   }
-
+  if (FLAGS_check_cuda_error) {
+    egr::CUDAErrorCheck("reshard_ad_function finish");
+  }
   return out;
 #else
   PADDLE_THROW(common::errors::Unavailable(

--- a/paddle/fluid/eager/api/manual/eager_manual/forwards/reshard_fwd_func.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/forwards/reshard_fwd_func.cc
@@ -26,7 +26,7 @@ paddle::Tensor reshard_ad_function(
 #ifdef PADDLE_WITH_DISTRIBUTE
   VLOG(3) << "Running AD API: "
           << "reshard dygraph";
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     egr::CUDAErrorCheck("reshard_ad_function begin");
   }
   // Dygraph Record Event
@@ -80,7 +80,7 @@ paddle::Tensor reshard_ad_function(
     }
     grad_node->SetGradInMeta(out, 0);
   }
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     egr::CUDAErrorCheck("reshard_ad_function finish");
   }
   return out;

--- a/paddle/fluid/eager/api/manual/eager_manual/forwards/sync_batch_norm_fwd_func.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/forwards/sync_batch_norm_fwd_func.cc
@@ -46,7 +46,7 @@ sync_batch_norm__ad_func(const paddle::Tensor& x,
   FLAGS_tensor_operants_mode = "eager";
   VLOG(3) << "Running AD API: "
           << "sync_batch_norm_";
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     egr::CUDAErrorCheck("sync_batch_norm__ad_func begin");
   }
   // Dygraph Record Event
@@ -356,7 +356,7 @@ sync_batch_norm__ad_func(const paddle::Tensor& x,
     VLOG(4) << paddle::string::Sprintf(
         INPUT_PRINT_TEMPLATE, input_str, output_str);
   }
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     egr::CUDAErrorCheck("sync_batch_norm__ad_func finish");
   }
   // Returns
@@ -391,7 +391,7 @@ sync_batch_norm__ad_func(const paddle::Tensor& x,
   FLAGS_tensor_operants_mode = "eager";
   VLOG(3) << "Running AD API: "
           << "sync_batch_norm_";
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     egr::CUDAErrorCheck("sparse::sync_batch_norm__ad_func begin");
   }
   // Dygraph Record Event
@@ -695,7 +695,7 @@ sync_batch_norm__ad_func(const paddle::Tensor& x,
     VLOG(4) << paddle::string::Sprintf(
         INPUT_PRINT_TEMPLATE, input_str, output_str);
   }
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     egr::CUDAErrorCheck("sparse::sync_batch_norm__ad_func finish");
   }
   // Returns

--- a/paddle/fluid/eager/api/manual/eager_manual/forwards/sync_batch_norm_fwd_func.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/forwards/sync_batch_norm_fwd_func.cc
@@ -24,6 +24,7 @@
 #pragma GCC diagnostic ignored "-Wunused-variable"
 COMMON_DECLARE_bool(check_nan_inf);
 COMMON_DECLARE_string(tensor_operants_mode);
+COMMON_DECLARE_bool(check_cuda_error);
 
 std::tuple<paddle::Tensor,
            paddle::Tensor&,
@@ -45,6 +46,9 @@ sync_batch_norm__ad_func(const paddle::Tensor& x,
   FLAGS_tensor_operants_mode = "eager";
   VLOG(3) << "Running AD API: "
           << "sync_batch_norm_";
+  if (FLAGS_check_cuda_error) {
+    egr::CUDAErrorCheck("sync_batch_norm__ad_func begin");
+  }
   // Dygraph Record Event
   phi::RecordEvent dygraph_entrance_record_event(
       "sync_batch_norm_ dygraph", phi::TracerEventType::Operator, 1);
@@ -352,7 +356,9 @@ sync_batch_norm__ad_func(const paddle::Tensor& x,
     VLOG(4) << paddle::string::Sprintf(
         INPUT_PRINT_TEMPLATE, input_str, output_str);
   }
-
+  if (FLAGS_check_cuda_error) {
+    egr::CUDAErrorCheck("sync_batch_norm__ad_func finish");
+  }
   // Returns
   return std::tuple<paddle::Tensor,
                     paddle::Tensor&,
@@ -385,6 +391,9 @@ sync_batch_norm__ad_func(const paddle::Tensor& x,
   FLAGS_tensor_operants_mode = "eager";
   VLOG(3) << "Running AD API: "
           << "sync_batch_norm_";
+  if (FLAGS_check_cuda_error) {
+    egr::CUDAErrorCheck("sparse::sync_batch_norm__ad_func begin");
+  }
   // Dygraph Record Event
   phi::RecordEvent dygraph_entrance_record_event(
       "sync_batch_norm_ dygraph", phi::TracerEventType::Operator, 1);
@@ -686,7 +695,9 @@ sync_batch_norm__ad_func(const paddle::Tensor& x,
     VLOG(4) << paddle::string::Sprintf(
         INPUT_PRINT_TEMPLATE, input_str, output_str);
   }
-
+  if (FLAGS_check_cuda_error) {
+    egr::CUDAErrorCheck("sparse::sync_batch_norm__ad_func finish");
+  }
   // Returns
   return std::tuple<paddle::Tensor,
                     paddle::Tensor&,

--- a/paddle/fluid/eager/api/manual/eager_manual/nodes/add_n_node.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/nodes/add_n_node.cc
@@ -26,6 +26,7 @@
 #include "paddle/phi/core/platform/profiler/event_tracing.h"
 
 COMMON_DECLARE_bool(check_nan_inf);
+COMMON_DECLARE_bool(check_cuda_error);
 
 paddle::small_vector<std::vector<paddle::Tensor>, egr::kSlotSmallVectorSize>
 AddNGradNodeFinal::operator()(
@@ -33,6 +34,11 @@ AddNGradNodeFinal::operator()(
         &grads,
     bool create_graph,
     bool is_new_grad) {
+  VLOG(3) << "Running AD API GRAD: "
+          << "add_n_grad";
+  if (FLAGS_check_cuda_error) {
+    egr::CUDAErrorCheck("AddNGradNodeFinal begin");
+  }
   // Fill Zero For GradIn Tensors
 
   // This 'Local_XXXGradNode' record event is different with
@@ -113,6 +119,9 @@ AddNGradNodeFinal::operator()(
     returns = ApplyNodePostHooks(returns, hooked_grads);
   }
 
+  if (FLAGS_check_cuda_error) {
+    egr::CUDAErrorCheck("AddNGradNodeFinal finish");
+  }
   if (NeedComplexToRealConversion()) HandleComplexGradToRealGrad(&returns);
   return returns;
 }

--- a/paddle/fluid/eager/api/manual/eager_manual/nodes/add_n_node.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/nodes/add_n_node.cc
@@ -36,7 +36,7 @@ AddNGradNodeFinal::operator()(
     bool is_new_grad) {
   VLOG(3) << "Running AD API GRAD: "
           << "add_n_grad";
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     egr::CUDAErrorCheck("AddNGradNodeFinal begin");
   }
   // Fill Zero For GradIn Tensors
@@ -119,7 +119,7 @@ AddNGradNodeFinal::operator()(
     returns = ApplyNodePostHooks(returns, hooked_grads);
   }
 
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     egr::CUDAErrorCheck("AddNGradNodeFinal finish");
   }
   if (NeedComplexToRealConversion()) HandleComplexGradToRealGrad(&returns);

--- a/paddle/fluid/eager/api/manual/eager_manual/nodes/conv2d_nodes.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/nodes/conv2d_nodes.cc
@@ -42,7 +42,7 @@ Conv2dGradNodeFinal::operator()(
     bool is_new_grad) {
   // Fill Zero For GradIn Tensors
   VLOG(3) << " Running Conv2dGradNodeFinal: " << this;
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     egr::CUDAErrorCheck("Conv2dGradNodeFinal begin");
   }
   // This 'Local_XXXGradNode' record event is different with
@@ -234,7 +234,7 @@ Conv2dGradNodeFinal::operator()(
     returns = ApplyNodePostHooks(returns, hooked_grads);
   }
 
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     egr::CUDAErrorCheck("Conv2dGradNodeFinal finish");
   }
 
@@ -249,7 +249,7 @@ Conv2dDoubleGradNodeFinal::operator()(
                          egr::kSlotSmallVectorSize>& grads,
     bool create_graph,
     bool is_new_grad) {
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     egr::CUDAErrorCheck("Conv2dDoubleGradNodeFinal begin");
   }
   // This 'Local_XXXGradNode' record event is different with
@@ -435,7 +435,7 @@ Conv2dDoubleGradNodeFinal::operator()(
     returns = ApplyNodePostHooks(returns, hooked_grads);
   }
 
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     egr::CUDAErrorCheck("Conv2dDoubleGradNodeFinal finish");
   }
 

--- a/paddle/fluid/eager/api/manual/eager_manual/nodes/conv2d_nodes.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/nodes/conv2d_nodes.cc
@@ -32,6 +32,7 @@ using egr::ConvertAllInputsToDistTensor;
 using egr::InputsContainDistTensor;
 
 COMMON_DECLARE_bool(check_nan_inf);
+COMMON_DECLARE_bool(check_cuda_error);
 
 paddle::small_vector<std::vector<paddle::Tensor>, egr::kSlotSmallVectorSize>
 Conv2dGradNodeFinal::operator()(
@@ -41,6 +42,9 @@ Conv2dGradNodeFinal::operator()(
     bool is_new_grad) {
   // Fill Zero For GradIn Tensors
   VLOG(3) << " Running Conv2dGradNodeFinal: " << this;
+  if (FLAGS_check_cuda_error) {
+    egr::CUDAErrorCheck("Conv2dGradNodeFinal begin");
+  }
   // This 'Local_XXXGradNode' record event is different with
   // 'Global_XXXGradNode' event.
   // * 'Local_XXXGradNode' will only cover execution time of this function.
@@ -230,6 +234,10 @@ Conv2dGradNodeFinal::operator()(
     returns = ApplyNodePostHooks(returns, hooked_grads);
   }
 
+  if (FLAGS_check_cuda_error) {
+    egr::CUDAErrorCheck("Conv2dGradNodeFinal finish");
+  }
+
   // Return
   if (NeedComplexToRealConversion()) HandleComplexGradToRealGrad(&returns);
   return returns;
@@ -241,6 +249,9 @@ Conv2dDoubleGradNodeFinal::operator()(
                          egr::kSlotSmallVectorSize>& grads,
     bool create_graph,
     bool is_new_grad) {
+  if (FLAGS_check_cuda_error) {
+    egr::CUDAErrorCheck("Conv2dDoubleGradNodeFinal begin");
+  }
   // This 'Local_XXXGradNode' record event is different with
   // 'Global_XXXGradNode' event.
   // * 'Local_XXXGradNode' will only cover execution time of this function.
@@ -422,6 +433,10 @@ Conv2dDoubleGradNodeFinal::operator()(
 
   if (HasNodePostHook()) {
     returns = ApplyNodePostHooks(returns, hooked_grads);
+  }
+
+  if (FLAGS_check_cuda_error) {
+    egr::CUDAErrorCheck("Conv2dDoubleGradNodeFinal finish");
   }
 
   // Return

--- a/paddle/fluid/eager/api/manual/eager_manual/nodes/dtensor_from_local_node.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/nodes/dtensor_from_local_node.cc
@@ -19,6 +19,7 @@
 #include "paddle/fluid/eager/utils.h"
 #include "paddle/fluid/imperative/tracer.h"
 #include "paddle/phi/core/platform/profiler/event_tracing.h"
+COMMON_DECLARE_bool(check_cuda_error);
 
 paddle::small_vector<std::vector<paddle::Tensor>,
                      egr::kSlotSmallVectorSize>  // NOLINT
@@ -30,6 +31,9 @@ DtensorFromLocalGradNode::operator()(
 #ifdef PADDLE_WITH_DISTRIBUTE
   VLOG(3) << "Running AD API GRAD: "
           << "dtensor_from_local";
+  if (FLAGS_check_cuda_error) {
+    egr::CUDAErrorCheck("DtensorFromLocalGradNode begin");
+  }
 
   bool rank_is_in_current_mesh = phi::distributed::IsCurRankInMesh(
       static_cast<phi::distributed::DistTensor*>(grads[0][0].impl().get())
@@ -121,6 +125,10 @@ DtensorFromLocalGradNode::operator()(
     output_str += output_x_grad_str;
     VLOG(4) << paddle::string::Sprintf(
         INPUT_PRINT_TEMPLATE, input_str, output_str);
+  }
+
+  if (FLAGS_check_cuda_error) {
+    egr::CUDAErrorCheck("DtensorFromLocalGradNode finish");
   }
 
   return returns;

--- a/paddle/fluid/eager/api/manual/eager_manual/nodes/dtensor_from_local_node.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/nodes/dtensor_from_local_node.cc
@@ -31,7 +31,7 @@ DtensorFromLocalGradNode::operator()(
 #ifdef PADDLE_WITH_DISTRIBUTE
   VLOG(3) << "Running AD API GRAD: "
           << "dtensor_from_local";
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     egr::CUDAErrorCheck("DtensorFromLocalGradNode begin");
   }
 
@@ -127,7 +127,7 @@ DtensorFromLocalGradNode::operator()(
         INPUT_PRINT_TEMPLATE, input_str, output_str);
   }
 
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     egr::CUDAErrorCheck("DtensorFromLocalGradNode finish");
   }
 

--- a/paddle/fluid/eager/api/manual/eager_manual/nodes/dtensor_to_local_node.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/nodes/dtensor_to_local_node.cc
@@ -19,6 +19,7 @@
 #include "paddle/fluid/eager/utils.h"
 #include "paddle/fluid/imperative/tracer.h"
 #include "paddle/phi/core/platform/profiler/event_tracing.h"
+COMMON_DECLARE_bool(check_cuda_error);
 
 paddle::small_vector<std::vector<paddle::Tensor>,
                      egr::kSlotSmallVectorSize>  // NOLINT
@@ -30,6 +31,9 @@ DtensorToLocalGradNode::operator()(
 #ifdef PADDLE_WITH_DISTRIBUTE
   VLOG(3) << "Running AD API GRAD: "
           << "dtensor_to_local";
+  if (FLAGS_check_cuda_error) {
+    egr::CUDAErrorCheck("DtensorToLocalGradNode begin");
+  }
 
   if (grads[0][0].is_dist_tensor()) {
     VLOG(3) << "Input grads is a distributed tensor, no need to convert.";
@@ -115,6 +119,10 @@ DtensorToLocalGradNode::operator()(
     output_str += output_x_grad_str;
     VLOG(4) << paddle::string::Sprintf(
         INPUT_PRINT_TEMPLATE, input_str, output_str);
+  }
+
+  if (FLAGS_check_cuda_error) {
+    egr::CUDAErrorCheck("DtensorToLocalGradNode finish");
   }
 
   return returns;

--- a/paddle/fluid/eager/api/manual/eager_manual/nodes/dtensor_to_local_node.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/nodes/dtensor_to_local_node.cc
@@ -31,7 +31,7 @@ DtensorToLocalGradNode::operator()(
 #ifdef PADDLE_WITH_DISTRIBUTE
   VLOG(3) << "Running AD API GRAD: "
           << "dtensor_to_local";
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     egr::CUDAErrorCheck("DtensorToLocalGradNode begin");
   }
 
@@ -121,7 +121,7 @@ DtensorToLocalGradNode::operator()(
         INPUT_PRINT_TEMPLATE, input_str, output_str);
   }
 
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     egr::CUDAErrorCheck("DtensorToLocalGradNode finish");
   }
 

--- a/paddle/fluid/eager/api/manual/eager_manual/nodes/multiply_node.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/nodes/multiply_node.cc
@@ -33,6 +33,7 @@
 
 using egr::ConvertAllInputsToDistTensor;
 using egr::InputsContainDistTensor;
+COMMON_DECLARE_bool(check_cuda_error);
 
 COMMON_DECLARE_bool(check_nan_inf);
 
@@ -44,6 +45,9 @@ MultiplyGradNode::operator()(
     bool is_new_grad) {
   VLOG(3) << "Running AD API GRAD: "
           << "multiply_grad";
+  if (FLAGS_check_cuda_error) {
+    egr::CUDAErrorCheck("MultiplyGradNode begin");
+  }
   // This 'Local_XXXGradNode' record event is different with
   // 'Global_XXXGradNode' event.
   // * 'Local_XXXGradNode' will only cover execution time of this function.
@@ -258,6 +262,10 @@ MultiplyGradNode::operator()(
     returns = ApplyNodePostHooks(returns, hooked_grads);
   }
 
+  if (FLAGS_check_cuda_error) {
+    egr::CUDAErrorCheck("MultiplyGradNode finish");
+  }
+
   // Return
   if (NeedComplexToRealConversion()) HandleComplexGradToRealGrad(&returns);
   return returns;
@@ -271,6 +279,9 @@ MultiplyDoubleGradNode::operator()(
     bool is_new_grad) {
   VLOG(3) << "Running AD API GRAD: "
           << "multiply_double_grad";
+  if (FLAGS_check_cuda_error) {
+    egr::CUDAErrorCheck("MultiplyDoubleGradNode begin");
+  }
   // This 'Local_XXXGradNode' record event is different with
   // 'Global_XXXGradNode' event.
   // * 'Local_XXXGradNode' will only cover execution time of this function.
@@ -532,6 +543,10 @@ MultiplyDoubleGradNode::operator()(
     returns = ApplyNodePostHooks(returns, hooked_grads);
   }
 
+  if (FLAGS_check_cuda_error) {
+    egr::CUDAErrorCheck("MultiplyDoubleGradNode finish");
+  }
+
   // Return
   if (NeedComplexToRealConversion()) HandleComplexGradToRealGrad(&returns);
   return returns;
@@ -546,6 +561,9 @@ MultiplyGradNode::operator()(
     bool is_new_grad) {
   VLOG(3) << "Running AD API GRAD: "
           << "multiply_grad";
+  if (FLAGS_check_cuda_error) {
+    egr::CUDAErrorCheck("sparse::MultiplyGradNode begin");
+  }
   // This 'Local_XXXGradNode' record event is different with
   // 'Global_XXXGradNode' event.
   // * 'Local_XXXGradNode' will only cover execution time of this function.
@@ -692,7 +710,9 @@ MultiplyGradNode::operator()(
   if (HasNodePostHook()) {
     returns = ApplyNodePostHooks(returns, hooked_grads);
   }
-
+  if (FLAGS_check_cuda_error) {
+    egr::CUDAErrorCheck("sparse::MultiplyGradNode finish");
+  }
   // Return
   if (NeedComplexToRealConversion()) HandleComplexGradToRealGrad(&returns);
   return returns;

--- a/paddle/fluid/eager/api/manual/eager_manual/nodes/multiply_node.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/nodes/multiply_node.cc
@@ -45,7 +45,7 @@ MultiplyGradNode::operator()(
     bool is_new_grad) {
   VLOG(3) << "Running AD API GRAD: "
           << "multiply_grad";
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     egr::CUDAErrorCheck("MultiplyGradNode begin");
   }
   // This 'Local_XXXGradNode' record event is different with
@@ -262,7 +262,7 @@ MultiplyGradNode::operator()(
     returns = ApplyNodePostHooks(returns, hooked_grads);
   }
 
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     egr::CUDAErrorCheck("MultiplyGradNode finish");
   }
 
@@ -279,7 +279,7 @@ MultiplyDoubleGradNode::operator()(
     bool is_new_grad) {
   VLOG(3) << "Running AD API GRAD: "
           << "multiply_double_grad";
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     egr::CUDAErrorCheck("MultiplyDoubleGradNode begin");
   }
   // This 'Local_XXXGradNode' record event is different with
@@ -543,7 +543,7 @@ MultiplyDoubleGradNode::operator()(
     returns = ApplyNodePostHooks(returns, hooked_grads);
   }
 
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     egr::CUDAErrorCheck("MultiplyDoubleGradNode finish");
   }
 
@@ -561,7 +561,7 @@ MultiplyGradNode::operator()(
     bool is_new_grad) {
   VLOG(3) << "Running AD API GRAD: "
           << "multiply_grad";
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     egr::CUDAErrorCheck("sparse::MultiplyGradNode begin");
   }
   // This 'Local_XXXGradNode' record event is different with
@@ -710,7 +710,7 @@ MultiplyGradNode::operator()(
   if (HasNodePostHook()) {
     returns = ApplyNodePostHooks(returns, hooked_grads);
   }
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     egr::CUDAErrorCheck("sparse::MultiplyGradNode finish");
   }
   // Return

--- a/paddle/fluid/eager/api/manual/eager_manual/nodes/reshard_node.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/nodes/reshard_node.cc
@@ -31,7 +31,7 @@ ReshardGradNode::operator()(
 #ifdef PADDLE_WITH_DISTRIBUTE
   VLOG(3) << "Running AD API GRAD: "
           << "reshard_grad";
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     egr::CUDAErrorCheck("ReshardGradNode begin");
   }
   // This 'Local_XXXGradNode' record event is different with
@@ -110,7 +110,7 @@ ReshardGradNode::operator()(
     VLOG(4) << paddle::string::Sprintf(
         INPUT_PRINT_TEMPLATE, input_str, output_str);
   }
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     egr::CUDAErrorCheck("ReshardGradNode finish");
   }
   return returns;

--- a/paddle/fluid/eager/api/manual/eager_manual/nodes/reshard_node.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/nodes/reshard_node.cc
@@ -19,6 +19,7 @@
 #include "paddle/fluid/eager/utils.h"
 #include "paddle/fluid/imperative/tracer.h"
 #include "paddle/phi/core/platform/profiler/event_tracing.h"
+COMMON_DECLARE_bool(check_cuda_error);
 
 paddle::small_vector<std::vector<paddle::Tensor>,
                      egr::kSlotSmallVectorSize>  // NOLINT
@@ -30,6 +31,9 @@ ReshardGradNode::operator()(
 #ifdef PADDLE_WITH_DISTRIBUTE
   VLOG(3) << "Running AD API GRAD: "
           << "reshard_grad";
+  if (FLAGS_check_cuda_error) {
+    egr::CUDAErrorCheck("ReshardGradNode begin");
+  }
   // This 'Local_XXXGradNode' record event is different with
   // 'Global_XXXGradNode' event.
   // * 'Local_XXXGradNode' will only cover execution time of this function.
@@ -106,7 +110,9 @@ ReshardGradNode::operator()(
     VLOG(4) << paddle::string::Sprintf(
         INPUT_PRINT_TEMPLATE, input_str, output_str);
   }
-
+  if (FLAGS_check_cuda_error) {
+    egr::CUDAErrorCheck("ReshardGradNode finish");
+  }
   return returns;
 #else
   PADDLE_THROW(common::errors::Unavailable(

--- a/paddle/fluid/eager/api/manual/eager_manual/nodes/sync_batch_norm_node.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/nodes/sync_batch_norm_node.cc
@@ -29,6 +29,7 @@
 #include "paddle/phi/core/platform/profiler/event_tracing.h"
 
 COMMON_DECLARE_bool(check_nan_inf);
+COMMON_DECLARE_bool(check_cuda_error);
 
 paddle::small_vector<std::vector<paddle::Tensor>, egr::kSlotSmallVectorSize>
 SyncBatchNormGradNode::operator()(
@@ -38,6 +39,9 @@ SyncBatchNormGradNode::operator()(
     bool is_new_grad) {
   VLOG(3) << "Running AD API GRAD: "
           << "sync_batch_norm_grad";
+  if (FLAGS_check_cuda_error) {
+    egr::CUDAErrorCheck("SyncBatchNormGradNode begin");
+  }
   // This 'Local_XXXGradNode' record event is different with
   // 'Global_XXXGradNode' event.
   // * 'Local_XXXGradNode' will only cover execution time of this function.
@@ -259,7 +263,9 @@ SyncBatchNormGradNode::operator()(
   if (HasNodePostHook()) {
     returns = ApplyNodePostHooks(returns, hooked_grads);
   }
-
+  if (FLAGS_check_cuda_error) {
+    egr::CUDAErrorCheck("SyncBatchNormGradNode finish");
+  }
   // Return
   if (NeedComplexToRealConversion()) HandleComplexGradToRealGrad(&returns);
   return returns;
@@ -274,6 +280,9 @@ SyncBatchNormGradNode::operator()(
     bool is_new_grad) {
   VLOG(3) << "Running AD API GRAD: "
           << "sync_batch_norm_grad";
+  if (FLAGS_check_cuda_error) {
+    egr::CUDAErrorCheck("sparse::SyncBatchNormGradNode begin");
+  }
   // This 'Local_XXXGradNode' record event is different with
   // 'Global_XXXGradNode' event.
   // * 'Local_XXXGradNode' will only cover execution time of this function.
@@ -496,7 +505,9 @@ SyncBatchNormGradNode::operator()(
   if (HasNodePostHook()) {
     returns = ApplyNodePostHooks(returns, hooked_grads);
   }
-
+  if (FLAGS_check_cuda_error) {
+    egr::CUDAErrorCheck("sparse::SyncBatchNormGradNode finish");
+  }
   // Return
   if (NeedComplexToRealConversion()) HandleComplexGradToRealGrad(&returns);
   return returns;

--- a/paddle/fluid/eager/api/manual/eager_manual/nodes/sync_batch_norm_node.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/nodes/sync_batch_norm_node.cc
@@ -39,7 +39,7 @@ SyncBatchNormGradNode::operator()(
     bool is_new_grad) {
   VLOG(3) << "Running AD API GRAD: "
           << "sync_batch_norm_grad";
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     egr::CUDAErrorCheck("SyncBatchNormGradNode begin");
   }
   // This 'Local_XXXGradNode' record event is different with
@@ -263,7 +263,7 @@ SyncBatchNormGradNode::operator()(
   if (HasNodePostHook()) {
     returns = ApplyNodePostHooks(returns, hooked_grads);
   }
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     egr::CUDAErrorCheck("SyncBatchNormGradNode finish");
   }
   // Return
@@ -280,7 +280,7 @@ SyncBatchNormGradNode::operator()(
     bool is_new_grad) {
   VLOG(3) << "Running AD API GRAD: "
           << "sync_batch_norm_grad";
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     egr::CUDAErrorCheck("sparse::SyncBatchNormGradNode begin");
   }
   // This 'Local_XXXGradNode' record event is different with
@@ -505,7 +505,7 @@ SyncBatchNormGradNode::operator()(
   if (HasNodePostHook()) {
     returns = ApplyNodePostHooks(returns, hooked_grads);
   }
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     egr::CUDAErrorCheck("sparse::SyncBatchNormGradNode finish");
   }
   // Return

--- a/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
@@ -328,6 +328,9 @@ class {} : public egr::GradNodeBase {{
 GRAD_FUNCTION_TEMPLATE = """
 paddle::small_vector<std::vector<paddle::Tensor>, egr::kSlotSmallVectorSize> {}::operator()(paddle::small_vector<std::vector<paddle::Tensor>, egr::kSlotSmallVectorSize>& grads, bool create_graph, bool is_new_grad) {{
   VLOG(3) << \"Running AD API GRAD: \" << \"{}\";
+  if (FLAGS_check_cuda_error) {{
+    egr::CUDAErrorCheck(\"{} begin\");
+  }}
 
    // This 'Local_XXXGradNode' record event is different with 'Global_XXXGradNode' event.
    // * 'Local_XXXGradNode' will only cover execution time of this function.
@@ -375,6 +378,10 @@ paddle::small_vector<std::vector<paddle::Tensor>, egr::kSlotSmallVectorSize> {}:
     returns = ApplyNodePostHooks(returns, hooked_grads);
   }}
 
+  if (FLAGS_check_cuda_error) {{
+    egr::CUDAErrorCheck(\"{} finish\");
+  }}
+
   // Return
 {}
 }}
@@ -384,6 +391,9 @@ FORWARD_FUNCTION_TEMPLATE = """
 TEST_API {} {}({}) {{
   FLAGS_tensor_operants_mode = "eager";
   VLOG(3) << \"Running AD API: \" << \"{}\";
+  if (FLAGS_check_cuda_error) {{
+    egr::CUDAErrorCheck(\"{} begin\");
+  }}
 {}
   // Dygraph Record Event
 {}
@@ -432,6 +442,9 @@ TEST_API {} {}({}) {{
   VLOG(4) << \"Finish AD API: {}";
   // LOG IF DEBUG
 {}
+  if (FLAGS_check_cuda_error) {{
+    egr::CUDAErrorCheck(\"{} finish\");
+  }}
   // Returns
   return {};
 }}
@@ -463,6 +476,9 @@ FORWARD_ONLY_FUNCTION_TEMPLATE = """
 TEST_API {} {}({}) {{
   FLAGS_tensor_operants_mode = "eager";
   VLOG(3) << \"Running AD API: \" << \"{}\";
+  if (FLAGS_check_cuda_error) {{
+    egr::CUDAErrorCheck(\"{} begin\");
+  }}
 {}
   // Dygraph Record Event
 {}
@@ -491,6 +507,9 @@ TEST_API {} {}({}) {{
 {}{}
   // LOG IF DEBUG
 {}
+  if (FLAGS_check_cuda_error) {{
+    egr::CUDAErrorCheck(\"{} finish\");
+  }}
   // Returns
   return {};
 }}
@@ -575,6 +594,7 @@ NODE_CC_FILE_TEMPLATE = """
 #include "paddle/phi/core/memory/stats.h"
 #include "paddle/phi/api/lib/data_transform.h"
 COMMON_DECLARE_bool(check_nan_inf);
+COMMON_DECLARE_bool(check_cuda_error);
 {}
 """
 
@@ -618,6 +638,7 @@ COMMON_DECLARE_bool(check_nan_inf);
 COMMON_DECLARE_int32(call_stack_level);
 COMMON_DECLARE_string(tensor_operants_mode);
 COMMON_DECLARE_bool(use_stride_kernel);
+COMMON_DECLARE_bool(check_cuda_error);
 {}
 {}
 """
@@ -2203,6 +2224,7 @@ class DygraphForwardFunctionGenerator(DygraphFunctionGeneratorBase):
                     forward_ad_function_name,
                     inputs_args_definition_str,
                     forward_api_name,
+                    forward_ad_function_name,
                     strided_flags_check,
                     dygraph_event_str,
                     amp_logic_str,
@@ -2219,6 +2241,7 @@ class DygraphForwardFunctionGenerator(DygraphFunctionGeneratorBase):
                     check_inplace_str,
                     bump_inplace_version_str,
                     log_str,
+                    forward_ad_function_name,
                     returns_str,
                 )
             )
@@ -2228,6 +2251,7 @@ class DygraphForwardFunctionGenerator(DygraphFunctionGeneratorBase):
                 forward_ad_function_name,
                 inputs_args_definition_str,
                 forward_api_name,
+                forward_ad_function_name,
                 strided_flags_check,
                 dygraph_event_str,
                 amp_logic_str,
@@ -2251,6 +2275,7 @@ class DygraphForwardFunctionGenerator(DygraphFunctionGeneratorBase):
                 node_creation_after_call_str,
                 forward_api_name,
                 log_str,
+                forward_ad_function_name,
                 returns_str,
             )
 
@@ -3126,6 +3151,7 @@ if (paddle::prim::PrimCommonUtils::IsEagerPrimEnabled() && !need_skip) {{
             grad_node_name,
             self.backward_api_name,
             grad_node_name,
+            grad_node_name,
             fill_zero_str,
             get_grad_in_args_str,
             convert_input_to_dist_tensor_str,
@@ -3142,6 +3168,7 @@ if (paddle::prim::PrimCommonUtils::IsEagerPrimEnabled() && !need_skip) {{
             next_grad_node_creation_str,
             self.backward_api_name,
             log_str,
+            grad_node_name,
             returns_str,
         )
 

--- a/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
@@ -328,7 +328,7 @@ class {} : public egr::GradNodeBase {{
 GRAD_FUNCTION_TEMPLATE = """
 paddle::small_vector<std::vector<paddle::Tensor>, egr::kSlotSmallVectorSize> {}::operator()(paddle::small_vector<std::vector<paddle::Tensor>, egr::kSlotSmallVectorSize>& grads, bool create_graph, bool is_new_grad) {{
   VLOG(3) << \"Running AD API GRAD: \" << \"{}\";
-  if (FLAGS_check_cuda_error) {{
+  if (FLAGS_check_cuda_error) [[unlikely]] {{
     egr::CUDAErrorCheck(\"{} begin\");
   }}
 
@@ -378,7 +378,7 @@ paddle::small_vector<std::vector<paddle::Tensor>, egr::kSlotSmallVectorSize> {}:
     returns = ApplyNodePostHooks(returns, hooked_grads);
   }}
 
-  if (FLAGS_check_cuda_error) {{
+  if (FLAGS_check_cuda_error) [[unlikely]] {{
     egr::CUDAErrorCheck(\"{} finish\");
   }}
 
@@ -391,7 +391,7 @@ FORWARD_FUNCTION_TEMPLATE = """
 TEST_API {} {}({}) {{
   FLAGS_tensor_operants_mode = "eager";
   VLOG(3) << \"Running AD API: \" << \"{}\";
-  if (FLAGS_check_cuda_error) {{
+  if (FLAGS_check_cuda_error) [[unlikely]] {{
     egr::CUDAErrorCheck(\"{} begin\");
   }}
 {}
@@ -442,7 +442,7 @@ TEST_API {} {}({}) {{
   VLOG(4) << \"Finish AD API: {}";
   // LOG IF DEBUG
 {}
-  if (FLAGS_check_cuda_error) {{
+  if (FLAGS_check_cuda_error) [[unlikely]] {{
     egr::CUDAErrorCheck(\"{} finish\");
   }}
   // Returns
@@ -476,7 +476,7 @@ FORWARD_ONLY_FUNCTION_TEMPLATE = """
 TEST_API {} {}({}) {{
   FLAGS_tensor_operants_mode = "eager";
   VLOG(3) << \"Running AD API: \" << \"{}\";
-  if (FLAGS_check_cuda_error) {{
+  if (FLAGS_check_cuda_error) [[unlikely]] {{
     egr::CUDAErrorCheck(\"{} begin\");
   }}
 {}
@@ -507,7 +507,7 @@ TEST_API {} {}({}) {{
 {}{}
   // LOG IF DEBUG
 {}
-  if (FLAGS_check_cuda_error) {{
+  if (FLAGS_check_cuda_error) [[unlikely]] {{
     egr::CUDAErrorCheck(\"{} finish\");
   }}
   // Returns

--- a/paddle/fluid/eager/custom_operator/custom_operator_node.cc
+++ b/paddle/fluid/eager/custom_operator/custom_operator_node.cc
@@ -21,6 +21,7 @@
 #include "paddle/phi/api/lib/data_transform.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/platform/profiler/event_tracing.h"
+COMMON_DECLARE_bool(check_cuda_error);
 
 namespace egr {
 
@@ -166,6 +167,9 @@ RunCustomOpNode::operator()(paddle::small_vector<std::vector<paddle::Tensor>,
                                                  kSlotSmallVectorSize>& grads,
                             bool create_graph,
                             bool is_new_grad) {  // NOLINT
+  if (FLAGS_check_cuda_error) {
+    egr::CUDAErrorCheck("RunCustomOpNode begin");
+  }
   paddle::CustomOpKernelContext ctx;
   const auto& meta_info_map = egr::Controller::Instance().GetOpMetaInfoMap();
   const auto& vec_map = meta_info_map.at(op_type_);
@@ -377,6 +381,10 @@ RunCustomOpNode::operator()(paddle::small_vector<std::vector<paddle::Tensor>,
     outs = ApplyNodePostHooks(outs, hooked_grads);
   }
 
+  if (FLAGS_check_cuda_error) {
+    egr::CUDAErrorCheck("RunCustomOpNode finish");
+  }
+
   return outs;
 }
 
@@ -386,6 +394,9 @@ RunCustomOpDoubleGradNode::operator()(
         grads,
     bool create_graph,
     bool is_new_grad) {  // NOLINT
+  if (FLAGS_check_cuda_error) {
+    egr::CUDAErrorCheck("RunCustomOpDoubleGradNode begin");
+  }
   paddle::CustomOpKernelContext ctx;
   const auto& meta_info_map = egr::Controller::Instance().GetOpMetaInfoMap();
   const auto& vec_map = meta_info_map.at(op_type_);
@@ -465,6 +476,10 @@ RunCustomOpDoubleGradNode::operator()(
 
   if (HasNodePostHook()) {
     outs = ApplyNodePostHooks(outs, hooked_grads);
+  }
+
+  if (FLAGS_check_cuda_error) {
+    egr::CUDAErrorCheck("RunCustomOpDoubleGradNode finish");
   }
 
   return outs;

--- a/paddle/fluid/eager/custom_operator/custom_operator_node.cc
+++ b/paddle/fluid/eager/custom_operator/custom_operator_node.cc
@@ -167,7 +167,7 @@ RunCustomOpNode::operator()(paddle::small_vector<std::vector<paddle::Tensor>,
                                                  kSlotSmallVectorSize>& grads,
                             bool create_graph,
                             bool is_new_grad) {  // NOLINT
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     egr::CUDAErrorCheck("RunCustomOpNode begin");
   }
   paddle::CustomOpKernelContext ctx;
@@ -381,7 +381,7 @@ RunCustomOpNode::operator()(paddle::small_vector<std::vector<paddle::Tensor>,
     outs = ApplyNodePostHooks(outs, hooked_grads);
   }
 
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     egr::CUDAErrorCheck("RunCustomOpNode finish");
   }
 
@@ -394,7 +394,7 @@ RunCustomOpDoubleGradNode::operator()(
         grads,
     bool create_graph,
     bool is_new_grad) {  // NOLINT
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     egr::CUDAErrorCheck("RunCustomOpDoubleGradNode begin");
   }
   paddle::CustomOpKernelContext ctx;
@@ -478,7 +478,7 @@ RunCustomOpDoubleGradNode::operator()(
     outs = ApplyNodePostHooks(outs, hooked_grads);
   }
 
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     egr::CUDAErrorCheck("RunCustomOpDoubleGradNode finish");
   }
 

--- a/paddle/fluid/eager/pylayer/py_layer_node.cc
+++ b/paddle/fluid/eager/pylayer/py_layer_node.cc
@@ -41,7 +41,7 @@ GradNodePyLayer::operator()(
                          kSlotSmallVectorSize>& grads,  // NOLINT
     bool create_graph,
     bool is_new_grad) {
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     egr::CUDAErrorCheck("GradNodePyLayer begin");
   }
   pybind11::gil_scoped_acquire gil;
@@ -244,7 +244,7 @@ GradNodePyLayer::operator()(
   Py_XDECREF(ctx_);
   ctx_ = nullptr;
 
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     egr::CUDAErrorCheck("GradNodePyLayer finish");
   }
 

--- a/paddle/fluid/eager/pylayer/py_layer_node.cc
+++ b/paddle/fluid/eager/pylayer/py_layer_node.cc
@@ -17,6 +17,7 @@
 #include "glog/logging.h"
 #include "paddle/common/errors.h"
 #include "paddle/fluid/eager/eager_tensor.h"
+#include "paddle/fluid/eager/utils.h"
 #include "paddle/fluid/platform/enforce.h"
 #include "paddle/fluid/pybind/eager.h"
 #include "paddle/fluid/pybind/eager_utils.h"
@@ -25,6 +26,8 @@
 #include "paddle/phi/core/platform/device_context.h"
 #pragma GCC diagnostic ignored "-Wattributes"
 #include "pybind11/pytypes.h"
+
+COMMON_DECLARE_bool(check_cuda_error);
 
 namespace egr {
 GradNodePyLayer::~GradNodePyLayer() {  // NOLINT
@@ -38,6 +41,9 @@ GradNodePyLayer::operator()(
                          kSlotSmallVectorSize>& grads,  // NOLINT
     bool create_graph,
     bool is_new_grad) {
+  if (FLAGS_check_cuda_error) {
+    egr::CUDAErrorCheck("GradNodePyLayer begin");
+  }
   pybind11::gil_scoped_acquire gil;
   VLOG(3) << "Running Eager Backward Node: " << name();
 
@@ -237,6 +243,10 @@ GradNodePyLayer::operator()(
   Py_XDECREF(outputs);
   Py_XDECREF(ctx_);
   ctx_ = nullptr;
+
+  if (FLAGS_check_cuda_error) {
+    egr::CUDAErrorCheck("GradNodePyLayer finish");
+  }
 
   return grad_out;
 }

--- a/paddle/fluid/eager/utils.h
+++ b/paddle/fluid/eager/utils.h
@@ -355,4 +355,12 @@ void ConvertAllInputsToDistTensor(const phi::distributed::ProcessMesh* mesh,
 void ConvertToDistTensor(paddle::Tensor* x,
                          const phi::distributed::ProcessMesh* mesh);
 
+void inline CUDAErrorCheck(const std::string& check_tag) {
+#ifdef PADDLE_WITH_CUDA
+  std::cout << check_tag << " checking..." << std::endl;
+  PADDLE_ENFORCE_GPU_SUCCESS(cudaDeviceSynchronize());
+  PADDLE_ENFORCE_GPU_SUCCESS(cudaGetLastError());
+  std::cout << check_tag << " check done." << std::endl;
+#endif
+}
 }  // namespace egr

--- a/paddle/fluid/framework/new_executor/instruction/builtin_combine_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/builtin_combine_instruction.cc
@@ -16,6 +16,8 @@
 #include "paddle/fluid/framework/new_executor/instruction/instruction_util.h"
 #include "paddle/fluid/framework/new_executor/new_executor_defs.h"
 
+COMMON_DECLARE_bool(check_cuda_error);
+
 namespace paddle::framework {
 
 BuiltinCombineInstruction::BuiltinCombineInstruction(

--- a/paddle/fluid/framework/new_executor/instruction/cinn_jit_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/cinn_jit_instruction.cc
@@ -336,7 +336,7 @@ CinnJitInstruction::CinnJitInstruction(
 }
 
 void CinnJitInstruction::Run() {
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     CUDAErrorCheck("CinnJitInstruction begin");
   }
 
@@ -374,7 +374,7 @@ void CinnJitInstruction::Run() {
              "support CUDA/HIP kernel";
 #endif
 
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     CUDAErrorCheck("CinnJitInstruction finish");
   }
 }

--- a/paddle/fluid/framework/new_executor/instruction/cinn_jit_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/cinn_jit_instruction.cc
@@ -19,6 +19,7 @@
 #include "paddle/cinn/hlir/framework/pir_compiler.h"
 #include "paddle/common/errors.h"
 #include "paddle/common/performance_statistician.h"
+#include "paddle/fluid/framework/new_executor/instruction/instruction_util.h"
 #include "paddle/fluid/framework/new_executor/pir_adaptor/pir_adaptor_util.h"
 #include "paddle/phi/backends/gpu/gpu_info.h"
 #include "paddle/phi/backends/gpu/gpu_resources.h"
@@ -29,6 +30,7 @@ PD_DECLARE_bool(cinn_measure_kernel_time);
 PD_DECLARE_string(tile_config_policy);
 PD_DECLARE_string(cinn_kernel_execution_label);
 PD_DECLARE_bool(cinn_check_jit_instruction_shape);
+COMMON_DECLARE_bool(check_cuda_error);
 
 namespace paddle {
 namespace framework {
@@ -334,6 +336,10 @@ CinnJitInstruction::CinnJitInstruction(
 }
 
 void CinnJitInstruction::Run() {
+  if (FLAGS_check_cuda_error) {
+    CUDAErrorCheck("CinnJitInstruction begin");
+  }
+
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
   void* running_stream = nullptr;
   bool is_gpu = false;
@@ -367,6 +373,10 @@ void CinnJitInstruction::Run() {
   VLOG(0) << "Not Supported: cinn jit instruction currently does not "
              "support CUDA/HIP kernel";
 #endif
+
+  if (FLAGS_check_cuda_error) {
+    CUDAErrorCheck("CinnJitInstruction finish");
+  }
 }
 
 const std::string& CinnJitInstruction::Name() const {

--- a/paddle/fluid/framework/new_executor/instruction/control_flow/assert_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/control_flow/assert_instruction.cc
@@ -18,6 +18,8 @@
 #include "paddle/fluid/pir/dialect/operator/ir/control_flow_op.h"
 #include "paddle/phi/kernels/funcs/tensor_formatter.h"
 
+COMMON_DECLARE_bool(check_cuda_error);
+
 namespace paddle::framework {
 AssertInstruction::AssertInstruction(size_t id,
                                      const phi::Place& place,
@@ -53,6 +55,10 @@ AssertInstruction::AssertInstruction(size_t id,
 }
 
 void AssertInstruction::Run() {
+  if (FLAGS_check_cuda_error) {
+    CUDAErrorCheck("AssertInstruction begin");
+  }
+
   DeviceContext().Wait();
   const phi::DenseTensor& cond = cond_var_->Get<phi::DenseTensor>();
 
@@ -98,6 +104,10 @@ void AssertInstruction::Run() {
       "true, but received false. %s",
       value_exe_info_->GetVarName(cond_var_),
       error_msg));
+
+  if (FLAGS_check_cuda_error) {
+    CUDAErrorCheck("AssertInstruction finish");
+  }
 }
 
 }  // namespace paddle::framework

--- a/paddle/fluid/framework/new_executor/instruction/control_flow/assert_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/control_flow/assert_instruction.cc
@@ -55,7 +55,7 @@ AssertInstruction::AssertInstruction(size_t id,
 }
 
 void AssertInstruction::Run() {
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     CUDAErrorCheck("AssertInstruction begin");
   }
 
@@ -105,7 +105,7 @@ void AssertInstruction::Run() {
       value_exe_info_->GetVarName(cond_var_),
       error_msg));
 
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     CUDAErrorCheck("AssertInstruction finish");
   }
 }

--- a/paddle/fluid/framework/new_executor/instruction/control_flow/has_elements_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/control_flow/has_elements_instruction.cc
@@ -56,7 +56,7 @@ HasElementsInstruction::HasElementsInstruction(
 
 void HasElementsInstruction::Run() {
   VLOG(6) << "run has_elements instruction";
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     CUDAErrorCheck("HasElementsInstruction begin");
   }
 
@@ -64,7 +64,7 @@ void HasElementsInstruction::Run() {
   bool* has_elements = pool.Get(phi::CPUPlace())->Alloc<bool>(bool_tensor_);
   *has_elements = !stack_element_var_array_->empty();
 
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     CUDAErrorCheck("HasElementsInstruction finish");
   }
 }

--- a/paddle/fluid/framework/new_executor/instruction/control_flow/has_elements_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/control_flow/has_elements_instruction.cc
@@ -17,6 +17,8 @@
 #include "paddle/fluid/framework/new_executor/pir_adaptor/pir_adaptor_util.h"
 #include "paddle/fluid/pir/dialect/operator/ir/control_flow_op.h"
 
+COMMON_DECLARE_bool(check_cuda_error);
+
 namespace paddle {
 namespace framework {
 HasElementsInstruction::HasElementsInstruction(
@@ -54,9 +56,17 @@ HasElementsInstruction::HasElementsInstruction(
 
 void HasElementsInstruction::Run() {
   VLOG(6) << "run has_elements instruction";
+  if (FLAGS_check_cuda_error) {
+    CUDAErrorCheck("HasElementsInstruction begin");
+  }
+
   phi::DeviceContextPool& pool = phi::DeviceContextPool::Instance();
   bool* has_elements = pool.Get(phi::CPUPlace())->Alloc<bool>(bool_tensor_);
   *has_elements = !stack_element_var_array_->empty();
+
+  if (FLAGS_check_cuda_error) {
+    CUDAErrorCheck("HasElementsInstruction finish");
+  }
 }
 }  // namespace framework
 }  // namespace paddle

--- a/paddle/fluid/framework/new_executor/instruction/control_flow/if_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/control_flow/if_instruction.cc
@@ -41,6 +41,8 @@
 #include "paddle/fluid/platform/onednn_helper.h"
 #endif
 
+COMMON_DECLARE_bool(check_cuda_error);
+
 namespace paddle::framework {
 
 IfInstruction::IfInstruction(size_t id,
@@ -216,6 +218,10 @@ void IfInstruction::SetInputHooks(const std::vector<PirHookFunc>& hookfuncs) {
 }
 
 void IfInstruction::Run() {
+  if (FLAGS_check_cuda_error) {
+    CUDAErrorCheck("IfInstruction begin");
+  }
+
   bool cond = true;
   if (cond_var_->IsType<phi::DenseTensor>()) {
     auto& cond_tensor = cond_var_->Get<phi::DenseTensor>();
@@ -263,6 +269,10 @@ void IfInstruction::Run() {
     false_branch_inter_->Run({}, false);
   }
   // copy output
+
+  if (FLAGS_check_cuda_error) {
+    CUDAErrorCheck("IfInstruction finish");
+  }
 }
 
 }  // namespace paddle::framework

--- a/paddle/fluid/framework/new_executor/instruction/control_flow/if_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/control_flow/if_instruction.cc
@@ -218,7 +218,7 @@ void IfInstruction::SetInputHooks(const std::vector<PirHookFunc>& hookfuncs) {
 }
 
 void IfInstruction::Run() {
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     CUDAErrorCheck("IfInstruction begin");
   }
 
@@ -270,7 +270,7 @@ void IfInstruction::Run() {
   }
   // copy output
 
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     CUDAErrorCheck("IfInstruction finish");
   }
 }

--- a/paddle/fluid/framework/new_executor/instruction/control_flow/pylayer_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/control_flow/pylayer_instruction.cc
@@ -151,7 +151,7 @@ PyLayerInstruction::~PyLayerInstruction() { delete fwd_inter_; }
 
 void PyLayerInstruction::Run() {
   VLOG(6) << "start pylayer forward block interpreter";
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     CUDAErrorCheck("PyLayerInstruction begin");
   }
 
@@ -163,7 +163,7 @@ void PyLayerInstruction::Run() {
 #endif
   fwd_inter_->Run({}, false);
 
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     CUDAErrorCheck("PyLayerInstruction finish");
   }
 }

--- a/paddle/fluid/framework/new_executor/instruction/control_flow/pylayer_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/control_flow/pylayer_instruction.cc
@@ -40,6 +40,8 @@
 #include "paddle/fluid/platform/onednn_helper.h"
 #endif
 
+COMMON_DECLARE_bool(check_cuda_error);
+
 namespace paddle::framework {
 
 PyLayerInstruction::PyLayerInstruction(
@@ -149,6 +151,9 @@ PyLayerInstruction::~PyLayerInstruction() { delete fwd_inter_; }
 
 void PyLayerInstruction::Run() {
   VLOG(6) << "start pylayer forward block interpreter";
+  if (FLAGS_check_cuda_error) {
+    CUDAErrorCheck("PyLayerInstruction begin");
+  }
 
 #ifdef PADDLE_WITH_DNNL
   // Executor on being destroyed clears oneDNN cache and resets
@@ -157,6 +162,10 @@ void PyLayerInstruction::Run() {
   paddle::platform::DontClearMKLDNNCache(fwd_inter_->GetPlace());
 #endif
   fwd_inter_->Run({}, false);
+
+  if (FLAGS_check_cuda_error) {
+    CUDAErrorCheck("PyLayerInstruction finish");
+  }
 }
 
 }  // namespace paddle::framework

--- a/paddle/fluid/framework/new_executor/instruction/control_flow/select_input_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/control_flow/select_input_instruction.cc
@@ -125,7 +125,7 @@ class AssignFunctor {
 
 void SelectInputInstruction::Run() {
   VLOG(6) << "run select_input instruction";
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     CUDAErrorCheck("SelectInputInstruction begin");
   }
 
@@ -142,7 +142,7 @@ void SelectInputInstruction::Run() {
           inputs_.size()));
   Variable *selected = inputs_[output_branch];
   VisitVarType(*selected, AssignFunctor(out_));
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     CUDAErrorCheck("SelectInputInstruction finish");
   }
 }

--- a/paddle/fluid/framework/new_executor/instruction/control_flow/select_input_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/control_flow/select_input_instruction.cc
@@ -17,6 +17,8 @@
 #include "paddle/fluid/framework/new_executor/new_executor_defs.h"
 #include "paddle/fluid/framework/new_executor/pir_adaptor/pir_adaptor_util.h"
 
+COMMON_DECLARE_bool(check_cuda_error);
+
 namespace paddle::framework {
 
 SelectInputInstruction::SelectInputInstruction(
@@ -123,6 +125,10 @@ class AssignFunctor {
 
 void SelectInputInstruction::Run() {
   VLOG(6) << "run select_input instruction";
+  if (FLAGS_check_cuda_error) {
+    CUDAErrorCheck("SelectInputInstruction begin");
+  }
+
   auto &mask = mask_->Get<phi::DenseTensor>();
   size_t output_branch = static_cast<size_t>(GetBranchNumber(mask));
   PADDLE_ENFORCE_LT(
@@ -136,6 +142,9 @@ void SelectInputInstruction::Run() {
           inputs_.size()));
   Variable *selected = inputs_[output_branch];
   VisitVarType(*selected, AssignFunctor(out_));
+  if (FLAGS_check_cuda_error) {
+    CUDAErrorCheck("SelectInputInstruction finish");
+  }
 }
 
 }  // namespace paddle::framework

--- a/paddle/fluid/framework/new_executor/instruction/control_flow/select_output_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/control_flow/select_output_instruction.cc
@@ -124,7 +124,7 @@ class AssignFunctor {
 
 void SelectOutputInstruction::Run() {
   VLOG(6) << "run select_output instruction";
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     CUDAErrorCheck("SelectOutputInstruction begin");
   }
 
@@ -141,7 +141,7 @@ void SelectOutputInstruction::Run() {
           outputs_.size()));
   Variable *selected = outputs_[output_branch];
   VisitVarType(*input_, AssignFunctor(selected));
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     CUDAErrorCheck("SelectOutputInstruction finish");
   }
 }

--- a/paddle/fluid/framework/new_executor/instruction/control_flow/select_output_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/control_flow/select_output_instruction.cc
@@ -17,6 +17,8 @@
 #include "paddle/fluid/framework/new_executor/new_executor_defs.h"
 #include "paddle/fluid/framework/new_executor/pir_adaptor/pir_adaptor_util.h"
 
+COMMON_DECLARE_bool(check_cuda_error);
+
 namespace paddle::framework {
 
 SelectOutputInstruction::SelectOutputInstruction(
@@ -122,6 +124,10 @@ class AssignFunctor {
 
 void SelectOutputInstruction::Run() {
   VLOG(6) << "run select_output instruction";
+  if (FLAGS_check_cuda_error) {
+    CUDAErrorCheck("SelectOutputInstruction begin");
+  }
+
   auto &mask = mask_->Get<phi::DenseTensor>();
   size_t output_branch = static_cast<size_t>(GetBranchNumber(mask));
   PADDLE_ENFORCE_LE(
@@ -135,6 +141,9 @@ void SelectOutputInstruction::Run() {
           outputs_.size()));
   Variable *selected = outputs_[output_branch];
   VisitVarType(*input_, AssignFunctor(selected));
+  if (FLAGS_check_cuda_error) {
+    CUDAErrorCheck("SelectOutputInstruction finish");
+  }
 }
 
 }  // namespace paddle::framework

--- a/paddle/fluid/framework/new_executor/instruction/control_flow/tuple_pop_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/control_flow/tuple_pop_instruction.cc
@@ -129,7 +129,7 @@ void ShareVarData(const Variable* src_var, Variable* dst_var) {
 
 void TuplePopInstruction::Run() {
   VLOG(6) << "run tuple_pop instruction";
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     CUDAErrorCheck("TuplePopInstruction begin");
   }
 
@@ -154,7 +154,7 @@ void TuplePopInstruction::Run() {
       AddEagerGCVar(gc_front_var);
     }
   }
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     CUDAErrorCheck("TuplePopInstruction finish");
   }
 }

--- a/paddle/fluid/framework/new_executor/instruction/control_flow/tuple_pop_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/control_flow/tuple_pop_instruction.cc
@@ -19,6 +19,8 @@
 #include "paddle/fluid/framework/new_executor/instruction/instruction_util.h"
 #include "paddle/fluid/framework/new_executor/pir_adaptor/pir_adaptor_util.h"
 
+COMMON_DECLARE_bool(check_cuda_error);
+
 namespace paddle {
 namespace framework {
 TuplePopInstruction::TuplePopInstruction(size_t id,
@@ -127,6 +129,10 @@ void ShareVarData(const Variable* src_var, Variable* dst_var) {
 
 void TuplePopInstruction::Run() {
   VLOG(6) << "run tuple_pop instruction";
+  if (FLAGS_check_cuda_error) {
+    CUDAErrorCheck("TuplePopInstruction begin");
+  }
+
   if (tuple_pop_op_.tuple_size() == 0) {
     stack_element_var_array_->pop_back();
   } else {
@@ -147,6 +153,9 @@ void TuplePopInstruction::Run() {
       Variable* gc_front_var = const_cast<Variable*>(front_var);
       AddEagerGCVar(gc_front_var);
     }
+  }
+  if (FLAGS_check_cuda_error) {
+    CUDAErrorCheck("TuplePopInstruction finish");
   }
 }
 

--- a/paddle/fluid/framework/new_executor/instruction/control_flow/tuple_push_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/control_flow/tuple_push_instruction.cc
@@ -18,6 +18,8 @@
 #include "paddle/fluid/pir/dialect/kernel/ir/kernel_type.h"
 #include "paddle/phi/core/compat/convert_utils.h"
 
+COMMON_DECLARE_bool(check_cuda_error);
+
 namespace paddle::framework {
 bool ParsePlace(const pir::Type& type, OpFuncType* type_) {
   if (type.isa<paddle::dialect::AllocatedDenseTensorType>()) {
@@ -95,6 +97,10 @@ TuplePushInstruction::TuplePushInstruction(size_t id,
 
 void TuplePushInstruction::Run() {
   VLOG(4) << "run tuple_push instruction";
+  if (FLAGS_check_cuda_error) {
+    CUDAErrorCheck("TuplePushInstruction begin");
+  }
+
   if (tuple_push_op_.tuple_size() == 0) {
     stack_element_var_array_->emplace_back(nullptr);
   } else {
@@ -132,6 +138,10 @@ void TuplePushInstruction::Run() {
       VLOG(6) << "push back var: " << new_name << "[" << copy_var << "]"
               << "to: " << stack_element_var_array_;
     }
+  }
+
+  if (FLAGS_check_cuda_error) {
+    CUDAErrorCheck("TuplePushInstruction finish");
   }
 }
 }  // namespace paddle::framework

--- a/paddle/fluid/framework/new_executor/instruction/control_flow/tuple_push_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/control_flow/tuple_push_instruction.cc
@@ -97,7 +97,7 @@ TuplePushInstruction::TuplePushInstruction(size_t id,
 
 void TuplePushInstruction::Run() {
   VLOG(4) << "run tuple_push instruction";
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     CUDAErrorCheck("TuplePushInstruction begin");
   }
 
@@ -140,7 +140,7 @@ void TuplePushInstruction::Run() {
     }
   }
 
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     CUDAErrorCheck("TuplePushInstruction finish");
   }
 }

--- a/paddle/fluid/framework/new_executor/instruction/control_flow/while_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/control_flow/while_instruction.cc
@@ -42,6 +42,8 @@
 #include "paddle/fluid/platform/onednn_helper.h"
 #endif
 
+COMMON_DECLARE_bool(check_cuda_error);
+
 namespace paddle::framework {
 
 WhileInstruction::WhileInstruction(
@@ -212,6 +214,10 @@ void WhileInstruction::CheckGCEarly(const CheckGCEarlyHook& check_gc_early) {
 }
 
 void WhileInstruction::Run() {
+  if (FLAGS_check_cuda_error) {
+    CUDAErrorCheck("WhileInstruction begin");
+  }
+
 #ifdef PADDLE_WITH_DNNL
   // Executor on being destroyed clears oneDNN cache and resets
   // registered model data layout. This is unwanted for nested
@@ -234,6 +240,10 @@ void WhileInstruction::Run() {
     ShareConditionData();
   }
   VLOG(6) << "while instruction run done";
+
+  if (FLAGS_check_cuda_error) {
+    CUDAErrorCheck("WhileInstruction finish");
+  }
 }
 
 }  // namespace paddle::framework

--- a/paddle/fluid/framework/new_executor/instruction/control_flow/while_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/control_flow/while_instruction.cc
@@ -214,7 +214,7 @@ void WhileInstruction::CheckGCEarly(const CheckGCEarlyHook& check_gc_early) {
 }
 
 void WhileInstruction::Run() {
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     CUDAErrorCheck("WhileInstruction begin");
   }
 
@@ -241,7 +241,7 @@ void WhileInstruction::Run() {
   }
   VLOG(6) << "while instruction run done";
 
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     CUDAErrorCheck("WhileInstruction finish");
   }
 }

--- a/paddle/fluid/framework/new_executor/instruction/control_flow/yield_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/control_flow/yield_instruction.cc
@@ -114,7 +114,7 @@ void FullFakeTensor(const pir::Value &output_value, Variable *output_var) {
 #endif
 }
 void YieldInstruction::Run() {
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     CUDAErrorCheck("YieldInstruction begin");
   }
 
@@ -141,7 +141,7 @@ void YieldInstruction::Run() {
                                                  input_vars_[i]->Type()));
     }
   }
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     CUDAErrorCheck("YieldInstruction finish");
   }
 }

--- a/paddle/fluid/framework/new_executor/instruction/control_flow/yield_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/control_flow/yield_instruction.cc
@@ -23,6 +23,8 @@
 #include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/pir/include/core/builtin_type.h"
 
+COMMON_DECLARE_bool(check_cuda_error);
+
 namespace paddle {
 namespace framework {
 
@@ -112,6 +114,10 @@ void FullFakeTensor(const pir::Value &output_value, Variable *output_var) {
 #endif
 }
 void YieldInstruction::Run() {
+  if (FLAGS_check_cuda_error) {
+    CUDAErrorCheck("YieldInstruction begin");
+  }
+
   for (size_t i = 0; i < input_vars_.size(); ++i) {
     if (input_vars_[i] == nullptr) {
       output_vars_[i] = nullptr;
@@ -134,6 +140,9 @@ void YieldInstruction::Run() {
       PADDLE_THROW(common::errors::Unimplemented("unsupported type %d",
                                                  input_vars_[i]->Type()));
     }
+  }
+  if (FLAGS_check_cuda_error) {
+    CUDAErrorCheck("YieldInstruction finish");
   }
 }
 

--- a/paddle/fluid/framework/new_executor/instruction/cuda_graph_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/cuda_graph_instruction.cc
@@ -33,6 +33,8 @@
 #include "paddle/fluid/framework/new_executor/instruction/instruction_util.h"
 #include "paddle/fluid/pir/dialect/operator/ir/manual_op.h"
 
+COMMON_DECLARE_bool(check_cuda_error);
+
 #ifdef PADDLE_WITH_CUDA || defined(PADDLE_WITH_HIP)
 
 namespace paddle::framework {
@@ -166,6 +168,10 @@ void CudaGraphInstruction::SetInputHooks(
 }
 
 void CudaGraphInstruction::Run() {
+  if (FLAGS_check_cuda_error) {
+    CUDAErrorCheck("CudaGraphInstruction begin");
+  }
+
   if (cuda_graph_ != nullptr && *cuda_graph_state_ref_ == 3) {
     VLOG(4) << "Start replaying cuda graph @" << cuda_graph_.get();
     for (size_t i = 0; i < input_vars_.size(); ++i) {
@@ -232,6 +238,10 @@ void CudaGraphInstruction::Run() {
   } else {
     VLOG(4) << "Run interpreter without cuda graph";
     interpreter_->Run({}, false);
+  }
+
+  if (FLAGS_check_cuda_error) {
+    CUDAErrorCheck("CudaGraphInstruction finish");
   }
 }
 

--- a/paddle/fluid/framework/new_executor/instruction/cuda_graph_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/cuda_graph_instruction.cc
@@ -168,7 +168,7 @@ void CudaGraphInstruction::SetInputHooks(
 }
 
 void CudaGraphInstruction::Run() {
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     CUDAErrorCheck("CudaGraphInstruction begin");
   }
 
@@ -240,7 +240,7 @@ void CudaGraphInstruction::Run() {
     interpreter_->Run({}, false);
   }
 
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     CUDAErrorCheck("CudaGraphInstruction finish");
   }
 }

--- a/paddle/fluid/framework/new_executor/instruction/custom_engine_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/custom_engine_instruction.cc
@@ -21,6 +21,8 @@
 #include "paddle/fluid/pir/dialect/operator/ir/op_dialect.h"
 #include "paddle/fluid/pir/dialect/operator/utils/op_yaml_info_parser.h"
 
+COMMON_DECLARE_bool(check_cuda_error);
+
 namespace paddle {
 namespace framework {
 namespace {
@@ -209,6 +211,10 @@ CustomEngineInstruction::CustomEngineInstruction(
 }
 
 void CustomEngineInstruction::Run() {
+  if (FLAGS_check_cuda_error) {
+    CUDAErrorCheck("CustomEngineInstruction " + op_name_ + " begin");
+  }
+
   if (!is_builed_) {
     VLOG(6) << "Start Build custom engine";
     interface_ = paddle::custom_engine::CustomEngineManager::Instance()
@@ -239,6 +245,10 @@ void CustomEngineInstruction::Run() {
     PADDLE_THROW(common::errors::Unimplemented(
         "CustomEngineInstruction's C_CustomEngineInterface->graph_engine_run "
         "not implemented"));
+  }
+
+  if (FLAGS_check_cuda_error) {
+    CUDAErrorCheck("CustomEngineInstruction " + op_name_ + " finish");
   }
 }
 

--- a/paddle/fluid/framework/new_executor/instruction/custom_engine_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/custom_engine_instruction.cc
@@ -211,7 +211,7 @@ CustomEngineInstruction::CustomEngineInstruction(
 }
 
 void CustomEngineInstruction::Run() {
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     CUDAErrorCheck("CustomEngineInstruction " + op_name_ + " begin");
   }
 
@@ -247,7 +247,7 @@ void CustomEngineInstruction::Run() {
         "not implemented"));
   }
 
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     CUDAErrorCheck("CustomEngineInstruction " + op_name_ + " finish");
   }
 }

--- a/paddle/fluid/framework/new_executor/instruction/custom_kernel_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/custom_kernel_instruction.cc
@@ -500,7 +500,7 @@ void CustomKernelInstruction::BuildShapeDtype() {
 }
 
 void CustomKernelInstruction::Run() {
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     CUDAErrorCheck("CustomKernelInstruction " + custom_op_name_ + " begin");
   }
 
@@ -528,7 +528,7 @@ void CustomKernelInstruction::Run() {
   }
   VLOG(6) << "Run custom op " << custom_op_name_ << " kernel.";
   kernel_func_(&custom_kernel_ctx_);
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     CUDAErrorCheck("CustomKernelInstruction " + custom_op_name_ + " finish");
   }
 }

--- a/paddle/fluid/framework/new_executor/instruction/custom_kernel_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/custom_kernel_instruction.cc
@@ -22,6 +22,8 @@
 #include "paddle/pir/include/core/operation.h"
 #include "paddle/pir/include/core/value.h"
 
+COMMON_DECLARE_bool(check_cuda_error);
+
 namespace paddle::framework {
 
 void CustomKernelInstruction::BuildCustomContext(
@@ -498,6 +500,10 @@ void CustomKernelInstruction::BuildShapeDtype() {
 }
 
 void CustomKernelInstruction::Run() {
+  if (FLAGS_check_cuda_error) {
+    CUDAErrorCheck("CustomKernelInstruction " + custom_op_name_ + " begin");
+  }
+
   VLOG(3) << "Custom Operator: InferShape - calc output ddim.";
   BuildShapeDtype();
   std::vector<std::vector<int64_t>> output_shapes =
@@ -522,5 +528,8 @@ void CustomKernelInstruction::Run() {
   }
   VLOG(6) << "Run custom op " << custom_op_name_ << " kernel.";
   kernel_func_(&custom_kernel_ctx_);
+  if (FLAGS_check_cuda_error) {
+    CUDAErrorCheck("CustomKernelInstruction " + custom_op_name_ + " finish");
+  }
 }
 }  // namespace paddle::framework

--- a/paddle/fluid/framework/new_executor/instruction/instruction_util.h
+++ b/paddle/fluid/framework/new_executor/instruction/instruction_util.h
@@ -68,5 +68,15 @@ void HandleForInplaceOp(pir::Operation* op,
                         InstructionBase* instr);
 
 void ShareVarBuffer(const Variable* src_var, Variable* dst_var);
+
+void inline CUDAErrorCheck(const std::string& check_tag) {
+#ifdef PADDLE_WITH_CUDA
+  std::cout << check_tag << " checking..." << std::endl;
+  PADDLE_ENFORCE_GPU_SUCCESS(cudaDeviceSynchronize());
+  PADDLE_ENFORCE_GPU_SUCCESS(cudaGetLastError());
+  std::cout << check_tag << " check done." << std::endl;
+#endif
+}
+
 }  // namespace framework
 }  // namespace paddle

--- a/paddle/fluid/framework/new_executor/instruction/legacy_kernel_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/legacy_kernel_instruction.cc
@@ -29,6 +29,8 @@
 #include "paddle/phi/core/platform/device_context.h"
 #include "paddle/phi/core/type_defs.h"
 
+COMMON_DECLARE_bool(check_cuda_error);
+
 namespace paddle::framework {
 
 LegacyKernelInstruction::LegacyKernelInstruction(
@@ -186,6 +188,10 @@ LegacyKernelInstruction::~LegacyKernelInstruction() {
 }
 
 void LegacyKernelInstruction::Run() {
+  if (FLAGS_check_cuda_error) {
+    CUDAErrorCheck("LegacyKernelInstruction " + legacy_op_name_ + " begin");
+  }
+
   VLOG(6) << "Run op " << legacy_op_name_ << " infer meta.";
   if (infer_meta_interface_) {
     infer_meta_interface_->infer_meta_(&(infer_meta_context_));
@@ -195,5 +201,9 @@ void LegacyKernelInstruction::Run() {
   }
   VLOG(6) << "Run op " << legacy_op_name_ << " kernel.";
   (*(phi_kernel_))((kernel_context_));
+
+  if (FLAGS_check_cuda_error) {
+    CUDAErrorCheck("LegacyKernelInstruction " + legacy_op_name_ + " finish");
+  }
 }
 }  // namespace paddle::framework

--- a/paddle/fluid/framework/new_executor/instruction/legacy_kernel_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/legacy_kernel_instruction.cc
@@ -188,7 +188,7 @@ LegacyKernelInstruction::~LegacyKernelInstruction() {
 }
 
 void LegacyKernelInstruction::Run() {
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     CUDAErrorCheck("LegacyKernelInstruction " + legacy_op_name_ + " begin");
   }
 
@@ -202,7 +202,7 @@ void LegacyKernelInstruction::Run() {
   VLOG(6) << "Run op " << legacy_op_name_ << " kernel.";
   (*(phi_kernel_))((kernel_context_));
 
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     CUDAErrorCheck("LegacyKernelInstruction " + legacy_op_name_ + " finish");
   }
 }

--- a/paddle/fluid/framework/new_executor/instruction/onednn/onednn_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/onednn/onednn_instruction.cc
@@ -406,7 +406,7 @@ OneDNNPhiKernelInstruction::~OneDNNPhiKernelInstruction() {
 }
 
 void OneDNNPhiKernelInstruction::Run() {
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     CUDAErrorCheck("OneDNNPhiKernelInstruction " + phi_op_name_ + " begin");
   }
 
@@ -520,7 +520,7 @@ void OneDNNPhiKernelInstruction::Run() {
   // Step5. ClearDnnAttr
   one_dnn_ctx->ClearDnnAttr();
 
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     CUDAErrorCheck("OneDNNPhiKernelInstruction " + phi_op_name_ + " finish");
   }
 }

--- a/paddle/fluid/framework/new_executor/instruction/onednn/onednn_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/onednn/onednn_instruction.cc
@@ -40,6 +40,8 @@
 #include "paddle/phi/backends/onednn/onednn_helper.h"
 #include "paddle/phi/kernels/funcs/data_layout_transform.h"
 
+COMMON_DECLARE_bool(check_cuda_error);
+
 namespace paddle::framework {
 
 static phi::Attribute ConvertPirAttribute2RuntimeAttribute(
@@ -404,6 +406,10 @@ OneDNNPhiKernelInstruction::~OneDNNPhiKernelInstruction() {
 }
 
 void OneDNNPhiKernelInstruction::Run() {
+  if (FLAGS_check_cuda_error) {
+    CUDAErrorCheck("OneDNNPhiKernelInstruction " + phi_op_name_ + " begin");
+  }
+
   std::vector<std::shared_ptr<phi::DenseTensor>> tmp_holders;
   auto tmp_kernel_context = kernel_context_;
   auto tmp_infer_meta_context_ = infer_meta_context_;
@@ -513,6 +519,10 @@ void OneDNNPhiKernelInstruction::Run() {
 
   // Step5. ClearDnnAttr
   one_dnn_ctx->ClearDnnAttr();
+
+  if (FLAGS_check_cuda_error) {
+    CUDAErrorCheck("OneDNNPhiKernelInstruction " + phi_op_name_ + " finish");
+  }
 }
 
 }  // namespace paddle::framework

--- a/paddle/fluid/framework/new_executor/instruction/onednn/onednn_legacy_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/onednn/onednn_legacy_instruction.cc
@@ -260,7 +260,7 @@ OneDNNLegacyKernelInstruction::~OneDNNLegacyKernelInstruction() {
 }
 
 void OneDNNLegacyKernelInstruction::Run() {
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     CUDAErrorCheck("OneDNNLegacyKernelInstruction " + legacy_op_name_ +
                    " begin");
   }
@@ -319,7 +319,7 @@ void OneDNNLegacyKernelInstruction::Run() {
   VLOG(6) << "Run op " << legacy_op_name_ << " kernel.";
   (*(phi_kernel_))((kernel_context_));
 
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     CUDAErrorCheck("OneDNNLegacyKernelInstruction " + legacy_op_name_ +
                    " finish");
   }

--- a/paddle/fluid/framework/new_executor/instruction/onednn/onednn_legacy_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/onednn/onednn_legacy_instruction.cc
@@ -37,6 +37,8 @@
 #include "paddle/phi/backends/onednn/onednn_helper.h"
 #include "paddle/phi/kernels/funcs/data_layout_transform.h"
 
+COMMON_DECLARE_bool(check_cuda_error);
+
 namespace paddle::framework {
 
 static paddle::framework::Attribute ConvertPirAttribute2FrameworkAttribute(
@@ -258,6 +260,11 @@ OneDNNLegacyKernelInstruction::~OneDNNLegacyKernelInstruction() {
 }
 
 void OneDNNLegacyKernelInstruction::Run() {
+  if (FLAGS_check_cuda_error) {
+    CUDAErrorCheck("OneDNNLegacyKernelInstruction " + legacy_op_name_ +
+                   " begin");
+  }
+
   // Step1. TransLayout
   auto inputs = kernel_context_->InNameList();
   for (auto& input_name : inputs) {
@@ -311,5 +318,10 @@ void OneDNNLegacyKernelInstruction::Run() {
   // Step3. Run kernel
   VLOG(6) << "Run op " << legacy_op_name_ << " kernel.";
   (*(phi_kernel_))((kernel_context_));
+
+  if (FLAGS_check_cuda_error) {
+    CUDAErrorCheck("OneDNNLegacyKernelInstruction " + legacy_op_name_ +
+                   " finish");
+  }
 }
 }  // namespace paddle::framework

--- a/paddle/fluid/framework/new_executor/instruction/onednn/onednn_mixed_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/onednn/onednn_mixed_instruction.cc
@@ -40,6 +40,8 @@
 #include "paddle/phi/backends/onednn/onednn_helper.h"
 #include "paddle/phi/kernels/funcs/data_layout_transform.h"
 
+COMMON_DECLARE_bool(check_cuda_error);
+
 namespace paddle::framework {
 
 OneDNNMixedPhiKernelInstruction::OneDNNMixedPhiKernelInstruction(
@@ -57,6 +59,11 @@ OneDNNMixedPhiKernelInstruction::OneDNNMixedPhiKernelInstruction(
 }
 
 void OneDNNMixedPhiKernelInstruction::Run() {
+  if (FLAGS_check_cuda_error) {
+    CUDAErrorCheck("OneDNNMixedPhiKernelInstruction " + phi_op_name_ +
+                   " begin");
+  }
+
   std::vector<std::shared_ptr<phi::DenseTensor>> tmp_holders;
   // Step1. Mixed Dynamic Choose Kernel
   if (!has_choose_kernel_) {
@@ -152,6 +159,11 @@ void OneDNNMixedPhiKernelInstruction::Run() {
     VLOG(6) << "Begin run op " << phi_op_name_ << " kernel.";
     (*(phi_kernel_))(&(tmp_kernel_context));
     VLOG(6) << "End run op " << phi_op_name_ << " kernel.";
+  }
+
+  if (FLAGS_check_cuda_error) {
+    CUDAErrorCheck("OneDNNMixedPhiKernelInstruction " + phi_op_name_ +
+                   " finish");
   }
 }
 

--- a/paddle/fluid/framework/new_executor/instruction/onednn/onednn_mixed_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/onednn/onednn_mixed_instruction.cc
@@ -59,7 +59,7 @@ OneDNNMixedPhiKernelInstruction::OneDNNMixedPhiKernelInstruction(
 }
 
 void OneDNNMixedPhiKernelInstruction::Run() {
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     CUDAErrorCheck("OneDNNMixedPhiKernelInstruction " + phi_op_name_ +
                    " begin");
   }
@@ -161,7 +161,7 @@ void OneDNNMixedPhiKernelInstruction::Run() {
     VLOG(6) << "End run op " << phi_op_name_ << " kernel.";
   }
 
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     CUDAErrorCheck("OneDNNMixedPhiKernelInstruction " + phi_op_name_ +
                    " finish");
   }

--- a/paddle/fluid/framework/new_executor/instruction/phi_kernel_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/phi_kernel_instruction.cc
@@ -184,7 +184,7 @@ PhiKernelInstruction::PhiKernelInstruction(
 PhiKernelInstruction::~PhiKernelInstruction() { delete phi_kernel_; }
 
 void PhiKernelInstruction::Run() {
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     CUDAErrorCheck("PhiKernelInstruction " + phi_op_name_ + " begin");
   }
 
@@ -235,7 +235,7 @@ void PhiKernelInstruction::Run() {
 
   VLOG(6) << "End run op " << phi_op_name_ << " kernel.";
 
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     CUDAErrorCheck("PhiKernelInstruction " + phi_op_name_ + " finish");
   }
 }

--- a/paddle/fluid/framework/new_executor/instruction/phi_kernel_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/phi_kernel_instruction.cc
@@ -37,7 +37,7 @@
 PHI_DEFINE_EXPORTED_bool(print_kernel_run_info,
                          false,
                          "Whether print kernel run info.");
-
+COMMON_DECLARE_bool(check_cuda_error);
 namespace paddle::framework {
 
 PhiKernelInstruction::PhiKernelInstruction(
@@ -184,6 +184,10 @@ PhiKernelInstruction::PhiKernelInstruction(
 PhiKernelInstruction::~PhiKernelInstruction() { delete phi_kernel_; }
 
 void PhiKernelInstruction::Run() {
+  if (FLAGS_check_cuda_error) {
+    CUDAErrorCheck("PhiKernelInstruction " + phi_op_name_ + " begin");
+  }
+
   auto place =
       kernel_context_.GetDeviceContext<phi::DeviceContext>().GetPlace();
   if (FLAGS_print_kernel_run_info) {
@@ -230,6 +234,10 @@ void PhiKernelInstruction::Run() {
   }
 
   VLOG(6) << "End run op " << phi_op_name_ << " kernel.";
+
+  if (FLAGS_check_cuda_error) {
+    CUDAErrorCheck("PhiKernelInstruction " + phi_op_name_ + " finish");
+  }
 }
 
 }  // namespace paddle::framework

--- a/paddle/fluid/framework/new_executor/instruction/tensorrt_engine_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/tensorrt_engine_instruction.cc
@@ -848,7 +848,7 @@ void TensorRTEngineInstruction::RunTrt() {
 }
 
 void TensorRTEngineInstruction::Run() {
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     CUDAErrorCheck("TensorRTEngineInstruction " + op_name_ + " begin");
   }
 
@@ -862,7 +862,7 @@ void TensorRTEngineInstruction::Run() {
   InputsCheck();
   RunTrt();
 
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     CUDAErrorCheck("TensorRTEngineInstruction " + op_name_ + " finish");
   }
 }

--- a/paddle/fluid/framework/new_executor/instruction/tensorrt_engine_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/tensorrt_engine_instruction.cc
@@ -26,6 +26,7 @@
 #include "paddle/phi/kernels/funcs/data_type_transform.h"
 
 COMMON_DECLARE_string(trt_engine_serialized_path);
+COMMON_DECLARE_bool(check_cuda_error);
 
 namespace paddle {
 namespace framework {
@@ -847,6 +848,10 @@ void TensorRTEngineInstruction::RunTrt() {
 }
 
 void TensorRTEngineInstruction::Run() {
+  if (FLAGS_check_cuda_error) {
+    CUDAErrorCheck("TensorRTEngineInstruction " + op_name_ + " begin");
+  }
+
 #if IS_TRT_VERSION_LT(8500)
   PADDLE_THROW(
       common::errors::Unimplemented("PIR-TRT only support TensorRT "
@@ -856,6 +861,10 @@ void TensorRTEngineInstruction::Run() {
 #endif
   InputsCheck();
   RunTrt();
+
+  if (FLAGS_check_cuda_error) {
+    CUDAErrorCheck("TensorRTEngineInstruction " + op_name_ + " finish");
+  }
 }
 
 std::string TensorRTEngineInstruction::ReadBinaryFileToString(

--- a/paddle/fluid/pybind/eager_functions.cc
+++ b/paddle/fluid/pybind/eager_functions.cc
@@ -544,7 +544,7 @@ PyObject* eager_api_run_custom_op(PyObject* self,
 
   std::string op_type = CastPyArg2AttrString(PyTuple_GET_ITEM(args, 0), 0);
   VLOG(7) << "Get things from python for Custom Op: " << op_type;
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     egr::CUDAErrorCheck("eager_api_run_custom_op " + op_type + " begin");
   }
   paddle::CustomOpKernelContext ctx;
@@ -864,7 +864,7 @@ PyObject* eager_api_run_custom_op(PyObject* self,
       grad_node->SetAttrs(attrs);
     }
   }
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     egr::CUDAErrorCheck("eager_api_run_custom_op " + op_type + " finish");
   }
   return ToPyObject(*ctx.AllMutableOutput());

--- a/paddle/fluid/pybind/eager_functions.cc
+++ b/paddle/fluid/pybind/eager_functions.cc
@@ -536,9 +536,6 @@ PyObject* eager_api_run_custom_op(PyObject* self,
                                   PyObject* kwargs) {
   EAGER_TRY
   FLAGS_tensor_operants_mode = "phi";
-  if (FLAGS_check_cuda_error) {
-    egr::CUDAErrorCheck("eager_api_run_custom_op begin");
-  }
   if (paddle::OperantsManager::Instance().phi_operants.get() == nullptr) {
     paddle::OperantsManager::Instance().phi_operants =
         std::make_unique<paddle::operants::PhiTensorOperants>();
@@ -547,6 +544,9 @@ PyObject* eager_api_run_custom_op(PyObject* self,
 
   std::string op_type = CastPyArg2AttrString(PyTuple_GET_ITEM(args, 0), 0);
   VLOG(7) << "Get things from python for Custom Op: " << op_type;
+  if (FLAGS_check_cuda_error) {
+    egr::CUDAErrorCheck("eager_api_run_custom_op " + op_type + " begin");
+  }
   paddle::CustomOpKernelContext ctx;
   auto meta_info_map = egr::Controller::Instance().GetOpMetaInfoMap();
   PADDLE_ENFORCE_NE(meta_info_map.find(op_type),
@@ -865,7 +865,7 @@ PyObject* eager_api_run_custom_op(PyObject* self,
     }
   }
   if (FLAGS_check_cuda_error) {
-    egr::CUDAErrorCheck("eager_api_run_custom_op finish");
+    egr::CUDAErrorCheck("eager_api_run_custom_op " + op_type + " finish");
   }
   return ToPyObject(*ctx.AllMutableOutput());
   EAGER_CATCH_AND_THROW_RETURN_NULL

--- a/paddle/fluid/pybind/eager_functions.cc
+++ b/paddle/fluid/pybind/eager_functions.cc
@@ -70,6 +70,7 @@ typedef SSIZE_T ssize_t;
 #endif
 
 COMMON_DECLARE_string(tensor_operants_mode);
+COMMON_DECLARE_bool(check_cuda_error);
 
 using egr::ConvertAllInputsToDistTensor;
 using egr::InputsContainDistTensor;
@@ -535,6 +536,9 @@ PyObject* eager_api_run_custom_op(PyObject* self,
                                   PyObject* kwargs) {
   EAGER_TRY
   FLAGS_tensor_operants_mode = "phi";
+  if (FLAGS_check_cuda_error) {
+    egr::CUDAErrorCheck("eager_api_run_custom_op begin");
+  }
   if (paddle::OperantsManager::Instance().phi_operants.get() == nullptr) {
     paddle::OperantsManager::Instance().phi_operants =
         std::make_unique<paddle::operants::PhiTensorOperants>();
@@ -859,6 +863,9 @@ PyObject* eager_api_run_custom_op(PyObject* self,
       }
       grad_node->SetAttrs(attrs);
     }
+  }
+  if (FLAGS_check_cuda_error) {
+    egr::CUDAErrorCheck("eager_api_run_custom_op finish");
   }
   return ToPyObject(*ctx.AllMutableOutput());
   EAGER_CATCH_AND_THROW_RETURN_NULL

--- a/paddle/fluid/pybind/eager_py_layer.cc
+++ b/paddle/fluid/pybind/eager_py_layer.cc
@@ -147,7 +147,7 @@ PyObject* pylayer_method_apply(PyObject* cls,
     return nullptr;
   }
   VLOG(6) << "PyLayer construct PyLayerContext finish...";
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     egr::CUDAErrorCheck("pylayer_method_apply " +
                         std::string(Py_TYPE(ctx)->tp_name) + " begin");
   }
@@ -527,7 +527,7 @@ PyObject* pylayer_method_apply(PyObject* cls,
   Py_XDECREF(forward_fn);
   Py_XDECREF(ctx);
 
-  if (FLAGS_check_cuda_error) {
+  if (FLAGS_check_cuda_error) [[unlikely]] {
     egr::CUDAErrorCheck("pylayer_method_apply " +
                         std::string(Py_TYPE(ctx)->tp_name) + " finish");
   }

--- a/paddle/fluid/pybind/eager_py_layer.cc
+++ b/paddle/fluid/pybind/eager_py_layer.cc
@@ -133,9 +133,6 @@ PyObject* pylayer_method_apply(PyObject* cls,
   EAGER_TRY
   SetPythonStack();
   VLOG(6) << "Begin run PyLayer apply...";
-  if (FLAGS_check_cuda_error) {
-    egr::CUDAErrorCheck("pylayer_method_apply begin");
-  }
   PyObject* backward_function =
       PyObject_GetAttrString(cls, "_backward_function");
   if (!backward_function) {
@@ -150,6 +147,10 @@ PyObject* pylayer_method_apply(PyObject* cls,
     return nullptr;
   }
   VLOG(6) << "PyLayer construct PyLayerContext finish...";
+  if (FLAGS_check_cuda_error) {
+    egr::CUDAErrorCheck("pylayer_method_apply " +
+                        std::string(Py_TYPE(ctx)->tp_name) + " begin");
+  }
 
   bool require_any_grad = false;
 
@@ -527,7 +528,8 @@ PyObject* pylayer_method_apply(PyObject* cls,
   Py_XDECREF(ctx);
 
   if (FLAGS_check_cuda_error) {
-    egr::CUDAErrorCheck("pylayer_method_apply finish");
+    egr::CUDAErrorCheck("pylayer_method_apply " +
+                        std::string(Py_TYPE(ctx)->tp_name) + " finish");
   }
 
   return outputs;

--- a/paddle/fluid/pybind/eager_py_layer.cc
+++ b/paddle/fluid/pybind/eager_py_layer.cc
@@ -35,6 +35,7 @@ limitations under the License. */
 #include "pybind11/pytypes.h"
 #pragma GCC diagnostic ignored "-Wwrite-strings"
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+COMMON_DECLARE_bool(check_cuda_error);
 
 using egr::ConvertToDistTensor;
 
@@ -132,6 +133,9 @@ PyObject* pylayer_method_apply(PyObject* cls,
   EAGER_TRY
   SetPythonStack();
   VLOG(6) << "Begin run PyLayer apply...";
+  if (FLAGS_check_cuda_error) {
+    egr::CUDAErrorCheck("pylayer_method_apply begin");
+  }
   PyObject* backward_function =
       PyObject_GetAttrString(cls, "_backward_function");
   if (!backward_function) {
@@ -521,6 +525,10 @@ PyObject* pylayer_method_apply(PyObject* cls,
   Py_XDECREF(backward_function);
   Py_XDECREF(forward_fn);
   Py_XDECREF(ctx);
+
+  if (FLAGS_check_cuda_error) {
+    egr::CUDAErrorCheck("pylayer_method_apply finish");
+  }
 
   return outputs;
   EAGER_CATCH_AND_THROW_RETURN_NULL


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
业务中、CINN中高频出现CUDA 700，CUDA 9，CUDA 719等问题。
新增FLAGS_check_cuda_error用于检查CUDA Error
支持动态图和PIR，PIR中OneDNN为了防止可能出现OneDNN与GPU混用，也加了Check。

CUDA700问题使用时最好是：
export FLAGS_use_system_allocator=1
export FLAGS_check_cuda_error=1
FLAGS_use_system_allocator=1的含义是不使用Allocator缓存池，直接使用cudaMalloc和cudaFree。使用缓存池可能导致访问越界无法发现。

Pcard-67164