### PR TITLE
fix bug for adaptive_log_softmax_with_loss

### DIFF
--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -4555,7 +4555,7 @@ def adaptive_log_softmax_with_loss(
         high_idx = cutoff_values[i + 1]
 
         label_mask = (label >= low_idx) & (label < high_idx)
-        row_indices = label_mask.nonzero().squeeze()
+        row_indices = label_mask.nonzero(as_tuple=True)[0]
 
         if row_indices.numel() == 0:
             continue

--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -4555,7 +4555,9 @@ def adaptive_log_softmax_with_loss(
         high_idx = cutoff_values[i + 1]
 
         label_mask = (label >= low_idx) & (label < high_idx)
-        row_indices = label_mask.nonzero(as_tuple=True)[0]
+        row_indices = label_mask.nonzero().squeeze()
+        if row_indices.dim() == 0:
+            row_indices.unsqueeze_(0)
 
         if row_indices.numel() == 0:
             continue

--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -4556,6 +4556,7 @@ def adaptive_log_softmax_with_loss(
 
         label_mask = (label >= low_idx) & (label < high_idx)
         row_indices = label_mask.nonzero().squeeze()
+
         if row_indices.dim() == 0:
             row_indices.unsqueeze_(0)
 

--- a/test/amp/test_tensor_checker.py
+++ b/test/amp/test_tensor_checker.py
@@ -49,9 +49,7 @@ class TestTensorChecker(unittest.TestCase):
         )
         y = paddle.to_tensor([0, 0, 1], dtype='float32')
         try:
-            print("------------")
             res = paddle.pow(x, y)
-            print(res)
             # test backward
             paddle.autograd.backward([res])
             res = paddle.divide(y, x)
@@ -103,7 +101,7 @@ class TestTensorChecker(unittest.TestCase):
                         f"-- [iter_id={iter_id}, place={place}] num_nan={num_nan}, num_inf={num_inf}"
                     )
                     self.assertEqual(
-                        0,
+                        1,
                         num_nan,
                         f"Expected num_nan to be 1, but received {num_nan}, place={place}.",
                     )

--- a/test/amp/test_tensor_checker.py
+++ b/test/amp/test_tensor_checker.py
@@ -49,7 +49,9 @@ class TestTensorChecker(unittest.TestCase):
         )
         y = paddle.to_tensor([0, 0, 1], dtype='float32')
         try:
+            print("------------")
             res = paddle.pow(x, y)
+            print(res)
             # test backward
             paddle.autograd.backward([res])
             res = paddle.divide(y, x)
@@ -101,7 +103,7 @@ class TestTensorChecker(unittest.TestCase):
                         f"-- [iter_id={iter_id}, place={place}] num_nan={num_nan}, num_inf={num_inf}"
                     )
                     self.assertEqual(
-                        1,
+                        0,
                         num_nan,
                         f"Expected num_nan to be 1, but received {num_nan}, place={place}.",
                     )


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience
### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes
### Description
<!-- Describe what you’ve done -->
原本的代码
row_indices = label_mask.nonzero().squeeze()
可能产生标量的结果导致接下来unsqueeze(1)失败
进行更改 使得row_indices不再为标量
![截屏2025-06-23 16 06 21](https://github.com/user-attachments/assets/8c74fd63-dd56-4bb8-b763-998068c5e342)

