### PR TITLE
[XPU] bugfix: skip async_offload for eb45 since cudaHostAllocPortable issue

### DIFF
--- a/python/paddle/incubate/tensor/manipulation.py
+++ b/python/paddle/incubate/tensor/manipulation.py
@@ -157,10 +157,8 @@ def async_offload(src_tensor, async_load):
     if is_xpu_tensor:
         # sync fallback
         host_tensor = src_tensor.cpu()
-        pinned = paddle.to_tensor(
-            host_tensor.numpy(), place=paddle.XPUPinnedPlace()
-        )
-        return pinned, _NoopAsyncTask()
+        out = paddle.to_tensor(host_tensor.numpy(), place=paddle.CPUPlace())
+        return out, _NoopAsyncTask()
 
     return _load_reload_impl(src_tensor, async_load.offload)
 
@@ -182,7 +180,7 @@ def async_reload(src_tensor, async_load):
     if (
         paddle.is_compiled_with_xpu()
         and hasattr(src_tensor, "place")
-        and src_tensor.place.is_xpu_pinned_place()
+        and src_tensor.place.is_cpu_place()
     ):
         arr = src_tensor.numpy()
         xpu = paddle.to_tensor(arr, place=paddle.XPUPlace(0))

--- a/python/paddle/incubate/tensor/manipulation.py
+++ b/python/paddle/incubate/tensor/manipulation.py
@@ -156,8 +156,11 @@ def async_offload(src_tensor, async_load):
 
     if is_xpu_tensor:
         # sync fallback
-        cpu_tensor = src_tensor.cpu()
-        return cpu_tensor, _NoopAsyncTask()
+        host_tensor = src_tensor.cpu()
+        pinned = paddle.to_tensor(
+            host_tensor.numpy(), place=paddle.XPUPinnedPlace()
+        )
+        return pinned, _NoopAsyncTask()
 
     return _load_reload_impl(src_tensor, async_load.offload)
 
@@ -175,6 +178,16 @@ def async_reload(src_tensor, async_load):
          - dest_tensor (EagerParamBase|paddle.Tensor): The destination tensor.
          - task (Task): The task that reloads the source tensor into the destination tensor.
     """
+
+    if (
+        paddle.is_compiled_with_xpu()
+        and hasattr(src_tensor, "place")
+        and src_tensor.place.is_xpu_pinned_place()
+    ):
+        arr = src_tensor.numpy()
+        xpu = paddle.to_tensor(arr, place=paddle.XPUPlace(0))
+        return xpu, _NoopAsyncTask()
+
     return _load_reload_impl(src_tensor, async_load.reload)
 
 

--- a/python/paddle/incubate/tensor/manipulation.py
+++ b/python/paddle/incubate/tensor/manipulation.py
@@ -122,6 +122,19 @@ def create_xpu_async_load():
     return core.XpuAsyncLoad()
 
 
+class _NoopAsyncTask:
+    """A dummy Task for sync‐fallback on XPU."""
+
+    def is_completed(self):
+        return True
+
+    def cpu_wait(self):
+        pass
+
+    def xpu_wait(self):
+        pass
+
+
 def async_offload(src_tensor, async_load):
     """
     Loads the source tensor into the destination tensor asynchronously.
@@ -135,6 +148,17 @@ def async_offload(src_tensor, async_load):
          - dest_tensor (EagerParamBase|paddle.Tensor): The destination tensor.
          - task (Task): The task that loads the source tensor into the destination tensor.
     """
+    is_xpu_tensor = (
+        paddle.is_compiled_with_xpu()
+        and hasattr(src_tensor, "place")
+        and src_tensor.place.is_xpu_place()
+    )
+
+    if is_xpu_tensor:
+        # sync fallback
+        cpu_tensor = src_tensor.cpu()
+        return cpu_tensor, _NoopAsyncTask()
+
     return _load_reload_impl(src_tensor, async_load.offload)
 
 

--- a/test/xpu/test_xpu_async_offload_reload_loadtest.py
+++ b/test/xpu/test_xpu_async_offload_reload_loadtest.py
@@ -48,7 +48,7 @@ class TestLargeTensorOffloadAndReloadRepeated(unittest.TestCase):
         for i in range(1):
             # print(f"\n--- Iteration {i+1} ---")
             # Create a large tensor on XPU.
-            large_arr = np.empty((512, 512, 10000), dtype="float32")
+            large_arr = np.empty((512, 512, 1000), dtype="float32")
             large_tensor = paddle.to_tensor(large_arr, place=paddle.XPUPlace(0))
             print_debug_info(large_tensor, "large_tensor (original)")
             loader = create_xpu_async_load()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Custom Device

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Skip async_offload for eb45 since cudaHostAllocPortable issue.