### PR TITLE
[Big tensor] fix paddle error in reduce all

### DIFF
--- a/paddle/phi/kernels/gpu/mean_all_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/mean_all_grad_kernel.cu
@@ -19,11 +19,11 @@
 namespace phi {
 
 template <typename T>
-__global__ void MeanRunKernel(const T* in_data, T* out_data, int N) {
+__global__ void MeanRunKernel(const T* in_data, T* out_data, int64_t N) {
   using MT = typename dtype::MPTypeTrait<T>::Type;
-  int idx = blockDim.x * blockIdx.x + threadIdx.x;
+  int64_t idx = static_cast<int64_t>(blockDim.x) * blockIdx.x + threadIdx.x;
   auto data = static_cast<MT>(in_data[0]);
-  for (; idx < N; idx += blockDim.x * gridDim.x) {
+  for (; idx < N; idx += static_cast<int64_t>(blockDim.x) * gridDim.x) {
     out_data[idx] = static_cast<T>(data / (static_cast<MT>(N)));
   }
 }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
 Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164
修复了mean模式下binary_crossentropy 大张量溢出的问题