### PR TITLE
[Accuracy diff No.1][BIT] Fix accuracy diff for `paddle.add_n` API

### DIFF
--- a/paddle/phi/kernels/cpu/add_n_kernel.cc
+++ b/paddle/phi/kernels/cpu/add_n_kernel.cc
@@ -30,6 +30,9 @@ void AddNKernel(const Context& dev_ctx,
   if (!x.empty() && x[0]->initialized() && DenseTensor::classof(x[0])) {
     if ((static_cast<const DenseTensor*>(x[0]))->Holder() == out->Holder()) {
       in_place = true;
+      if (in_num == 1) {
+        return;
+      }
     }
   }
 

--- a/paddle/phi/kernels/cpu/add_n_kernel.cc
+++ b/paddle/phi/kernels/cpu/add_n_kernel.cc
@@ -25,7 +25,6 @@ void AddNKernel(const Context& dev_ctx,
                 DenseTensor* out) {
   size_t in_num = x.size();
   dev_ctx.template Alloc<T>(out);
-
   bool in_place = false;
   if (!x.empty() && x[0]->initialized() && DenseTensor::classof(x[0])) {
     if ((static_cast<const DenseTensor*>(x[0]))->Holder() == out->Holder()) {
@@ -33,12 +32,15 @@ void AddNKernel(const Context& dev_ctx,
     }
   }
 
+  // Using MPType to leverage precision
   using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
   DenseTensor temp_out;
   temp_out.Resize(out->dims());
   dev_ctx.template Alloc<MPType>(&temp_out);
-  auto result_mp = EigenVector<MPType>::Flatten(temp_out);
+  phi::funcs::SetConstant<Context, MPType> constant_functor;
+  constant_functor(dev_ctx, &temp_out, static_cast<MPType>(0));
 
+  auto result_mp = EigenVector<MPType>::Flatten(temp_out);
   auto& place = *dev_ctx.eigen_device();
   int start = in_place ? 1 : 0;
   if (!in_place) {
@@ -53,11 +55,6 @@ void AddNKernel(const Context& dev_ctx,
         result_mp.device(place) = in_0_e + in_1_e;
         start = 2;
       }
-    }
-    if (start != 2) {
-      VLOG(10) << "Fill with constant = 0 in sum kernel.";
-      phi::funcs::SetConstant<Context, T> constant_functor;
-      constant_functor(dev_ctx, out, static_cast<T>(0));
     }
   }
 

--- a/paddle/phi/kernels/cpu/add_n_kernel.cc
+++ b/paddle/phi/kernels/cpu/add_n_kernel.cc
@@ -35,33 +35,19 @@ void AddNKernel(const Context& dev_ctx,
 
   // using MPType to keep precision
   using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
-  auto& place = *devCtx.eigen_device;
+  auto& place = *dev_ctx.eigen_device;
 
   if constexpr (std::is_same_v<MPType, T>) {
     // compute in out
     auto result = EigenVector<T>::Flatten(*out);
-    size_t start = in_place ? 1 : 0;
 
-    if (!in_place && in_num >= 2 && DenseTensor::classof(x[0]) &&
-        DenseTensor::classof(x[1]) && x[0]->initialized() &&
-        x[1]->initialized()) {
-      auto& in_0 = *(static_cast<const DenseTensor*>(x[0]));
-      auto& in_1 = *(static_cast<const DenseTensor*>(x[1]));
-      if (in_0.numel() && in_1.numel()) {
-        auto in_0_e = EigenVector<T>::Flatten(in_0);
-        auto in_1_e = EigenVector<T>::Flatten(in_1);
-        result.device(place) = in_0_e + in_1_e;
-        start = 2;
-      }
-    }
-
-    if (!in_place && start != 2) {
-      VLOG(10) << "Fill with constant = 0 in sum kernel.";
+    if (!in_place) {
       phi::funcs::SetConstant<Context, T> constant_functor;
-      constant_functor(devCtx, out, static_cast<T>(0));
+      constant_functor(dev_ctx, out, static_cast<T>(0));
     }
 
     phi::funcs::SelectedRowsAddToTensor<Context, T> functor;
+    size_t start = in_place ? 1 : 0;
     for (size_t i = start; i < in_num; i++) {
       if (DenseTensor::classof(x[i])) {
         auto& in_t = *(static_cast<const DenseTensor*>(x[i]));
@@ -72,7 +58,7 @@ void AddNKernel(const Context& dev_ctx,
         result.device(place) = result + in;
       } else if (SelectedRows::classof(x[i])) {
         auto& in_t = *(static_cast<const SelectedRows*>(x[i]));
-        functor(devCtx, in_t, out);
+        functor(dev_ctx, in_t, out);
       } else {
         PADDLE_THROW(common::errors::InvalidArgument(
             "Expected type of Input(X) of %d-th must be Tensor, "
@@ -86,6 +72,7 @@ void AddNKernel(const Context& dev_ctx,
     DenseTensor temp_out;
     temp_out.Resize(out->dims());
     dev_ctx.template Alloc<MPType>(&temp_out);
+
     auto result_mp = EigenVector<MPType>::Flatten(temp_out);
 
     // set temp_out
@@ -96,15 +83,15 @@ void AddNKernel(const Context& dev_ctx,
         auto in_0_e = EigenVector<T>::Flatten(in_0).template cast<MPType>();
         result_mp.device(place) = in_0_e;
       } else {
-        constant_functor(devCtx, &temp_out, static_cast<MPType>(0));
+        constant_functor(dev_ctx, &temp_out, static_cast<MPType>(0));
       }
     } else {
-      constant_functor(devCtx, &temp_out, static_cast<MPType>(0));
+      constant_functor(dev_ctx, &temp_out, static_cast<MPType>(0));
     }
 
     phi::funcs::SelectedRowsAddToTensor<Context, MPType> functor;
-    size_t start_idx = in_place ? 1 : 0;
-    for (size_t i = start_idx; i < in_num; i++) {
+    size_t start = in_place ? 1 : 0;
+    for (size_t i = start; i < in_num; i++) {
       if (DenseTensor::classof(x[i])) {
         auto& in_t = *(static_cast<const DenseTensor*>(x[i]));
         if (!in_t.initialized() || in_t.numel() == 0) {
@@ -128,8 +115,6 @@ void AddNKernel(const Context& dev_ctx,
     auto result = EigenVector<T>::Flatten(*out);
     result.device(place) = result_mp.template cast<T>();
   }
-
-  VLOG(10) << "end add_n kernel";
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/cpu/add_n_kernel.cc
+++ b/paddle/phi/kernels/cpu/add_n_kernel.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "paddle/phi/kernels/impl/add_n_kernel_impl.h"
+#include "paddle/phi/common/amp_type_traits.h"
 
 #include "glog/logging.h"
 
@@ -32,7 +33,12 @@ void AddNKernel(const Context& dev_ctx,
     }
   }
 
-  auto result = EigenVector<T>::Flatten(*out);
+  using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
+  DenseTensor temp_out;
+  temp_out.Resize(out->dims());
+  dev_ctx.template Alloc<MPType>(&temp_out);
+  auto result_mp = EigenVector<MPType>::Flatten(temp_out);
+
   auto& place = *dev_ctx.eigen_device();
   int start = in_place ? 1 : 0;
   if (!in_place) {
@@ -42,9 +48,9 @@ void AddNKernel(const Context& dev_ctx,
       auto& in_0 = *(static_cast<const DenseTensor*>(x[0]));
       auto& in_1 = *(static_cast<const DenseTensor*>(x[1]));
       if (in_0.numel() && in_1.numel()) {
-        auto in_0_e = EigenVector<T>::Flatten(in_0);
-        auto in_1_e = EigenVector<T>::Flatten(in_1);
-        result.device(place) = in_0_e + in_1_e;
+        auto in_0_e = EigenVector<T>::Flatten(in_0).template cast<MPType>();
+        auto in_1_e = EigenVector<T>::Flatten(in_1).template cast<MPType>();
+        result_mp.device(place) = in_0_e + in_1_e;
         start = 2;
       }
     }
@@ -55,7 +61,7 @@ void AddNKernel(const Context& dev_ctx,
     }
   }
 
-  phi::funcs::SelectedRowsAddToTensor<Context, T> functor;
+  phi::funcs::SelectedRowsAddToTensor<Context, MPType> functor;
   // If in_place, just skip the first tensor
   for (size_t i = start; i < in_num; i++) {
     if (DenseTensor::classof(x[i])) {
@@ -63,11 +69,11 @@ void AddNKernel(const Context& dev_ctx,
       if (!in_t.initialized() || in_t.numel() == 0) {
         continue;
       }
-      auto in = EigenVector<T>::Flatten(in_t);
-      result.device(place) = result + in;
+      auto in = EigenVector<T>::Flatten(in_t).template cast<MPType>();
+      result_mp.device(place) = result_mp + in;
     } else if (SelectedRows::classof(x[i])) {
       auto& in_t = *(static_cast<const SelectedRows*>(x[i]));
-      functor(dev_ctx, in_t, out);
+      functor(dev_ctx, in_t, &temp_out);
     } else {
       PADDLE_THROW(common::errors::InvalidArgument(
           "Expected type of Input(X) of %d-th must be Tensor, "
@@ -76,6 +82,8 @@ void AddNKernel(const Context& dev_ctx,
           x[i]->type_info().name()));
     }
   }
+  auto result = EigenVector<T>::Flatten(*out);
+  result.device(place) = result_mp.template cast<T>();
   VLOG(10) << "end add_n kernel";
 }
 

--- a/paddle/phi/kernels/cpu/add_n_kernel.cc
+++ b/paddle/phi/kernels/cpu/add_n_kernel.cc
@@ -38,7 +38,7 @@ void AddNKernel(const Context& dev_ctx,
 
   // using MPType to keep precision
   using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
-  auto& place = *dev_ctx.eigen_device;
+  auto& place = *dev_ctx.eigen_device();
 
   if constexpr (std::is_same_v<MPType, T>) {
     // compute in out

--- a/paddle/phi/kernels/cpu/add_n_kernel.cc
+++ b/paddle/phi/kernels/cpu/add_n_kernel.cc
@@ -25,6 +25,7 @@ void AddNKernel(const Context& dev_ctx,
                 DenseTensor* out) {
   size_t in_num = x.size();
   dev_ctx.template Alloc<T>(out);
+
   bool in_place = false;
   if (!x.empty() && x[0]->initialized() && DenseTensor::classof(x[0])) {
     if ((static_cast<const DenseTensor*>(x[0]))->Holder() == out->Holder()) {
@@ -32,55 +33,102 @@ void AddNKernel(const Context& dev_ctx,
     }
   }
 
-  // Using MPType to leverage precision
+  // using MPType to keep precision
   using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
-  DenseTensor temp_out;
-  temp_out.Resize(out->dims());
-  dev_ctx.template Alloc<MPType>(&temp_out);
-  phi::funcs::SetConstant<Context, MPType> constant_functor;
-  constant_functor(dev_ctx, &temp_out, static_cast<MPType>(0));
+  auto& place = *devCtx.eigen_device;
 
-  auto result_mp = EigenVector<MPType>::Flatten(temp_out);
-  auto& place = *dev_ctx.eigen_device();
-  int start = in_place ? 1 : 0;
-  if (!in_place) {
-    if ((in_num >= 2) && DenseTensor::classof(x[0]) &&
+  if constexpr (std::is_same_v<MPType, T>) {
+    // compute in out
+    auto result = EigenVector<T>::Flatten(*out);
+    size_t start = in_place ? 1 : 0;
+
+    if (!in_place && in_num >= 2 && DenseTensor::classof(x[0]) &&
         DenseTensor::classof(x[1]) && x[0]->initialized() &&
         x[1]->initialized()) {
       auto& in_0 = *(static_cast<const DenseTensor*>(x[0]));
       auto& in_1 = *(static_cast<const DenseTensor*>(x[1]));
       if (in_0.numel() && in_1.numel()) {
-        auto in_0_e = EigenVector<T>::Flatten(in_0).template cast<MPType>();
-        auto in_1_e = EigenVector<T>::Flatten(in_1).template cast<MPType>();
-        result_mp.device(place) = in_0_e + in_1_e;
+        auto in_0_e = EigenVector<T>::Flatten(in_0);
+        auto in_1_e = EigenVector<T>::Flatten(in_1);
+        result.device(place) = in_0_e + in_1_e;
         start = 2;
       }
     }
+
+    if (!in_place && start != 2) {
+      VLOG(10) << "Fill with constant = 0 in sum kernel.";
+      phi::funcs::SetConstant<Context, T> constant_functor;
+      constant_functor(devCtx, out, static_cast<T>(0));
+    }
+
+    phi::funcs::SelectedRowsAddToTensor<Context, T> functor;
+    for (size_t i = start; i < in_num; i++) {
+      if (DenseTensor::classof(x[i])) {
+        auto& in_t = *(static_cast<const DenseTensor*>(x[i]));
+        if (!in_t.initialized() || in_t.numel() == 0) {
+          continue;
+        }
+        auto in = EigenVector<T>::Flatten(in_t);
+        result.device(place) = result + in;
+      } else if (SelectedRows::classof(x[i])) {
+        auto& in_t = *(static_cast<const SelectedRows*>(x[i]));
+        functor(devCtx, in_t, out);
+      } else {
+        PADDLE_THROW(common::errors::InvalidArgument(
+            "Expected type of Input(X) of %d-th must be Tensor, "
+            "SelectedRows. But got "
+            "unsupported type: %s.",
+            x[i]->type_info().name()));
+      }
+    }
+  } else {
+    // compute in temp_out by using MPType
+    DenseTensor temp_out;
+    temp_out.Resize(out->dims());
+    dev_ctx.template Alloc<MPType>(&temp_out);
+    auto result_mp = EigenVector<MPType>::Flatten(temp_out);
+
+    // set temp_out
+    phi::funcs::SetConstant<Context, MPType> constant_functor;
+    if (in_place && DenseTensor::classof(x[0]) && x[0]->initialized()) {
+      auto& in_0 = *(static_cast<const DenseTensor*>(x[0]));
+      if (in_0.numel()) {
+        auto in_0_e = EigenVector<T>::Flatten(in_0).template cast<MPType>();
+        result_mp.device(place) = in_0_e;
+      } else {
+        constant_functor(devCtx, &temp_out, static_cast<MPType>(0));
+      }
+    } else {
+      constant_functor(devCtx, &temp_out, static_cast<MPType>(0));
+    }
+
+    phi::funcs::SelectedRowsAddToTensor<Context, MPType> functor;
+    size_t start_idx = in_place ? 1 : 0;
+    for (size_t i = start_idx; i < in_num; i++) {
+      if (DenseTensor::classof(x[i])) {
+        auto& in_t = *(static_cast<const DenseTensor*>(x[i]));
+        if (!in_t.initialized() || in_t.numel() == 0) {
+          continue;
+        }
+        auto in = EigenVector<T>::Flatten(in_t).template cast<MPType>();
+        result_mp.device(place) = result_mp + in;
+      } else if (SelectedRows::classof(x[i])) {
+        auto& in_t = *(static_cast<const SelectedRows*>(x[i]));
+        functor(dev_ctx, in_t, &temp_out);
+      } else {
+        PADDLE_THROW(common::errors::InvalidArgument(
+            "Expected type of Input(X) of %d-th must be Tensor, "
+            "SelectedRows. But got "
+            "unsupported type: %s.",
+            x[i]->type_info().name()));
+      }
+    }
+
+    // cast back to T, and copy to out
+    auto result = EigenVector<T>::Flatten(*out);
+    result.device(place) = result_mp.template cast<T>();
   }
 
-  phi::funcs::SelectedRowsAddToTensor<Context, MPType> functor;
-  // If in_place, just skip the first tensor
-  for (size_t i = start; i < in_num; i++) {
-    if (DenseTensor::classof(x[i])) {
-      auto& in_t = *(static_cast<const DenseTensor*>(x[i]));
-      if (!in_t.initialized() || in_t.numel() == 0) {
-        continue;
-      }
-      auto in = EigenVector<T>::Flatten(in_t).template cast<MPType>();
-      result_mp.device(place) = result_mp + in;
-    } else if (SelectedRows::classof(x[i])) {
-      auto& in_t = *(static_cast<const SelectedRows*>(x[i]));
-      functor(dev_ctx, in_t, &temp_out);
-    } else {
-      PADDLE_THROW(common::errors::InvalidArgument(
-          "Expected type of Input(X) of %d-th must be Tensor, "
-          "SelectedRows. But got "
-          "unsupported type: %s.",
-          x[i]->type_info().name()));
-    }
-  }
-  auto result = EigenVector<T>::Flatten(*out);
-  result.device(place) = result_mp.template cast<T>();
   VLOG(10) << "end add_n kernel";
 }
 

--- a/paddle/phi/kernels/cpu/add_n_kernel.cc
+++ b/paddle/phi/kernels/cpu/add_n_kernel.cc
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "paddle/phi/kernels/impl/add_n_kernel_impl.h"
 #include "paddle/phi/common/amp_type_traits.h"
+#include "paddle/phi/kernels/impl/add_n_kernel_impl.h"
 
 #include "glog/logging.h"
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
The `AddNKernel` for `paddle.add_n` api on CPU (location: `paddle/phi/kernels/cpu/add_n_kernel.cc`) did not implement type promotion, resulting in accuracy diff compared to torch.

This pr resolves the issue by utilizing `MPTypeTrait` and `temp_out` for intermediate computations.
- When types are promoted, `temp_out` is requested and finally casts back to the original type. 
- When types are consistent, in-place operation is retained. 
- Removes the old code for adding two tensors (failed to zero `out` in edge cases).

All `paddle.add_n` test cases pass in CPU mode on PaddleAPITest:
![image](https://github.com/user-attachments/assets/d7b1d96c-f34e-4ab5-bce6-94578a4c208d)
