### PR TITLE
[BIT] Optimize print speed

### DIFF
--- a/python/paddle/tensor/to_string.py
+++ b/python/paddle/tensor/to_string.py
@@ -183,24 +183,24 @@ def _format_tensor(var, summary, indent=0, max_width=0, signed=False):
         return _format_item(var, max_width, signed)
     elif len(var.shape) == 1:
         item_length = max_width + 2
-        items_per_line = (linewidth - indent) // item_length
-        items_per_line = max(1, items_per_line)
+        items_per_line = max(1, (linewidth - indent) // item_length)
 
         if summary and var.shape[0] > 2 * edgeitems:
             items = (
                 [
-                    _format_item(item, max_width, signed)
-                    for item in list(var)[:edgeitems]
+                    _format_item(var[i], max_width, signed)
+                    for i in range(edgeitems)
                 ]
                 + ['...']
                 + [
-                    _format_item(item, max_width, signed)
-                    for item in list(var)[(-1 * edgeitems) :]
+                    _format_item(var[i], max_width, signed)
+                    for i in range(var.shape[0] - edgeitems, var.shape[0])
                 ]
             )
         else:
             items = [
-                _format_item(item, max_width, signed) for item in list(var)
+                _format_item(var[i], max_width, signed)
+                for i in range(var.shape[0])
             ]
         lines = [
             items[i : i + items_per_line]
@@ -215,28 +215,27 @@ def _format_tensor(var, summary, indent=0, max_width=0, signed=False):
         if summary and var.shape[0] > 2 * edgeitems:
             vars = (
                 [
-                    _format_tensor(x, summary, indent + 1, max_width, signed)
-                    for x in var[:edgeitems]
+                    _format_tensor(
+                        var[i], summary, indent + 1, max_width, signed
+                    )
+                    for i in range(edgeitems)
                 ]
                 + ['...']
                 + [
-                    _format_tensor(x, summary, indent + 1, max_width, signed)
-                    for x in var[(-1 * edgeitems) :]
+                    _format_tensor(
+                        var[i], summary, indent + 1, max_width, signed
+                    )
+                    for i in range(var.shape[0] - edgeitems, var.shape[0])
                 ]
             )
         else:
             vars = [
-                _format_tensor(x, summary, indent + 1, max_width, signed)
-                for x in var
+                _format_tensor(var[i], summary, indent + 1, max_width, signed)
+                for i in range(var.shape[0])
             ]
 
-        return (
-            '['
-            + (',' + '\n' * (len(var.shape) - 1) + ' ' * (indent + 1)).join(
-                vars
-            )
-            + ']'
-        )
+        s = (',' + '\n' * (len(var.shape) - 1) + ' ' * (indent + 1)).join(vars)
+        return '[' + s + ']'
 
 
 def to_string(var, prefix='Tensor'):

--- a/python/paddle/tensor/to_string.py
+++ b/python/paddle/tensor/to_string.py
@@ -308,16 +308,7 @@ def _format_dense_tensor(tensor, indent):
     ):
         np_tensor = mask_xpu_bf16_tensor(np_tensor)
 
-    if len(tensor.shape) == 0:
-        size = 0
-    else:
-        size = 1
-        for dim in tensor.shape:
-            size *= dim
-
-    summary = False
-    if size > DEFAULT_PRINT_OPTIONS.threshold:
-        summary = True
+    summary = tensor.numel() > DEFAULT_PRINT_OPTIONS.threshold
 
     max_width, signed = _get_max_width(_to_summary(np_tensor))
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
Optimizing tensor printing speed:

In old code `list(var)` would iterate through all elements before slicing, which was extremely slow. 

Using direct index access `var[i]` will significantly reduce element access time, proving especially useful for ultra-large tensors. 

The printing speed for elements up to **the uint32 limit** will be reduced from 10 minutes to 5 seconds:
```python
import paddle
import time

start = time.time()
paddle_tensor = paddle.full([4294967300], 0.1, dtype=paddle.float16)
mid = time.time()
print(paddle_tensor)
end = time.time()

> Tensor(shape=[4294967300], dtype=float16, place=Place(gpu:0), stop_gradient=True,
>        [0.09997559, 0.09997559, 0.09997559, ..., 0.09997559, 0.09997559,
>         0.09997559])
> paddle.full print time:  5.98477506637573
```