### PR TITLE
Align paddle.linalg.qr kernel with torch

### DIFF
--- a/paddle/phi/backends/dynload/cusolver.h
+++ b/paddle/phi/backends/dynload/cusolver.h
@@ -77,6 +77,7 @@ CUSOLVER_ROUTINE_EACH(DECLARE_DYNAMIC_LOAD_CUSOLVER_WRAP);
   __macro(cusolverDnDgeqrf_bufferSize);   \
   __macro(cusolverDnCgeqrf_bufferSize);   \
   __macro(cusolverDnZgeqrf_bufferSize);   \
+  __macro(cusolverDnXgeqrf_bufferSize);   \
   __macro(cusolverDnSorgqr_bufferSize);   \
   __macro(cusolverDnDorgqr_bufferSize);   \
   __macro(cusolverDnSormqr_bufferSize);   \
@@ -103,6 +104,7 @@ CUSOLVER_ROUTINE_EACH(DECLARE_DYNAMIC_LOAD_CUSOLVER_WRAP);
   __macro(cusolverDnDgeqrf);              \
   __macro(cusolverDnCgeqrf);              \
   __macro(cusolverDnZgeqrf);              \
+  __macro(cusolverDnXgeqrf);              \
   __macro(cusolverDnSorgqr);              \
   __macro(cusolverDnDorgqr);              \
   __macro(cusolverDnSormqr);              \

--- a/paddle/phi/kernels/gpu/qr_kernel.cu
+++ b/paddle/phi/kernels/gpu/qr_kernel.cu
@@ -411,47 +411,139 @@ void BatchedGeqrf<GPUContext, float>(const GPUContext& dev_ctx,
                                      float* tau,
                                      int a_stride,
                                      int tau_stride) {
-  int lwork = 0;
+  if (static_cast<int64_t>(m) * static_cast<int64_t>(n) * 171 >
+      std::numeric_limits<int>::max()) {
+    std::cout << "执行Xgeqrf" << std::endl;
+    const int64_t batch_size_64 = static_cast<int64_t>(batch_size);
+    const int64_t m_64 = static_cast<int64_t>(m);
+    const int64_t n_64 = static_cast<int64_t>(n);
+    const int64_t lda_64 = static_cast<int64_t>(lda);
+    const int64_t a_stride_64 = static_cast<int64_t>(a_stride);
+    const int64_t tau_stride_64 = static_cast<int64_t>(tau_stride);
 
-  auto handle = dev_ctx.cusolver_dn_handle();
-  PADDLE_ENFORCE_GPU_SUCCESS(
-      phi::dynload::cusolverDnSgeqrf_bufferSize(handle, m, n, a, lda, &lwork));
+    auto handle = dev_ctx.cusolver_dn_handle();
 
-  DenseTensor workspace = DenseTensor();
-  workspace.Resize(common::make_ddim({lwork}));
-  float* workspace_ptr = dev_ctx.template Alloc<float>(&workspace);
+    size_t workspace_in_bytes_on_device = 0;
+    size_t workspace_in_bytes_on_host = 0;
 
-  DenseTensor info = DenseTensor();
-  info.Resize(common::make_ddim({1}));
-  int* info_d = dev_ctx.template Alloc<int>(&info);
+    PADDLE_ENFORCE_GPU_SUCCESS(
+        cusolverDnXgeqrf_bufferSize(handle,
+                                    nullptr,
+                                    m_64,
+                                    n_64,
+                                    CUDA_R_32F,
+                                    a,
+                                    lda_64,
+                                    CUDA_R_32F,
+                                    tau,
+                                    CUDA_R_32F,
+                                    &workspace_in_bytes_on_device,
+                                    &workspace_in_bytes_on_host));
 
-  for (int i = 0; i < batch_size; ++i) {
-    float* a_working_ptr = &a[i * a_stride];
-    float* tau_working_ptr = &tau[i * tau_stride];
-    // compute geqrf
-    PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::cusolverDnSgeqrf(handle,
-                                                              m,
-                                                              n,
-                                                              a_working_ptr,
-                                                              lda,
-                                                              tau_working_ptr,
-                                                              workspace_ptr,
-                                                              lwork,
-                                                              info_d));
-    // Do we need synchronized here?
-    // check the error info
-    int info_h;
-    memory_utils::Copy(phi::CPUPlace(),
-                       &info_h,
-                       dev_ctx.GetPlace(),
-                       info_d,
-                       sizeof(int),
-                       dev_ctx.stream());
-    PADDLE_ENFORCE_EQ(
-        info_h,
-        0,
-        common::errors::PreconditionNotMet(
-            "For batch [%d]: CUSolver geqrf is not zero. [%d]", i, info_h));
+    DenseTensor device_workspace;
+    device_workspace.Resize(common::make_ddim(
+        {static_cast<int64_t>(workspace_in_bytes_on_device)}));
+    uint8_t* device_workspace_ptr =
+        dev_ctx.template Alloc<uint8_t>(&device_workspace);
+
+    DenseTensor host_workspace;
+    uint8_t* host_workspace_ptr = nullptr;  // Default to nullptr
+
+    if (workspace_in_bytes_on_host > 0) {
+      // Allocate only if cuSOLVER requests it
+      host_workspace.Resize(common::make_ddim(
+          {static_cast<int64_t>(workspace_in_bytes_on_host)}));
+      host_workspace_ptr = dev_ctx.template HostAlloc<uint8_t>(&host_workspace);
+    }
+
+    DenseTensor info;
+    info.Resize(common::make_ddim({1}));
+    int* info_d = dev_ctx.template Alloc<int>(&info);
+
+    for (int64_t i = 0; i < batch_size_64; ++i) {
+      float* a_working_ptr = &a[i * a_stride_64];
+      float* tau_working_ptr = &tau[i * tau_stride_64];
+
+      PADDLE_ENFORCE_GPU_SUCCESS(cusolverDnXgeqrf(handle,
+                                                  nullptr,
+                                                  m_64,
+                                                  n_64,
+                                                  CUDA_R_32F,
+                                                  a_working_ptr,
+                                                  lda_64,
+                                                  CUDA_R_32F,
+                                                  tau_working_ptr,
+                                                  CUDA_R_32F,
+                                                  device_workspace_ptr,
+                                                  workspace_in_bytes_on_device,
+                                                  host_workspace_ptr,
+                                                  workspace_in_bytes_on_host,
+                                                  info_d));
+
+      int info_h;
+      memory_utils::Copy(phi::CPUPlace(),
+                         &info_h,
+                         dev_ctx.GetPlace(),
+                         info_d,
+                         sizeof(int),
+                         dev_ctx.stream());
+      PADDLE_ENFORCE_EQ(
+          info_h,
+          0,
+          common::errors::PreconditionNotMet(
+              "For batch [%d]: CUSolver (64-bit) geqrf is not zero. [%d]",
+              i,
+              info_h));
+    }
+  } else {
+    int lwork = 0;
+
+    auto handle = dev_ctx.cusolver_dn_handle();
+
+    PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::cusolverDnSgeqrf_bufferSize(
+        handle, m, n, a, lda, &lwork));
+    // std::cout << "打印" << std::endl;
+    // std::cout << " m = " << m << std::endl;
+    // std::cout << " n = " << n << std::endl;
+    // std::cout << " lwork = " << lwork << std::endl;
+    // std::cout << " batch_size " << batch_size << std::endl;
+
+    DenseTensor workspace = DenseTensor();
+    workspace.Resize(common::make_ddim({lwork}));
+    float* workspace_ptr = dev_ctx.template Alloc<float>(&workspace);
+
+    DenseTensor info = DenseTensor();
+    info.Resize(common::make_ddim({1}));
+    int* info_d = dev_ctx.template Alloc<int>(&info);
+
+    for (int i = 0; i < batch_size; ++i) {
+      float* a_working_ptr = &a[i * a_stride];
+      float* tau_working_ptr = &tau[i * tau_stride];
+      // compute geqrf
+      PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::cusolverDnSgeqrf(handle,
+                                                                m,
+                                                                n,
+                                                                a_working_ptr,
+                                                                lda,
+                                                                tau_working_ptr,
+                                                                workspace_ptr,
+                                                                lwork,
+                                                                info_d));
+      // Do we need synchronized here?
+      // check the error info
+      int info_h;
+      memory_utils::Copy(phi::CPUPlace(),
+                         &info_h,
+                         dev_ctx.GetPlace(),
+                         info_d,
+                         sizeof(int),
+                         dev_ctx.stream());
+      PADDLE_ENFORCE_EQ(
+          info_h,
+          0,
+          common::errors::PreconditionNotMet(
+              "For batch [%d]: CUSolver geqrf is not zero. [%d]", i, info_h));
+    }
   }
 }
 

--- a/paddle/phi/kernels/gpu/qr_kernel.cu
+++ b/paddle/phi/kernels/gpu/qr_kernel.cu
@@ -413,7 +413,6 @@ void BatchedGeqrf<GPUContext, float>(const GPUContext& dev_ctx,
                                      int tau_stride) {
   if (static_cast<int64_t>(m) * static_cast<int64_t>(n) * 171 >
       std::numeric_limits<int>::max()) {
-    std::cout << "执行Xgeqrf" << std::endl;
     const int64_t batch_size_64 = static_cast<int64_t>(batch_size);
     const int64_t m_64 = static_cast<int64_t>(m);
     const int64_t n_64 = static_cast<int64_t>(n);
@@ -447,10 +446,9 @@ void BatchedGeqrf<GPUContext, float>(const GPUContext& dev_ctx,
         dev_ctx.template Alloc<uint8_t>(&device_workspace);
 
     DenseTensor host_workspace;
-    uint8_t* host_workspace_ptr = nullptr;  // Default to nullptr
+    uint8_t* host_workspace_ptr = nullptr;
 
     if (workspace_in_bytes_on_host > 0) {
-      // Allocate only if cuSOLVER requests it
       host_workspace.Resize(common::make_ddim(
           {static_cast<int64_t>(workspace_in_bytes_on_host)}));
       host_workspace_ptr = dev_ctx.template HostAlloc<uint8_t>(&host_workspace);
@@ -499,14 +497,8 @@ void BatchedGeqrf<GPUContext, float>(const GPUContext& dev_ctx,
     int lwork = 0;
 
     auto handle = dev_ctx.cusolver_dn_handle();
-
     PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::cusolverDnSgeqrf_bufferSize(
         handle, m, n, a, lda, &lwork));
-    // std::cout << "打印" << std::endl;
-    // std::cout << " m = " << m << std::endl;
-    // std::cout << " n = " << n << std::endl;
-    // std::cout << " lwork = " << lwork << std::endl;
-    // std::cout << " batch_size " << batch_size << std::endl;
 
     DenseTensor workspace = DenseTensor();
     workspace.Resize(common::make_ddim({lwork}));

--- a/paddle/phi/kernels/gpu/qr_kernel.cu
+++ b/paddle/phi/kernels/gpu/qr_kernel.cu
@@ -411,8 +411,7 @@ void BatchedGeqrf<GPUContext, float>(const GPUContext& dev_ctx,
                                      float* tau,
                                      int a_stride,
                                      int tau_stride) {
-  if (static_cast<int64_t>(m) * static_cast<int64_t>(n) * 171 >
-      std::numeric_limits<int>::max()) {
+  if (static_cast<int64_t>(m) * n * 171 > std::numeric_limits<int>::max()) {
     const int64_t batch_size_64 = static_cast<int64_t>(batch_size);
     const int64_t m_64 = static_cast<int64_t>(m);
     const int64_t n_64 = static_cast<int64_t>(n);
@@ -426,18 +425,18 @@ void BatchedGeqrf<GPUContext, float>(const GPUContext& dev_ctx,
     size_t workspace_in_bytes_on_host = 0;
 
     PADDLE_ENFORCE_GPU_SUCCESS(
-        cusolverDnXgeqrf_bufferSize(handle,
-                                    nullptr,
-                                    m_64,
-                                    n_64,
-                                    CUDA_R_32F,
-                                    a,
-                                    lda_64,
-                                    CUDA_R_32F,
-                                    tau,
-                                    CUDA_R_32F,
-                                    &workspace_in_bytes_on_device,
-                                    &workspace_in_bytes_on_host));
+        phi::dynload::cusolverDnXgeqrf_bufferSize(handle,
+                                                  nullptr,
+                                                  m_64,
+                                                  n_64,
+                                                  CUDA_R_32F,
+                                                  a,
+                                                  lda_64,
+                                                  CUDA_R_32F,
+                                                  tau,
+                                                  CUDA_R_32F,
+                                                  &workspace_in_bytes_on_device,
+                                                  &workspace_in_bytes_on_host));
 
     DenseTensor device_workspace;
     device_workspace.Resize(common::make_ddim(
@@ -462,21 +461,22 @@ void BatchedGeqrf<GPUContext, float>(const GPUContext& dev_ctx,
       float* a_working_ptr = &a[i * a_stride_64];
       float* tau_working_ptr = &tau[i * tau_stride_64];
 
-      PADDLE_ENFORCE_GPU_SUCCESS(cusolverDnXgeqrf(handle,
-                                                  nullptr,
-                                                  m_64,
-                                                  n_64,
-                                                  CUDA_R_32F,
-                                                  a_working_ptr,
-                                                  lda_64,
-                                                  CUDA_R_32F,
-                                                  tau_working_ptr,
-                                                  CUDA_R_32F,
-                                                  device_workspace_ptr,
-                                                  workspace_in_bytes_on_device,
-                                                  host_workspace_ptr,
-                                                  workspace_in_bytes_on_host,
-                                                  info_d));
+      PADDLE_ENFORCE_GPU_SUCCESS(
+          phi::dynload::cusolverDnXgeqrf(handle,
+                                         nullptr,
+                                         m_64,
+                                         n_64,
+                                         CUDA_R_32F,
+                                         a_working_ptr,
+                                         lda_64,
+                                         CUDA_R_32F,
+                                         tau_working_ptr,
+                                         CUDA_R_32F,
+                                         device_workspace_ptr,
+                                         workspace_in_bytes_on_device,
+                                         host_workspace_ptr,
+                                         workspace_in_bytes_on_host,
+                                         info_d));
 
       int info_h;
       memory_utils::Copy(phi::CPUPlace(),


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
improvements

### Description
<!-- Describe what you’ve done -->
- 背景介绍：qr分解是将一个矩阵分解成正交矩阵Q和上三角矩阵R。在求解的过程中一般包括两个步骤，首先利用cusolverDn*geqrf_bufferSize计算分解所需空间，而后利用cusolverDn*geqrf执行分解（其中*表示不同的api类型）
- 当前的局限性：代码中采用的api是cusolverDnSgeqrf_bufferSize。这个函数功能是在单精度下计算qr分解时需要的内存大小，计算结果存在int类型数据lwork中，但是当矩阵规模过大，会导致lwork溢出，报错误参数的问题：CUSOLVER error(3).CUSOLVER_STATUS_INVALID_VALUE
- 修改方法：添加一个矩阵大小判定的过程，对大规模矩阵采用cusolverDnXgeqrf_bufferSize，这个api对应的lwork为int64_t类型，可以处理更大规模的矩阵分解（pytorch在大尺寸下也是用的这个api）
- 修改结果：
![image](https://github.com/user-attachments/assets/0437aa9d-a6a6-4e20-a564-1b4e57044966)
![image](https://github.com/user-attachments/assets/0bf74692-155a-42ba-b4ce-5cb6c17972cd)
- 补充说明：部分测例不合理，比如Tensor([2, 3, 380283564]，执行qr分解所需的内存远超一般gpu显存大小。



