### PR TITLE
Update dynamic_loader.cc

### DIFF
--- a/paddle/phi/backends/dynload/dynamic_loader.cc
+++ b/paddle/phi/backends/dynload/dynamic_loader.cc
@@ -296,9 +296,9 @@ static inline void* GetDsoHandleFromSearchPath(
     std::wstring win_path_wstring =
         converter.from_bytes(FLAGS_win_cuda_bin_dir);
     search_path = win_path_wstring + L"\\" + search_path + L"\\bin";
-   #ifdef PADDLE_WITH_CUDA
+#ifdef PADDLE_WITH_CUDA
     AddDllDirectory(search_path.c_str());
-#endif 
+#endif
   }
 #endif
   std::vector<std::string> dso_names = split(dso_name, ";");

--- a/paddle/phi/backends/dynload/dynamic_loader.cc
+++ b/paddle/phi/backends/dynload/dynamic_loader.cc
@@ -296,7 +296,9 @@ static inline void* GetDsoHandleFromSearchPath(
     std::wstring win_path_wstring =
         converter.from_bytes(FLAGS_win_cuda_bin_dir);
     search_path = win_path_wstring + L"\\" + search_path + L"\\bin";
+   #ifdef PADDLE_WITH_CUDA
     AddDllDirectory(search_path.c_str());
+#endif 
   }
 #endif
   std::vector<std::string> dso_names = split(dso_name, ";");


### PR DESCRIPTION
### PR Category

Inference

### PR Types

Bug fixes

### Description

修复win7系统下使用C++版本的CPU推理时报错
“无法定位程序输入点 AddDllDirectory 于动态链接库 KERNEL32.dll 上。”问题， 该方法仅用于GPU模式，
改成 PADDLE_WITH_CUDA条件编译。

