### PR TITLE
[Distributed] fix recreate nccl comm bug

### DIFF
--- a/paddle/fluid/distributed/collective/process_group_nccl.cc
+++ b/paddle/fluid/distributed/collective/process_group_nccl.cc
@@ -988,8 +988,8 @@ void ProcessGroupNCCL::Restart() {
     phi::distributed::P2POption p2p_opts = place_to_p2p_opts_.at(place_key);
     phi::distributed::CommContextManager::RecreateNCCLComm(
         store_, store_key, rank_, std::to_string(create_count_), &p2p_opts);
-    create_count_++;
   }
+  create_count_++;
 }
 
 void ProcessGroupNCCL::SyncCalcStream(const Place& place,

--- a/paddle/fluid/distributed/collective/process_group_nccl.h
+++ b/paddle/fluid/distributed/collective/process_group_nccl.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <chrono>
+#include <map>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -276,7 +277,7 @@ class ProcessGroupNCCL final : public ProcessGroupWithStream {
 
   uint64_t comm_seq_{0};
   std::unordered_map<std::string, uint64_t> p2p_comm_seq_;
-  std::unordered_map<std::string, std::string> place_to_group_key_;
+  std::map<std::string, std::string> place_to_group_key_;
 
   // TODO(sunyilun): attrs below will be removed later
   std::mutex mutex_;

--- a/paddle/phi/core/distributed/comm_context_manager.cc
+++ b/paddle/phi/core/distributed/comm_context_manager.cc
@@ -130,7 +130,7 @@ void CommContextManager::CreateNCCLCommContext(
 void CommContextManager::RecreateNCCLComm(const std::shared_ptr<Store>& store,
                                           const std::string& unique_comm_key,
                                           int rank,
-                                          const std::string& hash_key,
+                                          const std::string& recreate_key,
                                           const P2POption* p2p_opt) {
   auto& comm_context_manager = CommContextManager::GetInstance();
 
@@ -139,7 +139,8 @@ void CommContextManager::RecreateNCCLComm(const std::shared_ptr<Store>& store,
     PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::ncclGetUniqueId(&nccl_id));
   }
 
-  std::string unique_key = "NCCLCommContext/" + unique_comm_key + hash_key;
+  std::string unique_key =
+      "NCCLCommContext/" + unique_comm_key + "/" + recreate_key;
   if (rank == 0 || (p2p_opt && p2p_opt->is_p2p_op && p2p_opt->p2p_rank == 0)) {
     std::vector<uint8_t> nccl_id_wrapper(
         reinterpret_cast<uint8_t*>(&nccl_id),


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Distributed Strategy

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes 

### Description
<!-- Describe what you’ve done -->
Pcard-90602
在开pp的场景下recreate nccl comm存在hang的问题， 原因是同一个通信组内 tcp通信时unique_key的获取是无序的，导致相互等待。当前通过有序map代替无序map来修复这个问题。