### PR TITLE
[SOT] Limit dataclass types to prevent endless alignment support

### DIFF
--- a/python/paddle/jit/dy2static/utils.py
+++ b/python/paddle/jit/dy2static/utils.py
@@ -308,10 +308,6 @@ def is_dataclass_type(obj):
     return is_dataclass(obj) and isinstance(obj, type)
 
 
-def is_plain_dataclass_inst(val):
-    return is_dataclass_instance(val) and len(val.__class__.__mro__) == 2
-
-
 def is_plain_dataclass_type(cls: type):
     return is_dataclass_type(cls) and len(cls.__mro__) == 2
 

--- a/python/paddle/jit/dy2static/utils.py
+++ b/python/paddle/jit/dy2static/utils.py
@@ -308,6 +308,14 @@ def is_dataclass_type(obj):
     return is_dataclass(obj) and isinstance(obj, type)
 
 
+def is_plain_dataclass_inst(val):
+    return is_dataclass_instance(val) and len(val.__class__.__mro__) == 2
+
+
+def is_plain_dataclass_type(cls: type):
+    return is_dataclass_type(cls) and len(cls.__mro__) == 2
+
+
 def dataclass_as_dict(obj):
     return {f.name: getattr(obj, f.name) for f in dataclasses.fields(obj)}
 

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
@@ -18,7 +18,7 @@ import dataclasses
 import operator
 import sys
 import types
-from dataclasses import asdict, is_dataclass
+from dataclasses import asdict
 from enum import Enum
 from functools import cached_property, reduce
 from typing import TYPE_CHECKING, Any
@@ -30,6 +30,7 @@ from paddle._typing import unreached
 from paddle.framework import core
 from paddle.jit.dy2static.utils import (
     dataclass_from_dict,
+    is_plain_dataclass_inst,
 )
 from paddle.jit.sot.opcode_translator.executor.pycode_generator import PyCodeGen
 from paddle.pir.core import _PADDLE_PIR_DTYPE_2_NUMPY_DTYPE
@@ -2581,7 +2582,7 @@ class DataClassInstanceVariable(VariableBase):
 
     @VariableFactory.register_from_value()
     def from_value(value: object, graph: FunctionGraph, tracker: Tracker):
-        if DataClassInstanceVariable.is_plain_dataclass_inst(value):
+        if is_plain_dataclass_inst(value):
             class_var = VariableFactory.from_value(
                 type(value), graph, DanglingTracker()
             )
@@ -2599,12 +2600,3 @@ class DataClassInstanceVariable(VariableBase):
             class_var.tracker = GetAttrTracker(var, "__class__")
             return var
         return None
-
-    @staticmethod
-    def is_plain_dataclass_inst(val):
-        # Note: Currently, this only supports dataclasses without multiple or complex inheritance.
-        return (
-            is_dataclass(val)
-            and not isinstance(val, type)
-            and len(val.__class__.__mro__) == 2
-        )

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
@@ -18,6 +18,7 @@ import dataclasses
 import operator
 import sys
 import types
+from dataclasses import asdict, is_dataclass
 from enum import Enum
 from functools import cached_property, reduce
 from typing import TYPE_CHECKING, Any
@@ -28,9 +29,7 @@ import paddle
 from paddle._typing import unreached
 from paddle.framework import core
 from paddle.jit.dy2static.utils import (
-    dataclass_as_dict,
     dataclass_from_dict,
-    is_dataclass_instance,
 )
 from paddle.jit.sot.opcode_translator.executor.pycode_generator import PyCodeGen
 from paddle.pir.core import _PADDLE_PIR_DTYPE_2_NUMPY_DTYPE
@@ -2462,7 +2461,23 @@ class DataClassInstanceVariable(VariableBase):
     def getattr(self, name: str, default=None):
         if name == "__class__":
             return self.class_var
-        return self.proxy.get(name)
+        if name == "__post_init__":
+            cls_var = self.getattr("__class__")
+            return VariableFactory.from_value(
+                cls_var.value.__post_init__,
+                self.graph,
+                GetAttrTracker(cls_var, "__post_init__"),
+            ).bind(self, "__post_init__")
+        if name == "__dataclass_fields__":
+            return VariableFactory.from_value(
+                {fd.name: fd for fd in dataclasses.fields(self.value)},
+                graph=self.graph,
+                tracker=GetAttrTracker(self, "__dataclass_fields__"),
+            )
+        res = self.proxy.get(name)
+        if self.proxy.is_empty(res):
+            return super().getattr(name, default)
+        return res
 
     def setattr(self, key: str, value):
         self.proxy.set(key, value)
@@ -2566,12 +2581,16 @@ class DataClassInstanceVariable(VariableBase):
 
     @VariableFactory.register_from_value()
     def from_value(value: object, graph: FunctionGraph, tracker: Tracker):
-        if is_dataclass_instance(value):
+        if DataClassInstanceVariable.is_plain_dataclass_inst(value):
             class_var = VariableFactory.from_value(
                 type(value), graph, DanglingTracker()
             )
+            try:
+                data_dict = asdict(value)
+            except:
+                data_dict = {}
             var = DataClassInstanceVariable(
-                dataclass_as_dict(value),
+                data_dict,
                 class_var,
                 id(value),
                 graph=graph,
@@ -2580,3 +2599,12 @@ class DataClassInstanceVariable(VariableBase):
             class_var.tracker = GetAttrTracker(var, "__class__")
             return var
         return None
+
+    @staticmethod
+    def is_plain_dataclass_inst(val):
+        # Note: Currently, this only supports dataclasses without multiple or complex inheritance.
+        return (
+            is_dataclass(val)
+            and not isinstance(val, type)
+            and len(val.__class__.__mro__) == 2
+        )

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
@@ -30,7 +30,7 @@ from paddle._typing import unreached
 from paddle.framework import core
 from paddle.jit.dy2static.utils import (
     dataclass_from_dict,
-    is_plain_dataclass_inst,
+    is_plain_dataclass_type,
 )
 from paddle.jit.sot.opcode_translator.executor.pycode_generator import PyCodeGen
 from paddle.pir.core import _PADDLE_PIR_DTYPE_2_NUMPY_DTYPE
@@ -2582,7 +2582,7 @@ class DataClassInstanceVariable(VariableBase):
 
     @VariableFactory.register_from_value()
     def from_value(value: object, graph: FunctionGraph, tracker: Tracker):
-        if is_plain_dataclass_inst(value):
+        if is_plain_dataclass_type(type(value)):
             class_var = VariableFactory.from_value(
                 type(value), graph, DanglingTracker()
             )

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/callable.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/callable.py
@@ -23,7 +23,7 @@ import operator
 import random
 import sys
 import types
-from dataclasses import fields, is_dataclass
+from dataclasses import fields
 from functools import partial, reduce
 from typing import (
     TYPE_CHECKING,
@@ -36,7 +36,10 @@ from paddle.base.dygraph.base import (
     _DecoratorContextManager,
     in_sot_simulation_mode,
 )
-from paddle.jit.dy2static.utils import TransformOptions
+from paddle.jit.dy2static.utils import (
+    TransformOptions,
+    is_plain_dataclass_type,
+)
 
 from .... import psdb
 from ....profiler import EventGuard
@@ -1348,19 +1351,10 @@ class DataClassVariable(ClassVariable):
 
     @VariableFactory.register_from_value(successor="ClassVariable")
     def from_value(value: object, graph: FunctionGraph, tracker: Tracker):
-        if DataClassVariable.is_plain_dataclass_type(value):
+        if is_plain_dataclass_type(value):
             var = DataClassVariable(value, graph=graph, tracker=tracker)
             return var
         return None
-
-    @staticmethod
-    def is_plain_dataclass_type(cls: type):
-        # Note: Currently, this only supports dataclasses without multiple or complex inheritance.
-        return (
-            is_dataclass(cls)
-            and isinstance(cls, type)
-            and len(cls.__mro__) == 2
-        )
 
 
 class NamedTupleClassVariable(ClassVariable):

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/callable.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/callable.py
@@ -23,7 +23,7 @@ import operator
 import random
 import sys
 import types
-from dataclasses import fields
+from dataclasses import fields, is_dataclass
 from functools import partial, reduce
 from typing import (
     TYPE_CHECKING,
@@ -36,7 +36,7 @@ from paddle.base.dygraph.base import (
     _DecoratorContextManager,
     in_sot_simulation_mode,
 )
-from paddle.jit.dy2static.utils import TransformOptions, is_dataclass_type
+from paddle.jit.dy2static.utils import TransformOptions
 
 from .... import psdb
 from ....profiler import EventGuard
@@ -1320,11 +1320,7 @@ class DataClassVariable(ClassVariable):
             DummyTracker([*args, *kwargs.values()]),
         )
         if hasattr(self.value, "__post_init__"):
-            post_init = VariableFactory.from_value(
-                self.value.__post_init__,
-                self.graph,
-                GetAttrTracker(self, "__post_init__"),
-            ).bind(instance, "__post_init__")
+            post_init = instance.getattr("__post_init__")
             post_init()
         return instance
 
@@ -1352,10 +1348,19 @@ class DataClassVariable(ClassVariable):
 
     @VariableFactory.register_from_value(successor="ClassVariable")
     def from_value(value: object, graph: FunctionGraph, tracker: Tracker):
-        if is_dataclass_type(value):
+        if DataClassVariable.is_plain_dataclass_type(value):
             var = DataClassVariable(value, graph=graph, tracker=tracker)
             return var
         return None
+
+    @staticmethod
+    def is_plain_dataclass_type(cls: type):
+        # Note: Currently, this only supports dataclasses without multiple or complex inheritance.
+        return (
+            is_dataclass(cls)
+            and isinstance(cls, type)
+            and len(cls.__mro__) == 2
+        )
 
 
 class NamedTupleClassVariable(ClassVariable):

--- a/test/sot/test_dataclass.py
+++ b/test/sot/test_dataclass.py
@@ -100,10 +100,18 @@ def set_attr(data: DataMeta):
     return res
 
 
+@check_no_breakgraph
+def get__dataclass_fields__(data: DataMeta):
+    return list(data.__dataclass_fields__), list(
+        data.__class__.__dataclass_fields__
+    )
+
+
 class TestDataClassInstance(TestCaseBase):
     def test_get_attr(self):
         dm = DataMeta(x=paddle.randn([1, 2]), y=paddle.randn([1]))
         self.assert_results(get_attr, dm)
+        self.assert_results(get__dataclass_fields__, dm)
 
     def test_set_attr(self):
         dm = DataMeta(x=paddle.ones([1, 2]), n=2)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->

当前的 dataclass 会有很多实现，包括一些自定义的方法：

```python
class ModelOutput(OrderedDict):
    def to_tuple(self) -> Tuple[Any]:
        ......

@dataclass
class BaseModelOutput(ModelOutput):
	...
```
```
 paddle.jit.sot.utils.exceptions.HasNoAttributeError: DataClassInstanceVariable DataClassInstanceVariable(object_57672, self) has no attribute to_tuple
```

这个pr增加一些限制，让 `DataClassVariable` 和 `DataClassInstanceVariable` 适配 pure dataclasses，即：

```python
from dataclasses import dataclass

@dataclass
class Person:
    name : str
	id: int
```

PCard-66972