### PR TITLE
feat: capi添加新配置接口以启用新执行器和新IR，并支持优化模型

### DIFF
--- a/paddle/fluid/inference/capi_exp/pd_config.cc
+++ b/paddle/fluid/inference/capi_exp/pd_config.cc
@@ -508,4 +508,32 @@ __pd_give PD_Cstr* PD_ConfigSummary(__pd_keep PD_Config* pd_config) {
   return paddle_infer::CvtStrToCstr(sum_str);
 }
 
+void PD_ConfigEnableNewExecutor(__pd_keep PD_Config* pd_config,
+                                PD_Bool x) {
+  CHECK_AND_CONVERT_PD_CONFIG;
+  config->EnableNewExecutor(x);
+}
+
+PD_Bool PD_ConfigNewExecutorEnabled(__pd_keep PD_Config* pd_config) {
+  CHECK_AND_CONVERT_PD_CONFIG;
+  return config->new_executor_enabled();  // NOLINT
+}
+
+void PD_ConfigEnableNewIR(__pd_keep PD_Config* pd_config,
+                          PD_Bool x) {
+  CHECK_AND_CONVERT_PD_CONFIG;
+  config->EnableNewIR(x);
+}
+
+PD_Bool PD_ConfigNewIREnabled(__pd_keep PD_Config* pd_config) {
+  CHECK_AND_CONVERT_PD_CONFIG;
+  return config->new_ir_enabled();  // NOLINT
+}
+
+void PD_ConfigUseOptimizedModel(__pd_keep PD_Config* pd_config,
+                                PD_Bool x) {
+  CHECK_AND_CONVERT_PD_CONFIG;
+  config->UseOptimizedModel(x);
+}
+
 }  // extern "C"

--- a/paddle/fluid/inference/capi_exp/pd_config.cc
+++ b/paddle/fluid/inference/capi_exp/pd_config.cc
@@ -508,8 +508,7 @@ __pd_give PD_Cstr* PD_ConfigSummary(__pd_keep PD_Config* pd_config) {
   return paddle_infer::CvtStrToCstr(sum_str);
 }
 
-void PD_ConfigEnableNewExecutor(__pd_keep PD_Config* pd_config,
-                                PD_Bool x) {
+void PD_ConfigEnableNewExecutor(__pd_keep PD_Config* pd_config, PD_Bool x) {
   CHECK_AND_CONVERT_PD_CONFIG;
   config->EnableNewExecutor(x);
 }
@@ -519,8 +518,7 @@ PD_Bool PD_ConfigNewExecutorEnabled(__pd_keep PD_Config* pd_config) {
   return config->new_executor_enabled();  // NOLINT
 }
 
-void PD_ConfigEnableNewIR(__pd_keep PD_Config* pd_config,
-                          PD_Bool x) {
+void PD_ConfigEnableNewIR(__pd_keep PD_Config* pd_config, PD_Bool x) {
   CHECK_AND_CONVERT_PD_CONFIG;
   config->EnableNewIR(x);
 }
@@ -530,8 +528,7 @@ PD_Bool PD_ConfigNewIREnabled(__pd_keep PD_Config* pd_config) {
   return config->new_ir_enabled();  // NOLINT
 }
 
-void PD_ConfigUseOptimizedModel(__pd_keep PD_Config* pd_config,
-                                PD_Bool x) {
+void PD_ConfigUseOptimizedModel(__pd_keep PD_Config* pd_config, PD_Bool x) {
   CHECK_AND_CONVERT_PD_CONFIG;
   config->UseOptimizedModel(x);
 }

--- a/paddle/fluid/inference/capi_exp/pd_config.h
+++ b/paddle/fluid/inference/capi_exp/pd_config.h
@@ -743,6 +743,39 @@ PADDLE_CAPI_EXPORT extern __pd_give PD_OneDimArrayCstr* PD_ConfigAllPasses(
 PADDLE_CAPI_EXPORT extern __pd_give PD_Cstr* PD_ConfigSummary(
     __pd_keep PD_Config* pd_config);
 
+/// \brief A boolean state telling whether to use new executor.
+/// \param[in] pd_config config
+/// \param[in] x enable new executor or not
+PADDLE_CAPI_EXPORT extern void PD_ConfigEnableNewExecutor(
+    __pd_keep PD_Config* pd_config,
+    PD_Bool x);
+
+/// \brief A boolean state telling whether the new executor is enabled.
+/// \param[in] pd_config config
+/// \return Whether new executor is enabled
+PADDLE_CAPI_EXPORT extern PD_Bool PD_ConfigNewExecutorEnabled(
+    __pd_keep PD_Config* pd_config);
+
+/// \brief A boolean state telling whether to use new IR.
+/// \param[in] pd_config config
+/// \param[in] x enable new IR or not
+PADDLE_CAPI_EXPORT extern void PD_ConfigEnableNewIR(
+    __pd_keep PD_Config* pd_config,
+    PD_Bool x);
+
+/// \brief A boolean state telling whether the new IR is enabled.
+/// \param[in] pd_config config
+/// \return Whether new IR is enabled
+PADDLE_CAPI_EXPORT extern PD_Bool PD_ConfigNewIREnabled(
+    __pd_keep PD_Config* pd_config);
+
+/// \brief Control whether to use optimized model to inference.
+/// \param[in] pd_config config
+/// \param[in] x whether to use optimized model
+PADDLE_CAPI_EXPORT extern void PD_ConfigUseOptimizedModel(
+    __pd_keep PD_Config* pd_config,
+    PD_Bool x);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif

--- a/paddle/fluid/inference/capi_exp/pd_config.h
+++ b/paddle/fluid/inference/capi_exp/pd_config.h
@@ -747,8 +747,7 @@ PADDLE_CAPI_EXPORT extern __pd_give PD_Cstr* PD_ConfigSummary(
 /// \param[in] pd_config config
 /// \param[in] x enable new executor or not
 PADDLE_CAPI_EXPORT extern void PD_ConfigEnableNewExecutor(
-    __pd_keep PD_Config* pd_config,
-    PD_Bool x);
+    __pd_keep PD_Config* pd_config, PD_Bool x);
 
 /// \brief A boolean state telling whether the new executor is enabled.
 /// \param[in] pd_config config
@@ -760,8 +759,7 @@ PADDLE_CAPI_EXPORT extern PD_Bool PD_ConfigNewExecutorEnabled(
 /// \param[in] pd_config config
 /// \param[in] x enable new IR or not
 PADDLE_CAPI_EXPORT extern void PD_ConfigEnableNewIR(
-    __pd_keep PD_Config* pd_config,
-    PD_Bool x);
+    __pd_keep PD_Config* pd_config, PD_Bool x);
 
 /// \brief A boolean state telling whether the new IR is enabled.
 /// \param[in] pd_config config
@@ -773,8 +771,7 @@ PADDLE_CAPI_EXPORT extern PD_Bool PD_ConfigNewIREnabled(
 /// \param[in] pd_config config
 /// \param[in] x whether to use optimized model
 PADDLE_CAPI_EXPORT extern void PD_ConfigUseOptimizedModel(
-    __pd_keep PD_Config* pd_config,
-    PD_Bool x);
+    __pd_keep PD_Config* pd_config, PD_Bool x);
 
 #ifdef __cplusplus
 }  // extern "C"


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Environment Adaptation

### PR Types
Improvements

### Description
C API目前不支持新执行器，通过这个PR就可以启用（在我的PaddleSharp开源项目中测试通过，有CICD编译记录：https://github.com/sdcb/PaddleSharp/actions/runs/15808058135）

![image](https://github.com/user-attachments/assets/c72c1e5a-c8a2-48c9-b244-9c7d7a422c37)
