### PR TITLE
修复macOS-x64在使用-DONNXRUNTIME=ON时编译失败的问题

### DIFF
--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -244,7 +244,6 @@ if(APPLE)
   set(COMMON_FLAGS
       -Wno-deprecated-register
       -Werror=format
-      -Werror=inconsistent-missing-override
       -Werror=braced-scalar-init
       -Werror=uninitialized
       -Werror=tautological-constant-out-of-range-compare


### PR DESCRIPTION
### PR Category
Environment Adaptation


### PR Types
Bug fixes

### Description
修复macOS-x64在使用-DONNXRUNTIME=ON时编译失败的问题

具体编译报错如下：
```
[2134/2169] Building CXX object paddle/fluid/inference/CMakeFiles/paddle_inference_shared.dir/__/framework/data_feed_factory.cc.o
[2135/2169] Building CXX object paddle/fluid/inference/api/CMakeFiles/analysis_predictor.dir/onnxruntime_predictor.cc.o
FAILED: paddle/fluid/inference/api/CMakeFiles/analysis_predictor.dir/onnxruntime_predictor.cc.o 
/Applications/Xcode_15.2.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -DGLOG_NO_ABBREVIATED_SEVERITIES -DHPPL_STUB_FUNC -DLAPACK_FOUND -DPADDLE_DISABLE_PROFILER -DPADDLE_DLL_EXPORT -DPADDLE_NO_PYTHON -DPADDLE_ON_INFERENCE -DPADDLE_USE_ACCELERATE -DPADDLE_VERSION=3.0.0 -DPADDLE_VERSION_INTEGER=3000000 -DPADDLE_WITH_AVX -DPADDLE_WITH_CRYPTO -DPADDLE_WITH_ONNXRUNTIME -DPADDLE_WITH_POCKETFFT -DPADDLE_WITH_SSE3 -DPHI_INNER -DPHI_SHARED -DSTATIC_IR -DYAML_CPP_STATIC_DEFINE -I/Users/runner/work/PaddleSharp/PaddleSharp/paddle-src/build -I/Users/runner/work/PaddleSharp/PaddleSharp/paddle-src/paddle/fluid/framework/io -I/Users/runner/work/PaddleSharp/PaddleSharp/paddle-src/build/third_party/install/zlib/include -I/Users/runner/work/PaddleSharp/PaddleSharp/paddle-src/build/third_party/install -I/Users/runner/work/PaddleSharp/PaddleSharp/paddle-src/build/third_party/install/gflags/include -I/Users/runner/work/PaddleSharp/PaddleSharp/paddle-src/build/third_party/install/glog/include -I/Users/runner/work/PaddleSharp/PaddleSharp/paddle-src/third_party/eigen3 -I/Users/runner/work/PaddleSharp/PaddleSharp/paddle-src/third_party/threadpool -I/Users/runner/work/PaddleSharp/PaddleSharp/paddle-src/third_party/dlpack/include -I/Users/runner/work/PaddleSharp/PaddleSharp/paddle-src/build/third_party/install/xxhash/include -I/Users/runner/work/PaddleSharp/PaddleSharp/paddle-src/build/third_party/install/warpctc/include -I/Users/runner/work/PaddleSharp/PaddleSharp/paddle-src/build/third_party/install/warprnnt/include -I/Users/runner/work/PaddleSharp/PaddleSharp/paddle-src/build/third_party/install/utf8proc/include -I/Users/runner/work/PaddleSharp/PaddleSharp/paddle-src/build/third_party/install/protobuf/include -I/Users/runner/work/PaddleSharp/PaddleSharp/paddle-src/third_party/nlohmann_json/include -I/Users/runner/work/PaddleSharp/PaddleSharp/paddle-src/build/third_party/install/yaml-cpp/include -I/Users/runner/work/PaddleSharp/PaddleSharp/paddle-src/build/third_party/install/onnxruntime/include -I/Users/runner/work/PaddleSharp/PaddleSharp/paddle-src/build/third_party/install/paddle2onnx/include -I/Users/runner/work/PaddleSharp/PaddleSharp/paddle-src/build/third_party/install/cryptopp/include -I/Users/runner/work/PaddleSharp/PaddleSharp/paddle-src/build/third_party/pocketfft/src -I/Users/runner/work/PaddleSharp/PaddleSharp/paddle-src -I/Users/runner/work/PaddleSharp/PaddleSharp/paddle-src/build/../paddle/fluid/framework/io -Wno-error=deprecated-declarations -Wno-deprecated-declarations -std=c++17 -m64 -Wno-deprecated-register -Werror=format -Werror=inconsistent-missing-override -Werror=braced-scalar-init -Werror=uninitialized -Werror=tautological-constant-out-of-range-compare -Werror=literal-conversion -Werror=pragma-pack -Werror=c++17-extensions -mavx -Wno-error=pessimizing-move -O3 -DNDEBUG -arch x86_64 -isysroot /Applications/Xcode_15.2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.2.sdk -mmacosx-version-min=13.7 -MD -MT paddle/fluid/inference/api/CMakeFiles/analysis_predictor.dir/onnxruntime_predictor.cc.o -MF paddle/fluid/inference/api/CMakeFiles/analysis_predictor.dir/onnxruntime_predictor.cc.o.d -o paddle/fluid/inference/api/CMakeFiles/analysis_predictor.dir/onnxruntime_predictor.cc.o -c /Users/runner/work/PaddleSharp/PaddleSharp/paddle-src/paddle/fluid/inference/api/onnxruntime_predictor.cc
In file included from /Users/runner/work/PaddleSharp/PaddleSharp/paddle-src/paddle/fluid/inference/api/onnxruntime_predictor.cc:15:
/Users/runner/work/PaddleSharp/PaddleSharp/paddle-src/paddle/fluid/inference/api/onnxruntime_predictor.h:137:28: error: 'GetInputNames' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
  std::vector<std::string> GetInputNames();
                           ^
/Users/runner/work/PaddleSharp/PaddleSharp/paddle-src/paddle/fluid/inference/api/paddle_api.h:239:36: note: overridden virtual function is here
  virtual std::vector<std::string> GetInputNames() { return {}; }
                                   ^
In file included from /Users/runner/work/PaddleSharp/PaddleSharp/paddle-src/paddle/fluid/inference/api/onnxruntime_predictor.cc:15:
/Users/runner/work/PaddleSharp/PaddleSharp/paddle-src/paddle/fluid/inference/api/onnxruntime_predictor.h:144:28: error: 'GetOutputNames' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
  std::vector<std::string> GetOutputNames();
                           ^
/Users/runner/work/PaddleSharp/PaddleSharp/paddle-src/paddle/fluid/inference/api/paddle_api.h:256:36: note: overridden virtual function is here
  virtual std::vector<std::string> GetOutputNames() { return {}; }
                                   ^
2 errors generated.
[2136/2169] Building CXX object paddle/fluid/inference/CMakeFiles/paddle_inference_shared.dir/__/framework/dataset_factory.cc.o
[2137/2169] Building CXX object paddle/fluid/inference/CMakeFiles/paddle_inference_shared.dir/__/platform/init_phi.cc.o
[2138/2169] Building CXX object paddle/fluid/inference/CMakeFiles/paddle_inference_shared.dir/io.cc.o
[2139/2169] Building CXX object paddle/fluid/inference/CMakeFiles/paddle_inference_shared.dir/__/framework/data_feed.cc.o
[2140/2169] Building CXX object paddle/fluid/inference/api/CMakeFiles/analysis_predictor.dir/analysis_predictor.cc.o
FAILED: paddle/fluid/inference/api/CMakeFiles/analysis_predictor.dir/analysis_predictor.cc.o 
/Applications/Xcode_15.2.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -DGLOG_NO_ABBREVIATED_SEVERITIES -DHPPL_STUB_FUNC -DLAPACK_FOUND -DPADDLE_DISABLE_PROFILER -DPADDLE_DLL_EXPORT -DPADDLE_NO_PYTHON -DPADDLE_ON_INFERENCE -DPADDLE_USE_ACCELERATE -DPADDLE_VERSION=3.0.0 -DPADDLE_VERSION_INTEGER=3000000 -DPADDLE_WITH_AVX -DPADDLE_WITH_CRYPTO -DPADDLE_WITH_ONNXRUNTIME -DPADDLE_WITH_POCKETFFT -DPADDLE_WITH_SSE3 -DPHI_INNER -DPHI_SHARED -DSTATIC_IR -DYAML_CPP_STATIC_DEFINE -I/Users/runner/work/PaddleSharp/PaddleSharp/paddle-src/build -I/Users/runner/work/PaddleSharp/PaddleSharp/paddle-src/paddle/fluid/framework/io -I/Users/runner/work/PaddleSharp/PaddleSharp/paddle-src/build/third_party/install/zlib/include -I/Users/runner/work/PaddleSharp/PaddleSharp/paddle-src/build/third_party/install -I/Users/runner/work/PaddleSharp/PaddleSharp/paddle-src/build/third_party/install/gflags/include -I/Users/runner/work/PaddleSharp/PaddleSharp/paddle-src/build/third_party/install/glog/include -I/Users/runner/work/PaddleSharp/PaddleSharp/paddle-src/third_party/eigen3 -I/Users/runner/work/PaddleSharp/PaddleSharp/paddle-src/third_party/threadpool -I/Users/runner/work/PaddleSharp/PaddleSharp/paddle-src/third_party/dlpack/include -I/Users/runner/work/PaddleSharp/PaddleSharp/paddle-src/build/third_party/install/xxhash/include -I/Users/runner/work/PaddleSharp/PaddleSharp/paddle-src/build/third_party/install/warpctc/include -I/Users/runner/work/PaddleSharp/PaddleSharp/paddle-src/build/third_party/install/warprnnt/include -I/Users/runner/work/PaddleSharp/PaddleSharp/paddle-src/build/third_party/install/utf8proc/include -I/Users/runner/work/PaddleSharp/PaddleSharp/paddle-src/build/third_party/install/protobuf/include -I/Users/runner/work/PaddleSharp/PaddleSharp/paddle-src/third_party/nlohmann_json/include -I/Users/runner/work/PaddleSharp/PaddleSharp/paddle-src/build/third_party/install/yaml-cpp/include -I/Users/runner/work/PaddleSharp/PaddleSharp/paddle-src/build/third_party/install/onnxruntime/include -I/Users/runner/work/PaddleSharp/PaddleSharp/paddle-src/build/third_party/install/paddle2onnx/include -I/Users/runner/work/PaddleSharp/PaddleSharp/paddle-src/build/third_party/install/cryptopp/include -I/Users/runner/work/PaddleSharp/PaddleSharp/paddle-src/build/third_party/pocketfft/src -I/Users/runner/work/PaddleSharp/PaddleSharp/paddle-src -I/Users/runner/work/PaddleSharp/PaddleSharp/paddle-src/build/../paddle/fluid/framework/io -Wno-error=deprecated-declarations -Wno-deprecated-declarations -std=c++17 -m64 -Wno-deprecated-register -Werror=format -Werror=inconsistent-missing-override -Werror=braced-scalar-init -Werror=uninitialized -Werror=tautological-constant-out-of-range-compare -Werror=literal-conversion -Werror=pragma-pack -Werror=c++17-extensions -mavx -Wno-error=pessimizing-move -O3 -DNDEBUG -arch x86_64 -isysroot /Applications/Xcode_15.2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.2.sdk -mmacosx-version-min=13.7 -MD -MT paddle/fluid/inference/api/CMakeFiles/analysis_predictor.dir/analysis_predictor.cc.o -MF paddle/fluid/inference/api/CMakeFiles/analysis_predictor.dir/analysis_predictor.cc.o.d -o paddle/fluid/inference/api/CMakeFiles/analysis_predictor.dir/analysis_predictor.cc.o -c /Users/runner/work/PaddleSharp/PaddleSharp/paddle-src/paddle/fluid/inference/api/analysis_predictor.cc
In file included from /Users/runner/work/PaddleSharp/PaddleSharp/paddle-src/paddle/fluid/inference/api/analysis_predictor.cc:82:
/Users/runner/work/PaddleSharp/PaddleSharp/paddle-src/paddle/fluid/inference/api/onnxruntime_predictor.h:137:28: error: 'GetInputNames' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
  std::vector<std::string> GetInputNames();
                           ^
/Users/runner/work/PaddleSharp/PaddleSharp/paddle-src/paddle/fluid/inference/api/paddle_api.h:239:36: note: overridden virtual function is here
  virtual std::vector<std::string> GetInputNames() { return {}; }
                                   ^
In file included from /Users/runner/work/PaddleSharp/PaddleSharp/paddle-src/paddle/fluid/inference/api/analysis_predictor.cc:82:
/Users/runner/work/PaddleSharp/PaddleSharp/paddle-src/paddle/fluid/inference/api/onnxruntime_predictor.h:144:28: error: 'GetOutputNames' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
  std::vector<std::string> GetOutputNames();
                           ^
/Users/runner/work/PaddleSharp/PaddleSharp/paddle-src/paddle/fluid/inference/api/paddle_api.h:256:36: note: overridden virtual function is here
  virtual std::vector<std::string> GetOutputNames() { return {}; }
                                   ^
2 errors generated.
ninja: build stopped: subcommand failed.
```

CICD链接：
https://github.com/sdcb/PaddleSharp/actions/runs/15697462900/job/44225250427