### PR TITLE
[0-size Tensor No.216] Add 0-size Tensor support for paddle.nn.functional.sequence_mask

### DIFF
--- a/paddle/phi/kernels/impl/sequence_mask_kernel_impl.h
+++ b/paddle/phi/kernels/impl/sequence_mask_kernel_impl.h
@@ -57,6 +57,10 @@ void SequenceMaskScalarKernel(const Context& dev_ctx,
     y_dim.push_back(maxlen);
     y->Resize(common::make_ddim(y_dim));
   }
+  if (x_numel == 0) {
+    dev_ctx.Alloc(y, out_dtype);
+    return;
+  }
 
   phi::VisitDataType(out_dtype,
                      phi::funcs::SequenceMaskFunctor<Context, T>(

--- a/test/sequence/test_sequence_mask.py
+++ b/test/sequence/test_sequence_mask.py
@@ -208,5 +208,34 @@ class TestSequenceMaskWithEmptyTensor(unittest.TestCase):
         self.assertEqual(list(mask.shape), [0, 0])
 
 
+class SequenceMaskTest_ZeroSize(OpTest):
+    def initDefaultParameters(self):
+        self.op_type = 'sequence_mask'
+        self.python_api = sequence_mask_wrapper
+        self.maxlen = 10
+        self.mask_dtype = 'int64'
+        self.x = np.random.random([0, 3]).astype('int64')
+        self.y = np.random.random([0, 3, 10]).astype('int64')
+
+    def initParameters(self):
+        pass
+
+    def setUp(self):
+        self.initDefaultParameters()
+        self.initParameters()
+        if not isinstance(self.x, np.ndarray):
+            self.x = np.array(self.x)
+
+        self.inputs = {'X': self.x}
+        self.outputs = {'Y': self.y}
+        self.attrs = {
+            'maxlen': self.maxlen,
+            'out_dtype': convert_np_dtype_to_proto_type(self.mask_dtype),
+        }
+
+    def test_check_output(self):
+        self.check_output(check_pir=True)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->
paddle.nn.functional.sequence_mask
kernel 为impl，修改x numel为0时返回
增加单测

PaddleAPITest测试通过
GPU
![image](https://github.com/user-attachments/assets/6f8144f6-302c-4b07-a5a3-459dd8a3edf1)
CPU 为torch error
![image](https://github.com/user-attachments/assets/055dcdb8-fb3f-457d-9b1f-9587cd24addf)
