### PR TITLE
[Phi]Fix group_norm and its grad kernel for big tensor

### DIFF
--- a/paddle/phi/kernels/gpu/group_norm_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/group_norm_grad_kernel.cu
@@ -27,67 +27,70 @@ __global__ void GroupNormBackwardGetMeanAndVar(const T* x,
                                                const T* scale,
                                                const T* bias,
                                                const T* d_y,
-                                               int N,
-                                               int C,
-                                               int W,
-                                               int imsize,
+                                               int64_t N,
+                                               int64_t C,
+                                               int64_t W,
+                                               int64_t imsize,
                                                int groups,
-                                               int group_size,
+                                               int64_t group_size,
                                                float epsilon,
                                                AccT* d_mean,
                                                AccT* d_var,
                                                T* d_scale,
                                                T* d_bias) {
   int gid = blockIdx.y;
-  int cid = blockIdx.x;
-  int bid = blockIdx.z;
-  int H = imsize / W;
-  int number = min(group_size, static_cast<int>(C - gid * group_size));
-  int ccid = gid * group_size + cid;
-  if (ccid >= C) return;
-  T x_scale = (flags & kHasScale) ? scale[ccid] : static_cast<T>(1);
-  T x_bias = (flags & kHasBias) ? bias[ccid] : static_cast<T>(0);
-  T x_scale_inv = static_cast<T>(0);
-  if (x_scale != static_cast<T>(0)) x_scale_inv = static_cast<T>(1.0) / x_scale;
-  AccT d_mean_data = static_cast<AccT>(0);
-  AccT d_var_data = static_cast<AccT>(0);
-  AccT d_scale_data = static_cast<AccT>(0);
-  AccT d_bias_data = static_cast<AccT>(0);
+  for (int64_t cid = blockIdx.x; cid < group_size; cid += gridDim.x) {
+    for (int64_t bid = blockIdx.z; bid < N; bid += gridDim.z) {
+      int64_t H = imsize / W;
+      int64_t number = min(group_size, C - gid * group_size);
+      int64_t ccid = gid * group_size + cid;
+      if (ccid >= C) return;
+      T x_scale = (flags & kHasScale) ? scale[ccid] : static_cast<T>(1);
+      T x_bias = (flags & kHasBias) ? bias[ccid] : static_cast<T>(0);
+      T x_scale_inv = static_cast<T>(0);
+      if (x_scale != static_cast<T>(0))
+        x_scale_inv = static_cast<T>(1.0) / x_scale;
+      AccT d_mean_data = static_cast<AccT>(0);
+      AccT d_var_data = static_cast<AccT>(0);
+      AccT d_scale_data = static_cast<AccT>(0);
+      AccT d_bias_data = static_cast<AccT>(0);
 
-  for (int imid = threadIdx.x; imid < imsize; imid += blockDim.x) {
-    AccT val, dval;
+      for (int64_t imid = threadIdx.x; imid < imsize; imid += blockDim.x) {
+        AccT val, dval;
 
-    int hid = imid / W;
-    int wid = imid % W;
-    val = static_cast<AccT>(x[(bid * H + hid) * W * C + wid * C + ccid]) -
-          static_cast<AccT>(x_bias);
-    dval = static_cast<AccT>(d_y[(bid * H + hid) * W * C + wid * C + ccid]);
+        int64_t hid = imid / W;
+        int64_t wid = imid % W;
+        val = static_cast<AccT>(x[(bid * H + hid) * W * C + wid * C + ccid]) -
+              static_cast<AccT>(x_bias);
+        dval = static_cast<AccT>(d_y[(bid * H + hid) * W * C + wid * C + ccid]);
 
-    d_var_data += val * dval;
-    d_mean_data += dval * static_cast<AccT>(x_scale);
+        d_var_data += val * dval;
+        d_mean_data += dval * static_cast<AccT>(x_scale);
 
-    val = val * static_cast<AccT>(x_scale_inv);
-    d_bias_data += dval;
-    d_scale_data += val * dval;
-  }
-  CudaAtomicAddWithWarp(&(d_mean[bid * groups + gid]),
-                        static_cast<AccT>(d_mean_data));
-  CudaAtomicAddWithWarp(&(d_var[bid * groups + gid]),
-                        static_cast<AccT>(d_var_data));
+        val = val * static_cast<AccT>(x_scale_inv);
+        d_bias_data += dval;
+        d_scale_data += val * dval;
+      }
+      CudaAtomicAddWithWarp(&(d_mean[bid * groups + gid]),
+                            static_cast<AccT>(d_mean_data));
+      CudaAtomicAddWithWarp(&(d_var[bid * groups + gid]),
+                            static_cast<AccT>(d_var_data));
 
-  if (flags & kHasScale) {
+      if (flags & kHasScale) {
 #if CUDA_VERSION >= 11070
-    phi::CudaAtomicAdd(&(d_scale[ccid]), static_cast<T>(d_scale_data));
+        phi::CudaAtomicAdd(&(d_scale[ccid]), static_cast<T>(d_scale_data));
 #else
-    CudaAtomicAddWithWarp(&(d_scale[ccid]), static_cast<T>(d_scale_data));
+        CudaAtomicAddWithWarp(&(d_scale[ccid]), static_cast<T>(d_scale_data));
 #endif
-  }
-  if (flags & kHasBias) {
+      }
+      if (flags & kHasBias) {
 #if CUDA_VERSION >= 11070
-    phi::CudaAtomicAdd(&(d_bias[ccid]), static_cast<T>(d_bias_data));
+        phi::CudaAtomicAdd(&(d_bias[ccid]), static_cast<T>(d_bias_data));
 #else
-    CudaAtomicAddWithWarp(&(d_bias[ccid]), static_cast<T>(d_bias_data));
+        CudaAtomicAddWithWarp(&(d_bias[ccid]), static_cast<T>(d_bias_data));
 #endif
+      }
+    }
   }
 }
 
@@ -99,68 +102,77 @@ __global__ void GroupNormBackward(const T* x,
                                   const AccT* var,
                                   const AccT* d_mean,
                                   const AccT* d_var,
-                                  int N,
-                                  int C,
-                                  int W,
-                                  int imsize,
+                                  int64_t N,
+                                  int64_t C,
+                                  int64_t W,
+                                  int64_t imsize,
                                   int groups,
-                                  int group_size,
+                                  int64_t group_size,
                                   float epsilon,
                                   T* d_x) {
   // using AccT = typename phi::dtype::MPTypeTrait<T>::Type;
 
   int gid = blockIdx.y;
-  int cid = blockIdx.x;
-  int bid = blockIdx.z;
-  int H = imsize / W;
-  int number = min(group_size, static_cast<int>(C - gid * group_size));
-  int ccid = gid * group_size + cid;
-  if (ccid >= C) return;
-  AccT x_var = var[bid * groups + gid];
-  AccT d_x_mean = static_cast<AccT>(d_mean[bid * groups + gid]);
-  AccT d_x_var = static_cast<AccT>(d_var[bid * groups + gid]);
+  for (int64_t cid = blockIdx.x; cid < group_size; cid += gridDim.x) {
+    for (int64_t bid = blockIdx.z; bid < N; bid += gridDim.z) {
+      int64_t H = imsize / W;
+      int64_t number = min(group_size, C - gid * group_size);
+      int64_t ccid = gid * group_size + cid;
+      if (ccid >= C) return;
+      AccT x_var = var[bid * groups + gid];
+      AccT d_x_mean = static_cast<AccT>(d_mean[bid * groups + gid]);
+      AccT d_x_var = static_cast<AccT>(d_var[bid * groups + gid]);
 
-  AccT x_var_inv = static_cast<AccT>(1.0) / sqrt((x_var) + epsilon);
-  AccT number_inv =
-      static_cast<AccT>(1.0) / static_cast<AccT>((number * imsize));
+      AccT x_var_inv = static_cast<AccT>(1.0) / sqrt((x_var) + epsilon);
+      AccT number_inv =
+          static_cast<AccT>(1.0) / static_cast<AccT>((number * imsize));
 
-  AccT x_scale = (flags & kHasScale) ? static_cast<AccT>(scale[ccid])
-                                     : static_cast<AccT>(1);
-  AccT x_bias =
-      (flags & kHasBias) ? static_cast<AccT>(bias[ccid]) : static_cast<AccT>(0);
-  AccT x_scale_inv = static_cast<AccT>(0);
-  if (x_scale != static_cast<AccT>(0))
-    x_scale_inv = static_cast<AccT>(1.0) / x_scale;
+      AccT x_scale = (flags & kHasScale) ? static_cast<AccT>(scale[ccid])
+                                         : static_cast<AccT>(1);
+      AccT x_bias = (flags & kHasBias) ? static_cast<AccT>(bias[ccid])
+                                       : static_cast<AccT>(0);
+      AccT x_scale_inv = static_cast<AccT>(0);
+      if (x_scale != static_cast<AccT>(0))
+        x_scale_inv = static_cast<AccT>(1.0) / x_scale;
 
-  for (int imid = threadIdx.x; imid < imsize; imid += blockDim.x) {
-    int hid = imid / W;
-    int wid = imid % W;
-    AccT tmp = static_cast<AccT>(x[(bid * H + hid) * W * C + wid * C + ccid]);
-    AccT v_y = (tmp - x_bias) * x_scale_inv;
-    AccT dly = static_cast<AccT>(d_y[(bid * H + hid) * W * C + wid * C + ccid]);
-    d_x[(bid * H + hid) * W * C + wid * C + ccid] =
-        static_cast<T>(x_var_inv * ((dly) * (x_scale)-number_inv * d_x_var *
-                                    (v_y)-number_inv * d_x_mean));
+      for (int64_t imid = threadIdx.x; imid < imsize; imid += blockDim.x) {
+        int64_t hid = imid / W;
+        int64_t wid = imid % W;
+        AccT tmp =
+            static_cast<AccT>(x[(bid * H + hid) * W * C + wid * C + ccid]);
+        AccT v_y = (tmp - x_bias) * x_scale_inv;
+        AccT dly =
+            static_cast<AccT>(d_y[(bid * H + hid) * W * C + wid * C + ccid]);
+        d_x[(bid * H + hid) * W * C + wid * C + ccid] =
+            static_cast<T>(x_var_inv * ((dly) * (x_scale)-number_inv * d_x_var *
+                                        (v_y)-number_inv * d_x_mean));
+      }
+    }
   }
 }
 
 template <typename T, typename AccT>
-__global__ void ScalarGetDsDbCUDAKernel(
-    int imsize, const T* x, const T* dy, AccT* ds, AccT* db) {
-  const int nc = blockIdx.x;
-  AccT ds_sum = 0;
-  AccT db_sum = 0;
-  for (int i = threadIdx.x; i < imsize; i += blockDim.x) {
-    const int index = nc * imsize + i;
-    ds_sum += static_cast<AccT>(dy[index]) * static_cast<AccT>(x[index]);
-    db_sum += static_cast<AccT>(dy[index]);
+__global__ void ScalarGetDsDbCUDAKernel(int64_t imsize,
+                                        const T* x,
+                                        const T* dy,
+                                        AccT* ds,
+                                        AccT* db,
+                                        int64_t total_groups) {
+  for (int64_t nc = blockIdx.x; nc < total_groups; nc += gridDim.x) {
+    AccT ds_sum = 0;
+    AccT db_sum = 0;
+    for (int64_t i = threadIdx.x; i < imsize; i += blockDim.x) {
+      const int64_t index = nc * imsize + i;
+      ds_sum += static_cast<AccT>(dy[index]) * static_cast<AccT>(x[index]);
+      db_sum += static_cast<AccT>(dy[index]);
+    }
+    ReduceMeanAndVar<AccT>(db, ds, db_sum, ds_sum, 1, nc);
   }
-  ReduceMeanAndVar<AccT>(db, ds, db_sum, ds_sum, 1);
 }
 
 template <typename T, typename AccT>
-__global__ void GetScaleBiasGradientCUDAKernel(int N,
-                                               int C,
+__global__ void GetScaleBiasGradientCUDAKernel(int64_t N,
+                                               int64_t C,
                                                int group,
                                                float epsilon,
                                                const AccT* mean,
@@ -169,15 +181,16 @@ __global__ void GetScaleBiasGradientCUDAKernel(int N,
                                                const AccT* db,
                                                T* d_scale,
                                                T* d_bias) {
-  const int c = blockIdx.x * blockDim.x + threadIdx.x;
+  // TODO(guoxiangmin) :add check when C / block >= gridDim.x
+  const int64_t c = blockIdx.x * blockDim.x + threadIdx.x;
   if (c < C) {
     const int G = group;
-    const int D = C / G;
+    const int64_t D = C / G;
     AccT sum1 = static_cast<AccT>(0);
     AccT sum2 = static_cast<AccT>(0);
-    for (int n = 0; n < N; ++n) {
-      const int nc = n * C + c;
-      const int ng = n * G + c / D;
+    for (int64_t n = 0; n < N; ++n) {
+      const int64_t nc = n * C + c;
+      const int64_t ng = n * G + c / D;
       sum1 +=
           (d_scale == nullptr)
               ? AccT(0)
@@ -194,9 +207,10 @@ __global__ void GetScaleBiasGradientCUDAKernel(int N,
 }
 
 template <typename T, typename AccT, int BlockDim>
-__global__ void GetBackwardParamsCUDAKernel(int imsize,
+__global__ void GetBackwardParamsCUDAKernel(int64_t N,
+                                            int64_t imsize,
                                             int groups,
-                                            int group_size,
+                                            int64_t group_size,
                                             float epsilon,
                                             const AccT* mean,
                                             const AccT* var,
@@ -206,44 +220,46 @@ __global__ void GetBackwardParamsCUDAKernel(int imsize,
                                             AccT* p1,
                                             AccT* p2,
                                             AccT* p3) {
-  const int n = blockIdx.x;
-  const int g = blockIdx.y;
-  const int ng = n * groups + g;
-  AccT sum1 = 0;
-  AccT sum2 = 0;
-  AccT var_inv = rsqrt(static_cast<AccT>(var[ng]) + epsilon);
-  for (int64_t i = threadIdx.x; i < group_size; i += blockDim.x) {
-    const int64_t index = ng * group_size + i;
-    const int64_t c = g * group_size + i;
-    const AccT scale_v =
-        scale == nullptr ? static_cast<AccT>(1) : static_cast<AccT>(scale[c]);
-    sum1 += static_cast<AccT>(ds[index]) * scale_v;
-    sum2 += static_cast<AccT>(db[index]) * scale_v;
-    const AccT scale_c =
-        scale == nullptr ? static_cast<AccT>(0) : static_cast<AccT>(scale[c]);
-    p1[index] = static_cast<AccT>(scale_c) * var_inv;
-  }
+  for (int64_t n = blockIdx.x; n < N; n += gridDim.x) {
+    const int g = blockIdx.y;
+    const int64_t ng = n * groups + g;
+    AccT sum1 = 0;
+    AccT sum2 = 0;
+    AccT var_inv = rsqrt(static_cast<AccT>(var[ng]) + epsilon);
+    for (int64_t i = threadIdx.x; i < group_size; i += blockDim.x) {
+      const int64_t index = ng * group_size + i;
+      const int64_t c = g * group_size + i;
+      const AccT scale_v =
+          scale == nullptr ? static_cast<AccT>(1) : static_cast<AccT>(scale[c]);
+      sum1 += static_cast<AccT>(ds[index]) * scale_v;
+      sum2 += static_cast<AccT>(db[index]) * scale_v;
+      const AccT scale_c =
+          scale == nullptr ? static_cast<AccT>(0) : static_cast<AccT>(scale[c]);
+      p1[index] = static_cast<AccT>(scale_c) * var_inv;
+    }
 
-  typedef cub::BlockReduce<AccT, BlockDim> BlockReduce;
-  __shared__ typename BlockReduce::TempStorage ds_storage;
-  __shared__ typename BlockReduce::TempStorage db_storage;
-  sum1 = BlockReduce(ds_storage).Reduce(sum1, cub::Sum());
-  sum2 = BlockReduce(db_storage).Reduce(sum2, cub::Sum());
+    typedef cub::BlockReduce<AccT, BlockDim> BlockReduce;
+    __shared__ typename BlockReduce::TempStorage ds_storage;
+    __shared__ typename BlockReduce::TempStorage db_storage;
+    sum1 = BlockReduce(ds_storage).Reduce(sum1, cub::Sum());
+    sum2 = BlockReduce(db_storage).Reduce(sum2, cub::Sum());
 
-  if (threadIdx.x == 0) {
-    const AccT s =
-        static_cast<AccT>(1) / static_cast<AccT>(group_size * imsize);
-    const AccT x = (sum2 * static_cast<AccT>(mean[ng]) - sum1) * (var_inv) *
-                   (var_inv) * (var_inv)*s;
-    p2[ng] = x;
-    p3[ng] = -x * (mean[ng]) - (sum2 * var_inv) * s;
+    if (threadIdx.x == 0) {
+      const AccT s =
+          static_cast<AccT>(1) / static_cast<AccT>(group_size * imsize);
+      const AccT x = (sum2 * static_cast<AccT>(mean[ng]) - sum1) * (var_inv) *
+                     (var_inv) * (var_inv)*s;
+      p2[ng] = x;
+      p3[ng] = -x * (mean[ng]) - (sum2 * var_inv) * s;
+    }
   }
 }
 
 template <typename T, typename AccT>
-__global__ void GetXGradientCUDAKernel(int imsize,
-                                       int C,
-                                       int group_size,
+__global__ void GetXGradientCUDAKernel(int64_t N,
+                                       int64_t imsize,
+                                       int64_t C,
+                                       int64_t group_size,
                                        int groups,
                                        AccT* p1,
                                        AccT* p2,
@@ -251,16 +267,19 @@ __global__ void GetXGradientCUDAKernel(int imsize,
                                        const T* x,
                                        const T* dy,
                                        T* dx) {
-  int cid = blockIdx.x;
   int gid = blockIdx.y;
-  int bid = blockIdx.z;
-  int ccid = bid * C + gid * group_size + cid;
-  int ng = bid * groups + gid;
-  int nc = gid * group_size + cid;
-  for (int imid = threadIdx.x; imid < imsize; imid += blockDim.x) {
-    int index = (bid * C + nc) * imsize + imid;
-    dx[index] = static_cast<T>(p1[ccid] * static_cast<AccT>(dy[index]) +
-                               p2[ng] * static_cast<AccT>(x[index]) + p3[ng]);
+  for (int64_t cid = blockIdx.x; cid < group_size; cid += gridDim.x) {
+    for (int64_t bid = blockIdx.z; bid < N; bid += gridDim.z) {
+      int64_t ccid = bid * C + gid * group_size + cid;
+      int64_t ng = bid * groups + gid;
+      int64_t nc = gid * group_size + cid;
+      for (int64_t imid = threadIdx.x; imid < imsize; imid += blockDim.x) {
+        int64_t index = (bid * C + nc) * imsize + imid;
+        dx[index] =
+            static_cast<T>(p1[ccid] * static_cast<AccT>(dy[index]) +
+                           p2[ng] * static_cast<AccT>(x[index]) + p3[ng]);
+      }
+    }
   }
 }
 
@@ -308,11 +327,13 @@ void GroupNormGradKernel(const Context& dev_ctx,
   const auto bias_ptr = bias.get_ptr();
 
   const auto& x_dims = x.dims();
-  const int C = (data_layout == DataLayout::kNCHW ? x_dims[1]
-                                                  : x_dims[x_dims.size() - 1]);
-  const int group_size = C / groups;
-  const int W = (data_layout == DataLayout::kNCHW ? x_dims[x_dims.size() - 1]
-                                                  : x_dims[x_dims.size() - 2]);
+  const int64_t C =
+      (data_layout == DataLayout::kNCHW ? x_dims[1]
+                                        : x_dims[x_dims.size() - 1]);
+  const int64_t group_size = C / groups;
+  const int64_t W =
+      (data_layout == DataLayout::kNCHW ? x_dims[x_dims.size() - 1]
+                                        : x_dims[x_dims.size() - 2]);
 
   if (d_x) {
     dev_ctx.template Alloc<T>(d_x);
@@ -348,7 +369,7 @@ void GroupNormGradKernel(const Context& dev_ctx,
   const T* bias_data = nullptr;
   if (bias_ptr) bias_data = bias_ptr->data<T>();
 
-  int imsize = 1;
+  int64_t imsize = 1;
   if (data_layout == DataLayout::kNCHW) {
     for (int i = 2; i < x_dims.size(); ++i) {
       imsize *= x_dims[i];
@@ -359,15 +380,20 @@ void GroupNormGradKernel(const Context& dev_ctx,
     }
   }
 
-  int block_size = std::min(1024, imsize);
+  int block_size = std::min(static_cast<int64_t>(1024), imsize);
   const int block_dims = 1024;
-  dim3 grid(group_size, groups, x_dims[0]);
+  int64_t max_grid_x = dev_ctx.GetCUDAMaxGridDimSize()[0];
+  int64_t max_grid_z = dev_ctx.GetCUDAMaxGridDimSize()[2];
+  dim3 grid(std::min(max_grid_x, group_size),
+            groups,
+            std::min(max_grid_z, x_dims[0]));
   dim3 threads(block_size, 1, 1);
   int flags =
       (scale_data != nullptr) * kHasScale + (bias_data != nullptr) * kHasBias;
   if (data_layout == DataLayout::kNCHW) {
     const int max_num_threads = 1024;
-    int max_block_size = std::min(imsize, max_num_threads);
+    int max_block_size =
+        std::min(imsize, static_cast<int64_t>(max_num_threads));
     int block_size_nchw = 1;
     while (block_size_nchw < max_block_size) {
       block_size_nchw *= 2;
@@ -375,8 +401,8 @@ void GroupNormGradKernel(const Context& dev_ctx,
     block_size_nchw = std::max(block_size_nchw, kps::details::kWarpSize);
     dim3 blocks(block_size_nchw);
     ScalarGetDsDbCUDAKernel<T, AccT>
-        <<<x_dims[0] * C, blocks, 0, dev_ctx.stream()>>>(
-            imsize, x_data, dy_data, ds_data, db_data);
+        <<<std::min(x_dims[0] * C, max_grid_x), blocks, 0, dev_ctx.stream()>>>(
+            imsize, x_data, dy_data, ds_data, db_data, x_dims[0] * C);
 
     if (d_scale || d_bias) {
       const int block = 256;
@@ -409,21 +435,25 @@ void GroupNormGradKernel(const Context& dev_ctx,
       AccT* p3_data = dev_ctx.template Alloc<AccT>(&p3);
 
       GetBackwardParamsCUDAKernel<T, AccT, block_dims>
-          <<<dim3(x_dims[0], groups), block_dims, 0, dev_ctx.stream()>>>(
-              imsize,
-              groups,
-              group_size,
-              epsilon,
-              mean_data,
-              var_data,
-              scale_data,
-              ds_data,
-              db_data,
-              p1_data,
-              p2_data,
-              p3_data);
+          <<<dim3(std::min(x_dims[0], max_grid_x), groups),
+             block_dims,
+             0,
+             dev_ctx.stream()>>>(x_dims[0],
+                                 imsize,
+                                 groups,
+                                 group_size,
+                                 epsilon,
+                                 mean_data,
+                                 var_data,
+                                 scale_data,
+                                 ds_data,
+                                 db_data,
+                                 p1_data,
+                                 p2_data,
+                                 p3_data);
       GetXGradientCUDAKernel<T, AccT>
-          <<<grid, threads, 0, dev_ctx.stream()>>>(imsize,
+          <<<grid, threads, 0, dev_ctx.stream()>>>(x_dims[0],
+                                                   imsize,
                                                    C,
                                                    group_size,
                                                    groups,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
对Group_norm的前向和反向算子GPU Kernel进行修复，支持大Tensor计算。NDHWC Layout的GPU Kernel后续再修复。
- 将imsize N C等参数改为int64_t类型
- 限制Grid的大小，在kernel内部增加循环。 
- 性能前后对比：

  | N H W C = [4, 1024, 1024, 8] | Backward(ns) | Forward(ns) |
  | ----------------------------- | -------------- | ----------- |
  |Before | 1,499,555.2 |  1,297,977.1 |
  |After | 1,516,646.6 |  1,295,388.3  |

  性能波动在2%以内。