### PR TITLE
[PHI]Fix paddle.vision.ops.roi_align to support big Tensor

### DIFF
--- a/paddle/phi/kernels/gpu/roi_align_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/roi_align_grad_kernel.cu
@@ -267,7 +267,8 @@ void RoiAlignGradKernel(const Context& dev_ctx,
   uint32_t threads = kNumCUDAThreads;
 
   if (output_grad_size > 0) {
-    if (output_grad_size > std::numeric_limits<int32_t>::max()) {
+    if (output_grad_size > std::numeric_limits<int>::max() ||
+        dx->numel() > std::numeric_limits<int>::max()) {
       GPURoiAlignBackward<T, int64_t>
           <<<blocks, threads, 0, dev_ctx.stream()>>>(output_grad_size,
                                                      boxes.data<T>(),

--- a/paddle/phi/kernels/gpu/roi_align_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/roi_align_grad_kernel.cu
@@ -30,32 +30,33 @@ static constexpr int kNumCUDAThreads = 512;
 static constexpr int kNumMaximumNumBlocks = 4096;
 static constexpr int kROISize = 4;
 
-static inline int NumBlocks(const int N) {
-  return std::min((N + kNumCUDAThreads - 1) / kNumCUDAThreads,
-                  kNumMaximumNumBlocks);
+static inline uint32_t NumBlocks(const int64_t N) {
+  return static_cast<uint32_t>(
+      std::min((N + kNumCUDAThreads - 1) / kNumCUDAThreads,
+               static_cast<int64_t>(kNumMaximumNumBlocks)));
 }
 
-template <class T>
-__device__ void BilinearInterpolateGradient(const int height,
-                                            const int width,
+template <class T, typename IndexType>
+__device__ void BilinearInterpolateGradient(const IndexType height,
+                                            const IndexType width,
                                             T y,
                                             T x,
                                             T* w1,
                                             T* w2,
                                             T* w3,
                                             T* w4,
-                                            int* x_low,
-                                            int* x_high,
-                                            int* y_low,
-                                            int* y_high) {
+                                            IndexType* x_low,
+                                            IndexType* x_high,
+                                            IndexType* y_low,
+                                            IndexType* y_high) {
   if (y < -1.0 || y > height || x < -1.0 || x > width) {
     return;
   }
 
   y = y <= 0 ? 0 : y;
   x = x <= 0 ? 0 : x;
-  *y_low = static_cast<int>(y);
-  *x_low = static_cast<int>(x);
+  *y_low = static_cast<IndexType>(y);
+  *x_low = static_cast<IndexType>(x);
   if (*y_low >= height - 1) {
     *y_high = *y_low = height - 1;
     y = static_cast<T>(*y_low);
@@ -75,26 +76,26 @@ __device__ void BilinearInterpolateGradient(const int height,
   return;
 }
 
-template <typename T>
-__global__ void GPURoiAlignBackward(const int nthreads,
+template <typename T, typename IndexType>
+__global__ void GPURoiAlignBackward(const IndexType nthreads,
                                     const T* input_rois,
                                     const T* out_grad,
-                                    const int num_rois,
+                                    const IndexType num_rois,
                                     const float spatial_scale,
-                                    const int channels,
-                                    const int height,
-                                    const int width,
+                                    const IndexType channels,
+                                    const IndexType height,
+                                    const IndexType width,
                                     const int pooled_height,
                                     const int pooled_width,
                                     const int sampling_ratio,
                                     int* roi_batch_id_data,
                                     T* input_grad,
                                     const bool continuous_coordinate) {
-  CUDA_KERNEL_LOOP(i, nthreads) {
-    int pw = i % pooled_width;
-    int ph = (i / pooled_width) % pooled_height;
-    int c = (i / pooled_width / pooled_height) % channels;
-    int n = i / pooled_width / pooled_height / channels;
+  CUDA_KERNEL_LOOP_TYPE(i, nthreads, IndexType) {
+    IndexType pw = i % pooled_width;
+    IndexType ph = (i / pooled_width) % pooled_height;
+    IndexType c = (i / pooled_width / pooled_height) % channels;
+    IndexType n = i / pooled_width / pooled_height / channels;
     const T* offset_input_rois = input_rois + n * kROISize;
     int roi_batch_ind = roi_batch_id_data[n];
 
@@ -136,7 +137,7 @@ __global__ void GPURoiAlignBackward(const int nthreads,
                     static_cast<T>(ix + .5f) * bin_size_w /
                         static_cast<T>(roi_bin_grid_w);
         T w1 = 0, w2 = 0, w3 = 0, w4 = 0;
-        int x_low = -1, x_high = -1, y_low = -1, y_high = -1;
+        IndexType x_low = -1, x_high = -1, y_low = -1, y_high = -1;
         BilinearInterpolateGradient(height,
                                     width,
                                     y,
@@ -185,11 +186,11 @@ void RoiAlignGradKernel(const Context& dev_ctx,
     return;
   }
 
-  int rois_num = boxes.dims()[0];
+  int64_t rois_num = boxes.dims()[0];
 
-  int channels = x.dims()[1];
-  int height = x.dims()[2];
-  int width = x.dims()[3];
+  int64_t channels = x.dims()[1];
+  int64_t height = x.dims()[2];
+  int64_t width = x.dims()[3];
 
   if (!dx) {
     return;
@@ -207,7 +208,7 @@ void RoiAlignGradKernel(const Context& dev_ctx,
   auto cplace = phi::CPUPlace();
   auto gplace = dev_ctx.GetPlace();
   if (boxes_num) {
-    int boxes_batch_size = boxes_num->numel();
+    int64_t boxes_batch_size = boxes_num->numel();
     if (boxes_num->dtype() == phi::DataType::INT64) {
       std::vector<int64_t> boxes_num_list(boxes_batch_size);
       memory_utils::Copy(cplace,
@@ -231,8 +232,8 @@ void RoiAlignGradKernel(const Context& dev_ctx,
                          boxes_num->data<int>(),
                          sizeof(int) * boxes_batch_size,
                          0);
-      int start = 0;
-      for (int n = 0; n < boxes_batch_size; ++n) {
+      int64_t start = 0;
+      for (int64_t n = 0; n < boxes_batch_size; ++n) {
         for (size_t i = start; i < start + boxes_num_list[n]; ++i) {
           box_batch_size[i] = n;
         }
@@ -241,8 +242,8 @@ void RoiAlignGradKernel(const Context& dev_ctx,
     }
   } else {
     auto boxes_lod = boxes.lod().back();
-    int boxes_batch_size = boxes_lod.size() - 1;
-    for (int n = 0; n < boxes_batch_size; ++n) {
+    int64_t boxes_batch_size = boxes_lod.size() - 1;
+    for (int64_t n = 0; n < boxes_batch_size; ++n) {
       for (size_t i = boxes_lod[n]; i < boxes_lod[n + 1]; ++i) {
         box_batch_size[i] = n;
       }
@@ -253,7 +254,7 @@ void RoiAlignGradKernel(const Context& dev_ctx,
       box_batch_id_list.numel() * sizeof(int),
       phi::Stream(reinterpret_cast<phi::StreamId>(dev_ctx.stream())));
   int* roi_id_data = reinterpret_cast<int*>(roi_ptr->ptr());
-  int bytes = box_batch_id_list.numel() * sizeof(int);
+  int64_t bytes = box_batch_id_list.numel() * sizeof(int);
   memory_utils::Copy(
       gplace, roi_id_data, cplace, box_batch_size, bytes, dev_ctx.stream());
   dev_ctx.template Alloc<T>(dx);
@@ -261,26 +262,44 @@ void RoiAlignGradKernel(const Context& dev_ctx,
   phi::funcs::SetConstant<Context, T> set_zero;
   set_zero(dev_ctx, dx, static_cast<T>(0));
 
-  int output_grad_size = out_grad.numel();
-  int blocks = NumBlocks(output_grad_size);
-  int threads = kNumCUDAThreads;
+  int64_t output_grad_size = out_grad.numel();
+  uint32_t blocks = NumBlocks(output_grad_size);
+  uint32_t threads = kNumCUDAThreads;
 
   if (output_grad_size > 0) {
-    GPURoiAlignBackward<T>
-        <<<blocks, threads, 0, dev_ctx.stream()>>>(output_grad_size,
-                                                   boxes.data<T>(),
-                                                   out_grad.data<T>(),
-                                                   rois_num,
-                                                   spatial_scale,
-                                                   channels,
-                                                   height,
-                                                   width,
-                                                   pooled_height,
-                                                   pooled_width,
-                                                   sampling_ratio,
-                                                   roi_id_data,
-                                                   dx->data<T>(),
-                                                   aligned);
+    if (output_grad_size > std::numeric_limits<int32_t>::max()) {
+      GPURoiAlignBackward<T, int64_t>
+          <<<blocks, threads, 0, dev_ctx.stream()>>>(output_grad_size,
+                                                     boxes.data<T>(),
+                                                     out_grad.data<T>(),
+                                                     rois_num,
+                                                     spatial_scale,
+                                                     channels,
+                                                     height,
+                                                     width,
+                                                     pooled_height,
+                                                     pooled_width,
+                                                     sampling_ratio,
+                                                     roi_id_data,
+                                                     dx->data<T>(),
+                                                     aligned);
+    } else {
+      GPURoiAlignBackward<T, int32_t>
+          <<<blocks, threads, 0, dev_ctx.stream()>>>(output_grad_size,
+                                                     boxes.data<T>(),
+                                                     out_grad.data<T>(),
+                                                     rois_num,
+                                                     spatial_scale,
+                                                     channels,
+                                                     height,
+                                                     width,
+                                                     pooled_height,
+                                                     pooled_width,
+                                                     sampling_ratio,
+                                                     roi_id_data,
+                                                     dx->data<T>(),
+                                                     aligned);
+    }
   }
 }
 

--- a/paddle/phi/kernels/gpu/roi_align_kernel.cu
+++ b/paddle/phi/kernels/gpu/roi_align_kernel.cu
@@ -27,9 +27,10 @@ static constexpr int kNumCUDAThreads = 512;
 static constexpr int kNumMaximumNumBlocks = 4096;
 static constexpr int kROISize = 4;
 
-static inline int NumBlocks(const int N) {
-  return std::min((N + kNumCUDAThreads - 1) / kNumCUDAThreads,
-                  kNumMaximumNumBlocks);
+static inline uint32_t NumBlocks(const int64_t N) {
+  return static_cast<uint32_t>(
+      std::min((N + kNumCUDAThreads - 1) / kNumCUDAThreads,
+               static_cast<int64_t>(kNumMaximumNumBlocks)));
 }
 
 template <class T>
@@ -156,21 +157,21 @@ void RoiAlignKernel(const Context& dev_ctx,
     return;
   }
   auto in_dims = x.dims();
-  int batch_size = in_dims[0];
-  int channels = in_dims[1];
-  int height = in_dims[2];
-  int width = in_dims[3];
+  int64_t batch_size = in_dims[0];
+  int64_t channels = in_dims[1];
+  int64_t height = in_dims[2];
+  int64_t width = in_dims[3];
 
-  int rois_num = boxes.dims()[0];
+  int64_t rois_num = boxes.dims()[0];
 
   if (rois_num == 0) {
     dev_ctx.template Alloc<T>(out);
     return;
   }
 
-  int output_size = out->numel();
-  int blocks = NumBlocks(output_size);
-  int threads = kNumCUDAThreads;
+  int64_t output_size = out->numel();
+  uint32_t blocks = NumBlocks(output_size);
+  uint32_t threads = kNumCUDAThreads;
 #ifdef WITH_NV_JETSON
   backends::gpu::ChangeThreadNum(dev_ctx, &threads, 256);
 #endif

--- a/paddle/phi/kernels/gpu/roi_align_kernel.cu
+++ b/paddle/phi/kernels/gpu/roi_align_kernel.cu
@@ -33,18 +33,21 @@ static inline uint32_t NumBlocks(const int64_t N) {
                static_cast<int64_t>(kNumMaximumNumBlocks)));
 }
 
-template <class T>
-__device__ T BilinearInterpolate(
-    const T* input_data, const int height, const int width, T y, T x) {
+template <class T, typename IndexType>
+__device__ T BilinearInterpolate(const T* input_data,
+                                 const IndexType height,
+                                 const IndexType width,
+                                 T y,
+                                 T x) {
   if (y < -1.0 || y > height || x < -1.0 || x > width) {
     return 0;
   }
   y = y <= 0 ? 0 : y;
   x = x <= 0 ? 0 : x;
-  int y_low = static_cast<int>(y);
-  int x_low = static_cast<int>(x);
-  int y_high;
-  int x_high;
+  IndexType y_low = static_cast<IndexType>(y);
+  IndexType x_low = static_cast<IndexType>(x);
+  IndexType y_high;
+  IndexType x_high;
   if (y_low >= height - 1) {
     y_high = y_low = height - 1;
     y = static_cast<T>(y_low);
@@ -70,25 +73,25 @@ __device__ T BilinearInterpolate(
   return val;
 }
 
-template <class T>
-__global__ void GPURoiAlignForward(const int nthreads,
+template <class T, typename IndexType>
+__global__ void GPURoiAlignForward(const IndexType nthreads,
                                    const T* input_data,
                                    const T* input_rois,
                                    const float spatial_scale,
-                                   const int channels,
-                                   const int height,
-                                   const int width,
+                                   const IndexType channels,
+                                   const IndexType height,
+                                   const IndexType width,
                                    const int pooled_height,
                                    const int pooled_width,
                                    const int sampling_ratio,
                                    int* roi_batch_id_data,
                                    T* output_data,
                                    const bool continuous_coordinate) {
-  CUDA_KERNEL_LOOP(i, nthreads) {
-    int pw = i % pooled_width;
-    int ph = (i / pooled_width) % pooled_height;
-    int c = (i / pooled_width / pooled_height) % channels;
-    int n = i / pooled_width / pooled_height / channels;
+  CUDA_KERNEL_LOOP_TYPE(i, nthreads, IndexType) {
+    IndexType pw = i % pooled_width;
+    IndexType ph = (i / pooled_width) % pooled_height;
+    IndexType c = (i / pooled_width / pooled_height) % channels;
+    IndexType n = i / pooled_width / pooled_height / channels;
 
     const T* offset_input_rois = input_rois + n * kROISize;
     int roi_batch_ind = roi_batch_id_data[n];
@@ -127,7 +130,8 @@ __global__ void GPURoiAlignForward(const int nthreads,
         const T x = roi_xmin + pw * bin_size_w +
                     static_cast<T>(ix + .5f) * bin_size_w /
                         static_cast<T>(roi_bin_grid_w);
-        T val = BilinearInterpolate(offset_input_data, height, width, y, x);
+        T val = BilinearInterpolate<T, IndexType>(
+            offset_input_data, height, width, y, x);
         output_val += val;
       }
     }
@@ -181,7 +185,7 @@ void RoiAlignKernel(const Context& dev_ctx,
   auto cplace = phi::CPUPlace();
   auto gplace = dev_ctx.GetPlace();
   if (boxes_num) {
-    int boxes_batch_size = boxes_num->numel();
+    int64_t boxes_batch_size = boxes_num->numel();
     PADDLE_ENFORCE_EQ(
         boxes_batch_size,
         batch_size,
@@ -215,9 +219,9 @@ void RoiAlignKernel(const Context& dev_ctx,
                          boxes_num->data<int>(),
                          sizeof(int) * boxes_batch_size,
                          0);
-      int start = 0;
-      for (int n = 0; n < boxes_batch_size; ++n) {
-        for (int i = start; i < start + boxes_num_list[n]; ++i) {
+      int64_t start = 0;
+      for (int64_t n = 0; n < boxes_batch_size; ++n) {
+        for (int64_t i = start; i < start + boxes_num_list[n]; ++i) {
           roi_batch_id_data[i] = n;
         }
         start += boxes_num_list[n];
@@ -251,13 +255,13 @@ void RoiAlignKernel(const Context& dev_ctx,
             "of rois from RoIsLoD is %d",
             rois_num,
             boxes_num_with_lod));
-    for (int n = 0; n < boxes_batch_size; ++n) {
+    for (int64_t n = 0; n < boxes_batch_size; ++n) {
       for (size_t i = boxes_lod[n]; i < boxes_lod[n + 1]; ++i) {
         roi_batch_id_data[i] = n;
       }
     }
   }
-  int bytes = roi_batch_id_list.numel() * sizeof(int);
+  int64_t bytes = roi_batch_id_list.numel() * sizeof(int);
   auto roi_ptr = phi::memory_utils::Alloc(
       dev_ctx.GetPlace(),
       bytes,
@@ -265,20 +269,38 @@ void RoiAlignKernel(const Context& dev_ctx,
   int* roi_id_data = reinterpret_cast<int*>(roi_ptr->ptr());
   memory_utils::Copy(
       gplace, roi_id_data, cplace, roi_batch_id_data, bytes, dev_ctx.stream());
-  GPURoiAlignForward<T>
-      <<<blocks, threads, 0, dev_ctx.stream()>>>(output_size,
-                                                 x.data<T>(),
-                                                 boxes.data<T>(),
-                                                 spatial_scale,
-                                                 channels,
-                                                 height,
-                                                 width,
-                                                 pooled_height,
-                                                 pooled_width,
-                                                 sampling_ratio,
-                                                 roi_id_data,
-                                                 dev_ctx.template Alloc<T>(out),
-                                                 aligned);
+  if (output_size > std::numeric_limits<int>::max() ||
+      x.numel() > std::numeric_limits<int>::max()) {
+    GPURoiAlignForward<T, int64_t><<<blocks, threads, 0, dev_ctx.stream()>>>(
+        output_size,
+        x.data<T>(),
+        boxes.data<T>(),
+        spatial_scale,
+        channels,
+        height,
+        width,
+        pooled_height,
+        pooled_width,
+        sampling_ratio,
+        roi_id_data,
+        dev_ctx.template Alloc<T>(out),
+        aligned);
+  } else {
+    GPURoiAlignForward<T, int32_t><<<blocks, threads, 0, dev_ctx.stream()>>>(
+        output_size,
+        x.data<T>(),
+        boxes.data<T>(),
+        spatial_scale,
+        channels,
+        height,
+        width,
+        pooled_height,
+        pooled_width,
+        sampling_ratio,
+        roi_id_data,
+        dev_ctx.template Alloc<T>(out),
+        aligned);
+  }
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/gpu/roi_align_kernel.cu
+++ b/paddle/phi/kernels/gpu/roi_align_kernel.cu
@@ -234,7 +234,7 @@ void RoiAlignKernel(const Context& dev_ctx,
                       errors::InvalidArgument("Input(ROIs) in ROIAlignOp does "
                                               "not contain LoD information."));
     auto boxes_lod = lod.back();
-    int boxes_batch_size = boxes_lod.size() - 1;
+    int64_t boxes_batch_size = boxes_lod.size() - 1;
     PADDLE_ENFORCE_EQ(
         boxes_batch_size,
         batch_size,
@@ -244,7 +244,7 @@ void RoiAlignKernel(const Context& dev_ctx,
             "and images batch size = %d",
             boxes_batch_size,
             batch_size));
-    int boxes_num_with_lod = boxes_lod[boxes_batch_size];
+    int64_t boxes_num_with_lod = boxes_lod[boxes_batch_size];
     PADDLE_ENFORCE_EQ(
         rois_num,
         boxes_num_with_lod,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure 
### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修复了paddle.vision.ops.roi_align 由于int溢出导致cuda Error 9 和cuda Error 700 的问题。

trochvision 对应的kernel也不支持大Tensor https://github.com/pytorch/vision/blob/0721867e42841171254c7acaa45fbaf8ee16d3d7/torchvision/csrc/ops/cuda/roi_align_kernel.cu#L69-L143  因此没办法进行精度对比。
paddleAPITest（paddle_only）模式下的回测结果：
cuda error消失，有一些非法case引起的参数检查没过。
![image](https://github.com/user-attachments/assets/202d9a54-acc4-496e-89cd-05c6201e2adf)



pcard-67164

