### PR TITLE
[PHI] Fix accuracy diff  for paddle.nn.Hardshrink

### DIFF
--- a/paddle/phi/kernels/funcs/activation_functor.h
+++ b/paddle/phi/kernels/funcs/activation_functor.h
@@ -1955,8 +1955,8 @@ struct HardShrinkFunctor : public BaseActivationFunctor<T> {
   }
   template <typename Device, typename X, typename Out>
   void operator()(Device d, X x, Out out) const {
-    auto temp1 = x < static_cast<T>(threshold * -1.f);  // NOLINT
-    auto temp2 = x > static_cast<T>(threshold);
+    auto temp1 = x <= static_cast<T>(threshold * -1.f);  // NOLINT
+    auto temp2 = x >= static_cast<T>(threshold);
     out.device(d) = x * (temp1 || temp2).template cast<T>();
   }
 };
@@ -1975,8 +1975,8 @@ struct HardShrinkGradFunctor : public BaseActivationFunctor<T> {
             typename dOut,
             typename dX>
   void operator()(Device d, X x, Out out UNUSED, dOut dout, dX dx) const {
-    auto temp1 = x < static_cast<T>(threshold * -1.f);  // NOLINT
-    auto temp2 = x > static_cast<T>(threshold);
+    auto temp1 = x <= static_cast<T>(threshold * -1.f);  // NOLINT
+    auto temp2 = x >= static_cast<T>(threshold);
     dx.device(d) = dout * (temp1 || temp2).template cast<T>();
   }
 
@@ -4578,7 +4578,7 @@ struct CudaHardShrinkFunctor : public BaseActivationFunctor<T> {
   // hadrshrink(x) = (x > -threshold && x < threshold) ? 0 : x
   __device__ __forceinline__ T operator()(const T x) const {
     T t = static_cast<T>(threshold);
-    return (x > -t && x < t) ? zero : x;
+    return (x >= -t && x <= t) ? zero : x;
   }
 };
 
@@ -4594,7 +4594,7 @@ struct CudaHardShrinkGradFunctor : public BaseActivationFunctor<T> {
   // dx = (x > -threshold && x < threshold) ? 0 : dout
   __device__ __forceinline__ T operator()(const T dout, const T x) const {
     T t = static_cast<T>(threshold);
-    return (x > -t && x < t) ? zero : dout;
+    return (x >= -t && x <= t) ? zero : dout;
   }
 
   static constexpr ActBwdOpFwdDeps FwdDeps() { return ActBwdOpFwdDeps::kDepX; }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
从大Tensor测试中发现的精度问题，但是小Tensor也会存在类似问题。本PR将paddle和torch的处理方式对齐。

**出现问题的原因是**：对临界点的处理和torch略有区别,导致的结果不对齐。
### API接口描述：
Torch：
![image](https://github.com/user-attachments/assets/4f88f124-de43-4b5b-acbf-d7850ccd1d7d)
Paddle：
![image](https://github.com/user-attachments/assets/395cfea0-5b70-4737-86e1-ee9e7a39d295)
二者接口描述一致，但是关于``` threshold ```临界点的处理却不同。

### threshold  临界点的处理方式：
Torch hardshrink_kernel 源码 ： 
https://github.com/pytorch/pytorch/blob/455dfd258980294f0745bd90aee12a323e37224d/aten/src/ATen/native/cuda/ActivationHardshrinkKernel.cu#L22
![image](https://github.com/user-attachments/assets/4f3a662b-1f32-4643-97db-abbb2026d029)
Paddle CudaHardShrinkFunctor源码：

https://github.com/PaddlePaddle/Paddle/blob/0d647f97463e60cf0801a5b5298835aaa1c281a0/paddle/phi/kernels/funcs/activation_functor.h#L4570-L4583

**针对于threshold这一临界点：**
- torch的处理方式是：
``` res =  (x >= -threshold && x <= threshold) ? zero : x ```
- Paddle的处理方式是：
``` res =  (x > -threshold && x < threshold) ? zero : x ```

由于上述threshold临界点处理方式的区别，导致了一些结果无法对齐。

### PaddleAPITest回测：
能与torch保持对齐
![image](https://github.com/user-attachments/assets/e56c3139-b0fb-4ffd-a852-c5ad03179f7e)

pcard-67164