### PR TITLE
Fix paddle.linalg.lu_unpack for big tensor 

### DIFF
--- a/paddle/phi/kernels/gpu/arange_kernel.cu
+++ b/paddle/phi/kernels/gpu/arange_kernel.cu
@@ -28,7 +28,7 @@ namespace phi {
 
 template <typename T, typename OUT_TYPE>
 __global__ void Range(T start, T step, int64_t size, OUT_TYPE* out) {
-  CUDA_KERNEL_LOOP(index, size) {
+  CUDA_KERNEL_LOOP_TYPE(index, size, int64_t) {
     out[index] = static_cast<OUT_TYPE>(start + step * index);
   }
 }

--- a/paddle/phi/kernels/impl/lu_kernel_impl.h
+++ b/paddle/phi/kernels/impl/lu_kernel_impl.h
@@ -405,7 +405,8 @@ struct OneFunctor {
       : output_(output), idtptr_(idtptr), w_(w), dim_(dim) {}
 
   HOSTDEVICE void operator()(size_t idx) const {
-    output_[w_ * idtptr_[idx] + idx % dim_] = static_cast<T>(1);
+    int64_t addr = static_cast<int64_t>(w_) * idtptr_[idx] + idx % dim_;
+    output_[addr] = static_cast<T>(1);
   }
 
   T* output_;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修复了paddle.linalg.lu_unpack的memory error和精度误差问题
- 大部分测例的参数设置不正确，导致了memory error问题
- 在对L矩阵对角线进行赋值的时候，溢出导致了精度问题 
