### PR TITLE
[PHI]Fix paddle.vision.ops.roi_pool to support big Tensor 

### DIFF
--- a/paddle/phi/kernels/gpu/roi_pool_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/roi_pool_grad_kernel.cu
@@ -27,41 +27,43 @@ namespace phi {
 static constexpr int kNumCUDAThreads = 512;
 static constexpr int kNumMaximumNumBlocks = 4096;
 
-static inline int NumBlocks(const int N) {
-  return std::min((N + kNumCUDAThreads - 1) / kNumCUDAThreads,
-                  kNumMaximumNumBlocks);
+static inline uint32_t NumBlocks(const int64_t N) {
+  return static_cast<uint32_t>(
+      std::min((N + kNumCUDAThreads - 1) / kNumCUDAThreads,
+               static_cast<int64_t>(kNumMaximumNumBlocks)));
 }
 
-template <typename T>
-__global__ void GPURoiPoolBackward(const int nthreads,
+template <typename T, typename IndexType>
+__global__ void GPURoiPoolBackward(const IndexType nthreads,
                                    const T* input_rois,
                                    const T* output_grad,
                                    const int64_t* arg_max_data,
-                                   const int num_rois,
+                                   const IndexType num_rois,
                                    const float spatial_scale,
-                                   const int channels,
-                                   const int height,
-                                   const int width,
+                                   const IndexType channels,
+                                   const IndexType height,
+                                   const IndexType width,
                                    const int pooled_height,
                                    const int pooled_width,
                                    int* box_batch_id_data,
                                    T* input_grad) {
-  int index = blockIdx.x * blockDim.x + threadIdx.x;
-  int offset = blockDim.x * gridDim.x;
-  for (int i = index; i < nthreads; i += offset) {
-    int pw = i % pooled_width;
-    int ph = (i / pooled_width) % pooled_height;
-    int c = (i / pooled_width / pooled_height) % channels;
-    int n = i / pooled_width / pooled_height / channels;
+  IndexType index =
+      static_cast<IndexType>(blockIdx.x) * blockDim.x + threadIdx.x;
+  IndexType offset = static_cast<IndexType>(blockDim.x) * gridDim.x;
+  for (IndexType i = index; i < nthreads; i += offset) {
+    IndexType pw = i % pooled_width;
+    IndexType ph = (i / pooled_width) % pooled_height;
+    IndexType c = (i / pooled_width / pooled_height) % channels;
+    IndexType n = i / pooled_width / pooled_height / channels;
 
     int roi_batch_ind = box_batch_id_data[n];
-    int input_offset = (roi_batch_ind * channels + c) * height * width;
-    int output_offset = (n * channels + c) * pooled_height * pooled_width;
+    IndexType input_offset = (roi_batch_ind * channels + c) * height * width;
+    IndexType output_offset = (n * channels + c) * pooled_height * pooled_width;
     const T* offset_output_grad = output_grad + output_offset;
     T* offset_input_grad = input_grad + input_offset;
     const int64_t* offset_arg_max_data = arg_max_data + output_offset;
 
-    int arg_max = offset_arg_max_data[ph * pooled_width + pw];
+    int64_t arg_max = offset_arg_max_data[ph * pooled_width + pw];
     if (arg_max != -1) {
       phi::CudaAtomicAdd(
           offset_input_grad + arg_max,
@@ -82,10 +84,10 @@ void RoiPoolGradKernel(const Context& dev_ctx,
                        float spatial_scale,
                        DenseTensor* dx) {
   auto x_dims = x.dims();
-  int channels = x_dims[1];
-  int height = x_dims[2];
-  int width = x_dims[3];
-  int rois_num = boxes.dims()[0];
+  int64_t channels = x_dims[1];
+  int64_t height = x_dims[2];
+  int64_t width = x_dims[3];
+  int64_t rois_num = boxes.dims()[0];
 
   if (dx) {
     DenseTensor box_batch_id_list;
@@ -136,9 +138,9 @@ void RoiPoolGradKernel(const Context& dev_ctx,
     phi::funcs::SetConstant<Context, T> set_zero;
     set_zero(dev_ctx, dx, static_cast<T>(0));
 
-    int output_grad_size = out_grad.numel();
-    int blocks = NumBlocks(output_grad_size);
-    int threads = kNumCUDAThreads;
+    int64_t output_grad_size = out_grad.numel();
+    uint32_t blocks = NumBlocks(output_grad_size);
+    uint32_t threads = kNumCUDAThreads;
 
     if (output_grad_size > 0) {
       GPURoiPoolBackward<T>

--- a/paddle/phi/kernels/gpu/roi_pool_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/roi_pool_grad_kernel.cu
@@ -143,20 +143,38 @@ void RoiPoolGradKernel(const Context& dev_ctx,
     uint32_t threads = kNumCUDAThreads;
 
     if (output_grad_size > 0) {
-      GPURoiPoolBackward<T>
-          <<<blocks, threads, 0, dev_ctx.stream()>>>(output_grad_size,
-                                                     boxes.data<T>(),
-                                                     out_grad.data<T>(),
-                                                     arg_max.data<int64_t>(),
-                                                     rois_num,
-                                                     spatial_scale,
-                                                     channels,
-                                                     height,
-                                                     width,
-                                                     pooled_height,
-                                                     pooled_width,
-                                                     roi_id_data,
-                                                     dx->data<T>());
+      if (output_grad_size > std::numeric_limits<int32_t>::max() ||
+          dx->numel() > std::numeric_limits<int32_t>::max()) {
+        GPURoiPoolBackward<T, int64_t>
+            <<<blocks, threads, 0, dev_ctx.stream()>>>(output_grad_size,
+                                                       boxes.data<T>(),
+                                                       out_grad.data<T>(),
+                                                       arg_max.data<int64_t>(),
+                                                       rois_num,
+                                                       spatial_scale,
+                                                       channels,
+                                                       height,
+                                                       width,
+                                                       pooled_height,
+                                                       pooled_width,
+                                                       roi_id_data,
+                                                       dx->data<T>());
+      } else {
+        GPURoiPoolBackward<T, int32_t>
+            <<<blocks, threads, 0, dev_ctx.stream()>>>(output_grad_size,
+                                                       boxes.data<T>(),
+                                                       out_grad.data<T>(),
+                                                       arg_max.data<int64_t>(),
+                                                       rois_num,
+                                                       spatial_scale,
+                                                       channels,
+                                                       height,
+                                                       width,
+                                                       pooled_height,
+                                                       pooled_width,
+                                                       roi_id_data,
+                                                       dx->data<T>());
+      }
     }
   }
 }

--- a/paddle/phi/kernels/gpu/roi_pool_kernel.cu
+++ b/paddle/phi/kernels/gpu/roi_pool_kernel.cu
@@ -203,19 +203,36 @@ void RoiPoolKernel(const Context& dev_ctx,
 
   T* output_data = dev_ctx.template Alloc<T>(out);
   int64_t* arg_max_data = dev_ctx.template Alloc<int64_t>(arg_max);
-  GPURoiPoolForward<T>
-      <<<blocks, threads, 0, dev_ctx.stream()>>>(output_size,
-                                                 x.data<T>(),
-                                                 boxes.data<T>(),
-                                                 spatial_scale,
-                                                 channels,
-                                                 height,
-                                                 width,
-                                                 pooled_height,
-                                                 pooled_width,
-                                                 box_id_data,
-                                                 output_data,
-                                                 arg_max_data);
+  if (output_size > std::numeric_limits<int32_t>::max() ||
+      x.numel() > std::numeric_limits<int32_t>::max()) {
+    GPURoiPoolForward<T, int64_t>
+        <<<blocks, threads, 0, dev_ctx.stream()>>>(output_size,
+                                                   x.data<T>(),
+                                                   boxes.data<T>(),
+                                                   spatial_scale,
+                                                   channels,
+                                                   height,
+                                                   width,
+                                                   pooled_height,
+                                                   pooled_width,
+                                                   box_id_data,
+                                                   output_data,
+                                                   arg_max_data);
+  } else {
+    GPURoiPoolForward<T, int32_t>
+        <<<blocks, threads, 0, dev_ctx.stream()>>>(output_size,
+                                                   x.data<T>(),
+                                                   boxes.data<T>(),
+                                                   spatial_scale,
+                                                   channels,
+                                                   height,
+                                                   width,
+                                                   pooled_height,
+                                                   pooled_width,
+                                                   box_id_data,
+                                                   output_data,
+                                                   arg_max_data);
+  }
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/gpu/roi_pool_kernel.cu
+++ b/paddle/phi/kernels/gpu/roi_pool_kernel.cu
@@ -25,31 +25,33 @@ namespace phi {
 static constexpr int kNumCUDAThreads = 512;
 static constexpr int kNumMaximumNumBlocks = 4096;
 
-static inline int NumBlocks(const int N) {
-  return std::min((N + kNumCUDAThreads - 1) / kNumCUDAThreads,
-                  kNumMaximumNumBlocks);
+static inline uint32_t NumBlocks(const int64_t N) {
+  return static_cast<uint32_t>(
+      std::min((N + kNumCUDAThreads - 1) / kNumCUDAThreads,
+               static_cast<int64_t>(kNumMaximumNumBlocks)));
 }
 
-template <typename T>
-__global__ void GPURoiPoolForward(const int nthreads,
+template <typename T, typename IndexType>
+__global__ void GPURoiPoolForward(const IndexType nthreads,
                                   const T* input_data,
                                   const T* input_rois,
                                   const float spatial_scale,
-                                  const int channels,
-                                  const int height,
-                                  const int width,
+                                  const IndexType channels,
+                                  const IndexType height,
+                                  const IndexType width,
                                   const int pooled_height,
                                   const int pooled_width,
                                   int* box_batch_id_data,
                                   T* output_data,
                                   int64_t* arg_max_data) {
-  int index = blockIdx.x * blockDim.x + threadIdx.x;
-  int offset = blockDim.x * gridDim.x;
+  IndexType index =
+      static_cast<IndexType>(blockIdx.x) * blockDim.x + threadIdx.x;
+  IndexType offset = static_cast<IndexType>(blockDim.x) * gridDim.x;
   for (size_t i = index; i < nthreads; i += offset) {
-    int pw = i % pooled_width;
-    int ph = (i / pooled_width) % pooled_height;
-    int c = (i / pooled_width / pooled_height) % channels;
-    int n = i / pooled_width / pooled_height / channels;
+    IndexType pw = i % pooled_width;
+    IndexType ph = (i / pooled_width) % pooled_height;
+    IndexType c = (i / pooled_width / pooled_height) % channels;
+    IndexType n = i / pooled_width / pooled_height / channels;
 
     const T* offset_input_rois = input_rois + n * kROISize;
     int box_batch_ind = box_batch_id_data[n];
@@ -61,22 +63,22 @@ __global__ void GPURoiPoolForward(const int nthreads,
     int box_width = max(box_end_w - box_start_w + 1, 1);
     int box_height = max(box_end_h - box_start_h + 1, 1);
 
-    int hstart = static_cast<int>(
+    IndexType hstart = static_cast<IndexType>(
         floor(static_cast<double>(ph) * static_cast<double>(box_height) /
               static_cast<double>(pooled_height)));
-    int wstart = static_cast<int>(
+    IndexType wstart = static_cast<IndexType>(
         floor(static_cast<double>(pw) * static_cast<double>(box_width) /
               static_cast<double>(pooled_width)));
-    int hend = static_cast<int>(
+    IndexType hend = static_cast<IndexType>(
         ceil(static_cast<double>(ph + 1) * static_cast<double>(box_height) /
              static_cast<double>(pooled_height)));
-    int wend = static_cast<int>(
+    IndexType wend = static_cast<IndexType>(
         ceil(static_cast<double>(pw + 1) * static_cast<double>(box_width) /
              static_cast<double>(pooled_width)));
-    hstart = min(max(hstart + box_start_h, 0), height);
-    hend = min(max(hend + box_start_h, 0), height);
-    wstart = min(max(wstart + box_start_w, 0), width);
-    wend = min(max(wend + box_start_w, 0), width);
+    hstart = min(max(hstart + box_start_h, static_cast<IndexType>(0)), height);
+    hend = min(max(hend + box_start_h, static_cast<IndexType>(0)), height);
+    wstart = min(max(wstart + box_start_w, static_cast<IndexType>(0)), width);
+    wend = min(max(wend + box_start_w, static_cast<IndexType>(0)), width);
     bool is_empty = (hend <= hstart) || (wend <= wstart);
 
     T maxval = is_empty ? 0 : -std::numeric_limits<T>::max();
@@ -85,7 +87,7 @@ __global__ void GPURoiPoolForward(const int nthreads,
         input_data + (box_batch_ind * channels + c) * height * width;
     for (int h = hstart; h < hend; ++h) {
       for (int w = wstart; w < wend; ++w) {
-        int input_data_index = h * width + w;
+        IndexType input_data_index = h * width + w;
         if (offset_input_data[input_data_index] > maxval) {
           maxval = offset_input_data[input_data_index];
           maxidx = input_data_index;
@@ -110,22 +112,22 @@ void RoiPoolKernel(const Context& dev_ctx,
                    DenseTensor* out,
                    DenseTensor* arg_max) {
   auto x_dims = x.dims();
-  int batch_size = x_dims[0];
+  int64_t batch_size = x_dims[0];
   auto in_stride = common::stride(x_dims);
-  int channels = x_dims[1];
-  int height = x_dims[2];
-  int width = x_dims[3];
+  int64_t channels = x_dims[1];
+  int64_t height = x_dims[2];
+  int64_t width = x_dims[3];
 
-  int rois_num = boxes.dims()[0];
+  int64_t rois_num = boxes.dims()[0];
 
   if (rois_num == 0) {
     dev_ctx.template Alloc<T>(out);
     return;
   }
 
-  int output_size = out->numel();
-  int blocks = NumBlocks(output_size);
-  int threads = kNumCUDAThreads;
+  int64_t output_size = out->numel();
+  uint32_t blocks = NumBlocks(output_size);
+  uint32_t threads = kNumCUDAThreads;
 
   DenseTensor box_batch_id_list;
   box_batch_id_list.Resize({rois_num});
@@ -201,7 +203,6 @@ void RoiPoolKernel(const Context& dev_ctx,
 
   T* output_data = dev_ctx.template Alloc<T>(out);
   int64_t* arg_max_data = dev_ctx.template Alloc<int64_t>(arg_max);
-
   GPURoiPoolForward<T>
       <<<blocks, threads, 0, dev_ctx.stream()>>>(output_size,
                                                  x.data<T>(),


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修复了由于int溢出引起的roi_pool前向和反向的非法访存的问题。该问题和https://github.com/PaddlePaddle/Paddle/pull/73638 非常相似。
修复方法是将可能发生int溢出的变量替换成int64，根据Tensor的规模选择GPU CUDA Kernel IndexType为int32还是int64。


### PaddleAPITest回测结果：
由于torch vision同样不支持大Tensor也会报CUDA Error 700。torch vision的实现：https://github.com/pytorch/vision/blob/0721867e42841171254c7acaa45fbaf8ee16d3d7/torchvision/csrc/ops/cuda/roi_pool_kernel.cu#L16-L79
因此测试在paddle_only模式下进行。
![image](https://github.com/user-attachments/assets/c70c4145-aff3-4330-92a8-a5288a911bcf)

pcard-67164

