### PR TITLE
[BIG tensor] fix segment fault in multi_dot

### DIFF
--- a/paddle/phi/kernels/impl/multi_dot_kernel_impl.h
+++ b/paddle/phi/kernels/impl/multi_dot_kernel_impl.h
@@ -128,7 +128,7 @@ std::vector<uint64_t> GetOrder(const std::vector<const DenseTensor*>& ins,
   for (uint64_t l = 1; l < n; l++) {
     for (uint64_t i = 0; i < n - l; i++) {
       auto j = i + l;
-      m[i * n + j] = 0xffffffff;
+      m[i * n + j] = std::numeric_limits<uint64_t>::max();
       for (uint64_t k = i; k < j; k++) {
         uint64_t q =
             m[i * n + k] + m[(k + 1) * n + j] + p[i] * p[k + 1] * p[j + 1];


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
 Execute Infrastructure 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes 

### Description
<!-- Describe what you’ve done -->
Pcard-67164
修复了因为大shape引起的段错误问题，发现是因为部分变量的上限设置有问题，导致进入了死循环函数调用。