### PR TITLE
[BIT] Add not support enforce for lu big tensor

### DIFF
--- a/paddle/phi/kernels/gpu/lu_kernel.cu
+++ b/paddle/phi/kernels/gpu/lu_kernel.cu
@@ -127,6 +127,19 @@ void LUKernel(const Context& dev_ctx,
               DenseTensor* out,
               DenseTensor* pivots,
               DenseTensor* infos) {
+  // big tensor currently not supported
+  PADDLE_ENFORCE_GE(x.dims().size(), 2);
+  int64_t largest_matrix = (1LL << 31) - 1;
+  int64_t last = x.dims()[x.dims().size() - 1],
+          second_last = x.dims()[x.dims().size() - 2];
+  int64_t matrix_size = last * second_last;
+  PADDLE_ENFORCE_LE(matrix_size,
+                    largest_matrix,
+                    ::common::errors::PreconditionNotMet(
+                        "Matrix size too large for LU decomposition. Maximum "
+                        "allowed size is 2 ^ 31 - 1 elements, but got %lld",
+                        matrix_size));
+
   const int64_t kMaxBlockDim = 512;
 
   *out = Transpose2DTo6D<Context, T>(dev_ctx, x);

--- a/paddle/phi/kernels/gpu/lu_kernel.cu
+++ b/paddle/phi/kernels/gpu/lu_kernel.cu
@@ -128,7 +128,11 @@ void LUKernel(const Context& dev_ctx,
               DenseTensor* pivots,
               DenseTensor* infos) {
   // big tensor currently not supported
-  PADDLE_ENFORCE_GE(x.dims().size(), 2);
+  PADDLE_ENFORCE_GE(
+      x.dims().size(),
+      2,
+      ::common::errors::PreconditionNotMet(
+          "Invalid input x dimensionality: %d (expected ≥2)", x.dims().size()));
   int64_t largest_matrix = (1LL << 31) - 1;
   int64_t last = x.dims()[x.dims().size() - 1],
           second_last = x.dims()[x.dims().size() - 2];


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Execute Infrastructure
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->


### PR Types
Improvements
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->


### Description
<!-- Describe what you’ve done -->
为 paddle.linalg.lu 添加显式不支持大 tensor 检查，目前的 paddle.linalg.lu 调用 cusolver 库 32 位表示矩阵大小的 api: cusolverDnSgetrf / cusolverDnDgetrf 有以下情况：
* 面对大 tensor （m * n > INT_MAX）出现 cuda error 700
* 稍小一点的 tensor （eg. 20000 * 20000）出现精度错误（~80% error），这一部分配置没有出现在 PaddleAPITest 中，由大 tensor 配置修改而来
* PaddleAPITest 下的小 tensor 配置和 batch 维度数值较大的小 tensor 配置通过

在[实验分支](https://github.com/Cutelemon6/Paddle/tree/debug_lu)下换用 cusolver 64 位表示矩阵大小的 api: cusolverDnXgetrf 后（[commit: f33fd4c](https://github.com/PaddlePaddle/Paddle/commit/f33fd4cf11cefaf091e5270e094e8d418136c7a4)），仍有以上的情况，故添加 PADDLE_ENFORCE_* 检查，显式不支持大 tensor。cusolverDnXgetrf 依赖 cuda toolkit >= 11.01。

torch 对应 api：torch.lu 使用 magma 线性代数库，与 paddle 不同（cusolver 线性代数库），面对大 tensor case 同样会出现 cuda error 700。