### PR TITLE
[BIG tensor] fix cuda 700 in margin_cross_entropy

### DIFF
--- a/paddle/phi/kernels/gpu/margin_cross_entropy_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/margin_cross_entropy_grad_kernel.cu
@@ -70,8 +70,8 @@ void MarginCrossEntropyGradKernel(const Context& dev_ctx,
                                   DenseTensor* logits_grad) {
   const auto softmax_dims = softmax.dims();
   const int axis = softmax_dims.size() - 1;
-  const int N = phi::funcs::SizeToAxis(axis, softmax_dims);
-  const int D = phi::funcs::SizeFromAxis(axis, softmax_dims);
+  const int64_t N = phi::funcs::SizeToAxis(axis, softmax_dims);
+  const int64_t D = phi::funcs::SizeFromAxis(axis, softmax_dims);
 
   if (return_softmax) {
     phi::Copy<Context>(

--- a/paddle/phi/kernels/gpu/margin_cross_entropy_kernel.cu
+++ b/paddle/phi/kernels/gpu/margin_cross_entropy_kernel.cu
@@ -27,10 +27,10 @@ __global__ void AddMarginToPositiveLogitsKernel(T* logit,
                                                 const int64_t D,
                                                 const int* class_interval_ptr) {
   using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
-  int start_index = class_interval_ptr[rank];
-  int end_index = class_interval_ptr[rank + 1];
+  int64_t start_index = class_interval_ptr[rank];
+  int64_t end_index = class_interval_ptr[rank + 1];
   int num_classes = class_interval_ptr[nranks];
-  CUDA_KERNEL_LOOP(i, N) {
+  CUDA_KERNEL_LOOP_TYPE(i, N, int64_t) {
     auto real_label = label[i];
     PADDLE_ENFORCE((real_label < num_classes) && (real_label >= 0),
                    "The index is out of bounds, "
@@ -158,8 +158,8 @@ void MarginCrossEntropyKernel(const Context& dev_ctx,
   const auto& labels_dims = labels.dims();
 
   const int axis = logits_dims.size() - 1;
-  const int N = phi::funcs::SizeToAxis(axis, logits_dims);
-  const int D = phi::funcs::SizeFromAxis(axis, logits_dims);
+  const int64_t N = phi::funcs::SizeToAxis(axis, logits_dims);
+  const int64_t D = phi::funcs::SizeFromAxis(axis, logits_dims);
 
   int blocks = NumBlocks(N);
   int threads = kNumCUDAThreads;

--- a/paddle/phi/kernels/impl/margin_cross_entropy.cu.h
+++ b/paddle/phi/kernels/impl/margin_cross_entropy.cu.h
@@ -46,11 +46,10 @@ namespace cub = hipcub;
 #include "paddle/phi/backends/gpu/gpu_context.h"
 
 namespace phi {
+static constexpr int64_t kNumCUDAThreads = 512;
+static constexpr int64_t kNumMaximumNumBlocks = 4096;
 
-static constexpr int kNumCUDAThreads = 512;
-static constexpr int kNumMaximumNumBlocks = 4096;
-
-static inline int NumBlocks(const int N) {
+static inline int NumBlocks(const int64_t N) {
   return std::min((N + kNumCUDAThreads - 1) / kNumCUDAThreads,
                   kNumMaximumNumBlocks);
 }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes 

### Description
<!-- Describe what you’ve done -->
Pcard-67164
修复了margin_cross_entropy遇到的cuda700,和溢出导致的精度问题