### PR TITLE
[BIG tensor] fix cuda 700 in poison_nll_loss

### DIFF
--- a/paddle/phi/kernels/gpu/elementwise_grad.h
+++ b/paddle/phi/kernels/gpu/elementwise_grad.h
@@ -255,6 +255,22 @@ static __global__ void SimpleElemwiseSubGradCUDAKernel(const T *dout,
 }
 
 template <typename T>
+static __global__ void SimpleElemwiseSubGradExCUDAKernel(const T *dout,
+                                                         int64_t size,
+                                                         T *dx,
+                                                         T *dy) {
+  int64_t col = static_cast<int64_t>(BLOCK_ID_X) * BLOCK_NUM_X + THREAD_ID_X;
+
+  while (col < size) {
+    if (dx != nullptr) {
+      dx[col] = dout[col];
+    }
+    dy[col] = -dout[col];
+    col += static_cast<int64_t>(BLOCK_NUM_X) * GRID_NUM_X;
+  }
+}
+
+template <typename T>
 void default_elementwise_sub_grad(const GPUContext &ctx,
                                   const DenseTensor &x,
                                   const DenseTensor &y,
@@ -319,11 +335,19 @@ void elementwise_sub_grad(const GPUContext &ctx,
   auto size = x.numel();
   dim3 grid_size =
       dim3((size + PREDEFINED_BLOCK_SIZE - 1) / PREDEFINED_BLOCK_SIZE, 1);
-  SimpleElemwiseSubGradCUDAKernel<T>
-      <<<grid_size, block_size, 0, ctx.stream()>>>(dout.data<T>(),
-                                                   size,
-                                                   ctx.template Alloc<T>(dx),
-                                                   ctx.template Alloc<T>(dy));
+  if (size > std::numeric_limits<int>::max()) {
+    SimpleElemwiseSubGradExCUDAKernel<T>
+        <<<grid_size, block_size, 0, ctx.stream()>>>(dout.data<T>(),
+                                                     size,
+                                                     ctx.template Alloc<T>(dx),
+                                                     ctx.template Alloc<T>(dy));
+  } else {
+    SimpleElemwiseSubGradCUDAKernel<T>
+        <<<grid_size, block_size, 0, ctx.stream()>>>(dout.data<T>(),
+                                                     size,
+                                                     ctx.template Alloc<T>(dx),
+                                                     ctx.template Alloc<T>(dy));
+  }
 }
 /*
 ******************************


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
 Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164
修复了poisson_nll_loss 大张量int溢出导致的cuda700问题