### PR TITLE
[0-size Tensor No.159、161、163] Add 0-size Tensor support for conv1d

### DIFF
--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/binary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/binary_infer_sym.cc
@@ -414,7 +414,11 @@ bool Conv2dOpInferSymbolicShape(pir::Operation *op,
   const symbol::ShapeOrDataDimExprs &shape_data = [&] {
     std::vector<symbol::DimExpr> out_s_or_d({in_s_or_d.shape()[0]});
     if (!channel_last) {
-      out_s_or_d.push_back(filter_s_or_d.shape()[0]);
+      if (filter_s_or_d.shape()[1] == 0) {
+        out_s_or_d.push_back(symbol::DimExpr{0});
+      } else {
+        out_s_or_d.push_back(filter_s_or_d.shape()[0]);
+      }
     }
 
     for (size_t i = 0; i < in_data_dims.size(); ++i) {
@@ -427,7 +431,11 @@ bool Conv2dOpInferSymbolicShape(pir::Operation *op,
       out_s_or_d.push_back(output_size);
     }
     if (channel_last) {
-      out_s_or_d.push_back(filter_s_or_d.shape()[0]);
+      if (filter_s_or_d.shape()[1] == 0) {
+        out_s_or_d.push_back(symbol::DimExpr{0});
+      } else {
+        out_s_or_d.push_back(filter_s_or_d.shape()[0]);
+      }
     }
 
     return symbol::ShapeOrDataDimExprs{

--- a/paddle/phi/kernels/gpu/depthwise_conv_kernel.cu
+++ b/paddle/phi/kernels/gpu/depthwise_conv_kernel.cu
@@ -17,6 +17,7 @@
 #include "paddle/phi/common/float16.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/cpu/conv_util.h"
+#include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/funcs/batch_norm_utils.h"
 #include "paddle/phi/kernels/gpu/depthwise_conv.h"
 
@@ -34,7 +35,8 @@ void DepthwiseConvKernel(const Context& dev_ctx,
                          const std::string& data_format,
                          DenseTensor* out) {
   if (input.numel() == 0) {
-    dev_ctx.template Alloc<T>(out);
+    phi::Full<T, Context>(
+        dev_ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
     return;
   }
   DenseTensor* output = out;

--- a/paddle/phi/kernels/gpu/depthwise_conv_kernel.cu
+++ b/paddle/phi/kernels/gpu/depthwise_conv_kernel.cu
@@ -33,6 +33,10 @@ void DepthwiseConvKernel(const Context& dev_ctx,
                          const std::vector<int>& dilations_t,
                          const std::string& data_format,
                          DenseTensor* out) {
+  if (input.numel() == 0) {
+    dev_ctx.template Alloc<T>(out);
+    return;
+  }
   DenseTensor* output = out;
   dev_ctx.template Alloc<T>(output);
 

--- a/paddle/phi/kernels/gpudnn/conv_kernel.cu
+++ b/paddle/phi/kernels/gpudnn/conv_kernel.cu
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 #include "paddle/phi/kernels/conv_kernel.h"
-#include "paddle/phi/kernels/gpudnn/conv_gpudnn.h"
-
 #include "glog/logging.h"
+#include "paddle/phi/kernels/full_kernel.h"
+#include "paddle/phi/kernels/gpudnn/conv_gpudnn.h"
 
 #include "paddle/phi/backends/context_pool.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
@@ -314,7 +314,8 @@ void ConvCudnnKernel(const Context& dev_ctx,
                      const std::string& data_format,
                      DenseTensor* output) {
   if (input.numel() == 0) {
-    dev_ctx.template Alloc<T>(output);
+    phi::Full<T, Context>(
+        dev_ctx, phi::IntArray(common::vectorize(output->dims())), 0, output);
     return;
   }
   dev_ctx.template Alloc<T>(output);

--- a/paddle/phi/kernels/gpudnn/conv_kernel.cu
+++ b/paddle/phi/kernels/gpudnn/conv_kernel.cu
@@ -313,6 +313,10 @@ void ConvCudnnKernel(const Context& dev_ctx,
                      int groups,
                      const std::string& data_format,
                      DenseTensor* output) {
+  if (input.numel() == 0) {
+    dev_ctx.template Alloc<T>(output);
+    return;
+  }
   dev_ctx.template Alloc<T>(output);
   std::vector<int> paddings = paddings_t;
   std::vector<int> dilations = dilations_t;

--- a/paddle/phi/kernels/impl/conv_kernel_impl.h
+++ b/paddle/phi/kernels/impl/conv_kernel_impl.h
@@ -38,6 +38,10 @@ void ConvKernelImpl(const Context& dev_ctx,
   std::vector<int> paddings = paddings_t;
   std::vector<int> dilations = dilations_t;
   DenseTensor filter = filter_t;
+  if (input.numel() == 0) {
+    dev_ctx.template Alloc<T>(output);
+    return;
+  }
   // The filter will be reshaped in the calculations,
   // so here use an assignment operation,
   // that avoids modifying the variable in the Scope.

--- a/paddle/phi/kernels/impl/conv_kernel_impl.h
+++ b/paddle/phi/kernels/impl/conv_kernel_impl.h
@@ -16,6 +16,7 @@
 
 #include "paddle/phi/kernels/conv_kernel.h"
 #include "paddle/phi/kernels/cpu/conv_util.h"
+#include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/funcs/batch_norm_utils.h"
 #include "paddle/phi/kernels/funcs/blas/blas.h"
 #include "paddle/phi/kernels/funcs/im2col.h"
@@ -39,7 +40,8 @@ void ConvKernelImpl(const Context& dev_ctx,
   std::vector<int> dilations = dilations_t;
   DenseTensor filter = filter_t;
   if (input.numel() == 0) {
-    dev_ctx.template Alloc<T>(output);
+    phi::Full<T, Context>(
+        dev_ctx, phi::IntArray(common::vectorize(output->dims())), 0, output);
     return;
   }
   // The filter will be reshaped in the calculations,

--- a/paddle/phi/kernels/xpu/conv_kernel.cc
+++ b/paddle/phi/kernels/xpu/conv_kernel.cc
@@ -17,6 +17,7 @@
 #include "paddle/phi/backends/xpu/enforce_xpu.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/cpu/conv_util.h"
+#include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/xpu/conv_utils_xpu.h"
 #include "paddle/phi/kernels/xpu/xpu_api_wrapper.h"
 #ifdef PADDLE_WITH_XPU_XRE5
@@ -38,7 +39,8 @@ void ConvKernel(const Context& dev_ctx,
                 const std::string& data_format,
                 DenseTensor* out) {
   if (input.numel() == 0) {
-    dev_ctx.template Alloc<T>(out);
+    phi::Full<T, Context>(
+        dev_ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
     return;
   }
   using XPUType = typename XPUTypeTrait<T>::Type;

--- a/paddle/phi/kernels/xpu/conv_kernel.cc
+++ b/paddle/phi/kernels/xpu/conv_kernel.cc
@@ -37,6 +37,10 @@ void ConvKernel(const Context& dev_ctx,
                 int groups,
                 const std::string& data_format,
                 DenseTensor* out) {
+  if (input.numel() == 0) {
+    dev_ctx.template Alloc<T>(out);
+    return;
+  }
   using XPUType = typename XPUTypeTrait<T>::Type;
   std::vector<int64_t> paddings(paddings_t.begin(), paddings_t.end());
   std::vector<int64_t> dilations(dilations_t.begin(), dilations_t.end());

--- a/test/legacy_test/test_functional_conv1d.py
+++ b/test/legacy_test/test_functional_conv1d.py
@@ -102,7 +102,7 @@ class TestFunctionalConv1D_ZeroSize(TestCase):
     def init_data(self):
         self.input = np.random.randn(0, 1, 2)
         self.filter = np.random.randn(1, 1, 2)
-        self.np_out = np.random.random([0, 1, 1])
+        self.np_out = np.zeros([0, 1, 1])
 
     def setUp(self):
         self.init_data()
@@ -150,7 +150,7 @@ class TestFunctionalConv1D_ZeroSize2(TestFunctionalConv1D_ZeroSize):
     def init_data(self):
         self.input = np.random.randn(0, 0, 2)
         self.filter = np.random.randn(1, 0, 2)
-        self.np_out = np.random.random([0, 0, 1])
+        self.np_out = np.zeros([0, 0, 1])
 
 
 if __name__ == "__main__":

--- a/test/legacy_test/test_functional_conv1d.py
+++ b/test/legacy_test/test_functional_conv1d.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import unittest
 from unittest import TestCase
 
@@ -20,6 +21,7 @@ import numpy as np
 import paddle
 import paddle.base.dygraph as dg
 import paddle.nn.functional as F
+from paddle import base
 
 
 class TestFunctionalConv1DError(TestCase):
@@ -70,18 +72,6 @@ class TestFunctionalConv1DErrorCase1(TestFunctionalConv1DError):
         self.data_format = "NCL"
 
 
-class TestFunctionalConv1DErrorCase2(TestFunctionalConv1DError):
-    def setUp(self):
-        self.input = np.random.randn(0, 0, 0)
-        self.filter = np.random.randn(1, 0, 0)
-        self.bias = None
-        self.padding = 0
-        self.stride = 1
-        self.dilation = 1
-        self.groups = 1
-        self.data_format = "NCL"
-
-
 class TestFunctionalConv1D_CPU_FP16(TestCase):
     def setUp(self):
         self.padding = 0
@@ -106,6 +96,61 @@ class TestFunctionalConv1D_CPU_FP16(TestCase):
                 data_format=self.data_format,
             )
             np.testing.assert_allclose(y.numpy(), [[[2]]])
+
+
+class TestFunctionalConv1D_ZeroSize(TestCase):
+    def init_data(self):
+        self.input = np.random.randn(0, 1, 2)
+        self.filter = np.random.randn(1, 1, 2)
+        self.np_out = np.random.random([0, 1, 1])
+
+    def setUp(self):
+        self.init_data()
+        self.bias = None
+        self.padding = 0
+        self.stride = 1
+        self.dilation = 1
+        self.groups = 1
+        self.data_format = "NCL"
+        self.places = []
+        if (
+            os.environ.get('FLAGS_CI_both_cpu_and_gpu', 'False').lower()
+            in ['1', 'true', 'on']
+            or not base.core.is_compiled_with_cuda()
+        ):
+            self.places.append(base.CPUPlace())
+        if base.core.is_compiled_with_cuda():
+            self.places.append(base.CUDAPlace(0))
+
+    def test_dygraph(self):
+        for place in self.places:
+            with dg.guard(place):
+                input = paddle.to_tensor(self.input)
+                input.stop_gradient = False
+                filter = paddle.to_tensor(self.filter)
+                filter.stop_gradient = False
+                y = F.conv1d(
+                    input,
+                    filter,
+                    self.bias,
+                    padding=self.padding,
+                    stride=self.stride,
+                    dilation=self.dilation,
+                    groups=self.groups,
+                    data_format=self.data_format,
+                )
+                np.testing.assert_allclose(y.numpy(), self.np_out)
+                loss = y.sum()
+                loss.backward()
+                np.testing.assert_allclose(input.grad.shape, input.shape)
+                np.testing.assert_allclose(filter.grad, np.zeros(filter.shape))
+
+
+class TestFunctionalConv1D_ZeroSize2(TestFunctionalConv1D_ZeroSize):
+    def init_data(self):
+        self.input = np.random.randn(0, 0, 2)
+        self.filter = np.random.randn(1, 0, 2)
+        self.np_out = np.random.random([0, 0, 1])
 
 
 if __name__ == "__main__":

--- a/test/legacy_test/test_functional_conv2d.py
+++ b/test/legacy_test/test_functional_conv2d.py
@@ -287,7 +287,7 @@ class TestFunctionalConv2D_ZeroSize(TestCase):
     def init_data(self):
         self.input = np.random.random([0, 3, 4, 4])
         self.filter = np.random.random([2, 3, 3, 3])
-        self.np_out = np.random.random([0, 2, 2, 2])
+        self.np_out = np.zeros([0, 2, 2, 2])
 
     def setUp(self):
         self.init_data()
@@ -333,7 +333,7 @@ class TestFunctionalConv2D_ZeroSize2(TestFunctionalConv2D_ZeroSize):
     def init_data(self):
         self.input = np.random.random([0, 0, 4, 4])
         self.filter = np.random.random([2, 0, 3, 3])
-        self.np_out = np.random.random([0, 0, 2, 2])
+        self.np_out = np.zeros([0, 0, 2, 2])
 
 
 if __name__ == "__main__":

--- a/test/legacy_test/test_functional_conv2d.py
+++ b/test/legacy_test/test_functional_conv2d.py
@@ -219,15 +219,15 @@ class TestFunctionalConv2DErrorCase11(TestFunctionalConv2DError):
 
 class TestFunctionalConv2DErrorCase12(TestCase):
     def setUp(self):
-        self.input = np.array([])
-        self.filter = np.array([])
-        self.num_filters = 0
-        self.filter_size = 0
+        self.input = np.random.randn(1, 3, 3, 3)
+        self.filter = np.random.randn(3, 3, 1, 1)
+        self.num_filters = 3
+        self.filter_size = 1
         self.bias = None
         self.padding = 0
         self.stride = 1
         self.dilation = 1
-        self.groups = 1
+        self.groups = 0
         self.data_format = "NCHW"
 
     def dygraph_case(self):
@@ -253,34 +253,6 @@ class TestFunctionalConv2DErrorCase12(TestCase):
     def test_dygraph_exception(self):
         with self.assertRaises(ValueError):
             self.dygraph_case()
-
-
-class TestFunctionalConv2DErrorCase13(TestFunctionalConv2DErrorCase12):
-    def setUp(self):
-        self.input = np.random.randn(1, 3, 3, 3)
-        self.filter = np.random.randn(3, 3, 1, 1)
-        self.num_filters = 3
-        self.filter_size = 1
-        self.bias = None
-        self.padding = 0
-        self.stride = 1
-        self.dilation = 1
-        self.groups = 0
-        self.data_format = "NCHW"
-
-
-class TestFunctionalConv2DErrorCase14(TestFunctionalConv2DErrorCase12):
-    def setUp(self):
-        self.input = np.random.randn(0, 0, 0, 0)
-        self.filter = np.random.randn(1, 0, 0, 0)
-        self.num_filters = 0
-        self.filter_size = 0
-        self.bias = None
-        self.padding = 0
-        self.stride = 1
-        self.dilation = 1
-        self.groups = 1
-        self.data_format = "NCHW"
 
 
 class TestFunctionalConv2D_ZeroSize(TestCase):

--- a/test/legacy_test/test_functional_conv2d.py
+++ b/test/legacy_test/test_functional_conv2d.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import unittest
 from unittest import TestCase
 
@@ -280,6 +281,59 @@ class TestFunctionalConv2DErrorCase14(TestFunctionalConv2DErrorCase12):
         self.dilation = 1
         self.groups = 1
         self.data_format = "NCHW"
+
+
+class TestFunctionalConv2D_ZeroSize(TestCase):
+    def init_data(self):
+        self.input = np.random.random([0, 3, 4, 4])
+        self.filter = np.random.random([2, 3, 3, 3])
+        self.np_out = np.random.random([0, 2, 2, 2])
+
+    def setUp(self):
+        self.init_data()
+        self.bias = None
+        self.padding = 0
+        self.stride = 1
+        self.dilation = 1
+        self.groups = 1
+        self.data_format = "NCHW"
+        self.places = []
+        if (
+            os.environ.get('FLAGS_CI_both_cpu_and_gpu', 'False').lower()
+            in ['1', 'true', 'on']
+            or not base.core.is_compiled_with_cuda()
+        ):
+            self.places.append(base.CPUPlace())
+        if base.core.is_compiled_with_cuda():
+            self.places.append(base.CUDAPlace(0))
+
+    def test_dygraph(self):
+        for place in self.places:
+            with dg.guard(place):
+                input = paddle.to_tensor(self.input)
+                input.stop_gradient = False
+                filter = paddle.to_tensor(self.filter)
+                y = F.conv2d(
+                    input,
+                    filter,
+                    self.bias,
+                    padding=self.padding,
+                    stride=self.stride,
+                    dilation=self.dilation,
+                    groups=self.groups,
+                    data_format=self.data_format,
+                )
+                np.testing.assert_allclose(y.numpy(), self.np_out)
+                loss = y.sum()
+                loss.backward()
+                np.testing.assert_allclose(input.grad.shape, input.shape)
+
+
+class TestFunctionalConv2D_ZeroSize2(TestFunctionalConv2D_ZeroSize):
+    def init_data(self):
+        self.input = np.random.random([0, 0, 4, 4])
+        self.filter = np.random.random([2, 0, 3, 3])
+        self.np_out = np.random.random([0, 0, 2, 2])
 
 
 if __name__ == "__main__":

--- a/test/legacy_test/test_functional_conv3d.py
+++ b/test/legacy_test/test_functional_conv3d.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import unittest
 from unittest import TestCase
 
@@ -261,6 +262,59 @@ class TestFunctionalConv3DErrorCase13(TestFunctionalConv3DErrorCase11):
         self.dilation = 1
         self.groups = 1
         self.data_format = "NCDHW"
+
+
+class TestFunctionalConv3D_ZeroSize(TestCase):
+    def init_data(self):
+        self.input = np.random.random([4, 3, 0, 8, 8])
+        self.filter = np.random.random([5, 3, 3, 3, 3])
+        self.np_out = np.random.random([4, 5, 0, 8, 8])
+
+    def setUp(self):
+        self.init_data()
+        self.bias = None
+        self.padding = 1
+        self.stride = 1
+        self.dilation = 1
+        self.groups = 1
+        self.data_format = "NCDHW"
+        self.places = []
+        if (
+            os.environ.get('FLAGS_CI_both_cpu_and_gpu', 'False').lower()
+            in ['1', 'true', 'on']
+            or not base.core.is_compiled_with_cuda()
+        ):
+            self.places.append(base.CPUPlace())
+        if base.core.is_compiled_with_cuda():
+            self.places.append(base.CUDAPlace(0))
+
+    def test_dygraph(self):
+        for place in self.places:
+            with dg.guard(place):
+                input = paddle.to_tensor(self.input)
+                input.stop_gradient = False
+                filter = paddle.to_tensor(self.filter)
+                y = F.conv3d(
+                    input,
+                    filter,
+                    self.bias,
+                    padding=self.padding,
+                    stride=self.stride,
+                    dilation=self.dilation,
+                    groups=self.groups,
+                    data_format=self.data_format,
+                )
+                np.testing.assert_allclose(y.numpy(), self.np_out)
+                loss = y.sum()
+                loss.backward()
+                np.testing.assert_allclose(input.grad.shape, input.shape)
+
+
+class TestFunctionalConv3D_ZeroSize2(TestFunctionalConv3D_ZeroSize):
+    def init_data(self):
+        self.input = np.random.random([4, 0, 0, 8, 8])
+        self.filter = np.random.random([5, 0, 3, 3, 3])
+        self.np_out = np.random.random([4, 0, 0, 8, 8])
 
 
 if __name__ == "__main__":

--- a/test/legacy_test/test_functional_conv3d.py
+++ b/test/legacy_test/test_functional_conv3d.py
@@ -200,15 +200,15 @@ class TestFunctionalConv3DErrorCase10(TestFunctionalConv3DError):
 
 class TestFunctionalConv3DErrorCase11(TestCase):
     def setUp(self):
-        self.input = np.array([])
-        self.filter = np.array([])
-        self.num_filters = 0
-        self.filter_size = 0
+        self.input = np.random.randn(1, 3, 3, 3, 3)
+        self.filter = np.random.randn(3, 3, 1, 1, 1)
+        self.num_filters = 3
+        self.filter_size = 1
         self.bias = None
         self.padding = 0
         self.stride = 1
         self.dilation = 1
-        self.groups = 1
+        self.groups = 0
         self.data_format = "NCDHW"
 
     def dygraph_case(self):
@@ -234,34 +234,6 @@ class TestFunctionalConv3DErrorCase11(TestCase):
     def test_dygraph_exception(self):
         with self.assertRaises(ValueError):
             self.dygraph_case()
-
-
-class TestFunctionalConv3DErrorCase12(TestFunctionalConv3DErrorCase11):
-    def setUp(self):
-        self.input = np.random.randn(1, 3, 3, 3, 3)
-        self.filter = np.random.randn(3, 3, 1, 1, 1)
-        self.num_filters = 3
-        self.filter_size = 1
-        self.bias = None
-        self.padding = 0
-        self.stride = 1
-        self.dilation = 1
-        self.groups = 0
-        self.data_format = "NCDHW"
-
-
-class TestFunctionalConv3DErrorCase13(TestFunctionalConv3DErrorCase11):
-    def setUp(self):
-        self.input = np.random.randn(0, 0, 0, 0, 0)
-        self.filter = np.random.randn(1, 0, 0, 0, 0)
-        self.num_filters = 1
-        self.filter_size = 1
-        self.bias = None
-        self.padding = 0
-        self.stride = 1
-        self.dilation = 1
-        self.groups = 1
-        self.data_format = "NCDHW"
 
 
 class TestFunctionalConv3D_ZeroSize(TestCase):

--- a/test/legacy_test/test_functional_conv3d.py
+++ b/test/legacy_test/test_functional_conv3d.py
@@ -268,7 +268,7 @@ class TestFunctionalConv3D_ZeroSize(TestCase):
     def init_data(self):
         self.input = np.random.random([4, 3, 0, 8, 8])
         self.filter = np.random.random([5, 3, 3, 3, 3])
-        self.np_out = np.random.random([4, 5, 0, 8, 8])
+        self.np_out = np.zeros([4, 5, 0, 8, 8])
 
     def setUp(self):
         self.init_data()
@@ -314,7 +314,7 @@ class TestFunctionalConv3D_ZeroSize2(TestFunctionalConv3D_ZeroSize):
     def init_data(self):
         self.input = np.random.random([4, 0, 0, 8, 8])
         self.filter = np.random.random([5, 0, 3, 3, 3])
-        self.np_out = np.random.random([4, 0, 0, 8, 8])
+        self.np_out = np.zeros([4, 0, 0, 8, 8])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
paddle.nn.functional.conv1d
paddle.nn.functional.conv2d
paddle.nn.functional.conv3d

Infermeta 去掉维度为0检查，如果filter_dims[1] 为0，结果对应维度设置为0，原有代码是设置filter_dims[0]，符号推导同样修改。
修改kernel，只用判断input 维度为0
torch不支持单独filter设置为0维度
![image](https://github.com/user-attachments/assets/28b41dfa-bf32-4f2a-9adb-82300b3f8531)

kernel 使用到depthwise_conv 和 conv kernel， 修改 depthwise_conv 和 conv kernel

正向测试返回填充为0，需要修改tester/accuracy.py输出结果， PaddleAPITest 对输入增加了pad
```
python engine.py --accuracy=True --api_config='paddle.nn.functional.conv3d(Tensor([4, 3, 8, 0, 8],"float32"), Tensor([5, 3, 3, 3, 3],"float32"), None, padding=list[list[0,0,],list[0,0,],list[1,1,],list[2,2,],list[2,2,],], stride=1, dilation=1, groups=1, data_format="NCDHW", )'
```
反向测试filter为填充0
```
import torch
x=torch.randn([0,1,1])
y=torch.randn([1,1,1])
x.requires_grad=True
y.requires_grad=True
z=torch.nn.functional.conv1d(x, y, groups=1)
z.sum().backward()
y.grad

tensor([[[0.]]])
```
PaddleAPITest 测试
GPU测试为torch error
![image](https://github.com/user-attachments/assets/78155021-ba4d-463d-ab01-a0f6e421587b)
![image](https://github.com/user-attachments/assets/7d61a3db-8954-440b-a7c4-e2dc556461fc)

CPU测试为torch error
![image](https://github.com/user-attachments/assets/2dd84f39-88aa-4884-bcb5-453045352840)
![image](https://github.com/user-attachments/assets/49d1b163-9d87-444c-9f8c-2c745327d413)
