### PR TITLE
[0-size Tensor No.160、162、164] Add 0-size Tensor support for conv1d_transpose

### DIFF
--- a/paddle/phi/infermeta/binary.cc
+++ b/paddle/phi/infermeta/binary.cc
@@ -888,19 +888,23 @@ void ConvTransposeInferMeta(const MetaTensor& x,
                 common::make_ddim(output_size).to_str(),
                 i,
                 infer_shape));
-        PADDLE_ENFORCE_LT(
-            output_size[i],
-            infer_shape + strides[i],
-            errors::InvalidArgument(
-                "output_size of Op(ConvTransposeOp) should be less "
-                "than inferred size + stride. But received output_size = [%s], "
-                "whose dim %d is not less than the inferred output size (%d) + "
-                "stride (%d) = %d",
-                common::make_ddim(output_size).to_str(),
-                i,
-                infer_shape,
-                strides[i],
-                infer_shape + strides[i]));
+        if (common::product(x_dims) != 0) {
+          PADDLE_ENFORCE_LT(
+              output_size[i],
+              infer_shape + strides[i],
+              errors::InvalidArgument(
+                  "output_size of Op(ConvTransposeOp) should be less "
+                  "than inferred size + stride. But received output_size = "
+                  "[%s], "
+                  "whose dim %d is not less than the inferred output size (%d) "
+                  "+ "
+                  "stride (%d) = %d",
+                  common::make_ddim(output_size).to_str(),
+                  i,
+                  infer_shape,
+                  strides[i],
+                  infer_shape + strides[i]));
+        }
       }
       output_shape.push_back(output_size[i]);
     } else if (!output_padding.empty()) {

--- a/paddle/phi/kernels/gpu/conv_transpose_kernel.cu
+++ b/paddle/phi/kernels/gpu/conv_transpose_kernel.cu
@@ -37,6 +37,11 @@ void DepthwiseConv2dTransposeKernel(const Context& dev_ctx,
                                     const std::vector<int>& dilations,
                                     const std::string& data_format,
                                     DenseTensor* out) {
+  if (x.numel() == 0 || filter.numel() == 0) {
+    phi::Full<T, Context>(
+        dev_ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
+    return;
+  }
   const DataLayout data_layout = common::StringToDataLayout(data_format);
   DenseTensor filter_ = filter;
   dev_ctx.template Alloc<T>(out);

--- a/paddle/phi/kernels/gpudnn/conv_transpose_grad_kernel.cu
+++ b/paddle/phi/kernels/gpudnn/conv_transpose_grad_kernel.cu
@@ -37,6 +37,7 @@ limitations under the License. */
 #include "paddle/phi/backends/gpu/cuda/cudnn_workspace_helper.h"
 #include "paddle/phi/kernels/gpudnn/conv_cudnn_v7.h"
 #endif
+#include "paddle/phi/kernels/full_kernel.h"
 
 namespace phi {
 
@@ -55,6 +56,26 @@ void ConvTransposeGradRawGPUDNNKernel(const Context& dev_ctx,
                                       const std::string& data_format,
                                       DenseTensor* dx,
                                       DenseTensor* dfilter) {
+  // 0-size
+  if (x.numel() == 0) {
+    if (dx) dev_ctx.template Alloc<T>(dx);
+    if (dfilter) {
+      phi::Full<T, Context>(dev_ctx,
+                            phi::IntArray(common::vectorize(dfilter->dims())),
+                            0,
+                            dfilter);
+    }
+    return;
+  }
+  if (filter.numel() == 0) {
+    if (dfilter) dev_ctx.template Alloc<T>(dfilter);
+    if (dx) {
+      phi::Full<T, Context>(
+          dev_ctx, phi::IntArray(common::vectorize(dx->dims())), 0, dx);
+    }
+    return;
+  }
+
   const T* filter_data = filter.data<T>();
   std::vector<int> paddings_ = paddings;
   std::vector<int> dilations_ =

--- a/paddle/phi/kernels/gpudnn/conv_transpose_kernel.cu
+++ b/paddle/phi/kernels/gpudnn/conv_transpose_kernel.cu
@@ -35,6 +35,7 @@ limitations under the License. */
 #include "paddle/phi/backends/gpu/cuda/cudnn_workspace_helper.h"
 #include "paddle/phi/kernels/gpudnn/conv_cudnn_v7.h"
 #endif
+#include "paddle/phi/kernels/full_kernel.h"
 
 namespace phi {
 
@@ -51,6 +52,11 @@ void ConvTransposeRawGPUDNNKernel(const Context& dev_ctx,
                                   const std::vector<int>& dilations,
                                   const std::string& data_format,
                                   DenseTensor* out) {
+  if (x.numel() == 0 || filter.numel() == 0) {
+    phi::Full<T, Context>(
+        dev_ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
+    return;
+  }
   std::vector<int> paddings_ = paddings;
   std::vector<int> dilations_ =
       dilations;  // cudnn v5 does not support dilations

--- a/paddle/phi/kernels/impl/conv_transpose_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/conv_transpose_grad_kernel_impl.h
@@ -18,6 +18,7 @@
 #include "paddle/common/layout.h"
 #include "paddle/phi/kernels/conv_transpose_grad_kernel.h"
 #include "paddle/phi/kernels/cpu/conv_util.h"
+#include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/funcs/blas/blas.h"
 #include "paddle/phi/kernels/funcs/concat_and_split_functor.h"
 #include "paddle/phi/kernels/funcs/im2col.h"
@@ -45,6 +46,26 @@ void ConvTransposeGradRawKernel(const Context& dev_ctx,
   DenseTensor filter_ = filter;
 
   if ((!dx) && (!dfilter)) {
+    return;
+  }
+
+  // 0-size
+  if (x.numel() == 0) {
+    if (dx) dev_ctx.template Alloc<T>(dx);
+    if (dfilter) {
+      phi::Full<T, Context>(dev_ctx,
+                            phi::IntArray(common::vectorize(dfilter->dims())),
+                            0,
+                            dfilter);
+    }
+    return;
+  }
+  if (filter.numel() == 0) {
+    if (dfilter) dev_ctx.template Alloc<T>(dfilter);
+    if (dx) {
+      phi::Full<T, Context>(
+          dev_ctx, phi::IntArray(common::vectorize(dx->dims())), 0, dx);
+    }
     return;
   }
 

--- a/paddle/phi/kernels/impl/conv_transpose_kernel_impl.h
+++ b/paddle/phi/kernels/impl/conv_transpose_kernel_impl.h
@@ -18,6 +18,7 @@
 #include "paddle/common/layout.h"
 #include "paddle/phi/kernels/conv_transpose_kernel.h"
 #include "paddle/phi/kernels/cpu/conv_util.h"
+#include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/funcs/blas/blas.h"
 #include "paddle/phi/kernels/funcs/concat_and_split_functor.h"
 #include "paddle/phi/kernels/funcs/im2col.h"
@@ -37,6 +38,11 @@ void ConvTransposeRawKernel(const Context& dev_ctx,
                             const std::vector<int>& dilations,
                             const std::string& data_format,
                             DenseTensor* out) {
+  if (x.numel() == 0 || filter.numel() == 0) {
+    phi::Full<T, Context>(
+        dev_ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
+    return;
+  }
   const DataLayout data_layout = common::StringToDataLayout(data_format);
   // The filter will be reshaped, so it should not be constant
   DenseTensor filter_ = filter;

--- a/paddle/phi/kernels/xpu/conv_transpose_kernel.cc
+++ b/paddle/phi/kernels/xpu/conv_transpose_kernel.cc
@@ -19,6 +19,7 @@
 #include "paddle/phi/backends/xpu/enforce_xpu.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/cpu/conv_util.h"
+#include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/xpu/conv_utils_xpu.h"
 #include "paddle/phi/kernels/xpu/xpu_api_wrapper.h"
 #ifdef PADDLE_WITH_XPU_XRE5
@@ -41,7 +42,11 @@ void Conv2dTransposeKernel(const Context& dev_ctx,
                            const std::string& data_format,
                            DenseTensor* out) {
   using XPUType = typename XPUTypeTrait<T>::Type;
-
+  if (x.numel() == 0 || filter.numel() == 0) {
+    phi::Full<T, Context>(
+        dev_ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
+    return;
+  }
   dev_ctx.template Alloc<T>(out);
 
   PADDLE_ENFORCE_EQ(

--- a/test/legacy_test/test_functional_conv1d_transpose.py
+++ b/test/legacy_test/test_functional_conv1d_transpose.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import unittest
 from unittest import TestCase
 
@@ -20,6 +21,7 @@ import numpy as np
 import paddle
 import paddle.base.dygraph as dg
 import paddle.nn.functional as F
+from paddle import base
 
 
 class TestFunctionalConv1DError(TestCase):
@@ -30,7 +32,7 @@ class TestFunctionalConv1DError(TestCase):
         self.padding = 0
         self.stride = 1
         self.dilation = 1
-        self.groups = 1
+        self.groups = 0
         self.data_format = "NCL"
 
     def dygraph_case(self):
@@ -82,16 +84,61 @@ class TestFunctionalConv1DErrorCase2(TestFunctionalConv1DError):
         self.data_format = "NCL"
 
 
-class TestFunctionalConv1DErrorCase3(TestFunctionalConv1DError):
+class TestFunctionalConv1DTranspose_ZeroSize(TestCase):
+    def init_data(self):
+        self.input = np.random.randn(0, 1, 2)
+        self.filter = np.random.randn(1, 1, 2)
+        self.np_out = np.zeros([0, 1, 3])
+
     def setUp(self):
-        self.input = np.random.randn(6, 0, 6)
-        self.filter = np.random.randn(6, 0, 0)
+        self.init_data()
         self.bias = None
         self.padding = 0
         self.stride = 1
         self.dilation = 1
         self.groups = 1
         self.data_format = "NCL"
+        self.places = []
+        if (
+            os.environ.get('FLAGS_CI_both_cpu_and_gpu', 'False').lower()
+            in ['1', 'true', 'on']
+            or not base.core.is_compiled_with_cuda()
+        ):
+            self.places.append(base.CPUPlace())
+        if base.core.is_compiled_with_cuda():
+            self.places.append(base.CUDAPlace(0))
+
+    def test_dygraph(self):
+        for place in self.places:
+            with dg.guard(place):
+                input = paddle.to_tensor(self.input)
+                input.stop_gradient = False
+                filter = paddle.to_tensor(self.filter)
+                filter.stop_gradient = False
+                y = F.conv1d_transpose(
+                    input,
+                    filter,
+                    self.bias,
+                    padding=self.padding,
+                    stride=self.stride,
+                    dilation=self.dilation,
+                    groups=self.groups,
+                    data_format=self.data_format,
+                )
+                np.testing.assert_allclose(y.numpy(), self.np_out)
+                loss = y.sum()
+                loss.backward()
+                np.testing.assert_allclose(input.grad.shape, input.shape)
+                np.testing.assert_allclose(filter.grad, np.zeros(filter.shape))
+
+
+class TestFunctionalConv1DTranspose_ZeroSize2(
+    TestFunctionalConv1DTranspose_ZeroSize
+):
+    def init_data(self):
+        self.input = np.random.randn(2, 3, 2)
+        self.filter = np.random.randn(3, 0, 3)
+        self.np_out = np.zeros([2, 0, 4])
 
 
 if __name__ == "__main__":

--- a/test/legacy_test/test_functional_conv3d_transpose.py
+++ b/test/legacy_test/test_functional_conv3d_transpose.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import unittest
 from unittest import TestCase
 
@@ -223,7 +224,7 @@ class TestFunctionalConv3DTransposeErrorCase10(TestCase):
         self.padding = 0
         self.stride = 1
         self.dilation = 1
-        self.groups = 1
+        self.groups = 0
         self.data_format = "NCDHW"
 
     def dygraph_case(self):
@@ -265,6 +266,63 @@ class TestFunctionalConv3DTransposeErrorCase11(
         self.dilation = 1
         self.groups = 0
         self.data_format = "NCDHW"
+
+
+class TestFunctionalConv3DTranspose_ZeroSize(TestCase):
+    def init_data(self):
+        self.input = np.random.randn(0, 2, 2, 2, 3)
+        self.filter = np.random.randn(2, 1, 3, 3, 3)
+        self.np_out = np.zeros([0, 1, 4, 4, 5])
+
+    def setUp(self):
+        self.init_data()
+        self.bias = None
+        self.padding = 0
+        self.stride = 1
+        self.dilation = 1
+        self.groups = 1
+        self.data_format = "NCDHW"
+        self.places = []
+        if (
+            os.environ.get('FLAGS_CI_both_cpu_and_gpu', 'False').lower()
+            in ['1', 'true', 'on']
+            or not base.core.is_compiled_with_cuda()
+        ):
+            self.places.append(base.CPUPlace())
+        if base.core.is_compiled_with_cuda():
+            self.places.append(base.CUDAPlace(0))
+
+    def test_dygraph(self):
+        for place in self.places:
+            with dg.guard(place):
+                input = paddle.to_tensor(self.input)
+                input.stop_gradient = False
+                filter = paddle.to_tensor(self.filter)
+                filter.stop_gradient = False
+                y = F.conv3d_transpose(
+                    input,
+                    filter,
+                    self.bias,
+                    padding=self.padding,
+                    stride=self.stride,
+                    dilation=self.dilation,
+                    groups=self.groups,
+                    data_format=self.data_format,
+                )
+                np.testing.assert_allclose(y.numpy(), self.np_out)
+                loss = y.sum()
+                loss.backward()
+                np.testing.assert_allclose(input.grad.shape, input.shape)
+                np.testing.assert_allclose(filter.grad, np.zeros(filter.shape))
+
+
+class TestFunctionalConv3DTranspose_ZeroSize2(
+    TestFunctionalConv3DTranspose_ZeroSize
+):
+    def init_data(self):
+        self.input = np.random.randn(2, 3, 1, 1, 1)
+        self.filter = np.random.randn(3, 0, 3, 3, 3)
+        self.np_out = np.zeros([2, 0, 3, 3, 3])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->
[0-size Tensor No.160、162、164] Add 0-size Tensor support for conv1d_transpose

paddle.nn.functional.conv1d_transpose
paddle.nn.functional.conv2d_transpose
paddle.nn.functional.conv3d_transpose

修改 infermeta ，如果维度为0，不检查output_size 和 infer_shape 比较
符号推导没有对应代码
https://github.com/PaddlePaddle/Paddle/blob/3ad243cee3fc076300af25b9c806c47a09d7aa5c/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/binary_infer_sym.cc#L447

kernel 使用到depthwise_conv 和 conv kernel， 修改 depthwise_conv 和 conv kernel
正向测试返回填充时torch为错误，这里按0填充
```
python engine.py --accuracy=True --api_config='paddle.nn.functional.conv3d(Tensor([2, 1, 1, 1, 1],"float32"
), Tensor([3, 1, 3, 3, 0],"float32"), None, padding=1, stride=1, dilation=1, groups=1, data_format="NCDHW", )'
```
反向测试filter为填充0
```
import torch
x=torch.randn([0,1,1])
y=torch.randn([1,1,1])
x.requires_grad=True
y.requires_grad=True
z=torch.nn.functional.conv_transpose1d(x, y, groups=1)
z.sum().backward()
y.grad

tensor([[[0.]]])
```

PaddleAPITest 测试
GPU测试为torch error
![image](https://github.com/user-attachments/assets/42a400ea-816e-459e-9d12-0a863566c3af)
![image](https://github.com/user-attachments/assets/1835a624-ad45-48e9-8c69-92b40188f58d)
![image](https://github.com/user-attachments/assets/9bdcf73b-335a-422a-bc1b-c34c8df447ac)

CPU测试为torch error
![image](https://github.com/user-attachments/assets/0dae4729-c217-4ef7-b91c-553b97e8d837)
