### PR TITLE
[SOT] Open strict mode when handle `SotCapturedException`

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/executor_cache.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/executor_cache.py
@@ -456,9 +456,8 @@ def start_translate(
             "Note: This fallback may be triggered by user code, or it could result from an internal "
             "SOT exception being incorrectly captured. Please investigate carefully.\n",
         )
-        # TODO(DrRyanHuang): Consider whether an exception should be raised here in the future
-        # if is_strict_mode():
-        #     raise
+        if is_strict_mode():
+            raise
         dummy_guard_chain: GuardChain = [paddle.framework.core.DummyGuardNode()]
         return (CustomCode(None, True), dummy_guard, dummy_guard_chain)
     except Exception as e:

--- a/python/paddle/jit/sot/opcode_translator/executor/opcode_inline_executor.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/opcode_inline_executor.py
@@ -24,6 +24,7 @@ from ...utils import (
     FallbackError,
     UnsupportedIteratorBreak,
 )
+from ...utils.exceptions import SotCapturedStopIteration
 from ..instruction_utils import Instruction
 from .dispatch_functions import generator_send
 from .opcode_executor import OpcodeExecutorBase, Stop
@@ -53,7 +54,7 @@ def inline_for_iter_impl(exe: OpcodeExecutorBase, instr: Instruction):
     if not isinstance(iterator, UserDefinedIterVariable):
         try:
             exe.stack.push(iterator.next())
-        except StopIteration:
+        except SotCapturedStopIteration:
             exe.stack.pop()
             assert isinstance(instr.jump_to, Instruction)
             exe.vframe.lasti = exe.indexof(instr.jump_to)

--- a/python/paddle/jit/sot/opcode_translator/executor/variable_dispatch.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variable_dispatch.py
@@ -41,7 +41,7 @@ from ...utils import (
     UnsupportedOperationBreak,
     do_until_stop_iteration,
 )
-from ...utils.exceptions import InnerError
+from ...utils.exceptions import InnerError, SotCapturedStopIteration
 from ...utils.magic_methods import (
     BINARY_OPS,
     NEED_GUARD_ZERO_DIVISION_ERROR_OPS,
@@ -1406,7 +1406,7 @@ def dispatch_reduce(
     ):
         try:
             initializer = iterator.next()
-        except StopIteration:
+        except SotCapturedStopIteration:
             raise InnerError("reduce() of empty iterable with no initial value")
     result = initializer
 
@@ -1424,7 +1424,7 @@ def dispatch_max_iterable(var: ContainerVariable | IterVariable):
     call_next = BuiltinVariable(next, var.graph, DanglingTracker())
     try:
         res = call_next(it)
-    except StopIteration:
+    except SotCapturedStopIteration:
         raise InnerError("max() arg is an empty sequence")
     call_gt = BuiltinVariable(operator.gt, var.graph, DanglingTracker())
 
@@ -1655,7 +1655,7 @@ def dispatch_any(var: ContainerVariable | IterVariable):
             assert isinstance(bool_item, ConstantVariable)
             if bool_item.get_py_value():
                 return ConstantVariable(True, graph, DummyTracker([var]))
-        except StopIteration:
+        except SotCapturedStopIteration:
             break
     return ConstantVariable(False, graph, DummyTracker([var]))
 
@@ -1673,7 +1673,7 @@ def dispatch_all(var: ContainerVariable | IterVariable):
             assert isinstance(bool_item, ConstantVariable)
             if not bool_item.get_py_value():
                 return ConstantVariable(False, graph, DummyTracker([var]))
-        except StopIteration:
+        except SotCapturedStopIteration:
             break
     return ConstantVariable(True, graph, DummyTracker([var]))
 

--- a/python/paddle/jit/sot/opcode_translator/executor/variable_dispatch.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variable_dispatch.py
@@ -647,8 +647,8 @@ Dispatcher.register(
 
 def register_exception(exc_type: type[Exception]):
     @Dispatcher.register_decorator(exc_type)
-    def builtin_exception_dispatcher(*args) -> int:
-        exc = exc_type(*args)
+    def builtin_exception_dispatcher(*args: VariableBase) -> int:
+        exc = exc_type(*[arg.get_py_value() for arg in args])
         return ExceptionVariable(
             exc,
             graph=Dispatcher.graph,

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
@@ -2471,7 +2471,10 @@ class DataClassInstanceVariable(VariableBase):
             ).bind(self, "__post_init__")
         if name == "__dataclass_fields__":
             return VariableFactory.from_value(
-                {fd.name: fd for fd in dataclasses.fields(self.value)},
+                {
+                    fd.name: fd
+                    for fd in dataclasses.fields(self.class_var.value)
+                },
                 graph=self.graph,
                 tracker=GetAttrTracker(self, "__dataclass_fields__"),
             )

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/callable.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/callable.py
@@ -76,6 +76,7 @@ from ....utils.exceptions import (
     PsdbBreakReason,
     SotCapturedException,
     SotCapturedExceptionFactory,
+    SotCapturedStopIteration,
     SotErrorBase,
     UnsupportedNumPyAPIBreak,
     UnsupportedOperationBreak,
@@ -967,6 +968,11 @@ class BuiltinVariable(FunctionVariable):
         if handler is not None:
             try:
                 return handler(*args, **kwargs)
+            except SotCapturedStopIteration:
+                # Although SotCapturedStopIteration is a subclass of SotErrorBase,
+                # this exception is handled separately because StopIteration is essential for generator operation.
+                # Explicitly separating this branch clarifies its role and makes debugging easier.
+                raise
             except SotErrorBase as e:
                 # NOTE: BuiltinVariable.call_function cat not raise SotCapturedException,
                 # so we can directly raise SotErrorBase.

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/iter.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/iter.py
@@ -28,6 +28,7 @@ from ....utils.exceptions import (
     FallbackError,
     FallbackInlineCallBreak,
     OtherInlineCallBreak,
+    SotCapturedStopIteration,
     SotErrorBase,
     UnsupportedOperationBreak,
 )
@@ -124,7 +125,7 @@ class SequenceIterVariable(IterVariable):
             self.idx += 1
             return val
         else:
-            raise StopIteration
+            raise SotCapturedStopIteration
 
     def to_list(self) -> list:
         if self.has_side_effect():
@@ -356,7 +357,9 @@ class GeneratorVariable(IterVariable):
             ):
                 output: VariableBase = inline_gen_executor.inline_call()
                 if inline_gen_executor.stop_state == "Return":
-                    raise StopIteration
+                    raise SotCapturedStopIteration
+        except SotCapturedStopIteration:
+            raise
         except SotErrorBase as error:
             self.graph.restore_memo(checkpoint)
             self.vframe.restore_state(frame_state)

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/iter.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/iter.py
@@ -28,6 +28,7 @@ from ....utils.exceptions import (
     FallbackError,
     FallbackInlineCallBreak,
     OtherInlineCallBreak,
+    SotCapturedExceptionFactory,
     SotCapturedStopIteration,
     SotErrorBase,
     UnsupportedOperationBreak,
@@ -125,7 +126,7 @@ class SequenceIterVariable(IterVariable):
             self.idx += 1
             return val
         else:
-            raise SotCapturedStopIteration
+            raise SotCapturedExceptionFactory.create(StopIteration())
 
     def to_list(self) -> list:
         if self.has_side_effect():
@@ -357,7 +358,7 @@ class GeneratorVariable(IterVariable):
             ):
                 output: VariableBase = inline_gen_executor.inline_call()
                 if inline_gen_executor.stop_state == "Return":
-                    raise SotCapturedStopIteration
+                    raise SotCapturedExceptionFactory.create(StopIteration())
         except SotCapturedStopIteration:
             raise
         except SotErrorBase as error:

--- a/python/paddle/jit/sot/utils/utils.py
+++ b/python/paddle/jit/sot/utils/utils.py
@@ -476,11 +476,13 @@ def get_numpy_ufuncs():
 
 
 def do_until_stop_iteration(fn: Callable[[], T]) -> list[T]:
+    from paddle.jit.sot.utils.exceptions import SotCapturedStopIteration
+
     res = []
     while True:
         try:
             res.append(fn())
-        except StopIteration:
+        except SotCapturedStopIteration:
             break
     return res
 

--- a/test/sot/test_24_exceptions.py
+++ b/test/sot/test_24_exceptions.py
@@ -945,6 +945,7 @@ class TestGuard(TestCaseBase):
 
 
 class TestBuiltinFunctionRaiseExceptionGuard(TestCaseBase):
+    @strict_mode_guard(False)
     def test_guard_run(self):
         def foo_floordiv(x):
             1 / x


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->

此前，一些 SOT 内部异常在进入该分支后会直接 fallback，导致部分潜在问题被隐藏。
本 PR 通过设置环境变量 `STRICT_MODE` 启用严格模式时，遇到相关异常将不再静默 fallback，而是直接抛出原始异常，便于及时发现和定位问题。

另外，本PR一并将SOT生成器相关的 StopIteration -> SotCapturedStopIteration

PCard-91591