### PR TITLE
[0-size Tensor No.12、71] Add 0-size Tensor support for paddle.frac

### DIFF
--- a/test/legacy_test/test_complex_view_op.py
+++ b/test/legacy_test/test_complex_view_op.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import unittest
 
 import numpy as np
@@ -19,7 +20,7 @@ from op_test import OpTest
 
 import paddle
 from paddle import static
-from paddle.base import dygraph
+from paddle.base import core, dygraph
 
 paddle.enable_static()
 
@@ -119,6 +120,34 @@ class TestViewAsRealAPI(unittest.TestCase):
         exe.run(sp)
         [out_np] = exe.run(mp, feed={"x": self.x}, fetch_list=[out])
         np.testing.assert_allclose(self.out, out_np, rtol=1e-05)
+
+
+class TestViewAsRealAPI_ZeroSize(unittest.TestCase):
+    def get_places(self):
+        places = []
+        if (
+            os.environ.get('FLAGS_CI_both_cpu_and_gpu', 'False').lower()
+            in ['1', 'true', 'on']
+            or not core.is_compiled_with_cuda()
+        ):
+            places.append(core.CPUPlace())
+        if core.is_compiled_with_cuda():
+            places.append(core.CUDAPlace(0))
+        return places
+
+    def setUp(self):
+        self.x = np.random.randn(10, 0) + 1j * np.random.randn(10, 0)
+        self.out = ref_view_as_real(self.x)
+
+    def test_dygraph(self):
+        for place in self.get_places():
+            with dygraph.guard(place):
+                x_tensor = paddle.to_tensor(self.x)
+                x_tensor.stop_gradient = False
+                out = paddle.as_real(x_tensor)
+                np.testing.assert_allclose(self.out, out.numpy(), rtol=1e-05)
+                out.sum().backward()
+                np.testing.assert_allclose(x_tensor.grad.shape, x_tensor.shape)
 
 
 if __name__ == "__main__":

--- a/test/legacy_test/test_frac_api.py
+++ b/test/legacy_test/test_frac_api.py
@@ -110,5 +110,29 @@ class TestFracError(unittest.TestCase):
         self.assertRaises(TypeError, paddle.frac, x)
 
 
+class TestFracAPI_ZeroSize(unittest.TestCase):
+    def set_dtype(self):
+        self.dtype = 'float64'
+
+    def setUp(self):
+        self.set_dtype()
+        self.x_np = np.random.random([0, 3]).astype(self.dtype)
+        self.place = (
+            paddle.CUDAPlace(0)
+            if core.is_compiled_with_cuda()
+            else paddle.CPUPlace()
+        )
+
+    def test_api_dygraph(self):
+        paddle.disable_static(self.place)
+        x = paddle.to_tensor(self.x_np)
+        x.stop_gradient = False
+        out = paddle.frac(x)
+        out_ref = ref_frac(self.x_np)
+        np.testing.assert_allclose(out_ref, out.numpy(), rtol=1e-05)
+        out.sum().backward()
+        np.testing.assert_allclose(x.grad.shape, x.shape)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
[0-size Tensor No.12、71] Add 0-size Tensor support for paddle.frac

PaddleAPITest测试通过增加单测 

71 paddle.frac
PaddleAPITest测试通过
![image](https://github.com/user-attachments/assets/1cec24fa-a06a-41fa-8942-d8b48e9936c2)

12 paddle.as_real
PaddleAPITest测试通过
![image](https://github.com/user-attachments/assets/7ddb66dc-603c-468d-a50e-1da2d2144657)
