### PR TITLE
[SOT] Use `dataclass_as_dict` instande of `asdict`

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
@@ -18,7 +18,6 @@ import dataclasses
 import operator
 import sys
 import types
-from dataclasses import asdict
 from enum import Enum
 from functools import cached_property, reduce
 from typing import TYPE_CHECKING, Any
@@ -29,6 +28,7 @@ import paddle
 from paddle._typing import unreached
 from paddle.framework import core
 from paddle.jit.dy2static.utils import (
+    dataclass_as_dict,
     dataclass_from_dict,
     is_plain_dataclass_type,
 )
@@ -2471,7 +2471,10 @@ class DataClassInstanceVariable(VariableBase):
             ).bind(self, "__post_init__")
         if name == "__dataclass_fields__":
             return VariableFactory.from_value(
-                {fd.name: fd for fd in dataclasses.fields(self.value)},
+                {
+                    fd.name: fd
+                    for fd in dataclasses.fields(self.class_var.value)
+                },
                 graph=self.graph,
                 tracker=GetAttrTracker(self, "__dataclass_fields__"),
             )
@@ -2587,7 +2590,7 @@ class DataClassInstanceVariable(VariableBase):
                 type(value), graph, DanglingTracker()
             )
             try:
-                data_dict = asdict(value)
+                data_dict = dataclass_as_dict(value)
             except:
                 data_dict = {}
             var = DataClassInstanceVariable(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes 

### Description
<!-- Describe what you’ve done -->

解决 #73627 错误解决冲突导致的问题，

- ~原 `asdict` 会导致深拷贝，新实现的 `dataclass_as_dict` 是浅拷贝~
- 原来的 `asdict` 会进入 `try except` 语句中的 `except` 分支，导致很多属性无法获取

<!-- PCard-66972 -->