### PR TITLE
[AutoParallel] addd sync param dynamic

### DIFF
--- a/python/paddle/distributed/auto_parallel/pipelining/schedules.py
+++ b/python/paddle/distributed/auto_parallel/pipelining/schedules.py
@@ -343,12 +343,6 @@ class PipelineScheduleSingle(_PipelineSchedule):
         self._stage.has_backward = self._has_backward
         self._stage_initialized = False
 
-        # for idx, stage in enumerate(self._stage):
-        #     print("xxx idx stage: ", idx)
-        for param in self._stage.get_stage_parameters():
-            print("    xxx param : ", param.name, param.shape)
-                
-
     def _initialize_stage(self, args, kwargs, labels):
         if self._stage.is_first:
             next_stage_args = self._stage._prepare_forward_infra(
@@ -392,52 +386,11 @@ class PipelineScheduleSingle(_PipelineSchedule):
         # Run microbatches
         self._step_microbatches(args_split, kwargs_split, targets_split, losses)
 
-
         # Return merged results per original format
         if self._stage.is_last:
             return self._merge_outputs(self._stage.output_chunks)
         else:
             return None
-
-        
-    def sync_shared_params(self):
-        print("xxx enter sync_shared_params")
-        stage = self._stage
-        shared_map = stage.get_shared_map()
-        cur_rank = stage.group_rank
-        # print("xxx shared_map: ", shared_map)
-        
-        if len(shared_map) == 0 :
-            return
-        for a_map in shared_map.values():
-            if a_map["src_rank"] != cur_rank:
-                continue
-            peers = a_map["peers"]
-            ranks = sorted(peers + [cur_rank])
-            # find param
-            param_name = a_map["param_name"]
-            sync_param = None
-            for param in stage.get_stage_parameters():
-                if param.name != param_name:
-                    continue
-                # sync_param = param.grad
-                sync_param = param._local_value()
-                break
-            # print("xxx sync_param: ", sync_param)
-            assert sync_param is not None
-
-            # build comm group
-            # group = paddle.distributed.new_group(ranks=ranks)
-            group = a_map["group"]
-            # print("xxx group: ", group)
-            # allreduce params
-            with paddle.no_grad():
-                paddle.distributed.all_reduce(
-                    sync_param,
-                    op=paddle.distributed.ReduceOp.SUM,
-                    group=group
-                )
-            print("xxx allreduce OK")
 
 
 def _batch_p2p(p2p_ops: list[dist.P2POp], desc: str | None = None):
@@ -489,7 +442,6 @@ class ScheduleFThenB(PipelineScheduleSingle):
         target_mbs: list | None = None,
         losses: list | None = None,
     ):
-        print("xxx ScheduleFThenB")
         """
         Run one iteration of the pipeline schedule with list of microbatches.
         Will go through all the microbatches according to the FThenB schedule.
@@ -570,6 +522,9 @@ class ScheduleFThenB(PipelineScheduleSingle):
         for work in bwd_sends_to_wait:
             work.wait()
 
+        # Synchronize the gradients of shared parameters.
+        self._stage.sync_shared_params()
+
 
 class Schedule1F1B(PipelineScheduleSingle):
     """
@@ -584,7 +539,6 @@ class Schedule1F1B(PipelineScheduleSingle):
         target_mbs: list | None = None,
         losses: list | None = None,
     ):
-        print("xxx Schedule1F1B")
         """
         Run one iteration of the pipeline schedule with list of microbatches.
         Will go through all the microbatches according to the 1F1B schedule.
@@ -601,8 +555,6 @@ class Schedule1F1B(PipelineScheduleSingle):
                 self._initialize_stage(arg_mbs[0], kwarg_mbs[0], target_mbs[0])
             else:
                 self._initialize_stage(arg_mbs[0], kwarg_mbs[0], None)
-
-        
 
         # Last stage has 1 warmup, second-to-last 2 warmups, ...
         # first stage `num_stages` warmups
@@ -729,10 +681,11 @@ class Schedule1F1B(PipelineScheduleSingle):
         if send_work:
             send_work.wait()
 
-        self.sync_shared_params()
-
         # Return losses if there is a container passed in
         self._update_losses(self._stage, losses)
+
+        # Synchronize the gradients of shared parameters.
+        self._stage.sync_shared_params()
 
 
 class PipelineScheduleMulti(_PipelineSchedule):
@@ -771,12 +724,6 @@ class PipelineScheduleMulti(_PipelineSchedule):
                 stage.stage_index_to_group_rank = stage_index_to_group_rank
         self.stage_index_to_group_rank = stages[0].stage_index_to_group_rank
 
-        
-        # for idx, stage in enumerate(self._stages):
-        #     print("xxx idx stage: ", idx)
-        #     for param in stage.get_stage_parameters():
-        #         print("    xxx param : ", param.name, param.shape)
-
         # Set the same has_backward flag for stage object
         for stage in self._stages:
             stage.has_backward = self._has_backward
@@ -796,8 +743,6 @@ class PipelineScheduleMulti(_PipelineSchedule):
             )
 
     def _initialize_stages(self, args: tuple[Any, ...], kwargs, labels):
-        # for arg in args: # not output
-        #     print("xxx arg: ",arg.name)
         # may be 'none' value (if this stage sends its output shapes to the next stage via P2P)
         # or real value (if this stage and next stage are on the same device)
         next_stage_args: tuple[Any, ...] = ()
@@ -867,7 +812,6 @@ class PipelineScheduleMulti(_PipelineSchedule):
         target_mbs: list | None = None,
         losses: list | None = None,
     ):
-        print("xxx PipelineScheduleMulti")
         """
         Operate on the microbatches for looped schedules (multiple stages on each rank).
         """
@@ -1041,36 +985,9 @@ class PipelineScheduleMulti(_PipelineSchedule):
         # Return losses if there is a container passed in
         self._update_losses(self._stages, losses)
 
-    # def sync_shared_params(self):
-    #     for stage in self._stages:
-    #         if not stage.need_sync_params():
-    #             continue
-    #         shared_map = self.get_shared_map()
-    #         cur_rank = stage.group_rank
-    #         if shared_map["src_rank"] != cur_rank:
-    #             continue
-    #         peers = shared_map["peers"]
-    #         ranks = sorted(peer + [cur_rank])
-    #         # find param
-    #         param_name = shared_map["param_name"]
-    #         sync_param = None
-    #         for param in stage.get_stage_parameters():
-    #             if param.name != param_name:
-    #                 continue
-    #             sync_param = param
-    #             break
-        
-    #         assert sync_param is not None
-
-    #         # build comm group
-    #         group = paddle.distributed.new_group(ranks=ranks)
-    #         # allreduce params
-    #         with paddle.no_grad():
-    #             paddle.distributed.all_reduce(
-    #                 sync_param,
-    #                 group
-    #             )
-    #         print("xxx allreduce OK")
+        # Synchronize the gradients of shared parameters.
+        for stage in self._stages:
+            stage.sync_shared_params()
 
 
 def _get_1f1b_rank_ops(

--- a/python/paddle/distributed/auto_parallel/pipelining/schedules.py
+++ b/python/paddle/distributed/auto_parallel/pipelining/schedules.py
@@ -523,7 +523,7 @@ class ScheduleFThenB(PipelineScheduleSingle):
             work.wait()
 
         # Synchronize the gradients of shared parameters.
-        self._stage.sync_shared_param_grads()
+        self._stage._sync_shared_param_grads()
 
 
 class Schedule1F1B(PipelineScheduleSingle):
@@ -685,7 +685,7 @@ class Schedule1F1B(PipelineScheduleSingle):
         self._update_losses(self._stage, losses)
 
         # Synchronize the gradients of shared parameters.
-        self._stage.sync_shared_param_grads()
+        self._stage._sync_shared_param_grads()
 
 
 class PipelineScheduleMulti(_PipelineSchedule):
@@ -987,7 +987,7 @@ class PipelineScheduleMulti(_PipelineSchedule):
 
         # Synchronize the gradients of shared parameters.
         for stage in self._stages:
-            stage.sync_shared_param_grads()
+            stage._sync_shared_param_grads()
 
 
 def _get_1f1b_rank_ops(

--- a/python/paddle/distributed/auto_parallel/pipelining/schedules.py
+++ b/python/paddle/distributed/auto_parallel/pipelining/schedules.py
@@ -523,7 +523,7 @@ class ScheduleFThenB(PipelineScheduleSingle):
             work.wait()
 
         # Synchronize the gradients of shared parameters.
-        self._stage.sync_shared_params()
+        self._stage.sync_shared_param_grads()
 
 
 class Schedule1F1B(PipelineScheduleSingle):
@@ -685,7 +685,7 @@ class Schedule1F1B(PipelineScheduleSingle):
         self._update_losses(self._stage, losses)
 
         # Synchronize the gradients of shared parameters.
-        self._stage.sync_shared_params()
+        self._stage.sync_shared_param_grads()
 
 
 class PipelineScheduleMulti(_PipelineSchedule):
@@ -987,7 +987,7 @@ class PipelineScheduleMulti(_PipelineSchedule):
 
         # Synchronize the gradients of shared parameters.
         for stage in self._stages:
-            stage.sync_shared_params()
+            stage.sync_shared_param_grads()
 
 
 def _get_1f1b_rank_ops(

--- a/python/paddle/distributed/auto_parallel/pipelining/schedules.py
+++ b/python/paddle/distributed/auto_parallel/pipelining/schedules.py
@@ -343,6 +343,12 @@ class PipelineScheduleSingle(_PipelineSchedule):
         self._stage.has_backward = self._has_backward
         self._stage_initialized = False
 
+        # for idx, stage in enumerate(self._stage):
+        #     print("xxx idx stage: ", idx)
+        for param in self._stage.get_stage_parameters():
+            print("    xxx param : ", param.name, param.shape)
+                
+
     def _initialize_stage(self, args, kwargs, labels):
         if self._stage.is_first:
             next_stage_args = self._stage._prepare_forward_infra(
@@ -386,11 +392,52 @@ class PipelineScheduleSingle(_PipelineSchedule):
         # Run microbatches
         self._step_microbatches(args_split, kwargs_split, targets_split, losses)
 
+
         # Return merged results per original format
         if self._stage.is_last:
             return self._merge_outputs(self._stage.output_chunks)
         else:
             return None
+
+        
+    def sync_shared_params(self):
+        print("xxx enter sync_shared_params")
+        stage = self._stage
+        shared_map = stage.get_shared_map()
+        cur_rank = stage.group_rank
+        # print("xxx shared_map: ", shared_map)
+        
+        if len(shared_map) == 0 :
+            return
+        for a_map in shared_map.values():
+            if a_map["src_rank"] != cur_rank:
+                continue
+            peers = a_map["peers"]
+            ranks = sorted(peers + [cur_rank])
+            # find param
+            param_name = a_map["param_name"]
+            sync_param = None
+            for param in stage.get_stage_parameters():
+                if param.name != param_name:
+                    continue
+                # sync_param = param.grad
+                sync_param = param._local_value()
+                break
+            # print("xxx sync_param: ", sync_param)
+            assert sync_param is not None
+
+            # build comm group
+            # group = paddle.distributed.new_group(ranks=ranks)
+            group = a_map["group"]
+            # print("xxx group: ", group)
+            # allreduce params
+            with paddle.no_grad():
+                paddle.distributed.all_reduce(
+                    sync_param,
+                    op=paddle.distributed.ReduceOp.SUM,
+                    group=group
+                )
+            print("xxx allreduce OK")
 
 
 def _batch_p2p(p2p_ops: list[dist.P2POp], desc: str | None = None):
@@ -442,6 +489,7 @@ class ScheduleFThenB(PipelineScheduleSingle):
         target_mbs: list | None = None,
         losses: list | None = None,
     ):
+        print("xxx ScheduleFThenB")
         """
         Run one iteration of the pipeline schedule with list of microbatches.
         Will go through all the microbatches according to the FThenB schedule.
@@ -536,6 +584,7 @@ class Schedule1F1B(PipelineScheduleSingle):
         target_mbs: list | None = None,
         losses: list | None = None,
     ):
+        print("xxx Schedule1F1B")
         """
         Run one iteration of the pipeline schedule with list of microbatches.
         Will go through all the microbatches according to the 1F1B schedule.
@@ -552,6 +601,8 @@ class Schedule1F1B(PipelineScheduleSingle):
                 self._initialize_stage(arg_mbs[0], kwarg_mbs[0], target_mbs[0])
             else:
                 self._initialize_stage(arg_mbs[0], kwarg_mbs[0], None)
+
+        
 
         # Last stage has 1 warmup, second-to-last 2 warmups, ...
         # first stage `num_stages` warmups
@@ -678,6 +729,8 @@ class Schedule1F1B(PipelineScheduleSingle):
         if send_work:
             send_work.wait()
 
+        self.sync_shared_params()
+
         # Return losses if there is a container passed in
         self._update_losses(self._stage, losses)
 
@@ -718,6 +771,12 @@ class PipelineScheduleMulti(_PipelineSchedule):
                 stage.stage_index_to_group_rank = stage_index_to_group_rank
         self.stage_index_to_group_rank = stages[0].stage_index_to_group_rank
 
+        
+        # for idx, stage in enumerate(self._stages):
+        #     print("xxx idx stage: ", idx)
+        #     for param in stage.get_stage_parameters():
+        #         print("    xxx param : ", param.name, param.shape)
+
         # Set the same has_backward flag for stage object
         for stage in self._stages:
             stage.has_backward = self._has_backward
@@ -737,6 +796,8 @@ class PipelineScheduleMulti(_PipelineSchedule):
             )
 
     def _initialize_stages(self, args: tuple[Any, ...], kwargs, labels):
+        # for arg in args: # not output
+        #     print("xxx arg: ",arg.name)
         # may be 'none' value (if this stage sends its output shapes to the next stage via P2P)
         # or real value (if this stage and next stage are on the same device)
         next_stage_args: tuple[Any, ...] = ()
@@ -806,6 +867,7 @@ class PipelineScheduleMulti(_PipelineSchedule):
         target_mbs: list | None = None,
         losses: list | None = None,
     ):
+        print("xxx PipelineScheduleMulti")
         """
         Operate on the microbatches for looped schedules (multiple stages on each rank).
         """
@@ -978,6 +1040,37 @@ class PipelineScheduleMulti(_PipelineSchedule):
                 raise e
         # Return losses if there is a container passed in
         self._update_losses(self._stages, losses)
+
+    # def sync_shared_params(self):
+    #     for stage in self._stages:
+    #         if not stage.need_sync_params():
+    #             continue
+    #         shared_map = self.get_shared_map()
+    #         cur_rank = stage.group_rank
+    #         if shared_map["src_rank"] != cur_rank:
+    #             continue
+    #         peers = shared_map["peers"]
+    #         ranks = sorted(peer + [cur_rank])
+    #         # find param
+    #         param_name = shared_map["param_name"]
+    #         sync_param = None
+    #         for param in stage.get_stage_parameters():
+    #             if param.name != param_name:
+    #                 continue
+    #             sync_param = param
+    #             break
+        
+    #         assert sync_param is not None
+
+    #         # build comm group
+    #         group = paddle.distributed.new_group(ranks=ranks)
+    #         # allreduce params
+    #         with paddle.no_grad():
+    #             paddle.distributed.all_reduce(
+    #                 sync_param,
+    #                 group
+    #             )
+    #         print("xxx allreduce OK")
 
 
 def _get_1f1b_rank_ops(

--- a/python/paddle/distributed/auto_parallel/pipelining/stage.py
+++ b/python/paddle/distributed/auto_parallel/pipelining/stage.py
@@ -292,7 +292,6 @@ class _PipelineStageBase(ABC):
                 return None
 
         map_structure(map_recv_to_send, args_recv_info)
-        # print("xxx Grad send info: ", self.log_prefix, grad_send_info)
 
         logger.debug("%s Grad send info: %s", self.log_prefix, grad_send_info)
         return grad_send_info
@@ -430,7 +429,7 @@ class _PipelineStageBase(ABC):
         for this stage.
         """
         recv_infos: tuple[InputInfo, ...] = self.args_recv_info[fwd_chunk_id]
-        # print("xxx get_fwd_recv_ops recv_infos ")
+
         return self._get_recv_ops(recv_infos)
 
     def get_bwd_recv_ops(self, bwd_chunk_id: int) -> list[dist.P2POp]:
@@ -440,7 +439,7 @@ class _PipelineStageBase(ABC):
         """
         if not self.has_backward or self.is_last:
             return []
-        # print("xxx get_bwd_recv_ops recv_infos ")
+
         recv_infos = self.grad_recv_info[bwd_chunk_id]
         return self._get_recv_ops(recv_infos)
 
@@ -458,7 +457,6 @@ class _PipelineStageBase(ABC):
         for idx, out in enumerate(output_tuple):
             dst_stages = self.act_send_info[idx]
             for dst in dst_stages:
-                # print("xxx get_fwd_send_ops beg, dst, out: ", idx, dst)
                 if dst is None:
                     continue
                 logger.debug(
@@ -515,7 +513,6 @@ class _PipelineStageBase(ABC):
         ops: list[dist.P2POp] = []
         grads_input = self.bwd_cache.pop(bwd_chunk_id)
         for grad, grad_recv_stage in zip(grads_input, self.grad_send_info):
-            # print("xxx get_bwd_send_ops ,grad: ", grad_recv_stage)
             if isinstance(grad, paddle.Tensor) and grad_recv_stage is not None:
                 logger.debug(
                     "%s Sending gradient to Stage %s: %s",
@@ -848,7 +845,7 @@ class PipelineStage(_PipelineStageBase):
     A class representing a pipeline stage in a pipeline parallelism setup.
 
     PipelineStage assumes sequential partitioning of the model, i.e. the model is split into chunks where outputs from
-    one chunk feed into inputs of the next chunk, with no skip connections.
+    one chunk feed into inputs of the next chunk. Additionally, optimization of shared parameters is also supported here.
 
     PipelineStage performs runtime shape/dtype inference automatically by propagating the outputs from stage0 to
     stage1 and so forth, in linear order.  To bypass shape inference, pass the `input_args` and `output_args` to each
@@ -861,6 +858,9 @@ class PipelineStage(_PipelineStageBase):
         input_args (TensorMeta|tuple[TensorMeta, ...]|None): The input arguments for the layer.
         output_args (TensorMeta|tuple[TensorMeta, ...]|None): The output arguments for the layer.
         group (Group, None): The process group for distributed training. If None, default group.
+        shared_param_map (dict[str, dict[str, paddle.Tensor | paddle.distributed.collective.Group]] | None): A description
+            for shared parameter pairs. Each pair of shared parameters includes a unique identifier for the shared parameter,
+            the shared model parameter tensor, and the process group for synchronization operations.
     """
 
     def __init__(
@@ -871,15 +871,16 @@ class PipelineStage(_PipelineStageBase):
         input_args: TensorMeta | tuple[TensorMeta, ...] | None = None,
         output_args: TensorMeta | tuple[TensorMeta, ...] | None = None,
         group: Group | None = None,
-        shared_map = None,
+        shared_param_map: dict[str, dict[str, paddle.Tensor | paddle.distributed.collective.Group]] | None = None,  # type: ignore
     ):
-        
         super().__init__(layer, stage_index, num_stages, group)
         self.inputs: list[paddle.Tensor] | None = None
         self.inputs_meta: tuple[TensorMeta, ...] | None = None
         # output's grad meta-info
         self.grads_meta: tuple[TensorMeta, ...] | None = None
-        self.shared_map = shared_map
+        self.shared_param_map = (
+            shared_param_map if shared_param_map is not None else {}
+        )
 
         if input_args is None:
             assert output_args is None, (
@@ -933,53 +934,41 @@ class PipelineStage(_PipelineStageBase):
 
         logger.debug(dbg_str)
 
-        print("xxx self.sublayer param sum : ", len(self.sublayer.parameters()))
-        print("xxx enter PipelineStage")
+        # Synchronize the shared parameters.
+        self.broadcast_shared_params()
 
-        for a_map in self.shared_map.values():
-            src_rank = a_map["src_rank"]
-            print("xxx src_rank : ", src_rank, self.group_rank)
-            if src_rank != self.group_rank:
-                continue
-            need_share_data = a_map["need_share_data"]
-            if not need_share_data:
-                continue
-            # sync_param = a_map["param"]
-            # peer_sync_param = a_map["peer_params"]
-            # print("xxx sync_param: ", sync_param.name, sync_param.shape, sync_param._is_initialized())
-            # print("xxx peer_sync_param: ", peer_sync_param.name, peer_sync_param.shape, peer_sync_param._is_initialized())
-            # sync_param.initialize() 
-            # peer_sync_param.initialize() 
-            # print("xxx lazy init not : ", sync_param)
-            # print("xxx lazy init not : ", peer_sync_param)
-            # sync_param._local_value().get_tensor()._share_data_with(peer_sync_param._local_value().get_tensor())
+    def broadcast_shared_params(self):
+        # When initializing the stage, perform broadcast synchronization
+        # on the shared parameters.
+        for _, a_map in self.shared_param_map.items():
+            sync_param = a_map["param"]
+            sync_group = a_map["group"]
+            assert (
+                sync_param is not None and sync_group is not None
+            ), "Shared parameter (param) or synchronization group (group) in shared_param_map is None."
+            group_ranks = sorted(sync_group.ranks)
+            with paddle.no_grad():
+                paddle.distributed.broadcast(
+                    sync_param._local_value(),
+                    src=group_ranks[0],
+                    group=sync_group,
+                )
 
-
-
-        # for param in self.sublayer.parameters(): 
-        #     # print("xxx stage param: ", param.name, param._is_initialized())
-
-        #     for a_map in self.shared_map:
-        #         param_name = a_map["param_name"]
-        #     if self.shared_map is not None and  param.name in shared_map:
-        #         print("xxx find shared params")
-        #         print("xxx embedding weight: ", shared_map[param.name]._is_initialized())
-        #         print("xxx lmhead weight: ", param._is_initialized())
-        #         print("xxx embedding weight: ", shared_map[param.name])
-        #         # shared_map[param.name].get_tensor()._share_data_with(param)
-        #         print("xxx param type : ", type(param))
-        #         print("xxx param.get_tensor() type : ", type(param.get_tensor()))
-        #         # param.get_tensor()._share_data_with(shared_map[param.name].get_tensor())
-        #         # param.get_tensor()._share_data_nocheck_with(shared_map[param.name].get_tensor())
-        #         # _share_data_nocheck_with
-
-        print("xxx self.sublayer param sum : ", len(self.sublayer.parameters()))
-
-    def need_sync_params(self):
-        return len(self.shared_map) == 0
-
-    def get_shared_map(self):
-        return self.shared_map
+    def sync_shared_params(self):
+        # After the stage scheduling ends, perform allreduce synchronization
+        # on the gradients of shared parameters.
+        for _, a_map in self.shared_param_map.items():
+            sync_param = a_map["param"]
+            sync_group = a_map["group"]
+            assert (
+                sync_param is not None and sync_group is not None
+            ), "Shared parameter (param) or synchronization group (group) in shared_param_map is None."
+            with paddle.no_grad():
+                paddle.distributed.all_reduce(
+                    sync_param.grad._local_value(),
+                    op=paddle.distributed.ReduceOp.SUM,
+                    group=sync_group,
+                )
 
     def _shape_inference(
         self,
@@ -1260,12 +1249,8 @@ class PipelineStage(_PipelineStageBase):
         self.clear_runtime_states()
         # Clear grads of the stage.
         for param in self.sublayer.parameters():
-            # print("xxx _prepare_backward_infra param: ", param.name)
             param.clear_grad()
         return grads
-
-    def get_stage_parameters(self) -> list[Parameter]:
-        return self.sublayer.parameters()
 
     def _create_grad_recv_info(
         self,

--- a/python/paddle/distributed/auto_parallel/pipelining/stage.py
+++ b/python/paddle/distributed/auto_parallel/pipelining/stage.py
@@ -858,11 +858,14 @@ class PipelineStage(_PipelineStageBase):
         input_args (TensorMeta|tuple[TensorMeta, ...]|None): The input arguments for the layer.
         output_args (TensorMeta|tuple[TensorMeta, ...]|None): The output arguments for the layer.
         group (Group, None): The process group for distributed training. If None, default group.
-        shared_param_map (dict[str, dict[str, paddle.Tensor | paddle.distributed.collective.Group]] | None): A description
-            of information for multiple groups of shared parameter pairs. Each entry contains:
+        shared_param_map (dict[str, dict[str, paddle.Tensor | paddle.distributed.collective.Group]] | None): A nested
+            dictionary containing information about multiple groups of shared parameter pairs.
+            Each entry in the dictionary maps a unique identifier to a sub-dictionary. Each entry has following keys:
                 - key: Unique identifier for the shared parameter.
-                    - param: The shared model parameter tensor.
-                    - group: The process group for synchronization operations.
+                    - ori_param (paddle.Tensor): The original parameter before synchronization.
+                    - sync_param (paddle.Tensor): The synchronized parameter after communication.
+                    - ori_mesh (paddle.distributed.collective.Group): The process mesh of the original parameter.
+                    - sync_mesh (paddle.distributed.collective.Group): The process mesh of the synchronized parameter.
     """
 
     def __init__(
@@ -883,6 +886,12 @@ class PipelineStage(_PipelineStageBase):
         self.shared_param_map = (
             shared_param_map if shared_param_map is not None else {}
         )
+
+        # Build shared parameter information for the current rank.
+        self.init_shared_group()
+
+        # Synchronize the initialized shared parameters.
+        self.broadcast_shared_params()
 
         if input_args is None:
             assert output_args is None, (
@@ -936,66 +945,87 @@ class PipelineStage(_PipelineStageBase):
 
         logger.debug(dbg_str)
 
-        # Synchronize the shared parameters.
-        self.broadcast_shared_params()
+    def init_shared_group(self):
+        get_group_from_ranks = {}
+        for key, a_map in self.shared_param_map.items():
+            # Build identical communication groups for each rank within the mesh.
+            assert (
+                "ori_mesh" in a_map and "sync_mesh" in a_map
+            ), "Missing 'ori_mesh' or `sync_mesh` key in `shared_param_map` entry"
+            ori_ranks = a_map["ori_mesh"].process_ids
+            sync_ranks = a_map["sync_mesh"].process_ids
+            assert len(ori_ranks) == len(sync_ranks)
+            assert (
+                ori_ranks != sync_ranks
+            ), "Shared parameters must be on different stage meshes."
+            cur_rank = dist.get_rank()
+            for ori_rank, sync_rank in zip(ori_ranks, sync_ranks):
+                group_ranks = tuple(sorted([ori_rank, sync_rank]))
+                if group_ranks not in get_group_from_ranks:
+                    get_group_from_ranks[group_ranks] = dist.new_group(
+                        ranks=list(group_ranks)
+                    )
+                if cur_rank in group_ranks:
+                    # Record communication group associated with the current rank.
+                    a_map["group"] = get_group_from_ranks[group_ranks]
+                    logger.debug(
+                        f"Build communication group {a_map['group'].name} for shared parameter `{key}` in rank {cur_rank}"
+                    )
+            # Find the shared parameter on the current rank.
+            assert (
+                "ori_param" in a_map and "sync_param" in a_map
+            ), "Missing 'ori_param' or `sync_param` key in `shared_param_map` entry"
+            ori_param = a_map["ori_param"]
+            sync_param = a_map["sync_param"]
+            # Default no shared parameter exists on current rank.
+            cur_param = None
+            if ori_param is not None and ori_param._is_initialized():
+                cur_param = ori_param
+            elif sync_param is not None and sync_param._is_initialized():
+                cur_param = sync_param
+            # Record shared parameter associated with the current rank.
+            a_map["param"] = cur_param
 
     def broadcast_shared_params(self):
         # When initializing the stage, perform broadcast synchronization
         # on the shared parameters.
-        if len(self.shared_param_map) == 0:
-            logger.debug("No shared parameters need to be processed.")
-            return
         for key, a_map in self.shared_param_map.items():
-            assert (
-                "param" in a_map
-            ), "Missing 'param' key in `shared_param_map` entry"
-            assert (
-                "group" in a_map
-            ), "Missing 'group' key in `shared_param_map` entry"
-
-            sync_param = a_map["param"]
+            if "param" not in a_map or "group" not in a_map:
+                continue
+            param = a_map["param"]
+            if param is None or not param._is_initialized():
+                continue
             sync_group = a_map["group"]
-            assert (
-                sync_param is not None and sync_group is not None
-            ), "Shared parameter (param) or synchronization group (group) in shared_param_map is None."
-            group_ranks = sorted(sync_group.ranks)
+            cur_rank = dist.get_rank()
+            assert cur_rank in sync_group.ranks
             logger.debug(
-                "Call `broadcast` for synchronization of shared parameters `%s`",
-                key,
+                f"Call `broadcast` for synchronization of shared parameters `{key}`",
             )
             with paddle.no_grad():
                 paddle.distributed.broadcast(
-                    sync_param._local_value(),
-                    src=group_ranks[0],
+                    param._local_value(),
+                    src=sync_group.ranks[0],
                     group=sync_group,
                 )
 
     def sync_shared_param_grads(self):
         # After the stage scheduling ends, perform allreduce synchronization
         # on the gradients of shared parameters.
-        if len(self.shared_param_map) == 0:
-            logger.debug("No shared parameters need to be processed.")
-            return
         for key, a_map in self.shared_param_map.items():
-            assert (
-                "param" in a_map
-            ), "Missing 'param' key in `shared_param_map` entry"
-            assert (
-                "group" in a_map
-            ), "Missing 'group' key in `shared_param_map` entry"
-
-            sync_param = a_map["param"]
+            if "param" not in a_map or "group" not in a_map:
+                continue
+            param = a_map["param"]
+            if param is None or not param._is_initialized():
+                continue
             sync_group = a_map["group"]
-            assert (
-                sync_param is not None and sync_group is not None
-            ), "Shared parameter (param) or synchronization group (group) in shared_param_map is None."
+            cur_rank = dist.get_rank()
+            assert cur_rank in sync_group.ranks
             logger.debug(
-                "Call `all_reduce` for gradient synchronization of shared parameters `%s`",
-                key,
+                f"Call `all_reduce` for gradient synchronization of shared parameters `{key}`",
             )
             with paddle.no_grad():
                 paddle.distributed.all_reduce(
-                    sync_param.grad._local_value(),
+                    param.grad._local_value(),
                     op=paddle.distributed.ReduceOp.SUM,
                     group=sync_group,
                 )

--- a/python/paddle/distributed/auto_parallel/pipelining/stage.py
+++ b/python/paddle/distributed/auto_parallel/pipelining/stage.py
@@ -857,14 +857,9 @@ class PipelineStage(_PipelineStageBase):
         input_args (TensorMeta|tuple[TensorMeta, ...]|None): The input arguments for the layer.
         output_args (TensorMeta|tuple[TensorMeta, ...]|None): The output arguments for the layer.
         group (Group, None): The process group for distributed training. If None, default group.
-        shared_param_map (dict[str, dict], optional): A dictionary that defines shared parameters between pipeline stages.
-            Each key is a unique name for a pair of shared parameters, and the corresponding value is a nested dictionary
-            with the following optional keys:
-                - params (list[EagerParamBase], required): Exact 2 parameters to share across stages.
-            In VPP mode, a same shared_param_map is reused across multiple stage builds. To avoid redundant group creation,
-            it may include:
-                - group (Group, optional): initialized sync group matching the ranks of the two shared parameters.
-                - shared_param (EagerParamBase, optional): The shared parameter instance assigned to the current rank.
+        shared_parameters (list[dict[str, list[EagerParamBase]]]|None): A list of dictionaries defining shared parameter
+        pairs between pipeline stages. Each dictionary represents a unique parameter pair with:
+            - "params" (list[EagerParamBase], required): Exactly 2 parameters to share across stages.
     """
 
     def __init__(
@@ -875,22 +870,17 @@ class PipelineStage(_PipelineStageBase):
         input_args: TensorMeta | tuple[TensorMeta, ...] | None = None,
         output_args: TensorMeta | tuple[TensorMeta, ...] | None = None,
         group: Group | None = None,
-        shared_param_map: dict[str, dict] | None = None,
+        shared_parameters: list[dict[str, list[EagerParamBase]]] | None = None,
     ):
         super().__init__(layer, stage_index, num_stages, group)
         self.inputs: list[paddle.Tensor] | None = None
         self.inputs_meta: tuple[TensorMeta, ...] | None = None
         # output's grad meta-info
         self.grads_meta: tuple[TensorMeta, ...] | None = None
-        self.shared_param_map = (
-            shared_param_map if shared_param_map is not None else {}
-        )
 
-        # Build shared parameter information for the current rank.
-        self.init_shared_group()
-
-        # Synchronize the initialized shared parameters.
-        self.broadcast_shared_params()
+        # Synchronize shared parameters on the current rank.
+        self.shared_parameters = shared_parameters
+        self.sync_shared_param()
 
         if input_args is None:
             assert output_args is None, (
@@ -944,64 +934,106 @@ class PipelineStage(_PipelineStageBase):
 
         logger.debug(dbg_str)
 
-    def check_a_shared_param_map(self, key_name, a_shared_map):
-        # Validate map structure and key_name.
-        assert (
-            isinstance(key_name, str) and key_name.strip()
-        ), f"Invalid shared parameter pair name: expected non-empty string, but got {type(key_name).__name__} '{key_name}'."
-        assert len(a_shared_map) <= 3, (
-            f"Shared param pair '{key_name}' exceeds size limit (max 3 keys). "
-            f"Allowed: ['params', 'group', 'shared_param'], got: {list(a_shared_map)}"
-        )
-        # Validate required 'params' entry.
-        params = a_shared_map.get("params")
-        assert (
-            params is not None
-        ), f"Missing shared parameter 'params' not found in shared_param_map['{key_name}']. Available keys: {list(a_shared_map)}."
-        assert (
-            isinstance(params, list) and len(params) == 2
-        ), f"Shared parameter only support 2 shared parameters, but got {len(params)}."
-        # Validate parameter types and placements.
-        param_1, param_2 = params
-        assert isinstance(param_1, EagerParamBase) and isinstance(
-            param_2, EagerParamBase
-        ), (
-            f"Shared parameter expects parameters are 'EagerParamBase' type, but got "
-            f"'{type(param_1).__name__}' and '{type(param_2).__name__}' respectively."
-        )
-        assert param_1.placements == param_2.placements, (
-            f"Shared parameters must have identical placements for optimal performance."
-            f"But placements mismatch: {param_1.placements} vs {param_2.placements}"
-        )
-        # Validate process meshes.
-        ranks_1 = param_1.process_mesh.process_ids
-        ranks_2 = param_2.process_mesh.process_ids
-        assert len(ranks_1) == len(ranks_2)
-        assert (
-            ranks_1 != ranks_2
-        ), f"Shared parameters must be on different stage meshes, but both are on {ranks_1}."
+    def sync_shared_param(self):
+        if self.shared_parameters is None:
+            # 1. Default no shared parameters to process.
+            self.shared_parameters = {}
+            return
 
-        # In VPP mode, `shared_param_map` may contain "group" and "shared_param" as it's reused for multiple stage builds.
-        # Validate optional 'group' entry.
-        if "group" in a_shared_map:
-            group = a_shared_map["group"]
-            assert group is None or isinstance(
-                group, Group
-            ), f"Expected 'shared_param_map[\"{key_name}\"][\"group\"]' is 'Group' or None, but got '{type(a_shared_map['group']).__name__}'."
-        # Validate optional 'sync_param' entry.
-        if "sync_param" in a_shared_map:
-            sync_param = a_shared_map["sync_param"]
-            assert sync_param is None or sync_param in list(
-                param_1, param_2
-            ), f"Expected 'shared_param_map[\"{key_name}\"][\"sync_param\"]' is one of the two params or None."
+        # 2. Validate parameters.
+        # TODO: Currently, shared parameter information relies on user input, so strict validation is required here.
+        # A more robust interface implementation is desired in the future.
+        self.validate_shared_parameter_pair()
+
+        # 3. Build shared parameter information for the current rank.
+        self.init_shared_group()
+
+        # 4. Synchronize the initialized shared parameters.
+        # When initializing the stage, perform broadcast synchronization on the shared parameters.
+        for idx, a_map in enumerate(self.shared_parameters):
+            shared_param = a_map["shared_param"]
+            if shared_param is None or not shared_param._is_initialized():
+                # Skip processing shared parameters that are not assigned to the current rank.
+                continue
+            group = a_map.get("group")
+            assert group is not None and dist.get_rank() in group.ranks
+            logger.debug(
+                f"Call `broadcast` for synchronization of Shared parameter pair at index {idx}",
+            )
+            with paddle.no_grad():
+                paddle.distributed.broadcast(
+                    shared_param._local_value(),
+                    src=group.ranks[0],
+                    group=group,
+                )
+
+    def validate_shared_parameter_pair(self):
+        # Validate shared_parameters structure.
+        assert isinstance(
+            self.shared_parameters, list
+        ), f"Expected `shared_parameters` to return a list, but got {type(self.shared_parameters).__name__}. "
+
+        # Validate every pair shard parameter.
+        for idx, a_shared_map in enumerate(self.shared_parameters):
+            # Validate map structure.
+            assert isinstance(
+                a_shared_map, dict
+            ), f"Invalid shared parameter pair: expected dict, but got {type(a_shared_map).__name__}."
+            assert len(a_shared_map) <= 3, (
+                f"shared_parameters['{idx}'] exceeds size limit (max 3 keys). "
+                f"Allowed: ['params', 'group', 'shared_param'], got: {list(a_shared_map.keys())}"
+            )
+            # Validate required 'params' entry.
+            params = a_shared_map.get("params")
+            assert (
+                params is not None
+            ), f"Missing shared parameter 'params' not found in shared_parameters['{idx}']. Available keys: {list(a_shared_map)}."
+            assert (isinstance(params, list) or tuple(params, list)) and len(
+                params
+            ) == 2, f"Shared parameter only support 2 shared parameters in list or tuple, but got {len(params)}."
+            # Validate parameter types and placements.
+            param_1, param_2 = params
+            assert isinstance(param_1, EagerParamBase) and isinstance(
+                param_2, EagerParamBase
+            ), (
+                f"Shared parameter expects parameters are 'EagerParamBase' type, but got "
+                f"'{type(param_1).__name__}' and '{type(param_2).__name__}' respectively."
+            )
+            assert param_1.placements == param_2.placements, (
+                f"Shared parameters must have identical placements for optimal performance."
+                f"But placements mismatch: {param_1.placements} vs {param_2.placements}"
+            )
+            # Validate process meshes.
+            ranks_1 = param_1.process_mesh.process_ids
+            ranks_2 = param_2.process_mesh.process_ids
+            assert len(ranks_1) == len(ranks_2)
+            assert (
+                ranks_1 != ranks_2
+            ), f"Shared parameters must be on different stage meshes, but both are on {ranks_1}."
+
+            # In VPP mode, a same shared_parameters is reused across stage builds. To avoid redundant group creation, the 'shared_param'
+            # and 'group' attributes may already exist, as they are created during the `init_shared_group` call.
+            # Validate optional 'group' entry.
+            if "group" in a_shared_map:
+                group = a_shared_map["group"]
+                assert group is None or isinstance(
+                    group, Group
+                ), f"Expected 'shared_parameters[{idx}][\"group\"]' is 'Group' or None, but got '{type(a_shared_map['group']).__name__}'."
+            # Validate optional 'sync_param' entry.
+            if "sync_param" in a_shared_map:
+                sync_param = a_shared_map["sync_param"]
+                assert sync_param is None or sync_param in list(
+                    param_1, param_2
+                ), f"Expected 'shared_parameters[{idx}][\"sync_param\"]' is one of the two params or None."
 
     def init_shared_group(self):
+        # Retrieve the parameters to be shared and the required communication group information for the current rank, and store them in
+        # the 'shared_param' and 'group' attributes of the shared_parameters respectively:
+        #   - group (Group, optional): Communication group for sharing the current parameter pair on the current rank (auto-created if missing)
+        #   - shared_param (EagerParamBase, optional): Parameter to be shared on the current rank, should be one of 'params'; if None, it means
+        #           no sharing is required on this rank. (auto-populated if missing)
         get_group_from_ranks = {}
-        for key, a_map in self.shared_param_map.items():
-            # TODO: Currently, shared parameter information relies on user input, so strict validation is required here.
-            # A more robust interface implementation is desired in the future.
-            self.check_a_shared_param_map(key, a_map)
-
+        for idx, a_map in enumerate(self.shared_parameters):
             params = a_map["params"]
             ranks_1 = params[0].process_mesh.process_ids
             ranks_2 = params[1].process_mesh.process_ids
@@ -1011,6 +1043,8 @@ class PipelineStage(_PipelineStageBase):
             for rank_1, rank_2 in zip(ranks_1, ranks_2):
                 group_ranks = tuple(sorted([rank_1, rank_2]))
                 if "group" in a_map:
+                    # In VPP mode, since `shared_parameters`` is reused across stage creations,
+                    # the 'group' may already exist, avoiding redundant group creation.
                     assert group_ranks == tuple(
                         a_map["group"].ranks
                     ), f"Shared Parameter group ranks mismatch: expected {group_ranks}, but got {a_map['group'].ranks}. "
@@ -1020,14 +1054,14 @@ class PipelineStage(_PipelineStageBase):
                             ranks=list(group_ranks)
                         )
                     if cur_rank in group_ranks:
-                        # Record communication group associated with the current rank.
+                        # Record `group` is communication group associated with the current rank.
                         a_map["group"] = get_group_from_ranks[group_ranks]
                         logger.debug(
-                            f"Build communication group {a_map['group'].name} for shared parameter `{key}` in rank {cur_rank}"
+                            f"Build communication group {a_map['group'].name} for Shared parameter pair at index {idx} in rank {cur_rank}"
                         )
 
             # Find the shared parameter on the current rank.
-            # Default no shared parameter exists on current rank.
+            # Record `shared_param` is None default no shared parameter exists on current rank.
             cur_param = None
             if cur_rank in ranks_1:
                 cur_param = params[0]
@@ -1036,30 +1070,10 @@ class PipelineStage(_PipelineStageBase):
             # Record shared parameter associated with the current rank.
             a_map["shared_param"] = cur_param
 
-    def broadcast_shared_params(self):
-        # When initializing the stage, perform broadcast synchronization
-        # on the shared parameters.
-        for key, a_map in self.shared_param_map.items():
-            shared_param = a_map["shared_param"]
-            if shared_param is None or not shared_param._is_initialized():
-                # Skip processing shared parameters that are not assigned to the current rank.
-                continue
-            group = a_map.get("group")
-            assert group is not None and dist.get_rank() in group.ranks
-            logger.debug(
-                f"Call `broadcast` for synchronization of shared parameters `{key}`",
-            )
-            with paddle.no_grad():
-                paddle.distributed.broadcast(
-                    shared_param._local_value(),
-                    src=group.ranks[0],
-                    group=group,
-                )
-
     def sync_shared_param_grads(self):
         # After the stage scheduling ends, perform allreduce synchronization
         # on the gradients of shared parameters.
-        for key, a_map in self.shared_param_map.items():
+        for idx, a_map in enumerate(self.shared_parameters):
             shared_param = a_map["shared_param"]
             if shared_param is None or not shared_param._is_initialized():
                 # Skip processing shared parameters that are not assigned to the current rank.
@@ -1067,7 +1081,7 @@ class PipelineStage(_PipelineStageBase):
             group = a_map.get("group")
             assert group is not None and dist.get_rank() in group.ranks
             logger.debug(
-                f"Call `all_reduce` for gradient synchronization of shared parameters `{key}`",
+                f"Call `all_reduce` for gradient synchronization of Shared parameter pair at index {idx}",
             )
             with paddle.no_grad():
                 paddle.distributed.all_reduce(

--- a/python/paddle/distributed/auto_parallel/pipelining/stage.py
+++ b/python/paddle/distributed/auto_parallel/pipelining/stage.py
@@ -948,6 +948,8 @@ class PipelineStage(_PipelineStageBase):
     def init_shared_group(self):
         get_group_from_ranks = {}
         for key, a_map in self.shared_param_map.items():
+            if "param" in a_map and "group" in a_map:
+                continue
             # Build identical communication groups for each rank within the mesh.
             assert (
                 "ori_mesh" in a_map and "sync_mesh" in a_map

--- a/python/paddle/distributed/auto_parallel/pipelining/stage.py
+++ b/python/paddle/distributed/auto_parallel/pipelining/stage.py
@@ -942,7 +942,10 @@ class PipelineStage(_PipelineStageBase):
     def broadcast_shared_params(self):
         # When initializing the stage, perform broadcast synchronization
         # on the shared parameters.
-        for _, a_map in self.shared_param_map.items():
+        if len(self.shared_param_map) == 0:
+            logger.debug("No shared parameters need to be processed.")
+            return
+        for key, a_map in self.shared_param_map.items():
             assert (
                 "param" in a_map
             ), "Missing 'param' key in `shared_param_map` entry"
@@ -956,6 +959,10 @@ class PipelineStage(_PipelineStageBase):
                 sync_param is not None and sync_group is not None
             ), "Shared parameter (param) or synchronization group (group) in shared_param_map is None."
             group_ranks = sorted(sync_group.ranks)
+            logger.debug(
+                "Call `broadcast` for synchronization of shared parameters `%s`",
+                key,
+            )
             with paddle.no_grad():
                 paddle.distributed.broadcast(
                     sync_param._local_value(),
@@ -966,7 +973,10 @@ class PipelineStage(_PipelineStageBase):
     def sync_shared_param_grads(self):
         # After the stage scheduling ends, perform allreduce synchronization
         # on the gradients of shared parameters.
-        for _, a_map in self.shared_param_map.items():
+        if len(self.shared_param_map) == 0:
+            logger.debug("No shared parameters need to be processed.")
+            return
+        for key, a_map in self.shared_param_map.items():
             assert (
                 "param" in a_map
             ), "Missing 'param' key in `shared_param_map` entry"
@@ -979,6 +989,10 @@ class PipelineStage(_PipelineStageBase):
             assert (
                 sync_param is not None and sync_group is not None
             ), "Shared parameter (param) or synchronization group (group) in shared_param_map is None."
+            logger.debug(
+                "Call `all_reduce` for gradient synchronization of shared parameters `%s`",
+                key,
+            )
             with paddle.no_grad():
                 paddle.distributed.all_reduce(
                     sync_param.grad._local_value(),

--- a/python/paddle/distributed/auto_parallel/pipelining/stage.py
+++ b/python/paddle/distributed/auto_parallel/pipelining/stage.py
@@ -17,15 +17,17 @@ from __future__ import annotations
 import logging
 from abc import ABC, abstractmethod
 from functools import partial
-from typing import TYPE_CHECKING, Any, Callable, Union
+from typing import Any, Callable, Union
 
 import paddle
 import paddle.distributed as dist
 from paddle import nn
+from paddle.base.framework import EagerParamBase
 from paddle.distributed.auto_parallel.api import (
     dtensor_from_local,
     dtensor_to_local,
 )
+from paddle.distributed.communication.group import Group
 
 from ._backward import stage_backward
 from .utils import (
@@ -39,10 +41,6 @@ from .utils import (
     _zero_initialize_with_meta,
     map_structure,
 )
-
-if TYPE_CHECKING:
-    from paddle.distributed.auto_parallel.process_mesh import ProcessMesh
-    from paddle.distributed.communication.group import Group
 
 logger = logging.getLogger(__name__)
 
@@ -859,14 +857,14 @@ class PipelineStage(_PipelineStageBase):
         input_args (TensorMeta|tuple[TensorMeta, ...]|None): The input arguments for the layer.
         output_args (TensorMeta|tuple[TensorMeta, ...]|None): The output arguments for the layer.
         group (Group, None): The process group for distributed training. If None, default group.
-        shared_param_map (dict[str, dict[str, paddle.Tensor | ProcessMesh]] | None): A nested dictionary containing
-            information about multiple groups of shared parameter pairs.Each entry in the dictionary maps a unique
-            identifier to a sub-dictionary. Each entry has following keys:
-                - key: Unique identifier for the shared parameter.
-                    - ori_param (paddle.Tensor): The original parameter before synchronization.
-                    - sync_param (paddle.Tensor): The synchronized parameter after communication.
-                    - ori_mesh (ProcessMesh): The process mesh of the original parameter.
-                    - sync_mesh (ProcessMesh): The process mesh of the synchronized parameter.
+        shared_param_map (dict[str, dict], optional): A dictionary that defines shared parameters between pipeline stages.
+            Each key is a unique name for a pair of shared parameters, and the corresponding value is a nested dictionary
+            with the following optional keys:
+                - params (list[EagerParamBase], required): Exact 2 parameters to share across stages.
+            In VPP mode, a same shared_param_map is reused across multiple stage builds. To avoid redundant group creation,
+            it may include:
+                - group (Group, optional): initialized sync group matching the ranks of the two shared parameters.
+                - shared_param (EagerParamBase, optional): The shared parameter instance assigned to the current rank.
     """
 
     def __init__(
@@ -877,7 +875,7 @@ class PipelineStage(_PipelineStageBase):
         input_args: TensorMeta | tuple[TensorMeta, ...] | None = None,
         output_args: TensorMeta | tuple[TensorMeta, ...] | None = None,
         group: Group | None = None,
-        shared_param_map: dict[str, dict[str, paddle.Tensor | ProcessMesh]] | None = None,  # type: ignore
+        shared_param_map: dict[str, dict] | None = None,
     ):
         super().__init__(layer, stage_index, num_stages, group)
         self.inputs: list[paddle.Tensor] | None = None
@@ -946,91 +944,136 @@ class PipelineStage(_PipelineStageBase):
 
         logger.debug(dbg_str)
 
+    def check_a_shared_param_map(self, key_name, a_shared_map):
+        # Validate map structure and key_name.
+        assert (
+            isinstance(key_name, str) and key_name.strip()
+        ), f"Invalid shared parameter pair name: expected non-empty string, but got {type(key_name).__name__} '{key_name}'."
+        assert len(a_shared_map) <= 3, (
+            f"Shared param pair '{key_name}' exceeds size limit (max 3 keys). "
+            f"Allowed: ['params', 'group', 'shared_param'], got: {list(a_shared_map)}"
+        )
+        # Validate required 'params' entry.
+        params = a_shared_map.get("params")
+        assert (
+            params is not None
+        ), f"Missing shared parameter 'params' not found in shared_param_map['{key_name}']. Available keys: {list(a_shared_map)}."
+        assert (
+            isinstance(params, list) and len(params) == 2
+        ), f"Shared parameter only support 2 shared parameters, but got {len(params)}."
+        # Validate parameter types and placements.
+        param_1, param_2 = params
+        assert isinstance(param_1, EagerParamBase) and isinstance(
+            param_2, EagerParamBase
+        ), (
+            f"Shared parameter expects parameters are 'EagerParamBase' type, but got "
+            f"'{type(param_1).__name__}' and '{type(param_2).__name__}' respectively."
+        )
+        assert param_1.placements == param_2.placements, (
+            f"Shared parameters must have identical placements for optimal performance."
+            f"But placements mismatch: {param_1.placements} vs {param_2.placements}"
+        )
+        # Validate process meshes.
+        ranks_1 = param_1.process_mesh.process_ids
+        ranks_2 = param_2.process_mesh.process_ids
+        assert len(ranks_1) == len(ranks_2)
+        assert (
+            ranks_1 != ranks_2
+        ), f"Shared parameters must be on different stage meshes, but both are on {ranks_1}."
+
+        # In VPP mode, `shared_param_map` may contain "group" and "shared_param" as it's reused for multiple stage builds.
+        # Validate optional 'group' entry.
+        if "group" in a_shared_map:
+            group = a_shared_map["group"]
+            assert group is None or isinstance(
+                group, Group
+            ), f"Expected 'shared_param_map[\"{key_name}\"][\"group\"]' is 'Group' or None, but got '{type(a_shared_map['group']).__name__}'."
+        # Validate optional 'sync_param' entry.
+        if "sync_param" in a_shared_map:
+            sync_param = a_shared_map["sync_param"]
+            assert sync_param is None or sync_param in list(
+                param_1, param_2
+            ), f"Expected 'shared_param_map[\"{key_name}\"][\"sync_param\"]' is one of the two params or None."
+
     def init_shared_group(self):
         get_group_from_ranks = {}
         for key, a_map in self.shared_param_map.items():
-            if "param" in a_map and "group" in a_map:
-                continue
-            # Build identical communication groups for each rank within the mesh.
-            assert (
-                "ori_mesh" in a_map and "sync_mesh" in a_map
-            ), "Missing 'ori_mesh' or `sync_mesh` key in `shared_param_map` entry"
-            ori_ranks = a_map["ori_mesh"].process_ids
-            sync_ranks = a_map["sync_mesh"].process_ids
-            assert len(ori_ranks) == len(sync_ranks)
-            assert (
-                ori_ranks != sync_ranks
-            ), "Shared parameters must be on different stage meshes."
+            # TODO: Currently, shared parameter information relies on user input, so strict validation is required here.
+            # A more robust interface implementation is desired in the future.
+            self.check_a_shared_param_map(key, a_map)
+
+            params = a_map["params"]
+            ranks_1 = params[0].process_mesh.process_ids
+            ranks_2 = params[1].process_mesh.process_ids
             cur_rank = dist.get_rank()
-            for ori_rank, sync_rank in zip(ori_ranks, sync_ranks):
-                group_ranks = tuple(sorted([ori_rank, sync_rank]))
-                if group_ranks not in get_group_from_ranks:
-                    get_group_from_ranks[group_ranks] = dist.new_group(
-                        ranks=list(group_ranks)
-                    )
-                if cur_rank in group_ranks:
-                    # Record communication group associated with the current rank.
-                    a_map["group"] = get_group_from_ranks[group_ranks]
-                    logger.debug(
-                        f"Build communication group {a_map['group'].name} for shared parameter `{key}` in rank {cur_rank}"
-                    )
+
+            # Build communication groups for every shared parameters pair.
+            for rank_1, rank_2 in zip(ranks_1, ranks_2):
+                group_ranks = tuple(sorted([rank_1, rank_2]))
+                if "group" in a_map:
+                    assert group_ranks == tuple(
+                        a_map["group"].ranks
+                    ), f"Shared Parameter group ranks mismatch: expected {group_ranks}, but got {a_map['group'].ranks}. "
+                else:
+                    if group_ranks not in get_group_from_ranks:
+                        get_group_from_ranks[group_ranks] = dist.new_group(
+                            ranks=list(group_ranks)
+                        )
+                    if cur_rank in group_ranks:
+                        # Record communication group associated with the current rank.
+                        a_map["group"] = get_group_from_ranks[group_ranks]
+                        logger.debug(
+                            f"Build communication group {a_map['group'].name} for shared parameter `{key}` in rank {cur_rank}"
+                        )
+
             # Find the shared parameter on the current rank.
-            assert (
-                "ori_param" in a_map and "sync_param" in a_map
-            ), "Missing 'ori_param' or `sync_param` key in `shared_param_map` entry"
-            ori_param = a_map["ori_param"]
-            sync_param = a_map["sync_param"]
             # Default no shared parameter exists on current rank.
             cur_param = None
-            if ori_param is not None and ori_param._is_initialized():
-                cur_param = ori_param
-            elif sync_param is not None and sync_param._is_initialized():
-                cur_param = sync_param
+            if cur_rank in ranks_1:
+                cur_param = params[0]
+            elif cur_rank in ranks_2:
+                cur_param = params[1]
             # Record shared parameter associated with the current rank.
-            a_map["param"] = cur_param
+            a_map["shared_param"] = cur_param
 
     def broadcast_shared_params(self):
         # When initializing the stage, perform broadcast synchronization
         # on the shared parameters.
         for key, a_map in self.shared_param_map.items():
-            if "param" not in a_map or "group" not in a_map:
+            shared_param = a_map["shared_param"]
+            if shared_param is None or not shared_param._is_initialized():
+                # Skip processing shared parameters that are not assigned to the current rank.
                 continue
-            param = a_map["param"]
-            if param is None or not param._is_initialized():
-                continue
-            sync_group = a_map["group"]
-            cur_rank = dist.get_rank()
-            assert cur_rank in sync_group.ranks
+            group = a_map.get("group")
+            assert group is not None and dist.get_rank() in group.ranks
             logger.debug(
                 f"Call `broadcast` for synchronization of shared parameters `{key}`",
             )
             with paddle.no_grad():
                 paddle.distributed.broadcast(
-                    param._local_value(),
-                    src=sync_group.ranks[0],
-                    group=sync_group,
+                    shared_param._local_value(),
+                    src=group.ranks[0],
+                    group=group,
                 )
 
     def sync_shared_param_grads(self):
         # After the stage scheduling ends, perform allreduce synchronization
         # on the gradients of shared parameters.
         for key, a_map in self.shared_param_map.items():
-            if "param" not in a_map or "group" not in a_map:
+            shared_param = a_map["shared_param"]
+            if shared_param is None or not shared_param._is_initialized():
+                # Skip processing shared parameters that are not assigned to the current rank.
                 continue
-            param = a_map["param"]
-            if param is None or not param._is_initialized():
-                continue
-            sync_group = a_map["group"]
-            cur_rank = dist.get_rank()
-            assert cur_rank in sync_group.ranks
+            group = a_map.get("group")
+            assert group is not None and dist.get_rank() in group.ranks
             logger.debug(
                 f"Call `all_reduce` for gradient synchronization of shared parameters `{key}`",
             )
             with paddle.no_grad():
                 paddle.distributed.all_reduce(
-                    param.grad._local_value(),
+                    shared_param.grad._local_value(),
                     op=paddle.distributed.ReduceOp.SUM,
-                    group=sync_group,
+                    group=group,
                 )
 
     def _shape_inference(

--- a/python/paddle/distributed/auto_parallel/pipelining/stage.py
+++ b/python/paddle/distributed/auto_parallel/pipelining/stage.py
@@ -292,6 +292,7 @@ class _PipelineStageBase(ABC):
                 return None
 
         map_structure(map_recv_to_send, args_recv_info)
+        # print("xxx Grad send info: ", self.log_prefix, grad_send_info)
 
         logger.debug("%s Grad send info: %s", self.log_prefix, grad_send_info)
         return grad_send_info
@@ -429,7 +430,7 @@ class _PipelineStageBase(ABC):
         for this stage.
         """
         recv_infos: tuple[InputInfo, ...] = self.args_recv_info[fwd_chunk_id]
-
+        # print("xxx get_fwd_recv_ops recv_infos ")
         return self._get_recv_ops(recv_infos)
 
     def get_bwd_recv_ops(self, bwd_chunk_id: int) -> list[dist.P2POp]:
@@ -439,7 +440,7 @@ class _PipelineStageBase(ABC):
         """
         if not self.has_backward or self.is_last:
             return []
-
+        # print("xxx get_bwd_recv_ops recv_infos ")
         recv_infos = self.grad_recv_info[bwd_chunk_id]
         return self._get_recv_ops(recv_infos)
 
@@ -457,6 +458,7 @@ class _PipelineStageBase(ABC):
         for idx, out in enumerate(output_tuple):
             dst_stages = self.act_send_info[idx]
             for dst in dst_stages:
+                # print("xxx get_fwd_send_ops beg, dst, out: ", idx, dst)
                 if dst is None:
                     continue
                 logger.debug(
@@ -513,6 +515,7 @@ class _PipelineStageBase(ABC):
         ops: list[dist.P2POp] = []
         grads_input = self.bwd_cache.pop(bwd_chunk_id)
         for grad, grad_recv_stage in zip(grads_input, self.grad_send_info):
+            # print("xxx get_bwd_send_ops ,grad: ", grad_recv_stage)
             if isinstance(grad, paddle.Tensor) and grad_recv_stage is not None:
                 logger.debug(
                     "%s Sending gradient to Stage %s: %s",
@@ -868,12 +871,15 @@ class PipelineStage(_PipelineStageBase):
         input_args: TensorMeta | tuple[TensorMeta, ...] | None = None,
         output_args: TensorMeta | tuple[TensorMeta, ...] | None = None,
         group: Group | None = None,
+        shared_map = None,
     ):
+        
         super().__init__(layer, stage_index, num_stages, group)
         self.inputs: list[paddle.Tensor] | None = None
         self.inputs_meta: tuple[TensorMeta, ...] | None = None
         # output's grad meta-info
         self.grads_meta: tuple[TensorMeta, ...] | None = None
+        self.shared_map = shared_map
 
         if input_args is None:
             assert output_args is None, (
@@ -926,6 +932,54 @@ class PipelineStage(_PipelineStageBase):
             dbg_str += " running shape-inference at runtime"
 
         logger.debug(dbg_str)
+
+        print("xxx self.sublayer param sum : ", len(self.sublayer.parameters()))
+        print("xxx enter PipelineStage")
+
+        for a_map in self.shared_map.values():
+            src_rank = a_map["src_rank"]
+            print("xxx src_rank : ", src_rank, self.group_rank)
+            if src_rank != self.group_rank:
+                continue
+            need_share_data = a_map["need_share_data"]
+            if not need_share_data:
+                continue
+            # sync_param = a_map["param"]
+            # peer_sync_param = a_map["peer_params"]
+            # print("xxx sync_param: ", sync_param.name, sync_param.shape, sync_param._is_initialized())
+            # print("xxx peer_sync_param: ", peer_sync_param.name, peer_sync_param.shape, peer_sync_param._is_initialized())
+            # sync_param.initialize() 
+            # peer_sync_param.initialize() 
+            # print("xxx lazy init not : ", sync_param)
+            # print("xxx lazy init not : ", peer_sync_param)
+            # sync_param._local_value().get_tensor()._share_data_with(peer_sync_param._local_value().get_tensor())
+
+
+
+        # for param in self.sublayer.parameters(): 
+        #     # print("xxx stage param: ", param.name, param._is_initialized())
+
+        #     for a_map in self.shared_map:
+        #         param_name = a_map["param_name"]
+        #     if self.shared_map is not None and  param.name in shared_map:
+        #         print("xxx find shared params")
+        #         print("xxx embedding weight: ", shared_map[param.name]._is_initialized())
+        #         print("xxx lmhead weight: ", param._is_initialized())
+        #         print("xxx embedding weight: ", shared_map[param.name])
+        #         # shared_map[param.name].get_tensor()._share_data_with(param)
+        #         print("xxx param type : ", type(param))
+        #         print("xxx param.get_tensor() type : ", type(param.get_tensor()))
+        #         # param.get_tensor()._share_data_with(shared_map[param.name].get_tensor())
+        #         # param.get_tensor()._share_data_nocheck_with(shared_map[param.name].get_tensor())
+        #         # _share_data_nocheck_with
+
+        print("xxx self.sublayer param sum : ", len(self.sublayer.parameters()))
+
+    def need_sync_params(self):
+        return len(self.shared_map) == 0
+
+    def get_shared_map(self):
+        return self.shared_map
 
     def _shape_inference(
         self,
@@ -1206,8 +1260,12 @@ class PipelineStage(_PipelineStageBase):
         self.clear_runtime_states()
         # Clear grads of the stage.
         for param in self.sublayer.parameters():
+            # print("xxx _prepare_backward_infra param: ", param.name)
             param.clear_grad()
         return grads
+
+    def get_stage_parameters(self) -> list[Parameter]:
+        return self.sublayer.parameters()
 
     def _create_grad_recv_info(
         self,

--- a/python/paddle/distributed/auto_parallel/pipelining/stage.py
+++ b/python/paddle/distributed/auto_parallel/pipelining/stage.py
@@ -880,7 +880,7 @@ class PipelineStage(_PipelineStageBase):
 
         # Synchronize shared parameters on the current rank.
         self.shared_parameters = shared_parameters
-        self.sync_shared_param()
+        self._sync_shared_param()
 
         if input_args is None:
             assert output_args is None, (
@@ -934,19 +934,19 @@ class PipelineStage(_PipelineStageBase):
 
         logger.debug(dbg_str)
 
-    def sync_shared_param(self):
+    def _sync_shared_param(self):
         if self.shared_parameters is None:
             # 1. Default no shared parameters to process.
             self.shared_parameters = {}
             return
 
         # 2. Validate parameters.
-        # TODO: Currently, shared parameter information relies on user input, so strict validation is required here.
+        # TODO(xuexixi): Currently, shared parameter information relies on user input, so strict validation is required here.
         # A more robust interface implementation is desired in the future.
-        self.validate_shared_parameter_pair()
+        self._validate_shared_parameter_pair()
 
         # 3. Build shared parameter information for the current rank.
-        self.init_shared_group()
+        self._init_shared_group()
 
         # 4. Synchronize the initialized shared parameters.
         # When initializing the stage, perform broadcast synchronization on the shared parameters.
@@ -967,7 +967,7 @@ class PipelineStage(_PipelineStageBase):
                     group=group,
                 )
 
-    def validate_shared_parameter_pair(self):
+    def _validate_shared_parameter_pair(self):
         # Validate shared_parameters structure.
         assert isinstance(
             self.shared_parameters, list
@@ -1012,7 +1012,7 @@ class PipelineStage(_PipelineStageBase):
             ), f"Shared parameters must be on different stage meshes, but both are on {ranks_1}."
 
             # In VPP mode, a same shared_parameters is reused across stage builds. To avoid redundant group creation, the 'shared_param'
-            # and 'group' attributes may already exist, as they are created during the `init_shared_group` call.
+            # and 'group' attributes may already exist, as they are created during the `_init_shared_group` call.
             # Validate optional 'group' entry.
             if "group" in a_shared_map:
                 group = a_shared_map["group"]
@@ -1026,7 +1026,7 @@ class PipelineStage(_PipelineStageBase):
                     param_1, param_2
                 ), f"Expected 'shared_parameters[{idx}][\"sync_param\"]' is one of the two params or None."
 
-    def init_shared_group(self):
+    def _init_shared_group(self):
         # Retrieve the parameters to be shared and the required communication group information for the current rank, and store them in
         # the 'shared_param' and 'group' attributes of the shared_parameters respectively:
         #   - group (Group, optional): Communication group for sharing the current parameter pair on the current rank (auto-created if missing)
@@ -1045,9 +1045,10 @@ class PipelineStage(_PipelineStageBase):
                 if "group" in a_map:
                     # In VPP mode, since `shared_parameters`` is reused across stage creations,
                     # the 'group' may already exist, avoiding redundant group creation.
-                    assert group_ranks == tuple(
-                        a_map["group"].ranks
-                    ), f"Shared Parameter group ranks mismatch: expected {group_ranks}, but got {a_map['group'].ranks}. "
+                    if cur_rank in group_ranks:
+                        assert group_ranks == tuple(
+                            a_map["group"].ranks
+                        ), f"Shared Parameter group ranks mismatch: expected {group_ranks}, but got {a_map['group'].ranks}. "
                 else:
                     if group_ranks not in get_group_from_ranks:
                         get_group_from_ranks[group_ranks] = dist.new_group(
@@ -1070,7 +1071,7 @@ class PipelineStage(_PipelineStageBase):
             # Record shared parameter associated with the current rank.
             a_map["shared_param"] = cur_param
 
-    def sync_shared_param_grads(self):
+    def _sync_shared_param_grads(self):
         # After the stage scheduling ends, perform allreduce synchronization
         # on the gradients of shared parameters.
         for idx, a_map in enumerate(self.shared_parameters):

--- a/python/paddle/distributed/auto_parallel/pipelining/stage.py
+++ b/python/paddle/distributed/auto_parallel/pipelining/stage.py
@@ -41,6 +41,7 @@ from .utils import (
 )
 
 if TYPE_CHECKING:
+    from paddle.distributed.auto_parallel.process_mesh import ProcessMesh
     from paddle.distributed.communication.group import Group
 
 logger = logging.getLogger(__name__)
@@ -858,14 +859,14 @@ class PipelineStage(_PipelineStageBase):
         input_args (TensorMeta|tuple[TensorMeta, ...]|None): The input arguments for the layer.
         output_args (TensorMeta|tuple[TensorMeta, ...]|None): The output arguments for the layer.
         group (Group, None): The process group for distributed training. If None, default group.
-        shared_param_map (dict[str, dict[str, paddle.Tensor | paddle.distributed.collective.Group]] | None): A nested
-            dictionary containing information about multiple groups of shared parameter pairs.
-            Each entry in the dictionary maps a unique identifier to a sub-dictionary. Each entry has following keys:
+        shared_param_map (dict[str, dict[str, paddle.Tensor | ProcessMesh]] | None): A nested dictionary containing
+            information about multiple groups of shared parameter pairs.Each entry in the dictionary maps a unique
+            identifier to a sub-dictionary. Each entry has following keys:
                 - key: Unique identifier for the shared parameter.
                     - ori_param (paddle.Tensor): The original parameter before synchronization.
                     - sync_param (paddle.Tensor): The synchronized parameter after communication.
-                    - ori_mesh (paddle.distributed.collective.Group): The process mesh of the original parameter.
-                    - sync_mesh (paddle.distributed.collective.Group): The process mesh of the synchronized parameter.
+                    - ori_mesh (ProcessMesh): The process mesh of the original parameter.
+                    - sync_mesh (ProcessMesh): The process mesh of the synchronized parameter.
     """
 
     def __init__(
@@ -876,7 +877,7 @@ class PipelineStage(_PipelineStageBase):
         input_args: TensorMeta | tuple[TensorMeta, ...] | None = None,
         output_args: TensorMeta | tuple[TensorMeta, ...] | None = None,
         group: Group | None = None,
-        shared_param_map: dict[str, dict[str, paddle.Tensor | paddle.distributed.collective.Group]] | None = None,  # type: ignore
+        shared_param_map: dict[str, dict[str, paddle.Tensor | ProcessMesh]] | None = None,  # type: ignore
     ):
         super().__init__(layer, stage_index, num_stages, group)
         self.inputs: list[paddle.Tensor] | None = None

--- a/python/paddle/distributed/auto_parallel/pipelining/stage.py
+++ b/python/paddle/distributed/auto_parallel/pipelining/stage.py
@@ -859,8 +859,10 @@ class PipelineStage(_PipelineStageBase):
         output_args (TensorMeta|tuple[TensorMeta, ...]|None): The output arguments for the layer.
         group (Group, None): The process group for distributed training. If None, default group.
         shared_param_map (dict[str, dict[str, paddle.Tensor | paddle.distributed.collective.Group]] | None): A description
-            for shared parameter pairs. Each pair of shared parameters includes a unique identifier for the shared parameter,
-            the shared model parameter tensor, and the process group for synchronization operations.
+            of information for multiple groups of shared parameter pairs. Each entry contains:
+                - key: Unique identifier for the shared parameter.
+                    - param: The shared model parameter tensor.
+                    - group: The process group for synchronization operations.
     """
 
     def __init__(
@@ -941,6 +943,13 @@ class PipelineStage(_PipelineStageBase):
         # When initializing the stage, perform broadcast synchronization
         # on the shared parameters.
         for _, a_map in self.shared_param_map.items():
+            assert (
+                "param" in a_map
+            ), "Missing 'param' key in `shared_param_map` entry"
+            assert (
+                "group" in a_map
+            ), "Missing 'group' key in `shared_param_map` entry"
+
             sync_param = a_map["param"]
             sync_group = a_map["group"]
             assert (
@@ -958,6 +967,13 @@ class PipelineStage(_PipelineStageBase):
         # After the stage scheduling ends, perform allreduce synchronization
         # on the gradients of shared parameters.
         for _, a_map in self.shared_param_map.items():
+            assert (
+                "param" in a_map
+            ), "Missing 'param' key in `shared_param_map` entry"
+            assert (
+                "group" in a_map
+            ), "Missing 'group' key in `shared_param_map` entry"
+
             sync_param = a_map["param"]
             sync_group = a_map["group"]
             assert (

--- a/python/paddle/distributed/auto_parallel/pipelining/stage.py
+++ b/python/paddle/distributed/auto_parallel/pipelining/stage.py
@@ -963,7 +963,7 @@ class PipelineStage(_PipelineStageBase):
                     group=sync_group,
                 )
 
-    def sync_shared_params(self):
+    def sync_shared_param_grads(self):
         # After the stage scheduling ends, perform allreduce synchronization
         # on the gradients of shared parameters.
         for _, a_map in self.shared_param_map.items():

--- a/test/auto_parallel/CMakeLists.txt
+++ b/test/auto_parallel/CMakeLists.txt
@@ -192,6 +192,7 @@ if(WITH_DISTRIBUTE AND WITH_GPU)
     FLAGS_embedding_deterministic=1
     NVIDIA_TF32_OVERRIDE=0)
   py_test_modules(test_PP_Schedules MODULES test_PP_Schedules)
+  py_test_modules(test_PP_shared_parameters MODULES test_PP_shared_parameters)
   py_test_modules(
     test_context_parallel
     MODULES

--- a/test/auto_parallel/CMakeLists.txt
+++ b/test/auto_parallel/CMakeLists.txt
@@ -192,7 +192,8 @@ if(WITH_DISTRIBUTE AND WITH_GPU)
     FLAGS_embedding_deterministic=1
     NVIDIA_TF32_OVERRIDE=0)
   py_test_modules(test_PP_Schedules MODULES test_PP_Schedules)
-  py_test_modules(test_PP_shared_parameters MODULES test_PP_shared_parameters)
+  py_test_modules(test_pipeline_sync_shared_parameters MODULES
+                  test_pipeline_sync_shared_parameters)
   py_test_modules(
     test_context_parallel
     MODULES

--- a/test/auto_parallel/pipeline_sync_shared_parameters_unittest.py
+++ b/test/auto_parallel/pipeline_sync_shared_parameters_unittest.py
@@ -1,0 +1,307 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import random
+
+import numpy as np
+
+import paddle
+import paddle.distributed as dist
+from paddle import nn
+from paddle.distributed import fleet
+from paddle.distributed.auto_parallel.pipelining.schedules import (
+    ScheduleFThenB,
+)
+from paddle.distributed.auto_parallel.pipelining.stage import PipelineStage
+from paddle.io import DataLoader, Dataset
+
+
+def fix_seeds(seed=2025):
+    """Fix random seeds to ensure reproducibility"""
+    paddle.seed(seed)
+    random.seed(seed)
+    np.random.seed(seed)
+
+
+class PPMyModel(nn.Layer):
+    def __init__(self, name_prefix="", shared_param_map={}):
+        super().__init__(name_scope=name_prefix)
+        self.name_prefix = name_prefix
+        self.mesh = paddle.distributed.ProcessMesh(
+            [0, 1, 2, 3], dim_names=["pp"]
+        )
+        self.num_layers = 8
+        self.num_layers_per_card = self.num_layers // 4
+        self.shared_param_map = shared_param_map
+
+        self.linears = nn.LayerList()
+        for i in range(self.num_layers):
+            linear = nn.Linear(8, 8, bias_attr=False)
+
+            linear.weight.name = f"{self.name_prefix}_linear_{i}_weight"
+
+            # Mark network parameters
+            linear.weight = dist.shard_tensor(
+                linear.weight,
+                self.get_pp_mesh(i),
+                [dist.Replicate()],
+            )
+
+            self.linears.append(linear)
+
+        self.set_shared_param()
+
+    def set_shared_param(self):
+        for _, pair in self.shared_param_map.items():
+            assert len(pair) == 2
+            ori_name = pair[0]
+            sync_name = pair[1]
+            ori_weight_idx = -1
+            sync_weight_idx = -1
+            for idx, linear in enumerate(self.linears):
+                if ori_name == linear.weight.name:
+                    ori_weight_idx = idx
+                elif sync_name == linear.weight.name:
+                    sync_weight_idx = idx
+            assert ori_weight_idx != -1 and sync_weight_idx != -1
+            self.linears[sync_weight_idx].weight = self.linears[
+                ori_weight_idx
+            ].weight
+
+    def get_pp_mesh(self, layer_index):
+        # layer_index=0-3 corresponds to mesh_idx 0,0,1,1,2,2,3,3
+        mesh_idx = int(layer_index / (self.num_layers / 4))
+        return self.mesh[mesh_idx]
+
+    def forward(self, x):
+        x.stop_gradient = False
+        out = x
+        for i in range(self.num_layers):
+            # Mark intermediate variables, reshard when switching devices
+            cur_mesh = self.get_pp_mesh(i)
+            if i % self.num_layers_per_card == 0 and i > 0:
+                out = dist.reshard(out, cur_mesh, [dist.Replicate()])
+            if self.linears[i].weight.process_mesh != cur_mesh:
+                y = dist.reshard(
+                    self.linears[i].weight, cur_mesh, [dist.Replicate()]
+                )
+                out = paddle.matmul(out, y)
+            else:
+                out = self.linears[i](out)
+        return paddle.cast(out, 'float32')
+
+
+class SingleStage(nn.Layer):
+    def __init__(self, layers):
+        super().__init__()
+        self.layers = layers
+
+    def forward(self, x):
+        x.stop_gradient = False
+        out = x
+        for i in range(len(self.layers)):
+            out = self.layers[i](out)
+        return paddle.cast(out, 'float32')
+
+
+class RandomDataset(Dataset):
+    def __init__(self, image_size, output_size, num_samples=1):
+        super().__init__()
+        self.image_size = image_size
+        self.num_samples = num_samples
+        self.output_size = output_size
+
+    def __getitem__(self, index):
+        input = paddle.rand([self.image_size], dtype='float32')
+        label = paddle.rand([self.output_size], dtype='float32')
+        return input, label
+
+    def __len__(self):
+        return self.num_samples
+
+
+def _get_param_from_name(param_name, model):
+    for param in model.parameters():
+        if param.name == param_name:
+            return param
+    return None
+
+
+def _build_current_sync_commm_group(ranks_1, ranks_2, get_group_from_ranks):
+    cur_rank = paddle.distributed.get_rank()
+    cur_group = None
+    assert len(ranks_1) == len(ranks_2)
+    for idx in range(len(ranks_1)):
+        group_ranks = tuple(sorted([ranks_1[idx], ranks_2[idx]]))
+        if group_ranks not in get_group_from_ranks:
+            new_group = dist.new_group(ranks=list(group_ranks))
+            get_group_from_ranks[group_ranks] = new_group
+        if cur_rank in group_ranks:
+            cur_group = get_group_from_ranks[group_ranks]
+    return cur_group
+
+
+def build_shared_param_map(shared_params_names, model):
+    shared_mp = {}
+    get_group_from_ranks = {}
+    cur_rank = paddle.distributed.get_rank()
+    for key, pair in shared_params_names.items():
+        assert len(pair) == 2
+        ori_name = pair[0]
+        sync_name = pair[1]
+        ori_param = _get_param_from_name(ori_name, model)
+        sync_param = _get_param_from_name(sync_name, model)
+        assert ori_param is not None and sync_param is not None
+        ori_process_ids = ori_param.process_mesh.process_ids
+        sync_process_ids = sync_param.process_mesh.process_ids
+        cur_group = _build_current_sync_commm_group(
+            ori_process_ids, sync_process_ids, get_group_from_ranks
+        )
+        cur_param = None
+        if cur_rank in ori_process_ids:
+            cur_param = ori_param
+        elif cur_rank in sync_process_ids:
+            cur_param = sync_param
+        if cur_param is not None and cur_group is not None:
+            shared_mp[key] = {
+                "param": cur_param,
+                "group": cur_group,
+            }
+    return shared_mp
+
+
+rtol = 1e-2
+
+
+class TestSharedParameters:
+    @classmethod
+    def setUpClass(cls):
+        """Initialize test class setup"""
+        paddle.distributed.init_parallel_env()
+        cls.group = paddle.distributed.new_group([0, 1, 2, 3])
+        cls.rank = dist.get_rank()
+        cls.mesh = paddle.distributed.ProcessMesh(
+            [0, 1, 2, 3], dim_names=["pp"]
+        )
+        fleet.auto.set_mesh(cls.mesh)
+
+    def test_ScheduleFThenB(self):
+        fix_seeds()
+        name_prefix = "ScheduleFThenB"
+        self.model = PPMyModel(name_prefix=name_prefix)
+
+        self.micro_batches = 8
+        shared_params_names = {
+            "gpt_shared_weight": [
+                f"{name_prefix}_linear_0_weight.dist",
+                f"{name_prefix}_linear_7_weight.dist",
+            ]
+        }
+        shared_mp = build_shared_param_map(shared_params_names, self.model)
+
+        num_layers_per_card = 2
+        cur_rank = dist.get_rank()
+        stage_layers = SingleStage(
+            self.model.linears[
+                cur_rank
+                * num_layers_per_card : (cur_rank + 1)
+                * num_layers_per_card
+            ]
+        )
+
+        self.stage = PipelineStage(
+            stage_layers,
+            self.rank,
+            4,
+            group=self.group,
+            shared_param_map=shared_mp,
+        )
+
+        self.stage.has_backward = True
+        loss_fn_ = nn.MSELoss()
+        schedule = ScheduleFThenB(
+            self.stage, self.micro_batches, loss_fn=loss_fn_
+        )
+        opt = paddle.optimizer.AdamW(
+            learning_rate=0.001, parameters=self.model.parameters()
+        )
+        dataset = RandomDataset(image_size=8, output_size=8, num_samples=8)
+        loader = DataLoader(dataset, batch_size=8)
+        losses_by_step = []
+        num_iterations = 4
+
+        for _ in range(num_iterations):
+            losses_by_micro_batch = []
+            for _, (data, label) in enumerate(loader):
+                schedule.step(data, target=label, losses=losses_by_micro_batch)
+                if self.rank == 3:
+                    losses_by_step.append(
+                        np.array(losses_by_micro_batch, dtype=np.float32).mean()
+                    )
+            opt.step()
+            opt.clear_grad()
+        return losses_by_step
+
+    def test_pp_model(self):
+        """Test pipeline parallel model using PPMyModel as the baseline"""
+        fix_seeds()
+        name_prefix = "pp_model"
+        shared_params_names = {
+            "gpt_shared_weight": [
+                f"{name_prefix}_linear_0_weight.dist",
+                f"{name_prefix}_linear_7_weight.dist",
+            ]
+        }
+        pp_model = PPMyModel(
+            name_prefix=name_prefix, shared_param_map=shared_params_names
+        )
+        opt = paddle.optimizer.AdamW(
+            learning_rate=0.001, parameters=pp_model.parameters()
+        )
+        loss_fn = nn.MSELoss()
+        dataset = RandomDataset(image_size=8, output_size=8, num_samples=8)
+        loader = DataLoader(dataset, batch_size=1)
+        pp_losses_step = []
+        num_iterations = 4
+
+        for _ in range(num_iterations):
+            pp_losses_micro_batch = []
+            for _, (data, label) in enumerate(loader):
+                output = pp_model(data)
+                loss = loss_fn(output, label)
+                pp_losses_micro_batch.append(loss.item())
+                loss.backward()
+            pp_losses_step.append(
+                np.array(pp_losses_micro_batch, dtype=np.float32).mean()
+            )
+            opt.step()
+            opt.clear_grad()
+        return pp_losses_step
+
+    def run_test(self):
+        """Compare losses between three training methods"""
+        self.setUpClass()
+        scheduleFThenB_losses = self.test_ScheduleFThenB()
+        pp_losses = self.test_pp_model()
+
+        if self.rank == 3:
+            np.testing.assert_allclose(
+                pp_losses,
+                scheduleFThenB_losses,
+                rtol=rtol,
+            )
+
+
+if __name__ == '__main__':
+    TestSharedParameters().run_test()

--- a/test/auto_parallel/pipeline_sync_shared_parameters_unittest.py
+++ b/test/auto_parallel/pipeline_sync_shared_parameters_unittest.py
@@ -152,7 +152,7 @@ def _get_param_from_name(param_name, model):
 
 
 def build_shared_param_map(shared_params_names, model):
-    # Find the two shared parameters and their process meshes based on parameter names.
+    # Find the two shared parameters and build shared parameter information.
     shared_mp = {}
     for key, pair in shared_params_names.items():
         assert len(pair) == 2
@@ -160,14 +160,8 @@ def build_shared_param_map(shared_params_names, model):
         sync_name = pair[1]
         ori_param = _get_param_from_name(ori_name, model)
         sync_param = _get_param_from_name(sync_name, model)
-        ori_mesh = ori_param.process_mesh
-        sync_mesh = sync_param.process_mesh
-        shared_mp[key] = {
-            "ori_param": ori_param,
-            "sync_param": sync_param,
-            "ori_mesh": ori_mesh,
-            "sync_mesh": sync_mesh,
-        }
+        # Note: Users must strictly maintain the format of the data structure here.
+        shared_mp[key] = {"params": [ori_param, sync_param]}
     return shared_mp
 
 
@@ -194,11 +188,12 @@ class TestSharedParameters:
 
         self.micro_batches = 8
         shared_params_names = {
-            "gpt_shared_weight": [
+            "embedding_shared_weight": [
                 f"{name_prefix}_linear_0_weight.dist",
                 f"{name_prefix}_linear_7_weight.dist",
             ]
         }
+        # Pre-build shared parameter information.
         shared_mp = build_shared_param_map(shared_params_names, self.model)
 
         num_layers_per_card = 2
@@ -264,11 +259,12 @@ class TestSharedParameters:
         self.stage_list = []
 
         shared_params_names = {
-            "gpt_shared_weight": [
+            "embedding_shared_weight": [
                 f"{name_prefix}_linear_0_weight.dist",
                 f"{name_prefix}_linear_7_weight.dist",
             ]
         }
+        # Pre-build shared parameter information.
         shared_mp = build_shared_param_map(shared_params_names, self.model)
 
         cur_rank = dist.get_rank()
@@ -276,6 +272,8 @@ class TestSharedParameters:
             stage_layers = SingleStage(
                 self.model.linears[cur_rank + i * 4 : cur_rank + i * 4 + 1]
             )
+            # Note: In VPP mode, the same `shared_mp` is used for building multiple
+            # stages to avoid redundant group creation.
             self.stage_list.append(
                 PipelineStage(
                     stage_layers,
@@ -316,7 +314,7 @@ class TestSharedParameters:
         fix_seeds()
         name_prefix = "pp_model"
         shared_params_names = {
-            "gpt_shared_weight": [
+            "embedding_shared_weight": [
                 f"{name_prefix}_linear_0_weight.dist",
                 f"{name_prefix}_linear_7_weight.dist",
             ]

--- a/test/auto_parallel/pipeline_sync_shared_parameters_unittest.py
+++ b/test/auto_parallel/pipeline_sync_shared_parameters_unittest.py
@@ -151,46 +151,23 @@ def _get_param_from_name(param_name, model):
     return None
 
 
-def _build_current_sync_commm_group(ranks_1, ranks_2, get_group_from_ranks):
-    cur_rank = paddle.distributed.get_rank()
-    cur_group = None
-    assert len(ranks_1) == len(ranks_2)
-    for idx in range(len(ranks_1)):
-        group_ranks = tuple(sorted([ranks_1[idx], ranks_2[idx]]))
-        if group_ranks not in get_group_from_ranks:
-            new_group = dist.new_group(ranks=list(group_ranks))
-            get_group_from_ranks[group_ranks] = new_group
-        if cur_rank in group_ranks:
-            cur_group = get_group_from_ranks[group_ranks]
-    return cur_group
-
-
 def build_shared_param_map(shared_params_names, model):
+    # Find the two shared parameters and their process meshes based on parameter names.
     shared_mp = {}
-    get_group_from_ranks = {}
-    cur_rank = paddle.distributed.get_rank()
     for key, pair in shared_params_names.items():
         assert len(pair) == 2
         ori_name = pair[0]
         sync_name = pair[1]
         ori_param = _get_param_from_name(ori_name, model)
         sync_param = _get_param_from_name(sync_name, model)
-        assert ori_param is not None and sync_param is not None
-        ori_process_ids = ori_param.process_mesh.process_ids
-        sync_process_ids = sync_param.process_mesh.process_ids
-        cur_group = _build_current_sync_commm_group(
-            ori_process_ids, sync_process_ids, get_group_from_ranks
-        )
-        cur_param = None
-        if cur_rank in ori_process_ids:
-            cur_param = ori_param
-        elif cur_rank in sync_process_ids:
-            cur_param = sync_param
-        if cur_param is not None and cur_group is not None:
-            shared_mp[key] = {
-                "param": cur_param,
-                "group": cur_group,
-            }
+        ori_mesh = ori_param.process_mesh
+        sync_mesh = sync_param.process_mesh
+        shared_mp[key] = {
+            "ori_param": ori_param,
+            "sync_param": sync_param,
+            "ori_mesh": ori_mesh,
+            "sync_mesh": sync_mesh,
+        }
     return shared_mp
 
 

--- a/test/auto_parallel/pipeline_sync_shared_parameters_unittest.py
+++ b/test/auto_parallel/pipeline_sync_shared_parameters_unittest.py
@@ -21,7 +21,9 @@ import paddle.distributed as dist
 from paddle import nn
 from paddle.distributed import fleet
 from paddle.distributed.auto_parallel.pipelining.schedules import (
+    Schedule1F1B,
     ScheduleFThenB,
+    ScheduleVPP,
 )
 from paddle.distributed.auto_parallel.pipelining.stage import PipelineStage
 from paddle.io import DataLoader, Dataset
@@ -34,8 +36,8 @@ def fix_seeds(seed=2025):
     np.random.seed(seed)
 
 
-class PPMyModel(nn.Layer):
-    def __init__(self, name_prefix="", shared_param_map={}):
+class PPModel(nn.Layer):
+    def __init__(self, name_prefix="", schedule="FThenB", shared_param_map={}):
         super().__init__(name_scope=name_prefix)
         self.name_prefix = name_prefix
         self.mesh = paddle.distributed.ProcessMesh(
@@ -54,11 +56,17 @@ class PPMyModel(nn.Layer):
             # Mark network parameters
             linear.weight = dist.shard_tensor(
                 linear.weight,
-                self.get_pp_mesh(i),
+                (
+                    self.get_pp_mesh(i)
+                    if schedule != "VPP"
+                    else self.get_vpp_mesh(i)
+                ),
                 [dist.Replicate()],
             )
 
             self.linears.append(linear)
+
+        self.model_shared_param_mp = {}
 
         self.set_shared_param()
 
@@ -75,13 +83,16 @@ class PPMyModel(nn.Layer):
                 elif sync_name == linear.weight.name:
                     sync_weight_idx = idx
             assert ori_weight_idx != -1 and sync_weight_idx != -1
-            self.linears[sync_weight_idx].weight = self.linears[
+            self.model_shared_param_mp[sync_name] = self.linears[
                 ori_weight_idx
             ].weight
 
     def get_pp_mesh(self, layer_index):
-        # layer_index=0-3 corresponds to mesh_idx 0,0,1,1,2,2,3,3
         mesh_idx = int(layer_index / (self.num_layers / 4))
+        return self.mesh[mesh_idx]
+
+    def get_vpp_mesh(self, layer_index):
+        mesh_idx = int(layer_index % 4)
         return self.mesh[mesh_idx]
 
     def forward(self, x):
@@ -92,11 +103,14 @@ class PPMyModel(nn.Layer):
             cur_mesh = self.get_pp_mesh(i)
             if i % self.num_layers_per_card == 0 and i > 0:
                 out = dist.reshard(out, cur_mesh, [dist.Replicate()])
-            if self.linears[i].weight.process_mesh != cur_mesh:
-                y = dist.reshard(
-                    self.linears[i].weight, cur_mesh, [dist.Replicate()]
+            weight = self.linears[i].weight
+            if weight.name in self.model_shared_param_mp:
+                weight = dist.reshard(
+                    self.model_shared_param_mp[weight.name],
+                    cur_mesh,
+                    [dist.Replicate()],
                 )
-                out = paddle.matmul(out, y)
+                out = paddle.matmul(out, weight)
             else:
                 out = self.linears[i](out)
         return paddle.cast(out, 'float32')
@@ -181,7 +195,7 @@ def build_shared_param_map(shared_params_names, model):
     return shared_mp
 
 
-rtol = 1e-2
+rtol = 1e-5
 
 
 class TestSharedParameters:
@@ -196,10 +210,10 @@ class TestSharedParameters:
         )
         fleet.auto.set_mesh(cls.mesh)
 
-    def test_ScheduleFThenB(self):
+    def test_single_schedule(self, sing_schedule="FThenB"):
         fix_seeds()
-        name_prefix = "ScheduleFThenB"
-        self.model = PPMyModel(name_prefix=name_prefix)
+        name_prefix = "pp_" + sing_schedule
+        self.model = PPModel(name_prefix=name_prefix)
 
         self.micro_batches = 8
         shared_params_names = {
@@ -230,16 +244,26 @@ class TestSharedParameters:
 
         self.stage.has_backward = True
         loss_fn_ = nn.MSELoss()
-        schedule = ScheduleFThenB(
-            self.stage, self.micro_batches, loss_fn=loss_fn_
-        )
+        if sing_schedule == "FThenB":
+            schedule = ScheduleFThenB(
+                self.stage, self.micro_batches, loss_fn=loss_fn_
+            )
+        elif sing_schedule == "1F1B":
+            schedule = Schedule1F1B(
+                self.stage, self.micro_batches, loss_fn=loss_fn_
+            )
+        else:
+            raise ValueError(
+                f"Unknown schedule type: {sing_schedule}. "
+                f"Currently `test_single_schedule` supported types are 'FThenB' and '1F1B'."
+            )
         opt = paddle.optimizer.AdamW(
             learning_rate=0.001, parameters=self.model.parameters()
         )
         dataset = RandomDataset(image_size=8, output_size=8, num_samples=8)
         loader = DataLoader(dataset, batch_size=8)
         losses_by_step = []
-        num_iterations = 4
+        num_iterations = 20
 
         for _ in range(num_iterations):
             losses_by_micro_batch = []
@@ -253,8 +277,64 @@ class TestSharedParameters:
             opt.clear_grad()
         return losses_by_step
 
+    def test_multi_schedule(self, multi_schedule="VPP"):
+        fix_seeds()
+        name_prefix = "pp_" + multi_schedule
+        self.model = PPModel(name_prefix=name_prefix, schedule="VPP")
+        self.local_stages = 2
+        self.micro_batches = 8
+        self.stage_list = []
+
+        shared_params_names = {
+            "gpt_shared_weight": [
+                f"{name_prefix}_linear_0_weight.dist",
+                f"{name_prefix}_linear_7_weight.dist",
+            ]
+        }
+        shared_mp = build_shared_param_map(shared_params_names, self.model)
+
+        cur_rank = dist.get_rank()
+        for i in range(self.local_stages):
+            stage_layers = SingleStage(
+                self.model.linears[cur_rank + i * 4 : cur_rank + i * 4 + 1]
+            )
+            self.stage_list.append(
+                PipelineStage(
+                    stage_layers,
+                    cur_rank + i * 4,
+                    8,
+                    group=self.group,
+                    shared_param_map=shared_mp,
+                )
+            )
+            self.stage_list[i].has_backward = True
+
+        loss_fn_ = nn.MSELoss()
+        schedule = ScheduleVPP(
+            self.stage_list, self.micro_batches, loss_fn=loss_fn_
+        )
+        opt = paddle.optimizer.AdamW(
+            learning_rate=0.001, parameters=self.model.parameters()
+        )
+        dataset = RandomDataset(image_size=8, output_size=8, num_samples=8)
+        loader = DataLoader(dataset, batch_size=8)
+        losses_by_micro_batch = []
+        losses_by_step = []
+        num_iterations = 20
+
+        for _ in range(num_iterations):
+            for _, (data, label) in enumerate(loader):
+                schedule.step(data, target=label, losses=losses_by_micro_batch)
+                if self.rank == 3:
+                    losses_by_step.append(
+                        np.array(losses_by_micro_batch, dtype=np.float32).mean()
+                    )
+            opt.step()
+            opt.clear_grad()
+        return losses_by_step
+
     def test_pp_model(self):
-        """Test pipeline parallel model using PPMyModel as the baseline"""
+        """Test pipeline parallel model using PPModel as the baseline"""
         fix_seeds()
         name_prefix = "pp_model"
         shared_params_names = {
@@ -263,7 +343,7 @@ class TestSharedParameters:
                 f"{name_prefix}_linear_7_weight.dist",
             ]
         }
-        pp_model = PPMyModel(
+        pp_model = PPModel(
             name_prefix=name_prefix, shared_param_map=shared_params_names
         )
         opt = paddle.optimizer.AdamW(
@@ -273,7 +353,7 @@ class TestSharedParameters:
         dataset = RandomDataset(image_size=8, output_size=8, num_samples=8)
         loader = DataLoader(dataset, batch_size=1)
         pp_losses_step = []
-        num_iterations = 4
+        num_iterations = 20
 
         for _ in range(num_iterations):
             pp_losses_micro_batch = []
@@ -290,15 +370,27 @@ class TestSharedParameters:
         return pp_losses_step
 
     def run_test(self):
-        """Compare losses between three training methods"""
+        """Compare shared params losses between three training methods"""
         self.setUpClass()
-        scheduleFThenB_losses = self.test_ScheduleFThenB()
         pp_losses = self.test_pp_model()
+        pp_FThenB_losses = self.test_single_schedule(sing_schedule="FThenB")
+        pp_1F1B_losses = self.test_single_schedule(sing_schedule="1F1B")
+        pp_vpp_losses = self.test_multi_schedule(multi_schedule="VPP")
 
         if self.rank == 3:
             np.testing.assert_allclose(
                 pp_losses,
-                scheduleFThenB_losses,
+                pp_FThenB_losses,
+                rtol=rtol,
+            )
+            np.testing.assert_allclose(
+                pp_losses,
+                pp_1F1B_losses,
+                rtol=rtol,
+            )
+            np.testing.assert_allclose(
+                pp_losses,
+                pp_vpp_losses,
                 rtol=rtol,
             )
 

--- a/test/auto_parallel/pipeline_sync_shared_parameters_unittest.py
+++ b/test/auto_parallel/pipeline_sync_shared_parameters_unittest.py
@@ -153,7 +153,7 @@ def _get_param_from_name(param_name, model):
 
 def build_shared_parameters(shared_params_names, model):
     # Find the two shared parameters and build shared parameter information.
-    shared_mp = {}
+    shared_mp = []
     for pair in shared_params_names:
         assert len(pair) == 2
         ori_name = pair[0]
@@ -258,12 +258,12 @@ class TestSharedParameters:
         self.micro_batches = 8
         self.stage_list = []
 
-        shared_params_names = {
-            "embedding_shared_weight": [
+        shared_params_names = [
+            [
                 f"{name_prefix}_linear_0_weight.dist",
                 f"{name_prefix}_linear_7_weight.dist",
             ]
-        }
+        ]
         # Pre-build shared parameter information.
         shared_mp = build_shared_parameters(shared_params_names, self.model)
 
@@ -313,12 +313,12 @@ class TestSharedParameters:
         """Test pipeline parallel model using PPModel as the baseline"""
         fix_seeds()
         name_prefix = "pp_model"
-        shared_params_names = {
-            "embedding_shared_weight": [
+        shared_params_names = [
+            [
                 f"{name_prefix}_linear_0_weight.dist",
                 f"{name_prefix}_linear_7_weight.dist",
             ]
-        }
+        ]
         pp_model = PPModel(
             name_prefix=name_prefix, shared_parameters=shared_params_names
         )

--- a/test/auto_parallel/pipeline_sync_shared_parameters_unittest.py
+++ b/test/auto_parallel/pipeline_sync_shared_parameters_unittest.py
@@ -45,12 +45,14 @@ class PPModel(nn.Layer):
         )
         self.num_layers = 8
         self.num_layers_per_card = self.num_layers // 4
+        # Store the names of each pair of shared parameters.
         self.shared_param_map = shared_param_map
 
         self.linears = nn.LayerList()
         for i in range(self.num_layers):
             linear = nn.Linear(8, 8, bias_attr=False)
 
+            # Different models have distinct parameter name spaces to avoid naming conflicts.
             linear.weight.name = f"{self.name_prefix}_linear_{i}_weight"
 
             # Mark network parameters
@@ -66,8 +68,10 @@ class PPModel(nn.Layer):
 
             self.linears.append(linear)
 
+        # Store the parameters to be shared under different model names.
         self.model_shared_param_mp = {}
 
+        # Build `model_shared_param_mp`.
         self.set_shared_param()
 
     def set_shared_param(self):
@@ -75,17 +79,12 @@ class PPModel(nn.Layer):
             assert len(pair) == 2
             ori_name = pair[0]
             sync_name = pair[1]
-            ori_weight_idx = -1
-            sync_weight_idx = -1
-            for idx, linear in enumerate(self.linears):
+            ori_param = None
+            for _, linear in enumerate(self.linears):
                 if ori_name == linear.weight.name:
-                    ori_weight_idx = idx
-                elif sync_name == linear.weight.name:
-                    sync_weight_idx = idx
-            assert ori_weight_idx != -1 and sync_weight_idx != -1
-            self.model_shared_param_mp[sync_name] = self.linears[
-                ori_weight_idx
-            ].weight
+                    ori_param = linear.weight
+            assert ori_param is not None
+            self.model_shared_param_mp[sync_name] = ori_param
 
     def get_pp_mesh(self, layer_index):
         mesh_idx = int(layer_index / (self.num_layers / 4))
@@ -211,6 +210,7 @@ class TestSharedParameters:
         fleet.auto.set_mesh(cls.mesh)
 
     def test_single_schedule(self, sing_schedule="FThenB"):
+        """Test pipeline parallel model with shared parameters using FThenB/1F1B strategy"""
         fix_seeds()
         name_prefix = "pp_" + sing_schedule
         self.model = PPModel(name_prefix=name_prefix)
@@ -278,6 +278,7 @@ class TestSharedParameters:
         return losses_by_step
 
     def test_multi_schedule(self, multi_schedule="VPP"):
+        """Test pipeline parallel with shared parameters model using VPP strategy"""
         fix_seeds()
         name_prefix = "pp_" + multi_schedule
         self.model = PPModel(name_prefix=name_prefix, schedule="VPP")

--- a/test/auto_parallel/pipeline_sync_shared_parameters_unittest.py
+++ b/test/auto_parallel/pipeline_sync_shared_parameters_unittest.py
@@ -37,7 +37,7 @@ def fix_seeds(seed=2025):
 
 
 class PPModel(nn.Layer):
-    def __init__(self, name_prefix="", schedule="FThenB", shared_param_map={}):
+    def __init__(self, name_prefix="", schedule="FThenB", shared_parameters={}):
         super().__init__(name_scope=name_prefix)
         self.name_prefix = name_prefix
         self.mesh = paddle.distributed.ProcessMesh(
@@ -46,7 +46,7 @@ class PPModel(nn.Layer):
         self.num_layers = 8
         self.num_layers_per_card = self.num_layers // 4
         # Store the names of each pair of shared parameters.
-        self.shared_param_map = shared_param_map
+        self.shared_parameters = shared_parameters
 
         self.linears = nn.LayerList()
         for i in range(self.num_layers):
@@ -75,7 +75,7 @@ class PPModel(nn.Layer):
         self.set_shared_param()
 
     def set_shared_param(self):
-        for _, pair in self.shared_param_map.items():
+        for pair in self.shared_parameters:
             assert len(pair) == 2
             ori_name = pair[0]
             sync_name = pair[1]
@@ -151,17 +151,17 @@ def _get_param_from_name(param_name, model):
     return None
 
 
-def build_shared_param_map(shared_params_names, model):
+def build_shared_parameters(shared_params_names, model):
     # Find the two shared parameters and build shared parameter information.
     shared_mp = {}
-    for key, pair in shared_params_names.items():
+    for pair in shared_params_names:
         assert len(pair) == 2
         ori_name = pair[0]
         sync_name = pair[1]
         ori_param = _get_param_from_name(ori_name, model)
         sync_param = _get_param_from_name(sync_name, model)
         # Note: Users must strictly maintain the format of the data structure here.
-        shared_mp[key] = {"params": [ori_param, sync_param]}
+        shared_mp.append({"params": [ori_param, sync_param]})
     return shared_mp
 
 
@@ -187,14 +187,14 @@ class TestSharedParameters:
         self.model = PPModel(name_prefix=name_prefix)
 
         self.micro_batches = 8
-        shared_params_names = {
-            "embedding_shared_weight": [
+        shared_params_names = [
+            [
                 f"{name_prefix}_linear_0_weight.dist",
                 f"{name_prefix}_linear_7_weight.dist",
             ]
-        }
+        ]
         # Pre-build shared parameter information.
-        shared_mp = build_shared_param_map(shared_params_names, self.model)
+        shared_mp = build_shared_parameters(shared_params_names, self.model)
 
         num_layers_per_card = 2
         cur_rank = dist.get_rank()
@@ -211,7 +211,7 @@ class TestSharedParameters:
             self.rank,
             4,
             group=self.group,
-            shared_param_map=shared_mp,
+            shared_parameters=shared_mp,
         )
 
         self.stage.has_backward = True
@@ -265,7 +265,7 @@ class TestSharedParameters:
             ]
         }
         # Pre-build shared parameter information.
-        shared_mp = build_shared_param_map(shared_params_names, self.model)
+        shared_mp = build_shared_parameters(shared_params_names, self.model)
 
         cur_rank = dist.get_rank()
         for i in range(self.local_stages):
@@ -280,7 +280,7 @@ class TestSharedParameters:
                     cur_rank + i * 4,
                     8,
                     group=self.group,
-                    shared_param_map=shared_mp,
+                    shared_parameters=shared_mp,
                 )
             )
             self.stage_list[i].has_backward = True
@@ -320,7 +320,7 @@ class TestSharedParameters:
             ]
         }
         pp_model = PPModel(
-            name_prefix=name_prefix, shared_param_map=shared_params_names
+            name_prefix=name_prefix, shared_parameters=shared_params_names
         )
         opt = paddle.optimizer.AdamW(
             learning_rate=0.001, parameters=pp_model.parameters()

--- a/test/auto_parallel/test_pipeline_sync_shared_parameters.py
+++ b/test/auto_parallel/test_pipeline_sync_shared_parameters.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import collective.test_communication_api_base as test_base
+
+
+class TestPipelineSharedParameters(test_base.CommunicationTestDistBase):
+    def setUp(self):
+        super().setUp(num_of_devices=4, timeout=120)
+        self._default_envs = {
+            "shape": "(10, 20)",
+            "dtype": "float32",
+            "seeds": str(self._seeds),
+            "shard": "0",
+        }
+        self._changeable_envs = {
+            "backend": ["gpu"],
+        }
+
+    def test_PipelineSharedParameters(self):
+        envs_list = test_base.gen_product_envs_list(
+            self._default_envs, self._changeable_envs
+        )
+        for envs in envs_list:
+            self.run_test_case(
+                "pipeline_sync_shared_parameters_unittest.py",
+                user_defined_envs=envs,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->
### **动半pp支持参数共享优化实现**
### **一、代码实现：**

0. 需要用户在模型组网中创建 `shared_parameters ` 其为 `list[dict[str, list[EagerParamBase]]]` 类型，传入 `PipelineStage` 参与 stage 的构建
目前是需要用户在模型中找到要共享的两个参数，构建`shared_parameters ` ，其可支持多个共享参数描述，需要严格满足如下格式：
     ```c++
     // 所有共享参数对描述信息
     shared_parameters = [ 
          // 第1对共享参数描述
         {               
             "params": [param_1, param_2],    // 必需的，分别位于 2 个stage上的要共享的参数
         },
         // 第2对共享参数描述
         {               
             "params": [param_3, param_4],    // 必需的，分别位于 2 个stage上的要共享的参数
         },
     ]
     ``` 
     **注意：**在 VPP 模式下，当前 rank 上 multiple stage 都必须使用 同一个 `shared_parameters` 参数。第一次stage创建时，共享参数通信 `group` 信息可以保存在每对共享参数的 `dict` 中，之后stage的创建可以避免产生冗余 group。用法可见 `pipeline_sync_shared_parameters_unittest.py` 中 VPP 共享参数测试。

1. 在 `PipelineStage` 类里面添加 `shared_parameters` 参数，并添加4个成员函数：

     - `_validate_shared_parameter_pair`：因为目前是共享参数信息要依赖于用户输入，所以这里对 shared_parameters 参数进行严格的类型、个数等检查，并提供错误信息 log
     - `_init_shared_group`：在当前 rank 上对每对参数 dict 创建 "shared_param" 和 “group”，

          - `shared_param` ：当前 rank 上实际要进行共享的参数，一般为 "params" 中两个参数之一；如果当前 rank 上没有要共享的参数（"params"中两个参数都不位于当前rank 上），默认为 None
          - `group`：当前 rank 上参数共享所需的通讯组

     - `_sync_shared_param`：对当前rank 上 shared_param 进行 broadcast 同步

      - `_sync_shared_param_grads`：对当前rank 上 shared_param 梯度进行 allreduce 同步

3. 在stage init 时先调用 `_validate_shared_parameter_pair ` 对参数进行检查，再调用 `_init_shared_group ` 和 `_sync_shared_param` 完成共享参数同步
4. 在 schedule 的每次调度 step 结束时调用 `sync_shared_params` 完成共享参数梯度同步


### **二、测试：**

（朴素 pp +参数共享）应该分别与 （3 种 pp 调度( FThenB、 1F1B、 VPP)+参数共享优化）实现loss精度 diff < 1e-5


### **三、验证：**

在 GPT-13B 上进行 3000 step 收敛验证结果如下：
![image](https://github.com/user-attachments/assets/a42c6058-6301-4011-9eba-c3d4fe9286ec)
loss diff在0 上下波动，收敛一致

PCard-91691