### PR TITLE
[0-size Tensor No.271] Add 0-size Tensor support for paddle.take_along_axis API.

### DIFF
--- a/paddle/phi/kernels/cpu/take_along_axis_kernel.cc
+++ b/paddle/phi/kernels/cpu/take_along_axis_kernel.cc
@@ -18,6 +18,7 @@
 #include "paddle/phi/common/data_type.h"
 #include "paddle/phi/common/place.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/funcs/gather_scatter_functor.h"
 
 namespace phi {
@@ -28,6 +29,16 @@ void TakeAlongAxisKernel(const Context& dev_ctx,
                          const DenseTensor& index,
                          int axis,
                          DenseTensor* out) {
+  if (index.numel() == 0) {
+    dev_ctx.template Alloc<T>(out);
+    return;
+  }
+  if (x.numel() == 0) {
+    phi::Full<T, Context>(
+        dev_ctx, common::vectorize(out->dims()), static_cast<T>(0), out);
+    return;
+  }
+
   out->Resize(index.dims());
   dev_ctx.template Alloc<T>(out);
 

--- a/paddle/phi/kernels/gpu/take_along_axis_kernel.cu
+++ b/paddle/phi/kernels/gpu/take_along_axis_kernel.cu
@@ -18,6 +18,7 @@
 #include "paddle/phi/common/place.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/core/utils/data_type.h"
+#include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/funcs/gather_scatter_functor.h"
 
 namespace phi {
@@ -28,6 +29,16 @@ void TakeAlongAxisKernel(const Context& dev_ctx,
                          const DenseTensor& index,
                          int axis,
                          DenseTensor* out) {
+  if (index.numel() == 0) {
+    dev_ctx.template Alloc<T>(out);
+    return;
+  }
+  if (x.numel() == 0) {
+    phi::Full<T, Context>(
+        dev_ctx, common::vectorize(out->dims()), static_cast<T>(0), out);
+    return;
+  }
+
   out->Resize(index.dims());
   dev_ctx.template Alloc<T>(out);
 

--- a/paddle/phi/kernels/xpu/take_along_axis_kernel.cc
+++ b/paddle/phi/kernels/xpu/take_along_axis_kernel.cc
@@ -19,6 +19,7 @@
 #include "paddle/common/layout.h"
 #include "paddle/phi/backends/xpu/enforce_xpu.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/full_kernel.h"
 
 namespace phi {
 
@@ -28,6 +29,16 @@ void TakeAlongAxisKernel(const Context& dev_ctx,
                          const DenseTensor& index,
                          int axis,
                          DenseTensor* out) {
+  if (index.numel() == 0) {
+    dev_ctx.template Alloc<T>(out);
+    return;
+  }
+  if (x.numel() == 0) {
+    phi::Full<T, Context>(
+        dev_ctx, common::vectorize(out->dims()), static_cast<T>(0), out);
+    return;
+  }
+
   out->Resize(index.dims());
   dev_ctx.template Alloc<T>(out);
 

--- a/test/legacy_test/test_take_along_axis_op.py
+++ b/test/legacy_test/test_take_along_axis_op.py
@@ -26,6 +26,58 @@ from paddle.framework import core
 paddle.enable_static()
 
 
+class TestTakeAlongAxis0Size(OpTest):
+    def setUp(self):
+        self.python_api = paddle.take_along_axis
+        self.op_type = "take_along_axis"
+        self.dtype = "float64"
+        self.check_pir = True
+
+        x = np.zeros((2, 0, 5)).astype(self.dtype)
+        indices = np.zeros((2, 3, 5)).astype("int64")
+
+        self.inputs = {'Input': x, 'Index': indices}
+        self.attrs = {'Axis': 1}
+
+        output = np.zeros((2, 3, 5)).astype(self.dtype)
+        self.outputs = {'Result': output}
+
+    def test_check_output(self):
+        self.check_output(check_pir=self.check_pir)
+
+    def test_check_grad(self):
+        self.check_grad(['Input'], 'Result', check_pir=self.check_pir)
+
+
+class TestTakeAlongAxis0Size2(OpTest):
+    def setUp(self):
+        self.python_api = paddle.take_along_axis
+        self.op_type = "take_along_axis"
+        self.dtype = "float64"
+        self.check_pir = True
+
+        x = np.random.rand(2, 3, 5).astype(self.dtype)
+        indices = np.zeros((2, 0, 5)).astype("int64")
+
+        self.inputs = {'Input': x, 'Index': indices}
+        self.attrs = {'Axis': 1}
+
+        output = np.zeros((2, 0, 5)).astype(self.dtype)
+        self.outputs = {'Result': output}
+
+    def test_check_output(self):
+        self.check_output(check_pir=self.check_pir)
+
+    def test_check_grad(self):
+        self.grad = np.zeros_like(self.outputs['Result']).astype(self.dtype)
+        self.check_grad(
+            ['Input'],
+            'Result',
+            user_defined_grads=[self.grad],
+            check_pir=self.check_pir,
+        )
+
+
 class TestTakeAlongAxisOp(OpTest):
     def setUp(self):
         self.init_data()


### PR DESCRIPTION
### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
本次提交为完成任务 #72637 中关于 `paddle.take_along_axis` 的部分。

#### 修改历程介绍如下：

1.  **问题复现与分析：**
    * 根据任务要求，首先尝试使用`PaddleAPITest`复现BUG。在`PaddleAPITest`的`--accuracy=True`精度对比模式下，由于`paddle.take_along_axis(arr, index, axis)`与`torch.take_along_dim(input, indices, dim)`的参数名不统一，反复出现`TypeError: missing a required argument`的参数绑定错误，无法准确定位问题。
    * 切换到`PaddleAPITest`的`--paddle_only=True`模式后，成功触发了Python层的`TypeError: take_along_axis() got an unexpected keyword argument 'index'`报错，这暴露了API前后端参数名不一致的问题。
    * 为绕过Python接口问题，并直接验证C++ Kernel，最终采用`unittest`的`OpTest`框架编写单元测试。在未修复Kernel的情况下，成功复现了底层的C++错误：
      > ```text
      > PreconditionNotMetError: Tensor holds no memory. Call Tensor::mutable_data firstly.
      > [Hint: holder_ should not be null.] (at /home/aistudio/Paddle/paddle/phi/core/dense_tensor_impl.cc:46)
      > [operator < take_along_axis > error]
      > ```
    * 错误分析表明，当输入Tensor的元素个数为0时，算子Kernel未做特殊处理，导致程序在访问空Tensor的内存时崩溃。

2.  **前向修复 (Forward Fix)：**
    a. **定位API**: 在`Paddle/python/paddle/tensor/manipulation.py`中找到了`def take_along_axis(...)`的Python定义，其核心实现调用了`_C_ops.take_along_axis`。
    b. **定位算子定义**: 使用`grep`发现，该算子没有独立的`.yml`文件，其定义位于`paddle/phi/ops/yaml/ops.yaml`中。
    c. **检查InferMeta**: 根据`ops.yaml`的指引，在`paddle/phi/infermeta/binary.cc`中找到了`TakeAlongAxisInferMeta`函数。经分析，其`out->set_dims(index.dims())`逻辑能正确推导0-size Tensor的输出形状，无需修改。
    d. **修改Kernel**:
        * 根据`grep`结果，定位到CPU Kernel文件为`paddle/phi/kernels/cpu/take_along_axis_kernel.cc`。
        * 参照标准修复范式，在`TakeAlongAxisKernel`函数开头加入了对0-size情况的保护。核心逻辑是判断`index.numel()`是否为0，因为输出的形状完全由`index`决定。
        * **修复代码如下：**
      ```cpp
          if (index.numel() == 0) {
            dev_ctx.template Alloc<T>(out);
            return;
          }
          if (x.numel() == 0) {
            phi::Full<T, Context>(
                dev_ctx, common::vectorize(out->dims()), static_cast<T>(0), out);
            return;
          }
      ```
    d. 依照以上原则修改CPU、GPU、XPU Kernel

3.  **反向修复 (Backward Fix)：**
    * 本次修复的核心在于解决前向Kernel（take_along_axis_kernel）在处理0-size输入时，因访问未初始化内存而导致的PreconditionNotMetError。
    * 在添加的OpTest单元测试中，我们通过self.check_grad()对反向梯度进行了检查。
    * 在修复了前向Kernel之后，check_grad能够顺利通过。这表明，对于我们测试的0-size场景，正确的前向输出（一个0-size Tensor）能够保证反向计算图的正确建立和执行，因此本次并未对take_along_axis_grad_kernel.cc文件进行修改。

#### 4. 添加单测 (Add Unit Test)：

* 在`test/legacy_test/test_take_along_axis_op.py`文件中，为彻底解决因父类`TestTakeAlongAxisOp`的`setUp`方法无法兼容0-size数据而导致的CI报错（`IndexError`, `ValueError`），最终方案是**放弃继承**，添加了**两个全新的、独立的`OpTest`测试类**，分别覆盖两种不同的0-size边界场景。

* **测试场景一：输入`arr`为0-size，但`index`不为0-size**
    * 通过`TestTakeAlongAxis0Size1`类进行验证。完整测试代码如下：
        ```python
        # --- 场景一: 输入x为0-size, index不为0-size ---
        class TestTakeAlongAxis0Size1(OpTest):
            # 修复 tearDownClass 的 op_type 缺失问题
            op_type = "take_along_axis"

            def setUp(self):
                self.python_api = paddle.take_along_axis
                self.op_type = "take_along_axis"
                self.dtype = "float64"
                self.check_pir = True

                x = np.zeros((2, 0, 5)).astype(self.dtype)
                indices = np.zeros((2, 3, 5)).astype("int64")

                self.inputs = {'Input': x, 'Index': indices}
                self.attrs = {'Axis': 1}

                # 手动定义期望的输出，不再依赖父类的复杂计算
                output = np.zeros((2, 3, 5)).astype(self.dtype)
                self.outputs = {'Result': output}

            def test_check_output(self):
                self.check_output(check_pir=self.check_pir)

            def test_check_grad(self):
                self.check_grad(['Input'], 'Result', check_pir=self.check_pir)
        ```

* **测试场景二：索引`index`为0-size，但`arr`不为0-size**
    * 通过`TestTakeAlongAxis0Size2`类进行验证。完整测试代码如下：
        ```python
        # --- 场景二: 索引index为0-size, x不为0-size ---
        class TestTakeAlongAxis0Size2(OpTest):
            # 修复 tearDownClass 的 op_type 缺失问题
            op_type = "take_along_axis"

            def setUp(self):
                self.python_api = paddle.take_along_axis
                self.op_type = "take_along_axis"
                self.dtype = "float64"
                self.check_pir = True

                x = np.random.rand(2, 3, 5).astype(self.dtype)
                indices = np.zeros((2, 0, 5)).astype("int64")

                self.inputs = {'Input': x, 'Index': indices}
                self.attrs = {'Axis': 1}
                
                output = np.zeros((2, 0, 5)).astype(self.dtype)
                self.outputs = {'Result': output}

            def test_check_output(self):
                self.check_output(check_pir=self.check_pir)

            def test_check_grad(self):
                # 输出为0-size，其梯度也为0-size。
                # 通过 user_defined_grads 手动指定反向输入的梯度，
                # 帮助框架完成梯度检查。
                grad = np.zeros_like(self.outputs['Result']).astype(self.dtype)
                self.check_grad(
                    ['Input'],
                    'Result',
                    user_defined_grads=[grad],
                    check_pir=self.check_pir,
                )
        ```

5.  **测试结果**
    * **本地单元测试**: 在修复C++ Kernel并重新编译后，在`feature/fix_take_along_axis_0size`分支上运行添加的`OpTest`单元测试，结果为 `OK`，证明修复成功。
    * **PaddleAPITest回测**: 由于此API存在参数名不兼容问题，`--accuracy`模式无法使用。在`--paddle_only`模式下，修复后可顺利通过。


pcard-67164
