### PR TITLE
[Accuracy diff No.125] Fix accuracy diff for paddle.nn.functional.multi_margin_loss API

### DIFF
--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -4170,8 +4170,9 @@ def multi_margin_loss(
             )
         weight = paddle.gather(weight, label, axis=0).reshape((-1, 1))
         loss = paddle.mean(
-            paddle.pow(
-                paddle.clip(weight * (margin - index_sample + input), min=0.0),
+            weight
+            * paddle.pow(
+                paddle.clip((margin - index_sample + input), min=0.0),
                 p,
             ),
             axis=1,

--- a/test/legacy_test/test_multimarginloss.py
+++ b/test/legacy_test/test_multimarginloss.py
@@ -224,7 +224,7 @@ def calc_multi_margin_loss(
             [weight[label[i]] for i in range(label.size)]
         ).reshape(-1, 1)
         expected = np.mean(
-            np.maximum(weight * (margin + input - index_sample), 0.0) ** p,
+            weight * (np.maximum((margin + input - index_sample), 0.0) ** p),
             axis=1,
         ) - weight * (margin**p / input.shape[1])
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/nn/functional/multi_margin_loss_cn.html

![image](https://github.com/user-attachments/assets/62b29b02-13b5-4e85-8afc-3178631d817d)
multi_margin_loss  weight 应加到 pow计算后，因为有在0和运算值中取较大的值计算，如果weight有负值，计算会有误差

同样修改单测的计算

PaddleAPITest 测试通过，如果测试错误时会随机出现，需要重复运行几次
![image](https://github.com/user-attachments/assets/1461941c-36a3-4df4-9bc8-96b2980beaeb)
