### PR TITLE
[0-size Tensor No.12] Add 0-size Tensor support for as_real API.

### DIFF
--- a/paddle/phi/kernels/stride/as_real_kernel.cc
+++ b/paddle/phi/kernels/stride/as_real_kernel.cc
@@ -29,6 +29,21 @@ void AsRealStridedKernel(const Context& dev_ctx,
         "FLAGS_use_stride_kernel is closed. Strided kernel "
         "be called, something wrong has happened!"));
   }
+  if (out && out->numel() == 0) {
+    if (x.dtype() == DataType::COMPLEX64) {
+      out->set_type(DataType::FLOAT32);
+    } else if (x.dtype() == DataType::COMPLEX128) {
+      out->set_type(DataType::FLOAT64);
+    } else {
+      PADDLE_THROW(common::errors::Unimplemented(
+          "as_real is not supported data type (%s).",
+          DataTypeToString(x.dtype())));
+    }
+    out->set_offset(x.offset());
+    out->ResetHolder(x.Holder());
+    out->ShareInplaceVersionCounterWith(x);
+    return;
+  }
   auto out_stride_v = common::vectorize(x.strides());
   for (auto& v : out_stride_v) {
     v *= 2;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

![image](https://github.com/user-attachments/assets/a58d556c-26db-4b18-abdb-15bbba1e8825)

修复：
a. 在Paddle代码中检索def as_real，发现as_real的核心实现调用的是_C_ops的as_real
b. 以_C_ops的as_real在paddle/phi/ops/yaml中检索，发现as_real的InferMeta函数使用为：AsRealInferMeta
c. 在代码中检索AsRealInferMeta，其函数体位于paddle\phi\infermeta\unary.cc，检查其对于0-size张量发现并无直接的相关操作
d. 在paddle/phi/kernels中检索as_real（asreal），寻找有关Kernel的相关实现。发现存在函数AsRealStridedKernel，添加对于0-size问题的判定
```C
if (out && out->numel() == 0) {
    if (x.dtype() == DataType::COMPLEX64) {
      out->set_type(DataType::FLOAT32);
    } else if (x.dtype() == DataType::COMPLEX128) {
      out->set_type(DataType::FLOAT64);
    } else {
      PADDLE_THROW(common::errors::Unimplemented(
          "as_real is not supported data type (%s).",
          DataTypeToString(x.dtype())));
    }
    out->set_offset(x.offset());
    out->ResetHolder(x.Holder());
    out->ShareInplaceVersionCounterWith(x);
    return;
  }
```

PaddleAPITest测试结果：
![image](https://github.com/user-attachments/assets/4fc288d8-0f16-4a3e-9fa8-0a87be9d6961)

 pcard-67164
