### PR TITLE
[PHI] Add `is_runtime` check to `fused_bias_act`

### DIFF
--- a/paddle/phi/infermeta/multiary.cc
+++ b/paddle/phi/infermeta/multiary.cc
@@ -2488,12 +2488,22 @@ void FusedBiasActInferMeta(const MetaTensor& x,
   }
 
   if (act_method == "geglu" || act_method == "swiglu") {
-    PADDLE_ENFORCE_EQ(
-        dim % 2,
-        0,
-        common::errors::InvalidArgument(
-            "The second dimension of x must be even, but receive %d", dim));
-    x_shapes[x_last_dim] /= 2;
+    if (config.is_runtime || dim > 0) {
+      ENFORCE_EQ(
+          dim % 2,
+          0,
+          common::errors::InvalidArgument(
+              "The last dimension of x must be even, but receive %d", dim));
+      x_shapes[x_last_dim] /= 2;
+    } else {
+      ENFORCE_EQ(
+          dim,
+          -1,
+          common::errors::InvalidArgument("At compile time, a negative last "
+                                          "dimension must be -1, but got  %d",
+                                          dim));
+    }
+
     out->set_dims(common::make_ddim(x_shapes));
   } else if (act_method == "gelu" || act_method == "relu") {
     out->set_dims(common::make_ddim(x_shapes));

--- a/paddle/phi/infermeta/multiary.cc
+++ b/paddle/phi/infermeta/multiary.cc
@@ -2488,7 +2488,7 @@ void FusedBiasActInferMeta(const MetaTensor& x,
   }
 
   if (act_method == "geglu" || act_method == "swiglu") {
-    if (config.is_runtime || dim > 0) {
+    if (config.is_runtime || dim >= 0) {
       ENFORCE_EQ(
           dim % 2,
           0,

--- a/paddle/phi/infermeta/multiary.cc
+++ b/paddle/phi/infermeta/multiary.cc
@@ -2500,7 +2500,7 @@ void FusedBiasActInferMeta(const MetaTensor& x,
           dim,
           -1,
           common::errors::InvalidArgument("At compile time, a negative last "
-                                          "dimension must be -1, but got  %d",
+                                          "dimension must be -1, but got %d",
                                           dim));
     }
 

--- a/paddle/phi/infermeta/multiary.cc
+++ b/paddle/phi/infermeta/multiary.cc
@@ -2489,14 +2489,14 @@ void FusedBiasActInferMeta(const MetaTensor& x,
 
   if (act_method == "geglu" || act_method == "swiglu") {
     if (config.is_runtime || dim >= 0) {
-      ENFORCE_EQ(
+      PADDLE_ENFORCE_EQ(
           dim % 2,
           0,
           common::errors::InvalidArgument(
               "The last dimension of x must be even, but receive %d", dim));
       x_shapes[x_last_dim] /= 2;
     } else {
-      ENFORCE_EQ(
+      PADDLE_ENFORCE_EQ(
           dim,
           -1,
           common::errors::InvalidArgument("At compile time, a negative last "


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

```c
  // 编译期 dim 为 -1，无需走这个判断
  if (act_method == "geglu" || act_method == "swiglu") {
    PADDLE_ENFORCE_EQ(
        dim % 2,
        0,
        common::errors::InvalidArgument(
            "The second dimension of x must be even, but receive %d", dim));
    x_shapes[x_last_dim] /= 2;
```

<!-- PCard-66972 -->