### PR TITLE
[PHI] Fix `paddle.kthvalue` for big tensor

### DIFF
--- a/paddle/phi/kernels/funcs/top_k_function_cuda.h
+++ b/paddle/phi/kernels/funcs/top_k_function_cuda.h
@@ -694,10 +694,10 @@ __device__ void ExclusiveBinaryPrefixScan(
   }
 }
 
-template <typename T, typename RadixType>
+template <typename T, typename RadixType, typename IndexType>
 __device__ T FindPattern(const T* input,
                          T* shared_mem,
-                         int64_t slice_size,
+                         IndexType slice_size,
                          RadixType desired,
                          RadixType desired_mask) {
   if (threadIdx.x < 2) {
@@ -705,9 +705,9 @@ __device__ T FindPattern(const T* input,
   }
   __syncthreads();
 
-  int block_dim = static_cast<int>(blockDim.x);
-  int64_t loop = ((slice_size + block_dim - 1) / block_dim * block_dim);
-  for (int64_t i = threadIdx.x; i < loop; i += blockDim.x) {
+  IndexType block_dim = static_cast<IndexType>(blockDim.x);
+  IndexType loop = ((slice_size + block_dim - 1) / block_dim * block_dim);
+  for (IndexType i = threadIdx.x; i < loop; i += blockDim.x) {
     bool valid = (i < slice_size);
     T v = valid ? input[i] : static_cast<T>(0);
 
@@ -732,14 +732,18 @@ __device__ T FindPattern(const T* input,
   return static_cast<T>(0);
 }
 
-template <typename T, typename RadixType, int RadixSize, int RadixBits>
+template <typename T,
+          typename RadixType,
+          typename IndexType,
+          int RadixSize,
+          int RadixBits>
 __device__ void RadixCountUsingMask(const T* input,
-                                    int counts[RadixSize],
-                                    int* shared_mem,
+                                    IndexType counts[RadixSize],
+                                    IndexType* shared_mem,
                                     RadixType desired,
                                     RadixType desired_mask,
                                     int radix_digit_pos,
-                                    int64_t slice_size) {
+                                    IndexType slice_size) {
 #pragma unroll
   for (int i = 0; i < RadixSize; ++i) {
     counts[i] = 0;
@@ -750,7 +754,7 @@ __device__ void RadixCountUsingMask(const T* input,
   }
   __syncthreads();
 
-  for (int64_t i = threadIdx.x; i < slice_size; i += blockDim.x) {
+  for (IndexType i = threadIdx.x; i < slice_size; i += blockDim.x) {
     RadixType val = RadixTypeConfig<T>::Convert(input[i]);
 
     bool has_val = ((val & desired_mask) == desired);
@@ -781,44 +785,47 @@ __device__ void RadixCountUsingMask(const T* input,
   __syncthreads();
 }
 
-template <typename T, typename RadixType, bool Largest>
-__device__ void RadixSearch(
-    const T* input, int k, int64_t slice_size, int* shared_mem, T* kth_value) {
-  int counts[RADIX_SIZE];
-
+template <typename T, typename RadixType, typename IndexType, bool Largest>
+__device__ void RadixSearch(const T* input,
+                            IndexType k,
+                            IndexType slice_size,
+                            void* shared_mem,
+                            T* kth_value) {
+  IndexType counts[RADIX_SIZE];
+  IndexType k_left = k;
   RadixType desired = 0;
   RadixType desired_mask = 0;
-
-  int k_left = k;
 
 #pragma unroll
   for (int digit_pos = sizeof(T) * 8 - RADIX_BITS; digit_pos >= 0;
        digit_pos -= RADIX_BITS) {
-    RadixCountUsingMask<T, RadixType, RADIX_SIZE, RADIX_BITS>(input,
-                                                              counts,
-                                                              shared_mem,
-                                                              desired,
-                                                              desired_mask,
-                                                              digit_pos,
-                                                              slice_size);
+    RadixCountUsingMask<T, RadixType, IndexType, RADIX_SIZE, RADIX_BITS>(
+        input,
+        counts,
+        static_cast<IndexType*>(shared_mem),
+        desired,
+        desired_mask,
+        digit_pos,
+        slice_size);
 
-    auto found_unique = [&](int i, int count) -> bool {
+    auto found_unique = [&](int i, IndexType count) -> bool {
       if (count == 1 && k_left == 1) {
         desired =
             Bitfield<RadixType>::SetBitfield(desired, i, digit_pos, RADIX_BITS);
         desired_mask = Bitfield<RadixType>::SetBitfield(
             desired_mask, RADIX_MASK, digit_pos, RADIX_BITS);
 
-        *kth_value = FindPattern<T, RadixType>(input,
-                                               reinterpret_cast<T*>(shared_mem),
-                                               slice_size,
-                                               desired,
-                                               desired_mask);
+        *kth_value =
+            FindPattern<T, RadixType, IndexType>(input,
+                                                 static_cast<T*>(shared_mem),
+                                                 slice_size,
+                                                 desired,
+                                                 desired_mask);
         return true;
       }
       return false;
     };
-    auto found_non_unique = [&](int i, int count) -> bool {
+    auto found_non_unique = [&](int i, IndexType count) -> bool {
       if (count >= k_left) {
         desired =
             Bitfield<RadixType>::SetBitfield(desired, i, digit_pos, RADIX_BITS);
@@ -835,7 +842,7 @@ __device__ void RadixSearch(
 // Descending order
 #pragma unroll
       for (int i = RADIX_SIZE - 1; i >= 0; --i) {
-        int count = counts[i];
+        IndexType count = counts[i];
         if (found_unique(i, count)) {
           return;
         }
@@ -847,7 +854,7 @@ __device__ void RadixSearch(
 // Ascending order
 #pragma unroll
       for (int i = 0; i < RADIX_SIZE; ++i) {
-        int count = counts[i];
+        IndexType count = counts[i];
         if (found_unique(i, count)) {
           return;
         }
@@ -861,23 +868,25 @@ __device__ void RadixSearch(
   *kth_value = RadixTypeConfig<T>::Deconvert(desired);
 }
 
-template <typename T>
+template <typename T, typename IndexType>
 __global__ void GatherKthValue(const T* input,
-                               const int k,
-                               const int64_t num_rows,
-                               const int64_t num_cols,
+                               const IndexType k,
+                               const IndexType num_rows,
+                               const IndexType num_cols,
                                T* output,
                                int64_t* indices) {
-  __shared__ int shared_mem[32];
-  int row =
+  extern __shared__ char shared_mem_char[];
+  void* shared_mem = static_cast<void*>(shared_mem_char);
+
+  IndexType row =
       blockIdx.z * gridDim.y * gridDim.x + blockIdx.y * gridDim.x + blockIdx.x;
+  if (row >= num_rows) return;
   const T* cur_input = input + row * num_cols;
 
   // 1. Find the k-th value
   T kth_value = static_cast<T>(0);
-  RadixSearch<T, RadixTypeConfig<T>::RadixType, false>(
+  RadixSearch<T, RadixTypeConfig<T>::RadixType, IndexType, false>(
       cur_input, k, num_cols, shared_mem, &kth_value);
-  const auto converted_kth_value = RadixTypeConfig<T>::Convert(kth_value);
 
   // 2. find the k-th index
   int64_t kth_index = 0;
@@ -901,19 +910,52 @@ __global__ void GatherKthValue(const T* input,
   }
 }
 
-template <typename T>
+template <typename T, typename IndexType>
 void LaunchGatherKthValue(const phi::GPUContext& dev_ctx,
                           const T* input_data,
-                          const int64_t num_cols,
-                          const int64_t num_rows,
-                          const int k,
+                          const IndexType num_rows,
+                          const IndexType num_cols,
+                          const IndexType k,
                           T* out_data,
                           int64_t* indices_data) {
+  size_t size_for_count = RADIX_SIZE * sizeof(IndexType);
+  size_t size_for_find = 2 * sizeof(T);
+  size_t shared_mem_size = std::max(size_for_count, size_for_find);
+
   int num_threads = std::min(
       static_cast<int>(round_up(static_cast<int>(num_cols), WARP_SIZE)),
       MAX_NUM_THREADS);
-  GatherKthValue<T><<<num_rows, num_threads, 0, dev_ctx.stream()>>>(
-      input_data, k, num_rows, num_cols, out_data, indices_data);
+  dim3 block_dim(num_threads);
+
+  dim3 grid_dim;
+  const IndexType max_grid_x = dev_ctx.GetCUDAMaxGridDimSize()[0];
+  const IndexType max_grid_y = dev_ctx.GetCUDAMaxGridDimSize()[1];
+  const IndexType max_grid_z = dev_ctx.GetCUDAMaxGridDimSize()[2];
+  if (num_rows <= max_grid_x) {
+    grid_dim.x = num_rows;
+    grid_dim.y = 1;
+    grid_dim.z = 1;
+  } else {
+    grid_dim.x = max_grid_x;
+    IndexType remaining_rows = (num_rows + max_grid_x - 1) / max_grid_x;
+    if (remaining_rows <= max_grid_y) {
+      grid_dim.y = remaining_rows;
+      grid_dim.z = 1;
+    } else {
+      grid_dim.y = max_grid_y;
+      grid_dim.z = (remaining_rows + max_grid_y - 1) / max_grid_y;
+      PADDLE_ENFORCE_LE(grid_dim.z,
+                        max_grid_z,
+                        common::errors::InvalidArgument(
+                            "The number of rows (%d) is too large to be "
+                            "launched in a 3D CUDA grid.",
+                            num_rows));
+    }
+  }
+
+  GatherKthValue<T, IndexType>
+      <<<grid_dim, block_dim, shared_mem_size, dev_ctx.stream()>>>(
+          input_data, k, num_rows, num_cols, out_data, indices_data);
 }
 
 template <typename T, bool Largest>
@@ -927,8 +969,8 @@ __global__ void RadixTopK(const T* input,
 
   // 1. Find the k-th value
   T kth_value = static_cast<T>(0);
-  RadixSearch<T, typename RadixTypeConfig<T>::RadixType, Largest>(
-      input, k, slice_size, shared_mem, &kth_value);
+  RadixSearch<T, typename RadixTypeConfig<T>::RadixType, int64_t, Largest>(
+      input, k, slice_size, static_cast<void*>(shared_mem), &kth_value);
   const auto converted_kth_value = RadixTypeConfig<T>::Convert(kth_value);
 
   // 2. Select the value strictly less/greater than kth_value and their indices

--- a/paddle/phi/kernels/funcs/top_k_function_cuda.h
+++ b/paddle/phi/kernels/funcs/top_k_function_cuda.h
@@ -924,9 +924,10 @@ void LaunchGatherKthValue(const phi::GPUContext& dev_ctx,
   size_t size_for_find = 2 * sizeof(T);
   size_t shared_mem_size = std::max(size_for_count, size_for_find);
 
-  int num_threads = std::min(
-      static_cast<int>(round_up(static_cast<int>(num_cols), WARP_SIZE)),
-      MAX_NUM_THREADS);
+  IndexType num_threads =
+      std::min(static_cast<IndexType>(round_up(num_cols, WARP_SIZE)),
+               static_cast<IndexType>(MAX_NUM_THREADS));
+  num_threads = std::max(num_threads, IndexType(1));
   dim3 block_dim(num_threads);
 
   dim3 grid_dim;

--- a/paddle/phi/kernels/funcs/top_k_function_cuda.h
+++ b/paddle/phi/kernels/funcs/top_k_function_cuda.h
@@ -890,23 +890,18 @@ __global__ void GatherKthValue(const T* input,
 
   __shared__ int64_t block_min_idx;
   if (threadIdx.x == 0) {
-    block_min_idx = -1;
+    block_min_idx = num_cols;
   }
   __syncthreads();
 
   // 2. find the k-th index
-  for (int64_t i = threadIdx.x; i < num_cols; i += blockDim.x) {
-    int64_t current_min = block_min_idx;
-    if (current_min != -1 && i >= current_min) {
-      break;
-    }
+  for (IndexType i = threadIdx.x; i < num_cols; i += blockDim.x) {
     T v = cur_input[i];
     bool isKValue =
         ((v == kth_value) || (isnan(static_cast<float>(v)) &&
                               isnan(static_cast<float>(kth_value))));
     if (isKValue) {
-      phi::CudaAtomicMin(&block_min_idx, i);
-      break;
+      phi::CudaAtomicMin(&block_min_idx, static_cast<int64_t>(i));
     }
   }
   __syncthreads();

--- a/paddle/phi/kernels/funcs/top_k_function_cuda.h
+++ b/paddle/phi/kernels/funcs/top_k_function_cuda.h
@@ -1066,7 +1066,7 @@ __global__ void AssignGradWithAxis(const T* grad_out,
   for (int64_t i = blockIdx.x; i < pre; i += gridDim.x) {
     int64_t base_index = i * post * k;
     int64_t base_grad = i * post * raw_height;
-    for (int j = threadIdx.x; j < raw_height * post; j += blockDim.x) {
+    for (int64_t j = threadIdx.x; j < raw_height * post; j += blockDim.x) {
       grad_in[base_grad + j] = static_cast<T>(0);
     }
     __syncthreads();

--- a/paddle/phi/kernels/funcs/top_k_function_cuda.h
+++ b/paddle/phi/kernels/funcs/top_k_function_cuda.h
@@ -871,8 +871,8 @@ __device__ void RadixSearch(const T* input,
 template <typename T, typename IndexType>
 __global__ void GatherKthValue(const T* input,
                                const IndexType k,
-                               const IndexType num_rows,
                                const IndexType num_cols,
+                               const IndexType num_rows,
                                T* output,
                                int64_t* indices) {
   extern __shared__ char shared_mem_char[];
@@ -888,33 +888,40 @@ __global__ void GatherKthValue(const T* input,
   RadixSearch<T, RadixTypeConfig<T>::RadixType, IndexType, false>(
       cur_input, k, num_cols, shared_mem, &kth_value);
 
+  __shared__ int64_t block_min_idx;
+  if (threadIdx.x == 0) {
+    block_min_idx = -1;
+  }
+  __syncthreads();
+
   // 2. find the k-th index
-  int64_t kth_index = 0;
-  bool foundKValue = false;
   for (int64_t i = threadIdx.x; i < num_cols; i += blockDim.x) {
-    bool inRange = (i < num_cols);
-    T v = inRange ? cur_input[i] : static_cast<T>(0);
+    int64_t current_min = block_min_idx;
+    if (current_min != -1 && i >= current_min) {
+      break;
+    }
+    T v = cur_input[i];
     bool isKValue =
-        inRange && ((v == kth_value) || (isnan(static_cast<float>(v)) &&
-                                         isnan(static_cast<float>(kth_value))));
+        ((v == kth_value) || (isnan(static_cast<float>(v)) &&
+                              isnan(static_cast<float>(kth_value))));
     if (isKValue) {
-      kth_index = i;
-      foundKValue = true;
+      phi::CudaAtomicMin(&block_min_idx, i);
       break;
     }
   }
+  __syncthreads();
 
-  if (foundKValue) {
+  if (threadIdx.x == 0) {
     output[row] = kth_value;
-    indices[row] = kth_index;
+    indices[row] = block_min_idx;
   }
 }
 
 template <typename T, typename IndexType>
 void LaunchGatherKthValue(const phi::GPUContext& dev_ctx,
                           const T* input_data,
-                          const IndexType num_rows,
                           const IndexType num_cols,
+                          const IndexType num_rows,
                           const IndexType k,
                           T* out_data,
                           int64_t* indices_data) {
@@ -955,7 +962,7 @@ void LaunchGatherKthValue(const phi::GPUContext& dev_ctx,
 
   GatherKthValue<T, IndexType>
       <<<grid_dim, block_dim, shared_mem_size, dev_ctx.stream()>>>(
-          input_data, k, num_rows, num_cols, out_data, indices_data);
+          input_data, k, num_cols, num_rows, out_data, indices_data);
 }
 
 template <typename T, bool Largest>

--- a/paddle/phi/kernels/gpu/kthvalue_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/kthvalue_grad_kernel.cu
@@ -66,7 +66,8 @@ void KthvalueGradKernel(const Context& dev_ctx,
   const int64_t max_blocks = std::max(((max_threads - 1) / block_size + 1), 1);
   int64_t desired_grid_size = std::min(max_blocks, pre);
   int64_t grid_size =
-      std::min(desired_grid_size, dev_ctx.GetCUDAMaxGridDimSize()[0]);
+      std::min(desired_grid_size,
+               static_cast<int64_t>(dev_ctx.GetCUDAMaxGridDimSize()[0]));
   phi::funcs::AssignGradWithAxis<T>
       <<<grid_size, block_size, 64 * 4, dev_ctx.stream()>>>(
           out_grad_data, indices_data, x_grad_data, pre, post, n, 1);

--- a/paddle/phi/kernels/gpu/kthvalue_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/kthvalue_grad_kernel.cu
@@ -19,7 +19,7 @@
 #include "paddle/phi/kernels/funcs/top_k_function_cuda.h"
 
 namespace phi {
-static int getBlockSize(int col) {
+static int getBlockSize(int64_t col) {
   if (col > 512)
     return 1024;
   else if (col > 256 && col <= 512)
@@ -60,10 +60,13 @@ void KthvalueGradKernel(const Context& dev_ctx,
   const int64_t* indices_data = indices.data<int64_t>();
   int64_t pre, n, post;
   phi::funcs::GetDims(in_dims, axis, &pre, &n, &post);
+
   int block_size = getBlockSize(post * k);
   int max_threads = dev_ctx.GetMaxPhysicalThreadCount();
   const int64_t max_blocks = std::max(((max_threads - 1) / block_size + 1), 1);
-  int grid_size = std::min(max_blocks, pre);
+  int64_t desired_grid_size = std::min(max_blocks, pre);
+  int64_t grid_size =
+      std::min(desired_grid_size, dev_ctx.GetCUDAMaxGridDimSize()[0]);
   phi::funcs::AssignGradWithAxis<T>
       <<<grid_size, block_size, 64 * 4, dev_ctx.stream()>>>(
           out_grad_data, indices_data, x_grad_data, pre, post, n, 1);

--- a/paddle/phi/kernels/gpu/kthvalue_kernel.cu
+++ b/paddle/phi/kernels/gpu/kthvalue_kernel.cu
@@ -161,6 +161,9 @@ void KthvalueKernel(const Context& dev_ctx,
                     bool keepdim,
                     DenseTensor* output,
                     DenseTensor* indices) {
+  // TODO(cangtianhuang): support int64_t k
+  k = static_cast<int64_t>(k);
+
   if (x.numel() == 0) {
     phi::Full<T, Context>(
         dev_ctx, phi::IntArray(common::vectorize(output->dims())), NAN, output);
@@ -195,13 +198,24 @@ void KthvalueKernel(const Context& dev_ctx,
     const int64_t& input_width = in_dims[in_dims.size() - 1];
 #if defined(PADDLE_WITH_CUDA) && CUDA_VERSION >= 9000
     const T* input_data = x.data<T>();
-    funcs::LaunchGatherKthValue<T>(dev_ctx,
-                                   input_data,
-                                   input_width,
-                                   input_height,
-                                   k,
-                                   output_data,
-                                   indices_data);
+    if (input_width > std::numeric_limits<int32_t>::max()) {
+      funcs::LaunchGatherKthValue<T, int64_t>(dev_ctx,
+                                              input_data,
+                                              input_width,
+                                              input_height,
+                                              k,
+                                              output_data,
+                                              indices_data);
+    } else {
+      funcs::LaunchGatherKthValue<T, int32_t>(
+          dev_ctx,
+          input_data,
+          static_cast<int32_t>(input_width),
+          static_cast<int32_t>(input_height),
+          static_cast<int32_t>(k),
+          output_data,
+          indices_data);
+    }
 #else
     PADDLE_ENFORCE_EQ(
         SortKthvalue<T>(
@@ -209,7 +223,6 @@ void KthvalueKernel(const Context& dev_ctx,
         true,
         common::errors::External("KthvalueOP: Error when use cub sorting"));
 #endif
-
     return;
   } else {
     std::vector<int> trans;
@@ -257,13 +270,24 @@ void KthvalueKernel(const Context& dev_ctx,
     const int64_t input_width = trans_dims[trans_dims.size() - 1];
 
 #if defined(PADDLE_WITH_CUDA) && CUDA_VERSION >= 9000
-    funcs::LaunchGatherKthValue<T>(dev_ctx,
-                                   tran_input_data,
-                                   input_width,
-                                   input_height,
-                                   k,
-                                   tran_output_data,
-                                   tran_indices_data);
+    if (input_width > std::numeric_limits<int32_t>::max()) {
+      funcs::LaunchGatherKthValue<T, int64_t>(dev_ctx,
+                                              tran_input_data,
+                                              input_width,
+                                              input_height,
+                                              k,
+                                              tran_output_data,
+                                              tran_indices_data);
+    } else {
+      funcs::LaunchGatherKthValue<T, int32_t>(
+          dev_ctx,
+          tran_input_data,
+          static_cast<int32_t>(input_width),
+          static_cast<int32_t>(input_height),
+          static_cast<int32_t>(k),
+          tran_output_data,
+          tran_indices_data);
+    }
 #else
     PADDLE_ENFORCE_EQ(
         SortKthvalue<T>(dev_ctx,

--- a/paddle/phi/kernels/gpu/kthvalue_kernel.cu
+++ b/paddle/phi/kernels/gpu/kthvalue_kernel.cu
@@ -198,7 +198,7 @@ void KthvalueKernel(const Context& dev_ctx,
     const int64_t& input_width = in_dims[in_dims.size() - 1];
 #if defined(PADDLE_WITH_CUDA) && CUDA_VERSION >= 9000
     const T* input_data = x.data<T>();
-    if (input_width > std::numeric_limits<int32_t>::max()) {
+    if (input_width * input_height > std::numeric_limits<int32_t>::max()) {
       funcs::LaunchGatherKthValue<T, int64_t>(dev_ctx,
                                               input_data,
                                               input_width,
@@ -270,7 +270,7 @@ void KthvalueKernel(const Context& dev_ctx,
     const int64_t input_width = trans_dims[trans_dims.size() - 1];
 
 #if defined(PADDLE_WITH_CUDA) && CUDA_VERSION >= 9000
-    if (input_width > std::numeric_limits<int32_t>::max()) {
+    if (input_width * input_height > std::numeric_limits<int32_t>::max()) {
       funcs::LaunchGatherKthValue<T, int64_t>(dev_ctx,
                                               tran_input_data,
                                               input_width,

--- a/paddle/phi/kernels/gpu/kthvalue_kernel.cu
+++ b/paddle/phi/kernels/gpu/kthvalue_kernel.cu
@@ -23,7 +23,7 @@
 #include "paddle/phi/kernels/funcs/top_k_function_cuda.h"
 
 namespace phi {
-inline int getBlockSize(int col) {
+inline int getBlockSize(int64_t col) {
   if (col > 512)
     return 1024;
   else if (col > 256 && col <= 512)
@@ -41,7 +41,7 @@ bool SortKthvalue(const phi::GPUContext& dev_ctx,
                   const DenseTensor* input_tensor,
                   const int64_t num_cols,
                   const int64_t num_rows,
-                  const int k,
+                  const int64_t k,
                   DenseTensor* out_tensor,
                   DenseTensor* indices_tensor) {
   auto cu_stream = dev_ctx.stream();
@@ -103,7 +103,8 @@ bool SortKthvalue(const phi::GPUContext& dev_ctx,
   }
 #endif
   DenseTensor temp_storage;
-  temp_storage.Resize({static_cast<int>(temp_storage_bytes / sizeof(uint8_t))});
+  temp_storage.Resize(
+      {static_cast<int64_t>(temp_storage_bytes / sizeof(uint8_t))});
   uint8_t* temp_storage_data = dev_ctx.template Alloc<uint8_t>(&temp_storage);
 
   err = cub::DeviceSegmentedRadixSort::SortPairs(temp_storage_data,
@@ -140,7 +141,8 @@ bool SortKthvalue(const phi::GPUContext& dev_ctx,
   auto e_indices = EigenMatrix<int64_t>::From(*indices_tensor, dim);
   auto e_tmp_indices =
       EigenMatrix<int64_t>::From(static_cast<const DenseTensor>(temp_indices));
-  std::vector<int> odims = {static_cast<int>(num_rows), static_cast<int>(1)};
+
+  std::vector<int64_t> odims = {num_rows, 1};
   dim = common::make_ddim(odims);
   auto e_values = EigenMatrix<T>::From(*out_tensor, dim);
   auto e_tmp_values =
@@ -198,7 +200,7 @@ void KthvalueKernel(const Context& dev_ctx,
     const int64_t& input_width = in_dims[in_dims.size() - 1];
 #if defined(PADDLE_WITH_CUDA) && CUDA_VERSION >= 9000
     const T* input_data = x.data<T>();
-    if (input_width * input_height > std::numeric_limits<int32_t>::max()) {
+    if (input_width > std::numeric_limits<int32_t>::max() / input_height) {
       funcs::LaunchGatherKthValue<T, int64_t>(dev_ctx,
                                               input_data,
                                               input_width,
@@ -270,7 +272,7 @@ void KthvalueKernel(const Context& dev_ctx,
     const int64_t input_width = trans_dims[trans_dims.size() - 1];
 
 #if defined(PADDLE_WITH_CUDA) && CUDA_VERSION >= 9000
-    if (input_width * input_height > std::numeric_limits<int32_t>::max()) {
+    if (input_width > std::numeric_limits<int32_t>::max() / input_height) {
       funcs::LaunchGatherKthValue<T, int64_t>(dev_ctx,
                                               tran_input_data,
                                               input_width,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

#### Bug Fixes:
1. Add `typename IndexType` to distinguish index types
2. Change `shared_mem` to dynamic allocation, instead of hardcoding
3. Set `grid_dim, block_dim` to avoid exceeding
4. Resolve write race condition for `foundKValue` by adopting `CudaAtomicMin`
5. Fix grad_kernel `int64_t` handling

#### Tests:

The accuracy diff is due for multiple identical kth values, resulting in different index positions. 
![image](https://github.com/user-attachments/assets/56dbdde3-528c-4845-8833-9f3e277109d3)

After comparing only the first value, all accuracy tests pass
![image](https://github.com/user-attachments/assets/7825ef9a-3391-4d36-a021-349a29c4c4d9)

#### TODO:
- [x] 1. Support `int64_t k` param in API signature
- [ ] 2. Replace `shared_mem` in `RadixTopK` with dynamic allocation

Pcard-85711