### PR TITLE
pp_save_load_amp

### DIFF
--- a/python/paddle/distributed/auto_parallel/api.py
+++ b/python/paddle/distributed/auto_parallel/api.py
@@ -2317,7 +2317,6 @@ def shard_scaler(scaler: GradScaler) -> GradScaler:
         current_process_mesh = None
 
         self._found_inf = paddle.to_tensor(np.array([0]).astype(np.bool_))
-        self_found_inf_is_changed = self._found_inf.clone()
         mesh2param_grads = {}
         if getattr(optimizer, '_param_groups', None) and isinstance(
             optimizer._param_groups[0], dict
@@ -2431,7 +2430,7 @@ def shard_scaler(scaler: GradScaler) -> GradScaler:
             )
             self._found_inf = _C_ops.bitwise_or(self._found_inf, temp_found_inf)
         # nothing need to unscale and check inf
-        if paddle.equal(self._found_inf, self_found_inf_is_changed):
+        if not mesh2param_grads:
             return
         # The rank of src_mesh, should not overwrite the original variable `self._found_inf`
         if self._found_inf.process_mesh == current_process_mesh:

--- a/python/paddle/distributed/auto_parallel/api.py
+++ b/python/paddle/distributed/auto_parallel/api.py
@@ -2429,9 +2429,7 @@ def shard_scaler(scaler: GradScaler) -> GradScaler:
                 temp_found_inf, src_mesh, temp_found_inf.placements
             )
             self._found_inf = _C_ops.bitwise_or(self._found_inf, temp_found_inf)
-        # nothing need to unscale and check inf
-        if not mesh2param_grads:
-            return
+
         # The rank of src_mesh, should not overwrite the original variable `self._found_inf`
         if self._found_inf.process_mesh == current_process_mesh:
             for process_mesh in mesh2param_grads.keys():

--- a/python/paddle/distributed/auto_parallel/api.py
+++ b/python/paddle/distributed/auto_parallel/api.py
@@ -2317,6 +2317,7 @@ def shard_scaler(scaler: GradScaler) -> GradScaler:
         current_process_mesh = None
 
         self._found_inf = paddle.to_tensor(np.array([0]).astype(np.bool_))
+        self_found_inf_is_changed = self._found_inf.clone()
         mesh2param_grads = {}
         if getattr(optimizer, '_param_groups', None) and isinstance(
             optimizer._param_groups[0], dict
@@ -2324,7 +2325,12 @@ def shard_scaler(scaler: GradScaler) -> GradScaler:
             for group in optimizer._param_groups:
                 for param in group['params']:
                     tgt_grad = param._grad_ivar()
-                    if tgt_grad is not None:
+                    if (
+                        tgt_grad is not None
+                        and getattr(
+                            tgt_grad, '_is_initialized', lambda: False
+                        )()
+                    ):
                         if src_mesh is None:
                             src_mesh = tgt_grad.process_mesh
                         if (
@@ -2341,7 +2347,10 @@ def shard_scaler(scaler: GradScaler) -> GradScaler:
         else:
             for param in optimizer._parameter_list:
                 tgt_grad = param._grad_ivar()
-                if tgt_grad is not None:
+                if (
+                    tgt_grad is not None
+                    and getattr(tgt_grad, '_is_initialized', lambda: False)()
+                ):
                     if src_mesh is None:
                         src_mesh = tgt_grad.process_mesh
                     if (
@@ -2421,7 +2430,9 @@ def shard_scaler(scaler: GradScaler) -> GradScaler:
                 temp_found_inf, src_mesh, temp_found_inf.placements
             )
             self._found_inf = _C_ops.bitwise_or(self._found_inf, temp_found_inf)
-
+        # nothing need to unscale and check inf
+        if paddle.equal(self._found_inf, self_found_inf_is_changed):
+            return
         # The rank of src_mesh, should not overwrite the original variable `self._found_inf`
         if self._found_inf.process_mesh == current_process_mesh:
             for process_mesh in mesh2param_grads.keys():


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Auto Parallel


### PR Types
Bug fixes


### Description
#### 动半pp的save_load精度对齐，目前热启动存在两个问题需要修复，描述如下：

- 问题1 热启动报异常访问内存：

​	![image](https://github.com/user-attachments/assets/62c9a47a-83ad-4513-8beb-16ed37cfe8af)

​	**报错直接原因是**：

​	热启动的时候，在`float16精度`下(`bf16`也会如此)，为了防止数据下溢，反向过程中，对loss和梯度做scale，在参数更新时，即opt阶段，需要做unscale将数据缩放回来，此时会调用`auto_parallel.api`中的`unscale_method`方法，在该方法中，只要`param`的`grad`不为None，就会被添加到处理列表中，而对于非本rank的梯度，此时处于定义了但未初始化的状态，因此是未分配内存的，此时访问这些`grad`则会报非法访问的内存错误。

![image](https://github.com/user-attachments/assets/c255317c-3c1b-4efa-836f-f2018e8c2667)

- 问题2 热启动时参数未正确加载（不会报错，会直接用原始模型参数做初始化训练，但无法正确加载checkpoint）	

![image](https://github.com/user-attachments/assets/62150d9e-1c74-454e-b421-2ba6087efe7f)

​		**报错直接原因是：**

​			在save的时候，没有用到state_dict，而是直接保存了模型参数，未保存optimizer的参数，一方面保存的checkpoint中没有optimizer参数的信息，另一方面，导致加载时，key的名称对不上，以state_dict保存会有model.和optimizer.的前缀，后者没有。

![image](https://github.com/user-attachments/assets/150b20eb-be4f-4437-abc4-102134e41549)

![image](https://github.com/user-attachments/assets/68ca3b19-ca4a-4f59-a7e2-9025fb92ab6c)

- 问题1由本pr修复，问题2在paddlenlp由以下pr修复：https://github.com/PaddlePaddle/PaddleNLP/pull/10789
