### PR TITLE
[XPU]Support aarch64 for XPUFFT

### DIFF
--- a/cmake/external/xpu.cmake
+++ b/cmake/external/xpu.cmake
@@ -55,7 +55,7 @@ else()
 endif()
 
 if(NOT DEFINED XPU_FFT_BASE_DATE)
-  set(XPU_FFT_BASE_DATE "20250623")
+  set(XPU_FFT_BASE_DATE "20250630")
 endif()
 
 set(XPU_XRE_BASE_URL
@@ -89,10 +89,7 @@ if(WITH_XPU_XRE5)
 endif()
 
 if(WITH_XPU_FFT)
-  set(XPU_FFT_BASE_URL
-      "https://klx-sdk-release-public.su.bcebos.com/xpufft/kl3/${XPU_FFT_BASE_DATE}"
-  )
-  set(XPU_FFT_DIR_NAME "xpufft_ubuntu2004-x86_64")
+  set(XPU_FFT_BASE_URL "https://klx-sdk-release-public.su.bcebos.com/xpufft")
 endif()
 
 if(WITH_ARM)
@@ -106,6 +103,9 @@ if(WITH_ARM)
     set(XPU_XRE_DIR_NAME "")
     set(XPU_XCCL_DIR_NAME "") # TODO: xccl has no kylin output now.
     set(XPU_XFT_DIR_NAME "") # TODO: xft has no kylin output at now.
+  endif()
+  if(WITH_XPU_FFT)
+    set(XPU_FFT_DIR_NAME "kylin_v10_aarch64/xpufft_kylinv10_aarch64_v2")
   endif()
 elseif(WITH_SUNWAY)
   set(XPU_XRE_DIR_NAME "xre-deepin_sw6_64")
@@ -132,6 +132,9 @@ else()
   else()
     set(XPU_XRE_DIR_NAME "xre-ubuntu_1604_x86_64")
     set(XPU_XHPC_DIR_NAME "xhpc-ubuntu1604_x86_64")
+  endif()
+  if(WITH_XPU_FFT)
+    set(XPU_FFT_DIR_NAME "kl3/${XPU_FFT_BASE_DATE}/xpufft_ubuntu2004-x86_64")
   endif()
   set(XPU_XCCL_DIR_NAME "xccl_Linux_x86_64")
   set(XPU_XFT_DIR_NAME "xft_internal_ubuntu2004")
@@ -253,7 +256,6 @@ if(WITH_XPU_XRE5)
       ${CMAKE_SOURCE_DIR}/tools/xpu/get_xpti_dependence.sh ${XPU_XPTI_URL}
       ${XPU_XPTI_DIR_NAME} && bash
       ${CMAKE_SOURCE_DIR}/tools/xpu/get_xpufft_dependence.sh ${XPU_FFT_URL}
-      xpufft
     DOWNLOAD_NO_PROGRESS 1
     UPDATE_COMMAND ""
     CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${XPU_INSTALL_ROOT}
@@ -280,7 +282,6 @@ else()
       ${CMAKE_SOURCE_DIR}/tools/xpu/get_xpti_dependence.sh ${XPU_XPTI_URL}
       ${XPU_XPTI_DIR_NAME} && bash
       ${CMAKE_SOURCE_DIR}/tools/xpu/get_xpufft_dependence.sh ${XPU_FFT_URL}
-      xpufft
     DOWNLOAD_NO_PROGRESS 1
     UPDATE_COMMAND ""
     CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${XPU_INSTALL_ROOT}

--- a/paddle/phi/kernels/CMakeLists.txt
+++ b/paddle/phi/kernels/CMakeLists.txt
@@ -382,7 +382,8 @@ if(WITH_XPU)
   # The kernel related to xpufft must have WITH_XPU_FFT enabled.
   if(NOT WITH_XPU_FFT)
     list(REMOVE_ITEM kernel_xpu "xpu/complex_kernel.cc"
-         "xpu/complex_grad_kernel.cc")
+         "xpu/complex_grad_kernel.cc" "xpu/fft_kernel.cc"
+         "xpu/fft_grad_kernel.cc")
   endif()
 
   collect_srcs(kernels_srcs SRCS ${kernel_xpu})

--- a/tools/xpu/get_xpufft_dependence.sh
+++ b/tools/xpu/get_xpufft_dependence.sh
@@ -17,7 +17,7 @@
 set -ex
 
 FFT_URL=$1
-FFT_DIR_NAME=$2
+FFT_DIR_NAME="xpufft"
 
 if ! [ -n "$FFT_URL" ]; then
   exit 0


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Custom Device

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
为XPUFFT添加aarch64的支持，修复了cmake时不设置WITH_XPU_FFT时导致的编译报错
Pcard-75624