### PR TITLE
fix compile failed with WITH_NV_JETSON Flag

### DIFF
--- a/paddle/phi/kernels/funcs/pooling.cu
+++ b/paddle/phi/kernels/funcs/pooling.cu
@@ -1446,7 +1446,7 @@ class Pool3dFunctor<phi::GPUContext, PoolProcess, T> {
 
     int64_t nthreads = batch_size * output_channels * output_depth *
                        output_height * output_width;
-    int64_t thread_num = 1024;
+    int thread_num = 1024;
 #ifdef WITH_NV_JETSON
     backends::gpu::ChangeThreadNum(context, &thread_num);
 #endif


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
issue url: https://github.com/PaddlePaddle/Paddle/issues/73313
fix compile failed with WITH_NV_JETSON Flag
ChangeThreadNum 的 num_thread 的参数类型是 int*，而且 int 对于线程数的表示已经足够
cc @jaminegod