### PR TITLE
[3.1][SOT] Limit SOT to Only Support Plain Dataclasses (#73627, #73718)

### DIFF
--- a/python/paddle/jit/dy2static/utils.py
+++ b/python/paddle/jit/dy2static/utils.py
@@ -308,6 +308,10 @@ def is_dataclass_type(obj):
     return is_dataclass(obj) and isinstance(obj, type)
 
 
+def is_plain_dataclass_type(cls: type):
+    return is_dataclass_type(cls) and len(cls.__mro__) == 2
+
+
 def dataclass_as_dict(obj):
     return {f.name: getattr(obj, f.name) for f in dataclasses.fields(obj)}
 

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
@@ -18,7 +18,6 @@ import dataclasses
 import operator
 import sys
 import types
-from dataclasses import asdict
 from enum import Enum
 from functools import cached_property, reduce
 from typing import TYPE_CHECKING, Any
@@ -29,6 +28,7 @@ import paddle
 from paddle._typing import unreached
 from paddle.framework import core
 from paddle.jit.dy2static.utils import (
+    dataclass_as_dict,
     dataclass_from_dict,
     is_plain_dataclass_type,
 )
@@ -2471,7 +2471,10 @@ class DataClassInstanceVariable(VariableBase):
             ).bind(self, "__post_init__")
         if name == "__dataclass_fields__":
             return VariableFactory.from_value(
-                {fd.name: fd for fd in dataclasses.fields(self.value)},
+                {
+                    fd.name: fd
+                    for fd in dataclasses.fields(self.class_var.value)
+                },
                 graph=self.graph,
                 tracker=GetAttrTracker(self, "__dataclass_fields__"),
             )
@@ -2587,7 +2590,7 @@ class DataClassInstanceVariable(VariableBase):
                 type(value), graph, DanglingTracker()
             )
             try:
-                data_dict = asdict(value)
+                data_dict = dataclass_as_dict(value)
             except:
                 data_dict = {}
             var = DataClassInstanceVariable(

--- a/test/sot/test_dataclass.py
+++ b/test/sot/test_dataclass.py
@@ -100,10 +100,18 @@ def set_attr(data: DataMeta):
     return res
 
 
+@check_no_breakgraph
+def get__dataclass_fields__(data: DataMeta):
+    return list(data.__dataclass_fields__), list(
+        data.__class__.__dataclass_fields__
+    )
+
+
 class TestDataClassInstance(TestCaseBase):
     def test_get_attr(self):
         dm = DataMeta(x=paddle.randn([1, 2]), y=paddle.randn([1]))
         self.assert_results(get_attr, dm)
+        self.assert_results(get__dataclass_fields__, dm)
 
     def test_set_attr(self):
         dm = DataMeta(x=paddle.ones([1, 2]), n=2)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
原PR：https://github.com/PaddlePaddle/Paddle/pull/73627 https://github.com/PaddlePaddle/Paddle/pull/73718

这个pr增加一些限制，让 `DataClassVariable` 和 `DataClassInstanceVariable` 适配 plain dataclasses，即：
```python
from dataclasses import dataclass

@dataclass
class Person:
    name : str
	id: int
```