### PR TITLE
[0-size Tensor No.117] Add 0-size Tensor support for paddle.linalg.svd_lowrank

### DIFF
--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -3170,7 +3170,7 @@ def svd_lowrank(
     m, n = x.shape[-2:]
     if q is None:
         q = min(6, m, n)
-    elif not (q >= 0 and q <= min(m, n)):
+    elif min(m, n) != 0 and not (q >= 0 and q <= min(m, n)):
         raise ValueError(
             f'q(={q}) must be non-negative integer'
             f' and not greater than min(m, n)={min(m, n)}'
@@ -3194,7 +3194,8 @@ def svd_lowrank(
         else:
             B_t = paddle.matmul(x, Q_c) - paddle.matmul(M, Q_c)
         assert B_t.shape[-2] == m, (B_t.shape, m)
-        assert B_t.shape[-1] == q, (B_t.shape, q)
+        if B_t.shape[-1] != 0:
+            assert B_t.shape[-1] == q, (B_t.shape, q)
         assert B_t.shape[-1] <= B_t.shape[-2], B_t.shape
         U, S, Vh = paddle.linalg.svd(B_t, full_matrices=False)
         V = _transjugate(Vh)
@@ -3207,7 +3208,8 @@ def svd_lowrank(
         else:
             B = paddle.matmul(A_t, Q_c) - paddle.matmul(M_t, Q_c)
         B_t = _transpose(B)
-        assert B_t.shape[-2] == q, (B_t.shape, q)
+        if B_t.shape[-2] != 0:
+            assert B_t.shape[-2] == q, (B_t.shape, q)
         assert B_t.shape[-1] == n, (B_t.shape, n)
         assert B_t.shape[-1] <= B_t.shape[-2], B_t.shape
         U, S, Vh = paddle.linalg.svd(B_t, full_matrices=False)

--- a/test/legacy_test/test_svd_lowrank.py
+++ b/test/legacy_test/test_svd_lowrank.py
@@ -235,5 +235,28 @@ class TestStaticSvdLowrankAPI(unittest.TestCase):
                             )
 
 
+class TestSvdLowRankAPI_ZeroSize(unittest.TestCase):
+    def generate_input(self):
+        self._input_shape = (1, 4, 0)
+        self._input_data = np.random.random(self._input_shape).astype("float64")
+
+    def generate_output(self):
+        self._output_data = [
+            np.random.random((1, 4, 0)).astype("float64"),
+            np.random.random((1, 0)).astype("float64"),
+            np.random.random((1, 0, 0)).astype("float64"),
+        ]
+
+    def test_dygraph_api(self):
+        self.generate_input()
+        self.generate_output()
+        x = paddle.to_tensor(self._input_data)
+        x.stop_gradient = False
+        out = paddle.linalg.svd_lowrank(x, q=4)
+        np.testing.assert_allclose(out[0].numpy(), self._output_data[0])
+        np.testing.assert_allclose(out[1].numpy(), self._output_data[1])
+        np.testing.assert_allclose(out[2].numpy(), self._output_data[2])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
python部分增加0-size支持

https://github.com/PFCCLab/PaddleAPITest/blob/0081924ecedeb2eca0a97b74bee40719d4b7d3f8/tester/base.py#L547
![image](https://github.com/user-attachments/assets/2021ce95-c641-4986-83f7-d5e10dd242b6)
svd_lowrank是配置只支持前向
单测测试前向

PaddleAPITest测试通过
![image](https://github.com/user-attachments/assets/e6a43276-1827-45ce-aebb-6776a7486758)
