### PR TITLE
add FLAGS_paddle_grad_inputs_zero_copy, support paddle.grad zero copy…

### DIFF
--- a/paddle/common/flags.cc
+++ b/paddle/common/flags.cc
@@ -2158,3 +2158,14 @@ PHI_DEFINE_EXPORTED_int32(
 PHI_DEFINE_EXPORTED_bool(check_cuda_error,
                          false,
                          "Checking whether CUDA error occurred or not.");
+
+/**
+ * Dygraph related FLAG
+ * Name: FLAGS_paddle_grad_inputs_zero_copy
+ * Value Range: bool, default=false
+ * Example:
+ * Note: Whether zero copy paddle.grad's inputs.
+ */
+PHI_DEFINE_EXPORTED_bool(paddle_grad_inputs_zero_copy,
+                         false,
+                         "Whether zero copy paddle.grad's inputs.");

--- a/paddle/fluid/eager/backward.cc
+++ b/paddle/fluid/eager/backward.cc
@@ -19,6 +19,7 @@
 #include "paddle/phi/kernels/autotune/switch_autotune.h"
 
 COMMON_DECLARE_int32(call_stack_level);
+COMMON_DECLARE_bool(paddle_grad_inputs_zero_copy);
 namespace egr {
 
 std::unordered_map<GradNodeBase*, int> getInDegreeMap(
@@ -203,7 +204,7 @@ std::vector<paddle::Tensor> RunBackward(
         use_shared_buffer = output_tensor->IsSharedBufferWith(*input_tensor);
       }
 
-      if (use_shared_buffer) {
+      if (use_shared_buffer || FLAGS_paddle_grad_inputs_zero_copy) {
         // Share buffer with given grad_tensor
         paddle::small_vector<std::vector<paddle::Tensor>, kSlotSmallVectorSize>
             inputs_grad_tensors;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->
paddle.grad输入的反向梯度，进入backward后会复制一份显存，这在大模型高频使用paddle.grad的背景下很影响效率。不清楚早期设计基于哪些考虑做的拷贝，暂不敢直接去掉。

提供FLAGS_paddle_grad_inputs_zero_copy，用于设置paddle.grad不做深拷贝。

Pcard-67164