### PR TITLE
Change the name MKLDNN to ONEDNN in the test/mkldnn unit tests [fluid_ops]

### DIFF
--- a/test/mkldnn/mkldnn_op_test.py
+++ b/test/mkldnn/mkldnn_op_test.py
@@ -168,7 +168,7 @@ def check_if_mkldnn_batchnorm_primitives_exist_in_bwd(
                 for id, name in enumerate(test_case.fetch_list):
                     __assert_close(test_case, var_dict[name], out[id], name)
 
-        print("MKLDNN op test forward passed: ", str(place), data_layout)
+        print("ONEDNN op test forward passed: ", str(place), data_layout)
 
 
 def format_reorder(out, size):

--- a/test/mkldnn/test_activation_bf16_mkldnn_op.py
+++ b/test/mkldnn/test_activation_bf16_mkldnn_op.py
@@ -25,7 +25,7 @@ from paddle.base import core
 
 
 @OpTestTool.skip_if_not_cpu_bf16()
-class MKLDNNBF16ActivationOp(metaclass=abc.ABCMeta):
+class ONEDNNBF16ActivationOp(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def config(self):
         pass
@@ -74,7 +74,7 @@ class MKLDNNBF16ActivationOp(metaclass=abc.ABCMeta):
         )
 
 
-class TestMKLDNNSigmoidBF16Op(MKLDNNBF16ActivationOp, TestActivation):
+class TestONEDNNSigmoidBF16Op(ONEDNNBF16ActivationOp, TestActivation):
     def config(self):
         self.op_type = "sigmoid"
         self.check_pir_onednn = True
@@ -86,7 +86,7 @@ class TestMKLDNNSigmoidBF16Op(MKLDNNBF16ActivationOp, TestActivation):
         return dout * self.op_forward(x) * (1 - self.op_forward(x))
 
 
-class TestMKLDNNSqrtBF16Op(MKLDNNBF16ActivationOp, TestActivation):
+class TestONEDNNSqrtBF16Op(ONEDNNBF16ActivationOp, TestActivation):
     def config(self):
         self.op_type = "sqrt"
         self.check_pir_onednn = True
@@ -101,7 +101,7 @@ class TestMKLDNNSqrtBF16Op(MKLDNNBF16ActivationOp, TestActivation):
         return dout / (2 * np.sqrt(x))
 
 
-class TestMKLDNNGeluErfBF16Op(MKLDNNBF16ActivationOp, TestActivation):
+class TestONEDNNGeluErfBF16Op(ONEDNNBF16ActivationOp, TestActivation):
     def config(self):
         self.op_type = "gelu"
         self.check_pir_onednn = True
@@ -117,12 +117,12 @@ class TestMKLDNNGeluErfBF16Op(MKLDNNBF16ActivationOp, TestActivation):
         )
 
 
-class TestMKLDNNGeluErfDim2BF16Op(TestMKLDNNGeluErfBF16Op):
+class TestONEDNNGeluErfDim2BF16Op(TestONEDNNGeluErfBF16Op):
     def init_data(self):
         self.x = np.random.uniform(-1, 1, [11, 17]).astype(np.float32)
 
 
-class TestMKLDNNGeluTanhBF16Op(MKLDNNBF16ActivationOp, TestActivation):
+class TestONEDNNGeluTanhBF16Op(ONEDNNBF16ActivationOp, TestActivation):
     def config(self):
         self.op_type = "gelu"
         self.check_pir_onednn = True
@@ -150,12 +150,12 @@ class TestMKLDNNGeluTanhBF16Op(MKLDNNBF16ActivationOp, TestActivation):
         self.attrs = {"use_mkldnn": True, "approximate": True}
 
 
-class TestMKLDNNGeluTanhDim2BF16Op(TestMKLDNNGeluTanhBF16Op):
+class TestONEDNNGeluTanhDim2BF16Op(TestONEDNNGeluTanhBF16Op):
     def init_data(self):
         self.x = np.random.uniform(-1, 1, [11, 17]).astype(np.float32)
 
 
-class TestMKLDNNReluBF16Op(MKLDNNBF16ActivationOp, TestActivation):
+class TestONEDNNReluBF16Op(ONEDNNBF16ActivationOp, TestActivation):
     def config(self):
         self.op_type = "relu"
         self.check_pir_onednn = True
@@ -167,7 +167,7 @@ class TestMKLDNNReluBF16Op(MKLDNNBF16ActivationOp, TestActivation):
         return dout
 
 
-class TestMKLDNNMishBF16Op(MKLDNNBF16ActivationOp, TestActivation):
+class TestONEDNNMishBF16Op(ONEDNNBF16ActivationOp, TestActivation):
     def config(self):
         self.op_type = "mish"
         self.check_pir_onednn = True
@@ -186,7 +186,7 @@ class TestMKLDNNMishBF16Op(MKLDNNBF16ActivationOp, TestActivation):
         return dout * ((np.exp(x) * omega) / delta**2)
 
 
-class TestMKLDNNRelu6BF16Op(MKLDNNBF16ActivationOp, TestActivation):
+class TestONEDNNRelu6BF16Op(ONEDNNBF16ActivationOp, TestActivation):
     def config(self):
         self.op_type = "relu6"
         self.check_pir_onednn = True
@@ -198,7 +198,7 @@ class TestMKLDNNRelu6BF16Op(MKLDNNBF16ActivationOp, TestActivation):
         return np.where((x > 0) & (x <= 6), dout, 0)
 
 
-class TestMKLDNNLeakyReluBF16Op(MKLDNNBF16ActivationOp, TestActivation):
+class TestONEDNNLeakyReluBF16Op(ONEDNNBF16ActivationOp, TestActivation):
     def config(self):
         self.op_type = "leaky_relu"
         self.check_pir_onednn = True
@@ -214,7 +214,7 @@ class TestMKLDNNLeakyReluBF16Op(MKLDNNBF16ActivationOp, TestActivation):
         self.attrs = {"use_mkldnn": True, "alpha": self.alpha}
 
 
-class TestMKLDNNSwishBF16Op(MKLDNNBF16ActivationOp, TestActivation):
+class TestONEDNNSwishBF16Op(ONEDNNBF16ActivationOp, TestActivation):
     def config(self):
         self.op_type = "swish"
         self.check_pir_onednn = True
@@ -233,7 +233,7 @@ class TestMKLDNNSwishBF16Op(MKLDNNBF16ActivationOp, TestActivation):
         self.attrs = {"use_mkldnn": True, "beta": self.beta}
 
 
-class TestMKLDNNHardSwishBF16Op(MKLDNNBF16ActivationOp, TestActivation):
+class TestONEDNNHardSwishBF16Op(ONEDNNBF16ActivationOp, TestActivation):
     def config(self):
         self.op_type = "hard_swish"
         self.check_pir_onednn = True
@@ -247,7 +247,7 @@ class TestMKLDNNHardSwishBF16Op(MKLDNNBF16ActivationOp, TestActivation):
         return np.where(result > 3, dout, dout * (2 * x + 3) / 6)
 
 
-class TestMKLDNNTanhBF16Op(MKLDNNBF16ActivationOp, TestActivation):
+class TestONEDNNTanhBF16Op(ONEDNNBF16ActivationOp, TestActivation):
     def config(self):
         self.op_type = "tanh"
         self.check_pir_onednn = True
@@ -259,7 +259,7 @@ class TestMKLDNNTanhBF16Op(MKLDNNBF16ActivationOp, TestActivation):
         return dout * (1 - np.tanh(x) ** 2)
 
 
-class TestMKLDNNAbsBF16Op(MKLDNNBF16ActivationOp, TestActivation):
+class TestONEDNNAbsBF16Op(ONEDNNBF16ActivationOp, TestActivation):
     def config(self):
         self.op_type = "abs"
         self.check_pir_onednn = True
@@ -271,7 +271,7 @@ class TestMKLDNNAbsBF16Op(MKLDNNBF16ActivationOp, TestActivation):
         return dout * np.sign(x)
 
 
-class TestMKLDNNEluBF16Op(MKLDNNBF16ActivationOp, TestActivation):
+class TestONEDNNEluBF16Op(ONEDNNBF16ActivationOp, TestActivation):
     def config(self):
         self.op_type = "elu"
         self.check_pir_onednn = True
@@ -287,7 +287,7 @@ class TestMKLDNNEluBF16Op(MKLDNNBF16ActivationOp, TestActivation):
         self.attrs = {"use_mkldnn": True, "alpha": self.alpha}
 
 
-class TestMKLDNNExpBF16Op(MKLDNNBF16ActivationOp, TestActivation):
+class TestONEDNNExpBF16Op(ONEDNNBF16ActivationOp, TestActivation):
     def config(self):
         self.op_type = "exp"
         self.check_pir_onednn = True

--- a/test/mkldnn/test_batch_norm_mkldnn_op.py
+++ b/test/mkldnn/test_batch_norm_mkldnn_op.py
@@ -32,7 +32,7 @@ from paddle.base import core
 _set_use_system_allocator(True)
 
 
-class TestMKLDNNBatchNormOpTraining(TestBatchNormOpTraining):
+class TestONEDNNBatchNormOpTraining(TestBatchNormOpTraining):
     def init_kernel_type(self):
         self.use_mkldnn = True
         self.data_formats = ["NCHW"]
@@ -81,15 +81,15 @@ class TestMKLDNNBatchNormOpTraining(TestBatchNormOpTraining):
             super().test_forward_backward()
 
 
-class TestMKLDNNBatchNormOpTraining_NHWC(TestMKLDNNBatchNormOpTraining):
+class TestONEDNNBatchNormOpTraining_NHWC(TestONEDNNBatchNormOpTraining):
     def init_kernel_type(self):
         self.use_mkldnn = True
         self.data_formats = ["NHWC"]
 
 
-class TestMKLDNNBatchNormOpExistedPrimitives(TestMKLDNNBatchNormOpTraining):
+class TestONEDNNBatchNormOpExistedPrimitives(TestONEDNNBatchNormOpTraining):
     def init_test_case(self):
-        TestMKLDNNBatchNormOpTraining.init_test_case(self)
+        TestONEDNNBatchNormOpTraining.init_test_case(self)
         self.fetch_list = ['y', 'x@GRAD']
 
     def test_forward_backward(self):
@@ -136,7 +136,7 @@ class TestMKLDNNBatchNormOpExistedPrimitives(TestMKLDNNBatchNormOpTraining):
         )
 
 
-class TestMKLDNNBatchNormOpInference(TestBatchNormOpInference):
+class TestONEDNNBatchNormOpInference(TestBatchNormOpInference):
     def init_kernel_type(self):
         self.use_mkldnn = True
 
@@ -154,7 +154,7 @@ class TestMKLDNNBatchNormOpInference(TestBatchNormOpInference):
             )
 
 
-class TestMKLDNNBatchNormOpInference_NHWC(TestMKLDNNBatchNormOpInference):
+class TestONEDNNBatchNormOpInference_NHWC(TestONEDNNBatchNormOpInference):
     def test_check_output(self):
         place = core.CPUPlace()
         data_format = "NHWC"
@@ -164,7 +164,7 @@ class TestMKLDNNBatchNormOpInference_NHWC(TestMKLDNNBatchNormOpInference):
         )
 
 
-class TestMKLDNNBatchNormOpWithReluInference(TestBatchNormOpInference):
+class TestONEDNNBatchNormOpWithReluInference(TestBatchNormOpInference):
     def init_kernel_type(self):
         self.use_mkldnn = True
         self.fuse_with_relu = True

--- a/test/mkldnn/test_cast_mkldnn_op.py
+++ b/test/mkldnn/test_cast_mkldnn_op.py
@@ -24,7 +24,7 @@ from paddle.base import core
 @unittest.skipIf(
     not core.supports_bfloat16(), "place does not support BF16 evaluation"
 )
-class TestCastBF16ToFP32MKLDNNOp(OpTest):
+class TestCastBF16ToFP32ONEDNNOp(OpTest):
     def init_data(self):
         self.out = np.random.random(size=self.shape).astype("float32")
         self.x = convert_float_to_uint16(self.out)
@@ -64,25 +64,25 @@ class TestCastBF16ToFP32MKLDNNOp(OpTest):
         self.shape = [10, 10]
 
 
-class TestCastFP32ToBF16MKLDNNOp(TestCastBF16ToFP32MKLDNNOp):
+class TestCastFP32ToBF16ONEDNNOp(TestCastBF16ToFP32ONEDNNOp):
     def init_data(self):
         self.x = np.random.random(size=[2, 6]).astype("float32")
         self.out = convert_float_to_uint16(self.x)
 
 
-class TestCastBF16ToBF16MKLDNNOp(TestCastBF16ToFP32MKLDNNOp):
+class TestCastBF16ToBF16ONEDNNOp(TestCastBF16ToFP32ONEDNNOp):
     def init_data(self):
         self.x = np.random.random(size=[6, 13]).astype("uint16")
         self.out = self.x
 
 
-class TestCastFP32ToFP32MKLDNNOp(TestCastBF16ToFP32MKLDNNOp):
+class TestCastFP32ToFP32ONEDNNOp(TestCastBF16ToFP32ONEDNNOp):
     def init_data(self):
         self.x = np.random.random(size=[7, 15]).astype("float32")
         self.out = self.x
 
 
-class TestCastBF16ToFP32MKLDNNOp_ZeroDim(TestCastBF16ToFP32MKLDNNOp):
+class TestCastBF16ToFP32ONEDNNOp_ZeroDim(TestCastBF16ToFP32ONEDNNOp):
     def init_shape(self):
         self.shape = []
 

--- a/test/mkldnn/test_elementwise_div_mkldnn_op.py
+++ b/test/mkldnn/test_elementwise_div_mkldnn_op.py
@@ -26,7 +26,7 @@ from paddle.base.framework import _current_expected_place
     not (isinstance(_current_expected_place(), core.CPUPlace)),
     "GPU is not supported",
 )
-class TestMKLDNNElementwiseDivOp(OpTest):
+class TestONEDNNElementwiseDivOp(OpTest):
     def setUp(self):
         self.op_type = "elementwise_div"
         self.init_dtype()
@@ -73,21 +73,21 @@ class TestMKLDNNElementwiseDivOp(OpTest):
         self.check_output(check_pir_onednn=True)
 
 
-class TestMKLDNNElementwiseDivOp2(TestMKLDNNElementwiseDivOp):
+class TestONEDNNElementwiseDivOp2(TestONEDNNElementwiseDivOp):
     def init_input_output(self):
         self.x = np.random.uniform(0.1, 1, [100]).astype(self.dtype)
         self.y = np.random.uniform(0.1, 1, [100]).astype(self.dtype)
         self.out = np.divide(self.x, self.y)
 
 
-class TestMKLDNNElementwiseDivOp3(TestMKLDNNElementwiseDivOp):
+class TestONEDNNElementwiseDivOp3(TestONEDNNElementwiseDivOp):
     def init_input_output(self):
         self.x = np.random.uniform(0.1, 1, [2, 3, 4, 5]).astype(self.dtype)
         self.y = np.random.uniform(0.1, 1, [2, 3, 4, 5]).astype(self.dtype)
         self.out = np.divide(self.x, self.y)
 
 
-class TestMKLDNNElementwiseDivOp4(TestMKLDNNElementwiseDivOp):
+class TestONEDNNElementwiseDivOp4(TestONEDNNElementwiseDivOp):
     def init_input_output(self):
         self.x = np.random.uniform(1, 2, [2, 3, 4, 32]).astype(self.dtype)
         self.y = np.random.uniform(1, 2, [4, 32]).astype(self.dtype)
@@ -100,7 +100,7 @@ class TestMKLDNNElementwiseDivOp4(TestMKLDNNElementwiseDivOp):
         pass
 
 
-class TestMKLDNNElementwiseDivOp5(TestMKLDNNElementwiseDivOp):
+class TestONEDNNElementwiseDivOp5(TestONEDNNElementwiseDivOp):
     def init_input_output(self):
         self.x = np.random.uniform(1, 2, [2, 3, 4, 100]).astype(self.dtype)
         self.y = np.random.uniform(1, 2, [100]).astype(self.dtype)
@@ -113,7 +113,7 @@ class TestMKLDNNElementwiseDivOp5(TestMKLDNNElementwiseDivOp):
         pass
 
 
-class TestMKLDNNElementwiseDivOpZeroDim(TestMKLDNNElementwiseDivOp):
+class TestONEDNNElementwiseDivOpZeroDim(TestONEDNNElementwiseDivOp):
     def init_input_output(self):
         self.x = np.random.uniform(0.1, 1, [100]).astype(self.dtype)
         self.y = np.array(3.0).astype(self.dtype)
@@ -126,7 +126,7 @@ class TestMKLDNNElementwiseDivOpZeroDim(TestMKLDNNElementwiseDivOp):
         pass
 
 
-class TestMKLDNNElementwiseDivOpZeroDim2(TestMKLDNNElementwiseDivOp):
+class TestONEDNNElementwiseDivOpZeroDim2(TestONEDNNElementwiseDivOp):
     def init_input_output(self):
         self.x = np.array(3.0).astype(self.dtype)
         self.y = np.random.uniform(0.1, 1, [100]).astype(self.dtype)
@@ -139,7 +139,7 @@ class TestMKLDNNElementwiseDivOpZeroDim2(TestMKLDNNElementwiseDivOp):
         pass
 
 
-class TestMKLDNNElementwiseDivOpZeroDim3(TestMKLDNNElementwiseDivOp):
+class TestONEDNNElementwiseDivOpZeroDim3(TestONEDNNElementwiseDivOp):
     def init_input_output(self):
         self.x = np.array(3.0).astype(self.dtype)
         self.y = np.array(3.0).astype(self.dtype)
@@ -153,7 +153,7 @@ class TestMKLDNNElementwiseDivOpZeroDim3(TestMKLDNNElementwiseDivOp):
 
 
 @OpTestTool.skip_if_not_cpu_bf16()
-class TestBf16(TestMKLDNNElementwiseDivOp):
+class TestBf16(TestONEDNNElementwiseDivOp):
     def setUp(self):
         self.op_type = "elementwise_div"
         self.init_dtype()

--- a/test/mkldnn/test_fc_bf16_mkldnn_op.py
+++ b/test/mkldnn/test_fc_bf16_mkldnn_op.py
@@ -76,7 +76,7 @@ class TestFcBf16MklDNNOp(OpTest):
         pass
 
 
-class TestFCMKLDNNOp1(TestFcBf16MklDNNOp):
+class TestFCONEDNNOp1(TestFcBf16MklDNNOp):
     def generate_data(self):
         self.matrix = MatrixGenerate(2, 15, 48, 2, 2)
         self.bias = np.random.random(48).astype(np.float32)

--- a/test/mkldnn/test_fc_mkldnn_op.py
+++ b/test/mkldnn/test_fc_mkldnn_op.py
@@ -29,7 +29,7 @@ class MatrixGenerate:
         self.weights = np.random.random((ic * h * w, oc)).astype("float32")
 
 
-class TestFCMKLDNNOp(OpTest):
+class TestFCONEDNNOp(OpTest):
     def create_data(self):
         self.matrix = MatrixGenerate(1, 10, 15, 3, 3)
         self.bias = np.random.random(15).astype("float32")
@@ -64,7 +64,7 @@ class TestFCMKLDNNOp(OpTest):
         pass
 
 
-class TestFCMKLDNNOp1(TestFCMKLDNNOp):
+class TestFCONEDNNOp1(TestFCONEDNNOp):
     def create_data(self):
         self.matrix = MatrixGenerate(2, 15, 48, 2, 2)
         self.bias = np.random.random(48).astype("float32")

--- a/test/mkldnn/test_fusion_gru_bf16_mkldnn_op.py
+++ b/test/mkldnn/test_fusion_gru_bf16_mkldnn_op.py
@@ -25,7 +25,7 @@ from paddle.base import core
 @unittest.skipIf(
     not core.supports_bfloat16(), "place does not support BF16 evaluation"
 )
-class TestFusionGRUBF16MKLDNNOp(OpTest):
+class TestFusionGRUBF16ONEDNNOp(OpTest):
     def set_confs(self):
         pass
 
@@ -134,17 +134,17 @@ class TestFusionGRUBF16MKLDNNOp(OpTest):
         }
 
 
-class TestFusionGRUINT8MKLDNNOp2(TestFusionGRUBF16MKLDNNOp):
+class TestFusionGRUINT8ONEDNNOp2(TestFusionGRUBF16ONEDNNOp):
     def set_confs(self):
         self.origin_mode = False
 
 
-class TestFusionGRUINT8MKLDNNOp3(TestFusionGRUBF16MKLDNNOp):
+class TestFusionGRUINT8ONEDNNOp3(TestFusionGRUBF16ONEDNNOp):
     def set_confs(self):
         self.with_bias = False
 
 
-class TestFusionGRUINT8MKLDNNBF16WeightsOp(TestFusionGRUBF16MKLDNNOp):
+class TestFusionGRUINT8ONEDNNBF16WeightsOp(TestFusionGRUBF16ONEDNNOp):
     def set_confs(self):
         self.weights_dtype = 'bf16'
 

--- a/test/mkldnn/test_fusion_gru_int8_mkldnn_op.py
+++ b/test/mkldnn/test_fusion_gru_int8_mkldnn_op.py
@@ -20,7 +20,7 @@ from test_fusion_gru_op import fusion_gru
 from test_fusion_lstm_op import ACTIVATION
 
 
-class TestFusionGRUINT8MKLDNNOp(OpTest):
+class TestFusionGRUINT8ONEDNNOp(OpTest):
     def set_confs(self):
         pass
 
@@ -157,22 +157,22 @@ class TestFusionGRUINT8MKLDNNOp(OpTest):
         )
 
 
-class TestFusionGRUINT8MKLDNNOp2(TestFusionGRUINT8MKLDNNOp):
+class TestFusionGRUINT8ONEDNNOp2(TestFusionGRUINT8ONEDNNOp):
     def set_confs(self):
         self.force_fp32_output = False
 
 
-class TestFusionGRUINT8MKLDNNOp3(TestFusionGRUINT8MKLDNNOp):
+class TestFusionGRUINT8ONEDNNOp3(TestFusionGRUINT8ONEDNNOp):
     def set_confs(self):
         self.origin_mode = False
 
 
-class TestFusionGRUINT8MKLDNNOp4(TestFusionGRUINT8MKLDNNOp):
+class TestFusionGRUINT8ONEDNNOp4(TestFusionGRUINT8ONEDNNOp):
     def set_confs(self):
         self.with_bias = False
 
 
-class TestFusionGRUINT8MKLDNNOp5(TestFusionGRUINT8MKLDNNOp):
+class TestFusionGRUINT8ONEDNNOp5(TestFusionGRUINT8ONEDNNOp):
     def set_confs(self):
         self.with_h0 = False
 

--- a/test/mkldnn/test_fusion_gru_mkldnn_op.py
+++ b/test/mkldnn/test_fusion_gru_mkldnn_op.py
@@ -17,41 +17,41 @@ import unittest
 from test_fusion_gru_op import TestFusionGRUOp
 
 
-class TestFusionGRUMKLDNNOp(TestFusionGRUOp):
+class TestFusionGRUONEDNNOp(TestFusionGRUOp):
     def set_confs(self):
         self.use_mkldnn = True
         self.check_pir_onednn = True
 
 
-class TestFusionGRUMKLDNNOpNoInitial(TestFusionGRUOp):
+class TestFusionGRUONEDNNOpNoInitial(TestFusionGRUOp):
     def set_confs(self):
         self.with_h0 = False
         self.use_mkldnn = True
         self.check_pir_onednn = True
 
 
-class TestFusionGRUMKLDNNOpNoBias(TestFusionGRUOp):
+class TestFusionGRUONEDNNOpNoBias(TestFusionGRUOp):
     def set_confs(self):
         self.with_bias = False
         self.use_mkldnn = True
         self.check_pir_onednn = True
 
 
-class TestFusionGRUMKLDNNOpReverse(TestFusionGRUOp):
+class TestFusionGRUONEDNNOpReverse(TestFusionGRUOp):
     def set_confs(self):
         self.is_reverse = True
         self.use_mkldnn = True
         self.check_pir_onednn = True
 
 
-class TestFusionGRUMKLDNNOpOriginMode(TestFusionGRUOp):
+class TestFusionGRUONEDNNOpOriginMode(TestFusionGRUOp):
     def set_confs(self):
         self.origin_mode = True
         self.use_mkldnn = True
         self.check_pir_onednn = True
 
 
-class TestFusionGRUMKLDNNOpMD1(TestFusionGRUOp):
+class TestFusionGRUONEDNNOpMD1(TestFusionGRUOp):
     def set_confs(self):
         self.M = 36
         self.D = 8
@@ -59,7 +59,7 @@ class TestFusionGRUMKLDNNOpMD1(TestFusionGRUOp):
         self.check_pir_onednn = True
 
 
-class TestFusionGRUMKLDNNOpMD2(TestFusionGRUOp):
+class TestFusionGRUONEDNNOpMD2(TestFusionGRUOp):
     def set_confs(self):
         self.M = 8
         self.D = 8
@@ -67,7 +67,7 @@ class TestFusionGRUMKLDNNOpMD2(TestFusionGRUOp):
         self.check_pir_onednn = True
 
 
-class TestFusionGRUMKLDNNOpMD3(TestFusionGRUOp):
+class TestFusionGRUONEDNNOpMD3(TestFusionGRUOp):
     def set_confs(self):
         self.M = 17
         self.D = 15
@@ -75,7 +75,7 @@ class TestFusionGRUMKLDNNOpMD3(TestFusionGRUOp):
         self.check_pir_onednn = True
 
 
-class TestFusionGRUMKLDNNOpBS1(TestFusionGRUOp):
+class TestFusionGRUONEDNNOpBS1(TestFusionGRUOp):
     def set_confs(self):
         self.lod = [[3]]
         self.D = 16

--- a/test/mkldnn/test_fusion_lstm_int8_mkldnn_op.py
+++ b/test/mkldnn/test_fusion_lstm_int8_mkldnn_op.py
@@ -19,7 +19,7 @@ from op_test import OpTest
 from test_fusion_lstm_op import ACTIVATION, fusion_lstm
 
 
-class TestFusionLSTMINT8MKLDNNOp(OpTest):
+class TestFusionLSTMINT8ONEDNNOp(OpTest):
     def set_confs(self):
         pass
 
@@ -149,17 +149,17 @@ class TestFusionLSTMINT8MKLDNNOp(OpTest):
             )
 
 
-class TestFusionLSTMINT8MKLDNNOp2(TestFusionLSTMINT8MKLDNNOp):
+class TestFusionLSTMINT8ONEDNNOp2(TestFusionLSTMINT8ONEDNNOp):
     def set_confs(self):
         self.force_fp32_output = True
 
 
-class TestFusionLSTMINT8MKLDNNOp4(TestFusionLSTMINT8MKLDNNOp):
+class TestFusionLSTMINT8ONEDNNOp4(TestFusionLSTMINT8ONEDNNOp):
     def set_confs(self):
         self.is_reverse = True
 
 
-class TestFusionLSTMINT8MKLDNNOp5(TestFusionLSTMINT8MKLDNNOp):
+class TestFusionLSTMINT8ONEDNNOp5(TestFusionLSTMINT8ONEDNNOp):
     def set_confs(self):
         self.has_initial_state = True
 

--- a/test/mkldnn/test_gaussian_random_mkldnn_op.py
+++ b/test/mkldnn/test_gaussian_random_mkldnn_op.py
@@ -24,13 +24,13 @@ from test_gaussian_random_op import TestGaussianRandomOp
 import paddle
 
 
-class TestMKLDNNGaussianRandomOpSeed10(TestGaussianRandomOp):
+class TestONEDNNGaussianRandomOpSeed10(TestGaussianRandomOp):
     def init_kernel_type(self):
         self.use_mkldnn = True
         self.check_pir_onednn = True
 
 
-class TestMKLDNNGaussianRandomOpSeed0(TestGaussianRandomOp):
+class TestONEDNNGaussianRandomOpSeed0(TestGaussianRandomOp):
     def setUp(self):
         TestGaussianRandomOp.setUp(self)
         self.use_mkldnn = True


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
test/mkldnn 单测名称MKLDNN修改为ONEDNN
test/mkldnn下都替换有CI错误，所以拆分多个PR分步替换