### PR TITLE
[AP] Load cutlass3 in a safe way

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -16,6 +16,12 @@ if(WITH_CINN)
   endif()
 
   message(STATUS "PYTHON_EXECUTABLE: ${PYTHON_EXECUTABLE}")
+
+  add_custom_target(
+    apy_cutlass_build ALL
+    COMMAND bash load_cutlass.sh
+    WORKING_DIRECTORY ${PADDLE_SOURCE_DIR}/python/paddle/apy/matmul_pass/
+    COMMENT "Abstract pass's third_party cutlass construction script")
 endif()
 
 file(GLOB UTILS_PY_FILES . ./paddle/legacy/utils/*.py)

--- a/python/paddle/apy/matmul_pass/load_cutlass.sh
+++ b/python/paddle/apy/matmul_pass/load_cutlass.sh
@@ -1,0 +1,39 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -e
+
+SOURCE_CUTLASS_DIR="../../../../third_party/cutlass"
+SOURCE_CUTLASS_GIT_DIR="../../../../../../.git/modules/third_party/cutlass"
+cutlass_repo_directory="matmul/cutlass-3.7.0"
+if [ ! -d "$cutlass_repo_directory" ]; then
+    if [ -d "$SOURCE_CUTLASS_DIR" ]; then
+        echo "Cutlass folder exists in the submodule and is being copied to the current directory..."
+        cp -r "$SOURCE_CUTLASS_DIR" "$cutlass_repo_directory"
+        cd "$cutlass_repo_directory"
+        echo "Copy the .git directory of cutlass to the current directory"
+        rm -rf .git
+        cp -r "$SOURCE_CUTLASS_GIT_DIR" .git
+        sed -i '6c\ \ worktree = ../' .git/config
+        git checkout v3.7.0
+        cd ..
+        mkdir "cutlass"
+        cp -r "cutlass-3.7.0/tools" "cutlass"
+        cp -r "cutlass-3.7.0/include" "cutlass"
+        rm -rf "cutlass-3.7.0"
+        mv "cutlass" "cutlass-3.7.0"
+    else
+        echo "Cutlass folder does not exist in the submodule and is being downloaded..."
+        git clone --branch v3.7.0  https://github.com/NVIDIA/cutlass "$cutlass_repo_directory"
+    fi
+fi

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -767,34 +767,6 @@ def get_paddle_extra_install_requirements():
 
     return paddle_cuda_requires,paddle_tensorrt_requires
 
-def build_cutlass3_src_code():
-    target_path = "${PADDLE_BINARY_DIR}/python/paddle/apy/matmul_pass/matmul/cutlass-3.7.0"
-    if not os.path.exists(target_path):
-        os.mkdir(target_path)
-    try:
-        cmd = ['git', 'rev-parse', 'HEAD']
-        git_commit = subprocess.Popen(cmd, stdout = subprocess.PIPE,
-            cwd="${PADDLE_SOURCE_DIR}/third_party/cutlass").communicate()[0].strip()
-    except:
-        git_commit = 'Unknown'
-        raise Exception("obtain commit id of third_party cutlass failed")
-    commit_id = str(git_commit.decode())
-    command = (
-        'cd '
-        + '${PADDLE_SOURCE_DIR}/third_party/cutlass && '
-        + 'git checkout v3.7.0 && '
-        + 'cp '
-        + '${PADDLE_SOURCE_DIR}/third_party/cutlass/tools -r '
-        + f'{target_path} && '
-        + 'cp '
-        + '${PADDLE_SOURCE_DIR}/third_party/cutlass/include -r '
-        + f'{target_path} && '
-        + f'git checkout {commit_id}'
-    )
-    if os.system(command) != 0:
-        raise Exception(f"copy cutlass-3.7.0 failed, command: {command}")
-
-
 packages=['paddle',
           'paddle.libs',
           'paddle.utils',
@@ -1051,9 +1023,6 @@ shutil.copytree(src_cinn_config_path, whl_cinn_config_path)
 json_path_list = get_cinn_config_jsons()
 for json in json_path_list:
     package_data['paddle.cinn_config'] += [json]
-
-# if '${WITH_CINN}' == 'ON':
-#     build_cutlass3_src_code()
 
 package_data['paddle.apy'] = []
 file_path_list = get_apy_files()

--- a/setup.py
+++ b/setup.py
@@ -1290,41 +1290,6 @@ def get_paddle_extra_install_requirements():
     return paddle_cuda_requires, paddle_tensorrt_requires
 
 
-def build_cutlass3_src_code():
-    target_path = f"{paddle_binary_dir}/python/paddle/apy/matmul_pass/matmul/cutlass-3.7.0"
-    if not os.path.exists(target_path):
-        os.mkdir(target_path)
-    try:
-        cmd = ['git', 'rev-parse', 'HEAD']
-        git_commit = (
-            subprocess.Popen(
-                cmd,
-                stdout=subprocess.PIPE,
-                cwd=f"{paddle_source_dir}/third_party/cutlass",
-            )
-            .communicate()[0]
-            .strip()
-        )
-    except:
-        git_commit = 'Unknown'
-        raise Exception("obtain commit id of third_party cutlass failed")
-    commit_id = str(git_commit.decode())
-    command = (
-        'cd '
-        + f'{paddle_source_dir}/third_party/cutlass && '
-        + 'git checkout v3.7.0 && '
-        + 'cp '
-        + f'{paddle_source_dir}/third_party/cutlass/tools -r '
-        + f'{target_path} && '
-        + 'cp '
-        + f'{paddle_source_dir}/third_party/cutlass/include -r '
-        + f'{target_path} && '
-        + f'git checkout {commit_id}'
-    )
-    if os.system(command) != 0:
-        raise Exception(f"copy cutlass-3.7.0 failed, command: {command}")
-
-
 def get_cinn_config_jsons():
     from pathlib import Path
 
@@ -1426,9 +1391,6 @@ def get_package_data_and_package_dir():
     json_path_list = get_cinn_config_jsons()
     for json in json_path_list:
         package_data['paddle.cinn_config'] += [json]
-
-    # if env_dict.get("WITH_CINN") == 'ON':
-    #     build_cutlass3_src_code()
 
     package_data['paddle.apy'] = []
     file_path_list = get_apy_files()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67012
采用更安全的方式来解决部分机器第三方库cutlass没有 分支v3.7.0问题。将三方库.git 替换为更加完整的 一个。