### PR TITLE
Rename MKLDNN to ONEDNN in test cases - part2 [fluid_ops]

### DIFF
--- a/test/mkldnn/test_conv2d_int8_mkldnn_op.py
+++ b/test/mkldnn/test_conv2d_int8_mkldnn_op.py
@@ -469,7 +469,7 @@ create_test_int8_class(TestWith1x1)
 create_test_int8_class(TestWithInput1x1Filter1x1)
 
 
-class TestConv2DOp_AsyPadding_INT_MKLDNN(TestConv2DInt8Op):
+class TestConv2DOp_AsyPadding_INT_ONEDNN(TestConv2DInt8Op):
     def init_kernel_type(self):
         self.use_mkldnn = True
 
@@ -478,13 +478,13 @@ class TestConv2DOp_AsyPadding_INT_MKLDNN(TestConv2DInt8Op):
         self.padding_algorithm = "EXPLICIT"
 
 
-class TestConv2DOp_Same_INT_MKLDNN(TestConv2DOp_AsyPadding_INT_MKLDNN):
+class TestConv2DOp_Same_INT_ONEDNN(TestConv2DOp_AsyPadding_INT_ONEDNN):
     def init_paddings(self):
         self.pad = [0, 0]
         self.padding_algorithm = "SAME"
 
 
-class TestConv2DOp_Valid_INT_MKLDNN(TestConv2DOp_AsyPadding_INT_MKLDNN):
+class TestConv2DOp_Valid_INT_ONEDNN(TestConv2DOp_AsyPadding_INT_ONEDNN):
     def init_paddings(self):
         self.pad = [1, 1]
         self.padding_algorithm = "VALID"

--- a/test/mkldnn/test_conv2d_mkldnn_op.py
+++ b/test/mkldnn/test_conv2d_mkldnn_op.py
@@ -33,7 +33,7 @@ def conv2d_residual_naive(out, residual):
     return out
 
 
-class TestConv2DMKLDNNOp(TestConv2DOp):
+class TestConv2DONEDNNOp(TestConv2DOp):
     def init_group(self):
         self.groups = 1
 
@@ -114,7 +114,7 @@ class TestConv2DMKLDNNOp(TestConv2DOp):
         self.outputs['Output'] = output
 
 
-class TestConv2DMKLDNNOp2(TestConv2DOp):
+class TestConv2DONEDNNOp2(TestConv2DOp):
     def init_group(self):
         self.groups = 1
 
@@ -198,9 +198,9 @@ class TestConv2DMKLDNNOp2(TestConv2DOp):
 @skip_check_grad_ci(
     reason="Fusion is for inference only, check_grad is not required."
 )
-class TestWithbreluFusion(TestConv2DMKLDNNOp):
+class TestWithbreluFusion(TestConv2DONEDNNOp):
     def init_test_case(self):
-        TestConv2DMKLDNNOp.init_test_case(self)
+        TestConv2DONEDNNOp.init_test_case(self)
         self.fuse_activation = "relu6"
         self.fuse_beta = 6.0
         self.dsttype = np.float32
@@ -209,9 +209,9 @@ class TestWithbreluFusion(TestConv2DMKLDNNOp):
 @skip_check_grad_ci(
     reason="Fusion is for inference only, check_grad is not required."
 )
-class TestWithFuse(TestConv2DMKLDNNOp):
+class TestWithFuse(TestConv2DONEDNNOp):
     def init_test_case(self):
-        TestConv2DMKLDNNOp.init_test_case(self)
+        TestConv2DONEDNNOp.init_test_case(self)
         self.pad = [1, 1]
         self.fuse_bias = True
         self.bias_size = [6]
@@ -219,22 +219,22 @@ class TestWithFuse(TestConv2DMKLDNNOp):
         self.input_residual_size = [2, 6, 5, 5]
 
 
-class TestWithPadWithBias(TestConv2DMKLDNNOp):
+class TestWithPadWithBias(TestConv2DONEDNNOp):
     def init_test_case(self):
-        TestConv2DMKLDNNOp.init_test_case(self)
+        TestConv2DONEDNNOp.init_test_case(self)
         self.pad = [1, 1]
         self.input_size = [2, 3, 6, 6]
 
 
-class TestWithStride(TestConv2DMKLDNNOp):
+class TestWithStride(TestConv2DONEDNNOp):
     def init_test_case(self):
-        TestConv2DMKLDNNOp.init_test_case(self)
+        TestConv2DONEDNNOp.init_test_case(self)
         self.pad = [1, 1]
         self.stride = [2, 2]
         self.input_size = [2, 3, 6, 6]
 
 
-class TestWithGroup(TestConv2DMKLDNNOp):
+class TestWithGroup(TestConv2DONEDNNOp):
     def init_test_case(self):
         self.pad = [0, 0]
         self.stride = [1, 1]
@@ -247,15 +247,15 @@ class TestWithGroup(TestConv2DMKLDNNOp):
         self.groups = 3
 
 
-class TestWith1x1(TestConv2DMKLDNNOp):
+class TestWith1x1(TestConv2DONEDNNOp):
     def init_test_case(self):
-        TestConv2DMKLDNNOp.init_test_case(self)
+        TestConv2DONEDNNOp.init_test_case(self)
         self.filter_size = [40, 3, 1, 1]
 
 
-class TestWithInput1x1Filter1x1(TestConv2DMKLDNNOp):
+class TestWithInput1x1Filter1x1(TestConv2DONEDNNOp):
     def init_test_case(self):
-        TestConv2DMKLDNNOp.init_test_case(self)
+        TestConv2DONEDNNOp.init_test_case(self)
         self.input_size = [2, 60, 1, 1]  # NCHW
         assert np.mod(self.input_size[1], self.groups) == 0
         f_c = self.input_size[1] // self.groups
@@ -265,7 +265,7 @@ class TestWithInput1x1Filter1x1(TestConv2DMKLDNNOp):
         self.groups = 3
 
 
-class TestConv2DOp_AsyPadding_MKLDNN(TestConv2DOp_v2):
+class TestConv2DOp_AsyPadding_ONEDNN(TestConv2DOp_v2):
     def init_kernel_type(self):
         self.use_mkldnn = True
         self.dtype = np.float32
@@ -275,19 +275,19 @@ class TestConv2DOp_AsyPadding_MKLDNN(TestConv2DOp_v2):
         self.padding_algorithm = "EXPLICIT"
 
 
-class TestConv2DOp_Same_MKLDNN(TestConv2DOp_AsyPadding_MKLDNN):
+class TestConv2DOp_Same_ONEDNN(TestConv2DOp_AsyPadding_ONEDNN):
     def init_paddings(self):
         self.pad = [0, 0]
         self.padding_algorithm = "SAME"
 
 
-class TestConv2DOp_Valid_MKLDNN(TestConv2DOp_AsyPadding_MKLDNN):
+class TestConv2DOp_Valid_ONEDNN(TestConv2DOp_AsyPadding_ONEDNN):
     def init_paddings(self):
         self.pad = [1, 1]
         self.padding_algorithm = "VALID"
 
 
-class TestConv2DOp_Valid_NHWC_MKLDNN(TestConv2DOp_Valid_MKLDNN):
+class TestConv2DOp_Valid_NHWC_ONEDNN(TestConv2DOp_Valid_ONEDNN):
     def init_data_format(self):
         self.data_format = "NHWC"
 
@@ -296,21 +296,21 @@ class TestConv2DOp_Valid_NHWC_MKLDNN(TestConv2DOp_Valid_MKLDNN):
         self.input_size = [N, H, W, C]
 
 
-class TestConv2DOp_Same_NHWC_MKLDNN(TestConv2DOp_Valid_NHWC_MKLDNN):
+class TestConv2DOp_Same_NHWC_ONEDNN(TestConv2DOp_Valid_NHWC_ONEDNN):
     def init_paddings(self):
         self.pad = [0, 0]
         self.padding_algorithm = "SAME"
 
 
-class TestConv2DOp_AsyPadding_NHWC_MKLDNN(TestConv2DOp_Valid_NHWC_MKLDNN):
+class TestConv2DOp_AsyPadding_NHWC_ONEDNN(TestConv2DOp_Valid_NHWC_ONEDNN):
     def init_paddings(self):
         self.pad = [0, 0, 1, 2]
         self.padding_algorithm = "EXPLICIT"
 
 
-class TestMKLDNNDilations(TestConv2DMKLDNNOp):
+class TestONEDNNDilations(TestConv2DONEDNNOp):
     def init_test_case(self):
-        TestConv2DMKLDNNOp.init_test_case(self)
+        TestConv2DONEDNNOp.init_test_case(self)
         self.pad = [0, 0]
         self.stride = [1, 1]
         self.input_size = [2, 3, 10, 10]  # NCHW

--- a/test/mkldnn/test_conv2d_transpose_bf16_mkldnn_op.py
+++ b/test/mkldnn/test_conv2d_transpose_bf16_mkldnn_op.py
@@ -33,7 +33,7 @@ def conv2d_bias_naive(out, bias):
 @unittest.skipIf(
     not core.supports_bfloat16(), "place does not support BF16 evaluation"
 )
-class TestConv2DTransposeBF16MKLDNNOp(OpTest):
+class TestConv2DTransposeBF16ONEDNNOp(OpTest):
     def test_check_output(self):
         self.check_output_with_place(core.CPUPlace(), check_pir_onednn=True)
 
@@ -133,7 +133,7 @@ class TestConv2DTransposeBF16MKLDNNOp(OpTest):
         self.outputs['Output'] = output
 
 
-class TestMKLDNNFuseBias(TestConv2DTransposeBF16MKLDNNOp):
+class TestONEDNNFuseBias(TestConv2DTransposeBF16ONEDNNOp):
     def init_test_case(self):
         super().init_test_case()
         self.pad = [1, 1]
@@ -141,14 +141,14 @@ class TestMKLDNNFuseBias(TestConv2DTransposeBF16MKLDNNOp):
         self.bias_size = [6]
 
 
-class TestMKLDNNWithPad(TestConv2DTransposeBF16MKLDNNOp):
+class TestONEDNNWithPad(TestConv2DTransposeBF16ONEDNNOp):
     def init_test_case(self):
         super().init_test_case()
         self.pad = [1, 1]
         self.input_size = [2, 3, 10, 10]
 
 
-class TestMKLDNNWithStride(TestConv2DTransposeBF16MKLDNNOp):
+class TestONEDNNWithStride(TestConv2DTransposeBF16ONEDNNOp):
     def init_test_case(self):
         super().init_test_case()
         self.pad = [1, 1]
@@ -156,28 +156,28 @@ class TestMKLDNNWithStride(TestConv2DTransposeBF16MKLDNNOp):
         self.input_size = [2, 3, 6, 6]  # NCHW
 
 
-class TestMKLDNNWithAsymPad(TestConv2DTransposeBF16MKLDNNOp):
+class TestONEDNNWithAsymPad(TestConv2DTransposeBF16ONEDNNOp):
     def init_test_case(self):
         super().init_test_case()
         self.pad = [0, 0, 1, 2]
         self.padding_algorithm = "EXPLICIT"
 
 
-class TestMKLDNNWithSamePad(TestConv2DTransposeBF16MKLDNNOp):
+class TestONEDNNWithSamePad(TestConv2DTransposeBF16ONEDNNOp):
     def init_test_case(self):
         super().init_test_case()
         self.pad = [0, 0]
         self.padding_algorithm = "SAME"
 
 
-class TestMKLDNNWithValidPad(TestConv2DTransposeBF16MKLDNNOp):
+class TestONEDNNWithValidPad(TestConv2DTransposeBF16ONEDNNOp):
     def init_test_case(self):
         super().init_test_case()
         self.pad = [1, 1]
         self.padding_algorithm = "VALID"
 
 
-class TestMKLDNNWithValidPad_NHWC(TestMKLDNNWithValidPad):
+class TestONEDNNWithValidPad_NHWC(TestONEDNNWithValidPad):
     def init_test_case(self):
         super().init_test_case()
         self.data_format = 'NHWC'
@@ -185,8 +185,8 @@ class TestMKLDNNWithValidPad_NHWC(TestMKLDNNWithValidPad):
         self.input_size = [N, H, W, C]
 
 
-class TestConv2DTransposeMKLDNNWithDilationsExplicitPad(
-    TestConv2DTransposeBF16MKLDNNOp
+class TestConv2DTransposeONEDNNWithDilationsExplicitPad(
+    TestConv2DTransposeBF16ONEDNNOp
 ):
     def init_test_case(self):
         super().init_test_case()

--- a/test/mkldnn/test_conv2d_transpose_mkldnn_op.py
+++ b/test/mkldnn/test_conv2d_transpose_mkldnn_op.py
@@ -30,7 +30,7 @@ def conv2d_bias_naive(out, bias):
     return out
 
 
-class TestConv2DTransposeMKLDNNOp(TestConv2DTransposeOp):
+class TestConv2DTransposeONEDNNOp(TestConv2DTransposeOp):
     def test_check_grad(self):
         return
 
@@ -100,51 +100,51 @@ class TestConv2DTransposeMKLDNNOp(TestConv2DTransposeOp):
         self.outputs['Output'] = output
 
 
-class TestMKLDNNFuseBias(TestConv2DTransposeMKLDNNOp):
+class TestONEDNNFuseBias(TestConv2DTransposeONEDNNOp):
     def init_test_case(self):
-        TestConv2DTransposeMKLDNNOp.init_test_case(self)
+        TestConv2DTransposeONEDNNOp.init_test_case(self)
         self.pad = [1, 1]
         self.fuse_bias = True
         self.bias_size = [6]
 
 
-class TestMKLDNNWithPad(TestConv2DTransposeMKLDNNOp):
+class TestONEDNNWithPad(TestConv2DTransposeONEDNNOp):
     def init_test_case(self):
-        TestConv2DTransposeMKLDNNOp.init_test_case(self)
+        TestConv2DTransposeONEDNNOp.init_test_case(self)
         self.pad = [1, 1]
         self.input_size = [2, 3, 10, 10]
 
 
-class TestMKLDNNWithStride(TestConv2DTransposeMKLDNNOp):
+class TestONEDNNWithStride(TestConv2DTransposeONEDNNOp):
     def init_test_case(self):
-        TestConv2DTransposeMKLDNNOp.init_test_case(self)
+        TestConv2DTransposeONEDNNOp.init_test_case(self)
         self.pad = [1, 1]
         self.stride = [2, 2]
         self.input_size = [2, 3, 6, 6]  # NCHW
 
 
-class TestMKLDNNWithAsymPad(TestConv2DTransposeMKLDNNOp):
+class TestONEDNNWithAsymPad(TestConv2DTransposeONEDNNOp):
     def init_test_case(self):
-        TestConv2DTransposeMKLDNNOp.init_test_case(self)
+        TestConv2DTransposeONEDNNOp.init_test_case(self)
         self.pad = [0, 0, 1, 2]
         self.padding_algorithm = "EXPLICIT"
 
 
-class TestMKLDNNWithSamePad(TestConv2DTransposeMKLDNNOp):
+class TestONEDNNWithSamePad(TestConv2DTransposeONEDNNOp):
     def init_test_case(self):
-        TestConv2DTransposeMKLDNNOp.init_test_case(self)
+        TestConv2DTransposeONEDNNOp.init_test_case(self)
         self.pad = [0, 0]
         self.padding_algorithm = "SAME"
 
 
-class TestMKLDNNWithValidPad(TestConv2DTransposeMKLDNNOp):
+class TestONEDNNWithValidPad(TestConv2DTransposeONEDNNOp):
     def init_test_case(self):
-        TestConv2DTransposeMKLDNNOp.init_test_case(self)
+        TestConv2DTransposeONEDNNOp.init_test_case(self)
         self.pad = [1, 1]
         self.padding_algorithm = "VALID"
 
 
-class TestMKLDNNWithValidPad_NHWC(TestMKLDNNWithValidPad):
+class TestONEDNNWithValidPad_NHWC(TestONEDNNWithValidPad):
     def init_test_case(self):
         super().init_test_case()
         self.data_format = "NHWC"
@@ -152,11 +152,11 @@ class TestMKLDNNWithValidPad_NHWC(TestMKLDNNWithValidPad):
         self.input_size = [N, H, W, C]
 
 
-class TestConv2DTransposeMKLDNNWithDilationsExplicitPad(
-    TestConv2DTransposeMKLDNNOp
+class TestConv2DTransposeONEDNNWithDilationsExplicitPad(
+    TestConv2DTransposeONEDNNOp
 ):
     def init_test_case(self):
-        TestConv2DTransposeMKLDNNOp.init_test_case(self)
+        TestConv2DTransposeONEDNNOp.init_test_case(self)
         self.stride = [2, 1]
         self.dilations = [1, 2]
         self.groups = 1
@@ -167,9 +167,9 @@ class TestConv2DTransposeMKLDNNWithDilationsExplicitPad(
         self.padding_algorithm = "EXPLICIT"
 
 
-class TestMKLDNNWithGroups(TestConv2DTransposeMKLDNNOp):
+class TestONEDNNWithGroups(TestConv2DTransposeONEDNNOp):
     def init_test_case(self):
-        TestConv2DTransposeMKLDNNOp.init_test_case(self)
+        TestConv2DTransposeONEDNNOp.init_test_case(self)
         self.pad = [1, 1]
         self.groups = 2
         self.input_size = [2, 4, 5, 5]  # NCHW
@@ -177,9 +177,9 @@ class TestMKLDNNWithGroups(TestConv2DTransposeMKLDNNOp):
         self.filter_size = [f_c, 3, 3, 3]
 
 
-class TestMKLDNNWithGroups_NHWC(TestConv2DTransposeMKLDNNOp):
+class TestONEDNNWithGroups_NHWC(TestConv2DTransposeONEDNNOp):
     def init_test_case(self):
-        TestConv2DTransposeMKLDNNOp.init_test_case(self)
+        TestConv2DTransposeONEDNNOp.init_test_case(self)
         self.pad = [1, 1]
         self.groups = 2
         self.input_size = [2, 5, 5, 4]  # NHWC

--- a/test/mkldnn/test_conv3d_mkldnn_op.py
+++ b/test/mkldnn/test_conv3d_mkldnn_op.py
@@ -25,7 +25,7 @@ from test_conv3d_op import (
 )
 
 
-class TestMKLDNN(TestConv3DOp):
+class TestONEDNN(TestConv3DOp):
     def init_kernel_type(self):
         self.use_mkldnn = True
         self.data_format = "NCHW"
@@ -33,7 +33,7 @@ class TestMKLDNN(TestConv3DOp):
         self.check_pir_onednn = True
 
 
-class TestMKLDNNCase1(TestCase1):
+class TestONEDNNCase1(TestCase1):
     def init_kernel_type(self):
         self.use_mkldnn = True
         self.data_format = "NCHW"
@@ -41,7 +41,7 @@ class TestMKLDNNCase1(TestCase1):
         self.check_pir_onednn = True
 
 
-class TestMKLDNNGroup1(TestWithGroup1):
+class TestONEDNNGroup1(TestWithGroup1):
     def init_kernel_type(self):
         self.use_mkldnn = True
         self.data_format = "NCHW"
@@ -49,7 +49,7 @@ class TestMKLDNNGroup1(TestWithGroup1):
         self.check_pir_onednn = True
 
 
-class TestMKLDNNGroup2(TestWithGroup2):
+class TestONEDNNGroup2(TestWithGroup2):
     def init_kernel_type(self):
         self.use_mkldnn = True
         self.data_format = "NCHW"
@@ -57,7 +57,7 @@ class TestMKLDNNGroup2(TestWithGroup2):
         self.check_pir_onednn = True
 
 
-class TestMKLDNNWith1x1(TestWith1x1):
+class TestONEDNNWith1x1(TestWith1x1):
     def init_kernel_type(self):
         self.use_mkldnn = True
         self.data_format = "NCHW"
@@ -65,7 +65,7 @@ class TestMKLDNNWith1x1(TestWith1x1):
         self.check_pir_onednn = True
 
 
-class TestMKLDNNWithInput1x1Filter1x1(TestWithInput1x1Filter1x1):
+class TestONEDNNWithInput1x1Filter1x1(TestWithInput1x1Filter1x1):
     def init_kernel_type(self):
         self.use_mkldnn = True
         self.data_format = "NCHW"
@@ -73,7 +73,7 @@ class TestMKLDNNWithInput1x1Filter1x1(TestWithInput1x1Filter1x1):
         self.check_pir_onednn = True
 
 
-class TestConv3DOp_AsyPadding_MKLDNN(TestConv3DOp):
+class TestConv3DOp_AsyPadding_ONEDNN(TestConv3DOp):
     def init_kernel_type(self):
         self.use_mkldnn = True
         self.data_format = "NCHW"
@@ -85,7 +85,7 @@ class TestConv3DOp_AsyPadding_MKLDNN(TestConv3DOp):
         self.padding_algorithm = "EXPLICIT"
 
 
-class TestConv3DOp_Same_MKLDNN(TestConv3DOp_AsyPadding_MKLDNN):
+class TestConv3DOp_Same_ONEDNN(TestConv3DOp_AsyPadding_ONEDNN):
     def init_paddings(self):
         self.pad = [0, 0, 0]
         self.padding_algorithm = "SAME"
@@ -97,7 +97,7 @@ class TestConv3DOp_Same_MKLDNN(TestConv3DOp_AsyPadding_MKLDNN):
         self.check_pir_onednn = True
 
 
-class TestConv3DOp_Valid_MKLDNN(TestConv3DOp_AsyPadding_MKLDNN):
+class TestConv3DOp_Valid_ONEDNN(TestConv3DOp_AsyPadding_ONEDNN):
     def init_paddings(self):
         self.pad = [1, 1, 1]
         self.padding_algorithm = "VALID"


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
单测名称 MKLDNN 修改为ONEDNN
test/mkldnn下都替换有CI错误，所以拆分多个PR分步替换