### PR TITLE
Optimize fused_act_dequant op by remove redundant memset

### DIFF
--- a/paddle/phi/kernels/fusion/gpu/fused_act_dequant_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/fused_act_dequant_kernel.cu
@@ -94,8 +94,6 @@ void FusedActDequantKernel(const Context& dev_ctx,
 
   auto out_ptr =
       reinterpret_cast<void*>(out->template data<phi::dtype::bfloat16>());
-  cudaMemsetAsync(
-      out_ptr, 0, sizeof(phi::dtype::bfloat16) * rows * cols, dev_ctx.stream());
 
   dim3 grid(rows);
   dim3 block(256);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Operator Mechanism
### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Performance

### Description
Optimize fused_act_dequant op by remove redundant memset

pcard-91067
