### PR TITLE
fix paddle.where's infer scalar dtype

### DIFF
--- a/python/paddle/tensor/search.py
+++ b/python/paddle/tensor/search.py
@@ -781,10 +781,18 @@ def where(
              [3]]),)
     """
     if np.isscalar(x):
-        x = paddle.full([1], x, np.array([x]).dtype.name)
+        # TODO: Use `x = paddle.full([1], x)` after support int scalar dtype infer for `full`.
+        if isinstance(x, int):
+            x = paddle.full([1], x, dtype='int64')
+        else:
+            x = paddle.full([1], x)
 
     if np.isscalar(y):
-        y = paddle.full([1], y, np.array([y]).dtype.name)
+        # TODO: Use `y = paddle.full([1], y)` after support int scalar dtype infer for `full`.
+        if isinstance(y, int):
+            y = paddle.full([1], y, dtype='int64')
+        else:
+            y = paddle.full([1], y)
 
     if x is None and y is None:
         return nonzero(condition, as_tuple=True)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Fix paddle.where with infer scalar dtype to paddle's default float(float32) instead of numpy's default float(float64)。改完之后和 Pytorch 一致
issue url: https://github.com/PaddlePaddle/Paddle/issues/73775