### PR TITLE
Rename MKLDNN to ONEDNN in test cases - part3 [fluid_ops]

### DIFF
--- a/test/mkldnn/test_lrn_mkldnn_op.py
+++ b/test/mkldnn/test_lrn_mkldnn_op.py
@@ -19,7 +19,7 @@ sys.path.append("../deprecated/legacy_test")
 from test_lrn_op import TestLRNOp
 
 
-class TestLRNMKLDNNOp(TestLRNOp):
+class TestLRNONEDNNOp(TestLRNOp):
     def get_attrs(self):
         attrs = TestLRNOp.get_attrs(self)
         attrs['use_mkldnn'] = True
@@ -42,9 +42,9 @@ class TestLRNMKLDNNOp(TestLRNOp):
         )
 
 
-class TestLRNMKLDNNOpWithIsTest(TestLRNMKLDNNOp):
+class TestLRNONEDNNOpWithIsTest(TestLRNONEDNNOp):
     def get_attrs(self):
-        attrs = TestLRNMKLDNNOp.get_attrs(self)
+        attrs = TestLRNONEDNNOp.get_attrs(self)
         attrs['is_test'] = True
         return attrs
 
@@ -62,7 +62,7 @@ class TestLRNMKLDNNOpWithIsTest(TestLRNMKLDNNOp):
         self.assertRaises(AttributeError, check_raise_is_test)
 
 
-class TestLRNMKLDNNOpNHWC(TestLRNMKLDNNOp):
+class TestLRNONEDNNOpNHWC(TestLRNONEDNNOp):
     def init_test_case(self):
         self.data_format = 'NHWC'
 

--- a/test/mkldnn/test_mul_int8_mkldnn_op.py
+++ b/test/mkldnn/test_mul_int8_mkldnn_op.py
@@ -28,7 +28,7 @@ from paddle.base import core
 @skip_check_grad_ci(
     reason="mul_mkldnn_op does not implement grad operator, check_grad is not required."
 )
-class TestMKLDNNMulOpS8S8(OpTest):
+class TestONEDNNMulOpS8S8(OpTest):
     def setUp(self):
         self.op_type = "mul"
         self.init_kernel_type()
@@ -88,7 +88,7 @@ class TestMKLDNNMulOpS8S8(OpTest):
 '''
 
 
-class TestMKLDNNMulOpS8U8(TestMKLDNNMulOpS8S8):
+class TestONEDNNMulOpS8U8(TestONEDNNMulOpS8S8):
     def init_data_type(self):
         self.srctype = np.uint8
         self.dsttype = np.float32 if self.force_fp32 else np.int8
@@ -99,7 +99,7 @@ class TestMKLDNNMulOpS8U8(TestMKLDNNMulOpS8S8):
 '''
 
 
-class TestMKLDNNMulOpS8S8WithFlatten(TestMKLDNNMulOpS8S8):
+class TestONEDNNMulOpS8S8WithFlatten(TestONEDNNMulOpS8S8):
     def setUp(self):
         self.op_type = "mul"
         self.init_kernel_type()
@@ -154,7 +154,7 @@ class TestMKLDNNMulOpS8S8WithFlatten(TestMKLDNNMulOpS8S8):
 '''
 
 
-class TestMKLDNNMulOpS8U8WithFlatten(TestMKLDNNMulOpS8S8WithFlatten):
+class TestONEDNNMulOpS8U8WithFlatten(TestONEDNNMulOpS8S8WithFlatten):
     def init_data_type(self):
         self.srctype = np.uint8
         self.dsttype = np.float32 if self.force_fp32 else np.int8

--- a/test/mkldnn/test_nearest_interp_v2_mkldnn_op.py
+++ b/test/mkldnn/test_nearest_interp_v2_mkldnn_op.py
@@ -60,7 +60,7 @@ def nearest_neighbor_interp_mkldnn_np(
 
 @skip_check_grad_ci(reason="Haven not implement interpolate grad kernel.")
 @OpTestTool.skip_if_not_cpu_bf16()
-class TestNearestInterpV2MKLDNNOp(OpTest):
+class TestNearestInterpV2ONEDNNOp(OpTest):
     def init_test_case(self):
         pass
 
@@ -154,7 +154,7 @@ class TestNearestInterpV2MKLDNNOp(OpTest):
         self.check_output(check_dygraph=False, check_pir_onednn=True)
 
 
-class TestNearestInterpOpV2MKLDNNNHWC(TestNearestInterpV2MKLDNNOp):
+class TestNearestInterpOpV2ONEDNNNHWC(TestNearestInterpV2ONEDNNOp):
     def init_test_case(self):
         self.input_shape = [3, 2, 32, 16]
         self.out_h = 27
@@ -163,14 +163,14 @@ class TestNearestInterpOpV2MKLDNNNHWC(TestNearestInterpV2MKLDNNOp):
         self.data_layout = 'NHWC'
 
 
-class TestNearestNeighborInterpV2MKLDNNCase2(TestNearestInterpV2MKLDNNOp):
+class TestNearestNeighborInterpV2ONEDNNCase2(TestNearestInterpV2ONEDNNOp):
     def init_test_case(self):
         self.input_shape = [3, 3, 9, 6]
         self.out_h = 12
         self.out_w = 12
 
 
-class TestNearestNeighborInterpV2MKLDNNCase3(TestNearestInterpV2MKLDNNOp):
+class TestNearestNeighborInterpV2ONEDNNCase3(TestNearestInterpV2ONEDNNOp):
     def init_test_case(self):
         self.input_shape = [1, 1, 32, 64]
         self.out_h = 64
@@ -178,7 +178,7 @@ class TestNearestNeighborInterpV2MKLDNNCase3(TestNearestInterpV2MKLDNNOp):
         self.scale = [0.1, 0.05]
 
 
-class TestNearestNeighborInterpV2MKLDNNCase4(TestNearestInterpV2MKLDNNOp):
+class TestNearestNeighborInterpV2ONEDNNCase4(TestNearestInterpV2ONEDNNOp):
     def init_test_case(self):
         self.input_shape = [1, 1, 32, 64]
         self.out_h = 64
@@ -187,7 +187,7 @@ class TestNearestNeighborInterpV2MKLDNNCase4(TestNearestInterpV2MKLDNNOp):
         self.out_size = np.array([65, 129]).astype("int32")
 
 
-class TestNearestNeighborInterpV2MKLDNNSame(TestNearestInterpV2MKLDNNOp):
+class TestNearestNeighborInterpV2ONEDNNSame(TestNearestInterpV2ONEDNNOp):
     def init_test_case(self):
         self.input_shape = [2, 3, 32, 64]
         self.out_h = 32
@@ -220,12 +220,12 @@ def create_test_class(parent):
     globals()[TestUint8Case.__name__] = TestUint8Case
 
 
-create_test_class(TestNearestInterpV2MKLDNNOp)
-create_test_class(TestNearestInterpOpV2MKLDNNNHWC)
-create_test_class(TestNearestNeighborInterpV2MKLDNNCase2)
-create_test_class(TestNearestNeighborInterpV2MKLDNNCase3)
-create_test_class(TestNearestNeighborInterpV2MKLDNNCase4)
-create_test_class(TestNearestNeighborInterpV2MKLDNNSame)
+create_test_class(TestNearestInterpV2ONEDNNOp)
+create_test_class(TestNearestInterpOpV2ONEDNNNHWC)
+create_test_class(TestNearestNeighborInterpV2ONEDNNCase2)
+create_test_class(TestNearestNeighborInterpV2ONEDNNCase3)
+create_test_class(TestNearestNeighborInterpV2ONEDNNCase4)
+create_test_class(TestNearestNeighborInterpV2ONEDNNSame)
 
 if __name__ == "__main__":
     from paddle import enable_static

--- a/test/mkldnn/test_onnx_format_quantization_mobilenetv1.py
+++ b/test/mkldnn/test_onnx_format_quantization_mobilenetv1.py
@@ -356,7 +356,7 @@ class TestPostTrainingQuantization(unittest.TestCase):
         self.assertLess(delta_value, diff_threshold)
 
 
-class TestMKLDNNInt8ForResnet50AvgONNXFormat(TestPostTrainingQuantization):
+class TestONEDNNInt8ForResnet50AvgONNXFormat(TestPostTrainingQuantization):
     def test_onnx_format_avg_resnet50(self):
         model = "resnet50"
         algo = "avg"

--- a/test/mkldnn/test_pool2d_int8_mkldnn_op.py
+++ b/test/mkldnn/test_pool2d_int8_mkldnn_op.py
@@ -24,7 +24,7 @@ from test_pool2d_op import TestPool2D_Op, max_pool2D_forward_naive
 from paddle.base import core
 
 
-class TestPool2DMKLDNNInt8_Op(TestPool2D_Op):
+class TestPool2DONEDNNInt8_Op(TestPool2D_Op):
     def init_kernel_type(self):
         self.use_mkldnn = True
         self.check_pir_onednn = True
@@ -68,7 +68,7 @@ class TestPool2DMKLDNNInt8_Op(TestPool2D_Op):
         pass
 
 
-class TestCase1Avg(TestPool2DMKLDNNInt8_Op):
+class TestCase1Avg(TestPool2DONEDNNInt8_Op):
     def init_test_case(self):
         self.shape = [2, 3, 7, 7]
         self.ksize = [3, 3]
@@ -82,7 +82,7 @@ class TestCase1Avg(TestPool2DMKLDNNInt8_Op):
         self.exclusive = True
 
 
-class TestCase2Avg(TestPool2DMKLDNNInt8_Op):
+class TestCase2Avg(TestPool2DONEDNNInt8_Op):
     def init_test_case(self):
         self.shape = [2, 3, 7, 7]
         self.ksize = [3, 3]
@@ -96,7 +96,7 @@ class TestCase2Avg(TestPool2DMKLDNNInt8_Op):
         self.exclusive = False
 
 
-class TestCase0Max(TestPool2DMKLDNNInt8_Op):
+class TestCase0Max(TestPool2DONEDNNInt8_Op):
     def init_pool_type(self):
         self.pool_type = "max"
         self.pool2D_forward_naive = max_pool2D_forward_naive
@@ -131,7 +131,7 @@ def create_test_s8_u8_class(parent):
     globals()[cls_name_u8] = TestU8Case
 
 
-create_test_s8_u8_class(TestPool2DMKLDNNInt8_Op)
+create_test_s8_u8_class(TestPool2DONEDNNInt8_Op)
 create_test_s8_u8_class(TestCase1Avg)
 create_test_s8_u8_class(TestCase2Avg)
 create_test_s8_u8_class(TestCase0Max)

--- a/test/mkldnn/test_pool2d_mkldnn_op.py
+++ b/test/mkldnn/test_pool2d_mkldnn_op.py
@@ -30,7 +30,7 @@ from test_pool2d_op import (
 
 
 def create_test_mkldnn_use_ceil_class(parent):
-    class TestMKLDNNPool2DUseCeilCase(parent):
+    class TestONEDNNPool2DUseCeilCase(parent):
         def init_kernel_type(self):
             self.use_mkldnn = True
             self.check_pir_onednn = True
@@ -41,9 +41,9 @@ def create_test_mkldnn_use_ceil_class(parent):
         def init_data_type(self):
             self.dtype = np.float32
 
-    cls_name = "{}_{}".format(parent.__name__, "MKLDNNCeilModeCast")
-    TestMKLDNNPool2DUseCeilCase.__name__ = cls_name
-    globals()[cls_name] = TestMKLDNNPool2DUseCeilCase
+    cls_name = "{}_{}".format(parent.__name__, "ONEDNNCeilModeCast")
+    TestONEDNNPool2DUseCeilCase.__name__ = cls_name
+    globals()[cls_name] = TestONEDNNPool2DUseCeilCase
 
 
 create_test_mkldnn_use_ceil_class(TestPool2D_Op)
@@ -52,7 +52,7 @@ create_test_mkldnn_use_ceil_class(TestCase2)
 
 
 def create_test_mkldnn_class(parent):
-    class TestMKLDNNCase(parent):
+    class TestONEDNNCase(parent):
         def init_kernel_type(self):
             self.use_mkldnn = True
             self.check_pir_onednn = True
@@ -60,9 +60,9 @@ def create_test_mkldnn_class(parent):
         def init_data_type(self):
             self.dtype = np.float32
 
-    cls_name = "{}_{}".format(parent.__name__, "MKLDNNOp")
-    TestMKLDNNCase.__name__ = cls_name
-    globals()[cls_name] = TestMKLDNNCase
+    cls_name = "{}_{}".format(parent.__name__, "ONEDNNOp")
+    TestONEDNNCase.__name__ = cls_name
+    globals()[cls_name] = TestONEDNNCase
 
 
 create_test_mkldnn_class(TestPool2D_Op)

--- a/test/mkldnn/test_softmax_bf16_mkldnn_op.py
+++ b/test/mkldnn/test_softmax_bf16_mkldnn_op.py
@@ -42,7 +42,7 @@ def stable_softmax(x):
 @unittest.skipIf(
     not core.supports_bfloat16(), "place does not support BF16 evaluation"
 )
-class TestSoftmaxMKLDNNOp(TestSoftmaxOp):
+class TestSoftmaxONEDNNOp(TestSoftmaxOp):
     def get_x_shape(self):
         return [10, 10]
 
@@ -76,31 +76,31 @@ class TestSoftmaxMKLDNNOp(TestSoftmaxOp):
         self.use_mkldnn = True
 
 
-class TestSoftmaxMKLDNNOp2(TestSoftmaxOp2):
+class TestSoftmaxONEDNNOp2(TestSoftmaxOp2):
     def init_kernel_type(self):
         self.use_mkldnn = True
         self.check_pir_onednn = True
 
 
-class TestSoftmaxMKLDNNOp3(TestSoftmaxOp3):
+class TestSoftmaxONEDNNOp3(TestSoftmaxOp3):
     def init_kernel_type(self):
         self.use_mkldnn = True
         self.check_pir_onednn = True
 
 
-class TestSoftmaxMKLDNNOp4(TestSoftmaxOp4):
+class TestSoftmaxONEDNNOp4(TestSoftmaxOp4):
     def init_kernel_type(self):
         self.use_mkldnn = True
         self.check_pir_onednn = True
 
 
-class TestSoftmaxMKLDNNOp5(TestSoftmaxOp5):
+class TestSoftmaxONEDNNOp5(TestSoftmaxOp5):
     def init_kernel_type(self):
         self.use_mkldnn = True
         self.check_pir_onednn = True
 
 
-class TestSoftmaxMKLDNNOp6(TestSoftmaxOp6):
+class TestSoftmaxONEDNNOp6(TestSoftmaxOp6):
     def init_kernel_type(self):
         self.use_mkldnn = True
         self.check_pir_onednn = True

--- a/test/mkldnn/test_sum_bf16_mkldnn_op.py
+++ b/test/mkldnn/test_sum_bf16_mkldnn_op.py
@@ -25,7 +25,7 @@ from paddle.base import core
 @unittest.skipIf(
     not core.supports_bfloat16(), "place does not support BF16 evaluation"
 )
-class TestSumBF16MKLDNN(TestSumOp):
+class TestSumBF16ONEDNN(TestSumOp):
     def setUp(self):
         self.op_type = "sum"
         self.use_mkldnn = True

--- a/test/mkldnn/test_transpose_mkldnn_op.py
+++ b/test/mkldnn/test_transpose_mkldnn_op.py
@@ -18,7 +18,7 @@ import numpy as np
 from op_test import OpTest
 
 
-class TestTransposeMKLDNN(OpTest):
+class TestTransposeONEDNN(OpTest):
     def setUp(self):
         self.init_op_type()
         self.initTestCase()
@@ -53,43 +53,43 @@ class TestTransposeMKLDNN(OpTest):
         self.axis = (1, 0)
 
 
-class TestCase0MKLDNN(TestTransposeMKLDNN):
+class TestCase0ONEDNN(TestTransposeONEDNN):
     def initTestCase(self):
         self.shape = (100,)
         self.axis = (0,)
 
 
-class TestCase1a(TestTransposeMKLDNN):
+class TestCase1a(TestTransposeONEDNN):
     def initTestCase(self):
         self.shape = (3, 4, 10)
         self.axis = (0, 2, 1)
 
 
-class TestCase1b(TestTransposeMKLDNN):
+class TestCase1b(TestTransposeONEDNN):
     def initTestCase(self):
         self.shape = (3, 4, 10)
         self.axis = (2, 1, 0)
 
 
-class TestCase2(TestTransposeMKLDNN):
+class TestCase2(TestTransposeONEDNN):
     def initTestCase(self):
         self.shape = (2, 3, 4, 5)
         self.axis = (0, 2, 3, 1)
 
 
-class TestCase3(TestTransposeMKLDNN):
+class TestCase3(TestTransposeONEDNN):
     def initTestCase(self):
         self.shape = (2, 3, 4, 5, 6)
         self.axis = (4, 2, 3, 1, 0)
 
 
-class TestCase4(TestTransposeMKLDNN):
+class TestCase4(TestTransposeONEDNN):
     def initTestCase(self):
         self.shape = (2, 3, 4, 5, 6, 1)
         self.axis = (4, 2, 3, 1, 0, 5)
 
 
-class TestCase_ZeroDim(TestTransposeMKLDNN):
+class TestCase_ZeroDim(TestTransposeONEDNN):
     def initTestCase(self):
         self.shape = ()
         self.axis = ()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
单测名称 MKLDNN 修改为ONEDNN