### PR TITLE
Rename context to dev_ctx in paddle/phi/kernels/funcs/ [fluid_ops]

### DIFF
--- a/paddle/phi/kernels/funcs/concat_and_split_functor.cu
+++ b/paddle/phi/kernels/funcs/concat_and_split_functor.cu
@@ -24,7 +24,7 @@ limitations under the License. */
 namespace phi {
 namespace funcs {
 
-static inline void GetBlockDims(const phi::GPUContext& context,
+static inline void GetBlockDims(const phi::GPUContext& dev_ctx,
                                 int64_t num_rows,
                                 int64_t num_cols,
                                 dim3* block_dims,
@@ -39,7 +39,7 @@ static inline void GetBlockDims(const phi::GPUContext& context,
   *block_dims = dim3(block_cols, block_rows, 1);
 
   constexpr int waves = 1;
-  int max_threads = context.GetMaxPhysicalThreadCount() * waves;
+  int max_threads = dev_ctx.GetMaxPhysicalThreadCount() * waves;
   int64_t max_blocks = std::max(max_threads / kThreadsPerBlock, 1);
 
   int grid_cols =
@@ -605,14 +605,14 @@ void ConcatFunctorWithIndexType(const phi::GPUContext& dev_ctx,
 
 template <typename T>
 struct ConcatFunctor<phi::GPUContext, T> {
-  void operator()(const phi::GPUContext& context,
+  void operator()(const phi::GPUContext& dev_ctx,
                   const std::vector<phi::DenseTensor>& input,
                   int axis,
                   phi::DenseTensor* output) {
     if (output->numel() < std::numeric_limits<int32_t>::max()) {
-      ConcatFunctorWithIndexType<T, int32_t>(context, input, axis, output);
+      ConcatFunctorWithIndexType<T, int32_t>(dev_ctx, input, axis, output);
     } else {
-      ConcatFunctorWithIndexType<T, int64_t>(context, input, axis, output);
+      ConcatFunctorWithIndexType<T, int64_t>(dev_ctx, input, axis, output);
     }
   }
 };
@@ -805,7 +805,7 @@ void SplitFunctorDispatchWithIndexType(
 template <typename T>
 class SplitFunctor<phi::GPUContext, T> {
  public:
-  void operator()(const phi::GPUContext& context,
+  void operator()(const phi::GPUContext& dev_ctx,
                   const phi::DenseTensor& input,
                   const std::vector<const phi::DenseTensor*>& ref_inputs,
                   int axis,
@@ -819,10 +819,10 @@ class SplitFunctor<phi::GPUContext, T> {
 
     if (numel < std::numeric_limits<int32_t>::max()) {
       SplitFunctorDispatchWithIndexType<T, int32_t>(
-          context, axis, input, ref_inputs, outputs);
+          dev_ctx, axis, input, ref_inputs, outputs);
     } else {
       SplitFunctorDispatchWithIndexType<T, int64_t>(
-          context, axis, input, ref_inputs, outputs);
+          dev_ctx, axis, input, ref_inputs, outputs);
     }
   }
 };

--- a/paddle/phi/kernels/funcs/elementwise/elementwise_op_broadcast.cu.h
+++ b/paddle/phi/kernels/funcs/elementwise/elementwise_op_broadcast.cu.h
@@ -21,7 +21,7 @@ namespace funcs {
 
 template <typename OutT, typename Functor, int NumOuts = 1>
 void LaunchElementwiseCudaKernel(
-    const KPDevice &ctx,
+    const KPDevice &dev_ctx,
     const std::vector<const phi::DenseTensor *> &ins,
     std::vector<phi::DenseTensor *> *outs,
     Functor func,
@@ -50,7 +50,7 @@ void LaunchElementwiseCudaKernel(
     pt_outputs.push_back(pt_outputs_tmp[i].get());
   }
   phi::funcs::BroadcastKernel<OutT, Functor, NumOuts>(
-      ctx, pt_inputs, &pt_outputs, func, axis);
+      dev_ctx, pt_inputs, &pt_outputs, func, axis);
 }
 
 }  // namespace funcs

--- a/paddle/phi/kernels/funcs/elementwise/elementwise_op_impl.cu.h
+++ b/paddle/phi/kernels/funcs/elementwise/elementwise_op_impl.cu.h
@@ -24,7 +24,7 @@ namespace funcs {
 
 template <typename OutT, typename Functor, int NumOuts = 1>
 void LaunchSameDimsElementwiseCudaKernel(
-    const KPDevice &ctx,
+    const KPDevice &dev_ctx,
     const std::vector<const phi::DenseTensor *> &ins,
     std::vector<phi::DenseTensor *> *outs,
     Functor func) {
@@ -52,7 +52,7 @@ void LaunchSameDimsElementwiseCudaKernel(
     pt_outputs.push_back(pt_outputs_tmp[i].get());
   }
   phi::funcs::ElementwiseKernel<OutT, Functor, NumOuts>(
-      ctx, pt_inputs, &pt_outputs, func);
+      dev_ctx, pt_inputs, &pt_outputs, func);
 }
 
 }  // namespace funcs

--- a/paddle/phi/kernels/funcs/fc_functor.cc
+++ b/paddle/phi/kernels/funcs/fc_functor.cc
@@ -22,7 +22,7 @@ namespace phi {
 namespace funcs {
 
 template <typename DeviceContext, typename T>
-void FCFunctor<DeviceContext, T>::operator()(const DeviceContext& context,
+void FCFunctor<DeviceContext, T>::operator()(const DeviceContext& dev_ctx,
                                              const int M,
                                              const int N,
                                              const int K,
@@ -32,7 +32,7 @@ void FCFunctor<DeviceContext, T>::operator()(const DeviceContext& context,
                                              const T* B,
                                              bool relu,
                                              bool padding_weights) {
-  auto blas = GetBlas<DeviceContext, T>(context);
+  auto blas = GetBlas<DeviceContext, T>(dev_ctx);
   phi::DenseTensor Y1;
   T* Y1_data = nullptr;
   if (padding_weights) {
@@ -40,10 +40,10 @@ void FCFunctor<DeviceContext, T>::operator()(const DeviceContext& context,
     const int KK = K + 4;
     phi::DenseTensor X1;
     X1.Resize({M * KK});
-    T* X1_data = context.template HostAlloc<T>(&X1);
+    T* X1_data = dev_ctx.template HostAlloc<T>(&X1);
 
     Y1.Resize({M * (N + 4)});
-    Y1_data = context.template HostAlloc<T>(&Y1);
+    Y1_data = dev_ctx.template HostAlloc<T>(&Y1);
 #ifdef PADDLE_WITH_MKLML
 #pragma omp parallel for
 #endif

--- a/paddle/phi/kernels/funcs/fft_fill_conj.h
+++ b/paddle/phi/kernels/funcs/fft_fill_conj.h
@@ -138,7 +138,7 @@ struct FFTFillConjFunctor {
 };
 
 template <typename DeviceContext, typename C>
-void FFTFillConj(const DeviceContext& ctx,
+void FFTFillConj(const DeviceContext& dev_ctx,
                  const DenseTensor* src,
                  DenseTensor* dst,
                  const std::vector<int64_t>& axes) {
@@ -160,49 +160,49 @@ void FFTFillConj(const DeviceContext& ctx,
 #if defined(__NVCC__) || defined(__HIPCC__)
   DenseTensor src_strides_g;
   src_strides_g.Resize({(int64_t)src_strides_v.size()});
-  int64_t* src_strides = ctx.template Alloc<int64_t>(&src_strides_g);
+  int64_t* src_strides = dev_ctx.template Alloc<int64_t>(&src_strides_g);
   DenseTensor dst_strides_g;
   dst_strides_g.Resize({(int64_t)dst_strides_v.size()});
-  int64_t* dst_strides = ctx.template Alloc<int64_t>(&dst_strides_g);
+  int64_t* dst_strides = dev_ctx.template Alloc<int64_t>(&dst_strides_g);
   DenseTensor dst_shape_g;
   dst_shape_g.Resize({(int64_t)dst_shape_v.size()});
-  int64_t* dst_shape = ctx.template Alloc<int64_t>(&dst_shape_g);
+  int64_t* dst_shape = dev_ctx.template Alloc<int64_t>(&dst_shape_g);
   DenseTensor is_fft_axis_g;
   is_fft_axis_g.Resize({rank});
-  bool* p_is_fft_axis = ctx.template Alloc<bool>(&is_fft_axis_g);
+  bool* p_is_fft_axis = dev_ctx.template Alloc<bool>(&is_fft_axis_g);
   auto cplace = phi::CPUPlace();
-  const auto gplace = ctx.GetPlace();
+  const auto gplace = dev_ctx.GetPlace();
   memory_utils::Copy(gplace,
                      src_strides,
                      cplace,
                      src_strides_v.data(),
                      sizeof(int64_t) * src_strides_v.size(),
-                     ctx.stream());
+                     dev_ctx.stream());
   memory_utils::Copy(gplace,
                      dst_strides,
                      cplace,
                      dst_strides_v.data(),
                      sizeof(int64_t) * dst_strides_v.size(),
-                     ctx.stream());
+                     dev_ctx.stream());
   memory_utils::Copy(gplace,
                      dst_shape,
                      cplace,
                      dst_shape_v.data(),
                      sizeof(int64_t) * dst_shape_v.size(),
-                     ctx.stream());
+                     dev_ctx.stream());
   memory_utils::Copy(gplace,
                      p_is_fft_axis,
                      cplace,
                      _is_fft_axis.get(),
                      sizeof(bool) * rank,
-                     ctx.stream());
+                     dev_ctx.stream());
 #else
   const auto src_strides = src_strides_v.data();
   const auto dst_strides = dst_strides_v.data();
   const auto dst_shape = dst_shape_v.data();
   const auto p_is_fft_axis = _is_fft_axis.get();
 #endif
-  ForRange<DeviceContext> for_range(ctx, dst->numel());
+  ForRange<DeviceContext> for_range(dev_ctx, dst->numel());
   FFTFillConjFunctor<C> fill_conj_functor(src_data,
                                           dst_data,
                                           src_strides,

--- a/paddle/phi/kernels/funcs/fft_fill_conj_xpu.h
+++ b/paddle/phi/kernels/funcs/fft_fill_conj_xpu.h
@@ -44,7 +44,7 @@ int FFTFillConjGrad(int N,
 namespace phi {
 namespace funcs {
 template <typename DeviceContext, typename C>
-void FFTFillConj(const DeviceContext& ctx,
+void FFTFillConj(const DeviceContext& dev_ctx,
                  DenseTensor* src,
                  DenseTensor* dst,
                  const std::vector<int64_t>& axes) {
@@ -63,7 +63,7 @@ void FFTFillConj(const DeviceContext& ctx,
     _is_fft_axis[i] = true;
   }
 
-  xpu::ctx_guard RAII_GUARD(ctx.x_context());
+  xpu::ctx_guard RAII_GUARD(dev_ctx.x_context());
   int64_t* src_strides_ptr =
       RAII_GUARD.alloc_l3_or_gm<int64_t>(src_strides_v.size());
   PADDLE_ENFORCE_NOT_NULL(src_strides_ptr,
@@ -111,7 +111,7 @@ void FFTFillConj(const DeviceContext& ctx,
 }
 
 template <typename DeviceContext, typename C>
-void FFTFillConjGrad(const DeviceContext& ctx,
+void FFTFillConjGrad(const DeviceContext& dev_ctx,
                      const DenseTensor& out_grad,
                      const std::vector<int64_t>& axes,
                      DenseTensor* x_grad) {

--- a/paddle/phi/kernels/funcs/math/tree2col.cc
+++ b/paddle/phi/kernels/funcs/math/tree2col.cc
@@ -86,7 +86,7 @@ void Tree2ColUtil::construct_tree(const phi::DenseTensor &EdgeSet,
 template <typename T>
 class Tree2ColFunctor<phi::CPUContext, T> {
  public:
-  void operator()(const phi::CPUContext &context,
+  void operator()(const phi::CPUContext &dev_ctx,
                   const phi::DenseTensor &EdgeSet,
                   const phi::DenseTensor &node_features,
                   phi::DenseTensor *patch,
@@ -110,8 +110,8 @@ class Tree2ColFunctor<phi::CPUContext, T> {
 
     patch->Resize({static_cast<int64_t>(patch_size),
                    static_cast<int64_t>(patch_elem_size)});
-    T *patch_data = context.template Alloc<T>(patch);
-    constant(context, patch, 0);
+    T *patch_data = dev_ctx.template Alloc<T>(patch);
+    constant(dev_ctx, patch, 0);
     const T *features = node_features.data<T>();
 
     for (auto &patch_item : processing_list) {
@@ -138,7 +138,7 @@ class Tree2ColFunctor<phi::CPUContext, T> {
 template <typename T>
 class Col2TreeFunctor<phi::CPUContext, T> {
  public:
-  void operator()(const phi::CPUContext &context,
+  void operator()(const phi::CPUContext &dev_ctx,
                   const phi::DenseTensor &EdgeSet,
                   const phi::DenseTensor &out_grad,
                   phi::DenseTensor *in_grad,
@@ -167,9 +167,9 @@ class Col2TreeFunctor<phi::CPUContext, T> {
     }
     in_grad->Resize({static_cast<int64_t>(node_count),
                      static_cast<int64_t>(grad_elem_size)});
-    T *grad_data = context.template Alloc<T>(in_grad);
+    T *grad_data = dev_ctx.template Alloc<T>(in_grad);
 
-    constant(context, in_grad, 0);
+    constant(dev_ctx, in_grad, 0);
     const T *out_g = out_grad.data<T>();
     for (auto &patch_item : grad_list) {
       size_t pointer_base = grad_count * grad_elem_size;

--- a/paddle/phi/kernels/funcs/math/tree2col.h
+++ b/paddle/phi/kernels/funcs/math/tree2col.h
@@ -72,7 +72,7 @@ class Tree2ColUtil {
 template <typename DeviceContext, typename T>
 class Tree2ColFunctor {
  public:
-  void operator()(const DeviceContext &context,
+  void operator()(const DeviceContext &dev_ctx,
                   const phi::DenseTensor &EdgeSet,
                   const phi::DenseTensor &node_features,
                   phi::DenseTensor *patch,
@@ -81,7 +81,7 @@ class Tree2ColFunctor {
 template <typename DeviceContext, typename T>
 class Col2TreeFunctor {
  public:
-  void operator()(const DeviceContext &context,
+  void operator()(const DeviceContext &dev_ctx,
                   const phi::DenseTensor &EdgeSet,
                   const phi::DenseTensor &out_grad,
                   phi::DenseTensor *in_grad,

--- a/paddle/phi/kernels/funcs/math_function_blas_impl.h
+++ b/paddle/phi/kernels/funcs/math_function_blas_impl.h
@@ -32,7 +32,7 @@ namespace funcs {
 // and only failed for this case. So reimplemented it.
 template <>
 void ColwiseSum<phi::GPUContext, double>::operator()(
-    const phi::GPUContext& context,
+    const phi::GPUContext& dev_ctx,
     const phi::DenseTensor& input,
     phi::DenseTensor* vector) {
   auto in_dims = input.dims();
@@ -47,11 +47,11 @@ void ColwiseSum<phi::GPUContext, double>::operator()(
                         vector->numel()));
   phi::DenseTensor one;
   one.Resize({in_dims[0]});
-  context.template Alloc<double>(&one);
+  dev_ctx.template Alloc<double>(&one);
 
   SetConstant<phi::GPUContext, double> set;
-  set(context, &one, static_cast<double>(1.0));
-  phi::funcs::GetBlas<phi::GPUContext, double>(context).GEMV(
+  set(dev_ctx, &one, static_cast<double>(1.0));
+  phi::funcs::GetBlas<phi::GPUContext, double>(dev_ctx).GEMV(
       true,
       static_cast<int>(in_dims[0]),
       static_cast<int>(in_dims[1]),
@@ -68,7 +68,7 @@ void ColwiseSum<phi::GPUContext, double>::operator()(
 // mode,
 template <>
 void RowwiseSum<phi::GPUContext, double>::operator()(
-    const phi::GPUContext& context,
+    const phi::GPUContext& dev_ctx,
     const phi::DenseTensor& input,
     phi::DenseTensor* vector) {
   auto in_dims = input.dims();
@@ -83,11 +83,11 @@ void RowwiseSum<phi::GPUContext, double>::operator()(
                         vector->numel()));
   phi::DenseTensor one;
   one.Resize({size});
-  context.template Alloc<double>(&one);
+  dev_ctx.template Alloc<double>(&one);
 
   SetConstant<phi::GPUContext, double> set;
-  set(context, &one, static_cast<double>(1.0));
-  phi::funcs::GetBlas<phi::GPUContext, double>(context).GEMV(
+  set(dev_ctx, &one, static_cast<double>(1.0));
+  phi::funcs::GetBlas<phi::GPUContext, double>(dev_ctx).GEMV(
       true,
       static_cast<int>(in_dims[1]),
       static_cast<int>(in_dims[0]),

--- a/paddle/phi/kernels/funcs/repeat_tensor2index_tensor.cc
+++ b/paddle/phi/kernels/funcs/repeat_tensor2index_tensor.cc
@@ -24,10 +24,10 @@ namespace funcs {
 
 template <typename Context, typename RepeatsT>
 void RepeatsTensor2IndexTensorFunctor<Context, RepeatsT>::operator()(
-    const Context &ctx, const DenseTensor &repeats, DenseTensor *index) {
+    const Context &dev_ctx, const DenseTensor &repeats, DenseTensor *index) {
   DenseTensor repeats_cpu_copy;
   if (repeats.place().GetType() != phi::AllocationType::CPU) {
-    phi::Copy(ctx, repeats, phi::CPUPlace(), true, &repeats_cpu_copy);
+    phi::Copy(dev_ctx, repeats, phi::CPUPlace(), true, &repeats_cpu_copy);
   }
   const RepeatsT *repeats_data =
       repeats.place().GetType() == phi::AllocationType::CPU
@@ -51,7 +51,7 @@ void RepeatsTensor2IndexTensorFunctor<Context, RepeatsT>::operator()(
   }
   index->Resize(common::make_ddim({index_size}));
 
-  phi::TensorFromVector<RepeatsT>(index_vec, ctx, index);
+  phi::TensorFromVector<RepeatsT>(index_vec, dev_ctx, index);
 }
 
 template <typename RepeatsT>


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
Rename context to dev_ctx in paddle/phi/kernels/funcs/
Rename ctx to dev_ctx in paddle/phi/kernels/funcs/