### PR TITLE
[slice] fix llama_auto_dp2_mp2_pp2 std::bad array_new_length error

### DIFF
--- a/paddle/fluid/pybind/eager_method.cc
+++ b/paddle/fluid/pybind/eager_method.cc
@@ -1651,8 +1651,10 @@ static PyObject* tensor__getitem_dygraph(TensorObject* self,
 
     if (transed_tensor.is_gpu() && !is_combined_bool && !has_empty_index) {
       const phi::distributed::ProcessMesh* mesh = nullptr;
-      if (InputsContainDistTensor(&mesh, transed_tensor, transed_index)) {
-        ConvertAllInputsToDistTensor(mesh, transed_tensor, transed_index);
+      if (InputsContainDistTensor(
+              &mesh, self->tensor, transed_tensor, transed_index)) {
+        ConvertAllInputsToDistTensor(
+            mesh, self->tensor, transed_tensor, transed_index);
       }
 
       transed_index = expand_outplace(transed_index);
@@ -1684,7 +1686,7 @@ static PyObject* tensor__getitem_dygraph(TensorObject* self,
 
       AdvancedIndex ad = AdvancedIndex(transed_tensor, transed_index_int64);
       const bool accumulate = true;
-      out = index_elementwise_get_ad_func(tensor,
+      out = index_elementwise_get_ad_func(self->tensor,
                                           ad.indices,
                                           ad.src_sizes,
                                           ad.src_strides,

--- a/test/auto_parallel/hybrid_strategy/CMakeLists.txt
+++ b/test/auto_parallel/hybrid_strategy/CMakeLists.txt
@@ -147,6 +147,14 @@ if((WITH_GPU) AND (LINUX))
 endif()
 if((WITH_GPU) AND (LINUX))
   py_test_modules(
+    test_to_distributed_api_for_llama MODULES test_to_distributed_api_for_llama
+    ENVS
+    "http_proxy=;https_proxy=;PYTHONPATH=../..:${PADDLE_BINARY_DIR}/python")
+  set_tests_properties(test_to_distributed_api_for_llama
+                       PROPERTIES TIMEOUT "180" LABELS "RUN_TYPE=HYBRID")
+endif()
+if((WITH_GPU) AND (LINUX))
+  py_test_modules(
     test_parallel_api_with_llama_lora MODULES test_parallel_api_with_llama_lora
     ENVS
     "http_proxy=;https_proxy=;PYTHONPATH=../..:${PADDLE_BINARY_DIR}/python")

--- a/test/auto_parallel/hybrid_strategy/testslist.csv
+++ b/test/auto_parallel/hybrid_strategy/testslist.csv
@@ -16,5 +16,6 @@ test_semi_auto_llama_save_load,LINUX,GPU,180,HYBRID,test_runner.py,,,http_proxy=
 test_parallel_api_with_llama_1d,LINUX,GPU,400,HYBRID,test_runner.py,,,http_proxy=;https_proxy=;PYTHONPATH=../..,
 test_parallel_api_with_llama_2d,LINUX,GPU,400,HYBRID,test_runner.py,,,http_proxy=;https_proxy=;PYTHONPATH=../..,
 test_parallel_api_with_llama_3d,LINUX,GPU,400,HYBRID,test_runner.py,,,http_proxy=;https_proxy=;PYTHONPATH=../..,
+test_to_distributed_api_for_llama,LINUX,GPU,180,HYBRID,test_runner.py,,,http_proxy=;https_proxy=;PYTHONPATH=../..,
 test_parallel_api_with_llama_lora,LINUX,GPU,360,HYBRID,test_runner.py,,,http_proxy=;https_proxy=;PYTHONPATH=../..,
 test_process_mesh,LINUX,GPU,60,HYBRID,test_runner.py,,,http_proxy=;https_proxy=;PYTHONPATH=../..,


### PR DESCRIPTION
### PR Category
Performance Optimization

### PR Types
Improvements

### Description
[报错原因]
在分布式场景中 index_elementwise_get_ad_func 的第一个参数没有转换为 DistTensor 仍是 DenseTensor ，而 index 转换成了 DistTensor 因此产生了报错。API输入的 tensor 有可能是DenseTensor 或者 DistTensor，所以pybind层前面的代码中会判断输入中是否存在DistTensor，如果存在就把输入中其它DenseTensor 也都转为 DistTensor，以保证下层计算正确。需要确保输入是经过ConvertAllInputsToDistTensor处理后的Tensor。

fix llama_auto_dp2_mp2_pp2 std::bad array_new_length error
<img width="1200" alt="image" src="https://github.com/user-attachments/assets/1390aef1-a413-4f66-9d5b-ea0b2a8e5ded" />

test_to_distributed_api_for_llama.py单测通过
<img width="935" alt="image" src="https://github.com/user-attachments/assets/3814d0c4-a7f2-4280-998c-111ae68a5036" />


pcard-67164