### PR TITLE
[Auto Parallel] FIx inplaced ops save wrong dist_attr for backward in auto parallel

### DIFF
--- a/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
@@ -1415,7 +1415,7 @@ class DygraphFunctionGeneratorBase(FunctionGeneratorBase):
                         else forward_api_name
                     ) in special_inplace_list:
                         set_grad_out_meta = f"""
-    if ({name}.is_dist_tensor()&& {name}.impl()){{
+    if ({name}.is_dist_tensor() && {name}.impl()){{
   {indent}grad_node->SetGradOutMeta({name}, {pos}, {name}_dist_attr, {name}_dims);
     }} else{{
   {indent}grad_node->SetGradOutMeta({name}, {pos});
@@ -1856,9 +1856,9 @@ class DygraphForwardFunctionGenerator(DygraphFunctionGeneratorBase):
                     f"""
   phi::distributed::TensorDistAttr {name}_dist_attr;
   phi::DDim {name}_dims;
-  if ({name}.is_dist_tensor()&& {name}.impl()){{
+  if ({name}.is_dist_tensor() && {name}.impl()){{
     auto* {name}_dist_tensor = static_cast<phi::distributed::DistTensor*>({name}.impl().get());
-    {name}_dist_attr = {name}_dist_tensor -> dist_attr();
+    {name}_dist_attr = {name}_dist_tensor->dist_attr();
     {name}_dims = {name}_dist_tensor->dims();
    }}"""
                 )

--- a/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
@@ -193,6 +193,12 @@ special_prune_dict = {
     "matmul_grad": {"x": "grad_y", "y": "grad_x"},
 }
 
+
+# temporary list of inplace api to add record_inplace_original_dist_attr_list,
+# all inplace api in auto parallel should apply, for now only reshape_.
+special_inplace_list = {"reshape_"}
+
+
 strided_op_list = {
     "as_complex",
     "as_real",
@@ -1403,9 +1409,21 @@ class DygraphFunctionGeneratorBase(FunctionGeneratorBase):
                     )
                     set_grad_out_meta = f"{indent}grad_node->SetGradOutMeta({name}, {meta_name}, {pos});"
                 else:
-                    set_grad_out_meta = (
-                        f"{indent}grad_node->SetGradOutMeta({name}, {pos});"
-                    )
+                    if (
+                        GetInplacedFunctionName(forward_api_name)
+                        if is_inplaced
+                        else forward_api_name
+                    ) in special_inplace_list:
+                        set_grad_out_meta = f"""
+    if ({name}.is_dist_tensor()&& {name}.impl()){{
+  {indent}grad_node->SetGradOutMeta({name}, {pos}, {name}_dist_attr, {name}_dims);
+    }} else{{
+  {indent}grad_node->SetGradOutMeta({name}, {pos});
+    }}"""
+                    else:
+                        set_grad_out_meta = (
+                            f"{indent}grad_node->SetGradOutMeta({name}, {pos});"
+                        )
 
             set_grad_out_meta_list.append(set_grad_out_meta)
         set_grad_out_meta_str = "\n".join(set_grad_out_meta_list)
@@ -1720,6 +1738,7 @@ class DygraphForwardFunctionGenerator(DygraphFunctionGeneratorBase):
         layout_autotune_list = []
         layout_autotune_optional_list = []
         layout_tensors_vector_optional_list = []
+        record_inplace_original_dist_attr_list = []
         for name, (ttype, pos) in forward_inputs_position_map.items():
             inputs_call_list[pos] = f"{name}"
             amp_inputs_call_list[pos] = f"new_{name}"
@@ -1832,6 +1851,18 @@ class DygraphForwardFunctionGenerator(DygraphFunctionGeneratorBase):
             inputs_args_definition_list[pos] = arg_str
             inputs_args_declaration_list[pos] = arg_str
 
+            if is_inplaced and forward_api_name in special_inplace_list:
+                record_inplace_original_dist_attr_list.append(
+                    f"""
+  phi::distributed::TensorDistAttr {name}_dist_attr;
+  phi::DDim {name}_dims;
+  if ({name}.is_dist_tensor()&& {name}.impl()){{
+    auto* {name}_dist_tensor = static_cast<phi::distributed::DistTensor*>({name}.impl().get());
+    {name}_dist_attr = {name}_dist_tensor -> dist_attr();
+    {name}_dims = {name}_dist_tensor->dims();
+   }}"""
+                )
+
         # forward attrs
         for name, atype, default_val, pos in forward_attrs_list:
             inputs_call_list[pos] = name
@@ -1891,7 +1922,16 @@ class DygraphForwardFunctionGenerator(DygraphFunctionGeneratorBase):
   }}
 """
         else:
-            forward_call_str = f"{indent}{api_out_type} api_result = paddle::experimental::{namespace}{function_name}({inputs_call_args_str});"
+            if is_inplaced and forward_api_name in special_inplace_list:
+                record_inplace_original_dist_attr_srt = (
+                    "\n".join(record_inplace_original_dist_attr_list) + "\n"
+                )
+                forward_call_str = (
+                    record_inplace_original_dist_attr_srt
+                    + f"{indent}{api_out_type} api_result = paddle::experimental::{namespace}{function_name}({inputs_call_args_str});"
+                )
+            else:
+                forward_call_str = f"{indent}{api_out_type} api_result = paddle::experimental::{namespace}{function_name}({inputs_call_args_str});"
         num_outputs = len(forward_outputs_position_map) - len(
             intermediate_outputs
         )

--- a/paddle/fluid/eager/grad_node_info.cc
+++ b/paddle/fluid/eager/grad_node_info.cc
@@ -556,6 +556,86 @@ void GradNodeBase::SetGradOutMeta(const paddle::Tensor& fwd_in,
   }
 }
 
+/*
+Special func for inplace ops in auto parallel. For now, this func is only used
+in reshape_.
+*/
+void GradNodeBase::SetGradOutMeta(
+    const paddle::Tensor& fwd_in,
+    size_t slot_rank,
+    const phi::distributed::TensorDistAttr& fwd_in_dist_attr,
+    const phi::DDim& fwd_in_dims) {
+  auto* fwd_in_meta = egr::EagerUtils::nullable_autograd_meta(fwd_in);
+  PADDLE_ENFORCE_LE(
+      (slot_rank + 1),
+      bwd_out_meta_.size(),
+      common::errors::InvalidArgument(
+          "Slot Rank should less equal than bwd_out_meta_ size, "
+          "since bwd_out_meta_ is designed to hold as same num as "
+          "backward outputs."));
+  auto& metas = bwd_out_meta_.at(slot_rank);
+  // Init stop gradient vector before use to avoid push back
+  if (metas.empty()) {
+    metas.resize(1);
+  }
+  auto& meta = metas[0];
+  // Set Stop_gradient
+  if (fwd_in_meta) {
+    meta.SetStopGradient(fwd_in_meta->StopGradient());
+  } else {
+    meta.SetStopGradient(true);
+  }
+  // Set Adj Edges
+  if (fwd_in_meta && !fwd_in_meta->StopGradient()) {
+    auto node = fwd_in_meta->GetMutableGradNode();
+    if (!node || !node.get()) {
+      fwd_in_meta->SetGradNode(
+          std::make_shared<egr::GradNodeAccumulation>(fwd_in_meta));
+    }
+    VLOG(3) << "Add Edges for slot: " << slot_rank << ", the Edge is from "
+            << this->name() << " (addr: " << this << ") "
+            << " to " << fwd_in_meta->GetMutableGradNode()->name()
+            << " (addr: " << fwd_in_meta->GetMutableGradNode().get() << ")";
+
+    meta.SetEdge(fwd_in_meta->GetMutableGradNode(), fwd_in_meta->OutRankInfo());
+  }
+  // Record TensorMeta
+  if (fwd_in.impl() && fwd_in.impl().get()) {
+    if (phi::distributed::DistTensor::classof(fwd_in.impl().get())) {
+      const phi::distributed::DistTensor* dist_tensor =
+          static_cast<phi::distributed::DistTensor*>(fwd_in.impl().get());
+      const phi::DenseTensor& dense_tensor = dist_tensor->value();
+      PADDLE_ENFORCE_NE(
+          dense_tensor.meta().dtype,
+          phi::DataType::UNDEFINED,
+          common::errors::Fatal("Attempting to copy DenseTensorMeta "
+                                "with phi::DataType::UNDEFINED,"
+                                "which is illegal."));
+      meta.SetTensorMeta(dense_tensor.meta());
+      meta.SetPlace(fwd_in.place());
+      // Set DistAttr
+      // Forward input DistTensor could be uninitialized.
+      PADDLE_ENFORCE_NE(
+          dist_tensor->dist_attr().empty(),
+          true,
+          common::errors::InvalidArgument(
+              "The forward input DistTensor's dist attr is empty."));
+      auto dist_attr = fwd_in_dist_attr;
+      dist_attr.clean_partial_status();
+      meta.SetDistAttr(dist_attr);
+      meta.SetDistTensorGlobalDims(fwd_in_dims);
+      SetIsRunAutoParallel(true);
+    } else {
+      VLOG(7)
+          << "Unable to initialize the DenseTensorMeta of GradSlotMeta with "
+             "non-DistTensor argument.";
+    }
+  } else {
+    VLOG(7) << "Unable to initialize the DenseTensorMeta because the Tensor "
+               "is not initialized.";
+  }
+}
+
 void GradNodeBase::SetGradOutMeta(const std::vector<paddle::Tensor>& fwd_in,
                                   size_t slot_rank) {
   size_t slot_size = fwd_in.size();

--- a/paddle/fluid/eager/grad_node_info.h
+++ b/paddle/fluid/eager/grad_node_info.h
@@ -260,6 +260,10 @@ class GradNodeBase {
   void SetGradOutMeta(const paddle::Tensor& fwd_in,
                       const AutogradMeta* fwd_in_other,
                       size_t slot_rank);
+  void SetGradOutMeta(const paddle::Tensor& fwd_in,
+                      size_t slot_rank,
+                      const phi::distributed::TensorDistAttr& fwd_in_dist_attr,
+                      const phi::DDim& fwd_in_dims);
   /**
    * Default setters for Grad in/out meta this should be used for same special
    * Node which will not create by user


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
在inplaced操作中，api传入参数为引用，这意味这api的input参数与output参数指向同一个地址。由于SetGradOutMeta是在调用api后记录，此时记录的参数是已经被api修改后的错误值，而非api实际传入的参数。

在非自动并行中，SetGradOutMeta仅记录传入x的meta相关参数；但在自动并行中，SetGradOutMeta会同时记录经过api修改后传入x的dist_attr以及dims，这些错误的参数会导致反向计算时该node自动推导的过程中得到错误的dist_attr。

本pr通过在调用api前保存一份正确的dist_attr以及dims，并用这些值来设置SetGradOutMeta从而修复该问题。如下图所示，其中绿色为正确操作，红色为错误操作，虚线为本pr实现的操作。

TODO: 由于此更改应应用于所有inplaced操作，影响范围较广，目前仅限制在reshape_上生效

pcard-86802


![未命名绘图1 drawio (1)](https://github.com/user-attachments/assets/4ce25fef-f140-4606-ad5e-41d076e9c3d7)




修改前的dygraph_functions.cc
``` cpp
  // Forward API Call
  auto& api_result = paddle::experimental::reshape_(x, shape);
  // Log memory information
  paddle::memory::LogDeviceMemoryStats(egr::Controller::Instance().GetExpectedPlace(), "reshape_");
  // Check NaN and Inf if needed

  if (FLAGS_check_nan_inf) {
    egr::CheckTensorHasNanOrInf("reshape_", api_result);
  }

  // Get Outputs
  auto& out = api_result;

  // Get Output AutoGradMeta
  egr::AutogradMeta* out_autograd_meta = egr::EagerUtils::autograd_meta(&out);
  // Check Inplace if needed

  egr::EagerUtils::CheckInplace(x, x_autograd_meta, require_any_grad);

  // Bump Inplace Version
  x.bump_inplace_version();
  VLOG(3) << "Tensor(" << x.name() << ") uses Inplace Strategy.";

  // Set grad_node after API call
  if (require_any_grad) {

    egr::EagerUtils::PassStopGradient(false,out_autograd_meta);

    // SetGradOutMeta & SetEdges
    grad_node->SetGradOutMeta(x, 0);
    // SetOutRank & SetHistory & SetGradInMeta
    if (out_autograd_meta) {
      egr::EagerUtils::SetOutRankWithSlot(out_autograd_meta, 0);
    }
    if (out_autograd_meta) {
      egr::EagerUtils::SetHistory(out_autograd_meta, grad_node);
    }
    grad_node->SetGradInMeta(out, 0);
    // Set TensorWrappers for Forward Outputs if needed

  }
```
修改后的dygraph_functions.cc
``` cpp
  // Forward API Call

  phi::distributed::TensorDistAttr x_dist_attr;
  phi::DDim x_dims;
  if (x.is_dist_tensor()&& x.impl()){
    auto* x_dist_tensor = static_cast<phi::distributed::DistTensor*>(x.impl().get());
    x_dist_attr = x_dist_tensor -> dist_attr();
    x_dims = x_dist_tensor->dims();
   }
  auto& api_result = paddle::experimental::reshape_(x, shape);
  // Log memory information
  paddle::memory::LogDeviceMemoryStats(egr::Controller::Instance().GetExpectedPlace(), "reshape_");
  // Check NaN and Inf if needed

  if (FLAGS_check_nan_inf) {
    egr::CheckTensorHasNanOrInf("reshape_", api_result);
  }

  // Get Outputs
  auto& out = api_result;

  // Get Output AutoGradMeta
  egr::AutogradMeta* out_autograd_meta = egr::EagerUtils::autograd_meta(&out);
  // Check Inplace if needed

  egr::EagerUtils::CheckInplace(x, x_autograd_meta, require_any_grad);

  // Bump Inplace Version
  x.bump_inplace_version();
  VLOG(3) << "Tensor(" << x.name() << ") uses Inplace Strategy.";

  // Set grad_node after API call
  if (require_any_grad) {

    egr::EagerUtils::PassStopGradient(false,out_autograd_meta);

    // SetGradOutMeta & SetEdges

    if (x.is_dist_tensor()&& x.impl()){
      grad_node->SetGradOutMeta(x, 0, x_dist_attr, x_dims);
    } else{
      grad_node->SetGradOutMeta(x, 0);
    }
    // SetOutRank & SetHistory & SetGradInMeta
    if (out_autograd_meta) {
      egr::EagerUtils::SetOutRankWithSlot(out_autograd_meta, 0);
    }
    if (out_autograd_meta) {
      egr::EagerUtils::SetHistory(out_autograd_meta, grad_node);
    }
    grad_node->SetGradInMeta(out, 0);
    // Set TensorWrappers for Forward Outputs if needed

  }
```
