### PR TITLE
Updates `paddle.cumprod`'s signatures and documentation

### DIFF
--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -4683,7 +4683,7 @@ def logcumsumexp(
 
 def cumprod(
     x: Tensor,
-    dim: int | None = None,
+    dim: int,
     dtype: DTypeLike | None = None,
     name: str | None = None,
 ) -> Tensor:
@@ -4695,7 +4695,7 @@ def cumprod(
 
     Args:
         x (Tensor): the input tensor need to be cumproded.
-        dim (int|None, optional): the dimension along which the input tensor will be accumulated. It need to be in the range of [-x.rank, x.rank),
+        dim (int): the dimension along which the input tensor will be accumulated. It need to be in the range of [-x.rank, x.rank),
                     where x.rank means the dimensions of the input tensor x and -1 means the last dimension.
         dtype (str|paddle.dtype|np.dtype, optional): The data type of the output tensor, can be bfloat16, float16, float32, float64, int32, int64,
                     complex64, complex128. If specified, the input tensor is casted to dtype before the operation is performed.
@@ -4781,7 +4781,7 @@ def cumprod(
 @inplace_apis_in_dygraph_only
 def cumprod_(
     x: Tensor,
-    dim: int | None = None,
+    dim: int,
     dtype: DTypeLike | None = None,
     name: str | None = None,
 ) -> Tensor:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Updates `paddle.cumprod`'s signatures and documentation
api 之处在文档以及功能方面都没有支持 dim=None 的用法，只是函数签名写写了默认值 None https://github.com/PaddlePaddle/Paddle/pull/35185 .默认 None 会报错，所以删了默认值应该也没关系