### PR TITLE
Replace some op_test.get_places() - part11

### DIFF
--- a/test/legacy_test/test_index_put_op.py
+++ b/test/legacy_test/test_index_put_op.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import copy
-import os
 import unittest
 
 import numpy as np
@@ -121,17 +120,9 @@ class TestIndexPutAPIBase(unittest.TestCase):
         self.accumulate = False
 
     def setPlace(self):
-        self.place = []
-        if (
-            os.environ.get('FLAGS_CI_both_cpu_and_gpu', 'False').lower()
-            in ['1', 'true', 'on']
-            or not paddle.is_compiled_with_cuda()
-        ):
-            self.place.append('cpu')
-        if self.dtype_np is np.float16:
-            self.place = []
-        if paddle.is_compiled_with_cuda():
-            self.place.append('gpu')
+        self.place = get_places(string_format=True)
+        if self.dtype_np is np.float16 and "cpu" in self.place:
+            self.place.remove("cpu")
 
     def test_dygraph_forward(self):
         paddle.disable_static()
@@ -1028,17 +1019,9 @@ class TestIndexPutAPI_ZeroSize(unittest.TestCase):
         self.index_type_pd = paddle.int64
 
     def setPlace(self):
-        self.place = []
-        if (
-            os.environ.get('FLAGS_CI_both_cpu_and_gpu', 'False').lower()
-            in ['1', 'true', 'on']
-            or not paddle.is_compiled_with_cuda()
-        ):
-            self.place.append('cpu')
-        if self.dtype_np is np.float16:
-            self.place = []
-        if paddle.is_compiled_with_cuda():
-            self.place.append('gpu')
+        self.place = get_places(string_format=True)
+        if self.dtype_np is np.float16 and "cpu" in self.place:
+            self.place.remove("cpu")
 
     def test_dygraph_forward(self):
         paddle.disable_static()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
替换test/legacy_test/test_index_put_op.py 中 places 为 op_test.get_places()
如果类型为 np.float16， 不运行 cpu 测试