### PR TITLE
[0-size Tensor No.118] Add 0-size Tensor support for paddle.linalg.triangular_solve

### DIFF
--- a/paddle/phi/kernels/cpu/triangular_solve_kernel.cc
+++ b/paddle/phi/kernels/cpu/triangular_solve_kernel.cc
@@ -32,6 +32,10 @@ void TriangularSolveKernel(const Context& dev_ctx,
                            bool transpose,
                            bool unitriangular,
                            DenseTensor* out) {
+  if (x.numel() == 0 || y.numel() == 0) {
+    dev_ctx.template Alloc<T>(out);
+    return;
+  }
   // get broadcast dim
   std::vector<int64_t> x_bst_dims_vec;
   std::vector<int64_t> y_bst_dims_vec;

--- a/paddle/phi/kernels/gpu/triangular_solve_kernel.cu
+++ b/paddle/phi/kernels/gpu/triangular_solve_kernel.cu
@@ -33,6 +33,10 @@ void TriangularSolveKernel(const Context& dev_ctx,
                            bool transpose,
                            bool unitriangular,
                            DenseTensor* out) {
+  if (x.numel() == 0 || y.numel() == 0) {
+    dev_ctx.template Alloc<T>(out);
+    return;
+  }
   // get broadcast dim
   std::vector<int64_t> x_bst_dims_vec;
   std::vector<int64_t> y_bst_dims_vec;

--- a/test/legacy_test/test_triangular_solve_op.py
+++ b/test/legacy_test/test_triangular_solve_op.py
@@ -840,5 +840,27 @@ class TestTriangularSolveOpError(unittest.TestCase):
             )
 
 
+class TestTriangularSolveOp_ZeroSize(TestTriangularSolveOp):
+    def config(self):
+        self.__class__.exist_fp64_check_grad = True
+        self.x_shape = [0, 2, 2]
+        self.y_shape = [0, 2, 1]
+        self.upper = False
+        self.transpose = False
+        self.unitriangular = False
+        self.dtype = "float32"
+
+
+class TestTriangularSolveOp_ZeroSize2(TestTriangularSolveOp_ZeroSize):
+    def config(self):
+        self.__class__.exist_fp64_check_grad = True
+        self.x_shape = [3, 3]
+        self.y_shape = [3, 0]
+        self.upper = False
+        self.transpose = False
+        self.unitriangular = False
+        self.dtype = "float32"
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修改前向和反向，反向填充为0

torch测试反向填充，结果有0和-0，paddle中-0会转为0，所以按0填充
```
import torch
x = torch.randn([3,3])
x.requires_grad = True
y = torch.randn([3,0])
result = torch.linalg.solve_triangular(x,y,upper=False,left=True,unitriangular=False)
result.sum().backward()
print(x.grad)

tensor([[-0., 0., 0.],
        [-0., -0., 0.],
        [-0., -0., -0.]])

import paddle
paddle.to_tensor(-0)
Tensor(shape=[], dtype=int64, place=Place(gpu:0), stop_gradient=True,
       0)
```
PaddleAPITest 测试通过
![image](https://github.com/user-attachments/assets/853bf44f-f66c-4178-9821-ba861b4c94b2)
