### PR TITLE
[0-size Tensor Job2 No.56] Add 0-size Tensor support for paddle.nn.functional.dice_loss

### DIFF
--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -14,9 +14,7 @@
 
 from __future__ import annotations
 
-import functools
 import math
-import operator
 from typing import TYPE_CHECKING, Literal, overload
 
 import paddle
@@ -110,10 +108,6 @@ def dice_loss(
     assert (
         input.shape[:-1] == label.shape[:-1]
     ), "All dimensions should be equal except the last one."
-    assert (
-        functools.reduce(operator.mul, input.shape) != 0
-        and functools.reduce(operator.mul, label.shape) != 0
-    ), "Any dimension of input and label cannot be equal to 0."
 
     label = paddle.squeeze(label, [-1])
     label = paddle.nn.functional.one_hot(label, input.shape[-1])

--- a/test/legacy_test/test_nn_dice_loss.py
+++ b/test/legacy_test/test_nn_dice_loss.py
@@ -14,8 +14,27 @@
 
 import unittest
 
+import numpy as np
+from op_test import get_places
+
+import paddle
+
 num_classes = 4
 eps = 1e-6
+
+
+class TestDiceLossOpApi_ZeroSize(unittest.TestCase):
+    def test_api_with_dygraph(self):
+        for place in get_places():
+            paddle.disable_static(place)
+            input = paddle.randn([0, 2]).astype(paddle.float64)
+            input.stop_gradient = False
+            label = paddle.randn([0, 1]).astype(paddle.int64)
+            label.stop_gradient = False
+            out = paddle.nn.functional.dice_loss(input, label, 1e-5)
+            np.testing.assert_allclose(out.numpy(), paddle.nan)
+            out.sum().backward()
+            np.testing.assert_allclose(input.grad.shape, input.shape)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
取消python中输入维度为0的检查

增加单测

PaddleAPITest  中是自定义代码
https://github.com/PFCCLab/PaddleAPITest/blob/0537bad919ab82281a1f945b895882233314d361/tester/paddle_to_torch/rules.py#L1416
![image](https://github.com/user-attachments/assets/029469d7-3237-4d2f-acd4-bb94693e9406)

使用 PaddleAPITest 测试输出为NAN
![image](https://github.com/user-attachments/assets/4894e27e-2ea2-41fc-ba83-7fca717dd950)

PaddleAPITest  测试通过，错误为torch error，numpy error
![image](https://github.com/user-attachments/assets/63d5f541-6c29-48b0-9f74-af0c2a2b6458)
