### PR TITLE
[Typing] Simplify `PlaceLike` impl

### DIFF
--- a/python/paddle/_typing/device_like.py
+++ b/python/paddle/_typing/device_like.py
@@ -18,27 +18,9 @@ from typing import TYPE_CHECKING, Union
 from typing_extensions import TypeAlias
 
 if TYPE_CHECKING:
-    from paddle import (
-        CPUPlace,
-        CUDAPinnedPlace,
-        CUDAPlace,
-        CustomPlace,
-        IPUPlace,
-        XPUPinnedPlace,
-        XPUPlace,
-    )
-
-_Place: TypeAlias = Union[
-    "CPUPlace",
-    "CUDAPlace",
-    "CUDAPinnedPlace",
-    "XPUPinnedPlace",
-    "IPUPlace",
-    "CustomPlace",
-    "XPUPlace",
-]
+    from paddle.base.core import Place
 
 PlaceLike: TypeAlias = Union[
-    _Place,
+    "Place",
     str,  # some string like "cpu", "gpu:0", etc.
 ]


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

#73532 已经使 `CPUPlace` 等继承自 `Place`，因此不再需要单独维护 `_Place` 了，直接使用 `Place` 即可

<!-- PCard-66972 -->