### PR TITLE
[Slice]Fix empty index bug

### DIFF
--- a/paddle/fluid/pybind/eager_method.cc
+++ b/paddle/fluid/pybind/eager_method.cc
@@ -2112,44 +2112,47 @@ static PyObject* tensor__setitem_dygraph(TensorObject* self,
         if (transed_sub_tensor.is_gpu()) {
           transed_index = expandTensors(transed_index);
           transed_index = expand_outplace(transed_index);
-          for (int i = 0; i < pos_of_new_dim; ++i) {
-            transed_index.insert(
-                transed_index.begin(),
-                empty_ad_func(
-                    {}, transed_index[0].dtype(), transed_index[0].place()));
-          }
-          while (transed_index.size() <
-                 static_cast<size_t>(transed_sub_tensor.dims().size())) {
-            transed_index.emplace_back(empty_ad_func(
-                {}, transed_index[0].dtype(), transed_index[0].place()));
-          }
-          int64_t slice_offset =
-              static_cast<int64_t>(reinterpret_cast<char*>(sub_tensor.data()) -
-                                   reinterpret_cast<char*>(tensor.data()));
-
-          std::vector<paddle::Tensor> transed_index_int64;
-          for (auto& indice : transed_index) {
-            if (indice.defined() && indice.dtype() == paddle::DataType::INT32) {
-              indice = indice.cast(paddle::DataType::INT64);  // int32 -> int64
+          if (!transed_index.empty()) {
+            for (int i = 0; i < pos_of_new_dim; ++i) {
+              transed_index.insert(
+                  transed_index.begin(),
+                  empty_ad_func(
+                      {}, transed_index[0].dtype(), transed_index[0].place()));
             }
-            transed_index_int64.push_back(indice);
-          }
+            while (transed_index.size() <
+                   static_cast<size_t>(transed_sub_tensor.dims().size())) {
+              transed_index.emplace_back(empty_ad_func(
+                  {}, transed_index[0].dtype(), transed_index[0].place()));
+            }
+            int64_t slice_offset = static_cast<int64_t>(
+                reinterpret_cast<char*>(sub_tensor.data()) -
+                reinterpret_cast<char*>(tensor.data()));
 
-          AdvancedIndex ad =
-              AdvancedIndex(transed_sub_tensor, transed_index_int64);
-          transed_sub_tensor =
-              index_elementwise_put__ad_func(tensor,
-                                             ad.indices,
-                                             value_tensor,
-                                             ad.src_sizes,
-                                             ad.src_strides,
-                                             ad.indexed_sizes,
-                                             ad.indexed_strides,
-                                             slice_offset);
+            std::vector<paddle::Tensor> transed_index_int64;
+            for (auto& indice : transed_index) {
+              if (indice.defined() &&
+                  indice.dtype() == paddle::DataType::INT32) {
+                indice =
+                    indice.cast(paddle::DataType::INT64);  // int32 -> int64
+              }
+              transed_index_int64.push_back(indice);
+            }
+
+            AdvancedIndex ad =
+                AdvancedIndex(transed_sub_tensor, transed_index_int64);
+            transed_sub_tensor =
+                index_elementwise_put__ad_func(tensor,
+                                               ad.indices,
+                                               value_tensor,
+                                               ad.src_sizes,
+                                               ad.src_strides,
+                                               ad.indexed_sizes,
+                                               ad.indexed_strides,
+                                               slice_offset);
+          }
           // New kernel does not need to transpose back, so set out_is_view to
           // false. Remove when all cases use this branch.
           out_is_view = false;
-
         } else {
           transed_sub_tensor = index_put__ad_func(
               transed_sub_tensor, transed_index, value_tensor);

--- a/paddle/fluid/pybind/eager_method.cc
+++ b/paddle/fluid/pybind/eager_method.cc
@@ -1660,16 +1660,12 @@ static PyObject* tensor__getitem_dygraph(TensorObject* self,
       transed_index = expand_outplace(transed_index);
 
       for (int i = 0; i < pos_of_new_dim; ++i) {
-        transed_index.insert(
-            transed_index.begin(),
-            empty_ad_func(
-                {}, transed_index[0].dtype(), transed_index[0].place()));
+        transed_index.insert(transed_index.begin(), paddle::Tensor());
       }
 
       while (transed_index.size() <
              static_cast<size_t>(transed_tensor.dims().size())) {
-        transed_index.emplace_back(empty_ad_func(
-            {}, transed_index[0].dtype(), transed_index[0].place()));
+        transed_index.emplace_back(paddle::Tensor());
       }
 
       int64_t slice_offset =
@@ -2112,44 +2108,45 @@ static PyObject* tensor__setitem_dygraph(TensorObject* self,
         if (transed_sub_tensor.is_gpu()) {
           transed_index = expandTensors(transed_index);
           transed_index = expand_outplace(transed_index);
-          if (!transed_index.empty()) {
-            for (int i = 0; i < pos_of_new_dim; ++i) {
-              transed_index.insert(
-                  transed_index.begin(),
-                  empty_ad_func(
-                      {}, transed_index[0].dtype(), transed_index[0].place()));
-            }
-            while (transed_index.size() <
-                   static_cast<size_t>(transed_sub_tensor.dims().size())) {
-              transed_index.emplace_back(empty_ad_func(
-                  {}, transed_index[0].dtype(), transed_index[0].place()));
-            }
-            int64_t slice_offset = static_cast<int64_t>(
-                reinterpret_cast<char*>(sub_tensor.data()) -
-                reinterpret_cast<char*>(tensor.data()));
-
-            std::vector<paddle::Tensor> transed_index_int64;
-            for (auto& indice : transed_index) {
-              if (indice.defined() &&
-                  indice.dtype() == paddle::DataType::INT32) {
-                indice =
-                    indice.cast(paddle::DataType::INT64);  // int32 -> int64
-              }
-              transed_index_int64.push_back(indice);
-            }
-
-            AdvancedIndex ad =
-                AdvancedIndex(transed_sub_tensor, transed_index_int64);
-            transed_sub_tensor =
-                index_elementwise_put__ad_func(tensor,
-                                               ad.indices,
-                                               value_tensor,
-                                               ad.src_sizes,
-                                               ad.src_strides,
-                                               ad.indexed_sizes,
-                                               ad.indexed_strides,
-                                               slice_offset);
+          for (int i = 0; i < pos_of_new_dim; ++i) {
+            transed_index.insert(transed_index.begin(), paddle::Tensor());
           }
+          while (transed_index.size() <
+                 static_cast<size_t>(transed_sub_tensor.dims().size())) {
+            transed_index.emplace_back(paddle::Tensor());
+          }
+          int64_t slice_offset =
+              static_cast<int64_t>(reinterpret_cast<char*>(sub_tensor.data()) -
+                                   reinterpret_cast<char*>(tensor.data()));
+
+          std::vector<paddle::Tensor> transed_index_int64;
+          for (auto& indice : transed_index) {
+            if (indice.defined() && indice.dtype() == paddle::DataType::INT32) {
+              indice = indice.cast(paddle::DataType::INT64);  // int32 -> int64
+            }
+            transed_index_int64.push_back(indice);
+          }
+
+          AdvancedIndex ad =
+              AdvancedIndex(transed_sub_tensor, transed_index_int64);
+          PADDLE_ENFORCE_EQ(
+              phi::funcs::CheckIsDimsMatchBool(common::make_ddim(ad.src_sizes),
+                                               value_tensor.dims()),
+              true,
+              common::errors::InvalidArgument(
+                  "shape mismatch: value tensor of shape %s cannot be "
+                  "broadcast to indexing result of shape %s.",
+                  value_tensor.dims().to_str(),
+                  common::make_ddim(ad.src_sizes).to_str()));
+          transed_sub_tensor =
+              index_elementwise_put__ad_func(tensor,
+                                             ad.indices,
+                                             value_tensor,
+                                             ad.src_sizes,
+                                             ad.src_strides,
+                                             ad.indexed_sizes,
+                                             ad.indexed_strides,
+                                             slice_offset);
           // New kernel does not need to transpose back, so set out_is_view to
           // false. Remove when all cases use this branch.
           out_is_view = false;

--- a/paddle/fluid/pybind/slice_utils.h
+++ b/paddle/fluid/pybind/slice_utils.h
@@ -79,6 +79,9 @@ static inline std::vector<paddle::Tensor> expandTensors(
   for (auto& index : indices) {
     if (index.dtype() == paddle::DataType::BOOL) {
       auto bool_2_idx = nonzero_ad_func(index);
+      if (bool_2_idx.numel() == 0) {
+        return result;
+      }
       for (int j = 0; j < index.dims().size(); j++) {
         paddle::Tensor sliced_tensor =
             slice_ad_func(bool_2_idx, {1}, {j}, {j + 1}, {1}, {1});

--- a/paddle/fluid/pybind/slice_utils.h
+++ b/paddle/fluid/pybind/slice_utils.h
@@ -100,7 +100,7 @@ static inline std::vector<paddle::Tensor> expand_outplace(
   bool first = true;
   common::DDim sizes;
   for (size_t i = 0; i < to_expand.size(); i++) {
-    if (!to_expand[i].initialized()) {
+    if (!to_expand[i].defined()) {
       continue;
     } else if (first) {
       sizes = to_expand[i].dims();
@@ -112,7 +112,7 @@ static inline std::vector<paddle::Tensor> expand_outplace(
 
   std::vector<paddle::Tensor> result(to_expand.size());
   for (size_t i = 0; i < to_expand.size(); i++) {
-    if (!to_expand[i].initialized()) {
+    if (!to_expand[i].defined()) {
       continue;
     } else if (to_expand[i].dims() == sizes) {
       result[i] = to_expand[i];
@@ -176,7 +176,7 @@ inline AdvancedIndex::AdvancedIndex(paddle::Tensor src,
   std::vector<int64_t> idx_stride_vec = {};
 
   for (size_t dim = 0; dim < indices_list.size(); dim++) {
-    if (!indices_list[dim].defined() || indices_list[dim].dims().size() == 0) {
+    if (!indices_list[dim].defined()) {
       if (dims_indexed == 0) {
         dims_before++;
       } else {
@@ -203,7 +203,7 @@ inline AdvancedIndex::AdvancedIndex(paddle::Tensor src,
 
   // use dims_before and dims_after / move to cuda kernel
   for (auto& index : indices_list) {
-    if (index.defined() && index.dims().size() > 0) {
+    if (index.defined()) {
       this->indices.push_back(reshape_indexer(&index, dims_before, dims_after));
     }
   }

--- a/paddle/fluid/pybind/slice_utils.h
+++ b/paddle/fluid/pybind/slice_utils.h
@@ -79,9 +79,6 @@ static inline std::vector<paddle::Tensor> expandTensors(
   for (auto& index : indices) {
     if (index.dtype() == paddle::DataType::BOOL) {
       auto bool_2_idx = nonzero_ad_func(index);
-      if (bool_2_idx.numel() == 0) {
-        return result;
-      }
       for (int j = 0; j < index.dims().size(); j++) {
         paddle::Tensor sliced_tensor =
             slice_ad_func(bool_2_idx, {1}, {j}, {j + 1}, {1}, {1});


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-67164
Fix empty index bug and add value-index dims check：
1. 当transed_index为空时，无法正常获取dtype和place信息，因此使用空tensor代替empty_ad_func，作为非高阶索引维度的占位符。
2. 加入对value_tensor和赋值区域shape的dims拦截检查。
3. 修复对bool索引中全false情况的处理。该情况下transed_index是0-size tensor，numel==0 但是defined值为true，与占位符的空tensor不一样，在advanced index计算赋值区域时应该被识别。在之前的逻辑中，对全false索引的赋值tensor shape可以为任意值；修复后对全false index赋值也需要shape匹配才可以，否则会被拦截。