### PR TITLE
[PHI]Add CPU support for index_elementwise kernel

### DIFF
--- a/paddle/fluid/pybind/eager_method.cc
+++ b/paddle/fluid/pybind/eager_method.cc
@@ -1647,7 +1647,7 @@ static PyObject* tensor__getitem_dygraph(TensorObject* self,
       }
     }
 
-    if (!is_combined_bool && !has_empty_index) {
+    if (FLAGS_use_stride_kernel && !is_combined_bool && !has_empty_index) {
       const phi::distributed::ProcessMesh* mesh = nullptr;
       if (InputsContainDistTensor(
               &mesh, self->tensor, transed_tensor, transed_index)) {
@@ -2057,6 +2057,12 @@ static PyObject* tensor__setitem_dygraph(TensorObject* self,
         }
       }
 
+      if (value_tensor.dims().size() > 1 && pos_of_new_dim != 0) {
+        if (!FLAGS_use_stride_kernel) {
+          value_tensor = transpose_ad_func(value_tensor, trans_dim);
+        }
+      }
+
       const phi::distributed::ProcessMesh* mesh = nullptr;
       if (InputsContainDistTensor(
               &mesh, self->tensor, transed_sub_tensor, value_tensor)) {
@@ -2070,49 +2076,55 @@ static PyObject* tensor__setitem_dygraph(TensorObject* self,
         transed_sub_tensor =
             masked_fill__ad_func(transed_sub_tensor, mask_tensor, value_tensor);
       } else {
-        transed_index = expandTensors(transed_index);
-        transed_index = expand_outplace(transed_index);
-        for (int i = 0; i < pos_of_new_dim; ++i) {
-          transed_index.insert(transed_index.begin(), paddle::Tensor());
-        }
-        while (transed_index.size() <
-               static_cast<size_t>(transed_sub_tensor.dims().size())) {
-          transed_index.emplace_back(paddle::Tensor());
-        }
-        int64_t slice_offset =
-            static_cast<int64_t>(reinterpret_cast<char*>(sub_tensor.data()) -
-                                 reinterpret_cast<char*>(tensor.data()));
-
-        std::vector<paddle::Tensor> transed_index_int64;
-        for (auto& indice : transed_index) {
-          if (indice.defined() && indice.dtype() == paddle::DataType::INT32) {
-            indice = indice.cast(paddle::DataType::INT64);  // int32 -> int64
+        if (FLAGS_use_stride_kernel) {
+          transed_index = expandTensors(transed_index);
+          transed_index = expand_outplace(transed_index);
+          for (int i = 0; i < pos_of_new_dim; ++i) {
+            transed_index.insert(transed_index.begin(), paddle::Tensor());
           }
-          transed_index_int64.push_back(indice);
-        }
+          while (transed_index.size() <
+                 static_cast<size_t>(transed_sub_tensor.dims().size())) {
+            transed_index.emplace_back(paddle::Tensor());
+          }
+          int64_t slice_offset =
+              static_cast<int64_t>(reinterpret_cast<char*>(sub_tensor.data()) -
+                                   reinterpret_cast<char*>(tensor.data()));
 
-        AdvancedIndex ad =
-            AdvancedIndex(transed_sub_tensor, transed_index_int64);
-        PADDLE_ENFORCE_EQ(
-            phi::funcs::CheckIsDimsMatchBool(common::make_ddim(ad.src_sizes),
-                                             value_tensor.dims()),
-            true,
-            common::errors::InvalidArgument(
-                "shape mismatch: value tensor of shape %s cannot be "
-                "broadcast to indexing result of shape %s.",
-                value_tensor.dims().to_str(),
-                common::make_ddim(ad.src_sizes).to_str()));
-        transed_sub_tensor = index_elementwise_put__ad_func(tensor,
-                                                            ad.indices,
-                                                            value_tensor,
-                                                            ad.src_sizes,
-                                                            ad.src_strides,
-                                                            ad.indexed_sizes,
-                                                            ad.indexed_strides,
-                                                            slice_offset);
-        // New kernel does not need to transpose back, so set out_is_view to
-        // false. Remove when all cases use this branch.
-        out_is_view = false;
+          std::vector<paddle::Tensor> transed_index_int64;
+          for (auto& indice : transed_index) {
+            if (indice.defined() && indice.dtype() == paddle::DataType::INT32) {
+              indice = indice.cast(paddle::DataType::INT64);  // int32 -> int64
+            }
+            transed_index_int64.push_back(indice);
+          }
+
+          AdvancedIndex ad =
+              AdvancedIndex(transed_sub_tensor, transed_index_int64);
+          PADDLE_ENFORCE_EQ(
+              phi::funcs::CheckIsDimsMatchBool(common::make_ddim(ad.src_sizes),
+                                               value_tensor.dims()),
+              true,
+              common::errors::InvalidArgument(
+                  "shape mismatch: value tensor of shape %s cannot be "
+                  "broadcast to indexing result of shape %s.",
+                  value_tensor.dims().to_str(),
+                  common::make_ddim(ad.src_sizes).to_str()));
+          transed_sub_tensor =
+              index_elementwise_put__ad_func(tensor,
+                                             ad.indices,
+                                             value_tensor,
+                                             ad.src_sizes,
+                                             ad.src_strides,
+                                             ad.indexed_sizes,
+                                             ad.indexed_strides,
+                                             slice_offset);
+          // New kernel does not need to transpose back, so set out_is_view to
+          // false. Remove when all cases use this branch.
+          out_is_view = false;
+        } else {
+          transed_sub_tensor = index_put__ad_func(
+              transed_sub_tensor, transed_index, value_tensor);
+        }
       }
       if (out_is_view) {
         // NOTE(zoooo0820): if out_is_view is true, it is a case of

--- a/paddle/fluid/pybind/eager_method.cc
+++ b/paddle/fluid/pybind/eager_method.cc
@@ -2073,15 +2073,11 @@ static PyObject* tensor__setitem_dygraph(TensorObject* self,
         transed_index = expandTensors(transed_index);
         transed_index = expand_outplace(transed_index);
         for (int i = 0; i < pos_of_new_dim; ++i) {
-          transed_index.insert(
-              transed_index.begin(),
-              empty_ad_func(
-                  {}, transed_index[0].dtype(), transed_index[0].place()));
+          transed_index.insert(transed_index.begin(), paddle::Tensor());
         }
         while (transed_index.size() <
                static_cast<size_t>(transed_sub_tensor.dims().size())) {
-          transed_index.emplace_back(empty_ad_func(
-              {}, transed_index[0].dtype(), transed_index[0].place()));
+          transed_index.emplace_back(paddle::Tensor());
         }
         int64_t slice_offset =
             static_cast<int64_t>(reinterpret_cast<char*>(sub_tensor.data()) -
@@ -2097,6 +2093,15 @@ static PyObject* tensor__setitem_dygraph(TensorObject* self,
 
         AdvancedIndex ad =
             AdvancedIndex(transed_sub_tensor, transed_index_int64);
+        PADDLE_ENFORCE_EQ(
+            phi::funcs::CheckIsDimsMatchBool(common::make_ddim(ad.src_sizes),
+                                             value_tensor.dims()),
+            true,
+            common::errors::InvalidArgument(
+                "shape mismatch: value tensor of shape %s cannot be "
+                "broadcast to indexing result of shape %s.",
+                value_tensor.dims().to_str(),
+                common::make_ddim(ad.src_sizes).to_str()));
         transed_sub_tensor = index_elementwise_put__ad_func(tensor,
                                                             ad.indices,
                                                             value_tensor,

--- a/paddle/fluid/pybind/eager_method.cc
+++ b/paddle/fluid/pybind/eager_method.cc
@@ -2059,16 +2059,6 @@ static PyObject* tensor__setitem_dygraph(TensorObject* self,
         }
       }
 
-      if (value_tensor.dims().size() > 1 && pos_of_new_dim != 0) {
-#ifdef PADDLE_WITH_CUDA
-        if (!value_tensor.is_gpu()) {
-          value_tensor = transpose_ad_func(value_tensor, trans_dim);
-        }
-#else
-        value_tensor = transpose_ad_func(value_tensor, trans_dim);
-#endif
-      }
-
       const phi::distributed::ProcessMesh* mesh = nullptr;
       if (InputsContainDistTensor(
               &mesh, self->tensor, transed_sub_tensor, value_tensor)) {
@@ -2083,51 +2073,44 @@ static PyObject* tensor__setitem_dygraph(TensorObject* self,
             masked_fill__ad_func(transed_sub_tensor, mask_tensor, value_tensor);
       } else {
         // TODO(czy): remove in the future
-        if (transed_sub_tensor.is_gpu()) {
-          transed_index = expandTensors(transed_index);
-          transed_index = expand_outplace(transed_index);
-          for (int i = 0; i < pos_of_new_dim; ++i) {
-            transed_index.insert(
-                transed_index.begin(),
-                empty_ad_func(
-                    {}, transed_index[0].dtype(), transed_index[0].place()));
-          }
-          while (transed_index.size() <
-                 static_cast<size_t>(transed_sub_tensor.dims().size())) {
-            transed_index.emplace_back(empty_ad_func(
-                {}, transed_index[0].dtype(), transed_index[0].place()));
-          }
-          int64_t slice_offset =
-              static_cast<int64_t>(reinterpret_cast<char*>(sub_tensor.data()) -
-                                   reinterpret_cast<char*>(tensor.data()));
-
-          std::vector<paddle::Tensor> transed_index_int64;
-          for (auto& indice : transed_index) {
-            if (indice.defined() && indice.dtype() == paddle::DataType::INT32) {
-              indice = indice.cast(paddle::DataType::INT64);  // int32 -> int64
-            }
-            transed_index_int64.push_back(indice);
-          }
-
-          AdvancedIndex ad =
-              AdvancedIndex(transed_sub_tensor, transed_index_int64);
-          transed_sub_tensor =
-              index_elementwise_put__ad_func(tensor,
-                                             ad.indices,
-                                             value_tensor,
-                                             ad.src_sizes,
-                                             ad.src_strides,
-                                             ad.indexed_sizes,
-                                             ad.indexed_strides,
-                                             slice_offset);
-          // New kernel does not need to transpose back, so set out_is_view to
-          // false. Remove when all cases use this branch.
-          out_is_view = false;
-
-        } else {
-          transed_sub_tensor = index_put__ad_func(
-              transed_sub_tensor, transed_index, value_tensor);
+        transed_index = expandTensors(transed_index);
+        transed_index = expand_outplace(transed_index);
+        for (int i = 0; i < pos_of_new_dim; ++i) {
+          transed_index.insert(
+              transed_index.begin(),
+              empty_ad_func(
+                  {}, transed_index[0].dtype(), transed_index[0].place()));
         }
+        while (transed_index.size() <
+               static_cast<size_t>(transed_sub_tensor.dims().size())) {
+          transed_index.emplace_back(empty_ad_func(
+              {}, transed_index[0].dtype(), transed_index[0].place()));
+        }
+        int64_t slice_offset =
+            static_cast<int64_t>(reinterpret_cast<char*>(sub_tensor.data()) -
+                                 reinterpret_cast<char*>(tensor.data()));
+
+        std::vector<paddle::Tensor> transed_index_int64;
+        for (auto& indice : transed_index) {
+          if (indice.defined() && indice.dtype() == paddle::DataType::INT32) {
+            indice = indice.cast(paddle::DataType::INT64);  // int32 -> int64
+          }
+          transed_index_int64.push_back(indice);
+        }
+
+        AdvancedIndex ad =
+            AdvancedIndex(transed_sub_tensor, transed_index_int64);
+        transed_sub_tensor = index_elementwise_put__ad_func(tensor,
+                                                            ad.indices,
+                                                            value_tensor,
+                                                            ad.src_sizes,
+                                                            ad.src_strides,
+                                                            ad.indexed_sizes,
+                                                            ad.indexed_strides,
+                                                            slice_offset);
+        // New kernel does not need to transpose back, so set out_is_view to
+        // false. Remove when all cases use this branch.
+        out_is_view = false;
       }
       if (out_is_view) {
         // NOTE(zoooo0820): if out_is_view is true, it is a case of

--- a/paddle/fluid/pybind/eager_method.cc
+++ b/paddle/fluid/pybind/eager_method.cc
@@ -1639,8 +1639,6 @@ static PyObject* tensor__getitem_dygraph(TensorObject* self,
   } else {
     // get value for int tensor
     ParseBoolAndBroadcastIndices(&transed_index);
-
-#ifdef PADDLE_WITH_CUDA
     bool has_empty_index = false;
     for (const auto& tensor : transed_index) {
       if (!tensor.initialized()) {
@@ -1715,27 +1713,6 @@ static PyObject* tensor__getitem_dygraph(TensorObject* self,
       handle_transpose(out);
       return ToPyObject(out);
     }
-#else
-    paddle::Tensor transed_advanced_index_tensor;
-    if (transed_index.size() > 1) {
-      transed_advanced_index_tensor = stack_ad_func(transed_index, -1);
-    } else {
-      // fast path for single index tensor, since stack is much slower than
-      // unsqueeze
-      transed_advanced_index_tensor = unsqueeze_ad_func(transed_index[0], {-1});
-    }
-
-    const phi::distributed::ProcessMesh* mesh = nullptr;
-    if (InputsContainDistTensor(
-            &mesh, transed_tensor, transed_advanced_index_tensor)) {
-      ConvertAllInputsToDistTensor(
-          mesh, transed_tensor, transed_advanced_index_tensor);
-    }
-
-    out = gather_nd_ad_func(transed_tensor, transed_advanced_index_tensor);
-    handle_transpose(out);
-    return ToPyObject(out);
-#endif
   }
 
   handle_transpose(out);
@@ -2105,7 +2082,6 @@ static PyObject* tensor__setitem_dygraph(TensorObject* self,
         transed_sub_tensor =
             masked_fill__ad_func(transed_sub_tensor, mask_tensor, value_tensor);
       } else {
-#ifdef PADDLE_WITH_CUDA
         // TODO(czy): remove in the future
         if (transed_sub_tensor.is_gpu()) {
           transed_index = expandTensors(transed_index);
@@ -2152,10 +2128,6 @@ static PyObject* tensor__setitem_dygraph(TensorObject* self,
           transed_sub_tensor = index_put__ad_func(
               transed_sub_tensor, transed_index, value_tensor);
         }
-#else
-        transed_sub_tensor =
-            index_put__ad_func(transed_sub_tensor, transed_index, value_tensor);
-#endif
       }
       if (out_is_view) {
         // NOTE(zoooo0820): if out_is_view is true, it is a case of

--- a/paddle/fluid/pybind/eager_method.cc
+++ b/paddle/fluid/pybind/eager_method.cc
@@ -1647,7 +1647,7 @@ static PyObject* tensor__getitem_dygraph(TensorObject* self,
       }
     }
 
-    if (transed_tensor.is_gpu() && !is_combined_bool && !has_empty_index) {
+    if (!is_combined_bool && !has_empty_index) {
       const phi::distributed::ProcessMesh* mesh = nullptr;
       if (InputsContainDistTensor(&mesh, transed_tensor, transed_index)) {
         ConvertAllInputsToDistTensor(mesh, transed_tensor, transed_index);
@@ -2072,7 +2072,6 @@ static PyObject* tensor__setitem_dygraph(TensorObject* self,
         transed_sub_tensor =
             masked_fill__ad_func(transed_sub_tensor, mask_tensor, value_tensor);
       } else {
-        // TODO(czy): remove in the future
         transed_index = expandTensors(transed_index);
         transed_index = expand_outplace(transed_index);
         for (int i = 0; i < pos_of_new_dim; ++i) {

--- a/paddle/fluid/pybind/slice_utils.h
+++ b/paddle/fluid/pybind/slice_utils.h
@@ -657,7 +657,8 @@ static paddle::Tensor dealWithAdvancedIndex(
     transed_tensor = tensor;
   } else {
     *out_is_view = true;
-    if (*pos_of_new_dim != 0 && (is_for_setitem || int_tensor_only)) {
+    if (FLAGS_use_stride_kernel && *pos_of_new_dim != 0 &&
+        (is_for_setitem || int_tensor_only)) {
       transed_tensor = tensor;
     } else {
       transed_tensor = transpose_ad_func(tensor, *trans_dim);

--- a/paddle/fluid/pybind/slice_utils.h
+++ b/paddle/fluid/pybind/slice_utils.h
@@ -657,17 +657,11 @@ static paddle::Tensor dealWithAdvancedIndex(
     transed_tensor = tensor;
   } else {
     *out_is_view = true;
-#ifdef PADDLE_WITH_CUDA
-    // Remove the conditions when all cases are supported.
-    if (tensor.is_gpu() && *pos_of_new_dim != 0 &&
-        (is_for_setitem || int_tensor_only)) {
+    if (*pos_of_new_dim != 0 && (is_for_setitem || int_tensor_only)) {
       transed_tensor = tensor;
     } else {
       transed_tensor = transpose_ad_func(tensor, *trans_dim);
     }
-#else
-    transed_tensor = transpose_ad_func(tensor, *trans_dim);
-#endif
   }
 
   if (is_for_setitem) {

--- a/paddle/phi/kernels/cpu/index_elementwise_get_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_elementwise_get_grad_kernel.cc
@@ -1,0 +1,193 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/phi/kernels/index_elementwise_get_grad_kernel.h"
+
+#include "paddle/phi/backends/gpu/gpu_context.h"
+#include "paddle/phi/backends/gpu/gpu_primitives.h"
+#include "paddle/phi/common/bfloat16.h"
+#include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/funcs/eigen/common.h"
+#include "paddle/phi/kernels/funcs/index_elementwise.cu.h"
+#include "paddle/phi/kernels/funcs/stride_utils.h"
+
+namespace phi {
+template <typename T, typename IndexT, int nt, int vt, typename offset_calc_t>
+void IndexEleGetGradAccKernel(
+    int64_t N,
+    const char* in_ptr,
+    char* out_ptr,
+    const std::array<char*, DDim::kMaxRank> index_ptrs,
+    const std::array<int64_t, 25> sizes,
+    const std::array<int64_t, 25> strides,
+    int num_indices,
+    offset_calc_t offset_calc) {
+  for (int64_t idx = 0; idx < N; idx++) {
+    const auto offsets = offset_calc.cpu_get(idx);
+    char* const out_data = out_ptr + offsets[0];
+    const char* const in_data = in_ptr + offsets[1];
+
+    int64_t offset = 0;
+#pragma unroll
+    for (int i = 0; i < num_indices; i++) {
+      int64_t index = *reinterpret_cast<int64_t*>(index_ptrs[i] + offsets[2]);
+      if (index < 0) index += sizes[i];
+      offset += index * strides[i];
+    }
+
+    reinterpret_cast<T*>(out_data + offset) +=
+        *reinterpret_cast<const T*>(in_data);
+  }
+}
+
+template <typename T, typename IndexT = int>
+void CPUIndexElementwiseGetGrad(const phi::GPUContext& ctx,
+                                const DenseTensor& input,
+                                const DenseTensor& value,
+                                const std::vector<const DenseTensor*>& index,
+                                const std::vector<int64_t>& input_dims,
+                                const std::vector<int64_t>& input_strides,
+                                const std::vector<int64_t>& index_dims,
+                                const std::vector<int64_t>& index_strides,
+                                const int64_t slice_offset,
+                                const bool accumulate,
+                                DenseTensor* output) {
+  int64_t numel = 0;
+
+  auto num_indices = index_dims.size();
+
+  auto sizes = std::array<int64_t, 25>{};
+  auto strides = std::array<int64_t, 25>{};
+  for (unsigned i = 0; i < num_indices; i++) {
+    sizes[i] = index_dims[i];
+    strides[i] = index_strides[i];
+  }
+  auto index_ptrs = funcs::GetIndexDataPtrs<IndexT>(index);
+
+  std::array<int64_t*, 3> strides_array;
+  std::vector<int64_t> desired_shape;
+  std::array<std::vector<int64_t>, 3> strides_vec;
+
+  funcs::IndexPutStride<3>(input_dims,
+                           input_strides,
+                           phi::SizeOf(input.dtype()),
+                           std::vector<int64_t>(),
+                           std::vector<int64_t>(),
+                           phi::SizeOf(value.dtype()),
+                           common::vectorize<int64_t>(index[0]->dims()),
+                           common::vectorize<int64_t>(index[0]->strides()),
+                           phi::SizeOf(index[0]->dtype()),
+                           &desired_shape,
+                           &strides_array,
+                           &numel,
+                           strides_vec);
+  auto offset_calc =
+      funcs::make_offset_calculator_put<3>(desired_shape, strides_array);
+
+  const int64_t N = numel;
+
+  using dtype = funcs::OpaqueType<sizeof(T)>;
+
+  const char* in_ptr = reinterpret_cast<const char*>(value.data<T>());
+  char* out_ptr = reinterpret_cast<char*>(output->data<T>()) + slice_offset;
+
+  if (accumulate) {
+    IndexEleGetGradAccKernel<T, IndexT, nt, vt>
+        <<<grid, block, 0, stream>>>(N,
+                                     in_ptr,
+                                     out_ptr,
+                                     index_ptrs,
+                                     sizes,
+                                     strides,
+                                     num_indices,
+                                     offset_calc);
+  } else {
+    for (int64_t idx = 0; idx < N; i++) {
+      const auto offsets = offset_calc.cpu_get(idx);
+      char* const out_data = out_ptr + offsets[0];
+      const char* const in_data = in_ptr + offsets[1];
+
+      int64_t offset = 0;
+#pragma unroll
+      for (int i = 0; i < num_indices; i++) {
+        int64_t index = *reinterpret_cast<int64_t*>(index_ptrs[i] + offsets[2]);
+        if (index < 0) {
+          index += sizes[i];
+        }
+        offset += index * strides[i];
+      }
+      *reinterpret_cast<dtype*>(out_data + offset) =
+          *reinterpret_cast<const dtype*>(in_data);
+    }
+  }
+}
+
+template <typename T, typename Context>
+void IndexElementwiseGetGradKernel(const Context& ctx,
+                                   const DenseTensor& x,
+                                   const std::vector<const DenseTensor*>& index,
+                                   const DenseTensor& out_grad,
+                                   const std::vector<int64_t>& input_dims,
+                                   const std::vector<int64_t>& input_strides,
+                                   const std::vector<int64_t>& index_dims,
+                                   const std::vector<int64_t>& index_strides,
+                                   const int64_t slice_offset,
+                                   const bool accumulate,
+                                   DenseTensor* x_grad) {
+  ctx.template Alloc<T>(x_grad);
+  auto dxt = phi::EigenVector<T>::Flatten(*x_grad);
+  auto& place = *ctx.eigen_device();
+  dxt.device(place) = dxt.constant(static_cast<T>(0));
+  if (out_grad.numel() == 0) return;
+
+  const auto& index_type = index[0]->dtype();
+  PADDLE_ENFORCE_EQ(index_type == phi::DataType::INT64,
+                    true,
+                    common::errors::InvalidArgument(
+                        "Index holds the wrong type, it holds [%s], but "
+                        "desires to be [%s].",
+                        index_type,
+                        phi::DataType::INT32,
+                        phi::DataType::INT64));
+
+  CPUIndexElementwiseGetGrad<T, int64_t>(ctx,
+                                         x,
+                                         out_grad,
+                                         index,
+                                         input_dims,
+                                         input_strides,
+                                         index_dims,
+                                         index_strides,
+                                         slice_offset,
+                                         accumulate,
+                                         x_grad);
+}
+
+}  // namespace phi
+PD_REGISTER_KERNEL(index_elementwise_get_grad,
+                   CPU,
+                   ALL_LAYOUT,
+                   phi::IndexElementwiseGetGradKernel,
+                   bool,
+                   float,
+                   double,
+                   int,
+                   int8_t,
+                   int64_t,
+                   int16_t,
+                   uint8_t,
+                   phi::dtype::float16,
+                   phi::dtype::bfloat16,
+                   phi::dtype::complex<float>,
+                   phi::dtype::complex<double>) {}

--- a/paddle/phi/kernels/cpu/index_elementwise_get_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_elementwise_get_grad_kernel.cc
@@ -14,16 +14,14 @@
 
 #include "paddle/phi/kernels/index_elementwise_get_grad_kernel.h"
 
-#include "paddle/phi/backends/gpu/gpu_context.h"
-#include "paddle/phi/backends/gpu/gpu_primitives.h"
 #include "paddle/phi/common/bfloat16.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/eigen/common.h"
-#include "paddle/phi/kernels/funcs/index_elementwise.cu.h"
+#include "paddle/phi/kernels/funcs/index_elementwise.h"
 #include "paddle/phi/kernels/funcs/stride_utils.h"
 
 namespace phi {
-template <typename T, typename IndexT, int nt, int vt, typename offset_calc_t>
+template <typename T, typename IndexT, typename offset_calc_t>
 void IndexEleGetGradAccKernel(
     int64_t N,
     const char* in_ptr,
@@ -39,20 +37,19 @@ void IndexEleGetGradAccKernel(
     const char* const in_data = in_ptr + offsets[1];
 
     int64_t offset = 0;
-#pragma unroll
     for (int i = 0; i < num_indices; i++) {
       int64_t index = *reinterpret_cast<int64_t*>(index_ptrs[i] + offsets[2]);
       if (index < 0) index += sizes[i];
       offset += index * strides[i];
     }
 
-    reinterpret_cast<T*>(out_data + offset) +=
+    *reinterpret_cast<T*>(out_data + offset) +=
         *reinterpret_cast<const T*>(in_data);
   }
 }
 
 template <typename T, typename IndexT = int>
-void CPUIndexElementwiseGetGrad(const phi::GPUContext& ctx,
+void CPUIndexElementwiseGetGrad(const phi::CPUContext& ctx,
                                 const DenseTensor& input,
                                 const DenseTensor& value,
                                 const std::vector<const DenseTensor*>& index,
@@ -73,7 +70,7 @@ void CPUIndexElementwiseGetGrad(const phi::GPUContext& ctx,
     sizes[i] = index_dims[i];
     strides[i] = index_strides[i];
   }
-  auto index_ptrs = funcs::GetIndexDataPtrs<IndexT>(index);
+  auto index_ptrs = funcs::CPUGetIndexDataPtrs<IndexT>(index);
 
   std::array<int64_t*, 3> strides_array;
   std::vector<int64_t> desired_shape;
@@ -93,33 +90,31 @@ void CPUIndexElementwiseGetGrad(const phi::GPUContext& ctx,
                            &numel,
                            strides_vec);
   auto offset_calc =
-      funcs::make_offset_calculator_put<3>(desired_shape, strides_array);
+      funcs::CPUmake_offset_calculator_put<3>(desired_shape, strides_array);
 
   const int64_t N = numel;
 
-  using dtype = funcs::OpaqueType<sizeof(T)>;
+  using dtype = funcs::CPUOpaqueType<sizeof(T)>;
 
   const char* in_ptr = reinterpret_cast<const char*>(value.data<T>());
   char* out_ptr = reinterpret_cast<char*>(output->data<T>()) + slice_offset;
 
   if (accumulate) {
-    IndexEleGetGradAccKernel<T, IndexT, nt, vt>
-        <<<grid, block, 0, stream>>>(N,
-                                     in_ptr,
-                                     out_ptr,
-                                     index_ptrs,
-                                     sizes,
-                                     strides,
-                                     num_indices,
-                                     offset_calc);
+    IndexEleGetGradAccKernel<T, IndexT>(N,
+                                        in_ptr,
+                                        out_ptr,
+                                        index_ptrs,
+                                        sizes,
+                                        strides,
+                                        num_indices,
+                                        offset_calc);
   } else {
-    for (int64_t idx = 0; idx < N; i++) {
+    for (int64_t idx = 0; idx < N; idx++) {
       const auto offsets = offset_calc.cpu_get(idx);
       char* const out_data = out_ptr + offsets[0];
       const char* const in_data = in_ptr + offsets[1];
 
       int64_t offset = 0;
-#pragma unroll
       for (int i = 0; i < num_indices; i++) {
         int64_t index = *reinterpret_cast<int64_t*>(index_ptrs[i] + offsets[2]);
         if (index < 0) {

--- a/paddle/phi/kernels/cpu/index_elementwise_get_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_elementwise_get_grad_kernel.cc
@@ -35,14 +35,12 @@ void IndexEleGetGradAccKernel(
     const auto offsets = offset_calc.cpu_get(idx);
     char* const out_data = out_ptr + offsets[0];
     const char* const in_data = in_ptr + offsets[1];
-
     int64_t offset = 0;
     for (int i = 0; i < num_indices; i++) {
       int64_t index = *reinterpret_cast<int64_t*>(index_ptrs[i] + offsets[2]);
       if (index < 0) index += sizes[i];
       offset += index * strides[i];
     }
-
     *reinterpret_cast<T*>(out_data + offset) +=
         *reinterpret_cast<const T*>(in_data);
   }
@@ -61,9 +59,7 @@ void CPUIndexElementwiseGetGrad(const phi::CPUContext& ctx,
                                 const bool accumulate,
                                 DenseTensor* output) {
   int64_t numel = 0;
-
   auto num_indices = index_dims.size();
-
   auto sizes = std::array<int64_t, 25>{};
   auto strides = std::array<int64_t, 25>{};
   for (unsigned i = 0; i < num_indices; i++) {
@@ -71,11 +67,9 @@ void CPUIndexElementwiseGetGrad(const phi::CPUContext& ctx,
     strides[i] = index_strides[i];
   }
   auto index_ptrs = funcs::GetIndexDataPtrs<IndexT>(index);
-
   std::array<int64_t*, 3> strides_array;
   std::vector<int64_t> desired_shape;
   std::array<std::vector<int64_t>, 3> strides_vec;
-
   funcs::IndexPutStride<3>(input_dims,
                            input_strides,
                            phi::SizeOf(input.dtype()),
@@ -91,14 +85,10 @@ void CPUIndexElementwiseGetGrad(const phi::CPUContext& ctx,
                            strides_vec);
   auto offset_calc =
       funcs::CPUmake_offset_calculator_put<3>(desired_shape, strides_array);
-
   const int64_t N = numel;
-
   using dtype = funcs::OpaqueType<sizeof(T)>;
-
   const char* in_ptr = reinterpret_cast<const char*>(value.data<T>());
   char* out_ptr = reinterpret_cast<char*>(output->data<T>()) + slice_offset;
-
   if (accumulate) {
     IndexEleGetGradAccKernel<T, IndexT>(N,
                                         in_ptr,
@@ -113,7 +103,6 @@ void CPUIndexElementwiseGetGrad(const phi::CPUContext& ctx,
       const auto offsets = offset_calc.cpu_get(idx);
       char* const out_data = out_ptr + offsets[0];
       const char* const in_data = in_ptr + offsets[1];
-
       int64_t offset = 0;
       for (size_t i = 0; i < num_indices; i++) {
         int64_t index = *reinterpret_cast<int64_t*>(index_ptrs[i] + offsets[2]);
@@ -145,7 +134,6 @@ void IndexElementwiseGetGradKernel(const Context& ctx,
   auto& place = *ctx.eigen_device();
   dxt.device(place) = dxt.constant(static_cast<T>(0));
   if (out_grad.numel() == 0) return;
-
   const auto& index_type = index[0]->dtype();
   PADDLE_ENFORCE_EQ(index_type == phi::DataType::INT64,
                     true,
@@ -155,7 +143,6 @@ void IndexElementwiseGetGradKernel(const Context& ctx,
                         index_type,
                         phi::DataType::INT32,
                         phi::DataType::INT64));
-
   CPUIndexElementwiseGetGrad<T, int64_t>(ctx,
                                          x,
                                          out_grad,

--- a/paddle/phi/kernels/cpu/index_elementwise_get_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_elementwise_get_grad_kernel.cc
@@ -70,7 +70,7 @@ void CPUIndexElementwiseGetGrad(const phi::CPUContext& ctx,
     sizes[i] = index_dims[i];
     strides[i] = index_strides[i];
   }
-  auto index_ptrs = funcs::CPUGetIndexDataPtrs<IndexT>(index);
+  auto index_ptrs = funcs::GetIndexDataPtrs<IndexT>(index);
 
   std::array<int64_t*, 3> strides_array;
   std::vector<int64_t> desired_shape;
@@ -94,7 +94,7 @@ void CPUIndexElementwiseGetGrad(const phi::CPUContext& ctx,
 
   const int64_t N = numel;
 
-  using dtype = funcs::CPUOpaqueType<sizeof(T)>;
+  using dtype = funcs::OpaqueType<sizeof(T)>;
 
   const char* in_ptr = reinterpret_cast<const char*>(value.data<T>());
   char* out_ptr = reinterpret_cast<char*>(output->data<T>()) + slice_offset;
@@ -115,7 +115,7 @@ void CPUIndexElementwiseGetGrad(const phi::CPUContext& ctx,
       const char* const in_data = in_ptr + offsets[1];
 
       int64_t offset = 0;
-      for (int i = 0; i < num_indices; i++) {
+      for (size_t i = 0; i < num_indices; i++) {
         int64_t index = *reinterpret_cast<int64_t*>(index_ptrs[i] + offsets[2]);
         if (index < 0) {
           index += sizes[i];

--- a/paddle/phi/kernels/cpu/index_elementwise_get_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_elementwise_get_kernel.cc
@@ -1,0 +1,158 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/phi/kernels/index_elementwise_get_kernel.h"
+
+#include "paddle/phi/backends/cpu/cpu_context.h"
+#include "paddle/phi/common/bfloat16.h"
+#include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/funcs/index_elementwise.cu.h"
+#include "paddle/phi/kernels/funcs/stride_utils.h"
+
+namespace phi {
+template <typename T, typename IndexT = int>
+void CPUIndexElementwiseGetKernel(const phi::CPUContext& ctx,
+                                  const DenseTensor& input,
+                                  const std::vector<const DenseTensor*> index,
+                                  const std::vector<int64_t>& input_dims,
+                                  const std::vector<int64_t>& input_strides,
+                                  const std::vector<int64_t>& index_dims,
+                                  const std::vector<int64_t>& index_stride,
+                                  const int64_t slice_offset,
+                                  DenseTensor* output) {
+  int64_t numel = 0;
+  auto num_indices = index_dims.size();
+
+  auto index_ptrs = funcs::GetIndexDataPtrs<IndexT>(index);
+
+  auto sizes = std::array<int64_t, DDim::kMaxRank>{};
+  auto strides = std::array<int64_t, DDim::kMaxRank>{};
+
+  for (unsigned i = 0; i < num_indices; i++) {
+    sizes[i] = index_dims[i];
+    strides[i] = index_stride[i];
+  }
+
+  std::array<int64_t*, 3> strides_array;
+  std::vector<int64_t> desired_shape;
+  std::array<std::vector<int64_t>, 3> strides_vec;
+
+  funcs::IndexGetStride<3>(input_dims,
+                           input_strides,
+                           phi::SizeOf(input.dtype()),
+                           std::vector<int64_t>(),
+                           std::vector<int64_t>(),
+                           phi::SizeOf(input.dtype()),
+                           common::vectorize<int64_t>(index[0]->dims()),
+                           common::vectorize<int64_t>(index[0]->strides()),
+                           phi::SizeOf(index[0]->dtype()),
+                           &desired_shape,
+                           &strides_array,
+                           &numel,
+                           strides_vec);
+  auto offset_calc =
+      funcs::make_offset_calculator_put<3>(desired_shape, strides_array);
+
+  const int64_t N = output->numel();
+  PADDLE_ENFORCE_GE(
+      N, 0, common::errors::InvalidArgument("Output numel must >= 0"));
+  PADDLE_ENFORCE_LE(
+      N,
+      std::numeric_limits<int32_t>::max(),
+      common::errors::InvalidArgument("Output numel must <= INT32_MAX"));
+
+  using dtype = funcs::OpaqueType<sizeof(T)>;
+
+  const char* in_ptr =
+      reinterpret_cast<const char*>(input.data<T>()) + slice_offset;
+  char* out_ptr = reinterpret_cast<char*>(output->data<T>());
+
+  for (int64_t idx = 0; idx < N; i++) {
+    const auto offsets = offset_calc.cpu_get(idx);
+    char* const out_data = out_ptr + offsets[0];
+    const char* const in_data = in_ptr + offsets[1];
+
+    int64_t offset = 0;
+#pragma unroll
+    for (int i = 0; i < num_indices; i++) {
+      int64_t index = *reinterpret_cast<int64_t*>(index_ptrs[i] + offsets[2]);
+      if (index < 0) {
+        index += sizes[i];
+      }
+      offset += index * strides[i];
+    }
+
+    *reinterpret_cast<dtype*>(out_data) =
+        *reinterpret_cast<const dtype*>(in_data + offset);
+  }
+}
+
+template <typename T, typename Context>
+void IndexElementwiseGetKernel(const Context& ctx,
+                               const DenseTensor& x,
+                               const std::vector<const DenseTensor*>& index,
+                               const std::vector<int64_t>& input_dims,
+                               const std::vector<int64_t>& input_strides,
+                               const std::vector<int64_t>& index_dims,
+                               const std::vector<int64_t>& index_stride,
+                               const int64_t slice_offset,
+                               const bool accumulate,
+                               DenseTensor* out) {
+  const auto& index_type = index[0]->dtype();
+  PADDLE_ENFORCE_EQ(index_type == phi::DataType::INT64,
+                    true,
+                    common::errors::InvalidArgument(
+                        "Index holds the wrong type, it holds [%s], but "
+                        "desires to be [%s].",
+                        index_type,
+                        phi::DataType::INT64));
+
+  auto out_dims = out->dims();
+  if (out_dims.size() > 0) {
+    std::vector<int64_t> output_dims(input_dims);
+    out->Resize(phi::make_ddim(output_dims));
+  }
+
+  ctx.template Alloc<T>(out);
+  if (out->numel() == 0) return;
+
+  CPUIndexElementwiseGetKernel<T, int64_t>(ctx,
+                                           x,
+                                           index,
+                                           input_dims,
+                                           input_strides,
+                                           index_dims,
+                                           index_stride,
+                                           slice_offset,
+                                           out);
+}
+
+}  // namespace phi
+
+PD_REGISTER_KERNEL(index_elementwise_get,
+                   CPU,
+                   ALL_LAYOUT,
+                   phi::IndexElementwiseGetKernel,
+                   bool,
+                   float,
+                   double,
+                   int,
+                   int8_t,
+                   int64_t,
+                   int16_t,
+                   uint8_t,
+                   phi::dtype::float16,
+                   phi::dtype::bfloat16,
+                   phi::dtype::complex<float>,
+                   phi::dtype::complex<double>) {}

--- a/paddle/phi/kernels/cpu/index_elementwise_get_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_elementwise_get_kernel.cc
@@ -34,7 +34,7 @@ void CPUIndexElementwiseGetKernel(const phi::CPUContext& ctx,
   int64_t numel = 0;
   auto num_indices = index_dims.size();
 
-  auto index_ptrs = funcs::CPUGetIndexDataPtrs<IndexT>(index);
+  auto index_ptrs = funcs::GetIndexDataPtrs<IndexT>(index);
 
   auto sizes = std::array<int64_t, DDim::kMaxRank>{};
   auto strides = std::array<int64_t, DDim::kMaxRank>{};
@@ -72,7 +72,7 @@ void CPUIndexElementwiseGetKernel(const phi::CPUContext& ctx,
       std::numeric_limits<int32_t>::max(),
       common::errors::InvalidArgument("Output numel must <= INT32_MAX"));
 
-  using dtype = funcs::CPUOpaqueType<sizeof(T)>;
+  using dtype = funcs::OpaqueType<sizeof(T)>;
 
   const char* in_ptr =
       reinterpret_cast<const char*>(input.data<T>()) + slice_offset;
@@ -85,7 +85,7 @@ void CPUIndexElementwiseGetKernel(const phi::CPUContext& ctx,
 
     int64_t offset = 0;
 #pragma unroll
-    for (int i = 0; i < num_indices; i++) {
+    for (size_t i = 0; i < num_indices; i++) {
       int64_t index = *reinterpret_cast<int64_t*>(index_ptrs[i] + offsets[2]);
       if (index < 0) {
         index += sizes[i];

--- a/paddle/phi/kernels/cpu/index_elementwise_get_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_elementwise_get_kernel.cc
@@ -17,7 +17,7 @@
 #include "paddle/phi/backends/cpu/cpu_context.h"
 #include "paddle/phi/common/bfloat16.h"
 #include "paddle/phi/core/kernel_registry.h"
-#include "paddle/phi/kernels/funcs/index_elementwise.cu.h"
+#include "paddle/phi/kernels/funcs/index_elementwise.h"
 #include "paddle/phi/kernels/funcs/stride_utils.h"
 
 namespace phi {
@@ -34,7 +34,7 @@ void CPUIndexElementwiseGetKernel(const phi::CPUContext& ctx,
   int64_t numel = 0;
   auto num_indices = index_dims.size();
 
-  auto index_ptrs = funcs::GetIndexDataPtrs<IndexT>(index);
+  auto index_ptrs = funcs::CPUGetIndexDataPtrs<IndexT>(index);
 
   auto sizes = std::array<int64_t, DDim::kMaxRank>{};
   auto strides = std::array<int64_t, DDim::kMaxRank>{};
@@ -62,7 +62,7 @@ void CPUIndexElementwiseGetKernel(const phi::CPUContext& ctx,
                            &numel,
                            strides_vec);
   auto offset_calc =
-      funcs::make_offset_calculator_put<3>(desired_shape, strides_array);
+      funcs::CPUmake_offset_calculator_put<3>(desired_shape, strides_array);
 
   const int64_t N = output->numel();
   PADDLE_ENFORCE_GE(
@@ -72,13 +72,13 @@ void CPUIndexElementwiseGetKernel(const phi::CPUContext& ctx,
       std::numeric_limits<int32_t>::max(),
       common::errors::InvalidArgument("Output numel must <= INT32_MAX"));
 
-  using dtype = funcs::OpaqueType<sizeof(T)>;
+  using dtype = funcs::CPUOpaqueType<sizeof(T)>;
 
   const char* in_ptr =
       reinterpret_cast<const char*>(input.data<T>()) + slice_offset;
   char* out_ptr = reinterpret_cast<char*>(output->data<T>());
 
-  for (int64_t idx = 0; idx < N; i++) {
+  for (int64_t idx = 0; idx < N; idx++) {
     const auto offsets = offset_calc.cpu_get(idx);
     char* const out_data = out_ptr + offsets[0];
     const char* const in_data = in_ptr + offsets[1];

--- a/paddle/phi/kernels/cpu/index_elementwise_get_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_elementwise_get_kernel.cc
@@ -33,21 +33,16 @@ void CPUIndexElementwiseGetKernel(const phi::CPUContext& ctx,
                                   DenseTensor* output) {
   int64_t numel = 0;
   auto num_indices = index_dims.size();
-
   auto index_ptrs = funcs::GetIndexDataPtrs<IndexT>(index);
-
   auto sizes = std::array<int64_t, DDim::kMaxRank>{};
   auto strides = std::array<int64_t, DDim::kMaxRank>{};
-
   for (unsigned i = 0; i < num_indices; i++) {
     sizes[i] = index_dims[i];
     strides[i] = index_stride[i];
   }
-
   std::array<int64_t*, 3> strides_array;
   std::vector<int64_t> desired_shape;
   std::array<std::vector<int64_t>, 3> strides_vec;
-
   funcs::IndexGetStride<3>(input_dims,
                            input_strides,
                            phi::SizeOf(input.dtype()),
@@ -63,7 +58,6 @@ void CPUIndexElementwiseGetKernel(const phi::CPUContext& ctx,
                            strides_vec);
   auto offset_calc =
       funcs::CPUmake_offset_calculator_put<3>(desired_shape, strides_array);
-
   const int64_t N = output->numel();
   PADDLE_ENFORCE_GE(
       N, 0, common::errors::InvalidArgument("Output numel must >= 0"));
@@ -71,18 +65,14 @@ void CPUIndexElementwiseGetKernel(const phi::CPUContext& ctx,
       N,
       std::numeric_limits<int32_t>::max(),
       common::errors::InvalidArgument("Output numel must <= INT32_MAX"));
-
   using dtype = funcs::OpaqueType<sizeof(T)>;
-
   const char* in_ptr =
       reinterpret_cast<const char*>(input.data<T>()) + slice_offset;
   char* out_ptr = reinterpret_cast<char*>(output->data<T>());
-
   for (int64_t idx = 0; idx < N; idx++) {
     const auto offsets = offset_calc.cpu_get(idx);
     char* const out_data = out_ptr + offsets[0];
     const char* const in_data = in_ptr + offsets[1];
-
     int64_t offset = 0;
 #pragma unroll
     for (size_t i = 0; i < num_indices; i++) {
@@ -92,7 +82,6 @@ void CPUIndexElementwiseGetKernel(const phi::CPUContext& ctx,
       }
       offset += index * strides[i];
     }
-
     *reinterpret_cast<dtype*>(out_data) =
         *reinterpret_cast<const dtype*>(in_data + offset);
   }
@@ -123,10 +112,8 @@ void IndexElementwiseGetKernel(const Context& ctx,
     std::vector<int64_t> output_dims(input_dims);
     out->Resize(phi::make_ddim(output_dims));
   }
-
   ctx.template Alloc<T>(out);
   if (out->numel() == 0) return;
-
   CPUIndexElementwiseGetKernel<T, int64_t>(ctx,
                                            x,
                                            index,

--- a/paddle/phi/kernels/cpu/index_elementwise_put_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_elementwise_put_grad_kernel.cc
@@ -39,9 +39,7 @@ void CPUIndexElementwisePutGradKernel(
     DenseTensor* x_grad,
     DenseTensor* value_grad) {
   int64_t numel = 0;
-
   auto num_indices = index_dims.size();
-
   auto sizes = std::array<int64_t, 25>{};
   auto strides = std::array<int64_t, 25>{};
   for (unsigned i = 0; i < num_indices; i++) {
@@ -49,7 +47,6 @@ void CPUIndexElementwisePutGradKernel(
     strides[i] = index_strides[i];
   }
   auto index_ptrs = funcs::GetIndexDataPtrs<IndexT>(index);
-
   std::array<int64_t*, 3> strides_array;
   std::vector<int64_t> desired_shape;
   std::array<std::vector<int64_t>, 3> strides_vec;
@@ -59,7 +56,6 @@ void CPUIndexElementwisePutGradKernel(
     value_dims = common::vectorize<int64_t>(value_grad->dims());
     value_strides = common::vectorize<int64_t>(value_grad->strides());
   }
-
   funcs::IndexPutStride<3>(input_dims,
                            input_strides,
                            phi::SizeOf(out_grad.dtype()),
@@ -76,17 +72,18 @@ void CPUIndexElementwisePutGradKernel(
   auto offset_calc =
       funcs::CPUmake_offset_calculator_put<3>(desired_shape, strides_array);
   const int64_t N = numel;
-  PADDLE_ENFORCE(N >= 0 && N <= std::numeric_limits<int32_t>::max(),
-                 "N >= 0 && N <= std::numeric_limits<int32_t>::max()");
+  PADDLE_ENFORCE_GE(N, 0, ::common::errors::InvalidArgument("N >= 0"));
+  PADDLE_ENFORCE_LE(N,
+                    std::numeric_limits<int32_t>::max(),
+                    ::common::errors::InvalidArgument(
+                        "N <= std::numeric_limits<int32_t>::max()"));
 
   using dtype = funcs::OpaqueType<sizeof(T)>;
   if (!value_grad) {
     char* out_ptr = reinterpret_cast<char*>(x_grad->data<T>());
-
     for (int64_t idx = 0; idx < N; idx++) {
       const auto offsets = offset_calc.cpu_get(idx);
       char* const out_data = out_ptr + offsets[0] + slice_offset;
-
       int64_t offset = 0;
       for (size_t i = 0; i < num_indices; i++) {
         int64_t index = *reinterpret_cast<int64_t*>(index_ptrs[i] + offsets[2]);
@@ -99,16 +96,13 @@ void CPUIndexElementwisePutGradKernel(
       *reinterpret_cast<dtype*>(out_data + offset) =
           *reinterpret_cast<dtype*>(&num);
     }
-
   } else if (!x_grad) {
     const char* out_ptr = reinterpret_cast<const char*>(out_grad.data<T>());
     char* value_ptr = reinterpret_cast<char*>(value_grad->data<T>());
-
     for (int64_t idx = 0; idx < N; idx++) {
       const auto offsets = offset_calc.cpu_get(idx);
       const char* const out_data = out_ptr + offsets[0] + slice_offset;
       char* const value_data = value_ptr + offsets[1];
-
       int64_t offset = 0;
       for (size_t i = 0; i < num_indices; i++) {
         int64_t index = *reinterpret_cast<int64_t*>(index_ptrs[i] + offsets[2]);
@@ -120,16 +114,13 @@ void CPUIndexElementwisePutGradKernel(
       *reinterpret_cast<dtype*>(value_data) =
           *reinterpret_cast<const dtype*>(out_data + offset);
     }
-
   } else {
     char* out_ptr = reinterpret_cast<char*>(x_grad->data<T>());
     char* value_ptr = reinterpret_cast<char*>(value_grad->data<T>());
-
     for (int64_t idx = 0; idx < N; idx++) {
       const auto offsets = offset_calc.cpu_get(idx);
       char* const out_data = out_ptr + offsets[0] + slice_offset;
       char* const value_data = value_ptr + offsets[1];
-
       int64_t offset = 0;
       for (size_t i = 0; i < num_indices; i++) {
         int64_t index = *reinterpret_cast<int64_t*>(index_ptrs[i] + offsets[2]);
@@ -161,7 +152,6 @@ void LaunchIndexElementwisePutGradCudaKernel(
     DenseTensor* x_grad) {
   if (x_grad && !value_grad) {
     phi::Copy(dev_ctx, out_grad, dev_ctx.GetPlace(), false, x_grad);
-
     CPUIndexElementwisePutGradKernel<T, int64_t>(dev_ctx,
                                                  out_grad,
                                                  indices,
@@ -180,7 +170,6 @@ void LaunchIndexElementwisePutGradCudaKernel(
       DenseTensor tmp_value_grad(value_grad->dtype());
       tmp_value_grad.Resize(common::make_ddim(input_dims));
       dev_ctx.template Alloc<T>(&tmp_value_grad);
-
       CPUIndexElementwisePutGradKernel<T, int64_t>(dev_ctx,
                                                    out_grad,
                                                    indices,
@@ -217,7 +206,6 @@ void LaunchIndexElementwisePutGradCudaKernel(
       DenseTensor tmp_value_grad(value_grad->dtype());
       tmp_value_grad.Resize(common::make_ddim(input_dims));
       dev_ctx.template Alloc<T>(&tmp_value_grad);
-
       CPUIndexElementwisePutGradKernel<T, int64_t>(dev_ctx,
                                                    out_grad,
                                                    indices,
@@ -228,16 +216,13 @@ void LaunchIndexElementwisePutGradCudaKernel(
                                                    slice_offset,
                                                    x_grad,
                                                    &tmp_value_grad);
-
       std::vector<int64_t> after_dims =
           common::vectorize(tmp_value_grad.dims());
       std::vector<int64_t> before_dims = common::vectorize(value_grad->dims());
       std::vector<int64_t> compress_dims;
       std::vector<int64_t> dims_without_1;
-
       funcs::CalCompressedDimsWith1AndWithout1(
           &after_dims, &before_dims, &compress_dims, &dims_without_1);
-
       auto pre_dims = value_grad->dims();
       value_grad->Resize(common::make_ddim(dims_without_1));
       IntArray v_axis(compress_dims);
@@ -289,7 +274,6 @@ void IndexElementwisePutGradKernel(
     }
     return;
   }
-
   LaunchIndexElementwisePutGradCudaKernel<T, Context>(dev_ctx,
                                                       indices,
                                                       out_grad,

--- a/paddle/phi/kernels/cpu/index_elementwise_put_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_elementwise_put_grad_kernel.cc
@@ -19,7 +19,7 @@
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/cast_kernel.h"
 #include "paddle/phi/kernels/full_kernel.h"
-#include "paddle/phi/kernels/funcs/index_elementwise.cu.h"
+#include "paddle/phi/kernels/funcs/index_elementwise.h"
 #include "paddle/phi/kernels/funcs/index_put_utils.h"
 #include "paddle/phi/kernels/funcs/stride_utils.h"
 #include "paddle/phi/kernels/reduce_sum_kernel.h"
@@ -48,7 +48,7 @@ void CPUIndexElementwisePutGradKernel(
     sizes[i] = index_dims[i];
     strides[i] = index_strides[i];
   }
-  auto index_ptrs = funcs::GetIndexDataPtrs<IndexT>(index);
+  auto index_ptrs = funcs::CPUGetIndexDataPtrs<IndexT>(index);
 
   std::array<int64_t*, 3> strides_array;
   std::vector<int64_t> desired_shape;
@@ -74,16 +74,16 @@ void CPUIndexElementwisePutGradKernel(
                            &numel,
                            strides_vec);
   auto offset_calc =
-      funcs::make_offset_calculator_put<3>(desired_shape, strides_array);
+      funcs::CPUmake_offset_calculator_put<3>(desired_shape, strides_array);
   const int64_t N = numel;
   PADDLE_ENFORCE(N >= 0 && N <= std::numeric_limits<int32_t>::max(),
                  "N >= 0 && N <= std::numeric_limits<int32_t>::max()");
 
-  using dtype = funcs::OpaqueType<sizeof(T)>;
+  using dtype = funcs::CPUOpaqueType<sizeof(T)>;
   if (!value_grad) {
     char* out_ptr = reinterpret_cast<char*>(x_grad->data<T>());
 
-    for (int64_t idx = 0; idx < N; i++) {
+    for (int64_t idx = 0; idx < N; idx++) {
       const auto offsets = offset_calc.cpu_get(idx);
       char* const out_data = out_ptr + offsets[0] + slice_offset;
 
@@ -105,7 +105,7 @@ void CPUIndexElementwisePutGradKernel(
     const char* out_ptr = reinterpret_cast<const char*>(out_grad.data<T>());
     char* value_ptr = reinterpret_cast<char*>(value_grad->data<T>());
 
-    for (int64_t idx = 0; idx < N; i++) {
+    for (int64_t idx = 0; idx < N; idx++) {
       const auto offsets = offset_calc.cpu_get(idx);
       const char* const out_data = out_ptr + offsets[0] + slice_offset;
       char* const value_data = value_ptr + offsets[1];
@@ -127,7 +127,7 @@ void CPUIndexElementwisePutGradKernel(
     char* out_ptr = reinterpret_cast<char*>(x_grad->data<T>());
     char* value_ptr = reinterpret_cast<char*>(value_grad->data<T>());
 
-    for (int64_t idx = 0; idx < N; i++) {
+    for (int64_t idx = 0; idx < N; idx++) {
       const auto offsets = offset_calc.cpu_get(idx);
       char* const out_data = out_ptr + offsets[0] + slice_offset;
       char* const value_data = value_ptr + offsets[1];

--- a/paddle/phi/kernels/cpu/index_elementwise_put_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_elementwise_put_grad_kernel.cc
@@ -72,12 +72,8 @@ void CPUIndexElementwisePutGradKernel(
   auto offset_calc =
       funcs::CPUmake_offset_calculator_put<3>(desired_shape, strides_array);
   const int64_t N = numel;
-  PADDLE_ENFORCE_GE(N, 0, ::common::errors::InvalidArgument("N >= 0"));
-  PADDLE_ENFORCE_LE(N,
-                    std::numeric_limits<int32_t>::max(),
-                    ::common::errors::InvalidArgument(
-                        "N <= std::numeric_limits<int32_t>::max()"));
-
+  PADDLE_ENFORCE(N >= 0 && N <= std::numeric_limits<int32_t>::max(),
+                 "N >= 0 && N <= std::numeric_limits<int32_t>::max()");
   using dtype = funcs::OpaqueType<sizeof(T)>;
   if (!value_grad) {
     char* out_ptr = reinterpret_cast<char*>(x_grad->data<T>());

--- a/paddle/phi/kernels/cpu/index_elementwise_put_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_elementwise_put_grad_kernel.cc
@@ -48,7 +48,7 @@ void CPUIndexElementwisePutGradKernel(
     sizes[i] = index_dims[i];
     strides[i] = index_strides[i];
   }
-  auto index_ptrs = funcs::CPUGetIndexDataPtrs<IndexT>(index);
+  auto index_ptrs = funcs::GetIndexDataPtrs<IndexT>(index);
 
   std::array<int64_t*, 3> strides_array;
   std::vector<int64_t> desired_shape;
@@ -79,7 +79,7 @@ void CPUIndexElementwisePutGradKernel(
   PADDLE_ENFORCE(N >= 0 && N <= std::numeric_limits<int32_t>::max(),
                  "N >= 0 && N <= std::numeric_limits<int32_t>::max()");
 
-  using dtype = funcs::CPUOpaqueType<sizeof(T)>;
+  using dtype = funcs::OpaqueType<sizeof(T)>;
   if (!value_grad) {
     char* out_ptr = reinterpret_cast<char*>(x_grad->data<T>());
 
@@ -88,8 +88,7 @@ void CPUIndexElementwisePutGradKernel(
       char* const out_data = out_ptr + offsets[0] + slice_offset;
 
       int64_t offset = 0;
-#pragma unroll
-      for (int i = 0; i < num_indices; i++) {
+      for (size_t i = 0; i < num_indices; i++) {
         int64_t index = *reinterpret_cast<int64_t*>(index_ptrs[i] + offsets[2]);
         if (index < 0) {
           index += sizes[i];
@@ -111,8 +110,7 @@ void CPUIndexElementwisePutGradKernel(
       char* const value_data = value_ptr + offsets[1];
 
       int64_t offset = 0;
-#pragma unroll
-      for (int i = 0; i < num_indices; i++) {
+      for (size_t i = 0; i < num_indices; i++) {
         int64_t index = *reinterpret_cast<int64_t*>(index_ptrs[i] + offsets[2]);
         if (index < 0) {
           index += sizes[i];
@@ -133,8 +131,7 @@ void CPUIndexElementwisePutGradKernel(
       char* const value_data = value_ptr + offsets[1];
 
       int64_t offset = 0;
-#pragma unroll
-      for (int i = 0; i < num_indices; i++) {
+      for (size_t i = 0; i < num_indices; i++) {
         int64_t index = *reinterpret_cast<int64_t*>(index_ptrs[i] + offsets[2]);
         if (index < 0) {
           index += sizes[i];

--- a/paddle/phi/kernels/cpu/index_elementwise_put_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_elementwise_put_grad_kernel.cc
@@ -1,0 +1,325 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/phi/kernels/index_elementwise_put_grad_kernel.h"
+
+#include "paddle/phi/backends/cpu/cpu_context.h"
+#include "paddle/phi/common/bfloat16.h"
+#include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/cast_kernel.h"
+#include "paddle/phi/kernels/full_kernel.h"
+#include "paddle/phi/kernels/funcs/index_elementwise.cu.h"
+#include "paddle/phi/kernels/funcs/index_put_utils.h"
+#include "paddle/phi/kernels/funcs/stride_utils.h"
+#include "paddle/phi/kernels/reduce_sum_kernel.h"
+
+namespace phi {
+
+template <typename T, typename IndexT = int>
+void CPUIndexElementwisePutGradKernel(
+    const phi::CPUContext& dev_ctx,
+    const DenseTensor& out_grad,
+    const std::vector<const DenseTensor*>& index,
+    const std::vector<int64_t>& input_dims,
+    const std::vector<int64_t>& input_strides,
+    const std::vector<int64_t>& index_dims,
+    const std::vector<int64_t>& index_strides,
+    const int64_t slice_offset,
+    DenseTensor* x_grad,
+    DenseTensor* value_grad) {
+  int64_t numel = 0;
+
+  auto num_indices = index_dims.size();
+
+  auto sizes = std::array<int64_t, 25>{};
+  auto strides = std::array<int64_t, 25>{};
+  for (unsigned i = 0; i < num_indices; i++) {
+    sizes[i] = index_dims[i];
+    strides[i] = index_strides[i];
+  }
+  auto index_ptrs = funcs::GetIndexDataPtrs<IndexT>(index);
+
+  std::array<int64_t*, 3> strides_array;
+  std::vector<int64_t> desired_shape;
+  std::array<std::vector<int64_t>, 3> strides_vec;
+  std::vector<int64_t> value_dims;
+  std::vector<int64_t> value_strides;
+  if (value_grad) {
+    value_dims = common::vectorize<int64_t>(value_grad->dims());
+    value_strides = common::vectorize<int64_t>(value_grad->strides());
+  }
+
+  funcs::IndexPutStride<3>(input_dims,
+                           input_strides,
+                           phi::SizeOf(out_grad.dtype()),
+                           value_dims,
+                           value_strides,
+                           4,
+                           common::vectorize<int64_t>(index[0]->dims()),
+                           common::vectorize<int64_t>(index[0]->strides()),
+                           phi::SizeOf(index[0]->dtype()),
+                           &desired_shape,
+                           &strides_array,
+                           &numel,
+                           strides_vec);
+  auto offset_calc =
+      funcs::make_offset_calculator_put<3>(desired_shape, strides_array);
+  const int64_t N = numel;
+  PADDLE_ENFORCE(N >= 0 && N <= std::numeric_limits<int32_t>::max(),
+                 "N >= 0 && N <= std::numeric_limits<int32_t>::max()");
+
+  using dtype = funcs::OpaqueType<sizeof(T)>;
+  if (!value_grad) {
+    char* out_ptr = reinterpret_cast<char*>(x_grad->data<T>());
+
+    for (int64_t idx = 0; idx < N; i++) {
+      const auto offsets = offset_calc.cpu_get(idx);
+      char* const out_data = out_ptr + offsets[0] + slice_offset;
+
+      int64_t offset = 0;
+#pragma unroll
+      for (int i = 0; i < num_indices; i++) {
+        int64_t index = *reinterpret_cast<int64_t*>(index_ptrs[i] + offsets[2]);
+        if (index < 0) {
+          index += sizes[i];
+        }
+        offset += index * strides[i];
+      }
+      T num = T(0);
+      *reinterpret_cast<dtype*>(out_data + offset) =
+          *reinterpret_cast<dtype*>(&num);
+    }
+
+  } else if (!x_grad) {
+    const char* out_ptr = reinterpret_cast<const char*>(out_grad.data<T>());
+    char* value_ptr = reinterpret_cast<char*>(value_grad->data<T>());
+
+    for (int64_t idx = 0; idx < N; i++) {
+      const auto offsets = offset_calc.cpu_get(idx);
+      const char* const out_data = out_ptr + offsets[0] + slice_offset;
+      char* const value_data = value_ptr + offsets[1];
+
+      int64_t offset = 0;
+#pragma unroll
+      for (int i = 0; i < num_indices; i++) {
+        int64_t index = *reinterpret_cast<int64_t*>(index_ptrs[i] + offsets[2]);
+        if (index < 0) {
+          index += sizes[i];
+        }
+        offset += index * strides[i];
+      }
+      *reinterpret_cast<dtype*>(value_data) =
+          *reinterpret_cast<const dtype*>(out_data + offset);
+    }
+
+  } else {
+    char* out_ptr = reinterpret_cast<char*>(x_grad->data<T>());
+    char* value_ptr = reinterpret_cast<char*>(value_grad->data<T>());
+
+    for (int64_t idx = 0; idx < N; i++) {
+      const auto offsets = offset_calc.cpu_get(idx);
+      char* const out_data = out_ptr + offsets[0] + slice_offset;
+      char* const value_data = value_ptr + offsets[1];
+
+      int64_t offset = 0;
+#pragma unroll
+      for (int i = 0; i < num_indices; i++) {
+        int64_t index = *reinterpret_cast<int64_t*>(index_ptrs[i] + offsets[2]);
+        if (index < 0) {
+          index += sizes[i];
+        }
+        offset += index * strides[i];
+      }
+      T num = T(0);
+      *reinterpret_cast<dtype*>(value_data) =
+          *reinterpret_cast<dtype*>(out_data + offset);
+      *reinterpret_cast<dtype*>(out_data + offset) =
+          *reinterpret_cast<dtype*>(&num);
+    }
+  }
+}
+
+template <typename T, typename Context>
+void LaunchIndexElementwisePutGradCudaKernel(
+    const Context& dev_ctx,
+    const std::vector<const DenseTensor*>& indices,
+    const DenseTensor& out_grad,
+    const std::vector<int64_t>& input_dims,
+    const std::vector<int64_t>& input_strides,
+    const std::vector<int64_t>& index_dims,
+    const std::vector<int64_t>& index_strides,
+    const int64_t slice_offset,
+    DenseTensor* value_grad,
+    DenseTensor* x_grad) {
+  if (x_grad && !value_grad) {
+    phi::Copy(dev_ctx, out_grad, dev_ctx.GetPlace(), false, x_grad);
+
+    CPUIndexElementwisePutGradKernel<T, int64_t>(dev_ctx,
+                                                 out_grad,
+                                                 indices,
+                                                 input_dims,
+                                                 input_strides,
+                                                 index_dims,
+                                                 index_strides,
+                                                 slice_offset,
+                                                 x_grad,
+                                                 value_grad);
+  } else if (value_grad) {
+    if (x_grad) {
+      phi::Copy(dev_ctx, out_grad, dev_ctx.GetPlace(), false, x_grad);
+    }
+    if (value_grad->numel() == 1) {
+      DenseTensor tmp_value_grad(value_grad->dtype());
+      tmp_value_grad.Resize(common::make_ddim(input_dims));
+      dev_ctx.template Alloc<T>(&tmp_value_grad);
+
+      CPUIndexElementwisePutGradKernel<T, int64_t>(dev_ctx,
+                                                   out_grad,
+                                                   indices,
+                                                   input_dims,
+                                                   input_strides,
+                                                   index_dims,
+                                                   index_strides,
+                                                   slice_offset,
+                                                   x_grad,
+                                                   &tmp_value_grad);
+
+      std::vector<int> v_dims(tmp_value_grad.dims().size());
+      std::iota(v_dims.begin(), v_dims.end(), 0);
+      IntArray v_axis(v_dims);
+      SumKernel<T, Context>(dev_ctx,
+                            tmp_value_grad,
+                            v_axis,
+                            value_grad->dtype(),
+                            false,
+                            value_grad);
+    } else if (value_grad->dims() == common::make_ddim(input_dims)) {
+      dev_ctx.template Alloc<T>(value_grad);
+      CPUIndexElementwisePutGradKernel<T, int64_t>(dev_ctx,
+                                                   out_grad,
+                                                   indices,
+                                                   input_dims,
+                                                   input_strides,
+                                                   index_dims,
+                                                   index_strides,
+                                                   slice_offset,
+                                                   x_grad,
+                                                   value_grad);
+    } else {
+      DenseTensor tmp_value_grad(value_grad->dtype());
+      tmp_value_grad.Resize(common::make_ddim(input_dims));
+      dev_ctx.template Alloc<T>(&tmp_value_grad);
+
+      CPUIndexElementwisePutGradKernel<T, int64_t>(dev_ctx,
+                                                   out_grad,
+                                                   indices,
+                                                   input_dims,
+                                                   input_strides,
+                                                   index_dims,
+                                                   index_strides,
+                                                   slice_offset,
+                                                   x_grad,
+                                                   &tmp_value_grad);
+
+      std::vector<int64_t> after_dims =
+          common::vectorize(tmp_value_grad.dims());
+      std::vector<int64_t> before_dims = common::vectorize(value_grad->dims());
+      std::vector<int64_t> compress_dims;
+      std::vector<int64_t> dims_without_1;
+
+      funcs::CalCompressedDimsWith1AndWithout1(
+          &after_dims, &before_dims, &compress_dims, &dims_without_1);
+
+      auto pre_dims = value_grad->dims();
+      value_grad->Resize(common::make_ddim(dims_without_1));
+      IntArray v_axis(compress_dims);
+      SumKernel<T, Context>(dev_ctx,
+                            tmp_value_grad,
+                            v_axis,
+                            value_grad->dtype(),
+                            false,
+                            value_grad);
+      value_grad->Resize(pre_dims);
+    }
+  }
+}
+
+template <typename T, typename Context>
+void IndexElementwisePutGradKernel(
+    const Context& dev_ctx,
+    const DenseTensor& x,
+    const std::vector<const DenseTensor*>& indices,
+    const DenseTensor& value,
+    const DenseTensor& out_grad,
+    const std::vector<int64_t>& input_dims,
+    const std::vector<int64_t>& input_strides,
+    const std::vector<int64_t>& index_dims,
+    const std::vector<int64_t>& index_strides,
+    const int64_t slice_offset,
+    DenseTensor* x_grad,
+    DenseTensor* value_grad) {
+  const auto& index_type = indices[0]->dtype();
+  PADDLE_ENFORCE_EQ(index_type == phi::DataType::INT64,
+                    true,
+                    common::errors::InvalidArgument(
+                        "Index holds the wrong type, it holds [%s], but "
+                        "desires to be [%s].",
+                        index_type,
+                        phi::DataType::INT64));
+
+  std::vector<DenseTensor> tmp_args;
+  if (indices.empty()) {
+    if (x_grad) {
+      phi::Copy(dev_ctx, out_grad, dev_ctx.GetPlace(), false, x_grad);
+    }
+    if (value_grad) {
+      FullKernel<T, Context>(dev_ctx,
+                             common::vectorize(value_grad->dims()),
+                             0.0f,
+                             value_grad->dtype(),
+                             value_grad);
+    }
+    return;
+  }
+
+  LaunchIndexElementwisePutGradCudaKernel<T, Context>(dev_ctx,
+                                                      indices,
+                                                      out_grad,
+                                                      input_dims,
+                                                      input_strides,
+                                                      index_dims,
+                                                      index_strides,
+                                                      slice_offset,
+                                                      value_grad,
+                                                      x_grad);
+}
+
+}  // namespace phi
+
+PD_REGISTER_KERNEL(index_elementwise_put_grad,
+                   CPU,
+                   ALL_LAYOUT,
+                   phi::IndexElementwisePutGradKernel,
+                   bool,
+                   float,
+                   double,
+                   int,
+                   int8_t,
+                   int64_t,
+                   int16_t,
+                   uint8_t,
+                   phi::dtype::float16,
+                   phi::dtype::bfloat16,
+                   phi::dtype::complex<float>,
+                   phi::dtype::complex<double>) {}

--- a/paddle/phi/kernels/cpu/index_elementwise_put_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_elementwise_put_kernel.cc
@@ -70,11 +70,8 @@ void CPUIndexElementwisePutKernel(const phi::CPUContext& dev_ctx,
   auto offset_calc =
       funcs::CPUmake_offset_calculator_put<3>(desired_shape, strides_array);
   const int64_t N = numel;
-  PADDLE_ENFORCE_GE(N, 0, ::common::errors::InvalidArgument("N >= 0"));
-  PADDLE_ENFORCE_LE(N,
-                    std::numeric_limits<int32_t>::max(),
-                    ::common::errors::InvalidArgument(
-                        "N <= std::numeric_limits<int32_t>::max()"));
+  PADDLE_ENFORCE(N >= 0 && N <= std::numeric_limits<int32_t>::max(),
+                 "N >= 0 && N <= std::numeric_limits<int32_t>::max()");
   using dtype = funcs::OpaqueType<sizeof(T)>;
   const char* in_ptr = reinterpret_cast<const char*>(value.data<T>());
   char* out_ptr = reinterpret_cast<char*>(output_);

--- a/paddle/phi/kernels/cpu/index_elementwise_put_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_elementwise_put_kernel.cc
@@ -81,7 +81,6 @@ void CPUIndexElementwisePutKernel(const phi::CPUContext& dev_ctx,
     const char* const in_data = in_ptr + offsets[1];
 
     int64_t offset = 0;
-#pragma unroll
     for (size_t i = 0; i < num_indices; i++) {
       int64_t index = *reinterpret_cast<int64_t*>(index_ptrs[i] + offsets[2]);
       if (index < 0) {

--- a/paddle/phi/kernels/cpu/index_elementwise_put_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_elementwise_put_kernel.cc
@@ -43,7 +43,7 @@ void CPUIndexElementwisePutKernel(const phi::CPUContext& dev_ctx,
     sizes[i] = index_dims[i];
     strides[i] = index_strides[i];
   }
-  auto index_ptrs = funcs::CPUGetIndexDataPtrs<IndexT>(index);
+  auto index_ptrs = funcs::GetIndexDataPtrs<IndexT>(index);
 
   std::array<int64_t*, 3> strides_array;
   std::vector<int64_t> desired_shape;
@@ -70,7 +70,7 @@ void CPUIndexElementwisePutKernel(const phi::CPUContext& dev_ctx,
   PADDLE_ENFORCE(N >= 0 && N <= std::numeric_limits<int32_t>::max(),
                  "N >= 0 && N <= std::numeric_limits<int32_t>::max()");
 
-  using dtype = funcs::CPUOpaqueType<sizeof(T)>;
+  using dtype = funcs::OpaqueType<sizeof(T)>;
 
   const char* in_ptr = reinterpret_cast<const char*>(value.data<T>());
   char* out_ptr = reinterpret_cast<char*>(output->data<T>());
@@ -82,7 +82,7 @@ void CPUIndexElementwisePutKernel(const phi::CPUContext& dev_ctx,
 
     int64_t offset = 0;
 #pragma unroll
-    for (int i = 0; i < num_indices; i++) {
+    for (size_t i = 0; i < num_indices; i++) {
       int64_t index = *reinterpret_cast<int64_t*>(index_ptrs[i] + offsets[2]);
       if (index < 0) {
         index += sizes[i];

--- a/paddle/phi/kernels/cpu/index_elementwise_put_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_elementwise_put_kernel.cc
@@ -34,22 +34,16 @@ void CPUIndexElementwisePutKernel(const phi::CPUContext& dev_ctx,
                                   const int64_t slice_offset,
                                   DenseTensor* output) {
   int64_t numel = 0;
-
   bool is_initialized = output->initialized();
   bool is_same_place = true;
-
   if (is_initialized) {
     is_same_place = (input.place() == output->place());
   }
-
   T* output_ = dev_ctx.template Alloc<T>(output);
-
   if (!is_initialized || !is_same_place) {
     phi::Copy(dev_ctx, input, dev_ctx.GetPlace(), false, output);
   }
-
   auto num_indices = index_dims.size();
-
   auto sizes = std::array<int64_t, 25>{};
   auto strides = std::array<int64_t, 25>{};
   for (unsigned i = 0; i < num_indices; i++) {
@@ -57,11 +51,9 @@ void CPUIndexElementwisePutKernel(const phi::CPUContext& dev_ctx,
     strides[i] = index_strides[i];
   }
   auto index_ptrs = funcs::GetIndexDataPtrs<IndexT>(index);
-
   std::array<int64_t*, 3> strides_array;
   std::vector<int64_t> desired_shape;
   std::array<std::vector<int64_t>, 3> strides_vec;
-
   funcs::IndexPutStride<3>(input_dims,
                            input_strides,
                            phi::SizeOf(input.dtype()),
@@ -75,24 +67,21 @@ void CPUIndexElementwisePutKernel(const phi::CPUContext& dev_ctx,
                            &strides_array,
                            &numel,
                            strides_vec);
-
   auto offset_calc =
       funcs::CPUmake_offset_calculator_put<3>(desired_shape, strides_array);
-
   const int64_t N = numel;
-  PADDLE_ENFORCE(N >= 0 && N <= std::numeric_limits<int32_t>::max(),
-                 "N >= 0 && N <= std::numeric_limits<int32_t>::max()");
-
+  PADDLE_ENFORCE_GE(N, 0, ::common::errors::InvalidArgument("N >= 0"));
+  PADDLE_ENFORCE_LE(N,
+                    std::numeric_limits<int32_t>::max(),
+                    ::common::errors::InvalidArgument(
+                        "N <= std::numeric_limits<int32_t>::max()"));
   using dtype = funcs::OpaqueType<sizeof(T)>;
-
   const char* in_ptr = reinterpret_cast<const char*>(value.data<T>());
   char* out_ptr = reinterpret_cast<char*>(output_);
-
   for (int64_t idx = 0; idx < N; idx++) {
     const auto offsets = offset_calc.cpu_get(idx);
     char* const out_data = out_ptr + offsets[0] + slice_offset;
     const char* const in_data = in_ptr + offsets[1];
-
     int64_t offset = 0;
     for (size_t i = 0; i < num_indices; i++) {
       int64_t index = *reinterpret_cast<int64_t*>(index_ptrs[i] + offsets[2]);
@@ -125,19 +114,16 @@ void IndexElementwisePutKernel(const Context& dev_ctx,
                         "desires to be [%s].",
                         index_type,
                         phi::DataType::INT64));
-
   if (out && out->numel() == 0) {
     dev_ctx.template Alloc<T>(out);
     return;
   }
-
   if (index.empty()) {
     if (!out->initialized()) {
       phi::Copy(dev_ctx, x, dev_ctx.GetPlace(), false, out);
     }
     return;
   }
-
   if (out->numel() == 0) return;
   CPUIndexElementwisePutKernel<T, int64_t>(dev_ctx,
                                            x,

--- a/paddle/phi/kernels/cpu/index_elementwise_put_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_elementwise_put_kernel.cc
@@ -17,7 +17,7 @@
 #include "paddle/phi/backends/cpu/cpu_context.h"
 #include "paddle/phi/common/bfloat16.h"
 #include "paddle/phi/core/kernel_registry.h"
-#include "paddle/phi/kernels/funcs/index_elementwise.cu.h"
+#include "paddle/phi/kernels/funcs/index_elementwise.h"
 #include "paddle/phi/kernels/funcs/stride_utils.h"
 
 namespace phi {
@@ -43,7 +43,7 @@ void CPUIndexElementwisePutKernel(const phi::CPUContext& dev_ctx,
     sizes[i] = index_dims[i];
     strides[i] = index_strides[i];
   }
-  auto index_ptrs = funcs::GetIndexDataPtrs<IndexT>(index);
+  auto index_ptrs = funcs::CPUGetIndexDataPtrs<IndexT>(index);
 
   std::array<int64_t*, 3> strides_array;
   std::vector<int64_t> desired_shape;
@@ -64,18 +64,18 @@ void CPUIndexElementwisePutKernel(const phi::CPUContext& dev_ctx,
                            strides_vec);
 
   auto offset_calc =
-      funcs::make_offset_calculator_put<3>(desired_shape, strides_array);
+      funcs::CPUmake_offset_calculator_put<3>(desired_shape, strides_array);
 
   const int64_t N = numel;
   PADDLE_ENFORCE(N >= 0 && N <= std::numeric_limits<int32_t>::max(),
                  "N >= 0 && N <= std::numeric_limits<int32_t>::max()");
 
-  using dtype = funcs::OpaqueType<sizeof(T)>;
+  using dtype = funcs::CPUOpaqueType<sizeof(T)>;
 
   const char* in_ptr = reinterpret_cast<const char*>(value.data<T>());
   char* out_ptr = reinterpret_cast<char*>(output->data<T>());
 
-  for (int64_t idx = 0; idx < N; i++) {
+  for (int64_t idx = 0; idx < N; idx++) {
     const auto offsets = offset_calc.cpu_get(idx);
     char* const out_data = out_ptr + offsets[0] + slice_offset;
     const char* const in_data = in_ptr + offsets[1];

--- a/paddle/phi/kernels/cpu/index_elementwise_put_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_elementwise_put_kernel.cc
@@ -1,0 +1,148 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/phi/kernels/index_elementwise_put_kernel.h"
+
+#include "paddle/phi/backends/cpu/cpu_context.h"
+#include "paddle/phi/common/bfloat16.h"
+#include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/funcs/index_elementwise.cu.h"
+#include "paddle/phi/kernels/funcs/stride_utils.h"
+
+namespace phi {
+
+template <typename T, typename IndexT = int>
+void CPUIndexElementwisePutKernel(const phi::CPUContext& dev_ctx,
+                                  const DenseTensor& input,
+                                  const DenseTensor& value,
+                                  const std::vector<const DenseTensor*>& index,
+                                  const std::vector<int64_t>& input_dims,
+                                  const std::vector<int64_t>& input_strides,
+                                  const std::vector<int64_t>& index_dims,
+                                  const std::vector<int64_t>& index_strides,
+                                  const int64_t slice_offset,
+                                  DenseTensor* output) {
+  int64_t numel = 0;
+
+  auto num_indices = index_dims.size();
+
+  auto sizes = std::array<int64_t, 25>{};
+  auto strides = std::array<int64_t, 25>{};
+  for (unsigned i = 0; i < num_indices; i++) {
+    sizes[i] = index_dims[i];
+    strides[i] = index_strides[i];
+  }
+  auto index_ptrs = funcs::GetIndexDataPtrs<IndexT>(index);
+
+  std::array<int64_t*, 3> strides_array;
+  std::vector<int64_t> desired_shape;
+  std::array<std::vector<int64_t>, 3> strides_vec;
+
+  funcs::IndexPutStride<3>(input_dims,
+                           input_strides,
+                           phi::SizeOf(input.dtype()),
+                           common::vectorize<int64_t>(value.dims()),
+                           common::vectorize<int64_t>(value.strides()),
+                           phi::SizeOf(value.dtype()),
+                           common::vectorize<int64_t>(index[0]->dims()),
+                           common::vectorize<int64_t>(index[0]->strides()),
+                           phi::SizeOf(index[0]->dtype()),
+                           &desired_shape,
+                           &strides_array,
+                           &numel,
+                           strides_vec);
+
+  auto offset_calc =
+      funcs::make_offset_calculator_put<3>(desired_shape, strides_array);
+
+  const int64_t N = numel;
+  PADDLE_ENFORCE(N >= 0 && N <= std::numeric_limits<int32_t>::max(),
+                 "N >= 0 && N <= std::numeric_limits<int32_t>::max()");
+
+  using dtype = funcs::OpaqueType<sizeof(T)>;
+
+  const char* in_ptr = reinterpret_cast<const char*>(value.data<T>());
+  char* out_ptr = reinterpret_cast<char*>(output->data<T>());
+
+  for (int64_t idx = 0; idx < N; i++) {
+    const auto offsets = offset_calc.cpu_get(idx);
+    char* const out_data = out_ptr + offsets[0] + slice_offset;
+    const char* const in_data = in_ptr + offsets[1];
+
+    int64_t offset = 0;
+#pragma unroll
+    for (int i = 0; i < num_indices; i++) {
+      int64_t index = *reinterpret_cast<int64_t*>(index_ptrs[i] + offsets[2]);
+      if (index < 0) {
+        index += sizes[i];
+      }
+      offset += index * strides[i];
+    }
+    *reinterpret_cast<dtype*>(out_data + offset) =
+        *reinterpret_cast<const dtype*>(in_data);
+  }
+}
+
+template <typename T, typename Context>
+void IndexElementwisePutKernel(const Context& dev_ctx,
+                               const DenseTensor& x,
+                               const std::vector<const DenseTensor*>& index,
+                               const DenseTensor& value,
+                               const std::vector<int64_t>& input_dims,
+                               const std::vector<int64_t>& input_strides,
+                               const std::vector<int64_t>& index_dims,
+                               const std::vector<int64_t>& index_strides,
+                               const int64_t slice_offset,
+                               DenseTensor* out) {
+  const auto& index_type = index[0]->dtype();
+  PADDLE_ENFORCE_EQ(index_type == phi::DataType::INT64,
+                    true,
+                    common::errors::InvalidArgument(
+                        "Index holds the wrong type, it holds [%s], but "
+                        "desires to be [%s].",
+                        index_type,
+                        phi::DataType::INT64));
+
+  dev_ctx.template Alloc<T>(out);
+  if (out->numel() == 0) return;
+  CPUIndexElementwisePutKernel<T, int64_t>(dev_ctx,
+                                           x,
+                                           value,
+                                           index,
+                                           input_dims,
+                                           input_strides,
+                                           index_dims,
+                                           index_strides,
+                                           slice_offset,
+                                           out);
+}
+
+}  // namespace phi
+
+PD_REGISTER_KERNEL(index_elementwise_put,
+                   CPU,
+                   ALL_LAYOUT,
+                   phi::IndexElementwisePutKernel,
+                   bool,
+                   float,
+                   double,
+                   int,
+                   int8_t,
+                   int64_t,
+                   int16_t,
+                   uint8_t,
+                   phi::dtype::float16,
+                   phi::dtype::bfloat16,
+                   phi::dtype::complex<float>,
+                   phi::dtype::complex<double>) {}

--- a/paddle/phi/kernels/cpu/index_elementwise_put_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_elementwise_put_kernel.cc
@@ -35,6 +35,19 @@ void CPUIndexElementwisePutKernel(const phi::CPUContext& dev_ctx,
                                   DenseTensor* output) {
   int64_t numel = 0;
 
+  bool is_initialized = output->initialized();
+  bool is_same_place = true;
+
+  if (is_initialized) {
+    is_same_place = (input.place() == output->place());
+  }
+
+  T* output_ = dev_ctx.template Alloc<T>(output);
+
+  if (!is_initialized || !is_same_place) {
+    phi::Copy(dev_ctx, input, dev_ctx.GetPlace(), false, output);
+  }
+
   auto num_indices = index_dims.size();
 
   auto sizes = std::array<int64_t, 25>{};
@@ -73,7 +86,7 @@ void CPUIndexElementwisePutKernel(const phi::CPUContext& dev_ctx,
   using dtype = funcs::OpaqueType<sizeof(T)>;
 
   const char* in_ptr = reinterpret_cast<const char*>(value.data<T>());
-  char* out_ptr = reinterpret_cast<char*>(output->data<T>());
+  char* out_ptr = reinterpret_cast<char*>(output_);
 
   for (int64_t idx = 0; idx < N; idx++) {
     const auto offsets = offset_calc.cpu_get(idx);
@@ -113,7 +126,18 @@ void IndexElementwisePutKernel(const Context& dev_ctx,
                         index_type,
                         phi::DataType::INT64));
 
-  dev_ctx.template Alloc<T>(out);
+  if (out && out->numel() == 0) {
+    dev_ctx.template Alloc<T>(out);
+    return;
+  }
+
+  if (index.empty()) {
+    if (!out->initialized()) {
+      phi::Copy(dev_ctx, x, dev_ctx.GetPlace(), false, out);
+    }
+    return;
+  }
+
   if (out->numel() == 0) return;
   CPUIndexElementwisePutKernel<T, int64_t>(dev_ctx,
                                            x,

--- a/paddle/phi/kernels/funcs/index_elementwise.cu.h
+++ b/paddle/phi/kernels/funcs/index_elementwise.cu.h
@@ -21,18 +21,12 @@ limitations under the License. */
 
 #include "paddle/phi/backends/gpu/gpu_launch_config.h"
 #include "paddle/phi/backends/gpu/gpu_primitives.h"
-#include "paddle/phi/common/memory_utils.h"
-#include "paddle/phi/common/place.h"
-#include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/kernels/funcs/aligned_vector.h"
-#include "paddle/phi/kernels/funcs/math_function.h"
-#include "paddle/phi/kernels/funcs/stride_utils.h"
+#include "paddle/phi/kernels/funcs/index_elementwise_utils.h"
 #include "paddle/phi/kernels/primitive/kernel_primitives.h"
 
 namespace phi {
 namespace funcs {
-
-constexpr int MAX_DIMS = 9;
 
 static constexpr int launch_bound2 = 4;
 
@@ -51,11 +45,6 @@ __global__ void index_elementwise_kernel(const int64_t N, const func_t f) {
     }
   }
 }
-
-template <int N>
-struct alignas(N) OpaqueType {
-  char data[N];
-};
 
 template <typename Value>
 struct DivMod {
@@ -135,31 +124,6 @@ static OffsetCalculator<N, uint32_t, signed_strides> make_offset_calculator_put(
     std::vector<int64_t> desired_shape, std::array<int64_t*, N> strides_array) {
   return OffsetCalculator<N, uint32_t, signed_strides>(
       desired_shape.size(), desired_shape.data(), strides_array.data());
-}
-
-template <typename IndexT>
-std::array<char*, DDim::kMaxRank> GetIndexDataPtrs(
-    const std::vector<const DenseTensor*> index) {
-  std::array<char*, DDim::kMaxRank> index_ptrs{};
-
-  PADDLE_ENFORCE_LE(index.size(),
-                    DDim::kMaxRank,
-                    "The number of index tensors exceeds the maximum rank.");
-
-  for (size_t i = 0; i < index.size(); ++i) {
-    const IndexT* p_index = index[i]->data<IndexT>();
-
-    PADDLE_ENFORCE_NOT_NULL(
-        p_index,
-        ::common::errors::InvalidArgument(
-            "The pointer p_index is nullptr, "
-            "please check whether the index tensor is valid and "
-            "its data is correctly initialized."));
-
-    index_ptrs[i] = reinterpret_cast<char*>(const_cast<IndexT*>(p_index));
-  }
-
-  return index_ptrs;
 }
 
 template <int N, bool signed_strides = false>

--- a/paddle/phi/kernels/funcs/index_elementwise.cu.h
+++ b/paddle/phi/kernels/funcs/index_elementwise.cu.h
@@ -75,6 +75,10 @@ struct IntDivider {
     return DivMod<Value>(n / divisor, n % divisor);
   }
 
+  inline DivMod<Value> cpu_divmod(Value n) const {
+    return DivMod<Value>(n / divisor, n % divisor);
+  }
+
   Value divisor;
 };
 
@@ -116,6 +120,28 @@ struct OffsetCalculator {
         break;
       }
       auto divmod = sizes_[dim].divmod(linear_idx);
+      linear_idx = divmod.div;
+
+#pragma unroll
+      for (int arg = 0; arg < NARGS; arg++) {
+        offsets[arg] += divmod.mod * strides_[dim][arg];
+      }
+    }
+    return offsets;
+  }
+
+  offset_type cpu_get(index_t linear_idx) const {
+    offset_type offsets;
+#pragma unroll
+    for (int arg = 0; arg < NARGS; arg++) {
+      offsets[arg] = 0;
+    }
+#pragma unroll
+    for (int dim = 0; dim < MAX_DIMS; ++dim) {
+      if (dim == dims) {
+        break;
+      }
+      auto divmod = sizes_[dim].cpu_divmod(linear_idx);
       linear_idx = divmod.div;
 
 #pragma unroll

--- a/paddle/phi/kernels/funcs/index_elementwise.h
+++ b/paddle/phi/kernels/funcs/index_elementwise.h
@@ -19,21 +19,10 @@ limitations under the License. */
 #include <type_traits>
 #include <vector>
 
-#include "paddle/phi/common/memory_utils.h"
-#include "paddle/phi/common/place.h"
-#include "paddle/phi/core/dense_tensor.h"
-#include "paddle/phi/kernels/funcs/math_function.h"
-#include "paddle/phi/kernels/funcs/stride_utils.h"
+#include "paddle/phi/kernels/funcs/index_elementwise_utils.h"
 
 namespace phi {
 namespace funcs {
-
-constexpr int MAX_DIMS = 9;
-
-template <int N>
-struct alignas(N) CPUOpaqueType {
-  char data[N];
-};
 
 template <typename Value>
 struct CPUDivMod {
@@ -110,31 +99,6 @@ CPUmake_offset_calculator_put(std::vector<int64_t> desired_shape,
                               std::array<int64_t*, N> strides_array) {
   return CPUOffsetCalculator<N, uint32_t, signed_strides>(
       desired_shape.size(), desired_shape.data(), strides_array.data());
-}
-
-template <typename IndexT>
-std::array<char*, DDim::kMaxRank> CPUGetIndexDataPtrs(
-    const std::vector<const DenseTensor*> index) {
-  std::array<char*, DDim::kMaxRank> index_ptrs{};
-
-  PADDLE_ENFORCE_LE(index.size(),
-                    DDim::kMaxRank,
-                    "The number of index tensors exceeds the maximum rank.");
-
-  for (size_t i = 0; i < index.size(); ++i) {
-    const IndexT* p_index = index[i]->data<IndexT>();
-
-    PADDLE_ENFORCE_NOT_NULL(
-        p_index,
-        ::common::errors::InvalidArgument(
-            "The pointer p_index is nullptr, "
-            "please check whether the index tensor is valid and "
-            "its data is correctly initialized."));
-
-    index_ptrs[i] = reinterpret_cast<char*>(const_cast<IndexT*>(p_index));
-  }
-
-  return index_ptrs;
 }
 
 template <int N, bool signed_strides = false>

--- a/paddle/phi/kernels/funcs/index_elementwise.h
+++ b/paddle/phi/kernels/funcs/index_elementwise.h
@@ -19,74 +19,51 @@ limitations under the License. */
 #include <type_traits>
 #include <vector>
 
-#include "paddle/phi/backends/gpu/gpu_launch_config.h"
-#include "paddle/phi/backends/gpu/gpu_primitives.h"
 #include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/common/place.h"
 #include "paddle/phi/core/dense_tensor.h"
-#include "paddle/phi/kernels/funcs/aligned_vector.h"
 #include "paddle/phi/kernels/funcs/math_function.h"
 #include "paddle/phi/kernels/funcs/stride_utils.h"
-#include "paddle/phi/kernels/primitive/kernel_primitives.h"
 
 namespace phi {
 namespace funcs {
 
 constexpr int MAX_DIMS = 9;
 
-static constexpr int launch_bound2 = 4;
-
-static constexpr int launch_size_nd = 128;
-
-template <int nt, int vt, typename func_t>
-__global__ void index_elementwise_kernel(const int64_t N, const func_t f) {
-  const auto tid = threadIdx.x;
-  const auto nv = nt * vt;
-  auto idx = nv * blockIdx.x + tid;
-#pragma unroll
-  for (int i = 0; i < vt; i++) {
-    if (idx < N) {
-      f(idx);
-      idx += nt;
-    }
-  }
-}
-
 template <int N>
-struct alignas(N) OpaqueType {
+struct alignas(N) CPUOpaqueType {
   char data[N];
 };
 
 template <typename Value>
-struct DivMod {
+struct CPUDivMod {
   Value div, mod;
 
-  __host__ __device__ DivMod(Value div, Value mod) : div(div), mod(mod) {}
+  CPUDivMod(Value div, Value mod) : div(div), mod(mod) {}
 };
 
 template <typename Value>
-struct IntDivider {
-  IntDivider() = default;
-  explicit IntDivider(Value d) : divisor(d) {}
+struct CPUIntDivider {
+  CPUIntDivider() = default;
+  explicit CPUIntDivider(Value d) : divisor(d) {}
 
-  __host__ __device__ inline Value div(Value n) const { return n / divisor; }
-  __host__ __device__ inline Value mod(Value n) const { return n % divisor; }
-  __host__ __device__ inline DivMod<Value> divmod(Value n) const {
-    return DivMod<Value>(n / divisor, n % divisor);
+  inline CPUDivMod<Value> cpu_divmod(Value n) const {
+    return CPUDivMod<Value>(n / divisor, n % divisor);
   }
+
   Value divisor;
 };
 
 template <int NARGS, typename index_t = uint32_t, bool signed_strides = false>
-struct OffsetCalculator {
+struct CPUOffsetCalculator {
   using stride_t =
       std::conditional_t<signed_strides, std::make_signed_t<index_t>, index_t>;
   using offset_type = std::array<stride_t, std::max<int>(NARGS, 1)>;
 
-  OffsetCalculator(int dims,
-                   const int64_t* sizes,
-                   const int64_t* const* strides,
-                   const int64_t* element_sizes = nullptr)
+  CPUOffsetCalculator(int dims,
+                      const int64_t* sizes,
+                      const int64_t* const* strides,
+                      const int64_t* element_sizes = nullptr)
       : dims(dims) {
     PADDLE_ENFORCE_LE(
         dims,
@@ -94,7 +71,7 @@ struct OffsetCalculator {
         common::errors::InvalidArgument(
             "Tensor has too many dims. Maximum dim is d%.", MAX_DIMS));
     for (int i = 0; i < dims; i++) {
-      sizes_[i] = IntDivider<index_t>(sizes[i]);
+      sizes_[i] = CPUIntDivider<index_t>(sizes[i]);
       for (int arg = 0; arg < NARGS; arg++) {
         int64_t element_size =
             (element_sizes == nullptr ? 1LL : element_sizes[arg]);
@@ -103,21 +80,18 @@ struct OffsetCalculator {
     }
   }
 
-  __host__ __device__ offset_type get(index_t linear_idx) const {
+  offset_type cpu_get(index_t linear_idx) const {
     offset_type offsets;
-#pragma unroll
     for (int arg = 0; arg < NARGS; arg++) {
       offsets[arg] = 0;
     }
-#pragma unroll
     for (int dim = 0; dim < MAX_DIMS; ++dim) {
       if (dim == dims) {
         break;
       }
-      auto divmod = sizes_[dim].divmod(linear_idx);
+      auto divmod = sizes_[dim].cpu_divmod(linear_idx);
       linear_idx = divmod.div;
 
-#pragma unroll
       for (int arg = 0; arg < NARGS; arg++) {
         offsets[arg] += divmod.mod * strides_[dim][arg];
       }
@@ -126,19 +100,20 @@ struct OffsetCalculator {
   }
 
   int dims;
-  IntDivider<index_t> sizes_[MAX_DIMS];
+  CPUIntDivider<index_t> sizes_[MAX_DIMS];
   stride_t strides_[MAX_DIMS][std::max<int>(NARGS, 1)];
 };
 
 template <int N, bool signed_strides = false>
-static OffsetCalculator<N, uint32_t, signed_strides> make_offset_calculator_put(
-    std::vector<int64_t> desired_shape, std::array<int64_t*, N> strides_array) {
-  return OffsetCalculator<N, uint32_t, signed_strides>(
+static CPUOffsetCalculator<N, uint32_t, signed_strides>
+CPUmake_offset_calculator_put(std::vector<int64_t> desired_shape,
+                              std::array<int64_t*, N> strides_array) {
+  return CPUOffsetCalculator<N, uint32_t, signed_strides>(
       desired_shape.size(), desired_shape.data(), strides_array.data());
 }
 
 template <typename IndexT>
-std::array<char*, DDim::kMaxRank> GetIndexDataPtrs(
+std::array<char*, DDim::kMaxRank> CPUGetIndexDataPtrs(
     const std::vector<const DenseTensor*> index) {
   std::array<char*, DDim::kMaxRank> index_ptrs{};
 
@@ -163,16 +138,16 @@ std::array<char*, DDim::kMaxRank> GetIndexDataPtrs(
 }
 
 template <int N, bool signed_strides = false>
-static OffsetCalculator<N, uint32_t, signed_strides> make_offset_calculator(
-    int ndim,
-    const int64_t* shape,
-    const std::vector<std::vector<int64_t>>& strides) {
+static CPUOffsetCalculator<N, uint32_t, signed_strides>
+CPUmake_offset_calculator(int ndim,
+                          const int64_t* shape,
+                          const std::vector<std::vector<int64_t>>& strides) {
   std::array<const int64_t*, N> strides_array;
   for (int i = 0; i < N; ++i) {
     strides_array[i] = strides[i].data();
   }
 
-  return OffsetCalculator<N, uint32_t, signed_strides>(
+  return CPUOffsetCalculator<N, uint32_t, signed_strides>(
       ndim, shape, strides_array.data());
 }
 

--- a/paddle/phi/kernels/funcs/index_elementwise_utils.h
+++ b/paddle/phi/kernels/funcs/index_elementwise_utils.h
@@ -1,0 +1,64 @@
+/* Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <type_traits>
+#include <vector>
+
+#include "paddle/phi/common/memory_utils.h"
+#include "paddle/phi/common/place.h"
+#include "paddle/phi/core/dense_tensor.h"
+#include "paddle/phi/kernels/funcs/math_function.h"
+#include "paddle/phi/kernels/funcs/stride_utils.h"
+
+namespace phi {
+namespace funcs {
+
+constexpr int MAX_DIMS = 9;
+
+template <int N>
+struct alignas(N) OpaqueType {
+  char data[N];
+};
+
+template <typename IndexT>
+std::array<char*, DDim::kMaxRank> GetIndexDataPtrs(
+    const std::vector<const DenseTensor*> index) {
+  std::array<char*, DDim::kMaxRank> index_ptrs{};
+
+  PADDLE_ENFORCE_LE(index.size(),
+                    DDim::kMaxRank,
+                    "The number of index tensors exceeds the maximum rank.");
+
+  for (size_t i = 0; i < index.size(); ++i) {
+    const IndexT* p_index = index[i]->data<IndexT>();
+
+    PADDLE_ENFORCE_NOT_NULL(
+        p_index,
+        ::common::errors::InvalidArgument(
+            "The pointer p_index is nullptr, "
+            "please check whether the index tensor is valid and "
+            "its data is correctly initialized."));
+
+    index_ptrs[i] = reinterpret_cast<char*>(const_cast<IndexT*>(p_index));
+  }
+
+  return index_ptrs;
+}
+
+}  // namespace funcs
+}  // namespace phi

--- a/paddle/phi/kernels/funcs/stride_utils.h
+++ b/paddle/phi/kernels/funcs/stride_utils.h
@@ -73,7 +73,7 @@ static inline std::vector<int64_t> compute_strides(
     stride_bytes.resize(ndim, 0);
   else
     stride_bytes.resize(ndim);
-  for (int i = 0; i < original_shape.size(); i++) {
+  for (size_t i = 0; i < original_shape.size(); i++) {
     if (original_shape[i] == 1 && (*shape_)[offset + i] != 1) {
       stride_bytes[offset + i] = 0;
     } else {
@@ -105,7 +105,7 @@ static inline void permute_dimensions(const std::vector<int64_t> stride_size,
                                       std::vector<int64_t>* shape_) {
   auto reorder = [perm](std::vector<int64_t> data) {
     auto res = std::vector<int64_t>(data.size(), 0);
-    for (int64_t i = 0; i < perm.size(); i++) {
+    for (size_t i = 0; i < perm.size(); i++) {
       res[i] = data[perm[i]];
     }
     return res;
@@ -180,7 +180,7 @@ static inline void reorder_dimensions(const std::vector<int64_t> stride_size,
     return 0;
   };
   // insertion sort with support for ambiguous comparisons
-  for (int64_t i = 0; i < ndim; i++) {
+  for (size_t i = 0; i < ndim; i++) {
     int dim1 = i;
     for (int dim0 = i - 1; dim0 >= 0; dim0--) {
       int comparison = should_swap(perm_[dim0], perm_[dim1]);
@@ -230,10 +230,6 @@ static inline void coalesce_dimensions(const int64_t ndim,
                                        std::array<int64_t*, N>* strides_array,
                                        std::vector<int64_t>* stride_size,
                                        std::vector<int64_t>* shape_) {
-  for (size_t i = 0; i < N; i++) {
-    int64_t* stride_tmp = (*strides_array)[i];
-  }
-
   if (ndim <= 1) {
     return;
   }
@@ -333,7 +329,7 @@ static inline void IndexPutStride(
   coalesce_dimensions<N>(ndim, strides_array, &stride_size, desired_shape);
 
   int num = 1;
-  for (int i = 0; i < desired_shape->size(); i++) {
+  for (size_t i = 0; i < desired_shape->size(); i++) {
     num *= (*desired_shape)[i];
   }
   *numel = num;

--- a/paddle/phi/kernels/funcs/stride_utils.h
+++ b/paddle/phi/kernels/funcs/stride_utils.h
@@ -388,7 +388,7 @@ static inline void IndexGetStride(
   coalesce_dimensions<N>(ndim, strides_array, &stride_size, desired_shape);
 
   int num = 1;
-  for (int i = 0; i < desired_shape->size(); i++) {
+  for (size_t i = 0; i < desired_shape->size(); i++) {
     num *= (*desired_shape)[i];
   }
   *numel = num;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
pcard-67164

Add CPU kernel support for index_elementwise_put, index_elementwise_put_grad, index_elementwise_get, index_elementwise_get_grad. Remove redundant code in eager_method.cc.