### PR TITLE
Support 0 size tensor in ProcessGroupCustom::AllToAll

### DIFF
--- a/paddle/fluid/distributed/collective/process_group_custom.cc
+++ b/paddle/fluid/distributed/collective/process_group_custom.cc
@@ -284,8 +284,10 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupCustom::AllToAll(
       [&](const phi::stream::Stream& stream) {
         auto comm_context = this->GetCommContext();
 
-        int64_t in_row_size = in_tensor.numel() / in_dim[0],
-                out_row_size = out_tensor->numel() / out_dim[0];
+        int64_t in_row_size =
+            in_dim[0] == 0 ? 0 : in_tensor.numel() / in_dim[0];
+        int64_t out_row_size =
+            out_dim[0] == 0 ? 0 : out_tensor->numel() / out_dim[0];
         int64_t in_offset = 0, in_numel = 0, out_offset = 0, out_numel = 0;
         phi::DenseTensor input_partial, output_partial;
 

--- a/paddle/fluid/distributed/collective/process_group_custom.cc
+++ b/paddle/fluid/distributed/collective/process_group_custom.cc
@@ -25,6 +25,7 @@
 #include "paddle/phi/core/utils/data_type.h"
 
 #include "paddle/phi/core/distributed/comm_context_manager.h"
+#include "paddle/utils/string/string_helper.h"
 
 constexpr int64_t kWaitBlockTImeout = 10;
 
@@ -290,6 +291,22 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupCustom::AllToAll(
             out_dim[0] == 0 ? 0 : out_tensor->numel() / out_dim[0];
         int64_t in_offset = 0, in_numel = 0, out_offset = 0, out_numel = 0;
         phi::DenseTensor input_partial, output_partial;
+
+        VLOG(3) << "[AllToAll] "
+                << "sendbuff: " << in_tensor.data()
+                << ", recvbuff: " << out_tensor->data()
+                << ", count: " << in_tensor.numel()
+                << ", datatype: " << phi::DataTypeToString(in_tensor.dtype())
+                << ", xcclcomm: " << comm_context->GetXcclComm()
+                << ", stream address: " << &stream
+                << ", rank_in_group: " << rank_ << ", nranks: " << size_
+                << ", out_split_sizes: "
+                << string::join_strings(out_split_sizes, ',')
+                << ", in_split_sizes: "
+                << string::join_strings(in_split_sizes, ',')
+                << ", sync_op: " << sync_op
+                << ", use_calc_stream: " << use_calc_stream << ", "
+                << GetGroupMessage();
 
         std::vector<void*> send_buf, recv_buf;
         std::vector<size_t> send_count, recv_count;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Custom Device

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-67164
Support 0 size tensor in ProcessGroupCustom::AllToAll.
The error occurs when ​​all values in the out_split_sizes tensor are zero for a specific device​​. This indicates that the corresponding output tensor (out_tensor) on this device is empty​​. In this scenario, the dim[0] of out_tensor becomes ​​0​​. Subsequent operations attempt to divide by this zero dimension value, triggering a division-by-zero error.
This change has been verified on Metax backend.