### PR TITLE
[0-size Tensor Job2 No.66] Add 0-size Tensor support for paddle.nn.functional.softmax_with_cross_entropy

### DIFF
--- a/paddle/phi/kernels/cpu/cross_entropy_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/cross_entropy_grad_kernel.cc
@@ -34,6 +34,11 @@ void CrossEntropyWithSoftmaxGradCPUKernel(const CPUContext& dev_ctx,
                                           int ignore_index,
                                           int axis,
                                           DenseTensor* logits_grad) {
+  if (logits_grad->numel() == 0) {
+    dev_ctx.template Alloc<T>(logits_grad);
+    return;
+  }
+
   const DenseTensor* out_grad = &loss_grad;
   DenseTensor* logit_grad = logits_grad;
 

--- a/paddle/phi/kernels/gpu/cross_entropy_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/cross_entropy_grad_kernel.cu
@@ -241,6 +241,10 @@ void CrossEntropyWithSoftmaxGradKernel(const Context& dev_ctx,
                                        int ignore_index,
                                        int axis,
                                        DenseTensor* logits_grad) {
+  if (logits_grad->numel() == 0) {
+    dev_ctx.template Alloc<T>(logits_grad);
+    return;
+  }
   auto dtype = label.dtype();
   if (soft_label) {
     PADDLE_ENFORCE_EQ(

--- a/paddle/phi/kernels/xpu/cross_entropy_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/cross_entropy_grad_kernel.cc
@@ -33,6 +33,9 @@ void CrossEntropyWithSoftmaxGradKernel(const Context& dev_ctx,
                                        DenseTensor* logit_grad) {
   using XPUType = typename XPUTypeTrait<T>::Type;
   dev_ctx.template Alloc<T>(logit_grad);
+  if (logit_grad->numel() == 0) {
+    return;
+  }
 
   const int rank = logit_grad->dims().size();
   const int axis = phi::funcs::CanonicalAxis(axis_in, rank);

--- a/test/legacy_test/test_cross_entropy_op.py
+++ b/test/legacy_test/test_cross_entropy_op.py
@@ -468,5 +468,34 @@ class TestCrossEntropyOpError(unittest.TestCase):
             self.assertRaises(ValueError, test_input_dims)
 
 
+class TestCrossEntropyOp_ZeroSize(TestCrossEntropyOp):
+    def setUp(self):
+        self.op_type = "cross_entropy"
+        self.python_api = api_wrapper
+        self.soft_label = False
+        self.ignore_index = -100
+        self.dtype = np.float64
+        # 0-size
+        self.batch_size = 0
+        self.class_num = 10
+
+        self.init_dtype_type()
+        self.init_attr_type()
+        self.init_bs_class_num()
+        self.init_x()
+        self.init_label()
+        self.get_cross_entropy()
+
+        self.inputs = {"X": self.x, "Label": self.label}
+        self.outputs = {"Y": self.cross_entropy}
+        self.attrs = {
+            "soft_label": self.soft_label,
+            "ignore_index": self.ignore_index,
+        }
+
+    def get_cross_entropy(self):
+        self.cross_entropy = np.random.random([0, 1]).astype(np.float64)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
66 paddle.nn.functional.softmax_with_cross_entropy

soft_label 为False时，axis 所在列不能为0，其他列相同，所以 softmax, loss的numel 都为0，这里判断softmax 的numel为0
https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/nn/functional/softmax_with_cross_entropy_cn.html#softmax-with-cross-entropy
![image](https://github.com/user-attachments/assets/b8cc64f8-8894-4991-9517-817df9a0c9c5)

PaddleAPITest 测试通过，错误为numpy error
![image](https://github.com/user-attachments/assets/adf92528-a044-47b3-a400-320a0545f4f5)


55 paddle.nn.functional.cross_entropy - part
soft_label 为True时，loss维度中axis所在列设置为1，返回填充0
其中，在python端，如果reduction为mean，返回填充需要修改为nan，因为需要调试性能问题，这部分没有修改，在其他PR再修改
PaddleAPITest 测试通过，错误为numpy error
<img width="1338" height="310" alt="image" src="https://github.com/user-attachments/assets/bf50fe8e-8fc0-41a1-ad20-477c35556f58" />

