### PR TITLE
[0-size Tensor Job2 No.76] Add 0-size Tensor support for paddle.slice_scatter [fluid_ops] 

### DIFF
--- a/paddle/phi/kernels/gpu/set_value_kernel.cu
+++ b/paddle/phi/kernels/gpu/set_value_kernel.cu
@@ -42,6 +42,11 @@ void SetTensorValueKernelV2(const Context& dev_ctx,
                             const std::vector<int64_t>& decrease_axes,
                             const std::vector<int64_t>& none_axes,
                             DenseTensor* out) {
+  if (in.numel() == 0) {
+    dev_ctx.template Alloc<T>(out);
+    return;
+  }
+
   auto in_dims = in.dims();
   auto meta = in.meta();
   std::vector<int64_t> starts_local = starts.GetData();

--- a/paddle/phi/kernels/impl/set_value_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/set_value_grad_kernel_impl.h
@@ -259,8 +259,8 @@ void SetValueGradKernel(const Context& dev_ctx,
                         DenseTensor* x_grad,
                         DenseTensor* value_grad) {
   if (out_grad.numel() == 0) {
-    dev_ctx.template Alloc<T>(x_grad);
-    dev_ctx.template Alloc<T>(value_grad);
+    if (x_grad) dev_ctx.template Alloc<T>(x_grad);
+    if (value_grad) dev_ctx.template Alloc<T>(value_grad);
     return;
   }
   const int rank = out_grad.dims().size();

--- a/paddle/phi/kernels/impl/set_value_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/set_value_grad_kernel_impl.h
@@ -258,6 +258,11 @@ void SetValueGradKernel(const Context& dev_ctx,
                         const std::vector<int64_t>& none_axes,
                         DenseTensor* x_grad,
                         DenseTensor* value_grad) {
+  if (out_grad.numel() == 0) {
+    dev_ctx.template Alloc<T>(x_grad);
+    dev_ctx.template Alloc<T>(value_grad);
+    return;
+  }
   const int rank = out_grad.dims().size();
   std::vector<int64_t> starts_local = starts.GetData();
   std::vector<int64_t> ends_local = ends.GetData();

--- a/paddle/phi/kernels/impl/set_value_kernel_impl.h
+++ b/paddle/phi/kernels/impl/set_value_kernel_impl.h
@@ -149,6 +149,11 @@ void SetTensorValueKernel(const Context& dev_ctx,
                           const std::vector<int64_t>& decrease_axes,
                           const std::vector<int64_t>& none_axes,
                           DenseTensor* out) {
+  if (in.numel() == 0) {
+    dev_ctx.template Alloc<T>(out);
+    return;
+  }
+
   const int rank = x.dims().size();
 
   switch (rank) {

--- a/paddle/phi/kernels/impl/set_value_kernel_impl.h
+++ b/paddle/phi/kernels/impl/set_value_kernel_impl.h
@@ -149,7 +149,7 @@ void SetTensorValueKernel(const Context& dev_ctx,
                           const std::vector<int64_t>& decrease_axes,
                           const std::vector<int64_t>& none_axes,
                           DenseTensor* out) {
-  if (in.numel() == 0) {
+  if (x.numel() == 0) {
     dev_ctx.template Alloc<T>(out);
     return;
   }

--- a/paddle/phi/kernels/xpu/set_value_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/set_value_grad_kernel.cc
@@ -315,8 +315,8 @@ void SetValueGradKernel(const Context& dev_ctx,
                         DenseTensor* x_grad,
                         DenseTensor* value_grad) {
   if (out_grad.numel() == 0) {
-    dev_ctx.template Alloc<T>(x_grad);
-    dev_ctx.template Alloc<T>(value_grad);
+    if (x_grad) dev_ctx.template Alloc<T>(x_grad);
+    if (value_grad) dev_ctx.template Alloc<T>(value_grad);
     return;
   }
   const int rank = out_grad.dims().size();

--- a/paddle/phi/kernels/xpu/set_value_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/set_value_grad_kernel.cc
@@ -314,6 +314,11 @@ void SetValueGradKernel(const Context& dev_ctx,
                         const std::vector<int64_t>& none_axes,
                         DenseTensor* x_grad,
                         DenseTensor* value_grad) {
+  if (out_grad.numel() == 0) {
+    dev_ctx.template Alloc<T>(x_grad);
+    dev_ctx.template Alloc<T>(value_grad);
+    return;
+  }
   const int rank = out_grad.dims().size();
 
   switch (rank) {

--- a/paddle/phi/kernels/xpu/set_value_kernel.cc
+++ b/paddle/phi/kernels/xpu/set_value_kernel.cc
@@ -367,6 +367,10 @@ void SetTensorValueKernel(const Context& dev_ctx,
                           const std::vector<int64_t>& decrease_axes,
                           const std::vector<int64_t>& none_axes,
                           DenseTensor* out) {
+  if (x.numel() == 0) {
+    dev_ctx.template Alloc<T>(out);
+    return;
+  }
   SetValueKernelImpl<T, Context>(dev_ctx,
                                  x,
                                  value.data<T>(),


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/slice_scatter_cn.html#slice-scatter

slice_scatter 调用set_value_with_tensor
https://github.com/PaddlePaddle/Paddle/blob/95460c99f652e42ca441cc74e9b4a00fdba00d16/python/paddle/tensor/manipulation.py#L7666
![image](https://github.com/user-attachments/assets/090e5f5e-526d-4561-bb9c-f503378bb320)

修改前向和反向
输出维度和输入维度相同
![image](https://github.com/user-attachments/assets/c6098032-9920-433f-9570-4682e25dae59)

PaddleAPITest 测试通过
![image](https://github.com/user-attachments/assets/06a46fa3-42e7-47ed-be74-3e1db5ca1aad)
