### PR TITLE
[Auto-Parallel] fix bug of placements in all2all for moe

### DIFF
--- a/python/paddle/distributed/auto_parallel/moe_utils.py
+++ b/python/paddle/distributed/auto_parallel/moe_utils.py
@@ -202,7 +202,7 @@ class _NdMeshAlltoAll(PyLayer):
         ctx.out_placements = copy.deepcopy(placements)
 
         local_shape = _cal_local_shape(
-            dist_tensor.shape, sub_mesh, dist_tensor.placements
+            dist_tensor.shape, sub_mesh, [dist_tensor.placements[dim]]
         )
         out = _dtensor_from_local(
             dist_tensor._local_value(),
@@ -211,7 +211,7 @@ class _NdMeshAlltoAll(PyLayer):
             local_shape,
         )
         out = dist.reshard(out, sub_mesh, [placements[dim]])
-        local_shape = _cal_local_shape(out.shape, mesh, out.placements)
+        local_shape = _cal_local_shape(out.shape, sub_mesh, out.placements)
         out = _dtensor_from_local(
             out._local_value(), mesh, placements, local_shape
         )


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes 

### Description
<!-- Describe what you’ve done -->
fix bug of placements in all2all for moe.
- Use sub-placements instead of placements to calculate local shape
PCard-86802