### PR TITLE
Fix paddle.vision.ops.yolo_loss for big tensor

### DIFF
--- a/paddle/phi/kernels/cpu/yolo_loss_functor.h
+++ b/paddle/phi/kernels/cpu/yolo_loss_functor.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <iostream>
 namespace phi {
 
 template <typename T>
@@ -36,14 +37,15 @@ static inline Box<T> GetGtBox(const T* gt, int batch, int max_boxes, int idx) {
   return b;
 }
 
-static inline int GetEntryIndex(int batch,
-                                int an_idx,
-                                int hw_idx,
-                                int an_num,
-                                int an_stride,
-                                int stride,
-                                int entry) {
-  return (batch * an_num + an_idx) * an_stride + entry * stride + hw_idx;
+static inline int64_t GetEntryIndex(int batch,
+                                    int an_idx,
+                                    int hw_idx,
+                                    int an_num,
+                                    int an_stride,
+                                    int stride,
+                                    int entry) {
+  return (static_cast<int64_t>(batch) * an_num + an_idx) * an_stride +
+         entry * stride + hw_idx;
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/cpu/yolo_loss_functor.h
+++ b/paddle/phi/kernels/cpu/yolo_loss_functor.h
@@ -14,7 +14,6 @@
 
 #pragma once
 
-#include <iostream>
 namespace phi {
 
 template <typename T>

--- a/paddle/phi/kernels/cpu/yolo_loss_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/yolo_loss_grad_kernel.cc
@@ -41,7 +41,7 @@ static void CalcBoxLocationLossGrad(T* input_grad,
                                     Box<T> gt,
                                     std::vector<int> anchors,
                                     int an_idx,
-                                    int box_idx,
+                                    int64_t box_idx,
                                     int gi,
                                     int gj,
                                     int grid_size,
@@ -68,7 +68,7 @@ template <typename T>
 static inline void CalcLabelLossGrad(T* input_grad,
                                      const T loss,
                                      const T* input,
-                                     const int index,
+                                     const int64_t index,
                                      const int label,
                                      const int class_num,
                                      const int stride,
@@ -190,7 +190,7 @@ void YoloLossGradKernel(const Context& dev_ctx,
         int gi = static_cast<int>(gt.x * w);
         int gj = static_cast<int>(gt.y * h);
 
-        int box_idx = GetEntryIndex(
+        int64_t box_idx = GetEntryIndex(
             i, mask_idx, gj * w + gi, mask_num, an_stride, stride, 0);
         CalcBoxLocationLossGrad<T>(input_grad_data,
                                    loss_grad_data[i],
@@ -207,7 +207,7 @@ void YoloLossGradKernel(const Context& dev_ctx,
                                    score);
 
         int label = gt_label_data[i * b + t];
-        int label_idx = GetEntryIndex(
+        int64_t label_idx = GetEntryIndex(
             i, mask_idx, gj * w + gi, mask_num, an_stride, stride, 5);
         CalcLabelLossGrad<T>(input_grad_data,
                              loss_grad_data[i],


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
非法配置已根据文档修改为以下内容
```sh
paddle.vision.ops.yolo_loss(Tensor([2863312, 30, 5, 5],"float64"), gt_box=Tensor([2863312, 5, 4],"float64"), gt_label=Tensor([2863312, 5],"int32"), anchors=list[10,13,16,30,33,23,30,61,62,45,59,119,116,90,156,198,373,326,], anchor_mask=list[0,1,2,], class_num=5, ignore_thresh=0.7, downsample_ratio=32, gt_score=None, use_label_smooth=True, scale_x_y=1.0, )
paddle.vision.ops.yolo_loss(Tensor([2863312, 30, 5, 5],"float64"), gt_box=Tensor([2863312, 5, 4],"float64"), gt_label=Tensor([2863312, 5],"int32"), anchors=list[10,13,16,30,33,23,30,61,62,45,59,119,116,90,156,198,373,326,], anchor_mask=list[0,1,2,], class_num=5, ignore_thresh=0.7, downsample_ratio=32, gt_score=Tensor([2863312, 5],"float64"), use_label_smooth=False, scale_x_y=1.0, )
paddle.vision.ops.yolo_loss(Tensor([2863312, 30, 5, 5],"float64"), gt_box=Tensor([2863312, 5, 4],"float64"), gt_label=Tensor([2863312, 5],"int32"), anchors=list[10,13,16,30,33,23,30,61,62,45,59,119,116,90,156,198,373,326,], anchor_mask=list[0,1,2,], class_num=5, ignore_thresh=0.7, downsample_ratio=32, gt_score=Tensor([2863312, 5],"float64"), use_label_smooth=True, scale_x_y=1.0, )
paddle.vision.ops.yolo_loss(Tensor([4793491, 14, 8, 8],"float32"), gt_box=Tensor([4793491, 10, 4],"float32"), gt_label=Tensor([4793491, 10],"int32"), anchors=list[10,13,16,30,], anchor_mask=list[0,1,], class_num=2, ignore_thresh=0.7, downsample_ratio=8, use_label_smooth=True, scale_x_y=1.0, )
paddle.vision.ops.yolo_loss(x=Tensor([11665, 255, 38, 38],"float32"), gt_box=Tensor([11665, 1, 4],"float32"), gt_label=Tensor([11665, 1],"int32"), gt_score=Tensor([11665, 1],"float32"), anchors=list[10,13,16,30,33,23,30,61,62,45,59,119,116,90,156,198,373,326,], anchor_mask=list[3,4,5,], class_num=80, ignore_thresh=0.7, downsample_ratio=16, use_label_smooth=True, )
paddle.vision.ops.yolo_loss(x=Tensor([2917, 255, 76, 76],"float32"), gt_box=Tensor([11665, 1, 4],"float32"), gt_label=Tensor([11665, 1],"int32"), gt_score=Tensor([11665, 1],"float32"), anchors=list[10,13,16,30,33,23,30,61,62,45,59,119,116,90,156,198,373,326,], anchor_mask=list[0,1,2,], class_num=80, ignore_thresh=0.7, downsample_ratio=8, use_label_smooth=True, )
```

问题出现在 GetEntryIndex 返回值的溢出，改为int64并修改其他对应位置即可
![image](https://github.com/user-attachments/assets/e7d7770b-8066-402a-bb2f-70d5c567f486)

Pcard-67164