### PR TITLE
[Phi] Fix einsum kernel for big tensor

### DIFF
--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -1255,8 +1255,8 @@ void EinsumInferMeta(const std::vector<const MetaTensor*>& inputs,
   LabelMap labeltype(LabelType::Reduction);
   std::vector<LabelMap> label2perms(inputs.size(), LabelMap(-1));
   std::vector<char> all_labels;
-  std::vector<int> output_dims;
-  std::vector<std::vector<int>> broadcast_shapes(2);
+  std::vector<int64_t> output_dims;
+  std::vector<std::vector<int64_t>> broadcast_shapes(2);
 
   std::vector<DDim> input_dims;
   for (auto& i : inputs) {

--- a/paddle/phi/kernels/impl/tile_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/tile_grad_kernel_impl.h
@@ -27,8 +27,8 @@ namespace phi {
 template <typename Context, typename T, int Dims>
 void TileBackward(const Context& dev_ctx,
                   const DenseTensor& out_grad,
-                  const std::vector<int>& reshape_dims_vec,
-                  const std::vector<int>& reduce_dims_vec,
+                  const std::vector<int64_t>& reshape_dims_vec,
+                  const std::vector<int64_t>& reduce_dims_vec,
                   DenseTensor* x_grad) {
   size_t reshape_size = reshape_dims_vec.size();
   size_t reduce_size = reduce_dims_vec.size();
@@ -86,7 +86,7 @@ void TileGradKernel(const Context& dev_ctx,
                     const IntArray& repeat_times,
                     DenseTensor* x_grad) {
   auto x_dims = x.dims();
-  auto vec_x_dims = common::vectorize<int>(x_dims);
+  auto vec_x_dims = common::vectorize<int64_t>(x_dims);
   auto repeat_times_data = repeat_times.GetData();
   if (repeat_times_data.size() < vec_x_dims.size()) {
     int diff = vec_x_dims.size() - repeat_times_data.size();
@@ -99,8 +99,8 @@ void TileGradKernel(const Context& dev_ctx,
   // 2. reduce_dims_vec is the dimension parameter to compute gradients. For
   //    each dimension expanded, the gradients should be summed to original
   //    size.
-  std::vector<int> reshape_dims_vec;
-  std::vector<int> reduce_dims_vec;
+  std::vector<int64_t> reshape_dims_vec;
+  std::vector<int64_t> reduce_dims_vec;
   for (size_t i = 0; i < repeat_times_data.size(); ++i) {
     reduce_dims_vec.push_back(reshape_dims_vec.size());
     reshape_dims_vec.push_back(repeat_times_data[i]);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
将einsum的前向和反向kernel与shape有关的参数类型改为int64_t，支持大Tensor运算。
float16的精度问题仍然存在，预测与matmul kernel相关。