### PR TITLE
Fix Place in Select Kernel

### DIFF
--- a/paddle/phi/kernels/funcs/select_impl.cu.h
+++ b/paddle/phi/kernels/funcs/select_impl.cu.h
@@ -537,7 +537,6 @@ void RestrictSelectKernel(const KPDevice &dev_ctx,
   using CT = int64_t;  // set Count_data Type
   const int t_size = sizeof(CT);
 
-  // const phi::GPUPlace &cuda_place = dev_ctx.GetPlace();
   const phi::Place &cuda_place = dev_ctx.GetPlace();
   phi::CPUPlace cpu_place = phi::CPUPlace();
 

--- a/paddle/phi/kernels/funcs/select_impl.cu.h
+++ b/paddle/phi/kernels/funcs/select_impl.cu.h
@@ -396,7 +396,7 @@ void SelectKernel(const KPDevice &dev_ctx,
   using CT = int64_t;  // set Count_data Type
   const int t_size = sizeof(CT);
 
-  const phi::GPUPlace &cuda_place = dev_ctx.GetPlace();
+  const phi::Place &cuda_place = dev_ctx.GetPlace();
   phi::CPUPlace cpu_place = phi::CPUPlace();
 
   // 1.1 get stored data num of per block
@@ -537,7 +537,8 @@ void RestrictSelectKernel(const KPDevice &dev_ctx,
   using CT = int64_t;  // set Count_data Type
   const int t_size = sizeof(CT);
 
-  const phi::GPUPlace &cuda_place = dev_ctx.GetPlace();
+  // const phi::GPUPlace &cuda_place = dev_ctx.GetPlace();
+  const phi::Place &cuda_place = dev_ctx.GetPlace();
   phi::CPUPlace cpu_place = phi::CPUPlace();
 
   // 1.1 get stored data num of per block


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Custom Device 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-67164
CUDA Custom Device backends used wrong place when executing the copy operation.
