### PR TITLE
Fix TransformLocalIndicesToIters corner case.

### DIFF
--- a/paddle/cinn/ir/schedule/impl/loop_transformation.cc
+++ b/paddle/cinn/ir/schedule/impl/loop_transformation.cc
@@ -120,7 +120,9 @@ std::vector<Expr> DyScheduleImpl::Split(const Expr& loop,
     std::vector<Var> new_loop_vars;
     Expr substitute_value(0);
     for (int i = 0; i < processed_factors.size(); ++i) {
-      Var temp_var(cinn::common::UniqName(for_node->loop_var->name));
+      Var temp_var(Expr(0),
+                   Expr(processed_factors[i]),
+                   cinn::common::UniqName(for_node->loop_var->name));
       substitute_value =
           Expr(temp_var) + substitute_value * Expr(processed_factors[i]);
       new_loop_vars.push_back(temp_var);
@@ -227,7 +229,9 @@ std::vector<Expr> DyScheduleImpl::Split(const Expr& loop,
   std::vector<Var> new_loop_vars;
   Expr substitute_value(0);
   for (int i = 0; i < process_factors.size(); ++i) {
-    Var temp_var(common::UniqName(for_node->loop_var->name));
+    Var temp_var(Expr(0),
+                 process_factors[i],
+                 common::UniqName(for_node->loop_var->name));
     substitute_value = Expr(temp_var) + substitute_value * process_factors[i];
     new_loop_vars.push_back(temp_var);
   }
@@ -338,7 +342,9 @@ std::vector<Expr> DyScheduleImpl::Split(const Expr& loop,
   std::vector<Var> new_loop_vars;
   Expr substitute_value(0);
   for (int i = 0; i < process_factors.size(); ++i) {
-    Var temp_var(common::UniqName(for_node->loop_var->name));
+    Var temp_var(Expr(0),
+                 process_factors[i],
+                 common::UniqName(for_node->loop_var->name));
     substitute_value = Expr(temp_var) + substitute_value * process_factors[i];
     new_loop_vars.push_back(temp_var);
   }

--- a/test/cpp/pir/cinn/CMakeLists.txt
+++ b/test/cpp/pir/cinn/CMakeLists.txt
@@ -44,6 +44,9 @@ if(WITH_TESTING AND WITH_CINN)
 
   paddle_test(ir_simplify_test SRCS ir_simplify_test.cc)
 
+  paddle_test(eliminate_common_factor_of_local_index_test SRCS
+              eliminate_common_factor_of_local_index_test.cc)
+
   # DO NOT forget add test name here, otherwise it will not be executed in
   # CINN CI.
   set(cinn_unit_tests

--- a/test/cpp/pir/cinn/eliminate_common_factor_of_local_index_test.cc
+++ b/test/cpp/pir/cinn/eliminate_common_factor_of_local_index_test.cc
@@ -1,0 +1,192 @@
+// Copyright (c) 2025 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/cinn/optim/eliminate_common_factor_of_local_index.h"
+
+#include <gtest/gtest.h>
+
+#include "paddle/cinn/cinn.h"
+#include "paddle/cinn/ir/ir.h"
+#include "paddle/cinn/ir/ir_printer.h"
+#include "paddle/cinn/ir/op/ir_operators.h"
+#include "paddle/cinn/ir/schedule/ir_schedule.h"
+#include "paddle/cinn/ir/utils/ir_nodes_collector.h"
+#include "paddle/cinn/ir/utils/stmt_converter.h"
+#include "paddle/cinn/utils/string.h"
+
+namespace cinn {
+namespace optim {
+
+/*
+{
+  serial for (i_0, 0, 32) {
+    serial for (j_0, 0, 4) {
+      var_local[((i_0 * 3) + j_0), ((j_0 * 32) / 128)] =
+      var_global_in[i_0, ((j_0 * 32) / 128)]
+      var_global_out[((i_0 * 3) + j_0), j_0] =
+      var_local[((i_0 * 3) + j_0), ((j_0 * 32) / 128)]
+    }
+  }
+}
+*/
+TEST(EliminateCommonFactorOfLocalIndex, SimplifyLocalIndex) {
+  Context::Global().ResetNameId();
+
+  // Create input IR matching the specified pattern
+  const std::vector<ir::Expr> shape = {ir::Expr(128), ir::Expr(128)};
+  //   const std::vector<ir::Expr> indices = {ir::Expr(0)};
+  ir::Tensor var_global_in =
+      ir::_Tensor_::Make("var_global_in", ir::Float(32), shape, shape);
+  var_global_in->WithBuffer("global", "var_global_in_buffer");
+  ir::Tensor var_local_tensor =
+      ir::_Tensor_::Make("var_local", ir::Float(32), shape, shape);
+  var_local_tensor->WithBuffer("local", "var_local_buffer");
+  ir::Tensor var_global_out =
+      ir::_Tensor_::Make("var_global_out", ir::Float(32), shape, shape);
+  var_global_out->WithBuffer("global", "var_global_out_buffer");
+
+  ir::Var var_i_0 = ir::Var(ir::Expr(0), ir::Expr(32), "i_0");
+  ir::Var var_j_0 = ir::Var(ir::Expr(0), ir::Expr(4), "j_0");
+
+  std::vector<ir::Expr> block_contents = {
+      ir::Store::Make(
+          var_local_tensor,
+          ir::Load::Make(var_global_in, {var_i_0, (var_j_0 * 32) / 128}),
+          {var_i_0 * 3 + var_j_0, (var_j_0 * 32) / 128}),
+      ir::Store::Make(
+          var_global_out,
+          ir::Load::Make(var_local_tensor,
+                         {var_i_0 * 3 + var_j_0, (var_j_0 * 32) / 128}),
+          {var_i_0 * 3 + var_j_0, var_j_0})};
+
+  ir::Expr inner_loop_body = ir::Block::Make(block_contents);
+
+  std::vector<ir::Expr> j_loop_contents = {inner_loop_body};
+  ir::Expr j_loop = ir::For::Make(var_j_0,
+                                  ir::Expr(0),
+                                  ir::Expr(4),
+                                  ir::ForType::Serial,
+                                  ir::DeviceAPI::Host,
+                                  ir::Block::Make(j_loop_contents));
+
+  std::vector<ir::Expr> i_loop_contents = {j_loop};
+  ir::Expr loop_body = ir::For::Make(var_i_0,
+                                     ir::Expr(0),
+                                     ir::Expr(32),
+                                     ir::ForType::Serial,
+                                     ir::DeviceAPI::Host,
+                                     ir::Block::Make(i_loop_contents));
+
+  std::vector<ir::Expr> ij_loop_contents = {loop_body};
+  ir::Expr expr = ir::Block::Make(ij_loop_contents);
+
+  ir::stmt::BlockRef block = ir::ConvertExprBlockToStmtBlock(expr);
+  VLOG(6) << "Before EliminateCommonFactorOfLocalIndex: " << block;
+  EliminateCommonFactorOfLocalIndex(block);
+  VLOG(6) << "After EliminateCommonFactorOfLocalIndex: " << block;
+
+  // Expected output verification
+  std::string expected_ir = R"ROC({
+  serial for (i_0, 0, 32) {
+    serial for (j_0, 0, 4) {
+      var_local[i_0, j_0] = var_global_in[i_0, ((j_0 * 32) / 128)]
+      var_global_out[((i_0 * 3) + j_0), j_0] = var_local[i_0, j_0]
+    }
+  }
+})ROC";
+
+  EXPECT_EQ(utils::GetStreamCnt(block), utils::Trim(expected_ir));
+}
+
+/*
+{
+  serial for (i_0, 0, 32) {
+    serial for (j_0, 0, 4) {
+      var_local[(i_0 * 3), ((j_0 * 32) / 128)] =
+      var_global_in[i_0, ((j_0 * 32) / 128)]
+      var_global_out[((i_0 * 3) + j_0), j_0] =
+      var_local[(i_0 * 3), ((j_0 * 32) / 128)]
+    }
+  }
+}
+*/
+TEST(EliminateCommonFactorOfLocalIndex, SimplifyLocalIndexWithZeroIndex) {
+  Context::Global().ResetNameId();
+
+  // Create input IR matching the specified pattern
+  const std::vector<ir::Expr> shape = {ir::Expr(128), ir::Expr(128)};
+  //   const std::vector<ir::Expr> indices = {ir::Expr(0)};
+  ir::Tensor var_global_in =
+      ir::_Tensor_::Make("var_global_in", ir::Float(32), shape, shape);
+  var_global_in->WithBuffer("global", "var_global_in_buffer");
+  ir::Tensor var_local_tensor =
+      ir::_Tensor_::Make("var_local", ir::Float(32), shape, shape);
+  var_local_tensor->WithBuffer("local", "var_local_buffer");
+  ir::Tensor var_global_out =
+      ir::_Tensor_::Make("var_global_out", ir::Float(32), shape, shape);
+  var_global_out->WithBuffer("global", "var_global_out_buffer");
+
+  ir::Var var_i_0 = ir::Var(ir::Expr(0), ir::Expr(32), "i_0");
+  ir::Var var_j_0 = ir::Var(ir::Expr(0), ir::Expr(4), "j_0");
+
+  std::vector<ir::Expr> block_contents = {
+      ir::Store::Make(
+          var_local_tensor,
+          ir::Load::Make(var_global_in, {var_i_0, var_j_0 * 32 / 128}),
+          {var_i_0 * 3, var_j_0 * 32 / 128}),
+      ir::Store::Make(
+          var_global_out,
+          ir::Load::Make(var_local_tensor, {var_i_0 * 3, var_j_0 * 32 / 128}),
+          {var_i_0 * 3 + var_j_0, var_j_0})};
+
+  ir::Expr inner_loop_body = ir::Block::Make(block_contents);
+
+  std::vector<ir::Expr> j_loop_contents = {inner_loop_body};
+  ir::Expr j_loop = ir::For::Make(var_j_0,
+                                  ir::Expr(0),
+                                  ir::Expr(4),
+                                  ir::ForType::Serial,
+                                  ir::DeviceAPI::Host,
+                                  ir::Block::Make(j_loop_contents));
+
+  std::vector<ir::Expr> i_loop_contents = {j_loop};
+  ir::Expr loop_body = ir::For::Make(var_i_0,
+                                     ir::Expr(0),
+                                     ir::Expr(32),
+                                     ir::ForType::Serial,
+                                     ir::DeviceAPI::Host,
+                                     ir::Block::Make(i_loop_contents));
+
+  std::vector<ir::Expr> ij_loop_contents = {loop_body};
+  ir::Expr expr = ir::Block::Make(ij_loop_contents);
+
+  ir::stmt::BlockRef block = ir::ConvertExprBlockToStmtBlock(expr);
+  VLOG(6) << "Before EliminateCommonFactorOfLocalIndex: " << block;
+  EliminateCommonFactorOfLocalIndex(block);
+  VLOG(6) << "After EliminateCommonFactorOfLocalIndex: " << block;
+
+  // Expected output verification
+  std::string expected_ir = R"ROC({
+  serial for (i_0, 0, 32) {
+    serial for (j_0, 0, 4) {
+      var_local[0, i_0] = var_global_in[i_0, ((j_0 * 32) / 128)]
+      var_global_out[((i_0 * 3) + j_0), j_0] = var_local[0, i_0]
+    }
+  }
+})ROC";
+
+  EXPECT_EQ(utils::GetStreamCnt(block), utils::Trim(expected_ir));
+}
+}  // namespace optim
+}  // namespace cinn


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
<b>修复BUG1：</b>CINN TransformLocalIndicesToIters Pass修改
TransformLocalIndicesToIters支持的普遍场景如下：
```python
  for i:
    for j:
      for k:
        Local_var[IndiceFunc0(i,j)][IndiceFunc1(k)]  # 可被化简为 Local_var[i][j][k]
```
  当IndiceFunc是[Add Sub Mul Div Mod]的组合, Local_var可以被化简为Local_var[i][j][k]

具体的例子：
```python
  for i:
    for j: 
      for k:
         Local_var[i + 1024][j][k]  # 可被化简为 Local_var[i][j][k]
```

但是存在Corner Case
```python
  for i in [0,16):
    for j:
      for k:
        Local_var[(i + 1024)/2048]  # 错误：被化简为Local_var[i]，正确：被化简为Local_var[0]
```
Local_var[(i + 1024)/2048]，i取值范围[0,16)，
那么Local_var[(i + 1024)/2048]应该被化简为Local_var[0]，而不是Local_var[i]。
化简成Local_var[i]会生成越界的访问。

<b>修复BUG2：</b>CINN LoopTransformation Pass修改
Slip轴生成新temp_var的时候没有配置新Var的upper_bound和lower_bound

Pcard-90680