### PR TITLE
[0-size Tensor Job2 No.72-74] Add 0-size Tensor support for paddle.scatter [fluid_ops]

### DIFF
--- a/paddle/phi/infermeta/ternary.cc
+++ b/paddle/phi/infermeta/ternary.cc
@@ -2332,12 +2332,14 @@ void ScatterInferMeta(const MetaTensor& x,
   const auto& index_dims = index.dims();
 
   if (index_dims.size() == 2) {
-    PADDLE_ENFORCE_EQ(index_dims[1],
-                      1,
-                      common::errors::InvalidArgument(
-                          "The last dim of the index should be 1 when the "
-                          "index is a 2D tensor, but we get %d.",
-                          index_dims[1]));
+    if (index_dims[1] != 0) {
+      PADDLE_ENFORCE_EQ(index_dims[1],
+                        1,
+                        common::errors::InvalidArgument(
+                            "The last dim of the index should be 1 when the "
+                            "index is a 2D tensor, but we get %d.",
+                            index_dims[1]));
+    }
   } else {
     PADDLE_ENFORCE_EQ(index_dims.size() == 1 || index_dims.size() == 0,
                       true,

--- a/paddle/phi/kernels/cpu/scatter_kernel.cc
+++ b/paddle/phi/kernels/cpu/scatter_kernel.cc
@@ -28,6 +28,15 @@ void ScatterKernel(const Context &dev_ctx,
                    const DenseTensor &updates,
                    bool overwrite,
                    DenseTensor *out) {
+  if (index.numel() == 0) {
+    dev_ctx.template Alloc<T>(out);
+    phi::Copy(dev_ctx, x, dev_ctx.GetPlace(), false, out);
+    return;
+  }
+  if (out && out->numel() == 0) {
+    dev_ctx.template Alloc<T>(out);
+    return;
+  }
   // In place output: Out = X, Out[Ids] = Updates
   phi::Copy(dev_ctx, x, dev_ctx.GetPlace(), false, out);
   // Apply ScatterUpdate: Out[index] = Updates[:]

--- a/paddle/phi/kernels/cpu/scatter_nd_add_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/scatter_nd_add_grad_kernel.cc
@@ -17,8 +17,8 @@
 #include "paddle/phi/backends/cpu/cpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/core/tensor_utils.h"
+#include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/funcs/gather.h"
-
 namespace phi {
 
 template <typename T, typename Context>
@@ -28,6 +28,19 @@ void ScatterNdAddGradKernel(const Context &dev_ctx,
                             const DenseTensor &out_grad,
                             DenseTensor *x_grad,
                             DenseTensor *updates_grad) {
+  if (out_grad.numel() == 0) {
+    if (x_grad) {
+      dev_ctx.template Alloc<T>(x_grad);
+    }
+    if (updates_grad) {
+      phi::Full<T, Context>(
+          dev_ctx,
+          phi::IntArray(common::vectorize(updates_grad->dims())),
+          0,
+          updates_grad);
+    }
+    return;
+  }
   if (x_grad) {
     Copy(dev_ctx, out_grad, dev_ctx.GetPlace(), false, x_grad);
   }

--- a/paddle/phi/kernels/cpu/scatter_nd_add_kernel.cc
+++ b/paddle/phi/kernels/cpu/scatter_nd_add_kernel.cc
@@ -27,6 +27,10 @@ void ScatterNdAddKernel(const Context &dev_ctx,
                         const DenseTensor &index,
                         const DenseTensor &updates,
                         DenseTensor *out) {
+  if (out && out->numel() == 0) {
+    dev_ctx.template Alloc<T>(out);
+    return;
+  }
   // In place output: Out = X
   Copy(dev_ctx, x, dev_ctx.GetPlace(), true, out);
   const auto &index_type = index.dtype();

--- a/paddle/phi/kernels/gpu/scatter_kernel.cu
+++ b/paddle/phi/kernels/gpu/scatter_kernel.cu
@@ -29,6 +29,15 @@ void ScatterKernel(const Context &dev_ctx,
                    const DenseTensor &updates,
                    bool overwrite,
                    DenseTensor *out) {
+  if (index.numel() == 0) {
+    dev_ctx.template Alloc<T>(out);
+    phi::Copy(dev_ctx, x, dev_ctx.GetPlace(), false, out);
+    return;
+  }
+  if (out && out->numel() == 0) {
+    dev_ctx.template Alloc<T>(out);
+    return;
+  }
   phi::Copy(dev_ctx, x, dev_ctx.GetPlace(), false, out);
   // use template class to support int32_t and int64_t
   auto index_type = index.dtype();

--- a/paddle/phi/kernels/gpu/scatter_nd_add_kernel.cu
+++ b/paddle/phi/kernels/gpu/scatter_nd_add_kernel.cu
@@ -28,6 +28,10 @@ void ScatterNdAddKernel(const Context &dev_ctx,
                         const DenseTensor &index,
                         const DenseTensor &updates,
                         DenseTensor *out) {
+  if (out && out->numel() == 0) {
+    dev_ctx.template Alloc<T>(out);
+    return;
+  }
   Copy(dev_ctx, x, dev_ctx.GetPlace(), false, out);
   const auto &index_type = index.dtype();
   bool index_type_match =

--- a/paddle/phi/kernels/xpu/scatter_kernel.cc
+++ b/paddle/phi/kernels/xpu/scatter_kernel.cc
@@ -27,6 +27,15 @@ void ScatterKernel(const Context &dev_ctx,
                    const DenseTensor &updates,
                    bool overwrite,
                    DenseTensor *out) {
+  if (index.numel() == 0) {
+    dev_ctx.template Alloc<T>(out);
+    phi::Copy(dev_ctx, x, dev_ctx.GetPlace(), false, out);
+    return;
+  }
+  if (out && out->numel() == 0) {
+    dev_ctx.template Alloc<T>(out);
+    return;
+  }
   using XPUTypeT = typename XPUTypeTrait<T>::Type;
   out->Resize(x.dims());
   auto *x_data = reinterpret_cast<const XPUTypeT *>(x.data<T>());

--- a/paddle/phi/kernels/xpu/scatter_nd_add_kernel.cc
+++ b/paddle/phi/kernels/xpu/scatter_nd_add_kernel.cc
@@ -24,6 +24,10 @@ void ScatterNdAddKernel(const Context &dev_ctx,
                         const DenseTensor &index,
                         const DenseTensor &updates,
                         DenseTensor *out) {
+  if (out && out->numel() == 0) {
+    dev_ctx.template Alloc<T>(out);
+    return;
+  }
   const T *x_ptr = x.data<T>();
   const T *updates_ptr = updates.data<T>();
 

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -4374,6 +4374,9 @@ def scatter_nd_add(
             f"x and updates must have same data type but x.dtype={convert_dtype(x.dtype)}, updates.dtype={convert_dtype(updates.dtype)}"
         )
 
+    if in_dynamic_mode():
+        if index.size == 0:
+            return x.clone() + updates
     if in_dynamic_or_pir_mode():
         return _C_ops.scatter_nd_add(x, index, updates)
     else:

--- a/test/legacy_test/test_scatter_op.py
+++ b/test/legacy_test/test_scatter_op.py
@@ -912,6 +912,60 @@ class TestScatterError(unittest.TestCase):
         paddle.enable_static()
 
 
+class TestScatterOp_ZeroSize(OpTest):
+    def setUp(self):
+        paddle.disable_static()
+        self.op_type = "scatter"
+        self.python_api = paddle.scatter
+        self.public_python_api = paddle.scatter
+        self._set_dtype()
+        ref_np = np.ones((100, 1)).astype(self.dtype)
+        updates_np = np.random.random((4, 1)).astype(self.dtype)
+        index_np = np.random.random([0]).astype("int32")
+
+        output_np = np.copy(ref_np)
+        self.inputs = {'X': ref_np, 'Ids': index_np, 'Updates': updates_np}
+        self.outputs = {'Out': output_np}
+
+    def _set_dtype(self):
+        self.dtype = np.float32
+
+    def test_check_output(self):
+        self.check_output(check_pir=True)
+
+    def test_check_grad(self):
+        self.check_grad(
+            ["X"],
+            "Out",
+            check_pir=True,
+            max_relative_error=0.008,
+        )
+
+
+class TestScatterOp_ZeroSize2(TestScatterOp_ZeroSize):
+    def setUp(self):
+        paddle.disable_static()
+        self.op_type = "scatter"
+        self.python_api = paddle.scatter
+        self.public_python_api = paddle.scatter
+        self._set_dtype()
+        ref_np = np.ones((0, 1)).astype(self.dtype)
+        updates_np = np.random.random((4, 1)).astype(self.dtype)
+        index_np = np.random.random([4]).astype("int32")
+
+        output_np = np.copy(ref_np)
+        self.inputs = {'X': ref_np, 'Ids': index_np, 'Updates': updates_np}
+        self.outputs = {'Out': output_np}
+
+    def test_check_grad(self):
+        self.check_grad(
+            ["X", "Updates"],
+            "Out",
+            check_pir=True,
+            max_relative_error=0.008,
+        )
+
+
 if __name__ == "__main__":
     paddle.enable_static()
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
[0-size Tensor Job2 No.72-74] Add 0-size Tensor support for paddle.scatter

scatter_nd 调用的是scatter_nd_add
index 为0-size在 python部分判断，scatter修改有性能问题，改在kernel中使用phi::Copy，同时修改infermeta判断，符号推导没有对应代码
scatter_nd_add 返回x.clone() + updates, PaddleAPITest 中也是同样实现
https://github.com/PFCCLab/PaddleAPITest/blob/f360ad9c78a0c7ce095ec911ec52a29392a80404/tester/paddle_to_torch/rules.py#L5166
![image](https://github.com/user-attachments/assets/0acf4ae3-4125-48bf-815e-7b840359e1ea)

输出维度和输入x维度相同

修改前向，反向，反向updates填充0，PaddleAPITest中为自定义规则
https://github.com/PFCCLab/PaddleAPITest/blob/f360ad9c78a0c7ce095ec911ec52a29392a80404/tester/paddle_to_torch/rules.py#L5124
![image](https://github.com/user-attachments/assets/37555040-b711-4407-a1fc-42d0edf4157f)

增加单测，取消已有 TestScatterNdAddWithEmptyIndex 测试

PaddleAPITest测试通过，错误为numpy error
paddle.scatter
![image](https://github.com/user-attachments/assets/ed963a52-2112-4177-8e99-160292916142)

paddle.scatter_nd
![image](https://github.com/user-attachments/assets/4fb23a8f-802a-4543-a763-41c643835c94)

paddle.scatter_nd_add
![image](https://github.com/user-attachments/assets/89943848-cf58-4554-b760-3bc4f46fd286)


