### PR TITLE
Rename context to dev_ctx in expand_as_grad_kernel_impl.h [fluid_ops]

### DIFF
--- a/paddle/phi/kernels/impl/expand_as_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/expand_as_grad_kernel_impl.h
@@ -43,14 +43,14 @@ void ExpandAsBackward(const Context& dev_ctx,
 }
 
 template <typename T, typename Context>
-void ExpandAsGradKernel(const Context& context,
+void ExpandAsGradKernel(const Context& dev_ctx,
                         const DenseTensor& x,
                         const DenseTensor& out_grad,
                         const std::vector<int64_t>& target_shape,
                         DenseTensor* in_grad) {
   if (out_grad.numel() == 0) {
     phi::Full<T, Context>(
-        context, phi::IntArray(common::vectorize(in_grad->dims())), 0, in_grad);
+        dev_ctx, phi::IntArray(common::vectorize(in_grad->dims())), 0, in_grad);
     return;
   }
   auto x_dims = x.dims();
@@ -59,7 +59,7 @@ void ExpandAsGradKernel(const Context& context,
       phi::vectorize<int64_t>(out_grad_dims);
 
   if (in_grad->dims() == out_grad_dims) {
-    phi::Copy(context, out_grad, context.GetPlace(), false, in_grad);
+    phi::Copy(dev_ctx, out_grad, dev_ctx.GetPlace(), false, in_grad);
     return;
   }
 
@@ -98,39 +98,39 @@ void ExpandAsGradKernel(const Context& context,
   switch (dims) {
     case 0:
       ExpandAsBackward<Context, T, 0>(
-          context, out_grad, reshape_dims_vec, reduce_dims_vec, in_grad);
+          dev_ctx, out_grad, reshape_dims_vec, reduce_dims_vec, in_grad);
       break;
     case 1:
       ExpandAsBackward<Context, T, 1>(
-          context, out_grad, reshape_dims_vec, reduce_dims_vec, in_grad);
+          dev_ctx, out_grad, reshape_dims_vec, reduce_dims_vec, in_grad);
       break;
     case 2:
       ExpandAsBackward<Context, T, 2>(
-          context, out_grad, reshape_dims_vec, reduce_dims_vec, in_grad);
+          dev_ctx, out_grad, reshape_dims_vec, reduce_dims_vec, in_grad);
       break;
     case 3:
       ExpandAsBackward<Context, T, 3>(
-          context, out_grad, reshape_dims_vec, reduce_dims_vec, in_grad);
+          dev_ctx, out_grad, reshape_dims_vec, reduce_dims_vec, in_grad);
       break;
     case 4:
       ExpandAsBackward<Context, T, 4>(
-          context, out_grad, reshape_dims_vec, reduce_dims_vec, in_grad);
+          dev_ctx, out_grad, reshape_dims_vec, reduce_dims_vec, in_grad);
       break;
     case 5:
       ExpandAsBackward<Context, T, 5>(
-          context, out_grad, reshape_dims_vec, reduce_dims_vec, in_grad);
+          dev_ctx, out_grad, reshape_dims_vec, reduce_dims_vec, in_grad);
       break;
     case 6:
       ExpandAsBackward<Context, T, 6>(
-          context, out_grad, reshape_dims_vec, reduce_dims_vec, in_grad);
+          dev_ctx, out_grad, reshape_dims_vec, reduce_dims_vec, in_grad);
       break;
     case 7:
       ExpandAsBackward<Context, T, 7>(
-          context, out_grad, reshape_dims_vec, reduce_dims_vec, in_grad);
+          dev_ctx, out_grad, reshape_dims_vec, reduce_dims_vec, in_grad);
       break;
     case 8:
       ExpandAsBackward<Context, T, 8>(
-          context, out_grad, reshape_dims_vec, reduce_dims_vec, in_grad);
+          dev_ctx, out_grad, reshape_dims_vec, reduce_dims_vec, in_grad);
       break;
     default:
       PADDLE_THROW(errors::InvalidArgument(

--- a/paddle/phi/kernels/impl/expand_as_kernel_impl.h
+++ b/paddle/phi/kernels/impl/expand_as_kernel_impl.h
@@ -24,7 +24,7 @@
 namespace phi {
 
 template <typename Context, typename T, int Rank>
-void ExpandAs(const Context& context,
+void ExpandAs(const Context& dev_ctx,
               const DenseTensor& x,
               const std::vector<int64_t>& target_shape,
               DenseTensor* out) {
@@ -34,12 +34,12 @@ void ExpandAs(const Context& context,
   vec_in_dims.insert(vec_in_dims.begin(), diff, 1);
   std::vector<int64_t> repeat_times(vec_in_dims.size());
   if (Rank == 0) {
-    phi::Copy<Context>(context, x, context.GetPlace(), false, out);
+    phi::Copy<Context>(dev_ctx, x, dev_ctx.GetPlace(), false, out);
     return;
   }
   for (size_t i = 0; i < vec_in_dims.size(); ++i) {
     if (target_shape[i] == 0) {
-      context.template Alloc<T>(out);
+      dev_ctx.template Alloc<T>(out);
       return;
     }
     if (i < diff) {
@@ -85,10 +85,10 @@ void ExpandAs(const Context& context,
   phi::DDim out_dims = common::make_ddim(target_shape);
 
   out->Resize(out_dims);
-  context.template Alloc<T>(out);
+  dev_ctx.template Alloc<T>(out);
   auto x0 = EigenTensor<T, Rank>::From(x, new_in_dims);
   auto y = EigenTensor<T, Rank>::From(*out, out_dims);
-  auto& place = *context.eigen_device();
+  auto& place = *dev_ctx.eigen_device();
   funcs::EigenBroadcast<std::decay_t<decltype(place)>, T, Rank>::Eval(
       place, y, x0, bcast_dims);
 }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
Rename context to dev_ctx in expand_as_grad_kernel_impl.h
Rename context to dev_ctx in paddle/phi/backends/gpu/gpu_launch_config.h, the one used in the kernel is dev_ctx.