### PR TITLE
Fix paddle.diff for big tensor

### DIFF
--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -6742,6 +6742,11 @@ def diff(
             if x.dtype == paddle.bool or x.dtype == core.DataType.BOOL:
                 return _C_ops.logical_xor(input_back, input_front)
             else:
+                # NOTE(zrr1999): If input.numel() exceeds int32 range, elementwise_xxx two slices of the same variable may yield incorrect results.
+                if input_back.numel() >= 2**31:
+                    return _C_ops.subtract(
+                        paddle.clone(input_back), input_front
+                    )
                 return _C_ops.subtract(input_back, input_front)
         else:
             check_variable_and_dtype(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
slice 和 subtract同时使用会出现问题（理论上其他elementwise_xxx也会出现问题），简化的测试样例如下
```python
import paddle

input = paddle.randn([5, 760567127])
bbb=input[:4]
ccc=input[1:]

print(bbb[0][0])  # 正确
print(ccc[0][0])  # 正确
print((bbb-ccc)[0][0])  # 出错
print((paddle.abs(bbb)-ccc)[0][0])  # 正确
print((paddle.clone(bbb)-ccc)[0][0])  # 正确
```

目前排查了slice和subtract算子实现，并没有明显的错误，推测报错原因与slice的共享holder相关，暂时的对paddle.diff的解决方案是增加paddle.clone，可能会产生额外显存占用


Pcard-67164