### PR TITLE
[PHI] Fix `paddle.linalg.det` for big tensor

### DIFF
--- a/paddle/phi/kernels/impl/determinant_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/determinant_grad_kernel_impl.h
@@ -38,24 +38,27 @@ template <typename T>
 struct FoundZeroFunctor {
   using RealType = phi::dtype::Real<T>;
 
+  // epsilon_ should be smaller if linalg.det achieves higher precision
+  template <typename RealType>
+  inline constexpr RealType epsilon_v = 1e-3f;  // For float16
+
+  template <>
+  inline constexpr float epsilon_v<float> = 1e-5f;
+
+  template <>
+  inline constexpr double epsilon_v<double> = 1e-12;
+
   FoundZeroFunctor(const T* x, int64_t numel, bool* res)
-      : x_(x), numel_(numel), res_(res) {
-    // epsilon_ should be smaller if linalg.det achieves higher precision
-    if (std::is_same_v<RealType, float>) {
-      epsilon_ = 1e-5f;
-    } else if (std::is_same_v<RealType, double>) {
-      epsilon_ = 1e-12;
-    } else {  // For float16
-      epsilon_ = 1e-3f;
-    }
-  }
+      : x_(x), numel_(numel), res_(res), epsilon_(epsilon_v<RealType>) {}
 
   HOSTDEVICE void operator()(size_t idx) const {
     if (*res_ || idx >= static_cast<size_t>(numel_)) {
       // found a singular matrix
       return;
     }
-    *res_ = (abs(x_[idx]) < static_cast<RealType>(epsilon_));
+    if (abs(x_[idx]) < static_cast<RealType>(epsilon_)) {
+      *res_ = true;
+    }
   }
 
  private:

--- a/paddle/phi/kernels/impl/determinant_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/determinant_grad_kernel_impl.h
@@ -34,28 +34,36 @@
 namespace phi {
 namespace detail {
 
+// epsilon_ should be smaller if linalg.det achieves higher precision
+template <typename RealType>
+struct FoundZeroEpsilon {
+  // default for float16
+  static constexpr RealType value = static_cast<RealType>(1e-3f);
+};
+
+template <>
+struct FoundZeroEpsilon<float> {
+  static constexpr float value = 1e-5f;
+};
+
+template <>
+struct FoundZeroEpsilon<double> {
+  static constexpr double value = 1e-12;
+};
+
 template <typename T>
 struct FoundZeroFunctor {
   using RealType = phi::dtype::Real<T>;
 
   FoundZeroFunctor(const T* x, int64_t numel, bool* res)
-      : x_(x), numel_(numel), res_(res) {
-    // epsilon_ should be smaller if linalg.det achieves higher precision
-    if constexpr (std::is_same_v<RealType, float>) {
-      epsilon_ = 1e-5f;
-    } else if constexpr (std::is_same_v<RealType, double>) {
-      epsilon_ = 1e-12;
-    } else {
-      epsilon_ = 1e-3f;  // Default for float16
-    }
-  }
+      : x_(x), numel_(numel), res_(res) {}
 
   HOSTDEVICE void operator()(size_t idx) const {
     if (*res_ || idx >= static_cast<size_t>(numel_)) {
       // found a singular matrix
       return;
     }
-    if (abs(x_[idx]) < epsilon_) {
+    if (abs(x_[idx]) < FoundZeroEpsilon<RealType>::value) {
       *res_ = true;
     }
   }

--- a/paddle/phi/kernels/impl/determinant_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/determinant_grad_kernel_impl.h
@@ -17,6 +17,7 @@
 #include "glog/logging.h"
 #include "paddle/phi/common/amp_type_traits.h"
 
+#include "paddle/phi/common/type_traits.h"
 #include "paddle/phi/core/tensor_utils.h"
 #include "paddle/phi/kernels/cast_kernel.h"
 #include "paddle/phi/kernels/complex_kernel.h"
@@ -29,23 +30,39 @@
 #include "paddle/phi/kernels/funcs/matrix_inverse.h"
 #include "paddle/phi/kernels/funcs/unsqueeze.h"
 #include "paddle/phi/kernels/transpose_kernel.h"
+
 namespace phi {
 namespace detail {
 
 template <typename T>
 struct FoundZeroFunctor {
+  using RealType = phi::dtype::Real<T>;
+
   FoundZeroFunctor(const T* x, int64_t numel, bool* res)
-      : x_(x), numel_(numel), res_(res) {}
+      : x_(x), numel_(numel), res_(res) {
+    // epsilon_ should be smaller if linalg.det achieves higher precision
+    if (std::is_same_v<RealType, float>) {
+      epsilon_ = 1e-5f;
+    } else if (std::is_same_v<RealType, double>) {
+      epsilon_ = 1e-12;
+    } else {  // For float16
+      epsilon_ = 1e-3f;
+    }
+  }
+
   HOSTDEVICE void operator()(size_t idx) const {
     if (*res_ || idx >= static_cast<size_t>(numel_)) {
-      // founded zero number
+      // found a singular matrix
       return;
     }
-    *res_ = (x_[idx] == static_cast<T>(0));
+    *res_ = (abs(x_[idx]) < static_cast<RealType>(epsilon_));
   }
+
+ private:
   const T* x_;
   int64_t numel_;
   bool* res_;
+  RealType epsilon_;
 };
 
 template <typename T, typename Context>
@@ -120,9 +137,21 @@ void DeterminantGradKernel(const Context& dev_ctx,
   }
 
   using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
-  auto origin_dt = std::is_same<phi::dtype::float16, T>::value
-                       ? DataType::FLOAT16
-                       : DataType::BFLOAT16;
+  DenseTensor x_mp;
+  DenseTensor out_mp;
+  DenseTensor out_grad_mp;
+  if constexpr (!std::is_same_v<MPType, T>) {
+    x_mp = phi::Cast<T, Context>(
+        dev_ctx, x, phi::CppTypeToDataType<MPType>::Type());
+    out_mp = phi::Cast<T, Context>(
+        dev_ctx, out, phi::CppTypeToDataType<MPType>::Type());
+    out_grad_mp = phi::Cast<T, Context>(
+        dev_ctx, out_grad, phi::CppTypeToDataType<MPType>::Type());
+  } else {
+    x_mp = x;
+    out_mp = out;
+    out_grad_mp = out_grad;
+  }
 
   // The matrix is invertible
   // let |A| = Determinant(A)
@@ -137,13 +166,7 @@ void DeterminantGradKernel(const Context& dev_ctx,
   dev_ctx.template Alloc<MPType>(&inverse_A);
 
   phi::funcs::MatrixInverseFunctor<Context, MPType> mat_inv;
-  if (!std::is_same<MPType, T>::value) {
-    mat_inv(dev_ctx,
-            phi::Cast<T, Context>(dev_ctx, x, DataType::FLOAT32),
-            &inverse_A);
-  } else {
-    mat_inv(dev_ctx, x, &inverse_A);
-  }
+  mat_inv(dev_ctx, x_mp, &inverse_A);
 
   auto conj_inverse_A = phi::Conj<MPType>(dev_ctx, inverse_A);
   VLOG(3) << "inverse(A).conj() dims: " << conj_inverse_A.dims();
@@ -151,13 +174,12 @@ void DeterminantGradKernel(const Context& dev_ctx,
   // Second: inverse(A).conj().transpose(-2, -1)
   DenseTensor transpose_inverse_A =
       phi::TransposeLast2Dim<MPType>(dev_ctx, conj_inverse_A);
-
   VLOG(3) << "(dA * |A|).transpose(-2, -1) dims: "
           << transpose_inverse_A.dims();
 
   // Third: dA * |A|.conj()
-  auto conj_out = phi::Conj<MPType>(dev_ctx, out);
-  auto mul_dA_detA = phi::Multiply<T>(dev_ctx, out_grad, conj_out);
+  auto conj_out = phi::Conj<MPType>(dev_ctx, out_mp);
+  auto mul_dA_detA = phi::Multiply<MPType>(dev_ctx, out_grad_mp, conj_out);
   VLOG(3) << "dA * |A| dims: " << mul_dA_detA.dims();
 
   // Fourth: unsqueeze(dA * |A|, [-1, -2])
@@ -166,22 +188,14 @@ void DeterminantGradKernel(const Context& dev_ctx,
   VLOG(3) << "unsqueezed(dA * |A|) dims: " << unsqueeze2.dims();
 
   // Finally: unsqueeze(dA * |A|) * inverse(A)
-  DenseTensor res;
-  if (!std::is_same<MPType, T>::value) {
-    res = phi::Multiply<T>(
-        dev_ctx,
-        unsqueeze2,
-        phi::Cast<MPType, Context>(dev_ctx, transpose_inverse_A, origin_dt));
-  } else {
-    res = phi::Multiply<T>(dev_ctx, unsqueeze2, transpose_inverse_A);
-  }
-
-  VLOG(3) << "unsqueeze(dA * |A|) * inverse(A) dims: " << res.dims();
+  DenseTensor res_mp;
+  res_mp = phi::Multiply<MPType>(dev_ctx, unsqueeze2, transpose_inverse_A);
+  VLOG(3) << "unsqueeze(dA * |A|) * inverse(A) dims: " << res_mp.dims();
 
   x_grad->Resize(x.dims());
   VLOG(3) << "d|A| dims: " << x_grad->dims();
 
-  phi::Copy(dev_ctx, res, dev_ctx.GetPlace(), false, x_grad);
+  phi::Copy(dev_ctx, res_mp, dev_ctx.GetPlace(), false, x_grad);
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/impl/determinant_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/determinant_grad_kernel_impl.h
@@ -137,21 +137,6 @@ void DeterminantGradKernel(const Context& dev_ctx,
   }
 
   using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
-  DenseTensor x_mp;
-  DenseTensor out_mp;
-  DenseTensor out_grad_mp;
-  if constexpr (!std::is_same_v<MPType, T>) {
-    x_mp = phi::Cast<T, Context>(
-        dev_ctx, x, phi::CppTypeToDataType<MPType>::Type());
-    out_mp = phi::Cast<T, Context>(
-        dev_ctx, out, phi::CppTypeToDataType<MPType>::Type());
-    out_grad_mp = phi::Cast<T, Context>(
-        dev_ctx, out_grad, phi::CppTypeToDataType<MPType>::Type());
-  } else {
-    x_mp = x;
-    out_mp = out;
-    out_grad_mp = out_grad;
-  }
 
   // The matrix is invertible
   // let |A| = Determinant(A)
@@ -160,36 +145,59 @@ void DeterminantGradKernel(const Context& dev_ctx,
   // inverse(A).conj().transpose(-2, -1)
 
   // First: inverse(A)
-  DenseTensor inverse_A;
-  // A must be square matrices!
-  inverse_A.Resize(x.dims());
-  dev_ctx.template Alloc<MPType>(&inverse_A);
+  DenseTensor transpose_inverse_A;
+  {
+    DenseTensor inverse_A;
+    // A must be square matrices!
+    inverse_A.Resize(x.dims());
+    dev_ctx.template Alloc<MPType>(&inverse_A);
 
-  phi::funcs::MatrixInverseFunctor<Context, MPType> mat_inv;
-  mat_inv(dev_ctx, x_mp, &inverse_A);
+    phi::funcs::MatrixInverseFunctor<Context, MPType> mat_inv;
+    if constexpr (!std::is_same_v<MPType, T>) {
+      auto x_mp = phi::Cast<T, Context>(
+          dev_ctx, x, phi::CppTypeToDataType<MPType>::Type());
+      mat_inv(dev_ctx, x_mp, &inverse_A);
+    } else {
+      mat_inv(dev_ctx, x, &inverse_A);
+    }
 
-  auto conj_inverse_A = phi::Conj<MPType>(dev_ctx, inverse_A);
-  VLOG(3) << "inverse(A).conj() dims: " << conj_inverse_A.dims();
+    auto conj_inverse_A = phi::Conj<MPType>(dev_ctx, inverse_A);
+    VLOG(3) << "inverse(A).conj() dims: " << conj_inverse_A.dims();
 
-  // Second: inverse(A).conj().transpose(-2, -1)
-  DenseTensor transpose_inverse_A =
-      phi::TransposeLast2Dim<MPType>(dev_ctx, conj_inverse_A);
-  VLOG(3) << "(dA * |A|).transpose(-2, -1) dims: "
-          << transpose_inverse_A.dims();
+    // Second: inverse(A).conj().transpose(-2, -1)
+    transpose_inverse_A =
+        phi::TransposeLast2Dim<MPType>(dev_ctx, conj_inverse_A);
+    VLOG(3) << "(dA * |A|).transpose(-2, -1) dims: "
+            << transpose_inverse_A.dims();
+  }
 
-  // Third: dA * |A|.conj()
-  auto conj_out = phi::Conj<MPType>(dev_ctx, out_mp);
-  auto mul_dA_detA = phi::Multiply<MPType>(dev_ctx, out_grad_mp, conj_out);
-  VLOG(3) << "dA * |A| dims: " << mul_dA_detA.dims();
+  DenseTensor mul_unsqueezed;
+  {
+    DenseTensor mul_dA_detA;
+    // Third: dA * |A|.conj()
+    if constexpr (!std::is_same_v<MPType, T>) {
+      auto out_mp = phi::Cast<T, Context>(
+          dev_ctx, out, phi::CppTypeToDataType<MPType>::Type());
+      auto out_grad_mp = phi::Cast<T, Context>(
+          dev_ctx, out_grad, phi::CppTypeToDataType<MPType>::Type());
 
-  // Fourth: unsqueeze(dA * |A|, [-1, -2])
-  auto unsqueeze1 = phi::funcs::Unsqueeze(mul_dA_detA, -1);
-  auto unsqueeze2 = phi::funcs::Unsqueeze(unsqueeze1, -2);
-  VLOG(3) << "unsqueezed(dA * |A|) dims: " << unsqueeze2.dims();
+      auto conj_out_mp = phi::Conj<MPType>(dev_ctx, out_mp);
+      mul_dA_detA = phi::Multiply<MPType>(dev_ctx, out_grad_mp, conj_out_mp);
+    } else {
+      auto conj_out = phi::Conj<T>(dev_ctx, out);
+      mul_dA_detA = phi::Multiply<T>(dev_ctx, out_grad, conj_out);
+    }
+    VLOG(3) << "dA * |A| dims: " << mul_dA_detA.dims();
+
+    // Fourth: unsqueeze(dA * |A|, [-1, -2])
+    auto unsqueeze1 = phi::funcs::Unsqueeze(mul_dA_detA, -1);
+    mul_unsqueezed = phi::funcs::Unsqueeze(unsqueeze1, -2);
+    VLOG(3) << "unsqueezed(dA * |A|) dims: " << mul_unsqueezed.dims();
+  }
 
   // Finally: unsqueeze(dA * |A|) * inverse(A)
-  DenseTensor res_mp;
-  res_mp = phi::Multiply<MPType>(dev_ctx, unsqueeze2, transpose_inverse_A);
+  auto res_mp =
+      phi::Multiply<MPType>(dev_ctx, mul_unsqueezed, transpose_inverse_A);
   VLOG(3) << "unsqueeze(dA * |A|) * inverse(A) dims: " << res_mp.dims();
 
   x_grad->Resize(x.dims());

--- a/paddle/phi/kernels/impl/determinant_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/determinant_grad_kernel_impl.h
@@ -35,20 +35,20 @@ namespace phi {
 namespace detail {
 
 // epsilon_ should be smaller if linalg.det achieves higher precision
-template <typename RealType>
+template <typename T>
 struct FoundZeroEpsilon {
   // default for float16
-  static constexpr RealType value = static_cast<RealType>(1e-3f);
+  static constexpr T value() { return static_cast<T>(1e-3f); }
 };
 
 template <>
 struct FoundZeroEpsilon<float> {
-  static constexpr float value = 1e-5f;
+  static constexpr float value() { return 1e-5f; }
 };
 
 template <>
 struct FoundZeroEpsilon<double> {
-  static constexpr double value = 1e-12;
+  static constexpr double value() { return 1e-12; }
 };
 
 template <typename T>
@@ -63,7 +63,7 @@ struct FoundZeroFunctor {
       // found a singular matrix
       return;
     }
-    if (abs(x_[idx]) < FoundZeroEpsilon<RealType>::value) {
+    if (abs(x_[idx]) < FoundZeroEpsilon<RealType>::value()) {
       *res_ = true;
     }
   }
@@ -72,7 +72,6 @@ struct FoundZeroFunctor {
   const T* x_;
   int64_t numel_;
   bool* res_;
-  RealType epsilon_;
 };
 
 template <typename T, typename Context>

--- a/paddle/phi/kernels/impl/determinant_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/determinant_grad_kernel_impl.h
@@ -38,25 +38,24 @@ template <typename T>
 struct FoundZeroFunctor {
   using RealType = phi::dtype::Real<T>;
 
-  // epsilon_ should be smaller if linalg.det achieves higher precision
-  template <typename RealType>
-  inline constexpr RealType epsilon_v = 1e-3f;  // For float16
-
-  template <>
-  inline constexpr float epsilon_v<float> = 1e-5f;
-
-  template <>
-  inline constexpr double epsilon_v<double> = 1e-12;
-
   FoundZeroFunctor(const T* x, int64_t numel, bool* res)
-      : x_(x), numel_(numel), res_(res), epsilon_(epsilon_v<RealType>) {}
+      : x_(x), numel_(numel), res_(res) {
+    // epsilon_ should be smaller if linalg.det achieves higher precision
+    if constexpr (std::is_same_v<RealType, float>) {
+      epsilon_ = 1e-5f;
+    } else if constexpr (std::is_same_v<RealType, double>) {
+      epsilon_ = 1e-12;
+    } else {
+      epsilon_ = 1e-3f;  // Default for float16
+    }
+  }
 
   HOSTDEVICE void operator()(size_t idx) const {
     if (*res_ || idx >= static_cast<size_t>(numel_)) {
       // found a singular matrix
       return;
     }
-    if (abs(x_[idx]) < static_cast<RealType>(epsilon_)) {
+    if (abs(x_[idx]) < epsilon_) {
       *res_ = true;
     }
   }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

#### 修复 `paddle.linalg.det` 反向报错问题：

在输入有奇异矩阵时发生：
<img width="2066" height="210" alt="image" src="https://github.com/user-attachments/assets/3671867b-a89d-46a0-84f0-fa9d842ebb22" />

#### 问题定位：

`paddle.linalg.det` 的梯度计算采用以下公式：

$$
\frac{\partial \text{det}(A)}{\partial A} = \text{adj}(A)^\text{T} = \text{det}(A) \cdot A^{-\text{T}}
$$

直接通过矩阵逆运算实现，但奇异矩阵不可逆（ $\text{det}(A)=0$， $A^{-\text{T}}$ 不存在）导致计算失败。理论上，奇异矩阵的梯度应采用伴随矩阵 $\text{adj}(A)$ 直接计算。

此外，`FoundZeroFunctor` 直接进行零值判定，未考虑浮点数计算的误差，导致大量奇异矩阵被误判断为非奇异矩阵。

#### 解决方案：

1. 将零值判断改为使用 `epsilon` 阈值，`if` 避免写入竞争：
```cpp
*res_ = (x_[idx] == static_cast<T>(0));
```
```cpp
if (abs(x_[idx]) < FoundZeroEpsilon<RealType>::value()) {
  *res_ = true;
}
```

2. 将所有 `phi::Multiply` 运算提升为 `MPType`，并通过分块 `{}` 减少内存占用

#### 后续修复：

本修复仅解决反向报错问题。如果输入均为非奇异矩阵，测试全部通过：
- https://github.com/PFCCLab/PaddleAPITest/pull/357

如果需要完美计算奇异矩阵，算法需进行非常大调整，该工作将在 `paddle.linalg.lu` 支持复数功能后进行：
- https://github.com/PaddlePaddle/Paddle/pull/73885
