### PR TITLE
[AutoParallel]fix fuse flag bug

### DIFF
--- a/python/paddle/distributed/auto_parallel/api.py
+++ b/python/paddle/distributed/auto_parallel/api.py
@@ -1851,15 +1851,18 @@ class _ShardOptimizer(Optimizer):
 
     def _fused_comm_before_apply_optimize(self, params_grads):
         '''
-        In dynamic sharding mode, gradient clipping on partial gradients can trigger redundant allreduce
-        operations. Fused reduce_scatter optimizes this by marking mesh dimensions as shard in priority
-        order to reduce redundant synchronization:
-            1. Prioritize shard(0) for the specified sharding axis.
-            2. Sequentially mark other dimensions as shard(tensor_dim).
-            3. Default to replicate for non-shardable dimensions.
+        Optimizes gradient placements for parameters in dynamic sharding mode to minimize redundant allreduce
+        operations during gradient clipping. This function adjusts tensor placements across mesh axes based
+        on priority rules, prioritizing sharding for dimensions marked in `_sharding_axis`.
+        For each axis in the mesh:
+            1. Preserves existing `Shard(dim)` placements for any axis.
+            2. Converts `Partial()` placements to Shard(dim) where possible, falling back to `Replicate()` if sharding isn't feasible.
+            3. Maintains `Replicate()` placements unchanged.
+        Processes axes in order of `_sharding_axis` first before other mesh axes in their natural order.
+
             e.g.
                 a) sharding_axis = 0, tensor rank = 2,
-                    placements: [Partial(), Partial(), partial] -> [Shard(0), Shard(1), Repliacate()]
+                    placements: [Partial(), Partial(), Repliacate()] -> [Shard(0), Shard(1), Repliacate()]
                 b) sharding_axis = 0, tensor rank = 2,
                     placements: [Partial(), Shard(0), Partial() ] -> [Shard(1), Shard(0), Repliacate()]
         '''
@@ -1889,42 +1892,41 @@ class _ShardOptimizer(Optimizer):
                     tensor_dim = placement.get_dim()
                     shard_dims_set.add(tensor_dim)
 
-            # 2. Prioritize setting placement[sharding_axis] as shard (usually shard(0)), otherwise set as replicate.
+            # 2. Prioritize process `_sharding_axis`.
             tensor_dim = get_first_can_shard_dim(tensor_shape, shard_dims_set)
-            # Keep the shard state if already in shard mode.
+            # 2.1 Preserves existing shard status placements.
             if not grad.placements[self._sharding_axis].is_shard():
-                # The placement[sharding_axis]  should shard the tensor as much as possible;
-                # defaults to maintaining a replicate state.
+                # 2.2 Default to maintain replicate status.
                 new_placements[self._sharding_axis] = dist.Replicate()
-                if tensor_dim != -1 and tensor_shape[tensor_dim] != 1:
-                    if mesh_shape[self._sharding_axis] != 1:
-                        shard_dims_set.add(tensor_dim)
-                        new_placements[self._sharding_axis] = dist.Shard(
-                            tensor_dim
-                        )
+                # 2.3 Converts partial status to shard status where possible.
+                if tensor_dim != -1 and mesh_shape[self._sharding_axis] != 1:
+                    shard_dims_set.add(tensor_dim)
+                    new_placements[self._sharding_axis] = dist.Shard(tensor_dim)
 
+            # 3. Processes other mesh axes in their natural order.
             for mesh_axis, placement in enumerate(grad.placements):
                 if mesh_axis == self._sharding_axis:
                     continue
+                # 3.1 No sharding is needed as single-device mesh axis.
                 if mesh_shape[mesh_axis] == 1:
                     new_placements[mesh_axis] = dist.Replicate()
                     continue
-                # 3. Keep shard states in placements unchanged.
+                # 3.2  Keep shard states in placements unchanged.
                 if not placement.is_shard():
-                    # 4. Default all tensor dims are in shard state, set remaining placements to replicate.
                     new_placements[mesh_axis] = dist.Replicate()
                     tensor_dim = get_first_can_shard_dim(
                         tensor_shape, shard_dims_set
                     )
-                    # # When in partial state, convert to shard state as much as possible.
+                    # 3.3 When in partial state, convert to shard state as much as possible.
                     if placement.is_partial():
                         if tensor_dim == -1:
                             new_placements[mesh_axis] = dist.Replicate()
                         else:
+                            # 3.4 Default to maintain replicate status.
                             shard_dims_set.add(tensor_dim)
                             new_placements[mesh_axis] = dist.Shard(tensor_dim)
+            # 4. Update placements.
             if grad.placements != new_placements:
-                # 6. Add reduce_scatter comms via reshard API.
                 new_grad = dist.reshard(grad, grad.process_mesh, new_placements)
 
             new_params_grads.append((param, new_grad))

--- a/python/paddle/distributed/auto_parallel/api.py
+++ b/python/paddle/distributed/auto_parallel/api.py
@@ -1855,7 +1855,7 @@ class _ShardOptimizer(Optimizer):
         operations. Fused reduce_scatter optimizes this by marking mesh dimensions as shard in priority
         order to reduce redundant synchronization:
             1. Prioritize shard(0) for the specified sharding axis.
-            2. Sequentially mark other dimensions as shard(dim).
+            2. Sequentially mark other dimensions as shard(tensor_dim).
             3. Default to replicate for non-shardable dimensions.
             e.g.
                 a) sharding_axis = 0, tensor rank = 2,
@@ -1865,12 +1865,15 @@ class _ShardOptimizer(Optimizer):
         '''
         new_params_grads = []
 
-        # Get the first non-shard dim of tensor shape in ascending order.
-        # `shard_dims_set` records if dim is marked as shard in placement.
+        # Get the first non-shard tensor_dim of tensor shape in ascending order.
+        # `shard_dims_set` records if tensor_dim is marked as shard in placement.
         def get_first_can_shard_dim(tensor_shape, shard_dims_set):
-            for dim in range(len(tensor_shape)):
-                if dim not in shard_dims_set:
-                    return dim
+            for tensor_dim in range(len(tensor_shape)):
+                # The rank of the current dimension of the tensor is 1, so there is no need to shard it.
+                if tensor_shape[tensor_dim] == 1:
+                    continue
+                if tensor_dim not in shard_dims_set:
+                    return tensor_dim
             return -1
 
         for param, grad in params_grads:
@@ -1878,33 +1881,48 @@ class _ShardOptimizer(Optimizer):
             new_grad = grad
             tensor_shape = grad._local_shape
             shard_dims_set = set()
+            mesh_shape = grad.process_mesh.shape
 
             # 1. `shard_dims_set` records dims marked as shard in placement.
             for placement in grad.placements:
                 if placement.is_shard():
-                    dim = placement.get_dim()
-                    shard_dims_set.add(dim)
+                    tensor_dim = placement.get_dim()
+                    shard_dims_set.add(tensor_dim)
 
             # 2. Prioritize setting placement[sharding_axis] as shard (usually shard(0)), otherwise set as replicate.
-            dim = get_first_can_shard_dim(tensor_shape, shard_dims_set)
-            new_placements[self._sharding_axis] = dist.Replicate()
-            if dim != -1:
-                shard_dims_set.add(dim)
-                new_placements[self._sharding_axis] = dist.Shard(dim)
+            tensor_dim = get_first_can_shard_dim(tensor_shape, shard_dims_set)
+            # Keep the shard state if already in shard mode.
+            if not grad.placements[self._sharding_axis].is_shard():
+                # The placement[sharding_axis]  should shard the tensor as much as possible;
+                # defaults to maintaining a replicate state.
+                new_placements[self._sharding_axis] = dist.Replicate()
+                if tensor_dim != -1 and tensor_shape[tensor_dim] != 1:
+                    if mesh_shape[self._sharding_axis] != 1:
+                        shard_dims_set.add(tensor_dim)
+                        new_placements[self._sharding_axis] = dist.Shard(
+                            tensor_dim
+                        )
 
             for mesh_axis, placement in enumerate(grad.placements):
                 if mesh_axis == self._sharding_axis:
                     continue
+                if mesh_shape[mesh_axis] == 1:
+                    new_placements[mesh_axis] = dist.Replicate()
+                    continue
                 # 3. Keep shard states in placements unchanged.
                 if not placement.is_shard():
-                    dim = get_first_can_shard_dim(tensor_shape, shard_dims_set)
                     # 4. Default all tensor dims are in shard state, set remaining placements to replicate.
                     new_placements[mesh_axis] = dist.Replicate()
-                    if dim != -1:
-                        # 5. Turn other placements into shard state if possible.
-                        shard_dims_set.add(dim)
-                        new_placements[mesh_axis] = dist.Shard(dim)
-
+                    tensor_dim = get_first_can_shard_dim(
+                        tensor_shape, shard_dims_set
+                    )
+                    # # When in partial state, convert to shard state as much as possible.
+                    if placement.is_partial():
+                        if tensor_dim == -1:
+                            new_placements[mesh_axis] = dist.Replicate()
+                        else:
+                            shard_dims_set.add(tensor_dim)
+                            new_placements[mesh_axis] = dist.Shard(tensor_dim)
             if grad.placements != new_placements:
                 # 6. Add reduce_scatter comms via reshard API.
                 new_grad = dist.reshard(grad, grad.process_mesh, new_placements)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修复 https://github.com/PaddlePaddle/Paddle/pull/73744 默认开启 sharding fuse 优化引入的 bug：

1. 增加对维度 shape = 1 的边界处理情况：
    - 如果 tensor_shape[dim] == 1，那 param 这一维度不能被切分，只能是 replicate 的
    - 如果 mesh_shape[axis] == 1，那 mesh 这一维度也没必要去切分，保持 dist.Replicate()
  
2. 对每个 param 的梯度，分情况讨论 每个 axis 的 placements ：
    - 如果当前 placements[axis] 是 dist.Shard(dim) 的，placements 保持不变
    - 如果当前 placements[axis] 是 dist.Partial() 的，尽可能 reshard 转成 dist.Shard(dim)，否则转成 dist.Replicate()
    - 如果当前 placements[axis] 是 dist.Replicate()，placements 保持不变
    
PCard-91912
