### PR TITLE
[0-size Tensor No.89、86] Add 0-size Tensor support for paddle.incubate.softmax_mask_fuse [fluid_ops]

### DIFF
--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/multiary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/multiary_infer_sym.cc
@@ -3941,7 +3941,9 @@ bool RmsNormOpInferSymbolicShape(
   const std::vector<symbol::DimExpr> &norm_weight_dims =
       norm_weight_shape.shape();
 
-  infer_context->AddEqualCstr(normalized_dims, norm_weight_dims[0]);
+  if (normalized_dims != 0) {
+    infer_context->AddEqualCstr(normalized_dims, norm_weight_dims[0]);
+  }
 
   infer_context->SetShapeOrDataForValue(
       op->result(0),

--- a/paddle/phi/infermeta/multiary.cc
+++ b/paddle/phi/infermeta/multiary.cc
@@ -4949,15 +4949,17 @@ void RmsNormInferMeta(const MetaTensor& x,
     normalized_dims *= x.dims().at(i);
   }
 
-  PADDLE_ENFORCE_EQ(normalized_dims,
-                    norm_weight.dims()[0],
-                    common::errors::InvalidArgument(
-                        "The normalized size of Input(X) must equal to be "
-                        "the size of Weight, but received "
-                        "normalized size of Input(X) is [%d], received size "
-                        "of Weight is [%d]",
-                        normalized_dims,
-                        norm_weight.dims()[0]));
+  if (normalized_dims != 0) {
+    PADDLE_ENFORCE_EQ(normalized_dims,
+                      norm_weight.dims()[0],
+                      common::errors::InvalidArgument(
+                          "The normalized size of Input(X) must equal to be "
+                          "the size of Weight, but received "
+                          "normalized size of Input(X) is [%d], received size "
+                          "of Weight is [%d]",
+                          normalized_dims,
+                          norm_weight.dims()[0]));
+  }
 
   out->set_dims(x.dims());
 

--- a/paddle/phi/kernels/fusion/gpu/fused_softmax_mask_grad_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/fused_softmax_mask_grad_kernel.cu
@@ -15,6 +15,7 @@
 #include <algorithm>
 
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/fusion/gpu/fused_softmax_mask_utils.h"
 
 namespace phi {
@@ -119,10 +120,16 @@ __global__ void SoftmaxMaskFuseGradGPUKernel(const T* grad_input,
 
 template <typename T, typename Context>
 void FusedSoftmaxMaskGradKernel(const Context& dev_ctx,
+                                const DenseTensor& x UNUSED,
                                 const DenseTensor& out,
                                 const DenseTensor& out_grad,
                                 DenseTensor* x_grad) {
   auto* grad_x_data = dev_ctx.template Alloc<T>(x_grad);
+  if (out.numel() == 0) {
+    phi::Full<T, Context>(
+        dev_ctx, phi::IntArray(common::vectorize(x_grad->dims())), 0, x_grad);
+    return;
+  }
   auto* grad_y_data = out_grad.data<T>();
   auto* softmax_rst_data = out.data<T>();
 

--- a/paddle/phi/kernels/fusion/gpu/fused_softmax_mask_grad_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/fused_softmax_mask_grad_kernel.cu
@@ -120,7 +120,6 @@ __global__ void SoftmaxMaskFuseGradGPUKernel(const T* grad_input,
 
 template <typename T, typename Context>
 void FusedSoftmaxMaskGradKernel(const Context& dev_ctx,
-                                const DenseTensor& x UNUSED,
                                 const DenseTensor& out,
                                 const DenseTensor& out_grad,
                                 DenseTensor* x_grad) {

--- a/paddle/phi/kernels/fusion/gpu/fused_softmax_mask_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/fused_softmax_mask_kernel.cu
@@ -479,6 +479,7 @@ void FusedSoftmaxMaskKernel(const Context& dev_ctx,
                             DenseTensor* out) {
   auto* x_data = x.data<T>();
   auto* y_data = dev_ctx.template Alloc<T>(out);
+  if (out && out->numel() == 0) return;
 
   auto x_dim = x.dims();
   auto mask_dim = mask.dims();

--- a/python/paddle/incubate/operators/softmax_mask_fuse.py
+++ b/python/paddle/incubate/operators/softmax_mask_fuse.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import paddle
 from paddle import _C_ops
 from paddle.base.layer_helper import LayerHelper
 from paddle.framework import in_dynamic_or_pir_mode
@@ -65,6 +66,8 @@ def softmax_mask_fuse(
             [2, 8, 8, 32]
     """
     if in_dynamic_or_pir_mode():
+        if isinstance(mask, (paddle.Tensor)) and mask.size == 0:
+            return x + mask
         out = _C_ops.fused_softmax_mask(x, mask)
         return out
     helper = LayerHelper('fused_softmax_mask', **locals())

--- a/test/legacy_test/test_rms_norm_op.py
+++ b/test/legacy_test/test_rms_norm_op.py
@@ -900,5 +900,108 @@ class TestRMSNormAxisEquivalence(unittest.TestCase):
             )
 
 
+@unittest.skipIf(
+    not core.is_compiled_with_cuda() and not paddle.is_compiled_with_rocm(),
+    "core is not compiled with CUDA or ROCM",
+)
+class TestRMSNormOp_ZeroSize(unittest.TestCase):
+    def setUp(self):
+        np.random.seed(20)
+        # 0-size
+        batch = 0
+        cols = 256
+        self.x_np = np.random.random([batch, cols])
+        self.residual_np = np.random.random([batch, cols])
+        self.bias_np = np.random.random([cols])
+
+        self.norm_weight_np = np.random.random([cols])
+        self.norm_bias_np = np.random.random([cols])
+        self.epsilon = 1e-6
+        self.quant_scale = 0.15
+        self.quant_round_type = 1
+        self.quant_max_bound = 127
+        self.quant_min_bound = -127
+
+    def check_rmsnorm(self, x_np, gamma_np, beta_np, dtype):
+        paddle.disable_static()
+        x = paddle.to_tensor(x_np.astype(dtype))
+        gamma = paddle.to_tensor(gamma_np.astype(dtype))
+        beta = paddle.to_tensor(beta_np.astype(dtype))
+
+        paddle_rmsnorm_out = paddle.incubate.nn.functional.fused_rms_norm(
+            x, gamma, beta, self.epsilon, begin_norm_axis=1
+        )[0]
+        paddle_naive_rmsnorm_out = naive_rms_norm(x, gamma, beta, self.epsilon)
+        paddle.enable_static()
+        return paddle_rmsnorm_out, paddle_naive_rmsnorm_out
+
+    def test_rmsnorm_fp16(self):
+        if (
+            not paddle.is_compiled_with_cuda()
+            and not paddle.is_compiled_with_rocm()
+        ):
+            return
+        paddle_rmsnorm, paddle_naive_rmsnorm = self.check_rmsnorm(
+            self.x_np, self.norm_weight_np, self.norm_bias_np, 'float16'
+        )
+
+        np.testing.assert_allclose(
+            paddle_rmsnorm.numpy(),
+            paddle_naive_rmsnorm.numpy(),
+            rtol=1e-3,
+            atol=1e-3,
+        )
+
+    def test_rms_norm_backward(self):
+        def get_paddle_tensor(shape, dtype, bound=0.5):
+            tmp = paddle.uniform(shape, dtype=dtype, min=-bound, max=bound)
+            tmp.stop_gradient = False
+            return tmp
+
+        def get_forward_backward(func, seed, dtype):
+            paddle.disable_static()
+            paddle.seed(seed)
+            # 0-size
+            x = get_paddle_tensor([0, 256], dtype)
+            scale = get_paddle_tensor([256], dtype)
+            out_g = paddle.randn([0, 256], dtype)
+            out = func(x, scale)
+            paddle.autograd.backward([out], [out_g], True)
+            return out, (x.grad, scale.grad)
+
+        dtypes = [paddle.float32]
+        if paddle.amp.is_float16_supported('gpu'):
+            dtypes.append(paddle.float16)
+        for dtype in dtypes:
+            raw_out, raw_grads = get_forward_backward(
+                naive_rms_norm, seed=2024, dtype=dtype
+            )
+            fused_out, fused_grads = get_forward_backward(
+                fused_rms_norm, seed=2024, dtype=dtype
+            )
+            # forward rtol
+            rtol = 1e-5 if dtype == paddle.float32 else 1e-2
+            np.testing.assert_allclose(
+                raw_out.astype(paddle.float32).numpy(),
+                fused_out.astype(paddle.float32).numpy(),
+                rtol=rtol,
+            )
+            # backward rtol, only check float32 grad
+            rtol = 1e-3
+            if dtype == paddle.float32:
+                raw_x_grad, raw_scale_grad = raw_grads
+                fused_x_grad, fused_scale_grad = fused_grads
+                np.testing.assert_allclose(
+                    raw_x_grad.astype(paddle.float32).numpy(),
+                    fused_x_grad.astype(paddle.float32).numpy(),
+                    rtol=rtol,
+                )
+                np.testing.assert_allclose(
+                    raw_scale_grad.astype(paddle.float32).numpy(),
+                    fused_scale_grad.astype(paddle.float32).numpy(),
+                    rtol=rtol,
+                )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
89 paddle.incubate.softmax_mask_fuse
https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/incubate/softmax_mask_fuse_cn.html#softmax-mask-fuse
<img width="1165" height="534" alt="image" src="https://github.com/user-attachments/assets/cf3166f3-d303-4318-b0fb-7dccf33db6cd" />
API 只在GPU运行
输出维度和x相同，测试时如果mask 为0-size，维度和mask相同，所以修改infermeta, 符号推导

paddle/phi/ops/yaml/backward.yaml 增加x参数，x_grad维度和x相同

修改GPU 前向和反向，反向填充0，规则为paddle自定义规则
https://github.com/PFCCLab/PaddleAPITest/blob/d782af6c860fdf2f20a346f56be2f4baad2433c7/tester/paddle_to_torch/rules.py#L5702

PaddleAPITest测试通过
<img width="1582" height="343" alt="image" src="https://github.com/user-attachments/assets/11b538fa-8801-482b-be0c-f9f28cc605c9" />

86 fused_rms_norm 
修改infermeta和符号推导，如果normalized_dims为0，跳过检查

输出 out, residual_out 形状和 x 相同，inv_var形状为x形状取部分，可能不是0-size，使用0填充，PaddleAPITest 中fused_rms_norm 是自定义规则
https://github.com/PFCCLab/PaddleAPITest/blob/d782af6c860fdf2f20a346f56be2f4baad2433c7/tester/paddle_to_torch/rules.py#L2085
<img width="885" height="761" alt="image" src="https://github.com/user-attachments/assets/330083e2-1d64-40fc-8fb6-3bc793a5ac35" />

kernel不支持CPU
GPU 反向中 norm_bias_grad 没有使用所以没有修改

PaddleAPITest测试通过
<img width="1325" height="215" alt="image" src="https://github.com/user-attachments/assets/ce448409-9038-41fc-82c3-36ecaa8651aa" />
