### PR TITLE
[PHI] Fix out of bound error about Pad3DGradConst kernel

### DIFF
--- a/paddle/phi/kernels/gpu/pad3d_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/pad3d_grad_kernel.cu
@@ -52,9 +52,13 @@ __global__ void Pad3DGradConstNCDHW(const IndexType in_size,
     const IndexType out_d = in_d + pad_front;
     const IndexType out_h = in_h + pad_top;
     const IndexType out_w = in_w + pad_left;
+    bool out_of_bound = out_d < 0 || out_h < 0 || out_w < 0;
+
     d_in_data[in_index] =
-        d_out_data[nc * out_depth * out_height * out_width +
-                   out_d * out_height * out_width + out_h * out_width + out_w];
+        out_of_bound ? static_cast<T>(0)
+                     : d_out_data[nc * out_depth * out_height * out_width +
+                                  out_d * out_height * out_width +
+                                  out_h * out_width + out_w];
   }
 }
 
@@ -89,11 +93,13 @@ __global__ void Pad3DGradConstNDHWC(const IndexType in_size,
     const IndexType out_d = in_d + pad_front;
     const IndexType out_h = in_h + pad_top;
     const IndexType out_w = in_w + pad_left;
-
+    bool out_of_bound = out_d < 0 || out_h < 0 || out_w < 0;
     d_in_data[in_index] =
-        d_out_data[n * out_depth * out_height * out_width * channels +
-                   out_d * out_height * out_width * channels +
-                   out_h * out_width * channels + out_w * channels + c];
+        out_of_bound
+            ? static_cast<T>(0)
+            : d_out_data[n * out_depth * out_height * out_width * channels +
+                         out_d * out_height * out_width * channels +
+                         out_h * out_width * channels + out_w * channels + c];
   }
 }
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修复了paddle.nn.functional.pad 部分配置下出现的访存越界问题。
出错日志：
```
2025-07-05 16:46:42.635513 GPU 2 123616 test begin: paddle.nn.functional.pad(Tensor([13, 47197443, 7],"float32"), tuple(-3,0,), data_format="NCL", )
terminate called after throwing an instance of 'common::enforce::EnforceNotMet'
  what():  (External) CUDA error(700), an illegal memory access was encountered. 
  [Hint: 'cudaErrorIllegalAddress'. The device encountered a load or store instruction on an invalid memory address. This leaves the process in an inconsistentstate and any further CUDA work will return the same error. To continue using CUDA, the process must be terminated and relaunched. ] (at /host_home/ningzhengsheng/src/Paddle/paddle/phi/core/platform/device/gpu/gpu_info.cc:348)



--------------------------------------
C++ Traceback (most recent call last):
--------------------------------------
0   egr::Grad(std::vector<paddle::Tensor, std::allocator<paddle::Tensor> > const&, std::vector<paddle::Tensor, std::allocator<paddle::Tensor> > const&, std::vector<paddle::Tensor, std::allocator<paddle::Tensor> > const&, bool, bool, bool, bool, std::vector<paddle::Tensor, std::allocator<paddle::Tensor> > const&)
1   egr::RunBackward(std::vector<paddle::Tensor, std::allocator<paddle::Tensor> > const&, std::vector<paddle::Tensor, std::allocator<paddle::Tensor> > const&, bool, bool, std::vector<paddle::Tensor, std::allocator<paddle::Tensor> > const&, bool, std::vector<paddle::Tensor, std::allocator<paddle::Tensor> > const&)
2   std::vector<paddle::Tensor, std::allocator<paddle::Tensor> >::~vector()
3   phi::DenseTensor::~DenseTensor()
4   std::_Sp_counted_deleter<phi::Allocation*, std::function<void (phi::Allocation*)>, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>::_M_dispose()
5   paddle::memory::allocation::CUDAAllocator::FreeImpl(phi::Allocation*)

----------------------
Error Message Summary:
----------------------
FatalError: `Process abort signal` is detected by the operating system.
  [TimeInfo: *** Aborted at 1751705262 (unix time) try "date -d @1751705262" if you are using GNU date ***]
  [SignalInfo: *** SIGABRT (@0x1e2e0) received by PID 123616 (TID 0x7fd3a3c7b740) from PID 123616 ***]
```
问题分析：
当pad的output Tensor比input Tensor的numel小的时候比如参数pad=tuple(-3,0,)，也就是说pad完成后输出tensor比输入tensor小，这个时候反向过程可能出现负数的index导致访存越界。修复该问题，并检查结果和torch对齐。
<img width="1116" height="124" alt="image" src="https://github.com/user-attachments/assets/0c499ef9-51ce-4938-aa17-1861c69af5d5" />

pcard-67164
