### PR TITLE
[0-size Tensor No.84] Add 0-size Tensor support for paddle.incubate.nn.functional.fused_layer_norm [fluid_ops]

### DIFF
--- a/paddle/phi/kernels/fusion/gpu/fused_layernorm_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/fused_layernorm_kernel.cu
@@ -1044,6 +1044,13 @@ void FusedLayerNormKernel(const Context& dev_ctx,
   }
 
   using U = phi::funcs::LayerNormParamType<T>;
+  if (x.numel() == 0) {
+    dev_ctx.template Alloc<T>(out);
+    if (residual_out) dev_ctx.template Alloc<T>(residual_out);
+    if (mean) dev_ctx.template Alloc<U>(mean);
+    if (variance) dev_ctx.template Alloc<U>(variance);
+    return;
+  }
   const T* x_data = x.data<T>();
   const U* norm_weight_data =
       norm_weight ? norm_weight.get().data<U>() : nullptr;

--- a/test/legacy_test/test_fused_layernorm_op.py
+++ b/test/legacy_test/test_fused_layernorm_op.py
@@ -1204,5 +1204,30 @@ class TestlayernormStaticOpCPU(unittest.TestCase):
         )
 
 
+@unittest.skipIf(
+    not core.is_compiled_with_cuda() and not paddle.is_compiled_with_rocm(),
+    "core is not compiled with CUDA or ROCM",
+)
+class TestlayernormOp_ZeroSize(TestlayernormOp):
+    def setUp(self):
+        np.random.seed(20)
+        # 0-size
+        batch = 0
+        cols = 256
+
+        self.x_np = np.random.uniform(-0.05, 0.05, [batch, cols])
+        self.residual_np = np.random.uniform(-0.05, 0.05, [batch, cols])
+        self.bias_np = np.random.uniform(-0.05, 0.05, [cols])
+        self.norm_weight_np = np.random.uniform(-0.05, 0.05, [cols])
+        self.norm_bias_np = np.random.uniform(-0.05, 0.05, [cols])
+        self.epsilon = 1e-5
+        self.residual_alpha = np.random.uniform(low=0.1, high=1.1, size=[1])
+
+        self.quant_scale = 0.15
+        self.quant_round_type = 1
+        self.quant_max_bound = 127
+        self.quant_min_bound = -127
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修改前向，增加单测

PaddleAPITest测试通过，错误为torch error
<img width="1316" height="383" alt="image" src="https://github.com/user-attachments/assets/363e595a-cb50-4c21-87e2-4938208eef15" />
