### PR TITLE
Fix paddle.incubate.nn.functional.fused_rms_norm big Tensor 

### DIFF
--- a/paddle/phi/kernels/gpu/rms_norm_funcs.h
+++ b/paddle/phi/kernels/gpu/rms_norm_funcs.h
@@ -516,31 +516,31 @@ __global__ void cuApplyRMSNorm(T* __restrict__ output_vals,
 }
 
 template <typename T, typename U>
-__device__ void cuLoadWriteStridedInputs(const int i1_block,
-                                         const int thr_load_row_off,
-                                         const int thr_load_col_off,
-                                         const int i2_off,
-                                         const int row_stride,
+__device__ void cuLoadWriteStridedInputs(const int64_t i1_block,
+                                         const int64_t thr_load_row_off,
+                                         const int64_t thr_load_col_off,
+                                         const int64_t i2_off,
+                                         const int64_t row_stride,
                                          U* warp_buf1,
                                          U* warp_buf2,
                                          const T* input,
                                          const T* dout,
-                                         const int i1_end,
-                                         const int n2,
+                                         const int64_t i1_end,
+                                         const int64_t n2,
                                          const U* __restrict__ mean,
                                          const U* __restrict__ invvar,
                                          bool rms_only) {
-  int i1 = i1_block + thr_load_row_off;
+  int64_t i1 = i1_block + thr_load_row_off;
   if (i1 < i1_end) {
     U curr_mean;
     if (!rms_only) {
       curr_mean = mean[i1];
     }
     U curr_invvar = invvar[i1];
-    for (int k = 0; k < blockDim.y; ++k) {
-      int i2 = i2_off + k;
-      int load_idx = i1 * n2 + i2;
-      int write_idx = thr_load_row_off * row_stride + thr_load_col_off + k;
+    for (int64_t k = 0; k < blockDim.y; ++k) {
+      int64_t i2 = i2_off + k;
+      int64_t load_idx = i1 * n2 + i2;
+      int64_t write_idx = thr_load_row_off * row_stride + thr_load_col_off + k;
       if (i2 < n2) {
         U curr_input = static_cast<U>(input[load_idx]);
         U curr_dout = static_cast<U>(dout[load_idx]);
@@ -559,8 +559,8 @@ __device__ void cuLoadWriteStridedInputs(const int i1_block,
       }
     }
   } else {
-    for (int k = 0; k < blockDim.y; ++k) {
-      int write_idx = thr_load_row_off * row_stride + thr_load_col_off + k;
+    for (int64_t k = 0; k < blockDim.y; ++k) {
+      int64_t write_idx = thr_load_row_off * row_stride + thr_load_col_off + k;
       if (!rms_only) {
         warp_buf1[write_idx] = U(0);
       }
@@ -570,31 +570,31 @@ __device__ void cuLoadWriteStridedInputs(const int i1_block,
 }
 
 template <typename T, typename U>
-__device__ void cuLoadAddStridedInputs(const int i1_block,
-                                       const int thr_load_row_off,
-                                       const int thr_load_col_off,
-                                       const int i2_off,
-                                       const int row_stride,
+__device__ void cuLoadAddStridedInputs(const int64_t i1_block,
+                                       const int64_t thr_load_row_off,
+                                       const int64_t thr_load_col_off,
+                                       const int64_t i2_off,
+                                       const int64_t row_stride,
                                        U* warp_buf1,
                                        U* warp_buf2,
                                        const T* input,
                                        const T* dout,
-                                       const int i1_end,
-                                       const int n2,
+                                       const int64_t i1_end,
+                                       const int64_t n2,
                                        const U* __restrict__ mean,
                                        const U* __restrict__ invvar,
                                        bool rms_only) {
-  int i1 = i1_block + thr_load_row_off;
+  int64_t i1 = i1_block + thr_load_row_off;
   if (i1 < i1_end) {
     U curr_mean;
     if (!rms_only) {
       curr_mean = mean[i1];
     }
     U curr_invvar = invvar[i1];
-    for (int k = 0; k < blockDim.y; ++k) {
-      int i2 = i2_off + k;
-      int load_idx = i1 * n2 + i2;
-      int write_idx = thr_load_row_off * row_stride + thr_load_col_off + k;
+    for (int64_t k = 0; k < blockDim.y; ++k) {
+      int64_t i2 = i2_off + k;
+      int64_t load_idx = i1 * n2 + i2;
+      int64_t write_idx = thr_load_row_off * row_stride + thr_load_col_off + k;
       if (i2 < n2) {
         U curr_input = static_cast<U>(input[load_idx]);
         U curr_dout = static_cast<U>(dout[load_idx]);
@@ -613,26 +613,28 @@ __device__ void cuLoadAddStridedInputs(const int i1_block,
 template <typename T, typename U>
 __global__ void cuComputePartGradGammaBeta(const T* __restrict__ dout,
                                            const T* __restrict__ input,
-                                           const int n1,
-                                           const int n2,
+                                           const int64_t n1,
+                                           const int64_t n2,
                                            const U* __restrict__ mean,
                                            const U* __restrict__ invvar,
                                            U epsilon,
                                            U* part_grad_gamma,
                                            U* part_grad_beta,
                                            bool rms_only) {
-  const int numsegs_n1 =
+  const int64_t numsegs_n1 =
       (n1 + blockDim.y * blockDim.y - 1) / (blockDim.y * blockDim.y);
-  const int segs_per_block = (numsegs_n1 + gridDim.y - 1) / gridDim.y;
-  const int i1_beg = blockIdx.y * segs_per_block * blockDim.y * blockDim.y;
-  const int i1_beg_plus_one =
+  const int64_t segs_per_block = (numsegs_n1 + gridDim.y - 1) / gridDim.y;
+  const int64_t i1_beg = blockIdx.y * segs_per_block * blockDim.y * blockDim.y;
+  const int64_t i1_beg_plus_one =
       (blockIdx.y + 1) * segs_per_block * blockDim.y * blockDim.y;
-  const int i1_end = i1_beg_plus_one < n1 ? i1_beg_plus_one : n1;
-  const int row_stride = blockDim.x + 1;
-  const int thr_load_col_off = (threadIdx.x * blockDim.y) & (blockDim.x - 1);
-  const int thr_load_row_off =
+  const int64_t i1_end = i1_beg_plus_one < n1 ? i1_beg_plus_one : n1;
+
+  const int64_t row_stride = blockDim.x + 1;
+  const int64_t thr_load_col_off =
+      (threadIdx.x * blockDim.y) & (blockDim.x - 1);
+  const int64_t thr_load_row_off =
       (threadIdx.x * blockDim.y) / blockDim.x + threadIdx.y * blockDim.y;
-  const int i2_off = blockIdx.x * blockDim.x + thr_load_col_off;
+  const int64_t i2_off = blockIdx.x * blockDim.x + thr_load_col_off;
   SharedMemory<U> shared;
   U* buf = shared.getPointer();  // buf has at least blockDim.x * blockDim.y *
                                  // blockDim.y + (blockDim.y -
@@ -655,7 +657,7 @@ __global__ void cuComputePartGradGammaBeta(const T* __restrict__ dout,
                            mean,
                            invvar,
                            rms_only);
-  for (int i1_block = i1_beg + blockDim.y * blockDim.y; i1_block < i1_end;
+  for (int64_t i1_block = i1_beg + blockDim.y * blockDim.y; i1_block < i1_end;
        i1_block += blockDim.y * blockDim.y) {
     cuLoadAddStridedInputs(i1_block,
                            thr_load_row_off,
@@ -677,9 +679,9 @@ __global__ void cuComputePartGradGammaBeta(const T* __restrict__ dout,
   // sum within each warp
   U acc1 = U(0);
   U acc2 = U(0);
-  for (int k = 0; k < blockDim.y; ++k) {
-    int row1 = threadIdx.y + k * blockDim.y;
-    int idx1 = row1 * row_stride + threadIdx.x;
+  for (int64_t k = 0; k < blockDim.y; ++k) {
+    int64_t row1 = threadIdx.y + k * blockDim.y;
+    int64_t idx1 = row1 * row_stride + threadIdx.x;
     if (!rms_only) {
       acc1 += warp_buf1[idx1];
     }
@@ -692,12 +694,12 @@ __global__ void cuComputePartGradGammaBeta(const T* __restrict__ dout,
   warp_buf2[threadIdx.y * row_stride + threadIdx.x] = acc2;
   __syncthreads();
   // sum all warps
-  for (int offset = blockDim.y / 2; offset > 1; offset /= 2) {
+  for (int64_t offset = blockDim.y / 2; offset > 1; offset /= 2) {
     if (threadIdx.y < offset) {
-      int row1 = threadIdx.y;
-      int row2 = threadIdx.y + offset;
-      int idx1 = row1 * row_stride + threadIdx.x;
-      int idx2 = row2 * row_stride + threadIdx.x;
+      int64_t row1 = threadIdx.y;
+      int64_t row2 = threadIdx.y + offset;
+      int64_t idx1 = row1 * row_stride + threadIdx.x;
+      int64_t idx2 = row2 * row_stride + threadIdx.x;
       if (!rms_only) {
         warp_buf1[idx1] += warp_buf1[idx2];
       }
@@ -705,12 +707,12 @@ __global__ void cuComputePartGradGammaBeta(const T* __restrict__ dout,
     }
     __syncthreads();
   }
-  int i2 = blockIdx.x * blockDim.x + threadIdx.x;
+  int64_t i2 = blockIdx.x * blockDim.x + threadIdx.x;
   if (threadIdx.y == 0 && i2 < n2) {
-    int row1 = threadIdx.y;
-    int row2 = threadIdx.y + 1;
-    int idx1 = row1 * row_stride + threadIdx.x;
-    int idx2 = row2 * row_stride + threadIdx.x;
+    int64_t row1 = threadIdx.y;
+    int64_t row2 = threadIdx.y + 1;
+    int64_t idx1 = row1 * row_stride + threadIdx.x;
+    int64_t idx2 = row2 * row_stride + threadIdx.x;
     if (!rms_only) {
       part_grad_beta[blockIdx.y * n2 + i2] = warp_buf1[idx1] + warp_buf1[idx2];
     }
@@ -722,15 +724,15 @@ template <typename U, typename V>
 __global__ void cuComputeGradGammaBeta(const U* part_grad_gamma,
                                        const U* part_grad_beta,
                                        const int part_size,
-                                       const int n1,
-                                       const int n2,
+                                       const int64_t n1,
+                                       const int64_t n2,
                                        V* grad_gamma,
                                        V* grad_beta,
                                        bool rms_only) {
   // sum partial gradients for gamma and beta
   SharedMemory<U> shared;
   U* buf = shared.getPointer();
-  int i2 = blockIdx.x * blockDim.x + threadIdx.x;
+  int64_t i2 = blockIdx.x * blockDim.x + threadIdx.x;
   if (i2 < n2) {
     // each warp does sequential reductions until reduced part_size is
     // num_warps
@@ -749,11 +751,12 @@ __global__ void cuComputeGradGammaBeta(const U* part_grad_gamma,
       }
     }
     // inter-warp reductions
-    const int nbsize3 = blockDim.x * blockDim.y / 2;
-    for (int offset = blockDim.y / 2; offset >= 1; offset /= 2) {
+    const int64_t nbsize3 = blockDim.x * blockDim.y / 2;
+    for (int64_t offset = blockDim.y / 2; offset >= 1; offset /= 2) {
       // top half write to shared memory
       if (threadIdx.y >= offset && threadIdx.y < 2 * offset) {
-        const int write_idx = (threadIdx.y - offset) * blockDim.x + threadIdx.x;
+        const int64_t write_idx =
+            (threadIdx.y - offset) * blockDim.x + threadIdx.x;
         buf[write_idx] = sum_gamma;
         if (!rms_only) {
           buf[write_idx + nbsize3] = sum_beta;
@@ -762,7 +765,7 @@ __global__ void cuComputeGradGammaBeta(const U* part_grad_gamma,
       __syncthreads();
       // bottom half sums
       if (threadIdx.y < offset) {
-        const int read_idx = threadIdx.y * blockDim.x + threadIdx.x;
+        const int64_t read_idx = threadIdx.y * blockDim.x + threadIdx.x;
         sum_gamma += buf[read_idx];
         if (!rms_only) {
           sum_beta += buf[read_idx + nbsize3];
@@ -783,15 +786,15 @@ __global__ void cuComputeGradGammaBeta(const U* part_grad_gamma,
 template <typename T, typename U, typename V>
 __global__ void cuComputeGradInput(const T* __restrict__ dout,
                                    const T* __restrict__ input,
-                                   const int n1,
-                                   const int n2,
+                                   const int64_t n1,
+                                   const int64_t n2,
                                    const U* __restrict__ mean,
                                    const U* __restrict__ invvar,
                                    U epsilon,
                                    const V* gamma,
                                    T* grad_input,
                                    bool rms_only) {
-  for (auto i1 = blockIdx.y; i1 < n1; i1 += gridDim.y) {
+  for (int64_t i1 = blockIdx.y; i1 < n1; i1 += gridDim.y) {
     U sum_loss1 = U(0);
     U sum_loss2 = U(0);
     U c_mean;
@@ -804,9 +807,9 @@ __global__ void cuComputeGradInput(const T* __restrict__ dout,
     const int numx = blockDim.x * blockDim.y;
     const int thrx = threadIdx.x + threadIdx.y * blockDim.x;
     if (gamma != NULL) {
-      int l = 4 * thrx;
+      int64_t l = 4 * thrx;
       for (; l + 3 < n2; l += 4 * numx) {
-        for (int k = 0; k < 4; ++k) {
+        for (int64_t k = 0; k < 4; ++k) {
           const U c_h = static_cast<U>(k_input[l + k]);
           const U c_loss = static_cast<U>(k_dout[l + k]);
           const U gamma_tmp = static_cast<U>(gamma[l + k]);
@@ -830,9 +833,9 @@ __global__ void cuComputeGradInput(const T* __restrict__ dout,
         }
       }
     } else {
-      int l = 4 * thrx;
+      int64_t l = 4 * thrx;
       for (; l + 3 < n2; l += 4 * numx) {
-        for (int k = 0; k < 4; ++k) {
+        for (int64_t k = 0; k < 4; ++k) {
           const U c_h = static_cast<U>(k_input[l + k]);
           const U c_loss = static_cast<U>(k_dout[l + k]);
           if (!rms_only) {
@@ -904,7 +907,7 @@ __global__ void cuComputeGradInput(const T* __restrict__ dout,
     U term1 = (U(1) / fH) * c_invvar;
     T* k_grad_input = grad_input + i1 * n2;
     if (gamma != NULL) {
-      for (int l = thrx; l < n2; l += numx) {
+      for (int64_t l = thrx; l < n2; l += numx) {
         const U c_h = static_cast<U>(k_input[l]);
         const U c_loss = static_cast<U>(k_dout[l]);
         U f_grad_input = fH * c_loss * static_cast<U>(gamma[l]);
@@ -918,7 +921,7 @@ __global__ void cuComputeGradInput(const T* __restrict__ dout,
         k_grad_input[l] = static_cast<T>(f_grad_input);
       }
     } else {
-      for (int l = thrx; l < n2; l += numx) {
+      for (int64_t l = thrx; l < n2; l += numx) {
         const U c_h = static_cast<U>(k_input[l]);
         const U c_loss = static_cast<U>(k_dout[l]);
         U f_grad_input = fH * c_loss;

--- a/paddle/phi/kernels/gpu/rms_norm_funcs.h
+++ b/paddle/phi/kernels/gpu/rms_norm_funcs.h
@@ -43,8 +43,6 @@ namespace cub = hipcub;
 
 namespace phi {
 
-  
-
 namespace {  // NOLINT
 
 #define DEFAULT_THROW(NAME, TYPE)                              \

--- a/paddle/phi/kernels/gpu/rms_norm_funcs.h
+++ b/paddle/phi/kernels/gpu/rms_norm_funcs.h
@@ -43,6 +43,8 @@ namespace cub = hipcub;
 
 namespace phi {
 
+  
+
 namespace {  // NOLINT
 
 #define DEFAULT_THROW(NAME, TYPE)                              \

--- a/paddle/phi/kernels/gpu/rms_norm_funcs.h
+++ b/paddle/phi/kernels/gpu/rms_norm_funcs.h
@@ -634,7 +634,8 @@ __global__ void cuComputePartGradGammaBeta(const T* __restrict__ dout,
       (threadIdx.x * blockDim.y) & (blockDim.x - 1);
   const int64_t thr_load_row_off =
       (threadIdx.x * blockDim.y) / blockDim.x + threadIdx.y * blockDim.y;
-  const int64_t i2_off = blockIdx.x * blockDim.x + thr_load_col_off;
+  const int64_t i2_off =
+      static_cast<int64_t>(blockIdx.x) * blockDim.x + thr_load_col_off;
   SharedMemory<U> shared;
   U* buf = shared.getPointer();  // buf has at least blockDim.x * blockDim.y *
                                  // blockDim.y + (blockDim.y -
@@ -707,7 +708,7 @@ __global__ void cuComputePartGradGammaBeta(const T* __restrict__ dout,
     }
     __syncthreads();
   }
-  int64_t i2 = blockIdx.x * blockDim.x + threadIdx.x;
+  int64_t i2 = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   if (threadIdx.y == 0 && i2 < n2) {
     int64_t row1 = threadIdx.y;
     int64_t row2 = threadIdx.y + 1;
@@ -751,12 +752,13 @@ __global__ void cuComputeGradGammaBeta(const U* part_grad_gamma,
       }
     }
     // inter-warp reductions
-    const int64_t nbsize3 = static_cast<int64_t>(blockDim.x) * blockDim.y / 2;
+    const int64_t nbsize3 = blockDim.x * blockDim.y / 2;
     for (int64_t offset = blockDim.y / 2; offset >= 1; offset /= 2) {
       // top half write to shared memory
       if (threadIdx.y >= offset && threadIdx.y < 2 * offset) {
         const int64_t write_idx =
-            static_cast<int64_t>(threadIdx.y - offset) * blockDim.x + threadIdx.x;
+            static_cast<int64_t>(threadIdx.y - offset) * blockDim.x +
+            threadIdx.x;
         buf[write_idx] = sum_gamma;
         if (!rms_only) {
           buf[write_idx + nbsize3] = sum_beta;
@@ -765,7 +767,8 @@ __global__ void cuComputeGradGammaBeta(const U* part_grad_gamma,
       __syncthreads();
       // bottom half sums
       if (threadIdx.y < offset) {
-        const int64_t read_idx = static_cast<int64_t>(threadIdx.y) * blockDim.x + threadIdx.x;
+        const int64_t read_idx =
+            static_cast<int64_t>(threadIdx.y) * blockDim.x + threadIdx.x;
         sum_gamma += buf[read_idx];
         if (!rms_only) {
           sum_beta += buf[read_idx + nbsize3];

--- a/paddle/phi/kernels/gpu/rms_norm_funcs.h
+++ b/paddle/phi/kernels/gpu/rms_norm_funcs.h
@@ -732,7 +732,7 @@ __global__ void cuComputeGradGammaBeta(const U* part_grad_gamma,
   // sum partial gradients for gamma and beta
   SharedMemory<U> shared;
   U* buf = shared.getPointer();
-  int64_t i2 = blockIdx.x * blockDim.x + threadIdx.x;
+  int64_t i2 = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   if (i2 < n2) {
     // each warp does sequential reductions until reduced part_size is
     // num_warps
@@ -751,12 +751,12 @@ __global__ void cuComputeGradGammaBeta(const U* part_grad_gamma,
       }
     }
     // inter-warp reductions
-    const int64_t nbsize3 = blockDim.x * blockDim.y / 2;
+    const int64_t nbsize3 = static_cast<int64_t>(blockDim.x) * blockDim.y / 2;
     for (int64_t offset = blockDim.y / 2; offset >= 1; offset /= 2) {
       // top half write to shared memory
       if (threadIdx.y >= offset && threadIdx.y < 2 * offset) {
         const int64_t write_idx =
-            (threadIdx.y - offset) * blockDim.x + threadIdx.x;
+            static_cast<int64_t>(threadIdx.y - offset) * blockDim.x + threadIdx.x;
         buf[write_idx] = sum_gamma;
         if (!rms_only) {
           buf[write_idx + nbsize3] = sum_beta;
@@ -765,7 +765,7 @@ __global__ void cuComputeGradGammaBeta(const U* part_grad_gamma,
       __syncthreads();
       // bottom half sums
       if (threadIdx.y < offset) {
-        const int64_t read_idx = threadIdx.y * blockDim.x + threadIdx.x;
+        const int64_t read_idx = static_cast<int64_t>(threadIdx.y) * blockDim.x + threadIdx.x;
         sum_gamma += buf[read_idx];
         if (!rms_only) {
           sum_beta += buf[read_idx + nbsize3];

--- a/paddle/phi/kernels/gpu/rms_norm_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/rms_norm_grad_kernel.cu
@@ -47,8 +47,8 @@ void HostRMSNormGradient(const Context& dev_ctx,
                          const T* dout,
                          const U* invvar,
                          const DenseTensor& input,
-                         int n1,
-                         int n2,
+                         int64_t n1,
+                         int64_t n2,
                          const V* gamma,
                          double epsilon,
                          T* grad_input,
@@ -125,10 +125,15 @@ void cuda_rms_norm_gradient(const Context& dev_ctx,
                             DenseTensor* grad_x,
                             DenseTensor* grad_scale,
                             const int begin_norm_axis) {
-  const auto x_dims = x.dims();
-  auto matrix_dim = phi::flatten_to_2d(x_dims, begin_norm_axis);
-  int rows = static_cast<int>(matrix_dim[0]);
-  int cols = static_cast<int>(matrix_dim[1]);
+  int64_t rows = 1;
+  int64_t cols = 1;
+  for (int i = 0; i < begin_norm_axis; i++) {
+    rows *= x.dims()[i];
+  }
+
+  for (int i = begin_norm_axis; i < x.dims().size(); i++) {
+    cols *= x.dims()[i];
+  }
   dev_ctx.template Alloc<T>(grad_x);
 
   DISPATCH_SCALE_TYPE(T,

--- a/paddle/phi/kernels/gpu/rms_norm_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/rms_norm_grad_kernel.cu
@@ -42,6 +42,8 @@ namespace phi {
 
 namespace {
 
+  
+
 template <typename T, typename U, typename V, typename Context>
 void HostRMSNormGradient(const Context& dev_ctx,
                          const T* dout,

--- a/paddle/phi/kernels/gpu/rms_norm_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/rms_norm_grad_kernel.cu
@@ -42,8 +42,6 @@ namespace phi {
 
 namespace {
 
-  
-
 template <typename T, typename U, typename V, typename Context>
 void HostRMSNormGradient(const Context& dev_ctx,
                          const T* dout,

--- a/paddle/phi/kernels/gpu/rms_norm_kernel.cu
+++ b/paddle/phi/kernels/gpu/rms_norm_kernel.cu
@@ -106,6 +106,8 @@ __inline__ __device__ T BlockAllReduce(T val) {
   return result_broadcast;
 }
 
+
+
 template <typename T>
 __inline__ __device__ T Div(T a, T b);
 

--- a/paddle/phi/kernels/gpu/rms_norm_kernel.cu
+++ b/paddle/phi/kernels/gpu/rms_norm_kernel.cu
@@ -106,8 +106,6 @@ __inline__ __device__ T BlockAllReduce(T val) {
   return result_broadcast;
 }
 
-
-
 template <typename T>
 __inline__ __device__ T Div(T a, T b);
 

--- a/paddle/phi/kernels/gpu/rms_norm_kernel.cu
+++ b/paddle/phi/kernels/gpu/rms_norm_kernel.cu
@@ -202,11 +202,11 @@ struct alignas(sizeof(T) * N) Pack {
 template <typename SRC, typename DST>
 struct DirectLoad {
   using LoadType = DST;
-  DirectLoad(const SRC* src, int32_t row_size) : src(src), row_size(row_size) {}
+  DirectLoad(const SRC* src, int64_t row_size) : src(src), row_size(row_size) {}
   template <int N>
-  __device__ void load(DST* dst, int32_t row, int32_t col) const {
+  __device__ void load(DST* dst, int64_t row, int64_t col) const {
     Pack<SRC, N> pack;
-    const int32_t offset = (row * row_size + col) / N;
+    const int64_t offset = (row * row_size + col) / N;
     pack = *(reinterpret_cast<const Pack<SRC, N>*>(src) + offset);
 #pragma unroll
     for (int i = 0; i < N; ++i) {
@@ -214,7 +214,7 @@ struct DirectLoad {
     }
   }
   const SRC* src;
-  int32_t row_size;
+  int64_t row_size;
 };
 
 template <typename SRC, typename DST>
@@ -427,8 +427,8 @@ template <typename LOAD,
 __global__ void __launch_bounds__(block_size)
     RmsNormBlockSMemImpl(LOAD load,
                          STORE store,
-                         const int32_t rows,
-                         const int32_t cols,
+                         const int64_t rows,
+                         const int64_t cols,
                          const float epsilon,
                          ComputeType col_divisor,
                          float* inv_var_data) {
@@ -437,10 +437,10 @@ __global__ void __launch_bounds__(block_size)
   auto* buf = reinterpret_cast<LoadType*>(shared_buf);
   const int tid = threadIdx.x;
   assert(cols % kPackSize == 0);
-  const int num_packs = static_cast<int>(cols) / kPackSize;
-  for (int32_t row = blockIdx.x; row < rows; row += gridDim.x) {
+  const int64_t num_packs = cols / kPackSize;
+  for (int64_t row = blockIdx.x; row < rows; row += gridDim.x) {
     ComputeType thread_sum_square = 0;
-    for (int pack_id = tid; pack_id < num_packs; pack_id += block_size) {
+    for (int64_t pack_id = tid; pack_id < num_packs; pack_id += block_size) {
       LoadType pack[kPackSize];
       load.template load<kPackSize>(pack, row, pack_id * kPackSize);
 #pragma unroll
@@ -462,10 +462,10 @@ __global__ void __launch_bounds__(block_size)
     if (inv_var_data != nullptr) {
       inv_var_data[row] = row_inv_rms;
     }
-    for (int pack_id = tid; pack_id < num_packs; pack_id += block_size) {
+    for (int64_t pack_id = tid; pack_id < num_packs; pack_id += block_size) {
       ComputeType pack[kPackSize];
 #pragma unroll
-      for (int i = 0; i < kPackSize; ++i) {
+      for (int64_t i = 0; i < kPackSize; ++i) {
         pack[i] = static_cast<ComputeType>(buf[i * num_packs + pack_id]) *
                   row_inv_rms;
       }
@@ -483,8 +483,8 @@ inline GPU(Error_t) LaunchRmsNormBlockSMemImpl(GPU(Stream_t) stream,
                                                LOAD load,
                                                STORE store,
                                                int smem,
-                                               const int32_t rows,
-                                               const int32_t cols,
+                                               const int64_t rows,
+                                               const int64_t cols,
                                                const float epsilon,
                                                ComputeType col_divisor,
                                                float* inv_var_data) {
@@ -540,8 +540,8 @@ inline GPU(Error_t)
     TryDispatchRmsNormBlockSMemImplBlockSize(GPU(Stream_t) stream,
                                              LOAD load,
                                              STORE store,
-                                             const int32_t rows,
-                                             const int32_t cols,
+                                             const int64_t rows,
+                                             const int64_t cols,
                                              const float epsilon,
                                              ComputeType col_divisor,
                                              bool* success,
@@ -622,7 +622,6 @@ inline GPU(Error_t)
   }();
 
   const size_t smem = cols * sizeof(typename LOAD::LoadType);
-
   int max_active_blocks_conf_1;
   {
     GPU(Error_t)
@@ -729,6 +728,7 @@ inline GPU(Error_t)
       return err;
     }
   }
+
   if (max_active_blocks_conf_2 == max_active_blocks_conf_1 ||
       (max_active_blocks_conf_2 > 0 && rows <= sm_count)) {
     *success = true;
@@ -746,7 +746,6 @@ inline GPU(Error_t)
                                                          col_divisor,
                                                          inv_var_data);
   }
-
   *success = true;
   return LaunchRmsNormBlockSMemImpl<LOAD,
                                     STORE,
@@ -769,8 +768,8 @@ struct TryDispatchRmsNormBlockSMemImplPackSize {
   operator()(GPU(Stream_t) stream,
              LOAD load,
              STORE store,
-             const int32_t rows,
-             const int32_t cols,
+             const int64_t rows,
+             const int64_t cols,
              const float epsilon,
              ComputeType col_divisor,
              bool* success,
@@ -824,8 +823,8 @@ template <typename LOAD, typename STORE, typename ComputeType>
 inline GPU(Error_t) TryDispatchRmsNormBlockSMemImpl(GPU(Stream_t) stream,
                                                     LOAD load,
                                                     STORE store,
-                                                    const int32_t rows,
-                                                    const int32_t cols,
+                                                    const int64_t rows,
+                                                    const int64_t cols,
                                                     const float epsilon,
                                                     ComputeType col_divisor,
                                                     bool* success,
@@ -848,12 +847,12 @@ inline typename std::enable_if<!std::is_same<ComputeType, double>::value,
 DispatchRmsNorm(GPU(Stream_t) stream,
                 LOAD load,
                 STORE store,
-                const int32_t rows,
-                const int32_t cols,
+                const int64_t rows,
+                const int64_t cols,
                 const float epsilon,
                 float* inv_var_data) {
   const ComputeType col_divisor = 1.0f / cols;
-  bool dispatch_smem_impl_success;
+  bool dispatch_smem_impl_success = false;
   {
     GPU(Error_t)
     err = TryDispatchRmsNormBlockSMemImpl<LOAD, STORE, ComputeType>(
@@ -870,6 +869,16 @@ DispatchRmsNorm(GPU(Stream_t) stream,
       return err;
     }
   }
+  PADDLE_ENFORCE_EQ(
+      dispatch_smem_impl_success,
+      true,
+      common::errors::Fatal(
+          "Failed to launch RMSNorm kernel with shared memory implementation!"
+          "This is likely due to large 'cols' value (%ld) requiring too much "
+          "shared memory. "
+          "Consider using smaller 'cols' or switching to global memory "
+          "implementation.",
+          cols));
   return GPU(Success);
 }
 
@@ -924,15 +933,15 @@ struct SkipLoadAndStoreResidual {
 
 template <typename SRC, typename DST>
 struct AffineStore {
-  AffineStore(DST* y, int32_t row_size, const DST* gamma, const DST* beta)
+  AffineStore(DST* y, int64_t row_size, const DST* gamma, const DST* beta)
       : y(y), row_size(row_size), gamma(gamma), beta(beta) {}
   template <int N>
-  __device__ void store(const SRC* src, int32_t row, int32_t col) {
+  __device__ void store(const SRC* src, int64_t row, int64_t col) {
     Pack<DST, N> y_pack;
     Pack<DST, N> gamma_pack;
     Pack<DST, N> beta_pack;
-    const int32_t offset = (row * row_size + col) / N;
-    const int32_t gamma_offset = col / N;
+    const int64_t offset = (row * row_size + col) / N;
+    const int64_t gamma_offset = col / N;
     gamma_pack = *(reinterpret_cast<const Pack<DST, N>*>(gamma) + gamma_offset);
 
     // Author(Zhengzekang): Bias maybe optional.
@@ -956,7 +965,7 @@ struct AffineStore {
     *(reinterpret_cast<Pack<DST, N>*>(y) + offset) = y_pack;
   }
   DST* y;
-  int32_t row_size;
+  int64_t row_size;
   const DST* gamma;
   const DST* beta;
 };
@@ -1132,8 +1141,8 @@ void RmsNormKernel(const Context& dev_ctx,
     inv_var_data = dev_ctx.template Alloc<float>(inv_var);
   }
 
-  int32_t rows = 1;
-  int32_t cols = 1;
+  int64_t rows = 1;
+  int64_t cols = 1;
   for (int i = 0; i < begin_norm_axis; i++) {
     rows *= x.dims()[i];
   }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
- 修复fused_rms_norm 大Tensor 访存越界问题
- fused_rms_norm的kernel计算流程是将每一行加载到shared mem中，所以当col的取值过大时会导致kernel launch失败，在kernel中未做强制检查，导致kernel未launch就直接退出，输出结果变为全0。这里补充检查。
- 当输入数据类型为float16时，fused_rms_norm中会将数据cast成float32参与norm计算，以提升精度。在float16下，可以和下面的torch实现对齐精度。
```python
class RMSNormFunction(torch.autograd.Function):
    @staticmethod
    def forward(
        ctx,
        x: torch.Tensor,
        norm_weight: torch.Tensor,
        norm_bias: Optional[torch.Tensor],
        epsilon: float,
        begin_norm_axis: int,
        bias: Optional[torch.Tensor] = None,
        residual: Optional[torch.Tensor] = None,
        quant_scale: float = -1.0,
        quant_round_type: int = 0,
        quant_max_bound: float = 0.0,
        quant_min_bound: float = 0.0,
    ) -> torch.Tensor:
        """Forward pass of RMSNorm."""
        def _flatten_from_axis(tensor: torch.Tensor, axis: int) -> torch.Tensor:
            """Flatten tensor starting from given axis."""
            rows = torch.prod(torch.tensor(tensor.shape[:axis])).item()
            cols = torch.prod(torch.tensor(tensor.shape[axis:])).item()
            return tensor.reshape(rows, cols)

        # Save original dtype and shape for later
        origin_dtype = x.dtype
        origin_shape = x.shape

        # Convert inputs to float32 if needed
        x = x.float() if x.dtype == torch.float16 else x
        norm_weight = norm_weight.float() if norm_weight.dtype == torch.float16 else norm_weight
        residual = residual.float() if residual is not None and residual.dtype == torch.float16 else residual
        bias = bias.float() if bias is not None and bias.dtype == torch.float16 else bias
        norm_bias = norm_bias.float() if norm_bias is not None and norm_bias.dtype == torch.float16 else norm_bias

        # Apply residual and bias if provided
        output = x
        if residual is not None:
            output = output + residual
        if bias is not None:
            output = output + bias

        # Normalization
        output = _flatten_from_axis(output, begin_norm_axis)
        output_sq = output.pow(2)
        mean_output_sq = output_sq.mean(dim=-1, keepdim=True)
        rms = torch.sqrt(mean_output_sq + epsilon)
        invvar = 1.0 / rms
        output_norm = output * invvar
        output = output_norm * norm_weight

        # Add norm_bias if provided
        if norm_bias is not None:
            output = output + _flatten_from_axis(norm_bias, begin_norm_axis)

        # Quantization if enabled
        if quant_scale > 0:
            output = output / quant_scale
            if quant_round_type == 0:
                output = torch.round(output)
            elif quant_round_type == 1:
                output = torch.where(
                    output >= 0,
                    torch.ceil(output - 0.5),
                    torch.floor(output + 0.5),
                )
            else:
                raise ValueError(f"Unsupported quant_round_type: {quant_round_type}")
            output = output * quant_scale
            output = torch.clamp(output, min=quant_min_bound, max=quant_max_bound)

        # Convert back to original dtype if no quantization
        if origin_dtype == torch.float16 and quant_scale <= 0:
            output = output.to(origin_dtype)
            norm_weight = norm_weight.to(origin_dtype)

        # Save tensors and metadata for backward
        ctx.save_for_backward(x, norm_weight, invvar)
        ctx.epsilon = epsilon
        ctx.exist_residual = residual is not None
        ctx.exist_bias = bias is not None
        ctx.exist_norm_bias = norm_bias is not None
        ctx.quant_scale = quant_scale
        ctx.begin_norm_axis = begin_norm_axis
        ctx.origin_shape = origin_shape

        return output

    @staticmethod
    def backward(ctx, grad_output: torch.Tensor) -> Tuple[Optional[torch.Tensor], ...]:
        """Backward pass of RMSNorm."""
        def _flatten_from_axis(tensor: torch.Tensor, axis: int) -> torch.Tensor:
            """Flatten tensor starting from given axis."""
            rows = torch.prod(torch.tensor(tensor.shape[:axis])).item()
            cols = torch.prod(torch.tensor(tensor.shape[axis:])).item()
            return tensor.reshape(rows, cols)

        exist_bias = ctx.exist_bias
        exist_residual = ctx.exist_residual
        exist_norm_bias = ctx.exist_norm_bias
        quant_scale = ctx.quant_scale
    
        if quant_scale > 0 or exist_norm_bias or exist_bias or exist_residual:
            raise NotImplementedError

        # Retrieve saved tensors and metadata
        x, weight, invvar = ctx.saved_tensors
        origin_shape = ctx.origin_shape
        origin_dtype = grad_output.dtype

        # Flatten tensors for computation
        grad_output = _flatten_from_axis(grad_output.float(), ctx.begin_norm_axis)
        x = _flatten_from_axis(x.float(), ctx.begin_norm_axis)
        weight = weight.float()

        # Gradient w.r.t. weight (gamma)
        x_norm = x * invvar
        grad_weight = (grad_output * x_norm).sum(dim=tuple(range(grad_output.dim() - 1)), keepdim=False)
        grad_weight = grad_weight.to(origin_dtype)

        # Gradient w.r.t. input (x)
        D = x.size(-1)
        S = (grad_output * weight * x * invvar).sum(dim=1, keepdim=True)
        term1 = invvar / D
        grad_x = (D * grad_output * weight - x * invvar * S) * term1
        grad_x = grad_x.to(origin_dtype).reshape(origin_shape)

        # Return gradients (order matches forward inputs)
        return (
            grad_x,                   # x
            grad_weight,              # norm_weight
            None,                     # norm_bias
            None,                     # epsilon
            None,                     # begin_norm_axis
            None,                     # bias
            None,                     # residual
            None,                     # quant_scale
            None,                     # quant_round_type
            None,                     # quant_max_bound
            None,                     # quant_min_bound
        )
```
Pcard-73263