### PR TITLE
Fix paddle.incubate.nn.functional.fused_bias_dropout_residual_layer_norm big Tensor

### DIFF
--- a/paddle/phi/kernels/funcs/layer_norm_impl.cu.h
+++ b/paddle/phi/kernels/funcs/layer_norm_impl.cu.h
@@ -601,16 +601,16 @@ __global__ __launch_bounds__(THREADS_PER_CTA) void fused_ln_bwd_fast_kernel(
   using Vec_scale = phi::AlignedVector<ScaleT, VecSize>;
   using MaskLoadT = phi::AlignedVector<MaskType, VecSize>;
 
-  const int tidx = threadIdx.x;
-  const int bidx = blockIdx.x;
-  const int lane = tidx % THREADS_PER_WARP;            // 0, 1, ..., 31
-  const int warp = tidx / THREADS_PER_WARP;            // 0, 1, 2, 3
-  const int warp_m = warp / WARPS_N;                   // 0, 1, 2, 3
-  const int warp_n = warp % WARPS_N;                   // 0
-  const int tid_r = warp_n * THREADS_PER_WARP + lane;  // 0, 1, ..., 31
+  const int64_t tidx = threadIdx.x;
+  const int64_t bidx = blockIdx.x;
+  const int64_t lane = tidx % THREADS_PER_WARP;            // 0, 1, ..., 31
+  const int64_t warp = tidx / THREADS_PER_WARP;            // 0, 1, 2, 3
+  const int64_t warp_m = warp / WARPS_N;                   // 0, 1, 2, 3
+  const int64_t warp_n = warp % WARPS_N;                   // 0
+  const int64_t tid_r = warp_n * THREADS_PER_WARP + lane;  // 0, 1, ..., 31
 
-  const int r = bidx * ROWS_PER_CTA + warp_m;
-  const int c = warp_n * THREADS_PER_WARP + lane;
+  const int64_t r = bidx * ROWS_PER_CTA + warp_m;
+  const int64_t c = warp_n * THREADS_PER_WARP + lane;
 
   static_assert(ELTS_PER_ROW == THREADS_PER_ROW * LDGS * VecSize, "");
 
@@ -632,22 +632,22 @@ __global__ __launch_bounds__(THREADS_PER_CTA) void fused_ln_bwd_fast_kernel(
   // step-1: compute dx and local results of dscale and dbias
   constexpr float rn = 1.f / static_cast<float>(ELTS_PER_ROW);
   Vec_scale gamma[LDGS];
-  int col = c;
+  int64_t col = c;
 #pragma unroll
-  for (int it = 0; it < LDGS; it++) {
+  for (int64_t it = 0; it < LDGS; it++) {
     phi::Load<ScaleT, VecSize>(gamma_ptr + col * VecSize, &gamma[it]);
     col += THREADS_PER_ROW;
   }
 
 #pragma unroll 1
-  for (int row = r; row < rows; row += gridDim.x * ROWS_PER_CTA) {
+  for (int64_t row = r; row < rows; row += gridDim.x * ROWS_PER_CTA) {
     const U mean_cur_row = mean_ptr[row];
     const U var_cur_row = rsqrt_<U>(var_ptr[row] + epsilon);
     Vec dout[LDGS], x[LDGS];
     MaskLoadT mask_vec[LDGS];
-    int col = c;
+    int64_t col = c;
 #pragma unroll
-    for (int it = 0; it < LDGS; it++) {
+    for (int64_t it = 0; it < LDGS; it++) {
       phi::Load<T, VecSize>(dout_ptr + row * ELTS_PER_ROW + col * VecSize,
                             &dout[it]);
       phi::Load<T, VecSize>(x_ptr + row * ELTS_PER_ROW + col * VecSize, &x[it]);
@@ -874,7 +874,7 @@ __global__ __launch_bounds__(THREADS_PER_CTA) void ln_bwd_fast_final_kernel(
 
   __shared__ U smem_space[(WARPS_M - 1) * THREADS_PER_ROW * VecSize];
 
-  for (int col = c; col < VEC_COLS; col += gridDim.x * THREADS_PER_ROW) {
+  for (int64_t col = c; col < VEC_COLS; col += gridDim.x * THREADS_PER_ROW) {
     const U *dg_part_ptr = (dg_part_) + r * ELTS_PER_ROW + col * VecSize;
     const U *db_part_ptr = (db_part_) + r * ELTS_PER_ROW + col * VecSize;
 
@@ -883,7 +883,7 @@ __global__ __launch_bounds__(THREADS_PER_CTA) void ln_bwd_fast_final_kernel(
     memset(dg_sum, 0, sizeof(U) * VecSize);
     memset(db_sum, 0, sizeof(U) * VecSize);
 #pragma unroll
-    for (int row = r; row < rows; row += ROWS_PER_CTA) {
+    for (int64_t row = r; row < rows; row += ROWS_PER_CTA) {
       Vec dg;
       Vec db;
       phi::Load<U, VecSize>(dg_part_ptr, &dg);
@@ -1326,8 +1326,8 @@ __global__ void LayerNormBackwardSumGradGammaBeta(const U *part_grad_gamma,
 template <typename T, typename U, int BDIMX, int BDIMY, typename ScaleT>
 __global__ void LayerNormBackwardComputeGradInput(const T *__restrict__ dout,
                                                   const T *__restrict__ input,
-                                                  const int n1,
-                                                  const int n2,
+                                                  const int64_t n1,
+                                                  const int64_t n2,
                                                   const U *__restrict__ mean,
                                                   const U *__restrict__ var,
                                                   const float epsilon,
@@ -1347,7 +1347,7 @@ __global__ void LayerNormBackwardComputeGradInput(const T *__restrict__ dout,
     constexpr int numx = BDIMX * BDIMY;
     const int thrx = threadIdx.x + threadIdx.y * BDIMX;
     if (gamma != NULL) {
-      int l = 4 * thrx;
+      int64_t l = 4 * thrx;
       for (; l + 3 < n2; l += 4 * numx) {
         for (int k = 0; k < 4; ++k) {
           const U c_h = static_cast<U>(k_input[l + k]);
@@ -1365,7 +1365,7 @@ __global__ void LayerNormBackwardComputeGradInput(const T *__restrict__ dout,
             c_loss * static_cast<U>(gamma[l]) * (c_h - c_mean) * c_invvar;
       }
     } else {
-      int l = 4 * thrx;
+      int64_t l = 4 * thrx;
       for (; l + 3 < n2; l += 4 * numx) {
         for (int k = 0; k < 4; ++k) {
           const U c_h = static_cast<U>(k_input[l + k]);
@@ -1428,7 +1428,7 @@ __global__ void LayerNormBackwardComputeGradInput(const T *__restrict__ dout,
     U term1 = (U(1) / fH) * c_invvar;
     T *k_grad_input = grad_input + i1 * n2;
     if (gamma != NULL) {
-      for (int l = thrx; l < n2; l += numx) {
+      for (int64_t l = thrx; l < n2; l += numx) {
         const U c_h = static_cast<U>(k_input[l]);
         const U c_loss = static_cast<U>(k_dout[l]);
         U f_grad_input = fH * c_loss * static_cast<U>(gamma[l]);
@@ -1438,7 +1438,7 @@ __global__ void LayerNormBackwardComputeGradInput(const T *__restrict__ dout,
         k_grad_input[l] = static_cast<T>(f_grad_input);
       }
     } else {
-      for (int l = thrx; l < n2; l += numx) {
+      for (int64_t l = thrx; l < n2; l += numx) {
         const U c_h = static_cast<U>(k_input[l]);
         const U c_loss = static_cast<U>(k_dout[l]);
         U f_grad_input = fH * c_loss;
@@ -1473,9 +1473,9 @@ __global__ void LayerNormBackwardComputeGradInputWithSmallFeatureSize(
     const U c_mean = mean[bid];
     const U c_invvar = rsqrt_<U>(var[bid] + epsilon);
 
-    const int main_vec_n2 = n2 / DataPerTid;
-    const int tid_num = WarpSize * blockDim.y;
-    const int thrx = threadIdx.x + threadIdx.y * WarpSize;
+    const int64_t main_vec_n2 = n2 / DataPerTid;
+    const int64_t tid_num = WarpSize * blockDim.y;
+    const int64_t thrx = threadIdx.x + threadIdx.y * WarpSize;
 
     // One feature-size per block.
     const T *__restrict__ k_dout = dout + bid * n2;
@@ -1500,14 +1500,14 @@ __global__ void LayerNormBackwardComputeGradInputWithSmallFeatureSize(
     U gamma_data[8];
 
     if (gamma != NULL) {
-      int tid = thrx;
-      for (int i = 0; tid < main_vec_n2; tid += tid_num, ++i) {
+      int64_t tid = thrx;
+      for (int64_t i = 0; tid < main_vec_n2; tid += tid_num, ++i) {
         VecT v_tmp_dout = v_k_dout[tid];
         VecT v_tmp_input = v_k_input[tid];
         VecScaleT v_tmp_gamma = v_gamma[tid];
 #pragma unroll
-        for (int k = 0; k < DataPerTid; ++k) {
-          const int idx = k + i * DataPerTid;
+        for (int64_t k = 0; k < DataPerTid; ++k) {
+          const int64_t idx = k + i * DataPerTid;
           dout_data[idx] = static_cast<U>(v_tmp_dout[k]);
           input_data[idx] = static_cast<U>(v_tmp_input[k]);
           gamma_data[idx] = static_cast<U>(v_tmp_gamma[k]);
@@ -1517,13 +1517,13 @@ __global__ void LayerNormBackwardComputeGradInputWithSmallFeatureSize(
         }
       }
     } else {
-      int tid = thrx;
-      for (int i = 0; tid < main_vec_n2; tid += tid_num, ++i) {
+      int64_t tid = thrx;
+      for (int64_t i = 0; tid < main_vec_n2; tid += tid_num, ++i) {
         VecT v_tmp_dout = v_k_dout[tid];
         VecT v_tmp_input = v_k_input[tid];
 #pragma unroll
-        for (int k = 0; k < DataPerTid; ++k) {
-          const int idx = k + i * DataPerTid;
+        for (int64_t k = 0; k < DataPerTid; ++k) {
+          const int64_t idx = k + i * DataPerTid;
           dout_data[idx] = static_cast<U>(v_tmp_dout[k]);
           input_data[idx] = static_cast<U>(v_tmp_input[k]);
           sum_loss1 += dout_data[idx];
@@ -1579,8 +1579,8 @@ __global__ void LayerNormBackwardComputeGradInputWithSmallFeatureSize(
     U fH = static_cast<U>(n2);
     U ratio_term = (static_cast<U>(1) / fH) * c_invvar;
     if (gamma != NULL) {
-      int tid = thrx;
-      for (int i = 0; tid < main_vec_n2; tid += tid_num, ++i) {
+      int64_t tid = thrx;
+      for (int64_t i = 0; tid < main_vec_n2; tid += tid_num, ++i) {
         VecT temp_grad;
 #pragma unroll
         for (int k = 0; k < DataPerTid; ++k) {
@@ -1594,8 +1594,8 @@ __global__ void LayerNormBackwardComputeGradInputWithSmallFeatureSize(
         v_grad[tid] = temp_grad;
       }
     } else {
-      int tid = thrx;
-      for (int i = 0; tid < main_vec_n2; tid += tid_num, ++i) {
+      int64_t tid = thrx;
+      for (int64_t i = 0; tid < main_vec_n2; tid += tid_num, ++i) {
         VecT temp_grad;
 #pragma unroll
         for (int k = 0; k < DataPerTid; ++k) {
@@ -1691,7 +1691,7 @@ __global__ void LayerNormBackwardGradientScaleOrBias(
   __shared__ typename BlockReduce::TempStorage temp_storage;
   int64_t beg_idx = threadIdx.x * feature_size + blockIdx.x + col_offset;
   int64_t end_idx = batch_size * feature_size + blockIdx.x + col_offset;
-  int stride = BlockDim * feature_size;
+  int64_t stride = BlockDim * feature_size;
   U d_scale_or_d_bias_partial = static_cast<U>(0);
 
   for (int64_t i = beg_idx; i < end_idx; i += stride) {
@@ -1905,7 +1905,6 @@ static void LayerNormBackward(
                       ((d_scale != nullptr ? 1 : 0) << 1) |
                       ((d_bias != nullptr ? 1 : 0));
   if (gradient_flag == 0) return;
-
   if (batch_size == 1) {
     LayerNormBackwardWhenBatchSizeIsOne<T, U, ScaleBiasWithSameTypeX>
         <<<(feature_size + kMaxBlockDim - 1) / kMaxBlockDim,

--- a/paddle/phi/kernels/funcs/layer_norm_impl.cu.h
+++ b/paddle/phi/kernels/funcs/layer_norm_impl.cu.h
@@ -982,8 +982,8 @@ template <typename T,
           typename ScaleT = U,
           typename MaskType = uint8_t>
 void ln_bwd_fast_kernel_driver(const phi::GPUContext &dev_ctx,
-                               const int rows,
-                               const int cols,
+                               const int64_t rows,
+                               const int64_t cols,
                                float epsilon,
                                const T *x_ptr,
                                const ScaleT *scale_ptr,
@@ -1261,7 +1261,7 @@ __global__ void LayerNormBackwardPartGradGammaBeta(const T *__restrict__ dout,
     }
     __syncthreads();
   }
-  int64_t i2 = blockIdx.x * BDIMX + threadIdx.x;
+  int64_t i2 = static_cast<int64_t>(blockIdx.x) * BDIMX + threadIdx.x;
   if (threadIdx.y == 0 && i2 < n2) {
     int row1 = threadIdx.y;
     int row2 = threadIdx.y + 1;
@@ -1276,13 +1276,13 @@ template <typename T, typename U, int BDIMX, int BDIMY, typename ScaleT>
 __global__ void LayerNormBackwardSumGradGammaBeta(const U *part_grad_gamma,
                                                   const U *part_grad_beta,
                                                   const int part_size,
-                                                  const int n1,
-                                                  const int n2,
+                                                  const int64_t n1,
+                                                  const int64_t n2,
                                                   ScaleT *grad_gamma,
                                                   ScaleT *grad_beta) {
   // sum partial gradients for gamma and beta
   __shared__ U buf[BDIMX * BDIMY];
-  int64_t i2 = blockIdx.x * BDIMX + threadIdx.x;
+  int64_t i2 = static_cast<int64_t>(blockIdx.x) * BDIMX + threadIdx.x;
   if (i2 < n2) {
     // each warp does sequential reductions until reduced part_size is num_warps
     int num_warp_reductions = part_size / BDIMY;

--- a/paddle/phi/kernels/fusion/gpu/fused_bias_dropout_residual_layer_norm_grad_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/fused_bias_dropout_residual_layer_norm_grad_kernel.cu
@@ -86,11 +86,11 @@ void FusedBiasDropoutResidualLnGradKernel(
                                        ln_bias_grad->numel() * sizeof(U)));
 
   const auto input_x_dims = y_grad.dims();
-  int bsz_seq = 1;
+  int64_t bsz_seq = 1;
   for (int i = 0; i < input_x_dims.size() - 1; i++) {
     bsz_seq *= input_x_dims[i];
   }
-  int dim_embed = input_x_dims[input_x_dims.size() - 1];
+  int64_t dim_embed = input_x_dims[input_x_dims.size() - 1];
   phi::fusion::DropoutParam dropout_param(
       dropout_fix_seed,
       0,

--- a/paddle/phi/kernels/fusion/gpu/fused_layernorm_residual_dropout_bias.h
+++ b/paddle/phi/kernels/fusion/gpu/fused_layernorm_residual_dropout_bias.h
@@ -595,7 +595,7 @@ __global__ __launch_bounds__(THREADS_PER_CTA) void fused_fast_ln_fwd_kernel(
   Vec bias[LDGS];
   if (bias_ptr != nullptr) {
 #pragma unroll
-    for (int it = 0, col = c; it < LDGS; it++) {
+    for (int64_t it = 0, col = c; it < LDGS; it++) {
       phi::Load<T, VecSize>(bias_ptr + col * VecSize, &bias[it]);
       col += THREADS_PER_ROW;
     }
@@ -604,21 +604,21 @@ __global__ __launch_bounds__(THREADS_PER_CTA) void fused_fast_ln_fwd_kernel(
   Vec_scale gamma[LDGS];
   Vec_scale beta[LDGS];
 #pragma unroll
-  for (int it = 0, col = c; it < LDGS; it++) {
+  for (int64_t it = 0, col = c; it < LDGS; it++) {
     phi::Load<ScaleT, VecSize>(gamma_ptr + col * VecSize, &gamma[it]);
     phi::Load<ScaleT, VecSize>(beta_ptr + col * VecSize, &beta[it]);
     col += THREADS_PER_ROW;
   }
 
   constexpr U rn = 1.f / U(ELTS_PER_ROW);
-  for (int row = r; row < rows; row += gridDim.x * ROWS_PER_CTA) {
+  for (int64_t row = r; row < rows; row += gridDim.x * ROWS_PER_CTA) {
     Vec x[LDGS];
     Vec_in_type x_input[LDGS];
     Vec residual[LDGS];
     Vec_float dequant_out_scale[LDGS];
 
 #pragma unroll
-    for (int it = 0, col = c; it < LDGS; it++) {
+    for (int64_t it = 0, col = c; it < LDGS; it++) {
       int64_t index = row * ELTS_PER_ROW + col * VecSize;
       phi::Load<T, VecSize>(residual_ptr + index, &residual[it]);
       phi::Load<InType, VecSize>(x_ptr + index, &x_input[it]);
@@ -820,7 +820,7 @@ __global__ __launch_bounds__(THREADS_PER_CTA) void fused_fast_ln_fwd_kernel(
     }
 
 #pragma unroll
-    for (int it = 0, col = c; it < LDGS; it++) {
+    for (int64_t it = 0, col = c; it < LDGS; it++) {
       int64_t index = row * ELTS_PER_ROW + col * VecSize;
       if (std::is_same<OutType, int8_t>::value) {
         phi::Store<OutType, VecSize>(x_output[it], y_ptr + index);
@@ -1137,6 +1137,8 @@ void LaunchLayernormResidualDropoutGrad(
     LayerNormScaleBiasT<T, U, ScaleBiasWithSameTypeX> *d_layernorm_bias,
     T *d_residual,
     T *d_dropout_src) {
+  std::cout << "rows: " << rows << std::endl;
+  std::cout << "cols: " << cols << std::endl;
   const T zero = static_cast<T>(0.0f);
   auto factor = dropout_prob == static_cast<float>(1.0f)
                     ? zero

--- a/paddle/phi/kernels/fusion/gpu/fused_layernorm_residual_dropout_bias.h
+++ b/paddle/phi/kernels/fusion/gpu/fused_layernorm_residual_dropout_bias.h
@@ -1137,8 +1137,6 @@ void LaunchLayernormResidualDropoutGrad(
     LayerNormScaleBiasT<T, U, ScaleBiasWithSameTypeX> *d_layernorm_bias,
     T *d_residual,
     T *d_dropout_src) {
-  std::cout << "rows: " << rows << std::endl;
-  std::cout << "cols: " << cols << std::endl;
   const T zero = static_cast<T>(0.0f);
   auto factor = dropout_prob == static_cast<float>(1.0f)
                     ? zero

--- a/paddle/phi/kernels/fusion/gpu/fused_layernorm_residual_dropout_bias.h
+++ b/paddle/phi/kernels/fusion/gpu/fused_layernorm_residual_dropout_bias.h
@@ -141,7 +141,7 @@ __global__ void FusedLayernormResidualDropoutBias(
     LayerNormParamType<T> *var,
     const float residual_alpha = 1.0) {
   int64_t col_id = threadIdx.x;
-  int64_t row_id = blockIdx.x * gridDim.y + blockIdx.y;
+  int64_t row_id = static_cast<int64_t>(blockIdx.x) * gridDim.y + blockIdx.y;
   if (row_id >= rows) return;
   int64_t idx = row_id * cols + col_id;
   GPURAND(StatePhilox4_32_10_t) state;
@@ -611,7 +611,8 @@ __global__ __launch_bounds__(THREADS_PER_CTA) void fused_fast_ln_fwd_kernel(
   }
 
   constexpr U rn = 1.f / U(ELTS_PER_ROW);
-  for (int64_t row = r; row < rows; row += gridDim.x * ROWS_PER_CTA) {
+  for (int64_t row = r; row < rows;
+       row += static_cast<int64_t>(gridDim.x) * ROWS_PER_CTA) {
     Vec x[LDGS];
     Vec_in_type x_input[LDGS];
     Vec residual[LDGS];
@@ -1122,8 +1123,8 @@ template <typename T,
           bool ScaleBiasWithSameTypeX = false>
 void LaunchLayernormResidualDropoutGrad(
     const phi::GPUContext &dev_ctx,
-    const uint32_t rows,
-    const uint32_t cols,
+    const int64_t rows,
+    const int64_t cols,
     const float epsilon,
     const float dropout_prob,
     const bool is_upscale_in_train,

--- a/paddle/phi/kernels/fusion/gpu/fused_residual_dropout_bias.h
+++ b/paddle/phi/kernels/fusion/gpu/fused_residual_dropout_bias.h
@@ -186,8 +186,8 @@ __global__ void FusedResidualDropoutBiasGrad(const T *dout,
                                                factor == static_cast<T>(1.0));
 
   if (col_id * VecSize < cols) {
-    for (int row_id = threadIdx.y; row_id < rows; row_id += blockDim.y) {
-      int index = row_id * cols + col_id * VecSize;
+    for (int64_t row_id = threadIdx.y; row_id < rows; row_id += blockDim.y) {
+      int64_t index = row_id * cols + col_id * VecSize;
       LoadT out_vec;
       MaskLoadT mask_vec;
       StoreT dx_vec;

--- a/paddle/phi/kernels/fusion/gpu/fused_residual_dropout_bias.h
+++ b/paddle/phi/kernels/fusion/gpu/fused_residual_dropout_bias.h
@@ -174,7 +174,7 @@ __global__ void FusedResidualDropoutBiasGrad(const T *dout,
                                              const int64_t cols,
                                              T *dx,
                                              T *dbias) {
-  int64_t col_id = blockIdx.x * blockDim.x + threadIdx.x;
+  int64_t col_id = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
 
   using LoadT = phi::AlignedVector<T, VecSize>;
   using StoreT = phi::AlignedVector<T, VecSize>;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
- 修复int溢出导致的访存越界问题
- batch较大时存在精度diff，未定位出明显bug
```
[accuracy error] backward  paddle.incubate.nn.functional.fused_bias_dropout_residual_layer_norm(x=Tensor([270000000, 2, 4],"float32"), residual=Tensor([270000000, 2, 4],"float32"), bias=None, ln_scale=Tensor([4],"float32"), ln_bias=None, dropout_rate=0.0, ln_epsilon=1e-05, training=True, mode="upscale_in_train", name=None, ) 
 Not equal to tolerance rtol=0.01, atol=0.01
Tensor-likes are not close!

Mismatched elements: 3 / 2160000000 (0.0%)
Greatest absolute difference: 0.03557777404785156 at index (122354108, 0, 3) (up to 0.01 allowed)
Greatest relative difference: 0.1643351912498474 at index (64014755, 1, 3) (up to 0.01 allowed)
ACTUAL: (shape=torch.Size([270000000, 2, 4]), dtype=torch.float32)
```
通过一些测试发现和做layernorm在实现上和torch后很大的区别。
paddle实现位置：https://github.com/PaddlePaddle/Paddle/blob/develop/paddle/phi/kernels/funcs/layer_norm_impl.cu.h#L445
torch实现位置：https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/native/cuda/layer_norm_kernel.cu#L196
paddle通过$$D(x) = E(x^2) - (E(x))^2$$的方式计算方差，而torch采用了Welford算法，在数值上更具稳定性。另外，paddle和torch在计算dx时也有很大的计算差异：
paddle实现位置：
https://github.com/PaddlePaddle/Paddle/blob/develop/paddle/phi/kernels/funcs/layer_norm_impl.cu.h#L1735
torch实现位置：
https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/native/cuda/layer_norm_kernel.cu#L348
这些diff使得在feature_size在较小的情况下导致float32计算会产生上述精度diff。
```
[accuracy error] backward  paddle.incubate.nn.functional.fused_bias_dropout_residual_layer_norm(x=Tensor([200000000, 1, 4],"float32"), residual=Tensor([200000000, 1, 4],"float32"), bias=None, ln_scale=Tensor([4],"float32"), ln_bias=None, dropout_rate=0.0, ln_epsilon=1e-05, training=True, mode="upscale_in_train", name=None, ) 
 Not equal to tolerance rtol=0.01, atol=0.01
Tensor-likes are not close!

Mismatched elements: 1 / 800000000 (0.0%)
Greatest absolute difference: 0.02027149498462677 at index (7029107, 0, 3) (up to 0.01 allowed)
Greatest relative difference: 0.20506636798381805 at index (7029107, 0, 3) (up to 0.01 allowed)
ACTUAL: (shape=torch.Size([200000000, 1, 4]), dtype=torch.float32)
tensor([[[ 0.4957, -0.1273, -0.2506, -0.1178]],
```
在float64下正常：
```
[Pass] paddle.incubate.nn.functional.fused_bias_dropout_residual_layer_norm(x=Tensor([200000000, 1, 4],"float64"), residual=Tensor([200000000, 1, 4],"float64"), bias=None, ln_scale=Tensor([4],"float64"), ln_bias=None, dropout_rate=0.0, ln_epsilon=1e-05, training=True, mode="upscale_in_train", name=None, )
```
Pcard-73263