### PR TITLE
[API]Fix histogramdd accuracy for big tensor

### DIFF
--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -5680,6 +5680,19 @@ def histogramdd(
             ranges
         ), f"The length of ranges list must be {D * 2}\n"
 
+    def __compute_flattened_index(index_list, hist_shape):
+        strides = []
+        acc = 1
+        for size in reversed(hist_shape):
+            strides.insert(0, acc)
+            acc *= size
+
+        flattened_index = paddle.zeros_like(index_list[0])
+        for idx, stride in zip(index_list, strides):
+            flattened_index += idx * stride
+
+        return flattened_index
+
     check_type(density, 'density', bool, 'histogramdd')
 
     __check_x(x)
@@ -5759,10 +5772,7 @@ def histogramdd(
             )
             index_list = paddle.static.setitem(index_list, i, index_list_i)
     index_list = tuple(index_list)
-    lut = paddle.arange(
-        paddle.to_tensor(hist_shape).prod(),
-    ).reshape(hist_shape)
-    flattened_index = lut[index_list]
+    flattened_index = __compute_flattened_index(index_list, hist_shape)
     hist = paddle.bincount(
         flattened_index,
         reshaped_weights,

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -5681,15 +5681,17 @@ def histogramdd(
         ), f"The length of ranges list must be {D * 2}\n"
 
     def __compute_flattened_index(index_list, hist_shape):
-        strides = []
-        acc = 1
-        for size in reversed(hist_shape):
-            strides.insert(0, acc)
-            acc *= size
+        strides = (
+            paddle.to_tensor(hist_shape[::-1])
+            .cumprod(dim=0)
+            .flip(0)[1:]
+            .tolist()
+        )
+        strides.append(1)
+        strides_tensor = paddle.to_tensor(strides)
 
-        flattened_index = paddle.zeros_like(index_list[0])
-        for idx, stride in zip(index_list, strides):
-            flattened_index += idx * stride
+        stacked_indices = paddle.stack(index_list, axis=-1)
+        flattened_index = (stacked_indices * strides_tensor).sum(axis=-1)
 
         return flattened_index
 

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -5681,17 +5681,13 @@ def histogramdd(
         ), f"The length of ranges list must be {D * 2}\n"
 
     def __compute_flattened_index(index_list, hist_shape):
-        strides = (
-            paddle.to_tensor(hist_shape[::-1])
-            .cumprod(dim=0)
-            .flip(0)[1:]
-            .tolist()
+        strides = paddle.to_tensor(hist_shape[::-1]).cumprod(dim=0).flip(0)[1:]
+        strides = paddle.concat(
+            [strides, paddle.to_tensor([1], dtype=strides.dtype)]
         )
-        strides.append(1)
-        strides_tensor = paddle.to_tensor(strides)
 
         stacked_indices = paddle.stack(index_list, axis=-1)
-        flattened_index = (stacked_indices * strides_tensor).sum(axis=-1)
+        flattened_index = (stacked_indices * strides).sum(axis=-1)
 
         return flattened_index
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
高维索引在索引个数很多时会出现异常，改为计算实现。实现大tensor下的精度对齐。