### PR TITLE
[Phi]fix variable_length_memory_efficient_attention

### DIFF
--- a/paddle/phi/kernels/fusion/cutlass/memory_efficient_attention/generate_variable_forward_kernels.py
+++ b/paddle/phi/kernels/fusion/cutlass/memory_efficient_attention/generate_variable_forward_kernels.py
@@ -316,7 +316,7 @@ class FwdKernel:
     def get_all(cls) -> list[FwdKernel]:
         kernels: list[FwdKernel] = []
         for aligned, dtype, (sm, sm_max) in itertools.product(
-            [True, False], DTYPES.keys(), zip(SM, [*SM[1:], args.max_arch])
+            [False, False], DTYPES.keys(), zip(SM, [*SM[1:], args.max_arch])
         ):
             # Remove some kernels we don't use
             if dtype == "bf16" and sm < 80:

--- a/paddle/phi/kernels/fusion/cutlass/memory_efficient_attention/generate_variable_forward_kernels.py
+++ b/paddle/phi/kernels/fusion/cutlass/memory_efficient_attention/generate_variable_forward_kernels.py
@@ -316,12 +316,10 @@ class FwdKernel:
     def get_all(cls) -> list[FwdKernel]:
         kernels: list[FwdKernel] = []
         for aligned, dtype, (sm, sm_max) in itertools.product(
-            [False, False], DTYPES.keys(), zip(SM, [*SM[1:], args.max_arch])
+            [True, False], DTYPES.keys(), zip(SM, [*SM[1:], args.max_arch])
         ):
             # Remove some kernels we don't use
             if dtype == "bf16" and sm < 80:
-                continue
-            if not aligned and sm >= 80:
                 continue
             for q, k, single_value_iter in [
                 (32, 128, True),

--- a/paddle/phi/kernels/fusion/cutlass/variable_length_memory_efficient_attention_kernel.cu
+++ b/paddle/phi/kernels/fusion/cutlass/variable_length_memory_efficient_attention_kernel.cu
@@ -108,6 +108,9 @@ void MultiHeadAttentionVariableForwardKernel(
     if (params.head_size % KernelType::MM0::kAlignmentA) {
       return;
     }
+    if (params.value_head_size % KernelType::MM0::kAlignmentB) {
+      return;
+    }
     kernel_launched = true;
     kernel_fn(k_, params, dev_ctx);
   };


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Operator Mechanism
### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes
### Description
<!-- Describe what you’ve done -->
variable_length_memory_efficient_attention在默认情况下生成且调用的是对齐的kernel，但实际情况下输入qkv的维度可能不能对齐，为保障正确性，在SM>80时也支持生成非对齐kernel。同时添加value_head_size的对齐检查。