### PR TITLE
[CodeStyle] Revert yamlfmt to `v0.16.0`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -154,7 +154,7 @@ repos:
           )$
   # For YAML files
   - repo: https://github.com/PFCCLab/yamlfmt-pre-commit-mirror.git
-    rev: v0.17.2
+    rev: v0.16.0
     hooks:
       - id: yamlfmt
         files: |


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

#74001 更新后会导致部分机器报如下错误，故 revert

```bash
pre-commit run yamlfmt --all-files
[INFO] Initializing environment for https://github.com/PFCCLab/yamlfmt-pre-commit-mirror.git.
[WARNING] repo `https://github.com/PFCCLab/yamlfmt-pre-commit-mirror.git` uses deprecated stage names (commit, merge-commit, push) which will be removed in a future version.  Hint: often `pre-commit autoupdate --repo https://github.com/PFCCLab/yamlfmt-pre-commit-mirror.git` will fix this.  if it does not -- consider reporting an issue to that repo.
[INFO] Installing environment for https://github.com/PFCCLab/yamlfmt-pre-commit-mirror.git.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
yamlfmt..................................................................Failed
- hook id: yamlfmt
- exit code: 1

/home/nyakku/.cache/pre-commit/repohcg83f1m/py_env-python3.10/lib/python3.10/site-packages/yamlfmt/yamlfmt: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /home/nyakku/.cache/pre-commit/repohcg83f1m/py_env-python3.10/lib/python3.10/site-packages/yamlfmt/yamlfmt)
/home/nyakku/.cache/pre-commit/repohcg83f1m/py_env-python3.10/lib/python3.10/site-packages/yamlfmt/yamlfmt: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /home/nyakku/.cache/pre-commit/repohcg83f1m/py_env-python3.10/lib/python3.10/site-packages/yamlfmt/yamlfmt)
```

<!-- PCard-66972 -->