### PR TITLE
[0-size Tensor No.165、218] Add 0-size Tensor support for paddle.nn.functional.cosine_similarity [fluid_ops]

### DIFF
--- a/python/paddle/nn/functional/common.py
+++ b/python/paddle/nn/functional/common.py
@@ -2229,6 +2229,8 @@ def cosine_similarity(
             [ 0.97689527,  0.99996042, -0.55138415])
 
     """
+    if x1.shape[axis] == 0 or x2.shape[axis] == 0:
+        return sum(paddle.multiply(x1, x2), axis=axis)
     bs = paddle.broadcast_shape([x1.shape[axis]], [x2.shape[axis]])
     w12 = sum(paddle.multiply(x1, x2), axis=axis)
     w1 = sum(paddle.multiply(x1, x1), axis=axis)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
165 paddle.nn.functional.cosine_similarity
python部分修改判断，增加单测，
PaddleAPITest测试通过
<img width="1325" height="268" alt="image" src="https://github.com/user-attachments/assets/b5f57934-168b-4810-b836-2770ca4f25a4" />

218 paddle.nn.functional.sigmoid_focal_loss
增加单测
PaddleAPITest测试通过
<img width="1320" height="283" alt="image" src="https://github.com/user-attachments/assets/845ff13b-c922-46f5-a46b-467f76009c15" />

