### PR TITLE
[Auto Parallel] fix recompute reentrant:false bugs in auto parallel&dynamic graph

### DIFF
--- a/python/paddle/distributed/fleet/recompute/recompute.py
+++ b/python/paddle/distributed/fleet/recompute/recompute.py
@@ -475,17 +475,7 @@ def _recompute_without_reentrant(
                     storage[holder_list[unpack_counter - 1]()] = inner_x
                 else:
                     if inner_x.is_dist():
-                        # TODO(jeff41404): it seems better to use `tmp_tensor = core.eager.Tensor(inner_x)`,
-                        # but other errors will be triggered during the current period, and can be modified after resolution
-                        tmp_tensor = core.eager.Tensor(
-                            inner_x.dtype,
-                            inner_x.shape,
-                            inner_x.name + "cpy",
-                            core.VarDesc.VarType.DENSE_TENSOR,
-                            inner_x.persistable,
-                            inner_x.process_mesh,
-                            inner_x.placements,
-                        )
+                        tmp_tensor = core.eager.Tensor(inner_x)
                     else:
                         tmp_tensor = core.eager.Tensor(
                             inner_x.dtype,

--- a/python/paddle/distributed/fleet/recompute/recompute.py
+++ b/python/paddle/distributed/fleet/recompute/recompute.py
@@ -471,7 +471,7 @@ def _recompute_without_reentrant(
                 if inner_x is None:
                     storage[holder_list[unpack_counter - 1]()] = None
                     return
-                if hasattr(inner_x, "main_grad"):
+                if hasattr(inner_x, "main_grad") or inner_x.grad is not None:
                     storage[holder_list[unpack_counter - 1]()] = inner_x
                 else:
                     if inner_x.is_dist():


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes 

### Description
<!-- Describe what you’ve done -->
动态图自动并行使用recompute并设置reentrant:false时的一些问题：
1. 使用原先的tmp_tensor = core.eager.Tensor会出现backward过程中读取ctx里存储的tensor未初始化的情况（fused_layers.py中）
2. 如果ctx中保存的tensor有grad，使用原先的tmp_tensor会将grad清除
该pr修复上述两种情况

NOTE: 原先使用以下代码
```cpp
# TODO(jeff41404): it seems better to use `tmp_tensor = core.eager.Tensor(inner_x)`,
# but other errors will be triggered during the current period, and can be modified after resolution
tmp_tensor = core.eager.Tensor(
    inner_x.dtype,
    inner_x.shape,
    inner_x.name + "cpy",
    core.VarDesc.VarType.DENSE_TENSOR,
    inner_x.persistable,
    inner_x.process_mesh,
    inner_x.placements,
)
```
是因为早前框架存在某些bug，需通过这种方式绕过，现替换为
```cpp
tmp_tensor = core.eager.Tensor(inner_x)
```
修改后已在动半qwen、baichuan、gpt2、llama7b上完成测试，可正常生效且loss对齐
pcard-86802