### PR TITLE
[Accuracy diff No.106] Fix accuracy diff for paddle.nn.functional.adaptive_avg_pool2d API

### DIFF
--- a/paddle/phi/kernels/funcs/fast_divmod.h
+++ b/paddle/phi/kernels/funcs/fast_divmod.h
@@ -67,6 +67,11 @@ struct FastDivMod {
     return result;
   }
 
+  __device__ __forceinline__ uint32_t DivCeil(uint32_t n) const {
+    DivModT res = Divmod(n);
+    return res.val[1] > 0 ? res.val[0] + 1 : res.val[0];
+  }
+
   int32_t shift_val;
   uint32_t divisor;
   uint32_t multiplier;
@@ -107,6 +112,10 @@ struct FastDivMod<int64_t> {
   __device__ __forceinline__ DivModT Divmod(uint64_t n) const {
     uint64_t q = Div(n);
     return {q, n - q * divisor};
+  }
+  __device__ __forceinline__ uint64_t DivCeil(uint32_t n) const {
+    DivModT res = Divmod(n);
+    return res.val[1] > 0 ? res.val[0] + 1 : res.val[0];
   }
 
   int shift_val;

--- a/paddle/phi/kernels/funcs/pooling.cu
+++ b/paddle/phi/kernels/funcs/pooling.cu
@@ -132,21 +132,11 @@ __device__ void PreparationPoolSize(IndexT index,
                                     IndexT* tmp_size
 
 ) {
-  if (index == 0) {
-    auto ksize_divmod_next = divmods.Divmod((index + 1) * input_size);
-    *tmp_size = ksize_divmod_next.val[1] > 0 ? ksize_divmod_next.val[0] + 1
-                                             : ksize_divmod_next.val[0];
-
-  } else if (index == output_size - 1) {
-    *tmp_size = input_size - divmods.Div(index * input_size);
-  } else {
-    auto ksize_divmod = divmods.Divmod(index * input_size);
-    auto ksize_divmod_next = divmods.Divmod((index + 1) * input_size);
-    *tmp_size = ksize_divmod_next.val[0] - ksize_divmod.val[0];
-    if (ksize_divmod_next.val[1] != 0) {
-      *tmp_size += 1;
-    }
-  }
+  IndexT left = (index == 0) ? 0 : divmods.Div(index * input_size);
+  IndexT right = (index == output_size - 1)
+                     ? input_size
+                     : divmods.DivCeil((index + 1) * input_size);
+  *tmp_size = right - left;
 }
 
 template <typename PoolProcess, typename T, typename IndexT>

--- a/paddle/phi/kernels/funcs/pooling.cu
+++ b/paddle/phi/kernels/funcs/pooling.cu
@@ -300,22 +300,38 @@ __global__ void KernelPool2DGrad(
     output_grad += output_offset;
 
     if (adaptive) {
+      auto tmp_phstart = divmods.height.Divmod(h_offset * output_height);
+      auto tmp_pwstart = divmods.width.Divmod(w_offset * output_width);
       auto tmp_phend = divmods.height.Divmod((h_offset + 1) * output_height);
       auto tmp_pwend = divmods.width.Divmod((w_offset + 1) * output_width);
-      phstart = divmods.height.Div(h_offset * output_height);
-      pwstart = divmods.width.Div(w_offset * output_width);
+      phstart = tmp_phstart.val[0];
+      pwstart = tmp_pwstart.val[0];
       phend = tmp_phend.val[1] > 0 ? tmp_phend.val[0] + 1 : tmp_phend.val[0];
       pwend = tmp_pwend.val[1] > 0 ? tmp_pwend.val[0] + 1 : tmp_pwend.val[0];
 
       for (IndexT ph = phstart; ph < phend; ++ph) {
+        auto ksize_h_divmod = divmods.ksize_h.Divmod(input_height);
+        auto tmp_height = ksize_h_divmod.val[1] > 0 ? ksize_h_divmod.val[0] + 1
+                                                    : ksize_h_divmod.val[0];
+        if (phstart != phend) {
+          if (tmp_phstart.val[1] != 0 && ph == phstart) {
+            tmp_height += 1;
+          } else if (tmp_phend.val[1] != 0 && ph == phend - 1) {
+            tmp_height += 1;
+          }
+        }
+
         for (IndexT pw = pwstart; pw < pwend; ++pw) {
           auto ksize_w_divmod = divmods.ksize_w.Divmod(input_width);
-          auto ksize_h_divmod = divmods.ksize_h.Divmod(input_height);
           auto tmp_width = ksize_w_divmod.val[1] > 0 ? ksize_w_divmod.val[0] + 1
                                                      : ksize_w_divmod.val[0];
-          auto tmp_height = ksize_h_divmod.val[1] > 0
-                                ? ksize_h_divmod.val[0] + 1
-                                : ksize_h_divmod.val[0];
+          if (pwstart != pwend) {
+            if (tmp_pwstart.val[1] != 0 && pw == pwstart) {
+              tmp_width += 1;
+            } else if (tmp_pwend.val[1] != 0 && pw == pwend - 1) {
+              tmp_width += 1;
+            }
+          }
           IndexT pool_size = tmp_height * tmp_width;
           IndexT tmp_idx = ph * output_width + pw;
           IndexT output_sub_idx =

--- a/paddle/phi/kernels/funcs/pooling.cu
+++ b/paddle/phi/kernels/funcs/pooling.cu
@@ -124,6 +124,31 @@ __device__ void OffsetPreparationFor4Dimension(IndexT index,
   }
 }
 
+template <typename IndexT>
+__device__ void PreparationPoolSize(IndexT index,
+                                    IndexT input_size,
+                                    IndexT output_size,
+                                    FastDivMod<IndexT> divmods,
+                                    IndexT* tmp_size
+
+) {
+  if (index == 0) {
+    auto ksize_divmod_next = divmods.Divmod((index + 1) * input_size);
+    *tmp_size = ksize_divmod_next.val[1] > 0 ? ksize_divmod_next.val[0] + 1
+                                             : ksize_divmod_next.val[0];
+
+  } else if (index == output_size - 1) {
+    *tmp_size = input_size - divmods.Div(index * input_size);
+  } else {
+    auto ksize_divmod = divmods.Divmod(index * input_size);
+    auto ksize_divmod_next = divmods.Divmod((index + 1) * input_size);
+    *tmp_size = ksize_divmod_next.val[0] - ksize_divmod.val[0];
+    if (ksize_divmod_next.val[1] != 0) {
+      *tmp_size += 1;
+    }
+  }
+}
+
 template <typename PoolProcess, typename T, typename IndexT>
 __global__ void KernelPool2D(const IndexT nthreads,
                              const T* input_data,
@@ -309,29 +334,14 @@ __global__ void KernelPool2DGrad(
       phend = tmp_phend.val[1] > 0 ? tmp_phend.val[0] + 1 : tmp_phend.val[0];
       pwend = tmp_pwend.val[1] > 0 ? tmp_pwend.val[0] + 1 : tmp_pwend.val[0];
 
+      IndexT tmp_height, tmp_width;
       for (IndexT ph = phstart; ph < phend; ++ph) {
-        auto ksize_h_divmod = divmods.ksize_h.Divmod(input_height);
-        auto tmp_height = ksize_h_divmod.val[1] > 0 ? ksize_h_divmod.val[0] + 1
-                                                    : ksize_h_divmod.val[0];
-        if (phstart != phend) {
-          if (tmp_phstart.val[1] != 0 && ph == phstart) {
-            tmp_height += 1;
-          } else if (tmp_phend.val[1] != 0 && ph == phend - 1) {
-            tmp_height += 1;
-          }
-        }
+        PreparationPoolSize(
+            ph, input_height, output_height, divmods.ksize_h, &tmp_height);
 
         for (IndexT pw = pwstart; pw < pwend; ++pw) {
-          auto ksize_w_divmod = divmods.ksize_w.Divmod(input_width);
-          auto tmp_width = ksize_w_divmod.val[1] > 0 ? ksize_w_divmod.val[0] + 1
-                                                     : ksize_w_divmod.val[0];
-          if (pwstart != pwend) {
-            if (tmp_pwstart.val[1] != 0 && pw == pwstart) {
-              tmp_width += 1;
-            } else if (tmp_pwend.val[1] != 0 && pw == pwend - 1) {
-              tmp_width += 1;
-            }
-          }
+          PreparationPoolSize(
+              pw, input_width, output_width, divmods.ksize_w, &tmp_width);
           IndexT pool_size = tmp_height * tmp_width;
           IndexT tmp_idx = ph * output_width + pw;
           IndexT output_sub_idx =

--- a/test/legacy_test/test_adaptive_avg_pool2d.py
+++ b/test/legacy_test/test_adaptive_avg_pool2d.py
@@ -217,6 +217,28 @@ class TestAdaptiveAvgPool2DAPI(unittest.TestCase):
                 out_6.numpy(), self.res_3_np, rtol=1e-5, atol=1e-8
             )
 
+    def test_grad(self):
+        for use_cuda in (
+            [False, True] if core.is_compiled_with_cuda() else [False]
+        ):
+            place = paddle.CUDAPlace(0) if use_cuda else paddle.CPUPlace()
+            paddle.disable_static(place=place)
+            x = paddle.to_tensor(self.x_np)
+            x.stop_gradient = False
+            for output_size in [[3, 3], [2, 5], [8, 8]]:
+                out = paddle.nn.functional.adaptive_avg_pool2d(
+                    x=x, output_size=output_size
+                )
+                x_grad = paddle.grad(
+                    [out],
+                    [x],
+                    grad_outputs=paddle.ones_like(out),
+                    allow_unused=True,
+                )
+                np.testing.assert_allclose(
+                    paddle.sum(x_grad[0]), out.numel(), rtol=1e-6
+                )
+
 
 class TestAdaptiveAvgPool2DClassAPI(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修复 paddle.nn.functional.adaptive_avg_pool2d 反向的精度问题。增加单测判断梯度和是否符合预期。

错误出现的原因在于 KernelPool2DGrad 中对 pool_size的计算错误，原本的  pool_size 由 pool_height（即 input_height / output_height 向上取整） 和 pool_width 乘积计算得出，但是实际上这样每个位置都会产生误差（除非 input_height 可以被 output_height整除），设Y=adaptive_avg_pool2d（X），对于这个算子我们期望 Y 反向传播回来的梯度可以均匀分配到输入X所有相关的元素上，也就是说X各元素的梯度和与Y各元素的梯度和应该相等，可以验证原本的算法是做不到这点的。

根据adaptive_avg_pool2d的定义我们可以知道，对于Y的每个元素 pool_size 是可能不同的，使用  input_height / output_height 向上取整这个定值是不对的。
正确的计算方法如下：
$\textbf{min} (\lceil \frac{(k+1) h_i}{h_o} \rceil , h_i)-\textbf{max} (\lfloor \frac{k h_i}{h_o} \rfloor, 0)$

可通过下列代码复现
```python
import torch
import paddle
import numpy

device = torch.device("cuda:0")
torch.set_default_device(device)

def init_input(numpy_tensor):
    paddle_x = paddle.to_tensor(numpy_tensor)
    torch_x = torch.tensor(numpy_tensor, requires_grad=True)
    paddle_x.stop_gradient = False

    numpy.testing.assert_allclose(
        paddle_x.numpy(),
        torch_x.cpu().detach().numpy(),
        1e-10,
        1e-10,
        err_msg='intput diff'
    )
    return paddle_x, torch_x



# paddle.diff(Tensor([2, 760567127],"float32"), n=1, axis=0, prepend=Tensor([3, 760567127],"float32"), append=None, )
input_tensor = (numpy.ones([1, 1, 7, 7])).astype("float32") 
paddle_input, torch_input = init_input(input_tensor)
paddle_out = paddle.nn.functional.adaptive_avg_pool2d(paddle_input, output_size=(2, 5,), data_format="NCHW", name=None, )
torch_out = torch.nn.functional.adaptive_avg_pool2d(torch_input, output_size=(2, 5,))

print("input:", paddle_input[0][0])
print("torch shape:", torch_out.shape)
print("paddle shape:", paddle_out.shape)

print("paddle out:", paddle_out[0][0])
print("torch out:", torch_out[0][0])

numpy.testing.assert_allclose(
    torch_out.cpu().detach().numpy(),
    paddle_out.numpy(),
    1e-2,
    1e-2,
    err_msg='output diff'
)

numpy_tensor = (numpy.ones([1, 1, 2, 5])).astype("float32")
paddle_grad, torch_grad = init_input(numpy_tensor)
torch_x_grad = torch.autograd.grad([torch_out], [torch_input], grad_outputs=torch_grad)
paddle_x_grad = paddle.grad([paddle_out], [paddle_input], grad_outputs=paddle_grad, allow_unused=True)

print(torch_x_grad[0], torch.sum(torch_x_grad[0]))
print(paddle_x_grad[0], paddle.sum(paddle_x_grad[0]))
numpy.testing.assert_allclose(
    torch_x_grad[0].cpu().detach().numpy(),
    paddle_x_grad[0].numpy(),
    1e-2,
    1e-2,
    err_msg='output diff'
)
```

其他内容：
为了提升可读性，给 FastDivMod 结构体添加了 DivCeil方法，其他使用 Divmod 的代码后续也可以优化。

Pcard-67164