### PR TITLE
[Accuracy diff No.16] Fix accuracy diff for `paddle.cumsum` 、 `paddle.logcumsumexp` API

### DIFF
--- a/test/legacy_test/test_logcumsumexp_op.py
+++ b/test/legacy_test/test_logcumsumexp_op.py
@@ -77,8 +77,13 @@ def np_logcumsumexp_grad(
     exclusive: bool = False,
 ):
     out = np_logcumsumexp(x, axis, flatten, reverse, exclusive)
-    log_grad_positive = np.where(dout > 0, np.log(dout), np.finfo(x.dtype).min)
-    log_grad_negative = np.where(dout < 0, np.log(-dout), np.finfo(x.dtype).min)
+    dout = np.asarray(dout)
+    pos_mask = dout > 0
+    neg_mask = dout < 0
+    log_grad_positive = np.full_like(dout, np.finfo(x.dtype).min)
+    log_grad_negative = np.full_like(dout, np.finfo(x.dtype).min)
+    log_grad_positive[pos_mask] = np.log(dout[pos_mask])
+    log_grad_negative[neg_mask] = np.log(-dout[neg_mask])
 
     output_pos = np.exp(
         np_logcumsumexp(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

#### 错误定位：
1. `ThrustCumsumKernel` 自身的精度误差就极大
2. fp32 下大 tensor 拥有累计误差

#### 解决方案：
1. 直接删除 `ThrustCumsumKernel` 分支处理，进入后续 CUDA `cub` 计算
2. `BlockPrefixCallbackOp` 采用 Kahan 算法，参考：https://en.wikipedia.org/wiki/Kahan_summation_algorithm
3. `BlockPrefixCallbackOp` 对于 `LogAddExp` 算子特例，采用 Kahan + Online Scale，使其数值更稳定

#### 其他修改：
1. 优化 `np_logcumsumexp_grad` ，避免直接计算 `np.log(-dout)`  (dout > 0) 报错

#### 测试：
修复后，测试用例大致分为三类：
1. 累积维度小，直接 Pass
2. 累积维度过大，精度误差超 1e-2：
<img width="812" height="668" alt="image" src="https://github.com/user-attachments/assets/0f37cd14-e1f7-42da-be82-b36d34657a26" />

考虑到超大张量累积误差本身就更大，将 atol、rtol 改为 1 后基本通过测试：
<img width="834" height="108" alt="image" src="https://github.com/user-attachments/assets/bc63f774-cc47-4e9d-bb52-7659db1753d4" />

3. 数据类型为 fp16，torch 计算错误，paddle 使用 MPType，符合理论值：
<img width="862" height="768" alt="image" src="https://github.com/user-attachments/assets/51fadfe6-c9c0-4ad9-ae0a-1282605a049c" />

将其添加至 torch_error_skip 跳过精度测试

4. torch 直接报告 CUDA 700：
<img width="986" height="188" alt="image" src="https://github.com/user-attachments/assets/08f87b00-1b40-486e-95ef-54bfa8e00108" />

将其添加至 torch_error_skip 跳过精度测试

#### 补充测试：
1. paddle_only 测试全部通过：
<img width="1276" height="450" alt="image" src="https://github.com/user-attachments/assets/88977a35-9de8-4e02-91c9-e8ee24467c48" />

2. paddle 与 torch 在固定数值下的理论值分析，对于以下测试用例：
```
paddle.cumsum(x=Tensor([4294967297],"float32"), )
paddle.logcumsumexp(x=Tensor([4294967297],"float32"), )
```

张量通过 `full` 填充为 0.01，则 `cumsum` 期望值约为 `42949672.97` ， `logcumsumexp` 期望值约为 `22.1907` 
<img width="556" height="84" alt="image" src="https://github.com/user-attachments/assets/c0bf1f7f-f6fd-4ad6-9fdd-cf8b4dc4ec03" />
<img width="566" height="86" alt="image" src="https://github.com/user-attachments/assets/1712cf8b-12a2-4b30-ae60-8434ddb6cfb2" />

发现 `cumsum` 均与理论值有差异，但数值接近，用时相同；`logcumsumexp` 的 torch 更接近理论值，paddle 仍有差异，且远远慢于 torch，等待算法进一步修复

Pcard-85711
