### PR TITLE
Rename use_mkldnn to use_onednn in test/deprecated/

### DIFF
--- a/test/deprecated/legacy_test/test_batch_norm_op_deprecated.py
+++ b/test/deprecated/legacy_test/test_batch_norm_op_deprecated.py
@@ -150,7 +150,7 @@ def _reference_grad(x, y_grad, scale, mean, var, epsilon, data_format):
 
 class TestBatchNormOpTraining(unittest.TestCase):
     def setUp(self):
-        self.use_mkldnn = False
+        self.use_onednn = False
         self.fuse_with_relu = False
         self.data_formats = ["NCHW", "NHWC"]
         self.momentum = 0.9
@@ -303,7 +303,7 @@ class TestBatchNormOpTraining(unittest.TestCase):
                     "epsilon": epsilon,
                     "is_test": False,
                     "data_layout": data_layout,
-                    "use_mkldnn": self.use_mkldnn,
+                    "use_mkldnn": self.use_onednn,
                     "fuse_with_relu": self.fuse_with_relu,
                     "use_global_stats": self.use_global_stats,
                 }

--- a/test/deprecated/mkldnn/test_concat_mkldnn_op_deprecated.py
+++ b/test/deprecated/mkldnn/test_concat_mkldnn_op_deprecated.py
@@ -24,7 +24,7 @@ from paddle.base import core
 class TestConcatAxis0OneDNNOp(OpTest):
     def setUp(self):
         self.op_type = "concat"
-        self.mkldnn_data_type = "float32"
+        self.onednn_data_type = "float32"
         self.init_axis()
         self.init_shape()
         self.init_test_data()
@@ -33,7 +33,7 @@ class TestConcatAxis0OneDNNOp(OpTest):
         self.attrs = {
             'axis': self.axis,
             'use_mkldnn': True,
-            'mkldnn_data_type': self.mkldnn_data_type,
+            'mkldnn_data_type': self.onednn_data_type,
         }
 
         self.output = np.concatenate(
@@ -43,7 +43,7 @@ class TestConcatAxis0OneDNNOp(OpTest):
         self.outputs = {'Out': self.output}
 
     def configure_datatype(self):
-        self.mkldnn_data_type = "float32"
+        self.onednn_data_type = "float32"
         self.dtype = np.float32
 
     def test_check_output(self):
@@ -109,7 +109,7 @@ class TestConcatAxis3OneDNNOp(TestConcatAxis0OneDNNOp):
 class TestConcatLargeInputNum(OpTest):
     def setUp(self):
         self.op_type = "concat"
-        self.mkldnn_data_type = "float32"
+        self.onednn_data_type = "float32"
         self.init_axis()
         self.init_shape()
         self.init_test_data()
@@ -118,7 +118,7 @@ class TestConcatLargeInputNum(OpTest):
         self.attrs = {
             'axis': self.axis,
             'use_mkldnn': True,
-            'mkldnn_data_type': self.mkldnn_data_type,
+            'mkldnn_data_type': self.onednn_data_type,
         }
 
         self.output = np.concatenate(
@@ -128,7 +128,7 @@ class TestConcatLargeInputNum(OpTest):
         self.outputs = {'Out': self.output}
 
     def configure_datatype(self):
-        self.mkldnn_data_type = "float32"
+        self.onednn_data_type = "float32"
         self.dtype = np.float32
 
     def test_check_output(self):

--- a/test/deprecated/quantization/test_quant2_int8_mkldnn_pass_deprecated.py
+++ b/test/deprecated/quantization/test_quant2_int8_mkldnn_pass_deprecated.py
@@ -32,7 +32,7 @@ class TestQuant2Int8MkldnnPassMul(unittest.TestCase):
         self.scope = paddle.static.global_scope()
         self.place = paddle.CPUPlace()
         self.dtype = np.float32
-        self.use_mkldnn = True
+        self.use_onednn = True
 
         self.quantized_ops = self.op_name()
         self.mul_input_size = [1, 3]
@@ -64,7 +64,7 @@ class TestQuant2Int8MkldnnPassMul(unittest.TestCase):
             type=self.op_name(),
             inputs={"X": block.var('mul_input'), "Y": block.var('mul_weights')},
             outputs={"Out": block.var('mul_output')},
-            attrs={'use_mkldnn': self.use_mkldnn},
+            attrs={'use_mkldnn': self.use_onednn},
         )
 
     def test_dequantize_op_weights(self):
@@ -136,7 +136,7 @@ class TestQuant2Int8MkldnnPassConv2D(unittest.TestCase):
         self.place = paddle.CPUPlace()
         self.dtype = np.float32
         self.use_cudnn = False
-        self.use_mkldnn = True
+        self.use_onednn = True
         self.data_format = "ANYLAYOUT"
         self.pad = [0, 0]
         self.stride = [1, 1]
@@ -179,7 +179,7 @@ class TestQuant2Int8MkldnnPassConv2D(unittest.TestCase):
                 'groups': self.groups,
                 'dilations': self.dilations,
                 'use_cudnn': self.use_cudnn,
-                'use_mkldnn': self.use_mkldnn,
+                'use_mkldnn': self.use_onednn,
                 'data_format': self.data_format,
                 'fuse_relu': True,
             },
@@ -197,7 +197,7 @@ class TestQuant2Int8MkldnnPassConv2D(unittest.TestCase):
                 'groups': self.groups,
                 'dilations': self.dilations,
                 'use_cudnn': self.use_cudnn,
-                'use_mkldnn': self.use_mkldnn,
+                'use_mkldnn': self.use_onednn,
                 'data_format': self.data_format,
             },
         )
@@ -244,7 +244,7 @@ class TestQuant2Int8MkldnnPassConv2D(unittest.TestCase):
             self.place = paddle.CPUPlace()
             self.dtype = np.float32
             self.use_cudnn = False
-            self.use_mkldnn = True
+            self.use_onednn = True
 
             # conv2d
             self.data_format = "ANYLAYOUT"
@@ -312,7 +312,7 @@ class TestQuant2Int8MkldnnPassConv2D(unittest.TestCase):
                     'groups': self.groups,
                     'dilations': self.dilations,
                     'use_cudnn': self.use_cudnn,
-                    'use_mkldnn': self.use_mkldnn,
+                    'use_mkldnn': self.use_onednn,
                     'data_format': self.data_format,
                     'fuse_relu': True,
                 },
@@ -329,7 +329,7 @@ class TestQuant2Int8MkldnnPassConv2D(unittest.TestCase):
                     'out_w': self.out_w,
                     'scale': self.scale,
                     'data_layout': self.data_layout,
-                    'use_mkldnn': self.use_mkldnn,
+                    'use_mkldnn': self.use_onednn,
                 },
             )
             block.append_op(

--- a/test/legacy_test/hygon_dcu/hygon_llama_ops.py
+++ b/test/legacy_test/hygon_dcu/hygon_llama_ops.py
@@ -473,14 +473,14 @@ class TestAFP16SumOp(OpTest):
         self.public_python_api = paddle.add_n
         self.prim_op_type = "comp"
         self.init_kernel_type()
-        self.use_mkldnn = False
+        self.use_onednn = False
         x0 = np.random.random((3, 40)).astype(self.dtype)
         x1 = np.random.random((3, 40)).astype(self.dtype)
         x2 = np.random.random((3, 40)).astype(self.dtype)
         self.inputs = {"X": [("x0", x0), ("x1", x1), ("x2", x2)]}
         y = x0 + x1 + x2
         self.outputs = {'Out': y}
-        self.attrs = {'use_mkldnn': self.use_mkldnn}
+        self.attrs = {'use_mkldnn': self.use_onednn}
 
     def init_kernel_type(self):
         self.dtype = np.float16
@@ -545,14 +545,14 @@ class TestFP16ElementwiseAddOp(OpTest):
             'X': OpTest.np_dtype_to_base_dtype(self.x),
             'Y': OpTest.np_dtype_to_base_dtype(self.y),
         }
-        self.attrs = {'axis': self.axis, 'use_mkldnn': self.use_mkldnn}
+        self.attrs = {'axis': self.axis, 'use_mkldnn': self.use_onednn}
         self.outputs = {'Out': self.out}
 
     def init_kernel_type(self):
-        self.use_mkldnn = False
+        self.use_onednn = False
 
     def check_dygraph(self):
-        return not self.use_mkldnn and self.axis == -1
+        return not self.use_onednn and self.axis == -1
 
     def init_input_output(self):
         self.x = np.random.uniform(0.1, 1, [13, 17]).astype(self.dtype)
@@ -631,10 +631,10 @@ class TestElementwiseMulOpFp16(OpTest):
             'Y': OpTest.np_dtype_to_base_dtype(self.y),
         }
         self.outputs = {'Out': self.out}
-        self.attrs = {'axis': self.axis, 'use_mkldnn': self.use_mkldnn}
+        self.attrs = {'axis': self.axis, 'use_mkldnn': self.use_onednn}
 
     def init_kernel_type(self):
-        self.use_mkldnn = False
+        self.use_onednn = False
 
     def init_input_output(self):
         self.x = np.random.uniform(0.1, 1, [13, 17]).astype(self.dtype)
@@ -653,7 +653,7 @@ class TestElementwiseMulOpFp16(OpTest):
     def test_check_output(self):
         # TODO(wangzhongpu): support onednn op in dygraph mode
         self.check_output(
-            check_dygraph=(not self.use_mkldnn),
+            check_dygraph=(not self.use_onednn),
             check_pir_onednn=self.check_pir_onednn,
         )
 
@@ -662,10 +662,10 @@ class TestElementwiseMulOpFp16(OpTest):
         self.check_grad(
             ['X', 'Y'],
             'Out',
-            check_dygraph=(not self.use_mkldnn),
+            check_dygraph=(not self.use_onednn),
             check_prim=True,
-            check_prim_pir=(not self.use_mkldnn),
-            check_pir=(not self.use_mkldnn),
+            check_prim_pir=(not self.use_onednn),
+            check_pir=(not self.use_onednn),
             check_pir_onednn=self.check_pir_onednn,
         )
 
@@ -675,10 +675,10 @@ class TestElementwiseMulOpFp16(OpTest):
             ['Y'],
             'Out',
             no_grad_set=set("X"),
-            check_dygraph=(not self.use_mkldnn),
+            check_dygraph=(not self.use_onednn),
             check_prim=True,
-            check_prim_pir=(not self.use_mkldnn),
-            check_pir=(not self.use_mkldnn),
+            check_prim_pir=(not self.use_onednn),
+            check_pir=(not self.use_onednn),
             check_pir_onednn=self.check_pir_onednn,
         )
 
@@ -688,10 +688,10 @@ class TestElementwiseMulOpFp16(OpTest):
             ['X'],
             'Out',
             no_grad_set=set('Y'),
-            check_dygraph=(not self.use_mkldnn),
+            check_dygraph=(not self.use_onednn),
             check_prim=True,
-            check_prim_pir=(not self.use_mkldnn),
-            check_pir=(not self.use_mkldnn),
+            check_prim_pir=(not self.use_onednn),
+            check_pir=(not self.use_onednn),
             check_pir_onednn=self.check_pir_onednn,
         )
 

--- a/test/legacy_test/op_test.py
+++ b/test/legacy_test/op_test.py
@@ -490,9 +490,7 @@ class OpTest(unittest.TestCase):
             return hasattr(cls, "use_xpu") and cls.use_xpu
 
         def is_onednn_op_test():
-            return (hasattr(cls, "use_mkldnn") and cls.use_mkldnn) or (
-                hasattr(cls, "use_onednn") and cls.use_onednn
-            )
+            return hasattr(cls, "use_onednn") and cls.use_onednn
 
         def is_rocm_op_test():
             return core.is_compiled_with_rocm()
@@ -572,10 +570,6 @@ class OpTest(unittest.TestCase):
                 hasattr(self, 'output_dtype') and self.output_dtype == np.uint16
             )
             or (
-                hasattr(self, 'mkldnn_data_type')
-                and self.mkldnn_data_type == "bfloat16"
-            )
-            or (
                 hasattr(self, 'attrs')
                 and 'mkldnn_data_type' in self.attrs
                 and self.attrs['mkldnn_data_type'] == 'bfloat16'
@@ -597,10 +591,6 @@ class OpTest(unittest.TestCase):
                 and self.output_dtype == np.float16
             )
             or (
-                hasattr(self, 'mkldnn_data_type')
-                and self.mkldnn_data_type == "float16"
-            )
-            or (
                 hasattr(self, 'attrs')
                 and 'mkldnn_data_type' in self.attrs
                 and self.attrs['mkldnn_data_type'] == 'float16'
@@ -612,14 +602,10 @@ class OpTest(unittest.TestCase):
         )
 
     def is_onednn_op(self):
-        return (
-            (hasattr(self, "use_mkldnn") and self.use_mkldnn)
-            or (hasattr(self, "use_onednn") and self.use_onednn)
-            or (
-                hasattr(self, "attrs")
-                and "use_mkldnn" in self.attrs
-                and self.attrs["use_mkldnn"]
-            )
+        return (hasattr(self, "use_onednn") and self.use_onednn) or (
+            hasattr(self, "attrs")
+            and "use_mkldnn" in self.attrs
+            and self.attrs["use_mkldnn"]
         )
 
     def is_xpu_op(self):
@@ -882,7 +868,7 @@ class OpTest(unittest.TestCase):
             self.op_type
         )  # for ci check, please not delete it for now
         if self.is_onednn_op():
-            self.__class__.use_mkldnn = True
+            self.__class__.use_onednn = True
 
         if self.is_xpu_op():
             self.__class__.use_xpu = True
@@ -2955,7 +2941,7 @@ class OpTest(unittest.TestCase):
     ):
         self.__class__.op_type = self.op_type
         if self.is_onednn_op():
-            self.__class__.use_mkldnn = True
+            self.__class__.use_onednn = True
 
         if self.is_xpu_op():
             self.__class__.use_xpu = True

--- a/test/mkldnn/test_fusion_gru_mkldnn_op.py
+++ b/test/mkldnn/test_fusion_gru_mkldnn_op.py
@@ -19,35 +19,35 @@ from test_fusion_gru_op import TestFusionGRUOp
 
 class TestFusionGRUONEDNNOp(TestFusionGRUOp):
     def set_confs(self):
-        self.use_mkldnn = True
+        self.use_onednn = True
         self.check_pir_onednn = True
 
 
 class TestFusionGRUONEDNNOpNoInitial(TestFusionGRUOp):
     def set_confs(self):
         self.with_h0 = False
-        self.use_mkldnn = True
+        self.use_onednn = True
         self.check_pir_onednn = True
 
 
 class TestFusionGRUONEDNNOpNoBias(TestFusionGRUOp):
     def set_confs(self):
         self.with_bias = False
-        self.use_mkldnn = True
+        self.use_onednn = True
         self.check_pir_onednn = True
 
 
 class TestFusionGRUONEDNNOpReverse(TestFusionGRUOp):
     def set_confs(self):
         self.is_reverse = True
-        self.use_mkldnn = True
+        self.use_onednn = True
         self.check_pir_onednn = True
 
 
 class TestFusionGRUONEDNNOpOriginMode(TestFusionGRUOp):
     def set_confs(self):
         self.origin_mode = True
-        self.use_mkldnn = True
+        self.use_onednn = True
         self.check_pir_onednn = True
 
 
@@ -55,7 +55,7 @@ class TestFusionGRUONEDNNOpMD1(TestFusionGRUOp):
     def set_confs(self):
         self.M = 36
         self.D = 8
-        self.use_mkldnn = True
+        self.use_onednn = True
         self.check_pir_onednn = True
 
 
@@ -63,7 +63,7 @@ class TestFusionGRUONEDNNOpMD2(TestFusionGRUOp):
     def set_confs(self):
         self.M = 8
         self.D = 8
-        self.use_mkldnn = True
+        self.use_onednn = True
         self.check_pir_onednn = True
 
 
@@ -71,7 +71,7 @@ class TestFusionGRUONEDNNOpMD3(TestFusionGRUOp):
     def set_confs(self):
         self.M = 17
         self.D = 15
-        self.use_mkldnn = True
+        self.use_onednn = True
         self.check_pir_onednn = True
 
 
@@ -79,7 +79,7 @@ class TestFusionGRUONEDNNOpBS1(TestFusionGRUOp):
     def set_confs(self):
         self.lod = [[3]]
         self.D = 16
-        self.use_mkldnn = True
+        self.use_onednn = True
         self.check_pir_onednn = True
 
 

--- a/test/mkldnn/test_fusion_gru_mkldnn_op.py
+++ b/test/mkldnn/test_fusion_gru_mkldnn_op.py
@@ -47,7 +47,7 @@ class TestFusionGRUONEDNNOpReverse(TestFusionGRUOp):
 class TestFusionGRUONEDNNOpOriginMode(TestFusionGRUOp):
     def set_confs(self):
         self.origin_mode = True
-        self.use_onednn = True
+        self.use_mkldnn = True
         self.check_pir_onednn = True
 
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
修改 use_mkldnn 为 use_onednn， 在目录 test/deprecated/ 中
op_test.py 不再使用cls.use_mkldnn、cls.mkldnn_data_type，改用 cls.use_onednn、cls.onednn_data_type