### PR TITLE
Set the sync_param in pp config to be disabled by default

### DIFF
--- a/paddle/fluid/framework/distributed_strategy.proto
+++ b/paddle/fluid/framework/distributed_strategy.proto
@@ -97,7 +97,7 @@ message PpConfig {
     optional NCCLConfig coll_nccl_config = 15;
     optional NCCLConfig p2p_nccl_config = 16;
     optional NCCLConfig shared_nccl_config = 17;
-    optional bool sync_param = 18 [ default = true ];
+    optional bool sync_param = 18 [ default = false ];
     optional bool sync_moment = 19 [ default = false ];
     optional string sync_mode = 20 [ default = 'broadcast' ];
 }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Distributed Strategy

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Set the sync_param in pp config to be disabled by default
Pcard-76459