### PR TITLE
[Dy2St] Optimize memory allocation for inputs and params

### DIFF
--- a/paddle/fluid/pybind/eager_custom_python_api.h
+++ b/paddle/fluid/pybind/eager_custom_python_api.h
@@ -82,17 +82,19 @@ static PyObject *eager_api_run_program(PyObject *self,
                                        PyObject *kwargs) {
   PyThreadState *tstate = nullptr;
   try {
-    auto &X = GetTensorListFromArgs("run_program", "X", args, 0, true);
+    auto &X =
+        GetTensorListFromArgsWithoutMalloc("run_program", "X", args, 0, true);
 
-    auto &Params =
-        GetTensorListFromArgs("run_program", "Params", args, 1, true);
+    auto &Params = GetTensorListFromArgsWithoutMalloc(
+        "run_program", "Params", args, 1, true);
     auto OutScope =
         GetScopePtrListFromArgs("run_program", "OutScope", args, 2, false);
     const phi::distributed::ProcessMesh *mesh = nullptr;
     if (InputsContainDistTensor(&mesh, X, Params)) {
-      X = GetTensorListFromArgs("run_program", "X", args, 0, true, mesh);
-      Params =
-          GetTensorListFromArgs("run_program", "Params", args, 1, true, mesh);
+      X = GetTensorListFromArgsWithoutMalloc(
+          "run_program", "X", args, 0, true, mesh);
+      Params = GetTensorListFromArgsWithoutMalloc(
+          "run_program", "Params", args, 1, true, mesh);
     }
     framework::AttributeMap attrs;
     VLOG(6) << "Start PIR ConstructAttrMapFromPyArgs";

--- a/paddle/fluid/pybind/eager_custom_python_api.h
+++ b/paddle/fluid/pybind/eager_custom_python_api.h
@@ -82,18 +82,45 @@ static PyObject *eager_api_run_program(PyObject *self,
                                        PyObject *kwargs) {
   PyThreadState *tstate = nullptr;
   try {
-    TensorListProcessor X_processor("run_program", "X", args, 0, true);
-    auto &X = X_processor.get_tensor_list();
-    TensorListProcessor Params_processor(
-        "run_program", "Params", args, 1, true);
-    auto &Params = Params_processor.get_tensor_list();
+    auto X_info = GetPyArgumentInfo("run_program", "X", args, 0, true);
+    TensorListBufferAllocator X_allocator(X_info.second);
+    auto &X = GetTensorListFromArgsWithBuffer("run_program",
+                                              "X",
+                                              0,
+                                              nullptr,
+                                              X_info.first,
+                                              X_info.second,
+                                              X_allocator);
+
+    auto Params_info =
+        GetPyArgumentInfo("run_program", "Params", args, 1, true);
+    TensorListBufferAllocator Params_allocator(Params_info.second);
+    auto &Params = GetTensorListFromArgsWithBuffer("run_program",
+                                                   "Params",
+                                                   0,
+                                                   nullptr,
+                                                   Params_info.first,
+                                                   Params_info.second,
+                                                   Params_allocator);
 
     auto OutScope =
         GetScopePtrListFromArgs("run_program", "OutScope", args, 2, false);
     const phi::distributed::ProcessMesh *mesh = nullptr;
     if (InputsContainDistTensor(&mesh, X, Params)) {
-      X = X_processor.update_tensor_list(mesh);
-      Params = Params_processor.update_tensor_list(mesh);
+      X = GetTensorListFromArgsWithBuffer("run_program",
+                                          "X",
+                                          0,
+                                          nullptr,
+                                          X_info.first,
+                                          X_info.second,
+                                          X_allocator);
+      Params = GetTensorListFromArgsWithBuffer("run_program",
+                                               "Params",
+                                               0,
+                                               nullptr,
+                                               Params_info.first,
+                                               Params_info.second,
+                                               Params_allocator);
     }
     framework::AttributeMap attrs;
     VLOG(6) << "Start PIR ConstructAttrMapFromPyArgs";

--- a/paddle/fluid/pybind/eager_custom_python_api.h
+++ b/paddle/fluid/pybind/eager_custom_python_api.h
@@ -82,8 +82,10 @@ static PyObject *eager_api_run_program(PyObject *self,
                                        PyObject *kwargs) {
   PyThreadState *tstate = nullptr;
   try {
-    auto X = GetTensorListFromArgs("run_program", "X", args, 0, true);
-    auto Params = GetTensorListFromArgs("run_program", "Params", args, 1, true);
+    auto &X = GetTensorListFromArgs("run_program", "X", args, 0, true);
+
+    auto &Params =
+        GetTensorListFromArgs("run_program", "Params", args, 1, true);
     auto OutScope =
         GetScopePtrListFromArgs("run_program", "OutScope", args, 2, false);
     const phi::distributed::ProcessMesh *mesh = nullptr;
@@ -99,6 +101,7 @@ static PyObject *eager_api_run_program(PyObject *self,
     VLOG(6) << "Finish Pir ConstructAttrMapFromPyArgs";
     tstate = PyEval_SaveThread();
     auto out = egr::to_static::run_program_ad_func(X, Params, OutScope, attrs);
+    ClearTensorVectorState(&X, &Params);
     PyEval_RestoreThread(tstate);
     tstate = nullptr;
     return ToPyObject(out);

--- a/paddle/fluid/pybind/eager_custom_python_api.h
+++ b/paddle/fluid/pybind/eager_custom_python_api.h
@@ -82,19 +82,18 @@ static PyObject *eager_api_run_program(PyObject *self,
                                        PyObject *kwargs) {
   PyThreadState *tstate = nullptr;
   try {
-    auto &X =
-        GetTensorListFromArgsWithoutMalloc("run_program", "X", args, 0, true);
-
-    auto &Params = GetTensorListFromArgsWithoutMalloc(
+    TensorListProcessor X_processor("run_program", "X", args, 0, true);
+    auto &X = X_processor.get_tensor_list();
+    TensorListProcessor Params_processor(
         "run_program", "Params", args, 1, true);
+    auto &Params = Params_processor.get_tensor_list();
+
     auto OutScope =
         GetScopePtrListFromArgs("run_program", "OutScope", args, 2, false);
     const phi::distributed::ProcessMesh *mesh = nullptr;
     if (InputsContainDistTensor(&mesh, X, Params)) {
-      X = GetTensorListFromArgsWithoutMalloc(
-          "run_program", "X", args, 0, true, mesh);
-      Params = GetTensorListFromArgsWithoutMalloc(
-          "run_program", "Params", args, 1, true, mesh);
+      X = X_processor.update_tensor_list(mesh);
+      Params = Params_processor.update_tensor_list(mesh);
     }
     framework::AttributeMap attrs;
     VLOG(6) << "Start PIR ConstructAttrMapFromPyArgs";
@@ -103,7 +102,6 @@ static PyObject *eager_api_run_program(PyObject *self,
     VLOG(6) << "Finish Pir ConstructAttrMapFromPyArgs";
     tstate = PyEval_SaveThread();
     auto out = egr::to_static::run_program_ad_func(X, Params, OutScope, attrs);
-    ClearTensorVectorState(&X, &Params);
     PyEval_RestoreThread(tstate);
     tstate = nullptr;
     return ToPyObject(out);

--- a/paddle/fluid/pybind/eager_utils.cc
+++ b/paddle/fluid/pybind/eager_utils.cc
@@ -2446,66 +2446,63 @@ TensorListBufferAllocator::~TensorListBufferAllocator() {
     }
   }
 }
-
-TensorListProcessor::TensorListProcessor(
-    const std::string& op_type,
-    const std::string& arg_name,
-    PyObject* args,
-    ssize_t arg_idx,
-    bool dispensable,
-    const phi::distributed::ProcessMesh* mesh)
-    : op_type_(op_type),
-      arg_name_(arg_name),
-      arg_idx_(arg_idx),
-      list_len_(0),
-      allocator_ptr_(nullptr) {
-  list_obj_ = PyTuple_GET_ITEM(args, arg_idx);
-
-  if (list_obj_ == nullptr && !dispensable) {
+std::pair<PyObject*, ssize_t> GetPyArgumentInfo(const std::string& op_type,
+                                                const std::string& arg_name,
+                                                PyObject* args,
+                                                ssize_t arg_idx,
+                                                bool dispensable) {
+  PyObject* list = PyTuple_GET_ITEM(args, arg_idx);
+  ssize_t list_len = 0;
+  if (list == nullptr && !dispensable) {
     PADDLE_THROW(common::errors::InvalidArgument(
         "%s(): argument '%s' (position %d) must be list of Tensor, but got "
         "None",
-        op_type_,
-        arg_name_,
-        arg_idx_));
+        op_type,
+        arg_name,
+        arg_idx));
   }
-  if (list_obj_ == nullptr || list_obj_ == Py_None) {
-    list_len_ = -1;
-  } else if (PyList_Check(list_obj_)) {
-    list_len_ = PyList_Size(list_obj_);
-  } else if (PyTuple_Check(list_obj_)) {
-    list_len_ = PyTuple_Size(list_obj_);
+  if (list == nullptr || list == Py_None) {
+    list_len = -1;
+  } else if (PyList_Check(list)) {
+    list_len = PyList_Size(list);
+  } else if (PyTuple_Check(list)) {
+    list_len = PyTuple_Size(list);
   } else {
     PADDLE_THROW(common::errors::InvalidArgument(
         "%s(): argument '%s' (position %d) must be list of Tensors, but got "
         "%s",
-        op_type_,
-        arg_name_,
-        arg_idx_,
-        (reinterpret_cast<PyTypeObject*>(list_obj_->ob_type))->tp_name));
+        op_type,
+        arg_name,
+        arg_idx,
+        (reinterpret_cast<PyTypeObject*>(list->ob_type))->tp_name));
   }
-
-  allocator_ptr_ = std::make_unique<TensorListBufferAllocator>(list_len_);
-
-  GetTensorListFromArgsWithBuffer(mesh);
+  return std::make_pair(list, list_len);
 }
 
-void TensorListProcessor::GetTensorListFromArgsWithBuffer(
-    const phi::distributed::ProcessMesh* mesh) {
-  auto& result = allocator_ptr_->get();
+std::vector<paddle::Tensor>& GetTensorListFromArgsWithBuffer(
+    const std::string& op_type,
+    const std::string& arg_name,
+    ssize_t arg_idx,
+    const phi::distributed::ProcessMesh* mesh,
+    PyObject* list,
+    ssize_t list_len,
+    const TensorListBufferAllocator& allocator) {
+  auto& result = allocator.GetAllocatedBuffer();
+
   const phi::distributed::ProcessMesh* local_mesh = nullptr;
   ssize_t mesh_start_index = -1;
-  if (PyList_Check(list_obj_)) {
-    for (Py_ssize_t i = 0; i < list_len_; i++) {
-      PyObject* tensor_obj = PyList_GetItem(list_obj_, i);
+
+  if (PyList_Check(list)) {
+    for (Py_ssize_t i = 0; i < list_len; i++) {
+      PyObject* tensor_obj = PyList_GetItem(list, i);
       PADDLE_ENFORCE_EQ(
           PyObject_TypeCheck(tensor_obj, p_tensor_type),
           true,
           common::errors::InvalidArgument(
               "%s(): argument '%s' (position %d) must be list of Tensors",
-              op_type_,
-              arg_name_,
-              arg_idx_));
+              op_type,
+              arg_name,
+              arg_idx));
       paddle::Tensor& tensor =
           reinterpret_cast<TensorObject*>(tensor_obj)->tensor;
       if (local_mesh) {
@@ -2522,22 +2519,22 @@ void TensorListProcessor::GetTensorListFromArgsWithBuffer(
     }
     for (Py_ssize_t i = 0; i < mesh_start_index; i++) {
       paddle::Tensor& tensor =
-          reinterpret_cast<TensorObject*>(PyList_GetItem(list_obj_, i))->tensor;
+          reinterpret_cast<TensorObject*>(PyList_GetItem(list, i))->tensor;
       ConvertToDistTensor(&tensor, local_mesh);
       result[i] = tensor;
     }
 
-  } else if (PyTuple_Check(list_obj_)) {
-    for (Py_ssize_t i = 0; i < list_len_; i++) {
-      PyObject* tensor_obj = PyTuple_GetItem(list_obj_, i);
+  } else if (PyTuple_Check(list)) {
+    for (Py_ssize_t i = 0; i < list_len; i++) {
+      PyObject* tensor_obj = PyTuple_GetItem(list, i);
       PADDLE_ENFORCE_EQ(
           PyObject_TypeCheck(tensor_obj, p_tensor_type),
           true,
           common::errors::InvalidArgument(
               "%s(): argument '%s' (position %d) must be list of Tensors",
-              op_type_,
-              arg_name_,
-              arg_idx_));
+              op_type,
+              arg_name,
+              arg_idx));
       paddle::Tensor& tensor =
           reinterpret_cast<TensorObject*>(tensor_obj)->tensor;
       if (local_mesh) {
@@ -2554,34 +2551,12 @@ void TensorListProcessor::GetTensorListFromArgsWithBuffer(
     }
     for (Py_ssize_t i = 0; i < mesh_start_index; i++) {
       paddle::Tensor& tensor =
-          reinterpret_cast<TensorObject*>(PyTuple_GetItem(list_obj_, i))
-              ->tensor;
+          reinterpret_cast<TensorObject*>(PyTuple_GetItem(list, i))->tensor;
       ConvertToDistTensor(&tensor, local_mesh);
       result[i] = tensor;
     }
   }
-}
-std::vector<paddle::Tensor>& TensorListProcessor::get_tensor_list() {
-  if (!allocator_ptr_) {
-    PADDLE_THROW(common::errors::InvalidArgument(
-        "TensorList of %s(): argument '%s' (position %d) is not allocated.",
-        op_type_,
-        arg_name_,
-        arg_idx_));
-  }
-  return allocator_ptr_->get();
-}
-std::vector<paddle::Tensor>& TensorListProcessor::update_tensor_list(
-    const phi::distributed::ProcessMesh* mesh) {
-  if (!allocator_ptr_) {
-    PADDLE_THROW(common::errors::InvalidArgument(
-        "TensorList of %s(): argument '%s' (position %d) is not allocated.",
-        op_type_,
-        arg_name_,
-        arg_idx_));
-  }
-  GetTensorListFromArgsWithBuffer(mesh);
-  return allocator_ptr_->get();
+  return result;
 }
 
 paddle::Place CastPyArg2Place(PyObject* obj,

--- a/paddle/fluid/pybind/eager_utils.cc
+++ b/paddle/fluid/pybind/eager_utils.cc
@@ -1360,148 +1360,6 @@ paddle::Tensor& GetTensorFromArgs(const std::string& op_type,
   return GetTensorFromPyObject(op_type, arg_name, obj, arg_idx, dispensable);
 }
 
-TensorVectorMap& GetTensorVectorMap() {
-  static TensorVectorMap cache;
-  return cache;
-}
-
-void ClearTensorVectorState(std::vector<paddle::Tensor>* x,
-                            std::vector<paddle::Tensor>* params) {
-  for (auto& iter : GetTensorVectorMap()) {
-    iter.second.first = true;
-  }
-  for (size_t i = 0; i < x->size(); i++) {
-    x->at(i).reset();
-  }
-  for (size_t i = 0; i < params->size(); i++) {
-    params->at(i).reset();
-  }
-}
-
-std::vector<paddle::Tensor>& GetTensorListFromArgsWithoutMalloc(
-    const std::string& op_type,
-    const std::string& arg_name,
-    PyObject* args,
-    ssize_t arg_idx,
-    bool dispensable,
-    const phi::distributed::ProcessMesh* mesh) {
-  PyObject* list = PyTuple_GET_ITEM(args, arg_idx);
-  TensorVectorMapIter iter;
-
-  if (list == nullptr && !dispensable) {
-    PADDLE_THROW(common::errors::InvalidArgument(
-        "%s(): argument '%s' (position %d) must be list of Tensor, but got "
-        "None",
-        op_type,
-        arg_name,
-        arg_idx));
-  }
-  if (list == nullptr || list == Py_None) {
-    iter = GetTensorVectorMap().find(-1);
-    if (iter == GetTensorVectorMap().end()) {
-      iter = GetTensorVectorMap().emplace(
-          -1, std::make_pair(true, std::vector<paddle::Tensor>()));
-    }
-    return iter->second.second;
-  }
-
-  const phi::distributed::ProcessMesh* local_mesh = nullptr;
-  int mesh_start_index = -1;
-
-  Py_ssize_t len = PyList_Check(list)    ? PyList_Size(list)
-                   : PyTuple_Check(list) ? PyTuple_Size(list)
-                                         : 0;
-  auto range = GetTensorVectorMap().equal_range(static_cast<size_t>(len));
-  for (iter = range.first; iter != range.second; ++iter) {
-    if (iter->second.first) {
-      break;
-    }
-  }
-  if (iter == range.second) {
-    iter = GetTensorVectorMap().emplace(
-        static_cast<size_t>(len),
-        std::make_pair(true,
-                       std::vector<paddle::Tensor>(static_cast<size_t>(len))));
-  }
-  iter->second.first = false;
-  auto& result = iter->second.second;
-
-  if (PyList_Check(list)) {
-    for (Py_ssize_t i = 0; i < len; i++) {
-      PyObject* tensor_obj = PyList_GetItem(list, i);
-      PADDLE_ENFORCE_EQ(
-          PyObject_TypeCheck(tensor_obj, p_tensor_type),
-          true,
-          common::errors::InvalidArgument(
-              "%s(): argument '%s' (position %d) must be list of Tensors",
-              op_type,
-              arg_name,
-              arg_idx));
-      paddle::Tensor& tensor =
-          reinterpret_cast<TensorObject*>(tensor_obj)->tensor;
-      if (local_mesh) {
-        ConvertToDistTensor(&tensor, local_mesh);
-      } else {
-        if (tensor.is_dist_tensor()) {
-          local_mesh = &(std::static_pointer_cast<phi::distributed::DistTensor>(
-                             tensor.impl())
-                             ->process_mesh());
-          mesh_start_index = i;
-        }
-      }
-      result[i] = tensor;
-    }
-    for (Py_ssize_t i = 0; i < mesh_start_index; i++) {
-      paddle::Tensor& tensor =
-          reinterpret_cast<TensorObject*>(PyList_GetItem(list, i))->tensor;
-      ConvertToDistTensor(&tensor, local_mesh);
-      result[i] = tensor;
-    }
-
-  } else if (PyTuple_Check(list)) {
-    for (Py_ssize_t i = 0; i < len; i++) {
-      PyObject* tensor_obj = PyTuple_GetItem(list, i);
-      PADDLE_ENFORCE_EQ(
-          PyObject_TypeCheck(tensor_obj, p_tensor_type),
-          true,
-          common::errors::InvalidArgument(
-              "%s(): argument '%s' (position %d) must be list of Tensors",
-              op_type,
-              arg_name,
-              arg_idx));
-      paddle::Tensor& tensor =
-          reinterpret_cast<TensorObject*>(tensor_obj)->tensor;
-      if (local_mesh) {
-        ConvertToDistTensor(&tensor, local_mesh);
-      } else {
-        if (tensor.is_dist_tensor()) {
-          local_mesh = &(std::static_pointer_cast<phi::distributed::DistTensor>(
-                             tensor.impl())
-                             ->process_mesh());
-          mesh_start_index = i;
-        }
-      }
-      result[i] = tensor;
-    }
-    for (Py_ssize_t i = 0; i < mesh_start_index; i++) {
-      paddle::Tensor& tensor =
-          reinterpret_cast<TensorObject*>(PyTuple_GetItem(list, i))->tensor;
-      ConvertToDistTensor(&tensor, local_mesh);
-      result[i] = tensor;
-    }
-  } else {
-    PADDLE_THROW(common::errors::InvalidArgument(
-        "%s(): argument '%s' (position %d) must be list of Tensors, but got "
-        "%s",
-        op_type,
-        arg_name,
-        arg_idx,
-        (reinterpret_cast<PyTypeObject*>(list->ob_type))->tp_name));
-  }
-
-  return result;
-}
-
 std::vector<paddle::Tensor> GetTensorListFromArgs(
     const std::string& op_type,
     const std::string& arg_name,
@@ -2551,6 +2409,179 @@ std::vector<paddle::framework::Scope*> GetScopePtrListFromArgs(
         (reinterpret_cast<PyTypeObject*>(list->ob_type))->tp_name));
   }
   return result;
+}
+
+TensorListBufferAllocator::MapType
+    TensorListBufferAllocator::s_tensor_vector_map_;
+TensorListBufferAllocator::TensorListBufferAllocator(ssize_t len) : key_(len) {
+  MapIterType iter;
+  if (key_ == -1) {
+    iter = s_tensor_vector_map_.find(-1);
+    if (iter == s_tensor_vector_map_.end()) {
+      iter = s_tensor_vector_map_.emplace(-1,
+                                          std::make_unique<TensorListBuffer>());
+    }
+  } else {
+    auto range = s_tensor_vector_map_.equal_range(key_);
+    for (iter = range.first; iter != range.second; ++iter) {
+      if (iter->second->is_available) {
+        break;
+      }
+    }
+    if (iter == range.second) {
+      iter = s_tensor_vector_map_.emplace(
+          key_, std::make_unique<TensorListBuffer>(key_));
+    }
+    iter->second->is_available = false;
+  }
+  buffer_ptr_ = iter->second.get();
+}
+
+TensorListBufferAllocator::~TensorListBufferAllocator() {
+  if (buffer_ptr_) {
+    buffer_ptr_->is_available = true;
+
+    for (auto& tensor : buffer_ptr_->buffer) {
+      tensor.reset();
+    }
+  }
+}
+
+TensorListProcessor::TensorListProcessor(
+    const std::string& op_type,
+    const std::string& arg_name,
+    PyObject* args,
+    ssize_t arg_idx,
+    bool dispensable,
+    const phi::distributed::ProcessMesh* mesh)
+    : op_type_(op_type),
+      arg_name_(arg_name),
+      arg_idx_(arg_idx),
+      list_len_(0),
+      allocator_ptr_(nullptr) {
+  list_obj_ = PyTuple_GET_ITEM(args, arg_idx);
+
+  if (list_obj_ == nullptr && !dispensable) {
+    PADDLE_THROW(common::errors::InvalidArgument(
+        "%s(): argument '%s' (position %d) must be list of Tensor, but got "
+        "None",
+        op_type_,
+        arg_name_,
+        arg_idx_));
+  }
+  if (list_obj_ == nullptr || list_obj_ == Py_None) {
+    list_len_ = -1;
+  } else if (PyList_Check(list_obj_)) {
+    list_len_ = PyList_Size(list_obj_);
+  } else if (PyTuple_Check(list_obj_)) {
+    list_len_ = PyTuple_Size(list_obj_);
+  } else {
+    PADDLE_THROW(common::errors::InvalidArgument(
+        "%s(): argument '%s' (position %d) must be list of Tensors, but got "
+        "%s",
+        op_type_,
+        arg_name_,
+        arg_idx_,
+        (reinterpret_cast<PyTypeObject*>(list_obj_->ob_type))->tp_name));
+  }
+
+  allocator_ptr_ = std::make_unique<TensorListBufferAllocator>(list_len_);
+
+  GetTensorListFromArgsWithBuffer(mesh);
+}
+
+void TensorListProcessor::GetTensorListFromArgsWithBuffer(
+    const phi::distributed::ProcessMesh* mesh) {
+  auto& result = allocator_ptr_->get();
+  const phi::distributed::ProcessMesh* local_mesh = nullptr;
+  ssize_t mesh_start_index = -1;
+  if (PyList_Check(list_obj_)) {
+    for (Py_ssize_t i = 0; i < list_len_; i++) {
+      PyObject* tensor_obj = PyList_GetItem(list_obj_, i);
+      PADDLE_ENFORCE_EQ(
+          PyObject_TypeCheck(tensor_obj, p_tensor_type),
+          true,
+          common::errors::InvalidArgument(
+              "%s(): argument '%s' (position %d) must be list of Tensors",
+              op_type_,
+              arg_name_,
+              arg_idx_));
+      paddle::Tensor& tensor =
+          reinterpret_cast<TensorObject*>(tensor_obj)->tensor;
+      if (local_mesh) {
+        ConvertToDistTensor(&tensor, local_mesh);
+      } else {
+        if (tensor.is_dist_tensor()) {
+          local_mesh = &(std::static_pointer_cast<phi::distributed::DistTensor>(
+                             tensor.impl())
+                             ->process_mesh());
+          mesh_start_index = i;
+        }
+      }
+      result[i] = tensor;
+    }
+    for (Py_ssize_t i = 0; i < mesh_start_index; i++) {
+      paddle::Tensor& tensor =
+          reinterpret_cast<TensorObject*>(PyList_GetItem(list_obj_, i))->tensor;
+      ConvertToDistTensor(&tensor, local_mesh);
+      result[i] = tensor;
+    }
+
+  } else if (PyTuple_Check(list_obj_)) {
+    for (Py_ssize_t i = 0; i < list_len_; i++) {
+      PyObject* tensor_obj = PyTuple_GetItem(list_obj_, i);
+      PADDLE_ENFORCE_EQ(
+          PyObject_TypeCheck(tensor_obj, p_tensor_type),
+          true,
+          common::errors::InvalidArgument(
+              "%s(): argument '%s' (position %d) must be list of Tensors",
+              op_type_,
+              arg_name_,
+              arg_idx_));
+      paddle::Tensor& tensor =
+          reinterpret_cast<TensorObject*>(tensor_obj)->tensor;
+      if (local_mesh) {
+        ConvertToDistTensor(&tensor, local_mesh);
+      } else {
+        if (tensor.is_dist_tensor()) {
+          local_mesh = &(std::static_pointer_cast<phi::distributed::DistTensor>(
+                             tensor.impl())
+                             ->process_mesh());
+          mesh_start_index = i;
+        }
+      }
+      result[i] = tensor;
+    }
+    for (Py_ssize_t i = 0; i < mesh_start_index; i++) {
+      paddle::Tensor& tensor =
+          reinterpret_cast<TensorObject*>(PyTuple_GetItem(list_obj_, i))
+              ->tensor;
+      ConvertToDistTensor(&tensor, local_mesh);
+      result[i] = tensor;
+    }
+  }
+}
+std::vector<paddle::Tensor>& TensorListProcessor::get_tensor_list() {
+  if (!allocator_ptr_) {
+    PADDLE_THROW(common::errors::InvalidArgument(
+        "TensorList of %s(): argument '%s' (position %d) is not allocated.",
+        op_type_,
+        arg_name_,
+        arg_idx_));
+  }
+  return allocator_ptr_->get();
+}
+std::vector<paddle::Tensor>& TensorListProcessor::update_tensor_list(
+    const phi::distributed::ProcessMesh* mesh) {
+  if (!allocator_ptr_) {
+    PADDLE_THROW(common::errors::InvalidArgument(
+        "TensorList of %s(): argument '%s' (position %d) is not allocated.",
+        op_type_,
+        arg_name_,
+        arg_idx_));
+  }
+  GetTensorListFromArgsWithBuffer(mesh);
+  return allocator_ptr_->get();
 }
 
 paddle::Place CastPyArg2Place(PyObject* obj,

--- a/paddle/fluid/pybind/eager_utils.cc
+++ b/paddle/fluid/pybind/eager_utils.cc
@@ -1378,7 +1378,7 @@ void ClearTensorVectorState(std::vector<paddle::Tensor>* x,
   }
 }
 
-std::vector<paddle::Tensor>& GetTensorListFromArgs(
+std::vector<paddle::Tensor>& GetTensorListFromArgsWithoutMalloc(
     const std::string& op_type,
     const std::string& arg_name,
     PyObject* args,
@@ -1489,6 +1489,130 @@ std::vector<paddle::Tensor>& GetTensorListFromArgs(
       ConvertToDistTensor(&tensor, local_mesh);
       result[i] = tensor;
     }
+  } else {
+    PADDLE_THROW(common::errors::InvalidArgument(
+        "%s(): argument '%s' (position %d) must be list of Tensors, but got "
+        "%s",
+        op_type,
+        arg_name,
+        arg_idx,
+        (reinterpret_cast<PyTypeObject*>(list->ob_type))->tp_name));
+  }
+
+  return result;
+}
+
+std::vector<paddle::Tensor> GetTensorListFromArgs(
+    const std::string& op_type,
+    const std::string& arg_name,
+    PyObject* args,
+    ssize_t arg_idx,
+    bool dispensable,
+    const phi::distributed::ProcessMesh* mesh) {
+  PyObject* list = PyTuple_GET_ITEM(args, arg_idx);
+
+  if (list == nullptr) {
+    if (!dispensable) {
+      PADDLE_THROW(common::errors::InvalidArgument(
+          "%s(): argument '%s' (position %d) must be list of Tensor, but got "
+          "None",
+          op_type,
+          arg_name,
+          arg_idx));
+    }
+    return {};
+  }
+
+  std::vector<paddle::Tensor> result;
+  const phi::distributed::ProcessMesh* local_mesh = nullptr;
+  int mesh_start_index = -1;
+
+  if (PyList_Check(list)) {
+    Py_ssize_t len = PyList_Size(list);
+    result.reserve(static_cast<size_t>(len));
+    if (len == 0) {
+      PADDLE_THROW(common::errors::InvalidArgument(
+          "%s(): argument '%s' (position %d) must be list of Tensors, but got "
+          "empty list",
+          op_type,
+          arg_name,
+          arg_idx));
+    }
+    for (Py_ssize_t i = 0; i < len; i++) {
+      PyObject* tensor_obj = PyList_GetItem(list, i);
+      PADDLE_ENFORCE_EQ(
+          PyObject_TypeCheck(tensor_obj, p_tensor_type),
+          true,
+          common::errors::InvalidArgument(
+              "%s(): argument '%s' (position %d) must be list of Tensors",
+              op_type,
+              arg_name,
+              arg_idx));
+      paddle::Tensor& tensor =
+          reinterpret_cast<TensorObject*>(tensor_obj)->tensor;
+      if (local_mesh) {
+        ConvertToDistTensor(&tensor, local_mesh);
+      } else {
+        if (tensor.defined() && tensor.is_dist_tensor()) {
+          local_mesh =
+              &(std::dynamic_pointer_cast<phi::distributed::DistTensor>(
+                    tensor.impl())
+                    ->process_mesh());
+          mesh_start_index = i;
+        }
+      }
+      result.emplace_back(tensor);
+    }
+    for (Py_ssize_t i = 0; i < mesh_start_index; i++) {
+      paddle::Tensor& tensor =
+          reinterpret_cast<TensorObject*>(PyList_GetItem(list, i))->tensor;
+      ConvertToDistTensor(&tensor, local_mesh);
+      result[i] = tensor;
+    }
+  } else if (PyTuple_Check(list)) {
+    Py_ssize_t len = PyTuple_Size(list);
+    result.reserve(static_cast<size_t>(len));
+    if (len == 0) {
+      PADDLE_THROW(common::errors::InvalidArgument(
+          "%s(): argument '%s' (position %d) must be list of Tensors, but got "
+          "empty list",
+          op_type,
+          arg_name,
+          arg_idx));
+    }
+    for (Py_ssize_t i = 0; i < len; i++) {
+      PyObject* tensor_obj = PyTuple_GetItem(list, i);
+      PADDLE_ENFORCE_EQ(
+          PyObject_TypeCheck(tensor_obj, p_tensor_type),
+          true,
+          common::errors::InvalidArgument(
+              "%s(): argument '%s' (position %d) must be list of Tensors",
+              op_type,
+              arg_name,
+              arg_idx));
+      paddle::Tensor& tensor =
+          reinterpret_cast<TensorObject*>(tensor_obj)->tensor;
+      if (local_mesh) {
+        ConvertToDistTensor(&tensor, local_mesh);
+      } else {
+        if (tensor.defined() && tensor.is_dist_tensor()) {
+          local_mesh =
+              &(std::dynamic_pointer_cast<phi::distributed::DistTensor>(
+                    tensor.impl())
+                    ->process_mesh());
+          mesh_start_index = i;
+        }
+      }
+      result.emplace_back(tensor);
+    }
+    for (Py_ssize_t i = 0; i < mesh_start_index; i++) {
+      paddle::Tensor& tensor =
+          reinterpret_cast<TensorObject*>(PyTuple_GetItem(list, i))->tensor;
+      ConvertToDistTensor(&tensor, local_mesh);
+      result[i] = tensor;
+    }
+  } else if (list == Py_None) {
+    return {};
   } else {
     PADDLE_THROW(common::errors::InvalidArgument(
         "%s(): argument '%s' (position %d) must be list of Tensors, but got "

--- a/paddle/fluid/pybind/eager_utils.cc
+++ b/paddle/fluid/pybind/eager_utils.cc
@@ -1360,7 +1360,25 @@ paddle::Tensor& GetTensorFromArgs(const std::string& op_type,
   return GetTensorFromPyObject(op_type, arg_name, obj, arg_idx, dispensable);
 }
 
-std::vector<paddle::Tensor> GetTensorListFromArgs(
+TensorVectorMap& GetTensorVectorMap() {
+  static TensorVectorMap cache;
+  return cache;
+}
+
+void ClearTensorVectorState(std::vector<paddle::Tensor>* x,
+                            std::vector<paddle::Tensor>* params) {
+  for (auto& iter : GetTensorVectorMap()) {
+    iter.second.first = true;
+  }
+  for (size_t i = 0; i < x->size(); i++) {
+    x->at(i).reset();
+  }
+  for (size_t i = 0; i < params->size(); i++) {
+    params->at(i).reset();
+  }
+}
+
+std::vector<paddle::Tensor>& GetTensorListFromArgs(
     const std::string& op_type,
     const std::string& arg_name,
     PyObject* args,
@@ -1368,34 +1386,47 @@ std::vector<paddle::Tensor> GetTensorListFromArgs(
     bool dispensable,
     const phi::distributed::ProcessMesh* mesh) {
   PyObject* list = PyTuple_GET_ITEM(args, arg_idx);
+  TensorVectorMapIter iter;
 
-  if (list == nullptr) {
-    if (!dispensable) {
-      PADDLE_THROW(common::errors::InvalidArgument(
-          "%s(): argument '%s' (position %d) must be list of Tensor, but got "
-          "None",
-          op_type,
-          arg_name,
-          arg_idx));
+  if (list == nullptr && !dispensable) {
+    PADDLE_THROW(common::errors::InvalidArgument(
+        "%s(): argument '%s' (position %d) must be list of Tensor, but got "
+        "None",
+        op_type,
+        arg_name,
+        arg_idx));
+  }
+  if (list == nullptr || list == Py_None) {
+    iter = GetTensorVectorMap().find(-1);
+    if (iter == GetTensorVectorMap().end()) {
+      iter = GetTensorVectorMap().emplace(
+          -1, std::make_pair(true, std::vector<paddle::Tensor>()));
     }
-    return {};
+    return iter->second.second;
   }
 
-  std::vector<paddle::Tensor> result;
   const phi::distributed::ProcessMesh* local_mesh = nullptr;
   int mesh_start_index = -1;
 
-  if (PyList_Check(list)) {
-    Py_ssize_t len = PyList_Size(list);
-    result.reserve(static_cast<size_t>(len));
-    if (len == 0) {
-      PADDLE_THROW(common::errors::InvalidArgument(
-          "%s(): argument '%s' (position %d) must be list of Tensors, but got "
-          "empty list",
-          op_type,
-          arg_name,
-          arg_idx));
+  Py_ssize_t len = PyList_Check(list)    ? PyList_Size(list)
+                   : PyTuple_Check(list) ? PyTuple_Size(list)
+                                         : 0;
+  auto range = GetTensorVectorMap().equal_range(static_cast<size_t>(len));
+  for (iter = range.first; iter != range.second; ++iter) {
+    if (iter->second.first) {
+      break;
     }
+  }
+  if (iter == range.second) {
+    iter = GetTensorVectorMap().emplace(
+        static_cast<size_t>(len),
+        std::make_pair(true,
+                       std::vector<paddle::Tensor>(static_cast<size_t>(len))));
+  }
+  iter->second.first = false;
+  auto& result = iter->second.second;
+
+  if (PyList_Check(list)) {
     for (Py_ssize_t i = 0; i < len; i++) {
       PyObject* tensor_obj = PyList_GetItem(list, i);
       PADDLE_ENFORCE_EQ(
@@ -1411,15 +1442,14 @@ std::vector<paddle::Tensor> GetTensorListFromArgs(
       if (local_mesh) {
         ConvertToDistTensor(&tensor, local_mesh);
       } else {
-        if (tensor.defined() && tensor.is_dist_tensor()) {
-          local_mesh =
-              &(std::dynamic_pointer_cast<phi::distributed::DistTensor>(
-                    tensor.impl())
-                    ->process_mesh());
+        if (tensor.is_dist_tensor()) {
+          local_mesh = &(std::static_pointer_cast<phi::distributed::DistTensor>(
+                             tensor.impl())
+                             ->process_mesh());
           mesh_start_index = i;
         }
       }
-      result.emplace_back(tensor);
+      result[i] = tensor;
     }
     for (Py_ssize_t i = 0; i < mesh_start_index; i++) {
       paddle::Tensor& tensor =
@@ -1427,17 +1457,8 @@ std::vector<paddle::Tensor> GetTensorListFromArgs(
       ConvertToDistTensor(&tensor, local_mesh);
       result[i] = tensor;
     }
+
   } else if (PyTuple_Check(list)) {
-    Py_ssize_t len = PyTuple_Size(list);
-    result.reserve(static_cast<size_t>(len));
-    if (len == 0) {
-      PADDLE_THROW(common::errors::InvalidArgument(
-          "%s(): argument '%s' (position %d) must be list of Tensors, but got "
-          "empty list",
-          op_type,
-          arg_name,
-          arg_idx));
-    }
     for (Py_ssize_t i = 0; i < len; i++) {
       PyObject* tensor_obj = PyTuple_GetItem(list, i);
       PADDLE_ENFORCE_EQ(
@@ -1453,15 +1474,14 @@ std::vector<paddle::Tensor> GetTensorListFromArgs(
       if (local_mesh) {
         ConvertToDistTensor(&tensor, local_mesh);
       } else {
-        if (tensor.defined() && tensor.is_dist_tensor()) {
-          local_mesh =
-              &(std::dynamic_pointer_cast<phi::distributed::DistTensor>(
-                    tensor.impl())
-                    ->process_mesh());
+        if (tensor.is_dist_tensor()) {
+          local_mesh = &(std::static_pointer_cast<phi::distributed::DistTensor>(
+                             tensor.impl())
+                             ->process_mesh());
           mesh_start_index = i;
         }
       }
-      result.emplace_back(tensor);
+      result[i] = tensor;
     }
     for (Py_ssize_t i = 0; i < mesh_start_index; i++) {
       paddle::Tensor& tensor =
@@ -1469,8 +1489,6 @@ std::vector<paddle::Tensor> GetTensorListFromArgs(
       ConvertToDistTensor(&tensor, local_mesh);
       result[i] = tensor;
     }
-  } else if (list == Py_None) {
-    return {};
   } else {
     PADDLE_THROW(common::errors::InvalidArgument(
         "%s(): argument '%s' (position %d) must be list of Tensors, but got "

--- a/paddle/fluid/pybind/eager_utils.h
+++ b/paddle/fluid/pybind/eager_utils.h
@@ -50,13 +50,6 @@ namespace pybind {
 
 namespace py = ::pybind11;
 
-using TensorVectorMap =
-    std::unordered_multimap<size_t,
-                            std::pair<bool, std::vector<paddle::Tensor>>>;
-using TensorVectorMapIter = std::unordered_multimap<
-    size_t,
-    std::pair<bool, std::vector<paddle::Tensor>>>::iterator;
-
 template <typename T>
 static T PyObjectCast(PyObject* obj) {
   try {
@@ -400,19 +393,6 @@ paddle::optional<std::vector<paddle::Tensor>> GetOptionalTensorListFromArgs(
     bool dispensable = false,
     const phi::distributed::ProcessMesh* mesh = nullptr);
 
-TensorVectorMap& GetTensorVectorMap();
-
-void ClearTensorVectorState(std::vector<paddle::Tensor>* x,
-                            std::vector<paddle::Tensor>* params);
-
-std::vector<paddle::Tensor>& GetTensorListFromArgsWithoutMalloc(
-    const std::string& op_type,
-    const std::string& arg_name,
-    PyObject* args,
-    ssize_t arg_idx,
-    bool dispensable = false,
-    const phi::distributed::ProcessMesh* mesh = nullptr);
-
 std::vector<paddle::Tensor> GetTensorListFromArgs(
     const std::string& op_type,
     const std::string& arg_name,
@@ -464,6 +444,62 @@ class eager_gil_scoped_release {
 
  private:
   PyThreadState* tstate{nullptr};
+};
+
+class TensorListBufferAllocator {
+ private:
+  struct TensorListBuffer {
+    bool is_available;
+    std::vector<paddle::Tensor> buffer;
+    TensorListBuffer() = default;
+    explicit TensorListBuffer(ssize_t len) : buffer(len), is_available(true) {}
+  };
+
+  using MapType =
+      std::unordered_multimap<ssize_t, std::unique_ptr<TensorListBuffer>>;
+  using MapIterType = MapType::iterator;
+
+  ssize_t key_;
+  TensorListBuffer* buffer_ptr_ = nullptr;
+  static MapType s_tensor_vector_map_;
+
+ public:
+  explicit TensorListBufferAllocator(ssize_t len);
+  ~TensorListBufferAllocator();
+  std::vector<paddle::Tensor>& get() { return buffer_ptr_->buffer; }
+  TensorListBufferAllocator(const TensorListBufferAllocator&) = delete;
+  TensorListBufferAllocator& operator=(const TensorListBufferAllocator&) =
+      delete;
+};
+
+class TensorListProcessor {
+ public:
+  TensorListProcessor(const std::string& op_type,
+                      const std::string& arg_name,
+                      PyObject* args,
+                      ssize_t arg_idx,
+                      bool dispensable,
+                      const phi::distributed::ProcessMesh* mesh = nullptr);
+
+  std::vector<paddle::Tensor>& get_tensor_list();
+  std::vector<paddle::Tensor>& update_tensor_list(
+      const phi::distributed::ProcessMesh* mesh);
+
+  TensorListProcessor(const TensorListProcessor&) = delete;
+  TensorListProcessor& operator=(const TensorListProcessor&) = delete;
+  TensorListProcessor(TensorListProcessor&&) = delete;
+  TensorListProcessor& operator=(TensorListProcessor&&) = delete;
+
+ private:
+  PyObject* list_obj_ = nullptr;
+  ssize_t list_len_;
+  std::unique_ptr<TensorListBufferAllocator> allocator_ptr_;
+  std::string op_type_;
+  std::string arg_name_;
+  ssize_t arg_idx_;
+  // const phi::distributed::ProcessMesh* mesh_;
+  void GetTensorListFromArgsWithBuffer(
+      const phi::distributed::ProcessMesh* mesh);
 };
 
 /* ------------------ for SetStaticOpArgPreCastHook ----------------------- */

--- a/paddle/fluid/pybind/eager_utils.h
+++ b/paddle/fluid/pybind/eager_utils.h
@@ -465,42 +465,29 @@ class TensorListBufferAllocator {
 
  public:
   explicit TensorListBufferAllocator(ssize_t len);
-  ~TensorListBufferAllocator();
-  std::vector<paddle::Tensor>& get() { return buffer_ptr_->buffer; }
   TensorListBufferAllocator(const TensorListBufferAllocator&) = delete;
   TensorListBufferAllocator& operator=(const TensorListBufferAllocator&) =
       delete;
+  ~TensorListBufferAllocator();
+  std::vector<paddle::Tensor>& GetAllocatedBuffer() const {
+    return buffer_ptr_->buffer;
+  }
 };
 
-class TensorListProcessor {
- public:
-  TensorListProcessor(const std::string& op_type,
-                      const std::string& arg_name,
-                      PyObject* args,
-                      ssize_t arg_idx,
-                      bool dispensable,
-                      const phi::distributed::ProcessMesh* mesh = nullptr);
+std::pair<PyObject*, ssize_t> GetPyArgumentInfo(const std::string& op_type,
+                                                const std::string& arg_name,
+                                                PyObject* args,
+                                                ssize_t arg_idx,
+                                                bool dispensable);
 
-  std::vector<paddle::Tensor>& get_tensor_list();
-  std::vector<paddle::Tensor>& update_tensor_list(
-      const phi::distributed::ProcessMesh* mesh);
-
-  TensorListProcessor(const TensorListProcessor&) = delete;
-  TensorListProcessor& operator=(const TensorListProcessor&) = delete;
-  TensorListProcessor(TensorListProcessor&&) = delete;
-  TensorListProcessor& operator=(TensorListProcessor&&) = delete;
-
- private:
-  PyObject* list_obj_ = nullptr;
-  ssize_t list_len_;
-  std::unique_ptr<TensorListBufferAllocator> allocator_ptr_;
-  std::string op_type_;
-  std::string arg_name_;
-  ssize_t arg_idx_;
-  // const phi::distributed::ProcessMesh* mesh_;
-  void GetTensorListFromArgsWithBuffer(
-      const phi::distributed::ProcessMesh* mesh);
-};
+std::vector<paddle::Tensor>& GetTensorListFromArgsWithBuffer(
+    const std::string& op_type,
+    const std::string& arg_name,
+    ssize_t arg_idx,
+    const phi::distributed::ProcessMesh* mesh,
+    PyObject* list,
+    ssize_t list_len,
+    const TensorListBufferAllocator& allocator);
 
 /* ------------------ for SetStaticOpArgPreCastHook ----------------------- */
 

--- a/paddle/fluid/pybind/eager_utils.h
+++ b/paddle/fluid/pybind/eager_utils.h
@@ -405,7 +405,15 @@ TensorVectorMap& GetTensorVectorMap();
 void ClearTensorVectorState(std::vector<paddle::Tensor>* x,
                             std::vector<paddle::Tensor>* params);
 
-std::vector<paddle::Tensor>& GetTensorListFromArgs(
+std::vector<paddle::Tensor>& GetTensorListFromArgsWithoutMalloc(
+    const std::string& op_type,
+    const std::string& arg_name,
+    PyObject* args,
+    ssize_t arg_idx,
+    bool dispensable = false,
+    const phi::distributed::ProcessMesh* mesh = nullptr);
+
+std::vector<paddle::Tensor> GetTensorListFromArgs(
     const std::string& op_type,
     const std::string& arg_name,
     PyObject* args,

--- a/paddle/fluid/pybind/eager_utils.h
+++ b/paddle/fluid/pybind/eager_utils.h
@@ -50,6 +50,13 @@ namespace pybind {
 
 namespace py = ::pybind11;
 
+using TensorVectorMap =
+    std::unordered_multimap<size_t,
+                            std::pair<bool, std::vector<paddle::Tensor>>>;
+using TensorVectorMapIter = std::unordered_multimap<
+    size_t,
+    std::pair<bool, std::vector<paddle::Tensor>>>::iterator;
+
 template <typename T>
 static T PyObjectCast(PyObject* obj) {
   try {
@@ -393,7 +400,12 @@ paddle::optional<std::vector<paddle::Tensor>> GetOptionalTensorListFromArgs(
     bool dispensable = false,
     const phi::distributed::ProcessMesh* mesh = nullptr);
 
-std::vector<paddle::Tensor> GetTensorListFromArgs(
+TensorVectorMap& GetTensorVectorMap();
+
+void ClearTensorVectorState(std::vector<paddle::Tensor>* x,
+                            std::vector<paddle::Tensor>* params);
+
+std::vector<paddle::Tensor>& GetTensorListFromArgs(
     const std::string& op_type,
     const std::string& arg_name,
     PyObject* args,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->
背景：在静态图推理场景下，每个step中从Python端切换到C++端后第一次较大内存（>1KB）申请的开销会较大，例如申请包含55个Tensor的vector的时间从5us变到50us左右。

优化`run_program` 中存储输入和参数列表的vector内存申请的开销：
* 全局管理每个step输入和参数申请的vector内存，对它们进行复用，避免每个step都存在上述开销
* 返回vector的引用避免返回值的拷贝

cc @zyfncg @SigureMo 
pcard-67164