### PR TITLE
[PHI] Fix `conv_transpose` for cudnn big tensor

### DIFF
--- a/paddle/phi/kernels/gpudnn/conv_transpose_grad_kernel.cu
+++ b/paddle/phi/kernels/gpudnn/conv_transpose_grad_kernel.cu
@@ -179,6 +179,12 @@ void ConvTransposeGradRawGPUDNNKernel(const Context& dev_ctx,
   out_vec = common::vectorize<int>(transformed_dout.dims());
 
   // ------------------- cudnn descriptors ---------------------
+#ifndef PADDLE_WITH_HIP
+  CUDNN_ENFORCE_TENSOR_SIZE_SUPPORTED(transformed_dout);
+  CUDNN_ENFORCE_TENSOR_SIZE_SUPPORTED(filter);
+  CUDNN_ENFORCE_TENSOR_SIZE_SUPPORTED(x_transpose);
+#endif
+
   GPUDNNDataLayout layout;
 
   if (strides.size() == 2U) {
@@ -223,9 +229,6 @@ void ConvTransposeGradRawGPUDNNKernel(const Context& dev_ctx,
   SearchResult<miopenConvFwdAlgorithm_t> fwd_result;
   SearchResult<miopenConvBwdWeightsAlgorithm_t> filter_result;
 #else
-  CUDNN_ENFORCE_TENSOR_SIZE_SUPPORTED(transformed_dout);
-  CUDNN_ENFORCE_TENSOR_SIZE_SUPPORTED(filter);
-  CUDNN_ENFORCE_TENSOR_SIZE_SUPPORTED(x_transpose);
   SearchResult<cudnnConvolutionFwdAlgo_t> fwd_result;
   SearchResult<cudnnConvolutionBwdFilterAlgo_t> filter_result;
 #endif

--- a/paddle/phi/kernels/gpudnn/conv_transpose_kernel.cu
+++ b/paddle/phi/kernels/gpudnn/conv_transpose_kernel.cu
@@ -179,6 +179,12 @@ void ConvTransposeRawGPUDNNKernel(const Context& dev_ctx,
   }
   T* transformed_out_data = transformed_out.data<T>();
 
+#ifndef PADDLE_WITH_HIP
+  CUDNN_ENFORCE_TENSOR_SIZE_SUPPORTED(transformed_x);
+  CUDNN_ENFORCE_TENSOR_SIZE_SUPPORTED(filter);
+  CUDNN_ENFORCE_TENSOR_SIZE_SUPPORTED(transformed_out);
+#endif
+
   GPUDNNDataLayout layout;
 
   int iwo_groups = groups;
@@ -235,9 +241,6 @@ void ConvTransposeRawGPUDNNKernel(const Context& dev_ctx,
   bwd_result.algo =
       search::Find<T>(args, false, deterministic, workspace_size, dev_ctx);
 #else
-  CUDNN_ENFORCE_TENSOR_SIZE_SUPPORTED(transformed_x);
-  CUDNN_ENFORCE_TENSOR_SIZE_SUPPORTED(filter);
-  CUDNN_ENFORCE_TENSOR_SIZE_SUPPORTED(transformed_out);
   SearchResult<cudnnConvolutionBwdDataAlgo_t> bwd_result;
   using search = SearchAlgorithm<ConvKind::kBackwardData>;
   bwd_result = search::Find<T>(dev_ctx, args, false, deterministic, false);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

#### 错误描述：

在 https://github.com/PaddlePaddle/Paddle/pull/73194 显式抛出 bigtensor 错误后，`conv_transpose` 测试时仍旧报 CUDA error 9:
<img width="2368" height="386" alt="image" src="https://github.com/user-attachments/assets/a74c5df6-6864-471b-b344-73ec77814fb0" />

#### 问题定位：

检查发现 `CUDNN_ENFORCE_TENSOR_SIZE_SUPPORTED` check 的位置过于靠后，CUDNN 描述符 `ConvArgs` 在构造时就发生错误；因此将前反向的 check 均提前至 `GPUDNNDataLayout` 之前

修改后，测试通过（已由 `paddle_error_dismiss` 放行）：
<img width="1676" height="220" alt="image" src="https://github.com/user-attachments/assets/90f31e5d-8dd8-4411-8ac2-4817ff2028af" />

#### 其他：

1. `conv` 未发现此问题，但是 bigtensor 测试配置存在 [numpy error]、错误形状等情况，需要在 APITest 中修复
2. 等待配置修复完毕后，再进行 `conv` 、 `conv_transpose` 的全量回测

Pcard-85711