### PR TITLE
[0-size Tensor Job2 No.67] Add 0-size Tensor support for paddle.nn.functional.upsample [fluid_ops]

### DIFF
--- a/paddle/phi/infermeta/multiary.cc
+++ b/paddle/phi/infermeta/multiary.cc
@@ -3245,7 +3245,7 @@ static void Interpolate1DInferShapeCheck(
                         "Input(X) dimension is 3, but got method = %s .",
                         interp_method));
   const DataLayout data_layout = common::StringToDataLayout(data_layout_str);
-  for (int i = 0; i < dim_x.size(); ++i) {
+  for (int i = 2; i < dim_x.size(); ++i) {
     PADDLE_ENFORCE_NE(dim_x[i],
                       0,
                       common::errors::InvalidArgument(
@@ -3377,7 +3377,7 @@ static void Interpolate2DInferShapeCheck(
           interp_method));
   const DataLayout data_layout = common::StringToDataLayout(data_layout_str);
 
-  for (int i = 0; i < dim_x.size(); ++i) {
+  for (int i = 2; i < dim_x.size(); ++i) {
     PADDLE_ENFORCE_NE(dim_x[i],
                       0,
                       common::errors::InvalidArgument(
@@ -3530,7 +3530,7 @@ static void Interpolate3DInferShapeCheck(
           interp_method));
   const DataLayout data_layout = common::StringToDataLayout(data_layout_str);
 
-  for (int i = 0; i < dim_x.size(); ++i) {
+  for (int i = 2; i < dim_x.size(); ++i) {
     PADDLE_ENFORCE_NE(dim_x[i],
                       0,
                       common::errors::InvalidArgument(

--- a/paddle/phi/kernels/cpu/interpolate_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/interpolate_grad_kernel.cc
@@ -861,6 +861,10 @@ void InterpolateGradKernel(
     bool align_corners,
     int align_mode,
     DenseTensor* x_grad) {
+  if (x_grad && x_grad->numel() == 0) {
+    dev_ctx.template Alloc<T>(x_grad);
+    return;
+  }
   auto output_grad_dims = output_grad.dims();
   if (output_grad_dims.size() == 3) {  // 1D interpolation grad
     Interpolate1DCPUBwd<T, Context>(dev_ctx,

--- a/paddle/phi/kernels/cpu/interpolate_kernel.cc
+++ b/paddle/phi/kernels/cpu/interpolate_kernel.cc
@@ -1033,6 +1033,11 @@ void InterpolateKernel(
     bool align_corners,
     int align_mode,
     DenseTensor* output) {
+  if (x.numel() == 0) {
+    dev_ctx.template Alloc<T>(output);
+    return;
+  }
+
   auto input_dims = x.dims();
   if (input_dims.size() == 3) {  // 1D interpolation
     Interpolate1DCPUFwd<T, Context>(dev_ctx,

--- a/paddle/phi/kernels/gpu/interpolate_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/interpolate_grad_kernel.cu
@@ -1438,6 +1438,10 @@ void InterpolateGradKernel(
     bool align_corners,
     int align_mode,
     DenseTensor* x_grad) {
+  if (x_grad && x_grad->numel() == 0) {
+    dev_ctx.template Alloc<T>(x_grad);
+    return;
+  }
   auto output_grad_dims = output_grad.dims();
   if (output_grad_dims.size() == 3) {  // 1D interpolation grad
     Interpolate1DCUDABwd<T, Context>(dev_ctx,

--- a/paddle/phi/kernels/gpu/interpolate_kernel.cu
+++ b/paddle/phi/kernels/gpu/interpolate_kernel.cu
@@ -1230,6 +1230,10 @@ void InterpolateKernel(
     bool align_corners,
     int align_mode,
     DenseTensor* output) {
+  if (x.numel() == 0) {
+    dev_ctx.template Alloc<T>(output);
+    return;
+  }
   auto input_dims = x.dims();
   if (input_dims.size() == 3) {  // 1D interpolation
     Interpolate1DCUDAFwd<T, Context>(dev_ctx,

--- a/paddle/phi/kernels/xpu/interpolate_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/interpolate_grad_kernel.cc
@@ -39,6 +39,10 @@ void InterpolateGradKernel(
     bool align_corners,
     int align_mode,
     DenseTensor* x_grad) {
+  if (x_grad && x_grad->numel() == 0) {
+    dev_ctx.template Alloc<T>(x_grad);
+    return;
+  }
   const DataLayout data_layout = common::StringToDataLayout(data_layout_str);
   int n, c, in_d, in_h, in_w;
   funcs::ExtractNCDWH(x.dims(), data_layout, &n, &c, &in_d, &in_h, &in_w);

--- a/paddle/phi/kernels/xpu/interpolate_kernel.cc
+++ b/paddle/phi/kernels/xpu/interpolate_kernel.cc
@@ -38,6 +38,10 @@ void InterpolateKernel(
     bool align_corners,
     int align_mode,
     DenseTensor* output) {
+  if (x.numel() == 0) {
+    dev_ctx.template Alloc<T>(output);
+    return;
+  }
   using XPUType = typename XPUTypeTrait<T>::Type;
   const DataLayout data_layout = common::StringToDataLayout(data_layout_str);
   int n, c, in_d, in_h, in_w;

--- a/test/legacy_test/test_bicubic_interp_v2_op.py
+++ b/test/legacy_test/test_bicubic_interp_v2_op.py
@@ -912,7 +912,7 @@ class TestBicubicOpError(unittest.TestCase):
         self.assertRaises(ValueError, test_size_length)
         self.assertRaises(ValueError, test_size_tensor_ndim)
         self.assertRaises(ValueError, test_size_tensor_length)
-        self.assertRaises(ValueError, test_input_shape_1)
+        # self.assertRaises(ValueError, test_input_shape_1)
 
     def test_errors(self):
         with program_guard(Program(), Program()):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
181 paddle.nn.functional.interpolate

任务2中 67 paddle.nn.functional.upsample 调用的 interpolate，和 interpolate 相同

infermeta 修改非0检查从维度2开始，符号推导没有对应代码
https://github.com/PaddlePaddle/Paddle/blob/d9def19ef4b53d3ae9a5a9d4ccd5137c94010af8/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/multiary_infer_sym.cc#L440

修改kernel，不是batch的维度不为0，判断x.numel为0 返回
修改python部分，scale在python中是float64类型，在kernel中是float类型，需要重新计算转换为float32后传入kernel，计算方式为 scale * D/H/W最大值，向下取整，然后再除以 D/H/W最大值

PaddleAPITest测试通过，错误为torch error
<img width="1315" height="235" alt="image" src="https://github.com/user-attachments/assets/cd057ef5-c8d8-4dae-ba38-abc7b483f241" />

<img width="1329" height="375" alt="image" src="https://github.com/user-attachments/assets/d95736d1-b69d-4c97-b878-2b2610f7e9b9" />
