### PR TITLE
[Accuracy diff No.107] Fix accuracy diff for paddle.nn.functional.adaptive_avg_pool3d API 

### DIFF
--- a/paddle/phi/kernels/funcs/fast_divmod.h
+++ b/paddle/phi/kernels/funcs/fast_divmod.h
@@ -113,7 +113,7 @@ struct FastDivMod<int64_t> {
     uint64_t q = Div(n);
     return {q, n - q * divisor};
   }
-  __device__ __forceinline__ uint64_t DivCeil(uint32_t n) const {
+  __device__ __forceinline__ uint64_t DivCeil(uint64_t n) const {
     DivModT res = Divmod(n);
     return res.val[1] > 0 ? res.val[0] + 1 : res.val[0];
   }

--- a/test/legacy_test/test_adaptive_avg_pool3d.py
+++ b/test/legacy_test/test_adaptive_avg_pool3d.py
@@ -260,7 +260,7 @@ class TestAdaptiveAvgPool3DAPI(unittest.TestCase):
                     allow_unused=True,
                 )
                 np.testing.assert_allclose(
-                    paddle.sum(x_grad[0]), out.numel(), rtol=1e-6
+                    paddle.sum(x_grad[0]), out.numel(), rtol=1e-5
                 )
 
 

--- a/test/legacy_test/test_adaptive_avg_pool3d.py
+++ b/test/legacy_test/test_adaptive_avg_pool3d.py
@@ -241,6 +241,28 @@ class TestAdaptiveAvgPool3DAPI(unittest.TestCase):
                 out_6.numpy(), self.res_3_np, rtol=1e-5, atol=1e-8
             )
 
+    def test_grad(self):
+        for use_cuda in (
+            [False, True] if core.is_compiled_with_cuda() else [False]
+        ):
+            place = paddle.CUDAPlace(0) if use_cuda else paddle.CPUPlace()
+            paddle.disable_static(place=place)
+            x = paddle.to_tensor(self.x_np)
+            x.stop_gradient = False
+            for output_size in [[2, 3, 5], [3, 3, 3], [6, 8, 8]]:
+                out = paddle.nn.functional.adaptive_avg_pool3d(
+                    x=x, output_size=output_size
+                )
+                x_grad = paddle.grad(
+                    [out],
+                    [x],
+                    grad_outputs=paddle.ones_like(out),
+                    allow_unused=True,
+                )
+                np.testing.assert_allclose(
+                    paddle.sum(x_grad[0]), out.numel(), rtol=1e-6
+                )
+
 
 class TestAdaptiveAvgPool3DClassAPI(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修复 paddle.nn.functional.adaptive_avg_pool3d 反向的精度问题。增加单测判断梯度和是否符合预期。

与 adaptive_avg_pool2d 修改方法类似
https://github.com/PaddlePaddle/Paddle/pull/74077

Pcard-67164