### PR TITLE
[slice]Optimizing bool index getitem paths

### DIFF
--- a/paddle/fluid/pybind/slice_utils.h
+++ b/paddle/fluid/pybind/slice_utils.h
@@ -769,11 +769,6 @@ static paddle::Tensor getValueForBoolTensor(const paddle::Tensor& tensor,
     return masked_select_ad_func(tensor, bool_index);
   }
 
-  if (bool_index.shape().size() == 1) {
-    auto bool_2_idx = nonzero_ad_func(bool_index);
-    return gather_ad_func(tensor, bool_2_idx);
-  }
-
   auto bool_2_idx = nonzero_ad_func(bool_index);
 #ifdef PADDLE_WITH_CUDA
   if (tensor.is_gpu() && !is_combined_bool) {
@@ -803,9 +798,14 @@ static paddle::Tensor getValueForBoolTensor(const paddle::Tensor& tensor,
                                          slice_offset,
                                          accumulate);
   } else {
+    if (bool_index.shape().size() == 1)
+      return gather_ad_func(tensor, bool_2_idx);
+
     return gather_nd_ad_func(tensor, bool_2_idx);
   }
 #else
+  if (bool_index.shape().size() == 1) return gather_ad_func(tensor, bool_2_idx);
+
   return gather_nd_ad_func(tensor, bool_2_idx);
 #endif
 }


### PR DESCRIPTION
### PR Category
Performance Optimization

### PR Types
Others

### Description
bool_index.shape().size() == 1场景使用 index_elementwise_get kernel 替代 gather以获得更好的反向性能。
pcard-67164