### PR TITLE
[slice]Optimizing bool index getitem paths

### DIFF
--- a/paddle/fluid/pybind/eager_method.cc
+++ b/paddle/fluid/pybind/eager_method.cc
@@ -1686,14 +1686,17 @@ static PyObject* tensor__getitem_dygraph(TensorObject* self,
         out = reshape_ad_func(out, ad.src_sizes);
       } else {
         const bool accumulate = true;
+        const bool is_gather = false;
         out = index_elementwise_get_ad_func(self->tensor,
+                                            self->tensor,
                                             ad.indices,
                                             ad.src_sizes,
                                             ad.src_strides,
                                             ad.indexed_sizes,
                                             ad.indexed_strides,
                                             slice_offset,
-                                            accumulate);
+                                            accumulate,
+                                            is_gather);
         out_is_view = false;
       }
 

--- a/paddle/fluid/pybind/slice_utils.h
+++ b/paddle/fluid/pybind/slice_utils.h
@@ -769,14 +769,10 @@ static paddle::Tensor getValueForBoolTensor(const paddle::Tensor& tensor,
     return masked_select_ad_func(tensor, bool_index);
   }
 
-  if (bool_index.shape().size() == 1) {
-    auto bool_2_idx = nonzero_ad_func(bool_index);
-    return gather_ad_func(tensor, bool_2_idx);
-  }
-
   auto bool_2_idx = nonzero_ad_func(bool_index);
 #ifdef PADDLE_WITH_CUDA
   if (tensor.is_gpu() && !is_combined_bool) {
+    const bool is_gather = bool_index.shape().size() == 1;
     std::vector<paddle::Tensor> indices =
         PrepareIndices(tensor, bool_2_idx, bool_index);
     while (indices.size() < static_cast<size_t>(tensor.dims().size())) {
@@ -795,17 +791,25 @@ static paddle::Tensor getValueForBoolTensor(const paddle::Tensor& tensor,
     const bool accumulate = false;
 
     return index_elementwise_get_ad_func(tensor,
+                                         bool_2_idx,
                                          ad.indices,
                                          ad.src_sizes,
                                          ad.src_strides,
                                          ad.indexed_sizes,
                                          ad.indexed_strides,
                                          slice_offset,
-                                         accumulate);
+                                         accumulate,
+                                         is_gather);
   } else {
+    if (bool_index.shape().size() == 1) {
+      return gather_ad_func(tensor, bool_2_idx);
+    }
     return gather_nd_ad_func(tensor, bool_2_idx);
   }
 #else
+  if (bool_index.shape().size() == 1) {
+    return gather_ad_func(tensor, bool_2_idx);
+  }
   return gather_nd_ad_func(tensor, bool_2_idx);
 #endif
 }

--- a/paddle/phi/infermeta/backward.cc
+++ b/paddle/phi/infermeta/backward.cc
@@ -2131,6 +2131,7 @@ void FusedRMSNormGradInferMeta(const MetaTensor& x,
 
 void IndexElementwiseGetGradInferMeta(
     const MetaTensor& x,
+    const MetaTensor& gather_index,
     const std::vector<const MetaTensor*>& index,
     const MetaTensor& out_grad,
     const std::vector<int64_t>& input_dims,
@@ -2139,6 +2140,7 @@ void IndexElementwiseGetGradInferMeta(
     const std::vector<int64_t>& index_strides,
     const int64_t slice_offset,
     const bool accumulate,
+    const bool is_gather,
     MetaTensor* x_grad) {
   if (x_grad) {
     x_grad->share_meta(x);

--- a/paddle/phi/infermeta/backward.h
+++ b/paddle/phi/infermeta/backward.h
@@ -772,6 +772,7 @@ void FusedRMSNormGradInferMeta(const MetaTensor& x,
 
 void IndexElementwiseGetGradInferMeta(
     const MetaTensor& x,
+    const MetaTensor& gather_index,
     const std::vector<const MetaTensor*>& index,
     const MetaTensor& out_grad,
     const std::vector<int64_t>& input_dims,
@@ -780,5 +781,6 @@ void IndexElementwiseGetGradInferMeta(
     const std::vector<int64_t>& index_strides,
     const int64_t slice_offset,
     const bool accumulate,
+    const bool is_gather,
     MetaTensor* x_grad);
 }  // namespace phi

--- a/paddle/phi/infermeta/binary.cc
+++ b/paddle/phi/infermeta/binary.cc
@@ -2592,6 +2592,7 @@ void IndexElementwisePutWithTensorInferMeta(
 }
 
 void IndexElementwiseGetInferMeta(const MetaTensor& x,
+                                  const MetaTensor& gather_index,
                                   const std::vector<const MetaTensor*>& index,
                                   const std::vector<int64_t>& input_dims,
                                   const std::vector<int64_t>& input_strides,
@@ -2599,6 +2600,7 @@ void IndexElementwiseGetInferMeta(const MetaTensor& x,
                                   const std::vector<int64_t>& index_stride,
                                   const int64_t slice_offset,
                                   const bool accumulate,
+                                  const bool is_gather,
                                   MetaTensor* out) {
   out->set_dims(common::make_ddim(input_dims));
   out->set_dtype(x.dtype());

--- a/paddle/phi/infermeta/binary.h
+++ b/paddle/phi/infermeta/binary.h
@@ -486,6 +486,7 @@ void IndexElementwisePutWithTensorInferMeta(
     MetaTensor* out);
 
 void IndexElementwiseGetInferMeta(const MetaTensor& x,
+                                  const MetaTensor& gather_index,
                                   const std::vector<const MetaTensor*>& index,
                                   const std::vector<int64_t>& input_dims,
                                   const std::vector<int64_t>& input_strides,
@@ -493,6 +494,7 @@ void IndexElementwiseGetInferMeta(const MetaTensor& x,
                                   const std::vector<int64_t>& index_stride,
                                   const int64_t slice_offset,
                                   const bool accumulate,
+                                  const bool is_gather,
                                   MetaTensor* out);
 
 void KronInferMeta(const MetaTensor& x, const MetaTensor& y, MetaTensor* out);

--- a/paddle/phi/kernels/cpu/index_elementwise_get_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_elementwise_get_grad_kernel.cc
@@ -123,6 +123,7 @@ void CPUIndexElementwiseGetGrad(const phi::CPUContext& dev_ctx,
 template <typename T, typename Context>
 void IndexElementwiseGetGradKernel(const Context& dev_ctx,
                                    const DenseTensor& x,
+                                   const DenseTensor& gather_index,
                                    const std::vector<const DenseTensor*>& index,
                                    const DenseTensor& out_grad,
                                    const std::vector<int64_t>& input_dims,
@@ -131,6 +132,7 @@ void IndexElementwiseGetGradKernel(const Context& dev_ctx,
                                    const std::vector<int64_t>& index_strides,
                                    const int64_t slice_offset,
                                    const bool accumulate,
+                                   const bool is_gather,
                                    DenseTensor* x_grad) {
   dev_ctx.template Alloc<T>(x_grad);
   auto dxt = phi::EigenVector<T>::Flatten(*x_grad);

--- a/paddle/phi/kernels/cpu/index_elementwise_get_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_elementwise_get_kernel.cc
@@ -93,6 +93,7 @@ void CPUIndexElementwiseGetKernel(const phi::CPUContext& dev_ctx,
 template <typename T, typename Context>
 void IndexElementwiseGetKernel(const Context& dev_ctx,
                                const DenseTensor& x,
+                               const DenseTensor& gather_index,
                                const std::vector<const DenseTensor*>& index,
                                const std::vector<int64_t>& input_dims,
                                const std::vector<int64_t>& input_strides,
@@ -100,6 +101,7 @@ void IndexElementwiseGetKernel(const Context& dev_ctx,
                                const std::vector<int64_t>& index_stride,
                                const int64_t slice_offset,
                                const bool accumulate,
+                               const bool is_gather,
                                DenseTensor* out) {
   const auto& index_type = index[0]->dtype();
   PADDLE_ENFORCE_EQ(index_type == phi::DataType::INT64,

--- a/paddle/phi/kernels/gpu/index_elementwise_get_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_elementwise_get_grad_kernel.cu
@@ -153,6 +153,7 @@ void GPUIndexElementwiseGetGrad(const phi::GPUContext& dev_ctx,
 template <typename T, typename Context>
 void IndexElementwiseGetGradKernel(const Context& dev_ctx,
                                    const DenseTensor& x,
+                                   const DenseTensor& gather_index,
                                    const std::vector<const DenseTensor*>& index,
                                    const DenseTensor& out_grad,
                                    const std::vector<int64_t>& input_dims,
@@ -161,6 +162,7 @@ void IndexElementwiseGetGradKernel(const Context& dev_ctx,
                                    const std::vector<int64_t>& index_strides,
                                    const int64_t slice_offset,
                                    const bool accumulate,
+                                   const bool is_gather,
                                    DenseTensor* x_grad) {
   dev_ctx.template Alloc<T>(x_grad);
   phi::funcs::set_constant(dev_ctx, x_grad, static_cast<float>(0));

--- a/paddle/phi/kernels/gpu/index_elementwise_get_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_elementwise_get_kernel.cu
@@ -19,6 +19,7 @@
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/index_elementwise.cu.h"
 #include "paddle/phi/kernels/funcs/stride_utils.h"
+#include "paddle/phi/kernels/gather_kernel.h"
 
 namespace phi {
 template <typename T, typename IndexT = int>
@@ -110,6 +111,7 @@ void GPUIndexElementwiseGetKernel(const phi::GPUContext& dev_ctx,
 template <typename T, typename Context>
 void IndexElementwiseGetKernel(const Context& dev_ctx,
                                const DenseTensor& x,
+                               const DenseTensor& gather_index,
                                const std::vector<const DenseTensor*>& index,
                                const std::vector<int64_t>& input_dims,
                                const std::vector<int64_t>& input_strides,
@@ -117,16 +119,8 @@ void IndexElementwiseGetKernel(const Context& dev_ctx,
                                const std::vector<int64_t>& index_stride,
                                const int64_t slice_offset,
                                const bool accumulate,
+                               const bool is_gather,
                                DenseTensor* out) {
-  const auto& index_type = index[0]->dtype();
-  PADDLE_ENFORCE_EQ(index_type == phi::DataType::INT64,
-                    true,
-                    common::errors::InvalidArgument(
-                        "Index holds the wrong type, it holds [%s], but "
-                        "desires to be [%s].",
-                        index_type,
-                        phi::DataType::INT64));
-
   auto out_dims = out->dims();
   if (out_dims.size() > 0) {
     std::vector<int64_t> output_dims(input_dims);
@@ -135,6 +129,20 @@ void IndexElementwiseGetKernel(const Context& dev_ctx,
 
   dev_ctx.template Alloc<T>(out);
   if (out->numel() == 0) return;
+
+  if (is_gather) {
+    phi::GatherKernel<T, Context>(dev_ctx, x, gather_index, 0, out);
+    return;
+  }
+
+  const auto& index_type = index[0]->dtype();
+  PADDLE_ENFORCE_EQ(index_type == phi::DataType::INT64,
+                    true,
+                    common::errors::InvalidArgument(
+                        "Index holds the wrong type, it holds [%s], but "
+                        "desires to be [%s].",
+                        index_type,
+                        phi::DataType::INT64));
 
   GPUIndexElementwiseGetKernel<T, int64_t>(dev_ctx,
                                            x,

--- a/paddle/phi/kernels/index_elementwise_get_grad_kernel.h
+++ b/paddle/phi/kernels/index_elementwise_get_grad_kernel.h
@@ -22,6 +22,7 @@ namespace phi {
 template <typename T, typename Context>
 void IndexElementwiseGetGradKernel(const Context& ctx,
                                    const DenseTensor& x,
+                                   const DenseTensor& gather_index,
                                    const std::vector<const DenseTensor*>& index,
                                    const DenseTensor& out_grad,
                                    const std::vector<int64_t>& input_dims,
@@ -30,6 +31,7 @@ void IndexElementwiseGetGradKernel(const Context& ctx,
                                    const std::vector<int64_t>& index_strides,
                                    const int64_t slice_offset,
                                    const bool accumulate,
+                                   const bool is_gather,
                                    DenseTensor* x_grad);
 
 }  // namespace phi

--- a/paddle/phi/kernels/index_elementwise_get_kernel.h
+++ b/paddle/phi/kernels/index_elementwise_get_kernel.h
@@ -22,6 +22,7 @@ namespace phi {
 template <typename T, typename Context>
 void IndexElementwiseGetKernel(const Context &ctx,
                                const DenseTensor &x,
+                               const DenseTensor &gather_index,
                                const std::vector<const DenseTensor *> &index,
                                const std::vector<int64_t> &input_dims,
                                const std::vector<int64_t> &input_strides,
@@ -29,6 +30,7 @@ void IndexElementwiseGetKernel(const Context &ctx,
                                const std::vector<int64_t> &index_stride,
                                const int64_t slice_offset,
                                const bool accumulate,
+                               const bool is_gather,
                                DenseTensor *out);
 
 }  // namespace phi

--- a/paddle/phi/ops/yaml/backward.yaml
+++ b/paddle/phi/ops/yaml/backward.yaml
@@ -1690,14 +1690,14 @@
   no_need_buffer: add_value
 
 - backward_op : index_elementwise_get_double_grad
-  forward : index_elementwise_get_grad (Tensor x, Tensor[] index, Tensor out_grad, int64_t[] input_dims, int64_t[] input_strides, int64_t[] index_dims, int64_t[] index_stride, int64_t slice_offset, bool accumulate) -> Tensor(x_grad)
-  args : (Tensor[] index, Tensor x_grad_grad, int64_t[] input_dims, int64_t[] input_strides, int64_t[] index_dims, int64_t[] index_stride, int64_t slice_offset = 0, bool accumulate = true)
+  forward : index_elementwise_get_grad (Tensor x, Tensor gather_index, Tensor[] index, Tensor out_grad, int64_t[] input_dims, int64_t[] input_strides, int64_t[] index_dims, int64_t[] index_stride, int64_t slice_offset, bool accumulate, bool is_gather) -> Tensor(x_grad)
+  args : (Tensor gather_index, Tensor[] index, Tensor x_grad_grad, int64_t[] input_dims, int64_t[] input_strides, int64_t[] index_dims, int64_t[] index_stride, int64_t slice_offset, bool accumulate, bool is_gather)
   output : Tensor(out_grad_grad)
-  invoke : index_elementwise_get(x_grad_grad, index, input_dims, input_strides, index_dims, index_stride, slice_offset, accumulate)
+  invoke : index_elementwise_get(x_grad_grad, gather_index, index, input_dims, input_strides, index_dims, index_stride, slice_offset, accumulate, is_gather)
 
 - backward_op : index_elementwise_get_grad
-  forward : index_elementwise_get (Tensor x, Tensor[] index, int64_t[] input_dims, int64_t[] input_strides, int64_t[] index_dims, int64_t[] index_stride, int64_t slice_offset, bool accumulate) -> Tensor(out)
-  args : (Tensor x, Tensor[] index, Tensor out_grad, int64_t[] input_dims, int64_t[] input_strides, int64_t[] index_dims, int64_t[] index_stride, int64_t slice_offset = 0, bool accumulate = true)
+  forward : index_elementwise_get (Tensor x, Tensor gather_index, Tensor[] index, int64_t[] input_dims, int64_t[] input_strides, int64_t[] index_dims, int64_t[] index_stride, int64_t slice_offset, bool accumulate, bool is_gather) -> Tensor(out)
+  args : (Tensor x, Tensor gather_index, Tensor[] index, Tensor out_grad, int64_t[] input_dims, int64_t[] input_strides, int64_t[] index_dims, int64_t[] index_stride, int64_t slice_offset, bool accumulate, bool is_gather)
   output : Tensor(x_grad)
   infer_meta :
     func : IndexElementwiseGetGradInferMeta

--- a/paddle/phi/ops/yaml/op_compat.yaml
+++ b/paddle/phi/ops/yaml/op_compat.yaml
@@ -2032,7 +2032,7 @@
 - op : index_elementwise_get
   backward : index_elementwise_get_grad, index_elementwise_get_double_grad
   inputs :
-     {x : x, index : index, input_dims : input_dims, input_strides : input_strides, index_dims : index_dims, index_stride : index_stride, slice_offset : slice_offset, accumulate : accumulate}
+     {x : x, gather_index : gather_index, index : index, input_dims : input_dims, input_strides : input_strides, index_dims : index_dims, index_stride : index_stride, slice_offset : slice_offset, accumulate : accumulate, is_gather : is_gather}
   outputs :
      out : Out
 

--- a/paddle/phi/ops/yaml/ops.yaml
+++ b/paddle/phi/ops/yaml/ops.yaml
@@ -2802,7 +2802,7 @@
   interfaces : paddle::dialect::InferSymbolicShapeInterface, paddle::dialect::LayoutTransformationInterface
 
 - op : index_elementwise_get
-  args : (Tensor x, Tensor[] index, int64_t[] input_dims, int64_t[] input_strides, int64_t[] index_dims, int64_t[] index_stride, int64_t slice_offset = 0, bool accumulate = true)
+  args : (Tensor x, Tensor gather_index, Tensor[] index, int64_t[] input_dims, int64_t[] input_strides, int64_t[] index_dims, int64_t[] index_stride, int64_t slice_offset, bool accumulate, bool is_gather)
   output : Tensor (out)
   infer_meta :
     func : IndexElementwiseGetInferMeta


### PR DESCRIPTION
### PR Category
Performance Optimization

### PR Types
Others

### Description
bool_index.shape().size() == 1场景前向使用gather kernel，反向使用index_elementwise_get_grad kernel可以获得更好的性能。
例如： x.shape =  (108, 64, 12288) , index =  True
前向：807.00 us(index_elementwise_get) -> 518.00 us(gather)
反向：1611.02 us(gather grad) -> 1332.00 us(index_elementwise_get_grad)
pcard-67164