### PR TITLE
pp shared_comm

### DIFF
--- a/python/paddle/distributed/fleet/meta_optimizers/dygraph_optimizer/hybrid_parallel_optimizer.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/dygraph_optimizer/hybrid_parallel_optimizer.py
@@ -524,7 +524,7 @@ class HybridParallelOptimizer:
         if pp_configs and (pp_configs.sync_param or pp_configs.sync_moment):
             params = sorted(
                 [p for p in parameters_list if self._pp_filter_fn(p)],
-                key=lambda p: p.name,
+                key=lambda p: p.color['color'],
             )
         return params, pp_configs
 

--- a/python/paddle/distributed/fleet/meta_parallel/parallel_layers/pp_layers.py
+++ b/python/paddle/distributed/fleet/meta_parallel/parallel_layers/pp_layers.py
@@ -658,7 +658,7 @@ class PipelineLayer(nn.Layer):
                             )
                             hcg = fleet.get_hybrid_communicate_group()
                             shared_param.color = {
-                                "color": f"{SHARED_WEIGHT_SYNC_PREFIX}_{layer_name}",
+                                "color": f"{SHARED_WEIGHT_SYNC_PREFIX}_{layer_name}_{weight_attr}",
                                 "group": hcg.get_sharding_parallel_group(),
                                 "broadcast_group": group,
                             }

--- a/python/paddle/distributed/fleet/meta_parallel/parallel_layers/pp_layers.py
+++ b/python/paddle/distributed/fleet/meta_parallel/parallel_layers/pp_layers.py
@@ -506,8 +506,6 @@ class PipelineLayer(nn.Layer):
             self.run_function = []
             self._build_layer()
 
-        self.comm_key_to_layer_name = {}
-
         self.shared_comm = self._construct_shared_comm()
         self._synchronize_shared_weights()
 
@@ -604,59 +602,6 @@ class PipelineLayer(nn.Layer):
                     current_layer_idx_to_stage_idx
                 ] = layer_name_to_attrs_on_stage_idx
 
-        # The second loop generates comm keys and assigns stages and attrs to the comm key.
-        # Record all unique comm keys, the comm key is generated from the layer name and the stage idx.
-        # Each comm key represents a comm group.
-        comm_keys = []
-        # Maps comm key to layer name.
-        comm_key_to_layer_name = {}
-        # Maps comm key to two stage idx using the comm key.
-        comm_key_to_stage_idx = {}
-        # Maps comm key to all shared attrs that will be communicated by the comm group indicated by the comm key.
-        comm_key_to_shared_attrs = {}
-        for layer_name in layer_name_to_stage_idx.keys():
-            all_stage_idx_contains_layer = layer_name_to_stage_idx[layer_name]
-            # For all stages contain a same layer name,
-            # generate a comm group between each stage and the pivot explicitly.
-            for stage_idx in all_stage_idx_contains_layer:
-                comm_key = f'LAYER_NAME:{layer_name},STAGE_IDX:{stage_idx}'
-                for idx, layer in enumerate(self._layers_desc):
-                    current_layer_idx_to_stage_idx = self.get_stage_from_index(
-                        idx
-                    )
-                    if not isinstance(layer, SharedLayerDesc):
-                        continue
-                    if (
-                        current_layer_idx_to_stage_idx
-                        == layer_name_to_pivot_stage_idx[layer_name]
-                    ):
-                        # Skip the pivot, the pivot stage will be added automatically when creating a new comm group.
-                        continue
-                    if (
-                        layer.layer_name == layer_name
-                        and current_layer_idx_to_stage_idx == stage_idx
-                    ):
-                        # Add comm key to comm_keys and add current stage idx to comm group.
-                        if comm_key not in comm_keys:
-                            comm_keys.append(comm_key)
-                            comm_key_to_layer_name[comm_key] = layer_name
-                            # The comm will only happen between pivot and current stage.
-                            comm_key_to_stage_idx[comm_key] = [
-                                layer_name_to_pivot_stage_idx[layer_name],
-                                current_layer_idx_to_stage_idx,
-                            ]
-                            comm_key_to_shared_attrs[comm_key] = (
-                                stage_idx_to_layer_name_to_attrs[stage_idx][
-                                    layer.layer_name
-                                ]
-                            )
-
-        if len(comm_keys) == 0:
-            warnings.warn(
-                "No shared comm will be constructed, "
-                "this may happen when all shared attrs are on a same stage."
-            )
-
         from paddle.distributed import fleet
         from paddle.distributed.fleet.base.topology import message2nccl_config
         from paddle.distributed.fleet.meta_optimizers.dygraph_optimizer.hybrid_parallel_optimizer import (
@@ -665,14 +610,14 @@ class PipelineLayer(nn.Layer):
 
         hybrid_configs = fleet.fleet._user_defined_strategy.hybrid_configs
 
-        # The third loop generates comm group for each comm key.
-        for comm_key in comm_keys:
-            shared_stages = comm_key_to_stage_idx[comm_key]
-            layer_name = comm_key_to_layer_name[comm_key]
-            shared_attrs = comm_key_to_shared_attrs[comm_key]
+        # The next loop generates comm group for each layer_name.
+        for layer_name in layer_name_to_stage_idx.keys():
+            shared_stages = layer_name_to_stage_idx[layer_name]
+            weight_attrs = layer_name_to_pivot_attrs[layer_name]
+            shared_weight_attrs = layer_name_to_attrs_on_stage_idx[layer_name]
             logger.info(
-                f'Constructing shared comm for {comm_key} among pp stages {shared_stages}, '
-                f'this shared comm will communicate attrs: {shared_attrs}.'
+                f'Constructing shared comm for {layer_name} among pp stages {shared_stages}, '
+                f'this shared comm will communicate attrs: {weight_attrs}.'
             )
 
             if hasattr(self._topo, "_parent_hcg"):
@@ -693,10 +638,11 @@ class PipelineLayer(nn.Layer):
                 )
                 if self.global_rank in shared_ranks:
                     assert layer_name in self.shared_layers
-                    shared_comm[comm_key] = {
+                    shared_comm[layer_name] = {
                         "ranks": shared_ranks,
                         "group": group,
-                        "weight_attr": shared_attrs,
+                        "weight_attr": weight_attrs,
+                        "shared_weight_attr": shared_weight_attrs,
                         "layer": self.shared_layers[layer_name],
                     }
 
@@ -706,13 +652,13 @@ class PipelineLayer(nn.Layer):
                     ):
                         # Set color for shared parameters to facilitate synchronization of parameters
                         # and optimizer states after each step
-                        for weight_attr in shared_attrs:
+                        for weight_attr in weight_attrs:
                             shared_param = getattr(
                                 self.shared_layers[layer_name], weight_attr
                             )
                             hcg = fleet.get_hybrid_communicate_group()
                             shared_param.color = {
-                                "color": f"{SHARED_WEIGHT_SYNC_PREFIX}_{comm_key}",
+                                "color": f"{SHARED_WEIGHT_SYNC_PREFIX}_{layer_name}",
                                 "group": hcg.get_sharding_parallel_group(),
                                 "broadcast_group": group,
                             }
@@ -771,6 +717,9 @@ class PipelineLayer(nn.Layer):
                             grad_var,
                             group=comm['group'],
                         )
+                    # clear the grad of unused params in current stage
+                    if weight_attr not in comm["shared_weight_attr"]:
+                        param.clear_grad()
                 else:
                     with paddle.framework.no_grad():
                         framework._dygraph_tracer().trace_op(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience
### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
现有pp共享参数使用不同的通信组来共享不同的参数，比如用户组网如下

```
pp_stage 0：
shared_layer{**w0**, **w1**, **w2**}

pp_stage 1：
shared_layer{**w0**, w1, w2}

pp_stage 2：
shared_layer{w0, **w1**, w2}

pp_stage 3：
shared_layer{w0, w1, **w2**}
```


这种情况下对于pp_stage0的参与方，需要建立[0,1] ,[0, 2], [0,3]三个通信组
pp_stage0一般处于显存的峰值的位置，建立多个通信组对其显存造成压力

现在改成建立一个大的通信组[0, 1, 2, 3]这种方式来进行共享参数的广播，相比于上述方式会多一些通信量，但是会少建通信组。

另外这种方式仍然兼容原始的方式，用户可改写组网如下，与原始方式行为相同

```
pp_stage 0：
shared_layer_0{**w0**}
shared_layer_1{**w1**}
shared_layer_2{**w2**}

pp_stage 1：
shared_layer_0{**w0**}

pp_stage 2：
shared_layer_1{**w1**}

pp_stage 3：
shared_layer_2{**w2**}
```
