### PR TITLE
[Slice]Dispatch bool-only combined case to elementwise

### DIFF
--- a/paddle/fluid/pybind/slice_utils.h
+++ b/paddle/fluid/pybind/slice_utils.h
@@ -72,6 +72,18 @@ static inline common::DDim infer_size_symdimvector(common::DDim a,
   return expandedSizes;
 }
 
+static inline paddle::Tensor expand_inplace(paddle::Tensor tensor,
+                                            paddle::Tensor to_expand) {
+  if (tensor.dims() == to_expand.dims()) {
+    return to_expand;
+  } else if (tensor.dims()[0] == to_expand.dims()[0]) {
+    return expand_ad_func(to_expand, common::vectorize<int64_t>(tensor.dims()));
+  } else {
+    to_expand = squeeze_ad_func(to_expand, {-1});
+    return expand_ad_func(to_expand, common::vectorize<int64_t>(tensor.dims()));
+  }
+}
+
 static inline std::vector<paddle::Tensor> expandTensors(
     std::vector<paddle::Tensor> indices) {
   // expands bool to int tensors;

--- a/paddle/phi/kernels/cpu/index_elementwise_put_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_elementwise_put_grad_kernel.cc
@@ -49,7 +49,6 @@ void CPUIndexElementwisePutGradKernel(
     sizes[i] = index_dims[i];
     strides[i] = index_strides[i];
   }
-  auto index_ptrs = funcs::GetIndexDataPtrs<IndexT>(index);
   std::array<int64_t*, 3> strides_array;
   std::vector<int64_t> desired_shape;
   std::array<std::vector<int64_t>, 3> strides_vec;
@@ -90,6 +89,7 @@ void CPUIndexElementwisePutGradKernel(
         }
       }
     } else {
+      auto index_ptrs = funcs::GetIndexDataPtrs<IndexT>(index);
       for (int64_t idx = 0; idx < N; idx++) {
         const auto offsets = offset_calc.cpu_get(idx);
         char* const out_data = out_ptr + offsets[0] + slice_offset;
@@ -108,6 +108,7 @@ void CPUIndexElementwisePutGradKernel(
       }
     }
   } else if (!x_grad) {
+    auto index_ptrs = funcs::GetIndexDataPtrs<IndexT>(index);
     const char* out_ptr = reinterpret_cast<const char*>(out_grad.data<T>());
     char* value_ptr = reinterpret_cast<char*>(value_grad->data<T>());
     for (int64_t idx = 0; idx < N; idx++) {
@@ -126,6 +127,7 @@ void CPUIndexElementwisePutGradKernel(
           *reinterpret_cast<const dtype*>(out_data + offset);
     }
   } else {
+    auto index_ptrs = funcs::GetIndexDataPtrs<IndexT>(index);
     char* out_ptr = reinterpret_cast<char*>(x_grad->data<T>());
     char* value_ptr = reinterpret_cast<char*>(value_grad->data<T>());
     for (int64_t idx = 0; idx < N; idx++) {

--- a/paddle/phi/kernels/cpu/index_elementwise_put_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_elementwise_put_grad_kernel.cc
@@ -290,7 +290,7 @@ void IndexElementwisePutGradKernel(
   const auto& index_type = indices[0]->dtype();
   PADDLE_ENFORCE_EQ(
       index_type == phi::DataType::INT64 ||
-          (index_type == phi::DataType::BOOL && index.size() == 1),
+          (index_type == phi::DataType::BOOL && indices.size() == 1),
       true,
       common::errors::InvalidArgument(
           "Index holds the wrong type, it holds [%s], but "

--- a/paddle/phi/kernels/cpu/index_elementwise_put_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_elementwise_put_grad_kernel.cc
@@ -80,20 +80,32 @@ void CPUIndexElementwisePutGradKernel(
   using dtype = funcs::OpaqueType<sizeof(T)>;
   if (!value_grad) {
     char* out_ptr = reinterpret_cast<char*>(x_grad->data<T>());
-    for (int64_t idx = 0; idx < N; idx++) {
-      const auto offsets = offset_calc.cpu_get(idx);
-      char* const out_data = out_ptr + offsets[0] + slice_offset;
-      int64_t offset = 0;
-      for (int64_t i = 0; i < num_indices; i++) {
-        int64_t index = *reinterpret_cast<int64_t*>(index_ptrs[i] + offsets[2]);
-        if (index < 0) {
-          index += sizes[i];
+    if (index.size() == 1 && index[0]->dtype() == phi::DataType::BOOL) {
+      const bool* mask_data = index[0]->data<bool>();
+      for (int64_t idx = 0; idx < N; idx++) {
+        const auto offsets = offset_calc.cpu_get(idx);
+        char* const out_data = out_ptr + offsets[0] + slice_offset;
+        if (mask_data[idx]) {
+          *reinterpret_cast<T*>(out_data) = T(0);
         }
-        offset += index * strides[i];
       }
-      T num = T(0);
-      *reinterpret_cast<dtype*>(out_data + offset) =
-          *reinterpret_cast<dtype*>(&num);
+    } else {
+      for (int64_t idx = 0; idx < N; idx++) {
+        const auto offsets = offset_calc.cpu_get(idx);
+        char* const out_data = out_ptr + offsets[0] + slice_offset;
+        int64_t offset = 0;
+        for (int64_t i = 0; i < num_indices; i++) {
+          int64_t index =
+              *reinterpret_cast<int64_t*>(index_ptrs[i] + offsets[2]);
+          if (index < 0) {
+            index += sizes[i];
+          }
+          offset += index * strides[i];
+        }
+        T num = T(0);
+        *reinterpret_cast<dtype*>(out_data + offset) =
+            *reinterpret_cast<dtype*>(&num);
+      }
     }
   } else if (!x_grad) {
     const char* out_ptr = reinterpret_cast<const char*>(out_grad.data<T>());
@@ -276,13 +288,15 @@ void IndexElementwisePutGradKernel(
     const int64_t slice_offset,
     DenseTensor* x_grad) {
   const auto& index_type = indices[0]->dtype();
-  PADDLE_ENFORCE_EQ(index_type == phi::DataType::INT64,
-                    true,
-                    common::errors::InvalidArgument(
-                        "Index holds the wrong type, it holds [%s], but "
-                        "desires to be [%s].",
-                        index_type,
-                        phi::DataType::INT64));
+  PADDLE_ENFORCE_EQ(
+      index_type == phi::DataType::INT64 ||
+          (index_type == phi::DataType::BOOL && index.size() == 1),
+      true,
+      common::errors::InvalidArgument(
+          "Index holds the wrong type, it holds [%s], but "
+          "desires to be [%s].",
+          index_type,
+          phi::DataType::INT64));
 
   std::vector<DenseTensor> tmp_args;
   if (indices.empty()) {

--- a/paddle/phi/kernels/cpu/index_elementwise_put_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_elementwise_put_kernel.cc
@@ -131,7 +131,6 @@ void CPUIndexElementwisePutKernel(const phi::CPUContext& dev_ctx,
     sizes[i] = index_dims[i];
     strides[i] = index_strides[i];
   }
-  auto index_ptrs = funcs::GetIndexDataPtrs<IndexT>(index);
   std::array<int64_t*, 3> strides_array;
   std::vector<int64_t> desired_shape;
   std::array<std::vector<int64_t>, 3> strides_vec;
@@ -164,6 +163,7 @@ void CPUIndexElementwisePutKernel(const phi::CPUContext& dev_ctx,
       }
     }
   } else {
+    auto index_ptrs = funcs::GetIndexDataPtrs<IndexT>(index);
     for (int64_t idx = 0; idx < N; idx++) {
       const auto offsets = offset_calc.cpu_get(idx);
       char* const out_data = out_ptr + offsets[0] + slice_offset;

--- a/paddle/phi/kernels/cpu/index_elementwise_put_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_elementwise_put_kernel.cc
@@ -154,18 +154,29 @@ void CPUIndexElementwisePutKernel(const phi::CPUContext& dev_ctx,
   PADDLE_ENFORCE(N >= 0 && N <= std::numeric_limits<int32_t>::max(),
                  "N >= 0 && N <= std::numeric_limits<int32_t>::max()");
   char* out_ptr = reinterpret_cast<char*>(output_);
-  for (int64_t idx = 0; idx < N; idx++) {
-    const auto offsets = offset_calc.cpu_get(idx);
-    char* const out_data = out_ptr + offsets[0] + slice_offset;
-    int64_t offset = 0;
-    for (int64_t i = 0; i < num_indices; i++) {
-      int64_t index = *reinterpret_cast<int64_t*>(index_ptrs[i] + offsets[2]);
-      if (index < 0) {
-        index += sizes[i];
+  if (index.size() == 1 && index[0]->dtype() == phi::DataType::BOOL) {
+    const bool* mask_data = index[0]->data<bool>();
+    for (int64_t idx = 0; idx < N; idx++) {
+      const auto offsets = offset_calc.cpu_get(idx);
+      char* const out_data = out_ptr + offsets[0] + slice_offset;
+      if (mask_data[idx]) {
+        *reinterpret_cast<T*>(out_data) = value_T;
       }
-      offset += index * strides[i];
     }
-    *reinterpret_cast<T*>(out_data + offset) = value_T;
+  } else {
+    for (int64_t idx = 0; idx < N; idx++) {
+      const auto offsets = offset_calc.cpu_get(idx);
+      char* const out_data = out_ptr + offsets[0] + slice_offset;
+      int64_t offset = 0;
+      for (int64_t i = 0; i < num_indices; i++) {
+        int64_t index = *reinterpret_cast<int64_t*>(index_ptrs[i] + offsets[2]);
+        if (index < 0) {
+          index += sizes[i];
+        }
+        offset += index * strides[i];
+      }
+      *reinterpret_cast<T*>(out_data + offset) = value_T;
+    }
   }
 }
 
@@ -224,13 +235,15 @@ void IndexElementwisePutKernel(const Context& dev_ctx,
                                const int64_t slice_offset,
                                DenseTensor* out) {
   const auto& index_type = index[0]->dtype();
-  PADDLE_ENFORCE_EQ(index_type == phi::DataType::INT64,
-                    true,
-                    common::errors::InvalidArgument(
-                        "Index holds the wrong type, it holds [%s], but "
-                        "desires to be [%s].",
-                        index_type,
-                        phi::DataType::INT64));
+  PADDLE_ENFORCE_EQ(
+      index_type == phi::DataType::INT64 ||
+          (index_type == phi::DataType::BOOL && index.size() == 1),
+      true,
+      common::errors::InvalidArgument(
+          "Index holds the wrong type, it holds [%s], but "
+          "desires to be [%s].",
+          index_type,
+          phi::DataType::INT64));
   if (out && out->numel() == 0) {
     dev_ctx.template Alloc<T>(out);
     return;

--- a/paddle/phi/kernels/gpu/index_elementwise_put_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_elementwise_put_grad_kernel.cu
@@ -91,25 +91,37 @@ void GPUIndexElementwisePutGradKernel(
   using dtype = funcs::OpaqueType<sizeof(T)>;
   if (!value_grad) {
     char* out_ptr = reinterpret_cast<char*>(x_grad->data<T>());
-    funcs::index_elementwise_with_tensor_kernel<nt, vt>
-        <<<grid, block, 0, stream>>>(N, [=] __device__(int idx) {
-          const auto offsets = offset_calc.get(idx);
-          char* const out_data = out_ptr + offsets[0] + slice_offset;
-
-          int64_t offset = 0;
-#pragma unroll
-          for (int64_t i = 0; i < num_indices; i++) {
-            int64_t index =
-                *reinterpret_cast<int64_t*>(index_ptrs[i] + offsets[2]);
-            if (index < 0) {
-              index += sizes[i];
+    if (index.size() == 1 && index[0]->dtype() == phi::DataType::BOOL) {
+      const bool* mask_data = index[0]->data<bool>();
+      funcs::index_elementwise_with_tensor_kernel<nt, vt>
+          <<<grid, block, 0, stream>>>(N, [=] __device__(int idx) {
+            const auto offsets = offset_calc.get(idx);
+            char* const out_data = out_ptr + offsets[0] + slice_offset;
+            if (mask_data[idx]) {
+              *reinterpret_cast<T*>(out_data) = T(0);
             }
-            offset += index * strides[i];
-          }
-          T num = T(0);
-          *reinterpret_cast<dtype*>(out_data + offset) =
-              *reinterpret_cast<dtype*>(&num);
-        });
+          });
+    } else {
+      funcs::index_elementwise_with_tensor_kernel<nt, vt>
+          <<<grid, block, 0, stream>>>(N, [=] __device__(int idx) {
+            const auto offsets = offset_calc.get(idx);
+            char* const out_data = out_ptr + offsets[0] + slice_offset;
+
+            int64_t offset = 0;
+#pragma unroll
+            for (int64_t i = 0; i < num_indices; i++) {
+              int64_t index =
+                  *reinterpret_cast<int64_t*>(index_ptrs[i] + offsets[2]);
+              if (index < 0) {
+                index += sizes[i];
+              }
+              offset += index * strides[i];
+            }
+            T num = T(0);
+            *reinterpret_cast<dtype*>(out_data + offset) =
+                *reinterpret_cast<dtype*>(&num);
+          });
+    }
   } else if (!x_grad) {
     const char* out_ptr = reinterpret_cast<const char*>(out_grad.data<T>());
     char* value_ptr = reinterpret_cast<char*>(value_grad->data<T>());
@@ -305,14 +317,15 @@ void IndexElementwisePutGradKernel(
     const int64_t slice_offset,
     DenseTensor* x_grad) {
   const auto& index_type = indices[0]->dtype();
-  PADDLE_ENFORCE_EQ(index_type == phi::DataType::INT64,
-                    true,
-                    common::errors::InvalidArgument(
-                        "Index holds the wrong type, it holds [%s], but "
-                        "desires to be [%s].",
-                        index_type,
-                        phi::DataType::INT64));
-
+  PADDLE_ENFORCE_EQ(
+      index_type == phi::DataType::INT64 ||
+          (index_type == phi::DataType::BOOL && indices.size() == 1),
+      true,
+      common::errors::InvalidArgument(
+          "Index holds the wrong type, it holds [%s], but "
+          "desires to be [%s].",
+          index_type,
+          phi::DataType::INT64));
   std::vector<DenseTensor> tmp_args;
   if (indices.empty()) {
     if (x_grad) {

--- a/paddle/phi/kernels/gpu/index_elementwise_put_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_elementwise_put_grad_kernel.cu
@@ -52,7 +52,6 @@ void GPUIndexElementwisePutGradKernel(
     sizes[i] = index_dims[i];
     strides[i] = index_strides[i];
   }
-  auto index_ptrs = funcs::GetIndexDataPtrs<IndexT>(index);
 
   std::array<int64_t*, 3> strides_array;
   std::vector<int64_t> desired_shape;
@@ -102,6 +101,7 @@ void GPUIndexElementwisePutGradKernel(
             }
           });
     } else {
+      auto index_ptrs = funcs::GetIndexDataPtrs<IndexT>(index);
       funcs::index_elementwise_with_tensor_kernel<nt, vt>
           <<<grid, block, 0, stream>>>(N, [=] __device__(int idx) {
             const auto offsets = offset_calc.get(idx);
@@ -123,6 +123,7 @@ void GPUIndexElementwisePutGradKernel(
           });
     }
   } else if (!x_grad) {
+    auto index_ptrs = funcs::GetIndexDataPtrs<IndexT>(index);
     const char* out_ptr = reinterpret_cast<const char*>(out_grad.data<T>());
     char* value_ptr = reinterpret_cast<char*>(value_grad->data<T>());
     funcs::index_elementwise_with_tensor_kernel<nt, vt>
@@ -145,6 +146,7 @@ void GPUIndexElementwisePutGradKernel(
               *reinterpret_cast<const dtype*>(out_data + offset);
         });
   } else {
+    auto index_ptrs = funcs::GetIndexDataPtrs<IndexT>(index);
     char* out_ptr = reinterpret_cast<char*>(x_grad->data<T>());
     char* value_ptr = reinterpret_cast<char*>(value_grad->data<T>());
     funcs::index_elementwise_with_tensor_kernel<nt, vt>

--- a/paddle/phi/kernels/gpu/index_elementwise_put_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_elementwise_put_kernel.cu
@@ -45,7 +45,6 @@ void GPUIndexElementwisePutKernel(const phi::GPUContext& dev_ctx,
     sizes[i] = index_dims[i];
     strides[i] = index_strides[i];
   }
-  auto index_ptrs = funcs::GetIndexDataPtrs<IndexT>(index);
 
   std::array<int64_t*, 3> strides_array;
   std::vector<int64_t> desired_shape;
@@ -80,24 +79,36 @@ void GPUIndexElementwisePutKernel(const phi::GPUContext& dev_ctx,
   auto stream = dev_ctx.stream();
 
   char* out_ptr = reinterpret_cast<char*>(output->data<T>());
-
-  funcs::index_elementwise_kernel<nt, vt, T><<<grid, block, 0, stream>>>(
-      N, value_T, [=] __device__(int idx, const T value_tmp) {
-        const auto offsets = offset_calc.get(idx);
-        char* const out_data = out_ptr + offsets[0] + slice_offset;
-
-        int64_t offset = 0;
-#pragma unroll
-        for (int64_t i = 0; i < num_indices; i++) {
-          int64_t index =
-              *reinterpret_cast<int64_t*>(index_ptrs[i] + offsets[2]);
-          if (index < 0) {
-            index += sizes[i];
+  if (index.size() == 1 && index[0]->dtype() == phi::DataType::BOOL) {
+    const bool* mask_data = index[0]->data<bool>();
+    funcs::index_elementwise_with_tensor_kernel<nt, vt>
+        <<<grid, block, 0, stream>>>(N, [=] __device__(int idx) {
+          const auto offsets = offset_calc.get(idx);
+          char* const out_data = out_ptr + offsets[0] + slice_offset;
+          if (mask_data[idx]) {
+            *reinterpret_cast<T*>(out_data) = value_T;
           }
-          offset += index * strides[i];
-        }
-        *reinterpret_cast<T*>(out_data + offset) = value_tmp;
-      });
+        });
+  } else {
+    auto index_ptrs = funcs::GetIndexDataPtrs<IndexT>(index);
+    funcs::index_elementwise_kernel<nt, vt, T><<<grid, block, 0, stream>>>(
+        N, value_T, [=] __device__(int idx, const T value_tmp) {
+          const auto offsets = offset_calc.get(idx);
+          char* const out_data = out_ptr + offsets[0] + slice_offset;
+
+          int64_t offset = 0;
+#pragma unroll
+          for (int64_t i = 0; i < num_indices; i++) {
+            int64_t index =
+                *reinterpret_cast<int64_t*>(index_ptrs[i] + offsets[2]);
+            if (index < 0) {
+              index += sizes[i];
+            }
+            offset += index * strides[i];
+          }
+          *reinterpret_cast<T*>(out_data + offset) = value_tmp;
+        });
+  }
 }
 
 template <typename T, typename IndexT = int>
@@ -194,14 +205,15 @@ void IndexElementwisePutKernel(const Context& dev_ctx,
                                const int64_t slice_offset,
                                DenseTensor* out) {
   const auto& index_type = index[0]->dtype();
-  PADDLE_ENFORCE_EQ(index_type == phi::DataType::INT64,
-                    true,
-                    common::errors::InvalidArgument(
-                        "Index holds the wrong type, it holds [%s], but "
-                        "desires to be [%s].",
-                        index_type,
-                        phi::DataType::INT64));
-
+  PADDLE_ENFORCE_EQ(
+      index_type == phi::DataType::INT64 ||
+          (index_type == phi::DataType::BOOL && index.size() == 1),
+      true,
+      common::errors::InvalidArgument(
+          "Index holds the wrong type, it holds [%s], but "
+          "desires to be [%s].",
+          index_type,
+          phi::DataType::INT64));
   dev_ctx.template Alloc<T>(out);
   if (out->numel() == 0) return;
   GPUIndexElementwisePutKernel<T, int64_t>(dev_ctx,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
pcard-67164
dispatch bool-only combined case to elementwise
- 由于bool索引进入index_elementwise_put之前会经过non_zero，带来性能开销，因此对index_elementwise_put kernel进行扩展，加入mask_fill处理bool索引的逻辑，对于基础索引之后仅有单个bool索引的case单独处理，按照mask进行赋值操作。
- 当前只对赋值为scalar的index_elementwise_put kernel添加此分支。