### PR TITLE
fix flashmask sync and supprot seqlenq != seqlenk in flashmask

### DIFF
--- a/paddle/phi/kernels/gpu/flash_attn_utils.h
+++ b/paddle/phi/kernels/gpu/flash_attn_utils.h
@@ -105,15 +105,6 @@ static std::vector<int64_t> GetAttnSparseMaskDims(
             "startend_row_indices is [%s]",
             rank,
             origin_dims));
-    // PADDLE_ENFORCE_EQ(origin_dims[rank - 2],
-    //                   max_seqlen_q,
-    //                   common::errors::InvalidArgument(
-    //                       "The sparse_mask_dims[%d] of "
-    //                       "attn_mask_start_row_indices is expected to be "
-    //                       "equal to %d, but received %d.",
-    //                       rank - 2,
-    //                       max_seqlen_q,
-    //                       origin_dims[2]));
 
     int64_t first_dim = 1;
     for (int i = 0; i < rank - 3; i++) {

--- a/paddle/phi/kernels/gpu/flash_attn_utils.h
+++ b/paddle/phi/kernels/gpu/flash_attn_utils.h
@@ -105,15 +105,15 @@ static std::vector<int64_t> GetAttnSparseMaskDims(
             "startend_row_indices is [%s]",
             rank,
             origin_dims));
-    PADDLE_ENFORCE_EQ(origin_dims[rank - 2],
-                      max_seqlen_q,
-                      common::errors::InvalidArgument(
-                          "The sparse_mask_dims[%d] of "
-                          "attn_mask_start_row_indices is expected to be "
-                          "equal to %d, but received %d.",
-                          rank - 2,
-                          max_seqlen_q,
-                          origin_dims[2]));
+    // PADDLE_ENFORCE_EQ(origin_dims[rank - 2],
+    //                   max_seqlen_q,
+    //                   common::errors::InvalidArgument(
+    //                       "The sparse_mask_dims[%d] of "
+    //                       "attn_mask_start_row_indices is expected to be "
+    //                       "equal to %d, but received %d.",
+    //                       rank - 2,
+    //                       max_seqlen_q,
+    //                       origin_dims[2]));
 
     int64_t first_dim = 1;
     for (int i = 0; i < rank - 3; i++) {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Performance Optimization
 

### PR Types
Bug fixes


### Description
Resolve Synchronization Issue After Copy Operation When Skipping Computation of m_blocks in FlashMask Backward Pass, and Add Support for Cases Where seqlen_q ≠ seqlen_k
