### PR TITLE
[0-size Tensor No.185、151] Add 0-size Tensor support for paddle.nn.functional.layer_norm [fluid_ops]

### DIFF
--- a/paddle/phi/kernels/cpu/layer_norm_kernel.cc
+++ b/paddle/phi/kernels/cpu/layer_norm_kernel.cc
@@ -45,6 +45,7 @@ void LayerNormKernel(const Context& dev_ctx,
   dev_ctx.template Alloc<T>(y);
   dev_ctx.template Alloc<T>(mean);
   dev_ctx.template Alloc<T>(var);
+  if (x.numel() == 0) return;
 
   auto matrix_dim = common::flatten_to_2d(x_dims, begin_norm_axis);
   int left = static_cast<int>(matrix_dim[0]);

--- a/paddle/phi/kernels/gpu/layer_norm_kernel.cu
+++ b/paddle/phi/kernels/gpu/layer_norm_kernel.cu
@@ -508,6 +508,7 @@ void LayerNormKernel(const Context &dev_ctx,
   auto *y_data = dev_ctx.template Alloc<T>(y);
   auto *mean_data = dev_ctx.template Alloc<U>(mean);
   auto *var_data = dev_ctx.template Alloc<U>(var);
+  if (x.numel() == 0) return;
 
   bool valid_scale = (scale != nullptr);
   bool valid_bias = (bias != nullptr);

--- a/paddle/phi/kernels/xpu/layer_norm_kernel.cc
+++ b/paddle/phi/kernels/xpu/layer_norm_kernel.cc
@@ -43,6 +43,7 @@ void LayerNormKernelImpl(const Context& dev_ctx,
   auto* out_data = dev_ctx.template Alloc<T>(out);
   auto* mean_data = dev_ctx.template Alloc<float>(mean);
   auto* variance_data = dev_ctx.template Alloc<float>(variance);
+  if (x.numel() == 0) return;
 
   int r = xpu::layer_norm(dev_ctx.x_context(),
                           reinterpret_cast<const XPUType*>(x_data),

--- a/python/paddle/nn/functional/vision.py
+++ b/python/paddle/nn/functional/vision.py
@@ -104,9 +104,7 @@ def affine_grid(
         _out_shape = (
             out_shape.tolist() if isinstance(out_shape, Variable) else out_shape
         )
-        if (
-            isinstance(out_shape, paddle.Tensor) and _out_shape.size == 0
-        ) or _out_shape == []:
+        if isinstance(_out_shape, paddle.Tensor) and _out_shape.size == 0:
             raise ValueError("The out_shape cannot be empty.")
         theta = theta._use_gpudnn(use_cudnn)
         return _C_ops.affine_grid(theta, _out_shape, align_corners)

--- a/python/paddle/nn/functional/vision.py
+++ b/python/paddle/nn/functional/vision.py
@@ -104,6 +104,8 @@ def affine_grid(
         _out_shape = (
             out_shape.tolist() if isinstance(out_shape, Variable) else out_shape
         )
+        if _out_shape == []:
+            raise ValueError("The out_shape cannot be empty.")
         theta = theta._use_gpudnn(use_cudnn)
         return _C_ops.affine_grid(theta, _out_shape, align_corners)
     elif in_pir_mode():

--- a/python/paddle/nn/functional/vision.py
+++ b/python/paddle/nn/functional/vision.py
@@ -104,7 +104,7 @@ def affine_grid(
         _out_shape = (
             out_shape.tolist() if isinstance(out_shape, Variable) else out_shape
         )
-        if _out_shape == []:
+        if paddle.to_tensor(_out_shape).size == 0:
             raise ValueError("The out_shape cannot be empty.")
         theta = theta._use_gpudnn(use_cudnn)
         return _C_ops.affine_grid(theta, _out_shape, align_corners)

--- a/python/paddle/nn/functional/vision.py
+++ b/python/paddle/nn/functional/vision.py
@@ -104,7 +104,9 @@ def affine_grid(
         _out_shape = (
             out_shape.tolist() if isinstance(out_shape, Variable) else out_shape
         )
-        if isinstance(out_shape, paddle.Tensor) and _out_shape.size == 0:
+        if (
+            isinstance(out_shape, paddle.Tensor) and _out_shape.size == 0
+        ) or _out_shape == []:
             raise ValueError("The out_shape cannot be empty.")
         theta = theta._use_gpudnn(use_cudnn)
         return _C_ops.affine_grid(theta, _out_shape, align_corners)

--- a/python/paddle/nn/functional/vision.py
+++ b/python/paddle/nn/functional/vision.py
@@ -104,7 +104,7 @@ def affine_grid(
         _out_shape = (
             out_shape.tolist() if isinstance(out_shape, Variable) else out_shape
         )
-        if paddle.to_tensor(_out_shape).size == 0:
+        if isinstance(out_shape, paddle.Tensor) and _out_shape.size == 0:
             raise ValueError("The out_shape cannot be empty.")
         theta = theta._use_gpudnn(use_cudnn)
         return _C_ops.affine_grid(theta, _out_shape, align_corners)

--- a/test/legacy_test/test_affine_grid_op.py
+++ b/test/legacy_test/test_affine_grid_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest
+from op_test import OpTest, get_places
 
 import paddle
 
@@ -222,6 +222,33 @@ class TestAffineGridOp5DCase4(TestAffineGridOp):
         self.dynamic_shape = False
         self.use_cudnn = False
         self.align_corners = False
+
+
+class TestAffineGridAPI_ZeroSize(unittest.TestCase):
+    def init_dtype(self):
+        self.dtype = 'float32'
+
+    def setUp(self):
+        self.init_dtype()
+        self.place = get_places()
+        self.theta_shape = (17, 2, 3)
+        self.output_shape = np.random.random([0]).astype("int32")
+
+    def test_dygraph_api(self):
+        def run(place):
+            paddle.disable_static(place)
+            theta_np = np.random.randint(1, 3, self.theta_shape).astype(
+                self.dtype
+            )
+            theta = paddle.to_tensor(theta_np)
+            with self.assertRaises(ValueError):
+                paddle.nn.functional.vision.affine_grid(
+                    theta, paddle.to_tensor(self.output_shape)
+                )
+            paddle.enable_static()
+
+        for place in self.place:
+            run(place)
 
 
 if __name__ == '__main__':

--- a/test/legacy_test/test_layer_norm_op.py
+++ b/test/legacy_test/test_layer_norm_op.py
@@ -805,6 +805,29 @@ class TestFastMathLayerNormBF16Op(TestFastMathLayerNormOp):
         self.dtype = 'bfloat16'
 
 
+@unittest.skipIf(
+    not core.is_compiled_with_cuda() or paddle.is_compiled_with_rocm(),
+    "core is not compiled with CUDA",
+)
+class TestLayerNormBF16OpByOpTest_ZeroSize(TestLayerNormOpByOpTest):
+    def initConfig(self):
+        self.__class__.exist_fp64_check_grad = True
+        self.ori_atol = 1e-2
+        self.ori_rtol = 1e-2
+
+        self.max_relative_error = 1e-5
+
+        self.dtype = np.float32
+        self.x_shape = [2, 0, 6, 3]
+        self.epsilon = 0.00001
+        self.begin_norm_axis = 1
+        self.has_scale = True
+        self.has_bias = False
+        self.check_prim = False
+        self.check_prim_pir = False
+        self.check_pir = True
+
+
 if __name__ == '__main__':
     paddle.enable_static()
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
[0-size Tensor No.185] Add 0-size Tensor support for paddle.nn.functional.layer_norm
185 paddle.nn.functional.layer_norm
修改kernel前向和反向，GPU 反向如果x, weight类型不同，需要对grad修改类型

PaddleAPITest测试通过
<img width="1325" height="285" alt="image" src="https://github.com/user-attachments/assets/21de078d-babd-40be-9002-a8cc25642793" />

151 paddle.nn.functional.affine_grid
测试用例为numpy error，修改为抛出错误，配置移除在PR https://github.com/PFCCLab/PaddleAPITest/pull/354

