### PR TITLE
[PHI] Support complex for `paddle.linalg.lu_unpack` , `paddle.linalg.lu_solve`

### DIFF
--- a/paddle/phi/backends/dynload/cusolver.h
+++ b/paddle/phi/backends/dynload/cusolver.h
@@ -97,6 +97,8 @@ CUSOLVER_ROUTINE_EACH(DECLARE_DYNAMIC_LOAD_CUSOLVER_WRAP);
   __macro(cusolverDnSgetrf);              \
   __macro(cusolverDnSgetrs);              \
   __macro(cusolverDnDgetrs);              \
+  __macro(cusolverDnCgetrs);              \
+  __macro(cusolverDnZgetrs);              \
   __macro(cusolverDnDgetrf);              \
   __macro(cusolverDnCgetrf);              \
   __macro(cusolverDnZgetrf);              \

--- a/paddle/phi/backends/dynload/lapack.h
+++ b/paddle/phi/backends/dynload/lapack.h
@@ -52,6 +52,24 @@ extern "C" void dgetrs_(char *trans,
                         double *b,
                         int *ldb,
                         int *info);
+extern "C" void cgetrs_(char *trans,
+                        int *n,
+                        int *nrhs,
+                        std::complex<float> *a,
+                        int *lda,
+                        int *ipiv,
+                        std::complex<float> *b,
+                        int *ldb,
+                        int *info);
+extern "C" void zgetrs_(char *trans,
+                        int *n,
+                        int *nrhs,
+                        std::complex<double> *a,
+                        int *lda,
+                        int *ipiv,
+                        std::complex<double> *b,
+                        int *ldb,
+                        int *info);
 
 // evd
 extern "C" void zheevd_(char *jobz,
@@ -396,6 +414,8 @@ extern void *lapack_dso_handle;
   __macro(zgetrf_);                  \
   __macro(sgetrs_);                  \
   __macro(dgetrs_);                  \
+  __macro(cgetrs_);                  \
+  __macro(zgetrs_);                  \
   __macro(zheevd_);                  \
   __macro(cheevd_);                  \
   __macro(dsyevd_);                  \

--- a/paddle/phi/backends/dynload/rocsolver.h
+++ b/paddle/phi/backends/dynload/rocsolver.h
@@ -47,6 +47,8 @@ extern void *rocsolver_dso_handle;
   __macro(rocsolver_zpotrs);            \
   __macro(rocsolver_sgetrs);            \
   __macro(rocsolver_dgetrs);            \
+  __macro(rocsolver_cgetrs);            \
+  __macro(rocsolver_zgetrs);            \
   __macro(rocsolver_sgetrf);            \
   __macro(rocsolver_dgetrf);            \
   __macro(rocsolver_cgetrf);            \

--- a/paddle/phi/kernels/cpu/lu_solve_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/lu_solve_grad_kernel.cc
@@ -19,5 +19,11 @@
 #include "paddle/phi/kernels/lu_solve_grad_kernel.h"
 
 // Register the CPU backward kernel
-PD_REGISTER_KERNEL(
-    lu_solve_grad, CPU, ALL_LAYOUT, phi::LuSolveGradKernel, float, double) {}
+PD_REGISTER_KERNEL(lu_solve_grad,
+                   CPU,
+                   ALL_LAYOUT,
+                   phi::LuSolveGradKernel,
+                   float,
+                   double,
+                   phi::dtype::complex<float>,
+                   phi::dtype::complex<double>) {}

--- a/paddle/phi/kernels/cpu/lu_solve_kernel.cc
+++ b/paddle/phi/kernels/cpu/lu_solve_kernel.cc
@@ -78,5 +78,11 @@ void LuSolveKernel(const Context& dev_ctx,
 }
 }  // namespace phi
 
-PD_REGISTER_KERNEL(
-    lu_solve, CPU, ALL_LAYOUT, phi::LuSolveKernel, float, double) {}
+PD_REGISTER_KERNEL(lu_solve,
+                   CPU,
+                   ALL_LAYOUT,
+                   phi::LuSolveKernel,
+                   float,
+                   double,
+                   phi::dtype::complex<float>,
+                   phi::dtype::complex<double>) {}

--- a/paddle/phi/kernels/cpu/lu_unpack_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/lu_unpack_grad_kernel.cc
@@ -18,5 +18,11 @@
 #include "paddle/phi/kernels/impl/lu_unpack_grad_kernel_impl.h"
 #include "paddle/phi/kernels/lu_unpack_grad_kernel.h"
 
-PD_REGISTER_KERNEL(
-    lu_unpack_grad, CPU, ALL_LAYOUT, phi::LUUnpackGradKernel, float, double) {}
+PD_REGISTER_KERNEL(lu_unpack_grad,
+                   CPU,
+                   ALL_LAYOUT,
+                   phi::LUUnpackGradKernel,
+                   float,
+                   double,
+                   phi::dtype::complex<float>,
+                   phi::dtype::complex<double>) {}

--- a/paddle/phi/kernels/cpu/lu_unpack_kernel.cc
+++ b/paddle/phi/kernels/cpu/lu_unpack_kernel.cc
@@ -18,5 +18,11 @@
 #include "paddle/phi/kernels/impl/lu_unpack_kernel_impl.h"
 #include "paddle/phi/kernels/lu_unpack_kernel.h"
 
-PD_REGISTER_KERNEL(
-    lu_unpack, CPU, ALL_LAYOUT, phi::LUUnpackKernel, float, double) {}
+PD_REGISTER_KERNEL(lu_unpack,
+                   CPU,
+                   ALL_LAYOUT,
+                   phi::LUUnpackKernel,
+                   float,
+                   double,
+                   phi::dtype::complex<float>,
+                   phi::dtype::complex<double>) {}

--- a/paddle/phi/kernels/funcs/lapack/lapack_function.cc
+++ b/paddle/phi/kernels/funcs/lapack/lapack_function.cc
@@ -79,6 +79,48 @@ void lapackLuSolve<float>(char trans,
   dynload::sgetrs_(&trans, &n, &nrhs, a, &lda, ipiv, b, &ldb, info);
 }
 
+template <>
+void lapackLuSolve<phi::dtype::complex<float>>(char trans,
+                                               int n,
+                                               int nrhs,
+                                               phi::dtype::complex<float> *a,
+                                               int lda,
+                                               int *ipiv,
+                                               phi::dtype::complex<float> *b,
+                                               int ldb,
+                                               int *info) {
+  dynload::cgetrs_(&trans,
+                   &n,
+                   &nrhs,
+                   reinterpret_cast<std::complex<float> *>(a),
+                   &lda,
+                   ipiv,
+                   reinterpret_cast<std::complex<float> *>(b),
+                   &ldb,
+                   info);
+}
+
+template <>
+void lapackLuSolve<phi::dtype::complex<double>>(char trans,
+                                                int n,
+                                                int nrhs,
+                                                phi::dtype::complex<double> *a,
+                                                int lda,
+                                                int *ipiv,
+                                                phi::dtype::complex<double> *b,
+                                                int ldb,
+                                                int *info) {
+  dynload::zgetrs_(&trans,
+                   &n,
+                   &nrhs,
+                   reinterpret_cast<std::complex<double> *>(a),
+                   &lda,
+                   ipiv,
+                   reinterpret_cast<std::complex<double> *>(b),
+                   &ldb,
+                   info);
+}
+
 // eigh
 template <>
 void lapackEigh<float>(char jobz,

--- a/paddle/phi/kernels/gpu/lu_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/lu_grad_kernel.cu
@@ -22,7 +22,7 @@
 // HIP not support cusolver in LUKernel
 PD_REGISTER_KERNEL(lu_grad, GPU, ALL_LAYOUT, phi::LUGradKernel, float, double) {
 }
-#else
+#else  // PADDLE_WITH_CUDA
 PD_REGISTER_KERNEL(lu_grad,
                    GPU,
                    ALL_LAYOUT,
@@ -31,4 +31,4 @@ PD_REGISTER_KERNEL(lu_grad,
                    double,
                    phi::dtype::complex<float>,
                    phi::dtype::complex<double>) {}
-#endif  // PADDLE_WITH_HIP
+#endif

--- a/paddle/phi/kernels/gpu/lu_solve_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/lu_solve_grad_kernel.cu
@@ -22,7 +22,7 @@
 // blas_impl.hip.h not support CUBlas<T>::TRSM for complex in
 // TriangularSolveKernel
 PD_REGISTER_KERNEL(
-    lu_solve_grad, GPU, ALL_LAYOUT, phi::LuSolveGradKernel, float, double)
+    lu_solve_grad, GPU, ALL_LAYOUT, phi::LuSolveGradKernel, float, double) {}
 #else  // PADDLE_WITH_CUDA
 PD_REGISTER_KERNEL(lu_solve_grad,
                    GPU,

--- a/paddle/phi/kernels/gpu/lu_solve_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/lu_solve_grad_kernel.cu
@@ -18,6 +18,12 @@
 #include "paddle/phi/kernels/impl/lu_solve_grad_kernel_impl.h"
 #include "paddle/phi/kernels/lu_solve_grad_kernel.h"
 
+#ifdef PADDLE_WITH_HIP
+// blas_impl.hip.h not support CUBlas<T>::TRSM for complex in
+// TriangularSolveKernel
+PD_REGISTER_KERNEL(
+    lu_solve_grad, GPU, ALL_LAYOUT, phi::LuSolveGradKernel, float, double)
+#else  // PADDLE_WITH_CUDA
 PD_REGISTER_KERNEL(lu_solve_grad,
                    GPU,
                    ALL_LAYOUT,
@@ -26,3 +32,4 @@ PD_REGISTER_KERNEL(lu_solve_grad,
                    double,
                    phi::dtype::complex<float>,
                    phi::dtype::complex<double>) {}
+#endif

--- a/paddle/phi/kernels/gpu/lu_solve_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/lu_solve_grad_kernel.cu
@@ -18,5 +18,11 @@
 #include "paddle/phi/kernels/impl/lu_solve_grad_kernel_impl.h"
 #include "paddle/phi/kernels/lu_solve_grad_kernel.h"
 
-PD_REGISTER_KERNEL(
-    lu_solve_grad, GPU, ALL_LAYOUT, phi::LuSolveGradKernel, float, double) {}
+PD_REGISTER_KERNEL(lu_solve_grad,
+                   GPU,
+                   ALL_LAYOUT,
+                   phi::LuSolveGradKernel,
+                   float,
+                   double,
+                   phi::dtype::complex<float>,
+                   phi::dtype::complex<double>) {}

--- a/paddle/phi/kernels/gpu/lu_solve_kernle.cu
+++ b/paddle/phi/kernels/gpu/lu_solve_kernle.cu
@@ -65,6 +65,51 @@ void rocsolver_getrs<double>(const solverHandle_t& handle,
   PADDLE_ENFORCE_GPU_SUCCESS(
       dynload::rocsolver_dgetrs(handle, trans, n, nrhs, a, lda, ipiv, b, ldb));
 }
+
+template <>
+void rocsolver_getrs<dtype::complex<float>>(const solverHandle_t& handle,
+                                            rocblas_operation trans,
+                                            int n,
+                                            int nrhs,
+                                            dtype::complex<float>* a,
+                                            int lda,
+                                            int* ipiv,
+                                            dtype::complex<float>* b,
+                                            int ldb) {
+  PADDLE_ENFORCE_GPU_SUCCESS(
+      dynload::rocsolver_cgetrs(handle,
+                                trans,
+                                n,
+                                nrhs,
+                                reinterpret_cast<rocblas_float_complex*>(a),
+                                lda,
+                                ipiv,
+                                reinterpret_cast<rocblas_float_complex*>(b),
+                                ldb));
+}
+
+template <>
+void rocsolver_getrs<dtype::complex<double>>(const solverHandle_t& handle,
+                                             rocblas_operation trans,
+                                             int n,
+                                             int nrhs,
+                                             dtype::complex<double>* a,
+                                             int lda,
+                                             int* ipiv,
+                                             dtype::complex<double>* b,
+                                             int ldb) {
+  PADDLE_ENFORCE_GPU_SUCCESS(
+      dynload::rocsolver_zgetrs(handle,
+                                trans,
+                                n,
+                                nrhs,
+                                reinterpret_cast<rocblas_double_complex*>(a),
+                                lda,
+                                ipiv,
+                                reinterpret_cast<rocblas_double_complex*>(b),
+                                ldb));
+}
+
 #else
 template <typename T>
 void cusolver_getrs(const solverHandle_t& handle,
@@ -107,6 +152,55 @@ void cusolver_getrs<double>(const solverHandle_t& handle,
   PADDLE_ENFORCE_GPU_SUCCESS(dynload::cusolverDnDgetrs(
       handle, trans, n, nrhs, a, lda, ipiv, b, ldb, info));
 }
+
+template <>
+void cusolver_getrs<dtype::complex<float>>(const solverHandle_t& handle,
+                                           cublasOperation_t trans,
+                                           int n,
+                                           int nrhs,
+                                           dtype::complex<float>* a,
+                                           int lda,
+                                           int* ipiv,
+                                           dtype::complex<float>* b,
+                                           int ldb,
+                                           int* info) {
+  PADDLE_ENFORCE_GPU_SUCCESS(
+      dynload::cusolverDnCgetrs(handle,
+                                trans,
+                                n,
+                                nrhs,
+                                reinterpret_cast<cuComplex*>(a),
+                                lda,
+                                ipiv,
+                                reinterpret_cast<cuComplex*>(b),
+                                ldb,
+                                info));
+}
+
+template <>
+void cusolver_getrs<dtype::complex<double>>(const solverHandle_t& handle,
+                                            cublasOperation_t trans,
+                                            int n,
+                                            int nrhs,
+                                            dtype::complex<double>* a,
+                                            int lda,
+                                            int* ipiv,
+                                            dtype::complex<double>* b,
+                                            int ldb,
+                                            int* info) {
+  PADDLE_ENFORCE_GPU_SUCCESS(
+      dynload::cusolverDnZgetrs(handle,
+                                trans,
+                                n,
+                                nrhs,
+                                reinterpret_cast<cuDoubleComplex*>(a),
+                                lda,
+                                ipiv,
+                                reinterpret_cast<cuDoubleComplex*>(b),
+                                ldb,
+                                info));
+}
+
 #endif  // PADDLE_WITH_HIP
 
 template <typename T, typename Context>
@@ -199,5 +293,11 @@ void LuSolveKernel(const Context& dev_ctx,
 
 }  // namespace phi
 
-PD_REGISTER_KERNEL(
-    lu_solve, GPU, ALL_LAYOUT, phi::LuSolveKernel, float, double) {}
+PD_REGISTER_KERNEL(lu_solve,
+                   GPU,
+                   ALL_LAYOUT,
+                   phi::LuSolveKernel,
+                   float,
+                   double,
+                   phi::dtype::complex<float>,
+                   phi::dtype::complex<double>) {}

--- a/paddle/phi/kernels/gpu/lu_unpack_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/lu_unpack_grad_kernel.cu
@@ -18,5 +18,11 @@
 #include "paddle/phi/kernels/impl/lu_unpack_grad_kernel_impl.h"
 #include "paddle/phi/kernels/lu_unpack_grad_kernel.h"
 
-PD_REGISTER_KERNEL(
-    lu_unpack_grad, GPU, ALL_LAYOUT, phi::LUUnpackGradKernel, float, double) {}
+PD_REGISTER_KERNEL(lu_unpack_grad,
+                   GPU,
+                   ALL_LAYOUT,
+                   phi::LUUnpackGradKernel,
+                   float,
+                   double,
+                   phi::dtype::complex<float>,
+                   phi::dtype::complex<double>) {}

--- a/paddle/phi/kernels/gpu/lu_unpack_kernel.cu
+++ b/paddle/phi/kernels/gpu/lu_unpack_kernel.cu
@@ -18,5 +18,11 @@
 #include "paddle/phi/kernels/impl/lu_unpack_kernel_impl.h"
 #include "paddle/phi/kernels/lu_unpack_kernel.h"
 
-PD_REGISTER_KERNEL(
-    lu_unpack, GPU, ALL_LAYOUT, phi::LUUnpackKernel, float, double) {}
+PD_REGISTER_KERNEL(lu_unpack,
+                   GPU,
+                   ALL_LAYOUT,
+                   phi::LUUnpackKernel,
+                   float,
+                   double,
+                   phi::dtype::complex<float>,
+                   phi::dtype::complex<double>) {}

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -3610,10 +3610,16 @@ def lu_solve(
     given LU decomposition :math:`A` and column vector :math:`b`.
 
     Args:
-        b (Tensor): Column vector `b` in the above equation. It has shape :math:`(*, m, k)`, where :math:`*` is batch dimensions, with data type float32, float64.
-        lu (Tensor): LU decomposition. It has shape :math:`(*, m, m)`, where :math:`*` is batch dimensions, that can be decomposed into an upper triangular matrix U and a lower triangular matrix L, with data type float32, float64.
+        b (Tensor): Column vector `b` in the above equation. It has shape :math:`(*, m, k)`, where :math:`*` is batch dimensions,
+            with data type float32, float64, complex64, or complex128.
+
+        lu (Tensor): LU decomposition. It has shape :math:`(*, m, m)`, where :math:`*` is batch dimensions, that can be decomposed into an upper triangular matrix U and a lower triangular matrix L,
+            with data type float32, float64, complex64, or complex128.
+
         pivots (Tensor): Permutation matrix P of LU decomposition. It has shape :math:`(*, m)`, where :math:`*` is batch dimensions, that can be converted to a permutation matrix P, with data type int32.
+
         trans (str, optional): The transpose of the matrix A. It can be "N" , "T" or "C", "N" means :math:`Ax=b`, "T" means :math:`A^Tx=b`, "C" means :math:`A^Hx=b`, default is "N".
+
         name (str|None, optional): Name for the operation (optional, default is None).
             For more information, please refer to :ref:`api_guide_Name`.
 
@@ -3704,8 +3710,9 @@ def lu_unpack(
 
     Args:
         x (Tensor): The LU tensor get from paddle.linalg.lu, which is combined by L and U.
+            Its data type should be float32, float64, complex64, or complex128.
 
-        y (Tensor): Pivots get from paddle.linalg.lu.
+        y (Tensor): Pivots get from paddle.linalg.lu. Its data type should be int32.
 
         unpack_ludata (bool, optional): whether to unpack L and U from x. Default: True.
 
@@ -3774,7 +3781,10 @@ def lu_unpack(
         return P, L, U
     else:
         check_variable_and_dtype(
-            x, 'dtype', ['float32', 'float64'], 'lu_unpack'
+            x,
+            'dtype',
+            ['float32', 'float64', 'complex64', 'complex128'],
+            'lu_unpack',
         )
         helper = LayerHelper('lu_unpack', **locals())
         p = helper.create_variable_for_type_inference(dtype=x.dtype)

--- a/test/legacy_test/test_lu_solve_op.py
+++ b/test/legacy_test/test_lu_solve_op.py
@@ -186,6 +186,9 @@ class TestLuSolveOp5(TestLuSolveOp):
 
 
 # complex64
+@unittest.skipIf(
+    base.core.is_compiled_with_rocm(), "Skip when compiled by ROCM."
+)
 class TestLuSolveOp6(TestLuSolveOp):
     def init_value(self):
         self.A_shape = [10, 10]
@@ -195,6 +198,9 @@ class TestLuSolveOp6(TestLuSolveOp):
 
 
 # complex128
+@unittest.skipIf(
+    base.core.is_compiled_with_rocm(), "Skip when compiled by ROCM."
+)
 class TestLuSolveOp7(TestLuSolveOp):
     def init_value(self):
         self.A_shape = [10, 10]
@@ -344,6 +350,9 @@ class TestLuSolveOpAPI8(TestLuSolveOpAPI):
         self.rtol = 1e-05
 
 
+@unittest.skipIf(
+    base.core.is_compiled_with_rocm(), "Skip when compiled by ROCM."
+)
 class TestLuSolveOpAPI9(TestLuSolveOpAPI):
     def init_value(self):
         # Ax = b
@@ -354,6 +363,9 @@ class TestLuSolveOpAPI9(TestLuSolveOpAPI):
         self.rtol = 0.001
 
 
+@unittest.skipIf(
+    base.core.is_compiled_with_rocm(), "Skip when compiled by ROCM."
+)
 class TestLuSolveOpAPI10(TestLuSolveOpAPI):
     def init_value(self):
         # Ax = b

--- a/test/legacy_test/test_lu_solve_op.py
+++ b/test/legacy_test/test_lu_solve_op.py
@@ -37,7 +37,12 @@ def get_inandout(A_shape, b_shape, trans="N", dtype="float64"):
     np.random.seed(2025)
     A = np.random.random(A_shape).astype(dtype)
     b = np.random.random(b_shape).astype(dtype)
-    x_grad = paddle.to_tensor(np.random.random(b_shape).astype(dtype))
+    x_grad_np = np.random.random(b_shape).astype(dtype)
+    if 'complex' in dtype:
+        A += 1j * np.random.random(A_shape).astype(dtype)
+        b += 1j * np.random.random(b_shape).astype(dtype)
+        x_grad_np += 1j * np.random.random(b_shape).astype(dtype)
+    x_grad = paddle.to_tensor(x_grad_np)
     paddle_A = paddle.to_tensor(A)
     lu, pivots = paddle.linalg.lu(paddle_A)
     if trans == "N":  # Ax = b
@@ -180,6 +185,24 @@ class TestLuSolveOp5(TestLuSolveOp):
         self.dtype = "float64"
 
 
+# complex64
+class TestLuSolveOp6(TestLuSolveOp):
+    def init_value(self):
+        self.A_shape = [10, 10]
+        self.b_shape = [10, 10]
+        self.trans = "T"
+        self.dtype = "complex64"
+
+
+# complex128
+class TestLuSolveOp7(TestLuSolveOp):
+    def init_value(self):
+        self.A_shape = [10, 10]
+        self.b_shape = [10, 10]
+        self.trans = "T"
+        self.dtype = "complex128"
+
+
 class TestLuSolveOpAPI(unittest.TestCase):
     def setUp(self):
         self.init_value()
@@ -318,6 +341,26 @@ class TestLuSolveOpAPI8(TestLuSolveOpAPI):
         self.b_shape = [10, 5]
         self.trans = "T"
         self.dtype = "float64"
+        self.rtol = 1e-05
+
+
+class TestLuSolveOpAPI9(TestLuSolveOpAPI):
+    def init_value(self):
+        # Ax = b
+        self.A_shape = [10, 10]
+        self.b_shape = [10, 5]
+        self.trans = "N"
+        self.dtype = "complex64"
+        self.rtol = 0.001
+
+
+class TestLuSolveOpAPI10(TestLuSolveOpAPI):
+    def init_value(self):
+        # Ax = b
+        self.A_shape = [10, 10]
+        self.b_shape = [10, 5]
+        self.trans = "N"
+        self.dtype = "complex128"
         self.rtol = 1e-05
 
 

--- a/test/legacy_test/test_lu_unpack_op.py
+++ b/test/legacy_test/test_lu_unpack_op.py
@@ -132,6 +132,8 @@ class TestLU_UnpackOp(OpTest):
         self.python_out_sig = ["Pmat", "L", "U"]
         self.config()
         x = np.random.random(self.x_shape).astype(self.dtype)
+        if 'complex' in self.dtype:
+            x += 1j * np.random.random(self.x_shape).astype(self.dtype)
         if paddle.in_dynamic_mode():
             xt = paddle.to_tensor(x)
             lu, pivots = paddle.linalg.lu(xt)
@@ -214,6 +216,32 @@ class TestLU_UnpackOp4(TestLU_UnpackOp):
         self.dtype = "float64"
 
 
+# complex64
+class TestLU_UnpackOp5(TestLU_UnpackOp):
+    """
+    case 5
+    """
+
+    def config(self):
+        self.x_shape = [10, 12]
+        self.unpack_ludata = True
+        self.unpack_pivots = True
+        self.dtype = "complex64"
+
+
+# complex128
+class TestLU_UnpackOp6(TestLU_UnpackOp):
+    """
+    case 6
+    """
+
+    def config(self):
+        self.x_shape = [10, 12]
+        self.unpack_ludata = True
+        self.unpack_pivots = True
+        self.dtype = "complex128"
+
+
 class TestLU_UnpackAPI(unittest.TestCase):
     def setUp(self):
         np.random.seed(2022)
@@ -224,7 +252,13 @@ class TestLU_UnpackAPI(unittest.TestCase):
                 np_dtype = np.float32
             elif dtype == "float64":
                 np_dtype = np.float64
+            elif dtype == "complex64":
+                np_dtype = np.complex64
+            elif dtype == "complex128":
+                np_dtype = np.complex128
             a = np.random.rand(*shape).astype(np_dtype)
+            if dtype in {"complex64", "complex128"}:
+                a += 1j * np.random.rand(*shape).astype(np_dtype)
             m = a.shape[-2]
             n = a.shape[-1]
             min_mn = min(m, n)
@@ -252,7 +286,7 @@ class TestLU_UnpackAPI(unittest.TestCase):
             (3, 5, 5, 5),
             (4, 5, 5, 3),  # 4-dim Tensors
         ]
-        dtypes = ["float32", "float64"]
+        dtypes = ["float32", "float64", "complex64", "complex128"]
         for tensor_shape, dtype in itertools.product(tensor_shapes, dtypes):
             run_lu_unpack_dygraph(tensor_shape, dtype)
 
@@ -264,7 +298,13 @@ class TestLU_UnpackAPI(unittest.TestCase):
                 np_dtype = np.float32
             elif dtype == "float64":
                 np_dtype = np.float64
+            elif dtype == "complex64":
+                np_dtype = np.complex64
+            elif dtype == "complex128":
+                np_dtype = np.complex128
             a = np.random.rand(*shape).astype(np_dtype)
+            if dtype in {"complex64", "complex128"}:
+                a += 1j * np.random.rand(*shape).astype(np_dtype)
             m = a.shape[-2]
             n = a.shape[-1]
             min_mn = min(m, n)
@@ -306,7 +346,7 @@ class TestLU_UnpackAPI(unittest.TestCase):
             (3, 5, 5, 5),
             (4, 5, 5, 3),  # 4-dim Tensors
         ]
-        dtypes = ["float32", "float64"]
+        dtypes = ["float32", "float64", "complex64", "complex128"]
         for tensor_shape, dtype in itertools.product(tensor_shapes, dtypes):
             run_lu_static(tensor_shape, dtype)
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->

Support `complex64` , `complex128` for `paddle.linalg.lu_unpack` , `paddle.linalg.lu_solve` op.

Add `@unittest.skipIf` for `paddle.linalg.lu_solve` op test because its grad_impl doesn't support complex calculation in Linux-DCU.

Pcard-85711
