### PR TITLE
[Dy2St] Optimize AttributeMap in PIR run_program

### DIFF
--- a/paddle/fluid/eager/to_static/run_program_func.h
+++ b/paddle/fluid/eager/to_static/run_program_func.h
@@ -25,7 +25,8 @@ std::vector<paddle::Tensor> run_program_ad_func(
     const std::vector<paddle::Tensor>& x,
     const std::vector<paddle::Tensor>& params,
     std::vector<paddle::framework::Scope*>& step_scope,  // NOLINT
-    const paddle::framework::AttributeMap& attrs);
+    const paddle::framework::AttributeMap& prog_attrs,
+    const paddle::framework::AttributeMap& cuda_graph_attrs);
 
 void legacy_run_program_ad_func(
     const std::vector<paddle::Tensor>& x,

--- a/paddle/fluid/eager/to_static/run_program_impl.h
+++ b/paddle/fluid/eager/to_static/run_program_impl.h
@@ -34,12 +34,14 @@ std::vector<paddle::Tensor> RunProgramImpl(
     const std::vector<paddle::Tensor> &params,
     std::vector<paddle::framework::Scope *> &step_scope,  // NOLINT
     bool require_any_grad,
-    const paddle::framework::AttributeMap &attrs,
+    const paddle::framework::AttributeMap &prog_attrs,
+    const paddle::framework::AttributeMap &cuda_graph_attrs,
     const int64_t &place_hash_key);
 void RunProgramGradImpl(
     const std::vector<paddle::Tensor> &out_grad,
     const std::vector<paddle::framework::Scope *> &step_scope,  // NOLINT
-    const paddle::framework::AttributeMap &attrs,
+    const paddle::framework::AttributeMap &prog_attrs,
+    const paddle::framework::AttributeMap &cuda_graph_attrs,
     std::vector<paddle::Tensor> *x_grad,
     std::vector<paddle::Tensor> *params_grad,
     const int64_t &place_hash_key);

--- a/paddle/fluid/eager/to_static/run_program_node.cc
+++ b/paddle/fluid/eager/to_static/run_program_node.cc
@@ -37,7 +37,7 @@ GradNodeRunProgram::~GradNodeRunProgram() {
 void GradNodeRunProgram::ConstructXGradTensors(
     const std::vector<paddle::Tensor> &x, std::vector<paddle::Tensor> *x_grad) {
   auto x_grad_names =
-      PADDLE_GET_CONST(std::vector<std::string>, attrs_.at("bx_g_names"));
+      PADDLE_GET_CONST(std::vector<std::string>, prog_attrs_.at("bx_g_names"));
   PADDLE_ENFORCE_EQ(x.size(),
                     x_grad_names.size(),
                     common::errors::InvalidArgument(
@@ -68,7 +68,7 @@ void GradNodeRunProgram::ConstructParamGradTensors(
     const std::vector<paddle::Tensor> &params,
     std::vector<paddle::Tensor> *param_grads) {
   auto p_grad_names =
-      PADDLE_GET_CONST(std::vector<std::string>, attrs_.at("bp_g_names"));
+      PADDLE_GET_CONST(std::vector<std::string>, prog_attrs_.at("bp_g_names"));
   PADDLE_ENFORCE_EQ(params.size(),
                     p_grad_names.size(),
                     common::errors::InvalidArgument(
@@ -120,7 +120,7 @@ GradNodeRunProgram::operator()(
   }
 
   const auto &out_grad_names =
-      PADDLE_GET_CONST(std::vector<std::string>, attrs_.at("bo_g_names"));
+      PADDLE_GET_CONST(std::vector<std::string>, prog_attrs_.at("bo_g_names"));
   PADDLE_ENFORCE_EQ(hooked_grads[0].size(),
                     out_grad_names.size(),
                     common::errors::InvalidArgument(
@@ -129,7 +129,8 @@ GradNodeRunProgram::operator()(
 
   egr::to_static::RunProgramGradImpl(hooked_grads[0],
                                      step_scope_,
-                                     attrs_,
+                                     prog_attrs_,
+                                     cuda_graph_attrs_,
                                      &x_grad,
                                      &params_grad,
                                      place_hash_key_);

--- a/paddle/fluid/eager/to_static/run_program_node.h
+++ b/paddle/fluid/eager/to_static/run_program_node.h
@@ -39,8 +39,10 @@ class GradNodeRunProgram : public egr::GradNodeBase {
   }
 
   // SetAttrMap
-  void SetAttrMap(const paddle::framework::AttributeMap &attrs) {
-    attrs_ = attrs;
+  void SetAttrMap(const paddle::framework::AttributeMap &prog_attrs,
+                  const paddle::framework::AttributeMap &cuda_graph_attrs) {
+    prog_attrs_ = prog_attrs;
+    cuda_graph_attrs_ = cuda_graph_attrs;
   }
 
   void SetFwdX(const std::vector<paddle::Tensor> &tensors) { x_ = tensors; }
@@ -77,7 +79,8 @@ class GradNodeRunProgram : public egr::GradNodeBase {
   std::vector<paddle::framework::Scope *> step_scope_;
 
   // Attribute Map
-  paddle::framework::AttributeMap attrs_;
+  paddle::framework::AttributeMap prog_attrs_;
+  paddle::framework::AttributeMap cuda_graph_attrs_;
 
   int64_t place_hash_key_;
 

--- a/paddle/fluid/pybind/eager_custom_python_api.h
+++ b/paddle/fluid/pybind/eager_custom_python_api.h
@@ -122,13 +122,12 @@ static PyObject *eager_api_run_program(PyObject *self,
                                                Params_info.second,
                                                Params_allocator);
     }
-    framework::AttributeMap attrs;
-    VLOG(6) << "Start PIR ConstructAttrMapFromPyArgs";
-    ConstructAttrMapForRunProgram("run_program", args, 3, attrs);
-
-    VLOG(6) << "Finish Pir ConstructAttrMapFromPyArgs";
+    VLOG(6) << "Start PIR GetAttributesMapPtrFromPyArgs";
+    auto attrs_ptr = GetAttributesMapPtrFromPyArgs("run_program", args, 3);
+    VLOG(6) << "Finish Pir GetAttributesMapPtrFromPyArgs";
     tstate = PyEval_SaveThread();
-    auto out = egr::to_static::run_program_ad_func(X, Params, OutScope, attrs);
+    auto out =
+        egr::to_static::run_program_ad_func(X, Params, OutScope, *attrs_ptr);
     PyEval_RestoreThread(tstate);
     tstate = nullptr;
     return ToPyObject(out);

--- a/paddle/fluid/pybind/eager_custom_python_api.h
+++ b/paddle/fluid/pybind/eager_custom_python_api.h
@@ -122,12 +122,19 @@ static PyObject *eager_api_run_program(PyObject *self,
                                                Params_info.second,
                                                Params_allocator);
     }
-    VLOG(6) << "Start PIR GetAttributesMapPtrFromPyArgs";
-    auto attrs_ptr = GetAttributesMapPtrFromPyArgs("run_program", args, 3);
-    VLOG(6) << "Finish Pir GetAttributesMapPtrFromPyArgs";
+    VLOG(6) << "Start PIR GetProgramAttributesMapPtrFromPyArgs";
+    auto prog_attrs_ptr =
+        GetProgramAttributesMapPtrFromPyArgs("run_program", args, 3);
+    VLOG(6) << "Finish PIR GetProgramAttributesMapPtrFromPyArgs";
+
+    VLOG(6) << "Start PIR ConstructCudaGraphAttrMapForRunProgram";
+    paddle::framework::AttributeMap cuda_graph_attrs;
+    ConstructCudaGraphAttrMapForRunProgram(
+        "run_program", args, 4, cuda_graph_attrs);
+    VLOG(6) << "Finish PIR ConstructCudaGraphAttrMapForRunProgram";
     tstate = PyEval_SaveThread();
-    auto out =
-        egr::to_static::run_program_ad_func(X, Params, OutScope, *attrs_ptr);
+    auto out = egr::to_static::run_program_ad_func(
+        X, Params, OutScope, *prog_attrs_ptr, cuda_graph_attrs);
     PyEval_RestoreThread(tstate);
     tstate = nullptr;
     return ToPyObject(out);

--- a/paddle/fluid/pybind/eager_utils.cc
+++ b/paddle/fluid/pybind/eager_utils.cc
@@ -2988,13 +2988,8 @@ PyObject* CalcScopeCacheKey(PyObject* dummy, PyObject* args) {
 PyObject* GetProgramIdFromAttrs(PyObject* dummy, PyObject* args) {
   auto prog_attrs =
       GetProgramAttributesMapPtrFromPyArgs("run_program", args, 0);
-  int64_t* program_id_prt =
-      paddle::get_if<int64_t>(&(prog_attrs->at("program_id")));
-  if (!program_id_prt) {
-    PADDLE_THROW(common::errors::InvalidArgument(
-        "The type of attribute 'program_id' is not 'int64_t'."));
-  }
-  return ToPyObject(*program_id_prt);
+  int64_t program_id = PADDLE_GET(int64_t, prog_attrs->at("program_id"));
+  return ToPyObject(program_id);
 }
 
 /* ------------------ for auto parallel ----------------------- */

--- a/paddle/fluid/pybind/eager_utils.cc
+++ b/paddle/fluid/pybind/eager_utils.cc
@@ -15,6 +15,7 @@ limitations under the License. */
 #include <string>
 #include <vector>
 
+#include <variant>
 #include "paddle/common/exception.h"
 #include "paddle/common/flags.h"
 #include "paddle/fluid/eager/accumulation/accumulation_node.h"
@@ -2410,7 +2411,7 @@ std::vector<paddle::framework::Scope*> GetScopePtrListFromArgs(
   }
   return result;
 }
-paddle::framework::AttributeMap* GetAttributesMapPtrFromPyArgs(
+paddle::framework::AttributeMap* GetProgramAttributesMapPtrFromPyArgs(
     const std::string& op_type, PyObject* args, ssize_t arg_idx) {
   PyObject* py_attrs_capsule = PyTuple_GET_ITEM(args, arg_idx);
   paddle::framework::AttributeMap* attrs_ptr =
@@ -2984,6 +2985,18 @@ PyObject* CalcScopeCacheKey(PyObject* dummy, PyObject* args) {
   return ToPyObject(scope_cache_key);
 }
 
+PyObject* GetProgramIdFromAttrs(PyObject* dummy, PyObject* args) {
+  auto prog_attrs =
+      GetProgramAttributesMapPtrFromPyArgs("run_program", args, 0);
+  int64_t* program_id_prt =
+      paddle::get_if<int64_t>(&(prog_attrs->at("program_id")));
+  if (!program_id_prt) {
+    PADDLE_THROW(common::errors::InvalidArgument(
+        "The type of attribute 'program_id' is not 'int64_t'."));
+  }
+  return ToPyObject(*program_id_prt);
+}
+
 /* ------------------ for auto parallel ----------------------- */
 
 static PyMethodDef EagerUtilMethods[] = {  // NOLINT
@@ -2999,6 +3012,10 @@ static PyMethodDef EagerUtilMethods[] = {  // NOLINT
      (PyCFunction)CalcScopeCacheKey,
      METH_VARARGS,
      "Calculate the cache key for scope."},
+    {"get_program_id_from_attrs",
+     (PyCFunction)GetProgramIdFromAttrs,
+     METH_VARARGS,
+     "Get program id from program attrs map."},
     {nullptr, nullptr, 0, nullptr}};
 
 void BindEagerUtils(PyObject* module) {

--- a/paddle/fluid/pybind/eager_utils.cc
+++ b/paddle/fluid/pybind/eager_utils.cc
@@ -2410,6 +2410,23 @@ std::vector<paddle::framework::Scope*> GetScopePtrListFromArgs(
   }
   return result;
 }
+paddle::framework::AttributeMap* GetAttributesMapPtrFromPyArgs(
+    const std::string& op_type, PyObject* args, ssize_t arg_idx) {
+  PyObject* py_attrs_capsule = PyTuple_GET_ITEM(args, arg_idx);
+  paddle::framework::AttributeMap* attrs_ptr =
+      reinterpret_cast<paddle::framework::AttributeMap*>(PyCapsule_GetPointer(
+          py_attrs_capsule, "paddle.framework.AttributeMap"));
+  if (!attrs_ptr) {
+    PADDLE_THROW(common::errors::InvalidArgument(
+        "%s(): argument '%s' (position %d) must be AttributeMap, but got "
+        "%s",
+        op_type,
+        "attrs",
+        arg_idx,
+        (reinterpret_cast<PyTypeObject*>(py_attrs_capsule->ob_type))->tp_name));
+  }
+  return attrs_ptr;
+}
 
 TensorListBufferAllocator::MapType
     TensorListBufferAllocator::s_tensor_vector_map_;

--- a/paddle/fluid/pybind/eager_utils.h
+++ b/paddle/fluid/pybind/eager_utils.h
@@ -434,7 +434,7 @@ std::vector<paddle::framework::Scope*> GetScopePtrListFromArgs(
     ssize_t arg_idx,
     bool dispensable);
 
-paddle::framework::AttributeMap* GetAttributesMapPtrFromPyArgs(
+paddle::framework::AttributeMap* GetProgramAttributesMapPtrFromPyArgs(
     const std::string& op_type, PyObject* args, ssize_t arg_idx);
 
 class eager_gil_scoped_release {

--- a/paddle/fluid/pybind/eager_utils.h
+++ b/paddle/fluid/pybind/eager_utils.h
@@ -434,6 +434,9 @@ std::vector<paddle::framework::Scope*> GetScopePtrListFromArgs(
     ssize_t arg_idx,
     bool dispensable);
 
+paddle::framework::AttributeMap* GetAttributesMapPtrFromPyArgs(
+    const std::string& op_type, PyObject* args, ssize_t arg_idx);
+
 class eager_gil_scoped_release {
  public:
   eager_gil_scoped_release() { tstate = PyEval_SaveThread(); }

--- a/paddle/fluid/pybind/op_function_common.cc
+++ b/paddle/fluid/pybind/op_function_common.cc
@@ -1210,13 +1210,51 @@ void ConstructAttrMapForLegacyRunProgram(
   }
 }
 
-PyObject* ConstructAttrMapForRunProgram(PyObject* self, PyObject* args) {
+PyObject* ConstructProgramAttrMapForRunProgram(PyObject* self, PyObject* args) {
   const std::string op_type = "run_program";
   PyObject* attrs_dict = nullptr;
-
   if (!PyArg_ParseTuple(args, "O", &attrs_dict)) {
     return nullptr;
   }
+  paddle::framework::AttributeMap* attrs_ptr =
+      new (std::nothrow) paddle::framework::AttributeMap();
+  if (!attrs_ptr) {
+    PADDLE_THROW(common::errors::InvalidArgument(
+        "%s(): failed to allocate memory for AttributeMap.", op_type));
+  }
+  ConstructAttrMapForRunProgram(op_type, attrs_dict, *attrs_ptr);
+  PyObject* py_attrs_capsule = PyCapsule_New(
+      attrs_ptr, "paddle.framework.AttributeMap", [](PyObject* capsule) {
+        paddle::framework::AttributeMap* data =
+            reinterpret_cast<paddle::framework::AttributeMap*>(
+                PyCapsule_GetPointer(capsule, "paddle.framework.AttributeMap"));
+        if (data) {
+          delete data;
+        }
+      });
+
+  if (!py_attrs_capsule) {
+    delete attrs_ptr;
+    PyErr_SetString(PyExc_RuntimeError,
+                    "Failed to create PyCapsule for AttributeMap.");
+    return nullptr;
+  }
+  return py_attrs_capsule;
+}
+
+void ConstructCudaGraphAttrMapForRunProgram(
+    const std::string& op_type,
+    PyObject* args,
+    ssize_t arg_pos,
+    paddle::framework::AttributeMap& attrs) {  // NOLINT
+  PyObject* attrs_dict = PyTuple_GET_ITEM(args, arg_pos);
+  ConstructAttrMapForRunProgram(op_type, attrs_dict, attrs);
+}
+
+void ConstructAttrMapForRunProgram(
+    const std::string& op_type,
+    PyObject* attrs_dict,
+    paddle::framework::AttributeMap& attrs) {  // NOLINT
 
   if (!PyDict_Check(attrs_dict)) {
     PADDLE_THROW(common::errors::InvalidArgument(
@@ -1254,12 +1292,6 @@ PyObject* ConstructAttrMapForRunProgram(PyObject* self, PyObject* args) {
       {"cuda_graph_dispatch_key", CastPyArg2AttrLong},
   };
 
-  paddle::framework::AttributeMap* attrs_ptr =
-      new (std::nothrow) paddle::framework::AttributeMap();
-  if (!attrs_ptr) {
-    PADDLE_THROW(common::errors::InvalidArgument(
-        "%s(): failed to allocate memory for AttributeMap.", op_type));
-  }
   PyObject *key, *value;
   Py_ssize_t pos = 0;
   while (PyDict_Next(attrs_dict, &pos, &key, &value)) {
@@ -1276,7 +1308,7 @@ PyObject* ConstructAttrMapForRunProgram(PyObject* self, PyObject* args) {
     std::string_view key_view(key_ptr, static_cast<size_t>(key_len));
     auto it = kAttrFuncMap.find(std::string(key_view));
     if (it != kAttrFuncMap.end()) {
-      it->second(value, *attrs_ptr, std::string(key_view), op_type, 0);
+      it->second(value, attrs, std::string(key_view), op_type, 0);
     } else {
       PADDLE_THROW(common::errors::InvalidArgument(
           "Attribute key %.*s is not recognized for operator %s.",
@@ -1285,24 +1317,6 @@ PyObject* ConstructAttrMapForRunProgram(PyObject* self, PyObject* args) {
           op_type.c_str()));
     }
   }
-
-  PyObject* py_attrs_capsule = PyCapsule_New(
-      attrs_ptr, "paddle.framework.AttributeMap", [](PyObject* capsule) {
-        paddle::framework::AttributeMap* data =
-            reinterpret_cast<paddle::framework::AttributeMap*>(
-                PyCapsule_GetPointer(capsule, "paddle.framework.AttributeMap"));
-        if (data) {
-          delete data;
-        }
-      });
-
-  if (!py_attrs_capsule) {
-    delete attrs_ptr;
-    PyErr_SetString(PyExc_RuntimeError,
-                    "Failed to create PyCapsule for AttributeMap.");
-    return nullptr;
-  }
-  return py_attrs_capsule;
 }
 
 unsigned long GetUnsignedLongFromArgs(  // NOLINT
@@ -1387,8 +1401,8 @@ ssize_t GetIdxFromCoreOpsInfoMap(
 }
 
 static PyMethodDef OpFunctionCommonMethods[] = {  // NOLINT
-    {"construct_attribute_map",
-     (PyCFunction)ConstructAttrMapForRunProgram,
+    {"construct_program_attribute_map",
+     (PyCFunction)ConstructProgramAttrMapForRunProgram,
      METH_VARARGS,
      "create attribute map for run program"},
     {nullptr, nullptr, 0, nullptr}};

--- a/paddle/fluid/pybind/op_function_common.cc
+++ b/paddle/fluid/pybind/op_function_common.cc
@@ -1210,12 +1210,14 @@ void ConstructAttrMapForLegacyRunProgram(
   }
 }
 
-void ConstructAttrMapForRunProgram(
-    const std::string& op_type,
-    PyObject* args,
-    ssize_t arg_pos,
-    paddle::framework::AttributeMap& attrs) {  // NOLINT
-  PyObject* attrs_dict = PyTuple_GET_ITEM(args, arg_pos);
+PyObject* ConstructAttrMapForRunProgram(PyObject* self, PyObject* args) {
+  const std::string op_type = "run_program";
+  PyObject* attrs_dict = nullptr;
+
+  if (!PyArg_ParseTuple(args, "O", &attrs_dict)) {
+    return nullptr;
+  }
+
   if (!PyDict_Check(attrs_dict)) {
     PADDLE_THROW(common::errors::InvalidArgument(
         "%s(): argument must be dict, but got %s",
@@ -1252,6 +1254,12 @@ void ConstructAttrMapForRunProgram(
       {"cuda_graph_dispatch_key", CastPyArg2AttrLong},
   };
 
+  paddle::framework::AttributeMap* attrs_ptr =
+      new (std::nothrow) paddle::framework::AttributeMap();
+  if (!attrs_ptr) {
+    PADDLE_THROW(common::errors::InvalidArgument(
+        "%s(): failed to allocate memory for AttributeMap.", op_type));
+  }
   PyObject *key, *value;
   Py_ssize_t pos = 0;
   while (PyDict_Next(attrs_dict, &pos, &key, &value)) {
@@ -1268,7 +1276,7 @@ void ConstructAttrMapForRunProgram(
     std::string_view key_view(key_ptr, static_cast<size_t>(key_len));
     auto it = kAttrFuncMap.find(std::string(key_view));
     if (it != kAttrFuncMap.end()) {
-      it->second(value, attrs, std::string(key_view), op_type, 0);
+      it->second(value, *attrs_ptr, std::string(key_view), op_type, 0);
     } else {
       PADDLE_THROW(common::errors::InvalidArgument(
           "Attribute key %.*s is not recognized for operator %s.",
@@ -1277,6 +1285,24 @@ void ConstructAttrMapForRunProgram(
           op_type.c_str()));
     }
   }
+
+  PyObject* py_attrs_capsule = PyCapsule_New(
+      attrs_ptr, "paddle.framework.AttributeMap", [](PyObject* capsule) {
+        paddle::framework::AttributeMap* data =
+            reinterpret_cast<paddle::framework::AttributeMap*>(
+                PyCapsule_GetPointer(capsule, "paddle.framework.AttributeMap"));
+        if (data) {
+          delete data;
+        }
+      });
+
+  if (!py_attrs_capsule) {
+    delete attrs_ptr;
+    PyErr_SetString(PyExc_RuntimeError,
+                    "Failed to create PyCapsule for AttributeMap.");
+    return nullptr;
+  }
+  return py_attrs_capsule;
 }
 
 unsigned long GetUnsignedLongFromArgs(  // NOLINT
@@ -1358,6 +1384,21 @@ ssize_t GetIdxFromCoreOpsInfoMap(
     }
   }
   return -1;
+}
+
+static PyMethodDef OpFunctionCommonMethods[] = {  // NOLINT
+    {"construct_attribute_map",
+     (PyCFunction)ConstructAttrMapForRunProgram,
+     METH_VARARGS,
+     "create attribute map for run program"},
+    {nullptr, nullptr, 0, nullptr}};
+
+void BindOpFunctionCommon(PyObject* module) {
+  if (PyModule_AddFunctions(module, OpFunctionCommonMethods) < 0) {
+    PADDLE_THROW(common::errors::Fatal(
+        "Init Paddle error in BindOpFunctionCommon(PyModule_AddFunctions)."));
+    return;
+  }
 }
 
 }  // namespace paddle::pybind

--- a/paddle/fluid/pybind/op_function_common.h
+++ b/paddle/fluid/pybind/op_function_common.h
@@ -215,7 +215,18 @@ void ConstructAttrMapForLegacyRunProgram(
     ssize_t attr_end,
     paddle::framework::AttributeMap& attrs);  // NOLINT
 
-PyObject* ConstructAttrMapForRunProgram(PyObject* self, PyObject* args);
+void ConstructAttrMapForRunProgram(
+    const std::string& op_type,
+    PyObject* attrs_dict,
+    paddle::framework::AttributeMap& attrs);  // NOLINT
+
+PyObject* ConstructProgramAttrMapForRunProgram(PyObject* self, PyObject* args);
+
+void ConstructCudaGraphAttrMapForRunProgram(
+    const std::string& op_type,
+    PyObject* args,
+    ssize_t arg_pos,
+    paddle::framework::AttributeMap& attrs);  // NOLINT
 
 unsigned long GetUnsignedLongFromArgs(  // NOLINT
     const std::string& op_type,

--- a/paddle/fluid/pybind/op_function_common.h
+++ b/paddle/fluid/pybind/op_function_common.h
@@ -215,11 +215,7 @@ void ConstructAttrMapForLegacyRunProgram(
     ssize_t attr_end,
     paddle::framework::AttributeMap& attrs);  // NOLINT
 
-void ConstructAttrMapForRunProgram(
-    const std::string& op_type,
-    PyObject* args,
-    ssize_t arg_pos,
-    paddle::framework::AttributeMap& attrs);  // NOLINT
+PyObject* ConstructAttrMapForRunProgram(PyObject* self, PyObject* args);
 
 unsigned long GetUnsignedLongFromArgs(  // NOLINT
     const std::string& op_type,
@@ -236,5 +232,6 @@ ssize_t GetIdxFromCoreOpsInfoMap(
     const std::string& op_type,
     const std::string& name);
 
+void BindOpFunctionCommon(PyObject* module);
 }  // namespace pybind
 }  // namespace paddle

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -228,6 +228,7 @@ limitations under the License. */
 #include "paddle/fluid/prim/utils/static/static_tensor_operants.h"
 #include "paddle/fluid/primitive/base/decomp_trans.h"
 #include "paddle/fluid/pybind/eager_utils.h"
+#include "paddle/fluid/pybind/op_function_common.h"
 #include "paddle/phi/api/ext/op_meta_info.h"
 #include "paddle/phi/api/include/operants_manager.h"
 #include "paddle/phi/api/include/tensor_operants.h"
@@ -1462,6 +1463,7 @@ PYBIND11_MODULE(libpaddle, m) {
   BindSot(&m);
   BindCustomDevicePy(&m);
   BindEagerUtils(m.ptr());
+  BindOpFunctionCommon(m.ptr());
 
   // Not used, just make sure cpu_info.cc is linked.
   phi::backends::cpu::CpuTotalPhysicalMemory();

--- a/python/paddle/jit/dy2static/pir_partial_program.py
+++ b/python/paddle/jit/dy2static/pir_partial_program.py
@@ -745,16 +745,16 @@ class PartialProgramLayer:
         self._grad_var_names = {}
 
         self._compile_time_counter = TimeCounter()
-        self._attributes_map_cache = {}
+        self._prog_attrs_map_cache = {}
 
     @staticmethod
     def run_impl(partial_program_layer, inputs, parameters, attrs):
-        attrs_capsule, attrs_pydict = attrs
+        prog_attrs, cuda_graph_attrs = attrs
         scope_cache_key = paddle.base.core.calc_scope_cache_key(
-            attrs_pydict["program_id"],
+            paddle.base.core.get_program_id_from_attrs(prog_attrs),
             inputs,
-            attrs_pydict["cuda_graph_state"] != CUDAGraphState.DISABLE,
-            attrs_pydict["cuda_graph_dispatch_key"],
+            cuda_graph_attrs["cuda_graph_state"] != CUDAGraphState.DISABLE,
+            cuda_graph_attrs["cuda_graph_dispatch_key"],
         )
         return _C_ops.run_program(
             PartialProgramLayer._valid_vars(inputs),
@@ -763,7 +763,8 @@ class PartialProgramLayer:
                 cache_key=scope_cache_key,
                 use_scope_cache=True,
             ),
-            attrs_capsule,
+            prog_attrs,
+            cuda_graph_attrs,
         )
 
     def __call__(self, inputs):
@@ -1194,20 +1195,24 @@ class PartialProgramLayer:
         return whole_program
 
     def _prepare_attributes(self, in_sot_mode=False):
-        attrs_pydict = {
-            'forward_program': self.program.forward_program,
-            'backward_program': self.program.backward_program,
-            'is_test': not self.training,
-            'program_id': self.program_id,
-            'in_sot_mode': in_sot_mode,
+        prog_attr_key = (self.program_id, self.training, in_sot_mode)
+        if self._prog_attrs_map_cache.get(prog_attr_key, None) is None:
+            prog_attrs = {
+                'forward_program': self.program.forward_program,
+                'backward_program': self.program.backward_program,
+                'is_test': not self.training,
+                'program_id': self.program_id,
+                'in_sot_mode': in_sot_mode,
+            } | self.program.program_attr
+            self._prog_attrs_map_cache[prog_attr_key] = (
+                paddle.base.core.construct_program_attribute_map(prog_attrs)
+            )
+
+        cuda_graph_attrs = {
             'cuda_graph_state': CUDAGraphState.DISABLE,  # default value for not use cuda graph
             'cuda_graph_dispatch_key': 0,  # default value for not use cuda graph
-        } | self.program.program_attr
-        if self._attributes_map_cache.get(self.program_id, None) is None:
-            self._attributes_map_cache[self.program_id] = (
-                paddle.base.core.construct_attribute_map(attrs_pydict)
-            )
-        return self._attributes_map_cache[self.program_id], attrs_pydict
+        }
+        return self._prog_attrs_map_cache[prog_attr_key], cuda_graph_attrs
 
     def _prepare_inputs(self, inputs):
         """

--- a/python/paddle/jit/dy2static/pir_partial_program.py
+++ b/python/paddle/jit/dy2static/pir_partial_program.py
@@ -1196,7 +1196,7 @@ class PartialProgramLayer:
 
     def _prepare_attributes(self, in_sot_mode=False):
         prog_attr_key = (self.program_id, self.training, in_sot_mode)
-        if self._prog_attrs_map_cache.get(prog_attr_key, None) is None:
+        if prog_attr_key not in self._prog_attrs_map_cache:
             prog_attrs = {
                 'forward_program': self.program.forward_program,
                 'backward_program': self.program.backward_program,

--- a/python/paddle/jit/dy2static/pir_partial_program.py
+++ b/python/paddle/jit/dy2static/pir_partial_program.py
@@ -745,14 +745,16 @@ class PartialProgramLayer:
         self._grad_var_names = {}
 
         self._compile_time_counter = TimeCounter()
+        self._attributes_map_cache = {}
 
     @staticmethod
     def run_impl(partial_program_layer, inputs, parameters, attrs):
+        attrs_capsule, attrs_pydict = attrs
         scope_cache_key = paddle.base.core.calc_scope_cache_key(
-            attrs["program_id"],
+            attrs_pydict["program_id"],
             inputs,
-            attrs["cuda_graph_state"] != CUDAGraphState.DISABLE,
-            attrs["cuda_graph_dispatch_key"],
+            attrs_pydict["cuda_graph_state"] != CUDAGraphState.DISABLE,
+            attrs_pydict["cuda_graph_dispatch_key"],
         )
         return _C_ops.run_program(
             PartialProgramLayer._valid_vars(inputs),
@@ -761,7 +763,7 @@ class PartialProgramLayer:
                 cache_key=scope_cache_key,
                 use_scope_cache=True,
             ),
-            attrs,
+            attrs_capsule,
         )
 
     def __call__(self, inputs):
@@ -1192,7 +1194,7 @@ class PartialProgramLayer:
         return whole_program
 
     def _prepare_attributes(self, in_sot_mode=False):
-        return {
+        attrs_pydict = {
             'forward_program': self.program.forward_program,
             'backward_program': self.program.backward_program,
             'is_test': not self.training,
@@ -1201,6 +1203,11 @@ class PartialProgramLayer:
             'cuda_graph_state': CUDAGraphState.DISABLE,  # default value for not use cuda graph
             'cuda_graph_dispatch_key': 0,  # default value for not use cuda graph
         } | self.program.program_attr
+        if self._attributes_map_cache.get(self.program_id, None) is None:
+            self._attributes_map_cache[self.program_id] = (
+                paddle.base.core.construct_attribute_map(attrs_pydict)
+            )
+        return self._attributes_map_cache[self.program_id], attrs_pydict
 
     def _prepare_inputs(self, inputs):
         """


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->
优化PIR run_program中的AttributeMap：在Python层`PartialProgramLayer`中建立AttributeMap Cache，当目标AttributeMap不在Cache中则在C++层创建新的AttributeMap，并将该对象保存在AttributeMap Cache中；否则，直接返回AttributeMap Cache已存在的对象。减少了创建AttributeMap对象的开销（尤其堆内存申请带来的开销）。

`run_impl_hook` 中可能会对cuda graph相关的attrs进行修改，因此，将原来的attrs map拆分成两部分，一部分存储program相关的attrs，一部分存储cuda graph相关的attrs，只对program相关的attrs进行缓存。

cc @SigureMo @zyfncg 

pcard-67164