### PR TITLE
【slice】add stridedlementwisecopy kernel slice-check

### DIFF
--- a/paddle/phi/kernels/gpu/set_value_kernel.cu
+++ b/paddle/phi/kernels/gpu/set_value_kernel.cu
@@ -132,12 +132,12 @@ void SetTensorValueKernel(const Context& dev_ctx,
       Copy<Context>(dev_ctx, expand_tensor, dev_ctx.GetPlace(), false, out);
     }
   } else {
-    StridedCopyKernel<T, Context>(dev_ctx,
-                                  expand_tensor,
-                                  new_out_shape,
-                                  new_out_stride,
-                                  output_offset,
-                                  out);
+    StridedElementwiseCopyKernel<T, Context>(dev_ctx,
+                                             expand_tensor,
+                                             new_out_shape,
+                                             new_out_stride,
+                                             output_offset,
+                                             out);
   }
   out->set_meta(meta);
 }

--- a/paddle/phi/kernels/gpu/strided_elementwise_copy_kernel.cu
+++ b/paddle/phi/kernels/gpu/strided_elementwise_copy_kernel.cu
@@ -1,4 +1,4 @@
-/* Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+/* Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -13,6 +13,7 @@ limitations under the License. */
 #include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/index_elementwise.cu.h"
+#include "paddle/phi/kernels/funcs/slice_utils.h"
 #include "paddle/phi/kernels/strided_copy_kernel.h"
 
 namespace phi {
@@ -53,6 +54,15 @@ void StridedElementwiseCopyKernel(const Context& dev_ctx,
 
     return;
   }
+
+  bool can_expand = phi::funcs::CheckIsLastDimsMatch(input.dims(), out->dims());
+  PADDLE_ENFORCE_EQ(can_expand || input.numel() == 1,
+                    true,
+                    common::errors::InvalidArgument(
+                        "Input shape(%s) must expand to out shape(%s).",
+                        input.dims(),
+                        out->dims()));
+
   std::array<int64_t*, 2> strides_array;
   std::vector<int64_t> desired_shape;
   std::array<std::vector<int64_t>, 2> strides_vec;
@@ -69,7 +79,8 @@ void StridedElementwiseCopyKernel(const Context& dev_ctx,
                        strides_vec);
 
   auto offset_calc =
-      funcs::make_offset_calculator_put<2>(desired_shape, strides_array);
+      funcs::make_offset_calculator_put<2, true>(desired_shape, strides_array);
+
   constexpr int block_size = 128;
   constexpr int loop_size = 4;
   const dim3 block(block_size);
@@ -78,7 +89,6 @@ void StridedElementwiseCopyKernel(const Context& dev_ctx,
   using dtype = funcs::OpaqueType<sizeof(T)>;
   const char* in_ptr = reinterpret_cast<const char*>(input.data<T>());
   char* out_ptr = reinterpret_cast<char*>(out->data<T>());
-
   funcs::index_elementwise_with_tensor_kernel<block_size, loop_size>
       <<<grid, block, 0, stream>>>(numel, [=] __device__(int idx) {
         const auto offsets = offset_calc.get(idx);

--- a/paddle/phi/kernels/gpu/strided_elementwise_copy_kernel.cu
+++ b/paddle/phi/kernels/gpu/strided_elementwise_copy_kernel.cu
@@ -1,0 +1,112 @@
+/* Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include "paddle/phi/backends/gpu/gpu_launch_config.h"
+#include "paddle/phi/common/memory_utils.h"
+#include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/funcs/index_elementwise.cu.h"
+#include "paddle/phi/kernels/strided_copy_kernel.h"
+
+namespace phi {
+template <typename T, typename Context>
+void StridedElementwiseCopyKernel(const Context& dev_ctx,
+                                  const DenseTensor& input,
+                                  const std::vector<int64_t>& out_dims,
+                                  const std::vector<int64_t>& out_strides,
+                                  int64_t out_offset,
+                                  DenseTensor* out) {
+  phi::DenseTensorMeta meta = input.meta();
+  meta.strides = common::make_ddim(out_strides);
+  meta.dims = common::make_ddim(out_dims);
+  meta.offset = out_offset;
+  out->set_meta(meta);
+  auto numel = out->numel();
+  T* output_data = out->data<T>();
+  PADDLE_ENFORCE_NOT_NULL(
+      output_data,
+      common::errors::InvalidArgument(
+          "StridedElementwiseCopyKernel's out tensor must complete "
+          "mutable data before call kernel."));
+
+  const T* input_data = input.data<T>();
+
+  if (numel == 1) {
+#ifdef PADDLE_WITH_HIP
+    hipMemcpy(output_data,
+              input_data,
+              phi::SizeOf(input.dtype()),
+              hipMemcpyDeviceToDevice);
+#else
+    cudaMemcpy(output_data,
+               input_data,
+               phi::SizeOf(input.dtype()),
+               cudaMemcpyDeviceToDevice);
+#endif
+
+    return;
+  }
+  std::array<int64_t*, 2> strides_array;
+  std::vector<int64_t> desired_shape;
+  std::array<std::vector<int64_t>, 2> strides_vec;
+
+  funcs::CopyStride<2>(out_dims,
+                       out_strides,
+                       phi::SizeOf(out->dtype()),
+                       common::vectorize<int64_t>(input.dims()),
+                       common::vectorize<int64_t>(input.strides()),
+                       phi::SizeOf(input.dtype()),
+                       &desired_shape,
+                       &strides_array,
+                       &numel,
+                       strides_vec);
+
+  auto offset_calc =
+      funcs::make_offset_calculator_put<2>(desired_shape, strides_array);
+  constexpr int block_size = 128;
+  constexpr int loop_size = 4;
+  const dim3 block(block_size);
+  const dim3 grid((numel + block.x * loop_size - 1) / (block.x * loop_size));
+  auto stream = dev_ctx.stream();
+  using dtype = funcs::OpaqueType<sizeof(T)>;
+  const char* in_ptr = reinterpret_cast<const char*>(input.data<T>());
+  char* out_ptr = reinterpret_cast<char*>(out->data<T>());
+
+  funcs::index_elementwise_with_tensor_kernel<block_size, loop_size>
+      <<<grid, block, 0, stream>>>(numel, [=] __device__(int idx) {
+        const auto offsets = offset_calc.get(idx);
+        char* const out_data = out_ptr + offsets[0];
+        const char* const in_data = in_ptr + offsets[1];
+
+        *reinterpret_cast<dtype*>(out_data) =
+            *reinterpret_cast<const dtype*>(in_data);
+      });
+}
+
+}  // namespace phi
+
+PD_REGISTER_KERNEL(strided_elementwise_copy,
+                   GPU,
+                   ALL_LAYOUT,
+                   phi::StridedElementwiseCopyKernel,
+                   bool,
+                   uint8_t,
+                   int8_t,
+                   int16_t,
+                   int32_t,
+                   int64_t,
+                   float,
+                   double,
+                   ::phi::dtype::float16,
+                   ::phi::dtype::bfloat16,
+                   ::phi::dtype::complex<float>,
+                   ::phi::dtype::complex<double>,
+                   ::phi::dtype::float8_e4m3fn,
+                   ::phi::dtype::float8_e5m2) {}

--- a/paddle/phi/kernels/strided_copy_kernel.h
+++ b/paddle/phi/kernels/strided_copy_kernel.h
@@ -43,4 +43,13 @@ DenseTensor StridedCopy(const Context& dev_ctx,
       dev_ctx, input, dims, out_stride, offset, &dense_out);
   return dense_out;
 }
+
+template <typename T, typename Context>
+void StridedElementwiseCopyKernel(const Context& dev_ctx,
+                                  const DenseTensor& input,
+                                  const std::vector<int64_t>& out_dims,
+                                  const std::vector<int64_t>& out_strides,
+                                  int64_t out_offset,
+                                  DenseTensor* out);
+
 }  // namespace phi


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
pcard-67164
stridecopy kernel的其他实现，减少原始kernel 的代码量，该kernel 支持非连续/连续的输入输出拷贝，同时支持src numel != dst, 只需要满足可expand即可

相比于原来的stridecopy , 之前的default kernel 可以使用向量化，但是当前的kernel 更通用的选择位置，无法支持向量化。导致fp16 slice(0,100,2) 的set_item case 性能回退20%