### PR TITLE
fix group_norm, layer_norm spmd 

### DIFF
--- a/paddle/phi/infermeta/spmd_rules/group_norm.cc
+++ b/paddle/phi/infermeta/spmd_rules/group_norm.cc
@@ -221,6 +221,18 @@ SpmdInfo GroupNormGradInferSpmdBase(const DistMetaTensor& x,
       common::errors::InvalidArgument(
           "The ndim of bias in group_norm should be 1, but got [%d].",
           bias_ndim));
+  PADDLE_ENFORCE_EQ(
+      mean_ndim,
+      2,
+      common::errors::InvalidArgument(
+          "The ndim of bias in group_norm should be 2, but got [%d].",
+          bias_ndim));
+  PADDLE_ENFORCE_EQ(
+      variance_ndim,
+      2,
+      common::errors::InvalidArgument(
+          "The ndim of bias in group_norm should be 2, but got [%d].",
+          bias_ndim));
 
   // Step1: Build Einsum Notation
   // Only N axis can be sharded.

--- a/paddle/phi/infermeta/spmd_rules/group_norm.cc
+++ b/paddle/phi/infermeta/spmd_rules/group_norm.cc
@@ -77,8 +77,14 @@ SpmdInfo GroupNormInferSpmdBase(const DistMetaTensor& x,
   for (int i = 0; i < x_ndim; ++i) {
     x_axes[i] = alphabet[i];
   }
-  std::string mean_axes(1, x_axes[0]);
-  std::string variance_axes(1, x_axes[0]);
+  std::string mean_axes(2, '1');
+  std::string variance_axes(2, '1');
+
+  for (int i = 0; i < 2; ++i) {
+    mean_axes[i] = x_axes[i];
+    variance_axes[i] = x_axes[i];
+  }
+
   // x_axes[0] = alphabet[0];
   std::string scale_axes(1, x_axes[0]);
   std::string bias_axes(1, x_axes[0]);
@@ -215,18 +221,6 @@ SpmdInfo GroupNormGradInferSpmdBase(const DistMetaTensor& x,
       common::errors::InvalidArgument(
           "The ndim of bias in group_norm should be 1, but got [%d].",
           bias_ndim));
-  PADDLE_ENFORCE_EQ(
-      mean_ndim,
-      1,
-      common::errors::InvalidArgument(
-          "The ndim of mean in group_norm should be 1, but got [%d].",
-          mean_ndim));
-  PADDLE_ENFORCE_EQ(
-      variance_ndim,
-      1,
-      common::errors::InvalidArgument(
-          "The ndim of variance in group_norm should be 1, but got [%d].",
-          variance_ndim));
 
   // Step1: Build Einsum Notation
   // Only N axis can be sharded.
@@ -243,8 +237,13 @@ SpmdInfo GroupNormGradInferSpmdBase(const DistMetaTensor& x,
   }
   std::string scale_axes(1, x_axes[0]);
   std::string bias_axes(1, x_axes[0]);
-  std::string mean_axes(1, x_axes[0]);
-  std::string variance_axes(1, x_axes[0]);
+  std::string mean_axes(2, '1');
+  std::string variance_axes(2, '1');
+
+  for (int i = 0; i < 2; ++i) {
+    mean_axes[i] = x_axes[i];
+    variance_axes[i] = x_axes[i];
+  }
   // output
   std::string x_grad_axes = x_axes;
   std::string scale_grad_axes(1, x_axes[0]);  // C axis

--- a/paddle/phi/infermeta/spmd_rules/layer_norm.cc
+++ b/paddle/phi/infermeta/spmd_rules/layer_norm.cc
@@ -416,8 +416,12 @@ SpmdInfo LayerNormGradInferSpmd(const DistMetaTensor& x,
       partial_on_dims.push_back(mapping);
     }
   }
-  scale_grad_dist_attr.set_partial_status(partial_on_dims);
-  bias_grad_dist_attr.set_partial_status(partial_on_dims);
+  if (!scale_grad_dist_attr.empty()) {
+    scale_grad_dist_attr.set_partial_status(partial_on_dims);
+  }
+  if (!bias_grad_dist_attr.empty()) {
+    bias_grad_dist_attr.set_partial_status(partial_on_dims);
+  }
 
   VLOG(4) << "LayerNormGradInferSpmd:";
   VLOG(4) << "begin_norm_axis: " << begin_norm_axis;

--- a/test/cpp/auto_parallel/spmd_rule_test.cc
+++ b/test/cpp/auto_parallel/spmd_rule_test.cc
@@ -560,7 +560,7 @@ TEST(GroupNorm, Ctor) {
   std::vector<int64_t> x_shape = {64, 64, 64, 64};  // N,C,H,W
   std::vector<int64_t> scale_shape = {64};
   std::vector<int64_t> bias_shape = {64};
-  std::vector<int64_t> mean_and_variance_shape = {64};
+  std::vector<int64_t> mean_and_variance_shape = {64, 64};
   std::vector<int64_t> mesh_shape = {2, 3};
   std::vector<int64_t> process_ids = {0, 1, 2, 3, 4, 5};
   std::vector<std::string> dim_names = {"x", "y"};
@@ -646,8 +646,8 @@ TEST(GroupNorm, Ctor) {
   check_dim_mapping(backward_info.first[1], {-1});
   check_dim_mapping(backward_info.first[2], {-1});
   check_dim_mapping(backward_info.first[3], {0, -1, -1, -1});
-  check_dim_mapping(backward_info.first[4], {0});
-  check_dim_mapping(backward_info.first[5], {0});
+  check_dim_mapping(backward_info.first[4], {0, -1});
+  check_dim_mapping(backward_info.first[5], {0, -1});
   check_dim_mapping(backward_info.first[6], {0, -1, -1, -1});
   check_dim_mapping(backward_info.second[0], {0, -1, -1, -1});
   check_dim_mapping(backward_info.second[1], {-1});

--- a/test/cpp/auto_parallel/spmd_rule_test.cc
+++ b/test/cpp/auto_parallel/spmd_rule_test.cc
@@ -607,8 +607,8 @@ TEST(GroupNorm, Ctor) {
   check_dim_mapping(forward_info.first[1], {-1});
   check_dim_mapping(forward_info.first[2], {-1});
   check_dim_mapping(forward_info.second[0], {0, -1, -1, -1});
-  check_dim_mapping(forward_info.second[1], {0});
-  check_dim_mapping(forward_info.second[2], {0});
+  check_dim_mapping(forward_info.second[1], {0, -1});
+  check_dim_mapping(forward_info.second[2], {0, -1});
   VLOG(4) << "test forward done.";
 
   // Test backward.
@@ -618,7 +618,7 @@ TEST(GroupNorm, Ctor) {
   // infer output:[0, 1, -1, -1], [-1],[-1]
   TensorDistAttr mean_and_variance_dist_attr = TensorDistAttr();
   mean_and_variance_dist_attr.set_process_mesh(process_mesh);
-  mean_and_variance_dist_attr.set_dims_mapping(std::vector<int64_t>({-1}));
+  mean_and_variance_dist_attr.set_dims_mapping(std::vector<int64_t>({-1, -1}));
   mean_and_variance_dist_attr.set_dynamic_dims(std::vector<bool>({false}));
   phi::distributed::DistMetaTensor y(common::make_ddim(x_shape), x_dist_attr);
   phi::distributed::DistMetaTensor y_grad(common::make_ddim(x_shape),


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-73145
修改group_norm及layernorm 切分推导bug
- group_norm中mean，variance，shape应该是二维[N, G]，原实现是一维，需修改
- layernorm中bias可能为None，需添加check