### PR TITLE
Fix accuracy diff for paddle.nn.functional.batch_norm  API 

### DIFF
--- a/paddle/phi/kernels/gpu/batch_norm_kernel.cu
+++ b/paddle/phi/kernels/gpu/batch_norm_kernel.cu
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <iostream>
 #ifdef __NVCC__
 #include "cub/cub.cuh"
 #endif
@@ -534,9 +535,8 @@ void BatchNormKernel(const Context &dev_ctx,
                      DenseTensor *saved_variance,
                      DenseTensor *reserve_space) {
   double epsilon = epsilon_f;
-  const bool trainable_stats = trainable_statistics;
   const DataLayout data_layout = common::StringToDataLayout(data_layout_str);
-  bool test_mode = is_test && (!trainable_stats);
+  bool test_mode = is_test && (!trainable_statistics);
 
   // Get the size for each dimension.
   // NCHW [batch_size, in_channels, in_height, in_width]
@@ -700,7 +700,7 @@ void BatchNormKernel(const Context &dev_ctx,
   // Now, depending on whether we are running test or not, we have two paths.
   // It is training mode when it's not reference AND not using pre-trained
   // model.
-  bool training = !test_mode && !use_global_stats;
+  bool training = !is_test && !use_global_stats;
   if (!training) {
     // only when test we use input to do computation.
     const auto *est_mean = &mean;

--- a/paddle/phi/kernels/gpu/batch_norm_kernel.cu
+++ b/paddle/phi/kernels/gpu/batch_norm_kernel.cu
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <iostream>
 #ifdef __NVCC__
 #include "cub/cub.cuh"
 #endif


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修复 paddle.nn.functional.batch_norm 的计算行为与文档保持一致。

#### paddle 使用全局均值和方差的行为
1 
training = False
use_global_stats = True
使用全局
2
training = False
use_global_stats = False
不使用全局
3
training = True
use_global_stats = True
使用全局
4
training = True
use_global_stats = False
不使用全局

第二种情况与CPU不一致，相当于paddle用use_global_stats = False 覆盖了training = False，而pytorch选择了用training = False 覆盖use_global_stats = False

实测与文档的描述不同，文档中说第四种情况会按照第三种情况执行，实际情况为第二种情况会按照第四种情况执行。


paddle CPU Kernel 源码
  bool test_mode = is_test && (!trainable_statistics);
  bool global_stats = test_mode || use_global_stats;

python端传入trainable_statistics = not use_global_stats
化简得到 test_mode = (not training) and use_global_stats
use_global_stats = (not test_mode) or use_global_stats
实际上后续没有用到 training，只需要通过use_global_stats判断行为，use_global_stats最后可以化简为
use_global_stats = ((not training) and use_global_stats) or use_global_stats = (not training) or use_global_stats
也就是说这部分应该是符合文档描述的。

paddle GPU Kernel 源码
主要到 bool training= !test_mode && !use_global_stats = !（!training&& (use_global_stats)） && !use_global_stats=(training || !use_global_stats)&& !use_global_stats ;
我们期望的是training && !use_global_stats，这里出现了错误。

Pcard-67164