### PR TITLE
Replace use_mkldnn to use_onednn in paddle/fluid/framework/ir/onednn tests

### DIFF
--- a/paddle/fluid/framework/ir/onednn/cpu_quantize_pass_tester.cc
+++ b/paddle/fluid/framework/ir/onednn/cpu_quantize_pass_tester.cc
@@ -34,14 +34,14 @@ void SetOp(ProgramDesc* prog,
            const std::string& name,
            const std::vector<std::string>& inputs,
            const std::vector<std::string>& outputs,
-           bool use_mkldnn,
-           const std::string& mkldnn_data_type = "float32") {
+           bool use_onednn,
+           const std::string& onednn_data_type = "float32") {
   auto* op = prog->MutableBlock(0)->AppendOp();
   op->SetType(type);
-  op->SetAttr("use_mkldnn", use_mkldnn);
+  op->SetAttr("use_mkldnn", use_onednn);
   op->SetAttr("name", name);
   if (type != "dropout" && type != "quantize" && type != "dequantize") {
-    op->SetAttr("mkldnn_data_type", mkldnn_data_type);
+    op->SetAttr("mkldnn_data_type", onednn_data_type);
   }
 
   if (type == "conv2d") {
@@ -258,8 +258,8 @@ static const std::initializer_list<std::string> variable_names{"a",
 // d->Dropout1->g and (g, w5, b3)->Fc1->h and (h,w3,b1,i)->Conv3->j
 //
 // (d,w4, b2)->Conv4->i
-ProgramDesc BuildProgramDesc(bool use_mkldnn,
-                             const std::string& mkldnn_data_type) {
+ProgramDesc BuildProgramDesc(bool use_onednn,
+                             const std::string& onednn_data_type) {
   ProgramDesc prog;
   for (auto& v : variable_names) {
     auto* var = prog.MutableBlock(0)->Var(v);
@@ -273,49 +273,49 @@ ProgramDesc BuildProgramDesc(bool use_mkldnn,
         "Conv1",
         {"a", "w1"},
         {"c"},
-        use_mkldnn,
-        mkldnn_data_type);
-  SetOp(&prog, "pool2d", "Pool1", {"c"}, {"d"}, use_mkldnn, mkldnn_data_type);
+        use_onednn,
+        onednn_data_type);
+  SetOp(&prog, "pool2d", "Pool1", {"c"}, {"d"}, use_onednn, onednn_data_type);
 
   SetOp(&prog,
         "conv2d",
         "Conv2",
         {"d", "w2"},
         {"e"},
-        use_mkldnn,
-        mkldnn_data_type);
-  SetOp(&prog, "pool2d", "Pool2", {"e"}, {"f"}, use_mkldnn, mkldnn_data_type);
+        use_onednn,
+        onednn_data_type);
+  SetOp(&prog, "pool2d", "Pool2", {"e"}, {"f"}, use_onednn, onednn_data_type);
 
-  SetOp(&prog, "dropout", "Dropout1", {"d"}, {"g"}, use_mkldnn);
+  SetOp(&prog, "dropout", "Dropout1", {"d"}, {"g"}, use_onednn);
   SetOp(&prog,
         "fc",
         "Fc1",
         {"g", "w5", "b3"},
         {"h"},
-        use_mkldnn,
-        mkldnn_data_type);
+        use_onednn,
+        onednn_data_type);
   SetOp(&prog,
         "conv2d",
         "Conv3",
         {"h", "w3", "b1", "i"},
         {"j"},
-        use_mkldnn,
-        mkldnn_data_type);
+        use_onednn,
+        onednn_data_type);
 
   SetOp(&prog,
         "conv2d",
         "Conv4",
         {"c", "w4", "b2"},
         {"i"},
-        use_mkldnn,
-        mkldnn_data_type);
+        use_onednn,
+        onednn_data_type);
 
   return prog;
 }
 
 TEST(CpuQuantizePass, quantize) {
-  bool use_mkldnn = true;
-  std::string mkldnn_data_type = "int8";
+  bool use_onednn = true;
+  std::string onednn_data_type = "int8";
   // (a->QUANT1->IN1,w1)->Conv1->OUT1->DEQUANT1->c and
   // c->QUANT2->IN2->Pool1->OUT2->DEQUANT2->d
   //
@@ -330,7 +330,7 @@ TEST(CpuQuantizePass, quantize) {
   int added_nodes = 8 + 8 + 7 + 7;
   std::unordered_map<std::string, int> expected_operators = {
       {"fused_conv2d", 4}, {"pool2d", 2}, {"quantize", 8}, {"dequantize", 7}};
-  MainTest(BuildProgramDesc(use_mkldnn, mkldnn_data_type),
+  MainTest(BuildProgramDesc(use_onednn, onednn_data_type),
            variable_names,
            expected_operators,
            added_nodes,
@@ -338,12 +338,12 @@ TEST(CpuQuantizePass, quantize) {
 }
 
 TEST(CpuQuantizePass, do_not_quantize) {
-  bool use_mkldnn = true;
-  std::string mkldnn_data_type = "float32";
+  bool use_onednn = true;
+  std::string onednn_data_type = "float32";
   int added_nodes = 0;
   std::unordered_map<std::string, int> expected_operators = {
       {"fused_conv2d", 4}, {"pool2d", 2}, {"quantize", 0}, {"dequantize", 0}};
-  MainTest(BuildProgramDesc(use_mkldnn, mkldnn_data_type),
+  MainTest(BuildProgramDesc(use_onednn, onednn_data_type),
            variable_names,
            expected_operators,
            added_nodes,

--- a/paddle/fluid/framework/ir/onednn/cpu_quantize_squash_pass_tester.cc
+++ b/paddle/fluid/framework/ir/onednn/cpu_quantize_squash_pass_tester.cc
@@ -25,19 +25,19 @@ void SetOp(ProgramDesc* prog,
            const std::string& name,
            const std::vector<std::string>& inputs,
            const std::vector<std::string>& outputs,
-           bool use_mkldnn,
+           bool use_onednn,
            const std::vector<float> scale = {},
            float bias = 0.0,
-           const std::string& mkldnn_data_type = "float32",
+           const std::string& onednn_data_type = "float32",
            bool bias_after_scale = false,
            int groups = 1,
            bool is_negative_input = true) {
   auto* op = prog->MutableBlock(0)->AppendOp();
   op->SetType(type);
-  op->SetAttr("use_mkldnn", use_mkldnn);
+  op->SetAttr("use_mkldnn", use_onednn);
   op->SetAttr("name", name);
   if (type != "dropout" && type != "quantize" && type != "dequantize") {
-    op->SetAttr("mkldnn_data_type", mkldnn_data_type);
+    op->SetAttr("mkldnn_data_type", onednn_data_type);
   }
   if (type == "pool2d") {  // NOLINT
     op->SetInput("X", {inputs[0]});
@@ -78,7 +78,7 @@ void SetOp(ProgramDesc* prog,
   } else if (type == "concat") {
     op->SetInput("X", inputs);
     op->SetOutput("Out", outputs);
-    op->SetAttr("mkldnn_data_type", mkldnn_data_type);
+    op->SetAttr("mkldnn_data_type", onednn_data_type);
   } else if (type == "fc") {
     op->SetInput("Input", {inputs[0]});
     PADDLE_ENFORCE_EQ(inputs.size(),
@@ -92,7 +92,7 @@ void SetOp(ProgramDesc* prog,
     if (!scale.empty()) op->SetAttr("Scale_in", scale[0]);
     if (scale.size() > 1) op->SetAttr("Scale_out", scale[1]);
     op->SetAttr("force_fp32_output", false);
-    op->SetAttr("mkldnn_data_type", mkldnn_data_type);
+    op->SetAttr("mkldnn_data_type", onednn_data_type);
   } else if (type == "scale") {
     op->SetInput("X", {inputs[0]});
     op->SetOutput("Out", {outputs[0]});
@@ -106,7 +106,7 @@ void SetOp(ProgramDesc* prog,
     if (!scale.empty()) op->SetAttr("Scale_x", scale[0]);
     if (scale.size() > 1) op->SetAttr("Scale_out", scale[1]);
     op->SetAttr("force_fp32_output", false);
-    op->SetAttr("mkldnn_data_type", mkldnn_data_type);
+    op->SetAttr("mkldnn_data_type", onednn_data_type);
   }
 }
 
@@ -114,7 +114,7 @@ void SetOp(ProgramDesc* prog,
 // d->Dequant(scale1)->e
 // e->Quant(scale2)->f
 // (f,w2,b2)->Conv2->i
-ProgramDesc BuildConvRequantProgramDesc(bool use_mkldnn,
+ProgramDesc BuildConvRequantProgramDesc(bool use_onednn,
                                         float scale_out,
                                         float scale_in) {
   ProgramDesc prog;
@@ -132,16 +132,16 @@ ProgramDesc BuildConvRequantProgramDesc(bool use_mkldnn,
         "Conv1",
         {"a", "w1", "b1"},
         {"d"},
-        use_mkldnn,
+        use_onednn,
         {1.23f, scale_out});
-  SetOp(&prog, "dequantize", "Dequant", {"d"}, {"e"}, use_mkldnn, {scale_out});
-  SetOp(&prog, "quantize", "Quant", {"e"}, {"f"}, use_mkldnn, {scale_in});
+  SetOp(&prog, "dequantize", "Dequant", {"d"}, {"e"}, use_onednn, {scale_out});
+  SetOp(&prog, "quantize", "Quant", {"e"}, {"f"}, use_onednn, {scale_in});
   SetOp(&prog,
         "conv2d",
         "Conv2",
         {"f", "w2", "b2"},
         {"i"},
-        use_mkldnn,
+        use_onednn,
         {scale_in, 2.34f});
   return prog;
 }
@@ -168,7 +168,7 @@ static const std::initializer_list<std::string> variable_names{"a",
 // c->Quant1(scale2)->d and d->(scale2)Conv2->e
 // c->Conv3->f
 // c->Quant2(scale3)->g and g->Concat->h
-ProgramDesc BuildConvMultiOutputProgramDesc(bool use_mkldnn,
+ProgramDesc BuildConvMultiOutputProgramDesc(bool use_onednn,
                                             float scale_out,
                                             float scale1,
                                             float scale2,
@@ -178,17 +178,17 @@ ProgramDesc BuildConvMultiOutputProgramDesc(bool use_mkldnn,
     prog.MutableBlock(0)->Var(v);
   }
 
-  SetOp(&prog, "conv2d", "Conv1", {"a"}, {"b"}, use_mkldnn, {1.23f, scale1});
-  SetOp(&prog, "dequantize", "Dequant", {"b"}, {"c"}, use_mkldnn, {scale1});
+  SetOp(&prog, "conv2d", "Conv1", {"a"}, {"b"}, use_onednn, {1.23f, scale1});
+  SetOp(&prog, "dequantize", "Dequant", {"b"}, {"c"}, use_onednn, {scale1});
 
-  SetOp(&prog, "quantize", "Quant1", {"c"}, {"d"}, use_mkldnn, {scale2});
+  SetOp(&prog, "quantize", "Quant1", {"c"}, {"d"}, use_onednn, {scale2});
   SetOp(
-      &prog, "conv2d", "Conv2", {"d"}, {"e"}, use_mkldnn, {scale2, scale_out});
+      &prog, "conv2d", "Conv2", {"d"}, {"e"}, use_onednn, {scale2, scale_out});
 
-  SetOp(&prog, "conv2d", "Conv3", {"c"}, {"f"}, use_mkldnn);
+  SetOp(&prog, "conv2d", "Conv3", {"c"}, {"f"}, use_onednn);
 
-  SetOp(&prog, "quantize", "Quant2", {"c"}, {"g"}, use_mkldnn, {scale3});
-  SetOp(&prog, "concat", "Concat", {"g"}, {"h"}, use_mkldnn);
+  SetOp(&prog, "quantize", "Quant2", {"c"}, {"g"}, use_onednn, {scale3});
+  SetOp(&prog, "concat", "Concat", {"g"}, {"h"}, use_onednn);
 
   return prog;
 }
@@ -197,7 +197,7 @@ ProgramDesc BuildConvMultiOutputProgramDesc(bool use_mkldnn,
 //  d->Fc->e->Requant(scale2)->f
 //  {x,y}->Matmul->g->Requant(scale3)->h
 //  {c,f,h}->Concat
-ProgramDesc BuildOpRequantProgramDesc(bool use_mkldnn,
+ProgramDesc BuildOpRequantProgramDesc(bool use_onednn,
                                       float conv_scale,
                                       float fc_scale,
                                       float matmul_scale,
@@ -209,37 +209,37 @@ ProgramDesc BuildOpRequantProgramDesc(bool use_mkldnn,
     prog.MutableBlock(0)->Var(v);
   }
 
-  SetOp(&prog, "conv2d", "Conv", {"a"}, {"b"}, use_mkldnn, {1.23f, conv_scale});
+  SetOp(&prog, "conv2d", "Conv", {"a"}, {"b"}, use_onednn, {1.23f, conv_scale});
   SetOp(&prog,
         "requantize",
         "Requant1",
         {"b"},
         {"c"},
-        use_mkldnn,
+        use_onednn,
         {conv_scale, requant_scale1});
-  SetOp(&prog, "fc", "Fc", {"d", "w1"}, {"e"}, use_mkldnn, {1.23f, fc_scale});
+  SetOp(&prog, "fc", "Fc", {"d", "w1"}, {"e"}, use_onednn, {1.23f, fc_scale});
   SetOp(&prog,
         "requantize",
         "Requant2",
         {"e"},
         {"f"},
-        use_mkldnn,
+        use_onednn,
         {fc_scale, requant_scale2});
   SetOp(&prog,
         "matmul",
         "Matmul",
         {"x", "y"},
         {"g"},
-        use_mkldnn,
+        use_onednn,
         {1.23f, matmul_scale});
   SetOp(&prog,
         "requantize",
         "Requant3",
         {"g"},
         {"h"},
-        use_mkldnn,
+        use_onednn,
         {matmul_scale, requant_scale3});
-  SetOp(&prog, "concat", "Concat", {"c", "f", "h"}, {"g"}, use_mkldnn);
+  SetOp(&prog, "concat", "Concat", {"c", "f", "h"}, {"g"}, use_onednn);
 
   return prog;
 }
@@ -249,7 +249,7 @@ ProgramDesc BuildOpRequantProgramDesc(bool use_mkldnn,
 // c->Quant(scale2)->d
 // d->Conv1->e
 // d->Conv2->f
-ProgramDesc BuildConcatDequantQuantProgramDesc(bool use_mkldnn,
+ProgramDesc BuildConcatDequantQuantProgramDesc(bool use_onednn,
                                                float scale_out,
                                                float scale1,
                                                float scale2) {
@@ -258,20 +258,20 @@ ProgramDesc BuildConcatDequantQuantProgramDesc(bool use_mkldnn,
     prog.MutableBlock(0)->Var(v);
   }
 
-  SetOp(&prog, "concat", "Concat", {"a"}, {"b"}, use_mkldnn);
-  SetOp(&prog, "dequantize", "Dequant", {"b"}, {"c"}, use_mkldnn, {scale1});
-  SetOp(&prog, "quantize", "Quant", {"c"}, {"d"}, use_mkldnn, {scale2});
+  SetOp(&prog, "concat", "Concat", {"a"}, {"b"}, use_onednn);
+  SetOp(&prog, "dequantize", "Dequant", {"b"}, {"c"}, use_onednn, {scale1});
+  SetOp(&prog, "quantize", "Quant", {"c"}, {"d"}, use_onednn, {scale2});
   SetOp(
-      &prog, "conv2d", "Conv1", {"d"}, {"e"}, use_mkldnn, {scale2, scale_out});
+      &prog, "conv2d", "Conv1", {"d"}, {"e"}, use_onednn, {scale2, scale_out});
   SetOp(
-      &prog, "conv2d", "Conv2", {"d"}, {"f"}, use_mkldnn, {scale2, scale_out});
+      &prog, "conv2d", "Conv2", {"d"}, {"f"}, use_onednn, {scale2, scale_out});
   return prog;
 }
 
 // a->Conv1->b
 // b->Requant1(Scale1)->c
 // b->Requant2(Scale2)->d
-ProgramDesc BuildConvMultiRequantProgramDesc(bool use_mkldnn,
+ProgramDesc BuildConvMultiRequantProgramDesc(bool use_onednn,
                                              float scale_out,
                                              float scale1,
                                              float scale2) {
@@ -279,20 +279,20 @@ ProgramDesc BuildConvMultiRequantProgramDesc(bool use_mkldnn,
   for (auto& v : variable_names) {
     prog.MutableBlock(0)->Var(v);
   }
-  SetOp(&prog, "conv2d", "Conv1", {"a"}, {"b"}, use_mkldnn, {1.23f, scale_out});
+  SetOp(&prog, "conv2d", "Conv1", {"a"}, {"b"}, use_onednn, {1.23f, scale_out});
   SetOp(&prog,
         "requantize",
         "Requant1",
         {"b"},
         {"c"},
-        use_mkldnn,
+        use_onednn,
         {scale_out, scale1});
   SetOp(&prog,
         "requantize",
         "Requant2",
         {"b"},
         {"d"},
-        use_mkldnn,
+        use_onednn,
         {scale_out, scale2});
   return prog;
 }
@@ -479,64 +479,64 @@ ProgramDesc BuildS8S8S8ConcatProgramDesc(float scale_out, float scale) {
 // a->Conv1->b
 // b->Dequant1(Scale1)->c
 // c->Concat
-ProgramDesc BuildConvDequantConcatProgramDesc(bool use_mkldnn,
+ProgramDesc BuildConvDequantConcatProgramDesc(bool use_onednn,
                                               float scale_out,
                                               float scale) {
   ProgramDesc prog;
   for (auto& v : variable_names) {
     prog.MutableBlock(0)->Var(v);
   }
-  SetOp(&prog, "conv2d", "Conv1", {"a"}, {"b"}, use_mkldnn, {1.23f, scale_out});
-  SetOp(&prog, "dequantize", "Dequant1", {"b"}, {"c"}, use_mkldnn, {scale});
-  SetOp(&prog, "concat", "Concat1", {"c"}, {"d"}, use_mkldnn);
+  SetOp(&prog, "conv2d", "Conv1", {"a"}, {"b"}, use_onednn, {1.23f, scale_out});
+  SetOp(&prog, "dequantize", "Dequant1", {"b"}, {"c"}, use_onednn, {scale});
+  SetOp(&prog, "concat", "Concat1", {"c"}, {"d"}, use_onednn);
   return prog;
 }
 
 // a->fc->b
 // b->Dequant1->c
 // c->Concat1->d
-ProgramDesc BuildFcDequantConcatProgramDesc(bool use_mkldnn,
+ProgramDesc BuildFcDequantConcatProgramDesc(bool use_onednn,
                                             float scale_out,
                                             float scale) {
   ProgramDesc prog;
   for (auto& v : variable_names) {
     prog.MutableBlock(0)->Var(v);
   }
-  SetOp(&prog, "fc", "Fc1", {"a", "w1"}, {"b"}, use_mkldnn, {1.23f, scale_out});
-  SetOp(&prog, "dequantize", "Dequant1", {"b"}, {"c"}, use_mkldnn, {scale});
-  SetOp(&prog, "concat", "Concat1", {"c"}, {"d"}, use_mkldnn);
+  SetOp(&prog, "fc", "Fc1", {"a", "w1"}, {"b"}, use_onednn, {1.23f, scale_out});
+  SetOp(&prog, "dequantize", "Dequant1", {"b"}, {"c"}, use_onednn, {scale});
+  SetOp(&prog, "concat", "Concat1", {"c"}, {"d"}, use_onednn);
   return prog;
 }
 
 // a->fc->b
 // b->Dequant1->c
 // b->fc->d
-ProgramDesc BuildFcDequantFcProgramDesc(bool use_mkldnn,
+ProgramDesc BuildFcDequantFcProgramDesc(bool use_onednn,
                                         float scale_out,
                                         float scale) {
   ProgramDesc prog;
   for (auto& v : variable_names) {
     prog.MutableBlock(0)->Var(v);
   }
-  SetOp(&prog, "fc", "Fc1", {"a", "w1"}, {"b"}, use_mkldnn, {1.23f, scale_out});
-  SetOp(&prog, "dequantize", "Dequant1", {"b"}, {"c"}, use_mkldnn, {scale});
-  SetOp(&prog, "fc", "Fc2", {"b", "w2"}, {"d"}, use_mkldnn, {scale_out, 2.34f});
+  SetOp(&prog, "fc", "Fc1", {"a", "w1"}, {"b"}, use_onednn, {1.23f, scale_out});
+  SetOp(&prog, "dequantize", "Dequant1", {"b"}, {"c"}, use_onednn, {scale});
+  SetOp(&prog, "fc", "Fc2", {"b", "w2"}, {"d"}, use_onednn, {scale_out, 2.34f});
   return prog;
 }
 
 // a->Conv1->b
 // b->Dequant1(Scale1)->c
 // b->Conv2->d
-ProgramDesc BuildConvDequantConvProgramDesc(bool use_mkldnn,
+ProgramDesc BuildConvDequantConvProgramDesc(bool use_onednn,
                                             float scale_out,
                                             float scale) {
   ProgramDesc prog;
   for (auto& v : variable_names) {
     prog.MutableBlock(0)->Var(v);
   }
-  SetOp(&prog, "conv2d", "Conv1", {"a"}, {"b"}, use_mkldnn, {1.23f, scale_out});
-  SetOp(&prog, "dequantize", "Dequant1", {"b"}, {"c"}, use_mkldnn, {scale});
-  SetOp(&prog, "conv2d", "Conv2", {"b"}, {"d"}, use_mkldnn);
+  SetOp(&prog, "conv2d", "Conv1", {"a"}, {"b"}, use_onednn, {1.23f, scale_out});
+  SetOp(&prog, "dequantize", "Dequant1", {"b"}, {"c"}, use_onednn, {scale});
+  SetOp(&prog, "conv2d", "Conv2", {"b"}, {"d"}, use_onednn);
   return prog;
 }
 
@@ -544,27 +544,27 @@ ProgramDesc BuildConvDequantConvProgramDesc(bool use_mkldnn,
 // b->Quant1(Scale1)->c->fc->f
 // b->Quant2(Scale2)->d->fc->g
 // b->concat->e
-ProgramDesc BuildMultipleQuantizeProgramDesc(bool use_mkldnn,
+ProgramDesc BuildMultipleQuantizeProgramDesc(bool use_onednn,
                                              float first_scale,
                                              float second_scale) {
   ProgramDesc prog;
   for (auto& v : variable_names) {
     prog.MutableBlock(0)->Var(v);
   }
-  SetOp(&prog, "concat", "Concat1", {"a"}, {"b"}, use_mkldnn);
+  SetOp(&prog, "concat", "Concat1", {"a"}, {"b"}, use_onednn);
   SetOp(
-      &prog, "quantize", "Quantize1", {"b"}, {"c"}, use_mkldnn, {first_scale});
+      &prog, "quantize", "Quantize1", {"b"}, {"c"}, use_onednn, {first_scale});
   SetOp(
-      &prog, "quantize", "Quantize2", {"b"}, {"d"}, use_mkldnn, {second_scale});
-  SetOp(&prog, "concat", "Concat2", {"b"}, {"e"}, use_mkldnn);
+      &prog, "quantize", "Quantize2", {"b"}, {"d"}, use_onednn, {second_scale});
+  SetOp(&prog, "concat", "Concat2", {"b"}, {"e"}, use_onednn);
   SetOp(
-      &prog, "fc", "Fc1", {"c", "w1"}, {"f"}, use_mkldnn, {first_scale, 1.23f});
+      &prog, "fc", "Fc1", {"c", "w1"}, {"f"}, use_onednn, {first_scale, 1.23f});
   SetOp(&prog,
         "fc",
         "Fc2",
         {"d", "w2"},
         {"g"},
-        use_mkldnn,
+        use_onednn,
         {second_scale, 2.34f});
 
   return prog;
@@ -572,7 +572,7 @@ ProgramDesc BuildMultipleQuantizeProgramDesc(bool use_mkldnn,
 
 // a->Dequant->b
 // b->Scale->c
-ProgramDesc BuildDequantScaleProgramDesc(bool use_mkldnn,
+ProgramDesc BuildDequantScaleProgramDesc(bool use_onednn,
                                          float dequant_scale,
                                          float scale_scale,
                                          float bias) {
@@ -585,16 +585,16 @@ ProgramDesc BuildDequantScaleProgramDesc(bool use_mkldnn,
         "Dequant",
         {"a"},
         {"b"},
-        use_mkldnn,
+        use_onednn,
         {dequant_scale});
-  SetOp(&prog, "scale", "Scale", {"b"}, {"c"}, use_mkldnn, {scale_scale}, bias);
+  SetOp(&prog, "scale", "Scale", {"b"}, {"c"}, use_onednn, {scale_scale}, bias);
 
   return prog;
 }
 
 // a->Scale->b
 // b->Quant->c
-ProgramDesc BuildScaleQuantProgramDesc(bool use_mkldnn,
+ProgramDesc BuildScaleQuantProgramDesc(bool use_onednn,
                                        float scale_scale,
                                        float quant_scale,
                                        float bias) {
@@ -602,27 +602,27 @@ ProgramDesc BuildScaleQuantProgramDesc(bool use_mkldnn,
   for (auto& v : variable_names) {
     prog.MutableBlock(0)->Var(v);
   }
-  SetOp(&prog, "scale", "Scale", {"a"}, {"b"}, use_mkldnn, {scale_scale}, bias);
-  SetOp(&prog, "quantize", "Quant", {"b"}, {"c"}, use_mkldnn, {quant_scale});
+  SetOp(&prog, "scale", "Scale", {"a"}, {"b"}, use_onednn, {scale_scale}, bias);
+  SetOp(&prog, "quantize", "Quant", {"b"}, {"c"}, use_onednn, {quant_scale});
 
   return prog;
 }
 
 // {x,y}->Matmul->b
 // b->Dequant->c
-ProgramDesc BuildMatmulDequantProgramDesc(bool use_mkldnn,
+ProgramDesc BuildMatmulDequantProgramDesc(bool use_onednn,
                                           float dequant_scale) {
   ProgramDesc prog;
   for (auto& v : variable_names) {
     prog.MutableBlock(0)->Var(v);
   }
-  SetOp(&prog, "matmul", "Matmul", {"x", "y"}, {"b"}, use_mkldnn);
+  SetOp(&prog, "matmul", "Matmul", {"x", "y"}, {"b"}, use_onednn);
   SetOp(&prog,
         "dequantize",
         "Dequant",
         {"b"},
         {"c"},
-        use_mkldnn,
+        use_onednn,
         {dequant_scale});
 
   return prog;
@@ -632,7 +632,7 @@ ProgramDesc BuildMatmulDequantProgramDesc(bool use_mkldnn,
 // c->Requant2->d->Fc->e
 // f->Requant3->g->Conv->h
 // {b,e,h}->Concat->i
-ProgramDesc BuildRequantOpProgramDesc(bool use_mkldnn,
+ProgramDesc BuildRequantOpProgramDesc(bool use_onednn,
                                       float requant_scale_in,
                                       float op_scale_in,
                                       float op_scale_out) {
@@ -645,67 +645,67 @@ ProgramDesc BuildRequantOpProgramDesc(bool use_mkldnn,
         "Requant1",
         {"a"},
         {"x"},
-        use_mkldnn,
+        use_onednn,
         {requant_scale_in, op_scale_in});
   SetOp(&prog,
         "matmul",
         "Matmul",
         {"x", "y"},
         {"b"},
-        use_mkldnn,
+        use_onednn,
         {op_scale_in, op_scale_out});
   SetOp(&prog,
         "requantize",
         "Requant2",
         {"c"},
         {"d"},
-        use_mkldnn,
+        use_onednn,
         {requant_scale_in, op_scale_in});
   SetOp(&prog,
         "fc",
         "Fc",
         {"d", "w1"},
         {"e"},
-        use_mkldnn,
+        use_onednn,
         {op_scale_in, op_scale_out});
   SetOp(&prog,
         "requantize",
         "Requant3",
         {"f"},
         {"g"},
-        use_mkldnn,
+        use_onednn,
         {requant_scale_in, op_scale_in});
   SetOp(&prog,
         "conv2d",
         "Conv",
         {"g"},
         {"h"},
-        use_mkldnn,
+        use_onednn,
         {op_scale_in, op_scale_out});
-  SetOp(&prog, "concat", "Concat", {"b", "e", "h"}, {"i"}, use_mkldnn);
+  SetOp(&prog, "concat", "Concat", {"b", "e", "h"}, {"i"}, use_onednn);
 
   return prog;
 }
 
 // a->Quant->b
 // b->Conv2d->c
-ProgramDesc BuildQuantConv2dProgramDesc(const bool& use_mkldnn,
+ProgramDesc BuildQuantConv2dProgramDesc(const bool& use_onednn,
                                         const float& quant_scale,
-                                        const std::string& mkldnn_data_type) {
+                                        const std::string& onednn_data_type) {
   ProgramDesc prog;
   for (auto& v : variable_names) {
     prog.MutableBlock(0)->Var(v);
   }
-  SetOp(&prog, "quantize", "Quant", {"a"}, {"b"}, use_mkldnn, {quant_scale});
+  SetOp(&prog, "quantize", "Quant", {"a"}, {"b"}, use_onednn, {quant_scale});
   SetOp(&prog,
         "conv2d",
         "Conv2d",
         {"b", "filter"},
         {"c"},
-        use_mkldnn,
+        use_onednn,
         {},
         0.0f,
-        mkldnn_data_type);
+        onednn_data_type);
 
   return prog;
 }
@@ -834,11 +834,11 @@ void IsForceFp32OutputTest(const ProgramDesc& prog,
 TEST(CpuQuantizeSquashPass, equal_scales) {
   auto scale_out = 1.234f;
   auto scale = 2.345f;
-  auto use_mkldnn = true;
+  auto use_onednn = true;
   // Remove 4 nodes: Dequant, Quant, e, f
   auto remove_nodes = 4;
 
-  CountNodeTest(BuildConvRequantProgramDesc(use_mkldnn, scale_out, scale),
+  CountNodeTest(BuildConvRequantProgramDesc(use_onednn, scale_out, scale),
                 remove_nodes);
 }
 
@@ -848,14 +848,14 @@ TEST(CpuQuantizeSquashPass, equal_scales) {
 TEST(CpuQuantizeSquashPass, unequal_scales) {
   auto scale_out = 1.230f;
   auto scale_in = 2.34f;
-  auto use_mkldnn = true;
+  auto use_onednn = true;
   // Remove 4 nodes: Dequant, Quant, e, d
   auto remove_nodes = 4;
 
-  CountNodeTest(BuildConvRequantProgramDesc(use_mkldnn, scale_out, scale_in),
+  CountNodeTest(BuildConvRequantProgramDesc(use_onednn, scale_out, scale_in),
                 remove_nodes);
 
-  EqualScaleTest(BuildConvRequantProgramDesc(use_mkldnn, scale_out, scale_in),
+  EqualScaleTest(BuildConvRequantProgramDesc(use_onednn, scale_out, scale_in),
                  "Conv1",
                  "Scale_out",
                  scale_in);
@@ -873,10 +873,10 @@ TEST(CpuQuantizeSquashPass, op_requantize_squash) {
   auto requant_scale1 = 2.234f;
   auto requant_scale2 = 3.234f;
   auto requant_scale3 = 4.234f;
-  auto use_mkldnn = true;
+  auto use_onednn = true;
   // Remove 4 nodes: b, Requant1, e, Requant2, g, Requant3
   auto remove_nodes = 6;
-  auto program_desc = BuildOpRequantProgramDesc(use_mkldnn,
+  auto program_desc = BuildOpRequantProgramDesc(use_onednn,
                                                 conv_scale,
                                                 fc_scale,
                                                 matmul_scale,
@@ -903,16 +903,16 @@ TEST(CpuQuantizeSquashPass, branch_to_equal_unequal_and_fp32) {
   auto scale_out = 1.0f;
   auto scale = 1.2345f;
   auto scale2 = 21.0f;
-  auto use_mkldnn = true;
+  auto use_onednn = true;
   // Remove 3 nodes: Quant1, c, Quant2,
   // Insert 1 node: Requant
   auto remove_nodes = 2;
 
   CountNodeTest(BuildConvMultiOutputProgramDesc(
-                    use_mkldnn, scale_out, scale, scale, scale2),
+                    use_onednn, scale_out, scale, scale, scale2),
                 remove_nodes);
   CheckRequantScalesTest(BuildConvMultiOutputProgramDesc(
-                             use_mkldnn, scale_out, scale, scale, scale2),
+                             use_onednn, scale_out, scale, scale, scale2),
                          scale,
                          scale2);
 }
@@ -924,16 +924,16 @@ TEST(CpuQuantizeSquashPass,
   auto scale_out = 1.0f;
   auto scale = 1.2345f;
   auto scale2 = 21.0f;
-  auto use_mkldnn = true;
+  auto use_onednn = true;
   // Remove 3 nodes: Dequant1, c, Quant
   // Insert 1 node: Requant
   auto remove_nodes = 2;
 
   CountNodeTest(
-      BuildConcatDequantQuantProgramDesc(use_mkldnn, scale_out, scale, scale2),
+      BuildConcatDequantQuantProgramDesc(use_onednn, scale_out, scale, scale2),
       remove_nodes);
   CheckRequantScalesTest(
-      BuildConcatDequantQuantProgramDesc(use_mkldnn, scale_out, scale, scale2),
+      BuildConcatDequantQuantProgramDesc(use_onednn, scale_out, scale, scale2),
       scale,
       scale2);
 }
@@ -945,11 +945,11 @@ TEST(CpuQuantizeSquashPass, more_than_one_conv_out_outputs) {
   auto scale_out = 1.0f;
   auto scale = 1.2345f;
   auto scale2 = 21.0f;
-  auto use_mkldnn = true;
+  auto use_onednn = true;
   // nothing change
   auto remove_nodes = 0;
   CountNodeTest(
-      BuildConvMultiRequantProgramDesc(use_mkldnn, scale_out, scale, scale2),
+      BuildConvMultiRequantProgramDesc(use_onednn, scale_out, scale, scale2),
       remove_nodes);
 }
 
@@ -957,13 +957,13 @@ TEST(CpuQuantizeSquashPass, more_than_one_conv_out_outputs) {
 TEST(CpuQuantizeSquashPass, conv_dequant_only_one_output) {
   auto scale_out = 1.0f;
   auto scale = 1.2345f;
-  auto use_mkldnn = true;
+  auto use_onednn = true;
   // remove 2 nodes: Dequant1, c
   auto remove_nodes = 2;
-  CountNodeTest(BuildConvDequantConcatProgramDesc(use_mkldnn, scale_out, scale),
+  CountNodeTest(BuildConvDequantConcatProgramDesc(use_onednn, scale_out, scale),
                 remove_nodes);
   IsForceFp32OutputTest(
-      BuildConvDequantConcatProgramDesc(use_mkldnn, scale_out, scale),
+      BuildConvDequantConcatProgramDesc(use_onednn, scale_out, scale),
       "conv2d",
       true);
 }
@@ -972,13 +972,13 @@ TEST(CpuQuantizeSquashPass, conv_dequant_only_one_output) {
 TEST(CpuQuantizeSquashPass, conv_dequant_more_than_one_op_after_conv) {
   auto scale_out = 1.0f;
   auto scale = 1.2345f;
-  auto use_mkldnn = true;
+  auto use_onednn = true;
   // nothing change
   auto remove_nodes = 0;
-  CountNodeTest(BuildConvDequantConvProgramDesc(use_mkldnn, scale_out, scale),
+  CountNodeTest(BuildConvDequantConvProgramDesc(use_onednn, scale_out, scale),
                 remove_nodes);
   IsForceFp32OutputTest(
-      BuildConvDequantConvProgramDesc(use_mkldnn, scale_out, scale),
+      BuildConvDequantConvProgramDesc(use_onednn, scale_out, scale),
       "conv2d",
       false);
 }
@@ -990,13 +990,13 @@ TEST(CpuQuantizeSquashPass, conv_dequant_more_than_one_op_after_conv) {
 TEST(CpuQuantizeSquashPass, fc_dequant_only_one_output) {
   auto scale_out = 1.0f;
   auto scale = 1.2345f;
-  auto use_mkldnn = true;
+  auto use_onednn = true;
   // remove 2 nodes: b, Dequant1
   auto remove_nodes = 2;
-  CountNodeTest(BuildFcDequantConcatProgramDesc(use_mkldnn, scale_out, scale),
+  CountNodeTest(BuildFcDequantConcatProgramDesc(use_onednn, scale_out, scale),
                 remove_nodes);
   IsForceFp32OutputTest(
-      BuildFcDequantConcatProgramDesc(use_mkldnn, scale_out, scale),
+      BuildFcDequantConcatProgramDesc(use_onednn, scale_out, scale),
       "fc",
       true);
 }
@@ -1005,13 +1005,13 @@ TEST(CpuQuantizeSquashPass, fc_dequant_only_one_output) {
 TEST(CpuQuantizeSquashPass, fc_dequant_more_than_one_op_after_dequant) {
   auto scale_out = 1.0f;
   auto scale = 1.2345f;
-  auto use_mkldnn = true;
+  auto use_onednn = true;
   // nothing change
   auto remove_nodes = 0;
-  CountNodeTest(BuildFcDequantFcProgramDesc(use_mkldnn, scale_out, scale),
+  CountNodeTest(BuildFcDequantFcProgramDesc(use_onednn, scale_out, scale),
                 remove_nodes);
   IsForceFp32OutputTest(
-      BuildFcDequantFcProgramDesc(use_mkldnn, scale_out, scale), "fc", false);
+      BuildFcDequantFcProgramDesc(use_onednn, scale_out, scale), "fc", false);
 }
 
 // a->Concat1->b
@@ -1022,11 +1022,11 @@ TEST(CpuQuantizeSquashPass, fc_dequant_more_than_one_op_after_dequant) {
 TEST(CpuQuantizeSquashPass, quantize_with_same_scale) {
   auto first_scale = 1.2345f;
   auto second_scale = 1.2345f;
-  auto use_mkldnn = true;
+  auto use_onednn = true;
   // remove nodes: Quantize2 + d
   auto remove_nodes = 1 + 1;
   CountNodeTest(
-      BuildMultipleQuantizeProgramDesc(use_mkldnn, first_scale, second_scale),
+      BuildMultipleQuantizeProgramDesc(use_onednn, first_scale, second_scale),
       remove_nodes);
 }
 
@@ -1034,11 +1034,11 @@ TEST(CpuQuantizeSquashPass, quantize_with_same_scale) {
 TEST(CpuQuantizeSquashPass, quantize_with_different_scale) {
   auto first_scale = 1.2345f;
   auto second_scale = 1.5432f;
-  auto use_mkldnn = true;
+  auto use_onednn = true;
   // nothing change
   auto remove_nodes = 0;
   CountNodeTest(
-      BuildMultipleQuantizeProgramDesc(use_mkldnn, first_scale, second_scale),
+      BuildMultipleQuantizeProgramDesc(use_onednn, first_scale, second_scale),
       remove_nodes);
 }
 
@@ -1047,14 +1047,14 @@ TEST(CpuQuantizeSquashPass, dequantize_scale_with_no_bias) {
   auto dequant_scale = 1.2345f;
   auto scale_scale = 1.5432f;
   auto bias = 0.0f;
-  auto use_mkldnn = true;
+  auto use_onednn = true;
   // remove: dequant out, scale op
   auto remove_nodes = 2;
   CountNodeTest(BuildDequantScaleProgramDesc(
-                    use_mkldnn, dequant_scale, scale_scale, bias),
+                    use_onednn, dequant_scale, scale_scale, bias),
                 remove_nodes);
   EqualScaleTest(BuildDequantScaleProgramDesc(
-                     use_mkldnn, dequant_scale, scale_scale, bias),
+                     use_onednn, dequant_scale, scale_scale, bias),
                  "Dequant",
                  "Scale",
                  dequant_scale / scale_scale);
@@ -1065,14 +1065,14 @@ TEST(CpuQuantizeSquashPass, dequantize_scale_with_bias) {
   auto dequant_scale = 1.2345f;
   auto scale_scale = 1.5432f;
   auto bias = 1.0f;
-  auto use_mkldnn = true;
+  auto use_onednn = true;
   // nothing change
   auto remove_nodes = 0;
   CountNodeTest(BuildDequantScaleProgramDesc(
-                    use_mkldnn, dequant_scale, scale_scale, bias),
+                    use_onednn, dequant_scale, scale_scale, bias),
                 remove_nodes);
   EqualScaleTest(BuildDequantScaleProgramDesc(
-                     use_mkldnn, dequant_scale, scale_scale, bias),
+                     use_onednn, dequant_scale, scale_scale, bias),
                  "Dequant",
                  "Scale",
                  dequant_scale);
@@ -1083,14 +1083,14 @@ TEST(CpuQuantizeSquashPass, scale_with_no_bias_quantize) {
   constexpr auto scale_scale = 1.5432f;
   constexpr auto quant_scale = 1.2345f;
   constexpr auto bias = 0.0f;
-  auto use_mkldnn = true;
+  auto use_onednn = true;
   // remove: dequant out, scale op
   auto remove_nodes = 2;
   CountNodeTest(
-      BuildScaleQuantProgramDesc(use_mkldnn, scale_scale, quant_scale, bias),
+      BuildScaleQuantProgramDesc(use_onednn, scale_scale, quant_scale, bias),
       remove_nodes);
   EqualScaleTest(
-      BuildScaleQuantProgramDesc(use_mkldnn, scale_scale, quant_scale, bias),
+      BuildScaleQuantProgramDesc(use_onednn, scale_scale, quant_scale, bias),
       "Scale",
       "Quant",
       quant_scale * scale_scale);
@@ -1098,22 +1098,22 @@ TEST(CpuQuantizeSquashPass, scale_with_no_bias_quantize) {
 
 TEST(CpuQuantizeSquashPass, matmul_with_dequant) {
   auto dequant_scale = 1.2345f;
-  auto use_mkldnn = true;
+  auto use_onednn = true;
   // remove: matmul_out, dequant_op
   auto remove_nodes = 2;
-  CountNodeTest(BuildMatmulDequantProgramDesc(use_mkldnn, dequant_scale),
+  CountNodeTest(BuildMatmulDequantProgramDesc(use_onednn, dequant_scale),
                 remove_nodes);
   IsForceFp32OutputTest(
-      BuildMatmulDequantProgramDesc(use_mkldnn, dequant_scale), "matmul", true);
+      BuildMatmulDequantProgramDesc(use_onednn, dequant_scale), "matmul", true);
 }
 
 TEST(CpuQuantizeSquashPass, requantize_with_matmul_fc_conv) {
-  auto use_mkldnn = true;
+  auto use_onednn = true;
   auto requant_scale_in = 1.2f, op_scale_in = 2.3f, op_scale_out = 3.4f;
   // remove: 3 requant ops + 3 requant outs
   auto remove_nodes = 6;
   auto program_desc = BuildRequantOpProgramDesc(
-      use_mkldnn, requant_scale_in, op_scale_in, op_scale_out);
+      use_onednn, requant_scale_in, op_scale_in, op_scale_out);
   CountNodeTest(program_desc, remove_nodes);
   EqualScaleTest(program_desc, "Matmul", "Scale_x", requant_scale_in);
   EqualScaleTest(program_desc, "Fc", "Scale_in", requant_scale_in);
@@ -1122,12 +1122,12 @@ TEST(CpuQuantizeSquashPass, requantize_with_matmul_fc_conv) {
 
 TEST(CpuQuantizeSquashPass, quant_bf16_conv2d) {
   auto quant_scale = 1.0f;
-  auto use_mkldnn = true;
-  auto mkldnn_data_type = "bfloat16";
+  auto use_onednn = true;
+  auto onednn_data_type = "bfloat16";
   // remove: quant_op, conv_in
   auto remove_nodes = 2;
   CountNodeTest(
-      BuildQuantConv2dProgramDesc(use_mkldnn, quant_scale, mkldnn_data_type),
+      BuildQuantConv2dProgramDesc(use_onednn, quant_scale, onednn_data_type),
       remove_nodes);
 }
 

--- a/paddle/fluid/framework/ir/onednn/depthwise_conv_onednn_pass_tester.cc
+++ b/paddle/fluid/framework/ir/onednn/depthwise_conv_onednn_pass_tester.cc
@@ -24,10 +24,10 @@ void SetOp(ProgramDesc* prog,
            const std::string& name,
            const std::vector<std::string>& inputs,
            const std::vector<std::string>& outputs,
-           bool use_mkldnn = false) {
+           bool use_onednn = false) {
   auto* op = prog->MutableBlock(0)->AppendOp();
   op->SetType(type);
-  op->SetAttr("use_mkldnn", use_mkldnn);
+  op->SetAttr("use_mkldnn", use_onednn);
   op->SetAttr("name", name);
   op->SetAttr("groups", 1);
   op->SetAttr("padding_algorithm", std::string("EXPLICIT"));
@@ -41,10 +41,10 @@ void SetOp(ProgramDesc* prog,
   op->SetOutput("Output", outputs);
 }
 
-// (a, weights, bias)->depthwise conv mkldnn->b
-// (b, weights2, bias2)->depthwise conv no mkldnn->c
-// (c, weights3, bias3)->conv mkldnn->d
-// (d, weights3, bias3)->conv no mkldnn->e
+// (a, weights, bias)->depthwise conv onednn->b
+// (b, weights2, bias2)->depthwise conv no onednn->c
+// (c, weights3, bias3)->conv onednn->d
+// (d, weights3, bias3)->conv no onednn->e
 ProgramDesc BuildProgramDesc() {
   ProgramDesc prog;
   for (auto& v : std::vector<std::string>({"a",


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
paddle/fluid/framework/ir/onednn 单测修改变量 use_mkldnn 为 use_onednn