### PR TITLE
[0-size Tensor Job2 No.53] Add 0-size Tensor support for paddle.nn.functional.adaptive_log_softmax_with_loss [fluid_ops]

### DIFF
--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -4636,7 +4636,7 @@ def adaptive_log_softmax_with_loss(
     target_dim = label.dim()
 
     if target_dim == 1:
-        if input.shape[0] != label.shape[0]:
+        if input.shape[0] != label.shape[0] and label.shape[0] != 0:
             raise ValueError(
                 'Input and label should have the same size '
                 'in the batch dimension.'
@@ -4733,9 +4733,10 @@ def adaptive_log_softmax_with_loss(
         x=input, weight=head_weight, bias=head_bias
     )
     head_logprob = paddle.nn.functional.log_softmax(head_output, axis=1)
-    output += paddle.take_along_axis(
-        head_logprob, gather_inds.unsqueeze(1), axis=1
-    ).squeeze()
+    if gather_inds.size != 0:
+        output += paddle.take_along_axis(
+            head_logprob, gather_inds.unsqueeze(1), axis=1
+        ).squeeze()
     loss = (-output).mean()
 
     if not is_batched:

--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -4733,7 +4733,9 @@ def adaptive_log_softmax_with_loss(
         x=input, weight=head_weight, bias=head_bias
     )
     head_logprob = paddle.nn.functional.log_softmax(head_output, axis=1)
-    if gather_inds.size != 0:
+    if paddle.in_dynamic_mode() and gather_inds.size == 0:
+        pass
+    else:
         output += paddle.take_along_axis(
             head_logprob, gather_inds.unsqueeze(1), axis=1
         ).squeeze()

--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -4733,9 +4733,7 @@ def adaptive_log_softmax_with_loss(
         x=input, weight=head_weight, bias=head_bias
     )
     head_logprob = paddle.nn.functional.log_softmax(head_output, axis=1)
-    if paddle.in_dynamic_mode() and gather_inds.size == 0:
-        pass
-    else:
+    if gather_inds.size != 0:
         output += paddle.take_along_axis(
             head_logprob, gather_inds.unsqueeze(1), axis=1
         ).squeeze()

--- a/test/legacy_test/test_adaptive_log_softmax_with_loss.py
+++ b/test/legacy_test/test_adaptive_log_softmax_with_loss.py
@@ -393,6 +393,7 @@ class TestNNAdaptiveLogSoftmaxWithLossAPI(unittest.TestCase):
             assert not np.any(before != after)
 
     def test_cluster(self):
+        paddle.disable_static()
         model = SimpleModel(16, 20, [5, 10, 15], div_value=2.0)
         x = paddle.randn((128, 16))
         y = paddle.randint(low=0, high=20, shape=[128])

--- a/test/legacy_test/test_adaptive_log_softmax_with_loss.py
+++ b/test/legacy_test/test_adaptive_log_softmax_with_loss.py
@@ -574,5 +574,29 @@ class TestNNAdaptiveLogSoftmaxWithLossAPI(unittest.TestCase):
         np.allclose(analytic_grads, grad_numerical, rtol=1e-5, atol=1e-5)
 
 
+class TestAdaptiveLogSoftmaxWithLossAPI_ZeroSize(unittest.TestCase):
+    def setUp(self):
+        self.places = get_places()
+
+    def test_dygraph_api(self):
+        for place in self.places:
+            paddle.disable_static(place)
+            input = paddle.to_tensor(np.random.random([4, 8]))
+            label = paddle.to_tensor(np.random.random([0]))
+            head_weight = paddle.to_tensor(np.random.random([8, 3]))
+            tail_weights = [
+                [
+                    paddle.to_tensor(np.random.random([8, 4])),
+                    paddle.to_tensor(np.random.random([4, 2])),
+                ]
+            ]
+            cutoffs = [2, 4]
+            out = paddle.nn.functional.adaptive_log_softmax_with_loss(
+                input, label, head_weight, tail_weights, cutoffs
+            )
+            np.testing.assert_allclose(np.array([]), out[0].numpy())
+            paddle.enable_static()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/legacy_test/test_adaptive_log_softmax_with_loss.py
+++ b/test/legacy_test/test_adaptive_log_softmax_with_loss.py
@@ -595,7 +595,6 @@ class TestAdaptiveLogSoftmaxWithLossAPI_ZeroSize(unittest.TestCase):
                 input, label, head_weight, tail_weights, cutoffs
             )
             np.testing.assert_allclose(np.array([]), out[0].numpy())
-            paddle.enable_static()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修改python判断，增加单测，gather_inds 为0-size时，output为创建的tensor，没有反向，单测没有测试反向
<img width="711" height="244" alt="image" src="https://github.com/user-attachments/assets/41aaf637-a8ab-4fbd-8937-c4f9802171d6" />

PaddleAPITest测试通过
<img width="1303" height="163" alt="image" src="https://github.com/user-attachments/assets/c12b455e-0ec8-4f7d-a1ab-77da7d9bd1ef" />
