### PR TITLE
[DeepEP] Set multicast=2 for deep_ep kernels

### DIFF
--- a/paddle/fluid/distributed/collective/deep_ep/kernels/launch.cuh
+++ b/paddle/fluid/distributed/collective/deep_ep/kernels/launch.cuh
@@ -24,11 +24,15 @@
 #ifndef SETUP_LAUNCH_CONFIG
 #define SETUP_LAUNCH_CONFIG(num_sms, num_threads, stream)                     \
   cudaLaunchConfig_t cfg = {(num_sms), (num_threads), 0, stream, nullptr, 0}; \
-  cudaLaunchAttribute attr[1];                                                \
+  cudaLaunchAttribute attr[2];                                                \
   attr[0].id = cudaLaunchAttributeCooperative;                                \
   attr[0].val.cooperative = 1;                                                \
+  attr[1].id = cudaLaunchAttributeClusterDimension;                           \
+  attr[1].val.clusterDim.x = (num_sms % 2 == 0 ? 2 : 1);                      \
+  attr[1].val.clusterDim.y = 1;                                               \
+  attr[1].val.clusterDim.z = 1;                                               \
   cfg.attrs = attr;                                                           \
-  cfg.numAttrs = 1
+  cfg.numAttrs = 2
 #endif
 
 #ifndef LAUNCH_KERNEL


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Communication Library


### PR Types
Performance


### Description
This is a partial cherry-pick from https://github.com/deepseek-ai/DeepEP/pull/283

为了使deep_ep在与deep_gemm进行overlap时使用相同的SM分配策略，避免因为不连续分配SM导致deep_gemm的kernel无法launch，这里将deep_ep的kernel也设置成multicast=2，即使deep_ep并未使用multicast功能

Pcard-85711