### PR TITLE
[Typing] support Numeric with bool in type hints

### DIFF
--- a/paddle/fluid/pybind/eager_utils.cc
+++ b/paddle/fluid/pybind/eager_utils.cc
@@ -2040,8 +2040,8 @@ paddle::experimental::Scalar CastNumpy2Scalar(PyObject* obj,
   } else {
     PADDLE_THROW(common::errors::InvalidArgument(
         "%s(): argument (position %d) must be "
-        "numpy.float32/float64, numpy.int32/int64, numpy.complex64/complex128, "
-        "but got %s",
+        "numpy.float16/float32/float64, numpy.int32/int64, "
+        "numpy.complex64/complex128, but got %s",
         op_type,
         arg_pos + 1,
         type_name));  // NOLINT

--- a/python/paddle/_typing/basic.py
+++ b/python/paddle/_typing/basic.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
     from paddle.regularizer import WeightDecayRegularizer
 
 
-Numeric: TypeAlias = Union[int, float, complex, np.number, "Tensor"]
+Numeric: TypeAlias = Union[int, float, bool, complex, np.number, "Tensor"]
 TensorLike: TypeAlias = Union[npt.NDArray[Any], "Tensor", Numeric]
 _TensorIndexItem: TypeAlias = Union[
     None, bool, int, slice, "Tensor", EllipsisType

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -629,7 +629,7 @@ def transpose(
         return out
 
 
-def unstack(x: Tensor, axis: int = 0, num: int | None = None) -> Tensor:
+def unstack(x: Tensor, axis: int = 0, num: int | None = None) -> list[Tensor]:
     """
     This layer unstacks input Tensor :code:`x` into several Tensors along :code:`axis`.
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
- support Numeric with bool in type hints
  torch 中 Number 相关注解都会加上 bool，numpy 和 jax 中是 Scalar，也包含了 bool
  主要是 https://github.com/PaddlePaddle/Paddle/pull/74127 要用到了
- fix unstack type hints
- improve CastNumpy2Scalar's error message