### PR TITLE
[Slice] Fix maksed_fill_grad when x_grad is null

### DIFF
--- a/paddle/phi/kernels/cpu/masked_fill_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/masked_fill_grad_kernel.cc
@@ -46,12 +46,12 @@ void MaskedFillGradKernel(const Context& dev_ctx,
     return;
   }
 
-  auto x_grad_dims = x_grad->dims();
+  auto x_dims = x.dims();
   auto mask_dims = mask.dims();
   bool expand_x = false;
   bool expand_value = false;
   auto expanded_size =
-      common::vectorize(funcs::BroadcastTwoDims(x_grad_dims, mask_dims, -1));
+      common::vectorize(funcs::BroadcastTwoDims(x_dims, mask_dims, -1));
 
   DenseTensor mask_expand;
   DenseTensor x_grad_expand;
@@ -65,12 +65,13 @@ void MaskedFillGradKernel(const Context& dev_ctx,
   } else {
     mask_expand = mask;
   }
-
-  if (x_grad->dims() != expanded_dims) {
-    x_grad_expand = Empty<T, Context>(dev_ctx, IntArray(expanded_size));
-    expand_x = true;
-  } else {
-    x_grad_expand = *x_grad;
+  if (x_grad) {
+    if (x_grad->dims() != expanded_dims) {
+      x_grad_expand = Empty<T, Context>(dev_ctx, IntArray(expanded_size));
+      expand_x = true;
+    } else {
+      x_grad_expand = *x_grad;
+    }
   }
 
   if (v_grad) {
@@ -78,7 +79,7 @@ void MaskedFillGradKernel(const Context& dev_ctx,
       value_grad_expand = Empty<T, Context>(dev_ctx, IntArray(expanded_size));
       expand_value = true;
     } else {
-      value_grad_expand = *x_grad;
+      value_grad_expand = *v_grad;
     }
   }
 

--- a/paddle/phi/kernels/gpu/masked_fill_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/masked_fill_grad_kernel.cu
@@ -319,7 +319,7 @@ void MaskedFillGradKernel(const Context& dev_ctx,
     return;
   }
   auto out_grad_dims = out_grad.dims();
-  auto x_grad_dims = x_grad->dims();
+  auto x_dims = x.dims();
   auto mask_dims = mask.dims();
   DenseTensor mask_expand;
   DenseTensor x_grad_expand;
@@ -327,10 +327,10 @@ void MaskedFillGradKernel(const Context& dev_ctx,
   bool expand_x = false;
   bool expand_v = false;
   auto expanded_size =
-      common::vectorize(funcs::BroadcastTwoDims(x_grad_dims, mask_dims, -1));
+      common::vectorize(funcs::BroadcastTwoDims(x_dims, mask_dims, -1));
   auto expanded_dims = common::make_ddim(expanded_size);
   bool flag = funcs::CanDispatchMaskFillShortcut(out_grad_dims, mask_dims);
-  if (expanded_dims != x_grad_dims) flag = false;
+  if (expanded_dims != x_dims) flag = false;
   if (v_grad && v_grad->dims() != expanded_dims && v_grad->numel() != 1)
     flag = false;
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-67164
修复 maksed_fill_grad 无法正确处理 x_grad 为 null 的情况