### PR TITLE
[0-size Tensor No.85] Add 0-size Tensor support for paddle.incubate.nn.functional.fused_matmul_bias

### DIFF
--- a/python/paddle/incubate/nn/functional/fused_matmul_bias.py
+++ b/python/paddle/incubate/nn/functional/fused_matmul_bias.py
@@ -72,18 +72,6 @@ def fused_matmul_bias(
     """
     if bias is None:
         return matmul(x, y, transpose_x, transpose_y, name)
-    if in_dynamic_mode():
-        return _legacy_C_ops.fused_gemm_epilogue(
-            x,
-            y,
-            bias,
-            'trans_x',
-            transpose_x,
-            'trans_y',
-            transpose_y,
-            'activation',
-            'none',
-        )
     if in_dynamic_or_pir_mode():
         out, _ = _C_ops.fused_gemm_epilogue(
             x, y, bias, transpose_x, transpose_y, "none"

--- a/python/paddle/incubate/nn/functional/fused_matmul_bias.py
+++ b/python/paddle/incubate/nn/functional/fused_matmul_bias.py
@@ -72,6 +72,18 @@ def fused_matmul_bias(
     """
     if bias is None:
         return matmul(x, y, transpose_x, transpose_y, name)
+    if in_dynamic_mode():
+        return _legacy_C_ops.fused_gemm_epilogue(
+            x,
+            y,
+            bias,
+            'trans_x',
+            transpose_x,
+            'trans_y',
+            transpose_y,
+            'activation',
+            'none',
+        )
     if in_dynamic_or_pir_mode():
         out, _ = _C_ops.fused_gemm_epilogue(
             x, y, bias, transpose_x, transpose_y, "none"


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
[0-size Tensor Job2 No.27] Add 0-size Tensor support for paddle.incubate.nn.functional.fused_linear
[0-size Tensor No.85] Add 0-size Tensor support for paddle.incubate.nn.functional.fused_matmul_bias
fused_linear 和 fused_matmul_bias 是相同API
<img width="1000" height="416" alt="image" src="https://github.com/user-attachments/assets/81bd1214-6b59-406d-ba2f-6da2efa83864" />

增加单测
PaddleAPITest测试通过
<img width="1309" height="288" alt="image" src="https://github.com/user-attachments/assets/4f98742a-f2b1-47be-b8c1-dca8ba3b8e03" />
