### PR TITLE
[0-size Retest] Fix var、std、selu api to support 0-size Tensor

### DIFF
--- a/paddle/phi/kernels/impl/selu_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/selu_grad_kernel_impl.h
@@ -28,6 +28,7 @@ void SeluGradKernel(const Context& dev_ctx,
   SeluGradFunctor<T> functor(
       out.data<T>(), dout.data<T>(), alpha, scale, dx_ptr);
   size_t limit = static_cast<size_t>(out.numel());
+  if (limit == 0) return;
   phi::funcs::ForRange<Context> for_range(dev_ctx, limit);
   for_range(functor);
 }

--- a/python/paddle/tensor/stat.py
+++ b/python/paddle/tensor/stat.py
@@ -211,8 +211,10 @@ def var(
     out /= n
 
     def _replace_nan(out):
-        out_nan = paddle.full_like(out, paddle.nan)
-        out_nan.stop_gradient = out.stop_gradient
+        indices = paddle.arange(out.numel(), dtype='int64')
+        out_nan = paddle.index_fill(
+            out.flatten(), indices, 0, float('nan')
+        ).reshape(out.shape)
         return out_nan
 
     if 0 in x.shape:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
 Bug fixes

### Description
<!-- Describe what you’ve done -->
修复复测发现的0-size问题
- var相关的api（var、std）grad为none
  
``` 
def _replace_nan(out):
        out_nan = paddle.full_like(out, paddle.nan)
        out_nan.stop_gradient = out.stop_gradient
        return out_nan 
``` 
full_like没有反向，导致梯度回传时回传不到输入x
- selu反向过程报cuda error 9

修复完paddleapitest回测
var
<img width="1078" height="340" alt="image" src="https://github.com/user-attachments/assets/9de4d693-98be-4b44-8cbc-4123bea0afab" />
selu
<img width="1218" height="392" alt="image" src="https://github.com/user-attachments/assets/fe7a54dc-6a47-4962-ae4d-e285b83dd007" />


pcard-67164
