### PR TITLE
[Fix Issue] fix issue 73668

### DIFF
--- a/paddle/phi/kernels/cpu/arange_kernel.cc
+++ b/paddle/phi/kernels/cpu/arange_kernel.cc
@@ -27,10 +27,6 @@ void ArangeFunc(const Context& dev_ctx,
                 const T& step_value,
                 DenseTensor* out) {
   int64_t size = 0;
-  if (isnan(end_value)) {
-    PADDLE_THROW(errors::InvalidArgument(
-        "end_value cannot be NaN in arange operation."));
-  }
   phi::funcs::GetSize(start_value, end_value, step_value, &size);
   out->Resize(common::make_ddim({size}));
   T* out_data = dev_ctx.template Alloc<T>(out);
@@ -62,6 +58,10 @@ void ArangeKernel(const Context& dev_ctx,
   T start_value = start.to<T>();
   T end_value = end.to<T>();
   T step_value = step.to<T>();
+  if (isnan(end_value)) {
+    PADDLE_THROW(errors::InvalidArgument(
+        "end_value cannot be NaN in arange operation."));
+  }
   ArangeFunc<T, Context>(dev_ctx, start_value, end_value, step_value, out);
 }
 

--- a/paddle/phi/kernels/cpu/arange_kernel.cc
+++ b/paddle/phi/kernels/cpu/arange_kernel.cc
@@ -27,6 +27,10 @@ void ArangeFunc(const Context& dev_ctx,
                 const T& step_value,
                 DenseTensor* out) {
   int64_t size = 0;
+  if (isnan(end_value)) {
+    PADDLE_THROW(errors::InvalidArgument(
+        "end_value cannot be NaN in arange operation."));
+  }
   phi::funcs::GetSize(start_value, end_value, step_value, &size);
   out->Resize(common::make_ddim({size}));
   T* out_data = dev_ctx.template Alloc<T>(out);

--- a/paddle/phi/kernels/cpu/arange_kernel.cc
+++ b/paddle/phi/kernels/cpu/arange_kernel.cc
@@ -58,9 +58,11 @@ void ArangeKernel(const Context& dev_ctx,
   T start_value = start.to<T>();
   T end_value = end.to<T>();
   T step_value = step.to<T>();
-  if (isnan(end_value)) {
-    PADDLE_THROW(errors::InvalidArgument(
-        "end_value cannot be NaN in arange operation."));
+  if constexpr (std::is_floating_point_v<T>) {
+    if (std::isnan(end_value)) {
+      PADDLE_THROW(phi::errors::InvalidArgument(
+          "The end value of arange cannot be NaN. Please check your input."));
+    }
   }
   ArangeFunc<T, Context>(dev_ctx, start_value, end_value, step_value, out);
 }

--- a/paddle/phi/kernels/gpu/arange_kernel.cu
+++ b/paddle/phi/kernels/gpu/arange_kernel.cu
@@ -94,10 +94,17 @@ void ArangeKernel(const Context& dev_ctx,
   T start_value = start.to<T>();
   T end_value = end.to<T>();
   T step_value = step.to<T>();
-  if (isnan(end_value)) {
-    PADDLE_THROW(errors::InvalidArgument(
-        "end_value cannot be NaN in arange operation."));
+#if defined(__CUDACC__) || defined(__HIPCC__)
+  if (::isnan(end_value)) {
+    PADDLE_THROW(phi::errors::InvalidArgument(
+        "The end value of arange cannot be NaN. Please check your input."));
   }
+#else
+  if (std::isnan(end_value)) {
+    PADDLE_THROW(phi::errors::InvalidArgument(
+        "The end value of arange cannot be NaN. Please check your input."));
+  }
+#endif
   ArangeNullaryKernel<T, Context>(
       dev_ctx, start_value, end_value, step_value, out);
 }

--- a/paddle/phi/kernels/gpu/arange_kernel.cu
+++ b/paddle/phi/kernels/gpu/arange_kernel.cu
@@ -70,6 +70,27 @@ void ArangeNullaryKernel(const Context& dev_ctx,
   MPType start_value_mpt = static_cast<MPType>(start_value);
   MPType end_value_mpt = static_cast<MPType>(end_value);
   MPType step_value_mpt = static_cast<MPType>(step_value);
+  if constexpr (std::is_same_v<T, float>) {
+    if (std::isnan(static_cast<float>(end_value))) {
+      PADDLE_THROW(phi::errors::InvalidArgument(
+          "The end value of arange cannot be NaN. Please check your input."));
+    }
+  } else if constexpr (std::is_same_v<T, double>) {
+    if (std::isnan(static_cast<double>(end_value))) {
+      PADDLE_THROW(phi::errors::InvalidArgument(
+          "The end value of arange cannot be NaN. Please check your input."));
+    }
+  } else if constexpr (std::is_same_v<T, phi::dtype::float16>) {
+    if (phi::dtype::isnan(static_cast<phi::dtype::float16>(end_value))) {
+      PADDLE_THROW(phi::errors::InvalidArgument(
+          "The end value of arange cannot be NaN. Please check your input."));
+    }
+  } else if constexpr (std::is_same_v<T, phi::dtype::bfloat16>) {
+    if (phi::dtype::isnan(static_cast<phi::dtype::bfloat16>(end_value))) {
+      PADDLE_THROW(phi::errors::InvalidArgument(
+          "The end value of arange cannot be NaN. Please check your input."));
+    }
+  }
   int64_t size = 0;
   phi::funcs::GetSize(start_value_mpt, end_value_mpt, step_value_mpt, &size);
   out->Resize(common::make_ddim({size}));
@@ -94,17 +115,27 @@ void ArangeKernel(const Context& dev_ctx,
   T start_value = start.to<T>();
   T end_value = end.to<T>();
   T step_value = step.to<T>();
-#if defined(__CUDACC__) || defined(__HIPCC__)
-  if (::isnan(end_value)) {
-    PADDLE_THROW(phi::errors::InvalidArgument(
-        "The end value of arange cannot be NaN. Please check your input."));
+  if constexpr (std::is_same_v<T, float>) {
+    if (std::isnan(end_value)) {
+      PADDLE_THROW(phi::errors::InvalidArgument(
+          "The end value of arange cannot be NaN. Please check your input."));
+    }
+  } else if constexpr (std::is_same_v<T, double>) {
+    if (std::isnan(end_value)) {
+      PADDLE_THROW(phi::errors::InvalidArgument(
+          "The end value of arange cannot be NaN. Please check your input."));
+    }
+  } else if constexpr (std::is_same_v<T, phi::dtype::float16>) {
+    if (phi::dtype::isnan(end_value)) {
+      PADDLE_THROW(phi::errors::InvalidArgument(
+          "The end value of arange cannot be NaN. Please check your input."));
+    }
+  } else if constexpr (std::is_same_v<T, phi::dtype::bfloat16>) {
+    if (phi::dtype::isnan(end_value)) {
+      PADDLE_THROW(phi::errors::InvalidArgument(
+          "The end value of arange cannot be NaN. Please check your input."));
+    }
   }
-#else
-  if (std::isnan(end_value)) {
-    PADDLE_THROW(phi::errors::InvalidArgument(
-        "The end value of arange cannot be NaN. Please check your input."));
-  }
-#endif
   ArangeNullaryKernel<T, Context>(
       dev_ctx, start_value, end_value, step_value, out);
 }

--- a/paddle/phi/kernels/gpu/arange_kernel.cu
+++ b/paddle/phi/kernels/gpu/arange_kernel.cu
@@ -80,16 +80,6 @@ void ArangeNullaryKernel(const Context& dev_ctx,
       PADDLE_THROW(phi::errors::InvalidArgument(
           "The end value of arange cannot be NaN. Please check your input."));
     }
-  } else if constexpr (std::is_same_v<T, phi::dtype::float16>) {
-    if (phi::dtype::isnan(static_cast<phi::dtype::float16>(end_value))) {
-      PADDLE_THROW(phi::errors::InvalidArgument(
-          "The end value of arange cannot be NaN. Please check your input."));
-    }
-  } else if constexpr (std::is_same_v<T, phi::dtype::bfloat16>) {
-    if (phi::dtype::isnan(static_cast<phi::dtype::bfloat16>(end_value))) {
-      PADDLE_THROW(phi::errors::InvalidArgument(
-          "The end value of arange cannot be NaN. Please check your input."));
-    }
   }
   int64_t size = 0;
   phi::funcs::GetSize(start_value_mpt, end_value_mpt, step_value_mpt, &size);
@@ -122,16 +112,6 @@ void ArangeKernel(const Context& dev_ctx,
     }
   } else if constexpr (std::is_same_v<T, double>) {
     if (std::isnan(end_value)) {
-      PADDLE_THROW(phi::errors::InvalidArgument(
-          "The end value of arange cannot be NaN. Please check your input."));
-    }
-  } else if constexpr (std::is_same_v<T, phi::dtype::float16>) {
-    if (phi::dtype::isnan(end_value)) {
-      PADDLE_THROW(phi::errors::InvalidArgument(
-          "The end value of arange cannot be NaN. Please check your input."));
-    }
-  } else if constexpr (std::is_same_v<T, phi::dtype::bfloat16>) {
-    if (phi::dtype::isnan(end_value)) {
       PADDLE_THROW(phi::errors::InvalidArgument(
           "The end value of arange cannot be NaN. Please check your input."));
     }

--- a/paddle/phi/kernels/gpu/arange_kernel.cu
+++ b/paddle/phi/kernels/gpu/arange_kernel.cu
@@ -94,6 +94,10 @@ void ArangeKernel(const Context& dev_ctx,
   T start_value = start.to<T>();
   T end_value = end.to<T>();
   T step_value = step.to<T>();
+  if (isnan(end_value)) {
+    PADDLE_THROW(errors::InvalidArgument(
+        "end_value cannot be NaN in arange operation."));
+  }
   ArangeNullaryKernel<T, Context>(
       dev_ctx, start_value, end_value, step_value, out);
 }

--- a/paddle/phi/kernels/xpu/arange_kernel.cc
+++ b/paddle/phi/kernels/xpu/arange_kernel.cc
@@ -32,10 +32,11 @@ void ArangeTensorKernel(const Context& dev_ctx,
       static_cast<MPType>(GetValue<T, Context>(dev_ctx, start));
   MPType end_value = static_cast<MPType>(GetValue<T, Context>(dev_ctx, end));
   MPType step_value = static_cast<MPType>(GetValue<T, Context>(dev_ctx, step));
-  if (std::isnan(end_value)) {
-    paddle::errors::InvalidArgument(
-        "end_value cannot be inf in arange operation.");
+  if (std::isnan(static_cast<float>(end_value))) {
+    PADDLE_THROW(phi::errors::InvalidArgument(
+        "The end value of arange cannot be NaN. Please check your input."));
   }
+
   int64_t size = 0;
   phi::funcs::GetSize(start_value, end_value, step_value, &size);
   out->Resize(common::make_ddim({size}));

--- a/paddle/phi/kernels/xpu/arange_kernel.cc
+++ b/paddle/phi/kernels/xpu/arange_kernel.cc
@@ -32,7 +32,10 @@ void ArangeTensorKernel(const Context& dev_ctx,
       static_cast<MPType>(GetValue<T, Context>(dev_ctx, start));
   MPType end_value = static_cast<MPType>(GetValue<T, Context>(dev_ctx, end));
   MPType step_value = static_cast<MPType>(GetValue<T, Context>(dev_ctx, step));
-
+  if (std::isnan(end_value)) {
+    paddle::errors::InvalidArgument(
+        "end_value cannot be inf in arange operation.");
+  }
   int64_t size = 0;
   phi::funcs::GetSize(start_value, end_value, step_value, &size);
   out->Resize(common::make_ddim({size}));


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
#73668 

according to pytorch:

```python
import torch
try:
    start = torch.tensor(0)
    end = torch.tensor(float('inf'))
    a = torch.arange(start, end, 1, dtype=torch.int32)
except RuntimeError as e:
    print(f"PyTorch error: {e}")
```
This will output something like:
```bash
PyTorch error: arange_cpu(): invalid 'end'  inf, must be numeric and finite
```

So add check in ArangeFunc.