### PR TITLE
[Accuracy diff No.102] Fix accuracy diff for paddle.lstsq API

### DIFF
--- a/paddle/phi/infermeta/binary.cc
+++ b/paddle/phi/infermeta/binary.cc
@@ -4231,7 +4231,10 @@ void LstsqInferMeta(const MetaTensor& x,
 
   rank->set_dims(common::make_ddim(batch_dims_vec));
 
-  if (m > n) {
+  if (m > n && driver != "gelsy") {
+    if (driver == "gelss" || driver == "gelsd") {
+      residuals->set_dims(common::make_ddim({-1}));
+    }
     batch_dims_vec.emplace_back(nrhs);
     residuals->set_dims(common::make_ddim(batch_dims_vec));
     batch_dims_vec.pop_back();

--- a/paddle/phi/infermeta/binary.cc
+++ b/paddle/phi/infermeta/binary.cc
@@ -4234,10 +4234,11 @@ void LstsqInferMeta(const MetaTensor& x,
   if (m > n && driver != "gelsy") {
     if (driver == "gelss" || driver == "gelsd") {
       residuals->set_dims(common::make_ddim({-1}));
+    } else {
+      batch_dims_vec.emplace_back(nrhs);
+      residuals->set_dims(common::make_ddim(batch_dims_vec));
+      batch_dims_vec.pop_back();
     }
-    batch_dims_vec.emplace_back(nrhs);
-    residuals->set_dims(common::make_ddim(batch_dims_vec));
-    batch_dims_vec.pop_back();
   } else {
     residuals->set_dims(common::make_ddim({0}));
   }

--- a/paddle/phi/kernels/cpu/lstsq_kernel.cc
+++ b/paddle/phi/kernels/cpu/lstsq_kernel.cc
@@ -296,7 +296,8 @@ void LstsqKernel(const Context& dev_ctx,
     solution->Resize(common::make_ddim({n, nrhs}));
   }
 
-  GetResidualsTensor<Context, T>(dev_ctx, x, y, solution, residuals);
+  GetResidualsTensor<Context, T>(
+      dev_ctx, x, y, driver_string, solution, residuals, rank);
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/gpu/lstsq_kernel.cu
+++ b/paddle/phi/kernels/gpu/lstsq_kernel.cu
@@ -160,7 +160,8 @@ void LstsqKernel(const Context& dev_ctx,
   }
 
   if (batch_count == 1) solution->Resize(common::make_ddim({n, nrhs}));
-  GetResidualsTensor<Context, T>(dev_ctx, x, y, solution, residuals);
+  GetResidualsTensor<Context, T>(
+      dev_ctx, x, y, driver_string, solution, residuals, rank);
 }
 
 }  // namespace phi

--- a/test/legacy_test/test_linalg_lstsq_op.py
+++ b/test/legacy_test/test_linalg_lstsq_op.py
@@ -263,6 +263,15 @@ class LinalgLstsqTestCaseBatch2(LinalgLstsqTestCase):
         self._input_shape_2 = (10, 8, 10)
 
 
+class LinalgLstsqTestCaseBatch3(LinalgLstsqTestCase):
+    def init_config(self):
+        self.dtype = 'float64'
+        self.rcond = 1e-15
+        self.driver = "gelss"
+        self._input_shape_1 = (2, 10, 3)
+        self._input_shape_2 = (2, 10, 4)
+
+
 class LinalgLstsqTestCaseLarge1(LinalgLstsqTestCase):
     def init_config(self):
         self.dtype = 'float64'

--- a/test/legacy_test/test_linalg_lstsq_op.py
+++ b/test/legacy_test/test_linalg_lstsq_op.py
@@ -131,6 +131,7 @@ class LinalgLstsqTestCase(unittest.TestCase):
             if (
                 self._input_shape_1[-2] > self._input_shape_1[-1]
                 and self._output_rank == self._input_shape_1[-1]
+                and self.driver != "gelsy"
             ):
                 np.testing.assert_allclose(
                     self._result_residuals, self._output_residuals, rtol=1e-5
@@ -153,6 +154,7 @@ class LinalgLstsqTestCase(unittest.TestCase):
                 if (
                     self._input_shape_1[-2] > self._input_shape_1[-1]
                     and self._output_rank[i] == self._input_shape_1[-1]
+                    and self.driver != "gelsy"
                 ):
                     np.testing.assert_allclose(
                         self._result_residuals[i],


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
对齐 torch 中 residuals 是否返回空向量的逻辑
https://github.com/pytorch/pytorch/blob/91b69deeb0f67a4b4ad7b36cdbb7d5f805b375a0/aten/src/ATen/native/BatchLinearAlgebra.cpp#L3510-L3535

只要 m>n 且不是 gelsy，且在输入是满秩矩阵时（ driver == "gelss" || driver == "gelsd"），或者"gels" 会计算 residuals