### PR TITLE
Add custom device support for skipping unittest for non CUDA devices

### DIFF
--- a/test/legacy_test/op_test.py
+++ b/test/legacy_test/op_test.py
@@ -412,6 +412,24 @@ def get_places(string_format=False):
     return places
 
 
+def get_current_place():
+    if core.is_compiled_with_cuda():
+        return base.CUDAPlace(0)
+    custom_dev_types = paddle.device.get_all_custom_device_type()
+    if custom_dev_types and core.is_compiled_with_custom_device(
+        custom_dev_types[0]
+    ):
+        return base.CustomPlace(custom_dev_types[0], 0)
+    return base.CPUPlace()
+
+
+def check_cuda_and_custom_device():
+    custom_dev_types = core.get_all_custom_device_type()
+    return core.is_compiled_with_cuda() or core.is_compiled_with_custom_device(
+        custom_dev_types[0]
+    )
+
+
 @contextmanager
 def auto_parallel_test_guard(test_info_path, generated_test_file_path):
     test_info_file, generated_test_file = None, None

--- a/test/legacy_test/op_test.py
+++ b/test/legacy_test/op_test.py
@@ -425,9 +425,12 @@ def get_current_place():
 
 def check_cuda_and_custom_device():
     custom_dev_types = core.get_all_custom_device_type()
-    return core.is_compiled_with_cuda() or core.is_compiled_with_custom_device(
-        custom_dev_types[0]
+    has_custom = (
+        core.is_compiled_with_custom_device(custom_dev_types[0])
+        if custom_dev_types
+        else False
     )
+    return core.is_compiled_with_cuda() or has_custom
 
 
 @contextmanager

--- a/test/legacy_test/op_test.py
+++ b/test/legacy_test/op_test.py
@@ -412,15 +412,25 @@ def get_places(string_format=False):
     return places
 
 
-def get_current_place():
-    if core.is_compiled_with_cuda():
-        return base.CUDAPlace(0)
-    custom_dev_types = paddle.device.get_all_custom_device_type()
-    if custom_dev_types and core.is_compiled_with_custom_device(
-        custom_dev_types[0]
-    ):
-        return base.CustomPlace(custom_dev_types[0], 0)
-    return base.CPUPlace()
+def get_current_place(string_format=False):
+    if not string_format:
+        if core.is_compiled_with_cuda():
+            return base.CUDAPlace(0)
+        custom_dev_types = paddle.device.get_all_custom_device_type()
+        if custom_dev_types and core.is_compiled_with_custom_device(
+            custom_dev_types[0]
+        ):
+            return base.CustomPlace(custom_dev_types[0], 0)
+        return base.CPUPlace()
+    else:
+        if paddle.device.is_compiled_with_cuda():
+            return 'gpu'
+        custom_dev_types = paddle.device.get_all_custom_device_type()
+        if custom_dev_types and paddle.device.is_compiled_with_custom_device(
+            custom_dev_types[0]
+        ):
+            return f'{custom_dev_types[0]}:0'
+        return 'cpu'
 
 
 def check_cuda_and_custom_device():

--- a/test/legacy_test/test_adamax_op.py
+++ b/test/legacy_test/test_adamax_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, get_places
+from op_test import OpTest, get_current_place, get_places
 
 import paddle
 
@@ -288,7 +288,7 @@ class TestAdamaxMultiPrecision2_0(unittest.TestCase):
     def dygraph_adamax_mp(self, mp, use_amp):
         paddle.disable_static()
         paddle.seed(100)
-        paddle.set_device('gpu')
+        paddle.set_device(get_current_place(True))
         input = paddle.randn((2, 2))
         model = paddle.nn.Linear(2, 2)
         optimizer = paddle.optimizer.Adamax(0.5, parameters=model.parameters())
@@ -319,7 +319,7 @@ class TestAdamaxMultiPrecision2_0(unittest.TestCase):
         paddle.enable_static()
         paddle.seed(100)
         np.random.seed(100)
-        exe = paddle.static.Executor('gpu')
+        exe = paddle.static.Executor(get_current_place(True))
         train_program = paddle.static.Program()
         startup_program = paddle.static.Program()
         optimizer = paddle.optimizer.Adamax(0.1)

--- a/test/legacy_test/test_batch_norm_op_prim_nchw.py
+++ b/test/legacy_test/test_batch_norm_op_prim_nchw.py
@@ -16,7 +16,13 @@ import sys
 import unittest
 
 import numpy as np
-from op_test import OpTest, _set_use_system_allocator, convert_float_to_uint16
+from op_test import (
+    OpTest,
+    _set_use_system_allocator,
+    check_cuda_and_custom_device,
+    convert_float_to_uint16,
+    get_current_place,
+)
 
 import paddle
 import paddle.nn.functional as F
@@ -82,9 +88,9 @@ class TestBatchNormOp(OpTest):
                 only_check_prim=True,
                 check_prim_pir=self.check_prim_pir,
             )
-        if paddle.is_compiled_with_cuda():
+        if check_cuda_and_custom_device():
             self.check_output_with_place(
-                core.CUDAPlace(0),
+                get_current_place(),
                 no_check_set=None,
                 check_prim=True,
                 only_check_prim=True,
@@ -102,9 +108,9 @@ class TestBatchNormOp(OpTest):
                 only_check_prim=True,
                 check_prim_pir=self.check_cpu_prim_pir_grad,
             )
-        if paddle.is_compiled_with_cuda():
+        if check_cuda_and_custom_device():
             self.check_grad_with_place(
-                core.CUDAPlace(0),
+                get_current_place(),
                 ["X"],
                 ['Y'],
                 user_defined_grad_outputs=self.out_grad,
@@ -136,9 +142,9 @@ class TestBatchNormOp(OpTest):
                 only_check_prim=True,
                 check_prim_pir=self.check_cpu_prim_pir_grad,
             )
-        if paddle.is_compiled_with_cuda():
+        if check_cuda_and_custom_device():
             self.check_grad_with_place(
-                core.CUDAPlace(0),
+                get_current_place(),
                 ["X", "Scale", "Bias"],
                 ['Y'],
                 user_defined_grad_outputs=self.out_grad,
@@ -167,7 +173,7 @@ class TestBatchNormOp(OpTest):
     def initTestCase(self):
         if (
             self.dtype in ("uint16", "float16")
-            and not paddle.is_compiled_with_cuda()
+            and not check_cuda_and_custom_device()
         ):
             self.__class__.op_type = self.op_type
             self.__class__.no_need_check_grad = True
@@ -334,8 +340,8 @@ class TestBatchNormOpNCHWTestModeFp16(TestBatchNormOp):
 
 
 @unittest.skipIf(
-    not core.is_compiled_with_cuda()
-    or not core.is_bfloat16_supported(core.CUDAPlace(0)),
+    not check_cuda_and_custom_device()
+    or not core.is_bfloat16_supported(get_current_place()),
     "core is not compiled with CUDA or not support the bfloat16",
 )
 class TestBatchNormOpNCHWbf16(TestBatchNormOp):
@@ -363,8 +369,8 @@ class TestBatchNormOpNCHWbf16(TestBatchNormOp):
 
 
 @unittest.skipIf(
-    not core.is_compiled_with_cuda()
-    or not core.is_bfloat16_supported(core.CUDAPlace(0)),
+    not check_cuda_and_custom_device()
+    or not core.is_bfloat16_supported(get_current_place()),
     "core is not compiled with CUDA or not support the bfloat16",
 )
 class TestBatchNormOpNCHWTestModebf16(TestBatchNormOp):

--- a/test/legacy_test/test_binomial_op.py
+++ b/test/legacy_test/test_binomial_op.py
@@ -16,7 +16,12 @@ import math
 import unittest
 
 import numpy as np
-from op_test import OpTest, convert_float_to_uint16
+from op_test import (
+    OpTest,
+    check_cuda_and_custom_device,
+    convert_float_to_uint16,
+    get_current_place,
+)
 
 import paddle
 from paddle.base import core
@@ -116,7 +121,7 @@ class TestRandomValue(unittest.TestCase):
             return
 
         paddle.disable_static()
-        paddle.set_device('gpu')
+        paddle.set_device(get_current_place(True))
         paddle.seed(2023)
         count = paddle.full([32, 3, 1024, 768], 100.0, dtype="float32")
         probability = paddle.to_tensor(0.4)
@@ -221,8 +226,8 @@ class TestRandomValue(unittest.TestCase):
 
 
 @unittest.skipIf(
-    not core.is_compiled_with_cuda()
-    or not core.is_float16_supported(core.CUDAPlace(0)),
+    not check_cuda_and_custom_device()
+    or not core.is_float16_supported(get_current_place()),
     "core is not compiled with CUDA and not support the float16",
 )
 class TestBinomialFP16Op(TestBinomialOp):
@@ -232,7 +237,7 @@ class TestBinomialFP16Op(TestBinomialOp):
         self.outputs_dtype = np.int64
 
     def test_check_output(self):
-        place = core.CUDAPlace(0)
+        place = get_current_place()
         self.check_output_with_place_customized(self.verify_output, place)
 
     def verify_output(self, outs):
@@ -243,8 +248,8 @@ class TestBinomialFP16Op(TestBinomialOp):
 
 
 @unittest.skipIf(
-    not core.is_compiled_with_cuda()
-    or not core.is_bfloat16_supported(core.CUDAPlace(0)),
+    not check_cuda_and_custom_device()
+    or not core.is_bfloat16_supported(get_current_place()),
     "core is not compiled with CUDA and not support the bfloat16",
 )
 class TestBinomialBF16Op(TestBinomialOp):
@@ -254,7 +259,7 @@ class TestBinomialBF16Op(TestBinomialOp):
         self.outputs_dtype = np.int64
 
     def test_check_output(self):
-        place = core.CUDAPlace(0)
+        place = get_current_place()
         self.check_output_with_place_customized(self.verify_output, place)
 
     def init_test_case(self):

--- a/test/legacy_test/test_clip_op.py
+++ b/test/legacy_test/test_clip_op.py
@@ -15,7 +15,12 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, convert_float_to_uint16
+from op_test import (
+    OpTest,
+    check_cuda_and_custom_device,
+    convert_float_to_uint16,
+    get_current_place,
+)
 
 import paddle
 from paddle import base
@@ -201,8 +206,8 @@ class TestCase_ZeroSize(TestClipOp):
 
 
 @unittest.skipIf(
-    not core.is_compiled_with_cuda()
-    or not core.is_bfloat16_supported(core.CUDAPlace(0)),
+    not check_cuda_and_custom_device()
+    or not core.is_bfloat16_supported(get_current_place()),
     "core is not compiled with CUDA or not support the bfloat16",
 )
 class TestClipBF16Op(OpTest):
@@ -237,8 +242,8 @@ class TestClipBF16Op(OpTest):
         self.outputs = {'Out': convert_float_to_uint16(out)}
 
     def test_check_output(self):
-        if paddle.is_compiled_with_cuda():
-            place = paddle.CUDAPlace(0)
+        if check_cuda_and_custom_device():
+            place = get_current_place()
             paddle.enable_static()
             self.check_output_with_place(
                 place,
@@ -249,8 +254,8 @@ class TestClipBF16Op(OpTest):
             paddle.disable_static()
 
     def test_check_grad_normal(self):
-        if paddle.is_compiled_with_cuda():
-            place = paddle.CUDAPlace(0)
+        if check_cuda_and_custom_device():
+            place = get_current_place()
             paddle.enable_static()
             self.check_grad_with_place(place, ['X'], 'Out', check_pir=True)
             paddle.disable_static()

--- a/test/legacy_test/test_fused_gemm_epilogue_grad_op.py
+++ b/test/legacy_test/test_fused_gemm_epilogue_grad_op.py
@@ -17,7 +17,12 @@ import os
 import unittest
 
 import numpy as np
-from op_test import OpTest, skip_check_grad_ci
+from op_test import (
+    OpTest,
+    check_cuda_and_custom_device,
+    get_current_place,
+    skip_check_grad_ci,
+)
 
 import paddle
 from paddle.base import core
@@ -43,13 +48,13 @@ def get_outputs(DOut, X, Y):
 
 @skip_check_grad_ci(reason="no grap op")
 @unittest.skipIf(
-    not core.is_compiled_with_cuda() or not is_rocm_gfx928(),
+    not check_cuda_and_custom_device() or not is_rocm_gfx928(),
     "core is not compiled with CUDA",
 )
 class TestFuseGemmEpilogueGradOpDXYBiasFP16(OpTest):
     def setUp(self):
         self.op_type = "fused_gemm_epilogue_grad"
-        self.place = core.CUDAPlace(0)
+        self.place = get_current_place()
         self.init_dtype_type()
 
         self.inputs = {
@@ -81,7 +86,7 @@ class TestFuseGemmEpilogueGradOpDXYBiasFP16(OpTest):
 
 @skip_check_grad_ci(reason="no grap op")
 @unittest.skipIf(
-    not core.is_compiled_with_cuda() or not is_rocm_gfx928(),
+    not check_cuda_and_custom_device() or not is_rocm_gfx928(),
     "core is not compiled with CUDA",
 )
 class TestFuseGemmEpilogueGradOpDXYBiasFP32(
@@ -94,7 +99,7 @@ class TestFuseGemmEpilogueGradOpDXYBiasFP32(
 
 @skip_check_grad_ci(reason="no grap op")
 @unittest.skipIf(
-    not core.is_compiled_with_cuda() or core.is_compiled_with_rocm(),
+    not check_cuda_and_custom_device() or core.is_compiled_with_rocm(),
     "core is not compiled with CUDA or is compiled with ROCm",
 )
 class TestFuseGemmEpilogueGradOpDXYBiasFP64(
@@ -107,13 +112,13 @@ class TestFuseGemmEpilogueGradOpDXYBiasFP64(
 
 @skip_check_grad_ci(reason="no grap op")
 @unittest.skipIf(
-    not core.is_compiled_with_cuda() or not is_rocm_gfx928(),
+    not check_cuda_and_custom_device() or not is_rocm_gfx928(),
     "core is not compiled with CUDA",
 )
 class TestFuseGemmEpilogueGradOpDYBiasFP16(OpTest):
     def setUp(self):
         self.op_type = "fused_gemm_epilogue_grad"
-        self.place = core.CUDAPlace(0)
+        self.place = get_current_place()
         self.init_dtype_type()
 
         self.inputs = {
@@ -145,7 +150,7 @@ class TestFuseGemmEpilogueGradOpDYBiasFP16(OpTest):
 
 @skip_check_grad_ci(reason="no grap op")
 @unittest.skipIf(
-    not core.is_compiled_with_cuda() or not is_rocm_gfx928(),
+    not check_cuda_and_custom_device() or not is_rocm_gfx928(),
     "core is not compiled with CUDA",
 )
 class TestFuseGemmEpilogueGradOpDYBiasFP32(
@@ -158,7 +163,7 @@ class TestFuseGemmEpilogueGradOpDYBiasFP32(
 
 @skip_check_grad_ci(reason="no grap op")
 @unittest.skipIf(
-    not core.is_compiled_with_cuda() or core.is_compiled_with_rocm(),
+    not check_cuda_and_custom_device() or core.is_compiled_with_rocm(),
     "core is not compiled with CUDA or is compiled with ROCm",
 )
 class TestFuseGemmEpilogueGradOpDYBiasFP64(
@@ -171,13 +176,13 @@ class TestFuseGemmEpilogueGradOpDYBiasFP64(
 
 @skip_check_grad_ci(reason="no grap op")
 @unittest.skipIf(
-    not core.is_compiled_with_cuda() or not is_rocm_gfx928(),
+    not check_cuda_and_custom_device() or not is_rocm_gfx928(),
     "core is not compiled with CUDA",
 )
 class TestFuseGemmEpilogueGradOpDYFP16(OpTest):
     def setUp(self):
         self.op_type = "fused_gemm_epilogue_grad"
-        self.place = core.CUDAPlace(0)
+        self.place = get_current_place()
         self.init_dtype_type()
 
         self.inputs = {
@@ -209,7 +214,7 @@ class TestFuseGemmEpilogueGradOpDYFP16(OpTest):
 
 @skip_check_grad_ci(reason="no grap op")
 @unittest.skipIf(
-    not core.is_compiled_with_cuda() or not is_rocm_gfx928(),
+    not check_cuda_and_custom_device() or not is_rocm_gfx928(),
     "core is not compiled with CUDA",
 )
 class TestFuseGemmEpilogueGradOpDYFP32(TestFuseGemmEpilogueGradOpDYFP16):
@@ -220,7 +225,7 @@ class TestFuseGemmEpilogueGradOpDYFP32(TestFuseGemmEpilogueGradOpDYFP16):
 
 @skip_check_grad_ci(reason="no grap op")
 @unittest.skipIf(
-    not core.is_compiled_with_cuda() or core.is_compiled_with_rocm(),
+    not check_cuda_and_custom_device() or core.is_compiled_with_rocm(),
     "core is not compiled with CUDA or is compiled with ROCm",
 )
 class TestFuseGemmEpilogueGradOpDYFP64(TestFuseGemmEpilogueGradOpDYFP16):
@@ -231,13 +236,13 @@ class TestFuseGemmEpilogueGradOpDYFP64(TestFuseGemmEpilogueGradOpDYFP16):
 
 @skip_check_grad_ci(reason="no grap op")
 @unittest.skipIf(
-    not core.is_compiled_with_cuda() or not is_rocm_gfx928(),
+    not check_cuda_and_custom_device() or not is_rocm_gfx928(),
     "core is not compiled with CUDA",
 )
 class TestFuseGemmEpilogueGradOpDXYFP16(OpTest):
     def setUp(self):
         self.op_type = "fused_gemm_epilogue_grad"
-        self.place = core.CUDAPlace(0)
+        self.place = get_current_place()
         self.init_dtype_type()
 
         self.inputs = {
@@ -269,7 +274,7 @@ class TestFuseGemmEpilogueGradOpDXYFP16(OpTest):
 
 @skip_check_grad_ci(reason="no grap op")
 @unittest.skipIf(
-    not core.is_compiled_with_cuda() or not is_rocm_gfx928(),
+    not check_cuda_and_custom_device() or not is_rocm_gfx928(),
     "core is not compiled with CUDA",
 )
 class TestFuseGemmEpilogueGradOpDXYFP32(TestFuseGemmEpilogueGradOpDXYFP16):
@@ -280,7 +285,7 @@ class TestFuseGemmEpilogueGradOpDXYFP32(TestFuseGemmEpilogueGradOpDXYFP16):
 
 @skip_check_grad_ci(reason="no grap op")
 @unittest.skipIf(
-    not core.is_compiled_with_cuda() or core.is_compiled_with_rocm(),
+    not check_cuda_and_custom_device() or core.is_compiled_with_rocm(),
     "core is not compiled with CUDA or is compiled with ROCm",
 )
 class TestFuseGemmEpilogueGradOpDXYFP64(TestFuseGemmEpilogueGradOpDXYFP16):

--- a/test/legacy_test/test_norm_all.py
+++ b/test/legacy_test/test_norm_all.py
@@ -15,7 +15,12 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, convert_float_to_uint16
+from op_test import (
+    OpTest,
+    check_cuda_and_custom_device,
+    convert_float_to_uint16,
+    get_current_place,
+)
 from utils import static_guard
 
 import paddle
@@ -477,19 +482,19 @@ class TestPnormOpZeroSize4(TestPnormOpZeroSize):
 
 def create_test_fp16_class(parent, max_relative_error=2e-3):
     @unittest.skipIf(
-        not core.is_compiled_with_cuda(), "core is not compiled with CUDA"
+        not check_cuda_and_custom_device(), "core is not compiled with CUDA"
     )
     class TestPnormFP16Op(parent):
         def init_dtype(self):
             self.dtype = "float16"
 
         def test_check_output(self):
-            place = core.CUDAPlace(0)
+            place = get_current_place()
             if core.is_float16_supported(place):
                 self.check_output_with_place(place)
 
         def test_check_grad(self):
-            place = core.CUDAPlace(0)
+            place = get_current_place()
             if core.is_float16_supported(place):
                 self.check_grad_with_place(
                     place,
@@ -513,7 +518,7 @@ create_test_fp16_class(TestPnormOp6)
 
 
 @unittest.skipIf(
-    not core.is_compiled_with_cuda(), "core is not compiled with CUDA"
+    not check_cuda_and_custom_device(), "core is not compiled with CUDA"
 )
 class TestPnormBF16Op(OpTest):
     def setUp(self):
@@ -536,11 +541,11 @@ class TestPnormBF16Op(OpTest):
         self.outputs = {'Out': convert_float_to_uint16(self.norm)}
 
     def test_check_output(self):
-        place = core.CUDAPlace(0)
+        place = get_current_place()
         self.check_output_with_place(place, atol=1e-3, check_prim_pir=True)
 
     def test_check_grad(self):
-        place = core.CUDAPlace(0)
+        place = get_current_place()
         self.check_grad_with_place(
             place,
             ['X'],


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Custom Device

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
pcard-67164
Add custom device support for skipping unittest for non CUDA devices