### PR TITLE
[0-size Tensor Retest]Fix bincount、 chunk、gather_nd、einsum to support 0-size Tensor

### DIFF
--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -5354,7 +5354,7 @@ void TileInferMeta(const MetaTensor& x,
                    const IntArray& repeat_times,
                    MetaTensor* out,
                    MetaConfig config) {
-#define TILE_MAX_RANK_SUPPORTED 6
+#define TILE_MAX_RANK_SUPPORTED 7
 
   auto repeat_times_data = repeat_times.GetData();
   auto x_dims = x.dims();

--- a/paddle/phi/kernels/cpu/bincount_kernel.cc
+++ b/paddle/phi/kernels/cpu/bincount_kernel.cc
@@ -37,7 +37,7 @@ void BincountInner(const Context& dev_ctx,
     phi::DDim out_dim{minlength};
     output->Resize(out_dim);
     // Since minlength may >0 , so fill with 0.
-    phi::Full<InputT, Context>(
+    phi::Full<int64_t, Context>(
         dev_ctx, phi::IntArray(common::vectorize(output->dims())), 0, output);
     return;
   }

--- a/paddle/phi/kernels/gpu/bincount_kernel.cu
+++ b/paddle/phi/kernels/gpu/bincount_kernel.cu
@@ -101,7 +101,7 @@ void BincountCUDAInner(const Context& dev_ctx,
   if (input_data == nullptr) {
     phi::DDim out_dim{minlength};
     output->Resize(out_dim);
-    phi::Full<InputT, Context>(
+    phi::Full<int64_t, Context>(
         dev_ctx, phi::IntArray(common::vectorize(output->dims())), 0, output);
     return;
   }

--- a/paddle/phi/kernels/impl/einsum_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/einsum_grad_kernel_impl.h
@@ -122,9 +122,9 @@ void EinsumGradKernel(const Context& dev_ctx,
     if (i != nullptr) {
       if (i->numel() == 0) {
         has_zero_size_tensor = true;
-        phi::Full<T, Context>(
-            dev_ctx, phi::IntArray(common::vectorize(i->dims())), 0, i);
       }
+      phi::Full<T, Context>(
+          dev_ctx, phi::IntArray(common::vectorize(i->dims())), 0, i);
     }
   }
   if (has_zero_size_tensor) return;

--- a/paddle/phi/kernels/impl/tile_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/tile_grad_kernel_impl.h
@@ -171,9 +171,13 @@ void TileGradKernel(const Context& dev_ctx,
         TileBackward<Context, T, 6>(
             dev_ctx, out_grad, reshape_dims_vec, reduce_dims_vec, x_grad);
         break;
+      case 7:
+        TileBackward<Context, T, 7>(
+            dev_ctx, out_grad, reshape_dims_vec, reduce_dims_vec, x_grad);
+        break;
       default:
         PADDLE_THROW(errors::InvalidArgument(
-            "Only support tensor with rank being between 1 and 6. But "
+            "Only support tensor with rank being between 1 and 7. But "
             "received tensor's rank = %d.",
             dims));
     }

--- a/paddle/phi/kernels/impl/tile_kernel_impl.h
+++ b/paddle/phi/kernels/impl/tile_kernel_impl.h
@@ -127,6 +127,14 @@ void TileKernel(const Context& dev_ctx,
     case 6:
       Tile<Context, T, 6>(dev_ctx, x, repeat_times_data, out);
       break;
+    case 7:
+      Tile<Context, T, 7>(dev_ctx, x, repeat_times_data, out);
+      break;
+    default:
+      PADDLE_THROW(errors::InvalidArgument(
+          "Only support tensor with rank being between 0 and 7. But "
+          "received tensor's rank = %d.",
+          rank));
   }
 }
 

--- a/paddle/phi/kernels/tile_grad_kernel.h
+++ b/paddle/phi/kernels/tile_grad_kernel.h
@@ -17,7 +17,7 @@
 #include "paddle/phi/common/int_array.h"
 #include "paddle/phi/core/dense_tensor.h"
 
-#define MAX_RANK_SUPPORTED 6
+#define MAX_RANK_SUPPORTED 7
 
 namespace phi {
 

--- a/paddle/phi/kernels/tile_kernel.h
+++ b/paddle/phi/kernels/tile_kernel.h
@@ -17,7 +17,7 @@
 #include "paddle/phi/common/int_array.h"
 #include "paddle/phi/core/dense_tensor.h"
 
-#define MAX_RANK_SUPPORTED 6
+#define MAX_RANK_SUPPORTED 7
 
 namespace phi {
 

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -4489,7 +4489,7 @@ def chunk(
     if chunks <= 0 or (
         isinstance(axis, int)
         and axis >= 0
-        and chunks > x.shape[axis]
+        and (x.shape[axis] != 0 and chunks > x.shape[axis])
         and x.shape[axis] != -1
     ):
         raise ValueError(

--- a/test/legacy_test/test_gather_nd_op.py
+++ b/test/legacy_test/test_gather_nd_op.py
@@ -743,6 +743,9 @@ class TestGatherNdOp_ZeroSize(OpTest):
             check_pir=True,
         )
 
+    def test_check_output_cpu(self):
+        self.check_output_with_place(check_pir=True, place=paddle.CPUPlace())
+
 
 class TestGatherNdOp_ZeroSize2(TestGatherNdOp_ZeroSize):
     def setUp(self):
@@ -752,6 +755,19 @@ class TestGatherNdOp_ZeroSize2(TestGatherNdOp_ZeroSize):
         xnp = np.random.random([10, 20])
         index = np.random.random([2, 0]).astype("int32")
         output = np.tile(xnp, [2, 1, 1])
+
+        self.inputs = {'X': xnp, 'Index': index}
+        self.outputs = {'Out': output}
+
+
+class TestGatherNdOp_ZeroSize3(TestGatherNdOp_ZeroSize):
+    def setUp(self):
+        self.op_type = "gather_nd"
+        self.python_api = paddle.gather_nd
+        self.public_python_api = paddle.gather_nd
+        xnp = np.random.random([1, 2, 3, 2])
+        index = np.random.random([1, 1, 1, 0]).astype("int32")
+        output = np.tile(xnp, [1, 1, 1, 1, 1, 1, 1])
 
         self.inputs = {'X': xnp, 'Index': index}
         self.outputs = {'Out': output}

--- a/test/legacy_test/test_tile_op.py
+++ b/test/legacy_test/test_tile_op.py
@@ -496,6 +496,38 @@ class TestTileAPI(unittest.TestCase):
             np.testing.assert_array_equal(out_3.numpy(), np.tile(np_x, (2, 3)))
 
 
+class TestTileAPI7D(unittest.TestCase):
+    def init_data(self):
+        self.ori_shape = [1, 2, 3, 4, 5]
+        self.repeat_times = [1, 1, 1, 2, 1, 2, 1]
+
+    def _test_api(self, place):
+        with base.dygraph.guard():
+            np_x = np.random.random(self.ori_shape).astype("float32")
+            x = paddle.to_tensor(np_x, place=place)
+            x.stop_gradient = False
+            repeat_times = self.repeat_times
+            out = paddle.tile(x, repeat_times)
+            np.testing.assert_array_equal(
+                out.numpy(), np.tile(np_x, repeat_times)
+            )
+            loss = out.sum()
+            loss.backward()
+            np.testing.assert_array_equal(x.grad.shape, x.shape)
+
+    def test_tile7d(self):
+        places = get_places()
+        for place in places:
+            self.init_data()
+            self._test_api(place)
+
+
+class TestTileAPI7Dcase2(TestTileAPI7D):
+    def init_data(self):
+        self.ori_shape = [1, 2, 3, 4, 5, 1, 2]
+        self.repeat_times = [3, 2, 2, 1, 1, 2, 1]
+
+
 class TestTileDoubleGradCheck(unittest.TestCase):
     def tile_wrapper(self, x):
         return paddle.tile(x[0], [2, 1])


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Operator Mechanism 
### PR Types
<!-- One of [ New features | Operator Mechanism ｜Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
- bincount
问题：输入为int32时输出dtype不对, 应该为int64
<img width="968" height="276" alt="image" src="https://github.com/user-attachments/assets/04a59e42-7d5f-4503-b071-e51e540506c3" />

- chunk
问题：不支持 axis所在的dim为0
<img width="996" height="360" alt="image" src="https://github.com/user-attachments/assets/7f0c007f-3888-48f0-b534-bf96f477388b" />

- gather_nd
问题：gather_nd当输出tensor的维度大于等于7D时，cpu输出不对。因为调用的tile不支持7D的tensor

<img width="1340" height="174" alt="image" src="https://github.com/user-attachments/assets/e4e4d8cd-dd7b-452e-89bf-36fce2f56267" />

- einsum
问题：反向过程部分tensor为none

<img width="1194" height="460" alt="image" src="https://github.com/user-attachments/assets/8c9c1c31-240f-4374-8a29-496cbbbefed6" />



pcard-67164
