### PR TITLE
[0-size Tensor Job2 No.70、94、11] Add 0-size Tensor support for paddle.put_along_axis

### DIFF
--- a/test/legacy_test/test_put_along_axis_op.py
+++ b/test/legacy_test/test_put_along_axis_op.py
@@ -1410,6 +1410,24 @@ class TestPutAlongAxisDynamicShape3(TestPutAlongAxisDynamicShape):
         self.arr = np.random.random([32, 32, 32, 32]).astype(self.dtype)
 
 
+class TestPutAlongAxisDynamicShape_ZeroSize(TestPutAlongAxisDynamicShape):
+    def setUp(self):
+        np.random.seed(2024)
+        self.net = put_along_axis_net
+        self.enable_cinn = False
+        self.tol = 1e-6
+        self.dtype = "float32"
+        self.axis = -2
+        self.input_specs = [
+            InputSpec(
+                shape=(-1, -1, -1, -1),
+                dtype=self.dtype,
+                stop_gradient=False,
+            )
+        ]
+        self.arr = np.random.random([0, 10, 10, 10]).astype(self.dtype)
+
+
 if __name__ == "__main__":
     paddle.enable_static()
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
paddle.put_along_axis
paddle.Tensor.put_along_axis

PaddleAPITest测试通过，错误为numpy error，增加单测
<img width="1310" height="156" alt="image" src="https://github.com/user-attachments/assets/563dcea8-38ad-4132-a09a-924734978c8e" />
<img width="1303" height="179" alt="image" src="https://github.com/user-attachments/assets/2050388b-b02c-4ccc-9c2d-e78f3a504cda" />

11 paddle.expand_as 已在 https://github.com/PaddlePaddle/Paddle/pull/72986 修复，更新状态