### PR TITLE
[0-size Tensor No.114] Add 0-size Tensor support for paddle.linalg.pinv

### DIFF
--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -4163,7 +4163,10 @@ def pinv(
         if not hermitian:
             # combine svd and matmul op
             u, s, vt = _C_ops.svd(x, False)
-            max_singular_val = _C_ops.max(s, [-1], True)
+            if s.shape[-1] == 0:
+                max_singular_val = s
+            else:
+                max_singular_val = _C_ops.max(s, [-1], True)
             rcond = paddle.to_tensor(rcond, dtype=x.dtype)
             cutoff = rcond * max_singular_val
             y = float('inf')
@@ -4180,6 +4183,11 @@ def pinv(
             out_2 = _C_ops.matmul(out_1, u, False, True)
             return out_2
         else:
+            if x.size == 0:
+                dims = list(range(len(x.shape)))
+                perm = [*dims[:-2], dims[-1], dims[-2]]
+                return _C_ops.transpose(x, perm)
+
             # combine eigh and matmul op
             s, u = _C_ops.eigh(x, 'L')
             s_abs = paddle.abs(s)

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -4183,7 +4183,7 @@ def pinv(
             out_2 = _C_ops.matmul(out_1, u, False, True)
             return out_2
         else:
-            if x.size == 0:
+            if in_dynamic_mode() and x.size == 0:
                 dims = list(range(len(x.shape)))
                 perm = [*dims[:-2], dims[-1], dims[-2]]
                 return _C_ops.transpose(x, perm)

--- a/test/legacy_test/test_linalg_pinv_op.py
+++ b/test/legacy_test/test_linalg_pinv_op.py
@@ -302,9 +302,10 @@ class TestDivByZero(unittest.TestCase):
         paddle.linalg.pinv(x)
 
     def test_div_by_zero(self):
-        with self.assertRaises(ValueError):
-            self.pinv_zero_input_dynamic()
-            self.pinv_zero_input_static()
+        pass
+        # with self.assertRaises(ValueError):
+        #     self.pinv_zero_input_dynamic()
+        #     self.pinv_zero_input_static()
 
 
 class LinalgPinvTestCase_ZeroSize(unittest.TestCase):

--- a/test/legacy_test/test_linalg_pinv_op.py
+++ b/test/legacy_test/test_linalg_pinv_op.py
@@ -307,5 +307,66 @@ class TestDivByZero(unittest.TestCase):
             self.pinv_zero_input_static()
 
 
+class LinalgPinvTestCase_ZeroSize(unittest.TestCase):
+    def setUp(self):
+        self.init_config()
+        self.generate_input()
+        self.generate_output()
+        self.places = get_places()
+
+    def generate_output(self):
+        self._output_data = np.linalg.pinv(
+            self._input_data, rcond=self.rcond, hermitian=self.hermitian
+        )
+
+    def init_config(self):
+        self.dtype = 'float64'
+        self.rcond = 1e-15
+        self.hermitian = False
+
+    def test_dygraph(self):
+        for place in self.places:
+            paddle.disable_static(place)
+            x = paddle.to_tensor(self._input_data, place=place)
+            out = paddle.linalg.pinv(
+                x, rcond=self.rcond, hermitian=self.hermitian
+            ).numpy()
+            np.testing.assert_allclose(out, self._output_data)
+
+    def test_grad(self):
+        for place in self.places:
+            x = paddle.to_tensor(
+                self._input_data, place=place, stop_gradient=False
+            )
+            out = paddle.linalg.pinv(
+                x, rcond=self.rcond, hermitian=self.hermitian
+            )
+            out.backward()
+            np.testing.assert_allclose(x.grad, np.zeros(self._input_shape))
+
+    def generate_input(self):
+        self._input_shape = (0, 4, 5)
+        np.random.seed(123)
+        self._input_data = np.random.random(self._input_shape).astype(
+            self.dtype
+        )
+
+
+class LinalgPinvTestCaseHermitian_ZeroSize(LinalgPinvTestCase_ZeroSize):
+    def generate_input(self):
+        paddle.disable_static()
+        self._input_shape = (3, 0, 5)
+        np.random.seed(123)
+        x = np.random.random(self._input_shape).astype(
+            self.dtype
+        ) + 1j * np.random.random(self._input_shape).astype(self.dtype)
+        self._input_data = x
+
+    def init_config(self):
+        self.dtype = 'float32'
+        self.rcond = 1e-15
+        self.hermitian = True
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes 

### Description
<!-- Describe what you’ve done -->
修改python，hermitian为False时 max_singular_val 取 s
hermitian 为 True时，判断x.size为0，转置x结尾两个维度返回，在hermitian为False时也有转置结尾两个维度的部分
<img width="754" height="177" alt="image" src="https://github.com/user-attachments/assets/4465f7fb-abcc-4253-918d-9088ac25f74f" />

注释原有抛出异常单测

PaddleAPITest 测试通过
<img width="1227" height="209" alt="image" src="https://github.com/user-attachments/assets/ee2fcc0c-abcd-4de5-ae8e-8e51f097fca5" />
