### PR TITLE
[0-size Tensor Job2 No.40、41] Add 0-size Tensor support for paddle.linalg.cholesky

### DIFF
--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -2291,6 +2291,10 @@ def cholesky(x: Tensor, upper: bool = False, name: str | None = None) -> Tensor:
              [1.30602181, 0.08326444, 0.22790681]])
     """
     if in_dynamic_or_pir_mode():
+        x_shape = x.shape
+        assert (
+            len(x_shape) >= 2 and x_shape[-1] == x_shape[-2]
+        ), "Shape must have at least 2 dimensions and last two dimensions must be equal."
         return _C_ops.cholesky(x, upper)
     else:
         check_variable_and_dtype(x, 'dtype', ['float32', 'float64'], 'cholesky')
@@ -4049,8 +4053,6 @@ def eigh(
              [ 0.3826833963394165j    , -0.9238795042037964j    ]])
 
     """
-    if in_dynamic_mode():
-        return _C_ops.eigh(x, UPLO)
 
     def __check_input(x, UPLO):
         x_shape = list(x.shape)
@@ -4068,7 +4070,7 @@ def eigh(
                 f"UPLO must be L or U. But received UPLO is: {UPLO}"
             )
 
-    if in_pir_mode():
+    if in_dynamic_mode() or in_pir_mode():
         __check_input(x, UPLO)
         return _C_ops.eigh(x, UPLO)
 

--- a/test/legacy_test/test_cholesky_op.py
+++ b/test/legacy_test/test_cholesky_op.py
@@ -226,6 +226,14 @@ class TestCholeskySingularAPI(unittest.TestCase):
                     print("The mat is singular")
 
 
+class TestCholeskyAPIError_ZeroSize(unittest.TestCase):
+    def _test_case(self):
+        paddle.linalg.cholesky(paddle.randn([0, 5]))
+
+    def test_error(self):
+        self.assertRaises(AssertionError, self._test_case)
+
+
 if __name__ == "__main__":
     paddle.enable_static()
     unittest.main()

--- a/test/legacy_test/test_eigh_op.py
+++ b/test/legacy_test/test_eigh_op.py
@@ -375,5 +375,13 @@ class TestEighBatchAPIZeroSize1(TestEighAPIZeroSize):
         self.x_shape = [5, 0, 0]
 
 
+class TestEighAPIError_ZeroSize(unittest.TestCase):
+    def _test_case(self):
+        paddle.linalg.eigh(paddle.randn([0, 5]))
+
+    def test_error(self):
+        self.assertRaises(ValueError, self._test_case)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
40 paddle.linalg.cholesky
41 paddle.linalg.eigh  

cholesky 增加输入参数验证，结尾两个维度应相等
eigh已有0-size单测，部分测试用例numpy error，增加输入参数验证，结尾两个维度应相等

numpy 测试
```
import numpy as np
np.linalg.cholesky(np.random.random([2,0]))
numpy.linalg.LinAlgError: Last 2 dimensions of the array must be square

np.linalg.eigh(np.random.random([2,0]))
numpy.linalg.LinAlgError: Last 2 dimensions of the array must be square
```

清理配置PR https://github.com/PFCCLab/PaddleAPITest/pull/420/