### PR TITLE
add warning of tf32-tensor-cores for LBFGS optimizer

### DIFF
--- a/python/paddle/optimizer/lbfgs.py
+++ b/python/paddle/optimizer/lbfgs.py
@@ -63,7 +63,7 @@ def check_tf32_override():
         warnings.warn(
             "Warning! TF32 Tensor Cores are enabled by default on some NVIDIA GPUs for faster computation, "
             "but may compromise numerical precision in specific cases, particularly with the L-BFGS optimizer. "
-            "To disable it, set os.environ['NVIDIA_TF32_OVERRIDE'] = '0'."
+            "To disable it, set: NVIDIA_TF32_OVERRIDE=0"
         )
 
 

--- a/python/paddle/optimizer/lbfgs.py
+++ b/python/paddle/optimizer/lbfgs.py
@@ -14,6 +14,8 @@
 
 from __future__ import annotations
 
+import os
+import warnings
 from collections import defaultdict
 from functools import reduce
 from typing import TYPE_CHECKING, NoReturn, TypedDict
@@ -53,6 +55,16 @@ class _LbfgsState(TypedDict):
 
 class _LbfgsStateDict(TypedDict):
     state: _LbfgsState
+
+
+def check_tf32_override():
+    """Check and warn about TF32 acceleration status"""
+    if os.getenv("NVIDIA_TF32_OVERRIDE") != "0":  # None or "1"
+        warnings.warn(
+            "Warning! TF32 Tensor Cores are enabled by default on some NVIDIA GPUs for faster computation, "
+            "but may compromise numerical precision in specific cases, particularly with the L-BFGS optimizer. "
+            "To disable it, set os.environ['NVIDIA_TF32_OVERRIDE'] = '0'."
+        )
 
 
 def dot(x, y):
@@ -444,6 +456,8 @@ class LBFGS(Optimizer):
         grad_clip: GradientClipBase | None = None,
         name: str | None = None,
     ) -> None:
+        check_tf32_override()
+
         if max_eval is None:
             max_eval = max_iter * 5 // 4
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
Pcard-66961
问题：使用L-BFGS优化器时，在部分机器上有案例的精度无法复现 https://github.com/PaddlePaddle/PaddleScience/issues/1185
出现原因：在Nvidia的部分卡上默认使用TF32而不是FP32来加速计算，但是在部分场景下这会导致精度损失
<img width="778" height="173" alt="c4e51671579d94bb5dac14cd59ad7200" src="https://github.com/user-attachments/assets/9d09e0c1-4169-4618-93ff-d30cd11b096f" />
复现方法：如上issue连接，使用A100机器，运行PaddleScience下biharmonic2d案例
修改方案：在L-BFGS优化器中添加warning，引导用户export NVIDIA_TF32_OVERRIDE=0
验证：如上Issue所示，用户已验证