### PR TITLE
[0-size Tensor Job2 No.44] Add 0-size Tensor support for paddle.linalg.lu_unpack[fluid_ops] 

### DIFF
--- a/paddle/phi/infermeta/binary.cc
+++ b/paddle/phi/infermeta/binary.cc
@@ -2825,8 +2825,8 @@ void LUUnpackInferMeta(const MetaTensor& x,
                     common::errors::InvalidArgument(
                         "The rank of input must greater than 2."));
 
-  int m = static_cast<int>(x_dims[x_rank - 1]);
-  int n = static_cast<int>(x_dims[x_rank - 2]);
+  int m = static_cast<int>(x_dims[x_rank - 2]);
+  int n = static_cast<int>(x_dims[x_rank - 1]);
   int min_mn = std::min(m, n);
   if (unpack_ludata) {
     auto ldims = x_dims;

--- a/paddle/phi/kernels/impl/lu_unpack_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/lu_unpack_grad_kernel_impl.h
@@ -31,6 +31,7 @@ void LUUnpackGradKernel(const Context& dev_ctx,
                         bool unpack_pivots UNUSED,
                         DenseTensor* x_grad) {
   dev_ctx.template Alloc<T>(x_grad);
+  if (x_grad->numel() == 0) return;
 
   DenseTensor dl_tril, du_triu;
   const auto ldims = l_grad.dims();

--- a/test/legacy_test/test_lu_unpack_op.py
+++ b/test/legacy_test/test_lu_unpack_op.py
@@ -413,6 +413,28 @@ class TestLU_UnpackAPIError(unittest.TestCase):
             self.assertRaises(Exception, test_y_data)
 
 
+class TestLuUnpackAPI_ZeroSize(unittest.TestCase):
+    def test_dygraph_api(self):
+        for place in get_places():
+            paddle.disable_static(place)
+            x_np = np.random.random([2, 3, 0])
+            y_np = np.random.random([2, 3])
+            x = paddle.to_tensor(x_np)
+            x.stop_gradient = False
+            y = paddle.to_tensor(y_np)
+            out = paddle.linalg.lu_unpack(x, y)
+            np_out0 = np.array([np.eye(3) for _ in range(2)])
+            np_out1 = np.random.random([2, 3, 0])
+            np_out2 = np.random.random([2, 0, 0])
+            np.testing.assert_allclose(out[0].numpy(), np_out0)
+            np.testing.assert_allclose(out[1].numpy(), np_out1)
+            np.testing.assert_allclose(out[2].numpy(), np_out2)
+
+            paddle.sum(out[0]).backward()
+            np.testing.assert_allclose(x.grad.shape, x.shape)
+            paddle.enable_static()
+
+
 if __name__ == "__main__":
     paddle.enable_static()
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修改infermeta，m, n值设置反了，符号推导没有问题，非0-size运行时kernel中有Resize，所以没有影响
前向计算P需要按eye方式填充

增加单测，PaddleAPITest测试通过，错误为numpy error
<img width="1250" height="254" alt="image" src="https://github.com/user-attachments/assets/c0ee813b-dd66-4c66-a337-4fa163ad4d11" />
