### PR TITLE
[Slice] Support multi-dim bool tensor index

### DIFF
--- a/paddle/fluid/pybind/slice_utils.h
+++ b/paddle/fluid/pybind/slice_utils.h
@@ -519,21 +519,31 @@ static void ParseIndex(const paddle::Tensor& tensor,
           estimated_dim++;
         }
       } else {
-        if (slice_tensor.dtype() == phi::DataType::BOOL) {
-          PADDLE_ENFORCE_EQ(slice_tensor.shape()[0],
-                            dim_len,
-                            common::errors::OutOfRange(
-                                "The shape of boolean index %d did not match"
-                                "indexed tensor %d along axis %d.",
-                                slice_tensor.shape()[0],
-                                dim_len,
-                                current_dim));
-        }
         *has_advanced_index = true;
+        if (slice_tensor.dtype() == phi::DataType::BOOL) {
+          // bool tensor consumes (rank of index tensor) dimensions of input
+          // tensor
+          for (int i = 0; i < slice_tensor.shape().size(); i++) {
+            PADDLE_ENFORCE_EQ(slice_tensor.shape()[i],
+                              dim_len,
+                              common::errors::OutOfRange(
+                                  "The shape of boolean index %d did not match"
+                                  "indexed tensor %d along axis %d.",
+                                  slice_tensor.shape()[0],
+                                  dim_len,
+                                  current_dim));
+            (*advanced_index_dim)[estimated_dim] = estimated_dim;
+            estimated_dim++;
+            current_dim++;
+            dim_len = shape[current_dim];
+          }
+        } else {
+          // int tensor consumes only one dimension of input tensor
+          (*advanced_index_dim)[estimated_dim] = estimated_dim;
+          estimated_dim++;
+          current_dim++;
+        }
         advanced_index->push_back(std::move(slice_tensor));
-        (*advanced_index_dim)[estimated_dim] = estimated_dim;
-        estimated_dim++;
-        current_dim++;
       }
 
     } else {
@@ -648,13 +658,15 @@ static paddle::Tensor dealWithAdvancedIndex(
     int* rank_of_new_dim,
     std::vector<int>* trans_dim,
     bool* out_is_view) {
+  *rank_of_new_dim = 0;
   int p = 0;
   bool int_tensor_only = true;
+
   for (size_t i = 0; i < advanced_index_dim->size(); ++i) {
     auto index_dim = (*advanced_index_dim)[i];
     if (index_dim != -1) {
-      // size of advanced_index is same to number of non -1 element in
-      // advanced_index_dim
+      // sum of each advanced_index_tensor's rank equals to number of non -1
+      // element in advanced_index_dim
       auto index = (*advanced_index)[p++];
       if (index.dtype() == phi::DataType::BOOL) {
         int_tensor_only = false;
@@ -671,11 +683,23 @@ static paddle::Tensor dealWithAdvancedIndex(
       } else {
         *pos_of_new_dim = std::min(index_dim, *pos_of_new_dim);
       }
-      *rank_of_new_dim =
-          std::max(*rank_of_new_dim, static_cast<int>(index.shape().size()));
 
-      trans_dim->push_back(index_dim);
-      transed_index->push_back(std::move(index));
+      if (index.dtype() == phi::DataType::BOOL) {
+        *rank_of_new_dim = std::max(*rank_of_new_dim, 1);
+        i--;
+        for (int j = 0; j < index.shape().size(); j++) {
+          i++;
+          index_dim = (*advanced_index_dim)[i];
+          trans_dim->push_back(index_dim);
+        }
+        transed_index->push_back(std::move(index));
+      } else {
+        *rank_of_new_dim =
+            std::max(*rank_of_new_dim, static_cast<int>(index.shape().size()));
+
+        trans_dim->push_back(index_dim);
+        transed_index->push_back(std::move(index));
+      }
     }
   }
 

--- a/test/indexing/test_getitem_appendix.py
+++ b/test/indexing/test_getitem_appendix.py
@@ -230,6 +230,16 @@ class TestGetitemDygraphCombinedIndex(unittest.TestCase):
         # case 6:
         # [[[4 , 5 ],[10, 11],[16, 17],[22, 23]]]
         self.accuracy_check(x[[True, False], :, -1], y[[True, False], :, -1])
+        # case 7:
+        # [[0, 3, 4, 5], [24, 26, 28, 29]]
+        index_np = np.array([[True, False], [False, True], [True, True]])
+        index_paddle = paddle.to_tensor(index_np)
+        self.accuracy_check(x[:, 0, index_np], y[:, 0, index_paddle])
+        # case 8:
+        # [[[[0, 1]], [[2, 3]], [[24, 25]], [[26, 27]]]]
+        index_np = np.array([[0], [1]])
+        index_paddle = paddle.to_tensor(index_np)
+        self.accuracy_check(x[:, 0, index_np], y[:, 0, index_paddle])
 
 
 class Test0DTensorIndexing(unittest.TestCase):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-67164
getitem 无法正确处理含有 秩>2 的布尔高级索引。

以 Tensor([3,4,5],"float32"), (slice(None,None,None),tuple(Tensor([4,5],"bool")) 为例，
parseIndex 无法识别出布尔索引会 consume input 的 1 和 2 两个维度，而是按照整数索引的处理方式认为其只作用在第 1 维度上，从而导致在 dealWithAdvancedIndex 拿到的转置的 tensor 的形状为 [4, 3, 5]，而不是预期的 [4, 5, 3]。最终引发了维度不匹配报错：
```text
Traceback (most recent call last):
  File "/work/PaddleX/PaddleCustomDevice/Paddle/test/indexing/test_getitem_appendix.py", line 237, in test_combined
    self.accuracy_check(x[:, 0, index_np], y[:, 0, index_paddle])
  File "/work/PaddleX/PaddleCustomDevice/.venv/lib/python3.10/site-packages/paddle/base/dygraph/tensor_patch_methods.py", line 1070, in __getitem__
    return self._getitem_dygraph(item)
ValueError: (InvalidArgument) The reduce dim index 0 should be in the range [ -dimension(X), dimension(X) ) which dimension = 2. But received dim index = 2.
  [Hint: Expected axis[i] < x_rank, but received axis[i]:2 >= x_rank:2.] (at /paddle/paddle/phi/infermeta/unary.cc:5619)
```