### PR TITLE
Fix paddle.linalg.vector_norm for big tensor

### DIFF
--- a/paddle/phi/kernels/gpu/p_norm_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/p_norm_grad_kernel.cu
@@ -14,31 +14,20 @@
 
 #include "paddle/phi/kernels/p_norm_grad_kernel.h"
 
+#include <vector>
+
+#include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/abs_kernel.h"
+#include "paddle/phi/kernels/elementwise_multiply_kernel.h"
+#include "paddle/phi/kernels/funcs/eigen/common.h"
+#include "paddle/phi/kernels/funcs/eigen/eigen_function.h"
 #include "paddle/phi/kernels/funcs/math_function.h"
 #include "paddle/phi/kernels/funcs/reduce_grad_functions.h"
+#include "paddle/phi/kernels/reduce_amax_grad_kernel.h"
+#include "paddle/phi/kernels/sign_kernel.h"
 
 namespace phi {
-
-template <typename T>
-struct AbsMaxAndMinGradFunctor {
-  template <typename Context,
-            typename X,
-            typename Y,
-            typename DX,
-            typename DY,
-            typename Dim>
-  void operator()(const Context& place,
-                  X* x,
-                  Y* y,
-                  DX* dx,
-                  DY* dy,
-                  const Dim& dim,
-                  int size) {
-    dx->device(place) = dy->broadcast(dim) * (*x).sign() *
-                        ((*x).abs() == y->broadcast(dim)).template cast<T>();
-  }
-};
 
 template <typename T>
 struct PNormGradFunctor {
@@ -109,17 +98,45 @@ void PNormGradKernel(const Context& dev_ctx,
 
   auto xdim = in_x->dims();
   bool reduce_all = (in_norm->numel() == 1);
-  if (axis < 0) axis = xdim.size() + axis;
+  if (axis < 0) {
+    axis = xdim.size() + axis;
+  }
   const std::vector<int> dims = {axis};
 
   if (porder == 0) {
     phi::funcs::SetConstant<Context, T> set_zero;
     set_zero(dev_ctx, out_dx, static_cast<T>(0));
   } else if (porder == INFINITY || porder == -INFINITY) {
-    AbsMaxAndMinGradFunctor<T> functor;
-    funcs::LaunchReduceGradKernel<Context, T, AbsMaxAndMinGradFunctor<T>>(
-        dev_ctx, in_x, in_norm, in_norm_dy, out_dx, functor, dims, reduce_all);
+    std::vector<int64_t> dims_for_amax;
+    if (reduce_all) {
+      dims_for_amax.resize(xdim.size());
+      for (int i = 0; i < xdim.size(); ++i) dims_for_amax[i] = i;
+    } else {
+      dims_for_amax.push_back(axis);
+    }
 
+    DenseTensor x_abs;
+    x_abs.Resize(in_x->dims());
+    dev_ctx.template Alloc<T>(&x_abs);
+    phi::AbsKernel<T, Context>(dev_ctx, *in_x, &x_abs);
+
+    DenseTensor amax_grad_out;
+    amax_grad_out.Resize(in_x->dims());
+    dev_ctx.template Alloc<T>(&amax_grad_out);
+    phi::ReduceAMaxGradKernel<T, Context>(dev_ctx,
+                                          x_abs,
+                                          *in_norm,
+                                          *in_norm_dy,
+                                          dims_for_amax,
+                                          keepdim,
+                                          reduce_all,
+                                          &amax_grad_out);
+    DenseTensor x_sign;
+    x_sign.Resize(in_x->dims());
+    dev_ctx.template Alloc<T>(&x_sign);
+    phi::SignKernel<T, Context>(dev_ctx, *in_x, &x_sign);
+
+    phi::MultiplyKernel<T, Context>(dev_ctx, amax_grad_out, x_sign, out_dx);
   } else {
     auto functor = PNormGradFunctor<T>(porder, epsilon);
     funcs::LaunchReduceGradKernel<Context, T, PNormGradFunctor<T>>(
@@ -127,6 +144,7 @@ void PNormGradKernel(const Context& dev_ctx,
   }
 }
 }  // namespace phi
+
 PD_REGISTER_KERNEL(p_norm_grad,
                    GPU,
                    ALL_LAYOUT,

--- a/paddle/phi/kernels/gpu/p_norm_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/p_norm_grad_kernel.cu
@@ -66,50 +66,6 @@ struct PNormGradFunctor {
   MT eps;
 };
 
-//   template <typename Context,
-//             typename X,
-//             typename Y,
-//             typename DX,
-//             typename DY,
-//             typename Dim>
-//   void operator()(const Context& place,
-//                   X* x,
-//                   Y* y,
-//                   DX* dx,
-//                   DY* dy,
-//                   const Dim& dim,
-//                   int size) {
-//     auto x_mt = x->template cast<MT>();
-//     auto y_mt = y->template cast<MT>();
-//     auto dy_mt = dy->template cast<MT>();
-
-//     auto norm_pow = y_mt.pow(-this->porder);
-//     auto mask_norm_nonzero = (y_mt != static_cast<MT>(0)).template
-//     cast<MT>();
-
-//     // Set to 0 where porder < 0 and x == 0
-//     MT zero = static_cast<MT>(0);
-//     auto mask_x_zero = (x_mt == zero).template cast<MT>();
-
-//     MT is_porder_negative =
-//         this->porder < zero ? static_cast<MT>(1) : static_cast<MT>(0);
-//     auto invalid_mask = (mask_x_zero * is_porder_negative);
-//     auto safe_pow =
-//         x_mt.abs().pow(this->porder) * (static_cast<MT>(1) - invalid_mask);
-
-//     dx->device(place) =
-//         (safe_pow * x_mt.sign() * dy_mt.broadcast(dim) *
-//          norm_pow.broadcast(dim) *
-//          mask_norm_nonzero.broadcast(dim)  // Mask out positions where norm
-//          == 0
-//          )
-//             .template cast<T>();
-//   }
-
-//   MT porder;
-//   MT eps;
-// };
-
 template <typename T, typename Context>
 void PNormGradKernel(const Context& dev_ctx,
                      const DenseTensor& x,

--- a/paddle/phi/kernels/gpu/p_norm_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/p_norm_grad_kernel.cu
@@ -52,12 +52,10 @@ struct PNormGradFunctor {
                   int size) {
     auto unstable_term =
         (*x).abs().template cast<MT>().pow(this->porder).template cast<T>();
-
     auto mask = (*x) == x->constant(static_cast<T>(0));
     auto stable_term =
         mask.select(x->constant(static_cast<T>(0)), unstable_term);
     auto self_scaled = (*x).sign() * stable_term;
-
     auto norm_term =
         (*y).template cast<MT>().pow(-this->porder).template cast<T>();
     dx->device(place) =

--- a/paddle/phi/kernels/gpu/p_norm_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/p_norm_grad_kernel.cu
@@ -50,29 +50,14 @@ struct PNormGradFunctor {
                   DY* dy,
                   const Dim& dim,
                   int size) {
-    auto x_mt = x->template cast<MT>();
-    auto y_mt = y->template cast<MT>();
-    auto dy_mt = dy->template cast<MT>();
-
-    auto norm_pow = y_mt.pow(-this->porder);
-    auto mask_norm_nonzero = (y_mt != static_cast<MT>(0)).template cast<MT>();
-
-    // Set to 0 where porder < 0 and x == 0
-    MT zero = static_cast<MT>(0);
-    auto mask_x_zero = (x_mt == zero).template cast<MT>();
-
-    MT is_porder_negative =
-        this->porder < zero ? static_cast<MT>(1) : static_cast<MT>(0);
-    auto invalid_mask = (mask_x_zero * is_porder_negative);
-    auto safe_pow =
-        x_mt.abs().pow(this->porder) * (static_cast<MT>(1) - invalid_mask);
-
+    auto unstable_term = (*x).abs().pow(this->porder);
+    auto mask = (*x) == x->constant(static_cast<T>(0));
+    auto stable_term =
+        mask.select(x->constant(static_cast<T>(0)), unstable_term);
+    auto self_scaled = (*x).sign() * stable_term;
+    auto norm_term = (*y).pow(-this->porder);
     dx->device(place) =
-        (safe_pow * x_mt.sign() * dy_mt.broadcast(dim) *
-         norm_pow.broadcast(dim) *
-         mask_norm_nonzero.broadcast(dim)  // Mask out positions where norm == 0
-         )
-            .template cast<T>();
+        self_scaled * dy->broadcast(dim) * norm_term.broadcast(dim);
   }
 
   MT porder;

--- a/paddle/phi/kernels/gpu/p_norm_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/p_norm_grad_kernel.cu
@@ -33,7 +33,7 @@ template <typename T>
 struct PNormGradFunctor {
   using MT = typename phi::dtype::MPTypeTrait<T>::Type;
   HOSTDEVICE explicit inline PNormGradFunctor(float porder, float eps) {
-    this->porder = static_cast<MT>(porder - 1.);
+    this->porder = static_cast<MT>(porder - 1.0f);
     this->eps = static_cast<MT>(eps);
   }
 
@@ -50,12 +50,16 @@ struct PNormGradFunctor {
                   DY* dy,
                   const Dim& dim,
                   int size) {
-    auto unstable_term = (*x).abs().pow(this->porder);
+    auto unstable_term =
+        (*x).abs().template cast<MT>().pow(this->porder).template cast<T>();
+
     auto mask = (*x) == x->constant(static_cast<T>(0));
     auto stable_term =
         mask.select(x->constant(static_cast<T>(0)), unstable_term);
     auto self_scaled = (*x).sign() * stable_term;
-    auto norm_term = (*y).pow(-this->porder);
+
+    auto norm_term =
+        (*y).template cast<MT>().pow(-this->porder).template cast<T>();
     dx->device(place) =
         self_scaled * dy->broadcast(dim) * norm_term.broadcast(dim);
   }
@@ -63,6 +67,50 @@ struct PNormGradFunctor {
   MT porder;
   MT eps;
 };
+
+//   template <typename Context,
+//             typename X,
+//             typename Y,
+//             typename DX,
+//             typename DY,
+//             typename Dim>
+//   void operator()(const Context& place,
+//                   X* x,
+//                   Y* y,
+//                   DX* dx,
+//                   DY* dy,
+//                   const Dim& dim,
+//                   int size) {
+//     auto x_mt = x->template cast<MT>();
+//     auto y_mt = y->template cast<MT>();
+//     auto dy_mt = dy->template cast<MT>();
+
+//     auto norm_pow = y_mt.pow(-this->porder);
+//     auto mask_norm_nonzero = (y_mt != static_cast<MT>(0)).template
+//     cast<MT>();
+
+//     // Set to 0 where porder < 0 and x == 0
+//     MT zero = static_cast<MT>(0);
+//     auto mask_x_zero = (x_mt == zero).template cast<MT>();
+
+//     MT is_porder_negative =
+//         this->porder < zero ? static_cast<MT>(1) : static_cast<MT>(0);
+//     auto invalid_mask = (mask_x_zero * is_porder_negative);
+//     auto safe_pow =
+//         x_mt.abs().pow(this->porder) * (static_cast<MT>(1) - invalid_mask);
+
+//     dx->device(place) =
+//         (safe_pow * x_mt.sign() * dy_mt.broadcast(dim) *
+//          norm_pow.broadcast(dim) *
+//          mask_norm_nonzero.broadcast(dim)  // Mask out positions where norm
+//          == 0
+//          )
+//             .template cast<T>();
+//   }
+
+//   MT porder;
+//   MT eps;
+// };
 
 template <typename T, typename Context>
 void PNormGradKernel(const Context& dev_ctx,
@@ -120,7 +168,6 @@ void PNormGradKernel(const Context& dev_ctx,
     x_sign.Resize(in_x->dims());
     dev_ctx.template Alloc<T>(&x_sign);
     phi::SignKernel<T, Context>(dev_ctx, *in_x, &x_sign);
-
     phi::MultiplyKernel<T, Context>(dev_ctx, amax_grad_out, x_sign, out_dx);
   } else {
     auto functor = PNormGradFunctor<T>(porder, epsilon);

--- a/paddle/phi/kernels/gpu/p_norm_kernel.cu
+++ b/paddle/phi/kernels/gpu/p_norm_kernel.cu
@@ -22,7 +22,6 @@
 #include "paddle/phi/kernels/funcs/reduce_function.h"
 #include "paddle/phi/kernels/gpu/reduce.h"
 
-#include "paddle/fluid/framework/tensor_util.h"
 #include "paddle/phi/kernels/activation_kernel.h"
 
 namespace phi {
@@ -135,6 +134,7 @@ void PNormKernel(const Context& dev_ctx,
       // fast 1-norm
       phi::funcs::ReduceKernel<T, T, kps::AddFunctor, FabsFunctor<T>>(
           dev_ctx, *in_x, out_norm, FabsFunctor<T>(), reduce_axis);
+      return;
     } else if (porder == 2.0) {
       // fast 2-norm
       using MT = typename phi::dtype::MPTypeTrait<T>::Type;
@@ -154,7 +154,6 @@ void PNormKernel(const Context& dev_ctx,
       phi::SqrtKernel<MT>(dev_ctx, temp_sum_of_squares_hp, &temp_norm_hp);
       phi::CastKernel<MT>(dev_ctx, temp_norm_hp, out_norm->dtype(), out_norm);
       return;
-
     } else if (porder == 3.0) {
       // fast 3-norm
       phi::funcs::ReduceKernel<T, MT, kps::AddFunctor, FabsCubicFunctor<MT>>(
@@ -168,14 +167,11 @@ void PNormKernel(const Context& dev_ctx,
           UnsignedPowFunctor<MT>(porder),
           reduce_axis);
     }
-
-    if (porder != 1.0) {
-      std::vector<const DenseTensor*> ins = {&out_temp};
-      std::vector<DenseTensor*> outs = {out_norm};
-      MT p_order_ = static_cast<MT>(1.f / porder);
-      phi::funcs::ElementwiseKernel<T>(
-          dev_ctx, ins, &outs, UnsignedPowFunctor<MT>(p_order_));
-    }
+    std::vector<const DenseTensor*> ins = {&out_temp};
+    std::vector<DenseTensor*> outs = {out_norm};
+    MT p_order_ = static_cast<MT>(1.f / porder);
+    phi::funcs::ElementwiseKernel<T>(
+        dev_ctx, ins, &outs, UnsignedPowFunctor<MT>(p_order_));
 #endif
   }
 }

--- a/paddle/phi/kernels/gpu/p_norm_kernel.cu
+++ b/paddle/phi/kernels/gpu/p_norm_kernel.cu
@@ -22,6 +22,9 @@
 #include "paddle/phi/kernels/funcs/reduce_function.h"
 #include "paddle/phi/kernels/gpu/reduce.h"
 
+#include "paddle/fluid/framework/tensor_util.h"
+#include "paddle/phi/kernels/activation_kernel.h"
+
 namespace phi {
 template <typename T>
 struct NonzeroFunctor {
@@ -134,8 +137,24 @@ void PNormKernel(const Context& dev_ctx,
           dev_ctx, *in_x, out_norm, FabsFunctor<T>(), reduce_axis);
     } else if (porder == 2.0) {
       // fast 2-norm
-      phi::funcs::ReduceKernel<T, MT, kps::AddFunctor, SquareFunctor<MT>>(
-          dev_ctx, *in_x, &out_temp, SquareFunctor<MT>(), reduce_axis);
+      using MT = typename phi::dtype::MPTypeTrait<T>::Type;
+      phi::DenseTensor temp_sum_of_squares_hp;
+      temp_sum_of_squares_hp.Resize(out_norm->dims());
+      dev_ctx.template Alloc<MT>(&temp_sum_of_squares_hp);
+      phi::funcs::ReduceKernel<T, MT, kps::AddFunctor, SquareFunctor<T>>(
+          dev_ctx,
+          *in_x,
+          &temp_sum_of_squares_hp,
+          SquareFunctor<T>(),
+          reduce_axis);
+
+      phi::DenseTensor temp_norm_hp;
+      temp_norm_hp.Resize(out_norm->dims());
+      dev_ctx.template Alloc<MT>(&temp_norm_hp);
+      phi::SqrtKernel<MT>(dev_ctx, temp_sum_of_squares_hp, &temp_norm_hp);
+      phi::CastKernel<MT>(dev_ctx, temp_norm_hp, out_norm->dtype(), out_norm);
+      return;
+
     } else if (porder == 3.0) {
       // fast 3-norm
       phi::funcs::ReduceKernel<T, MT, kps::AddFunctor, FabsCubicFunctor<MT>>(

--- a/paddle/phi/kernels/gpu/reduce_kernel.cu
+++ b/paddle/phi/kernels/gpu/reduce_kernel.cu
@@ -262,7 +262,9 @@ PD_REGISTER_KERNEL(amax_grad,
                    float,
                    double,
                    int,
-                   int64_t) {}
+                   int64_t,
+                   phi::dtype::float16,
+                   phi::dtype::bfloat16) {}
 
 PD_REGISTER_KERNEL(amin_grad,
                    GPU,


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Bug fixes

### Description

---

### 修复 `p_norm` 内核及相关 API 的多项问题

#### 一、 概述 

本次修复主要针对 `p_norm` kernel在以下四个方面的问题：

1.  **无穷范数 (p=inf)**：反向梯度分配策略与 PyTorch 不一致。
2.  **L2范数 (p=2)**：在 `FP16` 精度下，中间结果累加可能导致上溢出变为 `inf`。
3.  **多种范数**：计算过程中存在 `int32` 溢出风险，可能导致 `error 700` 或精度错误。（rebase以后发现已经被修改）
4.  **负数范数 (p=-1)**：反向传播的计算逻辑与 PyTorch 未对齐，导致精度问题。

下面将对每个问题的具体成因和修复方案进行详细说明。

---

#### 二、 问题详情与修复方案

##### 1. 无穷范数 (p=inf) 的反向梯度分配策略

*   **问题描述**：
    在计算无穷范数的反向梯度时，当输入张量中存在多个绝对值相等的最大值时，PaddlePaddle 与 PyTorch 的梯度分配策略存在差异。
    *   **PaddlePaddle (修复前)**: 将梯度 `1.0` 赋给**所有**绝对值最大的元素。
    *   **PyTorch (对齐目标)**: 将梯度 `1.0` 在所有绝对值最大的元素之间进行**平均分配**。

*   **修复方案**：
    在 `p_norm_grad_kernel.cu` 中，参考了 `amax` kernel 实现。该 kernel 会统计出绝对值最大元素的个数，并在反向传播时将梯度进行平均分配，从而与 PyTorch 的行为保持一致。

##### 2. L2范数 (p=2) 在 FP16 精度下的溢出问题

*   **问题描述**：
    当使用 `FP16` 数据类型计算 L2 范数时，`ReduceAnyKernel` 和 `ReduceHigherDimKernel` 中的累加操作使用了 `FP32` 的累加器 `reduce_var` 以保证精度。但在计算结束后，通过 `Ty result = static_cast<Ty>(reduce_var);` 将结果转换回 `FP16` (`Ty` 此时为 `half`)。如果 `reduce_var` 的值超过了 `FP16` 的最大表示范围 (65504)，`result` 就会上溢出为 `inf`。

*   **修复方案**：
    考虑到 `Reduce*` kernel 的通用性，为避免影响其他模块，选择在调用层进行处理。在 `p_norm_kernel.cu` 中，对调用 `Reduce*` kernel 的模板参数进行了修改，**强制要求返回类型 `Ty` 为 `FP32`**，从而避免了从 `FP32` 到 `FP16` 的溢出转换，同时对计算结果直接进行开方和强转，避免后续的问题。

##### 3. 多种范数下的整数溢出风险

*   **问题描述**：
    在 `reduce_grad_functions.h` 的实现中，部分用于索引计算或计数的变量使用了 `int` (32位整型)。当处理超大规模的张量时，这些变量可能发生整数溢出，进而导致 `error 700`  或计算结果的精度错误。

*   **修复方案**：
    将 `reduce_grad_functions.h` 中存在溢出风险的 `int` 类型变量统一调整为 `int64_t`，确保在处理大规模数据时能够正确计算。

##### 4. 负数范数 (p=-1) 的反向传播逻辑

*   **问题描述**：
    当 `p = -1` 时，`p_norm` 反向传播的计算逻辑与 PyTorch 未完全对齐，导致在特定场景下出现精度差异。

*   **修复方案**：
    在 `p_norm_grad_kernel.cu` 的 `PNormGradFunctor` 函数中，对 `p < 0` 分支下的反向计算公式进行了修正，使其与 PyTorch 的实现逻辑对齐。
