### PR TITLE
[0-size Tensor Job2 No.97] Add 0-size Tensor support for paddle.Tensor.set_[fluid_ops]

### DIFF
--- a/paddle/phi/kernels/set_kernel.cc
+++ b/paddle/phi/kernels/set_kernel.cc
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include "paddle/phi/kernels/set_kernel.h"
+#include "glog/logging.h"
 #include "paddle/phi/core/kernel_registry.h"
-
+#include "paddle/phi/kernels/full_kernel.h"
 namespace phi {
 
 template <typename T, typename Context>
@@ -28,6 +29,17 @@ void SetKernel(const Context& dev_ctx,
   meta.dims = DDim(dims.data(), static_cast<int>(dims.size()));
   meta.strides = DDim(stride.data(), static_cast<int>(stride.size()));
   meta.offset = offset;
+  if (x.numel() == 0 || source.numel() == 0) {
+    if (source.numel() != 0) {
+      out->clear();
+      *out = DenseTensor{source.Holder(), meta};
+    } else if (x.numel() == 0) {
+      phi::Full<T, Context>(
+          dev_ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
+    }
+    out->ShareInplaceVersionCounterWith(x);
+    return;
+  }
   if (x.IsSharedWith(source)) {
     out->set_meta(meta);
   } else {

--- a/paddle/phi/kernels/set_kernel.cc
+++ b/paddle/phi/kernels/set_kernel.cc
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include "paddle/phi/kernels/set_kernel.h"
-#include "glog/logging.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/full_kernel.h"
 namespace phi {

--- a/test/legacy_test/test_inplace.py
+++ b/test/legacy_test/test_inplace.py
@@ -16,6 +16,7 @@ import functools
 import unittest
 
 import numpy as np
+from op_test import get_places
 
 import paddle
 
@@ -2489,6 +2490,17 @@ class TestDygraphInplaceResizeBF16(TestDygraphInplaceResize):
                 x = paddle.to_tensor(self.x_np).astype(self.dtype)
                 inplace_x2 = self.inplace_api_processing(x, self.new_shape2)
                 self.assertTrue(id(x) == id(inplace_x2))
+
+
+class TestSet_API_ZeroSize(unittest.TestCase):
+    def setUp(self):
+        self.places = get_places()
+
+    def test_set_api(self):
+        for place in self.places:
+            with paddle.base.dygraph.guard(place):
+                out = paddle.randn([20]).set_(paddle.randn([0, 3]), [20], [2])
+                np.testing.assert_allclose(out.shape, [20])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
因为torch返回结果为随机值，增加单测是测试返回shape
如果source numel 不为0，按source Holder构造返回数据，如果x numel为0，使用0填充返回

torch 测试代码
```
import torch
x = torch.ones([20])
ret = x.set_(torch.ones([0, 3]), 0, [20], [2])
print(ret)

tensor([-8.7228e-09,  1.7631e+00,  0.0000e+00,  0.0000e+00,  1.8491e+31,
         3.2181e+21,  1.0961e+18,  3.9173e-02,  7.5650e+28,  4.5927e+27,
         2.6912e+20,  1.1718e-32,  1.0832e+24,  3.0981e+32,  3.2181e+21,
         8.0424e+20,  1.0927e+24,  6.5952e+22,  7.7140e+31,  1.2695e+31])
```

PaddleAPITest是精度错误，在PaddleAPITest修改配置 https://github.com/PFCCLab/PaddleAPITest/pull/426
<img width="1347" height="475" alt="image" src="https://github.com/user-attachments/assets/b3592467-0ef0-4b24-81b9-67b2b1aa543f" />
