### PR TITLE
add phi::Full out parameter check

### DIFF
--- a/paddle/phi/kernels/full_kernel.h
+++ b/paddle/phi/kernels/full_kernel.h
@@ -62,6 +62,7 @@ void Full(const Context& dev_ctx,
           const IntArray& shape,
           const Scalar& val,
           DenseTensor* out) {
+  if (!out) return;
   FullKernel<T, Context>(
       dev_ctx, shape, val, phi::CppTypeToDataType<T>::Type(), out);
 }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
kernel 中调用  phi::Full 时，out 参数可能为空，增加为空检查