### PR TITLE
[BIG tensor]Fix int32 overflow for l1_loss

### DIFF
--- a/paddle/phi/kernels/funcs/reduce_function.h
+++ b/paddle/phi/kernels/funcs/reduce_function.h
@@ -607,7 +607,8 @@ __global__ void ReduceAnyKernel(const Tx* x,
                                 bool is_mean,
                                 MPType* tmp_data,
                                 bool need_store_tmp = false) {
-  IndexType input_idx, left_idx, stride;
+  int64_t input_idx;
+  IndexType left_idx, stride;
   IndexType block_size = 0;
   bool need_store = true;
   IndexType loop_left = 0;
@@ -644,7 +645,7 @@ __global__ void ReduceAnyKernel(const Tx* x,
   // 1. reduce for each thread
   MPType input_compute[REDUCE_VEC_SIZE];
   Tx input_reg[REDUCE_VEC_SIZE];
-  IndexType input_idx_tmp = input_idx;
+  int64_t input_idx_tmp = input_idx;
   for (IndexType i = 0; i < loop_left; i += stride_left) {
     IndexType input_offset = left_index_calculator(left_idx + i);
     const _ptr_ Tx* input = x + input_offset;
@@ -653,7 +654,7 @@ __global__ void ReduceAnyKernel(const Tx* x,
     IndexType bound = reduce_num - (REDUCE_VEC_SIZE - 1) * stride;
     input_idx = input_idx_tmp;
     for (; input_idx + block_size < bound;
-         input_idx += REDUCE_VEC_SIZE * stride) {
+         input_idx += REDUCE_VEC_SIZE * static_cast<int64_t>(stride)) {
       kps::ReadDataReduce<Tx,
                           Tx,
                           1,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
#### 修复paddle.nn.functional.l1_loss底层Reduce Kernel int32溢出问题
Pcard-73145

- 测例
```
import paddle
input = paddle.rand([1, 2147483646], dtype="float16") //接近但小于int32边界
label = paddle.rand([1, 2147483646], dtype="float16") //接近但小于int32边界
l1_loss = paddle.nn.functional.l1_loss(input, label)
print(l1_loss)
```
- 触发原因
input.numel() 小于int32 边界 -> 走ReduceAnyKernel indextype int32分支 ->
`
for (; input_idx + block_size < bound; input_idx += REDUCE_VEC_SIZE * stride)
`
input_idx在循环最后一次可能int32溢出