### PR TITLE
[0-size Tensor Job2 No.51] Add 0-size Tensor support for paddle.multiplex 

### DIFF
--- a/paddle/phi/kernels/cpu/multiplex_kernel.cc
+++ b/paddle/phi/kernels/cpu/multiplex_kernel.cc
@@ -26,6 +26,7 @@ void MultiplexKernel(const Context& dev_ctx,
                      const DenseTensor& ids,
                      DenseTensor* out) {
   dev_ctx.template Alloc<T>(out);
+  if (out->numel() == 0) return;
   for (size_t i = 0; i < ins.size(); ++i) {
     PADDLE_ENFORCE_GT(
         ins[i]->numel(),

--- a/paddle/phi/kernels/gpu/multiplex_kernel.cu
+++ b/paddle/phi/kernels/gpu/multiplex_kernel.cu
@@ -27,6 +27,7 @@ void MultiplexKernel(const Context& dev_ctx,
                      const DenseTensor& ids,
                      DenseTensor* out) {
   dev_ctx.template Alloc<T>(out);
+  if (out->numel() == 0) return;
   for (size_t i = 0; i < ins.size(); ++i) {
     PADDLE_ENFORCE_GT(
         ins[i]->numel(),


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
<!--
输入为数组，包含多个Tensor
修改infermeta，符号推导，选择输入shape中不为0-size的项设置为输出维度
因为index参数可能选择0-size的项或不选择，如果选择的都是0-size，输出需要Resize，所以kernel结尾增加Resize部分
-->
输入shape一致都为0-size，判断out numel返回

PaddleAPITest中为自定义规则torch.stack
https://github.com/PFCCLab/PaddleAPITest/blob/81e9f10d78ec53b8a56684b75bcdcf108f38a43f/tester/paddle_to_torch/rules.py#L3795
<img width="819" height="310" alt="image" src="https://github.com/user-attachments/assets/34a1b6fa-1f72-417a-98b5-4fc1c934ade0" />


增加单测
PaddleAPITest测试通过，错误为 torch error
<img width="1338" height="452" alt="image" src="https://github.com/user-attachments/assets/25c4e4a8-55c4-4e40-8062-ddf27abb9a28" />
