### PR TITLE
[Auto Parallel] add spmd_rule for moe_combine moe_combine_grad moe_gate_dispatch moe_gate_dispatch_grad

### DIFF
--- a/paddle/phi/infermeta/spmd_rules/moe_combine.cc
+++ b/paddle/phi/infermeta/spmd_rules/moe_combine.cc
@@ -25,9 +25,9 @@ limitations under the License. */
 namespace phi {
 namespace distributed {
 
-SpmdInfo MoECombineFwdInferSpmd(const DistMetaTensor& x,
-                                const DistMetaTensor& combine_weights,
-                                const DistMetaTensor& scatter_index) {
+SpmdInfo MoECombineInferSpmd(const DistMetaTensor& x,
+                             const DistMetaTensor& combine_weights,
+                             const DistMetaTensor& scatter_index) {
   /* kernel logic:
   y is [seqlen, hidden_size]
   for kk in k:
@@ -107,10 +107,10 @@ SpmdInfo MoECombineFwdInferSpmd(const DistMetaTensor& x,
           {y_dist_attr_dst}};
 }
 
-SpmdInfo MoECombineBwdInferSpmd(const DistMetaTensor& x,
-                                const DistMetaTensor& combine_weights,
-                                const DistMetaTensor& scatter_index,
-                                const DistMetaTensor& grad_y) {
+SpmdInfo MoECombineGradInferSpmd(const DistMetaTensor& x,
+                                 const DistMetaTensor& combine_weights,
+                                 const DistMetaTensor& scatter_index,
+                                 const DistMetaTensor& grad_y) {
   /* kernel logic:
   for(int i = 0; i < s; ++i) {
       for(int j = 0; j < h; ++j) {

--- a/paddle/phi/infermeta/spmd_rules/moe_combine.h
+++ b/paddle/phi/infermeta/spmd_rules/moe_combine.h
@@ -22,14 +22,14 @@ limitations under the License. */
 namespace phi {
 namespace distributed {
 
-SpmdInfo MoECombineFwdInferSpmd(const DistMetaTensor& x,
-                                const DistMetaTensor& combine_weights,
-                                const DistMetaTensor& scatter_index);
+SpmdInfo MoECombineInferSpmd(const DistMetaTensor& x,
+                             const DistMetaTensor& combine_weights,
+                             const DistMetaTensor& scatter_index);
 
-SpmdInfo MoECombineBwdInferSpmd(const DistMetaTensor& x,
-                                const DistMetaTensor& combine_weights,
-                                const DistMetaTensor& scatter_index,
-                                const DistMetaTensor& grad_y);
+SpmdInfo MoECombineGradInferSpmd(const DistMetaTensor& x,
+                                 const DistMetaTensor& combine_weights,
+                                 const DistMetaTensor& scatter_index,
+                                 const DistMetaTensor& grad_y);
 
 }  // namespace distributed
 }  // namespace phi

--- a/paddle/phi/infermeta/spmd_rules/moe_gate_dispatch.cc
+++ b/paddle/phi/infermeta/spmd_rules/moe_gate_dispatch.cc
@@ -32,7 +32,7 @@ SpmdInfo MoEGateDispatchInferSpmd(const DistMetaTensor& x,
   inputs:
     x: [S, H], S = b*s
     gate_logits: [S, E]
-    corr_bias: [E] (could be nullptr)
+    corr_bias: [E] (optional)
   outputs:
     y: [E, C, H] is use_pad is true, else [S, K, H], currently only support
   use_pad=true combine_weights: [S, K] scatter_index: [K, S] expert_offset: [E]

--- a/paddle/phi/infermeta/spmd_rules/moe_gate_dispatch.cc
+++ b/paddle/phi/infermeta/spmd_rules/moe_gate_dispatch.cc
@@ -22,11 +22,11 @@ limitations under the License. */
 namespace phi {
 namespace distributed {
 
-SpmdInfo MoEGateDispatchFwdInferSpmd(const DistMetaTensor& x,
-                                     const DistMetaTensor& gate_logits,
-                                     int64_t k,
-                                     int64_t capacity,
-                                     bool use_pad) {
+SpmdInfo MoEGateDispatchInferSpmd(const DistMetaTensor& x,
+                                  const DistMetaTensor& gate_logits,
+                                  int64_t k,
+                                  int64_t capacity,
+                                  bool use_pad) {
   /*
   inputs:
     x: [S, H], S = b*s
@@ -115,14 +115,15 @@ SpmdInfo MoEGateDispatchFwdInferSpmd(const DistMetaTensor& x,
            expert_id_dist_attr}};
 }
 
-SpmdInfo MoEGateDispatchBwdInferSpmd(const DistMetaTensor& combine_weights,
-                                     const DistMetaTensor& scatter_index,
-                                     const DistMetaTensor& expert_id,
-                                     const DistMetaTensor& grad_y,
-                                     const DistMetaTensor& grad_combine_weights,
-                                     int64_t k,
-                                     int64_t capacity,
-                                     bool use_pad) {
+SpmdInfo MoEGateDispatchGradInferSpmd(
+    const DistMetaTensor& combine_weights,
+    const DistMetaTensor& scatter_index,
+    const DistMetaTensor& expert_id,
+    const DistMetaTensor& grad_y,
+    const DistMetaTensor& grad_combine_weights,
+    int64_t k,
+    int64_t capacity,
+    bool use_pad) {
   /*
     inputs:
       combine_weights: [S, K]

--- a/paddle/phi/infermeta/spmd_rules/moe_gate_dispatch.cc
+++ b/paddle/phi/infermeta/spmd_rules/moe_gate_dispatch.cc
@@ -24,6 +24,7 @@ namespace distributed {
 
 SpmdInfo MoEGateDispatchInferSpmd(const DistMetaTensor& x,
                                   const DistMetaTensor& gate_logits,
+                                  const DistMetaTensor& corr_bias,
                                   int64_t k,
                                   int64_t capacity,
                                   bool use_pad) {
@@ -31,6 +32,7 @@ SpmdInfo MoEGateDispatchInferSpmd(const DistMetaTensor& x,
   inputs:
     x: [S, H], S = b*s
     gate_logits: [S, E]
+    corr_bias: [E] (could be nullptr)
   outputs:
     y: [E, C, H] is use_pad is true, else [S, K, H], currently only support
   use_pad=true combine_weights: [S, K] scatter_index: [K, S] expert_offset: [E]
@@ -52,6 +54,15 @@ SpmdInfo MoEGateDispatchInferSpmd(const DistMetaTensor& x,
       errors::InvalidArgument("gate_logits should be a 2-D tensor, but "
                               "got gate_logits_shape.size() == %d",
                               gate_logits_shape.size()));
+  if (corr_bias.initialized()) {
+    EXTRACT_SHAPE_AND_DIST_ATTR_WITH_DIM_CK(corr_bias);
+    PADDLE_ENFORCE_EQ(
+        corr_bias_shape.size(),
+        1,
+        errors::InvalidArgument("corr_bias should be a 1-D tensor, but "
+                                "got corr_bias_shape.size() == %d",
+                                corr_bias_shape.size()));
+  }
   // infer axes dims_mapping
   std::string x_axes = "sh";
   std::string gate_logits_axes = "se";
@@ -73,6 +84,7 @@ SpmdInfo MoEGateDispatchInferSpmd(const DistMetaTensor& x,
   TensorDistAttr gate_logits_dist_attr_dst =
       CopyTensorDistAttrForOutput(gate_logits_dist_attr_src);
   gate_logits_dist_attr_dst.set_dims_mapping(gate_logits_dims_mapping_dst);
+  TensorDistAttr corr_bias_dist_attr_dst;
 
   // output axes
   std::string y_axes = "esh";
@@ -107,7 +119,16 @@ SpmdInfo MoEGateDispatchInferSpmd(const DistMetaTensor& x,
   TensorDistAttr expert_id_dist_attr =
       CopyTensorDistAttrForOutput(x_dist_attr_src);
   expert_id_dist_attr.set_dims_mapping(expert_id_dims_mapping);
-  return {{x_dist_attr_dst, gate_logits_dist_attr_dst},
+  if (corr_bias.initialized()) {
+    EXTRACT_SHAPE_AND_DIST_ATTR(corr_bias);
+    corr_bias_dist_attr_dst =
+        CopyTensorDistAttrForOutput(corr_bias_dist_attr_src);
+    corr_bias_dist_attr_dst.set_dims_mapping(
+        std::vector<int64_t>{gate_logits_dist_attr_dst.dims_mapping().back()});
+  } else {
+    corr_bias_dist_attr_dst = TensorDistAttr();
+  }
+  return {{x_dist_attr_dst, gate_logits_dist_attr_dst, corr_bias_dist_attr_dst},
           {y_dist_attr_dst,
            combine_weights_dist_attr,
            scatter_index_dist_attr,

--- a/paddle/phi/infermeta/spmd_rules/moe_gate_dispatch.h
+++ b/paddle/phi/infermeta/spmd_rules/moe_gate_dispatch.h
@@ -21,6 +21,7 @@ namespace distributed {
 
 SpmdInfo MoEGateDispatchInferSpmd(const DistMetaTensor& x,
                                   const DistMetaTensor& gate_logits,
+                                  const DistMetaTensor& corr_bias,
                                   int64_t k,
                                   int64_t capacity,
                                   bool use_pad);

--- a/paddle/phi/infermeta/spmd_rules/moe_gate_dispatch.h
+++ b/paddle/phi/infermeta/spmd_rules/moe_gate_dispatch.h
@@ -19,21 +19,22 @@ limitations under the License. */
 namespace phi {
 namespace distributed {
 
-SpmdInfo MoEGateDispatchFwdInferSpmd(const DistMetaTensor& x,
-                                     const DistMetaTensor& gate_logits,
-                                     int64_t k,
-                                     int64_t capacity,
-                                     bool use_pad);
+SpmdInfo MoEGateDispatchInferSpmd(const DistMetaTensor& x,
+                                  const DistMetaTensor& gate_logits,
+                                  int64_t k,
+                                  int64_t capacity,
+                                  bool use_pad);
 // out: "y", "combine_weights", "scatter_index", "expert_offset", "expert_id"
 
-SpmdInfo MoEGateDispatchBwdInferSpmd(const DistMetaTensor& combine_weights,
-                                     const DistMetaTensor& scatter_index,
-                                     const DistMetaTensor& expert_id,
-                                     const DistMetaTensor& grad_y,
-                                     const DistMetaTensor& grad_combine_weights,
-                                     int64_t k,
-                                     int64_t capacity,
-                                     bool use_pad);
+SpmdInfo MoEGateDispatchGradInferSpmd(
+    const DistMetaTensor& combine_weights,
+    const DistMetaTensor& scatter_index,
+    const DistMetaTensor& expert_id,
+    const DistMetaTensor& grad_y,
+    const DistMetaTensor& grad_combine_weights,
+    int64_t k,
+    int64_t capacity,
+    bool use_pad);
 // out: "x_grad", "gate_logits_grad"
 
 }  // namespace distributed

--- a/paddle/phi/infermeta/spmd_rules/rules.cc
+++ b/paddle/phi/infermeta/spmd_rules/rules.cc
@@ -835,4 +835,14 @@ PD_REGISTER_SPMD_RULE(
 PD_REGISTER_SPMD_RULE(einsum,
                       PD_INFER_SPMD(phi::distributed::EinsumInferSpmd),
                       PD_INFER_SPMD(phi::distributed::EinsumGradInferSpmd));
+// moe_gate_dispatch
+PD_REGISTER_SPMD_RULE(
+    moe_gate_dispatch,
+    PD_INFER_SPMD(phi::distributed::MoEGateDispatchInferSpmd),
+    PD_INFER_SPMD(phi::distributed::MoEGateDispatchGradInferSpmd));
+
+// moe_combine
+PD_REGISTER_SPMD_RULE(moe_combine,
+                      PD_INFER_SPMD(phi::distributed::MoECombineInferSpmd),
+                      PD_INFER_SPMD(phi::distributed::MoECombineGradInferSpmd));
 }  // namespace phi::distributed

--- a/paddle/phi/ops/yaml/backward.yaml
+++ b/paddle/phi/ops/yaml/backward.yaml
@@ -2356,6 +2356,7 @@
   output : Tensor(x_grad), Tensor(combine_weights_grad)
   infer_meta :
     func : MoeCombineGradInferMeta
+    spmd_rule : MoECombineBwdInferSpmd
   kernel :
     func : moe_combine_grad
 
@@ -2376,6 +2377,7 @@
   output : Tensor(x_grad), Tensor(gate_logits_grad)
   infer_meta :
     func : MoeGateDispatchGradInferMeta
+    spmd_rule : MoEGateDispatchBwdInferSpmd
   kernel :
     func : moe_gate_dispatch_grad
     data_type : y_grad

--- a/paddle/phi/ops/yaml/backward.yaml
+++ b/paddle/phi/ops/yaml/backward.yaml
@@ -2356,7 +2356,7 @@
   output : Tensor(x_grad), Tensor(combine_weights_grad)
   infer_meta :
     func : MoeCombineGradInferMeta
-    spmd_rule : MoECombineBwdInferSpmd
+    spmd_rule : MoECombineGradInferSpmd
   kernel :
     func : moe_combine_grad
 
@@ -2377,7 +2377,7 @@
   output : Tensor(x_grad), Tensor(gate_logits_grad)
   infer_meta :
     func : MoeGateDispatchGradInferMeta
-    spmd_rule : MoEGateDispatchBwdInferSpmd
+    spmd_rule : MoEGateDispatchGradInferSpmd
   kernel :
     func : moe_gate_dispatch_grad
     data_type : y_grad

--- a/paddle/phi/ops/yaml/ops.yaml
+++ b/paddle/phi/ops/yaml/ops.yaml
@@ -3689,6 +3689,7 @@
   output : Tensor(y)
   infer_meta :
     func : MoeCombineInferMeta
+    spmd_rule : MoECombineFwdInferSpmd
   kernel :
     func : moe_combine
     data_type : x
@@ -3709,6 +3710,7 @@
   output : Tensor(y), Tensor(combine_weights), Tensor(scatter_index), Tensor(expert_offset), Tensor(expert_id)
   infer_meta :
     func : MoeGateDispatchInferMeta
+    spmd_rule : MoEGateDispatchFwdInferSpmd
   kernel :
     func : moe_gate_dispatch
     data_type : x

--- a/paddle/phi/ops/yaml/ops.yaml
+++ b/paddle/phi/ops/yaml/ops.yaml
@@ -3689,7 +3689,7 @@
   output : Tensor(y)
   infer_meta :
     func : MoeCombineInferMeta
-    spmd_rule : MoECombineFwdInferSpmd
+    spmd_rule : MoECombineInferSpmd
   kernel :
     func : moe_combine
     data_type : x
@@ -3710,7 +3710,7 @@
   output : Tensor(y), Tensor(combine_weights), Tensor(scatter_index), Tensor(expert_offset), Tensor(expert_id)
   infer_meta :
     func : MoeGateDispatchInferMeta
-    spmd_rule : MoEGateDispatchFwdInferSpmd
+    spmd_rule : MoEGateDispatchInferSpmd
   kernel :
     func : moe_gate_dispatch
     data_type : x

--- a/test/cpp/auto_parallel/moe_combine_spmd_rule_test.cc
+++ b/test/cpp/auto_parallel/moe_combine_spmd_rule_test.cc
@@ -67,12 +67,12 @@ void test_moe_combine_spmd(
 
   phi::distributed::SpmdInfo spmd_info;
   if (test_bwd_spmd) {
-    spmd_info = phi::distributed::MoECombineBwdInferSpmd(dist_meta_tensors[0],
-                                                         dist_meta_tensors[1],
-                                                         dist_meta_tensors[2],
-                                                         dist_meta_tensors[3]);
+    spmd_info = phi::distributed::MoECombineGradInferSpmd(dist_meta_tensors[0],
+                                                          dist_meta_tensors[1],
+                                                          dist_meta_tensors[2],
+                                                          dist_meta_tensors[3]);
   } else {
-    spmd_info = phi::distributed::MoECombineFwdInferSpmd(
+    spmd_info = phi::distributed::MoECombineInferSpmd(
         dist_meta_tensors[0], dist_meta_tensors[1], dist_meta_tensors[2]);
   }
 

--- a/test/cpp/auto_parallel/moe_gate_dispatch_spmd_rule_test.cc
+++ b/test/cpp/auto_parallel/moe_gate_dispatch_spmd_rule_test.cc
@@ -68,16 +68,16 @@ void test_moe_gate_dispatch_spmd(
   phi::distributed::SpmdInfo spmd_info;
   if (test_bwd_spmd) {
     spmd_info =
-        phi::distributed::MoEGateDispatchBwdInferSpmd(dist_meta_tensors[0],
-                                                      dist_meta_tensors[1],
-                                                      dist_meta_tensors[2],
-                                                      dist_meta_tensors[3],
-                                                      dist_meta_tensors[4],
-                                                      k,
-                                                      capacity,
-                                                      use_pad);
+        phi::distributed::MoEGateDispatchGradInferSpmd(dist_meta_tensors[0],
+                                                       dist_meta_tensors[1],
+                                                       dist_meta_tensors[2],
+                                                       dist_meta_tensors[3],
+                                                       dist_meta_tensors[4],
+                                                       k,
+                                                       capacity,
+                                                       use_pad);
   } else {
-    spmd_info = phi::distributed::MoEGateDispatchFwdInferSpmd(
+    spmd_info = phi::distributed::MoEGateDispatchInferSpmd(
         dist_meta_tensors[0], dist_meta_tensors[1], k, capacity, use_pad);
   }
 

--- a/test/cpp/auto_parallel/moe_gate_dispatch_spmd_rule_test.cc
+++ b/test/cpp/auto_parallel/moe_gate_dispatch_spmd_rule_test.cc
@@ -26,12 +26,13 @@ void test_moe_gate_dispatch_spmd(
     int64_t k,
     int64_t capacity,
     bool use_pad,
-    bool test_bwd_spmd = false) {
+    bool test_bwd_spmd = false,
+    bool optional = true) {
   size_t num_inputs = 0;
   if (test_bwd_spmd) {
     num_inputs = 5;
   } else {
-    num_inputs = 2;
+    num_inputs = 3;
   }
 
   EXPECT_EQ(input_shapes.size(), num_inputs)
@@ -77,8 +78,14 @@ void test_moe_gate_dispatch_spmd(
                                                        capacity,
                                                        use_pad);
   } else {
+    phi::distributed::DistMetaTensor uninitialized_tensor;
     spmd_info = phi::distributed::MoEGateDispatchInferSpmd(
-        dist_meta_tensors[0], dist_meta_tensors[1], k, capacity, use_pad);
+        dist_meta_tensors[0],
+        dist_meta_tensors[1],
+        optional ? dist_meta_tensors[2] : uninitialized_tensor,
+        k,
+        capacity,
+        use_pad);
   }
 
   for (size_t i = 0; i < 2; ++i) {
@@ -106,17 +113,18 @@ void test_moe_gate_dispatch_spmd(
 TEST(MoECombineSPMDRule, test_moe_gate_dispatch_spmd) {
   int64_t s = 1024, h = 512, k = 2, e = 8, capacity = 1024;
   bool use_pad = true;
-  const std::vector<std::vector<int64_t>>& forward_input_shapes = {{s, h},
-                                                                   {s, e}};
+  const std::vector<std::vector<int64_t>>& forward_input_shapes = {
+      {s, h}, {s, e}, {e}};
   const std::vector<std::vector<int64_t>>& backward_input_shapes = {
       {s, k}, {k, s}, {s, k}, {e, capacity, h}, {s, k}};
 
   // replicated case, forward
-  std::vector<std::vector<int64_t>> input_dims_mappings = {{-1, -1}, {-1, -1}};
+  std::vector<std::vector<int64_t>> input_dims_mappings = {
+      {-1, -1}, {-1, -1}, {-1}};
   std::pair<std::vector<std::vector<int64_t>>,
             std::vector<std::vector<int64_t>>>
       expected_dims_mappings = {
-          {{-1, -1}, {-1, -1}},
+          {{-1, -1}, {-1, -1}, {-1}},
           {{-1, -1, -1}, {-1, -1}, {-1, -1}, {-1}, {-1, -1}}};
   test_moe_gate_dispatch_spmd(forward_input_shapes,
                               input_dims_mappings,
@@ -139,8 +147,8 @@ TEST(MoECombineSPMDRule, test_moe_gate_dispatch_spmd) {
                               true);
 
   // ep case, forward
-  input_dims_mappings = {{0, -1}, {-1, -1}};
-  expected_dims_mappings = {{{0, -1}, {0, -1}},
+  input_dims_mappings = {{0, -1}, {-1, -1}, {-1}};
+  expected_dims_mappings = {{{0, -1}, {0, -1}, {-1}},
                             {{-1, 0, -1}, {0, -1}, {-1, 0}, {-1}, {0, -1}}};
   test_moe_gate_dispatch_spmd(forward_input_shapes,
                               input_dims_mappings,
@@ -160,6 +168,19 @@ TEST(MoECombineSPMDRule, test_moe_gate_dispatch_spmd) {
                               capacity,
                               use_pad,
                               true);
+
+  // ep, corr_bias is none case, forward
+  input_dims_mappings = {{0, -1}, {-1, -1}, {-1}};
+  expected_dims_mappings = {{{0, -1}, {0, -1}, {}},
+                            {{-1, 0, -1}, {0, -1}, {-1, 0}, {-1}, {0, -1}}};
+  test_moe_gate_dispatch_spmd(forward_input_shapes,
+                              input_dims_mappings,
+                              expected_dims_mappings,
+                              k,
+                              capacity,
+                              use_pad,
+                              false,
+                              false);
 }
 
 }  // namespace auto_parallel


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
为moe_combine、moe_combine_grad、moe_gate_dispatch、moe_gate_dispatch_grad算子适配自动推导规则
pcard-86802

NOTE：
1. 这几个算子的InferSpmd命名未规范化 本pr将修改InferSpmd命名从而与其他推导规则统一：
MoECombineFwdInferSpmd -> MoECombineInferSpmd
MoECombineBwdInferSpmd -> MoECombineGradInferSpmd
MoEGateDispatchFwdInferSpmd -> MoEGateDispatchInferSpmd
MoEGateDispatchBwdInferSpmd -> MoEGateDispatchGradInferSpmd
ERNIE中自定义算子需要按照上述变化修改moe_gate_dispatch_auto(grad)和moe_combine_auto(grad)所绑定的spmd规则
2. moe_gate_dispatch相较ERNIE中的自定义算子新增了一个optional的corr_bias参数，如不需使用可直接传入None