### PR TITLE
Add dtype check for MatmulInferMeta

### DIFF
--- a/paddle/phi/infermeta/binary.cc
+++ b/paddle/phi/infermeta/binary.cc
@@ -2978,6 +2978,12 @@ void MatmulInferMeta(const MetaTensor& x,
                     common::errors::InvalidArgument(
                         "The Input(y) dims size must be greater than 0,"
                         " but received dims size is 0. "));
+  PADDLE_ENFORCE_EQ(
+      x.dtype(),
+      y.dtype(),
+      common::errors::InvalidArgument(
+          "The Input(x) dtype must be the same as Input(y),"
+          " but received Input(x) dtype is %s, Input(y) dtype is %s."));
 
   bool x_broadcasted = false, y_broadcasted = false;
   if (ndims_x == 1) {

--- a/paddle/phi/infermeta/binary.cc
+++ b/paddle/phi/infermeta/binary.cc
@@ -2976,14 +2976,8 @@ void MatmulInferMeta(const MetaTensor& x,
   PADDLE_ENFORCE_GT(ndims_y,
                     0UL,
                     common::errors::InvalidArgument(
-                        "The Input(y) dims size must be greater than 0,"
+                        "The Input(y) dims size must be greater than 0," A
                         " but received dims size is 0. "));
-  PADDLE_ENFORCE_EQ(
-      x.dtype(),
-      y.dtype(),
-      common::errors::InvalidArgument(
-          "The Input(x) dtype must be the same as Input(y),"
-          " but received Input(x) dtype is %s, Input(y) dtype is %s."));
 
   bool x_broadcasted = false, y_broadcasted = false;
   if (ndims_x == 1) {

--- a/paddle/phi/kernels/matmul_kernel.h
+++ b/paddle/phi/kernels/matmul_kernel.h
@@ -44,6 +44,14 @@ DenseTensor Matmul(const Context& dev_ctx,
                    const DenseTensor& y,
                    bool transpose_x = false,
                    bool transpose_y = false) {
+  if (x.place() == phi::CPUPlace()) {
+    PADDLE_ENFORCE_EQ(
+        x.dtype(),
+        y.dtype(),
+        common::errors::InvalidArgument(
+            "The Input(x) dtype must be the same as Input(y),"
+            " but received Input(x) dtype is %s, Input(y) dtype is %s."));
+  }
   DenseTensor dense_out;
   MetaTensor meta_out(&dense_out);
   MatmulInferMeta(x, y, transpose_x, transpose_y, &meta_out);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
linear 精度报错与 matmul 相关，暴露出 matmul 的报错信息不明确的问题，给MatmulInferMeta添加额外的检查可以让报错信息更明确。

matmul 的 x 和 y 类型不一致时，目前出现过两种报错
第一种报错
 (InvalidArgument) The type of data we are trying to retrieve (float32) does not match the type of data (float16) currently contained in the container.
  [Hint: Expected dtype() == phi::CppTypeToDataType<T>::Type(), but received dtype():15 != phi::CppTypeToDataType<T>::Type():10.] (at ../paddle/phi/core/dense_tensor.cc:160)
  [operator < linear > error]
第二种报错
Traceback (most recent call last):
  File "/workspace/PaddleAPITest/tester/accuracy.py", line 92, in test
    exec(code.core_compiled, exec_globals, exec_locals)
  File "<string>", line 10, in <module>
  File "/workspace/PaddleAPITest/.venv/lib/python3.10/site-packages/torch/utils/_device.py", line 104, in __torch_function__
    return func(*args, **kwargs)
RuntimeError: expected mat1 and mat2 to have the same dtype, but got: c10::Half != float
paddle kernel的核心源码如下

可以看到实际上是要求x和y输入类型一致的，但是不一致时并不会直接报错，因为 MatmulInferMeta 里并没有检查，所以需要添加检查从而减少后续错误排查的工作量。

Pcard-67164