### PR TITLE
[0-size Tensor No.169] Add 0-size Tensor support for paddle.nn.functional.fold

### DIFF
--- a/python/paddle/nn/functional/common.py
+++ b/python/paddle/nn/functional/common.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import math
 from typing import TYPE_CHECKING, Literal
 
 import numpy
@@ -2753,6 +2754,9 @@ def fold(
     )
 
     assert len(x.shape) == 3, "input should be the format of [N, C, L]"
+    assert (
+        math.prod(x.shape) > 0
+    ), "The number of elements must greater than zero."
 
     def _is_list_or_tuple_(data):
         return isinstance(data, (list, tuple))

--- a/test/legacy_test/test_fold_op.py
+++ b/test/legacy_test/test_fold_op.py
@@ -283,6 +283,17 @@ class TestFoldOpError(unittest.TestCase):
                     strides=0,
                 )
 
+            def test_zero_size():
+                x = paddle.randn(shape=[0, 1, 1], dtype="float32")
+                out = fold(
+                    x,
+                    output_sizes=[0, 0],
+                    kernel_sizes=[0, 0],
+                    dilations=0,
+                    paddings=[0, 0],
+                    strides=0,
+                )
+
             self.assertRaises(AssertionError, test_input_shape)
             self.assertRaises(AssertionError, test_kernel_shape)
             self.assertRaises(ValueError, test_padding_shape)
@@ -292,6 +303,7 @@ class TestFoldOpError(unittest.TestCase):
             self.assertRaises(TypeError, test_output_size_2)
             self.assertRaises(ValueError, test_block_h_w)
             self.assertRaises(ValueError, test_GT_0)
+            self.assertRaises(AssertionError, test_zero_size)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
paddle.nn.functional.fold 在PaddleAPITest没有测试用例，修改为抛出错误
<img width="1149" height="41" alt="image" src="https://github.com/user-attachments/assets/ee5b6801-e497-4715-904d-62e1dea15a18" />
