### PR TITLE
[BIG tensor]add PADDLE_ENFORCE_LE for unbind

### DIFF
--- a/paddle/phi/kernels/impl/unbind_kernel_impl.h
+++ b/paddle/phi/kernels/impl/unbind_kernel_impl.h
@@ -24,6 +24,13 @@ void UnbindKernel(const Context& dev_ctx,
                   const DenseTensor& x,
                   int axis,
                   std::vector<DenseTensor*> outs) {
+  int64_t unbind_numel = x.numel();
+  PADDLE_ENFORCE_LE(unbind_numel,
+                    std::numeric_limits<int>::max(),
+                    ::common::errors::PreconditionNotMet(
+                        "The number of proposals in unbind should be less than "
+                        "2^31, but got %lld. Please check the input tensor. ",
+                        unbind_numel));
   auto x_dims = x.dims();
   axis = axis < 0 ? x_dims.size() + axis : axis;
 

--- a/paddle/phi/kernels/stride/unbind_kernel.cc
+++ b/paddle/phi/kernels/stride/unbind_kernel.cc
@@ -32,6 +32,13 @@ void UnbindStridedKernel(const Context& dev_ctx,
         "FLAGS_use_stride_kernel is closed. Strided kernel "
         "be called, something wrong has happened!"));
   }
+  int64_t unbind_numel = x.numel();
+  PADDLE_ENFORCE_LE(unbind_numel,
+                    std::numeric_limits<int>::max(),
+                    ::common::errors::PreconditionNotMet(
+                        "The number of proposals in unbind should be less than "
+                        "2^31, but got %lld. Please check the input tensor. ",
+                        unbind_numel));
   int64_t num = static_cast<int64_t>(outs.size());
   int64_t start = 0;
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-73145
由于 paddle.unbind API 在大tensor上的计算过慢（即使不超过int32），因此本PR 为 unbind 算子添加了尺寸检查，在超过int32范围时报错提醒用户。