### PR TITLE
[CINN] Fixed longlong2int induced minmax type mismatch

### DIFF
--- a/paddle/cinn/backends/codegen_gpu_dev.h
+++ b/paddle/cinn/backends/codegen_gpu_dev.h
@@ -127,6 +127,10 @@ class CodeGenGpuDev : public CodeGenC {
   // prefix
   std::unordered_set<std::string> vectorized_tensor_names_;
 
+  // This map is used to store the name and type of the dynamic shape func args
+  // so that during codegen of ir::Min & ir::Max call, we can have correct type
+  std::unordered_map<std::string, common::Type> dynamic_shape_map_;
+
   ir::Expr dyn_shared_mem_offset_{-1};
   std::vector<ir::Buffer> dynamic_alloc_buffers_;
 };

--- a/paddle/cinn/common/ir_util.h
+++ b/paddle/cinn/common/ir_util.h
@@ -178,5 +178,15 @@ inline bool IsZero(const Expr &expr) {
 void OpDataTypePromote(ir::Expr *expr);
 void OpDataTypePromote(ir::Module *module);
 void OpDataTypePromote(ir::LoweredFunc *func);
+
+// only process ir::Min and ir::Max where the operands 1. contains dynamic shape
+// symbols. 2. the operands are both int types and both are 32/64 bits. Returns
+// the number of bits for unifying operands (by casting)
+int UnifiedOperandTypeBits(
+    const std::unordered_map<std::string, common::Type> *search_map,
+    const ir::Min *op);
+int UnifiedOperandTypeBits(
+    const std::unordered_map<std::string, common::Type> *search_map,
+    const ir::Max *op);
 }  // namespace common
 }  // namespace cinn

--- a/test/ir/pir/cinn/test_unifying_minmax_type.py
+++ b/test/ir/pir/cinn/test_unifying_minmax_type.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy
+import utils
+
+import paddle
+from paddle.static import InputSpec
+
+
+class TestMinMaxOperandCast:
+    def eval(self, dy_compute, inputs, input_spec=None):
+        dy_out = dy_compute(*inputs)
+
+        static_compute = utils.apply_to_static(
+            dy_compute, input_spec=input_spec, use_cinn=True
+        )
+        st_out = static_compute(*inputs)
+
+        for a, b in zip(
+            paddle.utils.flatten(dy_out), paddle.utils.flatten(st_out)
+        ):
+            numpy.testing.assert_allclose(a, b, atol=1e-6, rtol=1e-6)
+
+    def test_simplest(self):
+        def func(x):
+            y = paddle.zeros([1024], dtype="int32")
+            return paddle.minimum(
+                y, paddle.full([1024], x.shape[1], dtype="int32")
+            )
+
+        x_spec = InputSpec(shape=[1024, -1])
+        x = paddle.randn([1024, 64])
+        self.eval(func, [x], [x_spec])
+
+    def test_fuse_with_gather_nd(self):
+        def func(x):
+            indices = paddle.full([2048], x.shape[1], dtype="int32")[:1024]
+            return x[indices, :1].reshape([1, -1])
+
+        x_spec = InputSpec(shape=[1024, -1])
+        x = paddle.randn([1024, 64])
+        self.eval(func, [x], [x_spec])
+
+    def test_nested_min_max(self):
+        def func(x, y, z):
+            maximum = paddle.maximum(
+                z, paddle.full([x.shape[0]], 2 * x.shape[1] + 1, dtype="int32")
+            )
+            return paddle.minimum(y[:512], maximum)
+
+        x_spec = InputSpec(shape=[-1, -1])
+        y_spec = InputSpec(shape=[1024])
+        z_spec = InputSpec(shape=[-1])
+        x = paddle.randn([512, 90])
+        y = paddle.randint(0, 128, [1024], dtype="int32")
+        z = paddle.randint(0, 128, [x.shape[0]], dtype="int32")
+        self.eval(func, [x, y, z], [x_spec, y_spec, z_spec])
+
+    def test_gather_nd_slice(self):
+        def func(x):
+            indices = paddle.full([2048], x.shape[1], dtype="int32")[:1024]
+            return x[indices, :1].reshape([1, -1])
+
+        x_spec = InputSpec(shape=[1024, -1])
+        x = paddle.randn([1024, 64])
+        self.eval(func, [x], [x_spec])
+
+    def test_multi_dim_reduce(self):
+        def func(x, y):
+            max_threshold = paddle.full(
+                x.shape, x.shape[1] * x.shape[1] - 20, dtype="int32"
+            )
+            min_threshold = paddle.full(x.shape[:-1], x.shape[1], dtype="int64")
+            min_vals = paddle.minimum(max_threshold, x + y)
+            reduced = min_vals.max(axis=-1).to("int64")
+            return paddle.maximum(reduced, min_threshold).sum(axis=0).max()
+
+        x_spec = InputSpec(shape=[99, -1, 18])
+        y_spec = InputSpec(shape=[99, -1, 1])
+        x = paddle.randint(0, 128, [99, 17, 18], dtype="int32")
+        y = paddle.randint(0, 128, [99, 17, 1], dtype="int32")
+        self.eval(func, [x, y], [x_spec, y_spec])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
CINN

### PR Types
Bug fixes


### Description
longlong2int 是一个 int类型计算的 optimization pass，包括了：
- `OpDataTypePromote` （显式在 `CodeGenAndJit`中调用）
- `TryElevateIntxxtoIntxx`（32->64或者反过来都有）：这个函数在很多类型、函数中都隐式调用了。包括 ir::BinaryNode 构造时

特别是第二点，导致type cast问题涉及的范围很广（甚至在 IrPrinter 生成代码的环节都能出现 type cast，比如 load/store node调用 index 方法时）。问题的主要表现是：当被编译操作中含有 `ir::Min` / `ir::Max` 两种 node 时，可能会因为动态 shape 的存在而导致 operand type 不匹配。究其原因：
- CINN 根据 predicate 对动态shape同一个 kernel 编译几个版本：比如 shape 大时，动态 shape 输入将会使用 int64，反之用 int32，kernel 在 host 端通过 branches 进行选择。
- 输入参数的动态 shape 表达式（`ir::LoweredFunc`）的 `ir::Argument` 与在 kernel 内部的动态 shape 表达式（`ir::_Var_`）不是强关联的，导致同时有 int32 / int64 版本`ir::Argument` 的 LoweredFunc，但 func body 内部类型并没有正确设置。具体表现如下：

```c++
// func body IR: i32 version
var[some_index] = cinn_min(S0, 0);
// func body IR: i64 version
var[some_index] = cinn_min(S0, 0ll);
// CUDA code:
// 32bit ir::Argument
__global__ foo_predicate_le_int_max_kernel(int S0) {
    var[threadIdx.x] = cinn_min(S0, 0ll);    // 报错！
}
// 64bit ir::Argument
__global__ foo_predicate_gt_int_max_kernel(int64_t S0) {
    var[threadIdx.x] = cinn_min(S0, 0ll);    // 不报错
}
```

这一问题的解决，可以说目前我的方案还比较暴力（但可能很难找到更简单的方法了）：
- codegen 开始阶段（GPU only），通过哈希表记录变量名到动态shape symbol 类型的关系
- 在codegen阶段，IrPrinter 打印 `ir::Min` / `ir::Max` node 时，对于左右operands进行 ir-visiting：当左右operand都是int类型输入，并且都包含ir::Argument中已经记录的symbol名称时，确定 **最大的** int类型 bit 数（32/64）。
- 根据最大bit数，将左右 operand 进行 cast，IrPrinter print cast 后（unified type）的 operands。

举个例子：`cinn_min((S0 + 1), 1024ll)`，`ir::Argument` 中的 `S0` 是 int32类型的 `ir::_Var_`，其left operand 包含动态shape symbol，并且查哈希表知，最大 bit 是32，而 right operand 不包含动态 shape symbol，故为0，则这个 min node 应该被整体 cast 为 int32 类型的（否则在 codegen 带入时，`S0` 是 int，左边整体是int）。

之所以说目前没有更简单的方法，就是因为 longlong2int 相关的改动设计的API太多了，从 PostProcess 到 CodeGen 的 string code printing 过程都有int类型的相互变换。

感兴趣可以测试一下本 PR 提供的单测：`test_unifying_minmax_type.py`。本 PR 前此单测没有一个可以通过，并且原始的 bug 也影响了一些 CINN 算子的支持（比如 `gather_nd` 我尝试将min/max 进行简单的 type unify，统一到int64，引入了一定的性能问题，见 #73940），后续会对对应算子支持进行进一步简化。

Pcard-89620