### PR TITLE
[BIG tensor] fix acc error of margin f16

### DIFF
--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -2460,6 +2460,9 @@ def margin_cross_entropy(
         label = paddle.unsqueeze(label, axis=-1)
 
     if in_dynamic_or_pir_mode():
+        out_type = logits.dtype
+        if out_type == paddle.float16:
+            logits = paddle.cast(logits, paddle.float32)
         softmax, loss = _C_ops.margin_cross_entropy(
             logits,
             label,
@@ -2476,6 +2479,11 @@ def margin_cross_entropy(
             loss = paddle.mean(loss)
         elif reduction == 'sum':
             loss = paddle.sum(loss)
+
+        if out_type == paddle.float16:
+            softmax = paddle.cast(softmax, out_type)
+            loss = paddle.cast(loss, out_type)
+
         if not return_softmax:
             return loss
         else:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
Pcard-67164
1. 改动提升了总体精度，对齐了torch
2. 改动不会影响性能：
因为改动仅仅影响线性规模的参数，paddle本来 float 16运算过程也做了精度提升，只是有线性个中间结果用float16存储的，所以在保存中间结果的时候又产生了误差。
3. 为什么不在c++层面修改：
   paddle中间过程拆得很碎，拆成了5个中间过程，如果仅对中间结果提升精度，改起来工作量很大。
 (见Paddle/paddle/phi/kernels/gpu/margin_cross_entropy_kernel.cu:19)
4. 实验速度——修复后f16性能略有提升
```
大tensor
修复后 7.63s

 Time (%)  Total Time (ns)  Instances     Avg (ns)         Med (ns)        Min (ns)       Max (ns)     StdDev (ns)                                                   Name                                                
 --------  ---------------  ---------  ---------------  ---------------  -------------  -------------  ------------  ----------------------------------------------------------------------------------------------------
     82.6    6,313,407,732          1  6,313,407,732.0  6,313,407,732.0  6,313,407,732  6,313,407,732           0.0  void phi::HardLabelSoftmaxWithCrossEntropyKernel<float, long>(T1 *, T1 *, const T2 *, int, long, lo…
修复前：8.08s
 Time (%)  Total Time (ns)  Instances     Avg (ns)         Med (ns)        Min (ns)       Max (ns)     StdDev (ns)                                                  Name                                                
 --------  ---------------  ---------  ---------------  ---------------  -------------  -------------  -----------  ----------------------------------------------------------------------------------------------------
     84.1    6,873,639,751          1  6,873,639,751.0  6,873,639,751.0  6,873,639,751  6,873,639,751          0.0  void phi::HardLabelSoftmaxWithCrossEntropyKernel<phi::dtype::float16, long>(T1 *, T1 *, const T2 *,…
      8.0      649,658,963  
```