### PR TITLE
[BIG tensor] fix acc error in cross_entropy

### DIFF
--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -2999,10 +2999,16 @@ def cross_entropy(
             valid_label = (
                 paddle.cast(label != ignore_index, dtype=label.dtype) * label
             )
+        out_type = input.dtype
+        if out_type == paddle.float16:
+            input = paddle.cast(input, paddle.float32)
+
         _, out = _C_ops.cross_entropy_with_softmax(
             input, label, soft_label, use_softmax, True, ignore_index, axis
         )
 
+        if out_type == paddle.float16:
+            out = paddle.cast(out, out_type)
         if weight is not None:
             # trans weight from class to sample, shape:N or [N,H,W] for 1d and 2d cases.
             if soft_label:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164
1. 对齐了torch
现状：torch 对float16的数据进行了精度提升，而paddle没有。
torch:
cross_entropy -> 分为 log_softmax (float16->float32) +  nll_loss   （float16 -> float32）
pytorch/aten/src/ATen/native/LossNLL.cpp:695
-> pytorch/aten/src/ATen/native/cuda/Loss.cu:224


Paddle: 
cross_entropy ->  分为 cross_entropy_with_softmax(float16)  +  mean_all(float16 -> float32)  
Paddle/python/paddle/nn/functional/loss.py:3124
-> Paddle/paddle/phi/kernels/gpu/cross_entropy_kernel.cu:1405

2. 为什么不在c++层面做：
 cross_entropy 有太多分支，修改成本过高

3. 性能变化：