### PR TITLE
[CINN] Symplify gather_nd min/max type unifying

### DIFF
--- a/test/ir/pir/cinn/test_cinn_gather_nd.py
+++ b/test/ir/pir/cinn/test_cinn_gather_nd.py
@@ -26,7 +26,7 @@ class TestGatherNd(unittest.TestCase):
         dy_out = dy_compute(*inputs)
 
         static_compute = utils.apply_to_static(
-            dy_compute, use_cinn=True, input_spec=None
+            dy_compute, use_cinn=True, input_spec=input_spec
         )
         st_out = static_compute(*inputs)
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
CINN


### PR Types
Improvements


### Description
Further improvements of 
- #73940

It is mentioned in #73940 that `ir::Select` introduces some performance overhead, but the main culprit turns out to be the type casting: to make sure the operand of `ir::Min` and `ir::Max` have matched operand type, int64 casting is performed. 

However
- #74240 

fixes type mismatch problem, therefore, `gather_nd` negative index solution can be much simplified. 

Also, the original implementation of `gather_nd` performs LOTS of int64 casting, which are unnecessary (since they will eventually be elevated or downcasted by post-processing or other passes). These are also removed.

Performance results (for `test_llama forward.py` and `test_llama inference.py` related `gather_nd` kernel)
- Original: ~12us
- In PR 73940: ~17.5us
- This PR: ~14us

Pcard-89620