### PR TITLE
[0-size Tensor No.82] Add 0-size Tensor support for paddle.incubate.nn.functional.fused_bias_act [fluid_ops]

### DIFF
--- a/paddle/phi/infermeta/multiary.cc
+++ b/paddle/phi/infermeta/multiary.cc
@@ -2476,13 +2476,11 @@ void FusedBiasActInferMeta(const MetaTensor& x,
     x_shapes.push_back(x_dims[i]);
   }
 
-  if (config.is_runtime) {
-    if (x.numel() != 0) {
-      PADDLE_ENFORCE_GT(
-          x.numel() / dim,
-          0,
-          common::errors::InvalidArgument("The size of Attr(rows) must > 0"));
-    }
+  if (config.is_runtime && x.numel() != 0) {
+    PADDLE_ENFORCE_GT(
+        x.numel() / dim,
+        0,
+        common::errors::InvalidArgument("The size of Attr(rows) must > 0"));
 
     PADDLE_ENFORCE_GT(
         dim,

--- a/paddle/phi/infermeta/multiary.cc
+++ b/paddle/phi/infermeta/multiary.cc
@@ -2477,10 +2477,12 @@ void FusedBiasActInferMeta(const MetaTensor& x,
   }
 
   if (config.is_runtime) {
-    PADDLE_ENFORCE_GE(
-        x.numel() / dim,
-        0,
-        common::errors::InvalidArgument("The size of Attr(rows) must >= 0"));
+    if (x.numel() != 0) {
+      PADDLE_ENFORCE_GT(
+          x.numel() / dim,
+          0,
+          common::errors::InvalidArgument("The size of Attr(rows) must > 0"));
+    }
 
     PADDLE_ENFORCE_GT(
         dim,

--- a/paddle/phi/infermeta/multiary.cc
+++ b/paddle/phi/infermeta/multiary.cc
@@ -2477,10 +2477,10 @@ void FusedBiasActInferMeta(const MetaTensor& x,
   }
 
   if (config.is_runtime) {
-    PADDLE_ENFORCE_GT(
+    PADDLE_ENFORCE_GE(
         x.numel() / dim,
         0,
-        common::errors::InvalidArgument("The size of Attr(rows) must > 0"));
+        common::errors::InvalidArgument("The size of Attr(rows) must >= 0"));
 
     PADDLE_ENFORCE_GT(
         dim,

--- a/paddle/phi/kernels/fusion/gpu/fused_bias_act_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/fused_bias_act_kernel.cu
@@ -559,6 +559,12 @@ void FusedBiasActKernel(const Context &dev_ctx,
   if (out && out->numel() == 0) {
     if (quant_scale > 0) {
       dev_ctx.template Alloc<int8_t>(out);
+    } else if (compute_dtype == "fp16") {
+      dev_ctx.template Alloc<phi::dtype::float16>(out);
+    } else if (compute_dtype == "bf16") {
+      dev_ctx.template Alloc<phi::dtype::bfloat16>(out);
+    } else if (compute_dtype == "fp32") {
+      dev_ctx.template Alloc<float>(out);
     } else {
       dev_ctx.template Alloc<T>(out);
     }

--- a/paddle/phi/kernels/fusion/gpu/fused_bias_act_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/fused_bias_act_kernel.cu
@@ -557,7 +557,11 @@ void FusedBiasActKernel(const Context &dev_ctx,
                         float quant_min_bound,
                         DenseTensor *out) {
   if (out && out->numel() == 0) {
-    dev_ctx.template Alloc<T>(out);
+    if (quant_scale > 0) {
+      dev_ctx.template Alloc<int8_t>(out);
+    } else {
+      dev_ctx.template Alloc<T>(out);
+    }
     return;
   }
   int64_t cols = x.dims()[x.dims().size() - 1];

--- a/paddle/phi/kernels/fusion/gpu/fused_bias_act_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/fused_bias_act_kernel.cu
@@ -556,6 +556,10 @@ void FusedBiasActKernel(const Context &dev_ctx,
                         float quant_max_bound,
                         float quant_min_bound,
                         DenseTensor *out) {
+  if (out && out->numel() == 0) {
+    dev_ctx.template Alloc<T>(out);
+    return;
+  }
   int64_t cols = x.dims()[x.dims().size() - 1];
   int64_t rows = x.numel() / cols;
   if (x.dtype() == phi::DataType::INT32) {

--- a/paddle/phi/kernels/fusion/xpu/fused_bias_act_kernel.cc
+++ b/paddle/phi/kernels/fusion/xpu/fused_bias_act_kernel.cc
@@ -112,6 +112,7 @@ void FusedBiasActKernel(const Context &dev_ctx,
                         DenseTensor *out) {
   auto xpu_ctx = static_cast<const phi::XPUContext *>(&dev_ctx);
   dev_ctx.template Alloc<T>(out);
+  if (out->numel() == 0) return;
 
   if (dequant_scales && dequant_scales.get().numel() > 0) {
     return DispatchComputeImpl<T>(xpu_ctx,

--- a/test/legacy_test/test_fused_bias_act_op.py
+++ b/test/legacy_test/test_fused_bias_act_op.py
@@ -784,5 +784,31 @@ class TestWithoutBias(unittest.TestCase):
         )
 
 
+@unittest.skipIf(
+    not core.is_compiled_with_cuda() and not core.is_compiled_with_rocm(),
+    "core is not compiled with CUDA or ROCm",
+)
+class TestFusedBiasActOp_ZeroSize(TestWithoutBias):
+    def setUp(self):
+        paddle.seed(2017)
+        np.random.seed(2017)
+
+        self.op_type = "fused_bias_act"
+        self.rtol = 1e-5
+        self.atol = 1e-3
+
+        self.batch_size = 2
+        self.seq_len = 0
+        self.cols = 512
+
+        self.dtype = 'float32'
+        self.act_method = 'gelu'
+
+        self.use_glu = False
+
+        self.init_test_case()
+        self.generate_inputs()
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
82 paddle.incubate.nn.functional.fused_bias_act

修改infermeta，x numel为0跳过检查，符号推导没有对应代码
kernel按 quant_scale 和 compute_dtype 参数不同返回不同类型 out，如果 quant_scale > 0，返回int8类型，如果 compute_dtype 有设置，按 compute_dtype 返回，其他按 x 类型设置

PaddleAPITest测试通过
<img width="1403" height="524" alt="image" src="https://github.com/user-attachments/assets/3c6649d3-f00e-48b3-9211-fd8675b76852" />
