### PR TITLE
[Deep_ep]Fix deepep calc_stream bug

### DIFF
--- a/paddle/fluid/distributed/collective/deep_ep/src/CUDAStream.cc
+++ b/paddle/fluid/distributed/collective/deep_ep/src/CUDAStream.cc
@@ -27,7 +27,7 @@ cudaStream_t GetCalcStreamFromGroup(int context_ring_id) {
   const auto& place = phi::GPUPlace(device_id);
   const auto& calc_ctx = reinterpret_cast<phi::GPUContext*>(
       reinterpret_cast<paddle::distributed::ProcessGroupNCCL*>(pg)
-          ->GetDeviceContext(place, true));
+          ->GetOrCreateCalcContext(place, true));
   return calc_ctx->stream();
 }
 

--- a/paddle/fluid/distributed/collective/process_group_nccl.cc
+++ b/paddle/fluid/distributed/collective/process_group_nccl.cc
@@ -197,6 +197,11 @@ phi::DeviceContext* ProcessGroupNCCL::GetDeviceContext(
   const std::string& key = GetKeyFromPlace(place);
   if (use_calc_stream) {
     const auto& iter = place_to_calc_ctx_.find(key);
+    PADDLE_ENFORCE_NE(
+        iter,
+        place_to_calc_ctx_.end(),
+        common::errors::NotFound(
+            "Cannot find the device context in this process group."));
     return iter->second;
   } else {
     const auto& iter = place_to_comm_ctx_.find(key);
@@ -229,6 +234,17 @@ phi::distributed::NCCLCommContext* ProcessGroupNCCL::GetOrCreateCommContext(
     CreateNCCLEnvCache(place, key, store_key, comm_type, 0, nccl_config_ptr_);
   }
   return GetCommContext(&store_key);
+}
+
+phi::DeviceContext* ProcessGroupNCCL::GetOrCreateCalcContext(
+    const Place& place, bool use_calc_stream) {
+  const auto& key = GetKeyFromPlace(place);
+  if (place_to_calc_ctx_.find(key) == place_to_calc_ctx_.end()) {
+    auto* calc_ctx = static_cast<phi::GPUContext*>(
+        phi::DeviceContextPool::Instance().Get(place));
+    place_to_calc_ctx_.emplace(key, calc_ctx);
+  }
+  return GetDeviceContext(place, use_calc_stream);
 }
 
 std::shared_ptr<ProcessGroup::Task> ProcessGroupNCCL::AllGather(
@@ -953,13 +969,11 @@ void ProcessGroupNCCL::CreateNCCLEnvCache(
         group_key, global_ranks);
   }
 
-  auto* calc_ctx = static_cast<phi::GPUContext*>(
-      phi::DeviceContextPool::Instance().Get(place));
-
   place_to_calc_event_.emplace(
       place_key,
       platform::DeviceEvent(place, platform::GenerateDeviceEventFlag()));
-  place_to_calc_ctx_.emplace(place_key, calc_ctx);
+
+  GetOrCreateCalcContext(place, true);
   place_to_comm_ctx_.emplace(place_key, std::move(comm_ctx));
   place_to_p2p_opts_.emplace(place_key, std::move(p2p_opts));
 

--- a/paddle/fluid/distributed/collective/process_group_nccl.h
+++ b/paddle/fluid/distributed/collective/process_group_nccl.h
@@ -195,6 +195,9 @@ class ProcessGroupNCCL final : public ProcessGroupWithStream {
   phi::distributed::NCCLCommContext* GetOrCreateCommContext(
       const Place& place, CommType comm_type = CommType::UNKNOWN);
 
+  phi::DeviceContext* GetOrCreateCalcContext(const Place& place,
+                                             bool use_calc_stream);
+
   void Shutdown();
   void Restart();
   phi::CUDAStream GetStream(const Place& place);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Distributed Strategy

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-67164
原有逻辑获取calc stream之前必须先调用获取comm stream的命令，因为新建的代码写在调comm stream的逻辑里。本PR修复这一问题，并添加相应报错检查。