### PR TITLE
synchronize before print bf16 cast

### DIFF
--- a/python/paddle/tensor/to_string.py
+++ b/python/paddle/tensor/to_string.py
@@ -252,6 +252,7 @@ def to_string(var, prefix='Tensor'):
         return "Tensor(Not initialized)"
 
     if var.dtype == paddle.bfloat16:
+        paddle.device.synchronize()
         var = var.astype('float32')
     np_var = var.numpy(False)
 

--- a/python/paddle/tensor/to_string.py
+++ b/python/paddle/tensor/to_string.py
@@ -298,6 +298,7 @@ def _format_dense_tensor(tensor, indent):
         or dtype == core.VarDesc.VarType.FP8_E4M3FN
         or dtype == core.VarDesc.VarType.FP8_E5M2
     ):
+        paddle.device.synchronize()
         tensor = tensor.astype('float32')
 
     # TODO(zhouwei): will remove 0-D Tensor.numpy() hack

--- a/python/paddle/tensor/to_string.py
+++ b/python/paddle/tensor/to_string.py
@@ -252,7 +252,8 @@ def to_string(var, prefix='Tensor'):
         return "Tensor(Not initialized)"
 
     if var.dtype == paddle.bfloat16:
-        paddle.device.synchronize()
+        if paddle.is_compiled_with_cuda() or paddle.is_compiled_with_xpu():
+            paddle.device.synchronize()
         var = var.astype('float32')
     np_var = var.numpy(False)
 
@@ -298,7 +299,8 @@ def _format_dense_tensor(tensor, indent):
         or dtype == core.VarDesc.VarType.FP8_E4M3FN
         or dtype == core.VarDesc.VarType.FP8_E5M2
     ):
-        paddle.device.synchronize()
+        if paddle.is_compiled_with_cuda() or paddle.is_compiled_with_xpu():
+            paddle.device.synchronize()
         tensor = tensor.astype('float32')
 
     # TODO(zhouwei): will remove 0-D Tensor.numpy() hack

--- a/python/paddle/tensor/to_string.py
+++ b/python/paddle/tensor/to_string.py
@@ -252,7 +252,7 @@ def to_string(var, prefix='Tensor'):
         return "Tensor(Not initialized)"
 
     if var.dtype == paddle.bfloat16:
-        if paddle.is_compiled_with_cuda() or paddle.is_compiled_with_xpu():
+        if not var.place.is_cpu_place():
             paddle.device.synchronize()
         var = var.astype('float32')
     np_var = var.numpy(False)
@@ -299,7 +299,7 @@ def _format_dense_tensor(tensor, indent):
         or dtype == core.VarDesc.VarType.FP8_E4M3FN
         or dtype == core.VarDesc.VarType.FP8_E5M2
     ):
-        if paddle.is_compiled_with_cuda() or paddle.is_compiled_with_xpu():
+        if not tensor.place.is_cpu_place():
             paddle.device.synchronize()
         tensor = tensor.astype('float32')
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
bf16由于类型支持问题，在print的时候需要转成fp32，以使用numpy的功能。
但Tensor.numpy是有Sync的。cast没有。在多流情况下，主流CPU，print分流Tensor时，如果cast没有Sync会在Tensor没有运算完就cast。会导致精度异常。

Pcard-67164