### PR TITLE
[Big Tensor]Fix accuracy diff for paddle.nn.functional.adaptive_max_pool3d API. 

### DIFF
--- a/paddle/phi/kernels/funcs/pooling.h
+++ b/paddle/phi/kernels/funcs/pooling.h
@@ -126,18 +126,15 @@ class LPPoolGrad {
 
 /* used for adaptive pool to calculate start and end index of each divided grid
  */
-template <typename T = int>
+template <typename T = int64_t>
 HOSTDEVICE inline T AdaptStartIndex(T ph, T input_size, T output_size) {
-  return static_cast<T>(
-      floor(static_cast<float>(ph * input_size) / output_size));
+  return (ph * input_size) / output_size;
 }
 
-template <typename T = int>
+template <typename T = int64_t>
 HOSTDEVICE inline T AdaptEndIndex(T ph, T input_size, T output_size) {
-  return static_cast<T>(
-      ceil(static_cast<float>((ph + 1) * input_size) / output_size));
+  return ((ph + 1) * input_size + output_size - 1) / output_size;
 }
-
 /* used for fractional pool to calculate start and end index of each divided
  * grid
  */


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes 

### Description
<!-- Describe what you’ve done -->
修改了pooling中的AdaptStartIndex\AdaptEndIndex 计算函数，pooling相关API前向精度问题应该都有改善
在大Tensor情况下，传入变量ph较大，原先的AdaptStartIndex\AdaptEndIndex 计算能会由于浮点数的精度限制而导致错误的结果

Pcard-67164