### PR TITLE
Add not support enforce for lstsq big tensor

### DIFF
--- a/paddle/phi/kernels/gpu/lstsq_kernel.cu
+++ b/paddle/phi/kernels/gpu/lstsq_kernel.cu
@@ -16,6 +16,7 @@
 #include <algorithm>
 #include <complex>
 
+#include "paddle/phi/backends/gpu/cuda/cudnn_workspace_helper.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/full_kernel.h"
@@ -62,23 +63,8 @@ void LstsqKernel(const Context& dev_ctx,
     return;
   }
 
-  int64_t largest_matrix = (1LL << 31) - 1;
-  int64_t matrix_size_x = 1;
-  int64_t matrix_size_y = 1;
-  for (int i = 0; i < x.dims().size(); ++i) {
-    matrix_size_x *= x.dims()[i];
-  }
-  for (int i = 0; i < y.dims().size(); ++i) {
-    matrix_size_y *= y.dims()[i];
-  }
-  int64_t matrix_size = std::max(matrix_size_x, matrix_size_y);
-  PADDLE_ENFORCE_LE(
-      matrix_size,
-      largest_matrix,
-      ::common::errors::PreconditionNotMet(
-          "Matrix size too large for LeaST SQuares solution. Maximum "
-          "allowed size is 2 ^ 31 - 1 elements, but got %lld",
-          matrix_size));
+  CUDNN_ENFORCE_TENSOR_SIZE_SUPPORTED(x);
+  CUDNN_ENFORCE_TENSOR_SIZE_SUPPORTED(y);
 
   auto x_dims = x.dims();
   auto y_dims = y.dims();

--- a/paddle/phi/kernels/gpu/lstsq_kernel.cu
+++ b/paddle/phi/kernels/gpu/lstsq_kernel.cu
@@ -61,6 +61,25 @@ void LstsqKernel(const Context& dev_ctx,
           singular_values);
     return;
   }
+
+  int64_t largest_matrix = (1LL << 31) - 1;
+  int64_t matrix_size_x = 1;
+  int64_t matrix_size_y = 1;
+  for (int i = 0; i < x.dims().size(); ++i) {
+    matrix_size_x *= x.dims()[i];
+  }
+  for (int i = 0; i < y.dims().size(); ++i) {
+    matrix_size_y *= y.dims()[i];
+  }
+  int64_t matrix_size = std::max(matrix_size_x, matrix_size_y);
+  PADDLE_ENFORCE_LE(
+      matrix_size,
+      largest_matrix,
+      ::common::errors::PreconditionNotMet(
+          "Matrix size too large for LeaST SQuares solution. Maximum "
+          "allowed size is 2 ^ 31 - 1 elements, but got %lld",
+          matrix_size));
+
   auto x_dims = x.dims();
   auto y_dims = y.dims();
   int dim_size = x_dims.size();


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Execute Infrastructure


### PR Types
Improvements


### Description
为 paddle.linalg.lstsq添加显式不支持大 tensor 检查。
针对大tensor，执行过程中cusolverDnSormqr_bufferSize会报错，torch和paddle均有这一问题。


Pcard-67164
