### PR TITLE
[PHI] Move some core impl to `.cc` to avoid include glog in header

### DIFF
--- a/paddle/phi/api/profiler/CMakeLists.txt
+++ b/paddle/phi/api/profiler/CMakeLists.txt
@@ -26,4 +26,4 @@ if(WITH_PYTHON AND EXISTS ${PADDLE_BINARY_DIR})
   endif()
 endif()
 
-collect_srcs(api_srcs SRCS device_tracer.cc profiler.cc)
+collect_srcs(api_srcs SRCS device_tracer.cc event.cc profiler.cc)

--- a/paddle/phi/api/profiler/event.cc
+++ b/paddle/phi/api/profiler/event.cc
@@ -1,0 +1,81 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/phi/api/profiler/event.h"
+
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+#include "glog/logging.h"
+#endif
+
+namespace phi {
+
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+
+CudaEvent::CudaEvent() {
+#ifdef PADDLE_WITH_HIP
+  hipEventCreateWithFlags(&event_, flags_);
+#else
+  cudaEventCreateWithFlags(&event_, flags_);
+#endif
+  VLOG(4) << "CudaEvent " << event_;
+}
+
+CudaEvent::CudaEvent(unsigned int flags) : flags_(flags) {
+#ifdef PADDLE_WITH_HIP
+  hipEventCreateWithFlags(&event_, flags_);
+#else
+  cudaEventCreateWithFlags(&event_, flags_);
+#endif
+  VLOG(4) << "CudaEvent " << event_;
+}
+
+bool CudaEvent::Query() {
+#ifdef PADDLE_WITH_HIP
+  gpuError_t err = hipEventQuery(event_);
+  if (err == hipSuccess) {
+    return true;
+  }
+  if (err == hipErrorNotReady) {
+    return false;
+  }
+#else
+  gpuError_t err = cudaEventQuery(event_);
+  if (err == cudaSuccess) {
+    return true;
+  }
+  if (err == cudaErrorNotReady) {
+    return false;
+  }
+#endif
+  PADDLE_ENFORCE_GPU_SUCCESS(err);
+  return false;
+}
+
+float CudaEvent::ElapsedTime(CudaEvent *end_event) {
+  float milliseconds = 0;
+#ifdef PADDLE_WITH_HIP
+  hipEventSynchronize(end_event->GetRawCudaEvent());
+  PADDLE_ENFORCE_GPU_SUCCESS(
+      hipEventElapsedTime(&milliseconds, event_, end_event->GetRawCudaEvent()));
+#else
+  cudaEventSynchronize(end_event->GetRawCudaEvent());
+  PADDLE_ENFORCE_GPU_SUCCESS(cudaEventElapsedTime(
+      &milliseconds, event_, end_event->GetRawCudaEvent()));
+#endif
+  return milliseconds;
+}
+
+#endif
+
+}  // namespace phi

--- a/paddle/phi/api/profiler/event.h
+++ b/paddle/phi/api/profiler/event.h
@@ -29,7 +29,6 @@ limitations under the License. */
 #endif
 
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
-#include "glog/logging.h"
 #include "paddle/phi/core/cuda_stream.h"
 #endif
 
@@ -141,23 +140,9 @@ class CudaEvent {
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
 
  public:
-  CudaEvent() {
-#ifdef PADDLE_WITH_HIP
-    hipEventCreateWithFlags(&event_, flags_);
-#else
-    cudaEventCreateWithFlags(&event_, flags_);
-#endif
-    VLOG(4) << "CudaEvent " << event_;
-  }
+  CudaEvent();
 
-  explicit CudaEvent(unsigned int flags) : flags_(flags) {
-#ifdef PADDLE_WITH_HIP
-    hipEventCreateWithFlags(&event_, flags_);
-#else
-    cudaEventCreateWithFlags(&event_, flags_);
-#endif
-    VLOG(4) << "CudaEvent " << event_;
-  }
+  explicit CudaEvent(unsigned int flags);
 
   ~CudaEvent() {
 #ifdef PADDLE_WITH_HIP
@@ -175,41 +160,9 @@ class CudaEvent {
 #endif
   }
 
-  bool Query() {
-#ifdef PADDLE_WITH_HIP
-    gpuError_t err = hipEventQuery(event_);
-    if (err == hipSuccess) {
-      return true;
-    }
-    if (err == hipErrorNotReady) {
-      return false;
-    }
-#else
-    gpuError_t err = cudaEventQuery(event_);
-    if (err == cudaSuccess) {
-      return true;
-    }
-    if (err == cudaErrorNotReady) {
-      return false;
-    }
-#endif
-    PADDLE_ENFORCE_GPU_SUCCESS(err);
-    return false;
-  }
+  bool Query();
 
-  float ElapsedTime(CudaEvent *end_event) {
-    float milliseconds = 0;
-#ifdef PADDLE_WITH_HIP
-    hipEventSynchronize(end_event->GetRawCudaEvent());
-    PADDLE_ENFORCE_GPU_SUCCESS(hipEventElapsedTime(
-        &milliseconds, event_, end_event->GetRawCudaEvent()));
-#else
-    cudaEventSynchronize(end_event->GetRawCudaEvent());
-    PADDLE_ENFORCE_GPU_SUCCESS(cudaEventElapsedTime(
-        &milliseconds, event_, end_event->GetRawCudaEvent()));
-#endif
-    return milliseconds;
-  }
+  float ElapsedTime(CudaEvent *end_event);
 
   void Synchronize() {
 #ifdef PADDLE_WITH_HIP

--- a/paddle/phi/api/profiler/event.h
+++ b/paddle/phi/api/profiler/event.h
@@ -19,6 +19,7 @@ limitations under the License. */
 #include <string>
 #include <utility>
 
+#include "glog/logging.h"
 #include "paddle/phi/common/place.h"
 
 #ifdef PADDLE_WITH_CUDA

--- a/paddle/phi/api/profiler/event.h
+++ b/paddle/phi/api/profiler/event.h
@@ -19,7 +19,6 @@ limitations under the License. */
 #include <string>
 #include <utility>
 
-#include "glog/logging.h"
 #include "paddle/phi/common/place.h"
 
 #ifdef PADDLE_WITH_CUDA
@@ -30,6 +29,7 @@ limitations under the License. */
 #endif
 
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+#include "glog/logging.h"
 #include "paddle/phi/core/cuda_stream.h"
 #endif
 

--- a/paddle/phi/core/CMakeLists.txt
+++ b/paddle/phi/core/CMakeLists.txt
@@ -36,6 +36,7 @@ collect_srcs(
   selected_rows_impl.cc
   selected_rows.cc
   device_context.cc
+  cuda_stream.cc
   custom_kernel.cc
   mixed_vector.cc
   generator.cc

--- a/paddle/phi/core/cuda_stream.cc
+++ b/paddle/phi/core/cuda_stream.cc
@@ -1,0 +1,101 @@
+/* Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include "paddle/phi/core/cuda_stream.h"
+
+#include "glog/logging.h"
+
+namespace phi {
+
+CUDAStream::CUDAStream(const Place& place,
+                       const int priority,
+                       const StreamFlag& flag) {
+  place_ = place;
+  gpuStream_t stream = nullptr;
+  backends::gpu::GPUDeviceGuard guard(place_.device);
+
+  // Stream priorities follow a convention where lower numbers imply greater
+  // priorities
+  auto priority_range = backends::gpu::GetGpuStreamPriorityRange();
+  int least_priority = priority_range.first;      // 0 in V100
+  int greatest_priority = priority_range.second;  // -5 in V100
+
+  // NOTE(Ruibiao): Replacing the following `PADDLE_ENFORCE_EQ` with
+  // `PADDLE_ENFORCE` leads to a nvcc compile error. This is probably a bug.
+  PADDLE_ENFORCE_EQ(
+      priority <= least_priority && priority >= greatest_priority,
+      true,
+      common::errors::InvalidArgument(
+          "Cannot create a stream with priority = %d because stream priority "
+          "must be inside the meaningful range [%d, %d].",
+          priority,
+          least_priority,
+          greatest_priority));
+
+#ifdef PADDLE_WITH_HIP
+  PADDLE_ENFORCE_GPU_SUCCESS(hipStreamCreateWithPriority(
+      &stream, static_cast<unsigned int>(flag), priority));
+#else
+  PADDLE_ENFORCE_GPU_SUCCESS(cudaStreamCreateWithPriority(
+      &stream, static_cast<unsigned int>(flag), priority));
+#endif
+
+  VLOG(10) << "Create CUDAStream " << stream << " with priority = " << priority
+           << ", flag = " << static_cast<unsigned int>(flag);
+  stream_ = Stream(reinterpret_cast<StreamId>(stream));
+  owned_ = true;
+}
+
+bool CUDAStream::Query() const {
+#ifdef PADDLE_WITH_HIP
+  hipError_t err = hipStreamQuery(raw_stream());
+  if (err == hipSuccess) {
+    return true;
+  }
+  if (err == hipErrorNotReady) {
+    return false;
+  }
+#else
+  cudaError_t err = cudaStreamQuery(raw_stream());
+  if (err == cudaSuccess) {
+    return true;
+  }
+  if (err == cudaErrorNotReady) {
+    return false;
+  }
+#endif
+
+  PADDLE_ENFORCE_GPU_SUCCESS(err);
+  return false;
+}
+
+void CUDAStream::Synchronize() const {
+  VLOG(10) << "Synchronize " << raw_stream();
+  backends::gpu::GpuStreamSync(raw_stream());
+}
+
+CUDAStream::~CUDAStream() {
+  VLOG(10) << "~CUDAStream " << raw_stream();
+  if (owned_ && stream_.id() != 0) {
+    Synchronize();
+    backends::gpu::GPUDeviceGuard guard(place_.device);
+#ifdef PADDLE_WITH_HIP
+    hipStreamDestroy(raw_stream());
+#else
+    cudaStreamDestroy(raw_stream());
+#endif
+  }
+}
+
+}  // namespace phi

--- a/paddle/phi/core/cuda_stream.cc
+++ b/paddle/phi/core/cuda_stream.cc
@@ -18,6 +18,8 @@ limitations under the License. */
 
 namespace phi {
 
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+
 CUDAStream::CUDAStream(const Place& place,
                        const int priority,
                        const StreamFlag& flag) {
@@ -97,5 +99,7 @@ CUDAStream::~CUDAStream() {
 #endif
   }
 }
+
+#endif
 
 }  // namespace phi

--- a/paddle/phi/core/cuda_stream.cc
+++ b/paddle/phi/core/cuda_stream.cc
@@ -12,7 +12,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
 
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
 #include "paddle/phi/core/cuda_stream.h"
+#endif
 
 #include "glog/logging.h"
 

--- a/paddle/phi/core/platform/CMakeLists.txt
+++ b/paddle/phi/core/platform/CMakeLists.txt
@@ -4,7 +4,7 @@ list(APPEND DEVICE_SRCS collective_helper.cc profiler.cc)
 
 if(WITH_GPU OR WITH_ROCM)
   list(APPEND DEVICE_SRCS device/gpu/gpu_info.cc profiler.cu
-       device/gpu/gpu_resource_pool.cc)
+       cuda_device_guard.cc device/gpu/gpu_resource_pool.cc)
   list(APPEND DEVICE_SRCS stream_callback_manager.cc)
 endif()
 

--- a/paddle/phi/core/platform/cuda_device_guard.cc
+++ b/paddle/phi/core/platform/cuda_device_guard.cc
@@ -1,0 +1,41 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/phi/core/platform/cuda_device_guard.h"
+#include "glog/logging.h"
+
+namespace paddle {
+namespace platform {
+
+CUDADeviceGuard::~CUDADeviceGuard() {
+  static thread_local bool is_first_time_ = true;
+  if (prev_id_ != -1) {
+    // Do not set device back for the first time, since
+    // `cudaGetDevice` returns 0 when `cudaSetDevice` is
+    // not called.
+    // In that case, if CUDADeviceGuard(7) is called,
+    // prev_id will be 0 and we don`t need to set it back to 0.
+    // If cudaSetDevice(0) is called, it may use hundreds MB of
+    // the gpu memory.
+    VLOG(10) << __func__ << " prev_id: " << prev_id_ << ", is_first_time_"
+             << is_first_time_;
+    if (!(is_first_time_ && prev_id_ == 0)) {
+      phi::backends::gpu::SetDeviceId(prev_id_);
+      is_first_time_ = false;
+    }
+  }
+}
+
+}  // namespace platform
+}  // namespace paddle

--- a/paddle/phi/core/platform/cuda_device_guard.h
+++ b/paddle/phi/core/platform/cuda_device_guard.h
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #pragma once
-#include "glog/logging.h"
 #include "paddle/phi/backends/gpu/gpu_info.h"
 #include "paddle/phi/common/place.h"
 
@@ -30,24 +29,7 @@ class CUDADeviceGuard {
   // create uninitialized CUDADeviceGuard
   CUDADeviceGuard() {}
 
-  ~CUDADeviceGuard() {
-    static thread_local bool is_first_time_ = true;
-    if (prev_id_ != -1) {
-      // Do not set device back for the first time, since
-      // `cudaGetDevice` returns 0 when `cudaSetDevice` is
-      // not called.
-      // In that case, if CUDADeviceGuard(7) is called,
-      // prev_id will be 0 and we don`t need to set it back to 0.
-      // If cudaSetDevice(0) is called, it may use hundreds MB of
-      // the gpu memory.
-      VLOG(10) << __func__ << " prev_id: " << prev_id_ << ", is_first_time_"
-               << is_first_time_;
-      if (!(is_first_time_ && prev_id_ == 0)) {
-        phi::backends::gpu::SetDeviceId(prev_id_);
-        is_first_time_ = false;
-      }
-    }
-  }
+  ~CUDADeviceGuard();
 
   inline void SetDeviceIndex(const int dev_id) {
     int prev_id = phi::backends::gpu::GetCurrentDeviceId();


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

将部分 core 里的实现移动到 `.cc`，避免在 `.h` 里 include glog 导致在自定义算子中无法 include 这些 header（不是直接 include，是通过 #72987 间接 include），因为比较独立，因此拆到单独 PR

<!-- PCard-66972 -->