### PR TITLE
fix_linalg_solve

### DIFF
--- a/paddle/phi/kernels/funcs/matrix_solve.cu
+++ b/paddle/phi/kernels/funcs/matrix_solve.cu
@@ -13,12 +13,12 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 #include "paddle/phi/kernels/funcs/matrix_solve.h"
+#include "paddle/phi/backends/gpu/cuda/cudnn_workspace_helper.h"
 #include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/core/tensor_utils.h"
 #include "paddle/phi/kernels/funcs/blas/blas.h"
 #include "paddle/phi/kernels/funcs/math_function.h"
 #include "paddle/phi/kernels/funcs/scatter.cu.h"
-#include "paddle/phi/backends/gpu/cuda/cudnn_workspace_helper.h"
 
 namespace phi {
 namespace funcs {
@@ -163,7 +163,6 @@ void MatrixSolveFunctor<Context, T>::operator()(const Context& dev_ctx,
   int lda = n;
   int64_t batch_size = a_rank > 2 ? a.numel() / (n * n) : 1;
   CUDNN_ENFORCE_TENSOR_SIZE_SUPPORTED(a);
-
 
   const auto& b_dims = b.dims();
   const int b_rank = b_dims.size();

--- a/paddle/phi/kernels/funcs/matrix_solve.cu
+++ b/paddle/phi/kernels/funcs/matrix_solve.cu
@@ -18,6 +18,7 @@ limitations under the License. */
 #include "paddle/phi/kernels/funcs/blas/blas.h"
 #include "paddle/phi/kernels/funcs/math_function.h"
 #include "paddle/phi/kernels/funcs/scatter.cu.h"
+#include "paddle/phi/backends/gpu/cuda/cudnn_workspace_helper.h"
 
 namespace phi {
 namespace funcs {
@@ -161,11 +162,14 @@ void MatrixSolveFunctor<Context, T>::operator()(const Context& dev_ctx,
   int n = a_dims[a_rank - 1];
   int lda = n;
   int64_t batch_size = a_rank > 2 ? a.numel() / (n * n) : 1;
+  CUDNN_ENFORCE_TENSOR_SIZE_SUPPORTED(a);
+
 
   const auto& b_dims = b.dims();
   const int b_rank = b_dims.size();
   int nrhs = b_dims[b_rank - 1];
   int ldb = n;
+  CUDNN_ENFORCE_TENSOR_SIZE_SUPPORTED(b);
 
   // 1. Copy input A to a temporary tensor tmp_a for LU factorization.
   DenseTensor tmp_a(a.dtype());


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- Choose one or more from below -->
Operator Mechanism

### PR Types
<!-- Choose one from below -->
Bug fixes

### Description

修复了 `paddle.linalg.solve` 在某些输入场景下未正确抛出异常的问题。在 paddle 中加入显式报错，然后再添加到 paddle_error_dismiss，apiTest中的修改：https://github.com/PFCCLab/PaddleAPITest/pull/454

修改原因：
1.cublas的输入是int，外面使用更大的类型也没有用
2.n是矩阵的边长，边长不可能超过int（哪怕n^2也不可能超过int，不然数值不稳定解不出来）
可参考https://github.com/PaddlePaddle/Paddle/pull/72608
