### PR TITLE
[Typos] Rename namespace for TensorFormatter

### DIFF
--- a/paddle/fluid/framework/new_executor/instruction/control_flow/assert_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/control_flow/assert_instruction.cc
@@ -75,7 +75,7 @@ void AssertInstruction::Run() {
     return;
   }
 
-  funcs::TensorFormatter formatter;
+  phi::funcs::TensorFormatter formatter;
   formatter.SetSummarize(
       op_->attribute<::pir::Int64Attribute>("summarize").data());
 

--- a/paddle/fluid/operators/assert_op.cc
+++ b/paddle/fluid/operators/assert_op.cc
@@ -73,7 +73,7 @@ class AssertOp : public framework::OperatorBase {
       return;
     }
 
-    funcs::TensorFormatter formatter;
+    phi::funcs::TensorFormatter formatter;
     formatter.SetSummarize(Attr<int64_t>(kSummarize.data()));
 
     const std::vector<std::string> &x_names = Inputs(kData.data());

--- a/paddle/fluid/operators/print_op.cc
+++ b/paddle/fluid/operators/print_op.cc
@@ -87,7 +87,7 @@ class PrintOp : public framework::OperatorBase {
     int first_n = Attr<int>("first_n");
     if (first_n > 0 && ++times_ > first_n) return;
 
-    funcs::TensorFormatter formatter;
+    phi::funcs::TensorFormatter formatter;
     const std::string &name =
         Attr<bool>("print_tensor_name") ? printed_var_name : "";
     formatter.SetPrintTensorType(Attr<bool>("print_tensor_type"));

--- a/paddle/phi/kernels/assert_kernel.cc
+++ b/paddle/phi/kernels/assert_kernel.cc
@@ -31,7 +31,7 @@ void AssertKernel(const Context& dev_ctx,
     return;
   }
 
-  paddle::funcs::TensorFormatter formatter;
+  phi::funcs::TensorFormatter formatter;
   formatter.SetSummarize(summarize);
 
   for (size_t i = 0; i < data.size(); ++i) {

--- a/paddle/phi/kernels/funcs/tensor_formatter.cc
+++ b/paddle/phi/kernels/funcs/tensor_formatter.cc
@@ -20,8 +20,7 @@
 #include "paddle/phi/common/place.h"
 #include "paddle/phi/core/tensor_utils.h"
 
-namespace paddle {
-namespace funcs {
+namespace phi::funcs {
 
 void TensorFormatter::SetPrintTensorType(bool print_tensor_type) {
   print_tensor_type_ = print_tensor_type;
@@ -185,5 +184,4 @@ template void TensorFormatter::FormatData<phi::dtype::complex<float>>(
 template void TensorFormatter::FormatData<phi::dtype::complex<double>>(
     const phi::DenseTensor& print_tensor, std::stringstream& log_stream);
 
-}  // namespace funcs
-}  // namespace paddle
+}  // namespace phi::funcs

--- a/paddle/phi/kernels/funcs/tensor_formatter.h
+++ b/paddle/phi/kernels/funcs/tensor_formatter.h
@@ -21,8 +21,7 @@ namespace phi {
 class DenseTensor;
 }  // namespace phi
 
-namespace paddle {
-namespace funcs {
+namespace phi::funcs {
 
 class TensorFormatter {
  public:
@@ -54,5 +53,4 @@ class TensorFormatter {
   bool print_tensor_layout_ = true;
 };
 
-}  // namespace funcs
-}  // namespace paddle
+}  // namespace phi::funcs

--- a/paddle/phi/kernels/impl/data_impl.h
+++ b/paddle/phi/kernels/impl/data_impl.h
@@ -105,7 +105,7 @@ void PrintKernel(const Context& dev_ctx,
   // if (first_n > 0 && ++times_ > first_n) return;
 
   // TODO(phlrain): support printed_var_name
-  paddle::funcs::TensorFormatter formatter;
+  phi::funcs::TensorFormatter formatter;
   const std::string& name = print_tensor_name ? "var" : "";
   formatter.SetPrintTensorType(print_tensor_type);
   formatter.SetPrintTensorShape(print_tensor_shape);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
In paddle/phi/kernels
rename 

namespace paddle {
namespace funcs {

to

namespace phi::funcs

And rename usage.