### PR TITLE
[Typos] Fix paddle::operator::math to phi::math for `depthwise_conv.h`

### DIFF
--- a/paddle/phi/kernels/gpu/conv_transpose_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/conv_transpose_grad_kernel.cu
@@ -115,7 +115,7 @@ void DepthwiseConv2dTransposeGradKernel(const Context& dev_ctx,
       &paddings_, &dilations_, padding_algorithm, in_data_dims, strides, ksize);
 
   if (dx) {
-    paddle::operators::math::DepthwiseConvFunctor<Context, T> depthwiseConv;
+    phi::math::DepthwiseConvFunctor<Context, T> depthwiseConv;
     depthwiseConv(dev_ctx,
                   dout,
                   filter_,
@@ -132,7 +132,7 @@ void DepthwiseConv2dTransposeGradKernel(const Context& dev_ctx,
     dev_ctx.template Alloc<T>(dfilter);
     set_zero(dev_ctx, dfilter, static_cast<T>(0));
 
-    paddle::operators::math::DepthwiseConvFilterGradFunctor<Context, T>
+    phi::math::DepthwiseConvFilterGradFunctor<Context, T>
         depthwiseConvFilterGrad;
     depthwiseConvFilterGrad(
         dev_ctx,

--- a/paddle/phi/kernels/gpu/conv_transpose_kernel.cu
+++ b/paddle/phi/kernels/gpu/conv_transpose_kernel.cu
@@ -86,8 +86,7 @@ void DepthwiseConv2dTransposeKernel(const Context& dev_ctx,
   funcs::SetConstant<Context, T> set_zero;
   set_zero(dev_ctx, out, static_cast<T>(0));
 
-  paddle::operators::math::DepthwiseConvInputGradFunctor<Context, T>
-      depthwiseConvInputGrad;
+  phi::math::DepthwiseConvInputGradFunctor<Context, T> depthwiseConvInputGrad;
   depthwiseConvInputGrad(
       dev_ctx,
       *out,

--- a/paddle/phi/kernels/gpu/depthwise_conv.h
+++ b/paddle/phi/kernels/gpu/depthwise_conv.h
@@ -119,9 +119,7 @@ struct DWConvParams {
 
 }  // namespace phi
 
-namespace paddle {
-namespace operators {
-namespace math {
+namespace phi::math {
 
 /*
  * \brief Compute the depthwise convolution which include
@@ -2002,6 +2000,4 @@ template class DepthwiseConvFilterGradFunctor<phi::GPUContext,
                                               phi::dtype::float16,
                                               true>;
 
-}  // namespace math
-}  // namespace operators
-}  // namespace paddle
+}  // namespace phi::math

--- a/paddle/phi/kernels/gpu/depthwise_conv_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/depthwise_conv_grad_kernel.cu
@@ -125,7 +125,7 @@ void DepthwiseConvGradKernel(const Context& dev_ctx,
     set_zero(dev_ctx, input_grad, static_cast<T>(0));
 
     if (fuse_relu) {
-      paddle::operators::math::DepthwiseConvInputGradFunctor<Context, T, true>
+      phi::math::DepthwiseConvInputGradFunctor<Context, T, true>
           depthwiseConvInputGrad;
       depthwiseConvInputGrad(dev_ctx,
                              input,
@@ -137,7 +137,7 @@ void DepthwiseConvGradKernel(const Context& dev_ctx,
                              input_grad,
                              data_layout);
     } else {
-      paddle::operators::math::DepthwiseConvInputGradFunctor<Context, T, false>
+      phi::math::DepthwiseConvInputGradFunctor<Context, T, false>
           depthwiseConvInputGrad;
       depthwiseConvInputGrad(dev_ctx,
                              input,
@@ -155,7 +155,7 @@ void DepthwiseConvGradKernel(const Context& dev_ctx,
     dev_ctx.template Alloc<T>(filter_grad);
     set_zero(dev_ctx, filter_grad, static_cast<T>(0));
     if (fuse_relu) {
-      paddle::operators::math::DepthwiseConvFilterGradFunctor<Context, T, true>
+      phi::math::DepthwiseConvFilterGradFunctor<Context, T, true>
           depthwiseConvFilterGrad;
       depthwiseConvFilterGrad(dev_ctx,
                               input,
@@ -166,7 +166,7 @@ void DepthwiseConvGradKernel(const Context& dev_ctx,
                               filter_grad,
                               data_layout);
     } else {
-      paddle::operators::math::DepthwiseConvFilterGradFunctor<Context, T, false>
+      phi::math::DepthwiseConvFilterGradFunctor<Context, T, false>
           depthwiseConvFilterGrad;
       depthwiseConvFilterGrad(dev_ctx,
                               input,

--- a/paddle/phi/kernels/gpu/depthwise_conv_kernel.cu
+++ b/paddle/phi/kernels/gpu/depthwise_conv_kernel.cu
@@ -122,8 +122,7 @@ void DepthwiseConvKernel(const Context& dev_ctx,
   }
 
   if (fuse_relu) {
-    paddle::operators::math::DepthwiseConvFunctor<Context, T, true>
-        depthwiseConv;
+    phi::math::DepthwiseConvFunctor<Context, T, true> depthwiseConv;
     depthwiseConv(dev_ctx,
                   input,
                   filter,
@@ -133,8 +132,7 @@ void DepthwiseConvKernel(const Context& dev_ctx,
                   output,
                   data_layout);
   } else {
-    paddle::operators::math::DepthwiseConvFunctor<Context, T, false>
-        depthwiseConv;
+    phi::math::DepthwiseConvFunctor<Context, T, false> depthwiseConv;
     depthwiseConv(dev_ctx,
                   input,
                   filter,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Fix paddle::operator::math to phi::math for `depthwise_conv.h`