### PR TITLE
[Complex] Fix wrong reciprocal result when meets complex dtype

### DIFF
--- a/paddle/phi/kernels/funcs/activation_functor.h
+++ b/paddle/phi/kernels/funcs/activation_functor.h
@@ -308,6 +308,41 @@ struct ReciprocalFunctor : public BaseActivationFunctor<T> {
 };
 
 template <typename T>
+struct Reciprocal {
+  HOSTDEVICE ComplexType<T> operator()(const ComplexType<T>& val) const {
+    auto both_inf = [](T real, T imag) {
+      return (std::isinf(real) && std::isinf(imag));
+    };
+
+    auto either_inf = [](T real, T imag) {
+      return std::isinf(real) || std::isinf(imag);
+    };
+
+    auto either_nan = [](T real, T imag) {
+      return std::isnan(real) || std::isnan(imag);
+    };
+    if (either_nan(val.real, val.imag) || both_inf(val.real, val.imag)) {
+      // If either is Nan or both are infinite, return {nan, nan}
+      return ComplexType<T>(std::numeric_limits<T>::quiet_NaN(),
+                            std::numeric_limits<T>::quiet_NaN());
+    } else if (either_inf(val.real, val.imag)) {
+      // If either is Inf, return {0, 0}
+      return ComplexType<T>{static_cast<T>(0), static_cast<T>(0)};
+    }
+    return static_cast<ComplexType<T>>(1.0) / val;
+  }
+};
+
+template <typename T>
+struct ReciprocalFunctor<ComplexType<T>>
+    : public BaseActivationFunctor<ComplexType<T>> {
+  template <typename Device, typename X, typename Out>
+  void operator()(Device d, X x, Out out) const {
+    out.device(d) = x.unaryExpr(Reciprocal<T>());
+  }
+};
+
+template <typename T>
 struct ReciprocalGradFunctor : public BaseActivationFunctor<T> {
   template <typename Device,
             typename X,
@@ -3604,6 +3639,34 @@ struct CudaReciprocalFunctor : public BaseActivationFunctor<T> {
 
   __device__ __forceinline__ T operator()(const T x) const {
     return static_cast<T>(one / static_cast<MPType>(x));
+  }
+};
+
+template <typename T>
+struct CudaReciprocalFunctor<ComplexType<T>>
+    : public BaseActivationFunctor<ComplexType<T>> {
+  __device__ __forceinline__ ComplexType<T> operator()(
+      const ComplexType<T> x) const {
+    auto both_inf = [](T real, T imag) {
+      return (::isinf(real) && ::isinf(imag));
+    };
+
+    auto either_inf = [](T real, T imag) {
+      return ::isinf(real) || ::isinf(imag);
+    };
+
+    auto either_nan = [](T real, T imag) {
+      return ::isnan(real) || ::isnan(imag);
+    };
+    if (either_nan(x.real, x.imag) || both_inf(x.real, x.imag)) {
+      // If either is Nan or both are infinite, return {nan, nan}
+      return ComplexType<T>(std::numeric_limits<T>::quiet_NaN(),
+                            std::numeric_limits<T>::quiet_NaN());
+    } else if (either_inf(x.real, x.imag)) {
+      // If either is Inf, return {0, 0}
+      return ComplexType<T>(static_cast<T>(0), static_cast<T>(0));
+    }
+    return static_cast<ComplexType<T>>(1.0) / x;
   }
 };
 

--- a/paddle/phi/kernels/funcs/activation_functor.h
+++ b/paddle/phi/kernels/funcs/activation_functor.h
@@ -3660,8 +3660,11 @@ struct CudaReciprocalFunctor<ComplexType<T>>
     };
     if (either_nan(x.real, x.imag) || both_inf(x.real, x.imag)) {
       // If either is Nan or both are infinite, return {nan, nan}
-      return ComplexType<T>(std::numeric_limits<T>::quiet_NaN(),
-                            std::numeric_limits<T>::quiet_NaN());
+      if constexpr (std::is_same<T, float>::value) {
+        return ComplexType<T>(nanf(""), nanf(""));
+      } else if constexpr (std::is_same<T, double>::value) {
+        return ComplexType<T>(nan(""), nan(""));
+      }
     } else if (either_inf(x.real, x.imag)) {
       // If either is Inf, return {0, 0}
       return ComplexType<T>(static_cast<T>(0), static_cast<T>(0));

--- a/test/legacy_test/test_activation_op.py
+++ b/test/legacy_test/test_activation_op.py
@@ -3952,6 +3952,26 @@ class TestReciprocal_ZeroDim(TestReciprocal):
         self.shape = []
 
 
+class TestReciprocalComplex(unittest.TestCase):
+    def test_reciprocal_complex(self):
+        for place in get_places():
+            x_np = np.array(
+                [
+                    complex(float('inf'), 0),
+                    complex(0, float('inf')),
+                    complex(float('inf'), float('inf')),
+                    complex(0, float('nan')),
+                    complex(0, 1),
+                ],
+                dtype=np.complex64,
+            )
+            res_np = np.reciprocal(x_np)
+            with paddle.base.dygraph.guard(place):
+                x = paddle.to_tensor(x_np, dtype='complex64', place=place)
+                res = paddle.reciprocal(x)
+                np.testing.assert_allclose(res.numpy(), res_np)
+
+
 class TestLog(TestActivation):
     def setUp(self):
         self.op_type = "log"


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
https://github.com/PaddlePaddle/Paddle/issues/73714

Fix wrong reciprocal result when meets complex dtype