### PR TITLE
CINN Add more Simplify scenario: Select2MinMax, BoundSimplify, PowerL…

### DIFF
--- a/paddle/cinn/common/ir_util.cc
+++ b/paddle/cinn/common/ir_util.cc
@@ -270,6 +270,16 @@ bool is_zero(Expr v) {
   return false;
 }
 
+Expr NormalizeUpperBound(Expr upper_bound, bool minus_one /* = true */) {
+  if (upper_bound == SymbolicExprLimit::positive_inf) {
+    return upper_bound;
+  }
+  if (minus_one) {
+    return upper_bound - ir::Expr(1);  // [lower, upper) to [lower, upper]
+  }
+  return upper_bound + ir::Expr(1);  // (lower, upper] to [lower, upper)
+}
+
 Expr CastIfNeeded(Expr body, Type type) {
   if (body.type() == type) return body;
   return ir::Cast::Make(type, body);

--- a/paddle/cinn/common/ir_util.h
+++ b/paddle/cinn/common/ir_util.h
@@ -91,6 +91,8 @@ std::vector<std::string> GatherItersToTensorProducer(
 
 bool is_zero(Expr v);
 
+Expr NormalizeUpperBound(Expr upper_bound, bool minus_one = true);
+
 bool MathEqual(const Expr &a, const Expr &b);
 
 //! helper function to get a ir::Select node.

--- a/paddle/cinn/ir/ir.h
+++ b/paddle/cinn/ir/ir.h
@@ -421,6 +421,7 @@ struct _Var_ : public ExprNode<_Var_> {
 };
 
 //! A named variable.
+// i ∈ [lower_bound, upper_bound)
 struct Var : public IrNodeRef {
   Var() = default;
   explicit Var(IrNode* n) : IrNodeRef(n) {}
@@ -846,6 +847,7 @@ struct For : public ExprNode<For>, public ForBase {
   //! The minimum value of the iteration.
   Expr min;
   //! The extent of the iteration.
+  // loop_var ∈ [min, min + extent)
   Expr extent;
 
   Expr body;

--- a/test/cpp/pir/cinn/CMakeLists.txt
+++ b/test/cpp/pir/cinn/CMakeLists.txt
@@ -47,6 +47,10 @@ if(WITH_TESTING AND WITH_CINN)
   paddle_test(eliminate_common_factor_of_local_index_test SRCS
               eliminate_common_factor_of_local_index_test.cc)
 
+  paddle_test(ir_simplify_select_test SRCS ir_simplify_select_test.cc)
+
+  paddle_test(ir_simplify_bound_test SRCS ir_simplify_bound_test.cc)
+
   # DO NOT forget add test name here, otherwise it will not be executed in
   # CINN CI.
   set(cinn_unit_tests

--- a/test/cpp/pir/cinn/adt/index_expr_test.cc
+++ b/test/cpp/pir/cinn/adt/index_expr_test.cc
@@ -52,6 +52,7 @@ class TestIndexExpr : public ::testing::Test {
 
   ir::Var S4, S5, S6, S7, S8, S9, f;
 };
+
 TEST_F(TestIndexExpr, IndexExpr_0) {
   ir::IndexExpr a(14);
   ir::IndexExpr b(7);
@@ -643,10 +644,11 @@ TEST_F(TestIndexExpr, MatchPattern) {
   EXPECT_EQ(result9->at("x"), x);
   EXPECT_EQ(result9->at("y"), y);
 }
+
 TEST_F(TestIndexExpr, BoundSimplify) {
   ir::Var S0 = ir::Var("S0");
-  ir::Var i = ir::Var(ir::Expr(0), ir::Expr(5), "i");
-  ir::Var j = ir::Var(ir::Expr(0), S0, "j");
+  ir::Var i = ir::Var(ir::Expr(0), ir::Expr(5), "i");  // i ∈ [0, 5)
+  ir::Var j = ir::Var(ir::Expr(0), S0, "j");           // j ∈ [0, S0)
 
   ir::Expr q0 = i / Expr(5);
   ir::Expr q1 = i / Expr(4);

--- a/test/cpp/pir/cinn/adt/iter_simplify_test.cc
+++ b/test/cpp/pir/cinn/adt/iter_simplify_test.cc
@@ -47,11 +47,12 @@ class TestIterSimplify : public ::testing::Test {
     i_j_k_fused =
         ir::Var(ir::Expr(0), ir::Expr(64), "i_j_k_fused").set_index(1);
     var_intervals = {
-        {"i", CasInterval(i->lower_bound, i->upper_bound)},
-        {"j", CasInterval(j->lower_bound, j->upper_bound)},
-        {"k", CasInterval(k->lower_bound, k->upper_bound)},
+        {"i", CasInterval(i->lower_bound, i->upper_bound - ir::Expr(1))},
+        {"j", CasInterval(j->lower_bound, j->upper_bound - ir::Expr(1))},
+        {"k", CasInterval(k->lower_bound, k->upper_bound - ir::Expr(1))},
         {"i_j_k_fused",
-         CasInterval(i_j_k_fused->lower_bound, i_j_k_fused->upper_bound)}};
+         CasInterval(i_j_k_fused->lower_bound,
+                     i_j_k_fused->upper_bound - ir::Expr(1))}};
   };
 
   ir::Var i;

--- a/test/cpp/pir/cinn/ir_simplify_bound_test.cc
+++ b/test/cpp/pir/cinn/ir_simplify_bound_test.cc
@@ -1,0 +1,191 @@
+// Copyright (c) 2025 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/cinn/optim/ir_simplify.h"
+
+#include <gtest/gtest.h>
+
+#include "paddle/cinn/cinn.h"
+#include "paddle/cinn/ir/ir.h"
+#include "paddle/cinn/ir/ir_base.h"
+#include "paddle/cinn/ir/ir_printer.h"
+#include "paddle/cinn/ir/op/ir_operators.h"
+#include "paddle/cinn/ir/schedule/ir_schedule.h"
+#include "paddle/cinn/ir/utils/ir_nodes_collector.h"
+#include "paddle/cinn/ir/utils/stmt_converter.h"
+#include "paddle/cinn/utils/string.h"
+
+namespace cinn {
+namespace optim {
+
+/*
+i_j_fused: [0ll, 524288ll)
+j_0: [0, 128)
+Before Normalize:
+(j_0 % 128)
+After Normalize:
+j_0
+*/
+TEST(IRSimplifyBound, SimplifyMod) {
+  Context::Global().ResetNameId();
+
+  // Create input IR matching the specified pattern
+  // Define loop variable
+  ir::Var var_j_0 = ir::Var(ir::Expr(0), ir::Expr(128), "j_0");
+
+  // Final expression
+  ir::Expr expr = ir::Mod::Make(var_j_0, ir::Expr(128));
+
+  VLOG(6) << "Before Simplify: " << expr;
+  auto res = expr.as_index().ir::IndexExpr::Normalize(
+      ir::IndexExpr::OptLevel::kLevel3);
+  VLOG(6) << "After Simplify: " << res;
+
+  // Expected output verification
+  std::string expected_ir = R"ROC(j_0)ROC";
+
+  EXPECT_EQ(utils::GetStreamCnt(res), utils::Trim(expected_ir));
+}
+
+/*
+i_j_fused: [0ll, 524288ll)
+j_0: [0, 128)
+Before Normalize:
+(j_0 / 128)
+After Normalize:
+0
+*/
+TEST(IRSimplifyBound, SimplifyDiv) {
+  Context::Global().ResetNameId();
+
+  // Create input IR matching the specified pattern
+  // Define loop variable
+  ir::Var var_j_0 = ir::Var(ir::Expr(0), ir::Expr(128), "j_0");
+
+  // Final expression
+  ir::Expr expr = ir::Div::Make(var_j_0, ir::Expr(128));
+
+  VLOG(6) << "Before Normalize: " << expr;
+  auto res = expr.as_index().ir::IndexExpr::Normalize(
+      ir::IndexExpr::OptLevel::kLevel3);
+  VLOG(6) << "After Normalize: " << res;
+
+  // Expected output verification
+  std::string expected_ir = R"ROC(0)ROC";
+
+  EXPECT_EQ(utils::GetStreamCnt(res), utils::Trim(expected_ir));
+}
+
+/*
+i_j_fused: [0ll, 524288ll)
+j_0: [0, 128)
+Before Normalize:
+((((i_j_fused % 16) * 128) + j_0) / 128)
+After Normalize:
+(i_j_fused % 16)
+*/
+TEST(IRSimplifyBound, SimplifyLinearDiv) {
+  Context::Global().ResetNameId();
+
+  // Create input IR matching the specified pattern
+  // Define loop variables
+  ir::Var var_i_j_fused = ir::Var(ir::Expr(0), ir::Expr(524288), "i_j_fused");
+  ir::Var var_j_0 = ir::Var(ir::Expr(0), ir::Expr(128), "j_0");
+
+  // Final expression
+  ir::Expr expr = ir::Div::Make(
+      ir::Add::Make(ir::Mul::Make(ir::Mod::Make(var_i_j_fused, ir::Expr(16)),
+                                  ir::Expr(128)),
+                    var_j_0),
+      ir::Expr(128));
+
+  VLOG(6) << "Before Normalize: " << expr;
+  auto res = expr.as_index().ir::IndexExpr::Normalize(
+      ir::IndexExpr::OptLevel::kLevel3);
+  VLOG(6) << "After Normalize: " << res;
+
+  // Expected output verification
+  std::string expected_ir = R"ROC((i_j_fused % 16))ROC";
+
+  EXPECT_EQ(utils::GetStreamCnt(res), utils::Trim(expected_ir));
+}
+
+/*
+i_j_fused: [0ll, 524288ll)
+j_0: [0, 128)
+Before Normalize:
+((((i_j_fused % 16) * 128) + j_0) % 128)
+After Normalize:
+j_0
+*/
+TEST(IRSimplifyBound, SimplifyLinearMod) {
+  Context::Global().ResetNameId();
+
+  // Create input IR matching the specified pattern
+  // Define loop variables
+  ir::Var var_i_j_fused = ir::Var(ir::Expr(0), ir::Expr(524288), "i_j_fused");
+  ir::Var var_j_0 = ir::Var(ir::Expr(0), ir::Expr(128), "j_0");
+
+  // Final expression
+  ir::Expr expr = ir::Mod::Make(
+      ir::Add::Make(ir::Mul::Make(ir::Mod::Make(var_i_j_fused, ir::Expr(16)),
+                                  ir::Expr(128)),
+                    var_j_0),
+      ir::Expr(128));
+
+  VLOG(6) << "Before Normalize: " << expr;
+  auto res = expr.as_index().ir::IndexExpr::Normalize(
+      ir::IndexExpr::OptLevel::kLevel3);
+  VLOG(6) << "After Normalize: " << res;
+
+  // Expected output verification
+  std::string expected_ir = R"ROC(j_0)ROC";
+
+  EXPECT_EQ(utils::GetStreamCnt(res), utils::Trim(expected_ir));
+}
+
+/*
+loop_var_2: [0, 32)
+loop_var_3: [0, 4)
+Before Normalize:
+(((loop_var_3 * 32ll) + loop_var_2) / 128ll)
+After Normalize:
+0
+*/
+TEST(IRSimplifyBound, SimplifyLinearDiv2) {
+  Context::Global().ResetNameId();
+
+  // Create input IR matching the specified pattern
+  // Define loop variables
+  ir::Var loop_var_2 = ir::Var(ir::Expr(0), ir::Expr(32), "loop_var_2");
+  ir::Var loop_var_3 = ir::Var(ir::Expr(0), ir::Expr(4), "loop_var_3");
+
+  // Final expression
+  ir::Expr expr = ir::Div::Make(
+      ir::Add::Make(ir::Mul::Make(loop_var_3, ir::Expr(32)), loop_var_2),
+      ir::Expr(128));
+
+  VLOG(6) << "Before Normalize: " << expr;
+  auto res = expr.as_index().ir::IndexExpr::Normalize(
+      ir::IndexExpr::OptLevel::kLevel3);
+  VLOG(6) << "After Normalize: " << res;
+
+  // Expected output verification
+  std::string expected_ir = R"ROC(0)ROC";
+
+  EXPECT_EQ(utils::GetStreamCnt(res), utils::Trim(expected_ir));
+}
+
+}  // namespace optim
+}  // namespace cinn

--- a/test/cpp/pir/cinn/ir_simplify_select_test.cc
+++ b/test/cpp/pir/cinn/ir_simplify_select_test.cc
@@ -1,0 +1,336 @@
+// Copyright (c) 2025 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/cinn/optim/ir_simplify.h"
+
+#include <gtest/gtest.h>
+
+#include "paddle/cinn/cinn.h"
+#include "paddle/cinn/ir/ir.h"
+#include "paddle/cinn/ir/ir_printer.h"
+#include "paddle/cinn/ir/op/ir_operators.h"
+#include "paddle/cinn/ir/schedule/ir_schedule.h"
+#include "paddle/cinn/ir/utils/ir_nodes_collector.h"
+#include "paddle/cinn/ir/utils/stmt_converter.h"
+#include "paddle/cinn/utils/string.h"
+
+namespace cinn {
+namespace optim {
+
+/*
+serial for (i, 0ll, 32768ll) {
+  serial for (j, 0ll, 16ll) {
+    serial for (reduce_k_0, 0ll, 128ll) {
+        var_18[i, j] = select((var_18[i, j] > var_17[i, j, reduce_k_0]),
+var_18[i, j], var_17[i, j, reduce_k_0])
+      }
+    }
+  }
+}
+*/
+TEST(IRSimplifySelect, SimplifySelectToMax) {
+  Context::Global().ResetNameId();
+
+  // Create input IR matching the specified pattern
+  const std::vector<ir::Expr> shape_2d = {ir::Expr(32768), ir::Expr(16)};
+  const std::vector<ir::Expr> shape_3d = {
+      ir::Expr(32768), ir::Expr(16), ir::Expr(128)};
+
+  ir::Tensor var_17 =
+      ir::_Tensor_::Make("var_17", ir::Float(32), shape_3d, shape_3d);
+  var_17->WithBuffer("global", "var_17_buffer");
+
+  ir::Tensor var_18 =
+      ir::_Tensor_::Make("var_18", ir::Float(32), shape_2d, shape_2d);
+  var_18->WithBuffer("global", "var_18_buffer");
+
+  // Define loop variables
+  ir::Var var_i = ir::Var(ir::Expr(0), ir::Expr(32768), "i");
+  ir::Var var_j = ir::Var(ir::Expr(0), ir::Expr(16), "j");
+  ir::Var var_reduce_k_0 = ir::Var(ir::Expr(0), ir::Expr(128), "reduce_k_0");
+
+  // Create innermost reduction loop body
+  ir::Expr reduce_body = ir::Store::Make(
+      var_18,
+      ir::Select::Make(
+          ir::GT::Make(ir::Load::Make(var_18, {var_i, var_j}),
+                       ir::Load::Make(var_17, {var_i, var_j, var_reduce_k_0})),
+          ir::Load::Make(var_18, {var_i, var_j}),
+          ir::Load::Make(var_17, {var_i, var_j, var_reduce_k_0})),
+      {var_i, var_j});
+
+  // Create reduction loop
+  ir::Expr reduce_loop = ir::For::Make(var_reduce_k_0,
+                                       ir::Expr(0),
+                                       ir::Expr(128),
+                                       ir::ForType::Serial,
+                                       ir::DeviceAPI::Host,
+                                       ir::Block::Make({reduce_body}));
+
+  // Create j loop
+  ir::Expr j_loop = ir::For::Make(var_j,
+                                  ir::Expr(0),
+                                  ir::Expr(16),
+                                  ir::ForType::Serial,
+                                  ir::DeviceAPI::Host,
+                                  ir::Block::Make({reduce_loop}));
+
+  // Create i loop
+  ir::Expr i_loop = ir::For::Make(var_i,
+                                  ir::Expr(0),
+                                  ir::Expr(32768),
+                                  ir::ForType::Serial,
+                                  ir::DeviceAPI::Host,
+                                  ir::Block::Make({j_loop}));
+
+  // Final expression
+  ir::Expr expr = ir::Block::Make({i_loop});
+
+  VLOG(6) << "Before Simplify: " << expr;
+  Simplify(&expr);
+  VLOG(6) << "After Simplify: " << expr;
+
+  // Expected output verification
+  std::string expected_ir = R"ROC({
+  serial for (i, 0, 32768)
+  {
+    serial for (j, 0, 16)
+    {
+      serial for (reduce_k_0, 0, 128)
+      {
+        var_18[i, j] = cinn_max(var_17[i, j, reduce_k_0], var_18[i, j])
+      }
+    }
+  }
+})ROC";
+
+  EXPECT_EQ(utils::GetStreamCnt(expr), utils::Trim(expected_ir));
+}
+
+/*
+serial for (i, 0ll, 32768ll) {
+  serial for (j, 0ll, 16ll) {
+    serial for (reduce_k_0, 0ll, 128ll) {
+        var_18[i, j] = select((var_18[i, j] < var_17[i, j, reduce_k_0]),
+var_18[i, j], var_17[i, j, reduce_k_0])
+      }
+    }
+  }
+}
+*/
+TEST(IRSimplifySelect, SimplifySelectToMin) {
+  Context::Global().ResetNameId();
+
+  // Create input IR matching the specified pattern
+  const std::vector<ir::Expr> shape_2d = {ir::Expr(32768), ir::Expr(16)};
+  const std::vector<ir::Expr> shape_3d = {
+      ir::Expr(32768), ir::Expr(16), ir::Expr(128)};
+
+  ir::Tensor var_17 =
+      ir::_Tensor_::Make("var_17", ir::Float(32), shape_3d, shape_3d);
+  var_17->WithBuffer("global", "var_17_buffer");
+
+  ir::Tensor var_18 =
+      ir::_Tensor_::Make("var_18", ir::Float(32), shape_2d, shape_2d);
+  var_18->WithBuffer("global", "var_18_buffer");
+
+  // Define loop variables
+  ir::Var var_i = ir::Var(ir::Expr(0), ir::Expr(32768), "i");
+  ir::Var var_j = ir::Var(ir::Expr(0), ir::Expr(16), "j");
+  ir::Var var_reduce_k_0 = ir::Var(ir::Expr(0), ir::Expr(128), "reduce_k_0");
+
+  // Create innermost reduction loop body
+  ir::Expr reduce_body = ir::Store::Make(
+      var_18,
+      ir::Select::Make(
+          ir::LT::Make(ir::Load::Make(var_18, {var_i, var_j}),
+                       ir::Load::Make(var_17, {var_i, var_j, var_reduce_k_0})),
+          ir::Load::Make(var_18, {var_i, var_j}),
+          ir::Load::Make(var_17, {var_i, var_j, var_reduce_k_0})),
+      {var_i, var_j});
+
+  // Create reduction loop
+  ir::Expr reduce_loop = ir::For::Make(var_reduce_k_0,
+                                       ir::Expr(0),
+                                       ir::Expr(128),
+                                       ir::ForType::Serial,
+                                       ir::DeviceAPI::Host,
+                                       ir::Block::Make({reduce_body}));
+
+  // Create j loop
+  ir::Expr j_loop = ir::For::Make(var_j,
+                                  ir::Expr(0),
+                                  ir::Expr(16),
+                                  ir::ForType::Serial,
+                                  ir::DeviceAPI::Host,
+                                  ir::Block::Make({reduce_loop}));
+
+  // Create i loop
+  ir::Expr i_loop = ir::For::Make(var_i,
+                                  ir::Expr(0),
+                                  ir::Expr(32768),
+                                  ir::ForType::Serial,
+                                  ir::DeviceAPI::Host,
+                                  ir::Block::Make({j_loop}));
+
+  // Final expression
+  ir::Expr expr = ir::Block::Make({i_loop});
+
+  VLOG(6) << "Before Simplify: " << expr;
+  Simplify(&expr);
+  VLOG(6) << "After Simplify: " << expr;
+
+  // Expected output verification
+  std::string expected_ir = R"ROC({
+  serial for (i, 0, 32768)
+  {
+    serial for (j, 0, 16)
+    {
+      serial for (reduce_k_0, 0, 128)
+      {
+        var_18[i, j] = cinn_min(var_18[i, j], var_17[i, j, reduce_k_0])
+      }
+    }
+  }
+})ROC";
+
+  EXPECT_EQ(utils::GetStreamCnt(expr), utils::Trim(expected_ir));
+}
+
+/*
+serial for (i, 0ll, 32768ll)
+{
+    serial for (j, 0, 16)
+    {
+        serial for (j_0, 0, 128)
+        {
+            var_45[i, j, j_0)] = select(
+                (var_18[i, ((((j * 128ll) + j_0) / 128ll) + 0ll)] <=
+                 float32(3.4028234663852886e+38)),
+                select(
+                    (var_18[i, ((((j * 128ll) + j_0) / 128ll) + 0ll)] >=
+                     float32(9.9999997473787516e-05)),
+                    var_18[i, ((((j * 128ll) + j_0) / 128ll) + 0ll)],
+                    float32(9.9999997473787516e-05)
+                ),
+                float32(3.4028234663852886e+38)
+            )
+        }
+    }
+}
+*/
+TEST(IRSimplifySelect, SimplifySelectToMinMax) {
+  Context::Global().ResetNameId();
+
+  // Create input IR matching the specified pattern
+  const std::vector<ir::Expr> shape_2d = {ir::Expr(32768), ir::Expr(16)};
+  const std::vector<ir::Expr> shape_3d = {
+      ir::Expr(32768), ir::Expr(16), ir::Expr(128)};
+
+  ir::Tensor var_18 =
+      ir::_Tensor_::Make("var_18", ir::Float(32), shape_2d, shape_2d);
+  var_18->WithBuffer("global", "var_18_buffer");
+
+  ir::Tensor var_45 =
+      ir::_Tensor_::Make("var_45", ir::Float(32), shape_3d, shape_3d);
+  var_45->WithBuffer("global", "var_45_buffer");
+
+  // Define loop variables
+  ir::Var var_i = ir::Var(ir::Expr(0), ir::Expr(32768), "i");
+  ir::Var var_j = ir::Var(ir::Expr(0), ir::Expr(16), "j");
+  ir::Var var_j_0 = ir::Var(ir::Expr(0), ir::Expr(128), "j_0");
+
+  // Create innermost loop body
+  ir::Expr body = ir::Store::Make(
+      var_45,
+      ir::Select::Make(
+          ir::LE::Make(
+              ir::Load::Make(
+                  var_18,
+                  {var_i,
+                   ir::Div::Make(
+                       ir::Add::Make(ir::Mul::Make(var_j, ir::Expr(128)),
+                                     var_j_0),
+                       ir::Expr(128))}),
+              ir::Expr(3.4028234663852886e+38f)),
+          ir::Select::Make(
+              ir::GE::Make(
+                  ir::Load::Make(
+                      var_18,
+                      {var_i,
+                       ir::Div::Make(
+                           ir::Add::Make(ir::Mul::Make(var_j, ir::Expr(128)),
+                                         var_j_0),
+                           ir::Expr(128))}),
+                  ir::Expr(9.9999997473787516e-05f)),
+              ir::Load::Make(
+                  var_18,
+                  {var_i,
+                   ir::Div::Make(
+                       ir::Add::Make(ir::Mul::Make(var_j, ir::Expr(128)),
+                                     var_j_0),
+                       ir::Expr(128))}),
+              ir::Expr(9.9999997473787516e-05f)),
+          ir::Expr(3.4028234663852886e+38f)),
+      {var_i, var_j, var_j_0});
+
+  // Create j_0 loop
+  ir::Expr j_0_loop = ir::For::Make(var_j_0,
+                                    ir::Expr(0),
+                                    ir::Expr(128),
+                                    ir::ForType::Serial,
+                                    ir::DeviceAPI::Host,
+                                    ir::Block::Make({body}));
+
+  // Create j loop
+  ir::Expr j_loop = ir::For::Make(var_j,
+                                  ir::Expr(0),
+                                  ir::Expr(16),
+                                  ir::ForType::Serial,
+                                  ir::DeviceAPI::Host,
+                                  ir::Block::Make({j_0_loop}));
+
+  // Create i loop
+  ir::Expr i_loop = ir::For::Make(var_i,
+                                  ir::Expr(0),
+                                  ir::Expr(32768),
+                                  ir::ForType::Serial,
+                                  ir::DeviceAPI::Host,
+                                  ir::Block::Make({j_loop}));
+
+  // Final expression
+  ir::Expr expr = ir::Block::Make({i_loop});
+
+  VLOG(6) << "Before Simplify: " << expr;
+  Simplify(&expr);
+  VLOG(6) << "After Simplify: " << expr;
+
+  // Expected output verification
+  std::string expected_ir = R"ROC({
+  serial for (i, 0, 32768)
+  {
+    serial for (j, 0, 16)
+    {
+      serial for (j_0, 0, 128)
+      {
+        var_45[i, j, j_0] = cinn_min(cinn_max(var_18[i, (((j * 128) + j_0) / 128)], 9.99999975e-05f), 3.40282347e+38f)
+      }
+    }
+  }
+})ROC";
+
+  EXPECT_EQ(utils::GetStreamCnt(expr), utils::Trim(expected_ir));
+}
+}  // namespace optim
+}  // namespace cinn


### PR DESCRIPTION
### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
DeepSeek子网涉及到的一些Simplify优化:
SelectOp -> Min Max
BoundSimplify优化：支持 (a*x + b)/a, a > b  --> x,  (a*x + b)% a, a > b  --> b, 
“Power+Log”优化成“Bit操作+ldexpf"

明确CINN中UpperBound能否取到，修正UpperBound的传递关系，使其计算更准确
Var [LowerBound, UpperBound）左闭右开，
For loop_var  [LowerBound, UpperBound）左闭右开，
CasInterval [LowerBound, UpperBound]左闭右闭，
SymbolicExprAnalyzer [LowerBound, UpperBound]左闭右闭

Pcard-90680