### PR TITLE
[0-size Tensor Retest]Fix fold、fused_feedforward、lstsq、broadcast_tensor api to sopport 0-size Tensor

### DIFF
--- a/python/paddle/nn/functional/common.py
+++ b/python/paddle/nn/functional/common.py
@@ -2755,8 +2755,8 @@ def fold(
 
     assert len(x.shape) == 3, "input should be the format of [N, C, L]"
     assert (
-        math.prod(x.shape) > 0
-    ), "The number of elements must greater than zero."
+        math.prod(x.shape) >= 0
+    ), "The number of elements must greater or equal than zero."
 
     def _is_list_or_tuple_(data):
         return isinstance(data, (list, tuple))

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -4829,7 +4829,7 @@ def lstsq(
             x, y, rcond, driver
         )
         if driver == "gels":
-            rank = paddle.empty(shape=[0], dtype="int32")
+            rank = paddle.empty(shape=[0], dtype="int64")
             singular_values = paddle.empty(shape=[0], dtype=x.dtype)
         elif driver == "gelsy":
             singular_values = paddle.empty(shape=[0], dtype=x.dtype)

--- a/test/legacy_test/test_broadcast_tensors_op.py
+++ b/test/legacy_test/test_broadcast_tensors_op.py
@@ -501,7 +501,27 @@ class TestBroadcastTensorsAPIZeroSize(unittest.TestCase):
             ]
             outputs = paddle.broadcast_tensors(inputs)
             self.assertEqual(outputs[0].shape, self.expected_shape)
+
+    def test_zero_size_dynamic_backward(self):
+        with dygraph_guard():
+            data1 = np.ones(self.shape1, dtype=self.dtype)
+            data2 = np.ones(self.shape2, dtype=self.dtype)
+            input1 = paddle.to_tensor(
+                data1, dtype=self.dtype, stop_gradient=False
+            )
+            input2 = paddle.to_tensor(
+                data2, dtype=self.dtype, stop_gradient=False
+            )
+            inputs = [
+                input1,
+                input2,
+            ]
+            outputs = paddle.broadcast_tensors(inputs)
+            self.assertEqual(outputs[0].shape, self.expected_shape)
             self.assertEqual(outputs[1].shape, self.expected_shape)
+            grads = paddle.grad(
+                inputs, outputs, retain_graph=True, allow_unused=True
+            )
 
 
 class TestBroadcastTensorsAPIZeroSize_bool(TestBroadcastTensorsAPIZeroSize):

--- a/test/legacy_test/test_fold_op.py
+++ b/test/legacy_test/test_fold_op.py
@@ -283,17 +283,6 @@ class TestFoldOpError(unittest.TestCase):
                     strides=0,
                 )
 
-            def test_zero_size():
-                x = paddle.randn(shape=[0, 1, 1], dtype="float32")
-                out = fold(
-                    x,
-                    output_sizes=[0, 0],
-                    kernel_sizes=[0, 0],
-                    dilations=0,
-                    paddings=[0, 0],
-                    strides=0,
-                )
-
             self.assertRaises(AssertionError, test_input_shape)
             self.assertRaises(AssertionError, test_kernel_shape)
             self.assertRaises(ValueError, test_padding_shape)
@@ -303,7 +292,6 @@ class TestFoldOpError(unittest.TestCase):
             self.assertRaises(TypeError, test_output_size_2)
             self.assertRaises(ValueError, test_block_h_w)
             self.assertRaises(ValueError, test_GT_0)
-            self.assertRaises(AssertionError, test_zero_size)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修复fold、fused_feedforward、lstsq、broadcast_tensor 0-size复测报错
- fold
之前添加的限制导致报错‘
- fused_feedforward 
反向填充不为0
- lstsq
rank的dtype不对
- broadcast_tensor
cpu 反向报段错误

pcard-67164
