### PR TITLE
[0-size Tensor Retest] fix 0-size of unique

### DIFF
--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -6211,6 +6211,21 @@ void UniqueRawInferMeta(const MetaTensor& x,
     counts->set_dims(common::make_ddim({-1}));
     counts->set_dtype(dtype);
   }
+  if (x.numel() == 0) {
+    if (!axis.empty()) {
+      auto out_dims = x.dims();
+      out_dims[axis[0]] = 0;
+      out->set_dims(out_dims);
+    } else {
+      out->set_dims(common::make_ddim({0}));
+    }
+    if (return_index) {
+      indices->set_dims(common::make_ddim({0}));
+    }
+    if (return_counts) {
+      counts->set_dims(common::make_ddim({0}));
+    }
+  }
 }
 
 void UnsqueezeInferMeta(const MetaTensor& x,

--- a/paddle/phi/kernels/cpu/unique_kernel.cc
+++ b/paddle/phi/kernels/cpu/unique_kernel.cc
@@ -36,6 +36,13 @@ void UniqueKernel(const Context& dev_ctx,
                   DenseTensor* index,
                   DenseTensor* counts) {
   bool is_sorted = true;
+  if (x.numel() == 0) {
+    dev_ctx.template Alloc<T>(out);
+    dev_ctx.template Alloc<int64_t>(indices);
+    dev_ctx.template Alloc<int64_t>(index);
+    dev_ctx.template Alloc<int64_t>(counts);
+    return;
+  }
   UniqueRawKernel<T, Context>(dev_ctx,
                               x,
                               return_index,

--- a/paddle/phi/kernels/gpu/unique_kernel.cu
+++ b/paddle/phi/kernels/gpu/unique_kernel.cu
@@ -690,6 +690,13 @@ void UniqueKernel(const Context& dev_ctx,
                   DenseTensor* index,
                   DenseTensor* counts) {
   bool is_sorted = true;
+  if (x.numel() == 0) {
+    dev_ctx.template Alloc<T>(out);
+    dev_ctx.template Alloc<int64_t>(indices);
+    dev_ctx.template Alloc<int64_t>(index);
+    dev_ctx.template Alloc<int64_t>(counts);
+    return;
+  }
   UniqueRawKernel<T, Context>(dev_ctx,
                               x,
                               return_index,

--- a/test/legacy_test/test_unique.py
+++ b/test/legacy_test/test_unique.py
@@ -482,5 +482,22 @@ class TestUniqueError(unittest.TestCase):
             self.assertRaises(TypeError, test_axis)
 
 
+class Test_ZeroSize(TestUniqueOp):
+    def init_config(self):
+        self.inputs = {
+            'X': np.array([2, 0], dtype=self.dtype),
+        }
+        self.attrs = {'dtype': int(core.VarDesc.VarType.INT32)}
+        self.outputs = {
+            'Out': np.array([2, 0], dtype=self.dtype),
+            'Index': np.array([0, 1], dtype='int32'),
+        }
+
+    def test_check_output(self):
+        self.check_output_with_place(core.CPUPlace(), check_dygraph=False)
+        if core.is_compiled_with_cuda():
+            self.check_output_with_place(core.CUDAPlace(0), check_dygraph=False)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
**unique**修复过程：
在Kernel中加入0-size判断，并Alloc后return。但是会出现Alloc错误，排查发现UniqueRawInferMeta的shape的dims赋值为-1，从而导致在kernel中判断0-size返回时出现Alloc错误，所以在UniqueRawInferMeta增大对0-size的支持修改。
<img width="1212" height="300" alt="image" src="https://github.com/user-attachments/assets/e0d9e592-1bc7-4667-9eef-46d92ad66840" />


pcard-67164