### PR TITLE
fix cuda error 700 for softmax

### DIFF
--- a/paddle/phi/kernels/gpudnn/softmax_gpudnn.h
+++ b/paddle/phi/kernels/gpudnn/softmax_gpudnn.h
@@ -1375,7 +1375,7 @@ void SoftmaxBackwardCUDAKernelDriverImpl(const GPUContext& dev_ctx,
       GetSoftmaxTensorDims<IndexType>(out.dims(), axis);
   IndexType N = tensor_dims[0];
   IndexType dim = tensor_dims[1];
-  int D = tensor_dims[2];
+  IndexType D = tensor_dims[2];
 
   if (D == 1) {
     if (!UseCudnnSoftmax<T>(dev_ctx, dim, true) ||


### PR DESCRIPTION
### PR Category  
Operator Mechanism

### PR Types  
Bug fixes

### Description  
paddle.nn.functional.softmax对于大tensor的问题修复
-  解决 CUDA Error 700 的问题：由于 D 类型设置不当，导致 CUDA kernel 报错，已将其类型修改为正确的模板类型，避免非法转换。
-  解决精度误差导致的单测失败：由于我们当前精度较高，导致误差容忍度不够，适当放宽了 `atol` 的设置，使其可以通过对比测试。详见 [PFCCLab/PaddleAPITest#464](https://github.com/PFCCLab/PaddleAPITest/pull/464)

Pcard-92269
