### PR TITLE
[Auto Parallel] Add spmd_rule about sharding on the same tensor dim by many mesh dim for softmax

### DIFF
--- a/paddle/phi/infermeta/spmd_rules/softmax.cc
+++ b/paddle/phi/infermeta/spmd_rules/softmax.cc
@@ -32,7 +32,8 @@ SpmdInfo SoftmaxInferSpmd(const DistMetaTensor& x, int axis) {
   auto x_shape = common::vectorize(x.dims());
   int x_ndim = static_cast<int>(x_shape.size());
   auto x_dist_attr_src = x.dist_attr();
-  std::vector<int64_t> x_dims_mapping = x_dist_attr_src.dims_mapping();
+  std::vector<std::vector<int64_t>> x_dims_mapping =
+      x_dist_attr_src.multi_dims_mapping();
   PADDLE_ENFORCE_EQ(
       x_ndim,
       x_dims_mapping.size(),
@@ -60,8 +61,8 @@ SpmdInfo SoftmaxInferSpmd(const DistMetaTensor& x, int axis) {
   // naive support for sharding on softmax_axis
   // softmax_axis should be resharded as replicated (TODO: support sharding on
   // softmax_axis efficiently)
-  if (x_dims_mapping[axis] >= 0) {
-    x_dims_mapping[axis] = -1;
+  if (IsSharedDim(x_dims_mapping[axis])) {
+    x_dims_mapping[axis] = std::vector<int64_t>({});
     VLOG(6) << "SoftmaxSPMDRule InferForward: softmax axis is reshard to be "
                "replicated: "
             << "original dims_mapping["
@@ -70,13 +71,14 @@ SpmdInfo SoftmaxInferSpmd(const DistMetaTensor& x, int axis) {
   }
 
   // Avoid multiple tensor axes sharded by same mesh dimension
-  std::unordered_map<std::string, int64_t> axis_to_dim_map =
-      ShardingMergeForTensors({{x_axes, x_dims_mapping}}, false);
+  std::unordered_map<std::string, std::vector<int64_t>> axis_to_dim_map =
+      ShardingMergeForTensors({{x_axes, x_dims_mapping}},
+                              false);  // need merge
 
   // Step3: Infer Output's Dims Mapping.
   TensorDistAttr out_dist_attr = CopyTensorDistAttrForOutput(x_dist_attr_src);
-  std::vector<int64_t> out_dims_mapping =
-      GetDimsMappingForAxes(out_axes, axis_to_dim_map);
+  std::vector<std::vector<int64_t>> out_dims_mapping =
+      GetDimsMappingForAxes(out_axes, axis_to_dim_map);  // need merge
   out_dist_attr.set_dims_mapping(out_dims_mapping);
 
   // Update x's dist_attr
@@ -102,7 +104,8 @@ SpmdInfo SoftmaxInferSpmdReverse(const DistMetaTensor& x,
   int x_ndim = static_cast<int>(x_shape.size());
   int out_ndim = static_cast<int>(out_shape.size());
   auto out_dist_attr_src = out.dist_attr();
-  std::vector<int64_t> out_dims_mapping = out_dist_attr_src.dims_mapping();
+  std::vector<std::vector<int64_t>> out_dims_mapping =
+      out_dist_attr_src.multi_dims_mapping();
   PADDLE_ENFORCE_EQ(
       out_ndim,
       out_dims_mapping.size(),
@@ -123,15 +126,15 @@ SpmdInfo SoftmaxInferSpmdReverse(const DistMetaTensor& x,
 
   // sharding on softmax_axis is not supported now,
   // so set its dim mapping to -1
-  out_dims_mapping[axis] = -1;
+  out_dims_mapping[axis] = std::vector<int64_t>({});
 
   // Step2: Sharding Propagation
-  std::unordered_map<std::string, int64_t> axis_to_dim_map =
-      ShardingMergeForTensors({{out_axes, out_dims_mapping}});
+  std::unordered_map<std::string, std::vector<int64_t>> axis_to_dim_map =
+      ShardingMergeForTensors({{out_axes, out_dims_mapping}});  // need merge
 
   // infer input's dims mapping.
-  std::vector<int64_t> x_dims_mapping =
-      GetDimsMappingForAxes(x_axes, axis_to_dim_map);
+  std::vector<std::vector<int64_t>> x_dims_mapping =
+      GetDimsMappingForAxes(x_axes, axis_to_dim_map);  // need merge
   TensorDistAttr x_dist_attr = CopyTensorDistAttrForOutput(x.dist_attr());
   x_dist_attr.set_dims_mapping(x_dims_mapping);
 
@@ -156,28 +159,29 @@ SpmdInfo SoftmaxGradInferSpmd(const DistMetaTensor& out,
                               const DistMetaTensor& out_grad,
                               int axis) {
   axis = axis < 0 ? out.dims().size() + axis : axis;
+  std::vector<std::vector<int64_t>> out_grad_dims_mapping =
+      out_grad.dist_attr().multi_dims_mapping();
 
   PADDLE_ENFORCE_EQ(out_grad.dims().size(),
-                    out_grad.dist_attr().dims_mapping().size(),
+                    out_grad_dims_mapping.size(),
                     common::errors::InvalidArgument(
                         "The Tensor out_grad's rank [%d] and out_grad's "
                         "dims_mapping size [%d] are not matched.",
                         out_grad.dims().size(),
-                        out_grad.dist_attr().dims_mapping().size()));
+                        out_grad_dims_mapping.size()));
 
-  PADDLE_ENFORCE_GE(out_grad.dist_attr().dims_mapping().size(),
-                    axis,
-                    common::errors::InvalidArgument(
-                        "The Tensor out_grad's rank [%d] must be "
-                        "greater than axis [%d].",
-                        out_grad.dist_attr().dims_mapping().size(),
-                        axis));
+  PADDLE_ENFORCE_GE(
+      out_grad_dims_mapping.size(),
+      axis,
+      common::errors::InvalidArgument("The Tensor out_grad's rank [%d] must be "
+                                      "greater than axis [%d].",
+                                      out_grad_dims_mapping.size(),
+                                      axis));
 
   // To keeping consistent with forward propagation, sharding on softmax_axis
   // is not supported now, the axis should be resharded as replicated.
-  auto out_grad_dims_mapping = out_grad.dist_attr().dims_mapping();
-  if (out_grad_dims_mapping[axis] >= 0) {
-    out_grad_dims_mapping[axis] = -1;
+  if (IsSharedDim(out_grad_dims_mapping[axis])) {
+    out_grad_dims_mapping[axis] = std::vector<int64_t>({});
     VLOG(6) << "SoftmaxGradInferSpmd: The out_grad's softmax_axis is reshard "
                "to be replicated: "
             << "original dims_mapping["
@@ -185,9 +189,10 @@ SpmdInfo SoftmaxGradInferSpmd(const DistMetaTensor& out,
             << "resharded dims_mapping[" << str_join(out_grad_dims_mapping)
             << "].";
   }
-  auto out_dims_mapping = out.dist_attr().dims_mapping();
-  if (out_dims_mapping[axis] >= 0) {
-    out_dims_mapping[axis] = -1;
+  std::vector<std::vector<int64_t>> out_dims_mapping =
+      out.dist_attr().multi_dims_mapping();
+  if (IsSharedDim(out_dims_mapping[axis])) {
+    out_dims_mapping[axis] = std::vector<int64_t>({});
     VLOG(6) << "SoftmaxGradInferSpmd: The out's softmax_axis is reshard "
                "to be replicated: "
             << "original dims_mapping["
@@ -202,7 +207,7 @@ SpmdInfo SoftmaxGradInferSpmd(const DistMetaTensor& out,
 
   return ElementwiseBinaryInferSpmd(
       DistMetaTensor(out.dims(), out_dist_attr),
-      DistMetaTensor(out_grad.dims(), out_grad_dist_attr));
+      DistMetaTensor(out_grad.dims(), out_grad_dist_attr));  // need merge
 }
 
 }  // namespace phi::distributed

--- a/paddle/phi/infermeta/spmd_rules/utils.h
+++ b/paddle/phi/infermeta/spmd_rules/utils.h
@@ -32,6 +32,12 @@ inline bool IsEmpty(const std::vector<int64_t>& shape) {
   return shape.empty() || shape.at(0) == 0;
 }
 
+inline bool IsSharedDim(const std::vector<int64_t>& dims_mapping) {
+  return std::any_of(dims_mapping.begin(), dims_mapping.end(), [](int64_t i) {
+    return i >= 0;
+  });
+}
+
 // Generate the axis notation of tensor for the einsum notation of a broadcast
 // operation(alignment star from the rightmost axis). tensor_ndim: the size of
 // the tensor. broadcast_ndim: the maximum size of tensors in this broadcast

--- a/test/cpp/auto_parallel/softmax_co_shard_spmd_rule_test.cc
+++ b/test/cpp/auto_parallel/softmax_co_shard_spmd_rule_test.cc
@@ -1,0 +1,175 @@
+/* Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include "test/cpp/auto_parallel/spmd_rule_test_util.h"
+
+namespace paddle {
+namespace distributed {
+namespace auto_parallel {
+
+struct SoftmaxTestCase {
+  // input
+  std::vector<int64_t> input_shape;
+  std::vector<std::vector<int64_t>> input_dims_mapping;
+
+  // axis attribute
+  int axis;
+
+  // output
+  std::vector<std::vector<int64_t>> expected_input_dims_mapping;
+  std::vector<std::vector<int64_t>> expected_output_dims_mapping;
+};
+
+struct SoftmaxGradTestCase {
+  // input
+  std::vector<int64_t> out_shape;
+  std::vector<std::vector<int64_t>> out_dims_mapping;
+
+  std::vector<int64_t> out_grad_shape;
+  std::vector<std::vector<int64_t>> out_grad_dims_mapping;
+
+  // axis attribute
+  int axis;
+
+  // output
+  std::vector<std::vector<int64_t>> expected_out_dims_mapping;
+  std::vector<std::vector<int64_t>> expected_out_grad_dims_mapping;
+
+  std::vector<std::vector<int64_t>> expected_x_grad_dims_mapping;
+};
+
+TEST(SoftmaxInferSpmd, Ctor) {
+  std::vector<int64_t> mesh_shape = {2, 2, 2};
+  std::vector<int64_t> process_ids = {0, 1, 2, 3, 4, 5, 6, 7};
+  std::vector<std::string> dim_names = {"x", "y", "z"};
+  ProcessMesh process_mesh(mesh_shape, process_ids, dim_names);
+
+  std::vector<SoftmaxTestCase> test_cases = {
+      // shape = [32, 48, 128], axis = 0
+      // [[0,1],[2],[]] -> [[],[2],[]], [[],[2],[]]
+      {{32, 48, 128}, {{0, 1}, {2}, {}}, 0, {{}, {2}, {}}, {{}, {2}, {}}},
+      {{32, 48, 128}, {{0, 1}, {2}, {}}, -3, {{}, {2}, {}}, {{}, {2}, {}}},
+
+      // shape = [32, 48, 128], axis = 1
+      // [[0,1],[2],[]] -> [[0, 1],[],[]], [[0, 1],[],[]]
+      {{32, 48, 128},
+       {{0, 1}, {2}, {}},
+       1,
+       {{0, 1}, {}, {}},
+       {{0, 1}, {}, {}}}};
+
+  for (const auto& tc : test_cases) {
+    TensorDistAttr t_dist_attr = TensorDistAttr();
+    t_dist_attr.set_process_mesh(process_mesh);
+    t_dist_attr.set_dims_mapping(tc.input_dims_mapping);
+    t_dist_attr.set_dynamic_dims(
+        std::vector<bool>(tc.input_shape.size(), false));
+    phi::distributed::DistMetaTensor x = phi::distributed::DistMetaTensor(
+        common::make_ddim(tc.input_shape), t_dist_attr);
+
+    // test forward
+    phi::distributed::SpmdInfo forward_spmd_info =
+        phi::distributed::SoftmaxInferSpmd(x, tc.axis);
+    EXPECT_EQ(forward_spmd_info.first.size(), static_cast<size_t>(1));
+    EXPECT_EQ(forward_spmd_info.second.size(), static_cast<size_t>(1));
+    check_multi_dims_mapping(forward_spmd_info.first[0],
+                             tc.expected_input_dims_mapping);
+    check_multi_dims_mapping(forward_spmd_info.second[0],
+                             tc.expected_output_dims_mapping);
+  }
+}
+
+TEST(SoftmaxGradInferSpmd, Ctor) {
+  std::vector<int64_t> mesh_shape = {2, 2, 2};
+  std::vector<int64_t> process_ids = {0, 1, 2, 3, 4, 5, 6, 7};
+  std::vector<std::string> dim_names = {"x", "y", "z"};
+  ProcessMesh process_mesh(mesh_shape, process_ids, dim_names);
+
+  std::vector<SoftmaxGradTestCase> test_cases = {
+      // out_shape = [32, 48, 128], out_grad_shape = [32, 48, 128], axis = 0
+      // [[0,1],[2],[]], [[0,1],[2],[]] -> [[],[2],[]], [[],[2],[]], [[],[2],[]]
+      {{32, 48, 128},
+       {{0, 1}, {2}, {}},
+       {32, 48, 128},
+       {{0, 1}, {2}, {}},
+       0,
+       {{0, 1}, {}, {}},
+       {{0, 1}, {}, {}},
+       {{0, 1}, {}, {}}},
+      // axis = 0
+      // [[0,1],[2],[]], [[0],[1,2],[]] -> [[],[1,2],[]], [[],[1, 2],[]],
+      // [[],[1,2],[]]
+      {{32, 48, 128},
+       {{0, 1}, {2}, {}},
+       {32, 48, 128},
+       {{0}, {1, 2}, {}},
+       0,
+       {{}, {1, 2}, {}},
+       {{}, {1, 2}, {}},
+       {{}, {1, 2}, {}}}  // axis = 1
+      // [[0,1],[2],[]], [[2],[0,1],[]] -> [[0,1,2],[],[]], [[0, 1, 2],[],[]],
+      // [[0, 1, 2],[],[]]
+      {{32, 48, 128},
+       {{0, 1}, {2}, {}},
+       {32, 48, 128},
+       {{2}, {0, 1}, {}},
+       1,
+       {{0, 1, 2}, {}, {}},
+       {{0, 1, 2}, {}, {}},
+       {{0, 1, 2}, {}, {}}}  // axis = 1
+      // [[0,1],[],[]], [[],[],[2]] -> [[0,1],[],[2]], [[0,1],[],[2]],
+      // [[0,1],[],[2]]
+      {{32, 48, 128},
+       {{0, 1}, {}, {}},
+       {32, 48, 128},
+       {{}, {}, {2}},
+       1,
+       {{0, 1}, {}, {2}},
+       {{0, 1}, {}, {2}},
+       {{0, 1}, {}, {2}}}};
+  for (const auto& tc : test_cases) {
+    TensorDistAttr out_dist_attr = TensorDistAttr();
+    out_dist_attr.set_process_mesh(process_mesh);
+    out_dist_attr.set_dims_mapping(tc.out_dims_mapping);
+    out_dist_attr.set_dynamic_dims(
+        std::vector<bool>(tc.out_shape.size(), false));
+    phi::distributed::DistMetaTensor out = phi::distributed::DistMetaTensor(
+        common::make_ddim(tc.out_shape), out_dist_attr);
+    TensorDistAttr out_grad_attr = TensorDistAttr();
+    out_grad_attr.set_process_mesh(process_mesh);
+    out_grad_attr.set_dims_mapping(tc.out_grad_dims_mapping);
+    out_grad_attr.set_dynamic_dims(
+        std::vector<bool>(tc.out_grad_shape.size(), false));
+    phi::distributed::DistMetaTensor out_grad =
+        phi::distributed::DistMetaTensor(common::make_ddim(tc.out_grad_shape),
+                                         out_grad_attr);
+
+    // test backward
+    phi::distributed::SpmdInfo backward_spmd_info =
+        phi::distributed::SoftmaxGradInferSpmd(out, out_grad, tc.axis);
+    EXPECT_EQ(backward_spmd_info.first.size(), static_cast<size_t>(2));
+    EXPECT_EQ(backward_spmd_info.second.size(), static_cast<size_t>(1));
+    check_multi_dims_mapping(backward_spmd_info.first[0],
+                             tc.expected_out_dims_mapping);
+    check_multi_dims_mapping(backward_spmd_info.first[1],
+                             tc.expected_out_grad_dims_mapping);
+    check_multi_dims_mapping(backward_spmd_info.second[0],
+                             tc.expected_x_grad_dims_mapping);
+  }
+}
+
+}  // namespace auto_parallel
+}  // namespace distributed
+}  // namespace paddle
+// [[0,1],[2]] [[2],[]]


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
Add spmd_rule about sharding on the same tensor dim by many mesh dim for softmax

#### TODO
暂时修改了调用的接口，基础组件（ShardingMergeForTensors，GetDimsMappingForAxes）和 ElementwiseBinaryInferSpmd 我看见 https://github.com/PaddlePaddle/Paddle/pull/74253 已经写了，避免冲突，先加了注释空着