### PR TITLE
Fix einsum accuracy diff when with contraction dim

### DIFF
--- a/paddle/phi/kernels/impl/einsum_kernel_impl.h
+++ b/paddle/phi/kernels/impl/einsum_kernel_impl.h
@@ -546,10 +546,32 @@ DenseTensor PerformContraction(
       trans_t = PerformTranspose<T, Context>(
           dev_ctx, reduct_t, perm, reordered_all_labels, label2type);
       if (cache[operand_idx] != nullptr) {
-        cache[operand_idx]->ShareBufferWith(trans_t);
-        cache[operand_idx]->Resize(trans_t.dims());
-        VLOG(5) << "Set dims of cache[" << operand_idx
-                << "]: " << trans_t.dims();
+        if (common::vectorize<int64_t>(t.dims()) ==
+            broadcast_shapes[operand_idx]) {
+          cache[operand_idx]->ShareBufferWith(trans_t);
+          cache[operand_idx]->Resize(trans_t.dims());
+          VLOG(5) << "Set dims of cache[" << operand_idx
+                  << "]: " << trans_t.dims();
+        } else {
+          auto reduct_t_for_cache = PerformDiagonalAndReduction<T, Context>(
+              dev_ctx,
+              t,
+              input_strs[operand_idx],
+              perm,
+              all_labels,
+              common::vectorize<int64_t>(t.dims()),
+              label2type);
+          DenseTensor trans_t_for_cache;
+          trans_t_for_cache = PerformTranspose<T, Context>(dev_ctx,
+                                                           reduct_t_for_cache,
+                                                           perm,
+                                                           reordered_all_labels,
+                                                           label2type);
+          cache[operand_idx]->ShareBufferWith(trans_t_for_cache);
+          cache[operand_idx]->Resize(trans_t_for_cache.dims());
+          VLOG(5) << "Set dims of cache[" << operand_idx
+                  << "]: " << trans_t_for_cache.dims();
+        }
       }
     }
     auto mul_dims = GetShapeByType<int64_t>(

--- a/paddle/phi/kernels/impl/einsum_kernel_impl.h
+++ b/paddle/phi/kernels/impl/einsum_kernel_impl.h
@@ -546,21 +546,40 @@ DenseTensor PerformContraction(
       trans_t = PerformTranspose<T, Context>(
           dev_ctx, reduct_t, perm, reordered_all_labels, label2type);
       if (cache[operand_idx] != nullptr) {
-        if (common::vectorize<int64_t>(t.dims()) ==
-            broadcast_shapes[operand_idx]) {
+        std::vector<int64_t> broadcast_shapes_restore(
+            broadcast_shapes[operand_idx].size());
+
+        auto contraction_dim1 =
+            [&](const std::vector<int64_t>& broadcast_shapes,
+                const std::vector<int64_t>& original_shapes) -> bool {
+          bool found = false;
+          for (size_t i = 0; i < broadcast_shapes.size(); ++i) {
+            if (broadcast_shapes[i] != original_shapes[i] &&
+                label2type[input_strs[operand_idx][i]] ==
+                    LabelType::Contraction) {
+              broadcast_shapes_restore[i] = original_shapes[i];
+              found = true;
+            } else {
+              broadcast_shapes_restore[i] = broadcast_shapes[i];
+            }
+          }
+          return found;
+        };
+        if (!contraction_dim1(broadcast_shapes[operand_idx],
+                              common::vectorize<int64_t>(t.dims()))) {
           cache[operand_idx]->ShareBufferWith(trans_t);
           cache[operand_idx]->Resize(trans_t.dims());
           VLOG(5) << "Set dims of cache[" << operand_idx
                   << "]: " << trans_t.dims();
         } else {
-          auto reduct_t_for_cache = PerformDiagonalAndReduction<T, Context>(
-              dev_ctx,
-              t,
-              input_strs[operand_idx],
-              perm,
-              all_labels,
-              common::vectorize<int64_t>(t.dims()),
-              label2type);
+          auto reduct_t_for_cache =
+              PerformDiagonalAndReduction<T, Context>(dev_ctx,
+                                                      t,
+                                                      input_strs[operand_idx],
+                                                      perm,
+                                                      all_labels,
+                                                      broadcast_shapes_restore,
+                                                      label2type);
           DenseTensor trans_t_for_cache;
           trans_t_for_cache = PerformTranspose<T, Context>(dev_ctx,
                                                            reduct_t_for_cache,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
当前einsum op对contraction dim的处理导致了两个问题，一个是非法地址访问，另一个是精度问题。
问题描述如下：A=[b, d],B=[b,1],einsum equation=
"bd,bd->b",其中d在AB中均出现并且输出中消除因此为contraction dim，前向过程首先需要对B广播成[b,d]，再执行contraction操作，得到输出[b]。
- 对于非法地址访问，当执行完dA = B*dC时，dA=[b,1]，需要对dA进行Tile等操作。当前处理逻辑直接将A Resize为[b,d]，而没有分配新的内存空间，因此出错。
- 对于精度问题，反向过程中默认使用cache，cache保留的是前向过程中经过广播和转置等操作的A，B矩阵；而反向计算实际需要的是没有经过广播的A B矩阵。当前逻辑直接将[b,d]shape的cache B Resize成[b,1]，得到的其实是cache B的前b个元素，而不是未经广播的B=[b,1]。