### PR TITLE
[0-size Tensor No.354、355] Add 0-size Tensor support for unique

### DIFF
--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -3503,7 +3503,7 @@ def unique_consecutive(
         attr_dtype = convert_np_dtype_to_dtype_(dtype)
 
     if in_dynamic_mode():
-        if x.size == 0:
+        if math.prod(x.shape) == 0:
             if axis == []:
                 outs = [paddle.to_tensor([], dtype=x.dtype)]
             else:
@@ -3756,7 +3756,7 @@ def unique(
         axis = [axis]
     attr_dtype = convert_np_dtype_to_dtype_(dtype)
     if in_dynamic_mode():
-        if x.size == 0:
+        if math.prod(x.shape) == 0:
             outs = [x.clone()]
             if dtype == 'int32' or dtype == paddle.int32:
                 return_dtype = paddle.int32

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -3502,6 +3502,24 @@ def unique_consecutive(
     ):
         attr_dtype = convert_np_dtype_to_dtype_(dtype)
 
+    if in_dynamic_mode():
+        if x.size == 0:
+            if axis == []:
+                outs = [paddle.to_tensor([], dtype=x.dtype)]
+            else:
+                outs = [x.clone()]
+            if dtype == 'int32' or dtype == paddle.int32:
+                return_dtype = paddle.int32
+            else:
+                return_dtype = paddle.int64
+            if return_inverse:
+                outs.append(paddle.to_tensor([], dtype=return_dtype))
+            if return_counts:
+                outs.append(paddle.to_tensor([], dtype=return_dtype))
+            if len(outs) == 1:
+                return outs[0]
+            return tuple(outs)
+
     if in_dynamic_or_pir_mode():
         out, inverse, counts = _C_ops.unique_consecutive(
             x, return_inverse, return_counts, axis, attr_dtype
@@ -3738,6 +3756,22 @@ def unique(
         axis = [axis]
     attr_dtype = convert_np_dtype_to_dtype_(dtype)
     if in_dynamic_mode():
+        if x.size == 0:
+            outs = [x.clone()]
+            if dtype == 'int32' or dtype == paddle.int32:
+                return_dtype = paddle.int32
+            else:
+                return_dtype = paddle.int64
+            if return_index:
+                outs.append(paddle.to_tensor([], dtype=return_dtype))
+            if return_inverse:
+                outs.append(paddle.to_tensor([], dtype=return_dtype))
+            if return_counts:
+                outs.append(paddle.to_tensor([], dtype=return_dtype))
+            if len(outs) == 1:
+                return outs[0]
+            return tuple(outs)
+
         out, indices, inverse, counts = _C_ops.unique(
             x, return_index, return_inverse, return_counts, axis, attr_dtype
         )

--- a/test/legacy_test/test_unique.py
+++ b/test/legacy_test/test_unique.py
@@ -482,5 +482,15 @@ class TestUniqueError(unittest.TestCase):
             self.assertRaises(TypeError, test_axis)
 
 
+class TestUniqueAPI_ZeroSize(unittest.TestCase):
+    def test_dygraph_api_out(self):
+        paddle.disable_static()
+        x_data = np.random.randint(0, 10, (0, 2))
+        x = paddle.to_tensor(x_data)
+        out = paddle.unique(x)
+        expected_out = np.random.random([0, 2])
+        np.testing.assert_allclose(out.numpy(), expected_out)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/legacy_test/test_unique_consecutive_op.py
+++ b/test/legacy_test/test_unique_consecutive_op.py
@@ -347,6 +347,33 @@ class TestUniqueConsecutiveEmptyInput(OpTest):
         self.check_output(check_pir=True, check_symbol_infer=False)
 
 
+class TestUniqueConsecutive_ZeroSize(OpTest):
+    def config(self):
+        self.python_api = paddle.unique_consecutive
+
+    def init_kernel_type(self):
+        self.dtype = "float32" if core.is_compiled_with_rocm() else "float64"
+
+    def setUp(self):
+        paddle.disable_static()
+        self.init_kernel_type()
+        self.config()
+        self.op_type = "unique_consecutive"
+        x = np.random.random([2, 0]).astype(self.dtype)
+        out = np.array([]).astype(self.dtype)
+        self.inputs = {
+            'X': x,
+        }
+        self.python_out_sig = ["Out"]
+        self.attrs = {'dtype': paddle.int32}
+        self.outputs = {
+            'Out': out,
+        }
+
+    def test_check_output(self):
+        self.check_output(check_pir=True, check_symbol_infer=False)
+
+
 if __name__ == "__main__":
     paddle.enable_static()
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
infermeta中维度为-1不确定维度，修改python部分实现
<img width="756" height="387" alt="image" src="https://github.com/user-attachments/assets/0abf419b-35b9-4b04-b031-8963dddefc5c" />


PaddleAPITest 测试通过
unique 
<img width="970" height="236" alt="image" src="https://github.com/user-attachments/assets/b752b618-3b27-4b32-99f0-bdfc2f9b83cd" />

unique_consecutive 
<img width="1264" height="270" alt="image" src="https://github.com/user-attachments/assets/13f5f986-5741-40f8-9329-45c2f09e59fd" />

