### PR TITLE
Add moe_permute & unpermute with do_gather(fill_x) feature to fleety

### DIFF
--- a/paddle/phi/infermeta/multiary.cc
+++ b/paddle/phi/infermeta/multiary.cc
@@ -6201,5 +6201,91 @@ void TopPSamplingInferMeta(const MetaTensor& x,
   }
 }
 
+void MoePermuteInferMeta(const MetaTensor& X,
+                         const MetaTensor& XScale,
+                         const MetaTensor& expert_routemap_topk,
+                         const MetaTensor& expert_prob_topk,
+                         const int num_experts,
+                         const std::vector<int>& tokens_per_expert,
+                         const int padding_alignment,
+                         const bool do_gather,
+                         MetaTensor* X_unzipped,
+                         MetaTensor* zipped_expertwise_rowmap,
+                         MetaTensor* token_prob_unzipped,
+                         MetaTensor* XScale_unzipped) {
+  PADDLE_ENFORCE_EQ(
+      X.dims().size(),
+      2,
+      common::errors::InvalidArgument("Input X's dims should be 2, but got %u.",
+                                      X.dims().size()));
+  PADDLE_ENFORCE_EQ(X.dtype() == phi::DataType::BFLOAT16 ||
+                        X.dtype() == phi::DataType::FLOAT8_E4M3FN,
+                    true,
+                    common::errors::InvalidArgument(
+                        "Input X's dtype should be BFLOAT16 or FLOAT8_E4M3FN"));
+  PADDLE_ENFORCE_EQ(expert_routemap_topk.dtype() == phi::DataType::INT32,
+                    true,
+                    common::errors::InvalidArgument(
+                        "Input expert_routemap_topk's dtype should be INT32"));
+  PADDLE_ENFORCE_EQ(expert_prob_topk.dtype() == phi::DataType::FLOAT32,
+                    true,
+                    common::errors::InvalidArgument(
+                        "Input expert_prob_topk's dtype should be FLOAT32"));
+  if (XScale && do_gather) {
+    PADDLE_ENFORCE_EQ(XScale.dtype(),
+                      phi::DataType::FLOAT32,
+                      common::errors::InvalidArgument(
+                          "Input XScale's dtype should be FLOAT32"));
+    const int quanted_cols = XScale.dims()[1];
+    XScale_unzipped->set_dims({-1, quanted_cols});
+    XScale_unzipped->set_dtype(XScale.dtype());
+  } else {
+    XScale_unzipped->set_dims({0});
+    XScale_unzipped->set_dtype(phi::DataType::FLOAT32);
+  }
+  const int rows = X.dims()[0];
+  const int cols = X.dims()[1];
+
+  if (do_gather) {
+    X_unzipped->set_dims({-1, cols});
+    X_unzipped->set_dtype(X.dtype());
+  } else {
+    // Meta only, not
+    X_unzipped->set_dims({0, cols});
+    X_unzipped->set_dtype(X.dtype());
+  }
+
+  zipped_expertwise_rowmap->set_dims({rows, num_experts});
+  zipped_expertwise_rowmap->set_dtype(phi::DataType::INT32);
+  token_prob_unzipped->set_dims({-1});
+  token_prob_unzipped->set_dtype(expert_prob_topk.dtype());
+}
+
+void MoeUnpermuteInferMeta(const MetaTensor& unzipped_tokens,
+                           const MetaTensor& zipped_expertwise_rowmap,
+                           const MetaTensor& expert_routemap_topk,
+                           const MetaTensor& unzipped_token_probs,
+                           const int total_zipped_tokens_num,
+                           const int num_experts,
+                           const bool MP,
+                           MetaTensor* zipped_tokens,
+                           MetaTensor* zipped_probs_topk) {
+  PADDLE_ENFORCE_EQ(unzipped_tokens.dtype() == phi::DataType::BFLOAT16,
+                    true,
+                    common::errors::InvalidArgument(
+                        "Input unzipped_tokens's dtype should be BFLOAT16"));
+  PADDLE_ENFORCE_EQ(
+      unzipped_token_probs.dtype() == phi::DataType::FLOAT32,
+      true,
+      common::errors::InvalidArgument(
+          "Input unzipped_token_probs's dtype should be FLOAT32"));
+  const int cols = unzipped_tokens.dims()[1];
+  const int topk = expert_routemap_topk.dims()[1];
+  zipped_tokens->set_dims({total_zipped_tokens_num, cols});
+  zipped_tokens->set_dtype(unzipped_tokens.dtype());
+  zipped_probs_topk->set_dims({total_zipped_tokens_num, topk});
+  zipped_probs_topk->set_dtype(unzipped_token_probs.dtype());
+}
+
 }  // namespace phi
 PD_REGISTER_INFER_META_FN(batch_norm_infer, phi::BatchNormInferInferMeta);

--- a/paddle/phi/infermeta/multiary.h
+++ b/paddle/phi/infermeta/multiary.h
@@ -786,6 +786,28 @@ void MomentumInferMeta(const MetaTensor& param,
                        MetaTensor* param_out,
                        MetaTensor* velocity_out,
                        MetaTensor* master_param_out);
+void MoePermuteInferMeta(const MetaTensor& X,
+                         const MetaTensor& XScale,
+                         const MetaTensor& expert_routemap_topk,
+                         const MetaTensor& expert_prob_topk,
+                         const int num_experts,
+                         const std::vector<int>& tokens_per_expert,
+                         const int padding_alignment,
+                         const bool do_gather,
+                         MetaTensor* X_unzipped,
+                         MetaTensor* zipped_expertwise_rowmap,
+                         MetaTensor* token_prob_unzipped,
+                         MetaTensor* XScale_unzipped);
+
+void MoeUnpermuteInferMeta(const MetaTensor& unzipped_tokens,
+                           const MetaTensor& zipped_expertwise_rowmap,
+                           const MetaTensor& expert_routemap_topk,
+                           const MetaTensor& unzipped_token_probs,
+                           const int total_zipped_tokens_num,
+                           const int num_experts,
+                           const bool MP,
+                           MetaTensor* zipped_tokens,
+                           MetaTensor* zipped_probs_topk);
 
 void MultiDotInferMeta(const std::vector<const MetaTensor*>& x,
                        MetaTensor* out);

--- a/paddle/phi/kernels/gpu/moe_permute_kernel.cu
+++ b/paddle/phi/kernels/gpu/moe_permute_kernel.cu
@@ -1,0 +1,373 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/phi/backends/gpu/gpu_context.h"
+#include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/full_kernel.h"
+#include "paddle/phi/kernels/gpu/moe_permute_utils.h"
+#include "paddle/utils/optional.h"
+
+namespace phi {
+
+#define CUMSUM_BLOCK_SIZE 48
+#define CUMSUM_INVALID_TAG -1
+#ifndef MAX_NUM_EXPERTS
+#define MAX_NUM_EXPERTS 64
+#endif
+
+template <typename probs_T>
+struct expert_infos {
+  int expert_row_idx;
+  probs_T expert_probs;
+
+  __device__ __host__ expert_infos()
+      : expert_row_idx(-1), expert_probs(probs_T(0)) {}
+  __device__ __host__ expert_infos(int idx, probs_T prob)
+      : expert_row_idx(idx), expert_probs(prob) {}
+
+  __device__ __host__ expert_infos &operator=(const expert_infos &other) {
+    expert_row_idx = other.expert_row_idx;
+    expert_probs = other.expert_probs;
+    return *this;
+  }
+};
+
+template <typename X_T,
+          typename routemap_T,
+          typename probs_T,
+          bool has_scale,
+          bool do_gather>
+__global__ __launch_bounds__(512) void tokens_unzip_stable_kernel(
+    const X_T *__restrict__ X,
+    const routemap_T *__restrict__ routemap_topk,
+    const probs_T *__restrict__ probs_topk,
+    const float *__restrict__ XScale,
+    const int *__restrict__ expert_base_offset,
+    X_T *__restrict__ X_unzipped,
+    int *__restrict__ zipped_expertwise_rowmap,
+    probs_T *__restrict__ probs_unzipped,
+    float *__restrict__ XScale_unzipped,
+    int *global_expertwise_block_cumsum,
+    const int total_zipped_tokens_num,
+    const int token_length,
+    const int scale_length,
+    const int num_experts,
+    const int topk) {
+  using expert_infos_t = expert_infos<probs_T>;
+  int local_cumsum = 0;
+  int local_expert_offsets;
+  const int block_row_base = blockIdx.x * CUMSUM_BLOCK_SIZE;
+  int cumsum_offset = (blockIdx.x != 0) * CUMSUM_INVALID_TAG;
+  __shared__ expert_infos_t
+      shared_expert_infos[CUMSUM_BLOCK_SIZE][MAX_NUM_EXPERTS];
+
+  // ---------------Expertwise deterministic job scheduling ---------------
+  if (threadIdx.x < num_experts) {
+    local_expert_offsets = expert_base_offset[threadIdx.x];
+    expert_infos_t local_expert_infos[CUMSUM_BLOCK_SIZE];
+    for (int row = block_row_base; row < block_row_base + CUMSUM_BLOCK_SIZE;
+         row++) {
+      if (row >= total_zipped_tokens_num) break;
+      const int internal_row = row - block_row_base;
+#pragma unroll
+      for (int k = 0; k < topk; k++) {
+        expert_infos_t proposed = {routemap_topk[row * topk + k],
+                                   probs_topk[row * topk + k]};
+        if (proposed.expert_row_idx == -1) continue;
+        if (threadIdx.x == proposed.expert_row_idx) {
+          local_expert_infos[internal_row] = {
+              local_cumsum + local_expert_offsets, proposed.expert_probs};
+          local_cumsum += 1;
+        }
+      }
+    }
+    // Inter-block communication
+    const int anticipate_signal_idx = blockIdx.x * num_experts + threadIdx.x;
+    const int push_signal_idx = (blockIdx.x + 1) * num_experts + threadIdx.x;
+    if (blockIdx.x != 0) {
+      // signal receive from previous block, using light-weight atomicAdd(check)
+      // this will not change any data, only do fetch in low-cost
+      while ((cumsum_offset = atomicAdd(
+                  &global_expertwise_block_cumsum[anticipate_signal_idx], 0)) ==
+             CUMSUM_INVALID_TAG) {
+      }
+    }
+    // signal send for next block, with current cumsum
+    const int proposed_offset = cumsum_offset + local_cumsum;
+    global_expertwise_block_cumsum[push_signal_idx] = proposed_offset;
+    // Intra-block communication;
+#pragma unroll
+    for (int i = 0; i < CUMSUM_BLOCK_SIZE; i++) {
+      local_expert_infos[i].expert_row_idx =
+          (local_expert_infos[i].expert_row_idx == -1)
+              ? -1
+              : local_expert_infos[i].expert_row_idx + cumsum_offset;
+      shared_expert_infos[i][threadIdx.x] = local_expert_infos[i];
+    }
+  }
+
+  // --------------------------- Jobs schedule done -------------------------
+  __syncthreads();
+  for (int row = block_row_base; row < block_row_base + CUMSUM_BLOCK_SIZE;
+       row++) {
+    // OOB check
+    if (row >= total_zipped_tokens_num) return;
+    const int internal_row = row - block_row_base;
+#pragma unroll
+    for (int expert = 0; expert < num_experts; expert++) {
+      const expert_infos_t this_expert_token_info =
+          shared_expert_infos[internal_row][expert];
+      const int proposed_row_idx = this_expert_token_info.expert_row_idx;
+      if (threadIdx.x == 0)
+        zipped_expertwise_rowmap[row * num_experts + expert] = proposed_row_idx;
+      if (proposed_row_idx == -1) continue;  // no memcpy
+      if (threadIdx.x == 0)
+        probs_unzipped[proposed_row_idx] = this_expert_token_info.expert_probs;
+      if constexpr (do_gather) {
+        // vec copy
+        if constexpr (has_scale) {
+          vectorized_memcpy(&XScale[(int64_t)row * (int64_t)scale_length],
+                            &XScale_unzipped[(int64_t)proposed_row_idx *
+                                             (int64_t)scale_length],
+                            scale_length);
+        }
+        vectorized_memcpy(
+            &X[(int64_t)row * (int64_t)token_length],
+            &X_unzipped[(int64_t)proposed_row_idx * (int64_t)token_length],
+            token_length);
+      }
+    }
+  }
+}
+template <typename T, typename Context>
+void dispatch_tokens_unzip_stable(const Context &dev_ctx,
+                                  const DenseTensor &X,
+                                  const DenseTensor &expert_routemap_topk,
+                                  const DenseTensor &expert_prob_topk,
+                                  const paddle::optional<DenseTensor> &XScale,
+                                  const DenseTensor &expert_offsets,
+                                  DenseTensor *X_unzipped,
+                                  DenseTensor *zipped_expertwise_rowmap,
+                                  DenseTensor *token_prob_unzipped,
+                                  DenseTensor *XScale_unzipped,
+                                  DenseTensor *global_expertwise_block_cumsum,
+                                  const int total_zipped_tokens_num,
+                                  const int token_length,
+                                  const int topk,  // deprecated
+                                  const int num_experts,
+                                  const int scale_length,
+                                  const bool do_gather) {
+  dim3 grid, block;
+  grid.x =
+      (total_zipped_tokens_num + CUMSUM_BLOCK_SIZE - 1) / CUMSUM_BLOCK_SIZE;
+  block.x = 512;
+
+#define DTYPE_CASE(dtype, type) dtype == phi::DataType::type
+#define GET_DATA(tensor, type) tensor.data<type>()
+#define GET_PTR_DATA(tensor, type) tensor->data<type>()
+#define DISPATCH_CASE(TOKEN_T, PROB_T, INT_T, HAS_SCALE, DO_GATHER) \
+  auto kernel = tokens_unzip_stable_kernel<TOKEN_T,                 \
+                                           INT_T,                   \
+                                           PROB_T,                  \
+                                           HAS_SCALE,               \
+                                           DO_GATHER>;              \
+  kernel<<<grid, block, 0, dev_ctx.stream()>>>(                     \
+      GET_DATA(X, TOKEN_T),                                         \
+      GET_DATA(expert_routemap_topk, INT_T),                        \
+      GET_DATA(expert_prob_topk, PROB_T),                           \
+      XScale ? XScale.get_ptr()->data<float>() : nullptr,           \
+      GET_DATA(expert_offsets, int),                                \
+      GET_PTR_DATA(X_unzipped, TOKEN_T),                            \
+      GET_PTR_DATA(zipped_expertwise_rowmap, INT_T),                \
+      GET_PTR_DATA(token_prob_unzipped, PROB_T),                    \
+      XScale_unzipped->data<float>(),                               \
+      global_expertwise_block_cumsum->data<int>(),                  \
+      total_zipped_tokens_num,                                      \
+      token_length,                                                 \
+      scale_length,                                                 \
+      num_experts,                                                  \
+      topk);
+
+#define HANDLE_GATHER_CASE(TOKEN_T, PROB_T, INT_T, HAS_SCALE) \
+  if (do_gather) {                                            \
+    DISPATCH_CASE(TOKEN_T, PROB_T, INT_T, HAS_SCALE, true)    \
+  } else {                                                    \
+    DISPATCH_CASE(TOKEN_T, PROB_T, INT_T, HAS_SCALE, false)   \
+  }
+
+#define HANDLE_TOKEN_TYPE(PROB_T, INT_T)                        \
+  if (DTYPE_CASE(X.dtype(), BFLOAT16)) {                        \
+    HANDLE_GATHER_CASE(phi::bfloat16, PROB_T, INT_T, false)     \
+  } else if (DTYPE_CASE(X.dtype(), FLOAT8_E4M3FN)) {            \
+    HANDLE_GATHER_CASE(phi::float8_e4m3fn, PROB_T, INT_T, true) \
+  }
+
+#define HANDLE_PROB_TYPE(INT_T)                               \
+  if (DTYPE_CASE(expert_prob_topk.dtype(), BFLOAT16)) {       \
+    HANDLE_TOKEN_TYPE(phi::bfloat16, INT_T)                   \
+  } else if (DTYPE_CASE(expert_prob_topk.dtype(), FLOAT32)) { \
+    HANDLE_TOKEN_TYPE(float, INT_T)                           \
+  }
+
+  if (DTYPE_CASE(zipped_expertwise_rowmap->dtype(), INT32)) {
+    HANDLE_PROB_TYPE(int)
+  }
+
+#undef DTYPE_CASE
+#undef GET_DATA
+#undef DISPATCH_CASE
+#undef HANDLE_EXPERT_CASE
+#undef HANDLE_TOKEN_TYPE
+#undef HANDLE_PROB_TYPE
+}
+
+template <typename T, typename Context>
+void MoePermuteKernel(const Context &dev_ctx,
+                      const DenseTensor &X,
+                      const paddle::optional<DenseTensor> &XScale,
+                      const DenseTensor &expert_routemap_topk,
+                      const DenseTensor &expert_prob_topk,
+                      const int num_experts,
+                      const std::vector<int> &tokens_per_expert,
+                      const int padding_multiplex,
+                      const bool do_gather,
+                      DenseTensor *X_unzipped,
+                      DenseTensor *zipped_expertwise_rowmap,
+                      DenseTensor *token_prob_unzipped,
+                      DenseTensor *XScale_unzipped) {
+  const int rows = X.dims()[0];
+  const int cols = X.dims()[1];
+  PADDLE_ENFORCE_LE(
+      num_experts,
+      MAX_NUM_EXPERTS,
+      common::errors::InvalidArgument(
+          "Currently we support no more than (%ld), received num_expert: "
+          "(%ld). Please check input "
+          "value.",
+          MAX_NUM_EXPERTS,
+          num_experts));
+
+  const int quanted_cols = (XScale) ? XScale.get_ptr()->dims()[1] : 0;
+  int expert_offset[MAX_NUM_EXPERTS];
+  int tokens_cumulated = 0;
+  for (int i = 0; i < MAX_NUM_EXPERTS; i++) {
+    if (i < num_experts) {
+      expert_offset[i] = tokens_cumulated;
+      tokens_cumulated +=
+          ((tokens_per_expert[i] + padding_multiplex - 1) / padding_multiplex) *
+          padding_multiplex;
+    } else {
+      expert_offset[i] = 0;
+    }
+  }
+  DenseTensor expert_offset_tensor;
+  expert_offset_tensor.Resize({MAX_NUM_EXPERTS});
+  dev_ctx.template Alloc<int>(&expert_offset_tensor);
+  cudaMemcpyAsync(expert_offset_tensor.data<int>(),
+                  expert_offset,
+                  sizeof(int) * MAX_NUM_EXPERTS,
+                  cudaMemcpyHostToDevice,
+                  dev_ctx.stream());
+  const int output_rows = tokens_cumulated;
+  const int topk_calculated = expert_routemap_topk.dims()[1];
+  X_unzipped->Resize({output_rows, cols});
+  token_prob_unzipped->Resize({output_rows});
+  if (XScale) {
+    const int quanted_cols = XScale.get_ptr()->dims()[1];
+    XScale_unzipped->Resize({output_rows, quanted_cols});
+  }
+  dev_ctx.template Alloc<float>(XScale_unzipped);
+  dev_ctx.template Alloc<int>(zipped_expertwise_rowmap);
+  dev_ctx.template Alloc<T>(X_unzipped);
+  dev_ctx.template Alloc<float>(token_prob_unzipped);
+  auto X_unzipped_ptr = reinterpret_cast<void *>(X_unzipped->data<T>());
+
+  for (int i = 0; i < num_experts; i++) {
+    int next_expert_offset =
+        i < num_experts - 1 ? expert_offset[i + 1] : output_rows;
+    int invalid_rows =
+        next_expert_offset - expert_offset[i] - tokens_per_expert[i];
+    int cur_expert_end = expert_offset[i] + tokens_per_expert[i];
+    cudaMemsetAsync(X_unzipped_ptr + cur_expert_end * cols * sizeof(T),
+                    0,
+                    sizeof(T) * invalid_rows * cols,
+                    dev_ctx.stream());
+  }
+  if (XScale) {
+    auto XScale_unzipped_ptr =
+        reinterpret_cast<void *>(XScale_unzipped->data<float>());
+    for (int i = 0; i < num_experts; i++) {
+      int next_expert_offset =
+          i < num_experts - 1 ? expert_offset[i + 1] : output_rows;
+      int invalid_rows =
+          next_expert_offset - expert_offset[i] - tokens_per_expert[i];
+      int cur_expert_end = expert_offset[i] + tokens_per_expert[i];
+      cudaMemsetAsync(
+          XScale_unzipped_ptr + cur_expert_end * quanted_cols * sizeof(float),
+          0,
+          sizeof(float) * invalid_rows * quanted_cols,
+          dev_ctx.stream());
+    }
+  }
+
+  auto token_prob_unzipped_ptr =
+      reinterpret_cast<void *>(token_prob_unzipped->data<float>());
+
+  for (int i = 0; i < num_experts; i++) {
+    int next_expert_offset =
+        i < num_experts - 1 ? expert_offset[i + 1] : output_rows;
+    int invalid_rows =
+        next_expert_offset - expert_offset[i] - tokens_per_expert[i];
+    int cur_expert_end = expert_offset[i] + tokens_per_expert[i];
+    cudaMemsetAsync(token_prob_unzipped_ptr + cur_expert_end * sizeof(float),
+                    0,
+                    sizeof(float) * invalid_rows,
+                    dev_ctx.stream());
+  }
+  if (X.numel() == 0) return;
+  const int cumsum_blocknum =
+      (rows + CUMSUM_BLOCK_SIZE - 1) / CUMSUM_BLOCK_SIZE;
+  DenseTensor global_expertwise_block_cumsum =
+      phi::Full<int, Context>(dev_ctx,
+                              phi::IntArray({cumsum_blocknum + 1, num_experts}),
+                              CUMSUM_INVALID_TAG);
+  dispatch_tokens_unzip_stable<T, Context>(dev_ctx,
+                                           X,
+                                           expert_routemap_topk,
+                                           expert_prob_topk,
+                                           XScale,
+                                           expert_offset_tensor,
+                                           X_unzipped,
+                                           zipped_expertwise_rowmap,
+                                           token_prob_unzipped,
+                                           XScale_unzipped,
+                                           &global_expertwise_block_cumsum,
+                                           rows,
+                                           cols,
+                                           topk_calculated,
+                                           num_experts,
+                                           quanted_cols,
+                                           do_gather);
+}
+#undef CUMSUM_BLOCK_SIZE
+#undef CUMSUM_INVALID_TAG
+#undef MAX_NUM_EXPERTS
+}  // namespace phi
+
+PD_REGISTER_KERNEL(moe_permute,
+                   GPU,
+                   ALL_LAYOUT,
+                   phi::MoePermuteKernel,
+                   phi::dtype::float8_e4m3fn,
+                   phi::dtype::bfloat16) {}

--- a/paddle/phi/kernels/gpu/moe_permute_utils.h
+++ b/paddle/phi/kernels/gpu/moe_permute_utils.h
@@ -1,0 +1,104 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include <cuda.h>
+#include <cuda_bf16.h>
+#include <cuda_fp8.h>
+#include <cuda_runtime.h>
+
+#include <iostream>
+#include <limits>
+
+#include "paddle/phi/kernels/funcs/math_cuda_utils.h"
+
+namespace phi {
+
+template <paddle::DataType DType>
+struct TypeMap;
+template <>
+struct TypeMap<paddle::DataType::BFLOAT16> {
+  using type = phi::bfloat16;
+};
+template <>
+struct TypeMap<paddle::DataType::FLOAT16> {
+  using type = phi::float16;
+};
+template <>
+struct TypeMap<paddle::DataType::FLOAT32> {
+  using type = float;
+};
+template <>
+struct TypeMap<paddle::DataType::INT32> {
+  using type = int;
+};
+template <>
+struct TypeMap<paddle::DataType::INT64> {
+  using type = int64_t;
+};
+
+template <typename T, int N>
+struct alignas(16) VectorType {
+  T data[N];
+};
+
+template <>
+struct alignas(16) VectorType<float, 4> {
+  float4 data;  // Built-in CUDA vector type
+};
+
+template <>
+struct alignas(16) VectorType<__nv_bfloat16, 8> {
+  __nv_bfloat16 data[8];
+};
+
+template <>
+struct alignas(16) VectorType<__nv_fp8_e4m3, 16> {
+  __nv_fp8_e4m3 data[16];
+};
+
+template <>
+struct alignas(16) VectorType<uint8_t, 16> {
+  uint8_t data[16];
+};
+
+// Helper function to perform vectorized memory copy
+template <typename T>
+__device__ __forceinline__ void vectorized_memcpy(const T* src,
+                                                  T* dst,
+                                                  int num_elements) {
+  constexpr int vector_size_in_bytes = 16;
+  const int elements_per_vector = vector_size_in_bytes / sizeof(T);
+
+  int num_vectors = num_elements / elements_per_vector;
+  int remaining_elements = num_elements % elements_per_vector;
+
+  using VecType = VectorType<T, elements_per_vector>;
+  const VecType* src_vec = reinterpret_cast<const VecType*>(src);
+  VecType* dst_vec = reinterpret_cast<VecType*>(dst);
+
+#pragma unroll
+  for (int idx = threadIdx.x; idx < num_vectors; idx += blockDim.x) {
+    dst_vec[idx] = src_vec[idx];
+  }
+
+  if (remaining_elements > 0) {
+    int offset = num_vectors * elements_per_vector;
+    for (int i = threadIdx.x; i < remaining_elements; i += blockDim.x) {
+      dst[offset + i] = src[offset + i];
+    }
+  }
+}
+
+}  // namespace phi

--- a/paddle/phi/kernels/gpu/moe_unpermute_kernel.cu
+++ b/paddle/phi/kernels/gpu/moe_unpermute_kernel.cu
@@ -1,0 +1,270 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/phi/backends/gpu/gpu_context.h"
+#include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/full_kernel.h"
+#include "paddle/phi/kernels/gpu/moe_permute_utils.h"
+
+namespace phi {
+struct __custom_bfloat164 {
+  __nv_bfloat16 x;
+  __nv_bfloat16 y;
+  __nv_bfloat16 z;
+  __nv_bfloat16 w;
+};
+__device__ __nv_bfloat16 __custom_hadd(__nv_bfloat16 x, __nv_bfloat16 y) {
+  return static_cast<__nv_bfloat16>(static_cast<float>(x) +
+                                    static_cast<float>(y));
+}
+#ifndef MAX_NUM_EXPERTS
+#define MAX_NUM_EXPERTS 64
+#endif
+template <bool MP>
+__global__ __launch_bounds__(256) void tokens_zip_kernel(
+    const phi::bfloat16 *__restrict__ unzipped_tokens_in,
+    const int *__restrict__ zipped_expertwise_rowmap,
+    const int *__restrict__ expert_routemap_topk,
+    const float *__restrict__ unzipped_token_probs,
+    phi::bfloat16 *__restrict__ zipped_tokens_out,
+    float *__restrict__ zipped_probs_topk,
+    const int total_zipped_tokens_num,
+    const int token_length,
+    const int num_experts,
+    const int topk) {
+  const int this_row = blockIdx.x;
+  if (this_row >= total_zipped_tokens_num) return;
+
+  const __nv_bfloat16 *unzipped_tokens =
+      reinterpret_cast<const __nv_bfloat16 *>(unzipped_tokens_in);
+  __nv_bfloat16 *zipped_tokens =
+      reinterpret_cast<__nv_bfloat16 *>(zipped_tokens_out);
+
+  int local_row_fetchlist[MAX_NUM_EXPERTS];
+
+#pragma unroll
+  for (int expert = 0; expert < num_experts; ++expert) {
+    const int fetch_row =
+        zipped_expertwise_rowmap[this_row * num_experts + expert];
+    local_row_fetchlist[expert] = fetch_row;
+  }
+
+#pragma unroll
+  for (int k = 0; k < topk; ++k) {
+    const int expert_idx = expert_routemap_topk[this_row * topk + k];
+    if (expert_idx < 0) [[likely]]
+      continue;
+    const int expert_fetch_row = local_row_fetchlist[expert_idx];
+    zipped_probs_topk[this_row * topk + k] =
+        unzipped_token_probs[expert_fetch_row];
+  }
+
+  constexpr int vecSize = 4;
+  const int num_full_vec = token_length / vecSize;
+  const int remaining_elems = token_length % vecSize;
+  const int thread_stride = blockDim.x * vecSize;
+
+  if constexpr (MP) {
+    for (int x_offset = threadIdx.x * vecSize;
+         x_offset < num_full_vec * vecSize;
+         x_offset += thread_stride) {
+      float4 sum = {0.0f, 0.0f, 0.0f, 0.0f};
+      __custom_bfloat164 raw = {0.0f, 0.0f, 0.0f, 0.0f};
+      int aggreg_cnt = 0;
+      __custom_bfloat164 *out_ptr = reinterpret_cast<__custom_bfloat164 *>(
+          &zipped_tokens[(int64_t)this_row * (int64_t)token_length + x_offset]);
+#pragma unroll
+      for (int expert = 0; expert < num_experts; ++expert) {
+        const int fetch_row = local_row_fetchlist[expert];
+        if (fetch_row < 0) continue;
+        aggreg_cnt++;
+        raw = *reinterpret_cast<const __custom_bfloat164 *>(
+            &unzipped_tokens[(int64_t)fetch_row * (int64_t)token_length +
+                             x_offset]);
+        float4 token_vec = {0.0f, 0.0f, 0.0f, 0.0f};
+        token_vec.x = static_cast<float>(raw.x);
+        token_vec.y = static_cast<float>(raw.y);
+        token_vec.z = static_cast<float>(raw.z);
+        token_vec.w = static_cast<float>(raw.w);
+        sum.x = __fadd_rn(token_vec.x, sum.x);
+        sum.y = __fadd_rn(token_vec.y, sum.y);
+        sum.z = __fadd_rn(token_vec.z, sum.z);
+        sum.w = __fadd_rn(token_vec.w, sum.w);
+      }
+      if (aggreg_cnt > 1) {
+        (*out_ptr).x = static_cast<__nv_bfloat16>(sum.x);
+        (*out_ptr).y = static_cast<__nv_bfloat16>(sum.y);
+        (*out_ptr).z = static_cast<__nv_bfloat16>(sum.z);
+        (*out_ptr).w = static_cast<__nv_bfloat16>(sum.w);
+      } else {
+        *out_ptr = raw;
+      }
+    }
+
+    for (int i = num_full_vec * vecSize + threadIdx.x; i < token_length;
+         i += blockDim.x) {
+      float sum = 0.0f;
+      __nv_bfloat16 raw = 0.0f;
+      int aggreg_cnt = 0;
+#pragma unroll
+      for (int expert = 0; expert < num_experts; ++expert) {
+        int fetch_row = local_row_fetchlist[expert];
+        if (fetch_row < 0) continue;
+        aggreg_cnt++;
+        raw = unzipped_tokens[(int64_t)fetch_row * (int64_t)token_length + i];
+        float token_val = static_cast<float>(raw);
+        sum = __fadd_rn(token_val, sum);
+      }
+      zipped_tokens[(int64_t)this_row * (int64_t)token_length + i] =
+          (aggreg_cnt > 1) ? static_cast<__nv_bfloat16>(sum) : raw;
+    }
+  } else {
+    for (int x_offset = threadIdx.x * vecSize;
+         x_offset < num_full_vec * vecSize;
+         x_offset += thread_stride) {
+      __custom_bfloat164 sum = {0.0f, 0.0f, 0.0f, 0.0f};
+      __custom_bfloat164 *out_ptr = reinterpret_cast<__custom_bfloat164 *>(
+          &zipped_tokens[(int64_t)this_row * (int64_t)token_length + x_offset]);
+#pragma unroll
+      for (int expert = 0; expert < num_experts; ++expert) {
+        const int fetch_row = local_row_fetchlist[expert];
+        if (fetch_row < 0) continue;
+        __custom_bfloat164 token_vec =
+            *reinterpret_cast<const __custom_bfloat164 *>(
+                &unzipped_tokens[(int64_t)fetch_row * (int64_t)token_length +
+                                 x_offset]);
+        sum.x = __custom_hadd(sum.x, token_vec.x);
+        sum.y = __custom_hadd(sum.y, token_vec.y);
+        sum.z = __custom_hadd(sum.z, token_vec.z);
+        sum.w = __custom_hadd(sum.w, token_vec.w);
+      }
+      *out_ptr = sum;
+    }
+
+    for (int i = num_full_vec * vecSize + threadIdx.x; i < token_length;
+         i += blockDim.x) {
+      __nv_bfloat16 sum = (__nv_bfloat16)0.0f;
+#pragma unroll
+      for (int expert = 0; expert < num_experts; ++expert) {
+        int fetch_row = local_row_fetchlist[expert];
+        if (fetch_row < 0) continue;
+        __nv_bfloat16 token_val =
+            unzipped_tokens[(int64_t)fetch_row * (int64_t)token_length + i];
+        sum = __custom_hadd(sum, token_val);
+      }
+      zipped_tokens[(int64_t)this_row * (int64_t)token_length + i] = sum;
+    }
+  }
+}
+
+template <typename T, typename Context>
+void dispatch_tokens_zip(const Context &dev_ctx,
+                         const DenseTensor &unzipped_tokens,
+                         const DenseTensor &zipped_expertwise_rowmap,
+                         const DenseTensor &expert_routemap_topk,
+                         const DenseTensor &unzipped_token_probs,
+                         DenseTensor *zipped_tokens,
+                         DenseTensor *zipped_probs_topk,
+                         const int total_zipped_tokens_num,
+                         const int num_experts,
+                         const int token_length,
+                         const int topk,
+                         const bool MP) {
+  dim3 grid, block;
+  grid.x = total_zipped_tokens_num;
+  block.x = 256;
+
+  // Map data types to C++ types
+  if (unzipped_token_probs.dtype() == paddle::DataType::FLOAT32) {
+    if (MP == true) {
+      tokens_zip_kernel<true><<<grid, block, 0, dev_ctx.stream()>>>(
+          unzipped_tokens.data<phi::bfloat16>(),
+          zipped_expertwise_rowmap.data<int>(),
+          expert_routemap_topk.data<int>(),
+          unzipped_token_probs.data<float>(),
+          zipped_tokens->data<phi::bfloat16>(),
+          zipped_probs_topk->data<float>(),
+          total_zipped_tokens_num,
+          token_length,
+          num_experts,
+          topk);
+    } else {
+      tokens_zip_kernel<false><<<grid, block, 0, dev_ctx.stream()>>>(
+          unzipped_tokens.data<phi::bfloat16>(),
+          zipped_expertwise_rowmap.data<int>(),
+          expert_routemap_topk.data<int>(),
+          unzipped_token_probs.data<float>(),
+          zipped_tokens->data<phi::bfloat16>(),
+          zipped_probs_topk->data<float>(),
+          total_zipped_tokens_num,
+          token_length,
+          num_experts,
+          topk);
+    }
+  }
+}
+
+template <typename T, typename Context>
+void MoeUnpermuteKernel(const Context &dev_ctx,
+                        const DenseTensor &unzipped_tokens,
+                        const DenseTensor &zipped_expertwise_rowmap,
+                        const DenseTensor &expert_routemap_topk,
+                        const DenseTensor &unzipped_token_probs,
+                        const int total_zipped_tokens_num,
+                        const int num_experts,
+                        const bool MP,
+                        DenseTensor *zipped_tokens,
+                        DenseTensor *zipped_probs_topk) {
+  const int rows = unzipped_tokens.dims()[0];
+  const int cols = unzipped_tokens.dims()[1];
+  PADDLE_ENFORCE_LE(
+      num_experts,
+      MAX_NUM_EXPERTS,
+      common::errors::InvalidArgument(
+          "Currently we support no more than (%ld), received num_expert: "
+          "(%ld). Please check input "
+          "value.",
+          MAX_NUM_EXPERTS,
+          num_experts));
+  const int topk = expert_routemap_topk.dims()[1];
+  dev_ctx.template Alloc<T>(zipped_tokens);
+  dev_ctx.template Alloc<float>(zipped_probs_topk);
+  if (unzipped_tokens.numel() == 0) return;  // 0-size tensor
+  void *zipped_probs_topk_ptr =
+      reinterpret_cast<void *>(zipped_probs_topk->data<float>());
+  cudaMemsetAsync(zipped_probs_topk_ptr,
+                  0,
+                  sizeof(float) * total_zipped_tokens_num * topk,
+                  dev_ctx.stream());
+
+  dispatch_tokens_zip<T, Context>(dev_ctx,
+                                  unzipped_tokens,
+                                  zipped_expertwise_rowmap,
+                                  expert_routemap_topk,
+                                  unzipped_token_probs,
+                                  zipped_tokens,
+                                  zipped_probs_topk,
+                                  total_zipped_tokens_num,
+                                  num_experts,
+                                  cols,
+                                  topk,
+                                  MP);
+}
+}  // namespace phi
+
+PD_REGISTER_KERNEL(moe_unpermute,
+                   GPU,
+                   ALL_LAYOUT,
+                   phi::MoeUnpermuteKernel,
+                   phi::dtype::bfloat16) {}

--- a/paddle/phi/ops/yaml/ops.yaml
+++ b/paddle/phi/ops/yaml/ops.yaml
@@ -3528,6 +3528,25 @@
   backward : mode_grad
   interfaces : paddle::dialect::InferSymbolicShapeInterface, paddle::dialect::LayoutTransformationInterface
 
+- op : moe_permute
+  args : (Tensor hidden_states, Tensor scale, Tensor expert_routemap_topk, Tensor expert_prob_topk, int num_experts, int[] tokens_per_expert, int padding_alignment, bool do_gather)
+  output : Tensor(hidden_states_unzipped), Tensor(zipped_expertwise_rowmap), Tensor(token_prob_unzipped), Tensor(scale_unzipped)
+  infer_meta:
+    func : MoePermuteInferMeta
+  kernel :
+    func : moe_permute
+    data_type : hidden_states
+  optional : scale
+
+- op : moe_unpermute
+  args : (Tensor hidden_states_unzipped, Tensor zipped_expertwise_rowmap, Tensor expert_routemap_topk, Tensor token_prob_unzipped, int total_zipped_tokens_num, int num_experts, bool use_mix_precision)
+  output : Tensor(hidden_states), Tensor(expert_prob_topk)
+  infer_meta :
+    func : MoeUnpermuteInferMeta
+  kernel :
+    func : moe_unpermute
+    data_type : hidden_states_unzipped
+
 - op : momentum_
   args : (Tensor param, Tensor grad, Tensor velocity, Tensor learning_rate, Tensor master_param, float mu, bool use_nesterov = false, str regularization_method = "", float regularization_coeff = 0.0f, bool multi_precision = false, float rescale_grad = 1.0f)
   output : Tensor(param_out), Tensor(velocity_out), Tensor(master_param_out)

--- a/python/paddle/nn/functional/__init__.py
+++ b/python/paddle/nn/functional/__init__.py
@@ -129,6 +129,8 @@ from .loss import (
     triplet_margin_loss,
     triplet_margin_with_distance_loss,
 )
+from .moe_permute import moe_permute
+from .moe_unpermute import moe_unpermute
 from .norm import (
     batch_norm,
     group_norm,
@@ -236,6 +238,8 @@ __all__ = [
     'max_unpool1d',
     'max_unpool2d',
     'max_unpool3d',
+    'moe_permute',
+    'moe_unpermute',
     'adaptive_avg_pool1d',
     'adaptive_avg_pool2d',
     'adaptive_avg_pool3d',

--- a/python/paddle/nn/functional/moe_permute.py
+++ b/python/paddle/nn/functional/moe_permute.py
@@ -1,0 +1,145 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from paddle import _C_ops
+from paddle.base.framework import in_dynamic_or_pir_mode
+
+if TYPE_CHECKING:
+    from paddle import Tensor
+
+
+def moe_permute(
+    hidden_states: Tensor,
+    scale: Tensor | None,
+    expert_routemap_topk: Tensor,
+    expert_prob_topk: Tensor,
+    num_experts: int,
+    tokens_per_expert: list,
+    padding_alignment: int,
+    do_gather: bool = True,
+    name: str | None = None,
+) -> tuple[Tensor, Tensor, Tensor, Tensor]:
+    r"""
+    Permute tokens for Mixture of Experts (MoE) computation in distributed training scenarios.
+
+    Note:
+        This function reorganizes input tokens based on expert assignments to prepare for expert computation.
+        It handles both bfloat16 and float8_e4m3fn data types with proper scaling for float8 inputs.
+
+        1. This function is typically used in pair of moe_unpermute to provide complete MoE functionality.
+        2. For float8 inputs, proper scaling must be provided via the scale parameter.
+        3. The padding_alignment parameter affects memory efficiency but not correctness.
+        4. Any output tokens can find an exact-match in the original input tokens.
+        5. This permute function has overcomed the aadiff issue, is deterministic.
+
+    Args:
+        hidden_states (Tensor): The input tensor containing tokens to be permuted, stored in row-major layout.
+            Supported data types: bfloat16 or float8_e4m3fn.
+            Shape: [sequence_length, token_dimension]
+        scale (Tensor|None): Scaling factors required when hidden_states is of float8 type.
+            For float8 inputs, this tensor provides the scaling factors for dequantization.
+            Shape: [sequence_length, ceil(token_dimension / 128)]
+            Data type: float32
+        expert_routemap_topk (Tensor): Tensor indicating expert assignments for each token (top-k experts).
+            Each value represents the expert index the token is assigned to (-1 indicates not assigned).
+            Shape: [sequence_length, top_k_experts]
+            Data type: int32
+            Value range: [-1, num_experts)
+        expert_prob_topk (Tensor): Tensor containing routing probabilities for top-k experts.
+            Shape: [sequence_length, top_k_experts]
+            Data type: float32
+        num_experts (int): Total number of experts in the MoE layer, limited between 1 and 64.
+        tokens_per_expert (list[int]): List where each element indicates the number of tokens
+            assigned to the corresponding expert.
+        padding_alignment (int): Tokens alignment requirement for expert buffers (in bytes).
+            Must be a power of 2. Typical values are 16, 32 or 64 for optimal memory access.
+        do_gather(bool): Decide whether do actual tokens gather operation or not, default is True.
+        name (str|None, optional): Name prefix for the operation (optional).
+            Default: None
+
+    Returns:
+        tuple[Tensor, Tensor, Tensor, Tensor]:
+            - hidden_states_unzipped (Tensor): The permuted and broadcasted input tensor.
+                Shape: [total_tokens_after_broadcast, token_dimension]
+                Data type: same as input hidden_states
+            - zipped_expertwise_rowmap (Tensor): Mapping tensor used to restore original order (unpermute).
+                Shape: [sequence_length, num_experts]
+                Data type: int32
+            - token_prob_unzipped (Tensor): Flattened expert probabilities aligned with permuted tokens.
+                Shape: [total_tokens_after_broadcast, 1]
+                Data type: float32
+            - scale_unzipped (Tensor): Broadcasted scale tensor (only valid for float8 inputs).
+                Shape: [total_tokens_after_broadcast, ceil(token_dimension / 128)]
+                Data type: float32
+
+    Examples:
+        .. code-block:: python
+
+            >>> # doctest: +REQUIRES(env:GPU)
+            >>> # doctest: +SKIP('This is only support in cuda 12.0+')
+            >>> import paddle
+            >>> import numpy as np
+            >>> import paddle.nn.functional as F
+            >>> hidden_states = paddle.randn([3, 128], dtype='bfloat16')
+            >>> expert_routemap_topk = paddle.to_tensor([[-1, 0, -1, -1, 2, -1, -1, -1],
+            ...                                          [1, -1, -1, -1, -1, -1, -1, -1],
+            ...                                          [-1, -1, -1, -1, -1, -1, 1, -1]],
+            ...                                           dtype='int32')
+            >>> expert_prob_topk= paddle.to_tensor([[0.0, 0.6, 0.0, 0.0, 0.4, 0.0, 0.0, 0.0],
+            ...                                     [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            ...                                     [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0]],
+            ...                                          dtype='float32')
+            >>> num_experts = 3
+            >>> tokens_per_expert = [1, 2, 1]
+            >>> padding_alignment = 2
+            >>> hidden_states_unzipped, zipped_expertwise_rowmap, token_prob_unzipped, scale_unzipped = F.moe_permute(
+            ...     hidden_states,
+            ...     None,
+            ...     expert_routemap_topk,
+            ...     expert_prob_topk,
+            ...     num_experts,
+            ...     tokens_per_expert,
+            ...     padding_alignment,
+            ... )
+            >>> # weighted by probs.
+            >>> hidden_states_unzipped = (hidden_states_unzipped.astype("float32") * token_prob_unzipped.astype("float32").unsqueeze(-1)).astype("bfloat16")
+            >>> zipped_tokens, zipped_probs = F.moe_unpermute(hidden_states_unzipped, zipped_expertwise_rowmap, expert_routemap_topk, token_prob_unzipped,3,3)
+            >>> np.testing.assert_allclose(zipped_tokens.numpy(), hidden_states.numpy(), rtol=1e-05, atol=1e-06)
+    """
+    if in_dynamic_or_pir_mode():
+        (
+            hidden_states_unzipped,
+            zipped_expertwise_rowmap,
+            token_prob_unzipped,
+            scale_unzipped,
+        ) = _C_ops.moe_permute(
+            hidden_states,
+            scale,
+            expert_routemap_topk,
+            expert_prob_topk,
+            num_experts,
+            tokens_per_expert,
+            padding_alignment,
+            do_gather,
+        )
+        return (
+            hidden_states_unzipped,
+            zipped_expertwise_rowmap,
+            token_prob_unzipped,
+            scale_unzipped,
+        )

--- a/python/paddle/nn/functional/moe_unpermute.py
+++ b/python/paddle/nn/functional/moe_unpermute.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from paddle import _C_ops
+from paddle.base.framework import in_dynamic_or_pir_mode
+
+if TYPE_CHECKING:
+    from paddle import Tensor
+
+
+def moe_unpermute(
+    hidden_states_unzipped: Tensor,
+    zipped_expertwise_rowmap: Tensor,
+    expert_routemap_topk: Tensor,
+    token_prob_unzipped: Tensor,
+    total_zipped_tokens: int,
+    num_experts: int,
+    use_mix_precision: bool = True,
+    name: str | None = None,
+) -> tuple[Tensor, Tensor]:
+    r"""
+    Args:
+        hidden_states_unzipped (Tensor): The input Tensor containing broadcasted and permuted hidden states.
+            Shape: (seqlen_broadcasted, token_len). Dtype: bfloat16.
+        zipped_expertwise_rowmap (Tensor): The input Tensor recording the mapping relationship for unpermute operation.
+            Shape: (seqlen, num_experts). Dtype: int32.
+        expert_routemap_topk (Tensor): The input Tensor indicating which expert each token is assigned to.
+            Shape: (seqlen, 8). Value range: [-1, num_experts]. Dtype: int32.
+        token_prob_unzipped (Tensor): The input Tensor containing flattened expert probabilities corresponding to hidden_states_unzipped.
+            Shape: (seqlen_broadcasted, 1). Dtype: float32.
+        total_zipped_tokens_num (int): The total number of tokens before permutation for output buffer allocation. Dtype: int32.
+        num_experts (int): The number of experts. Dtype: int32.
+        use_mix_precision (bool, optional): Whether to use mixed precision during accumulation.
+            This option significantly improves precision when number of experts > 4. Default: True.
+        name (str|None, optional): Name for the operation. Default: None.
+
+    Returns:
+        tuple[Tensor, Tensor]: A tuple containing:
+            - hidden_states (Tensor): The output Tensor with unpermuted tokens.
+              Shape: (seqlen, token_len). Dtype: bfloat16.
+            - expert_prob_topk (Tensor): The output Tensor with unpermuted probabilities.
+              Shape: (seqlen, topk). Dtype: float32.
+
+    Examples:
+        .. code-block:: python
+
+            >>> # doctest: +REQUIRES(env:GPU)
+            >>> # doctest: +SKIP('This is only support in cuda 12.0+')
+            >>> import paddle
+            >>> import numpy as np
+            >>> import paddle.nn.functional as F
+            >>> hidden_states = paddle.randn([3, 128], dtype='bfloat16')
+            >>> expert_routemap_topk = paddle.to_tensor([[-1, 0, -1, -1, 2, -1, -1, -1],
+            ...                                          [1, -1, -1, -1, -1, -1, -1, -1],
+            ...                                          [-1, -1, -1, -1, -1, -1, 1, -1]],
+            ...                                           dtype='int32')
+            >>> expert_prob_topk= paddle.to_tensor([[0.0, 0.6, 0.0, 0.0, 0.4, 0.0, 0.0, 0.0],
+            ...                                     [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            ...                                     [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0]],
+            ...                                          dtype='float32')
+            >>> num_experts = 3
+            >>> tokens_per_expert = [1, 2, 1]
+            >>> padding_alignment = 2
+            >>> hidden_states_unzipped, zipped_expertwise_rowmap, token_prob_unzipped, scale_unzipped = F.moe_permute(
+            ...     hidden_states,
+            ...     None,
+            ...     expert_routemap_topk,
+            ...     expert_prob_topk,
+            ...     num_experts,
+            ...     tokens_per_expert,
+            ...     padding_alignment,
+            ... )
+            >>> # weighted by probs.
+            >>> hidden_states_unzipped = (hidden_states_unzipped.astype("float32") * token_prob_unzipped.astype("float32").unsqueeze(-1)).astype("bfloat16")
+            >>> zipped_tokens, zipped_probs = F.moe_unpermute(hidden_states_unzipped, zipped_expertwise_rowmap, expert_routemap_topk, token_prob_unzipped,3,3)
+            >>> np.testing.assert_allclose(zipped_tokens.numpy(), hidden_states.numpy(), rtol=1e-05, atol=1e-06)
+    """
+    if in_dynamic_or_pir_mode():
+        zipped_tokens, zipped_probs_topk = _C_ops.moe_unpermute(
+            hidden_states_unzipped,
+            zipped_expertwise_rowmap,
+            expert_routemap_topk,
+            token_prob_unzipped,
+            total_zipped_tokens,
+            num_experts,
+            use_mix_precision,
+        )
+        return (zipped_tokens, zipped_probs_topk)

--- a/test/legacy_test/test_moe_permute_unpermute.py
+++ b/test/legacy_test/test_moe_permute_unpermute.py
@@ -1,0 +1,206 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import itertools
+import unittest
+
+import numpy as np
+
+import paddle
+from paddle.nn.functional import moe_permute, moe_unpermute
+
+
+def fabricate_dispatch_result(
+    seqlen,
+    token_length,
+    topk,
+    num_experts,
+    data_type="bfloat16",
+    broadcast_ratio=0.5,
+):
+    """Helper function to generate test data."""
+    hidden_states = paddle.randn([seqlen, token_length]).astype(data_type)
+
+    scale = paddle.empty([0])
+    if data_type == "float8_e4m3fn":
+        scale_cols = (token_length + 127) // 128
+        scale = paddle.randn([seqlen, scale_cols], dtype="float32")
+
+    # Calculate expert counts with normal distribution
+    expected_experts = max(1, min(broadcast_ratio * num_experts, topk))
+    std_dev = max(1, expected_experts / 6)
+    experts_count = paddle.normal(expected_experts, std_dev, [seqlen])
+    experts_count = paddle.clip(
+        paddle.round(experts_count), 1, min(topk, num_experts)
+    )
+    experts_count = paddle.cast(experts_count, "int32")
+
+    # Preallocate results
+    expert_routemap_topk = paddle.full([seqlen, topk], -1, dtype="int32")
+    expert_prob_topk = paddle.zeros([seqlen, topk], dtype="float32")
+
+    # Batch generate expert indices and probabilities
+    for i in range(seqlen):
+        count = experts_count[i].item()
+        indices = paddle.randperm(num_experts)[:count]
+        expert_routemap_topk[i, :count] = indices
+        prob_value = 1.0 / count
+        expert_prob_topk[i, :count] = paddle.full(
+            [count], prob_value, dtype=data_type
+        )
+
+    # Calculate expert token counts
+    valid_indices = expert_routemap_topk.reshape([-1])
+    valid_mask = valid_indices >= 0
+    valid_experts = valid_indices[valid_mask]
+    tokens_per_expert = paddle.histogram(
+        valid_experts, bins=num_experts, min=0, max=num_experts - 1
+    )
+    tokens_per_expert = paddle.cast(tokens_per_expert, "int32")
+    tokens_per_expert = list(tokens_per_expert)
+
+    return (
+        hidden_states,
+        scale,
+        expert_routemap_topk,
+        expert_prob_topk,
+        tokens_per_expert,
+    )
+
+
+def tensor_max_abs_rel_err(a, b, eps=1e-8):
+    """Calculate max absolute and relative error between two tensors."""
+    max_abs_err = paddle.max(paddle.abs(a - b))
+    denom = paddle.maximum(paddle.abs(a), paddle.abs(b))
+    denom = paddle.maximum(denom, paddle.to_tensor(eps, dtype=denom.dtype))
+    max_rel_err = paddle.max(paddle.abs(a - b) / denom)
+    return max_abs_err, max_rel_err
+
+
+class TestFusedMoePermuteUnpermute(unittest.TestCase):
+    """Test cases for moe_permute and moe_unpermute."""
+
+    SEQLEN = 16384
+    TOKEN_LEN = 7168
+    DTYPES = ["float8_e4m3fn", "bfloat16"]
+    EXPERT_NUMS = [4, 8, 16, 32, 64]
+    TOPKS = [4, 8, 16]
+
+    def setUp(self):
+        """Initialize test environment."""
+        paddle.seed(42)  # For reproducibility
+
+    def test_permute_unpermute_consistency(self):
+        """Test that permute + unpermute recovers original tensors."""
+        for dt, expert_num, topk in itertools.product(
+            self.DTYPES, self.EXPERT_NUMS, self.TOPKS
+        ):
+            with self.subTest(dtype=dt, expert_num=expert_num, topk=topk):
+                (
+                    hidden_states,
+                    scale,
+                    expert_routemap_topk,
+                    expert_prob_topk,
+                    tokens_per_expert,
+                ) = fabricate_dispatch_result(
+                    self.SEQLEN,
+                    self.TOKEN_LEN,
+                    topk,
+                    expert_num,
+                    data_type=dt,
+                    broadcast_ratio=0.5,
+                )
+                if dt == "bfloat16":
+                    scale = None
+
+                # Permute step
+                (
+                    unzipped_tokens,
+                    zipped_expertwise_rowmap,
+                    unzipped_probs,
+                    unzipped_scales,
+                ) = moe_permute(
+                    hidden_states,
+                    scale,
+                    expert_routemap_topk,
+                    expert_prob_topk,
+                    num_experts=expert_num,
+                    tokens_per_expert=tokens_per_expert,
+                    padding_alignment=128,
+                )
+                # do_gather = False
+                (
+                    _,
+                    zipped_expertwise_rowmap_no_gather,
+                    unzipped_probs_no_gather,
+                    _,
+                ) = moe_permute(
+                    hidden_states,
+                    scale,
+                    expert_routemap_topk,
+                    expert_prob_topk,
+                    num_experts=expert_num,
+                    tokens_per_expert=tokens_per_expert,
+                    padding_alignment=128,
+                    do_gather=False,
+                )
+
+                unpermute_input = (
+                    unzipped_tokens.astype("float32")
+                    * unzipped_probs.unsqueeze(-1)
+                ).astype("bfloat16")
+
+                unzipped_tokens_recovered, expert_prob_topk_recovered = (
+                    moe_unpermute(
+                        unpermute_input,
+                        zipped_expertwise_rowmap,
+                        expert_routemap_topk,
+                        unzipped_probs,
+                        total_zipped_tokens=self.SEQLEN,
+                        num_experts=expert_num,
+                    )
+                )
+
+                # Check tensor recovery
+                max_abs_err, max_rel_err = tensor_max_abs_rel_err(
+                    hidden_states.astype("float32"),
+                    unzipped_tokens_recovered.astype("float32"),
+                )
+
+                self.assertLess(
+                    max_rel_err,
+                    1e-1 if dt == "float8_e4m3fn" else 1e-2,
+                    f"Tokens relative error too large, permute-unpermute tokens max relative error: {max_rel_err}",
+                )
+
+                np.testing.assert_equal(
+                    expert_prob_topk._md5sum(),
+                    expert_prob_topk_recovered._md5sum(),
+                    err_msg="moe_permute_unpermute probs do not match",
+                )
+
+                np.testing.assert_equal(
+                    zipped_expertwise_rowmap_no_gather._md5sum(),
+                    zipped_expertwise_rowmap._md5sum(),
+                    err_msg="no_gather's zipped_expertwise_rowmap do not match",
+                )
+                np.testing.assert_equal(
+                    unzipped_probs_no_gather._md5sum(),
+                    unzipped_probs._md5sum(),
+                    err_msg="no_gather's unzipped_probs do not match",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features 

### Description
Add moe_permute & unpermute with do_gather(fill_x) feature to fleety
pcard-91067
