### PR TITLE
[Stride]Fix stride permute bug

### DIFF
--- a/paddle/phi/kernels/funcs/stride_utils.h
+++ b/paddle/phi/kernels/funcs/stride_utils.h
@@ -119,7 +119,9 @@ static inline void permute_dimensions(const std::vector<int64_t> stride_size,
       std::vector<int64_t> original_data((*strides_array)[i],
                                          (*strides_array)[i] + stride_size[i]);
       temp_strides[i] = reorder(original_data);
-      (*strides_array)[i] = temp_strides[i].data();
+      for (int64_t j = 0; j < stride_size[i]; j++) {
+        (*strides_array)[i][j] = temp_strides[i][j];
+      }
     }
   }
 }
@@ -180,7 +182,7 @@ static inline void reorder_dimensions(const std::vector<int64_t> stride_size,
     return 0;
   };
   // insertion sort with support for ambiguous comparisons
-  for (size_t i = 0; i < ndim; i++) {
+  for (size_t i = 1; i < ndim; i++) {
     int dim1 = i;
     for (int dim0 = i - 1; dim0 >= 0; dim0--) {
       int comparison = should_swap(perm_[dim0], perm_[dim1]);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
pcard-67164
- The previous `permute_dimensions` function failed to write the correct merged strides into `strides_array`, diminishing the performance benefits of dimension merging.  
- This PR fixes the issue.