### PR TITLE
[0-size Tensor Retest] add avg/max poll for float16

### DIFF
--- a/paddle/phi/kernels/cpu/pool_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/pool_grad_kernel.cc
@@ -17,8 +17,13 @@
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/impl/pool_grad_kernel_impl.h"
 
-PD_REGISTER_KERNEL(
-    pool2d_grad, CPU, ALL_LAYOUT, phi::Pool2dGradKernel, float, double) {}
+PD_REGISTER_KERNEL(pool2d_grad,
+                   CPU,
+                   ALL_LAYOUT,
+                   phi::Pool2dGradKernel,
+                   float,
+                   double,
+                   phi::dtype::float16) {}
 PD_REGISTER_KERNEL(
     lp_pool2d_grad, CPU, ALL_LAYOUT, phi::LPPool2dGradKernel, float, double) {}
 PD_REGISTER_KERNEL(pool2d_double_grad,
@@ -36,8 +41,13 @@ PD_REGISTER_KERNEL(max_pool2d_with_index_grad,
   kernel->InputAt(1).SetDataType(phi::CppTypeToDataType<int>::Type());
 }
 
-PD_REGISTER_KERNEL(
-    pool3d_grad, CPU, ALL_LAYOUT, phi::Pool3dGradKernel, float, double) {}
+PD_REGISTER_KERNEL(pool3d_grad,
+                   CPU,
+                   ALL_LAYOUT,
+                   phi::Pool3dGradKernel,
+                   float,
+                   double,
+                   phi::dtype::float16) {}
 PD_REGISTER_KERNEL(max_pool3d_with_index_grad,
                    CPU,
                    ALL_LAYOUT,

--- a/paddle/phi/kernels/cpu/pool_kernel.cc
+++ b/paddle/phi/kernels/cpu/pool_kernel.cc
@@ -17,7 +17,13 @@
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/impl/pool_kernel_impl.h"
 
-PD_REGISTER_KERNEL(pool2d, CPU, ALL_LAYOUT, phi::Pool2dKernel, float, double) {}
+PD_REGISTER_KERNEL(pool2d,
+                   CPU,
+                   ALL_LAYOUT,
+                   phi::Pool2dKernel,
+                   float,
+                   double,
+                   phi::dtype::float16) {}
 PD_REGISTER_KERNEL(
     lp_pool2d, CPU, ALL_LAYOUT, phi::LPPool2dKernel, float, double) {}
 PD_REGISTER_KERNEL(max_pool2d_with_index,
@@ -29,7 +35,13 @@ PD_REGISTER_KERNEL(max_pool2d_with_index,
   kernel->OutputAt(1).SetDataType(phi::CppTypeToDataType<int>::Type());
 }
 
-PD_REGISTER_KERNEL(pool3d, CPU, ALL_LAYOUT, phi::Pool3dKernel, float, double) {}
+PD_REGISTER_KERNEL(pool3d,
+                   CPU,
+                   ALL_LAYOUT,
+                   phi::Pool3dKernel,
+                   float,
+                   double,
+                   phi::dtype::float16) {}
 PD_REGISTER_KERNEL(max_pool3d_with_index,
                    CPU,
                    ALL_LAYOUT,

--- a/paddle/phi/kernels/funcs/pooling.cc
+++ b/paddle/phi/kernels/funcs/pooling.cc
@@ -464,6 +464,8 @@ class MaxPool2dGradFunctor<CPUContext, T> {
 template class MaxPool2dGradFunctor<CPUContext, float>;
 template class MaxPool2dGradFunctor<CPUContext, double>;
 
+template class MaxPool2dGradFunctor<CPUContext, dtype::float16>;
+
 template class Pool2dFunctor<CPUContext, MaxPool<float>, float>;
 template class Pool2dFunctor<CPUContext, AvgPool<float>, float>;
 template class Pool2dFunctor<CPUContext, LPPool<float>, float>;
@@ -477,6 +479,24 @@ template class Pool2dGradFunctor<CPUContext, MaxPoolGrad<double>, double>;
 template class Pool2dGradFunctor<CPUContext, AvgPoolGrad<double>, double>;
 template class Pool2dGradFunctor<CPUContext, LPPoolGrad<double>, double>;
 
+template class Pool2dFunctor<phi::CPUContext,
+                             MaxPool<dtype::float16>,
+                             dtype::float16>;
+template class Pool2dFunctor<phi::CPUContext,
+                             AvgPool<dtype::float16>,
+                             dtype::float16>;
+template class Pool2dFunctor<phi::CPUContext,
+                             LPPool<dtype::float16>,
+                             dtype::float16>;
+template class Pool2dGradFunctor<phi::CPUContext,
+                                 MaxPoolGrad<dtype::float16>,
+                                 dtype::float16>;
+template class Pool2dGradFunctor<phi::CPUContext,
+                                 AvgPoolGrad<dtype::float16>,
+                                 dtype::float16>;
+template class Pool2dGradFunctor<phi::CPUContext,
+                                 LPPoolGrad<dtype::float16>,
+                                 dtype::float16>;
 /*
  * Tensors are in NCDHW or NDHWC format.
  * Ksize, strides, paddings are three elements. These three elements represent
@@ -1057,6 +1077,7 @@ class MaxPool3dGradFunctor<CPUContext, T> {
 };
 template class MaxPool3dGradFunctor<CPUContext, float>;
 template class MaxPool3dGradFunctor<CPUContext, double>;
+template class MaxPool3dGradFunctor<CPUContext, dtype::float16>;
 
 template class Pool3dFunctor<CPUContext, MaxPool<float>, float>;
 template class Pool3dFunctor<CPUContext, AvgPool<float>, float>;
@@ -1067,6 +1088,21 @@ template class Pool3dFunctor<CPUContext, AvgPool<double>, double>;
 template class Pool3dGradFunctor<CPUContext, MaxPoolGrad<double>, double>;
 template class Pool3dGradFunctor<CPUContext, AvgPoolGrad<double>, double>;
 
+template class Pool3dFunctor<phi::CPUContext,
+                             MaxPool<dtype::float16>,
+                             dtype::float16>;
+template class Pool3dFunctor<phi::CPUContext,
+                             AvgPool<dtype::float16>,
+                             dtype::float16>;
+template class Pool3dFunctor<phi::CPUContext,
+                             LPPool<dtype::float16>,
+                             dtype::float16>;
+template class Pool3dGradFunctor<phi::CPUContext,
+                                 MaxPoolGrad<dtype::float16>,
+                                 dtype::float16>;
+template class Pool3dGradFunctor<phi::CPUContext,
+                                 AvgPoolGrad<dtype::float16>,
+                                 dtype::float16>;
 /*
  * All tensors are in NCHW format.
  * Ksize, strides, paddings are two elements. These two elements represent

--- a/paddle/phi/kernels/gpudnn/pool_kernel.cu
+++ b/paddle/phi/kernels/gpudnn/pool_kernel.cu
@@ -305,7 +305,7 @@ void Pool3dGPUDNNKernel(const Context& dev_ctx,
                         const std::string& padding_algorithm,
                         DenseTensor* out) {
   if (x.numel() == 0) {
-    if (pooling_type == "max" || pooling_type == "avg") {
+    if (pooling_type == "max") {
       phi::Full<T, Context>(
           dev_ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
     } else {

--- a/paddle/phi/kernels/impl/pool_kernel_impl.h
+++ b/paddle/phi/kernels/impl/pool_kernel_impl.h
@@ -389,7 +389,7 @@ void Pool3dKernel(const Context& dev_ctx,
                   const std::string& padding_algorithm,
                   DenseTensor* out) {
   if (x.numel() == 0) {
-    if (pooling_type == "max" || pooling_type == "avg") {
+    if (pooling_type == "max") {
       phi::Full<T, Context>(
           dev_ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
     } else {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
adaptive_avg_pool2d、adaptive_avg_pool3d、adaptive_max_pool2d、adaptive_avg_pool3d
1. 存在精度问题，是0-size时返回的初始化填充问题，avg时改为nan即可。
<img width="914" height="208" alt="image" src="https://github.com/user-attachments/assets/abd1ac30-9c02-4507-b2e6-6d68059e1a3d" />
2. 解决上面问题后，GPU测试通过，但是CPU测试出现float16类型不支持问题，原因是cpu没有支持flaot16的kernel实现。
<img width="1170" height="78" alt="image" src="https://github.com/user-attachments/assets/1fefcdf3-a295-4c1c-a549-dd7526f1b0c1" />

增加对float16的支持后测试：
adaptive_avg_pool2d
<img width="960" height="169" alt="image" src="https://github.com/user-attachments/assets/ba8c55fb-3349-4dac-a3c0-ab5f95679b40" />
adaptive_avg_pool3d
<img width="960" height="126" alt="image" src="https://github.com/user-attachments/assets/eb7b5c07-118d-410c-b99b-6405acccae49" />
adaptive_max_pool2d
<img width="960" height="119" alt="image" src="https://github.com/user-attachments/assets/7678f6e2-ee4f-4f47-8c29-ce04a98bf07e" />
adaptive_avg_pool3d
<img width="960" height="118" alt="image" src="https://github.com/user-attachments/assets/71af2013-23b1-44f2-9e90-eb88c88b27c3" />

pcard-67164