### PR TITLE
[Slice] Dispatch bool-only combined case to elementwise_get

### DIFF
--- a/paddle/fluid/pybind/eager_method.cc
+++ b/paddle/fluid/pybind/eager_method.cc
@@ -62,6 +62,7 @@ typedef SSIZE_T ssize_t;
 #include "paddle/phi/core/distributed/auto_parallel/reshard/reshard_function_registry.h"
 #include "paddle/phi/core/distributed/auto_parallel/reshard/reshard_utils.h"
 #include "paddle/phi/core/memory/allocation/mmap_allocator.h"
+#include "paddle/phi/core/scope_guard.h"
 #include "paddle/phi/core/tensor_utils.h"
 #include "paddle/phi/kernels/funcs/math_function.h"
 #include "paddle/utils/pybind.h"

--- a/paddle/fluid/pybind/eager_method.cc
+++ b/paddle/fluid/pybind/eager_method.cc
@@ -1601,19 +1601,10 @@ static PyObject* tensor__getitem_dygraph(TensorObject* self,
                                                         &trans_dim,
                                                         &out_is_view);
 
-  bool has_bool_index = false;
-  for (auto& index : transed_index) {
-    if (index.dtype() == phi::DataType::BOOL) {
-      has_bool_index = true;
-    }
-  }
   const int index_size = PyTuple_GET_SIZE(index_ptr);
-  const bool is_combined_bool = has_bool_index && index_size > 1;
-
   ApplyGetitem(index_size,
                pos_of_new_dim,
                rank_of_new_dim,
-               is_combined_bool,
                &transed_index,
                &tensor,
                &self->tensor,

--- a/paddle/fluid/pybind/slice_utils.h
+++ b/paddle/fluid/pybind/slice_utils.h
@@ -17,22 +17,17 @@
 #include <Python.h>
 
 #include <algorithm>
-#include "paddle/fluid/eager/api/all.h"
 #include "paddle/fluid/eager/api/generated/eager_generated/forwards/dygraph_functions.h"
 #include "paddle/fluid/eager/utils.h"
 #include "paddle/fluid/framework/convert_utils.h"
-#include "paddle/fluid/framework/scope_guard.h"
 #include "paddle/fluid/imperative/amp_utils.h"
 #include "paddle/fluid/pybind/tensor_py.h"
 #include "paddle/phi/common/data_type.h"
-#include "paddle/phi/core/compat/convert_utils.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/kernels/funcs/common_infer_shape_functions.h"
 #include "paddle/phi/kernels/funcs/slice_utils.h"
-#include "paddle/phi/kernels/funcs/strided_slice.h"
+#include "paddle/utils/pybind.h"
 #include "pybind11/numpy.h"
-#include "pybind11/pybind11.h"
-#include "pybind11/stl.h"
 
 using egr::ConvertAllInputsToDistTensor;
 using egr::InputsContainDistTensor;
@@ -80,7 +75,7 @@ static inline paddle::Tensor expand_inplace(paddle::Tensor tensor,
   } else if (tensor.dims()[0] == to_expand.dims()[0]) {
     return expand_ad_func(to_expand, common::vectorize<int64_t>(tensor.dims()));
   } else {
-    to_expand = squeeze_ad_func(to_expand, {-1});
+    // to_expand = squeeze_ad_func(to_expand, {-1});
     return expand_ad_func(to_expand, common::vectorize<int64_t>(tensor.dims()));
   }
 }
@@ -519,6 +514,7 @@ static void ParseIndex(const paddle::Tensor& tensor,
           estimated_dim++;
         }
       } else {
+        dim_len = shape[static_cast<int>(current_dim)];
         if (slice_tensor.dtype() == phi::DataType::BOOL) {
           PADDLE_ENFORCE_EQ(slice_tensor.shape()[0],
                             dim_len,
@@ -614,6 +610,7 @@ static paddle::Tensor getTensorWithBasicIndexing(
 }
 
 inline static bool MaskedFillDispatching(
+    const int pos_of_new_dim,
     const paddle::Tensor& tensor,
     const std::vector<paddle::Tensor>& indices,
     paddle::Tensor* mask_tensor,
@@ -627,10 +624,23 @@ inline static bool MaskedFillDispatching(
   if ((indices)[0].dtype() != phi::DataType::BOOL) {
     return false;
   } else {
-    num_ind += (indices)[0].shape().size();
+    num_ind += static_cast<int>((indices)[0].shape().size());
   }
-
   *mask_tensor = (indices)[0];
+  PADDLE_ENFORCE_LE(
+      num_ind + pos_of_new_dim,
+      tensor.shape().size(),
+      common::errors::InvalidArgument(
+          "The index tensor dim %d + pos_of_new_dim %d should be less than "
+          "the indexed tensor dim %d.",
+          num_ind,
+          pos_of_new_dim,
+          tensor.shape().size()));
+  for (int i = 0; i < pos_of_new_dim; i++) {
+    *mask_tensor = unsqueeze_ad_func(*mask_tensor, {0});
+  }
+  num_ind += pos_of_new_dim;
+
   for (size_t i = num_ind; i < tensor.shape().size(); i++) {
     *mask_tensor = unsqueeze_ad_func(*mask_tensor, {-1});
   }
@@ -649,16 +659,11 @@ static paddle::Tensor dealWithAdvancedIndex(
     std::vector<int>* trans_dim,
     bool* out_is_view) {
   int p = 0;
-  bool int_tensor_only = true;
-  for (size_t i = 0; i < advanced_index_dim->size(); ++i) {
-    auto index_dim = (*advanced_index_dim)[i];
+  for (int index_dim : *advanced_index_dim) {
     if (index_dim != -1) {
       // size of advanced_index is same to number of non -1 element in
       // advanced_index_dim
       auto index = (*advanced_index)[p++];
-      if (index.dtype() == phi::DataType::BOOL) {
-        int_tensor_only = false;
-      }
 
       if (index_dim == 0) {
         // case 1: advanced indices at axis 0, the new dim will be at first.
@@ -746,7 +751,7 @@ static paddle::Tensor getValueForBoolTensor(const paddle::Tensor& tensor,
   while (i < bool_index.shape().size()) {
     PADDLE_ENFORCE_EQ(
         bool_index.shape()[i],
-        tensor_shape[i],
+        tensor_shape[i + pos_of_new_dim],
         common::errors::OutOfRange(
             "The dimension of bool index doesn't match indexed array along "
             "dimension %d, the target dimension is %d, but received %d",
@@ -765,37 +770,49 @@ static paddle::Tensor getValueForBoolTensor(const paddle::Tensor& tensor,
     return masked_select_ad_func(tensor, bool_index);
   }
 
-  auto bool_2_idx = nonzero_ad_func(bool_index);
   if (FLAGS_use_stride_kernel) {
-    std::vector<paddle::Tensor> indices =
-        PrepareIndices(tensor, bool_2_idx, bool_index);
-    for (int i = 0; i < pos_of_new_dim; ++i) {
-      indices.insert(indices.begin(), paddle::Tensor());
-    }
-    while (indices.size() < static_cast<size_t>(tensor.dims().size())) {
-      indices.emplace_back(paddle::Tensor());
-    }
+    std::vector<paddle::Tensor> indices = {bool_index};
+    std::vector<int64_t> tensor_shape = tensor.shape();
+    std::vector<int64_t> flattened_shape;
 
-    std::vector<paddle::Tensor> indices_int64;
-    for (auto& indice : indices) {
-      if (indice.defined() && indice.dtype() == paddle::DataType::INT32) {
-        indice = indice.cast(paddle::DataType::INT64);  // int32 -> int64
+    for (int i = 0; i < pos_of_new_dim; i++) {
+      indices[0] = unsqueeze_ad_func(indices[0], {0});
+    }
+    uint64_t after_index =
+        tensor.shape().size() - pos_of_new_dim - bool_index.shape().size();
+    for (uint64_t i = 0; i < after_index; i++) {
+      indices[0] = unsqueeze_ad_func(indices[0], {-1});
+    }
+    indices[0] = expand_inplace(tensor, indices[0]);
+
+    paddle::Tensor get_tensor = index_elementwise_get_ad_func(
+        self_tensor,
+        indices,
+        common::vectorize(tensor.dims()),
+        common::vectorize(tensor.strides()),
+        common::vectorize(indices[0].dims()),
+        common::vectorize(indices[0].strides()),
+        static_cast<int64_t>(reinterpret_cast<const char*>(tensor.data()) -
+                             reinterpret_cast<const char*>(self_tensor.data())),
+        true);
+
+    std::vector<int64_t> output_shape = tensor.shape();
+    if (get_tensor.numel() != 0) {
+      output_shape[pos_of_new_dim] = -1;
+    } else {
+      paddle::Tensor non_zero_count = sum_ad_func(bool_index);
+      if (non_zero_count.is_cpu()) {
+        output_shape[pos_of_new_dim] = non_zero_count.data<int64_t>()[0];
+      } else {
+        paddle::Tensor non_zero_count_cpu =
+            non_zero_count.copy_to<int64_t>(phi::CPUPlace());
+        output_shape[pos_of_new_dim] = non_zero_count_cpu.data<int64_t>()[0];
       }
-      indices_int64.push_back(indice);
     }
-
-    AdvancedIndex ad = AdvancedIndex(tensor, indices_int64);
-    const bool accumulate = false;
-
-    return index_elementwise_get_ad_func(self_tensor,
-                                         ad.indices,
-                                         ad.src_sizes,
-                                         ad.src_strides,
-                                         ad.indexed_sizes,
-                                         ad.indexed_strides,
-                                         slice_offset,
-                                         accumulate);
+    auto ret = reshape_ad_func(get_tensor, output_shape);
+    return ret;
   } else {
+    auto bool_2_idx = nonzero_ad_func(bool_index);
     if (bool_index.shape().size() == 1)
       return gather_ad_func(tensor, bool_2_idx);
 
@@ -827,8 +844,6 @@ static void ParseBoolAndBroadcastIndices(
     }
 
     if (need_broadcast) {
-      // Here advanced_index has been checked ContainDistTensor
-      // and transed in dealWithAdvancedIndex
       auto common_shape_vec = common::vectorize<int64_t>(common_shape);
       for (size_t i = 0; i < advanced_index->size(); ++i) {
         auto current_shape = (*advanced_index)[i].shape();
@@ -967,14 +982,15 @@ static void DealWithIndex(const int pos_of_new_dim,
 }
 
 static inline paddle::Tensor expand_inplace(paddle::Tensor* tensor,
-                                            paddle::Tensor* to_expand) {
+                                            paddle::Tensor* to_expand,
+                                            int axis = 0) {
   if (tensor->dims() == to_expand->dims()) {
     return *to_expand;
   } else if (tensor->dims()[0] == to_expand->dims()[0]) {
     return expand_ad_func(*to_expand,
                           common::vectorize<int64_t>(tensor->dims()));
   } else {
-    *to_expand = squeeze_ad_func(*to_expand, {-1});
+    // *to_expand = squeeze_ad_func(*to_expand, {-1});
     return expand_ad_func(*to_expand,
                           common::vectorize<int64_t>(tensor->dims()));
   }
@@ -989,8 +1005,11 @@ static void DispatchSetitemKernel(const int pos_of_new_dim,
                                   paddle::Tensor* value_tensor,
                                   std::vector<phi::Scalar>* values) {
   paddle::Tensor mask_tensor;
-  if (MaskedFillDispatching(
-          *transed_sub_tensor, *transed_index, &mask_tensor, value_tensor)) {
+  if (MaskedFillDispatching(pos_of_new_dim,
+                            *transed_sub_tensor,
+                            *transed_index,
+                            &mask_tensor,
+                            value_tensor)) {
     if (value_tensor->initialized()) {
       if (!*out_is_view) {
         *transed_sub_tensor = masked_fill__ad_func(
@@ -1283,8 +1302,12 @@ static void ApplyGetitem(const int index_size,
       return;
     }
   }
-
-  handle_transpose(*out);
+  if (!(transed_index[0][0].dtype() == phi::DataType::BOOL &&
+        FLAGS_use_stride_kernel)) {
+    // Case for bool tensor with stride kernel is handled in
+    // getValueForBoolTensor, so needn't to transpose out again.
+    handle_transpose(*out);
+  }
 }
 
 }  // namespace pybind

--- a/paddle/fluid/pybind/slice_utils.h
+++ b/paddle/fluid/pybind/slice_utils.h
@@ -695,8 +695,7 @@ static paddle::Tensor dealWithAdvancedIndex(
     transed_tensor = tensor;
   } else {
     *out_is_view = true;
-    if (FLAGS_use_stride_kernel && *pos_of_new_dim != 0 &&
-        (is_for_setitem || int_tensor_only)) {
+    if (FLAGS_use_stride_kernel && *pos_of_new_dim != 0) {
       transed_tensor = tensor;
     } else {
       transed_tensor = transpose_ad_func(tensor, *trans_dim);
@@ -731,9 +730,10 @@ static std::vector<paddle::Tensor> PrepareIndices(
 }
 
 static paddle::Tensor getValueForBoolTensor(const paddle::Tensor& tensor,
+                                            const paddle::Tensor& self_tensor,
                                             const paddle::Tensor& bool_index,
                                             const int64_t slice_offset,
-                                            const bool is_combined_bool) {
+                                            const int64_t pos_of_new_dim) {
   PADDLE_ENFORCE(bool_index.shape().size() <= tensor.shape().size(),
                  common::errors::InvalidArgument(
                      "The dims of bool index doesn't match indexed array, "
@@ -757,8 +757,8 @@ static paddle::Tensor getValueForBoolTensor(const paddle::Tensor& tensor,
   }
 
   const phi::distributed::ProcessMesh* mesh = nullptr;
-  if (InputsContainDistTensor(&mesh, tensor, bool_index)) {
-    ConvertAllInputsToDistTensor(mesh, tensor, bool_index);
+  if (InputsContainDistTensor(&mesh, tensor, self_tensor, bool_index)) {
+    ConvertAllInputsToDistTensor(mesh, tensor, self_tensor, bool_index);
   }
 
   if (bool_index.shape().size() == tensor_shape.size()) {
@@ -766,11 +766,14 @@ static paddle::Tensor getValueForBoolTensor(const paddle::Tensor& tensor,
   }
 
   auto bool_2_idx = nonzero_ad_func(bool_index);
-  if (FLAGS_use_stride_kernel && !is_combined_bool) {
+  if (FLAGS_use_stride_kernel) {
     std::vector<paddle::Tensor> indices =
         PrepareIndices(tensor, bool_2_idx, bool_index);
+    for (int i = 0; i < pos_of_new_dim; ++i) {
+      indices.insert(indices.begin(), paddle::Tensor());
+    }
     while (indices.size() < static_cast<size_t>(tensor.dims().size())) {
-      indices.emplace_back();
+      indices.emplace_back(paddle::Tensor());
     }
 
     std::vector<paddle::Tensor> indices_int64;
@@ -784,7 +787,7 @@ static paddle::Tensor getValueForBoolTensor(const paddle::Tensor& tensor,
     AdvancedIndex ad = AdvancedIndex(tensor, indices_int64);
     const bool accumulate = false;
 
-    return index_elementwise_get_ad_func(tensor,
+    return index_elementwise_get_ad_func(self_tensor,
                                          ad.indices,
                                          ad.src_sizes,
                                          ad.src_strides,
@@ -1172,7 +1175,6 @@ static void ApplySetitem(const std::vector<int> trans_dim,
 static void ApplyGetitem(const int index_size,
                          const int pos_of_new_dim,
                          const int rank_of_new_dim,
-                         const bool is_combined_bool,
                          std::vector<paddle::Tensor>* transed_index,
                          paddle::Tensor* tensor,
                          paddle::Tensor* self_tensor,
@@ -1202,8 +1204,11 @@ static void ApplyGetitem(const int index_size,
       (*transed_index)[0].dtype() == phi::DataType::BOOL) {
     // get value for bool tensor
     int64_t slice_offset = 0;
-    *out = getValueForBoolTensor(
-        *transed_tensor, (*transed_index)[0], slice_offset, is_combined_bool);
+    *out = getValueForBoolTensor(*transed_tensor,
+                                 (*self_tensor),
+                                 (*transed_index)[0],
+                                 slice_offset,
+                                 pos_of_new_dim);
   } else {
     // get value for int tensor
     ParseBoolAndBroadcastIndices(transed_index);
@@ -1215,7 +1220,7 @@ static void ApplyGetitem(const int index_size,
       }
     }
 
-    if (FLAGS_use_stride_kernel && !is_combined_bool && !has_empty_index) {
+    if (FLAGS_use_stride_kernel && !has_empty_index) {
       const phi::distributed::ProcessMesh* mesh = nullptr;
       if (InputsContainDistTensor(
               &mesh, *self_tensor, *transed_tensor, *transed_index)) {
@@ -1223,6 +1228,7 @@ static void ApplyGetitem(const int index_size,
             mesh, *self_tensor, *transed_tensor, *transed_index);
       }
 
+      *transed_index = expandTensors(*transed_index);
       *transed_index = expand_outplace(*transed_index);
 
       std::vector<paddle::Tensor> transed_index_int64;

--- a/paddle/fluid/pybind/slice_utils.h
+++ b/paddle/fluid/pybind/slice_utils.h
@@ -72,10 +72,7 @@ static inline paddle::Tensor expand_inplace(paddle::Tensor tensor,
                                             paddle::Tensor to_expand) {
   if (tensor.dims() == to_expand.dims()) {
     return to_expand;
-  } else if (tensor.dims()[0] == to_expand.dims()[0]) {
-    return expand_ad_func(to_expand, common::vectorize<int64_t>(tensor.dims()));
   } else {
-    // to_expand = squeeze_ad_func(to_expand, {-1});
     return expand_ad_func(to_expand, common::vectorize<int64_t>(tensor.dims()));
   }
 }
@@ -982,8 +979,7 @@ static void DealWithIndex(const int pos_of_new_dim,
 }
 
 static inline paddle::Tensor expand_inplace(paddle::Tensor* tensor,
-                                            paddle::Tensor* to_expand,
-                                            int axis = 0) {
+                                            paddle::Tensor* to_expand) {
   if (tensor->dims() == to_expand->dims()) {
     return *to_expand;
   } else if (tensor->dims()[0] == to_expand->dims()[0]) {
@@ -1228,6 +1224,7 @@ static void ApplyGetitem(const int index_size,
                                  (*transed_index)[0],
                                  slice_offset,
                                  pos_of_new_dim);
+    return;
   } else {
     // get value for int tensor
     ParseBoolAndBroadcastIndices(transed_index);
@@ -1302,12 +1299,7 @@ static void ApplyGetitem(const int index_size,
       return;
     }
   }
-  if (!(transed_index[0][0].dtype() == phi::DataType::BOOL &&
-        FLAGS_use_stride_kernel)) {
-    // Case for bool tensor with stride kernel is handled in
-    // getValueForBoolTensor, so needn't to transpose out again.
-    handle_transpose(*out);
-  }
+  handle_transpose(*out);
 }
 
 }  // namespace pybind

--- a/paddle/phi/kernels/cpu/index_elementwise_get_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_elementwise_get_grad_kernel.cc
@@ -15,6 +15,7 @@
 #include "paddle/phi/kernels/index_elementwise_get_grad_kernel.h"
 
 #include "paddle/phi/common/bfloat16.h"
+#include "paddle/phi/common/data_type.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/eigen/common.h"
 #include "paddle/phi/kernels/funcs/index_elementwise.h"
@@ -49,7 +50,7 @@ void IndexEleGetGradAccKernel(
 template <typename T, typename IndexT = int>
 void CPUIndexElementwiseGetGrad(const phi::CPUContext& dev_ctx,
                                 const DenseTensor& input,
-                                const DenseTensor& value,
+                                const DenseTensor& out_grad,
                                 const std::vector<const DenseTensor*>& index,
                                 const std::vector<int64_t>& input_dims,
                                 const std::vector<int64_t>& input_strides,
@@ -58,64 +59,90 @@ void CPUIndexElementwiseGetGrad(const phi::CPUContext& dev_ctx,
                                 const int64_t slice_offset,
                                 const bool accumulate,
                                 DenseTensor* output) {
-  int64_t numel = 0;
-  int64_t num_indices = 0;
-  std::vector<int64_t> shape_tmp;
-  std::vector<int64_t> stride_tmp;
-  funcs::cal_shape_stride(index_dims, &num_indices, &shape_tmp, &stride_tmp);
-  auto sizes = std::array<int64_t, phi::DDim::kMaxRank + 1>{};
-  auto strides = std::array<int64_t, phi::DDim::kMaxRank + 1>{};
-  for (int64_t i = 0; i < num_indices; i++) {
-    sizes[i] = index_dims[i];
-    strides[i] = index_strides[i];
-  }
-  auto index_ptrs = funcs::GetIndexDataPtrs<IndexT>(index);
-  std::array<int64_t*, 3> strides_array;
-  std::vector<int64_t> desired_shape;
-  std::array<std::vector<int64_t>, 3> strides_vec;
-  funcs::IndexPutStride<3>(input_dims,
-                           input_strides,
-                           phi::SizeOf(input.dtype()),
-                           common::vectorize<int64_t>(value.dims()),
-                           common::vectorize<int64_t>(value.strides()),
-                           phi::SizeOf(value.dtype()),
-                           shape_tmp,
-                           stride_tmp,
-                           phi::SizeOf(index[0]->dtype()),
-                           &desired_shape,
-                           &strides_array,
-                           &numel,
-                           strides_vec);
-  auto offset_calc =
-      funcs::CPUmake_offset_calculator_put<3>(desired_shape, strides_array);
-  const int64_t N = numel;
-  using dtype = funcs::OpaqueType<sizeof(T)>;
-  const char* in_ptr = reinterpret_cast<const char*>(value.data<T>());
-  char* out_ptr = reinterpret_cast<char*>(output->data<T>()) + slice_offset;
-  if (accumulate) {
-    IndexEleGetGradAccKernel<T, IndexT>(N,
-                                        in_ptr,
-                                        out_ptr,
-                                        index_ptrs,
-                                        sizes,
-                                        strides,
-                                        num_indices,
-                                        offset_calc);
-  } else {
-    for (int64_t idx = 0; idx < N; idx++) {
-      const auto offsets = offset_calc.cpu_get(idx);
-      char* const out_data = out_ptr + offsets[0];
-      const char* const in_data = in_ptr + offsets[1];
-      int64_t offset = 0;
-      for (int64_t i = 0; i < num_indices; i++) {
-        int64_t index = *reinterpret_cast<int64_t*>(index_ptrs[i] + offsets[2]);
-        if (index < 0) {
-          index += sizes[i];
+  if (index[0]->dtype() == phi::DataType::BOOL) {
+    const T* out_grad_data = out_grad.data<T>();
+    const bool* index_data = index[0]->data<bool>();
+    T* output_data =
+        output->data<T>() + slice_offset / phi::SizeOf(output->dtype());
+    auto reverse_shape = std::vector(input_dims.rbegin(), input_dims.rend());
+    int64_t numel = index[0]->numel();
+    int64_t true_count = 0;
+    auto offset_calc = funcs::CPUmake_offset_calculator<1>(
+        static_cast<int32_t>(input_dims.size()),
+        reverse_shape.data(),
+        {{input_strides.rbegin(), input_strides.rend()}});
+    for (int64_t i = 0; i < numel; ++i) {
+      if (index_data[i]) {
+        int64_t output_offset = offset_calc.cpu_get(i)[0];
+        if (accumulate) {
+          output_data[output_offset] += out_grad_data[true_count++];
+        } else {
+          output_data[output_offset] = out_grad_data[true_count++];
         }
-        offset += index * strides[i];
       }
-      *reinterpret_cast<dtype*>(out_data + offset) =
-          *reinterpret_cast<const dtype*>(in_data);
+    }
+    return;
+  } else {
+    int64_t numel = 0;
+    int64_t num_indices = 0;
+    std::vector<int64_t> shape_tmp;
+    std::vector<int64_t> stride_tmp;
+    funcs::cal_shape_stride(index_dims, &num_indices, &shape_tmp, &stride_tmp);
+    auto sizes = std::array<int64_t, phi::DDim::kMaxRank + 1>{};
+    auto strides = std::array<int64_t, phi::DDim::kMaxRank + 1>{};
+    for (int64_t i = 0; i < num_indices; i++) {
+      sizes[i] = index_dims[i];
+      strides[i] = index_strides[i];
+    }
+    auto index_ptrs = funcs::GetIndexDataPtrs<IndexT>(index);
+    std::array<int64_t*, 3> strides_array;
+    std::vector<int64_t> desired_shape;
+    std::array<std::vector<int64_t>, 3> strides_vec;
+    funcs::IndexPutStride<3>(input_dims,
+                             input_strides,
+                             phi::SizeOf(input.dtype()),
+                             common::vectorize<int64_t>(out_grad.dims()),
+                             common::vectorize<int64_t>(out_grad.strides()),
+                             phi::SizeOf(out_grad.dtype()),
+                             shape_tmp,
+                             stride_tmp,
+                             phi::SizeOf(index[0]->dtype()),
+                             &desired_shape,
+                             &strides_array,
+                             &numel,
+                             strides_vec);
+    auto offset_calc =
+        funcs::CPUmake_offset_calculator_put<3>(desired_shape, strides_array);
+    const int64_t N = numel;
+    using dtype = funcs::OpaqueType<sizeof(T)>;
+    const char* in_ptr = reinterpret_cast<const char*>(out_grad.data<T>());
+    char* out_ptr = reinterpret_cast<char*>(output->data<T>()) + slice_offset;
+    if (accumulate) {
+      IndexEleGetGradAccKernel<T, IndexT>(N,
+                                          in_ptr,
+                                          out_ptr,
+                                          index_ptrs,
+                                          sizes,
+                                          strides,
+                                          num_indices,
+                                          offset_calc);
+    } else {
+      for (int64_t idx = 0; idx < N; idx++) {
+        const auto offsets = offset_calc.cpu_get(idx);
+        char* const out_data = out_ptr + offsets[0];
+        const char* const in_data = in_ptr + offsets[1];
+        int64_t offset = 0;
+        for (int64_t i = 0; i < num_indices; i++) {
+          int64_t index =
+              *reinterpret_cast<int64_t*>(index_ptrs[i] + offsets[2]);
+          if (index < 0) {
+            index += sizes[i];
+          }
+          offset += index * strides[i];
+        }
+        *reinterpret_cast<dtype*>(out_data + offset) =
+            *reinterpret_cast<const dtype*>(in_data);
+      }
     }
   }
 }
@@ -138,14 +165,15 @@ void IndexElementwiseGetGradKernel(const Context& dev_ctx,
   dxt.device(place) = dxt.constant(static_cast<T>(0));
   if (out_grad.numel() == 0) return;
   const auto& index_type = index[0]->dtype();
-  PADDLE_ENFORCE_EQ(index_type == phi::DataType::INT64,
-                    true,
-                    common::errors::InvalidArgument(
-                        "Index holds the wrong type, it holds [%s], but "
-                        "desires to be [%s].",
-                        index_type,
-                        phi::DataType::INT32,
-                        phi::DataType::INT64));
+  PADDLE_ENFORCE_EQ(
+      index_type == phi::DataType::INT64 ||
+          (index_type == phi::DataType::BOOL && index.size() == 1),
+      true,
+      common::errors::InvalidArgument(
+          "Index holds the wrong type, it holds [%s], but "
+          "desires to be [%s] or bool.",
+          index_type,
+          phi::DataType::INT64));
   CPUIndexElementwiseGetGrad<T, int64_t>(dev_ctx,
                                          x,
                                          out_grad,

--- a/paddle/phi/kernels/cpu/index_elementwise_get_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_elementwise_get_kernel.cc
@@ -165,8 +165,6 @@ void IndexElementwiseGetKernel(const Context& dev_ctx,
     return;
   }
 
-  // x.dims differs with input_dims when x is a non-contiguous tensor, but is
-  // transformed to contiguous one for this kernel is not registered as strided.
   CPUIndexElementwiseGetKernel<T, int64_t>(dev_ctx,
                                            x,
                                            index,

--- a/paddle/phi/kernels/cpu/index_elementwise_get_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_elementwise_get_kernel.cc
@@ -14,8 +14,12 @@
 
 #include "paddle/phi/kernels/index_elementwise_get_kernel.h"
 
+#include "paddle/common/ddim.h"
+#include "paddle/common/enforce.h"
 #include "paddle/phi/backends/cpu/cpu_context.h"
 #include "paddle/phi/common/bfloat16.h"
+#include "paddle/phi/common/data_type.h"
+#include "paddle/phi/core/ddim.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/index_elementwise.h"
 #include "paddle/phi/kernels/funcs/stride_utils.h"
@@ -31,62 +35,107 @@ void CPUIndexElementwiseGetKernel(const phi::CPUContext& dev_ctx,
                                   const std::vector<int64_t>& index_stride,
                                   const int64_t slice_offset,
                                   DenseTensor* output) {
-  int64_t numel = 0;
-  int64_t num_indices = 0;
-  std::vector<int64_t> shape_tmp;
-  std::vector<int64_t> stride_tmp;
-  funcs::cal_shape_stride(index_dims, &num_indices, &shape_tmp, &stride_tmp);
+  if (index[0]->dtype() == phi::DataType::BOOL) {
+    const T* input_data =
+        input.data<T>() + slice_offset / phi::SizeOf(input.dtype());
+    const bool* index_data = index[0]->data<bool>();
 
-  auto index_ptrs = funcs::GetIndexDataPtrs<IndexT>(index);
-  auto sizes = std::array<int64_t, DDim::kMaxRank>{};
-  auto strides = std::array<int64_t, DDim::kMaxRank>{};
-  for (int64_t i = 0; i < num_indices; i++) {
-    sizes[i] = index_dims[i];
-    strides[i] = index_stride[i];
-  }
-  std::array<int64_t*, 3> strides_array;
-  std::vector<int64_t> desired_shape;
-  std::array<std::vector<int64_t>, 3> strides_vec;
-  funcs::IndexGetStride<3>(input_dims,
-                           input_strides,
-                           phi::SizeOf(input.dtype()),
-                           std::vector<int64_t>(),
-                           std::vector<int64_t>(),
-                           phi::SizeOf(input.dtype()),
-                           shape_tmp,
-                           stride_tmp,
-                           phi::SizeOf(index[0]->dtype()),
-                           &desired_shape,
-                           &strides_array,
-                           &numel,
-                           strides_vec);
-  auto offset_calc =
-      funcs::CPUmake_offset_calculator_put<3>(desired_shape, strides_array);
-  const int64_t N = output->numel();
-  PADDLE_ENFORCE_GE(
-      N, 0, common::errors::InvalidArgument("Output numel must >= 0"));
-  PADDLE_ENFORCE_LE(
-      N,
-      std::numeric_limits<int32_t>::max(),
-      common::errors::InvalidArgument("Output numel must <= INT32_MAX"));
-  using dtype = funcs::OpaqueType<sizeof(T)>;
-  const char* in_ptr =
-      reinterpret_cast<const char*>(input.data<T>()) + slice_offset;
-  char* out_ptr = reinterpret_cast<char*>(output->data<T>());
-  for (int64_t idx = 0; idx < N; idx++) {
-    const auto offsets = offset_calc.cpu_get(idx);
-    char* const out_data = out_ptr + offsets[0];
-    const char* const in_data = in_ptr + offsets[1];
-    int64_t offset = 0;
-    for (int64_t i = 0; i < num_indices; i++) {
-      int64_t index = *reinterpret_cast<int64_t*>(index_ptrs[i] + offsets[2]);
-      if (index < 0) {
-        index += sizes[i];
+    PADDLE_ENFORCE_EQ(
+        index[0]->strides(),
+        ::common::make_ddim(index_stride),
+        common::errors::InvalidArgument("Index tensor should be contiguous."));
+    int64_t numel = index[0]->numel();
+    int64_t true_count = 0;
+    for (int64_t i = 0; i < numel; ++i) {
+      if (index_data[i]) {
+        true_count++;
       }
-      offset += index * strides[i];
     }
-    *reinterpret_cast<dtype*>(out_data) =
-        *reinterpret_cast<const dtype*>(in_data + offset);
+    output->Resize(common::make_ddim({true_count}));
+    dev_ctx.template Alloc<T>(output);
+
+    auto reverse_shape = std::vector(input_dims.rbegin(), input_dims.rend());
+    auto offset_calc = funcs::CPUmake_offset_calculator<1>(
+        static_cast<int32_t>(input_dims.size()),
+        reverse_shape.data(),
+        {
+            {input_strides.rbegin(), input_strides.rend()},
+        });
+    T* output_data = output->data<T>();
+    int64_t output_index = 0;
+    for (int64_t i = 0; i < numel; ++i) {
+      if (index_data[i]) {
+        auto offset = offset_calc.cpu_get(i)[0];
+        output_data[output_index++] = input_data[offset];
+      }
+    }
+    return;
+  } else {  // INT64
+    auto out_dims = output->dims();
+    if (out_dims.size() > 0) {
+      std::vector<int64_t> output_dims(input_dims);
+      output->Resize(phi::make_ddim(output_dims));
+    }
+    dev_ctx.template Alloc<T>(output);
+    if (output->numel() == 0) return;
+    int64_t numel = 0;
+    int64_t num_indices = 0;
+    std::vector<int64_t> shape_tmp;
+    std::vector<int64_t> stride_tmp;
+    funcs::cal_shape_stride(index_dims, &num_indices, &shape_tmp, &stride_tmp);
+
+    auto index_ptrs = funcs::GetIndexDataPtrs<IndexT>(index);
+    auto sizes = std::array<int64_t, DDim::kMaxRank>{};
+    auto strides = std::array<int64_t, DDim::kMaxRank>{};
+    for (int64_t i = 0; i < num_indices; i++) {
+      sizes[i] = index_dims[i];
+      strides[i] = index_stride[i];
+    }
+    std::array<int64_t*, 3> strides_array;
+    std::vector<int64_t> desired_shape;
+    std::array<std::vector<int64_t>, 3> strides_vec;
+    funcs::IndexGetStride<3>(
+        input_dims,
+        input_strides,
+        static_cast<int64_t>(phi::SizeOf(input.dtype())),
+        std::vector<int64_t>(),
+        std::vector<int64_t>(),
+        static_cast<int64_t>(phi::SizeOf(input.dtype())),
+        shape_tmp,
+        stride_tmp,
+        static_cast<int64_t>(phi::SizeOf(index[0]->dtype())),
+        &desired_shape,
+        &strides_array,
+        &numel,
+        strides_vec);
+    auto offset_calc =
+        funcs::CPUmake_offset_calculator_put<3>(desired_shape, strides_array);
+    const int64_t N = output->numel();
+    PADDLE_ENFORCE_GE(
+        N, 0, common::errors::InvalidArgument("Output numel must >= 0"));
+    PADDLE_ENFORCE_LE(
+        N,
+        std::numeric_limits<int32_t>::max(),
+        common::errors::InvalidArgument("Output numel must <= INT32_MAX"));
+    using dtype = funcs::OpaqueType<sizeof(T)>;
+    const char* in_ptr =
+        reinterpret_cast<const char*>(input.data<T>()) + slice_offset;
+    char* out_ptr = reinterpret_cast<char*>(output->data<T>());
+    for (int64_t idx = 0; idx < N; idx++) {
+      const auto offsets = offset_calc.cpu_get(idx);
+      char* const out_data = out_ptr + offsets[0];
+      const char* const in_data = in_ptr + offsets[1];
+      int64_t offset = 0;
+      for (int64_t i = 0; i < num_indices; i++) {
+        int64_t index = *reinterpret_cast<int64_t*>(index_ptrs[i] + offsets[2]);
+        if (index < 0) {
+          index += sizes[i];
+        }
+        offset += index * strides[i];
+      }
+      *reinterpret_cast<dtype*>(out_data) =
+          *reinterpret_cast<const dtype*>(in_data + offset);
+    }
   }
 }
 
@@ -102,21 +151,22 @@ void IndexElementwiseGetKernel(const Context& dev_ctx,
                                const bool accumulate,
                                DenseTensor* out) {
   const auto& index_type = index[0]->dtype();
-  PADDLE_ENFORCE_EQ(index_type == phi::DataType::INT64,
-                    true,
-                    common::errors::InvalidArgument(
-                        "Index holds the wrong type, it holds [%s], but "
-                        "desires to be [%s].",
-                        index_type,
-                        phi::DataType::INT64));
-
-  auto out_dims = out->dims();
-  if (out_dims.size() > 0) {
-    std::vector<int64_t> output_dims(input_dims);
-    out->Resize(phi::make_ddim(output_dims));
+  PADDLE_ENFORCE_EQ(
+      index_type == phi::DataType::INT64 ||
+          (index_type == phi::DataType::BOOL && index.size() == 1),
+      true,
+      common::errors::InvalidArgument(
+          "Index holds the wrong type, it holds [%s], but "
+          "desires to be [%s] or bool.",
+          index_type,
+          phi::DataType::INT64));
+  if (out && out->numel() == 0) {
+    dev_ctx.template Alloc<T>(out);
+    return;
   }
-  dev_ctx.template Alloc<T>(out);
-  if (out->numel() == 0) return;
+
+  // x.dims differs with input_dims when x is a non-contiguous tensor, but is
+  // transformed to contiguous one for this kernel is not registered as strided.
   CPUIndexElementwiseGetKernel<T, int64_t>(dev_ctx,
                                            x,
                                            index,

--- a/paddle/phi/kernels/cum_kernel.h
+++ b/paddle/phi/kernels/cum_kernel.h
@@ -16,6 +16,8 @@
 
 #include "paddle/phi/common/scalar.h"
 #include "paddle/phi/core/dense_tensor.h"
+#include "paddle/phi/core/meta_tensor.h"
+#include "paddle/phi/infermeta/unary.h"
 
 namespace phi {
 
@@ -36,5 +38,21 @@ void LogcumsumexpKernel(const Context& dev_ctx,
                         bool exclusive,
                         bool reverse,
                         DenseTensor* out);
+
+template <typename T, typename Context>
+DenseTensor Cumsum(const Context& dev_ctx,
+                   const DenseTensor& x,
+                   const Scalar& axis,
+                   bool flatten,
+                   bool exclusive,
+                   bool reverse) {
+  DenseTensor dense_out;
+  MetaTensor meta_out(&dense_out);
+  CumInferMeta(
+      MetaTensor(x), axis.to<int>(), flatten, exclusive, reverse, &meta_out);
+  CumsumKernel<T, Context>(
+      dev_ctx, x, axis, flatten, exclusive, reverse, &dense_out);
+  return dense_out;
+}
 
 }  // namespace phi

--- a/paddle/phi/kernels/gpu/index_elementwise_get_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_elementwise_get_grad_kernel.cu
@@ -17,9 +17,12 @@
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/backends/gpu/gpu_primitives.h"
 #include "paddle/phi/common/bfloat16.h"
+#include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/kernel_registry.h"
-#include "paddle/phi/kernels/funcs/eigen/common.h"
+#include "paddle/phi/kernels/cast_kernel.h"
+#include "paddle/phi/kernels/cum_kernel.h"
 #include "paddle/phi/kernels/funcs/index_elementwise.cu.h"
+#include "paddle/phi/kernels/funcs/math_function.h"
 #include "paddle/phi/kernels/funcs/stride_utils.h"
 
 namespace phi {
@@ -61,7 +64,7 @@ __global__ void IndexEleGetGradAccKernel(
 template <typename T, typename IndexT = int>
 void GPUIndexElementwiseGetGrad(const phi::GPUContext& dev_ctx,
                                 const DenseTensor& input,
-                                const DenseTensor& value,
+                                const DenseTensor& out_grad,
                                 const std::vector<const DenseTensor*>& index,
                                 const std::vector<int64_t>& input_dims,
                                 const std::vector<int64_t>& input_strides,
@@ -70,83 +73,121 @@ void GPUIndexElementwiseGetGrad(const phi::GPUContext& dev_ctx,
                                 const int64_t slice_offset,
                                 const bool accumulate,
                                 DenseTensor* output) {
-  int64_t numel = 0;
-
-  int64_t num_indices = 0;
-  std::vector<int64_t> shape_tmp;
-  std::vector<int64_t> stride_tmp;
-  funcs::cal_shape_stride(index_dims, &num_indices, &shape_tmp, &stride_tmp);
-
-  auto sizes = std::array<int64_t, phi::DDim::kMaxRank + 1>{};
-  auto strides = std::array<int64_t, phi::DDim::kMaxRank + 1>{};
-  for (int64_t i = 0; i < num_indices; i++) {
-    sizes[i] = index_dims[i];
-    strides[i] = index_strides[i];
-  }
-  auto index_ptrs = funcs::GetIndexDataPtrs<IndexT>(index);
-
-  std::array<int64_t*, 3> strides_array;
-  std::vector<int64_t> desired_shape;
-  std::array<std::vector<int64_t>, 3> strides_vec;
-
-  funcs::IndexPutStride<3>(input_dims,
-                           input_strides,
-                           phi::SizeOf(input.dtype()),
-                           common::vectorize<int64_t>(value.dims()),
-                           common::vectorize<int64_t>(value.strides()),
-                           phi::SizeOf(value.dtype()),
-                           shape_tmp,
-                           stride_tmp,
-                           phi::SizeOf(index[0]->dtype()),
-                           &desired_shape,
-                           &strides_array,
-                           &numel,
-                           strides_vec);
-  auto offset_calc =
-      funcs::make_offset_calculator_put<3>(desired_shape, strides_array);
-
-  const int64_t N = numel;
-  constexpr int nt = 128;
-  constexpr int vt = 4;
-  const dim3 block(nt);
-  const dim3 grid((N + block.x * vt - 1) / (block.x * vt));
-  auto stream = dev_ctx.stream();
-
-  using dtype = funcs::OpaqueType<sizeof(T)>;
-
-  const char* in_ptr = reinterpret_cast<const char*>(value.data<T>());
-  char* out_ptr = reinterpret_cast<char*>(output->data<T>()) + slice_offset;
-
-  if (accumulate) {
-    IndexEleGetGradAccKernel<T, IndexT, nt, vt>
-        <<<grid, block, 0, stream>>>(N,
-                                     in_ptr,
-                                     out_ptr,
-                                     index_ptrs,
-                                     sizes,
-                                     strides,
-                                     num_indices,
-                                     offset_calc);
-  } else {
-    funcs::index_elementwise_with_tensor_kernel<nt, vt>
-        <<<grid, block, 0, stream>>>(N, [=] __device__(int idx) {
-          const auto offsets = offset_calc.get(idx);
-          char* const out_data = out_ptr + offsets[0];
-          const char* const in_data = in_ptr + offsets[1];
-
-          int64_t offset = 0;
-#pragma unroll
-          for (int64_t i = 0; i < num_indices; i++) {
-            int64_t index =
-                *reinterpret_cast<int64_t*>(index_ptrs[i] + offsets[2]);
-            if (index < 0) {
-              index += sizes[i];
-            }
-            offset += index * strides[i];
-          }
-          *reinterpret_cast<dtype*>(out_data + offset) =
-              *reinterpret_cast<const dtype*>(in_data);
+  if (index.size() == 1 && index[0]->dtype() == phi::DataType::BOOL) {
+    T* output_data =
+        output->data<T>() + slice_offset / phi::SizeOf(output->dtype());
+    int64_t numel = index[0]->numel();
+    phi::DenseTensor index_int64 =
+        Cast<bool>(dev_ctx, *index[0], phi::DataType::INT64);
+    phi::DenseTensor prefix_sum_tensor =
+        Cumsum<int64_t>(dev_ctx, index_int64, {}, true, true, false);
+    const int64_t* prefix_sum_data = prefix_sum_tensor.data<int64_t>();
+    const bool* index_data = index[0]->data<bool>();
+    const T* out_grad_data = out_grad.data<T>();
+    auto reverse_shape = std::vector(input_dims.rbegin(), input_dims.rend());
+    auto offset_calc = funcs::make_offset_calculator<1>(
+        static_cast<int32_t>(input_dims.size()),
+        reverse_shape.data(),
+        {
+            {input_strides.rbegin(), input_strides.rend()},
         });
+    constexpr int nt = 128;
+    constexpr int vt = 4;
+    const dim3 block(nt);
+    auto stream = dev_ctx.stream();
+    const dim3 grid((numel + block.x * vt - 1) / (block.x * vt));
+    funcs::index_elementwise_with_tensor_kernel<nt, vt>
+        <<<grid, block, 0, stream>>>(numel, [=] __device__(int idx) {
+          const auto offset = offset_calc.get(idx)[0];
+          if (index_data[idx]) {
+            if (accumulate) {
+              phi::CudaAtomicAdd(output_data + offset,
+                                 out_grad_data[prefix_sum_data[idx]]);
+            } else {
+              output_data[offset] = out_grad_data[prefix_sum_data[idx]];
+            }
+          }
+        });
+    return;
+  } else {
+    int64_t numel = 0;
+
+    int64_t num_indices = 0;
+    std::vector<int64_t> shape_tmp;
+    std::vector<int64_t> stride_tmp;
+    funcs::cal_shape_stride(index_dims, &num_indices, &shape_tmp, &stride_tmp);
+
+    auto sizes = std::array<int64_t, phi::DDim::kMaxRank + 1>{};
+    auto strides = std::array<int64_t, phi::DDim::kMaxRank + 1>{};
+    for (int64_t i = 0; i < num_indices; i++) {
+      sizes[i] = index_dims[i];
+      strides[i] = index_strides[i];
+    }
+    auto index_ptrs = funcs::GetIndexDataPtrs<IndexT>(index);
+
+    std::array<int64_t*, 3> strides_array;
+    std::vector<int64_t> desired_shape;
+    std::array<std::vector<int64_t>, 3> strides_vec;
+
+    funcs::IndexPutStride<3>(input_dims,
+                             input_strides,
+                             phi::SizeOf(input.dtype()),
+                             common::vectorize<int64_t>(out_grad.dims()),
+                             common::vectorize<int64_t>(out_grad.strides()),
+                             phi::SizeOf(out_grad.dtype()),
+                             shape_tmp,
+                             stride_tmp,
+                             phi::SizeOf(index[0]->dtype()),
+                             &desired_shape,
+                             &strides_array,
+                             &numel,
+                             strides_vec);
+    auto offset_calc =
+        funcs::make_offset_calculator_put<3>(desired_shape, strides_array);
+
+    const int64_t N = numel;
+    constexpr int nt = 128;
+    constexpr int vt = 4;
+    const dim3 block(nt);
+    const dim3 grid((N + block.x * vt - 1) / (block.x * vt));
+    auto stream = dev_ctx.stream();
+
+    using dtype = funcs::OpaqueType<sizeof(T)>;
+
+    const char* in_ptr = reinterpret_cast<const char*>(out_grad.data<T>());
+    char* out_ptr = reinterpret_cast<char*>(output->data<T>()) + slice_offset;
+
+    if (accumulate) {
+      IndexEleGetGradAccKernel<T, IndexT, nt, vt>
+          <<<grid, block, 0, stream>>>(N,
+                                       in_ptr,
+                                       out_ptr,
+                                       index_ptrs,
+                                       sizes,
+                                       strides,
+                                       num_indices,
+                                       offset_calc);
+    } else {
+      funcs::index_elementwise_with_tensor_kernel<nt, vt>
+          <<<grid, block, 0, stream>>>(N, [=] __device__(int idx) {
+            const auto offsets = offset_calc.get(idx);
+            char* const out_data = out_ptr + offsets[0];
+            const char* const in_data = in_ptr + offsets[1];
+
+            int64_t offset = 0;
+#pragma unroll
+            for (int64_t i = 0; i < num_indices; i++) {
+              int64_t index =
+                  *reinterpret_cast<int64_t*>(index_ptrs[i] + offsets[2]);
+              if (index < 0) {
+                index += sizes[i];
+              }
+              offset += index * strides[i];
+            }
+            *reinterpret_cast<dtype*>(out_data + offset) =
+                *reinterpret_cast<const dtype*>(in_data);
+          });
+    }
   }
 }
 
@@ -167,14 +208,15 @@ void IndexElementwiseGetGradKernel(const Context& dev_ctx,
   if (out_grad.numel() == 0) return;
 
   const auto& index_type = index[0]->dtype();
-  PADDLE_ENFORCE_EQ(index_type == phi::DataType::INT64,
-                    true,
-                    common::errors::InvalidArgument(
-                        "Index holds the wrong type, it holds [%s], but "
-                        "desires to be [%s].",
-                        index_type,
-                        phi::DataType::INT32,
-                        phi::DataType::INT64));
+  PADDLE_ENFORCE_EQ(
+      index_type == phi::DataType::INT64 ||
+          (index_type == phi::DataType::BOOL && index.size() == 1),
+      true,
+      common::errors::InvalidArgument(
+          "Index holds the wrong type, it holds [%s], but "
+          "desires to be [%s] or bool.",
+          index_type,
+          phi::DataType::INT64));
 
   GPUIndexElementwiseGetGrad<T, int64_t>(dev_ctx,
                                          x,

--- a/paddle/phi/kernels/gpu/index_elementwise_get_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_elementwise_get_kernel.cu
@@ -16,11 +16,17 @@
 
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/common/bfloat16.h"
+#include "paddle/phi/common/data_type.h"
+#include "paddle/phi/common/memory_utils.h"
+#include "paddle/phi/core/ddim.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/cast_kernel.h"
+#include "paddle/phi/kernels/cum_kernel.h"
 #include "paddle/phi/kernels/funcs/index_elementwise.cu.h"
 #include "paddle/phi/kernels/funcs/stride_utils.h"
 
 namespace phi {
+
 template <typename T, typename IndexT = int>
 void GPUIndexElementwiseGetKernel(const phi::GPUContext& dev_ctx,
                                   const DenseTensor& input,
@@ -31,80 +37,138 @@ void GPUIndexElementwiseGetKernel(const phi::GPUContext& dev_ctx,
                                   const std::vector<int64_t>& index_stride,
                                   const int64_t slice_offset,
                                   DenseTensor* output) {
-  int64_t numel = 0;
-  int64_t num_indices = 0;
-  std::vector<int64_t> shape_tmp;
-  std::vector<int64_t> stride_tmp;
-  funcs::cal_shape_stride(index_dims, &num_indices, &shape_tmp, &stride_tmp);
+  if (index.size() == 1 && index[0]->dtype() == phi::DataType::BOOL) {
+    PADDLE_ENFORCE_EQ(
+        index[0]->strides(),
+        ::common::make_ddim(index_stride),
+        common::errors::InvalidArgument("Index tensor should be contiguous."));
+    const bool* index_data = index[0]->data<bool>();
+    const T* input_data =
+        input.data<T>() + slice_offset / phi::SizeOf(input.dtype());
+    DenseTensor index_int64 =
+        Cast<bool>(dev_ctx, *index[0], phi::DataType::INT64);
+    DenseTensor prefix_sum_tensor =
+        Cumsum<int64_t>(dev_ctx, index_int64, {}, true, false, false);
+    const int64_t* prefix_sum_data = prefix_sum_tensor.data<int64_t>();
 
-  auto index_ptrs = funcs::GetIndexDataPtrs<IndexT>(index);
+    int64_t numel = index[0]->numel();
+    int64_t true_count = 0;
+    memory_utils::Copy(phi::CPUPlace(),
+                       &true_count,
+                       phi::GPUPlace(),
+                       &prefix_sum_tensor.data<int64_t>()[numel - 1],
+                       sizeof(int64_t),
+                       dev_ctx.stream());
+    dev_ctx.Wait();
 
-  auto sizes = std::array<int64_t, DDim::kMaxRank>{};
-  auto strides = std::array<int64_t, DDim::kMaxRank>{};
+    output->Resize(common::make_ddim({true_count}));
+    dev_ctx.template Alloc<T>(output);
+    T* output_data = output->data<T>();
 
-  for (int64_t i = 0; i < num_indices; i++) {
-    sizes[i] = index_dims[i];
-    strides[i] = index_stride[i];
-  }
+    if (true_count == 0) {
+      return;
+    }
 
-  std::array<int64_t*, 3> strides_array;
-  std::vector<int64_t> desired_shape;
-  std::array<std::vector<int64_t>, 3> strides_vec;
+    auto reverse_shape = std::vector(input_dims.rbegin(), input_dims.rend());
 
-  funcs::IndexGetStride<3>(input_dims,
-                           input_strides,
-                           phi::SizeOf(input.dtype()),
-                           std::vector<int64_t>(),
-                           std::vector<int64_t>(),
-                           phi::SizeOf(input.dtype()),
-                           shape_tmp,
-                           stride_tmp,
-                           phi::SizeOf(index[0]->dtype()),
-                           &desired_shape,
-                           &strides_array,
-                           &numel,
-                           strides_vec);
-  auto offset_calc =
-      funcs::make_offset_calculator_put<3>(desired_shape, strides_array);
+    auto offset_calc = funcs::make_offset_calculator<1>(
+        static_cast<int32_t>(input_dims.size()),
+        reverse_shape.data(),
+        {
+            {input_strides.rbegin(), input_strides.rend()},
+        });
 
-  const int64_t N = output->numel();
-  PADDLE_ENFORCE_GE(
-      N, 0, common::errors::InvalidArgument("Output numel must >= 0"));
-  PADDLE_ENFORCE_LE(
-      N,
-      std::numeric_limits<int32_t>::max(),
-      common::errors::InvalidArgument("Output numel must <= INT32_MAX"));
-  constexpr int nt = 128;
-  constexpr int vt = 4;
-  const dim3 block(nt);
-  const dim3 grid((N + block.x * vt - 1) / (block.x * vt));
-  auto stream = dev_ctx.stream();
-
-  using dtype = funcs::OpaqueType<sizeof(T)>;
-
-  const char* in_ptr =
-      reinterpret_cast<const char*>(input.data<T>()) + slice_offset;
-  char* out_ptr = reinterpret_cast<char*>(output->data<T>());
-  funcs::index_elementwise_with_tensor_kernel<nt, vt>
-      <<<grid, block, 0, stream>>>(N, [=] __device__(int idx) {
-        const auto offsets = offset_calc.get(idx);
-        char* const out_data = out_ptr + offsets[0];
-        const char* const in_data = in_ptr + offsets[1];
-
-        int64_t offset = 0;
-#pragma unroll
-        for (int64_t i = 0; i < num_indices; i++) {
-          int64_t index =
-              *reinterpret_cast<int64_t*>(index_ptrs[i] + offsets[2]);
-          if (index < 0) {
-            index += sizes[i];
+    constexpr int nt = 128;
+    constexpr int vt = 4;
+    const dim3 block(nt);
+    auto stream = dev_ctx.stream();
+    const dim3 grid((numel + block.x * vt - 1) / (block.x * vt));
+    funcs::index_elementwise_with_tensor_kernel<nt, vt>
+        <<<grid, block, 0, stream>>>(numel, [=] __device__(int idx) {
+          const auto offset = offset_calc.get(idx)[0];
+          if (index_data[idx]) {
+            int64_t index = prefix_sum_data[idx] - 1;  // 0-based index
+            output_data[index] = input_data[offset];
           }
-          offset += index * strides[i];
-        }
+        });
+    return;
 
-        *reinterpret_cast<dtype*>(out_data) =
-            *reinterpret_cast<const dtype*>(in_data + offset);
-      });
+  } else {
+    int64_t numel = 0;
+    int64_t num_indices = 0;
+    std::vector<int64_t> shape_tmp;
+    std::vector<int64_t> stride_tmp;
+    funcs::cal_shape_stride(index_dims, &num_indices, &shape_tmp, &stride_tmp);
+
+    auto index_ptrs = funcs::GetIndexDataPtrs<IndexT>(index);
+
+    auto sizes = std::array<int64_t, DDim::kMaxRank>{};
+    auto strides = std::array<int64_t, DDim::kMaxRank>{};
+
+    for (int64_t i = 0; i < num_indices; i++) {
+      sizes[i] = index_dims[i];
+      strides[i] = index_stride[i];
+    }
+
+    std::array<int64_t*, 3> strides_array;
+    std::vector<int64_t> desired_shape;
+    std::array<std::vector<int64_t>, 3> strides_vec;
+
+    funcs::IndexGetStride<3>(input_dims,
+                             input_strides,
+                             phi::SizeOf(input.dtype()),
+                             std::vector<int64_t>(),
+                             std::vector<int64_t>(),
+                             phi::SizeOf(input.dtype()),
+                             shape_tmp,
+                             stride_tmp,
+                             phi::SizeOf(index[0]->dtype()),
+                             &desired_shape,
+                             &strides_array,
+                             &numel,
+                             strides_vec);
+    auto offset_calc =
+        funcs::make_offset_calculator_put<3>(desired_shape, strides_array);
+
+    const int64_t N = output->numel();
+    PADDLE_ENFORCE_GE(
+        N, 0, common::errors::InvalidArgument("Output numel must >= 0"));
+    PADDLE_ENFORCE_LE(
+        N,
+        std::numeric_limits<int32_t>::max(),
+        common::errors::InvalidArgument("Output numel must <= INT32_MAX"));
+    constexpr int nt = 128;
+    constexpr int vt = 4;
+    const dim3 block(nt);
+    const dim3 grid((N + block.x * vt - 1) / (block.x * vt));
+    auto stream = dev_ctx.stream();
+
+    using dtype = funcs::OpaqueType<sizeof(T)>;
+
+    const char* in_ptr =
+        reinterpret_cast<const char*>(input.data<T>()) + slice_offset;
+    char* out_ptr = reinterpret_cast<char*>(output->data<T>());
+    funcs::index_elementwise_with_tensor_kernel<nt, vt>
+        <<<grid, block, 0, stream>>>(N, [=] __device__(int idx) {
+          const auto offsets = offset_calc.get(idx);
+          char* const out_data = out_ptr + offsets[0];
+          const char* const in_data = in_ptr + offsets[1];
+
+          int64_t offset = 0;
+#pragma unroll
+          for (int64_t i = 0; i < num_indices; i++) {
+            int64_t index =
+                *reinterpret_cast<int64_t*>(index_ptrs[i] + offsets[2]);
+            if (index < 0) {
+              index += sizes[i];
+            }
+            offset += index * strides[i];
+          }
+
+          *reinterpret_cast<dtype*>(out_data) =
+              *reinterpret_cast<const dtype*>(in_data + offset);
+        });
+  }
 }
 
 template <typename T, typename Context>
@@ -119,13 +183,15 @@ void IndexElementwiseGetKernel(const Context& dev_ctx,
                                const bool accumulate,
                                DenseTensor* out) {
   const auto& index_type = index[0]->dtype();
-  PADDLE_ENFORCE_EQ(index_type == phi::DataType::INT64,
-                    true,
-                    common::errors::InvalidArgument(
-                        "Index holds the wrong type, it holds [%s], but "
-                        "desires to be [%s].",
-                        index_type,
-                        phi::DataType::INT64));
+  PADDLE_ENFORCE_EQ(
+      index_type == phi::DataType::INT64 ||
+          (index_type == phi::DataType::BOOL && index.size() == 1),
+      true,
+      common::errors::InvalidArgument(
+          "Index holds the wrong type, it holds [%s], but "
+          "desires to be [%s] or bool.",
+          index_type,
+          phi::DataType::INT64));
 
   auto out_dims = out->dims();
   if (out_dims.size() > 0) {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
pcard-67164

- 由于 bool 索引进入 index_elementwise_get 之前会经过 non-zero，带来性能开销，因此对index_elementwise_get kernel进行扩展，使之支持 bool 索引。

