### PR TITLE
[0-size Tensor No.87、214]Add 0-size Tensor support for paddle.incubate.nn.functional. fused_rotary_position_embedding 、scaled_dot_product_attention

### DIFF
--- a/paddle/phi/infermeta/fusion.cc
+++ b/paddle/phi/infermeta/fusion.cc
@@ -4508,6 +4508,20 @@ void VariableLengthMemoryEfficientAttentionInferMeta(
                     true,
                     common::errors::InvalidArgument(
                         "The seq length of Key, Value should be equal."));
+  if (mask) {
+    PADDLE_ENFORCE_EQ(
+        mask.dims().size(),
+        4,
+        common::errors::InvalidArgument("Mask should be a 4-D tensor"
+                                        "But received Value dimension(%s)",
+                                        mask.dims().size()));
+    const int64_t mask_batch_size = mask.dims()[0];
+    PADDLE_ENFORCE_EQ(
+        query_batch_size == mask_batch_size,
+        true,
+        common::errors::InvalidArgument(
+            "The batch size of Query, Key, Value and Mask should be equal."));
+  }
 
   std::vector<int64_t> out_dims(
       {query_batch_size, query_num_head, query_seq_length, value_head_size});

--- a/paddle/phi/kernels/fusion/cutlass/variable_length_memory_efficient_attention_kernel.cu
+++ b/paddle/phi/kernels/fusion/cutlass/variable_length_memory_efficient_attention_kernel.cu
@@ -67,7 +67,8 @@ void MultiHeadAttentionVariableForwardKernel(
   params.causal = causal;
   params.pre_cache_length = pre_cache_length;
 
-  if (mask) {
+  // if the mask is 0-size tensor, we don't need to set mask_ptr
+  if (mask && mask.get().numel() > 0) {
     // [B, 1, S, D]
     auto mask_tensor = mask.get();
     int64_t mask_num_heads = mask_tensor.dims()[1];

--- a/paddle/phi/kernels/fusion/gpu/fused_rope_grad_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/fused_rope_grad_kernel.cu
@@ -38,8 +38,10 @@ void FusedRopeGradKernel(const Context& dev_ctx,
                          DenseTensor* dk,
                          DenseTensor* dv) {
   int64_t numel = dout_q.numel();
-  if (numel <= 0) return;
   dev_ctx.template Alloc<T>(dq);
+  if (dout_k) dev_ctx.template Alloc<T>(dk);
+  if (dout_v) dev_ctx.template Alloc<T>(dv);
+  if (numel <= 0) return;
 
   phi::Array<int64_t, 3> inputs_num_heads;
   // small size for broadcast
@@ -70,22 +72,19 @@ void FusedRopeGradKernel(const Context& dev_ctx,
   outs_data[0] = dq->data<T>();
   int num_inputs = 1;
 
-  if (dout_k) {
-    dev_ctx.template Alloc<T>(dk);
+  if (dk->numel() > 0) {
     outs_data[num_inputs] = dk->data<T>();
     ins_data[num_inputs] = dout_k->data<T>();
     inputs_num_heads[num_inputs] = dk->dims()[2];
     num_inputs++;
   }
 
-  if (dout_v) {
-    dev_ctx.template Alloc<T>(dv);
+  if (dv->numel() > 0) {
     outs_data[num_inputs] = dv->data<T>();
     ins_data[num_inputs] = dout_v->data<T>();
     inputs_num_heads[num_inputs] = dv->dims()[2];
     num_inputs++;
   }
-
   using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
   MPType div_c = static_cast<MPType>(1.0f / head_dim);
 

--- a/paddle/phi/kernels/fusion/gpu/fused_rope_grad_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/fused_rope_grad_kernel.cu
@@ -72,14 +72,14 @@ void FusedRopeGradKernel(const Context& dev_ctx,
   outs_data[0] = dq->data<T>();
   int num_inputs = 1;
 
-  if (dk->numel() > 0) {
+  if (dk && dk->numel() > 0) {
     outs_data[num_inputs] = dk->data<T>();
     ins_data[num_inputs] = dout_k->data<T>();
     inputs_num_heads[num_inputs] = dk->dims()[2];
     num_inputs++;
   }
 
-  if (dv->numel() > 0) {
+  if (dv && dv->numel() > 0) {
     outs_data[num_inputs] = dv->data<T>();
     ins_data[num_inputs] = dout_v->data<T>();
     inputs_num_heads[num_inputs] = dv->dims()[2];

--- a/paddle/phi/kernels/fusion/gpu/fused_rope_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/fused_rope_kernel.cu
@@ -38,8 +38,10 @@ void FusedRopeKernel(const Context& dev_ctx,
                      DenseTensor* out_k,
                      DenseTensor* out_v) {
   int64_t numel = q.numel();
-  if (numel <= 0) return;
   dev_ctx.template Alloc<T>(out_q);
+  if (k) dev_ctx.template Alloc<T>(out_k);
+  if (v) dev_ctx.template Alloc<T>(out_v);
+  if (numel <= 0) return;
 
   phi::Array<int64_t, 3> inputs_num_heads;
 
@@ -73,16 +75,13 @@ void FusedRopeKernel(const Context& dev_ctx,
   outs_data[0] = out_q->data<T>();
   int num_inputs = 1;
 
-  if (k) {
-    dev_ctx.template Alloc<T>(out_k);
+  if (out_k->numel() > 0) {
     ins_data[num_inputs] = k->data<T>();
     outs_data[num_inputs] = out_k->data<T>();
     inputs_num_heads[num_inputs] = k->dims()[2];
     num_inputs++;
   }
-
-  if (v) {
-    dev_ctx.template Alloc<T>(out_v);
+  if (out_v->numel() > 0) {
     ins_data[num_inputs] = v->data<T>();
     outs_data[num_inputs] = out_v->data<T>();
     inputs_num_heads[num_inputs] = v->dims()[2];

--- a/paddle/phi/kernels/fusion/gpu/fused_rope_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/fused_rope_kernel.cu
@@ -75,13 +75,13 @@ void FusedRopeKernel(const Context& dev_ctx,
   outs_data[0] = out_q->data<T>();
   int num_inputs = 1;
 
-  if (out_k->numel() > 0) {
+  if (out_k && out_k->numel() > 0) {
     ins_data[num_inputs] = k->data<T>();
     outs_data[num_inputs] = out_k->data<T>();
     inputs_num_heads[num_inputs] = k->dims()[2];
     num_inputs++;
   }
-  if (out_v->numel() > 0) {
+  if (out_v && out_v->numel() > 0) {
     ins_data[num_inputs] = v->data<T>();
     outs_data[num_inputs] = out_v->data<T>();
     inputs_num_heads[num_inputs] = v->dims()[2];

--- a/paddle/phi/kernels/gpu/flash_attn_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/flash_attn_grad_kernel.cu
@@ -927,6 +927,18 @@ void FlashAttnGradKernel(const Context& dev_ctx,
   if (dv) {
     dev_ctx.template Alloc<T>(dv);
   }
+  if (dout.numel() == 0) {
+    if (dq)
+      Full<T, Context>(
+          dev_ctx, phi::IntArray(common::vectorize(dq->dims())), 0, dq);
+    if (dk)
+      Full<T, Context>(
+          dev_ctx, phi::IntArray(common::vectorize(dk->dims())), 0, dk);
+    if (dv)
+      Full<T, Context>(
+          dev_ctx, phi::IntArray(common::vectorize(dv->dims())), 0, dv);
+    return;
+  }
   FlashAttnGradBaseKernel<T, Context>(dev_ctx,
                                       q,
                                       k,

--- a/paddle/phi/kernels/gpu/flash_attn_kernel.cu
+++ b/paddle/phi/kernels/gpu/flash_attn_kernel.cu
@@ -633,6 +633,31 @@ void FlashAttnKernel(const Context& dev_ctx,
                      DenseTensor* softmax,
                      DenseTensor* softmax_lse,
                      DenseTensor* seed_offset) {
+  if (q.numel() == 0 || k.numel() == 0 || v.numel() == 0) {
+    if (out) {
+      Full<T, Context>(
+          dev_ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
+    }
+    if (softmax) {
+      Full<T, Context>(dev_ctx,
+                       phi::IntArray(common::vectorize(softmax->dims())),
+                       0,
+                       softmax);
+    }
+    if (softmax_lse) {
+      Full<T, Context>(dev_ctx,
+                       phi::IntArray(common::vectorize(softmax_lse->dims())),
+                       0,
+                       softmax_lse);
+    }
+    if (seed_offset) {
+      Full<T, Context>(dev_ctx,
+                       phi::IntArray(common::vectorize(seed_offset->dims())),
+                       0,
+                       seed_offset);
+    }
+    return;
+  }
   FlashAttnBaseKernel<T, Context>(dev_ctx,
                                   q,
                                   k,

--- a/test/legacy_test/test_scaled_dot_product_attention.py
+++ b/test/legacy_test/test_scaled_dot_product_attention.py
@@ -220,5 +220,14 @@ class TestAttentionWith3DInput(unittest.TestCase):
         np.testing.assert_allclose(out.numpy(), out_ref, rtol=5e-03, atol=1e-03)
 
 
+class TestAttentionWithBoolMaskZeroSize(TestAttentionWithBoolMask):
+    def setUp(self):
+        self.place = paddle.CUDAPlace(0)
+        self.shape = (0, 1, 8, 8)
+        self.dtype = 'float32'
+        self.dropout = 0.0
+        self.causal = False
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

- 修复fused_rotary_position_embedding
修复rope部分返回tensor 没有holder
- 修复scaled_dot_product_attention
flash_atten 支持0-size Tensor
- 修复variable_length_memory_efficient_attention
mask为0-size时可能引发段错误

pcard-67164
