### PR TITLE
[BIG tensor] 修复paddle.nansum/nanmean梯度计算

### DIFF
--- a/paddle/phi/kernels/gpu/where_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/where_grad_kernel.cu
@@ -22,8 +22,7 @@ namespace phi {
 template <typename T, typename IndexT>
 __global__ void WhereGradCUDAKernel(
     const IndexT N, const T* dout, const bool* cond, T* dx, T* dy) {
-  IndexT idx = blockDim.x * blockIdx.x + threadIdx.x;
-  for (; idx < N; idx += blockDim.x * gridDim.x) {
+  CUDA_KERNEL_LOOP_TYPE(idx, N, IndexT) {
     if (dx != nullptr) {
       dx[idx] = cond[idx] ? dout[idx] : static_cast<T>(0.);
     }


### PR DESCRIPTION
### PR Category
Operator Mechanism


### PR Types
 Bug fixes


### Description
Pcard-67164
paddle.nansum/nanmean梯度计算hang住，修改WhereGradCUDAKernel，改用CUDA_KERNEL_LOOP_TYPE宏
