### PR TITLE
[0-size Tensor Retest] fix pool3d and adaptive_pool3d for 0-size

### DIFF
--- a/paddle/phi/kernels/gpudnn/pool_kernel.cu
+++ b/paddle/phi/kernels/gpudnn/pool_kernel.cu
@@ -305,7 +305,7 @@ void Pool3dGPUDNNKernel(const Context& dev_ctx,
                         const std::string& padding_algorithm,
                         DenseTensor* out) {
   if (x.numel() == 0) {
-    if (pooling_type == "max") {
+    if (pooling_type == "max" || (!adaptive && pooling_type == "avg")) {
       phi::Full<T, Context>(
           dev_ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
     } else {

--- a/paddle/phi/kernels/impl/pool_kernel_impl.h
+++ b/paddle/phi/kernels/impl/pool_kernel_impl.h
@@ -389,7 +389,7 @@ void Pool3dKernel(const Context& dev_ctx,
                   const std::string& padding_algorithm,
                   DenseTensor* out) {
   if (x.numel() == 0) {
-    if (pooling_type == "max") {
+    if (pooling_type == "max" || (!adaptive && pooling_type == "avg")) {
       phi::Full<T, Context>(
           dev_ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
     } else {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
由于avg_pool3d和adaptive_avg_pool3d共用一个Pool3dKernel，当输入为0size时，两个函数的返回填充值竟然不相同，在前面修复的时候，导致修了其中一个另一个就报错，所以需要在Pool3dKernel中分别对avg_pool3d和adaptive_avg_pool3d进行不同的填充返回（可以通过adaptive 参数进行区分）。

avg_pool3d测试结果：
<img width="1580" height="160" alt="image" src="https://github.com/user-attachments/assets/e5c3ac09-803a-4ffe-abbd-0db0fe728e62" />

adaptive_avg_pool3d测试结果：
<img width="1406" height="220" alt="image" src="https://github.com/user-attachments/assets/3852d4e4-13ee-4142-b24b-ae04682f6e59" />

pcard-67164