### PR TITLE
[CppExtension] Auto define `PADDLE_EXTENSION_NAME` macro

### DIFF
--- a/python/paddle/utils/cpp_extension/cpp_extension.py
+++ b/python/paddle/utils/cpp_extension/cpp_extension.py
@@ -32,6 +32,7 @@ from .extension_utils import (
     find_ccache_home,
     find_rocm_home,
     normalize_extension_kwargs,
+    define_paddle_extension_name,
 )
 from .extension_utils import (
     is_cuda_file,
@@ -438,6 +439,9 @@ class BuildExtension(build_ext):
             self.compiler._cpp_extensions += ['.cu', '.cuh']
             original_compile = self.compiler.compile
             original_spawn = self.compiler.spawn
+
+        for extension in self.extensions:
+            define_paddle_extension_name(extension)
 
         def unix_custom_compile_single_file(
             self, obj, src, ext, cc_args, extra_postargs, pp_opts

--- a/python/paddle/utils/cpp_extension/extension_utils.py
+++ b/python/paddle/utils/cpp_extension/extension_utils.py
@@ -944,6 +944,14 @@ def add_compile_flag(extra_compile_args, flags):
         extra_compile_args.extend(flags)
 
 
+def define_paddle_extension_name(extension):
+    # Allow user use PADDLE_EXTENSION_NAME to access shared library name
+    names = extension.name.split('.')
+    name = names[-1]
+    define = f'-DPADDLE_EXTENSION_NAME={name}'
+    add_compile_flag(extension.extra_compile_args, [define])
+
+
 def is_cuda_file(path):
     cuda_suffix = {'.cu'}
     items = os.path.splitext(path)

--- a/test/cpp_extension/custom_extension.cc
+++ b/test/cpp_extension/custom_extension.cc
@@ -60,7 +60,7 @@ paddle::optional<paddle::Tensor> optional_tensor(bool return_option = false) {
   return t;
 }
 
-PYBIND11_MODULE(custom_cpp_extension, m) {
+PYBIND11_MODULE(PADDLE_EXTENSION_NAME, m) {
   m.def("custom_add", &custom_add, "exp(x) + exp(y)");
   m.def("custom_optional_add", &custom_optional_add, "exp(x) + optional(y)");
   m.def("custom_sub", &custom_sub, "exp(x) - exp(y)");


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Improvements

### Description
<!-- Describe what you’ve done -->

允许用户使用宏 `PADDLE_EXTENSION_NAME` 来获取 extension 的 name

<!-- PCard-66972 -->