### PR TITLE
[slice]add IndexPutWithSortKernel in index_elementwise_get_grad slice…

### DIFF
--- a/paddle/fluid/pybind/slice_utils.h
+++ b/paddle/fluid/pybind/slice_utils.h
@@ -1240,6 +1240,11 @@ static void ApplyGetitem(const int index_size,
                     &transed_index_int64);
 
       AdvancedIndex ad = AdvancedIndex(*transed_tensor, transed_index_int64);
+      // is_combined:
+      //   Distinguishes between regular indexing (single index) and combined
+      //   indexing (multiple indices). When false (single index case), enables
+      //   optimized backward pass using IndexPutWithSortKernel for better
+      //   performance.
       const bool is_combined = (index_size == 1) ? false : true;
       const bool accumulate = true;
       *out = index_elementwise_get_ad_func(*self_tensor,

--- a/paddle/fluid/pybind/slice_utils.h
+++ b/paddle/fluid/pybind/slice_utils.h
@@ -782,6 +782,7 @@ static paddle::Tensor getValueForBoolTensor(const paddle::Tensor& tensor,
     }
 
     AdvancedIndex ad = AdvancedIndex(tensor, indices_int64);
+    const bool is_combined = false;
     const bool accumulate = false;
 
     return index_elementwise_get_ad_func(tensor,
@@ -791,7 +792,8 @@ static paddle::Tensor getValueForBoolTensor(const paddle::Tensor& tensor,
                                          ad.indexed_sizes,
                                          ad.indexed_strides,
                                          slice_offset,
-                                         accumulate);
+                                         accumulate,
+                                         is_combined);
   } else {
     if (bool_index.shape().size() == 1)
       return gather_ad_func(tensor, bool_2_idx);
@@ -1238,23 +1240,17 @@ static void ApplyGetitem(const int index_size,
                     &transed_index_int64);
 
       AdvancedIndex ad = AdvancedIndex(*transed_tensor, transed_index_int64);
-      if (index_size == 1) {
-        paddle::Tensor flattened_tensor =
-            flatten_ad_func((*transed_index)[0], 0, -1);
-        *out = gather_ad_func(*transed_tensor, flattened_tensor);
-        *out = reshape_ad_func(*out, ad.src_sizes);
-      } else {
-        const bool accumulate = true;
-        *out = index_elementwise_get_ad_func(*self_tensor,
-                                             ad.indices,
-                                             ad.src_sizes,
-                                             ad.src_strides,
-                                             ad.indexed_sizes,
-                                             ad.indexed_strides,
-                                             slice_offset,
-                                             accumulate);
-      }
-
+      const bool is_combined = (index_size == 1) ? false : true;
+      const bool accumulate = true;
+      *out = index_elementwise_get_ad_func(*self_tensor,
+                                           ad.indices,
+                                           ad.src_sizes,
+                                           ad.src_strides,
+                                           ad.indexed_sizes,
+                                           ad.indexed_strides,
+                                           slice_offset,
+                                           accumulate,
+                                           is_combined);
       return;
     } else {
       paddle::Tensor transed_advanced_index_tensor;

--- a/paddle/phi/infermeta/backward.cc
+++ b/paddle/phi/infermeta/backward.cc
@@ -2168,6 +2168,7 @@ void IndexElementwiseGetGradInferMeta(
     const std::vector<int64_t>& index_strides,
     const int64_t slice_offset,
     const bool accumulate,
+    const bool is_combined,
     MetaTensor* x_grad) {
   if (x_grad) {
     x_grad->share_meta(x);

--- a/paddle/phi/infermeta/backward.h
+++ b/paddle/phi/infermeta/backward.h
@@ -788,5 +788,6 @@ void IndexElementwiseGetGradInferMeta(
     const std::vector<int64_t>& index_strides,
     const int64_t slice_offset,
     const bool accumulate,
+    const bool is_combined,
     MetaTensor* x_grad);
 }  // namespace phi

--- a/paddle/phi/infermeta/binary.cc
+++ b/paddle/phi/infermeta/binary.cc
@@ -2599,6 +2599,7 @@ void IndexElementwiseGetInferMeta(const MetaTensor& x,
                                   const std::vector<int64_t>& index_stride,
                                   const int64_t slice_offset,
                                   const bool accumulate,
+                                  const bool is_combined,
                                   MetaTensor* out) {
   out->set_dims(common::make_ddim(input_dims));
   out->set_dtype(x.dtype());

--- a/paddle/phi/infermeta/binary.h
+++ b/paddle/phi/infermeta/binary.h
@@ -493,6 +493,7 @@ void IndexElementwiseGetInferMeta(const MetaTensor& x,
                                   const std::vector<int64_t>& index_stride,
                                   const int64_t slice_offset,
                                   const bool accumulate,
+                                  const bool is_combined,
                                   MetaTensor* out);
 
 void KronInferMeta(const MetaTensor& x, const MetaTensor& y, MetaTensor* out);

--- a/paddle/phi/kernels/cpu/index_elementwise_get_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_elementwise_get_grad_kernel.cc
@@ -131,6 +131,7 @@ void IndexElementwiseGetGradKernel(const Context& dev_ctx,
                                    const std::vector<int64_t>& index_strides,
                                    const int64_t slice_offset,
                                    const bool accumulate,
+                                   const bool is_combined,
                                    DenseTensor* x_grad) {
   dev_ctx.template Alloc<T>(x_grad);
   auto dxt = phi::EigenVector<T>::Flatten(*x_grad);

--- a/paddle/phi/kernels/cpu/index_elementwise_get_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_elementwise_get_kernel.cc
@@ -100,6 +100,7 @@ void IndexElementwiseGetKernel(const Context& dev_ctx,
                                const std::vector<int64_t>& index_stride,
                                const int64_t slice_offset,
                                const bool accumulate,
+                               const bool is_combined,
                                DenseTensor* out) {
   const auto& index_type = index[0]->dtype();
   PADDLE_ENFORCE_EQ(index_type == phi::DataType::INT64,

--- a/paddle/phi/kernels/funcs/radix_sort.cu
+++ b/paddle/phi/kernels/funcs/radix_sort.cu
@@ -18,8 +18,8 @@
 namespace phi {
 namespace funcs {
 
+#ifdef PADDLE_WITH_CUDA
 namespace {
-
 template <typename T>
 struct CudaType {
   using type = T;
@@ -113,5 +113,6 @@ INSTANTIATE_SORT_PAIRS(int64_t, 4)
 INSTANTIATE_SORT_PAIRS(int32_t, 8)
 INSTANTIATE_SORT_PAIRS(int64_t, 8)
 
+#endif
 }  // namespace funcs
 }  // namespace phi

--- a/paddle/phi/kernels/funcs/radix_sort.cu
+++ b/paddle/phi/kernels/funcs/radix_sort.cu
@@ -1,0 +1,117 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/phi/kernels/funcs/radix_sort.h"
+#include "paddle/phi/common/memory_utils.h"
+
+namespace phi {
+namespace funcs {
+
+namespace {
+
+template <typename T>
+struct CudaType {
+  using type = T;
+};
+
+template <>
+struct CudaType<int64_t> {
+  using type = long long;  // NOLINT
+};
+
+#define PADDLE_CUB_WRAPPER(func, ...)                                     \
+  do {                                                                    \
+    size_t temp_storage_bytes = 0;                                        \
+    func(nullptr, temp_storage_bytes, __VA_ARGS__);                       \
+    auto temp_storage =                                                   \
+        phi::memory_utils::Alloc(dev_ctx.GetPlace(), temp_storage_bytes); \
+    func(temp_storage->ptr(), temp_storage_bytes, __VA_ARGS__);           \
+  } while (0)
+
+}  // namespace
+
+template <typename key_t, int value_size>
+void RadixSortPairsImpl(const phi::GPUContext& dev_ctx,
+                        const key_t* keys_in,
+                        key_t* keys_out,
+                        const OpaqueTypeRadix<value_size>* values_in,
+                        OpaqueTypeRadix<value_size>* values_out,
+                        int64_t n,
+                        bool descending,
+                        int64_t begin_bit,
+                        int64_t end_bit) {
+  PADDLE_ENFORCE_LE(
+      n,
+      std::numeric_limits<int>::max(),
+      phi::errors::InvalidArgument(
+          "CUB sort does not support sorting more than INT_MAX elements"));
+
+  using key_t_ = typename CudaType<key_t>::type;
+
+  phi::Allocator::AllocationPtr keys_out_owner;
+  if (keys_out == nullptr) {
+    keys_out_owner =
+        phi::memory_utils::Alloc(dev_ctx.GetPlace(), n * sizeof(key_t));
+    keys_out = reinterpret_cast<key_t*>(keys_out_owner->ptr());
+  }
+
+  const key_t_* keys_in_ = reinterpret_cast<const key_t_*>(keys_in);
+  key_t_* keys_out_ = reinterpret_cast<key_t_*>(keys_out);
+
+  if (descending) {
+    PADDLE_CUB_WRAPPER(cub::DeviceRadixSort::SortPairsDescending,
+                       keys_in_,
+                       keys_out_,
+                       values_in,
+                       values_out,
+                       static_cast<int>(n),
+                       begin_bit,
+                       end_bit,
+                       dev_ctx.stream());
+  } else {
+    PADDLE_CUB_WRAPPER(cub::DeviceRadixSort::SortPairs,
+                       keys_in_,
+                       keys_out_,
+                       values_in,
+                       values_out,
+                       static_cast<int>(n),
+                       begin_bit,
+                       end_bit,
+                       dev_ctx.stream());
+  }
+}
+
+#define INSTANTIATE_SORT_PAIRS(key_t, value_size)      \
+  template void RadixSortPairsImpl<key_t, value_size>( \
+      const phi::GPUContext&,                          \
+      const key_t*,                                    \
+      key_t*,                                          \
+      const OpaqueTypeRadix<value_size>*,              \
+      OpaqueTypeRadix<value_size>*,                    \
+      int64_t,                                         \
+      bool,                                            \
+      int64_t,                                         \
+      int64_t);
+
+INSTANTIATE_SORT_PAIRS(int32_t, 1)
+INSTANTIATE_SORT_PAIRS(int32_t, 2)
+INSTANTIATE_SORT_PAIRS(int32_t, 4)
+INSTANTIATE_SORT_PAIRS(int64_t, 1)
+INSTANTIATE_SORT_PAIRS(int64_t, 2)
+INSTANTIATE_SORT_PAIRS(int64_t, 4)
+INSTANTIATE_SORT_PAIRS(int32_t, 8)
+INSTANTIATE_SORT_PAIRS(int64_t, 8)
+
+}  // namespace funcs
+}  // namespace phi

--- a/paddle/phi/kernels/funcs/radix_sort.h
+++ b/paddle/phi/kernels/funcs/radix_sort.h
@@ -1,0 +1,80 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include <cub/cub.cuh>
+#include "paddle/phi/backends/gpu/gpu_context.h"
+#include "paddle/phi/core/dense_tensor.h"
+
+namespace phi {
+namespace funcs {
+
+template <int kValueSize>
+struct OpaqueTypeRadix {
+  uint8_t data[kValueSize];
+  __device__ __host__ OpaqueTypeRadix() = default;
+};
+
+template <typename key_t, int kValueSize>
+void RadixSortPairsImpl(const phi::GPUContext& dev_ctx,
+                        const key_t* keys_in,
+                        key_t* keys_out,
+                        const OpaqueTypeRadix<kValueSize>* values_in,
+                        OpaqueTypeRadix<kValueSize>* values_out,
+                        int64_t n,
+                        bool descending = false,
+                        int64_t begin_bit = 0,
+                        int64_t end_bit = sizeof(key_t) * 8);
+
+template <typename key_t, typename value_t>
+void RadixSortPairs(const phi::GPUContext& dev_ctx,
+                    const key_t* keys_in,
+                    key_t* keys_out,
+                    const value_t* values_in,
+                    value_t* values_out,
+                    int64_t n,
+                    bool descending = false,
+                    int64_t begin_bit = 0,
+                    int64_t end_bit = sizeof(key_t) * 8) {
+  PADDLE_ENFORCE_EQ(
+      std::is_trivially_copyable<value_t>::value,
+      true,
+      phi::errors::InvalidArgument(
+          "RadixSortPairs value type must be trivially copyable"));
+
+  using opaque_t = OpaqueTypeRadix<sizeof(value_t)>;
+  PADDLE_ENFORCE_EQ(
+      sizeof(value_t) <= 8 && (sizeof(value_t) & (sizeof(value_t) - 1)) == 0,
+      true,
+      phi::errors::InvalidArgument(
+          "Unsupported value_t size (must be 1, 2, 4, or 8 bytes)"));
+  PADDLE_ENFORCE_EQ(
+      sizeof(value_t),
+      alignof(value_t),
+      phi::errors::InvalidArgument("Expected value_t to be size-aligned"));
+
+  RadixSortPairsImpl<key_t, sizeof(value_t)>(
+      dev_ctx,
+      keys_in,
+      keys_out,
+      reinterpret_cast<const opaque_t*>(values_in),
+      reinterpret_cast<opaque_t*>(values_out),
+      n,
+      descending,
+      begin_bit,
+      end_bit);
+}
+
+}  // namespace funcs
+}  // namespace phi

--- a/paddle/phi/kernels/funcs/radix_sort.h
+++ b/paddle/phi/kernels/funcs/radix_sort.h
@@ -13,13 +13,16 @@
 // limitations under the License.
 
 #pragma once
+#ifdef PADDLE_WITH_CUDA
 #include <cub/cub.cuh>
+#endif
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/core/dense_tensor.h"
 
 namespace phi {
 namespace funcs {
 
+#ifdef PADDLE_WITH_CUDA
 template <int kValueSize>
 struct OpaqueTypeRadix {
   uint8_t data[kValueSize];
@@ -76,5 +79,6 @@ void RadixSortPairs(const phi::GPUContext& dev_ctx,
       end_bit);
 }
 
+#endif
 }  // namespace funcs
 }  // namespace phi

--- a/paddle/phi/kernels/funcs/stride_utils.h
+++ b/paddle/phi/kernels/funcs/stride_utils.h
@@ -17,10 +17,20 @@
 #include <vector>
 #include "paddle/common/array.h"
 #include "paddle/phi/backends/context_pool.h"
+#include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/common/int_array.h"
 #include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/common/place.h"
 #include "paddle/phi/core/dense_tensor.h"
+#include "paddle/phi/kernels/cast_kernel.h"
+#include "paddle/phi/kernels/elementwise_add_kernel.h"
+#include "paddle/phi/kernels/elementwise_kernel.h"
+#include "paddle/phi/kernels/elementwise_multiply_kernel.h"
+#include "paddle/phi/kernels/expand_kernel.h"
+#include "paddle/phi/kernels/full_kernel.h"
+#include "paddle/phi/kernels/nonzero_kernel.h"
+#include "paddle/phi/kernels/slice_kernel.h"
+#include "paddle/phi/kernels/transpose_kernel.h"
 
 #if defined(__NVCC__) || defined(__HIPCC__)
 #ifdef __NVCC__
@@ -533,5 +543,316 @@ static inline void ScatterAddStride(
   }
   *numel = num;
 }
+
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+
+static inline std::vector<phi::DenseTensor> expandTensors(
+    const phi::GPUContext& dev_ctx,
+    const std::vector<const phi::DenseTensor*>& indices) {
+  std::vector<phi::DenseTensor> result;
+  for (const auto& index : indices) {
+    if (index == nullptr) {
+      result.emplace_back();
+      continue;
+    }
+
+    if (index->dtype() == phi::DataType::BOOL) {
+      phi::DenseTensor bool_2_idx;
+      phi::NonZeroKernel<bool, phi::GPUContext>(dev_ctx, *index, &bool_2_idx);
+
+      for (int j = 0; j < index->dims().size(); ++j) {
+        phi::DenseTensor sliced_tensor;
+        phi::SliceKernel<int64_t, phi::GPUContext>(
+            dev_ctx, bool_2_idx, {1}, {j}, {j + 1}, {1}, {}, &sliced_tensor);
+        result.emplace_back(sliced_tensor);
+      }
+    } else {
+      result.emplace_back(*index);
+    }
+  }
+  return result;
+}
+
+static inline common::DDim infer_size_symdimvector(common::DDim a,
+                                                   common::DDim b) {
+  auto dimsA = a.size();
+  auto dimsB = b.size();
+  auto ndim = dimsA > dimsB ? dimsA : dimsB;
+  common::DDim expandedSizes = common::make_ddim(std::vector<int64_t>(ndim, 0));
+
+  for (int64_t i = ndim - 1; i >= 0; --i) {
+    int64_t offset = ndim - 1 - i;
+    int64_t dimA = dimsA - 1 - offset;
+    int64_t dimB = dimsB - 1 - offset;
+    auto sizeA = (dimA >= 0) ? a[dimA] : 1;
+    auto sizeB = (dimB >= 0) ? b[dimB] : 1;
+
+    PADDLE_ENFORCE_EQ(
+        sizeA == sizeB || sizeA == 1 || sizeB == 1,
+        true,
+        common::errors::Fatal("The size of tensor a (",
+                              sizeA,
+                              ") must match the size of tensor b (",
+                              sizeB,
+                              ") at non-singleton dimension ",
+                              i));
+
+    expandedSizes[i] = sizeA == 1 ? sizeB : sizeA;
+  }
+
+  return expandedSizes;
+}
+
+static inline std::vector<phi::DenseTensor> expand_outplace(
+    const phi::GPUContext& dev_ctx, std::vector<phi::DenseTensor> to_expand) {
+  bool first = true;
+  phi::DDim target_shape;
+  for (size_t i = 0; i < to_expand.size(); ++i) {
+    if (!to_expand[i].initialized()) continue;
+    if (first) {
+      target_shape = to_expand[i].dims();
+      first = false;
+    } else {
+      target_shape = infer_size_symdimvector(target_shape, to_expand[i].dims());
+    }
+  }
+
+  std::vector<phi::DenseTensor> result(to_expand.size());
+  for (size_t i = 0; i < to_expand.size(); ++i) {
+    if (!to_expand[i].initialized()) continue;
+    if (to_expand[i].dims() == target_shape) {
+      result[i] = to_expand[i];
+    } else {
+      phi::ExpandKernel<float, phi::GPUContext>(
+          dev_ctx,
+          to_expand[i],
+          phi::IntArray(common::vectorize<int64_t>(target_shape)),
+          &result[i]);
+    }
+  }
+  return result;
+}
+
+static inline bool hasContiguousSubspace(
+    const std::vector<phi::DenseTensor>& tl) {
+  auto isDefined = [](const phi::DenseTensor& tensor) {
+    return tensor.initialized();
+  };
+  auto isNull = [](const phi::DenseTensor& tensor) {
+    return !tensor.initialized();
+  };
+
+  auto start = std::find_if(tl.begin(), tl.end(), isDefined);
+  auto stop = std::find_if(tl.rbegin(), tl.rend(), isDefined);
+  auto it = std::find_if(start, stop.base(), isNull);
+  return it == stop.base();
+}
+
+template <typename T>
+inline std::
+    tuple<phi::DenseTensor, std::vector<phi::DenseTensor>, std::vector<int64_t>>
+    transposeToFrontAndInvPerm(const phi::GPUContext& dev_ctx,
+                               const phi::DenseTensor& self,
+                               const std::vector<phi::DenseTensor>& indices) {
+  std::vector<int> dims;
+  std::vector<int64_t> inv_perm;
+  std::vector<phi::DenseTensor> transposed_indices;
+  dims.reserve(self.dims().size());
+  inv_perm.resize(self.dims().size());
+
+  for (int64_t i = 0; i < self.dims().size(); ++i) {
+    if (indices[i].initialized()) {
+      dims.push_back(static_cast<int>(i));
+      transposed_indices.emplace_back(indices[i]);
+    }
+  }
+
+  for (int64_t i = 0; i < self.dims().size(); ++i) {
+    if (!indices[i].initialized()) {
+      dims.push_back(static_cast<int>(i));
+      transposed_indices.emplace_back();
+    }
+  }
+
+  for (int64_t i = 0; i < self.dims().size(); ++i) {
+    inv_perm[dims[i]] = i;
+  }
+
+  phi::DenseTensor transposed_self;
+  phi::TransposeKernel<T, phi::GPUContext>(
+      dev_ctx, self, dims, &transposed_self);
+
+  return std::make_tuple(transposed_self, transposed_indices, inv_perm);
+}
+
+static inline std::vector<int64_t> computeLinearStride(
+    const phi::DenseTensor& tensor) {
+  auto sizes = phi::vectorize<int64_t>(tensor.dims());
+  std::vector<int64_t> stride(sizes.size());
+  if (stride.empty()) {
+    return stride;
+  }
+  stride.back() = 1;
+  std::partial_sum(sizes.rbegin(),
+                   sizes.rend() - 1,
+                   stride.rbegin() + 1,
+                   std::multiplies<int64_t>());
+  return stride;
+}
+
+static inline phi::DenseTensor wrapIndexOnce(const phi::GPUContext& dev_ctx,
+                                             const phi::DenseTensor& index,
+                                             int64_t dim,
+                                             int64_t dim_size,
+                                             bool check_range) {
+  phi::DenseTensor dim_size_tensor;
+  dim_size_tensor.Resize(index.dims());
+  dev_ctx.Alloc<int64_t>(&dim_size_tensor);
+
+  auto* dim_size_data = dim_size_tensor.data<int64_t>();
+  auto numel = index.numel();
+  std::vector<int64_t> host_data(numel, dim_size);
+  phi::memory_utils::Copy(dev_ctx.GetPlace(),
+                          dim_size_data,
+                          CPUPlace(),
+                          host_data.data(),
+                          numel * sizeof(int64_t),
+                          dev_ctx.stream());
+
+  return phi::Remainder<int64_t>(dev_ctx, index, dim_size_tensor);
+}
+
+static inline std::tuple<phi::DenseTensor, int64_t, int64_t, int64_t>
+computeLinearIndex(const phi::GPUContext& dev_ctx,
+                   const phi::DenseTensor& src,
+                   const std::vector<phi::DenseTensor>& indices,
+                   bool check_range) {
+  std::vector<int64_t> strides = computeLinearStride(src);
+  phi::DenseTensor linearIndex;
+  int64_t nElemBefore = 1, nElemAfter = 1, strideBefore = 0;
+
+  for (int64_t i = 0; i < src.dims().size(); ++i) {
+    if (indices[i].initialized()) {
+      auto wrapped_index =
+          wrapIndexOnce(dev_ctx, indices[i], i, src.dims()[i], check_range);
+
+      auto strides_tensor = phi::Full<int64_t, phi::GPUContext>(
+          dev_ctx,
+          common::vectorize<int64_t>(wrapped_index.dims()),
+          phi::Scalar(strides[i]));
+
+      auto scaled_index = phi::Multiply<int64_t, phi::GPUContext>(
+          dev_ctx, wrapped_index, strides_tensor);
+
+      if (linearIndex.initialized()) {
+        phi::AddKernel<int64_t, phi::GPUContext>(
+            dev_ctx, linearIndex, scaled_index, &linearIndex);
+      } else {
+        linearIndex = scaled_index;
+        if (i > 0) {
+          strideBefore = src.strides()[i - 1];
+        }
+      }
+    } else if (linearIndex.initialized()) {
+      nElemAfter *= src.dims()[i];
+    } else {
+      nElemBefore *= src.dims()[i];
+    }
+  }
+
+  return std::make_tuple(
+      std::move(linearIndex), nElemBefore, strideBefore, nElemAfter);
+}
+
+template <typename T>
+static inline std::tuple<DenseTensor,
+                         DenseTensor,
+                         int64_t,
+                         int64_t,
+                         int64_t,
+                         std::vector<int64_t>>
+makeLinearIndex(const phi::GPUContext& dev_ctx,
+                const DenseTensor& self,
+                const std::vector<const DenseTensor*>& orig,
+                bool check_range) {
+  auto indices = expandTensors(dev_ctx, orig);
+  for (auto& idx : indices) {
+    if (idx.initialized() && idx.dtype() == phi::DataType::INT32) {
+      idx = phi::Cast<int32_t, phi::GPUContext>(
+          dev_ctx, idx, phi::DataType::INT64);
+    }
+  }
+  indices = expand_outplace(dev_ctx, std::move(indices));
+
+  while (indices.size() < static_cast<size_t>(self.dims().size())) {
+    indices.emplace_back();
+  }
+
+  std::vector<int64_t> inverse_perm;
+  DenseTensor transposed_self = self;
+  std::vector<phi::DenseTensor> transposed_indices;
+  std::vector<int64_t> inv_perm;
+  if (!hasContiguousSubspace(indices)) {
+    auto [tmp_self, tmp_indices, tmp_perm] =
+        transposeToFrontAndInvPerm<T>(dev_ctx, self, indices);
+    transposed_self = std::move(tmp_self);
+    transposed_indices = std::move(tmp_indices);
+    inv_perm = std::move(tmp_perm);
+  } else {
+    transposed_indices = indices;
+  }
+
+  auto [linear_index, n_elem_before, stride_before, n_elem_after] =
+      computeLinearIndex(
+          dev_ctx, transposed_self, transposed_indices, check_range);
+
+  return std::make_tuple(linear_index,
+                         transposed_self,
+                         n_elem_before,
+                         stride_before,
+                         n_elem_after,
+                         inv_perm);
+}
+
+inline bool are_expandable(const std::vector<int64_t>& shape1,
+                           const std::vector<int64_t>& shape2) {
+  size_t ndim1 = shape1.size();
+  size_t ndim2 = shape2.size();
+  size_t ndim = std::min(ndim1, ndim2);
+
+  for (int64_t i = static_cast<int64_t>(ndim) - 1; i >= 0; --i) {
+    auto dim1 = shape1[--ndim1];
+    auto dim2 = shape2[--ndim2];
+    if (dim1 == dim2 || dim1 == 1 || dim2 == 1) {
+      continue;
+    }
+    return false;
+  }
+  return true;
+}
+
+inline int64_t LargestIndex(const phi::DenseTensor& tensor) {
+  int64_t result = 0;
+  const auto& dims = tensor.dims();
+  const auto& strides = tensor.strides();
+
+  for (int i = 0; i < dims.size(); ++i) {
+    result += (dims[i] - 1) * strides[i];
+  }
+  return result;
+}
+
+inline int GetNumBits(uint64_t max_val) {
+  if (max_val == 0) return 1;
+
+  int num_bits = 1;
+  while (max_val > 1) {
+    max_val >>= 1;
+    num_bits++;
+  }
+  return num_bits;
+}
+
+#endif
 }  // namespace funcs
 }  // namespace phi

--- a/paddle/phi/kernels/funcs/stride_utils.h
+++ b/paddle/phi/kernels/funcs/stride_utils.h
@@ -544,35 +544,6 @@ static inline void ScatterAddStride(
   *numel = num;
 }
 
-#if defined(PADDLE_WITH_CUDA)
-
-static inline std::vector<phi::DenseTensor> expandTensors(
-    const phi::GPUContext& dev_ctx,
-    const std::vector<const phi::DenseTensor*>& indices) {
-  std::vector<phi::DenseTensor> result;
-  for (const auto& index : indices) {
-    if (index == nullptr) {
-      result.emplace_back();
-      continue;
-    }
-
-    if (index->dtype() == phi::DataType::BOOL) {
-      phi::DenseTensor bool_2_idx;
-      phi::NonZeroKernel<bool, phi::GPUContext>(dev_ctx, *index, &bool_2_idx);
-
-      for (int j = 0; j < index->dims().size(); ++j) {
-        phi::DenseTensor sliced_tensor;
-        phi::SliceKernel<int64_t, phi::GPUContext>(
-            dev_ctx, bool_2_idx, {1}, {j}, {j + 1}, {1}, {}, &sliced_tensor);
-        result.emplace_back(sliced_tensor);
-      }
-    } else {
-      result.emplace_back(*index);
-    }
-  }
-  return result;
-}
-
 static inline common::DDim infer_size_symdimvector(common::DDim a,
                                                    common::DDim b) {
   auto dimsA = a.size();
@@ -603,6 +574,50 @@ static inline common::DDim infer_size_symdimvector(common::DDim a,
   return expandedSizes;
 }
 
+static inline bool hasContiguousSubspace(
+    const std::vector<phi::DenseTensor>& tl) {
+  auto isDefined = [](const phi::DenseTensor& tensor) {
+    return tensor.initialized();
+  };
+  auto isNull = [](const phi::DenseTensor& tensor) {
+    return !tensor.initialized();
+  };
+
+  auto start = std::find_if(tl.begin(), tl.end(), isDefined);
+  auto stop = std::find_if(tl.rbegin(), tl.rend(), isDefined);
+  auto it = std::find_if(start, stop.base(), isNull);
+  return it == stop.base();
+}
+
+#if defined(PADDLE_WITH_CUDA)
+
+static inline std::vector<phi::DenseTensor> expandTensors(
+    const phi::GPUContext& dev_ctx,
+    const std::vector<const phi::DenseTensor*>& indices) {
+  std::vector<phi::DenseTensor> result;
+  for (const auto& index : indices) {
+    if (index == nullptr) {
+      result.emplace_back();
+      continue;
+    }
+
+    if (index->dtype() == phi::DataType::BOOL) {
+      phi::DenseTensor bool_2_idx;
+      phi::NonZeroKernel<bool, phi::GPUContext>(dev_ctx, *index, &bool_2_idx);
+
+      for (int j = 0; j < index->dims().size(); ++j) {
+        phi::DenseTensor sliced_tensor;
+        phi::SliceKernel<int64_t, phi::GPUContext>(
+            dev_ctx, bool_2_idx, {1}, {j}, {j + 1}, {1}, {}, &sliced_tensor);
+        result.emplace_back(sliced_tensor);
+      }
+    } else {
+      result.emplace_back(*index);
+    }
+  }
+  return result;
+}
+
 static inline std::vector<phi::DenseTensor> expand_outplace(
     const phi::GPUContext& dev_ctx, std::vector<phi::DenseTensor> to_expand) {
   bool first = true;
@@ -631,21 +646,6 @@ static inline std::vector<phi::DenseTensor> expand_outplace(
     }
   }
   return result;
-}
-
-static inline bool hasContiguousSubspace(
-    const std::vector<phi::DenseTensor>& tl) {
-  auto isDefined = [](const phi::DenseTensor& tensor) {
-    return tensor.initialized();
-  };
-  auto isNull = [](const phi::DenseTensor& tensor) {
-    return !tensor.initialized();
-  };
-
-  auto start = std::find_if(tl.begin(), tl.end(), isDefined);
-  auto stop = std::find_if(tl.rbegin(), tl.rend(), isDefined);
-  auto it = std::find_if(start, stop.base(), isNull);
-  return it == stop.base();
 }
 
 template <typename T>
@@ -814,6 +814,7 @@ makeLinearIndex(const phi::GPUContext& dev_ctx,
                          inv_perm);
 }
 
+#endif
 inline bool are_expandable(const std::vector<int64_t>& shape1,
                            const std::vector<int64_t>& shape2) {
   size_t ndim1 = shape1.size();
@@ -852,7 +853,5 @@ inline int GetNumBits(uint64_t max_val) {
   }
   return num_bits;
 }
-
-#endif
 }  // namespace funcs
 }  // namespace phi

--- a/paddle/phi/kernels/funcs/stride_utils.h
+++ b/paddle/phi/kernels/funcs/stride_utils.h
@@ -544,7 +544,7 @@ static inline void ScatterAddStride(
   *numel = num;
 }
 
-#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+#if defined(PADDLE_WITH_CUDA)
 
 static inline std::vector<phi::DenseTensor> expandTensors(
     const phi::GPUContext& dev_ctx,

--- a/paddle/phi/kernels/gpu/index_elementwise_get_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_elementwise_get_grad_kernel.cu
@@ -156,6 +156,7 @@ void GPUIndexElementwiseGetGrad(const phi::GPUContext& dev_ctx,
   }
 }
 
+#ifdef PADDLE_WITH_CUDA
 #define WARP_SIZE 32
 
 template <typename scalar_t, int SZ>
@@ -372,6 +373,7 @@ void IndexPutWithSortKernel(const phi::GPUContext& dev_ctx,
     }
   }
 }
+#endif
 
 template <typename T, typename Context>
 void IndexElementwiseGetGradKernel(const Context& dev_ctx,
@@ -401,6 +403,7 @@ void IndexElementwiseGetGradKernel(const Context& dev_ctx,
                         phi::DataType::INT64));
 
   if (accumulate && index.size() == 1 && !is_combined) {
+#ifdef PADDLE_WITH_CUDA
     IndexPutWithSortKernel<T, int64_t>(dev_ctx,
                                        x,
                                        out_grad,
@@ -412,19 +415,21 @@ void IndexElementwiseGetGradKernel(const Context& dev_ctx,
                                        slice_offset,
                                        accumulate,
                                        x_grad);
-  } else {
-    GPUIndexElementwiseGetGrad<T, int64_t>(dev_ctx,
-                                           x,
-                                           out_grad,
-                                           index,
-                                           input_dims,
-                                           input_strides,
-                                           index_dims,
-                                           index_strides,
-                                           slice_offset,
-                                           accumulate,
-                                           x_grad);
+    return;
+#endif
   }
+
+  GPUIndexElementwiseGetGrad<T, int64_t>(dev_ctx,
+                                         x,
+                                         out_grad,
+                                         index,
+                                         input_dims,
+                                         input_strides,
+                                         index_dims,
+                                         index_strides,
+                                         slice_offset,
+                                         accumulate,
+                                         x_grad);
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/gpu/index_elementwise_get_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_elementwise_get_grad_kernel.cu
@@ -18,9 +18,15 @@
 #include "paddle/phi/backends/gpu/gpu_primitives.h"
 #include "paddle/phi/common/bfloat16.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/arange_kernel.h"
+#include "paddle/phi/kernels/contiguous_kernel.h"
+#include "paddle/phi/kernels/elementwise_kernel.h"
 #include "paddle/phi/kernels/funcs/eigen/common.h"
 #include "paddle/phi/kernels/funcs/index_elementwise.cu.h"
+#include "paddle/phi/kernels/funcs/radix_sort.h"
 #include "paddle/phi/kernels/funcs/stride_utils.h"
+#include "paddle/phi/kernels/reshape_kernel.h"
+#include "paddle/phi/kernels/transpose_kernel.h"
 
 namespace phi {
 template <typename T, typename IndexT, int nt, int vt, typename offset_calc_t>
@@ -58,7 +64,7 @@ __global__ void IndexEleGetGradAccKernel(
   }
 }
 
-template <typename T, typename IndexT = int>
+template <typename T, typename IndexT>
 void GPUIndexElementwiseGetGrad(const phi::GPUContext& dev_ctx,
                                 const DenseTensor& input,
                                 const DenseTensor& value,
@@ -150,6 +156,223 @@ void GPUIndexElementwiseGetGrad(const phi::GPUContext& dev_ctx,
   }
 }
 
+#define WARP_SIZE 32
+
+template <typename scalar_t, int SZ>
+__global__ void IndexingBackwardKernel(const int64_t* sorted_indices,
+                                       const int64_t* indices,
+                                       const scalar_t* grad_output,
+                                       scalar_t* grad_weight,
+                                       int64_t numel,
+                                       int64_t stride,
+                                       int64_t stride_before,
+                                       int64_t outer_dim,
+                                       bool accumulate) {
+  using opmath_t = typename phi::dtype::MPTypeTrait<scalar_t>::Type;
+
+  for (int64_t z = blockIdx.z; z < outer_dim; z += gridDim.z) {
+    int64_t idx = blockIdx.x * blockDim.y + threadIdx.y;
+    if (idx < numel &&
+        (idx == 0 || sorted_indices[idx] != sorted_indices[idx - 1])) {
+      do {
+        int64_t start_feature = threadIdx.x + blockIdx.y * blockDim.x * SZ;
+        if (!accumulate && (idx < numel - 1) &&
+            sorted_indices[idx] == sorted_indices[idx + 1]) {
+          idx++;
+          continue;
+        }
+
+        const int64_t weight_row =
+            sorted_indices[idx] * stride + z * stride_before;
+        const int64_t grad_row = indices[idx] * stride + z * numel * stride;
+        const opmath_t scale = static_cast<opmath_t>(1.0);
+
+        opmath_t gradient[SZ];
+        opmath_t weight[SZ];
+
+        while (start_feature < stride) {
+#pragma unroll
+          for (int ii = 0; ii < SZ; ii++) {
+            int64_t feature_dim = start_feature + ii * WARP_SIZE;
+            if (feature_dim < stride) {
+              gradient[ii] =
+                  static_cast<opmath_t>(grad_output[grad_row + feature_dim]);
+              if (accumulate) {
+                weight[ii] = static_cast<opmath_t>(
+                    grad_weight[weight_row + feature_dim]);
+              }
+            }
+          }
+
+#pragma unroll
+          for (int ii = 0; ii < SZ; ii++) {
+            if (accumulate) {
+              weight[ii] += gradient[ii] * scale;
+            } else {
+              weight[ii] = gradient[ii] * scale;
+            }
+          }
+
+#pragma unroll
+          for (int ii = 0; ii < SZ; ii++) {
+            int64_t feature_dim = start_feature + ii * WARP_SIZE;
+            if (feature_dim < stride) {
+              grad_weight[weight_row + feature_dim] =
+                  static_cast<scalar_t>(weight[ii]);
+            }
+          }
+          start_feature += gridDim.y * blockDim.x * SZ;
+        }
+        idx++;
+      } while (idx < numel && sorted_indices[idx] == sorted_indices[idx - 1]);
+    }
+  }
+}
+
+template <typename T, typename IndexT>
+void IndexPutWithSortKernel(const phi::GPUContext& dev_ctx,
+                            const DenseTensor& input,
+                            const DenseTensor& value,
+                            const std::vector<const DenseTensor*>& indices,
+                            const std::vector<int64_t>& input_dims,
+                            const std::vector<int64_t>& input_strides,
+                            const std::vector<int64_t>& index_dims,
+                            const std::vector<int64_t>& index_strides,
+                            const int64_t slice_offset,
+                            const bool accumulate,
+                            DenseTensor* output) {
+  DenseTensor& self = *output;
+
+  if (indices.size() > static_cast<size_t>(self.dims().size())) {
+    PADDLE_THROW(phi::errors::InvalidArgument(
+        "Too many indices for tensor of dimension %d (got %d).",
+        self.dims().size(),
+        indices.size()));
+  }
+
+  const bool unsafe = true;
+  const bool self_contiguous = self.meta().is_contiguous();
+  auto self_ = self_contiguous
+                   ? self
+                   : phi::Contiguous<T, phi::GPUContext>(dev_ctx, self);
+  DenseTensor linearIndex, src, expandedValue = value;
+  int64_t nElemBefore, strideBefore, sliceSize;
+  std::vector<int64_t> inversePerm;
+  std::tie(
+      linearIndex, src, nElemBefore, strideBefore, sliceSize, inversePerm) =
+      funcs::makeLinearIndex<T>(dev_ctx, self_, indices, !unsafe);
+
+  int64_t num_indices = linearIndex.numel();
+
+  if (expandedValue.numel() < num_indices * nElemBefore * sliceSize) {
+    auto expanded_size = common::vectorize<int64_t>(expandedValue.dims());
+    auto size1 = common::vectorize<int64_t>(expandedValue.dims());
+    auto size2 = common::vectorize<int64_t>(linearIndex.dims());
+    if (funcs::are_expandable(size1, size2)) {
+      expanded_size = funcs::infer_size_dimvector(size1, size2);
+    }
+    if (nElemBefore > 1) {
+      expanded_size.insert(expanded_size.begin(), nElemBefore);
+    }
+    if (sliceSize > 1) {
+      expanded_size.insert(expanded_size.end(), sliceSize);
+    }
+
+    DenseTensor expanded_tensor;
+    phi::ExpandKernel<T, phi::GPUContext>(
+        dev_ctx, expandedValue, phi::IntArray(expanded_size), &expanded_tensor);
+    expandedValue = expanded_tensor;
+  }
+  if (!expandedValue.meta().is_contiguous()) {
+    expandedValue = phi::Contiguous<T, phi::GPUContext>(dev_ctx, expandedValue);
+  }
+
+  if (num_indices > 0 && sliceSize > 0) {
+    const bool permuted = !src.meta().is_contiguous();
+    DenseTensor src_ =
+        permuted ? phi::Contiguous<T, phi::GPUContext>(dev_ctx, src) : src;
+    linearIndex =
+        phi::Reshape<IndexT, phi::GPUContext>(dev_ctx, linearIndex, {-1});
+
+    DenseTensor sorted_indices;
+    sorted_indices.Resize(linearIndex.dims());
+    dev_ctx.Alloc<IndexT>(&sorted_indices);
+    DenseTensor orig_indices;
+    orig_indices.Resize(linearIndex.dims());
+    dev_ctx.Alloc<IndexT>(&orig_indices);
+
+    auto stream = dev_ctx.stream();
+    constexpr int blockSize = 256;
+    int gridSize = (num_indices + blockSize - 1) / blockSize;
+
+    auto shape = phi::IntArray(common::vectorize<int64_t>(linearIndex.dims()));
+    auto divisor = phi::Full<IndexT, phi::GPUContext>(
+        dev_ctx, shape, phi::Scalar(sliceSize));
+
+    DenseTensor linearIndex_d = phi::FloorDivide<IndexT, phi::GPUContext>(
+        dev_ctx, linearIndex, divisor);
+
+    DenseTensor range;
+    range.Resize({num_indices});
+    dev_ctx.Alloc<IndexT>(&range);
+    phi::ArangeKernel<IndexT>(dev_ctx,
+                              phi::Scalar(0),
+                              phi::Scalar(num_indices),
+                              phi::Scalar(1),
+                              &range);
+    int64_t nbits = funcs::GetNumBits(funcs::LargestIndex(self_) / sliceSize);
+
+    funcs::RadixSortPairs<IndexT, IndexT>(dev_ctx,
+                                          linearIndex_d.data<IndexT>(),
+                                          sorted_indices.data<IndexT>(),
+                                          range.data<IndexT>(),
+                                          orig_indices.data<IndexT>(),
+                                          num_indices,
+                                          false,
+                                          0,
+                                          nbits);
+
+    const int UNROLL = 4;
+    const int INDICES_PER_BLOCK = 4;
+    auto max_grid_size = phi::backends::gpu::GetGpuMaxGridDimSize(
+        dev_ctx.GetPlace().GetDeviceId());
+
+    dim3 grid((num_indices + INDICES_PER_BLOCK - 1) / INDICES_PER_BLOCK,
+              std::min<int>(
+                  max_grid_size[1],
+                  (sliceSize + WARP_SIZE * UNROLL - 1) / (WARP_SIZE * UNROLL)),
+              std::min<int>(std::max<int>(1, static_cast<int>(nElemBefore)),
+                            max_grid_size[2]));
+    dim3 block(WARP_SIZE, INDICES_PER_BLOCK);
+
+    IndexingBackwardKernel<T, UNROLL>
+        <<<grid, block, 0, stream>>>(sorted_indices.data<IndexT>(),
+                                     orig_indices.data<IndexT>(),
+                                     expandedValue.data<T>(),
+                                     src_.data<T>(),
+                                     num_indices,
+                                     sliceSize,
+                                     strideBefore,
+                                     nElemBefore,
+                                     true);
+
+    if (permuted) {
+      phi::DenseTensor transposed_src;
+      std::vector<int> inversePerm_int(inversePerm.size());
+      std::transform(inversePerm.begin(),
+                     inversePerm.end(),
+                     inversePerm_int.begin(),
+                     [](int64_t x) { return static_cast<int>(x); });
+
+      phi::Transpose<T, phi::GPUContext>(
+          dev_ctx, src_, inversePerm_int, &transposed_src);
+      phi::Copy(dev_ctx, transposed_src, dev_ctx.GetPlace(), false, output);
+    } else if (!self_contiguous) {
+      phi::Copy(dev_ctx, self_, dev_ctx.GetPlace(), false, output);
+    }
+  }
+}
+
 template <typename T, typename Context>
 void IndexElementwiseGetGradKernel(const Context& dev_ctx,
                                    const DenseTensor& x,
@@ -161,6 +384,7 @@ void IndexElementwiseGetGradKernel(const Context& dev_ctx,
                                    const std::vector<int64_t>& index_strides,
                                    const int64_t slice_offset,
                                    const bool accumulate,
+                                   const bool is_combined,
                                    DenseTensor* x_grad) {
   dev_ctx.template Alloc<T>(x_grad);
   phi::funcs::set_constant(dev_ctx, x_grad, static_cast<float>(0));
@@ -176,17 +400,31 @@ void IndexElementwiseGetGradKernel(const Context& dev_ctx,
                         phi::DataType::INT32,
                         phi::DataType::INT64));
 
-  GPUIndexElementwiseGetGrad<T, int64_t>(dev_ctx,
-                                         x,
-                                         out_grad,
-                                         index,
-                                         input_dims,
-                                         input_strides,
-                                         index_dims,
-                                         index_strides,
-                                         slice_offset,
-                                         accumulate,
-                                         x_grad);
+  if (accumulate && index.size() == 1 && !is_combined) {
+    IndexPutWithSortKernel<T, int64_t>(dev_ctx,
+                                       x,
+                                       out_grad,
+                                       index,
+                                       input_dims,
+                                       input_strides,
+                                       index_dims,
+                                       index_strides,
+                                       slice_offset,
+                                       accumulate,
+                                       x_grad);
+  } else {
+    GPUIndexElementwiseGetGrad<T, int64_t>(dev_ctx,
+                                           x,
+                                           out_grad,
+                                           index,
+                                           input_dims,
+                                           input_strides,
+                                           index_dims,
+                                           index_strides,
+                                           slice_offset,
+                                           accumulate,
+                                           x_grad);
+  }
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/gpu/index_elementwise_get_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_elementwise_get_kernel.cu
@@ -117,6 +117,7 @@ void IndexElementwiseGetKernel(const Context& dev_ctx,
                                const std::vector<int64_t>& index_stride,
                                const int64_t slice_offset,
                                const bool accumulate,
+                               const bool is_combined,
                                DenseTensor* out) {
   const auto& index_type = index[0]->dtype();
   PADDLE_ENFORCE_EQ(index_type == phi::DataType::INT64,

--- a/paddle/phi/kernels/index_elementwise_get_grad_kernel.h
+++ b/paddle/phi/kernels/index_elementwise_get_grad_kernel.h
@@ -30,6 +30,7 @@ void IndexElementwiseGetGradKernel(const Context& ctx,
                                    const std::vector<int64_t>& index_strides,
                                    const int64_t slice_offset,
                                    const bool accumulate,
+                                   const bool is_combined,
                                    DenseTensor* x_grad);
 
 }  // namespace phi

--- a/paddle/phi/kernels/index_elementwise_get_kernel.h
+++ b/paddle/phi/kernels/index_elementwise_get_kernel.h
@@ -29,6 +29,7 @@ void IndexElementwiseGetKernel(const Context &ctx,
                                const std::vector<int64_t> &index_stride,
                                const int64_t slice_offset,
                                const bool accumulate,
+                               const bool is_combined,
                                DenseTensor *out);
 
 }  // namespace phi

--- a/paddle/phi/ops/yaml/backward.yaml
+++ b/paddle/phi/ops/yaml/backward.yaml
@@ -1708,14 +1708,14 @@
   no_need_buffer: add_value
 
 - backward_op : index_elementwise_get_double_grad
-  forward : index_elementwise_get_grad (Tensor x, Tensor[] index, Tensor out_grad, int64_t[] input_dims, int64_t[] input_strides, int64_t[] index_dims, int64_t[] index_stride, int64_t slice_offset, bool accumulate) -> Tensor(x_grad)
-  args : (Tensor[] index, Tensor x_grad_grad, int64_t[] input_dims, int64_t[] input_strides, int64_t[] index_dims, int64_t[] index_stride, int64_t slice_offset = 0, bool accumulate = true)
+  forward : index_elementwise_get_grad (Tensor x, Tensor[] index, Tensor out_grad, int64_t[] input_dims, int64_t[] input_strides, int64_t[] index_dims, int64_t[] index_stride, int64_t slice_offset, bool accumulate, bool is_combined) -> Tensor(x_grad)
+  args : (Tensor[] index, Tensor x_grad_grad, int64_t[] input_dims, int64_t[] input_strides, int64_t[] index_dims, int64_t[] index_stride, int64_t slice_offset = 0, bool accumulate = true, bool is_combined = false)
   output : Tensor(out_grad_grad)
-  invoke : index_elementwise_get(x_grad_grad, index, input_dims, input_strides, index_dims, index_stride, slice_offset, accumulate)
+  invoke : index_elementwise_get(x_grad_grad, index, input_dims, input_strides, index_dims, index_stride, slice_offset, accumulate, is_combined)
 
 - backward_op : index_elementwise_get_grad
-  forward : index_elementwise_get (Tensor x, Tensor[] index, int64_t[] input_dims, int64_t[] input_strides, int64_t[] index_dims, int64_t[] index_stride, int64_t slice_offset, bool accumulate) -> Tensor(out)
-  args : (Tensor x, Tensor[] index, Tensor out_grad, int64_t[] input_dims, int64_t[] input_strides, int64_t[] index_dims, int64_t[] index_stride, int64_t slice_offset = 0, bool accumulate = true)
+  forward : index_elementwise_get (Tensor x, Tensor[] index, int64_t[] input_dims, int64_t[] input_strides, int64_t[] index_dims, int64_t[] index_stride, int64_t slice_offset, bool accumulate, bool is_combined) -> Tensor(out)
+  args : (Tensor x, Tensor[] index, Tensor out_grad, int64_t[] input_dims, int64_t[] input_strides, int64_t[] index_dims, int64_t[] index_stride, int64_t slice_offset = 0, bool accumulate = true, bool is_combined = false)
   output : Tensor(x_grad)
   infer_meta :
     func : IndexElementwiseGetGradInferMeta

--- a/paddle/phi/ops/yaml/op_compat.yaml
+++ b/paddle/phi/ops/yaml/op_compat.yaml
@@ -2032,7 +2032,7 @@
 - op : index_elementwise_get
   backward : index_elementwise_get_grad, index_elementwise_get_double_grad
   inputs :
-     {x : x, index : index, input_dims : input_dims, input_strides : input_strides, index_dims : index_dims, index_stride : index_stride, slice_offset : slice_offset, accumulate : accumulate}
+     {x : x, index : index, input_dims : input_dims, input_strides : input_strides, index_dims : index_dims, index_stride : index_stride, slice_offset : slice_offset, accumulate : accumulate, is_combined : is_combined}
   outputs :
      out : Out
 

--- a/paddle/phi/ops/yaml/op_compat.yaml
+++ b/paddle/phi/ops/yaml/op_compat.yaml
@@ -2032,9 +2032,10 @@
 - op : index_elementwise_get
   backward : index_elementwise_get_grad, index_elementwise_get_double_grad
   inputs :
-     {x : x, index : index, input_dims : input_dims, input_strides : input_strides, index_dims : index_dims, index_stride : index_stride, slice_offset : slice_offset, accumulate : accumulate, is_combined : is_combined}
+     {x : x, index : index, input_dims : input_dims, input_strides : input_strides, index_dims : index_dims, index_stride : index_stride}
   outputs :
      out : Out
+  attrs : {slice_offset : slice_offset, accumulate : accumulate, is_combined : is_combined}
 
 - op : index_sample
   inputs :

--- a/paddle/phi/ops/yaml/ops.yaml
+++ b/paddle/phi/ops/yaml/ops.yaml
@@ -2803,7 +2803,7 @@
   interfaces : paddle::dialect::InferSymbolicShapeInterface, paddle::dialect::LayoutTransformationInterface
 
 - op : index_elementwise_get
-  args : (Tensor x, Tensor[] index, int64_t[] input_dims, int64_t[] input_strides, int64_t[] index_dims, int64_t[] index_stride, int64_t slice_offset = 0, bool accumulate = true)
+  args : (Tensor x, Tensor[] index, int64_t[] input_dims, int64_t[] input_strides, int64_t[] index_dims, int64_t[] index_stride, int64_t slice_offset = 0, bool accumulate = true, bool is_combined = false)
   output : Tensor (out)
   infer_meta :
     func : IndexElementwiseGetInferMeta


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Improvements

### Description
<img width="992" height="323" alt="image" src="https://github.com/user-attachments/assets/b1522abc-82f5-420c-98b7-a7f3f4a6211a" />
将 index size 为1的场景从 flatten + gather + reshape 转为 index_elementwise_get，前向性能会有所下降，加速比在1以内。
同时，针对 非 bool index size 为 1 的反向场景，在 index_elementwise_get_grad 的反向计算中引入 IndexPutWithSortKernel 作为快速路径，以提升该场景下的性能。
time line 如下：

GPUIndexElementwiseGetGrad性能：
<img width="441" height="155" alt="image" src="https://github.com/user-attachments/assets/6b517b0e-dd77-4a6a-afe1-2791ea0b7fac" />

IndexPutWithSortKernel性能：
<img width="447" height="162" alt="image" src="https://github.com/user-attachments/assets/04a14e3d-b728-4972-994f-69f1c4d3de1b" />

torch性能：
<img width="463" height="161" alt="image" src="https://github.com/user-attachments/assets/37682bc8-80a0-4a6d-8188-c8df4295c62f" />


pcard-67164