### PR TITLE
[0-size Tensor No.237] Add 0-size Tensor support for paddle.nn.utils.vector_to_parameters	

### DIFF
--- a/test/legacy_test/test_parameter.py
+++ b/test/legacy_test/test_parameter.py
@@ -150,5 +150,47 @@ class ParameterChecks(unittest.TestCase):
             self.assertEqual(vec.shape, [15])
 
 
+class TestVectorToParam(unittest.TestCase):
+    def test_vector_to_param_zerosize(self):
+        # test the case that the parameters contains zero size tensor
+        with guard():
+            vec = paddle.randn([18], dtype='float32')
+            param1 = paddle.empty([5], dtype='float32')
+            param2 = paddle.empty([5], dtype='float32')
+            param3 = paddle.empty([8], dtype='float32')
+            param4 = paddle.empty([0], dtype='float32')
+            params = [param1, param2, param3, param4]
+            paddle.nn.utils.vector_to_parameters(vec, params)
+            # concat the parameters and get the original vector
+            vec_ = paddle.concat(params, axis=0)
+            np.testing.assert_array_equal(vec_.numpy(), vec.numpy())
+
+    def test_vector_to_param1(self):
+        # test the case that the sum of parameter's elements less than vector elements
+        with guard():
+            vec = paddle.randn([18], dtype='float32')
+            param1 = paddle.empty([5], dtype='float32')
+            param2 = paddle.empty([5], dtype='float32')
+            param3 = paddle.empty([7], dtype='float32')
+            params = [param1, param2, param3]
+            paddle.nn.utils.vector_to_parameters(vec, params)
+            # concat the parameters and get the original vector
+            vec_ = paddle.concat(params, axis=0)
+            np.testing.assert_array_equal(vec_.numpy(), vec[:17].numpy())
+
+    def test_vector_to_param2(self):
+        # test the case that the sum of parameter's elements grater than vector elements
+        def _test_vector_to_param():
+            with guard():
+                vec = paddle.randn([18], dtype='float32')
+                param1 = paddle.empty([5], dtype='float32')
+                param2 = paddle.empty([5], dtype='float32')
+                param3 = paddle.empty([9], dtype='float32')
+                params = [param1, param2, param3]
+                paddle.nn.utils.vector_to_parameters(vec, params)
+
+        self.assertRaises(ValueError, _test_vector_to_param)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
添加paddle.nn.utils.vector_to_parameters对vector的元素总个数多于所有parameters的元素个数之和这一情况的支持。

- 当vector中所有的元素个数等于（ == ）parameters中所有元素之和时使用paddle.split实现。
- 当vector中所有的元素个数小于  ( < ) parameters中所有元素之和时,报错 。
- 当vector中所有的元素个数多于（ > ）parameters中所有元素之和时，仿照pytorch使用slice机制实现 。


pytorch 的实现：
```python
def vector_to_parameters(vec: torch.Tensor, parameters: Iterable[torch.Tensor]) -> None:
    r"""Copy slices of a vector into an iterable of parameters.

    Args:
        vec (Tensor): a single vector representing the parameters of a model.
        parameters (Iterable[Tensor]): an iterable of Tensors that are the
            parameters of a model.
    """
    # Ensure vec of type Tensor
    if not isinstance(vec, torch.Tensor):
        raise TypeError(f"expected torch.Tensor, but got: {torch.typename(vec)}")
    # Flag for the device where the parameter is located
    param_device = None

    # Pointer for slicing the vector for each parameter
    pointer = 0
    for param in parameters:
        # Ensure the parameters are located in the same device
        param_device = _check_param_device(param, param_device)

        # The length of the parameter
        num_param = param.numel()
        # Slice the vector, reshape it, and replace the old data of the parameter
        param.data = vec[pointer : pointer + num_param].view_as(param).data

        # Increment the pointer
        pointer += num_param

```

pcard-67164

