### PR TITLE
【Inference Fix Bug】Fix stream_k in moe_gemm

### DIFF
--- a/paddle/phi/kernels/fusion/cutlass/cutlass_kernels/cutlass_heuristic.h
+++ b/paddle/phi/kernels/fusion/cutlass/cutlass_kernels/cutlass_heuristic.h
@@ -125,7 +125,7 @@ static std::vector<CutlassGemmConfig> get_candidate_configs(
   // variable `export CUTLASS_GEMM_STREAM_K=1`.
   SplitKStyle env_split_k = SplitKStyle::NO_SPLIT_K;
   const char* env_stream_k = std::getenv("CUTLASS_GEMM_STREAM_K");
-  if (env_stream_k != nullptr) {
+  if (env_stream_k != nullptr && !is_moe) {
     env_split_k = SplitKStyle::SPLIT_K_SERIAL;
   }
   for (const auto& tile_config : tiles) {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes
### Description
<!-- Describe what you’ve done -->
Pcard-71500
Fixed the issue that moe_gemm does not support stream_k