### PR TITLE
split get_places function, add is_custom_device in op_test

### DIFF
--- a/test/legacy_test/op_test.py
+++ b/test/legacy_test/op_test.py
@@ -2920,13 +2920,13 @@ class OpTest(unittest.TestCase):
                     return [place]
                 else:
                     return []
-            # elif is_custom_device():
-            #     dev_type = paddle.device.get_all_custom_device_type()[0]
-            #     place = core.CustomPlace(dev_type, 0)
-            #     if core.is_float16_supported(place):
-            #         return [place]
-            #     else:
-            #         return []
+            elif is_custom_device():
+                dev_type = paddle.device.get_all_custom_device_type()[0]
+                place = core.CustomPlace(dev_type, 0)
+                if core.is_float16_supported(place):
+                    return [place]
+                else:
+                    return []
             else:
                 return []
         places = []

--- a/test/legacy_test/op_test.py
+++ b/test/legacy_test/op_test.py
@@ -2920,13 +2920,13 @@ class OpTest(unittest.TestCase):
                     return [place]
                 else:
                     return []
-            elif is_custom_device():
-                dev_type = paddle.device.get_all_custom_device_type()[0]
-                place = core.CustomPlace(dev_type, 0)
-                if core.is_float16_supported(place):
-                    return [place]
-                else:
-                    return []
+            # elif is_custom_device():
+            #     dev_type = paddle.device.get_all_custom_device_type()[0]
+            #     place = core.CustomPlace(dev_type, 0)
+            #     if core.is_float16_supported(place):
+            #         return [place]
+            #     else:
+            #         return []
             else:
                 return []
         places = []

--- a/test/legacy_test/test_activation_op.py
+++ b/test/legacy_test/test_activation_op.py
@@ -23,6 +23,7 @@ from op_test import (
     convert_float_to_uint16,
     get_device_place,
     get_places,
+    is_custom_device,
 )
 from scipy.special import erf, expit
 from utils import static_guard
@@ -497,7 +498,8 @@ class TestSigmoid_ZeroDim(TestSigmoid):
 
 
 @unittest.skipIf(
-    not core.is_compiled_with_cuda() or core.is_compiled_with_rocm(),
+    not (core.is_compiled_with_cuda() or is_custom_device())
+    or core.is_compiled_with_rocm(),
     "core is not compiled with CUDA",
 )
 class TestSigmoidBF16(OpTest):
@@ -1765,7 +1767,8 @@ class TestSqrt_Complex128(TestSqrt):
 
 
 @unittest.skipIf(
-    not core.is_compiled_with_cuda() or core.is_compiled_with_rocm(),
+    not (core.is_compiled_with_cuda() or is_custom_device())
+    or core.is_compiled_with_rocm(),
     "core is not compiled with CUDA",
 )
 class TestSqrtBF16(OpTest):
@@ -2037,7 +2040,7 @@ class TestCeil(TestActivation):
         self.inputs = {'X': OpTest.np_dtype_to_base_dtype(x)}
         self.outputs = {'Out': out}
         self.convert_input_output()
-        if not core.is_compiled_with_cuda():
+        if not (core.is_compiled_with_cuda() or is_custom_device()):
             self.__class__.no_need_check_grad = True
 
     def init_shape(self):
@@ -2091,7 +2094,7 @@ class TestFloor(TestActivation):
         self.inputs = {'X': OpTest.np_dtype_to_base_dtype(x)}
         self.outputs = {'Out': out}
         self.convert_input_output()
-        if not core.is_compiled_with_cuda():
+        if not (core.is_compiled_with_cuda() or is_custom_device()):
             self.__class__.no_need_check_grad = True
 
     def init_shape(self):
@@ -4563,7 +4566,8 @@ class TestSquare_ZeroDim(TestSquare):
 
 
 @unittest.skipIf(
-    not core.is_compiled_with_cuda() or core.is_compiled_with_rocm(),
+    not (core.is_compiled_with_cuda() or is_custom_device())
+    or core.is_compiled_with_rocm(),
     "core is not compiled with CUDA",
 )
 class TestSquareBF16(OpTest):
@@ -4917,7 +4921,8 @@ class TestSoftplus_ZeroDim(TestSoftplus):
 
 
 @unittest.skipIf(
-    not core.is_compiled_with_cuda() or core.is_compiled_with_rocm(),
+    not (core.is_compiled_with_cuda() or is_custom_device())
+    or core.is_compiled_with_rocm(),
     "core is not compiled with CUDA",
 )
 class TestSoftplusBF16(OpTest):
@@ -5595,7 +5600,8 @@ class TestMishAPI(unittest.TestCase):
 # ------------------ Test Cudnn Activation----------------------
 def create_test_act_cudnn_class(parent, atol=1e-3, grad_atol=1e-3):
     @unittest.skipIf(
-        not core.is_compiled_with_cuda(), "core is not compiled with CUDA"
+        not (core.is_compiled_with_cuda() or is_custom_device()),
+        "core is not compiled with CUDA",
     )
     class TestActCudnn(parent):
         def init_kernel_type(self):

--- a/test/legacy_test/test_adadelta_op.py
+++ b/test/legacy_test/test_adadelta_op.py
@@ -294,10 +294,10 @@ class TestAdadeltaOpMultiPrecision(unittest.TestCase):
         paddle.enable_static()
 
     def test_main(self):
-        for device in get_devices():
+        for place in get_devices():
             use_amp_list = [True, False]
             for use_amp in use_amp_list:
-                self._test_adadelta_op_dygraph_place_amp(device, use_amp)
+                self._test_adadelta_op_dygraph_place_amp(place, use_amp)
 
 
 class TestAdadeltaMultiPrecision2_0(unittest.TestCase):

--- a/test/legacy_test/test_adadelta_op.py
+++ b/test/legacy_test/test_adadelta_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, get_device_place, get_places
+from op_test import OpTest, get_device_place, get_devices
 
 import paddle
 from paddle import base
@@ -294,10 +294,10 @@ class TestAdadeltaOpMultiPrecision(unittest.TestCase):
         paddle.enable_static()
 
     def test_main(self):
-        for place in get_places(string_format=True):
+        for device in get_devices():
             use_amp_list = [True, False]
             for use_amp in use_amp_list:
-                self._test_adadelta_op_dygraph_place_amp(place, use_amp)
+                self._test_adadelta_op_dygraph_place_amp(device, use_amp)
 
 
 class TestAdadeltaMultiPrecision2_0(unittest.TestCase):

--- a/test/legacy_test/test_adagrad_op.py
+++ b/test/legacy_test/test_adagrad_op.py
@@ -17,7 +17,7 @@ import unittest
 
 import numpy as np
 from op import Operator
-from op_test import OpTest, get_device_place, get_places
+from op_test import OpTest, get_device_place, get_devices, get_places
 
 import paddle
 from paddle.base import core
@@ -242,10 +242,10 @@ class TestAdagradOpMultiPrecision(unittest.TestCase):
         paddle.enable_static()
 
     def test_main(self):
-        for place in get_places(string_format=True):
+        for device in get_devices():
             use_amp_list = [True, False]
             for use_amp in use_amp_list:
-                self._test_adagrad_op_dygraph_place_amp(place, use_amp)
+                self._test_adagrad_op_dygraph_place_amp(device, use_amp)
 
 
 class TestAdagradMultiPrecision2_0(unittest.TestCase):

--- a/test/legacy_test/test_adagrad_op.py
+++ b/test/legacy_test/test_adagrad_op.py
@@ -242,10 +242,10 @@ class TestAdagradOpMultiPrecision(unittest.TestCase):
         paddle.enable_static()
 
     def test_main(self):
-        for device in get_devices():
+        for place in get_devices():
             use_amp_list = [True, False]
             for use_amp in use_amp_list:
-                self._test_adagrad_op_dygraph_place_amp(device, use_amp)
+                self._test_adagrad_op_dygraph_place_amp(place, use_amp)
 
 
 class TestAdagradMultiPrecision2_0(unittest.TestCase):

--- a/test/legacy_test/test_adam_op.py
+++ b/test/legacy_test/test_adam_op.py
@@ -16,7 +16,7 @@ import unittest
 
 import numpy as np
 from op import Operator
-from op_test import OpTest, get_places
+from op_test import OpTest, get_devices, get_places
 
 import paddle
 from paddle import base
@@ -1296,7 +1296,7 @@ class TestMultiTensorAdam(unittest.TestCase):
         return out
 
     def _get_places(self):
-        return get_places(string_format=True)
+        return get_devices()
 
     def _check_with_place_amp(self, place, use_amp):
         # test dygraph mode

--- a/test/legacy_test/test_adamax_op.py
+++ b/test/legacy_test/test_adamax_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, get_device_place, get_places
+from op_test import OpTest, get_device_place, get_devices
 
 import paddle
 
@@ -275,7 +275,7 @@ class TestAdamaxOpMultiPrecision(unittest.TestCase):
         paddle.enable_static()
 
     def _get_places(self):
-        return get_places(string_format=True)
+        return get_devices()
 
     def test_main(self):
         for place in self._get_places():

--- a/test/legacy_test/test_adamw_op.py
+++ b/test/legacy_test/test_adamw_op.py
@@ -18,7 +18,7 @@ import unittest
 from functools import partial
 
 import numpy as np
-from op_test import OpTest, get_places
+from op_test import OpTest, get_devices
 
 import paddle
 from paddle import base, nn
@@ -758,7 +758,7 @@ class TestAdamWOpMultiPrecision(unittest.TestCase):
                 optimizer.clear_grad()
 
     def _get_places(self):
-        places = get_places(string_format=True)
+        places = get_devices()
         if paddle.is_compiled_with_xpu():
             places.append('xpu')
         return places

--- a/test/legacy_test/test_adaptive_log_softmax_with_loss.py
+++ b/test/legacy_test/test_adaptive_log_softmax_with_loss.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import get_places
+from op_test import get_devices, get_places
 
 import paddle
 import paddle.optimizer as optim
@@ -58,7 +58,7 @@ class SimpleModel(nn.Layer):
 class TestNNAdaptiveLogSoftmaxWithLossAPI(unittest.TestCase):
     def setUp(self):
         paddle.seed(2024)
-        self.place = get_places(string_format=True)
+        self.place = get_devices()
         self.log_np = np.random.randn(4, 8).astype('float32')
         self.predict_np = np.abs(np.random.randn(64, 8).astype('float32'))
 

--- a/test/legacy_test/test_blha_get_max_len_op.py
+++ b/test/legacy_test/test_blha_get_max_len_op.py
@@ -15,6 +15,7 @@
 import unittest
 
 import numpy as np
+from op_test import is_custom_device
 
 import paddle
 from paddle.base import core
@@ -109,7 +110,8 @@ class TestBlhaGetMaxLenOp(unittest.TestCase):
 
 
 @unittest.skipIf(
-    not core.is_compiled_with_cuda() and not core.is_compiled_with_xpu(),
+    not (core.is_compiled_with_cuda() or is_custom_device())
+    and not core.is_compiled_with_xpu(),
     "Only support XPU or GPU in CUDA mode.",
 )
 class TestBlhaGetMaxLenOp_ZeroSize(unittest.TestCase):

--- a/test/legacy_test/test_cartesian_prod.py
+++ b/test/legacy_test/test_cartesian_prod.py
@@ -16,7 +16,7 @@ import unittest
 from itertools import product
 
 import numpy as np
-from op_test import get_places
+from op_test import get_devices
 
 import paddle
 from paddle.base import core
@@ -36,7 +36,7 @@ class TestCartesianProdAPIBase(unittest.TestCase):
         self.c_np = np.random.random(self.c_shape).astype(self.dtype_np)
         self.d_np = np.empty(0, self.dtype_np)
 
-        self.place = get_places(string_format=True)
+        self.place = get_devices()
 
     def init_setting(self):
         self.dtype_np = 'float32'
@@ -119,7 +119,7 @@ class TestCartesianProd_ZeroSize(unittest.TestCase):
         self.a_np = np.random.random(self.a_shape).astype(self.dtype_np)
         self.b_np = np.empty(0, self.dtype_np)
 
-        self.place = get_places(string_format=True)
+        self.place = get_devices()
 
     def init_setting(self):
         self.dtype_np = 'float32'

--- a/test/legacy_test/test_cauchy_inplace.py
+++ b/test/legacy_test/test_cauchy_inplace.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import get_places
+from op_test import get_devices
 
 import paddle
 
@@ -35,7 +35,7 @@ class TestCauchyInplaceDtype(unittest.TestCase):
             tensor_fp64.cauchy_()
             self.assertEqual(tensor_fp64.dtype, paddle.float64)
 
-        for place in get_places(string_format=True):
+        for place in get_devices():
             paddle.set_device(place)
             test_fp32()
             test_fp64()
@@ -92,7 +92,7 @@ class TestCauchyInplaceDistribution(unittest.TestCase):
 class TestCauchyInplaceEmptyTensor(unittest.TestCase):
     def test_cauchy_inplace_op_empty_tensor(self):
         test_shapes = [(200, 1), (1, 200)]
-        for place in get_places(string_format=True):
+        for place in get_devices():
             paddle.set_device(place)
             for test_shape in test_shapes:
                 tensor = paddle.empty(shape=test_shape)
@@ -118,7 +118,7 @@ class TestCauchyInplaceGrad(unittest.TestCase):
             cauchy_grad = tensor_b.grad.numpy()
             self.assertTrue((cauchy_grad == 0).all())
 
-        for place in get_places(string_format=True):
+        for place in get_devices():
             paddle.set_device(place)
             test_grad()
 

--- a/test/legacy_test/test_cholesky_op.py
+++ b/test/legacy_test/test_cholesky_op.py
@@ -17,7 +17,7 @@ import unittest
 import numpy as np
 from decorator_helper import prog_scope
 from gradient_checker import grad_check
-from op_test import OpTest, skip_check_grad_ci
+from op_test import OpTest, get_places, skip_check_grad_ci
 
 import paddle
 from paddle import base
@@ -173,9 +173,7 @@ class TestDygraph(unittest.TestCase):
 
 class TestCholeskySingularAPI(unittest.TestCase):
     def setUp(self):
-        self.places = [base.CPUPlace()]
-        if core.is_compiled_with_cuda() and (not core.is_compiled_with_rocm()):
-            self.places.append(base.CUDAPlace(0))
+        self.places = get_places()
 
     def check_static_result(self, place, input_shape, with_out=False):
         with paddle.static.program_guard(

--- a/test/legacy_test/test_cholesky_op.py
+++ b/test/legacy_test/test_cholesky_op.py
@@ -17,7 +17,7 @@ import unittest
 import numpy as np
 from decorator_helper import prog_scope
 from gradient_checker import grad_check
-from op_test import OpTest, get_places, skip_check_grad_ci
+from op_test import OpTest, skip_check_grad_ci
 
 import paddle
 from paddle import base
@@ -173,7 +173,9 @@ class TestDygraph(unittest.TestCase):
 
 class TestCholeskySingularAPI(unittest.TestCase):
     def setUp(self):
-        self.places = get_places()
+        self.places = [base.CPUPlace()]
+        if core.is_compiled_with_cuda() and (not core.is_compiled_with_rocm()):
+            self.places.append(base.CUDAPlace(0))
 
     def check_static_result(self, place, input_shape, with_out=False):
         with paddle.static.program_guard(

--- a/test/legacy_test/test_class_center_sample_op.py
+++ b/test/legacy_test/test_class_center_sample_op.py
@@ -15,10 +15,9 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, paddle_static_guard
+from op_test import OpTest, get_places, paddle_static_guard
 
 import paddle
-from paddle.base import core
 
 
 def class_center_sample_numpy(label, classes_list, num_samples):
@@ -135,9 +134,7 @@ class TestClassCenterSampleV2(unittest.TestCase):
         self.initParams()
         np.random.seed(self.seed)
         paddle.framework.random._manual_program_seed(2021)
-        self.places = [paddle.base.CPUPlace()]
-        if core.is_compiled_with_cuda():
-            self.places.append(paddle.base.CUDAPlace(0))
+        self.places = get_places()
 
     def initParams(self):
         self.batch_size = 10
@@ -235,9 +232,7 @@ class TestClassCenterSampleAPIError(unittest.TestCase):
     def setUp(self):
         self.initParams()
         np.random.seed(self.seed)
-        self.places = [paddle.base.CPUPlace()]
-        if core.is_compiled_with_cuda():
-            self.places.append(paddle.base.CUDAPlace(0))
+        self.places = get_places()
 
     def initParams(self):
         self.batch_size = 20
@@ -275,9 +270,7 @@ class TestClassCenterSampleAPIError1(unittest.TestCase):
     def setUp(self):
         self.initParams()
         np.random.seed(self.seed)
-        self.places = [paddle.base.CPUPlace()]
-        if core.is_compiled_with_cuda():
-            self.places.append(paddle.base.CUDAPlace(0))
+        self.places = get_places()
 
     def initParams(self):
         self.batch_size = 5

--- a/test/legacy_test/test_combinations.py
+++ b/test/legacy_test/test_combinations.py
@@ -16,7 +16,7 @@ import unittest
 from itertools import combinations, combinations_with_replacement
 
 import numpy as np
-from op_test import get_places
+from op_test import get_devices
 
 import paddle
 from paddle.base import Program
@@ -47,7 +47,7 @@ class TestCombinationsAPIBase(unittest.TestCase):
         self.modify_setting()
         self.x_np = np.random.random(self.x_shape).astype(self.dtype_np)
 
-        self.place = get_places(string_format=True)
+        self.place = get_devices()
 
     def init_setting(self):
         self.dtype_np = 'float64'
@@ -120,7 +120,7 @@ class TestCombinationsAPI2(TestCombinationsAPIBase):
 
 class TestCombinationsEmpty(unittest.TestCase):
     def setUp(self):
-        self.place = get_places(string_format=True)
+        self.place = get_devices()
 
     def test_dygraph(self):
         paddle.disable_static()

--- a/test/legacy_test/test_cross_op.py
+++ b/test/legacy_test/test_cross_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, convert_float_to_uint16
+from op_test import OpTest, convert_float_to_uint16, is_custom_device
 
 import paddle
 from paddle import base
@@ -77,7 +77,8 @@ class TestCrossOpCase1(TestCrossOp):
 
 
 @unittest.skipIf(
-    not core.is_compiled_with_cuda(), "core is not compiled with CUDA"
+    not (core.is_compiled_with_cuda() or is_custom_device()),
+    "core is not compiled with CUDA",
 )
 class TestCrossFP16Op(TestCrossOp):
     def initTestCase(self):

--- a/test/legacy_test/test_determinant_op.py
+++ b/test/legacy_test/test_determinant_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest
+from op_test import OpTest, get_places
 
 import paddle
 
@@ -430,9 +430,7 @@ class TestSlogDeterminantAPIComplex(unittest.TestCase):
         self.x = np.vectorize(complex)(
             np.random.random(self.shape), np.random.random(self.shape)
         ).astype(self.dtype)
-        self.places = [paddle.CPUPlace()]
-        if paddle.base.core.is_compiled_with_cuda():
-            self.places.append(paddle.CUDAPlace(0))
+        self.places = get_places()
         self.out_grad = (
             np.array([1 + 0j, 1 + 0j] * 3 * 3)
             .reshape(2, 3, 3)
@@ -502,9 +500,7 @@ class TestSlogDeterminantAPIComplex2(TestSlogDeterminantAPIComplex):
         self.x = np.vectorize(complex)(
             np.random.random(self.shape), np.random.random(self.shape)
         ).astype(self.dtype)
-        self.places = [paddle.CPUPlace()]
-        if paddle.base.core.is_compiled_with_cuda():
-            self.places.append(paddle.CUDAPlace(0))
+        self.places = get_places()
         self.out_grad = np.array([3 + 0j, 3 + 0j] * 6).reshape(2, 6)
         self.x_grad_ref_dy = self.get_numeric_grad(
             self.x, self.shape, self.out_grad

--- a/test/legacy_test/test_elementwise_mod_op.py
+++ b/test/legacy_test/test_elementwise_mod_op.py
@@ -16,7 +16,12 @@ import random
 import unittest
 
 import numpy as np
-from op_test import OpTest, convert_float_to_uint16, convert_uint16_to_float
+from op_test import (
+    OpTest,
+    convert_float_to_uint16,
+    convert_uint16_to_float,
+    is_custom_device,
+)
 from utils import dygraph_guard, static_guard
 
 import paddle
@@ -124,7 +129,8 @@ class TestElementwiseModOpFloat(TestElementwiseModOp):
 
 
 @unittest.skipIf(
-    not core.is_compiled_with_cuda(), "core is not compiled with CUDA"
+    not (core.is_compiled_with_cuda() or is_custom_device()),
+    "core is not compiled with CUDA",
 )
 class TestElementwiseModFP16Op(TestElementwiseModOp):
     def init_dtype(self):

--- a/test/legacy_test/test_elementwise_mul_op.py
+++ b/test/legacy_test/test_elementwise_mul_op.py
@@ -15,7 +15,12 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, convert_float_to_uint16, skip_check_grad_ci
+from op_test import (
+    OpTest,
+    convert_float_to_uint16,
+    is_custom_device,
+    skip_check_grad_ci,
+)
 
 import paddle
 from paddle import base
@@ -472,7 +477,8 @@ class TestElementwiseMulOp_broadcast_5(ElementwiseMulOp_broadcast):
 
 
 @unittest.skipIf(
-    not core.is_compiled_with_cuda(), "core is not compiled with CUDA"
+    not (core.is_compiled_with_cuda() or is_custom_device()),
+    "core is not compiled with CUDA",
 )
 class TestElementwiseMulOpFp16(ElementwiseMulOp):
     def init_dtype(self):

--- a/test/legacy_test/test_embedding_scale_grad_by_freq.py
+++ b/test/legacy_test/test_embedding_scale_grad_by_freq.py
@@ -15,6 +15,7 @@
 import unittest
 
 import numpy as np
+from op_test import get_places
 
 import paddle
 from paddle.nn.functional import embedding
@@ -32,9 +33,7 @@ def ref_embedding_scale_grad_(x, weight_unscaled_grad):
 class TestEmbeddingAPIScaleGradByFreq(unittest.TestCase):
     def setUp(self):
         self.init_data()
-        self.places = [paddle.CPUPlace()]
-        if paddle.core.is_compiled_with_cuda():
-            self.places.append(paddle.CUDAPlace(0))
+        self.places = get_places()
 
     def init_data(self):
         self.dtype = "float32"

--- a/test/legacy_test/test_fused_gate_attention_op.py
+++ b/test/legacy_test/test_fused_gate_attention_op.py
@@ -20,7 +20,12 @@ os.environ['FLAGS_new_einsum'] = "0"
 import unittest
 
 import numpy as np
-from op_test import OpTest, convert_float_to_uint16, convert_uint16_to_float
+from op_test import (
+    OpTest,
+    convert_float_to_uint16,
+    convert_uint16_to_float,
+    is_custom_device,
+)
 from test_sparse_attention_op import get_cuda_version
 
 import paddle
@@ -30,7 +35,8 @@ from paddle.base import core
 
 
 @unittest.skipIf(
-    not core.is_compiled_with_cuda(), "Paddle is not compiled with CUDA"
+    not (core.is_compiled_with_cuda() or is_custom_device()),
+    "Paddle is not compiled with CUDA",
 )
 class TestFusedGateAttentionOp(OpTest):
     def setUp(self):
@@ -474,7 +480,7 @@ class TestFusedGateAttentionApi(unittest.TestCase):
         ]
 
     def test_api(self):
-        if not core.is_compiled_with_cuda():
+        if not (core.is_compiled_with_cuda() or is_custom_device()):
             pass
 
         query = paddle.rand(shape=self.query_shape, dtype="float32")

--- a/test/legacy_test/test_fused_rotary_position_embedding.py
+++ b/test/legacy_test/test_fused_rotary_position_embedding.py
@@ -16,6 +16,7 @@ import unittest
 
 import numpy as np
 import parameterized as param
+from op_test import is_custom_device
 
 import paddle
 from paddle.base import core
@@ -158,7 +159,8 @@ def paddle_fused_rotary_position_embedding(
 
 
 @unittest.skipIf(
-    not core.is_compiled_with_cuda() and not paddle.is_compiled_with_rocm(),
+    not (core.is_compiled_with_cuda() or is_custom_device())
+    and not paddle.is_compiled_with_rocm(),
     "core is not compiled with CUDA or ROCM ",
 )
 @param.parameterized_class(
@@ -693,7 +695,8 @@ class TestFusedRotaryPositionEmbedding(unittest.TestCase):
 
 
 @unittest.skipIf(
-    not core.is_compiled_with_cuda() and not paddle.is_compiled_with_rocm(),
+    not (core.is_compiled_with_cuda() or is_custom_device())
+    and not paddle.is_compiled_with_rocm(),
     "core is not compiled with CUDA or ROCM ",
 )
 class TestFusedRotaryPositionEmbeddingZeroSize(unittest.TestCase):

--- a/test/legacy_test/test_gaussian_random_op.py
+++ b/test/legacy_test/test_gaussian_random_op.py
@@ -15,7 +15,12 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, convert_uint16_to_float, paddle_static_guard
+from op_test import (
+    OpTest,
+    convert_uint16_to_float,
+    is_custom_device,
+    paddle_static_guard,
+)
 
 import paddle
 from paddle import base
@@ -61,7 +66,8 @@ class TestGaussianRandomOp(OpTest):
 
 
 @unittest.skipIf(
-    not core.is_compiled_with_cuda(), "core is not compiled with CUDA"
+    not (core.is_compiled_with_cuda() or is_custom_device()),
+    "core is not compiled with CUDA",
 )
 class TestGaussianRandomFP16Op(OpTest):
     def setUp(self):
@@ -111,7 +117,8 @@ def gaussian_wrapper(dtype_=np.uint16):
 
 
 @unittest.skipIf(
-    not core.is_compiled_with_cuda(), "core is not compiled with CUDA"
+    not (core.is_compiled_with_cuda() or is_custom_device()),
+    "core is not compiled with CUDA",
 )
 class TestGaussianRandomBF16Op(OpTest):
     def setUp(self):

--- a/test/legacy_test/test_geometric_inplace.py
+++ b/test/legacy_test/test_geometric_inplace.py
@@ -16,7 +16,7 @@ import unittest
 
 import numpy as np
 import scipy.stats
-from op_test import get_places
+from op_test import get_devices
 
 import paddle
 
@@ -36,7 +36,7 @@ class TestGeometricInplaceDtype(unittest.TestCase):
             tensor_fp64.geometric_(probs=0.3)
             self.assertEqual(tensor_fp64.dtype, paddle.float64)
 
-        for place in get_places(string_format=True):
+        for place in get_devices():
             paddle.set_device(place)
             test_fp32()
             test_fp64()
@@ -96,7 +96,7 @@ class TestGeometricInplaceDistribution(unittest.TestCase):
 class TestGeometricInplaceEmptyTensor(unittest.TestCase):
     def test_geometric_inplace_op_empty_tensor(self):
         test_shapes = [(200, 1), (1, 200)]
-        for place in get_places(string_format=True):
+        for place in get_devices():
             paddle.set_device(place)
             for test_shape in test_shapes:
                 tensor = paddle.empty(shape=test_shape)
@@ -122,7 +122,7 @@ class TestGeometricInplaceGrad(unittest.TestCase):
             geometric_grad = tensor_b.grad.numpy()
             self.assertTrue((geometric_grad == 0).all())
 
-        for place in get_places(string_format=True):
+        for place in get_devices():
             paddle.set_device(place)
             test_grad()
 

--- a/test/legacy_test/test_group_norm_op_v2.py
+++ b/test/legacy_test/test_group_norm_op_v2.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import get_places
+from op_test import get_places, is_custom_device
 from utils import dygraph_guard
 
 import paddle
@@ -243,7 +243,7 @@ class TestGroupNormAPIV2_With_NDHWC(unittest.TestCase):
 class TestGroupNormAPIV2_With_General_Dimensions_fp16(unittest.TestCase):
     def test_numerical_accuracy(self):
         # fp16 only supported in cuda
-        if not core.is_compiled_with_cuda():
+        if not (core.is_compiled_with_cuda() or is_custom_device()):
             return
         paddle.disable_static()
         shapes = [
@@ -286,7 +286,7 @@ class TestGroupNormAPIV2_With_General_Dimensions_fp16(unittest.TestCase):
 
 class TestGroupNormAPIV2_With_NCL_fp16(unittest.TestCase):
     def test_numerical_accuracy(self):
-        if not core.is_compiled_with_cuda():
+        if not (core.is_compiled_with_cuda() or is_custom_device()):
             return
         paddle.disable_static()
         shape = (2, 6, 4)
@@ -327,7 +327,7 @@ class TestGroupNormAPIV2_With_NCL_fp16(unittest.TestCase):
 
 class TestGroupNormAPIV2_With_NCDHW_fp16(unittest.TestCase):
     def test_numerical_accuracy(self):
-        if not core.is_compiled_with_cuda():
+        if not (core.is_compiled_with_cuda() or is_custom_device()):
             return
         paddle.disable_static()
         shape = (2, 6, 4, 2, 2)
@@ -368,7 +368,7 @@ class TestGroupNormAPIV2_With_NCDHW_fp16(unittest.TestCase):
 
 class TestGroupNormAPIV2_With_NLC_fp16(unittest.TestCase):
     def test_numerical_accuracy(self):
-        if not core.is_compiled_with_cuda():
+        if not (core.is_compiled_with_cuda() or is_custom_device()):
             return
         paddle.disable_static()
         shape = (2, 4, 6)
@@ -409,7 +409,7 @@ class TestGroupNormAPIV2_With_NLC_fp16(unittest.TestCase):
 
 class TestGroupNormAPIV2_With_NHWC_fp16(unittest.TestCase):
     def test_numerical_accuracy(self):
-        if not core.is_compiled_with_cuda():
+        if not (core.is_compiled_with_cuda() or is_custom_device()):
             return
         paddle.disable_static()
         shape = (2, 4, 2, 6)
@@ -450,7 +450,7 @@ class TestGroupNormAPIV2_With_NHWC_fp16(unittest.TestCase):
 
 class TestGroupNormAPIV2_With_NDHWC_fp16(unittest.TestCase):
     def test_numerical_accuracy(self):
-        if not core.is_compiled_with_cuda():
+        if not (core.is_compiled_with_cuda() or is_custom_device()):
             return
         paddle.disable_static()
         shape = (2, 4, 2, 2, 6)

--- a/test/legacy_test/test_imperative_triple_grad.py
+++ b/test/legacy_test/test_imperative_triple_grad.py
@@ -16,6 +16,7 @@ import unittest
 from unittest import TestCase
 
 import numpy as np
+from op_test import get_devices
 
 import paddle
 from paddle import base
@@ -327,9 +328,7 @@ class TestDygraphTripleGradMatmulcase1(TestCase):
         self.input_numpy_dout = None
         self.input_numpy_ddx = None
         self.input_numpy_ddy = None
-        self.places = ["cpu"]
-        if paddle.is_compiled_with_cuda():
-            self.places.append("gpu")
+        self.places = get_devices()
 
     def actual(self):
         x = paddle.to_tensor(
@@ -657,9 +656,7 @@ class TestDygraphTripleGradMatmulcase3(TestCase):
         self.input_numpy_dout = None
         self.input_numpy_ddx = None
         self.input_numpy_ddy = None
-        self.places = ["cpu"]
-        if paddle.is_compiled_with_cuda():
-            self.places.append("gpu")
+        self.places = get_devices()
 
     def actual(self):
         x = paddle.to_tensor(
@@ -961,9 +958,7 @@ class TestDygraphTripleGradMatmulcase5(TestCase):
         self.input_numpy_dout = None
         self.input_numpy_ddx = None
         self.input_numpy_ddy = None
-        self.places = ["cpu"]
-        if paddle.is_compiled_with_cuda():
-            self.places.append("gpu")
+        self.places = get_devices()
 
     def actual(self):
         x = paddle.to_tensor(

--- a/test/legacy_test/test_index_add_op.py
+++ b/test/legacy_test/test_index_add_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, convert_float_to_uint16
+from op_test import OpTest, convert_float_to_uint16, get_devices
 
 import paddle
 from paddle.base import core
@@ -199,10 +199,7 @@ class TestIndexAddAPI(unittest.TestCase):
         self.index_type = np.int32
 
     def setPlace(self):
-        self.place = []
-        self.place.append('cpu')
-        if paddle.is_compiled_with_cuda():
-            self.place.append('gpu')
+        self.place = get_devices()
 
     def config(self):
         self.axis = 0

--- a/test/legacy_test/test_index_fill.py
+++ b/test/legacy_test/test_index_fill.py
@@ -16,7 +16,7 @@ import unittest
 from itertools import combinations
 
 import numpy as np
-from op_test import get_places
+from op_test import get_devices
 
 import paddle
 from paddle.base import Program
@@ -44,7 +44,7 @@ class TestIndexFillAPIBase(unittest.TestCase):
             self.index_type
         )
 
-        self.place = get_places(string_format=True)
+        self.place = get_devices()
         if self.dtype_np == 'float16' and 'cpu' in self.place:
             self.place.remove('cpu')
 
@@ -150,7 +150,7 @@ class TestIndexFillAPI_ZeroSize(unittest.TestCase):
             self.index_type
         )
 
-        self.place = get_places(string_format=True)
+        self.place = get_devices()
         if self.dtype_np == 'float16' and 'cpu' in self.place:
             self.place.remove('cpu')
 

--- a/test/legacy_test/test_index_put_op.py
+++ b/test/legacy_test/test_index_put_op.py
@@ -16,7 +16,7 @@ import copy
 import unittest
 
 import numpy as np
-from op_test import get_places
+from op_test import get_devices
 
 import paddle
 
@@ -120,7 +120,7 @@ class TestIndexPutAPIBase(unittest.TestCase):
         self.accumulate = False
 
     def setPlace(self):
-        self.place = get_places(string_format=True)
+        self.place = get_devices()
         if self.dtype_np is np.float16 and "cpu" in self.place:
             self.place.remove("cpu")
 
@@ -620,7 +620,7 @@ class TestIndexPutInplaceAPI(unittest.TestCase):
         self.accumulate = False
 
     def setPlace(self):
-        self.place = get_places(string_format=True)
+        self.place = get_devices()
 
     def test_dygraph_forward(self):
         paddle.disable_static()
@@ -661,7 +661,7 @@ class TestIndexPutAPIBackward(unittest.TestCase):
         self.setPlace()
 
     def setPlace(self):
-        self.place = get_places(string_format=True)
+        self.place = get_devices()
 
     def test_backward(self):
         paddle.disable_static()
@@ -1019,7 +1019,7 @@ class TestIndexPutAPI_ZeroSize(unittest.TestCase):
         self.index_type_pd = paddle.int64
 
     def setPlace(self):
-        self.place = get_places(string_format=True)
+        self.place = get_devices()
         if self.dtype_np is np.float16 and "cpu" in self.place:
             self.place.remove("cpu")
 

--- a/test/legacy_test/test_inplace.py
+++ b/test/legacy_test/test_inplace.py
@@ -2090,9 +2090,7 @@ class TestDygraphInplaceBernoulliError(unittest.TestCase):
 class TestDygraphInplaceSet(unittest.TestCase):
     def setUp(self):
         self.init_data()
-        self.places = [paddle.CPUPlace()]
-        if paddle.base.core.is_compiled_with_cuda():
-            self.places.append(paddle.CUDAPlace(0))
+        self.places = get_places()
         self.support_dtypes = [
             'float32',
             'float64',
@@ -2274,7 +2272,7 @@ class TestDygraphInplaceSet(unittest.TestCase):
 class TestDygraphInplaceSetFP16(TestDygraphInplaceSet):
     def setUp(self):
         self.init_data()
-        self.places = [paddle.CUDAPlace(0)]
+        self.places = get_places()
 
     def init_data(self):
         self.x_np = np.random.uniform(-5, 5, [7, 20, 2])
@@ -2304,7 +2302,7 @@ class TestDygraphInplaceSetFP16(TestDygraphInplaceSet):
 class TestDygraphInplaceSetBF16(TestDygraphInplaceSet):
     def setUp(self):
         self.init_data()
-        self.places = [paddle.CUDAPlace(0)]
+        self.places = get_places()
 
     def init_data(self):
         self.x_np = np.random.uniform(-5, 5, [7, 20, 2])
@@ -2329,9 +2327,7 @@ class TestDygraphInplaceSetBF16(TestDygraphInplaceSet):
 class TestDygraphInplaceResize(unittest.TestCase):
     def setUp(self):
         self.init_data()
-        self.places = [paddle.CPUPlace()]
-        if paddle.base.core.is_compiled_with_cuda():
-            self.places.append(paddle.CUDAPlace(0))
+        self.places = get_places()
         self.support_dtypes = [
             'float32',
             'float64',
@@ -2444,7 +2440,7 @@ class TestDygraphInplaceResize(unittest.TestCase):
 class TestDygraphInplaceResizeFP16(TestDygraphInplaceResize):
     def setUp(self):
         self.init_data()
-        self.places = [paddle.CUDAPlace(0)]
+        self.places = get_places()
 
     def init_data(self):
         self.x_np = np.random.uniform(-5, 5, [3, 10, 2])
@@ -2472,7 +2468,7 @@ class TestDygraphInplaceResizeFP16(TestDygraphInplaceResize):
 class TestDygraphInplaceResizeBF16(TestDygraphInplaceResize):
     def setUp(self):
         self.init_data()
-        self.places = [paddle.CUDAPlace(0)]
+        self.places = get_places()
 
     def init_data(self):
         self.x_np = np.random.uniform(-5, 5, [3, 10, 2])

--- a/test/legacy_test/test_ldexp.py
+++ b/test/legacy_test/test_ldexp.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import get_places
+from op_test import get_devices, get_places
 
 import paddle
 
@@ -86,7 +86,7 @@ def check_dtype(input, desired_dtype):
 
 class TestLdexpAPIWithDynamic(unittest.TestCase):
     def setUp(self):
-        self.places = get_places(string_format=True)
+        self.places = get_devices()
 
     def test_ldexp_dynamic(self):
         np.random.seed(7)
@@ -136,7 +136,7 @@ class TestLdexpAPIWithDynamic(unittest.TestCase):
 
 class TestLdexpAPIWithStatic(unittest.TestCase):
     def setUp(self):
-        self.places = get_places(string_format=True)
+        self.places = get_devices()
 
     def test_ldexp_static(self):
         np.random.seed(7)

--- a/test/legacy_test/test_linalg_vecdot.py
+++ b/test/legacy_test/test_linalg_vecdot.py
@@ -17,6 +17,7 @@ import sys
 import unittest
 
 import numpy as np
+from op_test import get_places
 
 import paddle
 from paddle.base import core
@@ -34,9 +35,7 @@ class VecDotTestCase(unittest.TestCase):
         self.init_config()
         self.generate_input()
         self.generate_expected_output()
-        self.places = [paddle.CPUPlace()]
-        if paddle.is_compiled_with_cuda():
-            self.places.append(paddle.CUDAPlace(0))
+        self.places = get_places()
 
     def generate_input(self):
         np.random.seed(123)

--- a/test/legacy_test/test_log_normal_inplace.py
+++ b/test/legacy_test/test_log_normal_inplace.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import get_places
+from op_test import get_devices
 
 import paddle
 
@@ -44,7 +44,7 @@ class TestLogNormalRandomInplaceOpDtype(unittest.TestCase):
             tensor_fp64.log_normal_()
             self.assertEqual(tensor_fp64.dtype, paddle.float64)
 
-        places = get_places(string_format=True)
+        places = get_devices()
         for place in places:
             paddle.set_device(place)
             test_fp32()
@@ -105,7 +105,7 @@ class TestLogNormalRandomInplaceOpDistribution(unittest.TestCase):
 
 class TestLogNormalRandomInplaceOpEmptyTensor(unittest.TestCase):
     def test_log_normal_inplace_op_empty_tensor(self):
-        places = get_places(string_format=True)
+        places = get_devices()
         test_shapes = [(200, 0), (0, 200)]
         for place in places:
             paddle.set_device(place)
@@ -133,7 +133,7 @@ class TestLogNormalRandomInplaceGrad(unittest.TestCase):
             log_normal_grad = tensor_b.grad.numpy()
             self.assertTrue((log_normal_grad == 0).all())
 
-        places = get_places(string_format=True)
+        places = get_devices()
         for place in places:
             paddle.set_device(place)
             test_grad()

--- a/test/legacy_test/test_margin_cross_entropy_op.py
+++ b/test/legacy_test/test_margin_cross_entropy_op.py
@@ -15,7 +15,13 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, convert_float_to_uint16, paddle_static_guard
+from op_test import (
+    OpTest,
+    convert_float_to_uint16,
+    get_places,
+    is_custom_device,
+    paddle_static_guard,
+)
 
 import paddle
 from paddle.base import core
@@ -329,16 +335,15 @@ class TestMarginCrossEntropyOpCPU(TestMarginCrossEntropyOp):
 
 
 @unittest.skipIf(
-    not core.is_compiled_with_cuda(), "core is not compiled with CUDA"
+    not (core.is_compiled_with_cuda() or is_custom_device()),
+    "core is not compiled with CUDA",
 )
 class TestMarginCrossEntropyOpV2(unittest.TestCase):
     def setUp(self):
         self.initParams()
         np.random.seed(self.seed)
         paddle.framework.random._manual_program_seed(self.seed)
-        self.places = []
-        if core.is_compiled_with_cuda():
-            self.places.append(paddle.base.CUDAPlace(0))
+        self.places = get_places()
 
     def initParams(self):
         self.python_out_sig = ["Loss"]
@@ -501,16 +506,15 @@ class TestMarginCrossEntropyOpV4(TestMarginCrossEntropyOpV2):
 
 
 @unittest.skipIf(
-    not core.is_compiled_with_cuda(), "core is not compiled with CUDA"
+    not (core.is_compiled_with_cuda() or is_custom_device()),
+    "core is not compiled with CUDA",
 )
 class TestMarginCrossEntropyOpAPIError(unittest.TestCase):
     def setUp(self):
         self.initParams()
         np.random.seed(self.seed)
         paddle.framework.random._manual_program_seed(self.seed)
-        self.places = []
-        if core.is_compiled_with_cuda():
-            self.places.append(paddle.base.CUDAPlace(0))
+        self.places = get_places()
 
     def initParams(self):
         self.python_api = python_api

--- a/test/legacy_test/test_matmul_0_size_op.py
+++ b/test/legacy_test/test_matmul_0_size_op.py
@@ -14,13 +14,16 @@
 
 import unittest
 
+from op_test import is_custom_device
+
 import paddle
 from paddle import _C_ops
 from paddle.base import core
 
 
 @unittest.skipIf(
-    not core.is_compiled_with_cuda(), "mamtul 0 size only with in cuda"
+    not (core.is_compiled_with_cuda() or is_custom_device()),
+    "mamtul 0 size only with in cuda",
 )
 class TestMatmulDygraph(unittest.TestCase):
     def test_matmul(self):

--- a/test/legacy_test/test_max_op.py
+++ b/test/legacy_test/test_max_op.py
@@ -156,9 +156,7 @@ class TestMaxZeroSize1(unittest.TestCase):
         self.expect_res = np.max(
             self.data, axis=tuple(self.axis), keepdims=self.keepdims
         )
-        self.places = [core.CPUPlace()]
-        if core.is_compiled_with_cuda():
-            self.places.append(core.CUDAPlace(0))
+        self.places = get_places()
 
     def test_static(self):
         with static_guard():

--- a/test/legacy_test/test_mean_op.py
+++ b/test/legacy_test/test_mean_op.py
@@ -828,9 +828,7 @@ class TestMeanAPIInt32(unittest.TestCase):
         self.x_np = np.random.randint(-1, 10000, self.x_shape).astype(
             self.dtype
         )
-        self.places = [paddle.CPUPlace()]
-        if core.is_compiled_with_cuda():
-            self.places.append(paddle.CUDAPlace(0))
+        self.places = get_places()
 
     def test_dygraph(self):
         for place in self.places:
@@ -864,9 +862,7 @@ class TestMeanAPIInt64(TestMeanAPIInt32):
         self.x_np = np.random.randint(-1, 10000, self.x_shape).astype(
             self.dtype
         )
-        self.places = [paddle.CPUPlace()]
-        if core.is_compiled_with_cuda():
-            self.places.append(paddle.CUDAPlace(0))
+        self.places = get_places()
 
 
 class TestMeanAPIBool(TestMeanAPIInt32):
@@ -874,9 +870,7 @@ class TestMeanAPIBool(TestMeanAPIInt32):
         self.x_shape = [2, 3, 4, 5]
         self.dtype = "bool"
         self.x_np = np.random.uniform(-1, 1, self.x_shape).astype(self.dtype)
-        self.places = [paddle.CPUPlace()]
-        if core.is_compiled_with_cuda():
-            self.places.append(paddle.CUDAPlace(0))
+        self.places = get_places()
 
 
 class TestMeanWithTensorAxis1(TestReduceOPTensorAxisBase):

--- a/test/legacy_test/test_merged_adam_op.py
+++ b/test/legacy_test/test_merged_adam_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import get_places
+from op_test import get_devices
 
 import paddle
 from paddle import _C_ops
@@ -205,7 +205,7 @@ class TestMergedAdam(unittest.TestCase):
 
     def test_main(self):
         for multi_precision in [False, True]:
-            for place in get_places(string_format=True):
+            for place in get_devices():
                 self.check_with_place(place, multi_precision)
 
 

--- a/test/legacy_test/test_min_op.py
+++ b/test/legacy_test/test_min_op.py
@@ -143,9 +143,7 @@ class TestMinZeroSize1(unittest.TestCase):
         self.expect_res = np.min(
             self.data, axis=tuple(self.axis), keepdims=self.keepdims
         )
-        self.places = [core.CPUPlace()]
-        if core.is_compiled_with_cuda():
-            self.places.append(core.CUDAPlace(0))
+        self.places = get_places()
 
     def test_static(self):
         with static_guard():

--- a/test/legacy_test/test_mode_op.py
+++ b/test/legacy_test/test_mode_op.py
@@ -15,7 +15,12 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, convert_float_to_uint16, convert_uint16_to_float
+from op_test import (
+    OpTest,
+    convert_float_to_uint16,
+    convert_uint16_to_float,
+    is_custom_device,
+)
 
 import paddle
 from paddle import base
@@ -121,7 +126,8 @@ class TestModeOp(OpTest):
 
 
 @unittest.skipIf(
-    not core.is_compiled_with_cuda(), "core is not compiled with CUDA"
+    not (core.is_compiled_with_cuda() or is_custom_device()),
+    "core is not compiled with CUDA",
 )
 class TestModeFP16Op(TestModeOp):
     def init_dtype(self):
@@ -168,7 +174,8 @@ class TestModeOpLastdim(TestModeOp):
 
 
 @unittest.skipIf(
-    not core.is_compiled_with_cuda(), "core is not compiled with CUDA"
+    not (core.is_compiled_with_cuda() or is_custom_device()),
+    "core is not compiled with CUDA",
 )
 class TestModeFP16OpLastdim(TestModeFP16Op):
     def init_args(self):
@@ -177,7 +184,8 @@ class TestModeFP16OpLastdim(TestModeFP16Op):
 
 
 @unittest.skipIf(
-    not core.is_compiled_with_cuda(), "core is not compiled with CUDA"
+    not (core.is_compiled_with_cuda() or is_custom_device()),
+    "core is not compiled with CUDA",
 )
 class TestModeBF16OpLastdim(TestModeBF16Op):
     def init_args(self):

--- a/test/legacy_test/test_momentum_op.py
+++ b/test/legacy_test/test_momentum_op.py
@@ -16,7 +16,7 @@ import unittest
 
 import numpy as np
 from op import Operator
-from op_test import OpTest, get_places
+from op_test import OpTest, get_devices, get_places
 
 import paddle
 from paddle import base
@@ -1036,7 +1036,7 @@ class TestMultiTensorMomentumDygraph(unittest.TestCase):
             np.testing.assert_allclose(params1[idx], params2[idx], rtol=1e-05)
 
     def test_main(self):
-        for place in get_places(string_format=True):
+        for place in get_devices():
             use_amp_list = [True, False]
             for use_amp in use_amp_list:
                 self._check_with_place_amp(place, use_amp)

--- a/test/legacy_test/test_multi_label_soft_margin_loss.py
+++ b/test/legacy_test/test_multi_label_soft_margin_loss.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import get_places
+from op_test import get_devices
 
 import paddle
 
@@ -145,7 +145,7 @@ class TestMultiLabelMarginLoss(unittest.TestCase):
         input = np.random.uniform(0.1, 0.8, size=(5, 5)).astype(np.float64)
         label = np.random.randint(0, 2, size=(5, 5)).astype(np.float64)
 
-        places = get_places(string_format=True)
+        places = get_devices()
         reductions = ['sum', 'mean', 'none']
         for place in places:
             for reduction in reductions:

--- a/test/legacy_test/test_nadam_op.py
+++ b/test/legacy_test/test_nadam_op.py
@@ -16,7 +16,7 @@ import unittest
 from copy import deepcopy
 
 import numpy as np
-from op_test import OpTest, get_device_place, get_places
+from op_test import OpTest, get_device_place, get_devices, get_places
 
 import paddle
 from paddle import base
@@ -460,7 +460,7 @@ class TestNAdamMultiPrecision(unittest.TestCase):
                 optimizer.clear_grad()
 
     def test_main(self):
-        for place in get_places(string_format=True):
+        for place in get_devices():
             use_amp_list = [True, False]
             for use_amp in use_amp_list:
                 self._test_nadam_dygraph_place_amp(place, use_amp)

--- a/test/legacy_test/test_normal_inplace.py
+++ b/test/legacy_test/test_normal_inplace.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import get_places
+from op_test import get_devices
 
 import paddle
 
@@ -43,7 +43,7 @@ class TestNormalRandomInplaceOpDtype(unittest.TestCase):
             tensor_fp64.normal_()
             self.assertEqual(tensor_fp64.dtype, paddle.float64)
 
-        for place in get_places(string_format=True):
+        for place in get_devices():
             paddle.set_device(place)
             test_fp32()
             test_fp64()
@@ -64,7 +64,7 @@ class TestNormalRandomComplexInplaceOpDtype(unittest.TestCase):
             tensor_fp64.normal_()
             self.assertEqual(tensor_fp64.dtype, paddle.complex128)
 
-        for place in get_places(string_format=True):
+        for place in get_devices():
             paddle.set_device(place)
             test_fp32()
             test_fp64()
@@ -164,7 +164,7 @@ class TestNormalRandomComplexInplaceOpDistribution(unittest.TestCase):
 class TestNormalRandomInplaceOpEmptyTensor(unittest.TestCase):
     def test_normal_inplace_op_empty_tensor(self):
         test_shapes = [(200, 0), (0, 200)]
-        for place in get_places(string_format=True):
+        for place in get_devices():
             paddle.set_device(place)
             for test_shape in test_shapes:
                 tensor = paddle.empty(shape=test_shape)
@@ -190,7 +190,7 @@ class TestNormalRandomInplaceGrad(unittest.TestCase):
             normal_grad = tensor_b.grad.numpy()
             self.assertTrue((normal_grad == 0).all())
 
-        for place in get_places(string_format=True):
+        for place in get_devices():
             paddle.set_device(place)
             test_grad()
 
@@ -215,7 +215,7 @@ class TestNormalRandomComplexInplaceGrad(unittest.TestCase):
             self.assertTrue((normal_grad.real == 0).all())
             self.assertTrue((normal_grad.imag == 0).all())
 
-        for place in get_places(string_format=True):
+        for place in get_devices():
             paddle.set_device(place)
             test_grad()
 

--- a/test/legacy_test/test_pad3d_op.py
+++ b/test/legacy_test/test_pad3d_op.py
@@ -15,7 +15,12 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, convert_float_to_uint16, get_places
+from op_test import (
+    OpTest,
+    convert_float_to_uint16,
+    get_places,
+    is_custom_device,
+)
 
 import paddle
 import paddle.nn.functional as F
@@ -221,7 +226,8 @@ class TestCase10(TestPad3dOp):
 
 def create_test_fp16(parent):
     @unittest.skipIf(
-        not core.is_compiled_with_cuda(), "core is not compiled with CUDA"
+        not (core.is_compiled_with_cuda() or is_custom_device()),
+        "core is not compiled with CUDA",
     )
     class TestPad3dFp16(parent):
         def get_dtype(self):
@@ -304,7 +310,8 @@ create_test_bf16(TestCase10)
 # ----------------Pad3d complex64----------------
 def create_test_complex64(parent):
     @unittest.skipIf(
-        not core.is_compiled_with_cuda(), "core is not compiled with CUDA"
+        not (core.is_compiled_with_cuda() or is_custom_device()),
+        "core is not compiled with CUDA",
     )
     class TestPad3dComplex64(parent):
         def get_dtype(self):
@@ -344,7 +351,8 @@ create_test_complex64(TestCase10)
 
 def create_test_complex128(parent):
     @unittest.skipIf(
-        not core.is_compiled_with_cuda(), "core is not compiled with CUDA"
+        not (core.is_compiled_with_cuda() or is_custom_device()),
+        "core is not compiled with CUDA",
     )
     class TestPad3dComplex128(parent):
         def get_dtype(self):

--- a/test/legacy_test/test_pow.py
+++ b/test/legacy_test/test_pow.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import get_places
+from op_test import get_devices
 
 import paddle
 from paddle.static import Program, program_guard
@@ -79,7 +79,7 @@ class TestPowerAPI(unittest.TestCase):
     """TestPowerAPI."""
 
     def setUp(self):
-        self.places = get_places(string_format=True)
+        self.places = get_devices()
 
     def test_power(self):
         """test_power."""
@@ -227,7 +227,7 @@ class TestPowerAPI_ZeroSize(unittest.TestCase):
     """TestPowerAPI."""
 
     def setUp(self):
-        self.places = get_places(string_format=True)
+        self.places = get_devices()
 
     def _test_power(self, shape):
         np.random.seed(7)

--- a/test/legacy_test/test_pow_op.py
+++ b/test/legacy_test/test_pow_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest
+from op_test import OpTest, get_places
 
 import paddle
 from paddle.framework import core
@@ -39,9 +39,7 @@ class TestPowOp(OpTest):
             self.outputs = {
                 'Out': np.power(self.inputs['X'], self.attrs["factor"])
             }
-        self.places = [core.CPUPlace()]
-        if core.is_compiled_with_cuda():
-            self.places.append(core.CUDAPlace(0))
+        self.places = get_places()
 
     def custom_setting(self):
         self.inputs = {

--- a/test/legacy_test/test_psroi_pool_op.py
+++ b/test/legacy_test/test_psroi_pool_op.py
@@ -16,7 +16,7 @@ import math
 import unittest
 
 import numpy as np
-from op_test import OpTest, get_places
+from op_test import OpTest, get_devices, get_places
 
 import paddle
 
@@ -228,7 +228,7 @@ class TestPSROIPoolDynamicFunctionAPI(unittest.TestCase):
             )
             np.testing.assert_allclose(out, expect_out, rtol=1e-05)
 
-        places = get_places(string_format=True)
+        places = get_devices()
         for place in places:
             paddle.set_device(place)
             test_output_size_is_int()
@@ -282,7 +282,7 @@ class TestPSROIPoolDynamicClassAPI(unittest.TestCase):
             np.testing.assert_allclose(out, expect_out, rtol=1e-05)
 
         paddle.disable_static()
-        places = get_places(string_format=True)
+        places = get_devices()
         for place in places:
             paddle.set_device(place)
             test_output_size_is_int()

--- a/test/legacy_test/test_radam_op.py
+++ b/test/legacy_test/test_radam_op.py
@@ -16,7 +16,7 @@ import unittest
 from copy import deepcopy
 
 import numpy as np
-from op_test import OpTest, get_device_place, get_places
+from op_test import OpTest, get_device_place, get_devices, get_places
 
 import paddle
 from paddle import base
@@ -471,7 +471,7 @@ class TestRAdamMultiPrecision(unittest.TestCase):
                 optimizer.clear_grad()
 
     def test_main(self):
-        for place in get_places(string_format=True):
+        for place in get_devices():
             use_amp_list = [True, False]
             for use_amp in use_amp_list:
                 self._test_radam_dygraph_place_amp(place, use_amp)

--- a/test/legacy_test/test_random_seed.py
+++ b/test/legacy_test/test_random_seed.py
@@ -16,6 +16,7 @@
 import unittest
 
 import numpy as np
+from op_test import is_custom_device
 
 import paddle
 from paddle import base
@@ -51,7 +52,10 @@ class TestGeneratorSeed(unittest.TestCase):
         x2_np = x2.numpy()
         x3_np = x3.numpy()
 
-        if not core.is_compiled_with_cuda() and not core.is_compiled_with_xpu():
+        if (
+            not (core.is_compiled_with_cuda() or is_custom_device())
+            and not core.is_compiled_with_xpu()
+        ):
             np.testing.assert_allclose(x1_np, x2_np, rtol=1e-05)
             np.testing.assert_allclose(x_np, x3_np, rtol=1e-05)
 
@@ -85,7 +89,7 @@ class TestGeneratorSeed(unittest.TestCase):
             out2_res2 = np.array(out2[1])
 
             if (
-                not core.is_compiled_with_cuda()
+                not (core.is_compiled_with_cuda() or is_custom_device())
                 and not core.is_compiled_with_xpu()
             ):
                 np.testing.assert_allclose(out1_res1, out2_res1, rtol=1e-05)
@@ -107,7 +111,10 @@ class TestGeneratorSeed(unittest.TestCase):
         y_np = y.numpy()
         y1_np = y1.numpy()
 
-        if not core.is_compiled_with_cuda() and not core.is_compiled_with_xpu():
+        if (
+            not (core.is_compiled_with_cuda() or is_custom_device())
+            and not core.is_compiled_with_xpu()
+        ):
             print(">>>>>>> dropout dygraph >>>>>>>")
             np.testing.assert_allclose(y_np, y1_np, rtol=1e-05)
 
@@ -132,7 +139,10 @@ class TestGeneratorSeed(unittest.TestCase):
         out1_np = np.array(out1[0])
         out2_np = np.array(out2[0])
 
-        if not core.is_compiled_with_cuda() and not core.is_compiled_with_xpu():
+        if (
+            not (core.is_compiled_with_cuda() or is_custom_device())
+            and not core.is_compiled_with_xpu()
+        ):
             print(">>>>>>> dropout static >>>>>>>")
             np.testing.assert_allclose(out1_np, out2_np, rtol=1e-05)
 
@@ -153,7 +163,10 @@ class TestGeneratorSeed(unittest.TestCase):
         x2_np = x2.numpy()
         x3_np = x3.numpy()
 
-        if not core.is_compiled_with_cuda() and not core.is_compiled_with_xpu():
+        if (
+            not (core.is_compiled_with_cuda() or is_custom_device())
+            and not core.is_compiled_with_xpu()
+        ):
             print(">>>>>>> gaussian random dygraph >>>>>>>")
             np.testing.assert_allclose(x1_np, x2_np, rtol=1e-05)
             np.testing.assert_allclose(x_np, x3_np, rtol=1e-05)
@@ -188,7 +201,7 @@ class TestGeneratorSeed(unittest.TestCase):
             out2_res2 = np.array(out2[1])
 
             if (
-                not core.is_compiled_with_cuda()
+                not (core.is_compiled_with_cuda() or is_custom_device())
                 and not core.is_compiled_with_xpu()
             ):
                 print(">>>>>>> gaussian random static >>>>>>>")
@@ -213,7 +226,10 @@ class TestGeneratorSeed(unittest.TestCase):
         x2_np = x2.numpy()
         x3_np = x3.numpy()
 
-        if not core.is_compiled_with_cuda() and not core.is_compiled_with_xpu():
+        if (
+            not (core.is_compiled_with_cuda() or is_custom_device())
+            and not core.is_compiled_with_xpu()
+        ):
             print(">>>>>>> randint dygraph >>>>>>>")
             np.testing.assert_allclose(x1_np, x2_np, rtol=1e-05)
             np.testing.assert_allclose(x_np, x3_np, rtol=1e-05)
@@ -248,7 +264,7 @@ class TestGeneratorSeed(unittest.TestCase):
             out2_res2 = np.array(out2[1])
 
             if (
-                not core.is_compiled_with_cuda()
+                not (core.is_compiled_with_cuda() or is_custom_device())
                 and not core.is_compiled_with_xpu()
             ):
                 np.testing.assert_allclose(out1_res1, out2_res1, rtol=1e-05)
@@ -271,7 +287,10 @@ class TestGeneratorSeed(unittest.TestCase):
         x1_np = x1.numpy()
         x2_np = x2.numpy()
         x3_np = x3.numpy()
-        if not core.is_compiled_with_cuda() and not core.is_compiled_with_xpu():
+        if (
+            not (core.is_compiled_with_cuda() or is_custom_device())
+            and not core.is_compiled_with_xpu()
+        ):
             np.testing.assert_allclose(x1_np, x2_np, rtol=1e-05)
             np.testing.assert_allclose(x_np, x3_np, rtol=1e-05)
 
@@ -305,7 +324,7 @@ class TestGeneratorSeed(unittest.TestCase):
             out2_res2 = np.array(out2[1])
 
             if (
-                not core.is_compiled_with_cuda()
+                not (core.is_compiled_with_cuda() or is_custom_device())
                 and not core.is_compiled_with_xpu()
             ):
                 print(">>>>>>> randint static >>>>>>>")
@@ -331,7 +350,10 @@ class TestGeneratorSeed(unittest.TestCase):
         x2_np = x2.numpy()
         x3_np = x3.numpy()
 
-        if not core.is_compiled_with_cuda() and not core.is_compiled_with_xpu():
+        if (
+            not (core.is_compiled_with_cuda() or is_custom_device())
+            and not core.is_compiled_with_xpu()
+        ):
             print(">>>>>>> randperm dygraph >>>>>>>")
             np.testing.assert_allclose(x1_np, x2_np, rtol=1e-05)
             np.testing.assert_allclose(x_np, x3_np, rtol=1e-05)
@@ -366,7 +388,7 @@ class TestGeneratorSeed(unittest.TestCase):
             out2_res2 = np.array(out2[1])
 
             if (
-                not core.is_compiled_with_cuda()
+                not (core.is_compiled_with_cuda() or is_custom_device())
                 and not core.is_compiled_with_xpu()
             ):
                 print(">>>>>>> randperm static >>>>>>>")

--- a/test/legacy_test/test_reduce_op.py
+++ b/test/legacy_test/test_reduce_op.py
@@ -19,6 +19,7 @@ from op_test import (
     OpTest,
     convert_float_to_uint16,
     get_places,
+    is_custom_device,
     skip_check_grad_ci,
 )
 from utils import dygraph_guard, static_guard
@@ -192,7 +193,8 @@ class TestSumOp3Dim(TestSumOp):
 
 def create_test_fp16_class(parent):
     @unittest.skipIf(
-        not core.is_compiled_with_cuda(), "core is not compiled with CUDA"
+        not (core.is_compiled_with_cuda() or is_custom_device()),
+        "core is not compiled with CUDA",
     )
     class TestSumOpFp16(parent):
         def init_dtype(self):
@@ -341,9 +343,7 @@ class TestSumAPIZeroDimKeepDim(unittest.TestCase):
     def setUp(self):
         np.random.seed(123)
         paddle.enable_static()
-        self.places = [paddle.CPUPlace()]
-        if paddle.is_compiled_with_cuda():
-            self.places.append(paddle.CUDAPlace(0))
+        self.places = get_places()
 
     def test_static(self):
         for place in self.places:
@@ -2365,9 +2365,7 @@ class TestAllZero(unittest.TestCase):
             "complex64",
             "complex128",
         ]
-        self.places = [base.CPUPlace()]
-        if core.is_compiled_with_cuda():
-            self.places.append(base.CUDAPlace(0))
+        self.places = get_places()
 
     def calculate_expected_result(self, x_np, axis, keepdim):
         expected_result = np.all(x_np, axis=axis, keepdims=keepdim)
@@ -2454,9 +2452,7 @@ class TestAnyZero(unittest.TestCase):
             "complex64",
             "complex128",
         ]
-        self.places = [base.CPUPlace()]
-        if core.is_compiled_with_cuda():
-            self.places.append(base.CUDAPlace(0))
+        self.places = get_places()
 
     def calculate_expected_result(self, x_np, axis, keepdim):
         expected_result = np.any(x_np, axis=axis, keepdims=keepdim)

--- a/test/legacy_test/test_restrict_nonzero.py
+++ b/test/legacy_test/test_restrict_nonzero.py
@@ -15,13 +15,15 @@
 import unittest
 
 import numpy as np
+from op_test import is_custom_device
 
 import paddle
 from paddle.base import core
 
 
 @unittest.skipIf(
-    not core.is_compiled_with_cuda(), "core is not compiled with CUDA"
+    not (core.is_compiled_with_cuda() or is_custom_device()),
+    "core is not compiled with CUDA",
 )
 class TestRestrictNonzero(unittest.TestCase):
     def test_restrict_nonzero(self):

--- a/test/legacy_test/test_rmsprop_op.py
+++ b/test/legacy_test/test_rmsprop_op.py
@@ -16,7 +16,7 @@ import unittest
 
 import numpy as np
 from op import Operator
-from op_test import get_device_place, get_places
+from op_test import get_device_place, get_devices, get_places
 
 import paddle
 from paddle import base
@@ -416,7 +416,7 @@ class TestRMSOpMultiPrecision(unittest.TestCase):
         paddle.enable_static()
 
     def test_main(self):
-        for place in get_places(string_format=True):
+        for place in get_devices():
             use_amp_list = [True, False]
             for use_amp in use_amp_list:
                 self._test_rms_op_dygraph_place_amp(place, use_amp)

--- a/test/legacy_test/test_rrelu_op.py
+++ b/test/legacy_test/test_rrelu_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, convert_float_to_uint16, get_places
+from op_test import OpTest, convert_float_to_uint16, get_device_place
 
 import paddle
 import paddle.nn.functional as F
@@ -50,7 +50,7 @@ class TestFunctionalRReluAPI(unittest.TestCase):
         self.upper_0 = 0.25
         self.upper_1 = 0.33
 
-        self.places = get_places()
+        self.places = [get_device_place()]
 
     def check_static_result(self, place):
         with paddle.static.program_guard(

--- a/test/legacy_test/test_rrelu_op.py
+++ b/test/legacy_test/test_rrelu_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, convert_float_to_uint16
+from op_test import OpTest, convert_float_to_uint16, get_places
 
 import paddle
 import paddle.nn.functional as F
@@ -50,13 +50,7 @@ class TestFunctionalRReluAPI(unittest.TestCase):
         self.upper_0 = 0.25
         self.upper_1 = 0.33
 
-        self.places = [
-            (
-                base.CUDAPlace(0)
-                if core.is_compiled_with_cuda()
-                else base.CPUPlace()
-            )
-        ]
+        self.places = get_places()
 
     def check_static_result(self, place):
         with paddle.static.program_guard(

--- a/test/legacy_test/test_set_value_op.py
+++ b/test/legacy_test/test_set_value_op.py
@@ -17,7 +17,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, convert_float_to_uint16, get_places
+from op_test import OpTest, convert_float_to_uint16, get_devices
 
 import paddle
 from paddle.base import core
@@ -1277,7 +1277,7 @@ class TestSetValueValueShape6(TestSetValueApi):
         return x
 
     def test_api(self):
-        for place in get_places(string_format=True):
+        for place in get_devices():
             paddle.set_device(place)
 
             static_out = self._run_static()

--- a/test/legacy_test/test_sign_op.py
+++ b/test/legacy_test/test_sign_op.py
@@ -194,10 +194,7 @@ class TestSignAPI(unittest.TestCase):
 
 class TestSignComplexAPI(TestSignAPI):
     def setUp(self):
-        self.place = []
-        self.place.append(base.CPUPlace())
-        if core.is_compiled_with_cuda():
-            self.place.append(base.CUDAPlace(0))
+        self.place = get_places()
 
     def test_dygraph(self):
         with base.dygraph.guard():

--- a/test/legacy_test/test_soft_margin_loss.py
+++ b/test/legacy_test/test_soft_margin_loss.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import get_places
+from op_test import get_devices, get_places
 
 import paddle
 
@@ -127,7 +127,7 @@ class TestSoftMarginLoss(unittest.TestCase):
     def test_SoftMarginLoss(self):
         input_np = np.random.uniform(0.1, 0.8, size=(5, 5)).astype(np.float64)
         types = [np.int32, np.int64, np.float32, np.float64]
-        places = get_places(string_format=True)
+        places = get_devices()
         reductions = ['sum', 'mean', 'none']
         for place in places:
             for reduction in reductions:

--- a/test/legacy_test/test_sum_op.py
+++ b/test/legacy_test/test_sum_op.py
@@ -889,9 +889,7 @@ class TestSum_BoolToInt64_ZeroSize(unittest.TestCase):
     def setUp(self):
         np.random.seed(123)
         self.shape = [3, 0, 2]
-        self.places = [base.CPUPlace()]
-        if core.is_compiled_with_cuda():
-            self.places.append(base.CUDAPlace(0))
+        self.places = get_places()
 
     def check_result(
         self, dygraph_result, expected_result, axis, keepdim, dtype, place

--- a/test/legacy_test/test_tensor_type_autocast.py
+++ b/test/legacy_test/test_tensor_type_autocast.py
@@ -15,6 +15,7 @@
 import unittest
 
 import numpy as np
+from op_test import get_places
 
 import paddle
 
@@ -22,9 +23,7 @@ import paddle
 class TestAutocastBase(unittest.TestCase):
     def setUp(self):
         self.set_api_and_dtypes()
-        self.places = [paddle.CPUPlace()]
-        if paddle.core.is_compiled_with_cuda():
-            self.places.append(paddle.CUDAPlace(0))
+        self.places = get_places()
 
     def set_api_and_dtypes(self):
         pass

--- a/test/legacy_test/test_trace_op.py
+++ b/test/legacy_test/test_trace_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, convert_float_to_uint16
+from op_test import OpTest, convert_float_to_uint16, get_places
 
 import paddle
 from paddle import base, tensor
@@ -202,9 +202,7 @@ class TestTraceAPICase(unittest.TestCase):
 
 class TestTraceAPIZerodimCase(unittest.TestCase):
     def setUp(self):
-        self.places = [paddle.CPUPlace()]
-        if paddle.is_compiled_with_cuda():
-            self.places.append(paddle.CUDAPlace(0))
+        self.places = get_places()
         self.x = np.random.random([5, 0, 0, 0]).astype('float32')
 
     def test_dygraph(self):

--- a/test/legacy_test/test_transforms.py
+++ b/test/legacy_test/test_transforms.py
@@ -19,7 +19,7 @@ import unittest
 
 import cv2
 import numpy as np
-from op_test import get_places
+from op_test import get_devices
 from PIL import Image
 
 import paddle
@@ -819,7 +819,7 @@ class TestFunctional(unittest.TestCase):
         np_img_gray = (np.random.rand(28, 28, 1) * 255).astype('uint8')
         tensor_img_gray = F.to_tensor(np_img_gray)
 
-        places = get_places(string_format=True)
+        places = get_devices()
 
         def test_adjust_brightness(np_img, tensor_img):
             result_cv2 = np.array(F.adjust_brightness(np_img, 1.2))
@@ -956,7 +956,7 @@ class TestFunctional(unittest.TestCase):
         np.testing.assert_equal(np.array(pil_result), expected)
 
         np_data = np.random.rand(3, 28, 28).astype('float32')
-        for place in get_places(string_format=True):
+        for place in get_devices():
             paddle.set_device(place)
             tensor_img = paddle.to_tensor(np_data)
             expected_tensor = tensor_img.clone()

--- a/test/legacy_test/test_uniform_random_inplace_op.py
+++ b/test/legacy_test/test_uniform_random_inplace_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, convert_uint16_to_float, get_places
+from op_test import OpTest, convert_uint16_to_float, get_devices
 
 import paddle
 from paddle.base import core
@@ -44,7 +44,7 @@ class TestUniformRandomInplaceOpDtype(unittest.TestCase):
             tensor_fp64.uniform_()
             self.assertEqual(tensor_fp64.dtype, paddle.float64)
 
-        for place in get_places(string_format=True):
+        for place in get_devices():
             paddle.set_device(place)
             test_fp32()
             test_fp64()
@@ -215,7 +215,7 @@ class TestUniformRandomInplaceOpError(unittest.TestCase):
 class TestUniformRandomInplaceOpEmptyTensor(unittest.TestCase):
     def test_uniform_random_inplace_op_empty_tensor(self):
         test_shapes = [(200, 0), (0, 200)]
-        for place in get_places(string_format=True):
+        for place in get_devices():
             paddle.set_device(place)
             for test_shape in test_shapes:
                 tensor = paddle.empty(shape=test_shape)
@@ -241,7 +241,7 @@ class TestUniformRandomInplaceGrad(unittest.TestCase):
             uniform_grad = tensor_b.grad.numpy()
             self.assertTrue((uniform_grad == 0).all())
 
-        for place in get_places(string_format=True):
+        for place in get_devices():
             paddle.set_device(place)
             test_grad()
 

--- a/test/legacy_test/test_uniform_random_op.py
+++ b/test/legacy_test/test_uniform_random_op.py
@@ -16,7 +16,12 @@ import unittest
 
 import numpy as np
 from op import Operator
-from op_test import OpTest, convert_uint16_to_float, get_places
+from op_test import (
+    OpTest,
+    convert_uint16_to_float,
+    get_places,
+    is_custom_device,
+)
 
 import paddle
 from paddle import base
@@ -187,7 +192,8 @@ class TestUniformRandomOp(OpTest):
 
 
 @unittest.skipIf(
-    not core.is_compiled_with_cuda(), "core is not compiled with CUDA"
+    not (core.is_compiled_with_cuda() or is_custom_device()),
+    "core is not compiled with CUDA",
 )
 class TestUniformRandomFP16Op(TestUniformRandomOp):
     def init_dtype(self):

--- a/test/legacy_test/test_zero_dim_no_backward_api.py
+++ b/test/legacy_test/test_zero_dim_no_backward_api.py
@@ -21,7 +21,7 @@ import unittest
 
 import numpy as np
 from decorator_helper import prog_scope
-from op_test import get_places
+from op_test import get_devices
 
 import paddle
 
@@ -182,7 +182,7 @@ class TestNoBackwardAPI(unittest.TestCase):
         self.assertEqual(one_hot_label.numpy()[2], 1)
 
     def test_unique_consecutive(self):
-        for place in get_places(string_format=True):
+        for place in get_devices():
             paddle.set_device(place)
             x = paddle.rand([])
             y, inverse, counts = paddle.unique_consecutive(
@@ -199,7 +199,7 @@ class TestNoBackwardAPI(unittest.TestCase):
             self.assertEqual(counts.shape, [1])
 
     def test_unique(self):
-        for place in get_places(string_format=True):
+        for place in get_devices():
             paddle.set_device(place)
             x = paddle.rand([])
             y, index, inverse, counts = paddle.unique(

--- a/test/legacy_test/test_zero_dim_sundry_dygraph_api.py
+++ b/test/legacy_test/test_zero_dim_sundry_dygraph_api.py
@@ -21,7 +21,7 @@ import os
 import unittest
 
 import numpy as np
-from op_test import get_device_place, get_places
+from op_test import get_device_place, get_devices
 
 import paddle
 import paddle.nn.functional as F
@@ -1691,7 +1691,7 @@ class TestSundryAPI(unittest.TestCase):
         self.assertEqual(y2.grad.shape, [])
 
     def test_repeat_interleave(self):
-        for place in get_places(string_format=True):
+        for place in get_devices():
             paddle.set_device(place)
 
             x = paddle.randn(())


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Custom Device

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
pcard-67164
split get_places function, add is_custom_device in op_test