### PR TITLE
Fix class center sample

### DIFF
--- a/paddle/phi/kernels/gpu/class_center_sample_kernel.cu
+++ b/paddle/phi/kernels/gpu/class_center_sample_kernel.cu
@@ -333,14 +333,15 @@ void ClassCenterSampleKernel(const Context& dev_ctx,
   auto place = dev_ctx.GetPlace();
 
   int batch_size = label.numel();
-  PADDLE_ENFORCE_LE(label.numel(), 
-                    std::numeric_limits<int>::max(),
-                    errors::InvalidArgument(
-                        "The total number of elements for 'label' should be less than "
-                        "%d, "
-                        "but received %d",
-                        std::numeric_limits<int>::max(),
-                        label.numel()));
+  PADDLE_ENFORCE_LE(
+      label.numel(),
+      std::numeric_limits<int>::max(),
+      errors::InvalidArgument(
+          "The total number of elements for 'label' should be less than "
+          "%d, "
+          "but received %d",
+          std::numeric_limits<int>::max(),
+          label.numel()));
   // Algorithm:
   // We first randomly generate a value in [0, num_classes) on each position
   // in a array(shape[num_classes]). Then, we mark the element as negative
@@ -416,14 +417,15 @@ void ClassCenterSampleKernel(const Context& dev_ctx,
       std::max(std::max(cub_sort_temp_store_size, cub_scan_temp_store_size),
                cub_sum_temp_store_size);
   int num_temp_ele = cub_temp_storage_bytes / sizeof(T) + 1;
-  PADDLE_ENFORCE_GT((4 * num_buffer_ele + 3 * (nranks + 1) + num_temp_ele),
-                    0,
-                    errors::InvalidArgument(
-                        "Illegal memory allocation, total allocated space "
-                        "must be greater than 0, "
-                        "but received %d."
-                        "This is mainly caused by the size of 'label' being too large.",
-                        (4 * num_buffer_ele + 3 * (nranks + 1) + num_temp_ele)));
+  PADDLE_ENFORCE_GT(
+      (4 * num_buffer_ele + 3 * (nranks + 1) + num_temp_ele),
+      0,
+      errors::InvalidArgument(
+          "Illegal memory allocation, total allocated space must be greater "
+          "than 0, "
+          "but received %d."
+          "This is mainly caused by the size of 'label' being too large.",
+          (4 * num_buffer_ele + 3 * (nranks + 1) + num_temp_ele)));
 
   // step 3: Alloc buffer memory so that we can reuse allocated memory
   MemoryBuffer<T, Context> memory_buffer =

--- a/paddle/phi/kernels/gpu/class_center_sample_kernel.cu
+++ b/paddle/phi/kernels/gpu/class_center_sample_kernel.cu
@@ -333,6 +333,14 @@ void ClassCenterSampleKernel(const Context& dev_ctx,
   auto place = dev_ctx.GetPlace();
 
   int batch_size = label.numel();
+  PADDLE_ENFORCE_LE(label.numel(), 
+                    std::numeric_limits<int>::max(),
+                    errors::InvalidArgument(
+                        "The total number of elements for 'label' should be less than "
+                        "%d, "
+                        "but received %d",
+                        std::numeric_limits<int>::max(),
+                        label.numel()));
   // Algorithm:
   // We first randomly generate a value in [0, num_classes) on each position
   // in a array(shape[num_classes]). Then, we mark the element as negative
@@ -408,6 +416,14 @@ void ClassCenterSampleKernel(const Context& dev_ctx,
       std::max(std::max(cub_sort_temp_store_size, cub_scan_temp_store_size),
                cub_sum_temp_store_size);
   int num_temp_ele = cub_temp_storage_bytes / sizeof(T) + 1;
+  PADDLE_ENFORCE_GT((4 * num_buffer_ele + 3 * (nranks + 1) + num_temp_ele),
+                    0,
+                    errors::InvalidArgument(
+                        "Illegal memory allocation, total allocated space "
+                        "must be greater than 0, "
+                        "but received %d."
+                        "This is mainly caused by the size of 'label' being too large.",
+                        (4 * num_buffer_ele + 3 * (nranks + 1) + num_temp_ele)));
 
   // step 3: Alloc buffer memory so that we can reuse allocated memory
   MemoryBuffer<T, Context> memory_buffer =


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
主要修复：
1. label.numel() 为大Tensor时的错误抛出
2. label.numel() 导致 MemoryBuffer 分配尺寸溢出的错误抛出
导致错误的原始case可见 https://github.com/PFCCLab/PaddleAPITest/pull/488

class_center_sample 是一个调用第三方库的实现，
- 在文档中的定义为 [paddle.nn.functional.class_center_sample](https://www.paddlepaddle.org.cn/documentation/docs/zh/2.6/api/paddle/nn/functional/class_center_sample_cn.html#class-center-sample) 该 API 的输入参数为 `(label, num_classes, num_samples, group=None)`；
- 其中 label 是 1-D 的Tensor，数据类型为 int32 或者 int64，每个元素的取值范围在 [0, num_classes)
- 在  `PaddleAPITest/tester/api_config/config_analyzer.py` 的输入数据约束中已经对参数做了语意上的限制，即 0<= label[i] < num_classes

#### label.numel() 为大Tensor时的错误抛出
<meta charset="UTF-8"><ol data-morpho-type="ordered-list-item" data-slate-node="element" class="mp-ordered-list" type="1" start="1"><li class="mp-list-item" data-morpho-list-depth="0" data-morpho-list-index="2"><div class="mp-list-item-child"><div><span data-morpho-text="%E4%BA%8E%20paddleonly%20%E7%9A%84%E6%B5%8B%E8%AF%95%EF%BC%8C%E5%8F%96%E5%85%B8%E5%9E%8B%E5%80%BC%E7%9A%84%E9%94%99%E8%AF%AF%E6%83%85%E5%86%B5%E5%B9%B6%E4%B8%8D%E7%BB%9F%E4%B8%80%EF%BC%8C%E5%85%B7%E4%BD%93%E6%83%85%E5%86%B5%E5%A6%82%E4%B8%8B">于 paddleonly 的测试，取典型值的错误情况并不统一，具体情况如下</span></div></div></li></ol><div class="mp-table-align"><div class="mp-table-wrapper"><div data-slate-node="element" style="padding-left:0px" class="mp-table-container">
  | 4294967295 | 2294967295 | 2094967295 | 294967295
-- | -- | -- | -- | --
数据说明 | 恰好小于 uint 32 | 大于 int32 | 小于int32 | 远小于 int32
torch（Accuracy = Ture） | [torch error]  num_inp 4294967295 is too big to for CUB | [torch error]  num_inp 2294967295 is too big to for CUB | [paddle error] (PreconditionNotMet) The meta data must be valid when call the mutable data function.但是无法定位代码，报错信息指向/Paddle/paddle/phi/core/dense_tensor.cc | [Pass]在A100-SXM4-80GB执行时间约 20mins
paddleonly | [paddle error]  (External) CUDA error(1), invalid argument.可以定位到 /Paddle/paddle/phi/kernels/gpu/class_center_sample_kernel.cu | [paddle error] (PreconditionNotMet) The meta data must be valid when call the mutable data function.但是无法定位代码，报错信息指向/Paddle/paddle/phi/core/dense_tensor.cc | [paddle error] (PreconditionNotMet) The meta data must be valid when call the mutable data function.但是无法定位代码，报错信息指向/Paddle/paddle/phi/core/dense_tensor.cc

</div><div class="mp-table-serialize-flag"><br/></div></div></div><span data-morpho-doc-data='{"token":"eyJhbGciOiJkaXIiLCJlbmMiOiJBMjU2R0NNIiwiYXBwSWQiOjEsInVpZCI6Il9uWkZpd0VDQXYiLCJkb2NJZCI6ImgtTjY2V29namF1YkpkIn0..Sc44U3g43tA0Chio.AoCKMKMRNuZY3toxor9YFRhzuWJ4C84f612C10XoOjSvBYewt6ComNIb8z50a8cJoeEreX5MZXxGCpId_dCmX2kzwOiWzZbbTp4zGvcVzPyihsEMBJriIgZvwpfvoEud8Uxw5pFhU7sP4oGHXLqIGnzPnETxnhxwW8bMy2pyGAkjvcccDWqqXgRq42XADmwdbGd-hRZ9k3bamdgsOYF9Um_bHw.tsb27kW1EBJgaSnfgBprGg","appId":"1"}' class='mp-morpho-clipboard-doc-data'></span>

进一步检查，通过在 `Paddle/paddle/phi/kernels/gpu/class_center_sample_kernel.cu` 定位到具体实现在  [Paddle/third_party/cub/cub/cub.cuh](https://github.com/NVIDIA/cub/blob/48b555897ee66bcd057a521ed39d62b7688c7d59/cub/cub.cuh)，该第三方库不支持label.numel()为大Tensor的情况。
因此在 `class_center_sample_kernel.cu` 通过 `PADDLE_ENFORCE_LE` 对大Tensor 错误抛出。

<meta charset="UTF-8"><div class="mp-paragraph-wrapper hxj" data-morpho-type="paragraph" style="padding-left:0px;--indent-pixels:0px" data-slate-node="element" data-morpho-padding="0"><span data-morpho-text="%E7%94%B1%E4%BA%8E%20paddleonly%20%E7%9A%84%E6%B5%8B%E8%AF%95%E5%9C%A8%20label.numel()%20%E7%9A%84%E5%B0%8FTensor%20%E6%83%85%E5%86%B5%E4%B8%8B%E4%BB%8D%E7%84%B6%E5%87%BA%E7%8E%B0%E9%94%99%E8%AF%AF%EF%BC%8C%E8%BF%9B%E4%B8%80%E6%AD%A5%EF%BC%88%E4%BA%8C%E5%88%86%E6%B3%95%EF%BC%89%E6%8E%92%E6%9F%A5%20label.numel()%20%20%E4%BC%9A%E5%AF%BC%E8%87%B4%20">由于 paddleonly 的测试在 label.numel() 的小Tensor 情况下仍然出现错误，进一步（二分法）排查 label.numel()  会导致 </span><div class="mp-paragraph-block-selection"></div></div><div class="mp-paragraph-wrapper hxj" data-morpho-type="paragraph" style="padding-left:0px;--indent-pixels:0px" data-slate-node="element" data-morpho-padding="0"><span data-morpho-text="%20%20(PreconditionNotMet)%20%E7%B1%BB%E6%8A%A5%E9%94%99%E7%9A%84%E8%BE%B9%E7%95%8C%E5%80%BC%E3%80%82"><span data-raw-font-value="#3b3b3b" style="color:#3b3b3b"><span>  (PreconditionNotMet) 类报错的边界值。</span></span></span><span data-morpho-text="%E7%BB%8F%E5%A4%9A%E4%B8%AAcase%E6%A0%B8%E6%9F%A5%EF%BC%8C%E8%AF%A5%E6%95%B0%E5%80%BC%E4%BB%85%E5%92%8C%20label.numel()%20%20%E6%9C%89%E5%85%B3%EF%BC%8C%E5%92%8C%E5%85%B6%E4%BB%96%E4%B8%A4%E4%B8%AA%E8%BE%93%E5%85%A5%E6%97%A0%E5%85%B3%E3%80%82%E5%85%B7%E4%BD%93">经多个case核查，该数值仅和 label.numel()  有关，和其他两个输入无关。具体</span><span data-morpho-text="%E6%83%85%E5%86%B5%E5%A6%82%E4%B8%8B%EF%BC%9A"><span data-raw-font-value="#3b3b3b" style="color:#3b3b3b"><span>情况如下：</span></span></span><div class="mp-paragraph-block-selection"></div></div><div class="mp-table-align"><div class="mp-table-wrapper"><div data-slate-node="element" style="padding-left:0px" class="mp-table-container">
label.numel() | 356493280 | 356493279 | 356493278
-- | -- | -- | --
数据说明 | (PreconditionNotMet) The meta data must be valid when call the mutable data function. 报错 | 报错临界点，大于该值均有报错 | 能正确的通过，小于该值均Pass

</div><div class="mp-table-serialize-flag"><br/></div></div></div><span data-morpho-doc-data='{"token":"eyJhbGciOiJkaXIiLCJlbmMiOiJBMjU2R0NNIiwiYXBwSWQiOjEsInVpZCI6Il9uWkZpd0VDQXYiLCJkb2NJZCI6ImgtTjY2V29namF1YkpkIn0..Sc44U3g43tA0Chio.AoCKMKMRNuZY3toxor9YFRhzuWJ4C84f612C10XoOjSvBYewt6ComNIb8z50a8cJoeEreX5MZXxGCpId_dCmX2kzwOiWzZbbTp4zGvcVzPyihsEMBJriIgZvwpfvoEud8Uxw5pFhU7sP4oGHXLqIGnzPnETxnhxwW8bMy2pyGAkjvcccDWqqXgRq42XADmwdbGd-hRZ9k3bamdgsOYF9Um_bHw.tsb27kW1EBJgaSnfgBprGg","appId":"1"}' class='mp-morpho-clipboard-doc-data'></span>

插桩排查后定位问题在
```cpp
MemoryBuffer<T, Context> memory_buffer =
      MemoryBuffer<T, Context>(num_buffer_ele, num_temp_ele, nranks, dev_ctx);
```

MemoryBuffer 实例化时 经过 `buffer.Resize({4 * num_buffer_ele + 3 * (nranks + 1) + num_temp_ele})`; 重新分配了空间，当 label.numel() 较大时导致了这个值溢出。故在此前用 `PADDLE_ENFORCE_GT` 进行尺寸的检查，使它不能是负数。