### PR TITLE
[BIG tensor] add invalid shape check for preventing implicit overflow

### DIFF
--- a/paddle/phi/kernels/gpu/cross_entropy_kernel.cu
+++ b/paddle/phi/kernels/gpu/cross_entropy_kernel.cu
@@ -1397,7 +1397,6 @@ void CrossEntropyWithSoftmaxKernel(const Context& dev_ctx,
                                    DenseTensor* loss) {
   const int rank = logits.dims().size();
   const int64_t axis_v = phi::funcs::CanonicalAxis(axis, rank);
-  const int64_t axis_dim = logits.dims()[axis_v];
   const int64_t d = phi::funcs::SizeFromAxis<int64_t>(axis_v, logits.dims());
   PADDLE_ENFORCE_LE(d,
                     std::numeric_limits<int>::max(),

--- a/paddle/phi/kernels/gpu/cross_entropy_kernel.cu
+++ b/paddle/phi/kernels/gpu/cross_entropy_kernel.cu
@@ -1395,6 +1395,15 @@ void CrossEntropyWithSoftmaxKernel(const Context& dev_ctx,
                                    int axis,
                                    DenseTensor* softmax,
                                    DenseTensor* loss) {
+  const int rank = logits.dims().size();
+  const int64_t axis_v = phi::funcs::CanonicalAxis(axis, rank);
+  const int64_t axis_dim = logits.dims()[axis_v];
+  const int64_t d = phi::funcs::SizeFromAxis<int64_t>(axis_v, logits.dims());
+  PADDLE_ENFORCE_LE(d,
+                    std::numeric_limits<int>::max(),
+                    common::errors::InvalidArgument(
+                        "(PreconditionNotMet) The num of"
+                        " the classes should be <= INT_MAX(2147483647)"));
   if (softmax->numel() == 0) {
     // When soft_label is False, the axis column cannot be 0. Other dimensions
     // are the same, so the numel of softmax and loss are both 0.


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164
cross_entropy 输入input 维度为 [N,..., C], 其中C 为类别数的意思，在API文档 和 yaml文件中，这个 C不能超过int最大值，从语义角度来说，也不会存在这么多类别。因此添加该检查