### PR TITLE
[BIG tensor] enhance robustness of size calculation

### DIFF
--- a/paddle/phi/kernels/funcs/axis_utils.h
+++ b/paddle/phi/kernels/funcs/axis_utils.h
@@ -26,7 +26,7 @@ static inline int CanonicalAxis(const int axis, const int rank) {
   return axis;
 }
 
-template <typename T = int>
+template <typename T = int64_t>
 static inline T SizeToAxis(const int axis, DDim dims) {
   T size = 1;
   for (int i = 0; i < axis; i++) {
@@ -35,7 +35,7 @@ static inline T SizeToAxis(const int axis, DDim dims) {
   return size;
 }
 
-template <typename T = int>
+template <typename T = int64_t>
 static inline T SizeFromAxis(const int axis, DDim dims) {
   T size = 1;
   for (int i = axis; i < dims.size(); i++) {
@@ -44,7 +44,7 @@ static inline T SizeFromAxis(const int axis, DDim dims) {
   return size;
 }
 
-template <typename T = int>
+template <typename T = int64_t>
 static inline T SizeOutAxis(const int axis, DDim dims) {
   T size = 1;
   for (int i = axis + 1; i < dims.size(); i++) {

--- a/paddle/phi/kernels/funcs/axis_utils.h
+++ b/paddle/phi/kernels/funcs/axis_utils.h
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
 
+
 #pragma once
 
 #include "paddle/common/ddim.h"

--- a/paddle/phi/kernels/funcs/axis_utils.h
+++ b/paddle/phi/kernels/funcs/axis_utils.h
@@ -12,7 +12,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
 
-
 #pragma once
 
 #include "paddle/common/ddim.h"


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes 

### Description
<!-- Describe what you’ve done -->
Pcard-67164
模板参数应该写成  int64_t，这个计算应该出现次数也是常数级别，不影响性能。但是如果不改很容易错，轴序号一般是int, 计算形状的时候模板参数就自动填充为int, 不支持大tensor