### PR TITLE
[Custom Device] add float16 and bfloat16 supported api for custom device

### DIFF
--- a/paddle/fluid/pybind/place.cc
+++ b/paddle/fluid/pybind/place.cc
@@ -360,6 +360,14 @@ void BindPlace(pybind11::module &m) {  // NOLINT
            [](const phi::CustomPlace &self) { return self.GetDeviceType(); })
       .def("__repr__", string::to_string<const phi::CustomPlace &>)
       .def("__str__", string::to_string<const phi::CustomPlace &>);
+#if defined(PADDLE_WITH_CUSTOM_DEVICE)
+  m.def("is_float16_supported", [](const phi::CustomPlace &place) -> bool {
+    return phi::DeviceManager::IsFloat16Supported(place);
+  });
+  m.def("is_bfloat16_supported", [](const phi::CustomPlace &place) -> bool {
+    return phi::DeviceManager::IsBFloat16Supported(place);
+  });
+#endif
   py::class_<phi::GPUPlace, phi::Place> cudaplace(m, "CUDAPlace", R"DOC(
 
     CUDAPlace is a descriptor of a device.

--- a/paddle/phi/backends/custom/custom_device.cc
+++ b/paddle/phi/backends/custom/custom_device.cc
@@ -628,6 +628,26 @@ class CustomDevice : public DeviceInterface {
     return grid_dim_size;
   }
 
+  bool IsFloat16Supported(size_t dev_id) {
+    const auto device = &devices_pool[dev_id];
+    bool supported = false;
+    if (pimpl_->is_float16_supported) {
+      pimpl_->is_float16_supported(device, &supported);
+    }
+    VLOG(10) << Type() << " is float16 supported: " << supported;
+    return supported;
+  }
+
+  bool IsBFloat16Supported(size_t dev_id) {
+    const auto device = &devices_pool[dev_id];
+    bool supported = false;
+    if (pimpl_->is_bfloat16_supported) {
+      pimpl_->is_bfloat16_supported(device, &supported);
+    }
+    VLOG(10) << Type() << " is bfloat16 supported: " << false;
+    return supported;
+  }
+
   void* InitEigenDevice(const Place& place,
                         phi::stream::stream_t stream,
                         phi::Allocator* allocator) override {

--- a/paddle/phi/backends/device_base.cc
+++ b/paddle/phi/backends/device_base.cc
@@ -37,7 +37,7 @@ size_t DeviceInterface::GetComputeCapability(size_t dev_id) {
 }
 
 DeviceProp& DeviceInterface::GetDeviceProperties(size_t dev_id) {
-  DeviceProp prop;
+  static DeviceProp prop;
   VLOG(10) << Type() << " get device properties " << 0;
   return prop;
 }
@@ -71,6 +71,16 @@ std::array<unsigned int, 3> DeviceInterface::GetMaxGridDimSize(size_t dev_id) {
   VLOG(10) << Type() << " get max grid dim size [" << 0 << ", " << 0 << ", "
            << 0 << "]";
   return {0, 0, 0};
+}
+
+bool DeviceInterface::IsFloat16Supported(size_t dev_id) {
+  VLOG(10) << Type() << " is float16 supported: " << false;
+  return false;
+}
+
+bool DeviceInterface::IsBFloat16Supported(size_t dev_id) {
+  VLOG(10) << Type() << " is bfloat16 supported: " << false;
+  return false;
 }
 
 void* DeviceInterface::InitEigenDevice(const Place& place,

--- a/paddle/phi/backends/device_base.h
+++ b/paddle/phi/backends/device_base.h
@@ -79,6 +79,10 @@ class DeviceInterface {  // Driver / Runtime
 
   virtual std::array<unsigned int, 3> GetMaxGridDimSize(size_t dev_id);
 
+  virtual bool IsFloat16Supported(size_t dev_id);
+
+  virtual bool IsBFloat16Supported(size_t dev_id);
+
   virtual void* InitEigenDevice(const Place& place,
                                 phi::stream::stream_t stream,
                                 phi::Allocator* allocator);

--- a/paddle/phi/backends/device_ext.h
+++ b/paddle/phi/backends/device_ext.h
@@ -591,6 +591,20 @@ struct C_DeviceInterface {
                                     std::array<unsigned int, 3>* grid_dim_size);
 
   /**
+   * @brief Is float16 supported
+   *
+   * @param[C_Device, bool*]    grid_dim_size
+   */
+  C_Status (*is_float16_supported)(const C_Device device, bool* supported);
+
+  /**
+   * @brief Is bfloat16 supported
+   *
+   * @param[C_Device, bool*]      grid_dim_size
+   */
+  C_Status (*is_bfloat16_supported)(const C_Device device, bool* supported);
+
+  /**
    * @brief init eigen device
    *
    * @param[C_Place, C_EigenDevice*, C_Stream, C_Allocator]    eigen_device

--- a/paddle/phi/backends/device_ext.h
+++ b/paddle/phi/backends/device_ext.h
@@ -593,14 +593,14 @@ struct C_DeviceInterface {
   /**
    * @brief Is float16 supported
    *
-   * @param[C_Device, bool*]    grid_dim_size
+   * @param[C_Device, bool*]     device, supported
    */
   C_Status (*is_float16_supported)(const C_Device device, bool* supported);
 
   /**
    * @brief Is bfloat16 supported
    *
-   * @param[C_Device, bool*]      grid_dim_size
+   * @param[C_Device, bool*]     device, supported
    */
   C_Status (*is_bfloat16_supported)(const C_Device device, bool* supported);
 

--- a/paddle/phi/backends/device_manager.cc
+++ b/paddle/phi/backends/device_manager.cc
@@ -523,6 +523,20 @@ std::array<unsigned int, 3> DeviceManager::GetMaxGridDimSize(
   return dev_impl->GetMaxGridDimSize(device_id);
 }
 
+bool DeviceManager::IsFloat16Supported(const Place& place) {
+  auto device_type = place.GetDeviceType();
+  auto device_id = place.GetDeviceId();
+  auto dev_impl = GetDeviceInterfaceWithType(device_type);
+  return dev_impl->IsFloat16Supported(device_id);
+}
+
+bool DeviceManager::IsBFloat16Supported(const Place& place) {
+  auto device_type = place.GetDeviceType();
+  auto device_id = place.GetDeviceId();
+  auto dev_impl = GetDeviceInterfaceWithType(device_type);
+  return dev_impl->IsBFloat16Supported(device_id);
+}
+
 void* DeviceManager::InitEigenDevice(const Place& place,
                                      phi::stream::stream_t stream,
                                      phi::Allocator* allocator) {

--- a/paddle/phi/backends/device_manager.h
+++ b/paddle/phi/backends/device_manager.h
@@ -186,6 +186,10 @@ class DeviceManager {
 
   static std::array<unsigned int, 3> GetMaxGridDimSize(const Place& place);
 
+  static bool IsFloat16Supported(const Place& place);
+
+  static bool IsBFloat16Supported(const Place& place);
+
   static void* InitEigenDevice(const Place& place,
                                phi::stream::stream_t stream,
                                phi::Allocator* allocator);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Custom Device

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
pcard-67164
paddle.amp.is_bfloat16_supported() and paddle.amp.is_float16_supported() support custom device now.