### PR TITLE
Add LOG(WARNING) for kernel fallback

### DIFF
--- a/paddle/phi/core/kernel_factory.cc
+++ b/paddle/phi/core/kernel_factory.cc
@@ -387,9 +387,10 @@ KernelResult KernelFactory::SelectKernelOrThrowError(
             kernel_name,
             KernelSelectionErrorMessage(kernel_name, kernel_key)));
 
-    VLOG(3) << "missing " << kernel_key.backend() << " kernel: " << kernel_name
-            << ", expected_kernel_key:" << kernel_key
-            << ", fallbacking to CPU one!";
+    LOG(WARNING) << "missing " << kernel_key.backend()
+                 << " kernel: " << kernel_name
+                 << ", expected_kernel_key:" << kernel_key
+                 << ", fallbacking to CPU one!";
 
     return {kernel_iter->second, true, false};
   }

--- a/paddle/phi/core/kernel_factory.cc
+++ b/paddle/phi/core/kernel_factory.cc
@@ -386,7 +386,7 @@ KernelResult KernelFactory::SelectKernelOrThrowError(
             kernel_key,
             kernel_name,
             KernelSelectionErrorMessage(kernel_name, kernel_key)));
-#ifndef PADDLE_WITH_CUSTOM_DEVICE
+#if !defined(PADDLE_WITH_CUDA) || !defined(PADDLE_WITH_CUSTOM_DEVICE)
     VLOG(3) << "missing " << kernel_key.backend() << " kernel: " << kernel_name
             << ", expected_kernel_key:" << kernel_key
             << ", fallbacking to CPU one!";

--- a/paddle/phi/core/kernel_factory.cc
+++ b/paddle/phi/core/kernel_factory.cc
@@ -386,11 +386,16 @@ KernelResult KernelFactory::SelectKernelOrThrowError(
             kernel_key,
             kernel_name,
             KernelSelectionErrorMessage(kernel_name, kernel_key)));
-
+#ifndef PADDLE_WITH_CUSTOM_DEVICE
+    VLOG(3) << "missing " << kernel_key.backend() << " kernel: " << kernel_name
+            << ", expected_kernel_key:" << kernel_key
+            << ", fallbacking to CPU one!";
+#else
     LOG(WARNING) << "missing " << kernel_key.backend()
                  << " kernel: " << kernel_name
                  << ", expected_kernel_key:" << kernel_key
                  << ", fallbacking to CPU one!";
+#endif
 
     return {kernel_iter->second, true, false};
   }

--- a/paddle/phi/core/kernel_factory.cc
+++ b/paddle/phi/core/kernel_factory.cc
@@ -386,16 +386,9 @@ KernelResult KernelFactory::SelectKernelOrThrowError(
             kernel_key,
             kernel_name,
             KernelSelectionErrorMessage(kernel_name, kernel_key)));
-#if !defined(PADDLE_WITH_CUDA) || !defined(PADDLE_WITH_CUSTOM_DEVICE)
-    VLOG(3) << "missing " << kernel_key.backend() << " kernel: " << kernel_name
+    VLOG(1) << "missing " << kernel_key.backend() << " kernel: " << kernel_name
             << ", expected_kernel_key:" << kernel_key
             << ", fallbacking to CPU one!";
-#else
-    LOG(WARNING) << "missing " << kernel_key.backend()
-                 << " kernel: " << kernel_name
-                 << ", expected_kernel_key:" << kernel_key
-                 << ", fallbacking to CPU one!";
-#endif
 
     return {kernel_iter->second, true, false};
   }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
pcard-67164
Add LOG(WARNING) when kernel fallback to CPU.