### PR TITLE
Fix set_paddle_lib_path

### DIFF
--- a/python/paddle/base/core.py
+++ b/python/paddle/base/core.py
@@ -414,7 +414,7 @@ def set_paddle_lib_path():
                 os.path.sep.join([lib_dir, '..', '..', 'paddle_custom_device'])
             )
             return
-    if hasattr(site, 'USER_SITE'):
+    if hasattr(site, 'USER_SITE') and site.USER_SITE:
         lib_dir = os.path.sep.join([site.USER_SITE, 'paddle', 'libs'])
         if os.path.exists(lib_dir):
             _set_paddle_lib_path(lib_dir)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
https://github.com/PaddlePaddle/Paddle/issues/68406

site.USER_SITE 可能为 None https://docs.python.org/zh-cn/3.10/library/site.html#site.USER_SITE （比如在 pyinstaller 打包之后的运行环境中，没有调用 gitusersitepackages 就会是 None 值），导致 os.path.sep.join 报错。