### PR TITLE
[Feat]: cpu max kernel support bool dtype

### DIFF
--- a/paddle/phi/kernels/cpu/reduce_max_kernel.cc
+++ b/paddle/phi/kernels/cpu/reduce_max_kernel.cc
@@ -40,4 +40,4 @@ void MaxKernel(const Context& dev_ctx,
 }  // namespace phi
 
 PD_REGISTER_KERNEL(
-    max, CPU, ALL_LAYOUT, phi::MaxKernel, float, double, int, int64_t) {}
+    max, CPU, ALL_LAYOUT, phi::MaxKernel, bool, float, double, int, int64_t) {}

--- a/test/legacy_test/test_max_op.py
+++ b/test/legacy_test/test_max_op.py
@@ -68,6 +68,16 @@ class ApiMaxTest(unittest.TestCase):
             (res,) = exe.run(feed={"data": input_data}, fetch_list=[result_max])
         self.assertEqual((res == np.max(input_data, axis=(0, 1))).all(), True)
 
+        with paddle.static.program_guard(
+            paddle.static.Program(), paddle.static.Program()
+        ):
+            data = paddle.static.data("data", shape=[10, 10], dtype="bool")
+            result_max = paddle.max(x=data, axis=(0, 1))
+            exe = paddle.static.Executor(self.place)
+            input_data = np.random.randint(10, size=(10, 10)).astype(np.bool)
+            (res,) = exe.run(feed={"data": input_data}, fetch_list=[result_max])
+        self.assertEqual((res == np.max(input_data, axis=(0, 1))).all(), True)
+
     def test_errors(self):
         paddle.enable_static()
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->


### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
Add bool dtype support for cpu max kernel.