### PR TITLE
修复paddle.linalg.cholesky分解大Tensor的问题

### DIFF
--- a/paddle/phi/backends/dynload/cusolver.h
+++ b/paddle/phi/backends/dynload/cusolver.h
@@ -46,8 +46,10 @@ extern void *cusolver_dso_handle;
   __macro(cusolverDnSetStream);         \
   __macro(cusolverDnSpotrf_bufferSize); \
   __macro(cusolverDnDpotrf_bufferSize); \
+  __macro(cusolverDnXpotrf_bufferSize); \
   __macro(cusolverDnSpotrf);            \
   __macro(cusolverDnDpotrf);            \
+  __macro(cusolverDnXpotrf);            \
   __macro(cusolverDnSpotrs);            \
   __macro(cusolverDnDpotrs);            \
   __macro(cusolverDnCpotrs);            \
@@ -120,6 +122,8 @@ CUSOLVER_ROUTINE_EACH_R1(DECLARE_DYNAMIC_LOAD_CUSOLVER_WRAP)
 #if CUDA_VERSION >= 9020
 #define CUSOLVER_ROUTINE_EACH_R2(__macro)      \
   __macro(cusolverDnCreateSyevjInfo);          \
+  __macro(cusolverDnCreateParams);             \
+  __macro(cusolverDnDestroyParams);            \
   __macro(cusolverDnSsyevj_bufferSize);        \
   __macro(cusolverDnDsyevj_bufferSize);        \
   __macro(cusolverDnCheevj_bufferSize);        \

--- a/paddle/phi/kernels/gpu/cholesky_kernel.cu
+++ b/paddle/phi/kernels/gpu/cholesky_kernel.cu
@@ -237,8 +237,6 @@ void CholeskyKernel(const Context& dev_ctx,
     for (int i = 0; i < batch_count; i++) {
       int64_t offset = static_cast<int64_t>(i) * m * m;
 #if CUDA_VERSION >= 11040
-      // COMPILATION FIX: Call Potrf64 directly without the <T> specialization,
-      // as the macro FUNC_WITH_TYPES already handles the float/double types.
       Potrf64(dev_ctx, uplo, m, out_data + offset, m, info_ptr + i);
 #else
     Potrf(dev_ctx, uplo, m, out_data + offset, m, info_ptr + i);

--- a/paddle/phi/kernels/gpu/cholesky_kernel.cu
+++ b/paddle/phi/kernels/gpu/cholesky_kernel.cu
@@ -92,6 +92,60 @@ struct MatrixBandPartFunctor {
 
 FUNC_WITH_TYPES(POTRF_INSTANCE);
 
+#if CUDA_VERSION >= 11040
+#define POTRF64_INSTANCE(T, C)                                            \
+  void Potrf64(const GPUContext& dev_ctx,                                 \
+               cublasFillMode_t uplo,                                     \
+               int64_t n,                                                 \
+               T* A,                                                      \
+               int64_t lda,                                               \
+               int* info) {                                               \
+    auto handle = dev_ctx.cusolver_dn_handle();                           \
+    cusolverDnParams_t params;                                            \
+    PADDLE_ENFORCE_GPU_SUCCESS(dynload::cusolverDnCreateParams(&params)); \
+    size_t workspace_device_size = 0;                                     \
+    size_t workspace_host_size = 0;                                       \
+    cudaDataType_t data_type =                                            \
+        std::is_same<T, float>::value ? CUDA_R_32F : CUDA_R_64F;          \
+    PADDLE_ENFORCE_GPU_SUCCESS(                                           \
+        dynload::cusolverDnXpotrf_bufferSize(handle,                      \
+                                             params,                      \
+                                             uplo,                        \
+                                             n,                           \
+                                             data_type,                   \
+                                             A,                           \
+                                             lda,                         \
+                                             data_type,                   \
+                                             &workspace_device_size,      \
+                                             &workspace_host_size));      \
+    auto workspace_device = phi::memory_utils::Alloc(                     \
+        dev_ctx.GetPlace(),                                               \
+        workspace_device_size,                                            \
+        phi::Stream(reinterpret_cast<phi::StreamId>(dev_ctx.stream())));  \
+    auto workspace_host = phi::memory_utils::Alloc(                       \
+        phi::CPUPlace(),                                                  \
+        workspace_host_size,                                              \
+        phi::Stream(reinterpret_cast<phi::StreamId>(dev_ctx.stream())));  \
+    PADDLE_ENFORCE_GPU_SUCCESS(                                           \
+        dynload::cusolverDnXpotrf(handle,                                 \
+                                  params,                                 \
+                                  uplo,                                   \
+                                  n,                                      \
+                                  data_type,                              \
+                                  A,                                      \
+                                  lda,                                    \
+                                  data_type,                              \
+                                  workspace_device->ptr(),                \
+                                  workspace_device_size,                  \
+                                  workspace_host->ptr(),                  \
+                                  workspace_host_size,                    \
+                                  info));                                 \
+    PADDLE_ENFORCE_GPU_SUCCESS(dynload::cusolverDnDestroyParams(params)); \
+  }
+
+FUNC_WITH_TYPES(POTRF64_INSTANCE);
+#endif
+
 #if CUDA_VERSION >= 9020 && !defined(_WIN32)
 #define POTRF_BATCH_INSTANCE(T, C)                                   \
   void PotrfBatched(const GPUContext& dev_ctx,                       \
@@ -114,7 +168,7 @@ void CholeskyKernel(const Context& dev_ctx,
                     const DenseTensor& x,
                     bool upper,
                     DenseTensor* out) {
-  if (out->numel() == 0) {
+  if (x.numel() == 0) {
     dev_ctx.template Alloc<T>(out);
     return;
   }
@@ -125,7 +179,7 @@ void CholeskyKernel(const Context& dev_ctx,
     batch_count *= dims[i];
   }
   int m = dims[dims.size() - 1];
-  int tensor_size = batch_count * m * m;
+  int64_t tensor_size = batch_count * static_cast<int64_t>(m) * m;
 
   const auto* x_data = x.data<T>();
   auto* out_data = dev_ctx.template Alloc<T>(out);
@@ -135,22 +189,16 @@ void CholeskyKernel(const Context& dev_ctx,
       upper ? CUBLAS_FILL_MODE_LOWER : CUBLAS_FILL_MODE_UPPER;
   // portf is inplace, thus copy the triangular part of the input matrices to
   // the output and set the other triangular part to 0 firstly
+
   phi::funcs::ForRange<GPUContext> for_range(dev_ctx, tensor_size);
+  // Pre-processing
   if (upper) {
-    MatrixBandPartFunctor<T> matrix_band_part_functor(m,
-                                                      m,
-                                                      /* num_lower_diags */ 0,
-                                                      /* num_upper_diags */ m,
-                                                      x_data,
-                                                      out_data);
+    MatrixBandPartFunctor<T> matrix_band_part_functor(
+        m, m, 0, -1, x_data, out_data);
     for_range(matrix_band_part_functor);
   } else {
-    MatrixBandPartFunctor<T> matrix_band_part_functor(m,
-                                                      m,
-                                                      /* num_lower_diags */ m,
-                                                      /* num_upper_diags */ 0,
-                                                      x_data,
-                                                      out_data);
+    MatrixBandPartFunctor<T> matrix_band_part_functor(
+        m, m, -1, 0, x_data, out_data);
     for_range(matrix_band_part_functor);
   }
 
@@ -164,7 +212,7 @@ void CholeskyKernel(const Context& dev_ctx,
   if (batch_count > 1) {
     std::vector<T*> output_ptrs;
     for (int i = 0; i < batch_count; i++) {
-      output_ptrs.emplace_back(out_data + i * m * m);
+      output_ptrs.emplace_back(out_data + static_cast<int64_t>(i) * m * m);
     }
     thrust::device_vector<T*> dev_output_ptrs(output_ptrs.begin(),
                                               output_ptrs.end());
@@ -178,28 +226,30 @@ void CholeskyKernel(const Context& dev_ctx,
     // TODO(guosheng): There seems to a bug in cusolver potrfBatched and need
     // to clear the upper triangle of the output. Remove this workaround once
     // the bug is fixed.
+
     if (!upper) {
-      MatrixBandPartFunctor<T> matrix_band_part_functor(m,
-                                                        m,
-                                                        /* num_lower_diags */ m,
-                                                        /* num_upper_diags */ 0,
-                                                        out_data,
-                                                        out_data);
+      MatrixBandPartFunctor<T> matrix_band_part_functor(
+          m, m, -1, 0, out_data, out_data);
       for_range(matrix_band_part_functor);
     }
   } else {
 #endif
     for (int i = 0; i < batch_count; i++) {
-      Potrf(dev_ctx, uplo, m, out_data + i * m * m, m, info_ptr + i);
+      int64_t offset = static_cast<int64_t>(i) * m * m;
+#if CUDA_VERSION >= 11040
+      // COMPILATION FIX: Call Potrf64 directly without the <T> specialization,
+      // as the macro FUNC_WITH_TYPES already handles the float/double types.
+      Potrf64(dev_ctx, uplo, m, out_data + offset, m, info_ptr + i);
+#else
+    Potrf(dev_ctx, uplo, m, out_data + offset, m, info_ptr + i);
+#endif
     }
-
 #if CUDA_VERSION >= 9020 && !defined(_WIN32)
   }
 #endif
   // check the info
-  std::vector<int> error_info;  // only for checking positive matrix
+  std::vector<int> error_info;
   error_info.resize(batch_count);
-
   memory_utils::Copy(CPUPlace(),
                      error_info.data(),
                      dev_ctx.GetPlace(),
@@ -208,13 +258,37 @@ void CholeskyKernel(const Context& dev_ctx,
                      dev_ctx.stream());
 
   for (int i = 0; i < batch_count; ++i) {
-    PADDLE_ENFORCE_EQ(error_info[i],
-                      0,
-                      errors::PreconditionNotMet(
-                          "For batch [%d]: U(%d, %d) is zero, singular U.",
-                          i,
-                          error_info[i],
-                          error_info[i]));
+    const int info = error_info[i];
+    if (info == 0) {
+      continue;
+    }
+    if (info < 0) {
+      PADDLE_ENFORCE_EQ(
+          info,
+          0,
+          errors::InvalidArgument("Cholesky kernel failed for batch %d: "
+                                  "The %d-th argument was invalid, please "
+                                  "check the kernel implementation.",
+                                  i,
+                                  -info));
+    }
+    PADDLE_ENFORCE_EQ(
+        info,
+        0,
+        errors::PreconditionNotMet(
+            "Cholesky decomposition failed for batch %d: "
+            "The leading minor of order %d is not positive definite.",
+            i,
+            info));
+  }
+
+  // Post-processing to clear the other triangle
+  if (upper) {
+    MatrixBandPartFunctor<T> band_part_post(m, m, 0, -1, out_data, out_data);
+    for_range(band_part_post);
+  } else {
+    MatrixBandPartFunctor<T> band_part_post(m, m, -1, 0, out_data, out_data);
+    for_range(band_part_post);
   }
 }
 

--- a/paddle/phi/kernels/impl/cholesky_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/cholesky_grad_kernel_impl.h
@@ -254,7 +254,7 @@ void CholeskyGradKernel(const Context& dev_ctx,
     batch_count *= dims[i];
   }
   auto m = dims[dims.size() - 1];
-  int tensor_size = batch_count * m * m;
+  int64_t tensor_size = static_cast<int64_t>(batch_count) * m * m;
 
   std::vector<int> axis(dims.size() - 2);
   std::iota(axis.begin(), axis.end(), 0);
@@ -304,6 +304,7 @@ void CholeskyGradKernel(const Context& dev_ctx,
   for_range(eye_functor);
   // TODO(guosheng): use trsmBatched for GPU
   for (int i = 0; i < batch_count; i++) {
+    int64_t offset = static_cast<int64_t>(i) * m * m;
     blas.TRSM(/*side*/ CblasLeft,
               /*uplo*/ CblasLower,
               /*trans*/ CblasNoTrans,
@@ -311,9 +312,9 @@ void CholeskyGradKernel(const Context& dev_ctx,
               /*m*/ m,
               /*n*/ m,
               /*alpha*/ T(1),
-              l_data + i * m * m,
+              l_data + offset,
               /*lda*/ m,
-              identity_data + i * m * m,
+              identity_data + offset,
               /*ldb*/ m);
   }
   DenseTensor& l_inverse = identity;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes


### Description
<!-- Describe what you’ve done -->
#### 1. 背景

Cholesky 分解是一种将正定方阵 A 分解为下三角矩阵 L 与其转置 L' 乘积（A = LL'）的常用方法。

#### 2. 存在的问题

旧版的 `cholesky_kernel` 实现主要存在以下两个问题：

*   **cuSOLVER API 限制**：由于调用的 API 限制，无法处理元素数量巨大的 Tensor 矩阵。
*   **报错信息模糊**：错误提示不够清晰，容易误导问题排查方向。

#### 3. 解决方案

针对上述问题，本次提交进行了如下修改：

*   **升级 cuSOLVER API**
    *   **问题详情**：原先调用的 `cusolverDnSpotrf` API 中，其工作空间大小参数 `Lwork` 为 `int` 类型。当矩阵元素总数超过 `int` 类型的最大值时，会发生溢出，导致计算失败。
    *   **修改方案**：将 API 调用更新为 `cusolverDnXpotrf()`，该 API 支持更大的工作空间。同时，在 `cholesky_grad` 中也做了对应的兼容性修改，从而可以处理更大规模的矩阵。

*   **优化报错逻辑**
    *   **问题详情**：旧实现中，只要 `info[i]` 不为零，就笼统地报告为“主子式非正定”的错误。这导致当处理大矩阵因 API 调用失败时，用户看到的报错信息仍然是关于矩阵正定性的，从而产生误导。
    *   **修改方案**：根据 cuSOLVER 官方文档，对 `info` 的不同返回值进行更准确、具体的错误提示。
 #### 4. 实验结果
 
<img width="1237" height="168" alt="image" src="https://github.com/user-attachments/assets/0946cde1-7769-4c20-b896-a235597c373e" />
