### PR TITLE
修复随机数某些平台生成重复数字

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/pir_to_py_code_converter.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/pir_to_py_code_converter.cc
@@ -230,9 +230,9 @@ std::string DataToString(const phi::DenseTensor& tensor,
 }
 
 int64_t GetRandomId() {
-  std::random_device rd{};
-  std::mt19937_64 gen(rd());
-  std::uniform_int_distribution<int64_t> dis(
+  static std::random_device rd{};
+  static std::mt19937_64 gen(rd());
+  static std::uniform_int_distribution<int64_t> dis(
       0, std::numeric_limits<int64_t>::max());
   return dis(gen);
 }

--- a/paddle/pir/src/core/program.cc
+++ b/paddle/pir/src/core/program.cc
@@ -25,9 +25,9 @@ namespace pir {
 namespace {
 
 int64_t GetRandomId() {
-  std::random_device rd{};
-  std::mt19937_64 gen(rd());
-  std::uniform_int_distribution<int64_t> dis(
+  static std::random_device rd{};
+  static std::mt19937_64 gen(rd());
+  static std::uniform_int_distribution<int64_t> dis(
       0, std::numeric_limits<int64_t>::max());
   return dis(gen);
 }


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Bug fixes

### Description
GetRandomId() 函数每次调用时都会重新初始化随机数生成器 (std::random_device 和 std::mt19937_64)，这会导致生成的随机数可能重复或不够随机。

1. std::random_device 被重复初始化：
每次调用函数时都新建 random_device 和 mt19937_64，可能导致种子相似（尤其在某些平台上 random_device 实现不够完善）。

2. 伪随机数引擎未复用：
mt19937_64 的状态在每次函数调用时重置，失去了伪随机序列的长期统计特性
