### PR TITLE
conv_kernel.cc add onednn_data_type [fluid_ops]

### DIFF
--- a/paddle/phi/kernels/onednn/conv_kernel.cc
+++ b/paddle/phi/kernels/onednn/conv_kernel.cc
@@ -42,6 +42,11 @@ void ConvKernel(const Context& dev_ctx,
                              dev_ctx.GetDnnAttr("mkldnn_data_type")) ==
                 "bfloat16"
           : false;
+  is_BFLOAT16 = dev_ctx.HasDnnAttr("onednn_data_type")
+                    ? PADDLE_GET_CONST(
+                          std::string,
+                          dev_ctx.GetDnnAttr("onednn_data_type")) == "bfloat16"
+                    : is_BFLOAT16;
   bool force_fp32_output =
       dev_ctx.HasDnnAttr("force_fp32_output")
           ? PADDLE_GET_CONST(bool, dev_ctx.GetDnnAttr("force_fp32_output"))

--- a/paddle/phi/kernels/onednn/conv_kernel.cc
+++ b/paddle/phi/kernels/onednn/conv_kernel.cc
@@ -42,11 +42,12 @@ void ConvKernel(const Context& dev_ctx,
                              dev_ctx.GetDnnAttr("mkldnn_data_type")) ==
                 "bfloat16"
           : false;
-  is_BFLOAT16 = dev_ctx.HasDnnAttr("onednn_data_type")
-                    ? PADDLE_GET_CONST(
-                          std::string,
-                          dev_ctx.GetDnnAttr("onednn_data_type")) == "bfloat16"
-                    : is_BFLOAT16;
+  bool is_onednn_BFLOAT16 =
+      dev_ctx.HasDnnAttr("onednn_data_type")
+          ? PADDLE_GET_CONST(std::string,
+                             dev_ctx.GetDnnAttr("onednn_data_type")) ==
+                "bfloat16"
+          : is_BFLOAT16;
   bool force_fp32_output =
       dev_ctx.HasDnnAttr("force_fp32_output")
           ? PADDLE_GET_CONST(bool, dev_ctx.GetDnnAttr("force_fp32_output"))
@@ -64,7 +65,7 @@ void ConvKernel(const Context& dev_ctx,
                 groups,
                 data_format,
                 is_test,
-                is_BFLOAT16,
+                is_onednn_BFLOAT16,
                 "",
                 false,
                 force_fp32_output,

--- a/paddle/phi/kernels/onednn/conv_transpose_kernel.cc
+++ b/paddle/phi/kernels/onednn/conv_transpose_kernel.cc
@@ -157,7 +157,13 @@ class ConvTransposeOneDNNHandlerT
                                dev_ctx.GetDnnAttr("mkldnn_data_type")) ==
                   "bfloat16"
             : false;
-    if (is_BFLOAT16 || std::is_same<T_out, dtype::bfloat16>::value) {
+    const bool is_onednn_BFLOAT16 =
+        dev_ctx.HasDnnAttr("onednn_data_type")
+            ? PADDLE_GET_CONST(std::string,
+                               dev_ctx.GetDnnAttr("onednn_data_type")) ==
+                  "bfloat16"
+            : is_BFLOAT16;
+    if (is_onednn_BFLOAT16 || std::is_same<T_out, dtype::bfloat16>::value) {
       data_type = dnnl::memory::data_type::bf16;
     }
 
@@ -494,11 +500,17 @@ void Conv2dTransposeKernel(const Context& dev_ctx,
                              dev_ctx.GetDnnAttr("mkldnn_data_type")) ==
                 "bfloat16"
           : false;
+  const bool is_onednn_BFLOAT16 =
+      dev_ctx.HasDnnAttr("onednn_data_type")
+          ? PADDLE_GET_CONST(std::string,
+                             dev_ctx.GetDnnAttr("onednn_data_type")) ==
+                "bfloat16"
+          : is_BFLOAT16;
   const bool force_fp32_output =
       dev_ctx.HasDnnAttr("force_fp32_output")
           ? PADDLE_GET_CONST(bool, dev_ctx.GetDnnAttr("force_fp32_output"))
           : false;
-  const bool use_bfloat16 = (!force_fp32_output && is_BFLOAT16);
+  const bool use_bfloat16 = (!force_fp32_output && is_onednn_BFLOAT16);
 
   if (use_bfloat16) {
     Execute<T, dtype::bfloat16>(dev_ctx,
@@ -545,11 +557,17 @@ void Conv2dTransposeBiasKernel(const Context& dev_ctx,
                              dev_ctx.GetDnnAttr("mkldnn_data_type")) ==
                 "bfloat16"
           : false;
+  const bool is_one_BFLOAT16 =
+      dev_ctx.HasDnnAttr("onednn_data_type")
+          ? PADDLE_GET_CONST(std::string,
+                             dev_ctx.GetDnnAttr("onednn_data_type")) ==
+                "bfloat16"
+          : is_BFLOAT16;
   const bool force_fp32_output =
       dev_ctx.HasDnnAttr("force_fp32_output")
           ? PADDLE_GET_CONST(bool, dev_ctx.GetDnnAttr("force_fp32_output"))
           : false;
-  const bool use_bfloat16 = (!force_fp32_output && is_BFLOAT16);
+  const bool use_bfloat16 = (!force_fp32_output && is_one_BFLOAT16);
 
   if (use_bfloat16) {
     Execute<T, dtype::bfloat16>(dev_ctx,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
paddle/phi/kernels/onednn/conv_kernel.cc
paddle/phi/kernels/onednn/conv_transpose_kernel.cc 增加 onednn_data_type 支持