### PR TITLE
support to fallback to sharding by one mesh dim from by more than one

### DIFF
--- a/paddle/phi/core/distributed/auto_parallel/dist_attr.h
+++ b/paddle/phi/core/distributed/auto_parallel/dist_attr.h
@@ -231,8 +231,9 @@ class TEST_API TensorDistAttr {
   // delete it after all 1d vector dims_mapping_ have been upgraded to 2d.
   class DimMapProxy final {
    public:
-    DimMapProxy(std::vector<std::vector<int64_t>>* dims_mapping_2d)
-        : dims_mapping_2d(dims_mapping_2d) {}
+    DimMapProxy(std::vector<std::vector<int64_t>>* dims_mapping_2d,
+                const ProcessMesh& process_mesh)
+        : dims_mapping_2d(dims_mapping_2d), process_mesh(process_mesh) {}
 
     DimMapProxy& operator=(
         const std::vector<std::vector<int64_t>>& dims_mapping);
@@ -248,6 +249,7 @@ class TEST_API TensorDistAttr {
     void sync_2d_map();
     mutable std::vector<int64_t> dims_mapping_1d;
     std::vector<std::vector<int64_t>>* dims_mapping_2d;
+    const ProcessMesh& process_mesh;
   };
 
   static std::vector<std::string> fields_;
@@ -266,7 +268,7 @@ class TEST_API TensorDistAttr {
 
   std::vector<std::vector<int64_t>> dims_mapping_;
   // for short time, backward compatible for existing spmd relus.
-  DimMapProxy dims_mapping_proxy{&dims_mapping_};
+  DimMapProxy dims_mapping_proxy{&dims_mapping_, process_mesh_};
 };
 
 inline std::ostream& operator<<(std::ostream& os, const TensorDistAttr& obj) {

--- a/test/auto_parallel/co_shard.py
+++ b/test/auto_parallel/co_shard.py
@@ -189,6 +189,11 @@ class TestCoShard:
             str(relu_out.placements[1]), "Shard(dim=0, shard_order=1)"
         )
 
+        # test fallback to shard by one dim.
+        add_out = paddle.add(relu_out, relu_out)
+        np.testing.assert_equal(str(add_out.placements[0]), "Shard(dim=0)")
+        np.testing.assert_equal(str(add_out.placements[1]), "Replicate()")
+
     def run_test_case_main(self):
         self.basic_interface_case()
         self.run_test_case_0()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
when one op not support  co-shard in spmd rules receive one input with co-shard, system will make this input fallback to shard by only one dim.

Pcard-67164
