### PR TITLE
op_compat.yaml add use_onednn

### DIFF
--- a/paddle/phi/ops/yaml/op_compat.yaml
+++ b/paddle/phi/ops/yaml/op_compat.yaml
@@ -42,7 +42,7 @@
     out : Out
   backward : acosh_grad
   extra :
-    attrs : [bool use_mkldnn = false, bool use_cudnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, bool use_cudnn = false]
 
 - op : adadelta_ (adadelta)
   inputs :
@@ -104,7 +104,7 @@
   attrs :
     {scale_x : Scale_x, scale_y : Scale_y, scale_out : Scale_out}
   extra :
-    attrs : [bool use_mkldnn = false, str mkldnn_data_type = "float32",
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, str mkldnn_data_type = "float32",
              bool use_quantizer = false, float Scale_x = 1.0f, float Scale_y = 1.0f, float Scale_out = 1.0f]
   complex_promote : [X, Y]
 
@@ -114,7 +114,7 @@
   outputs:
     {out : Out}
   extra :
-    attrs : [bool use_mkldnn = false, str mkldnn_data_type = "float32"]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, str mkldnn_data_type = "float32"]
 
 - op : add_position_encoding
   backward: add_position_encoding_grad
@@ -310,7 +310,7 @@
   outputs :
     out : Out
   extra :
-    attrs : [bool use_mkldnn = false, bool use_cudnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, bool use_cudnn = false]
 
 - op : assert
   inputs :
@@ -357,7 +357,7 @@
   outputs :
     out : Out
   extra :
-    attrs : [bool use_mkldnn = false, bool use_cudnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, bool use_cudnn = false]
 
 - op : attention_lstm
   backward: attention_lstm_grad
@@ -414,7 +414,7 @@
   attrs:
     data_format: data_layout
   extra :
-    attrs : [bool use_mkldnn = false, bool fuse_with_relu = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, bool fuse_with_relu = false]
 
 - op : bce_loss
   backward : bce_loss_grad
@@ -462,7 +462,7 @@
   attrs:
     data_format: data_layout
   extra :
-    attrs : [bool use_mkldnn = false, str mkldnn_data_type = "float32"]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, str mkldnn_data_type = "float32"]
 
 - op : bincount
   inputs :
@@ -564,7 +564,7 @@
   outputs :
     out : Out
   extra :
-    attrs : [bool use_mkldnn = false, str mkldnn_data_type = "float32"]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, str mkldnn_data_type = "float32"]
 
 - op : ceil
   backward : ceil_grad
@@ -573,7 +573,7 @@
   outputs :
     out : Out
   extra :
-    attrs : [bool use_mkldnn = false, bool use_cudnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, bool use_cudnn = false]
 
 - op : celu
   backward : celu_grad, celu_double_grad(celu_grad_grad)
@@ -622,7 +622,7 @@
       data_type :  float
       tensor_name : Max
   extra :
-    attrs : [bool use_mkldnn = false, str mkldnn_data_type = "float32"]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, str mkldnn_data_type = "float32"]
 
 - op : clip_by_norm
   inputs :
@@ -667,7 +667,7 @@
       tensor_name : AxisTensor
   drop_empty_grad : [x_grad]
   extra :
-    attrs : [bool use_mkldnn = false, bool use_quantizer = false, str mkldnn_data_type = "float32"]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, bool use_quantizer = false, str mkldnn_data_type = "float32"]
   get_expected_kernel_type :
     concat : GetConcatExpectedKernelType
 
@@ -689,7 +689,7 @@
   outputs :
     out : Output
   extra :
-    attrs : [bool is_test = false, bool use_cudnn = true, bool use_mkldnn = false, bool use_addto = false,
+    attrs : [bool is_test = false, bool use_cudnn = true, bool use_mkldnn = false, bool use_onednn = false, bool use_addto = false,
              bool force_fp32_output = false,
              int workspace_size_MB = phi::backends::gpu::GetDefaultConvWorkspaceSizeLimitMB(), bool exhaustive_search = false, str mkldnn_data_type = "float32"]
   get_expected_kernel_type :
@@ -707,7 +707,7 @@
       support_tensor : true
   extra :
     inputs : [bias]
-    attrs : [bool is_test = false, bool use_cudnn = true, bool use_mkldnn = false, bool force_fp32_output = false,
+    attrs : [bool is_test = false, bool use_cudnn = true, bool use_mkldnn = false, bool use_onednn = false, bool force_fp32_output = false,
              str mkldnn_data_type = "float32", bool fuse_relu = false,
              str fuse_activation = "", float fuse_alpha = 0.0f, float fuse_beta = 0.0f,
              int workspace_size_MB = phi::backends::gpu::GetDefaultConvWorkspaceSizeLimitMB()]
@@ -722,7 +722,7 @@
       data_type : int
       support_tensor : true
   extra :
-    attrs : [bool is_test = false, bool use_cudnn = false, bool use_mkldnn = true, bool force_fp32_output = false,
+    attrs : [bool is_test = false, bool use_cudnn = false, bool use_mkldnn = true, bool use_onednn = false, bool force_fp32_output = false,
              str mkldnn_data_type = "float32", bool fuse_relu = false,
              str fuse_activation = "", float fuse_alpha = 0.0f, float fuse_beta = 0.0f]
 
@@ -733,7 +733,7 @@
   outputs :
     out : Output
   extra :
-    attrs : [bool is_test = false, bool use_cudnn = true, bool use_mkldnn = false, str mkldnn_data_type = "float32", bool fuse_relu = false,
+    attrs : [bool is_test = false, bool use_cudnn = true, bool use_mkldnn = false, bool use_onednn = false, str mkldnn_data_type = "float32", bool fuse_relu = false,
              str fuse_activation = "", float fuse_alpha = 0.0f, float fuse_beta = 0.0f,
              bool use_addto = false, bool fuse_residual_connection = false, bool force_fp32_output = false,
              int workspace_size_MB = phi::backends::gpu::GetDefaultConvWorkspaceSizeLimitMB(), bool exhaustive_search = false]
@@ -747,7 +747,7 @@
   outputs :
     out : Output
   extra :
-    attrs : [bool use_cudnn = true, bool use_mkldnn = false, int workspace_size_MB = phi::backends::gpu::GetDefaultConvWorkspaceSizeLimitMB()]
+    attrs : [bool use_cudnn = true, bool use_mkldnn = false, bool use_onednn = false, int workspace_size_MB = phi::backends::gpu::GetDefaultConvWorkspaceSizeLimitMB()]
 
 - op : correlation
   backward : correlation_grad
@@ -765,7 +765,7 @@
   outputs :
     out : Out
   extra :
-    attrs : [bool use_mkldnn = false, bool use_cudnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, bool use_cudnn = false]
 
 - op : cosh
   backward : cosh_grad
@@ -774,7 +774,7 @@
   outputs :
     out : Out
   extra :
-    attrs : [bool use_mkldnn = false, bool use_cudnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, bool use_cudnn = false]
 
 - op : crop (crop_tensor)
   backward : crop_grad (crop_tensor_grad)
@@ -882,7 +882,7 @@
       support_tensor : true
   extra :
     inputs : [bias]
-    attrs : [bool is_test = false, bool use_cudnn = false, bool use_mkldnn = false, bool force_fp32_output = false,
+    attrs : [bool is_test = false, bool use_cudnn = false, bool use_mkldnn = false, bool use_onednn = false, bool force_fp32_output = false,
              str mkldnn_data_type = "float32", bool fuse_relu = false,
              str fuse_activation = "", float fuse_alpha = 0.0f, float fuse_beta = 0.0f,
              int workspace_size_MB = phi::backends::gpu::GetDefaultConvWorkspaceSizeLimitMB()]
@@ -979,7 +979,7 @@
   outputs :
     out: Out
   extra :
-    attrs : [bool use_mkldnn = false, str mkldnn_data_type = "float32",
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, str mkldnn_data_type = "float32",
              bool use_quantizer = false, float Scale_x = 1.0f, float Scale_y = 1.0f, float Scale_out = 1.0f]
 
 - op : dot
@@ -1069,7 +1069,7 @@
   outputs :
     {out : Out}
   extra :
-    attrs : [bool use_mkldnn = false, str mkldnn_data_type = "float32",
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, str mkldnn_data_type = "float32",
              bool use_quantizer = false, float Scale_x = 1.0f, float Scale_y = 1.0f, float Scale_out = 1.0f]
   complex_promote : [X, Y]
   manual_signature : [elementwise_pow]
@@ -1137,7 +1137,7 @@
   outputs :
     out : Out
   extra :
-    attrs : [bool use_mkldnn = false, bool use_cudnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, bool use_cudnn = false]
 
 - op : expand (expand_v2)
   backward : expand_grad (expand_v2_grad), expand_double_grad(expand_v2_double_grad)
@@ -1153,7 +1153,7 @@
       tensor_name : Shape
       tensors_name : expand_shapes_tensor
   extra :
-    attrs : [bool use_mkldnn = false, str mkldnn_data_type = "float32"]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, str mkldnn_data_type = "float32"]
   manual_signature : [expand, expand_grad]
 
 - op : expand_as (expand_as_v2)
@@ -1170,7 +1170,7 @@
   outputs :
     out : Out
   extra :
-    attrs : [bool use_mkldnn = false, bool use_cudnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, bool use_cudnn = false]
 
 - op : exponential_ (exponential)
   backward : exponential__grad (exponential_grad)
@@ -1280,7 +1280,7 @@
   attrs :
     {scale_in : Scale_in, scale_out : Scale_out, scale_weights : Scale_weights}
   extra :
-    attrs : [bool use_mkldnn = false, bool use_quantizer = false, str mkldnn_data_type = "float32", float Scale_in = 1.0f, "float[] Scale_weights = {1.0f}", float Scale_out = 1.0f, bool force_fp32_output = false, str fuse_activation = "" , float fuse_alpha = 0.0f, float fuse_beta = 0.0f, float fused_output_scale = 1.0f, 'int[] fused_reshape2_shape = {}']
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, bool use_quantizer = false, str mkldnn_data_type = "float32", float Scale_in = 1.0f, "float[] Scale_weights = {1.0f}", float Scale_out = 1.0f, bool force_fp32_output = false, str fuse_activation = "" , float fuse_alpha = 0.0f, float fuse_beta = 0.0f, float fused_output_scale = 1.0f, 'int[] fused_reshape2_shape = {}']
 
 - op : feed
   outputs: {out: Out}
@@ -1357,7 +1357,7 @@
     {start_axis : start_axis, stop_axis : stop_axis}
   extra :
     outputs : [xshape]
-    attrs : [bool use_mkldnn = false, str mkldnn_data_type = "float32"]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, str mkldnn_data_type = "float32"]
   manual_signature : [flatten, flatten_grad]
 
 - op : flip
@@ -1373,7 +1373,7 @@
   outputs :
     out : Out
   extra :
-    attrs : [bool use_mkldnn = false, bool use_cudnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, bool use_cudnn = false]
 
 - op : floor_divide (elementwise_floordiv)
   inputs :
@@ -1381,7 +1381,7 @@
   outputs :
     {out : Out}
   extra :
-    attrs : [bool use_mkldnn = false, str mkldnn_data_type = "float32",
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, str mkldnn_data_type = "float32",
              bool use_quantizer = false, float Scale_x = 1.0f, float Scale_y = 1.0f, float Scale_out = 1.0f]
   complex_promote : [X, Y]
   manual_signature : [floor_divide]
@@ -1393,7 +1393,7 @@
   outputs :
     {out : Out}
   extra :
-    attrs : [bool use_mkldnn = false, str mkldnn_data_type = "float32",
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, str mkldnn_data_type = "float32",
              bool use_quantizer = false, float Scale_x = 1.0f, float Scale_y = 1.0f, float Scale_out = 1.0f]
   complex_promote : [X, Y]
   manual_signature : [fmax]
@@ -1405,7 +1405,7 @@
   outputs :
     {out : Out}
   extra :
-    attrs : [bool use_mkldnn = false, str mkldnn_data_type = "float32",
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, str mkldnn_data_type = "float32",
              bool use_quantizer = false, float Scale_x = 1.0f, float Scale_y = 1.0f, float Scale_out = 1.0f]
   complex_promote : [X, Y]
   manual_signature : [fmin]
@@ -1565,7 +1565,7 @@
     {scale_in : Scale_in, scale_out : Scale_out, scale_in_eltwise : Scale_in_eltwise, scale_weights : Scale_weights}
   extra :
     attrs : [bool use_cudnn = false, float fuse_alpha = 0.0f, float fuse_beta = 0.0f, float Scale_in = 1.0f,
-             float Scale_out = 1.0f, float Scale_in_eltwise = 1.0f, 'float[] Scale_weights = {1.0f}', bool use_mkldnn = true, str mkldnn_data_type = "float32"]
+             float Scale_out = 1.0f, float Scale_in_eltwise = 1.0f, 'float[] Scale_weights = {1.0f}', bool use_mkldnn = true, bool use_onednn = false, str mkldnn_data_type = "float32"]
 
 - op : fused_conv2d_add_act
   inputs :
@@ -1594,7 +1594,7 @@
     {scale_in : Scale_in, scale_out : Scale_out, scale_in_eltwise : Scale_in_eltwise, scale_weights : Scale_weights}
   extra :
     attrs : [bool use_cudnn = false, float fuse_alpha = 0.0f, float fuse_beta = 0.0f, float Scale_in = 1.0f,
-             float Scale_out = 1.0f, float Scale_in_eltwise = 1.0f, 'float[] Scale_weights = {1.0f}', bool use_mkldnn = true, str mkldnn_data_type = "float32"]
+             float Scale_out = 1.0f, float Scale_in_eltwise = 1.0f, 'float[] Scale_weights = {1.0f}', bool use_mkldnn = true, bool use_onednn = false, str mkldnn_data_type = "float32"]
 
 - op : fused_elementwise_add
   inputs :
@@ -1741,7 +1741,7 @@
   attrs :
     {scale_data : Scale_data, shift_data : Shift_data, scale_weights : Scale_weights}
   extra :
-    attrs : [bool use_mkldnn = false, str mkldnn_data_type = "float32", float Scale_data = 1.0f, float Shift_data = 0.0f, 'float[] Scale_weights = {1.0f}']
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, str mkldnn_data_type = "float32", float Scale_data = 1.0f, float Shift_data = 0.0f, 'float[] Scale_weights = {1.0f}']
 
 - op : fusion_lstm
   inputs :
@@ -1765,7 +1765,7 @@
   attrs :
     {scale_data : Scale_data, shift_data : Shift_data, scale_weights : Scale_weights}
   extra :
-    attrs : [bool use_mkldnn = true, str mkldnn_data_type = "float32"]
+    attrs : [bool use_mkldnn = true, bool use_onednn = false, str mkldnn_data_type = "float32"]
 
 - op : fusion_repeated_fc_relu
   inputs :
@@ -1844,7 +1844,7 @@
   outputs :
     out : Out
   extra :
-    attrs : [bool use_mkldnn = false, str mkldnn_data_type = "float32"]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, str mkldnn_data_type = "float32"]
 
 - op : generate_proposals(generate_proposals_v2)
   inputs :
@@ -1873,7 +1873,7 @@
   outputs :
     {out : Out}
   extra :
-    attrs : [bool use_mkldnn = false, str mkldnn_data_type = "float32",
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, str mkldnn_data_type = "float32",
              bool use_quantizer = false, float Scale_x = 1.0f, float Scale_y = 1.0f, float Scale_out = 1.0f]
 
 - op : graph_khop_sampler
@@ -1973,7 +1973,7 @@
   outputs :
     {out : Out}
   extra :
-    attrs : [bool use_mkldnn = false, str mkldnn_data_type = "float32",
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, str mkldnn_data_type = "float32",
              bool use_quantizer = false, float Scale_x = 1.0f, float Scale_y = 1.0f, float Scale_out = 1.0f]
   complex_promote : [X, Y]
 
@@ -2136,7 +2136,7 @@
     out : Out
   backward : l1_norm_grad
   extra :
-    attrs : [bool use_mkldnn = false, bool use_cudnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, bool use_cudnn = false]
 
 - op : label_smooth
   inputs :
@@ -2161,7 +2161,7 @@
     mean : Mean
     variance : Variance
   extra :
-    attrs : [bool use_mkldnn = false, str mkldnn_data_type = "float32", bool is_test = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, str mkldnn_data_type = "float32", bool is_test = false]
   get_expected_kernel_type :
     layer_norm : GetLayerNormExpectedKernelType
 
@@ -2201,7 +2201,7 @@
       tensor_name : ExpandTimes
       tensors_name : expand_times_tensor
   extra :
-    attrs : [bool use_mkldnn = false, str mkldnn_data_type = "float32"]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, str mkldnn_data_type = "float32"]
   manual_signature : [legacy_expand, legacy_expand_grad]
 
 - op : legacy_generate_proposals(generate_proposals)
@@ -2250,7 +2250,7 @@
       tensor_name : Shape
       tensors_name : ShapeTensor
   extra :
-    attrs : [bool use_mkldnn = false, str mkldnn_data_type = "float32", bool use_quantizer = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, str mkldnn_data_type = "float32", bool use_quantizer = false]
 
 - op : lerp
   backward : lerp_grad
@@ -2308,7 +2308,7 @@
   outputs :
     out : Out
   extra :
-    attrs : [bool use_mkldnn = false, bool use_cudnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, bool use_cudnn = false]
 
 - op : log10
   backward : log10_grad
@@ -2317,7 +2317,7 @@
   outputs :
     out : Out
   extra :
-    attrs : [bool use_mkldnn = false, bool use_cudnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, bool use_cudnn = false]
 
 - op : log1p
   backward : log1p_grad
@@ -2326,7 +2326,7 @@
   outputs :
     out : Out
   extra :
-    attrs : [bool use_mkldnn = false, bool use_cudnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, bool use_cudnn = false]
 
 - op : log2
   backward : log2_grad
@@ -2335,7 +2335,7 @@
   outputs :
     out : Out
   extra :
-    attrs : [bool use_mkldnn = false, bool use_cudnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, bool use_cudnn = false]
 
 - op : log_loss
   backward : log_loss_grad
@@ -2397,7 +2397,7 @@
   outputs :
     out : Out
   extra :
-    attrs : [bool use_mkldnn = false, bool use_cudnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, bool use_cudnn = false]
 
 - op : logsumexp
   backward : logsumexp_grad
@@ -2423,7 +2423,7 @@
   outputs :
     {out : Out, mid_out : MidOut}
   extra :
-    attrs : [bool use_mkldnn = false, bool is_test = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, bool is_test = false]
 
 - op : lstsq
   inputs :
@@ -2472,7 +2472,7 @@
   outputs :
     out : Out
   extra :
-    attrs : [bool use_mkldnn = false, str mkldnn_data_type = "float32", bool force_fp32_output = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, str mkldnn_data_type = "float32", bool force_fp32_output = false]
   complex_promote : [X, Y]
 
 - op : matmul_with_flatten (mul)
@@ -2482,7 +2482,7 @@
   outputs :
     out : Out
   extra :
-    attrs : [bool use_mkldnn = false, float scale_x = 1.0f, 'float[] scale_y = {1.0f}',
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, float scale_x = 1.0f, 'float[] scale_y = {1.0f}',
              float scale_out = 1.0f, bool force_fp32_output = false]
 
 - op : matrix_nms
@@ -2548,7 +2548,7 @@
   outputs :
     {out : Out}
   extra :
-    attrs : [bool use_mkldnn = false, str mkldnn_data_type = "float32",
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, str mkldnn_data_type = "float32",
              bool use_quantizer = false, float Scale_x = 1.0f, float Scale_y = 1.0f, float Scale_out = 1.0f]
   complex_promote : [X, Y]
   manual_signature : [maximum]
@@ -2653,7 +2653,7 @@
   outputs :
     {out : Out}
   extra :
-    attrs : [bool use_mkldnn = false, str x_data_format = "", str y_data_format = "", str mkldnn_data_type = "float32",
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, str x_data_format = "", str y_data_format = "", str mkldnn_data_type = "float32",
              bool use_quantizer = false, float Scale_x = 1.0f, float Scale_y = 1.0f, float Scale_out = 1.0f]
   complex_promote : [X, Y]
   manual_signature : [minimum]
@@ -2750,7 +2750,7 @@
   outputs :
     out : Out
   extra :
-    attrs : [bool use_mkldnn = false, str mkldnn_data_type = "float32",
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, str mkldnn_data_type = "float32",
              bool use_quantizer = false, float Scale_x = 1.0f, float Scale_y = 1.0f, float Scale_out = 1.0f]
 
 - op : mv
@@ -2946,7 +2946,7 @@
     pool2d_grad : GetPoolExpectedKernelType
     pool2d_double_grad : GetPoolDoubleGradExpectedKernelType
   extra :
-    attrs : [bool use_mkldnn = false, bool use_quantizer = false,
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, bool use_quantizer = false,
               str mkldnn_data_type = "float32", bool is_test = false]
 
 - op : pool3d
@@ -2983,7 +2983,7 @@
   outputs :
     out : Out
   extra :
-    attrs : [bool use_mkldnn = false, str mkldnn_data_type = "float32", bool is_test = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, str mkldnn_data_type = "float32", bool is_test = false]
 
 - op : print
   inputs :
@@ -2997,7 +2997,7 @@
   outputs :
     {out: Boxes, var: Variances}
   extra :
-    attrs : [bool use_mkldnn = false, bool use_quantizer = false, str mkldnn_data_type = "float32"]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, bool use_quantizer = false, str mkldnn_data_type = "float32"]
 
 - op : prod (reduce_prod)
   backward : prod_grad (reduce_prod_grad)
@@ -3092,7 +3092,7 @@
   outputs :
     out : Out
   extra :
-    attrs : [bool use_mkldnn = false, bool use_cudnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, bool use_cudnn = false]
 
 - op : relu
   backward : relu_grad, relu_double_grad (relu_grad_grad)
@@ -3101,7 +3101,7 @@
   outputs :
     out : Out
   extra :
-    attrs : [bool use_mkldnn = false, bool use_cudnn = false, str mkldnn_data_type = "float32"]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, bool use_cudnn = false, str mkldnn_data_type = "float32"]
 
 - op : relu6
   backward : relu6_grad
@@ -3110,7 +3110,7 @@
   outputs :
     out : Out
   extra :
-    attrs : [bool use_mkldnn = false, float threshold = 6.0]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, float threshold = 6.0]
 
 - op : remainder (elementwise_mod)
   inputs :
@@ -3118,7 +3118,7 @@
   outputs :
     {out : Out}
   extra :
-    attrs : [bool use_mkldnn = false, str mkldnn_data_type = "float32",
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, str mkldnn_data_type = "float32",
              bool use_quantizer = false, float Scale_x = 1.0f, float Scale_y = 1.0f, float Scale_out = 1.0f]
   complex_promote : [X, Y]
   manual_signature : [remainder]
@@ -3130,7 +3130,7 @@
   outputs :
     out : Out
   extra :
-    attrs : [bool use_mkldnn = false, bool use_cudnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, bool use_cudnn = false]
 
 - op : repeat_interleave
   inputs :
@@ -3179,7 +3179,7 @@
       tensor_name : Shape
       tensors_name : ShapeTensor
   extra :
-    attrs : [bool use_mkldnn = false, str mkldnn_data_type = "float32", bool use_quantizer = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, str mkldnn_data_type = "float32", bool use_quantizer = false]
 
 - op : resnet_basic_block
   backward: resnet_basic_block_grad
@@ -3252,7 +3252,7 @@
   outputs :
     out : Out
   extra :
-    attrs : [bool use_mkldnn = false, bool use_cudnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, bool use_cudnn = false]
 
 - op : row_conv
   backward : row_conv_grad
@@ -3268,7 +3268,7 @@
   outputs :
     out : Out
   extra :
-    attrs : [bool use_mkldnn = false, bool use_cudnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, bool use_cudnn = false]
 
 - op : save_combine
   inputs :
@@ -3288,7 +3288,7 @@
       data_type : float
       support_tensor : false
   extra :
-    attrs : [bool use_mkldnn = false, str mkldnn_data_type = "float32"]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, str mkldnn_data_type = "float32"]
 
 - op : scatter
   backward : scatter_grad
@@ -3407,7 +3407,7 @@
 
 - op : shape
   extra :
-    attrs : [bool use_mkldnn = false, str mkldnn_data_type = "float32"]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, str mkldnn_data_type = "float32"]
 
 - op : shard_index
   inputs :
@@ -3451,7 +3451,7 @@
   outputs :
     out : Out
   extra :
-    attrs : [bool use_mkldnn = false, bool use_cudnn = false, str mkldnn_data_type = "float32"]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, bool use_cudnn = false, str mkldnn_data_type = "float32"]
 
 - op : sign
   backward : sign_grad
@@ -3467,7 +3467,7 @@
   outputs :
     out : Out
   extra :
-    attrs : [bool use_mkldnn = false, bool use_cudnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, bool use_cudnn = false]
 
 - op : sin
   backward : sin_grad, sin_double_grad, sin_triple_grad
@@ -3476,7 +3476,7 @@
   outputs :
     out : Out
   extra :
-    attrs : [bool use_mkldnn = false, bool use_cudnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, bool use_cudnn = false]
 
 - op : sinh
   backward : sinh_grad
@@ -3485,7 +3485,7 @@
   outputs :
     out : Out
   extra :
-    attrs : [bool use_mkldnn = false, bool use_cudnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, bool use_cudnn = false]
 
 - op : slice
   backward : slice_grad
@@ -3494,7 +3494,7 @@
   outputs :
     out : Out
   extra :
-    attrs : [bool use_mkldnn = false, str mkldnn_data_type = "float32"]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, str mkldnn_data_type = "float32"]
   int_array :
     starts :
       data_type : int
@@ -3529,7 +3529,7 @@
     softmax : GetSoftmaxExpectedKernelType
     softmax_grad : GetSoftmaxGradExpectedKernelType
   extra :
-    attrs : [str data_format = "AnyLayout", bool use_cudnn = true, bool use_mkldnn = false, str mkldnn_data_type = "float32", bool is_test = false]
+    attrs : [str data_format = "AnyLayout", bool use_cudnn = true, bool use_mkldnn = false, bool use_onednn = false, str mkldnn_data_type = "float32", bool is_test = false]
 
 - op : softplus
   backward : softplus_grad, softplus_double_grad
@@ -3538,7 +3538,7 @@
   outputs :
     out : Out
   extra :
-    attrs : [bool use_mkldnn = false, bool use_cudnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, bool use_cudnn = false]
 
 - op : softshrink
   backward : softshrink_grad
@@ -3556,7 +3556,7 @@
   outputs :
     out : Out
   extra :
-    attrs : [bool use_mkldnn = false, bool use_cudnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, bool use_cudnn = false]
 
 - op : solve
   inputs :
@@ -3618,7 +3618,7 @@
       data_type : int
       support_tensor : true
   extra :
-    attrs : [bool use_mkldnn = false, str mkldnn_data_type = "float32"]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, str mkldnn_data_type = "float32"]
 
 - op : split_with_num
   scalar :
@@ -3634,7 +3634,7 @@
   outputs :
     out : Out
   extra :
-    attrs : [bool use_mkldnn = false, bool use_cudnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, bool use_cudnn = false]
 
 - op : square
   backward : square_grad, square_double_grad (square_grad_grad)
@@ -3643,7 +3643,7 @@
   outputs :
     out : Out
   extra :
-    attrs : [bool use_mkldnn = false, bool use_cudnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, bool use_cudnn = false]
 
 - op : squeeze (squeeze2)
   backward : squeeze_grad (squeeze2_grad), squeeze_double_grad(squeeze2_double_grad)
@@ -3658,7 +3658,7 @@
       data_type : int
       support_tensor : true
   extra :
-    attrs : [bool use_mkldnn = false, str mkldnn_data_type = "float32"]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, str mkldnn_data_type = "float32"]
     outputs : [xshape]
 
 - op : stack
@@ -3715,7 +3715,7 @@
   outputs :
     out : Out
   extra :
-    attrs : [bool use_mkldnn = false, str mkldnn_data_type = "float32",
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, str mkldnn_data_type = "float32",
              bool use_quantizer = false, float Scale_x = 1.0f, float Scale_y = 1.0f, float Scale_out = 1.0f]
   complex_promote : [X, Y]
 
@@ -3728,7 +3728,7 @@
   attrs:
     { axis : dim,  keepdim : keep_dim, dtype : out_dtype}
   extra :
-    attrs : [bool use_mkldnn = false, str mkldnn_data_type = "float32"]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, str mkldnn_data_type = "float32"]
   int_array:
       axis :
         data_type : int
@@ -3752,7 +3752,7 @@
   outputs :
     out : Out
   extra :
-    attrs : [bool use_mkldnn = false, float beta = 1.0]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, float beta = 1.0]
 
 - op : sync_batch_norm
   inputs :
@@ -3763,7 +3763,7 @@
   attrs:
     data_format: data_layout
   extra :
-    attrs : [bool use_mkldnn = false, bool fuse_with_relu = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, bool fuse_with_relu = false]
 
 - op : take_along_axis
   backward : take_along_axis_grad
@@ -3781,7 +3781,7 @@
   outputs :
     out : Out
   extra :
-    attrs : [bool use_mkldnn = false, bool use_cudnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, bool use_cudnn = false]
 
 - op : tanh
   backward : tanh_grad, tanh_double_grad (tanh_grad_grad), tanh_triple_grad
@@ -3790,7 +3790,7 @@
   outputs :
     out : Out
   extra :
-    attrs : [bool use_mkldnn = false, bool use_cudnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, bool use_cudnn = false]
 
 - op : tanh_shrink
   backward : tanh_shrink_grad
@@ -3799,7 +3799,7 @@
   outputs :
     out : Out
   extra :
-    attrs : [bool use_mkldnn = false, bool use_cudnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, bool use_cudnn = false]
 
 - op : tdm_child
   inputs :
@@ -3871,7 +3871,7 @@
     perm : axis
   extra :
     outputs : [XShape]
-    attrs : [bool use_mkldnn = false, str data_format = "AnyLayout", str mkldnn_data_type = "float32"]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false, str data_format = "AnyLayout", str mkldnn_data_type = "float32"]
 
 - op : triangular_solve
   backward : triangular_solve_grad

--- a/paddle/phi/ops/yaml/op_compat.yaml
+++ b/paddle/phi/ops/yaml/op_compat.yaml
@@ -21,7 +21,7 @@
   outputs :
     out : Out
   extra :
-    attrs : [bool use_mkldnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false]
 
 - op : accuracy
   inputs :
@@ -132,7 +132,7 @@
   attrs :
     {alpha : Alpha, beta : Beta}
   extra :
-    attrs : [bool use_mkldnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false]
 
 - op : affine_channel
   backward: affine_channel_grad
@@ -163,7 +163,7 @@
     out : Out
   manual_signature : [all]
   extra :
-    attrs : [bool use_mkldnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false]
 
 - op : allclose
   inputs :
@@ -187,7 +187,7 @@
   attrs:
     { axis : dim,  keepdim : keep_dim }
   extra :
-    attrs : [bool use_mkldnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false]
   get_expected_kernel_type :
     amax_grad : GetReduceGradExpectedKernelType
   manual_signature : [amax]
@@ -201,7 +201,7 @@
   attrs:
     { axis : dim,  keepdim : keep_dim }
   extra :
-    attrs : [bool use_mkldnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false]
   get_expected_kernel_type :
     amin_grad : GetReduceGradExpectedKernelType
   manual_signature : [amin]
@@ -219,7 +219,7 @@
   outputs :
     out : Out
   extra :
-    attrs : [bool use_mkldnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false]
 
 - op : any (reduce_any)
   inputs :
@@ -229,7 +229,7 @@
   attrs:
     { axis : dim,  keepdim : keep_dim }
   extra :
-    attrs : [bool use_mkldnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false]
   get_expected_kernel_type :
     any : GetReduceOpUseInputPlaceExpectedKernelType
   manual_signature : [any]
@@ -381,7 +381,7 @@
   attrs :
     {alpha : Alpha, beta : Beta}
   extra :
-    attrs : [bool use_mkldnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false]
 
 - op : barrier
   inputs :
@@ -444,7 +444,7 @@
   attrs:
     data_format: data_layout
   extra :
-    attrs : [bool use_mkldnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false]
 
 - op : bilinear (bilinear_tensor_product)
   backward: bilinear_grad (bilinear_tensor_product_grad)
@@ -756,7 +756,7 @@
   outputs :
     out : Output
   extra :
-    attrs : [bool use_mkldnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false]
 
 - op : cos
   backward : cos_grad, cos_double_grad, cos_triple_grad
@@ -837,7 +837,7 @@
 - op : data_norm
   backward : data_norm_grad
   extra :
-    attrs : [bool use_mkldnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false]
 
 - op : decode_jpeg
   inputs :
@@ -861,7 +861,7 @@
   attrs :
     {scale_in : Scale_in, scale_out : Scale_out, scale_in_eltwise : Scale_in_eltwise, scale_weights : Scale_weights}
   extra :
-    attrs : [bool is_test = false, bool use_cudnn = false, bool fuse_relu_before_depthwise_conv = false, bool use_mkldnn = false,
+    attrs : [bool is_test = false, bool use_cudnn = false, bool fuse_relu_before_depthwise_conv = false, bool use_mkldnn = false, bool use_onednn = false,
              bool use_quantizer = false, str mkldnn_data_type = "float32", bool fuse_relu = false,
              str fuse_activation = "", float fuse_alpha = 0.0f, float fuse_beta = 0.0f, bool use_addto = false,
              bool fuse_residual_connection = false, float Scale_in = 1.0f, float Scale_out = 1.0f,
@@ -1081,7 +1081,7 @@
   outputs :
     out : Out
   extra :
-    attrs : [bool use_mkldnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false]
 
 - op : embedding (lookup_table_v2)
   backward : embedding_grad (lookup_table_v2_grad)
@@ -1439,13 +1439,13 @@
     frobenius_norm : GetReduceExpectedKernelType
     frobenius_norm_grad : GetReduceGradExpectedKernelType
   extra :
-    attrs : [bool use_mkldnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false]
 
 - op : full (fill_constant)
   outputs :
     out : Out
   extra :
-    attrs : [bool use_mkldnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false]
 
 - op : full_like (fill_any_like)
   inputs :
@@ -1577,7 +1577,7 @@
     output : Output
     outputs : Outputs
   extra :
-    attrs : [bool is_test = false, bool use_cudnn = true, bool fuse_relu_before_depthwise_conv = false, bool use_mkldnn = false,
+    attrs : [bool is_test = false, bool use_cudnn = true, bool fuse_relu_before_depthwise_conv = false, bool use_mkldnn = false, bool use_onednn = false,
              bool use_quantizer = false, str mkldnn_data_type = "float32", bool fuse_relu = false,
              str fuse_activation = "", float fuse_beta = 0.0f, bool use_addto = false,
              bool fuse_residual_connection = false, float Scale_in = 1.0f, float Scale_out = 1.0f,
@@ -1834,7 +1834,7 @@
       tensor_name : ShapeTensor
       tensors_name : ShapeTensorList
   extra :
-    attrs : [bool use_mkldnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false]
   manual_signature : [gaussian]
 
 - op : gelu
@@ -1948,7 +1948,7 @@
     out : Out
   backward : hardswish_grad (hard_swish_grad)
   extra :
-    attrs : [bool use_mkldnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false]
   manual_signature : [hardswish]
 
 - op : hardtanh (brelu)
@@ -2174,7 +2174,7 @@
   attrs:
     negative_slope : alpha
   extra :
-    attrs : [bool use_mkldnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false]
 
 - op : legacy_bilinear_interp (bilinear_interp)
   backward : legacy_bilinear_interp_grad (bilinear_interp_grad)
@@ -2185,7 +2185,7 @@
   attrs:
     data_format: data_layout
   extra :
-    attrs : [bool use_mkldnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false]
 
 - op : legacy_expand (expand)
   backward : legacy_expand_grad (expand_grad)
@@ -2235,7 +2235,7 @@
   attrs:
     data_format: data_layout
   extra :
-    attrs : [bool use_mkldnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false]
 
 - op : legacy_reshape (reshape)
   backward : legacy_reshape_grad (reshape_grad)
@@ -2286,7 +2286,7 @@
   attrs:
     data_format: data_layout
   extra :
-    attrs : [bool use_mkldnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false]
 
 - op : linspace
   inputs :
@@ -2351,7 +2351,7 @@
   outputs :
     out: Out
   extra :
-    attrs : [bool use_mkldnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false]
 
 - op : logcumsumexp
   backward : logcumsumexp_grad
@@ -2515,7 +2515,7 @@
   outputs:
     out : Out
   extra :
-    attrs : [bool use_mkldnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false]
   int_array:
     axis :
       data_type : int
@@ -2568,7 +2568,7 @@
   attrs :
     {axis : dim, keepdim : keep_dim}
   extra :
-    attrs : [bool use_mkldnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false]
   int_array:
       axis :
         data_type : int
@@ -2636,7 +2636,7 @@
   attrs:
     { axis : dim,  keepdim : keep_dim}
   extra :
-    attrs : [bool use_mkldnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false]
   int_array:
     axis :
       data_type : int
@@ -2665,7 +2665,7 @@
   outputs:
     out: Out
   extra :
-    attrs : [bool use_mkldnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false]
 
 - op : mode
   backward : mode_grad
@@ -2780,7 +2780,7 @@
   attrs:
     data_format: data_layout
   extra :
-    attrs : [bool use_mkldnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false]
 
 - op : nll_loss
   backward : nll_loss_grad
@@ -2862,7 +2862,7 @@
 - op : pad2d
   backward : pad2d_grad
   extra :
-    attrs : [bool use_mkldnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false]
 
 - op : pad3d
   backward : pad3d_grad, pad3d_double_grad
@@ -2877,7 +2877,7 @@
   attrs :
     pad_value : value
   extra :
-    attrs : [bool use_mkldnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false]
 
 - op : partial_allgather
   inputs :
@@ -2893,7 +2893,7 @@
     out : Out
   drop_empty_grad : [x_grad]
   extra :
-    attrs : [bool use_mkldnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false]
 
 - op : partial_recv
   outputs :
@@ -2907,7 +2907,7 @@
     out : Out
   drop_empty_grad : [x_grad]
   extra :
-    attrs : [bool use_mkldnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false]
 
 - op : pixel_shuffle
   backward : pixel_shuffle_grad
@@ -2961,7 +2961,7 @@
     pool3d : GetPoolExpectedKernelType
     pool3d_grad : GetPoolExpectedKernelType
   extra :
-    attrs : [bool use_mkldnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false]
 
 - op : pow
   backward : pow_grad, pow_double_grad, pow_triple_grad
@@ -3012,7 +3012,7 @@
       data_type : int
       support_tensor : true
   extra :
-    attrs : [bool use_mkldnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false]
   get_expected_kernel_type :
     prod : GetReduceExpectedKernelType
     prod_grad : GetReduceGradExpectedKernelType
@@ -3397,7 +3397,7 @@
   get_expected_kernel_type :
     sgd_ : GetSgdExpectedKernelType
   extra :
-    attrs : [bool use_mkldnn=false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false]
 
 - op : shape
   inputs :
@@ -3442,7 +3442,7 @@
   outputs:
     {out : Out}
   extra :
-    attrs : [bool use_mkldnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false]
 
 - op : sigmoid
   backward : sigmoid_grad, sigmoid_double_grad (sigmoid_grad_grad), sigmoid_triple_grad
@@ -3668,7 +3668,7 @@
   outputs :
     out : Y
   extra :
-    attrs : [bool use_mkldnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false]
   drop_empty_grad : [x_grad]
 
 - op : stanh
@@ -3807,7 +3807,7 @@
   outputs :
     {child : Child, leaf_mask : LeafMask}
   extra :
-    attrs : [bool use_mkldnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false]
 
 - op : tdm_sampler
   inputs:
@@ -3896,7 +3896,7 @@
   attrs:
     data_format: data_layout
   extra :
-    attrs : [bool use_mkldnn = false]
+    attrs : [bool use_mkldnn = false, bool use_onednn = false]
 
 - op : trunc
   inputs :

--- a/test/mkldnn/test_shape_mkldnn_op.py
+++ b/test/mkldnn/test_shape_mkldnn_op.py
@@ -26,7 +26,7 @@ class TestShape3DFP32OneDNNOp(OpTest):
         self.op_type = "shape"
         self.python_api = paddle.tensor.shape
         self.config()
-        self.attrs = {'use_mkldnn': True}
+        self.attrs = {'use_onednn': True}
         self.inputs = {'Input': np.zeros(self.shape).astype(self.dtype)}
         self.outputs = {'Out': np.array(self.shape)}
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
paddle/phi/ops/yaml/op_compat.yaml 算子如果有use_mkldnn属性，增加 use_onednn 属性，默认值为false，代码中是判断use_mkldnn或use_onednn是否为true，use_mkldnn废弃时，再修改use_onednn值为算子use_mkldnn默认值

测试设置算子use_onednn属性，算子会使用ONEDNN
<img width="1631" height="140" alt="image" src="https://github.com/user-attachments/assets/53464ffa-4737-407b-8e35-91cb198c0fb4" />
