### PR TITLE
[Custom Device ]Solved several problems for CUDA custom device backend

### DIFF
--- a/paddle/phi/kernels/funcs/elementwise/elementwise_op_function.h
+++ b/paddle/phi/kernels/funcs/elementwise/elementwise_op_function.h
@@ -24,6 +24,10 @@
 #include "paddle/phi/backends/gpu/gpu_info.h"
 #include "paddle/phi/common/transform.h"
 #include "paddle/phi/core/dense_tensor.h"
+#ifndef PADDLE_WITH_CUSTOM_DEVICE
+#include "paddle/phi/kernels/cpu/elementwise.h"
+#include "paddle/phi/kernels/cpu/elementwise_grad.h"
+#endif
 #include "paddle/phi/kernels/funcs/eigen/common.h"
 #include "paddle/phi/kernels/funcs/elementwise_functor.h"
 
@@ -31,7 +35,7 @@
 #ifdef __NVCC__
 #include <cuda.h>
 #elif defined(__HIPCC__)
-#include <hip/hip_runtime.h>
+#endif
 #endif
 #include <thrust/iterator/iterator_adaptor.h>
 

--- a/paddle/phi/kernels/funcs/elementwise/elementwise_op_function.h
+++ b/paddle/phi/kernels/funcs/elementwise/elementwise_op_function.h
@@ -24,8 +24,6 @@
 #include "paddle/phi/backends/gpu/gpu_info.h"
 #include "paddle/phi/common/transform.h"
 #include "paddle/phi/core/dense_tensor.h"
-#include "paddle/phi/kernels/cpu/elementwise.h"
-#include "paddle/phi/kernels/cpu/elementwise_grad.h"
 #include "paddle/phi/kernels/funcs/eigen/common.h"
 #include "paddle/phi/kernels/funcs/elementwise_functor.h"
 

--- a/paddle/phi/kernels/funcs/elementwise/elementwise_op_function.h
+++ b/paddle/phi/kernels/funcs/elementwise/elementwise_op_function.h
@@ -24,7 +24,7 @@
 #include "paddle/phi/backends/gpu/gpu_info.h"
 #include "paddle/phi/common/transform.h"
 #include "paddle/phi/core/dense_tensor.h"
-#ifndef PADDLE_WITH_CUDA
+#if !defined(PADDLE_WITH_CUDA) || !defined(PADDLE_WITH_CUSTOM_DEVICE)
 #include "paddle/phi/kernels/cpu/elementwise.h"
 #include "paddle/phi/kernels/cpu/elementwise_grad.h"
 #endif

--- a/paddle/phi/kernels/funcs/elementwise/elementwise_op_function.h
+++ b/paddle/phi/kernels/funcs/elementwise/elementwise_op_function.h
@@ -35,7 +35,7 @@
 #ifdef __NVCC__
 #include <cuda.h>
 #elif defined(__HIPCC__)
-#endif
+#include <hip/hip_runtime.h>
 #endif
 #include <thrust/iterator/iterator_adaptor.h>
 

--- a/paddle/phi/kernels/funcs/elementwise/elementwise_op_function.h
+++ b/paddle/phi/kernels/funcs/elementwise/elementwise_op_function.h
@@ -24,7 +24,7 @@
 #include "paddle/phi/backends/gpu/gpu_info.h"
 #include "paddle/phi/common/transform.h"
 #include "paddle/phi/core/dense_tensor.h"
-#ifndef PADDLE_WITH_CUSTOM_DEVICE
+#ifndef PADDLE_WITH_CUDA
 #include "paddle/phi/kernels/cpu/elementwise.h"
 #include "paddle/phi/kernels/cpu/elementwise_grad.h"
 #endif

--- a/paddle/phi/kernels/funcs/quant_dequant.h
+++ b/paddle/phi/kernels/funcs/quant_dequant.h
@@ -20,7 +20,6 @@ limitations under the License. */
 #include "paddle/phi/common/float16.h"
 #include "paddle/phi/common/transform.h"
 #include "paddle/phi/kernels/funcs/aligned_vector.h"
-#include "paddle/phi/kernels/funcs/blas/blas.h"
 
 namespace phi {
 

--- a/paddle/phi/kernels/funcs/quant_dequant.h
+++ b/paddle/phi/kernels/funcs/quant_dequant.h
@@ -20,7 +20,9 @@ limitations under the License. */
 #include "paddle/phi/common/float16.h"
 #include "paddle/phi/common/transform.h"
 #include "paddle/phi/kernels/funcs/aligned_vector.h"
-
+#ifndef PADDLE_WITH_CUSTOM_DEVICE
+#include "paddle/phi/kernels/funcs/blas/blas.h"
+#endif
 namespace phi {
 
 using backends::gpu::GpuLaunchConfig;

--- a/paddle/phi/kernels/funcs/sparse/convolution.h
+++ b/paddle/phi/kernels/funcs/sparse/convolution.h
@@ -19,7 +19,7 @@ limitations under the License. */
 #include "paddle/phi/core/tensor_utils.h"
 #include "paddle/phi/kernels/empty_kernel.h"
 
-#ifndef PADDLE_WITH_CUSTOM_DEVICE
+#if !defined(PADDLE_WITH_CUDA) || !defined(PADDLE_WITH_CUSTOM_DEVICE)
 #include "paddle/phi/kernels/funcs/sparse/convolution_blas.h"
 #endif
 

--- a/paddle/phi/kernels/funcs/sparse/convolution.h
+++ b/paddle/phi/kernels/funcs/sparse/convolution.h
@@ -18,7 +18,10 @@ limitations under the License. */
 #include "paddle/phi/core/kmap_cache.h"
 #include "paddle/phi/core/tensor_utils.h"
 #include "paddle/phi/kernels/empty_kernel.h"
-#include "paddle/phi/kernels/funcs/blas/blas.h"
+
+#ifndef PADDLE_WITH_CUSTOM_DEVICE
+#include "paddle/phi/kernels/funcs/sparse/convolution_blas.h"
+#endif
 
 namespace phi {
 namespace funcs {
@@ -152,47 +155,6 @@ inline void ResetSubmKernelSizeAndStrides(const DDim& kernel_dims,
     (*paddings)[i] = kernel_dims[i] / 2;
     (*strides)[i] = 1;
   }
-}
-
-template <typename T, typename Context>
-inline void SubmPreProcess(const Context& dev_ctx,
-                           const SparseCooTensor& x,
-                           const DenseTensor& kernel,
-                           const DenseTensor& out_grad,
-                           const int in_channels,
-                           const int out_channels,
-                           const int half_kernel_size,
-                           DenseTensor* kernel_grad,
-                           DenseTensor* x_grad) {
-  auto blas = phi::funcs::GetBlas<Context, T>(dev_ctx);
-  const bool is_params_freezing = kernel_grad == nullptr;
-  if (!is_params_freezing) {
-    T* d_kernel_ptr = kernel_grad->data<T>();
-    blas.GEMM(CblasTrans,
-              CblasNoTrans,
-              x.non_zero_elements().dims()[1],
-              out_grad.dims()[1],
-              x.non_zero_elements().dims()[0],
-              static_cast<T>(1),
-              x.non_zero_elements().data<T>(),
-              out_grad.data<T>(),
-              static_cast<T>(0),
-              d_kernel_ptr + half_kernel_size * in_channels * out_channels);
-  }
-
-  // call gemm: d_x = out_grad * transpose(kernel)
-  // (n, out_channels) * (out_channels, in_channels)
-  T* x_grad_ptr = x_grad->data<T>();
-  blas.GEMM(CblasNoTrans,
-            CblasTrans,
-            out_grad.dims()[0],
-            in_channels,
-            out_grad.dims()[1],
-            static_cast<T>(1),
-            out_grad.data<T>(),
-            kernel.data<T>() + half_kernel_size * in_channels * out_channels,
-            static_cast<T>(0),
-            x_grad_ptr);
 }
 
 inline const std::vector<int> PoolResetKernel(

--- a/paddle/phi/kernels/funcs/sparse/convolution_blas.h
+++ b/paddle/phi/kernels/funcs/sparse/convolution_blas.h
@@ -1,0 +1,70 @@
+/* Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#pragma once
+
+#include "paddle/common/ddim.h"
+#include "paddle/phi/core/kmap_cache.h"
+#include "paddle/phi/core/tensor_utils.h"
+#include "paddle/phi/kernels/empty_kernel.h"
+#include "paddle/phi/kernels/funcs/blas/blas.h"
+
+namespace phi {
+namespace funcs {
+namespace sparse {
+
+template <typename T, typename Context>
+inline void SubmPreProcess(const Context& dev_ctx,
+                           const SparseCooTensor& x,
+                           const DenseTensor& kernel,
+                           const DenseTensor& out_grad,
+                           const int in_channels,
+                           const int out_channels,
+                           const int half_kernel_size,
+                           DenseTensor* kernel_grad,
+                           DenseTensor* x_grad) {
+  auto blas = phi::funcs::GetBlas<Context, T>(dev_ctx);
+  const bool is_params_freezing = kernel_grad == nullptr;
+  if (!is_params_freezing) {
+    T* d_kernel_ptr = kernel_grad->data<T>();
+    blas.GEMM(CblasTrans,
+              CblasNoTrans,
+              x.non_zero_elements().dims()[1],
+              out_grad.dims()[1],
+              x.non_zero_elements().dims()[0],
+              static_cast<T>(1),
+              x.non_zero_elements().data<T>(),
+              out_grad.data<T>(),
+              static_cast<T>(0),
+              d_kernel_ptr + half_kernel_size * in_channels * out_channels);
+  }
+
+  // call gemm: d_x = out_grad * transpose(kernel)
+  // (n, out_channels) * (out_channels, in_channels)
+  T* x_grad_ptr = x_grad->data<T>();
+  blas.GEMM(CblasNoTrans,
+            CblasTrans,
+            out_grad.dims()[0],
+            in_channels,
+            out_grad.dims()[1],
+            static_cast<T>(1),
+            out_grad.data<T>(),
+            kernel.data<T>() + half_kernel_size * in_channels * out_channels,
+            static_cast<T>(0),
+            x_grad_ptr);
+}
+
+}  // namespace sparse
+}  // namespace funcs
+}  // namespace phi

--- a/paddle/phi/kernels/stride/as_complex_kernel.cc
+++ b/paddle/phi/kernels/stride/as_complex_kernel.cc
@@ -91,7 +91,7 @@ PD_REGISTER_KERNEL(
 }
 #endif
 
-#ifdef PADDLE_WITH_CUSTOM_DEVICE
+#if defined(PADDLE_WITH_CUSTOM_DEVICE) && !defined(PADDLE_WITH_CUDA)
 PD_REGISTER_KERNEL(
     as_complex, Custom, STRIDED, phi::AsComplexStridedKernel, float, double) {
   kernel->OutputAt(0).SetDataType(phi::dtype::ToReal(kernel_key.dtype()));

--- a/paddle/phi/kernels/stride/as_real_kernel.cc
+++ b/paddle/phi/kernels/stride/as_real_kernel.cc
@@ -71,7 +71,7 @@ PD_REGISTER_KERNEL(as_real,
 }
 #endif
 
-#ifdef PADDLE_WITH_CUSTOM_DEVICE
+#if defined(PADDLE_WITH_CUSTOM_DEVICE) && !defined(PADDLE_WITH_CUDA)
 PD_REGISTER_KERNEL(as_real,
                    Custom,
                    STRIDED,

--- a/paddle/phi/kernels/stride/complex_grad_kernel.cc
+++ b/paddle/phi/kernels/stride/complex_grad_kernel.cc
@@ -126,7 +126,7 @@ PD_REGISTER_KERNEL(imag_grad,
 }
 #endif
 
-#ifdef PADDLE_WITH_CUSTOM_DEVICE
+#if defined(PADDLE_WITH_CUSTOM_DEVICE) && !defined(PADDLE_WITH_CUDA)
 PD_REGISTER_KERNEL(real_grad,
                    Custom,
                    STRIDED,

--- a/paddle/phi/kernels/stride/complex_kernel.cc
+++ b/paddle/phi/kernels/stride/complex_kernel.cc
@@ -119,7 +119,7 @@ PD_REGISTER_KERNEL(imag,
 }
 #endif
 
-#ifdef PADDLE_WITH_CUSTOM_DEVICE
+#if defined(PADDLE_WITH_CUSTOM_DEVICE) && !defined(PADDLE_WITH_CUDA)
 PD_REGISTER_KERNEL(real,
                    Custom,
                    STRIDED,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Custom Device

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-67164
Metax is adding more kernels to its backend. I checked all the remaining kernels. This PR ​​fixes 4 stride kernels​​ which were being instantiated twice in the ​​CUDA custom device backend​​. Also it ​​modifies​​ some header files ​​to make them compilable​​ on this kind of backend.