### PR TITLE
Temp fix namespace seperation between pir_op and custom_op

### DIFF
--- a/paddle/fluid/framework/custom_operator.cc
+++ b/paddle/fluid/framework/custom_operator.cc
@@ -961,7 +961,8 @@ void RegisterOperatorWithMetaInfo(const std::vector<OpMetaInfo>& op_meta_infos,
 
   auto& base_op_meta = op_meta_infos.front();
 
-  auto op_name = OpMetaInfoHelper::GetOpName(base_op_meta);
+  auto op_name = paddle::framework::kCustomDialectPrefix +
+                 OpMetaInfoHelper::GetOpName(base_op_meta);
 
   if (OpInfoMap::Instance().Has(op_name)) {
     LOG(WARNING) << "Operator (" << op_name << ") has been registered.";
@@ -1084,7 +1085,8 @@ void RegisterOperatorWithMetaInfo(const std::vector<OpMetaInfo>& op_meta_infos,
   for (size_t i = 1; i < op_meta_infos.size(); ++i) {
     auto& cur_grad_op = op_meta_infos[i];
 
-    auto& grad_op_name = OpMetaInfoHelper::GetOpName(cur_grad_op);
+    auto grad_op_name = paddle::framework::kCustomDialectPrefix +
+                        OpMetaInfoHelper::GetOpName(cur_grad_op);
     auto& grad_op_inputs = OpMetaInfoHelper::GetInputs(cur_grad_op);
     auto& grad_op_outputs = OpMetaInfoHelper::GetOutputs(cur_grad_op);
     auto& grad_op_attrs = OpMetaInfoHelper::GetAttrs(cur_grad_op);
@@ -1282,6 +1284,8 @@ void RegisterOperatorWithMetaInfoMap(
 
     // Register PIR op
 
+    // Note(Pan Zhaowu): This context guard is prevent custom op registered in
+    // same name, but will not check the naming conflict with PIR op.
     if (custom_dialect->HasRegistered(pair.first)) {
       VLOG(3) << "The operator `" << pair.first
               << "` has been registered. "
@@ -1291,10 +1295,12 @@ void RegisterOperatorWithMetaInfoMap(
     for (const auto& meta_info : pair.second) {
       VLOG(3) << "register pir custom op :"
               << OpMetaInfoHelper::GetOpName(meta_info);
+      // TODO(Pan Zhaowu): Do namespace quarantine between PIR op and custom op.
       custom_dialect->RegisterCustomOp(meta_info);
     }
 
     // Register Fluid op
+    // TODO(Pan Zhaowu): Do namespace quarantine between PIR op and custom op.
     RegisterOperatorWithMetaInfo(pair.second, dso_handle);
   }
 }

--- a/paddle/fluid/pybind/eager_functions.cc
+++ b/paddle/fluid/pybind/eager_functions.cc
@@ -18,6 +18,7 @@ typedef SSIZE_T ssize_t;
 #include <Python.h>
 
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 
@@ -474,6 +475,11 @@ static PyObject* eager_api__get_custom_operator_inplace_reverse_idx(
   EAGER_TRY
   std::string op_type = CastPyArg2AttrString(PyTuple_GET_ITEM(args, 0), 0);
   auto meta_info_map = egr::Controller::Instance().GetOpMetaInfoMap();
+  auto trim_custom_prefix = [](std::string_view str) {
+    constexpr std::string_view prefix(paddle::framework::kCustomDialectPrefix);
+    return str.substr(prefix.size());
+  };
+  op_type = trim_custom_prefix(op_type);
   PADDLE_ENFORCE_NE(meta_info_map.find(op_type),
                     meta_info_map.end(),
                     common::errors::NotFound(
@@ -543,6 +549,11 @@ PyObject* eager_api_run_custom_op(PyObject* self,
   }
 
   std::string op_type = CastPyArg2AttrString(PyTuple_GET_ITEM(args, 0), 0);
+  auto trim_custom_prefix = [](std::string_view str) {
+    constexpr std::string_view prefix(paddle::framework::kCustomDialectPrefix);
+    return str.substr(prefix.size());
+  };
+  op_type = trim_custom_prefix(op_type);
   VLOG(7) << "Get things from python for Custom Op: " << op_type;
   if (FLAGS_check_cuda_error) [[unlikely]] {
     egr::CUDAErrorCheck("eager_api_run_custom_op " + op_type + " begin");

--- a/python/paddle/utils/cpp_extension/extension_utils.py
+++ b/python/paddle/utils/cpp_extension/extension_utils.py
@@ -206,7 +206,8 @@ def custom_write_stub(resource, pyfile):
                     mod = types.ModuleType(__name__)
 
             for custom_op in custom_ops:
-                setattr(mod, custom_op, eval(custom_op))
+                trimmed_custom_op = custom_op.replace("custom_op.", "")
+                setattr(mod, trimmed_custom_op, eval(trimmed_custom_op))
 
         __bootstrap__()
 
@@ -1226,7 +1227,7 @@ def _custom_api_content(op_name):
         from paddle.jit.marker import unified
 
         @unified
-        def {op_name}({params_list}):
+        def {op_name_trimmed}({params_list}):
             # The output variable's dtype use default value 'float32',
             # and the actual dtype of output variable will be inferred in runtime.
             if in_dynamic_or_pir_mode():
@@ -1236,9 +1237,10 @@ def _custom_api_content(op_name):
                 {static_content}
             """
     ).lstrip()
-
+    op_name_trimmed = op_name.removeprefix("custom_op.")
     # generate python api file
     api_content = API_TEMPLATE.format(
+        op_name_trimmed=op_name_trimmed,
         op_name=op_name,
         params_list=params_list,
         dynamic_content=dynamic_content,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Improvements
### Description
Temp fix namespace seperation between pir_op and custom_op
pcard-91067
