### PR TITLE
[API compatibility] add dtype conversion method

### DIFF
--- a/python/paddle/base/dygraph/math_op_patch.py
+++ b/python/paddle/base/dygraph/math_op_patch.py
@@ -65,6 +65,35 @@ _complex_dtypes = [
 _already_patch_eager_tensor = False
 
 
+_supported_dtype_conversions = {
+    # float
+    'float16': 'float16',
+    'half': 'float16',
+    'bfloat16': 'bfloat16',
+    'float32': 'float32',
+    'float': 'float32',
+    'float64': 'float64',
+    'double': 'float64',
+    # int
+    'int8': 'int8',
+    'char': 'int8',
+    'uint8': 'uint8',
+    'byte': 'uint8',
+    'int16': 'int16',
+    'short': 'int16',
+    'int32': 'int32',
+    'int': 'int32',
+    'int64': 'int64',
+    'long': 'int64',
+    # other
+    'bool': 'bool',
+    'complex64': 'complex64',
+    'complex128': 'complex128',
+    'cfloat': 'complex64',
+    'cdouble': 'complex128',
+}
+
+
 def monkey_patch_math_tensor():
     """
     Similar to monkey_patch_variable.
@@ -104,37 +133,32 @@ def monkey_patch_math_tensor():
 
         return _C_ops.cast(self, dtype)
 
-    def bool(self: Tensor) -> Tensor:
+    def _create_dtype_conversion_methods():
         """
-
-        Cast a Tensor to boolean data type if it differs from the current dtype;
-        otherwise, return the original Tensor. Non-zero elements will be cast to True,
-        and zero elements will be cast to False.
-
-        Returns:
-            Tensor: a new Tensor with bool dtype
-
-        Examples:
-            .. code-block:: python
-
-                >>> import paddle
-
-                >>> original_tensor = paddle.to_tensor([1, 0, -3])
-                >>> print("original tensor's dtype is: {}".format(original_tensor.dtype))
-                original tensor's dtype is: paddle.int64
-                >>> bool_tensor = original_tensor.bool()
-                >>> print("bool tensor's dtype is: {}".format(bool_tensor.dtype))
-                bool tensor's dtype is: paddle.bool
-                >>> print(bool_tensor)
-                [True False True]
+        Batch create all data type conversion methods
         """
+        methods = []
 
-        if (
-            self.dtype == core.DataType.BOOL
-            or self.dtype == core.VarDesc.VarType.BOOL
-        ):
-            return self
-        return _C_ops.cast(self, core.DataType.BOOL)
+        for method_name, target_dtype in _supported_dtype_conversions.items():
+
+            def make_conversion_method(dtype):
+                def conversion_method(self: Tensor) -> Tensor:
+                    return astype(self, dtype)
+
+                return conversion_method
+
+            method_impl = make_conversion_method(target_dtype)
+            method_impl.__name__ = method_name
+            method_impl.__doc__ = f"""
+            Cast a Tensor to {target_dtype} data type if it differs from the current dtype;
+            otherwise, return the original Tensor.
+            Returns:
+                Tensor: a new Tensor with {target_dtype} dtype
+            """
+
+            methods.append((method_name, method_impl))
+
+        return methods
 
     def _scalar_elementwise_op_(
         var: Tensor, scale: float, bias: float
@@ -257,7 +281,6 @@ def monkey_patch_math_tensor():
         ('__len__', _len_),
         ('__index__', _index_),
         ('astype', astype),
-        ('bool', bool),
         ('dim', dim),
         ('ndimension', ndimension),
         ('ndim', _ndim),
@@ -267,6 +290,9 @@ def monkey_patch_math_tensor():
         # for logical compare
         ('__array_ufunc__', None),
     ]
+
+    dtype_conversion_methods = _create_dtype_conversion_methods()
+    eager_methods.extend(dtype_conversion_methods)
 
     eager_cpp_level_patch = [
         "__add__",

--- a/python/paddle/base/dygraph/math_op_patch.py
+++ b/python/paddle/base/dygraph/math_op_patch.py
@@ -104,6 +104,36 @@ def monkey_patch_math_tensor():
 
         return _C_ops.cast(self, dtype)
 
+    def bool(self: Tensor) -> Tensor:
+        """
+
+        Cast a Tensor to boolean data type if it differs from the current dtype;
+        otherwise, return the original Tensor. Non-zero elements will be cast to True,
+        and zero elements will be cast to False.
+
+        Returns:
+            Tensor: a new Tensor with bool dtype
+
+        Examples:
+            .. code-block:: python
+    
+                >>> import paddle
+    
+                >>> original_tensor = paddle.to_tensor([1, 0, -3])
+                >>> print("original tensor's dtype is: {}".format(original_tensor.dtype))
+                original tensor's dtype is: paddle.int64
+                >>> bool_tensor = original_tensor.bool()
+                >>> print("bool tensor's dtype is: {}".format(bool_tensor.dtype))
+                bool tensor's dtype is: paddle.bool
+                >>> print(bool_tensor)
+                [True False True]
+        """
+
+        if self.dtype == core.DataType.BOOL or self.dtype == core.VarDesc.VarType.BOOL:
+            return self
+
+        return _C_ops.cast(self, core.DataType.BOOL)
+
     def _scalar_elementwise_op_(
         var: Tensor, scale: float, bias: float
     ) -> Tensor:
@@ -225,6 +255,7 @@ def monkey_patch_math_tensor():
         ('__len__', _len_),
         ('__index__', _index_),
         ('astype', astype),
+        ('bool', bool),
         ('dim', dim),
         ('ndimension', ndimension),
         ('ndim', _ndim),

--- a/python/paddle/base/dygraph/math_op_patch.py
+++ b/python/paddle/base/dygraph/math_op_patch.py
@@ -77,8 +77,9 @@ _supported_dtype_conversions = {
     # int
     'int8': 'int8',
     'char': 'int8',
-    'uint8': 'uint8',
-    'byte': 'uint8',
+    # We handle uint8 conversion separately
+    # 'uint8': 'uint8',
+    # 'byte': 'uint8',
     'int16': 'int16',
     'short': 'int16',
     'int32': 'int32',
@@ -132,6 +133,17 @@ def monkey_patch_math_tensor():
             return self
 
         return _C_ops.cast(self, dtype)
+
+    def byte(self: Tensor) -> Tensor:
+        # since paddle don't support float to uint8, so we need to convert it to int8 first
+        if self.is_floating_point():
+            tensor = astype(self, 'int8')
+            return astype(tensor, 'uint8')
+        elif self.is_complex():
+            real = astype(self.real(), 'int8')
+            return astype(real, 'uint8')
+        else:
+            return astype(self, 'uint8')
 
     def _create_dtype_conversion_methods():
         """
@@ -281,6 +293,8 @@ def monkey_patch_math_tensor():
         ('__len__', _len_),
         ('__index__', _index_),
         ('astype', astype),
+        ('byte', byte),
+        ('uint8', byte),
         ('dim', dim),
         ('ndimension', ndimension),
         ('ndim', _ndim),

--- a/python/paddle/base/dygraph/math_op_patch.py
+++ b/python/paddle/base/dygraph/math_op_patch.py
@@ -116,9 +116,9 @@ def monkey_patch_math_tensor():
 
         Examples:
             .. code-block:: python
-    
+
                 >>> import paddle
-    
+
                 >>> original_tensor = paddle.to_tensor([1, 0, -3])
                 >>> print("original tensor's dtype is: {}".format(original_tensor.dtype))
                 original tensor's dtype is: paddle.int64
@@ -129,9 +129,11 @@ def monkey_patch_math_tensor():
                 [True False True]
         """
 
-        if self.dtype == core.DataType.BOOL or self.dtype == core.VarDesc.VarType.BOOL:
+        if (
+            self.dtype == core.DataType.BOOL
+            or self.dtype == core.VarDesc.VarType.BOOL
+        ):
             return self
-
         return _C_ops.cast(self, core.DataType.BOOL)
 
     def _scalar_elementwise_op_(

--- a/python/paddle/pir/math_op_patch.py
+++ b/python/paddle/pir/math_op_patch.py
@@ -37,6 +37,34 @@ _supported_int_dtype_ = [
     DataType.INT64,
 ]
 
+_supported_dtype_conversions = {
+    # float
+    'float16': 'float16',
+    'half': 'float16',
+    'bfloat16': 'bfloat16',
+    'float32': 'float32',
+    'float': 'float32',
+    'float64': 'float64',
+    'double': 'float64',
+    # int
+    'int8': 'int8',
+    'char': 'int8',
+    'uint8': 'uint8',
+    'byte': 'uint8',
+    'int16': 'int16',
+    'short': 'int16',
+    'int32': 'int32',
+    'int': 'int32',
+    'int64': 'int64',
+    'long': 'int64',
+    # other
+    'bool': 'bool',
+    'complex64': 'complex64',
+    'complex128': 'complex128',
+    'cfloat': 'complex64',
+    'cdouble': 'complex128',
+}
+
 SUPPORT_PROMOTION_OPS = [
     "__add__",
     "__radd__",
@@ -369,6 +397,30 @@ def monkey_patch_value():
             return self
 
         return _C_ops.cast(self, dtype)
+
+    def _create_dtype_conversion_methods():
+        """
+        Batch create all data type conversion methods
+        """
+        methods = []
+        for method_name, target_dtype in _supported_dtype_conversions.items():
+
+            def make_conversion_method(dtype):
+                def conversion_method(self):
+                    return astype(self, dtype)
+
+                return conversion_method
+
+            method_impl = make_conversion_method(target_dtype)
+            method_impl.__name__ = method_name
+            method_impl.__doc__ = f"""
+            Cast a Value to {target_dtype} data type if it differs from the current dtype;
+            otherwise, return the original Value.
+            Returns:
+                Value: a new Value with {target_dtype} dtype
+            """
+            methods.append((method_name, method_impl))
+        return methods
 
     def _scalar_add_(var, value):
         return paddle.scale(var, 1.0, value)
@@ -1253,6 +1305,8 @@ def monkey_patch_value():
         ('__bool__', _bool_),
         ('__complex__', _complex_),
     ]
+    dtype_conversion_methods = _create_dtype_conversion_methods()
+    value_methods.extend(dtype_conversion_methods)
 
     global _already_patch_value
     if not _already_patch_value:

--- a/python/paddle/pir/math_op_patch.py
+++ b/python/paddle/pir/math_op_patch.py
@@ -49,8 +49,9 @@ _supported_dtype_conversions = {
     # int
     'int8': 'int8',
     'char': 'int8',
-    'uint8': 'uint8',
-    'byte': 'uint8',
+    # We handle uint8 conversion separately
+    # 'uint8': 'uint8',
+    # 'byte': 'uint8',
     'int16': 'int16',
     'short': 'int16',
     'int32': 'int32',
@@ -397,6 +398,17 @@ def monkey_patch_value():
             return self
 
         return _C_ops.cast(self, dtype)
+
+    def byte(self):
+        # since paddle don't support float to uint8, so we need to convert it to int8 first
+        if self.is_floating_point():
+            tensor = astype(self, 'int8')
+            return astype(tensor, 'uint8')
+        elif self.is_complex():
+            real = astype(self.real(), 'int8')
+            return astype(real, 'uint8')
+        else:
+            return astype(self, 'uint8')
 
     def _create_dtype_conversion_methods():
         """
@@ -1161,6 +1173,8 @@ def monkey_patch_value():
         ('ndimension', ndimension),
         ('ndim', _ndim),
         ('astype', astype),
+        ('byte', byte),
+        ('uint8', byte),
         ('size', _size_),
         ('T', _T_),
         ('mT', _mT_),

--- a/test/legacy_test/test_math_op_patch_var_base.py
+++ b/test/legacy_test/test_math_op_patch_var_base.py
@@ -608,51 +608,6 @@ class TestMathOpPatchesVarBase(unittest.TestCase):
             np.testing.assert_array_equal(res1.numpy(), res2.numpy())
             np.testing.assert_array_equal(res1.numpy(), res3.numpy())
 
-    def test_bool(self):
-        dtypes = [
-            np.float16,
-            np.float32,
-            np.float64,
-            np.complex64,
-            np.complex128,
-        ]
-        with base.dygraph.guard():
-            for dtype in dtypes:
-                data_np = np.random.uniform(-1, 1, self.shape).astype(dtype)
-                data = paddle.to_tensor(data_np, dtype=dtype)
-                res = data.bool()
-                res_np = data_np.astype(bool)
-                self.assertEqual(res.dtype, paddle.bool)
-                np.testing.assert_array_equal(res.numpy(), res_np)
-
-        dtypes = [np.int8, np.int16, np.int32, np.int64, np.uint8]
-        with base.dygraph.guard():
-            for dtype in dtypes:
-                data_np = np.random.randint(-100, 100, self.shape).astype(dtype)
-                data = paddle.to_tensor(data_np, dtype=dtype)
-                res = data.bool()
-                res_np = data_np.astype(bool)
-                self.assertEqual(res.dtype, paddle.bool)
-                np.testing.assert_array_equal(res.numpy(), res_np)
-
-        dtypes = [paddle.bfloat16]
-        with base.dygraph.guard():
-            for dtype in dtypes:
-                data_np = np.random.uniform(-1, 1, self.shape)
-                data = paddle.to_tensor(data_np, dtype=dtype)
-                res = data.bool()
-                res_np = data.numpy().astype(bool)
-                self.assertEqual(res.dtype, paddle.bool)
-                np.testing.assert_array_equal(res.numpy(), res_np)
-
-        with base.dygraph.guard():
-            data_np = np.random.uniform(-1, 1, self.shape).astype(bool)
-            data = paddle.to_tensor(data_np)
-            res = data.bool()
-            self.assertEqual(
-                data.data_ptr(), res.data_ptr()
-            )  # zero-copy if same dtype
-
     def test_conpare_op_broadcast(self):
         a_np = np.random.uniform(-1, 1, [10, 1, 10]).astype(self.dtype)
         b_np = np.random.uniform(-1, 1, [1, 1, 10]).astype(self.dtype)

--- a/test/legacy_test/test_math_op_patch_var_base.py
+++ b/test/legacy_test/test_math_op_patch_var_base.py
@@ -609,7 +609,13 @@ class TestMathOpPatchesVarBase(unittest.TestCase):
             np.testing.assert_array_equal(res1.numpy(), res3.numpy())
 
     def test_bool(self):
-        dtypes = [np.float16, np.float32, np.float64, np.complex64, np.complex128]
+        dtypes = [
+            np.float16,
+            np.float32,
+            np.float64,
+            np.complex64,
+            np.complex128,
+        ]
         with base.dygraph.guard():
             for dtype in dtypes:
                 data_np = np.random.uniform(-1, 1, self.shape).astype(dtype)
@@ -639,6 +645,13 @@ class TestMathOpPatchesVarBase(unittest.TestCase):
                 self.assertEqual(res.dtype, paddle.bool)
                 np.testing.assert_array_equal(res.numpy(), res_np)
 
+        with base.dygraph.guard():
+            data_np = np.random.uniform(-1, 1, self.shape).astype(bool)
+            data = paddle.to_tensor(data_np)
+            res = data.bool()
+            self.assertEqual(
+                data.data_ptr(), res.data_ptr()
+            )  # zero-copy if same dtype
 
     def test_conpare_op_broadcast(self):
         a_np = np.random.uniform(-1, 1, [10, 1, 10]).astype(self.dtype)

--- a/test/legacy_test/test_math_op_patch_var_base.py
+++ b/test/legacy_test/test_math_op_patch_var_base.py
@@ -608,6 +608,38 @@ class TestMathOpPatchesVarBase(unittest.TestCase):
             np.testing.assert_array_equal(res1.numpy(), res2.numpy())
             np.testing.assert_array_equal(res1.numpy(), res3.numpy())
 
+    def test_bool(self):
+        dtypes = [np.float16, np.float32, np.float64, np.complex64, np.complex128]
+        with base.dygraph.guard():
+            for dtype in dtypes:
+                data_np = np.random.uniform(-1, 1, self.shape).astype(dtype)
+                data = paddle.to_tensor(data_np, dtype=dtype)
+                res = data.bool()
+                res_np = data_np.astype(bool)
+                self.assertEqual(res.dtype, paddle.bool)
+                np.testing.assert_array_equal(res.numpy(), res_np)
+
+        dtypes = [np.int8, np.int16, np.int32, np.int64, np.uint8]
+        with base.dygraph.guard():
+            for dtype in dtypes:
+                data_np = np.random.randint(-100, 100, self.shape).astype(dtype)
+                data = paddle.to_tensor(data_np, dtype=dtype)
+                res = data.bool()
+                res_np = data_np.astype(bool)
+                self.assertEqual(res.dtype, paddle.bool)
+                np.testing.assert_array_equal(res.numpy(), res_np)
+
+        dtypes = [paddle.bfloat16]
+        with base.dygraph.guard():
+            for dtype in dtypes:
+                data_np = np.random.uniform(-1, 1, self.shape)
+                data = paddle.to_tensor(data_np, dtype=dtype)
+                res = data.bool()
+                res_np = data.numpy().astype(bool)
+                self.assertEqual(res.dtype, paddle.bool)
+                np.testing.assert_array_equal(res.numpy(), res_np)
+
+
     def test_conpare_op_broadcast(self):
         a_np = np.random.uniform(-1, 1, [10, 1, 10]).astype(self.dtype)
         b_np = np.random.uniform(-1, 1, [1, 1, 10]).astype(self.dtype)

--- a/test/legacy_test/test_tensor_type_convert_api.py
+++ b/test/legacy_test/test_tensor_type_convert_api.py
@@ -52,30 +52,48 @@ class TensorDtypeConversionsTest(unittest.TestCase):
         'cdouble': 'complex128',
     }
     _device = paddle.device.get_device()
+    _total_init_dtype = [
+        'float16',
+        'float32',
+        'float64',
+        'int8',
+        'uint8',
+        'int16',
+        'int32',
+        'int64',
+        'bool',
+        'complex64',
+        'complex128',
+    ]
 
     def setUp(self):
-        """Set up test data for different types."""
-        self.test_values = {
-            'float': np.array([1.5, 2.5, 3.5]),
-            'int': np.array([1, 2, 3]),
-            'bool': np.array([True, False, True]),
-            'complex': np.array([1 + 2j, 3 + 4j, 5 + 6j]),
-        }
+        self.shape = [10, 1000]
 
     def _get_paddle_dtype(self, dtype_str):
         """Get the Paddle dtype constant by string name."""
         return getattr(paddle, dtype_str)
 
-    def _get_appropriate_test_data(self, target_dtype):
-        """Select appropriate test data according to target dtype."""
-        if target_dtype in ['complex64', 'complex128']:
-            return self.test_values['complex']
-        elif target_dtype == 'bool':
-            return self.test_values['bool']
-        elif target_dtype.startswith(('int', 'long')):
-            return self.test_values['int']
-        else:  # float types
-            return self.test_values['float']
+    def test_bfloat16_conversion(self):
+        for init_dtype in self._total_init_dtype:
+            if self._device.startswith('xpu') and init_dtype == 'complex128':
+                continue
+            tensor = paddle.randn(self.shape).astype(init_dtype)
+            converted_tensor = tensor.bfloat16()
+            self.assertEqual(converted_tensor.dtype, paddle.bfloat16)
+            self.assertEqual(converted_tensor.shape, tensor.shape)
+
+        for (
+            method_name,
+            target_dtype,
+        ) in self._supported_dtype_conversions.items():
+            if self._device.startswith('xpu') and target_dtype == 'complex128':
+                continue
+            tensor = paddle.randn(self.shape).astype('bfloat16')
+            converted_tensor = getattr(tensor, method_name)()
+            self.assertEqual(
+                converted_tensor.dtype, self._get_paddle_dtype(target_dtype)
+            )
+            self.assertEqual(converted_tensor.shape, tensor.shape)
 
     def test_all_dtype_conversions(self):
         """Test all dtype conversion methods."""
@@ -83,32 +101,46 @@ class TensorDtypeConversionsTest(unittest.TestCase):
             method_name,
             target_dtype,
         ) in self._supported_dtype_conversions.items():
-            if self._device.startswith('xpu') and target_dtype == 'complex128':
-                self.skipTest("Skipping complex conversion tests on XPU")
-            with self.subTest(method=method_name, target_dtype=target_dtype):
-                self._test_single_dtype_conversion(method_name, target_dtype)
+            if target_dtype == 'bfloat16':
+                continue
+            for init_dtype in self._total_init_dtype:
+                if self._device.startswith('xpu') and (
+                    target_dtype == 'complex128' or init_dtype == 'complex128'
+                ):
+                    self.skipTest("Skipping complex conversion tests on XPU")
 
-    def _test_single_dtype_conversion(self, method_name, target_dtype):
+                with self.subTest(
+                    method=method_name,
+                    init_dtype=init_dtype,
+                    target_dtype=target_dtype,
+                ):
+                    self._test_single_dtype_conversion(
+                        method_name, init_dtype, target_dtype
+                    )
+
+    def _test_single_dtype_conversion(
+        self, method_name, init_dtype, target_dtype
+    ):
         """Test a single dtype conversion method."""
-        # Select appropriate test data
-        test_data = self._get_appropriate_test_data(target_dtype)
-
-        # Create initial tensor (use float32 unless special type)
-        if target_dtype in ['complex64', 'complex128']:
-            initial_dtype = 'complex64'
-        elif target_dtype == 'bool':
-            initial_dtype = 'bool'
+        if init_dtype.startswith('float'):
+            data_np = np.random.randn(*self.shape).astype(init_dtype)
+        elif init_dtype.startswith('complex'):
+            data_np_real = np.random.randn(*self.shape)
+            data_np_imag = np.random.randn(*self.shape)
+            data_np = data_np_real + data_np_imag * 1j
+            data_np = data_np.astype(init_dtype)
         else:
-            initial_dtype = 'float32'
+            data_np = np.random.randint(-100, 100, size=self.shape).astype(
+                init_dtype
+            )
 
-        tensor = paddle.to_tensor(test_data, dtype=initial_dtype)
+        tensor = paddle.to_tensor(data_np, dtype=init_dtype)
 
         # Check if conversion method exists
         self.assertTrue(
             hasattr(tensor, method_name),
             f"Tensor should have method '{method_name}'",
         )
-
         # Perform dtype conversion
         converted_tensor = getattr(tensor, method_name)()
 
@@ -127,51 +159,21 @@ class TensorDtypeConversionsTest(unittest.TestCase):
             f"Shape should remain unchanged after {method_name} conversion",
         )
 
-    def test_float_to_int_conversion(self):
-        """Test float to int conversion."""
-        float_tensor = paddle.to_tensor([1.7, 2.3, 3.9], dtype='float32')
-        int_tensor = float_tensor.int32()
+        if target_dtype.endswith('float16'):
+            rtol = 1e-3
+            atol = 1e-3
+        else:
+            rtol = 1e-7
+            atol = 0
 
-        self.assertEqual(int_tensor.dtype, paddle.int32)
-
-    def test_int_to_float_conversion(self):
-        """Test int to float conversion."""
-        int_tensor = paddle.to_tensor([1, 2, 3], dtype='int32')
-        float_tensor = int_tensor.float32()
-
-        self.assertEqual(float_tensor.dtype, paddle.float32)
-        expected = np.array([1.0, 2.0, 3.0], dtype=np.float32)
-        np.testing.assert_array_equal(float_tensor.numpy(), expected)
-
-    def test_complex_conversions(self):
-        """Test complex dtype conversions."""
-        if self._device.startswith('xpu'):
-            self.skipTest("Skipping complex conversion tests on XPU")
-        # Create a complex tensor
-        complex_data = np.array([1 + 2j, 3 + 4j], dtype=np.complex64)
-        tensor = paddle.to_tensor(complex_data, dtype='complex64')
-
-        # Test complex64 to complex128
-        complex128_tensor = tensor.complex128()
-        self.assertEqual(complex128_tensor.dtype, paddle.complex128)
-
-        # Test complex128 to complex64
-        complex64_tensor = complex128_tensor.complex64()
-        self.assertEqual(complex64_tensor.dtype, paddle.complex64)
-
-    def test_bool_conversions(self):
-        """Test bool dtype conversions."""
-        # From numeric to bool
-        numeric_tensor = paddle.to_tensor([0, 1, 2, -1], dtype='int32')
-        bool_tensor = numeric_tensor.bool()
-        self.assertEqual(bool_tensor.dtype, paddle.bool)
-
-        # From bool to numeric
-        bool_data = paddle.to_tensor([True, False, True], dtype='bool')
-        int_tensor = bool_data.int32()
-        self.assertEqual(int_tensor.dtype, paddle.int32)
-        expected = np.array([1, 0, 1], dtype=np.int32)
-        np.testing.assert_array_equal(int_tensor.numpy(), expected)
+        # Check the value after conversion
+        np.testing.assert_allclose(
+            converted_tensor.numpy(),
+            data_np.astype(target_dtype),
+            rtol=rtol,
+            atol=atol,
+            err_msg=f"Value mismatch after {method_name} conversion",
+        )
 
     def test_method_chaining(self):
         """Test method chaining for dtype conversions."""
@@ -191,27 +193,32 @@ class TensorDtypeConversionsTest(unittest.TestCase):
                 method_name,
                 target_dtype,
             ) in self._supported_dtype_conversions.items():
-                if (
-                    self._device.startswith('xpu')
-                    and target_dtype == 'complex128'
-                ):
-                    self.skipTest("Skipping complex conversion tests on XPU")
-                with self.subTest(
-                    pir_method=method_name, pir_target_dtype=target_dtype
-                ):
-                    self._pir_single_dtype_conversion(method_name, target_dtype)
 
-    def _pir_single_dtype_conversion(self, method_name, target_dtype):
-        # Select appropriate test data
-        test_data = self._get_appropriate_test_data(target_dtype)
-        shape = test_data.shape
-        dtype = 'float32'
-        if target_dtype in ['complex64', 'complex128']:
-            dtype = 'complex64'
-        elif target_dtype == 'bool':
-            dtype = 'bool'
+                if target_dtype == 'bfloat16':
+                    continue
+                for init_dtype in self._total_init_dtype:
+                    if (
+                        self._device.startswith('xpu')
+                        and target_dtype == 'complex128'
+                    ):
+                        self.skipTest(
+                            "Skipping complex conversion tests on XPU"
+                        )
+                    with self.subTest(
+                        pir_method=method_name,
+                        pir_init_dtype=init_dtype,
+                        pir_target_dtype=target_dtype,
+                    ):
+                        self._pir_single_dtype_conversion(
+                            method_name, init_dtype, target_dtype
+                        )
+
+    def _pir_single_dtype_conversion(
+        self, method_name, init_dtype, target_dtype
+    ):
+
         # Create static graph input
-        x = paddle.static.data(name="x", shape=shape, dtype=dtype)
+        x = paddle.static.data(name="x", shape=self.shape, dtype=init_dtype)
         # Check if the method exists
         self.assertTrue(
             hasattr(x, method_name),

--- a/test/legacy_test/test_tensor_type_convert_api.py
+++ b/test/legacy_test/test_tensor_type_convert_api.py
@@ -51,6 +51,7 @@ class TensorDtypeConversionsTest(unittest.TestCase):
         'cfloat': 'complex64',
         'cdouble': 'complex128',
     }
+    _device = paddle.device.get_device()
 
     def setUp(self):
         """Set up test data for different types."""
@@ -82,6 +83,8 @@ class TensorDtypeConversionsTest(unittest.TestCase):
             method_name,
             target_dtype,
         ) in self._supported_dtype_conversions.items():
+            if self._device.startswith('xpu') and target_dtype == 'complex128':
+                self.skipTest("Skipping complex conversion tests on XPU")
             with self.subTest(method=method_name, target_dtype=target_dtype):
                 self._test_single_dtype_conversion(method_name, target_dtype)
 
@@ -142,6 +145,8 @@ class TensorDtypeConversionsTest(unittest.TestCase):
 
     def test_complex_conversions(self):
         """Test complex dtype conversions."""
+        if self._device.startswith('xpu'):
+            self.skipTest("Skipping complex conversion tests on XPU")
         # Create a complex tensor
         complex_data = np.array([1 + 2j, 3 + 4j], dtype=np.complex64)
         tensor = paddle.to_tensor(complex_data, dtype='complex64')
@@ -186,6 +191,11 @@ class TensorDtypeConversionsTest(unittest.TestCase):
                 method_name,
                 target_dtype,
             ) in self._supported_dtype_conversions.items():
+                if (
+                    self._device.startswith('xpu')
+                    and target_dtype == 'complex128'
+                ):
+                    self.skipTest("Skipping complex conversion tests on XPU")
                 with self.subTest(
                     pir_method=method_name, pir_target_dtype=target_dtype
                 ):

--- a/test/legacy_test/test_tensor_type_convert_api.py
+++ b/test/legacy_test/test_tensor_type_convert_api.py
@@ -1,0 +1,228 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+
+import paddle
+
+
+class TensorDtypeConversionsTest(unittest.TestCase):
+    """
+    Unit tests for all supported tensor dtype conversion methods.
+    """
+
+    _supported_dtype_conversions = {
+        # float
+        'float16': 'float16',
+        'half': 'float16',
+        'bfloat16': 'bfloat16',
+        'float32': 'float32',
+        'float': 'float32',
+        'float64': 'float64',
+        'double': 'float64',
+        # int
+        'int8': 'int8',
+        'char': 'int8',
+        'uint8': 'uint8',
+        'byte': 'uint8',
+        'int16': 'int16',
+        'short': 'int16',
+        'int32': 'int32',
+        'int': 'int32',
+        'int64': 'int64',
+        'long': 'int64',
+        # other
+        'bool': 'bool',
+        'complex64': 'complex64',
+        'complex128': 'complex128',
+        'cfloat': 'complex64',
+        'cdouble': 'complex128',
+    }
+
+    def setUp(self):
+        """Set up test data for different types."""
+        self.test_values = {
+            'float': np.array([1.5, 2.5, 3.5]),
+            'int': np.array([1, 2, 3]),
+            'bool': np.array([True, False, True]),
+            'complex': np.array([1 + 2j, 3 + 4j, 5 + 6j]),
+        }
+
+    def _get_paddle_dtype(self, dtype_str):
+        """Get the Paddle dtype constant by string name."""
+        return getattr(paddle, dtype_str)
+
+    def _get_appropriate_test_data(self, target_dtype):
+        """Select appropriate test data according to target dtype."""
+        if target_dtype in ['complex64', 'complex128']:
+            return self.test_values['complex']
+        elif target_dtype == 'bool':
+            return self.test_values['bool']
+        elif target_dtype.startswith(('int', 'long')):
+            return self.test_values['int']
+        else:  # float types
+            return self.test_values['float']
+
+    def test_all_dtype_conversions(self):
+        """Test all dtype conversion methods."""
+        for (
+            method_name,
+            target_dtype,
+        ) in self._supported_dtype_conversions.items():
+            with self.subTest(method=method_name, target_dtype=target_dtype):
+                self._test_single_dtype_conversion(method_name, target_dtype)
+
+    def _test_single_dtype_conversion(self, method_name, target_dtype):
+        """Test a single dtype conversion method."""
+        # Select appropriate test data
+        test_data = self._get_appropriate_test_data(target_dtype)
+
+        # Create initial tensor (use float32 unless special type)
+        if target_dtype in ['complex64', 'complex128']:
+            initial_dtype = 'complex64'
+        elif target_dtype == 'bool':
+            initial_dtype = 'bool'
+        else:
+            initial_dtype = 'float32'
+
+        tensor = paddle.to_tensor(test_data, dtype=initial_dtype)
+
+        # Check if conversion method exists
+        self.assertTrue(
+            hasattr(tensor, method_name),
+            f"Tensor should have method '{method_name}'",
+        )
+
+        # Perform dtype conversion
+        converted_tensor = getattr(tensor, method_name)()
+
+        # Check the dtype after conversion
+        expected_dtype = self._get_paddle_dtype(target_dtype)
+        self.assertEqual(
+            converted_tensor.dtype,
+            expected_dtype,
+            f"Expected dtype {expected_dtype}, but got {converted_tensor.dtype} for method '{method_name}'",
+        )
+
+        # Check that the shape remains unchanged
+        self.assertEqual(
+            tensor.shape,
+            converted_tensor.shape,
+            f"Shape should remain unchanged after {method_name} conversion",
+        )
+
+    def test_float_to_int_conversion(self):
+        """Test float to int conversion."""
+        float_tensor = paddle.to_tensor([1.7, 2.3, 3.9], dtype='float32')
+        int_tensor = float_tensor.int32()
+
+        self.assertEqual(int_tensor.dtype, paddle.int32)
+
+    def test_int_to_float_conversion(self):
+        """Test int to float conversion."""
+        int_tensor = paddle.to_tensor([1, 2, 3], dtype='int32')
+        float_tensor = int_tensor.float32()
+
+        self.assertEqual(float_tensor.dtype, paddle.float32)
+        expected = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+        np.testing.assert_array_equal(float_tensor.numpy(), expected)
+
+    def test_complex_conversions(self):
+        """Test complex dtype conversions."""
+        # Create a complex tensor
+        complex_data = np.array([1 + 2j, 3 + 4j], dtype=np.complex64)
+        tensor = paddle.to_tensor(complex_data, dtype='complex64')
+
+        # Test complex64 to complex128
+        complex128_tensor = tensor.complex128()
+        self.assertEqual(complex128_tensor.dtype, paddle.complex128)
+
+        # Test complex128 to complex64
+        complex64_tensor = complex128_tensor.complex64()
+        self.assertEqual(complex64_tensor.dtype, paddle.complex64)
+
+    def test_bool_conversions(self):
+        """Test bool dtype conversions."""
+        # From numeric to bool
+        numeric_tensor = paddle.to_tensor([0, 1, 2, -1], dtype='int32')
+        bool_tensor = numeric_tensor.bool()
+        self.assertEqual(bool_tensor.dtype, paddle.bool)
+
+        # From bool to numeric
+        bool_data = paddle.to_tensor([True, False, True], dtype='bool')
+        int_tensor = bool_data.int32()
+        self.assertEqual(int_tensor.dtype, paddle.int32)
+        expected = np.array([1, 0, 1], dtype=np.int32)
+        np.testing.assert_array_equal(int_tensor.numpy(), expected)
+
+    def test_method_chaining(self):
+        """Test method chaining for dtype conversions."""
+        tensor = paddle.to_tensor([1.5, 2.5, 3.5], dtype='float32')
+
+        # float32 -> int32 -> float64 -> int64
+        result = tensor.int32().float64().int64()
+        self.assertEqual(result.dtype, paddle.int64)
+
+    def test_pir_all_dtype_conversions(self):
+        """Test all dtype conversion methods for pir.Value in static graph."""
+        paddle.enable_static()
+        startup_prog = paddle.static.Program()
+        main_prog = paddle.static.Program()
+        with paddle.static.program_guard(main_prog, startup_prog):
+            for (
+                method_name,
+                target_dtype,
+            ) in self._supported_dtype_conversions.items():
+                with self.subTest(
+                    pir_method=method_name, pir_target_dtype=target_dtype
+                ):
+                    self._pir_single_dtype_conversion(method_name, target_dtype)
+
+    def _pir_single_dtype_conversion(self, method_name, target_dtype):
+        # Select appropriate test data
+        test_data = self._get_appropriate_test_data(target_dtype)
+        shape = test_data.shape
+        dtype = 'float32'
+        if target_dtype in ['complex64', 'complex128']:
+            dtype = 'complex64'
+        elif target_dtype == 'bool':
+            dtype = 'bool'
+        # Create static graph input
+        x = paddle.static.data(name="x", shape=shape, dtype=dtype)
+        # Check if the method exists
+        self.assertTrue(
+            hasattr(x, method_name),
+            f"pir.Value should have method '{method_name}'",
+        )
+        # Perform dtype conversion
+        converted = getattr(x, method_name)()
+        # Check the dtype
+        expected_dtype = self._get_paddle_dtype(target_dtype)
+        self.assertEqual(
+            converted.dtype,
+            expected_dtype,
+            f"Expected pir.Value dtype {expected_dtype}, but got {converted.dtype} for method '{method_name}'",
+        )
+        # Check the shape
+        self.assertEqual(
+            tuple(x.shape),
+            tuple(converted.shape),
+            f"pir.Value shape should remain unchanged after {method_name} conversion",
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

New features

### Description
<!-- Describe what you’ve done -->

add Tensor.bool, Tensor.float16, Tensor.half, Tensor.bfloat16, Tensor.float32, Tensor.float, Tensor.float64, Tensor.double, Tensor.int8, Tensor.char, Tensor.uint8, Tensor.byte, Tensor.int16, Tensor.short, Tensor.int32, Tensor.int, Tensor.int64, Tensor.long, Tensor.complex64, Tensor.complex128, Tensor.cfloat, Tensor.cdouble API

Pcard-75624