### PR TITLE
(rebase) add get_device_place in op_test.py, and replace the method of obtaining place in legacy_test

### DIFF
--- a/test/legacy_test/op_test.py
+++ b/test/legacy_test/op_test.py
@@ -2931,10 +2931,6 @@ class OpTest(unittest.TestCase):
             and not cpu_only
         ):
             places.append(core.CUDAPlace(0))
-        if len(core.get_all_custom_device_type()) > 0:
-            dev_type = core.get_all_custom_device_type()[0]
-            if core.is_compiled_with_custom_device(dev_type) and not cpu_only:
-                places.append(core.CustomPlace(dev_type, 0))
         return places
 
     def check_output(

--- a/test/legacy_test/op_test.py
+++ b/test/legacy_test/op_test.py
@@ -400,10 +400,6 @@ def get_places(string_format=False):
             places.append(base.CPUPlace())
         if core.is_compiled_with_cuda():
             places.append(base.CUDAPlace(0))
-        if len(core.get_all_custom_device_type()) > 0:
-            dev_type = core.get_all_custom_device_type()[0]
-            if core.is_compiled_with_custom_device(dev_type):
-                places.append(base.CustomPlace(dev_type, 0))
     else:
         if (
             os.environ.get('FLAGS_CI_both_cpu_and_gpu', 'False').lower()
@@ -413,22 +409,16 @@ def get_places(string_format=False):
             places.append('cpu')
         if paddle.is_compiled_with_cuda():
             places.append('gpu')
-        if len(paddle.device.get_all_custom_device_type()) > 0:
-            dev_type = paddle.device.get_all_custom_device_type()[0]
-            if paddle.device.is_compiled_with_custom_device(dev_type):
-                places.append(f'{dev_type}:0')
     return places
 
 
-def get_current_place():
+def get_device_place():
     if core.is_compiled_with_cuda():
-        print("core.is_compiled_with_cuda: ", core.is_compiled_with_cuda())
         return base.CUDAPlace(0)
     custom_dev_types = paddle.device.get_all_custom_device_type()
     if custom_dev_types and core.is_compiled_with_custom_device(
         custom_dev_types[0]
     ):
-        print("custom_dev_types: ", custom_dev_types)
         return base.CustomPlace(custom_dev_types[0], 0)
     return base.CPUPlace()
 

--- a/test/legacy_test/op_test.py
+++ b/test/legacy_test/op_test.py
@@ -400,6 +400,10 @@ def get_places(string_format=False):
             places.append(base.CPUPlace())
         if core.is_compiled_with_cuda():
             places.append(base.CUDAPlace(0))
+        if len(core.get_all_custom_device_type()) > 0:
+            dev_type = core.get_all_custom_device_type()[0]
+            if core.is_compiled_with_custom_device(dev_type):
+                places.append(base.CustomPlace(dev_type, 0))
     else:
         if (
             os.environ.get('FLAGS_CI_both_cpu_and_gpu', 'False').lower()
@@ -409,7 +413,24 @@ def get_places(string_format=False):
             places.append('cpu')
         if paddle.is_compiled_with_cuda():
             places.append('gpu')
+        if len(paddle.device.get_all_custom_device_type()) > 0:
+            dev_type = paddle.device.get_all_custom_device_type()[0]
+            if paddle.device.is_compiled_with_custom_device(dev_type):
+                places.append(f'{dev_type}:0')
     return places
+
+
+def get_current_place():
+    if core.is_compiled_with_cuda():
+        print("core.is_compiled_with_cuda: ", core.is_compiled_with_cuda())
+        return base.CUDAPlace(0)
+    custom_dev_types = paddle.device.get_all_custom_device_type()
+    if custom_dev_types and core.is_compiled_with_custom_device(
+        custom_dev_types[0]
+    ):
+        print("custom_dev_types: ", custom_dev_types)
+        return base.CustomPlace(custom_dev_types[0], 0)
+    return base.CPUPlace()
 
 
 @contextmanager
@@ -2920,6 +2941,10 @@ class OpTest(unittest.TestCase):
             and not cpu_only
         ):
             places.append(core.CUDAPlace(0))
+        if len(core.get_all_custom_device_type()) > 0:
+            dev_type = core.get_all_custom_device_type()[0]
+            if core.is_compiled_with_custom_device(dev_type) and not cpu_only:
+                places.append(core.CustomPlace(dev_type, 0))
         return places
 
     def check_output(

--- a/test/legacy_test/test_activation_op.py
+++ b/test/legacy_test/test_activation_op.py
@@ -21,7 +21,7 @@ import numpy as np
 from op_test import (
     OpTest,
     convert_float_to_uint16,
-    get_current_place,
+    get_device_place,
     get_places,
 )
 from scipy.special import erf, expit
@@ -642,7 +642,7 @@ class TestSiluAPI(unittest.TestCase):
     # test paddle.nn.Silu, paddle.nn.functional.silu
     def setUp(self):
         self.x_np = np.random.uniform(-1, 1, [11, 17]).astype('float32')
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def test_static_api(self):
         with static_guard():
@@ -740,7 +740,7 @@ class TestLogSigmoidAPI(unittest.TestCase):
     def setUp(self):
         np.random.seed(1024)
         self.x_np = np.random.uniform(-1, 1, [11, 17]).astype('float32')
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def test_static_api(self):
         with static_guard():
@@ -880,7 +880,7 @@ class TestTanhAPI(unittest.TestCase):
         self.dtype = 'float32'
         np.random.seed(1024)
         self.x_np = np.random.uniform(-1, 1, [10, 12]).astype(self.dtype)
-        self.place = get_current_place()
+        self.place = get_device_place()
         self.executed_api()
 
     def executed_api(self):
@@ -1321,7 +1321,7 @@ class TestTanhshrinkAPI(unittest.TestCase):
     def setUp(self):
         np.random.seed(1024)
         self.x_np = np.random.uniform(10, 20, [10, 17]).astype(np.float64)
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def test_static_api(self):
         with static_guard():
@@ -1430,7 +1430,7 @@ class TestHardShrinkAPI(unittest.TestCase):
     def setUp(self):
         np.random.seed(1024)
         self.x_np = np.random.uniform(-1, 1, [10, 12]).astype('float32')
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def test_static_api(self):
         with static_guard():
@@ -1495,7 +1495,7 @@ class TestHardtanhAPI(unittest.TestCase):
         np.random.seed(1024)
         self.init_shape()
         self.x_np = np.random.uniform(-3, 3, self.x_shape).astype('float32')
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def init_shape(self):
         self.x_shape = [10, 12]
@@ -1601,7 +1601,7 @@ class TestSoftshrinkAPI(unittest.TestCase):
         self.threshold = 0.8
         np.random.seed(1024)
         self.x_np = np.random.uniform(0.25, 10, [10, 12]).astype(np.float64)
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def test_static_api(self):
         with static_guard():
@@ -2224,7 +2224,7 @@ class TestTan(TestActivation):
                 np.random.uniform(-1, 1, self.shape)
                 + 1j * np.random.uniform(-1, 1, self.shape)
             ).astype(self.dtype)
-        self.place = get_current_place()
+        self.place = get_device_place()
 
         out = np.tan(self.x_np)
 
@@ -2275,7 +2275,7 @@ class TestTanAPI(unittest.TestCase):
         np.random.seed(1024)
         self.dtype = 'float32'
         self.x_np = np.random.uniform(-1, 1, [11, 17]).astype(self.dtype)
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def test_dygraph_api(self):
         with dynamic_guard():
@@ -2821,7 +2821,7 @@ class TestReluAPI(unittest.TestCase):
     def setUp(self):
         np.random.seed(1024)
         self.x_np = np.random.uniform(-1, 1, [10, 12]).astype('float32')
-        self.place = get_current_place()
+        self.place = get_device_place()
         self.executed_api()
 
     def executed_api(self):
@@ -2961,7 +2961,7 @@ class TestLeakyReluAPI(unittest.TestCase):
     def setUp(self):
         np.random.seed(1024)
         self.x_np = np.random.uniform(-1, 1, [10, 12]).astype('float32')
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def test_static_api(self):
         with static_guard():
@@ -3137,7 +3137,7 @@ class TestGELUAPI(unittest.TestCase):
     def setUp(self):
         np.random.seed(1024)
         self.x_np = np.random.uniform(-1, 1, [11, 17]).astype('float32')
-        self.place = get_current_place()
+        self.place = get_device_place()
         self.enable_cinn = False
 
         # The backward decomposite of gelu is inconsistent with raw kernel on
@@ -3292,7 +3292,7 @@ class TestRelu6API(unittest.TestCase):
         np.random.seed(1024)
         self.x_np = np.random.uniform(-1, 10, [10, 12]).astype(np.float64)
         self.x_np[np.abs(self.x_np) < 0.005] = 0.02
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def test_static_api(self):
         with static_guard():
@@ -3477,7 +3477,7 @@ class TestHardswishAPI(unittest.TestCase):
     # test paddle.nn.Hardswish, paddle.nn.functional.hardswish
     def setUp(self):
         self.x_np = np.random.uniform(-1, 1, [10, 12]).astype(np.float64)
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def test_static_api(self):
         with static_guard():
@@ -3640,7 +3640,7 @@ class TestELUAPI(unittest.TestCase):
     def setUp(self):
         np.random.seed(1024)
         self.x_np = np.random.uniform(-3, 3, [10, 12]).astype('float32')
-        self.place = get_current_place()
+        self.place = get_device_place()
         self.executed_api()
 
     def executed_api(self):
@@ -3751,7 +3751,7 @@ class TestCELUAPI(unittest.TestCase):
     def setUp(self):
         np.random.seed(1024)
         self.x_np = np.random.uniform(-3, 3, [10, 12]).astype('float32')
-        self.place = get_current_place()
+        self.place = get_device_place()
         self.executed_api()
 
     def executed_api(self):
@@ -4782,7 +4782,7 @@ class TestSTanhAPI(unittest.TestCase):
         self.x_np = np.random.uniform(-1, 1, [10, 12]).astype('float32')
         self.scale_a = self.get_scale_a()
         self.scale_b = self.get_scale_b()
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def test_static_api(self):
         with static_guard():
@@ -4962,7 +4962,7 @@ class TestSoftplusAPI(unittest.TestCase):
         self.threshold = 15
         np.random.seed(1024)
         self.x_np = np.random.uniform(-1, 1, [10, 12]).astype(np.float64)
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def test_static_api(self):
         with static_guard():
@@ -5093,7 +5093,7 @@ class TestSoftsignAPI(unittest.TestCase):
     def setUp(self):
         np.random.seed(1024)
         self.x_np = np.random.uniform(-1, 1, [10, 12]).astype(np.float64)
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def test_static_api(self):
         with static_guard():
@@ -5194,7 +5194,7 @@ class TestThresholdedReluAPI(unittest.TestCase):
         np.random.seed(1024)
         self.x_np = np.random.uniform(-20, 20, [10, 12]).astype(np.float64)
         self.x_np[np.abs(self.x_np) < 0.005] = 0.02
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def test_static_api(self):
         with static_guard():
@@ -5322,7 +5322,7 @@ class TestHardsigmoidAPI(unittest.TestCase):
     # test paddle.nn.Hardsigmoid, paddle.nn.functional.hardsigmoid
     def setUp(self):
         self.x_np = np.random.uniform(-1, 1, [10, 12]).astype(np.float64)
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def test_static_api(self):
         with static_guard():
@@ -5429,7 +5429,7 @@ class TestSwishAPI(unittest.TestCase):
     def setUp(self):
         np.random.seed(1024)
         self.x_np = np.random.uniform(-1, 1, [10, 12]).astype(np.float64)
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def test_static_api(self):
         with static_guard():
@@ -5536,7 +5536,7 @@ class TestMishAPI(unittest.TestCase):
     def setUp(self):
         np.random.seed(1024)
         self.x_np = np.random.uniform(-1, 1, [10, 12]).astype(np.float64)
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def test_static_api(self):
         with static_guard():

--- a/test/legacy_test/test_activation_op.py
+++ b/test/legacy_test/test_activation_op.py
@@ -18,7 +18,12 @@ import warnings
 from contextlib import contextmanager
 
 import numpy as np
-from op_test import OpTest, convert_float_to_uint16, get_places
+from op_test import (
+    OpTest,
+    convert_float_to_uint16,
+    get_current_place,
+    get_places,
+)
 from scipy.special import erf, expit
 from utils import static_guard
 
@@ -637,11 +642,7 @@ class TestSiluAPI(unittest.TestCase):
     # test paddle.nn.Silu, paddle.nn.functional.silu
     def setUp(self):
         self.x_np = np.random.uniform(-1, 1, [11, 17]).astype('float32')
-        self.place = (
-            paddle.CUDAPlace(0)
-            if core.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def test_static_api(self):
         with static_guard():
@@ -739,11 +740,7 @@ class TestLogSigmoidAPI(unittest.TestCase):
     def setUp(self):
         np.random.seed(1024)
         self.x_np = np.random.uniform(-1, 1, [11, 17]).astype('float32')
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def test_static_api(self):
         with static_guard():
@@ -883,11 +880,7 @@ class TestTanhAPI(unittest.TestCase):
         self.dtype = 'float32'
         np.random.seed(1024)
         self.x_np = np.random.uniform(-1, 1, [10, 12]).astype(self.dtype)
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
         self.executed_api()
 
     def executed_api(self):
@@ -1328,11 +1321,7 @@ class TestTanhshrinkAPI(unittest.TestCase):
     def setUp(self):
         np.random.seed(1024)
         self.x_np = np.random.uniform(10, 20, [10, 17]).astype(np.float64)
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def test_static_api(self):
         with static_guard():
@@ -1441,11 +1430,7 @@ class TestHardShrinkAPI(unittest.TestCase):
     def setUp(self):
         np.random.seed(1024)
         self.x_np = np.random.uniform(-1, 1, [10, 12]).astype('float32')
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def test_static_api(self):
         with static_guard():
@@ -1510,11 +1495,7 @@ class TestHardtanhAPI(unittest.TestCase):
         np.random.seed(1024)
         self.init_shape()
         self.x_np = np.random.uniform(-3, 3, self.x_shape).astype('float32')
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def init_shape(self):
         self.x_shape = [10, 12]
@@ -1620,11 +1601,7 @@ class TestSoftshrinkAPI(unittest.TestCase):
         self.threshold = 0.8
         np.random.seed(1024)
         self.x_np = np.random.uniform(0.25, 10, [10, 12]).astype(np.float64)
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def test_static_api(self):
         with static_guard():
@@ -2247,11 +2224,7 @@ class TestTan(TestActivation):
                 np.random.uniform(-1, 1, self.shape)
                 + 1j * np.random.uniform(-1, 1, self.shape)
             ).astype(self.dtype)
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
         out = np.tan(self.x_np)
 
@@ -2302,11 +2275,7 @@ class TestTanAPI(unittest.TestCase):
         np.random.seed(1024)
         self.dtype = 'float32'
         self.x_np = np.random.uniform(-1, 1, [11, 17]).astype(self.dtype)
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def test_dygraph_api(self):
         with dynamic_guard():
@@ -2852,11 +2821,7 @@ class TestReluAPI(unittest.TestCase):
     def setUp(self):
         np.random.seed(1024)
         self.x_np = np.random.uniform(-1, 1, [10, 12]).astype('float32')
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
         self.executed_api()
 
     def executed_api(self):
@@ -2996,11 +2961,7 @@ class TestLeakyReluAPI(unittest.TestCase):
     def setUp(self):
         np.random.seed(1024)
         self.x_np = np.random.uniform(-1, 1, [10, 12]).astype('float32')
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def test_static_api(self):
         with static_guard():
@@ -3176,11 +3137,7 @@ class TestGELUAPI(unittest.TestCase):
     def setUp(self):
         np.random.seed(1024)
         self.x_np = np.random.uniform(-1, 1, [11, 17]).astype('float32')
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
         self.enable_cinn = False
 
         # The backward decomposite of gelu is inconsistent with raw kernel on
@@ -3335,11 +3292,7 @@ class TestRelu6API(unittest.TestCase):
         np.random.seed(1024)
         self.x_np = np.random.uniform(-1, 10, [10, 12]).astype(np.float64)
         self.x_np[np.abs(self.x_np) < 0.005] = 0.02
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def test_static_api(self):
         with static_guard():
@@ -3524,11 +3477,7 @@ class TestHardswishAPI(unittest.TestCase):
     # test paddle.nn.Hardswish, paddle.nn.functional.hardswish
     def setUp(self):
         self.x_np = np.random.uniform(-1, 1, [10, 12]).astype(np.float64)
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def test_static_api(self):
         with static_guard():
@@ -3691,11 +3640,7 @@ class TestELUAPI(unittest.TestCase):
     def setUp(self):
         np.random.seed(1024)
         self.x_np = np.random.uniform(-3, 3, [10, 12]).astype('float32')
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
         self.executed_api()
 
     def executed_api(self):
@@ -3806,11 +3751,7 @@ class TestCELUAPI(unittest.TestCase):
     def setUp(self):
         np.random.seed(1024)
         self.x_np = np.random.uniform(-3, 3, [10, 12]).astype('float32')
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
         self.executed_api()
 
     def executed_api(self):
@@ -4841,11 +4782,7 @@ class TestSTanhAPI(unittest.TestCase):
         self.x_np = np.random.uniform(-1, 1, [10, 12]).astype('float32')
         self.scale_a = self.get_scale_a()
         self.scale_b = self.get_scale_b()
-        self.place = (
-            paddle.CUDAPlace(0)
-            if core.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def test_static_api(self):
         with static_guard():
@@ -5025,11 +4962,7 @@ class TestSoftplusAPI(unittest.TestCase):
         self.threshold = 15
         np.random.seed(1024)
         self.x_np = np.random.uniform(-1, 1, [10, 12]).astype(np.float64)
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def test_static_api(self):
         with static_guard():
@@ -5160,11 +5093,7 @@ class TestSoftsignAPI(unittest.TestCase):
     def setUp(self):
         np.random.seed(1024)
         self.x_np = np.random.uniform(-1, 1, [10, 12]).astype(np.float64)
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def test_static_api(self):
         with static_guard():
@@ -5265,11 +5194,7 @@ class TestThresholdedReluAPI(unittest.TestCase):
         np.random.seed(1024)
         self.x_np = np.random.uniform(-20, 20, [10, 12]).astype(np.float64)
         self.x_np[np.abs(self.x_np) < 0.005] = 0.02
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def test_static_api(self):
         with static_guard():
@@ -5397,11 +5322,7 @@ class TestHardsigmoidAPI(unittest.TestCase):
     # test paddle.nn.Hardsigmoid, paddle.nn.functional.hardsigmoid
     def setUp(self):
         self.x_np = np.random.uniform(-1, 1, [10, 12]).astype(np.float64)
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def test_static_api(self):
         with static_guard():
@@ -5508,11 +5429,7 @@ class TestSwishAPI(unittest.TestCase):
     def setUp(self):
         np.random.seed(1024)
         self.x_np = np.random.uniform(-1, 1, [10, 12]).astype(np.float64)
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def test_static_api(self):
         with static_guard():
@@ -5619,11 +5536,7 @@ class TestMishAPI(unittest.TestCase):
     def setUp(self):
         np.random.seed(1024)
         self.x_np = np.random.uniform(-1, 1, [10, 12]).astype(np.float64)
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def test_static_api(self):
         with static_guard():

--- a/test/legacy_test/test_adadelta_op.py
+++ b/test/legacy_test/test_adadelta_op.py
@@ -337,7 +337,7 @@ class TestAdadeltaMultiPrecision2_0(unittest.TestCase):
         paddle.enable_static()
         paddle.seed(100)
         np.random.seed(100)
-        exe = paddle.static.Executor(get_device_place)
+        exe = paddle.static.Executor(get_device_place())
         train_program = paddle.static.Program()
         startup_program = paddle.static.Program()
         optimizer = paddle.optimizer.Adadelta(0.1)

--- a/test/legacy_test/test_adadelta_op.py
+++ b/test/legacy_test/test_adadelta_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, get_places
+from op_test import OpTest, get_device_place, get_places
 
 import paddle
 from paddle import base
@@ -337,7 +337,7 @@ class TestAdadeltaMultiPrecision2_0(unittest.TestCase):
         paddle.enable_static()
         paddle.seed(100)
         np.random.seed(100)
-        exe = paddle.static.Executor('gpu')
+        exe = paddle.static.Executor(get_device_place)
         train_program = paddle.static.Program()
         startup_program = paddle.static.Program()
         optimizer = paddle.optimizer.Adadelta(0.1)

--- a/test/legacy_test/test_adagrad_op.py
+++ b/test/legacy_test/test_adagrad_op.py
@@ -17,7 +17,7 @@ import unittest
 
 import numpy as np
 from op import Operator
-from op_test import OpTest, get_places
+from op_test import OpTest, get_device_place, get_places
 
 import paddle
 from paddle.base import core
@@ -283,7 +283,7 @@ class TestAdagradMultiPrecision2_0(unittest.TestCase):
         paddle.enable_static()
         paddle.seed(100)
         np.random.seed(100)
-        exe = paddle.static.Executor('gpu')
+        exe = paddle.static.Executor(get_device_place())
         train_program = paddle.static.Program()
         startup_program = paddle.static.Program()
         optimizer = paddle.optimizer.Adagrad(0.1)

--- a/test/legacy_test/test_adamax_op.py
+++ b/test/legacy_test/test_adamax_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, get_places
+from op_test import OpTest, get_device_place, get_places
 
 import paddle
 
@@ -319,7 +319,7 @@ class TestAdamaxMultiPrecision2_0(unittest.TestCase):
         paddle.enable_static()
         paddle.seed(100)
         np.random.seed(100)
-        exe = paddle.static.Executor('gpu')
+        exe = paddle.static.Executor(get_device_place())
         train_program = paddle.static.Program()
         startup_program = paddle.static.Program()
         optimizer = paddle.optimizer.Adamax(0.1)

--- a/test/legacy_test/test_arange.py
+++ b/test/legacy_test/test_arange.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, convert_float_to_uint16
+from op_test import OpTest, convert_float_to_uint16, get_current_place
 
 import paddle
 from paddle.base import core
@@ -146,11 +146,7 @@ class TestArangeAPI(unittest.TestCase):
         ):
             x1 = paddle.arange(0, 5, 1, 'float32')
 
-            place = (
-                paddle.CUDAPlace(0)
-                if core.is_compiled_with_cuda()
-                else paddle.CPUPlace()
-            )
+            place = get_current_place()
             exe = paddle.static.Executor(place)
             out = exe.run(fetch_list=[x1])
 
@@ -162,11 +158,7 @@ class TestArangeAPI(unittest.TestCase):
 
 class TestArangeImperative(unittest.TestCase):
     def test_out(self):
-        place = (
-            paddle.CUDAPlace(0)
-            if core.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        place = get_current_place()
         paddle.disable_static(place)
         x1 = paddle.arange(0, 5, 1)
         x2 = paddle.tensor.arange(5)

--- a/test/legacy_test/test_arange.py
+++ b/test/legacy_test/test_arange.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, convert_float_to_uint16, get_current_place
+from op_test import OpTest, convert_float_to_uint16, get_device_place
 
 import paddle
 from paddle.base import core
@@ -146,7 +146,7 @@ class TestArangeAPI(unittest.TestCase):
         ):
             x1 = paddle.arange(0, 5, 1, 'float32')
 
-            place = get_current_place()
+            place = get_device_place()
             exe = paddle.static.Executor(place)
             out = exe.run(fetch_list=[x1])
 
@@ -158,7 +158,7 @@ class TestArangeAPI(unittest.TestCase):
 
 class TestArangeImperative(unittest.TestCase):
     def test_out(self):
-        place = get_current_place()
+        place = get_device_place()
         paddle.disable_static(place)
         x1 = paddle.arange(0, 5, 1)
         x2 = paddle.tensor.arange(5)

--- a/test/legacy_test/test_array_read_write_op.py
+++ b/test/legacy_test/test_array_read_write_op.py
@@ -15,6 +15,7 @@
 import unittest
 
 import numpy as np
+from op_test import get_current_place
 
 import paddle
 from paddle import base
@@ -181,11 +182,7 @@ class TestPirArrayOp(unittest.TestCase):
                 out0 = paddle.tensor.array_read(array, 0)
                 out1 = paddle.tensor.array_read(array, 1)
 
-            place = (
-                paddle.base.CPUPlace()
-                if not paddle.base.core.is_compiled_with_cuda()
-                else paddle.base.CUDAPlace(0)
-            )
+            place = get_current_place()
             exe = paddle.base.Executor(place)
             [fetched_out0, fetched_out1] = exe.run(
                 main_program, feed={}, fetch_list=[out0, out1]
@@ -214,11 +211,7 @@ class TestPirArrayOp(unittest.TestCase):
             mean = paddle.mean(out)
             grad_list = append_backward(mean)
 
-            place = (
-                base.CUDAPlace(0)
-                if core.is_compiled_with_cuda()
-                else base.CPUPlace()
-            )
+            place = get_current_place()
             d = np.random.random(size=[10]).astype('float32')
             exe = base.Executor(place)
 
@@ -277,11 +270,7 @@ class TestPirArrayOp(unittest.TestCase):
                 i = paddle.increment(i, 1)
                 out_2 = paddle.tensor.array_read(array=add_array, i=i)
 
-                place = (
-                    base.CUDAPlace(0)
-                    if core.is_compiled_with_cuda()
-                    else base.CPUPlace()
-                )
+                place = get_current_place()
                 d0 = np.random.random(size=[10]).astype('float32')
                 d1 = np.random.random(size=[10]).astype('float32')
                 exe = base.Executor(place)

--- a/test/legacy_test/test_array_read_write_op.py
+++ b/test/legacy_test/test_array_read_write_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import get_current_place
+from op_test import get_device_place
 
 import paddle
 from paddle import base
@@ -182,7 +182,7 @@ class TestPirArrayOp(unittest.TestCase):
                 out0 = paddle.tensor.array_read(array, 0)
                 out1 = paddle.tensor.array_read(array, 1)
 
-            place = get_current_place()
+            place = get_device_place()
             exe = paddle.base.Executor(place)
             [fetched_out0, fetched_out1] = exe.run(
                 main_program, feed={}, fetch_list=[out0, out1]
@@ -211,7 +211,7 @@ class TestPirArrayOp(unittest.TestCase):
             mean = paddle.mean(out)
             grad_list = append_backward(mean)
 
-            place = get_current_place()
+            place = get_device_place()
             d = np.random.random(size=[10]).astype('float32')
             exe = base.Executor(place)
 
@@ -270,7 +270,7 @@ class TestPirArrayOp(unittest.TestCase):
                 i = paddle.increment(i, 1)
                 out_2 = paddle.tensor.array_read(array=add_array, i=i)
 
-                place = get_current_place()
+                place = get_device_place()
                 d0 = np.random.random(size=[10]).astype('float32')
                 d1 = np.random.random(size=[10]).astype('float32')
                 exe = base.Executor(place)

--- a/test/legacy_test/test_asgd_op.py
+++ b/test/legacy_test/test_asgd_op.py
@@ -18,6 +18,7 @@ import numpy as np
 from op_test import (
     OpTest,
     convert_float_to_uint16,
+    get_device_place,
 )
 from utils import dygraph_guard
 
@@ -274,7 +275,7 @@ class TestASGDMultiPrecision(unittest.TestCase):
         with paddle.pir_utils.OldIrGuard():
             paddle.seed(10)
             np.random.seed(10)
-            exe = paddle.static.Executor('gpu')
+            exe = paddle.static.Executor(get_device_place())
             train_program = paddle.static.Program()
             startup_program = paddle.static.Program()
             optimizer = paddle.optimizer.ASGD(batch_num=2, multi_precision=mp)
@@ -322,7 +323,7 @@ class TestASGDMultiPrecision(unittest.TestCase):
         with paddle.pir_utils.IrGuard():
             paddle.seed(10)
             np.random.seed(10)
-            exe = paddle.static.Executor('gpu')
+            exe = paddle.static.Executor(get_device_place())
             train_program = paddle.static.Program()
             startup_program = paddle.static.Program()
 
@@ -423,7 +424,7 @@ class TestASGDSimple(unittest.TestCase):
             paddle.seed(10)
             np.random.seed(10)
 
-            exe = paddle.static.Executor('gpu')
+            exe = paddle.static.Executor(get_device_place())
             train_program = paddle.static.Program()
             startup_program = paddle.static.Program()
 

--- a/test/legacy_test/test_assign_op.py
+++ b/test/legacy_test/test_assign_op.py
@@ -21,7 +21,7 @@ from decorator_helper import prog_scope
 from op_test import (
     convert_float_to_uint16,
     convert_uint16_to_float,
-    get_current_place,
+    get_device_place,
     get_places,
 )
 
@@ -137,7 +137,7 @@ class TestAssignOpWithTensorArray(unittest.TestCase):
             mean = paddle.mean(sums)
             [(_, x_grad)] = append_backward(mean, parameter_list=[x])
 
-        place = get_current_place()
+        place = get_device_place()
         exe = paddle.static.Executor(place)
         feed_x = np.random.random(size=(100, 10)).astype('float32')
         ones = np.ones((100, 10)).astype('float32')

--- a/test/legacy_test/test_assign_op.py
+++ b/test/legacy_test/test_assign_op.py
@@ -18,7 +18,12 @@ import gradient_checker
 import numpy as np
 import op_test
 from decorator_helper import prog_scope
-from op_test import convert_float_to_uint16, convert_uint16_to_float, get_places
+from op_test import (
+    convert_float_to_uint16,
+    convert_uint16_to_float,
+    get_current_place,
+    get_places,
+)
 
 import paddle
 from paddle import base
@@ -132,11 +137,7 @@ class TestAssignOpWithTensorArray(unittest.TestCase):
             mean = paddle.mean(sums)
             [(_, x_grad)] = append_backward(mean, parameter_list=[x])
 
-        place = (
-            paddle.CUDAPlace(0)
-            if paddle.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        place = get_current_place()
         exe = paddle.static.Executor(place)
         feed_x = np.random.random(size=(100, 10)).astype('float32')
         ones = np.ones((100, 10)).astype('float32')

--- a/test/legacy_test/test_assign_value_op.py
+++ b/test/legacy_test/test_assign_value_op.py
@@ -16,6 +16,7 @@ import unittest
 
 import numpy as np
 import op_test
+from op_test import get_current_place
 
 import paddle
 from paddle import base
@@ -105,11 +106,7 @@ class TestAssignApi(unittest.TestCase):
             self.value = (-100 + 200 * np.random.random(size=(2, 5))).astype(
                 self.dtype
             )
-            self.place = (
-                base.CUDAPlace(0)
-                if base.is_compiled_with_cuda()
-                else base.CPUPlace()
-            )
+            self.place = get_current_place()
 
     def init_dtype(self):
         self.dtype = "float32"
@@ -155,11 +152,7 @@ class TestAssignApi4(TestAssignApi):
             self.value = np.random.choice(a=[False, True], size=(2, 5)).astype(
                 np.bool_
             )
-            self.place = (
-                base.CUDAPlace(0)
-                if base.is_compiled_with_cuda()
-                else base.CPUPlace()
-            )
+            self.place = get_current_place()
 
     def init_dtype(self):
         self.dtype = "bool"
@@ -178,11 +171,7 @@ class TestAssignApi6(TestAssignApi):
                 np.random.random(size=(2, 5))
                 + 1j * (np.random.random(size=(2, 5)))
             ).astype(np.complex64)
-            self.place = (
-                base.CUDAPlace(0)
-                if base.is_compiled_with_cuda()
-                else base.CPUPlace()
-            )
+            self.place = get_current_place()
 
     def init_dtype(self):
         self.dtype = "complex64"
@@ -196,11 +185,7 @@ class TestAssignApi7(TestAssignApi):
                 np.random.random(size=(2, 5))
                 + 1j * (np.random.random(size=(2, 5)))
             ).astype(np.complex128)
-            self.place = (
-                base.CUDAPlace(0)
-                if base.is_compiled_with_cuda()
-                else base.CPUPlace()
-            )
+            self.place = get_current_place()
 
     def init_dtype(self):
         self.dtype = "complex128"

--- a/test/legacy_test/test_assign_value_op.py
+++ b/test/legacy_test/test_assign_value_op.py
@@ -16,7 +16,7 @@ import unittest
 
 import numpy as np
 import op_test
-from op_test import get_current_place
+from op_test import get_device_place
 
 import paddle
 from paddle import base
@@ -106,7 +106,7 @@ class TestAssignApi(unittest.TestCase):
             self.value = (-100 + 200 * np.random.random(size=(2, 5))).astype(
                 self.dtype
             )
-            self.place = get_current_place()
+            self.place = get_device_place()
 
     def init_dtype(self):
         self.dtype = "float32"
@@ -152,7 +152,7 @@ class TestAssignApi4(TestAssignApi):
             self.value = np.random.choice(a=[False, True], size=(2, 5)).astype(
                 np.bool_
             )
-            self.place = get_current_place()
+            self.place = get_device_place()
 
     def init_dtype(self):
         self.dtype = "bool"
@@ -171,7 +171,7 @@ class TestAssignApi6(TestAssignApi):
                 np.random.random(size=(2, 5))
                 + 1j * (np.random.random(size=(2, 5)))
             ).astype(np.complex64)
-            self.place = get_current_place()
+            self.place = get_device_place()
 
     def init_dtype(self):
         self.dtype = "complex64"
@@ -185,7 +185,7 @@ class TestAssignApi7(TestAssignApi):
                 np.random.random(size=(2, 5))
                 + 1j * (np.random.random(size=(2, 5)))
             ).astype(np.complex128)
-            self.place = get_current_place()
+            self.place = get_device_place()
 
     def init_dtype(self):
         self.dtype = "complex128"

--- a/test/legacy_test/test_bce_loss.py
+++ b/test/legacy_test/test_bce_loss.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, get_current_place, get_places
+from op_test import OpTest, get_device_place, get_places
 
 import paddle
 from paddle.base import core
@@ -195,7 +195,7 @@ class TestBCELoss(unittest.TestCase):
             np.float64
         )
         weight_np = np.random.random(size=(3, 4, 10)).astype(np.float64)
-        place = get_current_place()
+        place = get_device_place()
         for reduction in ['sum', 'mean', 'none']:
             static_result = test_static_layer(
                 place, input_np, label_np, reduction, weight_np=weight_np

--- a/test/legacy_test/test_bce_loss.py
+++ b/test/legacy_test/test_bce_loss.py
@@ -15,10 +15,9 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, get_places
+from op_test import OpTest, get_current_place, get_places
 
 import paddle
-from paddle import base
 from paddle.base import core
 
 
@@ -196,11 +195,7 @@ class TestBCELoss(unittest.TestCase):
             np.float64
         )
         weight_np = np.random.random(size=(3, 4, 10)).astype(np.float64)
-        place = (
-            base.CUDAPlace(0)
-            if base.core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
         for reduction in ['sum', 'mean', 'none']:
             static_result = test_static_layer(
                 place, input_np, label_np, reduction, weight_np=weight_np

--- a/test/legacy_test/test_bce_with_logits_loss.py
+++ b/test/legacy_test/test_bce_with_logits_loss.py
@@ -15,10 +15,9 @@
 import unittest
 
 import numpy as np
-from op_test import get_places
+from op_test import get_current_place, get_places
 
 import paddle
-from paddle import base
 
 
 def call_bce_layer(
@@ -199,11 +198,7 @@ class TestBCEWithLogitsLoss(unittest.TestCase):
             np.float64
         )
         weight_np = np.random.random(size=(2, 3, 4, 10)).astype(np.float64)
-        place = (
-            base.CUDAPlace(0)
-            if base.core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
         for reduction in ['sum', 'mean', 'none']:
             dy_result = test_dygraph(
                 place,
@@ -264,11 +259,7 @@ class TestBCEWithLogitsLoss(unittest.TestCase):
         )
         pos_weight_np = np.random.random(size=(3, 4, 10)).astype(np.float64)
         weight_np = np.random.random(size=(2, 3, 4, 10)).astype(np.float64)
-        place = (
-            base.CUDAPlace(0)
-            if base.core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
         reduction = "mean"
 
         dy_result = test_dygraph(

--- a/test/legacy_test/test_bce_with_logits_loss.py
+++ b/test/legacy_test/test_bce_with_logits_loss.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import get_current_place, get_places
+from op_test import get_device_place, get_places
 
 import paddle
 
@@ -198,7 +198,7 @@ class TestBCEWithLogitsLoss(unittest.TestCase):
             np.float64
         )
         weight_np = np.random.random(size=(2, 3, 4, 10)).astype(np.float64)
-        place = get_current_place()
+        place = get_device_place()
         for reduction in ['sum', 'mean', 'none']:
             dy_result = test_dygraph(
                 place,
@@ -259,7 +259,7 @@ class TestBCEWithLogitsLoss(unittest.TestCase):
         )
         pos_weight_np = np.random.random(size=(3, 4, 10)).astype(np.float64)
         weight_np = np.random.random(size=(2, 3, 4, 10)).astype(np.float64)
-        place = get_current_place()
+        place = get_device_place()
         reduction = "mean"
 
         dy_result = test_dygraph(

--- a/test/legacy_test/test_bicubic_interp_v2_op.py
+++ b/test/legacy_test/test_bicubic_interp_v2_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, convert_float_to_uint16, get_current_place
+from op_test import OpTest, convert_float_to_uint16, get_device_place
 
 import paddle
 from paddle import base
@@ -599,7 +599,7 @@ class TestBicubicInterpOpAPI(unittest.TestCase):
 
         prog = paddle.static.Program()
         startup_prog = paddle.static.Program()
-        place = get_current_place()
+        place = get_device_place()
 
         with paddle.static.program_guard(prog, startup_prog):
             x = paddle.static.data(

--- a/test/legacy_test/test_bicubic_interp_v2_op.py
+++ b/test/legacy_test/test_bicubic_interp_v2_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, convert_float_to_uint16
+from op_test import OpTest, convert_float_to_uint16, get_current_place
 
 import paddle
 from paddle import base
@@ -599,11 +599,7 @@ class TestBicubicInterpOpAPI(unittest.TestCase):
 
         prog = paddle.static.Program()
         startup_prog = paddle.static.Program()
-        place = (
-            base.CUDAPlace(0)
-            if base.core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
 
         with paddle.static.program_guard(prog, startup_prog):
             x = paddle.static.data(

--- a/test/legacy_test/test_bincount_op.py
+++ b/test/legacy_test/test_bincount_op.py
@@ -19,7 +19,7 @@ import unittest
 
 sys.path.append("../../legacy_test")
 import numpy as np
-from op_test import OpTest
+from op_test import OpTest, get_current_place
 
 import paddle
 import paddle.inference as paddle_infer
@@ -251,11 +251,7 @@ class TestTensorMinlength(unittest.TestCase):
         self.save_path = os.path.join(
             self.temp_dir.name, 'tensor_minlength_bincount'
         )
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def test_dygraph(self):
         paddle.disable_static()

--- a/test/legacy_test/test_bincount_op.py
+++ b/test/legacy_test/test_bincount_op.py
@@ -19,7 +19,7 @@ import unittest
 
 sys.path.append("../../legacy_test")
 import numpy as np
-from op_test import OpTest, get_current_place
+from op_test import OpTest, get_device_place
 
 import paddle
 import paddle.inference as paddle_infer
@@ -251,7 +251,7 @@ class TestTensorMinlength(unittest.TestCase):
         self.save_path = os.path.join(
             self.temp_dir.name, 'tensor_minlength_bincount'
         )
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def test_dygraph(self):
         paddle.disable_static()

--- a/test/legacy_test/test_bitwise_shift_op.py
+++ b/test/legacy_test/test_bitwise_shift_op.py
@@ -15,6 +15,7 @@
 import unittest
 
 import numpy as np
+from op_test import get_current_place
 
 import paddle
 
@@ -64,11 +65,7 @@ def ref_right_shift_logical(x, y):
 class TestBitwiseLeftShiftAPI(unittest.TestCase):
     def setUp(self):
         self.init_input()
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def init_input(self):
         self.x = np.random.randint(0, 256, [200, 300]).astype('uint8')
@@ -248,11 +245,7 @@ class TestBitwiseLeftShiftAPI_special_case4(TestBitwiseLeftShiftAPI):
 class TestTensorRlshiftAPI(unittest.TestCase):
     def setUp(self):
         self.init_input()
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def init_input(self):
         self.x = np.random.randint(-255, 256)
@@ -309,11 +302,7 @@ class TestTensorRlshiftAPI_INT64(TestTensorRlshiftAPI):
 class TestBitwiseRightShiftAPI(unittest.TestCase):
     def setUp(self):
         self.init_input()
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def init_input(self):
         self.x = np.random.randint(0, 256, [200, 300]).astype('uint8')
@@ -493,11 +482,7 @@ class TestBitwiseRightShiftAPI_special_case4(TestBitwiseRightShiftAPI):
 class TestTensorRrshiftAPI(unittest.TestCase):
     def setUp(self):
         self.init_input()
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def init_input(self):
         self.x = np.random.randint(-255, 256)
@@ -554,11 +539,7 @@ class TestTensorRrshiftAPI_INT64(TestTensorRrshiftAPI):
 class TestTensorShiftAPI_FLOAT(unittest.TestCase):
     def setup(self):
         paddle.disable_static()
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def test_lshift_float(self):
         x = paddle.to_tensor(np.random.randint(-255, 256, [200, 300]))

--- a/test/legacy_test/test_bitwise_shift_op.py
+++ b/test/legacy_test/test_bitwise_shift_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import get_current_place
+from op_test import get_device_place
 
 import paddle
 
@@ -65,7 +65,7 @@ def ref_right_shift_logical(x, y):
 class TestBitwiseLeftShiftAPI(unittest.TestCase):
     def setUp(self):
         self.init_input()
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def init_input(self):
         self.x = np.random.randint(0, 256, [200, 300]).astype('uint8')
@@ -245,7 +245,7 @@ class TestBitwiseLeftShiftAPI_special_case4(TestBitwiseLeftShiftAPI):
 class TestTensorRlshiftAPI(unittest.TestCase):
     def setUp(self):
         self.init_input()
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def init_input(self):
         self.x = np.random.randint(-255, 256)
@@ -302,7 +302,7 @@ class TestTensorRlshiftAPI_INT64(TestTensorRlshiftAPI):
 class TestBitwiseRightShiftAPI(unittest.TestCase):
     def setUp(self):
         self.init_input()
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def init_input(self):
         self.x = np.random.randint(0, 256, [200, 300]).astype('uint8')
@@ -482,7 +482,7 @@ class TestBitwiseRightShiftAPI_special_case4(TestBitwiseRightShiftAPI):
 class TestTensorRrshiftAPI(unittest.TestCase):
     def setUp(self):
         self.init_input()
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def init_input(self):
         self.x = np.random.randint(-255, 256)
@@ -539,7 +539,7 @@ class TestTensorRrshiftAPI_INT64(TestTensorRrshiftAPI):
 class TestTensorShiftAPI_FLOAT(unittest.TestCase):
     def setup(self):
         paddle.disable_static()
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def test_lshift_float(self):
         x = paddle.to_tensor(np.random.randint(-255, 256, [200, 300]))

--- a/test/legacy_test/test_case.py
+++ b/test/legacy_test/test_case.py
@@ -16,7 +16,7 @@ import unittest
 from functools import partial
 
 import numpy as np
-from op_test import get_current_place
+from op_test import get_device_place
 
 import paddle
 from paddle import base
@@ -84,7 +84,7 @@ class TestAPICase(unittest.TestCase):
                 pred_fn_pairs=[(pred_2, fn_2)]
             )
 
-            place = get_current_place()
+            place = get_device_place()
             exe = base.Executor(place)
 
             res = exe.run(
@@ -141,7 +141,7 @@ class TestAPICase(unittest.TestCase):
                 pred_fn_pairs=[(pred_2, fn_2)]
             )
 
-            place = get_current_place()
+            place = get_device_place()
             exe = base.Executor(place)
 
             res = exe.run(
@@ -173,7 +173,7 @@ class TestAPICase(unittest.TestCase):
             )
             grad_list = append_backward(out)
 
-        place = get_current_place()
+        place = get_device_place()
         exe = base.Executor(place)
 
         if paddle.framework.in_pir_mode():
@@ -285,7 +285,7 @@ class TestAPICase(unittest.TestCase):
                 ((pred_1, fn_1), (pred_2, fn_2)), fn_3
             )
 
-            place = get_current_place()
+            place = get_device_place()
             exe = base.Executor(place)
             ret = exe.run(main_program, fetch_list=out)
 
@@ -403,7 +403,7 @@ class TestAPICase_Nested(unittest.TestCase):
                 pred_fn_pairs=[(x == y, fn_1), (x == z, fn_2)], default=fn_3
             )
 
-            place = get_current_place()
+            place = get_device_place()
             exe = base.Executor(place)
 
             res = exe.run(main_program, fetch_list=[out_1, out_2, out_3])
@@ -499,7 +499,7 @@ class TestAPICase_Nested(unittest.TestCase):
                 pred_fn_pairs=[(x == y, fn_1), (x == z, fn_2)], default=fn_3
             )
 
-            place = get_current_place()
+            place = get_device_place()
             exe = base.Executor(place)
 
             res = exe.run(main_program, fetch_list=[out_1, out_2, out_3])

--- a/test/legacy_test/test_case.py
+++ b/test/legacy_test/test_case.py
@@ -16,10 +16,10 @@ import unittest
 from functools import partial
 
 import numpy as np
+from op_test import get_current_place
 
 import paddle
 from paddle import base
-from paddle.base import core
 from paddle.base.backward import append_backward
 from paddle.base.framework import Program, program_guard
 
@@ -84,11 +84,7 @@ class TestAPICase(unittest.TestCase):
                 pred_fn_pairs=[(pred_2, fn_2)]
             )
 
-            place = (
-                base.CUDAPlace(0)
-                if core.is_compiled_with_cuda()
-                else base.CPUPlace()
-            )
+            place = get_current_place()
             exe = base.Executor(place)
 
             res = exe.run(
@@ -145,11 +141,7 @@ class TestAPICase(unittest.TestCase):
                 pred_fn_pairs=[(pred_2, fn_2)]
             )
 
-            place = (
-                base.CUDAPlace(0)
-                if core.is_compiled_with_cuda()
-                else base.CPUPlace()
-            )
+            place = get_current_place()
             exe = base.Executor(place)
 
             res = exe.run(
@@ -181,11 +173,7 @@ class TestAPICase(unittest.TestCase):
             )
             grad_list = append_backward(out)
 
-        place = (
-            base.CUDAPlace(0)
-            if core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
         exe = base.Executor(place)
 
         if paddle.framework.in_pir_mode():
@@ -297,11 +285,7 @@ class TestAPICase(unittest.TestCase):
                 ((pred_1, fn_1), (pred_2, fn_2)), fn_3
             )
 
-            place = (
-                base.CUDAPlace(0)
-                if core.is_compiled_with_cuda()
-                else base.CPUPlace()
-            )
+            place = get_current_place()
             exe = base.Executor(place)
             ret = exe.run(main_program, fetch_list=out)
 
@@ -419,11 +403,7 @@ class TestAPICase_Nested(unittest.TestCase):
                 pred_fn_pairs=[(x == y, fn_1), (x == z, fn_2)], default=fn_3
             )
 
-            place = (
-                base.CUDAPlace(0)
-                if core.is_compiled_with_cuda()
-                else base.CPUPlace()
-            )
+            place = get_current_place()
             exe = base.Executor(place)
 
             res = exe.run(main_program, fetch_list=[out_1, out_2, out_3])
@@ -519,11 +499,7 @@ class TestAPICase_Nested(unittest.TestCase):
                 pred_fn_pairs=[(x == y, fn_1), (x == z, fn_2)], default=fn_3
             )
 
-            place = (
-                base.CUDAPlace(0)
-                if core.is_compiled_with_cuda()
-                else base.CPUPlace()
-            )
+            place = get_current_place()
             exe = base.Executor(place)
 
             res = exe.run(main_program, fetch_list=[out_1, out_2, out_3])

--- a/test/legacy_test/test_copysign_op.py
+++ b/test/legacy_test/test_copysign_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, convert_float_to_uint16
+from op_test import OpTest, convert_float_to_uint16, get_current_place
 
 import paddle
 from paddle.base import core
@@ -116,11 +116,7 @@ class TestCopySignAPI(unittest.TestCase):
         self.y = np.random.randn(20, 6).astype('float64')
 
     def place_init(self):
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def test_static_api(self):
         paddle.enable_static()

--- a/test/legacy_test/test_copysign_op.py
+++ b/test/legacy_test/test_copysign_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, convert_float_to_uint16, get_current_place
+from op_test import OpTest, convert_float_to_uint16, get_device_place
 
 import paddle
 from paddle.base import core
@@ -116,7 +116,7 @@ class TestCopySignAPI(unittest.TestCase):
         self.y = np.random.randn(20, 6).astype('float64')
 
     def place_init(self):
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def test_static_api(self):
         paddle.enable_static()

--- a/test/legacy_test/test_count_nonzero_api.py
+++ b/test/legacy_test/test_count_nonzero_api.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import get_current_place
+from op_test import get_device_place
 
 import paddle
 
@@ -28,7 +28,7 @@ class TestCountNonzeroAPI(unittest.TestCase):
     def setUp(self):
         self.x_shape = [2, 3, 4, 5]
         self.x = np.random.uniform(-1, 1, self.x_shape).astype(np.float32)
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def test_api_static(self):
         paddle.enable_static()

--- a/test/legacy_test/test_count_nonzero_api.py
+++ b/test/legacy_test/test_count_nonzero_api.py
@@ -15,9 +15,9 @@
 import unittest
 
 import numpy as np
+from op_test import get_current_place
 
 import paddle
-from paddle.base import core
 
 np.random.seed(10)
 
@@ -28,11 +28,7 @@ class TestCountNonzeroAPI(unittest.TestCase):
     def setUp(self):
         self.x_shape = [2, 3, 4, 5]
         self.x = np.random.uniform(-1, 1, self.x_shape).astype(np.float32)
-        self.place = (
-            paddle.CUDAPlace(0)
-            if core.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def test_api_static(self):
         paddle.enable_static()

--- a/test/legacy_test/test_cross_entropy_loss.py
+++ b/test/legacy_test/test_cross_entropy_loss.py
@@ -18,7 +18,7 @@ import unittest
 import numpy as np
 
 sys.path.append("../deprecated/legacy_test")
-from op_test import get_current_place
+from op_test import get_device_place
 from test_softmax_op import stable_softmax
 from test_softmax_with_cross_entropy_op import cross_entropy
 
@@ -335,7 +335,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = get_current_place()
+        place = get_device_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input', shape=[self.N, self.C], dtype=self.dtype
@@ -428,7 +428,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = get_current_place()
+        place = get_device_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input', shape=[self.N, self.C], dtype=self.dtype
@@ -516,7 +516,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = get_current_place()
+        place = get_device_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input', shape=[self.N, self.C], dtype=self.dtype
@@ -597,7 +597,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = get_current_place()
+        place = get_device_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input', shape=[self.N, self.C], dtype=self.dtype
@@ -697,7 +697,7 @@ class CrossEntropyLoss(unittest.TestCase):
             paddle.enable_static()
             prog = base.Program()
             startup_prog = base.Program()
-            place = get_current_place()
+            place = get_device_place()
             with base.program_guard(prog, startup_prog):
                 input = paddle.static.data(
                     name='input',
@@ -792,7 +792,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = get_current_place()
+        place = get_device_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input',
@@ -895,7 +895,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = get_current_place()
+        place = get_device_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input', shape=[self.N, self.C], dtype=self.dtype
@@ -988,7 +988,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = get_current_place()
+        place = get_device_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input', shape=[self.N, self.C], dtype=self.dtype
@@ -1095,7 +1095,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = get_current_place()
+        place = get_device_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input',
@@ -1197,7 +1197,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = get_current_place()
+        place = get_device_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input',
@@ -1301,7 +1301,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = get_current_place()
+        place = get_device_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input', shape=[self.N, self.C], dtype=self.input_dtype
@@ -1397,7 +1397,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = get_current_place()
+        place = get_device_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input', shape=[self.N, self.C], dtype=self.input_dtype
@@ -1503,7 +1503,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = get_current_place()
+        place = get_device_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input',
@@ -1607,7 +1607,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = get_current_place()
+        place = get_device_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input',
@@ -1654,7 +1654,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = get_current_place()
+        place = get_device_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input', shape=[2, 4], dtype=self.dtype
@@ -1698,7 +1698,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = get_current_place()
+        place = get_device_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input', shape=[N, C], dtype=self.dtype
@@ -1744,7 +1744,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = get_current_place()
+        place = get_device_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input', shape=[N, C], dtype=self.dtype
@@ -1821,7 +1821,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = get_current_place()
+        place = get_device_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input', shape=[2, 4], dtype=self.dtype
@@ -1872,7 +1872,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = get_current_place()
+        place = get_device_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input', shape=[100, 200], dtype=self.dtype
@@ -1922,7 +1922,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = get_current_place()
+        place = get_device_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input', shape=[100, 200], dtype=self.dtype
@@ -1974,7 +1974,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = get_current_place()
+        place = get_device_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input', shape=[100, 200], dtype=self.dtype
@@ -2022,7 +2022,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = get_current_place()
+        place = get_device_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input', shape=[100, 200], dtype=self.dtype
@@ -2056,7 +2056,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = get_current_place()
+        place = get_device_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input', shape=[100, 200], dtype=self.dtype
@@ -2094,7 +2094,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = get_current_place()
+        place = get_device_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input', shape=[100, 200], dtype=self.dtype
@@ -2140,7 +2140,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = get_current_place()
+        place = get_device_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input', shape=[2, 2, 2, 3], dtype=self.dtype
@@ -2198,7 +2198,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = get_current_place()
+        place = get_device_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input', shape=[2, 3, 2, 2], dtype=self.dtype
@@ -2284,7 +2284,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = get_current_place()
+        place = get_device_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input', shape=[2, 2, 2, 3], dtype=self.dtype
@@ -2340,7 +2340,7 @@ class CrossEntropyLoss(unittest.TestCase):
 
         prog = base.Program()
         startup_prog = base.Program()
-        place = get_current_place()
+        place = get_device_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input', shape=[2, 2, 2, 3], dtype=self.dtype
@@ -2394,7 +2394,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = get_current_place()
+        place = get_device_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input', shape=[2, 2, 2, 3], dtype=self.dtype
@@ -2443,7 +2443,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = get_current_place()
+        place = get_device_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input', shape=[2, 2, 2, 3], dtype=self.dtype
@@ -2493,7 +2493,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = get_current_place()
+        place = get_device_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input', shape=[2, 2, 2, 3], dtype=self.dtype
@@ -2590,7 +2590,7 @@ class TestCrossEntropyFAPIError(unittest.TestCase):
                 paddle.enable_static()
                 prog = base.Program()
                 startup_prog = base.Program()
-                place = get_current_place()
+                place = get_device_place()
                 with base.program_guard(prog, startup_prog):
                     input = paddle.static.data(
                         name='input', shape=[2, 4], dtype='float32'

--- a/test/legacy_test/test_cross_entropy_loss.py
+++ b/test/legacy_test/test_cross_entropy_loss.py
@@ -18,6 +18,7 @@ import unittest
 import numpy as np
 
 sys.path.append("../deprecated/legacy_test")
+from op_test import get_current_place
 from test_softmax_op import stable_softmax
 from test_softmax_with_cross_entropy_op import cross_entropy
 
@@ -334,11 +335,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = (
-            base.CUDAPlace(0)
-            if base.core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input', shape=[self.N, self.C], dtype=self.dtype
@@ -431,11 +428,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = (
-            base.CUDAPlace(0)
-            if base.core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input', shape=[self.N, self.C], dtype=self.dtype
@@ -523,11 +516,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = (
-            base.CUDAPlace(0)
-            if base.core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input', shape=[self.N, self.C], dtype=self.dtype
@@ -608,11 +597,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = (
-            base.CUDAPlace(0)
-            if base.core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input', shape=[self.N, self.C], dtype=self.dtype
@@ -712,11 +697,7 @@ class CrossEntropyLoss(unittest.TestCase):
             paddle.enable_static()
             prog = base.Program()
             startup_prog = base.Program()
-            place = (
-                base.CUDAPlace(0)
-                if base.core.is_compiled_with_cuda()
-                else base.CPUPlace()
-            )
+            place = get_current_place()
             with base.program_guard(prog, startup_prog):
                 input = paddle.static.data(
                     name='input',
@@ -811,11 +792,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = (
-            base.CUDAPlace(0)
-            if base.core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input',
@@ -918,11 +895,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = (
-            base.CUDAPlace(0)
-            if base.core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input', shape=[self.N, self.C], dtype=self.dtype
@@ -1015,11 +988,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = (
-            base.CUDAPlace(0)
-            if base.core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input', shape=[self.N, self.C], dtype=self.dtype
@@ -1126,11 +1095,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = (
-            base.CUDAPlace(0)
-            if base.core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input',
@@ -1232,11 +1197,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = (
-            base.CUDAPlace(0)
-            if base.core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input',
@@ -1340,11 +1301,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = (
-            base.CUDAPlace(0)
-            if base.core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input', shape=[self.N, self.C], dtype=self.input_dtype
@@ -1440,11 +1397,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = (
-            base.CUDAPlace(0)
-            if base.core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input', shape=[self.N, self.C], dtype=self.input_dtype
@@ -1550,11 +1503,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = (
-            base.CUDAPlace(0)
-            if base.core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input',
@@ -1658,11 +1607,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = (
-            base.CUDAPlace(0)
-            if base.core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input',
@@ -1709,11 +1654,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = (
-            base.CUDAPlace(0)
-            if base.core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input', shape=[2, 4], dtype=self.dtype
@@ -1757,11 +1698,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = (
-            base.CUDAPlace(0)
-            if base.core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input', shape=[N, C], dtype=self.dtype
@@ -1807,11 +1744,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = (
-            base.CUDAPlace(0)
-            if base.core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input', shape=[N, C], dtype=self.dtype
@@ -1888,11 +1821,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = (
-            base.CUDAPlace(0)
-            if base.core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input', shape=[2, 4], dtype=self.dtype
@@ -1943,11 +1872,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = (
-            base.CUDAPlace(0)
-            if base.core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input', shape=[100, 200], dtype=self.dtype
@@ -1997,11 +1922,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = (
-            base.CUDAPlace(0)
-            if base.core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input', shape=[100, 200], dtype=self.dtype
@@ -2053,11 +1974,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = (
-            base.CUDAPlace(0)
-            if base.core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input', shape=[100, 200], dtype=self.dtype
@@ -2105,11 +2022,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = (
-            base.CUDAPlace(0)
-            if base.core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input', shape=[100, 200], dtype=self.dtype
@@ -2143,11 +2056,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = (
-            base.CUDAPlace(0)
-            if base.core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input', shape=[100, 200], dtype=self.dtype
@@ -2185,11 +2094,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = (
-            base.CUDAPlace(0)
-            if base.core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input', shape=[100, 200], dtype=self.dtype
@@ -2235,11 +2140,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = (
-            base.CUDAPlace(0)
-            if base.core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input', shape=[2, 2, 2, 3], dtype=self.dtype
@@ -2297,11 +2198,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = (
-            base.CUDAPlace(0)
-            if base.core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input', shape=[2, 3, 2, 2], dtype=self.dtype
@@ -2387,11 +2284,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = (
-            base.CUDAPlace(0)
-            if base.core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input', shape=[2, 2, 2, 3], dtype=self.dtype
@@ -2447,11 +2340,7 @@ class CrossEntropyLoss(unittest.TestCase):
 
         prog = base.Program()
         startup_prog = base.Program()
-        place = (
-            base.CUDAPlace(0)
-            if base.core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input', shape=[2, 2, 2, 3], dtype=self.dtype
@@ -2505,11 +2394,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = (
-            base.CUDAPlace(0)
-            if base.core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input', shape=[2, 2, 2, 3], dtype=self.dtype
@@ -2558,11 +2443,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = (
-            base.CUDAPlace(0)
-            if base.core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input', shape=[2, 2, 2, 3], dtype=self.dtype
@@ -2612,11 +2493,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
         prog = base.Program()
         startup_prog = base.Program()
-        place = (
-            base.CUDAPlace(0)
-            if base.core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
         with base.program_guard(prog, startup_prog):
             input = paddle.static.data(
                 name='input', shape=[2, 2, 2, 3], dtype=self.dtype
@@ -2713,11 +2590,7 @@ class TestCrossEntropyFAPIError(unittest.TestCase):
                 paddle.enable_static()
                 prog = base.Program()
                 startup_prog = base.Program()
-                place = (
-                    base.CUDAPlace(0)
-                    if base.core.is_compiled_with_cuda()
-                    else base.CPUPlace()
-                )
+                place = get_current_place()
                 with base.program_guard(prog, startup_prog):
                     input = paddle.static.data(
                         name='input', shape=[2, 4], dtype='float32'

--- a/test/legacy_test/test_cumsum_op.py
+++ b/test/legacy_test/test_cumsum_op.py
@@ -22,7 +22,7 @@ from paddle.framework import use_pir_api
 sys.path.append("../../legacy_test")
 
 import numpy as np
-from op_test import OpTest, convert_float_to_uint16, get_current_place
+from op_test import OpTest, convert_float_to_uint16, get_device_place
 
 import paddle
 import paddle.inference as paddle_infer
@@ -611,7 +611,7 @@ class TestTensorAxis(unittest.TestCase):
         paddle.seed(2022)
         self.temp_dir = tempfile.TemporaryDirectory()
         self.save_path = os.path.join(self.temp_dir.name, 'tensor_axis_cumsum')
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def test_dygraph(self):
         paddle.disable_static()

--- a/test/legacy_test/test_cumsum_op.py
+++ b/test/legacy_test/test_cumsum_op.py
@@ -22,7 +22,7 @@ from paddle.framework import use_pir_api
 sys.path.append("../../legacy_test")
 
 import numpy as np
-from op_test import OpTest, convert_float_to_uint16
+from op_test import OpTest, convert_float_to_uint16, get_current_place
 
 import paddle
 import paddle.inference as paddle_infer
@@ -611,11 +611,7 @@ class TestTensorAxis(unittest.TestCase):
         paddle.seed(2022)
         self.temp_dir = tempfile.TemporaryDirectory()
         self.save_path = os.path.join(self.temp_dir.name, 'tensor_axis_cumsum')
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def test_dygraph(self):
         paddle.disable_static()

--- a/test/legacy_test/test_deg2rad.py
+++ b/test/legacy_test/test_deg2rad.py
@@ -15,10 +15,10 @@
 import unittest
 
 import numpy as np
+from op_test import get_current_place
 
 import paddle
 from paddle import base
-from paddle.base import core
 
 paddle.enable_static()
 
@@ -41,11 +41,7 @@ class TestDeg2radAPI(unittest.TestCase):
             )
             out = paddle.deg2rad(x)
 
-            place = (
-                base.CUDAPlace(0)
-                if core.is_compiled_with_cuda()
-                else base.CPUPlace()
-            )
+            place = get_current_place()
             exe = base.Executor(place)
             res = exe.run(
                 feed={'input': self.x_np},

--- a/test/legacy_test/test_deg2rad.py
+++ b/test/legacy_test/test_deg2rad.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import get_current_place
+from op_test import get_device_place
 
 import paddle
 from paddle import base
@@ -41,7 +41,7 @@ class TestDeg2radAPI(unittest.TestCase):
             )
             out = paddle.deg2rad(x)
 
-            place = get_current_place()
+            place = get_device_place()
             exe = base.Executor(place)
             res = exe.run(
                 feed={'input': self.x_np},

--- a/test/legacy_test/test_diagonal_scatter.py
+++ b/test/legacy_test/test_diagonal_scatter.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import convert_float_to_uint16, get_current_place
+from op_test import convert_float_to_uint16, get_device_place
 
 import paddle
 from paddle import base
@@ -143,7 +143,7 @@ class TestDiagonalScatterAPI(unittest.TestCase):
                 x, y, offset=self.offset, axis1=self.axis1, axis2=self.axis2
             )
 
-            place = get_current_place()
+            place = get_device_place()
 
             exe = base.Executor(place)
             result = exe.run(

--- a/test/legacy_test/test_diagonal_scatter.py
+++ b/test/legacy_test/test_diagonal_scatter.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import convert_float_to_uint16
+from op_test import convert_float_to_uint16, get_current_place
 
 import paddle
 from paddle import base
@@ -143,11 +143,7 @@ class TestDiagonalScatterAPI(unittest.TestCase):
                 x, y, offset=self.offset, axis1=self.axis1, axis2=self.axis2
             )
 
-            place = (
-                base.CUDAPlace(0)
-                if core.is_compiled_with_cuda()
-                else base.CPUPlace()
-            )
+            place = get_current_place()
 
             exe = base.Executor(place)
             result = exe.run(

--- a/test/legacy_test/test_dist_op.py
+++ b/test/legacy_test/test_dist_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest
+from op_test import OpTest, get_current_place
 
 import paddle
 from paddle import base
@@ -290,11 +290,7 @@ class TestDistAPI(unittest.TestCase):
             x_i = np.random.random((2, 3, 4, 5)).astype(self.data_type)
             y_i = np.random.random((3, 1, 5)).astype(self.data_type)
             result = paddle.dist(x, y, p)
-            place = (
-                base.CUDAPlace(0)
-                if core.is_compiled_with_cuda()
-                else base.CPUPlace()
-            )
+            place = get_current_place()
             exe = base.Executor(place)
             out = exe.run(
                 main_program,

--- a/test/legacy_test/test_dist_op.py
+++ b/test/legacy_test/test_dist_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, get_current_place
+from op_test import OpTest, get_device_place
 
 import paddle
 from paddle import base
@@ -290,7 +290,7 @@ class TestDistAPI(unittest.TestCase):
             x_i = np.random.random((2, 3, 4, 5)).astype(self.data_type)
             y_i = np.random.random((3, 1, 5)).astype(self.data_type)
             result = paddle.dist(x, y, p)
-            place = get_current_place()
+            place = get_device_place()
             exe = base.Executor(place)
             out = exe.run(
                 main_program,

--- a/test/legacy_test/test_eigh_op.py
+++ b/test/legacy_test/test_eigh_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest
+from op_test import OpTest, get_current_place
 from utils import dygraph_guard, static_guard
 
 import paddle
@@ -158,11 +158,7 @@ class TestEighAPI(unittest.TestCase):
         self.UPLO = 'L'
         self.rtol = 1e-5  # for test_eigh_grad
         self.atol = 1e-5  # for test_eigh_grad
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
         np.random.seed(123)
 
     def init_input_shape(self):
@@ -290,11 +286,7 @@ class TestEighAPIError(unittest.TestCase):
 class TestEighAPIZeroSize(unittest.TestCase):
     def setUp(self):
         self.init_input_data()
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
         self.rtol = 1e-5  # for test_eigh_grad
         self.atol = 1e-5  # for test_eigh_grad
         np.random.seed(123)

--- a/test/legacy_test/test_eigh_op.py
+++ b/test/legacy_test/test_eigh_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, get_current_place
+from op_test import OpTest, get_device_place
 from utils import dygraph_guard, static_guard
 
 import paddle
@@ -158,7 +158,7 @@ class TestEighAPI(unittest.TestCase):
         self.UPLO = 'L'
         self.rtol = 1e-5  # for test_eigh_grad
         self.atol = 1e-5  # for test_eigh_grad
-        self.place = get_current_place()
+        self.place = get_device_place()
         np.random.seed(123)
 
     def init_input_shape(self):
@@ -286,7 +286,7 @@ class TestEighAPIError(unittest.TestCase):
 class TestEighAPIZeroSize(unittest.TestCase):
     def setUp(self):
         self.init_input_data()
-        self.place = get_current_place()
+        self.place = get_device_place()
         self.rtol = 1e-5  # for test_eigh_grad
         self.atol = 1e-5  # for test_eigh_grad
         np.random.seed(123)

--- a/test/legacy_test/test_eigvalsh_op.py
+++ b/test/legacy_test/test_eigvalsh_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, get_current_place
+from op_test import OpTest, get_device_place
 from utils import dygraph_guard, static_guard
 
 import paddle
@@ -128,7 +128,7 @@ class TestEigvalshAPI(unittest.TestCase):
         self.UPLO = 'L'
         self.rtol = 1e-5  # test_eigvalsh_grad
         self.atol = 1e-5  # test_eigvalsh_grad
-        self.place = get_current_place()
+        self.place = get_device_place()
         np.random.seed(123)
         self.init_input_shape()
         self.init_input_data()
@@ -256,7 +256,7 @@ class TestEigvalshAPIError(unittest.TestCase):
 class TestEigvalshAPIZeroSize(unittest.TestCase):
     def setUp(self):
         self.dtype = "float32"
-        self.place = get_current_place()
+        self.place = get_device_place()
         np.random.seed(123)
         self.init_input_shape()
         self.init_input_data()

--- a/test/legacy_test/test_eigvalsh_op.py
+++ b/test/legacy_test/test_eigvalsh_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest
+from op_test import OpTest, get_current_place
 from utils import dygraph_guard, static_guard
 
 import paddle
@@ -128,11 +128,7 @@ class TestEigvalshAPI(unittest.TestCase):
         self.UPLO = 'L'
         self.rtol = 1e-5  # test_eigvalsh_grad
         self.atol = 1e-5  # test_eigvalsh_grad
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
         np.random.seed(123)
         self.init_input_shape()
         self.init_input_data()
@@ -260,11 +256,7 @@ class TestEigvalshAPIError(unittest.TestCase):
 class TestEigvalshAPIZeroSize(unittest.TestCase):
     def setUp(self):
         self.dtype = "float32"
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
         np.random.seed(123)
         self.init_input_shape()
         self.init_input_data()

--- a/test/legacy_test/test_empty_like_op.py
+++ b/test/legacy_test/test_empty_like_op.py
@@ -15,10 +15,9 @@
 import unittest
 
 import numpy as np
-from op_test import convert_uint16_to_float
+from op_test import convert_uint16_to_float, get_current_place
 
 import paddle
-from paddle.base import core
 from paddle.base.data_feeder import convert_dtype
 
 
@@ -182,11 +181,7 @@ class TestEmptyLikeAPI_Static(TestEmptyLikeAPICommon):
 
             out = paddle.empty_like(data_x)
 
-            place = (
-                paddle.CUDAPlace(0)
-                if core.is_compiled_with_cuda()
-                else paddle.CPUPlace()
-            )
+            place = get_current_place()
             exe = paddle.static.Executor(place)
             res = exe.run(train_program, feed={'x': x}, fetch_list=[out])
 

--- a/test/legacy_test/test_empty_like_op.py
+++ b/test/legacy_test/test_empty_like_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import convert_uint16_to_float, get_current_place
+from op_test import convert_uint16_to_float, get_device_place
 
 import paddle
 from paddle.base.data_feeder import convert_dtype
@@ -181,7 +181,7 @@ class TestEmptyLikeAPI_Static(TestEmptyLikeAPICommon):
 
             out = paddle.empty_like(data_x)
 
-            place = get_current_place()
+            place = get_device_place()
             exe = paddle.static.Executor(place)
             res = exe.run(train_program, feed={'x': x}, fetch_list=[out])
 

--- a/test/legacy_test/test_frac_api.py
+++ b/test/legacy_test/test_frac_api.py
@@ -15,10 +15,10 @@
 import unittest
 
 import numpy as np
+from op_test import get_current_place
 
 import paddle
 from paddle import base
-from paddle.base import core
 
 
 def ref_frac(x):
@@ -34,11 +34,7 @@ class TestFracAPI(unittest.TestCase):
     def setUp(self):
         self.set_dtype()
         self.x_np = np.random.uniform(-3, 3, [2, 3]).astype(self.dtype)
-        self.place = (
-            paddle.CUDAPlace(0)
-            if core.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def test_api_static(self):
         paddle.enable_static()
@@ -92,11 +88,7 @@ class TestFracError(unittest.TestCase):
 
     def setUp(self):
         self.x_np = np.random.uniform(-3, 3, [2, 3]).astype('int16')
-        self.place = (
-            paddle.CUDAPlace(0)
-            if core.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def test_static_error(self):
         paddle.enable_static()
@@ -117,11 +109,7 @@ class TestFracAPI_ZeroSize(unittest.TestCase):
     def setUp(self):
         self.set_dtype()
         self.x_np = np.random.random([0, 3]).astype(self.dtype)
-        self.place = (
-            paddle.CUDAPlace(0)
-            if core.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def test_api_dygraph(self):
         paddle.disable_static(self.place)

--- a/test/legacy_test/test_frac_api.py
+++ b/test/legacy_test/test_frac_api.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import get_current_place
+from op_test import get_device_place
 
 import paddle
 from paddle import base
@@ -34,7 +34,7 @@ class TestFracAPI(unittest.TestCase):
     def setUp(self):
         self.set_dtype()
         self.x_np = np.random.uniform(-3, 3, [2, 3]).astype(self.dtype)
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def test_api_static(self):
         paddle.enable_static()
@@ -88,7 +88,7 @@ class TestFracError(unittest.TestCase):
 
     def setUp(self):
         self.x_np = np.random.uniform(-3, 3, [2, 3]).astype('int16')
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def test_static_error(self):
         paddle.enable_static()
@@ -109,7 +109,7 @@ class TestFracAPI_ZeroSize(unittest.TestCase):
     def setUp(self):
         self.set_dtype()
         self.x_np = np.random.random([0, 3]).astype(self.dtype)
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def test_api_dygraph(self):
         paddle.disable_static(self.place)

--- a/test/legacy_test/test_frexp_api.py
+++ b/test/legacy_test/test_frexp_api.py
@@ -14,6 +14,7 @@
 import unittest
 
 import numpy as np
+from op_test import get_current_place
 
 import paddle
 import paddle.base
@@ -24,11 +25,7 @@ class TestFrexpAPI(unittest.TestCase):
         np.random.seed(1024)
         self.rtol = 1e-5
         self.atol = 1e-8
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
         self.set_input()
 
     def set_input(self):
@@ -98,11 +95,7 @@ class TestSplitsFloat64Case2(TestFrexpAPI):
 
 class TestFrexpAPI_ZeroSize(unittest.TestCase):
     def setUp(self):
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
         self.set_input()
 
     def set_input(self):

--- a/test/legacy_test/test_frexp_api.py
+++ b/test/legacy_test/test_frexp_api.py
@@ -14,7 +14,7 @@
 import unittest
 
 import numpy as np
-from op_test import get_current_place
+from op_test import get_device_place
 
 import paddle
 import paddle.base
@@ -25,7 +25,7 @@ class TestFrexpAPI(unittest.TestCase):
         np.random.seed(1024)
         self.rtol = 1e-5
         self.atol = 1e-8
-        self.place = get_current_place()
+        self.place = get_device_place()
         self.set_input()
 
     def set_input(self):
@@ -95,7 +95,7 @@ class TestSplitsFloat64Case2(TestFrexpAPI):
 
 class TestFrexpAPI_ZeroSize(unittest.TestCase):
     def setUp(self):
-        self.place = get_current_place()
+        self.place = get_device_place()
         self.set_input()
 
     def set_input(self):

--- a/test/legacy_test/test_fused_feedforward_op.py
+++ b/test/legacy_test/test_fused_feedforward_op.py
@@ -14,7 +14,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest
+from op_test import OpTest, get_device_place
 
 import paddle
 import paddle.incubate.nn.functional as incubate_f
@@ -279,7 +279,7 @@ class APITestStaticFusedFFN(unittest.TestCase):
                 pre_layer_norm=False,
             )
 
-            exe = paddle.static.Executor(paddle.CUDAPlace(0))
+            exe = paddle.static.Executor(get_device_place())
 
             fetch = exe.run(
                 feed={
@@ -357,7 +357,7 @@ class APITestStaticFusedFFN(unittest.TestCase):
                 bias=ln2_bias,
             )
 
-            exe = paddle.static.Executor(paddle.CUDAPlace(0))
+            exe = paddle.static.Executor(get_device_place())
 
             fetch = exe.run(
                 feed={

--- a/test/legacy_test/test_gammainc.py
+++ b/test/legacy_test/test_gammainc.py
@@ -15,11 +15,10 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest
+from op_test import OpTest, get_current_place
 from scipy import special
 
 import paddle
-from paddle.base import core
 
 
 def ref_gammainc(x, y):
@@ -32,11 +31,7 @@ class TestGammaincApi(unittest.TestCase):
         self.init_dtype_type()
         self.x_np = np.random.random(self.shape).astype(self.dtype) + 1
         self.y_np = np.random.random(self.shape).astype(self.dtype) + 1
-        self.place = (
-            paddle.CUDAPlace(0)
-            if core.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def init_dtype_type(self):
         self.dtype = "float64"

--- a/test/legacy_test/test_gammainc.py
+++ b/test/legacy_test/test_gammainc.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, get_current_place
+from op_test import OpTest, get_device_place
 from scipy import special
 
 import paddle
@@ -31,7 +31,7 @@ class TestGammaincApi(unittest.TestCase):
         self.init_dtype_type()
         self.x_np = np.random.random(self.shape).astype(self.dtype) + 1
         self.y_np = np.random.random(self.shape).astype(self.dtype) + 1
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def init_dtype_type(self):
         self.dtype = "float64"

--- a/test/legacy_test/test_gammaln_op.py
+++ b/test/legacy_test/test_gammaln_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, convert_float_to_uint16
+from op_test import OpTest, convert_float_to_uint16, get_current_place
 from scipy import special
 
 import paddle
@@ -172,11 +172,7 @@ class TestGammalnOpApi(unittest.TestCase):
         self.shape = [2, 3, 4, 5]
         self.init_dtype_type()
         self.x_np = np.random.random(self.shape).astype(self.dtype) + 1
-        self.place = (
-            paddle.CUDAPlace(0)
-            if core.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def init_dtype_type(self):
         self.dtype = "float64"

--- a/test/legacy_test/test_gammaln_op.py
+++ b/test/legacy_test/test_gammaln_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, convert_float_to_uint16, get_current_place
+from op_test import OpTest, convert_float_to_uint16, get_device_place
 from scipy import special
 
 import paddle
@@ -172,7 +172,7 @@ class TestGammalnOpApi(unittest.TestCase):
         self.shape = [2, 3, 4, 5]
         self.init_dtype_type()
         self.x_np = np.random.random(self.shape).astype(self.dtype) + 1
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def init_dtype_type(self):
         self.dtype = "float64"

--- a/test/legacy_test/test_gaussian_nll_loss.py
+++ b/test/legacy_test/test_gaussian_nll_loss.py
@@ -15,10 +15,10 @@
 import unittest
 
 import numpy as np
+from op_test import get_current_place
 
 import paddle
 import paddle.nn.functional as F
-from paddle.base import core
 
 np.random.seed(10)
 
@@ -86,11 +86,7 @@ class TestGaussianNLLLossAPI(unittest.TestCase):
         if type == 'test_err':
             self.variance_np = -np.ones(self.shape).astype(np.float32)
 
-        self.place = (
-            paddle.CUDAPlace(0)
-            if core.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def test_dynamic_case(self, type=None, full=False, reduction='none'):
         self.setUp(type)

--- a/test/legacy_test/test_gaussian_nll_loss.py
+++ b/test/legacy_test/test_gaussian_nll_loss.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import get_current_place
+from op_test import get_device_place
 
 import paddle
 import paddle.nn.functional as F
@@ -86,7 +86,7 @@ class TestGaussianNLLLossAPI(unittest.TestCase):
         if type == 'test_err':
             self.variance_np = -np.ones(self.shape).astype(np.float32)
 
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def test_dynamic_case(self, type=None, full=False, reduction='none'):
         self.setUp(type)

--- a/test/legacy_test/test_gumbel_softmax_op.py
+++ b/test/legacy_test/test_gumbel_softmax_op.py
@@ -13,7 +13,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, get_current_place
+from op_test import OpTest, get_device_place
 
 import paddle
 import paddle.nn.functional as F
@@ -226,7 +226,7 @@ class TestGumbelSoftmaxAPI(unittest.TestCase):
         self.x_shape = [2, 3, 4, 5]
         self.x = np.random.uniform(-1.0, 1.0, self.x_shape).astype(np.float32)
         self.count_expected = 24
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def test_check_api(self):
         # test static api

--- a/test/legacy_test/test_gumbel_softmax_op.py
+++ b/test/legacy_test/test_gumbel_softmax_op.py
@@ -13,7 +13,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest
+from op_test import OpTest, get_current_place
 
 import paddle
 import paddle.nn.functional as F
@@ -226,11 +226,7 @@ class TestGumbelSoftmaxAPI(unittest.TestCase):
         self.x_shape = [2, 3, 4, 5]
         self.x = np.random.uniform(-1.0, 1.0, self.x_shape).astype(np.float32)
         self.count_expected = 24
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.base.core.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def test_check_api(self):
         # test static api

--- a/test/legacy_test/test_histogramdd_op.py
+++ b/test/legacy_test/test_histogramdd_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import get_current_place
+from op_test import get_device_place
 
 import paddle
 
@@ -40,7 +40,7 @@ class TestHistogramddAPI(unittest.TestCase):
 
         self.init_input()
         self.set_expect_output()
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def init_input(self):
         # self.sample = np.array([[0.0, 1.0], [1.0, 0.0], [2.0, 0.0], [2.0, 2.0]])

--- a/test/legacy_test/test_histogramdd_op.py
+++ b/test/legacy_test/test_histogramdd_op.py
@@ -15,6 +15,7 @@
 import unittest
 
 import numpy as np
+from op_test import get_current_place
 
 import paddle
 
@@ -39,11 +40,7 @@ class TestHistogramddAPI(unittest.TestCase):
 
         self.init_input()
         self.set_expect_output()
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def init_input(self):
         # self.sample = np.array([[0.0, 1.0], [1.0, 0.0], [2.0, 0.0], [2.0, 2.0]])

--- a/test/legacy_test/test_hypot.py
+++ b/test/legacy_test/test_hypot.py
@@ -15,10 +15,10 @@
 import unittest
 
 import numpy as np
+from op_test import get_current_place
 
 import paddle
 from paddle import base
-from paddle.base import core
 
 paddle.enable_static()
 
@@ -43,11 +43,7 @@ class TestHypotAPI(unittest.TestCase):
             )
             out = paddle.hypot(x, y)
 
-            place = (
-                base.CUDAPlace(0)
-                if core.is_compiled_with_cuda()
-                else base.CPUPlace()
-            )
+            place = get_current_place()
             exe = base.Executor(place)
             res = exe.run(
                 base.default_main_program(),

--- a/test/legacy_test/test_hypot.py
+++ b/test/legacy_test/test_hypot.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import get_current_place
+from op_test import get_device_place
 
 import paddle
 from paddle import base
@@ -43,7 +43,7 @@ class TestHypotAPI(unittest.TestCase):
             )
             out = paddle.hypot(x, y)
 
-            place = get_current_place()
+            place = get_device_place()
             exe = base.Executor(place)
             res = exe.run(
                 base.default_main_program(),

--- a/test/legacy_test/test_imperative_container_parameterdict.py
+++ b/test/legacy_test/test_imperative_container_parameterdict.py
@@ -16,6 +16,7 @@ import unittest
 from collections import OrderedDict
 
 import numpy as np
+from op_test import get_current_place
 
 import paddle
 from paddle import base
@@ -46,11 +47,7 @@ class MyLayer(paddle.nn.Layer):
 
 class TestImperativeContainerParameterDict(unittest.TestCase):
     def parameter_dict(self):
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
         data_np = np.random.uniform(-1, 1, [5, 2]).astype('float32')
         with base.dygraph.guard():
             x = paddle.to_tensor(data_np)

--- a/test/legacy_test/test_imperative_container_parameterdict.py
+++ b/test/legacy_test/test_imperative_container_parameterdict.py
@@ -16,7 +16,7 @@ import unittest
 from collections import OrderedDict
 
 import numpy as np
-from op_test import get_current_place
+from op_test import get_device_place
 
 import paddle
 from paddle import base
@@ -47,7 +47,7 @@ class MyLayer(paddle.nn.Layer):
 
 class TestImperativeContainerParameterDict(unittest.TestCase):
     def parameter_dict(self):
-        self.place = get_current_place()
+        self.place = get_device_place()
         data_np = np.random.uniform(-1, 1, [5, 2]).astype('float32')
         with base.dygraph.guard():
             x = paddle.to_tensor(data_np)

--- a/test/legacy_test/test_imperative_data_parallel.py
+++ b/test/legacy_test/test_imperative_data_parallel.py
@@ -15,10 +15,10 @@
 import unittest
 
 import numpy as np
+from op_test import get_current_place
 
 import paddle
 from paddle import base
-from paddle.base import core
 from paddle.nn import Linear
 
 
@@ -46,11 +46,7 @@ class TestDataParallelStateDict(unittest.TestCase):
             parallel_state = parallel_mlp.state_dict()
 
             base_para = {}
-            place = (
-                base.CPUPlace()
-                if not core.is_compiled_with_cuda()
-                else base.CUDAPlace(0)
-            )
+            place = get_current_place()
             for k, v in single_state.items():
                 self.assertTrue(k in parallel_state)
 

--- a/test/legacy_test/test_imperative_data_parallel.py
+++ b/test/legacy_test/test_imperative_data_parallel.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import get_current_place
+from op_test import get_device_place
 
 import paddle
 from paddle import base
@@ -46,7 +46,7 @@ class TestDataParallelStateDict(unittest.TestCase):
             parallel_state = parallel_mlp.state_dict()
 
             base_para = {}
-            place = get_current_place()
+            place = get_device_place()
             for k, v in single_state.items():
                 self.assertTrue(k in parallel_state)
 

--- a/test/legacy_test/test_imperative_optimizer.py
+++ b/test/legacy_test/test_imperative_optimizer.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import get_current_place
+from op_test import get_device_place
 from test_imperative_base import new_program_scope
 
 import paddle
@@ -63,7 +63,7 @@ class TestImperativeOptimizerBase(unittest.TestCase):
         seed = 90
         batch_size = 128
         if place is None:
-            place = get_current_place()
+            place = get_device_place()
 
         with base.dygraph.guard(place):
             try:
@@ -81,7 +81,7 @@ class TestImperativeOptimizerBase(unittest.TestCase):
         batch_size = 128
 
         if place is None:
-            place = get_current_place()
+            place = get_device_place()
 
         with base.dygraph.guard(place):
             paddle.seed(seed)
@@ -132,7 +132,7 @@ class TestImperativeOptimizerBase(unittest.TestCase):
             paddle.framework.random._manual_program_seed(seed)
 
             if place is None:
-                place = get_current_place()
+                place = get_device_place()
 
             exe = base.Executor(place)
 

--- a/test/legacy_test/test_imperative_optimizer.py
+++ b/test/legacy_test/test_imperative_optimizer.py
@@ -15,6 +15,7 @@
 import unittest
 
 import numpy as np
+from op_test import get_current_place
 from test_imperative_base import new_program_scope
 
 import paddle
@@ -62,11 +63,7 @@ class TestImperativeOptimizerBase(unittest.TestCase):
         seed = 90
         batch_size = 128
         if place is None:
-            place = (
-                base.CUDAPlace(0)
-                if core.is_compiled_with_cuda()
-                else base.CPUPlace()
-            )
+            place = get_current_place()
 
         with base.dygraph.guard(place):
             try:
@@ -84,11 +81,7 @@ class TestImperativeOptimizerBase(unittest.TestCase):
         batch_size = 128
 
         if place is None:
-            place = (
-                base.CPUPlace()
-                if not core.is_compiled_with_cuda()
-                else base.CUDAPlace(0)
-            )
+            place = get_current_place()
 
         with base.dygraph.guard(place):
             paddle.seed(seed)
@@ -139,11 +132,7 @@ class TestImperativeOptimizerBase(unittest.TestCase):
             paddle.framework.random._manual_program_seed(seed)
 
             if place is None:
-                place = (
-                    base.CPUPlace()
-                    if not core.is_compiled_with_cuda()
-                    else base.CUDAPlace(0)
-                )
+                place = get_current_place()
 
             exe = base.Executor(place)
 

--- a/test/legacy_test/test_imperative_optimizer_v2.py
+++ b/test/legacy_test/test_imperative_optimizer_v2.py
@@ -16,6 +16,7 @@ import itertools
 import unittest
 
 import numpy as np
+from op_test import get_current_place
 from test_imperative_base import new_program_scope
 
 import paddle
@@ -88,11 +89,7 @@ class TestImperativeOptimizerBase(unittest.TestCase):
         seed = 90
         batch_size = 128
         if place is None:
-            place = (
-                base.CUDAPlace(0)
-                if core.is_compiled_with_cuda()
-                else base.CPUPlace()
-            )
+            place = get_current_place()
 
         try:
             paddle.disable_static()
@@ -118,11 +115,7 @@ class TestImperativeOptimizerBase(unittest.TestCase):
         batch_size = 128
 
         if place is None:
-            place = (
-                base.CPUPlace()
-                if not core.is_compiled_with_cuda()
-                else base.CUDAPlace(0)
-            )
+            place = get_current_place()
 
         paddle.disable_static(place)
         paddle.seed(seed)
@@ -195,11 +188,7 @@ class TestImperativeOptimizerBase(unittest.TestCase):
                 paddle.framework.random._manual_program_seed(seed)
 
             if place is None:
-                place = (
-                    base.CPUPlace()
-                    if not core.is_compiled_with_cuda()
-                    else base.CUDAPlace(0)
-                )
+                place = get_current_place()
 
             exe = base.Executor(place)
 

--- a/test/legacy_test/test_imperative_optimizer_v2.py
+++ b/test/legacy_test/test_imperative_optimizer_v2.py
@@ -16,7 +16,7 @@ import itertools
 import unittest
 
 import numpy as np
-from op_test import get_current_place
+from op_test import get_device_place
 from test_imperative_base import new_program_scope
 
 import paddle
@@ -89,7 +89,7 @@ class TestImperativeOptimizerBase(unittest.TestCase):
         seed = 90
         batch_size = 128
         if place is None:
-            place = get_current_place()
+            place = get_device_place()
 
         try:
             paddle.disable_static()
@@ -115,7 +115,7 @@ class TestImperativeOptimizerBase(unittest.TestCase):
         batch_size = 128
 
         if place is None:
-            place = get_current_place()
+            place = get_device_place()
 
         paddle.disable_static(place)
         paddle.seed(seed)
@@ -188,7 +188,7 @@ class TestImperativeOptimizerBase(unittest.TestCase):
                 paddle.framework.random._manual_program_seed(seed)
 
             if place is None:
-                place = get_current_place()
+                place = get_device_place()
 
             exe = base.Executor(place)
 

--- a/test/legacy_test/test_imperative_save_load_v2.py
+++ b/test/legacy_test/test_imperative_save_load_v2.py
@@ -17,7 +17,7 @@ import tempfile
 import unittest
 
 import numpy as np
-from op_test import get_current_place
+from op_test import get_device_place
 
 import paddle
 from paddle import base
@@ -271,7 +271,7 @@ class TestDygraphPtbRnn(unittest.TestCase):
                 new_lr = 1.0
                 lr_arr.append(new_lr)
 
-            place = get_current_place()
+            place = get_device_place()
             scheduler = paddle.optimizer.lr.PiecewiseDecay(
                 boundaries=bd, values=lr_arr
             )
@@ -370,7 +370,7 @@ class TestDygraphPtbRnn(unittest.TestCase):
                 new_lr = 1.0
                 lr_arr.append(new_lr)
 
-            place = get_current_place()
+            place = get_device_place()
             scheduler = paddle.optimizer.lr.PiecewiseDecay(
                 boundaries=bd, values=lr_arr
             )
@@ -488,7 +488,7 @@ class TestDygraphPtbRnn(unittest.TestCase):
                 new_lr = 1.0
                 lr_arr.append(new_lr)
 
-            place = get_current_place()
+            place = get_device_place()
             scheduler = paddle.optimizer.lr.PiecewiseDecay(
                 boundaries=bd, values=lr_arr
             )
@@ -602,7 +602,7 @@ class TestDygraphPtbRnn(unittest.TestCase):
                 new_lr = 1.0
                 lr_arr.append(new_lr)
 
-            place = get_current_place()
+            place = get_device_place()
             scheduler = paddle.optimizer.lr.PiecewiseDecay(
                 boundaries=bd, values=lr_arr
             )
@@ -714,7 +714,7 @@ class TestDygraphPtbRnn(unittest.TestCase):
                 init_scale=init_scale,
             )
 
-            place = get_current_place()
+            place = get_device_place()
             adam = Adam(
                 learning_rate=0.0,
                 beta1=0.8,
@@ -807,7 +807,7 @@ class TestDygraphPtbRnn(unittest.TestCase):
                 new_lr = 0.0
                 lr_arr.append(new_lr)
 
-            place = get_current_place()
+            place = get_device_place()
             adam = Adam(
                 learning_rate=0.0,
                 beta1=0.8,
@@ -905,7 +905,7 @@ class TestDygraphPtbRnn(unittest.TestCase):
                 new_lr = 0.0
                 lr_arr.append(new_lr)
 
-            place = get_current_place()
+            place = get_device_place()
             scheduler = paddle.optimizer.lr.PiecewiseDecay(
                 boundaries=bd, values=lr_arr
             )

--- a/test/legacy_test/test_imperative_save_load_v2.py
+++ b/test/legacy_test/test_imperative_save_load_v2.py
@@ -17,6 +17,7 @@ import tempfile
 import unittest
 
 import numpy as np
+from op_test import get_current_place
 
 import paddle
 from paddle import base
@@ -270,11 +271,7 @@ class TestDygraphPtbRnn(unittest.TestCase):
                 new_lr = 1.0
                 lr_arr.append(new_lr)
 
-            place = (
-                base.CPUPlace()
-                if not core.is_compiled_with_cuda()
-                else base.CUDAPlace(0)
-            )
+            place = get_current_place()
             scheduler = paddle.optimizer.lr.PiecewiseDecay(
                 boundaries=bd, values=lr_arr
             )
@@ -373,11 +370,7 @@ class TestDygraphPtbRnn(unittest.TestCase):
                 new_lr = 1.0
                 lr_arr.append(new_lr)
 
-            place = (
-                base.CPUPlace()
-                if not core.is_compiled_with_cuda()
-                else base.CUDAPlace(0)
-            )
+            place = get_current_place()
             scheduler = paddle.optimizer.lr.PiecewiseDecay(
                 boundaries=bd, values=lr_arr
             )
@@ -495,11 +488,7 @@ class TestDygraphPtbRnn(unittest.TestCase):
                 new_lr = 1.0
                 lr_arr.append(new_lr)
 
-            place = (
-                base.CPUPlace()
-                if not core.is_compiled_with_cuda()
-                else base.CUDAPlace(0)
-            )
+            place = get_current_place()
             scheduler = paddle.optimizer.lr.PiecewiseDecay(
                 boundaries=bd, values=lr_arr
             )
@@ -613,11 +602,7 @@ class TestDygraphPtbRnn(unittest.TestCase):
                 new_lr = 1.0
                 lr_arr.append(new_lr)
 
-            place = (
-                base.CPUPlace()
-                if not core.is_compiled_with_cuda()
-                else base.CUDAPlace(0)
-            )
+            place = get_current_place()
             scheduler = paddle.optimizer.lr.PiecewiseDecay(
                 boundaries=bd, values=lr_arr
             )
@@ -729,11 +714,7 @@ class TestDygraphPtbRnn(unittest.TestCase):
                 init_scale=init_scale,
             )
 
-            place = (
-                base.CPUPlace()
-                if not core.is_compiled_with_cuda()
-                else base.CUDAPlace(0)
-            )
+            place = get_current_place()
             adam = Adam(
                 learning_rate=0.0,
                 beta1=0.8,
@@ -826,11 +807,7 @@ class TestDygraphPtbRnn(unittest.TestCase):
                 new_lr = 0.0
                 lr_arr.append(new_lr)
 
-            place = (
-                base.CPUPlace()
-                if not core.is_compiled_with_cuda()
-                else base.CUDAPlace(0)
-            )
+            place = get_current_place()
             adam = Adam(
                 learning_rate=0.0,
                 beta1=0.8,
@@ -928,11 +905,7 @@ class TestDygraphPtbRnn(unittest.TestCase):
                 new_lr = 0.0
                 lr_arr.append(new_lr)
 
-            place = (
-                base.CPUPlace()
-                if not core.is_compiled_with_cuda()
-                else base.CUDAPlace(0)
-            )
+            place = get_current_place()
             scheduler = paddle.optimizer.lr.PiecewiseDecay(
                 boundaries=bd, values=lr_arr
             )

--- a/test/legacy_test/test_inner.py
+++ b/test/legacy_test/test_inner.py
@@ -15,6 +15,7 @@
 import unittest
 
 import numpy as np
+from op_test import get_current_place
 
 import paddle
 
@@ -33,11 +34,7 @@ class TestMultiplyApi(unittest.TestCase):
             )
             res = paddle.inner(x, y)
 
-            place = (
-                paddle.CUDAPlace(0)
-                if paddle.is_compiled_with_cuda()
-                else paddle.CPUPlace()
-            )
+            place = get_current_place()
             exe = paddle.static.Executor(place)
             outs = exe.run(
                 paddle.static.default_main_program(),

--- a/test/legacy_test/test_inner.py
+++ b/test/legacy_test/test_inner.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import get_current_place
+from op_test import get_device_place
 
 import paddle
 
@@ -34,7 +34,7 @@ class TestMultiplyApi(unittest.TestCase):
             )
             res = paddle.inner(x, y)
 
-            place = get_current_place()
+            place = get_device_place()
             exe = paddle.static.Executor(place)
             outs = exe.run(
                 paddle.static.default_main_program(),

--- a/test/legacy_test/test_linear.py
+++ b/test/legacy_test/test_linear.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import get_current_place, get_places
+from op_test import get_device_place, get_places
 
 import paddle
 import paddle.nn.functional as F
@@ -28,7 +28,7 @@ class LinearTestCase(unittest.TestCase):
         self.input = np.ones((3, 1, 2)).astype(self.dtype)
         self.weight = np.ones((2, 2)).astype(self.dtype)
         self.bias = np.ones(2).astype(self.dtype)
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def functional(self, place):
         paddle.disable_static(place)

--- a/test/legacy_test/test_linear.py
+++ b/test/legacy_test/test_linear.py
@@ -15,12 +15,11 @@
 import unittest
 
 import numpy as np
-from op_test import get_places
+from op_test import get_current_place, get_places
 
 import paddle
 import paddle.nn.functional as F
 from paddle import base
-from paddle.base import core
 
 
 class LinearTestCase(unittest.TestCase):
@@ -29,11 +28,7 @@ class LinearTestCase(unittest.TestCase):
         self.input = np.ones((3, 1, 2)).astype(self.dtype)
         self.weight = np.ones((2, 2)).astype(self.dtype)
         self.bias = np.ones(2).astype(self.dtype)
-        self.place = (
-            paddle.CUDAPlace(0)
-            if core.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def functional(self, place):
         paddle.disable_static(place)

--- a/test/legacy_test/test_load_state_dict_from_old_format.py
+++ b/test/legacy_test/test_load_state_dict_from_old_format.py
@@ -20,7 +20,7 @@ import unittest
 sys.path.append("../../legacy_test")
 import nets
 import numpy as np
-from op_test import get_current_place
+from op_test import get_device_place
 from test_imperative_base import new_program_scope
 
 import paddle
@@ -165,7 +165,7 @@ class TestLoadStateDictFromSaveInferenceModel(unittest.TestCase):
 
             prediction, avg_loss = static_train_net(img, label)
 
-            place = get_current_place()
+            place = get_device_place()
 
             exe = base.Executor(place)
 

--- a/test/legacy_test/test_load_state_dict_from_old_format.py
+++ b/test/legacy_test/test_load_state_dict_from_old_format.py
@@ -20,11 +20,11 @@ import unittest
 sys.path.append("../../legacy_test")
 import nets
 import numpy as np
+from op_test import get_current_place
 from test_imperative_base import new_program_scope
 
 import paddle
 from paddle import base
-from paddle.base import core
 from paddle.framework import in_pir_mode
 
 
@@ -165,11 +165,7 @@ class TestLoadStateDictFromSaveInferenceModel(unittest.TestCase):
 
             prediction, avg_loss = static_train_net(img, label)
 
-            place = (
-                base.CUDAPlace(0)
-                if core.is_compiled_with_cuda()
-                else base.CPUPlace()
-            )
+            place = get_current_place()
 
             exe = base.Executor(place)
 

--- a/test/legacy_test/test_log_normal.py
+++ b/test/legacy_test/test_log_normal.py
@@ -15,6 +15,7 @@
 import unittest
 
 import numpy as np
+from op_test import get_current_place
 
 import paddle
 
@@ -41,11 +42,7 @@ class TestLogNormalAPI(unittest.TestCase):
         self.duplicates = 1000
         self.set_attrs()
         self.dtype = self.get_dtype()
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.base.core.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def set_attrs(self):
         self.shape = [self.duplicates]

--- a/test/legacy_test/test_log_normal.py
+++ b/test/legacy_test/test_log_normal.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import get_current_place
+from op_test import get_device_place
 
 import paddle
 
@@ -42,7 +42,7 @@ class TestLogNormalAPI(unittest.TestCase):
         self.duplicates = 1000
         self.set_attrs()
         self.dtype = self.get_dtype()
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def set_attrs(self):
         self.shape = [self.duplicates]

--- a/test/legacy_test/test_log_softmax.py
+++ b/test/legacy_test/test_log_softmax.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, convert_float_to_uint16, get_current_place
+from op_test import OpTest, convert_float_to_uint16, get_device_place
 
 import paddle
 import paddle.nn.functional as F
@@ -174,7 +174,7 @@ class TestNNLogSoftmaxAPI(unittest.TestCase):
     def setUp(self):
         self.x_shape = [2, 3, 4, 5]
         self.x = np.random.uniform(-1.0, 1.0, self.x_shape).astype(np.float32)
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def check_api(self, axis=-1):
         ref_out = np.apply_along_axis(ref_log_softmax, axis, self.x)
@@ -204,7 +204,7 @@ class TestNNFunctionalLogSoftmaxAPI(unittest.TestCase):
     def setUp(self):
         self.x_shape = [2, 3, 4, 5]
         self.x = np.random.uniform(-1, 1, self.x_shape).astype(np.float32)
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def check_api(self, axis=-1, dtype=None):
         x = self.x.copy()

--- a/test/legacy_test/test_log_softmax.py
+++ b/test/legacy_test/test_log_softmax.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, convert_float_to_uint16
+from op_test import OpTest, convert_float_to_uint16, get_current_place
 
 import paddle
 import paddle.nn.functional as F
@@ -174,11 +174,7 @@ class TestNNLogSoftmaxAPI(unittest.TestCase):
     def setUp(self):
         self.x_shape = [2, 3, 4, 5]
         self.x = np.random.uniform(-1.0, 1.0, self.x_shape).astype(np.float32)
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.base.core.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def check_api(self, axis=-1):
         ref_out = np.apply_along_axis(ref_log_softmax, axis, self.x)
@@ -208,11 +204,7 @@ class TestNNFunctionalLogSoftmaxAPI(unittest.TestCase):
     def setUp(self):
         self.x_shape = [2, 3, 4, 5]
         self.x = np.random.uniform(-1, 1, self.x_shape).astype(np.float32)
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.base.core.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def check_api(self, axis=-1, dtype=None):
         x = self.x.copy()

--- a/test/legacy_test/test_logaddexp.py
+++ b/test/legacy_test/test_logaddexp.py
@@ -15,6 +15,7 @@
 import unittest
 
 import numpy as np
+from op_test import get_current_place
 
 import paddle
 
@@ -31,11 +32,7 @@ def ref_logaddexp(x, y):
 
 class TestLogsumexpAPI(unittest.TestCase):
     def setUp(self):
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.base.core.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def api_case(self):
         self.x = np.random.uniform(-1, 1, self.xshape).astype(self.dtype)
@@ -81,11 +78,7 @@ class TestLogsumexpAPI(unittest.TestCase):
 
 class TestLogsumexpAPI_ZeroSize(unittest.TestCase):
     def setUp(self):
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.base.core.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def api_case(self):
         self.x = np.random.uniform(-1, 1, self.xshape).astype(self.dtype)

--- a/test/legacy_test/test_logaddexp.py
+++ b/test/legacy_test/test_logaddexp.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import get_current_place
+from op_test import get_device_place
 
 import paddle
 
@@ -32,7 +32,7 @@ def ref_logaddexp(x, y):
 
 class TestLogsumexpAPI(unittest.TestCase):
     def setUp(self):
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def api_case(self):
         self.x = np.random.uniform(-1, 1, self.xshape).astype(self.dtype)
@@ -78,7 +78,7 @@ class TestLogsumexpAPI(unittest.TestCase):
 
 class TestLogsumexpAPI_ZeroSize(unittest.TestCase):
     def setUp(self):
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def api_case(self):
         self.x = np.random.uniform(-1, 1, self.xshape).astype(self.dtype)

--- a/test/legacy_test/test_logit_op.py
+++ b/test/legacy_test/test_logit_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, convert_float_to_uint16, get_current_place
+from op_test import OpTest, convert_float_to_uint16, get_device_place
 
 import paddle
 from paddle.base import core
@@ -183,7 +183,7 @@ class TestLogitAPI(unittest.TestCase):
     def setUp(self):
         self.init_data()
         self.x = np.random.uniform(-1.0, 1.0, self.x_shape).astype(self.x_dtype)
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def check_api(self, eps=1e-8):
         ref_out = logit(self.x, eps)

--- a/test/legacy_test/test_logit_op.py
+++ b/test/legacy_test/test_logit_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, convert_float_to_uint16
+from op_test import OpTest, convert_float_to_uint16, get_current_place
 
 import paddle
 from paddle.base import core
@@ -183,11 +183,7 @@ class TestLogitAPI(unittest.TestCase):
     def setUp(self):
         self.init_data()
         self.x = np.random.uniform(-1.0, 1.0, self.x_shape).astype(self.x_dtype)
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.base.core.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def check_api(self, eps=1e-8):
         ref_out = logit(self.x, eps)

--- a/test/legacy_test/test_logsumexp.py
+++ b/test/legacy_test/test_logsumexp.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, convert_float_to_uint16, get_current_place
+from op_test import OpTest, convert_float_to_uint16, get_device_place
 
 import paddle
 from paddle.base import core
@@ -257,7 +257,7 @@ class TestLogsumexpAPI(unittest.TestCase):
     def setUp(self):
         self.shape = [2, 3, 4, 5]
         self.x = np.random.uniform(-1, 1, self.shape).astype(np.float32)
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def api_case(self, axis=None, keepdim=False):
         out_ref = ref_logsumexp(self.x, axis, keepdim)

--- a/test/legacy_test/test_logsumexp.py
+++ b/test/legacy_test/test_logsumexp.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, convert_float_to_uint16
+from op_test import OpTest, convert_float_to_uint16, get_current_place
 
 import paddle
 from paddle.base import core
@@ -257,11 +257,7 @@ class TestLogsumexpAPI(unittest.TestCase):
     def setUp(self):
         self.shape = [2, 3, 4, 5]
         self.x = np.random.uniform(-1, 1, self.shape).astype(np.float32)
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.base.core.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def api_case(self, axis=None, keepdim=False):
         out_ref = ref_logsumexp(self.x, axis, keepdim)

--- a/test/legacy_test/test_masked_fill.py
+++ b/test/legacy_test/test_masked_fill.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import convert_float_to_uint16, get_current_place, get_places
+from op_test import convert_float_to_uint16, get_device_place, get_places
 
 import paddle
 from paddle import base
@@ -71,7 +71,7 @@ class TestMaskedFillAPI(unittest.TestCase):
             )
             out = paddle.masked_fill(x, mask, value)
 
-            place = get_current_place()
+            place = get_device_place()
             exe = base.Executor(place)
             res = exe.run(
                 base.default_main_program(),

--- a/test/legacy_test/test_masked_fill.py
+++ b/test/legacy_test/test_masked_fill.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import convert_float_to_uint16, get_places
+from op_test import convert_float_to_uint16, get_current_place, get_places
 
 import paddle
 from paddle import base
@@ -71,11 +71,7 @@ class TestMaskedFillAPI(unittest.TestCase):
             )
             out = paddle.masked_fill(x, mask, value)
 
-            place = (
-                base.CUDAPlace(0)
-                if core.is_compiled_with_cuda()
-                else base.CPUPlace()
-            )
+            place = get_current_place()
             exe = base.Executor(place)
             res = exe.run(
                 base.default_main_program(),

--- a/test/legacy_test/test_masked_scatter.py
+++ b/test/legacy_test/test_masked_scatter.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import convert_float_to_uint16, get_current_place, get_places
+from op_test import convert_float_to_uint16, get_device_place, get_places
 
 import paddle
 from paddle import base
@@ -108,7 +108,7 @@ class TestMaskedScatterAPI(unittest.TestCase):
             )
             out = paddle.masked_scatter(x, mask, value)
 
-            place = get_current_place()
+            place = get_device_place()
             exe = base.Executor(place)
             res = exe.run(
                 base.default_main_program(),

--- a/test/legacy_test/test_masked_scatter.py
+++ b/test/legacy_test/test_masked_scatter.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import convert_float_to_uint16, get_places
+from op_test import convert_float_to_uint16, get_current_place, get_places
 
 import paddle
 from paddle import base
@@ -108,11 +108,7 @@ class TestMaskedScatterAPI(unittest.TestCase):
             )
             out = paddle.masked_scatter(x, mask, value)
 
-            place = (
-                base.CUDAPlace(0)
-                if core.is_compiled_with_cuda()
-                else base.CPUPlace()
-            )
+            place = get_current_place()
             exe = base.Executor(place)
             res = exe.run(
                 base.default_main_program(),

--- a/test/legacy_test/test_math_op_patch.py
+++ b/test/legacy_test/test_math_op_patch.py
@@ -16,6 +16,7 @@ import unittest
 
 import numpy as np
 from decorator_helper import prog_scope
+from op_test import get_current_place
 from utils import dygraph_guard
 
 import paddle
@@ -338,11 +339,7 @@ class TestMathOpPatches(unittest.TestCase):
 
     @prog_scope()
     def test_ror(self):
-        place = (
-            paddle.CUDAPlace(0)
-            if paddle.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        place = get_current_place()
         x_int = 5
         y_np = np.random.randint(-100, 100, [2, 3, 5]).astype("int32")
         y = paddle.static.data("y", y_np.shape, dtype=y_np.dtype)
@@ -392,11 +389,7 @@ class TestMathOpPatches(unittest.TestCase):
 
     @prog_scope()
     def test_rxor(self):
-        place = (
-            paddle.CUDAPlace(0)
-            if paddle.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        place = get_current_place()
         x_int = 5
         y_np = np.random.randint(-100, 100, [2, 3, 5]).astype("int32")
         y = paddle.static.data("y", y_np.shape, dtype=y_np.dtype)

--- a/test/legacy_test/test_math_op_patch.py
+++ b/test/legacy_test/test_math_op_patch.py
@@ -16,7 +16,7 @@ import unittest
 
 import numpy as np
 from decorator_helper import prog_scope
-from op_test import get_current_place
+from op_test import get_device_place
 from utils import dygraph_guard
 
 import paddle
@@ -339,7 +339,7 @@ class TestMathOpPatches(unittest.TestCase):
 
     @prog_scope()
     def test_ror(self):
-        place = get_current_place()
+        place = get_device_place()
         x_int = 5
         y_np = np.random.randint(-100, 100, [2, 3, 5]).astype("int32")
         y = paddle.static.data("y", y_np.shape, dtype=y_np.dtype)
@@ -389,7 +389,7 @@ class TestMathOpPatches(unittest.TestCase):
 
     @prog_scope()
     def test_rxor(self):
-        place = get_current_place()
+        place = get_device_place()
         x_int = 5
         y_np = np.random.randint(-100, 100, [2, 3, 5]).astype("int32")
         y = paddle.static.data("y", y_np.shape, dtype=y_np.dtype)

--- a/test/legacy_test/test_max_min_amax_amin_op.py
+++ b/test/legacy_test/test_max_min_amax_amin_op.py
@@ -15,10 +15,10 @@
 import unittest
 
 import numpy as np
+from op_test import get_current_place
 
 import paddle
 from paddle import base
-from paddle.base import core
 
 paddle.enable_static()
 
@@ -27,11 +27,7 @@ class TestMaxMinAmaxAminAPI(unittest.TestCase):
     def setUp(self):
         self.init_case()
         self.cal_np_out_and_gradient()
-        self.place = (
-            base.CUDAPlace(0)
-            if core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def init_case(self):
         self.x_np = np.array([[0.2, 0.3, 0.5, 0.9], [0.1, 0.2, 0.6, 0.7]])

--- a/test/legacy_test/test_max_min_amax_amin_op.py
+++ b/test/legacy_test/test_max_min_amax_amin_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import get_current_place
+from op_test import get_device_place
 
 import paddle
 from paddle import base
@@ -27,7 +27,7 @@ class TestMaxMinAmaxAminAPI(unittest.TestCase):
     def setUp(self):
         self.init_case()
         self.cal_np_out_and_gradient()
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def init_case(self):
         self.x_np = np.array([[0.2, 0.3, 0.5, 0.9], [0.1, 0.2, 0.6, 0.7]])

--- a/test/legacy_test/test_maxout_op.py
+++ b/test/legacy_test/test_maxout_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, get_current_place
+from op_test import OpTest, get_device_place
 
 import paddle
 import paddle.nn.functional as F
@@ -94,7 +94,7 @@ class TestMaxoutAPI(unittest.TestCase):
         self.x_np = np.random.uniform(-1, 1, [2, 6, 5, 4]).astype(np.float64)
         self.groups = 2
         self.axis = 1
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def test_static_api(self):
         with paddle.static.program_guard(paddle.static.Program()):

--- a/test/legacy_test/test_maxout_op.py
+++ b/test/legacy_test/test_maxout_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest
+from op_test import OpTest, get_current_place
 
 import paddle
 import paddle.nn.functional as F
@@ -94,11 +94,7 @@ class TestMaxoutAPI(unittest.TestCase):
         self.x_np = np.random.uniform(-1, 1, [2, 6, 5, 4]).astype(np.float64)
         self.groups = 2
         self.axis = 1
-        self.place = (
-            paddle.CUDAPlace(0)
-            if core.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def test_static_api(self):
         with paddle.static.program_guard(paddle.static.Program()):

--- a/test/legacy_test/test_model.py
+++ b/test/legacy_test/test_model.py
@@ -18,6 +18,7 @@ import tempfile
 import unittest
 
 import numpy as np
+from op_test import get_current_place
 
 import paddle
 from paddle import Model, base, jit, to_tensor
@@ -860,11 +861,7 @@ class TestModelFunction(unittest.TestCase):
             ori_results = model.predict_batch(tensor_img)
             base.disable_dygraph() if dynamic else None
 
-            place = (
-                base.CPUPlace()
-                if not base.is_compiled_with_cuda()
-                else base.CUDAPlace(0)
-            )
+            place = get_current_place()
             new_scope = base.Scope()
             with base.scope_guard(new_scope):
                 exe = base.Executor(place)

--- a/test/legacy_test/test_model.py
+++ b/test/legacy_test/test_model.py
@@ -18,7 +18,7 @@ import tempfile
 import unittest
 
 import numpy as np
-from op_test import get_current_place
+from op_test import get_device_place
 
 import paddle
 from paddle import Model, base, jit, to_tensor
@@ -861,7 +861,7 @@ class TestModelFunction(unittest.TestCase):
             ori_results = model.predict_batch(tensor_img)
             base.disable_dygraph() if dynamic else None
 
-            place = get_current_place()
+            place = get_device_place()
             new_scope = base.Scope()
             with base.scope_guard(new_scope):
                 exe = base.Executor(place)

--- a/test/legacy_test/test_mse_loss.py
+++ b/test/legacy_test/test_mse_loss.py
@@ -15,6 +15,7 @@
 import unittest
 
 import numpy as np
+from op_test import get_current_place
 from utils import dygraph_guard
 
 import paddle
@@ -98,11 +99,7 @@ class TestNNMseLoss(unittest.TestCase):
             paddle.enable_static()
             prog = base.Program()
             startup_prog = base.Program()
-            place = (
-                base.CUDAPlace(0)
-                if base.core.is_compiled_with_cuda()
-                else base.CPUPlace()
-            )
+            place = get_current_place()
             with base.program_guard(prog, startup_prog):
                 input = paddle.static.data(
                     name='input', shape=dim, dtype='float32'
@@ -142,11 +139,7 @@ class TestNNMseLoss(unittest.TestCase):
             paddle.enable_static()
             prog = base.Program()
             startup_prog = base.Program()
-            place = (
-                base.CUDAPlace(0)
-                if base.core.is_compiled_with_cuda()
-                else base.CPUPlace()
-            )
+            place = get_current_place()
             with base.program_guard(prog, startup_prog):
                 input = paddle.static.data(
                     name='input', shape=dim, dtype='float32'
@@ -186,11 +179,7 @@ class TestNNMseLoss(unittest.TestCase):
             paddle.enable_static()
             prog = base.Program()
             startup_prog = base.Program()
-            place = (
-                base.CUDAPlace(0)
-                if base.core.is_compiled_with_cuda()
-                else base.CPUPlace()
-            )
+            place = get_current_place()
             with base.program_guard(prog, startup_prog):
                 input = paddle.static.data(
                     name='input', shape=dim, dtype='float32'
@@ -233,11 +222,7 @@ class TestNNFunctionalMseLoss(unittest.TestCase):
             paddle.enable_static()
             prog = paddle.static.Program()
             startup_prog = paddle.static.Program()
-            place = (
-                paddle.CUDAPlace(0)
-                if core.is_compiled_with_cuda()
-                else paddle.CPUPlace()
-            )
+            place = get_current_place()
             with paddle.static.program_guard(prog, startup_prog):
                 input = paddle.static.data(
                     name='input', shape=dim, dtype='float32'
@@ -275,11 +260,7 @@ class TestNNFunctionalMseLoss(unittest.TestCase):
             paddle.enable_static()
             prog = paddle.static.Program()
             startup_prog = paddle.static.Program()
-            place = (
-                paddle.CUDAPlace(0)
-                if core.is_compiled_with_cuda()
-                else paddle.CPUPlace()
-            )
+            place = get_current_place()
             with paddle.static.program_guard(prog, startup_prog):
                 input = paddle.static.data(
                     name='input', shape=dim, dtype='float32'
@@ -317,11 +298,7 @@ class TestNNFunctionalMseLoss(unittest.TestCase):
             paddle.enable_static()
             prog = paddle.static.Program()
             startup_prog = paddle.static.Program()
-            place = (
-                paddle.CUDAPlace(0)
-                if core.is_compiled_with_cuda()
-                else paddle.CPUPlace()
-            )
+            place = get_current_place()
             with paddle.static.program_guard(prog, startup_prog):
                 input = paddle.static.data(
                     name='input', shape=dim, dtype='float32'

--- a/test/legacy_test/test_mse_loss.py
+++ b/test/legacy_test/test_mse_loss.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import get_current_place
+from op_test import get_device_place
 from utils import dygraph_guard
 
 import paddle
@@ -99,7 +99,7 @@ class TestNNMseLoss(unittest.TestCase):
             paddle.enable_static()
             prog = base.Program()
             startup_prog = base.Program()
-            place = get_current_place()
+            place = get_device_place()
             with base.program_guard(prog, startup_prog):
                 input = paddle.static.data(
                     name='input', shape=dim, dtype='float32'
@@ -139,7 +139,7 @@ class TestNNMseLoss(unittest.TestCase):
             paddle.enable_static()
             prog = base.Program()
             startup_prog = base.Program()
-            place = get_current_place()
+            place = get_device_place()
             with base.program_guard(prog, startup_prog):
                 input = paddle.static.data(
                     name='input', shape=dim, dtype='float32'
@@ -179,7 +179,7 @@ class TestNNMseLoss(unittest.TestCase):
             paddle.enable_static()
             prog = base.Program()
             startup_prog = base.Program()
-            place = get_current_place()
+            place = get_device_place()
             with base.program_guard(prog, startup_prog):
                 input = paddle.static.data(
                     name='input', shape=dim, dtype='float32'
@@ -222,7 +222,7 @@ class TestNNFunctionalMseLoss(unittest.TestCase):
             paddle.enable_static()
             prog = paddle.static.Program()
             startup_prog = paddle.static.Program()
-            place = get_current_place()
+            place = get_device_place()
             with paddle.static.program_guard(prog, startup_prog):
                 input = paddle.static.data(
                     name='input', shape=dim, dtype='float32'
@@ -260,7 +260,7 @@ class TestNNFunctionalMseLoss(unittest.TestCase):
             paddle.enable_static()
             prog = paddle.static.Program()
             startup_prog = paddle.static.Program()
-            place = get_current_place()
+            place = get_device_place()
             with paddle.static.program_guard(prog, startup_prog):
                 input = paddle.static.data(
                     name='input', shape=dim, dtype='float32'
@@ -298,7 +298,7 @@ class TestNNFunctionalMseLoss(unittest.TestCase):
             paddle.enable_static()
             prog = paddle.static.Program()
             startup_prog = paddle.static.Program()
-            place = get_current_place()
+            place = get_device_place()
             with paddle.static.program_guard(prog, startup_prog):
                 input = paddle.static.data(
                     name='input', shape=dim, dtype='float32'

--- a/test/legacy_test/test_multigammaln.py
+++ b/test/legacy_test/test_multigammaln.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import get_current_place
+from op_test import get_device_place
 from scipy import special
 
 import paddle
@@ -39,7 +39,7 @@ class TestMultigammalnAPI(unittest.TestCase):
         self.x = np.random.rand(10, 20).astype('float32') + 1.0
         self.p = 2
         self.init_input()
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def init_input(self):
         pass
@@ -79,7 +79,7 @@ class TestMultigammalnGrad(unittest.TestCase):
         self.dtype = 'float32'
         self.x = np.array([2, 3, 4, 5, 6, 7, 8]).astype(dtype=self.dtype)
         self.p = 3
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def test_backward(self):
         expected_x_grad = ref_multigammaln_grad(self.x, self.p)

--- a/test/legacy_test/test_multigammaln.py
+++ b/test/legacy_test/test_multigammaln.py
@@ -15,6 +15,7 @@
 import unittest
 
 import numpy as np
+from op_test import get_current_place
 from scipy import special
 
 import paddle
@@ -38,11 +39,7 @@ class TestMultigammalnAPI(unittest.TestCase):
         self.x = np.random.rand(10, 20).astype('float32') + 1.0
         self.p = 2
         self.init_input()
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def init_input(self):
         pass
@@ -82,11 +79,7 @@ class TestMultigammalnGrad(unittest.TestCase):
         self.dtype = 'float32'
         self.x = np.array([2, 3, 4, 5, 6, 7, 8]).astype(dtype=self.dtype)
         self.p = 3
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def test_backward(self):
         expected_x_grad = ref_multigammaln_grad(self.x, self.p)

--- a/test/legacy_test/test_multiply.py
+++ b/test/legacy_test/test_multiply.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import get_current_place
+from op_test import get_device_place
 
 import paddle
 from paddle import static, tensor
@@ -34,7 +34,7 @@ class TestMultiplyApi(unittest.TestCase):
             )
             res = tensor.multiply(x, y)
 
-            place = get_current_place()
+            place = get_device_place()
             exe = paddle.static.Executor(place)
             outs = exe.run(
                 paddle.static.default_main_program(),
@@ -191,7 +191,7 @@ class TestMultiplyInplaceApi(TestMultiplyApi):
             )
             res = x.multiply_(y)
 
-            place = get_current_place()
+            place = get_device_place()
             exe = paddle.static.Executor(place)
             outs = exe.run(
                 paddle.static.default_main_program(),

--- a/test/legacy_test/test_multiply.py
+++ b/test/legacy_test/test_multiply.py
@@ -15,6 +15,7 @@
 import unittest
 
 import numpy as np
+from op_test import get_current_place
 
 import paddle
 from paddle import static, tensor
@@ -33,11 +34,7 @@ class TestMultiplyApi(unittest.TestCase):
             )
             res = tensor.multiply(x, y)
 
-            place = (
-                paddle.CUDAPlace(0)
-                if paddle.is_compiled_with_cuda()
-                else paddle.CPUPlace()
-            )
+            place = get_current_place()
             exe = paddle.static.Executor(place)
             outs = exe.run(
                 paddle.static.default_main_program(),
@@ -194,11 +191,7 @@ class TestMultiplyInplaceApi(TestMultiplyApi):
             )
             res = x.multiply_(y)
 
-            place = (
-                paddle.CUDAPlace(0)
-                if paddle.is_compiled_with_cuda()
-                else paddle.CPUPlace()
-            )
+            place = get_current_place()
             exe = paddle.static.Executor(place)
             outs = exe.run(
                 paddle.static.default_main_program(),

--- a/test/legacy_test/test_nadam_op.py
+++ b/test/legacy_test/test_nadam_op.py
@@ -16,7 +16,7 @@ import unittest
 from copy import deepcopy
 
 import numpy as np
-from op_test import OpTest, get_places
+from op_test import OpTest, get_device_place, get_places
 
 import paddle
 from paddle import base
@@ -501,7 +501,7 @@ class TestNdamaxMultiPrecision2_0(unittest.TestCase):
         paddle.enable_static()
         paddle.seed(2024)
         with paddle.pir_utils.OldIrGuard():
-            exe = paddle.static.Executor('gpu')
+            exe = paddle.static.Executor(get_device_place())
             train_program = paddle.static.Program()
             startup_program = paddle.static.Program()
             optimizer = paddle.optimizer.NAdam(0.1)
@@ -550,7 +550,7 @@ class TestNdamaxMultiPrecision2_0(unittest.TestCase):
         paddle.enable_static()
         with paddle.pir_utils.IrGuard():
             paddle.seed(2024)
-            exe = paddle.static.Executor('gpu')
+            exe = paddle.static.Executor(get_device_place())
             train_program = paddle.static.Program()
             startup_program = paddle.static.Program()
 
@@ -607,7 +607,7 @@ class TestNdamaxMultiPrecision2_0(unittest.TestCase):
             train_program = paddle.static.Program()
             startup_program = paddle.static.Program()
             with paddle.static.program_guard(train_program, startup_program):
-                exe = paddle.static.Executor('gpu')
+                exe = paddle.static.Executor(get_device_place())
                 linear = paddle.nn.Linear(2, 10)
                 optimizer = paddle.optimizer.NAdam(
                     0.1, parameters=linear.parameters()

--- a/test/legacy_test/test_nan_to_num_op.py
+++ b/test/legacy_test/test_nan_to_num_op.py
@@ -17,9 +17,9 @@ from __future__ import annotations
 import unittest
 
 import numpy as np
+from op_test import get_current_place
 
 import paddle
-from paddle.base import core
 
 # from op_test import OpTest
 
@@ -56,11 +56,7 @@ def np_nan_to_num_grad(x: np.ndarray, dout: np.ndarray) -> np.ndarray:
 
 class TestNanToNum(unittest.TestCase):
     def setUp(self):
-        self.place = (
-            paddle.CUDAPlace(0)
-            if core.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def test_static(self):
         x_np = np.array([[1, np.nan, -2], [np.inf, 0, -np.inf]]).astype(
@@ -204,11 +200,7 @@ class TestNanToNum(unittest.TestCase):
 
 class TestNanToNum_ZeroSize(unittest.TestCase):
     def setUp(self):
-        self.place = (
-            paddle.CUDAPlace(0)
-            if core.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
         self.x_np = np.random.random([2, 0, 3]).astype(np.float32)
 
     def test_dygraph(self):

--- a/test/legacy_test/test_nan_to_num_op.py
+++ b/test/legacy_test/test_nan_to_num_op.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import unittest
 
 import numpy as np
-from op_test import get_current_place
+from op_test import get_device_place
 
 import paddle
 
@@ -56,7 +56,7 @@ def np_nan_to_num_grad(x: np.ndarray, dout: np.ndarray) -> np.ndarray:
 
 class TestNanToNum(unittest.TestCase):
     def setUp(self):
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def test_static(self):
         x_np = np.array([[1, np.nan, -2], [np.inf, 0, -np.inf]]).astype(
@@ -200,7 +200,7 @@ class TestNanToNum(unittest.TestCase):
 
 class TestNanToNum_ZeroSize(unittest.TestCase):
     def setUp(self):
-        self.place = get_current_place()
+        self.place = get_device_place()
         self.x_np = np.random.random([2, 0, 3]).astype(np.float32)
 
     def test_dygraph(self):

--- a/test/legacy_test/test_nanmean_api.py
+++ b/test/legacy_test/test_nanmean_api.py
@@ -15,9 +15,9 @@
 import unittest
 
 import numpy as np
+from op_test import get_current_place
 
 import paddle
-from paddle.base import core
 
 np.random.seed(10)
 
@@ -32,11 +32,7 @@ class TestNanmeanAPI(unittest.TestCase):
         self.x_grad = np.array(
             [[np.nan, np.nan, 3.0], [0.0, np.nan, 2.0]]
         ).astype(np.float32)
-        self.place = (
-            paddle.CUDAPlace(0)
-            if core.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def test_api_static(self):
         paddle.enable_static()
@@ -141,11 +137,7 @@ class TestNanmeanAPI_ZeroSize(unittest.TestCase):
         self.x_shape = [2, 0, 4, 5]
         self.x = np.random.uniform(-1, 1, self.x_shape).astype(np.float32)
         self.x[0, :, :, :] = np.nan
-        self.place = (
-            paddle.CUDAPlace(0)
-            if core.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def test_api_dygraph(self):
         paddle.disable_static(self.place)

--- a/test/legacy_test/test_nanmean_api.py
+++ b/test/legacy_test/test_nanmean_api.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import get_current_place
+from op_test import get_device_place
 
 import paddle
 
@@ -32,7 +32,7 @@ class TestNanmeanAPI(unittest.TestCase):
         self.x_grad = np.array(
             [[np.nan, np.nan, 3.0], [0.0, np.nan, 2.0]]
         ).astype(np.float32)
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def test_api_static(self):
         paddle.enable_static()
@@ -137,7 +137,7 @@ class TestNanmeanAPI_ZeroSize(unittest.TestCase):
         self.x_shape = [2, 0, 4, 5]
         self.x = np.random.uniform(-1, 1, self.x_shape).astype(np.float32)
         self.x[0, :, :, :] = np.nan
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def test_api_dygraph(self):
         paddle.disable_static(self.place)

--- a/test/legacy_test/test_nanmedian.py
+++ b/test/legacy_test/test_nanmedian.py
@@ -16,7 +16,7 @@ import copy
 import unittest
 
 import numpy as np
-from op_test import OpTest, convert_float_to_uint16, get_current_place
+from op_test import OpTest, convert_float_to_uint16, get_device_place
 
 import paddle
 from paddle.base import core
@@ -142,7 +142,7 @@ class TestNanmedianModeMin(unittest.TestCase):
         col_data[:, :, 2, 3:] = np.nan
         self.fake_data["col_nan_odd"] = col_data.astype(np.float32)
 
-        self.place = get_current_place()
+        self.place = get_device_place()
         self.axis_candidate_list = [
             None,
             0,
@@ -393,7 +393,7 @@ class TestNanmedianModeMean(unittest.TestCase):
         col_data[:, :, 2, 3:] = np.nan
         self.fake_data["col_nan_odd"] = col_data.astype(np.float32)
 
-        self.place = get_current_place()
+        self.place = get_device_place()
         self.axis_candidate_list = [
             None,
             0,

--- a/test/legacy_test/test_nanmedian.py
+++ b/test/legacy_test/test_nanmedian.py
@@ -16,7 +16,7 @@ import copy
 import unittest
 
 import numpy as np
-from op_test import OpTest, convert_float_to_uint16
+from op_test import OpTest, convert_float_to_uint16, get_current_place
 
 import paddle
 from paddle.base import core
@@ -142,11 +142,7 @@ class TestNanmedianModeMin(unittest.TestCase):
         col_data[:, :, 2, 3:] = np.nan
         self.fake_data["col_nan_odd"] = col_data.astype(np.float32)
 
-        self.place = (
-            paddle.CUDAPlace(0)
-            if core.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
         self.axis_candidate_list = [
             None,
             0,
@@ -397,11 +393,7 @@ class TestNanmedianModeMean(unittest.TestCase):
         col_data[:, :, 2, 3:] = np.nan
         self.fake_data["col_nan_odd"] = col_data.astype(np.float32)
 
-        self.place = (
-            paddle.CUDAPlace(0)
-            if core.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
         self.axis_candidate_list = [
             None,
             0,

--- a/test/legacy_test/test_nextafter_op.py
+++ b/test/legacy_test/test_nextafter_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest
+from op_test import OpTest, get_current_place
 
 import paddle
 
@@ -33,11 +33,7 @@ class TestNextafterAPI(unittest.TestCase):
         self.y1 = np.array([np.inf, -np.inf, 10]).astype("float32")
         self.x2 = np.random.rand(100).astype("float32")
         self.y2 = np.random.rand(100).astype("float32")
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def test_static_api(self):
         paddle.enable_static()

--- a/test/legacy_test/test_nextafter_op.py
+++ b/test/legacy_test/test_nextafter_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, get_current_place
+from op_test import OpTest, get_device_place
 
 import paddle
 
@@ -33,7 +33,7 @@ class TestNextafterAPI(unittest.TestCase):
         self.y1 = np.array([np.inf, -np.inf, 10]).astype("float32")
         self.x2 = np.random.rand(100).astype("float32")
         self.y2 = np.random.rand(100).astype("float32")
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def test_static_api(self):
         paddle.enable_static()

--- a/test/legacy_test/test_nll_loss.py
+++ b/test/legacy_test/test_nll_loss.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, get_current_place
+from op_test import OpTest, get_device_place
 
 import paddle
 from paddle import base
@@ -84,7 +84,7 @@ class TestNLLLoss(unittest.TestCase):
         np.random.seed(200)
         label_np = np.random.randint(0, 10, size=(10,)).astype(np.int64)
 
-        place = get_current_place()
+        place = get_device_place()
 
         expected = nll_loss_1d(input_np, label_np)[0]
         with base.dygraph.guard():
@@ -127,7 +127,7 @@ class TestNLLLoss(unittest.TestCase):
         np.random.seed(200)
         label_np = np.random.randint(0, 10, size=(10,)).astype(np.int64)
 
-        place = get_current_place()
+        place = get_device_place()
         expected = nll_loss_1d(input_np, label_np, reduction='sum')[0]
 
         def test_static_or_pir_mode():
@@ -180,7 +180,7 @@ class TestNLLLoss(unittest.TestCase):
         label_np = np.random.randint(0, 10, size=(10,)).astype(np.int64)
         weight_np = np.random.random(size=(10,)).astype(np.float64)
 
-        place = get_current_place()
+        place = get_device_place()
 
         expected = nll_loss_1d(input_np, label_np, weight=weight_np)[0]
 
@@ -243,7 +243,7 @@ class TestNLLLoss(unittest.TestCase):
         label_np = np.random.randint(0, 10, size=(10,)).astype(np.int64)
         weight_np = np.random.random(size=(10,)).astype(np.float64)
 
-        place = get_current_place()
+        place = get_device_place()
         # place = base.CPUPlace()
 
         expected = nll_loss_1d(
@@ -407,7 +407,7 @@ class TestNLLLoss(unittest.TestCase):
         np.random.seed(200)
         label_np = np.random.randint(0, 3, size=(5, 5, 5)).astype(np.int64)
 
-        place = get_current_place()
+        place = get_device_place()
         expected = nll_loss_2d(input_np, label_np)[0]
         with base.dygraph.guard():
             nll_loss = paddle.nn.loss.NLLLoss()
@@ -451,7 +451,7 @@ class TestNLLLoss(unittest.TestCase):
         label_np = np.random.randint(0, 3, size=(5, 5, 5)).astype(np.int64)
         prog = paddle.static.Program()
         startup_prog = paddle.static.Program()
-        place = get_current_place()
+        place = get_device_place()
         # place = base.CPUPlace()
 
         expected = nll_loss_2d(input_np, label_np, reduction='sum')[0]
@@ -495,7 +495,7 @@ class TestNLLLoss(unittest.TestCase):
         label_np = np.random.randint(0, 3, size=(5, 5, 5)).astype(np.int64)
         weight_np = np.random.random(size=(3,)).astype(np.float64)
 
-        place = get_current_place()
+        place = get_device_place()
         with base.dygraph.guard():
             nll_loss = paddle.nn.loss.NLLLoss(
                 weight=paddle.to_tensor(weight_np)
@@ -602,7 +602,7 @@ class TestNLLLoss(unittest.TestCase):
         label_np = np.random.randint(0, 3, size=(5, 5, 5)).astype(np.int64)
         weight_np = np.random.random(size=(3,)).astype(np.float64)
 
-        place = get_current_place()
+        place = get_device_place()
 
         expected = nll_loss_2d(
             input_np, label_np, weight=weight_np, reduction='sum'
@@ -658,7 +658,7 @@ class TestNLLLoss(unittest.TestCase):
         np.random.seed(200)
         label_np = np.random.randint(0, 3, size=(5, 5, 5, 5)).astype(np.int64)
 
-        place = get_current_place()
+        place = get_device_place()
         # place = base.CPUPlace()
         input_shape = input_np.shape
         label_shape = label_np.shape
@@ -707,7 +707,7 @@ class TestNLLLoss(unittest.TestCase):
         label_np = np.random.randint(0, 3, size=(5, 5, 5, 5)).astype(np.int64)
         weight_np = np.random.random(size=(3,)).astype(np.float64)
 
-        place = get_current_place()
+        place = get_device_place()
         # place = base.CPUPlace()
         input_shape = input_np.shape
         label_shape = label_np.shape
@@ -768,7 +768,7 @@ class TestNLLLoss(unittest.TestCase):
         label_np = np.random.randint(0, 3, size=(5, 5, 5, 5)).astype(np.int64)
         weight_np = np.random.random(size=(3,)).astype(np.float64)
 
-        place = get_current_place()
+        place = get_device_place()
         place = base.CPUPlace()
 
         input_shape = input_np.shape
@@ -834,7 +834,7 @@ class TestNLLLoss(unittest.TestCase):
         label_np = np.random.randint(0, 3, size=(5, 5, 5, 5)).astype(np.int64)
         weight_np = np.random.random(size=(3,)).astype(np.float64)
 
-        place = get_current_place()
+        place = get_device_place()
         # place = base.CPUPlace()
 
         input_shape = input_np.shape

--- a/test/legacy_test/test_nll_loss.py
+++ b/test/legacy_test/test_nll_loss.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest
+from op_test import OpTest, get_current_place
 
 import paddle
 from paddle import base
@@ -84,11 +84,7 @@ class TestNLLLoss(unittest.TestCase):
         np.random.seed(200)
         label_np = np.random.randint(0, 10, size=(10,)).astype(np.int64)
 
-        place = (
-            base.CUDAPlace(0)
-            if base.core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
 
         expected = nll_loss_1d(input_np, label_np)[0]
         with base.dygraph.guard():
@@ -131,11 +127,7 @@ class TestNLLLoss(unittest.TestCase):
         np.random.seed(200)
         label_np = np.random.randint(0, 10, size=(10,)).astype(np.int64)
 
-        place = (
-            base.CUDAPlace(0)
-            if base.core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
         expected = nll_loss_1d(input_np, label_np, reduction='sum')[0]
 
         def test_static_or_pir_mode():
@@ -188,11 +180,7 @@ class TestNLLLoss(unittest.TestCase):
         label_np = np.random.randint(0, 10, size=(10,)).astype(np.int64)
         weight_np = np.random.random(size=(10,)).astype(np.float64)
 
-        place = (
-            base.CUDAPlace(0)
-            if base.core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
 
         expected = nll_loss_1d(input_np, label_np, weight=weight_np)[0]
 
@@ -255,11 +243,7 @@ class TestNLLLoss(unittest.TestCase):
         label_np = np.random.randint(0, 10, size=(10,)).astype(np.int64)
         weight_np = np.random.random(size=(10,)).astype(np.float64)
 
-        place = (
-            base.CUDAPlace(0)
-            if base.core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
         # place = base.CPUPlace()
 
         expected = nll_loss_1d(
@@ -423,11 +407,7 @@ class TestNLLLoss(unittest.TestCase):
         np.random.seed(200)
         label_np = np.random.randint(0, 3, size=(5, 5, 5)).astype(np.int64)
 
-        place = (
-            base.CUDAPlace(0)
-            if base.core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
         expected = nll_loss_2d(input_np, label_np)[0]
         with base.dygraph.guard():
             nll_loss = paddle.nn.loss.NLLLoss()
@@ -471,11 +451,7 @@ class TestNLLLoss(unittest.TestCase):
         label_np = np.random.randint(0, 3, size=(5, 5, 5)).astype(np.int64)
         prog = paddle.static.Program()
         startup_prog = paddle.static.Program()
-        place = (
-            base.CUDAPlace(0)
-            if base.core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
         # place = base.CPUPlace()
 
         expected = nll_loss_2d(input_np, label_np, reduction='sum')[0]
@@ -519,11 +495,7 @@ class TestNLLLoss(unittest.TestCase):
         label_np = np.random.randint(0, 3, size=(5, 5, 5)).astype(np.int64)
         weight_np = np.random.random(size=(3,)).astype(np.float64)
 
-        place = (
-            base.CUDAPlace(0)
-            if base.core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
         with base.dygraph.guard():
             nll_loss = paddle.nn.loss.NLLLoss(
                 weight=paddle.to_tensor(weight_np)
@@ -630,11 +602,7 @@ class TestNLLLoss(unittest.TestCase):
         label_np = np.random.randint(0, 3, size=(5, 5, 5)).astype(np.int64)
         weight_np = np.random.random(size=(3,)).astype(np.float64)
 
-        place = (
-            base.CUDAPlace(0)
-            if base.core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
 
         expected = nll_loss_2d(
             input_np, label_np, weight=weight_np, reduction='sum'
@@ -690,11 +658,7 @@ class TestNLLLoss(unittest.TestCase):
         np.random.seed(200)
         label_np = np.random.randint(0, 3, size=(5, 5, 5, 5)).astype(np.int64)
 
-        place = (
-            base.CUDAPlace(0)
-            if base.core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
         # place = base.CPUPlace()
         input_shape = input_np.shape
         label_shape = label_np.shape
@@ -743,11 +707,7 @@ class TestNLLLoss(unittest.TestCase):
         label_np = np.random.randint(0, 3, size=(5, 5, 5, 5)).astype(np.int64)
         weight_np = np.random.random(size=(3,)).astype(np.float64)
 
-        place = (
-            base.CUDAPlace(0)
-            if base.core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
         # place = base.CPUPlace()
         input_shape = input_np.shape
         label_shape = label_np.shape
@@ -808,11 +768,7 @@ class TestNLLLoss(unittest.TestCase):
         label_np = np.random.randint(0, 3, size=(5, 5, 5, 5)).astype(np.int64)
         weight_np = np.random.random(size=(3,)).astype(np.float64)
 
-        place = (
-            base.CUDAPlace(0)
-            if base.core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
         place = base.CPUPlace()
 
         input_shape = input_np.shape
@@ -878,11 +834,7 @@ class TestNLLLoss(unittest.TestCase):
         label_np = np.random.randint(0, 3, size=(5, 5, 5, 5)).astype(np.int64)
         weight_np = np.random.random(size=(3,)).astype(np.float64)
 
-        place = (
-            base.CUDAPlace(0)
-            if base.core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
         # place = base.CPUPlace()
 
         input_shape = input_np.shape

--- a/test/legacy_test/test_nn_functional_embedding_static.py
+++ b/test/legacy_test/test_nn_functional_embedding_static.py
@@ -15,6 +15,7 @@
 import unittest
 
 import numpy as np
+from op_test import get_current_place
 
 import paddle
 from paddle import base
@@ -113,11 +114,7 @@ class EmbeddingStatic(unittest.TestCase):
         max_norm = 5.0
         norm_type = 2.0
         y_ref = self.ref_embedding_renorm_(x_np, weight_np, max_norm, norm_type)
-        place = (
-            paddle.CUDAPlace(0)
-            if paddle.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        place = get_current_place()
         prog = paddle.static.Program()
         with paddle.static.program_guard(prog):
             x = paddle.static.data(name="x", shape=[-1, 3], dtype="int64")

--- a/test/legacy_test/test_nn_functional_embedding_static.py
+++ b/test/legacy_test/test_nn_functional_embedding_static.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import get_current_place
+from op_test import get_device_place
 
 import paddle
 from paddle import base
@@ -114,7 +114,7 @@ class EmbeddingStatic(unittest.TestCase):
         max_norm = 5.0
         norm_type = 2.0
         y_ref = self.ref_embedding_renorm_(x_np, weight_np, max_norm, norm_type)
-        place = get_current_place()
+        place = get_device_place()
         prog = paddle.static.Program()
         with paddle.static.program_guard(prog):
             x = paddle.static.data(name="x", shape=[-1, 3], dtype="int64")

--- a/test/legacy_test/test_ones_like.py
+++ b/test/legacy_test/test_ones_like.py
@@ -15,10 +15,11 @@
 import unittest
 
 import numpy as np
+from op_test import get_current_place
 
 import paddle
 from paddle import _C_ops, base, ones_like
-from paddle.base import Program, core, program_guard
+from paddle.base import Program, program_guard
 from paddle.base.framework import convert_np_dtype_to_dtype_
 
 
@@ -37,11 +38,7 @@ class TestOnesLikeAPI(unittest.TestCase):
             out4 = ones_like(x, 'int32')
             out5 = ones_like(x, 'int64')
 
-        place = (
-            base.CUDAPlace(0)
-            if core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
         exe = base.Executor(place)
         outs = exe.run(
             train_program,
@@ -59,11 +56,7 @@ class TestOnesLikeAPI(unittest.TestCase):
 class TestOnesAPI(unittest.TestCase):
     def test_api(self):
         shape = [3, 4]
-        place = (
-            base.CUDAPlace(0)
-            if core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
         paddle.disable_static(place)
 
         for dtype in [np.float32, np.float64, np.int32, np.int64]:

--- a/test/legacy_test/test_ones_like.py
+++ b/test/legacy_test/test_ones_like.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import get_current_place
+from op_test import get_device_place
 
 import paddle
 from paddle import _C_ops, base, ones_like
@@ -38,7 +38,7 @@ class TestOnesLikeAPI(unittest.TestCase):
             out4 = ones_like(x, 'int32')
             out5 = ones_like(x, 'int64')
 
-        place = get_current_place()
+        place = get_device_place()
         exe = base.Executor(place)
         outs = exe.run(
             train_program,
@@ -56,7 +56,7 @@ class TestOnesLikeAPI(unittest.TestCase):
 class TestOnesAPI(unittest.TestCase):
     def test_api(self):
         shape = [3, 4]
-        place = get_current_place()
+        place = get_device_place()
         paddle.disable_static(place)
 
         for dtype in [np.float32, np.float64, np.int32, np.int64]:

--- a/test/legacy_test/test_ormqr.py
+++ b/test/legacy_test/test_ormqr.py
@@ -15,6 +15,7 @@
 import unittest
 
 import numpy as np
+from op_test import get_current_place
 
 import paddle
 
@@ -116,11 +117,7 @@ def ref_ormqr(input, tau, y, left=True, transpose=False):
 class TestOrmqrAPI(unittest.TestCase):
     def setUp(self):
         paddle.seed(2024)
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
         self.init_input()
 
     def init_input(self):

--- a/test/legacy_test/test_ormqr.py
+++ b/test/legacy_test/test_ormqr.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import get_current_place
+from op_test import get_device_place
 
 import paddle
 
@@ -117,7 +117,7 @@ def ref_ormqr(input, tau, y, left=True, transpose=False):
 class TestOrmqrAPI(unittest.TestCase):
     def setUp(self):
         paddle.seed(2024)
-        self.place = get_current_place()
+        self.place = get_device_place()
         self.init_input()
 
     def init_input(self):

--- a/test/legacy_test/test_outer.py
+++ b/test/legacy_test/test_outer.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import get_current_place
+from op_test import get_device_place
 
 import paddle
 
@@ -34,7 +34,7 @@ class TestMultiplyApi(unittest.TestCase):
             )
             res = paddle.outer(x, y)
 
-            place = get_current_place()
+            place = get_device_place()
             exe = paddle.static.Executor(place)
             outs = exe.run(
                 paddle.static.default_main_program(),

--- a/test/legacy_test/test_outer.py
+++ b/test/legacy_test/test_outer.py
@@ -15,6 +15,7 @@
 import unittest
 
 import numpy as np
+from op_test import get_current_place
 
 import paddle
 
@@ -33,11 +34,7 @@ class TestMultiplyApi(unittest.TestCase):
             )
             res = paddle.outer(x, y)
 
-            place = (
-                paddle.CUDAPlace(0)
-                if paddle.is_compiled_with_cuda()
-                else paddle.CPUPlace()
-            )
+            place = get_current_place()
             exe = paddle.static.Executor(place)
             outs = exe.run(
                 paddle.static.default_main_program(),

--- a/test/legacy_test/test_paddle_save_load_binary.py
+++ b/test/legacy_test/test_paddle_save_load_binary.py
@@ -19,7 +19,7 @@ import unittest
 from io import BytesIO
 
 import numpy as np
-from op_test import get_current_place
+from op_test import get_device_place
 from test_imperative_base import new_program_scope
 
 import paddle
@@ -84,7 +84,7 @@ class TestSaveLoadBinaryFormat(unittest.TestCase):
             z = paddle.static.nn.fc(x, 10, bias_attr=False)
             z = paddle.static.nn.fc(z, 128, bias_attr=False)
             loss = paddle.mean(z)
-            place = get_current_place()
+            place = get_device_place()
             exe = paddle.static.Executor(place)
             exe.run(paddle.static.default_startup_program())
             prog = paddle.static.default_main_program()
@@ -152,7 +152,7 @@ class TestSaveLoadBinaryFormat(unittest.TestCase):
                 name='fc_vars',
             )
             prog = paddle.static.default_main_program()
-            place = get_current_place()
+            place = get_device_place()
             exe = base.Executor(place)
             prog = paddle.static.default_main_program()
             exe.run(base.default_startup_program())
@@ -234,7 +234,7 @@ class TestSaveLoadBinaryFormat(unittest.TestCase):
 
     def test_save_load_selected_rows(self):
         paddle.enable_static()
-        place = get_current_place()
+        place = get_device_place()
         height = 10
         rows = [0, 4, 7]
         row_numel = 12

--- a/test/legacy_test/test_paddle_save_load_binary.py
+++ b/test/legacy_test/test_paddle_save_load_binary.py
@@ -19,6 +19,7 @@ import unittest
 from io import BytesIO
 
 import numpy as np
+from op_test import get_current_place
 from test_imperative_base import new_program_scope
 
 import paddle
@@ -83,11 +84,7 @@ class TestSaveLoadBinaryFormat(unittest.TestCase):
             z = paddle.static.nn.fc(x, 10, bias_attr=False)
             z = paddle.static.nn.fc(z, 128, bias_attr=False)
             loss = paddle.mean(z)
-            place = (
-                base.CPUPlace()
-                if not paddle.base.core.is_compiled_with_cuda()
-                else base.CUDAPlace(0)
-            )
+            place = get_current_place()
             exe = paddle.static.Executor(place)
             exe.run(paddle.static.default_startup_program())
             prog = paddle.static.default_main_program()
@@ -155,11 +152,7 @@ class TestSaveLoadBinaryFormat(unittest.TestCase):
                 name='fc_vars',
             )
             prog = paddle.static.default_main_program()
-            place = (
-                base.CPUPlace()
-                if not paddle.base.core.is_compiled_with_cuda()
-                else base.CUDAPlace(0)
-            )
+            place = get_current_place()
             exe = base.Executor(place)
             prog = paddle.static.default_main_program()
             exe.run(base.default_startup_program())
@@ -241,11 +234,7 @@ class TestSaveLoadBinaryFormat(unittest.TestCase):
 
     def test_save_load_selected_rows(self):
         paddle.enable_static()
-        place = (
-            base.CPUPlace()
-            if not paddle.base.core.is_compiled_with_cuda()
-            else base.CUDAPlace(0)
-        )
+        place = get_current_place()
         height = 10
         rows = [0, 4, 7]
         row_numel = 12

--- a/test/legacy_test/test_pairwise_distance.py
+++ b/test/legacy_test/test_pairwise_distance.py
@@ -15,10 +15,9 @@
 import unittest
 
 import numpy as np
-from op_test import get_places
+from op_test import get_current_place, get_places
 
 import paddle
-from paddle import base
 
 
 def np_pairwise_distance(x, y, p=2.0, epsilon=1e-6, keepdim=False):
@@ -48,11 +47,7 @@ def test_static(
 ):
     prog = paddle.static.Program()
     startup_prog = paddle.static.Program()
-    place = (
-        base.CUDAPlace(0)
-        if paddle.base.core.is_compiled_with_cuda()
-        else base.CPUPlace()
-    )
+    place = get_current_place()
     paddle.enable_static()
     with paddle.static.program_guard(prog, startup_prog):
         x = paddle.static.data(name='x', shape=x_np.shape, dtype=x_np.dtype)

--- a/test/legacy_test/test_pairwise_distance.py
+++ b/test/legacy_test/test_pairwise_distance.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import get_current_place, get_places
+from op_test import get_device_place, get_places
 
 import paddle
 
@@ -47,7 +47,7 @@ def test_static(
 ):
     prog = paddle.static.Program()
     startup_prog = paddle.static.Program()
-    place = get_current_place()
+    place = get_device_place()
     paddle.enable_static()
     with paddle.static.program_guard(prog, startup_prog):
         x = paddle.static.data(name='x', shape=x_np.shape, dtype=x_np.dtype)

--- a/test/legacy_test/test_pdist.py
+++ b/test/legacy_test/test_pdist.py
@@ -15,6 +15,7 @@
 import unittest
 
 import numpy as np
+from op_test import get_current_place
 
 import paddle
 
@@ -36,11 +37,7 @@ class TestPdistAPI(unittest.TestCase):
         self.x = np.random.rand(10, 20).astype('float32')
         self.p = 2.0
         self.init_input()
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def init_input(self):
         pass
@@ -122,11 +119,7 @@ class TestPdistAPI_ZeroSize(unittest.TestCase):
         self.init_shape()
         self.x = np.random.rand(*self.shape).astype('float32')
         self.p = 2.0
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def init_shape(self):
         self.shape = (0, 20)

--- a/test/legacy_test/test_pdist.py
+++ b/test/legacy_test/test_pdist.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import get_current_place
+from op_test import get_device_place
 
 import paddle
 
@@ -37,7 +37,7 @@ class TestPdistAPI(unittest.TestCase):
         self.x = np.random.rand(10, 20).astype('float32')
         self.p = 2.0
         self.init_input()
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def init_input(self):
         pass
@@ -119,7 +119,7 @@ class TestPdistAPI_ZeroSize(unittest.TestCase):
         self.init_shape()
         self.x = np.random.rand(*self.shape).astype('float32')
         self.p = 2.0
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def init_shape(self):
         self.shape = (0, 20)

--- a/test/legacy_test/test_poisson_nll_loss.py
+++ b/test/legacy_test/test_poisson_nll_loss.py
@@ -15,6 +15,7 @@
 import unittest
 
 import numpy as np
+from op_test import get_current_place
 
 import paddle
 import paddle.nn.functional as F
@@ -68,11 +69,7 @@ class TestPoissonNLLLossBasicCase(unittest.TestCase):
         self.dtype = dtype
         self.input_np = np.random.random(self.shape).astype(self.dtype)
         self.label_np = np.random.random(self.shape).astype(self.dtype)
-        self.place = (
-            paddle.CUDAPlace(0)
-            if core.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def test_static_case(
         self,
@@ -252,11 +249,7 @@ class TestPoissonNLLLossCase_ZeroSize(unittest.TestCase):
         self.dtype = dtype
         self.input_np = np.random.random(self.shape).astype(self.dtype)
         self.label_np = np.random.random(self.shape).astype(self.dtype)
-        self.place = (
-            paddle.CUDAPlace(0)
-            if core.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def _test_dynamic_case_and_grad(
         self,

--- a/test/legacy_test/test_poisson_nll_loss.py
+++ b/test/legacy_test/test_poisson_nll_loss.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import get_current_place
+from op_test import get_device_place
 
 import paddle
 import paddle.nn.functional as F
@@ -69,7 +69,7 @@ class TestPoissonNLLLossBasicCase(unittest.TestCase):
         self.dtype = dtype
         self.input_np = np.random.random(self.shape).astype(self.dtype)
         self.label_np = np.random.random(self.shape).astype(self.dtype)
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def test_static_case(
         self,
@@ -249,7 +249,7 @@ class TestPoissonNLLLossCase_ZeroSize(unittest.TestCase):
         self.dtype = dtype
         self.input_np = np.random.random(self.shape).astype(self.dtype)
         self.label_np = np.random.random(self.shape).astype(self.dtype)
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def _test_dynamic_case_and_grad(
         self,

--- a/test/legacy_test/test_prelu_op.py
+++ b/test/legacy_test/test_prelu_op.py
@@ -15,7 +15,12 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, convert_float_to_uint16, skip_check_grad_ci
+from op_test import (
+    OpTest,
+    convert_float_to_uint16,
+    get_current_place,
+    skip_check_grad_ci,
+)
 
 import paddle
 import paddle.nn.functional as F
@@ -39,11 +44,7 @@ def ref_prelu_nn(x, num_parameters, init):
 
 class TestFunctionalPReluAPI(unittest.TestCase):
     def setUp(self):
-        self.place = (
-            paddle.CUDAPlace(0)
-            if core.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
         self.x_np = np.random.uniform(-1.0, 1.0, [1, 2, 3, 4]).astype('float32')
         self.weight_np_0 = np.random.randn(1).astype('float32')
         self.weight_np_1 = np.random.randn(self.x_np.shape[1]).astype('float32')
@@ -99,11 +100,7 @@ class TestFunctionalPReluAPI(unittest.TestCase):
 
 class TestNNPReluAPI(unittest.TestCase):
     def setUp(self):
-        self.place = (
-            paddle.CUDAPlace(0)
-            if core.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
         self.x_np = np.ones([1, 2, 3, 4]).astype('float32')
 
     def test_static_api(self):

--- a/test/legacy_test/test_prelu_op.py
+++ b/test/legacy_test/test_prelu_op.py
@@ -18,7 +18,7 @@ import numpy as np
 from op_test import (
     OpTest,
     convert_float_to_uint16,
-    get_current_place,
+    get_device_place,
     skip_check_grad_ci,
 )
 
@@ -44,7 +44,7 @@ def ref_prelu_nn(x, num_parameters, init):
 
 class TestFunctionalPReluAPI(unittest.TestCase):
     def setUp(self):
-        self.place = get_current_place()
+        self.place = get_device_place()
         self.x_np = np.random.uniform(-1.0, 1.0, [1, 2, 3, 4]).astype('float32')
         self.weight_np_0 = np.random.randn(1).astype('float32')
         self.weight_np_1 = np.random.randn(self.x_np.shape[1]).astype('float32')
@@ -100,7 +100,7 @@ class TestFunctionalPReluAPI(unittest.TestCase):
 
 class TestNNPReluAPI(unittest.TestCase):
     def setUp(self):
-        self.place = get_current_place()
+        self.place = get_device_place()
         self.x_np = np.ones([1, 2, 3, 4]).astype('float32')
 
     def test_static_api(self):

--- a/test/legacy_test/test_rad2deg.py
+++ b/test/legacy_test/test_rad2deg.py
@@ -15,10 +15,10 @@
 import unittest
 
 import numpy as np
+from op_test import get_current_place
 
 import paddle
 from paddle import base
-from paddle.base import core
 
 paddle.enable_static()
 
@@ -41,11 +41,7 @@ class TestRad2degAPI(unittest.TestCase):
             )
             out = paddle.rad2deg(x)
 
-            place = (
-                base.CUDAPlace(0)
-                if core.is_compiled_with_cuda()
-                else base.CPUPlace()
-            )
+            place = get_current_place()
             exe = base.Executor(place)
             res = exe.run(
                 feed={'input': self.x_np},

--- a/test/legacy_test/test_rad2deg.py
+++ b/test/legacy_test/test_rad2deg.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import get_current_place
+from op_test import get_device_place
 
 import paddle
 from paddle import base
@@ -41,7 +41,7 @@ class TestRad2degAPI(unittest.TestCase):
             )
             out = paddle.rad2deg(x)
 
-            place = get_current_place()
+            place = get_device_place()
             exe = base.Executor(place)
             res = exe.run(
                 feed={'input': self.x_np},

--- a/test/legacy_test/test_radam_op.py
+++ b/test/legacy_test/test_radam_op.py
@@ -16,7 +16,7 @@ import unittest
 from copy import deepcopy
 
 import numpy as np
-from op_test import OpTest, get_places
+from op_test import OpTest, get_device_place, get_places
 
 import paddle
 from paddle import base
@@ -511,7 +511,7 @@ class TestNdamaxMultiPrecision2_0(unittest.TestCase):
     def static_radam_mp(self, mp, use_amp):
         paddle.seed(2024)
         paddle.enable_static()
-        exe = paddle.static.Executor('gpu')
+        exe = paddle.static.Executor(get_device_place())
         train_program = paddle.static.Program()
         startup_program = paddle.static.Program()
 

--- a/test/legacy_test/test_randint_like.py
+++ b/test/legacy_test/test_randint_like.py
@@ -15,6 +15,7 @@
 import unittest
 
 import numpy as np
+from op_test import get_current_place
 
 import paddle
 
@@ -30,11 +31,7 @@ class TestRandintLikeAPI(unittest.TestCase):
         self.x_float64 = np.zeros((10, 12)).astype("float64")
 
         self.dtype = ["bool", "int32", "int64", "float16", "float32", "float64"]
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def test_static_api(self):
         paddle.enable_static()

--- a/test/legacy_test/test_randint_like.py
+++ b/test/legacy_test/test_randint_like.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import get_current_place
+from op_test import get_device_place
 
 import paddle
 
@@ -31,7 +31,7 @@ class TestRandintLikeAPI(unittest.TestCase):
         self.x_float64 = np.zeros((10, 12)).astype("float64")
 
         self.dtype = ["bool", "int32", "int64", "float16", "float32", "float64"]
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def test_static_api(self):
         paddle.enable_static()

--- a/test/legacy_test/test_randint_op.py
+++ b/test/legacy_test/test_randint_op.py
@@ -15,10 +15,9 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest
+from op_test import OpTest, get_current_place
 
 import paddle
-from paddle.base import core
 
 paddle.enable_static()
 
@@ -145,11 +144,7 @@ class TestRandintAPI(unittest.TestCase):
                 low=1, high=1000, shape=var_shape, dtype='int64'
             )
 
-            place = (
-                paddle.CUDAPlace(0)
-                if core.is_compiled_with_cuda()
-                else paddle.CPUPlace()
-            )
+            place = get_current_place()
             exe = paddle.static.Executor(place)
             outs = exe.run(
                 feed={'var_shape': np.array([100, 100]).astype('int64')},

--- a/test/legacy_test/test_randint_op.py
+++ b/test/legacy_test/test_randint_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, get_current_place
+from op_test import OpTest, get_device_place
 
 import paddle
 
@@ -144,7 +144,7 @@ class TestRandintAPI(unittest.TestCase):
                 low=1, high=1000, shape=var_shape, dtype='int64'
             )
 
-            place = get_current_place()
+            place = get_device_place()
             exe = paddle.static.Executor(place)
             outs = exe.run(
                 feed={'var_shape': np.array([100, 100]).astype('int64')},

--- a/test/legacy_test/test_randn_like.py
+++ b/test/legacy_test/test_randn_like.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import get_current_place
+from op_test import get_device_place
 from utils import dygraph_guard, static_guard
 
 import paddle
@@ -29,7 +29,7 @@ class TestRandnLikeAPI(unittest.TestCase):
         self.x_float64 = np.zeros((10, 12)).astype("float64")
 
         self.dtype = ["float16", "float32", "float64"]
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def test_static_api(self):
         with (

--- a/test/legacy_test/test_randn_like.py
+++ b/test/legacy_test/test_randn_like.py
@@ -15,6 +15,7 @@
 import unittest
 
 import numpy as np
+from op_test import get_current_place
 from utils import dygraph_guard, static_guard
 
 import paddle
@@ -28,11 +29,7 @@ class TestRandnLikeAPI(unittest.TestCase):
         self.x_float64 = np.zeros((10, 12)).astype("float64")
 
         self.dtype = ["float16", "float32", "float64"]
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def test_static_api(self):
         with (

--- a/test/legacy_test/test_randn_op.py
+++ b/test/legacy_test/test_randn_op.py
@@ -15,9 +15,9 @@
 import unittest
 
 import numpy as np
+from op_test import get_current_place
 
 import paddle
-from paddle.base import core
 from paddle.static import Program, program_guard
 
 
@@ -37,11 +37,7 @@ class TestRandnOp(unittest.TestCase):
             var_shape = paddle.static.data('X', [2], 'int32')
             x4 = paddle.randn(var_shape)
 
-        place = (
-            paddle.CUDAPlace(0)
-            if core.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        place = get_current_place()
         exe = paddle.static.Executor(place)
         res = exe.run(
             train_program,
@@ -57,11 +53,7 @@ class TestRandnOp(unittest.TestCase):
 class TestRandnOpForDygraph(unittest.TestCase):
     def test_api(self):
         shape = [1000, 784]
-        place = (
-            paddle.CUDAPlace(0)
-            if core.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        place = get_current_place()
         paddle.disable_static(place)
         x1 = paddle.randn(shape, 'float32')
         x2 = paddle.randn(shape, 'float64')

--- a/test/legacy_test/test_randn_op.py
+++ b/test/legacy_test/test_randn_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import get_current_place
+from op_test import get_device_place
 
 import paddle
 from paddle.static import Program, program_guard
@@ -37,7 +37,7 @@ class TestRandnOp(unittest.TestCase):
             var_shape = paddle.static.data('X', [2], 'int32')
             x4 = paddle.randn(var_shape)
 
-        place = get_current_place()
+        place = get_device_place()
         exe = paddle.static.Executor(place)
         res = exe.run(
             train_program,
@@ -53,7 +53,7 @@ class TestRandnOp(unittest.TestCase):
 class TestRandnOpForDygraph(unittest.TestCase):
     def test_api(self):
         shape = [1000, 784]
-        place = get_current_place()
+        place = get_device_place()
         paddle.disable_static(place)
         x1 = paddle.randn(shape, 'float32')
         x2 = paddle.randn(shape, 'float64')

--- a/test/legacy_test/test_randperm_op.py
+++ b/test/legacy_test/test_randperm_op.py
@@ -15,7 +15,12 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, convert_float_to_uint16, convert_uint16_to_float
+from op_test import (
+    OpTest,
+    convert_float_to_uint16,
+    convert_uint16_to_float,
+    get_current_place,
+)
 
 import paddle
 from paddle.base import core
@@ -171,11 +176,7 @@ class TestRandpermAPI(unittest.TestCase):
     def test_out(self):
         paddle.enable_static()
         n = 10
-        place = (
-            paddle.CUDAPlace(0)
-            if core.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        place = get_current_place()
         with paddle.static.program_guard(
             paddle.static.Program(), paddle.static.Program()
         ):

--- a/test/legacy_test/test_randperm_op.py
+++ b/test/legacy_test/test_randperm_op.py
@@ -19,7 +19,7 @@ from op_test import (
     OpTest,
     convert_float_to_uint16,
     convert_uint16_to_float,
-    get_current_place,
+    get_device_place,
 )
 
 import paddle
@@ -176,7 +176,7 @@ class TestRandpermAPI(unittest.TestCase):
     def test_out(self):
         paddle.enable_static()
         n = 10
-        place = get_current_place()
+        place = get_device_place()
         with paddle.static.program_guard(
             paddle.static.Program(), paddle.static.Program()
         ):

--- a/test/legacy_test/test_rmsprop_op.py
+++ b/test/legacy_test/test_rmsprop_op.py
@@ -16,7 +16,7 @@ import unittest
 
 import numpy as np
 from op import Operator
-from op_test import get_places
+from op_test import get_device_place, get_places
 
 import paddle
 from paddle import base
@@ -457,7 +457,7 @@ class TestRMSPropMultiPrecision2_0(unittest.TestCase):
         paddle.enable_static()
         paddle.seed(100)
         np.random.seed(100)
-        exe = paddle.static.Executor('gpu')
+        exe = paddle.static.Executor(get_device_place())
         train_program = paddle.static.Program()
         startup_program = paddle.static.Program()
 
@@ -545,7 +545,7 @@ class TestRMSPropMultiPrecision2_0(unittest.TestCase):
         with paddle.pir_utils.IrGuard():
             paddle.seed(100)
             np.random.seed(100)
-            exe = paddle.static.Executor('gpu')
+            exe = paddle.static.Executor(get_device_place())
             train_program = paddle.static.Program()
             startup_program = paddle.static.Program()
             optimizer = paddle.optimizer.RMSProp(0.1)

--- a/test/legacy_test/test_round_op.py
+++ b/test/legacy_test/test_round_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, get_current_place
+from op_test import OpTest, get_device_place
 from test_activation_op import TestActivation
 from utils import dygraph_guard, static_guard
 
@@ -329,7 +329,7 @@ class TestRoundAPI(unittest.TestCase):
     def setUp(self):
         np.random.seed(1024)
         self.x_np = np.random.uniform(-5, 5, [10, 12]).astype(np.float64)
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def test_dygraph_api(self):
         with dygraph_guard():

--- a/test/legacy_test/test_round_op.py
+++ b/test/legacy_test/test_round_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest
+from op_test import OpTest, get_current_place
 from test_activation_op import TestActivation
 from utils import dygraph_guard, static_guard
 
@@ -329,11 +329,7 @@ class TestRoundAPI(unittest.TestCase):
     def setUp(self):
         np.random.seed(1024)
         self.x_np = np.random.uniform(-5, 5, [10, 12]).astype(np.float64)
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def test_dygraph_api(self):
         with dygraph_guard():

--- a/test/legacy_test/test_rprop_op.py
+++ b/test/legacy_test/test_rprop_op.py
@@ -18,6 +18,7 @@ import numpy as np
 from op_test import (
     OpTest,
     convert_float_to_uint16,
+    get_device_place,
 )
 from utils import dygraph_guard
 
@@ -223,7 +224,7 @@ class TestRpropMultiPrecision2_0(unittest.TestCase):
         paddle.enable_static()
         paddle.seed(10)
         np.random.seed(10)
-        exe = paddle.static.Executor('gpu')
+        exe = paddle.static.Executor(get_device_place())
         train_program = paddle.static.Program()
         startup_program = paddle.static.Program()
 
@@ -345,7 +346,7 @@ class TestRpropSimple(unittest.TestCase):
             paddle.seed(10)
             np.random.seed(10)
 
-            exe = paddle.static.Executor('gpu')
+            exe = paddle.static.Executor(get_device_place())
             train_program = paddle.static.Program()
             startup_program = paddle.static.Program()
 

--- a/test/legacy_test/test_selu_op.py
+++ b/test/legacy_test/test_selu_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, convert_float_to_uint16
+from op_test import OpTest, convert_float_to_uint16, get_current_place
 
 import paddle
 import paddle.nn.functional as F
@@ -131,11 +131,7 @@ class TestSeluAPI(unittest.TestCase):
         # Since zero point in selu is not differentiable, avoid randomize
         # zero.
         self.x_np[np.abs(self.x_np) < 0.005] = 0.02
-        self.place = (
-            paddle.CUDAPlace(0)
-            if core.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def test_static_api(self):
         with paddle.static.program_guard(paddle.static.Program()):

--- a/test/legacy_test/test_selu_op.py
+++ b/test/legacy_test/test_selu_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, convert_float_to_uint16, get_current_place
+from op_test import OpTest, convert_float_to_uint16, get_device_place
 
 import paddle
 import paddle.nn.functional as F
@@ -131,7 +131,7 @@ class TestSeluAPI(unittest.TestCase):
         # Since zero point in selu is not differentiable, avoid randomize
         # zero.
         self.x_np[np.abs(self.x_np) < 0.005] = 0.02
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def test_static_api(self):
         with paddle.static.program_guard(paddle.static.Program()):

--- a/test/legacy_test/test_sgd_op.py
+++ b/test/legacy_test/test_sgd_op.py
@@ -16,7 +16,7 @@ import unittest
 
 import numpy as np
 from op import Operator
-from op_test import OpTest, get_places
+from op_test import OpTest, get_device_place, get_places
 from utils import dygraph_guard
 
 import paddle
@@ -271,7 +271,7 @@ class TestSGDSimple(unittest.TestCase):
             paddle.seed(10)
             np.random.seed(10)
 
-            exe = paddle.static.Executor('gpu')
+            exe = paddle.static.Executor(get_device_place())
             train_program = paddle.static.Program()
             startup_program = paddle.static.Program()
 

--- a/test/legacy_test/test_slice_op.py
+++ b/test/legacy_test/test_slice_op.py
@@ -20,7 +20,7 @@ from decorator_helper import prog_scope
 from op_test import (
     OpTest,
     convert_float_to_uint16,
-    get_current_place,
+    get_device_place,
     get_places,
     paddle_static_guard,
 )
@@ -942,7 +942,7 @@ class TestSliceApiWithDenseTensorArray(unittest.TestCase):
         self.end = 2
         self.axis = 1
 
-        self.place = get_current_place()
+        self.place = get_device_place()
         self.exe = base.Executor(self.place)
 
     def set_program_and_run(self, main_program, case_num):

--- a/test/legacy_test/test_slice_op.py
+++ b/test/legacy_test/test_slice_op.py
@@ -20,6 +20,7 @@ from decorator_helper import prog_scope
 from op_test import (
     OpTest,
     convert_float_to_uint16,
+    get_current_place,
     get_places,
     paddle_static_guard,
 )
@@ -941,11 +942,7 @@ class TestSliceApiWithDenseTensorArray(unittest.TestCase):
         self.end = 2
         self.axis = 1
 
-        self.place = (
-            base.CUDAPlace(0)
-            if base.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        self.place = get_current_place()
         self.exe = base.Executor(self.place)
 
     def set_program_and_run(self, main_program, case_num):

--- a/test/legacy_test/test_smooth_l1_loss.py
+++ b/test/legacy_test/test_smooth_l1_loss.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import get_places
+from op_test import get_current_place, get_places
 
 import paddle
 from paddle import base
@@ -70,11 +70,7 @@ class SmoothL1Loss(unittest.TestCase):
         input_np = np.random.random([100, 200]).astype(np.float32)
         label_np = np.random.random([100, 200]).astype(np.float32)
 
-        place = (
-            base.CUDAPlace(0)
-            if base.core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
 
         expected = smooth_l1_loss_np(input_np, label_np, reduction='mean')
 
@@ -118,11 +114,7 @@ class SmoothL1Loss(unittest.TestCase):
         input_np = np.random.random([100, 200]).astype(np.float32)
         label_np = np.random.random([100, 200]).astype(np.float32)
 
-        place = (
-            base.CUDAPlace(0)
-            if base.core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
         expected = smooth_l1_loss_np(input_np, label_np, reduction='sum')
 
         def test_static():
@@ -165,11 +157,7 @@ class SmoothL1Loss(unittest.TestCase):
         input_np = np.random.random([100, 200]).astype(np.float32)
         label_np = np.random.random([100, 200]).astype(np.float32)
 
-        place = (
-            base.CUDAPlace(0)
-            if base.core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
         expected = smooth_l1_loss_np(input_np, label_np, reduction='none')
 
         def test_static():
@@ -213,11 +201,7 @@ class SmoothL1Loss(unittest.TestCase):
         label_np = np.random.random([100, 200]).astype(np.float32)
         delta = np.random.rand()
 
-        place = (
-            base.CUDAPlace(0)
-            if base.core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
         expected = smooth_l1_loss_np(input_np, label_np, delta=delta)
 
         def test_static():
@@ -295,11 +279,7 @@ class SmoothL1LossDivDelta(unittest.TestCase):
         input_np = np.random.random([100, 200]).astype(np.float32)
         label_np = np.random.random([100, 200]).astype(np.float32)
 
-        place = (
-            base.CUDAPlace(0)
-            if base.core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
 
         expected = smooth_l1_loss_div_delta_np(
             input_np, label_np, reduction='mean'
@@ -345,11 +325,7 @@ class SmoothL1LossDivDelta(unittest.TestCase):
         input_np = np.random.random([100, 200]).astype(np.float32)
         label_np = np.random.random([100, 200]).astype(np.float32)
 
-        place = (
-            base.CUDAPlace(0)
-            if base.core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
         expected = smooth_l1_loss_div_delta_np(
             input_np, label_np, reduction='sum'
         )
@@ -398,11 +374,7 @@ class SmoothL1LossDivDelta(unittest.TestCase):
         input_np = np.random.random([100, 200]).astype(np.float32)
         label_np = np.random.random([100, 200]).astype(np.float32)
 
-        place = (
-            base.CUDAPlace(0)
-            if base.core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
         expected = smooth_l1_loss_div_delta_np(
             input_np, label_np, reduction='none'
         )
@@ -452,11 +424,7 @@ class SmoothL1LossDivDelta(unittest.TestCase):
         label_np = np.random.random([100, 200]).astype(np.float32)
         delta = np.random.rand()
 
-        place = (
-            base.CUDAPlace(0)
-            if base.core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
         expected = smooth_l1_loss_div_delta_np(input_np, label_np, delta=delta)
 
         def test_static():

--- a/test/legacy_test/test_smooth_l1_loss.py
+++ b/test/legacy_test/test_smooth_l1_loss.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import get_current_place, get_places
+from op_test import get_device_place, get_places
 
 import paddle
 from paddle import base
@@ -70,7 +70,7 @@ class SmoothL1Loss(unittest.TestCase):
         input_np = np.random.random([100, 200]).astype(np.float32)
         label_np = np.random.random([100, 200]).astype(np.float32)
 
-        place = get_current_place()
+        place = get_device_place()
 
         expected = smooth_l1_loss_np(input_np, label_np, reduction='mean')
 
@@ -114,7 +114,7 @@ class SmoothL1Loss(unittest.TestCase):
         input_np = np.random.random([100, 200]).astype(np.float32)
         label_np = np.random.random([100, 200]).astype(np.float32)
 
-        place = get_current_place()
+        place = get_device_place()
         expected = smooth_l1_loss_np(input_np, label_np, reduction='sum')
 
         def test_static():
@@ -157,7 +157,7 @@ class SmoothL1Loss(unittest.TestCase):
         input_np = np.random.random([100, 200]).astype(np.float32)
         label_np = np.random.random([100, 200]).astype(np.float32)
 
-        place = get_current_place()
+        place = get_device_place()
         expected = smooth_l1_loss_np(input_np, label_np, reduction='none')
 
         def test_static():
@@ -201,7 +201,7 @@ class SmoothL1Loss(unittest.TestCase):
         label_np = np.random.random([100, 200]).astype(np.float32)
         delta = np.random.rand()
 
-        place = get_current_place()
+        place = get_device_place()
         expected = smooth_l1_loss_np(input_np, label_np, delta=delta)
 
         def test_static():
@@ -279,7 +279,7 @@ class SmoothL1LossDivDelta(unittest.TestCase):
         input_np = np.random.random([100, 200]).astype(np.float32)
         label_np = np.random.random([100, 200]).astype(np.float32)
 
-        place = get_current_place()
+        place = get_device_place()
 
         expected = smooth_l1_loss_div_delta_np(
             input_np, label_np, reduction='mean'
@@ -325,7 +325,7 @@ class SmoothL1LossDivDelta(unittest.TestCase):
         input_np = np.random.random([100, 200]).astype(np.float32)
         label_np = np.random.random([100, 200]).astype(np.float32)
 
-        place = get_current_place()
+        place = get_device_place()
         expected = smooth_l1_loss_div_delta_np(
             input_np, label_np, reduction='sum'
         )
@@ -374,7 +374,7 @@ class SmoothL1LossDivDelta(unittest.TestCase):
         input_np = np.random.random([100, 200]).astype(np.float32)
         label_np = np.random.random([100, 200]).astype(np.float32)
 
-        place = get_current_place()
+        place = get_device_place()
         expected = smooth_l1_loss_div_delta_np(
             input_np, label_np, reduction='none'
         )
@@ -424,7 +424,7 @@ class SmoothL1LossDivDelta(unittest.TestCase):
         label_np = np.random.random([100, 200]).astype(np.float32)
         delta = np.random.rand()
 
-        place = get_current_place()
+        place = get_device_place()
         expected = smooth_l1_loss_div_delta_np(input_np, label_np, delta=delta)
 
         def test_static():

--- a/test/legacy_test/test_softmax2d.py
+++ b/test/legacy_test/test_softmax2d.py
@@ -18,7 +18,7 @@ import unittest
 import numpy as np
 
 sys.path.append("../deprecated/legacy_test")
-from op_test import get_current_place
+from op_test import get_device_place
 from test_softmax_op import ref_softmax
 
 import paddle
@@ -29,7 +29,7 @@ class TestSoftmax2DAPI(unittest.TestCase):
         self.shape = [2, 6, 5, 4]
         self.x_np = np.random.uniform(-1, 1, self.shape).astype('float64')
         self.axis = -3
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def test_static_api(self):
         paddle.enable_static()
@@ -57,7 +57,7 @@ class TestSoftmax2DShape(TestSoftmax2DAPI):
         self.shape = [2, 6, 4]
         self.x_np = np.random.uniform(-1, 1, self.shape).astype('float64')
         self.axis = -3
-        self.place = get_current_place()
+        self.place = get_device_place()
 
 
 class TestSoftmax2DFloat32(TestSoftmax2DAPI):
@@ -65,7 +65,7 @@ class TestSoftmax2DFloat32(TestSoftmax2DAPI):
         self.shape = [2, 3, 4]
         self.x_np = np.random.uniform(-1, 1, self.shape).astype('float32')
         self.axis = -3
-        self.place = get_current_place()
+        self.place = get_device_place()
 
 
 class TestSoftmax2DCPU(TestSoftmax2DAPI):
@@ -78,7 +78,7 @@ class TestSoftmax2DCPU(TestSoftmax2DAPI):
 
 class TestSoftmax2DRepr(unittest.TestCase):
     def setUp(self):
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def test_extra_repr(self):
         paddle.disable_static(self.place)
@@ -89,7 +89,7 @@ class TestSoftmax2DRepr(unittest.TestCase):
 
 class TestSoftmax2DError(unittest.TestCase):
     def setUp(self):
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def test_static_error(self):
         paddle.enable_static()

--- a/test/legacy_test/test_softmax2d.py
+++ b/test/legacy_test/test_softmax2d.py
@@ -18,10 +18,10 @@ import unittest
 import numpy as np
 
 sys.path.append("../deprecated/legacy_test")
+from op_test import get_current_place
 from test_softmax_op import ref_softmax
 
 import paddle
-from paddle.base import core
 
 
 class TestSoftmax2DAPI(unittest.TestCase):
@@ -29,11 +29,7 @@ class TestSoftmax2DAPI(unittest.TestCase):
         self.shape = [2, 6, 5, 4]
         self.x_np = np.random.uniform(-1, 1, self.shape).astype('float64')
         self.axis = -3
-        self.place = (
-            paddle.CUDAPlace(0)
-            if core.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def test_static_api(self):
         paddle.enable_static()
@@ -61,11 +57,7 @@ class TestSoftmax2DShape(TestSoftmax2DAPI):
         self.shape = [2, 6, 4]
         self.x_np = np.random.uniform(-1, 1, self.shape).astype('float64')
         self.axis = -3
-        self.place = (
-            paddle.CUDAPlace(0)
-            if core.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
 
 class TestSoftmax2DFloat32(TestSoftmax2DAPI):
@@ -73,11 +65,7 @@ class TestSoftmax2DFloat32(TestSoftmax2DAPI):
         self.shape = [2, 3, 4]
         self.x_np = np.random.uniform(-1, 1, self.shape).astype('float32')
         self.axis = -3
-        self.place = (
-            paddle.CUDAPlace(0)
-            if core.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
 
 class TestSoftmax2DCPU(TestSoftmax2DAPI):
@@ -90,11 +78,7 @@ class TestSoftmax2DCPU(TestSoftmax2DAPI):
 
 class TestSoftmax2DRepr(unittest.TestCase):
     def setUp(self):
-        self.place = (
-            paddle.CUDAPlace(0)
-            if core.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def test_extra_repr(self):
         paddle.disable_static(self.place)
@@ -105,11 +89,7 @@ class TestSoftmax2DRepr(unittest.TestCase):
 
 class TestSoftmax2DError(unittest.TestCase):
     def setUp(self):
-        self.place = (
-            paddle.CUDAPlace(0)
-            if core.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def test_static_error(self):
         paddle.enable_static()

--- a/test/legacy_test/test_softmax_op.py
+++ b/test/legacy_test/test_softmax_op.py
@@ -15,7 +15,12 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, convert_float_to_uint16, get_places
+from op_test import (
+    OpTest,
+    convert_float_to_uint16,
+    get_current_place,
+    get_places,
+)
 from utils import static_guard
 
 import paddle
@@ -528,11 +533,7 @@ class TestSoftmaxBF16CUDNNOp(TestSoftmaxBF16Op):
 
 class TestSoftmaxAPI(unittest.TestCase):
     def setUp(self):
-        self.place = (
-            paddle.CUDAPlace(0)
-            if core.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
         self.x_np = np.random.uniform(-1.0, 1.0, [2, 3, 4, 5]).astype('float32')
         self.out_ref = np.apply_along_axis(stable_softmax, -1, self.x_np)
         self.executed_api()

--- a/test/legacy_test/test_softmax_op.py
+++ b/test/legacy_test/test_softmax_op.py
@@ -18,7 +18,7 @@ import numpy as np
 from op_test import (
     OpTest,
     convert_float_to_uint16,
-    get_current_place,
+    get_device_place,
     get_places,
 )
 from utils import static_guard
@@ -533,7 +533,7 @@ class TestSoftmaxBF16CUDNNOp(TestSoftmaxBF16Op):
 
 class TestSoftmaxAPI(unittest.TestCase):
     def setUp(self):
-        self.place = get_current_place()
+        self.place = get_device_place()
         self.x_np = np.random.uniform(-1.0, 1.0, [2, 3, 4, 5]).astype('float32')
         self.out_ref = np.apply_along_axis(stable_softmax, -1, self.x_np)
         self.executed_api()

--- a/test/legacy_test/test_std_layer.py
+++ b/test/legacy_test/test_std_layer.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import get_current_place
+from op_test import get_device_place
 
 import paddle
 
@@ -38,7 +38,7 @@ class TestStdAPI(unittest.TestCase):
         self.unbiased = True
         self.set_attrs()
         self.x = np.random.uniform(-1, 1, self.shape).astype(self.dtype)
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def set_attrs(self):
         pass

--- a/test/legacy_test/test_std_layer.py
+++ b/test/legacy_test/test_std_layer.py
@@ -15,6 +15,7 @@
 import unittest
 
 import numpy as np
+from op_test import get_current_place
 
 import paddle
 
@@ -37,11 +38,7 @@ class TestStdAPI(unittest.TestCase):
         self.unbiased = True
         self.set_attrs()
         self.x = np.random.uniform(-1, 1, self.shape).astype(self.dtype)
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.base.core.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def set_attrs(self):
         pass

--- a/test/legacy_test/test_svdvals_op.py
+++ b/test/legacy_test/test_svdvals_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest
+from op_test import OpTest, get_current_place
 from utils import dygraph_guard, static_guard
 
 import paddle
@@ -94,11 +94,7 @@ class TestSvdvalsAPI(unittest.TestCase):
     def setUp(self):
         np.random.seed(1024)
         self.x_np = np.random.uniform(-3, 3, [10, 12]).astype('float32')
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def test_dygraph_api(self):
         with dygraph_guard():

--- a/test/legacy_test/test_svdvals_op.py
+++ b/test/legacy_test/test_svdvals_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, get_current_place
+from op_test import OpTest, get_device_place
 from utils import dygraph_guard, static_guard
 
 import paddle
@@ -94,7 +94,7 @@ class TestSvdvalsAPI(unittest.TestCase):
     def setUp(self):
         np.random.seed(1024)
         self.x_np = np.random.uniform(-3, 3, [10, 12]).astype('float32')
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def test_dygraph_api(self):
         with dygraph_guard():

--- a/test/legacy_test/test_switch_autotune.py
+++ b/test/legacy_test/test_switch_autotune.py
@@ -19,6 +19,7 @@ import unittest
 import warnings
 
 import numpy as np
+from op_test import get_current_place
 
 import paddle
 
@@ -133,11 +134,7 @@ class TestStaticAutoTuneStatus(TestAutoTune):
                 )
                 net = SimpleNet()
                 loss = static_program(net, data)
-            place = (
-                paddle.CUDAPlace(0)
-                if paddle.base.core.is_compiled_with_cuda()
-                else paddle.CPUPlace()
-            )
+            place = get_current_place()
             exe = paddle.static.Executor(place)
             exe.run(startup_program)
             x = np.random.random(size=data_shape).astype('float32')

--- a/test/legacy_test/test_switch_autotune.py
+++ b/test/legacy_test/test_switch_autotune.py
@@ -19,7 +19,7 @@ import unittest
 import warnings
 
 import numpy as np
-from op_test import get_current_place
+from op_test import get_device_place
 
 import paddle
 
@@ -134,7 +134,7 @@ class TestStaticAutoTuneStatus(TestAutoTune):
                 )
                 net = SimpleNet()
                 loss = static_program(net, data)
-            place = get_current_place()
+            place = get_device_place()
             exe = paddle.static.Executor(place)
             exe.run(startup_program)
             x = np.random.random(size=data_shape).astype('float32')

--- a/test/legacy_test/test_switch_case.py
+++ b/test/legacy_test/test_switch_case.py
@@ -16,7 +16,7 @@ import unittest
 from functools import partial
 
 import numpy as np
-from op_test import get_current_place
+from op_test import get_device_place
 
 import paddle
 from paddle import base
@@ -84,7 +84,7 @@ class TestAPISwitchCase(unittest.TestCase):
                 branch_fns=[(1, fn_1), (3, fn_2), (2, fn_3)],
             )
 
-            place = get_current_place()
+            place = get_device_place()
             exe = base.Executor(place)
 
             res = exe.run(
@@ -167,7 +167,7 @@ class TestAPISwitchCase(unittest.TestCase):
                 branch_fns=[(1, fn_1), (3, fn_2), (2, fn_3)],
             )
 
-            place = get_current_place()
+            place = get_device_place()
             exe = base.Executor(place)
 
             res = exe.run(
@@ -226,7 +226,7 @@ class TestAPISwitchCase(unittest.TestCase):
             )
             grad_list = append_backward(out)
 
-        place = get_current_place()
+        place = get_device_place()
         exe = base.Executor(place)
         if paddle.framework.in_pir_mode():
             for p, g in grad_list:
@@ -358,7 +358,7 @@ class TestAPISwitchCase(unittest.TestCase):
                 index_1, ((1, fn_1), (2, fn_2)), fn_3
             )
 
-            place = get_current_place()
+            place = get_device_place()
             exe = base.Executor(place)
             ret = exe.run(main_program, fetch_list=out)
 
@@ -453,7 +453,7 @@ class TestAPISwitchCase_Nested(unittest.TestCase):
                 branch_index=index_3, branch_fns={1: fn_1, 2: fn_2, 3: fn_3}
             )
 
-            place = get_current_place()
+            place = get_device_place()
             exe = base.Executor(place)
 
             res = exe.run(
@@ -546,7 +546,7 @@ class TestAPISwitchCase_Nested(unittest.TestCase):
                 branch_index=index_3, branch_fns={1: fn_1, 2: fn_2, 3: fn_3}
             )
 
-            place = get_current_place()
+            place = get_device_place()
             exe = base.Executor(place)
 
             res = exe.run(

--- a/test/legacy_test/test_switch_case.py
+++ b/test/legacy_test/test_switch_case.py
@@ -16,10 +16,10 @@ import unittest
 from functools import partial
 
 import numpy as np
+from op_test import get_current_place
 
 import paddle
 from paddle import base
-from paddle.base import core
 from paddle.base.backward import append_backward
 
 paddle.enable_static()
@@ -84,11 +84,7 @@ class TestAPISwitchCase(unittest.TestCase):
                 branch_fns=[(1, fn_1), (3, fn_2), (2, fn_3)],
             )
 
-            place = (
-                base.CUDAPlace(0)
-                if core.is_compiled_with_cuda()
-                else base.CPUPlace()
-            )
+            place = get_current_place()
             exe = base.Executor(place)
 
             res = exe.run(
@@ -171,11 +167,7 @@ class TestAPISwitchCase(unittest.TestCase):
                 branch_fns=[(1, fn_1), (3, fn_2), (2, fn_3)],
             )
 
-            place = (
-                base.CUDAPlace(0)
-                if core.is_compiled_with_cuda()
-                else base.CPUPlace()
-            )
+            place = get_current_place()
             exe = base.Executor(place)
 
             res = exe.run(
@@ -234,11 +226,7 @@ class TestAPISwitchCase(unittest.TestCase):
             )
             grad_list = append_backward(out)
 
-        place = (
-            base.CUDAPlace(0)
-            if core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
         exe = base.Executor(place)
         if paddle.framework.in_pir_mode():
             for p, g in grad_list:
@@ -370,11 +358,7 @@ class TestAPISwitchCase(unittest.TestCase):
                 index_1, ((1, fn_1), (2, fn_2)), fn_3
             )
 
-            place = (
-                base.CUDAPlace(0)
-                if core.is_compiled_with_cuda()
-                else base.CPUPlace()
-            )
+            place = get_current_place()
             exe = base.Executor(place)
             ret = exe.run(main_program, fetch_list=out)
 
@@ -469,11 +453,7 @@ class TestAPISwitchCase_Nested(unittest.TestCase):
                 branch_index=index_3, branch_fns={1: fn_1, 2: fn_2, 3: fn_3}
             )
 
-            place = (
-                base.CUDAPlace(0)
-                if core.is_compiled_with_cuda()
-                else base.CPUPlace()
-            )
+            place = get_current_place()
             exe = base.Executor(place)
 
             res = exe.run(
@@ -566,11 +546,7 @@ class TestAPISwitchCase_Nested(unittest.TestCase):
                 branch_index=index_3, branch_fns={1: fn_1, 2: fn_2, 3: fn_3}
             )
 
-            place = (
-                base.CUDAPlace(0)
-                if core.is_compiled_with_cuda()
-                else base.CPUPlace()
-            )
+            place = get_current_place()
             exe = base.Executor(place)
 
             res = exe.run(

--- a/test/legacy_test/test_take.py
+++ b/test/legacy_test/test_take.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import get_current_place
+from op_test import get_device_place
 
 import paddle
 
@@ -42,7 +42,7 @@ class TestTakeAPI(unittest.TestCase):
         self.set_mode()
         self.set_dtype()
         self.set_input()
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def test_static_graph(self):
         paddle.enable_static()
@@ -167,7 +167,7 @@ class TestTakeModeRaisePos(unittest.TestCase):
         self.set_mode()
         self.set_dtype()
         self.set_input()
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def test_static_index_error(self):
         """When the index is out of range,
@@ -215,7 +215,7 @@ class TestTakeModeRaiseNeg(TestTakeModeRaisePos):
         self.set_mode()
         self.set_dtype()
         self.set_input()
-        self.place = get_current_place()
+        self.place = get_device_place()
 
 
 class TestTakeModeWrap(TestTakeAPI):
@@ -278,7 +278,7 @@ class TestTakeAPI_ZeroSize(unittest.TestCase):
         self.set_mode()
         self.set_dtype()
         self.set_input()
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def test_dygraph(self):
         paddle.disable_static(self.place)

--- a/test/legacy_test/test_take.py
+++ b/test/legacy_test/test_take.py
@@ -15,10 +15,9 @@
 import unittest
 
 import numpy as np
+from op_test import get_current_place
 
 import paddle
-from paddle import base
-from paddle.base import core
 
 
 class TestTakeAPI(unittest.TestCase):
@@ -43,11 +42,7 @@ class TestTakeAPI(unittest.TestCase):
         self.set_mode()
         self.set_dtype()
         self.set_input()
-        self.place = (
-            base.CUDAPlace(0)
-            if core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def test_static_graph(self):
         paddle.enable_static()
@@ -172,11 +167,7 @@ class TestTakeModeRaisePos(unittest.TestCase):
         self.set_mode()
         self.set_dtype()
         self.set_input()
-        self.place = (
-            base.CUDAPlace(0)
-            if core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def test_static_index_error(self):
         """When the index is out of range,
@@ -224,11 +215,7 @@ class TestTakeModeRaiseNeg(TestTakeModeRaisePos):
         self.set_mode()
         self.set_dtype()
         self.set_input()
-        self.place = (
-            base.CUDAPlace(0)
-            if core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        self.place = get_current_place()
 
 
 class TestTakeModeWrap(TestTakeAPI):
@@ -291,11 +278,7 @@ class TestTakeAPI_ZeroSize(unittest.TestCase):
         self.set_mode()
         self.set_dtype()
         self.set_input()
-        self.place = (
-            base.CUDAPlace(0)
-            if core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def test_dygraph(self):
         paddle.disable_static(self.place)

--- a/test/legacy_test/test_tensor_array_to_tensor.py
+++ b/test/legacy_test/test_tensor_array_to_tensor.py
@@ -15,6 +15,7 @@
 import unittest
 
 import numpy as np
+from op_test import get_current_place
 
 import paddle
 from paddle import base
@@ -194,11 +195,7 @@ class TestPirArrayOp(unittest.TestCase):
                     input=array, axis=1, use_stack=False
                 )
 
-            place = (
-                paddle.base.CPUPlace()
-                if not paddle.base.core.is_compiled_with_cuda()
-                else paddle.base.CUDAPlace(0)
-            )
+            place = get_current_place()
             exe = paddle.base.Executor(place)
             [fetched_out0, fetched_out1] = exe.run(
                 main_program, feed={}, fetch_list=[output, output_index]
@@ -235,11 +232,7 @@ class TestPirArrayOp(unittest.TestCase):
             loss = paddle.mean(output)
             dout = paddle.base.gradients(loss, [x, y])
 
-        place = (
-            paddle.base.CPUPlace()
-            if not paddle.base.core.is_compiled_with_cuda()
-            else paddle.base.CUDAPlace(0)
-        )
+        place = get_current_place()
         exe = paddle.base.Executor(place)
         [fetched_out0, fetched_out1, fetched_out2] = exe.run(
             main_program, feed={}, fetch_list=[output, dout[0], dout[1]]
@@ -283,11 +276,7 @@ class TestPirArrayOp(unittest.TestCase):
             loss = paddle.mean(output)
             dout = paddle.base.gradients(loss, [x, y])
 
-        place = (
-            paddle.base.CPUPlace()
-            if not paddle.base.core.is_compiled_with_cuda()
-            else paddle.base.CUDAPlace(0)
-        )
+        place = get_current_place()
         exe = paddle.base.Executor(place)
         [fetched_out0, fetched_out1, fetched_out2] = exe.run(
             main_program, feed={}, fetch_list=[output, dout[0], dout[1]]

--- a/test/legacy_test/test_tensor_array_to_tensor.py
+++ b/test/legacy_test/test_tensor_array_to_tensor.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import get_current_place
+from op_test import get_device_place
 
 import paddle
 from paddle import base
@@ -195,7 +195,7 @@ class TestPirArrayOp(unittest.TestCase):
                     input=array, axis=1, use_stack=False
                 )
 
-            place = get_current_place()
+            place = get_device_place()
             exe = paddle.base.Executor(place)
             [fetched_out0, fetched_out1] = exe.run(
                 main_program, feed={}, fetch_list=[output, output_index]
@@ -232,7 +232,7 @@ class TestPirArrayOp(unittest.TestCase):
             loss = paddle.mean(output)
             dout = paddle.base.gradients(loss, [x, y])
 
-        place = get_current_place()
+        place = get_device_place()
         exe = paddle.base.Executor(place)
         [fetched_out0, fetched_out1, fetched_out2] = exe.run(
             main_program, feed={}, fetch_list=[output, dout[0], dout[1]]
@@ -276,7 +276,7 @@ class TestPirArrayOp(unittest.TestCase):
             loss = paddle.mean(output)
             dout = paddle.base.gradients(loss, [x, y])
 
-        place = get_current_place()
+        place = get_device_place()
         exe = paddle.base.Executor(place)
         [fetched_out0, fetched_out1, fetched_out2] = exe.run(
             main_program, feed={}, fetch_list=[output, dout[0], dout[1]]

--- a/test/legacy_test/test_transfer_layout_op.py
+++ b/test/legacy_test/test_transfer_layout_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, convert_float_to_uint16
+from op_test import OpTest, convert_float_to_uint16, get_current_place
 
 import paddle
 from paddle import base
@@ -75,11 +75,7 @@ class TestTransferLayoutOpGpu(unittest.TestCase):
                 y = softmax_with_data_format(x, data_format='NCHW')
                 z = softmax_with_data_format(y, data_format='NHWC')
 
-            place = (
-                base.CUDAPlace(0)
-                if core.is_compiled_with_cuda()
-                else base.CPUPlace()
-            )
+            place = get_current_place()
             exe = base.Executor(place)
             exe.run(startup_program)
             ret = exe.run(

--- a/test/legacy_test/test_transfer_layout_op.py
+++ b/test/legacy_test/test_transfer_layout_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, convert_float_to_uint16, get_current_place
+from op_test import OpTest, convert_float_to_uint16, get_device_place
 
 import paddle
 from paddle import base
@@ -75,7 +75,7 @@ class TestTransferLayoutOpGpu(unittest.TestCase):
                 y = softmax_with_data_format(x, data_format='NCHW')
                 z = softmax_with_data_format(y, data_format='NHWC')
 
-            place = get_current_place()
+            place = get_device_place()
             exe = base.Executor(place)
             exe.run(startup_program)
             ret = exe.run(

--- a/test/legacy_test/test_tril_triu_op.py
+++ b/test/legacy_test/test_tril_triu_op.py
@@ -14,7 +14,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, convert_float_to_uint16
+from op_test import OpTest, convert_float_to_uint16, get_current_place
 
 import paddle
 from paddle import base, tensor
@@ -261,11 +261,7 @@ class TestTrilTriuOpAPI(unittest.TestCase):
                     ).astype(dtype)
                 tril_out, triu_out = tensor.tril(x), tensor.triu(x)
 
-                place = (
-                    base.CUDAPlace(0)
-                    if base.core.is_compiled_with_cuda()
-                    else base.CPUPlace()
-                )
+                place = get_current_place()
                 exe = base.Executor(place)
                 tril_out, triu_out = exe.run(
                     prog,
@@ -314,11 +310,7 @@ class TestTrilTriuOpAPI(unittest.TestCase):
                     ).astype(dtype)
                 triu_out = paddle.triu(x)
 
-                place = (
-                    base.CUDAPlace(0)
-                    if base.core.is_compiled_with_cuda()
-                    else base.CPUPlace()
-                )
+                place = get_current_place()
                 exe = base.Executor(place)
                 triu_out = exe.run(
                     prog,

--- a/test/legacy_test/test_tril_triu_op.py
+++ b/test/legacy_test/test_tril_triu_op.py
@@ -14,7 +14,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, convert_float_to_uint16, get_current_place
+from op_test import OpTest, convert_float_to_uint16, get_device_place
 
 import paddle
 from paddle import base, tensor
@@ -261,7 +261,7 @@ class TestTrilTriuOpAPI(unittest.TestCase):
                     ).astype(dtype)
                 tril_out, triu_out = tensor.tril(x), tensor.triu(x)
 
-                place = get_current_place()
+                place = get_device_place()
                 exe = base.Executor(place)
                 tril_out, triu_out = exe.run(
                     prog,
@@ -310,7 +310,7 @@ class TestTrilTriuOpAPI(unittest.TestCase):
                     ).astype(dtype)
                 triu_out = paddle.triu(x)
 
-                place = get_current_place()
+                place = get_device_place()
                 exe = base.Executor(place)
                 triu_out = exe.run(
                     prog,

--- a/test/legacy_test/test_vander.py
+++ b/test/legacy_test/test_vander.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import get_current_place
+from op_test import get_device_place
 
 import paddle
 
@@ -32,7 +32,7 @@ class TestVanderAPI(unittest.TestCase):
     def setUp(self):
         self.shape = [5]
         self.x = np.random.uniform(-1, 1, self.shape).astype(np.float32)
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def api_case(self, N=None, increasing=False):
         paddle.enable_static()

--- a/test/legacy_test/test_vander.py
+++ b/test/legacy_test/test_vander.py
@@ -15,9 +15,9 @@
 import unittest
 
 import numpy as np
+from op_test import get_current_place
 
 import paddle
-from paddle.base import core
 
 np.random.seed(10)
 
@@ -32,11 +32,7 @@ class TestVanderAPI(unittest.TestCase):
     def setUp(self):
         self.shape = [5]
         self.x = np.random.uniform(-1, 1, self.shape).astype(np.float32)
-        self.place = (
-            paddle.CUDAPlace(0)
-            if core.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def api_case(self, N=None, increasing=False):
         paddle.enable_static()

--- a/test/legacy_test/test_variance_layer.py
+++ b/test/legacy_test/test_variance_layer.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import get_current_place
+from op_test import get_device_place
 
 import paddle
 
@@ -38,7 +38,7 @@ class TestVarAPI(unittest.TestCase):
         self.unbiased = True
         self.set_attrs()
         self.x = np.random.uniform(-1, 1, self.shape).astype(self.dtype)
-        self.place = get_current_place()
+        self.place = get_device_place()
 
     def set_attrs(self):
         pass

--- a/test/legacy_test/test_variance_layer.py
+++ b/test/legacy_test/test_variance_layer.py
@@ -15,6 +15,7 @@
 import unittest
 
 import numpy as np
+from op_test import get_current_place
 
 import paddle
 
@@ -37,11 +38,7 @@ class TestVarAPI(unittest.TestCase):
         self.unbiased = True
         self.set_attrs()
         self.x = np.random.uniform(-1, 1, self.shape).astype(self.dtype)
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.base.core.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
+        self.place = get_current_place()
 
     def set_attrs(self):
         pass

--- a/test/legacy_test/test_zero_dim_sundry_dygraph_api.py
+++ b/test/legacy_test/test_zero_dim_sundry_dygraph_api.py
@@ -21,7 +21,7 @@ import os
 import unittest
 
 import numpy as np
-from op_test import get_current_place, get_places
+from op_test import get_device_place, get_places
 
 import paddle
 import paddle.nn.functional as F
@@ -2031,7 +2031,7 @@ class TestSundryAPI(unittest.TestCase):
                     di = g
                 elif p.is_same(x):
                     dx = g
-            place = get_current_place()
+            place = get_device_place()
             exe = base.Executor(place)
             main_program = paddle.static.default_main_program()
             out_i, out_x, di, dx = exe.run(

--- a/test/legacy_test/test_zero_dim_sundry_dygraph_api.py
+++ b/test/legacy_test/test_zero_dim_sundry_dygraph_api.py
@@ -21,11 +21,11 @@ import os
 import unittest
 
 import numpy as np
-from op_test import get_places
+from op_test import get_current_place, get_places
 
 import paddle
 import paddle.nn.functional as F
-from paddle import base, core
+from paddle import base
 from paddle.framework import in_dynamic_mode
 
 
@@ -2031,11 +2031,7 @@ class TestSundryAPI(unittest.TestCase):
                     di = g
                 elif p.is_same(x):
                     dx = g
-            place = (
-                base.CUDAPlace(0)
-                if core.is_compiled_with_cuda()
-                else base.CPUPlace()
-            )
+            place = get_current_place()
             exe = base.Executor(place)
             main_program = paddle.static.default_main_program()
             out_i, out_x, di, dx = exe.run(

--- a/test/legacy_test/test_zeros_like_op.py
+++ b/test/legacy_test/test_zeros_like_op.py
@@ -15,10 +15,11 @@
 import unittest
 
 import numpy as np
+from op_test import get_current_place
 
 import paddle
 from paddle import _C_ops, base, zeros_like
-from paddle.base import Program, core, program_guard
+from paddle.base import Program, program_guard
 from paddle.base.framework import convert_np_dtype_to_dtype_
 
 
@@ -34,11 +35,7 @@ class TestZerosLikeAPI(unittest.TestCase):
             out3 = zeros_like(x, 'float64')
             out4 = zeros_like(x, 'int32')
             out5 = zeros_like(x, 'int64')
-        place = (
-            base.CUDAPlace(0)
-            if core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
         exe = base.Executor(place)
         outs = exe.run(
             train_program,
@@ -55,11 +52,7 @@ class TestZerosLikeAPI(unittest.TestCase):
 class TestZerosLikeImperative(unittest.TestCase):
     def test_out(self):
         shape = [3, 4]
-        place = (
-            base.CUDAPlace(0)
-            if core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
         paddle.disable_static(place)
         x = paddle.to_tensor(np.ones(shape))
         for dtype in [np.bool_, np.float32, np.float64, np.int32, np.int64]:
@@ -77,11 +70,7 @@ class TestZerosLikeImperative(unittest.TestCase):
 class TestZerosAPI(unittest.TestCase):
     def test_api(self):
         shape = [3, 4]
-        place = (
-            base.CUDAPlace(0)
-            if core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
+        place = get_current_place()
         paddle.disable_static(place)
 
         for dtype in [np.float32, np.float64, np.int32, np.int64]:

--- a/test/legacy_test/test_zeros_like_op.py
+++ b/test/legacy_test/test_zeros_like_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import get_current_place
+from op_test import get_device_place
 
 import paddle
 from paddle import _C_ops, base, zeros_like
@@ -35,7 +35,7 @@ class TestZerosLikeAPI(unittest.TestCase):
             out3 = zeros_like(x, 'float64')
             out4 = zeros_like(x, 'int32')
             out5 = zeros_like(x, 'int64')
-        place = get_current_place()
+        place = get_device_place()
         exe = base.Executor(place)
         outs = exe.run(
             train_program,
@@ -52,7 +52,7 @@ class TestZerosLikeAPI(unittest.TestCase):
 class TestZerosLikeImperative(unittest.TestCase):
     def test_out(self):
         shape = [3, 4]
-        place = get_current_place()
+        place = get_device_place()
         paddle.disable_static(place)
         x = paddle.to_tensor(np.ones(shape))
         for dtype in [np.bool_, np.float32, np.float64, np.int32, np.int64]:
@@ -70,7 +70,7 @@ class TestZerosLikeImperative(unittest.TestCase):
 class TestZerosAPI(unittest.TestCase):
     def test_api(self):
         shape = [3, 4]
-        place = get_current_place()
+        place = get_device_place()
         paddle.disable_static(place)
 
         for dtype in [np.float32, np.float64, np.int32, np.int64]:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Custom Device

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
pcard-67164
Rebase Latest
add get_device_place in op_test.py, and replace the method of obtaining place in legacy_test