### PR TITLE
[Phi] Add MonotonicAllocator to avoid memory fragmentation in certain scenarios

### DIFF
--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -85,12 +85,12 @@ limitations under the License. */
 #include "paddle/phi/common/int_array.h"
 #include "paddle/phi/core/framework/reader.h"
 #include "paddle/phi/core/memory/allocation/allocator_strategy.h"
+#include "paddle/phi/core/memory/allocation/monotonic_allocator.h"
 #include "paddle/phi/core/raw_tensor.h"
 #include "paddle/phi/core/tensor_meta.h"
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
 #include "paddle/phi/core/memory/allocation/auto_growth_best_fit_allocator_v2.h"
 #include "paddle/phi/core/memory/allocation/cuda_ipc_allocator.h"
-#include "paddle/phi/core/memory/allocation/monotonic_allocator.h"
 #endif
 #include "paddle/common/macros.h"
 #include "paddle/fluid/operators/ops_extra_info.h"
@@ -3963,7 +3963,6 @@ All parameter, weight, gradient are variables in Paddle.
   });
 #endif
 
-#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
   py::class_<paddle::memory::allocation::MonotonicAllocatorManager>(
       m, "_MonotonicAllocatorManager")
       .def("_enable",
@@ -3996,7 +3995,6 @@ All parameter, weight, gradient are variables in Paddle.
         paddle::memory::allocation::MonotonicAllocatorManager::Instance()
             .ResetBuffer(place);
       });
-#endif
 
 #if defined(PADDLE_WITH_PSLIB) && !defined(PADDLE_WITH_HETERPS)
   BindHeterWrapper(&m);

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -90,6 +90,7 @@ limitations under the License. */
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
 #include "paddle/phi/core/memory/allocation/auto_growth_best_fit_allocator_v2.h"
 #include "paddle/phi/core/memory/allocation/cuda_ipc_allocator.h"
+#include "paddle/phi/core/memory/allocation/monotonic_allocator.h"
 #endif
 #include "paddle/common/macros.h"
 #include "paddle/fluid/operators/ops_extra_info.h"
@@ -3960,6 +3961,41 @@ All parameter, weight, gradient are variables in Paddle.
   m.def("register_paddle_plugin", []() {
     paddle::platform::TrtPluginRegistry::Global()->RegisterToTrt();
   });
+#endif
+
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+  py::class_<paddle::memory::allocation::MonotonicAllocatorManager>(
+      m, "_MonotonicAllocatorManager")
+      .def("_enable",
+           [] {
+             paddle::memory::allocation::MonotonicAllocatorManager::Instance()
+                 .Enable();
+           })
+      .def("_disable",
+           [] {
+             paddle::memory::allocation::MonotonicAllocatorManager::Instance()
+                 .Disable();
+           })
+      .def("_is_enabled",
+           [] {
+             return paddle::memory::allocation::MonotonicAllocatorManager::
+                 Instance()
+                     .IsEnabled();
+           })
+      .def("_allocate_buffer",
+           [](const phi::Place &place, size_t capacity) {
+             paddle::memory::allocation::MonotonicAllocatorManager::Instance()
+                 .AllocateBuffer(place, capacity);
+           })
+      .def("_deallocate_buffer",
+           [](const phi::Place &place) {
+             paddle::memory::allocation::MonotonicAllocatorManager::Instance()
+                 .DeallocateBuffer(place);
+           })
+      .def("_reset_buffer", [](const phi::Place &place) {
+        paddle::memory::allocation::MonotonicAllocatorManager::Instance()
+            .ResetBuffer(place);
+      });
 #endif
 
 #if defined(PADDLE_WITH_PSLIB) && !defined(PADDLE_WITH_HETERPS)

--- a/paddle/phi/core/device_context.cc
+++ b/paddle/phi/core/device_context.cc
@@ -16,8 +16,10 @@
 
 #if defined(PADDLE_WITH_CUDA)
 #include "paddle/phi/backends/gpu/cuda/cuda_graph.h"
+#include "paddle/phi/core/memory/allocation/monotonic_allocator.h"
 #elif defined(PADDLE_WITH_HIP)
 #include "paddle/phi/backends/gpu/rocm/hip_graph.h"
+#include "paddle/phi/core/memory/allocation/monotonic_allocator.h"
 #endif
 
 #include "paddle/phi/core/dense_tensor.h"
@@ -29,7 +31,7 @@ namespace phi {
 using DataType = phi::DataType;
 
 struct DeviceContext::Impl {
-  Impl() = default;
+  explicit Impl(DeviceContext* ctx) : device_ctx_(ctx) {}
   ~Impl() = default;
 
   void SetAllocator(const Allocator* allocator) {
@@ -166,16 +168,22 @@ struct DeviceContext::Impl {
             ? zero_allocator_
             : (pinned ? pinned_allocator_ : device_allocator_);
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
-    bool must_cuda_graph_allocator =
-        (!fake_alloc && tensor->numel() != 0) && !pinned;
-    if (must_cuda_graph_allocator &&
-        place.GetType() == phi::AllocationType::GPU &&
+    bool use_cuda_allocator = (!fake_alloc && tensor->numel() != 0) && !pinned;
+    if (use_cuda_allocator && place.GetType() == phi::AllocationType::GPU &&
         phi::backends::gpu::CUDAGraph::IsThisThreadCapturing()) {
       PADDLE_ENFORCE_NOT_NULL(cuda_graph_allocator_,
                               common::errors::InvalidArgument(
                                   "Required cuda_graph_allocator_ shall not be "
                                   "nullptr, but received nullptr."));
       allocator = cuda_graph_allocator_;
+    }
+    if (use_cuda_allocator && place.GetType() == phi::AllocationType::GPU &&
+        paddle::memory::allocation::MonotonicAllocatorManager::Instance()
+            .IsEnabled()) {
+      allocator =
+          paddle::memory::allocation::MonotonicAllocatorManager::Instance()
+              .GetAllocator(place)
+              .get();
     }
 #endif
     return tensor->AllocateFrom(const_cast<Allocator*>(allocator),
@@ -298,12 +306,13 @@ struct DeviceContext::Impl {
   Generator* host_generator_{nullptr};
 
   distributed::CommContext* comm_context_{nullptr};
+  DeviceContext* device_ctx_{nullptr};
 };
 
-DeviceContext::DeviceContext() { impl_ = std::make_unique<Impl>(); }
+DeviceContext::DeviceContext() { impl_ = std::make_unique<Impl>(this); }
 
 DeviceContext::DeviceContext(const DeviceContext& other) {
-  impl_ = std::make_unique<Impl>();
+  impl_ = std::make_unique<Impl>(this);
   impl_->SetHostAllocator(&other.GetHostAllocator());
   impl_->SetAllocator(&other.GetAllocator());
   impl_->SetZeroAllocator(&other.GetZeroAllocator());

--- a/paddle/phi/core/device_context.cc
+++ b/paddle/phi/core/device_context.cc
@@ -165,9 +165,10 @@ struct DeviceContext::Impl {
         (fake_alloc || tensor->numel() == 0) && requested_size == 0
             ? zero_allocator_
             : (pinned ? pinned_allocator_ : device_allocator_);
+    bool use_normal_allocator =
+        (!fake_alloc && tensor->numel() != 0) && !pinned;
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
-    bool use_cuda_allocator = (!fake_alloc && tensor->numel() != 0) && !pinned;
-    if (use_cuda_allocator && place.GetType() == phi::AllocationType::GPU &&
+    if (use_normal_allocator && place.GetType() == phi::AllocationType::GPU &&
         phi::backends::gpu::CUDAGraph::IsThisThreadCapturing()) {
       PADDLE_ENFORCE_NOT_NULL(cuda_graph_allocator_,
                               common::errors::InvalidArgument(
@@ -175,15 +176,15 @@ struct DeviceContext::Impl {
                                   "nullptr, but received nullptr."));
       allocator = cuda_graph_allocator_;
     }
-    if (use_cuda_allocator && place.GetType() == phi::AllocationType::GPU &&
+#endif
+    if (use_normal_allocator && place.GetType() == phi::AllocationType::GPU &&
         paddle::memory::allocation::MonotonicAllocatorManager::Instance()
             .IsEnabled()) {
       allocator =
           paddle::memory::allocation::MonotonicAllocatorManager::Instance()
-              .GetAllocator(place)
+              .CreateOrGetAllocator(place, const_cast<Allocator*>(allocator))
               .get();
     }
-#endif
     return tensor->AllocateFrom(const_cast<Allocator*>(allocator),
                                 dtype,
                                 requested_size,

--- a/paddle/phi/core/device_context.cc
+++ b/paddle/phi/core/device_context.cc
@@ -16,14 +16,12 @@
 
 #if defined(PADDLE_WITH_CUDA)
 #include "paddle/phi/backends/gpu/cuda/cuda_graph.h"
-#include "paddle/phi/core/memory/allocation/monotonic_allocator.h"
 #elif defined(PADDLE_WITH_HIP)
 #include "paddle/phi/backends/gpu/rocm/hip_graph.h"
-#include "paddle/phi/core/memory/allocation/monotonic_allocator.h"
 #endif
-
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/enforce.h"
+#include "paddle/phi/core/memory/allocation/monotonic_allocator.h"
 #include "paddle/phi/core/selected_rows.h"
 #include "paddle/phi/core/string_tensor.h"
 
@@ -31,7 +29,7 @@ namespace phi {
 using DataType = phi::DataType;
 
 struct DeviceContext::Impl {
-  explicit Impl(DeviceContext* ctx) : device_ctx_(ctx) {}
+  Impl() = default;
   ~Impl() = default;
 
   void SetAllocator(const Allocator* allocator) {
@@ -306,13 +304,12 @@ struct DeviceContext::Impl {
   Generator* host_generator_{nullptr};
 
   distributed::CommContext* comm_context_{nullptr};
-  DeviceContext* device_ctx_{nullptr};
 };
 
-DeviceContext::DeviceContext() { impl_ = std::make_unique<Impl>(this); }
+DeviceContext::DeviceContext() { impl_ = std::make_unique<Impl>(); }
 
 DeviceContext::DeviceContext(const DeviceContext& other) {
-  impl_ = std::make_unique<Impl>(this);
+  impl_ = std::make_unique<Impl>();
   impl_->SetHostAllocator(&other.GetHostAllocator());
   impl_->SetAllocator(&other.GetAllocator());
   impl_->SetZeroAllocator(&other.GetZeroAllocator());

--- a/paddle/phi/core/memory/allocation/CMakeLists.txt
+++ b/paddle/phi/core/memory/allocation/CMakeLists.txt
@@ -15,7 +15,8 @@ set(ALLOCATOR_SRCS
     memory_block_desc.cc
     meta_cache.cc
     buddy_allocator.cc
-    system_allocator.cc)
+    system_allocator.cc
+    monotonic_allocator.cc)
 
 if(WITH_GPU OR WITH_ROCM)
   list(
@@ -26,8 +27,7 @@ if(WITH_GPU OR WITH_ROCM)
     cuda_malloc_async_allocator.cc
     pinned_allocator.cc
     stream_safe_cuda_allocator.cc
-    thread_local_allocator.cc
-    monotonic_allocator.cc)
+    thread_local_allocator.cc)
 endif()
 
 if(CUDA_VERSION VERSION_GREATER_EQUAL 10.2)

--- a/paddle/phi/core/memory/allocation/CMakeLists.txt
+++ b/paddle/phi/core/memory/allocation/CMakeLists.txt
@@ -26,7 +26,8 @@ if(WITH_GPU OR WITH_ROCM)
     cuda_malloc_async_allocator.cc
     pinned_allocator.cc
     stream_safe_cuda_allocator.cc
-    thread_local_allocator.cc)
+    thread_local_allocator.cc
+    monotonic_allocator.cc)
 endif()
 
 if(CUDA_VERSION VERSION_GREATER_EQUAL 10.2)

--- a/paddle/phi/core/memory/allocation/allocator_facade.cc
+++ b/paddle/phi/core/memory/allocation/allocator_facade.cc
@@ -366,13 +366,6 @@ class AllocatorFacadePrivate {
         UNLIKELY(IsCUDAGraphCapturing())) {
       WrapCUDAGraphAllocator();
     }
-
-    // MonotonicAllocator is not compatible with CUDAGraphAllocator and
-    // StreamSafeCUDAAllocator
-    if (is_stream_safe_cuda_allocator_used_ ||
-        !UNLIKELY(IsCUDAGraphCapturing)) {
-      InitMonotonicCUDAAllocator();
-    }
 #endif
   }
 
@@ -1176,17 +1169,6 @@ class AllocatorFacadePrivate {
     }
 #endif
 #endif
-  }
-
-  void InitMonotonicCUDAAllocator() {
-    for (const auto& pair : allocators_) {
-      if (phi::is_gpu_place(pair.first)) {
-        MonotonicAllocatorManager::Instance().SetAllocator(
-            std::make_shared<MonotonicAllocator>(pair.second,
-                                                 platform::GpuMinChunkSize()),
-            pair.first);
-      }
-    }
   }
 
   void InitThreadLocalCUDAAllocator(phi::GPUPlace p) {

--- a/paddle/phi/core/memory/allocation/allocator_facade.cc
+++ b/paddle/phi/core/memory/allocation/allocator_facade.cc
@@ -36,6 +36,7 @@
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/core/memory/allocation/cuda_allocator.h"
 #include "paddle/phi/core/memory/allocation/cuda_managed_allocator.h"
+#include "paddle/phi/core/memory/allocation/monotonic_allocator.h"
 #include "paddle/phi/core/memory/allocation/pinned_allocator.h"
 #include "paddle/phi/core/memory/allocation/stream_safe_cuda_allocator.h"
 #include "paddle/phi/core/memory/allocation/thread_local_allocator.h"
@@ -359,6 +360,11 @@ class AllocatorFacadePrivate {
 
     CheckAllocThreadSafe();
 
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+    for (int dev_id = 0; dev_id < platform::GetGPUDeviceCount(); ++dev_id) {
+      InitMonotonicCUDAAllocator(phi::GPUPlace(dev_id));
+    }
+#endif
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
     // No need to wrap CUDAGraphAllocator for StreamSafeCUDAAllocator
     if (!is_stream_safe_cuda_allocator_used_ &&
@@ -1166,6 +1172,68 @@ class AllocatorFacadePrivate {
       allocators_[p] = std::make_shared<AutoGrowthBestFitAllocator>(
           underlying_allocator, alignment, chunk_size, allow_free_idle_chunk);
     }
+#endif
+#endif
+  }
+
+  void InitMonotonicCUDAAllocator(phi::GPUPlace p) {
+#if defined(PADDLE_WITH_HIP)
+    auto cuda_allocator = CreateCUDAAllocator(p);
+    MonotonicAllocatorManager::Instance().SetAllocator(
+        std::make_shared<MonotonicAllocator>(cuda_allocator,
+                                             platform::GpuMinChunkSize()),
+        p);
+#endif
+
+#if defined(PADDLE_WITH_CUDA)
+#if CUDA_VERSION >= 10020
+    CUdevice device;
+    int val;
+    try {
+      PADDLE_ENFORCE_GPU_SUCCESS(
+          phi::dynload::cuDeviceGet(&device, p.GetDeviceId()));
+
+      PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::cuDeviceGetAttribute(
+          &val,
+          CU_DEVICE_ATTRIBUTE_VIRTUAL_ADDRESS_MANAGEMENT_SUPPORTED,
+          device));
+    } catch (...) {
+      val = 0;
+    }
+    auto cuda_allocator = CreateCUDAAllocator(p);
+    MonotonicAllocatorManager::Instance().SetAllocator(
+        std::make_shared<MonotonicAllocator>(cuda_allocator,
+                                             platform::GpuMinChunkSize()),
+        p);
+#else
+    auto cuda_allocator = CreateCUDAAllocator(p);
+    auto alignment = platform::GpuMinChunkSize();
+    bool need_addr_align = true;
+
+    try {
+      const auto& prop = platform::GetDeviceProperties(p.GetDeviceId());
+      need_addr_align = prop.textureAlignment < alignment;
+      VLOG(4) << "GetDeviceProperties ok, textureAlignment: "
+              << prop.textureAlignment
+              << ", set need_addr_align=" << need_addr_align;
+    } catch (...) {
+      need_addr_align = true;
+      VLOG(4) << "GetDeviceProperties failed, set need_addr_align=true";
+    }
+    // The address returned is aligned already,
+    // ref:
+    // https://stackoverflow.com/questions/14082964/cuda-alignment-256bytes-seriously/14083295#14083295
+    std::shared_ptr<Allocator> underlying_allocator{nullptr};
+    if (need_addr_align) {
+      VLOG(10) << "use AlignedAllocator with alignment: " << alignment;
+      underlying_allocator =
+          std::make_shared<AlignedAllocator>(underlying_allocator, alignment);
+    } else {
+      VLOG(10) << "not use AlignedAllocator with alignment: " << alignment;
+      underlying_allocator = cuda_allocator;
+    }
+    MonotonicAllocatorManager::Instance().SetAllocator(
+        std::make_shared<MonotonicAllocator>(cuda_allocator, alignment), p);
 #endif
 #endif
   }

--- a/paddle/phi/core/memory/allocation/allocator_facade.cc
+++ b/paddle/phi/core/memory/allocation/allocator_facade.cc
@@ -361,15 +361,17 @@ class AllocatorFacadePrivate {
     CheckAllocThreadSafe();
 
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
-    for (int dev_id = 0; dev_id < platform::GetGPUDeviceCount(); ++dev_id) {
-      InitMonotonicCUDAAllocator(phi::GPUPlace(dev_id));
-    }
-#endif
-#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
     // No need to wrap CUDAGraphAllocator for StreamSafeCUDAAllocator
     if (!is_stream_safe_cuda_allocator_used_ &&
         UNLIKELY(IsCUDAGraphCapturing())) {
       WrapCUDAGraphAllocator();
+    }
+
+    // MonotonicAllocator is not compatible with CUDAGraphAllocator and
+    // StreamSafeCUDAAllocator
+    if (is_stream_safe_cuda_allocator_used_ ||
+        !UNLIKELY(IsCUDAGraphCapturing)) {
+      InitMonotonicCUDAAllocator();
     }
 #endif
   }
@@ -1176,66 +1178,15 @@ class AllocatorFacadePrivate {
 #endif
   }
 
-  void InitMonotonicCUDAAllocator(phi::GPUPlace p) {
-#if defined(PADDLE_WITH_HIP)
-    auto cuda_allocator = CreateCUDAAllocator(p);
-    MonotonicAllocatorManager::Instance().SetAllocator(
-        std::make_shared<MonotonicAllocator>(cuda_allocator,
-                                             platform::GpuMinChunkSize()),
-        p);
-#endif
-
-#if defined(PADDLE_WITH_CUDA)
-#if CUDA_VERSION >= 10020
-    CUdevice device;
-    int val;
-    try {
-      PADDLE_ENFORCE_GPU_SUCCESS(
-          phi::dynload::cuDeviceGet(&device, p.GetDeviceId()));
-
-      PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::cuDeviceGetAttribute(
-          &val,
-          CU_DEVICE_ATTRIBUTE_VIRTUAL_ADDRESS_MANAGEMENT_SUPPORTED,
-          device));
-    } catch (...) {
-      val = 0;
+  void InitMonotonicCUDAAllocator() {
+    for (const auto& pair : allocators_) {
+      if (phi::is_gpu_place(pair.first)) {
+        MonotonicAllocatorManager::Instance().SetAllocator(
+            std::make_shared<MonotonicAllocator>(pair.second,
+                                                 platform::GpuMinChunkSize()),
+            pair.first);
+      }
     }
-    auto cuda_allocator = CreateCUDAAllocator(p);
-    MonotonicAllocatorManager::Instance().SetAllocator(
-        std::make_shared<MonotonicAllocator>(cuda_allocator,
-                                             platform::GpuMinChunkSize()),
-        p);
-#else
-    auto cuda_allocator = CreateCUDAAllocator(p);
-    auto alignment = platform::GpuMinChunkSize();
-    bool need_addr_align = true;
-
-    try {
-      const auto& prop = platform::GetDeviceProperties(p.GetDeviceId());
-      need_addr_align = prop.textureAlignment < alignment;
-      VLOG(4) << "GetDeviceProperties ok, textureAlignment: "
-              << prop.textureAlignment
-              << ", set need_addr_align=" << need_addr_align;
-    } catch (...) {
-      need_addr_align = true;
-      VLOG(4) << "GetDeviceProperties failed, set need_addr_align=true";
-    }
-    // The address returned is aligned already,
-    // ref:
-    // https://stackoverflow.com/questions/14082964/cuda-alignment-256bytes-seriously/14083295#14083295
-    std::shared_ptr<Allocator> underlying_allocator{nullptr};
-    if (need_addr_align) {
-      VLOG(10) << "use AlignedAllocator with alignment: " << alignment;
-      underlying_allocator =
-          std::make_shared<AlignedAllocator>(underlying_allocator, alignment);
-    } else {
-      VLOG(10) << "not use AlignedAllocator with alignment: " << alignment;
-      underlying_allocator = cuda_allocator;
-    }
-    MonotonicAllocatorManager::Instance().SetAllocator(
-        std::make_shared<MonotonicAllocator>(cuda_allocator, alignment), p);
-#endif
-#endif
   }
 
   void InitThreadLocalCUDAAllocator(phi::GPUPlace p) {

--- a/paddle/phi/core/memory/allocation/allocator_facade.h
+++ b/paddle/phi/core/memory/allocation/allocator_facade.h
@@ -16,7 +16,6 @@
 #include <memory>
 
 #include "paddle/phi/core/memory/allocation/allocator.h"
-#include "paddle/phi/core/memory/allocation/spin_lock.h"
 #ifdef PADDLE_WITH_CUDA
 #include "paddle/phi/core/platform/device/gpu/gpu_info.h"
 #endif

--- a/paddle/phi/core/memory/allocation/allocator_facade.h
+++ b/paddle/phi/core/memory/allocation/allocator_facade.h
@@ -16,6 +16,7 @@
 #include <memory>
 
 #include "paddle/phi/core/memory/allocation/allocator.h"
+#include "paddle/phi/core/memory/allocation/spin_lock.h"
 #ifdef PADDLE_WITH_CUDA
 #include "paddle/phi/core/platform/device/gpu/gpu_info.h"
 #endif

--- a/paddle/phi/core/memory/allocation/monotonic_allocator.cc
+++ b/paddle/phi/core/memory/allocation/monotonic_allocator.cc
@@ -60,10 +60,13 @@ phi::Allocation* MonotonicAllocator::AllocateImpl(size_t unaligned_size) {
            << ", Free size " << free_size;
 
   if (free_size >= size) {
+    if (buffer_allocation_ == nullptr) {
+      PADDLE_THROW(phi::errors::InvalidArgument(
+          "MonotonicAllocator::Allocate: buffer_allocation_ is null"));
+    }
     void* ptr = reinterpret_cast<char*>(buffer_ptr_) + buffer_offset_;
     buffer_offset_ += size;
-    phi::GPUPlace place(phi::backends::gpu::GetCurrentDeviceId());
-    return new MonotonicAllocation(ptr, size, place);
+    return new MonotonicAllocation(ptr, size, buffer_allocation_->place());
   } else {
     VLOG(10) << "Allocate fail, fallback to underlying_allocator";
     AllocationPtr underlying_allocation = underlying_allocator_->Allocate(size);

--- a/paddle/phi/core/memory/allocation/monotonic_allocator.cc
+++ b/paddle/phi/core/memory/allocation/monotonic_allocator.cc
@@ -1,0 +1,143 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/phi/core/memory/allocation/monotonic_allocator.h"
+
+#include <algorithm>
+#include <mutex>  // NOLINT
+#include <utility>
+
+#include "paddle/phi/api/profiler/event_tracing.h"
+#include "paddle/phi/backends/device_manager.h"
+#include "paddle/phi/core/memory/allocation/aligned_allocator.h"
+
+namespace paddle::memory::allocation {
+
+void MonotonicAllocator::AllocateBuffer(size_t capacity) {
+  std::lock_guard<SpinLock> guard(spinlock_);
+  if (buffer_ptr_ == nullptr) {
+    buffer_allocation_ = std::move(underlying_allocator_->Allocate(capacity));
+    buffer_ptr_ = buffer_allocation_->ptr();
+    buffer_offset_ = 0;
+    capacity_ = capacity;
+  } else {
+    PADDLE_THROW(phi::errors::InvalidArgument(
+        "MonotonicAllocator::Allocate: buffer_ptr_ is not null"));
+  }
+}
+
+void MonotonicAllocator::DeallocateBuffer() {
+  std::lock_guard<SpinLock> guard(spinlock_);
+  buffer_offset_ = 0;
+  buffer_ptr_ = nullptr;
+  capacity_ = 0;
+  buffer_allocation_.reset();
+}
+
+void MonotonicAllocator::ResetBuffer() {
+  std::lock_guard<SpinLock> guard(spinlock_);
+  buffer_offset_ = 0;
+}
+
+phi::Allocation* MonotonicAllocator::AllocateImpl(size_t unaligned_size) {
+  std::lock_guard<SpinLock> guard(spinlock_);
+  size_t size = AlignedSize(unaligned_size, alignment_);
+
+  size_t free_size = capacity_ - buffer_offset_;
+
+  VLOG(10) << "Allocate " << unaligned_size << " bytes, aligned to " << size
+           << ", Free size " << free_size;
+
+  if (free_size >= size) {
+    void* ptr = reinterpret_cast<char*>(buffer_ptr_) + buffer_offset_;
+    buffer_offset_ += size;
+    phi::GPUPlace place(phi::backends::gpu::GetCurrentDeviceId());
+    return new MonotonicAllocation(ptr, size, place);
+  } else {
+    VLOG(10) << "Allocate fail, fallback to underlying_allocator";
+    AllocationPtr underlying_allocation = underlying_allocator_->Allocate(size);
+    // Leveraging the features of unique_ptr, the Deleter can be automatically
+    // invoked in FreeImpl to release the underlying_allocation.
+    return new MonotonicAllocation(
+        static_unique_ptr_cast<Allocation>(std::move(underlying_allocation)));
+  }
+}
+
+void MonotonicAllocator::FreeImpl(phi::Allocation* allocation) {
+  VLOG(10) << "Free " << allocation->size()
+           << " bytes, ptr = " << allocation->ptr();
+  std::lock_guard<SpinLock> guard(spinlock_);
+  delete allocation;
+}
+
+void MonotonicAllocatorManager::SetAllocator(
+    std::shared_ptr<Allocator> allocator, const phi::Place& place) {
+  std::lock_guard<SpinLock> guard(spinlock_);
+  allocators_[place] = std::move(allocator);
+}
+
+std::shared_ptr<Allocator> MonotonicAllocatorManager::GetAllocator(
+    const phi::Place& place) {
+  std::lock_guard<SpinLock> guard(spinlock_);
+  return allocators_[place];
+}
+
+void MonotonicAllocatorManager::AllocateBuffer(const phi::Place& place,
+                                               size_t capacity) {
+  std::lock_guard<SpinLock> guard(spinlock_);
+
+  if (allocators_.find(place) != allocators_.end()) {
+    auto monotonic_allocator =
+        std::dynamic_pointer_cast<MonotonicAllocator>(allocators_[place]);
+    if (monotonic_allocator) {
+      monotonic_allocator->AllocateBuffer(capacity);
+    }
+  } else {
+    PADDLE_THROW(phi::errors::InvalidArgument(
+        "MonotonicAllocatorManager: place %s is not initialized.",
+        place.DebugString()));
+  }
+}
+
+void MonotonicAllocatorManager::DeallocateBuffer(const phi::Place& place) {
+  std::lock_guard<SpinLock> guard(spinlock_);
+  if (allocators_.find(place) != allocators_.end()) {
+    auto monotonic_allocator =
+        std::dynamic_pointer_cast<MonotonicAllocator>(allocators_[place]);
+    if (monotonic_allocator) {
+      monotonic_allocator->DeallocateBuffer();
+    }
+  } else {
+    PADDLE_THROW(phi::errors::InvalidArgument(
+        "MonotonicAllocatorManager: place %s is not initialized.",
+        place.DebugString()));
+  }
+}
+
+void MonotonicAllocatorManager::ResetBuffer(const phi::Place& place) {
+  std::lock_guard<SpinLock> guard(spinlock_);
+  if (allocators_.find(place) != allocators_.end()) {
+    auto monotonic_allocator =
+        std::dynamic_pointer_cast<MonotonicAllocator>(allocators_[place]);
+    if (monotonic_allocator) {
+      monotonic_allocator->ResetBuffer();
+    }
+  } else {
+    PADDLE_THROW(phi::errors::InvalidArgument(
+        "MonotonicAllocatorManager: place %s is not initialized.",
+        place.DebugString()));
+  }
+}
+
+}  // namespace paddle::memory::allocation

--- a/paddle/phi/core/memory/allocation/monotonic_allocator.cc
+++ b/paddle/phi/core/memory/allocation/monotonic_allocator.cc
@@ -18,9 +18,9 @@
 #include <mutex>  // NOLINT
 #include <utility>
 
-#include "paddle/phi/api/profiler/event_tracing.h"
-#include "paddle/phi/backends/device_manager.h"
-#include "paddle/phi/core/memory/allocation/aligned_allocator.h"
+#ifdef PADDLE_WITH_CUDA
+#include "paddle/phi/core/platform/device/gpu/gpu_info.h"
+#endif
 
 namespace paddle::memory::allocation {
 
@@ -84,15 +84,18 @@ void MonotonicAllocator::FreeImpl(phi::Allocation* allocation) {
   delete allocation;
 }
 
-void MonotonicAllocatorManager::SetAllocator(
-    std::shared_ptr<Allocator> allocator, const phi::Place& place) {
+std::shared_ptr<Allocator> MonotonicAllocatorManager::CreateOrGetAllocator(
+    const phi::Place& place, phi::Allocator* underlying_allocator) {
   std::lock_guard<SpinLock> guard(spinlock_);
-  allocators_[place] = std::move(allocator);
-}
-
-std::shared_ptr<Allocator> MonotonicAllocatorManager::GetAllocator(
-    const phi::Place& place) {
-  std::lock_guard<SpinLock> guard(spinlock_);
+#ifdef PADDLE_WITH_CUDA
+  size_t alignment = platform::GpuMinChunkSize();
+#else
+  size_t alignment = 1 << 8;
+#endif
+  if (allocators_.find(place) == allocators_.end()) {
+    allocators_[place] =
+        std::make_shared<MonotonicAllocator>(underlying_allocator, alignment);
+  }
   return allocators_[place];
 }
 

--- a/paddle/phi/core/memory/allocation/monotonic_allocator.h
+++ b/paddle/phi/core/memory/allocation/monotonic_allocator.h
@@ -1,0 +1,121 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <atomic>
+#include <list>
+#include <map>
+#include <memory>
+#include <mutex>  // NOLINT
+#include <utility>
+
+#include "paddle/phi/core/memory/allocation/allocator.h"
+#include "paddle/phi/core/memory/allocation/spin_lock.h"
+
+namespace paddle {
+namespace memory {
+namespace allocation {
+
+class MonotonicAllocation;
+class MonotonicAllocator : public Allocator {
+ public:
+  explicit MonotonicAllocator(std::shared_ptr<Allocator> underlying_allocator,
+                              size_t alignment)
+      : underlying_allocator_(std::move(underlying_allocator)),
+        alignment_(alignment) {}
+
+  bool IsAllocThreadSafe() const override { return true; }
+
+  void AllocateBuffer(size_t capacity);
+  void DeallocateBuffer();
+  void ResetBuffer();
+
+ protected:
+  phi::Allocation* AllocateImpl(size_t unaligned_size) override;
+
+  void FreeImpl(phi::Allocation* allocation) override;
+
+  uint64_t ReleaseImpl(const phi::Place& place) {
+    return underlying_allocator_->Release(place);
+  }
+
+ protected:
+  std::shared_ptr<Allocator> underlying_allocator_;
+  AllocationPtr buffer_allocation_;
+
+  size_t capacity_{0};
+  size_t buffer_offset_{0};
+  void* buffer_ptr_{nullptr};
+
+  size_t alignment_{0};
+
+  SpinLock spinlock_;
+};
+
+class MonotonicAllocation : public Allocation {
+ public:
+  explicit MonotonicAllocation(void* ptr, size_t size, phi::Place place)
+      : Allocation(ptr, size, place) {}
+
+  explicit MonotonicAllocation(DecoratedAllocationPtr underlying_allocation)
+      : Allocation(underlying_allocation->ptr(),
+                   underlying_allocation->base_ptr(),
+                   underlying_allocation->size(),
+                   underlying_allocation->place()),
+        underlying_allocation_(std::move(underlying_allocation)) {}
+
+ private:
+  DecoratedAllocationPtr underlying_allocation_{nullptr};
+};
+
+class MonotonicAllocatorManager {
+ public:
+  using AllocatorMap = std::map<phi::GPUPlace, std::shared_ptr<Allocator>>;
+
+  static MonotonicAllocatorManager& Instance() noexcept {
+    static MonotonicAllocatorManager instance;
+    return instance;
+  }
+
+  MonotonicAllocatorManager(const MonotonicAllocatorManager&) = delete;
+  MonotonicAllocatorManager& operator=(const MonotonicAllocatorManager&) =
+      delete;
+  MonotonicAllocatorManager(MonotonicAllocatorManager&&) = delete;
+  MonotonicAllocatorManager& operator=(MonotonicAllocatorManager&&) = delete;
+
+  void Enable() { enabled_ = true; }
+  void Disable() { enabled_ = false; }
+  bool IsEnabled() const { return enabled_; }
+
+  void SetAllocator(std::shared_ptr<Allocator> allocator,
+                    const phi::Place& place);
+  std::shared_ptr<Allocator> GetAllocator(const phi::Place& place);
+
+  void AllocateBuffer(const phi::Place& place, size_t capacity);
+  void DeallocateBuffer(const phi::Place& place);
+  void ResetBuffer(const phi::Place& place);
+
+ private:
+  MonotonicAllocatorManager() = default;
+
+  AllocatorMap allocators_{};
+  bool enabled_{false};
+
+  SpinLock spinlock_;
+};
+
+}  // namespace allocation
+}  // namespace memory
+}  // namespace paddle

--- a/paddle/phi/core/memory/allocation/monotonic_allocator.h
+++ b/paddle/phi/core/memory/allocation/monotonic_allocator.h
@@ -47,7 +47,7 @@ class MonotonicAllocator : public Allocator {
 
   void FreeImpl(phi::Allocation* allocation) override;
 
-  uint64_t ReleaseImpl(const phi::Place& place) {
+  uint64_t ReleaseImpl(const phi::Place& place) override {
     return underlying_allocator_->Release(place);
   }
 

--- a/paddle/phi/core/memory/allocation/monotonic_allocator.h
+++ b/paddle/phi/core/memory/allocation/monotonic_allocator.h
@@ -31,10 +31,9 @@ namespace allocation {
 class MonotonicAllocation;
 class MonotonicAllocator : public Allocator {
  public:
-  explicit MonotonicAllocator(std::shared_ptr<Allocator> underlying_allocator,
+  explicit MonotonicAllocator(phi::Allocator* underlying_allocator,
                               size_t alignment)
-      : underlying_allocator_(std::move(underlying_allocator)),
-        alignment_(alignment) {}
+      : underlying_allocator_(underlying_allocator), alignment_(alignment) {}
 
   bool IsAllocThreadSafe() const override { return true; }
 
@@ -47,12 +46,10 @@ class MonotonicAllocator : public Allocator {
 
   void FreeImpl(phi::Allocation* allocation) override;
 
-  uint64_t ReleaseImpl(const phi::Place& place) override {
-    return underlying_allocator_->Release(place);
-  }
+  uint64_t ReleaseImpl(const phi::Place& place) override { return 0; }
 
  protected:
-  std::shared_ptr<Allocator> underlying_allocator_;
+  phi::Allocator* underlying_allocator_;
   AllocationPtr buffer_allocation_;
 
   size_t capacity_{0};
@@ -99,9 +96,8 @@ class MonotonicAllocatorManager {
   void Disable() { enabled_ = false; }
   bool IsEnabled() const { return enabled_; }
 
-  void SetAllocator(std::shared_ptr<Allocator> allocator,
-                    const phi::Place& place);
-  std::shared_ptr<Allocator> GetAllocator(const phi::Place& place);
+  std::shared_ptr<Allocator> CreateOrGetAllocator(
+      const phi::Place& place, phi::Allocator* underlying_allocator);
 
   void AllocateBuffer(const phi::Place& place, size_t capacity);
   void DeallocateBuffer(const phi::Place& place);

--- a/python/paddle/base/core.py
+++ b/python/paddle/base/core.py
@@ -309,6 +309,7 @@ try:
         _is_compiled_with_heterps,
         _is_dygraph_debug_enabled,
         _is_program_version_supported,
+        _MonotonicAllocatorManager,
         _Profiler,
         _ProfilerResult,
         _promote_types_if_complex_exists,

--- a/python/paddle/distributed/fleet/utils/__init__.py
+++ b/python/paddle/distributed/fleet/utils/__init__.py
@@ -24,13 +24,20 @@ from . import (  # noqa: F401
     sequence_parallel_utils,
     tensor_parallel_utils,
 )
+from .allocator_utils import MonotonicAllocatorManager
 from .fs import HDFSClient, LocalFS
 from .ps_util import DistributedInfer
 
 if TYPE_CHECKING:
     from paddle.nn import Layer
 
-__all__ = ["LocalFS", "recompute", "DistributedInfer", "HDFSClient"]
+__all__ = [
+    "LocalFS",
+    "recompute",
+    "DistributedInfer",
+    "HDFSClient",
+    "MonotonicAllocatorManager",
+]
 
 
 def recompute(

--- a/python/paddle/distributed/fleet/utils/allocator_utils.py
+++ b/python/paddle/distributed/fleet/utils/allocator_utils.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import contextlib
+
+import paddle
+from paddle.base import core
+
+
+class MonotonicAllocatorManager:
+    @staticmethod
+    def enable():
+        core._MonotonicAllocatorManager._enable()
+
+    @staticmethod
+    def disable():
+        core._MonotonicAllocatorManager._disable()
+
+    @staticmethod
+    def allocate_buffer(size):
+        place = paddle.framework._current_expected_place()
+        # The framework's device_context is lazily inited. When manually calling allocate,
+        # the device_context may not have finished initialization yet. Therefore, calling
+        # paddle.empty([1]) triggers the initialization of device_context.
+        paddle.empty([1])
+        core._MonotonicAllocatorManager._allocate_buffer(place, size)
+
+    @staticmethod
+    def deallocate_buffer():
+        place = paddle.framework._current_expected_place()
+        core._MonotonicAllocatorManager._deallocate_buffer(place)
+
+    @staticmethod
+    def reset_buffer():
+        place = paddle.framework._current_expected_place()
+        core._MonotonicAllocatorManager._reset_buffer(place)
+
+    @staticmethod
+    @contextlib.contextmanager
+    def switch_to_monotonic_allocator():
+        MonotonicAllocatorManager.enable()
+        try:
+            yield
+        finally:
+            MonotonicAllocatorManager.disable()

--- a/python/paddle/distributed/fleet/utils/allocator_utils.py
+++ b/python/paddle/distributed/fleet/utils/allocator_utils.py
@@ -33,7 +33,8 @@ class MonotonicAllocatorManager:
         # The framework's device_context is lazily inited. When manually calling allocate,
         # the device_context may not have finished initialization yet. Therefore, calling
         # paddle.empty([1]) triggers the initialization of device_context.
-        paddle.empty([1])
+        with MonotonicAllocatorManager.switch_to_monotonic_allocator():
+            paddle.empty([1])
         core._MonotonicAllocatorManager._allocate_buffer(place, size)
 
     @staticmethod

--- a/test/collective/fleet/CMakeLists.txt
+++ b/test/collective/fleet/CMakeLists.txt
@@ -836,3 +836,8 @@ if((WITH_GPU) AND LOCAL_ALL_PLAT)
   )
   set_tests_properties(test_shutdown_process_group PROPERTIES TIMEOUT "200")
 endif()
+if((WITH_GPU) AND LOCAL_ALL_PLAT)
+  py_test_modules(
+    test_monotonic_allocator MODULES test_monotonic_allocator ENVS
+    "http_proxy=;https_proxy=;PYTHONPATH=../..:${PADDLE_BINARY_DIR}/python")
+endif()

--- a/test/collective/fleet/test_monotonic_allocator.py
+++ b/test/collective/fleet/test_monotonic_allocator.py
@@ -1,0 +1,84 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+
+import paddle
+from paddle.distributed.fleet.utils import MonotonicAllocatorManager
+
+
+class MonotonicAllocatorTest(unittest.TestCase):
+    def test_monotonic_allocator_basic(self):
+        if paddle.device.cuda.device_count() < 1:
+            return
+
+        paddle.seed(42)
+        data_ref = paddle.randn(shape=[1024, 1024], dtype='float32')
+
+        paddle.seed(42)
+        MonotonicAllocatorManager.allocate_buffer(1024 * 1024 * 6)
+        with MonotonicAllocatorManager.switch_to_monotonic_allocator():
+            data = paddle.randn(shape=[1024, 1024], dtype='float32')
+
+        MonotonicAllocatorManager.deallocate_buffer()
+        np.testing.assert_array_equal(data_ref.numpy(), data.numpy())
+
+    def test_monotonic_allocator_out_of_memory(self):
+        if paddle.device.cuda.device_count() < 1:
+            return
+
+        paddle.seed(42)
+        data_ref = paddle.randn(shape=[1024, 1024], dtype='float32')
+
+        paddle.seed(42)
+        MonotonicAllocatorManager.allocate_buffer(1024 * 1024 * 2)
+        with MonotonicAllocatorManager.switch_to_monotonic_allocator():
+            data = paddle.randn(shape=[1024, 1024], dtype='float32')
+
+        MonotonicAllocatorManager.deallocate_buffer()
+        np.testing.assert_array_equal(data_ref.numpy(), data.numpy())
+
+    def test_monotonic_allocator_reset(self):
+        if paddle.device.cuda.device_count() < 1:
+            return
+
+        paddle.seed(42)
+        MonotonicAllocatorManager.allocate_buffer(1024 * 1024 * 6)
+        with MonotonicAllocatorManager.switch_to_monotonic_allocator():
+            data = paddle.randn(shape=[1024, 1024], dtype='float32')
+
+        data_clone = data.clone()
+        MonotonicAllocatorManager.reset_buffer()
+
+        paddle.seed(42)
+        with MonotonicAllocatorManager.switch_to_monotonic_allocator():
+            new_data = paddle.randn(shape=[1024, 1024], dtype='float32')
+
+        np.testing.assert_array_equal(data_clone.numpy(), new_data.numpy())
+        MonotonicAllocatorManager.deallocate_buffer()
+
+    def test_monotonic_allocator_non_cuda(self):
+        paddle.seed(42)
+        data_ref = paddle.randn(shape=[1024, 1024], dtype='float32').cpu()
+
+        paddle.seed(42)
+        with MonotonicAllocatorManager.switch_to_monotonic_allocator():
+            data = paddle.randn(shape=[1024, 1024], dtype='float32').cpu()
+            np.testing.assert_array_equal(data_ref.numpy(), data.numpy())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/collective/fleet/testslist.csv
+++ b/test/collective/fleet/testslist.csv
@@ -71,3 +71,4 @@ test_dygraph_dist_save_load,LINUX,GPU,300,DIST,test_runner.py,,,http_proxy=;http
 test_dualpipe.py,,GPU,500,DIST,../../legacy_test/dist_test.sh,2,,http_proxy=;https_proxy=;PYTHONPATH=../..,
 test_zero_bubble_utils,LINUX;APPLE,,500,DIST,../../legacy_test/dist_test.sh,2,,http_proxy=;https_proxy=;PYTHONPATH=../..,
 test_shutdown_process_group,,GPU,,DIST,../../legacy_test/dist_test.sh,2,,http_proxy=;https_proxy=,
+test_monotonic_allocator,,GPU,,,test_runner.py,2,,http_proxy=;https_proxy=;PYTHONPATH=../..,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
Add MonotonicAllocator to avoid memory fragmentation in certain scenarios

When using DeepEP in MoE training, the dispatched output has a dynamic shape. When employing a Best-Fit Allocation-based allocator, the constantly changing shapes lead to a significant increase in memory fragmentation, which in turn causes frequent OOM (Out-of-Memory) errors during MoE model training. Therefore, measures are needed to mitigate the impact of dynamic shapes on the allocator.

The most intuitive approach is to assign tensors with dynamic shapes and static shapes in the network to different allocators to avoid mutual interference. Furthermore, for pipeline scheduling in the VPP FthenB (Forward-then-Backward) series, we aim to develop a simple allocator—MonotonicAllocator—based on the characteristic of consecutive Forward (F) operations in FthenB scheduling. 

<img width="708" height="146" alt="a163dbbf52a6ad9d247cc6fcb93ff5f4" src="https://github.com/user-attachments/assets/b912629b-3fe4-46b3-9f98-d0b5064b60c2" />

The design principle of MonotonicAllocator is straightforward: it pre-allocates a persistent, contiguous GPU memory buffer and maintains an offset. Whenever a tensor requests memory through MonotonicAllocator, it allocates memory from the offset in the buffer and moves the offset forward. At the end of each step, the offset is reset to zero. Through this simple mechanism, we ensure that under FthenB scheduling, activation values with dynamic shapes do not generate fragmentation.

<img width="601" height="366" alt="ab3be755-bef7-4cbe-92d9-6f659721455d" src="https://github.com/user-attachments/assets/07c4a144-4220-416e-a078-4fe09b36c893" />


Pcard-76459
