### PR TITLE
Parameter mapping from torch to paddle（broadcast_to）

### DIFF
--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -24,8 +24,8 @@ from typing_extensions import overload
 import paddle
 from paddle import _C_ops
 from paddle.tensor import fill_constant
+from paddle.utils.decorator_utils import param_alias
 from paddle.utils.inplace_utils import inplace_apis_in_dygraph_only
-from paddle.utils.param_alias_utils import param_alias
 
 from ..base.data_feeder import (
     check_dtype,

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -4763,7 +4763,7 @@ def expand_as(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
         return out
 
 
-@param_alias({"x": ["input"], "shape": ["size"]}, 2)
+@param_alias({"x": ["input"], "shape": ["size"]})
 def broadcast_to(
     x: Tensor, shape: ShapeLike, name: str | None = None
 ) -> Tensor:

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -25,6 +25,7 @@ import paddle
 from paddle import _C_ops
 from paddle.tensor import fill_constant
 from paddle.utils.inplace_utils import inplace_apis_in_dygraph_only
+from paddle.utils.param_alias_utils import param_alias
 
 from ..base.data_feeder import (
     check_dtype,
@@ -4762,6 +4763,7 @@ def expand_as(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
         return out
 
 
+@param_alias({"x": ["input"], "shape": ["size"]}, 2)
 def broadcast_to(
     x: Tensor, shape: ShapeLike, name: str | None = None
 ) -> Tensor:

--- a/python/paddle/utils/__init__.py
+++ b/python/paddle/utils/__init__.py
@@ -15,11 +15,11 @@
 from ..base.framework import require_version
 from . import (  # noqa: F401
     cpp_extension,
+    decorator_utils,
     dlpack,
     download,
     image_util,
     layers_utils,
-    param_alias_utils,
     unique_name,
 )
 from .deprecated import deprecated

--- a/python/paddle/utils/__init__.py
+++ b/python/paddle/utils/__init__.py
@@ -19,6 +19,7 @@ from . import (  # noqa: F401
     download,
     image_util,
     layers_utils,
+    param_alias_utils,
     unique_name,
 )
 from .deprecated import deprecated

--- a/python/paddle/utils/decorator_utils.py
+++ b/python/paddle/utils/decorator_utils.py
@@ -15,23 +15,19 @@
 from __future__ import annotations
 
 import functools
+import inspect
 from typing import TYPE_CHECKING, Any, Callable, TypeVar
-
-from paddle.base.wrapped_decorator import signature_safe_contextmanager
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
-
 F = TypeVar('F', bound=Callable[..., Any])
 
 
 def param_alias(alias_mapping: dict[str, Iterable[str]]) -> Callable[[F], F]:
     """Decorator for handling parameter aliases in function calls.
-
     Args:
         alias_mapping: Dictionary mapping original parameter names to their aliases.
                       Example: {'original': ['alias1', 'alias2']}
-
     Returns:
         A decorator that processes parameter aliases before calling the original function.
     """
@@ -42,7 +38,6 @@ def param_alias(alias_mapping: dict[str, Iterable[str]]) -> Callable[[F], F]:
             raise TypeError(f"Aliases for '{k}' must be iterable")
 
     def decorator(func: F) -> F:
-        @signature_safe_contextmanager
         @functools.wraps(func)
         def wrapper(*args: Any, **kwargs: Any) -> Any:
             if not kwargs:
@@ -61,6 +56,7 @@ def param_alias(alias_mapping: dict[str, Iterable[str]]) -> Callable[[F], F]:
                             )
             return func(*args, **processed_kwargs)
 
-        return wrapper  # type: ignore
+        wrapper.__signature__ = inspect.signature(func)
+        return wrapper
 
     return decorator

--- a/python/paddle/utils/param_alias_utils.py
+++ b/python/paddle/utils/param_alias_utils.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import functools
+from typing import Callable, dict, list
+
+
+def param_alias(
+    alias_mapping: dict[str, list[str]], paddle_param_len: int
+) -> Callable:
+    """
+    Decorator to map parameter names between different API conventions.
+    """
+
+    def decorator(func: Callable):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            if not kwargs or len(args) >= paddle_param_len:
+                return func(*args, **kwargs)
+            for original, aliases in alias_mapping.items():
+                for alias in aliases:
+                    if alias in kwargs:
+                        if original not in kwargs:
+                            kwargs[original] = kwargs[alias]
+                        else:
+                            raise KeyError(
+                                f"Both {original} and {alias} are provided. Please specify only one."
+                            )
+                        del kwargs[alias]
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/python/paddle/utils/param_alias_utils.py
+++ b/python/paddle/utils/param_alias_utils.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import functools
+import inspect
 from typing import TYPE_CHECKING, Any, Callable, TypeVar
 
 if TYPE_CHECKING:
@@ -58,6 +59,7 @@ def param_alias(alias_mapping: dict[str, Iterable[str]]) -> Callable[[F], F]:
                             )
             return func(*args, **processed_kwargs)
 
+        wrapper.__signature__ = inspect.signature(func)
         return wrapper  # type: ignore
 
     return decorator

--- a/python/paddle/utils/param_alias_utils.py
+++ b/python/paddle/utils/param_alias_utils.py
@@ -25,7 +25,6 @@ if TYPE_CHECKING:
 F = TypeVar('F', bound=Callable[..., Any])
 
 
-@signature_safe_contextmanager
 def param_alias(alias_mapping: dict[str, Iterable[str]]) -> Callable[[F], F]:
     """Decorator for handling parameter aliases in function calls.
 
@@ -43,6 +42,7 @@ def param_alias(alias_mapping: dict[str, Iterable[str]]) -> Callable[[F], F]:
             raise TypeError(f"Aliases for '{k}' must be iterable")
 
     def decorator(func: F) -> F:
+        @signature_safe_contextmanager
         @functools.wraps(func)
         def wrapper(*args: Any, **kwargs: Any) -> Any:
             if not kwargs:

--- a/python/paddle/utils/param_alias_utils.py
+++ b/python/paddle/utils/param_alias_utils.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 import functools
-from typing import TYPE_CHECKING, Any, Callable, TypeVar, dict
+from typing import TYPE_CHECKING, Any, Callable, TypeVar
 
 if TYPE_CHECKING:
     from collections.abc import Iterable

--- a/python/paddle/utils/param_alias_utils.py
+++ b/python/paddle/utils/param_alias_utils.py
@@ -15,31 +15,49 @@
 from __future__ import annotations
 
 import functools
-from typing import Callable, dict, list
+from typing import TYPE_CHECKING, Any, Callable, TypeVar, dict
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+F = TypeVar('F', bound=Callable[..., Any])
 
 
-def param_alias(alias_mapping: dict[str, list[str]]) -> Callable:
+def param_alias(alias_mapping: dict[str, Iterable[str]]) -> Callable[[F], F]:
+    """Decorator for handling parameter aliases in function calls.
+
+    Args:
+        alias_mapping: Dictionary mapping original parameter names to their aliases.
+                      Example: {'original': ['alias1', 'alias2']}
+
+    Returns:
+        A decorator that processes parameter aliases before calling the original function.
     """
-    Decorator to map parameter names between different API conventions.
-    """
+    if not isinstance(alias_mapping, dict):
+        raise TypeError("alias_mapping must be a dictionary")
+    for k, v in alias_mapping.items():
+        if not isinstance(v, (list, tuple, set)):
+            raise TypeError(f"Aliases for '{k}' must be iterable")
 
-    def decorator(func: Callable):
+    def decorator(func: F) -> F:
         @functools.wraps(func)
-        def wrapper(*args, **kwargs):
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
             if not kwargs:
                 return func(*args, **kwargs)
+            processed_kwargs = kwargs.copy()
             for original, aliases in alias_mapping.items():
                 for alias in aliases:
-                    if alias in kwargs:
-                        if original not in kwargs:
-                            kwargs[original] = kwargs[alias]
-                        else:
-                            raise KeyError(
-                                f"Both {original} and {alias} are provided. Please specify only one."
+                    if alias in processed_kwargs:
+                        if original not in processed_kwargs:
+                            processed_kwargs[original] = processed_kwargs.pop(
+                                alias
                             )
-                        del kwargs[alias]
-            return func(*args, **kwargs)
+                        else:
+                            raise ValueError(
+                                f"Cannot specify both '{original}' and its alias '{alias}'"
+                            )
+            return func(*args, **processed_kwargs)
 
-        return wrapper
+        return wrapper  # type: ignore
 
     return decorator

--- a/python/paddle/utils/param_alias_utils.py
+++ b/python/paddle/utils/param_alias_utils.py
@@ -15,16 +15,24 @@
 from __future__ import annotations
 
 import functools
-import inspect
+from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, Callable, TypeVar
+
+from typing_extensions import ParamSpec
+
+from paddle.base.wrapped_decorator import signature_safe_contextmanager
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
-F = TypeVar('F', bound=Callable[..., Any])
+
+_InputT = ParamSpec("_InputT")
+_RetT = TypeVar("_RetT")
 
 
-def param_alias(alias_mapping: dict[str, Iterable[str]]) -> Callable[[F], F]:
+def param_alias(
+    alias_mapping: dict[str, Iterable[str]],
+) -> Callable[[Callable[_InputT, _RetT]], Callable[_InputT, _RetT]]:
     """Decorator for handling parameter aliases in function calls.
 
     Args:
@@ -40,26 +48,30 @@ def param_alias(alias_mapping: dict[str, Iterable[str]]) -> Callable[[F], F]:
         if not isinstance(v, (list, tuple, set)):
             raise TypeError(f"Aliases for '{k}' must be iterable")
 
-    def decorator(func: F) -> F:
+    @signature_safe_contextmanager
+    def alias_context(
+        *args: _InputT.args, **kwargs: _InputT.kwargs
+    ) -> Iterable[dict[str, Any]]:
+        processed_kwargs = kwargs.copy()
+        for original, aliases in alias_mapping.items():
+            for alias in aliases:
+                if alias in processed_kwargs:
+                    if original not in processed_kwargs:
+                        processed_kwargs[original] = processed_kwargs.pop(alias)
+                    else:
+                        raise ValueError(
+                            f"Cannot specify both '{original}' and its alias '{alias}'"
+                        )
+        yield processed_kwargs
+
+    def decorator(func: Callable[_InputT, _RetT]) -> Callable[_InputT, _RetT]:
         @functools.wraps(func)
-        def wrapper(*args: Any, **kwargs: Any) -> Any:
+        def wrapper(*args: _InputT.args, **kwargs: _InputT.kwargs) -> _RetT:
             if not kwargs:
                 return func(*args, **kwargs)
-            processed_kwargs = kwargs.copy()
-            for original, aliases in alias_mapping.items():
-                for alias in aliases:
-                    if alias in processed_kwargs:
-                        if original not in processed_kwargs:
-                            processed_kwargs[original] = processed_kwargs.pop(
-                                alias
-                            )
-                        else:
-                            raise ValueError(
-                                f"Cannot specify both '{original}' and its alias '{alias}'"
-                            )
-            return func(*args, **processed_kwargs)
+            with alias_context(*args, **kwargs) as processed_kwargs:
+                return func(*args, **processed_kwargs)
 
-        wrapper.__signature__ = inspect.signature(func)
-        return wrapper  # type: ignore
+        return wrapper
 
     return decorator

--- a/python/paddle/utils/param_alias_utils.py
+++ b/python/paddle/utils/param_alias_utils.py
@@ -18,9 +18,7 @@ import functools
 from typing import Callable, dict, list
 
 
-def param_alias(
-    alias_mapping: dict[str, list[str]], paddle_param_len: int
-) -> Callable:
+def param_alias(alias_mapping: dict[str, list[str]]) -> Callable:
     """
     Decorator to map parameter names between different API conventions.
     """
@@ -28,7 +26,7 @@ def param_alias(
     def decorator(func: Callable):
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
-            if not kwargs or len(args) >= paddle_param_len:
+            if not kwargs:
                 return func(*args, **kwargs)
             for original, aliases in alias_mapping.items():
                 for alias in aliases:

--- a/python/paddle/utils/param_alias_utils.py
+++ b/python/paddle/utils/param_alias_utils.py
@@ -15,24 +15,18 @@
 from __future__ import annotations
 
 import functools
-from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, Callable, TypeVar
-
-from typing_extensions import ParamSpec
 
 from paddle.base.wrapped_decorator import signature_safe_contextmanager
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
-
-_InputT = ParamSpec("_InputT")
-_RetT = TypeVar("_RetT")
+F = TypeVar('F', bound=Callable[..., Any])
 
 
-def param_alias(
-    alias_mapping: dict[str, Iterable[str]],
-) -> Callable[[Callable[_InputT, _RetT]], Callable[_InputT, _RetT]]:
+@signature_safe_contextmanager
+def param_alias(alias_mapping: dict[str, Iterable[str]]) -> Callable[[F], F]:
     """Decorator for handling parameter aliases in function calls.
 
     Args:
@@ -48,30 +42,25 @@ def param_alias(
         if not isinstance(v, (list, tuple, set)):
             raise TypeError(f"Aliases for '{k}' must be iterable")
 
-    @signature_safe_contextmanager
-    def alias_context(
-        *args: _InputT.args, **kwargs: _InputT.kwargs
-    ) -> Iterable[dict[str, Any]]:
-        processed_kwargs = kwargs.copy()
-        for original, aliases in alias_mapping.items():
-            for alias in aliases:
-                if alias in processed_kwargs:
-                    if original not in processed_kwargs:
-                        processed_kwargs[original] = processed_kwargs.pop(alias)
-                    else:
-                        raise ValueError(
-                            f"Cannot specify both '{original}' and its alias '{alias}'"
-                        )
-        yield processed_kwargs
-
-    def decorator(func: Callable[_InputT, _RetT]) -> Callable[_InputT, _RetT]:
+    def decorator(func: F) -> F:
         @functools.wraps(func)
-        def wrapper(*args: _InputT.args, **kwargs: _InputT.kwargs) -> _RetT:
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
             if not kwargs:
                 return func(*args, **kwargs)
-            with alias_context(*args, **kwargs) as processed_kwargs:
-                return func(*args, **processed_kwargs)
+            processed_kwargs = kwargs.copy()
+            for original, aliases in alias_mapping.items():
+                for alias in aliases:
+                    if alias in processed_kwargs:
+                        if original not in processed_kwargs:
+                            processed_kwargs[original] = processed_kwargs.pop(
+                                alias
+                            )
+                        else:
+                            raise ValueError(
+                                f"Cannot specify both '{original}' and its alias '{alias}'"
+                            )
+            return func(*args, **processed_kwargs)
 
-        return wrapper
+        return wrapper  # type: ignore
 
     return decorator


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
[ 仅参数名不一致 ]torch.broadcast_to
api参数映射关系：[点击链接](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/guides/model_convert/convert_from_pytorch/api_difference/torch/torch.broadcast_to.html)

1. 增加参数装饰器；
2. 单测已存在：/test/legacy_test/test_broadcast_to_op.py

测试：
```
>>> import paddle 
>>> x = paddle.to_tensor([1, 2, 3])
>>> y = paddle.broadcast_to(x, [2, 3])
>>> print(y.shape)
[2, 3]
>>> 
>>> y = paddle.broadcast_to(x, size=[2, 3])
>>> print(y.shape)
[2, 3]
>>> 
>>> y = paddle.broadcast_to(input=x, size=[2, 3])
>>> print(y.shape)
[2, 3]
>>> 
>>> 
>>> y = paddle.broadcast_to(x=x, size=[2, 3])
>>> print(y.shape)
[2, 3]
```

pcard-67164
