### PR TITLE
[API compatibility] add `device` alias for `place` in `paddle.to_tensor`

### DIFF
--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -25,7 +25,7 @@ import numpy as np
 import paddle
 from paddle import _C_ops
 from paddle.utils.inplace_utils import inplace_apis_in_dygraph_only
-from paddle.utils.param_alias_utils import param_alias
+from paddle.utils.param_decorator import param_alias
 
 from ..base.data_feeder import (
     check_dtype,

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -25,6 +25,7 @@ import numpy as np
 import paddle
 from paddle import _C_ops
 from paddle.utils.inplace_utils import inplace_apis_in_dygraph_only
+from paddle.utils.param_alias_utils import param_alias
 
 from ..base.data_feeder import (
     check_dtype,
@@ -876,6 +877,7 @@ def _to_tensor_static(
     return output
 
 
+@param_alias({"place": ["device"]})
 def to_tensor(
     data: TensorLike | NestedNumericSequence,
     dtype: DTypeLike | None = None,
@@ -911,6 +913,7 @@ def to_tensor(
         place(CPUPlace|CUDAPinnedPlace|CUDAPlace|str, optional): The place to allocate Tensor. Can be
             CPUPlace, CUDAPinnedPlace, CUDAPlace. Default: None, means global place. If ``place`` is
             string, It can be ``cpu``, ``gpu:x`` and ``gpu_pinned``, where ``x`` is the index of the GPUs.
+            Note: 'device' is accepted as alias via @param_alias.
         stop_gradient(bool, optional): Whether to block the gradient propagation of Autograd. Default: True.
 
     Returns:
@@ -938,6 +941,11 @@ def to_tensor(
             1)
 
             >>> paddle.to_tensor([[0.1, 0.2], [0.3, 0.4]], place=paddle.CPUPlace(), stop_gradient=False)
+            Tensor(shape=[2, 2], dtype=float32, place=Place(cpu), stop_gradient=False,
+            [[0.10000000, 0.20000000],
+             [0.30000001, 0.40000001]])
+
+             >>> paddle.to_tensor([[0.1, 0.2], [0.3, 0.4]], device=paddle.CPUPlace(), stop_gradient=False)
             Tensor(shape=[2, 2], dtype=float32, place=Place(cpu), stop_gradient=False,
             [[0.10000000, 0.20000000],
              [0.30000001, 0.40000001]])

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -891,6 +891,10 @@ def to_tensor(
     If the ``data`` is already a Tensor, copy will be performed and return a new tensor.
     If you only want to change stop_gradient property, please call ``Tensor.stop_gradient = stop_gradient`` directly.
 
+    .. note::
+    Alias Support: The parameter name ``device`` can be used as an alias for ``place``.
+    For example, ``device=paddle.CUDAPlace(0)`` is equivalent to ``place=paddle.CUDAPlace(0)``.
+
     .. code-block:: text
 
         We use the dtype conversion rules following this:
@@ -913,7 +917,7 @@ def to_tensor(
         place(CPUPlace|CUDAPinnedPlace|CUDAPlace|str, optional): The place to allocate Tensor. Can be
             CPUPlace, CUDAPinnedPlace, CUDAPlace. Default: None, means global place. If ``place`` is
             string, It can be ``cpu``, ``gpu:x`` and ``gpu_pinned``, where ``x`` is the index of the GPUs.
-            Note: 'device' is accepted as alias via @param_alias.
+        device: An alias for ``place`` , with identical behavior.
         stop_gradient(bool, optional): Whether to block the gradient propagation of Autograd. Default: True.
 
     Returns:

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -949,7 +949,7 @@ def to_tensor(
             [[0.10000000, 0.20000000],
              [0.30000001, 0.40000001]])
 
-             >>> paddle.to_tensor([[0.1, 0.2], [0.3, 0.4]], device=paddle.CPUPlace(), stop_gradient=False)
+            >>> paddle.to_tensor([[0.1, 0.2], [0.3, 0.4]], device=paddle.CPUPlace(), stop_gradient=False)
             Tensor(shape=[2, 2], dtype=float32, place=Place(cpu), stop_gradient=False,
             [[0.10000000, 0.20000000],
              [0.30000001, 0.40000001]])

--- a/python/paddle/utils/__init__.py
+++ b/python/paddle/utils/__init__.py
@@ -19,6 +19,7 @@ from . import (  # noqa: F401
     download,
     image_util,
     layers_utils,
+    param_alias_utils,
     unique_name,
 )
 from .deprecated import deprecated

--- a/python/paddle/utils/__init__.py
+++ b/python/paddle/utils/__init__.py
@@ -19,7 +19,7 @@ from . import (  # noqa: F401
     download,
     image_util,
     layers_utils,
-    param_alias_utils,
+    param_decorator,
     unique_name,
 )
 from .deprecated import deprecated

--- a/python/paddle/utils/param_alias_utils.py
+++ b/python/paddle/utils/param_alias_utils.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import functools
+from typing import Callable
+
+
+def param_alias(alias_mapping: dict[str, list[str]]) -> Callable:
+    """
+    Decorator to map parameter names between different API conventions.
+    """
+
+    def decorator(func: Callable):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            if not kwargs:
+                return func(*args, **kwargs)
+            for original, aliases in alias_mapping.items():
+                for alias in aliases:
+                    if alias in kwargs:
+                        if original not in kwargs:
+                            kwargs[original] = kwargs[alias]
+                        else:
+                            raise KeyError(
+                                f"Both {original} and {alias} are provided. Please specify only one."
+                            )
+                        del kwargs[alias]
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/python/paddle/utils/param_decorator.py
+++ b/python/paddle/utils/param_decorator.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import functools
+import inspect
 from typing import Callable
 
 
@@ -38,6 +39,7 @@ def param_alias(alias_mapping: dict[str, list[str]]) -> Callable:
                         del kwargs[alias]
             return func(*args, **kwargs)
 
+        wrapper.__signature__ = inspect.signature(func)
         return wrapper
 
     return decorator

--- a/test/legacy_test/test_eager_tensor.py
+++ b/test/legacy_test/test_eager_tensor.py
@@ -377,11 +377,11 @@ class TestEagerTensor(unittest.TestCase):
         self.assertEqual(var.dtype, paddle.float32)
         self.assertEqual(var.type, core.VarDesc.VarType.DENSE_TENSOR)
 
-    def test_to_tensor_param_map(self):
+    def test_to_tensor_param_alias(self):
         """Test paddle.to_tensor parameter mapping ("place": ["device"])."""
         # 1. Test equivalence of place and device parameters
-        tensor_place = paddle.to_tensor(self.array, place=paddle.CUDAPlace(0))
-        tensor_device = paddle.to_tensor(self.array, device=paddle.CUDAPlace(0))
+        tensor_place = paddle.to_tensor(self.array, place=paddle.CPUPlace())
+        tensor_device = paddle.to_tensor(self.array, device=paddle.CPUPlace())
 
         np.testing.assert_array_equal(
             tensor_device.numpy(), tensor_place.numpy()
@@ -392,8 +392,8 @@ class TestEagerTensor(unittest.TestCase):
         with self.assertRaises(KeyError) as context:
             paddle.to_tensor(
                 self.array,
-                place=paddle.CUDAPlace(0),
-                device=paddle.CUDAPlace(0),  # Conflict
+                place=paddle.CPUPlace(),
+                device=paddle.CPUPlace(),  # Conflict
             )
         self.assertIn(
             "Both place and device are provided.", str(context.exception)
@@ -401,10 +401,10 @@ class TestEagerTensor(unittest.TestCase):
 
         # 3. Test dtype and stop_gradient consistency
         tensor1 = paddle.to_tensor(
-            self.array, dtype="float32", device=paddle.CUDAPlace(0)
+            self.array, dtype="float32", device=paddle.CPUPlace()
         )
         tensor2 = paddle.to_tensor(
-            self.array, dtype="float32", place=paddle.CUDAPlace(0)
+            self.array, dtype="float32", place=paddle.CPUPlace()
         )
 
         self.assertEqual(tensor1.dtype, tensor2.dtype)
@@ -413,7 +413,9 @@ class TestEagerTensor(unittest.TestCase):
         self.assertEqual(tensor1.stop_gradient, tensor2.stop_gradient)
 
         # 4. Test cross-device compatibility (CPU/GPU)
-        for device in [paddle.CPUPlace(), paddle.CUDAPlace(0)]:
+        for device in [paddle.CPUPlace()] + (
+            [paddle.CUDAPlace(0)] if core.is_compiled_with_cuda() else []
+        ):
             tensor_device = paddle.to_tensor(self.array, device=device)
             tensor_place = paddle.to_tensor(self.array, place=device)
 

--- a/test/legacy_test/test_eager_tensor.py
+++ b/test/legacy_test/test_eager_tensor.py
@@ -377,6 +377,49 @@ class TestEagerTensor(unittest.TestCase):
         self.assertEqual(var.dtype, paddle.float32)
         self.assertEqual(var.type, core.VarDesc.VarType.DENSE_TENSOR)
 
+    def test_to_tensor_param_map(self):
+        """Test paddle.to_tensor parameter mapping ("place": ["device"])."""
+        # 1. Test equivalence of place and device parameters
+        tensor_place = paddle.to_tensor(self.array, place=paddle.CUDAPlace(0))
+        tensor_device = paddle.to_tensor(self.array, device=paddle.CUDAPlace(0))
+
+        np.testing.assert_array_equal(
+            tensor_device.numpy(), tensor_place.numpy()
+        )
+        self.assertEqual(tensor_device.place, tensor_place.place)
+
+        # 2. Test conflict between place and device (should raise KeyError)
+        with self.assertRaises(KeyError) as context:
+            paddle.to_tensor(
+                self.array,
+                place=paddle.CUDAPlace(0),
+                device=paddle.CUDAPlace(0),  # Conflict
+            )
+        self.assertIn(
+            "Both place and device are provided.", str(context.exception)
+        )
+
+        # 3. Test dtype and stop_gradient consistency
+        tensor1 = paddle.to_tensor(
+            self.array, dtype="float32", device=paddle.CUDAPlace(0)
+        )
+        tensor2 = paddle.to_tensor(
+            self.array, dtype="float32", place=paddle.CUDAPlace(0)
+        )
+
+        self.assertEqual(tensor1.dtype, tensor2.dtype)
+        self.assertEqual(tensor1.dtype, paddle.float32)
+        self.assertTrue(tensor1.stop_gradient)
+        self.assertEqual(tensor1.stop_gradient, tensor2.stop_gradient)
+
+        # 4. Test cross-device compatibility (CPU/GPU)
+        for device in [paddle.CPUPlace(), paddle.CUDAPlace(0)]:
+            tensor_device = paddle.to_tensor(self.array, device=device)
+            tensor_place = paddle.to_tensor(self.array, place=device)
+
+            self.assertEqual(tensor_device.place, tensor_place.place)
+            self.assertEqual(tensor_device.place, device)
+
     def test_list_to_tensor(self):
         array = [[[1, 2], [1, 2], [1.0, 2]], [[1, 2], [1, 2], [1, 2]]]
         var = paddle.to_tensor(array, dtype="int32")


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Operator Mechanism


### PR Types
Improvements


### Description

- [API parameter mapping](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/guides/model_convert/convert_from_pytorch/api_difference/torch/torch.as_tensor.html)，[ 仅参数名不一致 ]。
- Added API compatibility with PyTorch by introducing device as an alias parameter for place in paddle.to_tensor.
- Implemented a reusable param_alias decorator to handle parameter name mapping between frameworks
#### example
```
# Traditional Paddle call
t1 = paddle.to_tensor([1, 2], place=paddle.CPUPlace())

# New PyTorch-compatible call
t2 = paddle.to_tensor([1, 2], device=paddle.CPUPlace())  # Maps to `place=paddle.CPUPlace()`
```
#### Other
add test `test_to_tensor_param_alias`。


pcard-67164