### PR TITLE
Add paddle.is_autocast_enabled and get_autocast_gpu_dtype API

### DIFF
--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -130,6 +130,7 @@ from . import (
     utils as utils,
 )
 from .amp import (
+    get_autocast_cpu_dtype,
     get_autocast_dtype,
     get_autocast_gpu_dtype,
     is_autocast_enabled,
@@ -1236,6 +1237,7 @@ __all__ = [
     'e',
     'is_autocast_enabled',
     'get_autocast_dtype',
+    'get_autocast_cpu_dtype',
     'get_autocast_gpu_dtype',
 ]
 

--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -129,6 +129,11 @@ from . import (
     tensor as tensor,
     utils as utils,
 )
+from .amp import (
+    get_autocast_dtype,
+    get_autocast_gpu_dtype,
+    is_autocast_enabled,
+)
 from .autograd import (
     enable_grad,
     grad,
@@ -1229,6 +1234,9 @@ __all__ = [
     'nan',
     'pi',
     'e',
+    'is_autocast_enabled',
+    'get_autocast_dtype',
+    'get_autocast_gpu_dtype',
 ]
 
 import os

--- a/python/paddle/amp/__init__.py
+++ b/python/paddle/amp/__init__.py
@@ -50,9 +50,11 @@ __all__ = [
     'is_bfloat16_supported',
     'is_autocast_enabled',
     'get_autocast_dtype',
+    'get_autocast_cpu_dtype',
     'get_autocast_gpu_dtype',
 ]
 
+get_autocast_cpu_dtype = get_autocast_dtype
 get_autocast_gpu_dtype = get_autocast_dtype
 
 

--- a/python/paddle/amp/__init__.py
+++ b/python/paddle/amp/__init__.py
@@ -33,6 +33,8 @@ from .auto_cast import (  # noqa: F401
     amp_guard,
     auto_cast,
     decorate,
+    get_autocast_dtype,
+    is_autocast_enabled,
 )
 from .grad_scaler import (  # noqa: F401
     AmpScaler,
@@ -46,7 +48,12 @@ __all__ = [
     'decorate',
     'is_float16_supported',
     'is_bfloat16_supported',
+    'is_autocast_enabled',
+    'get_autocast_dtype',
+    'get_autocast_gpu_dtype',
 ]
+
+get_autocast_gpu_dtype = get_autocast_dtype
 
 
 def is_float16_supported(device: str | None = None) -> bool:

--- a/python/paddle/amp/auto_cast.py
+++ b/python/paddle/amp/auto_cast.py
@@ -28,9 +28,6 @@ from typing import (
 )
 
 import paddle
-
-if TYPE_CHECKING:
-    from paddle._typing import PlaceLike
 from paddle.base import core
 from paddle.base.framework import (
     _current_expected_place,
@@ -51,6 +48,7 @@ if TYPE_CHECKING:
     from typing_extensions import TypeAlias, TypeGuard
 
     from paddle import Tensor
+    from paddle._typing import PlaceLike
     from paddle._typing.dtype_like import _DTypeLiteral
     from paddle.nn import Layer
     from paddle.nn.layer.layers import _StateDict
@@ -1364,7 +1362,7 @@ def is_autocast_enabled(device_type: PlaceLike | None = None) -> bool:
 
 def get_autocast_dtype(device_type: PlaceLike | None = None) -> _DTypeLiteral:
     """
-    Get the auto-mixed-precision dtype in the current context.
+    Get the auto-mixed-precision dtype in the current context if autocast is enabled else default AMP dtype(float16).
 
     Args:
         device_type (PlaceLike, optional): The device type to check. This argument is ignored for all devices sharing the same AMP state in paddlepaddle.
@@ -1380,18 +1378,18 @@ def get_autocast_dtype(device_type: PlaceLike | None = None) -> _DTypeLiteral:
             >>> import paddle
             >>> paddle.device.set_device('gpu')
             >>> print(paddle.get_autocast_dtype())
-            float32
+            float16
 
             >>> # Demo2: Enable auto-mixed-precision and get the dtype
             >>> with paddle.amp.auto_cast():
             ...     print(paddle.get_autocast_dtype())
             float16
     """
+    if not is_autocast_enabled():
+        return "float16"
     if in_pir_mode():
         amp_attrs = core._get_amp_attrs()
         return amp_attrs._amp_dtype
     else:
         tracer = _dygraph_tracer()
-        if tracer:
-            return tracer._amp_dtype
-        return 'float32'
+        return tracer._amp_dtype

--- a/python/paddle/amp/auto_cast.py
+++ b/python/paddle/amp/auto_cast.py
@@ -1338,7 +1338,7 @@ def is_autocast_enabled(device_type: PlaceLike | None = None) -> bool:
         bool: True if auto-mixed-precision is enabled, False otherwise.
 
     Examples:
-    .. code-block:: python
+        .. code-block:: python
 
             >>> # doctest: +REQUIRES(env:GPU)
             >>> # Demo1: Check if auto-mixed-precision is enabled by default
@@ -1373,7 +1373,7 @@ def get_autocast_dtype(device_type: PlaceLike | None = None) -> _DTypeLiteral:
         _DTypeLiteral: The current AMP dtype.
 
     Examples:
-    .. code-block:: python
+        .. code-block:: python
 
             >>> # doctest: +REQUIRES(env:GPU)
             >>> # Demo1: Get default auto-mixed-precision dtype

--- a/python/paddle/amp/auto_cast.py
+++ b/python/paddle/amp/auto_cast.py
@@ -28,6 +28,9 @@ from typing import (
 )
 
 import paddle
+
+if TYPE_CHECKING:
+    from paddle._typing import PlaceLike
 from paddle.base import core
 from paddle.base.framework import (
     _current_expected_place,
@@ -1322,3 +1325,73 @@ def decorate(
             master_grad,
             excluded_layers,
         )
+
+
+def is_autocast_enabled(device_type: PlaceLike | None = None) -> bool:
+    """
+    Check whether auto-mixed-precision is enabled in the current context.
+
+    Args:
+        device_type (PlaceLike, optional): The device type to check. This argument is ignored for all devices sharing the same AMP state in paddlepaddle.
+
+    Returns:
+        bool: True if auto-mixed-precision is enabled, False otherwise.
+
+    Examples:
+    .. code-block:: python
+
+            >>> # doctest: +REQUIRES(env:GPU)
+            >>> # Demo1: Check if auto-mixed-precision is enabled by default
+            >>> import paddle
+            >>> paddle.device.set_device('gpu')
+            >>> print(paddle.is_autocast_enabled())
+            False
+
+            >>> # Demo2: Enable auto-mixed-precision and check again
+            >>> with paddle.amp.auto_cast():
+            ...     print(paddle.is_autocast_enabled())
+            True
+    """
+    if in_pir_mode():
+        amp_attrs = core._get_amp_attrs()
+        return amp_attrs._amp_level != AMP_LEVEL.O0
+    else:
+        tracer = _dygraph_tracer()
+        if tracer:
+            return tracer._amp_level != core.AmpLevel.O0
+        return False
+
+
+def get_autocast_dtype(device_type: PlaceLike | None = None) -> _DTypeLiteral:
+    """
+    Get the auto-mixed-precision dtype in the current context.
+
+    Args:
+        device_type (PlaceLike, optional): The device type to check. This argument is ignored for all devices sharing the same AMP state in paddlepaddle.
+
+    Returns:
+        _DTypeLiteral: The current AMP dtype.
+
+    Examples:
+    .. code-block:: python
+
+            >>> # doctest: +REQUIRES(env:GPU)
+            >>> # Demo1: Get default auto-mixed-precision dtype
+            >>> import paddle
+            >>> paddle.device.set_device('gpu')
+            >>> print(paddle.get_autocast_dtype())
+            float32
+
+            >>> # Demo2: Enable auto-mixed-precision and get the dtype
+            >>> with paddle.amp.auto_cast():
+            ...     print(paddle.get_autocast_dtype())
+            float16
+    """
+    if in_pir_mode():
+        amp_attrs = core._get_amp_attrs()
+        return amp_attrs._amp_dtype
+    else:
+        tracer = _dygraph_tracer()
+        if tracer:
+            return tracer._amp_dtype
+        return 'float32'

--- a/test/amp/test_get_autocast_dtype.py
+++ b/test/amp/test_get_autocast_dtype.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import paddle
+
+
+@unittest.skipIf(paddle.device.get_device() == "cpu", "Skip AMP test on CPU")
+class TestAutocast(unittest.TestCase):
+    def setUp(self) -> None:
+        paddle.disable_static()
+        self.device_list = [None, paddle.device.get_device()]
+        self.default_dtype = "float32"
+
+    def do_test(self, device, expected_type):
+        self.assertTrue(paddle.get_autocast_dtype(device) == expected_type)
+        self.assertTrue(paddle.get_autocast_gpu_dtype() == expected_type)
+        self.assertTrue(paddle.amp.get_autocast_dtype(device) == expected_type)
+        self.assertTrue(paddle.amp.get_autocast_gpu_dtype() == expected_type)
+
+    def test_amp_default(self):
+        for device in self.device_list:
+            self.do_test(device, self.default_dtype)
+
+    def test_amp_autocast_fp16(self):
+        for device in self.device_list:
+            with paddle.amp.auto_cast(True, dtype="float16"):
+                self.do_test(device, "float16")
+            self.do_test(device, self.default_dtype)
+
+    def test_amp_autocast_bf16(self):
+        for device in self.device_list:
+            with paddle.amp.auto_cast(True, dtype="bfloat16"):
+                self.do_test(device, "bfloat16")
+            self.do_test(device, self.default_dtype)
+
+    def test_amp_autocast_false_bf16(self):
+        for device in self.device_list:
+            with paddle.amp.auto_cast(True, dtype="bfloat16"):
+                self.do_test(device, "bfloat16")
+            self.do_test(device, self.default_dtype)
+
+    def test_amp_nested_context(self):
+        for device in self.device_list:
+            with paddle.amp.auto_cast(True, dtype="bfloat16"):
+                self.do_test(device, "bfloat16")
+                with paddle.amp.auto_cast(True, dtype="float16"):
+                    self.do_test(device, "float16")
+                self.do_test(device, "bfloat16")
+            self.do_test(device, self.default_dtype)
+
+
+class TestAutocastStatic(TestAutocast):
+    def setUp(self) -> None:
+        paddle.enable_static()
+        self.device_list = [None, paddle.device.get_device()]
+        self.default_dtype = "float32"
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/amp/test_get_autocast_dtype.py
+++ b/test/amp/test_get_autocast_dtype.py
@@ -22,13 +22,17 @@ class TestAutocast(unittest.TestCase):
     def setUp(self) -> None:
         paddle.disable_static()
         self.device_list = [None, paddle.device.get_device()]
-        self.default_dtype = "float32"
+        self.default_dtype = "float16"
 
     def do_test(self, device, expected_type):
         self.assertTrue(paddle.get_autocast_dtype(device) == expected_type)
         self.assertTrue(paddle.get_autocast_gpu_dtype() == expected_type)
         self.assertTrue(paddle.amp.get_autocast_dtype(device) == expected_type)
         self.assertTrue(paddle.amp.get_autocast_gpu_dtype() == expected_type)
+        self.assertTrue(paddle.amp.get_autocast_cpu_dtype() == expected_type)
+        self.assertTrue(
+            paddle.amp.get_autocast_cpu_dtype(device) == expected_type
+        )
 
     def test_amp_default(self):
         for device in self.device_list:
@@ -66,7 +70,7 @@ class TestAutocastStatic(TestAutocast):
     def setUp(self) -> None:
         paddle.enable_static()
         self.device_list = [None, paddle.device.get_device()]
-        self.default_dtype = "float32"
+        self.default_dtype = "float16"
 
 
 if __name__ == "__main__":

--- a/test/amp/test_is_autocast_enabled.py
+++ b/test/amp/test_is_autocast_enabled.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import paddle
+
+
+@unittest.skipIf(paddle.device.get_device() == "cpu", "Skip AMP test on CPU")
+class TestAutocast(unittest.TestCase):
+    def setUp(self) -> None:
+        paddle.disable_static()
+        self.device_list = [None, paddle.device.get_device()]
+
+    def test_amp_default(self):
+        for device in self.device_list:
+            self.assertFalse(paddle.is_autocast_enabled(device))
+            self.assertFalse(paddle.amp.is_autocast_enabled(device))
+
+    def test_amp_autocast_true(self):
+        for device in self.device_list:
+            with paddle.amp.auto_cast(True):
+                self.assertTrue(paddle.is_autocast_enabled(device))
+                self.assertTrue(paddle.amp.is_autocast_enabled(device))
+
+            self.assertFalse(paddle.is_autocast_enabled(device))
+            self.assertFalse(paddle.amp.is_autocast_enabled(device))
+
+    def test_amp_autocast_false(self):
+        for device in self.device_list:
+            with paddle.amp.auto_cast(False):
+                self.assertFalse(paddle.is_autocast_enabled(device))
+                self.assertFalse(paddle.amp.is_autocast_enabled(device))
+
+            self.assertFalse(paddle.is_autocast_enabled(device))
+            self.assertFalse(paddle.amp.is_autocast_enabled(device))
+
+    def test_amp_nested_context(self):
+        for device in self.device_list:
+            with paddle.amp.auto_cast(True):
+                self.assertTrue(paddle.is_autocast_enabled(device))
+                self.assertTrue(paddle.amp.is_autocast_enabled(device))
+
+                with paddle.amp.auto_cast(False):
+                    self.assertFalse(paddle.is_autocast_enabled(device))
+                    self.assertFalse(paddle.amp.is_autocast_enabled(device))
+
+                self.assertTrue(paddle.is_autocast_enabled(device))
+                self.assertTrue(paddle.amp.is_autocast_enabled(device))
+            self.assertFalse(paddle.is_autocast_enabled(device))
+            self.assertFalse(paddle.amp.is_autocast_enabled(device))
+
+
+class TestAutocastStatic(TestAutocast):
+    def setUp(self) -> None:
+        paddle.enable_static()
+        self.device_list = [None, paddle.device.get_device()]
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->
新增 paddle.is_autocast_enabled 、get_autocast_dtype get_autocast_gpu_dtype API。其中，get_autocast_gpu_dtype是get_autocast_dtype的别名。

三个 API 均接收一个可选参数`device_dtype`，仅出于兼容 torch 对应 API 而设置。Paddle 中所有设备共享同一套 AMP 配置，`device_dtype` 不影响返回结果。

CN doc: https://github.com/PaddlePaddle/docs/pull/7375