### PR TITLE
【stride】fix copy_, set_value when dst is nullptr canot use stridecopy

### DIFF
--- a/paddle/fluid/pybind/eager_method.cc
+++ b/paddle/fluid/pybind/eager_method.cc
@@ -1414,8 +1414,8 @@ static PyObject* tensor_method_set_underline_tensor(TensorObject* self,
     if (self->tensor.is_dense_tensor()) {
       auto* dst_tensor =
           static_cast<phi::DenseTensor*>(self->tensor.impl().get());
-      if (self->tensor.has_allocation() &&
-              self->tensor.initialized() !dst_tensor->meta().is_contiguous() ||
+      if (self->tensor.has_allocation() && self->tensor.initialized() &&
+              !dst_tensor->meta().is_contiguous() ||
           !src_tensor->meta().is_contiguous()) {
         VLOG(8) << "set_tensor() method , src or dst tensor is not contiguous";
         if (!FLAGS_use_stride_kernel) {

--- a/paddle/fluid/pybind/eager_method.cc
+++ b/paddle/fluid/pybind/eager_method.cc
@@ -1415,7 +1415,7 @@ static PyObject* tensor_method_set_underline_tensor(TensorObject* self,
       auto* dst_tensor =
           static_cast<phi::DenseTensor*>(self->tensor.impl().get());
       if (self->tensor.has_allocation() &&
-              !dst_tensor->meta().is_contiguous() ||
+              self->tensor.initialized() !dst_tensor->meta().is_contiguous() ||
           !src_tensor->meta().is_contiguous()) {
         VLOG(8) << "set_tensor() method , src or dst tensor is not contiguous";
         if (!FLAGS_use_stride_kernel) {

--- a/paddle/phi/api/lib/tensor_method.cc
+++ b/paddle/phi/api/lib/tensor_method.cc
@@ -198,7 +198,8 @@ void Tensor::copy_(const Tensor &src,
     return;
   }
 #endif
-    if(is_dense_tensor() && has_allocation() && src.is_dense_tensor()) {
+    if(is_dense_tensor() && has_allocation() &&
+      initialized() && src.is_dense_tensor()) {
       auto dst_tensor = static_cast<phi::DenseTensor*>(impl_.get());
       auto src_tensor = std::static_pointer_cast<phi::DenseTensor>(src.impl_);
       if(!dst_tensor->meta().is_contiguous() ||


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
 Bug fixes 

### Description
<!-- Describe what you’ve done -->
pcard-67164
https://github.com/PaddlePaddle/Paddle/pull/74341 补充其他判断