### PR TITLE
[API compatibility] Parameter mapping from torch to paddle（broadcast_to）

### DIFF
--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -24,7 +24,7 @@ from typing_extensions import overload
 import paddle
 from paddle import _C_ops
 from paddle.tensor import fill_constant
-from paddle.utils.decorator_utils import param_alias
+from paddle.utils.decorator_utils import ParamAliasDecorator
 from paddle.utils.inplace_utils import inplace_apis_in_dygraph_only
 
 from ..base.data_feeder import (
@@ -4763,7 +4763,7 @@ def expand_as(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
         return out
 
 
-@param_alias({"x": ["input"], "shape": ["size"]})
+@ParamAliasDecorator({"x": ["input"], "shape": ["size"]})
 def broadcast_to(
     x: Tensor, shape: ShapeLike, name: str | None = None
 ) -> Tensor:

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -24,6 +24,7 @@ from typing_extensions import overload
 import paddle
 from paddle import _C_ops
 from paddle.tensor import fill_constant
+from paddle.utils.decorator_utils import param_alias
 from paddle.utils.inplace_utils import inplace_apis_in_dygraph_only
 
 from ..base.data_feeder import (
@@ -4762,6 +4763,7 @@ def expand_as(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
         return out
 
 
+@param_alias({"x": ["input"], "shape": ["size"]})
 def broadcast_to(
     x: Tensor, shape: ShapeLike, name: str | None = None
 ) -> Tensor:

--- a/python/paddle/utils/__init__.py
+++ b/python/paddle/utils/__init__.py
@@ -15,6 +15,7 @@
 from ..base.framework import require_version
 from . import (  # noqa: F401
     cpp_extension,
+    decorator_utils,
     dlpack,
     download,
     image_util,

--- a/python/paddle/utils/decorator_utils.py
+++ b/python/paddle/utils/decorator_utils.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import functools
+import inspect
+from typing import TYPE_CHECKING, Any, Callable, TypeVar
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+F = TypeVar('F', bound=Callable[..., Any])
+
+
+def param_alias(alias_mapping: dict[str, Iterable[str]]) -> Callable[[F], F]:
+    """Decorator for handling parameter aliases in function calls.
+    Args:
+        alias_mapping: Dictionary mapping original parameter names to their aliases.
+                      Example: {'original': ['alias1', 'alias2']}
+    Returns:
+        A decorator that processes parameter aliases before calling the original function.
+    """
+    if not isinstance(alias_mapping, dict):
+        raise TypeError("alias_mapping must be a dictionary")
+    for k, v in alias_mapping.items():
+        if not isinstance(v, (list, tuple, set)):
+            raise TypeError(f"Aliases for '{k}' must be iterable")
+
+    def decorator(func: F) -> F:
+        @functools.wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            if not kwargs:
+                return func(*args, **kwargs)
+            processed_kwargs = kwargs.copy()
+            for original, aliases in alias_mapping.items():
+                for alias in aliases:
+                    if alias in processed_kwargs:
+                        if original not in processed_kwargs:
+                            processed_kwargs[original] = processed_kwargs.pop(
+                                alias
+                            )
+                        else:
+                            raise ValueError(
+                                f"Cannot specify both '{original}' and its alias '{alias}'"
+                            )
+            return func(*args, **processed_kwargs)
+
+        wrapper.__signature__ = inspect.signature(func)
+        return wrapper
+
+    return decorator

--- a/python/paddle/utils/decorator_utils.py
+++ b/python/paddle/utils/decorator_utils.py
@@ -16,47 +16,92 @@ from __future__ import annotations
 
 import functools
 import inspect
-from typing import TYPE_CHECKING, Any, Callable, TypeVar
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Generic,
+    TypeVar,
+    cast,
+)
+
+from typing_extensions import ParamSpec
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
-F = TypeVar('F', bound=Callable[..., Any])
 
 
-def param_alias(alias_mapping: dict[str, Iterable[str]]) -> Callable[[F], F]:
-    """Decorator for handling parameter aliases in function calls.
-    Args:
-        alias_mapping: Dictionary mapping original parameter names to their aliases.
-                      Example: {'original': ['alias1', 'alias2']}
-    Returns:
-        A decorator that processes parameter aliases before calling the original function.
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
+_DecoratedFunc = Callable[_P, _R]
+
+
+class DecoratorBase(Generic[_P, _R]):
+    """装饰器基类，提供通用装饰器框架
+
+    子类只需实现 `process` 方法定义核心逻辑
     """
-    if not isinstance(alias_mapping, dict):
-        raise TypeError("alias_mapping must be a dictionary")
-    for k, v in alias_mapping.items():
-        if not isinstance(v, (list, tuple, set)):
-            raise TypeError(f"Aliases for '{k}' must be iterable")
 
-    def decorator(func: F) -> F:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """初始化装饰器参数"""
+        self.args = args
+        self.kwargs = kwargs
+
+    def __call__(self, func: _DecoratedFunc[_P, _R]) -> _DecoratedFunc[_P, _R]:
+        """作为装饰器应用的入口点"""
+
         @functools.wraps(func)
-        def wrapper(*args: Any, **kwargs: Any) -> Any:
-            if not kwargs:
-                return func(*args, **kwargs)
-            processed_kwargs = kwargs.copy()
-            for original, aliases in alias_mapping.items():
-                for alias in aliases:
-                    if alias in processed_kwargs:
-                        if original not in processed_kwargs:
-                            processed_kwargs[original] = processed_kwargs.pop(
-                                alias
-                            )
-                        else:
-                            raise ValueError(
-                                f"Cannot specify both '{original}' and its alias '{alias}'"
-                            )
-            return func(*args, **processed_kwargs)
+        def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R:
+            # 预处理参数
+            processed_args, processed_kwargs = self.process(args, kwargs)
+            # 调用原函数
+            return func(*processed_args, **processed_kwargs)
 
+        # 保留原始签名
         wrapper.__signature__ = inspect.signature(func)
-        return wrapper
+        return cast("_DecoratedFunc[_P, _R]", wrapper)
 
-    return decorator
+    def process(
+        self, args: tuple[Any, ...], kwargs: dict[str, Any]
+    ) -> tuple[tuple[Any, ...], dict[str, Any]]:
+        """子类必须实现的核心处理方法
+
+        Args:
+            args: 位置参数
+            kwargs: 关键字参数
+
+        Returns:
+            处理后的 (args, kwargs) 元组
+        """
+        raise NotImplementedError("Subclasses must implement this method")
+
+
+# 示例实现：参数别名装饰器
+class ParamAliasDecorator(DecoratorBase[_P, _R]):
+    """参数别名处理的装饰器实现"""
+
+    def __init__(self, alias_mapping: dict[str, Iterable[str]]) -> None:
+        super().__init__()
+        if not isinstance(alias_mapping, dict):
+            raise TypeError("alias_mapping must be a dictionary")
+        for k, v in alias_mapping.items():
+            if not isinstance(v, (list, tuple, set)):
+                raise TypeError(f"Aliases for '{k}' must be iterable")
+        self.alias_mapping = alias_mapping
+
+    def process(
+        self, args: tuple[Any, ...], kwargs: dict[str, Any]
+    ) -> tuple[tuple[Any, ...], dict[str, Any]]:
+        if not kwargs:
+            return args, kwargs
+        processed_kwargs = kwargs.copy()
+        for original, aliases in self.alias_mapping.items():
+            for alias in aliases:
+                if alias in processed_kwargs:
+                    if original not in processed_kwargs:
+                        processed_kwargs[original] = processed_kwargs.pop(alias)
+                    else:
+                        raise ValueError(
+                            f"Cannot specify both '{original}' and its alias '{alias}'"
+                        )
+        return args, processed_kwargs


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
[ 仅参数名不一致 ]torch.broadcast_to
api参数映射关系：[点击链接](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/guides/model_convert/convert_from_pytorch/api_difference/torch/torch.broadcast_to.html)

1. 增加参数装饰器；
2. 单测已存在：/test/legacy_test/test_broadcast_to_op.py

测试：
```
>>> import paddle 
>>> x = paddle.to_tensor([1, 2, 3])
>>> y = paddle.broadcast_to(x, [2, 3])
>>> print(y.shape)
[2, 3]
>>> 
>>> y = paddle.broadcast_to(x, size=[2, 3])
>>> print(y.shape)
[2, 3]
>>> 
>>> y = paddle.broadcast_to(input=x, size=[2, 3])
>>> print(y.shape)
[2, 3]
>>> 
>>> 
>>> y = paddle.broadcast_to(x=x, size=[2, 3])
>>> print(y.shape)
[2, 3]
```

pcard-67164