### PR TITLE
[CINN] Align int pow with torch for base=0 and exponent<0

### DIFF
--- a/paddle/cinn/runtime/cuda/cinn_cuda_runtime_source.cuh
+++ b/paddle/cinn/runtime/cuda/cinn_cuda_runtime_source.cuh
@@ -338,7 +338,7 @@ extern "C" {
 
 __device__ inline int FN_INT32(pow)(int a, int b) {
   if (a == 0 && b < 0) {
-    return -1;
+    return 0;
   }
   float res = pow(__int2float_rd(a), __int2float_rd(b));
   return __float2int_rn(res);
@@ -418,6 +418,9 @@ __device__ inline long long int FN_INT64(exp)(long long int a) {
 
 __device__ inline long long int FN_INT64(pow)(long long int a,
                                               long long int b) {
+  if (a == 0 && b < 0) {
+    return 0;
+  }
   double res = pow(__ll2double_rd(a), __ll2double_rd(b));
   return __double2ll_rn(res);
 }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
CINN


### PR Types
Bug fixes


### Description
CINN在处理int类型的pow时，对 pow(0, -exp) 这种情况是返回-1，但torch是返回0；PHI算子库的pow已经跟torch对齐了（#73274），因此这个PR把CINN也和torch对齐

本PR的正确性通过CE的 [pow_0_func.py]( https://github.com/PaddlePaddle/PaddleTest/blob/8dc17ab355a2534a3ae11505644b7d8ffc9870bb/framework/e2e/PaddleLT_new/layerApicase/math_sublayer/pow_0_func.py) 验证

<b>注：</b>从数学上说pow底数为0时指数不允许为负数，这种情况就和0/0一样在数学上不存在，用户本来不应该指望此时的输出是有意义的值，但是考虑到框架使用的一致性，还是和torch对齐一下

Pcard-85711