### PR TITLE
Fix SliceTensor to fix paddle.functional.diff for big tensor 

### DIFF
--- a/paddle/phi/kernels/funcs/broadcast_function.h
+++ b/paddle/phi/kernels/funcs/broadcast_function.h
@@ -584,7 +584,7 @@ static void SliceTensor(DenseTensor *x,
   DenseTensorMeta meta(share->dtype(),
                        new_dim,
                        share->layout(),
-                       offset * SizeOf(share->dtype()));
+                       offset * SizeOf(share->dtype()) + share->offset());
   x->set_meta(meta);
   x->ShareBufferWith(*(share), true);
   x->Resize(new_dim);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
SliceTensor 中 忽略了输入tensor的原始offset，导致大tensor计算时会出现错误。修复后可以解决部分diff api的case，剩余case由其他问题导致，正在排查。

Pcard-67164