### PR TITLE
[Warning fix] fix warning for slice_utils.h

### DIFF
--- a/paddle/fluid/pybind/slice_utils.h
+++ b/paddle/fluid/pybind/slice_utils.h
@@ -525,7 +525,7 @@ static void ParseIndex(const paddle::Tensor& tensor,
         if (slice_tensor.dtype() == phi::DataType::BOOL) {
           // bool tensor consumes (rank of index tensor) dimensions of input
           // tensor
-          for (int i = 0; i < slice_tensor.shape().size(); i++) {
+          for (size_t i = 0; i < slice_tensor.shape().size(); i++) {
             PADDLE_ENFORCE_EQ(slice_tensor.shape()[i],
                               dim_len,
                               common::errors::OutOfRange(
@@ -684,7 +684,7 @@ static paddle::Tensor dealWithAdvancedIndex(
       if (index.dtype() == phi::DataType::BOOL) {
         *rank_of_new_dim = std::max(*rank_of_new_dim, 1);
         i--;
-        for (int j = 0; j < index.shape().size(); j++) {
+        for (size_t j = 0; j < index.shape().size(); j++) {
           i++;
           index_dim = (*advanced_index_dim)[i];
           trans_dim->push_back(index_dim);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
```bash
slice_utils.h:528:29: warning: comparison of integer expressions of different signedness: ‘int’ and ‘std::vector<long int>::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
           for (int i = 0; i < slice_tensor.shape().size(); i++) {

slice_utils.h:687:27: warning: comparison of integer expressions of different signedness: ‘int’ and ‘std::vector<long int>::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
         for (int j = 0; j < index.shape().size(); j++) {
```

change int to size_t