### PR TITLE
fix std /0 bug

### DIFF
--- a/paddle/phi/kernels/funcs/activation_functor.h
+++ b/paddle/phi/kernels/funcs/activation_functor.h
@@ -4206,7 +4206,7 @@ struct CudaSqrtGradFunctor : public BaseActivationFunctor<T> {
 
   // dx = dout * 0.5 / out
   __device__ __forceinline__ T operator()(const T dout, const T out) const {
-    return one_half * dout / out;
+    return out != T(0) ? one_half * dout / out : T(0);
   }
 
   static constexpr ActBwdOpFwdDeps FwdDeps() {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
#### paddle.std的反向求导公式未针对std结果为0的情况进行考虑，导致除0产生NAN 梯度。

+ torch 实现
<img width="709" height="304" alt="72bb1f2bdfc6d558ecaaaa2aca6e17d1" src="https://github.com/user-attachments/assets/e3e480ff-0d09-4606-b2d0-1631b5afd6ca" />

+ paddle实现
<img width="781" height="379" alt="66eda90c414804cc4a02f598b13962ea" src="https://github.com/user-attachments/assets/7ab02517-470f-402d-a2a4-9d8eb2050f3b" />

paddle并未对于std的结果为0的情况进行考虑。