### PR TITLE
[xpu] fix compile

### DIFF
--- a/cmake/external/xpu.cmake
+++ b/cmake/external/xpu.cmake
@@ -253,9 +253,9 @@ if(WITH_XPU_XRE5)
     DOWNLOAD_COMMAND
       bash ${CMAKE_SOURCE_DIR}/tools/xpu/pack_paddle_dependence.sh
       ${XPU_XRE_URL} ${XPU_XRE_DIR_NAME} ${XPU_XHPC_URL} ${XPU_XHPC_DIR_NAME}
-      ${XPU_XCCL_URL} ${XPU_XCCL_DIR_NAME} 1 ${WITH_MKL}
-      "${CMAKE_SOURCE_DIR}/build" && wget ${XPU_XFT_GET_DEPENCE_URL} && bash
-      ${XFT_COMMAND} ${XPU_XFT_URL} ${XPU_XFT_DIR_NAME} && bash
+      ${XPU_XCCL_URL} ${XPU_XCCL_DIR_NAME} 1 ${WITH_MKL} "${CMAKE_BINARY_DIR}"
+      && wget ${XPU_XFT_GET_DEPENCE_URL} && bash ${XFT_COMMAND} ${XPU_XFT_URL}
+      ${XPU_XFT_DIR_NAME} && bash
       ${CMAKE_SOURCE_DIR}/tools/xpu/get_xpti_dependence.sh ${XPU_XPTI_URL}
       ${XPU_XPTI_DIR_NAME} && bash
       ${CMAKE_SOURCE_DIR}/tools/xpu/get_xpufft_dependence.sh ${XPU_FFT_URL}

--- a/tools/xpu/pack_paddle_dependence.sh
+++ b/tools/xpu/pack_paddle_dependence.sh
@@ -94,10 +94,8 @@ function xhpc_prepare() {
     cp -r ${XHPC_DIR_NAME}/xpudnn/so/libxpu_dnn.so xpu/lib/
 
     if [[ "${WITH_MKL}" == "ON" ]]; then
-      cp -r ${BUILD_DIR}/third_party/install/mklml/lib/libiomp5.so xpu/lib/
-      pushd xpu/lib
-      ln -sf libiomp5.so libomp.so
-      popd
+      # Now xpu/lib/libomp.so is invalid. When we need libomp.so, libomp.so is valid.
+      ln -sf ${BUILD_DIR}/third_party/install/mklml/lib/libiomp5.so xpu/lib/libomp.so
     else
       cp -r ${XHPC_DIR_NAME}/xpudnn/so/libomp.so xpu/lib/
       pushd xpu/lib
@@ -160,10 +158,8 @@ function local_assemble() {
       cp -r ${LOCAL_PATH}/${XHPC_DIR_NAME}/xpudnn/so/libxpu_dnn.so xpu/lib/
 
       if [[ "${WITH_MKL}" == "ON" ]]; then
-        cp -r ${BUILD_DIR}/third_party/install/mklml/lib/libiomp5.so xpu/lib/
-        pushd xpu/lib
-        ln -sf libiomp5.so libomp.so
-        popd
+        # Now xpu/lib/libomp.so is invalid. When we need libomp.so, libomp.so is valid.
+        ln -sf ${BUILD_DIR}/third_party/install/mklml/lib/libiomp5.so xpu/lib/libomp.so
       else
         cp -r ${XHPC_DIR_NAME}/xpudnn/so/libomp.so xpu/lib/
         pushd xpu/lib


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修复 #74277 的遗留问题：第一次编译会有报找不到libiomp5.so的问题。

原因：执行.cmake的时候，mklml/lib/libiomp5.so还没有，直接拷贝会报错。

修复方案：先做一次假的软链接，当编译xpu库用到libomp.so的时候软链接是有效的。

card-71500