### PR TITLE
Rename ctx to the corresponding dev_ctx,xpu_ctx [fluid_ops]

### DIFF
--- a/paddle/phi/kernels/legacy/compare_kernel.h
+++ b/paddle/phi/kernels/legacy/compare_kernel.h
@@ -19,42 +19,42 @@ limitations under the License. */
 namespace phi {
 
 template <typename T, typename Context>
-void LessThanRawKernel(const Context& ctx,
+void LessThanRawKernel(const Context& dev_ctx,
                        const DenseTensor& x,
                        const DenseTensor& y,
                        int axis,
                        DenseTensor* out);
 
 template <typename T, typename Context>
-void LessEqualRawKernel(const Context& ctx,
+void LessEqualRawKernel(const Context& dev_ctx,
                         const DenseTensor& x,
                         const DenseTensor& y,
                         int axis,
                         DenseTensor* out);
 
 template <typename T, typename Context>
-void GreaterThanRawKernel(const Context& ctx,
+void GreaterThanRawKernel(const Context& dev_ctx,
                           const DenseTensor& x,
                           const DenseTensor& y,
                           int axis,
                           DenseTensor* out);
 
 template <typename T, typename Context>
-void GreaterEqualRawKernel(const Context& ctx,
+void GreaterEqualRawKernel(const Context& dev_ctx,
                            const DenseTensor& x,
                            const DenseTensor& y,
                            int axis,
                            DenseTensor* out);
 
 template <typename T, typename Context>
-void EqualRawKernel(const Context& ctx,
+void EqualRawKernel(const Context& dev_ctx,
                     const DenseTensor& x,
                     const DenseTensor& y,
                     int axis,
                     DenseTensor* out);
 
 template <typename T, typename Context>
-void NotEqualRawKernel(const Context& ctx,
+void NotEqualRawKernel(const Context& dev_ctx,
                        const DenseTensor& x,
                        const DenseTensor& y,
                        int axis,

--- a/paddle/phi/kernels/legacy/cpu/compare_kernel.cc
+++ b/paddle/phi/kernels/legacy/cpu/compare_kernel.cc
@@ -25,23 +25,23 @@ template <typename T,
           typename Context,
           typename Functor,
           typename InverseFunctor>
-inline void CompareRawKernelImpl(const Context& ctx,
+inline void CompareRawKernelImpl(const Context& dev_ctx,
                                  const DenseTensor& x,
                                  const DenseTensor& y,
                                  int axis,
                                  DenseTensor* out) {
-  ctx.template Alloc<bool>(out);
+  dev_ctx.template Alloc<bool>(out);
   if (x.dims().size() >= y.dims().size()) {
     funcs::ElementwiseCompute<Functor, T, bool>(
-        ctx, x, y, Functor(), out, axis);
+        dev_ctx, x, y, Functor(), out, axis);
   } else {
     funcs::ElementwiseCompute<InverseFunctor, T, bool>(
-        ctx, x, y, InverseFunctor(), out, axis);
+        dev_ctx, x, y, InverseFunctor(), out, axis);
   }
 }
 
 template <typename T, typename Context>
-void LessThanRawKernel(const Context& ctx,
+void LessThanRawKernel(const Context& dev_ctx,
                        const DenseTensor& x,
                        const DenseTensor& y,
                        int axis,
@@ -49,11 +49,11 @@ void LessThanRawKernel(const Context& ctx,
   CompareRawKernelImpl<T,
                        Context,
                        funcs::LessThanFunctor<T>,
-                       funcs::GreaterThanFunctor<T>>(ctx, x, y, axis, out);
+                       funcs::GreaterThanFunctor<T>>(dev_ctx, x, y, axis, out);
 }
 
 template <typename T, typename Context>
-void LessEqualRawKernel(const Context& ctx,
+void LessEqualRawKernel(const Context& dev_ctx,
                         const DenseTensor& x,
                         const DenseTensor& y,
                         int axis,
@@ -61,11 +61,11 @@ void LessEqualRawKernel(const Context& ctx,
   CompareRawKernelImpl<T,
                        Context,
                        funcs::LessEqualFunctor<T>,
-                       funcs::GreaterEqualFunctor<T>>(ctx, x, y, axis, out);
+                       funcs::GreaterEqualFunctor<T>>(dev_ctx, x, y, axis, out);
 }
 
 template <typename T, typename Context>
-void GreaterThanRawKernel(const Context& ctx,
+void GreaterThanRawKernel(const Context& dev_ctx,
                           const DenseTensor& x,
                           const DenseTensor& y,
                           int axis,
@@ -73,10 +73,10 @@ void GreaterThanRawKernel(const Context& ctx,
   CompareRawKernelImpl<T,
                        Context,
                        funcs::GreaterThanFunctor<T>,
-                       funcs::LessThanFunctor<T>>(ctx, x, y, axis, out);
+                       funcs::LessThanFunctor<T>>(dev_ctx, x, y, axis, out);
 }
 template <typename T, typename Context>
-void GreaterEqualRawKernel(const Context& ctx,
+void GreaterEqualRawKernel(const Context& dev_ctx,
                            const DenseTensor& x,
                            const DenseTensor& y,
                            int axis,
@@ -84,10 +84,10 @@ void GreaterEqualRawKernel(const Context& ctx,
   CompareRawKernelImpl<T,
                        Context,
                        funcs::GreaterEqualFunctor<T>,
-                       funcs::LessEqualFunctor<T>>(ctx, x, y, axis, out);
+                       funcs::LessEqualFunctor<T>>(dev_ctx, x, y, axis, out);
 }
 template <typename T, typename Context>
-void EqualRawKernel(const Context& ctx,
+void EqualRawKernel(const Context& dev_ctx,
                     const DenseTensor& x,
                     const DenseTensor& y,
                     int axis,
@@ -95,10 +95,10 @@ void EqualRawKernel(const Context& ctx,
   CompareRawKernelImpl<T,
                        Context,
                        funcs::EqualFunctor<T>,
-                       funcs::EqualFunctor<T>>(ctx, x, y, axis, out);
+                       funcs::EqualFunctor<T>>(dev_ctx, x, y, axis, out);
 }
 template <typename T, typename Context>
-void NotEqualRawKernel(const Context& ctx,
+void NotEqualRawKernel(const Context& dev_ctx,
                        const DenseTensor& x,
                        const DenseTensor& y,
                        int axis,
@@ -106,7 +106,7 @@ void NotEqualRawKernel(const Context& ctx,
   CompareRawKernelImpl<T,
                        Context,
                        funcs::NotEqualFunctor<T>,
-                       funcs::NotEqualFunctor<T>>(ctx, x, y, axis, out);
+                       funcs::NotEqualFunctor<T>>(dev_ctx, x, y, axis, out);
 }
 }  // namespace phi
 

--- a/paddle/phi/kernels/legacy/cpu/one_hot_kernel.cc
+++ b/paddle/phi/kernels/legacy/cpu/one_hot_kernel.cc
@@ -25,20 +25,20 @@ struct OneHotV2OpFunctor {
   const DenseTensor* in_;
   DenseTensor* out_;
   int depth_;
-  const DeviceContext& ctx_;
+  const DeviceContext& dev_ctx_;
 
   OneHotV2OpFunctor(const DenseTensor* in,
                     DenseTensor* out,
                     int depth,
-                    const DeviceContext& ctx)
-      : in_(in), out_(out), depth_(depth), ctx_(ctx) {}
+                    const DeviceContext& dev_ctx)
+      : in_(in), out_(out), depth_(depth), dev_ctx_(dev_ctx) {}
 
   template <typename OutT>
   void apply() const {
     auto* p_in_data = in_->data<InT>();
     auto numel = in_->numel();
-    auto* p_out_data = ctx_.template Alloc<OutT>(out_);
-    funcs::set_constant(ctx_, out_, 0.0);
+    auto* p_out_data = dev_ctx_.template Alloc<OutT>(out_);
+    funcs::set_constant(dev_ctx_, out_, 0.0);
 
     for (int i = 0; i < numel; ++i) {
       PADDLE_ENFORCE_GE(

--- a/paddle/phi/kernels/legacy/gpu/one_hot_kernel.cu
+++ b/paddle/phi/kernels/legacy/gpu/one_hot_kernel.cu
@@ -44,24 +44,24 @@ template <typename DeviceContext, typename InT>
 struct OneHotV2OpCUDAFunctor {
   const DenseTensor* in_;
   DenseTensor* out_;
-  const DeviceContext& ctx_;
+  const DeviceContext& dev_ctx_;
   int depth_;
 
   OneHotV2OpCUDAFunctor(const DenseTensor* in,
                         DenseTensor* out,
                         int depth,
-                        const DeviceContext& ctx)
-      : in_(in), out_(out), depth_(depth), ctx_(ctx) {}
+                        const DeviceContext& dev_ctx)
+      : in_(in), out_(out), depth_(depth), dev_ctx_(dev_ctx) {}
 
   template <typename OutT>
   void apply() const {
     auto* p_in_data = in_->data<InT>();
     auto numel = in_->numel();
-    auto* p_out_data = ctx_.template Alloc<OutT>(out_);
-    auto stream = ctx_.stream();
-    funcs::set_constant(ctx_, out_, 0.0);
+    auto* p_out_data = dev_ctx_.template Alloc<OutT>(out_);
+    auto stream = dev_ctx_.stream();
+    funcs::set_constant(dev_ctx_, out_, 0.0);
 
-    auto config = phi::backends::gpu::GetGpuLaunchConfig1D(ctx_, numel);
+    auto config = phi::backends::gpu::GetGpuLaunchConfig1D(dev_ctx_, numel);
 
     FillOutputKernel<<<config.block_per_grid,
                        config.thread_per_block,

--- a/paddle/phi/kernels/legacy/kps/compare_kernel.cu
+++ b/paddle/phi/kernels/legacy/kps/compare_kernel.cu
@@ -34,77 +34,77 @@
 namespace phi {
 
 template <typename T, typename Context, typename Functor>
-inline void CompareRawKernelImpl(const Context& ctx,
+inline void CompareRawKernelImpl(const Context& dev_ctx,
                                  const DenseTensor& x,
                                  const DenseTensor& y,
                                  int axis,
                                  DenseTensor* out) {
-  ctx.template Alloc<bool>(out);
+  dev_ctx.template Alloc<bool>(out);
   out->set_type(phi::DataType::BOOL);
   if (out->numel() == 0) return;
   std::vector<const DenseTensor*> ins{&x, &y};
   std::vector<DenseTensor*> outs{out};
-  funcs::BroadcastKernel<bool>(ctx, ins, &outs, Functor(), axis);
+  funcs::BroadcastKernel<bool>(dev_ctx, ins, &outs, Functor(), axis);
 }
 
 template <typename T, typename Context>
-void LessThanRawKernel(const Context& ctx,
+void LessThanRawKernel(const Context& dev_ctx,
                        const DenseTensor& x,
                        const DenseTensor& y,
                        int axis,
                        DenseTensor* out) {
   CompareRawKernelImpl<T, Context, funcs::LessThanFunctor<T>>(
-      ctx, x, y, axis, out);
+      dev_ctx, x, y, axis, out);
 }
 
 template <typename T, typename Context>
-void LessEqualRawKernel(const Context& ctx,
+void LessEqualRawKernel(const Context& dev_ctx,
                         const DenseTensor& x,
                         const DenseTensor& y,
                         int axis,
                         DenseTensor* out) {
   CompareRawKernelImpl<T, Context, funcs::LessEqualFunctor<T>>(
-      ctx, x, y, axis, out);
+      dev_ctx, x, y, axis, out);
 }
 
 template <typename T, typename Context>
-void GreaterThanRawKernel(const Context& ctx,
+void GreaterThanRawKernel(const Context& dev_ctx,
                           const DenseTensor& x,
                           const DenseTensor& y,
                           int axis,
                           DenseTensor* out) {
   CompareRawKernelImpl<T, Context, funcs::GreaterThanFunctor<T>>(
-      ctx, x, y, axis, out);
+      dev_ctx, x, y, axis, out);
 }
 
 template <typename T, typename Context>
-void GreaterEqualRawKernel(const Context& ctx,
+void GreaterEqualRawKernel(const Context& dev_ctx,
                            const DenseTensor& x,
                            const DenseTensor& y,
                            int axis,
                            DenseTensor* out) {
   CompareRawKernelImpl<T, Context, funcs::GreaterEqualFunctor<T>>(
-      ctx, x, y, axis, out);
+      dev_ctx, x, y, axis, out);
 }
 
 template <typename T, typename Context>
-void EqualRawKernel(const Context& ctx,
+void EqualRawKernel(const Context& dev_ctx,
                     const DenseTensor& x,
                     const DenseTensor& y,
                     int axis,
                     DenseTensor* out) {
   CompareRawKernelImpl<T, Context, funcs::EqualFunctor<T>>(
-      ctx, x, y, axis, out);
+      dev_ctx, x, y, axis, out);
 }
 
 template <typename T, typename Context>
-void NotEqualRawKernel(const Context& ctx,
+void NotEqualRawKernel(const Context& dev_ctx,
                        const DenseTensor& x,
                        const DenseTensor& y,
                        int axis,
                        DenseTensor* out) {
   CompareRawKernelImpl<T, Context, funcs::NotEqualFunctor<T>>(
-      ctx, x, y, axis, out);
+      dev_ctx, x, y, axis, out);
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/legacy/xpu/compare_kernel.cc
+++ b/paddle/phi/kernels/legacy/xpu/compare_kernel.cc
@@ -61,13 +61,13 @@ void XPUCompareRawKernelImpl(
                        int axis,                                         \
                        DenseTensor* out) {                               \
     using XPUType = typename XPUTypeTrait<T>::Type;                      \
-    auto f = [](xpu::Context* ctx,                                       \
+    auto f = [](xpu::Context* xpu_ctx,                                   \
                 const XPUType* x,                                        \
                 const XPUType* y,                                        \
                 bool* z,                                                 \
                 const std::vector<int64_t>& xshape,                      \
                 const std::vector<int64_t>& yshape) {                    \
-      return functor(ctx, x, y, z, xshape, yshape);                      \
+      return functor(xpu_ctx, x, y, z, xshape, yshape);                  \
     };                                                                   \
     XPUCompareRawKernelImpl<T, XPUType, Context>(dev_ctx, x, y, out, f); \
   }

--- a/paddle/phi/kernels/legacy/xpu/elementwise_add_kernel.cc
+++ b/paddle/phi/kernels/legacy/xpu/elementwise_add_kernel.cc
@@ -36,13 +36,13 @@ void AddRawKernel(const Context& dev_ctx,
                   DenseTensor* out) {
   using XPUType = typename XPUTypeTrait<T>::Type;
 
-  auto f = [](xpu::Context* ctx,
+  auto f = [](xpu::Context* xpu_ctx,
               const XPUType* x,
               const XPUType* y,
               XPUType* z,
               const std::vector<int64_t>& xshape,
               const std::vector<int64_t>& yshape) {
-    return xpu::broadcast_add<XPUType>(ctx, x, y, z, xshape, yshape);
+    return xpu::broadcast_add<XPUType>(xpu_ctx, x, y, z, xshape, yshape);
   };
 
   XPUElementwise<T, XPUType>(dev_ctx, x, y, axis, out, f);

--- a/paddle/phi/kernels/legacy/xpu/elementwise_divide_kernel.cc
+++ b/paddle/phi/kernels/legacy/xpu/elementwise_divide_kernel.cc
@@ -31,13 +31,13 @@ void DivideRawKernel(const Context& dev_ctx,
                      int axis,
                      DenseTensor* out) {
   using XPUType = typename XPUTypeTrait<T>::Type;
-  auto f = [](xpu::Context* ctx,
+  auto f = [](xpu::Context* xpu_ctx,
               const XPUType* x,
               const XPUType* y,
               XPUType* z,
               const std::vector<int64_t>& xshape,
               const std::vector<int64_t>& yshape) {
-    return xpu::broadcast_div<XPUType>(ctx, x, y, z, xshape, yshape);
+    return xpu::broadcast_div<XPUType>(xpu_ctx, x, y, z, xshape, yshape);
   };
 
   XPUElementwise<T, XPUType>(dev_ctx, x, y, axis, out, f);

--- a/paddle/phi/kernels/legacy/xpu/elementwise_kernel.cc
+++ b/paddle/phi/kernels/legacy/xpu/elementwise_kernel.cc
@@ -31,13 +31,13 @@ void MaximumRawKernel(const Context& dev_ctx,
   }
 
   using XPUType = typename XPUTypeTrait<T>::Type;
-  auto f = [](xpu::Context* ctx,
+  auto f = [](xpu::Context* xpu_ctx,
               const XPUType* x,
               const XPUType* y,
               XPUType* z,
               const std::vector<int64_t>& xshape,
               const std::vector<int64_t>& yshape) {
-    return xpu::broadcast_max<XPUType>(ctx, x, y, z, xshape, yshape);
+    return xpu::broadcast_max<XPUType>(xpu_ctx, x, y, z, xshape, yshape);
   };
 
   XPUElementwise<T, XPUType>(dev_ctx, x, y, axis, out, f);
@@ -55,13 +55,13 @@ void MinimumRawKernel(const Context& dev_ctx,
   }
 
   using XPUType = typename XPUTypeTrait<T>::Type;
-  auto f = [](xpu::Context* ctx,
+  auto f = [](xpu::Context* xpu_ctx,
               const XPUType* x,
               const XPUType* y,
               XPUType* z,
               const std::vector<int64_t>& xshape,
               const std::vector<int64_t>& yshape) {
-    return xpu::broadcast_min<XPUType>(ctx, x, y, z, xshape, yshape);
+    return xpu::broadcast_min<XPUType>(xpu_ctx, x, y, z, xshape, yshape);
   };
 
   XPUElementwise<T, XPUType>(dev_ctx, x, y, axis, out, f);
@@ -74,13 +74,13 @@ void RemainderRawKernel(const Context& dev_ctx,
                         int axis,
                         DenseTensor* out) {
   using XPUType = typename XPUTypeTrait<T>::Type;
-  auto f = [](xpu::Context* ctx,
+  auto f = [](xpu::Context* xpu_ctx,
               const XPUType* x,
               const XPUType* y,
               XPUType* z,
               const std::vector<int64_t>& xshape,
               const std::vector<int64_t>& yshape) {
-    return xpu::broadcast_mod<XPUType>(ctx, x, y, z, xshape, yshape);
+    return xpu::broadcast_mod<XPUType>(xpu_ctx, x, y, z, xshape, yshape);
   };
 
   XPUElementwise<T, XPUType>(dev_ctx, x, y, axis, out, f);
@@ -93,13 +93,13 @@ void FloorDivideRawKernel(const Context& dev_ctx,
                           int axis,
                           DenseTensor* out) {
   using XPUType = typename XPUTypeTrait<T>::Type;
-  auto f = [](xpu::Context* ctx,
+  auto f = [](xpu::Context* xpu_ctx,
               const XPUType* x,
               const XPUType* y,
               XPUType* z,
               const std::vector<int64_t>& xshape,
               const std::vector<int64_t>& yshape) {
-    return xpu::broadcast_floordiv<XPUType>(ctx, x, y, z, xshape, yshape);
+    return xpu::broadcast_floordiv<XPUType>(xpu_ctx, x, y, z, xshape, yshape);
   };
 
   XPUElementwise<T, XPUType>(dev_ctx, x, y, axis, out, f);
@@ -112,13 +112,13 @@ void ElementwisePowRawKernel(const Context& dev_ctx,
                              int axis,
                              DenseTensor* out) {
   using XPUType = typename XPUTypeTrait<T>::Type;
-  auto f = [](xpu::Context* ctx,
+  auto f = [](xpu::Context* xpu_ctx,
               const XPUType* x,
               const XPUType* y,
               XPUType* z,
               const std::vector<int64_t>& xshape,
               const std::vector<int64_t>& yshape) {
-    return xpu::broadcast_pow<XPUType>(ctx, x, y, z, xshape, yshape);
+    return xpu::broadcast_pow<XPUType>(xpu_ctx, x, y, z, xshape, yshape);
   };
 
   XPUElementwise<T, XPUType>(dev_ctx, x, y, axis, out, f);

--- a/paddle/phi/kernels/legacy/xpu/elementwise_multiply_kernel.cc
+++ b/paddle/phi/kernels/legacy/xpu/elementwise_multiply_kernel.cc
@@ -31,13 +31,13 @@ void MultiplyRawKernel(const Context& dev_ctx,
                        int axis,
                        DenseTensor* out) {
   using XPUType = typename XPUTypeTrait<T>::Type;
-  auto f = [](xpu::Context* ctx,
+  auto f = [](xpu::Context* xpu_ctx,
               const XPUType* x,
               const XPUType* y,
               XPUType* z,
               const std::vector<int64_t>& xshape,
               const std::vector<int64_t>& yshape) {
-    return xpu::broadcast_mul<XPUType>(ctx, x, y, z, xshape, yshape);
+    return xpu::broadcast_mul<XPUType>(xpu_ctx, x, y, z, xshape, yshape);
   };
 
   XPUElementwise<T, XPUType>(dev_ctx, x, y, axis, out, f);

--- a/paddle/phi/kernels/legacy/xpu/elementwise_subtract_kernel.cc
+++ b/paddle/phi/kernels/legacy/xpu/elementwise_subtract_kernel.cc
@@ -26,13 +26,13 @@ void SubtractRawKernel(const Context& dev_ctx,
                        int axis,
                        DenseTensor* out) {
   using XPUType = typename XPUTypeTrait<T>::Type;
-  auto f = [](xpu::Context* ctx,
+  auto f = [](xpu::Context* xpu_ctx,
               const XPUType* x,
               const XPUType* y,
               XPUType* z,
               const std::vector<int64_t>& xshape,
               const std::vector<int64_t>& yshape) {
-    return xpu::broadcast_sub<XPUType>(ctx, x, y, z, xshape, yshape);
+    return xpu::broadcast_sub<XPUType>(xpu_ctx, x, y, z, xshape, yshape);
   };
 
   phi::XPUElementwise<T, XPUType>(dev_ctx, x, y, axis, out, f);

--- a/paddle/phi/kernels/legacy/xpu/one_hot_kernel.cc
+++ b/paddle/phi/kernels/legacy/xpu/one_hot_kernel.cc
@@ -25,21 +25,21 @@ struct OneHotV2OpFunctor {
   const DenseTensor* in_;
   DenseTensor* out_;
   int depth_;
-  const Context& ctx_;
+  const Context& dev_ctx_;
 
   OneHotV2OpFunctor(const DenseTensor* in,
                     DenseTensor* out,
                     int depth,
-                    const Context& ctx)
-      : in_(in), out_(out), depth_(depth), ctx_(ctx) {}
+                    const Context& dev_ctx)
+      : in_(in), out_(out), depth_(depth), dev_ctx_(dev_ctx) {}
 
   template <typename OutT>
   void apply() const {
     auto* p_in_data = in_->data<InT>();
     auto numel = in_->numel();
-    auto* p_out_data = ctx_.template Alloc<float>(out_);
+    auto* p_out_data = dev_ctx_.template Alloc<float>(out_);
     int r = xpu::one_hot<InT>(
-        ctx_.x_context(), p_in_data, p_out_data, numel, depth_, 1.0, 0.0);
+        dev_ctx_.x_context(), p_in_data, p_out_data, numel, depth_, 1.0, 0.0);
     PADDLE_ENFORCE_XDNN_SUCCESS(r, "one_hot");
   }
 };

--- a/paddle/phi/kernels/legacy/xpu/reduce_max_kernel.cc
+++ b/paddle/phi/kernels/legacy/xpu/reduce_max_kernel.cc
@@ -30,12 +30,12 @@ void MaxRawKernel(const Context& dev_ctx,
                   DenseTensor* out) {
   reduce_all = recompute_reduce_all(x, dims, reduce_all);
   using XPUType = typename XPUTypeTrait<T>::Type;
-  auto f = [](xpu::Context* ctx,
+  auto f = [](xpu::Context* xpu_ctx,
               const T* x,
               T* y,
               const std::vector<int64_t>& xdims,
               const std::vector<int64_t>& reduce_dims) {
-    return xpu::reduce_max<XPUType>(ctx,
+    return xpu::reduce_max<XPUType>(xpu_ctx,
                                     reinterpret_cast<const XPUType*>(x),
                                     reinterpret_cast<XPUType*>(y),
                                     xdims,

--- a/paddle/phi/kernels/stride/index_select_kernel.cc
+++ b/paddle/phi/kernels/stride/index_select_kernel.cc
@@ -25,7 +25,7 @@ COMMON_DECLARE_bool(use_stride_kernel);
 namespace phi {
 
 template <typename Context>
-void IndexSelectStridedKernel(const Context& ctx,
+void IndexSelectStridedKernel(const Context& dev_ctx,
                               const DenseTensor& x,
                               int64_t index,
                               int dim,

--- a/paddle/phi/kernels/stride/slice_kernel.cc
+++ b/paddle/phi/kernels/stride/slice_kernel.cc
@@ -26,7 +26,7 @@ COMMON_DECLARE_bool(use_stride_kernel);
 namespace phi {
 
 template <typename Context>
-void SliceStridedKernel(const Context& ctx,
+void SliceStridedKernel(const Context& dev_ctx,
                         const DenseTensor& input,
                         const std::vector<int64_t>& axes,
                         const IntArray& starts_arr,

--- a/paddle/phi/kernels/stride/transpose_kernel.cc
+++ b/paddle/phi/kernels/stride/transpose_kernel.cc
@@ -22,7 +22,7 @@ COMMON_DECLARE_bool(use_stride_kernel);
 namespace phi {
 
 template <typename Context>
-void TransposeStridedKernel(const Context& ctx,
+void TransposeStridedKernel(const Context& dev_ctx,
                             const DenseTensor& x,
                             const std::vector<int>& axis,
                             DenseTensor* out) {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
Rename ctx to the corresponding dev_ctx,xpu_ctx