### PR TITLE
create_inference_config modify use_mkldnn [fluid_ops]

### DIFF
--- a/test/ir/inference/inference_pass_test.py
+++ b/test/ir/inference/inference_pass_test.py
@@ -37,7 +37,7 @@ class InferencePassTest(unittest.TestCase):
         self.feeds = None
         self.fetch_list = None
 
-        self.enable_mkldnn = False
+        self.enable_onednn = False
         self.enable_onednn_bfloat16 = False
         self.enable_trt = False
         self.enable_tensorrt_varseqlen = False
@@ -130,7 +130,7 @@ class InferencePassTest(unittest.TestCase):
         return outs
 
     def _get_analysis_config(
-        self, use_gpu=False, use_trt=False, use_mkldnn=False
+        self, use_gpu=False, use_trt=False, use_onednn=False
     ):
         '''
         Return a new object of AnalysisConfig.
@@ -178,7 +178,7 @@ class InferencePassTest(unittest.TestCase):
                 if self.enable_tensorrt_varseqlen:
                     config.enable_tensorrt_varseqlen()
 
-        elif use_mkldnn:
+        elif use_onednn:
             config.enable_onednn()
             if self.enable_onednn_bfloat16:
                 config.enable_onednn_bfloat16()
@@ -286,10 +286,10 @@ class InferencePassTest(unittest.TestCase):
                 )
 
         # Check whether the onednn results and the CPU results are the same.
-        if (not use_gpu) and self.enable_mkldnn:
+        if (not use_gpu) and self.enable_onednn:
             onednn_outputs = self._get_inference_outs(
                 self._get_analysis_config(
-                    use_gpu=use_gpu, use_mkldnn=self.enable_mkldnn
+                    use_gpu=use_gpu, use_onednn=self.enable_onednn
                 )
             )
 

--- a/test/ir/inference/quant_dequant_test.py
+++ b/test/ir/inference/quant_dequant_test.py
@@ -46,7 +46,7 @@ class QuantDequantTest(unittest.TestCase):
         self.test_startup_program = paddle.static.Program()
         self.feeds = None
         self.fetch_list = None
-        self.enable_mkldnn = False
+        self.enable_onednn = False
         self.enable_onednn_bfloat16 = False
         self.enable_trt = False
         self.enable_tensorrt_varseqlen = True
@@ -190,7 +190,7 @@ class QuantDequantTest(unittest.TestCase):
         return outs
 
     def _get_analysis_config(
-        self, use_gpu=False, use_trt=False, use_mkldnn=False
+        self, use_gpu=False, use_trt=False, use_onednn=False
     ):
         '''
         Return a new object of AnalysisConfig.
@@ -230,7 +230,7 @@ class QuantDequantTest(unittest.TestCase):
                 if self.enable_tensorrt_varseqlen:
                     config.enable_tensorrt_varseqlen()
 
-        elif use_mkldnn:
+        elif use_onednn:
             config.enable_onednn()
             if self.enable_onednn_bfloat16:
                 config.enable_onednn_bfloat16()
@@ -388,10 +388,10 @@ class QuantDequantTest(unittest.TestCase):
                 )
 
         # Check whether the onednn results and the CPU results are the same.
-        if (not use_gpu) and self.enable_mkldnn:
+        if (not use_gpu) and self.enable_onednn:
             onednn_outputs = self._get_inference_outs(
                 self._get_analysis_config(
-                    use_gpu=use_gpu, use_mkldnn=self.enable_mkldnn
+                    use_gpu=use_gpu, use_onednn=self.enable_onednn
                 )
             )
 

--- a/test/ir/inference/test_conv_act_onednn_fuse_pass.py
+++ b/test/ir/inference/test_conv_act_onednn_fuse_pass.py
@@ -207,7 +207,7 @@ class TestConvActOneDNNFusePass(PassAutoScanTest):
             groups=groups,
             dilations=dilations,
             data_format=data_format,
-            use_mkldnn=True,
+            use_onednn=True,
         )
 
         ops = [conv2d_op, act_op]

--- a/test/ir/inference/test_conv_bn_fuse_pass.py
+++ b/test/ir/inference/test_conv_bn_fuse_pass.py
@@ -108,7 +108,7 @@ class TestConvBnFusePass(PassAutoScanTest):
             groups=groups,
             paddings=paddings,
             strides=strides,
-            use_mkldnn=use_onednn,
+            use_onednn=use_onednn,
             has_bias=False,
             is_test=True,
         )

--- a/test/ir/inference/test_conv_bn_fuse_pass.py
+++ b/test/ir/inference/test_conv_bn_fuse_pass.py
@@ -158,7 +158,7 @@ class TestConvBnFusePass(PassAutoScanTest):
 
     def sample_predictor_configs(self, program_config):
         # for onednn
-        if program_config.ops[0].attrs['use_mkldnn']:
+        if program_config.ops[0].attrs['use_onednn']:
             config = self.create_inference_config(use_onednn=True)
             yield config, ['fused_conv2d'], (1e-5, 1e-5)
         else:

--- a/test/ir/inference/test_conv_transpose_bn_fuse_pass.py
+++ b/test/ir/inference/test_conv_transpose_bn_fuse_pass.py
@@ -67,7 +67,7 @@ class TestConvTransposeBnFusePass(PassAutoScanTest):
             st.sampled_from(["EXPLICIT", "SAME", "VALID"])
         )
         random_data_layout = draw(st.sampled_from(["NCHW", "NHWC"]))
-        random_use_mkldnn = draw(st.booleans())
+        random_use_onednn = draw(st.booleans())
         random_output_size = []
         random_filter = draw(
             st.lists(
@@ -133,7 +133,7 @@ class TestConvTransposeBnFusePass(PassAutoScanTest):
                 'data_format': random_data_layout,
                 'output_size': random_output_size,
                 'output_padding': random_output_size,
-                'use_mkldnn': random_use_mkldnn,
+                'use_mkldnn': random_use_onednn,
                 'is_test': True,
             },
         )
@@ -160,7 +160,7 @@ class TestConvTransposeBnFusePass(PassAutoScanTest):
                 'is_test': True,
                 'trainable_statistics': False,
                 'data_layout': random_data_layout,
-                'use_mkldnn': random_use_mkldnn,
+                'use_mkldnn': random_use_onednn,
             },
         )
 

--- a/test/ir/inference/test_conv_transpose_eltwiseadd_bn_fuse_pass.py
+++ b/test/ir/inference/test_conv_transpose_eltwiseadd_bn_fuse_pass.py
@@ -71,7 +71,7 @@ class TestConvTransposeEltwiseaddBnFusePass(PassAutoScanTest):
             st.sampled_from(["EXPLICIT", "SAME", "VALID"])
         )
         random_data_layout = draw(st.sampled_from(["NCHW", "NHWC"]))
-        random_use_mkldnn = draw(st.booleans())
+        random_use_onednn = draw(st.booleans())
         random_output_size = []
         random_filter = draw(
             st.lists(
@@ -141,7 +141,7 @@ class TestConvTransposeEltwiseaddBnFusePass(PassAutoScanTest):
                 'data_format': random_data_layout,
                 'output_size': random_output_size,
                 'output_padding': random_output_size,
-                'use_mkldnn': random_use_mkldnn,
+                'use_mkldnn': random_use_onednn,
                 'is_test': True,
             },
         )
@@ -182,7 +182,7 @@ class TestConvTransposeEltwiseaddBnFusePass(PassAutoScanTest):
                 'is_test': True,
                 'trainable_statistics': False,
                 'data_layout': random_data_layout,
-                'use_mkldnn': random_use_mkldnn,
+                'use_mkldnn': random_use_onednn,
             },
         )
 

--- a/test/ir/inference/test_fc_elementwise_layernorm_fuse_pass.py
+++ b/test/ir/inference/test_fc_elementwise_layernorm_fuse_pass.py
@@ -99,7 +99,7 @@ class TestFCElementwiseLayerNormFusePass(PassAutoScanTest):
             padding_weights=False,
             activation_type="",
             use_quantizer=False,
-            use_mkldnn=False,
+            use_onednn=False,
         )
         add_op = OpConfig(
             "elementwise_add",

--- a/test/ir/inference/test_mkldnn_int8_scale_calculation_pass.py
+++ b/test/ir/inference/test_mkldnn_int8_scale_calculation_pass.py
@@ -123,7 +123,7 @@ class TestInt8ScaleCalculationOnednnPass(PassAutoScanTest):
         bias_shape = [f_shape[0]]
         inputs = {}
         weights = {}
-        use_mkldnn = True
+        use_onednn = True
 
         has_bias = draw(st.booleans())
         if has_bias:
@@ -154,7 +154,7 @@ class TestInt8ScaleCalculationOnednnPass(PassAutoScanTest):
             groups=groups,
             dilations=dilations,
             data_format=data_format,
-            use_mkldnn=use_mkldnn,
+            use_onednn=use_onednn,
             mkldnn_data_type="int8",
         )
 

--- a/test/ir/inference/test_mkldnn_matmul_activation_fuse_pass.py
+++ b/test/ir/inference/test_mkldnn_matmul_activation_fuse_pass.py
@@ -140,7 +140,7 @@ class TestMatmulActivationOnednnFusePass(PassAutoScanTest):
 
     def sample_predictor_configs(self, program_config):
         config = self.create_inference_config(
-            use_mkldnn=True,
+            use_onednn=True,
             passes=[
                 'matmul_activation_onednn_fuse_pass',
                 'operator_scale_onednn_fuse_pass',

--- a/test/ir/inference/test_mkldnn_matmul_elementwise_add_activation_fuse_pass.py
+++ b/test/ir/inference/test_mkldnn_matmul_elementwise_add_activation_fuse_pass.py
@@ -60,7 +60,7 @@ class TestMatmulElementwiseAddActivationOnednnFusePass(PassAutoScanTest):
             inputs={'X': ['matmul_x'], 'Y': ['matmul_y']},
             outputs={'Out': ['matmul_output']},
             attrs={
-                'use_onednn': True,
+                'use_mkldnn': True,
             },
         )
 
@@ -73,7 +73,7 @@ class TestMatmulElementwiseAddActivationOnednnFusePass(PassAutoScanTest):
             type='elementwise_add',
             inputs=inputs,
             outputs={'Out': ['elementwise_add_output']},
-            attrs={'axis': axis, 'use_onednn': True},
+            attrs={'axis': axis, 'use_mkldnn': True},
         )
 
         if activation_type == "relu6":

--- a/test/ir/inference/test_mkldnn_matmul_elementwise_add_activation_fuse_pass.py
+++ b/test/ir/inference/test_mkldnn_matmul_elementwise_add_activation_fuse_pass.py
@@ -60,7 +60,7 @@ class TestMatmulElementwiseAddActivationOnednnFusePass(PassAutoScanTest):
             inputs={'X': ['matmul_x'], 'Y': ['matmul_y']},
             outputs={'Out': ['matmul_output']},
             attrs={
-                'use_mkldnn': True,
+                'use_onednn': True,
             },
         )
 
@@ -73,7 +73,7 @@ class TestMatmulElementwiseAddActivationOnednnFusePass(PassAutoScanTest):
             type='elementwise_add',
             inputs=inputs,
             outputs={'Out': ['elementwise_add_output']},
-            attrs={'axis': axis, 'use_mkldnn': True},
+            attrs={'axis': axis, 'use_onednn': True},
         )
 
         if activation_type == "relu6":
@@ -131,7 +131,7 @@ class TestMatmulElementwiseAddActivationOnednnFusePass(PassAutoScanTest):
 
     def sample_predictor_configs(self, program_config):
         config = self.create_inference_config(
-            use_mkldnn=True,
+            use_onednn=True,
             passes=[
                 'matmul_elementwise_add_onednn_fuse_pass',
                 'matmul_activation_onednn_fuse_pass',

--- a/test/ir/inference/test_mkldnn_matmul_elementwise_add_fuse_pass.py
+++ b/test/ir/inference/test_mkldnn_matmul_elementwise_add_fuse_pass.py
@@ -74,7 +74,7 @@ class TestMatmulElementwiseAddOnednnFusePass(PassAutoScanTest):
 
     def sample_predictor_configs(self, program_config):
         config = self.create_inference_config(
-            use_mkldnn=True, passes=['matmul_elementwise_add_onednn_fuse_pass']
+            use_onednn=True, passes=['matmul_elementwise_add_onednn_fuse_pass']
         )
         yield config, ['fused_matmul'], (1e-5, 1e-5)
 
@@ -137,7 +137,7 @@ class TestMatmulElementwiseAddMkldnnFuse1CHWPass(PassAutoScanTest):
 
     def sample_predictor_configs(self, program_config):
         config = self.create_inference_config(
-            use_mkldnn=True, passes=['matmul_elementwise_add_onednn_fuse_pass']
+            use_onednn=True, passes=['matmul_elementwise_add_onednn_fuse_pass']
         )
         yield config, ['fused_matmul'], (1e-5, 1e-5)
 
@@ -203,7 +203,7 @@ class TestMatmulElementwiseAddExpendResidualPass(PassAutoScanTest):
 
     def sample_predictor_configs(self, program_config):
         config = self.create_inference_config(
-            use_mkldnn=True, passes=['matmul_elementwise_add_onednn_fuse_pass']
+            use_onednn=True, passes=['matmul_elementwise_add_onednn_fuse_pass']
         )
         yield config, ['fused_matmul'], (1e-5, 1e-5)
 

--- a/test/ir/inference/test_mkldnn_matmul_v2_activation_fuse_pass.py
+++ b/test/ir/inference/test_mkldnn_matmul_v2_activation_fuse_pass.py
@@ -144,7 +144,7 @@ class TestMatmulv2ActivationOnednnFusePass(PassAutoScanTest):
 
     def sample_predictor_configs(self, program_config):
         config = self.create_inference_config(
-            use_mkldnn=True,
+            use_onednn=True,
             passes=[
                 'matmul_activation_onednn_fuse_pass',
                 'operator_scale_onednn_fuse_pass',

--- a/test/ir/inference/test_mkldnn_scale_matmul_fuse_pass.py
+++ b/test/ir/inference/test_mkldnn_scale_matmul_fuse_pass.py
@@ -137,7 +137,7 @@ class TestScaleMatmulOnednnFusePass(PassAutoScanTest):
 
     def sample_predictor_configs(self, program_config):
         config = self.create_inference_config(
-            use_mkldnn=True, passes=['scale_matmul_fuse_pass']
+            use_onednn=True, passes=['scale_matmul_fuse_pass']
         )
         yield config, ['matmul'], (1e-5, 1e-5)
 

--- a/test/ir/inference/test_onednn_conv_bias_fuse_pass.py
+++ b/test/ir/inference/test_onednn_conv_bias_fuse_pass.py
@@ -130,7 +130,7 @@ class TestConvBiasOneDNNFusePass(PassAutoScanTest):
         conv_bias_shape = []
         inputs = {}
         weights = {}
-        use_mkldnn = None
+        use_onednn = None
         conv_type = 'conv2d'
         if draw(st.booleans()):
             conv_bias_shape = [f_shape[0]]
@@ -145,7 +145,7 @@ class TestConvBiasOneDNNFusePass(PassAutoScanTest):
                 'bias': TensorConfig(shape=bias_shape),
                 'conv_bias': TensorConfig(shape=conv_bias_shape),
             }
-            use_mkldnn = True
+            use_onednn = True
         else:
             inputs = {
                 'Input': ['input_x'],
@@ -155,7 +155,7 @@ class TestConvBiasOneDNNFusePass(PassAutoScanTest):
                 'filter': TensorConfig(shape=f_shape),
                 'bias': TensorConfig(shape=bias_shape),
             }
-            use_mkldnn = False
+            use_onednn = False
 
         conv2d_op = OpConfig(
             conv_type,
@@ -167,7 +167,7 @@ class TestConvBiasOneDNNFusePass(PassAutoScanTest):
             groups=groups,
             dilations=dilations,
             data_format=data_format,
-            use_mkldnn=use_mkldnn,
+            use_onednn=use_onednn,
         )
 
         add_op = OpConfig(

--- a/test/ir/inference/test_onednn_conv_bn_fuse_pass.py
+++ b/test/ir/inference/test_onednn_conv_bn_fuse_pass.py
@@ -23,7 +23,7 @@ from program_config import OpConfig, ProgramConfig, TensorConfig
 
 class TestOneDNNConvBnFusePass(PassAutoScanTest):
     def sample_program_config(self, draw):
-        use_mkldnn = True
+        use_onednn = True
         padding_algorithm = draw(st.sampled_from(["EXPLICIT", "SAME", "VALID"]))
         groups = draw(st.integers(min_value=1, max_value=3))
         data_format = draw(st.sampled_from(["NCHW", "NHWC"]))
@@ -78,7 +78,7 @@ class TestOneDNNConvBnFusePass(PassAutoScanTest):
             groups=groups,
             paddings=paddings,
             strides=strides,
-            use_mkldnn=use_mkldnn,
+            use_onednn=use_onednn,
             has_bias=False,
             is_test=True,
         )

--- a/test/ir/inference/test_onednn_elementwise_add_activation_fuse_pass.py
+++ b/test/ir/inference/test_onednn_elementwise_add_activation_fuse_pass.py
@@ -116,7 +116,7 @@ class TestElementwiseAddActivationOneDNNFusePass(PassAutoScanTest):
 
     def sample_predictor_configs(self, program_config):
         config = self.create_inference_config(
-            use_mkldnn=True,
+            use_onednn=True,
             passes=[
                 'elementwise_act_onednn_fuse_pass',
                 'operator_scale_onednn_fuse_pass',

--- a/test/ir/inference/test_onednn_fc_activation_fuse_pass.py
+++ b/test/ir/inference/test_onednn_fc_activation_fuse_pass.py
@@ -134,7 +134,7 @@ class TestFCActivationOneDNNFusePass(PassAutoScanTest):
 
     def sample_predictor_configs(self, program_config):
         config = self.create_inference_config(
-            use_mkldnn=True,
+            use_onednn=True,
             passes=[
                 "fc_act_onednn_fuse_pass",
                 "operator_scale_onednn_fuse_pass",

--- a/test/ir/inference/test_onednn_fc_gru_fuse_pass.py
+++ b/test/ir/inference/test_onednn_fc_gru_fuse_pass.py
@@ -103,7 +103,7 @@ class TestOneDNNFCGruFusePass(PassAutoScanTest):
 
     def sample_predictor_configs(self, program_config):
         config = self.create_inference_config(
-            use_mkldnn=True,
+            use_onednn=True,
             passes=[
                 'onednn_placement_pass',
                 'fc_gru_fuse_pass',

--- a/test/ir/inference/test_onednn_fc_lstm_fuse_pass.py
+++ b/test/ir/inference/test_onednn_fc_lstm_fuse_pass.py
@@ -107,7 +107,7 @@ class TestOneDNNFCLstmFusePass(PassAutoScanTest):
 
     def sample_predictor_configs(self, program_config):
         config = self.create_inference_config(
-            use_mkldnn=True,
+            use_onednn=True,
             passes=[
                 'onednn_placement_pass',
                 'fc_lstm_fuse_pass',

--- a/test/ir/inference/test_onednn_multi_gru_fuse_pass.py
+++ b/test/ir/inference/test_onednn_multi_gru_fuse_pass.py
@@ -121,7 +121,7 @@ class TestOneDNNMultiGruFusePass(PassAutoScanTest):
 
     def sample_predictor_configs(self, program_config):
         config = self.create_inference_config(
-            use_mkldnn=True,
+            use_onednn=True,
             passes=['multi_gru_fuse_pass'],
         )
         yield config, ['multi_gru'], (1e-5, 1e-5)

--- a/test/ir/inference/test_onednn_multi_gru_seq_fuse_pass.py
+++ b/test/ir/inference/test_onednn_multi_gru_seq_fuse_pass.py
@@ -196,7 +196,7 @@ class TestOneDNNMultiGruSeqFusePass(PassAutoScanTest):
 
     def sample_predictor_configs(self, program_config):
         config = self.create_inference_config(
-            use_mkldnn=True,
+            use_onednn=True,
             passes=['multi_gru_fuse_pass', 'multi_gru_seq_fuse_pass'],
         )
         yield config, ['multi_gru'], (1e-5, 1e-5)

--- a/test/ir/inference/test_onednn_operator_reshape2_fuse_pass.py
+++ b/test/ir/inference/test_onednn_operator_reshape2_fuse_pass.py
@@ -75,7 +75,7 @@ class TestTranspose2Reshape2OneDNNFusePass(PassAutoScanTest):
 
     def sample_predictor_configs(self, program_config):
         config = self.create_inference_config(
-            use_mkldnn=True,
+            use_onednn=True,
             passes=[
                 "operator_reshape2_onednn_fuse_pass",
             ],

--- a/test/ir/inference/test_onednn_operator_unsqueeze2_fuse_pass.py
+++ b/test/ir/inference/test_onednn_operator_unsqueeze2_fuse_pass.py
@@ -73,7 +73,7 @@ class TestTranspose2Unsqueeze2OneDNNFusePass(PassAutoScanTest):
 
     def sample_predictor_configs(self, program_config):
         config = self.create_inference_config(
-            use_mkldnn=True,
+            use_onednn=True,
             passes=[
                 "operator_unsqueeze2_onednn_fuse_pass",
             ],
@@ -138,7 +138,7 @@ class TestElementwiseMulUnsqueeze2OneDNNFusePass(PassAutoScanTest):
 
     def sample_predictor_configs(self, program_config):
         config = self.create_inference_config(
-            use_mkldnn=True,
+            use_onednn=True,
             passes=[
                 "operator_unsqueeze2_onednn_fuse_pass",
             ],

--- a/test/ir/inference/test_onednn_quant_transpose_dequant_fuse_pass.py
+++ b/test/ir/inference/test_onednn_quant_transpose_dequant_fuse_pass.py
@@ -65,7 +65,7 @@ class TestQuantTranspose2DequantOneDNNFusePass(PassAutoScanTest):
                 'use_mkldnn': True,
                 'mkldnn_data_type': 'int8',
             },
-            use_mkldnn=True,
+            use_onednn=True,
         )
 
         transpose2_op_2 = OpConfig(
@@ -80,7 +80,7 @@ class TestQuantTranspose2DequantOneDNNFusePass(PassAutoScanTest):
                 'use_mkldnn': True,
                 'mkldnn_data_type': 'int8',
             },
-            use_mkldnn=True,
+            use_onednn=True,
         )
 
         dequantize_op = OpConfig(
@@ -106,7 +106,7 @@ class TestQuantTranspose2DequantOneDNNFusePass(PassAutoScanTest):
 
     def sample_predictor_configs(self, program_config):
         config = self.create_inference_config(
-            use_mkldnn=True,
+            use_onednn=True,
             passes=['quant_transpose2_dequant_onednn_fuse_pass'],
         )
         yield config, ['fused_transpose', 'fused_transpose'], (1e-5, 1e-5)

--- a/test/ir/inference/test_onednn_squeeze2_transpose2_fuse_pass.py
+++ b/test/ir/inference/test_onednn_squeeze2_transpose2_fuse_pass.py
@@ -78,7 +78,7 @@ class TestSqueeze2Transpose2OneDNNFusePass(PassAutoScanTest):
 
     def sample_predictor_configs(self, program_config):
         config = self.create_inference_config(
-            use_mkldnn=True,
+            use_onednn=True,
             passes=[
                 "squeeze2_transpose2_onednn_fuse_pass",
             ],


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
test/ir/inference/ 修改调用 create_inference_config 参数 use_mkldnn 为 use_onednn
enable_mkldnn 修改 enable_onednn