### PR TITLE
is_test_pass_tester.cc modify use_mkldnn [fluid_ops]

### DIFF
--- a/paddle/fluid/framework/ir/is_test_pass_tester.cc
+++ b/paddle/fluid/framework/ir/is_test_pass_tester.cc
@@ -29,14 +29,14 @@ void SetOp(ProgramDesc* prog,
            const std::string& name,
            const std::vector<std::string>& inputs,
            const std::vector<std::string>& outputs,
-           bool use_mkldnn = false,
+           bool use_onednn = false,
            ISTEST_STATE is_test = ISTEST_STATE::UNSET) {
   auto* op = prog->MutableBlock(0)->AppendOp();
   op->SetType(type);
   op->SetAttr("name", name);
   op->SetInput("X", inputs);
   op->SetOutput("Out", outputs);
-  op->SetAttr("use_mkldnn", use_mkldnn);
+  op->SetAttr("use_onednn", use_onednn);
   if (is_test == ISTEST_STATE::UNSET)
     op->MutableAttrMap()->erase("is_test");
   else if (is_test == ISTEST_STATE::FALSE)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
paddle/fluid/framework/ir/is_test_pass_tester.cc 修改 use_mkldnn 为 use_onednn