### PR TITLE
[API compatibility] torch.pow and torch.Tensor.pow

### DIFF
--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -25,6 +25,7 @@ from paddle import _C_ops
 from paddle.base.libpaddle import DataType
 from paddle.common_ops_import import VarDesc, dygraph_utils
 from paddle.pir import Value
+from paddle.utils.decorator_utils import ParamAliasDecorator
 from paddle.utils.inplace_utils import inplace_apis_in_dygraph_only
 
 from ..base.data_feeder import (
@@ -517,6 +518,7 @@ def scale_(
         return _C_ops.scale_(x, scale, float(bias), bias_after_scale)
 
 
+@ParamAliasDecorator({"x": ["input"], "y": ["exponent"]})
 def pow(x: Tensor, y: float | Tensor, name: str | None = None) -> Tensor:
     """
     Compute the power of Tensor elements. The equation is:
@@ -529,10 +531,15 @@ def pow(x: Tensor, y: float | Tensor, name: str | None = None) -> Tensor:
 
         .. _Introduction to Tensor: ../../guides/beginner/tensor_en.html#chapter5-broadcasting-of-tensor
 
+    .. note::
+            Alias Support: The parameter name ``input`` can be used as an alias for ``x``, The parameter name ``exponent`` can be used as an alias for ``y``.
+            For example, ``pow(input=2, exponent=1.1)`` is equivalent to ``pow(x=2, y=1.1)``.
 
     Args:
         x (Tensor): An N-D Tensor, the data type is bfloat16, float16, float32, float64, int32, int64, complex64 or complex128.
+        input: An alias for ``x`` , with identical behavior.
         y (float|int|Tensor): If it is an N-D Tensor, its data type should be the same as `x`.
+        exponent: An alias for ``y`` , with identical behavior.
         name (str|None, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
 
     Returns:

--- a/test/legacy_test/test_pow.py
+++ b/test/legacy_test/test_pow.py
@@ -270,6 +270,7 @@ class TestPowerAPI_Alias(unittest.TestCase):
             for alias_param_2 in ["y", "exponent"]:
                 for place in self.places:
                     paddle.set_device(place)
+                    paddle.disable_static(place)
                     for input_data, exp_data in self.test_cases:
                         input_tensor = paddle.to_tensor(input_data)
                         exp_tensor = paddle.to_tensor(exp_data)
@@ -289,6 +290,7 @@ class TestPowerAPI_Alias(unittest.TestCase):
         for alias_param_2 in ["y", "exponent"]:
             for place in self.places:
                 paddle.set_device(place)
+                paddle.disable_static(place)
                 for input_data, exp_data in self.test_cases:
                     input_tensor = paddle.to_tensor(input_data)
                     exp_tensor = paddle.to_tensor(exp_data)

--- a/test/legacy_test/test_pow.py
+++ b/test/legacy_test/test_pow.py
@@ -251,5 +251,56 @@ class TestPowerAPI_ZeroSize(unittest.TestCase):
         self._test_power((0, 0))
 
 
+class TestPowerAPI_Alias(unittest.TestCase):
+    """
+    Test the alias of pow function.
+    ``pow(input=2, exponent=1.1)`` is equivalent to ``pow(x=2, y=1.1)``
+    """
+
+    def setUp(self):
+        self.places = get_devices()
+        self.test_cases = [
+            ([1.0, 2.0, 3.0], [1.1]),  # 1D tensor
+            ([[1, 2], [3, 4]], 2),  # 2D tensor with scalar exponent
+            (3.0, [2.0]),  # Scalar input
+        ]
+
+    def test_powxy(self):
+        for alias_param_1 in ["x", "input"]:
+            for alias_param_2 in ["y", "exponent"]:
+                for place in self.places:
+                    paddle.set_device(place)
+                    for input_data, exp_data in self.test_cases:
+                        input_tensor = paddle.to_tensor(input_data)
+                        exp_tensor = paddle.to_tensor(exp_data)
+                        output_alias = paddle.pow(
+                            **{
+                                alias_param_1: input_tensor,
+                                alias_param_2: exp_tensor,
+                            }
+                        )
+                        output_std = paddle.pow(x=input_tensor, y=exp_tensor)
+                        self.assertTrue(
+                            paddle.allclose(output_alias, output_std),
+                            msg=f"Alias {alias_param_1}/{alias_param_2} failed on {place} with input {input_data}, exp {exp_data}",
+                        )
+
+    def test_xpowy(self):
+        for alias_param_2 in ["y", "exponent"]:
+            for place in self.places:
+                paddle.set_device(place)
+                for input_data, exp_data in self.test_cases:
+                    input_tensor = paddle.to_tensor(input_data)
+                    exp_tensor = paddle.to_tensor(exp_data)
+                    output_alias = input_tensor.pow(
+                        **{alias_param_2: exp_tensor}
+                    )
+                    output_std = input_tensor.pow(y=exp_tensor)
+                    self.assertTrue(
+                        paddle.allclose(output_alias, output_std),
+                        msg=f"Alias {alias_param_2} failed on {place} with input {input_data}, exp {exp_data}",
+                    )
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Operator Mechanism


### PR Types
Improvements


### Description

This PR introduces PyTorch API compatibility aliases and resolves type checking issues:
1. Added PyTorch-compatible parameter aliases:

| API | param | alias |
|----------|----------|----------|
| [torch.pow](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/guides/model_convert/convert_from_pytorch/api_difference/torch/torch.pow.html)  | x  | input  |
| [torch.pow](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/guides/model_convert/convert_from_pytorch/api_difference/torch/torch.pow.html)  | y  | exponent  |
| [torch.Tensor.pow](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.pow.html#paddle-tensor-pow)  | y  | exponent  |

Usage Example:
```
# Traditional Paddle call
ouput = paddle.pow(x=tensor_x, y=tensor_y)

# New PyTorch-compatible call
ouput = paddle.pow(input=tensor_x, exponent=tensor_y)
```

pcard-67164