### PR TITLE
为p_norm内核反向添加均分

### DIFF
--- a/paddle/phi/kernels/gpu/p_norm_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/p_norm_grad_kernel.cu
@@ -35,20 +35,20 @@ struct AbsMaxAndMinGradFunctor {
                   DY* dy,
                   const Dim& dim,
                   int size) {
-    auto abs_x = (*x).abs();
-    auto y_bc = y->broadcast(dim);
-    auto dy_bc = dy->broadcast(dim);
-    auto mask = (abs_x == y_bc).template cast<T>();
+    using MT = typename phi::dtype::MPTypeTrait<T>::Type;
+    auto abs_x = (*x).abs().template cast<MT>();
+    auto y_bc = y->broadcast(dim).template cast<MT>();
+    auto dy_bc = dy->broadcast(dim).template cast<MT>();
+    auto mask = (abs_x == y_bc).template cast<MT>();
 
     Eigen::array<int, 1> reduce_dim = {static_cast<int>(dim.size() - 1)};
     auto shape1 = (*x).dimensions();
     shape1[shape1.size() - 1] = 1;
     auto shape2 = (*x).dimensions();
     for (size_t i = 0; i < shape2.size() - 1; i++) shape2[i] = 1;
-
     auto count = mask.sum(reduce_dim).reshape(shape1).broadcast(shape2);
 
-    dx->device(place) = dy_bc * (*x).sign() * mask / count;
+    dx->device(place) = (dy_bc * (*x).sign() * mask / count).template cast<T>();
   }
 };
 

--- a/paddle/phi/kernels/gpu/p_norm_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/p_norm_grad_kernel.cu
@@ -35,8 +35,12 @@ struct AbsMaxAndMinGradFunctor {
                   DY* dy,
                   const Dim& dim,
                   int size) {
-    dx->device(place) = dy->broadcast(dim) * (*x).sign() *
-                        ((*x).abs() == y->broadcast(dim)).template cast<T>();
+    auto abs_x = x->abs();
+    auto y_bc = y->broadcast(dim);
+    auto mask = (abs_x == y_bc).template cast<T>();
+    auto count = mask.sum(dim);
+
+    dx->device(place) = dy->broadcast(dim) * x->sign() * mask / count;
   }
 };
 

--- a/paddle/phi/kernels/gpu/p_norm_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/p_norm_grad_kernel.cu
@@ -40,7 +40,7 @@ struct AbsMaxAndMinGradFunctor {
     auto mask = (abs_x == y_bc).template cast<T>();
     auto count = mask.sum(dim);
 
-    dx->device(place) = dy->broadcast(dim) * x->sign() * mask / count;
+    dx->device(place) = y_bc * x->sign() * mask / count;
   }
 };
 

--- a/paddle/phi/kernels/gpu/p_norm_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/p_norm_grad_kernel.cu
@@ -35,12 +35,20 @@ struct AbsMaxAndMinGradFunctor {
                   DY* dy,
                   const Dim& dim,
                   int size) {
-    auto abs_x = x->abs();
+    auto abs_x = (*x).abs();
     auto y_bc = y->broadcast(dim);
+    auto dy_bc = dy->broadcast(dim);
     auto mask = (abs_x == y_bc).template cast<T>();
-    auto count = mask.sum(dim);
 
-    dx->device(place) = y_bc * x->sign() * mask / count;
+    Eigen::array<int, 1> reduce_dim = {static_cast<int>(dim.size() - 1)};
+    auto shape1 = (*x).dimensions();
+    shape1[shape1.size() - 1] = 1;
+    auto shape2 = (*x).dimensions();
+    for (size_t i = 0; i < shape2.size() - 1; i++) shape2[i] = 1;
+
+    auto count = mask.sum(reduce_dim).reshape(shape1).broadcast(shape2);
+
+    dx->device(place) = dy_bc * (*x).sign() * mask / count;
   }
 };
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
本计划为pairwise_distance编写全新内核实现反向梯度均分与torch进行对齐
在与torch进行比对后发现 torch也是直接调用p_norm进行计算，差异仅仅是paddle的p_norm的反向梯度没有进行均分
而之前的paddle.nn.functional.normalize测试样例中没有对无穷范数的测试，所以该问题没有暴露出来
所以直接对p_norm在p为无穷的情况下进行反向求导修改，增加均分

运行测试后均能通过

此pr和 https://github.com/PaddlePaddle/Paddle/pull/74197 修改相同放出性能测试
此pr：
<img width="1288" height="686" alt="截屏2025-08-11 18 24 39" src="https://github.com/user-attachments/assets/8e050f59-21bd-4b52-aa5c-57856b0fa8fc" />
pr74197：
<img width="1288" height="686" alt="截屏2025-08-11 18 25 01" src="https://github.com/user-attachments/assets/8de300be-4f01-497e-a3a0-454184c33312" />
由于eign库使用的是先生成表达式在进行执行 所以没啥malloc的开销


---------------------
# eigen库存在bug 此pr废弃
1. 在float16进行计算时 gpu不支持 只能使用fp32进行计算才能达到正常速度
2. 对大tensor的sum reshape broatdcast操作中存在问题 会出现cuda700