### PR TITLE
[Warning fix] fix warning for cuda_graph_instruction.cc

### DIFF
--- a/paddle/fluid/framework/new_executor/instruction/cuda_graph_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/cuda_graph_instruction.cc
@@ -47,8 +47,8 @@ CudaGraphInstruction::CudaGraphInstruction(
     ValueExecutionInfo* value_exec_info,
     interpreter::ExecutionConfig execution_config)
     : InstructionBase(id, place),
-      op_(op),
       place_(place),
+      op_(op),
       cuda_graph_state_ref_(cuda_graph_state_ref),
       cuda_graph_capture_pool_id_(cuda_graph_capture_pool_id),
       name_("cuda_graph_instruction"),
@@ -95,7 +95,7 @@ CudaGraphInstruction::CudaGraphInstruction(
   SetInputs(inputs);
 
   std::unordered_map<pir::Value, std::vector<int>> outputs;
-  bool is_last_op = true;
+  bool is_last_op [[maybe_unused]] = true;
   for (size_t i = 0; i < op->num_results(); i++) {
     pir::Value value = op->result(i);
     if (value && value.type()) {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->

```bash
cuda_graph_instruction.h:61:19: warning: ‘paddle::framework::CudaGraphInstruction::op_’ will be initialized after [-Wreorder]
   pir::Operation* op_;
                   ^~~
cuda_graph_instruction.h:60:21: warning:   ‘const phi::Place& paddle::framework::CudaGraphInstruction::place_’ [-Wreorder]
   const phi::Place& place_;
                     ^~~~~~
cuda_graph_instruction.cc:41:1: warning:   when initialized here [-Wreorder]
 CudaGraphInstruction::CudaGraphInstruction(
 ^~~~~~~~~~~~~~~~~~~~
cuda_graph_instruction.cc:98:8: warning: variable ‘is_last_op’ set but not used [-Wunused-but-set-variable]
   bool is_last_op = true;
```

change sequence for op and place in .cc file.
add [[maybe_unused]] for is_last_op