### PR TITLE
test_conv_transpose_bn_fuse_pass.py modify use_mkldnn [fluid_ops]

### DIFF
--- a/test/ir/inference/test_conv_transpose_bn_fuse_pass.py
+++ b/test/ir/inference/test_conv_transpose_bn_fuse_pass.py
@@ -133,7 +133,7 @@ class TestConvTransposeBnFusePass(PassAutoScanTest):
                 'data_format': random_data_layout,
                 'output_size': random_output_size,
                 'output_padding': random_output_size,
-                'use_mkldnn': random_use_onednn,
+                'use_onednn': random_use_onednn,
                 'is_test': True,
             },
         )
@@ -160,7 +160,7 @@ class TestConvTransposeBnFusePass(PassAutoScanTest):
                 'is_test': True,
                 'trainable_statistics': False,
                 'data_layout': random_data_layout,
-                'use_mkldnn': random_use_onednn,
+                'use_onednn': random_use_onednn,
             },
         )
 
@@ -194,7 +194,7 @@ class TestConvTransposeBnFusePass(PassAutoScanTest):
 
     def sample_predictor_configs(self, program_config):
         # for onednn
-        if program_config.ops[0].attrs['use_mkldnn']:
+        if program_config.ops[0].attrs['use_onednn']:
             config = self.create_inference_config(use_onednn=True)
             yield config, ['conv2d_transpose_bias'], (1e-5, 1e-5)
         # for cpu

--- a/test/ir/inference/test_conv_transpose_eltwiseadd_bn_fuse_pass.py
+++ b/test/ir/inference/test_conv_transpose_eltwiseadd_bn_fuse_pass.py
@@ -141,7 +141,7 @@ class TestConvTransposeEltwiseaddBnFusePass(PassAutoScanTest):
                 'data_format': random_data_layout,
                 'output_size': random_output_size,
                 'output_padding': random_output_size,
-                'use_mkldnn': random_use_onednn,
+                'use_onednn': random_use_onednn,
                 'is_test': True,
             },
         )
@@ -182,7 +182,7 @@ class TestConvTransposeEltwiseaddBnFusePass(PassAutoScanTest):
                 'is_test': True,
                 'trainable_statistics': False,
                 'data_layout': random_data_layout,
-                'use_mkldnn': random_use_onednn,
+                'use_onednn': random_use_onednn,
             },
         )
 
@@ -220,7 +220,7 @@ class TestConvTransposeEltwiseaddBnFusePass(PassAutoScanTest):
 
     def sample_predictor_configs(self, program_config):
         # for onednn
-        if program_config.ops[2].attrs['use_mkldnn']:
+        if program_config.ops[2].attrs['use_onednn']:
             config = self.create_inference_config(use_onednn=True)
             yield config, ['conv2d_transpose', 'elementwise_add'], (1e-5, 1e-5)
         # cpu

--- a/test/ir/inference/test_mkldnn_depthwise_conv_pass.py
+++ b/test/ir/inference/test_mkldnn_depthwise_conv_pass.py
@@ -99,7 +99,7 @@ class DepthwiseConvMKLDNNPass(PassAutoScanTest):
                 'paddings': random_paddings,
                 'padding_algorithm': random_padding_algorithm,
                 'data_format': random_data_layout,
-                'use_mkldnn': True,
+                'use_onednn': True,
             },
         )
 

--- a/test/ir/inference/test_mkldnn_matmul_v2_activation_fuse_pass.py
+++ b/test/ir/inference/test_mkldnn_matmul_v2_activation_fuse_pass.py
@@ -81,7 +81,7 @@ class TestMatmulv2ActivationOnednnFusePass(PassAutoScanTest):
             attrs={
                 'trans_x': transpose_X,
                 'trans_y': transpose_Y,
-                'use_mkldnn': True,
+                'use_onednn': True,
             },
         )
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
test/ir/inference/test_conv_transpose_bn_fuse_pass.py 修改 use_mkldnn 为 use_onednn