### PR TITLE
[API-Compat] Add paddle.compat.Unfold that supports tensor inputs.

### DIFF
--- a/python/paddle/compat.py
+++ b/python/paddle/compat.py
@@ -13,13 +13,9 @@
 # limitations under the License.
 
 from .tensor.compat import (
+    Unfold,
     sort,
     split,
-    Unfold,
 )
 
-__all__ = [
-    'split',
-    'sort',
-    'Unfold'
-]
+__all__ = ['split', 'sort', 'Unfold']

--- a/python/paddle/compat.py
+++ b/python/paddle/compat.py
@@ -15,9 +15,11 @@
 from .tensor.compat import (
     sort,
     split,
+    Unfold,
 )
 
 __all__ = [
     'split',
     'sort',
+    'Unfold'
 ]

--- a/python/paddle/nn/layer/common.py
+++ b/python/paddle/nn/layer/common.py
@@ -45,6 +45,8 @@ if TYPE_CHECKING:
 
     _T_Padding = TypeVar("_T_Padding", Tensor, Sequence[int])
 
+from paddle.utils.decorator_utils import ForbidKeywordsDecorator
+
 __all__ = []
 
 
@@ -1908,6 +1910,11 @@ class Unfold(Layer):
     strides: Size2
     name: str | None
 
+    @ForbidKeywordsDecorator(
+        illegal_keys={"kernel_size", "dilation", "padding", "stride"},
+        func_name="paddle.nn.Unfold",
+        correct_name="paddle.compat.Unfold",
+    )
     def __init__(
         self,
         kernel_sizes: Size2,

--- a/python/paddle/tensor/compat.py
+++ b/python/paddle/tensor/compat.py
@@ -28,7 +28,14 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from paddle import Tensor
+    from paddle._typing import (
+        Size2,
+    )
 
+
+from paddle import nn
+
+from paddle.framework import in_dynamic_mode
 from paddle.utils.decorator_utils import ForbidKeywordsDecorator
 
 __all__ = []
@@ -316,3 +323,81 @@ def sort(
         return SortRetType(values=outputs, indices=indices)
     paddle.assign(outputs, out[0])
     paddle.assign(indices, out[1])
+        
+        
+class Unfold(nn.Unfold):
+    """
+    A compatible version of paddle.nn.Unfold:
+    - The keyword arguments are in non-plural forms, example: `kernel_size` instead of kernel_sizes
+    - `padding` restricts the size of the input to be 1(int) or 2, Size4 is not allowed. To use a more
+       input-flexible version of Unfold, please refer to `paddle.nn.Unfold`.
+    - All the input parameters allow `Tensor` or `pir.Value` as inputs, and will be converted to list
+    Other aspects are the same. See ``paddle.nn.Unfold`` for more details.
+    Parameters:
+        kernel_size(int|list|tuple|Tensor): The size of convolution kernel, should be [k_h, k_w]
+            or an integer k treated as [k, k].
+        stride(int|list|tuple|Tensor, optional): The strides, should be [stride_h, stride_w]
+            or an integer stride treated as [sride, stride]. For default, strides will be [1, 1].
+        padding(int|list|tuple|Tensor, optional): The paddings of each dimension, should be
+            a single integer or [padding_h, padding_w]. If [padding_h, padding_w] was given, it will expanded to
+            [padding_h, padding_w, padding_h, padding_w]. If an integer padding was given,
+            [padding, padding, padding, padding] will be used. By default, paddings will be 0.
+        dilation(int|list|tuple|Tensor, optional): The dilations of convolution kernel, should be
+            [dilation_h, dilation_w], or an integer dilation treated as [dilation, dilation].
+            For default, it will be [1, 1].
+    Examples:
+        .. code-block:: python
+            >>> import paddle
+            >>> x = paddle.randn((100, 3, 224, 224))
+            >>> unfold = paddle.compat.Unfold(kernel_size=[3, 3])
+            >>> result = unfold(x)
+            >>> print(result.shape)
+            [100, 27, 49284]
+    """
+
+    kernel_sizes: Size2
+    dilations: Size2
+    paddings: Size2
+    strides: Size2
+
+    @ForbidKeywordsDecorator(
+        illegal_keys={"kernel_sizes", "dilations", "paddings", "strides"},
+        func_name="paddle.compat.Unfold",
+        correct_name="paddle.nn.Unfold",
+    )
+    def __init__(
+        self,
+        kernel_size: Size2,
+        dilation: Size2 = 1,
+        padding: Size2 = 0,
+        stride: Size2 = 1,
+    ) -> None:
+
+        super().__init__(kernel_size, dilation, padding, stride)
+
+    def forward(self, input: Tensor) -> Tensor:
+        def to_list_if_necessary(x, size_check=False):
+            res = x
+            if in_dynamic_mode() and isinstance(
+                x, (paddle.pir.Value, paddle.Tensor)
+            ):
+                res = x.tolist()
+            else:
+                if not isinstance(x, (list, tuple, int)):
+                    raise TypeError(
+                        "paddle.compat.Unfold does not allow paddle.Tensor or pir.Value as inputs in static graph mode."
+                    )
+            if size_check and isinstance(res, (list, tuple)) and len(res) > 2:
+                raise ValueError(
+                    f"The `padding` field of paddle.compat.Unfold can only have size 1 or 2, now len={len(res)}. \nDid you mean to use paddle.nn.Unfold() instead?"
+                )
+            return res
+
+        return nn.functional.unfold(
+            input,
+            kernel_sizes=to_list_if_necessary(self.kernel_sizes),
+            strides=to_list_if_necessary(self.strides),
+            paddings=to_list_if_necessary(self.paddings, size_check=True),
+            dilations=to_list_if_necessary(self.dilations),
+            name=self.name,
+        )

--- a/python/paddle/tensor/compat.py
+++ b/python/paddle/tensor/compat.py
@@ -34,8 +34,6 @@ if TYPE_CHECKING:
 
 
 from paddle import nn
-
-from paddle.framework import in_dynamic_mode
 from paddle.utils.decorator_utils import ForbidKeywordsDecorator
 
 __all__ = []

--- a/python/paddle/tensor/compat.py
+++ b/python/paddle/tensor/compat.py
@@ -321,8 +321,8 @@ def sort(
         return SortRetType(values=outputs, indices=indices)
     paddle.assign(outputs, out[0])
     paddle.assign(indices, out[1])
-        
-        
+
+
 class Unfold(nn.Unfold):
     """
     A compatible version of paddle.nn.Unfold:

--- a/test/legacy_test/test_compat_unfold.py
+++ b/test/legacy_test/test_compat_unfold.py
@@ -1,0 +1,121 @@
+#   Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+
+import paddle
+
+
+class TestCompatUnfold(unittest.TestCase):
+    def _compare_with_origin(
+        self, input_tensor, kernel_size, dilation, padding, stride
+    ):
+        unfold_compat = paddle.compat.Unfold(
+            kernel_size=kernel_size,
+            dilation=dilation,
+            padding=padding,
+            stride=stride,
+        )
+        unfold_origin = paddle.nn.Unfold(
+            kernel_sizes=kernel_size,
+            dilations=dilation,
+            paddings=padding,
+            strides=stride,
+        )
+        expected_res = unfold_origin(input_tensor).numpy()
+        np.testing.assert_allclose(
+            unfold_compat(input_tensor).numpy(), expected_res
+        )
+
+        # test with tensor input
+        to_tensor = lambda x: x if isinstance(x, int) else paddle.to_tensor(x)
+        kernel_size = to_tensor(kernel_size)
+        dilation = to_tensor(dilation)
+        padding = to_tensor(padding)
+        stride = to_tensor(stride)
+        unfold_compat = paddle.compat.Unfold(
+            kernel_size=kernel_size,
+            dilation=dilation,
+            padding=padding,
+            stride=stride,
+        )
+        np.testing.assert_allclose(
+            unfold_compat(input_tensor).numpy(), expected_res
+        )
+
+    def test_compare_with_origin(self):
+        input_shape = (3, 4, 5, 6)
+        input_tensor = paddle.arange(360, dtype=paddle.float32).reshape(
+            input_shape
+        )
+        self._compare_with_origin(input_tensor, [3, 3], [1, 1], (1, 2), [1, 1])
+
+        input_shape = (5, 10, 13, 13)
+        input_tensor = paddle.ones(input_shape, dtype=paddle.float64)
+        self._compare_with_origin(input_tensor, [4, 4], [2, 2], 1, (1, 2))
+
+        input_shape = (12, 4, 10, 10)
+        input_tensor = paddle.ones(input_shape, dtype=paddle.float64)
+        self._compare_with_origin(input_tensor, 3, 2, 1, (1, 1))
+
+    def test_error_handling(self):
+        """Test whether there will be correct exception when users pass paddle.split kwargs in paddle.compat.split, vice versa."""
+        x = paddle.randn([3, 9, 5])
+
+        msg_gt_1 = "paddle.nn.Unfold() received unexpected keyword arguments 'dilation', 'stride'. \nDid you mean to use paddle.compat.Unfold() instead?"
+        msg_gt_2 = "paddle.compat.Unfold() received unexpected keyword argument 'paddings'. \nDid you mean to use paddle.nn.Unfold() instead?"
+        msg_gt_3 = "The `padding` field of paddle.compat.Unfold can only have size 1 or 2, now len=4. \nDid you mean to use paddle.nn.Unfold() instead?"
+        msg_gt_4 = "paddle.compat.Unfold does not allow paddle.Tensor or pir.Value as inputs in static graph mode."
+
+        with self.assertRaises(TypeError) as cm:
+            unfold = paddle.nn.Unfold([3, 3], dilation=[2, 2], stride=[1, 1])
+        self.assertEqual(str(cm.exception), msg_gt_1)
+
+        with self.assertRaises(TypeError) as cm:
+            unfold = paddle.compat.Unfold([3, 3], paddings=[2, 1])
+        self.assertEqual(str(cm.exception), msg_gt_2)
+
+        with self.assertRaises(ValueError) as cm:
+            unfold = paddle.compat.Unfold([3, 3], padding=[2, 1, 2, 2])
+            res = unfold(paddle.ones([2, 2, 5, 5]))
+        self.assertEqual(str(cm.exception), msg_gt_3)
+
+        with self.assertRaises(TypeError) as cm:
+            paddle.enable_static()
+            input_data = np.random.randn(2, 4, 8, 8).astype(np.float32)
+            with paddle.static.program_guard(paddle.static.Program()):
+                x = paddle.static.data(
+                    name='x', shape=[None, None, 8, 8], dtype='float32'
+                )
+                place = (
+                    paddle.CUDAPlace(0)
+                    if paddle.is_compiled_with_cuda()
+                    else paddle.CPUPlace()
+                )
+                unfold_pass = paddle.compat.Unfold(
+                    kernel_size=paddle.to_tensor([3, 3]),
+                    padding=paddle.to_tensor([1, 2]),
+                )
+                result = unfold_pass(x)
+                exe = paddle.static.Executor(place)
+                feed = {'x': input_data}
+                exe_res = exe.run(feed=feed)
+            paddle.disable_static()
+        self.assertEqual(str(cm.exception), msg_gt_4)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Operator Mechanism

### PR Types
New features

### Description

增加了 `paddle.compat.Unfold`。原始的`paddle.nn.Unfold`与PyTorch 中的`nn.Unfold` 操作主要有两点不同：
- padding 输入更加灵活：可以指定四个方向的 padding，而非左右/上下 对称 padding，本PR的 `compat.Unfold` 因此也限制了用户输入 Size4 padding（会报错提示用户使用 `nn.Unfold`）
- (重要)：PyTorch 的参数可以以 Tensor 输入。目前本 PR 只做到了动态图下 Tensor 输入，静态图的 Tensor 转 list 的 `tolist()` 方法无法使用，故不做 C++ 端处理可能（目前没有发现好的方法）无法正确转换输入。
- 增加了对应的单元测试：`test_compat_unfold.py`

Pcard-89620
