### PR TITLE
test_mkldnn_matmul_activation_fuse_pass.py modify use_mkldnn [fluid_ops]

### DIFF
--- a/test/ir/inference/test_mkldnn_matmul_elementwise_add_fuse_pass.py
+++ b/test/ir/inference/test_mkldnn_matmul_elementwise_add_fuse_pass.py
@@ -39,7 +39,7 @@ class TestMatmulElementwiseAddOnednnFusePass(PassAutoScanTest):
             inputs={'X': ['matmul_x'], 'Y': ['matmul_y']},
             outputs={'Out': ['matmul_output']},
             attrs={
-                'use_mkldnn': True,
+                'use_onednn': True,
             },
         )
 
@@ -52,7 +52,7 @@ class TestMatmulElementwiseAddOnednnFusePass(PassAutoScanTest):
             type='elementwise_add',
             inputs=inputs,
             outputs={'Out': ['elementwise_add_output']},
-            attrs={'axis': axis, 'use_mkldnn': True},
+            attrs={'axis': axis, 'use_onednn': True},
         )
 
         model_net = [matmul_op, elt_add_op]
@@ -102,7 +102,7 @@ class TestMatmulElementwiseAddMkldnnFuse1CHWPass(PassAutoScanTest):
             inputs={'X': ['matmul_x'], 'Y': ['matmul_y']},
             outputs={'Out': ['matmul_output']},
             attrs={
-                'use_mkldnn': True,
+                'use_onednn': True,
             },
         )
 
@@ -115,7 +115,7 @@ class TestMatmulElementwiseAddMkldnnFuse1CHWPass(PassAutoScanTest):
             type='elementwise_add',
             inputs=inputs,
             outputs={'Out': ['elementwise_add_output']},
-            attrs={'axis': axis, 'use_mkldnn': True},
+            attrs={'axis': axis, 'use_onednn': True},
         )
 
         model_net = [matmul_op, elt_add_op]
@@ -168,7 +168,7 @@ class TestMatmulElementwiseAddExpendResidualPass(PassAutoScanTest):
             inputs={'X': ['matmul_x'], 'Y': ['matmul_y']},
             outputs={'Out': ['matmul_output']},
             attrs={
-                'use_mkldnn': True,
+                'use_onednn': True,
             },
         )
 
@@ -181,7 +181,7 @@ class TestMatmulElementwiseAddExpendResidualPass(PassAutoScanTest):
             type='elementwise_add',
             inputs=inputs,
             outputs={'Out': ['elementwise_add_output']},
-            attrs={'use_mkldnn': True},
+            attrs={'use_onednn': True},
         )
 
         model_net = [matmul_op, elt_add_op]

--- a/test/ir/inference/test_onednn_batch_norm_act_fuse_pass.py
+++ b/test/ir/inference/test_onednn_batch_norm_act_fuse_pass.py
@@ -78,7 +78,7 @@ class TestScaleOneDNNFusePass(PassAutoScanTest):
                 'momentum': momentum,
                 'trainable_statistics': trainable_statistics,
                 'use_global_stats': use_global_stats,
-                'use_mkldnn': use_onednn1,
+                'use_onednn': use_onednn1,
             },
         )
 
@@ -86,7 +86,7 @@ class TestScaleOneDNNFusePass(PassAutoScanTest):
             type='relu',
             inputs={'X': ['norm_output']},
             outputs={'Out': ['relu_output']},
-            attrs={'use_cudnn': use_cudnn, 'use_mkldnn': use_onednn2},
+            attrs={'use_cudnn': use_cudnn, 'use_onednn': use_onednn2},
         )
 
         model_net = [batch_norm_op, relu_op]


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
test/ir/inference/test_mkldnn_matmul_activation_fuse_pass.py 修改 use_mkldnn 为 use_onednn