### PR TITLE
Fix test_get_autocast_dtype on FP16-unsupported device

### DIFF
--- a/test/amp/test_get_autocast_dtype.py
+++ b/test/amp/test_get_autocast_dtype.py
@@ -44,18 +44,30 @@ class TestAutocast(unittest.TestCase):
                 self.do_test(device, "float16")
             self.do_test(device, self.default_dtype)
 
+    @unittest.skipIf(
+        not paddle.amp.is_bfloat16_supported(),
+        "Skip BF16 test if BF16 is not supported",
+    )
     def test_amp_autocast_bf16(self):
         for device in self.device_list:
             with paddle.amp.auto_cast(True, dtype="bfloat16"):
                 self.do_test(device, "bfloat16")
             self.do_test(device, self.default_dtype)
 
+    @unittest.skipIf(
+        not paddle.amp.is_bfloat16_supported(),
+        "Skip BF16 test if BF16 is not supported",
+    )
     def test_amp_autocast_false_bf16(self):
         for device in self.device_list:
             with paddle.amp.auto_cast(True, dtype="bfloat16"):
                 self.do_test(device, "bfloat16")
             self.do_test(device, self.default_dtype)
 
+    @unittest.skipIf(
+        not paddle.amp.is_bfloat16_supported(),
+        "Skip BF16 test if BF16 is not supported",
+    )
     def test_amp_nested_context(self):
         for device in self.device_list:
             with paddle.amp.auto_cast(True, dtype="bfloat16"):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修复 https://github.com/PaddlePaddle/Paddle/pull/74441 引入的在不支持 FP16 的环境下单测报错问题。