### PR TITLE
Remove redundant GetDeviceContextByBackend

### DIFF
--- a/paddle/phi/api/generator/api_base.py
+++ b/paddle/phi/api/generator/api_base.py
@@ -1515,7 +1515,7 @@ PADDLE_API {self.get_return_type(inplace_flag=True)} {api_func_name}({self.get_d
 {fallback_kernel_output_trans}
 {self.reset_view_after_fallback(self.outputs['types'], code_indent, inplace_flag)}
 {code_indent}  }}
-{code_indent}  dev_ctx = GetDeviceContextByBackend(kernel_backend);
+{code_indent}{'  dev_ctx = GetDeviceContextByBackend(kernel_backend);' if transdata2strided != '' else ''}
 {transdata2strided}
 {code_indent}  {self.gene_return_code()}"""
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->
Pcard-75624

api.cc生成时，大部分函数末尾不必要的`dev_ctx = GetDeviceContextByBackend(kernel_backend);`可以删掉，该函数主要给TransStride场景使用

<img width="959" height="225" alt="image" src="https://github.com/user-attachments/assets/233317d1-322f-4bd6-b30c-3094769f7763" />
