### PR TITLE
[API Compatibility]add OrderedDict for paddle.nn.Sequential

### DIFF
--- a/python/paddle/nn/layer/container.py
+++ b/python/paddle/nn/layer/container.py
@@ -720,9 +720,18 @@ class Sequential(Layer):
             >>> res2 = model2(data)  # [30, 30]
     """
 
-    def __init__(self, *layers: Layer | tuple[str, Layer] | list[Any]) -> None:
+    def __init__(
+        self,
+        *layers: Layer
+        | tuple[str, Layer]
+        | list[Any]
+        | OrderedDict[str, Layer],
+    ) -> None:
         super().__init__()
-        if len(layers) > 0 and isinstance(layers[0], (list, tuple)):
+        if len(layers) == 1 and isinstance(layers[0], OrderedDict):
+            for name, layer in layers[0].items():
+                self.add_sublayer(name, layer)
+        elif len(layers) > 0 and isinstance(layers[0], (list, tuple)):
             for name, layer in layers:
                 self.add_sublayer(name, layer)
         else:

--- a/test/legacy_test/test_sequential.py
+++ b/test/legacy_test/test_sequential.py
@@ -11,8 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import unittest
+from collections import OrderedDict
 
 import paddle
 
@@ -38,6 +38,37 @@ class TestDataFeeder(unittest.TestCase):
 
         with self.assertRaises(IndexError):
             tmp = sequential[-11]
+
+    def test_ordereddict_init(self):
+        od = OrderedDict(
+            [
+                ('layer1', paddle.nn.Linear(4, 8)),
+                ('layer2', paddle.nn.Linear(8, 16)),
+                ('layer3', paddle.nn.Linear(16, 32)),
+            ]
+        )
+        sequential = paddle.nn.Sequential(od)
+
+        # Check if layer names are preserved in order
+        self.assertEqual(
+            list(sequential._sub_layers.keys()), ['layer1', 'layer2', 'layer3']
+        )
+
+        # Check if layers can be accessed by name
+        self.assertIsInstance(sequential['layer1'], paddle.nn.Linear)
+        self.assertIsInstance(sequential['layer2'], paddle.nn.Linear)
+
+        # Check the order and length of layers
+        self.assertEqual(len(sequential), 3)
+        layers = list(sequential)
+        self.assertIsInstance(layers[0], paddle.nn.Linear)
+        self.assertIsInstance(layers[1], paddle.nn.Linear)
+        self.assertIsInstance(layers[2], paddle.nn.Linear)
+
+        # Check forward propagation
+        x = paddle.randn([2, 4])
+        y = sequential(x)
+        self.assertEqual(list(y.shape), [2, 32])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
Pcard-73145
为paddle.nn.Sequential添加OrderedDict的支持