### PR TITLE
[AutoParallel] fix moe_combine(grad) kernel

### DIFF
--- a/paddle/phi/infermeta/backward.cc
+++ b/paddle/phi/infermeta/backward.cc
@@ -1248,26 +1248,32 @@ void MoeCombineGradInferMeta(const MetaTensor& x,
                              const MetaTensor& scatter_index,
                              const MetaTensor& y,
                              MetaTensor* grad_x,
-                             MetaTensor* grad_combine_weights_helper) {
+                             MetaTensor* grad_combine_weights_helper,
+                             MetaTensor* grad_scatter_index) {
   auto x_dim = x.dims();
   auto combine_weights_shape = combine_weights.dims();
+  auto scatter_index_dim = scatter_index.dims();
   PADDLE_ENFORCE_EQ(
       x_dim.size(),
       2,
-      errors::InvalidArgument("The input X should have 2 dimensions. "
+      errors::InvalidArgument("The input X should have 2 dimensions"
                               "But received X's dimension = %d",
                               x_dim.size()));
   PADDLE_ENFORCE_EQ(
       (scatter_index.dtype() == phi::DataType::INT32),
       true,
-      errors::InvalidArgument("The input scatter_index type should be int32. "
+      errors::InvalidArgument("The input scatter_index type should be int32"
                               "But received scatter_index type = %s",
                               scatter_index.dtype()));
   grad_x->set_dims(common::make_ddim({x_dim[0], x_dim[1]}));
   grad_x->set_dtype(x.dtype());
-  grad_combine_weights_helper->set_dims(common::make_ddim(
-      {combine_weights_shape[0], combine_weights_shape[1], x_dim[1]}));
+
+  grad_combine_weights_helper->set_dims(
+      common::make_ddim({combine_weights_shape[0], combine_weights_shape[1]}));
   grad_combine_weights_helper->set_dtype(x.dtype());
+
+  grad_scatter_index->set_dims(scatter_index_dim);
+  grad_scatter_index->set_dtype(phi::DataType::INT32);
 }
 
 void MoeGateDispatchPartialNoSoftmaxTopkGradInferMeta(

--- a/paddle/phi/infermeta/backward.h
+++ b/paddle/phi/infermeta/backward.h
@@ -475,7 +475,8 @@ void MoeCombineGradInferMeta(const MetaTensor& x,
                              const MetaTensor& scatter_index,
                              const MetaTensor& grad_y,
                              MetaTensor* grad_x,
-                             MetaTensor* grad_combine_weights_helper);
+                             MetaTensor* grad_combine_weights_helper,
+                             MetaTensor* grad_scatter_index);
 // Tensor combine_weights_out, Tensor scatter_index, Tensor scatter_index_rev,
 // Tensor expert_offset, Tensor expert_offset_local, Tensor y_grad, Tensor
 // combine_weights_out_grad, int64_t k, int64_t capacity, bool use_pad, int64_t

--- a/paddle/phi/kernels/legacy/gpu/moe_combine_grad_kernel.cu
+++ b/paddle/phi/kernels/legacy/gpu/moe_combine_grad_kernel.cu
@@ -15,6 +15,7 @@
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/full_kernel.h"
+#include "paddle/phi/kernels/reduce_sum_kernel.h"
 namespace phi {
 
 template <typename T>
@@ -141,9 +142,12 @@ void MoeCombineGradKernel(const Context& dev_ctx,
                           const DenseTensor& scatter_index,
                           const DenseTensor& grad_y,
                           DenseTensor* grad_x,
-                          DenseTensor* grad_combine_weights_helper) {
+                          DenseTensor* grad_combine_weights_helper,
+                          DenseTensor* grad_scatter_index) {
   dev_ctx.template Alloc<T>(grad_x);
   dev_ctx.template Alloc<T>(grad_combine_weights_helper);
+  dev_ctx.template Alloc<int32_t>(grad_scatter_index);
+
   phi::Full<T, Context>(
       dev_ctx, phi::IntArray(common::vectorize(grad_x->dims())), 0, grad_x);
   phi::Full<T, Context>(
@@ -151,6 +155,30 @@ void MoeCombineGradKernel(const Context& dev_ctx,
       phi::IntArray(common::vectorize(grad_combine_weights_helper->dims())),
       0,
       grad_combine_weights_helper);
+  phi::Full<int32_t, Context>(
+      dev_ctx,
+      phi::IntArray(common::vectorize(grad_scatter_index->dims())),
+      0,
+      grad_scatter_index);
+
+  // TODO(nieyuntao): Temporarily use 'grad_combine_weight_intermediate' to
+  // bypass the grad_combine_weights_helper's shape mismatch to kernel shape
+  // issue.
+  DenseTensor* grad_combine_weight_intermediate(grad_combine_weights_helper);
+  phi::MetaTensor grad_combine_weight_intermediate_meta(
+      grad_combine_weight_intermediate);
+  grad_combine_weight_intermediate_meta.set_dims(
+      common::make_ddim({grad_combine_weights_helper->dims()[0],
+                         grad_combine_weights_helper->dims()[1],
+                         x.dims()[1]}));
+  grad_combine_weight_intermediate_meta.set_dtype(combine_weights.dtype());
+  dev_ctx.template Alloc<T>(grad_combine_weight_intermediate);
+  phi::Full<T, Context>(dev_ctx,
+                        phi::IntArray(common::vectorize(
+                            grad_combine_weight_intermediate->dims())),
+                        0,
+                        grad_combine_weight_intermediate);
+
   auto x_shape = x.dims();
   auto combine_weights_shape = combine_weights.dims();
   moe_combine_bwd<T, Context>(dev_ctx,
@@ -159,10 +187,17 @@ void MoeCombineGradKernel(const Context& dev_ctx,
                               scatter_index,
                               grad_y,
                               grad_x,
-                              grad_combine_weights_helper,
+                              grad_combine_weight_intermediate,
                               combine_weights_shape[1],  // k
                               combine_weights_shape[0],  // seqlen
                               x_shape[1]);               // hidden_size
+
+  *grad_combine_weights_helper =
+      phi::Sum<T, Context>(dev_ctx,
+                           *grad_combine_weight_intermediate,
+                           {2},
+                           combine_weights.dtype(),
+                           false);
 }
 }  // namespace phi
 

--- a/paddle/phi/ops/yaml/backward.yaml
+++ b/paddle/phi/ops/yaml/backward.yaml
@@ -2364,8 +2364,8 @@
 
 - backward_op : moe_combine_grad
   forward : moe_combine (Tensor x, Tensor combine_weights, Tensor scatter_index) -> Tensor(y)
-  args : (Tensor x, Tensor combine_weights, Tensor scatter_index, Tensor y_grad), Tensor(scatter_index_grad)
-  output : Tensor(x_grad), Tensor(combine_weights_grad)
+  args : (Tensor x, Tensor combine_weights, Tensor scatter_index, Tensor y_grad)
+  output : Tensor(x_grad), Tensor(combine_weights_grad), Tensor(scatter_index_grad)
   infer_meta :
     func : MoeCombineGradInferMeta
     spmd_rule : MoECombineGradInferSpmd

--- a/paddle/phi/ops/yaml/backward.yaml
+++ b/paddle/phi/ops/yaml/backward.yaml
@@ -2364,7 +2364,7 @@
 
 - backward_op : moe_combine_grad
   forward : moe_combine (Tensor x, Tensor combine_weights, Tensor scatter_index) -> Tensor(y)
-  args : (Tensor x, Tensor combine_weights, Tensor scatter_index, Tensor y_grad)
+  args : (Tensor x, Tensor combine_weights, Tensor scatter_index, Tensor y_grad), Tensor(scatter_index_grad)
   output : Tensor(x_grad), Tensor(combine_weights_grad)
   infer_meta :
     func : MoeCombineGradInferMeta


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
https://github.com/PaddlePaddle/Paddle/pull/72957 该pr将moe_combine算子从自定义算子迁移到框架内实现，但动半版本仍有些问题：
moe_combine 无问题
moe_combine_grad:
1. 动半版本需要grad_scatter_index这一return；需修改动手组网，backward时需要多接受这一参数
2. grad_combine_weights_helper的shape问题  动半动手实际上都是需要一个shape与combine_weights相同的grad_combine_weights_helper，但kernel所需shape多一维，这里用较hack的方式处理了一下；动手目前组网中在调用该算子后会手动grad_combine_weight_helper.sum(-1)并reshape，经本pr修改后需要去掉这一操作