### PR TITLE
[Auto Parallel] fix moe_gata_dispatch(grad) kernel

### DIFF
--- a/paddle/phi/infermeta/backward.cc
+++ b/paddle/phi/infermeta/backward.cc
@@ -2109,24 +2109,24 @@ void MoeGateDispatchGradInferMeta(const MetaTensor& combine_weights,
 
   PADDLE_ENFORCE_EQ(
       y_grad_dims.size(),
-      2,
-      errors::InvalidArgument("Input y_grad should have 2 dimensions"));
+      3,
+      errors::InvalidArgument("Input y_grad should have 3 dimensions"));
 
   PADDLE_ENFORCE_EQ(combine_weights_grad_dims.size(),
                     2,
                     errors::InvalidArgument(
                         "Input combine_weights_grad should have 2 dimensions"));
 
-  int64_t num_experts = y_grad_dims[0] / capacity;
-  int64_t hidden_size = y_grad_dims[1];
+  int64_t num_experts = y_grad_dims[0];
+  int64_t hidden_size = y_grad_dims[2];
 
   int64_t num_rows = scatter_index_dims[1];
 
-  gate_logits_grad->set_dims(common::make_ddim({num_rows, num_experts}));
-  gate_logits_grad->set_dtype(phi::DataType::FLOAT32);
-
   x_grad->set_dims(common::make_ddim({num_rows, hidden_size}));
   x_grad->set_dtype(y_grad.dtype());
+
+  gate_logits_grad->set_dims(common::make_ddim({num_rows, num_experts}));
+  gate_logits_grad->set_dtype(phi::DataType::FLOAT32);
 }
 void FusedRMSNormGradInferMeta(const MetaTensor& x,
                                const MetaTensor& scale,

--- a/paddle/phi/infermeta/multiary.cc
+++ b/paddle/phi/infermeta/multiary.cc
@@ -6677,9 +6677,9 @@ void MoeGateDispatchInferMeta(const MetaTensor& x,
 
   std::vector<int64_t> y_dims;
   if (use_pad) {
-    y_dims = {num_experts * capacity, x_dims[1]};
+    y_dims = {num_experts, num_rows * k / num_experts, x_dims[1]};
   } else {
-    y_dims = {num_rows * k, x_dims[1]};
+    y_dims = {num_rows, k, x_dims[1]};
   }
 
   y->set_dims(common::make_ddim(y_dims));

--- a/paddle/phi/kernels/legacy/gpu/moe_gate_dispatch_grad_kernel.cu
+++ b/paddle/phi/kernels/legacy/gpu/moe_gate_dispatch_grad_kernel.cu
@@ -78,11 +78,7 @@ void moe_dispatch_bwd(const Context& dev_ctx,
                       int64_t num_local_experts = -1) {
   int64_t num_rows = combine_weights.dims()[0];
   int64_t k = combine_weights.dims()[1];
-#ifdef MOE_OPS_AUTO
   int64_t hidden_size = y_grad.dims()[2];
-#else
-  int64_t hidden_size = y_grad.dims()[1];
-#endif
   int64_t num_experts = gate_logits_grad.dims()[1];
 
   apply_moe_dispatch_bwd<T>(y_grad.data<T>(),
@@ -118,14 +114,6 @@ void MoeGateDispatchGradKernel(const Context& dev_ctx,
   auto y_grad_dims = y_grad.dims();
   auto scatter_index_dims = scatter_index.dims();
 
-#ifdef MOE_OPS_AUTO
-  // y_grad shape is [num_experts, capacity, h]
-  int64_t num_experts = y_grad_dims[0];
-  int64_t hidden_size = y_grad_dims[2];
-#else
-  int64_t num_experts = y_grad_dims[0] / capacity;
-  int64_t hidden_size = y_grad_dims[1];
-#endif
   int64_t num_rows = scatter_index_dims[1];
 
   const std::vector<int32_t> axis = {1, 0};

--- a/paddle/phi/kernels/legacy/gpu/moe_gate_dispatch_kernel.cu
+++ b/paddle/phi/kernels/legacy/gpu/moe_gate_dispatch_kernel.cu
@@ -109,7 +109,7 @@ void moe_dispatch_fwd(const Context &dev_ctx,
 }
 
 template <typename T, typename Context>
-void MoeGradDispatchKernel(const Context &dev_ctx,
+void MoeGateDispatchKernel(const Context &dev_ctx,
                            const DenseTensor &x,
                            const DenseTensor &gate_logits,
                            const paddle::optional<DenseTensor> &corr_bias,
@@ -158,7 +158,7 @@ void MoeGradDispatchKernel(const Context &dev_ctx,
 PD_REGISTER_KERNEL(moe_gate_dispatch,
                    GPU,
                    ALL_LAYOUT,
-                   phi::MoeGradDispatchKernel,
+                   phi::MoeGateDispatchKernel,
                    float,
                    double,
                    phi::dtype::float16,

--- a/paddle/phi/kernels/xpu/moe_gate_dispatch_kernel.cc
+++ b/paddle/phi/kernels/xpu/moe_gate_dispatch_kernel.cc
@@ -92,7 +92,7 @@ void moe_dispatch_fwd(const Context &dev_ctx,
 }
 
 template <typename T, typename Context>
-void MoeGradDispatchKernel(const Context &dev_ctx,
+void MoeGateDispatchKernel(const Context &dev_ctx,
                            const DenseTensor &x,
                            const DenseTensor &gate_logits,
                            const paddle::optional<DenseTensor> &corr_bias,
@@ -130,7 +130,7 @@ void MoeGradDispatchKernel(const Context &dev_ctx,
 PD_REGISTER_KERNEL(moe_gate_dispatch,
                    XPU,
                    ALL_LAYOUT,
-                   phi::MoeGradDispatchKernel,
+                   phi::MoeGateDispatchKernel,
                    float,
                    phi::dtype::float16,
                    phi::dtype::bfloat16) {}


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
https://github.com/PaddlePaddle/Paddle/pull/72957 该pr将moe_gate_dispatch算子从自定义算子迁移到框架内实现，但动半版本仍有些问题：
moe_gate_dispatch y输出shape不同 动半为3 动手为2
moe_gate_dispatch_grad: y_grad输入shape不同 动半为3 动手为2

NOTE：改pr目前只针对动半适配，后续需结合组网同时兼容动半动手