### PR TITLE
 Fix cinn hip float16 runtime bugs

### DIFF
--- a/paddle/cinn/backends/codegen_gpu_dev.cc
+++ b/paddle/cinn/backends/codegen_gpu_dev.cc
@@ -217,27 +217,6 @@ void CodeGenGpuDev::VisitStmt(const ir::stmt::Alloc &stmt) {
   PrintTempBufferCreation(stmt->destination().as_buffer_ref());
 }
 
-inline void ProcessMinMaxOperand(ir::Expr *a,
-                                 ir::Expr *b,
-                                 int unify_bit,
-                                 bool both_dyn) {
-  if (unify_bit > 0) {
-    std::string type_func = "int" + std::to_string(unify_bit) + "_t";
-    if (both_dyn) {
-      // if both contains dynamic symbol, like: min(S0, S1), it it likely that
-      // S0 is int and S1 is int64_t. So we need to enforce the type cast by
-      // ir::Call
-      *a = ir::Call::Make(
-          common::Int(unify_bit), type_func, {*a}, {}, ir::CallType::Intrinsic);
-      *b = ir::Call::Make(
-          common::Int(unify_bit), type_func, {*b}, {}, ir::CallType::Intrinsic);
-    } else {
-      *a = ir::Cast::Make(common::Int(unify_bit), *a);
-      *b = ir::Cast::Make(common::Int(unify_bit), *b);
-    }
-  }
-}
-
 void CodeGenGpuDev::Visit(const ir::Min *op) {
   str_ += "min(";
   ir::Expr a = op->a(), b = op->b();

--- a/paddle/cinn/backends/hip/codegen_hip_dev.cc
+++ b/paddle/cinn/backends/hip/codegen_hip_dev.cc
@@ -33,6 +33,30 @@ CodeGenHipDevice::CodeGenHipDevice(Target target) : CodeGenGpuDev(target) {}
 
 void CodeGenHipDevice::PrintIncludes() { str_ += GetSourceHeader(); }
 
+void CodeGenHipDevice::Visit(const ir::Min *op) {
+  str_ += "std::min(";
+  ir::Expr a = op->a(), b = op->b();
+  auto [unify_bit, both_dyn] =
+      common::UnifiedOperandTypeBits(&this->DynamicShapeMap(), op);
+  this->ProcessMinMaxOperand(&a, &b, unify_bit, both_dyn);
+  IrPrinter::Visit(a);
+  str_ += ", ";
+  IrPrinter::Visit(b);
+  str_ += ")";
+}
+
+void CodeGenHipDevice::Visit(const ir::Max *op) {
+  str_ += "std::max(";
+  ir::Expr a = op->a(), b = op->b();
+  auto [unify_bit, both_dyn] =
+      common::UnifiedOperandTypeBits(&this->DynamicShapeMap(), op);
+  this->ProcessMinMaxOperand(&a, &b, unify_bit, both_dyn);
+  IrPrinter::Visit(a);
+  str_ += ", ";
+  IrPrinter::Visit(b);
+  str_ += ")";
+}
+
 }  // namespace hip
 }  // namespace backends
 }  // namespace cinn

--- a/paddle/cinn/backends/hip/codegen_hip_dev.h
+++ b/paddle/cinn/backends/hip/codegen_hip_dev.h
@@ -33,6 +33,8 @@ class CodeGenHipDevice : public CodeGenGpuDev {
   explicit CodeGenHipDevice(Target target);
   static const std::string& GetSourceHeader();
   void PrintIncludes() override;
+  void Visit(const ir::Min* op) override;
+  void Visit(const ir::Max* op) override;
 
  private:
   static const std::string source_header_;

--- a/paddle/cinn/runtime/hip/hip_intrinsics_reduce.cc
+++ b/paddle/cinn/runtime/hip/hip_intrinsics_reduce.cc
@@ -12,9 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include "paddle/cinn/backends/extern_func_jit_register.h"
-// todo : hip bf16 and fp16
+#include "paddle/cinn/common/float16.h"
 // #define CINN_HIP_BF16
-// #define CINN_HIP_FP16
+#define CINN_HIP_FP16
+
+using cinn::common::float16;
 
 CINN_REGISTER_HELPER(hip_intrinsics_reduce) {
   auto target = cinn::common::DefaultHygonDcuHipTarget();

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -1165,7 +1165,10 @@ if '${WITH_CINN}' == 'ON':
     package_data['paddle.libs']+=['cinn_hip_runtime_source.h']
     package_data['paddle.libs']+=['cinn_sycl_runtime_source.h']
 
-    cinn_fp16_file = '${CINN_INCLUDE_DIR}/paddle/cinn/runtime/cuda/float16.h'
+    if '${WITH_ROCM}' == 'ON':
+        cinn_fp16_file = '${CINN_INCLUDE_DIR}/paddle/cinn/runtime/hip/float16.h'
+    else:
+        cinn_fp16_file = '${CINN_INCLUDE_DIR}/paddle/cinn/runtime/cuda/float16.h'
     if os.path.exists(cinn_fp16_file):
         shutil.copy(cinn_fp16_file, libs_path)
         package_data['paddle.libs']+=['float16.h']

--- a/setup.py
+++ b/setup.py
@@ -1579,10 +1579,14 @@ def get_package_data_and_package_dir():
         package_data['paddle.libs'] += ['cinn_hip_runtime_source.h']
         package_data['paddle.libs'] += ['cinn_sycl_runtime_source.h']
 
-        cinn_fp16_file = (
-            env_dict.get("CINN_INCLUDE_DIR")
-            + '/paddle/cinn/runtime/cuda/float16.h'
-        )
+        if env_dict.get("WITH_ROCM") == 'ON':
+            cinn_fp16_file = (
+                '${CINN_INCLUDE_DIR}/paddle/cinn/runtime/hip/float16.h'
+            )
+        else:
+            cinn_fp16_file = (
+                '${CINN_INCLUDE_DIR}/paddle/cinn/runtime/cuda/float16.h'
+            )
         if os.path.exists(cinn_fp16_file):
             shutil.copy(cinn_fp16_file, libs_path)
             package_data['paddle.libs'] += ['float16.h']


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

- Fix HIP not supporting half-shuffle operations by converting half to float for shuffles
- Fix HIP device not supporting `cinn::common::float16` max and min functions
- Fix issue with `float16.h` not found 