### PR TITLE
[API compatibility] update paddle add api

### DIFF
--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -97,6 +97,7 @@ from .ops import (  # noqa: F401
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+    from numbers import Number
 
     from paddle import Tensor
     from paddle._typing import DTypeLike
@@ -702,10 +703,18 @@ def _elementwise_op(helper):
     return helper.append_activation(out)
 
 
-def add(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
+@ParamAliasDecorator({"x": ["input"], "y": ["other"]})
+def add(
+    x: Tensor,
+    y: Tensor,
+    name: str | None = None,
+    *,
+    alpha: Number = 1,
+    out: Tensor | None = None,
+) -> Tensor:
     """
     Elementwise Add Operator.
-    Add two tensors element-wise
+    Add two tensors element-wise.
     The equation is:
 
     ..  math::
@@ -737,6 +746,8 @@ def add(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
             int8, int16, int32, int64, uint8, complex64, complex128.
         y (Tensor): Tensor of any dimensions. Its dtype should be bool, bfloat16, float16, float32, float64,
             int8, int16, int32, int64, uint8, complex64, complex128.
+        alpha (Number, optional): Scaling factor for Y. Default: 1.
+        out (Tensor, optional): The output tensor. Default: None.
         name (str|None, optional): For details, please refer to :ref:`api_guide_Name`. Generally, no setting is required. Default: None.
 
     Returns:
@@ -755,15 +766,46 @@ def add(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
             Tensor(shape=[3], dtype=float64, place=Place(cpu), stop_gradient=True,
             [3., 8., 6.])
     """
-
     if in_dynamic_or_pir_mode():
-        return _C_ops.add(x, y)
+        if alpha == 1:
+            return paddle._C_ops.add(x, y, out=out)
+        else:
+            return paddle._C_ops.add(x, y * alpha, out=out)
     else:
-        return _elementwise_op(LayerHelper('elementwise_add', **locals()))
+        helper = LayerHelper('elementwise_add', **locals())
+        scaled_y = (
+            helper.create_variable_for_type_inference(y.dtype)
+            if alpha != 1
+            else y
+        )
+
+        if alpha != 1:
+            helper.append_op(
+                type='scale',
+                inputs={'X': [y]},
+                outputs={'Out': [scaled_y]},
+                attrs={'scale': alpha, 'bias': 0.0},
+            )
+
+        output = helper.create_variable_for_type_inference(x.dtype)
+        helper.append_op(
+            type='elementwise_add',
+            inputs={'X': x, 'Y': scaled_y},
+            outputs={'Out': output},
+            attrs={'axis': -1},
+        )
+        return output
 
 
+@ParamAliasDecorator({"x": ["input"], "y": ["other"]})
 @inplace_apis_in_dygraph_only
-def add_(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
+def add_(
+    x: Tensor,
+    y: Tensor,
+    name: str | None = None,
+    *,
+    alpha: Number = 1,
+) -> Tensor:
     """
     Inplace version of ``add`` API, the output Tensor will be inplaced with input ``x``.
     Please refer to :ref:`api_paddle_add`.
@@ -775,7 +817,10 @@ def add_(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
             f"The shape of broadcast output {out_shape} is different from that of inplace tensor {x.shape} in the Inplace operation."
         )
 
-    return _C_ops.add_(x, y)
+    if alpha == 1:
+        return paddle._C_ops.add_(x, y)
+    else:
+        return paddle._C_ops.add_(x, y * alpha)
 
 
 def logaddexp(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:

--- a/test/legacy_test/test_add_op.py
+++ b/test/legacy_test/test_add_op.py
@@ -1,0 +1,264 @@
+#  Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+
+import numpy as np
+
+import paddle
+from paddle.base import core
+
+
+class TestPaddleAddNewFeatures(unittest.TestCase):
+    def setUp(self):
+        self.x_np = np.array([3, 5], dtype='float32')
+        self.y_np = np.array([2, 3], dtype='float32')
+        self.scalar = 2.0
+        self.place = (
+            core.CUDAPlace(0)
+            if core.is_compiled_with_cuda()
+            else core.CPUPlace()
+        )
+
+    def test_paddle_add_with_alpha(self):
+        """test paddle.add alpha"""
+        x = paddle.to_tensor(self.x_np, stop_gradient=False)
+        y = paddle.to_tensor(self.y_np, stop_gradient=False)
+        out = paddle.add(x, y, alpha=2)
+        expected = self.x_np + self.y_np * 2
+        np.testing.assert_array_equal(out.numpy(), expected)
+
+        out.mean().backward()
+        expected_x_grad = np.array([0.5, 0.5], dtype='float32')
+        expected_y_grad = np.array([1.0, 1.0], dtype='float32')  # alpha=2
+        np.testing.assert_array_equal(x.grad.numpy(), expected_x_grad)
+        np.testing.assert_array_equal(y.grad.numpy(), expected_y_grad)
+
+    def test_tensor_add_with_alpha(self):
+        """test paddle.Tensor.add alpha"""
+        x = paddle.to_tensor(self.x_np, stop_gradient=False)
+        y = paddle.to_tensor(self.y_np, stop_gradient=False)
+        out = x.add(y, alpha=2)
+        expected = self.x_np + self.y_np * 2
+        np.testing.assert_array_equal(out.numpy(), expected)
+
+        out.mean().backward()
+        expected_x_grad = np.array([0.5, 0.5], dtype='float32')
+        expected_y_grad = np.array([1.0, 1.0], dtype='float32')  # alpha=2
+        np.testing.assert_array_equal(x.grad.numpy(), expected_x_grad)
+        np.testing.assert_array_equal(y.grad.numpy(), expected_y_grad)
+
+    def test_tensor_add_inplace_with_alpha(self):
+        """test Tensor.add_ alpha"""
+        x = paddle.to_tensor(self.x_np)
+        y = paddle.to_tensor(self.y_np)
+        x.add_(y, alpha=2)
+        expected = self.x_np + self.y_np * 2
+        np.testing.assert_array_equal(x.numpy(), expected)
+
+    def test_consistency_between_apis(self):
+        """test different APIs consistency for add with alpha"""
+        x = paddle.to_tensor(self.x_np)
+        y = paddle.to_tensor(self.y_np)
+
+        out1 = paddle.add(x, y, alpha=2)
+        out2 = x.add(y, alpha=2)
+        x.add_(y, alpha=2)
+
+        expected = self.x_np + self.y_np * 2
+        np.testing.assert_array_equal(out1.numpy(), expected)
+        np.testing.assert_array_equal(out2.numpy(), expected)
+        np.testing.assert_array_equal(x.numpy(), expected)
+
+    def test_static_graph_add_with_alpha(self):
+        """test static graph add with alpha and parameter aliases"""
+        paddle.enable_static()
+        with paddle.static.program_guard(paddle.static.Program()):
+            x = paddle.static.data(name='x', shape=[-1, 2], dtype='float32')
+            y = paddle.static.data(name='y', shape=[-1, 2], dtype='float32')
+            out1 = paddle.add(x, y, alpha=2)
+            out2 = paddle.add(input=x, other=y, alpha=2)
+
+            exe = paddle.static.Executor(self.place)
+            res = exe.run(
+                feed={
+                    'x': self.x_np.reshape(1, 2),
+                    'y': self.y_np.reshape(1, 2),
+                },
+                fetch_list=[out1, out2],
+            )
+
+            expected = self.x_np + self.y_np * 2
+            for result in res:
+                np.testing.assert_array_equal(result.flatten(), expected)
+        paddle.disable_static()
+
+    def test_param_alias_input_other(self):
+        """test parameter alias input/other in dynamic graph"""
+        x = paddle.to_tensor(self.x_np)
+        y = paddle.to_tensor(self.y_np)
+
+        out1 = paddle.add(input=x, other=y, alpha=2)
+        out2 = x.add(other=y, alpha=2)
+        x_clone = x.clone()
+        x_clone.add_(other=y, alpha=2)
+
+        expected = self.x_np + self.y_np * 2
+        np.testing.assert_array_equal(out1.numpy(), expected)
+        np.testing.assert_array_equal(out2.numpy(), expected)
+        np.testing.assert_array_equal(x_clone.numpy(), expected)
+
+    # Note: y does not support scalars separately, but will support them uniformly in the future.
+    # def test_scalar_addition(self):
+    #     """test scalar addition"""
+    #     x = paddle.to_tensor(self.x_np)
+
+    #     out1 = paddle.add(x, self.scalar)
+    #     expected1 = self.x_np + self.scalar
+    #     np.testing.assert_array_equal(out1.numpy(), expected1)
+
+    #     out2 = x.add(self.scalar)
+    #     np.testing.assert_array_equal(out2.numpy(), expected1)
+
+    #     out3 = paddle.add(x, self.scalar, alpha=2)
+    #     expected3 = self.x_np + self.scalar * 2
+    #     np.testing.assert_array_equal(out3.numpy(), expected3)
+
+    # def test_scalar_addition_inplace(self):
+    #     """test inplace scalar addition"""
+    #     x = paddle.to_tensor(self.x_np)
+    #     x_clone = x.clone()
+
+    #     x_clone.add_(self.scalar)
+    #     expected = self.x_np + self.scalar
+    #     np.testing.assert_array_equal(x_clone.numpy(), expected)
+
+    #     x_clone2 = x.clone()
+    #     x_clone2.add_(self.scalar, alpha=2)
+    #     expected2 = self.x_np + self.scalar * 2
+    #     np.testing.assert_array_equal(x_clone2.numpy(), expected2)
+
+    # def test_different_dtype_scalar(self):
+    #     """test different dtype scalar addition"""
+    #     x = paddle.to_tensor(self.x_np)
+
+    #     out1 = x.add(2)
+    #     expected1 = self.x_np + 2
+    #     np.testing.assert_array_equal(out1.numpy(), expected1)
+
+    #     out2 = x.add(2.5)
+    #     expected2 = self.x_np + 2.5
+    #     np.testing.assert_array_equal(out2.numpy(), expected2)
+
+    # def test_scalar_addition_static_graph(self):
+    #     """test static graph scalar addition"""
+    #     paddle.enable_static()
+    #     with paddle.static.program_guard(paddle.static.Program()):
+    #         x = paddle.static.data(name='x', shape=[-1, 2], dtype='float32')
+    #         out1 = paddle.add(x, self.scalar)
+    #         out2 = paddle.add(x, self.scalar, alpha=2)
+
+    #         exe = paddle.static.Executor(self.place)
+    #         res = exe.run(
+    #             feed={'x': self.x_np.reshape(1, 2)},
+    #             fetch_list=[out1, out2],
+    #         )
+
+    #         expected1 = self.x_np + self.scalar
+    #         expected2 = self.x_np + self.scalar * 2
+    #         np.testing.assert_array_equal(res[0].flatten(), expected1)
+    #         np.testing.assert_array_equal(res[1].flatten(), expected2)
+    #     paddle.disable_static()
+
+
+class TestAddOut(unittest.TestCase):
+    def setUp(self):
+        paddle.disable_static()
+        if core.is_compiled_with_cuda():
+            self.place = core.CUDAPlace(0)
+        else:
+            self.place = core.CPUPlace()
+
+    def test_add_with_alpha_out(self):
+        def run_add_with_alpha(test_type):
+            x = paddle.to_tensor([1.0, 2.0, 3.0], stop_gradient=False)
+            y = paddle.to_tensor([4.0, 5.0, 6.0], stop_gradient=False)
+            out = paddle.zeros_like(x)
+            out.stop_gradient = False
+            alpha = 2.0
+
+            if test_type == "return":
+                out = paddle.add(x, y, alpha=alpha)
+            elif test_type == "input_out":
+                paddle.add(x, y, alpha=alpha, out=out)
+            elif test_type == "both_return":
+                out = paddle.add(x, y, alpha=alpha, out=out)
+            elif test_type == "both_input_out":
+                tmp = paddle.add(x, y, alpha=alpha, out=out)
+
+            expected = x + y * alpha
+            np.testing.assert_allclose(
+                out.numpy(),
+                expected.numpy(),
+                rtol=1e-20,
+                atol=1e-20,
+            )
+
+            loss = out.sum()
+            loss.backward()
+
+            return out, x.grad, y.grad, out.grad
+
+        out1, x1, y1, o1 = run_add_with_alpha("return")
+        out2, x2, y2, o2 = run_add_with_alpha("input_out")
+        out3, x3, y3, o3 = run_add_with_alpha("both_return")
+        out4, x4, y4, o4 = run_add_with_alpha("both_input_out")
+
+        np.testing.assert_allclose(
+            out1.numpy(), out2.numpy(), rtol=1e-20, atol=1e-20
+        )
+        np.testing.assert_allclose(
+            out1.numpy(), out3.numpy(), rtol=1e-20, atol=1e-20
+        )
+        np.testing.assert_allclose(
+            out1.numpy(), out4.numpy(), rtol=1e-20, atol=1e-20
+        )
+
+        np.testing.assert_allclose(
+            x1.numpy(), x2.numpy(), rtol=1e-20, atol=1e-20
+        )
+        np.testing.assert_allclose(
+            x1.numpy(), x3.numpy(), rtol=1e-20, atol=1e-20
+        )
+        np.testing.assert_allclose(
+            x1.numpy(), x4.numpy(), rtol=1e-20, atol=1e-20
+        )
+
+        np.testing.assert_allclose(
+            y1.numpy(), y2.numpy(), rtol=1e-20, atol=1e-20
+        )
+        np.testing.assert_allclose(
+            y1.numpy(), y3.numpy(), rtol=1e-20, atol=1e-20
+        )
+        np.testing.assert_allclose(
+            y1.numpy(), y4.numpy(), rtol=1e-20, atol=1e-20
+        )
+
+        np.testing.assert_equal(o1, None)
+        np.testing.assert_equal(o2, None)
+        np.testing.assert_equal(o3, None)
+        np.testing.assert_equal(o4, None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/legacy_test/test_add_op_fluid.py
+++ b/test/legacy_test/test_add_op_fluid.py
@@ -1,0 +1,79 @@
+#  Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import unittest
+
+import numpy as np
+
+os.environ['FLAGS_enable_pir_api'] = '0'
+import paddle
+from paddle.base import core
+
+
+class TestPaddleAddNewFeatures(unittest.TestCase):
+    def setUp(self):
+        self.x_np = np.array([3, 5], dtype='float32')
+        self.y_np = np.array([2, 3], dtype='float32')
+        self.scalar = 2.0
+        self.place = (
+            core.CUDAPlace(0)
+            if core.is_compiled_with_cuda()
+            else core.CPUPlace()
+        )
+
+    def test_static_graph_add_with_alpha(self):
+        """test static graph add with alpha and parameter aliases"""
+        paddle.enable_static()
+        x = paddle.static.data(name='x', shape=[-1, 2], dtype='float32')
+        y = paddle.static.data(name='y', shape=[-1, 2], dtype='float32')
+        out1 = paddle.add(x, y, alpha=2)
+        out2 = paddle.add(input=x, other=y, alpha=2)
+
+        exe = paddle.static.Executor(self.place)
+        res = exe.run(
+            feed={
+                'x': self.x_np.reshape(1, 2),
+                'y': self.y_np.reshape(1, 2),
+            },
+            fetch_list=[out1, out2],
+        )
+
+        expected = self.x_np + self.y_np * 2
+        for result in res:
+            np.testing.assert_array_equal(result.flatten(), expected)
+        paddle.disable_static()
+
+    def test_static_graph_add_with_alpha_1(self):
+        paddle.enable_static()
+        """Test static graph add with alpha=1 (default behavior)"""
+        x = paddle.static.data(name='x', shape=[-1, 2], dtype='float32')
+        y = paddle.static.data(name='y', shape=[-1, 2], dtype='float32')
+        out = paddle.add(x, y, alpha=1)
+
+        exe = paddle.static.Executor(self.place)
+        res = exe.run(
+            feed={
+                'x': self.x_np.reshape(1, 2),
+                'y': self.y_np.reshape(1, 2),
+            },
+            fetch_list=[out],
+        )
+
+        expected = self.x_np + self.y_np
+        np.testing.assert_array_equal(res[0].flatten(), expected)
+        paddle.disable_static()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### PR Category
User Experience

### PR Types
New features

### Description
1. paddle.add：新增默认参数alpha，out。输入映射x：input、y：other。
2. paddle.Tensor.add：新增默认参数alpha。输入映射y：other。
3. paddle.Tensor.add_新增默认参数alpha。输入映射y：other。

注：
1. y不单独支持scalar，后续会统一支持。

pcard-67164