### PR TITLE
int8_scale_calculation_onednn_pass_tester modify use_mkldnn [fluid_ops]

### DIFF
--- a/paddle/fluid/framework/ir/onednn/int8_scale_calculation_onednn_pass_tester.cc
+++ b/paddle/fluid/framework/ir/onednn/int8_scale_calculation_onednn_pass_tester.cc
@@ -28,7 +28,7 @@ void SetOp(ProgramDesc* prog,
 
   op->SetType(type);
   if (type == "conv2d") {
-    op->SetAttr("use_mkldnn", true);
+    op->SetAttr("use_onednn", true);
     op->SetAttr("name", name);
     op->SetAttr("strides", std::vector<int>({1, 1}));
     op->SetAttr("groups", 1);
@@ -47,7 +47,7 @@ void SetOp(ProgramDesc* prog,
     op->SetAttr("Scale_in", 1.0f);
     op->SetAttr("Scale_out", 1.0f);
     op->SetAttr("Scale_weights", scale_weights);
-    op->SetAttr("use_mkldnn", true);
+    op->SetAttr("use_onednn", true);
     op->SetAttr("mkldnn_data_type", std::string("int8"));
   } else {
     FAIL() << "Unexpected operator type.";
@@ -103,7 +103,7 @@ void MainTest(bool convWithExistingBias,
   for (auto* node : graph->Nodes()) {
     if (node->IsOp() && node->Op()->Type() == "conv2d") {
       auto* op = node->Op();
-      ASSERT_TRUE(op->HasAttr("use_mkldnn"));
+      ASSERT_TRUE(op->HasAttr("use_mkldnn") || op->HasAttr("use_onednn"));
 
       EXPECT_EQ(op->GetAttrIfExists<std::vector<float>>("Scale_weights"),
                 scale_weights);

--- a/paddle/fluid/framework/ir/onednn/operator_reshape2_onednn_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/onednn/operator_reshape2_onednn_fuse_pass.cc
@@ -55,9 +55,15 @@ void FuseOperatorReshape2OneDNNPass::FuseReshape2(Graph *graph,
     GET_IR_NODE_FROM_SUBGRAPH(reshape2_op, reshape2_op, op_reshape2_pattern);
     GET_IR_NODE_FROM_SUBGRAPH(reshape2_out, reshape2_out, op_reshape2_pattern);
 
-    if (!operator_op->Op()->HasAttr("use_mkldnn") ||
+    bool use_mkldnn_not =
+        !operator_op->Op()->HasAttr("use_mkldnn") ||
         (operator_op->Op()->HasAttr("use_mkldnn") &&
-         !(PADDLE_GET_CONST(bool, operator_op->Op()->GetAttr("use_mkldnn"))))) {
+         !(PADDLE_GET_CONST(bool, operator_op->Op()->GetAttr("use_mkldnn"))));
+    bool use_onednn_not =
+        !operator_op->Op()->HasAttr("use_onednn") ||
+        (operator_op->Op()->HasAttr("use_onednn") &&
+         !(PADDLE_GET_CONST(bool, operator_op->Op()->GetAttr("use_onednn"))));
+    if (use_mkldnn_not && use_onednn_not) {
       VLOG(4) << "Only oneDNN version of " << op_type
               << "can be fused with reshape2.";
       return;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
paddle/fluid/framework/ir/onednn/int8_scale_calculation_onednn_pass_tester.cc 修改 use_mkldnn