### PR TITLE
[PHI] Skip dim check in `RmsNormInferMeta` on dynamic dim

### DIFF
--- a/paddle/fluid/pir/dialect/op_generator/op_build_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_build_gen.py
@@ -94,6 +94,7 @@ _INFERMETA_NEED_META_CONFIG = {
     'LegacyInterpolateInferMeta',
     'NceInferMeta',
     'PyramidHashInferMeta',
+    'RmsNormInferMeta',
     'SigmoidCrossEntropyWithLogitsInferMeta',
     'StackInferMeta',
     'WeightOnlyLinearInferMeta',

--- a/paddle/phi/infermeta/multiary.cc
+++ b/paddle/phi/infermeta/multiary.cc
@@ -4944,26 +4944,34 @@ void RmsNormInferMeta(const MetaTensor& x,
                       const float quant_min_bound,
                       MetaTensor* out,
                       MetaTensor* residual_out,
-                      MetaTensor* inv_var) {
+                      MetaTensor* inv_var,
+                      MetaConfig config) {
   size_t x_dims_size = x.dims().size();
 
   size_t normalized_dims = 1;
+  bool has_minus_one = false;
   for (size_t i = begin_norm_axis; i < x_dims_size; ++i) {
     normalized_dims *= x.dims().at(i);
+    has_minus_one |= (x.dims().at(i) == -1);
   }
 
-  if (normalized_dims != 0) {
-    PADDLE_ENFORCE_EQ(normalized_dims,
-                      norm_weight.dims()[0],
-                      common::errors::InvalidArgument(
-                          "The normalized size of Input(X) must equal to be "
-                          "the size of Weight, but received "
-                          "normalized size of Input(X) is [%d], received size "
-                          "of Weight is [%d]",
-                          normalized_dims,
-                          norm_weight.dims()[0]));
-  }
+  // NOTE: Although 'goto' is generally discouraged, its use here replaces two
+  // obscure if-statements, improves readability, and does not cross large code
+  // blocks or affect resource management. The jump is clear and safe in this
+  // context.
+  if (normalized_dims == 0) goto skip_check;
+  if (has_minus_one && !config.is_runtime) goto skip_check;
 
+  PADDLE_ENFORCE_EQ(normalized_dims,
+                    norm_weight.dims()[0],
+                    common::errors::InvalidArgument(
+                        "The normalized size of Input(X) must equal to be "
+                        "the size of Weight, but received "
+                        "normalized size of Input(X) is [%d], received size "
+                        "of Weight is [%d]",
+                        normalized_dims,
+                        norm_weight.dims()[0]));
+skip_check:
   out->set_dims(x.dims());
 
   if (quant_scale > 0) {

--- a/paddle/phi/infermeta/multiary.cc
+++ b/paddle/phi/infermeta/multiary.cc
@@ -4955,23 +4955,21 @@ void RmsNormInferMeta(const MetaTensor& x,
     has_minus_one |= (x.dims().at(i) == -1);
   }
 
-  // NOTE: Although 'goto' is generally discouraged, its use here replaces two
-  // obscure if-statements, improves readability, and does not cross large code
-  // blocks or affect resource management. The jump is clear and safe in this
-  // context.
-  if (normalized_dims == 0) goto skip_check;
-  if (has_minus_one && !config.is_runtime) goto skip_check;
+  bool skip_check = false;
+  if (normalized_dims == 0) skip_check = true;
+  if (has_minus_one && !config.is_runtime) skip_check = true;
 
-  PADDLE_ENFORCE_EQ(normalized_dims,
-                    norm_weight.dims()[0],
-                    common::errors::InvalidArgument(
-                        "The normalized size of Input(X) must equal to be "
-                        "the size of Weight, but received "
-                        "normalized size of Input(X) is [%d], received size "
-                        "of Weight is [%d]",
-                        normalized_dims,
-                        norm_weight.dims()[0]));
-skip_check:
+  if (!skip_check) {
+    PADDLE_ENFORCE_EQ(normalized_dims,
+                      norm_weight.dims()[0],
+                      common::errors::InvalidArgument(
+                          "The normalized size of Input(X) must equal to be "
+                          "the size of Weight, but received "
+                          "normalized size of Input(X) is [%d], received size "
+                          "of Weight is [%d]",
+                          normalized_dims,
+                          norm_weight.dims()[0]));
+  }
   out->set_dims(x.dims());
 
   if (quant_scale > 0) {

--- a/paddle/phi/infermeta/multiary.h
+++ b/paddle/phi/infermeta/multiary.h
@@ -988,7 +988,8 @@ void RmsNormInferMeta(const MetaTensor& x,
                       const float quant_min_bound,
                       MetaTensor* out,
                       MetaTensor* residual_out,
-                      MetaTensor* inv_var);
+                      MetaTensor* inv_var,
+                      MetaConfig config = MetaConfig());
 
 void RmspropInferMeta(const MetaTensor& param,
                       const MetaTensor& mean_square,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

跑 DeepseekV3 报错：
```shell
    File "/workspace/Paddle/build/python/paddle/incubate/nn/functional/fused_rms_norm.py", line 127, in fused_rms_norm
	return _C_ops.rms_norm(

    ValueError: (InvalidArgument) The normalized size of Input(X) must equal to be the size of Weight, but received normalized size of Input(X) is [18446744073709551615], received size of Weight is [512]
  [Hint: Expected normalized_dims == norm_weight.dims()[0], but received normalized_dims:18446744073709551615 != norm_weight.dims()[0]:512.] (at /workspace/Paddle/paddle/phi/infermeta/multiary.cc:4956)
```

注意到 `18446744073709551615 + 1 == 2^64` 来到 rms_norm 的 infermeta：

```cpp
  size_t x_dims_size = x.dims().size();

  size_t normalized_dims = 1;
  for (size_t i = 1; i < x_dims_size; ++i) {
    normalized_dims *= x.dims().at(i);
  }
```

如果 `x` 的 dim 为 `[32, -1]`，`-1` 转化为 `unsigned int64`，也就是 `18446744073709551615`

之后在这里加上，如果是编译期且存在-1，也跳过参数检查即可：
```
  if (normalized_dims != 0) {
    PADDLE_ENFORCE_EQ(...);
  }
```

pcard-91591