### PR TITLE
[Stride] Set up DenseTensorIterator And Support Stride Kernel For Elementwise_Add

### DIFF
--- a/paddle/common/flags.cc
+++ b/paddle/common/flags.cc
@@ -2180,3 +2180,15 @@ PHI_DEFINE_EXPORTED_bool(check_cuda_error,
 PHI_DEFINE_EXPORTED_bool(use_default_stream,
                          false,
                          "Whether use default stream.");
+
+/**
+ * DenseTensorIterator related FLAG
+ * Name: FLAGS_use_densetensor_iterator
+ * Since Version: 3.1.1
+ * Value Range: bool, default=false
+ * Example:
+ * Note: Whether use DensetensorIterator.
+ */
+PHI_DEFINE_EXPORTED_bool(use_densetensor_iterator,
+                         false,
+                         "Whether use DensetensorIterator.");

--- a/paddle/common/flags.cc
+++ b/paddle/common/flags.cc
@@ -2190,5 +2190,5 @@ PHI_DEFINE_EXPORTED_bool(use_default_stream,
  * Note: Whether use DensetensorIterator.
  */
 PHI_DEFINE_EXPORTED_bool(use_densetensor_iterator,
-                         false,
+                         true,
                          "Whether use DensetensorIterator.");

--- a/paddle/common/flags.cc
+++ b/paddle/common/flags.cc
@@ -2182,13 +2182,13 @@ PHI_DEFINE_EXPORTED_bool(use_default_stream,
                          "Whether use default stream.");
 
 /**
- * DenseTensorIterator related FLAG
- * Name: FLAGS_use_densetensor_iterator
+ * Stride_Compute_Kernel related FLAG
+ * Name: FLAGS_use_stride_compute_kernel
  * Since Version: 3.2
  * Value Range: bool, default=false
  * Example:
- * Note: Whether use DensetensorIterator.
+ * Note: Whether use Stride_Compute_Kernel.
  */
-PHI_DEFINE_EXPORTED_bool(use_densetensor_iterator,
+PHI_DEFINE_EXPORTED_bool(use_stride_compute_kernel,
                          false,
-                         "Whether use DensetensorIterator.");
+                         "Whether use Stride_Compute_Kernel.");

--- a/paddle/common/flags.cc
+++ b/paddle/common/flags.cc
@@ -2184,11 +2184,11 @@ PHI_DEFINE_EXPORTED_bool(use_default_stream,
 /**
  * DenseTensorIterator related FLAG
  * Name: FLAGS_use_densetensor_iterator
- * Since Version: 3.1.1
+ * Since Version: 3.2
  * Value Range: bool, default=false
  * Example:
  * Note: Whether use DensetensorIterator.
  */
 PHI_DEFINE_EXPORTED_bool(use_densetensor_iterator,
-                         true,
+                         false,
                          "Whether use DensetensorIterator.");

--- a/paddle/phi/kernels/CMakeLists.txt
+++ b/paddle/phi/kernels/CMakeLists.txt
@@ -31,6 +31,7 @@ file(
   RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}"
   "gpudnn/*.cu"
   "kps/*.cu"
+  "stride/*.cu"
   "legacy/kps/*.cu"
   "legacy/gpu/*.cu"
   "selected_rows/gpu/*.cu"

--- a/paddle/phi/kernels/funcs/dense_tensor_iterator.cc
+++ b/paddle/phi/kernels/funcs/dense_tensor_iterator.cc
@@ -16,6 +16,15 @@
 
 namespace phi {
 
+static bool judge_valid_stride(std::vector<int64_t> tmp_stride) {
+  for (size_t i = 0; i < tmp_stride.size(); i++) {
+    if (tmp_stride[i] == 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
 void DenseOperandInfo::tensor(DenseTensor*&& tensor) {
   tensor_base_ = std::move(tensor);
 }
@@ -52,9 +61,7 @@ void DenseTensorIteratorBase::reorder_dimensions() {
     perm_[0] = 0;
     return;
   }
-
   std::iota(perm_.rbegin(), perm_.rend(), 0);
-
   auto should_swap = [&](size_t dim0, size_t dim1) {
     for (auto arg = 0; arg < ntensors(); arg++) {
       if (operands_[arg].stride_bytes.empty() || operands_[arg].will_resize) {
@@ -83,7 +90,6 @@ void DenseTensorIteratorBase::reorder_dimensions() {
     }
     return 0;
   };
-
   for (auto i = 1; i < ndim(); i++) {
     int dim1 = i;
     for (int dim0 = i - 1; dim0 >= 0; dim0--) {
@@ -96,7 +102,6 @@ void DenseTensorIteratorBase::reorder_dimensions() {
       }
     }
   }
-
   permute_dimensions(perm_);
 }
 
@@ -105,7 +110,6 @@ void DenseTensorIteratorBase::permute_dimensions(std::vector<int64_t> perm) {
       perm.size(),
       static_cast<unsigned>(ndim()),
       "perm.size() must equal to ndim in DenseDenseTensorIterator");
-
   auto reorder = [perm](std::vector<int64_t> data) {
     auto res = std::vector<int64_t>(data.size(), 0);
     for (size_t i = 0; i < perm.size(); i++) {
@@ -113,7 +117,6 @@ void DenseTensorIteratorBase::permute_dimensions(std::vector<int64_t> perm) {
     }
     return res;
   };
-
   shape_ = reorder(shape_);
   for (auto& op : operands_) {
     if (!op.stride_bytes.empty()) {
@@ -145,14 +148,8 @@ std::vector<int64_t> DenseTensorIteratorBase::invert_perm(
 void DenseTensorIteratorBase::allocate_or_resize_outputs() {
   for (auto i = 0; i < num_outputs_; i++) {
     auto& op = operands_[i];
-    bool valid_stride = true;
-    auto tmp_stride = common::vectorize<int64_t>(op.tensor().strides());
-    for (size_t i = 0; i < tmp_stride.size(); i++) {
-      if (tmp_stride[i] == 0) {
-        valid_stride = false;
-        break;
-      }
-    }
+    bool valid_stride =
+        judge_valid_stride(common::vectorize<int64_t>(op.tensor().strides()));
     if (!op.tensor().initialized() || op.will_resize || !valid_stride) {
       auto element_size = phi::SizeOf(op.tensor().dtype());
       op.stride_bytes = compatible_stride(static_cast<int64_t>(element_size));
@@ -193,14 +190,8 @@ void DenseTensorIterator::set_output_raw_strided(int64_t output_idx,
                                                  std::vector<int64_t> sizes,
                                                  std::vector<int64_t> strides) {
   auto& op = operands_[output_idx];
-  bool valid_stride = true;
-  auto tmp_stride = common::vectorize<int64_t>(op.tensor().strides());
-  for (size_t i = 0; i < tmp_stride.size(); i++) {
-    if (tmp_stride[i] == 0) {
-      valid_stride = false;
-      break;
-    }
-  }
+  bool valid_stride =
+      judge_valid_stride(common::vectorize<int64_t>(op.tensor().strides()));
   if (!op.tensor().initialized() || !valid_stride) {
     if (strides.empty()) {
       auto meta = op.tensor().meta();
@@ -227,7 +218,6 @@ void DenseTensorIteratorBase::coalesce_dimensions() {
   if (ndim() <= 1) {
     return;
   }
-
   auto can_coalesce = [&](int dim0, int dim1) {
     auto shape0 = shape_[dim0];
     auto shape1 = shape_[dim1];
@@ -242,14 +232,12 @@ void DenseTensorIteratorBase::coalesce_dimensions() {
     }
     return true;
   };
-
   auto replace_stride = [&](int dim0, int dim1) {
     for (auto i = 0; i < ntensors(); i++) {
       auto& stride = operands_[i].stride_bytes;
       stride[dim0] = stride[dim1];
     }
   };
-
   int prev_dim = 0;
   for (auto dim = 1; dim < ndim(); dim++) {
     if (can_coalesce(prev_dim, dim)) {
@@ -290,17 +278,14 @@ static inline std::vector<int64_t> infer_size_dimvector(
   auto dimsB = b.size();
   auto ndim = dimsA > dimsB ? dimsA : dimsB;
   std::vector<int64_t> expandedSizes = std::vector<int64_t>(ndim, 0);
-
   for (int64_t i = ndim - 1; i >= 0; --i) {
     int64_t offset = ndim - 1 - i;
     int64_t dimA = dimsA - 1 - offset;
     int64_t dimB = dimsB - 1 - offset;
     auto sizeA = (dimA >= 0) ? a[dimA] : 1;
     auto sizeB = (dimB >= 0) ? b[dimB] : 1;
-
     expandedSizes[i] = sizeA == 1 ? sizeB : sizeA;
   }
-
   return expandedSizes;
 }
 
@@ -318,7 +303,6 @@ FastSetupType DenseTensorIteratorBase::compute_fast_setup_type(
   if (is_reduction_ || !all_ops_same_shape_) {
     return FastSetupType::NONE;
   }
-
   bool is_contiguous = true;
   for (const auto& op : operands_) {
     if (op.tensor().initialized() && !op.will_resize) {
@@ -337,7 +321,6 @@ bool DenseTensorIteratorBase::fast_set_up(
   if (setup_type == FastSetupType::NONE) {
     return false;
   }
-
   switch (setup_type) {
     case FastSetupType::CONTIGUOUS: {
       for (auto i = 0; i < num_outputs_; i++) {
@@ -371,14 +354,8 @@ void DenseTensorIteratorBase::compute_shape(
   bool has_scalars = false;
   bool has_tensors = false;
   for (auto& op : operands_) {
-    bool valid_stride = true;
-    auto tmp_stride = common::vectorize<int64_t>(op.tensor().strides());
-    for (size_t i = 0; i < tmp_stride.size(); i++) {
-      if (tmp_stride[i] == 0) {
-        valid_stride = false;
-        break;
-      }
-    }
+    bool valid_stride =
+        judge_valid_stride(common::vectorize<int64_t>(op.tensor().strides()));
     if (!op.tensor().initialized() || !valid_stride) continue;
     if (config.resize_outputs_ && op.is_output) continue;
     auto shape = common::vectorize<int64_t>(op.tensor().dims());
@@ -403,14 +380,8 @@ void DenseTensorIteratorBase::compute_shape(
 void DenseTensorIteratorBase::compute_strides(
     const DenseTensorIteratorConfig& config) {
   for (auto& op : operands_) {
-    bool valid_stride = true;
-    auto tmp_stride = common::vectorize<int64_t>(op.tensor().strides());
-    for (size_t i = 0; i < tmp_stride.size(); i++) {
-      if (tmp_stride[i] == 0) {
-        valid_stride = false;
-        break;
-      }
-    }
+    bool valid_stride =
+        judge_valid_stride(common::vectorize<int64_t>(op.tensor().strides()));
     if (op.tensor().initialized() && !op.will_resize && valid_stride) {
       std::vector<int64_t> original_shape =
           config.static_shape_ ? shape_
@@ -436,24 +407,12 @@ void DenseTensorIteratorBase::compute_strides(
 
 void DenseTensorIteratorBase::build(DenseTensorIteratorConfig& config) {
   populate_operands(config);
-
   compute_shape(config);
-
   if (!fast_set_up(config)) {
     compute_strides(config);
-
     reorder_dimensions();
-
     allocate_or_resize_outputs();
-
     coalesce_dimensions();
   }
-
-  for (int i = 0; i < ntensors(); i++) {
-    if (i < num_outputs_) continue;
-    auto& op = operands_[i];
-    op.data = const_cast<void*>(op.tensor().data());
-  }
 }
-
 }  // namespace phi

--- a/paddle/phi/kernels/funcs/dense_tensor_iterator.cc
+++ b/paddle/phi/kernels/funcs/dense_tensor_iterator.cc
@@ -1,0 +1,459 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/phi/kernels/funcs/dense_tensor_iterator.h"
+
+namespace phi {
+
+void DenseOperandInfo::tensor(DenseTensor*&& tensor) {
+  tensor_base_ = std::move(tensor);
+}
+
+DenseTensorIteratorConfig& DenseTensorIteratorConfig::add_borrowed_output(
+    const DenseTensor& output) {
+  PADDLE_ENFORCE_EQ(num_inputs_,
+                    0,
+                    "Keep in mind that you have to add all outputs first "
+                    "before adding any input.");
+  tensors_.push_back(&output);
+  num_outputs_++;
+  return *this;
+}
+
+DenseTensorIteratorConfig& DenseTensorIteratorConfig::add_borrowed_input(
+    const DenseTensor& input) {
+  tensors_.push_back(&input);
+  num_inputs_++;
+  return *this;
+}
+
+DenseTensorIteratorConfig& DenseTensorIteratorConfig::add_borrowed_const_input(
+    const DenseTensor& input) {
+  const_tensor_indices_.push_back(tensors_.size());
+  tensors_.push_back(&input);
+  num_inputs_++;
+  return *this;
+}
+
+void DenseTensorIteratorBase::reorder_dimensions() {
+  perm_.resize(ndim());
+  if (ndim() == 1) {
+    perm_[0] = 0;
+    return;
+  }
+
+  std::iota(perm_.rbegin(), perm_.rend(), 0);
+
+  auto should_swap = [&](size_t dim0, size_t dim1) {
+    for (auto arg = 0; arg < ntensors(); arg++) {
+      if (operands_[arg].stride_bytes.empty() || operands_[arg].will_resize) {
+        continue;
+      }
+      int64_t stride0 = operands_[arg].stride_bytes[dim0];
+      int64_t stride1 = operands_[arg].stride_bytes[dim1];
+      if (is_reduction_ && operands_[arg].is_output) {
+        if ((stride0 == 0) != (stride1 == 0)) {
+          return stride1 == 0 ? 1 : -1;
+        }
+      }
+      if (stride0 == 0 || stride1 == 0) {
+        continue;
+      } else if (stride0 < stride1) {
+        return -1;
+      } else if (stride0 > stride1) {
+        return 1;
+      } else {
+        auto t_dim0 = shape_[dim0];
+        auto t_dim1 = shape_[dim1];
+        if (t_dim0 > t_dim1) {
+          return 1;
+        }
+      }
+    }
+    return 0;
+  };
+
+  for (auto i = 1; i < ndim(); i++) {
+    int dim1 = i;
+    for (int dim0 = i - 1; dim0 >= 0; dim0--) {
+      int comparison = should_swap(perm_[dim0], perm_[dim1]);
+      if (comparison > 0) {
+        std::swap(perm_[dim0], perm_[dim1]);
+        dim1 = dim0;
+      } else if (comparison < 0) {
+        break;
+      }
+    }
+  }
+
+  permute_dimensions(perm_);
+}
+
+void DenseTensorIteratorBase::permute_dimensions(std::vector<int64_t> perm) {
+  PADDLE_ENFORCE_EQ(
+      perm.size(),
+      static_cast<unsigned>(ndim()),
+      "perm.size() must equal to ndim in DenseDenseTensorIterator");
+
+  auto reorder = [perm](std::vector<int64_t> data) {
+    auto res = std::vector<int64_t>(data.size(), 0);
+    for (size_t i = 0; i < perm.size(); i++) {
+      res[i] = data[perm[i]];
+    }
+    return res;
+  };
+
+  shape_ = reorder(shape_);
+  for (auto& op : operands_) {
+    if (!op.stride_bytes.empty()) {
+      op.stride_bytes = reorder(op.stride_bytes);
+    }
+  }
+}
+
+std::vector<int64_t> DenseTensorIteratorBase::compatible_stride(
+    int64_t element_size) const {
+  std::vector<int64_t> stride;
+  int64_t next_stride = element_size;
+  for (auto dim = 0; dim < ndim(); dim++) {
+    stride.push_back(next_stride);
+    next_stride *= shape_[dim];
+  }
+  return stride;
+}
+
+std::vector<int64_t> DenseTensorIteratorBase::invert_perm(
+    std::vector<int64_t> input) const {
+  auto res = std::vector<int64_t>(input.size());
+  for (auto dim = 0; dim < ndim(); dim++) {
+    res[perm_[dim]] = input[dim];
+  }
+  return res;
+}
+
+void DenseTensorIteratorBase::allocate_or_resize_outputs() {
+  for (auto i = 0; i < num_outputs_; i++) {
+    auto& op = operands_[i];
+    bool valid_stride = true;
+    auto tmp_stride = common::vectorize<int64_t>(op.tensor().strides());
+    for (size_t i = 0; i < tmp_stride.size(); i++) {
+      if (tmp_stride[i] == 0) {
+        valid_stride = false;
+        break;
+      }
+    }
+    if (!op.tensor().initialized() || op.will_resize || !valid_stride) {
+      auto element_size = phi::SizeOf(op.tensor().dtype());
+      op.stride_bytes = compatible_stride(static_cast<int64_t>(element_size));
+      bool inverted = true;
+      for (auto j = 0; j < ndim(); j++) {
+        if (perm_[j] != ndim() - j - 1) {
+          inverted = false;
+          break;
+        }
+      }
+      auto tensor_shape = invert_perm(shape_);
+      if (inverted) {
+        set_output_raw_strided(i, tensor_shape, {});
+      } else {
+        auto tensor_stride = invert_perm(op.stride_bytes);
+        for (auto dim = 0; dim < ndim(); dim++) {
+          tensor_stride[dim] /= static_cast<int64_t>(element_size);
+        }
+        set_output_raw_strided(i, tensor_shape, tensor_stride);
+      }
+      op.current_dtype = op.target_dtype;
+    } else if (op.tensor().initialized()) {
+      set_output_raw_strided(
+          i, common::vectorize<int64_t>(op.tensor().dims()), {});
+    }
+  }
+}
+
+void DenseTensorIteratorBase::set_output_raw_strided(
+    int64_t output_idx,
+    std::vector<int64_t> sizes,
+    std::vector<int64_t> strides) {
+  PADDLE_THROW(
+      common::errors::Fatal("Virtual Set Output Stride, Unsupported!"));
+}
+
+void DenseTensorIterator::set_output_raw_strided(int64_t output_idx,
+                                                 std::vector<int64_t> sizes,
+                                                 std::vector<int64_t> strides) {
+  auto& op = operands_[output_idx];
+  bool valid_stride = true;
+  auto tmp_stride = common::vectorize<int64_t>(op.tensor().strides());
+  for (size_t i = 0; i < tmp_stride.size(); i++) {
+    if (tmp_stride[i] == 0) {
+      valid_stride = false;
+      break;
+    }
+  }
+  if (!op.tensor().initialized() || !valid_stride) {
+    if (strides.empty()) {
+      auto meta = op.tensor().meta();
+      auto new_dims = common::make_ddim(sizes);
+      auto new_strides = meta.calc_strides(new_dims);
+      meta.dims = new_dims;
+      meta.strides = new_strides;
+      op.tensor().set_meta(meta);
+    } else {
+      auto meta = op.tensor().meta();
+      auto new_dims = common::make_ddim(sizes);
+      auto new_strides = common::make_ddim(strides);
+      meta.dims = new_dims;
+      meta.strides = new_strides;
+      op.tensor().set_meta(meta);
+    }
+    op.current_dtype = op.target_dtype;
+  } else if (op.will_resize) {
+    PADDLE_THROW(common::errors::Fatal("Opreator Reize not Implemented!"));
+  }
+}
+
+void DenseTensorIteratorBase::coalesce_dimensions() {
+  if (ndim() <= 1) {
+    return;
+  }
+
+  auto can_coalesce = [&](int dim0, int dim1) {
+    auto shape0 = shape_[dim0];
+    auto shape1 = shape_[dim1];
+    if (shape0 == 1 || shape1 == 1) {
+      return true;
+    }
+    for (auto i = 0; i < ntensors(); i++) {
+      auto& stride = operands_[i].stride_bytes;
+      if (shape0 * stride[dim0] != stride[dim1]) {
+        return false;
+      }
+    }
+    return true;
+  };
+
+  auto replace_stride = [&](int dim0, int dim1) {
+    for (auto i = 0; i < ntensors(); i++) {
+      auto& stride = operands_[i].stride_bytes;
+      stride[dim0] = stride[dim1];
+    }
+  };
+
+  int prev_dim = 0;
+  for (auto dim = 1; dim < ndim(); dim++) {
+    if (can_coalesce(prev_dim, dim)) {
+      if (shape_[prev_dim] == 1) {
+        replace_stride(prev_dim, dim);
+      }
+      shape_[prev_dim] *= shape_[dim];
+    } else {
+      prev_dim++;
+      if (prev_dim != dim) {
+        replace_stride(prev_dim, dim);
+        shape_[prev_dim] = shape_[dim];
+      }
+    }
+  }
+  shape_.resize(prev_dim + 1);
+  for (auto i = 0; i < ntensors(); i++) {
+    operands_[i].stride_bytes.resize(ndim());
+  }
+  has_coalesced_dimensions_ = true;
+}
+
+int64_t DenseTensorIteratorBase::numel() const {
+  int64_t numel = 1;
+  for (int64_t size : shape_) {
+    numel *= size;
+  }
+  return numel;
+}
+
+void* DenseTensorIteratorBase::data_ptr(int64_t arg) const {
+  return const_cast<void*>(operands_[arg].tensor().data());
+}
+
+static inline std::vector<int64_t> infer_size_dimvector(
+    std::vector<int64_t> a, std::vector<int64_t> b) {
+  auto dimsA = a.size();
+  auto dimsB = b.size();
+  auto ndim = dimsA > dimsB ? dimsA : dimsB;
+  std::vector<int64_t> expandedSizes = std::vector<int64_t>(ndim, 0);
+
+  for (int64_t i = ndim - 1; i >= 0; --i) {
+    int64_t offset = ndim - 1 - i;
+    int64_t dimA = dimsA - 1 - offset;
+    int64_t dimB = dimsB - 1 - offset;
+    auto sizeA = (dimA >= 0) ? a[dimA] : 1;
+    auto sizeB = (dimB >= 0) ? b[dimB] : 1;
+
+    expandedSizes[i] = sizeA == 1 ? sizeB : sizeA;
+  }
+
+  return expandedSizes;
+}
+
+void DenseTensorIteratorBase::populate_operands(
+    DenseTensorIteratorConfig& config) {
+  for (size_t idx = 0; idx < config.tensors_.size(); idx++) {
+    auto& tensor = config.tensors_[idx];
+    operands_.emplace_back(std::move(const_cast<DenseTensor*>(tensor)));
+  }
+  num_outputs_ = config.num_outputs_;
+}
+
+FastSetupType DenseTensorIteratorBase::compute_fast_setup_type(
+    const DenseTensorIteratorConfig& config) {
+  if (is_reduction_ || !all_ops_same_shape_) {
+    return FastSetupType::NONE;
+  }
+
+  bool is_contiguous = true;
+  for (const auto& op : operands_) {
+    if (op.tensor().initialized() && !op.will_resize) {
+      is_contiguous &= op.tensor().meta().is_contiguous();
+    }
+  }
+  if (is_contiguous) {
+    return FastSetupType::CONTIGUOUS;
+  }
+  return FastSetupType::NONE;
+}
+
+bool DenseTensorIteratorBase::fast_set_up(
+    const DenseTensorIteratorConfig& config) {
+  FastSetupType setup_type = compute_fast_setup_type(config);
+  if (setup_type == FastSetupType::NONE) {
+    return false;
+  }
+
+  switch (setup_type) {
+    case FastSetupType::CONTIGUOUS: {
+      for (auto i = 0; i < num_outputs_; i++) {
+        set_output_raw_strided(i, shape_, {});
+      }
+      break;
+    }
+    default:
+      PADDLE_THROW(common::errors::Fatal("Unsupported Fast Setup Type!"));
+  }
+  if (ndim() > 1) {
+    has_coalesced_dimensions_ = true;
+  }
+  if (ndim() >= 1) {
+    shape_[0] = numel();
+    shape_.resize(1);
+  }
+  for (auto& op : operands_) {
+    auto element_size_in_bytes = phi::SizeOf(op.tensor().dtype());
+    op.stride_bytes.resize(ndim());
+    if (ndim() > 0) {
+      op.stride_bytes[0] = element_size_in_bytes;
+    }
+  }
+  return true;
+}
+
+void DenseTensorIteratorBase::compute_shape(
+    const DenseTensorIteratorConfig& config) {
+  all_ops_same_shape_ = true;
+  bool has_scalars = false;
+  bool has_tensors = false;
+  for (auto& op : operands_) {
+    bool valid_stride = true;
+    auto tmp_stride = common::vectorize<int64_t>(op.tensor().strides());
+    for (size_t i = 0; i < tmp_stride.size(); i++) {
+      if (tmp_stride[i] == 0) {
+        valid_stride = false;
+        break;
+      }
+    }
+    if (!op.tensor().initialized() || !valid_stride) continue;
+    if (config.resize_outputs_ && op.is_output) continue;
+    auto shape = common::vectorize<int64_t>(op.tensor().dims());
+    if (shape.empty()) {
+      has_scalars = true;
+    } else {
+      has_tensors = true;
+    }
+    if (has_scalars && has_tensors) {
+      all_ops_same_shape_ = false;
+    }
+    if (shape_.empty()) {
+      shape_ = shape;
+    } else if (!(shape == shape_)) {
+      all_ops_same_shape_ = false;
+      shape_ = infer_size_dimvector(shape_, shape);
+    }
+  }
+  all_ops_are_scalars_ = !has_tensors;
+}
+
+void DenseTensorIteratorBase::compute_strides(
+    const DenseTensorIteratorConfig& config) {
+  for (auto& op : operands_) {
+    bool valid_stride = true;
+    auto tmp_stride = common::vectorize<int64_t>(op.tensor().strides());
+    for (size_t i = 0; i < tmp_stride.size(); i++) {
+      if (tmp_stride[i] == 0) {
+        valid_stride = false;
+        break;
+      }
+    }
+    if (op.tensor().initialized() && !op.will_resize && valid_stride) {
+      std::vector<int64_t> original_shape =
+          config.static_shape_ ? shape_
+                               : common::vectorize<int64_t>(op.tensor().dims());
+      auto original_stride = common::vectorize<int64_t>(op.tensor().strides());
+      auto element_size_in_bytes = phi::SizeOf(op.tensor().dtype());
+      auto offset = ndim() - original_shape.size();
+      if (offset > 0)
+        op.stride_bytes.resize(ndim(), 0);
+      else
+        op.stride_bytes.resize(ndim());
+      for (size_t i = 0; i < original_shape.size(); i++) {
+        if (original_shape[i] == 1 && shape_[offset + i] != 1) {
+          op.stride_bytes[offset + i] = 0;
+        } else {
+          op.stride_bytes[offset + i] =
+              original_stride[i] * element_size_in_bytes;
+        }
+      }
+    }
+  }
+}
+
+void DenseTensorIteratorBase::build(DenseTensorIteratorConfig& config) {
+  populate_operands(config);
+
+  compute_shape(config);
+
+  if (!fast_set_up(config)) {
+    compute_strides(config);
+
+    reorder_dimensions();
+
+    allocate_or_resize_outputs();
+
+    coalesce_dimensions();
+  }
+
+  for (int i = 0; i < ntensors(); i++) {
+    if (i < num_outputs_) continue;
+    auto& op = operands_[i];
+    op.data = const_cast<void*>(op.tensor().data());
+  }
+}
+
+}  // namespace phi

--- a/paddle/phi/kernels/funcs/dense_tensor_iterator.cc
+++ b/paddle/phi/kernels/funcs/dense_tensor_iterator.cc
@@ -268,8 +268,8 @@ int64_t DenseTensorIteratorBase::numel() const {
   return numel;
 }
 
-void* DenseTensorIteratorBase::data_ptr(int64_t arg) const {
-  return const_cast<void*>(operands_[arg].tensor().data());
+const void* DenseTensorIteratorBase::data_ptr(int64_t arg) const {
+  return static_cast<void*>(operands_[arg].tensor().data());
 }
 
 static inline std::vector<int64_t> infer_size_dimvector(

--- a/paddle/phi/kernels/funcs/dense_tensor_iterator.h
+++ b/paddle/phi/kernels/funcs/dense_tensor_iterator.h
@@ -45,22 +45,14 @@ struct DenseOperandInfo {
   inline ~DenseOperandInfo() = default;
 
   void* data = nullptr;
-
   std::vector<int64_t> stride_bytes;
-
   DataType target_dtype = DataType::UNDEFINED;
   DataType current_dtype = DataType::UNDEFINED;
-
-  bool is_type_defined() const { return target_dtype != DataType::UNDEFINED; }
-
   bool is_output = false;
-
   bool will_resize = false;
-
   bool is_read_write = false;
-
   bool is_const = false;
-
+  bool is_type_defined() const { return target_dtype != DataType::UNDEFINED; }
   DenseTensor& tensor() const { return *tensor_base_; }
   void tensor(DenseTensor*&& tensor);
 
@@ -70,14 +62,11 @@ struct DenseOperandInfo {
 
 struct DenseTensorIteratorBase {
   void build(DenseTensorIteratorConfig&);
-
   int ndim() const { return static_cast<int>(shape_.size()); }
   std::vector<int64_t> shape() const { return shape_; }
   int64_t numel() const;
   int ntensors() const { return static_cast<int>(operands_.size()); }
-
   bool is_contiguous() const;
-
   std::vector<int64_t> strides(int64_t arg) const {
     return operands_[arg].stride_bytes;
   }
@@ -107,7 +96,6 @@ struct DenseTensorIteratorBase {
   std::vector<DenseOperandInfo> operands_;
   std::vector<int64_t> compatible_stride(int64_t element_size) const;
   std::vector<int64_t> invert_perm(std::vector<int64_t> input) const;
-
   virtual void set_output_raw_strided(int64_t output_idx,
                                       std::vector<int64_t> sizes,
                                       std::vector<int64_t> strides);
@@ -130,7 +118,6 @@ class DenseTensorIteratorConfig final {
   friend struct DenseTensorIterator;
 
   DenseTensorIteratorConfig() = default;
-
   DenseTensorIteratorConfig(DenseTensorIteratorConfig&&) = default;
   DenseTensorIteratorConfig& operator=(DenseTensorIteratorConfig&&) = default;
   ~DenseTensorIteratorConfig() = default;

--- a/paddle/phi/kernels/funcs/dense_tensor_iterator.h
+++ b/paddle/phi/kernels/funcs/dense_tensor_iterator.h
@@ -19,8 +19,6 @@
 #include "paddle/common/ddim.h"
 #include "paddle/phi/core/dense_tensor.h"
 
-#include "glog/logging.h"
-
 namespace phi {
 
 class DenseTensorIteratorConfig;

--- a/paddle/phi/kernels/funcs/dense_tensor_iterator.h
+++ b/paddle/phi/kernels/funcs/dense_tensor_iterator.h
@@ -1,0 +1,187 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <optional>
+
+#include "paddle/common/ddim.h"
+#include "paddle/phi/core/dense_tensor.h"
+
+#include "glog/logging.h"
+
+namespace phi {
+
+class DenseTensorIteratorConfig;
+struct DenseTensorIterator;
+
+enum class FastSetupType : uint8_t { NONE, CONTIGUOUS };
+
+struct DenseOperandInfo {
+  DenseOperandInfo() = default;
+  inline explicit DenseOperandInfo(DenseTensor*&& t) {
+    if (t->initialized()) {
+      target_dtype = t->dtype();
+      current_dtype = target_dtype;
+    }
+    tensor(std::move(t));
+  }
+
+  inline DenseOperandInfo(const DenseOperandInfo&) = default;
+  inline DenseOperandInfo& operator=(const DenseOperandInfo&) = default;
+  inline DenseOperandInfo(DenseOperandInfo&&) noexcept = default;
+  inline DenseOperandInfo& operator=(DenseOperandInfo&&) noexcept = default;
+  inline ~DenseOperandInfo() = default;
+
+  void* data = nullptr;
+
+  std::vector<int64_t> stride_bytes;
+
+  DataType target_dtype = DataType::UNDEFINED;
+  DataType current_dtype = DataType::UNDEFINED;
+
+  bool is_type_defined() const { return target_dtype != DataType::UNDEFINED; }
+
+  bool is_output = false;
+
+  bool will_resize = false;
+
+  bool is_read_write = false;
+
+  bool is_const = false;
+
+  DenseTensor& tensor() const { return *tensor_base_; }
+  void tensor(DenseTensor*&& tensor);
+
+ private:
+  DenseTensor* tensor_base_;
+};
+
+struct DenseTensorIteratorBase {
+  void build(DenseTensorIteratorConfig&);
+
+  int ndim() const { return static_cast<int>(shape_.size()); }
+  std::vector<int64_t> shape() const { return shape_; }
+  int64_t numel() const;
+  int ntensors() const { return static_cast<int>(operands_.size()); }
+
+  bool is_contiguous() const;
+
+  std::vector<int64_t> strides(int64_t arg) const {
+    return operands_[arg].stride_bytes;
+  }
+  void* data_ptr(int64_t arg) const;
+
+ protected:
+  void populate_operands(DenseTensorIteratorConfig&);
+  void compute_shape(const DenseTensorIteratorConfig&);
+  void compute_strides(const DenseTensorIteratorConfig&);
+  void reorder_dimensions();
+  void permute_dimensions(std::vector<int64_t> perm);
+  void allocate_or_resize_outputs();
+  bool fast_set_up(const DenseTensorIteratorConfig&);
+  FastSetupType compute_fast_setup_type(const DenseTensorIteratorConfig&);
+  void coalesce_dimensions();
+
+ protected:
+  std::vector<int64_t> shape_;
+  std::vector<int64_t> perm_;
+  bool has_coalesced_dimensions_ = false;
+  int num_outputs_ = 0;
+  bool accumulate_ = false;
+  bool all_ops_same_shape_ = false;
+  bool all_ops_are_scalars_ = false;
+
+ public:
+  std::vector<DenseOperandInfo> operands_;
+  std::vector<int64_t> compatible_stride(int64_t element_size) const;
+  std::vector<int64_t> invert_perm(std::vector<int64_t> input) const;
+
+  virtual void set_output_raw_strided(int64_t output_idx,
+                                      std::vector<int64_t> sizes,
+                                      std::vector<int64_t> strides);
+  bool is_reduction_ = false;
+};
+
+struct DenseTensorIterator final : public DenseTensorIteratorBase {
+  DenseTensorIterator() : DenseTensorIteratorBase() {}
+  DenseTensorIterator(const DenseTensorIteratorBase& iter)
+      : DenseTensorIteratorBase(iter) {}
+
+  void set_output_raw_strided(int64_t output_idx,
+                              std::vector<int64_t> sizes,
+                              std::vector<int64_t> strides) override;
+};
+
+class DenseTensorIteratorConfig final {
+ public:
+  friend struct DenseTensorIteratorBase;
+  friend struct DenseTensorIterator;
+
+  DenseTensorIteratorConfig() = default;
+
+  DenseTensorIteratorConfig(DenseTensorIteratorConfig&&) = default;
+  DenseTensorIteratorConfig& operator=(DenseTensorIteratorConfig&&) = default;
+  ~DenseTensorIteratorConfig() = default;
+
+  DenseTensorIteratorConfig& add_output(const DenseTensor& output) {
+    return add_borrowed_output(output);
+  }
+  DenseTensorIteratorConfig& add_input(const DenseTensor& input) {
+    return add_borrowed_input(input);
+  }
+  DenseTensorIteratorConfig& add_const_input(const DenseTensor& input) {
+    return add_borrowed_const_input(input);
+  }
+
+  DenseTensorIteratorConfig& add_output(DenseTensor&& output) = delete;
+  DenseTensorIteratorConfig& add_input(DenseTensor&& input) = delete;
+  DenseTensorIteratorConfig& add_const_input(DenseTensor&& input) = delete;
+
+  DenseTensorIteratorConfig& add_borrowed_output(const DenseTensor& output);
+  DenseTensorIteratorConfig& add_borrowed_input(const DenseTensor& input);
+  DenseTensorIteratorConfig& add_borrowed_const_input(const DenseTensor& input);
+
+  DenseTensorIteratorConfig& add_borrowed_output(DenseTensor&& output) = delete;
+  DenseTensorIteratorConfig& add_borrowed_input(DenseTensor&& input) = delete;
+  DenseTensorIteratorConfig& add_borrowed_const_input(DenseTensor&& input) =
+      delete;
+
+  DenseTensorIteratorConfig& resize_outputs(bool resize_outputs) {
+    resize_outputs_ = resize_outputs;
+    return *this;
+  }
+
+  DenseTensorIterator build() {
+    DenseTensorIterator iter;
+    iter.build(*this);
+    return iter;
+  }
+
+ private:
+  std::vector<const DenseTensor*> tensors_;
+  std::vector<size_t> const_tensor_indices_;
+  int num_outputs_ = 0;
+  int num_inputs_ = 0;
+
+  std::optional<std::vector<int64_t>> static_shape_ = std::nullopt;
+  bool check_mem_overlap_ = true;
+  bool allow_cpu_scalars_ = false;
+  bool is_reduction_ = false;
+  bool resize_outputs_ = true;
+  bool check_all_same_dtype_ = true;
+  bool check_all_same_device_ = true;
+};
+
+}  // namespace phi

--- a/paddle/phi/kernels/funcs/dense_tensor_iterator.h
+++ b/paddle/phi/kernels/funcs/dense_tensor_iterator.h
@@ -21,11 +21,15 @@
 
 namespace phi {
 
-class DenseTensorIteratorConfig;
+struct DenseTensorIteratorConfig;
 struct DenseTensorIterator;
 
-enum class FastSetupType : uint8_t { NONE, CONTIGUOUS };
+enum struct FastSetupType : uint8_t { NONE, CONTIGUOUS };
 
+/**
+ * DenseOperandInfo: Used to store tensor-related information.
+ * Contains metadata and details about tensors participating in operations.
+ */
 struct DenseOperandInfo {
   DenseOperandInfo() = default;
   inline explicit DenseOperandInfo(DenseTensor*&& t) {
@@ -58,17 +62,21 @@ struct DenseOperandInfo {
   DenseTensor* tensor_base_;
 };
 
+/**
+ * DenseTensorIteratorBase: Base class for DenseTensorIterator.
+ * Defines and supports the key functions used by DenseTensorIterator.
+ */
 struct DenseTensorIteratorBase {
   void build(DenseTensorIteratorConfig&);
   int ndim() const { return static_cast<int>(shape_.size()); }
-  std::vector<int64_t> shape() const { return shape_; }
+  const std::vector<int64_t>& shape() const { return shape_; }
   int64_t numel() const;
   int ntensors() const { return static_cast<int>(operands_.size()); }
   bool is_contiguous() const;
-  std::vector<int64_t> strides(int64_t arg) const {
+  const std::vector<int64_t>& strides(int64_t arg) const {
     return operands_[arg].stride_bytes;
   }
-  void* data_ptr(int64_t arg) const;
+  const void* data_ptr(int64_t arg) const;
 
  protected:
   void populate_operands(DenseTensorIteratorConfig&);
@@ -86,7 +94,6 @@ struct DenseTensorIteratorBase {
   std::vector<int64_t> perm_;
   bool has_coalesced_dimensions_ = false;
   int num_outputs_ = 0;
-  bool accumulate_ = false;
   bool all_ops_same_shape_ = false;
   bool all_ops_are_scalars_ = false;
 
@@ -100,6 +107,11 @@ struct DenseTensorIteratorBase {
   bool is_reduction_ = false;
 };
 
+/**
+ * DenseTensorIterator: Used for preprocessing metadata of tensors participating
+ * in computation. Can be directly used as OffsetCalculator input parameter to
+ * assist with index calculations.
+ */
 struct DenseTensorIterator final : public DenseTensorIteratorBase {
   DenseTensorIterator() : DenseTensorIteratorBase() {}
   DenseTensorIterator(const DenseTensorIteratorBase& iter)
@@ -110,7 +122,24 @@ struct DenseTensorIterator final : public DenseTensorIteratorBase {
                               std::vector<int64_t> strides) override;
 };
 
-class DenseTensorIteratorConfig final {
+/**
+ * DenseTensorIteratorConfig: Used to configure tensors and computation rules
+ * for DenseTensorIterator
+ *
+ * This class configures the tensors participating in computation and the
+ * operation rules for DenseTensorIterator. Usage example:
+ *
+ * DenseTensorIteratorConfig config;
+ * // Add tensors participating in computation
+ * // Set whether to use specific methods in TensorIterator
+ * config.add_output(a);
+ * config.add_const_input(b);
+ * config.add_const_input(c);
+ *
+ * // Calculate the common broadcast shape and transformed strides for each
+ * dimension DenseTensorIterator iter = config.build();
+ */
+struct DenseTensorIteratorConfig final {
  public:
   friend struct DenseTensorIteratorBase;
   friend struct DenseTensorIterator;
@@ -161,12 +190,8 @@ class DenseTensorIteratorConfig final {
   int num_inputs_ = 0;
 
   std::optional<std::vector<int64_t>> static_shape_ = std::nullopt;
-  bool check_mem_overlap_ = true;
-  bool allow_cpu_scalars_ = false;
   bool is_reduction_ = false;
   bool resize_outputs_ = true;
-  bool check_all_same_dtype_ = true;
-  bool check_all_same_device_ = true;
 };
 
 }  // namespace phi

--- a/paddle/phi/kernels/legacy/elementwise_add_kernel.h
+++ b/paddle/phi/kernels/legacy/elementwise_add_kernel.h
@@ -25,4 +25,11 @@ void AddRawKernel(const Context& dev_ctx,
                   int axis,
                   DenseTensor* out);
 
+template <typename T, typename Context>
+void AddStrideRawKernel(const Context& dev_ctx,
+                        const DenseTensor& x,
+                        const DenseTensor& y,
+                        int axis,
+                        DenseTensor* out);
+
 }  // namespace phi

--- a/paddle/phi/kernels/legacy/elementwise_add_kernel.h
+++ b/paddle/phi/kernels/legacy/elementwise_add_kernel.h
@@ -25,11 +25,4 @@ void AddRawKernel(const Context& dev_ctx,
                   int axis,
                   DenseTensor* out);
 
-template <typename T, typename Context>
-void AddStrideRawKernel(const Context& dev_ctx,
-                        const DenseTensor& x,
-                        const DenseTensor& y,
-                        int axis,
-                        DenseTensor* out);
-
 }  // namespace phi

--- a/paddle/phi/kernels/stride/elementwise_kernel.cu
+++ b/paddle/phi/kernels/stride/elementwise_kernel.cu
@@ -1,0 +1,250 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifdef PADDLE_WITH_CUDA
+
+#include "paddle/common/flags.h"
+#include "paddle/phi/backends/gpu/gpu_context.h"
+#ifndef PADDLE_WITH_XPU_KP
+#include "paddle/phi/common/complex.h"
+#include "paddle/phi/common/float16.h"
+#endif
+#include "paddle/phi/api/lib/data_transform.h"
+#include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/contiguous_kernel.h"
+#include "paddle/phi/kernels/funcs/broadcast_function.h"
+#include "paddle/phi/kernels/funcs/dense_tensor_iterator.h"
+#include "paddle/phi/kernels/funcs/elementwise_base.h"
+#include "paddle/phi/kernels/funcs/elementwise_functor.h"
+#include "paddle/phi/kernels/funcs/index_elementwise.cu.h"
+#include "paddle/phi/kernels/impl/elementwise_kernel_impl.h"
+#include "paddle/phi/kernels/legacy/elementwise_add_kernel.h"
+
+#if defined(__NVCC__) || defined(__HIPCC__) || defined(__xpu__)
+#include "paddle/phi/kernels/funcs/dims_simplifier.h"
+
+namespace kps = phi::kps;
+
+#endif
+
+COMMON_DECLARE_bool(use_stride_kernel);
+COMMON_DECLARE_bool(use_densetensor_iterator);
+
+namespace phi {
+template <typename Functor,
+          typename OutT,
+          int Arity,
+          int NumOuts,
+          int VecSize,
+          int LoadType>
+__global__ void BinaryElementwiseKernel(
+    Array<const _ptr_ char *__restrict__, Arity> ins,
+    Array<_ptr_ OutT *, NumOuts> outs,
+    uint32_t numel,
+    int read_lens,
+    Functor func,
+    funcs::OffsetCalculator<Arity + NumOuts> offset_calc) {
+  int64_t block_offset = BLOCK_ID_X * BLOCK_NUM_X * VecSize;
+  int64_t tid = THREAD_ID_X;
+  int64_t nv = BLOCK_NUM_X * VecSize;
+  int64_t idx = nv * BLOCK_ID_X + tid;
+
+#pragma unroll
+  for (int i = 0; i < VecSize; i++) {
+    if (idx < numel) {
+      auto offsets = offset_calc.get(idx);
+      using Traits = phi::funcs::FunctionTraits<Functor>;
+      using ArgsT = typename Traits::ArgsTuple;
+      __simd__ ArgsT args[VecSize];
+      __simd__ ConditionalT<OutT, NumOuts> result[VecSize];
+
+      std::get<0>(args[idx]) =
+          *(reinterpret_cast<const _ptr_ std::tuple_element_t<0, ArgsT> *>(
+              reinterpret_cast<const _ptr_ char *>(ins[0]) + offsets[1]));
+
+      std::get<1>(args[idx]) =
+          *(reinterpret_cast<const _ptr_ std::tuple_element_t<1, ArgsT> *>(
+              reinterpret_cast<const _ptr_ char *>(ins[1]) + offsets[2]));
+
+      funcs::SameDimsElementwisePrimitiveCaller<ConditionalT<OutT, NumOuts>,
+                                                VecSize,
+                                                Functor,
+                                                ArgsT,
+                                                Arity>()(
+          func, args, result, read_lens);
+
+      char *out_ptr = reinterpret_cast<char *>(outs[0]) + offsets[0];
+
+      *reinterpret_cast<OutT *>(out_ptr) =
+          *reinterpret_cast<const OutT *>(&(result[0]));
+
+      idx += BLOCK_NUM_X;
+    }
+  }
+}
+
+template <typename OutT, typename Functor, int NumOuts = 1>
+void StrideBroadcastKernel(const KPDevice &dev_ctx,
+                           const std::vector<const DenseTensor *> &ins,
+                           std::vector<DenseTensor *> *outs,
+                           Functor func,
+                           int axis = -1) {
+  using Traits = phi::funcs::FunctionTraits<Functor>;
+  const int Arity = Traits::arity;
+
+  for (auto i = 0; i < outs->size(); ++i) {
+    if (i > 0) {
+      PADDLE_ENFORCE_EQ(
+          (*outs)[i]->dims(),
+          (*outs)[0]->dims(),
+          common::errors::InvalidArgument(
+              "The shape of each output tensor shall be identical yet, but "
+              "%d-th output tensor`s shape is not.",
+              i));
+    }
+    dev_ctx.template Alloc<OutT>((*outs)[i]);
+  }
+  if ((*outs)[0]->numel() == 0) {
+    return;
+  }
+
+  int max_rank = 0;
+  int min_rank = phi::DDim::kMaxRank;
+  for (auto *in : ins) {
+    max_rank = std::max(max_rank, in->dims().size());
+    min_rank = std::min(min_rank, in->dims().size());
+  }
+  if (ins.size() == 1) {
+    max_rank = std::max(max_rank, (*outs)[0]->dims().size());
+  }
+  axis = axis == -1 ? max_rank - min_rank : axis;
+
+  auto classifier =
+      funcs::BroadcastTypeClassifier<OutT, Functor, Arity, NumOuts>(
+          ins, outs, axis);
+
+  DenseTensorIteratorConfig config;
+  config.add_output(*((*outs)[0]));
+  config.add_const_input(*(ins[0]));
+  config.add_const_input(*(ins[1]));
+  DenseTensorIterator iter = config.build();
+
+  const int &numel = iter.numel();
+
+  funcs::OffsetCalculator offset_calc = funcs::make_offset_calculator<3>(iter);
+
+  constexpr int unroll_factor = sizeof(OutT) >= 4 ? 2 : 4;
+
+  auto stream = dev_ctx.stream();
+  auto threads = 128;
+  auto blocks = (numel + 128 * unroll_factor - 1) / (128 * unroll_factor);
+
+  // Support Vectorized Kernel
+  int vec_size = 1;
+  int main_offset = (numel / (vec_size * threads)) * vec_size * threads;
+
+  BinaryElementwiseKernel<Functor, OutT, Arity, NumOuts, 1, funcs::kElementwise>
+      <<<blocks, threads, 0, stream>>>(classifier.ins_data,
+                                       classifier.outs_data,
+                                       numel,
+                                       vec_size,
+                                       func,
+                                       offset_calc);
+}
+
+template <typename T, typename Context>
+void AddStrideRawKernel(const Context &dev_ctx,
+                        const DenseTensor &x,
+                        const DenseTensor &y,
+                        int axis,
+                        DenseTensor *out) {
+  std::vector<const DenseTensor *> inputs = {&x, &y};
+  std::vector<DenseTensor *> outputs = {out};
+  dev_ctx.template Alloc<T>(out);
+  StrideBroadcastKernel<T>(
+      dev_ctx, inputs, &outputs, funcs::AddFunctor<T>(), axis);
+}
+
+template <typename T, typename Context>
+void AddStrideKernel(const Context &dev_ctx,
+                     const DenseTensor &x,
+                     const DenseTensor &y,
+                     DenseTensor *out) {
+  if (!FLAGS_use_stride_kernel) {
+    PADDLE_THROW(common::errors::Fatal(
+        "FLAGS_use_stride_kernel is closed. Strided kernel "
+        "be called, something wrong has happened!"));
+  }
+  DenseTensor x_;
+  DenseTensor y_;
+
+  if (!FLAGS_use_densetensor_iterator) {
+    if (!x.meta().is_contiguous()) {
+      x_ = paddle::experimental::Trans2Contiguous(x);
+    } else {
+      x_ = x;
+    }
+    if (!y.meta().is_contiguous()) {
+      y_ = paddle::experimental::Trans2Contiguous(y);
+    } else {
+      y_ = y;
+    }
+  } else {
+    x_ = x;
+    y_ = y;
+  }
+
+  if (x_.meta().is_contiguous() && y_.meta().is_contiguous()) {
+    auto meta = out->meta();
+    meta.strides = meta.calc_strides(out->dims());
+    out->set_meta(meta);
+
+    phi::AddKernel<T, Context>(dev_ctx, x_, y_, out);
+    return;
+  }
+
+  if (!FLAGS_use_densetensor_iterator) {
+    PADDLE_THROW(
+        common::errors::Fatal("FLAGS_use_densetensor_iterator is closed. "
+                              "Kernel using DenseTensorIterator "
+                              "be called, something wrong has happened!"));
+  }
+  phi::AddStrideRawKernel<T, Context>(dev_ctx, x_, y_, -1, out);
+}
+
+}  // namespace phi
+
+using float16 = phi::dtype::float16;
+using bfloat16 = phi::dtype::bfloat16;
+using complex64 = ::phi::dtype::complex<float>;
+using complex128 = ::phi::dtype::complex<double>;
+
+PD_REGISTER_KERNEL(add,
+                   GPU,
+                   STRIDED,
+                   phi::AddStrideKernel,
+                   float,
+                   double,
+                   int16_t,
+                   int,
+                   bool,
+                   uint8_t,
+                   int8_t,
+                   int64_t,
+                   phi::dtype::float16,
+                   phi::dtype::bfloat16,
+                   complex64,
+                   complex128) {}
+
+#endif

--- a/paddle/phi/kernels/stride/elementwise_kernel.cu
+++ b/paddle/phi/kernels/stride/elementwise_kernel.cu
@@ -16,11 +16,6 @@
 
 #include "paddle/common/flags.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
-#ifndef PADDLE_WITH_XPU_KP
-#include "paddle/phi/common/complex.h"
-#include "paddle/phi/common/float16.h"
-#endif
-#include "paddle/phi/api/lib/data_transform.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/contiguous_kernel.h"
 #include "paddle/phi/kernels/elementwise_add_kernel.h"
@@ -163,6 +158,17 @@ void LaunchBinaryElementwiseStrideKernel(const Context &dev_ctx,
       dev_ctx, inputs, &outputs, func, axis);
 }
 
+template <typename T, typename Context>
+phi::DenseTensor Tensor2Contiguous(const Context &dev_ctx,
+                                   const phi::DenseTensor &tensor) {
+  phi::DenseTensor dense_out;
+  phi::MetaTensor meta_input(tensor);
+  phi::MetaTensor meta_out(&dense_out);
+  UnchangedInferMeta(meta_input, &meta_out);
+  phi::ContiguousKernel<T, Context>(dev_ctx, tensor, &dense_out);
+  return dense_out;
+}
+
 #define DEFINE_CUDA_BINARY_ELEMENTWISE_STRIDE_OP(name)                        \
   template <typename T, typename Context>                                     \
   void name##StrideKernel(const Context &dev_ctx,                             \
@@ -179,12 +185,12 @@ void LaunchBinaryElementwiseStrideKernel(const Context &dev_ctx,
     if (!FLAGS_use_stride_compute_kernel || x.offset() != 0 ||                \
         y.offset() != 0) {                                                    \
       if (!x.meta().is_contiguous() || x.offset() != 0) {                     \
-        x_ = paddle::experimental::Trans2Contiguous(x);                       \
+        x_ = Tensor2Contiguous<T, Context>(dev_ctx, x);                       \
       } else {                                                                \
         x_ = x;                                                               \
       }                                                                       \
       if (!y.meta().is_contiguous() || y.offset() != 0) {                     \
-        y_ = paddle::experimental::Trans2Contiguous(y);                       \
+        y_ = Tensor2Contiguous<T, Context>(dev_ctx, y);                       \
       } else {                                                                \
         y_ = y;                                                               \
       }                                                                       \

--- a/paddle/phi/kernels/stride/elementwise_kernel.cu
+++ b/paddle/phi/kernels/stride/elementwise_kernel.cu
@@ -64,23 +64,19 @@ __global__ void BinaryElementwiseKernel(
       using ArgsT = typename Traits::ArgsTuple;
       __simd__ ArgsT args[VecSize];
       __simd__ ConditionalT<OutT, NumOuts> result[VecSize];
-
       std::get<0>(args[idx]) =
           *(reinterpret_cast<const _ptr_ std::tuple_element_t<0, ArgsT> *>(
               reinterpret_cast<const _ptr_ char *>(ins[0]) + offsets[1]));
       std::get<1>(args[idx]) =
           *(reinterpret_cast<const _ptr_ std::tuple_element_t<1, ArgsT> *>(
               reinterpret_cast<const _ptr_ char *>(ins[1]) + offsets[2]));
-
       funcs::SameDimsElementwisePrimitiveCaller<ConditionalT<OutT, NumOuts>,
                                                 VecSize,
                                                 Functor,
                                                 ArgsT,
                                                 Arity>()(
           func, args, result, read_lens);
-
       char *out_ptr = reinterpret_cast<char *>(outs[0]) + offsets[0];
-
       *reinterpret_cast<OutT *>(out_ptr) =
           *reinterpret_cast<const OutT *>(&(result[0]));
       idx += BLOCK_NUM_X;

--- a/paddle/phi/kernels/stride/elementwise_kernel.cu
+++ b/paddle/phi/kernels/stride/elementwise_kernel.cu
@@ -47,7 +47,7 @@ template <typename Functor,
           int Arity,
           int NumOuts,
           int VecSize,
-          int LoadType>
+          int vt>
 __global__ void BinaryElementwiseKernel(
     Array<const _ptr_ char *__restrict__, Arity> ins,
     Array<_ptr_ OutT *, NumOuts> outs,
@@ -55,13 +55,12 @@ __global__ void BinaryElementwiseKernel(
     int read_lens,
     Functor func,
     funcs::OffsetCalculator<Arity + NumOuts> offset_calc) {
-  int64_t block_offset = BLOCK_ID_X * BLOCK_NUM_X * VecSize;
   int64_t tid = THREAD_ID_X;
-  int64_t nv = BLOCK_NUM_X * VecSize;
+  int64_t nv = BLOCK_NUM_X * vt;
   int64_t idx = nv * BLOCK_ID_X + tid;
 
 #pragma unroll
-  for (int i = 0; i < VecSize; i++) {
+  for (int i = 0; i < vt; i++) {
     if (idx < numel) {
       auto offsets = offset_calc.get(idx);
       using Traits = phi::funcs::FunctionTraits<Functor>;
@@ -154,7 +153,7 @@ void StrideBroadcastKernel(const KPDevice &dev_ctx,
   int vec_size = 1;
   int main_offset = (numel / (vec_size * threads)) * vec_size * threads;
 
-  BinaryElementwiseKernel<Functor, OutT, Arity, NumOuts, 1, funcs::kElementwise>
+  BinaryElementwiseKernel<Functor, OutT, Arity, NumOuts, 1, unroll_factor>
       <<<blocks, threads, 0, stream>>>(classifier.ins_data,
                                        classifier.outs_data,
                                        numel,

--- a/paddle/phi/kernels/stride/elementwise_kernel.cu
+++ b/paddle/phi/kernels/stride/elementwise_kernel.cu
@@ -23,23 +23,21 @@
 #include "paddle/phi/api/lib/data_transform.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/contiguous_kernel.h"
+#include "paddle/phi/kernels/elementwise_add_kernel.h"
 #include "paddle/phi/kernels/funcs/broadcast_function.h"
 #include "paddle/phi/kernels/funcs/dense_tensor_iterator.h"
 #include "paddle/phi/kernels/funcs/elementwise_base.h"
 #include "paddle/phi/kernels/funcs/elementwise_functor.h"
 #include "paddle/phi/kernels/funcs/index_elementwise.cu.h"
 #include "paddle/phi/kernels/impl/elementwise_kernel_impl.h"
-#include "paddle/phi/kernels/legacy/elementwise_add_kernel.h"
 
 #if defined(__NVCC__) || defined(__HIPCC__) || defined(__xpu__)
 #include "paddle/phi/kernels/funcs/dims_simplifier.h"
 
-namespace kps = phi::kps;
-
 #endif
 
 COMMON_DECLARE_bool(use_stride_kernel);
-COMMON_DECLARE_bool(use_densetensor_iterator);
+COMMON_DECLARE_bool(use_stride_compute_kernel);
 
 namespace phi {
 template <typename Functor,
@@ -58,7 +56,6 @@ __global__ void BinaryElementwiseKernel(
   int64_t tid = THREAD_ID_X;
   int64_t nv = BLOCK_NUM_X * vt;
   int64_t idx = nv * BLOCK_ID_X + tid;
-
 #pragma unroll
   for (int i = 0; i < vt; i++) {
     if (idx < numel) {
@@ -71,7 +68,6 @@ __global__ void BinaryElementwiseKernel(
       std::get<0>(args[idx]) =
           *(reinterpret_cast<const _ptr_ std::tuple_element_t<0, ArgsT> *>(
               reinterpret_cast<const _ptr_ char *>(ins[0]) + offsets[1]));
-
       std::get<1>(args[idx]) =
           *(reinterpret_cast<const _ptr_ std::tuple_element_t<1, ArgsT> *>(
               reinterpret_cast<const _ptr_ char *>(ins[1]) + offsets[2]));
@@ -87,21 +83,22 @@ __global__ void BinaryElementwiseKernel(
 
       *reinterpret_cast<OutT *>(out_ptr) =
           *reinterpret_cast<const OutT *>(&(result[0]));
-
       idx += BLOCK_NUM_X;
     }
   }
 }
 
-template <typename OutT, typename Functor, int NumOuts = 1>
-void StrideBroadcastKernel(const KPDevice &dev_ctx,
-                           const std::vector<const DenseTensor *> &ins,
-                           std::vector<DenseTensor *> *outs,
-                           Functor func,
-                           int axis = -1) {
+// Not Support Vectorized Kernel For Now
+#define VEC_SIZE 1
+
+template <typename OutT, typename Context, typename Functor, int NumOuts = 1>
+void BinaryStrideBroadcastKernel(const Context &dev_ctx,
+                                 const std::vector<const DenseTensor *> &ins,
+                                 std::vector<DenseTensor *> *outs,
+                                 Functor func,
+                                 int axis = -1) {
   using Traits = phi::funcs::FunctionTraits<Functor>;
   const int Arity = Traits::arity;
-
   for (auto i = 0; i < outs->size(); ++i) {
     if (i > 0) {
       PADDLE_ENFORCE_EQ(
@@ -117,7 +114,6 @@ void StrideBroadcastKernel(const KPDevice &dev_ctx,
   if ((*outs)[0]->numel() == 0) {
     return;
   }
-
   int max_rank = 0;
   int min_rank = phi::DDim::kMaxRank;
   for (auto *in : ins) {
@@ -128,32 +124,27 @@ void StrideBroadcastKernel(const KPDevice &dev_ctx,
     max_rank = std::max(max_rank, (*outs)[0]->dims().size());
   }
   axis = axis == -1 ? max_rank - min_rank : axis;
-
   auto classifier =
       funcs::BroadcastTypeClassifier<OutT, Functor, Arity, NumOuts>(
           ins, outs, axis);
-
   DenseTensorIteratorConfig config;
   config.add_output(*((*outs)[0]));
   config.add_const_input(*(ins[0]));
   config.add_const_input(*(ins[1]));
   DenseTensorIterator iter = config.build();
-
   const int &numel = iter.numel();
-
   funcs::OffsetCalculator offset_calc = funcs::make_offset_calculator<3>(iter);
-
   constexpr int unroll_factor = sizeof(OutT) >= 4 ? 2 : 4;
-
   auto stream = dev_ctx.stream();
   auto threads = 128;
   auto blocks = (numel + 128 * unroll_factor - 1) / (128 * unroll_factor);
-
-  // Support Vectorized Kernel
-  int vec_size = 1;
-  int main_offset = (numel / (vec_size * threads)) * vec_size * threads;
-
-  BinaryElementwiseKernel<Functor, OutT, Arity, NumOuts, 1, unroll_factor>
+  int vec_size = VEC_SIZE;
+  BinaryElementwiseKernel<Functor,
+                          OutT,
+                          Arity,
+                          NumOuts,
+                          VEC_SIZE,
+                          unroll_factor>
       <<<blocks, threads, 0, stream>>>(classifier.ins_data,
                                        classifier.outs_data,
                                        numel,
@@ -162,65 +153,67 @@ void StrideBroadcastKernel(const KPDevice &dev_ctx,
                                        offset_calc);
 }
 
-template <typename T, typename Context>
-void AddStrideRawKernel(const Context &dev_ctx,
-                        const DenseTensor &x,
-                        const DenseTensor &y,
-                        int axis,
-                        DenseTensor *out) {
+template <typename T, typename Context, typename Functor>
+void LaunchBinaryElementwiseStrideKernel(const Context &dev_ctx,
+                                         const DenseTensor &x,
+                                         const DenseTensor &y,
+                                         Functor func,
+                                         int axis,
+                                         DenseTensor *out) {
   std::vector<const DenseTensor *> inputs = {&x, &y};
   std::vector<DenseTensor *> outputs = {out};
   dev_ctx.template Alloc<T>(out);
-  StrideBroadcastKernel<T>(
-      dev_ctx, inputs, &outputs, funcs::AddFunctor<T>(), axis);
+  BinaryStrideBroadcastKernel<T, Context>(
+      dev_ctx, inputs, &outputs, func, axis);
 }
 
-template <typename T, typename Context>
-void AddStrideKernel(const Context &dev_ctx,
-                     const DenseTensor &x,
-                     const DenseTensor &y,
-                     DenseTensor *out) {
-  if (!FLAGS_use_stride_kernel) {
-    PADDLE_THROW(common::errors::Fatal(
-        "FLAGS_use_stride_kernel is closed. Strided kernel "
-        "be called, something wrong has happened!"));
+#define DEFINE_CUDA_BINARY_ELEMENTWISE_STRIDE_OP(name)                        \
+  template <typename T, typename Context>                                     \
+  void name##StrideKernel(const Context &dev_ctx,                             \
+                          const DenseTensor &x,                               \
+                          const DenseTensor &y,                               \
+                          DenseTensor *out) {                                 \
+    if (!FLAGS_use_stride_kernel) {                                           \
+      PADDLE_THROW(common::errors::Fatal(                                     \
+          "FLAGS_use_stride_kernel is closed. Strided kernel "                \
+          "be called, something wrong has happened!"));                       \
+    }                                                                         \
+    DenseTensor x_;                                                           \
+    DenseTensor y_;                                                           \
+    if (!FLAGS_use_stride_compute_kernel || x.offset() != 0 ||                \
+        y.offset() != 0) {                                                    \
+      if (!x.meta().is_contiguous() || x.offset() != 0) {                     \
+        x_ = paddle::experimental::Trans2Contiguous(x);                       \
+      } else {                                                                \
+        x_ = x;                                                               \
+      }                                                                       \
+      if (!y.meta().is_contiguous() || y.offset() != 0) {                     \
+        y_ = paddle::experimental::Trans2Contiguous(y);                       \
+      } else {                                                                \
+        y_ = y;                                                               \
+      }                                                                       \
+    } else {                                                                  \
+      x_ = x;                                                                 \
+      y_ = y;                                                                 \
+    }                                                                         \
+    if (x_.meta().is_contiguous() && y_.meta().is_contiguous()) {             \
+      auto meta = out->meta();                                                \
+      meta.strides = meta.calc_strides(out->dims());                          \
+      out->set_meta(meta);                                                    \
+      phi::name##Kernel<T, Context>(dev_ctx, x_, y_, out);                    \
+      return;                                                                 \
+    }                                                                         \
+    if (!FLAGS_use_stride_compute_kernel) {                                   \
+      PADDLE_THROW(                                                           \
+          common::errors::Fatal("FLAGS_use_stride_compute_kernel is closed. " \
+                                "Kernel using DenseTensorIterator "           \
+                                "be called, something wrong has happened!")); \
+    }                                                                         \
+    LaunchBinaryElementwiseStrideKernel<T, Context>(                          \
+        dev_ctx, x_, y_, funcs::name##Functor<T>(), -1, out);                 \
   }
-  DenseTensor x_;
-  DenseTensor y_;
 
-  if (!FLAGS_use_densetensor_iterator) {
-    if (!x.meta().is_contiguous()) {
-      x_ = paddle::experimental::Trans2Contiguous(x);
-    } else {
-      x_ = x;
-    }
-    if (!y.meta().is_contiguous()) {
-      y_ = paddle::experimental::Trans2Contiguous(y);
-    } else {
-      y_ = y;
-    }
-  } else {
-    x_ = x;
-    y_ = y;
-  }
-
-  if (x_.meta().is_contiguous() && y_.meta().is_contiguous()) {
-    auto meta = out->meta();
-    meta.strides = meta.calc_strides(out->dims());
-    out->set_meta(meta);
-
-    phi::AddKernel<T, Context>(dev_ctx, x_, y_, out);
-    return;
-  }
-
-  if (!FLAGS_use_densetensor_iterator) {
-    PADDLE_THROW(
-        common::errors::Fatal("FLAGS_use_densetensor_iterator is closed. "
-                              "Kernel using DenseTensorIterator "
-                              "be called, something wrong has happened!"));
-  }
-  phi::AddStrideRawKernel<T, Context>(dev_ctx, x_, y_, -1, out);
-}
+DEFINE_CUDA_BINARY_ELEMENTWISE_STRIDE_OP(Add)
 
 }  // namespace phi
 

--- a/paddle/phi/kernels/stride/elementwise_kernel.cu
+++ b/paddle/phi/kernels/stride/elementwise_kernel.cu
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef PADDLE_WITH_CUDA
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
 
 #include "paddle/common/flags.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"

--- a/test/legacy_test/test_elementwise_add_op.py
+++ b/test/legacy_test/test_elementwise_add_op.py
@@ -1167,10 +1167,7 @@ class TestElementwiseAddOp_Stride(TestElementwiseAddOp):
         self.outputs = {'Out': self.out}
 
     def test_check_output(self):
-        # TODO(wangzhongpu): support onednn op in dygraph mode
-        self.check_output(
-            check_dygraph=True,
-        )
+        self.check_output()
 
     def init_input_output(self):
         self.strided_input_type = "transpose"

--- a/test/legacy_test/test_elementwise_add_op.py
+++ b/test/legacy_test/test_elementwise_add_op.py
@@ -1242,6 +1242,26 @@ class TestElementwiseAddOp_Stride5(TestElementwiseAddOp_Stride):
         self.stride_param = [520, 260, 20, 1]
 
 
+class TestElementwiseAddOp_Stride_ZeroDim1(TestElementwiseAddOp_Stride):
+    def init_input_output(self):
+        self.strided_input_type = "transpose"
+        self.x = np.random.uniform(0.1, 1, []).astype(self.dtype)
+        self.y = np.random.uniform(0.1, 1, [13, 17]).astype(self.dtype)
+        self.out = np.add(self.x, self.y)
+        self.perm = [1, 0]
+        self.y_trans = np.transpose(self.y, self.perm)
+
+
+class TestElementwiseAddOp_Stride_ZeroSize1(TestElementwiseAddOp_Stride):
+    def init_data(self):
+        self.strided_input_type = "transpose"
+        self.x = np.random.rand(1, 0, 2).astype('float32')
+        self.y = np.random.rand(3, 0, 1).astype('float32')
+        self.out = np.add(self.x, self.y)
+        self.perm = [2, 1, 0]
+        self.y_trans = np.transpose(self.y, self.perm)
+
+
 if __name__ == '__main__':
     paddle.enable_static()
     unittest.main()

--- a/test/legacy_test/test_elementwise_add_op.py
+++ b/test/legacy_test/test_elementwise_add_op.py
@@ -1137,6 +1137,111 @@ class TestElementwiseAddOpAutoParallelXYShardBroadcast(
         self.out = np.add(self.x, self.y)
 
 
+@unittest.skipIf(
+    not core.is_compiled_with_cuda(), "core is not compiled with CUDA"
+)
+class TestElementwiseAddOp_Stride(TestElementwiseAddOp):
+    def setUp(self):
+        self.op_type = "elementwise_add"
+        self.python_api = paddle.add
+        self.public_python_api = paddle.add
+        self.transpose_api = paddle.transpose
+        self.as_stride_api = paddle.as_strided
+        self.check_strided_input = True
+        self.init_dtype()
+        self.init_input_output()
+        self.init_kernel_type()
+        self.init_axis()
+
+        self.attrs = {'axis': self.axis, 'use_onednn': self.use_onednn}
+
+        self.inputs = {
+            'X': OpTest.np_dtype_to_base_dtype(self.x),
+            'Y': OpTest.np_dtype_to_base_dtype(self.y),
+        }
+
+        self.inputs_stride = {
+            'X': OpTest.np_dtype_to_base_dtype(self.x),
+            'Y': OpTest.np_dtype_to_base_dtype(self.y_trans),
+        }
+        self.outputs = {'Out': self.out}
+
+    def test_check_output(self):
+        # TODO(wangzhongpu): support onednn op in dygraph mode
+        self.check_output(
+            check_dygraph=True,
+        )
+
+    def init_input_output(self):
+        self.strided_input_type = "transpose"
+        self.x = np.random.uniform(0.1, 1, [13, 17]).astype(self.dtype)
+        self.y = np.random.uniform(0.1, 1, [13, 17]).astype(self.dtype)
+        self.out = np.add(self.x, self.y)
+        self.perm = [1, 0]
+        self.y_trans = np.transpose(self.y, self.perm)
+
+    def test_check_grad_normal(self):
+        pass
+
+    def test_check_grad_ignore_x(self):
+        pass
+
+    def test_check_grad_ignore_y(self):
+        pass
+
+
+class TestElementwiseAddOp_Stride1(TestElementwiseAddOp_Stride):
+    def init_input_output(self):
+        self.strided_input_type = "transpose"
+        self.x = np.random.uniform(0.1, 1, [20, 2, 13, 17]).astype(self.dtype)
+        self.y = np.random.uniform(0.1, 1, [20, 2, 13, 17]).astype(self.dtype)
+        self.out = np.add(self.x, self.y)
+        self.perm = [0, 1, 3, 2]
+        self.y_trans = np.transpose(self.y, self.perm)
+
+
+class TestElementwiseAddOp_Stride2(TestElementwiseAddOp_Stride):
+    def init_input_output(self):
+        self.strided_input_type = "transpose"
+        self.x = np.random.uniform(0.1, 1, [20, 2, 13, 17]).astype(self.dtype)
+        self.y = np.random.uniform(0.1, 1, [20, 2, 13, 17]).astype(self.dtype)
+        self.out = np.add(self.x, self.y)
+        self.perm = [0, 2, 1, 3]
+        self.y_trans = np.transpose(self.y, self.perm)
+
+
+class TestElementwiseAddOp_Stride3(TestElementwiseAddOp_Stride):
+    def init_input_output(self):
+        self.strided_input_type = "transpose"
+        self.x = np.random.uniform(0.1, 1, [20, 2, 13, 17]).astype(self.dtype)
+        self.y = np.random.uniform(0.1, 1, [20, 2, 13, 1]).astype(self.dtype)
+        self.out = np.add(self.x, self.y)
+        self.perm = [0, 1, 3, 2]
+        self.y_trans = np.transpose(self.y, self.perm)
+
+
+class TestElementwiseAddOp_Stride4(TestElementwiseAddOp_Stride):
+    def init_input_output(self):
+        self.strided_input_type = "transpose"
+        self.x = np.random.uniform(0.1, 1, [1, 2, 13, 17]).astype(self.dtype)
+        self.y = np.random.uniform(0.1, 1, [20, 2, 13, 1]).astype(self.dtype)
+        self.out = np.add(self.x, self.y)
+        self.perm = [1, 0, 2, 3]
+        self.y_trans = np.transpose(self.y, self.perm)
+
+
+class TestElementwiseAddOp_Stride5(TestElementwiseAddOp_Stride):
+    def init_input_output(self):
+        self.strided_input_type = "as_stride"
+        self.x = np.random.uniform(0.1, 1, [23, 10, 1, 17]).astype(self.dtype)
+        self.y = np.random.uniform(0.1, 1, [23, 2, 13, 20]).astype(self.dtype)
+        self.y_trans = self.y
+        self.y = self.y[:, 0:1, :, 0:1]
+        self.out = np.add(self.x, self.y)
+        self.shape_param = [23, 1, 13, 1]
+        self.stride_param = [520, 260, 20, 1]
+
+
 if __name__ == '__main__':
     paddle.enable_static()
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
pcard-67164

# PR简介：基于DenseTensorIterator的算子计算机制优化

## 一、简介

本PR以Paddle DenseTensor数据结构为基础，设计并实现了基于**DenseTensorIterator**的算子计算机制，用于在处理非连续输入时获得性能提升/显存占用降低以及正确性生态对齐。

## 二、整体设计

<img width="2426" height="2975" alt="流程图-202508181405 (1)" src="https://github.com/user-attachments/assets/9c85895d-5aa7-4d39-9d63-c59f75b84c41" />

## 三、实现方法

本PR主要实现了设计中的**Paddle TensorIterator**以及其相关的**通用CUDA Stride Kernel**部分，通过以上实现确保了elementwise_add算子性能及正确性提升，下面由上到下讲解具体实现。

### 1. Strided Kernel

该部分需要注册并实现一个GPU上的stride kernel。

- **实现位置**: `paddle/phi/kernels/stride/elementwise_kernel.cu`
- **实现方法**: 使用`PD_REGISTER_KERNEL`进行定义，并在`elementwise_kernel.cu`中实现
- **函数命名规则**: `XXStrideKernel`
- **扩展机制**: 为方便后续扩量生成StrideKernel，已使用宏语言编程方式做了处理，后续只需要通过例如`DEFINE_CUDA_BINARY_ELEMENTWISE_STRIDE_OP(Add)`的方式生成函数即可

### 2. Risk Control (Flag)

该部分需要实现一个用于风险管理的Flag，预防新增功能不稳定带来的正确性以及性能影响。

- **实现位置**: `paddle/common/flags.cc`
- **Flag名称**: `FLAGS_use_stride_compute_kernel`
- **使用方式**: 
 - 当使用`FLAGS_use_stride_compute_kernel=1`运行Paddle程序时，Kernel会分派到新的实现方法，直接处理非连续输入运算
 - 反之则会回退到之前版本，先将输入变连续再进行运算

### 3. Paddle TensorIterator (DenseTensorIterator)

该部分需要实现一个对任意张量进行运算前预处理的类，目前命名为**DenseTensorIterator**。

- **实现位置**: 
 - `paddle/phi/kernels/funcs/dense_tensor_iterator.cc`
 - `paddle/phi/kernels/funcs/dense_tensor_iterator.h`
- **主要功能**: DenseTensorIterator保证了张量进入通用CUDA kernel前拥有最佳的shape/stride以供后续运算，同时保证了输出张量的连续性与生态对齐

### 4. CUDA strided_kernel_impl

该部分需要实现一个通用的CUDA kernel，用于处理DenseTensorIterator给出的shape和stride，并按照Functor的定义完成运算。

- **实现位置**: `paddle/phi/kernels/stride/elementwise_kernel.cu`
- **实现方法**: 使用Slice优化时引入的`OffsetCalculator`进行index计算，之后复用KP中的Functor相关实现进行运算
- **编译优化**: 为了保证不带来过多的编译体积增加，本PR去除了KP相关的模版，只保留type以及Functor相关模版，保证了编译体积可控

## 四、相关影响

### 1. 正确性影响

当`FLAGS_use_stride_compute_kernel=1`时，elementwise_add将按照如下规则进行输出处理：

对于两个参与二元Elementwise操作的操作数，一个必要的前提是需要将两个操作数能广播到一个共同的尺寸上，我们定义这个尺寸为**广播尺寸**。

- 如果两个操作数的尺寸都为广播尺寸，那么输出的stride由第一个操作数决定（按顺序决定）
- 如果其中一个操作数需要广播到广播尺寸，那么输出的stride由与广播尺寸相同的操作数决定（与顺序无关）

当`FLAGS_use_stride_compute_kernel=0`时，elementwise_add将全输出连续张量。

### 2. 性能影响

#### Transpose + Add 性能测试

| Shape | Before (μs) | After (μs) | Improvement |
|-------|------------|------------|-------------|
| 64×108×12288 | 2262.79 | 1243.12 | **81.9% faster** |

#### As_strided + Add 性能测试

| Shape | Before (μs) | After (μs) | Improvement |
|-------|------------|------------|-------------|
| 54×32×12288 | 651.61 | 451.13 | **44.3% faster** |

## 五、风险管理

为保证`FLAGS_use_stride_compute_kernel=1`后正确性可以保证，对elementwise_add新增了单测。

- **单测位置**: `test/legacy_test/test_elementwise_add_op.py`
- **覆盖场景**: 单测覆盖了transpose/as_strided、广播、0dim、0size等多种情况，最大限度保证了正确性