### PR TITLE
Improve PowKernel and PowGradKernel for GPU

### DIFF
--- a/paddle/phi/common/amp_type_traits.h
+++ b/paddle/phi/common/amp_type_traits.h
@@ -15,6 +15,7 @@ limitations under the License. */
 #pragma once
 
 #include "paddle/phi/common/bfloat16.h"
+#include "paddle/phi/common/complex.h"
 #include "paddle/phi/common/float16.h"
 #include "paddle/phi/common/float8_e4m3fn.h"
 #include "paddle/phi/common/float8_e5m2.h"
@@ -50,6 +51,11 @@ template <>
 class MPTypeTrait<phi::dtype::float8_e5m2> {
  public:
   using Type = float;
+};
+
+template <>
+struct MPTypeTrait<phi::dtype::complex<float16>> {
+  using type = phi::dtype::complex<float>;
 };
 
 }  // namespace dtype

--- a/paddle/phi/kernels/funcs/activation_functor.h
+++ b/paddle/phi/kernels/funcs/activation_functor.h
@@ -5501,36 +5501,38 @@ __device__ __forceinline__
   return llrint(pow(static_cast<double>(a), b));
 }
 
-template <typename T>
+template <typename T, typename MPType>
 __device__ __forceinline__
-    typename std::enable_if<!std::is_integral<T>::value, double>::type
-    compute_pow(const T a, const double b) {
-  return pow(static_cast<double>(a), b);
+    typename std::enable_if<!std::is_integral<T>::value, MPType>::type
+    compute_pow(const T a, const MPType b) {
+  return pow(static_cast<MPType>(a), b);
 }
 
-template <typename T>
+template <typename T, typename MPType>
 __device__ __forceinline__ typename std::enable_if<!std::is_integral<T>::value,
-                                                   ComplexType<double>>::type
-compute_pow(const ComplexType<T> a, const ComplexType<double> b) {
-  return pow(static_cast<ComplexType<double>>(a), b);
+                                                   ComplexType<MPType>>::type
+compute_pow(const ComplexType<T> a, const ComplexType<MPType> b) {
+  return pow(static_cast<ComplexType<MPType>>(a), b);
 }
 
 template <typename T>
 struct BaseCudaPowFunctor : public BaseActivationFunctor<T> {
-  double factor;
+  using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
+  MPType factor;
   typename BaseActivationFunctor<T>::AttrPair GetAttrs() {
     return {{"factor", &factor}};
   }
-  void SetFactor(double factor) { this->factor = factor; }
+  void SetFactor(double factor) { this->factor = static_cast<MPType>(factor); }
 };
 
 template <typename T>
 struct BaseCudaPowGradFunctor : public BaseActivationFunctor<T> {
-  double factor;
+  using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
+  MPType factor;
   typename BaseActivationFunctor<T>::AttrPair GetAttrs() {
     return {{"factor", &factor}};
   }
-  void SetFactor(double factor) { this->factor = factor; }
+  void SetFactor(double factor) { this->factor = static_cast<MPType>(factor); }
   static constexpr ActBwdOpFwdDeps FwdDeps() { return ActBwdOpFwdDeps::kDepX; }
 };
 
@@ -5538,16 +5540,6 @@ template <typename T>
 struct CudaPowFunctor : public BaseCudaPowFunctor<T> {
   __device__ __forceinline__ T operator()(const T x) const {
     return static_cast<T>(compute_pow(x, this->factor));
-  }
-};
-
-template <typename T>
-struct CudaPowFunctor<ComplexType<T>>
-    : public BaseCudaPowFunctor<ComplexType<T>> {
-  __device__ __forceinline__ ComplexType<T> operator()(
-      const ComplexType<T> x) const {
-    return static_cast<ComplexType<T>>(
-        compute_pow(x, static_cast<ComplexType<double>>(this->factor)));
   }
 };
 
@@ -5563,14 +5555,14 @@ struct CudaPowGradFunctor : public BaseCudaPowGradFunctor<T> {
 template <typename T>
 struct CudaPowGradFunctor<ComplexType<T>>
     : public BaseCudaPowGradFunctor<ComplexType<T>> {
-  ComplexType<double> one = static_cast<ComplexType<double>>(1.0f);
+  using MPType = typename phi::dtype::MPTypeTrait<ComplexType<T>>::Type;
+  MPType one = static_cast<MPType>(1.0f);
 
   // dx = dout * (4 * (x*x*x))
   __device__ __forceinline__ ComplexType<T> operator()(
       const ComplexType<T> dout, const ComplexType<T> x) const {
-    auto factor = static_cast<ComplexType<double>>(this->factor);
     return dout * static_cast<ComplexType<T>>(
-                      conj(factor * compute_pow(x, factor - one)));
+                      conj(this->factor * compute_pow(x, this->factor - one)));
   }
 };
 

--- a/paddle/phi/kernels/funcs/activation_functor.h
+++ b/paddle/phi/kernels/funcs/activation_functor.h
@@ -3643,38 +3643,6 @@ struct CudaRsquareGradFunctor<ComplexType<T>>
 };
 
 template <typename T>
-struct CudaCubeFunctor : public BaseActivationFunctor<T> {
-  // cube(x) = x * x * x
-  __device__ __forceinline__ T operator()(const T x) const { return x * x * x; }
-};
-
-template <typename T>
-struct CudaCubeGradFunctor : public BaseActivationFunctor<T> {
-  T three = static_cast<T>(3.0f);
-
-  // dx = dout * 3 * x * x
-  __device__ __forceinline__ T operator()(const T dout, const T x) const {
-    return dout * three * x * x;
-  }
-
-  static constexpr ActBwdOpFwdDeps FwdDeps() { return ActBwdOpFwdDeps::kDepX; }
-};
-
-template <typename T>
-struct CudaCubeGradFunctor<ComplexType<T>>
-    : public BaseActivationFunctor<ComplexType<T>> {
-  ComplexType<T> three = static_cast<ComplexType<T>>(3.0f);
-
-  // dx = dout * 3 * conj(x * x)
-  __device__ __forceinline__ ComplexType<T> operator()(
-      const ComplexType<T> dout, const ComplexType<T> x) const {
-    return static_cast<ComplexType<T>>(dout * three * conj(x * x));
-  }
-
-  static constexpr ActBwdOpFwdDeps FwdDeps() { return ActBwdOpFwdDeps::kDepX; }
-};
-
-template <typename T>
 struct CudaExpGradFunctor : public BaseActivationFunctor<T> {
   // dx = dout * out
   __device__ __forceinline__ T operator()(const T dout, const T out) const {
@@ -3771,6 +3739,36 @@ struct CudaReciprocalGradFunctor<ComplexType<T>>
   static constexpr ActBwdOpFwdDeps FwdDeps() {
     return ActBwdOpFwdDeps::kDepOut;
   }
+};
+
+// for pow(x, -1)
+template <typename T>
+struct CudaReciprocalGradDepXFunctor : public BaseActivationFunctor<T> {
+  using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
+  MPType one = static_cast<MPType>(1.0f);
+
+  // dx = -dout * out^2
+  __device__ __forceinline__ T operator()(const T arg_dout,
+                                          const T arg_x) const {
+    MPType dout = static_cast<MPType>(arg_dout);
+    MPType x = static_cast<MPType>(arg_x);
+    return static_cast<T>(-dout * (one / (x * x)));
+  }
+
+  static constexpr ActBwdOpFwdDeps FwdDeps() { return ActBwdOpFwdDeps::kDepX; }
+};
+
+template <typename T>
+struct CudaReciprocalGradDepXFunctor<ComplexType<T>>
+    : public BaseActivationFunctor<ComplexType<T>> {
+  ComplexType<T> one = static_cast<ComplexType<T>>(1.0f);
+  // dx = -dout * out^2
+  __device__ __forceinline__ ComplexType<T> operator()(
+      const ComplexType<T> dout, const ComplexType<T> x) const {
+    return -dout * conj(one / (x * x));
+  }
+
+  static constexpr ActBwdOpFwdDeps FwdDeps() { return ActBwdOpFwdDeps::kDepX; }
 };
 
 template <typename T>
@@ -4362,6 +4360,36 @@ struct CudaSqrtGradFunctor<ComplexType<T>>
   static constexpr ActBwdOpFwdDeps FwdDeps() {
     return ActBwdOpFwdDeps::kDepOut;
   }
+};
+
+// for pow(x, 0.5)
+template <typename T>
+struct CudaSqrtGradDepXFunctor : public BaseActivationFunctor<T> {
+  using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
+
+  MPType one_half = static_cast<MPType>(0.5f);
+
+  // dx = dout * (0.5 * rsqrt(x))
+  __device__ __forceinline__ T operator()(const T dout, const T arg_x) const {
+    MPType x = static_cast<MPType>(arg_x);
+    return dout * static_cast<T>(one_half * rsqrt(x));
+  }
+
+  static constexpr ActBwdOpFwdDeps FwdDeps() { return ActBwdOpFwdDeps::kDepX; }
+};
+
+template <typename T>
+struct CudaSqrtGradDepXFunctor<ComplexType<T>>
+    : public BaseActivationFunctor<ComplexType<T>> {
+  ComplexType<T> one_half = static_cast<ComplexType<T>>(0.5f);
+
+  // dx = dout * conj(0.5 * rsqrt(x))
+  __device__ __forceinline__ ComplexType<T> operator()(
+      const ComplexType<T> dout, const ComplexType<T> x) const {
+    return dout * conj(one_half / sqrt(x));
+  }
+
+  static constexpr ActBwdOpFwdDeps FwdDeps() { return ActBwdOpFwdDeps::kDepX; }
 };
 
 template <typename T>
@@ -5555,16 +5583,6 @@ struct CudaPowFunctor : public BaseCudaPowFunctor<T> {
 };
 
 template <typename T>
-struct CudaPowGradFunctor : public BaseCudaPowGradFunctor<T> {
-  using MT = typename phi::dtype::MPTypeTrait<T>::Type;
-  // dx = dout * n * pow(x, n - 1)
-  __device__ __forceinline__ T operator()(const T dout, const T x) const {
-    return dout * static_cast<T>(this->factor) *
-           compute_pow<T, MT>(x, static_cast<MT>(this->factor - 1));
-  }
-};
-
-template <typename T>
 struct CudaPowFunctor<ComplexType<T>>
     : public BaseCudaPowFunctor<ComplexType<T>> {
   __device__ __forceinline__ ComplexType<T> operator()(
@@ -5574,14 +5592,112 @@ struct CudaPowFunctor<ComplexType<T>>
 };
 
 template <typename T>
+struct CudaPowGradFunctor : public BaseCudaPowGradFunctor<T> {
+  using MT = typename phi::dtype::MPTypeTrait<T>::Type;
+  // dx = dout * n * pow(x, n - 1)
+  __device__ __forceinline__ T operator()(const T dout, const T x) const {
+    return dout * (static_cast<T>(this->factor) *
+                   compute_pow<T, MT>(x, static_cast<MT>(this->factor - 1)));
+  }
+};
+
+template <typename T>
 struct CudaPowGradFunctor<ComplexType<T>>
     : public BaseCudaPowGradFunctor<ComplexType<T>> {
-  // dx = dout * n * pow(x, n - 1)
+  // dx = dout * (4 * (x*x*x))
   __device__ __forceinline__ ComplexType<T> operator()(
       const ComplexType<T> dout, const ComplexType<T> x) const {
     return dout * conj(static_cast<ComplexType<T>>(this->factor) *
                        pow(x, static_cast<ComplexType<T>>(this->factor - 1)));
   }
+};
+
+template <typename T>
+struct CudaCubeFunctor : public BaseActivationFunctor<T> {
+  // cube(x) = x * x * x
+  __device__ __forceinline__ T operator()(const T x) const { return x * x * x; }
+};
+
+template <typename T>
+struct CudaCubeGradFunctor : public BaseActivationFunctor<T> {
+  T three = static_cast<T>(3.0f);
+
+  // dx = dout * 3 * x * x
+  __device__ __forceinline__ T operator()(const T dout, const T x) const {
+    return dout * (three * (x * x));
+  }
+
+  static constexpr ActBwdOpFwdDeps FwdDeps() { return ActBwdOpFwdDeps::kDepX; }
+};
+
+template <typename T>
+struct CudaCubeGradFunctor<ComplexType<T>>
+    : public BaseActivationFunctor<ComplexType<T>> {
+  ComplexType<T> three = static_cast<ComplexType<T>>(3.0f);
+
+  // dx = dout * conj(3 * x * x)
+  __device__ __forceinline__ ComplexType<T> operator()(
+      const ComplexType<T> dout, const ComplexType<T> x) const {
+    return static_cast<ComplexType<T>>(dout * conj(three * (x * x)));
+  }
+
+  static constexpr ActBwdOpFwdDeps FwdDeps() { return ActBwdOpFwdDeps::kDepX; }
+};
+
+template <typename T>
+struct CudaPow4GradFunctor : public BaseActivationFunctor<T> {
+  T four = static_cast<T>(4.0f);
+
+  // dx = dout * 4 * x * x * x
+  __device__ __forceinline__ T operator()(const T dout, const T x) const {
+    return dout * (four * (x * x * x));
+  }
+
+  static constexpr ActBwdOpFwdDeps FwdDeps() { return ActBwdOpFwdDeps::kDepX; }
+};
+
+template <typename T>
+struct CudaPow4GradFunctor<ComplexType<T>>
+    : public BaseActivationFunctor<ComplexType<T>> {
+  ComplexType<T> four = static_cast<ComplexType<T>>(4.0f);
+
+  // dx = dout * conj(4 * x * x * x)
+  __device__ __forceinline__ ComplexType<T> operator()(
+      const ComplexType<T> dout, const ComplexType<T> x) const {
+    return static_cast<ComplexType<T>>(dout * conj(four * (x * x * x)));
+  }
+
+  static constexpr ActBwdOpFwdDeps FwdDeps() { return ActBwdOpFwdDeps::kDepX; }
+};
+
+// for pow(x, 1.5)
+template <typename T>
+struct CudaPow1p5GradFunctor : public BaseActivationFunctor<T> {
+  using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
+
+  MPType f1p5 = static_cast<T>(1.5f);
+
+  // dx = dout * 1.5 * sqrt(x)
+  __device__ __forceinline__ T operator()(const T dout, const T arg_x) const {
+    MPType x = static_cast<MPType>(arg_x);
+    return dout * static_cast<T>(f1p5 * sqrt(x));
+  }
+
+  static constexpr ActBwdOpFwdDeps FwdDeps() { return ActBwdOpFwdDeps::kDepX; }
+};
+
+template <typename T>
+struct CudaPow1p5GradFunctor<ComplexType<T>>
+    : public BaseActivationFunctor<ComplexType<T>> {
+  ComplexType<T> f1p5 = static_cast<ComplexType<T>>(1.5f);
+
+  // dx = dout * conj(1.5 * sqrt(x))
+  __device__ __forceinline__ ComplexType<T> operator()(
+      const ComplexType<T> dout, const ComplexType<T> x) const {
+    return static_cast<ComplexType<T>>(dout * conj(f1p5 * sqrt(x)));
+  }
+
+  static constexpr ActBwdOpFwdDeps FwdDeps() { return ActBwdOpFwdDeps::kDepX; }
 };
 
 template <typename T>

--- a/paddle/phi/kernels/funcs/activation_functor.h
+++ b/paddle/phi/kernels/funcs/activation_functor.h
@@ -5410,7 +5410,7 @@ struct CudaCeilFunctor : public BaseActivationFunctor<T> {
 template <typename T, typename MPType>
 __device__ __forceinline__
     typename std::enable_if<std::is_integral<T>::value, T>::type
-    compute_pow(const T a, const T b) {
+    compute_pow(const T a, const MPType b) {
   // TODO(wujionghao): A potential speed improvement is supporting different
   // types in C++.
   // On CUDAPlace, pow(3, 1) calls pow(float, float), and
@@ -5423,10 +5423,9 @@ __device__ __forceinline__
 template <typename T, typename MPType>
 __device__ __forceinline__
     typename std::enable_if<!std::is_integral<T>::value, T>::type
-    compute_pow(const T a, const T b) {
+    compute_pow(const T a, const MPType b) {
   MPType a_val = static_cast<MPType>(a);
-  MPType b_val = static_cast<MPType>(b);
-  return static_cast<T>(pow(a_val, b_val));
+  return static_cast<T>(pow(a_val, b));
 }
 
 template <typename T>
@@ -5437,7 +5436,7 @@ struct CudaPowFunctor : public BaseActivationFunctor<T> {
     return {{"factor", &factor}};
   }
   __device__ __forceinline__ T operator()(const T x) const {
-    return compute_pow<T, MT>(x, static_cast<T>(factor));
+    return compute_pow<T, MT>(x, static_cast<MT>(factor));
   }
 };
 
@@ -5451,7 +5450,7 @@ struct CudaPowGradFunctor : public BaseActivationFunctor<T> {
   // dx = dout * n * pow(x, n - 1)
   __device__ __forceinline__ T operator()(const T dout, const T x) const {
     return dout * static_cast<T>(factor) *
-           compute_pow<T, MT>(x, static_cast<T>(factor - 1));
+           compute_pow<T, MT>(x, static_cast<MT>(factor - 1));
   }
   static constexpr ActBwdOpFwdDeps FwdDeps() { return ActBwdOpFwdDeps::kDepX; }
 };

--- a/paddle/phi/kernels/funcs/activation_functor.h
+++ b/paddle/phi/kernels/funcs/activation_functor.h
@@ -3616,33 +3616,6 @@ struct CudaRsquareFunctor : public BaseActivationFunctor<T> {
 };
 
 template <typename T>
-struct CudaRsquareGradFunctor : public BaseActivationFunctor<T> {
-  T minus_two = static_cast<T>(-2.0f);
-  // dx = dout * -2 / (x * x * x)
-  __device__ __forceinline__ T operator()(const T dout, const T x) const {
-    return dout * minus_two / (x * x * x);
-  }
-
-  static constexpr ActBwdOpFwdDeps FwdDeps() { return ActBwdOpFwdDeps::kDepX; }
-};
-
-template <typename T>
-struct CudaRsquareGradFunctor<ComplexType<T>>
-    : public BaseActivationFunctor<ComplexType<T>> {
-  ComplexType<T> minus_two = static_cast<ComplexType<T>>(-2.0f);
-  ComplexType<T> one = static_cast<ComplexType<T>>(1.0f);
-
-  // dx = dout * -2 / (x * x * x)
-  __device__ __forceinline__ ComplexType<T> operator()(
-      const ComplexType<T> dout, const ComplexType<T> x) const {
-    return static_cast<ComplexType<T>>(dout * minus_two *
-                                       conj(one / (x * x * x)));
-  }
-
-  static constexpr ActBwdOpFwdDeps FwdDeps() { return ActBwdOpFwdDeps::kDepX; }
-};
-
-template <typename T>
 struct CudaExpGradFunctor : public BaseActivationFunctor<T> {
   // dx = dout * out
   __device__ __forceinline__ T operator()(const T dout, const T out) const {
@@ -4426,23 +4399,6 @@ struct CudaRsqrtGradFunctor : public BaseActivationFunctor<T> {
     MPType dout = static_cast<MPType>(arg_dout);
     MPType out = static_cast<MPType>(arg_out);
     return static_cast<T>(minus_one_half * dout * out * out * out);
-  }
-
-  static constexpr ActBwdOpFwdDeps FwdDeps() {
-    return ActBwdOpFwdDeps::kDepOut;
-  }
-};
-
-template <typename T>
-struct CudaRsqrtGradFunctor<ComplexType<T>>
-    : public BaseActivationFunctor<ComplexType<T>> {
-  ComplexType<T> minus_one_half = static_cast<ComplexType<T>>(-0.5f);
-
-  // dx = -0.5 * dout * out^3
-  __device__ __forceinline__ ComplexType<T> operator()(
-      const ComplexType<T> arg_dout, const ComplexType<T> arg_out) const {
-    return static_cast<ComplexType<T>>(minus_one_half * arg_dout *
-                                       conj(arg_out * arg_out * arg_out));
   }
 
   static constexpr ActBwdOpFwdDeps FwdDeps() {

--- a/paddle/phi/kernels/funcs/activation_functor.h
+++ b/paddle/phi/kernels/funcs/activation_functor.h
@@ -4364,22 +4364,13 @@ struct CudaSqrtGradFunctor<ComplexType<T>>
   }
 };
 
-template <typename T, typename Enable = void>
+template <typename T>
 struct CudaRsqrtFunctor : public BaseActivationFunctor<T> {
   using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
 
   // rsqrt(x) = rsqrt(x)
   __device__ __forceinline__ T operator()(const T arg_x) const {
     MPType x = static_cast<MPType>(arg_x);
-    return static_cast<T>(rsqrt(x));
-  }
-};
-template <typename T>
-struct CudaRsqrtFunctor<T, std::enable_if_t<std::is_integral_v<T>>>
-    : public BaseActivationFunctor<T> {
-  // rsqrt(x) = rsqrt(x)
-  __device__ __forceinline__ T operator()(const T arg_x) const {
-    float x = static_cast<float>(arg_x);
     return static_cast<T>(rsqrt(x));
   }
 };

--- a/paddle/phi/kernels/funcs/activation_functor.h
+++ b/paddle/phi/kernels/funcs/activation_functor.h
@@ -3607,6 +3607,74 @@ struct CudaSquareGradFunctor<ComplexType<T>>
 };
 
 template <typename T>
+struct CudaRsquareFunctor : public BaseActivationFunctor<T> {
+  // square(x) = 1 / (x * x)
+  T one = static_cast<T>(1.0f);
+  __device__ __forceinline__ T operator()(const T x) const {
+    return one / (x * x);
+  }
+};
+
+template <typename T>
+struct CudaRsquareGradFunctor : public BaseActivationFunctor<T> {
+  T minus_two = static_cast<T>(-2.0f);
+  // dx = dout * -2 / (x * x * x)
+  __device__ __forceinline__ T operator()(const T dout, const T x) const {
+    return dout * minus_two / (x * x * x);
+  }
+
+  static constexpr ActBwdOpFwdDeps FwdDeps() { return ActBwdOpFwdDeps::kDepX; }
+};
+
+template <typename T>
+struct CudaRsquareGradFunctor<ComplexType<T>>
+    : public BaseActivationFunctor<ComplexType<T>> {
+  ComplexType<T> minus_two = static_cast<ComplexType<T>>(-2.0f);
+  ComplexType<T> one = static_cast<ComplexType<T>>(1.0f);
+
+  // dx = dout * -2 / (x * x * x)
+  __device__ __forceinline__ ComplexType<T> operator()(
+      const ComplexType<T> dout, const ComplexType<T> x) const {
+    return static_cast<ComplexType<T>>(dout * minus_two *
+                                       conj(one / (x * x * x)));
+  }
+
+  static constexpr ActBwdOpFwdDeps FwdDeps() { return ActBwdOpFwdDeps::kDepX; }
+};
+
+template <typename T>
+struct CudaCubeFunctor : public BaseActivationFunctor<T> {
+  // cube(x) = x * x * x
+  __device__ __forceinline__ T operator()(const T x) const { return x * x * x; }
+};
+
+template <typename T>
+struct CudaCubeGradFunctor : public BaseActivationFunctor<T> {
+  T three = static_cast<T>(3.0f);
+
+  // dx = dout * 3 * x * x
+  __device__ __forceinline__ T operator()(const T dout, const T x) const {
+    return dout * three * x * x;
+  }
+
+  static constexpr ActBwdOpFwdDeps FwdDeps() { return ActBwdOpFwdDeps::kDepX; }
+};
+
+template <typename T>
+struct CudaCubeGradFunctor<ComplexType<T>>
+    : public BaseActivationFunctor<ComplexType<T>> {
+  ComplexType<T> three = static_cast<ComplexType<T>>(3.0f);
+
+  // dx = dout * 3 * conj(x * x)
+  __device__ __forceinline__ ComplexType<T> operator()(
+      const ComplexType<T> dout, const ComplexType<T> x) const {
+    return static_cast<ComplexType<T>>(dout * three * conj(x * x));
+  }
+
+  static constexpr ActBwdOpFwdDeps FwdDeps() { return ActBwdOpFwdDeps::kDepX; }
+};
+
+template <typename T>
 struct CudaExpGradFunctor : public BaseActivationFunctor<T> {
   // dx = dout * out
   __device__ __forceinline__ T operator()(const T dout, const T out) const {
@@ -4296,7 +4364,7 @@ struct CudaSqrtGradFunctor<ComplexType<T>>
   }
 };
 
-template <typename T>
+template <typename T, typename Enable = void>
 struct CudaRsqrtFunctor : public BaseActivationFunctor<T> {
   using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
 
@@ -4304,6 +4372,27 @@ struct CudaRsqrtFunctor : public BaseActivationFunctor<T> {
   __device__ __forceinline__ T operator()(const T arg_x) const {
     MPType x = static_cast<MPType>(arg_x);
     return static_cast<T>(rsqrt(x));
+  }
+};
+template <typename T>
+struct CudaRsqrtFunctor<T, std::enable_if_t<std::is_integral_v<T>>>
+    : public BaseActivationFunctor<T> {
+  // rsqrt(x) = rsqrt(x)
+  __device__ __forceinline__ T operator()(const T arg_x) const {
+    float x = static_cast<float>(arg_x);
+    return static_cast<T>(rsqrt(x));
+  }
+};
+
+template <typename T>
+struct CudaRsqrtFunctor<ComplexType<T>>
+    : public BaseActivationFunctor<ComplexType<T>> {
+  ComplexType<T> one = static_cast<ComplexType<T>>(1.0f);
+
+  // rsqrt(x) = 1 / sqrt(x)
+  __device__ __forceinline__ ComplexType<T> operator()(
+      const ComplexType<T> arg_x) const {
+    return one / sqrt(arg_x);
   }
 };
 
@@ -4318,6 +4407,23 @@ struct CudaRsqrtGradFunctor : public BaseActivationFunctor<T> {
     MPType dout = static_cast<MPType>(arg_dout);
     MPType out = static_cast<MPType>(arg_out);
     return static_cast<T>(minus_one_half * dout * out * out * out);
+  }
+
+  static constexpr ActBwdOpFwdDeps FwdDeps() {
+    return ActBwdOpFwdDeps::kDepOut;
+  }
+};
+
+template <typename T>
+struct CudaRsqrtGradFunctor<ComplexType<T>>
+    : public BaseActivationFunctor<ComplexType<T>> {
+  ComplexType<T> minus_one_half = static_cast<ComplexType<T>>(-0.5f);
+
+  // dx = -0.5 * dout * out^3
+  __device__ __forceinline__ ComplexType<T> operator()(
+      const ComplexType<T> arg_dout, const ComplexType<T> arg_out) const {
+    return static_cast<ComplexType<T>>(minus_one_half * arg_dout *
+                                       conj(arg_out * arg_out * arg_out));
   }
 
   static constexpr ActBwdOpFwdDeps FwdDeps() {
@@ -5459,24 +5565,6 @@ struct CudaPowFunctor : public BaseCudaPowFunctor<T> {
 
 template <typename T>
 struct CudaPowGradFunctor : public BaseCudaPowGradFunctor<T> {
-  using MT = typename phi::dtype::MPTypeTrait<T>::Type;
-  // dx = dout * n * pow(x, n - 1)
-  __device__ __forceinline__ T operator()(const T dout, const T x) const {
-    return dout * static_cast<T>(this->factor) *
-           compute_pow<T, MT>(x, static_cast<MT>(this->factor - 1));
-  }
-};
-
-template <typename T>
-struct CudaPowFastFunctor : public BaseCudaPowFunctor<T> {
-  using MT = typename phi::dtype::MPTypeTrait<T>::Type;
-  __device__ __forceinline__ T operator()(const T x) const {
-    return compute_pow<T, MT>(x, static_cast<MT>(this->factor));
-  }
-};
-
-template <typename T>
-struct CudaPowGradFastFunctor : public BaseCudaPowGradFunctor<T> {
   using MT = typename phi::dtype::MPTypeTrait<T>::Type;
   // dx = dout * n * pow(x, n - 1)
   __device__ __forceinline__ T operator()(const T dout, const T x) const {

--- a/paddle/phi/kernels/funcs/activation_functor.h
+++ b/paddle/phi/kernels/funcs/activation_functor.h
@@ -5488,53 +5488,56 @@ struct CudaCeilFunctor : public BaseActivationFunctor<T> {
   }
 };
 
-template <typename T, typename MPType>
+template <typename T>
 __device__ __forceinline__
-    typename std::enable_if<std::is_integral<T>::value, T>::type
-    compute_pow(const T a, const MPType b) {
+    typename std::enable_if<std::is_integral<T>::value, int64_t>::type
+    compute_pow(const T a, const double b) {
   // TODO(wujionghao): A potential speed improvement is supporting different
   // types in C++.
   // On CUDAPlace, pow(3, 1) calls pow(float, float), and
   // it will return a float number like 2.99... , which floor to 2
   // when cast to int by default and it is wrong.
   // Use llrint to cast it to the nearest integer, which is 3.
-  return llrint(pow(static_cast<double>(a), static_cast<double>(b)));
+  return llrint(pow(static_cast<double>(a), b));
 }
 
-template <typename T, typename MPType>
+template <typename T>
 __device__ __forceinline__
-    typename std::enable_if<!std::is_integral<T>::value, T>::type
-    compute_pow(const T a, const MPType b) {
-  MPType a_val = static_cast<MPType>(a);
-  return static_cast<T>(pow(a_val, b));
+    typename std::enable_if<!std::is_integral<T>::value, double>::type
+    compute_pow(const T a, const double b) {
+  return pow(static_cast<double>(a), b);
+}
+
+template <typename T>
+__device__ __forceinline__ typename std::enable_if<!std::is_integral<T>::value,
+                                                   ComplexType<double>>::type
+compute_pow(const ComplexType<T> a, const ComplexType<double> b) {
+  return pow(static_cast<ComplexType<double>>(a), b);
 }
 
 template <typename T>
 struct BaseCudaPowFunctor : public BaseActivationFunctor<T> {
-  using MT = typename phi::dtype::MPTypeTrait<T>::Type;
-  float factor;
+  double factor;
   typename BaseActivationFunctor<T>::AttrPair GetAttrs() {
     return {{"factor", &factor}};
   }
-  void SetFactor(float factor) { this->factor = factor; }
+  void SetFactor(double factor) { this->factor = factor; }
 };
 
 template <typename T>
 struct BaseCudaPowGradFunctor : public BaseActivationFunctor<T> {
-  using MT = typename phi::dtype::MPTypeTrait<T>::Type;
-  float factor;
+  double factor;
   typename BaseActivationFunctor<T>::AttrPair GetAttrs() {
     return {{"factor", &factor}};
   }
-  void SetFactor(float factor) { this->factor = factor; }
+  void SetFactor(double factor) { this->factor = factor; }
   static constexpr ActBwdOpFwdDeps FwdDeps() { return ActBwdOpFwdDeps::kDepX; }
 };
 
 template <typename T>
 struct CudaPowFunctor : public BaseCudaPowFunctor<T> {
-  using MT = typename phi::dtype::MPTypeTrait<T>::Type;
   __device__ __forceinline__ T operator()(const T x) const {
-    return compute_pow<T, MT>(x, static_cast<MT>(this->factor));
+    return static_cast<T>(compute_pow(x, this->factor));
   }
 };
 
@@ -5543,28 +5546,31 @@ struct CudaPowFunctor<ComplexType<T>>
     : public BaseCudaPowFunctor<ComplexType<T>> {
   __device__ __forceinline__ ComplexType<T> operator()(
       const ComplexType<T> x) const {
-    return pow(x, static_cast<ComplexType<T>>(this->factor));
+    return static_cast<ComplexType<T>>(
+        compute_pow(x, static_cast<ComplexType<double>>(this->factor)));
   }
 };
 
 template <typename T>
 struct CudaPowGradFunctor : public BaseCudaPowGradFunctor<T> {
-  using MT = typename phi::dtype::MPTypeTrait<T>::Type;
   // dx = dout * n * pow(x, n - 1)
   __device__ __forceinline__ T operator()(const T dout, const T x) const {
-    return dout * (static_cast<T>(this->factor) *
-                   compute_pow<T, MT>(x, static_cast<MT>(this->factor - 1)));
+    return dout *
+           static_cast<T>(this->factor * compute_pow(x, this->factor - 1));
   }
 };
 
 template <typename T>
 struct CudaPowGradFunctor<ComplexType<T>>
     : public BaseCudaPowGradFunctor<ComplexType<T>> {
+  ComplexType<double> one = static_cast<ComplexType<double>>(1.0f);
+
   // dx = dout * (4 * (x*x*x))
   __device__ __forceinline__ ComplexType<T> operator()(
       const ComplexType<T> dout, const ComplexType<T> x) const {
-    return dout * conj(static_cast<ComplexType<T>>(this->factor) *
-                       pow(x, static_cast<ComplexType<T>>(this->factor - 1)));
+    auto factor = static_cast<ComplexType<double>>(this->factor);
+    return dout * static_cast<ComplexType<T>>(
+                      conj(factor * compute_pow(x, factor - one)));
   }
 };
 

--- a/paddle/phi/kernels/funcs/activation_functor.h
+++ b/paddle/phi/kernels/funcs/activation_functor.h
@@ -5429,59 +5429,80 @@ __device__ __forceinline__
 }
 
 template <typename T>
-struct CudaPowFunctor : public BaseActivationFunctor<T> {
+struct BaseCudaPowFunctor : public BaseActivationFunctor<T> {
   using MT = typename phi::dtype::MPTypeTrait<T>::Type;
   float factor;
   typename BaseActivationFunctor<T>::AttrPair GetAttrs() {
     return {{"factor", &factor}};
   }
-  __device__ __forceinline__ T operator()(const T x) const {
-    return compute_pow<T, MT>(x, static_cast<MT>(factor));
-  }
+  void SetFactor(float factor) { this->factor = factor; }
 };
 
 template <typename T>
-struct CudaPowGradFunctor : public BaseActivationFunctor<T> {
+struct BaseCudaPowGradFunctor : public BaseActivationFunctor<T> {
   using MT = typename phi::dtype::MPTypeTrait<T>::Type;
   float factor;
   typename BaseActivationFunctor<T>::AttrPair GetAttrs() {
     return {{"factor", &factor}};
   }
-  // dx = dout * n * pow(x, n - 1)
-  __device__ __forceinline__ T operator()(const T dout, const T x) const {
-    return dout * static_cast<T>(factor) *
-           compute_pow<T, MT>(x, static_cast<MT>(factor - 1));
-  }
+  void SetFactor(float factor) { this->factor = factor; }
   static constexpr ActBwdOpFwdDeps FwdDeps() { return ActBwdOpFwdDeps::kDepX; }
 };
 
 template <typename T>
-struct CudaPowFunctor<ComplexType<T>>
-    : public BaseActivationFunctor<ComplexType<T>> {
-  float factor;
-  typename BaseActivationFunctor<T>::AttrPair GetAttrs() {
-    return {{"factor", &factor}};
+struct CudaPowFunctor : public BaseCudaPowFunctor<T> {
+  using MT = typename phi::dtype::MPTypeTrait<T>::Type;
+  __device__ __forceinline__ T operator()(const T x) const {
+    return compute_pow<T, MT>(x, static_cast<MT>(this->factor));
   }
+};
+
+template <typename T>
+struct CudaPowGradFunctor : public BaseCudaPowGradFunctor<T> {
+  using MT = typename phi::dtype::MPTypeTrait<T>::Type;
+  // dx = dout * n * pow(x, n - 1)
+  __device__ __forceinline__ T operator()(const T dout, const T x) const {
+    return dout * static_cast<T>(this->factor) *
+           compute_pow<T, MT>(x, static_cast<MT>(this->factor - 1));
+  }
+};
+
+template <typename T>
+struct CudaPowFastFunctor : public BaseCudaPowFunctor<T> {
+  using MT = typename phi::dtype::MPTypeTrait<T>::Type;
+  __device__ __forceinline__ T operator()(const T x) const {
+    return compute_pow<T, MT>(x, static_cast<MT>(this->factor));
+  }
+};
+
+template <typename T>
+struct CudaPowGradFastFunctor : public BaseCudaPowGradFunctor<T> {
+  using MT = typename phi::dtype::MPTypeTrait<T>::Type;
+  // dx = dout * n * pow(x, n - 1)
+  __device__ __forceinline__ T operator()(const T dout, const T x) const {
+    return dout * static_cast<T>(this->factor) *
+           compute_pow<T, MT>(x, static_cast<MT>(this->factor - 1));
+  }
+};
+
+template <typename T>
+struct CudaPowFunctor<ComplexType<T>>
+    : public BaseCudaPowFunctor<ComplexType<T>> {
   __device__ __forceinline__ ComplexType<T> operator()(
       const ComplexType<T> x) const {
-    return pow(x, static_cast<ComplexType<T>>(factor));
+    return pow(x, static_cast<ComplexType<T>>(this->factor));
   }
 };
 
 template <typename T>
 struct CudaPowGradFunctor<ComplexType<T>>
-    : public BaseActivationFunctor<ComplexType<T>> {
-  float factor;
-  typename BaseActivationFunctor<T>::AttrPair GetAttrs() {
-    return {{"factor", &factor}};
-  }
+    : public BaseCudaPowGradFunctor<ComplexType<T>> {
   // dx = dout * n * pow(x, n - 1)
   __device__ __forceinline__ ComplexType<T> operator()(
       const ComplexType<T> dout, const ComplexType<T> x) const {
-    return dout * conj(static_cast<ComplexType<T>>(factor) *
-                       pow(x, static_cast<ComplexType<T>>(factor - 1)));
+    return dout * conj(static_cast<ComplexType<T>>(this->factor) *
+                       pow(x, static_cast<ComplexType<T>>(this->factor - 1)));
   }
-  static constexpr ActBwdOpFwdDeps FwdDeps() { return ActBwdOpFwdDeps::kDepX; }
 };
 
 template <typename T>

--- a/paddle/phi/kernels/funcs/elementwise_functor.h
+++ b/paddle/phi/kernels/funcs/elementwise_functor.h
@@ -1324,7 +1324,7 @@ struct ElementwiseInversePowFunctor<ComplexType<T>> {
   inline HOSTDEVICE ComplexType<T> operator()(const ComplexType<T> a,
                                               const ComplexType<T> b) const {
 #if defined(__CUDA_ARCH__) || defined(__HIPCC__)
-    return pow(a, b);
+    return pow(b, a);
 #else
     return std::pow(static_cast<std::complex<T>>(b),
                     static_cast<std::complex<T>>(a));

--- a/paddle/phi/kernels/gpu/activation_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/activation_grad_kernel.cu
@@ -318,8 +318,7 @@ void PowGradKernel(const Context& dev_ctx,
     return;
   }
   funcs::CudaPowGradFunctor<T> functor;
-  auto attrs = functor.GetAttrs();
-  *(attrs[0].second) = factor.to<float>();
+  functor.SetFactor(factor.to<float>());
   ActivationGradGPUImpl<T, Context, funcs::CudaPowGradFunctor<T>>(
       dev_ctx, &x, nullptr, &dout, dx, functor);
 }

--- a/paddle/phi/kernels/gpu/activation_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/activation_grad_kernel.cu
@@ -317,16 +317,15 @@ void PowGradKernel(const Context& dev_ctx,
         dev_ctx, phi::IntArray(vec_dims), static_cast<T>(0), dx);
     return;
   }
-  if (factor.to<float>() == 0.5) {
-    funcs::CudaSqrtGradFunctor<T> functor;
-    ActivationGradGPUImpl<T, Context, funcs::CudaSqrtGradFunctor<T>>(
-        dev_ctx, &x, nullptr, &dout, dx, functor);
-    return;
-  }
+  // if (factor.to<float>() == 0.5) {
+  //   funcs::CudaSqrtGradFunctor<T> functor;
+  //   ActivationGradGPUImpl<T, Context, funcs::CudaSqrtGradFunctor<T>>(
+  //       dev_ctx, &x, nullptr, &dout, dx, functor);
+  //   return;
+  // }
   if (factor.to<float>() == 1) {
     std::vector<int64_t> vec_dims = common::vectorize(dx->dims());
-    phi::Full<T, Context>(
-        dev_ctx, phi::IntArray(vec_dims), static_cast<T>(1), dx);
+    phi::Copy<Context>(dev_ctx, dout, dev_ctx.GetPlace(), false, dx);
     return;
   }
   if (factor.to<float>() == 2) {
@@ -341,23 +340,25 @@ void PowGradKernel(const Context& dev_ctx,
         dev_ctx, &x, nullptr, &dout, dx, functor);
     return;
   }
-  if (factor.to<float>() == -0.5) {
-    funcs::CudaRsqrtGradFunctor<T> functor;
-    ActivationGradGPUImpl<T, Context, funcs::CudaRsqrtGradFunctor<T>>(
-        dev_ctx, &x, nullptr, &dout, dx, functor);
-    return;
-  }
-  if (factor.to<float>() == -1) {
-    funcs::CudaReciprocalGradFunctor<T> functor;
-    ActivationGradGPUImpl<T, Context, funcs::CudaReciprocalGradFunctor<T>>(
-        dev_ctx, &x, nullptr, &dout, dx, functor);
-    return;
-  }
-  if (factor.to<float>() == -2) {
-    funcs::CudaRsquareGradFunctor<T> functor;
-    ActivationGradGPUImpl<T, Context, funcs::CudaRsquareGradFunctor<T>>(
-        dev_ctx, &x, nullptr, &dout, dx, functor);
-    return;
+  if constexpr (!std::is_integral<T>::value) {
+    // if (factor.to<float>() == -0.5) {
+    //   funcs::CudaRsqrtGradFunctor<T> functor;
+    //   ActivationGradGPUImpl<T, Context, funcs::CudaRsqrtGradFunctor<T>>(
+    //       dev_ctx, &x, nullptr, &dout, dx, functor);
+    //   return;
+    // }
+    // if (factor.to<float>() == -1) {
+    //   funcs::CudaReciprocalGradFunctor<T> functor;
+    //   ActivationGradGPUImpl<T, Context, funcs::CudaReciprocalGradFunctor<T>>(
+    //       dev_ctx, &x, nullptr, &dout, dx, functor);
+    //   return;
+    // }
+    if (factor.to<float>() == -2) {
+      funcs::CudaRsquareGradFunctor<T> functor;
+      ActivationGradGPUImpl<T, Context, funcs::CudaRsquareGradFunctor<T>>(
+          dev_ctx, &x, nullptr, &dout, dx, functor);
+      return;
+    }
   }
   funcs::CudaPowGradFunctor<T> functor;
   functor.SetFactor(factor.to<float>());

--- a/paddle/phi/kernels/gpu/activation_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/activation_grad_kernel.cu
@@ -317,6 +317,48 @@ void PowGradKernel(const Context& dev_ctx,
         dev_ctx, phi::IntArray(vec_dims), static_cast<T>(0), dx);
     return;
   }
+  if (factor.to<float>() == 0.5) {
+    funcs::CudaSqrtGradFunctor<T> functor;
+    ActivationGradGPUImpl<T, Context, funcs::CudaSqrtGradFunctor<T>>(
+        dev_ctx, &x, nullptr, &dout, dx, functor);
+    return;
+  }
+  if (factor.to<float>() == 1) {
+    std::vector<int64_t> vec_dims = common::vectorize(dx->dims());
+    phi::Full<T, Context>(
+        dev_ctx, phi::IntArray(vec_dims), static_cast<T>(1), dx);
+    return;
+  }
+  if (factor.to<float>() == 2) {
+    funcs::CudaSquareGradFunctor<T> functor;
+    ActivationGradGPUImpl<T, Context, funcs::CudaSquareGradFunctor<T>>(
+        dev_ctx, &x, nullptr, &dout, dx, functor);
+    return;
+  }
+  if (factor.to<float>() == 3) {
+    funcs::CudaCubeGradFunctor<T> functor;
+    ActivationGradGPUImpl<T, Context, funcs::CudaCubeGradFunctor<T>>(
+        dev_ctx, &x, nullptr, &dout, dx, functor);
+    return;
+  }
+  if (factor.to<float>() == -0.5) {
+    funcs::CudaRsqrtGradFunctor<T> functor;
+    ActivationGradGPUImpl<T, Context, funcs::CudaRsqrtGradFunctor<T>>(
+        dev_ctx, &x, nullptr, &dout, dx, functor);
+    return;
+  }
+  if (factor.to<float>() == -1) {
+    funcs::CudaReciprocalGradFunctor<T> functor;
+    ActivationGradGPUImpl<T, Context, funcs::CudaReciprocalGradFunctor<T>>(
+        dev_ctx, &x, nullptr, &dout, dx, functor);
+    return;
+  }
+  if (factor.to<float>() == -2) {
+    funcs::CudaRsquareGradFunctor<T> functor;
+    ActivationGradGPUImpl<T, Context, funcs::CudaRsquareGradFunctor<T>>(
+        dev_ctx, &x, nullptr, &dout, dx, functor);
+    return;
+  }
   funcs::CudaPowGradFunctor<T> functor;
   functor.SetFactor(factor.to<float>());
   ActivationGradGPUImpl<T, Context, funcs::CudaPowGradFunctor<T>>(

--- a/paddle/phi/kernels/gpu/activation_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/activation_grad_kernel.cu
@@ -322,6 +322,12 @@ void PowGradKernel(const Context& dev_ctx,
     phi::Copy<Context>(dev_ctx, dout, dev_ctx.GetPlace(), false, dx);
     return;
   }
+  if (factor.to<float>() == 1.5) {
+    funcs::CudaPow1p5GradFunctor<T> functor;
+    ActivationGradGPUImpl<T, Context, funcs::CudaPow1p5GradFunctor<T>>(
+        dev_ctx, &x, nullptr, &dout, dx, functor);
+    return;
+  }
   if (factor.to<float>() == 2) {
     funcs::CudaSquareGradFunctor<T> functor;
     ActivationGradGPUImpl<T, Context, funcs::CudaSquareGradFunctor<T>>(
@@ -334,28 +340,24 @@ void PowGradKernel(const Context& dev_ctx,
         dev_ctx, &x, nullptr, &dout, dx, functor);
     return;
   }
+  if (factor.to<float>() == 4) {
+    funcs::CudaPow4GradFunctor<T> functor;
+    ActivationGradGPUImpl<T, Context, funcs::CudaPow4GradFunctor<T>>(
+        dev_ctx, &x, nullptr, &dout, dx, functor);
+    return;
+  }
   if constexpr (!std::is_integral<T>::value) {
-    // if (factor.to<float>() == 0.5) {
-    //   funcs::CudaSqrtGradFunctor<T> functor;
-    //   ActivationGradGPUImpl<T, Context, funcs::CudaSqrtGradFunctor<T>>(
-    //       dev_ctx, &x, nullptr, &dout, dx, functor);
-    //   return;
-    // }
-    // if (factor.to<float>() == -0.5) {
-    //   funcs::CudaRsqrtGradFunctor<T> functor;
-    //   ActivationGradGPUImpl<T, Context, funcs::CudaRsqrtGradFunctor<T>>(
-    //       dev_ctx, &x, nullptr, &dout, dx, functor);
-    //   return;
-    // }
-    // if (factor.to<float>() == -1) {
-    //   funcs::CudaReciprocalGradFunctor<T> functor;
-    //   ActivationGradGPUImpl<T, Context, funcs::CudaReciprocalGradFunctor<T>>(
-    //       dev_ctx, &x, nullptr, &dout, dx, functor);
-    //   return;
-    // }
-    if (factor.to<float>() == -2) {
-      funcs::CudaRsquareGradFunctor<T> functor;
-      ActivationGradGPUImpl<T, Context, funcs::CudaRsquareGradFunctor<T>>(
+    if (factor.to<float>() == 0.5) {
+      funcs::CudaSqrtGradDepXFunctor<T> functor;
+      ActivationGradGPUImpl<T, Context, funcs::CudaSqrtGradDepXFunctor<T>>(
+          dev_ctx, &x, nullptr, &dout, dx, functor);
+      return;
+    }
+    if (factor.to<float>() == -1) {
+      funcs::CudaReciprocalGradDepXFunctor<T> functor;
+      ActivationGradGPUImpl<T,
+                            Context,
+                            funcs::CudaReciprocalGradDepXFunctor<T>>(
           dev_ctx, &x, nullptr, &dout, dx, functor);
       return;
     }

--- a/paddle/phi/kernels/gpu/activation_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/activation_grad_kernel.cu
@@ -317,12 +317,6 @@ void PowGradKernel(const Context& dev_ctx,
         dev_ctx, phi::IntArray(vec_dims), static_cast<T>(0), dx);
     return;
   }
-  // if (factor.to<float>() == 0.5) {
-  //   funcs::CudaSqrtGradFunctor<T> functor;
-  //   ActivationGradGPUImpl<T, Context, funcs::CudaSqrtGradFunctor<T>>(
-  //       dev_ctx, &x, nullptr, &dout, dx, functor);
-  //   return;
-  // }
   if (factor.to<float>() == 1) {
     std::vector<int64_t> vec_dims = common::vectorize(dx->dims());
     phi::Copy<Context>(dev_ctx, dout, dev_ctx.GetPlace(), false, dx);
@@ -341,6 +335,12 @@ void PowGradKernel(const Context& dev_ctx,
     return;
   }
   if constexpr (!std::is_integral<T>::value) {
+    // if (factor.to<float>() == 0.5) {
+    //   funcs::CudaSqrtGradFunctor<T> functor;
+    //   ActivationGradGPUImpl<T, Context, funcs::CudaSqrtGradFunctor<T>>(
+    //       dev_ctx, &x, nullptr, &dout, dx, functor);
+    //   return;
+    // }
     // if (factor.to<float>() == -0.5) {
     //   funcs::CudaRsqrtGradFunctor<T> functor;
     //   ActivationGradGPUImpl<T, Context, funcs::CudaRsqrtGradFunctor<T>>(

--- a/paddle/phi/kernels/gpu/activation_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/activation_grad_kernel.cu
@@ -322,12 +322,6 @@ void PowGradKernel(const Context& dev_ctx,
     phi::Copy<Context>(dev_ctx, dout, dev_ctx.GetPlace(), false, dx);
     return;
   }
-  if (factor.to<float>() == 1.5) {
-    funcs::CudaPow1p5GradFunctor<T> functor;
-    ActivationGradGPUImpl<T, Context, funcs::CudaPow1p5GradFunctor<T>>(
-        dev_ctx, &x, nullptr, &dout, dx, functor);
-    return;
-  }
   if (factor.to<float>() == 2) {
     funcs::CudaSquareGradFunctor<T> functor;
     ActivationGradGPUImpl<T, Context, funcs::CudaSquareGradFunctor<T>>(
@@ -347,6 +341,12 @@ void PowGradKernel(const Context& dev_ctx,
     return;
   }
   if constexpr (!std::is_integral<T>::value) {
+    if (factor.to<float>() == 1.5) {
+      funcs::CudaPow1p5GradFunctor<T> functor;
+      ActivationGradGPUImpl<T, Context, funcs::CudaPow1p5GradFunctor<T>>(
+          dev_ctx, &x, nullptr, &dout, dx, functor);
+      return;
+    }
     if (factor.to<float>() == 0.5) {
       funcs::CudaSqrtGradDepXFunctor<T> functor;
       ActivationGradGPUImpl<T, Context, funcs::CudaSqrtGradDepXFunctor<T>>(

--- a/paddle/phi/kernels/gpu/activation_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/activation_grad_kernel.cu
@@ -311,49 +311,49 @@ void PowGradKernel(const Context& dev_ctx,
                    const DenseTensor& dout,
                    const Scalar& factor,
                    DenseTensor* dx) {
-  if (factor.to<float>() == 0) {
+  if (factor.to<double>() == 0) {
     std::vector<int64_t> vec_dims = common::vectorize(dx->dims());
     phi::Full<T, Context>(
         dev_ctx, phi::IntArray(vec_dims), static_cast<T>(0), dx);
     return;
   }
-  if (factor.to<float>() == 1) {
+  if (factor.to<double>() == 1) {
     std::vector<int64_t> vec_dims = common::vectorize(dx->dims());
     phi::Copy<Context>(dev_ctx, dout, dev_ctx.GetPlace(), false, dx);
     return;
   }
-  if (factor.to<float>() == 2) {
+  if (factor.to<double>() == 2) {
     funcs::CudaSquareGradFunctor<T> functor;
     ActivationGradGPUImpl<T, Context, funcs::CudaSquareGradFunctor<T>>(
         dev_ctx, &x, nullptr, &dout, dx, functor);
     return;
   }
-  if (factor.to<float>() == 3) {
+  if (factor.to<double>() == 3) {
     funcs::CudaCubeGradFunctor<T> functor;
     ActivationGradGPUImpl<T, Context, funcs::CudaCubeGradFunctor<T>>(
         dev_ctx, &x, nullptr, &dout, dx, functor);
     return;
   }
-  if (factor.to<float>() == 4) {
+  if (factor.to<double>() == 4) {
     funcs::CudaPow4GradFunctor<T> functor;
     ActivationGradGPUImpl<T, Context, funcs::CudaPow4GradFunctor<T>>(
         dev_ctx, &x, nullptr, &dout, dx, functor);
     return;
   }
   if constexpr (!std::is_integral<T>::value) {
-    if (factor.to<float>() == 1.5) {
+    if (factor.to<double>() == 1.5) {
       funcs::CudaPow1p5GradFunctor<T> functor;
       ActivationGradGPUImpl<T, Context, funcs::CudaPow1p5GradFunctor<T>>(
           dev_ctx, &x, nullptr, &dout, dx, functor);
       return;
     }
-    if (factor.to<float>() == 0.5) {
+    if (factor.to<double>() == 0.5) {
       funcs::CudaSqrtGradDepXFunctor<T> functor;
       ActivationGradGPUImpl<T, Context, funcs::CudaSqrtGradDepXFunctor<T>>(
           dev_ctx, &x, nullptr, &dout, dx, functor);
       return;
     }
-    if (factor.to<float>() == -1) {
+    if (factor.to<double>() == -1) {
       funcs::CudaReciprocalGradDepXFunctor<T> functor;
       ActivationGradGPUImpl<T,
                             Context,
@@ -363,7 +363,7 @@ void PowGradKernel(const Context& dev_ctx,
     }
   }
   funcs::CudaPowGradFunctor<T> functor;
-  functor.SetFactor(factor.to<float>());
+  functor.SetFactor(factor.to<double>());
   ActivationGradGPUImpl<T, Context, funcs::CudaPowGradFunctor<T>>(
       dev_ctx, &x, nullptr, &dout, dx, functor);
 }

--- a/paddle/phi/kernels/gpu/activation_kernel.cu
+++ b/paddle/phi/kernels/gpu/activation_kernel.cu
@@ -222,13 +222,60 @@ void PowKernel(const Context& dev_ctx,
         dev_ctx, phi::IntArray(vec_dims), static_cast<T>(1), out);
     return;
   }
+  if (factor.to<float>() == 0.5) {
+    funcs::CudaSqrtFunctor<T> functor;
+    ActivationGPUImpl<T, Context, funcs::CudaSqrtFunctor<T>>(
+        dev_ctx, x, out, functor);
+    return;
+  }
   if (factor.to<float>() == 1) {
     phi::Copy<Context>(dev_ctx, x, dev_ctx.GetPlace(), false, out);
     return;
   }
+  // if (factor.to<float>() == 2) {
+  //   ActivationGPUImpl<T, Context, std::function<T(const T)>>(
+  //       dev_ctx, x, out, []__device__(const T x){
+  //         return x * x;
+  //       });
+  //   return;
+  // }
+  // if (factor.to<float>() == 3) {
+  //   ActivationGPUImpl<T, Context, std::function<T(const T)>>(
+  //       dev_ctx, x, out, [=] __host__ __device__(const T x) -> T {
+  //         return x * x*x;
+  //       });
+  //   return;
+  // }
+  // TODO(zrr1999): to add for CudaRsqrtFunctor
+  // if (factor.to<float>() == -0.5) {
+  //   funcs::CudaRsqrtFunctor<T> functor;
+  //   ActivationGPUImpl<T, Context, funcs::CudaRsqrtFunctor<T>>(
+  //       dev_ctx, x, out, functor);
+  //   return;
+  // }
+  if (factor.to<float>() == -1) {
+    funcs::CudaReciprocalFunctor<T> functor;
+    ActivationGPUImpl<T, Context, funcs::CudaReciprocalFunctor<T>>(
+        dev_ctx, x, out, functor);
+    return;
+  }
+  // if (factor.to<float>() == -2) {
+  //   ActivationGPUImpl<T, Context, std::function<T(const T)>>(
+  //       dev_ctx, x, out, [=] __host__ __device__(const T x) -> T {
+  //         return static_cast<T>(1)/ (x * x);
+  //       });
+  //   return;
+  // }
+  // if (factor.to<float>() == -3) {
+  //   ActivationGPUImpl<T, Context, std::function<T(const T)>>(
+  //       dev_ctx, x, out, [=] __host__ __device__(const T x) -> T {
+  //         return static_cast<T>(1)/ (x * x *x);
+  //       });
+  //   return;
+  // }
+
   funcs::CudaPowFunctor<T> functor;
-  auto attrs = functor.GetAttrs();
-  *(attrs[0].second) = factor.to<float>();
+  functor.SetFactor(factor.to<float>());
   ActivationGPUImpl<T, Context, funcs::CudaPowFunctor<T>>(
       dev_ctx, x, out, functor);
 }

--- a/paddle/phi/kernels/gpu/activation_kernel.cu
+++ b/paddle/phi/kernels/gpu/activation_kernel.cu
@@ -216,12 +216,6 @@ void PowKernel(const Context& dev_ctx,
         common::errors::InvalidArgument(
             "Integers to negative integer powers are not allowed."));
   } else {
-    if (factor.to<float>() == 0.5) {
-      funcs::CudaSqrtFunctor<T> functor;
-      ActivationGPUImpl<T, Context, funcs::CudaSqrtFunctor<T>>(
-          dev_ctx, x, out, functor);
-      return;
-    }
     if (factor.to<float>() == -0.5) {
       funcs::CudaRsqrtFunctor<T> functor;
       ActivationGPUImpl<T, Context, funcs::CudaRsqrtFunctor<T>>(
@@ -245,6 +239,12 @@ void PowKernel(const Context& dev_ctx,
     std::vector<int64_t> vec_dims = common::vectorize(out->dims());
     phi::Full<T, Context>(
         dev_ctx, phi::IntArray(vec_dims), static_cast<T>(1), out);
+    return;
+  }
+  if (factor.to<float>() == 0.5) {
+    funcs::CudaSqrtFunctor<T> functor;
+    ActivationGPUImpl<T, Context, funcs::CudaSqrtFunctor<T>>(
+        dev_ctx, x, out, functor);
     return;
   }
   if (factor.to<float>() == 1) {

--- a/paddle/phi/kernels/gpu/activation_kernel.cu
+++ b/paddle/phi/kernels/gpu/activation_kernel.cu
@@ -215,6 +215,25 @@ void PowKernel(const Context& dev_ctx,
         0,
         common::errors::InvalidArgument(
             "Integers to negative integer powers are not allowed."));
+  } else {
+    if (factor.to<float>() == -0.5) {
+      funcs::CudaRsqrtFunctor<T> functor;
+      ActivationGPUImpl<T, Context, funcs::CudaRsqrtFunctor<T>>(
+          dev_ctx, x, out, functor);
+      return;
+    }
+    if (factor.to<float>() == -1) {
+      funcs::CudaReciprocalFunctor<T> functor;
+      ActivationGPUImpl<T, Context, funcs::CudaReciprocalFunctor<T>>(
+          dev_ctx, x, out, functor);
+      return;
+    }
+    if (factor.to<float>() == -2) {
+      funcs::CudaRsquareFunctor<T> functor;
+      ActivationGPUImpl<T, Context, funcs::CudaRsquareFunctor<T>>(
+          dev_ctx, x, out, functor);
+      return;
+    }
   }
   if (factor.to<float>() == 0) {
     std::vector<int64_t> vec_dims = common::vectorize(out->dims());
@@ -241,24 +260,6 @@ void PowKernel(const Context& dev_ctx,
   if (factor.to<float>() == 3) {
     funcs::CudaCubeFunctor<T> functor;
     ActivationGPUImpl<T, Context, funcs::CudaCubeFunctor<T>>(
-        dev_ctx, x, out, functor);
-    return;
-  }
-  if (factor.to<float>() == -0.5) {
-    funcs::CudaRsqrtFunctor<T> functor;
-    ActivationGPUImpl<T, Context, funcs::CudaRsqrtFunctor<T>>(
-        dev_ctx, x, out, functor);
-    return;
-  }
-  if (factor.to<float>() == -1) {
-    funcs::CudaReciprocalFunctor<T> functor;
-    ActivationGPUImpl<T, Context, funcs::CudaReciprocalFunctor<T>>(
-        dev_ctx, x, out, functor);
-    return;
-  }
-  if (factor.to<float>() == -2) {
-    funcs::CudaRsquareFunctor<T> functor;
-    ActivationGPUImpl<T, Context, funcs::CudaRsquareFunctor<T>>(
         dev_ctx, x, out, functor);
     return;
   }

--- a/paddle/phi/kernels/gpu/activation_kernel.cu
+++ b/paddle/phi/kernels/gpu/activation_kernel.cu
@@ -216,6 +216,12 @@ void PowKernel(const Context& dev_ctx,
         common::errors::InvalidArgument(
             "Integers to negative integer powers are not allowed."));
   } else {
+    if (factor.to<float>() == 0.5) {
+      funcs::CudaSqrtFunctor<T> functor;
+      ActivationGPUImpl<T, Context, funcs::CudaSqrtFunctor<T>>(
+          dev_ctx, x, out, functor);
+      return;
+    }
     if (factor.to<float>() == -0.5) {
       funcs::CudaRsqrtFunctor<T> functor;
       ActivationGPUImpl<T, Context, funcs::CudaRsqrtFunctor<T>>(
@@ -239,12 +245,6 @@ void PowKernel(const Context& dev_ctx,
     std::vector<int64_t> vec_dims = common::vectorize(out->dims());
     phi::Full<T, Context>(
         dev_ctx, phi::IntArray(vec_dims), static_cast<T>(1), out);
-    return;
-  }
-  if (factor.to<float>() == 0.5) {
-    funcs::CudaSqrtFunctor<T> functor;
-    ActivationGPUImpl<T, Context, funcs::CudaSqrtFunctor<T>>(
-        dev_ctx, x, out, functor);
     return;
   }
   if (factor.to<float>() == 1) {

--- a/paddle/phi/kernels/gpu/activation_kernel.cu
+++ b/paddle/phi/kernels/gpu/activation_kernel.cu
@@ -211,53 +211,53 @@ void PowKernel(const Context& dev_ctx,
                DenseTensor* out) {
   if constexpr (std::is_integral<T>::value) {
     PADDLE_ENFORCE_GE(
-        factor.to<float>(),
+        factor.to<double>(),
         0,
         common::errors::InvalidArgument(
             "Integers to negative integer powers are not allowed."));
   } else {
-    if (factor.to<float>() == 0.5) {
+    if (factor.to<double>() == 0.5) {
       funcs::CudaSqrtFunctor<T> functor;
       ActivationGPUImpl<T, Context, funcs::CudaSqrtFunctor<T>>(
           dev_ctx, x, out, functor);
       return;
     }
-    if (factor.to<float>() == -0.5) {
+    if (factor.to<double>() == -0.5) {
       funcs::CudaRsqrtFunctor<T> functor;
       ActivationGPUImpl<T, Context, funcs::CudaRsqrtFunctor<T>>(
           dev_ctx, x, out, functor);
       return;
     }
-    if (factor.to<float>() == -1) {
+    if (factor.to<double>() == -1) {
       funcs::CudaReciprocalFunctor<T> functor;
       ActivationGPUImpl<T, Context, funcs::CudaReciprocalFunctor<T>>(
           dev_ctx, x, out, functor);
       return;
     }
-    if (factor.to<float>() == -2) {
+    if (factor.to<double>() == -2) {
       funcs::CudaRsquareFunctor<T> functor;
       ActivationGPUImpl<T, Context, funcs::CudaRsquareFunctor<T>>(
           dev_ctx, x, out, functor);
       return;
     }
   }
-  if (factor.to<float>() == 0) {
+  if (factor.to<double>() == 0) {
     std::vector<int64_t> vec_dims = common::vectorize(out->dims());
     phi::Full<T, Context>(
         dev_ctx, phi::IntArray(vec_dims), static_cast<T>(1), out);
     return;
   }
-  if (factor.to<float>() == 1) {
+  if (factor.to<double>() == 1) {
     phi::Copy<Context>(dev_ctx, x, dev_ctx.GetPlace(), false, out);
     return;
   }
-  if (factor.to<float>() == 2) {
+  if (factor.to<double>() == 2) {
     funcs::CudaSquareFunctor<T> functor;
     ActivationGPUImpl<T, Context, funcs::CudaSquareFunctor<T>>(
         dev_ctx, x, out, functor);
     return;
   }
-  if (factor.to<float>() == 3) {
+  if (factor.to<double>() == 3) {
     funcs::CudaCubeFunctor<T> functor;
     ActivationGPUImpl<T, Context, funcs::CudaCubeFunctor<T>>(
         dev_ctx, x, out, functor);
@@ -265,7 +265,7 @@ void PowKernel(const Context& dev_ctx,
   }
 
   funcs::CudaPowFunctor<T> functor;
-  functor.SetFactor(factor.to<float>());
+  functor.SetFactor(factor.to<double>());
   ActivationGPUImpl<T, Context, funcs::CudaPowFunctor<T>>(
       dev_ctx, x, out, functor);
 }

--- a/paddle/phi/kernels/gpu/activation_kernel.cu
+++ b/paddle/phi/kernels/gpu/activation_kernel.cu
@@ -232,47 +232,36 @@ void PowKernel(const Context& dev_ctx,
     phi::Copy<Context>(dev_ctx, x, dev_ctx.GetPlace(), false, out);
     return;
   }
-  // if (factor.to<float>() == 2) {
-  //   ActivationGPUImpl<T, Context, std::function<T(const T)>>(
-  //       dev_ctx, x, out, []__device__(const T x){
-  //         return x * x;
-  //       });
-  //   return;
-  // }
-  // if (factor.to<float>() == 3) {
-  //   ActivationGPUImpl<T, Context, std::function<T(const T)>>(
-  //       dev_ctx, x, out, [=] __host__ __device__(const T x) -> T {
-  //         return x * x*x;
-  //       });
-  //   return;
-  // }
-  // TODO(zrr1999): to add for CudaRsqrtFunctor
-  // if (factor.to<float>() == -0.5) {
-  //   funcs::CudaRsqrtFunctor<T> functor;
-  //   ActivationGPUImpl<T, Context, funcs::CudaRsqrtFunctor<T>>(
-  //       dev_ctx, x, out, functor);
-  //   return;
-  // }
+  if (factor.to<float>() == 2) {
+    funcs::CudaSquareFunctor<T> functor;
+    ActivationGPUImpl<T, Context, funcs::CudaSquareFunctor<T>>(
+        dev_ctx, x, out, functor);
+    return;
+  }
+  if (factor.to<float>() == 3) {
+    funcs::CudaCubeFunctor<T> functor;
+    ActivationGPUImpl<T, Context, funcs::CudaCubeFunctor<T>>(
+        dev_ctx, x, out, functor);
+    return;
+  }
+  if (factor.to<float>() == -0.5) {
+    funcs::CudaRsqrtFunctor<T> functor;
+    ActivationGPUImpl<T, Context, funcs::CudaRsqrtFunctor<T>>(
+        dev_ctx, x, out, functor);
+    return;
+  }
   if (factor.to<float>() == -1) {
     funcs::CudaReciprocalFunctor<T> functor;
     ActivationGPUImpl<T, Context, funcs::CudaReciprocalFunctor<T>>(
         dev_ctx, x, out, functor);
     return;
   }
-  // if (factor.to<float>() == -2) {
-  //   ActivationGPUImpl<T, Context, std::function<T(const T)>>(
-  //       dev_ctx, x, out, [=] __host__ __device__(const T x) -> T {
-  //         return static_cast<T>(1)/ (x * x);
-  //       });
-  //   return;
-  // }
-  // if (factor.to<float>() == -3) {
-  //   ActivationGPUImpl<T, Context, std::function<T(const T)>>(
-  //       dev_ctx, x, out, [=] __host__ __device__(const T x) -> T {
-  //         return static_cast<T>(1)/ (x * x *x);
-  //       });
-  //   return;
-  // }
+  if (factor.to<float>() == -2) {
+    funcs::CudaRsquareFunctor<T> functor;
+    ActivationGPUImpl<T, Context, funcs::CudaRsquareFunctor<T>>(
+        dev_ctx, x, out, functor);
+    return;
+  }
 
   funcs::CudaPowFunctor<T> functor;
   functor.SetFactor(factor.to<float>());

--- a/paddle/phi/kernels/impl/elementwise_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/elementwise_grad_kernel_impl.h
@@ -1430,8 +1430,7 @@ compute_pow_grad_dx(T x, T y, T out, T dout) {
   if (y == static_cast<T>(0.0)) return static_cast<T>(0.0);
   MPType x_val = static_cast<MPType>(x);
   MPType y_val = static_cast<MPType>(y);
-  return static_cast<T>(static_cast<MPType>(dout) * y_val *
-                        pow(x_val, y_val - 1));
+  return dout * static_cast<T>(y_val * pow(x_val, y_val - 1));
 }
 template <typename T, typename MPType>
 HOSTDEVICE typename std::enable_if<std::is_integral<T>::value, T>::type
@@ -1448,8 +1447,7 @@ compute_pow_grad_dy(T x, T y, T out, T dout) {
     return static_cast<T>(0);
   MPType x_val = static_cast<MPType>(x);
   MPType y_val = static_cast<MPType>(y);
-  return static_cast<T>(static_cast<MPType>(dout) * log(x_val) *
-                        pow(x_val, y_val));
+  return dout * static_cast<T>(log(x_val) * pow(x_val, y_val));
 }
 #else
 template <typename T, typename MPType>
@@ -1457,8 +1455,7 @@ HOSTDEVICE T compute_pow_grad_dx(T x, T y, T out UNUSED, T dout) {
   if (y == static_cast<T>(0.0)) return static_cast<T>(0.0);
   MPType x_val = static_cast<MPType>(x);
   MPType y_val = static_cast<MPType>(y);
-  return static_cast<T>(static_cast<MPType>(dout) * y_val *
-                        std::pow(x_val, y_val - 1));
+  return dout * static_cast<T>(y_val * std::pow(x_val, y_val - 1));
 }
 template <typename T, typename MPType>
 HOSTDEVICE T compute_pow_grad_dy(T x, T y, T out UNUSED, T dout) {
@@ -1466,8 +1463,7 @@ HOSTDEVICE T compute_pow_grad_dy(T x, T y, T out UNUSED, T dout) {
     return static_cast<T>(0);
   MPType x_val = static_cast<MPType>(x);
   MPType y_val = static_cast<MPType>(y);
-  return static_cast<T>(static_cast<MPType>(dout) * std::log(x_val) *
-                        std::pow(x_val, y_val));
+  return dout * static_cast<T>(std::log(x_val) * std::pow(x_val, y_val));
 }
 #endif
 

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -574,7 +574,7 @@ def pow(x: Tensor, y: float | Tensor, name: str | None = None) -> Tensor:
 
     # in dynamic graph mode
     if in_dynamic_or_pir_mode():
-        if isinstance(y, (int, float)) or (in_dynamic_mode() and y.size == 1):
+        if isinstance(y, (int, float)) or y.dim() == 0:
             return _C_ops.pow(x, y)
         elif isinstance(y, (paddle.Tensor, Variable, paddle.pir.Value)):
             return _C_ops.elementwise_pow(x, y)

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -574,7 +574,7 @@ def pow(x: Tensor, y: float | Tensor, name: str | None = None) -> Tensor:
 
     # in dynamic graph mode
     if in_dynamic_or_pir_mode():
-        if isinstance(y, (int, float)) or y.dim() == 0:
+        if isinstance(y, (int, float)):
             return _C_ops.pow(x, y)
         elif isinstance(y, (paddle.Tensor, Variable, paddle.pir.Value)):
             return _C_ops.elementwise_pow(x, y)

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -574,7 +574,7 @@ def pow(x: Tensor, y: float | Tensor, name: str | None = None) -> Tensor:
 
     # in dynamic graph mode
     if in_dynamic_or_pir_mode():
-        if isinstance(y, (int, float)):
+        if isinstance(y, (int, float)) or (in_dynamic_mode() and y.size == 1):
             return _C_ops.pow(x, y)
         elif isinstance(y, (paddle.Tensor, Variable, paddle.pir.Value)):
             return _C_ops.elementwise_pow(x, y)

--- a/test/legacy_test/test_pow.py
+++ b/test/legacy_test/test_pow.py
@@ -261,7 +261,7 @@ class TestPowerAPI_Specialization(unittest.TestCase):
         np.random.seed(7)
         inputs = [
             np.random.rand(10, 10) * 10,
-            np.complex64(
+            np.complex128(
                 np.random.rand(10, 10) * 10 + 1j * np.random.rand(10, 10)
             ),
         ]

--- a/test/legacy_test/test_pow.py
+++ b/test/legacy_test/test_pow.py
@@ -273,12 +273,12 @@ class TestPowerAPI_Specialization(unittest.TestCase):
 
     def test_power(self):
         self._test_power(0)
-        # self._test_power(0.5)
+        self._test_power(0.5)
         self._test_power(1)
         self._test_power(2)
         self._test_power(3)
-        # self._test_power(-0.5)
-        # self._test_power(-1)
+        self._test_power(-0.5)
+        self._test_power(-1)
         self._test_power(-2)
 
 

--- a/test/legacy_test/test_pow.py
+++ b/test/legacy_test/test_pow.py
@@ -259,17 +259,23 @@ class TestPowerAPI_Specialization(unittest.TestCase):
 
     def _test_power(self, factor: float):
         np.random.seed(7)
-        for place in self.places:
-            x = (np.random.rand(10, 10) * 10).astype(np.float64)
-            paddle.disable_static()
-            paddle.set_device(place)
-            x_ = paddle.to_tensor(x)
-            x_.stop_gradient = False
-            res = paddle.pow(x_, factor)
-            np.testing.assert_allclose(res, np.power(x, factor), rtol=1e-05)
-            loss = paddle.sum(res)
-            loss.backward()
-            np.testing.assert_allclose(x_.grad.shape, x_.shape)
+        inputs = [
+            np.random.rand(10, 10) * 10,
+            np.complex64(
+                np.random.rand(10, 10) * 10 + 1j * np.random.rand(10, 10)
+            ),
+        ]
+        for x in inputs:
+            for place in self.places:
+                paddle.disable_static()
+                paddle.set_device(place)
+                x_ = paddle.to_tensor(x)
+                x_.stop_gradient = False
+                res = paddle.pow(x_, factor)
+                np.testing.assert_allclose(res, np.power(x, factor), rtol=1e-05)
+                loss = paddle.sum(res)
+                loss.backward()
+                np.testing.assert_allclose(x_.grad.shape, x_.shape)
 
     def test_power(self):
         self._test_power(0)

--- a/test/legacy_test/test_pow.py
+++ b/test/legacy_test/test_pow.py
@@ -274,9 +274,11 @@ class TestPowerAPI_Specialization(unittest.TestCase):
     def test_power(self):
         self._test_power(0)
         self._test_power(0.5)
+        self._test_power(1.5)
         self._test_power(1)
         self._test_power(2)
         self._test_power(3)
+        self._test_power(4)
         self._test_power(-0.5)
         self._test_power(-1)
         self._test_power(-2)

--- a/test/legacy_test/test_pow.py
+++ b/test/legacy_test/test_pow.py
@@ -251,6 +251,37 @@ class TestPowerAPI_ZeroSize(unittest.TestCase):
         self._test_power((0, 0))
 
 
+class TestPowerAPI_Specialization(unittest.TestCase):
+    """TestPowerAPI."""
+
+    def setUp(self):
+        self.places = get_devices()
+
+    def _test_power(self, factor: float):
+        np.random.seed(7)
+        for place in self.places:
+            x = (np.random.rand(10, 10) * 10).astype(np.float64)
+            paddle.disable_static()
+            paddle.set_device(place)
+            x_ = paddle.to_tensor(x)
+            x_.stop_gradient = False
+            res = paddle.pow(x_, factor)
+            np.testing.assert_allclose(res, np.power(x, factor), rtol=1e-05)
+            loss = paddle.sum(res)
+            loss.backward()
+            np.testing.assert_allclose(x_.grad.shape, x_.shape)
+
+    def test_power(self):
+        self._test_power(0)
+        # self._test_power(0.5)
+        self._test_power(1)
+        self._test_power(2)
+        self._test_power(3)
+        # self._test_power(-0.5)
+        # self._test_power(-1)
+        self._test_power(-2)
+
+
 class TestPowerAPI_Alias(unittest.TestCase):
     """
     Test the alias of pow function.

--- a/test/legacy_test/test_pow_op.py
+++ b/test/legacy_test/test_pow_op.py
@@ -64,7 +64,9 @@ class TestPowOp_ZeroDim1(TestPowOp):
         self.inputs = {
             'X': np.random.uniform(1, 2, []).astype("float64"),
         }
-        self.attrs = {"factor": float(np.random.uniform(1, 2, []))}
+        self.attrs = {
+            "factor": float(np.random.uniform(1, 2, []).astype(np.float32))
+        }
 
 
 class TestPowOp_big_shape_1(TestPowOp):
@@ -72,7 +74,9 @@ class TestPowOp_big_shape_1(TestPowOp):
         self.inputs = {
             'X': np.random.uniform(1, 2, [10, 10]).astype("float64"),
         }
-        self.attrs = {"factor": float(np.random.uniform(0, 10, []))}
+        self.attrs = {
+            "factor": float(np.random.uniform(0, 10, []).astype(np.float32))
+        }
 
 
 class TestPowOp_big_shape_2(TestPowOp):
@@ -80,7 +84,9 @@ class TestPowOp_big_shape_2(TestPowOp):
         self.inputs = {
             'X': np.random.uniform(1, 2, [4, 6, 8]).astype("float64"),
         }
-        self.attrs = {"factor": float(np.random.uniform(0, 10, []))}
+        self.attrs = {
+            "factor": float(np.random.uniform(0, 10, []).astype(np.float32))
+        }
 
 
 class TestPowOpInt(TestPowOp):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->
#### 修改内容
- 原本的 Paddle GPU PowKernel 仅针对 factor为0和 1 进行了特化，本PR 额外添加了对 0.5 2 3 -0.5 -1 -2 的特化（对齐PyTorch），其中 -0.5 -1 -2 不对整数类型进行特化。
- 原本的 Paddle GPU PowGradKernel 仅针对 factor 为0 进行了特化，本PR 额外添加了对 1 1.5 2 3 4 0.5 -1 的特化（对齐PyTorch），其中 0.5 -1 不对整数类型进行特化。  
-  PowGradKernel 的 1 特化使用copy。2 特化复用现有functor。-1 0.5特化使用新的CudaReciprocalGradDepXFunctor 和 CudaSqrtGradDepXFunctor，依赖于X而不是out。1.5 3 4 使用新的 CudaPow1p5GradFunctor,CudaCubeGradFunctor, CudaPow4GradFunctor。
- PowKernel 的 0.5 2 -0.5 -1 特化复用现有functor。3 -2 使用新的CudaCubeFunctor 和 CudaRsquareFunctor。
- PowKernel 和 PowGradKernel 的非特化部分通过修改计算顺序可以对齐PyTorch的精度 <img width="1019" height="324" alt="image" src="https://github.com/user-attachments/assets/3f3734ad-6947-4e74-b2cf-2ea77e7be6e9" />
- MPTypeTrait 添加 complex<float16> 到 complex<float> 的提升，与pytorch对齐。
- exponent 当前使用 float 保存，存在精度损失，~本PR修改为double~ 本PR修改为T，与PyTorch对齐
- ElementwisePowGradKernel 的 compute_pow_grad_dx 和 compute_pow_grad_dy 通过修改计算顺序和精度对齐PyTorch的精度。
- test_pow_op单测中，numpy 会将 float(np.random.uniform(1, 2, [])) 视为float32,但实际上这个值是float64，Paddle与PyTorch对齐后，这部分输入将视为float64,因此添加 .astype(np.float32)保证float64和float32在这个值上是一致的，从而与numpy的输入保持一致。
- ElementwiseInversePowFunctor<ComplexType<T>> 的实现中，gpu的逻辑把 pow(a,b)修正为pow(b, a)。

#### 特化实现思路
PyTorch 的反向实现如下：
```c++
Tensor pow_backward_self(
    const Tensor& grad,
    const Tensor& self,
    const Tensor& exponent) {
  auto out = at::where(
      exponent == 0.0,
      at::scalar_tensor(0.0, grad.options()),
      grad * (exponent * self.pow(exponent - 1)).conj());
  return handle_r_to_c(self, std::move(out));
}
```
PyTorch 与 Paddle，PyTorch的反向和正向使用了相同的算子库，因此对pow特化的时候，反向不需要额外的特化，但是Paddle实现要注意以下几点：
- PyTorch 许多算子实数和复数使用了同一套实现，因此一些计算并不是最优路径，
- PyTorch 采用了统一的实现（包括实数和复数），所以在计算顺序上并不是通常的顺序计算，例如 1/x的反向，最优应该是-dout/(x\*x)，但PyTorch是dout\*(-1/(x\*x))。x^3的反向 dout \* three \* x \* x 要改成 dout * (three * (x * x)) 。
- PyTorch 的正向对 0 0.5 1 2 3 -0.5 -1 -2 进行了特化，根据上述实现可知反向对 1 1.5 2 3 4 0.5 0 -1 实现了特化。

#### 剩余问题
本PR合入后剩余不对齐 case如下：
```bash
paddle.pow(Tensor([2, 3, 4],"float32"), Tensor([],"float32"), )
paddle.pow(Tensor([20, 1],"float32"), Tensor([],"float32"), )
paddle.pow(Tensor([20000, 1],"float32"), Tensor([],"float32"), )
paddle.pow(Tensor([20600, 1],"float32"), Tensor([],"float32"), )
paddle.pow(Tensor([4, 3, 2],"float32"), Tensor([4, 3, 2],"float16"), )
paddle.pow(Tensor([4, 3, 2],"float64"), Tensor([4, 3, 2],"float16"), )
paddle.pow(Tensor([4, 3, 2],"float64"), Tensor([4, 3, 2],"float32"), )
paddle.pow(Tensor([5, 9, 7],"float64"), Tensor([7],"float64"), )
paddle.pow(Tensor([],"float32"), Tensor([209],"float32"), )
paddle.pow(Tensor([4, 3, 2],"float64"), Tensor([4, 3, 2],"float32"), )
paddle.pow(Tensor([4, 3, 2],"float64"), Tensor([4, 3, 2],"float16"), )
```
其余问题目前汇总如下：
- 目前特化只针对pow(tensor, scalar)，需要补充pow(tensor, tensor)
- 第一个输入是常数或0d的情况 PyTorch 也单独写了一个kernel，Paddle目前无法对齐，需要新增kernel。
- a b 的shape不一致时，广播可能产生随机性。
- a b 的dtype不一致时且a的精度高于b的精度，根据分析 PyTorch 的实现（grad * (exponent * self.pow(exponent - 1)).conj()）可以发现，PyTorch的反向是复用的前向算子，并未有类型提升机制，exponent - 1 的会产生精度误差，虽然进行self.pow(exponent - 1)计算的时候会进行类型提升，但是精度损失已经产生，而 paddle 则提前进行了类型提升，所以进行类似的 exponent - 1 时精度本身就是更高的，后续的计算与PyTorch可以对齐。

其他不能与PyTorch 对齐的情况：
- tensor^scalar当，tensor为int，scalar为float的时候，torch会返回f32,paddle返回与tensor一致。

#### 其他问题：
下列内容与本PR的具体修改内容无关：
- 随机输入生成的问题，将在 https://github.com/PFCCLab/PaddleAPITest/pull/528 修复。
- PowGradDX和PowGradDY的复数实现可能存在问题。

Pcard-67164