### PR TITLE
[API Compatibility] add device/dtype/bias paramters and its unit test for nn.Conv1/2/3D/nn.Embedding

### DIFF
--- a/python/paddle/base/layer_helper_base.py
+++ b/python/paddle/base/layer_helper_base.py
@@ -340,6 +340,7 @@ class LayerHelperBase:
         default_initializer=None,
         stop_gradient=False,
         type=core.VarDesc.VarType.DENSE_TENSOR,
+        device=None,
     ):
         """Create parameters for this layers.
 
@@ -349,6 +350,7 @@ class LayerHelperBase:
                dtype: data type of this parameter
                is_bias: if this is a bias parameter
                default_initializer: set the default initializer for this parameter
+               device: device where this parameter will be placed
 
         Returns created parameter Variable.
         """
@@ -439,13 +441,16 @@ class LayerHelperBase:
                     "Please check the parameter attr value passed to self.create_parameter or "
                     "constructor of dygraph Layers"
                 )
-            return self.main_program.global_block().create_parameter(
+            param = self.main_program.global_block().create_parameter(
                 dtype=dtype,
                 shape=shape,
                 type=type,
                 stop_gradient=stop_gradient,
                 **attr._to_kwargs(with_initializer=True),
             )
+            if device is not None:
+                param = param.to(device)
+            return param
         else:
             if in_pir_mode():
                 if isinstance(dtype, core.VarDesc.VarType):

--- a/python/paddle/base/layer_helper_base.py
+++ b/python/paddle/base/layer_helper_base.py
@@ -455,11 +455,14 @@ class LayerHelperBase:
             if in_pir_mode():
                 if isinstance(dtype, core.VarDesc.VarType):
                     dtype = paddle.pir.core.vartype_to_datatype[dtype]
-                return paddle.pir.core.create_parameter(
+                param = paddle.pir.core.create_parameter(
                     dtype=dtype,
                     shape=shape,
                     **attr._to_kwargs(with_initializer=True),
                 )
+                if device is not None:
+                    param = param.to(device)
+                return param
             self.startup_program.global_block().create_parameter(
                 dtype=dtype,
                 shape=shape,

--- a/python/paddle/nn/__init__.py
+++ b/python/paddle/nn/__init__.py
@@ -87,8 +87,10 @@ from .layer.container import (
 )
 from .layer.conv import (
     Conv1D,
+    Conv1d,
     Conv1DTranspose,
     Conv2D,
+    Conv2d,
     Conv2DTranspose,
     Conv3D,
     Conv3d,
@@ -246,6 +248,7 @@ __all__ = [
     'NLLLoss',
     'PoissonNLLLoss',
     'Conv1D',
+    'Conv1d',
     'Sequential',
     'Hardswish',
     'Conv1DTranspose',
@@ -256,6 +259,7 @@ __all__ = [
     'ParameterDict',
     'ParameterList',
     'Conv2D',
+    'Conv2d',
     'Softshrink',
     'Hardtanh',
     'TransformerDecoderLayer',

--- a/python/paddle/nn/__init__.py
+++ b/python/paddle/nn/__init__.py
@@ -91,6 +91,7 @@ from .layer.conv import (
     Conv2D,
     Conv2DTranspose,
     Conv3D,
+    Conv3d,
     Conv3DTranspose,
 )
 from .layer.distance import PairwiseDistance
@@ -272,6 +273,7 @@ __all__ = [
     'Layer',
     'TransformerDecoder',
     'Conv3D',
+    'Conv3d',
     'Tanh',
     'Conv3DTranspose',
     'Flatten',

--- a/python/paddle/nn/functional/conv.py
+++ b/python/paddle/nn/functional/conv.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-import contextlib
 from typing import TYPE_CHECKING
 
 import paddle
@@ -197,28 +196,23 @@ def _conv_nd(
             return pre_bias
 
     if in_dynamic_or_pir_mode() and op_type == "conv3d":
-        with (
-            paddle.base.framework._dygraph_place_guard(place=weight.place)
-            if in_dynamic_mode()
-            else contextlib.nullcontext()
-        ):
-            pre_bias = _C_ops.conv3d(
-                x,
-                weight,
-                stride,
-                padding,
-                padding_algorithm,
-                groups,
-                dilation,
-                data_format,
-            )
-            if bias is not None:
-                new_shape = [1] * len(x.shape)
-                new_shape[channel_dim] = -1
-                bias = bias.reshape(new_shape)
-                return _C_ops.add(pre_bias, bias)
-            else:
-                return pre_bias
+        pre_bias = _C_ops.conv3d(
+            x,
+            weight,
+            stride,
+            padding,
+            padding_algorithm,
+            groups,
+            dilation,
+            data_format,
+        )
+        if bias is not None:
+            new_shape = [1] * len(x.shape)
+            new_shape[channel_dim] = -1
+            bias = bias.reshape(new_shape)
+            return _C_ops.add(pre_bias, bias)
+        else:
+            return pre_bias
 
     if in_dynamic_mode():
         attrs = (

--- a/python/paddle/nn/functional/conv.py
+++ b/python/paddle/nn/functional/conv.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import contextlib
 from typing import TYPE_CHECKING
 
 import paddle
@@ -196,23 +197,28 @@ def _conv_nd(
             return pre_bias
 
     if in_dynamic_or_pir_mode() and op_type == "conv3d":
-        pre_bias = _C_ops.conv3d(
-            x,
-            weight,
-            stride,
-            padding,
-            padding_algorithm,
-            groups,
-            dilation,
-            data_format,
-        )
-        if bias is not None:
-            new_shape = [1] * len(x.shape)
-            new_shape[channel_dim] = -1
-            bias = bias.reshape(new_shape)
-            return _C_ops.add(pre_bias, bias)
-        else:
-            return pre_bias
+        with (
+            paddle.base.framework._dygraph_place_guard(place=weight.place)
+            if in_dynamic_mode()
+            else contextlib.nullcontext()
+        ):
+            pre_bias = _C_ops.conv3d(
+                x,
+                weight,
+                stride,
+                padding,
+                padding_algorithm,
+                groups,
+                dilation,
+                data_format,
+            )
+            if bias is not None:
+                new_shape = [1] * len(x.shape)
+                new_shape[channel_dim] = -1
+                bias = bias.reshape(new_shape)
+                return _C_ops.add(pre_bias, bias)
+            else:
+                return pre_bias
 
     if in_dynamic_mode():
         attrs = (

--- a/python/paddle/nn/layer/common.py
+++ b/python/paddle/nn/layer/common.py
@@ -1730,8 +1730,8 @@ class Embedding(Layer):
         _freeze(bool, optional): Indicates whether to freeze the embedding weights. If set to True, the provided embedding tensor
             will be treated as a fixed lookup table and will not be updated during training.
             If set to False, the provided tensor remains learnable. Default: False.
-        device(str, optional): Device where the computation takes place when :attr:`weight_attr` is specified. Default: None
-        dtype(str, optional): Data type of the weights when :attr:`weight_attr` is specified. Default: None.
+        device(PlaceLike, optional): Device where the computation takes place when :attr:`weight_attr` is specified. Default: None
+        dtype(DTypeLike, optional): Data type of the weights when :attr:`weight_attr` is specified. Default: None.
         weight_attr(ParamAttr|None, optional): To specify the weight parameter property. If set, the :attr:`_freeze` attribute will be
             ignored and whether the weight is trainable  depends on the ``trainable`` option in ``weight_attr`. Default: None, which means the
             default weight parameter property is used. See usage for details in :ref:`api_paddle_ParamAttr` . In addition,
@@ -1799,7 +1799,7 @@ class Embedding(Layer):
         sparse: bool = False,
         _weight: Tensor | None = None,
         _freeze: bool = False,
-        device: str | PlaceLike | None = None,
+        device: PlaceLike | None = None,
         dtype: DTypeLike | None = None,
         weight_attr: ParamAttrLike | None = None,
         name: str | None = None,

--- a/python/paddle/nn/layer/common.py
+++ b/python/paddle/nn/layer/common.py
@@ -1866,6 +1866,10 @@ class Embedding(Layer):
             with paddle.no_grad():
                 self.weight[padding_idx] = 0.0
 
+    @property
+    def padding_idx(self):
+        return self._padding_idx
+
     @param_one_alias(["x", "input"])
     def forward(self, x: Tensor) -> Tensor:
         return F.embedding(

--- a/python/paddle/nn/layer/common.py
+++ b/python/paddle/nn/layer/common.py
@@ -18,7 +18,6 @@ from typing import TYPE_CHECKING, Any, TypeVar, overload
 
 import paddle
 from paddle import in_dynamic_mode
-from paddle.base.param_attr import ParamAttr
 from paddle.utils.decorator_utils import param_one_alias
 
 from .. import functional as F
@@ -1728,14 +1727,13 @@ class Embedding(Layer):
             word ids in input `x`. Default: False.
         _weight(Tensor, optional): The learnable weights to be applied to the input embeddings.
             If :attr:`_weight` is specified, the :attr:`weight_attr` is ignored. Default: None.
-        _freeze(bool, optional): Indicates whether to freeze the embedding weights when
-            :attr:`_weight` is provided. If set to True, the provided embedding tensor
+        _freeze(bool, optional): Indicates whether to freeze the embedding weights. If set to True, the provided embedding tensor
             will be treated as a fixed lookup table and will not be updated during training.
-            If set to False, the provided tensor remains learnable. Only takes effect when
-            :attr:`_weight` is specified. Default: False.
-        device(str, optional): Device where the computation takes place. Default: None
-        dtype(str, optional): Data type of the weights and bias. Default: None.
-        weight_attr(ParamAttr|None, optional): To specify the weight parameter property. Default: None, which means the
+            If set to False, the provided tensor remains learnable. Default: False.
+        device(str, optional): Device where the computation takes place when :attr:`weight_attr` is specified. Default: None
+        dtype(str, optional): Data type of the weights when :attr:`weight_attr` is specified. Default: None.
+        weight_attr(ParamAttr|None, optional): To specify the weight parameter property. If set, the :attr:`_freeze` attribute will be
+            ignored and whether the weight is trainable  depends on the ``trainable`` option in ``weight_attr`. Default: None, which means the
             default weight parameter property is used. See usage for details in :ref:`api_paddle_ParamAttr` . In addition,
             user-defined or pre-trained word vectors can be loaded with the :attr:`param_attr` parameter.
             The local word vector needs to be transformed into numpy format, and the shape of local word
@@ -1843,26 +1841,26 @@ class Embedding(Layer):
         )
         self._size = [self._num_embeddings, self._embedding_dim]
 
+        self._weight_attr = weight_attr
+        self._remote_prefetch = False
+        self._name = name
         if _weight is not None:
             assert list(_weight.shape) == [
                 num_embeddings,
                 embedding_dim,
             ], "Shape of weight does not match num_embeddings and embedding_dim"
-            self._weight_attr = ParamAttr(
-                initializer=paddle.nn.initializer.Assign(value=_weight),
-                trainable=not _freeze,
-            )
+            self.weight = _weight
+            self.weight.stop_gradient = _freeze
         else:
-            self._weight_attr = weight_attr
-        self._remote_prefetch = False
-        self._name = name
-        self.weight = self.create_parameter(
-            attr=self._weight_attr,
-            shape=self._size,
-            dtype=self._dtype,
-            is_bias=False,
-            device=self._device,
-        )
+            self.weight = self.create_parameter(
+                attr=self._weight_attr,
+                shape=self._size,
+                dtype=self._dtype,
+                is_bias=False,
+                device=self._device,
+            )
+            if self._weight_attr is None:
+                self.weight.stop_gradient = _freeze
 
         if in_dynamic_mode() and padding_idx != -1:
             with paddle.no_grad():

--- a/python/paddle/nn/layer/common.py
+++ b/python/paddle/nn/layer/common.py
@@ -18,6 +18,8 @@ from typing import TYPE_CHECKING, Any, TypeVar, overload
 
 import paddle
 from paddle import in_dynamic_mode
+from paddle.base.param_attr import ParamAttr
+from paddle.utils.decorator_utils import param_one_alias
 
 from .. import functional as F
 from .layers import Layer
@@ -31,7 +33,9 @@ if TYPE_CHECKING:
         DataLayout1DVariant,
         DataLayout2D,
         DataLayout3D,
+        DTypeLike,
         ParamAttrLike,
+        PlaceLike,
         ShapeLike,
         Size2,
         Size4,
@@ -1720,14 +1724,23 @@ class Embedding(Layer):
             True because sparse update is faster. But some optimizer does not support sparse update,
             such as :ref:`api_paddle_optimizer_adadelta_Adadelta` , :ref:`api_paddle_optimizer_adamax_Adamax` , :ref:`api_paddle_optimizer_lamb_Lamb`.
             In these case, sparse must be False. Default: False.
+        scale_grad_by_freq(bool, optional): Indicating whether to scale the gradients by the inverse frequency of the
+            word ids in input `x`. Default: False.
+        _weight(Tensor, optional): The learnable weights to be applied to the input embeddings.
+            If :attr:`_weight` is specified, the :attr:`weight_attr` is ignored. Default: None.
+        _freeze(bool, optional): Indicates whether to freeze the embedding weights when
+            :attr:`_weight` is provided. If set to True, the provided embedding tensor
+            will be treated as a fixed lookup table and will not be updated during training.
+            If set to False, the provided tensor remains learnable. Only takes effect when
+            :attr:`_weight` is specified. Default: False.
+        device(str, optional): Device where the computation takes place. Default: None
+        dtype(str, optional): Data type of the weights and bias. Default: None.
         weight_attr(ParamAttr|None, optional): To specify the weight parameter property. Default: None, which means the
             default weight parameter property is used. See usage for details in :ref:`api_paddle_ParamAttr` . In addition,
             user-defined or pre-trained word vectors can be loaded with the :attr:`param_attr` parameter.
             The local word vector needs to be transformed into numpy format, and the shape of local word
             vector should be consistent with :attr:`num_embeddings` . Then :ref:`api_paddle_nn_initializer_Assign`
             is used to load custom or pre-trained word vectors. See code example for details.
-        scale_grad_by_freq(bool, optional): Indicating whether to scale the gradients by the inverse frequency of the
-            word ids in input `x`. Default: False.
         name(str|None, optional): For detailed information, please refer to :ref:`api_guide_Name`. Usually name is no need to set and
             None by default.
 
@@ -1783,9 +1796,14 @@ class Embedding(Layer):
         padding_idx: float | None = None,
         max_norm: float | None = None,
         norm_type: float = 2.0,
-        sparse: bool = False,
-        weight_attr: ParamAttrLike | None = None,
+        *,
         scale_grad_by_freq: bool = False,
+        sparse: bool = False,
+        _weight: Tensor | None = None,
+        _freeze: bool = False,
+        device: str | PlaceLike | None = None,
+        dtype: DTypeLike | None = None,
+        weight_attr: ParamAttrLike | None = None,
         name: str | None = None,
     ) -> None:
         super().__init__()
@@ -1797,6 +1815,7 @@ class Embedding(Layer):
         self._norm_type = norm_type
         self._padding_idx = padding_idx
         self._scale_grad_by_freq = scale_grad_by_freq
+        self._device = device
 
         if self._num_embeddings <= 0:
             raise ValueError("num_embeddings must be gather than 0")
@@ -1819,10 +1838,22 @@ class Embedding(Layer):
                 f"padding_idx must be within [-{num_embeddings}, {num_embeddings})"
             )
 
-        self._dtype = self._helper.get_default_dtype()
+        self._dtype = (
+            self._helper.get_default_dtype() if dtype is None else dtype
+        )
         self._size = [self._num_embeddings, self._embedding_dim]
 
-        self._weight_attr = weight_attr
+        if _weight is not None:
+            assert list(_weight.shape) == [
+                num_embeddings,
+                embedding_dim,
+            ], "Shape of weight does not match num_embeddings and embedding_dim"
+            self._weight_attr = ParamAttr(
+                initializer=paddle.nn.initializer.Assign(value=_weight),
+                trainable=not _freeze,
+            )
+        else:
+            self._weight_attr = weight_attr
         self._remote_prefetch = False
         self._name = name
         self.weight = self.create_parameter(
@@ -1830,12 +1861,14 @@ class Embedding(Layer):
             shape=self._size,
             dtype=self._dtype,
             is_bias=False,
+            device=self._device,
         )
 
         if in_dynamic_mode() and padding_idx != -1:
             with paddle.no_grad():
                 self.weight[padding_idx] = 0.0
 
+    @param_one_alias(["x", "input"])
     def forward(self, x: Tensor) -> Tensor:
         return F.embedding(
             x,

--- a/python/paddle/nn/layer/conv.py
+++ b/python/paddle/nn/layer/conv.py
@@ -21,6 +21,7 @@ import numpy as np
 import paddle
 from paddle import get_flags
 from paddle.base.framework import in_dygraph_mode
+from paddle.utils.decorator_utils import ParamAliasDecorator
 
 from ...device import (
     get_cudnn_version,
@@ -42,7 +43,9 @@ if TYPE_CHECKING:
         DataLayout2D,
         DataLayout3D,
         DataLayoutND,
+        DTypeLike,
         ParamAttrLike,
+        PlaceLike,
         Size1,
         Size2,
         Size3,
@@ -51,7 +54,6 @@ if TYPE_CHECKING:
     )
 
     from ..functional.common import _PaddingSizeMode, _PaddingTensorMode
-
 
 __all__ = []
 
@@ -92,6 +94,8 @@ class _ConvNd(Layer):
         weight_attr: ParamAttrLike | None = None,
         bias_attr: ParamAttrLike | None = None,
         data_format: DataLayoutND = "NCHW",
+        device: str | PlaceLike | None = None,
+        dtype: DTypeLike | None = None,
     ) -> None:
         super().__init__()
         assert weight_attr is not False, (
@@ -103,6 +107,8 @@ class _ConvNd(Layer):
         self._in_channels = in_channels
         self._out_channels = out_channels
         self._data_format = data_format
+        self._device = device
+        self._dtype = dtype
 
         valid_padding_modes = {'zeros', 'reflect', 'replicate', 'circular'}
         if padding_mode not in valid_padding_modes:
@@ -183,12 +189,16 @@ class _ConvNd(Layer):
         self.weight = self.create_parameter(
             shape=filter_shape,
             attr=self._param_attr,
+            dtype=self._dtype,
             default_initializer=_get_default_param_initializer(),
+            device=self._device,
         )
         self.bias = self.create_parameter(
             attr=self._bias_attr,
             shape=[self._out_channels],
             is_bias=True,
+            dtype=self._dtype,
+            device=self._device,
         )
 
         cudnn_version = get_cudnn_version()
@@ -955,6 +965,7 @@ class Conv2DTranspose(_ConvNd):
         return out
 
 
+@ParamAliasDecorator({"bias_attr": ["bias"]})
 class Conv3D(_ConvNd):
     r"""
     **Convlution3d Layer**
@@ -1017,6 +1028,8 @@ class Conv3D(_ConvNd):
             is not set, the bias is initialized zero. The default value is None.
         data_format(str, optional): Data format that specifies the layout of input.
             It can be "NCDHW" or "NDHWC". Default: "NCDHW".
+        device(str, optional): Device where the computation takes place. Default: None
+        dtype(str, optional): Data type of the weights and bias. Default: None.
 
     Attribute:
 
@@ -1074,6 +1087,8 @@ class Conv3D(_ConvNd):
         weight_attr: ParamAttrLike | None = None,
         bias_attr: ParamAttrLike | None = None,
         data_format: DataLayout3D = "NCDHW",
+        device: str | PlaceLike | None = None,
+        dtype: DTypeLike | None = None,
     ) -> None:
         super().__init__(
             in_channels,
@@ -1089,6 +1104,8 @@ class Conv3D(_ConvNd):
             weight_attr=weight_attr,
             bias_attr=bias_attr,
             data_format=data_format,
+            device=device,
+            dtype=dtype,
         )
 
     def forward(self, x: Tensor) -> Tensor:

--- a/python/paddle/nn/layer/conv.py
+++ b/python/paddle/nn/layer/conv.py
@@ -21,7 +21,6 @@ import numpy as np
 import paddle
 from paddle import get_flags
 from paddle.base.framework import in_dygraph_mode
-from paddle.utils.decorator_utils import ParamAliasDecorator
 
 from ...device import (
     get_cudnn_version,
@@ -965,7 +964,6 @@ class Conv2DTranspose(_ConvNd):
         return out
 
 
-@ParamAliasDecorator({"bias_attr": ["bias"]})
 class Conv3D(_ConvNd):
     r"""
     **Convlution3d Layer**
@@ -1132,6 +1130,135 @@ class Conv3D(_ConvNd):
             use_cudnn=self._use_cudnn,
         )
         return out
+
+
+class Conv3d(Conv3D):
+    r"""
+    **Convlution3d Layer**
+    The convolution3d layer calculates the output based on the input, filter
+    and strides, paddings, dilations, groups parameters. Input(Input) and
+    Output(Output) are multidimensional tensors with a shape of
+    :math:`[N, C, D, H, W]` . Where N is batch size, C is the number of
+    channels, D is the depth of the feature, H is the height of the feature,
+    and W is the width of the feature. Convlution3D is similar with Convlution2D
+    but adds one dimension(depth). If bias attribution and activation type are
+    provided, bias is added to the output of the convolution, and the
+    corresponding activation function is applied to the final result.
+    For each input :math:`X`, the equation is:
+
+    ..  math::
+
+        Out = \sigma (W \ast X + b)
+
+    In the above equation:
+
+    * :math:`X`: Input value, a tensor with NCDHW or NDHWC format.
+    * :math:`W`: Filter value, a tensor with MCDHW format.
+    * :math:`\ast`: Convolution operation.
+    * :math:`b`: Bias value, a 1-D tensor with shape [M].
+    * :math:`\sigma`: Activation function.
+    * :math:`Out`: Output value, the shape of :math:`Out` and :math:`X` may be different.
+
+    Parameters:
+        in_channels(int): The number of input channels in the input image.
+        out_channels(int): The number of output channels produced by the convolution.
+        kernel_size(int|list|tuple): The size of the convolving kernel.
+        stride(int|list|tuple, optional): The stride size. If stride is a list/tuple, it must
+            contain three integers, (stride_D, stride_H, stride_W). Otherwise, the
+            stride_D = stride_H = stride_W = stride. The default value is 1.
+        padding(int|str|tuple|list, optional): The padding size. Padding could be in one of the following forms.
+            1. a string in ['valid', 'same'].
+            2. an int, which means each spartial dimension(depth, height, width) is zero paded by size of `padding`
+            3. a list[int] or tuple[int] whose length is the number of spartial dimensions, which contains the amount of padding on each side for each spartial dimension. It has the form [pad_d1, pad_d2, ...].
+            4. a list[int] or tuple[int] whose length is 2 * number of spartial dimensions. It has the form  [pad_before, pad_after, pad_before, pad_after, ...] for all spartial dimensions.
+            5. a list or tuple of pairs of ints. It has the form [[pad_before, pad_after], [pad_before, pad_after], ...]. Note that, the batch dimension and channel dimension are also included. Each pair of integers correspond to the amount of padding for a dimension of the input. Padding in batch dimension and channel dimension should be [0, 0] or (0, 0).
+            The default value is 0.
+        dilation(int|list|tuple, optional): The dilation size. If dilation is a list/tuple, it must
+            contain three integers, (dilation_D, dilation_H, dilation_W). Otherwise, the
+            dilation_D = dilation_H = dilation_W = dilation. The default value is 1.
+        groups(int, optional): The groups number of the Conv3D Layer. According to grouped
+            convolution in Alex Krizhevsky's Deep CNN paper: when group=2,
+            the first half of the filters is only connected to the first half
+            of the input channels, while the second half of the filters is only
+            connected to the second half of the input channels. The default value is 1.
+        bias(bool, optional): Whether to add a bias to the conv3d. If ``False``, then no bias will be added. Default: ``True``.
+        padding_mode(str, optional): ``'zeros'``, ``'reflect'``, ``'replicate'`` or ``'circular'``. Default: ``'zeros'``.
+        device(str, optional): Device where the computation takes place. Default: None
+        dtype(str, optional): Data type of the weights and bias. Default: None.
+
+    Attribute:
+
+        **weight** (Parameter): the learnable weights of filters of this layer.
+
+        **bias** (Parameter): the learnable bias of this layer.
+
+    Shape:
+
+        - x: :math:`(N, C_{in}, D_{in}, H_{in}, W_{in})`
+
+        - weight: :math:`(C_{out}, C_{in}, K_{d}, K_{h}, K_{w})`
+
+        - bias: :math:`(C_{out})`
+
+        - output: :math:`(N, C_{out}, D_{out}, H_{out}, W_{out})`
+
+        Where
+
+        ..  math::
+
+           D_{out}&= \frac{(D_{in} + 2 * paddings[0] - (dilations[0] * (kernel\_size[0] - 1) + 1))}{strides[0]} + 1
+
+           H_{out}&= \frac{(H_{in} + 2 * paddings[1] - (dilations[1] * (kernel\_size[1] - 1) + 1))}{strides[1]} + 1
+
+           W_{out}&= \frac{(W_{in} + 2 * paddings[2] - (dilations[2] * (kernel\_size[2] - 1) + 1))}{strides[2]} + 1
+
+    Examples:
+
+        .. code-block:: python
+
+            >>> import paddle
+            >>> import paddle.nn as nn
+
+            >>> paddle.disable_static()
+
+            >>> x_var = paddle.uniform((2, 4, 8, 8, 8), dtype='float32', min=-1., max=1.)
+
+            >>> conv = nn.Conv3d(4, 6, (3, 3, 3))
+            >>> y_var = conv(x_var)
+            >>> print(y_var.shape)
+            [2, 6, 6, 6, 6]
+    """
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: Size3,
+        stride: Size3 = 1,
+        padding: _PaddingSizeMode | Size3 | Size6 | Sequence[Size2] = 0,
+        dilation: Size3 = 1,
+        groups: int = 1,
+        bias: bool = True,
+        padding_mode: _PaddingTensorMode = 'zeros',
+        device: str | PlaceLike | None = None,
+        dtype: DTypeLike | None = None,
+    ) -> None:
+        super().__init__(
+            in_channels,
+            out_channels,
+            kernel_size,
+            stride,
+            padding,
+            dilation,
+            groups,
+            padding_mode=padding_mode,
+            bias_attr=bias,
+            device=device,
+            dtype=dtype,
+        )
+
+    def forward(self, input: Tensor) -> Tensor:
+        return super().forward(input)
 
 
 class Conv3DTranspose(_ConvNd):

--- a/python/paddle/nn/layer/conv.py
+++ b/python/paddle/nn/layer/conv.py
@@ -19,8 +19,9 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 import paddle
-from paddle import get_flags
+from paddle import Tensor, get_flags
 from paddle.base.framework import in_dygraph_mode
+from paddle.utils.decorator_utils import param_one_alias
 
 from ...device import (
     get_cudnn_version,
@@ -314,12 +315,16 @@ class Conv1D(_ConvNd):
             the first half of the filters is only connected to the first half
             of the input channels, while the second half of the filters is only
             connected to the second half of the input channels. Default: 1.
+        bias(bool, optional): Whether to learn and add the bias of this layer. If set
+            to False, no bias will be created and :attr:`bias_attr` is ignored. Default: True.
         padding_mode(str, optional): Four modes: 'zeros', 'reflect', 'replicate', 'circular'.
             When in 'zeros' mode, this op uses zeros to pad the input tensor.
             When in 'reflect' mode, uses reflection of the input boundaries to pad the input tensor.
             When in 'replicate' mode, uses input boundaries to pad the input tensor.
             When in 'circular' mode, uses circular input to pad the input tensor.
             Default is 'zeros'.
+        device(str, optional): Device where the computation takes place. Default: None
+        dtype(str, optional): Data type of the weights and bias. Default: None.
         weight_attr (ParamAttr, optional): The parameter attribute for learnable weights(Parameter)
             of conv1d. If it is set to None or one attribute of ParamAttr, conv1d
             will create ParamAttr as param_attr. If the Initializer of the param_attr
@@ -377,11 +382,17 @@ class Conv1D(_ConvNd):
         padding: _PaddingSizeMode | Size1 | Size2 | Sequence[Size2] = 0,
         dilation: Size1 = 1,
         groups: int = 1,
+        *,
+        bias: bool = True,
         padding_mode: _PaddingTensorMode = 'zeros',
+        device: str | PlaceLike | None = None,
+        dtype: DTypeLike | None = None,
         weight_attr: ParamAttrLike | None = None,
         bias_attr: ParamAttrLike | None = None,
         data_format: DataLayout1D = "NCL",
     ) -> None:
+        if bias is False:
+            bias_attr = False
         super().__init__(
             in_channels,
             out_channels,
@@ -396,8 +407,11 @@ class Conv1D(_ConvNd):
             weight_attr=weight_attr,
             bias_attr=bias_attr,
             data_format=data_format,
+            device=device,
+            dtype=dtype,
         )
 
+    @param_one_alias(["x", "input"])
     def forward(self, x: Tensor) -> Tensor:
         padding = 0
         if self._padding_mode != "zeros":
@@ -421,6 +435,9 @@ class Conv1D(_ConvNd):
             data_format=self._data_format,
         )
         return out
+
+
+Conv1d = Conv1D
 
 
 class Conv1DTranspose(_ConvNd):
@@ -656,7 +673,11 @@ class Conv2D(_ConvNd):
             the first half of the filters is only connected to the first half
             of the input channels, while the second half of the filters is only
             connected to the second half of the input channels. The default value is 1.
+        bias(bool, optional): Whether to learn and add the bias of this layer. If set
+            to False, no bias will be created and :attr:`bias_attr` is ignored. Default: True.
         padding_mode(str, optional): ``'zeros'``, ``'reflect'``, ``'replicate'`` or ``'circular'``. Default: ``'zeros'``.
+        device(str, optional): Device where the computation takes place. Default: None
+        dtype(str, optional): Data type of the weights and bias. Default: None.
         weight_attr(ParamAttr, optional): The parameter attribute for learnable parameters/weights
             of conv2d. If it is set to None or one attribute of ParamAttr, conv2d
             will create ParamAttr as param_attr. If it is set to None, the parameter
@@ -669,7 +690,6 @@ class Conv2D(_ConvNd):
             is not set, the bias is initialized zero. The default value is None.
         data_format(str, optional): Data format that specifies the layout of input.
             It can be "NCHW" or "NHWC". Default: "NCHW".
-
     Attribute:
 
         **weight** (Parameter): the learnable weights of filter of this layer.
@@ -720,11 +740,17 @@ class Conv2D(_ConvNd):
         padding: _PaddingSizeMode | Size2 | Size4 | Sequence[Size2] = 0,
         dilation: Size2 = 1,
         groups: int = 1,
+        *,
+        bias: bool = True,
         padding_mode: _PaddingTensorMode = 'zeros',
+        device: str | PlaceLike | None = None,
+        dtype: DTypeLike | None = None,
         weight_attr: ParamAttrLike | None = None,
         bias_attr: ParamAttrLike | None = None,
         data_format: DataLayout2D = "NCHW",
     ) -> None:
+        if bias is False:
+            bias_attr = False
         super().__init__(
             in_channels,
             out_channels,
@@ -739,8 +765,11 @@ class Conv2D(_ConvNd):
             weight_attr=weight_attr,
             bias_attr=bias_attr,
             data_format=data_format,
+            device=device,
+            dtype=dtype,
         )
 
+    @param_one_alias(["x", "input"])
     def forward(self, x: Tensor) -> Tensor:
         if self._padding_mode != 'zeros':
             x = F.pad(
@@ -792,6 +821,9 @@ class Conv2D(_ConvNd):
             use_cudnn=self._use_cudnn,
         )
         return out
+
+
+Conv2d = Conv2D
 
 
 class Conv2DTranspose(_ConvNd):
@@ -1013,7 +1045,11 @@ class Conv3D(_ConvNd):
             the first half of the filters is only connected to the first half
             of the input channels, while the second half of the filters is only
             connected to the second half of the input channels. The default value is 1.
+        bias(bool, optional): Whether to learn and add the bias of this layer. If set
+            to False, no bias will be created and :attr:`bias_attr` is ignored. Default: True.
         padding_mode(str, optional): ``'zeros'``, ``'reflect'``, ``'replicate'`` or ``'circular'``. Default: ``'zeros'``.
+        device(str, optional): Device where the computation takes place. Default: None
+        dtype(str, optional): Data type of the weights and bias. Default: None.
         weight_attr(ParamAttr, optional): The parameter attribute for learnable parameters/weights
             of conv3d. If it is set to None or one attribute of ParamAttr, conv3d
             will create ParamAttr as param_attr. If it is set to None, the parameter
@@ -1026,8 +1062,6 @@ class Conv3D(_ConvNd):
             is not set, the bias is initialized zero. The default value is None.
         data_format(str, optional): Data format that specifies the layout of input.
             It can be "NCDHW" or "NDHWC". Default: "NCDHW".
-        device(str, optional): Device where the computation takes place. Default: None
-        dtype(str, optional): Data type of the weights and bias. Default: None.
 
     Attribute:
 
@@ -1081,13 +1115,18 @@ class Conv3D(_ConvNd):
         padding: _PaddingSizeMode | Size3 | Size6 | Sequence[Size2] = 0,
         dilation: Size3 = 1,
         groups: int = 1,
+        *,
+        bias: bool = True,
         padding_mode: _PaddingTensorMode = 'zeros',
+        device: str | PlaceLike | None = None,
+        dtype: DTypeLike | None = None,
         weight_attr: ParamAttrLike | None = None,
         bias_attr: ParamAttrLike | None = None,
         data_format: DataLayout3D = "NCDHW",
-        device: str | PlaceLike | None = None,
-        dtype: DTypeLike | None = None,
     ) -> None:
+        if bias is False:
+            bias_attr = False
+
         super().__init__(
             in_channels,
             out_channels,
@@ -1106,6 +1145,7 @@ class Conv3D(_ConvNd):
             dtype=dtype,
         )
 
+    @param_one_alias(["x", "input"])
     def forward(self, x: Tensor) -> Tensor:
         if self._padding_mode != 'zeros':
             x = F.pad(
@@ -1132,133 +1172,7 @@ class Conv3D(_ConvNd):
         return out
 
 
-class Conv3d(Conv3D):
-    r"""
-    **Convlution3d Layer**
-    The convolution3d layer calculates the output based on the input, filter
-    and strides, paddings, dilations, groups parameters. Input(Input) and
-    Output(Output) are multidimensional tensors with a shape of
-    :math:`[N, C, D, H, W]` . Where N is batch size, C is the number of
-    channels, D is the depth of the feature, H is the height of the feature,
-    and W is the width of the feature. Convlution3D is similar with Convlution2D
-    but adds one dimension(depth). If bias attribution and activation type are
-    provided, bias is added to the output of the convolution, and the
-    corresponding activation function is applied to the final result.
-    For each input :math:`X`, the equation is:
-
-    ..  math::
-
-        Out = \sigma (W \ast X + b)
-
-    In the above equation:
-
-    * :math:`X`: Input value, a tensor with NCDHW or NDHWC format.
-    * :math:`W`: Filter value, a tensor with MCDHW format.
-    * :math:`\ast`: Convolution operation.
-    * :math:`b`: Bias value, a 1-D tensor with shape [M].
-    * :math:`\sigma`: Activation function.
-    * :math:`Out`: Output value, the shape of :math:`Out` and :math:`X` may be different.
-
-    Parameters:
-        in_channels(int): The number of input channels in the input image.
-        out_channels(int): The number of output channels produced by the convolution.
-        kernel_size(int|list|tuple): The size of the convolving kernel.
-        stride(int|list|tuple, optional): The stride size. If stride is a list/tuple, it must
-            contain three integers, (stride_D, stride_H, stride_W). Otherwise, the
-            stride_D = stride_H = stride_W = stride. The default value is 1.
-        padding(int|str|tuple|list, optional): The padding size. Padding could be in one of the following forms.
-            1. a string in ['valid', 'same'].
-            2. an int, which means each spartial dimension(depth, height, width) is zero paded by size of `padding`
-            3. a list[int] or tuple[int] whose length is the number of spartial dimensions, which contains the amount of padding on each side for each spartial dimension. It has the form [pad_d1, pad_d2, ...].
-            4. a list[int] or tuple[int] whose length is 2 * number of spartial dimensions. It has the form  [pad_before, pad_after, pad_before, pad_after, ...] for all spartial dimensions.
-            5. a list or tuple of pairs of ints. It has the form [[pad_before, pad_after], [pad_before, pad_after], ...]. Note that, the batch dimension and channel dimension are also included. Each pair of integers correspond to the amount of padding for a dimension of the input. Padding in batch dimension and channel dimension should be [0, 0] or (0, 0).
-            The default value is 0.
-        dilation(int|list|tuple, optional): The dilation size. If dilation is a list/tuple, it must
-            contain three integers, (dilation_D, dilation_H, dilation_W). Otherwise, the
-            dilation_D = dilation_H = dilation_W = dilation. The default value is 1.
-        groups(int, optional): The groups number of the Conv3D Layer. According to grouped
-            convolution in Alex Krizhevsky's Deep CNN paper: when group=2,
-            the first half of the filters is only connected to the first half
-            of the input channels, while the second half of the filters is only
-            connected to the second half of the input channels. The default value is 1.
-        bias(bool, optional): Whether to add a bias to the conv3d. If ``False``, then no bias will be added. Default: ``True``.
-        padding_mode(str, optional): ``'zeros'``, ``'reflect'``, ``'replicate'`` or ``'circular'``. Default: ``'zeros'``.
-        device(str, optional): Device where the computation takes place. Default: None
-        dtype(str, optional): Data type of the weights and bias. Default: None.
-
-    Attribute:
-
-        **weight** (Parameter): the learnable weights of filters of this layer.
-
-        **bias** (Parameter): the learnable bias of this layer.
-
-    Shape:
-
-        - x: :math:`(N, C_{in}, D_{in}, H_{in}, W_{in})`
-
-        - weight: :math:`(C_{out}, C_{in}, K_{d}, K_{h}, K_{w})`
-
-        - bias: :math:`(C_{out})`
-
-        - output: :math:`(N, C_{out}, D_{out}, H_{out}, W_{out})`
-
-        Where
-
-        ..  math::
-
-           D_{out}&= \frac{(D_{in} + 2 * paddings[0] - (dilations[0] * (kernel\_size[0] - 1) + 1))}{strides[0]} + 1
-
-           H_{out}&= \frac{(H_{in} + 2 * paddings[1] - (dilations[1] * (kernel\_size[1] - 1) + 1))}{strides[1]} + 1
-
-           W_{out}&= \frac{(W_{in} + 2 * paddings[2] - (dilations[2] * (kernel\_size[2] - 1) + 1))}{strides[2]} + 1
-
-    Examples:
-
-        .. code-block:: python
-
-            >>> import paddle
-            >>> import paddle.nn as nn
-
-            >>> paddle.disable_static()
-
-            >>> x_var = paddle.uniform((2, 4, 8, 8, 8), dtype='float32', min=-1., max=1.)
-
-            >>> conv = nn.Conv3d(4, 6, (3, 3, 3))
-            >>> y_var = conv(x_var)
-            >>> print(y_var.shape)
-            [2, 6, 6, 6, 6]
-    """
-
-    def __init__(
-        self,
-        in_channels: int,
-        out_channels: int,
-        kernel_size: Size3,
-        stride: Size3 = 1,
-        padding: _PaddingSizeMode | Size3 | Size6 | Sequence[Size2] = 0,
-        dilation: Size3 = 1,
-        groups: int = 1,
-        bias: bool = True,
-        padding_mode: _PaddingTensorMode = 'zeros',
-        device: str | PlaceLike | None = None,
-        dtype: DTypeLike | None = None,
-    ) -> None:
-        super().__init__(
-            in_channels,
-            out_channels,
-            kernel_size,
-            stride,
-            padding,
-            dilation,
-            groups,
-            padding_mode=padding_mode,
-            bias_attr=bias,
-            device=device,
-            dtype=dtype,
-        )
-
-    def forward(self, input: Tensor) -> Tensor:
-        return super().forward(input)
+Conv3d = Conv3D
 
 
 class Conv3DTranspose(_ConvNd):

--- a/python/paddle/nn/layer/conv.py
+++ b/python/paddle/nn/layer/conv.py
@@ -94,7 +94,7 @@ class _ConvNd(Layer):
         weight_attr: ParamAttrLike | None = None,
         bias_attr: ParamAttrLike | None = None,
         data_format: DataLayoutND = "NCHW",
-        device: str | PlaceLike | None = None,
+        device: PlaceLike | None = None,
         dtype: DTypeLike | None = None,
     ) -> None:
         super().__init__()

--- a/python/paddle/nn/layer/conv.py
+++ b/python/paddle/nn/layer/conv.py
@@ -323,8 +323,8 @@ class Conv1D(_ConvNd):
             When in 'replicate' mode, uses input boundaries to pad the input tensor.
             When in 'circular' mode, uses circular input to pad the input tensor.
             Default is 'zeros'.
-        device(str, optional): Device where the computation takes place. Default: None
-        dtype(str, optional): Data type of the weights and bias. Default: None.
+        device(PlaceLike, optional): Device where the computation takes place. Default: None
+        dtype(DTypeLike, optional): Data type of the weights and bias. Default: None.
         weight_attr (ParamAttr, optional): The parameter attribute for learnable weights(Parameter)
             of conv1d. If it is set to None or one attribute of ParamAttr, conv1d
             will create ParamAttr as param_attr. If the Initializer of the param_attr
@@ -385,7 +385,7 @@ class Conv1D(_ConvNd):
         *,
         bias: bool = True,
         padding_mode: _PaddingTensorMode = 'zeros',
-        device: str | PlaceLike | None = None,
+        device: PlaceLike | None = None,
         dtype: DTypeLike | None = None,
         weight_attr: ParamAttrLike | None = None,
         bias_attr: ParamAttrLike | None = None,
@@ -676,8 +676,8 @@ class Conv2D(_ConvNd):
         bias(bool, optional): Whether to learn and add the bias of this layer. If set
             to False, no bias will be created and :attr:`bias_attr` is ignored. Default: True.
         padding_mode(str, optional): ``'zeros'``, ``'reflect'``, ``'replicate'`` or ``'circular'``. Default: ``'zeros'``.
-        device(str, optional): Device where the computation takes place. Default: None
-        dtype(str, optional): Data type of the weights and bias. Default: None.
+        device(PlaceLike, optional): Device where the computation takes place. Default: None
+        dtype(DTypeLike, optional): Data type of the weights and bias. Default: None.
         weight_attr(ParamAttr, optional): The parameter attribute for learnable parameters/weights
             of conv2d. If it is set to None or one attribute of ParamAttr, conv2d
             will create ParamAttr as param_attr. If it is set to None, the parameter
@@ -743,7 +743,7 @@ class Conv2D(_ConvNd):
         *,
         bias: bool = True,
         padding_mode: _PaddingTensorMode = 'zeros',
-        device: str | PlaceLike | None = None,
+        device: PlaceLike | None = None,
         dtype: DTypeLike | None = None,
         weight_attr: ParamAttrLike | None = None,
         bias_attr: ParamAttrLike | None = None,
@@ -1048,8 +1048,8 @@ class Conv3D(_ConvNd):
         bias(bool, optional): Whether to learn and add the bias of this layer. If set
             to False, no bias will be created and :attr:`bias_attr` is ignored. Default: True.
         padding_mode(str, optional): ``'zeros'``, ``'reflect'``, ``'replicate'`` or ``'circular'``. Default: ``'zeros'``.
-        device(str, optional): Device where the computation takes place. Default: None
-        dtype(str, optional): Data type of the weights and bias. Default: None.
+        device(PlaceLike, optional): Device where the computation takes place. Default: None
+        dtype(DTypeLike, optional): Data type of the weights and bias. Default: None.
         weight_attr(ParamAttr, optional): The parameter attribute for learnable parameters/weights
             of conv3d. If it is set to None or one attribute of ParamAttr, conv3d
             will create ParamAttr as param_attr. If it is set to None, the parameter
@@ -1118,7 +1118,7 @@ class Conv3D(_ConvNd):
         *,
         bias: bool = True,
         padding_mode: _PaddingTensorMode = 'zeros',
-        device: str | PlaceLike | None = None,
+        device: PlaceLike | None = None,
         dtype: DTypeLike | None = None,
         weight_attr: ParamAttrLike | None = None,
         bias_attr: ParamAttrLike | None = None,

--- a/python/paddle/nn/layer/layers.py
+++ b/python/paddle/nn/layer/layers.py
@@ -789,6 +789,7 @@ class Layer:
         dtype: DTypeLike | None = None,
         is_bias: bool = False,
         default_initializer: Initializer | None = None,
+        device: str | PlaceLike | None = None,
     ) -> Tensor:
         """Create parameters for this layer.
 
@@ -802,6 +803,7 @@ class Layer:
             default_initializer(Initializer, optional): the default initializer for this parameter.
                 If set None, default initializer will be set to paddle.nn.initializer.Xavier and paddle.nn.initializer.Constant
                 for non-bias and bias parameter, respectively. Default: None.
+            device(str|Place, optional): the device place for the parameter. Default: None.
 
         Returns:
             :Tensor, created parameter.
@@ -839,7 +841,7 @@ class Layer:
         if isinstance(temp_attr, str) and temp_attr == "":
             temp_attr = None
         return self._helper.create_parameter(
-            temp_attr, shape, dtype, is_bias, default_initializer
+            temp_attr, shape, dtype, is_bias, default_initializer, device=device
         )
 
     @deprecated(

--- a/python/paddle/nn/layer/layers.py
+++ b/python/paddle/nn/layer/layers.py
@@ -789,7 +789,7 @@ class Layer:
         dtype: DTypeLike | None = None,
         is_bias: bool = False,
         default_initializer: Initializer | None = None,
-        device: str | PlaceLike | None = None,
+        device: PlaceLike | None = None,
     ) -> Tensor:
         """Create parameters for this layer.
 
@@ -803,7 +803,7 @@ class Layer:
             default_initializer(Initializer, optional): the default initializer for this parameter.
                 If set None, default initializer will be set to paddle.nn.initializer.Xavier and paddle.nn.initializer.Constant
                 for non-bias and bias parameter, respectively. Default: None.
-            device(str|Place, optional): the device place for the parameter. Default: None.
+            device(PlaceLike, optional): the device place for the parameter. Default: None.
 
         Returns:
             :Tensor, created parameter.

--- a/test/legacy_test/test_nn_dtype_device_bias.py
+++ b/test/legacy_test/test_nn_dtype_device_bias.py
@@ -503,6 +503,11 @@ class Test_Embedding(unittest.TestCase):
             )
             assert layer.weight.stop_gradient
 
+    def test_padding_idx(self):
+        with dygraph_guard():
+            layer = self.api(32, 16, padding_idx=2)
+            assert layer._padding_idx == layer.padding_idx
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/legacy_test/test_nn_dtype_device_bias.py
+++ b/test/legacy_test/test_nn_dtype_device_bias.py
@@ -1,0 +1,91 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+import unittest
+
+from utils import dygraph_guard
+
+import paddle
+from paddle import nn
+
+
+def convert_place_to_device(place):
+    re_exp = re.compile(r'[(](.+?)[)]', re.DOTALL)
+    place_str = re.findall(re_exp, str(place))[0]
+    return place_str
+
+
+class Test_Conv3D(unittest.TestCase):
+
+    def check(self, tensor, dtype, device):
+        if isinstance(dtype, str):
+            assert tensor.dtype == getattr(
+                paddle, dtype
+            ), f"expect {dtype}, but got {tensor.dtype}"
+        else:
+            assert (
+                tensor.dtype == dtype
+            ), f"expect {dtype}, but got {tensor.dtype}"
+
+        place = convert_place_to_device(tensor.place)
+        if not isinstance(device, str):
+            device = convert_place_to_device(device)
+        assert place == device, f"expect {device}, but got {place}"
+
+    def setUp(self):
+        self.devices = [paddle.CPUPlace(), "cpu"]
+        if paddle.device.is_compiled_with_cuda():
+            count = paddle.device.cuda.device_count()
+            self.devices.extend([f"gpu:{i}" for i in range(count)])
+            self.devices.extend([paddle.CUDAPlace(i) for i in range(count)])
+        if paddle.device.is_compiled_with_xpu():
+            self.devices.append(paddle.device.XPUPlace(0))
+        if paddle.device.is_compiled_with_ipu():
+            self.devices.append(paddle.device.IPUPlace())
+
+        self.dtypes = ["float32", paddle.float32, 'float64', paddle.float64]
+
+    def run_test_dygraph_one(self, dtype, device):
+        with dygraph_guard():
+            x_var = paddle.randn([10, 16, 32, 32, 32], dtype=dtype).to(device)
+            x_var.stop_gradient = False
+            conv = nn.Conv3D(16, 33, 3, dtype=dtype, device=device)
+            self.check(conv.weight, dtype, device)
+            self.check(conv.bias, dtype, device)
+
+            y_var = conv(x_var)
+            self.check(y_var, dtype, device)
+
+    def test_dygraph(self):
+        for dtype in self.dtypes:
+            for device in self.devices:
+                with self.subTest(msg=f"Testing {dtype} on {device}"):
+                    self.run_test_dygraph_one(dtype=dtype, device=device)
+
+    def test_bias(self):
+        with dygraph_guard():
+            x_var = paddle.randn([10, 16, 32, 32, 32])
+            x_var.stop_gradient = False
+            conv = nn.Conv3D(16, 33, 3, bias=True)
+            y_var = conv(x_var)
+            assert isinstance(conv.bias, paddle.Tensor)
+
+            conv = nn.Conv3D(16, 33, 3, bias=False)
+            y_var = conv(x_var)
+            assert conv.bias is None
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/legacy_test/test_nn_dtype_device_bias.py
+++ b/test/legacy_test/test_nn_dtype_device_bias.py
@@ -28,60 +28,180 @@ def convert_place_to_device(place):
     return place_str
 
 
+def devices_and_type():
+    devices = {paddle.CPUPlace(): 0, "cpu": 0}
+    if paddle.device.is_compiled_with_cuda():
+        # 1 means cuda place, see paddle/phi/kernels/memcpy_kernel.cc
+        devices[paddle.CUDAPlace(0)] = 1
+        devices['gpu:0'] = 1
+    if paddle.device.is_compiled_with_xpu():
+        devices[paddle.device.XPUPlace(0)] = 3
+    if paddle.device.is_compiled_with_ipu():
+        devices[paddle.device.IPUPlace()] = 4
+    return devices
+
+
+def check_dtype_device(tensor, dtype, device):
+    if isinstance(dtype, str):
+        assert tensor.dtype == getattr(
+            paddle, dtype
+        ), f"expect {dtype}, but got {tensor.dtype}"
+    else:
+        assert tensor.dtype == dtype, f"expect {dtype}, but got {tensor.dtype}"
+
+    place = convert_place_to_device(tensor.place)
+    if not isinstance(device, str):
+        device = convert_place_to_device(device)
+    assert place == device, f"expect {device}, but got {place}"
+
+
 class Test_Conv3D(unittest.TestCase):
 
-    def check(self, tensor, dtype, device):
-        if isinstance(dtype, str):
-            assert tensor.dtype == getattr(
-                paddle, dtype
-            ), f"expect {dtype}, but got {tensor.dtype}"
-        else:
-            assert (
-                tensor.dtype == dtype
-            ), f"expect {dtype}, but got {tensor.dtype}"
-
-        place = convert_place_to_device(tensor.place)
-        if not isinstance(device, str):
-            device = convert_place_to_device(device)
-        assert place == device, f"expect {device}, but got {place}"
-
     def setUp(self):
-        self.devices = [paddle.CPUPlace(), "cpu"]
-        if paddle.device.is_compiled_with_cuda():
-            count = paddle.device.cuda.device_count()
-            self.devices.extend([f"gpu:{i}" for i in range(count)])
-            self.devices.extend([paddle.CUDAPlace(i) for i in range(count)])
-        if paddle.device.is_compiled_with_xpu():
-            self.devices.append(paddle.device.XPUPlace(0))
-        if paddle.device.is_compiled_with_ipu():
-            self.devices.append(paddle.device.IPUPlace())
-
+        self.devices = devices_and_type()
         self.dtypes = ["float32", paddle.float32, 'float64', paddle.float64]
+        self.op_name = 'pd_op.memcpy'
 
     def run_test_dygraph_one(self, dtype, device):
         with dygraph_guard():
             x_var = paddle.randn([10, 16, 32, 32, 32], dtype=dtype).to(device)
             conv = nn.Conv3D(16, 33, 3, dtype=dtype, device=device)
-            self.check(conv.weight, dtype, device)
-            self.check(conv.bias, dtype, device)
+            check_dtype_device(conv.weight, dtype, device)
+            check_dtype_device(conv.bias, dtype, device)
 
             y_var = conv(x_var)
-            self.check(y_var, dtype, device)
+            check_dtype_device(y_var, dtype, device)
 
     def test_dygraph(self):
         for dtype in self.dtypes:
-            for device in self.devices:
+            for device, _ in self.devices.items():
                 with self.subTest(msg=f"Testing {dtype} on {device}"):
                     self.run_test_dygraph_one(dtype=dtype, device=device)
+
+    def run_test_static_one(self, dtype, device, dst_place_type):
+        with static_guard():
+            main = base.Program()
+            start = base.Program()
+            with (
+                base.unique_name.guard(),
+                base.program_guard(main, start),
+            ):
+                input_shape = (-1, 16, -1, -1, -1)
+
+                x_var = paddle.static.data("input", input_shape, dtype=dtype)
+                conv = paddle.nn.Conv3D(
+                    in_channels=16,
+                    out_channels=33,
+                    kernel_size=3,
+                    dtype=dtype,
+                    device=device,
+                )
+                y_var = conv(x_var)
+            if isinstance(dtype, str):
+                dtype_str = dtype
+            else:
+                dtype_str = str(dtype).replace('paddle.', '')
+            input = np.random.randn(10, 16, 32, 32, 32).astype(dtype_str)
+
+            feed_dict = {"input": input}
+            exe = base.Executor(device)
+            exe.run(start)
+            (y_np,) = exe.run(main, feed=feed_dict, fetch_list=[y_var])
+            assert y_np.dtype == dtype_str
+            for op in main.global_block().ops:
+                if op.name() == self.op_name:
+                    assert (
+                        op.attrs()['dst_place_type'] == dst_place_type
+                    ), f"expect {dst_place_type}, but got {op.attrs()['dst_place_type']}"
+
+    def test_static(self):
+        for dtype in self.dtypes:
+            for device, dst_place_type in self.devices.items():
+                with self.subTest(msg=f"Testing {dtype} on {device}"):
+                    self.run_test_static_one(
+                        dtype=dtype,
+                        device=device,
+                        dst_place_type=dst_place_type,
+                    )
+
+
+class Test_Conv3d(unittest.TestCase):
+
+    def setUp(self):
+        self.devices = devices_and_type()
+        self.dtypes = ["float32", paddle.float32, 'float64', paddle.float64]
+        self.op_name = 'pd_op.memcpy'
+
+    def run_test_dygraph_one(self, dtype, device):
+        with dygraph_guard():
+            x_var = paddle.randn([10, 16, 32, 32, 32], dtype=dtype).to(device)
+            conv = nn.Conv3d(16, 33, 3, dtype=dtype, device=device)
+            check_dtype_device(conv.weight, dtype, device)
+            check_dtype_device(conv.bias, dtype, device)
+
+            y_var = conv(x_var)
+            check_dtype_device(y_var, dtype, device)
+
+    def test_dygraph(self):
+        for dtype in self.dtypes:
+            for device, _ in self.devices.items():
+                with self.subTest(msg=f"Testing {dtype} on {device}"):
+                    self.run_test_dygraph_one(dtype=dtype, device=device)
+
+    def run_test_static_one(self, dtype, device, dst_place_type):
+        with static_guard():
+            main = base.Program()
+            start = base.Program()
+            with (
+                base.unique_name.guard(),
+                base.program_guard(main, start),
+            ):
+                input_shape = (-1, 16, -1, -1, -1)
+
+                x_var = paddle.static.data("input", input_shape, dtype=dtype)
+                conv = paddle.nn.Conv3d(
+                    in_channels=16,
+                    out_channels=33,
+                    kernel_size=3,
+                    dtype=dtype,
+                    device=device,
+                )
+                y_var = conv(x_var)
+            if isinstance(dtype, str):
+                dtype_str = dtype
+            else:
+                dtype_str = str(dtype).replace('paddle.', '')
+            input = np.random.randn(10, 16, 32, 32, 32).astype(dtype_str)
+
+            feed_dict = {"input": input}
+            exe = base.Executor(device)
+            exe.run(start)
+            (y_np,) = exe.run(main, feed=feed_dict, fetch_list=[y_var])
+            assert y_np.dtype == dtype_str
+            for op in main.global_block().ops:
+                if op.name() == self.op_name:
+                    assert (
+                        op.attrs()['dst_place_type'] == dst_place_type
+                    ), f"expect {dst_place_type}, but got {op.attrs()['dst_place_type']}"
+
+    def test_static(self):
+        for dtype in self.dtypes:
+            for device, dst_place_type in self.devices.items():
+                with self.subTest(msg=f"Testing {dtype} on {device}"):
+                    self.run_test_static_one(
+                        dtype=dtype,
+                        device=device,
+                        dst_place_type=dst_place_type,
+                    )
 
     def test_bias_dygraph(self):
         with dygraph_guard():
             x_var = paddle.randn([10, 16, 32, 32, 32])
-            conv = nn.Conv3D(16, 33, 3, bias=True)
+            conv = nn.Conv3d(16, 33, 3, bias=True)
             y_var = conv(x_var)
             assert isinstance(conv.bias, paddle.Tensor)
 
-            conv = nn.Conv3D(16, 33, 3, bias=False)
+            conv = nn.Conv3d(16, 33, 3, bias=False)
             y_var = conv(x_var)
             assert conv.bias is None
 
@@ -97,7 +217,7 @@ class Test_Conv3D(unittest.TestCase):
                 input_shape = (-1, 16, -1, -1, -1)
 
                 x_var = paddle.static.data("input", input_shape)
-                conv = nn.Conv3D(16, 33, 3, bias=False)
+                conv = nn.Conv3d(16, 33, 3, bias=False)
                 y_var = conv(x_var)
                 assert conv.bias is None
 

--- a/test/legacy_test/test_nn_dtype_device_bias.py
+++ b/test/legacy_test/test_nn_dtype_device_bias.py
@@ -43,9 +43,9 @@ def devices_and_type():
 
 def check_dtype_device(tensor, dtype, device):
     if isinstance(dtype, str):
-        assert tensor.dtype == getattr(
-            paddle, dtype
-        ), f"expect {dtype}, but got {tensor.dtype}"
+        assert tensor.dtype == getattr(paddle, dtype), (
+            f"expect {dtype}, but got {tensor.dtype}"
+        )
     else:
         assert tensor.dtype == dtype, f"expect {dtype}, but got {tensor.dtype}"
 
@@ -56,20 +56,28 @@ def check_dtype_device(tensor, dtype, device):
 
 
 class Test_Conv3D(unittest.TestCase):
-
     def setUp(self):
         self.devices = devices_and_type()
         self.dtypes = ["float32", paddle.float32, 'float64', paddle.float64]
         self.op_name = 'pd_op.memcpy'
+        self.api = nn.Conv3D
 
     def run_test_dygraph_one(self, dtype, device):
         with dygraph_guard():
             x_var = paddle.randn([10, 16, 32, 32, 32], dtype=dtype).to(device)
-            conv = nn.Conv3D(16, 33, 3, dtype=dtype, device=device)
+            conv = self.api(16, 33, 3, dtype=dtype, device=device)
             check_dtype_device(conv.weight, dtype, device)
             check_dtype_device(conv.bias, dtype, device)
 
             y_var = conv(x_var)
+            check_dtype_device(y_var, dtype, device)
+
+            # check "input"
+            y_var = conv(input=x_var)
+            check_dtype_device(y_var, dtype, device)
+
+            # check "x"
+            y_var = conv(x=x_var)
             check_dtype_device(y_var, dtype, device)
 
     def test_dygraph(self):
@@ -89,14 +97,17 @@ class Test_Conv3D(unittest.TestCase):
                 input_shape = (-1, 16, -1, -1, -1)
 
                 x_var = paddle.static.data("input", input_shape, dtype=dtype)
-                conv = paddle.nn.Conv3D(
+                conv = self.api(
                     in_channels=16,
                     out_channels=33,
                     kernel_size=3,
                     dtype=dtype,
                     device=device,
                 )
-                y_var = conv(x_var)
+                # check "input"
+                y_var = conv(input=x_var)
+                # check "x"
+                y_var = conv(x=x_var)
             if isinstance(dtype, str):
                 dtype_str = dtype
             else:
@@ -110,79 +121,9 @@ class Test_Conv3D(unittest.TestCase):
             assert y_np.dtype == dtype_str
             for op in main.global_block().ops:
                 if op.name() == self.op_name:
-                    assert (
-                        op.attrs()['dst_place_type'] == dst_place_type
-                    ), f"expect {dst_place_type}, but got {op.attrs()['dst_place_type']}"
-
-    def test_static(self):
-        for dtype in self.dtypes:
-            for device, dst_place_type in self.devices.items():
-                with self.subTest(msg=f"Testing {dtype} on {device}"):
-                    self.run_test_static_one(
-                        dtype=dtype,
-                        device=device,
-                        dst_place_type=dst_place_type,
+                    assert op.attrs()['dst_place_type'] == dst_place_type, (
+                        f"expect {dst_place_type}, but got {op.attrs()['dst_place_type']}"
                     )
-
-
-class Test_Conv3d(unittest.TestCase):
-
-    def setUp(self):
-        self.devices = devices_and_type()
-        self.dtypes = ["float32", paddle.float32, 'float64', paddle.float64]
-        self.op_name = 'pd_op.memcpy'
-
-    def run_test_dygraph_one(self, dtype, device):
-        with dygraph_guard():
-            x_var = paddle.randn([10, 16, 32, 32, 32], dtype=dtype).to(device)
-            conv = nn.Conv3d(16, 33, 3, dtype=dtype, device=device)
-            check_dtype_device(conv.weight, dtype, device)
-            check_dtype_device(conv.bias, dtype, device)
-
-            y_var = conv(x_var)
-            check_dtype_device(y_var, dtype, device)
-
-    def test_dygraph(self):
-        for dtype in self.dtypes:
-            for device, _ in self.devices.items():
-                with self.subTest(msg=f"Testing {dtype} on {device}"):
-                    self.run_test_dygraph_one(dtype=dtype, device=device)
-
-    def run_test_static_one(self, dtype, device, dst_place_type):
-        with static_guard():
-            main = base.Program()
-            start = base.Program()
-            with (
-                base.unique_name.guard(),
-                base.program_guard(main, start),
-            ):
-                input_shape = (-1, 16, -1, -1, -1)
-
-                x_var = paddle.static.data("input", input_shape, dtype=dtype)
-                conv = paddle.nn.Conv3d(
-                    in_channels=16,
-                    out_channels=33,
-                    kernel_size=3,
-                    dtype=dtype,
-                    device=device,
-                )
-                y_var = conv(x_var)
-            if isinstance(dtype, str):
-                dtype_str = dtype
-            else:
-                dtype_str = str(dtype).replace('paddle.', '')
-            input = np.random.randn(10, 16, 32, 32, 32).astype(dtype_str)
-
-            feed_dict = {"input": input}
-            exe = base.Executor(device)
-            exe.run(start)
-            (y_np,) = exe.run(main, feed=feed_dict, fetch_list=[y_var])
-            assert y_np.dtype == dtype_str
-            for op in main.global_block().ops:
-                if op.name() == self.op_name:
-                    assert (
-                        op.attrs()['dst_place_type'] == dst_place_type
-                    ), f"expect {dst_place_type}, but got {op.attrs()['dst_place_type']}"
 
     def test_static(self):
         for dtype in self.dtypes:
@@ -197,16 +138,15 @@ class Test_Conv3d(unittest.TestCase):
     def test_bias_dygraph(self):
         with dygraph_guard():
             x_var = paddle.randn([10, 16, 32, 32, 32])
-            conv = nn.Conv3d(16, 33, 3, bias=True)
+            conv = self.api(16, 33, 3, bias=True)
             y_var = conv(x_var)
             assert isinstance(conv.bias, paddle.Tensor)
 
-            conv = nn.Conv3d(16, 33, 3, bias=False)
+            conv = self.api(16, 33, 3, bias=False, bias_attr=True)
             y_var = conv(x_var)
             assert conv.bias is None
 
     def test_bias_static(self):
-
         with static_guard():
             main = base.Program()
             start = base.Program()
@@ -217,7 +157,7 @@ class Test_Conv3d(unittest.TestCase):
                 input_shape = (-1, 16, -1, -1, -1)
 
                 x_var = paddle.static.data("input", input_shape)
-                conv = nn.Conv3d(16, 33, 3, bias=False)
+                conv = self.api(16, 33, 3, bias=False)
                 y_var = conv(x_var)
                 assert conv.bias is None
 
@@ -227,6 +167,341 @@ class Test_Conv3d(unittest.TestCase):
             exe = base.Executor()
             exe.run(start)
             (y_np,) = exe.run(main, feed=feed_dict, fetch_list=[y_var])
+
+
+class Test_Conv3d(Test_Conv3D):
+    def setUp(self):
+        self.devices = devices_and_type()
+        self.dtypes = ["float32", paddle.float32, 'float64', paddle.float64]
+        self.op_name = 'pd_op.memcpy'
+        self.api = nn.Conv3d
+
+
+class Test_Conv2D(unittest.TestCase):
+    def setUp(self):
+        self.devices = devices_and_type()
+        self.dtypes = ["float32", paddle.float32, 'float64', paddle.float64]
+        self.op_name = 'pd_op.memcpy'
+        self.api = nn.Conv2D
+
+    def run_test_dygraph_one(self, dtype, device):
+        with dygraph_guard():
+            x_var = paddle.randn([10, 16, 32, 32], dtype=dtype).to(device)
+            conv = self.api(16, 33, 3, dtype=dtype, device=device)
+            check_dtype_device(conv.weight, dtype, device)
+            check_dtype_device(conv.bias, dtype, device)
+
+            y_var = conv(x_var)
+            check_dtype_device(y_var, dtype, device)
+
+            y_var = conv(input=x_var)
+            check_dtype_device(y_var, dtype, device)
+
+            y_var = conv(x=x_var)
+            check_dtype_device(y_var, dtype, device)
+
+    def test_dygraph(self):
+        for dtype in self.dtypes:
+            for device, _ in self.devices.items():
+                with self.subTest(msg=f"Testing {dtype} on {device}"):
+                    self.run_test_dygraph_one(dtype=dtype, device=device)
+
+    def run_test_static_one(self, dtype, device, dst_place_type):
+        with static_guard():
+            main = base.Program()
+            start = base.Program()
+            with (
+                base.unique_name.guard(),
+                base.program_guard(main, start),
+            ):
+                input_shape = (-1, 16, -1, -1)
+
+                x_var = paddle.static.data("input", input_shape, dtype=dtype)
+                conv = self.api(
+                    in_channels=16,
+                    out_channels=33,
+                    kernel_size=3,
+                    dtype=dtype,
+                    device=device,
+                )
+                y_var = conv(x_var)
+                y_var = conv(input=x_var)
+
+            if isinstance(dtype, str):
+                dtype_str = dtype
+            else:
+                dtype_str = str(dtype).replace('paddle.', '')
+            input = np.random.randn(10, 16, 32, 32).astype(dtype_str)
+
+            feed_dict = {"input": input}
+            exe = base.Executor(device)
+            exe.run(start)
+            (y_np,) = exe.run(main, feed=feed_dict, fetch_list=[y_var])
+            assert y_np.dtype == dtype_str
+            for op in main.global_block().ops:
+                if op.name() == self.op_name:
+                    assert op.attrs()['dst_place_type'] == dst_place_type, (
+                        f"expect {dst_place_type}, but got {op.attrs()['dst_place_type']}"
+                    )
+
+    def test_static(self):
+        for dtype in self.dtypes:
+            for device, dst_place_type in self.devices.items():
+                with self.subTest(msg=f"Testing {dtype} on {device}"):
+                    self.run_test_static_one(
+                        dtype=dtype,
+                        device=device,
+                        dst_place_type=dst_place_type,
+                    )
+
+    def test_bias_dygraph(self):
+        with dygraph_guard():
+            x_var = paddle.randn([10, 16, 32, 32])
+            conv = self.api(16, 33, 3, bias=True)
+            y_var = conv(x_var)
+            assert isinstance(conv.bias, paddle.Tensor)
+
+            conv = self.api(16, 33, 3, bias=False)
+            y_var = conv(x_var)
+            assert conv.bias is None
+
+    def test_bias_static(self):
+        with static_guard():
+            main = base.Program()
+            start = base.Program()
+            with (
+                base.unique_name.guard(),
+                base.program_guard(main, start),
+            ):
+                input_shape = (-1, 16, -1, -1)
+
+                x_var = paddle.static.data("input", input_shape)
+                conv = self.api(16, 33, 3, bias=False)
+                y_var = conv(x_var)
+                assert conv.bias is None
+
+            feed_dict = {
+                "input": np.random.randn(10, 16, 32, 32).astype('float32')
+            }
+            exe = base.Executor()
+            exe.run(start)
+            (y_np,) = exe.run(main, feed=feed_dict, fetch_list=[y_var])
+
+
+class Test_Conv2d(Test_Conv2D):
+    def setUp(self):
+        self.devices = devices_and_type()
+        self.dtypes = ["float32", paddle.float32, 'float64', paddle.float64]
+        self.op_name = 'pd_op.memcpy'
+        self.api = nn.Conv2d
+
+
+class Test_Conv1D(unittest.TestCase):
+    def setUp(self):
+        self.devices = devices_and_type()
+        self.dtypes = ["float32", paddle.float32, 'float64', paddle.float64]
+        self.op_name = 'pd_op.memcpy'
+        self.api = nn.Conv1D
+
+    def run_test_dygraph_one(self, dtype, device):
+        with dygraph_guard():
+            x_var = paddle.randn([10, 16, 32], dtype=dtype).to(device)
+            conv = self.api(16, 33, 3, dtype=dtype, device=device)
+            check_dtype_device(conv.weight, dtype, device)
+            check_dtype_device(conv.bias, dtype, device)
+
+            y_var = conv(x_var)
+            check_dtype_device(y_var, dtype, device)
+
+            y_var = conv(input=x_var)
+            check_dtype_device(y_var, dtype, device)
+
+            y_var = conv(x=x_var)
+            check_dtype_device(y_var, dtype, device)
+
+    def test_dygraph(self):
+        for dtype in self.dtypes:
+            for device, _ in self.devices.items():
+                with self.subTest(msg=f"Testing {dtype} on {device}"):
+                    self.run_test_dygraph_one(dtype=dtype, device=device)
+
+    def run_test_static_one(self, dtype, device, dst_place_type):
+        with static_guard():
+            main = base.Program()
+            start = base.Program()
+            with (
+                base.unique_name.guard(),
+                base.program_guard(main, start),
+            ):
+                input_shape = (-1, 16, -1)
+
+                x_var = paddle.static.data("input", input_shape, dtype=dtype)
+                conv = self.api(
+                    in_channels=16,
+                    out_channels=33,
+                    kernel_size=3,
+                    dtype=dtype,
+                    device=device,
+                )
+                y_var = conv(x_var)
+                y_var = conv(input=x_var)
+
+            if isinstance(dtype, str):
+                dtype_str = dtype
+            else:
+                dtype_str = str(dtype).replace('paddle.', '')
+            input = np.random.randn(10, 16, 32).astype(dtype_str)
+
+            feed_dict = {"input": input}
+            exe = base.Executor(device)
+            exe.run(start)
+            (y_np,) = exe.run(main, feed=feed_dict, fetch_list=[y_var])
+            assert y_np.dtype == dtype_str
+            for op in main.global_block().ops:
+                if op.name() == self.op_name:
+                    assert op.attrs()['dst_place_type'] == dst_place_type, (
+                        f"expect {dst_place_type}, but got {op.attrs()['dst_place_type']}"
+                    )
+
+    def test_static(self):
+        for dtype in self.dtypes:
+            for device, dst_place_type in self.devices.items():
+                with self.subTest(msg=f"Testing {dtype} on {device}"):
+                    self.run_test_static_one(
+                        dtype=dtype,
+                        device=device,
+                        dst_place_type=dst_place_type,
+                    )
+
+    def test_bias_dygraph(self):
+        with dygraph_guard():
+            x_var = paddle.randn([10, 16, 32])
+            conv = self.api(16, 33, 3, bias=True)
+            y_var = conv(x_var)
+            assert isinstance(conv.bias, paddle.Tensor)
+
+            conv = self.api(16, 33, 3, bias=False)
+            y_var = conv(x_var)
+            assert conv.bias is None
+
+    def test_bias_static(self):
+        with static_guard():
+            main = base.Program()
+            start = base.Program()
+            with (
+                base.unique_name.guard(),
+                base.program_guard(main, start),
+            ):
+                input_shape = (-1, 16, -1)
+
+                x_var = paddle.static.data("input", input_shape)
+                conv = self.api(16, 33, 3, bias=False)
+                y_var = conv(x_var)
+                assert conv.bias is None
+
+            feed_dict = {"input": np.random.randn(10, 16, 32).astype('float32')}
+            exe = base.Executor()
+            exe.run(start)
+            (y_np,) = exe.run(main, feed=feed_dict, fetch_list=[y_var])
+
+
+class Test_Conv1d(Test_Conv1D):
+    def setUp(self):
+        self.devices = devices_and_type()
+        self.dtypes = ["float32", paddle.float32, 'float64', paddle.float64]
+        self.op_name = 'pd_op.memcpy'
+        self.api = nn.Conv1d
+
+
+class Test_Embedding(unittest.TestCase):
+    def setUp(self):
+        self.devices = devices_and_type()
+        self.dtypes = ["float32", paddle.float32, 'float64', paddle.float64]
+        self.op_name = 'pd_op.memcpy'
+        self.api = nn.Embedding
+
+    def run_test_dygraph_one(self, dtype, device):
+        with dygraph_guard():
+            x_var = paddle.randint(low=0, high=256, shape=[1024]).to(device)
+            layer = self.api(256, 128, dtype=dtype, device=device)
+            check_dtype_device(layer.weight, dtype, device)
+
+            y_var = layer(x_var)
+            check_dtype_device(y_var, dtype, device)
+
+            y_var = layer(input=x_var)
+            check_dtype_device(y_var, dtype, device)
+
+            y_var = layer(x=x_var)
+            check_dtype_device(y_var, dtype, device)
+
+    def test_dygraph(self):
+        for dtype in self.dtypes:
+            for device, _ in self.devices.items():
+                with self.subTest(msg=f"Testing {dtype} on {device}"):
+                    self.run_test_dygraph_one(dtype=dtype, device=device)
+
+    def run_test_static_one(self, dtype, device, dst_place_type):
+        with static_guard():
+            main = base.Program()
+            start = base.Program()
+            with (
+                base.unique_name.guard(),
+                base.program_guard(main, start),
+            ):
+                input_shape = (-1,)
+
+                x_var = paddle.static.data("input", input_shape, dtype=dtype)
+                layer = self.api(
+                    256,
+                    128,
+                    dtype=dtype,
+                    device=device,
+                )
+                y_var = layer(x_var)
+                y_var = layer(input=x_var)
+
+            if isinstance(dtype, str):
+                dtype_str = dtype
+            else:
+                dtype_str = str(dtype).replace('paddle.', '')
+            input = np.random.randint(0, 256, size=(1024,))
+
+            feed_dict = {"input": input}
+            exe = base.Executor(device)
+            exe.run(start)
+            (y_np,) = exe.run(main, feed=feed_dict, fetch_list=[y_var])
+            assert y_np.dtype == dtype_str
+            for op in main.global_block().ops:
+                if op.name() == self.op_name:
+                    assert op.attrs()['dst_place_type'] == dst_place_type, (
+                        f"expect {dst_place_type}, but got {op.attrs()['dst_place_type']}"
+                    )
+
+    def test_static(self):
+        for dtype in self.dtypes:
+            for device, dst_place_type in self.devices.items():
+                with self.subTest(msg=f"Testing {dtype} on {device}"):
+                    self.run_test_static_one(
+                        dtype=dtype,
+                        device=device,
+                        dst_place_type=dst_place_type,
+                    )
+
+    def test_weight_freeze(self):
+        with dygraph_guard():
+            x_var = paddle.randint(low=0, high=256, shape=[1024])
+            weight = paddle.randn([256, 128])
+            layer = self.api(256, 128, _weight=weight, _freeze=True)
+
+            y_var = layer(x_var)
+            np.testing.assert_allclose(weight.numpy(), layer.weight.numpy())
+            np.testing.assert_allclose(
+                y_var.numpy(),
+                paddle.nn.functional.one_hot(x_var, num_classes=256).numpy()
+                @ weight.numpy(),
+            )
+            assert layer.weight.stop_gradient
 
 
 if __name__ == '__main__':

--- a/test/legacy_test/test_nn_dtype_device_bias.py
+++ b/test/legacy_test/test_nn_dtype_device_bias.py
@@ -15,10 +15,11 @@
 import re
 import unittest
 
-from utils import dygraph_guard
+import numpy as np
+from utils import dygraph_guard, static_guard
 
 import paddle
-from paddle import nn
+from paddle import base, nn
 
 
 def convert_place_to_device(place):
@@ -60,7 +61,6 @@ class Test_Conv3D(unittest.TestCase):
     def run_test_dygraph_one(self, dtype, device):
         with dygraph_guard():
             x_var = paddle.randn([10, 16, 32, 32, 32], dtype=dtype).to(device)
-            x_var.stop_gradient = False
             conv = nn.Conv3D(16, 33, 3, dtype=dtype, device=device)
             self.check(conv.weight, dtype, device)
             self.check(conv.bias, dtype, device)
@@ -74,10 +74,9 @@ class Test_Conv3D(unittest.TestCase):
                 with self.subTest(msg=f"Testing {dtype} on {device}"):
                     self.run_test_dygraph_one(dtype=dtype, device=device)
 
-    def test_bias(self):
+    def test_bias_dygraph(self):
         with dygraph_guard():
             x_var = paddle.randn([10, 16, 32, 32, 32])
-            x_var.stop_gradient = False
             conv = nn.Conv3D(16, 33, 3, bias=True)
             y_var = conv(x_var)
             assert isinstance(conv.bias, paddle.Tensor)
@@ -85,6 +84,29 @@ class Test_Conv3D(unittest.TestCase):
             conv = nn.Conv3D(16, 33, 3, bias=False)
             y_var = conv(x_var)
             assert conv.bias is None
+
+    def test_bias_static(self):
+
+        with static_guard():
+            main = base.Program()
+            start = base.Program()
+            with (
+                base.unique_name.guard(),
+                base.program_guard(main, start),
+            ):
+                input_shape = (-1, 16, -1, -1, -1)
+
+                x_var = paddle.static.data("input", input_shape)
+                conv = nn.Conv3D(16, 33, 3, bias=False)
+                y_var = conv(x_var)
+                assert conv.bias is None
+
+            feed_dict = {
+                "input": np.random.randn(10, 16, 32, 32, 32).astype('float32')
+            }
+            exe = base.Executor()
+            exe.run(start)
+            (y_np,) = exe.run(main, feed=feed_dict, fetch_list=[y_var])
 
 
 if __name__ == '__main__':

--- a/test/legacy_test/test_nn_dtype_device_bias.py
+++ b/test/legacy_test/test_nn_dtype_device_bias.py
@@ -64,8 +64,8 @@ class Test_Conv3D(unittest.TestCase):
 
     def run_test_dygraph_one(self, dtype, device):
         with dygraph_guard():
-            x_var = paddle.randn([10, 16, 32, 32, 32], dtype=dtype).to(device)
-            conv = self.api(16, 33, 3, dtype=dtype, device=device)
+            x_var = paddle.randn([5, 8, 12, 12, 12], dtype=dtype).to(device)
+            conv = self.api(8, 16, 3, dtype=dtype, device=device)
             check_dtype_device(conv.weight, dtype, device)
             check_dtype_device(conv.bias, dtype, device)
 
@@ -94,12 +94,12 @@ class Test_Conv3D(unittest.TestCase):
                 base.unique_name.guard(),
                 base.program_guard(main, start),
             ):
-                input_shape = (-1, 16, -1, -1, -1)
+                input_shape = (-1, 8, -1, -1, -1)
 
                 x_var = paddle.static.data("input", input_shape, dtype=dtype)
                 conv = self.api(
-                    in_channels=16,
-                    out_channels=33,
+                    in_channels=8,
+                    out_channels=16,
                     kernel_size=3,
                     dtype=dtype,
                     device=device,
@@ -112,7 +112,7 @@ class Test_Conv3D(unittest.TestCase):
                 dtype_str = dtype
             else:
                 dtype_str = str(dtype).replace('paddle.', '')
-            input = np.random.randn(10, 16, 32, 32, 32).astype(dtype_str)
+            input = np.random.randn(5, 8, 12, 12, 12).astype(dtype_str)
 
             feed_dict = {"input": input}
             exe = base.Executor(device)
@@ -137,12 +137,12 @@ class Test_Conv3D(unittest.TestCase):
 
     def test_bias_dygraph(self):
         with dygraph_guard():
-            x_var = paddle.randn([10, 16, 32, 32, 32])
-            conv = self.api(16, 33, 3, bias=True)
+            x_var = paddle.randn([5, 8, 12, 12, 12])
+            conv = self.api(8, 16, 3, bias=True)
             y_var = conv(x_var)
             assert isinstance(conv.bias, paddle.Tensor)
 
-            conv = self.api(16, 33, 3, bias=False, bias_attr=True)
+            conv = self.api(8, 16, 3, bias=False, bias_attr=True)
             y_var = conv(x_var)
             assert conv.bias is None
 
@@ -154,15 +154,15 @@ class Test_Conv3D(unittest.TestCase):
                 base.unique_name.guard(),
                 base.program_guard(main, start),
             ):
-                input_shape = (-1, 16, -1, -1, -1)
+                input_shape = (-1, 8, -1, -1, -1)
 
                 x_var = paddle.static.data("input", input_shape)
-                conv = self.api(16, 33, 3, bias=False)
+                conv = self.api(8, 16, 3, bias=False)
                 y_var = conv(x_var)
                 assert conv.bias is None
 
             feed_dict = {
-                "input": np.random.randn(10, 16, 32, 32, 32).astype('float32')
+                "input": np.random.randn(5, 8, 12, 12, 12).astype('float32')
             }
             exe = base.Executor()
             exe.run(start)
@@ -186,8 +186,8 @@ class Test_Conv2D(unittest.TestCase):
 
     def run_test_dygraph_one(self, dtype, device):
         with dygraph_guard():
-            x_var = paddle.randn([10, 16, 32, 32], dtype=dtype).to(device)
-            conv = self.api(16, 33, 3, dtype=dtype, device=device)
+            x_var = paddle.randn([5, 8, 12, 12], dtype=dtype).to(device)
+            conv = self.api(8, 16, 3, dtype=dtype, device=device)
             check_dtype_device(conv.weight, dtype, device)
             check_dtype_device(conv.bias, dtype, device)
 
@@ -214,12 +214,12 @@ class Test_Conv2D(unittest.TestCase):
                 base.unique_name.guard(),
                 base.program_guard(main, start),
             ):
-                input_shape = (-1, 16, -1, -1)
+                input_shape = (-1, 8, -1, -1)
 
                 x_var = paddle.static.data("input", input_shape, dtype=dtype)
                 conv = self.api(
-                    in_channels=16,
-                    out_channels=33,
+                    in_channels=8,
+                    out_channels=16,
                     kernel_size=3,
                     dtype=dtype,
                     device=device,
@@ -231,7 +231,7 @@ class Test_Conv2D(unittest.TestCase):
                 dtype_str = dtype
             else:
                 dtype_str = str(dtype).replace('paddle.', '')
-            input = np.random.randn(10, 16, 32, 32).astype(dtype_str)
+            input = np.random.randn(5, 8, 12, 12).astype(dtype_str)
 
             feed_dict = {"input": input}
             exe = base.Executor(device)
@@ -256,12 +256,12 @@ class Test_Conv2D(unittest.TestCase):
 
     def test_bias_dygraph(self):
         with dygraph_guard():
-            x_var = paddle.randn([10, 16, 32, 32])
-            conv = self.api(16, 33, 3, bias=True)
+            x_var = paddle.randn([5, 8, 12, 12])
+            conv = self.api(8, 16, 3, bias=True)
             y_var = conv(x_var)
             assert isinstance(conv.bias, paddle.Tensor)
 
-            conv = self.api(16, 33, 3, bias=False)
+            conv = self.api(8, 16, 3, bias=False)
             y_var = conv(x_var)
             assert conv.bias is None
 
@@ -273,15 +273,15 @@ class Test_Conv2D(unittest.TestCase):
                 base.unique_name.guard(),
                 base.program_guard(main, start),
             ):
-                input_shape = (-1, 16, -1, -1)
+                input_shape = (-1, 8, -1, -1)
 
                 x_var = paddle.static.data("input", input_shape)
-                conv = self.api(16, 33, 3, bias=False)
+                conv = self.api(8, 16, 3, bias=False)
                 y_var = conv(x_var)
                 assert conv.bias is None
 
             feed_dict = {
-                "input": np.random.randn(10, 16, 32, 32).astype('float32')
+                "input": np.random.randn(5, 8, 12, 12).astype('float32')
             }
             exe = base.Executor()
             exe.run(start)
@@ -305,8 +305,8 @@ class Test_Conv1D(unittest.TestCase):
 
     def run_test_dygraph_one(self, dtype, device):
         with dygraph_guard():
-            x_var = paddle.randn([10, 16, 32], dtype=dtype).to(device)
-            conv = self.api(16, 33, 3, dtype=dtype, device=device)
+            x_var = paddle.randn([5, 8, 12], dtype=dtype).to(device)
+            conv = self.api(8, 16, 3, dtype=dtype, device=device)
             check_dtype_device(conv.weight, dtype, device)
             check_dtype_device(conv.bias, dtype, device)
 
@@ -333,12 +333,12 @@ class Test_Conv1D(unittest.TestCase):
                 base.unique_name.guard(),
                 base.program_guard(main, start),
             ):
-                input_shape = (-1, 16, -1)
+                input_shape = (-1, 8, -1)
 
                 x_var = paddle.static.data("input", input_shape, dtype=dtype)
                 conv = self.api(
-                    in_channels=16,
-                    out_channels=33,
+                    in_channels=8,
+                    out_channels=16,
                     kernel_size=3,
                     dtype=dtype,
                     device=device,
@@ -350,7 +350,7 @@ class Test_Conv1D(unittest.TestCase):
                 dtype_str = dtype
             else:
                 dtype_str = str(dtype).replace('paddle.', '')
-            input = np.random.randn(10, 16, 32).astype(dtype_str)
+            input = np.random.randn(5, 8, 12).astype(dtype_str)
 
             feed_dict = {"input": input}
             exe = base.Executor(device)
@@ -375,12 +375,12 @@ class Test_Conv1D(unittest.TestCase):
 
     def test_bias_dygraph(self):
         with dygraph_guard():
-            x_var = paddle.randn([10, 16, 32])
-            conv = self.api(16, 33, 3, bias=True)
+            x_var = paddle.randn([5, 8, 12])
+            conv = self.api(8, 16, 3, bias=True)
             y_var = conv(x_var)
             assert isinstance(conv.bias, paddle.Tensor)
 
-            conv = self.api(16, 33, 3, bias=False)
+            conv = self.api(8, 16, 3, bias=False)
             y_var = conv(x_var)
             assert conv.bias is None
 
@@ -392,14 +392,14 @@ class Test_Conv1D(unittest.TestCase):
                 base.unique_name.guard(),
                 base.program_guard(main, start),
             ):
-                input_shape = (-1, 16, -1)
+                input_shape = (-1, 8, -1)
 
                 x_var = paddle.static.data("input", input_shape)
-                conv = self.api(16, 33, 3, bias=False)
+                conv = self.api(8, 16, 3, bias=False)
                 y_var = conv(x_var)
                 assert conv.bias is None
 
-            feed_dict = {"input": np.random.randn(10, 16, 32).astype('float32')}
+            feed_dict = {"input": np.random.randn(5, 8, 12).astype('float32')}
             exe = base.Executor()
             exe.run(start)
             (y_np,) = exe.run(main, feed=feed_dict, fetch_list=[y_var])
@@ -422,8 +422,8 @@ class Test_Embedding(unittest.TestCase):
 
     def run_test_dygraph_one(self, dtype, device):
         with dygraph_guard():
-            x_var = paddle.randint(low=0, high=256, shape=[1024]).to(device)
-            layer = self.api(256, 128, dtype=dtype, device=device)
+            x_var = paddle.randint(low=0, high=32, shape=[128]).to(device)
+            layer = self.api(32, 16, dtype=dtype, device=device)
             check_dtype_device(layer.weight, dtype, device)
 
             y_var = layer(x_var)
@@ -453,8 +453,8 @@ class Test_Embedding(unittest.TestCase):
 
                 x_var = paddle.static.data("input", input_shape, dtype=dtype)
                 layer = self.api(
-                    256,
-                    128,
+                    32,
+                    16,
                     dtype=dtype,
                     device=device,
                 )
@@ -465,7 +465,7 @@ class Test_Embedding(unittest.TestCase):
                 dtype_str = dtype
             else:
                 dtype_str = str(dtype).replace('paddle.', '')
-            input = np.random.randint(0, 256, size=(1024,))
+            input = np.random.randint(0, 32, size=(128,))
 
             feed_dict = {"input": input}
             exe = base.Executor(device)
@@ -490,15 +490,15 @@ class Test_Embedding(unittest.TestCase):
 
     def test_weight_freeze(self):
         with dygraph_guard():
-            x_var = paddle.randint(low=0, high=256, shape=[1024])
-            weight = paddle.randn([256, 128])
-            layer = self.api(256, 128, _weight=weight, _freeze=True)
+            x_var = paddle.randint(low=0, high=32, shape=[128])
+            weight = paddle.randn([32, 16])
+            layer = self.api(32, 16, _weight=weight, _freeze=True)
 
             y_var = layer(x_var)
             np.testing.assert_allclose(weight.numpy(), layer.weight.numpy())
             np.testing.assert_allclose(
                 y_var.numpy(),
-                paddle.nn.functional.one_hot(x_var, num_classes=256).numpy()
+                paddle.nn.functional.one_hot(x_var, num_classes=32).numpy()
                 @ weight.numpy(),
             )
             assert layer.weight.stop_gradient


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

New features

### Description
<!-- Describe what you’ve done -->

add device/dtype/bias paramters  for nn.Conv1/2/3D, nn.Embedding
add new api: paddle.nn.Conv1/2/3d

pcard-67164
