### PR TITLE
[Safetensors]Add frombuffer for paddle

### DIFF
--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -1693,6 +1693,65 @@ PYBIND11_MODULE(libpaddle, m) {
                               phi::DataLayout::NCHW,
                               phi::CPUPlace());
            });
+  m.def("frombuffer",
+        [](py::object buffer,
+           phi::DataType dtype,
+           int64_t count,
+           int64_t offset) {
+          size_t actual_count = 0;
+          auto elsize = phi::SizeOf(dtype);
+          Py_buffer view;
+          if (PyObject_GetBuffer(buffer.ptr(), &view, PyBUF_WRITABLE) < 0) {
+            PADDLE_ENFORCE_EQ(
+                PyObject_GetBuffer(buffer.ptr(), &view, PyBUF_SIMPLE) >= 0,
+                true,
+                common::errors::InvalidArgument(
+                    "could not retrieve buffer from object"));
+            PyErr_Clear();
+          }
+          Py_INCREF(view.obj);
+          std::unique_ptr<PyObject> obj(view.obj);
+          auto len = view.len;
+          auto buf = view.buf;
+          PyBuffer_Release(&view);
+          PADDLE_ENFORCE_EQ(
+              len > 0 && count != 0,
+              true,
+              common::errors::InvalidArgument(
+                  "both buffer length and count must be greater than 0"));
+          PADDLE_ENFORCE_EQ(
+              offset >= 0 && offset < len,
+              true,
+              common::errors::InvalidArgument("offset must be non-negative and "
+                                              "no greater than buffer length"));
+          PADDLE_ENFORCE_EQ(
+              count > 0 || (len - offset) % elsize == 0,
+              true,
+              common::errors::InvalidArgument("buffer length after offset must "
+                                              "be a multiple of element size"));
+          if (count < 0) {
+            actual_count = (len - offset) / elsize;
+          } else {
+            actual_count = static_cast<size_t>(count);
+          }
+
+          PADDLE_ENFORCE_LE(static_cast<size_t>(offset) + actual_count * elsize,
+                            static_cast<size_t>(len),
+                            common::errors::InvalidArgument(
+                                "requested buffer length after offset must not "
+                                "be greater than actual buffer length"));
+
+          auto offset_buf = static_cast<char *>(buf) + offset;
+          return from_blob(offset_buf,
+                           phi::IntArray({actual_count}),
+                           dtype,
+                           phi::DataLayout::NCHW,
+                           phi::CPUPlace(),
+                           [obj = obj.release()](void *) {
+                             pybind11::gil_scoped_acquire gil;
+                             Py_DECREF(obj);
+                           });
+        });
 
   m.def("from_dlpack", [](py::object data) {
     DLManagedTensor *dlMTensor = reinterpret_cast<DLManagedTensor *>(

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -1698,7 +1698,7 @@ PYBIND11_MODULE(libpaddle, m) {
            phi::DataType dtype,
            int64_t count,
            int64_t offset) {
-          size_t actual_count = 0;
+          int64_t actual_count = 0;
           auto elsize = phi::SizeOf(dtype);
           Py_buffer view;
           if (PyObject_GetBuffer(buffer.ptr(), &view, PyBUF_WRITABLE) < 0) {
@@ -1730,16 +1730,17 @@ PYBIND11_MODULE(libpaddle, m) {
               common::errors::InvalidArgument("buffer length after offset must "
                                               "be a multiple of element size"));
           if (count < 0) {
-            actual_count = (len - offset) / elsize;
+            actual_count = static_cast<int64_t>(len - offset) / elsize;
           } else {
-            actual_count = static_cast<size_t>(count);
+            actual_count = static_cast<int64_t>(count);
           }
 
-          PADDLE_ENFORCE_LE(static_cast<size_t>(offset) + actual_count * elsize,
-                            static_cast<size_t>(len),
-                            common::errors::InvalidArgument(
-                                "requested buffer length after offset must not "
-                                "be greater than actual buffer length"));
+          PADDLE_ENFORCE_LE(
+              static_cast<int64_t>(offset) + actual_count * elsize,
+              static_cast<int64_t>(len),
+              common::errors::InvalidArgument(
+                  "requested buffer length after offset must not "
+                  "be greater than actual buffer length"));
 
           auto offset_buf = static_cast<char *>(buf) + offset;
           return from_blob(offset_buf,

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -1693,66 +1693,70 @@ PYBIND11_MODULE(libpaddle, m) {
                               phi::DataLayout::NCHW,
                               phi::CPUPlace());
            });
-  m.def("frombuffer",
-        [](py::object buffer,
-           phi::DataType dtype,
-           int64_t count,
-           int64_t offset) {
-          int64_t actual_count = 0;
-          auto elsize = phi::SizeOf(dtype);
-          Py_buffer view;
-          if (PyObject_GetBuffer(buffer.ptr(), &view, PyBUF_WRITABLE) < 0) {
-            PADDLE_ENFORCE_EQ(
-                PyObject_GetBuffer(buffer.ptr(), &view, PyBUF_SIMPLE) >= 0,
-                true,
-                common::errors::InvalidArgument(
-                    "could not retrieve buffer from object"));
-            PyErr_Clear();
-          }
-          Py_INCREF(view.obj);
-          std::unique_ptr<PyObject> obj(view.obj);
-          auto len = view.len;
-          auto buf = view.buf;
-          PyBuffer_Release(&view);
+  m.def(
+      "frombuffer",
+      [](py::object buffer,
+         phi::DataType dtype,
+         int64_t count,
+         int64_t offset) {
+        int64_t actual_count = 0;
+        auto elsize = phi::SizeOf(dtype);
+        Py_buffer view;
+        if (PyObject_GetBuffer(buffer.ptr(), &view, PyBUF_WRITABLE) < 0) {
           PADDLE_ENFORCE_EQ(
-              len > 0 && count != 0,
+              PyObject_GetBuffer(buffer.ptr(), &view, PyBUF_SIMPLE) >= 0,
               true,
               common::errors::InvalidArgument(
-                  "both buffer length and count must be greater than 0"));
-          PADDLE_ENFORCE_EQ(
-              offset >= 0 && offset < len,
-              true,
-              common::errors::InvalidArgument("offset must be non-negative and "
-                                              "no greater than buffer length"));
-          PADDLE_ENFORCE_EQ(
-              count > 0 || (len - offset) % elsize == 0,
-              true,
-              common::errors::InvalidArgument("buffer length after offset must "
-                                              "be a multiple of element size"));
-          if (count < 0) {
-            actual_count = static_cast<int64_t>(len - offset) / elsize;
-          } else {
-            actual_count = static_cast<int64_t>(count);
-          }
+                  "could not retrieve buffer from object"));
+          PyErr_Clear();
+        }
+        Py_INCREF(view.obj);
+        std::unique_ptr<PyObject> obj(view.obj);
+        auto len = view.len;
+        auto buf = view.buf;
+        PyBuffer_Release(&view);
+        PADDLE_ENFORCE_EQ(
+            len > 0 && count != 0,
+            true,
+            common::errors::InvalidArgument(
+                "both buffer length and count must be greater than 0"));
+        PADDLE_ENFORCE_EQ(
+            offset >= 0 && offset < len,
+            true,
+            common::errors::InvalidArgument("offset must be non-negative and "
+                                            "no greater than buffer length"));
+        PADDLE_ENFORCE_EQ(
+            count > 0 || (len - offset) % elsize == 0,
+            true,
+            common::errors::InvalidArgument("buffer length after offset must "
+                                            "be a multiple of element size"));
+        if (count < 0) {
+          actual_count = static_cast<int64_t>(len - offset) / elsize;
+        } else {
+          actual_count = static_cast<int64_t>(count);
+        }
 
-          PADDLE_ENFORCE_LE(
-              static_cast<int64_t>(offset) + actual_count * elsize,
-              static_cast<int64_t>(len),
-              common::errors::InvalidArgument(
-                  "requested buffer length after offset must not "
-                  "be greater than actual buffer length"));
+        PADDLE_ENFORCE_LE(static_cast<int64_t>(offset) + actual_count * elsize,
+                          static_cast<int64_t>(len),
+                          common::errors::InvalidArgument(
+                              "requested buffer length after offset must not "
+                              "be greater than actual buffer length"));
 
-          auto offset_buf = static_cast<char *>(buf) + offset;
-          return from_blob(offset_buf,
-                           phi::IntArray({actual_count}),
-                           dtype,
-                           phi::DataLayout::NCHW,
-                           phi::CPUPlace(),
-                           [obj = obj.release()](void *) {
-                             pybind11::gil_scoped_acquire gil;
-                             Py_DECREF(obj);
-                           });
-        });
+        auto offset_buf = static_cast<char *>(buf) + offset;
+        return from_blob(offset_buf,
+                         phi::IntArray({actual_count}),
+                         dtype,
+                         phi::DataLayout::NCHW,
+                         phi::CPUPlace(),
+                         [obj = obj.release()](void *) {
+                           pybind11::gil_scoped_acquire gil;
+                           Py_DECREF(obj);
+                         });
+      },
+      py::arg("buffer"),
+      py::arg("dtype"),
+      py::arg("count") = -1,
+      py::arg("offset") = 0);
 
   m.def("from_dlpack", [](py::object data) {
     DLManagedTensor *dlMTensor = reinterpret_cast<DLManagedTensor *>(

--- a/test/legacy_test/test_mmap_storage.py
+++ b/test/legacy_test/test_mmap_storage.py
@@ -30,7 +30,7 @@ class TestMmapStorageBase(unittest.TestCase):
         self.nbytes = self.data.size * self.data.element_size()
 
     def init_cfg(self):
-        self.shape = [400, 50, 20]
+        self.shape = [4, 5, 2]
         self.dtype = 'float64'
 
     def test_mmap_storage(self):
@@ -41,9 +41,9 @@ class TestMmapStorageBase(unittest.TestCase):
 
     def test_from_buffer(self):
         buffer = self.data.numpy().tobytes()
-        tmp = paddle.base.core.frombuffer(
-            buffer, self.data.dtype, self.data.size, 0
-        ).reshape(self.shape)
+        tmp = paddle.base.core.frombuffer(buffer, self.data.dtype).reshape(
+            self.shape
+        )
         np.testing.assert_allclose(tmp.numpy(), self.data.numpy())
 
 

--- a/test/legacy_test/test_mmap_storage.py
+++ b/test/legacy_test/test_mmap_storage.py
@@ -39,6 +39,13 @@ class TestMmapStorageBase(unittest.TestCase):
         res = tmp.get_slice(self.dtype, 0, self.data.size).reshape(self.shape)
         np.testing.assert_allclose(res.numpy(), self.data.numpy())
 
+    def test_from_buffer(self):
+        buffer = self.data.numpy().tobytes()
+        tmp = paddle.base.core.frombuffer(
+            buffer, self.data.dtype, self.data.size, 0
+        ).reshape(self.shape)
+        np.testing.assert_allclose(tmp.numpy(), self.data.numpy())
+
 
 class TestMmapStorage1(TestMmapStorageBase):
     def init_cfg(self):
@@ -104,3 +111,7 @@ class TestMmapStorage8(TestMmapStorage4):
     def init_cfg(self):
         self.shape = [300, 40, 10]
         self.dtype = 'bool'
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
pcard-67164
Bind frombuffer for safetensors.paddle.load.
This functions loads paddle tensor from bytes or buffer objects.
``` python
frombuffer(buffer, dtype, count=-1, offset=0)
```
Usage：
``` python
buffer = self.data.numpy().tobytes()
# default value of count and offset means to load the whole buffer.
tmp = paddle.base.core.frombuffer(buffer, self.data.dtype).reshape(self.shape)
```