### PR TITLE
[Auto Paralle] [Cherry-pick] cherry-pick for auto parallel verison custom ops (moe_combine moe_gate_dispatch)

### DIFF
--- a/paddle/phi/infermeta/backward.h
+++ b/paddle/phi/infermeta/backward.h
@@ -476,6 +476,14 @@ void MoeCombineGradInferMeta(const MetaTensor& x,
                              const MetaTensor& grad_y,
                              MetaTensor* grad_x,
                              MetaTensor* grad_combine_weights_helper);
+
+void MoeCombineAutoGradInferMeta(const MetaTensor& x,
+                                 const MetaTensor& combine_weights,
+                                 const MetaTensor& scatter_index,
+                                 const MetaTensor& grad_y,
+                                 MetaTensor* grad_x,
+                                 MetaTensor* grad_combine_weights_helper,
+                                 MetaTensor* grad_scatter_index);
 // Tensor combine_weights_out, Tensor scatter_index, Tensor scatter_index_rev,
 // Tensor expert_offset, Tensor expert_offset_local, Tensor y_grad, Tensor
 // combine_weights_out_grad, int64_t k, int64_t capacity, bool use_pad, int64_t
@@ -769,6 +777,17 @@ void MoeGateDispatchGradInferMeta(const MetaTensor& combine_weights,
                                   const bool use_pad,
                                   MetaTensor* x_grad,
                                   MetaTensor* gate_logits_grad);
+
+void MoeGateDispatchAutoGradInferMeta(const MetaTensor& combine_weights,
+                                      const MetaTensor& scatter_index,
+                                      const MetaTensor& expert_id,
+                                      const MetaTensor& y_grad,
+                                      const MetaTensor& combine_weights_grad,
+                                      const int64_t k,
+                                      const int64_t capacity,
+                                      const bool use_pad,
+                                      MetaTensor* x_grad,
+                                      MetaTensor* gate_logits_grad);
 
 void FusedRMSNormGradInferMeta(const MetaTensor& x,
                                const MetaTensor& scale,

--- a/paddle/phi/infermeta/multiary.cc
+++ b/paddle/phi/infermeta/multiary.cc
@@ -6698,5 +6698,97 @@ void MoeGateDispatchInferMeta(const MetaTensor& x,
   expert_id->set_dtype(phi::DataType::INT32);
 }
 
+void MoeGateDispatchAutoInferMeta(const MetaTensor& x,
+                                  const MetaTensor& gate_logits,
+                                  const MetaTensor& corr_bias,
+                                  const int64_t k,
+                                  const int64_t capacity,
+                                  const bool use_pad,
+                                  MetaTensor* y,
+                                  MetaTensor* combine_weights,
+                                  MetaTensor* scatter_index,
+                                  MetaTensor* expert_offset,
+                                  MetaTensor* expert_id) {
+  auto x_dims = x.dims();
+  auto gate_logits_dims = gate_logits.dims();
+
+  const int64_t num_rows = x_dims[0];
+  const int64_t num_experts = gate_logits_dims[1];
+
+  PADDLE_ENFORCE_EQ(
+      x_dims.size(),
+      2,
+      errors::InvalidArgument("Input x should have 2 dimensions"));
+
+  PADDLE_ENFORCE_EQ(
+      gate_logits_dims.size(),
+      2,
+      errors::InvalidArgument("Input gate_logits should have 2 dimensions"));
+
+  PADDLE_ENFORCE_EQ(
+      x_dims[0],
+      gate_logits_dims[0],
+      errors::InvalidArgument(
+          "The 0-th dimension of x [%d] "
+          "must match that of the 0-th dimension gate_logits [%d].",
+          x_dims[0],
+          gate_logits_dims[0]));
+
+  PADDLE_ENFORCE_EQ(gate_logits_dims[1] >= k,
+                    true,
+                    errors::InvalidArgument(
+                        "The 1-th dimension of gate_logits [%d] "
+                        "must be greater than or equal to that of k [%d].",
+                        gate_logits_dims[1],
+                        k));
+
+  if (corr_bias) {
+    auto corr_bias_dims = corr_bias.dims();
+    PADDLE_ENFORCE_EQ(
+        corr_bias.dtype(),
+        phi::DataType::FLOAT32,
+        errors::InvalidArgument(
+            "The dtype of rotary_tensor must be float32, but got %d",
+            corr_bias.dtype()));
+
+    PADDLE_ENFORCE_EQ(
+        corr_bias_dims.size(),
+        1,
+        errors::InvalidArgument("Input corr_bias should have 1 dimensions"));
+
+    PADDLE_ENFORCE_EQ(
+        corr_bias_dims[0],
+        gate_logits_dims[1],
+        errors::InvalidArgument(
+            "The 0-th dimension of x [%d] "
+            "must match that of the 0-th dimension gate_logits [%d].",
+            corr_bias_dims[0],
+            gate_logits_dims[1]));
+  }
+
+  std::vector<int64_t> y_dims;
+
+  if (use_pad) {
+    y_dims = {num_experts, num_rows * k / num_experts, x_dims[1]};
+  } else {
+    y_dims = {num_rows, k, x_dims[1]};
+  }
+
+  y->set_dims(common::make_ddim(y_dims));
+  y->set_dtype(x.dtype());
+
+  combine_weights->set_dims(common::make_ddim({num_rows, k}));
+  combine_weights->set_dtype(phi::DataType::FLOAT32);
+
+  scatter_index->set_dims(common::make_ddim({k, num_rows}));
+  scatter_index->set_dtype(phi::DataType::INT32);
+
+  expert_offset->set_dims(common::make_ddim({num_experts}));
+  expert_offset->set_dtype(phi::DataType::INT64);
+
+  expert_id->set_dims(common::make_ddim({num_rows, k}));
+  expert_id->set_dtype(phi::DataType::INT32);
+}
+
 }  // namespace phi
 PD_REGISTER_INFER_META_FN(batch_norm_infer, phi::BatchNormInferInferMeta);

--- a/paddle/phi/infermeta/multiary.h
+++ b/paddle/phi/infermeta/multiary.h
@@ -1351,4 +1351,15 @@ void MoeGateDispatchInferMeta(const MetaTensor& x,
                               MetaTensor* expert_offset,
                               MetaTensor* expert_id);
 
+void MoeGateDispatchAutoInferMeta(const MetaTensor& x,
+                                  const MetaTensor& gate_logits,
+                                  const MetaTensor& corr_bias,
+                                  const int64_t k,
+                                  const int64_t capacity,
+                                  const bool use_pad,
+                                  MetaTensor* y,
+                                  MetaTensor* combine_weights,
+                                  MetaTensor* scatter_index,
+                                  MetaTensor* expert_offset,
+                                  MetaTensor* expert_id);
 }  // namespace phi

--- a/paddle/phi/infermeta/spmd_rules/moe_combine.cc
+++ b/paddle/phi/infermeta/spmd_rules/moe_combine.cc
@@ -25,6 +25,202 @@ limitations under the License. */
 namespace phi {
 namespace distributed {
 
+SpmdInfo MoECombineFwdInferSpmd(const DistMetaTensor& x,
+                                const DistMetaTensor& combine_weights,
+                                const DistMetaTensor& scatter_index) {
+  /* kernel logic:
+  y is [seqlen, hidden_size]
+  for kk in k:
+    y[i][j] += x[scatter_index[i][kk]][j] * combine_weights[i][kk]
+  */
+
+  // Step 0: validity check
+  EXTRACT_SHAPE_AND_DIST_ATTR_WITH_DIM_CK(x);
+  EXTRACT_SHAPE_AND_DIST_ATTR_WITH_DIM_CK(combine_weights);
+  EXTRACT_SHAPE_AND_DIST_ATTR_WITH_DIM_CK(scatter_index);
+
+  PADDLE_ENFORCE_EQ(
+      x_shape.size(),
+      2,
+      errors::InvalidArgument(
+          "x should be a 2-D tensor, but got x_shape.size() == %d",
+          x_shape.size()));
+  PADDLE_ENFORCE_EQ(
+      combine_weights_shape.size(),
+      2,
+      errors::InvalidArgument("combine_weights should be a 2-D tensor, but got "
+                              "combine_weights_shape.size() == %d",
+                              combine_weights.size()));
+  PADDLE_ENFORCE_EQ(
+      scatter_index_shape.size(),
+      2,
+      errors::InvalidArgument("scatter_index should be a 2-D tensor, but got "
+                              "scatter_index_shape.size() == %d",
+                              scatter_index.size()));
+
+  // Step 1: infer sharding
+  std::string x_axes = "sh", combine_weights_axes = "sk",
+              scatter_index_axes = "sk", out_axes = "sh";
+  std::unordered_map<std::string, int64_t> axis_to_dim_map =
+      ShardingMergeForTensors(
+          {{x_axes, x_dims_mapping_src},
+           {combine_weights_axes, combine_weights_dims_mapping_src},
+           {scatter_index_axes, scatter_index_dims_mapping_src}});
+
+  if (axis_to_dim_map["k"] != -1) {
+    axis_to_dim_map["h"] =
+        -1;  // Not allowed that k-dim and h-dim both be sharded
+  }
+
+  std::vector<int64_t> y_dims_mapping =
+      GetDimsMappingForAxes(out_axes, axis_to_dim_map);
+
+  TensorDistAttr x_dist_attr_dst = CopyTensorDistAttrForOutput(x_dist_attr_src);
+  TensorDistAttr combine_weights_dist_attr_dst =
+      CopyTensorDistAttrForOutput(combine_weights_dist_attr_src);
+  TensorDistAttr scatter_index_dist_attr_dst =
+      CopyTensorDistAttrForOutput(scatter_index_dist_attr_src);
+  TensorDistAttr y_dist_attr_dst = CopyTensorDistAttrForOutput(x_dist_attr_src);
+
+  x_dist_attr_dst.set_dims_mapping(
+      GetDimsMappingForAxes(x_axes, axis_to_dim_map));
+  combine_weights_dist_attr_dst.set_dims_mapping(
+      GetDimsMappingForAxes(combine_weights_axes, axis_to_dim_map));
+  scatter_index_dist_attr_dst.set_dims_mapping(
+      GetDimsMappingForAxes(scatter_index_axes, axis_to_dim_map));
+  y_dist_attr_dst.set_dims_mapping(y_dims_mapping);
+
+  // Step 2: infer partial, the output h-dim is partial when k is sharded
+  if (axis_to_dim_map["k"] != -1) {
+    y_dist_attr_dst.set_partial_status(std::vector<int64_t>({1}));
+  }
+
+  // Step 3: Log messages
+  LOG_SPMD_INPUT(x);
+  LOG_SPMD_INPUT(combine_weights);
+  LOG_SPMD_INPUT(scatter_index);
+  LOG_SPMD_OUTPUT(y_dist_attr_dst);
+
+  return {{x_dist_attr_dst,
+           combine_weights_dist_attr_dst,
+           scatter_index_dist_attr_dst},
+          {y_dist_attr_dst}};
+}
+
+SpmdInfo MoECombineBwdInferSpmd(const DistMetaTensor& x,
+                                const DistMetaTensor& combine_weights,
+                                const DistMetaTensor& scatter_index,
+                                const DistMetaTensor& grad_y) {
+  /* kernel logic:
+  for(int i = 0; i < s; ++i) {
+      for(int j = 0; j < h; ++j) {
+          for(int ki = 0; ki < k; ++ki) {
+              grad_x[scatter_index[i][ki]][j] = grad_y[i][j] *
+  combine_weights[i][ki]; grad_combine_weights_helper[i][ki][j] = grad_y[i][j] *
+  x[scatter_index[i][ki]][j];
+          }
+      }
+  }
+  */
+
+  // step 0 : validity check
+  EXTRACT_SHAPE_AND_DIST_ATTR_WITH_DIM_CK(x);
+  EXTRACT_SHAPE_AND_DIST_ATTR_WITH_DIM_CK(combine_weights);
+  EXTRACT_SHAPE_AND_DIST_ATTR_WITH_DIM_CK(scatter_index);
+  EXTRACT_SHAPE_AND_DIST_ATTR_WITH_DIM_CK(grad_y);
+
+  PADDLE_ENFORCE_EQ(
+      x_shape.size(),
+      2,
+      errors::InvalidArgument(
+          "x should be a 2-D tensor, but got x_shape.size() == %d",
+          x_shape.size()));
+
+  PADDLE_ENFORCE_EQ(
+      combine_weights_shape.size(),
+      2,
+      errors::InvalidArgument("combine_weights should be a 2-D tensor, but got "
+                              "combine_weights_shape.size() == %d",
+                              combine_weights_shape.size()));
+  PADDLE_ENFORCE_EQ(
+      scatter_index_shape.size(),
+      2,
+      errors::InvalidArgument("scatter_index should be a 2-D tensor, but got "
+                              "scatter_index_shape.size() == %d",
+                              scatter_index_shape.size()));
+  PADDLE_ENFORCE_EQ(
+      grad_y_shape.size(),
+      2,
+      errors::InvalidArgument(
+          "grad_y should be a 2-D tensor, but got grad_y_shape.size() == %d",
+          grad_y_shape.size()));
+
+  // step 1 : infer sharding
+  std::string x_axes = "sh", combine_weights_axes = "sk",
+              scatter_index_axes = "sk", grad_y_axes = "sh", grad_x_axes = "sh",
+              grad_combine_weights_axes = "sk", grad_scatter_index_axes = "sk";
+  std::unordered_map<std::string, int64_t> axis_to_dim_map =
+      ShardingMergeForTensors(
+          {{x_axes, x_dims_mapping_src},
+           {combine_weights_axes, combine_weights_dims_mapping_src},
+           {scatter_index_axes, scatter_index_dims_mapping_src},
+           {grad_y_axes, grad_y_dims_mapping_src}});
+
+  // k-dim should be replicated
+  axis_to_dim_map["k"] = -1;
+
+  std::vector<int64_t> grad_x_dims_mapping =
+      GetDimsMappingForAxes(grad_x_axes, axis_to_dim_map);
+  std::vector<int64_t> grad_combine_weights_dims_mapping =
+      GetDimsMappingForAxes(grad_combine_weights_axes, axis_to_dim_map);
+  std::vector<int64_t> grad_scatter_index_dims_mapping =
+      GetDimsMappingForAxes(grad_scatter_index_axes, axis_to_dim_map);
+
+  TensorDistAttr x_dist_attr_dst = CopyTensorDistAttrForOutput(x_dist_attr_src);
+  TensorDistAttr combine_weights_dist_attr_dst =
+      CopyTensorDistAttrForOutput(combine_weights_dist_attr_src);
+  TensorDistAttr scatter_index_dist_attr_dst =
+      CopyTensorDistAttrForOutput(scatter_index_dist_attr_src);
+  TensorDistAttr grad_y_dist_attr_dst =
+      CopyTensorDistAttrForOutput(grad_y_dist_attr_src);
+  TensorDistAttr grad_x_dist_attr_dst =
+      CopyTensorDistAttrForOutput(grad_y_dist_attr_src);
+  TensorDistAttr grad_combine_weights_dist_attr_dst =
+      CopyTensorDistAttrForOutput(grad_y_dist_attr_src);
+  TensorDistAttr grad_scatter_index_dist_attr_dst =
+      CopyTensorDistAttrForOutput(grad_y_dist_attr_src);
+
+  x_dist_attr_dst.set_dims_mapping(
+      GetDimsMappingForAxes(x_axes, axis_to_dim_map));
+  combine_weights_dist_attr_dst.set_dims_mapping(
+      GetDimsMappingForAxes(combine_weights_axes, axis_to_dim_map));
+  scatter_index_dist_attr_dst.set_dims_mapping(
+      GetDimsMappingForAxes(scatter_index_axes, axis_to_dim_map));
+  grad_y_dist_attr_dst.set_dims_mapping(
+      GetDimsMappingForAxes(grad_y_axes, axis_to_dim_map));
+  grad_x_dist_attr_dst.set_dims_mapping(grad_x_dims_mapping);
+  grad_combine_weights_dist_attr_dst.set_dims_mapping(
+      grad_combine_weights_dims_mapping);
+  grad_scatter_index_dist_attr_dst.set_dims_mapping(
+      grad_scatter_index_dims_mapping);
+
+  // Step 2: Log messages
+  LOG_SPMD_INPUT(x);
+  LOG_SPMD_INPUT(combine_weights);
+  LOG_SPMD_INPUT(scatter_index);
+  LOG_SPMD_INPUT(grad_y);
+  LOG_SPMD_OUTPUT(grad_x_dist_attr_dst);
+  LOG_SPMD_OUTPUT(grad_combine_weights_dist_attr_dst);
+
+  return {{x_dist_attr_dst,
+           combine_weights_dist_attr_dst,
+           scatter_index_dist_attr_dst,
+           grad_y_dist_attr_dst},
+          {grad_x_dist_attr_dst,
+           grad_combine_weights_dist_attr_dst,
+           grad_scatter_index_dist_attr_dst}};
+}
+
 SpmdInfo MoECombineInferSpmd(const DistMetaTensor& x,
                              const DistMetaTensor& combine_weights,
                              const DistMetaTensor& scatter_index) {

--- a/paddle/phi/infermeta/spmd_rules/moe_combine.h
+++ b/paddle/phi/infermeta/spmd_rules/moe_combine.h
@@ -22,6 +22,15 @@ limitations under the License. */
 namespace phi {
 namespace distributed {
 
+SpmdInfo MoECombineFwdInferSpmd(const DistMetaTensor& x,
+                                const DistMetaTensor& combine_weights,
+                                const DistMetaTensor& scatter_index);
+
+SpmdInfo MoECombineBwdInferSpmd(const DistMetaTensor& x,
+                                const DistMetaTensor& combine_weights,
+                                const DistMetaTensor& scatter_index,
+                                const DistMetaTensor& grad_y);
+
 SpmdInfo MoECombineInferSpmd(const DistMetaTensor& x,
                              const DistMetaTensor& combine_weights,
                              const DistMetaTensor& scatter_index);

--- a/paddle/phi/infermeta/spmd_rules/moe_gate_dispatch.cc
+++ b/paddle/phi/infermeta/spmd_rules/moe_gate_dispatch.cc
@@ -22,6 +22,222 @@ limitations under the License. */
 namespace phi {
 namespace distributed {
 
+SpmdInfo MoEGateDispatchFwdInferSpmd(const DistMetaTensor& x,
+                                     const DistMetaTensor& gate_logits,
+                                     int64_t k,
+                                     int64_t capacity,
+                                     bool use_pad) {
+  /*
+  inputs:
+    x: [S, H], S = b*s
+    gate_logits: [S, E]
+  outputs:
+    y: [E, C, H] is use_pad is true, else [S, K, H], currently only support
+  use_pad=true combine_weights: [S, K] scatter_index: [K, S] expert_offset: [E]
+    expert_id: [S, K]
+  */
+  EXTRACT_SHAPE_AND_DIST_ATTR_WITH_DIM_CK(x);
+  EXTRACT_SHAPE_AND_DIST_ATTR_WITH_DIM_CK(gate_logits);
+
+  // do some check
+  PADDLE_ENFORCE_EQ(
+      x_shape.size(),
+      2,
+      errors::InvalidArgument(
+          "x should be a 2-D tensor, but got x_shape.size() == %d",
+          x_shape.size()));
+  PADDLE_ENFORCE_EQ(
+      gate_logits_shape.size(),
+      2,
+      errors::InvalidArgument("gate_logits should be a 2-D tensor, but "
+                              "got gate_logits_shape.size() == %d",
+                              gate_logits_shape.size()));
+  // infer axes dims_mapping
+  std::string x_axes = "sh";
+  std::string gate_logits_axes = "se";
+
+  std::unordered_map<std::string, int64_t> axis_to_dim_map =
+      ShardingMergeForTensors(
+          {{x_axes, x_dims_mapping_src},
+           {gate_logits_axes, gate_logits_dims_mapping_src}});
+  axis_to_dim_map["k"] = -1;  // not allowed dim k to be sharded
+
+  // input axes
+  std::vector<int64_t> x_dims_mapping_dst =
+      GetDimsMappingForAxes(x_axes, axis_to_dim_map);
+  std::vector<int64_t> gate_logits_dims_mapping_dst =
+      GetDimsMappingForAxes(gate_logits_axes, axis_to_dim_map);
+  // infer input dist attr
+  TensorDistAttr x_dist_attr_dst = CopyTensorDistAttrForOutput(x_dist_attr_src);
+  x_dist_attr_dst.set_dims_mapping(x_dims_mapping_dst);
+  TensorDistAttr gate_logits_dist_attr_dst =
+      CopyTensorDistAttrForOutput(gate_logits_dist_attr_src);
+  gate_logits_dist_attr_dst.set_dims_mapping(gate_logits_dims_mapping_dst);
+
+  // output axes
+  std::string y_axes = "esh";
+  std::vector<int64_t> y_dims_mapping =
+      GetDimsMappingForAxes(y_axes, axis_to_dim_map);
+
+  std::string combine_weights_axes = "sk";
+  std::vector<int64_t> combine_weights_dims_mapping =
+      GetDimsMappingForAxes(combine_weights_axes, axis_to_dim_map);
+
+  std::string scatter_index_axes = "ks";
+  std::vector<int64_t> scatter_index_dims_mapping =
+      GetDimsMappingForAxes(scatter_index_axes, axis_to_dim_map);
+  std::string expert_offset_axes = "e";
+  std::vector<int64_t> expert_offset_dims_mapping =
+      GetDimsMappingForAxes(expert_offset_axes, axis_to_dim_map);
+  std::string expert_id_axes = "sk";
+  std::vector<int64_t> expert_id_dims_mapping =
+      GetDimsMappingForAxes(expert_id_axes, axis_to_dim_map);
+  // infer output dist attr
+  TensorDistAttr y_dist_attr_dst = CopyTensorDistAttrForOutput(x_dist_attr_src);
+  y_dist_attr_dst.set_dims_mapping(y_dims_mapping);
+  TensorDistAttr combine_weights_dist_attr =
+      CopyTensorDistAttrForOutput(x_dist_attr_src);
+  combine_weights_dist_attr.set_dims_mapping(combine_weights_dims_mapping);
+  TensorDistAttr scatter_index_dist_attr =
+      CopyTensorDistAttrForOutput(x_dist_attr_src);
+  scatter_index_dist_attr.set_dims_mapping(scatter_index_dims_mapping);
+  TensorDistAttr expert_offset_dist_attr =
+      CopyTensorDistAttrForOutput(x_dist_attr_src);
+  expert_offset_dist_attr.set_dims_mapping(expert_offset_dims_mapping);
+  TensorDistAttr expert_id_dist_attr =
+      CopyTensorDistAttrForOutput(x_dist_attr_src);
+  expert_id_dist_attr.set_dims_mapping(expert_id_dims_mapping);
+
+  return {{x_dist_attr_dst, gate_logits_dist_attr_dst},
+          {y_dist_attr_dst,
+           combine_weights_dist_attr,
+           scatter_index_dist_attr,
+           expert_offset_dist_attr,
+           expert_id_dist_attr}};
+}
+
+SpmdInfo MoEGateDispatchBwdInferSpmd(const DistMetaTensor& combine_weights,
+                                     const DistMetaTensor& scatter_index,
+                                     const DistMetaTensor& expert_id,
+                                     const DistMetaTensor& grad_y,
+                                     const DistMetaTensor& grad_combine_weights,
+                                     int64_t k,
+                                     int64_t capacity,
+                                     bool use_pad) {
+  /*
+    inputs:
+      combine_weights: [S, K]
+      scatter_index: [K, S]
+      expert_id: [S, K]
+      grad_y: [E, C, H] is use_pad is true, else [S, K, H], currently only
+    support use_pad=true grad_combine_weights: [S, K] outputs: grad_x: [S, H]
+      grad_gate_logits: [S, E]
+   */
+  EXTRACT_SHAPE_AND_DIST_ATTR_WITH_DIM_CK(combine_weights);
+  EXTRACT_SHAPE_AND_DIST_ATTR_WITH_DIM_CK(scatter_index);
+  EXTRACT_SHAPE_AND_DIST_ATTR_WITH_DIM_CK(expert_id);
+  EXTRACT_SHAPE_AND_DIST_ATTR_WITH_DIM_CK(grad_y);
+  EXTRACT_SHAPE_AND_DIST_ATTR_WITH_DIM_CK(grad_combine_weights);
+  // do some check
+  PADDLE_ENFORCE_EQ(
+      combine_weights_shape.size(),
+      2,
+      errors::InvalidArgument("combine_weights should be a 2-D tensor, but "
+                              "got combine_weights_shape.size() == %d",
+                              combine_weights_shape.size()));
+  PADDLE_ENFORCE_EQ(
+      scatter_index_shape.size(),
+      2,
+      errors::InvalidArgument("scatter_index should be a 2-D tensor, but "
+                              "got scatter_index_shape.size() == %d",
+                              scatter_index_shape.size()));
+  PADDLE_ENFORCE_EQ(
+      expert_id_shape.size(),
+      2,
+      errors::InvalidArgument("expert_id should be a 2-D tensor, but "
+                              "got expert_id_shape.size() == %d",
+                              expert_id_shape.size()));
+  PADDLE_ENFORCE_EQ(
+      grad_y_shape.size(),
+      3,
+      errors::InvalidArgument("grad_y should be a 3-D tensor, but "
+                              "got grad_y_shape.size() == %d",
+                              grad_y_shape.size()));
+  PADDLE_ENFORCE_EQ(grad_combine_weights_shape.size(),
+                    2,
+                    errors::InvalidArgument(
+                        "grad_combine_weights should be a 2-D tensor, but "
+                        "got grad_combine_weights_shape.size() == %d",
+                        grad_combine_weights_shape.size()));
+
+  // infer axes dims_mapping
+  std::string combine_weights_axes = "sk";
+  std::string scatter_index_axes = "ks";
+  std::string expert_id_axes = "sk";
+  std::string grad_y_axes = "esh";
+  std::string grad_combine_weights_axes = "sk";
+  std::unordered_map<std::string, int64_t> axis_to_dim_map =
+      ShardingMergeForTensors(
+          {{combine_weights_axes, combine_weights_dims_mapping_src},
+           {scatter_index_axes, scatter_index_dims_mapping_src},
+           {expert_id_axes, expert_id_dims_mapping_src},
+           {grad_y_axes, grad_y_dims_mapping_src},
+           {grad_combine_weights_axes, grad_combine_weights_dims_mapping_src}});
+  // axis_to_dim_map["e"] = -1;  // not allowed dim e to be sharded
+  // input axes
+  std::vector<int64_t> combine_weights_dims_mapping_dst =
+      GetDimsMappingForAxes(combine_weights_axes, axis_to_dim_map);
+  std::vector<int64_t> scatter_index_dims_mapping_dst =
+      GetDimsMappingForAxes(scatter_index_axes, axis_to_dim_map);
+  std::vector<int64_t> expert_id_dims_mapping_dst =
+      GetDimsMappingForAxes(expert_id_axes, axis_to_dim_map);
+  std::vector<int64_t> grad_y_dims_mapping_dst =
+      GetDimsMappingForAxes(grad_y_axes, axis_to_dim_map);
+  std::vector<int64_t> grad_combine_weights_dims_mapping_dst =
+      GetDimsMappingForAxes(grad_combine_weights_axes, axis_to_dim_map);
+  // infer input dist attr
+  TensorDistAttr combine_weights_dist_attr_dst =
+      CopyTensorDistAttrForOutput(combine_weights_dist_attr_src);
+  combine_weights_dist_attr_dst.set_dims_mapping(
+      combine_weights_dims_mapping_dst);
+  TensorDistAttr scatter_index_dist_attr_dst =
+      CopyTensorDistAttrForOutput(scatter_index_dist_attr_src);
+  scatter_index_dist_attr_dst.set_dims_mapping(scatter_index_dims_mapping_dst);
+
+  TensorDistAttr expert_id_dist_attr_dst =
+      CopyTensorDistAttrForOutput(expert_id_dist_attr_src);
+  expert_id_dist_attr_dst.set_dims_mapping(expert_id_dims_mapping_dst);
+  TensorDistAttr grad_y_dist_attr_dst =
+      CopyTensorDistAttrForOutput(grad_y_dist_attr_src);
+  grad_y_dist_attr_dst.set_dims_mapping(grad_y_dims_mapping_dst);
+  TensorDistAttr grad_combine_weights_dist_attr_dst =
+      CopyTensorDistAttrForOutput(grad_combine_weights_dist_attr_src);
+  grad_combine_weights_dist_attr_dst.set_dims_mapping(
+      grad_combine_weights_dims_mapping_dst);
+
+  // output axes
+  std::string grad_x_axes = "sh";
+  std::string grad_gate_logits = "se";
+  std::vector<int64_t> grad_x_dims_mapping =
+      GetDimsMappingForAxes(grad_x_axes, axis_to_dim_map);
+  std::vector<int64_t> grad_gate_logits_dims_mapping =
+      GetDimsMappingForAxes(grad_gate_logits, axis_to_dim_map);
+  // output dist attr
+  TensorDistAttr grad_x_dist_attr_dst =
+      CopyTensorDistAttrForOutput(grad_y_dist_attr_src);
+  grad_x_dist_attr_dst.set_dims_mapping(grad_x_dims_mapping);
+  TensorDistAttr grad_gate_logits_dist_attr_dst =
+      CopyTensorDistAttrForOutput(grad_y_dist_attr_src);
+  grad_gate_logits_dist_attr_dst.set_dims_mapping(
+      grad_gate_logits_dims_mapping);
+  return {{combine_weights_dist_attr_dst,
+           scatter_index_dist_attr_dst,
+           expert_id_dist_attr_dst,
+           grad_y_dist_attr_dst,
+           grad_combine_weights_dist_attr_dst},
+          {grad_x_dist_attr_dst, grad_gate_logits_dist_attr_dst}};
+}
+
 SpmdInfo MoEGateDispatchInferSpmd(const DistMetaTensor& x,
                                   const DistMetaTensor& gate_logits,
                                   const DistMetaTensor& corr_bias,

--- a/paddle/phi/infermeta/spmd_rules/moe_gate_dispatch.h
+++ b/paddle/phi/infermeta/spmd_rules/moe_gate_dispatch.h
@@ -19,6 +19,22 @@ limitations under the License. */
 namespace phi {
 namespace distributed {
 
+SpmdInfo MoEGateDispatchFwdInferSpmd(const DistMetaTensor& x,
+                                     const DistMetaTensor& gate_logits,
+                                     int64_t k,
+                                     int64_t capacity,
+                                     bool use_pad);
+// out: "y", "combine_weights", "scatter_index", "expert_offset", "expert_id"
+
+SpmdInfo MoEGateDispatchBwdInferSpmd(const DistMetaTensor& combine_weights,
+                                     const DistMetaTensor& scatter_index,
+                                     const DistMetaTensor& expert_id,
+                                     const DistMetaTensor& grad_y,
+                                     const DistMetaTensor& grad_combine_weights,
+                                     int64_t k,
+                                     int64_t capacity,
+                                     bool use_pad);
+
 SpmdInfo MoEGateDispatchInferSpmd(const DistMetaTensor& x,
                                   const DistMetaTensor& gate_logits,
                                   const DistMetaTensor& corr_bias,

--- a/paddle/phi/kernels/legacy/gpu/moe_gate_dispatch_kernel.cu
+++ b/paddle/phi/kernels/legacy/gpu/moe_gate_dispatch_kernel.cu
@@ -109,7 +109,7 @@ void moe_dispatch_fwd(const Context &dev_ctx,
 }
 
 template <typename T, typename Context>
-void MoeGradDispatchKernel(const Context &dev_ctx,
+void MoeGateDispatchKernel(const Context &dev_ctx,
                            const DenseTensor &x,
                            const DenseTensor &gate_logits,
                            const paddle::optional<DenseTensor> &corr_bias,
@@ -158,7 +158,7 @@ void MoeGradDispatchKernel(const Context &dev_ctx,
 PD_REGISTER_KERNEL(moe_gate_dispatch,
                    GPU,
                    ALL_LAYOUT,
-                   phi::MoeGradDispatchKernel,
+                   phi::MoeGateDispatchKernel,
                    float,
                    double,
                    phi::dtype::float16,

--- a/paddle/phi/kernels/xpu/moe_gate_dispatch_kernel.cc
+++ b/paddle/phi/kernels/xpu/moe_gate_dispatch_kernel.cc
@@ -92,7 +92,7 @@ void moe_dispatch_fwd(const Context &dev_ctx,
 }
 
 template <typename T, typename Context>
-void MoeGradDispatchKernel(const Context &dev_ctx,
+void MoeGateDispatchKernel(const Context &dev_ctx,
                            const DenseTensor &x,
                            const DenseTensor &gate_logits,
                            const paddle::optional<DenseTensor> &corr_bias,
@@ -130,7 +130,7 @@ void MoeGradDispatchKernel(const Context &dev_ctx,
 PD_REGISTER_KERNEL(moe_gate_dispatch,
                    XPU,
                    ALL_LAYOUT,
-                   phi::MoeGradDispatchKernel,
+                   phi::MoeGateDispatchKernel,
                    float,
                    phi::dtype::float16,
                    phi::dtype::bfloat16) {}

--- a/paddle/phi/ops/yaml/backward.yaml
+++ b/paddle/phi/ops/yaml/backward.yaml
@@ -2362,13 +2362,22 @@
   kernel :
     func : mode_grad
 
+- backward_op : moe_combine_auto_grad
+  forward : moe_combine_auto (Tensor x, Tensor combine_weights, Tensor scatter_index) -> Tensor(y)
+  args : (Tensor x, Tensor combine_weights, Tensor scatter_index, Tensor y_grad)
+  output : Tensor(x_grad), Tensor(combine_weights_grad), Tensor(scatter_index_grad)
+  infer_meta :
+    func : MoeCombineAutoGradInferMeta
+    spmd_rule : MoECombineGradInferSpmd
+  kernel :
+    func : moe_combine_auto_grad
+
 - backward_op : moe_combine_grad
   forward : moe_combine (Tensor x, Tensor combine_weights, Tensor scatter_index) -> Tensor(y)
   args : (Tensor x, Tensor combine_weights, Tensor scatter_index, Tensor y_grad)
   output : Tensor(x_grad), Tensor(combine_weights_grad)
   infer_meta :
     func : MoeCombineGradInferMeta
-    spmd_rule : MoECombineGradInferSpmd
   kernel :
     func : moe_combine_grad
 
@@ -2383,13 +2392,23 @@
     func : moe_combine_no_weight_grad
   no_need_buffer : x
 
+- backward_op : moe_gate_dispatch_auto_grad
+  forward : moe_gate_dispatch_auto (Tensor x, Tensor gate_logits, Tensor corr_bias, int64_t k, int64_t capacity, bool use_pad) -> Tensor(y), Tensor(combine_weights), Tensor(scatter_index), Tensor(expert_offset), Tensor(expert_id)
+  args : (Tensor combine_weights, Tensor scatter_index, Tensor expert_id, Tensor y_grad, Tensor combine_weights_grad, int64_t k, int64_t capacity, bool use_pad)
+  output : Tensor(x_grad), Tensor(gate_logits_grad)
+  infer_meta :
+    func : MoeGateDispatchAutoGradInferMeta
+    spmd_rule : MoEGateDispatchGradInferSpmd
+  kernel :
+    func : moe_gate_dispatch_grad
+    data_type : y_grad
+
 - backward_op : moe_gate_dispatch_grad
   forward : moe_gate_dispatch (Tensor x, Tensor gate_logits, Tensor corr_bias, int64_t k, int64_t capacity, bool use_pad) -> Tensor(y), Tensor(combine_weights), Tensor(scatter_index), Tensor(expert_offset), Tensor(expert_id)
   args : (Tensor combine_weights, Tensor scatter_index, Tensor expert_id, Tensor y_grad, Tensor combine_weights_grad, int64_t k, int64_t capacity, bool use_pad)
   output : Tensor(x_grad), Tensor(gate_logits_grad)
   infer_meta :
     func : MoeGateDispatchGradInferMeta
-    spmd_rule : MoEGateDispatchGradInferSpmd
   kernel :
     func : moe_gate_dispatch_grad
     data_type : y_grad

--- a/paddle/phi/ops/yaml/ops.yaml
+++ b/paddle/phi/ops/yaml/ops.yaml
@@ -3690,11 +3690,21 @@
   output : Tensor(y)
   infer_meta :
     func : MoeCombineInferMeta
-    spmd_rule : MoECombineInferSpmd
   kernel :
     func : moe_combine
     data_type : x
   backward : moe_combine_grad
+
+- op : moe_combine_auto
+  args : (Tensor x, Tensor combine_weights, Tensor scatter_index)
+  output : Tensor(y)
+  infer_meta :
+    func : MoeCombineInferMeta
+    spmd_rule : MoECombineInferSpmd
+  kernel :
+    func : moe_combine
+    data_type : x
+  backward : moe_combine_auto_grad
 
 - op : moe_combine_no_weight
   args : (Tensor x, Tensor combine_weight, Tensor scatter_index, float epsilon = 1.0e-15)
@@ -3711,7 +3721,6 @@
   output : Tensor(y), Tensor(combine_weights), Tensor(scatter_index), Tensor(expert_offset), Tensor(expert_id)
   infer_meta :
     func : MoeGateDispatchInferMeta
-    spmd_rule : MoEGateDispatchInferSpmd
   kernel :
     func : moe_gate_dispatch
     data_type : x
@@ -3727,6 +3736,18 @@
     func : moe_gate_dispatch_and_quant
     data_type : x
   optional : corr_bias
+
+- op : moe_gate_dispatch_auto
+  args : (Tensor x, Tensor gate_logits, Tensor corr_bias, int64_t k, int64_t capacity, bool use_pad)
+  output : Tensor(y), Tensor(combine_weights), Tensor(scatter_index), Tensor(expert_offset), Tensor(expert_id)
+  infer_meta :
+    func : MoeGateDispatchAutoInferMeta
+    spmd_rule : MoEGateDispatchInferSpmd
+  kernel :
+    func : moe_gate_dispatch
+    data_type : x
+  optional : corr_bias
+  backward : moe_gate_dispatch_auto_grad
 
 - op : moe_gate_dispatch_partial_nosoftmaxtopk
   args : (Tensor x, Tensor combine_weights, Tensor expert_id, int64_t k, int64_t capacity, int64_t num_experts, bool use_pad, int64_t expert_start_index, int64_t expert_end_index, bool reverse_token_drop)

--- a/python/paddle/incubate/nn/functional/moe_combine.py
+++ b/python/paddle/incubate/nn/functional/moe_combine.py
@@ -42,6 +42,13 @@ def moe_combine(
         Output Combined output [s, dim]
     """
     if in_dynamic_or_pir_mode():
+        if not (
+            x.process_mesh is None
+            and combine_weights.process_mesh is None
+            and scatter_index.process_mesh is None
+        ):
+            # auto parallel mode
+            return _C_ops.moe_combine_auto(x, combine_weights, scatter_index)
         return _C_ops.moe_combine(x, combine_weights, scatter_index)
     helper = LayerHelper('moe_combine', **locals())
     y = helper.create_variable_for_type_inference(dtype=x.dtype)

--- a/python/paddle/incubate/nn/functional/moe_gate_dispatch.py
+++ b/python/paddle/incubate/nn/functional/moe_gate_dispatch.py
@@ -58,6 +58,12 @@ def moe_gate_dispatch(
                 x, gate_logits, corr_bias, k, capacity, use_pad
             )
         else:
+            if not (
+                x.process_mesh is None and gate_logits.process_mesh is None
+            ):
+                return _C_ops.moe_gate_dispatch_auto(
+                    x, gate_logits, corr_bias, k, capacity, use_pad
+                )
             return _C_ops.moe_gate_dispatch(
                 x, gate_logits, corr_bias, k, capacity, use_pad
             )


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
为了绕过切多刀，动手/动半自定义算子moe_gate_dispatch与moe_combine在最初的实现版本中output有很多不同，此pr通过新增 auto 版本算子来暂时将动半版本的自定义算子下沉至框架内实现，后续需将动手/动半统一为一个版本

具体的diff如下：
- moe_gate_dispatch
    - output y shape不同 动手为 num_experts * capacity, x_dims[1]；动半为 num_experts, num_rows * k / num_experts, x_dims[1]
    - 由于上一点不同，kernel 中依赖 y 来确定 hidden_size 的方式需要改变
- moe_gate_dispatch_grad
    - 由于 moe_gate_dispatch 第一点的不同，y_grad 维度由2变为3
    - 由于 moe_gate_dispatch 第一点的不同，确定 num_experts 和 hidden_size 的方式需要改变
- moe_combine
    - 动手动半版本实现相同
- moe_combine_grad
    - 动半相较动手需要额外返回scatter_index_grad
    - grad_combine_weights_helper 的 shape 动手为 combine_weights_shape[0], combine_weights_shape[1], x_dim[1]；动半为 combine_weights_shape[0], combine_weights_shape[1] (这里与kernel内部实现有关，动手在得到这个output后在组网内使用sum手动消除了最后一维，后续应统一成二维output)