### PR TITLE
[CodeStyle] `black -> ruff format` migration - part 6

### DIFF
--- a/test/legacy_test/test_broadcast_to_op.py
+++ b/test/legacy_test/test_broadcast_to_op.py
@@ -24,7 +24,6 @@ paddle.enable_static()
 
 
 class TestBroadcastToError(unittest.TestCase):
-
     def test_errors(self):
         with paddle.static.program_guard(
             paddle.static.Program(), paddle.static.Program()

--- a/test/legacy_test/test_calc_gradient.py
+++ b/test/legacy_test/test_calc_gradient.py
@@ -86,7 +86,6 @@ class TestDoubleGrad(unittest.TestCase):
 
 
 class TestGradientWithPrune(unittest.TestCase):
-
     def test_prune(self):
         with paddle.base.scope_guard(paddle.static.Scope()):
             x = paddle.static.data(name='x', shape=[3], dtype='float32')

--- a/test/legacy_test/test_case.py
+++ b/test/legacy_test/test_case.py
@@ -27,7 +27,6 @@ paddle.enable_static()
 
 
 class TestAPICase(unittest.TestCase):
-
     def test_return_single_var(self):
         def fn_1():
             return paddle.tensor.fill_constant(
@@ -298,7 +297,6 @@ class TestAPICase(unittest.TestCase):
 
 
 class TestAPICase_Nested(unittest.TestCase):
-
     def test_nested_case(self):
         def fn_1(x=1):
             var_5 = paddle.tensor.fill_constant(
@@ -513,7 +511,6 @@ class TestAPICase_Nested(unittest.TestCase):
 
 
 class TestAPICase_Error(unittest.TestCase):
-
     def test_error(self):
         def fn_1():
             return paddle.tensor.fill_constant(
@@ -582,7 +579,6 @@ class TestAPICase_Error(unittest.TestCase):
 
 # when optimizer in case
 class TestMultiTask(unittest.TestCase):
-
     def test_optimizer_in_case(self):
         BATCH_SIZE = 1
         INPUT_SIZE = 784

--- a/test/legacy_test/test_cast_op.py
+++ b/test/legacy_test/test_cast_op.py
@@ -194,7 +194,6 @@ class TestCastOpFp32ToBf16(OpTest):
 
 
 class TestCastOpError(unittest.TestCase):
-
     def test_errors(self):
         paddle.enable_static()
         with program_guard(Program(), Program()):

--- a/test/legacy_test/test_channel_shuffle.py
+++ b/test/legacy_test/test_channel_shuffle.py
@@ -252,7 +252,6 @@ class TestChannelShuffleAPI(unittest.TestCase):
 
 
 class TestChannelShuffleError(unittest.TestCase):
-
     def test_error_functional(self):
         def error_input():
             with paddle.base.dygraph.guard():

--- a/test/legacy_test/test_clip_op.py
+++ b/test/legacy_test/test_clip_op.py
@@ -301,7 +301,6 @@ class TestBF16Case5(TestClipBF16Op):
 
 
 class TestClipOpError(unittest.TestCase):
-
     def test_errors(self):
         paddle.enable_static()
         with paddle.static.program_guard(
@@ -489,7 +488,6 @@ class TestClipAPI(unittest.TestCase):
 
 
 class TestClipOpFp16(unittest.TestCase):
-
     def test_fp16(self):
         if base.core.is_compiled_with_cuda():
             paddle.enable_static()

--- a/test/legacy_test/test_compare_op.py
+++ b/test/legacy_test/test_compare_op.py
@@ -515,7 +515,6 @@ create_bf16_case('not_equal', lambda _a, _b: _a != _b, True)
 
 
 class TestCompareOpError(unittest.TestCase):
-
     def test_int16_support(self):
         paddle.enable_static()
         with paddle.static.program_guard(
@@ -530,7 +529,6 @@ class TestCompareOpError(unittest.TestCase):
 
 
 class API_TestElementwise_Equal(unittest.TestCase):
-
     def test_api(self):
         paddle.enable_static()
         with paddle.static.program_guard(
@@ -571,7 +569,6 @@ class API_TestElementwise_Equal(unittest.TestCase):
 
 
 class API_TestElementwise_Greater_Than(unittest.TestCase):
-
     def test_api_fp16(self):
         paddle.enable_static()
         with paddle.static.program_guard(
@@ -588,7 +585,6 @@ class API_TestElementwise_Greater_Than(unittest.TestCase):
 
 
 class TestCompareOpPlace(unittest.TestCase):
-
     def test_place_1(self):
         paddle.enable_static()
         place = paddle.CPUPlace()

--- a/test/legacy_test/test_concat_op.py
+++ b/test/legacy_test/test_concat_op.py
@@ -673,7 +673,6 @@ class TestConcatOpError(unittest.TestCase):
 
 
 class TestConcatAPI(unittest.TestCase):
-
     def test_base_api(self):
         paddle.enable_static()
         with paddle.base.program_guard(paddle.base.Program()):
@@ -1014,7 +1013,6 @@ class TestConcatOpAutoParallel(OpTest):
 
 
 class TestConcatOpErrorWithPir(unittest.TestCase):
-
     def test_errors_with_pir(self):
         paddle.enable_static()
         with paddle.base.program_guard(

--- a/test/legacy_test/test_cond.py
+++ b/test/legacy_test/test_cond.py
@@ -478,7 +478,6 @@ class TestCondInputOutput(unittest.TestCase):
 
 
 class TestCondNestedControlFlow(unittest.TestCase):
-
     def test_cond_inside_cond(self):
         """
         pseudocode:
@@ -930,7 +929,6 @@ class TestCondWithError(unittest.TestCase):
 
 
 class TestCondWithDict(unittest.TestCase):
-
     @compare_legacy_with_pt
     def test_input_with_dict(self):
         paddle.enable_static()

--- a/test/legacy_test/test_conj_op.py
+++ b/test/legacy_test/test_conj_op.py
@@ -155,7 +155,6 @@ class TestComplexConjOp(unittest.TestCase):
 
 
 class Testfp16ConjOp(unittest.TestCase):
-
     def testfp16(self):
         if paddle.is_compiled_with_cuda():
             input_x = (

--- a/test/legacy_test/test_conv2d_op.py
+++ b/test/legacy_test/test_conv2d_op.py
@@ -726,7 +726,6 @@ class TestCUDNNExhaustiveSearch(TestConv2DOp):
 
 
 class TestConv2DOpError(unittest.TestCase):
-
     def test_errors(self):
         with paddle.static.program_guard(
             paddle.static.Program(), paddle.static.Program()

--- a/test/legacy_test/test_conv_nn_grad.py
+++ b/test/legacy_test/test_conv_nn_grad.py
@@ -26,7 +26,6 @@ from paddle.base import core
 
 
 class TestConvDoubleGradCheck(unittest.TestCase):
-
     @prog_scope()
     def func_pir(self, place):
         shape = [2, 4, 3, 3]
@@ -50,7 +49,6 @@ class TestConvDoubleGradCheck(unittest.TestCase):
 
 
 class TestConvDoubleGradCheckTest0(unittest.TestCase):
-
     @prog_scope()
     def func_pir(self, place):
         shape = [2, 4, 3, 3]
@@ -74,7 +72,6 @@ class TestConvDoubleGradCheckTest0(unittest.TestCase):
 
 
 class TestConvDoubleGradCheckTest1(unittest.TestCase):
-
     @prog_scope()
     def func_pir(self, place):
         shape = [2, 3, 3, 3]
@@ -98,7 +95,6 @@ class TestConvDoubleGradCheckTest1(unittest.TestCase):
 
 
 class TestConv3DDoubleGradCheck(unittest.TestCase):
-
     @prog_scope()
     def func_pir(self, place):
         shape = [2, 4, 3, 4, 2]
@@ -122,7 +118,6 @@ class TestConv3DDoubleGradCheck(unittest.TestCase):
 
 
 class TestConv3DDoubleGradCheckTest1(unittest.TestCase):
-
     @prog_scope()
     def func_pir(self, place):
         shape = [2, 4, 5, 3, 2]
@@ -146,7 +141,6 @@ class TestConv3DDoubleGradCheckTest1(unittest.TestCase):
 
 
 class TestConv2DoubleGradCheck_AsyPadding(unittest.TestCase):
-
     @prog_scope()
     def func_pir(self, place):
         shape = [2, 2, 3, 3]
@@ -170,7 +164,6 @@ class TestConv2DoubleGradCheck_AsyPadding(unittest.TestCase):
 
 
 class TestConv2DoubleGradCheck_PaddingSAME(unittest.TestCase):
-
     @prog_scope()
     def func_pir(self, place):
         shape = [2, 2, 3, 3]
@@ -194,7 +187,6 @@ class TestConv2DoubleGradCheck_PaddingSAME(unittest.TestCase):
 
 
 class TestConv2DoubleGradCheck_PaddingVALID(unittest.TestCase):
-
     @prog_scope()
     def func_pir(self, place):
         shape = [2, 2, 3, 3]
@@ -218,7 +210,6 @@ class TestConv2DoubleGradCheck_PaddingVALID(unittest.TestCase):
 
 
 class TestConv2DoubleGradCheck_ChannelLast(unittest.TestCase):
-
     @prog_scope()
     def func_pir(self, place):
         x_shape = [2, 2, 3, 3]
@@ -243,7 +234,6 @@ class TestConv2DoubleGradCheck_ChannelLast(unittest.TestCase):
 
 
 class TestConv2DoubleGradCheck_ChannelLast_AsyPadding(unittest.TestCase):
-
     @prog_scope()
     def func_pir(self, place):
         x_shape = [2, 2, 3, 3]
@@ -268,7 +258,6 @@ class TestConv2DoubleGradCheck_ChannelLast_AsyPadding(unittest.TestCase):
 
 
 class TestConv3DDoubleGradCheck_AsyPadding(unittest.TestCase):
-
     @prog_scope()
     def func_pir(self, place):
         shape = [2, 2, 2, 2, 2]
@@ -292,7 +281,6 @@ class TestConv3DDoubleGradCheck_AsyPadding(unittest.TestCase):
 
 
 class TestConv3DoubleGradCheck_PaddingSAME(unittest.TestCase):
-
     @prog_scope()
     def func_pir(self, place):
         shape = [2, 2, 2, 2, 2]
@@ -316,7 +304,6 @@ class TestConv3DoubleGradCheck_PaddingSAME(unittest.TestCase):
 
 
 class TestConv3DoubleGradCheck_PaddingVALID(unittest.TestCase):
-
     @prog_scope()
     def func_pir(self, place):
         shape = [2, 2, 3, 3, 2]
@@ -340,7 +327,6 @@ class TestConv3DoubleGradCheck_PaddingVALID(unittest.TestCase):
 
 
 class TestConv3DDoubleGradCheck_ChannelLast(unittest.TestCase):
-
     @prog_scope()
     def func_pir(self, place):
         x_shape = [2, 2, 2, 2, 3]
@@ -365,7 +351,6 @@ class TestConv3DDoubleGradCheck_ChannelLast(unittest.TestCase):
 
 
 class TestConv3DDoubleGradCheck_ChannelLast_AsyPadding(unittest.TestCase):
-
     @prog_scope()
     def func_pir(self, place):
         x_shape = [2, 2, 2, 2, 3]
@@ -390,7 +375,6 @@ class TestConv3DDoubleGradCheck_ChannelLast_AsyPadding(unittest.TestCase):
 
 
 class TestDepthWiseConvDoubleGradCheck(unittest.TestCase):
-
     @prog_scope()
     def func_pir(self, place):
         x_shape = [2, 4, 3, 3]

--- a/test/legacy_test/test_crop_tensor_op.py
+++ b/test/legacy_test/test_crop_tensor_op.py
@@ -271,7 +271,6 @@ class TestCropTensorOpTensorAttrCase4(TestCropTensorOpTensorAttr):
 
 
 class TestCropTensorException(unittest.TestCase):
-
     def test_exception(self):
         paddle.enable_static()
         input1 = paddle.static.data(

--- a/test/legacy_test/test_cumsum_op.py
+++ b/test/legacy_test/test_cumsum_op.py
@@ -590,7 +590,6 @@ create_test_bf16_class(TestSumOpReverseExclusive)
 
 
 class BadInputTest(unittest.TestCase):
-
     def test_error(self):
         paddle.enable_static()
         with paddle.static.program_guard(
@@ -725,7 +724,6 @@ class TestTensorAxis(unittest.TestCase):
 
 
 class TestCumSumOpFp16(unittest.TestCase):
-
     def test_fp16(self):
         if core.is_compiled_with_cuda():
             paddle.enable_static()

--- a/test/legacy_test/test_deformable_conv_op.py
+++ b/test/legacy_test/test_deformable_conv_op.py
@@ -371,7 +371,6 @@ class TestWithDouble(TestModulatedDeformableConvOp):
 
 
 class TestModulatedDeformableConvInvalidInput(unittest.TestCase):
-
     def test_error_api(self):
         def test_invalid_input():
             paddle.enable_static()
@@ -428,7 +427,6 @@ class TestModulatedDeformableConvInvalidInput(unittest.TestCase):
 
 
 class TestDeformConv2DAPI(unittest.TestCase):
-
     def test_api(self):
         def test_deform_conv2d_v1():
             paddle.enable_static()

--- a/test/legacy_test/test_diag_embed.py
+++ b/test/legacy_test/test_diag_embed.py
@@ -60,7 +60,6 @@ class TestDiagEmbedOp_ZeroSize(TestDiagEmbedOp):
 
 
 class TestDiagEmbedAPICase(unittest.TestCase):
-
     def test_case1(self):
         paddle.enable_static()
         main = paddle.static.Program()

--- a/test/legacy_test/test_diag_v2.py
+++ b/test/legacy_test/test_diag_v2.py
@@ -106,7 +106,6 @@ class TestDiagV2OpCase4(TestDiagV2Op):
 
 
 class TestDiagV2Error(unittest.TestCase):
-
     def test_errors(self):
         paddle.enable_static()
         main = static.Program()

--- a/test/legacy_test/test_diff_op.py
+++ b/test/legacy_test/test_diff_op.py
@@ -306,7 +306,6 @@ class TestDiffOpPreAppendAxis(TestDiffOp):
 
 
 class TestDiffOpFp16(TestDiffOp):
-
     def test_fp16_with_gpu(self):
         paddle.enable_static()
         if paddle.base.core.is_compiled_with_cuda():

--- a/test/legacy_test/test_dlpack.py
+++ b/test/legacy_test/test_dlpack.py
@@ -332,7 +332,6 @@ from paddle.utils.dlpack import DLDeviceType
 class TestDLPackDevice(unittest.TestCase):
     def test_dlpack_device(self):
         with dygraph_guard():
-
             tensor_cpu = paddle.to_tensor([1, 2, 3], place=base.CPUPlace())
             device_type, device_id = tensor_cpu.__dlpack_device__()
             self.assertEqual(device_type, DLDeviceType.kDLCPU)
@@ -362,7 +361,6 @@ class TestDLPackDevice(unittest.TestCase):
 
     def test_dlpack_device_zero_dim(self):
         with dygraph_guard():
-
             tensor = paddle.to_tensor(5.0, place=base.CPUPlace())
             device_type, device_id = tensor.__dlpack_device__()
             self.assertEqual(device_type, DLDeviceType.kDLCPU)

--- a/test/legacy_test/test_dot_op.py
+++ b/test/legacy_test/test_dot_op.py
@@ -173,7 +173,6 @@ class DotOpBatch(DotOp):
 
 
 class TestDotOpError(unittest.TestCase):
-
     def test_errors(self):
         with paddle.static.program_guard(
             paddle.static.Program(), paddle.static.Program()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

* black 迁移到 ruff format
