### PR TITLE
[CodeStyle] `black -> ruff format` migration - part 8

### DIFF
--- a/test/legacy_test/test_gammaincc_op.py
+++ b/test/legacy_test/test_gammaincc_op.py
@@ -131,13 +131,11 @@ class TestGammainccOpFp32Api(TestGammainccOpApi):
 
 
 class TestGammainccOp_ZeroSize(TestGammainccOp):
-
     def init_shape(self):
         self.shape = (0, 40)
 
 
 class TestGammainccOp_ZeroSize2(TestGammainccOp):
-
     def init_shape(self):
         self.shape = (0, 0)
 

--- a/test/legacy_test/test_gather_nd_op.py
+++ b/test/legacy_test/test_gather_nd_op.py
@@ -562,7 +562,6 @@ class TestGatherNdOpWithHighRankDiffBF16(TestGatherNdOpWithHighRankDiff):
 
 # Test Python API
 class TestGatherNdOpAPI(unittest.TestCase):
-
     def test_case1(self):
         with static_guard():
             x1 = paddle.static.data(
@@ -596,7 +595,6 @@ class TestGatherNdOpAPI(unittest.TestCase):
 
 # Test Raise Index Error
 class TestGatherNdOpRaise(unittest.TestCase):
-
     def test_check_raise(self):
         def check_raise_is_test():
             with static_guard():
@@ -617,7 +615,6 @@ class TestGatherNdOpRaise(unittest.TestCase):
 
 
 class TestGatherNdError(unittest.TestCase):
-
     def test_error1(self):
         with (
             static_guard(),
@@ -661,7 +658,6 @@ class TestGatherNdError(unittest.TestCase):
 
 
 class TestGatherNdAPI2(unittest.TestCase):
-
     def test_static(self):
         with base.program_guard(base.Program(), base.Program()):
             data1 = paddle.static.data('data1', shape=[-1, 2], dtype='float64')

--- a/test/legacy_test/test_gather_op.py
+++ b/test/legacy_test/test_gather_op.py
@@ -705,7 +705,6 @@ class TestGatherOp5(TestGatherOp):
 
 
 class API_TestGather(unittest.TestCase):
-
     def test_out1(self):
         with base.program_guard(base.Program(), base.Program()):
             data1 = paddle.static.data('data1', shape=[-1, 2], dtype='float64')
@@ -813,7 +812,6 @@ class API_TestDygraphGather(unittest.TestCase):
 
 
 class TestGathertError(unittest.TestCase):
-
     def test_error1(self):
         with paddle.static.program_guard(
             paddle.static.Program(), paddle.static.Program()
@@ -887,7 +885,6 @@ class TestGathertError(unittest.TestCase):
 
 
 class TestCheckOutType(unittest.TestCase):
-
     def test_out_type(self):
         data = paddle.static.data(shape=[16, 10], dtype='int64', name='x')
         index = paddle.static.data(shape=[4], dtype='int64', name='index')

--- a/test/legacy_test/test_gather_tree_op.py
+++ b/test/legacy_test/test_gather_tree_op.py
@@ -55,7 +55,6 @@ class TestGatherTreeOp(OpTest):
 
 
 class TestGatherTreeOpAPI(unittest.TestCase):
-
     def test_case(self):
         paddle.enable_static()
         ids = paddle.static.data(name='ids', shape=[5, 2, 2], dtype='int64')
@@ -78,7 +77,6 @@ class TestGatherTreeOpAPI(unittest.TestCase):
 
 
 class TestGatherTreeOpError(unittest.TestCase):
-
     def test_errors(self):
         paddle.enable_static()
         with program_guard(Program(), Program()):

--- a/test/legacy_test/test_gelu_op.py
+++ b/test/legacy_test/test_gelu_op.py
@@ -202,13 +202,11 @@ class TestGeluOp_ZeroSize(unittest.TestCase):
 
 
 class TestGeluError(unittest.TestCase):
-
     def setUp(self):
         x = np.random.uniform(-1, 1, size=(11, 17)).astype(np.float32)
         self.x = paddle.to_tensor(x)
 
     def test_gelu_op_error(self):
-
         def test_type_error1():
             y = F.gelu(self.x, "tan")
 
@@ -219,7 +217,6 @@ class TestGeluError(unittest.TestCase):
         self.assertRaises(TypeError, test_type_error2)
 
     def test_gelu_class_error(self):
-
         def test_type_error1():
             func = nn.GELU("tan")
             y = func(self.x)

--- a/test/legacy_test/test_graph_send_recv_op.py
+++ b/test/legacy_test/test_graph_send_recv_op.py
@@ -378,7 +378,6 @@ def compute_graph_send_recv_for_min_max(inputs, attributes):
 
 
 class API_GraphSendRecvOpTest(unittest.TestCase):
-
     def test_static(self):
         paddle.enable_static()
         with paddle.static.program_guard(paddle.static.Program()):
@@ -541,7 +540,6 @@ class API_GraphSendRecvOpTest(unittest.TestCase):
 
 
 class API_GeometricSendURecvTest(unittest.TestCase):
-
     def test_static(self):
         paddle.enable_static()
         with paddle.static.program_guard(paddle.static.Program()):

--- a/test/legacy_test/test_grid_sample_function.py
+++ b/test/legacy_test/test_grid_sample_function.py
@@ -140,7 +140,6 @@ def load_tests(loader, standard_tests, pattern):
 
 
 class TestGridSampleAPI(unittest.TestCase):
-
     def test_errors(self):
         with self.assertRaises(ValueError):
             x = paddle.randn([1, 1, 3, 3])

--- a/test/legacy_test/test_i1_op.py
+++ b/test/legacy_test/test_i1_op.py
@@ -46,7 +46,6 @@ class Testi1API(unittest.TestCase):
         self.place = get_places()
 
     def test_api_static(self):
-
         def run(place):
             paddle.enable_static()
             with paddle.static.program_guard(paddle.static.Program()):

--- a/test/legacy_test/test_i1e_op.py
+++ b/test/legacy_test/test_i1e_op.py
@@ -46,7 +46,6 @@ class TestI1e_API(unittest.TestCase):
         self.place = get_places()
 
     def test_api_static(self):
-
         def run(place):
             paddle.enable_static()
             with paddle.static.program_guard(paddle.static.Program()):

--- a/test/legacy_test/test_increment.py
+++ b/test/legacy_test/test_increment.py
@@ -21,7 +21,6 @@ from paddle import base
 
 
 class TestIncrement(unittest.TestCase):
-
     def test_api(self):
         paddle.enable_static()
         with base.program_guard(base.Program(), base.Program()):
@@ -62,7 +61,6 @@ class TestIncrement(unittest.TestCase):
 
 
 class TestInplaceApiWithDataTransform(unittest.TestCase):
-
     def test_increment(self):
         if base.core.is_compiled_with_cuda():
             paddle.enable_static()
@@ -77,7 +75,6 @@ class TestInplaceApiWithDataTransform(unittest.TestCase):
 
 
 class TestIncrement_ZeroSize(unittest.TestCase):
-
     def test_api(self):
         with base.dygraph.guard():
             input = paddle.randn(shape=[0]).astype('int64')

--- a/test/legacy_test/test_incubate_expand_modality_expert_id.py
+++ b/test/legacy_test/test_incubate_expand_modality_expert_id.py
@@ -177,5 +177,4 @@ class Test_expand_modality_expert_id_API(unittest.TestCase):
 
 
 if __name__ == "__main__":
-
     unittest.main()

--- a/test/legacy_test/test_incubate_moe_combine.py
+++ b/test/legacy_test/test_incubate_moe_combine.py
@@ -195,5 +195,4 @@ class TestFused(unittest.TestCase):
 
 
 if __name__ == "__main__":
-
     unittest.main()

--- a/test/legacy_test/test_incubate_moe_gate_dispatch_w_permute.py
+++ b/test/legacy_test/test_incubate_moe_gate_dispatch_w_permute.py
@@ -32,7 +32,6 @@ os.environ["FLAGS_embedding_deterministic"] = "1"
 
 
 class TestFused(unittest.TestCase):
-
     def test_moe_ops(self):
         """
         test `moe-ops` w/ bias
@@ -202,5 +201,4 @@ class TestDispatchPermute(unittest.TestCase):
 
 
 if __name__ == "__main__":
-
     unittest.main()

--- a/test/legacy_test/test_index_fill.py
+++ b/test/legacy_test/test_index_fill.py
@@ -183,7 +183,6 @@ class TestIndexFillAPI_ZeroSize(unittest.TestCase):
 
 
 class TestIndexFillAPI_ZeroSize2(TestIndexFillAPI_ZeroSize):
-
     def init_setting(self):
         self.dtype_np = 'float64'
         self.index_type = 'int64'

--- a/test/legacy_test/test_index_sample_op.py
+++ b/test/legacy_test/test_index_sample_op.py
@@ -167,7 +167,6 @@ class TestIndexSampleOp_ZeroSize(OpTest):
 
 
 class TestIndexSampleOp_ZeroSize2(TestIndexSampleOp_ZeroSize):
-
     def config(self):
         self.x_shape = (0, 20)
         self.x_type = "float64"
@@ -247,7 +246,6 @@ class TestIndexSampleBF16Op(OpTest):
 
 
 class TestIndexSampleShape(unittest.TestCase):
-
     def test_shape(self):
         paddle.enable_static()
         with paddle.static.program_guard(paddle.static.Program()):

--- a/test/legacy_test/test_inference_model_io.py
+++ b/test/legacy_test/test_inference_model_io.py
@@ -25,7 +25,6 @@ paddle.enable_static()
 
 
 class TestLoadInferenceModelError(unittest.TestCase):
-
     def test_load_model_not_exist(self):
         place = core.CPUPlace()
         exe = executor.Executor(place)

--- a/test/legacy_test/test_inner.py
+++ b/test/legacy_test/test_inner.py
@@ -117,7 +117,6 @@ class TestMultiplyApi(unittest.TestCase):
 
 
 class TestMultiplyError(unittest.TestCase):
-
     def test_errors_static_case1(self):
         # test static computation graph: dtype can not be int8
         paddle.enable_static()

--- a/test/legacy_test/test_interp_recompute_scale_factor.py
+++ b/test/legacy_test/test_interp_recompute_scale_factor.py
@@ -241,7 +241,6 @@ def linear_interp_np(
 
 class TestBilinearInterpOpAPI_RecomputeScaleFactor(unittest.TestCase):
     def test_case(self):
-
         if core.is_compiled_with_cuda():
             place = core.CUDAPlace(0)
         else:
@@ -284,7 +283,6 @@ class TestBilinearInterpOpAPI_RecomputeScaleFactor(unittest.TestCase):
 
 class TestBilinearInterpOpAPI_RecomputeScaleFactorList(unittest.TestCase):
     def test_case(self):
-
         if core.is_compiled_with_cuda():
             place = core.CUDAPlace(0)
         else:
@@ -330,7 +328,6 @@ class TestBilinearInterpOpAPI_RecomputeScaleFactorDifferentTensors(
     unittest.TestCase
 ):
     def test_case(self):
-
         if core.is_compiled_with_cuda():
             place = core.CUDAPlace(0)
         else:
@@ -422,7 +419,6 @@ class TestBilinearInterpOpAPI_RecomputeScaleFactorScalarTensor(
 
 class TestNearestInterpOpAPI_RecomputeScaleFactor(unittest.TestCase):
     def test_case(self):
-
         if core.is_compiled_with_cuda():
             place = core.CUDAPlace(0)
         else:
@@ -511,7 +507,6 @@ class TestLinearInterpOpAPI_RecomputeScaleFactor(unittest.TestCase):
 
 class TestInterpRecomputeScaleFactorError(unittest.TestCase):
     def test_size_and_recompute_scale_factor_error(self):
-
         if core.is_compiled_with_cuda():
             place = core.CUDAPlace(0)
         else:

--- a/test/legacy_test/test_is_empty_op.py
+++ b/test/legacy_test/test_is_empty_op.py
@@ -40,7 +40,6 @@ class TestNotEmpty(TestEmpty):
 
 
 class TestIsEmptyOpError(unittest.TestCase):
-
     def test_errors(self):
         paddle.enable_static()
         with paddle.static.program_guard(

--- a/test/legacy_test/test_isclose_op.py
+++ b/test/legacy_test/test_isclose_op.py
@@ -114,7 +114,6 @@ class TestIscloseOpNanTrue(TestIscloseOp):
 
 
 class TestIscloseStatic(unittest.TestCase):
-
     def test_api_case(self):
         paddle.enable_static()
         x_data = np.random.rand(10, 10)
@@ -204,7 +203,6 @@ class TestIscloseError(unittest.TestCase):
 
 
 class TestIscloseOpFp16(unittest.TestCase):
-
     def test_fp16(self):
         if core.is_compiled_with_cuda():
             x_data = np.random.rand(10, 10).astype('float16')
@@ -263,7 +261,6 @@ class TestIscloseOpFloat64(TestIscloseOp):
 
 
 class TestIscloseOpCp64(unittest.TestCase):
-
     def test_cp64(self):
         x_data = (
             np.random.rand(10, 10) + 1.0j * np.random.rand(10, 10)
@@ -285,7 +282,6 @@ class TestIscloseOpCp64(unittest.TestCase):
 
 
 class TestIscloseOpCp128(unittest.TestCase):
-
     def test_cp128(self):
         x_data = (
             np.random.rand(10, 10) + 1.0j * np.random.rand(10, 10)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

* black 迁移到 ruff format
