### PR TITLE
[CodeStyle] `black -> ruff format` migration - part 16

### DIFF
--- a/python/paddle/incubate/fp8/deep_gemm/jit/compiler.py
+++ b/python/paddle/incubate/fp8/deep_gemm/jit/compiler.py
@@ -45,7 +45,7 @@ def get_jit_include_dir() -> str:
 @functools.cache
 def get_deep_gemm_version() -> str:
     # Update include directories
-    include_dir = f"{get_jit_include_dir()+'/../../../../include/paddle/fluid/fp8/deep_gemm/include'}"
+    include_dir = f"{get_jit_include_dir() + '/../../../../include/paddle/fluid/fp8/deep_gemm/include'}"
     assert os.path.exists(
         include_dir
     ), f"Cannot find GEMM include directory {include_dir}"

--- a/python/paddle/incubate/fp8/deep_gemm/jit/compiler.py
+++ b/python/paddle/incubate/fp8/deep_gemm/jit/compiler.py
@@ -45,7 +45,7 @@ def get_jit_include_dir() -> str:
 @functools.cache
 def get_deep_gemm_version() -> str:
     # Update include directories
-    include_dir = f"{get_jit_include_dir() + '/../../../../include/paddle/fluid/fp8/deep_gemm/include'}"
+    include_dir = f"{get_jit_include_dir()}/../../../../include/paddle/fluid/fp8/deep_gemm/include"
     assert os.path.exists(
         include_dir
     ), f"Cannot find GEMM include directory {include_dir}"

--- a/python/paddle/incubate/fp8/deep_gemm/jit/interleave_ffma.py
+++ b/python/paddle/incubate/fp8/deep_gemm/jit/interleave_ffma.py
@@ -104,9 +104,10 @@ def modify_segment(m, name, ffma_lines):
     for i in range(num_lines // 2):
         dst_reg = parse_registers(ffma_lines[i * 2])[-2]
         low_line, high_line = ffma_lines[i * 2], ffma_lines[i * 2 + 1]
-        low_hex, high_hex = extract_hex_from_line(
-            low_line
-        ), extract_hex_from_line(high_line)
+        low_hex, high_hex = (
+            extract_hex_from_line(low_line),
+            extract_hex_from_line(high_line),
+        )
         le_bytes.append(
             low_hex.to_bytes(8, "little") + high_hex.to_bytes(8, "little")
         )

--- a/python/paddle/incubate/fp8/deep_gemm/jit_kernels/gemm.py
+++ b/python/paddle/incubate/fp8/deep_gemm/jit_kernels/gemm.py
@@ -118,9 +118,10 @@ def get_best_configs(
     for block_m in block_ms:
         for block_n in block_ns:
             success = False
-            num_waves, best_num_waves = get_num_waves(
-                block_m, block_n
-            ), get_num_waves(best_block_m, best_block_n)
+            num_waves, best_num_waves = (
+                get_num_waves(block_m, block_n),
+                get_num_waves(best_block_m, best_block_n),
+            )
             if best_block_m is None or best_block_n is None:
                 success = True
             elif num_waves < best_num_waves:

--- a/python/paddle/incubate/nn/layer/fused_transformer.py
+++ b/python/paddle/incubate/nn/layer/fused_transformer.py
@@ -147,10 +147,9 @@ class FusedBiasDropoutResidualLayerNorm(Layer):
         name: str | None = None,
     ) -> None:
         super().__init__()
-        assert embed_dim > 0, (
-            "Expected embed_dim to be greater than 0, "
-            f"but received {embed_dim}"
-        )
+        assert (
+            embed_dim > 0
+        ), f"Expected embed_dim to be greater than 0, but received {embed_dim}"
         self._dtype = self._helper.get_default_dtype()
         self._bias_attr = bias_attr
         self._weight_attr = weight_attr
@@ -338,13 +337,12 @@ class FusedMultiHeadAttention(Layer):
     ) -> None:
         super().__init__()
 
-        assert embed_dim > 0, (
-            "Expected embed_dim to be greater than 0, "
-            f"but received {embed_dim}"
-        )
-        assert num_heads > 0, (
-            "Expected nhead to be greater than 0, " f"but received {num_heads}"
-        )
+        assert (
+            embed_dim > 0
+        ), f"Expected embed_dim to be greater than 0, but received {embed_dim}"
+        assert (
+            num_heads > 0
+        ), f"Expected nhead to be greater than 0, but received {num_heads}"
 
         self.normalize_before = normalize_before
         self._dtype = self._helper.get_default_dtype()
@@ -830,12 +828,12 @@ class FusedTransformerEncoderLayer(Layer):
         self._config.pop("__class__", None)  # py3
 
         super().__init__()
-        assert d_model > 0, (
-            "Expected d_model to be greater than 0, " f"but received {d_model}"
-        )
-        assert nhead > 0, (
-            "Expected nhead to be greater than 0, " f"but received {nhead}"
-        )
+        assert (
+            d_model > 0
+        ), f"Expected d_model to be greater than 0, but received {d_model}"
+        assert (
+            nhead > 0
+        ), f"Expected nhead to be greater than 0, but received {nhead}"
         assert dim_feedforward > 0, (
             "Expected dim_feedforward to be greater than 0, "
             f"but received {dim_feedforward}"
@@ -1306,13 +1304,12 @@ class FusedMultiTransformer(Layer):
     ) -> None:
         super().__init__()
 
-        assert embed_dim > 0, (
-            "Expected embed_dim to be greater than 0, "
-            f"but received {embed_dim}"
-        )
-        assert num_heads > 0, (
-            "Expected nhead to be greater than 0, " f"but received {num_heads}"
-        )
+        assert (
+            embed_dim > 0
+        ), f"Expected embed_dim to be greater than 0, but received {embed_dim}"
+        assert (
+            num_heads > 0
+        ), f"Expected nhead to be greater than 0, but received {num_heads}"
         assert (
             dim_feedforward > 0
         ), f"Expected dim_feedforward to be greater than 0, but received {dim_feedforward}"

--- a/python/paddle/incubate/operators/graph_khop_sampler.py
+++ b/python/paddle/incubate/operators/graph_khop_sampler.py
@@ -130,7 +130,7 @@ def graph_khop_sampler(
         if return_eids:
             if sorted_eids is None:
                 raise ValueError(
-                    "`sorted_eid` should not be None " "if return_eids is True."
+                    "`sorted_eid` should not be None if return_eids is True."
                 )
             (
                 edge_src,
@@ -171,7 +171,7 @@ def graph_khop_sampler(
     if return_eids:
         if sorted_eids is None:
             raise ValueError(
-                "`sorted_eid` should not be None " "if return_eids is True."
+                "`sorted_eid` should not be None if return_eids is True."
             )
         check_variable_and_dtype(
             sorted_eids, "Eids", ("int32", "int64"), "graph_khop_sampler"

--- a/python/paddle/incubate/operators/graph_sample_neighbors.py
+++ b/python/paddle/incubate/operators/graph_sample_neighbors.py
@@ -157,8 +157,7 @@ def graph_sample_neighbors(
     if flag_perm_buffer:
         if perm_buffer is None:
             raise ValueError(
-                "`perm_buffer` should not be None if `flag_perm_buffer`"
-                "is True."
+                "`perm_buffer` should not be None if `flag_perm_buffer` is True."
             )
 
     if in_dynamic_or_pir_mode():

--- a/python/paddle/incubate/optimizer/pipeline.py
+++ b/python/paddle/incubate/optimizer/pipeline.py
@@ -481,10 +481,9 @@ class PipelineOptimizer:
             else None
         )
         if device:
-            assert device[0:3] == 'gpu', (
-                "Now, only gpu devices are "
-                "supported in pipeline parallelism."
-            )
+            assert (
+                device[0:3] == 'gpu'
+            ), "Now, only gpu devices are supported in pipeline parallelism."
         return device
 
     def _add_op_device_attr_for_op(self, op, idx, block):
@@ -669,17 +668,16 @@ class PipelineOptimizer:
             ), f"op ({op.type}) has no {self._op_device_key} attribute."
 
             device = op.attr(self._op_device_key)
-            assert device, (
-                "op_device attribute for op " f"{op.type} has not been set."
-            )
+            assert (
+                device
+            ), f"op_device attribute for op {op.type} has not been set."
             if device == f"{self._device}:all":
                 continue
 
             dev_type = device.split(':')[0]
-            assert dev_type == "gpu", (
-                "Now only gpu devices are supported "
-                "for pipeline parallelism."
-            )
+            assert (
+                dev_type == "gpu"
+            ), "Now only gpu devices are supported for pipeline parallelism."
 
             if device not in device_list:
                 device_list.append(device)

--- a/python/paddle/io/dataloader/dataloader_iter.py
+++ b/python/paddle/io/dataloader/dataloader_iter.py
@@ -376,10 +376,9 @@ class _DataLoaderIterMultiProcess(_DataLoaderIterBase):
         self._persistent_workers = loader._persistent_workers
         self._resume_worker_cnt = 0
 
-        assert self._num_workers > 0, (
-            "Multi-process DataLoader "
-            f"invalid num_workers({self._num_workers})"
-        )
+        assert (
+            self._num_workers > 0
+        ), f"Multi-process DataLoader invalid num_workers({self._num_workers})"
 
         # subprocess wrokers' result queue
         self._data_queue = None

--- a/python/paddle/io/dataloader/dataset.py
+++ b/python/paddle/io/dataloader/dataset.py
@@ -87,14 +87,16 @@ class Dataset(Generic[_T]):
 
     def __getitem__(self, idx: int) -> _T:
         raise NotImplementedError(
-            "'{}' not implement in class "
-            "{}".format('__getitem__', self.__class__.__name__)
+            "'{}' not implement in class {}".format(
+                '__getitem__', self.__class__.__name__
+            )
         )
 
     def __len__(self) -> int:
         raise NotImplementedError(
-            "'{}' not implement in class "
-            "{}".format('__len__', self.__class__.__name__)
+            "'{}' not implement in class {}".format(
+                '__len__', self.__class__.__name__
+            )
         )
 
     if TYPE_CHECKING:
@@ -268,20 +270,23 @@ class IterableDataset(Dataset[_T]):
 
     def __iter__(self) -> Iterator[_T]:
         raise NotImplementedError(
-            "'{}' not implement in class "
-            "{}".format('__iter__', self.__class__.__name__)
+            "'{}' not implement in class {}".format(
+                '__iter__', self.__class__.__name__
+            )
         )
 
     def __getitem__(self, idx: int) -> Never:
         raise RuntimeError(
-            "'{}' should not be called for IterableDataset"
-            "{}".format('__getitem__', self.__class__.__name__)
+            "'{}' should not be called for IterableDataset{}".format(
+                '__getitem__', self.__class__.__name__
+            )
         )
 
     def __len__(self) -> Never:
         raise RuntimeError(
-            "'{}' should not be called for IterableDataset"
-            "{}".format('__len__', self.__class__.__name__)
+            "'{}' should not be called for IterableDataset{}".format(
+                '__len__', self.__class__.__name__
+            )
         )
 
 

--- a/python/paddle/jit/dy2static/error.py
+++ b/python/paddle/jit/dy2static/error.py
@@ -211,7 +211,7 @@ class ErrorData:
         func_str = None
         for frame in tb:
             searched_name = re.search(
-                fr'({RE_PYMODULE})*{frame.name}',
+                rf'({RE_PYMODULE})*{frame.name}',
                 error_line,
             )
             if searched_name:

--- a/python/paddle/jit/dy2static/pir_partial_program.py
+++ b/python/paddle/jit/dy2static/pir_partial_program.py
@@ -315,10 +315,13 @@ class RunnableProgram:
         ), "Please ensure only split once! don't call split_forward_backward manually."
         self.has_splited = True
         self.update_op_range()
-        [
-            fwd_prog,
-            bwd_prog,
-        ], prog_attr = paddle.base.libpaddle.pir.split_program(
+        (
+            [
+                fwd_prog,
+                bwd_prog,
+            ],
+            prog_attr,
+        ) = paddle.base.libpaddle.pir.split_program(
             self.program,
             self.x_values,
             self.param_values,
@@ -622,7 +625,10 @@ class ValuePreservePass:
         )
         names = paddle.utils.map_structure(
             lambda value: ValuePreservePass.attach_preserved_name(
-                value, program, value2name, name_generator  # noqa: F821
+                value,
+                program,
+                value2name,  # noqa: F821
+                name_generator,
             ),
             self.values,
         )

--- a/python/paddle/jit/dy2static/transformers/decorator_transformer.py
+++ b/python/paddle/jit/dy2static/transformers/decorator_transformer.py
@@ -78,7 +78,7 @@ class DecoratorTransformer(BaseTransformer):
                 # match case like:
                 # @a.d.g.deco
                 re_tmp = re.match(
-                    fr'({RE_PYMODULE})*({RE_PYNAME})$',
+                    rf'({RE_PYMODULE})*({RE_PYNAME})$',
                     deco_full_name,
                 )
                 deco_name = re_tmp.group(2)

--- a/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
@@ -523,11 +523,14 @@ class FunctionGraph:
         from ..breakpoint import BreakpointManager
 
         BreakpointManager().on_event("compile_function")
-        graph_fn, (
-            statement_ir,
-            symbolic_inputs,
-            _,
-            symbolic_outputs,
+        (
+            graph_fn,
+            (
+                statement_ir,
+                symbolic_inputs,
+                _,
+                symbolic_outputs,
+            ),
         ) = compile_graph_result
         compiled_fn_name = f"___graph_fn_{statement_ir.name}"
         # prepare function and inputs

--- a/python/paddle/nn/functional/common.py
+++ b/python/paddle/nn/functional/common.py
@@ -657,7 +657,7 @@ def interpolate(
             if len(x.shape) == 5:
                 if len(out_shape) != 3:
                     raise ValueError(
-                        "size length should be 3 for " "input 5-D tensor."
+                        "size length should be 3 for input 5-D tensor."
                     )
                 if contain_var:
                     attrs['out_d'] = size_list[0]

--- a/python/paddle/nn/functional/conv.py
+++ b/python/paddle/nn/functional/conv.py
@@ -963,8 +963,7 @@ def conv1d_transpose(
     else:
         if output_padding != 0:
             raise ValueError(
-                'output_padding option is mutually exclusive with '
-                'output_size'
+                'output_padding option is mutually exclusive with output_size'
             )
         if isinstance(output_size, (list, tuple, int)):
             output_size = [*convert_to_list(output_size, 1, 'output_size'), 1]
@@ -1236,8 +1235,7 @@ def conv2d_transpose(
     else:
         if output_padding != 0:
             raise ValueError(
-                'output_padding option is mutually exclusive with '
-                'output_size'
+                'output_padding option is mutually exclusive with output_size'
             )
         if isinstance(output_size, (list, tuple)):
             if _contain_var(output_size):
@@ -1710,8 +1708,7 @@ def conv3d_transpose(
     else:
         if output_padding != 0:
             raise ValueError(
-                'output_padding option is mutually exclusive with '
-                'output_size'
+                'output_padding option is mutually exclusive with output_size'
             )
         if isinstance(output_size, (list, tuple, int)):
             output_size = convert_to_list(output_size, 3, 'output_size')

--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -3917,9 +3917,7 @@ def triplet_margin_with_distance_loss(
 
     if not (input.shape == positive.shape == negative.shape):
         raise ValueError(
-            "input's shape must equal to "
-            "positive's shape and  "
-            "negative's shape"
+            "input's shape must equal to positive's shape and negative's shape"
         )
 
     distance_function = (
@@ -4064,9 +4062,7 @@ def triplet_margin_loss(
 
     if not (input.shape == positive.shape == negative.shape):
         raise ValueError(
-            "input's shape must equal to "
-            "positive's shape and  "
-            "negative's shape"
+            "input's shape must equal to positive's shape and negative's shape"
         )
 
     distance_function = paddle.nn.PairwiseDistance(p, epsilon=epsilon)
@@ -4420,7 +4416,7 @@ def soft_margin_loss(
         )
 
     if not (input.shape == label.shape):
-        raise ValueError("input's shape must equal to " "label's shape")
+        raise ValueError("input's shape must equal to label's shape")
 
     label = paddle.cast(label, input.dtype)
     out = paddle.log(1 + paddle.exp(-label * input))
@@ -4678,7 +4674,7 @@ def adaptive_log_softmax_with_loss(
             )
     else:
         raise ValueError(
-            '0D or 1D label tensor expected, ' 'multi-label not supported'
+            '0D or 1D label tensor expected, multi-label not supported'
         )
 
     is_batched = target_dim > 0

--- a/python/paddle/nn/layer/transformer.py
+++ b/python/paddle/nn/layer/transformer.py
@@ -197,14 +197,12 @@ class MultiHeadAttention(Layer):
     ) -> None:
         super().__init__()
 
-        assert embed_dim > 0, (
-            "Expected embed_dim to be greater than 0, "
-            f"but received {embed_dim}"
-        )
-        assert num_heads > 0, (
-            "Expected num_heads to be greater than 0, "
-            f"but received {num_heads}"
-        )
+        assert (
+            embed_dim > 0
+        ), f"Expected embed_dim to be greater than 0, but received {embed_dim}"
+        assert (
+            num_heads > 0
+        ), f"Expected num_heads to be greater than 0, but received {num_heads}"
 
         self.embed_dim = embed_dim
         self.kdim = kdim if kdim is not None else embed_dim
@@ -648,12 +646,12 @@ class TransformerEncoderLayer(Layer):
 
         super().__init__()
 
-        assert d_model > 0, (
-            "Expected d_model to be greater than 0, " f"but received {d_model}"
-        )
-        assert nhead > 0, (
-            "Expected nhead to be greater than 0, " f"but received {nhead}"
-        )
+        assert (
+            d_model > 0
+        ), f"Expected d_model to be greater than 0, but received {d_model}"
+        assert (
+            nhead > 0
+        ), f"Expected nhead to be greater than 0, but received {nhead}"
         assert dim_feedforward > 0, (
             "Expected dim_feedforward to be greater than 0, "
             f"but received {dim_feedforward}"
@@ -1019,12 +1017,12 @@ class TransformerDecoderLayer(Layer):
 
         super().__init__()
 
-        assert d_model > 0, (
-            "Expected d_model to be greater than 0, " f"but received {d_model}"
-        )
-        assert nhead > 0, (
-            "Expected nhead to be greater than 0, " f"but received {nhead}"
-        )
+        assert (
+            d_model > 0
+        ), f"Expected d_model to be greater than 0, but received {d_model}"
+        assert (
+            nhead > 0
+        ), f"Expected nhead to be greater than 0, but received {nhead}"
         assert dim_feedforward > 0, (
             "Expected dim_feedforward to be greater than 0, "
             f"but received {dim_feedforward}"
@@ -1549,12 +1547,12 @@ class Transformer(Layer):
     ) -> None:
         super().__init__()
 
-        assert d_model > 0, (
-            "Expected d_model to be greater than 0, " f"but received {d_model}"
-        )
-        assert nhead > 0, (
-            "Expected nhead to be greater than 0, " f"but received {nhead}"
-        )
+        assert (
+            d_model > 0
+        ), f"Expected d_model to be greater than 0, but received {d_model}"
+        assert (
+            nhead > 0
+        ), f"Expected nhead to be greater than 0, but received {nhead}"
         assert dim_feedforward > 0, (
             "Expected dim_feedforward to be greater than 0, "
             f"but received {dim_feedforward}"

--- a/python/paddle/static/amp/bf16/amp_lists.py
+++ b/python/paddle/static/amp/bf16/amp_lists.py
@@ -68,7 +68,7 @@ class AutoMixedPrecisionListsBF16:
             for op_name in self._custom_bf16_list:
                 if op_name in self._custom_fp32_list:
                     raise ValueError(
-                        "Custom bf16 list overlap " "custom fp32 list"
+                        "Custom bf16 list overlap custom fp32 list"
                     )
         if self._custom_bf16_list:
             for op_name in self._custom_bf16_list:

--- a/python/paddle/static/nn/common.py
+++ b/python/paddle/static/nn/common.py
@@ -725,7 +725,7 @@ def conv2d(
     )
     if len(input.shape) != 4:
         raise ValueError(
-            "Input size should be 4, " f"but received {len(input.shape)}"
+            f"Input size should be 4, but received {len(input.shape)}"
         )
     num_channels = input.shape[1]
     if not isinstance(use_cudnn, bool):
@@ -1367,7 +1367,7 @@ def conv2d_transpose(
     ), "param_attr should not be False in conv2d_transpose."
     if len(input.shape) != 4:
         raise ValueError(
-            "Input size should be 4, " f"but received {len(input.shape)}"
+            f"Input size should be 4, but received {len(input.shape)}"
         )
 
     if num_filters == 0:

--- a/python/paddle/static/nn/control_flow.py
+++ b/python/paddle/static/nn/control_flow.py
@@ -1159,7 +1159,7 @@ def case(pred_fn_pairs, default=None, name=None):
 
             if not callable(fn):
                 raise TypeError(
-                    "The fn of pred_fn_pairs in Op(case) must" " be callable."
+                    "The fn of pred_fn_pairs in Op(case) must be callable."
                 )
 
         if default is None:
@@ -1891,9 +1891,10 @@ def cond(pred, true_fn=None, false_fn=None, name=None, return_names=None):
         )
 
     if in_pir_mode():
-        flattened_true_output, flattened_false_output = flatten(
-            true_output
-        ), flatten(false_output)
+        flattened_true_output, flattened_false_output = (
+            flatten(true_output),
+            flatten(false_output),
+        )
         flattened_return_names = [
             name
             for seq_out, name in zip(
@@ -2110,8 +2111,9 @@ def select_input_with_buildin_type(inputs, mask, name):
         isinstance(true_var, UndefinedVar)
         and isinstance(false_var, (Variable, *support_ret_buildin_type))
     ):
-        true_var, false_var = to_static_variable(true_var), to_static_variable(
-            false_var
+        true_var, false_var = (
+            to_static_variable(true_var),
+            to_static_variable(false_var),
         )
         inputs = [false_var, true_var]
     else:

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -1854,14 +1854,13 @@ def arange(
         with device_guard("cpu"):
             if not np.isfinite(start):
                 raise ValueError(
-                    "The value of start must be finite, but received: "
-                    f"{start}."
+                    f"The value of start must be finite, but received: {start}."
                 )
             start = fill_constant([1], dtype, start, force_cpu=True)
     elif start.dtype != dtype:
         if in_dynamic_mode() and not paddle.isfinite(start):
             raise ValueError(
-                "The value of start must be finite, but received: " f"{start}."
+                f"The value of start must be finite, but received: {start}."
             )
         start = paddle.cast(start, dtype)
 
@@ -1869,13 +1868,13 @@ def arange(
         with device_guard("cpu"):
             if not np.isfinite(end):
                 raise ValueError(
-                    "The value of end must be finite, but received: " f"{end}."
+                    f"The value of end must be finite, but received: {end}."
                 )
             end = fill_constant([1], dtype, end, force_cpu=True)
     elif end.dtype != dtype:
         if in_dynamic_mode() and not paddle.isfinite(end):
             raise ValueError(
-                "The value of end must be finite, but received: " f"{end}."
+                f"The value of end must be finite, but received: {end}."
             )
         end = paddle.cast(end, dtype)
 

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -5050,9 +5050,9 @@ def cdist(
         f"But received Input x's last dimension is {x_shape[-1]}, "
         f"Input y's last dimension is {y_shape[-1]}.\n"
     )
-    assert p >= 0, (
-        "The p must be greater than or equal to 0, " f"But received p is {p}.\n"
-    )
+    assert (
+        p >= 0
+    ), f"The p must be greater than or equal to 0, But received p is {p}.\n"
 
     r1 = x.shape[-2]
     r2 = y.shape[-2]

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -5587,9 +5587,9 @@ def multigammaln(x: Tensor, p: int, name: str | None = None) -> Tensor:
                 [0.85704780  , 2.46648574  , 3.56509781  , 11.02241898 , 15.84497833 ,
                     26.09257698 , 170.68318176])
     """
-    assert p >= 1, (
-        "The p must be greater than or equal to 1, " f"But received p is {p}.\n"
-    )
+    assert (
+        p >= 1
+    ), f"The p must be greater than or equal to 1, But received p is {p}.\n"
     c = 0.25 * p * (p - 1) * math.log(math.pi)
     b = 0.5 * paddle.arange(start=(1 - p), end=1, step=1, dtype=x.dtype)
     return paddle.sum(paddle.lgamma(x.unsqueeze(-1) + b), axis=-1) + c
@@ -5601,9 +5601,9 @@ def multigammaln_(x: Tensor, p: int, name: str | None = None) -> Tensor:
     Inplace version of ``multigammaln_`` API, the output Tensor will be inplaced with input ``x``.
     Please refer to :ref:`api_paddle_multigammaln`.
     """
-    assert p >= 1, (
-        "The p must be greater than or equal to 1, " f"But received p is {p}.\n"
-    )
+    assert (
+        p >= 1
+    ), f"The p must be greater than or equal to 1, But received p is {p}.\n"
     c = 0.25 * p * (p - 1) * math.log(math.pi)
     c = paddle.to_tensor(c, dtype=x.dtype)
     b = 0.5 * paddle.arange(start=(1 - p), end=1, step=1, dtype=x.dtype)
@@ -7946,7 +7946,6 @@ def __rshift__(
     y: Tensor | int,
     is_arithmetic: bool = True,
 ) -> Tensor:
-
     if isinstance(y, int):
         y = paddle.to_tensor(y, dtype=x.dtype)
     elif isinstance(y, float):

--- a/python/paddle/text/datasets/imdb.py
+++ b/python/paddle/text/datasets/imdb.py
@@ -160,8 +160,8 @@ class Imdb(Dataset):
         return data
 
     def _load_anno(self) -> None:
-        pos_pattern = re.compile(fr"aclImdb/{self.mode}/pos/.*\.txt$")
-        neg_pattern = re.compile(fr"aclImdb/{self.mode}/neg/.*\.txt$")
+        pos_pattern = re.compile(rf"aclImdb/{self.mode}/pos/.*\.txt$")
+        neg_pattern = re.compile(rf"aclImdb/{self.mode}/neg/.*\.txt$")
 
         UNK = self.word_idx['<unk>']
 

--- a/python/paddle/text/datasets/wmt14.py
+++ b/python/paddle/text/datasets/wmt14.py
@@ -28,8 +28,7 @@ if TYPE_CHECKING:
 __all__ = []
 
 URL_DEV_TEST = (
-    'http://www-lium.univ-lemans.fr/~schwenk/'
-    'cslm_joint_paper/data/dev+test.tgz'
+    'http://www-lium.univ-lemans.fr/~schwenk/cslm_joint_paper/data/dev+test.tgz'
 )
 MD5_DEV_TEST = '7d7897317ddd8ba0ae5c5fa7248d3ff5'
 # this is a small set of data for test. The original data is too large and

--- a/python/paddle/utils/download.py
+++ b/python/paddle/utils/download.py
@@ -230,7 +230,7 @@ def _download(url, path, md5sum=None, method='get'):
             retry_cnt += 1
         else:
             raise RuntimeError(
-                f"Download from {url} failed. " "Retry limit reached"
+                f"Download from {url} failed. Retry limit reached"
             )
 
         if not _download_methods[method](url, fullname):

--- a/python/paddle/utils/image_util.py
+++ b/python/paddle/utils/image_util.py
@@ -27,8 +27,9 @@ def resize_image(img, target_size):
     target_size: the target resized image size.
     """
     percent = target_size / float(min(img.size[0], img.size[1]))
-    resized_size = int(round(img.size[0] * percent)), int(
-        round(img.size[1] * percent)
+    resized_size = (
+        int(round(img.size[0] * percent)),
+        int(round(img.size[1] * percent)),
     )
     img = img.resize(resized_size, Image.ANTIALIAS)
     return img
@@ -58,8 +59,9 @@ def crop_img(im, inner_size, color=True, test=True):
       If True, crop the center of images.
     """
     if color:
-        height, width = max(inner_size, im.shape[1]), max(
-            inner_size, im.shape[2]
+        height, width = (
+            max(inner_size, im.shape[1]),
+            max(inner_size, im.shape[2]),
         )
         padded_im = np.zeros((3, height, width))
         startY = (height - im.shape[1]) / 2
@@ -68,8 +70,9 @@ def crop_img(im, inner_size, color=True, test=True):
         padded_im[:, startY:endY, startX:endX] = im
     else:
         im = im.astype('float32')
-        height, width = max(inner_size, im.shape[0]), max(
-            inner_size, im.shape[1]
+        height, width = (
+            max(inner_size, im.shape[0]),
+            max(inner_size, im.shape[1]),
         )
         padded_im = np.zeros((height, width))
         startY = (height - im.shape[0]) / 2

--- a/test/collective/collective_alltoall_api.py
+++ b/test/collective/collective_alltoall_api.py
@@ -51,7 +51,7 @@ def alltoall_new(
     if isinstance(out_tensor_or_tensor_list, list):
         if len(out_tensor_or_tensor_list) != 0:
             raise ValueError(
-                "The 'out_tensor_list' for all_to_all " "must be an empty list."
+                "The 'out_tensor_list' for all_to_all must be an empty list."
             )
         out_tensor = helper.create_variable_for_type_inference(
             dtype=in_tensor.dtype

--- a/test/deprecated/ir/inference/test_trt_convert_conv2d_deprecated.py
+++ b/test/deprecated/ir/inference/test_trt_convert_conv2d_deprecated.py
@@ -173,37 +173,49 @@ class TrtConvertConv2dTest(TrtLayerAutoScanTest):
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         program_config.set_input_type(np.float32)
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False
-        ), 1e-5
+        yield (
+            self.create_inference_config(),
+            generate_trt_nodes_num(attrs, False),
+            1e-5,
+        )
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         program_config.set_input_type(np.float16)
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False
-        ), (1e-3, 1e-3)
+        yield (
+            self.create_inference_config(),
+            generate_trt_nodes_num(attrs, False),
+            (1e-3, 1e-3),
+        )
         self.trt_param.precision = paddle_infer.PrecisionType.Int8
         program_config.set_input_type(np.float32)
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False
-        ), (1e-2, 1e-2)
+        yield (
+            self.create_inference_config(),
+            generate_trt_nodes_num(attrs, False),
+            (1e-2, 1e-2),
+        )
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         program_config.set_input_type(np.float32)
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True
-        ), 1e-5
+        yield (
+            self.create_inference_config(),
+            generate_trt_nodes_num(attrs, True),
+            1e-5,
+        )
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         program_config.set_input_type(np.float16)
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True
-        ), (1e-3, 1e-3)
+        yield (
+            self.create_inference_config(),
+            generate_trt_nodes_num(attrs, True),
+            (1e-3, 1e-3),
+        )
         self.trt_param.precision = paddle_infer.PrecisionType.Int8
         program_config.set_input_type(np.float32)
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True
-        ), (1e-2, 1e-2)
+        yield (
+            self.create_inference_config(),
+            generate_trt_nodes_num(attrs, True),
+            (1e-2, 1e-2),
+        )
 
     def test(self):
         self.run_test()
@@ -364,15 +376,19 @@ class TrtConvertConv2dNotPersistableTest(TrtLayerAutoScanTest):
         self.generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         program_config.set_input_type(np.float32)
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True
-        ), (1e-2, 1e-2)
+        yield (
+            self.create_inference_config(),
+            generate_trt_nodes_num(attrs, True),
+            (1e-2, 1e-2),
+        )
 
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         program_config.set_input_type(np.float16)
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True
-        ), (1e-2, 1e-2)
+        yield (
+            self.create_inference_config(),
+            generate_trt_nodes_num(attrs, True),
+            (1e-2, 1e-2),
+        )
 
     def test(self):
         self.run_test(run_pir=True)

--- a/test/deprecated/ir/inference/test_trt_convert_conv2d_transpose_deprecated.py
+++ b/test/deprecated/ir/inference/test_trt_convert_conv2d_transpose_deprecated.py
@@ -196,14 +196,18 @@ class TrtConvertConv2dTransposeTest(TrtLayerAutoScanTest):
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         program_config.set_input_type(np.float32)
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False
-        ), 1e-5
+        yield (
+            self.create_inference_config(),
+            generate_trt_nodes_num(attrs, False),
+            1e-5,
+        )
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         program_config.set_input_type(np.float16)
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False
-        ), (1e-3, 1e-3)
+        yield (
+            self.create_inference_config(),
+            generate_trt_nodes_num(attrs, False),
+            (1e-3, 1e-3),
+        )
         # self.trt_param.precision = paddle_infer.PrecisionType.Int8
         # yield self.create_inference_config(), generate_trt_nodes_num(
         #     attrs, False), (1e-5, 1e-5)
@@ -212,14 +216,18 @@ class TrtConvertConv2dTransposeTest(TrtLayerAutoScanTest):
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         program_config.set_input_type(np.float32)
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True
-        ), 1e-5
+        yield (
+            self.create_inference_config(),
+            generate_trt_nodes_num(attrs, True),
+            1e-5,
+        )
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         program_config.set_input_type(np.float16)
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True
-        ), (1e-3, 1e-3)
+        yield (
+            self.create_inference_config(),
+            generate_trt_nodes_num(attrs, True),
+            (1e-3, 1e-3),
+        )
         # self.trt_param.precision = paddle_infer.PrecisionType.Int8
         # yield self.create_inference_config(), generate_trt_nodes_num(
         #     attrs, True), (1e-5, 1e-5)
@@ -344,27 +352,35 @@ class TrtConvertConv2dTransposeTest2(TrtLayerAutoScanTest):
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         program_config.set_input_type(np.float32)
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False
-        ), 1e-4
+        yield (
+            self.create_inference_config(),
+            generate_trt_nodes_num(attrs, False),
+            1e-4,
+        )
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         program_config.set_input_type(np.float16)
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False
-        ), (1e0, 1e-3)
+        yield (
+            self.create_inference_config(),
+            generate_trt_nodes_num(attrs, False),
+            (1e0, 1e-3),
+        )
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         program_config.set_input_type(np.float32)
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True
-        ), 1e-4
+        yield (
+            self.create_inference_config(),
+            generate_trt_nodes_num(attrs, True),
+            1e-4,
+        )
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         program_config.set_input_type(np.float16)
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True
-        ), (1e0, 1e-3)
+        yield (
+            self.create_inference_config(),
+            generate_trt_nodes_num(attrs, True),
+            (1e0, 1e-3),
+        )
 
     def add_skip_trt_case(self):
         pass

--- a/test/deprecated/ir/inference/test_trt_convert_conv3d_transpose_deprecated.py
+++ b/test/deprecated/ir/inference/test_trt_convert_conv3d_transpose_deprecated.py
@@ -121,17 +121,21 @@ class TrtConvertConv3dTransposeTest(TrtLayerAutoScanTest):
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         program_config.set_input_type(np.float32)
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False
-        ), 1e-3
+        yield (
+            self.create_inference_config(),
+            generate_trt_nodes_num(attrs, False),
+            1e-3,
+        )
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         program_config.set_input_type(np.float32)
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True
-        ), 1e-3
+        yield (
+            self.create_inference_config(),
+            generate_trt_nodes_num(attrs, True),
+            1e-3,
+        )
 
     def add_skip_trt_case(self):
         pass

--- a/test/deprecated/ir/inference/test_trt_convert_depthwise_conv2d_deprecated.py
+++ b/test/deprecated/ir/inference/test_trt_convert_depthwise_conv2d_deprecated.py
@@ -157,15 +157,23 @@ class TrtConvertDepthwiseConv2dTest(TrtLayerAutoScanTest):
         yield self.create_inference_config(), generate_trt_nodes_num(), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         program_config.set_input_type(np.float16)
-        yield self.create_inference_config(), generate_trt_nodes_num(), (
-            5e-3,
-            1e-3,
+        yield (
+            self.create_inference_config(),
+            generate_trt_nodes_num(),
+            (
+                5e-3,
+                1e-3,
+            ),
         )
         self.trt_param.precision = paddle_infer.PrecisionType.Int8
         program_config.set_input_type(np.float32)
-        yield self.create_inference_config(), generate_trt_nodes_num(), (
-            1e-3,
-            1e-3,
+        yield (
+            self.create_inference_config(),
+            generate_trt_nodes_num(),
+            (
+                1e-3,
+                1e-3,
+            ),
         )
 
         # for dynamic_shape
@@ -175,15 +183,23 @@ class TrtConvertDepthwiseConv2dTest(TrtLayerAutoScanTest):
         yield self.create_inference_config(), generate_trt_nodes_num(), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         program_config.set_input_type(np.float16)
-        yield self.create_inference_config(), generate_trt_nodes_num(), (
-            5e-3,
-            1e-3,
+        yield (
+            self.create_inference_config(),
+            generate_trt_nodes_num(),
+            (
+                5e-3,
+                1e-3,
+            ),
         )
         self.trt_param.precision = paddle_infer.PrecisionType.Int8
         program_config.set_input_type(np.float32)
-        yield self.create_inference_config(), generate_trt_nodes_num(), (
-            5e-3,
-            5e-3,
+        yield (
+            self.create_inference_config(),
+            generate_trt_nodes_num(),
+            (
+                5e-3,
+                5e-3,
+            ),
         )
 
     def add_skip_trt_case(self):

--- a/test/deprecated/ir/inference/test_trt_convert_depthwise_conv2d_transpose_deprecated.py
+++ b/test/deprecated/ir/inference/test_trt_convert_depthwise_conv2d_transpose_deprecated.py
@@ -166,14 +166,18 @@ class TrtConvertDepthwiseConv2dTransposeTest(TrtLayerAutoScanTest):
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         program_config.set_input_type(np.float32)
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False
-        ), 1e-5
+        yield (
+            self.create_inference_config(),
+            generate_trt_nodes_num(attrs, False),
+            1e-5,
+        )
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         program_config.set_input_type(np.float16)
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False
-        ), (1e-3, 1e-3)
+        yield (
+            self.create_inference_config(),
+            generate_trt_nodes_num(attrs, False),
+            (1e-3, 1e-3),
+        )
         # self.trt_param.precision = paddle_infer.PrecisionType.Int8
         # yield self.create_inference_config(), generate_trt_nodes_num(
         #     attrs, False), (1e-5, 1e-5)
@@ -182,14 +186,18 @@ class TrtConvertDepthwiseConv2dTransposeTest(TrtLayerAutoScanTest):
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         program_config.set_input_type(np.float32)
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True
-        ), 1e-5
+        yield (
+            self.create_inference_config(),
+            generate_trt_nodes_num(attrs, True),
+            1e-5,
+        )
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         program_config.set_input_type(np.float16)
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True
-        ), (1e-3, 1e-3)
+        yield (
+            self.create_inference_config(),
+            generate_trt_nodes_num(attrs, True),
+            (1e-3, 1e-3),
+        )
         # self.trt_param.precision = paddle_infer.PrecisionType.Int8
         # yield self.create_inference_config(), generate_trt_nodes_num(
         #     attrs, True), (1e-5, 1e-5)

--- a/test/deprecated/ir/inference/test_trt_convert_pad3d_deprecated.py
+++ b/test/deprecated/ir/inference/test_trt_convert_pad3d_deprecated.py
@@ -123,27 +123,35 @@ class TrtConvertPad3dTensorPadding(TrtLayerAutoScanTest):
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         program_config.set_input_type(np.float32)
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False
-        ), 1e-5
+        yield (
+            self.create_inference_config(),
+            generate_trt_nodes_num(attrs, False),
+            1e-5,
+        )
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         program_config.set_input_type(np.float16)
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False
-        ), 1e-3
+        yield (
+            self.create_inference_config(),
+            generate_trt_nodes_num(attrs, False),
+            1e-3,
+        )
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         program_config.set_input_type(np.float32)
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True
-        ), 1e-5
+        yield (
+            self.create_inference_config(),
+            generate_trt_nodes_num(attrs, True),
+            1e-5,
+        )
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         program_config.set_input_type(np.float16)
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True
-        ), 1e-3
+        yield (
+            self.create_inference_config(),
+            generate_trt_nodes_num(attrs, True),
+            1e-3,
+        )
 
     def test(self):
         self.run_test()
@@ -237,27 +245,35 @@ class TrtConvertPad3dListPadding(TrtLayerAutoScanTest):
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         program_config.set_input_type(np.float32)
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False
-        ), 1e-5
+        yield (
+            self.create_inference_config(),
+            generate_trt_nodes_num(attrs, False),
+            1e-5,
+        )
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         program_config.set_input_type(np.float16)
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False
-        ), (1e-3, 1e-3)
+        yield (
+            self.create_inference_config(),
+            generate_trt_nodes_num(attrs, False),
+            (1e-3, 1e-3),
+        )
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         program_config.set_input_type(np.float32)
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True
-        ), 1e-5
+        yield (
+            self.create_inference_config(),
+            generate_trt_nodes_num(attrs, True),
+            1e-5,
+        )
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         program_config.set_input_type(np.float16)
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True
-        ), (1e-3, 1e-3)
+        yield (
+            self.create_inference_config(),
+            generate_trt_nodes_num(attrs, True),
+            (1e-3, 1e-3),
+        )
 
     def test(self):
         self.run_test()

--- a/test/deprecated/ir/inference/test_trt_convert_temporal_shift_deprecated.py
+++ b/test/deprecated/ir/inference/test_trt_convert_temporal_shift_deprecated.py
@@ -110,27 +110,35 @@ class TrtConvertTemporalShiftTest(TrtLayerAutoScanTest):
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         program_config.set_input_type(np.float32)
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False
-        ), 1e-5
+        yield (
+            self.create_inference_config(),
+            generate_trt_nodes_num(attrs, False),
+            1e-5,
+        )
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         program_config.set_input_type(np.float16)
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False
-        ), 1e-3
+        yield (
+            self.create_inference_config(),
+            generate_trt_nodes_num(attrs, False),
+            1e-3,
+        )
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         program_config.set_input_type(np.float32)
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True
-        ), 1e-5
+        yield (
+            self.create_inference_config(),
+            generate_trt_nodes_num(attrs, True),
+            1e-5,
+        )
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         program_config.set_input_type(np.float16)
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True
-        ), 1e-3
+        yield (
+            self.create_inference_config(),
+            generate_trt_nodes_num(attrs, True),
+            1e-3,
+        )
 
     def test(self):
         self.run_test()

--- a/test/deprecated/legacy_test/test_add_reader_dependency_deprecated.py
+++ b/test/deprecated/legacy_test/test_add_reader_dependency_deprecated.py
@@ -65,9 +65,11 @@ class TestAddReaderDependency(unittest.TestCase):
             def data_source():
                 for _ in range(self.batch_num):
                     time.sleep(self.sleep_time)  # sleep some times
-                    yield np.random.uniform(low=-1, high=1, size=[1]).astype(
-                        'float32'
-                    ),
+                    yield (
+                        np.random.uniform(low=-1, high=1, size=[1]).astype(
+                            'float32'
+                        ),
+                    )
 
             persistable_in = paddle.static.data(
                 name='persistable_in', dtype='float32', shape=[1]

--- a/test/deprecated/legacy_test/test_auto_parallel_reshard_serial_deprecated.py
+++ b/test/deprecated/legacy_test/test_auto_parallel_reshard_serial_deprecated.py
@@ -58,10 +58,14 @@ class MLPLayer(nn.Layer):
     def forward(self, input):
         if _global_parallel_strategy == "pp":
             auto.shard_tensor(
-                self.linear0.weight, PP_MESH_0, [None, None]  # noqa: F821
+                self.linear0.weight,
+                PP_MESH_0,  # noqa: F821
+                [None, None],
             )
             auto.shard_tensor(
-                self.linear1.weight, PP_MESH_1, [None, None]  # noqa: F821
+                self.linear1.weight,
+                PP_MESH_1,  # noqa: F821
+                [None, None],
             )
         else:
             auto.shard_tensor(

--- a/test/deprecated/legacy_test/test_dataloader_early_reset_deprecated.py
+++ b/test/deprecated/legacy_test/test_dataloader_early_reset_deprecated.py
@@ -25,7 +25,7 @@ paddle.enable_static()
 def infinite_reader():
     num = 0
     while True:
-        yield (np.ones([8, 32]) * num).astype('float32'),
+        yield ((np.ones([8, 32]) * num).astype('float32'),)
         num += 1
 
 

--- a/test/deprecated/legacy_test/test_dataloader_keep_order_deprecated.py
+++ b/test/deprecated/legacy_test/test_dataloader_keep_order_deprecated.py
@@ -26,7 +26,7 @@ def create_reader(shape, batch_number):
     def __impl__():
         idx = 0
         for _ in range(batch_number):
-            yield np.ones(shape).astype('float32') * idx,
+            yield (np.ones(shape).astype('float32') * idx,)
             idx += 1
 
     return __impl__

--- a/test/deprecated/legacy_test/test_dataloader_unkeep_order_deprecated.py
+++ b/test/deprecated/legacy_test/test_dataloader_unkeep_order_deprecated.py
@@ -29,7 +29,7 @@ def create_reader(shape, batch_number):
     def __impl__():
         idx = 0
         for _ in range(batch_number):
-            yield np.ones(shape).astype('float32') * idx,
+            yield (np.ones(shape).astype('float32') * idx,)
             idx += 1
 
     return __impl__


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

使用性能更好，格式化效果更佳的 ruff format 替代 black 作为新的 formatter，由于我们很早就已经集成了 ruff lint，因此只是减少依赖而不会增加依赖

<!--

## 核心优势

通过集成 Ruff format，开发者可以享受到以下优势：

- 通过去除 black 对 python 环境依赖，极大降低了升级 formatter 带来的成本，后续无需考虑开发者本地 python 环境即可一键升级
- ruff 由 Rust 驱动，大幅加速 format 时间，降低开发者使用开发工具链的时间成本，减少 CI 时间，提升工程效率
- 格式化后呈现可读性更佳的效果，使得开发者更专注于代码开发而无需关心格式，阅读者也能够更加赏心悦目，极大增加了潜在贡献者的贡献意愿
- ruff 极大程度地兼容了 black 的格式化效果，能够平滑地替换现有的 black 配置
- ruff 更新频次高，能够快速响应社区反馈，持续优化格式化效果
- ruff 团队 Astral 最近开发的 ty 能够提供更强大的类型检查能力，后续可能与 ruff 集成，提供更好的开发体验
- PyTorch 最近已经完成迁移，追平竞品（在代码风格这块，我们一直做到了超越竞品，这次不能落后）

-->