### PR TITLE
[CodeStyle] `black -> ruff format` migration - part 17

### DIFF
--- a/test/deprecated/legacy_test/test_feed_data_check_shape_type_deprecated.py
+++ b/test/deprecated/legacy_test/test_feed_data_check_shape_type_deprecated.py
@@ -86,12 +86,6 @@ class TestFeedData(unittest.TestCase):
         for use_cuda in (
             [True, False] if core.is_compiled_with_cuda() else [False]
         ):
-            print('Test Parameters:'),
-            print(
-                {
-                    'use_cuda': use_cuda,
-                }
-            )
             # Test feeding without error
             self._test_feed_data_match_shape_type(use_cuda)
             self._test_feed_data_contains_neg_one(use_cuda)

--- a/test/deprecated/legacy_test/test_multiprocess_reader_exception_deprecated.py
+++ b/test/deprecated/legacy_test/test_multiprocess_reader_exception_deprecated.py
@@ -44,9 +44,9 @@ class TestMultiprocessReaderExceptionWithQueueSuccess(unittest.TestCase):
             def __impl__():
                 for _ in range(sample_num):
                     if not self.raise_exception:
-                        yield list(
-                            np.random.uniform(low=-1, high=1, size=[10])
-                        ),
+                        yield (
+                            list(np.random.uniform(low=-1, high=1, size=[10])),
+                        )
                     else:
                         raise ValueError
 

--- a/test/deprecated/legacy_test/test_py_func_op_deprecated.py
+++ b/test/deprecated/legacy_test/test_py_func_op_deprecated.py
@@ -167,8 +167,9 @@ def simple_fc_net(img, label, use_py_func_op):
 
 def reader():
     for _ in range(dev_cnt * 100):
-        yield np.random.random([784]), np.random.random_integers(
-            size=[1], low=0, high=9
+        yield (
+            np.random.random([784]),
+            np.random.random_integers(size=[1], low=0, high=9),
         )
 
 

--- a/test/deprecated/legacy_test/test_py_reader_sample_generator_deprecated.py
+++ b/test/deprecated/legacy_test/test_py_reader_sample_generator_deprecated.py
@@ -27,10 +27,11 @@ os.environ['CPU_NUM'] = '1'
 def random_reader(sample_num):
     def __impl__():
         for _ in range(sample_num):
-            yield np.random.random(size=[784]).astype(
-                'float32'
-            ), np.random.random_integers(low=0, high=9, size=[1]).astype(
-                'int64'
+            yield (
+                np.random.random(size=[784]).astype('float32'),
+                np.random.random_integers(low=0, high=9, size=[1]).astype(
+                    'int64'
+                ),
             )
 
     return paddle.reader.cache(__impl__)

--- a/test/distributed_passes/test_dist_fuse_resunit_pass.py
+++ b/test/distributed_passes/test_dist_fuse_resunit_pass.py
@@ -257,7 +257,7 @@ class TestFuseResUnitPass(DistPassTestBase):
             np.random.seed(seed + rank)
             for _ in range(10):
                 image_np = np.random.random(size=image.shape).astype('float32')
-                yield image_np,
+                yield (image_np,)
 
         main_program = paddle.static.default_main_program()
         startup_program = paddle.static.default_startup_program()

--- a/test/dygraph_to_static/test_dygraph_to_static_utils.py
+++ b/test/dygraph_to_static/test_dygraph_to_static_utils.py
@@ -47,10 +47,14 @@ DEFAULT_MODES = [
 
 class CheckTestCaseExistsMixin:
     def assert_hasattr(self, obj: object, attr: str):
-        self.assertTrue(hasattr(obj, attr), msg=f"{attr} not in {obj.__dict__.keys()}")  # type: ignore
+        self.assertTrue(  # type: ignore
+            hasattr(obj, attr), msg=f"{attr} not in {obj.__dict__.keys()}"
+        )
 
     def assert_not_hasattr(self, obj: object, attr: str):
-        self.assertFalse(hasattr(obj, attr), msg=f"{attr} in {obj.__dict__.keys()}")  # type: ignore
+        self.assertFalse(  # type: ignore
+            hasattr(obj, attr), msg=f"{attr} in {obj.__dict__.keys()}"
+        )
 
     def check_test_case_exists(
         self, test_case: Dy2StTestBase, case_name: str, mode_tuple: ModeTuple

--- a/test/dygraph_to_static/test_word2vec.py
+++ b/test/dygraph_to_static/test_word2vec.py
@@ -195,14 +195,11 @@ def build_batch(dataset, batch_size, epoch_num):
                 eval_word_batch.append([random.randint(0, vocab_size - 1)])
 
             if len(center_word_batch) == batch_size:
-                yield np.array(center_word_batch).astype("int64"), np.array(
-                    target_word_batch
-                ).astype("int64"), np.array(label_batch).astype(
-                    "float32"
-                ), np.array(
-                    eval_word_batch
-                ).astype(
-                    "int64"
+                yield (
+                    np.array(center_word_batch).astype("int64"),
+                    np.array(target_word_batch).astype("int64"),
+                    np.array(label_batch).astype("float32"),
+                    np.array(eval_word_batch).astype("int64"),
                 )
                 center_word_batch = []
                 target_word_batch = []
@@ -210,12 +207,11 @@ def build_batch(dataset, batch_size, epoch_num):
                 eval_word_batch = []
 
     if len(center_word_batch) > 0:
-        yield np.array(center_word_batch).astype("int64"), np.array(
-            target_word_batch
-        ).astype("int64"), np.array(label_batch).astype("float32"), np.array(
-            eval_word_batch
-        ).astype(
-            "int64"
+        yield (
+            np.array(center_word_batch).astype("int64"),
+            np.array(target_word_batch).astype("int64"),
+            np.array(label_batch).astype("float32"),
+            np.array(eval_word_batch).astype("int64"),
         )
 
 

--- a/test/ir/inference/test_emb_eltwise_layernorm_fuse_pass.py
+++ b/test/ir/inference/test_emb_eltwise_layernorm_fuse_pass.py
@@ -415,23 +415,31 @@ class TestEmbeddingEltwiseLayerNormFusePassNoBroadcast(PassAutoScanTest):
         # only used in gpu passes and trt passes.
         config = self.create_inference_config(use_gpu=True)
         if program_config.ops[0].type == 'lookup_table':
-            yield config, [
-                'lookup_table',
-                'lookup_table',
-                'lookup_table',
-                'elementwise_add',
-                'elementwise_add',
-                'layer_norm',
-            ], (1e-5, 1e-5)
+            yield (
+                config,
+                [
+                    'lookup_table',
+                    'lookup_table',
+                    'lookup_table',
+                    'elementwise_add',
+                    'elementwise_add',
+                    'layer_norm',
+                ],
+                (1e-5, 1e-5),
+            )
         else:
-            yield config, [
-                'lookup_table_v2',
-                'lookup_table_v2',
-                'lookup_table_v2',
-                'elementwise_add',
-                'elementwise_add',
-                'layer_norm',
-            ], (1e-5, 1e-5)
+            yield (
+                config,
+                [
+                    'lookup_table_v2',
+                    'lookup_table_v2',
+                    'lookup_table_v2',
+                    'elementwise_add',
+                    'elementwise_add',
+                    'layer_norm',
+                ],
+                (1e-5, 1e-5),
+            )
 
     def add_ignore_pass_case(self):
         pass

--- a/test/ir/inference/test_map_matmul_to_mul_pass.py
+++ b/test/ir/inference/test_map_matmul_to_mul_pass.py
@@ -29,15 +29,23 @@ class TestMapMatmulToMulPass(PassAutoScanTest):
     def sample_predictor_configs(self, program_config):
         # cpu
         config = self.create_inference_config(use_gpu=False)
-        yield config, [
-            "mul",
-        ], (1e-5, 1e-5)
+        yield (
+            config,
+            [
+                "mul",
+            ],
+            (1e-5, 1e-5),
+        )
 
         # for gpu
         config = self.create_inference_config(use_gpu=True)
-        yield config, [
-            "mul",
-        ], (1e-5, 1e-5)
+        yield (
+            config,
+            [
+                "mul",
+            ],
+            (1e-5, 1e-5),
+        )
 
         # TRT
         # config = self.create_trt_inference_config()

--- a/test/ir/inference/test_map_matmul_to_mul_pass.py
+++ b/test/ir/inference/test_map_matmul_to_mul_pass.py
@@ -31,9 +31,7 @@ class TestMapMatmulToMulPass(PassAutoScanTest):
         config = self.create_inference_config(use_gpu=False)
         yield (
             config,
-            [
-                "mul",
-            ],
+            ["mul"],
             (1e-5, 1e-5),
         )
 

--- a/test/ir/inference/test_map_matmul_to_mul_pass.py
+++ b/test/ir/inference/test_map_matmul_to_mul_pass.py
@@ -39,9 +39,7 @@ class TestMapMatmulToMulPass(PassAutoScanTest):
         config = self.create_inference_config(use_gpu=True)
         yield (
             config,
-            [
-                "mul",
-            ],
+            ["mul"],
             (1e-5, 1e-5),
         )
 

--- a/test/ir/inference/test_map_matmul_v2_to_matmul_pass.py
+++ b/test/ir/inference/test_map_matmul_v2_to_matmul_pass.py
@@ -39,9 +39,7 @@ class TestMapMatmulToMulPass(PassAutoScanTest):
         config = self.create_inference_config(use_gpu=True)
         yield (
             config,
-            [
-                "matmul",
-            ],
+            ["matmul"],
             (1e-5, 1e-5),
         )
 

--- a/test/ir/inference/test_map_matmul_v2_to_matmul_pass.py
+++ b/test/ir/inference/test_map_matmul_v2_to_matmul_pass.py
@@ -29,15 +29,23 @@ class TestMapMatmulToMulPass(PassAutoScanTest):
     def sample_predictor_configs(self, program_config):
         # cpu
         config = self.create_inference_config(use_gpu=False)
-        yield config, [
-            "matmul",
-        ], (1e-5, 1e-5)
+        yield (
+            config,
+            [
+                "matmul",
+            ],
+            (1e-5, 1e-5),
+        )
 
         # for gpu
         config = self.create_inference_config(use_gpu=True)
-        yield config, [
-            "matmul",
-        ], (1e-5, 1e-5)
+        yield (
+            config,
+            [
+                "matmul",
+            ],
+            (1e-5, 1e-5),
+        )
 
         # TRT
         # config = self.create_trt_inference_config()

--- a/test/ir/inference/test_map_matmul_v2_to_matmul_pass.py
+++ b/test/ir/inference/test_map_matmul_v2_to_matmul_pass.py
@@ -31,9 +31,7 @@ class TestMapMatmulToMulPass(PassAutoScanTest):
         config = self.create_inference_config(use_gpu=False)
         yield (
             config,
-            [
-                "matmul",
-            ],
+            ["matmul"],
             (1e-5, 1e-5),
         )
 

--- a/test/ir/inference/test_map_matmul_v2_to_mul_pass.py
+++ b/test/ir/inference/test_map_matmul_v2_to_mul_pass.py
@@ -29,15 +29,23 @@ class TestMapMatmulToMulPass(PassAutoScanTest):
     def sample_predictor_configs(self, program_config):
         # cpu
         config = self.create_inference_config(use_gpu=False)
-        yield config, [
-            "mul",
-        ], (1e-5, 1e-5)
+        yield (
+            config,
+            [
+                "mul",
+            ],
+            (1e-5, 1e-5),
+        )
 
         # for gpu
         config = self.create_inference_config(use_gpu=True)
-        yield config, [
-            "mul",
-        ], (1e-5, 1e-5)
+        yield (
+            config,
+            [
+                "mul",
+            ],
+            (1e-5, 1e-5),
+        )
 
         # TRT
         # config = self.create_trt_inference_config()

--- a/test/ir/inference/test_map_matmul_v2_to_mul_pass.py
+++ b/test/ir/inference/test_map_matmul_v2_to_mul_pass.py
@@ -31,9 +31,7 @@ class TestMapMatmulToMulPass(PassAutoScanTest):
         config = self.create_inference_config(use_gpu=False)
         yield (
             config,
-            [
-                "mul",
-            ],
+            ["mul"],
             (1e-5, 1e-5),
         )
 

--- a/test/ir/inference/test_map_matmul_v2_to_mul_pass.py
+++ b/test/ir/inference/test_map_matmul_v2_to_mul_pass.py
@@ -39,9 +39,7 @@ class TestMapMatmulToMulPass(PassAutoScanTest):
         config = self.create_inference_config(use_gpu=True)
         yield (
             config,
-            [
-                "mul",
-            ],
+            ["mul"],
             (1e-5, 1e-5),
         )
 

--- a/test/ir/inference/test_matmul_scale_fuse_pass.py
+++ b/test/ir/inference/test_matmul_scale_fuse_pass.py
@@ -49,9 +49,7 @@ class TestMatmulScaleFusePass(PassAutoScanTest):
         config = self.create_inference_config(use_gpu=True)
         yield (
             config,
-            [
-                "matmul",
-            ],
+            ["matmul"],
             (1e-5, 1e-5),
         )
 

--- a/test/ir/inference/test_matmul_scale_fuse_pass.py
+++ b/test/ir/inference/test_matmul_scale_fuse_pass.py
@@ -33,9 +33,7 @@ class TestMatmulScaleFusePass(PassAutoScanTest):
         config = self.create_inference_config(use_gpu=False)
         yield (
             config,
-            [
-                "matmul",
-            ],
+            ["matmul"],
             (1e-5, 1e-5),
         )
 

--- a/test/ir/inference/test_matmul_scale_fuse_pass.py
+++ b/test/ir/inference/test_matmul_scale_fuse_pass.py
@@ -41,9 +41,7 @@ class TestMatmulScaleFusePass(PassAutoScanTest):
         config = self.create_inference_config(use_onednn=True)
         yield (
             config,
-            [
-                "matmul",
-            ],
+            ["matmul"],
             (1e-5, 1e-5),
         )
 

--- a/test/ir/inference/test_matmul_scale_fuse_pass.py
+++ b/test/ir/inference/test_matmul_scale_fuse_pass.py
@@ -31,21 +31,33 @@ class TestMatmulScaleFusePass(PassAutoScanTest):
     def sample_predictor_configs(self, program_config):
         # cpu
         config = self.create_inference_config(use_gpu=False)
-        yield config, [
-            "matmul",
-        ], (1e-5, 1e-5)
+        yield (
+            config,
+            [
+                "matmul",
+            ],
+            (1e-5, 1e-5),
+        )
 
         # onednn
         config = self.create_inference_config(use_onednn=True)
-        yield config, [
-            "matmul",
-        ], (1e-5, 1e-5)
+        yield (
+            config,
+            [
+                "matmul",
+            ],
+            (1e-5, 1e-5),
+        )
 
         # gpu
         config = self.create_inference_config(use_gpu=True)
-        yield config, [
-            "matmul",
-        ], (1e-5, 1e-5)
+        yield (
+            config,
+            [
+                "matmul",
+            ],
+            (1e-5, 1e-5),
+        )
 
     def sample_program_config(self, draw):
         # 1. Generate shape and attr of matmul

--- a/test/ir/inference/test_matmul_v2_scale_fuse_pass.py
+++ b/test/ir/inference/test_matmul_v2_scale_fuse_pass.py
@@ -39,9 +39,7 @@ class TestMatmulV2ScaleFusePass(PassAutoScanTest):
         config = self.create_inference_config(use_onednn=True)
         yield (
             config,
-            [
-                "matmul_v2",
-            ],
+            ["matmul_v2"],
             (1e-5, 1e-5),
         )
 

--- a/test/ir/inference/test_matmul_v2_scale_fuse_pass.py
+++ b/test/ir/inference/test_matmul_v2_scale_fuse_pass.py
@@ -37,9 +37,13 @@ class TestMatmulV2ScaleFusePass(PassAutoScanTest):
 
         # onednn
         config = self.create_inference_config(use_onednn=True)
-        yield config, [
-            "matmul_v2",
-        ], (1e-5, 1e-5)
+        yield (
+            config,
+            [
+                "matmul_v2",
+            ],
+            (1e-5, 1e-5),
+        )
 
     def sample_program_config(self, draw):
         # 1. Generate shape and attr of matmul

--- a/test/ir/inference/test_multihead_matmul_roformer_fuse_pass.py
+++ b/test/ir/inference/test_multihead_matmul_roformer_fuse_pass.py
@@ -54,9 +54,13 @@ class TestMultiheadMatmulRoformerFusePass(PassAutoScanTest):
                 "sin_input": [1, 12, 128, 64],
             },
         )
-        yield config, ["multihead_matmul_roformer", "matrix_multiply"], (
-            1e-2,
-            1e-3,
+        yield (
+            config,
+            ["multihead_matmul_roformer", "matrix_multiply"],
+            (
+                1e-2,
+                1e-3,
+            ),
         )
 
     def sample_program_config(self, draw):

--- a/test/ir/inference/test_seqconv_eltadd_relu_fuse_pass.py
+++ b/test/ir/inference/test_seqconv_eltadd_relu_fuse_pass.py
@@ -105,9 +105,13 @@ class TestSeqconvEltaddReluFusePass(PassAutoScanTest):
 
     def sample_predictor_configs(self, program_config):
         config = self.create_inference_config()
-        yield config, ["im2sequence", "fusion_seqconv_eltadd_relu"], (
-            1e-5,
-            1e-5,
+        yield (
+            config,
+            ["im2sequence", "fusion_seqconv_eltadd_relu"],
+            (
+                1e-5,
+                1e-5,
+            ),
         )
 
     def test(self):

--- a/test/ir/inference/test_split_layernorm_to_math_ops_pass.py
+++ b/test/ir/inference/test_split_layernorm_to_math_ops_pass.py
@@ -46,17 +46,21 @@ class TestSplitLayernormToMathOpsPass(PassAutoScanTest):
                 "input_data": [1, 6, 16],
             },
         )
-        yield config, [
-            'reduce_mean',
-            'elementwise_sub',
-            'elementwise_pow',
-            'reduce_mean',
-            'elementwise_add',
-            'sqrt',
-            'elementwise_div',
-            'elementwise_mul',
-            'elementwise_add',
-        ], (1e-5, 1e-5)
+        yield (
+            config,
+            [
+                'reduce_mean',
+                'elementwise_sub',
+                'elementwise_pow',
+                'reduce_mean',
+                'elementwise_add',
+                'sqrt',
+                'elementwise_div',
+                'elementwise_mul',
+                'elementwise_add',
+            ],
+            (1e-5, 1e-5),
+        )
 
         # trt dynamic_shape
         config = self.create_trt_inference_config()
@@ -79,17 +83,21 @@ class TestSplitLayernormToMathOpsPass(PassAutoScanTest):
                 "input_data": [1, 6, 16],
             },
         )
-        yield config, [
-            'reduce_mean',
-            'elementwise_sub',
-            'elementwise_pow',
-            'reduce_mean',
-            'elementwise_add',
-            'sqrt',
-            'elementwise_div',
-            'elementwise_mul',
-            'elementwise_add',
-        ], (1e-2, 1e-2)
+        yield (
+            config,
+            [
+                'reduce_mean',
+                'elementwise_sub',
+                'elementwise_pow',
+                'reduce_mean',
+                'elementwise_add',
+                'sqrt',
+                'elementwise_div',
+                'elementwise_mul',
+                'elementwise_add',
+            ],
+            (1e-2, 1e-2),
+        )
 
         config = self.create_trt_inference_config()
         config.enable_tensorrt_engine(
@@ -100,17 +108,21 @@ class TestSplitLayernormToMathOpsPass(PassAutoScanTest):
             use_static=False,
             use_calib_mode=False,
         )
-        yield config, [
-            'reduce_mean',
-            'elementwise_sub',
-            'elementwise_pow',
-            'reduce_mean',
-            'elementwise_add',
-            'sqrt',
-            'elementwise_div',
-            'elementwise_mul',
-            'elementwise_add',
-        ], (1e-5, 1e-5)
+        yield (
+            config,
+            [
+                'reduce_mean',
+                'elementwise_sub',
+                'elementwise_pow',
+                'reduce_mean',
+                'elementwise_add',
+                'sqrt',
+                'elementwise_div',
+                'elementwise_mul',
+                'elementwise_add',
+            ],
+            (1e-5, 1e-5),
+        )
 
         config = self.create_trt_inference_config()
         config.enable_tensorrt_engine(
@@ -121,17 +133,21 @@ class TestSplitLayernormToMathOpsPass(PassAutoScanTest):
             use_static=False,
             use_calib_mode=False,
         )
-        yield config, [
-            'reduce_mean',
-            'elementwise_sub',
-            'elementwise_pow',
-            'reduce_mean',
-            'elementwise_add',
-            'sqrt',
-            'elementwise_div',
-            'elementwise_mul',
-            'elementwise_add',
-        ], (1e-2, 1e-2)
+        yield (
+            config,
+            [
+                'reduce_mean',
+                'elementwise_sub',
+                'elementwise_pow',
+                'reduce_mean',
+                'elementwise_add',
+                'sqrt',
+                'elementwise_div',
+                'elementwise_mul',
+                'elementwise_add',
+            ],
+            (1e-2, 1e-2),
+        )
 
     def sample_program_config(self, draw):
         epsilon = draw(st.floats(min_value=0.0000001, max_value=0.001))

--- a/test/ir/inference/test_transpose_flatten_concat_fuse_pass.py
+++ b/test/ir/inference/test_transpose_flatten_concat_fuse_pass.py
@@ -40,9 +40,7 @@ class TestTransposeFlattenConcatFusePass(PassAutoScanTest):
         config = self.create_inference_config(use_gpu=True)
         yield (
             config,
-            [
-                "fusion_transpose_flatten_concat",
-            ],
+            ["fusion_transpose_flatten_concat"],
             (1e-5, 1e-5),
         )
 

--- a/test/ir/inference/test_transpose_flatten_concat_fuse_pass.py
+++ b/test/ir/inference/test_transpose_flatten_concat_fuse_pass.py
@@ -38,9 +38,13 @@ class TestTransposeFlattenConcatFusePass(PassAutoScanTest):
 
         # for gpu
         config = self.create_inference_config(use_gpu=True)
-        yield config, [
-            "fusion_transpose_flatten_concat",
-        ], (1e-5, 1e-5)
+        yield (
+            config,
+            [
+                "fusion_transpose_flatten_concat",
+            ],
+            (1e-5, 1e-5),
+        )
 
     def is_program_valid(self, prog_config):
         concat_axis = prog_config.ops[-1].attrs["axis"]

--- a/test/ir/inference/test_trt_convert_activation.py
+++ b/test/ir/inference/test_trt_convert_activation.py
@@ -127,7 +127,6 @@ class TrtConvertActivationTest(TrtLayerAutoScanTest):
     def sample_predictor_configs(
         self, program_config, run_pir=False
     ) -> tuple[paddle_infer.Config, list[int], float]:
-
         def clear_dynamic_shape():
             self.dynamic_shape.min_input_shape = {}
             self.dynamic_shape.max_input_shape = {}
@@ -160,27 +159,35 @@ class TrtConvertActivationTest(TrtLayerAutoScanTest):
         if not run_pir:
             self.trt_param.precision = paddle_infer.PrecisionType.Float32
             program_config.set_input_type(np.float32)
-            yield self.create_inference_config(), generate_trt_nodes_num(
-                attrs, False
-            ), 1e-5
+            yield (
+                self.create_inference_config(),
+                generate_trt_nodes_num(attrs, False),
+                1e-5,
+            )
             self.trt_param.precision = paddle_infer.PrecisionType.Half
             program_config.set_input_type(np.float16)
-            yield self.create_inference_config(), generate_trt_nodes_num(
-                attrs, False
-            ), 1e-3
+            yield (
+                self.create_inference_config(),
+                generate_trt_nodes_num(attrs, False),
+                1e-3,
+            )
 
         # for dynamic_shape
         self.generate_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         program_config.set_input_type(np.float32)
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True
-        ), 1e-5
+        yield (
+            self.create_inference_config(),
+            generate_trt_nodes_num(attrs, True),
+            1e-5,
+        )
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         program_config.set_input_type(np.float16)
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True
-        ), 1e-3
+        yield (
+            self.create_inference_config(),
+            generate_trt_nodes_num(attrs, True),
+            1e-3,
+        )
 
     def test(self):
         self.run_test(run_pir=True)

--- a/test/ir/inference/test_trt_convert_affine_channel.py
+++ b/test/ir/inference/test_trt_convert_affine_channel.py
@@ -118,7 +118,6 @@ class TrtConvertAffineChannelTest(TrtLayerAutoScanTest):
     def sample_predictor_configs(
         self, program_config, run_pir=False
     ) -> tuple[paddle_infer.Config, list[int], float]:
-
         def clear_dynamic_shape():
             self.dynamic_shape.min_input_shape = {}
             self.dynamic_shape.max_input_shape = {}
@@ -138,24 +137,32 @@ class TrtConvertAffineChannelTest(TrtLayerAutoScanTest):
         clear_dynamic_shape()
         if not run_pir:
             self.trt_param.precision = paddle_infer.PrecisionType.Float32
-            yield self.create_inference_config(), generate_trt_nodes_num(
-                attrs, False
-            ), 1e-5
+            yield (
+                self.create_inference_config(),
+                generate_trt_nodes_num(attrs, False),
+                1e-5,
+            )
             self.trt_param.precision = paddle_infer.PrecisionType.Half
-            yield self.create_inference_config(), generate_trt_nodes_num(
-                attrs, False
-            ), (1e-3, 1e-3)
+            yield (
+                self.create_inference_config(),
+                generate_trt_nodes_num(attrs, False),
+                (1e-3, 1e-3),
+            )
 
         # for dynamic_shape
         self.generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True
-        ), 1e-5
+        yield (
+            self.create_inference_config(),
+            generate_trt_nodes_num(attrs, True),
+            1e-5,
+        )
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True
-        ), (1e-3, 1e-3)
+        yield (
+            self.create_inference_config(),
+            generate_trt_nodes_num(attrs, True),
+            (1e-3, 1e-3),
+        )
 
     def test(self):
         self.run_test(run_pir=True)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

使用性能更好，格式化效果更佳的 ruff format 替代 black 作为新的 formatter，由于我们很早就已经集成了 ruff lint，因此只是减少依赖而不会增加依赖

<!--

## 核心优势

通过集成 Ruff format，开发者可以享受到以下优势：

- 通过去除 black 对 python 环境依赖，极大降低了升级 formatter 带来的成本，后续无需考虑开发者本地 python 环境即可一键升级
- ruff 由 Rust 驱动，大幅加速 format 时间，降低开发者使用开发工具链的时间成本，减少 CI 时间，提升工程效率
- 格式化后呈现可读性更佳的效果，使得开发者更专注于代码开发而无需关心格式，阅读者也能够更加赏心悦目，极大增加了潜在贡献者的贡献意愿
- ruff 极大程度地兼容了 black 的格式化效果，能够平滑地替换现有的 black 配置
- ruff 更新频次高，能够快速响应社区反馈，持续优化格式化效果
- ruff 团队 Astral 最近开发的 ty 能够提供更强大的类型检查能力，后续可能与 ruff 集成，提供更好的开发体验
- PyTorch 最近已经完成迁移，追平竞品（在代码风格这块，我们一直做到了超越竞品，这次不能落后）

-->