### PR TITLE
[API Compatible] Support add signature and default mapping  when  Python API sink to the C++ layer 

### DIFF
--- a/paddle/fluid/eager/auto_code_generator/generator/codegen_utils.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/codegen_utils.py
@@ -532,8 +532,11 @@ class FunctionGeneratorBase:
         if 'name' in python_api_info.keys():
             self.python_api_names = python_api_info['name']
         if 'args_alias' in python_api_info.keys():
-            for arg, alias in python_api_info['args_alias'].items():
-                alias_set = set(alias)
+            for arg, alias_or_mode in python_api_info['args_alias'].items():
+                if arg == 'use_default_mapping':
+                    args_alias.update({arg: alias_or_mode})
+                    continue
+                alias_set = set(alias_or_mode)
                 # Add the original argument name to the alias set
                 alias_set.add(arg)
                 # Convert to C++ vector format

--- a/paddle/fluid/eager/auto_code_generator/generator/monkey_patch_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/monkey_patch_gen.py
@@ -38,14 +38,15 @@ methods_map = [
 """
 
 METHOD_TEMPLATE = """
-def _{name}(self,*args, **kwargs):
-    return _C_ops.{name}(self,*args, **kwargs)
+def _{name}(*args, **kwargs):
+    return _C_ops.{name}(*args, **kwargs)
 """
 SET_METHOD_TEMPLATE = """
     # set methods for Tensor in dygraph
     local_tensor = core.eager.Tensor
     for method_name, method in methods_map:
         setattr(local_tensor, method_name, method)
+        setattr(paddle, method_name, method)
 
 """
 

--- a/paddle/fluid/pir/dialect/op_generator/python_c_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/python_c_gen.py
@@ -23,6 +23,12 @@ from api_gen import (
     CodeGen,
 )
 
+args_default_mapping = {
+    "x": ["input"],
+    "y": ["other"],
+    "axis": ["dim"],
+    "keepdims": ["keepdim"],
+}
 H_FILE_TEMPLATE = """
 
 #pragma once
@@ -304,15 +310,20 @@ class PythonCCodeGen(CodeGen):
             f.write(H_FILE_TEMPLATE.format(body=body))
 
     def _gen_keywords_vector(self, args_alias_map, arg_name):
-        alias_vector = f'{{"{arg_name}"}}'
+        alias_set = set()
         if arg_name in args_alias_map.keys():
             alias_set = set(args_alias_map[arg_name])
-            # Add the original argument name to the alias set
-            alias_set.add(arg_name)
-            # Convert to C++ vector format
-            alias_vector = (
-                "{" + ",".join(f'"{name}"' for name in alias_set) + "}"
-            )
+        elif (
+            "use_default_mapping" in args_alias_map.keys()
+            and args_alias_map['use_default_mapping']
+        ):
+            # try to use default mapping
+            if arg_name in args_default_mapping.keys():
+                alias_set = set(args_default_mapping[arg_name])
+        # Add the original argument name to the alias set
+        alias_set.add(arg_name)
+        # Convert to C++ vector format
+        alias_vector = "{" + ",".join(f'"{name}"' for name in alias_set) + "}"
         return alias_vector
 
     def _gen_inputs(self, op_info, op_name, args_alias_map={}):

--- a/paddle/fluid/pybind/eager_functions.cc
+++ b/paddle/fluid/pybind/eager_functions.cc
@@ -1409,12 +1409,12 @@ PyObject* eager__add_doc_str(PyObject* self, PyObject* args) {
     if (func_obj->ob_type->tp_dict == nullptr) {
       func_obj->ob_type->tp_dict = PyDict_New();
     }
-    if (PyDict_SetItemString(
-            func_obj->ob_type->tp_dict, "__text_signature__", sig_obj) < 0) {
-      VLOG(6) << "eager__add_doc_str add __text_signature__ failed";
-      return nullptr;
-    }
-    Py_INCREF(sig_obj);
+    // if (PyDict_SetItemString(
+    //         func_obj->ob_type->tp_dict, "__text_signature__", sig_obj) < 0) {
+    //   VLOG(6) << "eager__add_doc_str add __text_signature__ failed";
+    //   return nullptr;
+    // }
+    // Py_INCREF(sig_obj);
     if (PyDict_SetItemString(
             func_obj->ob_type->tp_dict, "__annotations__", annotatio_obj) < 0) {
       VLOG(6) << "eager__add_doc_str add __annotations__ failed";

--- a/paddle/fluid/pybind/eager_functions.cc
+++ b/paddle/fluid/pybind/eager_functions.cc
@@ -1381,15 +1381,24 @@ PyObject* eager__is_run_in_backward(PyObject* self,
 PyObject* eager__add_doc_str(PyObject* self, PyObject* args) {
   EAGER_TRY
   static std::vector<std::string> all_docs;
-  PyObject* obj = nullptr;
+  PyObject* func_obj = nullptr;
   PyObject* doc_obj = nullptr;
-  if (!PyArg_ParseTuple(args, "OO", &obj, &doc_obj)) {
+  PyObject* sig_obj = nullptr;
+  PyObject* annotatio_obj = nullptr;
+  if (!PyArg_ParseTuple(
+          args, "OOOO", &func_obj, &doc_obj, &sig_obj, &annotatio_obj)) {
+    return nullptr;
+  }
+  if (PyDict_Check(annotatio_obj) == false) {
+    PADDLE_THROW(common::errors::InvalidArgument(
+        "The 4th arg which be used to init __annotations__  must be dict in "
+        "python!"));
     return nullptr;
   }
   std::string doc_string = CastPyArg2AttrString(doc_obj, 1);
 
-  if (Py_TYPE(obj) == &PyCFunction_Type) {
-    PyCFunctionObject* f = reinterpret_cast<PyCFunctionObject*>(obj);
+  if (Py_TYPE(func_obj) == &PyCFunction_Type) {
+    PyCFunctionObject* f = reinterpret_cast<PyCFunctionObject*>(func_obj);
     if (f->m_ml->ml_doc) {
       VLOG(6)
           << "eager__add_doc_str will update doc for PyCFunction, original doc "
@@ -1397,6 +1406,21 @@ PyObject* eager__add_doc_str(PyObject* self, PyObject* args) {
     }
     all_docs.emplace_back(doc_string);
     f->m_ml->ml_doc = all_docs.back().c_str();
+    if (func_obj->ob_type->tp_dict == nullptr) {
+      func_obj->ob_type->tp_dict = PyDict_New();
+    }
+    if (PyDict_SetItemString(
+            func_obj->ob_type->tp_dict, "__text_signature__", sig_obj) < 0) {
+      VLOG(6) << "eager__add_doc_str add __text_signature__ failed";
+      return nullptr;
+    }
+    Py_INCREF(sig_obj);
+    if (PyDict_SetItemString(
+            func_obj->ob_type->tp_dict, "__annotations__", annotatio_obj) < 0) {
+      VLOG(6) << "eager__add_doc_str add __annotations__ failed";
+      return nullptr;
+    }
+    Py_INCREF(annotatio_obj);
   }
   RETURN_PY_NONE
   EAGER_CATCH_AND_THROW_RETURN_NULL

--- a/paddle/phi/ops/yaml/ops.yaml
+++ b/paddle/phi/ops/yaml/ops.yaml
@@ -242,8 +242,7 @@
   python_api :
     name : [paddle.amax,paddle.Tensor.amax]
     args_alias:
-      x : [input,x1]
-      axis : [dim]
+      use_default_mapping : True
   output : Tensor(out)
   infer_meta :
     func : ReduceInferMeta
@@ -257,8 +256,7 @@
   python_api :
     name : [paddle.amin,paddle.Tensor.amin]
     args_alias :
-      x : [input,x1]
-      axis : [dim]
+      use_default_mapping : True
   output : Tensor(out)
   infer_meta :
     func : ReduceInferMeta

--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -58,7 +58,7 @@ monkey_patch_math_tensor()
 monkey_patch_value()
 monkey_patch_program()
 monkey_patch_dtype()
-monkey_patch_generated_methods_for_tensor()
+
 monkey_patch_generated_methods_for_value()
 
 from .base.dataset import *  # noqa: F403
@@ -1266,6 +1266,7 @@ __all__ = [
 ]
 import os
 
+monkey_patch_generated_methods_for_tensor()
 import paddle._paddle_docs
 
 FLAGS_trace_api = os.environ.get("FLAGS_trace_api", None)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
Python API C++ 下沉机制支持添加signature以及支持使用默认的args mapping
- signature的支持：add_doc_and_signature 接口添加signature和doc
- 默认args mapping：支持yaml中配置use_default_mapping : True选项，提供默认的参数名映射，默认映射关系：
```
args_default_mapping = {
    "x": ["input"],
    "y": ["other"],
    "axis": ["dim"],
    "keepdims": ["keepdim"],
}
```
- 为了更好的支持signature，_C_ops 又包了一层python实现
签名测试：
<img width="858" height="74" alt="image" src="https://github.com/user-attachments/assets/8ad1dd48-d4b0-47fb-8ee3-065e0e4082b4" />
<img width="858" height="92" alt="image" src="https://github.com/user-attachments/assets/59b4c343-be4c-426b-9c6c-cc29a9fc8189" />

pcard-67164