### PR TITLE
[PHI] Add uint8/int16 CUDA atomic mul/min/max and upgraded take/put_along_axis (input types)

### DIFF
--- a/paddle/phi/kernels/cpu/put_along_axis_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/put_along_axis_grad_kernel.cc
@@ -180,5 +180,6 @@ PD_REGISTER_KERNEL(put_along_axis_grad,
                    float,
                    double,
                    int,
+                   int16_t,
                    uint8_t,
                    int64_t) {}

--- a/paddle/phi/kernels/cpu/put_along_axis_kernel.cc
+++ b/paddle/phi/kernels/cpu/put_along_axis_kernel.cc
@@ -103,5 +103,6 @@ PD_REGISTER_KERNEL(put_along_axis,
                    float,
                    double,
                    int,
+                   int16_t,
                    uint8_t,
                    int64_t) {}

--- a/paddle/phi/kernels/cpu/take_along_axis_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/take_along_axis_grad_kernel.cc
@@ -66,5 +66,6 @@ PD_REGISTER_KERNEL(take_along_axis_grad,
                    float,
                    double,
                    int,
+                   int16_t,
                    uint8_t,
                    int64_t) {}

--- a/paddle/phi/kernels/cpu/take_along_axis_kernel.cc
+++ b/paddle/phi/kernels/cpu/take_along_axis_kernel.cc
@@ -65,5 +65,6 @@ PD_REGISTER_KERNEL(take_along_axis,
                    float,
                    double,
                    int,
+                   int16_t,
                    uint8_t,
                    int64_t) {}

--- a/paddle/phi/kernels/funcs/gather_scatter_functor.cu
+++ b/paddle/phi/kernels/funcs/gather_scatter_functor.cu
@@ -31,64 +31,36 @@ static TensorAssign tensor_assign;
 
 class ReduceAdd {
  public:
-  template <
-      typename tensor_t,
-      std::enable_if_t<!std::is_same<tensor_t, uint8_t>::value>* = nullptr>
+  template <typename tensor_t>
   __device__ void operator()(tensor_t* self_data, tensor_t* src_data) const {
     phi::CudaAtomicAdd(self_data, *src_data);
-  }
-  template <typename tensor_t,
-            std::enable_if_t<std::is_same<tensor_t, uint8_t>::value>* = nullptr>
-  __device__ void operator()(tensor_t* self_data, tensor_t* src_data) const {
-    *self_data += *src_data;
   }
 };
 static ReduceAdd reduce_add;
 
 class ReduceMul {
  public:
-  template <
-      typename tensor_t,
-      std::enable_if_t<!std::is_same<tensor_t, uint8_t>::value>* = nullptr>
+  template <typename tensor_t>
   __device__ void operator()(tensor_t* self_data, tensor_t* src_data) const {
     phi::CudaAtomicMul(self_data, *src_data);
-  }
-  template <typename tensor_t,
-            std::enable_if_t<std::is_same<tensor_t, uint8_t>::value>* = nullptr>
-  __device__ void operator()(tensor_t* self_data, tensor_t* src_data) const {
-    *self_data *= *src_data;
   }
 };
 static ReduceMul reduce_mul;
 
 class ReduceMax {
  public:
-  template <
-      typename tensor_t,
-      std::enable_if_t<!std::is_same<tensor_t, uint8_t>::value>* = nullptr>
+  template <typename tensor_t>
   __device__ void operator()(tensor_t* self_data, tensor_t* src_data) const {
     phi::CudaAtomicMax(self_data, *src_data);
-  }
-  template <typename tensor_t,
-            std::enable_if_t<std::is_same<tensor_t, uint8_t>::value>* = nullptr>
-  __device__ void operator()(tensor_t* self_data, tensor_t* src_data) const {
-    *self_data = *src_data > *self_data ? *src_data : *self_data;
   }
 };
 static ReduceMax reduce_max;
 
 class ReduceMin {
  public:
-  template <
-      typename tensor_t,
-      std::enable_if_t<!std::is_same<tensor_t, uint8_t>::value>* = nullptr>
+  template <typename tensor_t>
   __device__ void operator()(tensor_t* self_data, tensor_t* src_data) const {
     phi::CudaAtomicMin(self_data, *src_data);
-  }
-  template <typename tensor_t,
-            std::enable_if_t<std::is_same<tensor_t, uint8_t>::value>* = nullptr>
-  __device__ void operator()(tensor_t* self_data, tensor_t* src_data) const {
-    *self_data = *src_data < *self_data ? *src_data : *self_data;
   }
 };
 static ReduceMin reduce_min;

--- a/paddle/phi/kernels/funcs/gather_scatter_functor.h
+++ b/paddle/phi/kernels/funcs/gather_scatter_functor.h
@@ -29,7 +29,8 @@ namespace funcs {
           Instantiate_Template_Function_index_t(func, phi::dtype::float16)   \
               Instantiate_Template_Function_index_t(func,                    \
                                                     phi::dtype::bfloat16)    \
-                  Instantiate_Template_Function_index_t(func, unsigned char)
+                  Instantiate_Template_Function_index_t(func, unsigned char) \
+                      Instantiate_Template_Function_index_t(func, int16_t)
 
 #define Instantiate_Template_Function_index_t(func, tensor_t)           \
   template void func<tensor_t, int>(phi::DenseTensor input,             \
@@ -45,17 +46,19 @@ namespace funcs {
                                         bool include_self,              \
                                         const phi::DeviceContext& dev_ctx);
 
-#define Instantiate_Template_Function_With_Out(func)                        \
-  Instantiate_Template_Function_index_t_With_Out(func, int)                 \
-      Instantiate_Template_Function_index_t_With_Out(func, float)           \
-          Instantiate_Template_Function_index_t_With_Out(func, double)      \
-              Instantiate_Template_Function_index_t_With_Out(func, int64_t) \
-                  Instantiate_Template_Function_index_t_With_Out(           \
-                      func, phi::dtype::float16)                            \
-                      Instantiate_Template_Function_index_t_With_Out(       \
-                          func, phi::dtype::bfloat16)                       \
-                          Instantiate_Template_Function_index_t_With_Out(   \
-                              func, unsigned char)
+#define Instantiate_Template_Function_With_Out(func)                          \
+  Instantiate_Template_Function_index_t_With_Out(func, int)                   \
+      Instantiate_Template_Function_index_t_With_Out(func, float)             \
+          Instantiate_Template_Function_index_t_With_Out(func, double)        \
+              Instantiate_Template_Function_index_t_With_Out(func, int64_t)   \
+                  Instantiate_Template_Function_index_t_With_Out(             \
+                      func, phi::dtype::float16)                              \
+                      Instantiate_Template_Function_index_t_With_Out(         \
+                          func, phi::dtype::bfloat16)                         \
+                          Instantiate_Template_Function_index_t_With_Out(     \
+                              func, unsigned char)                            \
+                              Instantiate_Template_Function_index_t_With_Out( \
+                                  func, int16_t)
 #define Instantiate_Template_Function_index_t_With_Out(func, tensor_t)  \
   template void func<tensor_t, int>(phi::DenseTensor input,             \
                                     int dim,                            \

--- a/paddle/phi/kernels/gpu/put_along_axis_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/put_along_axis_grad_kernel.cu
@@ -179,5 +179,7 @@ PD_REGISTER_KERNEL(put_along_axis_grad,
                    double,
                    int64_t,
                    int,
+                   int16_t,
+                   uint8_t,
                    phi::dtype::float16,
                    phi::dtype::bfloat16) {}

--- a/paddle/phi/kernels/gpu/put_along_axis_kernel.cu
+++ b/paddle/phi/kernels/gpu/put_along_axis_kernel.cu
@@ -102,6 +102,8 @@ PD_REGISTER_KERNEL(put_along_axis,
                    float,
                    double,
                    int64_t,
+                   uint8_t,
+                   int16_t,
                    int,
                    phi::dtype::float16,
                    phi::dtype::bfloat16) {}

--- a/paddle/phi/kernels/gpu/take_along_axis_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/take_along_axis_grad_kernel.cu
@@ -73,5 +73,7 @@ PD_REGISTER_KERNEL(take_along_axis_grad,
                    double,
                    int64_t,
                    int,
+                   int16_t,
+                   uint8_t,
                    phi::dtype::float16,
                    phi::dtype::bfloat16) {}

--- a/paddle/phi/kernels/gpu/take_along_axis_kernel.cu
+++ b/paddle/phi/kernels/gpu/take_along_axis_kernel.cu
@@ -71,5 +71,7 @@ PD_REGISTER_KERNEL(take_along_axis,
                    double,
                    int64_t,
                    int,
+                   int16_t,
+                   uint8_t,
                    phi::dtype::float16,
                    phi::dtype::bfloat16) {}

--- a/test/legacy_test/test_put_along_axis_op.py
+++ b/test/legacy_test/test_put_along_axis_op.py
@@ -80,6 +80,8 @@ class TestPutAlongAxisOp(OpTest):
 
 
 class TestPutAlongAxisInt16OpBase(TestPutAlongAxisOp):
+    no_need_check_grad = True
+
     def init_data(self):
         self.set_type()
         self.x_shape = (10, 10, 10)
@@ -107,6 +109,8 @@ class TestPutAlongAxisInt16OpBase(TestPutAlongAxisOp):
 
 
 class TestPutAlongAxisUInt8OpBase(TestPutAlongAxisInt16OpBase):
+    no_need_check_grad = True
+
     def set_type(self):
         self.dtype = np.uint8
         self.x_type = "uint8"
@@ -1338,10 +1342,6 @@ class TestPutAlongAxisAPIMulInt64(unittest.TestCase):
         run(paddle.CUDAPlace(0))
 
 
-@unittest.skipIf(
-    not core.is_compiled_with_cuda(),
-    "core is not compiled with CUDA",
-)
 class TestPutAlongAxisAPIReduceLowBits(unittest.TestCase):
     def setUp(self):
         np.random.seed(0)
@@ -1421,10 +1421,6 @@ class TestPutAlongAxisAPIReduceLowBits(unittest.TestCase):
         run(paddle.CUDAPlace(0))
 
 
-@unittest.skipIf(
-    not core.is_compiled_with_cuda(),
-    "core is not compiled with CUDA",
-)
 class TestPutAlongAxisAPIMulInt16(TestPutAlongAxisAPIReduceLowBits):
     def setup_dtype(self):
         self.dtype = 'int16'
@@ -1432,10 +1428,6 @@ class TestPutAlongAxisAPIMulInt16(TestPutAlongAxisAPIReduceLowBits):
         self.value_type = "int16"
 
 
-@unittest.skipIf(
-    not core.is_compiled_with_cuda(),
-    "core is not compiled with CUDA",
-)
 class TestPutAlongAxisAPIMinInt16(TestPutAlongAxisAPIMulInt16):
     def set_range(self):
         self.ranges = [-32760, 32761]
@@ -1444,19 +1436,11 @@ class TestPutAlongAxisAPIMinInt16(TestPutAlongAxisAPIMulInt16):
         self.op = "amin"
 
 
-@unittest.skipIf(
-    not core.is_compiled_with_cuda(),
-    "core is not compiled with CUDA",
-)
 class TestPutAlongAxisAPIMaxInt16(TestPutAlongAxisAPIMinInt16):
     def set_op_to_test(self):
         self.op = "amax"
 
 
-@unittest.skipIf(
-    not core.is_compiled_with_cuda(),
-    "core is not compiled with CUDA",
-)
 class TestPutAlongAxisAPIMinUInt8(TestPutAlongAxisAPIReduceLowBits):
     def set_range(self):
         self.ranges = [0, 256]
@@ -1465,10 +1449,6 @@ class TestPutAlongAxisAPIMinUInt8(TestPutAlongAxisAPIReduceLowBits):
         self.op = "amin"
 
 
-@unittest.skipIf(
-    not core.is_compiled_with_cuda(),
-    "core is not compiled with CUDA",
-)
 class TestPutAlongAxisAPIMaxUInt8(TestPutAlongAxisAPIMinUInt8):
 
     def set_op_to_test(self):

--- a/test/legacy_test/test_put_along_axis_op.py
+++ b/test/legacy_test/test_put_along_axis_op.py
@@ -79,6 +79,89 @@ class TestPutAlongAxisOp(OpTest):
         self.axis_type = "int64"
 
 
+class TestPutAlongAxisInt16OpBase(TestPutAlongAxisOp):
+    def init_data(self):
+        self.set_type()
+        self.x_shape = (10, 10, 10)
+        self.index_type = "int64"
+        self.axis = 1
+        self.axis_type = "int64"
+        self.set_reduce_op()
+        self.set_value_and_index()
+
+    def set_type(self):
+        self.dtype = np.int16
+        self.x_type = "int16"
+        self.value_type = "int16"
+
+    def set_value_and_index(self):
+        self.value = np.array([99]).astype(self.value_type)
+        self.index = np.array([[[0]]]).astype(self.index_type)
+
+    def set_reduce_op(self):
+        self.reduce_op = "assign"
+
+    def test_check_grad(self):
+        """int16 can not pass check_grad data type check for op multiply"""
+        pass
+
+
+class TestPutAlongAxisUInt8OpBase(TestPutAlongAxisInt16OpBase):
+    def set_type(self):
+        self.dtype = np.uint8
+        self.x_type = "uint8"
+        self.value_type = "uint8"
+
+    def set_reduce_op(self):
+        self.reduce_op = "assign"
+        self.value = np.array([127]).astype(self.value_type)
+        self.index = np.array([[[0]]]).astype(self.index_type)
+
+    def test_check_grad(self):
+        """uint8 can not pass check_grad data type check for op multiply"""
+        pass
+
+
+class TestPutAlongAxisInt16OpAdd(TestPutAlongAxisInt16OpBase):
+    def set_reduce_op(self):
+        self.reduce_op = "add"
+
+
+class TestPutAlongAxisInt16OpMul(TestPutAlongAxisInt16OpBase):
+    def set_reduce_op(self):
+        self.reduce_op = "mul"
+
+
+class TestPutAlongAxisInt16OpAMin(TestPutAlongAxisInt16OpBase):
+    def set_reduce_op(self):
+        self.reduce_op = "amin"
+
+
+class TestPutAlongAxisInt16OpAMax(TestPutAlongAxisInt16OpBase):
+    def set_reduce_op(self):
+        self.reduce_op = "amax"
+
+
+class TestPutAlongAxisUInt8OpAdd(TestPutAlongAxisUInt8OpBase):
+    def set_reduce_op(self):
+        self.reduce_op = "add"
+
+
+class TestPutAlongAxisUInt8OpMul(TestPutAlongAxisUInt8OpBase):
+    def set_reduce_op(self):
+        self.reduce_op = "mul"
+
+
+class TestPutAlongAxisUInt8OpAMin(TestPutAlongAxisUInt8OpBase):
+    def set_reduce_op(self):
+        self.reduce_op = "amin"
+
+
+class TestPutAlongAxisUInt8OpAMax(TestPutAlongAxisUInt8OpBase):
+    def set_reduce_op(self):
+        self.reduce_op = "amax"
+
+
 class TestPutAlongAxisFP16Op(TestPutAlongAxisOp):
     def init_data(self):
         self.dtype = np.float16
@@ -1259,31 +1342,63 @@ class TestPutAlongAxisAPIMulInt64(unittest.TestCase):
     not core.is_compiled_with_cuda(),
     "core is not compiled with CUDA",
 )
-class TestPutAlongAxisAPIMulUint8(unittest.TestCase):
+class TestPutAlongAxisAPIReduceLowBits(unittest.TestCase):
     def setUp(self):
         np.random.seed(0)
-        self.dtype = 'uint8'
-        self.x_type = "uint8"
-        self.x_shape = (10, 10, 10)
-        self.value_type = "uint8"
-        self.value = np.random.randint(1, 5, (5, 5, 5)).astype(self.value_type)
+        self.setup_dtype()
+        self.set_range()
+        self.set_op_to_test()
+        self.x_shape = (8, 8)
+        self.value = np.random.randint(*self.ranges, (8, 8)).astype(
+            self.value_type
+        )
         self.index_type = "int64"
-        self.index = np.zeros((5, 5, 5)).astype(self.index_type)
+        self.index = np.ones((8, 8), dtype=np.int64)
         self.axis = 1
         self.axis_type = "int64"
         self.op_type = "put_along_axis"
         self.prim_op_type = "prim"
         self.public_python_api = paddle.tensor.put_along_axis
         self.python_api = paddle.tensor.put_along_axis
-        self.xnp = np.random.randint(1, 5, self.x_shape).astype(self.x_type)
+        self.xnp = np.random.randint(*self.ranges, self.x_shape).astype(
+            self.x_type
+        )
+        self.input_filter()
         # numpy put_along_axis is an inplace operation.
         self.target = copy.deepcopy(self.xnp)
-        for i in range(5):
-            for j in range(5):
-                for k in range(5):
-                    self.target[i, self.index[i, j, k], k] *= self.value[
-                        i, j, k
-                    ]
+        if self.op == "mul":
+            host_op = lambda x, y: x * y
+        elif self.op == "amax":
+            host_op = lambda x, y: max(x, y)
+        elif self.op == "amin":
+            host_op = lambda x, y: min(x, y)
+        else:
+            raise ValueError(
+                f"Unsupported reduce op for put along axis: {self.op}"
+            )
+        for i in range(8):
+            for j in range(8):
+                self.target[i, self.index[i, j]] = host_op(
+                    self.target[i, self.index[i, j]], self.value[i, j]
+                )
+
+    def input_filter(self):
+        if self.ranges[0] <= 0 and self.op == "mul":
+            is_zero = self.values == 0
+            self.values[is_zero] = 1
+            is_zero = self.xnp == 0
+            self.xnp[is_zero] = 1
+
+    def setup_dtype(self):
+        self.dtype = 'uint8'
+        self.x_type = "uint8"
+        self.value_type = "uint8"
+
+    def set_range(self):
+        self.ranges = [1, 5]
+
+    def set_op_to_test(self):
+        self.op = "mul"
 
     def test_api_dygraph(self):
         def run(place):
@@ -1296,7 +1411,7 @@ class TestPutAlongAxisAPIMulUint8(unittest.TestCase):
                 index_tensor,
                 value_tensor,
                 self.axis,
-                "mul",
+                self.op,
                 True,
                 False,
             )
@@ -1304,6 +1419,60 @@ class TestPutAlongAxisAPIMulUint8(unittest.TestCase):
             np.testing.assert_allclose(out.numpy(), out_ref, rtol=0.001)
 
         run(paddle.CUDAPlace(0))
+
+
+@unittest.skipIf(
+    not core.is_compiled_with_cuda(),
+    "core is not compiled with CUDA",
+)
+class TestPutAlongAxisAPIMulInt16(TestPutAlongAxisAPIReduceLowBits):
+    def setup_dtype(self):
+        self.dtype = 'int16'
+        self.x_type = "int16"
+        self.value_type = "int16"
+
+
+@unittest.skipIf(
+    not core.is_compiled_with_cuda(),
+    "core is not compiled with CUDA",
+)
+class TestPutAlongAxisAPIMinInt16(TestPutAlongAxisAPIMulInt16):
+    def set_range(self):
+        self.ranges = [-32760, 32761]
+
+    def set_op_to_test(self):
+        self.op = "amin"
+
+
+@unittest.skipIf(
+    not core.is_compiled_with_cuda(),
+    "core is not compiled with CUDA",
+)
+class TestPutAlongAxisAPIMaxInt16(TestPutAlongAxisAPIMinInt16):
+    def set_op_to_test(self):
+        self.op = "amax"
+
+
+@unittest.skipIf(
+    not core.is_compiled_with_cuda(),
+    "core is not compiled with CUDA",
+)
+class TestPutAlongAxisAPIMinUInt8(TestPutAlongAxisAPIReduceLowBits):
+    def set_range(self):
+        self.ranges = [0, 256]
+
+    def set_op_to_test(self):
+        self.op = "amin"
+
+
+@unittest.skipIf(
+    not core.is_compiled_with_cuda(),
+    "core is not compiled with CUDA",
+)
+class TestPutAlongAxisAPIMaxUInt8(TestPutAlongAxisAPIMinUInt8):
+
+    def set_op_to_test(self):
+        self.op = "amax"
 
 
 class TestPutAlongAxisDynamicShape(unittest.TestCase):

--- a/test/legacy_test/test_put_along_axis_op.py
+++ b/test/legacy_test/test_put_along_axis_op.py
@@ -1418,7 +1418,11 @@ class TestPutAlongAxisAPIReduceLowBits(unittest.TestCase):
             out_ref = self.target
             np.testing.assert_allclose(out.numpy(), out_ref, rtol=0.001)
 
-        run(paddle.CUDAPlace(0))
+        run(
+            paddle.CUDAPlace(0)
+            if core.is_compiled_with_cuda()
+            else paddle.CPUPlace()
+        )
 
 
 class TestPutAlongAxisAPIMulInt16(TestPutAlongAxisAPIReduceLowBits):

--- a/test/legacy_test/test_take_along_axis_op.py
+++ b/test/legacy_test/test_take_along_axis_op.py
@@ -462,6 +462,42 @@ class TestTakeAlongAxis_ZeroSize(OpTest):
             )
 
 
+class TestTakeAlongAxisInt16(TestTakeAlongAxisOp):
+    def init_data(self):
+        self.dtype = np.int16
+        self.x_type = "int16"
+        self.x_shape = (5, 5, 5)
+        self.index_type = "int32"
+        self.axis = 2
+        dim_size = self.x_shape[self.axis]
+        self.index = np.random.randint(
+            -dim_size, dim_size, size=(5, 1, 1)
+        ).astype(self.index_type)
+        self.axis_type = "int64"
+
+    def test_check_grad(self):
+        """int16 does not require and allow for grad check"""
+        pass
+
+
+class TestTakeAlongAxisUInt8(TestTakeAlongAxisOp):
+    def init_data(self):
+        self.dtype = np.uint8
+        self.x_type = "uint8"
+        self.x_shape = (5, 5, 5)
+        self.index_type = "int32"
+        self.axis = 2
+        dim_size = self.x_shape[self.axis]
+        self.index = np.random.randint(
+            -dim_size, dim_size, size=(5, 1, 1)
+        ).astype(self.index_type)
+        self.axis_type = "int64"
+
+    def test_check_grad(self):
+        """uint8 does not require and allow for grad check"""
+        pass
+
+
 if __name__ == "__main__":
     paddle.enable_static()
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Operator Mechanism


### PR Types
Improvements


### Description

在 gpu_primitives 中增加了 uint8/int16 两种类型的 CUDA atomic functions，针对如下三种操作：
- min
- max
- multiply

对应的单测通过 `put_along_axis` 相关的单测实现并进行。同时兼容升级了 `put_along_axis` 以及 `take_along_axis`，增加了 int16/uint8 的支持（除了上述三种op，add也增加了支持，只不过add的atomic uint8 int16操作原本就存在），删除了某些文件中 SFINAE 实现的 uint8/int16 绕过。除此之外，这些 atomic primitives 本身由于无法导出单测，本人在 [Enigmatisms/atomic_playground](https://github.com/Enigmatisms/atomic_playground) 中导出了 Python 接口，与 host 端 `std::accumulation` 结果进行了大量对比测试。

Pcard-89620
