### PR TITLE
[CodeStyle] `black -> ruff format` migration - part 23

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,7 +71,7 @@ repos:
 
             | setup.py
 
-            # | paddle/.+
+            | paddle/.+
 
             # | python/paddle/[a-c].+
 
@@ -127,7 +127,7 @@ repos:
 
             # | setup.py
 
-            | paddle/.+
+            # | paddle/.+
 
             | python/paddle/[a-c].+
 

--- a/paddle/fluid/eager/auto_code_generator/generator/codegen_utils.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/codegen_utils.py
@@ -328,9 +328,9 @@ def ParseYamlArgs(string):
             else None
         )
 
-        assert (
-            arg_type in yaml_types_mapping.keys()
-        ), f"The argument type {arg_type} in yaml config is not supported in yaml_types_mapping."
+        assert arg_type in yaml_types_mapping.keys(), (
+            f"The argument type {arg_type} in yaml config is not supported in yaml_types_mapping."
+        )
         if arg_type in ["DataLayout"] and default_value is not None:
             default_value = f"paddle::experimental::{default_value}"
         if arg_type in ["DataType"] and default_value is not None:
@@ -369,9 +369,9 @@ def ParseYamlReturns(string):
         else:
             ret_type = ret.strip()
 
-        assert (
-            ret_type in yaml_types_mapping.keys()
-        ), f"The return type {ret_type} in yaml config is not supported in yaml_types_mapping."
+        assert ret_type in yaml_types_mapping.keys(), (
+            f"The return type {ret_type} in yaml config is not supported in yaml_types_mapping."
+        )
         ret_type = yaml_types_mapping[ret_type]
 
         assert "Tensor" in ret_type, AssertMessage("Tensor", ret_type)
@@ -481,30 +481,18 @@ class FunctionGeneratorBase:
         self.forward_api_name = ""
         self.python_api_info = {}
 
-        self.orig_forward_inputs_list = (
-            []
-        )  # [ [arg_name, arg_type, orig_position], ...]
-        self.orig_forward_attrs_list = (
-            []
-        )  # [ [attr_name, attr_type, default_value, orig_position], ...]
-        self.orig_forward_returns_list = (
-            []
-        )  # [ [ret_name, ret_type, orig_position], ...]
+        self.orig_forward_inputs_list = []  # [ [arg_name, arg_type, orig_position], ...]
+        self.orig_forward_attrs_list = []  # [ [attr_name, attr_type, default_value, orig_position], ...]
+        self.orig_forward_returns_list = []  # [ [ret_name, ret_type, orig_position], ...]
 
         # Processed Forward Data
-        self.forward_inputs_position_map = (
-            {}
-        )  # { "name" : [type, fwd_position] }
-        self.forward_outputs_position_map = (
-            {}
-        )  # { "name" : [type, fwd_position] }
+        self.forward_inputs_position_map = {}  # { "name" : [type, fwd_position] }
+        self.forward_outputs_position_map = {}  # { "name" : [type, fwd_position] }
 
         # Special Op Attributes
         self.optional_inputs = []  # [name, ...]
         self.no_need_buffers = []  # [name, ...]
-        self.composite_func_info = (
-            {}
-        )  # {name: func_name, args: [input_name, ...]}
+        self.composite_func_info = {}  # {name: func_name, args: [input_name, ...]}
         self.intermediate_outputs = []  # [name, ...]
         self.forward_inplace_map = {}  # {name : name, ...}
         self.args_alias_map = {}  # {arg_name: alias_vector, ...}
@@ -611,15 +599,15 @@ class FunctionGeneratorBase:
         elif 'backward_op' in forward_api_contents.keys():
             self.forward_api_name = forward_api_contents['backward_op']
 
-        assert (
-            'args' in forward_api_contents.keys()
-        ), 'Unable to find "args" in forward_api_contents keys'
+        assert 'args' in forward_api_contents.keys(), (
+            'Unable to find "args" in forward_api_contents keys'
+        )
 
         forward_args_str = forward_api_contents['args']
 
-        assert (
-            'output' in forward_api_contents.keys()
-        ), 'Unable to find "output" in forward_api_contents keys'
+        assert 'output' in forward_api_contents.keys(), (
+            'Unable to find "output" in forward_api_contents keys'
+        )
 
         forward_returns_str = forward_api_contents['output']
         if 'python_api' in forward_api_contents.keys():

--- a/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
@@ -925,36 +925,18 @@ class DygraphFunctionGeneratorBase(FunctionGeneratorBase):
         self.backward_forward_str = ""
         self.backward_api_name = ""
 
-        self.forward_attrs_list = (
-            []
-        )  # [ [attr_name, attr_type, default_value, orig_position], ...]
-        self.forward_inputs_list = (
-            []
-        )  # [ [arg_name, arg_type, orig_position], ...]
-        self.forward_returns_list = (
-            []
-        )  # [ [ret_name, ret_type, orig_position], ...]
+        self.forward_attrs_list = []  # [ [attr_name, attr_type, default_value, orig_position], ...]
+        self.forward_inputs_list = []  # [ [arg_name, arg_type, orig_position], ...]
+        self.forward_returns_list = []  # [ [ret_name, ret_type, orig_position], ...]
 
-        self.backward_attrs_list = (
-            []
-        )  # [ [attr_name, attr_type, default_value, orig_position], ...]
-        self.backward_inputs_list = (
-            []
-        )  # [ [arg_name, arg_type, orig_position], ...]
-        self.backward_returns_list = (
-            []
-        )  # [ [ret_name, ret_type, orig_position], ...]
+        self.backward_attrs_list = []  # [ [attr_name, attr_type, default_value, orig_position], ...]
+        self.backward_inputs_list = []  # [ [arg_name, arg_type, orig_position], ...]
+        self.backward_returns_list = []  # [ [ret_name, ret_type, orig_position], ...]
 
         # SlotNameMatched Backward Data
-        self.backward_forward_inputs_map = (
-            {}
-        )  # { "name" : [type, is_fwd_input, orig_position] ...}
-        self.backward_grad_inputs_map = (
-            {}
-        )  # { "name" : [type, fwd_position, orig_position] ...}
-        self.backward_grad_outputs_map = (
-            {}
-        )  # { "name" : [type, fwd_position, orig_position] ...}
+        self.backward_forward_inputs_map = {}  # { "name" : [type, is_fwd_input, orig_position] ...}
+        self.backward_grad_inputs_map = {}  # { "name" : [type, fwd_position, orig_position] ...}
+        self.backward_grad_outputs_map = {}  # { "name" : [type, fwd_position, orig_position] ...}
 
         self.backward_inplace_map = {}  # {name : name, ...}
 
@@ -974,26 +956,26 @@ class DygraphFunctionGeneratorBase(FunctionGeneratorBase):
             'op' in forward_api_contents
             or 'backward_op' in forward_api_contents
         ), 'Unable to find "op" in ops.yaml'
-        assert (
-            'args' in forward_api_contents
-        ), 'Unable to find "args" in ops.yaml'
-        assert (
-            'output' in forward_api_contents
-        ), 'Unable to find "output" in ops.yaml'
+        assert 'args' in forward_api_contents, (
+            'Unable to find "args" in ops.yaml'
+        )
+        assert 'output' in forward_api_contents, (
+            'Unable to find "output" in ops.yaml'
+        )
 
         if grad_api_contents is not None:
-            assert (
-                'backward' in forward_api_contents
-            ), 'Unable to find "backward" in ops.yaml'
-            assert (
-                'args' in grad_api_contents
-            ), 'Unable to find "args" in backward.yaml'
-            assert (
-                'output' in grad_api_contents
-            ), 'Unable to find "output" in backward.yaml'
-            assert (
-                'forward' in grad_api_contents
-            ), 'Unable to find "forward" in backward.yaml'
+            assert 'backward' in forward_api_contents, (
+                'Unable to find "backward" in ops.yaml'
+            )
+            assert 'args' in grad_api_contents, (
+                'Unable to find "args" in backward.yaml'
+            )
+            assert 'output' in grad_api_contents, (
+                'Unable to find "output" in backward.yaml'
+            )
+            assert 'forward' in grad_api_contents, (
+                'Unable to find "forward" in backward.yaml'
+            )
 
     def ForwardsValidationCheck(self):
         forward_inputs_list = self.forward_inputs_list
@@ -1158,10 +1140,10 @@ class DygraphFunctionGeneratorBase(FunctionGeneratorBase):
             backward_fwd_name = FindForwardName(backward_input_name)
             if backward_fwd_name:
                 # Grad Input
-                assert (
-                    backward_fwd_name in forward_outputs_position_map
-                ), AssertMessage(
-                    backward_fwd_name, forward_outputs_position_map.keys()
+                assert backward_fwd_name in forward_outputs_position_map, (
+                    AssertMessage(
+                        backward_fwd_name, forward_outputs_position_map.keys()
+                    )
                 )
                 matched_forward_output_type = forward_outputs_position_map[
                     backward_fwd_name
@@ -1207,13 +1189,13 @@ class DygraphFunctionGeneratorBase(FunctionGeneratorBase):
             backward_output_pos = backward_output[2]
 
             backward_fwd_name = FindForwardName(backward_output_name)
-            assert (
-                backward_fwd_name is not None
-            ), f"Detected {backward_fwd_name} = None"
-            assert (
-                backward_fwd_name in forward_inputs_position_map
-            ), AssertMessage(
-                backward_fwd_name, forward_inputs_position_map.keys()
+            assert backward_fwd_name is not None, (
+                f"Detected {backward_fwd_name} = None"
+            )
+            assert backward_fwd_name in forward_inputs_position_map, (
+                AssertMessage(
+                    backward_fwd_name, forward_inputs_position_map.keys()
+                )
             )
 
             matched_forward_input_type = forward_inputs_position_map[
@@ -1711,14 +1693,14 @@ class DygraphForwardFunctionGenerator(DygraphFunctionGeneratorBase):
                 for key, value in self.forward_inplace_map.items():
                     if key not in self.forward_inputs_position_map:
                         key = FindRenameForwardName(key)
-                        assert (
-                            key in self.forward_inputs_position_map
-                        ), f"{key} not in {self.forward_api_name} forward_inputs_position_map"
+                        assert key in self.forward_inputs_position_map, (
+                            f"{key} not in {self.forward_api_name} forward_inputs_position_map"
+                        )
                     if value not in self.forward_outputs_position_map:
                         value = FindRenameForwardName(value)
-                        assert (
-                            value in self.forward_outputs_position_map
-                        ), f"{value} not in {self.forward_api_name} forward_outputs_position_map"
+                        assert value in self.forward_outputs_position_map, (
+                            f"{value} not in {self.forward_api_name} forward_outputs_position_map"
+                        )
                     forward_inplace_map[key] = value
                 self.forward_inplace_map = forward_inplace_map
             else:

--- a/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
@@ -545,9 +545,9 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
                 and parsing_function_name == "CastPyArg2Place"
             ):
                 expected_place_str = ""
-                assert (
-                    name == "place"
-                ), "Only support 'place' as template argument name in FUNCTION_SET_DEVICE_TEMPLATE."
+                assert name == "place", (
+                    "Only support 'place' as template argument name in FUNCTION_SET_DEVICE_TEMPLATE."
+                )
             if need_parse_python_api_args:
                 keywords = _get_keywords(name, args_alias_map)
                 if default_value is None:

--- a/paddle/fluid/operators/generator/generate_op.py
+++ b/paddle/fluid/operators/generator/generate_op.py
@@ -100,9 +100,9 @@ def process_scalar(op_item, scalar_configs):
         for attr_item in op_item['attrs']:
             if attr_item['name'] in scalar_configs:
                 attr_type = attr_item['typename']
-                assert (
-                    attr_type in scalar_map
-                ), f"{op_item['name']}'s scalar in op_compat.yaml is error, the data_type of {attr_item['name']} is expected to be one of Scalar, Scalar(float), Scalar(int) or Scalar(int64_t), but now is {attr_type}."
+                assert attr_type in scalar_map, (
+                    f"{op_item['name']}'s scalar in op_compat.yaml is error, the data_type of {attr_item['name']} is expected to be one of Scalar, Scalar(float), Scalar(int) or Scalar(int64_t), but now is {attr_type}."
+                )
 
                 scalar_config = scalar_configs[attr_item['name']]
                 attr_item['is_support_tensor'] = (
@@ -135,9 +135,9 @@ def process_int_array(op_item, int_array_configs):
         for attr_item in op_item['attrs']:
             if attr_item['name'] in int_array_configs:
                 attr_type = attr_item['typename']
-                assert (
-                    attr_item['typename'] == "IntArray"
-                ), f"{op_item['name']}'s int_array in op_compat.yaml is error, the data_type of {attr_item['name']} is expected to be one of IntArray, but now is {attr_type}."
+                assert attr_item['typename'] == "IntArray", (
+                    f"{op_item['name']}'s int_array in op_compat.yaml is error, the data_type of {attr_item['name']} is expected to be one of IntArray, but now is {attr_type}."
+                )
 
                 int_array_config = int_array_configs[attr_item['name']]
                 attr_item['is_support_tensor'] = (
@@ -498,9 +498,9 @@ def parse_drop_empty_grad(op_fluid_list: list, bw_op_dict: dict):
                                 'drop_empty_grad'
                             ] = False
                             bws_has_out_grad = True
-                assert (
-                    bws_has_out_grad
-                ), f'''{bw_names} with {op_comp_map['drop_empty_grad']} is not existed in output_dict '''
+                assert bws_has_out_grad, (
+                    f'''{bw_names} with {op_comp_map['drop_empty_grad']} is not existed in output_dict '''
+                )
 
 
 def parse_get_expected_kerneltype(

--- a/paddle/fluid/operators/generator/parse_utils.py
+++ b/paddle/fluid/operators/generator/parse_utils.py
@@ -53,21 +53,21 @@ def parse_arg(op_name: str, s: str) -> dict[str, str]:
     2. typename name = default_value
     """
     typename, rest = (item.strip() for item in s.split(" ", 1))
-    assert (
-        len(typename) > 0
-    ), f"The arg typename should not be empty. Please check the args of {op_name} in yaml."
+    assert len(typename) > 0, (
+        f"The arg typename should not be empty. Please check the args of {op_name} in yaml."
+    )
 
-    assert (
-        rest.count("=") <= 1
-    ), f"There is more than 1 = in an arg in {op_name}"
+    assert rest.count("=") <= 1, (
+        f"There is more than 1 = in an arg in {op_name}"
+    )
     if rest.count("=") == 1:
         name, default_value = (item.strip() for item in rest.split("=", 1))
-        assert (
-            len(name) > 0
-        ), f"The arg name should not be empty. Please check the args of {op_name} in yaml."
-        assert (
-            len(default_value) > 0
-        ), f"The default value should not be empty. Please check the args of {op_name} in yaml."
+        assert len(name) > 0, (
+            f"The arg name should not be empty. Please check the args of {op_name} in yaml."
+        )
+        assert len(default_value) > 0, (
+            f"The default value should not be empty. Please check the args of {op_name} in yaml."
+        )
         return {
             "typename": typename,
             "name": name,
@@ -75,9 +75,9 @@ def parse_arg(op_name: str, s: str) -> dict[str, str]:
         }
     else:
         name = rest.strip()
-        assert (
-            len(name) > 0
-        ), f"The arg name should not be empty. Please check the args of {op_name} in yaml."
+        assert len(name) > 0, (
+            f"The arg name should not be empty. Please check the args of {op_name} in yaml."
+        )
         return {"typename": typename, "name": name}
 
 
@@ -110,9 +110,9 @@ def parse_input_and_attr(
             inputs.append(item)
         elif is_attr(typename):
             if met_attr_with_default_value:
-                assert (
-                    "default_value" in item
-                ), f"{op_name}: Arguments with default value should not precede those without default value"
+                assert "default_value" in item, (
+                    f"{op_name}: Arguments with default value should not precede those without default value"
+                )
             elif "default_value" in item:
                 met_attr_with_default_value = True
             if typename.startswith('Scalar') or typename == 'IntArray':
@@ -249,14 +249,18 @@ def parse_kernel(op_name: str, kernel_config: dict[str, Any]) -> dict[str, Any]:
                 'selected_rows',
                 'sparse_coo',
                 'sparse_csr',
-            ], f"{op_name} : Invalid input tensor type ('{item}'), here we only support 'dense', 'selected_rows', 'sparse_coo' and 'sparse_csr'."
+            ], (
+                f"{op_name} : Invalid input tensor type ('{item}'), here we only support 'dense', 'selected_rows', 'sparse_coo' and 'sparse_csr'."
+            )
         for item in outputs:
             assert item in [
                 'dense',
                 'selected_rows',
                 'sparse_coo',
                 'sparse_csr',
-            ], f"{op_name} : Invalid output tensor type ('{item}'), here we only support 'dense', 'selected_rows', 'sparse_coo' and 'sparse_csr'."
+            ], (
+                f"{op_name} : Invalid output tensor type ('{item}'), here we only support 'dense', 'selected_rows', 'sparse_coo' and 'sparse_csr'."
+            )
 
         return (inputs, outputs)
 
@@ -389,21 +393,21 @@ def check_op_config(op_entry, op_name):
         'dispatch',
     )
     for key in op_entry.keys():
-        assert (
-            key in base_key_set
-        ), f"Op ({op_name}) : invalid key ({key}) in Yaml."
+        assert key in base_key_set, (
+            f"Op ({op_name}) : invalid key ({key}) in Yaml."
+        )
 
     if 'infer_meta' in op_entry:
         for infer_meta_key in op_entry['infer_meta'].keys():
-            assert (
-                infer_meta_key in infer_meta_key_set
-            ), f"Op ({op_name}) : invalid key (infer_meta.{infer_meta_key}) in Yaml."
+            assert infer_meta_key in infer_meta_key_set, (
+                f"Op ({op_name}) : invalid key (infer_meta.{infer_meta_key}) in Yaml."
+            )
 
     if 'kernel' in op_entry:
         for kernel_key in op_entry['kernel'].keys():
-            assert (
-                kernel_key in kernel_key_set
-            ), f"Op ({op_name}) : invalid key (kernel.{kernel_key}) in Yaml."
+            assert kernel_key in kernel_key_set, (
+                f"Op ({op_name}) : invalid key (kernel.{kernel_key}) in Yaml."
+            )
 
 
 def parse_op_entry(op_entry: dict[str, Any], name_field="op"):
@@ -419,16 +423,16 @@ def parse_op_entry(op_entry: dict[str, Any], name_field="op"):
             typename = attr["typename"]
             default_value = attr["default_value"]
             if typename == "DataType":
-                assert (
-                    "DataType" in default_value
-                ), f"invalid DataType default value in {op_name}"
+                assert "DataType" in default_value, (
+                    f"invalid DataType default value in {op_name}"
+                )
                 # remove namespace
                 default_value = default_value[default_value.find("DataType") :]
                 attr["default_value"] = default_value
             elif typename == "DataLayout":
-                assert (
-                    "DataLayout" in default_value
-                ), f"invalid DataLayout default value in {op_name}"
+                assert "DataLayout" in default_value, (
+                    f"invalid DataLayout default value in {op_name}"
+                )
                 default_value = default_value[
                     default_value.find("DataLayout") :
                 ]
@@ -447,9 +451,9 @@ def parse_op_entry(op_entry: dict[str, Any], name_field="op"):
     if "optional" in op_entry:
         optional_args = parse_plain_list(op_entry["optional"])
         for name in optional_args:
-            assert (
-                name in input_names or name in output_names
-            ), f"{op_name} has an optional tensor: '{name}' which is not in input or output."
+            assert name in input_names or name in output_names, (
+                f"{op_name} has an optional tensor: '{name}' which is not in input or output."
+            )
         for input in inputs:
             if input["name"] in optional_args:
                 input["optional"] = True
@@ -463,9 +467,9 @@ def parse_op_entry(op_entry: dict[str, Any], name_field="op"):
     if "intermediate" in op_entry:
         intermediate_outs = parse_plain_list(op_entry["intermediate"])
         for name in intermediate_outs:
-            assert (
-                name in output_names
-            ), f"{op_name} has an intermediate output: '{name}' which is not an output."
+            assert name in output_names, (
+                f"{op_name} has an intermediate output: '{name}' which is not an output."
+            )
         for output in outputs:
             if output["name"] in intermediate_outs:
                 output["intermediate"] = True
@@ -476,9 +480,9 @@ def parse_op_entry(op_entry: dict[str, Any], name_field="op"):
     if "no_need_buffer" in op_entry:
         no_buffer_args = parse_plain_list(op_entry["no_need_buffer"])
         for name in no_buffer_args:
-            assert (
-                name in input_names
-            ), f"{op_name} has an no buffer input: '{name}' which is not an input."
+            assert name in input_names, (
+                f"{op_name} has an no buffer input: '{name}' which is not an input."
+            )
         for input in inputs:
             if input["name"] in no_buffer_args:
                 input["no_need_buffer"] = True
@@ -496,18 +500,18 @@ def parse_op_entry(op_entry: dict[str, Any], name_field="op"):
         if "skip_transform" in data_trans:
             skip_trans_args = parse_plain_list(data_trans["skip_transform"])
             for name in skip_trans_args:
-                assert (
-                    name in input_names
-                ), f"{op_name} has an skip_transform input: '{name}' which is not an input."
+                assert name in input_names, (
+                    f"{op_name} has an skip_transform input: '{name}' which is not an input."
+                )
             data_trans["skip_transform"] = skip_trans_args
         if "support_trans_dtype" in data_trans:
             support_trans_args = parse_plain_list(
                 data_trans["support_trans_dtype"]
             )
             for name in support_trans_args:
-                assert (
-                    name in input_names
-                ), f"{op_name} has an support_trans_dtype input: '{name}' which is not an input."
+                assert name in input_names, (
+                    f"{op_name} has an support_trans_dtype input: '{name}' which is not an input."
+                )
             data_trans["support_trans_dtype"] = support_trans_args
         for input in inputs:
             if input["name"] in skip_trans_args:
@@ -632,9 +636,9 @@ def validate_backward_attrs(op, forward_attrs, backward_attrs):
     # this is a not-that-clean trick to allow backward op to has more attrs
     # than the forward op , as long as they all have default value
     for i in range(-num_exceptional_attrs, 0):
-        assert (
-            "default_value" in backward_attrs[i]
-        ), f"{op} has exceptional attr without default value"
+        assert "default_value" in backward_attrs[i], (
+            f"{op} has exceptional attr without default value"
+        )
 
 
 def validate_backward_inputs(
@@ -652,9 +656,9 @@ def validate_backward_inputs(
 def validate_backward_outputs(op, forward_inputs, backward_outputs):
     if op in ['fused_attention_grad']:
         return
-    assert len(backward_outputs) <= len(
-        forward_inputs
-    ), f"{op} has too many outputs"
+    assert len(backward_outputs) <= len(forward_inputs), (
+        f"{op} has too many outputs"
+    )
 
 
 def cross_validate(ops):
@@ -673,21 +677,21 @@ def cross_validate(ops):
                         f"Something Wrong here, {name}'s forward op ({fw_name}) does not claim {name} as its backward."
                     )
                 else:
-                    assert (
-                        fw_op["backward"] == name
-                    ), f"{name}: backward and forward name mismatch"
+                    assert fw_op["backward"] == name, (
+                        f"{name}: backward and forward name mismatch"
+                    )
 
-                assert len(fw_call["inputs"]) <= len(
-                    fw_op["inputs"]
-                ), f"{name}: forward call has more inputs than the op "
+                assert len(fw_call["inputs"]) <= len(fw_op["inputs"]), (
+                    f"{name}: forward call has more inputs than the op "
+                )
                 for input, input_ in zip(fw_call["inputs"], fw_op["inputs"]):
-                    assert (
-                        input["typename"] == input_["typename"]
-                    ), f"type mismatch in {name} and {fw_name}"
+                    assert input["typename"] == input_["typename"], (
+                        f"type mismatch in {name} and {fw_name}"
+                    )
 
-                assert len(fw_call["attrs"]) <= len(
-                    fw_op["attrs"]
-                ), f"{name}: forward call has more attrs than the op "
+                assert len(fw_call["attrs"]) <= len(fw_op["attrs"]), (
+                    f"{name}: forward call has more attrs than the op "
+                )
                 for attr, attr_ in zip(fw_call["attrs"], fw_op["attrs"]):
                     if attr["typename"] == "Scalar":
                         # special case for Scalar, fw_call can omit the type
@@ -695,16 +699,16 @@ def cross_validate(ops):
                             r"Scalar(\(\w+\))*", attr_["typename"]
                         ), f"type mismatch in {name} and {fw_name}"
                     else:
-                        assert (
-                            attr["typename"] == attr_["typename"]
-                        ), f"type mismatch in {name} and {fw_name}"
+                        assert attr["typename"] == attr_["typename"], (
+                            f"type mismatch in {name} and {fw_name}"
+                        )
 
-                assert len(fw_call["outputs"]) == len(
-                    fw_op["outputs"]
-                ), f"{name}: requires outputs number of fw_call == fw_op, but received {fw_call['outputs']} != {fw_op['outputs']}"
+                assert len(fw_call["outputs"]) == len(fw_op["outputs"]), (
+                    f"{name}: requires outputs number of fw_call == fw_op, but received {fw_call['outputs']} != {fw_op['outputs']}"
+                )
                 for output, output_ in zip(
                     fw_call["outputs"], fw_op["outputs"]
                 ):
-                    assert (
-                        output["typename"] == output_["typename"]
-                    ), f"type mismatch in {name} and {fw_name}"
+                    assert output["typename"] == output_["typename"], (
+                        f"type mismatch in {name} and {fw_name}"
+                    )

--- a/paddle/fluid/pir/dialect/op_generator/cache_grad_op_symbol_shape_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/cache_grad_op_symbol_shape_gen.py
@@ -205,7 +205,9 @@ class CacheGradOpSymbolShapeCodeGen:
                     assert (
                         mutable_attribute_name
                         in op_info_item.mutable_attribute_name_list
-                    ), f"{mutable_attribute_name} is not found in {op_info_item.backward_name}'s mutable_attribute name list."
+                    ), (
+                        f"{mutable_attribute_name} is not found in {op_info_item.backward_name}'s mutable_attribute name list."
+                    )
                     index = len(
                         op_info_item.input_name_list
                     ) + op_info_item.mutable_attribute_name_list.index(

--- a/paddle/fluid/pir/dialect/op_generator/op_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_gen.py
@@ -612,13 +612,13 @@ class OpInfoParser:
             return None
 
     def cross_check(self, name_list, type_list, optional_list=None):
-        assert len(name_list) == len(
-            type_list
-        ), "name list size != type list size."
+        assert len(name_list) == len(type_list), (
+            "name list size != type list size."
+        )
         if optional_list is not None:
-            assert len(name_list) == len(
-                optional_list
-            ), "type list size != optional list size."
+            assert len(name_list) == len(optional_list), (
+                "type list size != optional list size."
+            )
 
     def parse_custom_verify(self):
         if 'custom_verify' in self.op_yaml_item:
@@ -807,9 +807,9 @@ class OpInfoParser:
         }
         type_list = []
         for input_info in self.op_yaml_item['inputs']:
-            assert (
-                input_info['typename'] in input_types_map
-            ), f"{self.op_phi_name} : Input type error: the input type only support Tensor and Tensor[], but now is {input_info['typename']}."
+            assert input_info['typename'] in input_types_map, (
+                f"{self.op_phi_name} : Input type error: the input type only support Tensor and Tensor[], but now is {input_info['typename']}."
+            )
             type_list.append(input_types_map[input_info['typename']])
         return type_list
 
@@ -825,9 +825,9 @@ class OpInfoParser:
             }
             type_list = []
             for input_info in self.op_yaml_item['inputs']:
-                assert (
-                    input_info['typename'] in input_types_map
-                ), f"{self.op_phi_name} : Input type error: the input type only support Tensor and Tensor[], but now is {input_info['typename']}."
+                assert input_info['typename'] in input_types_map, (
+                    f"{self.op_phi_name} : Input type error: the input type only support Tensor and Tensor[], but now is {input_info['typename']}."
+                )
                 type_list.append(input_types_map[input_info['typename']])
 
             if self.kernel_map is None:
@@ -847,9 +847,9 @@ class OpInfoParser:
                 inputs = self.kernel_map['dispatch'][kernel_func_name][0]
                 type_list = []
                 for input_info in inputs:
-                    assert (
-                        input_info in input_types_map
-                    ), f"{self.op_phi_name} : Input type error: the input type only support dense and selected_rows, but now is {input_info}."
+                    assert input_info in input_types_map, (
+                        f"{self.op_phi_name} : Input type error: the input type only support dense and selected_rows, but now is {input_info}."
+                    )
                     type_list.append(input_types_map[input_info])
 
                 type_dict[kernel_func_name] = type_list
@@ -887,9 +887,9 @@ class OpInfoParser:
         }
         type_list = []
         for output_info in self.op_yaml_item['outputs']:
-            assert (
-                output_info['typename'] in output_type_map
-            ), f"{self.op_phi_name} : Output type error: the output type only support Tensor and Tensor[], but now is {output_info['typename']}."
+            assert output_info['typename'] in output_type_map, (
+                f"{self.op_phi_name} : Output type error: the output type only support Tensor and Tensor[], but now is {output_info['typename']}."
+            )
             type_list.append(output_type_map[output_info['typename']])
         return type_list
 
@@ -907,9 +907,9 @@ class OpInfoParser:
             }
             type_list = []
             for output_info in self.op_yaml_item['outputs']:
-                assert (
-                    output_info['typename'] in output_type_map
-                ), f"{self.op_phi_name} : Output type error: the output type only support Tensor and Tensor[], but now is {output_info['typename']}."
+                assert output_info['typename'] in output_type_map, (
+                    f"{self.op_phi_name} : Output type error: the output type only support Tensor and Tensor[], but now is {output_info['typename']}."
+                )
                 type_list.append(output_type_map[output_info['typename']])
 
             if self.kernel_map is None:
@@ -929,9 +929,9 @@ class OpInfoParser:
                 outputs = self.kernel_map['dispatch'][kernel_func_name][1]
                 type_list = []
                 for output_info in outputs:
-                    assert (
-                        output_info in output_type_map
-                    ), f"{self.op_phi_name} : Input type error: the input type only support dense and selected_rows, but now is {output_info}."
+                    assert output_info in output_type_map, (
+                        f"{self.op_phi_name} : Input type error: the input type only support dense and selected_rows, but now is {output_info}."
+                    )
                     type_list.append(output_type_map[output_info])
 
                 type_dict[kernel_func_name] = type_list
@@ -989,9 +989,9 @@ class OpInfoParser:
     def parse_attribute_build_arg_type_list(self):
         type_list = []
         for attribute_info in self.op_yaml_item['attrs']:
-            assert (
-                attribute_info['typename'] in self.attr_types_map
-            ), f"{self.op_phi_name} : Attr type error."
+            assert attribute_info['typename'] in self.attr_types_map, (
+                f"{self.op_phi_name} : Attr type error."
+            )
 
             # Scalar & IntArray has data_type
             temp_type = self.attr_types_map[attribute_info['typename']][1]
@@ -1020,9 +1020,9 @@ class OpInfoParser:
     def parse_attribute_gen_arg_type_list(self):
         type_list = []
         for attribute_info in self.op_yaml_item['attrs']:
-            assert (
-                attribute_info['typename'] in self.attr_types_map
-            ), f"{self.op_phi_name} : Attr type error."
+            assert attribute_info['typename'] in self.attr_types_map, (
+                f"{self.op_phi_name} : Attr type error."
+            )
 
             temp_type = self.attr_types_map[attribute_info['typename']][1]
             type_list.append(self.get_phi_dtype_name(temp_type))
@@ -1031,9 +1031,9 @@ class OpInfoParser:
     def parse_attribute_type_list(self):
         type_list = []
         for attribute_info in self.op_yaml_item['attrs']:
-            assert (
-                attribute_info['typename'] in self.attr_types_map
-            ), f"{self.op_phi_name} : Attr type error."
+            assert attribute_info['typename'] in self.attr_types_map, (
+                f"{self.op_phi_name} : Attr type error."
+            )
             type_list.append(self.attr_types_map[attribute_info['typename']][0])
         return type_list
 
@@ -1137,9 +1137,9 @@ def get_input_grad_semantic(
 
         bwd_fwd_input_list = bwd_op_info.forward_input_name_list
         if bwd_fwd_input_list is not None:
-            assert (
-                len(bwd_fwd_input_list) == num_inputs
-            ), "Configuration of forward op and backward op is not match."
+            assert len(bwd_fwd_input_list) == num_inputs, (
+                "Configuration of forward op and backward op is not match."
+            )
             for i in range(num_inputs):
                 if bwd_fwd_input_list[i] in bwd_output_list_new:
                     input_grad_semantics.append("true")
@@ -1218,9 +1218,9 @@ pir::Attribute attr_{attr_name} = pir::ArrayAttribute::get(pir::IrContext::Insta
     attr_str = ""
     array_attr_type = "pir::ArrayAttribute<"
     for idx in range(len(onednn_extra_args)):
-        assert (
-            onednn_extra_args[idx]['typename'] in attr_types_map
-        ), f"{onednn_extra_args[idx]['typename']} : Attr type error."
+        assert onednn_extra_args[idx]['typename'] in attr_types_map, (
+            f"{onednn_extra_args[idx]['typename']} : Attr type error."
+        )
         extra_arg_type = attr_types_map[onednn_extra_args[idx]['typename']][0]
 
         if array_attr_type in extra_arg_type:

--- a/paddle/fluid/pir/dialect/op_generator/ops_onednn_extra_parser.py
+++ b/paddle/fluid/pir/dialect/op_generator/ops_onednn_extra_parser.py
@@ -33,21 +33,21 @@ def parse_arg(op_name: str, s: str) -> dict[str, str]:
     2. typename name = default_value
     """
     typename, rest = (item.strip() for item in s.split(" ", 1))
-    assert (
-        len(typename) > 0
-    ), f"The arg typename should not be empty. Please check the args of {op_name} in yaml."
+    assert len(typename) > 0, (
+        f"The arg typename should not be empty. Please check the args of {op_name} in yaml."
+    )
 
-    assert (
-        rest.count("=") <= 1
-    ), f"There is more than 1 = in an arg in {op_name}"
+    assert rest.count("=") <= 1, (
+        f"There is more than 1 = in an arg in {op_name}"
+    )
     if rest.count("=") == 1:
         name, default_value = (item.strip() for item in rest.split("=", 1))
-        assert (
-            len(name) > 0
-        ), f"The arg name should not be empty. Please check the args of {op_name} in yaml."
-        assert (
-            len(default_value) > 0
-        ), f"The default value should not be empty. Please check the args of {op_name} in yaml."
+        assert len(name) > 0, (
+            f"The arg name should not be empty. Please check the args of {op_name} in yaml."
+        )
+        assert len(default_value) > 0, (
+            f"The default value should not be empty. Please check the args of {op_name} in yaml."
+        )
         return {
             "typename": typename,
             "name": name,
@@ -55,9 +55,9 @@ def parse_arg(op_name: str, s: str) -> dict[str, str]:
         }
     else:
         name = rest.strip()
-        assert (
-            len(name) > 0
-        ), f"The arg name should not be empty. Please check the args of {op_name} in yaml."
+        assert len(name) > 0, (
+            f"The arg name should not be empty. Please check the args of {op_name} in yaml."
+        )
         return {"typename": typename, "name": name}
 
 

--- a/paddle/phi/api/generator/api_base.py
+++ b/paddle/phi/api/generator/api_base.py
@@ -310,9 +310,9 @@ class BaseAPI:
         inputs = {'names': [], 'input_info': {}}
         attrs = {'names': [], 'attr_info': {}}
         args_str = args_config.strip()
-        assert args_str.startswith('(') and args_str.endswith(
-            ')'
-        ), f"Args declaration should start with '(' and end with ')', please check the args of {api_name} in yaml."
+        assert args_str.startswith('(') and args_str.endswith(')'), (
+            f"Args declaration should start with '(' and end with ')', please check the args of {api_name} in yaml."
+        )
         args_str = args_str[1:-1]
         pattern = re.compile(r',(?![^{]*\})')  # support int[] a={1,3}
         args_list = re.split(pattern, args_str.strip())
@@ -369,12 +369,12 @@ class BaseAPI:
             for in_type_symbol, in_type in input_types_map.items():
                 if type_and_name[0] == in_type_symbol:
                     input_name = type_and_name[1].strip()
-                    assert (
-                        len(input_name) > 0
-                    ), f"The input tensor name should not be empty. Please check the args of {api_name} in yaml."
-                    assert (
-                        len(attrs['names']) == 0
-                    ), f"The input Tensor should appear before attributes. please check the position of {api_name}:input({input_name}) in yaml"
+                    assert len(input_name) > 0, (
+                        f"The input tensor name should not be empty. Please check the args of {api_name} in yaml."
+                    )
+                    assert len(attrs['names']) == 0, (
+                        f"The input Tensor should appear before attributes. please check the position of {api_name}:input({input_name}) in yaml"
+                    )
 
                     if input_name in optional_vars:
                         in_type = optional_types_trans[in_type_symbol]
@@ -390,9 +390,9 @@ class BaseAPI:
             for attr_type_symbol, attr_type in attr_types_map.items():
                 if type_and_name[0] == attr_type_symbol:
                     attr_name = item[len(attr_type_symbol) :].strip()
-                    assert (
-                        len(attr_name) > 0
-                    ), f"The attribute name should not be empty. Please check the args of {api_name} in yaml."
+                    assert len(attr_name) > 0, (
+                        f"The attribute name should not be empty. Please check the args of {api_name} in yaml."
+                    )
                     default_value = None
                     if '=' in attr_name:
                         attr_infos = attr_name.split('=')
@@ -421,14 +421,14 @@ class BaseAPI:
                 r"(?P<out_type>[a-zA-Z0-9_[\]]+)\s*(?P<name>\([a-zA-Z0-9_@]+\))?\s*(?P<expr>\{[^\}]+\})?",
                 output_item,
             )
-            assert (
-                result is not None
-            ), f"{api_name} : the output config parse error."
+            assert result is not None, (
+                f"{api_name} : the output config parse error."
+            )
             out_type = result.group('out_type')
-            assert (
-                out_type in output_type_map
-            ), f"{api_name} : Output type error: the output type only support Tensor and Tensor[], \
+            assert out_type in output_type_map, (
+                f"{api_name} : Output type error: the output type only support Tensor and Tensor[], \
                   but now is {out_type}."
+            )
 
             out_name = (
                 'out'
@@ -508,14 +508,18 @@ class BaseAPI:
                     'selected_rows',
                     'sparse_coo',
                     'sparse_csr',
-                ], f"{self.api} : Invalid input tensor type ('{item}'), here we only support 'dense', 'selected_rows', 'sparse_coo' and 'sparse_csr'."
+                ], (
+                    f"{self.api} : Invalid input tensor type ('{item}'), here we only support 'dense', 'selected_rows', 'sparse_coo' and 'sparse_csr'."
+                )
             for item in outputs:
                 assert item in [
                     'dense',
                     'selected_rows',
                     'sparse_coo',
                     'sparse_csr',
-                ], f"{self.api} : Invalid output tensor type ('{item}'), here we only support 'dense', 'selected_rows', 'sparse_coo' and 'sparse_csr'."
+                ], (
+                    f"{self.api} : Invalid output tensor type ('{item}'), here we only support 'dense', 'selected_rows', 'sparse_coo' and 'sparse_csr'."
+                )
 
             return (inputs, outputs)
 
@@ -570,13 +574,15 @@ PADDLE_API {self.get_return_type(inplace_flag=True)} {api_func_name}({self.get_d
         if self.kernel['backend'] is not None:
             if '>' in self.kernel['backend']:
                 vars_list = self.kernel['backend'].split('>')
-                assert (
-                    len(vars_list) == 2
-                ), f"{self.api} api: The number of params to set backend with '>' only allows 2, but received {len(vars_list)}."
+                assert len(vars_list) == 2, (
+                    f"{self.api} api: The number of params to set backend with '>' only allows 2, but received {len(vars_list)}."
+                )
                 assert (vars_list[0].strip() in self.attrs['names']) and (
                     self.attrs['attr_info'][vars_list[0].strip()][0]
                     == 'const Place&'
-                ), f"{self.api} api: When use '>' to set kernel backend, the first param should be a attribute with Place type."
+                ), (
+                    f"{self.api} api: When use '>' to set kernel backend, the first param should be a attribute with Place type."
+                )
                 backend_select_code = f"""
   kernel_backend = ParseBackendWithInputOrder({vars_list[0].strip()}, {vars_list[1].strip()});
 """
@@ -608,19 +614,19 @@ PADDLE_API {self.get_return_type(inplace_flag=True)} {api_func_name}({self.get_d
         attr_data_type_count = 0
         for attr_name in attrs['names']:
             if attrs['attr_info'][attr_name][0] == 'const Place&':
-                assert (
-                    kernel['backend'] is not None
-                ), f"{api} api: When there is a parameter with 'Place' type in attributes, you must set backend of kernel manually."
+                assert kernel['backend'] is not None, (
+                    f"{api} api: When there is a parameter with 'Place' type in attributes, you must set backend of kernel manually."
+                )
                 attr_backend_count = attr_backend_count + 1
             if attrs['attr_info'][attr_name][0] == 'DataLayout':
-                assert (
-                    kernel['layout'] is not None
-                ), f"{api} api: When there is a parameter with 'DataLayout' type in attributes, you must set layout of kernel manually."
+                assert kernel['layout'] is not None, (
+                    f"{api} api: When there is a parameter with 'DataLayout' type in attributes, you must set layout of kernel manually."
+                )
                 attr_layout_count = attr_layout_count + 1
             if attrs['attr_info'][attr_name][0] == 'DataType':
-                assert (
-                    kernel['data_type'] is not None
-                ), f"{api} api: When there is a parameter with 'DataType' type in attributes, you must set data_type of kernel manually."
+                assert kernel['data_type'] is not None, (
+                    f"{api} api: When there is a parameter with 'DataType' type in attributes, you must set data_type of kernel manually."
+                )
                 attr_data_type_count = attr_data_type_count + 1
 
         # preprocess kernel configures
@@ -629,14 +635,16 @@ PADDLE_API {self.get_return_type(inplace_flag=True)} {api_func_name}({self.get_d
         if kernel['layout'] is not None:
             if '>' in kernel['layout']:
                 vars_list = kernel['layout'].split('>')
-                assert (
-                    len(vars_list) == 2
-                ), f"{api} api: The number of params to set layout with '>' only allows 2, but received {len(vars_list)}."
+                assert len(vars_list) == 2, (
+                    f"{api} api: The number of params to set layout with '>' only allows 2, but received {len(vars_list)}."
+                )
                 assert (
                     vars_list[0].strip() in attrs['names']
                     and attrs['attr_info'][vars_list[0].strip()][0]
                     == 'DataLayout'
-                ), f"{api} api: When use '>' to set kernel layout, the first param should be a attribute with DataLayout type."
+                ), (
+                    f"{api} api: When use '>' to set kernel layout, the first param should be a attribute with DataLayout type."
+                )
                 kernel_select_code = (
                     kernel_select_code
                     + f"""
@@ -646,9 +654,9 @@ PADDLE_API {self.get_return_type(inplace_flag=True)} {api_func_name}({self.get_d
 
             else:
                 vars_list = kernel['layout'].split(',')
-                assert (
-                    len(vars_list) == 1
-                ), f"{api} api: The number of params to set layout must be 1, but received {len(vars_list)}."
+                assert len(vars_list) == 1, (
+                    f"{api} api: The number of params to set layout must be 1, but received {len(vars_list)}."
+                )
                 kernel_select_code = (
                     kernel_select_code
                     + f"""
@@ -670,14 +678,16 @@ PADDLE_API {self.get_return_type(inplace_flag=True)} {api_func_name}({self.get_d
 
             if '>' in kernel['data_type']:
                 vars_list = kernel['data_type'].split('>')
-                assert (
-                    len(vars_list) == 2
-                ), f"{api} api: The number of params to set data_type with '>' only allows 2, but received {len(vars_list)}."
+                assert len(vars_list) == 2, (
+                    f"{api} api: The number of params to set data_type with '>' only allows 2, but received {len(vars_list)}."
+                )
                 assert (
                     vars_list[0].strip() in attrs['names']
                     and attrs['attr_info'][vars_list[0].strip()][0]
                     == 'DataType'
-                ), f"{api} api: When use '>' to set kernel data_type, the first param should be a attribute with DataType type."
+                ), (
+                    f"{api} api: When use '>' to set kernel data_type, the first param should be a attribute with DataType type."
+                )
                 kernel_select_code = (
                     kernel_select_code
                     + f"""
@@ -687,9 +697,9 @@ PADDLE_API {self.get_return_type(inplace_flag=True)} {api_func_name}({self.get_d
 
             else:
                 vars_list = kernel['data_type'].split(',')
-                assert (
-                    len(vars_list) == 1
-                ), f"{api} api: The number of params to set data_type only allows 1, but received {len(vars_list)}."
+                assert len(vars_list) == 1, (
+                    f"{api} api: The number of params to set data_type only allows 1, but received {len(vars_list)}."
+                )
                 kernel_select_code = (
                     kernel_select_code
                     + f"""
@@ -698,9 +708,9 @@ PADDLE_API {self.get_return_type(inplace_flag=True)} {api_func_name}({self.get_d
                 )
 
         if len(input_names) == 0:
-            assert (
-                attr_backend_count > 0 and attr_data_type_count > 0
-            ), f"{api} api: When there is no input tensor, the args must have 'Place' and 'DataType'."
+            assert attr_backend_count > 0 and attr_data_type_count > 0, (
+                f"{api} api: When there is no input tensor, the args must have 'Place' and 'DataType'."
+            )
 
         kernel_select_args = ""
         for input_name in input_names:
@@ -1520,9 +1530,9 @@ PADDLE_API {self.get_return_type(inplace_flag=True)} {api_func_name}({self.get_d
 {code_indent}  {self.gene_return_code()}"""
 
     def get_condition_code(self, kernel_name):
-        assert self.kernel['dispatch'][
-            kernel_name
-        ], f"{self.api} api: the tensor type of inputs and outputs for kernel isn't set, see also 'kernel:func' of 'scale' in ops.yaml."
+        assert self.kernel['dispatch'][kernel_name], (
+            f"{self.api} api: the tensor type of inputs and outputs for kernel isn't set, see also 'kernel:func' of 'scale' in ops.yaml."
+        )
         input_types = self.kernel['dispatch'][kernel_name][0]
         condition_list = []
         for i, in_type in enumerate(input_types):

--- a/paddle/phi/api/generator/api_gen.py
+++ b/paddle/phi/api/generator/api_gen.py
@@ -105,12 +105,12 @@ class ForwardAPI(BaseAPI):
                     result = re.search(r"(?P<in>\w+)\s*->\s*(?P<out>\w+)", item)
                     in_val = result.group('in')
                     out_val = result.group('out')
-                    assert (
-                        in_val in self.inputs['names']
-                    ), f"{self.api} : {mode} input error: the input var name('{in_val}') is not found in the input args of {self.api}."
-                    assert (
-                        out_val in self.outputs['names']
-                    ), f"{self.api} : {mode} output error: the output var name('{out_val}') is not found in the output args of {self.api}."
+                    assert in_val in self.inputs['names'], (
+                        f"{self.api} : {mode} input error: the input var name('{in_val}') is not found in the input args of {self.api}."
+                    )
+                    assert out_val in self.outputs['names'], (
+                        f"{self.api} : {mode} output error: the output var name('{out_val}') is not found in the output args of {self.api}."
+                    )
 
                     if mode == 'inplace':
                         inplace_map[out_val] = in_val
@@ -242,9 +242,9 @@ class ForwardAPI(BaseAPI):
                 return_type == 'std::vector<Tensor>'
                 or return_type == 'std::vector<Tensor>&'
             ):
-                assert (
-                    self.outputs['out_size_expr'][0] is not None
-                ), f"{self.api}: The out size expr : '{{expr}}' should be set when output has Tensor[]. You can refer 'split' api."
+                assert self.outputs['out_size_expr'][0] is not None, (
+                    f"{self.api}: The out size expr : '{{expr}}' should be set when output has Tensor[]. You can refer 'split' api."
+                )
                 output_create = (
                     output_create
                     + f"""
@@ -254,9 +254,9 @@ class ForwardAPI(BaseAPI):
                 return_type == 'paddle::optional<std::vector<Tensor>>'
                 or return_type == 'paddle::optional<std::vector<Tensor>>&'
             ):
-                assert (
-                    self.outputs['out_size_expr'][0] is not None
-                ), f"{self.api}: The out size expr : '{{expr}}' should be set when output has Tensor[]. You can refer 'split' api."
+                assert self.outputs['out_size_expr'][0] is not None, (
+                    f"{self.api}: The out size expr : '{{expr}}' should be set when output has Tensor[]. You can refer 'split' api."
+                )
                 output_create = (
                     output_create
                     + f"""
@@ -326,9 +326,9 @@ class ForwardAPI(BaseAPI):
                     get_out_code = f"std::get<{i}>(api_output).get_ptr()"
 
                 if out_dtype_list[i] == 'std::vector<Tensor>':
-                    assert (
-                        self.outputs['out_size_expr'][i] is not None
-                    ), f"{self.api}: The out size expr : '{{expr}}' should be set when output has Tensor[]. You can refer 'split' api."
+                    assert self.outputs['out_size_expr'][i] is not None, (
+                        f"{self.api}: The out size expr : '{{expr}}' should be set when output has Tensor[]. You can refer 'split' api."
+                    )
                     # Special case for inplace vector and inplace optional<vector>
                     if self.outputs['names'][i] in self.inplace_map:
                         set_out_func = "SetInplaceVectorKernelOutput"

--- a/paddle/phi/api/generator/backward_api_gen.py
+++ b/paddle/phi/api/generator/backward_api_gen.py
@@ -67,10 +67,10 @@ class BackwardAPI(BaseAPI):
             if input not in fw_inputs['names'] and input not in fw_outputs:
                 if input.endswith('_grad'):
                     original_name = input[:-5]
-                    assert (
-                        original_name in fw_outputs
-                    ), f"{self.api} : Input Tensor error: the input tensor({input}) of backward should be an input or output or grad of output in forward api. \
+                    assert original_name in fw_outputs, (
+                        f"{self.api} : Input Tensor error: the input tensor({input}) of backward should be an input or output or grad of output in forward api. \
                          Please check the forward of {self.api} in yaml."
+                    )
 
         # check the attributes of backward
         for attr in self.attrs['names']:
@@ -78,16 +78,16 @@ class BackwardAPI(BaseAPI):
                 attr in fw_attrs['names']
                 and self.attrs['attr_info'][attr][0]
                 == fw_attrs['attr_info'][attr][0]
-            ) or self.attrs['attr_info'][attr][
-                1
-            ] is not None, f"{self.api} : Attribute error: The attribute({attr}) of backward isn't consistent with forward api or doesn't have default value. \
+            ) or self.attrs['attr_info'][attr][1] is not None, (
+                f"{self.api} : Attribute error: The attribute({attr}) of backward isn't consistent with forward api or doesn't have default value. \
                  Please check the args of {self.api} in yaml."
+            )
 
         # check the output of backward
-        assert len(self.outputs['types']) <= len(
-            fw_inputs['names']
-        ), f"{self.api} : Output error: The number of outputs should be less then the number of inputs of forward api. \
+        assert len(self.outputs['types']) <= len(fw_inputs['names']), (
+            f"{self.api} : Output error: The number of outputs should be less then the number of inputs of forward api. \
              Please check the output of {self.api} in yaml."
+        )
 
     def get_declare_args(
         self, inplace_flag=False, grad_flag=False, append_input_out=False
@@ -181,9 +181,9 @@ PADDLE_API void {api_func_name}({self.get_declare_args()});
                 else 'SetSelectedRowsKernelOutput'
             )
             if out_dtype_list[0] == 'std::vector<Tensor>':
-                assert (
-                    self.outputs['out_size_expr'] is not None
-                ), f"{self.api}: The out size expr : '{{expr}}' should be set when output has Tensor[]. You can refer 'split' api."
+                assert self.outputs['out_size_expr'] is not None, (
+                    f"{self.api}: The out size expr : '{{expr}}' should be set when output has Tensor[]. You can refer 'split' api."
+                )
                 output_create = (
                     output_create
                     + f"""
@@ -238,9 +238,9 @@ PADDLE_API void {api_func_name}({self.get_declare_args()});
 {code_indent}  *{self.outputs['names'][i]} = {self.inplace_map[self.outputs['names'][i]]};"""
                         )
 
-                    assert (
-                        self.outputs['out_size_expr'][i] is not None
-                    ), f"{self.api}: The out size expr : '{{expr}}' should be set when output has Tensor[]. You can refer 'split' api."
+                    assert self.outputs['out_size_expr'][i] is not None, (
+                        f"{self.api}: The out size expr : '{{expr}}' should be set when output has Tensor[]. You can refer 'split' api."
+                    )
                     output_create = (
                         output_create
                         + f"""

--- a/paddle/phi/api/generator/dist_api_gen.py
+++ b/paddle/phi/api/generator/dist_api_gen.py
@@ -725,9 +725,9 @@ class DistForwardAPI(ForwardAPI):
         )
 
     def vector_output_size_assertion_check(self):
-        assert (
-            self.outputs['out_size_expr'] is not None
-        ), f"{self.api}: The out size expr : '{{expr}}' should be set when output has Tensor[]. You can refer 'split' api."
+        assert self.outputs['out_size_expr'] is not None, (
+            f"{self.api}: The out size expr : '{{expr}}' should be set when output has Tensor[]. You can refer 'split' api."
+        )
 
     def generate_non_computation_rank_clip_code(self) -> str:
         if len(self.inputs['names']) > 0:
@@ -785,13 +785,15 @@ class DistForwardAPI(ForwardAPI):
         if self.kernel['backend'] is not None:
             if '>' in self.kernel['backend']:
                 vars_list = self.kernel['backend'].split('>')
-                assert (
-                    len(vars_list) == 2
-                ), f"{self.api} api: The number of params to set backend with '>' only allows 2, but received {len(vars_list)}."
+                assert len(vars_list) == 2, (
+                    f"{self.api} api: The number of params to set backend with '>' only allows 2, but received {len(vars_list)}."
+                )
                 assert (vars_list[0].strip() in self.attrs['names']) and (
                     self.attrs['attr_info'][vars_list[0].strip()][0]
                     == 'const Place&'
-                ), f"{self.api} api: When use '>' to set kernel backend, the first param should be a attribute with Place type."
+                ), (
+                    f"{self.api} api: When use '>' to set kernel backend, the first param should be a attribute with Place type."
+                )
                 backend_select_code = f"""
     kernel_backend = ParseBackendWithInputOrder({vars_list[0].strip()}, {vars_list[1].strip()});
 """
@@ -825,19 +827,19 @@ class DistForwardAPI(ForwardAPI):
         attr_data_type_count = 0
         for attr_name in attrs['names']:
             if attrs['attr_info'][attr_name][0] == 'const Place&':
-                assert (
-                    kernel['backend'] is not None
-                ), f"{api} api: When there is a parameter with 'Place' type in attributes, you must set backend of kernel manually."
+                assert kernel['backend'] is not None, (
+                    f"{api} api: When there is a parameter with 'Place' type in attributes, you must set backend of kernel manually."
+                )
                 attr_backend_count = attr_backend_count + 1
             if attrs['attr_info'][attr_name][0] == 'DataLayout':
-                assert (
-                    kernel['layout'] is not None
-                ), f"{api} api: When there is a parameter with 'DataLayout' type in attributes, you must set layout of kernel manually."
+                assert kernel['layout'] is not None, (
+                    f"{api} api: When there is a parameter with 'DataLayout' type in attributes, you must set layout of kernel manually."
+                )
                 attr_layout_count = attr_layout_count + 1
             if attrs['attr_info'][attr_name][0] == 'DataType':
-                assert (
-                    kernel['data_type'] is not None
-                ), f"{api} api: When there is a parameter with 'DataType' type in attributes, you must set data_type of kernel manually."
+                assert kernel['data_type'] is not None, (
+                    f"{api} api: When there is a parameter with 'DataType' type in attributes, you must set data_type of kernel manually."
+                )
                 attr_data_type_count = attr_data_type_count + 1
 
         # preprocess kernel configures
@@ -846,14 +848,16 @@ class DistForwardAPI(ForwardAPI):
         if kernel['layout'] is not None:
             if '>' in kernel['layout']:
                 vars_list = kernel['layout'].split('>')
-                assert (
-                    len(vars_list) == 2
-                ), f"{api} api: The number of params to set layout with '>' only allows 2, but received {len(vars_list)}."
+                assert len(vars_list) == 2, (
+                    f"{api} api: The number of params to set layout with '>' only allows 2, but received {len(vars_list)}."
+                )
                 assert (
                     vars_list[0].strip() in attrs['names']
                     and attrs['attr_info'][vars_list[0].strip()][0]
                     == 'DataLayout'
-                ), f"{api} api: When use '>' to set kernel layout, the first param should be a attribute with DataLayout type."
+                ), (
+                    f"{api} api: When use '>' to set kernel layout, the first param should be a attribute with DataLayout type."
+                )
                 kernel_select_code = (
                     kernel_select_code
                     + f"""
@@ -863,9 +867,9 @@ class DistForwardAPI(ForwardAPI):
 
             else:
                 vars_list = kernel['layout'].split(',')
-                assert (
-                    len(vars_list) == 1
-                ), f"{api} api: The number of params to set layout must be 1, but received {len(vars_list)}."
+                assert len(vars_list) == 1, (
+                    f"{api} api: The number of params to set layout must be 1, but received {len(vars_list)}."
+                )
                 kernel_select_code = (
                     kernel_select_code
                     + f"""
@@ -887,14 +891,16 @@ class DistForwardAPI(ForwardAPI):
 
             if '>' in kernel['data_type']:
                 vars_list = kernel['data_type'].split('>')
-                assert (
-                    len(vars_list) == 2
-                ), f"{api} api: The number of params to set data_type with '>' only allows 2, but received {len(vars_list)}."
+                assert len(vars_list) == 2, (
+                    f"{api} api: The number of params to set data_type with '>' only allows 2, but received {len(vars_list)}."
+                )
                 assert (
                     vars_list[0].strip() in attrs['names']
                     and attrs['attr_info'][vars_list[0].strip()][0]
                     == 'DataType'
-                ), f"{api} api: When use '>' to set kernel data_type, the first param should be a attribute with DataType type."
+                ), (
+                    f"{api} api: When use '>' to set kernel data_type, the first param should be a attribute with DataType type."
+                )
                 kernel_select_code = (
                     kernel_select_code
                     + f"""
@@ -904,9 +910,9 @@ class DistForwardAPI(ForwardAPI):
 
             else:
                 vars_list = kernel['data_type'].split(',')
-                assert (
-                    len(vars_list) == 1
-                ), f"{api} api: The number of params to set data_type only allows 1, but received {len(vars_list)}."
+                assert len(vars_list) == 1, (
+                    f"{api} api: The number of params to set data_type only allows 1, but received {len(vars_list)}."
+                )
                 kernel_select_code = (
                     kernel_select_code
                     + f"""
@@ -915,9 +921,9 @@ class DistForwardAPI(ForwardAPI):
                 )
 
         if len(input_names) == 0:
-            assert (
-                attr_backend_count > 0 and attr_data_type_count > 0
-            ), f"{api} api: When there is no input tensor, the args must have 'Place' and 'DataType'."
+            assert attr_backend_count > 0 and attr_data_type_count > 0, (
+                f"{api} api: When there is no input tensor, the args must have 'Place' and 'DataType'."
+            )
 
         kernel_select_args = ""
         for input_name in input_names:

--- a/paddle/phi/api/generator/sparse_api_gen.py
+++ b/paddle/phi/api/generator/sparse_api_gen.py
@@ -351,9 +351,9 @@ class SparseAPI(ForwardAPI):
   {return_code}"""
 
     def get_condition_code(self, kernel_name):
-        assert self.kernel['dispatch'][
-            kernel_name
-        ], f"{self.api} api: the tensor type of inputs and outputs for kernel isn't set, see also 'kernel:func' of 'conv3d' in sparse_ops.yaml."
+        assert self.kernel['dispatch'][kernel_name], (
+            f"{self.api} api: the tensor type of inputs and outputs for kernel isn't set, see also 'kernel:func' of 'conv3d' in sparse_ops.yaml."
+        )
         input_types = self.kernel['dispatch'][kernel_name][0]
         sparse_type_map = {
             'sparse_coo': 'DataLayout::SPARSE_COO',

--- a/paddle/phi/api/generator/strings_api_gen.py
+++ b/paddle/phi/api/generator/strings_api_gen.py
@@ -251,9 +251,9 @@ class StringsAPI(ForwardAPI):
         attr_data_type_count = 0
         for attr_name in attrs['names']:
             if attrs['attr_info'][attr_name][0] == 'Backend':
-                assert (
-                    kernel['backend'] is not None
-                ), f"{api} api: When there is a parameter with 'Backend' type in attributes, you must set backend of kernel manually."
+                assert kernel['backend'] is not None, (
+                    f"{api} api: When there is a parameter with 'Backend' type in attributes, you must set backend of kernel manually."
+                )
                 attr_backend_count = attr_backend_count + 1
 
         # preprocess kernel configures
@@ -261,13 +261,15 @@ class StringsAPI(ForwardAPI):
         if kernel['backend'] is not None:
             if '>' in kernel['backend']:
                 vars_list = kernel['backend'].split('>')
-                assert (
-                    len(vars_list) == 2
-                ), f"{api} api: The number of params to set backend with '>' only allows 2, but received {len(vars_list)}."
+                assert len(vars_list) == 2, (
+                    f"{api} api: The number of params to set backend with '>' only allows 2, but received {len(vars_list)}."
+                )
                 assert (vars_list[0].strip() in attrs['names']) and (
                     attrs['attr_info'][vars_list[0].strip()][0]
                     == 'const Place&'
-                ), f"{api} api: When use '>' to set kernel backend, the first param should be a attribute with Place type."
+                ), (
+                    f"{api} api: When use '>' to set kernel backend, the first param should be a attribute with Place type."
+                )
                 kernel_select_code = (
                     kernel_select_code
                     + f"""

--- a/paddle/phi/api/generator/tensor_operants_gen.py
+++ b/paddle/phi/api/generator/tensor_operants_gen.py
@@ -489,14 +489,14 @@ class OperantsAPI(ForwardAPI):
     def get_declare_args_without_first_tensor(self, inplace_flag=False):
         func_name = self.get_api_func_name()
         declare_args = self.get_input_tensor_args(inplace_flag)
-        assert (
-            len(declare_args) >= 1
-        ), f"Error! Api {func_name} has no Tensor inputs"
+        assert len(declare_args) >= 1, (
+            f"Error! Api {func_name} has no Tensor inputs"
+        )
         first_input_type = " ".join(declare_args[0].split(" ")[:-1])
         # NOTE(HongyuJia): Do not consider "const paddle::optional<Tensor>&"
-        assert (
-            first_input_type == "const Tensor&"
-        ), f"Error! The first argument of Tensor Api {func_name} must be Tensor, but received {first_input_type}"
+        assert first_input_type == "const Tensor&", (
+            f"Error! The first argument of Tensor Api {func_name} must be Tensor, but received {first_input_type}"
+        )
         for name in self.attrs['names']:
             default_value = ''
             if self.attrs['attr_info'][name][1] is not None:
@@ -510,14 +510,14 @@ class OperantsAPI(ForwardAPI):
     def get_define_args_without_first_tensor(self, inplace_flag=False):
         func_name = self.get_api_func_name()
         define_args = self.get_input_tensor_args(inplace_flag)
-        assert (
-            len(define_args) >= 1
-        ), f"Error! Api {func_name} has no Tensor inputs"
+        assert len(define_args) >= 1, (
+            f"Error! Api {func_name} has no Tensor inputs"
+        )
         first_input_type = " ".join(define_args[0].split(" ")[:-1])
         # NOTE(HongyuJia): Do not consider "const paddle::optional<Tensor>&"
-        assert (
-            first_input_type == "const Tensor&"
-        ), f"Error! The first argument of Tensor Api {func_name} must be Tensor, but received {first_input_type}"
+        assert first_input_type == "const Tensor&", (
+            f"Error! The first argument of Tensor Api {func_name} must be Tensor, but received {first_input_type}"
+        )
         for name in self.attrs['names']:
             define_args.append(self.attrs['attr_info'][name][0] + ' ' + name)
         # remove first Tensor argument
@@ -525,9 +525,9 @@ class OperantsAPI(ForwardAPI):
 
     def gene_tensor_api_implementation(self):
         func_name = self.get_api_func_name()
-        assert (
-            len(self.inputs['names']) >= 1
-        ), f"Error! Api {func_name} has no Tensor inputs"
+        assert len(self.inputs['names']) >= 1, (
+            f"Error! Api {func_name} has no Tensor inputs"
+        )
         # remove first Tensor argument
         func_args = self.inputs['names'][1:] + self.attrs['names']
         if len(func_args) > 0:

--- a/paddle/phi/api/generator/wrapped_infermeta_gen.py
+++ b/paddle/phi/api/generator/wrapped_infermeta_gen.py
@@ -39,9 +39,9 @@ PD_REGISTER_INFER_META_FN({api.kernel['func'][0]}, phi::{api.infer_meta['func']}
             if kernel_params == api.infer_meta['param']:
                 return '', '', register_code
 
-            assert len(api.infer_meta['param']) <= len(
-                kernel_params
-            ), f"{api.api} api: Parameters error. The params of infer_meta should be a subset of kernel params."
+            assert len(api.infer_meta['param']) <= len(kernel_params), (
+                f"{api.api} api: Parameters error. The params of infer_meta should be a subset of kernel params."
+            )
 
             tensor_type_map = {
                 'const Tensor&': 'const MetaTensor&',

--- a/python/paddle/_paddle_docs.py
+++ b/python/paddle/_paddle_docs.py
@@ -74,6 +74,7 @@ def _parse_function_signature(
         if func_def.args.defaults and len(func_def.args.defaults) > (
             len(func_def.args.args) - len(func_def.args.defaults)
         ):
+
             idx = count - (
                 len(func_def.args.args) - len(func_def.args.defaults)
             )

--- a/python/paddle/_paddle_docs.py
+++ b/python/paddle/_paddle_docs.py
@@ -74,7 +74,6 @@ def _parse_function_signature(
         if func_def.args.defaults and len(func_def.args.defaults) > (
             len(func_def.args.args) - len(func_def.args.defaults)
         ):
-
             idx = count - (
                 len(func_def.args.args) - len(func_def.args.defaults)
             )


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

使用性能更好，格式化效果更佳的 ruff format 替代 black 作为新的 formatter，由于我们很早就已经集成了 ruff lint，因此只是减少依赖而不会增加依赖

<!--

## 核心优势

通过集成 Ruff format，开发者可以享受到以下优势：

- 通过去除 black 对 python 环境依赖，极大降低了升级 formatter 带来的成本，后续无需考虑开发者本地 python 环境即可一键升级
- ruff 由 Rust 驱动，大幅加速 format 时间，降低开发者使用开发工具链的时间成本，减少 CI 时间，提升工程效率
- 格式化后呈现可读性更佳的效果，使得开发者更专注于代码开发而无需关心格式，阅读者也能够更加赏心悦目，极大增加了潜在贡献者的贡献意愿
- ruff 极大程度地兼容了 black 的格式化效果，能够平滑地替换现有的 black 配置
- ruff 更新频次高，能够快速响应社区反馈，持续优化格式化效果
- ruff 团队 Astral 最近开发的 ty 能够提供更强大的类型检查能力，后续可能与 ruff 集成，提供更好的开发体验
- PyTorch 最近已经完成迁移，追平竞品（在代码风格这块，我们一直做到了超越竞品，这次不能落后）

-->