### PR TITLE
Support more hidden size choice in deep ep

### DIFF
--- a/paddle/fluid/distributed/collective/deep_ep/kernels/launch.cuh
+++ b/paddle/fluid/distributed/collective/deep_ep/kernels/launch.cuh
@@ -135,6 +135,12 @@
   } else if (hidden == 8192) {                     \
     constexpr size_t kHidden = 8192;               \
     __VA_ARGS__                                    \
+  } else if (hidden == 1536) {                     \
+    constexpr size_t kHidden = 1536;               \
+    __VA_ARGS__                                 \
+  } else if (hidden == 2048) {                     \
+    constexpr size_t kHidden = 2048;               \
+    __VA_ARGS__     
   } else {                                         \
     EP_HOST_ASSERT(false && "Unsupported hidden"); \
   }

--- a/paddle/fluid/distributed/collective/deep_ep/kernels/launch.cuh
+++ b/paddle/fluid/distributed/collective/deep_ep/kernels/launch.cuh
@@ -137,10 +137,10 @@
     __VA_ARGS__                                    \
   } else if (hidden == 1536) {                     \
     constexpr size_t kHidden = 1536;               \
-    __VA_ARGS__                                 \
+    __VA_ARGS__                                    \
   } else if (hidden == 2048) {                     \
     constexpr size_t kHidden = 2048;               \
-    __VA_ARGS__     
+    __VA_ARGS__                                    \
   } else {                                         \
     EP_HOST_ASSERT(false && "Unsupported hidden"); \
   }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Distributed Strategy

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
Support models whose hidden size is `2048` and `1536` in deep ep

Pcard-71500