### PR TITLE
[CodeStyle] `black -> ruff format` migration - part 25

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,7 +75,7 @@ repos:
 
             # | python/paddle/[a-c].+
 
-            # | python/paddle/de.+
+            | python/paddle/de.+
 
             # | python/paddle/distributed/a.+
 
@@ -131,7 +131,7 @@ repos:
 
             | python/paddle/[a-c].+
 
-            | python/paddle/de.+
+            # | python/paddle/de.+
 
             | python/paddle/distributed/a.+
 

--- a/python/paddle/_paddle_docs.py
+++ b/python/paddle/_paddle_docs.py
@@ -74,6 +74,7 @@ def _parse_function_signature(
         if func_def.args.defaults and len(func_def.args.defaults) > (
             len(func_def.args.args) - len(func_def.args.defaults)
         ):
+
             idx = count - (
                 len(func_def.args.args) - len(func_def.args.defaults)
             )

--- a/python/paddle/_paddle_docs.py
+++ b/python/paddle/_paddle_docs.py
@@ -74,7 +74,6 @@ def _parse_function_signature(
         if func_def.args.defaults and len(func_def.args.defaults) > (
             len(func_def.args.args) - len(func_def.args.defaults)
         ):
-
             idx = count - (
                 len(func_def.args.args) - len(func_def.args.defaults)
             )

--- a/python/paddle/decomposition/decomp.py
+++ b/python/paddle/decomposition/decomp.py
@@ -182,16 +182,16 @@ def _check_op_results(
                 f'when replace origin op {op_name} with composite rule, origin out dtype should be equal to new out dtype, '
                 f'but orig_out dtype={orig_dtype} and new_out dtype={new_dtype}'
             )
-            assert (
-                -1 not in new_shape
-            ), f'when replace origin op {op_name} with composite rule, composite out shape has -1.'
+            assert -1 not in new_shape, (
+                f'when replace origin op {op_name} with composite rule, composite out shape has -1.'
+            )
             assert orig_shape == new_shape, (
                 f'when replace origin op {op_name} with composite rule, origin out shape should be equal to new out shape, '
                 f'but orig_out shape={orig_shape} and new_out shape={new_shape}'
             )
-            assert not (orig_out is None) ^ (
-                new_out is None
-            ), "orig_out and new_out should match."
+            assert not (orig_out is None) ^ (new_out is None), (
+                "orig_out and new_out should match."
+            )
         return
 
 
@@ -261,9 +261,9 @@ def _check_op(
 
     bwd_op_input_names = bwd_op.get_input_names()
     bwd_inputs = [x.source() for x in bwd_op.operands()]
-    assert len(bwd_op_input_names) == len(
-        bwd_inputs
-    ), "backward op names do not match backward op inputs"
+    assert len(bwd_op_input_names) == len(bwd_inputs), (
+        "backward op names do not match backward op inputs"
+    )
     fwd_op_related_inputs_outputs = []
     for idx, name in enumerate(bwd_op_input_names):
         if "_grad" not in name:
@@ -417,14 +417,14 @@ def _prepare_grad_outputs(fwd_op, bwd_op):
     # check forward outputs and backward inputs
     fwd_outputs = fwd_op.results()
     fwd_output_names = fwd_op.get_output_names()
-    assert len(fwd_output_names) == len(
-        fwd_outputs
-    ), "forward op output names do not match forward op outputs"
+    assert len(fwd_output_names) == len(fwd_outputs), (
+        "forward op output names do not match forward op outputs"
+    )
     bwd_inputs = [x.source() for x in bwd_op.operands()]
     bwd_input_names = bwd_op.get_input_names()
-    assert len(bwd_input_names) == len(
-        bwd_inputs
-    ), "backward op input names do not match backward op inputs"
+    assert len(bwd_input_names) == len(bwd_inputs), (
+        "backward op input names do not match backward op inputs"
+    )
 
     # cut gradients from backward op's inputs
     fwd_inputs = [x.source() for x in fwd_op.operands()]
@@ -541,9 +541,9 @@ def _decomp_bwd_with_vjp(
                 res.append(grad_input[0])
             else:
                 res.append(pir.fake_value())
-        assert len(res) == len(
-            bwd_op.results()
-        ), "results of original backward op do not match results of decomposed backward op"
+        assert len(res) == len(bwd_op.results()), (
+            "results of original backward op do not match results of decomposed backward op"
+        )
 
         # step4: upgrade grad_var_to_var
         _upgrade_grad_var_to_var(
@@ -735,9 +735,9 @@ def _set_prim_state():
 
 
 def _reset_prim_state(state):
-    assert (
-        len(state) == 3
-    ), "state should contain fwd_prim_state, bwd_prim_state and pir_api_state"
+    assert len(state) == 3, (
+        "state should contain fwd_prim_state, bwd_prim_state and pir_api_state"
+    )
     core._set_prim_forward_enabled(state[0])
     core._set_prim_backward_enabled(state[1])
     paddle.framework.set_flags({"FLAGS_enable_pir_api": state[2]})

--- a/python/paddle/decomposition/recompute.py
+++ b/python/paddle/decomposition/recompute.py
@@ -243,13 +243,13 @@ class JudgeFusionLoop:
             return downstream_unrecomputable_ops
 
         for op in self.ops:
-            self.upstream_unrecomputable_ops_map[
-                op
-            ] |= _get_upstream_ops_recursively(op)
+            self.upstream_unrecomputable_ops_map[op] |= (
+                _get_upstream_ops_recursively(op)
+            )
         for op in reversed(self.ops):
-            self.downstream_unrecomputable_ops_map[
-                op
-            ] |= _get_downstream_ops_recursively(op)
+            self.downstream_unrecomputable_ops_map[op] |= (
+                _get_downstream_ops_recursively(op)
+            )
 
     def _has_unfusible_op_on_any_path(self, op1, op2):
         no_unfusible_op_on_path = (

--- a/python/paddle/decomposition/register.py
+++ b/python/paddle/decomposition/register.py
@@ -26,9 +26,9 @@ class Registry:
     def register(self, op_type, rule):
         assert isinstance(op_type, str)
         assert inspect.isfunction(rule)
-        assert (
-            op_type not in self.rules
-        ), f'name "{op_type}" should not be registered before.'
+        assert op_type not in self.rules, (
+            f'name "{op_type}" should not be registered before.'
+        )
         self.rules[op_type] = rule
 
     def lookup(self, op_type):

--- a/python/paddle/device/__init__.py
+++ b/python/paddle/device/__init__.py
@@ -683,18 +683,18 @@ def extract_device_id(device: _CustomPlaceLike, op_name: str) -> int:
             "Please input appropriate device again!"
         )
 
-    assert (
-        device_id >= 0
-    ), f"The device id must be not less than 0, but got id = {device_id}."
+    assert device_id >= 0, (
+        f"The device id must be not less than 0, but got id = {device_id}."
+    )
 
     if core.is_compiled_with_cuda():
-        assert (
-            device_id < device_count()
-        ), f"The device id {device_id} exceeds gpu card number {device_count()}"
+        assert device_id < device_count(), (
+            f"The device id {device_id} exceeds gpu card number {device_count()}"
+        )
     else:
-        assert device_id < core.get_custom_device_count(
-            device_type
-        ), f"The device id {device_id} exceeds {device_type} device card number {core.get_custom_device_count(device_type)}"
+        assert device_id < core.get_custom_device_count(device_type), (
+            f"The device id {device_id} exceeds {device_type} device card number {core.get_custom_device_count(device_type)}"
+        )
     return device_id
 
 

--- a/python/paddle/device/cuda/__init__.py
+++ b/python/paddle/device/cuda/__init__.py
@@ -253,18 +253,18 @@ def extract_cuda_device_id(device: _CudaPlaceLike, op_name: str) -> int:
             "Please input appropriate device again!"
         )
 
-    assert (
-        device_id >= 0
-    ), f"The device id must be not less than 0, but got id = {device_id}."
+    assert device_id >= 0, (
+        f"The device id must be not less than 0, but got id = {device_id}."
+    )
 
     if core.is_compiled_with_cuda():
-        assert (
-            device_id < device_count()
-        ), f"The device id {device_id} exceeds gpu card number {device_count()}"
+        assert device_id < device_count(), (
+            f"The device id {device_id} exceeds gpu card number {device_count()}"
+        )
     else:
-        assert device_id < core.get_custom_device_count(
-            device_type
-        ), f"The device id {device_id} exceeds {device_type} device card number {core.get_custom_device_count(device_type)}"
+        assert device_id < core.get_custom_device_count(device_type), (
+            f"The device id {device_id} exceeds {device_type} device card number {core.get_custom_device_count(device_type)}"
+        )
     return device_id
 
 

--- a/python/paddle/device/cuda/graphs.py
+++ b/python/paddle/device/cuda/graphs.py
@@ -42,9 +42,9 @@ cuda_graph_id = 0
 
 class CUDAGraph:
     def __init__(self, place=None, mode="thread_local", pool_id=None):
-        assert (
-            CoreCUDAGraph is not None
-        ), "CUDA Graph is only supported on PaddlePaddle compiled with NVIDIA GPU."
+        assert CoreCUDAGraph is not None, (
+            "CUDA Graph is only supported on PaddlePaddle compiled with NVIDIA GPU."
+        )
 
         self._graph = None
         if place is None:
@@ -73,9 +73,9 @@ class CUDAGraph:
         if not isinstance(dirname, (str, bytes)):
             dirname = dirname.name
         os.makedirs(name=dirname, exist_ok=True)
-        assert os.path.isdir(
-            dirname
-        ), f"The dirname {dirname} should be a directory"
+        assert os.path.isdir(dirname), (
+            f"The dirname {dirname} should be a directory"
+        )
         if flags is None:
             flags = 2047  # only all information. It can be any integer inside [1, 2048)
         self._graph.print_to_dot_files(dirname, flags)
@@ -238,16 +238,16 @@ def get_cuda_graph_sections(program):
 
     for idx, op in enumerate(block.ops):
         if op.type == 'conditional_block' or op.type == 'while':
-            assert (
-                op._cuda_graph_attr is None
-            ), "Cuda graph not support conditional block op and while op."
+            assert op._cuda_graph_attr is None, (
+                "Cuda graph not support conditional block op and while op."
+            )
         if op.has_attr('is_test') and op.attr('is_test'):
             is_test = True
         # find cuda graph sections
         if op._cuda_graph_attr is not None:
-            assert isinstance(
-                op._cuda_graph_attr, str
-            ), "cuda_graph_attr should be a str"
+            assert isinstance(op._cuda_graph_attr, str), (
+                "cuda_graph_attr should be a str"
+            )
             cuda_graph_attrs = op._cuda_graph_attr.split(';')
             assert len(cuda_graph_attrs) == 3, (
                 "cuda graph attr should have three fields: "
@@ -256,9 +256,9 @@ def get_cuda_graph_sections(program):
             local_cuda_graph_id = int(cuda_graph_attrs[2])
             if local_cuda_graph_id == current_cuda_graph_id:
                 if len(internal_section) > 0:
-                    assert len(internal_section) == len(
-                        internal_idx
-                    ), "len of internal section should be equal with len of internal idx"
+                    assert len(internal_section) == len(internal_idx), (
+                        "len of internal section should be equal with len of internal idx"
+                    )
                     for internal_op in internal_section:
                         loss_related = (
                             int(internal_op.attr(op_role_attr_name))
@@ -283,9 +283,9 @@ def get_cuda_graph_sections(program):
                             internal_section = []
                             internal_idx = []
                             # Beside clear the internal section, a new cuda graph section should be recorded
-                            assert len(current_section) == len(
-                                current_idx
-                            ), "num of section's op is not equal with the idx"
+                            assert len(current_section) == len(current_idx), (
+                                "num of section's op is not equal with the idx"
+                            )
                             if len(current_section) > 0:
                                 # store previous section
                                 cuda_graph_sections.append(current_section)
@@ -309,9 +309,9 @@ def get_cuda_graph_sections(program):
                 current_cuda_graph_id = (
                     local_cuda_graph_id  # start record a new section
                 )
-                assert len(current_section) == len(
-                    current_idx
-                ), "num of section's op is not equal with num of idx"
+                assert len(current_section) == len(current_idx), (
+                    "num of section's op is not equal with num of idx"
+                )
                 if len(current_section) > 0:
                     # store previous section
                     cuda_graph_sections.append(current_section)
@@ -324,9 +324,9 @@ def get_cuda_graph_sections(program):
             internal_idx.append(idx)
 
     # handle the last section
-    assert len(current_section) == len(
-        current_idx
-    ), "num of section's op is not equal with num of idx"
+    assert len(current_section) == len(current_idx), (
+        "num of section's op is not equal with num of idx"
+    )
     if len(current_section) > 0:
         # store previous section
         cuda_graph_sections.append(current_section)
@@ -377,9 +377,9 @@ def replace_cuda_graph_section(
             memory_pool_id = int(attrs[1])
             break
 
-    assert (
-        mode is not None and memory_pool_id is not None
-    ), "mode and memory pool id should be specified in cuda graph attr"
+    assert mode is not None and memory_pool_id is not None, (
+        "mode and memory pool id should be specified in cuda graph attr"
+    )
 
     cuda_graph_var = origin_block.create_var(
         name="cuda_graph_" + str(order),
@@ -445,9 +445,9 @@ def cuda_graph_transform(program):
     cuda_graph_sections, sections_idx, is_test = get_cuda_graph_sections(
         program
     )
-    assert len(cuda_graph_sections) == len(
-        sections_idx
-    ), "num of cuda graph sections is not equal with num of idx sections"
+    assert len(cuda_graph_sections) == len(sections_idx), (
+        "num of cuda graph sections is not equal with num of idx sections"
+    )
 
     # step 2: construct new program for each section and find inputs and outputs of each section.
     # The inputs are variables generated outside the section but will be used by this section.
@@ -461,9 +461,9 @@ def cuda_graph_transform(program):
         )
         ins_and_outs.append(ins_outs)
         section_programs.append(section_program)
-    assert len(section_programs) == len(
-        cuda_graph_sections
-    ), "the num of cuda graph sections should be equal with the num of new program"
+    assert len(section_programs) == len(cuda_graph_sections), (
+        "the num of cuda graph sections should be equal with the num of new program"
+    )
 
     # step 3: replace the ops in original program with run_program_op.
     # Will remove all ops in the section from origin program, and use run_program_op to replace them.

--- a/python/paddle/device/xpu/__init__.py
+++ b/python/paddle/device/xpu/__init__.py
@@ -121,12 +121,12 @@ def extract_xpu_device_id(device: _XPUPlaceLike, op_name: str) -> int:
             "Please input appropriate device again!"
         )
 
-    assert (
-        device_id >= 0
-    ), f"The device id must be not less than 0, but got id = {device_id}."
-    assert (
-        device_id < device_count()
-    ), f"The device id {device_id} exceeds xpu card number {device_count()}"
+    assert device_id >= 0, (
+        f"The device id must be not less than 0, but got id = {device_id}."
+    )
+    assert device_id < device_count(), (
+        f"The device id {device_id} exceeds xpu card number {device_count()}"
+    )
     return device_id
 
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

使用性能更好，格式化效果更佳的 ruff format 替代 black 作为新的 formatter，由于我们很早就已经集成了 ruff lint，因此只是减少依赖而不会增加依赖

<!--

## 核心优势

通过集成 Ruff format，开发者可以享受到以下优势：

- 通过去除 black 对 python 环境依赖，极大降低了升级 formatter 带来的成本，后续无需考虑开发者本地 python 环境即可一键升级
- ruff 由 Rust 驱动，大幅加速 format 时间，降低开发者使用开发工具链的时间成本，减少 CI 时间，提升工程效率
- 格式化后呈现可读性更佳的效果，使得开发者更专注于代码开发而无需关心格式，阅读者也能够更加赏心悦目，极大增加了潜在贡献者的贡献意愿
- ruff 极大程度地兼容了 black 的格式化效果，能够平滑地替换现有的 black 配置
- ruff 更新频次高，能够快速响应社区反馈，持续优化格式化效果
- ruff 团队 Astral 最近开发的 ty 能够提供更强大的类型检查能力，后续可能与 ruff 集成，提供更好的开发体验
- PyTorch 最近已经完成迁移，追平竞品（在代码风格这块，我们一直做到了超越竞品，这次不能落后）

-->