### PR TITLE
[CodeStyle] `black -> ruff format` migration - part 26

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,7 +77,7 @@ repos:
 
             # | python/paddle/de.+
 
-            # | python/paddle/distributed/a.+
+            | python/paddle/distributed/a.+
 
             # | python/paddle/distributed/[b-e].+
 
@@ -133,7 +133,7 @@ repos:
 
             | python/paddle/de.+
 
-            | python/paddle/distributed/a.+
+            # | python/paddle/distributed/a.+
 
             | python/paddle/distributed/[b-e].+
 

--- a/python/paddle/_paddle_docs.py
+++ b/python/paddle/_paddle_docs.py
@@ -74,6 +74,7 @@ def _parse_function_signature(
         if func_def.args.defaults and len(func_def.args.defaults) > (
             len(func_def.args.args) - len(func_def.args.defaults)
         ):
+
             idx = count - (
                 len(func_def.args.args) - len(func_def.args.defaults)
             )

--- a/python/paddle/_paddle_docs.py
+++ b/python/paddle/_paddle_docs.py
@@ -74,7 +74,6 @@ def _parse_function_signature(
         if func_def.args.defaults and len(func_def.args.defaults) > (
             len(func_def.args.args) - len(func_def.args.defaults)
         ):
-
             idx = count - (
                 len(func_def.args.args) - len(func_def.args.defaults)
             )

--- a/python/paddle/distributed/auto_parallel/auto_dp_utils.py
+++ b/python/paddle/distributed/auto_parallel/auto_dp_utils.py
@@ -21,9 +21,9 @@ _enable_auto_dp_mode = False
 
 def _fake_replicate_grad_to_partial(grad, partial_axis):
     new_placements = grad.placements
-    assert (
-        new_placements[partial_axis] == dist.Replicate()
-    ), "when reshard fake replicated grad to partial, the partial axis of grad should be Replicate"
+    assert new_placements[partial_axis] == dist.Replicate(), (
+        "when reshard fake replicated grad to partial, the partial axis of grad should be Replicate"
+    )
 
     new_placements[partial_axis] = dist.Partial(dist.ReduceType.kRedSum)
 

--- a/python/paddle/distributed/auto_parallel/high_level_api.py
+++ b/python/paddle/distributed/auto_parallel/high_level_api.py
@@ -34,9 +34,9 @@ class ToDistributedConfig:
 
 def cost_model(matched_programs, device_num, node_num):
     # TODO(jeff41404): multi-node will be supported later
-    assert (
-        node_num == 1
-    ), "we only support single node now, multi-node will be supported later"
+    assert node_num == 1, (
+        "we only support single node now, multi-node will be supported later"
+    )
 
     # TODO(jeff41404): will evaluate the best combination of parallel strategies
     # based on cost_model and return global_mesh, currently using pre-defined parallel strategy
@@ -224,7 +224,9 @@ def record_program_ops_post_hook(layer, inputs, outputs):
         assert (
             layer._op_recorder.start >= 0
             and layer._op_recorder.is_valid is True
-        ), f"{layer._full_name} has not recorded the start of the corresponding ops before"
+        ), (
+            f"{layer._full_name} has not recorded the start of the corresponding ops before"
+        )
         end = len(default_main_program().global_block().ops)
         # some layers, such as rotary_embedding, will not add new ops to program
         # assert end > layer._op_recorder.start, f"{layer._full_name} has not added new ops to the program"
@@ -754,9 +756,9 @@ def to_distributed(
     for pattern_name, matched_patterns in results.items():
         # process one pattern
         pattern_ops_dist_infos = get_pattern(pattern_name).ops_dist_infos
-        assert (
-            pattern_ops_dist_infos is not None
-        ), f"{pattern_name} does not contain ops_dist_infos, cannot reshard, please check"
+        assert pattern_ops_dist_infos is not None, (
+            f"{pattern_name} does not contain ops_dist_infos, cannot reshard, please check"
+        )
         processed_patterns = []
         for matched_pattern in matched_patterns:
             # convert pattern_ops_dist_infos to program_ops_dist_infos
@@ -764,9 +766,9 @@ def to_distributed(
             for pattern_ops_id, op_dist_info in pattern_ops_dist_infos.items():
                 program_ops_id = []
                 for pattern_op_id in pattern_ops_id:
-                    assert (
-                        pattern_op_id in matched_pattern.keys()
-                    ), f"please check ops_dist_infos of {pattern_name}, {pattern_op_id} not in matched_pattern: {matched_pattern.keys()}"
+                    assert pattern_op_id in matched_pattern.keys(), (
+                        f"please check ops_dist_infos of {pattern_name}, {pattern_op_id} not in matched_pattern: {matched_pattern.keys()}"
+                    )
                     program_op_id = matched_pattern[pattern_op_id]
                     program_ops_id.append(program_op_id)
                 program_ops_dist_infos[tuple(program_ops_id)] = op_dist_info
@@ -789,9 +791,9 @@ def to_distributed(
     if with_mp:
         num_hidden_layers = len(matched_programs[DECODER_LAYER_NAME])
         for pattern_name, processed_patterns in matched_programs.items():
-            assert (
-                len(processed_patterns) == num_hidden_layers
-            ), "transformer patterns matched are incomplete"
+            assert len(processed_patterns) == num_hidden_layers, (
+                "transformer patterns matched are incomplete"
+            )
             for idx, processed_pattern in enumerate(processed_patterns):
                 local_mesh = mesh
                 if with_pp:
@@ -801,9 +803,9 @@ def to_distributed(
                     local_mesh = mesh.get_mesh_with_dim("pp", pp_stage_id)
 
                 for program_ops_id, dist_infos in processed_pattern.items():
-                    assert (
-                        program_ops_id in ops_id_to_layer.keys()
-                    ), f"program_ops: {program_ops_id} is not corresponding to a dynamic layer"
+                    assert program_ops_id in ops_id_to_layer.keys(), (
+                        f"program_ops: {program_ops_id} is not corresponding to a dynamic layer"
+                    )
                     dynamic_layer = ops_id_to_layer[program_ops_id]
                     mesh_num_dims = len(local_mesh.shape)
                     sharding_info = dist_infos.get_dist_info(mesh_num_dims)
@@ -832,9 +834,9 @@ def to_distributed(
 
         if decoder_layers is not None:
             num_decoder_blocks = len(decoder_layers)
-            assert (
-                num_decoder_blocks == num_hidden_layers
-            ), f"decoder pattern layers matched are incomplete, num_decoder_blocks: {num_decoder_blocks} should be equal to num_hidden_layers: {num_hidden_layers}"
+            assert num_decoder_blocks == num_hidden_layers, (
+                f"decoder pattern layers matched are incomplete, num_decoder_blocks: {num_decoder_blocks} should be equal to num_hidden_layers: {num_hidden_layers}"
+            )
 
             pp_degree = mesh.get_dim_size("pp")
             num_blocks_per_stage = num_decoder_blocks // pp_degree

--- a/python/paddle/distributed/auto_parallel/interface.py
+++ b/python/paddle/distributed/auto_parallel/interface.py
@@ -73,17 +73,17 @@ def shard_tensor(x, process_mesh=None, shard_spec=None):
     """
 
     if process_mesh is not None:
-        assert isinstance(
-            process_mesh, core.ProcessMesh
-        ), f"Argument process_mesh {process_mesh} is not an instance of ProcessMesh"
+        assert isinstance(process_mesh, core.ProcessMesh), (
+            f"Argument process_mesh {process_mesh} is not an instance of ProcessMesh"
+        )
     else:
         process_mesh = get_current_process_mesh()
-        assert (
-            process_mesh is not None
-        ), "Specify the process mesh argument or use ProcessMesh context manager first."
-    assert isinstance(
-        shard_spec, list
-    ), f"Argument shard_spec {shard_spec} is not an instance of list"
+        assert process_mesh is not None, (
+            "Specify the process mesh argument or use ProcessMesh context manager first."
+        )
+    assert isinstance(shard_spec, list), (
+        f"Argument shard_spec {shard_spec} is not an instance of list"
+    )
     if isinstance(x, str):
         x = (
             paddle.static.default_main_program()
@@ -100,9 +100,9 @@ def shard_tensor(x, process_mesh=None, shard_spec=None):
     else:
         tensor_shape = serial_tensor.shape
     if shard_spec is not None:
-        assert verify_shard_spec(
-            shard_spec, tensor_shape, process_mesh
-        ), f"For tensor {serial_tensor.name}, shard_spec {shard_spec} is invalid with tensor_shape {tensor_shape} and process_mesh {process_mesh}."
+        assert verify_shard_spec(shard_spec, tensor_shape, process_mesh), (
+            f"For tensor {serial_tensor.name}, shard_spec {shard_spec} is invalid with tensor_shape {tensor_shape} and process_mesh {process_mesh}."
+        )
         dist_tensor.dist_attr.dims_mapping = convert_to_dims_mapping(
             shard_spec, process_mesh
         )
@@ -164,14 +164,14 @@ def shard_op(
     """
 
     if process_mesh is not None:
-        assert isinstance(
-            process_mesh, ProcessMesh
-        ), f"Argument process_mesh {process_mesh} is not an instance of ProcessMesh"
+        assert isinstance(process_mesh, ProcessMesh), (
+            f"Argument process_mesh {process_mesh} is not an instance of ProcessMesh"
+        )
     else:
         process_mesh = get_current_process_mesh()
-        assert (
-            process_mesh is not None
-        ), "Specify the process mesh argument or use ProcessMesh context manager first."
+        assert process_mesh is not None, (
+            "Specify the process mesh argument or use ProcessMesh context manager first."
+        )
     in_dims_mappings = []
     if in_shard_specs is not None:
         assert all(

--- a/python/paddle/distributed/auto_parallel/intermediate/context_parallel.py
+++ b/python/paddle/distributed/auto_parallel/intermediate/context_parallel.py
@@ -138,16 +138,16 @@ class PrepareContextParallel(PlanBase):
             if isinstance(args, (list, tuple)):
                 all_args = []
                 for input_tensor in args:
-                    assert (
-                        input_tensor.is_dist()
-                    ), "Input tensor must be a distributed tensor."
-                    assert (
-                        len(input_tensor.shape) == 2
-                    ), f"input_ids should be [batch_size, seq_len], but got {input_tensor.shape}"
+                    assert input_tensor.is_dist(), (
+                        "Input tensor must be a distributed tensor."
+                    )
+                    assert len(input_tensor.shape) == 2, (
+                        f"input_ids should be [batch_size, seq_len], but got {input_tensor.shape}"
+                    )
                     _, seq_len = input_tensor.shape
-                    assert (
-                        seq_len % cp_degree == 0
-                    ), f"sequence length {seq_len} must be divisible by cp degree {cp_degree}"
+                    assert seq_len % cp_degree == 0, (
+                        f"sequence length {seq_len} must be divisible by cp degree {cp_degree}"
+                    )
                     reshard_input = shard_tensor(input_tensor, 1)
                     all_args.append(reshard_input)
                 new_args = tuple(all_args)
@@ -170,21 +170,21 @@ class PrepareContextParallel(PlanBase):
                 all_args = []
                 for input_tensor in args:
                     # check input_ids
-                    assert (
-                        input_tensor.is_dist()
-                    ), "Input tensor must be a distributed tensor."
-                    assert (
-                        len(input_tensor.shape) == 2
-                    ), f"input_ids should be [batch_size, seq_len], but got {input_tensor.shape}"
+                    assert input_tensor.is_dist(), (
+                        "Input tensor must be a distributed tensor."
+                    )
+                    assert len(input_tensor.shape) == 2, (
+                        f"input_ids should be [batch_size, seq_len], but got {input_tensor.shape}"
+                    )
                     placements = input_tensor.placements
                     if placements is None:
                         placements = [
                             dist.Replicate()
                             for _ in range(len(process_mesh.shape))
                         ]
-                    assert (
-                        placements[cp_index] == dist.Replicate()
-                    ), "Input tensor must be a replicated tensor in cp mesh."
+                    assert placements[cp_index] == dist.Replicate(), (
+                        "Input tensor must be a replicated tensor in cp mesh."
+                    )
                     reshard_input = shard_seq_load_balance(input_tensor, 1)
                     all_args.append(reshard_input)
                 new_args = tuple(all_args)
@@ -319,9 +319,9 @@ class ContextParallel(PlanBase):
                 assert arg.is_dist(), f"arg {arg} must be a distributed tensor."
                 assert len(arg.shape) == 3 or len(arg.shape) == 4
                 placements = arg.placements
-                assert placements[cp_index] == dist.Shard(
-                    1
-                ), f"arg {arg} must be sharded in sequence dimension."
+                assert placements[cp_index] == dist.Shard(1), (
+                    f"arg {arg} must be sharded in sequence dimension."
+                )
                 # reshard [batch_size，seq_len/sep，num_head，head_dim] -> [batch_size，seq_len，num_head/sep，head_dim]
                 placements[cp_index] = dist.Shard(2)
                 target_arg = dist.reshard(arg, process_mesh, placements)
@@ -336,13 +336,13 @@ class ContextParallel(PlanBase):
             cp_index = process_mesh.dim_names.index('sep')
             cp_degree = process_mesh.shape[cp_index]
             placements = output.placements
-            assert (
-                output.is_dist()
-            ), f"output {output} must be a distributed tensor."
+            assert output.is_dist(), (
+                f"output {output} must be a distributed tensor."
+            )
             assert len(output.shape) == 4 or len(output.shape) == 3
-            assert placements[cp_index] == dist.Shard(
-                2
-            ), f"output {output} must be Shard(2) in sequence dimension."
+            assert placements[cp_index] == dist.Shard(2), (
+                f"output {output} must be Shard(2) in sequence dimension."
+            )
             # reshard [batch_size，seq_len，num_head/seq，head_dim]  ->  [batch_size，seq_len/sep，num_head，head_dim]
             placements[cp_index] = dist.Shard(1)
             target_output = dist.reshard(output, process_mesh, placements)
@@ -356,14 +356,14 @@ class ContextParallel(PlanBase):
             cp_degree = process_mesh.shape[cp_index]
             for arg in args:
                 # check q k v
-                assert (
-                    arg.is_dist()
-                ), "Input tensor must be a distributed tensor."
+                assert arg.is_dist(), (
+                    "Input tensor must be a distributed tensor."
+                )
                 assert len(arg.shape) == 3 or len(arg.shape) == 4
                 placements = arg.placements
-                assert placements[cp_index] == dist.Shard(
-                    1
-                ), f"arg {arg} must be Shard(1) in sequence dimension."
+                assert placements[cp_index] == dist.Shard(1), (
+                    f"arg {arg} must be Shard(1) in sequence dimension."
+                )
             # edit kwarg backend to 'p2p'
             new_kwargs = kwargs
             new_kwargs['backend'] = 'p2p'

--- a/python/paddle/distributed/auto_parallel/intermediate/parallel_base.py
+++ b/python/paddle/distributed/auto_parallel/intermediate/parallel_base.py
@@ -57,9 +57,9 @@ class ParallelOptimizer:
                     level = str(level)
                 assert level in ("0", "1", "2", "3", None)
                 if optimizer.level is not None:
-                    assert (
-                        level == optimizer.level
-                    ), f"The level passed in is not identical with previous level. Current level is {level}, previous level is {optimizer.level}"
+                    assert level == optimizer.level, (
+                        f"The level passed in is not identical with previous level. Current level is {level}, previous level is {optimizer.level}"
+                    )
                 self.level = level
                 self.sharding_mesh_dim = sharding_mesh_dim
         else:

--- a/python/paddle/distributed/auto_parallel/intermediate/parallelize.py
+++ b/python/paddle/distributed/auto_parallel/intermediate/parallelize.py
@@ -260,9 +260,9 @@ def parallelize(
         return model, optimizer
     assert isinstance(config, dict)
     if mesh is not None:
-        assert isinstance(
-            mesh, core.ProcessMesh
-        ), "The mesh must be an instance of paddle.distributed.ProcessMesh."
+        assert isinstance(mesh, core.ProcessMesh), (
+            "The mesh must be an instance of paddle.distributed.ProcessMesh."
+        )
         g_mesh = fleet.auto.get_mesh()
         if g_mesh is not None and g_mesh != mesh:
             warnings.warn(
@@ -322,9 +322,9 @@ def parallelize_model(model, mesh=None, config=None):
         return model
     assert isinstance(config, dict)
     if mesh is not None:
-        assert isinstance(
-            mesh, core.ProcessMesh
-        ), "The mesh must be an instance of paddle.distributed.ProcessMesh."
+        assert isinstance(mesh, core.ProcessMesh), (
+            "The mesh must be an instance of paddle.distributed.ProcessMesh."
+        )
         g_mesh = fleet.auto.get_mesh()
         if g_mesh is not None and g_mesh != mesh:
             warnings.warn(
@@ -346,9 +346,9 @@ def parallelize_optimizer(optimizer, mesh=None, config=None):
         return optimizer
     assert isinstance(config, dict)
     if mesh is not None:
-        assert isinstance(
-            mesh, core.ProcessMesh
-        ), "The mesh must be an instance of paddle.distributed.ProcessMesh."
+        assert isinstance(mesh, core.ProcessMesh), (
+            "The mesh must be an instance of paddle.distributed.ProcessMesh."
+        )
         g_mesh = fleet.auto.get_mesh()
         if g_mesh is not None and g_mesh != mesh:
             warnings.warn(
@@ -358,21 +358,21 @@ def parallelize_optimizer(optimizer, mesh=None, config=None):
         fleet.auto.set_mesh(mesh)
 
     global has_parallelized_model
-    assert (
-        has_parallelized_model
-    ), "Please parallelize the model before parallelize optimizer."
+    assert has_parallelized_model, (
+        "Please parallelize the model before parallelize optimizer."
+    )
     param_list = optimizer._parameter_list
     if isinstance(param_list[0], dict):
         for param_group in param_list:
             for param in param_group['params']:
-                assert (
-                    param.is_dist()
-                ), "Please use model after parallelize to create optimizer."
+                assert param.is_dist(), (
+                    "Please use model after parallelize to create optimizer."
+                )
     else:
         for param in param_list:
-            assert (
-                param.is_dist()
-            ), "Please use model after parallelize to create optimizer."
+            assert param.is_dist(), (
+                "Please use model after parallelize to create optimizer."
+            )
 
     dp_config = config.get('dp_config')
     level = None

--- a/python/paddle/distributed/auto_parallel/intermediate/pipeline_parallel.py
+++ b/python/paddle/distributed/auto_parallel/intermediate/pipeline_parallel.py
@@ -71,9 +71,9 @@ class PipelineParallel(ParallelModel):
             self.name_to_layer[layer_name] = layer
 
     def get_layer_by_name(self, name):
-        assert (
-            name in self.name_to_layer
-        ), f"layer name:{name} not in the model, please check the split_spec"
+        assert name in self.name_to_layer, (
+            f"layer name:{name} not in the model, please check the split_spec"
+        )
         return self.name_to_layer[name]
 
     def pipeline_parallel_fn(self, model):
@@ -135,9 +135,9 @@ class PipelineParallel(ParallelModel):
                         pipeline_layer_mark[i] = 1
                         is_valid = True
                         break
-                assert (
-                    is_valid
-                ), f"the last layer:{split_layer_name} must not be SplitPoint.END, please check the split_spec"
+                assert is_valid, (
+                    f"the last layer:{split_layer_name} must not be SplitPoint.END, please check the split_spec"
+                )
             else:
                 raise NotImplementedError(
                     "SplitPoint.BEGINNING is not supported currently"
@@ -288,12 +288,12 @@ def pipeline_parallel(model, optimizer=None, config=None):
         return model, optimizer
 
     mesh = fleet.auto.get_mesh()
-    assert (
-        mesh is not None
-    ), "global mesh must not be None, please call fleet.auto.set_mesh(global_mesh) firstly"
-    assert (
-        "pp" in mesh.dim_names
-    ), "pp must in the mesh dim_names when use pipeline_parallel"
+    assert mesh is not None, (
+        "global mesh must not be None, please call fleet.auto.set_mesh(global_mesh) firstly"
+    )
+    assert "pp" in mesh.dim_names, (
+        "pp must in the mesh dim_names when use pipeline_parallel"
+    )
 
     global_spec = config.get("global_spec")
     if isinstance(split_spec, str):
@@ -336,12 +336,12 @@ def pipeline_parallel(model, optimizer=None, config=None):
         matched_layer_name = filter_matched_layer(matched_layer_name)
         pp_size = mesh.get_dim_size("pp")
         layer_num = len(matched_layer_name)
-        assert (
-            layer_num > 0
-        ), "No layer match the split_spec, please check its correctness"
-        assert (
-            layer_num >= pp_size
-        ), "The number of layers must not be less than the pp size"
+        assert layer_num > 0, (
+            "No layer match the split_spec, please check its correctness"
+        )
+        assert layer_num >= pp_size, (
+            "The number of layers must not be less than the pp size"
+        )
         if layer_num % pp_size != 0:
             logger.warning(
                 f"The number of layers({layer_num}) must be divisible by the pp size({pp_size}), but got {layer_num} and {pp_size}"
@@ -383,18 +383,18 @@ def pipeline_parallel(model, optimizer=None, config=None):
         sublayer_names = [name for name, _ in model.named_sublayers()]
         split_spec_dict = split_spec
         for key, value in split_spec_dict.items():
-            assert (
-                key in sublayer_names
-            ), f"wrong split layer, expected one of {sublayer_names}"
+            assert key in sublayer_names, (
+                f"wrong split layer, expected one of {sublayer_names}"
+            )
             assert value is SplitPoint.END, "not supported split point at now."
 
     if global_spec:
         if isinstance(global_spec, str):
             global_spec = [global_spec]
         else:
-            assert isinstance(
-                global_spec, (list, tuple)
-            ), f"global_spec can only be list or list(str), but got:{type(global_spec)}"
+            assert isinstance(global_spec, (list, tuple)), (
+                f"global_spec can only be list or list(str), but got:{type(global_spec)}"
+            )
 
     logger.info(
         f"split_spec_dict: {split_spec_dict}, global_spec: {global_spec}, matched_layer_name: {matched_layer_name}"

--- a/python/paddle/distributed/auto_parallel/intermediate/sharded_data_parallel.py
+++ b/python/paddle/distributed/auto_parallel/intermediate/sharded_data_parallel.py
@@ -79,10 +79,10 @@ def sharded_data_parallel(model, optimizer=None, config=None):
 
     # check global_mesh
     mesh = fleet.auto.get_mesh()
-    assert (
-        mesh is not None
-    ), "global mesh must not be None, please call fleet.auto.set_mesh(global_mesh) firstly"
-    assert (
-        "dp" in mesh.dim_names
-    ), "dp must in the mesh dim_names when use sharded_data_parallel"
+    assert mesh is not None, (
+        "global mesh must not be None, please call fleet.auto.set_mesh(global_mesh) firstly"
+    )
+    assert "dp" in mesh.dim_names, (
+        "dp must in the mesh dim_names when use sharded_data_parallel"
+    )
     return sdp_model, optimizer

--- a/python/paddle/distributed/auto_parallel/intermediate/tensor_parallel.py
+++ b/python/paddle/distributed/auto_parallel/intermediate/tensor_parallel.py
@@ -821,15 +821,15 @@ class TensorParallel(ParallelModel):
         if parallelize_plan is not None:
             assert isinstance(parallelize_plan, dict)
             for key, plan in parallelize_plan.items():
-                assert isinstance(
-                    key, str
-                ), "The key of the parallelize plan should be a string."
+                assert isinstance(key, str), (
+                    "The key of the parallelize plan should be a string."
+                )
                 if not isinstance(plan, list):
                     plan = [plan]
                 for p in plan:
-                    assert isinstance(
-                        p, PlanBase
-                    ), "The value the the parallelize plan should be a instance of PlanBase or a list of PlanBase."
+                    assert isinstance(p, PlanBase), (
+                        "The value the the parallelize plan should be a instance of PlanBase or a list of PlanBase."
+                    )
 
             self.global_mesh = dist.auto_parallel.get_mesh()
             self.parallelize_plan = parallelize_plan
@@ -934,12 +934,12 @@ def tensor_parallel(model, optimizer=None, config=None):
 
     global_mesh = dist.auto_parallel.get_mesh()
 
-    assert (
-        global_mesh is not None
-    ), "global mesh must not be None, please call fleet.auto.set_mesh(global_mesh) firstly"
-    assert (
-        "mp" in global_mesh.dim_names
-    ), "mp must in the mesh dim_names when use tensor_parallel"
+    assert global_mesh is not None, (
+        "global mesh must not be None, please call fleet.auto.set_mesh(global_mesh) firstly"
+    )
+    assert "mp" in global_mesh.dim_names, (
+        "mp must in the mesh dim_names when use tensor_parallel"
+    )
 
     model = TensorParallel(model, parallelize_plan)
     if optimizer is not None:

--- a/python/paddle/distributed/auto_parallel/local_layer.py
+++ b/python/paddle/distributed/auto_parallel/local_layer.py
@@ -113,9 +113,9 @@ class LocalLayer(Layer):
         outputs back to distributed tensors based on the specified distribution attributes.
         """
         inputs = list(inputs)
-        assert len(inputs) == len(
-            self.grad_dist_attrs
-        ), f"The number of inputs ({len(inputs)}) does not match the number of grad_dist_attrs ({len(self.grad_dist_attrs)})."
+        assert len(inputs) == len(self.grad_dist_attrs), (
+            f"The number of inputs ({len(inputs)}) does not match the number of grad_dist_attrs ({len(self.grad_dist_attrs)})."
+        )
         for idx in range(len(inputs)):
             if inputs[idx].is_dist():
                 if self.grad_dist_attrs[idx] is None:
@@ -141,9 +141,9 @@ class LocalLayer(Layer):
 
         outputs = Layer.__call__(self, *inputs, **kwargs)
         list_outs = paddle.utils.flatten(outputs)
-        assert len(list_outs) == len(
-            self.out_dist_attrs
-        ), f"The number of outputs ({len(list_outs)}) does not match the number of distribution attributes ({len(self.out_dist_attrs)})."
+        assert len(list_outs) == len(self.out_dist_attrs), (
+            f"The number of outputs ({len(list_outs)}) does not match the number of distribution attributes ({len(self.out_dist_attrs)})."
+        )
 
         dist_outs = []
         for idx in range(len(list_outs)):

--- a/python/paddle/distributed/auto_parallel/local_map.py
+++ b/python/paddle/distributed/auto_parallel/local_map.py
@@ -203,9 +203,9 @@ def local_map(
             for out, out_placement in zip(flat_out, out_placements):
                 if paddle.in_dynamic_mode():
                     if isinstance(out, paddle.Tensor):
-                        assert not dist.auto_parallel.api.is_dist_tensor(
-                            out
-                        ), f"Expected dense tensor output but got {type(out)}: {out}"
+                        assert not dist.auto_parallel.api.is_dist_tensor(out), (
+                            f"Expected dense tensor output but got {type(out)}: {out}"
+                        )
 
                         flat_dist_and_arg_out.append(
                             dist.auto_parallel.api.dtensor_from_local(
@@ -220,9 +220,9 @@ def local_map(
                         flat_dist_and_arg_out.append(out)
                 else:
                     if isinstance(out, paddle.base.libpaddle.pir.Value):
-                        assert not dist.auto_parallel.api.is_dist_tensor(
-                            out
-                        ), f"Expected dense tensor output but got {type(out)}: {out}"
+                        assert not dist.auto_parallel.api.is_dist_tensor(out), (
+                            f"Expected dense tensor output but got {type(out)}: {out}"
+                        )
 
                         flat_dist_and_arg_out.append(
                             dist.auto_parallel.api.dtensor_from_local(
@@ -241,9 +241,9 @@ def local_map(
             flat_dist_and_arg_out = []
             for out, out_placement in zip(flat_out, out_placements):
                 if out_placement is not None:
-                    assert (
-                        process_mesh is not None
-                    ), "process_mesh must be specified when out_placements is not None"
+                    assert process_mesh is not None, (
+                        "process_mesh must be specified when out_placements is not None"
+                    )
                     flat_dist_and_arg_out.append(
                         dist.auto_parallel.api.dtensor_from_local(
                             out, process_mesh, out_placement

--- a/python/paddle/distributed/auto_parallel/moe_utils.py
+++ b/python/paddle/distributed/auto_parallel/moe_utils.py
@@ -104,12 +104,12 @@ def _dtensor_from_local(
 
     # TODO Adopt Mix2Dist Pass to allow the program could be executed actually.
     elif paddle.framework.in_pir_mode():
-        assert isinstance(
-            local_tensor, (type(None), paddle.pir.Value)
-        ), "input tensor is not pir value."
-        assert (
-            local_tensor.is_dense_tensor_type()
-        ), "dtensor_from_local() are only supported dense tensor type right."
+        assert isinstance(local_tensor, (type(None), paddle.pir.Value)), (
+            "input tensor is not pir value."
+        )
+        assert local_tensor.is_dense_tensor_type(), (
+            "dtensor_from_local() are only supported dense tensor type right."
+        )
         sharding_specs = (
             paddle.distributed.auto_parallel.placement_type.get_shard_spec(
                 mesh, placements, local_tensor.ndim
@@ -246,9 +246,9 @@ def infer_positive_shape(src_shape, tgt_shape):
 
     minus_one_idx = np.where(ret_shape == -1)[0]
     if minus_one_idx.size > 0:
-        assert (
-            minus_one_idx.size <= 1
-        ), "At most one -1 is allowed in target shape."
+        assert minus_one_idx.size <= 1, (
+            "At most one -1 is allowed in target shape."
+        )
 
         nelem = np.prod(src_shape)
         ret_shape[minus_one_idx[0]] = 1
@@ -340,9 +340,9 @@ def _dist_reshape(
             "dist_reshape is only supported in dynamic and pir mode."
         )
 
-    assert np.prod(tgt_local_shape) == np.prod(
-        src_local_shape
-    ), f"The local shapes {src_local_shape} and {tgt_local_shape} are mismatched."
+    assert np.prod(tgt_local_shape) == np.prod(src_local_shape), (
+        f"The local shapes {src_local_shape} and {tgt_local_shape} are mismatched."
+    )
 
     if paddle.in_dynamic_mode():
         return _local_reshape.apply(

--- a/python/paddle/distributed/auto_parallel/operators/dist_flash_attn.py
+++ b/python/paddle/distributed/auto_parallel/operators/dist_flash_attn.py
@@ -64,9 +64,9 @@ class DistributedFlashAttnImpl0(DistributedElementwiseImpl0):
             and not op_dist_attr.is_recompute
             and rank_id in op_dist_attr.process_mesh.process_ids
         ):
-            assert (
-                op_dist_attr is not None
-            ), f"forward op [{src_op}] don't have dist attribute !"
+            assert op_dist_attr is not None, (
+                f"forward op [{src_op}] don't have dist attribute !"
+            )
 
             if (
                 len(kwargs.get('fixed_seed_offset', [])) > 0

--- a/python/paddle/distributed/auto_parallel/pipelining/_backward.py
+++ b/python/paddle/distributed/auto_parallel/pipelining/_backward.py
@@ -75,17 +75,17 @@ def stage_backward(
             if isinstance(output_val, paddle.Tensor):
                 if output_val.stop_gradient and output_val.grad_fn is None:
                     return
-                assert isinstance(
-                    grad_val, (paddle.Tensor, type(None))
-                ), f"Expected Tensor or None gradient but got {type(grad_val)}"
+                assert isinstance(grad_val, (paddle.Tensor, type(None))), (
+                    f"Expected Tensor or None gradient but got {type(grad_val)}"
+                )
                 stage_output_tensors.append(output_val)
                 output_grad_tensors.append(grad_val)
             elif isinstance(output_val, (tuple, list)):
                 if grad_val is None:
                     return
-                assert isinstance(
-                    grad_val, (tuple, list)
-                ), f"grad_value expected to have type {type(output_val)} but got {type(grad_val)}"
+                assert isinstance(grad_val, (tuple, list)), (
+                    f"grad_value expected to have type {type(output_val)} but got {type(grad_val)}"
+                )
                 assert len(output_val) == len(grad_val)
                 for ov, gv in zip(output_val, grad_val):
                     extract_tensors_with_grads(

--- a/python/paddle/distributed/auto_parallel/pipelining/microbatch.py
+++ b/python/paddle/distributed/auto_parallel/pipelining/microbatch.py
@@ -42,9 +42,9 @@ def _split_tensor(x, num_chunks, split_axis=0):
 
             def _reorder_data_for_align():
                 nonlocal x
-                assert x.placements[0] == dist.Shard(
-                    0
-                ), "inputs should be placed on S(0)."
+                assert x.placements[0] == dist.Shard(0), (
+                    "inputs should be placed on S(0)."
+                )
 
                 shardings = x.process_mesh.shape[0]
 
@@ -116,9 +116,9 @@ def _split_args_helper(
     """
     A helper function of split_args_kwargs_into_chunks.
     """
-    assert len(args_dict) == len(
-        args_chunk_spec
-    ), f"args_dict.keys() = {list(args_dict.keys())} args_chunk_spec.keys() = {list(args_chunk_spec.keys())}"
+    assert len(args_dict) == len(args_chunk_spec), (
+        f"args_dict.keys() = {list(args_dict.keys())} args_chunk_spec.keys() = {list(args_chunk_spec.keys())}"
+    )
 
     shared_args_dict_flat = {}
     # handle args one by one
@@ -129,9 +129,9 @@ def _split_args_helper(
         assert chunk_spec is not None
 
         chunk_spec_flat = flatten(chunk_spec)
-        assert len(chunk_spec_flat) == len(
-            arg_flat
-        ), f"{arg_key} {len(arg_flat)} != {len(chunk_spec_flat)}"
+        assert len(chunk_spec_flat) == len(arg_flat), (
+            f"{arg_key} {len(arg_flat)} != {len(chunk_spec_flat)}"
+        )
 
         shard_arg_flat = []
 
@@ -280,9 +280,9 @@ def merge_chunks(
     chunk_spec = flatten(chunk_spec)
     for chunk in chunks:
         chunk_flat = flatten(chunk)
-        assert len(chunk_flat) == len(
-            chunk_spec
-        ), f"Chunk {chunk} did not match chunk spec {chunk_spec}"
+        assert len(chunk_flat) == len(chunk_spec), (
+            f"Chunk {chunk} did not match chunk spec {chunk_spec}"
+        )
         chunks_flat.append(chunk_flat)
 
     def _merge_non_tensor_type_arg(chunks, idx, chunk_spec_of_arg=None):

--- a/python/paddle/distributed/auto_parallel/pipelining/schedules.py
+++ b/python/paddle/distributed/auto_parallel/pipelining/schedules.py
@@ -860,9 +860,9 @@ class PipelineScheduleMulti(_PipelineSchedule):
                     computation_type = action.computation_type
                     mb_index = action.microbatch_index
                     stage_index = action.stage_index
-                    assert (
-                        mb_index is not None
-                    ), "All currently supported action types require valid microbatch_index"
+                    assert mb_index is not None, (
+                        "All currently supported action types require valid microbatch_index"
+                    )
                     if computation_type == _ActType.FORWARD:
                         # perform forward computation
                         stage = stage_index_to_stage[stage_index]
@@ -922,9 +922,9 @@ class PipelineScheduleMulti(_PipelineSchedule):
                         computation_type = prev_rank_action.computation_type
                         mb_index = prev_rank_action.microbatch_index
                         stage_index = prev_rank_action.stage_index
-                        assert (
-                            mb_index is not None
-                        ), "All currently supported action types require valid microbatch_index"
+                        assert mb_index is not None, (
+                            "All currently supported action types require valid microbatch_index"
+                        )
                         # Only handle sends for the forward from a previous rank
                         if computation_type == _ActType.FORWARD:
                             # If not the last stage, then receive fwd activations
@@ -953,9 +953,9 @@ class PipelineScheduleMulti(_PipelineSchedule):
                         computation_type = next_rank_action.computation_type
                         mb_index = next_rank_action.microbatch_index
                         stage_index = next_rank_action.stage_index
-                        assert (
-                            mb_index is not None
-                        ), "All currently supported action types require valid microbatch_index"
+                        assert mb_index is not None, (
+                            "All currently supported action types require valid microbatch_index"
+                        )
                         # Only handle receives for the backwards from a next rank
                         if computation_type in (FORWARD, BACKWARD_WEIGHT):
                             # Next rank doing forward or weight update has no influence for the current rank backward recv

--- a/python/paddle/distributed/auto_parallel/pipelining/utils.py
+++ b/python/paddle/distributed/auto_parallel/pipelining/utils.py
@@ -134,9 +134,9 @@ def _get_pp_mesh(pp_idx=0, pp_dim_names="pp"):
     Get the mesh of the {pp_idx}th PipelineStage.
     """
     mesh = fleet.auto.get_mesh()
-    assert (
-        mesh is not None
-    ), "the mesh is None, please call fleet.auto.set_mesh first."
+    assert mesh is not None, (
+        "the mesh is None, please call fleet.auto.set_mesh first."
+    )
     if "pp" in mesh.dim_names:
         mesh = mesh.get_mesh_with_dim("pp", pp_idx)
     else:

--- a/python/paddle/distributed/auto_parallel/placement_type.py
+++ b/python/paddle/distributed/auto_parallel/placement_type.py
@@ -140,9 +140,9 @@ def placemetns_to_dist_status(
                 split_factor_map[i] = cast(
                     "Shard", placement
                 ).get_split_factor()
-                assert (
-                    len(split_factor_map) == 1
-                ), "only support to rerrange at one mesh dim."
+                assert len(split_factor_map) == 1, (
+                    "only support to rerrange at one mesh dim."
+                )
         if placement.is_partial():
             partial_status[i] = cast("Partial", placement).reduce_type()
 

--- a/python/paddle/distributed/auto_parallel/process_mesh.py
+++ b/python/paddle/distributed/auto_parallel/process_mesh.py
@@ -160,28 +160,28 @@ class ProcessMesh(core.ProcessMesh):
         self._shape = list(self._mesh.shape)
         self._process_ids = self._mesh.flatten().tolist()
 
-        assert all(
-            isinstance(p, int) for p in self._process_ids
-        ), "All elements of the mesh must be integer"
-        assert (
-            min(self._process_ids) >= 0
-        ), 'All elements of the mesh must be >= 0.'
+        assert all(isinstance(p, int) for p in self._process_ids), (
+            "All elements of the mesh must be integer"
+        )
+        assert min(self._process_ids) >= 0, (
+            'All elements of the mesh must be >= 0.'
+        )
         unique_process_ids = set(self._process_ids)
-        assert len(unique_process_ids) == len(
-            self._process_ids
-        ), 'All elements of the mesh must be unique.'
+        assert len(unique_process_ids) == len(self._process_ids), (
+            'All elements of the mesh must be unique.'
+        )
 
         if dim_names is not None:
-            assert len(dim_names) == len(
-                self._shape
-            ), "The length of dims_names must be same as the shape of the mesh."
+            assert len(dim_names) == len(self._shape), (
+                "The length of dims_names must be same as the shape of the mesh."
+            )
             self._dim_names = copy.deepcopy(dim_names)
         else:
             self._dim_names = ["d" + str(i) for i in range(len(self._shape))]
         unique_dim_names = set(self._dim_names)
-        assert len(unique_dim_names) == len(
-            self._dim_names
-        ), f'All dim_names {dim_names} must be unique.'
+        assert len(unique_dim_names) == len(self._dim_names), (
+            f'All dim_names {dim_names} must be unique.'
+        )
 
         # Follow the requirement for using pybind11
         core.ProcessMesh.__init__(
@@ -296,9 +296,9 @@ class ProcessMesh(core.ProcessMesh):
         dim_name: str,
         index: slice | tuple[slice, ...] | SupportsIndex | None = None,
     ) -> ProcessMesh:
-        assert (
-            dim_name in self._dim_names
-        ), f'{dim_name} is not a valid dim name.'
+        assert dim_name in self._dim_names, (
+            f'{dim_name} is not a valid dim name.'
+        )
         index_axis = self._dim_names.index(dim_name)
         new_order = [index_axis] + [
             i for i in range(len(self._dim_names)) if i != index_axis

--- a/python/paddle/distributed/auto_parallel/random.py
+++ b/python/paddle/distributed/auto_parallel/random.py
@@ -79,12 +79,12 @@ def determinate_rng(
     rank, dims_mapping=None, process_mesh=None, placements=None
 ):
     assert process_mesh is not None, "Must provide process mesh"
-    assert (
-        dims_mapping is not None or placements is not None
-    ), "Must provide one of dims mapping or placements."
-    assert not (
-        dims_mapping is not None and placements is not None
-    ), "Cannot provide dims mapping and placements at same time."
+    assert dims_mapping is not None or placements is not None, (
+        "Must provide one of dims mapping or placements."
+    )
+    assert not (dims_mapping is not None and placements is not None), (
+        "Cannot provide dims mapping and placements at same time."
+    )
     # TODO(JZ-LIANG) Support Mesh with any high rank
     # use a string to unique integer hashing algorithm for seed computation.
     # instead of using offsets to coordinate seed across devices.
@@ -129,9 +129,9 @@ def determinate_rng(
     if sharding_expr in _rng_name_to_seed:
         assert _rng_name_to_seed[sharding_expr] == seed_
     else:
-        assert (
-            seed_ not in _rng_name_to_seed.values()
-        ), f"Seed Conflict! current seed: {seed_}, current sharding expr: {sharding_expr}, generated seed: {_rng_name_to_seed}"
+        assert seed_ not in _rng_name_to_seed.values(), (
+            f"Seed Conflict! current seed: {seed_}, current sharding expr: {sharding_expr}, generated seed: {_rng_name_to_seed}"
+        )
         _rng_name_to_seed[sharding_expr] = seed_
         if paddle.in_dynamic_mode():
             # for dygraph, just init the seed when meeting a new seed
@@ -145,9 +145,9 @@ def determinate_rng(
 @contextlib.contextmanager
 def rng_state(name):
     global _rng_name_to_states
-    assert (
-        name in _rng_name_to_states
-    ), f"The rng state name {name} haven't been init. "
+    assert name in _rng_name_to_states, (
+        f"The rng state name {name} haven't been init. "
+    )
     orig_rng_state = paddle.get_rng_state()
     paddle.set_rng_state(_rng_name_to_states[name])
     try:

--- a/python/paddle/distributed/auto_parallel/sharding.py
+++ b/python/paddle/distributed/auto_parallel/sharding.py
@@ -55,9 +55,9 @@ def get_placement_with_sharding(param, sharding_axis, param_placements=None):
         if isinstance(placement, dist.Shard):
             # the parameter can't be shard twice with sharding on different mesh now
             # for example, [Shard(0), Shard(1)], assert here in case
-            assert (
-                shard_axis == -1
-            ), "The parameter can't be shard twice with sharding strategy even in different mesh now."
+            assert shard_axis == -1, (
+                "The parameter can't be shard twice with sharding strategy even in different mesh now."
+            )
             shard_axis = placement.get_dim()
 
     placement_with_sharding = None
@@ -99,12 +99,14 @@ class ShardingOptimizerStage1(Optimizer):
     """
 
     def __init__(self, optimizer, shard_fn=None, strategy=None):
-        assert (
-            optimizer is not None
-        ), "The argument `optimizer` cannot be empty."
+        assert optimizer is not None, (
+            "The argument `optimizer` cannot be empty."
+        )
         assert isinstance(
             optimizer, (paddle.optimizer.AdamW, paddle.optimizer.SGD)
-        ), "`paddle.distributed.ShardOptimizer` only supports AdamW and SGD optimizer for now."
+        ), (
+            "`paddle.distributed.ShardOptimizer` only supports AdamW and SGD optimizer for now."
+        )
         self.__dict__["_inner_opt"] = optimizer
         self._shard_fn = shard_fn
         self._strategy = strategy or Strategy()
@@ -181,15 +183,17 @@ class ShardingOptimizerStage1(Optimizer):
                 continue
             param_dist_attr = param.dist_attr()
             grad_dist_attr = grad.dist_attr()
-            assert (
-                param_dist_attr is not None
-            ), f"parameter dist attribute must not None. but received {param.name} : {param}."
-            assert (
-                grad_dist_attr is not None
-            ), f"gradient dist attribute must not None. but received {param.name} grad : {grad}."
+            assert param_dist_attr is not None, (
+                f"parameter dist attribute must not None. but received {param.name} : {param}."
+            )
+            assert grad_dist_attr is not None, (
+                f"gradient dist attribute must not None. but received {param.name} grad : {grad}."
+            )
             assert (
                 param_dist_attr.process_mesh == grad_dist_attr.process_mesh
-            ), f"Parameter and grad should have same process_mesh. but received name:{param.name}, parameter:{param}, grad: {grad}."
+            ), (
+                f"Parameter and grad should have same process_mesh. but received name:{param.name}, parameter:{param}, grad: {grad}."
+            )
 
             if self._sharding_axis not in grad_dist_attr.partial_dims:
                 new_params_grads.append((param, grad))
@@ -204,9 +208,9 @@ class ShardingOptimizerStage1(Optimizer):
                 else:
                     param.optimize_attr["no_fusion"] = False
 
-            assert (
-                param_dist_attr.process_mesh in self.pp_meshes
-            ), f"parameter mesh mush be in pp_meshes. but received parameter name:{param.name}, mesh:{param_dist_attr.process_mesh}, pp_meshes: {self.pp_meshes}."
+            assert param_dist_attr.process_mesh in self.pp_meshes, (
+                f"parameter mesh mush be in pp_meshes. but received parameter name:{param.name}, mesh:{param_dist_attr.process_mesh}, pp_meshes: {self.pp_meshes}."
+            )
 
             if dist.get_rank() in param_dist_attr.process_mesh.process_ids:
                 sub_mesh = get_1D_sub_process_mesh(
@@ -214,20 +218,24 @@ class ShardingOptimizerStage1(Optimizer):
                 )
                 assert (
                     sorted(sub_mesh.process_ids) == self._sharding_group.ranks
-                ), f" all parameter must have the same sharding group. but received {param.name} sharding group is : {sub_mesh.process_ids}, global sharding group is: {self._sharding_group.ranks}"
+                ), (
+                    f" all parameter must have the same sharding group. but received {param.name} sharding group is : {sub_mesh.process_ids}, global sharding group is: {self._sharding_group.ranks}"
+                )
 
-            assert (
-                param_dist_attr.partial_dims == set()
-            ), f"Sharding fusion do not support partial parameter. but received {param.name} : {param}."
+            assert param_dist_attr.partial_dims == set(), (
+                f"Sharding fusion do not support partial parameter. but received {param.name} : {param}."
+            )
             assert (
                 param_dist_attr.dims_mapping == grad_dist_attr.dims_mapping
-            ), f"Parameter and grad should have same dims_mapping. but received name:{param.name}, parameter:{param}, grad: {grad}."
-            assert (
-                param.shape == grad.shape
-            ), f"Parameter and grad should have same global shape. but received name:{param.name}, parameter:{param}, grad: {grad}."
-            assert (
-                param._local_shape == grad._local_shape
-            ), f"Parameter and grad should have same local shape. but received name:{param.name}, parameter:{param}, grad: {grad}."
+            ), (
+                f"Parameter and grad should have same dims_mapping. but received name:{param.name}, parameter:{param}, grad: {grad}."
+            )
+            assert param.shape == grad.shape, (
+                f"Parameter and grad should have same global shape. but received name:{param.name}, parameter:{param}, grad: {grad}."
+            )
+            assert param._local_shape == grad._local_shape, (
+                f"Parameter and grad should have same local shape. but received name:{param.name}, parameter:{param}, grad: {grad}."
+            )
 
             if (
                 self._mp_degree > 1
@@ -501,9 +509,9 @@ class ShardingOptimizerStage1(Optimizer):
             for index in indices:
                 param = parameters[index]
                 self._slice_param_group_info[group_idx][param.name] = {}
-                self._slice_param_group_info[group_idx][param.name][
-                    "shape"
-                ] = param.shape
+                self._slice_param_group_info[group_idx][param.name]["shape"] = (
+                    param.shape
+                )
                 self._slice_param_group_info[group_idx][param.name][
                     "param_start"
                 ] = -1
@@ -531,14 +539,14 @@ class ShardingOptimizerStage1(Optimizer):
             ] = param_end
 
         for name, padded_size in padded_size_dict.items():
-            self._slice_param_group_info[group_idx][name][
-                "padded_size"
-            ] = padded_size
+            self._slice_param_group_info[group_idx][name]["padded_size"] = (
+                padded_size
+            )
 
         for name, _ in self._slice_param_group_info[group_idx].items():
-            self._slice_param_group_info[group_idx][name][
-                "align_size"
-            ] = align_size
+            self._slice_param_group_info[group_idx][name]["align_size"] = (
+                align_size
+            )
 
     def _reduce_scatter_overlap(self, group_grad_list, target_block):
         '''

--- a/python/paddle/distributed/auto_parallel/static/auto_align_tool.py
+++ b/python/paddle/distributed/auto_parallel/static/auto_align_tool.py
@@ -117,9 +117,9 @@ class AutoAlignTool:
         for block in self._blocks:
             for op in block.ops:
                 if is_loss_op(op):
-                    assert (
-                        len(op.desc.output_arg_names()) == 1
-                    ), "loss op should only output loss var"
+                    assert len(op.desc.output_arg_names()) == 1, (
+                        "loss op should only output loss var"
+                    )
                     loss_ops.append(op)
 
         for block in self._blocks:

--- a/python/paddle/distributed/auto_parallel/static/cluster_v2.py
+++ b/python/paddle/distributed/auto_parallel/static/cluster_v2.py
@@ -85,21 +85,21 @@ class DeviceMesh(core.DeviceMesh):
         self._shape = list(self._mesh.shape)
 
         self._device_ids = self._mesh.flatten().tolist()
-        assert all(
-            isinstance(p, int) for p in self._device_ids
-        ), "All elements of the mesh be integer"
-        assert (
-            min(self._device_ids) >= 0
-        ), 'All elements of the mesh must be >= 0.'
+        assert all(isinstance(p, int) for p in self._device_ids), (
+            "All elements of the mesh be integer"
+        )
+        assert min(self._device_ids) >= 0, (
+            'All elements of the mesh must be >= 0.'
+        )
         unique_device_ids = set(self._device_ids)
-        assert len(unique_device_ids) == len(
-            self._device_ids
-        ), 'All elements of the mesh must be unique.'
+        assert len(unique_device_ids) == len(self._device_ids), (
+            'All elements of the mesh must be unique.'
+        )
 
         if dim_names is not None:
-            assert len(dim_names) == len(
-                self._shape
-            ), "The length of dims_names must be same as the shape of the mesh."
+            assert len(dim_names) == len(self._shape), (
+                "The length of dims_names must be same as the shape of the mesh."
+            )
             self._dim_names = dim_names
         else:
             self._dim_names = ["d" + str(i) for i in range(len(self._shape))]

--- a/python/paddle/distributed/auto_parallel/static/completion.py
+++ b/python/paddle/distributed/auto_parallel/static/completion.py
@@ -1251,19 +1251,19 @@ class Completer:
                 seg_op_deps[struct_name] = [i]
                 seg_op_mesh[struct_name] = dist_op.dist_attr.process_mesh
             else:
-                assert (
-                    seg_op_deps[struct_name][-1] + 1 == i
-                ), "The segment's ops should be continuous."
+                assert seg_op_deps[struct_name][-1] + 1 == i, (
+                    "The segment's ops should be continuous."
+                )
                 pre_mesh = seg_op_mesh[struct_name]
-                assert (
-                    pre_mesh == dist_op.dist_attr.process_mesh
-                ), "The segment's ops should have same process_mesh."
+                assert pre_mesh == dist_op.dist_attr.process_mesh, (
+                    "The segment's ops should have same process_mesh."
+                )
                 seg_op_deps[struct_name].extend([i])
 
         num_chunks = pp_degree * vpp_degree
-        assert (
-            len(seg_op_deps) % num_chunks == 0
-        ), f"The number of layers[{seg_method}] ({len(seg_op_deps)}) should be divided by part number ({num_chunks})."
+        assert len(seg_op_deps) % num_chunks == 0, (
+            f"The number of layers[{seg_method}] ({len(seg_op_deps)}) should be divided by part number ({num_chunks})."
+        )
 
         # Step2: analysis whether the pp_stage is non-decreasing among segments
         # 1. if non_decreasing is True, the ops' process_mesh will be changed by vpp strategy
@@ -1634,9 +1634,9 @@ class Completer:
                                     input_name
                                 )
                             )
-                    assert (
-                        ref_dims_mapping is not None
-                    ), f"[{input_name}] 's dims mapping is NONE"
+                    assert ref_dims_mapping is not None, (
+                        f"[{input_name}] 's dims mapping is NONE"
+                    )
                     grad_op_dist_attr.set_input_dims_mapping(
                         input_name, ref_dims_mapping
                     )
@@ -1671,7 +1671,9 @@ class Completer:
                     output_name = grad_op.output_arg_names[0]
                     assert (
                         output_name in grad_var_to_var[appended_grad_times]
-                    ), f"sum op's output '{output_name}' has no corresponding var"
+                    ), (
+                        f"sum op's output '{output_name}' has no corresponding var"
+                    )
                     ref_fwd_var_name = grad_var_to_var[appended_grad_times][
                         output_name
                     ]
@@ -1755,9 +1757,9 @@ class Completer:
             return False
 
         def _get_forward_varname_from_grad_varname(grad_var_name):
-            assert _is_grad_var_name(
-                grad_var_name
-            ), f"[{grad_var_name}] is not a grad var name."
+            assert _is_grad_var_name(grad_var_name), (
+                f"[{grad_var_name}] is not a grad var name."
+            )
             return grad_var_name[: grad_var_name.find("@GRAD")]
 
         def _get_op_by_id(ops, id):
@@ -1828,9 +1830,9 @@ class Completer:
                                     input_name
                                 )
                             )
-                    assert (
-                        ref_dims_mapping is not None
-                    ), f"[{input_name}] 's dims mapping is NONE"
+                    assert ref_dims_mapping is not None, (
+                        f"[{input_name}] 's dims mapping is NONE"
+                    )
                     grad_op_dist_attr.set_input_dims_mapping(
                         input_name, ref_dims_mapping
                     )
@@ -1973,9 +1975,9 @@ class Completer:
                 first_backward_op_idx = idx
                 break
 
-        assert (
-            first_backward_op_idx >= 0 and loss_op is not None
-        ), "No backward procedure found in this program."
+        assert first_backward_op_idx >= 0 and loss_op is not None, (
+            "No backward procedure found in this program."
+        )
 
         ops = list(serial_main_program.global_block().ops)
         vars = serial_main_program.global_block().vars
@@ -1989,12 +1991,12 @@ class Completer:
             # complete the initial grad loss op
             if idx == first_backward_op_idx:
                 assert grad_op.type == "fill_constant"
-                assert (
-                    len(grad_op.input_arg_names) == 0
-                ), f"first backward op should has only ONE output, but got [{len(grad_op.input_arg_names)}]"
-                assert (
-                    len(grad_op.output_arg_names) == 1
-                ), f"first backward op should has only ONE output, but got [{len(grad_op.output_arg_names)}]"
+                assert len(grad_op.input_arg_names) == 0, (
+                    f"first backward op should has only ONE output, but got [{len(grad_op.input_arg_names)}]"
+                )
+                assert len(grad_op.output_arg_names) == 1, (
+                    f"first backward op should has only ONE output, but got [{len(grad_op.output_arg_names)}]"
+                )
 
                 loss_var = vars[loss_op.output_arg_names[0]]
                 loss_grad_var = vars[grad_op.output_arg_names[0]]
@@ -2069,9 +2071,9 @@ class Completer:
                 if grad_op.type in ['sum', 'grad_add']:
                     assert all(map(_is_grad_var_name, grad_op.input_arg_names))
                     output_name = grad_op.output_arg_names[0]
-                    assert (
-                        output_name in grad_var_to_var
-                    ), f"sum op's output '{output_name}' has no corresponding var"
+                    assert output_name in grad_var_to_var, (
+                        f"sum op's output '{output_name}' has no corresponding var"
+                    )
                     ref_fwd_var_name = grad_var_to_var[output_name]
                     ref_fwd_var = vars[ref_fwd_var_name]
                     ref_fwd_dist_attr = (
@@ -2297,12 +2299,12 @@ class Completer:
                     )
 
                 if "Grad" in op.input_names and "Param" in ops[idx].input_names:
-                    assert (
-                        len(op.input("Param")) == 1
-                    ), "Only support one-to-one now."
-                    assert (
-                        len(op.input("Grad")) == 1
-                    ), "Only support one-to-one now."
+                    assert len(op.input("Param")) == 1, (
+                        "Only support one-to-one now."
+                    )
+                    assert len(op.input("Grad")) == 1, (
+                        "Only support one-to-one now."
+                    )
                     param = vars[op.input("Param")[0]]
                     grad_var = vars[op.input("Grad")[0]]
 

--- a/python/paddle/distributed/auto_parallel/static/cost/base_cost.py
+++ b/python/paddle/distributed/auto_parallel/static/cost/base_cost.py
@@ -629,14 +629,14 @@ class Cost:
         assert val >= 0, "Time must be greater than or equal to 0."
 
     def _check_memory(self, val):
-        assert (
-            isinstance(val, int) and val >= 0
-        ), "Memory must be int and greater than equal to 0."
+        assert isinstance(val, int) and val >= 0, (
+            "Memory must be int and greater than equal to 0."
+        )
 
     def _check_flops(self, val):
-        assert (
-            isinstance(val, int) and val >= 0
-        ), "FLOPs must be int and greater than equal to 0."
+        assert isinstance(val, int) and val >= 0, (
+            "FLOPs must be int and greater than equal to 0."
+        )
 
     @property
     def time(self):
@@ -987,9 +987,9 @@ def calc_time_by_cost_model(op, cluster=None):
         var_name = op.output_arg_names[0]
         dtype = op.block._var_recursive(var_name).dtype
         device = cluster.get_device(0)
-        assert (
-            device.type == DeviceType.GPU
-        ), "Only GPU device is supported currently."
+        assert device.type == DeviceType.GPU, (
+            "Only GPU device is supported currently."
+        )
 
         gflops = 0.0
         if dtype == paddle.float64:

--- a/python/paddle/distributed/auto_parallel/static/cost/estimate_cost.py
+++ b/python/paddle/distributed/auto_parallel/static/cost/estimate_cost.py
@@ -37,9 +37,7 @@ class CostEstimator:
         self._loop_count = loop_count
         self._global_cost = Cost()
         self._local_cost_mapping = {}
-        self._detailed_cost = (
-            OrderedDict()
-        )  # {`op_id`: {"reshard": [], "dist_op": [], "local_cost": local_cost}}}
+        self._detailed_cost = OrderedDict()  # {`op_id`: {"reshard": [], "dist_op": [], "local_cost": local_cost}}}
         self._bubble_time_mapping = {}
         self._ordered_ops = []
         self.max_memories = {}
@@ -286,9 +284,7 @@ class CostEstimator:
 
         memories = {}
         self.max_memories = {}
-        var_info = (
-            {}
-        )  # var_name: [[process_mesh, dims_mapping], [id]], [[process_mesh, dims_mapping], [id]]}
+        var_info = {}  # var_name: [[process_mesh, dims_mapping], [id]], [[process_mesh, dims_mapping], [id]]}
 
         for block in self.program.blocks:
             for op in block.ops:

--- a/python/paddle/distributed/auto_parallel/static/cost/op_runtime_cost.py
+++ b/python/paddle/distributed/auto_parallel/static/cost/op_runtime_cost.py
@@ -271,19 +271,21 @@ def measure_program_real_op_cost(
     >>> measure_program_real_op_cost(program, verbose_level=1)
     '''
 
-    assert isinstance(
-        program, Program
-    ), f'"program" should be a instance of "paddle.base.framework.Program" but got type "{type(program).__name__}".'
+    assert isinstance(program, Program), (
+        f'"program" should be a instance of "paddle.base.framework.Program" but got type "{type(program).__name__}".'
+    )
     supported_places = [
         paddle.CUDAPlace,
     ]
     assert any(
         isinstance(place, supported_place)
         for supported_place in supported_places
-    ), f'Current place ({place}) does not support runtime profiling. "place" should be one of the following: {supported_places}.'
-    assert (
-        isinstance(run_iters, int) and run_iters >= 1
-    ), 'Invalid parameter run_iters set. run_iters should be an integer >= 1.'
+    ), (
+        f'Current place ({place}) does not support runtime profiling. "place" should be one of the following: {supported_places}.'
+    )
+    assert isinstance(run_iters, int) and run_iters >= 1, (
+        'Invalid parameter run_iters set. run_iters should be an integer >= 1.'
+    )
     if run_iters == 1:
         warnings.warn(
             'run_iters was set to 1, profiling results might be inaccurate due to outliers.'

--- a/python/paddle/distributed/auto_parallel/static/cost_model.py
+++ b/python/paddle/distributed/auto_parallel/static/cost_model.py
@@ -223,9 +223,9 @@ class CostModel:
         self.optim_time = []
 
     def _parse_sub_program(self, program, nodes, graph, cost_data, sub_idx):
-        assert (
-            len(program.blocks) == 1
-        ), "Program more than 1 block not supported."
+        assert len(program.blocks) == 1, (
+            "Program more than 1 block not supported."
+        )
         block = program.blocks[0]
 
         var_id = "lod_tensor_blocking_queue_0"

--- a/python/paddle/distributed/auto_parallel/static/dist_context.py
+++ b/python/paddle/distributed/auto_parallel/static/dist_context.py
@@ -478,9 +478,9 @@ class DistributedContext:
             self.copy_dist_attr_from_program_to_graph()
 
     def add_process_mesh(self, process_mesh):
-        assert isinstance(
-            process_mesh, (ProcessMesh, core.ProcessMesh)
-        ), 'The type of dim_mapping must be ProcessMesh.'
+        assert isinstance(process_mesh, (ProcessMesh, core.ProcessMesh)), (
+            'The type of dim_mapping must be ProcessMesh.'
+        )
         if process_mesh not in self.process_meshes:
             self._process_meshes.append(process_mesh)
 
@@ -787,9 +787,9 @@ class DistributedContext:
                     )
                 dist_tensor = cur_dist_tensor
                 self._node_id_to_tensor_id[_node_id(node)] = cur_tensor_id
-                assert (
-                    dist_tensor is not None
-                ), "Tensor must have a distributed tensor after the initialization for program."
+                assert dist_tensor is not None, (
+                    "Tensor must have a distributed tensor after the initialization for program."
+                )
                 serial_tensor_node_id = _node_id(node)
                 new_dist_tensor = DistributedTensor(
                     dist_tensor.serial_tensor, dist_tensor.dist_attr
@@ -810,9 +810,9 @@ class DistributedContext:
                     )
                 dist_op = cur_dist_op
                 self._node_id_to_op_id[_node_id(node)] = cur_op_id
-                assert (
-                    dist_op is not None
-                ), "Operator must have a distributed operator after the initialization for program."
+                assert dist_op is not None, (
+                    "Operator must have a distributed operator after the initialization for program."
+                )
                 serial_op_node_id = _node_id(node)
                 new_dist_op = DistributedOperator(
                     dist_op.serial_op, dist_op.dist_attr
@@ -843,9 +843,9 @@ class DistributedContext:
                         cur_tensor_id, None
                     )
                 dist_tensor = cur_dist_tensor
-                assert (
-                    dist_tensor is not None
-                ), "Tensor must have a distributed tensor after the initialization for program."
+                assert dist_tensor is not None, (
+                    "Tensor must have a distributed tensor after the initialization for program."
+                )
                 serial_tensor_node_id = _node_id(node)
                 new_dist_tensor = DistributedTensor(
                     dist_tensor.serial_tensor, dist_tensor.dist_attr
@@ -865,9 +865,9 @@ class DistributedContext:
                         cur_op_id, None
                     )
                 dist_op = cur_dist_op
-                assert (
-                    dist_op is not None
-                ), "Operator must have a distributed operator after the initialization for program."
+                assert dist_op is not None, (
+                    "Operator must have a distributed operator after the initialization for program."
+                )
                 serial_op_node_id = _node_id(node)
                 new_dist_op = DistributedOperator(
                     dist_op.serial_op, dist_op.dist_attr
@@ -875,9 +875,9 @@ class DistributedContext:
                 self._dist_ops_for_graph[serial_op_node_id] = new_dist_op
 
     def copy_dist_attr_from_graph_to_program(self):
-        assert (
-            self._is_initialized
-        ), "Both program and graph must be initialized."
+        assert self._is_initialized, (
+            "Both program and graph must be initialized."
+        )
         updated_tensors = {}
         all_nodes = self._serial_ordered_nodes
         process_meshes = [self.process_meshes[0]]
@@ -1023,9 +1023,9 @@ class DistributedContext:
         for block in self.serial_main_program.blocks:
             for tensor in block.vars.values():
                 dist_tensor = self.get_dist_tensor_for_program(tensor)
-                assert (
-                    dist_tensor is not None
-                ), f"Tensor {dist_tensor.serial_tensor.name} does not have a distributed attribute."
+                assert dist_tensor is not None, (
+                    f"Tensor {dist_tensor.serial_tensor.name} does not have a distributed attribute."
+                )
                 if (dist_tensor is not None) and (
                     not dist_tensor.validate_dist_attr()
                 ):
@@ -1034,9 +1034,9 @@ class DistributedContext:
                     )
             for op in block.ops:
                 dist_op = self.get_dist_op_for_program(op)
-                assert (
-                    dist_op is not None
-                ), f"Operator {dist_op.serial_op.type} does not have a distributed attribute."
+                assert dist_op is not None, (
+                    f"Operator {dist_op.serial_op.type} does not have a distributed attribute."
+                )
                 if (dist_op is not None) and (not dist_op.validate_dist_attr()):
                     raise AssertionError(
                         f"Operator {dist_op.serial_op.type} (id: {dist_op.serial_op.desc.id()}, original_id: {dist_op.serial_op.desc.original_id()}) has a wrong distributed attributes {dist_op.dist_attr} ."
@@ -1214,18 +1214,18 @@ class BlockState:
 
         for idx, block in enumerate(program.blocks):
             assert idx == block.idx, "index doesn't match"
-            assert (
-                block.forward_block_idx == -1
-            ), f"forward_block_idx of forward block [{idx}] is not [{block.forward_block_idx}]"
+            assert block.forward_block_idx == -1, (
+                f"forward_block_idx of forward block [{idx}] is not [{block.forward_block_idx}]"
+            )
             self.forward_indices.append(idx)
             self.nblock += 1
 
         assert self.nblock >= 1
 
     def parse_backward_blocks(self, program):
-        assert (
-            0 in self.forward_indices
-        ), f"forward block idx are{self.forward_indices}"
+        assert 0 in self.forward_indices, (
+            f"forward block idx are{self.forward_indices}"
+        )
         self.backward_to_forward_index_map[0] = 0
 
         for idx, block in enumerate(program.blocks):

--- a/python/paddle/distributed/auto_parallel/static/dist_loader.py
+++ b/python/paddle/distributed/auto_parallel/static/dist_loader.py
@@ -186,9 +186,9 @@ class DistributedDataLoaderFromGenerator(DistributedDataLoaderBase):
                         continue
 
                     batch_size = array.shape[0]
-                    assert (
-                        batch_size % self.dp_world_sizes[i] == 0
-                    ), f"batch_size [{batch_size}] is not divisible by dp_world_size [{self.dp_world_sizes[i]}]"
+                    assert batch_size % self.dp_world_sizes[i] == 0, (
+                        f"batch_size [{batch_size}] is not divisible by dp_world_size [{self.dp_world_sizes[i]}]"
+                    )
                     partial_data.append(
                         np.split(array, self.dp_world_sizes[i])[
                             self.dp_ranks[i]

--- a/python/paddle/distributed/auto_parallel/static/dist_op.py
+++ b/python/paddle/distributed/auto_parallel/static/dist_op.py
@@ -217,9 +217,9 @@ class DistributedOperatorHelper:
         tensor_to_dims_mapping = {}
         index = 0
         if self._in_dims_mappings:
-            assert len(args) + len(kwargs) == len(
-                self._in_dims_mappings
-            ), f"The length of dims_mapping {len(self._in_dims_mappings)} does not matching the length output {len(args) + len(kwargs)}."
+            assert len(args) + len(kwargs) == len(self._in_dims_mappings), (
+                f"The length of dims_mapping {len(self._in_dims_mappings)} does not matching the length output {len(args) + len(kwargs)}."
+            )
         for arg in args:
             if isinstance(arg, Variable) and self._in_dims_mappings:
                 tensor_to_dims_mapping[arg.name] = self._in_dims_mappings[index]
@@ -248,9 +248,9 @@ class DistributedOperatorHelper:
             raise ValueError("Unrecognized output.")
 
         if self._out_dims_mappings:
-            assert len(new_output) == len(
-                self._out_dims_mappings
-            ), f"The length of dims_mapping {len(self._out_dims_mappings)} does not matching the length output {len(new_output)}."
+            assert len(new_output) == len(self._out_dims_mappings), (
+                f"The length of dims_mapping {len(self._out_dims_mappings)} does not matching the length output {len(new_output)}."
+            )
         for i, item in enumerate(new_output):
             if isinstance(item, Variable) and self._out_dims_mappings:
                 tensor_to_dims_mapping[item.name] = self._out_dims_mappings[i]
@@ -282,7 +282,9 @@ class DistributedOperatorHelper:
                         )
                         assert verify_shard_spec(
                             shard_spec, tensor_shape, self._process_mesh
-                        ), f"For tensor {name}, shard_spec {shard_spec} is invalid with tensor_shape {tensor_shape} and process_mesh {self._process_mesh}."
+                        ), (
+                            f"For tensor {name}, shard_spec {shard_spec} is invalid with tensor_shape {tensor_shape} and process_mesh {self._process_mesh}."
+                        )
                         tensor_dist_attr.dims_mapping = dims_mapping
                         tensor_dist_attr.mark_annotated("dims_mapping")
             for name in dist_op.serial_op.output_arg_names:
@@ -306,7 +308,9 @@ class DistributedOperatorHelper:
                         )
                         assert verify_shard_spec(
                             shard_spec, tensor_shape, self._process_mesh
-                        ), f"For tensor {name}, shard_spec {shard_spec} is invalid with tensor_shape {tensor_shape} and process_mesh {self._process_mesh}."
+                        ), (
+                            f"For tensor {name}, shard_spec {shard_spec} is invalid with tensor_shape {tensor_shape} and process_mesh {self._process_mesh}."
+                        )
                         tensor_dist_attr.dims_mapping = dims_mapping
                         tensor_dist_attr.mark_annotated("dims_mapping")
             dist_op.dist_attr.process_mesh = self._process_mesh

--- a/python/paddle/distributed/auto_parallel/static/dist_tensor.py
+++ b/python/paddle/distributed/auto_parallel/static/dist_tensor.py
@@ -148,9 +148,9 @@ class DistributedTensor:
         local_sizes = DistributedTensor.get_local_sizes(
             global_sizes, dims_mapping, topology, processes, rank, shard_sizes
         )
-        assert len(local_sizes) == len(
-            local_offsets
-        ), f"The length of local_sizes must be equal to local_offsets, but got {len(local_sizes)} and {len(local_offsets)}."
+        assert len(local_sizes) == len(local_offsets), (
+            f"The length of local_sizes must be equal to local_offsets, but got {len(local_sizes)} and {len(local_offsets)}."
+        )
 
         local_end_offsets = [
             x[0] + x[1] for x in zip(local_offsets, local_sizes)
@@ -359,9 +359,9 @@ class DistributedTensor:
 
     def local_tensor(self, rank=None):
         rank = paddle.distributed.get_rank() if rank is None else rank
-        assert (
-            rank in self._local_tensor_map
-        ), f"The rank {rank} local tensor has not been created."
+        assert rank in self._local_tensor_map, (
+            f"The rank {rank} local tensor has not been created."
+        )
         return self._local_tensor_map[rank]
 
     def __deepcopy__(self, memo):

--- a/python/paddle/distributed/auto_parallel/static/engine.py
+++ b/python/paddle/distributed/auto_parallel/static/engine.py
@@ -284,9 +284,9 @@ class Engine:
             self._strategy.pipeline.enable
             and self._strategy.pipeline.schedule_mode == "1F1B"
         ):
-            assert (
-                os.getenv("CUDA_MODULE_LOADING") != "LAZY"
-            ), "EXP_CUDA_MODULE_LOADING_LAZY not supported in 1F1B pipeline."
+            assert os.getenv("CUDA_MODULE_LOADING") != "LAZY", (
+                "EXP_CUDA_MODULE_LOADING_LAZY not supported in 1F1B pipeline."
+            )
 
         self.history = None
 
@@ -471,28 +471,28 @@ class Engine:
             raise ValueError("Only support static graph mode.")
 
         if inputs_spec:
-            assert isinstance(
-                inputs_spec, list
-            ), f"inputs should be list, but received {type(inputs_spec)}"
-            assert isinstance(
-                inputs, list
-            ), f"inputs should be list, but received {type(inputs)}"
-            assert len(inputs_spec) == len(
-                inputs
-            ), "the number of `inputs_spec` should be equal to `inputs`'s."
+            assert isinstance(inputs_spec, list), (
+                f"inputs should be list, but received {type(inputs_spec)}"
+            )
+            assert isinstance(inputs, list), (
+                f"inputs should be list, but received {type(inputs)}"
+            )
+            assert len(inputs_spec) == len(inputs), (
+                "the number of `inputs_spec` should be equal to `inputs`'s."
+            )
             for input_spec, input in zip(inputs_spec, inputs):
                 if input_spec.shape != input.shape:
                     input.desc.set_shape(input_spec.shape)
         if labels_spec:
-            assert isinstance(
-                labels_spec, list
-            ), f"labels should be list, but received {type(labels_spec)}"
-            assert isinstance(
-                labels, list
-            ), f"labels should be list, but received {type(labels)}"
-            assert len(labels_spec) == len(
-                labels
-            ), "the number of `labels_spec` should be equal to `labels`'s."
+            assert isinstance(labels_spec, list), (
+                f"labels should be list, but received {type(labels_spec)}"
+            )
+            assert isinstance(labels, list), (
+                f"labels should be list, but received {type(labels)}"
+            )
+            assert len(labels_spec) == len(labels), (
+                "the number of `labels_spec` should be equal to `labels`'s."
+            )
             for label_spec, label in zip(labels_spec, labels):
                 if label_spec.shape != label.shape:
                     label.desc.set_shape(label_spec.shape)
@@ -562,18 +562,18 @@ class Engine:
             else:
                 raise ValueError(f"Unsupported data {data}")
         if user_feeds is not None:
-            assert isinstance(
-                user_feeds, dict
-            ), f"user_feeds must be a dict, but receive {type(user_feeds).__name__}"
+            assert isinstance(user_feeds, dict), (
+                f"user_feeds must be a dict, but receive {type(user_feeds).__name__}"
+            )
             for name, data in user_feeds.items():
                 feeds[name] = data
         return feeds
 
     def _prepare_fetch(self, user_fetches, mode):
         if user_fetches is not None:
-            assert isinstance(
-                user_fetches, list
-            ), f"user_fetches must be a list, but receive {type(user_fetches).__name__}"
+            assert isinstance(user_fetches, list), (
+                f"user_fetches must be a list, but receive {type(user_fetches).__name__}"
+            )
         fetch_names = []
         fetch_indices = []
 
@@ -1149,9 +1149,9 @@ class Engine:
                     if mode != "predict" and self._loss:
                         assert isinstance(
                             self._loss, paddle.nn.Layer
-                        ) or callable(
-                            self._loss
-                        ), "the type of `loss` of the Engine arguments should be sub classes of `paddle.nn.Layer` or any callable function."
+                        ) or callable(self._loss), (
+                            "the type of `loss` of the Engine arguments should be sub classes of `paddle.nn.Layer` or any callable function."
+                        )
                         self._losses = auto_utils.to_list(
                             self._loss(*(outputs + self._labels))
                         )
@@ -1164,9 +1164,9 @@ class Engine:
                                 )
                             )
             elif mode == "train":
-                assert isinstance(
-                    self._loss, Variable
-                ), "the type of `loss` of the Engine arguments should be Variable."
+                assert isinstance(self._loss, Variable), (
+                    "the type of `loss` of the Engine arguments should be Variable."
+                )
                 self._losses = auto_utils.to_list(self._loss)
 
         # TODO(zhiqiu): distributed_context is no longer used in pir_program
@@ -1237,7 +1237,9 @@ class Engine:
             self._json_config,
         )
         self._dist_contexts[mode].gradient_scale = self._strategy.gradient_scale
-        self._dist_contexts[mode].gradient_scale_using_allreduce_avg = (
+        self._dist_contexts[
+            mode
+        ].gradient_scale_using_allreduce_avg = (
             self._strategy.gradient_scale_using_allreduce_avg
         )
         self._fwd_main_progs[mode] = serial_main_prog.clone()
@@ -1270,9 +1272,9 @@ class Engine:
 
         if self._tuning.run_after_tuning:
             # update the strategy
-            self._dist_contexts[mode]._strategy = (
-                self._optimization_tuner.get_best_config()
-            )
+            self._dist_contexts[
+                mode
+            ]._strategy = self._optimization_tuner.get_best_config()
 
     def _plan(self, mode):
         if self._planned_mode is None:
@@ -1333,9 +1335,9 @@ class Engine:
         for ib, block in enumerate(origin_main_prog.blocks):
             for iop, op in enumerate(block.ops):
                 ref_op = ref_blocks[ib].ops[iop]
-                assert (
-                    op.type == ref_op.type
-                ), f"'{mode}' mode op '{op.type}' is different with '{ref_mode}' op '{ref_op.type}'. "
+                assert op.type == ref_op.type, (
+                    f"'{mode}' mode op '{op.type}' is different with '{ref_mode}' op '{ref_op.type}'. "
+                )
                 ref_op_dist_attr = (
                     ref_dist_context.get_op_dist_attr_for_program(ref_op)
                 )
@@ -1412,9 +1414,9 @@ class Engine:
                 for op in dist_main_prog.global_block().ops:
                     if op.name() == "pd_op.data":
                         var_name = op.str_attr("name")
-                        assert (
-                            var_name not in name_map_value
-                        ), f"The value {var_name} in {op} is already exist"
+                        assert var_name not in name_map_value, (
+                            f"The value {var_name} in {op} is already exist"
+                        )
                         name_map_value[var_name] = op.result(0)
                 del_ops = []
                 block = startup_prog.global_block()
@@ -2078,9 +2080,9 @@ class Engine:
             if self._orig_startup_prog is None:
                 self._orig_startup_prog = static.default_startup_program()
         else:
-            assert (
-                self._inputs_spec and self._labels_spec
-            ), "Please call the dataloader(...) before calling prepare(...)"
+            assert self._inputs_spec and self._labels_spec, (
+                "Please call the dataloader(...) before calling prepare(...)"
+            )
 
         self._inputs_spec, self._labels_spec = inputs_spec, labels_spec
         self._inputs, self._labels = inputs, labels
@@ -2265,12 +2267,12 @@ class Engine:
         if batch_size is None:
             return None
 
-        assert (
-            len(set(self._dp_world_sizes)) == 1
-        ), f"DistributedBatchSampler only support one data parallel group, but got [{len(set(self._dp_world_sizes))}] different data parallel groups"
-        assert (
-            batch_size % self._dp_world_sizes[0] == 0
-        ), f"batch_size [{batch_size}] is not divisible by dp_world_size [{self._dp_world_sizes[0]}]"
+        assert len(set(self._dp_world_sizes)) == 1, (
+            f"DistributedBatchSampler only support one data parallel group, but got [{len(set(self._dp_world_sizes))}] different data parallel groups"
+        )
+        assert batch_size % self._dp_world_sizes[0] == 0, (
+            f"batch_size [{batch_size}] is not divisible by dp_world_size [{self._dp_world_sizes[0]}]"
+        )
         return batch_size // self._dp_world_sizes[0]
 
     def _validate_batch(self, batch):
@@ -2311,9 +2313,9 @@ class Engine:
                     )
                 if self._acc_steps > 1:
                     shape = list(spec.shape)
-                    assert (
-                        shape[0] % self._acc_steps == 0
-                    ), f"Requires batch_size[{spec.shape[0]}] to be divisible by k_steps[{self._acc_steps}]."
+                    assert shape[0] % self._acc_steps == 0, (
+                        f"Requires batch_size[{spec.shape[0]}] to be divisible by k_steps[{self._acc_steps}]."
+                    )
                     shape[0] //= self._acc_steps
                     spec.shape = shape
         return specs or []
@@ -2341,9 +2343,9 @@ class Engine:
         return metrics_name
 
     def _switch_mode(self, mode):
-        assert (
-            mode in self._dist_contexts
-        ), f"{mode} model is not ready, please call `prepare()` first."
+        assert mode in self._dist_contexts, (
+            f"{mode} model is not ready, please call `prepare()` first."
+        )
         self.to_mode(mode)
 
     def to_mode(self, mode: _Mode) -> None:

--- a/python/paddle/distributed/auto_parallel/static/helper.py
+++ b/python/paddle/distributed/auto_parallel/static/helper.py
@@ -337,15 +337,15 @@ class ProgramHelper:
 
     def _verify_optimizer(self, optimizer):
         assert optimizer is not None
-        assert hasattr(
-            optimizer, "minimize"
-        ), "Optimizer must have minimize() method."
-        assert (
-            self.proxy_layer.mode == 'train'
-        ), f"Required mode == 'train', but received '{self.proxy_layer.mode}'"
-        assert (
-            len(self.loss_vars) == 1
-        ), f"Required len(loss_vars) == 1, but received len(loss_vars) = {len(self.loss_vars)}"
+        assert hasattr(optimizer, "minimize"), (
+            "Optimizer must have minimize() method."
+        )
+        assert self.proxy_layer.mode == 'train', (
+            f"Required mode == 'train', but received '{self.proxy_layer.mode}'"
+        )
+        assert len(self.loss_vars) == 1, (
+            f"Required len(loss_vars) == 1, but received len(loss_vars) = {len(self.loss_vars)}"
+        )
 
     def to(self, mode):
         """
@@ -353,9 +353,9 @@ class ProgramHelper:
         """
         assert mode in ['train', 'eval', 'predict']
         func = getattr(self.proxy_layer, '_' + mode)
-        assert isinstance(
-            func, StaticFunction
-        ), "Please call build_program(mode) firstly."
+        assert isinstance(func, StaticFunction), (
+            "Please call build_program(mode) firstly."
+        )
         self.proxy_layer.set_mode(mode)
 
     def static_func(self):
@@ -419,9 +419,9 @@ class ProgramHelper:
                 value_name = dy_param_name_to_pir_param_name[param.name]
                 value = value_name_to_value[value_name]
                 # get param_var's dist_attr
-                assert (
-                    value.is_dist_dense_tensor_type()
-                ), f"param [{value.name}] is not dist tensor type"
+                assert value.is_dist_dense_tensor_type(), (
+                    f"param [{value.name}] is not dist tensor type"
+                )
                 dist_attr = {
                     "dims_mapping": value.dist_attr().dims_mapping,
                     "process_shape": value.dist_attr().process_mesh.shape,
@@ -536,9 +536,9 @@ class ProgramHelper:
                 if param.dtype in [paddle.float16, paddle.bfloat16]:
                     continue
                 scope_tensor = global_scope().var(param.name).get_tensor()
-                assert (
-                    scope_var and scope_tensor._is_initialized()
-                ), f"Parameter: {param.name} is not put into global_scope or not initialized."
+                assert scope_var and scope_tensor._is_initialized(), (
+                    f"Parameter: {param.name} is not put into global_scope or not initialized."
+                )
                 param_used = param
                 # For the params without dist_attr.
                 # NOTE(lizhiyu): In principle, each param should have dist_attr.

--- a/python/paddle/distributed/auto_parallel/static/mapper.py
+++ b/python/paddle/distributed/auto_parallel/static/mapper.py
@@ -142,9 +142,9 @@ def analyze_comm_requirements_from_op(op, rank, g_process_group_map):
             comm_volume = get_comm_volume(op, rank, tgt_rank)
             if comm_volume is not None:
                 comm_requirements_to_ranks[tgt_rank] = {}
-                comm_requirements_to_ranks[tgt_rank][
-                    "comm_volume"
-                ] = comm_volume
+                comm_requirements_to_ranks[tgt_rank]["comm_volume"] = (
+                    comm_volume
+                )
     elif is_p2p_comm_op(op):
         tgt_rank = op.attr("peer")
         comm_volume = get_comm_volume(op, rank, tgt_rank)
@@ -170,9 +170,9 @@ def analyze_requirements_for_program(src_info, rank):
             )
             for tgt_rank, link_info in cur_comm_requirements_to_ranks.items():
                 if tgt_rank in comm_requirements_to_ranks:
-                    comm_requirements_to_ranks[tgt_rank][
-                        "comm_volume"
-                    ] += link_info["comm_volume"]
+                    comm_requirements_to_ranks[tgt_rank]["comm_volume"] += (
+                        link_info["comm_volume"]
+                    )
                 else:
                     comm_requirements_to_ranks[tgt_rank] = {}
                     comm_requirements_to_ranks[tgt_rank]["comm_volume"] = (
@@ -266,9 +266,9 @@ def mapping(distributed_program, cluster):
                     cur_rank_node["device"] = device_node["device"]
                     cur_device_node = device_node
                     break
-            assert (
-                cur_device_node
-            ), "Cannot find a device to satisfy the requirement."
+            assert cur_device_node, (
+                "Cannot find a device to satisfy the requirement."
+            )
 
             nbr_rank_edges = []
             for nbr_rank_node_id, nbr_rank_edge in process_graph.adjs[

--- a/python/paddle/distributed/auto_parallel/static/operators/common.py
+++ b/python/paddle/distributed/auto_parallel/static/operators/common.py
@@ -107,9 +107,9 @@ class DistributedOperatorImplContainer(abc.ABC):
         return self._impls
 
     def register_impl(self, dist_impl):
-        assert (
-            self.type == dist_impl.type
-        ), "Op type of container must be same as that of the implementation."
+        assert self.type == dist_impl.type, (
+            "Op type of container must be same as that of the implementation."
+        )
         impl_idx = len(self.impls)
         dist_impl.idx = impl_idx
         self._impls.append(dist_impl)
@@ -353,9 +353,9 @@ def is_parameter_related(varname, block, dist_context=None):
         varname = varname[: varname.index(".cast_bf")]
     if ".quantized" in varname:
         varname = varname[: varname.index(".quantized")]
-    assert block._find_var_recursive(
-        varname
-    ), f"cannot find var {varname} in cur block"
+    assert block._find_var_recursive(varname), (
+        f"cannot find var {varname} in cur block"
+    )
     var = block._var_recursive(varname)
     # NOTE(hack method): to find the param which is resharded
     if dist_context and "@RESHARD" in varname:
@@ -551,9 +551,9 @@ def sync_and_scale_gradients(dist_ctx, op, groups, allreduce_var_names):
                 added_ops.append(scale_op)
 
             dims_mapping = op_dist_attr.get_output_dims_mapping(grad_var.name)
-            assert (
-                dims_mapping is not None
-            ), f"Unexpected: dims_mapping of output [{grad_var.name}] of op [{op_dist_attr.op_type}] is None"
+            assert dims_mapping is not None, (
+                f"Unexpected: dims_mapping of output [{grad_var.name}] of op [{op_dist_attr.op_type}] is None"
+            )
             # NOTE auxiliary op's dist attr should follow dist_op not dist_tensor
             for new_op in added_ops:
                 new_op_attr = OperatorDistAttr()
@@ -586,9 +586,9 @@ def get_partial_groups(dist_ctx, op, out_grad_names, rank):
         if partial_dims is None:
             partial_dims = var_dist_attr._partial_dims()
         else:
-            assert (
-                partial_dims == var_dist_attr._partial_dims()
-            ), f"Partial dims of outputs {out_grad_names} of op [{op.type}] is not consistent"
+            assert partial_dims == var_dist_attr._partial_dims(), (
+                f"Partial dims of outputs {out_grad_names} of op [{op.type}] is not consistent"
+            )
 
     partial_dims = list(partial_dims)
     partial_dims.sort()

--- a/python/paddle/distributed/auto_parallel/static/operators/dist_check_finite_and_unscale.py
+++ b/python/paddle/distributed/auto_parallel/static/operators/dist_check_finite_and_unscale.py
@@ -84,9 +84,9 @@ class DistributedCheckFiniteAndUnscaleImpl(DistributedOperatorImpl):
         backward_op = dist_op_context.cur_src_op
         rank_id = dist_op_context.rank_id
         dist_attr = ctx.get_op_dist_attr_for_program(backward_op)
-        assert (
-            dist_attr is not None
-        ), f"backward op [{backward_op}] don't have dist attribute !"
+        assert dist_attr is not None, (
+            f"backward op [{backward_op}] don't have dist attribute !"
+        )
 
         assert rank_id in dist_attr.process_mesh.process_ids
 
@@ -97,20 +97,20 @@ class DistributedCheckFiniteAndUnscaleImpl(DistributedOperatorImpl):
             'FoundInfinite'
         )
 
-        assert (
-            len(kwargs['Scale']) == 1
-        ), "check_finite_and_unscale input Scale take 1 variable but got {}".format(
-            kwargs['Scale']
+        assert len(kwargs['Scale']) == 1, (
+            "check_finite_and_unscale input Scale take 1 variable but got {}".format(
+                kwargs['Scale']
+            )
         )
-        assert (
-            len(kwargs['FoundInfinite']) == 1
-        ), "check_finite_and_unscale input FoundInfinite take 1 variable but got {}".format(
-            kwargs['FoundInfinite']
+        assert len(kwargs['FoundInfinite']) == 1, (
+            "check_finite_and_unscale input FoundInfinite take 1 variable but got {}".format(
+                kwargs['FoundInfinite']
+            )
         )
-        assert len(kwargs['X']) == len(
-            kwargs['Out']
-        ), "check_finite_and_unscale got [{}] X and [{}] Out, which are supposed to be equal".format(
-            len(kwargs['X']), len(kwargs['Out'])
+        assert len(kwargs['X']) == len(kwargs['Out']), (
+            "check_finite_and_unscale got [{}] X and [{}] Out, which are supposed to be equal".format(
+                len(kwargs['X']), len(kwargs['Out'])
+            )
         )
 
         filter_vars = []

--- a/python/paddle/distributed/auto_parallel/static/operators/dist_concat.py
+++ b/python/paddle/distributed/auto_parallel/static/operators/dist_concat.py
@@ -32,9 +32,9 @@ class DistributedConcat(DistributedOperatorImplContainer):
         op_desc = dist_op.serial_op.desc
 
         axis_tensor = op_desc.input('AxisTensor')
-        assert (
-            len(axis_tensor) == 0
-        ), "Please use axis attr instead of AxisTensor"
+        assert len(axis_tensor) == 0, (
+            "Please use axis attr instead of AxisTensor"
+        )
 
         input_arg_names = op_desc.input_arg_names()
         output_arg_names = op_desc.output_arg_names()

--- a/python/paddle/distributed/auto_parallel/static/operators/dist_cross_entropy.py
+++ b/python/paddle/distributed/auto_parallel/static/operators/dist_cross_entropy.py
@@ -116,12 +116,12 @@ class DistributedCrossEntropy(DistributedOperatorImplContainer):
         axis = axis + logits_ndim if axis < 0 else axis
 
         if is_dim_shard(logits_dims_mapping[axis]):
-            assert (
-                soft_label is False
-            ), "parallel_cross_entropy does not support soft_label now."
-            assert (
-                axis == logits_ndim - 1
-            ), "parallel_cross_entropy can only support shard on the last dim now."
+            assert soft_label is False, (
+                "parallel_cross_entropy does not support soft_label now."
+            )
+            assert axis == logits_ndim - 1, (
+                "parallel_cross_entropy can only support shard on the last dim now."
+            )
             op_dist_attr.impl_idx = 1
         else:
             op_dist_attr.impl_idx = 0
@@ -162,9 +162,9 @@ class DistributedCrossEntropyImpl0(DistributedOperatorImpl):
         src_op = dist_op_context.cur_src_op
         rank_id = dist_op_context.rank_id
         op_dist_attr = ctx.get_op_dist_attr_for_program(src_op)
-        assert (
-            op_dist_attr is not None
-        ), f"forward op [{src_op}] don't have dist attribute !"
+        assert op_dist_attr is not None, (
+            f"forward op [{src_op}] don't have dist attribute !"
+        )
 
         # check validation of inputs / outputs
         assert 'Logits' in kwargs, "input [Logits] is not given"
@@ -172,12 +172,12 @@ class DistributedCrossEntropyImpl0(DistributedOperatorImpl):
         assert 'Loss' in kwargs, "output [Loss] is not given"
         assert 'Softmax' in kwargs, "output [Softmax] is not given"
 
-        assert (
-            len(kwargs['Logits']) == 1
-        ), "input [Logits] take 1 variable but got {}".format(kwargs['Logits'])
-        assert (
-            len(kwargs['Label']) == 1
-        ), "input [Label] take 1 variable but got {}".format(kwargs['Label'])
+        assert len(kwargs['Logits']) == 1, (
+            "input [Logits] take 1 variable but got {}".format(kwargs['Logits'])
+        )
+        assert len(kwargs['Label']) == 1, (
+            "input [Label] take 1 variable but got {}".format(kwargs['Label'])
+        )
 
         logits_var = main_block._var_recursive(kwargs['Logits'][0])
         label_var = main_block._var_recursive(kwargs['Label'][0])
@@ -228,9 +228,9 @@ class DistributedCrossEntropyImpl0(DistributedOperatorImpl):
         rank_id = dist_op_context.rank_id
         op_dist_attr = ctx.get_op_dist_attr_for_program(backward_op)
 
-        assert (
-            op_dist_attr is not None
-        ), f"backward op [{backward_op}] don't have dist attribute !"
+        assert op_dist_attr is not None, (
+            f"backward op [{backward_op}] don't have dist attribute !"
+        )
 
         # check validation of inputs / outputs
         assert 'Softmax' in kwargs, "input [Logits] is not given"
@@ -238,21 +238,21 @@ class DistributedCrossEntropyImpl0(DistributedOperatorImpl):
         assert 'Loss@GRAD' in kwargs, "input [Loss@GRAD] is not given"
         assert 'Logits@GRAD' in kwargs, "output [Logits@GRAD] is not given"
 
-        assert (
-            len(kwargs['Softmax']) == 1
-        ), "input [Softmax] take 1 variable but got {}".format(
-            kwargs['Softmax']
+        assert len(kwargs['Softmax']) == 1, (
+            "input [Softmax] take 1 variable but got {}".format(
+                kwargs['Softmax']
+            )
         )
-        assert (
-            len(kwargs['Label']) == 1
-        ), "input [Label] take 1 variable but got {}".format(kwargs['Label'])
-        assert (
-            len(kwargs['Loss@GRAD']) == 1
-        ), "input [Loss@GRAD] take 1 variable but got {}".format(kwargs['Out'])
-        assert (
-            len(kwargs['Logits@GRAD']) == 1
-        ), "output [Logits@GRAD] take 1 variable but got {}".format(
-            kwargs['Logits@GRAD']
+        assert len(kwargs['Label']) == 1, (
+            "input [Label] take 1 variable but got {}".format(kwargs['Label'])
+        )
+        assert len(kwargs['Loss@GRAD']) == 1, (
+            "input [Loss@GRAD] take 1 variable but got {}".format(kwargs['Out'])
+        )
+        assert len(kwargs['Logits@GRAD']) == 1, (
+            "output [Logits@GRAD] take 1 variable but got {}".format(
+                kwargs['Logits@GRAD']
+            )
         )
         # replicate op in dist program
         copy_op_without_infer_shape(backward_op, main_block, ctx, kwargs)
@@ -285,9 +285,9 @@ class DistributedCrossEntropyImpl1(DistributedOperatorImpl):
         src_op = dist_op_context.cur_src_op
         rank_id = dist_op_context.rank_id
         op_dist_attr = ctx.get_op_dist_attr_for_program(src_op)
-        assert (
-            op_dist_attr is not None
-        ), f"forward op [{src_op}] don't have dist attribute !"
+        assert op_dist_attr is not None, (
+            f"forward op [{src_op}] don't have dist attribute !"
+        )
 
         # check validation of inputs / outputs
         assert 'Logits' in kwargs, "input [Logits] is not given"
@@ -295,12 +295,12 @@ class DistributedCrossEntropyImpl1(DistributedOperatorImpl):
         assert 'Loss' in kwargs, "output [Loss] is not given"
         assert 'Softmax' in kwargs, "output [Softmax] is not given"
 
-        assert (
-            len(kwargs['Logits']) == 1
-        ), "input [Logits] take 1 variable but got {}".format(kwargs['Logits'])
-        assert (
-            len(kwargs['Label']) == 1
-        ), "input [Label] take 1 variable but got {}".format(kwargs['Label'])
+        assert len(kwargs['Logits']) == 1, (
+            "input [Logits] take 1 variable but got {}".format(kwargs['Logits'])
+        )
+        assert len(kwargs['Label']) == 1, (
+            "input [Label] take 1 variable but got {}".format(kwargs['Label'])
+        )
 
         logits_var = main_block._var_recursive(kwargs['Logits'][0])
         label_var = main_block._var_recursive(kwargs['Label'][0])
@@ -395,9 +395,9 @@ class DistributedCrossEntropyImpl1(DistributedOperatorImpl):
         rank_id = dist_op_context.rank_id
         op_dist_attr = ctx.get_op_dist_attr_for_program(backward_op)
 
-        assert (
-            op_dist_attr is not None
-        ), f"backward op [{backward_op}] don't have dist attribute !"
+        assert op_dist_attr is not None, (
+            f"backward op [{backward_op}] don't have dist attribute !"
+        )
 
         # check validation of inputs / outputs
         assert 'Softmax' in kwargs, "input [Softmax] is not given"
@@ -405,23 +405,23 @@ class DistributedCrossEntropyImpl1(DistributedOperatorImpl):
         assert 'Loss@GRAD' in kwargs, "input [Loss@GRAD] is not given"
         assert 'Logits@GRAD' in kwargs, "output [Logits@GRAD] is not given"
 
-        assert (
-            len(kwargs['Softmax']) == 1
-        ), "input [Softmax] take 1 variable but got {}".format(
-            kwargs['Softmax']
+        assert len(kwargs['Softmax']) == 1, (
+            "input [Softmax] take 1 variable but got {}".format(
+                kwargs['Softmax']
+            )
         )
-        assert (
-            len(kwargs['Label']) == 1
-        ), "input [Label] take 1 variable but got {}".format(kwargs['Label'])
-        assert (
-            len(kwargs['Loss@GRAD']) == 1
-        ), "input [Loss@GRAD] take 1 variable but got {}".format(
-            kwargs['Loss@GRAD']
+        assert len(kwargs['Label']) == 1, (
+            "input [Label] take 1 variable but got {}".format(kwargs['Label'])
         )
-        assert (
-            len(kwargs['Logits@GRAD']) == 1
-        ), "output [Logits@GRAD] take 1 variable but got {}".format(
-            kwargs['Logits@GRAD']
+        assert len(kwargs['Loss@GRAD']) == 1, (
+            "input [Loss@GRAD] take 1 variable but got {}".format(
+                kwargs['Loss@GRAD']
+            )
+        )
+        assert len(kwargs['Logits@GRAD']) == 1, (
+            "output [Logits@GRAD] take 1 variable but got {}".format(
+                kwargs['Logits@GRAD']
+            )
         )
 
         # got dist attribute info

--- a/python/paddle/distributed/auto_parallel/static/operators/dist_default.py
+++ b/python/paddle/distributed/auto_parallel/static/operators/dist_default.py
@@ -60,9 +60,9 @@ def prim_operator_data_parallel_functor(ctx, src_op):
 
     var_name = src_op.output_arg_names[0]
     if var_name in ctx.grads_params:
-        assert (
-            var_name not in ctx.synced_gradient
-        ), f"in primitive mode, grad is already {var_name} synced"
+        assert var_name not in ctx.synced_gradient, (
+            f"in primitive mode, grad is already {var_name} synced"
+        )
         ctx.synced_gradient.add(var_name)
         sync_group = new_process_group(ctx.data_parallel_group)
 
@@ -119,18 +119,18 @@ class DistributedDefault(DistributedOperatorImplContainer):
         num_inputs = len(input_arg_names)
         input_specs = []
         for i in range(num_inputs):
-            assert not is_parameter_related(
-                input_arg_names[i], main_block
-            ), f"input {input_arg_names[i]} of op {dist_op.serial_op} is parameter, op should not use default rule."
+            assert not is_parameter_related(input_arg_names[i], main_block), (
+                f"input {input_arg_names[i]} of op {dist_op.serial_op} is parameter, op should not use default rule."
+            )
             input_specs.append(
                 get_dist_tensor_spec(dist_op, input_arg_names[i])
             )
         num_outputs = len(output_arg_names)
         output_specs = []
         for i in range(num_outputs):
-            assert not is_parameter_related(
-                output_arg_names[i], main_block
-            ), f"output {output_arg_names[i]} of op {dist_op.serial_op} is parameter, op should not use default rule."
+            assert not is_parameter_related(output_arg_names[i], main_block), (
+                f"output {output_arg_names[i]} of op {dist_op.serial_op} is parameter, op should not use default rule."
+            )
             output_specs.append(
                 get_dist_tensor_spec(dist_op, output_arg_names[i], False)
             )
@@ -632,9 +632,9 @@ class DistributedDefaultImpl0(DistributedOperatorImpl):
         main_block = dist_op_context.work_block
         backward_op = dist_op_context.cur_src_op
         dist_attr = ctx.get_op_dist_attr_for_program(backward_op)
-        assert (
-            dist_attr is not None
-        ), f"backward op [{backward_op}] don't have dist attribute !"
+        assert dist_attr is not None, (
+            f"backward op [{backward_op}] don't have dist attribute !"
+        )
         rank_id = dist_op_context.rank_id
 
         # check validation of inputs / outputs

--- a/python/paddle/distributed/auto_parallel/static/operators/dist_dropout.py
+++ b/python/paddle/distributed/auto_parallel/static/operators/dist_dropout.py
@@ -109,17 +109,17 @@ class DistributedDropoutImpl0(DistributedElementwiseImpl0):
         src_op = dist_op_context.cur_src_op
         rank_id = dist_op_context.rank_id
         op_dist_attr = ctx.get_op_dist_attr_for_program(src_op)
-        assert (
-            op_dist_attr is not None
-        ), f"forward op [{src_op}] don't have dist attribute !"
+        assert op_dist_attr is not None, (
+            f"forward op [{src_op}] don't have dist attribute !"
+        )
 
         if is_enable_auto_rand_ctrl() and not op_dist_attr.is_recompute:
             # check validation of inputs / outputs
             assert 'X' in kwargs, "input [{}] is not given".format('X')
-            assert (
-                len(kwargs['X']) == 1
-            ), "input X should be only one tensor but got {}".format(
-                kwargs['X']
+            assert len(kwargs['X']) == 1, (
+                "input X should be only one tensor but got {}".format(
+                    kwargs['X']
+                )
             )
             assert 'Seed' in kwargs, "input [{}] is not given".format('Seed')
 

--- a/python/paddle/distributed/auto_parallel/static/operators/dist_eltwise.py
+++ b/python/paddle/distributed/auto_parallel/static/operators/dist_eltwise.py
@@ -47,13 +47,13 @@ class DistributedElementwise(DistributedOperatorImplContainer):
     def update_dims_mapping(dist_op):
         # step1: prepare inputs need for rule (order args as PHI definition and filter out unnecessary args)
         op_desc = dist_op.serial_op.desc
-        assert (
-            len(op_desc.input_arg_names()) >= 1
-        ), f"elementwise op [{op_desc.type}] has [{len(op_desc.input_arg_names())}] inputs"
+        assert len(op_desc.input_arg_names()) >= 1, (
+            f"elementwise op [{op_desc.type}] has [{len(op_desc.input_arg_names())}] inputs"
+        )
         input_arg_names = op_desc.input_arg_names()
-        assert (
-            len(op_desc.output_arg_names()) == 1
-        ), f"elementwise op [{dist_op.serial_op}] has [{len(op_desc.output_arg_names())}] outputs"
+        assert len(op_desc.output_arg_names()) == 1, (
+            f"elementwise op [{dist_op.serial_op}] has [{len(op_desc.output_arg_names())}] outputs"
+        )
         output_arg_name = op_desc.output_arg_names()[0]
         num_inputs = len(input_arg_names)
 

--- a/python/paddle/distributed/auto_parallel/static/operators/dist_embedding.py
+++ b/python/paddle/distributed/auto_parallel/static/operators/dist_embedding.py
@@ -66,9 +66,9 @@ class DistributedEmbedding(DistributedOperatorImplContainer):
     def update_dims_mapping(dist_op):
         # step1: prepare inputs need for rule (order args as PHI definition and filter out unnecessary args)
         op_desc = dist_op.serial_op.desc
-        assert (
-            dist_op.serial_op.type == "lookup_table_v2"
-        ), f"{dist_op.serial_op.type} is not supported by dist embedding yet."
+        assert dist_op.serial_op.type == "lookup_table_v2", (
+            f"{dist_op.serial_op.type} is not supported by dist embedding yet."
+        )
 
         x_name = op_desc.input('Ids')[0]
         w_name = op_desc.input('W')[0]
@@ -129,9 +129,9 @@ register_distributed_operator_impl_container(
 
 
 def adopt_lookup_table_v1(ctx, main_block, src_op, Ids_var):
-    assert (
-        len(Ids_var.shape) == 3
-    ), f"input Ids to lookup_table should have 3 dimensions but got [{Ids_var.name}] with shape [{Ids_var.shape}]"
+    assert len(Ids_var.shape) == 3, (
+        f"input Ids to lookup_table should have 3 dimensions but got [{Ids_var.name}] with shape [{Ids_var.shape}]"
+    )
     if not Ids_var.stop_gradient:
         raise NotImplementedError(
             'Requiring the gradient of Ids of lookup_table(v1) dist op is not currently supported. Please open an issue with details on your use case so that we can prioritize adding this (for instance, adversarial training for language model).'
@@ -421,29 +421,29 @@ class DistributedEmbeddingImpl(DistributedOperatorImpl):
         src_op = dist_op_context.cur_src_op
         rank_id = dist_op_context.rank_id
         op_dist_attr = ctx.get_op_dist_attr_for_program(src_op)
-        assert (
-            op_dist_attr is not None
-        ), f"forward op [{src_op}] don't have dist attribute !"
+        assert op_dist_attr is not None, (
+            f"forward op [{src_op}] don't have dist attribute !"
+        )
 
         # check validation of inputs / outputs
         assert 'Ids' in kwargs, "input [{}] is not given".format('Ids')
         assert 'W' in kwargs, "input [{}] is not given".format('W')
         assert 'Out' in kwargs, "output [{}] is not given".format('Out')
 
-        assert (
-            len(kwargs['Ids']) == 1
-        ), "row_parallel_embedding input Ids take 1 variable but got {}".format(
-            kwargs['Ids']
+        assert len(kwargs['Ids']) == 1, (
+            "row_parallel_embedding input Ids take 1 variable but got {}".format(
+                kwargs['Ids']
+            )
         )
-        assert (
-            len(kwargs['W']) == 1
-        ), "row_parallel_embedding input W take 1 variable but got {}".format(
-            kwargs['W']
+        assert len(kwargs['W']) == 1, (
+            "row_parallel_embedding input W take 1 variable but got {}".format(
+                kwargs['W']
+            )
         )
-        assert (
-            len(kwargs['Out']) == 1
-        ), "row_parallel_embedding output Out take 1 variable but got {}".format(
-            kwargs['Out']
+        assert len(kwargs['Out']) == 1, (
+            "row_parallel_embedding output Out take 1 variable but got {}".format(
+                kwargs['Out']
+            )
         )
 
         Ids_var = main_block._var_recursive(kwargs['Ids'][0])
@@ -458,9 +458,9 @@ class DistributedEmbeddingImpl(DistributedOperatorImpl):
         embedding_row_dim_mapping = op_dist_attr.get_input_dims_mapping(
             Weight_var.name
         )[0]
-        assert (
-            embedding_row_dim_mapping >= 0
-        ), f"row_parallel_embedding's row should be divided by a specific mesh axis, but got [{embedding_row_dim_mapping}]"
+        assert embedding_row_dim_mapping >= 0, (
+            f"row_parallel_embedding's row should be divided by a specific mesh axis, but got [{embedding_row_dim_mapping}]"
+        )
         process_mesh_shape = op_dist_attr.process_mesh.shape
         process_mesh_group = op_dist_attr.process_mesh.process_ids
 
@@ -576,9 +576,9 @@ class DistributedEmbeddingImpl(DistributedOperatorImpl):
         backward_op = dist_op_context.cur_src_op
         rank_id = dist_op_context.rank_id
         dist_attr = ctx.get_op_dist_attr_for_program(backward_op)
-        assert (
-            dist_attr is not None
-        ), f"backward op [{backward_op}] don't have dist attribute !"
+        assert dist_attr is not None, (
+            f"backward op [{backward_op}] don't have dist attribute !"
+        )
 
         # FIXME (JZ-LIANG) Remove this hack to support any op mesh group for Pipeline Parallelism
         if rank_id not in dist_attr.process_mesh.process_ids:
@@ -591,25 +591,25 @@ class DistributedEmbeddingImpl(DistributedOperatorImpl):
         assert 'Out@GRAD' in kwargs, "input [{}] is not given".format('Out')
         assert 'W@GRAD' in kwargs, "output [{}] is not given".format('W@GRAD')
 
-        assert (
-            len(kwargs['Ids']) == 1
-        ), "row_parallel_embedding input Ids take 1 variable but got {}".format(
-            kwargs['Ids']
+        assert len(kwargs['Ids']) == 1, (
+            "row_parallel_embedding input Ids take 1 variable but got {}".format(
+                kwargs['Ids']
+            )
         )
-        assert (
-            len(kwargs['W']) == 1
-        ), "row_parallel_embedding input Ids take 1 variable but got {}".format(
-            kwargs['W']
+        assert len(kwargs['W']) == 1, (
+            "row_parallel_embedding input Ids take 1 variable but got {}".format(
+                kwargs['W']
+            )
         )
-        assert (
-            len(kwargs['Out@GRAD']) == 1
-        ), "row_parallel_embedding input Ids take 1 variable but got {}".format(
-            kwargs['Out']
+        assert len(kwargs['Out@GRAD']) == 1, (
+            "row_parallel_embedding input Ids take 1 variable but got {}".format(
+                kwargs['Out']
+            )
         )
-        assert (
-            len(kwargs['W@GRAD']) == 1
-        ), "row_parallel_embedding output Ids take 1 variable but got {}".format(
-            kwargs['W@GRAD']
+        assert len(kwargs['W@GRAD']) == 1, (
+            "row_parallel_embedding output Ids take 1 variable but got {}".format(
+                kwargs['W@GRAD']
+            )
         )
 
         Ids_var = main_block._var_recursive(kwargs['Ids'][0])
@@ -620,9 +620,9 @@ class DistributedEmbeddingImpl(DistributedOperatorImpl):
         embedding_row_dim_mapping = dist_attr.get_input_dims_mapping(
             Weight_var.name
         )[0]
-        assert (
-            embedding_row_dim_mapping >= 0
-        ), f"row_parallel_embedding's row should be divided by a specific mesh axis, but got [{embedding_row_dim_mapping}]"
+        assert embedding_row_dim_mapping >= 0, (
+            f"row_parallel_embedding's row should be divided by a specific mesh axis, but got [{embedding_row_dim_mapping}]"
+        )
         process_mesh_shape = dist_attr.process_mesh.shape
         process_mesh_group = dist_attr.process_mesh.process_ids
 

--- a/python/paddle/distributed/auto_parallel/static/operators/dist_flash_attn.py
+++ b/python/paddle/distributed/auto_parallel/static/operators/dist_flash_attn.py
@@ -60,9 +60,9 @@ class DistributedFlashAttnImpl0(DistributedElementwiseImpl0):
             and not op_dist_attr.is_recompute
             and rank_id in op_dist_attr.process_mesh.process_ids
         ):
-            assert (
-                op_dist_attr is not None
-            ), f"forward op [{src_op}] don't have dist attribute !"
+            assert op_dist_attr is not None, (
+                f"forward op [{src_op}] don't have dist attribute !"
+            )
 
             if (
                 len(kwargs.get('fixed_seed_offset', [])) > 0

--- a/python/paddle/distributed/auto_parallel/static/operators/dist_fused_attention.py
+++ b/python/paddle/distributed/auto_parallel/static/operators/dist_fused_attention.py
@@ -172,9 +172,9 @@ class DistributedFusedAttentionImpl(DistributedOperatorImpl):
         qkv_w_col_dim_mapping = op_dist_attr.get_input_dims_mapping(qkv_w)[
             head_axis
         ]
-        assert (
-            qkv_w_col_dim_mapping >= 0
-        ), f"col_parallel_matmul's row should be divided by a specific mesh axis, but got [{qkv_w_col_dim_mapping}]"
+        assert qkv_w_col_dim_mapping >= 0, (
+            f"col_parallel_matmul's row should be divided by a specific mesh axis, but got [{qkv_w_col_dim_mapping}]"
+        )
         process_mesh_shape = op_dist_attr.process_mesh.shape
         process_mesh_group = op_dist_attr.process_mesh.process_ids
 
@@ -209,9 +209,9 @@ class DistributedFusedAttentionImpl(DistributedOperatorImpl):
         # infer logic comm presentation
         out_w = src_op.input('OutLinearW')[0]
         out_w_col_dim_mapping = op_dist_attr.get_input_dims_mapping(out_w)[-1]
-        assert (
-            out_w_col_dim_mapping >= 0
-        ), f"col_parallel_matmul's row should be divided by a specific mesh axis, but got [{out_w_col_dim_mapping}]"
+        assert out_w_col_dim_mapping >= 0, (
+            f"col_parallel_matmul's row should be divided by a specific mesh axis, but got [{out_w_col_dim_mapping}]"
+        )
         process_mesh_shape = op_dist_attr.process_mesh.shape
         process_mesh_group = op_dist_attr.process_mesh.process_ids
 

--- a/python/paddle/distributed/auto_parallel/static/operators/dist_fused_dropout_add.py
+++ b/python/paddle/distributed/auto_parallel/static/operators/dist_fused_dropout_add.py
@@ -72,9 +72,9 @@ class DistributedDropoutImpl0(DistributedElementwiseImpl0):
         op_dist_attr = ctx.get_op_dist_attr_for_program(src_op)
 
         if is_enable_auto_rand_ctrl() and not op_dist_attr.is_recompute:
-            assert (
-                op_dist_attr is not None
-            ), f"forward op [{src_op}] don't have dist attribute !"
+            assert op_dist_attr is not None, (
+                f"forward op [{src_op}] don't have dist attribute !"
+            )
 
             assert 'seed_tensor' in kwargs, "input [{}] is not given".format(
                 'seed_tensor'

--- a/python/paddle/distributed/auto_parallel/static/operators/dist_fused_feedforward.py
+++ b/python/paddle/distributed/auto_parallel/static/operators/dist_fused_feedforward.py
@@ -163,9 +163,9 @@ class DistributedFusedFeedForwardImpl(DistributedOperatorImpl):
         linear1_weight_col_dim_mapping = op_dist_attr.get_input_dims_mapping(
             linear1_weight
         )[-1]
-        assert (
-            linear1_weight_col_dim_mapping >= 0
-        ), f"col_parallel_matmul's row should be divided by a specific mesh axis, but got [{linear1_weight_col_dim_mapping}]"
+        assert linear1_weight_col_dim_mapping >= 0, (
+            f"col_parallel_matmul's row should be divided by a specific mesh axis, but got [{linear1_weight_col_dim_mapping}]"
+        )
         process_mesh_shape = op_dist_attr.process_mesh.shape
         process_mesh_group = op_dist_attr.process_mesh.process_ids
 
@@ -202,9 +202,9 @@ class DistributedFusedFeedForwardImpl(DistributedOperatorImpl):
         linear2_weight_col_dim_mapping = op_dist_attr.get_input_dims_mapping(
             linear2_weight
         )[-1]
-        assert (
-            linear2_weight_col_dim_mapping >= 0
-        ), f"col_parallel_matmul's row should be divided by a specific mesh axis, but got [{linear2_weight_col_dim_mapping}]"
+        assert linear2_weight_col_dim_mapping >= 0, (
+            f"col_parallel_matmul's row should be divided by a specific mesh axis, but got [{linear2_weight_col_dim_mapping}]"
+        )
         process_mesh_shape = op_dist_attr.process_mesh.shape
         process_mesh_group = op_dist_attr.process_mesh.process_ids
 

--- a/python/paddle/distributed/auto_parallel/static/operators/dist_matmul.py
+++ b/python/paddle/distributed/auto_parallel/static/operators/dist_matmul.py
@@ -315,9 +315,9 @@ def _right_operand_parameter_matmul_backward(ctx, *args, **kwargs):
     backward_op = dist_op_context.cur_src_op
     rank_id = dist_op_context.rank_id
     dist_attr = ctx.get_op_dist_attr_for_program(backward_op)
-    assert (
-        dist_attr is not None
-    ), f"backward op [{backward_op}] don't have dist attribute !"
+    assert dist_attr is not None, (
+        f"backward op [{backward_op}] don't have dist attribute !"
+    )
 
     # FIXME (JZ-LIANG) Remove this hack to support any op mesh group for Pipeline Parallelism
     if rank_id not in dist_attr.process_mesh.process_ids:
@@ -328,25 +328,25 @@ def _right_operand_parameter_matmul_backward(ctx, *args, **kwargs):
     assert 'Out@GRAD' in kwargs, "input [{}] is not given".format('Out@GRAD')
     assert 'Y@GRAD' in kwargs, "output [{}] is not given".format('Y@GRAD')
     assert 'X@GRAD' in kwargs, "output [{}] is not given".format('X@GRAD')
-    assert (
-        len(kwargs['Y']) == 1
-    ), "row_parallel_embedding input Ids take 1 variable but got {}".format(
-        kwargs['Y']
+    assert len(kwargs['Y']) == 1, (
+        "row_parallel_embedding input Ids take 1 variable but got {}".format(
+            kwargs['Y']
+        )
     )
-    assert (
-        len(kwargs['X']) == 1
-    ), "row_parallel_embedding input Ids take 1 variable but got {}".format(
-        kwargs['X']
+    assert len(kwargs['X']) == 1, (
+        "row_parallel_embedding input Ids take 1 variable but got {}".format(
+            kwargs['X']
+        )
     )
-    assert (
-        len(kwargs['Out@GRAD']) == 1
-    ), "row_parallel_embedding input Ids take 1 variable but got {}".format(
-        kwargs['Out']
+    assert len(kwargs['Out@GRAD']) == 1, (
+        "row_parallel_embedding input Ids take 1 variable but got {}".format(
+            kwargs['Out']
+        )
     )
-    assert (
-        len(kwargs['Y@GRAD']) == 1
-    ), "row_parallel_embedding output Ids take 1 variable but got {}".format(
-        kwargs['Y@GRAD']
+    assert len(kwargs['Y@GRAD']) == 1, (
+        "row_parallel_embedding output Ids take 1 variable but got {}".format(
+            kwargs['Y@GRAD']
+        )
     )
 
     X_var = main_block._var_recursive(kwargs['X'][0])
@@ -354,9 +354,9 @@ def _right_operand_parameter_matmul_backward(ctx, *args, **kwargs):
     Out_grad = main_block._var_recursive(kwargs['Out@GRAD'][0])
     Y_grad = main_block._var_recursive(kwargs['Y@GRAD'][0])
 
-    assert not is_parameter_related(
-        X_var.name, main_block
-    ), f"left operand(X) [{X_var.name}] of dist matmul should not be parameter"
+    assert not is_parameter_related(X_var.name, main_block), (
+        f"left operand(X) [{X_var.name}] of dist matmul should not be parameter"
+    )
 
     X_var_dims_mapping = dist_attr.get_input_dims_mapping(X_var.name)
     Y_var_dim_mapping = dist_attr.get_input_dims_mapping(Y_var.name)
@@ -781,9 +781,9 @@ class DistributedMatmulImpl0(DistributedOperatorImpl):
         src_op = dist_op_context.cur_src_op
         rank_id = dist_op_context.rank_id
         op_dist_attr = ctx.get_op_dist_attr_for_program(src_op)
-        assert (
-            op_dist_attr is not None
-        ), f"backward op [{src_op}] don't have dist attribute !"
+        assert op_dist_attr is not None, (
+            f"backward op [{src_op}] don't have dist attribute !"
+        )
 
         # FIXME (JZ-LIANG) Remove this hack to support any op mesh group for Pipeline Parallelism
         if rank_id not in op_dist_attr.process_mesh.process_ids:
@@ -817,9 +817,9 @@ class DistributedMatmulImpl0(DistributedOperatorImpl):
             matmul_col_dim_mapping = op_dist_attr.get_input_dims_mapping(
                 Weight_var.name
             )[-2]
-        assert (
-            matmul_col_dim_mapping >= 0
-        ), f"col_parallel_matmul's row should be divided by a specific mesh axis, but got [{matmul_col_dim_mapping}]"
+        assert matmul_col_dim_mapping >= 0, (
+            f"col_parallel_matmul's row should be divided by a specific mesh axis, but got [{matmul_col_dim_mapping}]"
+        )
         process_mesh_shape = op_dist_attr.process_mesh.shape
         process_mesh_group = op_dist_attr.process_mesh.process_ids
 
@@ -1036,9 +1036,9 @@ class DistributedMatmulImpl1(DistributedOperatorImpl):
         src_op = dist_op_context.cur_src_op
         rank_id = dist_op_context.rank_id
         op_dist_attr = ctx.get_op_dist_attr_for_program(src_op)
-        assert (
-            op_dist_attr is not None
-        ), f"backward op [{src_op}] don't have dist attribute !"
+        assert op_dist_attr is not None, (
+            f"backward op [{src_op}] don't have dist attribute !"
+        )
 
         # FIXME (JZ-LIANG) Remove this hack to support any op mesh group for Pipeline Parallelism
         if rank_id not in op_dist_attr.process_mesh.process_ids:
@@ -1072,9 +1072,9 @@ class DistributedMatmulImpl1(DistributedOperatorImpl):
             matmul_row_dim_mapping = op_dist_attr.get_input_dims_mapping(
                 Weight_var.name
             )[-1]
-        assert (
-            matmul_row_dim_mapping >= 0
-        ), f"row_parallel_matmul's row should be divided by a specific mesh axis, but got [{matmul_row_dim_mapping}]"
+        assert matmul_row_dim_mapping >= 0, (
+            f"row_parallel_matmul's row should be divided by a specific mesh axis, but got [{matmul_row_dim_mapping}]"
+        )
         process_mesh_shape = op_dist_attr.process_mesh.shape
         process_mesh_group = op_dist_attr.process_mesh.process_ids
 
@@ -1474,9 +1474,9 @@ class DistributedMatmulV2Impl0(DistributedOperatorImpl):
         src_op = dist_op_context.cur_src_op
         rank_id = dist_op_context.rank_id
         op_dist_attr = ctx.get_op_dist_attr_for_program(src_op)
-        assert (
-            op_dist_attr is not None
-        ), f"backward op [{src_op}] don't have dist attribute !"
+        assert op_dist_attr is not None, (
+            f"backward op [{src_op}] don't have dist attribute !"
+        )
 
         # FIXME (JZ-LIANG) Remove this hack to support any op mesh group for Pipeline Parallelism
         if rank_id not in op_dist_attr.process_mesh.process_ids:
@@ -1510,9 +1510,9 @@ class DistributedMatmulV2Impl0(DistributedOperatorImpl):
             matmul_col_dim_mapping = op_dist_attr.get_input_dims_mapping(
                 Weight_var.name
             )[-2]
-        assert (
-            matmul_col_dim_mapping >= 0
-        ), f"col_parallel_matmul's row should be divided by a specific mesh axis, but got [{matmul_col_dim_mapping}]"
+        assert matmul_col_dim_mapping >= 0, (
+            f"col_parallel_matmul's row should be divided by a specific mesh axis, but got [{matmul_col_dim_mapping}]"
+        )
 
         # infer new var shape with op dist attr
         x_tensor_dist_attr = ctx.get_tensor_dist_attr_for_program(X_var)
@@ -1723,9 +1723,9 @@ class DistributedMatmulV2Impl1(DistributedOperatorImpl):
         src_op = dist_op_context.cur_src_op
         rank_id = dist_op_context.rank_id
         op_dist_attr = ctx.get_op_dist_attr_for_program(src_op)
-        assert (
-            op_dist_attr is not None
-        ), f"backward op [{src_op}] don't have dist attribute !"
+        assert op_dist_attr is not None, (
+            f"backward op [{src_op}] don't have dist attribute !"
+        )
 
         # FIXME (JZ-LIANG) Remove this hack to support any op mesh group for Pipeline Parallelism
         if rank_id not in op_dist_attr.process_mesh.process_ids:
@@ -1759,9 +1759,9 @@ class DistributedMatmulV2Impl1(DistributedOperatorImpl):
             matmul_row_dim_mapping = op_dist_attr.get_input_dims_mapping(
                 Weight_var.name
             )[-1]
-        assert (
-            matmul_row_dim_mapping >= 0
-        ), f"row_parallel_matmul's row should be divided by a specific mesh axis, but got [{matmul_row_dim_mapping}]"
+        assert matmul_row_dim_mapping >= 0, (
+            f"row_parallel_matmul's row should be divided by a specific mesh axis, but got [{matmul_row_dim_mapping}]"
+        )
         process_mesh_shape = op_dist_attr.process_mesh.shape
         process_mesh_group = op_dist_attr.process_mesh.process_ids
 
@@ -2153,9 +2153,9 @@ class DistributedMulImpl0(DistributedOperatorImpl):
         src_op = dist_op_context.cur_src_op
         rank_id = dist_op_context.rank_id
         op_dist_attr = ctx.get_op_dist_attr_for_program(src_op)
-        assert (
-            op_dist_attr is not None
-        ), f"backward op [{src_op}] don't have dist attribute !"
+        assert op_dist_attr is not None, (
+            f"backward op [{src_op}] don't have dist attribute !"
+        )
 
         # FIXME (JZ-LIANG) Remove this hack to support any op mesh group for Pipeline Parallelism
         if rank_id not in op_dist_attr.process_mesh.process_ids:
@@ -2183,9 +2183,9 @@ class DistributedMulImpl0(DistributedOperatorImpl):
         matmul_col_dim_mapping = op_dist_attr.get_input_dims_mapping(
             Weight_var.name
         )[-1]
-        assert (
-            matmul_col_dim_mapping >= 0
-        ), f"col_parallel_matmul's row should be divided by a specific mesh axis, but got [{matmul_col_dim_mapping}]"
+        assert matmul_col_dim_mapping >= 0, (
+            f"col_parallel_matmul's row should be divided by a specific mesh axis, but got [{matmul_col_dim_mapping}]"
+        )
         process_mesh_shape = op_dist_attr.process_mesh.shape
         process_mesh_group = op_dist_attr.process_mesh.process_ids
 
@@ -2396,9 +2396,9 @@ class DistributedMulImpl1(DistributedOperatorImpl):
         src_op = dist_op_context.cur_src_op
         rank_id = dist_op_context.rank_id
         op_dist_attr = ctx.get_op_dist_attr_for_program(src_op)
-        assert (
-            op_dist_attr is not None
-        ), f"backward op [{src_op}] don't have dist attribute !"
+        assert op_dist_attr is not None, (
+            f"backward op [{src_op}] don't have dist attribute !"
+        )
 
         # FIXME (JZ-LIANG) Remove this hack to support any op mesh group for Pipeline Parallelism
         if rank_id not in op_dist_attr.process_mesh.process_ids:
@@ -2426,9 +2426,9 @@ class DistributedMulImpl1(DistributedOperatorImpl):
         matmul_row_dim_mapping = op_dist_attr.get_input_dims_mapping(
             Weight_var.name
         )[-2]
-        assert (
-            matmul_row_dim_mapping >= 0
-        ), f"row_parallel_matmul's row should be divided by a specific mesh axis, but got [{matmul_row_dim_mapping}]"
+        assert matmul_row_dim_mapping >= 0, (
+            f"row_parallel_matmul's row should be divided by a specific mesh axis, but got [{matmul_row_dim_mapping}]"
+        )
         process_mesh_shape = op_dist_attr.process_mesh.shape
         process_mesh_group = op_dist_attr.process_mesh.process_ids
 

--- a/python/paddle/distributed/auto_parallel/static/operators/dist_reduce_sum_p.py
+++ b/python/paddle/distributed/auto_parallel/static/operators/dist_reduce_sum_p.py
@@ -44,13 +44,13 @@ class DistributedReduceSum(DistributedOperatorImplContainer):
         # step1: prepare inputs need for rule (order args as PHI definition and filter out unnecessary args)
 
         op_desc = dist_op.serial_op.desc
-        assert (
-            len(op_desc.input_arg_names()) == 1
-        ), f"reduce_sum op [{op_desc.type}] has [{len(op_desc.input_arg_names())}] inputs"
+        assert len(op_desc.input_arg_names()) == 1, (
+            f"reduce_sum op [{op_desc.type}] has [{len(op_desc.input_arg_names())}] inputs"
+        )
         input_arg_name = op_desc.input_arg_names()[0]
-        assert (
-            len(op_desc.output_arg_names()) == 1
-        ), f"reduce_sum op [{op_desc.type}] has [{len(op_desc.output_arg_names())}] outputs"
+        assert len(op_desc.output_arg_names()) == 1, (
+            f"reduce_sum op [{op_desc.type}] has [{len(op_desc.output_arg_names())}] outputs"
+        )
         output_arg_name = op_desc.output_arg_names()[0]
         keep_dim = op_desc.attr('keep_dim')
         dims = op_desc.attr('dim')

--- a/python/paddle/distributed/auto_parallel/static/operators/dist_reshape.py
+++ b/python/paddle/distributed/auto_parallel/static/operators/dist_reshape.py
@@ -48,9 +48,9 @@ class DistributedReshape2(DistributedOperatorImplContainer):
     def update_dims_mapping(dist_op):
         # step1: prepare inputs need for rule (order args as PHI definition and filter out unnecessary args)
         op_desc = dist_op.serial_op.desc
-        assert (
-            dist_op.serial_op.type == "reshape2"
-        ), f"{dist_op.serial_op.type} is not supported by dist reshape yet."
+        assert dist_op.serial_op.type == "reshape2", (
+            f"{dist_op.serial_op.type} is not supported by dist reshape yet."
+        )
 
         x_name = op_desc.input('X')[0]
         out_name = op_desc.output('Out')[0]
@@ -293,9 +293,9 @@ class DistributedReshapeImpl0(DistributedOperatorImpl):
         src_op = dist_op_context.cur_src_op
         rank_id = dist_op_context.rank_id
         op_dist_attr = ctx.get_op_dist_attr_for_program(src_op)
-        assert (
-            op_dist_attr is not None
-        ), f"backward op [{src_op}] don't have dist attribute !"
+        assert op_dist_attr is not None, (
+            f"backward op [{src_op}] don't have dist attribute !"
+        )
 
         # check validation of inputs / outputs
         for input_name in src_op.desc.input_names():
@@ -549,9 +549,9 @@ class DistributedReshapeImpl1(DistributedOperatorImpl):
         src_op = dist_op_context.cur_src_op
         rank_id = dist_op_context.rank_id
         op_dist_attr = ctx.get_op_dist_attr_for_program(src_op)
-        assert (
-            op_dist_attr is not None
-        ), f"backward op [{src_op}] don't have dist attribute !"
+        assert op_dist_attr is not None, (
+            f"backward op [{src_op}] don't have dist attribute !"
+        )
 
         # check validation of inputs / outputs
         for input_name in src_op.desc.input_names():
@@ -798,9 +798,9 @@ class DistributedReshapeImpl2(DistributedOperatorImpl):
         main_block = dist_op_context.work_block
         src_op = dist_op_context.cur_src_op
         op_dist_attr = ctx.get_op_dist_attr_for_program(src_op)
-        assert (
-            op_dist_attr is not None
-        ), f"backward op [{src_op}] don't have dist attribute !"
+        assert op_dist_attr is not None, (
+            f"backward op [{src_op}] don't have dist attribute !"
+        )
 
         # check validation of inputs / outputs
         for input_name in src_op.desc.input_names():

--- a/python/paddle/distributed/auto_parallel/static/operators/dist_split.py
+++ b/python/paddle/distributed/auto_parallel/static/operators/dist_split.py
@@ -39,26 +39,26 @@ class DistributedSplit(DistributedOperatorImplContainer):
         op_desc = dist_op.serial_op.desc
 
         x_name = op_desc.input('X')[0]
-        assert (
-            len(op_desc.input('AxisTensor')) == 0
-        ), "Attribute AxisTensor is not supported by dist split."
-        assert (
-            len(op_desc.input('SectionsTensorList')) == 0
-        ), "Attribute SectionsTensorList is not supported by dist split."
+        assert len(op_desc.input('AxisTensor')) == 0, (
+            "Attribute AxisTensor is not supported by dist split."
+        )
+        assert len(op_desc.input('SectionsTensorList')) == 0, (
+            "Attribute SectionsTensorList is not supported by dist split."
+        )
         output_arg_names = op_desc.output('Out')
 
         num = op_desc.attr('num')
         sections = op_desc.attr('sections')
         if num:
-            assert (sections is None) or (
-                len(sections) == 0
-            ), f"Both Attributes of num: {num} and sections: {sections} are specified."
+            assert (sections is None) or (len(sections) == 0), (
+                f"Both Attributes of num: {num} and sections: {sections} are specified."
+            )
             first_attr = num
             rule_type = "split_with_num"
         else:
-            assert (
-                not num
-            ), f"Both Attributes of num: {num} and sections: {sections} are specified."
+            assert not num, (
+                f"Both Attributes of num: {num} and sections: {sections} are specified."
+            )
             first_attr = sections
             rule_type = "split"
         axis = op_desc.attr('axis')

--- a/python/paddle/distributed/auto_parallel/static/operators/dist_tile.py
+++ b/python/paddle/distributed/auto_parallel/static/operators/dist_tile.py
@@ -33,9 +33,9 @@ class DistributedTile(DistributedOperatorImplContainer):
     def update_dims_mapping(dist_op):
         # step1: prepare inputs need for rule (order args as PHI definition and filter out unnecessary args)
         op_desc = dist_op.serial_op.desc
-        assert (
-            dist_op.serial_op.type == "tile"
-        ), f"{dist_op.serial_op.type} is not supported by dist transpose yet."
+        assert dist_op.serial_op.type == "tile", (
+            f"{dist_op.serial_op.type} is not supported by dist transpose yet."
+        )
 
         x_name = op_desc.input('X')[0]
         out_name = op_desc.output('Out')[0]

--- a/python/paddle/distributed/auto_parallel/static/operators/dist_transpose.py
+++ b/python/paddle/distributed/auto_parallel/static/operators/dist_transpose.py
@@ -47,9 +47,9 @@ class DistributedTranspose2(DistributedOperatorImplContainer):
     def update_dims_mapping(dist_op):
         # step1: prepare inputs need for rule (order args as PHI definition and filter out unnecessary args)
         op_desc = dist_op.serial_op.desc
-        assert (
-            dist_op.serial_op.type == "transpose2"
-        ), f"{dist_op.serial_op.type} is not supported by dist transpose yet."
+        assert dist_op.serial_op.type == "transpose2", (
+            f"{dist_op.serial_op.type} is not supported by dist transpose yet."
+        )
 
         x_name = op_desc.input('X')[0]
         out_name = op_desc.output('Out')[0]

--- a/python/paddle/distributed/auto_parallel/static/operators/dist_update_loss_scaling.py
+++ b/python/paddle/distributed/auto_parallel/static/operators/dist_update_loss_scaling.py
@@ -72,9 +72,9 @@ class DistributedUpdateLossScalingImpl(DistributedOperatorImpl):
         backward_op = dist_op_context.cur_src_op
         rank_id = dist_op_context.rank_id
         dist_attr = ctx.get_op_dist_attr_for_program(backward_op)
-        assert (
-            dist_attr is not None
-        ), f"backward op [{backward_op}] don't have dist attribute !"
+        assert dist_attr is not None, (
+            f"backward op [{backward_op}] don't have dist attribute !"
+        )
 
         assert rank_id in dist_attr.process_mesh.process_ids
 
@@ -103,46 +103,46 @@ class DistributedUpdateLossScalingImpl(DistributedOperatorImpl):
             'OutBadSteps'
         )
 
-        assert (
-            len(kwargs['FoundInfinite']) == 1
-        ), "update_loss_scaling input FoundInfinite take 1 variable but got {}".format(
-            kwargs['FoundInfinite']
+        assert len(kwargs['FoundInfinite']) == 1, (
+            "update_loss_scaling input FoundInfinite take 1 variable but got {}".format(
+                kwargs['FoundInfinite']
+            )
         )
-        assert (
-            len(kwargs['PrevLossScaling']) == 1
-        ), "update_loss_scaling input PrevLossScaling take 1 variable but got {}".format(
-            kwargs['PrevLossScaling']
+        assert len(kwargs['PrevLossScaling']) == 1, (
+            "update_loss_scaling input PrevLossScaling take 1 variable but got {}".format(
+                kwargs['PrevLossScaling']
+            )
         )
-        assert (
-            len(kwargs['InGoodSteps']) == 1
-        ), "update_loss_scaling input InGoodSteps take 1 variable but got {}".format(
-            kwargs['InGoodSteps']
+        assert len(kwargs['InGoodSteps']) == 1, (
+            "update_loss_scaling input InGoodSteps take 1 variable but got {}".format(
+                kwargs['InGoodSteps']
+            )
         )
-        assert (
-            len(kwargs['InBadSteps']) == 1
-        ), "update_loss_scaling input InBadSteps take 1 variable but got {}".format(
-            kwargs['InBadSteps']
+        assert len(kwargs['InBadSteps']) == 1, (
+            "update_loss_scaling input InBadSteps take 1 variable but got {}".format(
+                kwargs['InBadSteps']
+            )
         )
-        assert (
-            len(kwargs['LossScaling']) == 1
-        ), "update_loss_scaling output LossScaling take 1 variable but got {}".format(
-            kwargs['LossScaling']
+        assert len(kwargs['LossScaling']) == 1, (
+            "update_loss_scaling output LossScaling take 1 variable but got {}".format(
+                kwargs['LossScaling']
+            )
         )
-        assert (
-            len(kwargs['OutGoodSteps']) == 1
-        ), "update_loss_scaling output OutGoodSteps take 1 variable but got {}".format(
-            kwargs['OutGoodSteps']
+        assert len(kwargs['OutGoodSteps']) == 1, (
+            "update_loss_scaling output OutGoodSteps take 1 variable but got {}".format(
+                kwargs['OutGoodSteps']
+            )
         )
-        assert (
-            len(kwargs['OutBadSteps']) == 1
-        ), "update_loss_scaling output OutBadSteps take 1 variable but got {}".format(
-            kwargs['OutBadSteps']
+        assert len(kwargs['OutBadSteps']) == 1, (
+            "update_loss_scaling output OutBadSteps take 1 variable but got {}".format(
+                kwargs['OutBadSteps']
+            )
         )
 
-        assert len(kwargs['X']) == len(
-            kwargs['Out']
-        ), "update_loss_scaling got [{}] X and [{}] Out, which are supposed to be equal".format(
-            len(kwargs['X']), len(kwargs['Out'])
+        assert len(kwargs['X']) == len(kwargs['Out']), (
+            "update_loss_scaling got [{}] X and [{}] Out, which are supposed to be equal".format(
+                len(kwargs['X']), len(kwargs['Out'])
+            )
         )
 
         filter_vars = []

--- a/python/paddle/distributed/auto_parallel/static/parallelizer.py
+++ b/python/paddle/distributed/auto_parallel/static/parallelizer.py
@@ -307,9 +307,9 @@ class AutoParallelizer:
 
         if self._enable_auto_mapping and self._need_rank_mapping:
             # Do the mapping pass before parallelization
-            assert (
-                self._cluster is not None
-            ), "The cluster must not be none when using auto mapping."
+            assert self._cluster is not None, (
+                "The cluster must not be none when using auto mapping."
+            )
             dist_programs = {}
             world_process_group = get_world_process_group()
             dist_context = None
@@ -417,9 +417,9 @@ class AutoParallelizer:
             ]
             new_process = subprocess.Popen(new_cmd)
             new_process.wait()
-            assert (
-                new_process.returncode == 0
-            ), "Launch failed with rank mapping"
+            assert new_process.returncode == 0, (
+                "Launch failed with rank mapping"
+            )
             print("Successfully do the second launch for auto mapping!")
             sys.exit(0)
         else:

--- a/python/paddle/distributed/auto_parallel/static/partitioner.py
+++ b/python/paddle/distributed/auto_parallel/static/partitioner.py
@@ -142,12 +142,12 @@ class Partitioner:
         for op in serial_startup_program.global_block().ops:
             # TODO if var not belong to this rank, should be filtered
             output_vars = op.desc.output_arg_names()
-            assert (
-                len(output_vars) == 1
-            ), f"initializer should output only ONE variable, but got [{op.desc}]"
-            assert (
-                temp_varname_map[output_vars[0]] in var2shape
-            ), f"try to initialize [{output_vars[0]}] which is not a persistable var"
+            assert len(output_vars) == 1, (
+                f"initializer should output only ONE variable, but got [{op.desc}]"
+            )
+            assert temp_varname_map[output_vars[0]] in var2shape, (
+                f"try to initialize [{output_vars[0]}] which is not a persistable var"
+            )
             new_op_desc = target_block.desc.append_op()
             new_op_desc.copy_from(op.desc)
             new_op_desc._rename_output(
@@ -398,17 +398,17 @@ def _get_dist_shape(var, dist_attr):
     if mapping == []:
         return var_shape
 
-    assert len(var_shape) == len(
-        mapping
-    ), f"variable shape [{var_shape}] and dim_mapping [{mapping}] is NOT match !"
+    assert len(var_shape) == len(mapping), (
+        f"variable shape [{var_shape}] and dim_mapping [{mapping}] is NOT match !"
+    )
     new_shape = []
     for idx in range(len(var_shape)):
         if var_shape[idx] == -1 or mapping[idx] == -1:
             new_shape.append(var_shape[idx])
         else:
-            assert (
-                var_shape[idx] % mesh[mapping[idx]] == 0
-            ), f"un-event partition: var_shape[idx]=[{var_shape[idx]}], mesh[{mesh[mapping[idx]]}], {var.name}, {var_shape}, {mesh}, {mapping}"
+            assert var_shape[idx] % mesh[mapping[idx]] == 0, (
+                f"un-event partition: var_shape[idx]=[{var_shape[idx]}], mesh[{mesh[mapping[idx]]}], {var.name}, {var_shape}, {mesh}, {mapping}"
+            )
             new_shape.append(var_shape[idx] // mesh[mapping[idx]])
 
     return new_shape

--- a/python/paddle/distributed/auto_parallel/static/planner.py
+++ b/python/paddle/distributed/auto_parallel/static/planner.py
@@ -159,9 +159,9 @@ class PlanSpace:
     @staticmethod
     def enum_process_mesh_topology(processes):
         """Enumerate all process meshes with the given processes."""
-        assert (
-            processes >= 1
-        ), "The processes must be number and greater than 0."
+        assert processes >= 1, (
+            "The processes must be number and greater than 0."
+        )
         # compute divisors
         divisors = []
         for i in range(1, processes + 1):
@@ -352,8 +352,7 @@ class PlanSpace:
                     auto.ProcessMesh(
                         mesh=np.array(
                             global_group[
-                                i
-                                * per_process_mesh_group : (i + 1)
+                                i * per_process_mesh_group : (i + 1)
                                 * per_process_mesh_group
                             ]
                         )
@@ -418,9 +417,9 @@ class PlanSpace:
                     program, op, op_process_mesh
                 )
 
-            assert (
-                op_valid_dist_attrs is not None
-            ), f"Enumerate {op} valid distributed attribute failed."
+            assert op_valid_dist_attrs is not None, (
+                f"Enumerate {op} valid distributed attribute failed."
+            )
             valid_dist_attr_dict[op.desc.id()] = [
                 op_valid_dist_attrs,
                 pipeline_stage,
@@ -645,9 +644,9 @@ class MCMC(SearchAlgorithm):
                 )
 
     def change_process_mesh(self, op, changed_process_mesh, vars, dist_context):
-        dist_context.get_op_dist_attr_for_program(op).process_mesh = (
-            changed_process_mesh
-        )
+        dist_context.get_op_dist_attr_for_program(
+            op
+        ).process_mesh = changed_process_mesh
         for var_name in op.output_arg_names:
             dist_context.get_tensor_dist_attr_for_program(
                 vars[var_name]
@@ -748,9 +747,9 @@ class MCMC(SearchAlgorithm):
                         )
 
                     # change the selected op stage and output dist attr
-                    new_valid_dist_attr_dict[selected_op.desc.id()][
-                        1
-                    ] = changed_stage
+                    new_valid_dist_attr_dict[selected_op.desc.id()][1] = (
+                        changed_stage
+                    )
                     new_process_mesh = pipeline_process_meshes[changed_stage]
                     selected_op_dist_attr.process_mesh = new_process_mesh
                     for op_dist_attr in new_valid_dist_attr_dict[
@@ -778,9 +777,9 @@ class MCMC(SearchAlgorithm):
                             changed_stage
                         ]
                         if stage == changed_stage + 1:
-                            new_valid_dist_attr_dict[ops[idx].desc.id()][
-                                1
-                            ] = changed_stage
+                            new_valid_dist_attr_dict[ops[idx].desc.id()][1] = (
+                                changed_stage
+                            )
                             for op_dist_attr in valid_dist_attr_list:
                                 op_dist_attr.process_mesh = new_process_mesh
                             new_dist_context.get_op_dist_attr_for_program(
@@ -843,9 +842,9 @@ class MCMC(SearchAlgorithm):
                         )
 
                     # change the selected op stage and output tensor dist attr
-                    new_valid_dist_attr_dict[selected_op.desc.id()][
-                        1
-                    ] = changed_stage
+                    new_valid_dist_attr_dict[selected_op.desc.id()][1] = (
+                        changed_stage
+                    )
                     new_process_mesh = pipeline_process_meshes[changed_stage]
                     selected_op_dist_attr.process_mesh = new_process_mesh
                     for op_dist_attr in new_valid_dist_attr_dict[
@@ -872,9 +871,9 @@ class MCMC(SearchAlgorithm):
                             changed_stage
                         ]
                         if stage == changed_stage - 1:
-                            new_valid_dist_attr_dict[ops[idx].desc.id()][
-                                1
-                            ] = changed_stage
+                            new_valid_dist_attr_dict[ops[idx].desc.id()][1] = (
+                                changed_stage
+                            )
                             for op_dist_attr in valid_dist_attr_list:
                                 op_dist_attr.process_mesh = new_process_mesh
 

--- a/python/paddle/distributed/auto_parallel/static/process_group.py
+++ b/python/paddle/distributed/auto_parallel/static/process_group.py
@@ -89,9 +89,9 @@ def new_process_group(
 class ProcessGroup:
     def __init__(self, group_id, ranks, group_type=None):
         if group_id == 0 and get_process_group(0) is not None:
-            assert (
-                group_id != 0
-            ), "Process group id 0 is reserved for all ranks."
+            assert group_id != 0, (
+                "Process group id 0 is reserved for all ranks."
+            )
         self._group_id = group_id
         self._ranks = ranks
         # Add the current ranks into group 0
@@ -121,9 +121,9 @@ class ProcessGroup:
         if set(new_ranks) <= set(self.ranks):
             return
         else:
-            assert (
-                not self.is_instantiate()
-            ), "Cannot add new ranks after instantiating the process group"
+            assert not self.is_instantiate(), (
+                "Cannot add new ranks after instantiating the process group"
+            )
         self._ranks.extend(new_ranks)
         self._ranks = list(set(self.ranks))
 

--- a/python/paddle/distributed/auto_parallel/static/process_mesh_v2.py
+++ b/python/paddle/distributed/auto_parallel/static/process_mesh_v2.py
@@ -56,21 +56,21 @@ class ProcessMesh(core.ProcessMesh):
         self._shape = list(self._mesh.shape)
 
         self._process_ids = self._mesh.flatten().tolist()
-        assert all(
-            isinstance(p, int) for p in self._process_ids
-        ), "All elements of the mesh must be integer"
-        assert (
-            min(self._process_ids) >= 0
-        ), 'All elements of the mesh must be >= 0.'
+        assert all(isinstance(p, int) for p in self._process_ids), (
+            "All elements of the mesh must be integer"
+        )
+        assert min(self._process_ids) >= 0, (
+            'All elements of the mesh must be >= 0.'
+        )
         unique_process_ids = set(self._process_ids)
-        assert len(unique_process_ids) == len(
-            self._process_ids
-        ), 'All elements of the mesh must be unique.'
+        assert len(unique_process_ids) == len(self._process_ids), (
+            'All elements of the mesh must be unique.'
+        )
 
         if dim_names is not None:
-            assert len(dim_names) == len(
-                self._shape
-            ), "The length of dims_names must be same as the shape of the mesh."
+            assert len(dim_names) == len(self._shape), (
+                "The length of dims_names must be same as the shape of the mesh."
+            )
             self._dim_names = dim_names
         else:
             self._dim_names = ["d" + str(i) for i in range(len(self._shape))]

--- a/python/paddle/distributed/auto_parallel/static/reshard.py
+++ b/python/paddle/distributed/auto_parallel/static/reshard.py
@@ -1096,9 +1096,9 @@ class Resharder:
                 "The type of auto_parallel_startup_prog should be Program or None, "
                 f"but got {type(auto_parallel_startup_prog)}."
             )
-        assert isinstance(
-            rank_id, int
-        ), f"The type of rank_id should be int, but got {type(rank_id)}."
+        assert isinstance(rank_id, int), (
+            f"The type of rank_id should be int, but got {type(rank_id)}."
+        )
         assert isinstance(dist_context, DistributedContext), (
             "The type of dist_context should be DistributedContext, "
             f"but got {type(dist_context)}."
@@ -1631,9 +1631,9 @@ class Resharder:
                             has_used = [False for x in has_used]
                             to_send_process = process_list[0]
                             has_used[0] = True
-                        assert (
-                            to_send_process is not None
-                        ), "Failed to find the send process."
+                        assert to_send_process is not None, (
+                            "Failed to find the send process."
+                        )
 
                         if to_send_process not in op_desc_seq.keys():
                             op_desc_seq[to_send_process] = []
@@ -1904,9 +1904,9 @@ class Resharder:
             if op.desc.id == reshard_op.desc.id:
                 idx = index
                 break
-        assert (
-            idx is not None
-        ), f"The op for reshard cannot be found in the rank {self.rank_id} program."
+        assert idx is not None, (
+            f"The op for reshard cannot be found in the rank {self.rank_id} program."
+        )
 
         src_name = src_tensor.name
 
@@ -2012,9 +2012,9 @@ class Resharder:
                                 for var_name in item[1]
                             ]
                             break
-                assert (
-                    tensor_list
-                ), "The result of parsing allgather op should not be None."
+                assert tensor_list, (
+                    "The result of parsing allgather op should not be None."
+                )
 
             elif isinstance(op_desc, SendOpDesc):
                 if src_name not in self.has_sent.keys():
@@ -2154,9 +2154,9 @@ class Resharder:
                                         )
                                         tensor_list.append(reset_lod_out)
                                         idx += 2
-                                        self.has_recv[src_name][
-                                            op_desc.src
-                                        ] = reset_lod_out
+                                        self.has_recv[src_name][op_desc.src] = (
+                                            reset_lod_out
+                                        )
                                         set_lod = True
                                         break
                                 if set_lod:
@@ -2461,9 +2461,9 @@ class Resharder:
         else:
             op_input_attrs = self._get_common_op_input_attrs(op, var_name)
 
-        assert (
-            op_input_attrs
-        ), f"The input '{op.name}' of op '{var_name}' has no distributed attributes in subblock"
+        assert op_input_attrs, (
+            f"The input '{op.name}' of op '{var_name}' has no distributed attributes in subblock"
+        )
 
         return op_input_attrs
 
@@ -2874,11 +2874,7 @@ class Resharder:
                                     -1
                                 ) != len(
                                     dist_tensor.dist_attr.dims_mapping
-                                ) or output_attr[
-                                    1
-                                ].count(
-                                    -1
-                                ) != len(
+                                ) or output_attr[1].count(-1) != len(
                                     output_attr[1]
                                 ):
                                     raise ValueError(

--- a/python/paddle/distributed/auto_parallel/static/reshard_funcs/nd_mesh_reshard_func.py
+++ b/python/paddle/distributed/auto_parallel/static/reshard_funcs/nd_mesh_reshard_func.py
@@ -357,9 +357,9 @@ class NdMeshReshardFunctionCrossMesh(ReshardFunction):
         )
 
         nd_mesh_func = NdMeshReshardFunction()
-        assert nd_mesh_func.is_suitable(
-            tmp_dist_attr, dst_dist_attr
-        ), f"Invoke the p to r reshard function is not valid from {tmp_dist_attr} to {dst_dist_attr}"
+        assert nd_mesh_func.is_suitable(tmp_dist_attr, dst_dist_attr), (
+            f"Invoke the p to r reshard function is not valid from {tmp_dist_attr} to {dst_dist_attr}"
+        )
         return nd_mesh_func.reshard(
             tmp_dist_attr, dst_dist_attr, src_value, dst_type
         )

--- a/python/paddle/distributed/auto_parallel/static/reshard_funcs/p_to_r_reshard_func.py
+++ b/python/paddle/distributed/auto_parallel/static/reshard_funcs/p_to_r_reshard_func.py
@@ -105,9 +105,9 @@ class PToRReshardFunctionCrossMesh(ReshardFunction):
         )
 
         p_to_r_func = PToRReshardFunction()
-        assert p_to_r_func.is_suitable(
-            tmp_dist_attr, dst_dist_attr
-        ), f"Invoke the p to r reshard function is not valid from {tmp_dist_attr} to {dst_dist_attr}"
+        assert p_to_r_func.is_suitable(tmp_dist_attr, dst_dist_attr), (
+            f"Invoke the p to r reshard function is not valid from {tmp_dist_attr} to {dst_dist_attr}"
+        )
         return p_to_r_func.reshard(
             tmp_dist_attr, dst_dist_attr, src_value, dst_type
         )

--- a/python/paddle/distributed/auto_parallel/static/reshard_funcs/p_to_s_reshard_func.py
+++ b/python/paddle/distributed/auto_parallel/static/reshard_funcs/p_to_s_reshard_func.py
@@ -47,9 +47,9 @@ class PToSReshardFunction(ReshardFunction):
     def reshard(self, src_dist_attr, dst_dist_attr, src_value, dst_type):
         src_mesh = src_dist_attr.process_mesh
         src_reduce_type = src_dist_attr.partial_status[0]
-        assert (
-            src_reduce_type == paddle.base.core.ReduceType.kRedSum
-        ), f"The p to s reshard func only support sum op, but received {src_reduce_type}"
+        assert src_reduce_type == paddle.base.core.ReduceType.kRedSum, (
+            f"The p to s reshard func only support sum op, but received {src_reduce_type}"
+        )
 
         chunk_id = -1
         if src_value.get_defining_op().dist_attr:

--- a/python/paddle/distributed/auto_parallel/static/reshard_funcs/r_to_s_reshard_func.py
+++ b/python/paddle/distributed/auto_parallel/static/reshard_funcs/r_to_s_reshard_func.py
@@ -133,9 +133,9 @@ class RToSReshardFunctionCrossMesh(ReshardFunction):
         curr_global_rank = paddle.distributed.get_rank()
         if curr_global_rank in dst_dist_attr.process_mesh.process_ids:
             r_to_s_func = RToSReshardFunction()
-            assert r_to_s_func.is_suitable(
-                tmp_dist_attr, dst_dist_attr
-            ), f"Invoke the r to s reshard function is not valid from {tmp_dist_attr} to {dst_dist_attr}"
+            assert r_to_s_func.is_suitable(tmp_dist_attr, dst_dist_attr), (
+                f"Invoke the r to s reshard function is not valid from {tmp_dist_attr} to {dst_dist_attr}"
+            )
             return r_to_s_func.reshard(
                 tmp_dist_attr, dst_dist_attr, out_value, dst_type
             )

--- a/python/paddle/distributed/auto_parallel/static/reshard_funcs/s_to_r_reshard_func.py
+++ b/python/paddle/distributed/auto_parallel/static/reshard_funcs/s_to_r_reshard_func.py
@@ -355,9 +355,9 @@ class SToRReshardFunctionCrossMesh(ReshardFunction):
         )
 
         s_to_r_func = SToRReshardFunction()
-        assert s_to_r_func.is_suitable(
-            tmp_dist_attr, dst_dist_attr
-        ), f"Invoke the p to r reshard function is not valid from {tmp_dist_attr} to {dst_dist_attr}"
+        assert s_to_r_func.is_suitable(tmp_dist_attr, dst_dist_attr), (
+            f"Invoke the p to r reshard function is not valid from {tmp_dist_attr} to {dst_dist_attr}"
+        )
         return s_to_r_func.reshard(
             tmp_dist_attr, dst_dist_attr, out_value, dst_type
         )

--- a/python/paddle/distributed/auto_parallel/static/reshard_funcs/same_status_reshard_func.py
+++ b/python/paddle/distributed/auto_parallel/static/reshard_funcs/same_status_reshard_func.py
@@ -123,9 +123,9 @@ class SameStatusReshardFunction(ReshardFunction):
                     if var.dist_attr().process_mesh == dst_mesh:
                         chunk_id = find_var_used_op_chunk_id(var)
 
-                assert (
-                    -1 not in dst_type.shape
-                ), "dynamic shape is not supported by pir-auto parallel yet."
+                assert -1 not in dst_type.shape, (
+                    "dynamic shape is not supported by pir-auto parallel yet."
+                )
 
                 comm_group = new_process_group([src, dst], group_type="p2p")
                 recv_value = paddle._C_ops.recv_v2(

--- a/python/paddle/distributed/auto_parallel/static/tuner/algorithms.py
+++ b/python/paddle/distributed/auto_parallel/static/tuner/algorithms.py
@@ -119,9 +119,9 @@ class ShardingStageAlgorithm(AlgorithmBase):
 
         stage_range = self._config.sharding.get("tuning_range", None)
         if stage_range:
-            assert set(stage_range).issubset(
-                {0, 1, 2, 3}
-            ), f"Sharding Stage should belong into range within 0 - 3 but got {stage_range}."
+            assert set(stage_range).issubset({0, 1, 2, 3}), (
+                f"Sharding Stage should belong into range within 0 - 3 but got {stage_range}."
+            )
             stage_range.sort(reverse=True)
         else:
             stage_range = list(range(self._max_stage + 1)).sort(reverse=True)

--- a/python/paddle/distributed/auto_parallel/static/tuner/optimization_tuner.py
+++ b/python/paddle/distributed/auto_parallel/static/tuner/optimization_tuner.py
@@ -85,9 +85,9 @@ def parse_process_groups():
 
 
 def get_metric(results):
-    assert isinstance(
-        results, dict
-    ), f"results should be type of dictionary, but got {type(results)}."
+    assert isinstance(results, dict), (
+        f"results should be type of dictionary, but got {type(results)}."
+    )
     if 'Throughput' in results and isinstance(results['Throughput'], float):
         return float(results['Throughput'])
     else:

--- a/python/paddle/distributed/auto_parallel/static/tuner/rule_based_tuner.py
+++ b/python/paddle/distributed/auto_parallel/static/tuner/rule_based_tuner.py
@@ -511,9 +511,9 @@ class GraphUtil:
                         else:
                             var_node.attrs["type"] = "var"
                         graph.attrs["var_to_id"][var_name] = var_node.id
-                        graph.attrs["id_to_var_desc_id"][
-                            var_node.id
-                        ] = var.desc.original_id()
+                        graph.attrs["id_to_var_desc_id"][var_node.id] = (
+                            var.desc.original_id()
+                        )
                         graph.attrs["id_to_var_name"][var_node.id] = var_name
                     else:
                         var_node_id = graph.attrs["var_to_id"][var_name]
@@ -539,12 +539,12 @@ class GraphUtil:
                             else:
                                 var_node.attrs["type"] = "var"
                             graph.attrs["var_to_id"][var_name] = var_node.id
-                            graph.attrs["id_to_var_desc_id"][
-                                var_node.id
-                            ] = var.desc.original_id()
-                            graph.attrs["id_to_var_name"][
-                                var_node.id
-                            ] = var_name
+                            graph.attrs["id_to_var_desc_id"][var_node.id] = (
+                                var.desc.original_id()
+                            )
+                            graph.attrs["id_to_var_name"][var_node.id] = (
+                                var_name
+                            )
                         else:
                             var_node_id = graph.attrs["var_to_id"][var_name]
                             var_node = graph._nodes[var_node_id]
@@ -1176,9 +1176,7 @@ class RuleBasedTuner:
                 self.op_original_id_to_op[op.desc.original_id()] = op
                 self.op_original_id_to_idx[op.desc.original_id()] = idx
 
-            grad_op_id_to_op_id = (
-                self.full_main_program_dist_context.dist_op_context.grad_op_id_to_op_id
-            )
+            grad_op_id_to_op_id = self.full_main_program_dist_context.dist_op_context.grad_op_id_to_op_id
 
             for grad_op_original_id in grad_op_id_to_op_id:
                 op_id = grad_op_id_to_op_id[grad_op_original_id]
@@ -1408,9 +1406,9 @@ class RuleBasedTuner:
                 if parallelism not in self.sub_programs_dist_context[idx]:
                     self.sub_programs_dist_context[idx][parallelism] = {}
                 key = self.convert_process_mesh_to_key(process_mesh)
-                self.sub_programs_dist_context[idx][parallelism][
-                    key
-                ] = dist_context
+                self.sub_programs_dist_context[idx][parallelism][key] = (
+                    dist_context
+                )
             else:
                 self._logger.info(
                     f"No pattern has be matched under {parallelism} parallelism when sub program is {sub_fwd_program}."
@@ -1534,9 +1532,9 @@ class RuleBasedTuner:
                         ref_dims_mapping = (
                             fwd_op_dist_attr.get_output_dims_mapping(input_name)
                         )
-                assert (
-                    ref_dims_mapping is not None
-                ), f"[{input_name}] 's dims mapping is NONE"
+                assert ref_dims_mapping is not None, (
+                    f"[{input_name}] 's dims mapping is NONE"
+                )
                 grad_op_dist_attr.set_input_dims_mapping(
                     input_name, ref_dims_mapping
                 )
@@ -1574,9 +1572,9 @@ class RuleBasedTuner:
                         map(_is_grad_var_name, grad_op_next_op.input_arg_names)
                     )
                     output_name = grad_op_next_op.output_arg_names[0]
-                    assert (
-                        output_name in grad_var_to_var
-                    ), f"sum op's output '{output_name}' has no corresponding var"
+                    assert output_name in grad_var_to_var, (
+                        f"sum op's output '{output_name}' has no corresponding var"
+                    )
                     ref_fwd_var_name = grad_var_to_var[output_name]
                     ref_fwd_var = vars[ref_fwd_var_name]
                     ref_fwd_dist_attr = sub_program_dist_context.get_tensor_dist_attr_for_program(
@@ -1756,12 +1754,12 @@ class RuleBasedTuner:
                             continue
 
                 if "Grad" in op.input_names and "Param" in ops[idx].input_names:
-                    assert (
-                        len(op.input("Param")) == 1
-                    ), "Only support one-to-one now."
-                    assert (
-                        len(op.input("Grad")) == 1
-                    ), "Only support one-to-one now."
+                    assert len(op.input("Param")) == 1, (
+                        "Only support one-to-one now."
+                    )
+                    assert len(op.input("Grad")) == 1, (
+                        "Only support one-to-one now."
+                    )
                     param = vars[op.input("Param")[0]]
                     grad_var = vars[op.input("Grad")[0]]
                     if param.desc.original_id() in dist_tensors:
@@ -1968,20 +1966,18 @@ class RuleBasedTuner:
                         1
                     ] = self.stage_best_cost_of_pm[start][end][key][
                         "dist_context"
-                    ][
-                        0
-                    ]
-                    self.stage_best_cost_of_pm[start][end][key]["cost"][
-                        0
-                    ] = cost
+                    ][0]
+                    self.stage_best_cost_of_pm[start][end][key]["cost"][0] = (
+                        cost
+                    )
                     self.stage_best_cost_of_pm[start][end][key]["dist_context"][
                         0
                     ] = dist_context
 
                 elif index == 1:
-                    self.stage_best_cost_of_pm[start][end][key]["cost"][
-                        1
-                    ] = cost
+                    self.stage_best_cost_of_pm[start][end][key]["cost"][1] = (
+                        cost
+                    )
                     self.stage_best_cost_of_pm[start][end][key]["dist_context"][
                         1
                     ] = dist_context
@@ -2045,9 +2041,9 @@ class RuleBasedTuner:
                 best_cost = self.stage_best_cost_of_pm[start][end][key][
                     "best_cost"
                 ]
-                self.stage_best_cost_of_dm[start][end][dm_key][
-                    "cost"
-                ] = best_cost
+                self.stage_best_cost_of_dm[start][end][dm_key]["cost"] = (
+                    best_cost
+                )
                 self.stage_best_cost_of_dm[start][end][dm_key][
                     "dist_context"
                 ] = self.stage_best_cost_of_pm[start][end][key][
@@ -2103,12 +2099,12 @@ class RuleBasedTuner:
                 )
                 if cost < best_cost:
                     best_cost = cost
-                    self.stage_best_cost_of_dm[start][end][dm_key][
-                        "cost"
-                    ] = cost
-                    self.stage_best_cost_of_dm[start][end][dm_key][
-                        "memory"
-                    ] = local_stage_memory
+                    self.stage_best_cost_of_dm[start][end][dm_key]["cost"] = (
+                        cost
+                    )
+                    self.stage_best_cost_of_dm[start][end][dm_key]["memory"] = (
+                        local_stage_memory
+                    )
                     self.stage_best_cost_of_dm[start][end][dm_key][
                         "dist_context"
                     ] = dist_context
@@ -2156,12 +2152,12 @@ class RuleBasedTuner:
         if (start <= 1 and end <= 2) or end == len(self.layers) - 1:
             cost, local_stage_memory = self._get_sub_program_cost(dist_context)
             self.stage_best_cost_of_dm[start][end][dm_key]["cost"] = cost
-            self.stage_best_cost_of_dm[start][end][dm_key][
-                "memory"
-            ] = local_stage_memory
-            self.stage_best_cost_of_dm[start][end][dm_key][
-                "dist_context"
-            ] = dist_context
+            self.stage_best_cost_of_dm[start][end][dm_key]["memory"] = (
+                local_stage_memory
+            )
+            self.stage_best_cost_of_dm[start][end][dm_key]["dist_context"] = (
+                dist_context
+            )
 
         # some cache is used to speed up because the layer 1~end is same, for example:
         # stage_best_cost_of_dm[0][2] = stage_best_cost_of_dm[0][1] + stage_best_cost_of_dm[0][1] - stage_best_cost_of_pm[0][0]
@@ -2180,9 +2176,9 @@ class RuleBasedTuner:
                     end - 1
                 ][dm_key]["memory"]
                 self.stage_best_cost_of_dm[start][end][dm_key]["cost"] = cost
-                self.stage_best_cost_of_dm[start][end][dm_key][
-                    "memory"
-                ] = local_stage_memory
+                self.stage_best_cost_of_dm[start][end][dm_key]["memory"] = (
+                    local_stage_memory
+                )
                 self.stage_best_cost_of_dm[start][end][dm_key][
                     "dist_context"
                 ] = dist_context
@@ -2207,9 +2203,9 @@ class RuleBasedTuner:
                     local_stage_memory_former_1 - local_stage_memory_former_2
                 )
                 self.stage_best_cost_of_dm[start][end][dm_key]["cost"] = cost
-                self.stage_best_cost_of_dm[start][end][dm_key][
-                    "memory"
-                ] = local_stage_memory
+                self.stage_best_cost_of_dm[start][end][dm_key]["memory"] = (
+                    local_stage_memory
+                )
                 self.stage_best_cost_of_dm[start][end][dm_key][
                     "dist_context"
                 ] = dist_context
@@ -2672,9 +2668,9 @@ class RuleBasedTuner:
         for key in best_dist_context._dist_tensors_for_program:
             if key in self._dist_context._dist_tensors_for_program:
                 dist_tensor = best_dist_context._dist_tensors_for_program[key]
-                dist_attrs["tensor"][
-                    key
-                ] = dist_tensor.dist_attr.serialize_to_string()
+                dist_attrs["tensor"][key] = (
+                    dist_tensor.dist_attr.serialize_to_string()
+                )
         assert dist_attrs["tensor"], "Tensor dist attrs must not be None."
 
         for key in best_dist_context._dist_ops_for_program:
@@ -2756,9 +2752,9 @@ class RuleBasedTuner:
             else:
                 best_dist_context = self.tune_o1()
 
-        assert (
-            best_dist_context is not None
-        ), "can not find a parallel strategy to run, please use passes such as recompute, amp or sharding."
+        assert best_dist_context is not None, (
+            "can not find a parallel strategy to run, please use passes such as recompute, amp or sharding."
+        )
 
         for key in best_dist_context._dist_tensors_for_program:
             if key in self._dist_context._dist_tensors_for_program:

--- a/python/paddle/distributed/auto_parallel/static/utils.py
+++ b/python/paddle/distributed/auto_parallel/static/utils.py
@@ -183,12 +183,12 @@ def compute_compatible_dims_mapping(dims_mapping_list):
         return None
     length = len(dims_mapping_list[0])
     for dims_mapping in dims_mapping_list:
-        assert (
-            dims_mapping is not None
-        ), "Dims mapping must not be None for compatible computation"
-        assert (
-            len(dims_mapping) == length
-        ), "The length of dims_mapping in list must be same for compatible computation."
+        assert dims_mapping is not None, (
+            "Dims mapping must not be None for compatible computation"
+        )
+        assert len(dims_mapping) == length, (
+            "The length of dims_mapping in list must be same for compatible computation."
+        )
     compatible_result = []
     for dim_mappings in zip(*dims_mapping_list):
         compatible_dim_mapping = compute_compatible_dim_mapping(
@@ -252,9 +252,9 @@ def check_distributed_attr_for_program(program, dist_context=None):
 
     if dist_context is None:
         dist_context = get_default_distributed_context()
-    assert (
-        dist_context.is_initialized_for_program()
-    ), "Distributed attributes must be initialized before check."
+    assert dist_context.is_initialized_for_program(), (
+        "Distributed attributes must be initialized before check."
+    )
     for block in program.blocks:
         for tensor in block.vars.values():
             dist_tensor = dist_context.get_dist_tensor_for_graph(tensor)
@@ -309,9 +309,9 @@ def _get_comm_group(processes, shape, axis, rank):
 
     # NOTE _linear_idx2coordinate assume processes mesh start with 0 and continuous
     # tricks to support processes mesh when it is not start with 0 or continuous
-    assert (
-        rank in processes
-    ), f"rank [{rank}] is NOT in processes group {processes}"
+    assert rank in processes, (
+        f"rank [{rank}] is NOT in processes group {processes}"
+    )
     rank_relative = processes.index(rank)
     coordinate = _linear_idx2coordinate(shape, rank_relative)
     coordinates_in_group = [coordinate[:] for i in range(shape[axis])]
@@ -377,16 +377,16 @@ def _coordinate2linear_idx(mesh_shape, coordinate):
     # e.g. process_mesh = { process_groups = [7, 8, 9,10, 12, 13, 14, 15], mesh = [2, 4]}
     # if you want a more general mapping, you should use cartesian product
 
-    assert len(mesh_shape) == len(
-        coordinate
-    ), f"coordinate should have the same size as mesh shape, but got shape: {mesh_shape}, coordinate: {coordinate}"
+    assert len(mesh_shape) == len(coordinate), (
+        f"coordinate should have the same size as mesh shape, but got shape: {mesh_shape}, coordinate: {coordinate}"
+    )
     for i in range(len(mesh_shape)):
-        assert (
-            coordinate[i] >= 0
-        ), f"index in dimension [{i}] is least than zero. coordinate: {coordinate}"
-        assert (
-            coordinate[i] < mesh_shape[i]
-        ), f"index beyond extent in dimension [{i}]. shape: {mesh_shape}, coordinate: {coordinate}"
+        assert coordinate[i] >= 0, (
+            f"index in dimension [{i}] is least than zero. coordinate: {coordinate}"
+        )
+        assert coordinate[i] < mesh_shape[i], (
+            f"index beyond extent in dimension [{i}]. shape: {mesh_shape}, coordinate: {coordinate}"
+        )
 
     base = mesh_shape[-1]
     linear_idx = coordinate[-1]
@@ -419,9 +419,9 @@ def _linear_idx2coordinate(mesh_shape, linear_idx):
     """
 
     assert linear_idx >= 0, f"linear index [{linear_idx}] is least than zero"
-    assert linear_idx < np.prod(
-        mesh_shape
-    ), f"linear index beyond the extent of mesh shape. shape: {mesh_shape}, linear index: {linear_idx}"
+    assert linear_idx < np.prod(mesh_shape), (
+        f"linear index beyond the extent of mesh shape. shape: {mesh_shape}, linear index: {linear_idx}"
+    )
 
     base = 1
     coordinate = [-1] * len(mesh_shape)
@@ -462,9 +462,9 @@ def _get_unshard_dist_shape(var, dist_attr):
     var_shape = var.shape
     mapping = dist_attr.dims_mapping
     mesh = dist_attr.process_mesh.shape
-    assert len(var_shape) == len(
-        mapping
-    ), f"variable shape [{var_shape}] and dim_mapping [{mapping}] is NOT match !"
+    assert len(var_shape) == len(mapping), (
+        f"variable shape [{var_shape}] and dim_mapping [{mapping}] is NOT match !"
+    )
     new_shape = []
     for idx in range(len(var_shape)):
         if var_shape[idx] == -1 or mapping[idx] == -1:
@@ -689,9 +689,9 @@ def load_distributed_checkpoint(checkpoint_path, dist_attr_path):
             ... ]
             >>> param_dict, dist_attr, add_info = load_distributed_checkpoint(ckpt_path, dist_attr_path)
     """
-    assert _check_valid_path(
-        checkpoint_path
-    ), "'checkpoint_path' cannot be None."
+    assert _check_valid_path(checkpoint_path), (
+        "'checkpoint_path' cannot be None."
+    )
     assert _check_valid_path(dist_attr_path), "'dist_attr_path' cannot be None."
 
     state_dict_info = _load_distributed_state_dict(checkpoint_path)
@@ -739,9 +739,9 @@ def load_checkpoint_into_program(
     from .dist_context import get_default_distributed_context
 
     assert isinstance(program, paddle.static.Program)
-    assert _check_valid_path(
-        checkpoint_path
-    ), "'checkpoint_path' cannot be None."
+    assert _check_valid_path(checkpoint_path), (
+        "'checkpoint_path' cannot be None."
+    )
     assert _check_valid_path(dist_attr_path), "'dist_attr_path' cannot be None."
     if dist_context is None:
         dist_context = get_default_distributed_context()
@@ -794,9 +794,9 @@ def _load_distributed_attribute(dist_attr_path):
     for dist_attr_file in dist_attr_path:
         dist_attr = paddle.load(dist_attr_file)
         pre_world_size = dist_attr["world_size"]
-        assert pre_world_size == len(
-            dist_attr_path
-        ), "The number of 'dist_attr_path' must be equal to the last training world size."
+        assert pre_world_size == len(dist_attr_path), (
+            "The number of 'dist_attr_path' must be equal to the last training world size."
+        )
         for name, attr in dist_attr["model"].items():
             if name not in total_dist_attr:
                 total_dist_attr[name] = attr
@@ -825,9 +825,9 @@ def _load_distributed_state_dict(checkpoint_path):
     for idx, ckpt_file in enumerate(checkpoint_path):
         state_dict_info = paddle.load(ckpt_file, return_numpy=True)
         pre_world_size = state_dict_info["world_size"]
-        assert pre_world_size == len(
-            checkpoint_path
-        ), "The number of 'checkpoint_path' must be equal to the last training world size."
+        assert pre_world_size == len(checkpoint_path), (
+            "The number of 'checkpoint_path' must be equal to the last training world size."
+        )
         if idx == 0:
             addition_info = state_dict_info["addition_info"]
         for name, value in state_dict_info["model"].items():
@@ -909,9 +909,9 @@ def merge_and_slice_parameter(dist_param_dict, pre_dist_attr, cur_dist_attr):
         dist_param_dict(dict): parameters' value of current rank.
     """
     assert _check_dist_attr(pre_dist_attr), "'pre_dist_attr' cannot be None."
-    assert isinstance(
-        dist_param_dict, dict
-    ), f"The type of 'dist_param_dict' should be 'dict', but got {type(dist_param_dict)}."
+    assert isinstance(dist_param_dict, dict), (
+        f"The type of 'dist_param_dict' should be 'dict', but got {type(dist_param_dict)}."
+    )
     for name, value in dist_param_dict.items():
         if not isinstance(name, str):
             raise TypeError(
@@ -1010,9 +1010,9 @@ def _merge_parameter_with_dist_attr(param_list, dist_attr):
                 complete_shape,
             )
 
-    assert (
-        len(partition_param_list) == 1 or not partition_param_list
-    ), "Fail to merge parameter"
+    assert len(partition_param_list) == 1 or not partition_param_list, (
+        "Fail to merge parameter"
+    )
     complete_param = partition_param_list[0][0]
     return complete_param
 
@@ -1356,9 +1356,9 @@ def get_loss_op(block):
     loss_ops = []
     for op in block.ops:
         if is_loss_op(op):
-            assert (
-                len(op.desc.output_arg_names()) == 1
-            ), "loss op should only output loss var"
+            assert len(op.desc.output_arg_names()) == 1, (
+                "loss op should only output loss var"
+            )
             loss_ops.append(op)
 
     assert len(loss_ops) == 1, "num of loss op is not equal to one"
@@ -1448,9 +1448,9 @@ def update_op_dims_mapping_by_default_dist_impl(dist_op):
         dims_mapping = op_dist_attr.get_input_dims_mapping(arg_name)
         if len(dims_mapping) > 1:
             for idx, mapping in enumerate(dims_mapping[1:]):
-                assert (
-                    mapping == -1
-                ), f"{op_desc.type()} only the batch dimension (0-dim) can be sharded, but the dimension {idx} is sharded by {mapping} part."
+                assert mapping == -1, (
+                    f"{op_desc.type()} only the batch dimension (0-dim) can be sharded, but the dimension {idx} is sharded by {mapping} part."
+                )
         if len(dims_mapping) >= 1:
             batch_dim_mappings.append(dims_mapping[0])
     for arg_name in op_desc.output_arg_names():
@@ -1461,26 +1461,26 @@ def update_op_dims_mapping_by_default_dist_impl(dist_op):
         if arg_name not in xshape_arg_names:
             if len(dims_mapping) > 1:
                 for idx, mapping in enumerate(dims_mapping[1:]):
-                    assert (
-                        mapping == -1
-                    ), f"{op_desc.type()} only the batch dimension (0-dim) can be sharded, but the dimension {idx} is sharded by {mapping} part."
+                    assert mapping == -1, (
+                        f"{op_desc.type()} only the batch dimension (0-dim) can be sharded, but the dimension {idx} is sharded by {mapping} part."
+                    )
             if len(dims_mapping) >= 1:
                 batch_dim_mappings.append(dims_mapping[0])
         else:
-            assert (
-                dims_mapping[0] == -1
-            ), f"{op_desc.type()} only the batch dimension (1-dim) of XShape can be sharded, but the dimension 0 is sharded by {mapping} part."
+            assert dims_mapping[0] == -1, (
+                f"{op_desc.type()} only the batch dimension (1-dim) of XShape can be sharded, but the dimension 0 is sharded by {mapping} part."
+            )
             if len(dims_mapping) > 2:
                 for idx, mapping in enumerate(dims_mapping[2:]):
-                    assert (
-                        mapping == -1
-                    ), f"{op_desc.type()} only the batch dimension (1-dim) of XShape can be sharded, but the dimension {idx} is sharded by {mapping} part."
+                    assert mapping == -1, (
+                        f"{op_desc.type()} only the batch dimension (1-dim) of XShape can be sharded, but the dimension {idx} is sharded by {mapping} part."
+                    )
             batch_dim_mappings.append(dims_mapping[1])
 
     compatible_dim_mapping = compute_compatible_dim_mapping(batch_dim_mappings)
-    assert (
-        compatible_dim_mapping is not None
-    ), "There is no compatible dim mapping."
+    assert compatible_dim_mapping is not None, (
+        "There is no compatible dim mapping."
+    )
     for arg_name in op_desc.input_arg_names():
         serial_tensor = dist_op.get_serial_input(arg_name)
         if serial_tensor.is_parameter:
@@ -1543,9 +1543,9 @@ def update_op_dims_mapping_by_elementwise_like_dist_impl(dist_op):
         dims_mapping_list.append(dims_mapping)
 
     compatible_dims_mapping = compute_compatible_dims_mapping(dims_mapping_list)
-    assert (
-        compatible_dims_mapping is not None
-    ), "There is no compatible dim mapping."
+    assert compatible_dims_mapping is not None, (
+        "There is no compatible dim mapping."
+    )
 
     for arg_name in input_arg_names:
         if input_dims_mapping_lens[arg_name] < max_dims_mapping_len:
@@ -1681,9 +1681,9 @@ def get_standalone_cost_data(distributed_programs):
                                 lambda x, y: x * y, var.shape
                             )
                         break
-        assert (
-            total_static_input_size > 0 and total_actual_input_size > 0
-        ), "Get input size failed."
+        assert total_static_input_size > 0 and total_actual_input_size > 0, (
+            "Get input size failed."
+        )
 
         actual_runtime = (
             total_actual_input_size / total_static_input_size * runtime
@@ -2196,21 +2196,21 @@ def insert_dependencies_for_two_ops(
     if is_sequential_run():
         return
 
-    assert (
-        len(prior_op.output_arg_names) >= 1
-    ), f"first op of dependency should at least have one output. [{prior_op}]"
-    assert (
-        len(posterior_op.input_arg_names) >= 1
-    ), f"second op of dependency should at least have one input. [{posterior_op}]"
+    assert len(prior_op.output_arg_names) >= 1, (
+        f"first op of dependency should at least have one output. [{prior_op}]"
+    )
+    assert len(posterior_op.input_arg_names) >= 1, (
+        f"second op of dependency should at least have one input. [{posterior_op}]"
+    )
     prior_op_mesh = dist_context.get_op_dist_attr_for_program(
         prior_op
     ).process_mesh
     posterior_mesh = dist_context.get_op_dist_attr_for_program(
         posterior_op
     ).process_mesh
-    assert (
-        prior_op_mesh == posterior_mesh
-    ), f"two ops of dependency should have same mesh but got [{prior_op_mesh}] and [{posterior_mesh}]"
+    assert prior_op_mesh == posterior_mesh, (
+        f"two ops of dependency should have same mesh but got [{prior_op_mesh}] and [{posterior_mesh}]"
+    )
 
     def _select_best_depend_var(vars):
         # parameter should not be dep var since it maybe partition in sharding pass
@@ -2431,9 +2431,9 @@ def get_pp_stage_by_process_mesh(process_mesh, pp_degree):
         if pp_stage_for_process_mesh is not None:
             if pp_stage != pp_stage_for_process_mesh:
                 return None
-            assert (
-                pp_stage == pp_stage_for_process_mesh
-            ), f"Can't get pp_stage by process_mesh with different pp_stage {pp_stage} and {pp_stage_for_process_mesh}"
+            assert pp_stage == pp_stage_for_process_mesh, (
+                f"Can't get pp_stage by process_mesh with different pp_stage {pp_stage} and {pp_stage_for_process_mesh}"
+            )
         pp_stage_for_process_mesh = pp_stage
 
     return pp_stage_for_process_mesh
@@ -2643,15 +2643,15 @@ def fuse_param_func(
 
     if is_qkv:
         # fuse_attention_qkv
-        assert (
-            num_heads
-        ), f"num_heads should be number of heads for Q, but got {num_heads}"
-        assert (
-            num_key_value_heads
-        ), f"num_key_value_heads should be number of key_value_heads for K and V, but got {num_key_value_heads}"
-        assert (
-            len(fuse_params) == 3
-        ), f"fuse_params length is not equal 3, it should be Q K V list. but got length {len(fuse_params)}"
+        assert num_heads, (
+            f"num_heads should be number of heads for Q, but got {num_heads}"
+        )
+        assert num_key_value_heads, (
+            f"num_key_value_heads should be number of key_value_heads for K and V, but got {num_key_value_heads}"
+        )
+        assert len(fuse_params) == 3, (
+            f"fuse_params length is not equal 3, it should be Q K V list. but got length {len(fuse_params)}"
+        )
         num_query_groups = num_heads // num_key_value_heads
         q_list = split_fn(fuse_params[0], num_heads, axis=-1)
         k_list = split_fn(fuse_params[1], num_key_value_heads, axis=-1)
@@ -2705,12 +2705,12 @@ def split_param_func(
 
     if is_qkv:
         # fuse_attention_qkv
-        assert (
-            num_heads
-        ), f"num_heads should be number of heads for Q, but got {num_heads}"
-        assert (
-            num_key_value_heads
-        ), f"num_key_value_heads should be number of key_value_heads for K and V, but got {num_key_value_heads}"
+        assert num_heads, (
+            f"num_heads should be number of heads for Q, but got {num_heads}"
+        )
+        assert num_key_value_heads, (
+            f"num_key_value_heads should be number of key_value_heads for K and V, but got {num_key_value_heads}"
+        )
         num_query_groups = num_heads // num_key_value_heads
         q_list, k_list, v_list = [], [], []
         split_heads = split_fn(

--- a/python/paddle/distributed/auto_tuner/recorder.py
+++ b/python/paddle/distributed/auto_tuner/recorder.py
@@ -69,9 +69,9 @@ class HistoryRecorder:
         if buffer is not None:
             if buffer < 0:
                 raise ValueError("The buffer should be not less than 0.")
-            assert (
-                max_mem_usage is not None
-            ), "max_mem_usage cannot be None when buffer is greater than 0."
+            assert max_mem_usage is not None, (
+                "max_mem_usage cannot be None when buffer is greater than 0."
+            )
             if max_mem_usage <= 0:
                 raise ValueError("max_mem_usage should be greater than 0.")
 

--- a/python/paddle/distributed/auto_tuner/search.py
+++ b/python/paddle/distributed/auto_tuner/search.py
@@ -103,9 +103,9 @@ class DpEstimationSearch(SearchAlgo):
             )
             tuner_cfg["candidates"]["dp_degree"] = [1]
         self.all_tasks = search_by_dp_estimation(tuner_cfg)
-        assert (
-            len(self.all_tasks) > 0
-        ), "Unable to perform single dp estimation search."
+        assert len(self.all_tasks) > 0, (
+            "Unable to perform single dp estimation search."
+        )
 
     def search_once(self, history_cfgs):
         new_cfg = None
@@ -146,9 +146,9 @@ class CustomizeSearch(SearchAlgo):
         super().__init__(tuner_cfg)
         self.idx = 0
         self.configs_csv = tuner_cfg.get("configs_csv", None)
-        assert os.path.exists(
-            self.configs_csv
-        ), "configs_csv file is necessary in CustomizeSearch mode."
+        assert os.path.exists(self.configs_csv), (
+            "configs_csv file is necessary in CustomizeSearch mode."
+        )
         self.all_tasks = load_configs_from_csv(self.configs_csv)
 
     def search_once(self, history_cfgs):

--- a/python/paddle/distributed/auto_tuner/utils.py
+++ b/python/paddle/distributed/auto_tuner/utils.py
@@ -1820,7 +1820,9 @@ def load_configs_from_csv(configs_csv):
             recompute_granularity == ""
             or recompute_granularity.lower()
             in __SUPPORTED_RECOMPUTE_GRANULARITY__
-        ), f"{recompute_granularity} must be one of {__SUPPORTED_RECOMPUTE_GRANULARITY__}, but got {recompute_granularity}."
+        ), (
+            f"{recompute_granularity} must be one of {__SUPPORTED_RECOMPUTE_GRANULARITY__}, but got {recompute_granularity}."
+        )
         config["recompute_granularity"] = (
             recompute_granularity if recompute_granularity != "" else None
         )


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

使用性能更好，格式化效果更佳的 ruff format 替代 black 作为新的 formatter，由于我们很早就已经集成了 ruff lint，因此只是减少依赖而不会增加依赖

<!--

## 核心优势

通过集成 Ruff format，开发者可以享受到以下优势：

- 通过去除 black 对 python 环境依赖，极大降低了升级 formatter 带来的成本，后续无需考虑开发者本地 python 环境即可一键升级
- ruff 由 Rust 驱动，大幅加速 format 时间，降低开发者使用开发工具链的时间成本，减少 CI 时间，提升工程效率
- 格式化后呈现可读性更佳的效果，使得开发者更专注于代码开发而无需关心格式，阅读者也能够更加赏心悦目，极大增加了潜在贡献者的贡献意愿
- ruff 极大程度地兼容了 black 的格式化效果，能够平滑地替换现有的 black 配置
- ruff 更新频次高，能够快速响应社区反馈，持续优化格式化效果
- ruff 团队 Astral 最近开发的 ty 能够提供更强大的类型检查能力，后续可能与 ruff 集成，提供更好的开发体验
- PyTorch 最近已经完成迁移，追平竞品（在代码风格这块，我们一直做到了超越竞品，这次不能落后）

-->