### PR TITLE
[CodeStyle] `black -> ruff format` migration - part 27

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -79,7 +79,7 @@ repos:
 
             # | python/paddle/distributed/a.+
 
-            # | python/paddle/distributed/[b-e].+
+            | python/paddle/distributed/[b-e].+
 
             # | python/paddle/distributed/f.+
 
@@ -135,7 +135,7 @@ repos:
 
             | python/paddle/distributed/a.+
 
-            | python/paddle/distributed/[b-e].+
+            # | python/paddle/distributed/[b-e].+
 
             | python/paddle/distributed/f.+
 

--- a/python/paddle/_paddle_docs.py
+++ b/python/paddle/_paddle_docs.py
@@ -74,6 +74,7 @@ def _parse_function_signature(
         if func_def.args.defaults and len(func_def.args.defaults) > (
             len(func_def.args.args) - len(func_def.args.defaults)
         ):
+
             idx = count - (
                 len(func_def.args.args) - len(func_def.args.defaults)
             )

--- a/python/paddle/_paddle_docs.py
+++ b/python/paddle/_paddle_docs.py
@@ -74,7 +74,6 @@ def _parse_function_signature(
         if func_def.args.defaults and len(func_def.args.defaults) > (
             len(func_def.args.args) - len(func_def.args.defaults)
         ):
-
             idx = count - (
                 len(func_def.args.args) - len(func_def.args.defaults)
             )

--- a/python/paddle/distributed/checkpoint/load_state_dict.py
+++ b/python/paddle/distributed/checkpoint/load_state_dict.py
@@ -65,17 +65,17 @@ def get_checkpoint_files(path, use_cache=True, unique_id=None):
         for file in accessible_files
         if file.endswith(f"{unique_id}.metadata")
     ]
-    assert (
-        len(metadata_files) > 0
-    ), f"No metadata file ends with '{unique_id}.metadata' found in the checkpoint directory: {path}."
+    assert len(metadata_files) > 0, (
+        f"No metadata file ends with '{unique_id}.metadata' found in the checkpoint directory: {path}."
+    )
     local_data_files = [
         file
         for file in accessible_files
         if file.endswith(f"{unique_id}.distcp")
     ]
-    assert (
-        len(local_data_files) > 0
-    ), f"No data file ends with '{unique_id}.distcp' found in the checkpoint directory:{path}."
+    assert len(local_data_files) > 0, (
+        f"No data file ends with '{unique_id}.distcp' found in the checkpoint directory:{path}."
+    )
     if use_cache:
         PATH_TO_CHECKPOINT_FILES[path] = (metadata_files, local_data_files)
     return (metadata_files, local_data_files)
@@ -100,9 +100,9 @@ def get_rank_to_files(
 
     for metadata in metadata_list:
         for local_tensor_index, file_name in metadata.storage_metadata.items():
-            assert (
-                local_tensor_index not in tensor_key_list
-            ), f"Duplicate tensor_key:{local_tensor_index} found. Check whether the metadata."
+            assert local_tensor_index not in tensor_key_list, (
+                f"Duplicate tensor_key:{local_tensor_index} found. Check whether the metadata."
+            )
             tensor_key_list.append(local_tensor_index.tensor_key)
             if local_tensor_index.tensor_key in state_dict:
                 necessary_files.append(file_name)
@@ -146,7 +146,9 @@ def get_rank_to_files(
     assert (
         global_data_files_set & global_necessary_files_set
         == global_necessary_files_set
-    ), f"The checkpoint files are not complete. Please check the checkpoint directory. global_data_files_set:{global_data_files_set}, necessary_data_files_set:{global_necessary_files_set}"
+    ), (
+        f"The checkpoint files are not complete. Please check the checkpoint directory. global_data_files_set:{global_data_files_set}, necessary_data_files_set:{global_necessary_files_set}"
+    )
     missing_keys = set(state_dict.keys()) - set(tensor_key_list)
     if len(missing_keys) > 0:
         if mw_name_compatibility:
@@ -417,9 +419,9 @@ def compute_overlap(
                 f"Invalid begin_offset:{begin_offset}, cur_offset:{cur_offset}, storage_offset:{storage_offset}"
             )
         lengths.append(end_offset - begin_offset)
-        assert (
-            lengths[-1] >= 0
-        ), f"Invalid length:{lengths[-1]}, end_offset:{end_offset}, begin_offset:{begin_offset}"
+        assert lengths[-1] >= 0, (
+            f"Invalid length:{lengths[-1]}, end_offset:{end_offset}, begin_offset:{begin_offset}"
+        )
     return cur_offsets, storage_offsets, lengths
 
 
@@ -480,9 +482,9 @@ def get_read_items(metadata_list, state_dict, process_group, use_dist):
             cur_chunk_metadata = LocalTensorMetadata(
                 global_offset, local_shape, str(val.dtype).split(".")[1]
             )
-            assert (
-                tensor_key in storage_state_dict_metadata
-            ), f"tensor_key:{tensor_key} not found in storage_state_dict_metadata:{storage_state_dict_metadata}."
+            assert tensor_key in storage_state_dict_metadata, (
+                f"tensor_key:{tensor_key} not found in storage_state_dict_metadata:{storage_state_dict_metadata}."
+            )
             for storage_local_tensor_metadata in storage_state_dict_metadata[
                 tensor_key
             ]:
@@ -568,15 +570,15 @@ def load_state_dict(
             >>> # doctest: -SKIP
     """
     with paddle.base.dygraph.guard():
-        assert isinstance(
-            state_dict, dict
-        ), "The state_dict should be a dictionary."
+        assert isinstance(state_dict, dict), (
+            "The state_dict should be a dictionary."
+        )
         flat_state_dict, mapping = flatten_state_dict(state_dict)
         if len(flat_state_dict) > 0:
             for val in flat_state_dict.values():
-                assert isinstance(
-                    val, paddle.Tensor
-                ), f"The value of state_dict should be a paddle.Tensor, but got: {val}."
+                assert isinstance(val, paddle.Tensor), (
+                    f"The value of state_dict should be a paddle.Tensor, but got: {val}."
+                )
 
         use_dist = True if paddle.distributed.get_world_size() > 1 else False
 
@@ -704,9 +706,9 @@ def _load_state_dict(
                 if target_state_dict[key].place.is_cpu_place():
                     state_dict_in_cpu.append(key)
                     target_state_dict[key] = target_state_dict[key].cuda()
-            assert (
-                item.local_tensor_index in load_infos
-            ), f"read item:{item}, load_infos:{load_infos}"
+            assert item.local_tensor_index in load_infos, (
+                f"read item:{item}, load_infos:{load_infos}"
+            )
 
             logger.debug(f"read item: {item}")
             src_rank, file_name = load_infos[item.local_tensor_index]

--- a/python/paddle/distributed/checkpoint/save_state_dict.py
+++ b/python/paddle/distributed/checkpoint/save_state_dict.py
@@ -79,9 +79,9 @@ def copy_dict_to_cpu(nested_dict):
 
 
 def merge_state_dict_metadata(global_state_dict_metadata):
-    assert isinstance(
-        global_state_dict_metadata, list
-    ), "The global_state_dict should be a list."
+    assert isinstance(global_state_dict_metadata, list), (
+        "The global_state_dict should be a list."
+    )
     out = {}
     for state_dict in global_state_dict_metadata:
         for key, val in state_dict.items():
@@ -166,15 +166,15 @@ def save_state_dict(
 
     """
     with paddle.base.dygraph.guard():
-        assert isinstance(
-            state_dict, dict
-        ), "The state_dict should be a dictionary."
+        assert isinstance(state_dict, dict), (
+            "The state_dict should be a dictionary."
+        )
         flat_state_dict, mapping = flatten_state_dict(state_dict)
         if len(flat_state_dict) > 0:
             for val in flat_state_dict.values():
-                assert isinstance(
-                    val, paddle.Tensor
-                ), f"The value of state_dict should be a paddle.Tensor, but got: {val}."
+                assert isinstance(val, paddle.Tensor), (
+                    f"The value of state_dict should be a paddle.Tensor, but got: {val}."
+                )
 
         if not os.path.exists(path):
             os.makedirs(path, exist_ok=True)

--- a/python/paddle/distributed/checkpoint/utils.py
+++ b/python/paddle/distributed/checkpoint/utils.py
@@ -120,9 +120,9 @@ def unflatten_state_dict(flat_state_dict, mapping):
     state_dict = {}
     for key, value in flat_state_dict.items():
         key_tuple = mapping[key]
-        assert isinstance(
-            key_tuple, tuple
-        ), f"The key should be tuple, but is {key_tuple}"
+        assert isinstance(key_tuple, tuple), (
+            f"The key should be tuple, but is {key_tuple}"
+        )
         tmp = state_dict
         for i in range(len(key_tuple) - 1):
             key = key_tuple[i]

--- a/python/paddle/distributed/communication/all_gather.py
+++ b/python/paddle/distributed/communication/all_gather.py
@@ -119,9 +119,9 @@ def all_gather_object(
             >>> print(object_list)
             >>> # [{'foo': [1, 2, 3]}, {'bar': [4, 5, 6]}] (2 GPUs)
     """
-    assert (
-        framework.in_dynamic_mode()
-    ), "all_gather_object doesn't support static graph mode."
+    assert framework.in_dynamic_mode(), (
+        "all_gather_object doesn't support static graph mode."
+    )
 
     tensor, len_of_tensor = convert_object_to_tensor(obj)
 

--- a/python/paddle/distributed/communication/broadcast.py
+++ b/python/paddle/distributed/communication/broadcast.py
@@ -113,9 +113,9 @@ def broadcast_object_list(
             >>> print(object_list)
             >>> # [{"bar": [4, 5, 6]}] (2 GPUs)
     """
-    assert (
-        framework.in_dynamic_mode()
-    ), "broadcast_object_list doesn't support static graph mode."
+    assert framework.in_dynamic_mode(), (
+        "broadcast_object_list doesn't support static graph mode."
+    )
 
     rank = dist.get_rank()
     obj_tensors = []

--- a/python/paddle/distributed/communication/deep_ep/buffer.py
+++ b/python/paddle/distributed/communication/deep_ep/buffer.py
@@ -266,9 +266,9 @@ class Buffer:
             144: Config(Buffer.num_sms, 32, 720, 12, 128),
             160: Config(Buffer.num_sms, 28, 720, 12, 128),
         }
-        assert (
-            num_ranks in config_map
-        ), f'Unsupported number of EP ranks: {num_ranks}'
+        assert num_ranks in config_map, (
+            f'Unsupported number of EP ranks: {num_ranks}'
+        )
         return config_map[num_ranks]
 
     @staticmethod
@@ -294,9 +294,9 @@ class Buffer:
             144: Config(Buffer.num_sms, 2, 720, 8, 128),
             160: Config(Buffer.num_sms, 2, 720, 8, 128),
         }
-        assert (
-            num_ranks in config_map
-        ), f'Unsupported number of EP ranks: {num_ranks}'
+        assert num_ranks in config_map, (
+            f'Unsupported number of EP ranks: {num_ranks}'
+        )
         return config_map[num_ranks]
 
     # noinspection PyTypeChecker

--- a/python/paddle/distributed/communication/gather.py
+++ b/python/paddle/distributed/communication/gather.py
@@ -69,7 +69,7 @@ def gather(
             >>> # [[1, 2, 3], [4, 5, 6]] (2 GPUs, out for rank 0)
             >>> # [] (2 GPUs, out for rank 1)
     """
-    assert (
-        framework.in_dynamic_mode()
-    ), "gather doesn't support static graph mode yet."
+    assert framework.in_dynamic_mode(), (
+        "gather doesn't support static graph mode yet."
+    )
     return stream.gather(tensor, gather_list, dst, group, sync_op)

--- a/python/paddle/distributed/communication/group.py
+++ b/python/paddle/distributed/communication/group.py
@@ -151,9 +151,9 @@ def _warn_cur_rank_not_in_group(group):
 
 def _get_or_throw_group_rank(global_rank, group):
     group_rank = group.get_group_rank(global_rank)
-    assert (
-        group_rank >= 0
-    ), f"The input rank {global_rank} can not be found inside the group {group.name}"
+    assert group_rank >= 0, (
+        f"The input rank {global_rank} can not be found inside the group {group.name}"
+    )
     return group_rank
 
 
@@ -218,9 +218,9 @@ def destroy_process_group(group: Group | None = None) -> None:
 
     """
     group = _get_global_group() if group is None else group
-    assert (
-        group.id in _GroupManager.group_map_by_id
-    ), f"Destroy group with id {group.id} is invalid."
+    assert group.id in _GroupManager.group_map_by_id, (
+        f"Destroy group with id {group.id} is invalid."
+    )
     if _is_global_group(group):
         _GroupManager.group_map_by_id.clear()
     else:

--- a/python/paddle/distributed/communication/scatter.py
+++ b/python/paddle/distributed/communication/scatter.py
@@ -127,9 +127,9 @@ def scatter_object_list(
             >>> # [{'bar': [1, 2, 3]}] (2 GPUs, out for rank 0)
             >>> # [{'bar': [4, 5, 6]}] (2 GPUs, out for rank 1)
     """
-    assert (
-        framework.in_dynamic_mode()
-    ), "scatter_object_list doesn't support static graph mode."
+    assert framework.in_dynamic_mode(), (
+        "scatter_object_list doesn't support static graph mode."
+    )
 
     rank = dist.get_rank()
     in_obj_tensors = []

--- a/python/paddle/distributed/communication/stream/all_gather.py
+++ b/python/paddle/distributed/communication/stream/all_gather.py
@@ -207,9 +207,9 @@ def all_gather(
                 tensor_or_tensor_list, tensor, group, sync_op, use_calc_stream
             )
     else:
-        assert (
-            group is None
-        ), "Group can not be used in static graph mode for now."
+        assert group is None, (
+            "Group can not be used in static graph mode for now."
+        )
         if paddle.is_tensor(tensor_or_tensor_list):
             raise RuntimeError(
                 "Only support passing a tensor list to `all_gather` in static graph mode now."

--- a/python/paddle/distributed/communication/stream/all_reduce.py
+++ b/python/paddle/distributed/communication/stream/all_reduce.py
@@ -158,9 +158,9 @@ def all_reduce(
             tensor, op, group, sync_op, use_calc_stream
         )
     else:
-        assert (
-            group is None
-        ), "Group can not be used in static graph mode for now."
+        assert group is None, (
+            "Group can not be used in static graph mode for now."
+        )
         return _all_reduce_in_static_mode(
             tensor, op, group, sync_op, use_calc_stream
         )

--- a/python/paddle/distributed/communication/stream/all_to_all.py
+++ b/python/paddle/distributed/communication/stream/all_to_all.py
@@ -245,9 +245,9 @@ def alltoall(
                 "The output and input should be both tensor or tensor list."
             )
     else:
-        assert (
-            group is None
-        ), "Group can not be used in static graph mode for now."
+        assert group is None, (
+            "Group can not be used in static graph mode for now."
+        )
         return _all_to_all_in_static_mode(
             out_tensor_or_tensor_list,
             in_tensor_or_tensor_list,

--- a/python/paddle/distributed/communication/stream/broadcast.py
+++ b/python/paddle/distributed/communication/stream/broadcast.py
@@ -148,9 +148,9 @@ def broadcast(
             tensor, src_rank_in_group, group, sync_op, use_calc_stream
         )
     else:
-        assert (
-            group is None
-        ), "Group can not be used in static graph mode for now."
+        assert group is None, (
+            "Group can not be used in static graph mode for now."
+        )
         return _broadcast_in_static_mode(
             tensor, src, group, sync_op, use_calc_stream
         )

--- a/python/paddle/distributed/communication/stream/gather.py
+++ b/python/paddle/distributed/communication/stream/gather.py
@@ -44,9 +44,9 @@ def _gather_in_dygraph(
     else:
         gather_list = [tensor for _ in range(nranks)]
 
-    assert (
-        len(gather_list) == nranks
-    ), f" gather_list length {len(gather_list)} and nrankd {nranks} not equal"
+    assert len(gather_list) == nranks, (
+        f" gather_list length {len(gather_list)} and nrankd {nranks} not equal"
+    )
 
     task = group.process_group.gather(
         tensor, gather_list, dst_rank_in_group, sync_op, use_calc_stream
@@ -105,9 +105,9 @@ def gather(
             >>> # [] (2 GPUs, out for rank 1)
     """
 
-    assert (
-        framework.in_dynamic_mode()
-    ), "gather doesn't support static graph mode yet."
+    assert framework.in_dynamic_mode(), (
+        "gather doesn't support static graph mode yet."
+    )
 
     if _warn_cur_rank_not_in_group(group):
         return
@@ -127,9 +127,9 @@ def gather(
             )
         gather_list = []
     else:
-        assert (
-            gather_list is not None
-        ), "gather_list must not be none for dst rank"
+        assert gather_list is not None, (
+            "gather_list must not be none for dst rank"
+        )
 
     group = _get_global_group() if group is None else group
     dst_rank_in_group = _get_or_throw_group_rank(dst, group)

--- a/python/paddle/distributed/communication/stream/recv.py
+++ b/python/paddle/distributed/communication/stream/recv.py
@@ -128,9 +128,9 @@ def recv(
             tensor, src_rank_in_group, group, sync_op, use_calc_stream
         )
     else:
-        assert (
-            group is None
-        ), "Group can not be used in static graph mode for now."
+        assert group is None, (
+            "Group can not be used in static graph mode for now."
+        )
         return _recv_in_static_mode(
             tensor, src, group, sync_op, use_calc_stream
         )

--- a/python/paddle/distributed/communication/stream/reduce.py
+++ b/python/paddle/distributed/communication/stream/reduce.py
@@ -148,9 +148,9 @@ def reduce(
             tensor, dst_rank_in_group, op, group, sync_op, use_calc_stream
         )
     else:
-        assert (
-            group is None
-        ), "Group can not be used in static graph mode for now."
+        assert group is None, (
+            "Group can not be used in static graph mode for now."
+        )
         return _reduce_in_static_mode(
             tensor, dst, op, group, sync_op, use_calc_stream
         )

--- a/python/paddle/distributed/communication/stream/reduce_scatter.py
+++ b/python/paddle/distributed/communication/stream/reduce_scatter.py
@@ -191,9 +191,9 @@ def reduce_scatter(
                 use_calc_stream,
             )
     else:
-        assert (
-            group is None
-        ), "Group can not be used in static graph mode for now."
+        assert group is None, (
+            "Group can not be used in static graph mode for now."
+        )
         return _reduce_scatter_in_static_mode(
             tensor, tensor_or_tensor_list, group
         )

--- a/python/paddle/distributed/communication/stream/scatter.py
+++ b/python/paddle/distributed/communication/stream/scatter.py
@@ -232,9 +232,9 @@ def scatter(
                 use_calc_stream,
             )
     else:
-        assert (
-            group is None
-        ), "Group can not be used in static graph mode for now."
+        assert group is None, (
+            "Group can not be used in static graph mode for now."
+        )
 
         return _scatter_in_static_mode(
             tensor,

--- a/python/paddle/distributed/communication/stream/send.py
+++ b/python/paddle/distributed/communication/stream/send.py
@@ -127,9 +127,9 @@ def send(
             tensor, dst_rank_in_group, group, sync_op, use_calc_stream
         )
     else:
-        assert (
-            group is None
-        ), "Group can not be used in static graph mode for now."
+        assert group is None, (
+            "Group can not be used in static graph mode for now."
+        )
         return _send_in_static_mode(
             tensor, dst, group, sync_op, use_calc_stream
         )


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

使用性能更好，格式化效果更佳的 ruff format 替代 black 作为新的 formatter，由于我们很早就已经集成了 ruff lint，因此只是减少依赖而不会增加依赖

<!--

## 核心优势

通过集成 Ruff format，开发者可以享受到以下优势：

- 通过去除 black 对 python 环境依赖，极大降低了升级 formatter 带来的成本，后续无需考虑开发者本地 python 环境即可一键升级
- ruff 由 Rust 驱动，大幅加速 format 时间，降低开发者使用开发工具链的时间成本，减少 CI 时间，提升工程效率
- 格式化后呈现可读性更佳的效果，使得开发者更专注于代码开发而无需关心格式，阅读者也能够更加赏心悦目，极大增加了潜在贡献者的贡献意愿
- ruff 极大程度地兼容了 black 的格式化效果，能够平滑地替换现有的 black 配置
- ruff 更新频次高，能够快速响应社区反馈，持续优化格式化效果
- ruff 团队 Astral 最近开发的 ty 能够提供更强大的类型检查能力，后续可能与 ruff 集成，提供更好的开发体验
- PyTorch 最近已经完成迁移，追平竞品（在代码风格这块，我们一直做到了超越竞品，这次不能落后）

-->