### PR TITLE
[Dy2St] Cleanup `IrMode` in `dygraph_to_static_utils.py`

### DIFF
--- a/test/dygraph_to_static/test_amp_case.py
+++ b/test/dygraph_to_static/test_amp_case.py
@@ -18,7 +18,6 @@ import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
     test_ast_only,
-    test_pir_only,
 )
 
 import paddle
@@ -58,7 +57,6 @@ class Net(paddle.nn.Layer):
 
 class TestPartialAutoCast(Dy2StTestBase):
     @test_ast_only
-    @test_pir_only
     def test_run(self):
         if not paddle.base.core.is_compiled_with_cuda():
             return

--- a/test/dygraph_to_static/test_ast_util.py
+++ b/test/dygraph_to_static/test_ast_util.py
@@ -21,7 +21,6 @@ from dygraph_to_static_utils import (
     Dy2StTestBase,
     static_guard,
     test_ast_only,
-    test_pir_only,
 )
 from ifelse_simple_func import (
     dyfunc_with_if_else,
@@ -49,7 +48,6 @@ class TestAST2Func(Dy2StTestBase):
         return transformed_func
 
     @test_ast_only
-    @test_pir_only
     def test_ast2func(self):
         def func(x, y):
             return x + y
@@ -58,7 +56,6 @@ class TestAST2Func(Dy2StTestBase):
         self.assertEqual(func(x, y), self._ast2func(func)(x, y))
 
     @test_ast_only
-    @test_pir_only
     def test_ast2func_dygraph(self):
         funcs = [dyfunc_with_if_else, dyfunc_with_if_else2, nested_if_else]
         x_data = np.random.random([10, 16]).astype('float32')
@@ -69,7 +66,6 @@ class TestAST2Func(Dy2StTestBase):
             np.testing.assert_allclose(true_ret, test_ret)
 
     @test_ast_only
-    @test_pir_only
     def test_ast2func_static(self):
         def func(x):
             y = F.relu(x)
@@ -88,7 +84,6 @@ class TestAST2Func(Dy2StTestBase):
                 np.testing.assert_allclose(ret[0], ret[1])
 
     @test_ast_only
-    @test_pir_only
     def test_ast2func_error(self):
         with self.assertRaises(Exception) as e:
             self.assertRaises(TypeError, ast_to_func("x = a + b", 'foo'))

--- a/test/dygraph_to_static/test_build_strategy.py
+++ b/test/dygraph_to_static/test_build_strategy.py
@@ -19,7 +19,6 @@ from dygraph_to_static_utils import (
     Dy2StTestBase,
     enable_to_static_guard,
     test_default_mode_only,
-    test_pir_only,
 )
 from test_resnet import ResNetHelper
 
@@ -66,7 +65,6 @@ class TestResnetWithPass(Dy2StTestBase):
             err_msg=f'predictor_pre:\n {predictor_pre}\n, st_pre: \n{st_pre}.',
         )
 
-    @test_pir_only
     def test_resnet(self):
         static_loss = self.train(to_static=True)
         dygraph_loss = self.train(to_static=False)

--- a/test/dygraph_to_static/test_cast.py
+++ b/test/dygraph_to_static/test_cast.py
@@ -18,7 +18,6 @@ import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
     test_ast_only,
-    test_pir_only,
 )
 
 import paddle
@@ -220,7 +219,6 @@ class TestComplexCast(TestCastBase):
     def set_func(self):
         self.func = paddle.jit.to_static(full_graph=True)(test_complex_cast)
 
-    @test_pir_only
     def test_cast_result(self):
         self.set_func()
         res = self.do_test().numpy()

--- a/test/dygraph_to_static/test_convert_call.py
+++ b/test/dygraph_to_static/test_convert_call.py
@@ -20,7 +20,6 @@ from dygraph_to_static_utils import (
     Dy2StTestBase,
     enable_to_static_guard,
     test_ast_only,
-    test_pir_only,
 )
 
 import paddle
@@ -97,7 +96,6 @@ class TestRecursiveCall1(Dy2StTestBase):
             res = self.dyfunc(self.input).numpy()
         return res
 
-    @test_pir_only
     def test_transformed_static_result(self):
         self.init_test_func()
         static_res = self.get_static_output()
@@ -186,7 +184,6 @@ class TestRecursiveCall2(Dy2StTestBase):
         with enable_to_static_guard(True):
             return self._run()
 
-    @test_pir_only
     def test_transformed_static_result(self):
         self.set_func()
         dygraph_res = self.get_dygraph_output()
@@ -230,7 +227,6 @@ class TestNotToConvert(TestRecursiveCall2):
         paddle.jit.not_to_static()(self.net.sum)
         self.dygraph_func = paddle.jit.to_static(self.net.outer)
 
-    @test_pir_only
     def test_transform_options(self):
         self.set_func()
         self.assertTrue(
@@ -244,7 +240,6 @@ class TestNotToConvert(TestRecursiveCall2):
             )
         )
 
-    @test_pir_only
     def test_code(self):
         self.set_func()
         # check 'if statement' is not converted
@@ -260,7 +255,6 @@ class TestNotToConvert2(TestRecursiveCall2):
         paddle.jit.not_to_static(self.net.sum)
         self.dygraph_func = paddle.jit.to_static(self.net.sum)
 
-    @test_pir_only
     def test_transform_options(self):
         self.set_func()
         self.assertTrue(
@@ -275,7 +269,6 @@ class TestNotToConvert2(TestRecursiveCall2):
         )
 
     @test_ast_only
-    @test_pir_only
     def test_code(self):
         self.set_func()
         self.dygraph_func = paddle.jit.to_static(self.net.sum)
@@ -293,7 +286,6 @@ def forward(self, x):
 
 class TestConvertPaddleAPI(Dy2StTestBase):
     @test_ast_only
-    @test_pir_only
     def test_functional_api(self):
         func = paddle.nn.functional.relu
         func = paddle.jit.to_static(func)
@@ -301,7 +293,6 @@ class TestConvertPaddleAPI(Dy2StTestBase):
         self.assertIn("if in_dynamic_or_pir_mode()", func.code)
 
     @test_ast_only
-    @test_pir_only
     def test_class_api(self):
         bn = paddle.nn.SyncBatchNorm(2)
         paddle.jit.to_static(bn)
@@ -309,7 +300,6 @@ class TestConvertPaddleAPI(Dy2StTestBase):
         self.assertIn("if in_dynamic_or_pir_mode()", bn.forward.code)
 
     @test_ast_only
-    @test_pir_only
     def test_class_patch_api(self):
         paddle.nn.SyncBatchNorm.forward = forward
         bn = paddle.nn.SyncBatchNorm(2)

--- a/test/dygraph_to_static/test_deal_inplace.py
+++ b/test/dygraph_to_static/test_deal_inplace.py
@@ -16,10 +16,7 @@ import copy
 import unittest
 
 import numpy as np
-from dygraph_to_static_utils import (
-    Dy2StTestBase,
-    test_pir_only,
-)
+from dygraph_to_static_utils import Dy2StTestBase
 
 import paddle
 
@@ -94,42 +91,36 @@ class TestDealInplace(Dy2StTestBase):
                 err_msg=f"Run {i}-th check failed.",
             )
 
-    @test_pir_only
     def test_deal_view(self):
         bn_layer = paddle.nn.BatchNorm2D(10)
         x = paddle.to_tensor(np.random.random((2, 10, 3, 3)).astype('float32'))
         x.stop_gradient = False
         self.run_test(fn_with_inplace_op, bn_layer, x, static_n_times=2)
 
-    @test_pir_only
     def test_deal_inplace(self):
         sigmoid_layer = paddle.nn.Sigmoid()
         x = paddle.to_tensor(np.random.random((2, 10, 3, 3)).astype('float32'))
         x.stop_gradient = False
         self.run_test(fn_with_inplace_op, sigmoid_layer, x, static_n_times=2)
 
-    @test_pir_only
     def test_param_inplace(self):
         net = ParamInplaceNet()
         x = paddle.to_tensor(np.random.random(10).astype('float32'))
         x.stop_gradient = False
         self.run_test(net, x, static_n_times=2)
 
-    @test_pir_only
     def test_param_directly_return(self):
         net = ParamDirectlyReturnNet()
         x = paddle.to_tensor(np.random.random(10).astype('float32'))
         x.stop_gradient = False
         self.run_test(net, x, static_n_times=2)
 
-    @test_pir_only
     def test_param_return_after_assign(self):
         net = ParamReturnAfterAssignNet()
         x = paddle.to_tensor(np.random.random(10).astype('float32'))
         x.stop_gradient = False
         self.run_test(net, x, static_n_times=2)
 
-    @test_pir_only
     def test_input_directly_return(self):
         net = InputDirectlyReturnNet()
         x = paddle.to_tensor(np.random.random(10).astype('float32'))

--- a/test/dygraph_to_static/test_dygraph_to_static_utils.py
+++ b/test/dygraph_to_static/test_dygraph_to_static_utils.py
@@ -17,29 +17,25 @@ from itertools import product
 
 from dygraph_to_static_utils import (
     DEFAULT_BACKEND_MODE,
-    DEFAULT_IR_MODE,
     DEFAULT_TO_STATIC_MODE,
     VALID_MODES,
     BackendMode,
     Dy2StTestBase,
     Dy2StTestMeta,
-    IrMode,
     ModeTuple,
     ToStaticMode,
     disable_test_case,
     set_backend_mode,
-    set_ir_mode,
     set_to_static_mode,
 )
 
-ALL_MODES = list(product(ToStaticMode, IrMode, BackendMode))
+ALL_MODES = list(product(ToStaticMode, BackendMode))
 DEFAULT_MODES = [
-    (to_static_mode, ir_mode, backend_mode)
-    for (to_static_mode, ir_mode, backend_mode) in ALL_MODES
+    (to_static_mode, backend_mode)
+    for (to_static_mode, backend_mode) in ALL_MODES
     if (
-        (to_static_mode, ir_mode, backend_mode) in VALID_MODES
+        (to_static_mode, backend_mode) in VALID_MODES
         and to_static_mode & DEFAULT_TO_STATIC_MODE
-        and ir_mode & DEFAULT_IR_MODE
         and backend_mode & DEFAULT_BACKEND_MODE
     )
 ]
@@ -74,17 +70,15 @@ class TestCaseBasic(Dy2StTestBase):
 
 
 class TestCaseDisableTestCase(Dy2StTestBase):
-    @disable_test_case((ToStaticMode.SOT, IrMode.PIR, BackendMode.CINN))
+    @disable_test_case((ToStaticMode.SOT, BackendMode.CINN))
     def test_disable_one(self): ...
 
-    @disable_test_case((ToStaticMode.SOT, IrMode.PIR, BackendMode.CINN))
-    @disable_test_case((ToStaticMode.SOT, IrMode.PIR, BackendMode.PHI))
-    @disable_test_case((ToStaticMode.AST, IrMode.PIR, BackendMode.PHI))
+    @disable_test_case((ToStaticMode.SOT, BackendMode.CINN))
+    @disable_test_case((ToStaticMode.SOT, BackendMode.PHI))
+    @disable_test_case((ToStaticMode.AST, BackendMode.PHI))
     def test_disable_multiple(self): ...
 
-    @disable_test_case(
-        (ToStaticMode.SOT, IrMode.PIR, BackendMode.CINN | BackendMode.PHI)
-    )
+    @disable_test_case((ToStaticMode.SOT, BackendMode.CINN | BackendMode.PHI))
     def test_disable_multiple_with_or(self): ...
 
 
@@ -92,14 +86,10 @@ class TestCaseSetMode(Dy2StTestBase):
     @set_to_static_mode(ToStaticMode.SOT)
     def test_set_to_static_mode(self): ...
 
-    @set_ir_mode(IrMode.PIR)
-    def test_set_ir_mode(self): ...
-
     @set_backend_mode(BackendMode.CINN)
     def test_set_backend_mode(self): ...
 
     @set_to_static_mode(ToStaticMode.SOT)
-    @set_ir_mode(IrMode.PIR)
     @set_backend_mode(BackendMode.CINN)
     def test_set_all(self): ...
 
@@ -117,7 +107,7 @@ class TestCheckTestCases(unittest.TestCase, CheckTestCaseExistsMixin):
         case_name = "test_disable_one"
         self.assert_not_hasattr(test_case, case_name)
         for mode_tuple in DEFAULT_MODES:
-            if mode_tuple == (ToStaticMode.SOT, IrMode.PIR, BackendMode.CINN):
+            if mode_tuple == (ToStaticMode.SOT, BackendMode.CINN):
                 self.check_test_case_not_exists(
                     test_case, case_name, mode_tuple
                 )
@@ -128,9 +118,9 @@ class TestCheckTestCases(unittest.TestCase, CheckTestCaseExistsMixin):
         self.assert_not_hasattr(test_case, case_name)
         for mode_tuple in DEFAULT_MODES:
             if mode_tuple in [
-                (ToStaticMode.SOT, IrMode.PIR, BackendMode.CINN),
-                (ToStaticMode.SOT, IrMode.PIR, BackendMode.PHI),
-                (ToStaticMode.AST, IrMode.PIR, BackendMode.PHI),
+                (ToStaticMode.SOT, BackendMode.CINN),
+                (ToStaticMode.SOT, BackendMode.PHI),
+                (ToStaticMode.AST, BackendMode.PHI),
             ]:
                 self.check_test_case_not_exists(
                     test_case, case_name, mode_tuple
@@ -142,8 +132,8 @@ class TestCheckTestCases(unittest.TestCase, CheckTestCaseExistsMixin):
         self.assert_not_hasattr(test_case, case_name)
         for mode_tuple in DEFAULT_MODES:
             if mode_tuple in [
-                (ToStaticMode.SOT, IrMode.PIR, BackendMode.CINN),
-                (ToStaticMode.SOT, IrMode.PIR, BackendMode.PHI),
+                (ToStaticMode.SOT, BackendMode.CINN),
+                (ToStaticMode.SOT, BackendMode.PHI),
             ]:
                 self.check_test_case_not_exists(
                     test_case, case_name, mode_tuple
@@ -156,19 +146,8 @@ class TestCheckTestCases(unittest.TestCase, CheckTestCaseExistsMixin):
         case_name = "test_set_to_static_mode"
         self.assert_not_hasattr(test_case, case_name)
         for mode_tuple in DEFAULT_MODES:
-            to_static_mode, _, _ = mode_tuple
+            to_static_mode, _ = mode_tuple
             if to_static_mode == ToStaticMode.SOT:
-                self.check_test_case_exists(test_case, case_name, mode_tuple)
-            else:
-                self.check_test_case_not_exists(
-                    test_case, case_name, mode_tuple
-                )
-
-        case_name = "test_set_ir_mode"
-        self.assert_not_hasattr(test_case, case_name)
-        for mode_tuple in DEFAULT_MODES:
-            _, ir_mode, _ = mode_tuple
-            if ir_mode == IrMode.PIR:
                 self.check_test_case_exists(test_case, case_name, mode_tuple)
             else:
                 self.check_test_case_not_exists(
@@ -178,7 +157,7 @@ class TestCheckTestCases(unittest.TestCase, CheckTestCaseExistsMixin):
         case_name = "test_set_backend_mode"
         self.assert_not_hasattr(test_case, case_name)
         for mode_tuple in DEFAULT_MODES:
-            _, _, backend_mode = mode_tuple
+            _, backend_mode = mode_tuple
             if backend_mode == BackendMode.CINN:
                 self.check_test_case_exists(test_case, case_name, mode_tuple)
             else:
@@ -189,7 +168,7 @@ class TestCheckTestCases(unittest.TestCase, CheckTestCaseExistsMixin):
         case_name = "test_set_all"
         self.assert_not_hasattr(test_case, case_name)
         for mode_tuple in DEFAULT_MODES:
-            if mode_tuple == (ToStaticMode.SOT, IrMode.PIR, BackendMode.CINN):
+            if mode_tuple == (ToStaticMode.SOT, BackendMode.CINN):
                 self.check_test_case_exists(test_case, case_name, mode_tuple)
             else:
                 self.check_test_case_not_exists(

--- a/test/dygraph_to_static/test_dynamic_shape_infermeta.py
+++ b/test/dygraph_to_static/test_dynamic_shape_infermeta.py
@@ -21,7 +21,6 @@ import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
     test_ast_only,
-    test_pir_only,
 )
 
 import paddle
@@ -45,7 +44,6 @@ class TestDynamicShapeInfermeta(Dy2StTestBase):
         )
         np.testing.assert_allclose(static_fn(*inputs), fn(*inputs), rtol=1e-05)
 
-    @test_pir_only
     @test_ast_only
     def test_conv2d(self):
         self.check_dynamic_shape(
@@ -54,7 +52,6 @@ class TestDynamicShapeInfermeta(Dy2StTestBase):
             [InputSpec(shape=[None, None, None, None], dtype='float32')],
         )
 
-    @test_pir_only
     @test_ast_only
     def test_bn(self):
         self.check_dynamic_shape(
@@ -63,7 +60,6 @@ class TestDynamicShapeInfermeta(Dy2StTestBase):
             [InputSpec(shape=[None, None, None, None], dtype='float32')],
         )
 
-    @test_pir_only
     @test_ast_only
     def test_depthwise_conv2d(self):
         self.check_dynamic_shape(
@@ -72,7 +68,6 @@ class TestDynamicShapeInfermeta(Dy2StTestBase):
             [InputSpec(shape=[None, None, None, None], dtype='float32')],
         )
 
-    @test_pir_only
     @test_ast_only
     def test_group_norm(self):
         self.check_dynamic_shape(
@@ -81,7 +76,6 @@ class TestDynamicShapeInfermeta(Dy2StTestBase):
             [InputSpec(shape=[None, None, None, None], dtype='float32')],
         )
 
-    @test_pir_only
     @test_ast_only
     def test_functional_conv(self):
         self.check_dynamic_shape(

--- a/test/dygraph_to_static/test_grad.py
+++ b/test/dygraph_to_static/test_grad.py
@@ -20,7 +20,6 @@ import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
     test_ast_only,
-    test_pir_only,
 )
 
 import paddle
@@ -162,7 +161,6 @@ class UnuseGradVarLayer(paddle.nn.Layer):
 
 
 class TestUnuseGradVar(Dy2StTestBase):
-    @test_pir_only
     def test_run(self):
         layer = UnuseGradVarLayer()
         layer = paddle.jit.to_static(layer)
@@ -191,7 +189,6 @@ class NoGradNet(paddle.nn.Layer):
 
 
 class TestNoGrad(Dy2StTestBase):
-    @test_pir_only
     def test_run(self):
         net = NoGradNet()
         net = paddle.jit.to_static(net)
@@ -209,7 +206,6 @@ def grad_with_if_case(x):
 
 
 class TestGradWithIf(Dy2StTestBase):
-    @test_pir_only
     @test_ast_only
     def test_grad_with_if(self):
         fn = grad_with_if_case

--- a/test/dygraph_to_static/test_high_order_net.py
+++ b/test/dygraph_to_static/test_high_order_net.py
@@ -18,7 +18,6 @@ import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
     test_ast_only,
-    test_pir_only,
 )
 
 import paddle
@@ -41,7 +40,6 @@ class HighOrderNet(paddle.nn.Layer):
 
 class TestBackwardHasNoGradError(Dy2StTestBase):
     @test_ast_only
-    @test_pir_only
     def _test_backward_has_no_grad_error(self):
         net = HighOrderNet()
         static_net = paddle.jit.to_static(net, full_graph=True)
@@ -98,7 +96,6 @@ class HighOrderCompareNet(HighOrderControlFlowNet):
 
 class TestBackwardControlFlow(Dy2StTestBase):
     @test_ast_only
-    @test_pir_only
     def test_control_flow_hign_order_backward(self):
         conf_net = HighOrderControlFlowNet()
         net = HighOrderCompareNet()

--- a/test/dygraph_to_static/test_ifelse.py
+++ b/test/dygraph_to_static/test_ifelse.py
@@ -19,7 +19,6 @@ from dygraph_to_static_utils import (
     Dy2StTestBase,
     enable_to_static_guard,
     test_ast_only,
-    test_pir_only,
 )
 from ifelse_simple_func import (
     NetWithControlFlowIf,
@@ -547,7 +546,6 @@ class IfElseNet(paddle.nn.Layer):
 
 
 class TestDy2StIfElseBackward(Dy2StTestBase):
-    @test_pir_only
     def test_run_backward(self):
         a = paddle.randn((4, 3), dtype='float32')
         a.stop_gradient = False
@@ -599,7 +597,6 @@ class TestIfElseMaybeUnbound(Dy2StTestBase):
         np.testing.assert_allclose(dygraph_out.numpy(), static_out.numpy())
 
     @test_ast_only
-    @test_pir_only
     def test_use_undefined_var(self):
         truethy = paddle.to_tensor(1)
         falsy = paddle.to_tensor(0)
@@ -622,7 +619,6 @@ def dynamic_shape_with_constant_promotion(x):
 
 class TestDynamicShapeWithConstantPromotion(Dy2StTestBase):
     @test_ast_only
-    @test_pir_only
     def test_dynamic_shape_with_constant_promotion(self):
         x = paddle.randn([5, 3])
         static_fn = paddle.jit.to_static(

--- a/test/dygraph_to_static/test_item.py
+++ b/test/dygraph_to_static/test_item.py
@@ -15,10 +15,7 @@
 import unittest
 
 import numpy as np
-from dygraph_to_static_utils import (
-    Dy2StTestBase,
-    test_pir_only,
-)
+from dygraph_to_static_utils import Dy2StTestBase
 
 import paddle
 
@@ -45,7 +42,6 @@ class TestItem(Dy2StTestBase):
         static_result = static_forward(t)
         self.assertEqual(dynamic_result, static_result)
 
-    @test_pir_only
     def test_1_arg(self):
         shape_list = [
             [9],
@@ -65,7 +61,6 @@ class TestItem(Dy2StTestBase):
             static_result = static_forward(t)
             self.assertEqual(dynamic_result, static_result)
 
-    @test_pir_only
     def test_n_arg(self):
         shape_and_idx_list = [
             [[3, 5], [1, 3]],
@@ -85,7 +80,6 @@ class TestItem(Dy2StTestBase):
             static_result = static_forward(t, idx)
             self.assertEqual(dynamic_result, static_result)
 
-    @test_pir_only
     def test_error(self):
         def test_raise_error(t, exception_type, expected_exception_str, *args):
             def dynamic_forward(x):

--- a/test/dygraph_to_static/test_no_need_buffer.py
+++ b/test/dygraph_to_static/test_no_need_buffer.py
@@ -18,7 +18,6 @@ import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
     test_ast_only,
-    test_pir_only,
 )
 
 import paddle
@@ -33,7 +32,6 @@ def concat_net(x):
 
 class TestNoNeedBuffer(Dy2StTestBase):
     @test_ast_only
-    @test_pir_only
     def test_no_need_buffer(self):
         input = paddle.to_tensor([1, 2])
         input.stop_gradient = False

--- a/test/dygraph_to_static/test_optional_tensor.py
+++ b/test/dygraph_to_static/test_optional_tensor.py
@@ -15,10 +15,7 @@
 import unittest
 
 import numpy as np
-from dygraph_to_static_utils import (
-    Dy2StTestBase,
-    test_pir_only,
-)
+from dygraph_to_static_utils import Dy2StTestBase
 
 import paddle
 
@@ -34,7 +31,6 @@ def call_fused_rms_norm(x, y):
 
 
 class TestOptionalTensorOutput(Dy2StTestBase):
-    @test_pir_only
     def test_fused_rms_norm(self):
         if not paddle.is_compiled_with_cuda():
             return

--- a/test/dygraph_to_static/test_parameters_persistent_mode.py
+++ b/test/dygraph_to_static/test_parameters_persistent_mode.py
@@ -18,7 +18,6 @@ import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
     test_phi_only,
-    test_pir_only,
     test_sot_mgs0_only,
 )
 
@@ -52,7 +51,6 @@ class TestParametersPersistentMode(Dy2StTestBase):
             outs.append(net(data))
         return outs
 
-    @test_pir_only
     def test_persistent_mode(self):
         net = NetWithParameters(10, 3)
         net.eval()
@@ -65,7 +63,6 @@ class TestParametersPersistentMode(Dy2StTestBase):
                 dy_out.numpy(), st_out.numpy(), rtol=1e-05, atol=1e-05
             )
 
-    @test_pir_only
     @test_sot_mgs0_only
     @test_phi_only
     def test_training_mode_error(self):

--- a/test/dygraph_to_static/test_save_load.py
+++ b/test/dygraph_to_static/test_save_load.py
@@ -21,7 +21,6 @@ from dygraph_to_static_utils import (
     Dy2StTestBase,
     enable_to_static_guard,
     test_ast_only,
-    test_pir_only,
 )
 from test_fetch_feed import Linear
 
@@ -123,7 +122,6 @@ class TestDyToStaticSaveLoad(Dy2StTestBase):
         return comp_op_type_list
 
     @test_ast_only
-    @test_pir_only
     def test_save_load_prim(self):
         with base.dygraph.guard(place):
             self.x = paddle.randn([4, 2, 6, 6], dtype="float32")
@@ -164,7 +162,6 @@ class TestDyToStaticSaveLoad(Dy2StTestBase):
             np.testing.assert_allclose(res.numpy(), new_res.numpy(), rtol=1e-05)
 
     @test_ast_only
-    @test_pir_only
     def test_save_load_prim_with_hook(self):
         with base.dygraph.guard(place):
             self.x = paddle.randn([4, 2, 6, 6], dtype="float32")

--- a/test/dygraph_to_static/test_sentiment.py
+++ b/test/dygraph_to_static/test_sentiment.py
@@ -18,7 +18,6 @@ import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
     enable_to_static_guard,
-    test_pir_only,
 )
 
 import paddle
@@ -424,19 +423,15 @@ class TestSentiment(Dy2StTestBase):
             err_msg=f'dy_out:\n {dy_out}\n st_out:\n {st_out}',
         )
 
-    @test_pir_only
     def test_train_cnn(self):
         self.train_model('cnn_net')
 
-    @test_pir_only
     def test_train_bow(self):
         self.train_model('bow_net')
 
-    @test_pir_only
     def test_train_gru(self):
         self.train_model('gru_net')
 
-    @test_pir_only
     def test_train_bigru(self):
         self.train_model('bigru_net')
 

--- a/test/dygraph_to_static/test_set_static_op_arg_pre_cast_hook.py
+++ b/test/dygraph_to_static/test_set_static_op_arg_pre_cast_hook.py
@@ -20,7 +20,6 @@ from dygraph_to_static_utils import (
     enable_to_static_guard,
     static_guard,
     test_ast_only,
-    test_pir_only,
 )
 
 import paddle
@@ -29,7 +28,6 @@ from paddle.pir.core import _convert_into_value, static_op_arg_cast_guard
 
 class TestSetStaticOpArgPreCastHook(Dy2StTestBase):
     @test_ast_only
-    @test_pir_only
     def test_set_static_op_arg_pre_cast_hook(self):
         eager_tensor = paddle.rand((10, 10), 'float32')
 
@@ -61,7 +59,6 @@ class NetWithEagerTensor(paddle.nn.Layer):
 
 class TestSetStaticOpArgPreCastHookWithEagerTensor(Dy2StTestBase):
     @test_ast_only
-    @test_pir_only
     def test_net_with_eager_tensor(self):
         net = NetWithEagerTensor()
         net.extra_inputs.append(paddle.rand((10, 10), 'float32'))

--- a/test/dygraph_to_static/test_tensor_memcpy_on_cpu.py
+++ b/test/dygraph_to_static/test_tensor_memcpy_on_cpu.py
@@ -18,7 +18,6 @@ import numpy as np
 from dygraph_to_static_utils import (
     BackendMode,
     Dy2StTestBase,
-    IrMode,
     ToStaticMode,
     disable_test_case,
     enable_to_static_guard,
@@ -101,7 +100,7 @@ class TestTensorCopyToCUDAWithWarningOnCPU(Dy2StTestBase):
         return x1.place, x2.place, x2.numpy()
 
     @disable_test_case(
-        (ToStaticMode.SOT_MGS10, IrMode.PIR, BackendMode.PHI | BackendMode.CINN)
+        (ToStaticMode.SOT_MGS10, BackendMode.PHI | BackendMode.CINN)
     )
     def test_with_warning_on_cpu(self):
         if not paddle.is_compiled_with_cuda():

--- a/test/dygraph_to_static/test_tensor_memcpy_on_gpu.py
+++ b/test/dygraph_to_static/test_tensor_memcpy_on_gpu.py
@@ -19,7 +19,6 @@ import numpy as np
 from dygraph_to_static_utils import (
     BackendMode,
     Dy2StTestBase,
-    IrMode,
     ToStaticMode,
     disable_test_case,
     enable_to_static_guard,
@@ -106,7 +105,7 @@ class TestTensorCopyToCUDAWithWarningOnGPU(Dy2StTestBase):
         return x1.place, x2.place, x2.numpy()
 
     @disable_test_case(
-        (ToStaticMode.SOT_MGS10, IrMode.PIR, BackendMode.PHI | BackendMode.CINN)
+        (ToStaticMode.SOT_MGS10, BackendMode.PHI | BackendMode.CINN)
     )
     def test_with_warning_on_gpu(self):
         if not paddle.is_compiled_with_cuda():

--- a/test/dygraph_to_static/test_tensor_methods.py
+++ b/test/dygraph_to_static/test_tensor_methods.py
@@ -19,7 +19,6 @@ from dygraph_to_static_utils import (
     Dy2StTestBase,
     enable_to_static_guard,
     test_ast_only,
-    test_pir_only,
 )
 
 import paddle
@@ -101,7 +100,6 @@ class TestTensorSize(Dy2StTestBase):
             ret = ret.numpy()
         return ret
 
-    @test_pir_only
     def test_tensor_size(self):
         dygraph_res = self._run(to_static=False)
         static_res = self._run(to_static=True)

--- a/test/dygraph_to_static/test_tensor_to.py
+++ b/test/dygraph_to_static/test_tensor_to.py
@@ -17,11 +17,9 @@ import unittest
 from dygraph_to_static_utils import (
     BackendMode,
     Dy2StTestBase,
-    IrMode,
     ToStaticMode,
     disable_test_case,
     test_ast_only,
-    test_pir_only,
     test_sot_only,
 )
 
@@ -116,7 +114,6 @@ def to_many_key_error(tensor_x, device, dtype):
 
 
 class TensorToTest(Dy2StTestBase):
-    @test_pir_only
     def test_tensor_to_dtype(self):
         tensor_x = paddle.to_tensor([1, 2, 3])
         for dtype in _valid_dtypes:
@@ -124,7 +121,6 @@ class TensorToTest(Dy2StTestBase):
             type_x_str = str(t.dtype)
             self.assertEqual(type_x_str, "paddle." + dtype)
 
-    @test_pir_only
     def test_tensor_to_device(self):
         if paddle.is_compiled_with_cuda():
             x = paddle.to_tensor([1, 2, 3], place="gpu")
@@ -137,7 +133,6 @@ class TensorToTest(Dy2StTestBase):
         y = paddle.jit.to_static(to_kwargs_tesnor_device)(y, x)
         self.assertEqual(str(x.place), str(y.place))
 
-    @test_pir_only
     def test_tensor_to_device2(self):
         if paddle.is_compiled_with_cuda():
             x = paddle.to_tensor([1, 2, 3], place="gpu")
@@ -151,7 +146,6 @@ class TensorToTest(Dy2StTestBase):
         y = paddle.jit.to_static(to_device)(y, x.place)
         self.assertEqual(str(x.place), str(y.place))
 
-    @test_pir_only
     def test_tensor_to_device_dtype(self):
         tensor_x = paddle.to_tensor([1, 2, 3])
         places = ["cpu"]
@@ -175,9 +169,8 @@ class TensorToTest(Dy2StTestBase):
                 self.assertEqual(type_x_str, "paddle." + dtype)
 
     # TODO(gouzil): Fix MIN_GRAPH_SIZE=10 case
-    @test_pir_only
     @disable_test_case(
-        (ToStaticMode.SOT_MGS10, IrMode.PIR, BackendMode.PHI | BackendMode.CINN)
+        (ToStaticMode.SOT_MGS10, BackendMode.PHI | BackendMode.CINN)
     )
     def test_tensor_to_blocking(self):
         tensor_x = paddle.to_tensor([1, 2, 3])
@@ -198,9 +191,8 @@ class TensorToTest(Dy2StTestBase):
         )
         self.assertEqual(tensor2.dtype, paddle.float16)
 
-    @test_pir_only
     @disable_test_case(
-        (ToStaticMode.SOT_MGS10, IrMode.PIR, BackendMode.PHI | BackendMode.CINN)
+        (ToStaticMode.SOT_MGS10, BackendMode.PHI | BackendMode.CINN)
     )
     def test_tensor_to_other(self):
         tensor1 = paddle.to_tensor([1, 2, 3], dtype="int8", place="cpu")
@@ -211,9 +203,8 @@ class TensorToTest(Dy2StTestBase):
         self.assertEqual(str(tensor1.place), _cpu_place)
         self.assertEqual(str(tensor2.place), get_place())
 
-    @test_pir_only
     @disable_test_case(
-        (ToStaticMode.SOT_MGS10, IrMode.PIR, BackendMode.PHI | BackendMode.CINN)
+        (ToStaticMode.SOT_MGS10, BackendMode.PHI | BackendMode.CINN)
     )
     def test_kwargs(self):
         tensor_x = paddle.to_tensor([1, 2, 3])
@@ -229,7 +220,6 @@ class TensorToTest(Dy2StTestBase):
         self.assertEqual(tensor2.dtype, paddle.int8)
 
     @test_ast_only
-    @test_pir_only
     def test_ast_error(self):
         tensor_x = paddle.to_tensor([1, 2, 3])
         # device value error
@@ -267,7 +257,6 @@ class TensorToTest(Dy2StTestBase):
         )
 
     @test_sot_only
-    @test_pir_only
     def test_sot_error(self):
         tensor_x = paddle.to_tensor([1, 2, 3])
         # device value error

--- a/test/dygraph_to_static/test_typing.py
+++ b/test/dygraph_to_static/test_typing.py
@@ -18,7 +18,7 @@ import tempfile
 import unittest
 
 import numpy as np
-from dygraph_to_static_utils import Dy2StTestBase, test_pir_only
+from dygraph_to_static_utils import Dy2StTestBase
 
 import paddle
 
@@ -94,7 +94,6 @@ class TestTyping(Dy2StTestBase):
         out, _ = self.net(self.x)
         return out
 
-    @test_pir_only
     def test_type(self):
         self.net = self.build_net()
         out = self.run_dy()

--- a/test/dygraph_to_static/test_utils.py
+++ b/test/dygraph_to_static/test_utils.py
@@ -15,14 +15,13 @@
 import types
 import unittest
 
-from dygraph_to_static_utils import Dy2StTestBase, test_pir_only
+from dygraph_to_static_utils import Dy2StTestBase
 
 from paddle.jit.dy2static.transformers.utils import index_in_list
 from paddle.jit.dy2static.utils import is_paddle_func
 
 
 class TestIndexInList(Dy2StTestBase):
-    @test_pir_only
     def test_index_in_list(self):
         list_to_test = [1, 2, 3, 4, 5]
         self.assertEqual(index_in_list(list_to_test, 4), 3)
@@ -57,7 +56,6 @@ class TestIsPaddle(Dy2StTestBase):
     def fake_module(self):
         return types.ModuleType('paddlenlp')
 
-    @test_pir_only
     def test_func(self):
         m = self.fake_module()
         self.assertFalse(is_paddle_func(m))

--- a/test/dygraph_to_static/test_warning.py
+++ b/test/dygraph_to_static/test_warning.py
@@ -18,7 +18,6 @@ import warnings
 from dygraph_to_static_utils import (
     Dy2StTestBase,
     test_ast_only,
-    test_pir_only,
 )
 
 import paddle
@@ -43,7 +42,6 @@ def false_fn():
 
 class TestReturnNoneInIfelse(Dy2StTestBase):
     @test_ast_only
-    @test_pir_only
     def test_dy2static_warning(self):
         paddle.disable_static()
         with warnings.catch_warnings(record=True) as w:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Deprecations

### Description
<!-- Describe what you’ve done -->

#74698 已经不再测试 老 IR，`IrMode` 只保留 PIR，因此将其保留为选项已经不再有意义，本 PR 彻底清理动转静单测体系中 `IrMode` 相关代码，降低复杂性

<!-- PCard-66972 -->