### PR TITLE
[Dy2St][PIR] Remove non-PIR branch in uts

### DIFF
--- a/test/dygraph_to_static/predictor_utils.py
+++ b/test/dygraph_to_static/predictor_utils.py
@@ -18,7 +18,6 @@ import numpy as np
 
 from paddle import base
 from paddle.base.core import AnalysisConfig, create_paddle_predictor
-from paddle.framework import use_pir_api
 
 
 class PredictorTools:
@@ -60,11 +59,10 @@ class PredictorTools:
         # in CUDA11
         config.switch_ir_optim(False)
 
-        if use_pir_api():
-            config.enable_new_ir()
-            config.enable_new_executor()
-            if os.name == 'nt':
-                config.delete_pass("conv2d_bn_fuse_pass")
+        config.enable_new_ir()
+        config.enable_new_executor()
+        if os.name == 'nt':
+            config.delete_pass("conv2d_bn_fuse_pass")
 
         return config
 

--- a/test/dygraph_to_static/test_bert.py
+++ b/test/dygraph_to_static/test_bert.py
@@ -30,7 +30,6 @@ import paddle
 from paddle import base
 from paddle.base import core
 from paddle.base.framework import unique_name
-from paddle.framework import use_pir_api
 from paddle.jit.pir_translated_layer import PIR_INFER_MODEL_SUFFIX
 from paddle.jit.translated_layer import INFER_MODEL_SUFFIX, INFER_PARAMS_SUFFIX
 
@@ -189,10 +188,7 @@ class TestBert(Dy2StTestBase):
     def predict_static(self, data):
         paddle.enable_static()
         exe = base.Executor(place)
-        if use_pir_api():
-            model_filename = self.pir_model_filename
-        else:
-            model_filename = self.model_filename
+        model_filename = self.pir_model_filename
 
         # load inference model
         [
@@ -274,10 +270,7 @@ class TestBert(Dy2StTestBase):
         return pred_res
 
     def predict_analysis_inference(self, data):
-        if use_pir_api():
-            model_filename = self.pir_model_filename
-        else:
-            model_filename = self.model_filename
+        model_filename = self.pir_model_filename
 
         output = PredictorTools(
             self.model_save_dir, model_filename, self.params_filename, data

--- a/test/dygraph_to_static/test_bmn.py
+++ b/test/dygraph_to_static/test_bmn.py
@@ -28,7 +28,6 @@ from predictor_utils import PredictorTools
 import paddle
 from paddle.base import ParamAttr
 from paddle.base.framework import unique_name
-from paddle.framework import use_pir_api
 from paddle.jit.pir_translated_layer import PIR_INFER_MODEL_SUFFIX
 from paddle.jit.translated_layer import INFER_MODEL_SUFFIX, INFER_PARAMS_SUFFIX
 
@@ -801,10 +800,7 @@ class TestTrain(Dy2StTestBase):
     def predict_static(self, data):
         with static_guard():
             exe = paddle.static.Executor(self.place)
-            if use_pir_api():
-                model_filename = self.pir_model_filename
-            else:
-                model_filename = self.model_filename
+            model_filename = self.pir_model_filename
             # load inference model
             [
                 inference_program,
@@ -834,10 +830,7 @@ class TestTrain(Dy2StTestBase):
         return pred_res
 
     def predict_analysis_inference(self, data):
-        if use_pir_api():
-            model_filename = self.pir_model_filename
-        else:
-            model_filename = self.model_filename
+        model_filename = self.pir_model_filename
 
         output = PredictorTools(
             self.model_save_dir,

--- a/test/dygraph_to_static/test_break_continue.py
+++ b/test/dygraph_to_static/test_break_continue.py
@@ -23,7 +23,6 @@ from dygraph_to_static_utils import (
 )
 
 import paddle
-from paddle.framework import use_pir_api
 from paddle.jit.dy2static.utils import Dygraph2StaticException
 
 SEED = 2020
@@ -355,11 +354,9 @@ class TestOptimBreakInWhile(TestContinueInWhile):
         dygraph_res = self.run_dygraph_mode()
         # NOTE(SigureMo): Temporarily run the test in sequential run mode to avoid dependency
         # on the execution order of the test cases.
-        if use_pir_api():
-            with exe_sequential_run_guard(True):
-                static_res = self.run_static_mode()
-        else:
+        with exe_sequential_run_guard(True):
             static_res = self.run_static_mode()
+
         np.testing.assert_allclose(
             dygraph_res,
             static_res,

--- a/test/dygraph_to_static/test_cache_program.py
+++ b/test/dygraph_to_static/test_cache_program.py
@@ -46,21 +46,13 @@ class TestCacheProgram(Dy2StTestBase):
             # Check forward ops
             prev_ops = cur_ops
 
-            if paddle.framework.use_pir_api():
-                cur_ops = Counter(
-                    [
-                        op.name()
-                        for op in static_net.forward.concrete_program.main_program.global_block().ops
-                    ]
-                )
+            cur_ops = Counter(
+                [
+                    op.name()
+                    for op in static_net.forward.concrete_program.main_program.global_block().ops
+                ]
+            )
 
-            else:
-                cur_ops = Counter(
-                    [
-                        op.type
-                        for op in static_net.forward.concrete_program.main_program.global_block().ops
-                    ]
-                )
             if batch_id > 0:
                 prev_out_numpy = (
                     prev_out[0].numpy()

--- a/test/dygraph_to_static/test_declarative.py
+++ b/test/dygraph_to_static/test_declarative.py
@@ -23,7 +23,6 @@ from dygraph_to_static_utils import (
 )
 
 import paddle
-from paddle.framework import use_pir_api
 from paddle.jit.dy2static.program_translator import (
     ConcreteProgram,
     StaticFunction,
@@ -201,10 +200,8 @@ class TestInputSpec(Dy2StTestBase):
             input_spec=[InputSpec([-1, 10]), InputSpec([-1, 10], name='y')],
         )
         cp1 = net.add_func.concrete_program
-        if use_pir_api():
-            self.assertTrue(cp1.inputs[-1].shape == [-1, 10])
-        else:
-            self.assertTrue(cp1.inputs[-1].shape == (-1, 10))
+        self.assertTrue(cp1.inputs[-1].shape == [-1, 10])
+
         self.assertTrue(cp1.inputs[-1].name == 'y')
 
         # generate another program
@@ -213,10 +210,8 @@ class TestInputSpec(Dy2StTestBase):
             input_spec=[InputSpec([10]), InputSpec([10], name='label')],
         )
         cp2 = net.add_func.concrete_program
-        if use_pir_api():
-            self.assertTrue(cp2.inputs[-1].shape == [10])
-        else:
-            self.assertTrue(cp2.inputs[-1].shape == (10,))
+        self.assertTrue(cp2.inputs[-1].shape == [10])
+
         self.assertTrue(cp2.inputs[-1].name == 'label')
         # Note(Aurelius84): New instance will be returned if we use `to_static(foo)` every time.
         # So number of cache program is 1.

--- a/test/dygraph_to_static/test_function_spec.py
+++ b/test/dygraph_to_static/test_function_spec.py
@@ -17,7 +17,6 @@ import unittest
 from test_declarative import foo_func
 
 import paddle
-from paddle.framework import in_pir_mode
 from paddle.jit.dy2static.function_spec import FunctionSpec
 from paddle.static import InputSpec
 
@@ -97,12 +96,7 @@ class TestFunctionSpec(unittest.TestCase):
         )
         self.assertTrue(len(input_with_spec) == 2)
         self.assertTrue(input_with_spec[0] == a_spec)  # a
-
-        if in_pir_mode():
-            self.assertEqual(input_with_spec[1].shape, [4, 10])  # b.shape
-        else:
-            self.assertTupleEqual(input_with_spec[1].shape, (4, 10))  # b.shape
-
+        self.assertEqual(input_with_spec[1].shape, [4, 10])  # b.shape
         self.assertEqual(input_with_spec[1].name, 'b_var')  # b.name
 
         # case 3

--- a/test/dygraph_to_static/test_layer_hook.py
+++ b/test/dygraph_to_static/test_layer_hook.py
@@ -93,14 +93,6 @@ class TestNestLayerHook(Dy2StTestBase):
             rtol=1e-05,
             err_msg=f'dygraph_res is {dy_out}\nstatic_res is {st_out}',
         )
-        if not paddle.base.framework.use_pir_api():
-            load_out = self.load_train()
-            np.testing.assert_allclose(
-                st_out,
-                load_out,
-                rtol=1e-05,
-                err_msg=f'load_out is {load_out}\nstatic_res is {st_out}',
-            )
 
 
 if __name__ == "__main__":

--- a/test/dygraph_to_static/test_mnist.py
+++ b/test/dygraph_to_static/test_mnist.py
@@ -26,9 +26,8 @@ from predictor_utils import PredictorTools
 
 import paddle
 from paddle import base
-from paddle.framework import use_pir_api
 from paddle.jit.pir_translated_layer import PIR_INFER_MODEL_SUFFIX
-from paddle.jit.translated_layer import INFER_MODEL_SUFFIX, INFER_PARAMS_SUFFIX
+from paddle.jit.translated_layer import INFER_PARAMS_SUFFIX
 from paddle.nn import Linear
 from paddle.optimizer import Adam
 
@@ -257,16 +256,14 @@ class TestMNISTWithToStatic(TestMNIST):
             )
             model_save_dir = os.path.join(self.temp_dir.name, 'inference')
             model_save_prefix = os.path.join(model_save_dir, 'mnist')
-            MODEL_SUFFIX = (
-                PIR_INFER_MODEL_SUFFIX if use_pir_api() else INFER_MODEL_SUFFIX
-            )
+            MODEL_SUFFIX = PIR_INFER_MODEL_SUFFIX
             model_filename = "mnist" + MODEL_SUFFIX
             params_filename = "mnist" + INFER_PARAMS_SUFFIX
             paddle.jit.save(
                 layer=model,
                 path=model_save_prefix,
                 input_spec=input_spec,
-                output_spec=[gt_out_index] if use_pir_api() else [gt_out],
+                output_spec=[gt_out_index],
                 input_names_after_prune=input_names_after_prune,
             )
             # load in static graph mode

--- a/test/dygraph_to_static/test_mobile_net.py
+++ b/test/dygraph_to_static/test_mobile_net.py
@@ -30,7 +30,6 @@ import paddle
 from paddle import base
 from paddle.base.framework import unique_name
 from paddle.base.param_attr import ParamAttr
-from paddle.framework import use_pir_api
 from paddle.jit.pir_translated_layer import PIR_INFER_MODEL_SUFFIX
 from paddle.jit.translated_layer import INFER_MODEL_SUFFIX, INFER_PARAMS_SUFFIX
 from paddle.nn import BatchNorm, Linear
@@ -602,10 +601,8 @@ def predict_static(args, data):
     paddle.enable_static()
     exe = base.Executor(args.place)
     # load inference model
-    if use_pir_api():
-        model_filename = args.pir_model_filename
-    else:
-        model_filename = args.model_filename
+    model_filename = args.pir_model_filename
+
     [
         inference_program,
         feed_target_names,
@@ -656,10 +653,8 @@ def predict_dygraph_jit(args, data):
 
 
 def predict_analysis_inference(args, data):
-    if use_pir_api():
-        model_filename = args.pir_model_filename
-    else:
-        model_filename = args.model_filename
+    model_filename = args.pir_model_filename
+
     output = PredictorTools(
         args.model_save_dir, model_filename, args.params_filename, [data]
     )
@@ -730,7 +725,7 @@ class TestMobileNet(Dy2StTestBase):
             rtol=1e-05,
             err_msg=f'dy_jit_pre:\n {dy_jit_pre}\n, st_pre: \n{st_pre}.',
         )
-        if os.name == "nt" and use_pir_api():
+        if os.name == "nt":
             return
         predictor_pre = predict_analysis_inference(self.args, image)
         np.testing.assert_allclose(

--- a/test/dygraph_to_static/test_resnet.py
+++ b/test/dygraph_to_static/test_resnet.py
@@ -29,7 +29,6 @@ from predictor_utils import PredictorTools
 
 import paddle
 from paddle.base import core
-from paddle.framework import use_pir_api
 
 SEED = 2020
 IMAGENET1000 = 1281167
@@ -371,10 +370,7 @@ class ResNetHelper:
     def predict_static(self, data):
         with static_guard():
             exe = paddle.static.Executor(place)
-            if use_pir_api():
-                model_filename = self.pir_model_filename
-            else:
-                model_filename = self.model_filename
+            model_filename = self.pir_model_filename
 
             [
                 inference_program,
@@ -405,10 +401,8 @@ class ResNetHelper:
         return ret
 
     def predict_analysis_inference(self, data):
-        if use_pir_api():
-            model_filename = self.pir_model_filename
-        else:
-            model_filename = self.model_filename
+        model_filename = self.pir_model_filename
+
         output = PredictorTools(
             self.model_save_dir,
             model_filename,

--- a/test/dygraph_to_static/test_save_inference_model.py
+++ b/test/dygraph_to_static/test_save_inference_model.py
@@ -25,13 +25,12 @@ from dygraph_to_static_utils import (
 import paddle
 from paddle import base
 from paddle.autograd import PyLayer
-from paddle.framework import use_pir_api
 from paddle.jit.dy2static.partial_program import partial_program_from
 from paddle.jit.dy2static.pir_partial_program import (
     partial_program_from as pir_partial_program_from,
 )
 from paddle.jit.pir_translated_layer import PIR_INFER_MODEL_SUFFIX
-from paddle.jit.translated_layer import INFER_MODEL_SUFFIX, INFER_PARAMS_SUFFIX
+from paddle.jit.translated_layer import INFER_PARAMS_SUFFIX
 
 SEED = 2020
 
@@ -121,7 +120,7 @@ class TestDyToStaticSaveInferenceModel(Dy2StTestBase):
             layer=layer,
             path=infer_model_prefix,
             input_spec=[x],
-            output_spec=[1] if use_pir_api() else [pred],
+            output_spec=[1],
         )
         # Check the correctness of the inference
         dygraph_out, _ = layer(x)
@@ -130,7 +129,7 @@ class TestDyToStaticSaveInferenceModel(Dy2StTestBase):
             layer,
             [x_data],
             dygraph_out.numpy(),
-            fetch=[0] if use_pir_api() else [loss],
+            fetch=[0],
         )
         self.check_save_inference_model(
             layer, [x_data], dygraph_out.numpy(), feed=[x]
@@ -163,7 +162,7 @@ class TestDyToStaticSaveInferenceModel(Dy2StTestBase):
             layer=layer,
             path=infer_model_prefix,
             input_spec=[x],
-            output_spec=[1] if use_pir_api() else [pred],
+            output_spec=[1],
         )
         # Check the correctness of the inference
         loss_out, _ = layer(x)
@@ -174,7 +173,7 @@ class TestDyToStaticSaveInferenceModel(Dy2StTestBase):
             layer,
             [x_data],
             loss_out_numpy,
-            fetch=[0] if use_pir_api() else [loss],
+            fetch=[0],
         )
         self.check_save_inference_model(
             layer, [x_data], loss_out_numpy, feed=[x]
@@ -191,10 +190,7 @@ class TestDyToStaticSaveInferenceModel(Dy2StTestBase):
         infer_model_dir = os.path.join(
             self.temp_dir.name, "test_dy2stat_inference"
         )
-        if use_pir_api():
-            model_filename = "model" + PIR_INFER_MODEL_SUFFIX
-        else:
-            model_filename = "model" + INFER_MODEL_SUFFIX
+        model_filename = "model" + PIR_INFER_MODEL_SUFFIX
         params_filename = "model" + INFER_PARAMS_SUFFIX
 
         paddle.jit.save(
@@ -254,19 +250,15 @@ class TestPartialProgramRaiseError(Dy2StTestBase):
         # TypeError: Type of self._params should be list or tuple,
         # but received <class 'paddle.base.framework.EagerParamBase'>.
         with self.assertRaises(TypeError):
-            if use_pir_api():
-                pir_partial_program_from(concrete_program)
-            else:
-                partial_program_from(concrete_program)
+            pir_partial_program_from(concrete_program)
 
         # Under PIR, params are tuples and cannot be modified
-        if not use_pir_api():
-            params[0] = "linear.w.0"
-            concrete_program.parameters = params
-            # TypeError: Type of self._params[0] should be framework.EagerParamBase,
-            # but received <type 'str'>.
-            with self.assertRaises(TypeError):
-                partial_program_from(concrete_program)
+        params[0] = "linear.w.0"
+        concrete_program.parameters = params
+        # TypeError: Type of self._params[0] should be framework.EagerParamBase,
+        # but received <type 'str'>.
+        with self.assertRaises(TypeError):
+            partial_program_from(concrete_program)
 
 
 if __name__ == '__main__':

--- a/test/dygraph_to_static/test_save_inference_model.py
+++ b/test/dygraph_to_static/test_save_inference_model.py
@@ -25,7 +25,6 @@ from dygraph_to_static_utils import (
 import paddle
 from paddle import base
 from paddle.autograd import PyLayer
-from paddle.jit.dy2static.partial_program import partial_program_from
 from paddle.jit.dy2static.pir_partial_program import (
     partial_program_from as pir_partial_program_from,
 )
@@ -251,14 +250,6 @@ class TestPartialProgramRaiseError(Dy2StTestBase):
         # but received <class 'paddle.base.framework.EagerParamBase'>.
         with self.assertRaises(TypeError):
             pir_partial_program_from(concrete_program)
-
-        # Under PIR, params are tuples and cannot be modified
-        params[0] = "linear.w.0"
-        concrete_program.parameters = params
-        # TypeError: Type of self._params[0] should be framework.EagerParamBase,
-        # but received <type 'str'>.
-        with self.assertRaises(TypeError):
-            partial_program_from(concrete_program)
 
 
 if __name__ == '__main__':

--- a/test/dygraph_to_static/test_save_load.py
+++ b/test/dygraph_to_static/test_save_load.py
@@ -112,14 +112,10 @@ class TestDyToStaticSaveLoad(Dy2StTestBase):
             )
 
     def _compute_op_num(self, composite_program):
-        if paddle.framework.use_pir_api():
-            comp_op_type_list = [
-                op.name() for op in composite_program.program.global_block().ops
-            ]
-        else:
-            comp_op_type_list = [
-                op.type for op in composite_program.block(0).ops
-            ]
+        comp_op_type_list = [
+            op.name() for op in composite_program.program.global_block().ops
+        ]
+
         return comp_op_type_list
 
     @test_ast_only

--- a/test/dygraph_to_static/test_se_resnet.py
+++ b/test/dygraph_to_static/test_se_resnet.py
@@ -29,7 +29,6 @@ from predictor_utils import PredictorTools
 
 import paddle
 from paddle import base
-from paddle.framework import use_pir_api
 from paddle.jit.pir_translated_layer import PIR_INFER_MODEL_SUFFIX
 from paddle.jit.translated_layer import INFER_MODEL_SUFFIX, INFER_PARAMS_SUFFIX
 from paddle.nn import BatchNorm, Linear
@@ -445,10 +444,7 @@ class TestSeResnet(Dy2StTestBase):
                     step_idx += 1
                     if step_idx == STEP_NUM:
                         if to_static:
-                            if use_pir_api():
-                                output_spec = [0]
-                            else:
-                                output_spec = [pred]
+                            output_spec = [0]
 
                             paddle.jit.save(
                                 se_resnext,
@@ -496,10 +492,7 @@ class TestSeResnet(Dy2StTestBase):
 
     def predict_static(self, data):
         paddle.enable_static()
-        if use_pir_api():
-            model_filename = self.pir_model_filename
-        else:
-            model_filename = self.model_filename
+        model_filename = self.pir_model_filename
 
         exe = base.Executor(place)
         [
@@ -531,10 +524,8 @@ class TestSeResnet(Dy2StTestBase):
             return pred_res.numpy()
 
     def predict_analysis_inference(self, data):
-        if use_pir_api():
-            model_filename = self.pir_model_filename
-        else:
-            model_filename = self.model_filename
+        model_filename = self.pir_model_filename
+
         output = PredictorTools(
             self.model_save_dir,
             model_filename,

--- a/test/dygraph_to_static/test_to_tensor.py
+++ b/test/dygraph_to_static/test_to_tensor.py
@@ -228,10 +228,7 @@ class TestNestedListWithTensor(Dy2StTestBase):
         paddle.enable_static()
         x = paddle.to_tensor(1)
         y = paddle.to_tensor([[x]])
-        if paddle.framework.use_pir_api():
-            self.assertEqual(y.shape, [1, 1])
-        else:
-            self.assertEqual(y.shape, (1, 1))
+        self.assertEqual(y.shape, [1, 1])
         self.assertEqual(y.dtype, paddle.int64)
 
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Deprecations

### Description
<!-- Describe what you’ve done -->

彻底移除动转静单测里的非 PIR 分支，因为 #74698 后所有 case 都不会跑非 PIR 模式，`use_pir_api()` 永远为 True

<!-- PCard-66972 -->