### PR TITLE
Fix gtest compile error

### DIFF
--- a/cmake/external/gtest.cmake
+++ b/cmake/external/gtest.cmake
@@ -126,6 +126,7 @@ else()
                -DCMAKE_C_FLAGS_DEBUG=${CMAKE_C_FLAGS_DEBUG}
                -DCMAKE_C_FLAGS_RELEASE=${CMAKE_C_FLAGS_RELEASE}
                -DCMAKE_INSTALL_PREFIX=${GTEST_INSTALL_DIR}
+               -DCMAKE_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR}
                -DCMAKE_POSITION_INDEPENDENT_CODE=ON
                -DBUILD_GMOCK=ON
                -Dgtest_disable_pthreads=ON

--- a/paddle/phi/backends/custom/custom_context.h
+++ b/paddle/phi/backends/custom/custom_context.h
@@ -32,12 +32,6 @@ struct GpuDevice;
 
 namespace phi {
 
-// #ifndef BLAS_HANDLE_TYPE
-// #define BLAS_HANDLE_TYPE void*
-// // #else
-// // // using cublasHandle_t = struct cublasContext*;
-// #endif
-
 class CustomContext : public DeviceContext,
                       public TypeInfoTraits<DeviceContext, CustomContext> {
  public:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-67164
On multi-arch Linux systems, CMAKE_INSTALL_LIBDIR defaults to lib/x86_64-linux-gnu, but gtest was being installed to lib/ by default. This caused Paddle to fail to find libgtest.a.
This PR passes -DCMAKE_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR} to gtest’s CMake, ensuring the library is installed to the correct location across all platforms.
This PR also removes useless comments。
