### PR TITLE
[API-Compat] ForbidKeywordsDecorator now warns user

### DIFF
--- a/python/paddle/nn/layer/common.py
+++ b/python/paddle/nn/layer/common.py
@@ -1914,6 +1914,7 @@ class Unfold(Layer):
         illegal_keys={"kernel_size", "dilation", "padding", "stride"},
         func_name="paddle.nn.Unfold",
         correct_name="paddle.compat.Unfold",
+        url_suffix="nn/torch.nn.Unfold",
     )
     def __init__(
         self,

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -2742,6 +2742,7 @@ def row_stack(x: Sequence[Tensor], name: str | None = None) -> Tensor:
     illegal_keys={"tensor", "split_size_or_sections", "dim"},
     func_name="paddle.split",
     correct_name="paddle.compat.split",
+    url_suffix="torch/torch.split",
 )
 def split(
     x: Tensor,

--- a/python/paddle/tensor/search.py
+++ b/python/paddle/tensor/search.py
@@ -631,6 +631,7 @@ def _restrict_nonzero(condition: Tensor, total_true_num: int) -> Tensor:
     illegal_keys={'input', 'dim'},
     func_name='paddle.sort',
     correct_name='paddle.compat.sort',
+    url_suffix="torch/torch.sort",
 )
 def sort(
     x: Tensor,

--- a/python/paddle/utils/decorator_utils.py
+++ b/python/paddle/utils/decorator_utils.py
@@ -323,11 +323,6 @@ def view_decorator():
 class ForbidKeywordsDecorator(DecoratorBase):
     """A decorator that hints users to use the correct `compat` functions, when erroneous keyword arguments are detected"""
 
-    _site_format = (
-        "https://www.paddlepaddle.org.cn/documentation/docs/en/develop/"
-        "guides/model_convert/convert_from_pytorch/api_difference/{url_suffix}.html"
-    )
-
     def __init__(
         self,
         illegal_keys: set[str],
@@ -352,7 +347,9 @@ class ForbidKeywordsDecorator(DecoratorBase):
         self.illegal_keys = illegal_keys
         self.func_name = func_name
         self.correct_name = correct_name
-        self.url_suffix = url_suffix
+        self.warn_msg = None
+        if url_suffix:
+            self.warn_msg = f"\nNon compatible API. Please refer to https://www.paddlepaddle.org.cn/documentation/docs/en/develop/guides/model_convert/convert_from_pytorch/api_difference/{url_suffix}.html first."
 
     def process(
         self, args: tuple[Any, ...], kwargs: dict[str, Any]
@@ -368,10 +365,9 @@ class ForbidKeywordsDecorator(DecoratorBase):
                 f"{self.func_name}() received unexpected keyword argument{plural} {keys_str}. "
                 f"\nDid you mean to use {self.correct_name}() instead?"
             )
-        if self.url_suffix:
+        if self.warn_msg is not None:
             warnings.warn(
-                f"\nThis is a non compatible API. Please refer to {self._site_format.format(url_suffix=self.url_suffix)} first."
-                f"\nA compatible version of this API: `{self.correct_name}` can be also used, make sure the correct API is called.",
+                self.warn_msg,
                 category=Warning,
             )
         return args, kwargs

--- a/python/paddle/utils/decorator_utils.py
+++ b/python/paddle/utils/decorator_utils.py
@@ -323,13 +323,36 @@ def view_decorator():
 class ForbidKeywordsDecorator(DecoratorBase):
     """A decorator that hints users to use the correct `compat` functions, when erroneous keyword arguments are detected"""
 
+    _site_format = (
+        "https://www.paddlepaddle.org.cn/documentation/docs/en/develop/"
+        "guides/model_convert/convert_from_pytorch/api_difference/{url_suffix}.html"
+    )
+
     def __init__(
-        self, illegal_keys: set[str], func_name: str, correct_name: str
+        self,
+        illegal_keys: set[str],
+        func_name: str,
+        correct_name: str,
+        url_suffix: str = "",
     ) -> None:
+        """
+        Args:
+            illegal_keys (set[str]): the keywords to reject
+            func_name (str): the name of the function being decorated (should incorporate module name, like paddle.nn.Unfold)
+            correct_name (str): the user hint that points to the correct function
+            url_suffix (str, optional): Only specified in non paddle.compat functions. If specified, the function being decorated
+                will emit a warning upon the first call, warning the users about the API difference and points to Docs.
+                Please correctly specifying the `url_suffix`, this should be the suffix of the api-difference doc. For example:
+
+                (prefix omitted)/docs/zh/develop/guides/model_convert/convert_from_pytorch/api_difference/**torch/torch.nn.Unfold**.html
+
+                In this example, the correct `url_suffix` should be 'torch/torch.nn.Unfold'. Defaults to an empty str.
+        """
         super().__init__()
         self.illegal_keys = illegal_keys
         self.func_name = func_name
         self.correct_name = correct_name
+        self.url_suffix = url_suffix
 
     def process(
         self, args: tuple[Any, ...], kwargs: dict[str, Any]
@@ -344,6 +367,12 @@ class ForbidKeywordsDecorator(DecoratorBase):
             raise TypeError(
                 f"{self.func_name}() received unexpected keyword argument{plural} {keys_str}. "
                 f"\nDid you mean to use {self.correct_name}() instead?"
+            )
+        if self.url_suffix:
+            warnings.warn(
+                f"\nThis is a non compatible API. Please refer to {self._site_format.format(url_suffix=self.url_suffix)} first."
+                f"\nA compatible version of this API: `{self.correct_name}` can be also used, make sure the correct API is called.",
+                category=Warning,
             )
         return args, kwargs
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Operator Mechanism


### PR Types
Improvements


### Description
修改了 `ForbidKeywordsDecorator`，其修饰的所有原函数（非 `compat` 版本）增加 `url_suffix` 参数，指定此参数后，用户第一次调用对应函数将会有 warning 报出，例如：
```
This is a non compatible API. Please refer to https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/guides/model_convert/convert_from_pytorch/api_difference/torch/torch.split.html first.
A compatible version of this API: `paddle.compat.split` can be also used, make sure the correct API is called.
```

Pcard-89620