### PR TITLE
Add _FLOATE4M3 and _FLOATE5M2 data type to GemmDataType.

### DIFF
--- a/paddle/phi/kernels/fusion/cutlass/cutlass_kernels/gemm_config_manager.h
+++ b/paddle/phi/kernels/fusion/cutlass/cutlass_kernels/gemm_config_manager.h
@@ -36,6 +36,8 @@ enum GemmDataType {
   _NVBFLOAT16,
   _INT8,
   _INT4,
+  _FLOATE4M3,
+  _FLOATE5M2,
 };
 
 enum GemmType {
@@ -55,6 +57,10 @@ constexpr GemmDataType getGemmDataType() {
     return GemmDataType::_INT8;
   } else if constexpr (std::is_same<T, cutlass::uint4b_t>::value) {
     return GemmDataType::_INT4;
+  } else if constexpr (std::is_same<T, cutlass::float_e4m3_t>::value) {
+    return GemmDataType::_FLOATE4M3;
+  } else if constexpr (std::is_same<T, cutlass::float_e5m2_t>::value) {
+    return GemmDataType::_FLOATE5M2;
   } else {
     static_assert(!std::is_same<T, T>::value,
                   "Unsupported data type combination for GemmDataType.");


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
Pcard-89071

Add a new data type _FLOATE4M3 and _FLOATE5M2 to GemmDataType to support customized floating-point operations in GEMM kernels.