### PR TITLE
[CodeStyle] black -> ruff format migration - part 28

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,7 +81,7 @@ repos:
 
             | python/paddle/distributed/[b-e].+
 
-            # | python/paddle/distributed/f.+
+            | python/paddle/distributed/f.+
 
             # | python/paddle/distributed/[g-z].+
 
@@ -137,7 +137,7 @@ repos:
 
             # | python/paddle/distributed/[b-e].+
 
-            | python/paddle/distributed/f.+
+            # | python/paddle/distributed/f.+
 
             | python/paddle/distributed/[g-z].+
 

--- a/python/paddle/distributed/fleet/base/orthogonal_strategy.py
+++ b/python/paddle/distributed/fleet/base/orthogonal_strategy.py
@@ -98,9 +98,9 @@ class OrthogonalStrategy:
         Returns:
             An instance of specific strategy group.
         """
-        assert (
-            name in self._list_of_strategy_name
-        ), f"Strategy group {name} is not created."
+        assert name in self._list_of_strategy_name, (
+            f"Strategy group {name} is not created."
+        )
         return self._name_to_group_dict[name]
 
     def fused_strategy_group(self, name):
@@ -113,9 +113,9 @@ class OrthogonalStrategy:
         Returns:
             (StrategyGroupBase): An instance of strategy group.
         """
-        assert (
-            name in self._name_to_fused_group_dict
-        ), f"Fused strategy group {name} is not created."
+        assert name in self._name_to_fused_group_dict, (
+            f"Fused strategy group {name} is not created."
+        )
         return self._name_to_fused_group_dict[name]
 
     def rank_in_strategy(self, name):
@@ -128,9 +128,9 @@ class OrthogonalStrategy:
         Returns:
             (Integer): Local rank in specific strategy.
         """
-        assert (
-            name in self._list_of_strategy_name
-        ), f"Strategy group {name} is not created."
+        assert name in self._list_of_strategy_name, (
+            f"Strategy group {name} is not created."
+        )
         return self._name_to_group_dict[name].group.rank
 
     def _check_valid_strategy(self):
@@ -141,15 +141,15 @@ class OrthogonalStrategy:
             lambda x, y: x * y, self._list_of_degree
         )
 
-        assert num_of_ranks == len(
-            self._strategy_rank_list
-        ), f"There are total {len(self._strategy_rank_list)} ranks, but need {num_of_ranks} ranks in this strategy."
+        assert num_of_ranks == len(self._strategy_rank_list), (
+            f"There are total {len(self._strategy_rank_list)} ranks, but need {num_of_ranks} ranks in this strategy."
+        )
 
         for fused_strategy in self._fused_strategy_dict.values():
             for strategy in fused_strategy:
-                assert (
-                    strategy in self._list_of_strategy_name
-                ), f"Can not fuse strategy {strategy} without defined previous."
+                assert strategy in self._list_of_strategy_name, (
+                    f"Can not fuse strategy {strategy} without defined previous."
+                )
 
     def _create_fused_group(self):
         for name in self._fused_strategy_dict:

--- a/python/paddle/distributed/fleet/base/role_maker.py
+++ b/python/paddle/distributed/fleet/base/role_maker.py
@@ -764,9 +764,9 @@ class PaddleCloudRoleMaker(RoleMakerBase):
     def _get_trainer_endpoint(self) -> str:
         if not self._role_is_generated:
             self._generate_role()
-        assert (
-            self._role == Role.WORKER
-        ), "get_trainer_endpoint should be called by trainer"
+        assert self._role == Role.WORKER, (
+            "get_trainer_endpoint should be called by trainer"
+        )
         return self._cur_endpoint
 
     def _get_heter_worker_endpoints(self) -> list[str]:
@@ -776,9 +776,9 @@ class PaddleCloudRoleMaker(RoleMakerBase):
         """
         if not self._role_is_generated:
             self._generate_role()
-        assert (
-            self._heter_trainer_endpoints != []
-        ), "Heter Worker Endpoints Not initialized"
+        assert self._heter_trainer_endpoints != [], (
+            "Heter Worker Endpoints Not initialized"
+        )
         return self._heter_trainer_endpoints
 
     def _get_heter_worker_endpoint(self) -> str:
@@ -788,9 +788,9 @@ class PaddleCloudRoleMaker(RoleMakerBase):
         """
         if not self._role_is_generated:
             self._generate_role()
-        assert (
-            self._role == Role.HETER_WORKER
-        ), "_get_heter_worker_endpoint should be invoked by heter worker"
+        assert self._role == Role.HETER_WORKER, (
+            "_get_heter_worker_endpoint should be invoked by heter worker"
+        )
         return self._cur_endpoint
 
     def _get_pserver_endpoints(self) -> list[str]:

--- a/python/paddle/distributed/fleet/base/strategy_group.py
+++ b/python/paddle/distributed/fleet/base/strategy_group.py
@@ -47,9 +47,9 @@ class StrategyGroupBase:
         """
         Initialize the communication group.
         """
-        assert (
-            dist.is_initialized()
-        ), "The global communication group need to be initialized."
+        assert dist.is_initialized(), (
+            "The global communication group need to be initialized."
+        )
         assert len(list_of_ranks), "The list_of_ranks can not be empty."
         self._rank = dist.get_rank()
         self._list_of_ranks = list_of_ranks
@@ -133,9 +133,9 @@ class DPGroup(StrategyGroupBase):
 
     def __init__(self, list_of_ranks):
         super().__init__(list_of_ranks)
-        assert not isinstance(
-            self.group, list
-        ), f"Rank {self._rank} belongs to multi dp groups"
+        assert not isinstance(self.group, list), (
+            f"Rank {self._rank} belongs to multi dp groups"
+        )
 
 
 class MPGroup(StrategyGroupBase):
@@ -152,9 +152,9 @@ class MPGroup(StrategyGroupBase):
 
     def __init__(self, list_of_ranks):
         super().__init__(list_of_ranks)
-        assert not isinstance(
-            self.group, list
-        ), f"Rank {self._rank} belongs to multi mp groups"
+        assert not isinstance(self.group, list), (
+            f"Rank {self._rank} belongs to multi mp groups"
+        )
 
 
 class ShardingGroup(StrategyGroupBase):
@@ -171,9 +171,9 @@ class ShardingGroup(StrategyGroupBase):
 
     def __init__(self, list_of_ranks):
         super().__init__(list_of_ranks)
-        assert not isinstance(
-            self.group, list
-        ), f"Rank {self._rank} belongs to multi sharding groups"
+        assert not isinstance(self.group, list), (
+            f"Rank {self._rank} belongs to multi sharding groups"
+        )
 
 
 class PPGroup(StrategyGroupBase):
@@ -190,9 +190,9 @@ class PPGroup(StrategyGroupBase):
 
     def __init__(self, list_of_ranks):
         super().__init__(list_of_ranks)
-        assert not isinstance(
-            self.group, list
-        ), f"Rank {self._rank} belongs to multi pp groups"
+        assert not isinstance(self.group, list), (
+            f"Rank {self._rank} belongs to multi pp groups"
+        )
 
         self._send_next_group = None
         self._send_prev_group = None

--- a/python/paddle/distributed/fleet/base/topology.py
+++ b/python/paddle/distributed/fleet/base/topology.py
@@ -276,9 +276,9 @@ class HybridCommunicateGroup:
         self._sep_parallel_id = self._get_sep_parallel_id()
         self.stage_id = self._get_pipe_parallel_id()
 
-        assert (
-            self._check_valid_topo()
-        ), f"nranks: {self.nranks}, mp_num: {self._mp_degree}, sharding_num: {self._sharding_degree}, pp_num: {self._pp_degree}, dp_num: {self._dp_degree}, sep_num: {self._sep_degree}"
+        assert self._check_valid_topo(), (
+            f"nranks: {self.nranks}, mp_num: {self._mp_degree}, sharding_num: {self._sharding_degree}, pp_num: {self._pp_degree}, dp_num: {self._dp_degree}, sep_num: {self._sep_degree}"
+        )
 
         # create comm group for pipe parallel
         self._pp_group, self._pp_comm_group = self._set_comm_group(
@@ -680,9 +680,9 @@ class HybridCommunicateGroup:
         return self._pp_comm_group
 
     def get_p2p_groups(self) -> tuple[Group, Group, Group, Group]:
-        assert (
-            _use_four_directions
-        ), "If you want to use four directions p2p group, set the environment variable PADDLE_USE_FOUR_DIRECTIONS_P2P to True."
+        assert _use_four_directions, (
+            "If you want to use four directions p2p group, set the environment variable PADDLE_USE_FOUR_DIRECTIONS_P2P to True."
+        )
         return (
             self.send_next_group,
             self.send_prev_group,
@@ -736,9 +736,9 @@ class HybridCommunicateGroup:
         fused_strategy_list: list[str],
         nccl_config: NCCLConfig | None = None,
     ) -> tuple[list[list[int]], list[Group]] | tuple[list[int], Group]:
-        assert (
-            len(fused_strategy_list) > 0
-        ), "the length of fused_strategy_list must be greater than 0."
+        assert len(fused_strategy_list) > 0, (
+            "the length of fused_strategy_list must be greater than 0."
+        )
 
         parallel_group = []
         parallel_comm_group = []
@@ -827,9 +827,9 @@ class EPHybridCommunicateGroup(HybridCommunicateGroup):
         dense_dims = [dim_dict[name] for name in dense_group_names]
         assert dense_group_names.index(
             "moe_sharding"
-        ) < dense_group_names.index(
-            "dense_sharding"
-        ), "moe_sharding must be before sharding."
+        ) < dense_group_names.index("dense_sharding"), (
+            "moe_sharding must be before sharding."
+        )
 
         self._dense_topo = CommunicateTopology(dense_group_names, dense_dims)
 
@@ -851,15 +851,15 @@ class EPHybridCommunicateGroup(HybridCommunicateGroup):
             self._moe_topo, "moe_sharding"
         )
 
-        assert (
-            self._moe_pp_degree == self._pp_degree
-        ), f"Mismatch moe_pp_degree:{self._moe_pp_degree}, pp_degree:{self._pp_degree}."
-        assert (
-            self._topo._world_size == self._moe_topo._world_size
-        ), f"Mismatch world_size:{self._topo._world_size}, moe_world_size:{self._moe_topo._world_size}."
-        assert (
-            self._sep_degree == 1 and self._dp_degree == 1
-        ), f"sep_degree {self._sep_degree} and dp_degree {self._dp_degree} must be 1 in MoE."
+        assert self._moe_pp_degree == self._pp_degree, (
+            f"Mismatch moe_pp_degree:{self._moe_pp_degree}, pp_degree:{self._pp_degree}."
+        )
+        assert self._topo._world_size == self._moe_topo._world_size, (
+            f"Mismatch world_size:{self._topo._world_size}, moe_world_size:{self._moe_topo._world_size}."
+        )
+        assert self._sep_degree == 1 and self._dp_degree == 1, (
+            f"sep_degree {self._sep_degree} and dp_degree {self._dp_degree} must be 1 in MoE."
+        )
 
         self._pp_group, self._pp_comm_group = self._set_comm_group(
             "pipe",
@@ -1076,9 +1076,9 @@ class EPHybridCommunicateGroup(HybridCommunicateGroup):
         for i in range(num_merged_groups):
             comm = []
             for j in range(topo._dims[outer_axis]):
-                assert i + j * interval < len(
-                    inner_comm_list
-                ), f"Unexpected error in merge_inner_comm_list, {i}, {j}, {interval}, {len(inner_comm_list)}"
+                assert i + j * interval < len(inner_comm_list), (
+                    f"Unexpected error in merge_inner_comm_list, {i}, {j}, {interval}, {len(inner_comm_list)}"
+                )
                 comm += inner_comm_list[i + j * interval]
             merged_comm_list.append(comm)
 

--- a/python/paddle/distributed/fleet/base/util_factory.py
+++ b/python/paddle/distributed/fleet/base/util_factory.py
@@ -73,9 +73,9 @@ class UtilBase:
         self.role_maker = role_maker
 
     def _set_file_system(self, fs_client: FS) -> None:
-        assert isinstance(
-            fs_client, FS
-        ), "fs_client must be the instance of paddle.distributed.fleet.utils.FS"
+        assert isinstance(fs_client, FS), (
+            "fs_client must be the instance of paddle.distributed.fleet.utils.FS"
+        )
         self.fs_client = fs_client
 
     def all_reduce(

--- a/python/paddle/distributed/fleet/fleet.py
+++ b/python/paddle/distributed/fleet/fleet.py
@@ -707,12 +707,12 @@ class Fleet:
 
         assert self.mp_degree >= 0, "mp_degree should be greater or equal to 0"
         assert self.pp_degree >= 0, "pp_degree should be greater or equal to 0"
-        assert (
-            self.sep_degree >= 0
-        ), "sep_degree should be greater or equal to 0"
-        assert (
-            self.sharding_degree >= 0
-        ), "sharding_degree should be greater or equal to 0"
+        assert self.sep_degree >= 0, (
+            "sep_degree should be greater or equal to 0"
+        )
+        assert self.sharding_degree >= 0, (
+            "sharding_degree should be greater or equal to 0"
+        )
 
         self.mp_degree = max(self.mp_degree, 1)
         self.pp_degree = max(self.pp_degree, 1)
@@ -1534,9 +1534,9 @@ class Fleet:
             if hasattr(self.user_defined_optimizer, 'amp_init'):
                 amp_optimizer = self.user_defined_optimizer
 
-        assert (
-            amp_optimizer is not None
-        ), "amp_init can only be used when the amp(auto mixed precision) strategy is turned on."
+        assert amp_optimizer is not None, (
+            "amp_init can only be used when the amp(auto mixed precision) strategy is turned on."
+        )
         return amp_optimizer
 
     def get_loss_scaling(self) -> float:
@@ -1620,9 +1620,9 @@ class Fleet:
             if hasattr(self.user_defined_optimizer, 'qat_init'):
                 qat_optimizer = self.user_defined_optimizer
 
-        assert (
-            qat_optimizer is not None
-        ), "qat_init can only be used when the qat(quantization aware training) strategy is turned on."
+        assert qat_optimizer is not None, (
+            "qat_init can only be used when the qat(quantization aware training) strategy is turned on."
+        )
         return qat_optimizer
 
     def qat_init(

--- a/python/paddle/distributed/fleet/launch.py
+++ b/python/paddle/distributed/fleet/launch.py
@@ -268,9 +268,9 @@ def get_cluster_from_args(args, device_mode, devices_per_proc):
         else:
             _, node_ip = get_host_name_ip()
 
-    assert (
-        node_ip in node_ips
-    ), f"Can't find your local ip {{{node_ip}}} in node_ips: {{{node_ips}}}"
+    assert node_ip in node_ips, (
+        f"Can't find your local ip {{{node_ip}}} in node_ips: {{{node_ips}}}"
+    )
     node_rank = node_ips.index(node_ip)
 
     logger.debug(
@@ -308,9 +308,9 @@ def cpuonly_check(args):
             f"CPUONLY launch only support single trainer, that is len(ips)=1, but got {args.ips}."
         )
     if args.run_mode:
-        assert (
-            args.run_mode == 'cpuonly'
-        ), "CPUONLY launch only support run mode is CPUONLY"
+        assert args.run_mode == 'cpuonly', (
+            "CPUONLY launch only support run mode is CPUONLY"
+        )
     if args.servers:
         raise RuntimeError("CPUONLY launch can't have --servers as arguments.")
     return True
@@ -341,9 +341,9 @@ def get_cluster_info(args):
         start_port = os.environ.get('FLAGS_START_PORT')
     # auto mapping between processes and devices for auto-parallel
     if args.enable_auto_mapping:
-        assert (
-            args.cluster_topo_path is not None
-        ), "The cluster topology must be provided when enabling auto mapping."
+        assert args.cluster_topo_path is not None, (
+            "The cluster topology must be provided when enabling auto mapping."
+        )
         rank_mapping_path = args.rank_mapping_path or os.getenv(
             "PADDLE_RANK_MAPPING_PATH"
         )
@@ -742,9 +742,9 @@ def launch():
             args
         )  # which_distributed_mode must modify args.backend
     else:
-        assert (
-            args.run_mode == 'collective' or args.run_mode is None
-        ), "When backend is not 'auto', run mode must be collective"
+        assert args.run_mode == 'collective' or args.run_mode is None, (
+            "When backend is not 'auto', run mode must be collective"
+        )
         check_backend(args.backend)
         distribute_mode = DistributeMode.COLLECTIVE
 

--- a/python/paddle/distributed/fleet/launch_utils.py
+++ b/python/paddle/distributed/fleet/launch_utils.py
@@ -111,9 +111,9 @@ class Cluster:
         r = []
         for pod in self.pods:
             ep = f"{pod.addr}:{pod.port}"
-            assert (
-                pod.port is not None and pod.addr is not None
-            ), f"{ep} not a valid endpoint"
+            assert pod.port is not None and pod.addr is not None, (
+                f"{ep} not a valid endpoint"
+            )
             r.append(ep)
         return r
 
@@ -274,9 +274,9 @@ def get_cluster(
 
         cur_node_endpoints = trainer_endpoints[node_rank]
         # when use paddlecloud, endpoints may > devices_per_proc(user_defined)
-        assert len(cur_node_endpoints) >= len(
-            devices_per_proc
-        ), "current trainer_endpoints size should be greater equal than accelerators size."
+        assert len(cur_node_endpoints) >= len(devices_per_proc), (
+            "current trainer_endpoints size should be greater equal than accelerators size."
+        )
         for i in range(len(devices_per_proc)):
             trainer = Trainer()
             if device_mode == DeviceMode.GPU:
@@ -761,9 +761,9 @@ def get_device_proc_info(args):
     if device_mode == DeviceMode.GPU:
         gpus = get_gpus(args.gpus)
         if args.nproc_per_node is not None:
-            assert (
-                len(gpus) % int(args.nproc_per_node)
-            ) == 0, f"gpus' number:{len(gpus)} mod args.nproc_per_node:{args.nproc_per_node} must == 0"
+            assert (len(gpus) % int(args.nproc_per_node)) == 0, (
+                f"gpus' number:{len(gpus)} mod args.nproc_per_node:{args.nproc_per_node} must == 0"
+            )
 
             n = int(len(gpus) / int(args.nproc_per_node))
             devices_per_proc = [gpus[i : i + n] for i in range(0, len(gpus), n)]
@@ -772,9 +772,9 @@ def get_device_proc_info(args):
     elif device_mode == DeviceMode.XPU:
         xpus = get_xpus(args.xpus)
         if args.nproc_per_node is not None:
-            assert (
-                len(xpus) % int(args.nproc_per_node)
-            ) == 0, f"xpus' number:{len(xpus)} mod args.nproc_per_node:{args.nproc_per_node} must == 0"
+            assert (len(xpus) % int(args.nproc_per_node)) == 0, (
+                f"xpus' number:{len(xpus)} mod args.nproc_per_node:{args.nproc_per_node} must == 0"
+            )
 
             n = int(len(xpus) / int(args.nproc_per_node))
             devices_per_proc = [xpus[i : i + n] for i in range(0, len(xpus), n)]
@@ -868,9 +868,9 @@ def get_mapped_cluster_without_rank_mapping(
     node_ips, node_ip, trainer_endpoints, device_mode, node_ranks
 ):
     assert type(trainer_endpoints) is list, "trainer_endpoints must be list"
-    assert (
-        device_mode == DeviceMode.GPU
-    ), "Only support get mapped cluster for gpu now."
+    assert device_mode == DeviceMode.GPU, (
+        "Only support get mapped cluster for gpu now."
+    )
     cluster = Cluster(hdfs=None)
     for node_rank, ip in enumerate(node_ips):
         pod = Pod()
@@ -894,9 +894,9 @@ def get_mapped_cluster_without_rank_mapping(
 
 
 def get_mapped_cluster_from_args_without_rank_mapping(args, device_mode):
-    assert (
-        device_mode == DeviceMode.GPU
-    ), "Only support get mapped cluster for gpu now."
+    assert device_mode == DeviceMode.GPU, (
+        "Only support get mapped cluster for gpu now."
+    )
     gpus_num = framework.core.get_cuda_device_count()
 
     # parse ip-ranks json file
@@ -918,14 +918,14 @@ def get_mapped_cluster_from_args_without_rank_mapping(args, device_mode):
         else:
             _, node_ip = get_host_name_ip()
 
-    assert (
-        node_ip in node_ips
-    ), f"Can't find your local ip {{{node_ip}}} in node_ips: {{{node_ips}}}"
+    assert node_ip in node_ips, (
+        f"Can't find your local ip {{{node_ip}}} in node_ips: {{{node_ips}}}"
+    )
     node_rank = node_ips.index(node_ip)
 
-    assert len(node_ranks) == len(
-        node_ips
-    ), "ranks length should be equal to ips length."
+    assert len(node_ranks) == len(node_ips), (
+        "ranks length should be equal to ips length."
+    )
 
     logger.debug(
         f"parsed from args: node_ips:{node_ips} node_ip:{node_ip} "
@@ -965,9 +965,9 @@ def get_mapped_cluster_with_rank_mapping(
     node_rank_mappings,
 ):
     assert type(trainer_endpoints) is list, "trainer_endpoints must be list"
-    assert (
-        device_mode == DeviceMode.GPU
-    ), "Only support get mapped cluster for gpu now."
+    assert device_mode == DeviceMode.GPU, (
+        "Only support get mapped cluster for gpu now."
+    )
 
     def get_relative_gpu_id(gpu_id):
         cuda_visible_devices = os.getenv("CUDA_VISIBLE_DEVICES")
@@ -997,9 +997,9 @@ def get_mapped_cluster_with_rank_mapping(
             local_device_ids = cur_node_rank_mapping["ranks"][
                 str(ranks_per_node[i])
             ]
-            assert (
-                len(local_device_ids) == 1
-            ), "Only support one process to one device mapping"
+            assert len(local_device_ids) == 1, (
+                "Only support one process to one device mapping"
+            )
             trainer.accelerators.append(
                 get_relative_gpu_id(local_device_ids[0])
             )
@@ -1013,9 +1013,9 @@ def get_mapped_cluster_with_rank_mapping(
 
 
 def get_mapped_cluster_from_args_with_rank_mapping(args, device_mode):
-    assert (
-        device_mode == DeviceMode.GPU
-    ), "Only support get mapped cluster for gpu now."
+    assert device_mode == DeviceMode.GPU, (
+        "Only support get mapped cluster for gpu now."
+    )
     gpus_num = framework.core.get_cuda_device_count()
 
     # parse ip-ranks json file
@@ -1048,17 +1048,17 @@ def get_mapped_cluster_from_args_with_rank_mapping(args, device_mode):
         else:
             _, node_ip = get_host_name_ip()
 
-    assert (
-        node_ip in node_ips
-    ), f"Can't find your local ip {{{node_ip}}} in node_ips: {{{node_ips}}}"
+    assert node_ip in node_ips, (
+        f"Can't find your local ip {{{node_ip}}} in node_ips: {{{node_ips}}}"
+    )
     node_rank = node_ips.index(node_ip)
 
-    assert (
-        len(node_ranks[node_rank]) <= gpus_num
-    ), "number of ranks mapped to one node should not exceed the available ones."
-    assert len(node_ranks) == len(
-        node_ips
-    ), "ranks length should be equal to ips length."
+    assert len(node_ranks[node_rank]) <= gpus_num, (
+        "number of ranks mapped to one node should not exceed the available ones."
+    )
+    assert len(node_ranks) == len(node_ips), (
+        "ranks length should be equal to ips length."
+    )
 
     logger.debug(
         f"parsed from args: node_ips:{node_ips} node_ip:{node_ip} "
@@ -1135,10 +1135,10 @@ class ParameterServerLauncher:
         if args.server_num:
             self.server_num = args.server_num
             if args.servers:
-                assert (
-                    len(args.servers.split(",")) == self.server_num
-                ), "The server_num and servers doesn't match. Expect servers endpoints num equal to server_num, but received servers endpoint num: {} and server_num {}".format(
-                    len(args.servers.split(",")), self.server_num
+                assert len(args.servers.split(",")) == self.server_num, (
+                    "The server_num and servers doesn't match. Expect servers endpoints num equal to server_num, but received servers endpoint num: {} and server_num {}".format(
+                        len(args.servers.split(",")), self.server_num
+                    )
                 )
                 self.server_endpoints = args.servers
             else:
@@ -1147,9 +1147,9 @@ class ParameterServerLauncher:
                     ["127.0.0.1:" + str(x) for x in ports]
                 )
         else:
-            assert (
-                args.servers != ""
-            ), "The setting of Parameter-Server must has server_num or servers."
+            assert args.servers != "", (
+                "The setting of Parameter-Server must has server_num or servers."
+            )
             self.server_endpoints = args.servers
             self.server_num = len(self.server_endpoints.split(","))
 
@@ -1157,10 +1157,10 @@ class ParameterServerLauncher:
         if args.worker_num:
             self.worker_num = args.worker_num
             if args.workers:
-                assert (
-                    len(args.workers.split(",")) == self.worker_num
-                ), "The worker_num and workers doesn't match. Expect workers endpoints num equal to worker_num, but received workers endpoint num: {} and worker_num {}".format(
-                    len(args.workers.split(",")), self.worker_num
+                assert len(args.workers.split(",")) == self.worker_num, (
+                    "The worker_num and workers doesn't match. Expect workers endpoints num equal to worker_num, but received workers endpoint num: {} and worker_num {}".format(
+                        len(args.workers.split(",")), self.worker_num
+                    )
                 )
 
                 self.worker_endpoints = args.workers
@@ -1170,9 +1170,9 @@ class ParameterServerLauncher:
                     ["127.0.0.1:" + str(x) for x in ports]
                 )
         else:
-            assert (
-                args.workers != ""
-            ), "The setting of Parameter-Server must has worker_num or workers."
+            assert args.workers != "", (
+                "The setting of Parameter-Server must has worker_num or workers."
+            )
             worker_endpoints_ips = [
                 x.strip().split(":")[0] for x in args.workers.split(",")
             ]
@@ -1211,8 +1211,10 @@ class ParameterServerLauncher:
             if args.coordinators:
                 assert (
                     len(args.coordinators.split(",")) == self.coordinator_num
-                ), "The coordinator_num and coordinators doesn't match. Expect coordinators endpoints num equal to coordinator_num, but received coordinator endpoint num: {} and coordinator_num {}".format(
-                    len(args.coordinators.split(",")), self.coordinator_num
+                ), (
+                    "The coordinator_num and coordinators doesn't match. Expect coordinators endpoints num equal to coordinator_num, but received coordinator endpoint num: {} and coordinator_num {}".format(
+                        len(args.coordinators.split(",")), self.coordinator_num
+                    )
                 )
 
                 self.coordinator_endpoints = args.coordinators
@@ -1225,9 +1227,9 @@ class ParameterServerLauncher:
 
         # get heter worker envs
         if self.distribute_mode == DistributeMode.PS_HETER:
-            assert (
-                args.heter_devices != ""
-            ), "The setting of Parameter-Server heter mode must has heter_devices."
+            assert args.heter_devices != "", (
+                "The setting of Parameter-Server heter mode must has heter_devices."
+            )
             self.stage_device_map[1] = "cpu"  # for cpu trainer
             heter_devices_list = args.heter_devices.split(";")
             for i in range(len(heter_devices_list)):
@@ -1244,9 +1246,11 @@ class ParameterServerLauncher:
                 if args.heter_workers:
                     assert len(args.heter_workers.split(";")) == len(
                         self.stage_heter_trainer_num
-                    ), "The stage_num and heter_workers doesn't match. Expect heter_workers endpoints stage num equal to heter_worker_num stage, but received heter_workers endpoint stage num: {} and heter_worker_num stage {}".format(
-                        len(args.heter_workers.split(";")),
-                        len(self.stage_heter_trainer_num),
+                    ), (
+                        "The stage_num and heter_workers doesn't match. Expect heter_workers endpoints stage num equal to heter_worker_num stage, but received heter_workers endpoint stage num: {} and heter_worker_num stage {}".format(
+                            len(args.heter_workers.split(";")),
+                            len(self.stage_heter_trainer_num),
+                        )
                     )
                     heter_worker_endpoints_list = args.heter_workers.split(";")
                     self.heter_worker_endpoints = ""
@@ -1259,7 +1263,9 @@ class ParameterServerLauncher:
                         assert (
                             len(heter_worker_endpoints)
                             == self.stage_heter_trainer_num[i]
-                        ), f"The heter trainer num in stage {i} is not equal in args.heter_worker_num and args.heter_workers"
+                        ), (
+                            f"The heter trainer num in stage {i} is not equal in args.heter_worker_num and args.heter_workers"
+                        )
 
                         heter_worker_endpoints_ips = [
                             x.strip().split(":")[0]
@@ -1320,9 +1326,9 @@ class ParameterServerLauncher:
                             self.heter_worker_endpoints += ","
                         self.heter_worker_endpoints += ip_port_list
             else:
-                assert (
-                    args.heter_workers != ""
-                ), "The setting of Parameter-Server heter mode must has heter_worker_num or heter_workers."
+                assert args.heter_workers != "", (
+                    "The setting of Parameter-Server heter mode must has heter_worker_num or heter_workers."
+                )
                 self.stage_heter_trainer_num = []
                 heter_worker_endpoints_list = args.heter_workers.split(";")
                 self.heter_worker_endpoints = ""
@@ -1445,9 +1451,9 @@ class ParameterServerLauncher:
             else:
                 self.current_node_ip = pod_ip
             if not self.distribute_mode == DistributeMode.PS_HETER:
-                assert (
-                    self.current_node_ip in self.node_ips
-                ), f"Can't find your local ip {{{self.current_node_ip}}} in args.servers and args.workers ips: {{{self.node_ips}}}"
+                assert self.current_node_ip in self.node_ips, (
+                    f"Can't find your local ip {{{self.current_node_ip}}} in args.servers and args.workers ips: {{{self.node_ips}}}"
+                )
         if self.current_node_ip in self.node_ips:
             self.node_rank = self.node_ips.index(self.current_node_ip)
             logger.debug(

--- a/python/paddle/distributed/fleet/layers/mpu/mp_layers.py
+++ b/python/paddle/distributed/fleet/layers/mpu/mp_layers.py
@@ -126,9 +126,9 @@ class VocabParallelEmbedding(paddle.nn.Layer):
         self.origin_num_embeddings = num_embeddings
         self.is_mp = self.world_size > 1
 
-        assert (
-            num_embeddings % self.world_size == 0
-        ), "The length of the vocabulary must be divisible by the parallelism degree of MP"
+        assert num_embeddings % self.world_size == 0, (
+            "The length of the vocabulary must be divisible by the parallelism degree of MP"
+        )
 
         per_part_size = num_embeddings // self.world_size
 
@@ -484,9 +484,9 @@ class ColumnParallelLinear(paddle.nn.Layer):
             or self.mp_skip_c_identity
             or self.mp_fused_linear_param_grad_add
         ):
-            assert (
-                paddle.in_dynamic_mode()
-            ), "mp_async_allreduce, mp_skip_c_identity and mp_fused_linear_param_grad_add are only available under dygraph mode"
+            assert paddle.in_dynamic_mode(), (
+                "mp_async_allreduce, mp_skip_c_identity and mp_fused_linear_param_grad_add are only available under dygraph mode"
+            )
         if self.fuse_matmul_bias:
             if not is_fused_matmul_bias_supported():
                 raise NotImplementedError(
@@ -663,9 +663,9 @@ class RowParallelLinear(paddle.nn.Layer):
             or self.mp_skip_c_identity
             or self.mp_fused_linear_param_grad_add
         ):
-            assert (
-                paddle.in_dynamic_mode()
-            ), "mp_async_allreduce, mp_skip_c_identity and mp_fused_linear_param_grad_add are only available under dygraph mode"
+            assert paddle.in_dynamic_mode(), (
+                "mp_async_allreduce, mp_skip_c_identity and mp_fused_linear_param_grad_add are only available under dygraph mode"
+            )
         assert in_features % self.world_size == 0, (
             f"Number of row of the weight for linear ({in_features}) must be"
             f" divisible by model parallel size ({self.world_size})"

--- a/python/paddle/distributed/fleet/layers/mpu/mp_ops.py
+++ b/python/paddle/distributed/fleet/layers/mpu/mp_ops.py
@@ -569,9 +569,9 @@ def _linear(x, weight, bias=None, name=None):
     else:
         helper = LayerHelper('linear', **locals())
         dtype = x.dtype
-        assert (
-            len(x.shape) < 4
-        ), "X latitude is not supported greater than 3 now."
+        assert len(x.shape) < 4, (
+            "X latitude is not supported greater than 3 now."
+        )
 
         check_variable_and_dtype(
             x, 'x', ['float16', 'float32', 'float64'], 'linear'
@@ -899,15 +899,15 @@ def split(
             ...     num_partitions=2)
 
     """
-    assert isinstance(
-        size, (list, tuple)
-    ), "The type of size for paddle.distributed.split must be list or tuple."
-    assert (
-        len(size) == 2
-    ), "Number of elements in size of paddle.distributed.split must be two."
-    assert isinstance(
-        operation, str
-    ), "The type of operation for paddle.distributed.split must be str."
+    assert isinstance(size, (list, tuple)), (
+        "The type of size for paddle.distributed.split must be list or tuple."
+    )
+    assert len(size) == 2, (
+        "Number of elements in size of paddle.distributed.split must be two."
+    )
+    assert isinstance(operation, str), (
+        "The type of operation for paddle.distributed.split must be str."
+    )
     supported_operations = [
         'linear',
         'embedding',

--- a/python/paddle/distributed/fleet/meta_optimizers/dgc_optimizer.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/dgc_optimizer.py
@@ -50,9 +50,9 @@ class DGCMomentumOptimizer(Optimizer):
         if in_dynamic_mode():
             raise Exception("In dygraph, don't support DGCMomentumOptimizer.")
 
-        assert (
-            core.is_compiled_with_cuda()
-        ), "Paddle is not compiled with CUDA. DGC is only support GPU for now."
+        assert core.is_compiled_with_cuda(), (
+            "Paddle is not compiled with CUDA. DGC is only support GPU for now."
+        )
 
         assert learning_rate is not None
         assert momentum is not None
@@ -82,12 +82,12 @@ class DGCMomentumOptimizer(Optimizer):
                 raise TypeError(
                     "The type of grad_clip should be 'ClipGradByNorm', because DGCMomentumOptimizer only support ClipGradByNorm"
                 )
-            assert isinstance(
-                num_trainers, int
-            ), f"The type of num_trainers should be 'int', but received {type(num_trainers)}"
-            assert (
-                num_trainers > 0
-            ), "The value of num_trainers should be greater than 0!"
+            assert isinstance(num_trainers, int), (
+                f"The type of num_trainers should be 'int', but received {type(num_trainers)}"
+            )
+            assert num_trainers > 0, (
+                "The value of num_trainers should be greater than 0!"
+            )
 
             self._dgc_clip_norm = grad_clip.clip_norm * (num_trainers**-0.5)
 

--- a/python/paddle/distributed/fleet/meta_optimizers/dygraph_optimizer/dygraph_sharding_optimizer.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/dygraph_optimizer/dygraph_sharding_optimizer.py
@@ -144,9 +144,9 @@ class DygraphShardingOptimizer:
         self.enable_fuse_optimizer_states = (
             sharding_configs.enable_fuse_optimizer_states
         )
-        assert (
-            not self.enable_fuse_optimizer_states
-        ), "enable_fuse_optimizer_states is not supported on sharding optimizer V1 now."
+        assert not self.enable_fuse_optimizer_states, (
+            "enable_fuse_optimizer_states is not supported on sharding optimizer V1 now."
+        )
 
         if self.use_reduce_avg and (not is_avg_reduce_op_supported()):
             self.use_reduce_avg = False
@@ -156,9 +156,9 @@ class DygraphShardingOptimizer:
 
         pp_overlap = strategy.hybrid_configs['pp_configs'].sharding_comm_overlap
         if self.tensor_fusion or self.comm_overlap:
-            assert (
-                not pp_overlap
-            ), "Can not enable pp's sharding_comm_overlap and sharding's tensor_fusion at the same time."
+            assert not pp_overlap, (
+                "Can not enable pp's sharding_comm_overlap and sharding's tensor_fusion at the same time."
+            )
 
         self._use_main_grad = hasattr(self._parameter_list[0], "main_grad")
         self._rank2decay = {}
@@ -175,9 +175,9 @@ class DygraphShardingOptimizer:
             paddle.is_compiled_with_xpu()
             and os.getenv("XPU_CDNN_CLUSTER_PARALLEL") is not None
         ):
-            assert (
-                not self.comm_overlap
-            ), "comm overlap not support when use xpu cdnn_cluster parallel."
+            assert not self.comm_overlap, (
+                "comm overlap not support when use xpu cdnn_cluster parallel."
+            )
 
         try:
             # The fp32 params such as layer_norm_0.w_0 will be at the end of param_list.
@@ -325,9 +325,9 @@ class DygraphShardingOptimizer:
             rank = sizes.index(min(sizes))
             mapping[rank].append(param)
             numel = reduce(lambda x, y: x * y, param.shape, 1)
-            assert (
-                numel > 0
-            ), f"param [{param.name}] should larger than 0, but it is [{numel}]"
+            assert numel > 0, (
+                f"param [{param.name}] should larger than 0, but it is [{numel}]"
+            )
             sizes[rank] += numel
 
         return mapping
@@ -359,9 +359,9 @@ class DygraphShardingOptimizer:
             return None
 
         if hasattr(param, "main_grad"):
-            assert (
-                param._grad_ivar() is None
-            ), "param.grad should be None when using main_grad"
+            assert param._grad_ivar() is None, (
+                "param.grad should be None when using main_grad"
+            )
             return param.main_grad
 
         return param._grad_ivar()
@@ -523,9 +523,9 @@ class DygraphShardingOptimizer:
     def _set_broadcast_overlap(self, broadcast_overlap, layers=None):
         self._broadcast_overlap = broadcast_overlap
         if self._broadcast_overlap:
-            assert (
-                layers is not None
-            ), "To Enable Stage1 Optimizer Broadcast Overlap Forward, layers cannot be None"
+            assert layers is not None, (
+                "To Enable Stage1 Optimizer Broadcast Overlap Forward, layers cannot be None"
+            )
             self._layers = layers
             warnings.warn(
                 r"Setting overlap broadcast implies that `paddle.device.cuda.synchronize()` must be manually invoked before calling `paddle.save()` and prior to inference"
@@ -797,29 +797,29 @@ class DygraphShardingOptimizerV2:
             paddle.is_compiled_with_xpu()
             and os.getenv("XPU_CDNN_CLUSTER_PARALLEL") is not None
         ):
-            assert (
-                not self.comm_overlap
-            ), "comm overlap not support when use xpu cdnn_cluster parallel."
+            assert not self.comm_overlap, (
+                "comm overlap not support when use xpu cdnn_cluster parallel."
+            )
 
         # Ensure acc_steps is greater than 0 when comm_overlap is used
         if self.comm_overlap:
-            assert (
-                acc_steps > 0
-            ), "acc_steps should be larger than 0 when using comm_overlap in sharding"
+            assert acc_steps > 0, (
+                "acc_steps should be larger than 0 when using comm_overlap in sharding"
+            )
 
         # Ensure pp_overlap and comm_overlap are not both True
-        assert not (
-            self.pp_overlap and self.comm_overlap
-        ), "pp_overlap and comm_overlap should not be True at the same time"
+        assert not (self.pp_overlap and self.comm_overlap), (
+            "pp_overlap and comm_overlap should not be True at the same time"
+        )
 
         # Determine the use of pipeline parallelism
         self._use_pipeline_parallel = strategy.hybrid_configs["pp_degree"] > 1
 
         # Ensure pipeline parallel and comm_overlap are not used together
         if self._use_pipeline_parallel:
-            assert (
-                not self.comm_overlap
-            ), "You should not use pipeline parallel and comm_overlap at the same time"
+            assert not self.comm_overlap, (
+                "You should not use pipeline parallel and comm_overlap at the same time"
+            )
 
         # Register reduce overlap hook if comm_overlap is used without pp_overlap
         if not self.pp_overlap and self.comm_overlap:
@@ -1036,9 +1036,9 @@ class DygraphShardingOptimizerV2:
             for k, v in comm_buffer._sharding_param_grad_view.items():
                 pad_tensor = v._get_padding()
                 if pad_tensor is not None:
-                    assert paddle.all(
-                        pad_tensor == 0
-                    ).item(), f"{SHARDING_PAD_NON_ZERO_ERROR}. The padding of Tensor {k} is not zero"
+                    assert paddle.all(pad_tensor == 0).item(), (
+                        f"{SHARDING_PAD_NON_ZERO_ERROR}. The padding of Tensor {k} is not zero"
+                    )
         if self._enable_timer:
             self.timers("check-padding-zero").stop()
 
@@ -1417,12 +1417,12 @@ class DygraphShardingOptimizerV2:
         for param_key, tensor in optim_state_dict.items():
             base_name, _ = _generate_base_static_name(param_key)
 
-            assert (
-                base_name in merged_slice_info
-            ), f"{base_name} not found in slice info"
-            assert (
-                base_name in merged_shape_info
-            ), f"{base_name} not found in shape info"
+            assert base_name in merged_slice_info, (
+                f"{base_name} not found in slice info"
+            )
+            assert base_name in merged_shape_info, (
+                f"{base_name} not found in shape info"
+            )
 
             if int(tensor.numel()) > 1:
                 begin, end = merged_slice_info[base_name]
@@ -1451,7 +1451,7 @@ class DygraphShardingOptimizerV2:
                         if end > begin:
                             offset_mapping[tensor_name][
                                 info["sharding_rank"]
-                            ] = (end - begin)
+                            ] = end - begin
 
                 # Convert sizes to cumulative offsets
                 running_total = 0
@@ -1491,9 +1491,9 @@ class DygraphShardingOptimizerV2:
                         sharding_rank = info["sharding_rank"]
                         break
 
-                assert (
-                    sharding_rank >= 0
-                ), f"Sharding info not found for {base_name}"
+                assert sharding_rank >= 0, (
+                    f"Sharding info not found for {base_name}"
+                )
                 flattened_offset = offset_mapping[base_name][sharding_rank]
 
                 sharded_weight = ShardedWeight(
@@ -1534,9 +1534,9 @@ class DygraphShardingOptimizerV2:
                         if weight_key in info:
                             sharding_rank = info["sharding_rank"]
                             break
-                    assert (
-                        sharding_rank >= 0
-                    ), f"Sharding info not found for {weight_key}"
+                    assert sharding_rank >= 0, (
+                        f"Sharding info not found for {weight_key}"
+                    )
                     flattened_offset = offset_mapping[weight_key][sharding_rank]
 
                     sharded_weight = ShardedWeight(

--- a/python/paddle/distributed/fleet/meta_optimizers/dygraph_optimizer/hybrid_parallel_optimizer.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/dygraph_optimizer/hybrid_parallel_optimizer.py
@@ -534,9 +534,9 @@ class HybridParallelOptimizer:
         # syc param and master weight after opt
         if pp_group.nranks > 1 and pp_configs and pp_configs.sync_param:
             for p in params:
-                assert (
-                    hasattr(p, 'color') and 'broadcast_group' in p.color
-                ), f"{p.name} has no color"
+                assert hasattr(p, 'color') and 'broadcast_group' in p.color, (
+                    f"{p.name} has no color"
+                )
                 broadcast_group = p.color["broadcast_group"]
                 src_rank = min(broadcast_group.ranks)
                 self.syc_param(
@@ -549,9 +549,9 @@ class HybridParallelOptimizer:
         # Moment sync after opt
         if pp_group.nranks > 1 and pp_configs and pp_configs.sync_moment:
             for p in params:
-                assert (
-                    hasattr(p, 'color') and 'broadcast_group' in p.color
-                ), f"{p.name} has no color"
+                assert hasattr(p, 'color') and 'broadcast_group' in p.color, (
+                    f"{p.name} has no color"
+                )
                 broadcast_group = p.color["broadcast_group"]
                 src_rank = min(broadcast_group.ranks)
                 self.syc_moment(

--- a/python/paddle/distributed/fleet/meta_optimizers/raw_program_optimizer.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/raw_program_optimizer.py
@@ -195,9 +195,9 @@ class RawProgramOptimizer(MetaOptimizerBase):
             if gm_cond_var_name is None:
                 gm_cond_var_name = op.attr(GRAD_MERGE_COND_NAME)
             else:
-                assert gm_cond_var_name == op.attr(
-                    GRAD_MERGE_COND_NAME
-                ), "multiple gradient merge condition found"
+                assert gm_cond_var_name == op.attr(GRAD_MERGE_COND_NAME), (
+                    "multiple gradient merge condition found"
+                )
         if gm_cond_var_name is None:
             return None
 

--- a/python/paddle/distributed/fleet/meta_optimizers/sharding/fp16_helper.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/sharding/fp16_helper.py
@@ -146,10 +146,10 @@ class FP16Utils:
                         if worker_idx == shard.worker_idx
                     }
                 )
-                assert (
-                    to_check_param == should_check_param
-                ), f"amp \
+                assert to_check_param == should_check_param, (
+                    f"amp \
                     check_finite_and_unscale checking miss [{should_check_param - to_check_param}] and got unexpected [{to_check_param - should_check_param}]"
+                )
 
         if update_loss_scaling_op_idx == -1:
             return

--- a/python/paddle/distributed/fleet/meta_optimizers/sharding/gradient_clip_helper.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/sharding/gradient_clip_helper.py
@@ -140,10 +140,10 @@ class GradientClipHelper:
                 if worker_idx == shard.worker_idx
             }
         )
-        assert (
-            to_check_param == should_check_param
-        ), f"amp check_finite_and_unscale \
+        assert to_check_param == should_check_param, (
+            f"amp check_finite_and_unscale \
         checking miss [{should_check_param - to_check_param}] and got unexpected [{to_check_param - should_check_param}]"
+        )
 
         for var_name in deprecated_vars:
             block._remove_var(var_name, sync=False)

--- a/python/paddle/distributed/fleet/meta_optimizers/sharding/offload_helper.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/sharding/offload_helper.py
@@ -196,15 +196,15 @@ class OffloadHelper:
 
                 if 'subprog' not in output_name:
                     assert output_name == input_name + '.cast_fp16'
-                    assert (
-                        input_name not in param_to_fp16
-                    ), "There must be only one cast op from fp32 param to fp16 param."
+                    assert input_name not in param_to_fp16, (
+                        "There must be only one cast op from fp32 param to fp16 param."
+                    )
                     param_to_fp16[input_name] = output_name
                 else:
                     # fp16-->recompute_var
-                    assert (
-                        input_name in param_to_fp16
-                    ), "param must first be cast to fp16"
+                    assert input_name in param_to_fp16, (
+                        "param must first be cast to fp16"
+                    )
                     fp16_param = param_to_fp16[input_name]
                     fp16_param_to_recompute[fp16_param] = output_name
                     recompute_to_fp16[output_name] = fp16_param
@@ -445,15 +445,15 @@ class OffloadHelper:
 
                 if 'subprog' not in output_name:
                     assert output_name == input_name + '.cast_fp16'
-                    assert (
-                        input_name not in param_to_fp16
-                    ), "There must be only one cast op from fp32 param to fp16 param."
+                    assert input_name not in param_to_fp16, (
+                        "There must be only one cast op from fp32 param to fp16 param."
+                    )
                     param_to_fp16[input_name] = output_name
                 else:
                     # fp16-->recompute_var
-                    assert (
-                        input_name in param_to_fp16
-                    ), "param must first be cast to fp16"
+                    assert input_name in param_to_fp16, (
+                        "param must first be cast to fp16"
+                    )
                     fp16_param = param_to_fp16[input_name]
                     fp16_param_to_recompute[fp16_param] = output_name
                     recompute_to_fp16[output_name] = fp16_param

--- a/python/paddle/distributed/fleet/meta_optimizers/sharding/utils.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/sharding/utils.py
@@ -177,7 +177,9 @@ def check_allreduce_sum(block, shard, sharding_ring_id, dp_ring_id=-1):
                     assert (
                         op.type == "reduce"
                         and op.desc.attr("reduce_type") == dist.ReduceOp.SUM
-                    ), "Grad in Sharding group should be reduce rather than allreduce"
+                    ), (
+                        "Grad in Sharding group should be reduce rather than allreduce"
+                    )
                     if var_name in vars_status:
                         _status = vars_status[var_name]
                     else:
@@ -632,9 +634,9 @@ def insert_reduce_ops(
             # 'FusedMergedGrad.cast_fp16._'
             grad_var = var.replace('FusedMergedGrad_', '')
         root_id = get_grad_device(grad_var, shard)
-        assert (
-            root_id >= 0
-        ), f"root id should be a positive int, but now root id is {root_id}"
+        assert root_id >= 0, (
+            f"root id should be a positive int, but now root id is {root_id}"
+        )
         if rank is not None and rank == root_id:
             grad_in_this_device.append(var)
         block._insert_op_without_sync(
@@ -737,9 +739,9 @@ def insert_broadcast_param_ops(
     param_in_this_device = []
     for param in params:
         root_id = shard.device(param)
-        assert (
-            root_id >= 0
-        ), f"root id should be a positive int, but now root id is {root_id}"
+        assert root_id >= 0, (
+            f"root id should be a positive int, but now root id is {root_id}"
+        )
         if rank is not None and rank == root_id:
             param_in_this_device.append(param)
         block._insert_op_without_sync(
@@ -824,9 +826,9 @@ def get_grad_device(grad_name, shard):
             base_name = re.sub(suffix, '', grad_name)
             break
 
-    assert (
-        base_name in shard.global_param2device
-    ), f"[{base_name}] should be a param variable."
+    assert base_name in shard.global_param2device, (
+        f"[{base_name}] should be a param variable."
+    )
 
     return shard.global_param2device[base_name]
 

--- a/python/paddle/distributed/fleet/meta_optimizers/sharding_optimizer.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/sharding_optimizer.py
@@ -120,14 +120,14 @@ class ShardingOptimizer(MetaOptimizerBase):
 
         if segment_strategy == "segment_broadcast_MB":
             self._broadcast_MB = sharding_configs["segment_broadcast_MB"]
-            assert (
-                self._broadcast_MB > 0
-            ), "segment size should larger than zero !"
+            assert self._broadcast_MB > 0, (
+                "segment size should larger than zero !"
+            )
         elif segment_strategy == "segment_anchors":
             self._sharding_segment_anchors = sharding_configs["segment_anchors"]
-            assert (
-                len(self._sharding_segment_anchors) > 0
-            ), "you should set the sharding segment anchors !"
+            assert len(self._sharding_segment_anchors) > 0, (
+                "you should set the sharding segment anchors !"
+            )
             self._backward_remain_anchors = self._sharding_segment_anchors[:]
             self._forward_remain_anchors = []
         else:
@@ -161,17 +161,21 @@ class ShardingOptimizer(MetaOptimizerBase):
             assert strategy.pipeline is True
 
         if os.getenv("PADDLE_MANUAL_PIPELINE_STAGE", None):
-            assert (
-                pp_degree == 2
-            ), "For manually set pipeline, only pp_degree = 2 is supported."
+            assert pp_degree == 2, (
+                "For manually set pipeline, only pp_degree = 2 is supported."
+            )
             assert (
                 global_world_size == mp_degree * sharding_degree * dp_degree
-            ), f"global work size [{global_world_size}], mp_degree [{mp_degree}], sharding_degree [{sharding_degree}], dp_degree [{dp_degree}]."
+            ), (
+                f"global work size [{global_world_size}], mp_degree [{mp_degree}], sharding_degree [{sharding_degree}], dp_degree [{dp_degree}]."
+            )
         else:
             assert (
                 global_world_size
                 == mp_degree * sharding_degree * pp_degree * dp_degree
-            ), f"global work size [{global_world_size}], mp_degree [{mp_degree}], sharding_degree [{sharding_degree}], pp_degree [{pp_degree}], dp_degree [{dp_degree}]."
+            ), (
+                f"global work size [{global_world_size}], mp_degree [{mp_degree}], sharding_degree [{sharding_degree}], pp_degree [{pp_degree}], dp_degree [{dp_degree}]."
+            )
 
         # FIXME (JZ-LIANG) deprecated hybrid_dp
         if sharding_configs["hybrid_dp"]:
@@ -555,9 +559,9 @@ class ShardingOptimizer(MetaOptimizerBase):
                 if is_optimizer_op(op) and op.type != 'c_sync_comm_stream':
                     tmp_first_opt_idx = idx
                     break
-            assert (
-                tmp_first_opt_idx is not None
-            ), 'Occurs some errors, no optimize ops'
+            assert tmp_first_opt_idx is not None, (
+                'Occurs some errors, no optimize ops'
+            )
             for grad in accumulated_grad_names:
                 main_block._insert_op_without_sync(
                     tmp_first_opt_idx,
@@ -933,12 +937,12 @@ class ShardingOptimizer(MetaOptimizerBase):
             self._segments.insert(0, segment)
 
         if self._sharding_segment_strategy == "segment_anchors":
-            assert (
-                len(self._forward_remain_anchors) == 0
-            ), f"remain anchors {self._forward_remain_anchors}"
-            assert (
-                len(self._backward_remain_anchors) == 0
-            ), f"remain anchors {self._backward_remain_anchors}"
+            assert len(self._forward_remain_anchors) == 0, (
+                f"remain anchors {self._forward_remain_anchors}"
+            )
+            assert len(self._backward_remain_anchors) == 0, (
+                f"remain anchors {self._backward_remain_anchors}"
+            )
 
         if self._verbose:
             for varname in sorted(
@@ -1455,18 +1459,18 @@ class ShardingOptimizer(MetaOptimizerBase):
         self._collective_helper = CollectiveHelper(
             self.role_maker, nrings=self._nrings_sharding
         )
-        assert (
-            self.global_word_size % self.mp_degree == 0
-        ), f"global_word_size: {self.global_word_size} should be divisible to the mp_degree: {self.mp_degree}"
-        assert (
-            self.global_word_size % self.sharding_degree == 0
-        ), f"global_word_size: {self.global_word_size} should be divisible to the sharding_degree: {self.sharding_degree}"
-        assert (
-            self.global_word_size % self.pp_degree == 0
-        ), f"global_word_size: {self.global_word_size} should be divisible to the pp_degree: {self.pp_degree}"
-        assert (
-            self.global_word_size % self.dp_degree == 0
-        ), f"global_word_size: {self.global_word_size} should be divisible to the dp_degree: {self.dp_degree}"
+        assert self.global_word_size % self.mp_degree == 0, (
+            f"global_word_size: {self.global_word_size} should be divisible to the mp_degree: {self.mp_degree}"
+        )
+        assert self.global_word_size % self.sharding_degree == 0, (
+            f"global_word_size: {self.global_word_size} should be divisible to the sharding_degree: {self.sharding_degree}"
+        )
+        assert self.global_word_size % self.pp_degree == 0, (
+            f"global_word_size: {self.global_word_size} should be divisible to the pp_degree: {self.pp_degree}"
+        )
+        assert self.global_word_size % self.dp_degree == 0, (
+            f"global_word_size: {self.global_word_size} should be divisible to the dp_degree: {self.dp_degree}"
+        )
 
         # mp group
         if self.mp_degree > 1:
@@ -1479,9 +1483,9 @@ class ShardingOptimizer(MetaOptimizerBase):
                 if idx // self.mp_degree == self.mp_group_id
             ]
             assert self.current_endpoint in self.mp_group_endpoints
-            assert (
-                len(self.mp_group_endpoints) == self.mp_degree
-            ), f"num of mp worker in group is [{len(self.mp_group_endpoints)}], but mp group size is [{self.mp_degree}]"
+            assert len(self.mp_group_endpoints) == self.mp_degree, (
+                f"num of mp worker in group is [{len(self.mp_group_endpoints)}], but mp group size is [{self.mp_degree}]"
+            )
         else:
             self.mp_degree = 1
             self.mp_ring_id = -1
@@ -1565,13 +1569,15 @@ class ShardingOptimizer(MetaOptimizerBase):
         # sharding-hybrid-dp as one scenario of outer-pure-dp
         local_pp_degree = self.pp_degree
         if os.getenv("PADDLE_MANUAL_PIPELINE_STAGE", None):
-            assert (
-                self.pp_degree == 2
-            ), "For manually set pipeline, only pp_degree = 2 is supported."
+            assert self.pp_degree == 2, (
+                "For manually set pipeline, only pp_degree = 2 is supported."
+            )
             assert (
                 self.global_word_size
                 == self.mp_degree * self.sharding_degree * self.dp_degree
-            ), f"global work size [{self.global_word_size}], mp_degree [{self.mp_degree}], sharding_degree [{self.sharding_degree}], dp_degree [{self.dp_degree}]."
+            ), (
+                f"global work size [{self.global_word_size}], mp_degree [{self.mp_degree}], sharding_degree [{self.sharding_degree}], dp_degree [{self.dp_degree}]."
+            )
             local_pp_degree = 1
         else:
             assert (
@@ -1580,7 +1586,9 @@ class ShardingOptimizer(MetaOptimizerBase):
                 * self.sharding_degree
                 * self.pp_degree
                 * self.dp_degree
-            ), f"mp_degree: [{self.mp_degree}], sharding_degree: [{self.sharding_degree}], pp_degree: [{self.pp_degree}], dp_degree: [{self.dp_degree}]; BUT global nrank: [{self.global_word_size}]"
+            ), (
+                f"mp_degree: [{self.mp_degree}], sharding_degree: [{self.sharding_degree}], pp_degree: [{self.pp_degree}], dp_degree: [{self.dp_degree}]; BUT global nrank: [{self.global_word_size}]"
+            )
 
         if self.dp_degree > 1:
             self.dp_ring_id = 2
@@ -1741,13 +1749,13 @@ class ShardingOptimizer(MetaOptimizerBase):
         self, main_block, startup_block, insert_idx, grad_names, shard
     ):
         for grad_name in grad_names:
-            assert (
-                get_grad_device(grad_name, shard) == shard.worker_idx
-            ), f"try to merge gradient not belong to current shard: [{grad_name}]"
+            assert get_grad_device(grad_name, shard) == shard.worker_idx, (
+                f"try to merge gradient not belong to current shard: [{grad_name}]"
+            )
             persistable_grad_name = grad_name + '@GradientMerge'
-            assert (
-                grad_name not in self._grad2merged_grad
-            ), f"grad [{grad_name}] already in grad2merged_grad, maybe you meet sharing weight case !"
+            assert grad_name not in self._grad2merged_grad, (
+                f"grad [{grad_name}] already in grad2merged_grad, maybe you meet sharing weight case !"
+            )
             self._grad2merged_grad[grad_name] = persistable_grad_name
             grad_var = main_block.var(grad_name)
             # create var
@@ -1876,9 +1884,9 @@ class ShardingOptimizer(MetaOptimizerBase):
 
         # allreduce grad@gradientmerge
         if self.hybrid_dp:
-            assert (
-                self.dp_ring_id >= 0
-            ), "dp_ring_id should larger than 0 when in sharding&DP mode"
+            assert self.dp_ring_id >= 0, (
+                "dp_ring_id should larger than 0 when in sharding&DP mode"
+            )
             for grad, merged_grad in self._grad2merged_grad.items():
                 merged_grad_var = main_block.var(merged_grad)
                 cur_block.append_op(

--- a/python/paddle/distributed/fleet/meta_parallel/dualpipev.py
+++ b/python/paddle/distributed/fleet/meta_parallel/dualpipev.py
@@ -202,9 +202,9 @@ class DualPipeVParallel(PipelineParallel):
             if isinstance(loss_tensor, (tuple, list)):
                 assert len(loss_tensor) == 1
                 loss_tensor = loss_tensor[0]
-            assert isinstance(
-                loss_tensor, paddle.Tensor
-            ), "Currently, loss_fn should obtain Paddle.Tensor dtype"
+            assert isinstance(loss_tensor, paddle.Tensor), (
+                "Currently, loss_fn should obtain Paddle.Tensor dtype"
+            )
 
             self.loss_tensors.append(loss_tensor)
             self.loss_fn_chunks.append(loss_fn_node)
@@ -623,18 +623,18 @@ class DualPipeVParallel(PipelineParallel):
         return micro_dataset
 
     def _prepare_training(self, data, optimizer, lr_scheduler):
-        assert isinstance(
-            optimizer, HybridParallelOptimizer
-        ), 'optimizer should be HybridParallelOptimizer subclass.'
+        assert isinstance(optimizer, HybridParallelOptimizer), (
+            'optimizer should be HybridParallelOptimizer subclass.'
+        )
 
-        assert (
-            framework._dygraph_tracer()._has_grad
-        ), 'Please enable the generation of gradients.'
+        assert framework._dygraph_tracer()._has_grad, (
+            'Please enable the generation of gradients.'
+        )
 
         if self.is_pipeline_first_stage():
-            assert (
-                data is not None
-            ), "For the first and the last stage, the data must be set."
+            assert data is not None, (
+                "For the first and the last stage, the data must be set."
+            )
         else:
             data = None
 
@@ -648,9 +648,9 @@ class DualPipeVParallel(PipelineParallel):
     def _broadcast_final_loss(self):
         loss_sum_tensor = paddle.zeros([1], "float32")
         if self.is_pipeline_first_stage():
-            assert (
-                len(self.loss_tensors) > 0
-            ), "train_batch() in last stage should obtain valid loss"
+            assert len(self.loss_tensors) > 0, (
+                "train_batch() in last stage should obtain valid loss"
+            )
             for loss in self.loss_tensors:
                 loss_sum_tensor += loss.detach().astype("float32")
             if self._delay_scale_loss:

--- a/python/paddle/distributed/fleet/meta_parallel/parallel_layers/pp_layers.py
+++ b/python/paddle/distributed/fleet/meta_parallel/parallel_layers/pp_layers.py
@@ -147,9 +147,9 @@ class SegmentLayers:
         self.num_virtual_pipeline_stage = num_virtual_pipeline_stage
         if self.num_virtual_pipeline_stage is not None:
             self.total_parts = num_parts * self.num_virtual_pipeline_stage
-        assert (
-            self.num_items >= self.num_parts
-        ), "layer number should be greater than number of segments"
+        assert self.num_items >= self.num_parts, (
+            "layer number should be greater than number of segments"
+        )
 
     def do_segment(self):
         if isinstance(self.method, list):
@@ -161,9 +161,9 @@ class SegmentLayers:
                 for part in seg_method:
                     assert isinstance(part, int), "part should be int"
                     assert part >= 0, f"part[{part}] should be greater than 0"
-                    assert (
-                        part <= self.num_items
-                    ), f"part[{part}] should be less than num_items[{self.num_items}]"
+                    assert part <= self.num_items, (
+                        f"part[{part}] should be less than num_items[{self.num_items}]"
+                    )
 
             check_sanity()
 
@@ -194,9 +194,9 @@ class SegmentLayers:
                 else self.total_parts
             )
 
-            assert (
-                sum(weights) % actual_num_parts == 0
-            ), f"number of layers ({sum(weights)}) should be divided by part number({actual_num_parts})"
+            assert sum(weights) % actual_num_parts == 0, (
+                f"number of layers ({sum(weights)}) should be divided by part number({actual_num_parts})"
+            )
             part_size = sum(weights) // actual_num_parts
             result = [0 for _ in range(actual_num_parts + 1)]
 
@@ -231,9 +231,9 @@ class SegmentLayers:
             if regex.search(name):
                 weight_idxs.append(idx)
 
-        assert (
-            len(weight_idxs) > 0
-        ), "weight_idxs' length should be greater than 0"
+        assert len(weight_idxs) > 0, (
+            "weight_idxs' length should be greater than 0"
+        )
         return weight_idxs
 
     def uniform(self, num_items, num_parts):
@@ -395,19 +395,19 @@ class PipelineLayer(nn.Layer):
             raise ValueError("should provide num_stages or topology")
 
         if num_virtual_pipeline_stages:
-            assert isinstance(
-                num_virtual_pipeline_stages, int
-            ), "virtual_pipeline_stage should be None or an int"
+            assert isinstance(num_virtual_pipeline_stages, int), (
+                "virtual_pipeline_stage should be None or an int"
+            )
             if num_virtual_pipeline_stages > 1:
                 logger.info(
                     "set num_virtual_pipeline_stages > 1 means using interleave scheduler instead of 1f1b scheduler"
                 )
-                assert isinstance(
-                    seg_method, str
-                ), "seg_method should be a str for interleave scheduler"
-                assert seg_method.startswith(
-                    'layer:'
-                ), "seg_method should be start with layer: for interleave scheduler"
+                assert isinstance(seg_method, str), (
+                    "seg_method should be a str for interleave scheduler"
+                )
+                assert seg_method.startswith('layer:'), (
+                    "seg_method should be start with layer: for interleave scheduler"
+                )
 
         self._num_virtual_pipeline_stages = (
             1
@@ -435,9 +435,9 @@ class PipelineLayer(nn.Layer):
         self._base_seed = 1234
 
         if recompute_interval > 0:
-            assert (
-                recompute_ctx is not None
-            ), "recompute_ctx must be not None for recompute."
+            assert recompute_ctx is not None, (
+                "recompute_ctx must be not None for recompute."
+            )
 
             offload = recompute_ctx.get('offload', False)
             partition = recompute_ctx.get('partition', False)
@@ -456,9 +456,9 @@ class PipelineLayer(nn.Layer):
                 self._stage_id = self._topo.get_coord(self.global_rank).pipe
                 self._num_stages = self._topo.get_dim_size("pipe")
             if num_stages:
-                assert (
-                    self._num_stages == num_stages
-                ), f"num_stages should be equal to be {self._num_stages}"
+                assert self._num_stages == num_stages, (
+                    f"num_stages should be equal to be {self._num_stages}"
+                )
         else:
             # construct default topology
             if world_size % num_stages != 0:
@@ -926,9 +926,9 @@ class PipelineLayer(nn.Layer):
         get_rng_state_tracker().set_states_tracker(orig_rng_tracker)
 
         if self._use_dualpipev:
-            assert (
-                len(self._model_chunks) == 2
-            ), "Only support two model chunks when using dualpipev"
+            assert len(self._model_chunks) == 2, (
+                "Only support two model chunks when using dualpipev"
+            )
         logger.info(f"model_chunks: {self._model_chunks}")
 
     def _build_layer(self):
@@ -989,9 +989,9 @@ class PipelineLayer(nn.Layer):
                     # for interleave, PipelineLayerChunk will do this
                     self.add_sublayer(str(layer_index), layer)
             elif isinstance(layer, SharedLayerDesc):
-                assert (
-                    not self._use_dualpipev
-                ), "dualpipev scheduler does not support SharedLayerDesc yet"
+                assert not self._use_dualpipev, (
+                    "dualpipev scheduler does not support SharedLayerDesc yet"
+                )
                 flush_into_run_function()
                 if layer.layer_name not in self.shared_layers:
                     self.shared_layers[layer.layer_name] = layer.build_layer()
@@ -1020,9 +1020,9 @@ class PipelineLayer(nn.Layer):
                             self.shared_layers[layer.layer_name],
                         )
             elif isinstance(layer, LocalSharedLayerDesc):
-                assert (
-                    self._use_dualpipev
-                ), "Only dualpipev is supported to use LocalSharedLayerDesc yet"
+                assert self._use_dualpipev, (
+                    "Only dualpipev is supported to use LocalSharedLayerDesc yet"
+                )
                 flush_into_run_function()
 
                 if layer.layer_name not in self.local_shared_layers:
@@ -1038,9 +1038,9 @@ class PipelineLayer(nn.Layer):
                     ]
                     weight_params = []
                     for attr in weight_attrs:
-                        assert hasattr(
-                            ref_layer_impl, attr
-                        ), f"The shared parameter {attr} is not in {layer.layer_name}."
+                        assert hasattr(ref_layer_impl, attr), (
+                            f"The shared parameter {attr} is not in {layer.layer_name}."
+                        )
                         param = getattr(ref_layer_impl, attr)
                         weight_params.append(param)
                     layer_impl = layer.build_layer(

--- a/python/paddle/distributed/fleet/meta_parallel/pipeline_hooks.py
+++ b/python/paddle/distributed/fleet/meta_parallel/pipeline_hooks.py
@@ -31,15 +31,15 @@ class PipelineHook:
         self._hooks_capacity = capacity
 
     def register_hook(self, hook_id: int, hook: Callable):
-        assert (
-            hook_id < self._hooks_capacity
-        ), f"hook_id {hook_id} is out of range, maximum capacity is {self._hooks_capacity}."
+        assert hook_id < self._hooks_capacity, (
+            f"hook_id {hook_id} is out of range, maximum capacity is {self._hooks_capacity}."
+        )
         self.hooks[hook_id].append(hook)
 
     def run_hook(self):
-        assert (
-            self._current_id < self._hooks_capacity
-        ), f"hook_id {self._current_id} is out of range, maximum capacity is {self._hooks_capacity}."
+        assert self._current_id < self._hooks_capacity, (
+            f"hook_id {self._current_id} is out of range, maximum capacity is {self._hooks_capacity}."
+        )
         for hook in self.hooks[self._current_id]:
             hook(self._current_id)
         self._current_id += 1

--- a/python/paddle/distributed/fleet/meta_parallel/pipeline_parallel.py
+++ b/python/paddle/distributed/fleet/meta_parallel/pipeline_parallel.py
@@ -135,9 +135,9 @@ class FakeMicroDataset:
             output = []
             for data in inputs:
                 if isinstance(data, list):
-                    assert (
-                        len(data) == self._acc_steps
-                    ), f"length of data should be {self._acc_steps}, but it is {len(data)}"
+                    assert len(data) == self._acc_steps, (
+                        f"length of data should be {self._acc_steps}, but it is {len(data)}"
+                    )
                     output.append(
                         data[micro_step].detach()
                         if data[micro_step] is not None
@@ -151,9 +151,9 @@ class FakeMicroDataset:
             return tuple(output)
 
         elif isinstance(inputs, list):
-            assert (
-                len(inputs) == self._acc_steps
-            ), f"length of data should be {self._acc_steps}, but it is {len(inputs)}"
+            assert len(inputs) == self._acc_steps, (
+                f"length of data should be {self._acc_steps}, but it is {len(inputs)}"
+            )
             return inputs[micro_step].detach()
         elif inputs is not None:
             self._check_data_valid(inputs)
@@ -206,9 +206,9 @@ class PipelineParallelMicroStepCallback:
         Raises:
             AssertionError: If the specified location is not a valid micro-step location.
         """
-        assert (
-            location in self.hooks
-        ), f"Invalid location '{location}'. Valid locations are 'forward_begin', 'forward_end', 'backward_begin', or 'backward_end'."
+        assert location in self.hooks, (
+            f"Invalid location '{location}'. Valid locations are 'forward_begin', 'forward_end', 'backward_begin', or 'backward_end'."
+        )
         self.hooks[location].append(hook)
 
     def on_location(
@@ -224,9 +224,9 @@ class PipelineParallelMicroStepCallback:
         Raises:
             AssertionError: If the specified location is not a valid micro-step location.
         """
-        assert (
-            location in self.hooks
-        ), f"Invalid location '{location}'. Valid locations are 'forward_begin', 'forward_end', 'backward_begin', or 'backward_end'."
+        assert location in self.hooks, (
+            f"Invalid location '{location}'. Valid locations are 'forward_begin', 'forward_end', 'backward_begin', or 'backward_end'."
+        )
         for hook in self.hooks[location]:
             hook(**kwargs)
 
@@ -381,9 +381,9 @@ class PipelineParallel(MetaParallelBase):
         if self._sharding_comm_overlap:
             assert self.use_sharding_parallel and self.num_stages > 1
 
-        assert not (
-            self._dp_comm_overlap and self._sharding_comm_overlap
-        ), "Cannot use dp pp overlap and sharding pp overlap at the same time."
+        assert not (self._dp_comm_overlap and self._sharding_comm_overlap), (
+            "Cannot use dp pp overlap and sharding pp overlap at the same time."
+        )
 
         self._chunk_2_comm_buffers = defaultdict(list)
         self._comm_overlap = (
@@ -512,17 +512,17 @@ class PipelineParallel(MetaParallelBase):
         ) * self.accumulate_steps
 
         if self.bubble_hooks:
-            assert (
-                self.bubble_hooks.current_id
-            ) == expected_bubble_step, f"bubble hooks status is not correct, current id is {self.bubble_hooks.current_id}, expected id is {expected_bubble_step}"
+            assert (self.bubble_hooks.current_id) == expected_bubble_step, (
+                f"bubble hooks status is not correct, current id is {self.bubble_hooks.current_id}, expected id is {expected_bubble_step}"
+            )
         if self.forward_hooks:
-            assert (
-                self.forward_hooks.current_id
-            ) == expected_forward_step, f"forward hooks status is not correct, current id is {self.forward_hooks.current_id}, expected id is {expected_forward_step}"
+            assert (self.forward_hooks.current_id) == expected_forward_step, (
+                f"forward hooks status is not correct, current id is {self.forward_hooks.current_id}, expected id is {expected_forward_step}"
+            )
         if self.backward_hooks:
-            assert (
-                self.backward_hooks.current_id
-            ) == expected_backward_step, f"backward hooks status is not correct, current id is {self.backward_hooks.current_id}, expected id is {expected_backward_step}"
+            assert (self.backward_hooks.current_id) == expected_backward_step, (
+                f"backward hooks status is not correct, current id is {self.backward_hooks.current_id}, expected id is {expected_backward_step}"
+            )
 
     def register_bubble_pipeline_parallel_hook(
         self, location: int, hook: Callable
@@ -723,9 +723,9 @@ class PipelineParallel(MetaParallelBase):
         if self.processed_steps < g_profile_pipeline_details_steps:
             get_sync_logger().info("start forward_backward_pipeline")
         if static_scheduler:
-            assert (
-                not self._profiling
-            ), "While _profiling, static scheduler is not available"
+            assert not self._profiling, (
+                "While _profiling, static scheduler is not available"
+            )
             if data is not None:
                 warnings.warn(
                     "Static scheduler run won't real run the model, but data has been provided"
@@ -894,9 +894,9 @@ class PipelineParallel(MetaParallelBase):
         self._flush_records()
 
         if self._comm_overlap:
-            assert (
-                len(self._chunk_2_comm_buffers) > 0
-            ), "comm buffers should be created"
+            assert len(self._chunk_2_comm_buffers) > 0, (
+                "comm buffers should be created"
+            )
             for _, buffers in self._chunk_2_comm_buffers.items():
                 for buffer in buffers:
                     buffer.scale_grads()
@@ -925,9 +925,9 @@ class PipelineParallel(MetaParallelBase):
 
     def register_sharding_comm_overlap_hook(self, optimizer):
         """for delayed hook register until we get optimizer"""
-        assert isinstance(
-            optimizer, HybridParallelOptimizer
-        ), 'optimizer should be HybridParallelOptimizer subclass.'
+        assert isinstance(optimizer, HybridParallelOptimizer), (
+            'optimizer should be HybridParallelOptimizer subclass.'
+        )
         self.optimizer = optimizer
         if self._sharding_comm_overlap and len(self._chunk_2_comm_buffers) == 0:
             self.register_allreduce_overlap_hook(
@@ -938,20 +938,20 @@ class PipelineParallel(MetaParallelBase):
         # reset the virtual pp rank for each run
         self.set_virtual_pipeline_rank(0)
 
-        assert isinstance(
-            optimizer, HybridParallelOptimizer
-        ), 'optimizer should be HybridParallelOptimizer subclass.'
+        assert isinstance(optimizer, HybridParallelOptimizer), (
+            'optimizer should be HybridParallelOptimizer subclass.'
+        )
 
-        assert (
-            framework._dygraph_tracer()._has_grad
-        ), 'Please enable the generation of gradients.'
+        assert framework._dygraph_tracer()._has_grad, (
+            'Please enable the generation of gradients.'
+        )
 
         if self.is_pipeline_first_stage(
             ignore_virtual=True
         ) or self.is_pipeline_last_stage(ignore_virtual=True):
-            assert (
-                data is not None
-            ), "For the first and the last stage, the data must be set."
+            assert data is not None, (
+                "For the first and the last stage, the data must be set."
+            )
         else:
             data = None
 
@@ -1102,9 +1102,9 @@ class PipelineParallel(MetaParallelBase):
         if self.is_pipeline_last_stage():
             # train calculate loss for train
             if self._compute_loss:
-                assert (
-                    self._layers._loss_fn[self.loss_fn_idx] is not None
-                ), "loss function should exist to compute loss"
+                assert self._layers._loss_fn[self.loss_fn_idx] is not None, (
+                    "loss function should exist to compute loss"
+                )
                 labels = next(micro_dataset)[1]
                 self._check_micro_batch_data_valid(labels)
                 for idx, loss_fn in enumerate(self._layers._loss_fn):
@@ -1121,9 +1121,9 @@ class PipelineParallel(MetaParallelBase):
                         loss_tensor = loss_fn_node.forward(output_tensor)
                     else:
                         loss_tensor = loss_fn(output_tensor, labels)
-                        assert isinstance(
-                            loss_tensor, paddle.Tensor
-                        ), "Currently, loss_fn should obtain Paddle.Tensor dtype"
+                        assert isinstance(loss_tensor, paddle.Tensor), (
+                            "Currently, loss_fn should obtain Paddle.Tensor dtype"
+                        )
 
                         with paddle.amp.auto_cast(enable=False):
                             if (
@@ -1233,7 +1233,9 @@ class PipelineParallel(MetaParallelBase):
                 if overlap_schedule_mode:
                     assert (
                         loss_fn_node is not None and schedule_chunk is not None
-                    ), "loss_fn_node and schedule_chunk should not be None in overlap_schedule_mode"
+                    ), (
+                        "loss_fn_node and schedule_chunk should not be None in overlap_schedule_mode"
+                    )
                     input_tensor_grad = loss_fn_node.backward(
                         scaler=self.scaler
                     )
@@ -1260,9 +1262,9 @@ class PipelineParallel(MetaParallelBase):
                     grad_tensors = [output_tensor_grad]
 
                 if overlap_schedule_mode:
-                    assert (
-                        schedule_chunk is not None
-                    ), "schedule_chunk should not be None in overlap_schedule_mode"
+                    assert schedule_chunk is not None, (
+                        "schedule_chunk should not be None in overlap_schedule_mode"
+                    )
                     input_tensor_grad = schedule_chunk.backward(grad_tensors)
                 else:
                     paddle.autograd.backward(
@@ -1311,9 +1313,9 @@ class PipelineParallel(MetaParallelBase):
         # Since the last backward run in interleave will set the virtual rank to 0,
         # here we need to check last stage ignoring virtual stage.
         if self.is_pipeline_last_stage(ignore_virtual=True):
-            assert (
-                self.total_loss is not None
-            ), "train_batch() in last stage should obtain valid loss"
+            assert self.total_loss is not None, (
+                "train_batch() in last stage should obtain valid loss"
+            )
             losses = []
             for idx in range(len(self._layers._loss_fn)):
                 self.total_loss[idx] = paddle.to_tensor(self.total_loss[idx])
@@ -1473,9 +1475,9 @@ class PipelineParallelWithInterleave(PipelineParallel):
         )
 
         if self.overlap_schedule_mode:
-            assert (
-                not self._profiling
-            ), "Profiling is not compatible with overlap_schedule_mode."
+            assert not self._profiling, (
+                "Profiling is not compatible with overlap_schedule_mode."
+            )
         logger.info(f"Using {self._get_scheduler_name()}")
 
         self._record_format = (
@@ -1510,9 +1512,9 @@ class PipelineParallelWithInterleave(PipelineParallel):
             "pp_configs"
         ].best_unbalanced_scheduler
         if self._best_unbalanced_scheduler:
-            assert (
-                not self._comm_overlap
-            ), "pp best unbalaced scheduler can not run together with dp/sharding overlap"
+            assert not self._comm_overlap, (
+                "pp best unbalaced scheduler can not run together with dp/sharding overlap"
+            )
 
         self._enable_offload_queue = self._strategy.hybrid_configs[
             "pp_configs"
@@ -1530,17 +1532,17 @@ class PipelineParallelWithInterleave(PipelineParallel):
         self.bubble_hooks.set_hooks_capacity(2 * self.num_stages - 2)
 
     def _check_sanity(self):
-        assert (
-            framework.in_dynamic_mode()
-        ), "virtual pipeline stage with interleave only support eager dygraph mode"
+        assert framework.in_dynamic_mode(), (
+            "virtual pipeline stage with interleave only support eager dygraph mode"
+        )
 
-        assert (
-            self.num_stages > 2
-        ), "virtual pipeline must run under pp degree > 2"
+        assert self.num_stages > 2, (
+            "virtual pipeline must run under pp degree > 2"
+        )
 
-        assert (
-            self.accumulate_steps >= 2 * self.num_stages
-        ), f"accumulate_steps({self.accumulate_steps}) should be greater than or equal to 2 * num_stages({self.num_stages}) for pipeline with interleave"
+        assert self.accumulate_steps >= 2 * self.num_stages, (
+            f"accumulate_steps({self.accumulate_steps}) should be greater than or equal to 2 * num_stages({self.num_stages}) for pipeline with interleave"
+        )
 
     def _reset_counter(self):
         for i in range(self.num_model_chunks):
@@ -1765,9 +1767,9 @@ class PipelineParallelWithInterleave(PipelineParallel):
         assert hasattr(self, 'output_tensors')
         assert hasattr(self, 'output_tensor_grads')
 
-        assert (
-            len(self.output_tensor_grads[virtual_pp_rank]) > 0
-        ), f"output_tensor_grads is empty for virtual_pp_rank {virtual_pp_rank}"
+        assert len(self.output_tensor_grads[virtual_pp_rank]) > 0, (
+            f"output_tensor_grads is empty for virtual_pp_rank {virtual_pp_rank}"
+        )
 
         assert len(self.input_tensors[virtual_pp_rank]) > 0
         assert len(self.output_tensors[virtual_pp_rank]) > 0
@@ -1998,17 +2000,17 @@ class PipelineParallelWithInterleave(PipelineParallel):
         # this strategy is inspired by:
         # https://github.com/NVIDIA/Megatron-LM/blob/main/megatron/schedules.py
         if not compute_loss:
-            assert (
-                not forward_only
-            ), "compute_loss can only be set to False when forward_only is set to True"
+            assert not forward_only, (
+                "compute_loss can only be set to False when forward_only is set to True"
+            )
 
         if static_scheduler:
-            assert (
-                not forward_only
-            ), "static_scheduler only for training not for eval"
-            assert (
-                not self._profiling
-            ), "While _profiling, static scheduler is not available"
+            assert not forward_only, (
+                "static_scheduler only for training not for eval"
+            )
+            assert not self._profiling, (
+                "While _profiling, static scheduler is not available"
+            )
             if data is not None:
                 warnings.warn(
                     "Static scheduler run won't real run the model, but data has been provided"
@@ -2018,9 +2020,9 @@ class PipelineParallelWithInterleave(PipelineParallel):
             )
             schedule = ""
         # NOTE(shenliang03): Due to ring_exchange for pipeline with interleave, cache should be enabled
-        assert (
-            self._using_cache
-        ), "cache should be enabled for pipeline with interleave"
+        assert self._using_cache, (
+            "cache should be enabled for pipeline with interleave"
+        )
 
         self.overlap_schedule_mode = (
             hasattr(type(self._layers), "overlapped_forward_backward")
@@ -2078,9 +2080,9 @@ class PipelineParallelWithInterleave(PipelineParallel):
 
         def _last_stage_recv_pp_rank(micro_step):
             if micro_step >= first_chunk_acc:
-                assert (
-                    len(last_stage_recv_queue) != 0
-                ), "last_stage_recv_queue can't be empty"
+                assert len(last_stage_recv_queue) != 0, (
+                    "last_stage_recv_queue can't be empty"
+                )
                 virtual_pp_stage = (last_stage_recv_queue.popleft())[1]
                 return virtual_pp_stage - 1
             else:
@@ -2868,13 +2870,13 @@ class PipelineParallelWithInterleaveFthenB(PipelineParallelWithInterleave):
         # self.bubble_hooks.set_hooks_capacity(2 * self.num_stages - 2)
 
     def _check_sanity(self):
-        assert (
-            framework.in_dynamic_mode()
-        ), "virtual pipeline stage with interleave only support eager dygraph mode"
+        assert framework.in_dynamic_mode(), (
+            "virtual pipeline stage with interleave only support eager dygraph mode"
+        )
 
-        assert (
-            self.num_stages > 2
-        ), "virtual pipeline must run under pp degree > 2"
+        assert self.num_stages > 2, (
+            "virtual pipeline must run under pp degree > 2"
+        )
 
     def _get_virtual_pp_rank(self, micro_step, forward):
         virtual_pp_stage = micro_step % (
@@ -2935,14 +2937,14 @@ class PipelineParallelWithInterleaveFthenB(PipelineParallelWithInterleave):
         if self.processed_steps < g_profile_pipeline_details_steps:
             get_sync_logger().info("start forward_backward_pipeline")
         if not compute_loss:
-            assert (
-                not forward_only
-            ), "compute_loss can only be set to False when forward_only is set to True"
+            assert not forward_only, (
+                "compute_loss can only be set to False when forward_only is set to True"
+            )
 
         # NOTE(shenliang03): Due to ring_exchange for pipeline with interleave, cache should be enabled
-        assert (
-            self._using_cache
-        ), "cache should be enabled for pipeline with interleave"
+        assert self._using_cache, (
+            "cache should be enabled for pipeline with interleave"
+        )
 
         # init some attributes for this batch run
         self.scaler = scaler
@@ -2954,7 +2956,9 @@ class PipelineParallelWithInterleaveFthenB(PipelineParallelWithInterleave):
         assert (
             self.accumulate_steps == self.num_stages
             or self.accumulate_steps % self.num_stages != 0
-        ), f"accumulate_steps({self.accumulate_steps}) and num_stages({self.num_stages}) should be a multiple or accumulate_steps % num_stages == 0"
+        ), (
+            f"accumulate_steps({self.accumulate_steps}) and num_stages({self.num_stages}) should be a multiple or accumulate_steps % num_stages == 0"
+        )
 
         self._backward_step_count = 0
         skip_steps = self.accumulate_steps - self.num_stages
@@ -3014,9 +3018,9 @@ class PipelineParallelWithInterleaveFthenB(PipelineParallelWithInterleave):
 
             self._release_output(output_tensor)
 
-        assert (
-            send_recv_buffer_queue.empty()
-        ), "send_recv buffer should be empty"
+        assert send_recv_buffer_queue.empty(), (
+            "send_recv buffer should be empty"
+        )
 
         # remaining backward steps
         if not forward_only:
@@ -3065,9 +3069,9 @@ class PipelineParallelWithInterleaveFthenB(PipelineParallelWithInterleave):
                     )
                 )
 
-            assert (
-                send_recv_buffer_queue.empty()
-            ), "send_recv buffer should be empty"
+            assert send_recv_buffer_queue.empty(), (
+                "send_recv buffer should be empty"
+            )
 
             self._sync_overlap_grads()
 
@@ -3161,12 +3165,12 @@ class VPPFhenBInBalancedMemory(PipelineParallelWithInterleaveFthenB):
     ):
         self._reset_user_hooks_status()
         if not compute_loss:
-            assert (
-                not forward_only
-            ), "compute_loss can only be set to False when forward_only is set to True"
-        assert (
-            self._using_cache
-        ), "cache should be enabled for pipeline with interleave"
+            assert not forward_only, (
+                "compute_loss can only be set to False when forward_only is set to True"
+            )
+        assert self._using_cache, (
+            "cache should be enabled for pipeline with interleave"
+        )
         self.user_hooks_enabled = not forward_only
         if forward_only:
             return super().forward_backward_pipeline(
@@ -3346,9 +3350,9 @@ class VPPFhenBInBalancedMemory(PipelineParallelWithInterleaveFthenB):
                     if self.user_hooks_enabled:
                         self.bubble_hooks.run_hook()
 
-        assert (
-            forward_send_recv_buffer_queue.qsize() == 0
-        ), forward_send_recv_buffer_queue.qsize()
+        assert forward_send_recv_buffer_queue.qsize() == 0, (
+            forward_send_recv_buffer_queue.qsize()
+        )
 
         next_backward_virtual_pp_rank = self._get_virtual_pp_rank(
             steady_1f1b_steps, forward=False
@@ -3406,9 +3410,9 @@ class VPPFhenBInBalancedMemory(PipelineParallelWithInterleaveFthenB):
                 )
             )
 
-        assert (
-            backward_send_recv_buffer_queue.empty()
-        ), "send_recv buffer should be empty"
+        assert backward_send_recv_buffer_queue.empty(), (
+            "send_recv buffer should be empty"
+        )
 
         # Bubbles after cooldown
         for _ in range(self.stage_id):

--- a/python/paddle/distributed/fleet/meta_parallel/pp_utils/batch_comm_helper.py
+++ b/python/paddle/distributed/fleet/meta_parallel/pp_utils/batch_comm_helper.py
@@ -53,9 +53,9 @@ class BatchCommHelper:
         shape_message = self._send_recv_meta.recv_shape_message
         dtype_message = self._send_recv_meta.recv_dtype_message
         stop_gradient = self._send_recv_meta.recv_stop_gradient
-        assert (shape_message is not None) and (
-            dtype_message is not None
-        ), "Failed to build from meta."
+        assert (shape_message is not None) and (dtype_message is not None), (
+            "Failed to build from meta."
+        )
 
         res = []
         if isinstance(shape_message, tuple):
@@ -79,9 +79,9 @@ class BatchCommHelper:
         shape_message = self._send_recv_meta.recv_shape_message
         dtype_message = self._send_recv_meta.recv_dtype_message
 
-        assert (shape_message is not None) and (
-            dtype_message is not None
-        ), "Failed to build from meta."
+        assert (shape_message is not None) and (dtype_message is not None), (
+            "Failed to build from meta."
+        )
 
         if isinstance(shape_message, tuple):
             assert isinstance(tensors, (list, tuple))

--- a/python/paddle/distributed/fleet/meta_parallel/pp_utils/forward_backward_overlap_utils.py
+++ b/python/paddle/distributed/fleet/meta_parallel/pp_utils/forward_backward_overlap_utils.py
@@ -139,9 +139,9 @@ class ScheduleNode:
             outputs = self.outputs
             if not isinstance(outputs, (tuple, list)):
                 outputs = (outputs,)
-            assert len(outputs) == len(
-                output_grad
-            ), f"{len(outputs)} of {type(outputs[0])} vs {len(output_grad)} of {type(output_grad[0])}"
+            assert len(outputs) == len(output_grad), (
+                f"{len(outputs)} of {type(outputs[0])} vs {len(output_grad)} of {type(output_grad[0])}"
+            )
 
             paddle.autograd.backward(outputs, output_grad)
 

--- a/python/paddle/distributed/fleet/meta_parallel/pp_utils/p2p_communication.py
+++ b/python/paddle/distributed/fleet/meta_parallel/pp_utils/p2p_communication.py
@@ -131,9 +131,9 @@ class SendRecvMeta:
             stop_grads.append(stop_gradient)
             keys.append(key)
 
-        assert (
-            len(data) == 0
-        ), f"send data must be parsed zero, now it is {data}"
+        assert len(data) == 0, (
+            f"send data must be parsed zero, now it is {data}"
+        )
 
         if tensor_type == 0:
             self.recv_shape_message = shapes[0]
@@ -247,15 +247,15 @@ class SendRecvMeta:
         actual_shape, actual_dtype, actual_key = self._obtain_send_message(
             tensor
         )
-        assert (
-            self.send_shape_message == actual_shape
-        ), f"send_shape_message: {self.send_shape_message}, actual_shape: {actual_shape}"
-        assert (
-            self.send_dtype_message == actual_dtype
-        ), f"send_dtype_message: {self.send_dtype_message}, actual_dtype: {actual_dtype}"
-        assert (
-            self.send_key_message == actual_key
-        ), f"send_key_message: {self.send_key_message}, actual_key: {actual_key}"
+        assert self.send_shape_message == actual_shape, (
+            f"send_shape_message: {self.send_shape_message}, actual_shape: {actual_shape}"
+        )
+        assert self.send_dtype_message == actual_dtype, (
+            f"send_dtype_message: {self.send_dtype_message}, actual_dtype: {actual_dtype}"
+        )
+        assert self.send_key_message == actual_key, (
+            f"send_key_message: {self.send_key_message}, actual_key: {actual_key}"
+        )
 
     def __repr__(self):
         return f"send_shape_message: {self.send_shape_message}, send_dtype_message: {self.send_dtype_message}, recv_shape_message: {self.recv_shape_message}, recv_dtype_message: {self.recv_dtype_message}, recv_stop_gradient: {self.recv_stop_gradient}"
@@ -270,9 +270,9 @@ def _is_valid_send_recv_partial(tensor, mp_degree):
 
 
 def _send_on_calc_stream(tensor, group, dst, nranks=1, rank_id=0):
-    assert (
-        group is not None
-    ), "Group should be an instance for _send_on_calc_stream."
+    assert group is not None, (
+        "Group should be an instance for _send_on_calc_stream."
+    )
     dst_rank_in_group = group.get_group_rank(dst)
     if _is_valid_send_recv_partial(tensor, nranks):
         return group.process_group.send_partial_on_calc_stream(
@@ -285,9 +285,9 @@ def _send_on_calc_stream(tensor, group, dst, nranks=1, rank_id=0):
 
 
 def _recv_on_calc_stream(tensor, group, src, nranks=1, rank_id=0):
-    assert (
-        group is not None
-    ), "Group should be an instance for _recv_on_calc_stream."
+    assert group is not None, (
+        "Group should be an instance for _recv_on_calc_stream."
+    )
     src_rank_in_group = group.get_group_rank(src)
     if _is_valid_send_recv_partial(tensor, nranks):
         return group.process_group.recv_partial_on_calc_stream(
@@ -918,9 +918,9 @@ class P2pHelper:
         if _timers is not None:
             _timers("send_forward_recv_backward").start()
 
-        assert (
-            not self._dynamic_shape
-        ), "p2p_helper.send_forward_recv_backward function doesn't support dynamic_shape now"
+        assert not self._dynamic_shape, (
+            "p2p_helper.send_forward_recv_backward function doesn't support dynamic_shape now"
+        )
 
         if pp_last_stage:
             output_tensor_grad = None
@@ -944,9 +944,9 @@ class P2pHelper:
         if _timers is not None:
             _timers("send_backward_recv_forward").start()
 
-        assert (
-            not self._dynamic_shape
-        ), "p2p_helper.send_backward_recv_forward function doesn't support dynamic_shape now"
+        assert not self._dynamic_shape, (
+            "p2p_helper.send_backward_recv_forward function doesn't support dynamic_shape now"
+        )
 
         if pp_first_stage:
             input_tensor = None
@@ -977,9 +977,9 @@ class P2pHelper:
         if _timers is not None:
             _timers("send_forward_backward_recv_forward_backward").start()
 
-        assert (
-            not self._dynamic_shape
-        ), "p2p_helper.send_forward_backward_recv_forward_backward function doesn't support dynamic_shape now"
+        assert not self._dynamic_shape, (
+            "p2p_helper.send_forward_backward_recv_forward_backward function doesn't support dynamic_shape now"
+        )
 
         if output_tensor is not None:
             self._send_meta(output_tensor, skip_check_meta=skip_check_meta)

--- a/python/paddle/distributed/fleet/meta_parallel/sharding/group_sharded_optimizer_stage2.py
+++ b/python/paddle/distributed/fleet/meta_parallel/sharding/group_sharded_optimizer_stage2.py
@@ -33,9 +33,7 @@ from paddle.framework import core
 from paddle.nn import ClipGradByGlobalNorm
 from paddle.optimizer import Optimizer
 
-HybridParallelClipGrad = (
-    fleet.meta_optimizers.dygraph_optimizer.hybrid_parallel_optimizer.HybridParallelClipGrad
-)
+HybridParallelClipGrad = fleet.meta_optimizers.dygraph_optimizer.hybrid_parallel_optimizer.HybridParallelClipGrad
 from paddle.distributed.collective import _get_global_group, new_group
 
 from .group_sharded_storage import GradStorage, ParamStorage
@@ -103,9 +101,9 @@ class GroupShardedOptimizerStage2(Optimizer):
         # record the last task used for comm overlap for sharding stage 2
         self._comm_task = None
 
-        assert hasattr(
-            self._optim, "_master_weights"
-        ), "Must use optimizer with _master_weights attribute"
+        assert hasattr(self._optim, "_master_weights"), (
+            "Must use optimizer with _master_weights attribute"
+        )
 
         # Support parameter group and parameter list
         self._local_params = []
@@ -120,9 +118,9 @@ class GroupShardedOptimizerStage2(Optimizer):
             if self.use_main_grad is None and hasattr(param, "main_grad"):
                 self.use_main_grad = True
             if self.use_main_grad:
-                assert hasattr(
-                    param, "main_grad"
-                ), "Params have different main grad attributes."
+                assert hasattr(param, "main_grad"), (
+                    "Params have different main grad attributes."
+                )
         if self.use_main_grad:
             assert not offload, "offload not support main_grad for now"
 
@@ -173,9 +171,9 @@ class GroupShardedOptimizerStage2(Optimizer):
         self._global_root_rank = self._group.ranks[0]
 
         if self._dp_group is not None and self._dp_group.nranks > 1:
-            assert (
-                not offload
-            ), "Not support! when using offload with sharding stage2, please use pure sharding stage2, exclude data parallel."
+            assert not offload, (
+                "Not support! when using offload with sharding stage2, please use pure sharding stage2, exclude data parallel."
+            )
 
         # Synchronous all ranks models
         if pretrain_sync_models:
@@ -222,9 +220,9 @@ class GroupShardedOptimizerStage2(Optimizer):
                         item["grad_clip"] = self._optim._grad_clip
 
         if offload:
-            assert (
-                self._pfp16
-            ), "Only support offload strategy while using 'Adam', 'AdamW' and 'Momentum' optimizer with AMP/Pure FP16"
+            assert self._pfp16, (
+                "Only support offload strategy while using 'Adam', 'AdamW' and 'Momentum' optimizer with AMP/Pure FP16"
+            )
 
         self.offload = offload  # Using for offload
         self.offload_device = "cpu"
@@ -280,9 +278,9 @@ class GroupShardedOptimizerStage2(Optimizer):
         # Enable post optimizer broadcasts overlap with the forward calculation of next batch.
         self._broadcast_overlap = broadcast_overlap
         if self._broadcast_overlap:
-            assert (
-                layers is not None
-            ), "To enable broadcast overlap forward, please pass the module to the function."
+            assert layers is not None, (
+                "To enable broadcast overlap forward, please pass the module to the function."
+            )
             self._layers = layers
             warnings.warn(
                 "Setting overlap broadcast means the `paddle.device.cuda.synchronize()` "
@@ -303,9 +301,9 @@ class GroupShardedOptimizerStage2(Optimizer):
             )
             num_groups = 1
 
-        assert (
-            isinstance(num_groups, int) and num_groups > 0
-        ), "num_groups should be a positive integer"
+        assert isinstance(num_groups, int) and num_groups > 0, (
+            "num_groups should be a positive integer"
+        )
 
         self._number_of_broadcast_groups = num_groups
         self._broadcast_groups = [

--- a/python/paddle/distributed/fleet/meta_parallel/sharding/group_sharded_stage2.py
+++ b/python/paddle/distributed/fleet/meta_parallel/sharding/group_sharded_stage2.py
@@ -93,9 +93,9 @@ class GroupShardedStage2(nn.Layer):
             else group
         )
         self._world_size_scaling = 1.0 / self._group.nranks
-        assert (
-            self._group.nranks > 1
-        ), "Training must be distributed, ranks must be greater than 1"
+        assert self._group.nranks > 1, (
+            "Training must be distributed, ranks must be greater than 1"
+        )
         self._rank = self._group.rank
         self._global_root_rank = self._group.ranks[
             0
@@ -113,9 +113,9 @@ class GroupShardedStage2(nn.Layer):
             if self.use_main_grad is None and hasattr(param, "main_grad"):
                 self.use_main_grad = True
             if self.use_main_grad:
-                assert hasattr(
-                    param, "main_grad"
-                ), "Params have different main grad attributes."
+                assert hasattr(param, "main_grad"), (
+                    "Params have different main grad attributes."
+                )
 
         # sharing stage 2 comm overlap flag
         self._reduce_overlap = False
@@ -146,9 +146,9 @@ class GroupShardedStage2(nn.Layer):
             filter(lambda optim: optim.offload, self._sharding_optimizers)
         )
         if len(self._offload_optims) > 0:
-            assert (
-                len(self._sharding_optimizers) == 1
-            ), "Only support offload strategy for single optimizer"
+            assert len(self._sharding_optimizers) == 1, (
+                "Only support offload strategy for single optimizer"
+            )
 
         self._offload = len(self._offload_optims) > 0
         self._offload_device = "cpu"
@@ -293,9 +293,9 @@ class GroupShardedStage2(nn.Layer):
         Synchronously or asynchronously convert the data type of the layer, the device is not supported now.
         """
         assert isinstance(device, str), "Device must be type str"
-        assert (
-            device == self._default_device
-        ), "New devices are not supported, because of the optimizer state is not sync"
+        assert device == self._default_device, (
+            "New devices are not supported, because of the optimizer state is not sync"
+        )
 
         self._layer.to(device=device, dtype=dtype, blocking=blocking)
 
@@ -321,9 +321,7 @@ class GroupShardedStage2(nn.Layer):
                 optim._update_opt_status()
 
             # Get the parameters split by the optimizer according to rank
-            for (
-                per_rank_params
-            ) in (
+            for per_rank_params in (
                 optim.dtype_rank_params.values()
             ):  # all the params from all ranks
                 for params in per_rank_params:
@@ -383,9 +381,9 @@ class GroupShardedStage2(nn.Layer):
         # model._set_reduce_overlap(True)
         self._reduce_overlap = reduce_overlap
         if self._reduce_overlap:
-            assert (
-                len(self._sharding_optimizers) == 1
-            ), "Only support comm overlap strategy for single optimizer"
+            assert len(self._sharding_optimizers) == 1, (
+                "Only support comm overlap strategy for single optimizer"
+            )
         self._sharding_optimizers[0]._set_reduce_overlap(reduce_overlap)
 
     def _get_scaled_grad_fn(self, param):
@@ -400,9 +398,9 @@ class GroupShardedStage2(nn.Layer):
                     and grad is not None
                     and grad.dtype == Type.fp16.value
                 ):
-                    assert (
-                        grad._is_initialized()
-                    ), "grad should be initialized in stage2"
+                    assert grad._is_initialized(), (
+                        "grad should be initialized in stage2"
+                    )
                     grad.scale_(self._world_size_scaling)
                 else:
                     self.scale_in_opt = True

--- a/python/paddle/distributed/fleet/meta_parallel/sharding/group_sharded_stage3.py
+++ b/python/paddle/distributed/fleet/meta_parallel/sharding/group_sharded_stage3.py
@@ -130,9 +130,9 @@ class GroupShardedStage3(nn.Layer):
         # stage3 support some layer set by users to be unslice
         # _exclude_layer=[layer_name or id(layer)]
         self._exclude_layer = [] if exclude_layer is None else exclude_layer
-        assert isinstance(
-            self._exclude_layer, (list, tuple)
-        ), "the exclude_layers must be a list with layers' name or layers' id"
+        assert isinstance(self._exclude_layer, (list, tuple)), (
+            "the exclude_layers must be a list with layers' name or layers' id"
+        )
 
         # segmentation size
         assert segment_size >= 0, "segment_size must be GE than 0."
@@ -161,9 +161,9 @@ class GroupShardedStage3(nn.Layer):
         )
         self._dp_group = dp_group
         self._world_size_scaling = 1.0 / self._group.nranks
-        assert (
-            self._group.nranks > 1
-        ), "Training must be distributed, ranks must be greater than 1."
+        assert self._group.nranks > 1, (
+            "Training must be distributed, ranks must be greater than 1."
+        )
         self._rank = self._group.rank
         self._global_root_rank = self._group.ranks[
             0
@@ -172,17 +172,15 @@ class GroupShardedStage3(nn.Layer):
         # Parameter segmentation for global ranks
         # After flatten -> self._param2buffer_size, self._param2buffer, self._trainable_params
         self._param2buffer_size = {}  # {param.name: size}
-        self._param2buffer = (
-            {}
-        )  # {param.name: [(start0, end0),(start1, end1), ...]}
+        self._param2buffer = {}  # {param.name: [(start0, end0),(start1, end1), ...]}
         self._trainable_params = {}  # {id(layer): [trainable_params]}
         self._unslice_params = OrderedSet()  # param's numel <= segment_size
         self._unslice_params2align = {}  # {param.name: param's align}
         self._grad_storages = {}  # {param.dtype: GradStorage}
 
-        assert not isinstance(
-            optimizer, list
-        ), "Multiple optimizers are not supported now."
+        assert not isinstance(optimizer, list), (
+            "Multiple optimizers are not supported now."
+        )
         self._optim = _OptimizerWrapper(
             optimizer, self._offload, self._group, self._update_params_slice
         )
@@ -247,9 +245,9 @@ class GroupShardedStage3(nn.Layer):
             if self.use_main_grad is None and hasattr(param, "main_grad"):
                 self.use_main_grad = True
             if self.use_main_grad:
-                assert hasattr(
-                    param, "main_grad"
-                ), "Params have different main grad attributes."
+                assert hasattr(param, "main_grad"), (
+                    "Params have different main grad attributes."
+                )
 
     @paddle.autograd.no_grad()
     def _sync_params_and_buffers(self):
@@ -280,9 +278,9 @@ class GroupShardedStage3(nn.Layer):
             )
         )
         for param in trainable_params:
-            assert hasattr(
-                param, "fw_storage"
-            ), f"Find {param.name} don't have fw_storage attribute."
+            assert hasattr(param, "fw_storage"), (
+                f"Find {param.name} don't have fw_storage attribute."
+            )
             if self.use_main_grad:
                 param.fw_storage.main_grad._clear()
                 param.fw_storage.main_grad = None
@@ -654,9 +652,9 @@ class GroupShardedStage3(nn.Layer):
         )
         # 1.Handle param's slice
         for param in trainable_params:
-            assert hasattr(
-                param, "fw_storage"
-            ), f"Find {param.name} don't have fw_storage attribute"
+            assert hasattr(param, "fw_storage"), (
+                f"Find {param.name} don't have fw_storage attribute"
+            )
 
             param.fw_storage = _TensorWrapper(param)
             if self.use_main_grad:
@@ -746,9 +744,9 @@ class GroupShardedStage3(nn.Layer):
     def _get_allreduce_fn(self, param):
         @paddle.autograd.no_grad()
         def allreduce_(*_):
-            assert (
-                param.trainable
-            ), "the param must be trainable for grad allreduced"
+            assert param.trainable, (
+                "the param must be trainable for grad allreduced"
+            )
             if param.name in self._task_flow.full_grad.keys():
                 full_grad = self._task_flow.full_grad[param.name]
                 # Only support sync allreduce current rank's layer now

--- a/python/paddle/distributed/fleet/meta_parallel/sharding/group_sharded_storage.py
+++ b/python/paddle/distributed/fleet/meta_parallel/sharding/group_sharded_storage.py
@@ -76,12 +76,12 @@ class InternalStorage:
         """
         Move the underlying buffer
         """
-        assert (
-            self.buffer is not None
-        ), "Cannot move a collapsed bucket, please rebuild it"
-        assert (
-            dtype == Type.fp32.value or Type.fp16.value
-        ), "Conversion type is not supported now"
+        assert self.buffer is not None, (
+            "Cannot move a collapsed bucket, please rebuild it"
+        )
+        assert dtype == Type.fp32.value or Type.fp16.value, (
+            "Conversion type is not supported now"
+        )
 
         if self._device != device:
             if device in paddle.device.get_all_custom_device_type():
@@ -171,9 +171,9 @@ class ParamStorage(InternalStorage):
 
     @paddle.autograd.no_grad()
     def _add_param_as_view(self, param, align, convert_gpu=True):
-        assert (
-            param.dtype == self.buffer.dtype
-        ), f"Different types for the InternalStorage and the param, cannot proceed: {param.dtype} - {self.buffer.dtype}"
+        assert param.dtype == self.buffer.dtype, (
+            f"Different types for the InternalStorage and the param, cannot proceed: {param.dtype} - {self.buffer.dtype}"
+        )
 
         var_end = self._fill + param._numel()
         offset = var_end + align
@@ -283,9 +283,9 @@ class GradStorage(InternalStorage):
         Add a new parameter gradient to the InternalStorage. Param.grad becomes a view of this InternalStorage buffer.
         """
 
-        assert (
-            id(param) not in self._param_ids
-        ), "The same gradients cannot be checked in twice"
+        assert id(param) not in self._param_ids, (
+            "The same gradients cannot be checked in twice"
+        )
 
         self._add_grad_as_view(param, align)
         self._params.append(param)
@@ -336,9 +336,9 @@ class GradStorage(InternalStorage):
 
     @paddle.autograd.no_grad()
     def _add_grad_as_view(self, param, align):
-        assert (
-            param._numel() > 0
-        ), "Cannot add a gradient to a released InternalStorage, please rebuild"
+        assert param._numel() > 0, (
+            "Cannot add a gradient to a released InternalStorage, please rebuild"
+        )
 
         use_main_grad = hasattr(param, "main_grad")
         if use_main_grad:

--- a/python/paddle/distributed/fleet/model.py
+++ b/python/paddle/distributed/fleet/model.py
@@ -156,9 +156,9 @@ def distributed_model(model):
     elif fleet_env._hcg.get_parallel_mode() == ParallelMode.TENSOR_PARALLEL:
         model = TensorParallel(model, fleet_env._hcg, strategy=strategy)
     elif fleet_env._hcg.get_parallel_mode() == ParallelMode.PIPELINE_PARALLEL:
-        assert isinstance(
-            model, PipelineLayer
-        ), "For pipeline parallel, the model should an instance of PipelineLayer"
+        assert isinstance(model, PipelineLayer), (
+            "For pipeline parallel, the model should an instance of PipelineLayer"
+        )
         if strategy.hybrid_configs["pp_configs"].use_dualpipev:
             model = DualPipeVParallel(model, fleet_env._hcg, strategy=strategy)
         elif model.get_num_virtual_stages() == 1:

--- a/python/paddle/distributed/fleet/optimizer.py
+++ b/python/paddle/distributed/fleet/optimizer.py
@@ -80,9 +80,9 @@ def _dygraph_distributed_optimizer(optimizer, strategy=None):
                 "pp_configs"
             ].sharding_comm_overlap:
                 hp_optim._sharding_enable = False
-                assert (
-                    not hp_optim._sep_enable
-                ), "sep parallel can not coexist with sharding_comm_overlap"
+                assert not hp_optim._sep_enable, (
+                    "sep parallel can not coexist with sharding_comm_overlap"
+                )
 
             return hp_optim
         else:

--- a/python/paddle/distributed/fleet/recompute/recompute.py
+++ b/python/paddle/distributed/fleet/recompute/recompute.py
@@ -255,9 +255,9 @@ class RecomputeFunction(PyLayer):
                 ctx.tensor_indices.append(i)
                 ctx.inputs.append(None)
             elif type(arg) is tuple:
-                assert (
-                    i not in ctx.offload_indices
-                ), f"offload_indices should not contain tensor tuple in position{i}"
+                assert i not in ctx.offload_indices, (
+                    f"offload_indices should not contain tensor tuple in position{i}"
+                )
                 is_tensors = [paddle.is_tensor(a) for a in arg]
                 if all(is_tensors):
                     # the tuple is a tuple of tensors

--- a/python/paddle/distributed/fleet/recompute/recompute_hybrid.py
+++ b/python/paddle/distributed/fleet/recompute/recompute_hybrid.py
@@ -57,9 +57,9 @@ def _split_activation(tensor, mp_group):
 
     tensor_numel = paddle.numel(tensor)
     assert tensor_numel != 0, "can't recompute zero element"
-    assert (
-        tensor_numel % mp_degree == 0
-    ), f"The capacity of the activation ({tensor_numel}) cannot be divisible by mp_degree({mp_degree})"
+    assert tensor_numel % mp_degree == 0, (
+        f"The capacity of the activation ({tensor_numel}) cannot be divisible by mp_degree({mp_degree})"
+    )
 
     # use inplace operation to save memory
     data = tensor.flatten_()
@@ -306,9 +306,9 @@ def recompute_hybrid(
 
     """
     mp_group = ctx.get('mp_group', None)
-    assert (
-        mp_group is not None
-    ), "ctx must contains mp_group and mp_group can not be None."
+    assert mp_group is not None, (
+        "ctx must contains mp_group and mp_group can not be None."
+    )
 
     offload = ctx.get('offload', False)
     partition = ctx.get('partition', False)

--- a/python/paddle/distributed/fleet/runtime/the_one_ps.py
+++ b/python/paddle/distributed/fleet/runtime/the_one_ps.py
@@ -988,17 +988,17 @@ class TheOnePSRuntime(RuntimeBase):
             program_idx = 0
             for table_name in tensor_table_dict:
                 if tensor_table_dict[table_name]["startup_program"] is not None:
-                    tensor_table_dict[table_name][
-                        "startup_program_id"
-                    ] = program_idx
+                    tensor_table_dict[table_name]["startup_program_id"] = (
+                        program_idx
+                    )
                     self._server_sub_program.append(
                         tensor_table_dict[table_name]["startup_program"].desc
                     )
                     program_idx += 1
                 if tensor_table_dict[table_name]["main_program"] is not None:
-                    tensor_table_dict[table_name][
-                        "main_program_id"
-                    ] = program_idx
+                    tensor_table_dict[table_name]["main_program_id"] = (
+                        program_idx
+                    )
                     self._server_sub_program.append(
                         tensor_table_dict[table_name]["main_program"].desc
                     )
@@ -1228,9 +1228,9 @@ class TheOnePSRuntime(RuntimeBase):
     def _stop_worker(self):
         self._communicator.stop()
         if self.role_maker._is_heter_parameter_server_mode:
-            assert (
-                self._heter_client is not None
-            ), "heter client should not be None in heterps mode"
+            assert self._heter_client is not None, (
+                "heter client should not be None in heterps mode"
+            )
             self._heter_client.stop()
         # executor = self._get_executor()
         # executor.close()

--- a/python/paddle/distributed/fleet/utils/hybrid_parallel_inference.py
+++ b/python/paddle/distributed/fleet/utils/hybrid_parallel_inference.py
@@ -250,9 +250,9 @@ class HybridParallelInferenceHelper:
                 dev_ids.append(cur_id)
         num_pp = len(dev_ids)
         num_pp = max(1, num_pp)
-        assert (
-            num_pp == self.num_pp
-        ), f'num_pp: {num_pp}, self.num_pp: {self.num_pp}'
+        assert num_pp == self.num_pp, (
+            f'num_pp: {num_pp}, self.num_pp: {self.num_pp}'
+        )
 
         collective_helper = fleet.meta_optimizers.common.CollectiveHelper(
             self.role_maker, wait_port=False
@@ -491,13 +491,13 @@ class HybridParallelInferenceHelper:
 
         pre_stage_id = None
         for op in block.ops:
-            assert op.has_attr(
-                self._op_role_key
-            ), f"{op.type} has no {self._op_role_key} set ."
+            assert op.has_attr(self._op_role_key), (
+                f"{op.type} has no {self._op_role_key} set ."
+            )
             op_role = op.attr(self._op_role_key)
-            assert op_role == int(
-                self._op_role.Forward
-            ), "Only forward is supported for inference."
+            assert op_role == int(self._op_role.Forward), (
+                "Only forward is supported for inference."
+            )
             if not op._has_kernel(op.type):
                 assert op.type in [
                     "while",
@@ -506,9 +506,9 @@ class HybridParallelInferenceHelper:
                 sub_block_id = op.attr('sub_block').id
                 sub_block = block.program.block(sub_block_id)
                 self._check_validation(sub_block)
-            assert op.has_attr(
-                self._op_device_key
-            ), f"{op.type} has no {self._op_device_key} set."
+            assert op.has_attr(self._op_device_key), (
+                f"{op.type} has no {self._op_device_key} set."
+            )
 
             device = op.attr(self._op_device_key)
             assert device, f"{op.type} has no {self._op_device_key} set."
@@ -571,9 +571,9 @@ class HybridParallelInferenceHelper:
                 if (cur_device, prev_device) in input_var_to_device[var_name]:
                     continue
 
-                assert (
-                    self._device == cur_device.split(':')[0]
-                ), "More than one device type found."
+                assert self._device == cur_device.split(':')[0], (
+                    "More than one device type found."
+                )
                 device_type = cur_device.split(':')[0] + ':'
 
                 def _insert_send_recv(cur_id, prev_id):

--- a/python/paddle/distributed/fleet/utils/hybrid_parallel_util.py
+++ b/python/paddle/distributed/fleet/utils/hybrid_parallel_util.py
@@ -51,9 +51,9 @@ def _apply_collective_grads(parameters, comm_group, bucket_size, scale=None):
     for param in parameters:
         if param.trainable and (param._grad_ivar() is not None):
             g_var = param._grad_ivar()
-            assert (
-                not g_var._is_sparse()
-            ), "Now, it doesn't support sparse parameters"
+            assert not g_var._is_sparse(), (
+                "Now, it doesn't support sparse parameters"
+            )
             grad_vars.append(g_var)
             assert g_var not in grad_var_set
             grad_var_set.add(g_var)
@@ -98,9 +98,9 @@ def _apply_collective_grads_eager(
             assert param._grad_ivar() is None, "param.grad is not None"
             g_var = param.main_grad
         if g_var is not None:
-            assert (
-                not g_var.is_sparse()
-            ), "Now, it doesn't support sparse parameters"
+            assert not g_var.is_sparse(), (
+                "Now, it doesn't support sparse parameters"
+            )
             grad_vars.append(g_var)
             assert g_var not in grad_var_set
             grad_var_set.add(g_var)
@@ -268,9 +268,9 @@ def fused_allreduce_gradients(parameter_list, hcg):
     if hcg is not None:
         dp_enabled = hcg.get_data_parallel_world_size() > 1
         sep_enabled = hcg.get_sep_parallel_world_size() > 1
-        assert (
-            dp_enabled or sep_enabled
-        ), f"dp_enabled {dp_enabled}; sep_enabled {sep_enabled}"
+        assert dp_enabled or sep_enabled, (
+            f"dp_enabled {dp_enabled}; sep_enabled {sep_enabled}"
+        )
         group = None
         # sep all reduce is not scaled
         scale = 1.0

--- a/python/paddle/distributed/fleet/utils/mix_precision_utils.py
+++ b/python/paddle/distributed/fleet/utils/mix_precision_utils.py
@@ -52,9 +52,9 @@ class MixPrecisionLayer(nn.Layer):
         # Hook used for back-prop and grad-merge.
         @paddle.autograd.no_grad()
         def param_hook(tmp_grad):
-            assert (
-                param.grad is None
-            ), f"In main_grad node, param.grad should be None, but find param[{param.name}] has grad."
+            assert param.grad is None, (
+                f"In main_grad node, param.grad should be None, but find param[{param.name}] has grad."
+            )
             if tmp_grad is not None and tmp_grad._is_initialized():
                 # Some previous pylayer may return None, should check grad validation.
                 if param.main_grad is None:

--- a/python/paddle/distributed/fleet/utils/pp_parallel_adaptor.py
+++ b/python/paddle/distributed/fleet/utils/pp_parallel_adaptor.py
@@ -545,9 +545,9 @@ def parse_args():
     if args.dst_pp is None:
         args.dst_pp = args.src_pp
 
-    assert (
-        args.src_mp == args.dst_mp
-    ), f"src mp {args.src_mp} dst mp {args.dst_mp}"
+    assert args.src_mp == args.dst_mp, (
+        f"src mp {args.src_mp} dst mp {args.dst_mp}"
+    )
 
     assert args.method in [
         'peek_model',

--- a/python/paddle/distributed/fleet/utils/sequence_parallel_utils.py
+++ b/python/paddle/distributed/fleet/utils/sequence_parallel_utils.py
@@ -459,8 +459,7 @@ class ColumnSequenceParallelLinear(Layer):
         self._name = name
         self.is_mp = self.world_size > 1
         assert gather_output is False, (
-            "If sequence_parallel is True, \
-                                        gather_output is False"
+            "If sequence_parallel is True, gather_output is False"
         )
 
         self.gather_output = gather_output
@@ -596,8 +595,7 @@ class RowSequenceParallelLinear(Layer):
         self.in_features = in_features
         self.out_features = out_features
         assert input_is_parallel is True, (
-            "If sequence_parallel is True, \
-                                           input_is_parallel should be true."
+            "If sequence_parallel is True, input_is_parallel should be true."
         )
 
         self.input_is_parallel = input_is_parallel

--- a/python/paddle/distributed/fleet/utils/sequence_parallel_utils.py
+++ b/python/paddle/distributed/fleet/utils/sequence_parallel_utils.py
@@ -48,9 +48,9 @@ def scatter(input):
     parallelism = group.nranks
     rank = group.rank
     seq_len = input.shape[0]
-    assert (
-        seq_len % parallelism == 0
-    ), f"Input sequence length {seq_len} can't be divided exactly by sequence parallelism {parallelism}"
+    assert seq_len % parallelism == 0, (
+        f"Input sequence length {seq_len} can't be divided exactly by sequence parallelism {parallelism}"
+    )
     interval = seq_len // parallelism
     input = paddle.slice(
         input, axes=[0], starts=[interval * rank], ends=[interval * (rank + 1)]
@@ -74,9 +74,9 @@ def reduce_scatter(input):
     group = hcg.get_model_parallel_group()
     parallelism = group.nranks
     output_shape = input.shape
-    assert (
-        input.shape[0] % parallelism == 0
-    ), f"Input sequence length {input.shape[0]} can't be divided exactly by sequence parallelism {parallelism}"
+    assert input.shape[0] % parallelism == 0, (
+        f"Input sequence length {input.shape[0]} can't be divided exactly by sequence parallelism {parallelism}"
+    )
     output_shape[0] = output_shape[0] // parallelism
     output = paddle.empty(shape=output_shape, dtype=input.dtype)
     dist.stream.reduce_scatter(
@@ -318,9 +318,9 @@ class SPInnerOverlapLinear(paddle.autograd.PyLayer):
                 dy, paddle.cast(weight, dtype=dy.dtype), transpose_y=True
             )
 
-        assert (
-            dinput_parallel.shape[0] % parallelism == 0
-        ), f"Input sequence length {dinput_parallel.shape[0]} can't be divided exactly by sequence parallelism {parallelism}"
+        assert dinput_parallel.shape[0] % parallelism == 0, (
+            f"Input sequence length {dinput_parallel.shape[0]} can't be divided exactly by sequence parallelism {parallelism}"
+        )
 
         if ctx.recompute_allgather:
             # wait the finish of all-gather of x
@@ -452,16 +452,16 @@ class ColumnSequenceParallelLinear(Layer):
             if mp_group is None
             else mp_group.nranks
         )
-        assert (
-            self.world_size > 1
-        ), "tensor parallel degree must be greater than 1 in sequence parallel"
+        assert self.world_size > 1, (
+            "tensor parallel degree must be greater than 1 in sequence parallel"
+        )
 
         self._name = name
         self.is_mp = self.world_size > 1
-        assert (
-            gather_output is False
-        ), "If sequence_parallel is True, \
+        assert gather_output is False, (
+            "If sequence_parallel is True, \
                                         gather_output is False"
+        )
 
         self.gather_output = gather_output
         assert out_features % self.world_size == 0, (
@@ -595,10 +595,10 @@ class RowSequenceParallelLinear(Layer):
 
         self.in_features = in_features
         self.out_features = out_features
-        assert (
-            input_is_parallel is True
-        ), "If sequence_parallel is True, \
+        assert input_is_parallel is True, (
+            "If sequence_parallel is True, \
                                            input_is_parallel should be true."
+        )
 
         self.input_is_parallel = input_is_parallel
         self._weight_attr = weight_attr

--- a/python/paddle/distributed/fleet/utils/tensor_fusion_helper.py
+++ b/python/paddle/distributed/fleet/utils/tensor_fusion_helper.py
@@ -66,9 +66,9 @@ def get_current_device_type():
                 device_type = current_device.get_device_type()
             except:
                 device_type = "unknown"
-        assert (
-            device_type in alignment.keys()
-        ), f"tensor fusion helper now only support {alignment.keys()}, but got device {device_type} instead."
+        assert device_type in alignment.keys(), (
+            f"tensor fusion helper now only support {alignment.keys()}, but got device {device_type} instead."
+        )
         __current_device_type__ = device_type
     return __current_device_type__
 
@@ -458,17 +458,17 @@ class FusedCommBuffer:
         self.sync_param_task = None
 
         if self._free_grads_in_comm:
-            assert (
-                acc_steps == 1
-            ), f"No need to use free_grads_in_comm when acc_steps `{acc_steps}` != 1"
-            assert (
-                act == HOOK_ACTION.REDUCE_SCATTER
-            ), "Currently, only support reduce_scatter"
+            assert acc_steps == 1, (
+                f"No need to use free_grads_in_comm when acc_steps `{acc_steps}` != 1"
+            )
+            assert act == HOOK_ACTION.REDUCE_SCATTER, (
+                "Currently, only support reduce_scatter"
+            )
             assert release_grads, "Currently, only support release_grads"
 
-        assert not (
-            self._fuse_param and self._release_grads
-        ), "It's not supported when using fuse_param and release_grad at the same time."
+        assert not (self._fuse_param and self._release_grads), (
+            "It's not supported when using fuse_param and release_grad at the same time."
+        )
 
         self.use_main_grad = (
             use_main_grad
@@ -605,9 +605,9 @@ class FusedCommBuffer:
             )
 
         if self._act == HOOK_ACTION.REDUCE_SCATTER:
-            self._sharding_param_grad_view[param.name]._grad_buffer = (
-                self.grad_storage
-            )
+            self._sharding_param_grad_view[
+                param.name
+            ]._grad_buffer = self.grad_storage
             tmp_var = self._sharding_param_grad_view[
                 param.name
             ]._slice_grad_from_buffer()
@@ -619,9 +619,9 @@ class FusedCommBuffer:
             )
 
         grad_var = param.main_grad if self.use_main_grad else param.grad
-        assert (
-            grad_var is not None
-        ), f"The current parameter[{param.name}] has no gradient, its stop_grdient is {param.stop_gradient}"
+        assert grad_var is not None, (
+            f"The current parameter[{param.name}] has no gradient, its stop_grdient is {param.stop_gradient}"
+        )
         grad_var.stop_gradient = True
         grad_var.flatten_()
 
@@ -1032,9 +1032,9 @@ def fused_parameters(
 
     if comm_overlap:
         if comm_group is None:
-            assert (
-                act == HOOK_ACTION.ALL_REDUCE
-            ), "Only allreduce action can use default comm group"
+            assert act == HOOK_ACTION.ALL_REDUCE, (
+                "Only allreduce action can use default comm group"
+            )
             comm_group = paddle.distributed.collective._get_default_group()
     if act == HOOK_ACTION.REDUCE:
         assert dst != -1
@@ -1045,12 +1045,12 @@ def fused_parameters(
         updated_parameters = []
         comm_buffers = []
         for idx, group_param in enumerate(parameters):
-            assert isinstance(
-                group_param, dict
-            ), "For group params, each group should be a dictionary."
-            assert (
-                'params' in group_param.keys()
-            ), "For group params, each group should have parameters."
+            assert isinstance(group_param, dict), (
+                "For group params, each group should be a dictionary."
+            )
+            assert 'params' in group_param.keys(), (
+                "For group params, each group should have parameters."
+            )
             real_param = group_param['params']
             (
                 group_decay_fused,

--- a/python/paddle/distributed/fleet/utils/tensor_parallel_utils.py
+++ b/python/paddle/distributed/fleet/utils/tensor_parallel_utils.py
@@ -84,10 +84,10 @@ def resolute_tensor_parallel_ring_id(program):
             if ring_id is None:
                 ring_id = int(op.attr("ring_id"))
             else:
-                assert ring_id == int(
-                    op.attr("ring_id")
-                ), "Found two different ring_id for Tensor Parallel: ring_id={} and ring_id={}.".format(
-                    ring_id, int(op.attr("ring_id"))
+                assert ring_id == int(op.attr("ring_id")), (
+                    "Found two different ring_id for Tensor Parallel: ring_id={} and ring_id={}.".format(
+                        ring_id, int(op.attr("ring_id"))
+                    )
                 )
     assert ring_id is not None, "Could NOT found ring_id for Tensor Parallel."
 
@@ -113,9 +113,9 @@ def copy_parameters(block_, params):
             error_clip=param.error_clip,
             name=param.name,
         )
-        assert (
-            param.is_distributed is False
-        ), f"Try to sync Distributed Parameter: {param}"
+        assert param.is_distributed is False, (
+            f"Try to sync Distributed Parameter: {param}"
+        )
         new_p.is_distributed = False
 
     block_.vars[new_p.name] = new_p
@@ -269,9 +269,9 @@ def insert_synchronization(
                         op_role,
                     )
 
-    assert (
-        len(unsync_param_names) == 0
-    ), f"The following param is unsync by some error: {unsync_param_names}"
+    assert len(unsync_param_names) == 0, (
+        f"The following param is unsync by some error: {unsync_param_names}"
+    )
 
 
 def add_extra_synchronization(
@@ -314,9 +314,9 @@ def add_extra_synchronization(
 
     # adopt for pipeline opt
     if program._pipeline_opt is not None:
-        assert (
-            program._pipeline_opt['section_program'] is not None
-        ), "Pipeline is enable but section_program is None"
+        assert program._pipeline_opt['section_program'] is not None, (
+            "Pipeline is enable but section_program is None"
+        )
         program = program._pipeline_opt['section_program']
 
     # step1: collect the param that need to be sync

--- a/python/paddle/distributed/fleet/utils/timer_helper.py
+++ b/python/paddle/distributed/fleet/utils/timer_helper.py
@@ -117,9 +117,9 @@ class Timers:
             timer = clazz(name)
             self.timers[name] = timer
         else:
-            assert (
-                type(timer) == clazz
-            ), f"Invalid timer type: {clazz} vs {type(timer)}"
+            assert type(timer) == clazz, (
+                f"Invalid timer type: {clazz} vs {type(timer)}"
+            )
         return timer
 
     def log(self, names, normalizer=1.0, reset=True):

--- a/python/paddle/distributed/flex_checkpoint/aoa/aoa_engine.py
+++ b/python/paddle/distributed/flex_checkpoint/aoa/aoa_engine.py
@@ -83,7 +83,7 @@ class AoAShardInfoContext:
                 f"layer_id_macro_tag '{layer_id_macro_tag}' not in name_with_layer_id '{name_with_layer_id}'"
             )
         prefix, suffix = name_with_layer_id.split(layer_id_macro_tag, 1)
-        pattern = re.compile(fr"{re.escape(prefix)}(\d+){re.escape(suffix)}")
+        pattern = re.compile(rf"{re.escape(prefix)}(\d+){re.escape(suffix)}")
         max_layer = 0
         for key in self.get_all_dst_state_keys():
             match = pattern.fullmatch(key)
@@ -155,7 +155,6 @@ class AoAEngine:
             sub_dst_slice[axis] = slice(0, sz)
             sub_slices = []
             for aidx, src_sl, dst_sl in tensor.slices:
-
                 dst_start = (
                     dst_sl[axis].start if dst_sl[axis].start is not None else 0
                 )

--- a/python/paddle/distributed/flex_checkpoint/aoa/lexer.py
+++ b/python/paddle/distributed/flex_checkpoint/aoa/lexer.py
@@ -55,7 +55,7 @@ def star_macro(tokens, expression, context):
         return expression
 
     def _sort_keys_by_numeric_part(prefix, suffix, allkeys):
-        pattern = re.compile(fr"{re.escape(prefix)}(\d+){re.escape(suffix)}")
+        pattern = re.compile(rf"{re.escape(prefix)}(\d+){re.escape(suffix)}")
         filtered_keys = []
         for key in allkeys:
             match = pattern.match(key)
@@ -77,9 +77,9 @@ def star_macro(tokens, expression, context):
                 if not pre_rarrow
                 else context.get_all_dst_state_keys()
             )
-            assert (
-                len(allkeys) != 0
-            ), f"No keys found with prefix {prefix} and suffix {suffix}!"
+            assert len(allkeys) != 0, (
+                f"No keys found with prefix {prefix} and suffix {suffix}!"
+            )
             keys = list(_sort_keys_by_numeric_part(prefix, suffix, allkeys))
             for key in keys:
                 new_tokens.append(Token(TokenType.IDENTIFIER, key))
@@ -198,14 +198,14 @@ def fused_qkv_macro(tokens, expression, context):
             right_var_end_pos = idx + 1
 
     assert attn_head_num and attn_head_num > 0, "num_heads must be positive."
-    assert (
-        num_key_value_groups and num_key_value_groups > 0
-    ), "num_key_value_groups must be positive."
+    assert num_key_value_groups and num_key_value_groups > 0, (
+        "num_key_value_groups must be positive."
+    )
     assert fused_qkv_pos is not None, "No fused_qkv tag found in expression."
     assert rarrow_pos is not None, "No -> found in expression."
-    assert (
-        attn_head_num % num_key_value_groups == 0
-    ), "num_heads must be divisible by num_key_value_groups."
+    assert attn_head_num % num_key_value_groups == 0, (
+        "num_heads must be divisible by num_key_value_groups."
+    )
 
     num_key_value_heads = attn_head_num // num_key_value_groups
 
@@ -278,9 +278,9 @@ def fused_ffn_macro(tokens, expression, context):
     FUSED_FFN_TAG = "fused_ffn"
     if FUSED_FFN_TAG not in expression:
         return expression
-    assert (
-        len(tokens) == 5 and tokens[4].value == FUSED_FFN_TAG
-    ), "Invalid tokens for FUSED_FFN operation ！"
+    assert len(tokens) == 5 and tokens[4].value == FUSED_FFN_TAG, (
+        "Invalid tokens for FUSED_FFN operation ！"
+    )
     src_ffn_weight_name = tokens[2].value
     dst_ffn_weight_name = tokens[0].value
     src_state_shard_num = context.get_src_state_shard_num(src_ffn_weight_name)

--- a/python/paddle/distributed/flex_checkpoint/dcp/load_state_dict.py
+++ b/python/paddle/distributed/flex_checkpoint/dcp/load_state_dict.py
@@ -72,17 +72,17 @@ def get_checkpoint_files(path, use_cache=True, unique_id=None):
         for file in accessible_files
         if file.endswith(f"{unique_id}.metadata")
     ]
-    assert (
-        len(metadata_files) > 0
-    ), f"No metadata file ends with '{unique_id}.metadata' found in the checkpoint directory: {path}."
+    assert len(metadata_files) > 0, (
+        f"No metadata file ends with '{unique_id}.metadata' found in the checkpoint directory: {path}."
+    )
     local_data_files = [
         file
         for file in accessible_files
         if file.endswith(f"{unique_id}.distcp")
     ]
-    assert (
-        len(local_data_files) > 0
-    ), f"No data file ends with '{unique_id}.distcp' found in the checkpoint directory:{path}."
+    assert len(local_data_files) > 0, (
+        f"No data file ends with '{unique_id}.distcp' found in the checkpoint directory:{path}."
+    )
     if use_cache:
         PATH_TO_CHECKPOINT_FILES[path] = (metadata_files, local_data_files)
     return (metadata_files, local_data_files)
@@ -107,9 +107,9 @@ def get_rank_to_files(
 
     for metadata in metadata_list:
         for local_tensor_index, file_name in metadata.storage_metadata.items():
-            assert (
-                local_tensor_index not in tensor_key_list
-            ), f"Duplicate tensor_key:{local_tensor_index} found. Check whether the metadata."
+            assert local_tensor_index not in tensor_key_list, (
+                f"Duplicate tensor_key:{local_tensor_index} found. Check whether the metadata."
+            )
             tensor_key_list.append(local_tensor_index.tensor_key)
             if local_tensor_index.tensor_key in state_dict:
                 necessary_files.append(file_name)
@@ -153,7 +153,9 @@ def get_rank_to_files(
     assert (
         global_data_files_set & global_necessary_files_set
         == global_necessary_files_set
-    ), f"The checkpoint files are not complete. Please check the checkpoint directory. global_data_files_set:{global_data_files_set}, necessary_data_files_set:{global_necessary_files_set}"
+    ), (
+        f"The checkpoint files are not complete. Please check the checkpoint directory. global_data_files_set:{global_data_files_set}, necessary_data_files_set:{global_necessary_files_set}"
+    )
     missing_keys = set(state_dict.keys()) - set(tensor_key_list)
     if len(missing_keys) > 0:
         if mw_name_compatibility:
@@ -424,9 +426,9 @@ def compute_overlap(
                 f"Invalid begin_offset:{begin_offset}, cur_offset:{cur_offset}, storage_offset:{storage_offset}"
             )
         lengths.append(end_offset - begin_offset)
-        assert (
-            lengths[-1] >= 0
-        ), f"Invalid length:{lengths[-1]}, end_offset:{end_offset}, begin_offset:{begin_offset}"
+        assert lengths[-1] >= 0, (
+            f"Invalid length:{lengths[-1]}, end_offset:{end_offset}, begin_offset:{begin_offset}"
+        )
     return cur_offsets, storage_offsets, lengths
 
 
@@ -501,9 +503,9 @@ def get_read_items(metadata_list, state_dict, process_group, use_dist):
         cur_chunk_metadata = LocalTensorMetadata(
             global_offset, local_shape, dtype
         )
-        assert (
-            tensor_key in storage_state_dict_metadata
-        ), f"tensor_key:{tensor_key} not found in storage_state_dict_metadata:{storage_state_dict_metadata}."
+        assert tensor_key in storage_state_dict_metadata, (
+            f"tensor_key:{tensor_key} not found in storage_state_dict_metadata:{storage_state_dict_metadata}."
+        )
         for storage_local_tensor_metadata in storage_state_dict_metadata[
             tensor_key
         ]:
@@ -671,9 +673,9 @@ def load_state_dict(
         else:
             load_dict = {}
             for key, val in state_dict.items():
-                assert (
-                    val.local_shape == val.global_shape
-                ), f"{key} is not replicated !"
+                assert val.local_shape == val.global_shape, (
+                    f"{key} is not replicated !"
+                )
                 load_dict[key] = val.local_tensor
 
             load_state_dict_impl(
@@ -708,15 +710,15 @@ def load_state_dict_impl(
     mw_name_compatibility: bool = True,
 ) -> None:
     with paddle.base.dygraph.guard():
-        assert isinstance(
-            state_dict, dict
-        ), "The state_dict should be a dictionary."
+        assert isinstance(state_dict, dict), (
+            "The state_dict should be a dictionary."
+        )
         flat_state_dict, mapping = flatten_state_dict(state_dict)
         if len(flat_state_dict) > 0:
             for val in flat_state_dict.values():
-                assert isinstance(
-                    val, (paddle.Tensor, ShardedWeight)
-                ), f"The value of state_dict should be a paddle.Tensor, but got: {val}."
+                assert isinstance(val, (paddle.Tensor, ShardedWeight)), (
+                    f"The value of state_dict should be a paddle.Tensor, but got: {val}."
+                )
 
         use_dist = True if paddle.distributed.get_world_size() > 1 else False
 
@@ -824,7 +826,6 @@ def _load_state_dict(
     offload=False,
 ) -> None:
     with paddle.base.dygraph.guard():
-
         use_dist = True if paddle.distributed.get_world_size() > 1 else False
 
         local_load_files = list(source_state_dict.keys())
@@ -855,9 +856,9 @@ def _load_state_dict(
                     copied_target_state_dict[key] = copied_target_state_dict[
                         key
                     ].cuda()
-            assert (
-                item.local_tensor_index in load_infos
-            ), f"read item:{item}, load_infos:{load_infos}"
+            assert item.local_tensor_index in load_infos, (
+                f"read item:{item}, load_infos:{load_infos}"
+            )
 
             logger.debug(f"read item: {item}")
             src_rank, file_name = load_infos[item.local_tensor_index]

--- a/python/paddle/distributed/flex_checkpoint/dcp/reshard.py
+++ b/python/paddle/distributed/flex_checkpoint/dcp/reshard.py
@@ -134,9 +134,9 @@ def validate_sharded_state_dict_boundaries(state_dict_shard_info):
                 shard
             )
             ndim = len(global_shape)
-            assert (
-                len(local_shape) == ndim == len(global_offset)
-            ), f"{tensor_key}: shape/offset dims mismatch"
+            assert len(local_shape) == ndim == len(global_offset), (
+                f"{tensor_key}: shape/offset dims mismatch"
+            )
             for d in range(ndim):
                 gs = global_shape[d]
                 ls = local_shape[d]
@@ -192,7 +192,6 @@ def reshard_sharded_state_dict(
     offload: bool | None = False,
     aoa_config: dist[str, list[str]] | None = None,
 ) -> None:
-
     local_src_state_dict_shard_info = {
         key: (
             value.global_offset,

--- a/python/paddle/distributed/flex_checkpoint/dcp/save_state_dict.py
+++ b/python/paddle/distributed/flex_checkpoint/dcp/save_state_dict.py
@@ -86,9 +86,9 @@ def copy_dict_to_cpu(nested_dict):
 
 
 def merge_state_dict_metadata(global_state_dict_metadata):
-    assert isinstance(
-        global_state_dict_metadata, list
-    ), "The global_state_dict should be a list."
+    assert isinstance(global_state_dict_metadata, list), (
+        "The global_state_dict should be a list."
+    )
     out = {}
     for state_dict in global_state_dict_metadata:
         for key, val in state_dict.items():
@@ -272,9 +272,9 @@ def save_state_dict(
         else:
             save_dict = {}
             for key, val in state_dict.items():
-                assert (
-                    val.local_shape == val.global_shape
-                ), f"{key} is not replicated !"
+                assert val.local_shape == val.global_shape, (
+                    f"{key} is not replicated !"
+                )
                 save_dict[key] = val.local_tensor
 
         save_state_dict_impl(
@@ -305,15 +305,15 @@ def save_state_dict_impl(
     async_save: bool = False,
 ) -> None:
     with paddle.base.dygraph.guard():
-        assert isinstance(
-            state_dict, dict
-        ), "The state_dict should be a dictionary."
+        assert isinstance(state_dict, dict), (
+            "The state_dict should be a dictionary."
+        )
         flat_state_dict, mapping = flatten_state_dict(state_dict)
         if len(flat_state_dict) > 0:
             for val in flat_state_dict.values():
-                assert isinstance(
-                    val, (paddle.Tensor, ShardedWeight)
-                ), f"The value of state_dict should be a paddle.Tensor or ShardedWeight, but got: {val}."
+                assert isinstance(val, (paddle.Tensor, ShardedWeight)), (
+                    f"The value of state_dict should be a paddle.Tensor or ShardedWeight, but got: {val}."
+                )
 
         if not os.path.exists(path):
             os.makedirs(path, exist_ok=True)

--- a/python/paddle/distributed/flex_checkpoint/dcp/utils.py
+++ b/python/paddle/distributed/flex_checkpoint/dcp/utils.py
@@ -55,7 +55,6 @@ def compute_local_shape_and_global_offset(
     process_mesh: core.ProcessMesh,
     placements: list[core.Placement],
 ) -> tuple[tuple[int], tuple[int]]:
-
     from paddle.distributed.auto_parallel.placement_type import (
         placemetns_to_dist_status,
     )
@@ -124,9 +123,9 @@ def unflatten_state_dict(flat_state_dict, mapping):
     state_dict = {}
     for key, value in flat_state_dict.items():
         key_tuple = mapping[key]
-        assert isinstance(
-            key_tuple, tuple
-        ), f"The key should be tuple, but is {key_tuple}"
+        assert isinstance(key_tuple, tuple), (
+            f"The key should be tuple, but is {key_tuple}"
+        )
         tmp = state_dict
         for i in range(len(key_tuple) - 1):
             key = key_tuple[i]


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

使用性能更好，格式化效果更佳的 ruff format 替代 black 作为新的 formatter，由于我们很早就已经集成了 ruff lint，因此只是减少依赖而不会增加依赖

<!--

## 核心优势

通过集成 Ruff format，开发者可以享受到以下优势：

- 通过去除 black 对 python 环境依赖，极大降低了升级 formatter 带来的成本，后续无需考虑开发者本地 python 环境即可一键升级
- ruff 由 Rust 驱动，大幅加速 format 时间，降低开发者使用开发工具链的时间成本，减少 CI 时间，提升工程效率
- 格式化后呈现可读性更佳的效果，使得开发者更专注于代码开发而无需关心格式，阅读者也能够更加赏心悦目，极大增加了潜在贡献者的贡献意愿
- ruff 极大程度地兼容了 black 的格式化效果，能够平滑地替换现有的 black 配置
- ruff 更新频次高，能够快速响应社区反馈，持续优化格式化效果
- ruff 团队 Astral 最近开发的 ty 能够提供更强大的类型检查能力，后续可能与 ruff 集成，提供更好的开发体验
- PyTorch 最近已经完成迁移，追平竞品（在代码风格这块，我们一直做到了超越竞品，这次不能落后）

-->