### PR TITLE
[CodeStyle] `black -> ruff format` migration - part 30

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -85,7 +85,7 @@ repos:
 
             # | python/paddle/distributed/[g-z].+
 
-            # | python/paddle/[e-i].+
+            | python/paddle/[e-i].+
 
             # | python/paddle/j.+
 
@@ -141,7 +141,7 @@ repos:
 
             | python/paddle/distributed/[g-z].+
 
-            | python/paddle/[e-i].+
+            # | python/paddle/[e-i].+
 
             | python/paddle/j.+
 

--- a/python/paddle/framework/io.py
+++ b/python/paddle/framework/io.py
@@ -235,9 +235,9 @@ def _load_state_dict_from_save_inference_model(model_path, config):
                 structured_name = extra_var_info[var_name].get(
                     'structured_name', None
                 )
-                assert (
-                    structured_name is not None
-                ), f"Cannot find saved variable ({var_name})'s structured name in saved model."
+                assert structured_name is not None, (
+                    f"Cannot find saved variable ({var_name})'s structured name in saved model."
+                )
                 structured_para_dict[structured_name] = load_param_dict[
                     var_name
                 ]

--- a/python/paddle/hapi/model.py
+++ b/python/paddle/hapi/model.py
@@ -368,13 +368,13 @@ class StaticPIRGraphAdapter:
         self.model.mode = value
 
     def train_batch(self, inputs, labels=None, update=True):
-        assert (
-            self.model._optimizer
-        ), "model not ready, please call `model.prepare()` first"
+        assert self.model._optimizer, (
+            "model not ready, please call `model.prepare()` first"
+        )
         self.mode = 'train'
-        assert (
-            update is True
-        ), "Does not support `update == False` in static graph mode by now."
+        assert update is True, (
+            "Does not support `update == False` in static graph mode by now."
+        )
         return self._run(inputs, labels)
 
     def eval_batch(self, inputs, labels=None):
@@ -500,16 +500,16 @@ class StaticPIRGraphAdapter:
                 # However, dygraph wouldn't save it.
                 if var.name not in state:
                     continue
-            assert (
-                var.name in converted_state
-            ), f"variable [{var.name}] is not in optimizer state file"
+            assert var.name in converted_state, (
+                f"variable [{var.name}] is not in optimizer state file"
+            )
             self._set_var(var.name, converted_state[var.name])
 
     def _run(self, inputs, labels=None):
         compiled_prog = self._compiled_progs.get(self.mode, None)
-        assert (
-            compiled_prog
-        ), "Model is not ready, please call `model.prepare()` first"
+        assert compiled_prog, (
+            "Model is not ready, please call `model.prepare()` first"
+        )
 
         inputs = to_list(inputs)
         if labels is not None:
@@ -689,9 +689,9 @@ class StaticPIRGraphAdapter:
         }
 
     def _initialize(self, prog, mode):
-        assert (
-            self.model._place is not None
-        ), "device is not set, please call `model.prepare()` first"
+        assert self.model._place is not None, (
+            "device is not set, please call `model.prepare()` first"
+        )
 
         place = self.model._place
 
@@ -756,13 +756,13 @@ class StaticGraphAdapter:
         self.model.mode = value
 
     def train_batch(self, inputs, labels=None, update=True):
-        assert (
-            self.model._optimizer
-        ), "model not ready, please call `model.prepare()` first"
+        assert self.model._optimizer, (
+            "model not ready, please call `model.prepare()` first"
+        )
         self.mode = 'train'
-        assert (
-            update is True
-        ), "Does not support `update == False` in static graph mode by now."
+        assert update is True, (
+            "Does not support `update == False` in static graph mode by now."
+        )
         return self._run(inputs, labels)
 
     def eval_batch(self, inputs, labels=None):
@@ -919,9 +919,9 @@ class StaticGraphAdapter:
                                 converted_state.pop(dy_state_name)
                             )
 
-            assert (
-                var.name in converted_state
-            ), f"variable [{var.name}] is not in optimizer state file"
+            assert var.name in converted_state, (
+                f"variable [{var.name}] is not in optimizer state file"
+            )
             self._set_var(var, converted_state[var.name])
 
     def _set_var(self, var, ndarray):
@@ -940,9 +940,9 @@ class StaticGraphAdapter:
 
     def _run(self, inputs, labels=None):
         compiled_prog = self._compiled_progs.get(self.mode, None)
-        assert (
-            compiled_prog
-        ), "Model is not ready, please call `model.prepare()` first"
+        assert compiled_prog, (
+            "Model is not ready, please call `model.prepare()` first"
+        )
 
         inputs = to_list(inputs)
         if labels is not None:
@@ -1141,9 +1141,9 @@ class StaticGraphAdapter:
         if compiled_prog is not None:
             return compiled_prog
 
-        assert (
-            self.model._place is not None
-        ), "device is not set, please call `model.prepare()` first"
+        assert self.model._place is not None, (
+            "device is not set, please call `model.prepare()` first"
+        )
 
         place = self.model._place
 
@@ -1234,9 +1234,9 @@ class DynamicGraphAdapter:
 
     # TODO multi device in dygraph mode not implemented at present time
     def train_batch(self, inputs, labels=None, update=True):
-        assert (
-            self.model._optimizer
-        ), "model not ready, please call `model.prepare()` first"
+        assert self.model._optimizer, (
+            "model not ready, please call `model.prepare()` first"
+        )
         self.model.network.train()
         self.mode = 'train'
         inputs = to_list(inputs)
@@ -2031,7 +2031,9 @@ class Model:
                 assert isinstance(
                     self._optimizer._grad_clip,
                     (paddle.nn.ClipGradByGlobalNorm, paddle.nn.ClipGradByNorm),
-                ), "Only ClipGradByNorm and ClipGradByGlobalNorm are supported in amp training with level=O2 currently."
+                ), (
+                    "Only ClipGradByNorm and ClipGradByGlobalNorm are supported in amp training with level=O2 currently."
+                )
 
         self._adapter._amp_custom_lists = {}
         self._adapter._amp_configs = {}
@@ -2188,9 +2190,9 @@ class Model:
 
         metrics = metrics or []
         for metric in to_list(metrics):
-            assert isinstance(
-                metric, Metric
-            ), f"{metric.__class__.__name__} is not sub class of Metric"
+            assert isinstance(metric, Metric), (
+                f"{metric.__class__.__name__} is not sub class of Metric"
+            )
         self._metrics = to_list(metrics)
         self._prepare_amp(amp_configs)
 
@@ -2353,9 +2355,9 @@ class Model:
         if isinstance(batch_size, (tuple, list)) and all(
             isinstance(x, int) for x in batch_size
         ):
-            assert (
-                len(batch_size) == 2
-            ), "batch_size length error, expected train_batch_size and eval_batch_size."
+            assert len(batch_size) == 2, (
+                "batch_size length error, expected train_batch_size and eval_batch_size."
+            )
             train_batch_size, eval_batch_size = batch_size
         elif isinstance(batch_size, int):
             train_batch_size, eval_batch_size = batch_size, batch_size
@@ -2748,9 +2750,9 @@ class Model:
             params_filename = file_prefix + INFER_PARAMS_SUFFIX
 
             prog = self._adapter._progs.get('test', None)
-            assert (
-                prog
-            ), "Model is not ready, please call `model.prepare()` first"
+            assert prog, (
+                "Model is not ready, please call `model.prepare()` first"
+            )
 
             if in_pir_mode():
                 infer_prog = prog
@@ -2914,9 +2916,9 @@ class Model:
                 {'total_params': 61610, 'trainable_params': 61610}
 
         """
-        assert (
-            input_size is not None or self._inputs is not None
-        ), "'input_size' or 'self._input' must be set"
+        assert input_size is not None or self._inputs is not None, (
+            "'input_size' or 'self._input' must be set"
+        )
         if input_size is not None:
             _input_size = input_size
         else:

--- a/python/paddle/hapi/model_summary.py
+++ b/python/paddle/hapi/model_summary.py
@@ -348,10 +348,10 @@ def summary(
         for item in input_size:
             if isinstance(item, int):
                 item = (item,)
-            assert isinstance(
-                item, (tuple, InputSpec)
-            ), f'When input_size is list, \
+            assert isinstance(item, (tuple, InputSpec)), (
+                f'When input_size is list, \
             expect item in input_size is a tuple or InputSpec, but got {type(item)}'
+            )
 
             if isinstance(item, InputSpec):
                 _input_size.append(tuple(item.shape))

--- a/python/paddle/incubate/asp/asp.py
+++ b/python/paddle/incubate/asp/asp.py
@@ -464,9 +464,9 @@ def prune_model(
         'mask_2d_greedy': MaskAlgo.MASK_2D_GREEDY,
         'mask_2d_best': MaskAlgo.MASK_2D_BEST,
     }
-    assert (
-        mask_algo in MaskAlgo_mapping
-    ), 'The "mask_algo" should be one of ["mask_1d", "mask_2d_greedy", "mask_2d_best"]'
+    assert mask_algo in MaskAlgo_mapping, (
+        'The "mask_algo" should be one of ["mask_1d", "mask_2d_greedy", "mask_2d_best"]'
+    )
 
     prune_func = None
     if isinstance(model, paddle.nn.Layer):
@@ -685,9 +685,9 @@ class ASPHelper:
             target_program = None
             for param in layer.parameters():
                 target_program = param.block.program
-            assert (
-                target_program is not None
-            ), 'Cannot get paddle.static.Program from Paddle.nn.Layer.'
+            assert target_program is not None, (
+                'Cannot get paddle.static.Program from Paddle.nn.Layer.'
+            )
             return ASPHelper.prune_model_by_program(
                 place,
                 target_program,
@@ -795,7 +795,9 @@ class ASPHelper:
         return False
 
     @classmethod
-    def _get_prune_func_by_name(cls, param_name: str) -> Callable[
+    def _get_prune_func_by_name(
+        cls, param_name: str
+    ) -> Callable[
         [npt.NDArray[Any], int, int, MaskAlgo, str],
         tuple[npt.NDArray[Any], npt.NDArray[Any]],
     ]:
@@ -1036,9 +1038,9 @@ class OptimizerWithSparsityGuarantee:
         )
         for param_name, var in asp_info.mask_vars.items():
             param_mask_name = ASPHelper._get_mask_name(param_name)
-            assert (
-                param_mask_name in state_dict
-            ), f"The {param_mask_name} is not found."
+            assert param_mask_name in state_dict, (
+                f"The {param_mask_name} is not found."
+            )
             var.set_value(state_dict[param_mask_name])
             asp_info.update_masks(param_name, var.numpy())
         return self._optimizer.set_state_dict(state_dict)

--- a/python/paddle/incubate/asp/utils.py
+++ b/python/paddle/incubate/asp/utils.py
@@ -74,9 +74,9 @@ class CheckMethod(Enum):
                 >>> print(CheckMethod.get_checking_method(MaskAlgo.MASK_2D_BEST))
                 CheckMethod.CHECK_2D
         """
-        assert isinstance(
-            mask_algo, MaskAlgo
-        ), "mask_algo should be MaskAlgo type"
+        assert isinstance(mask_algo, MaskAlgo), (
+            "mask_algo should be MaskAlgo type"
+        )
         if mask_algo == MaskAlgo.MASK_1D:
             return CheckMethod.CHECK_1D
         else:

--- a/python/paddle/incubate/autograd/primreg.py
+++ b/python/paddle/incubate/autograd/primreg.py
@@ -23,9 +23,9 @@ class Registry:
         self.tab = {}
 
     def register(self, name, value):
-        assert (
-            name not in self.tab
-        ), f'name "{name}" should not be registered before.'
+        assert name not in self.tab, (
+            f'name "{name}" should not be registered before.'
+        )
         self.tab[name] = value
 
     def lookup(self, name):
@@ -92,17 +92,17 @@ def op_position_inputs(op):
 
     """
     args = _primop_position_argnames.lookup(op.type)
-    assert (
-        args is not None
-    ), f'args of {op.type} should not be None in op_position_inputs().'
+    assert args is not None, (
+        f'args of {op.type} should not be None in op_position_inputs().'
+    )
     *input_names, _ = args
 
     inputs = []
     for name in input_names:
         vars = list(map(op.block.var, op.input(name)))
-        assert (
-            len(vars) >= 0
-        ), f'len(vars) should be greater than or equal to 0, but len(vars)={len(vars)}.'
+        assert len(vars) >= 0, (
+            f'len(vars) should be greater than or equal to 0, but len(vars)={len(vars)}.'
+        )
         if len(vars) > 1:
             inputs.append(vars)
         else:
@@ -142,9 +142,9 @@ def op_position_output(op):
     *_, output_name = args
 
     outvars = list(map(op.block.var, op.output(output_name)))
-    assert (
-        len(outvars) >= 0
-    ), f'len(outvars) should be greater than or equal to 0, but len(outvars)={len(outvars)}.'
+    assert len(outvars) >= 0, (
+        f'len(outvars) should be greater than or equal to 0, but len(outvars)={len(outvars)}.'
+    )
     if len(outvars) > 1:
         output = outvars
     else:
@@ -220,9 +220,9 @@ def REGISTER_ORIG2PRIM(op_type):
 
     def wrapper(f):
         def _lower(op, *args, **kwargs):
-            assert (
-                op.type == op_type
-            ), f'op.type should be equal to op_type, but op.type is {op.type} and op_type is {op_type}'
+            assert op.type == op_type, (
+                f'op.type should be equal to op_type, but op.type is {op.type} and op_type is {op_type}'
+            )
             return f(op, *args, **kwargs)
 
         _orig2prim.register(op_type, _lower)
@@ -260,9 +260,9 @@ def REGISTER_COMPOSITE(op_type):
 
     def wrapper(f):
         def _lower(op, *args, **kwargs):
-            assert (
-                op.type == op_type
-            ), f'op.type should be equal to op_type, but op.type is {op.type} and op_type is {op_type}'
+            assert op.type == op_type, (
+                f'op.type should be equal to op_type, but op.type is {op.type} and op_type is {op_type}'
+            )
             return f(*args, **kwargs)
 
         _composite_ops.register(op_type, _lower)
@@ -299,9 +299,9 @@ def REGISTER_PRIM2ORIG(op_type):
 
     def wrapper(f):
         def _lower(op, *args, **kwargs):
-            assert (
-                op.type == op_type
-            ), f'op.type should be equal to op_type, but op.type is {op.type} and op_type is {op_type}'
+            assert op.type == op_type, (
+                f'op.type should be equal to op_type, but op.type is {op.type} and op_type is {op_type}'
+            )
             return f(op, *args, **kwargs)
 
         _prim2orig.register(op_type, _lower)
@@ -336,9 +336,9 @@ def REGISTER_JVP(op_type):
 
     def wrapper(f):
         def _jvp(op, *args, **kwargs):
-            assert (
-                op.type == op_type
-            ), f'op.type should be equal to op_type, but op.type is {op.type} and op_type is {op_type}'
+            assert op.type == op_type, (
+                f'op.type should be equal to op_type, but op.type is {op.type} and op_type is {op_type}'
+            )
             return f(op, *args, **kwargs)
 
         _primop_jvp.register(op_type, _jvp)
@@ -374,9 +374,9 @@ def REGISTER_TRANSPOSE(op_type):
 
     def wrapper(f):
         def _transpose(op, dot_checker, *args, **kwargs):
-            assert (
-                op.type == op_type
-            ), f'op.type should be equal to op_type, but op.type is {op.type} and op_type is {op_type}'
+            assert op.type == op_type, (
+                f'op.type should be equal to op_type, but op.type is {op.type} and op_type is {op_type}'
+            )
             return f(op, dot_checker, *args, **kwargs)
 
         _primop_transpose.register(op_type, _transpose)

--- a/python/paddle/incubate/autograd/primx.py
+++ b/python/paddle/incubate/autograd/primx.py
@@ -74,9 +74,9 @@ def topo_path(
 
     # Initialize reached vars
     for x in xs:
-        assert (
-            x is None or x.block == block
-        ), 'x is not None and x.block != block'
+        assert x is None or x.block == block, (
+            'x is not None and x.block != block'
+        )
         reached_vars[id(x)] = x
 
     # Reaching test, returning whether an op is reached from the given input
@@ -216,9 +216,9 @@ class Transform:
     dot2bar: VarMap
 
     def __init__(self, block: Block) -> None:
-        assert (
-            block == default_main_program().current_block()
-        ), 'only support transform on current block of main program.'
+        assert block == default_main_program().current_block(), (
+            'only support transform on current block of main program.'
+        )
         self.block = block
         self.vars = self.init_vars(block)
         self.var2dot = VarMap('var2dot', self.vars)
@@ -342,9 +342,9 @@ def _lower(block, reverse, blacklist):
                 expand_nested_list(get_output_var_list(op)),
                 expand_nested_list(as_tensors(lower_fn(op, *input_args))),
             ):
-                assert not (orig_out is None) ^ (
-                    new_out is None
-                ), "orig_out and new_out should match."
+                assert not (orig_out is None) ^ (new_out is None), (
+                    "orig_out and new_out should match."
+                )
                 vars_to_remove.add(new_out.name)
                 value_table[new_out.name] = new_out
                 to_bind[orig_out.name] = new_out.name
@@ -394,9 +394,9 @@ def _lower(block, reverse, blacklist):
                 op._rename_output(out_name, to_bind_rev[out_name])
 
     for var_name in sorted(vars_to_remove):
-        assert (
-            var_name in to_bind_rev
-        ), f'var_name "{var_name}" is not in to_bind_rev.'
+        assert var_name in to_bind_rev, (
+            f'var_name "{var_name}" is not in to_bind_rev.'
+        )
         if var_name != to_bind_rev[var_name]:
             block.desc._remove_var(var_name.encode())
             del block.vars[var_name]
@@ -467,15 +467,15 @@ def _lower_composite(
         # Note, start_idx and backward_length cannot be both given, because the length of non-processed part must be kept unchanged.
         length = len(block.ops)
         idx_list = range(length)
-        assert (
-            -1 <= backward_length <= length
-        ), f'expect -1 <= backward_length <= {length}, but got backward_length: {backward_length}'
-        assert (
-            -1 <= start_idx <= length
-        ), f'expect -1 <= start_idx <= {length}, but got start_idx: {start_idx}'
-        assert not (
-            backward_length > -1 and start_idx > -1
-        ), f'got start_idx: {start_idx} and backward_length: {backward_length}'
+        assert -1 <= backward_length <= length, (
+            f'expect -1 <= backward_length <= {length}, but got backward_length: {backward_length}'
+        )
+        assert -1 <= start_idx <= length, (
+            f'expect -1 <= start_idx <= {length}, but got start_idx: {start_idx}'
+        )
+        assert not (backward_length > -1 and start_idx > -1), (
+            f'got start_idx: {start_idx} and backward_length: {backward_length}'
+        )
         if backward_length > -1:
             idx_list = range(length - backward_length)
         if start_idx > -1:
@@ -538,16 +538,16 @@ def _lower_composite(
                             f'when replace origin op {op_name} with composite rule, origin out dtype should be equal to new out dtype, '
                             f'but orig_out: {orig_out.name}.dtype={orig_out.dtype} and new_out: {new_out.name}.dtype={new_out.dtype}'
                         )
-                        assert (
-                            -1 not in new_out.shape
-                        ), f'when replace origin op {op_name} with composite rule, composite out shape has -1.'
+                        assert -1 not in new_out.shape, (
+                            f'when replace origin op {op_name} with composite rule, composite out shape has -1.'
+                        )
                         assert orig_out.shape == new_out.shape, (
                             f'when replace origin op {op_name} with composite rule, origin out shape should be equal to new out shape, '
                             f'but orig_out: {orig_out.name}.shape={orig_out.shape} and new_out: {new_out.name}.shape={new_out.shape}'
                         )
-                        assert not (orig_out is None) ^ (
-                            new_out is None
-                        ), "orig_out and new_out should match."
+                        assert not (orig_out is None) ^ (new_out is None), (
+                            "orig_out and new_out should match."
+                        )
                         vars_to_remove.add(new_out.name)
                         value_table[new_out.name] = new_out
                         to_bind[orig_out.name] = new_out.name
@@ -576,9 +576,9 @@ def _lower_composite(
                     op._rename_output(out_name, to_bind_rev[out_name])
 
         for var_name in sorted(vars_to_remove):
-            assert (
-                var_name in to_bind_rev
-            ), f'var_name "{var_name}" is not in to_bind_rev.'
+            assert var_name in to_bind_rev, (
+                f'var_name "{var_name}" is not in to_bind_rev.'
+            )
             if var_name != to_bind_rev[var_name]:
                 block.desc._remove_var(var_name.encode())
                 del block.vars[var_name]
@@ -635,9 +635,9 @@ def orig2prim(block: Block | None = None) -> None:
     """
 
     block = default_main_program().current_block() if block is None else block
-    assert (
-        block == default_main_program().current_block()
-    ), 'block is neither None nor current block of main program'
+    assert block == default_main_program().current_block(), (
+        'block is neither None nor current block of main program'
+    )
     _lower(block, reverse=False, blacklist=[])
 
 
@@ -683,8 +683,8 @@ def prim2orig(
     """
 
     block = default_main_program().current_block() if block is None else block
-    assert (
-        block == default_main_program().current_block()
-    ), 'block is neither None nor current block of main program'
+    assert block == default_main_program().current_block(), (
+        'block is neither None nor current block of main program'
+    )
     blacklist = [] if blacklist is None else blacklist
     _lower(block, reverse=True, blacklist=blacklist)

--- a/python/paddle/incubate/cc/ap/apy_to_axpr_json.py
+++ b/python/paddle/incubate/cc/ap/apy_to_axpr_json.py
@@ -114,9 +114,9 @@ class PyToAnfParser:
             for func_def in tree.body:
                 if isinstance(func_def, ast.Pass):
                     continue
-                assert isinstance(
-                    func_def, ast.FunctionDef
-                ), f"only method supported in class definition, {type(func_def)} were given."
+                assert isinstance(func_def, ast.FunctionDef), (
+                    f"only method supported in class definition, {type(func_def)} were given."
+                )
                 func_code = self.BindToTmpVar(
                     [
                         '__builtin_getattr__',

--- a/python/paddle/incubate/cc/ap/pir_attrs_serializer.py
+++ b/python/paddle/incubate/cc/ap/pir_attrs_serializer.py
@@ -37,9 +37,9 @@ class PirAttrsSerializer:
         print(attributes)
         attributes_names = {name for name, _ in attributes.items()}
         attr_names = {name for name, _ in self.attributes_schema}
-        assert (
-            attributes_names == attr_names
-        ), f"expected attr_names: {attr_names}, but actual attr_names are {attributes_names}"
+        assert attributes_names == attr_names, (
+            f"expected attr_names: {attr_names}, but actual attr_names are {attributes_names}"
+        )
         py_assigns = "\n".join(
             py_stmt
             for attr_name, attr_val in attributes.items()
@@ -76,15 +76,15 @@ class PirAttrsSerializer:
     def _check_attributes_schema_item_is_valid(self, attr_type):
         if attr_type in self._supported_basic_types():
             return
-        assert isinstance(
-            attr_type, list
-        ), f"attribute type {attr_type} is not supported."
-        assert (
-            len(attr_type) == 1
-        ), "only syntax like [bool], [int], [float], [str] supported."
-        assert (
-            attr_type[0] in self._supported_basic_types()
-        ), f"supported list element types are bool/int/float/str, not include {attr_type[0]}."
+        assert isinstance(attr_type, list), (
+            f"attribute type {attr_type} is not supported."
+        )
+        assert len(attr_type) == 1, (
+            "only syntax like [bool], [int], [float], [str] supported."
+        )
+        assert attr_type[0] in self._supported_basic_types(), (
+            f"supported list element types are bool/int/float/str, not include {attr_type[0]}."
+        )
 
     def _supported_basic_types(self):
         return (bool, int, float, str, DType)

--- a/python/paddle/incubate/cc/compiler.py
+++ b/python/paddle/incubate/cc/compiler.py
@@ -206,9 +206,9 @@ def _init_empty_input_spec_make_ctx(annotations, mut_ctx: InputSpecMakeCtx):
 def _init_input_spec_make_ctx_name2dtype_num_candidates(
     pct_type, mut_ctx: InputSpecMakeCtx
 ):
-    assert isinstance(
-        pct_type.dtype, pct.DTypeVar
-    ), f"pct_type.dtype should be a DTypeVar, but {type(pct_type.dtype)} were given."
+    assert isinstance(pct_type.dtype, pct.DTypeVar), (
+        f"pct_type.dtype should be a DTypeVar, but {type(pct_type.dtype)} were given."
+    )
     name = pct_type.dtype.name
     if name in mut_ctx.name2dtype_num_candidates:
         assert mut_ctx.name2dtype_num_candidates[name] == len(

--- a/python/paddle/incubate/distributed/fleet/collective.py
+++ b/python/paddle/incubate/distributed/fleet/collective.py
@@ -233,9 +233,9 @@ class CollectiveOpBasedOptimizer(DistributedOptimizer):
     """
 
     def __init__(self, optimizer, strategy=None):
-        assert isinstance(
-            strategy, DistributedStrategy
-        ), "strategy must be DistributedStrategy"
+        assert isinstance(strategy, DistributedStrategy), (
+            "strategy must be DistributedStrategy"
+        )
         super().__init__(optimizer, strategy)
 
     def backward(
@@ -320,9 +320,9 @@ class CollectiveOptimizer(DistributedOptimizer):
                 use_local_sgd=strategy.use_local_sgd,
                 use_lamb=main_program._use_lamb,
             )
-            assert (
-                strategy.dist_fc_config is not None
-            ), "DistributedStrategy.dist_fc_config should be set"
+            assert strategy.dist_fc_config is not None, (
+                "DistributedStrategy.dist_fc_config should be set"
+            )
 
         if strategy._ut4grad_allreduce:
             strategy.mode = "collective"
@@ -337,9 +337,9 @@ class CollectiveOptimizer(DistributedOptimizer):
             self._strategy.collective_mode == "local_sgd"
             or self._strategy.collective_mode == "grad_allreduce"
         ):
-            assert (
-                self._strategy.mode == "collective"
-            ), "local_sgd and grad_allreduce can be used under collective mode"
+            assert self._strategy.mode == "collective", (
+                "local_sgd and grad_allreduce can be used under collective mode"
+            )
 
     def _transpile(self, startup_program, main_program):
         """

--- a/python/paddle/incubate/distributed/fleet/parameter_server/ir/public.py
+++ b/python/paddle/incubate/distributed/fleet/parameter_server/ir/public.py
@@ -283,13 +283,13 @@ class CompileTimeStrategy:
         self.tensor_table_dict[feed_var_name] = {}
         self.tensor_table_dict[feed_var_name]["feed_var_name"] = feed_var_name
         self.tensor_table_dict[feed_var_name]["fetch_var_name"] = fetch_var_name
-        self.tensor_table_dict[feed_var_name][
-            "startup_program"
-        ] = startup_program
+        self.tensor_table_dict[feed_var_name]["startup_program"] = (
+            startup_program
+        )
         self.tensor_table_dict[feed_var_name]["main_program"] = main_program
-        self.tensor_table_dict[feed_var_name][
-            "tensor_table_class"
-        ] = tensor_table_class
+        self.tensor_table_dict[feed_var_name]["tensor_table_class"] = (
+            tensor_table_class
+        )
 
     def get_tensor_table_dict(self):
         return self.tensor_table_dict

--- a/python/paddle/incubate/distributed/fleet/parameter_server/ir/trainer_pass.py
+++ b/python/paddle/incubate/distributed/fleet/parameter_server/ir/trainer_pass.py
@@ -909,9 +909,9 @@ def find_heter_ops(program, default_device="cpu"):
 
             # for cpu-op block append
             if len(current_default_block_ops) > 1:
-                default_ops[default_device][
-                    block_index
-                ] = current_default_block_ops
+                default_ops[default_device][block_index] = (
+                    current_default_block_ops
+                )
                 program_block_ops.append(current_default_block_ops)
                 current_default_block_ops = []
                 block_index += 1
@@ -1552,9 +1552,9 @@ def union_forward_gradient_op(program_block_ops_list):
     '''
 
     union_program_block_ops_list = []
-    assert (
-        block_length % 2 != 0
-    ), "the length of program_block_ops_list should be odd"
+    assert block_length % 2 != 0, (
+        "the length of program_block_ops_list should be odd"
+    )
     for i in range(0, block_length // 2):
         block_op_list = {"forward": program_block_ops_list[i]}
         block_op_list.update(

--- a/python/paddle/incubate/distributed/fleet/parameter_server/pslib/optimizer_factory.py
+++ b/python/paddle/incubate/distributed/fleet/parameter_server/pslib/optimizer_factory.py
@@ -778,9 +778,9 @@ class DistributedAdam(DistributedOptimizerImplBase):
                             sparse_table_names,
                             dense_table_index,
                         )
-                        program_configs[program_id][
-                            'cond2denseid'
-                        ] = cond2denseid
+                        program_configs[program_id]['cond2denseid'] = (
+                            cond2denseid
+                        )
                         multi_task_dense_tables_push = dense_tables
                         multi_task_dense_tables_pull = dense_tables[:]
 
@@ -893,12 +893,12 @@ class DistributedAdam(DistributedOptimizerImplBase):
                             )
                     else:
                         if flag_multi_task:
-                            program_configs[program_id][
-                                "pull_dense"
-                            ] = multi_task_dense_tables_pull
-                            program_configs[program_id][
-                                "push_dense"
-                            ] = multi_task_dense_tables_push
+                            program_configs[program_id]["pull_dense"] = (
+                                multi_task_dense_tables_pull
+                            )
+                            program_configs[program_id]["push_dense"] = (
+                                multi_task_dense_tables_push
+                            )
                         else:
                             program_configs[program_id]["pull_dense"] = [
                                 dense_table_index

--- a/python/paddle/incubate/distributed/fleet/role_maker.py
+++ b/python/paddle/incubate/distributed/fleet/role_maker.py
@@ -537,9 +537,9 @@ class PaddleCloudRoleMaker(RoleMakerBase):
                 assert self._training_role == "TRAINER"
                 self._worker_endpoints = os.getenv("PADDLE_TRAINER_ENDPOINTS")
                 self._current_endpoint = os.getenv("PADDLE_CURRENT_ENDPOINT")
-                assert (
-                    self._worker_endpoints is not None
-                ), "can't find PADDLE_TRAINER_ENDPOINTS"
+                assert self._worker_endpoints is not None, (
+                    "can't find PADDLE_TRAINER_ENDPOINTS"
+                )
                 self._worker_endpoints = self._worker_endpoints.split(",")
                 self._trainers_num = len(self._worker_endpoints)
 

--- a/python/paddle/incubate/distributed/models/moe/grad_clip.py
+++ b/python/paddle/incubate/distributed/models/moe/grad_clip.py
@@ -94,9 +94,9 @@ class ClipGradForMOEByGlobalNorm(ClipGradBase):
         self.group_name = group_name
         self.moe_group = moe_group
         if moe_group is not None and moe_group.nranks > 1:
-            assert (
-                is_expert_param_func is not None
-            ), "When moe group size > 1, a function for selecting expert params must be specified."
+            assert is_expert_param_func is not None, (
+                "When moe group size > 1, a function for selecting expert params must be specified."
+            )
         self.is_expert_param_func = is_expert_param_func
 
     def __str__(self):

--- a/python/paddle/incubate/distributed/models/moe/moe_layer.py
+++ b/python/paddle/incubate/distributed/models/moe/moe_layer.py
@@ -341,9 +341,9 @@ class MoELayer(nn.Layer):
         if gate is None:
             gate = {}
 
-        assert isinstance(
-            gate, (dict, BaseGate)
-        ), "gate config' type must be dict or an instance of BaseGate"
+        assert isinstance(gate, (dict, BaseGate)), (
+            "gate config' type must be dict or an instance of BaseGate"
+        )
         # only support mp/dp
         self.group = moe_group
 

--- a/python/paddle/incubate/distributed/utils/io/dist_load.py
+++ b/python/paddle/incubate/distributed/utils/io/dist_load.py
@@ -81,13 +81,13 @@ def load(path, **configs):
     if "place" not in configs:
         configs["place"] = "cpu"
     place = configs["place"]
-    assert isinstance(
-        place, str
-    ), f"configs[place] must be a str, but this is a {type(place)}"
+    assert isinstance(place, str), (
+        f"configs[place] must be a str, but this is a {type(place)}"
+    )
 
-    assert re.search(
-        "^(cpu|gpu:[0-9]*)$", place
-    ), "configs[place] must be cpu, gpu:0, gpu:1 ..."
+    assert re.search("^(cpu|gpu:[0-9]*)$", place), (
+        "configs[place] must be cpu, gpu:0, gpu:1 ..."
+    )
 
     return load_with_place(path, **configs)
 

--- a/python/paddle/incubate/distributed/utils/io/dist_save.py
+++ b/python/paddle/incubate/distributed/utils/io/dist_save.py
@@ -127,9 +127,9 @@ def save(
 
     # gather_to is not None and world size > 1
     state_type = configs.get("state_type", None)
-    assert isinstance(
-        state_type, str
-    ), "must pass an arg state_type='params' or state_type='opt' to specify whether to save model state_dict or optimizer state_dict"
+    assert isinstance(state_type, str), (
+        "must pass an arg state_type='params' or state_type='opt' to specify whether to save model state_dict or optimizer state_dict"
+    )
     assert state_type in [
         "params",
         "opt",
@@ -144,20 +144,22 @@ def save(
     assert (
         hcg.get_model_parallel_world_size() == 1
         and hcg.get_pipe_parallel_world_size() == 1
-    ), f"Only DP and Sharding is supported now. However, current MP={hcg.get_model_parallel_world_size()} , PP={hcg.get_pipe_parallel_world_size()}"
+    ), (
+        f"Only DP and Sharding is supported now. However, current MP={hcg.get_model_parallel_world_size()} , PP={hcg.get_pipe_parallel_world_size()}"
+    )
 
     sharding_group = hcg.get_sharding_parallel_group()
     dp_group = hcg.get_data_parallel_group()
 
     if state_type == "params":
         if dp_group.nranks > 1:
-            assert _same_keys(
-                state_dict, dp_group
-            ), "only sharding stage 1/2 and DP are supported now"
+            assert _same_keys(state_dict, dp_group), (
+                "only sharding stage 1/2 and DP are supported now"
+            )
         if sharding_group.nranks > 1:
-            assert _same_keys(
-                state_dict, sharding_group
-            ), "only sharding stage 1/2 and DP are supported now"
+            assert _same_keys(state_dict, sharding_group), (
+                "only sharding stage 1/2 and DP are supported now"
+            )
         configs = _remove_not_supported_conf(configs)
         return paddle.save(state_dict, path, **configs)
 
@@ -248,9 +250,9 @@ def _parse_mem_size_to_bits(max_size):
     """
     assert isinstance(max_size, (int, str))
     if isinstance(max_size, str):
-        assert re.search(
-            "^[0-9]*[GMK]$", max_size
-        ), f"Wrong max_size 's format, the format ust be like 10K, 9M, 200G , etc, or an integer. However this is {max_size}"
+        assert re.search("^[0-9]*[GMK]$", max_size), (
+            f"Wrong max_size 's format, the format ust be like 10K, 9M, 200G , etc, or an integer. However this is {max_size}"
+        )
         num = int(max_size[:-1])
         if max_size[-1] == "G":
             max_size = num * 1024**3
@@ -278,9 +280,9 @@ def _gather_state_dict(state_dict, dst, group, max_size="3G"):
     Returns:
         Gathered state dict
     """
-    assert isinstance(
-        dst, (list, tuple, int)
-    ), "dst' type must be one of int, list and tuple"
+    assert isinstance(dst, (list, tuple, int)), (
+        "dst' type must be one of int, list and tuple"
+    )
     if isinstance(dst, int):
         dst = [dst]
 

--- a/python/paddle/incubate/distributed/utils/io/save_for_auto.py
+++ b/python/paddle/incubate/distributed/utils/io/save_for_auto.py
@@ -145,13 +145,13 @@ def _save_param_attr(state_dict_, path, dims_mapping_dict=None):
     state_dict.pop("LR_Scheduler", None)
 
     if dims_mapping_dict is not None:
-        assert isinstance(
-            dims_mapping_dict, dict
-        ), "dims_mapping_dict must be an instance of dict"
+        assert isinstance(dims_mapping_dict, dict), (
+            "dims_mapping_dict must be an instance of dict"
+        )
         for k in state_dict.keys():
-            assert (
-                k in dims_mapping_dict
-            ), f"param {k} cannot find dims mapping in dims_mapping_dict"
+            assert k in dims_mapping_dict, (
+                f"param {k} cannot find dims mapping in dims_mapping_dict"
+            )
     if dist.get_world_size() > 1:
         hcg = fleet.get_hybrid_communicate_group()
         dp_degree = hcg.get_data_parallel_world_size()
@@ -289,9 +289,9 @@ def _name_mapping_dist2single(state_dict, pp_group):
         for k in keys:
             matched = matcher.search(k)
             logger.debug(f"matched: {k}: {matched}")
-            assert (
-                matched is not None
-            ), f"the name of param, '{k}', is not satisfied the format 'name_idx.xxx'"
+            assert matched is not None, (
+                f"the name of param, '{k}', is not satisfied the format 'name_idx.xxx'"
+            )
             name_idx = k[matched.start() : matched.end()]
             logger.debug(f"get param_type_idx: {name_idx}")
 
@@ -313,9 +313,9 @@ def _name_mapping_dist2single(state_dict, pp_group):
             else:
                 types_idx[v[0]].append(v[1])
         for k, v in types_idx.items():
-            assert v == list(
-                range(v[0], v[-1] + 1)
-            ), f"{k} is not continuous: {v}"
+            assert v == list(range(v[0], v[-1] + 1)), (
+                f"{k} is not continuous: {v}"
+            )
 
     logger.debug(f"param type: {param_types}")
 

--- a/python/paddle/incubate/fp8/deep_gemm/jit/compiler.py
+++ b/python/paddle/incubate/fp8/deep_gemm/jit/compiler.py
@@ -46,9 +46,9 @@ def get_jit_include_dir() -> str:
 def get_deep_gemm_version() -> str:
     # Update include directories
     include_dir = f"{get_jit_include_dir()}/../../../../include/paddle/fluid/fp8/deep_gemm/include"
-    assert os.path.exists(
-        include_dir
-    ), f"Cannot find GEMM include directory {include_dir}"
+    assert os.path.exists(include_dir), (
+        f"Cannot find GEMM include directory {include_dir}"
+    )
     md5 = hashlib.md5()
     for filename in filter(
         lambda x: x.endswith(".cuh"), sorted(os.listdir(include_dir))
@@ -81,9 +81,9 @@ def get_nvcc_compiler() -> tuple[str, str]:
             match = version_pattern.search(os.popen(f"{path} --version").read())
             version = match.group(1)
             assert match, f"Cannot get the version of NVCC compiler {path}"
-            assert (
-                version >= least_version_required
-            ), f"NVCC {path} version {version} is lower than {least_version_required}"
+            assert version >= least_version_required, (
+                f"NVCC {path} version {version} is lower than {least_version_required}"
+            )
             return path, version
     raise RuntimeError("Cannot find any available NVCC compiler")
 

--- a/python/paddle/incubate/fp8/deep_gemm/jit/template.py
+++ b/python/paddle/incubate/fp8/deep_gemm/jit/template.py
@@ -101,9 +101,9 @@ def generate(
     )
     preload_package_includes = [f'"{include_dirs}"']
 
-    assert isinstance(
-        includes, (list, tuple)
-    ), "includes must be a list or tuple"
+    assert isinstance(includes, (list, tuple)), (
+        "includes must be a list or tuple"
+    )
     sys_includes = sorted(
         set(
             preload_sys_includes

--- a/python/paddle/incubate/fp8/deep_gemm/jit_kernels/m_grouped_gemm.py
+++ b/python/paddle/incubate/fp8/deep_gemm/jit_kernels/m_grouped_gemm.py
@@ -193,9 +193,9 @@ def auto_tuning_with_compilation_grouped_gemm_masked(
 
     # Extra checks for TMA store
     if num_groups > 1 and m > block_m:
-        assert (
-            m % block_m == 0
-        ), f"For masked grouped GEMM, shape M should be multiple of the block M (current block M: {block_m})"
+        assert m % block_m == 0, (
+            f"For masked grouped GEMM, shape M should be multiple of the block M (current block M: {block_m})"
+        )
 
     runtime = jit_tuner.compile_and_tune_group_gemm_masked(
         name="m_grouped_gemm_fp8_fp8_bf16_nt",

--- a/python/paddle/incubate/fp8/deep_gemm/jit_kernels/tuner.py
+++ b/python/paddle/incubate/fp8/deep_gemm/jit_kernels/tuner.py
@@ -77,9 +77,9 @@ class JITTuner:
                 print(
                     f"Tuned JIT kernel {name} with keys {keys} and tuned keys {tuned_keys} has time {elapsed_time}"
                 )
-        assert (
-            best_runtime is not None
-        ), f"Failed to tune JIT kernel {name} with keys {keys}"
+        assert best_runtime is not None, (
+            f"Failed to tune JIT kernel {name} with keys {keys}"
+        )
 
         # Cache the best runtime and return
         if os.getenv("DG_JIT_DEBUG", None) or os.getenv(
@@ -140,9 +140,9 @@ class JITTuner:
                 print(
                     f"Tuned JIT kernel {name} with keys {keys} and tuned keys {tuned_keys} has time {elapsed_time}"
                 )
-        assert (
-            best_runtime is not None
-        ), f"Failed to tune JIT kernel {name} with keys {keys}"
+        assert best_runtime is not None, (
+            f"Failed to tune JIT kernel {name} with keys {keys}"
+        )
 
         # Cache the best runtime and return
         if os.getenv("DG_JIT_DEBUG", None) or os.getenv(

--- a/python/paddle/incubate/jit/inference_decorator.py
+++ b/python/paddle/incubate/jit/inference_decorator.py
@@ -85,9 +85,9 @@ def get_tensor(run_time_args, arg_name):
     elif is_list_or_tuple(run_time_args):
         this_input_tensor_lists = []
         for ele in run_time_args:
-            assert isinstance(
-                ele, paddle.Tensor
-            ), f"the elements in {arg_name} must be paddle.Tensor"
+            assert isinstance(ele, paddle.Tensor), (
+                f"the elements in {arg_name} must be paddle.Tensor"
+            )
             this_input_tensor_lists.append(ele)
         return this_input_tensor_lists
     elif is_fixed_type(run_time_args):

--- a/python/paddle/incubate/layers/nn.py
+++ b/python/paddle/incubate/layers/nn.py
@@ -758,9 +758,9 @@ def tdm_sampler(
                 f"in the layer {layer_idx}, But received negative nums {neg_samples_num_list[layer_idx]}, and num of node at layer {layer_idx} "
                 f"is {layer_node_num_list[layer_idx]}, please check your input."
             )
-    assert (
-        leaf_node_num < node_nums
-    ), "leaf_node_num must be less than total node nums."
+    assert leaf_node_num < node_nums, (
+        "leaf_node_num must be less than total node nums."
+    )
 
     travel_shape = [leaf_node_num, layer_nums]
     travel = helper.create_parameter(
@@ -1320,9 +1320,9 @@ def pow2_decay_with_linear_warmup(
     helper.set_variable_initializer(
         step, paddle.nn.initializer.Constant(value=0)
     )
-    assert (
-        warmup_steps <= total_steps
-    ), "warmup_steps cannot be larger than total_steps"
+    assert warmup_steps <= total_steps, (
+        "warmup_steps cannot be larger than total_steps"
+    )
 
     helper.append_op(
         type="pow2_decay_with_linear_warmup",

--- a/python/paddle/incubate/nn/functional/fused_dot_product_attention.py
+++ b/python/paddle/incubate/nn/functional/fused_dot_product_attention.py
@@ -189,9 +189,9 @@ def fused_dot_product_attention(
         bias_type = "none"
 
     if attn_mask is not None:
-        assert (
-            attn_mask.dtype == query.dtype
-        ), "attn_mask dtype should be the same as qkv dtype"
+        assert attn_mask.dtype == query.dtype, (
+            "attn_mask dtype should be the same as qkv dtype"
+        )
 
     cu_seqlen_q = None
     cu_seqlen_k = None

--- a/python/paddle/incubate/nn/functional/fused_rotary_position_embedding.py
+++ b/python/paddle/incubate/nn/functional/fused_rotary_position_embedding.py
@@ -98,12 +98,12 @@ def fused_rotary_position_embedding(
                [-0.03628540, -0.20202637]]]])
     """
     if (sin is None) or (cos is None):
-        assert (
-            position_ids is None
-        ), "position_ids without sin/cos is not correctly supported now."
-        assert (
-            use_neox_rotary_style
-        ), "rotate_half without sin/cos is not correctly supported now."
+        assert position_ids is None, (
+            "position_ids without sin/cos is not correctly supported now."
+        )
+        assert use_neox_rotary_style, (
+            "rotate_half without sin/cos is not correctly supported now."
+        )
 
     if in_dynamic_or_pir_mode():
         return _C_ops.fused_rotary_position_embedding(

--- a/python/paddle/incubate/nn/functional/fused_transformer.py
+++ b/python/paddle/incubate/nn/functional/fused_transformer.py
@@ -410,19 +410,19 @@ def fused_bias_dropout_residual_layer_norm(
     )  # semantic transfer
 
     if ln_scale is not None:
-        assert (
-            len(ln_scale.shape) == 1
-        ), "The dims of the shape of ln_scale should be 1."
-        assert (
-            x.shape[len(x.shape) - 1] == ln_scale.shape[0]
-        ), "The dim of ln_scale must equal to the last dim of x."
+        assert len(ln_scale.shape) == 1, (
+            "The dims of the shape of ln_scale should be 1."
+        )
+        assert x.shape[len(x.shape) - 1] == ln_scale.shape[0], (
+            "The dim of ln_scale must equal to the last dim of x."
+        )
     if ln_bias is not None:
-        assert (
-            len(ln_bias.shape) == 1
-        ), "The dims of the shape of ln_bias should be 1."
-        assert (
-            x.shape[len(x.shape) - 1] == ln_bias.shape[0]
-        ), "The dim of ln_bias must equal to the last dim of x."
+        assert len(ln_bias.shape) == 1, (
+            "The dims of the shape of ln_bias should be 1."
+        )
+        assert x.shape[len(x.shape) - 1] == ln_bias.shape[0], (
+            "The dim of ln_bias must equal to the last dim of x."
+        )
 
     if in_dynamic_or_pir_mode():
         if default_main_program().random_seed != 0:
@@ -677,15 +677,15 @@ def fused_multi_head_attention(
         # qktv_out, softmax_out, attn_dropout_mask_out, attn_dropout_out, attn_mask_out, fmha_out,
         # linear_out, dropout_mask_out, ln_mean_out, ln_var_out, bias_dropout_residual_out, final_out
         if not transpose_qkv_wb:
-            assert (
-                len(qkv_weight.shape) == 4
-            ), "The dims of the shape of qkv_weight should be 4."
-            assert (
-                qkv_weight.shape[0] == 3
-            ), "The shape of qkv_weight should be [3, num_head, head_dim, embed_dim]."
-            assert (
-                qkv_weight.shape[3] == x.shape[2]
-            ), "The 3rd dim of qkv_weight and 2nd dim of x should be the same, i.e., embed_dim."
+            assert len(qkv_weight.shape) == 4, (
+                "The dims of the shape of qkv_weight should be 4."
+            )
+            assert qkv_weight.shape[0] == 3, (
+                "The shape of qkv_weight should be [3, num_head, head_dim, embed_dim]."
+            )
+            assert qkv_weight.shape[3] == x.shape[2], (
+                "The 3rd dim of qkv_weight and 2nd dim of x should be the same, i.e., embed_dim."
+            )
             if ring_id == -1:
                 # under mp, the num head will be split, this equation will not hold
                 assert (
@@ -693,9 +693,9 @@ def fused_multi_head_attention(
                     == qkv_weight.shape[3]
                 ), "embed_dim must be divisible by num_heads."
         else:
-            assert (
-                num_heads > 0
-            ), "When enable transpose_qkv_wb, the num_heads should be provided and greater than 0."
+            assert num_heads > 0, (
+                "When enable transpose_qkv_wb, the num_heads should be provided and greater than 0."
+            )
             assert len(qkv_weight.shape) == 2, (
                 "When enable transpose_qkv_wb, the dims of the shape of qkv_weight "
                 "should be 2 when enable transpose_qkv_wb."
@@ -711,9 +711,9 @@ def fused_multi_head_attention(
                 "should be the same, i.e., embed_dim."
             )
             if qkv_bias is not None:
-                assert (
-                    len(qkv_bias.shape) == 1
-                ), "When enable transpose_qkv_wb, the dims of the shape of qkv_bias should be 1."
+                assert len(qkv_bias.shape) == 1, (
+                    "When enable transpose_qkv_wb, the dims of the shape of qkv_bias should be 1."
+                )
                 assert qkv_bias.shape[0] == qkv_weight.shape[1], (
                     "When enable transpose_qkv_wb, the 1st dim of qkv_bias and 2nd dim of "
                     "qkv_weight should be the same, i.e., embed_dim."

--- a/python/paddle/incubate/nn/layer/fused_transformer.py
+++ b/python/paddle/incubate/nn/layer/fused_transformer.py
@@ -147,9 +147,9 @@ class FusedBiasDropoutResidualLayerNorm(Layer):
         name: str | None = None,
     ) -> None:
         super().__init__()
-        assert (
-            embed_dim > 0
-        ), f"Expected embed_dim to be greater than 0, but received {embed_dim}"
+        assert embed_dim > 0, (
+            f"Expected embed_dim to be greater than 0, but received {embed_dim}"
+        )
         self._dtype = self._helper.get_default_dtype()
         self._bias_attr = bias_attr
         self._weight_attr = weight_attr
@@ -337,12 +337,12 @@ class FusedMultiHeadAttention(Layer):
     ) -> None:
         super().__init__()
 
-        assert (
-            embed_dim > 0
-        ), f"Expected embed_dim to be greater than 0, but received {embed_dim}"
-        assert (
-            num_heads > 0
-        ), f"Expected nhead to be greater than 0, but received {num_heads}"
+        assert embed_dim > 0, (
+            f"Expected embed_dim to be greater than 0, but received {embed_dim}"
+        )
+        assert num_heads > 0, (
+            f"Expected nhead to be greater than 0, but received {num_heads}"
+        )
 
         self.normalize_before = normalize_before
         self._dtype = self._helper.get_default_dtype()
@@ -355,9 +355,9 @@ class FusedMultiHeadAttention(Layer):
         self.kdim = kdim
         self.vdim = vdim
         self.need_weights = need_weights
-        assert (
-            self.head_dim * num_heads == embed_dim
-        ), "embed_dim must be divisible by num_heads"
+        assert self.head_dim * num_heads == embed_dim, (
+            "embed_dim must be divisible by num_heads"
+        )
         assert need_weights is False, "Only support need_weight is False now."
 
         # tensor model parallel
@@ -615,12 +615,12 @@ class FusedFeedForward(Layer):
         name: str | None = None,
     ) -> None:
         super().__init__()
-        assert (
-            d_model > 0
-        ), f"Expected d_model to be greater than 0, but received {d_model}"
-        assert (
-            dim_feedforward > 0
-        ), f"Expected dim_feedforward to be greater than 0, but received {dim_feedforward}"
+        assert d_model > 0, (
+            f"Expected d_model to be greater than 0, but received {d_model}"
+        )
+        assert dim_feedforward > 0, (
+            f"Expected dim_feedforward to be greater than 0, but received {dim_feedforward}"
+        )
 
         self._dtype = self._helper.get_default_dtype()
         self._d_model = d_model
@@ -828,12 +828,12 @@ class FusedTransformerEncoderLayer(Layer):
         self._config.pop("__class__", None)  # py3
 
         super().__init__()
-        assert (
-            d_model > 0
-        ), f"Expected d_model to be greater than 0, but received {d_model}"
-        assert (
-            nhead > 0
-        ), f"Expected nhead to be greater than 0, but received {nhead}"
+        assert d_model > 0, (
+            f"Expected d_model to be greater than 0, but received {d_model}"
+        )
+        assert nhead > 0, (
+            f"Expected nhead to be greater than 0, but received {nhead}"
+        )
         assert dim_feedforward > 0, (
             "Expected dim_feedforward to be greater than 0, "
             f"but received {dim_feedforward}"
@@ -1304,15 +1304,15 @@ class FusedMultiTransformer(Layer):
     ) -> None:
         super().__init__()
 
-        assert (
-            embed_dim > 0
-        ), f"Expected embed_dim to be greater than 0, but received {embed_dim}"
-        assert (
-            num_heads > 0
-        ), f"Expected nhead to be greater than 0, but received {num_heads}"
-        assert (
-            dim_feedforward > 0
-        ), f"Expected dim_feedforward to be greater than 0, but received {dim_feedforward}"
+        assert embed_dim > 0, (
+            f"Expected embed_dim to be greater than 0, but received {embed_dim}"
+        )
+        assert num_heads > 0, (
+            f"Expected nhead to be greater than 0, but received {num_heads}"
+        )
+        assert dim_feedforward > 0, (
+            f"Expected dim_feedforward to be greater than 0, but received {dim_feedforward}"
+        )
 
         self.normalize_before = normalize_before
         self._dtype = self._helper.get_default_dtype()
@@ -1330,9 +1330,9 @@ class FusedMultiTransformer(Layer):
         self.embed_dim = embed_dim
         self.num_heads = num_heads
         self.head_dim = embed_dim // num_heads
-        assert (
-            self.head_dim * num_heads == embed_dim
-        ), "embed_dim must be divisible by num_heads"
+        assert self.head_dim * num_heads == embed_dim, (
+            "embed_dim must be divisible by num_heads"
+        )
 
         # tensor model parallel
         if nranks > 1:

--- a/python/paddle/incubate/optimizer/distributed_fused_lamb.py
+++ b/python/paddle/incubate/optimizer/distributed_fused_lamb.py
@@ -138,9 +138,9 @@ class DistributedFusedLamb(Optimizer):
         use_hierarchical_allreduce=False,
         name=None,
     ):
-        assert (
-            not paddle.in_dynamic_mode()
-        ), "DistributedFusedLamb does not support dygraph mode"
+        assert not paddle.in_dynamic_mode(), (
+            "DistributedFusedLamb does not support dygraph mode"
+        )
         super().__init__(learning_rate=learning_rate, grad_clip=None, name=name)
 
         self._beta1 = beta1
@@ -150,9 +150,9 @@ class DistributedFusedLamb(Optimizer):
             lamb_weight_decay if lamb_weight_decay is not None else 0.0
         )
         if grad_clip is not None:
-            assert isinstance(
-                grad_clip, ClipGradByGlobalNorm
-            ), "Only ClipGradByGlobalNorm is supported in DistributedFusedLamb"
+            assert isinstance(grad_clip, ClipGradByGlobalNorm), (
+                "Only ClipGradByGlobalNorm is supported in DistributedFusedLamb"
+            )
             max_global_grad_norm = grad_clip.clip_norm
         else:
             max_global_grad_norm = -1.0
@@ -278,9 +278,9 @@ class DistributedFusedLamb(Optimizer):
 
     def _apply_gradients_impl(self, params_grads):
         for p, g in params_grads:
-            assert (
-                g.type == core.VarDesc.VarType.DENSE_TENSOR
-            ), "Only support dense gradient"
+            assert g.type == core.VarDesc.VarType.DENSE_TENSOR, (
+                "Only support dense gradient"
+            )
             g.persistable = True  # the gradient must be persistable for fusion
 
         fp32_fused_param = self._create_persistable_var('fp32_fused_param')
@@ -348,9 +348,9 @@ class DistributedFusedLamb(Optimizer):
             nproc_per_node = nranks
         else:
             nproc_per_node = self._nproc_per_node
-        assert (
-            nranks % nproc_per_node == 0
-        ), "nranks should be exactly divided by nproc_per_node"
+        assert nranks % nproc_per_node == 0, (
+            "nranks should be exactly divided by nproc_per_node"
+        )
 
         shard_inside_node = nranks > nproc_per_node
         local_rank = rank % nproc_per_node
@@ -452,9 +452,9 @@ class DistributedFusedLamb(Optimizer):
                 lr = self._create_param_lr(p_g)
             else:
                 new_lr = self._create_param_lr(p_g)
-                assert id(lr) == id(
-                    new_lr
-                ), "The learning rate for each parameter should be the same"
+                assert id(lr) == id(new_lr), (
+                    "The learning rate for each parameter should be the same"
+                )
         assert lr is not None
 
         lamb_op = main_block.append_op(

--- a/python/paddle/incubate/optimizer/gradient_merge.py
+++ b/python/paddle/incubate/optimizer/gradient_merge.py
@@ -97,9 +97,9 @@ class GradientMergeOptimizer:
             )
 
         assert inner_optimizer is not None, "inner optimizer can not be None"
-        assert (
-            isinstance(k_steps, int) and k_steps > 0
-        ), "k_steps should be a positive integer"
+        assert isinstance(k_steps, int) and k_steps > 0, (
+            "k_steps should be a positive integer"
+        )
 
         self.inner_optimizer = inner_optimizer
         self.k_steps = k_steps
@@ -122,12 +122,12 @@ class GradientMergeOptimizer:
         callbacks=None,
     ):
         assert isinstance(loss, Variable), "The loss should be an Variable."
-        assert (
-            parameter_list is None
-        ), "The parameter_list should be None when using GradientMergeOptimizer"
-        assert (
-            no_grad_set is None
-        ), "The no_grad_set should be None when using GradientMergeOptimizer"
+        assert parameter_list is None, (
+            "The parameter_list should be None when using GradientMergeOptimizer"
+        )
+        assert no_grad_set is None, (
+            "The no_grad_set should be None when using GradientMergeOptimizer"
+        )
 
         params_grads = self.inner_optimizer.backward(
             loss, startup_program=startup_program
@@ -152,18 +152,18 @@ class GradientMergeOptimizer:
     def _remove_op_role_var(self, param, grad):
         op_maker = core.op_proto_and_checker_maker
         op = grad.op
-        assert self._is_the_backward_op(
-            op
-        ), f'grad.op={op} is not the backward op which produces the grad={grad.name}'
+        assert self._is_the_backward_op(op), (
+            f'grad.op={op} is not the backward op which produces the grad={grad.name}'
+        )
 
         block = grad.block
         var_attr = op.all_attrs()[op_maker.kOpRoleVarAttrName()]
-        assert (
-            param.name in var_attr
-        ), f'when using GradientMergeOptimizer, param={param.name} must be in var_attr={var_attr}'
-        assert (
-            grad.name in var_attr
-        ), f'when using GradientMergeOptimizer, grad={param.name} must be in var_attr={var_attr}'
+        assert param.name in var_attr, (
+            f'when using GradientMergeOptimizer, param={param.name} must be in var_attr={var_attr}'
+        )
+        assert grad.name in var_attr, (
+            f'when using GradientMergeOptimizer, grad={param.name} must be in var_attr={var_attr}'
+        )
 
         # remove (param, grad) from op_role_var
         var_attr.remove(param.name)
@@ -252,9 +252,9 @@ class GradientMergeOptimizer:
         # TODO(mapingshuo) support sparse embedding
         # step1: remove grad.op's op_role_var
         for param, grad in params_grads:
-            assert (
-                param.type != core.VarDesc.VarType.SELECTED_ROWS
-            ), "SELECTED_ROWS is not supported in GradientMergeOptimizer for now"
+            assert param.type != core.VarDesc.VarType.SELECTED_ROWS, (
+                "SELECTED_ROWS is not supported in GradientMergeOptimizer for now"
+            )
 
             self._remove_op_role_var(param, grad)
 

--- a/python/paddle/incubate/optimizer/lookahead.py
+++ b/python/paddle/incubate/optimizer/lookahead.py
@@ -137,9 +137,9 @@ class LookAhead(Optimizer):
         name: str | None = None,
     ) -> None:
         assert inner_optimizer is not None, "inner optimizer can not be None"
-        assert (
-            0.0 <= alpha <= 1.0
-        ), "alpha should be larger or equal to 0.0, and less or equal than 1.0"
+        assert 0.0 <= alpha <= 1.0, (
+            "alpha should be larger or equal to 0.0, and less or equal than 1.0"
+        )
         assert isinstance(k, int) and k > 0, "k should be a positive integer"
 
         self.inner_optimizer = inner_optimizer
@@ -338,9 +338,9 @@ class LookAhead(Optimizer):
                 >>> lookahead.clear_grad()
 
         """
-        assert isinstance(
-            loss, (Variable, paddle.pir.Value)
-        ), "The loss should be an Tensor."
+        assert isinstance(loss, (Variable, paddle.pir.Value)), (
+            "The loss should be an Tensor."
+        )
 
         # Apply inner optimizer to the main_program
         optimize_ops, params_grads = self.inner_optimizer.minimize(

--- a/python/paddle/incubate/optimizer/pipeline.py
+++ b/python/paddle/incubate/optimizer/pipeline.py
@@ -114,13 +114,13 @@ class PipelineOptimizer:
         while hasattr(self._origin_optimizer, "inner_opt"):
             self._origin_optimizer = self._origin_optimizer.inner_opt
 
-        assert (
-            num_microbatches >= 1
-        ), "num_microbatches must be a positive value."
+        assert num_microbatches >= 1, (
+            "num_microbatches must be a positive value."
+        )
         self._num_microbatches = num_microbatches
-        assert (
-            start_cpu_core_id >= 0
-        ), "start_cpu_core_id must be a non-negative integer."
+        assert start_cpu_core_id >= 0, (
+            "start_cpu_core_id must be a non-negative integer."
+        )
         self._start_cpu_core_id = start_cpu_core_id
         self._place_list = None
         op_maker = core.op_proto_and_checker_maker
@@ -481,9 +481,9 @@ class PipelineOptimizer:
             else None
         )
         if device:
-            assert (
-                device[0:3] == 'gpu'
-            ), "Now, only gpu devices are supported in pipeline parallelism."
+            assert device[0:3] == 'gpu', (
+                "Now, only gpu devices are supported in pipeline parallelism."
+            )
         return device
 
     def _add_op_device_attr_for_op(self, op, idx, block):
@@ -502,15 +502,15 @@ class PipelineOptimizer:
         elif op.type == "sum" and self._is_backward_op(op):
             # For sum ops that compute the sum of @RENAMED@ vars
             for name in op.desc.input_arg_names():
-                assert (
-                    '@RENAME@' in name
-                ), "The op must be sum used to accumulate renamed vars."
+                assert '@RENAME@' in name, (
+                    "The op must be sum used to accumulate renamed vars."
+                )
             assert len(op.desc.output_arg_names()) == 1
             out_name = op.desc.output_arg_names()[0]
             post_op = self._find_post_op(idx, out_name)
-            assert post_op.has_attr(
-                'op_device'
-            ), f"{post_op.type} has no op_device attr for var {out_name}"
+            assert post_op.has_attr('op_device'), (
+                f"{post_op.type} has no op_device attr for var {out_name}"
+            )
             device = post_op.attr(self._op_device_key)
             assert device, "The post op must have op_device set."
             op._set_attr(self._op_device_key, device)
@@ -655,29 +655,29 @@ class PipelineOptimizer:
                     "Now, the only supported op without kernel is "
                     "conditional_block, and its op role must be LRSched."
                 )
-            assert op.has_attr(
-                self._op_role_key
-            ), f"op ({op.type}) has no {self._op_role_key} attribute."
+            assert op.has_attr(self._op_role_key), (
+                f"op ({op.type}) has no {self._op_role_key} attribute."
+            )
             op_role = op.attr(self._op_role_key)
-            assert (
-                int(op_role) in valid_op_role_value
-            ), f"op_role {op_role} for op {op.type} must be one of {valid_op_role_value}"
+            assert int(op_role) in valid_op_role_value, (
+                f"op_role {op_role} for op {op.type} must be one of {valid_op_role_value}"
+            )
 
-            assert op.has_attr(
-                self._op_device_key
-            ), f"op ({op.type}) has no {self._op_device_key} attribute."
+            assert op.has_attr(self._op_device_key), (
+                f"op ({op.type}) has no {self._op_device_key} attribute."
+            )
 
             device = op.attr(self._op_device_key)
-            assert (
-                device
-            ), f"op_device attribute for op {op.type} has not been set."
+            assert device, (
+                f"op_device attribute for op {op.type} has not been set."
+            )
             if device == f"{self._device}:all":
                 continue
 
             dev_type = device.split(':')[0]
-            assert (
-                dev_type == "gpu"
-            ), "Now only gpu devices are supported for pipeline parallelism."
+            assert dev_type == "gpu", (
+                "Now only gpu devices are supported for pipeline parallelism."
+            )
 
             if device not in device_list:
                 device_list.append(device)
@@ -1835,9 +1835,9 @@ class PipelineOptimizer:
             'mp_rank',
         ]
         for key in required_keys:
-            assert (
-                key in pipeline_opt
-            ), f'Please use pipeline with fleet to use {key}.'
+            assert key in pipeline_opt, (
+                f'Please use pipeline with fleet to use {key}.'
+            )
         self.local_rank = pipeline_opt['local_rank']
         self.schedule_mode = pipeline_opt['schedule_mode']
         self.micro_batch_size = pipeline_opt['micro_batch_size']

--- a/python/paddle/incubate/passes/ir.py
+++ b/python/paddle/incubate/passes/ir.py
@@ -311,9 +311,9 @@ class PassDesc:
 
     class OpHelper:
         def _to_readable_code(self, skip_op_callstack=True):
-            assert isinstance(
-                skip_op_callstack, bool
-            ), f"skip_op_callstack parameter's type is error, expect bool, received {type(skip_op_callstack)}"
+            assert isinstance(skip_op_callstack, bool), (
+                f"skip_op_callstack parameter's type is error, expect bool, received {type(skip_op_callstack)}"
+            )
             outputs_str = "{"
             outputs_str += ", ".join(
                 [f"{k}={v}" for k, v in self._outputs.items()]

--- a/python/paddle/io/dataloader/batch_sampler.py
+++ b/python/paddle/io/dataloader/batch_sampler.py
@@ -115,35 +115,35 @@ class BatchSampler(Sampler[Sequence[int]]):
         drop_last: bool = False,
     ) -> None:
         if dataset is None:
-            assert (
-                sampler is not None
-            ), "either dataset or sampler should be set"
-            assert isinstance(
-                sampler, (Sampler, Iterable)
-            ), f"sampler should be either paddle.io.Sampler or Iterable, but got {type(sampler)}"
+            assert sampler is not None, (
+                "either dataset or sampler should be set"
+            )
+            assert isinstance(sampler, (Sampler, Iterable)), (
+                f"sampler should be either paddle.io.Sampler or Iterable, but got {type(sampler)}"
+            )
             assert not shuffle, "shuffle should be False when sampler is set"
             self.sampler = sampler
         else:
-            assert not isinstance(
-                dataset, IterableDataset
-            ), "dataset should not be a paddle.io.IterableDataset"
+            assert not isinstance(dataset, IterableDataset), (
+                "dataset should not be a paddle.io.IterableDataset"
+            )
             assert sampler is None, "should not set both dataset and sampler"
-            assert isinstance(
-                shuffle, bool
-            ), f"shuffle should be a boolean value, but got {type(shuffle)}"
+            assert isinstance(shuffle, bool), (
+                f"shuffle should be a boolean value, but got {type(shuffle)}"
+            )
             if shuffle:
                 self.sampler = RandomSampler(dataset)
             else:
                 self.sampler = SequenceSampler(dataset)
 
-        assert (
-            isinstance(batch_size, int) and batch_size > 0
-        ), f"batch_size should be a positive integer, but got {batch_size}"
+        assert isinstance(batch_size, int) and batch_size > 0, (
+            f"batch_size should be a positive integer, but got {batch_size}"
+        )
         self.batch_size = batch_size  # per_device_batch_size or mini_batch_size
         self.shuffle = shuffle
-        assert isinstance(
-            drop_last, bool
-        ), f"drop_last should be a boolean value, but got {type(drop_last)}"
+        assert isinstance(drop_last, bool), (
+            f"drop_last should be a boolean value, but got {type(drop_last)}"
+        )
         self.drop_last = drop_last
 
         # TODO(dev): consider to make it as public argument, acc_steps is only used
@@ -173,9 +173,9 @@ class _InfiniteIterableSampler(Sampler[Sequence[None]]):
     batch_size: int
 
     def __init__(self, dataset: IterableDataset, batch_size: int = 1) -> None:
-        assert isinstance(
-            dataset, IterableDataset
-        ), "dataset should be an instance of paddle.io.IterableDataset"
+        assert isinstance(dataset, IterableDataset), (
+            "dataset should be an instance of paddle.io.IterableDataset"
+        )
         self.dataset = dataset
         self.batch_size = batch_size
 
@@ -262,30 +262,30 @@ class DistributedBatchSampler(BatchSampler):
     ) -> None:
         self.dataset = dataset
 
-        assert (
-            isinstance(batch_size, int) and batch_size > 0
-        ), "batch_size should be a positive integer"
+        assert isinstance(batch_size, int) and batch_size > 0, (
+            "batch_size should be a positive integer"
+        )
         self.batch_size = batch_size
         assert isinstance(shuffle, bool), "shuffle should be a boolean value"
         self.shuffle = shuffle
-        assert isinstance(
-            drop_last, bool
-        ), "drop_last should be a boolean number"
+        assert isinstance(drop_last, bool), (
+            "drop_last should be a boolean number"
+        )
 
         from paddle.distributed import ParallelEnv
 
         if num_replicas is not None:
-            assert (
-                isinstance(num_replicas, int) and num_replicas > 0
-            ), "num_replicas should be a positive integer"
+            assert isinstance(num_replicas, int) and num_replicas > 0, (
+                "num_replicas should be a positive integer"
+            )
             self.nranks = num_replicas
         else:
             self.nranks = ParallelEnv().nranks
 
         if rank is not None:
-            assert (
-                isinstance(rank, int) and rank >= 0
-            ), "rank should be a non-negative integer"
+            assert isinstance(rank, int) and rank >= 0, (
+                "rank should be a non-negative integer"
+            )
             self.local_rank = rank
         else:
             self.local_rank = ParallelEnv().local_rank
@@ -334,8 +334,9 @@ class DistributedBatchSampler(BatchSampler):
             indices = indices[len(indices) - last_batch_size :]
             subsampled_indices.extend(
                 indices[
-                    self.local_rank
-                    * last_local_batch_size : (self.local_rank + 1)
+                    self.local_rank * last_local_batch_size : (
+                        self.local_rank + 1
+                    )
                     * last_local_batch_size
                 ]
             )

--- a/python/paddle/io/dataloader/dataloader_iter.py
+++ b/python/paddle/io/dataloader/dataloader_iter.py
@@ -376,9 +376,9 @@ class _DataLoaderIterMultiProcess(_DataLoaderIterBase):
         self._persistent_workers = loader._persistent_workers
         self._resume_worker_cnt = 0
 
-        assert (
-            self._num_workers > 0
-        ), f"Multi-process DataLoader invalid num_workers({self._num_workers})"
+        assert self._num_workers > 0, (
+            f"Multi-process DataLoader invalid num_workers({self._num_workers})"
+        )
 
         # subprocess wrokers' result queue
         self._data_queue = None
@@ -784,9 +784,9 @@ class _DataLoaderIterMultiProcess(_DataLoaderIterBase):
                     continue
 
     def _try_put_indices(self):
-        assert (
-            self._batches_outstanding <= self._outstanding_capacity
-        ), "too many indices have been put to queue"
+        assert self._batches_outstanding <= self._outstanding_capacity, (
+            "too many indices have been put to queue"
+        )
         # In multi-process mode for IterableDataset, _try_put_indices will
         # be called both in main process(for our implement has blocking queue,
         # and blocking queue read is in main process) and thread, which may

--- a/python/paddle/io/dataloader/dataset.py
+++ b/python/paddle/io/dataloader/dataset.py
@@ -398,16 +398,16 @@ class ComposeDataset(Dataset[tuple[Unpack[_Ts]]]):
         self.datasets = list(datasets)
         assert len(self.datasets) > 0, "input datasets should not be empty"
         for i, dataset in enumerate(self.datasets):
-            assert isinstance(
-                dataset, Dataset
-            ), "each input dataset should be paddle.io.Dataset"
-            assert not isinstance(
-                dataset, IterableDataset
-            ), "paddle.io.IterableDataset not supported"
+            assert isinstance(dataset, Dataset), (
+                "each input dataset should be paddle.io.Dataset"
+            )
+            assert not isinstance(dataset, IterableDataset), (
+                "paddle.io.IterableDataset not supported"
+            )
             if i > 0:
-                assert len(dataset) == len(
-                    self.datasets[i - 1]
-                ), "lengths of datasets should be same"
+                assert len(dataset) == len(self.datasets[i - 1]), (
+                    "lengths of datasets should be same"
+                )
 
     def __len__(self) -> int:
         return len(self.datasets[0])
@@ -463,9 +463,9 @@ class ChainDataset(IterableDataset[Any]):
         self.datasets = list(datasets)
         assert len(self.datasets) > 0, "input datasets should not be empty"
         for i, dataset in enumerate(self.datasets):
-            assert isinstance(
-                dataset, IterableDataset
-            ), "ChainDataset only support paddle.io.IterableDataset"
+            assert isinstance(dataset, IterableDataset), (
+                "ChainDataset only support paddle.io.IterableDataset"
+            )
 
     def __iter__(self) -> Iterator[Any]:
         for dataset in self.datasets:
@@ -694,13 +694,13 @@ class ConcatDataset(Dataset[_T]):
 
     def __init__(self, datasets: Iterable[Dataset[Any]]) -> None:
         self.datasets = list(datasets)
-        assert (
-            len(self.datasets) > 0
-        ), 'datasets should not be an empty iterable'
+        assert len(self.datasets) > 0, (
+            'datasets should not be an empty iterable'
+        )
         for d in self.datasets:
-            assert not isinstance(
-                d, IterableDataset
-            ), "ConcatDataset does not support IterableDataset"
+            assert not isinstance(d, IterableDataset), (
+                "ConcatDataset does not support IterableDataset"
+            )
         self.cumulative_sizes = self.cumsum(self.datasets)
 
     def __len__(self) -> int:

--- a/python/paddle/io/dataloader/flat.py
+++ b/python/paddle/io/dataloader/flat.py
@@ -106,9 +106,9 @@ def _restore_batch(flat_batch, structure):
                 if isinstance(field, str) and field.startswith(FIELD_PREFIX):
                     cur_field_idx = int(field.replace(FIELD_PREFIX, ''))
                     field_idx = max(field_idx, cur_field_idx)
-                    assert (
-                        flat_batch[cur_field_idx] is not None
-                    ), "flat_batch[{}] parsed repeatedly"
+                    assert flat_batch[cur_field_idx] is not None, (
+                        "flat_batch[{}] parsed repeatedly"
+                    )
                     structure[i] = flat_batch[cur_field_idx]
                     flat_batch[cur_field_idx] = None
                 elif isinstance(field, (str, bytes, numbers.Number)):
@@ -120,9 +120,9 @@ def _restore_batch(flat_batch, structure):
                 if isinstance(field, str) and field.startswith(FIELD_PREFIX):
                     cur_field_idx = int(field.replace(FIELD_PREFIX, ''))
                     field_idx = max(field_idx, cur_field_idx)
-                    assert (
-                        flat_batch[cur_field_idx] is not None
-                    ), "flat_batch[{}] parsed repeatedly"
+                    assert flat_batch[cur_field_idx] is not None, (
+                        "flat_batch[{}] parsed repeatedly"
+                    )
                     structure[k] = flat_batch[cur_field_idx]
                     flat_batch[cur_field_idx] = None
                 elif isinstance(field, (str, bytes, numbers.Number)):
@@ -143,9 +143,9 @@ def _restore_batch(flat_batch, structure):
 
     # sample only contains single fields
     if isinstance(structure, (str, bytes)):
-        assert (
-            structure == f'{FIELD_PREFIX}{0}'
-        ), f"invalid structure: {structure}"
+        assert structure == f'{FIELD_PREFIX}{0}', (
+            f"invalid structure: {structure}"
+        )
         return flat_batch[0]
     field_idx = _restore(structure, 0)
     assert field_idx + 1 == len(flat_batch), "Tensor parse incomplete"

--- a/python/paddle/io/dataloader/sampler.py
+++ b/python/paddle/io/dataloader/sampler.py
@@ -295,9 +295,9 @@ def _weighted_sample(weights, num_samples, replacement=True):
         weights = weights.numpy()
     if isinstance(weights, (list, tuple)):
         weights = np.array(weights)
-    assert isinstance(
-        weights, np.ndarray
-    ), "weights should be paddle.Tensor, numpy.ndarray, list or tuple"
+    assert isinstance(weights, np.ndarray), (
+        "weights should be paddle.Tensor, numpy.ndarray, list or tuple"
+    )
     assert len(weights.shape) <= 2, "weights should be a 1-D or 2-D array"
     weights = weights.reshape((-1, weights.shape[-1]))
     assert np.all(weights >= 0.0), "weights should be positive value"

--- a/python/paddle/io/dataloader/worker.py
+++ b/python/paddle/io/dataloader/worker.py
@@ -356,9 +356,9 @@ def _worker_loop(
 
             # None as poison piil, so worker event should be set
             if data is None:
-                assert (
-                    done_event.is_set() or iterator_drained
-                ), "get None when worker done_event set"
+                assert done_event.is_set() or iterator_drained, (
+                    "get None when worker done_event set"
+                )
                 break
             # If worker done event is set but get still get data in
             # indices_queue, remaining data should be get and skipped.

--- a/python/paddle/io/reader.py
+++ b/python/paddle/io/reader.py
@@ -476,9 +476,9 @@ class DataLoader:
         self.dataset = dataset
 
         if not return_list and not in_dynamic_mode():
-            assert (
-                feed_list is not None
-            ), "feed_list should be set when return_list=False"
+            assert feed_list is not None, (
+                "feed_list should be set when return_list=False"
+            )
         self.feed_list = feed_list
 
         if places is None:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

使用性能更好，格式化效果更佳的 ruff format 替代 black 作为新的 formatter，由于我们很早就已经集成了 ruff lint，因此只是减少依赖而不会增加依赖

<!--

## 核心优势

通过集成 Ruff format，开发者可以享受到以下优势：

- 通过去除 black 对 python 环境依赖，极大降低了升级 formatter 带来的成本，后续无需考虑开发者本地 python 环境即可一键升级
- ruff 由 Rust 驱动，大幅加速 format 时间，降低开发者使用开发工具链的时间成本，减少 CI 时间，提升工程效率
- 格式化后呈现可读性更佳的效果，使得开发者更专注于代码开发而无需关心格式，阅读者也能够更加赏心悦目，极大增加了潜在贡献者的贡献意愿
- ruff 极大程度地兼容了 black 的格式化效果，能够平滑地替换现有的 black 配置
- ruff 更新频次高，能够快速响应社区反馈，持续优化格式化效果
- ruff 团队 Astral 最近开发的 ty 能够提供更强大的类型检查能力，后续可能与 ruff 集成，提供更好的开发体验
- PyTorch 最近已经完成迁移，追平竞品（在代码风格这块，我们一直做到了超越竞品，这次不能落后）

-->