### PR TITLE
[CodeStyle] `black -> ruff format` migration - part 31

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -87,7 +87,7 @@ repos:
 
             # | python/paddle/[e-i].+
 
-            # | python/paddle/j.+
+            | python/paddle/j.+
 
             # | python/paddle/[k-n].+
 
@@ -143,7 +143,7 @@ repos:
 
             | python/paddle/[e-i].+
 
-            | python/paddle/j.+
+            # | python/paddle/j.+
 
             | python/paddle/[k-n].+
 

--- a/python/paddle/jit/dy2static/convert_operators.py
+++ b/python/paddle/jit/dy2static/convert_operators.py
@@ -756,13 +756,17 @@ def convert_var_dtype(var, dtype):
             'int32',
             'int64',
             'uint8',
-        ], f"The dtype of var {var.name} is {src_dtype}, which is not supported in the cast op."
+        ], (
+            f"The dtype of var {var.name} is {src_dtype}, which is not supported in the cast op."
+        )
         assert dtype in [
             'bool',
             'int',
             'float',
             'complex',
-        ], f"The casted target dtype is {dtype}, which is not supported in type casting."
+        ], (
+            f"The casted target dtype is {dtype}, which is not supported in type casting."
+        )
         cast_map = {
             'bool': 'bool',
             'int': 'int32',
@@ -776,7 +780,9 @@ def convert_var_dtype(var, dtype):
             'int',
             'float',
             'complex',
-        ], f"The casted target dtype is {dtype}, which is not supported in type casting."
+        ], (
+            f"The casted target dtype is {dtype}, which is not supported in type casting."
+        )
         return eval(dtype)(var)
 
 

--- a/python/paddle/jit/dy2static/origin_info.py
+++ b/python/paddle/jit/dy2static/origin_info.py
@@ -155,9 +155,9 @@ def create_and_update_origin_info_map(
     static_node = attach_origin_info(static_node, static_func)
 
     for t_node, s_node in ast_walk(transformed_node, static_node):
-        assert type(t_node) == type(
-            s_node
-        ), f"The node types should be the same, but received type(t_node) is {type(t_node)}, and type(s_node) is {type(s_node)}."
+        assert type(t_node) == type(s_node), (
+            f"The node types should be the same, but received type(t_node) is {type(t_node)}, and type(s_node) is {type(s_node)}."
+        )
         dygraph_info = getattr(t_node, ORIGIN_INFO, None)
         static_info = getattr(s_node, ORIGIN_INFO, None)
 
@@ -232,9 +232,9 @@ def ast_walk(transformed_node, static_node):
             ):
                 continue
 
-        assert type(t_node) == type(
-            s_node
-        ), f"The node types should be the same, but received type(t_node) is {type(t_node)}, and type(s_node) is {type(s_node)}."
+        assert type(t_node) == type(s_node), (
+            f"The node types should be the same, but received type(t_node) is {type(t_node)}, and type(s_node) is {type(s_node)}."
+        )
 
         yield t_node, s_node
 

--- a/python/paddle/jit/dy2static/pir_partial_program.py
+++ b/python/paddle/jit/dy2static/pir_partial_program.py
@@ -218,15 +218,15 @@ class RunnableProgram:
         forward_range=None,
         backward_range=None,
     ):
-        assert isinstance(
-            in_out_values, tuple
-        ), "in_out_values must be tuple with len == 3"
-        assert (
-            len(in_out_values) == 3
-        ), "in_out_values must be tuple with len == 3"
-        assert isinstance(
-            in_out_values[0], list
-        ), "in_out_values must be tuple with len == 3"
+        assert isinstance(in_out_values, tuple), (
+            "in_out_values must be tuple with len == 3"
+        )
+        assert len(in_out_values) == 3, (
+            "in_out_values must be tuple with len == 3"
+        )
+        assert isinstance(in_out_values[0], list), (
+            "in_out_values must be tuple with len == 3"
+        )
         self.program = program
         self.x_names = self.convert_name(in_out_values[0])
         self.param_names = self.convert_name(in_out_values[1])
@@ -310,9 +310,9 @@ class RunnableProgram:
         )
 
     def split_forward_backward(self):
-        assert (
-            self.has_splited is False
-        ), "Please ensure only split once! don't call split_forward_backward manually."
+        assert self.has_splited is False, (
+            "Please ensure only split once! don't call split_forward_backward manually."
+        )
         self.has_splited = True
         self.update_op_range()
         (
@@ -406,9 +406,9 @@ class RunnableProgram:
 
     @cached_property  # shouldn't changed when call this once.
     def program_attr(self):
-        assert (
-            self.finish_pass is False
-        ), "program_attr() is called by PartialProgramLayer, don't call it manually, use program_name_attr instead."
+        assert self.finish_pass is False, (
+            "program_attr() is called by PartialProgramLayer, don't call it manually, use program_name_attr instead."
+        )
         # can't apply pass after call this function.
         self.finish_pass = True
         fwd_map = RunnableProgram._get_name_value_map_from_program(
@@ -445,9 +445,9 @@ class RunnableProgram:
             program_attr[f"{k}_names"] = ns
 
         # Restore stop_gradient for output values
-        assert len(program_attr["fo_values"]) == len(
-            self.out_stop_gradients
-        ), "Output values and stop gradients length mismatch"
+        assert len(program_attr["fo_values"]) == len(self.out_stop_gradients), (
+            "Output values and stop gradients length mismatch"
+        )
         for v, stop_gradient in zip(
             program_attr["fo_values"], self.out_stop_gradients
         ):
@@ -474,9 +474,9 @@ class RunnableProgram:
         # Get all values again because some values has been erased.
         for value in RunnableProgram._get_program_all_values(program):
             if value.has_name:
-                assert (
-                    value._has_only_one_name()
-                ), f"Expected all values in Program have only one name, but {value} has multiple names: {value._names}"
+                assert value._has_only_one_name(), (
+                    f"Expected all values in Program have only one name, but {value} has multiple names: {value._names}"
+                )
         return rename_mapping
 
     @staticmethod

--- a/python/paddle/jit/dy2static/program_translator.py
+++ b/python/paddle/jit/dy2static/program_translator.py
@@ -672,9 +672,9 @@ class StaticFunction(Generic[_InputT, _RetT]):
             if self._patched_name is not None
             else self._dygraph_function.__name__
         )
-        assert (
-            fn_name in self.class_instance._original_funcs
-        ), f"Not Found function '{fn_name}' in class '{self.class_instance.__class__}'."
+        assert fn_name in self.class_instance._original_funcs, (
+            f"Not Found function '{fn_name}' in class '{self.class_instance.__class__}'."
+        )
         func = self.class_instance._original_funcs[fn_name]
         setattr(self.class_instance, fn_name, func.__get__(self.class_instance))
         return getattr(self.class_instance, fn_name)
@@ -1733,9 +1733,9 @@ class ProgramCache:
         return self._caches[item_id]
 
     def last(self):
-        assert (
-            len(self._caches) >= 1
-        ), "No valid cached program in ProgramCache."
+        assert len(self._caches) >= 1, (
+            "No valid cached program in ProgramCache."
+        )
         assert self._recent_key is not None
         return self._recent_key, self._caches[self._recent_key]
 

--- a/python/paddle/jit/dy2static/transformers/base.py
+++ b/python/paddle/jit/dy2static/transformers/base.py
@@ -184,9 +184,9 @@ class ForNodeVisitor:
     """
 
     def __init__(self, for_node):
-        assert isinstance(
-            for_node, gast.For
-        ), "Input node for the initialization of ForNodeVisitor is not gast.For node."
+        assert isinstance(for_node, gast.For), (
+            "Input node for the initialization of ForNodeVisitor is not gast.For node."
+        )
         # 1. original for node
         self.node = for_node
 
@@ -276,14 +276,14 @@ class ForNodeVisitor:
     def _args_check(self):
         if self.is_for_range_iter():
             self.args_length = len(self.iter_args)
-            assert (
-                self.args_length >= 1 and self.args_length <= 3
-            ), "range() function takes 1 to 3 arguments"
+            assert self.args_length >= 1 and self.args_length <= 3, (
+                "range() function takes 1 to 3 arguments"
+            )
         elif self.is_for_enumerate_iter():
             self.args_length = len(self.iter_args)
-            assert (
-                self.args_length >= 1 and self.args_length <= 2
-            ), "enumerate() function takes 1 to 2 arguments"
+            assert self.args_length >= 1 and self.args_length <= 2, (
+                "enumerate() function takes 1 to 2 arguments"
+            )
         else:
             self.args_length = None
 

--- a/python/paddle/jit/dy2static/transformers/break_continue_transformer.py
+++ b/python/paddle/jit/dy2static/transformers/break_continue_transformer.py
@@ -31,9 +31,9 @@ class ForToWhileTransformer(BaseTransformer):
     """
 
     def __init__(self, parent_node, loop_node, condition_node):
-        assert isinstance(
-            loop_node, gast.For
-        ), "loop_node is not gast.For in ForToWhileTransformer"
+        assert isinstance(loop_node, gast.For), (
+            "loop_node is not gast.For in ForToWhileTransformer"
+        )
         self.parent_node = parent_node
         self.loop_node = loop_node
         self.condition_node = condition_node
@@ -60,9 +60,9 @@ class ForToWhileTransformer(BaseTransformer):
         )
 
     def get_for_stmt_nodes(self, node):
-        assert isinstance(
-            node, gast.For
-        ), "Input node is NOT gast.For in get_for_stmt_nodes"
+        assert isinstance(node, gast.For), (
+            "Input node is NOT gast.For in get_for_stmt_nodes"
+        )
 
         # 1. parse current gast.For node
         current_for_node_parser = ForNodeVisitor(node)

--- a/python/paddle/jit/dy2static/transformers/early_return_transformer.py
+++ b/python/paddle/jit/dy2static/transformers/early_return_transformer.py
@@ -34,9 +34,9 @@ class EarlyReturnTransformer(BaseTransformer):
         self.visit(self.root)
 
     def is_define_return_in_if(self, node):
-        assert isinstance(
-            node, gast.If
-        ), f"Type of input node should be gast.If, but received {type(node)}."
+        assert isinstance(node, gast.If), (
+            f"Type of input node should be gast.If, but received {type(node)}."
+        )
         for child in node.body:
             if isinstance(child, gast.Return):
                 return True

--- a/python/paddle/jit/dy2static/transformers/logical_transformer.py
+++ b/python/paddle/jit/dy2static/transformers/logical_transformer.py
@@ -83,9 +83,9 @@ class LogicalTransformer(BaseTransformer):
           according to the actual order. In `convert_logical_and(lambda:x>1, lambda:y<1)`, `lambda:y<1`
           must be run after `lambda:x>1`, If `x>1` is False, `y<1` should NOT be run.
         '''
-        assert (
-            len(nodes) > 1
-        ), f"The length of BoolOp should be at least 2, but received {len(nodes)}."
+        assert len(nodes) > 1, (
+            f"The length of BoolOp should be at least 2, but received {len(nodes)}."
+        )
         if len(nodes) > 2:
             # Creates logic_and/logic_or node recursively.
             pre_logic_node = self._create_bool_op_node(nodes[:2], api_type)

--- a/python/paddle/jit/dy2static/transformers/loop_transformer.py
+++ b/python/paddle/jit/dy2static/transformers/loop_transformer.py
@@ -134,9 +134,9 @@ class NameVisitor(gast.NodeVisitor):
         self.visit(root_node)
 
     def get_loop_var_names(self, node):
-        assert isinstance(
-            node, (gast.While, gast.For)
-        ), "Input node is not gast loop node"
+        assert isinstance(node, (gast.While, gast.For)), (
+            "Input node is not gast loop node"
+        )
         loop_var_names = set()
         create_var_names = set()
         read_context = {type(gast.Load()), type(gast.AugLoad())}

--- a/python/paddle/jit/dy2static/transformers/name_load_transformer.py
+++ b/python/paddle/jit/dy2static/transformers/name_load_transformer.py
@@ -98,9 +98,9 @@ class AttributeJstTransformer(BaseTransformer):
     """
 
     def __init__(self, node):
-        assert isinstance(
-            node, gast.AST
-        ), "Input non-gast.AST node for the initialization of ToTensorTransformer."
+        assert isinstance(node, gast.AST), (
+            "Input non-gast.AST node for the initialization of ToTensorTransformer."
+        )
         self.interested_name = {
             'size',
         }

--- a/python/paddle/jit/dy2static/transformers/return_transformer.py
+++ b/python/paddle/jit/dy2static/transformers/return_transformer.py
@@ -85,9 +85,9 @@ class ReturnAnalysisVisitor(gast.NodeVisitor):
 
     def __init__(self, root_node):
         self.root = root_node
-        assert isinstance(
-            self.root, gast.FunctionDef
-        ), "Input is not gast.FunctionDef node"
+        assert isinstance(self.root, gast.FunctionDef), (
+            "Input is not gast.FunctionDef node"
+        )
 
         # the number of return statements
         self.count_return = 0
@@ -151,9 +151,9 @@ class SingleReturnTransformer(BaseTransformer):
 
     def __init__(self, root):
         self.root = root
-        assert isinstance(
-            self.root, gast.FunctionDef
-        ), "Input is not gast.FunctionDef node"
+        assert isinstance(self.root, gast.FunctionDef), (
+            "Input is not gast.FunctionDef node"
+        )
 
         self.ancestor_nodes = []
 

--- a/python/paddle/jit/dy2static/transformers/utils.py
+++ b/python/paddle/jit/dy2static/transformers/utils.py
@@ -268,16 +268,16 @@ def generate_name_node(name_ids, ctx=gast.Load(), gen_tuple_if_single=False):
 
 
 def get_attribute_full_name(node):
-    assert isinstance(
-        node, gast.Attribute
-    ), "Input non-Attribute node to get attribute full name"
+    assert isinstance(node, gast.Attribute), (
+        "Input non-Attribute node to get attribute full name"
+    )
     return ast_to_source_code(node).strip()
 
 
 def is_api_in_module(node, module_prefix):
-    assert isinstance(
-        node, gast.Call
-    ), "Input non-Call node for is_api_in_module"
+    assert isinstance(node, gast.Call), (
+        "Input non-Call node for is_api_in_module"
+    )
 
     # Python can have gast.Call as function, for example: convert_call(func)(x)
     # We only check the most outside function
@@ -385,9 +385,9 @@ class NameScope:
         it means global vars; otherwise, it means local vars.
         Only valid after FunctionNameLivenessAnalysis visitor.
         """
-        assert self._is_simple_name(
-            name
-        ), "is_global_var accept a simple name, but get `{name}`."
+        assert self._is_simple_name(name), (
+            "is_global_var accept a simple name, but get `{name}`."
+        )
         ancestor = self
         while ancestor is not None:
             if name in ancestor.globals:
@@ -612,9 +612,9 @@ class FunctionNameLivenessAnalysis(gast.NodeVisitor):
         this node is local to the function and shouldn't
         be created.
         """
-        assert isinstance(
-            node, gast.FunctionDef
-        ), "Input node is not function define node"
+        assert isinstance(node, gast.FunctionDef), (
+            "Input node is not function define node"
+        )
         names = list(node.args.args)
         names.append(node.args.vararg)
         names.append(node.args.kwarg)

--- a/python/paddle/jit/dy2static/utils.py
+++ b/python/paddle/jit/dy2static/utils.py
@@ -790,9 +790,9 @@ class GetterSetterHelper:
         if vars is None:
             return ()
         for n in names:
-            assert (
-                n in self.name2id
-            ), f"the name `{n}` not in name union set`{self.name2id.keys()}`."
+            assert n in self.name2id, (
+                f"the name `{n}` not in name union set`{self.name2id.keys()}`."
+            )
         return tuple(vars[self.name2id[n]] for n in names)
 
     def set(self, names, values):
@@ -804,9 +804,9 @@ class GetterSetterHelper:
         if vars is None:
             return
         for n in names:
-            assert (
-                n in self.name2id
-            ), f"the name `{n}` not in name union set`{self.name2id.keys()}`."
+            assert n in self.name2id, (
+                f"the name `{n}` not in name union set`{self.name2id.keys()}`."
+            )
         vars = list(vars)
         indices = [self.name2id[n] for n in names]
         for i, v in zip(indices, values):

--- a/python/paddle/jit/sot/infer_meta.py
+++ b/python/paddle/jit/sot/infer_meta.py
@@ -63,9 +63,9 @@ class DistInfo:
 
     @staticmethod
     def from_tensor(tensor: paddle.Tensor) -> DistInfo:
-        assert (
-            isinstance(tensor, paddle.Tensor) and tensor.is_dist()
-        ), f"Expect a Tensor, but got a {type(tensor)}."
+        assert isinstance(tensor, paddle.Tensor) and tensor.is_dist(), (
+            f"Expect a Tensor, but got a {type(tensor)}."
+        )
 
         mesh = tensor.process_mesh
         sharding_specs = get_shard_spec(
@@ -77,9 +77,9 @@ class DistInfo:
 
     @staticmethod
     def from_value(value: paddle.pir.Value) -> DistInfo:
-        assert (
-            isinstance(value, paddle.pir.Value) and value.is_dist()
-        ), f"Expect a Value, but got a {type(value)}."
+        assert isinstance(value, paddle.pir.Value) and value.is_dist(), (
+            f"Expect a Value, but got a {type(value)}."
+        )
         return DistInfo(
             value.dist_attr().process_mesh,
             value.dist_attr().dims_mapping,
@@ -149,13 +149,13 @@ class MetaInfoOrNull:
     ) -> MetaInfoOrNull:
         if not tensor._is_dense_tensor_hold_allocation():
             return MetaInfoOrNull.null()
-        assert isinstance(
-            tensor, paddle.Tensor
-        ), "Expect a Tensor, but got a Value."
+        assert isinstance(tensor, paddle.Tensor), (
+            "Expect a Tensor, but got a Value."
+        )
 
-        assert (
-            -1 not in tensor.shape
-        ), "Tensor shape should not contain -1, maybe you pass a Value to from_tensor"
+        assert -1 not in tensor.shape, (
+            "Tensor shape should not contain -1, maybe you pass a Value to from_tensor"
+        )
         user_specified_dynamic_axes = extract_tensor_dynamic_dims(tensor)
         dynamic_axes = dynamic_axes or []
         dynamic_axes = MetaInfoOrNull.mix_axes(
@@ -265,9 +265,9 @@ class MetaInfo:
         spec_name=None,
         dist_info=None,
     ):
-        assert (
-            -1 not in shape
-        ), "NOTE: Shape should not contain -1, consider convert it to SymbolicInt."
+        assert -1 not in shape, (
+            "NOTE: Shape should not contain -1, consider convert it to SymbolicInt."
+        )
         self.name = name
         self.persistable = persistable
         self.type = type
@@ -430,9 +430,9 @@ class VariableCreator(metaclass=Singleton):
                 placements = to_placements(meta.dist_info.dims_mapping, mesh)
                 var = paddle._pir_ops.shard_tensor(var, mesh, placements)
                 var.stop_gradient = meta.stop_gradient
-        assert not isinstance(
-            var, paddle.Tensor
-        ), "Expect a Variable, but got a Tensor."
+        assert not isinstance(var, paddle.Tensor), (
+            "Expect a Variable, but got a Tensor."
+        )
         return var
 
     def get_variable(self, meta: MetaInfoOrNull, without_cache=False):
@@ -513,9 +513,9 @@ def infer_meta(func, *args, **kwargs):
 
 
 def infer_meta_for_layer(layer, *args, **kwargs):
-    assert isinstance(
-        layer, paddle.nn.Layer
-    ), f"Expect a Layer, but got {layer}."
+    assert isinstance(layer, paddle.nn.Layer), (
+        f"Expect a Layer, but got {layer}."
+    )
     layer = paddle.jit.to_static(layer, full_graph=True)
 
     args_, kwargs_ = convert_meta_to_input_spec((args, kwargs))
@@ -636,9 +636,9 @@ class LayerInferMetaCache(Cache, metaclass=Singleton):
 
 class ConstrainedInputSpec(InputSpec):
     def __init__(self, dynamic_axes: list[int], *args, **kwargs):
-        self.ranges: list[tuple[int, int | None, int | None]] = (
-            []
-        )  # (idx of dim, min, max)
+        self.ranges: list[
+            tuple[int, int | None, int | None]
+        ] = []  # (idx of dim, min, max)
         super().__init__(*args, **kwargs)
         min_non_specialized_number = get_min_non_specialized_number()
         for i in dynamic_axes:

--- a/python/paddle/jit/sot/opcode_translator/executor/executor_cache.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/executor_cache.py
@@ -255,9 +255,9 @@ class OpcodeExecutorCache(metaclass=Singleton):
                     )
                     if not enable_unsafe_cache_fastpath:
                         # TODO(zrr1999): cache_index should be equal to index when enable_strict_guard.
-                        assert (
-                            cache_index is None or index == cache_index
-                        ), f"cache_index({cache_index}) is not equal to index({index})"
+                        assert cache_index is None or index == cache_index, (
+                            f"cache_index({cache_index}) is not equal to index({index})"
+                        )
 
                     if enable_unsafe_cache_fastpath:
                         if index == 0:

--- a/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
@@ -376,9 +376,9 @@ class FunctionGraph:
             guards = OrderedSet(guards)  # type: ignore
 
             for guard in guards:
-                assert isinstance(
-                    guard, StringifiedExpression
-                ), "guard must be StringifiedExpression."
+                assert isinstance(guard, StringifiedExpression), (
+                    "guard must be StringifiedExpression."
+                )
 
             return make_guard(guards)
 

--- a/python/paddle/jit/sot/opcode_translator/executor/guard.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/guard.py
@@ -224,9 +224,9 @@ def check_guard(
     fn: Callable[[CheckGuardInputT], list[StringifiedExpression]],
 ) -> Callable[[CheckGuardInputT], list[StringifiedExpression]]:
     def wrapper(self: CheckGuardInputT) -> list[StringifiedExpression]:
-        assert (
-            self.tracker.is_traceable()
-        ), "Cannot make guard from a non-tracable guard variable."
+        assert self.tracker.is_traceable(), (
+            "Cannot make guard from a non-tracable guard variable."
+        )
 
         def guard_log():
             frame_value_tracer = self.tracker.trace_value_from_frame()
@@ -246,9 +246,9 @@ def check_faster_guard(
     def wrapper(
         self: CheckGuardInputT,
     ) -> list[paddle.framework.core.GuardNodeBase]:
-        assert (
-            self.tracker.is_traceable()
-        ), "Cannot make guard from a non-tracable guard variable."
+        assert self.tracker.is_traceable(), (
+            "Cannot make guard from a non-tracable guard variable."
+        )
 
         def guard_log():
             frame_value_tracer = self.tracker.trace_value_from_frame()

--- a/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
@@ -567,9 +567,9 @@ class OpcodeExecutorBase:
         Pops the call stack until the current executor.
 
         """
-        assert (
-            self in OpcodeExecutorBase.call_stack
-        ), f"{self} not in call stack"
+        assert self in OpcodeExecutorBase.call_stack, (
+            f"{self} not in call stack"
+        )
         while OpcodeExecutorBase.call_stack.pop() is not self:
             pass
 
@@ -812,9 +812,9 @@ class OpcodeExecutorBase:
         # a1 a2 a3 ... an  <- TOS
         # the stack changes to
         # an a1 a2 a3 an-1 <- TOS
-        assert (
-            len(self.stack) >= n
-        ), f"There are not enough elements on the stack. {n} is needed."
+        assert len(self.stack) >= n, (
+            f"There are not enough elements on the stack. {n} is needed."
+        )
         top = self.stack.pop()
         self.stack.insert(n - 1, top)
 
@@ -1136,9 +1136,9 @@ class OpcodeExecutorBase:
 
     def BUILD_LIST(self, instr: Instruction):
         list_size = instr.arg
-        assert list_size <= len(
-            self.stack
-        ), f"OpExecutor want BUILD_LIST with size {list_size}, but current stack do not have enough elems."
+        assert list_size <= len(self.stack), (
+            f"OpExecutor want BUILD_LIST with size {list_size}, but current stack do not have enough elems."
+        )
         val_list = self.stack.pop_n(list_size)
         self.stack.push(
             ListVariable(
@@ -1148,9 +1148,9 @@ class OpcodeExecutorBase:
 
     def BUILD_TUPLE(self, instr: Instruction):
         tuple_size = instr.arg
-        assert tuple_size <= len(
-            self.stack
-        ), f"OpExecutor want BUILD_TUPLE with size {tuple_size}, but current stack do not have enough elems."
+        assert tuple_size <= len(self.stack), (
+            f"OpExecutor want BUILD_TUPLE with size {tuple_size}, but current stack do not have enough elems."
+        )
         val_tuple = self.stack.pop_n(tuple_size)
         self.stack.push(
             TupleVariable(
@@ -1162,9 +1162,9 @@ class OpcodeExecutorBase:
 
     def BUILD_STRING(self, instr: Instruction):
         count = instr.arg
-        assert count <= len(
-            self.stack
-        ), f"OpExecutor want BUILD_STRING with size {count}, but current stack do not have enough elems."
+        assert count <= len(self.stack), (
+            f"OpExecutor want BUILD_STRING with size {count}, but current stack do not have enough elems."
+        )
         str_list = self.stack.pop_n(count)
         new_str = ''
         for s in str_list:
@@ -1209,9 +1209,9 @@ class OpcodeExecutorBase:
 
     def BUILD_MAP(self, instr: Instruction):
         map_size = instr.arg
-        assert map_size * 2 <= len(
-            self.stack
-        ), f"OpExecutor want BUILD_MAP with size {map_size} * 2, but current stack do not have enough elems."
+        assert map_size * 2 <= len(self.stack), (
+            f"OpExecutor want BUILD_MAP with size {map_size} * 2, but current stack do not have enough elems."
+        )
         val_for_dict = self.stack.pop_n(map_size * 2)
         keys = val_for_dict[::2]
         values = val_for_dict[1::2]
@@ -1219,9 +1219,9 @@ class OpcodeExecutorBase:
 
     def BUILD_CONST_KEY_MAP(self, instr: Instruction):
         map_size = instr.arg
-        assert map_size + 1 <= len(
-            self.stack
-        ), f"OpExecutor want BUILD_CONST_KEY_MAP with size {map_size} + 1, but current stack do not have enough elems."
+        assert map_size + 1 <= len(self.stack), (
+            f"OpExecutor want BUILD_CONST_KEY_MAP with size {map_size} + 1, but current stack do not have enough elems."
+        )
         keys = self.stack.pop().get_wrapped_items()
         keys = list(keys) if isinstance(keys, tuple) else keys
         assert len(keys) == map_size
@@ -1399,9 +1399,9 @@ class OpcodeExecutorBase:
 
         args_variable = self.stack.pop()
         args_iter = args_variable.get_iter()
-        assert isinstance(
-            args_iter, IterVariable
-        ), f"args_iter should be IterVariable, but got {args_iter}"
+        assert isinstance(args_iter, IterVariable), (
+            f"args_iter should be IterVariable, but got {args_iter}"
+        )
         if not isinstance(args_iter, SequenceIterVariable):
             raise BreakGraphError(
                 UnsupportedOperationBreak(
@@ -1459,9 +1459,9 @@ class OpcodeExecutorBase:
     def TO_BOOL(self, instr: Instruction):
         # we don't do anything in TO_BOOL, we simply check if the bytecode is legal
         next_instr = self._instructions[self.vframe.lasti]
-        assert (
-            next_instr.opname in NEED_TO_BOOL
-        ), f"The bytecode is illegal! The opcode following TO_BOOL must be in ['POP_JUMP_IF_TRUE', 'POP_JUMP_IF_FALSE', 'UNARY_NOT'], the next instruction now is {next_instr.opname}"
+        assert next_instr.opname in NEED_TO_BOOL, (
+            f"The bytecode is illegal! The opcode following TO_BOOL must be in ['POP_JUMP_IF_TRUE', 'POP_JUMP_IF_FALSE', 'UNARY_NOT'], the next instruction now is {next_instr.opname}"
+        )
 
     @call_break_graph_decorator(push_n=1)
     def IS_OP(self, instr: Instruction):
@@ -1556,7 +1556,9 @@ class OpcodeExecutorBase:
         assert isinstance(
             origin_func,
             (UserDefinedGeneratorFunctionVariable, UserDefinedFunctionVariable),
-        ), f"The object we manipulate must be a function object. But now got {type(origin_func)}"
+        ), (
+            f"The object we manipulate must be a function object. But now got {type(origin_func)}"
+        )
         origin_func_val = origin_func.get_py_value()
         related_list = [origin_func]
         closure, related_list, kw_defaults, default_args = (
@@ -1773,9 +1775,9 @@ class OpcodeExecutorBase:
             # a, b, *c, d = e
             front_nums = instr.arg & 0xFF
             back_nums = instr.arg >> 8
-            assert (
-                len(sequence) >= front_nums + back_nums
-            ), f"Want unpack {sequence} to {front_nums + back_nums}, but {len(sequence)} is smaller than {front_nums + back_nums}."
+            assert len(sequence) >= front_nums + back_nums, (
+                f"Want unpack {sequence} to {front_nums + back_nums}, but {len(sequence)} is smaller than {front_nums + back_nums}."
+            )
 
             for i in range(
                 len(sequence) - 1, len(sequence) - back_nums - 1, -1
@@ -1789,9 +1791,9 @@ class OpcodeExecutorBase:
             )
         else:
             # a, b, c, *d = e
-            assert (
-                len(sequence) >= instr.arg
-            ), f"Want unpack {sequence} to {instr.arg}, but {len(sequence)} is smaller than {instr.arg}."
+            assert len(sequence) >= instr.arg, (
+                f"Want unpack {sequence} to {instr.arg}, but {len(sequence)} is smaller than {instr.arg}."
+            )
 
             slice_obj = slice(instr.arg, None)
             slice_var = SliceVariable(
@@ -2183,9 +2185,9 @@ class OpcodeExecutor(OpcodeExecutorBase):
             return Stop(state="BreakGraph")
 
     def RETURN_VALUE(self, instr: Instruction):
-        assert (
-            len(self.stack) == 1
-        ), f"Stack must have one element, but get {len(self.stack)} elements."
+        assert len(self.stack) == 1, (
+            f"Stack must have one element, but get {len(self.stack)} elements."
+        )
         ret_val = self.stack.pop()
         return self.compile_return(ret_val)
 

--- a/python/paddle/jit/sot/opcode_translator/executor/opcode_inline_executor.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/opcode_inline_executor.py
@@ -102,9 +102,9 @@ class OpcodeInlineExecutor(OpcodeExecutorBase):
         return self.return_value
 
     def RETURN_VALUE(self, instr: Instruction):
-        assert (
-            len(self.stack) == 1
-        ), f"Stack must have one element, but get {len(self.stack)} elements."
+        assert len(self.stack) == 1, (
+            f"Stack must have one element, but get {len(self.stack)} elements."
+        )
         self.return_value = self.stack.pop()
         return Stop(state="Return")
 
@@ -217,9 +217,9 @@ class OpcodeInlineGeneratorExecutor(OpcodeExecutorBase):
         return inline_for_iter_impl(self, instr)
 
     def RETURN_VALUE(self, instr: Instruction):
-        assert (
-            len(self.stack) == 1
-        ), f"Stack must have one element, but get {len(self.stack)} elements."
+        assert len(self.stack) == 1, (
+            f"Stack must have one element, but get {len(self.stack)} elements."
+        )
         self.return_value = self.stack.pop()
         return Stop(state="Return")
 

--- a/python/paddle/jit/sot/opcode_translator/executor/pycode_generator.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/pycode_generator.py
@@ -1021,9 +1021,9 @@ class ResumeFunctionCreator:
         self, inputs: list[str], stack_size: int, null_indices: list[int] = []
     ):
         stack_arg_str = self.name + '_stack_{}'
-        assert all(
-            idx < stack_size for idx in null_indices
-        ), "null index out of range"
+        assert all(idx < stack_size for idx in null_indices), (
+            "null index out of range"
+        )
 
         self.codegen._code_options['co_argcount'] = (
             len(inputs) + stack_size - len(null_indices)

--- a/python/paddle/jit/sot/opcode_translator/executor/variable_dispatch.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variable_dispatch.py
@@ -1200,7 +1200,9 @@ for binary_fn in BINARY_OPS:
                         "TensorVariable",
                     ),
                     partial(
-                        lambda reverse_magic_name, var, other: other.graph.call_tensor_method(
+                        lambda reverse_magic_name,
+                        var,
+                        other: other.graph.call_tensor_method(
                             reverse_magic_name, other, var
                         ),
                         magic_method.name,

--- a/python/paddle/jit/sot/opcode_translator/executor/variable_stack.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variable_stack.py
@@ -84,20 +84,20 @@ class VariableStack(Generic[StackDataT]):
                 assert 0 < index <= len(self._data)
                 return self._data[-index]
             if isinstance(index, slice):
-                assert (
-                    index.start is None and index.step is None
-                ), "slice which has start or step not supported"
+                assert index.start is None and index.step is None, (
+                    "slice which has start or step not supported"
+                )
                 assert 0 < index.stop <= len(self._data)
                 return self._data[-index.stop :]
             raise NotImplementedError(f"index type {type(index)} not supported")
 
         def __setitem__(self, index: int, value: Any):
-            assert isinstance(
-                index, int
-            ), f"index type {type(index)} not supported"
-            assert (
-                0 < index <= len(self._data)
-            ), f"index should be in [1, {len(self._data)}], but get {index}"
+            assert isinstance(index, int), (
+                f"index type {type(index)} not supported"
+            )
+            assert 0 < index <= len(self._data), (
+                f"index should be in [1, {len(self._data)}], but get {index}"
+            )
             self.validate_value_func(value)
             self._data[-index] = value
 
@@ -151,9 +151,9 @@ class VariableStack(Generic[StackDataT]):
             val: The variable to be inserted.
 
         """
-        assert (
-            0 <= index <= len(self)
-        ), f"index should be in [0, {len(self)}], but get {index}"
+        assert 0 <= index <= len(self), (
+            f"index should be in [0, {len(self)}], but get {index}"
+        )
         self.validate_value_func(val)
         self._data.insert(len(self) - index, val)
 
@@ -179,9 +179,9 @@ class VariableStack(Generic[StackDataT]):
             A list of the popped values.
 
         """
-        assert (
-            len(self) >= n >= 0
-        ), f"n should be in [0, {len(self)}], but get {n}"
+        assert len(self) >= n >= 0, (
+            f"n should be in [0, {len(self)}], but get {n}"
+        )
         if n == 0:
             return []
         retval = self._data[-n:]

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
@@ -216,9 +216,9 @@ class ConstantVariable(VariableBase):
         return ConstantVariable(bool(self), self.graph, DummyTracker([self]))
 
     def bool_not(self):
-        assert isinstance(
-            self.get_py_value(), bool
-        ), "Bool_not can only be applied to a bool variable."
+        assert isinstance(self.get_py_value(), bool), (
+            "Bool_not can only be applied to a bool variable."
+        )
         return ConstantVariable(
             not bool(self.get_py_value()), self.graph, DummyTracker([self])
         )
@@ -287,9 +287,9 @@ class ConstantVariable(VariableBase):
         """
         if isinstance(value, ConstantVariable):
             return value
-        assert isinstance(
-            value, ConstTypes
-        ), f"value: {value},type: {type(value)}"
+        assert isinstance(value, ConstTypes), (
+            f"value: {value},type: {type(value)}"
+        )
         return ConstantVariable(value, graph, ConstTracker(value))
 
 
@@ -985,16 +985,16 @@ class SymbolicVariable(VariableBase):
         super().__init__(graph, tracker)
         self.var_name = self.var_name_generator.next()
         if isinstance(value_or_meta, MetaInfoOrNull):
-            assert (
-                not value_or_meta.is_null()
-            ), "MetaInfoOrNull should not be null"
+            assert not value_or_meta.is_null(), (
+                "MetaInfoOrNull should not be null"
+            )
             assert len(value_or_meta.unwrap_unsafe().shape) == 0
             self.value = get_symbolic_from_meta(value_or_meta)
             self.meta = value_or_meta
         else:
-            assert isinstance(
-                value_or_meta, SymbolicInt
-            ), f"Unsupported type {type(value_or_meta)} for SymbolicVariable"
+            assert isinstance(value_or_meta, SymbolicInt), (
+                f"Unsupported type {type(value_or_meta)} for SymbolicVariable"
+            )
             self.value = value_or_meta
             self.meta = MetaInfo(
                 [], paddle.int64, True, self.var_name, False, None, None
@@ -1018,15 +1018,15 @@ class SymbolicVariable(VariableBase):
     def add_constraint(self, constraint: SymbolicConstraint):
         constraint_node, constraint_extern_vars = constraint
         for extern_var in constraint_extern_vars.values():
-            assert isinstance(
-                extern_var, SymbolicVariable
-            ), f"SymbolicVariable.add_constraint() got {extern_var}."
-            assert (
-                extern_var.value.is_backed()
-            ), "Only backed symbol is supported."
-            assert (
-                extern_var.tracker.is_traceable()
-            ), "Only traceable symbol is supported."
+            assert isinstance(extern_var, SymbolicVariable), (
+                f"SymbolicVariable.add_constraint() got {extern_var}."
+            )
+            assert extern_var.value.is_backed(), (
+                "Only backed symbol is supported."
+            )
+            assert extern_var.tracker.is_traceable(), (
+                "Only traceable symbol is supported."
+            )
         self.constraints.append(constraint)
 
     def to_constant(self):
@@ -1082,9 +1082,9 @@ class SymbolicVariable(VariableBase):
                 )
             )
         value = self.tracker.op(*input_values)
-        assert isinstance(
-            value, (bool, int, float)
-        ), f"SymbolicVariable.get_py_value() should return bool, int or float, but got {type(value)}"
+        assert isinstance(value, (bool, int, float)), (
+            f"SymbolicVariable.get_py_value() should return bool, int or float, but got {type(value)}"
+        )
         return value
 
     def get_example_value(
@@ -1112,9 +1112,9 @@ class SymbolicVariable(VariableBase):
                 )
             )
         value = self.tracker.op(*input_values)
-        assert isinstance(
-            value, (bool, int, float)
-        ), f"SymbolicVariable.get_example_value() should return bool, int or float, but got {type(value)}"
+        assert isinstance(value, (bool, int, float)), (
+            f"SymbolicVariable.get_example_value() should return bool, int or float, but got {type(value)}"
+        )
         return value
 
     def create_constraint_tree(
@@ -1127,9 +1127,9 @@ class SymbolicVariable(VariableBase):
         extern_vars = {}
         num_sym = 0
         for input in tracker.inputs:
-            assert isinstance(
-                input, (ConstantVariable, SymbolicVariable)
-            ), f"SymbolicVariable.create_constraint_tree() got {input}."
+            assert isinstance(input, (ConstantVariable, SymbolicVariable)), (
+                f"SymbolicVariable.create_constraint_tree() got {input}."
+            )
             if isinstance(input, ConstantVariable):
                 input_nodes.append(ConstantConstraintNode(input.get_py_value()))
             else:

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/callable.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/callable.py
@@ -1171,9 +1171,9 @@ class UserDefinedGeneratorFunctionVariable(FunctionVariable):
                 vframe, code_var, self.graph
             )
             gen = inline_gen_executor.inline_call()
-            assert isinstance(
-                gen, GeneratorVariable
-            ), f"GeneratorFunction calling result should be GeneratorVariable, but got {type(gen)}"
+            assert isinstance(gen, GeneratorVariable), (
+                f"GeneratorFunction calling result should be GeneratorVariable, but got {type(gen)}"
+            )
             gen.tracker = DummyTracker([self, *args, *kwargs.values()])
             return gen
         return GeneratorVariable(
@@ -1266,9 +1266,9 @@ class PaddleLayerClassVariable(ClassVariable):
         input_py_args = [var.get_py_value() for var in args]
         input_py_kwargs = {k: v.get_py_value() for k, v in kwargs.items()}
         new_layer = self.value(*input_py_args, **input_py_kwargs)
-        assert self.check_no_weight_and_buffers(
-            new_layer
-        ), "You have created a layer in to_static function which may have Potential bugs. please create it in __init__/main function."
+        assert self.check_no_weight_and_buffers(new_layer), (
+            "You have created a layer in to_static function which may have Potential bugs. please create it in __init__/main function."
+        )
         return VariableFactory.from_value(
             new_layer, self.graph, CreateLayerTracker(self, args, kwargs)
         )
@@ -1372,9 +1372,9 @@ class NamedTupleClassVariable(ClassVariable):
 
         parameters = fn_bind_inputs(self.value, self.graph, *args, **kwargs)
         fields = self.get_py_value()._fields
-        assert all(
-            field in parameters for field in fields
-        ), f"All fields of namedtuple should be in parameters, but got parameter {parameters} and fields {fields}"
+        assert all(field in parameters for field in fields), (
+            f"All fields of namedtuple should be in parameters, but got parameter {parameters} and fields {fields}"
+        )
 
         parameters_tuple = tuple(parameters[field] for field in fields)
         return NamedTupleVariable(

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/container.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/container.py
@@ -418,9 +418,9 @@ class ListVariable(ContainerVariable):
                 index_value, value
             )
             eq_bool = BuiltinVariable(bool, self.graph, DanglingTracker())(eq)
-            assert isinstance(
-                eq_bool, ConstantVariable
-            ), "bool should return ConstantVariable"
+            assert isinstance(eq_bool, ConstantVariable), (
+                "bool should return ConstantVariable"
+            )
             if eq.get_py_value() is True:
                 count += 1
                 continue
@@ -442,9 +442,9 @@ class ListVariable(ContainerVariable):
                 index_value, value
             )
             eq_bool = BuiltinVariable(bool, self.graph, DanglingTracker())(eq)
-            assert isinstance(
-                eq_bool, ConstantVariable
-            ), "bool should return ConstantVariable"
+            assert isinstance(eq_bool, ConstantVariable), (
+                "bool should return ConstantVariable"
+            )
             if eq.get_py_value() is True:
                 return ConstantVariable(
                     res, self.graph, DummyTracker([self, value])
@@ -641,9 +641,9 @@ class TupleVariable(ContainerVariable):
                 index_value, value
             )
             eq_bool = BuiltinVariable(bool, self.graph, DanglingTracker())(eq)
-            assert isinstance(
-                eq_bool, ConstantVariable
-            ), "bool should return ConstantVariable"
+            assert isinstance(eq_bool, ConstantVariable), (
+                "bool should return ConstantVariable"
+            )
             if eq.get_py_value() is True:
                 count += 1
                 continue
@@ -665,9 +665,9 @@ class TupleVariable(ContainerVariable):
                 index_value, value
             )
             eq_bool = BuiltinVariable(bool, self.graph, DanglingTracker())(eq)
-            assert isinstance(
-                eq_bool, ConstantVariable
-            ), "bool should return ConstantVariable"
+            assert isinstance(eq_bool, ConstantVariable), (
+                "bool should return ConstantVariable"
+            )
             if eq.get_py_value() is True:
                 return ConstantVariable(
                     res, self.graph, DummyTracker([self, value])

--- a/python/paddle/jit/sot/opcode_translator/executor/virtual_frame.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/virtual_frame.py
@@ -51,9 +51,9 @@ if TYPE_CHECKING:
 
 
 def validate_value(value):
-    assert isinstance(
-        value, VariableBase
-    ), f"value: {value}, type should be VariableBase(or derived), but get {type(value)}"
+    assert isinstance(value, VariableBase), (
+        f"value: {value}, type should be VariableBase(or derived), but get {type(value)}"
+    )
     assert not isinstance(value.tracker, DanglingTracker) or isinstance(
         value, (NullVariable, CellVariable)
     ), f"dangling variable {value} should not be pushed into stack."

--- a/python/paddle/jit/sot/opcode_translator/instruction_utils/instruction_utils.py
+++ b/python/paddle/jit/sot/opcode_translator/instruction_utils/instruction_utils.py
@@ -428,28 +428,28 @@ def modify_vars(instructions: list[Instruction], code_options):
             'STORE_FAST',
             'DELETE_FAST',
         ]:
-            assert (
-                instrs.argval in co_varnames
-            ), f"`{instrs.argval}` not in {co_varnames}"
+            assert instrs.argval in co_varnames, (
+                f"`{instrs.argval}` not in {co_varnames}"
+            )
             instrs.arg = co_varnames.index(instrs.argval)
         elif instrs.opname == "LOAD_DEREF" or instrs.opname == "STORE_DEREF":
             if sys.version_info >= (3, 11):
                 namemap = co_varnames + co_freevars
-                assert (
-                    instrs.argval in namemap
-                ), f"`{instrs.argval}` not in {namemap}"
+                assert instrs.argval in namemap, (
+                    f"`{instrs.argval}` not in {namemap}"
+                )
                 instrs.arg = namemap.index(instrs.argval)
         elif instrs.opname in [
             'LOAD_FAST_LOAD_FAST',
             'STORE_FAST_STORE_FAST',
             'STORE_FAST_LOAD_FAST',
         ]:
-            assert (
-                instrs.argval[0] in co_varnames
-            ), f"`{instrs.argval[0]}` not in {co_varnames}"
-            assert (
-                instrs.argval[1] in co_varnames
-            ), f"`{instrs.argval[1]}` not in {co_varnames}"
+            assert instrs.argval[0] in co_varnames, (
+                f"`{instrs.argval[0]}` not in {co_varnames}"
+            )
+            assert instrs.argval[1] in co_varnames, (
+                f"`{instrs.argval[1]}` not in {co_varnames}"
+            )
             instrs.arg = (
                 co_varnames.index(instrs.argval[0]) << 4
             ) + co_varnames.index(instrs.argval[1])

--- a/python/paddle/jit/sot/symbolic/builder.py
+++ b/python/paddle/jit/sot/symbolic/builder.py
@@ -91,12 +91,12 @@ class StatementIRBuilder:
         """
         Call a method of a api. The API here can be python or Paddle
         """
-        assert isinstance(
-            method_name, str
-        ), "call_METHOD must method api name. string."
-        assert isinstance(
-            inputs[0][0], Symbol
-        ), "call_METHOD first argument must be Symbol Variable."
+        assert isinstance(method_name, str), (
+            "call_METHOD must method api name. string."
+        )
+        assert isinstance(inputs[0][0], Symbol), (
+            "call_METHOD first argument must be Symbol Variable."
+        )
         stmt = MethodStatement(
             method_name,
             inputs,

--- a/python/paddle/jit/sot/symbolic/compile_cache.py
+++ b/python/paddle/jit/sot/symbolic/compile_cache.py
@@ -205,9 +205,9 @@ class FallbackWrapper:
         assert code is not None, f"Cannot find code for SIR: {SIR}"
 
         OpcodeExecutorCache().compile_time_stats.setdefault(code, 0)
-        OpcodeExecutorCache().compile_time_stats[
-            code
-        ] += partial_program_layer._compile_time_counter.get_total_time()
+        OpcodeExecutorCache().compile_time_stats[code] += (
+            partial_program_layer._compile_time_counter.get_total_time()
+        )
 
     @event_register(
         lambda self, *args, **kwargs: f"FallbackWrapper: {self.SIR.name}"

--- a/python/paddle/jit/sot/translate.py
+++ b/python/paddle/jit/sot/translate.py
@@ -101,9 +101,9 @@ def symbolic_translate(fn: Callable[P, R], **kwargs) -> Callable[P, R]:
 
     def impl(*args: P.args, **kwargs: P.kwargs) -> R:
         with StepInfoManager().step_guard(fn.__code__), SotStepProfilerGuard():
-            assert hasattr(
-                fn, "__code__"
-            ), "Target function doesn't have code for simulating."
+            assert hasattr(fn, "__code__"), (
+                "Target function doesn't have code for simulating."
+            )
             InfoCollector().clear_step_info()
             paddle.framework.core.set_eval_frame(callback)
             try:

--- a/python/paddle/jit/sot/utils/envs.py
+++ b/python/paddle/jit/sot/utils/envs.py
@@ -51,12 +51,12 @@ class PEP508LikeEnvironmentVariable(EnvironmentVariable[dict[str, list[str]]]):
 
     def convert_to_string(self, value: dict[str, list[str]]) -> str:
         assert isinstance(value, dict), "The input must be a dict"
-        assert all(
-            isinstance(x, str) for x in value.keys()
-        ), "Keys must be a string"
-        assert all(
-            isinstance(x, list) for x in value.values()
-        ), "Values must be a list"
+        assert all(isinstance(x, str) for x in value.keys()), (
+            "Keys must be a string"
+        )
+        assert all(isinstance(x, list) for x in value.values()), (
+            "Values must be a list"
+        )
 
         env_list = []
         for k, v in value.items():


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

使用性能更好，格式化效果更佳的 ruff format 替代 black 作为新的 formatter，由于我们很早就已经集成了 ruff lint，因此只是减少依赖而不会增加依赖

<!--

## 核心优势

通过集成 Ruff format，开发者可以享受到以下优势：

- 通过去除 black 对 python 环境依赖，极大降低了升级 formatter 带来的成本，后续无需考虑开发者本地 python 环境即可一键升级
- ruff 由 Rust 驱动，大幅加速 format 时间，降低开发者使用开发工具链的时间成本，减少 CI 时间，提升工程效率
- 格式化后呈现可读性更佳的效果，使得开发者更专注于代码开发而无需关心格式，阅读者也能够更加赏心悦目，极大增加了潜在贡献者的贡献意愿
- ruff 极大程度地兼容了 black 的格式化效果，能够平滑地替换现有的 black 配置
- ruff 更新频次高，能够快速响应社区反馈，持续优化格式化效果
- ruff 团队 Astral 最近开发的 ty 能够提供更强大的类型检查能力，后续可能与 ruff 集成，提供更好的开发体验
- PyTorch 最近已经完成迁移，追平竞品（在代码风格这块，我们一直做到了超越竞品，这次不能落后）

-->