### PR TITLE
[CodeStyle] `black -> ruff format` migration - part 33

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -91,7 +91,7 @@ repos:
 
             # | python/paddle/[k-n].+
 
-            # | python/paddle/[o-t].+
+            | python/paddle/[o-t].+
 
             # | python/paddle/[u-z].+
 
@@ -147,7 +147,7 @@ repos:
 
             | python/paddle/[k-n].+
 
-            | python/paddle/[o-t].+
+            # | python/paddle/[o-t].+
 
             | python/paddle/[u-z].+
 

--- a/python/paddle/optimizer/adamw.py
+++ b/python/paddle/optimizer/adamw.py
@@ -255,9 +255,9 @@ class AdamW(Optimizer):
         if self._parameter_list:
             if isinstance(self._parameter_list[0], dict):
                 for param_group in self._parameter_list:
-                    assert (
-                        'params' in param_group
-                    ), 'params should be set in parameters if parameter groups are optimized in different options'
+                    assert 'params' in param_group, (
+                        'params should be set in parameters if parameter groups are optimized in different options'
+                    )
                 self._dtype = self._parameter_list[0]['params'][0].dtype
             else:
                 self._dtype = self._parameter_list[0].dtype

--- a/python/paddle/optimizer/fusion_utils.py
+++ b/python/paddle/optimizer/fusion_utils.py
@@ -52,9 +52,9 @@ def get_current_device_type():
                 device_type = current_device.get_device_type()
             except:
                 device_type = "unknown"
-        assert (
-            device_type in alignment.keys()
-        ), f"tensor fusion helper now only support {alignment.keys()}, but got device {device_type} instead."
+        assert device_type in alignment.keys(), (
+            f"tensor fusion helper now only support {alignment.keys()}, but got device {device_type} instead."
+        )
         __current_device_type__ = device_type
     return __current_device_type__
 
@@ -210,13 +210,13 @@ class FusionStorageHelper:
         merged_model_params_meta,
         buffer_ipc_meta,
     ):
-        assert isinstance(
-            accumulators_meta, dict
-        ), "accumulators_meta must be a dict"
+        assert isinstance(accumulators_meta, dict), (
+            "accumulators_meta must be a dict"
+        )
         self.accumulators_meta = accumulators_meta
-        assert isinstance(
-            master_weights_meta, dict
-        ), "master_weights_meta must be a dict"
+        assert isinstance(master_weights_meta, dict), (
+            "master_weights_meta must be a dict"
+        )
         self.master_weights_meta = master_weights_meta
         assert (
             isinstance(merged_model_params_meta, dict)
@@ -242,9 +242,9 @@ class FusionStorageHelper:
         assert isinstance(start, int), "start must be an integer"
         assert isinstance(end, int), "end must be an integer"
         assert start >= 0, "start must be non-negative"
-        assert (
-            end <= self.buffer_length
-        ), "end must be less than or equal to the total buffer length"
+        assert end <= self.buffer_length, (
+            "end must be less than or equal to the total buffer length"
+        )
         task = async_offload_with_offset(
             src_tensor=self.buffer,
             dst_tensor=self.cpu_buffer,

--- a/python/paddle/optimizer/lr.py
+++ b/python/paddle/optimizer/lr.py
@@ -238,9 +238,9 @@ class LRScheduler:
                 continue
             value = self.__dict__[key]
             if isinstance(value, Tensor):
-                assert (
-                    value.size == 1
-                ), "numel of Tensor in state_dict must be 1"
+                assert value.size == 1, (
+                    "numel of Tensor in state_dict must be 1"
+                )
                 value = float(value)
             state_dict[key] = value
 
@@ -598,9 +598,9 @@ class NaturalExpDecay(LRScheduler):
         last_epoch: int = -1,
         verbose: bool = False,
     ) -> None:
-        assert (
-            gamma > 0.0
-        ), " 'gamma' must be a positive number so that the learning rate will decay."
+        assert gamma > 0.0, (
+            " 'gamma' must be a positive number so that the learning rate will decay."
+        )
         self.gamma = gamma
         super().__init__(learning_rate, last_epoch, verbose)
 
@@ -812,14 +812,14 @@ class PolynomialDecay(LRScheduler):
         last_epoch: int = -1,
         verbose: bool = False,
     ):
-        assert decay_steps > 0 and isinstance(
-            decay_steps, int
-        ), " 'decay_steps' must be a positive integer."
+        assert decay_steps > 0 and isinstance(decay_steps, int), (
+            " 'decay_steps' must be a positive integer."
+        )
         self.decay_steps = decay_steps
         self.end_lr = end_lr
-        assert (
-            power > 0.0
-        ), " 'power' must be greater than 0.0 so that the learning rate will decay."
+        assert power > 0.0, (
+            " 'power' must be greater than 0.0 so that the learning rate will decay."
+        )
         self.power = power
         self.cycle = cycle
         super().__init__(learning_rate, last_epoch, verbose)
@@ -955,15 +955,15 @@ class LinearWarmup(LRScheduler):
                 f"the type of learning_rate should be [int, float or LRScheduler], the current type is {learning_rate}"
             )
         self.learning_rate = learning_rate
-        assert warmup_steps > 0 and isinstance(
-            warmup_steps, int
-        ), " 'warmup_steps' must be a positive integer."
+        assert warmup_steps > 0 and isinstance(warmup_steps, int), (
+            " 'warmup_steps' must be a positive integer."
+        )
         self.warmup_steps = warmup_steps
         self.start_lr = start_lr
         self.end_lr = end_lr
-        assert (
-            end_lr > start_lr
-        ), f"end_lr {end_lr} must be greater than start_lr {start_lr}"
+        assert end_lr > start_lr, (
+            f"end_lr {end_lr} must be greater than start_lr {start_lr}"
+        )
         super().__init__(start_lr, last_epoch, verbose)
 
     def state_dict(self) -> _LRStateDict:
@@ -1085,9 +1085,9 @@ class ExponentialDecay(LRScheduler):
         last_epoch: int = -1,
         verbose: bool = False,
     ) -> None:
-        assert (
-            gamma > 0.0 and gamma < 1.0
-        ), " 'gamma' must be in interval (0.0, 1.0) so that the learning rate will decay."
+        assert gamma > 0.0 and gamma < 1.0, (
+            " 'gamma' must be in interval (0.0, 1.0) so that the learning rate will decay."
+        )
         self.gamma = gamma
         super().__init__(learning_rate, last_epoch, verbose)
 
@@ -1321,9 +1321,9 @@ class StepDecay(LRScheduler):
         if gamma >= 1.0:
             raise ValueError('gamma should be < 1.0.')
 
-        assert step_size > 0 and isinstance(
-            step_size, int
-        ), " 'step_size' must be a positive integer."
+        assert step_size > 0 and isinstance(step_size, int), (
+            " 'step_size' must be a positive integer."
+        )
         self.step_size = step_size
         self.gamma = gamma
         super().__init__(learning_rate, last_epoch, verbose)
@@ -1784,9 +1784,9 @@ class CosineAnnealingDecay(LRScheduler):
             raise TypeError(
                 f"The type of 'eta_min' in 'CosineAnnealingDecay' must be 'float, int', but received {type(eta_min)}."
             )
-        assert T_max > 0 and isinstance(
-            T_max, int
-        ), " 'T_max' must be a positive integer."
+        assert T_max > 0 and isinstance(T_max, int), (
+            " 'T_max' must be a positive integer."
+        )
         self.T_max = T_max
         self.eta_min = float(eta_min)
         super().__init__(learning_rate, last_epoch, verbose)

--- a/python/paddle/optimizer/momentum.py
+++ b/python/paddle/optimizer/momentum.py
@@ -553,9 +553,7 @@ class Momentum(Optimizer):
                         "use_nesterov": self._use_nesterov,
                         "regularization_method": self._regularization_method_dict[
                             key
-                        ][
-                            param_group_idx
-                        ],
+                        ][param_group_idx],
                         "regularization_coeff": self._regularization_coeff_dict[
                             key
                         ][param_group_idx],

--- a/python/paddle/optimizer/optimizer.py
+++ b/python/paddle/optimizer/optimizer.py
@@ -94,14 +94,14 @@ def append_backward_new(
     from paddle.incubate.autograd.primx import Transform, orig2prim
 
     program = default_main_program()
-    assert (
-        program.num_blocks == 1
-    ), "The append_backward_new interface is designed to process only one block."
+    assert program.num_blocks == 1, (
+        "The append_backward_new interface is designed to process only one block."
+    )
     block = program.current_block()
     for el in loss_list:
-        assert (
-            el.block == block
-        ), 'variable in loss_list should be in current block of main program'
+        assert el.block == block, (
+            'variable in loss_list should be in current block of main program'
+        )
 
     orig2prim(block)
     ad = Transform(block)
@@ -280,9 +280,9 @@ class Optimizer:
         if self._parameter_list:
             if isinstance(self._parameter_list[0], dict):
                 for param_group in self._parameter_list:
-                    assert (
-                        'params' in param_group
-                    ), 'params should be set in parameters if parameter groups are optimized in different options'
+                    assert 'params' in param_group, (
+                        'params should be set in parameters if parameter groups are optimized in different options'
+                    )
                 self._dtype = self._parameter_list[0]['params'][0].dtype
             else:
                 self._dtype = self._parameter_list[0].dtype
@@ -477,9 +477,9 @@ class Optimizer:
         if isinstance(self._learning_rate, LRScheduler):
             lr_state_dict = state_dict.get("LR_Scheduler", None)
             if not isinstance(self._learning_rate, LambdaDecay):
-                assert (
-                    lr_state_dict is not None
-                ), "LR_Scheduler state must be included in the state dict except LambdaDecay"
+                assert lr_state_dict is not None, (
+                    "LR_Scheduler state must be included in the state dict except LambdaDecay"
+                )
             if lr_state_dict:
                 self._learning_rate.set_state_dict(lr_state_dict)
 
@@ -495,9 +495,9 @@ class Optimizer:
         self._accumulators_holder = state_dict
         for k, v in self._accumulators.items():
             for para_name, var_tmp in v.items():
-                assert (
-                    var_tmp.name in state_dict
-                ), f"optimizer Tensor {var_tmp.name} not found"
+                assert var_tmp.name in state_dict, (
+                    f"optimizer Tensor {var_tmp.name} not found"
+                )
 
                 var = var_tmp.value()
                 tensor = var.get_tensor()
@@ -1112,9 +1112,9 @@ class Optimizer:
 
             if framework.in_dygraph_mode():
                 if len(self._accumulators_holder) > 0:
-                    assert (
-                        var_name in self._accumulators_holder
-                    ), f"Optimizer set error, {var_name} should in state dict"
+                    assert var_name in self._accumulators_holder, (
+                        f"Optimizer set error, {var_name} should in state dict"
+                    )
                     var.set_value(self._accumulators_holder.pop(var_name))
 
                     # load scale value for xpu
@@ -1231,9 +1231,9 @@ class Optimizer:
         target_block = global_block
         current_block = framework.default_main_program().current_block()
         if current_block.idx != global_block.idx:
-            assert (
-                current_block.backward_block_idx != -1
-            ), "current block is not global_block, but it doesn't have backward block."
+            assert current_block.backward_block_idx != -1, (
+                "current block is not global_block, but it doesn't have backward block."
+            )
             target_block = framework.default_main_program().blocks[
                 current_block.backward_block_idx
             ]
@@ -1669,9 +1669,7 @@ class Optimizer:
                 paddle.static.default_main_program(),
                 paddle.static.default_startup_program(),
             ):
-                auto_dp = (
-                    paddle.distributed.auto_parallel.auto_dp_utils.in_auto_dp_mode()
-                )
+                auto_dp = paddle.distributed.auto_parallel.auto_dp_utils.in_auto_dp_mode()
                 if auto_dp:
                     paddle.distributed.auto_parallel.auto_dp_utils._convert_fake_replicate_grad_to_partial(
                         params_grads
@@ -1943,9 +1941,9 @@ class Optimizer:
                 >>> adam.clear_grad()
 
         """
-        assert isinstance(
-            loss, (Variable, paddle.pir.Value)
-        ), "The loss should be an Tensor."
+        assert isinstance(loss, (Variable, paddle.pir.Value)), (
+            "The loss should be an Tensor."
+        )
 
         parameter_list = parameters if parameters else self._parameter_list
 
@@ -1969,9 +1967,9 @@ class Optimizer:
         params = (
             paddle.static.default_main_program().global_block().all_parameters()
         )
-        assert not isinstance(
-            self._parameter_list[0], dict
-        ), "Only list of parameters is supported while using optimizer in @paddle.jit.static."
+        assert not isinstance(self._parameter_list[0], dict), (
+            "Only list of parameters is supported while using optimizer in @paddle.jit.static."
+        )
         selected_params = {param.name for param in self._parameter_list}
         parameters = [param for param in params if param.trainable]
         parameters = list(
@@ -2141,9 +2139,9 @@ class Optimizer:
         :param dtype: instance of core.VarDesc.VarType
         :return: True if dtype is one of fp16 or bf16, False otherwise
         """
-        assert isinstance(
-            dtype, (core.VarDesc.VarType, core.DataType)
-        ), "The dtype should be an instance of core.VarDesc.VarType or core.DataType."
+        assert isinstance(dtype, (core.VarDesc.VarType, core.DataType)), (
+            "The dtype should be an instance of core.VarDesc.VarType or core.DataType."
+        )
         if isinstance(dtype, core.VarDesc.VarType):
             return (
                 dtype == core.VarDesc.VarType.FP16

--- a/python/paddle/pir/math_op_patch.py
+++ b/python/paddle/pir/math_op_patch.py
@@ -1026,9 +1026,9 @@ def monkey_patch_value():
         return _C_ops.sparse_indices(self)
 
     def set_shape(self, shape):
-        assert (
-            paddle.base.dygraph.base.in_to_static_mode()
-        ), "We only support call 'set_shape' in to_static mode."
+        assert paddle.base.dygraph.base.in_to_static_mode(), (
+            "We only support call 'set_shape' in to_static mode."
+        )
 
         if self.is_dense_tensor_type() or self.is_selected_row_type():
             type = paddle.pir.create_shaped_type(self.type(), shape)
@@ -1074,9 +1074,9 @@ def monkey_patch_value():
         if blocking is None:
             blocking = True
         else:
-            assert isinstance(
-                blocking, bool
-            ), "blocking value error, must be the True, False or None"
+            assert isinstance(blocking, bool), (
+                "blocking value error, must be the True, False or None"
+            )
 
         def transform(t, device, dtype, blocking):
             if dtype is None:

--- a/python/paddle/profiler/utils.py
+++ b/python/paddle/profiler/utils.py
@@ -128,9 +128,7 @@ class RecordEvent(ContextDecorator):
         if self.event_type not in _AllowedEventTypeList:
             warn(
                 "Only TracerEvent Type in [{}, {}, {}, {}, {}, {},{}]\
-                  can be recorded.".format(
-                    *_AllowedEventTypeList
-                )
+                  can be recorded.".format(*_AllowedEventTypeList)
             )
             self.event = None
         else:

--- a/python/paddle/quantization/config.py
+++ b/python/paddle/quantization/config.py
@@ -285,7 +285,9 @@ class QuantConfig:
         """
         assert isinstance(source, type) and issubclass(
             source, paddle.nn.Layer
-        ), "The source layer to be placed should be a subclass of paddle.nn.Layer"
+        ), (
+            "The source layer to be placed should be a subclass of paddle.nn.Layer"
+        )
         assert isinstance(target, type) and issubclass(
             target, paddle.nn.Layer
         ), "The target layer should be a subclass of paddle.nn.qat.Layer"

--- a/python/paddle/quantization/imperative/fuse_utils.py
+++ b/python/paddle/quantization/imperative/fuse_utils.py
@@ -113,13 +113,13 @@ def _fuse_func(layer_list):
 
 def _fuse_conv_bn(conv, bn):
     '''fuse conv and bn for train or eval'''
-    assert (
-        conv.training == bn.training
-    ), "Conv and BN both must be in the same mode (train or eval)."
+    assert conv.training == bn.training, (
+        "Conv and BN both must be in the same mode (train or eval)."
+    )
     if conv.training:
-        assert (
-            bn._num_features == conv._out_channels
-        ), 'Output channel of Conv2d must match num_features of BatchNorm2d'
+        assert bn._num_features == conv._out_channels, (
+            'Output channel of Conv2d must match num_features of BatchNorm2d'
+        )
         raise NotImplementedError
     else:
         return _fuse_conv_bn_eval(conv, bn)
@@ -166,13 +166,13 @@ def _fuse_conv_bn_weights(conv_w, conv_b, bn_rm, bn_rv, bn_eps, bn_w, bn_b):
 
 def _fuse_linear_bn(linear, bn):
     '''fuse linear and bn'''
-    assert (
-        linear.training == bn.training
-    ), "Linear and BN both must be in the same mode (train or eval)."
+    assert linear.training == bn.training, (
+        "Linear and BN both must be in the same mode (train or eval)."
+    )
     if linear.training:
-        assert (
-            bn._num_features == linear.weight.shape[1]
-        ), 'Output channel of Linear must match num_features of BatchNorm'
+        assert bn._num_features == linear.weight.shape[1], (
+            'Output channel of Linear must match num_features of BatchNorm'
+        )
         raise NotImplementedError
     else:
         return _fuse_linear_bn_eval(linear, bn)

--- a/python/paddle/quantization/imperative/ptq.py
+++ b/python/paddle/quantization/imperative/ptq.py
@@ -78,9 +78,9 @@ class ImperativePTQ:
         Return
             quantized_model(paddle.nn.Layer): The quantized model.
         """
-        assert isinstance(
-            model, paddle.nn.Layer
-        ), "The model must be the instance of paddle.nn.Layer."
+        assert isinstance(model, paddle.nn.Layer), (
+            "The model must be the instance of paddle.nn.Layer."
+        )
         if not inplace:
             model = copy.deepcopy(model)
         if fuse:
@@ -139,9 +139,9 @@ class ImperativePTQ:
             None
         """
 
-        assert isinstance(
-            model, paddle.nn.Layer
-        ), "The model must be the instance of paddle.nn.Layer."
+        assert isinstance(model, paddle.nn.Layer), (
+            "The model must be the instance of paddle.nn.Layer."
+        )
 
         # Convert and save dygraph quantized model
         self._convert(model)
@@ -235,9 +235,9 @@ class ImperativePTQ:
         Returns:
             None
         """
-        assert isinstance(
-            model, paddle.nn.Layer
-        ), "The input model must be the instance of paddle.nn.Layer."
+        assert isinstance(model, paddle.nn.Layer), (
+            "The input model must be the instance of paddle.nn.Layer."
+        )
 
         total_num = 0
         cur_num = 0
@@ -272,9 +272,9 @@ class ImperativePTQ:
         Returns:
             None
         """
-        assert isinstance(
-            sub_layer, paddle.nn.Layer
-        ), "The input model must be the instance of paddle.nn.Layer."
+        assert isinstance(sub_layer, paddle.nn.Layer), (
+            "The input model must be the instance of paddle.nn.Layer."
+        )
 
         layer_info = PTQRegistry.layer_info(sub_layer)
 
@@ -299,9 +299,9 @@ class ImperativePTQ:
         Returns:
             None
         """
-        assert isinstance(
-            model, paddle.nn.Layer
-        ), "The input model must be the instance of paddle.nn.Layer."
+        assert isinstance(model, paddle.nn.Layer), (
+            "The input model must be the instance of paddle.nn.Layer."
+        )
 
         for name, sub_layer in model.named_sublayers():
             if self._is_quant_layer(

--- a/python/paddle/quantization/imperative/ptq_hooks.py
+++ b/python/paddle/quantization/imperative/ptq_hooks.py
@@ -17,9 +17,9 @@ def quant_forward_post_hook(layer, inputs, outputs):
     """
     The forward_post_hook for PTQ.
     """
-    assert hasattr(
-        layer, '_quant_config'
-    ), "The layer should have _quant_config attr"
+    assert hasattr(layer, '_quant_config'), (
+        "The layer should have _quant_config attr"
+    )
 
     qc = layer._quant_config
     if qc.enable_in_act_quantizer:

--- a/python/paddle/quantization/imperative/ptq_registry.py
+++ b/python/paddle/quantization/imperative/ptq_registry.py
@@ -134,9 +134,9 @@ class PTQRegistry:
         Returns:
             layer_info(LayerInfo): The layer info of the input layer.
         """
-        assert cls.is_registered_layer(
-            layer
-        ), "The input layer is not register."
+        assert cls.is_registered_layer(layer), (
+            "The input layer is not register."
+        )
 
         for layer_key, layer_info in cls.registered_layers_map.items():
             if layer == layer_key or isinstance(layer, layer_key):

--- a/python/paddle/quantization/imperative/qat.py
+++ b/python/paddle/quantization/imperative/qat.py
@@ -282,9 +282,9 @@ class ImperativeQuantAware:
                 >>> # fake quant logical.
                 >>> imperative_qat.quantize(model)
         """
-        assert isinstance(
-            model, paddle.nn.Layer
-        ), "The model must be the instance of paddle.nn.Layer."
+        assert isinstance(model, paddle.nn.Layer), (
+            "The model must be the instance of paddle.nn.Layer."
+        )
 
         if self.fuse_conv_bn:
             fuse_utils.fuse_conv_bn(model)
@@ -368,25 +368,25 @@ class ImperativeQuantizeInputs:
             lambda bits: isinstance(bits, int) and bits >= 0 and bits <= 16
         )
         assert bits_check(weight_bits), "weight_bits should be 1, 2,... or 16."
-        assert bits_check(
-            activation_bits
-        ), "activation_bits should be 1, 2,... or 16."
+        assert bits_check(activation_bits), (
+            "activation_bits should be 1, 2,... or 16."
+        )
 
         layer_check = lambda method: method is None or issubclass(
             method, paddle.nn.Layer
         )
-        assert layer_check(
-            weight_preprocess_layer
-        ), "weight_preprocess should be nn.Layer."
-        assert layer_check(
-            act_preprocess_layer
-        ), "act_preprocess should be nn.Layer."
-        assert layer_check(
-            weight_quantize_layer
-        ), "weight_quantize should be nn.Layer."
-        assert layer_check(
-            act_quantize_layer
-        ), "act_quantize should be nn.Layer."
+        assert layer_check(weight_preprocess_layer), (
+            "weight_preprocess should be nn.Layer."
+        )
+        assert layer_check(act_preprocess_layer), (
+            "act_preprocess should be nn.Layer."
+        )
+        assert layer_check(weight_quantize_layer), (
+            "weight_quantize should be nn.Layer."
+        )
+        assert layer_check(act_quantize_layer), (
+            "act_quantize should be nn.Layer."
+        )
 
         self._kwargs = {
             "weight_quantize_type": weight_quantize_type,
@@ -413,9 +413,9 @@ class ImperativeQuantizeInputs:
             None
         """
 
-        assert isinstance(
-            model, paddle.nn.Layer
-        ), "The model must be the instance of paddle.nn.Layer."
+        assert isinstance(model, paddle.nn.Layer), (
+            "The model must be the instance of paddle.nn.Layer."
+        )
 
         for name, cur_layer in model.named_sublayers():
             if not isinstance(cur_layer, self._quantizable_layer_type) or (
@@ -438,9 +438,9 @@ class ImperativeQuantizeInputs:
             if isinstance(layer, value):
                 quant_layer_name = 'Quantized' + key
                 break
-        assert (
-            quant_layer_name is not None
-        ), f"The layer {layer.full_name()} is unsupported to be quantized."
+        assert quant_layer_name is not None, (
+            f"The layer {layer.full_name()} is unsupported to be quantized."
+        )
 
         return quant_layers.__dict__[quant_layer_name](layer, **self._kwargs)
 
@@ -476,9 +476,9 @@ class ImperativeQuantizeOutputs:
         Returns:
             None
         """
-        assert isinstance(
-            model, paddle.nn.Layer
-        ), "The model must be the instance of paddle.nn.Layer."
+        assert isinstance(model, paddle.nn.Layer), (
+            "The model must be the instance of paddle.nn.Layer."
+        )
 
         for cur_name, cur_layer in model.named_sublayers():
             if '_act_preprocess' in cur_name:
@@ -531,9 +531,9 @@ class ImperativeQuantizeOutputs:
         Returns:
             None
         """
-        assert isinstance(
-            model, paddle.nn.Layer
-        ), "The model must be the instance of paddle.nn.Layer."
+        assert isinstance(model, paddle.nn.Layer), (
+            "The model must be the instance of paddle.nn.Layer."
+        )
 
         if input_spec:
             paddle.jit.to_static(model, input_spec=input_spec)

--- a/python/paddle/quantization/imperative/utils.py
+++ b/python/paddle/quantization/imperative/utils.py
@@ -133,9 +133,9 @@ def find_parent_layer_and_sub_name(model, name):
     Returns:
         parent_layer, subname
     """
-    assert isinstance(
-        model, paddle.nn.Layer
-    ), "The model must be the instance of paddle.nn.Layer."
+    assert isinstance(model, paddle.nn.Layer), (
+        "The model must be the instance of paddle.nn.Layer."
+    )
     assert len(name) > 0, "The input (name) should not be empty."
 
     last_idx = 0

--- a/python/paddle/quantization/observers/groupwise.py
+++ b/python/paddle/quantization/observers/groupwise.py
@@ -62,12 +62,12 @@ class GroupWiseWeightObserverLayer(BaseObserver):
         absmax method to calculate the scale
         """
         input_shape = inputs.shape
-        assert (
-            self.group_size == 64 or self.group_size == 128
-        ), "group_size only support 64 or 128"
-        assert (
-            inputs.shape[0] % self.group_size == 0
-        ), "group_size must be a factor of input channels"
+        assert self.group_size == 64 or self.group_size == 128, (
+            "group_size only support 64 or 128"
+        )
+        assert inputs.shape[0] % self.group_size == 0, (
+            "group_size must be a factor of input channels"
+        )
         assert len(inputs.shape) == 2, "Currently only support 2D tensor"
         input_processed = inputs.transpose([1, 0]).reshape(
             [input_shape[1], input_shape[0] // self.group_size, self.group_size]

--- a/python/paddle/quantization/ptq.py
+++ b/python/paddle/quantization/ptq.py
@@ -116,14 +116,14 @@ class PTQ(Quantization):
         """
         _model = model
         if not inplace:
-            assert (
-                not self._is_parallel_training()
-            ), "'inplace' is not compatible with parallel training."
+            assert not self._is_parallel_training(), (
+                "'inplace' is not compatible with parallel training."
+            )
             _model = copy.deepcopy(model)
             _model.eval()
-        assert (
-            not model.training
-        ), "Post-Training Quantization should not work on training models. Please set evaluation mode by model.eval()."
+        assert not model.training, (
+            "Post-Training Quantization should not work on training models. Please set evaluation mode by model.eval()."
+        )
         self._config._specify(_model)
         self._convert_to_quant_layers(_model, self._config)
         self._insert_activation_observers(_model, self._config)

--- a/python/paddle/quantization/qat.py
+++ b/python/paddle/quantization/qat.py
@@ -112,9 +112,9 @@ class QAT(Quantization):
                   )
                 )
         """
-        assert (
-            model.training
-        ), "Quantization-Aware Training should work on training models. Please set training mode by model.train()."
+        assert model.training, (
+            "Quantization-Aware Training should work on training models. Please set training mode by model.train()."
+        )
         _model = model if inplace else copy.deepcopy(model)
         self._config._specify(_model)
         self._convert_to_quant_layers(_model, self._config)

--- a/python/paddle/reader/decorator.py
+++ b/python/paddle/reader/decorator.py
@@ -673,9 +673,9 @@ def multiprocess_reader(
         )
         import json
 
-    assert (
-        isinstance(readers, (list, tuple)) and len(readers) > 0
-    ), "`readers` must be list or tuple."
+    assert isinstance(readers, (list, tuple)) and len(readers) > 0, (
+        "`readers` must be list or tuple."
+    )
 
     def _read_into_queue(reader, queue):
         try:

--- a/python/paddle/signal.py
+++ b/python/paddle/signal.py
@@ -374,18 +374,18 @@ def stft(
         win_length = n_fft
 
     if in_dynamic_mode():
-        assert (
-            0 < n_fft <= x.shape[-1]
-        ), f'n_fft should be in (0, seq_length({x.shape[-1]})], but got {n_fft}.'
+        assert 0 < n_fft <= x.shape[-1], (
+            f'n_fft should be in (0, seq_length({x.shape[-1]})], but got {n_fft}.'
+        )
 
-    assert (
-        0 < win_length <= n_fft
-    ), f'win_length should be in (0, n_fft({n_fft})], but got {win_length}.'
+    assert 0 < win_length <= n_fft, (
+        f'win_length should be in (0, n_fft({n_fft})], but got {win_length}.'
+    )
 
     if window is not None:
-        assert (
-            len(window.shape) == 1 and len(window) == win_length
-        ), f'expected a 1D window tensor of size equal to win_length({win_length}), but got window with shape {window.shape}.'
+        assert len(window.shape) == 1 and len(window) == win_length, (
+            f'expected a 1D window tensor of size equal to win_length({win_length}), but got window with shape {window.shape}.'
+        )
     else:
         window = paddle.ones(shape=(win_length,), dtype=x.dtype)
 
@@ -423,9 +423,9 @@ def stft(
         onesided = not is_complex(x_frames)
 
     if is_complex(x_frames):
-        assert (
-            not onesided
-        ), 'onesided should be False when input or window is a complex Tensor.'
+        assert not onesided, (
+            'onesided should be False when input or window is a complex Tensor.'
+        )
 
     if not is_complex(x):
         out = fft_r2c(
@@ -557,13 +557,13 @@ def istft(
         win_length = n_fft
 
     # Assure no gaps between frames.
-    assert (
-        0 < hop_length <= win_length
-    ), f'hop_length should be in (0, win_length({win_length})], but got {hop_length}.'
+    assert 0 < hop_length <= win_length, (
+        f'hop_length should be in (0, win_length({win_length})], but got {hop_length}.'
+    )
 
-    assert (
-        0 < win_length <= n_fft
-    ), f'win_length should be in (0, n_fft({n_fft})], but got {win_length}.'
+    assert 0 < win_length <= n_fft, (
+        f'win_length should be in (0, n_fft({n_fft})], but got {win_length}.'
+    )
 
     n_frames = x.shape[-1]
     fft_size = x.shape[-2]
@@ -571,18 +571,18 @@ def istft(
     if in_dynamic_mode():
         assert x.size != 0, 'x should not be an empty tensor.'
         if onesided:
-            assert (
-                fft_size == n_fft // 2 + 1
-            ), f'fft_size should be equal to n_fft // 2 + 1({n_fft // 2 + 1}) when onesided is True, but got {fft_size}.'
+            assert fft_size == n_fft // 2 + 1, (
+                f'fft_size should be equal to n_fft // 2 + 1({n_fft // 2 + 1}) when onesided is True, but got {fft_size}.'
+            )
         else:
-            assert (
-                fft_size == n_fft
-            ), f'fft_size should be equal to n_fft({n_fft}) when onesided is False, but got {fft_size}.'
+            assert fft_size == n_fft, (
+                f'fft_size should be equal to n_fft({n_fft}) when onesided is False, but got {fft_size}.'
+            )
 
     if window is not None:
-        assert (
-            len(window.shape) == 1 and len(window) == win_length
-        ), f'expected a 1D window tensor of size equal to win_length({win_length}), but got window with shape {window.shape}.'
+        assert len(window.shape) == 1 and len(window) == win_length, (
+            f'expected a 1D window tensor of size equal to win_length({win_length}), but got window with shape {window.shape}.'
+        )
     else:
         window_dtype = (
             paddle.float32
@@ -605,15 +605,15 @@ def istft(
     norm = 'ortho' if normalized else 'backward'
 
     if return_complex:
-        assert (
-            not onesided
-        ), 'onesided should be False when input(output of istft) or window is a complex Tensor.'
+        assert not onesided, (
+            'onesided should be False when input(output of istft) or window is a complex Tensor.'
+        )
 
         out = fft_c2c(x=x, n=None, axis=-1, norm=norm, forward=False, name=None)
     else:
-        assert not is_complex(
-            window
-        ), 'Data type of window should not be complex when return_complex is False.'
+        assert not is_complex(window), (
+            'Data type of window should not be complex when return_complex is False.'
+        )
 
         if onesided is False:
             x = x[:, :, : n_fft // 2 + 1]
@@ -630,9 +630,7 @@ def istft(
         x=paddle.tile(
             x=paddle.multiply(window, window).unsqueeze(0),
             repeat_times=[n_frames, 1],
-        ).transpose(
-            perm=[1, 0]
-        ),  # (n_fft, num_frames)
+        ).transpose(perm=[1, 0]),  # (n_fft, num_frames)
         hop_length=hop_length,
         axis=-1,
     )  # (seq_length, )

--- a/python/paddle/sparse/binary.py
+++ b/python/paddle/sparse/binary.py
@@ -130,9 +130,9 @@ def matmul(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
                     [2., 2.],
                     [3., 3.]])
     """
-    assert (
-        in_dynamic_or_pir_mode()
-    ), "Currently, Sparse API only support dynamic mode or pir mode."
+    assert in_dynamic_or_pir_mode(), (
+        "Currently, Sparse API only support dynamic mode or pir mode."
+    )
     return _C_ops.sparse_matmul(x, y)
 
 
@@ -198,9 +198,9 @@ def masked_matmul(
                    values=[0.98986477, 0.97800624, 1.14591956, 0.68561077, 0.94714981])
 
     """
-    assert (
-        in_dynamic_or_pir_mode()
-    ), "Currently, Sparse API only support dynamic mode or pir mode."
+    assert in_dynamic_or_pir_mode(), (
+        "Currently, Sparse API only support dynamic mode or pir mode."
+    )
     return _C_ops.sparse_masked_matmul(x, y, mask)
 
 
@@ -258,9 +258,9 @@ def mv(x: Tensor, vec: Tensor, name: str | None = None) -> Tensor:
                    [-3.85499096, -2.42975140, -1.75087738])
 
     """
-    assert (
-        in_dynamic_or_pir_mode()
-    ), "Currently, Sparse API only support dynamic mode or pir mode."
+    assert in_dynamic_or_pir_mode(), (
+        "Currently, Sparse API only support dynamic mode or pir mode."
+    )
     return _C_ops.sparse_mv(x, vec)
 
 
@@ -494,9 +494,9 @@ def is_same_shape(x: Tensor, y: Tensor) -> bool:
             False
 
     """
-    assert (
-        in_dynamic_or_pir_mode()
-    ), "Currently, Sparse API only support dynamic mode or pir mode."
+    assert in_dynamic_or_pir_mode(), (
+        "Currently, Sparse API only support dynamic mode or pir mode."
+    )
     return x.is_same_shape(y)
 
 

--- a/python/paddle/sparse/multiary.py
+++ b/python/paddle/sparse/multiary.py
@@ -93,7 +93,7 @@ def addmm(
             >>> out = paddle.sparse.addmm(input, x, y, 3.0, 2.0)
 
     """
-    assert (
-        in_dynamic_or_pir_mode()
-    ), "Currently, Sparse API only support dynamic mode or pir mode."
+    assert in_dynamic_or_pir_mode(), (
+        "Currently, Sparse API only support dynamic mode or pir mode."
+    )
     return _C_ops.sparse_addmm(input, x, y, beta, alpha)

--- a/python/paddle/sparse/nn/functional/activation.py
+++ b/python/paddle/sparse/nn/functional/activation.py
@@ -177,9 +177,9 @@ def relu6(x: Tensor, name: str | None = None) -> Tensor:
             >>> sparse_x = dense_x.to_sparse_coo(1)
             >>> out = paddle.sparse.nn.functional.relu6(sparse_x)
     """
-    assert (
-        in_dynamic_or_pir_mode()
-    ), "Currently, Sparse API only support dynamic mode or pir mode."
+    assert in_dynamic_or_pir_mode(), (
+        "Currently, Sparse API only support dynamic mode or pir mode."
+    )
     return _C_ops.sparse_relu6(x)
 
 
@@ -217,7 +217,7 @@ def leaky_relu(
             >>> sparse_x = dense_x.to_sparse_coo(1)
             >>> out = paddle.sparse.nn.functional.leaky_relu(sparse_x, 0.5)
     """
-    assert (
-        in_dynamic_or_pir_mode()
-    ), "Currently, Sparse API only support dynamic mode or pir mode."
+    assert in_dynamic_or_pir_mode(), (
+        "Currently, Sparse API only support dynamic mode or pir mode."
+    )
     return _C_ops.sparse_leaky_relu(x, negative_slope)

--- a/python/paddle/sparse/nn/functional/pooling.py
+++ b/python/paddle/sparse/nn/functional/pooling.py
@@ -89,15 +89,15 @@ def max_pool3d(
             [1, 2, 2, 2, 3]
     """
 
-    assert (
-        in_dynamic_or_pir_mode()
-    ), "Currently, Sparse API only support dynamic mode or pir mode."
-    assert (
-        x.is_sparse_coo()
-    ), "Currently, sparse.relu only support the input of SparseCooTensor"
-    assert (
-        data_format == 'NDHWC'
-    ), "Currently, sparse.max_pool3d only support data format of 'NDHWC'"
+    assert in_dynamic_or_pir_mode(), (
+        "Currently, Sparse API only support dynamic mode or pir mode."
+    )
+    assert x.is_sparse_coo(), (
+        "Currently, sparse.relu only support the input of SparseCooTensor"
+    )
+    assert data_format == 'NDHWC', (
+        "Currently, sparse.max_pool3d only support data format of 'NDHWC'"
+    )
 
     kernel_size = convert_to_list(kernel_size, 3, 'pool_size')
     if stride is None:

--- a/python/paddle/sparse/nn/functional/transformer.py
+++ b/python/paddle/sparse/nn/functional/transformer.py
@@ -97,9 +97,9 @@ def attention(
             >>> output = paddle.sparse.nn.functional.attention(query, key, value, sp_mask, kp_mask, attn_mask)
             >>> output.backward()
     """
-    assert (
-        in_dynamic_or_pir_mode()
-    ), "Currently, Sparse API only support dynamic mode or pir mode."
+    assert in_dynamic_or_pir_mode(), (
+        "Currently, Sparse API only support dynamic mode or pir mode."
+    )
     return _C_ops.sparse_fused_attention(
         query, key, value, sparse_mask, key_padding_mask, attn_mask
     )

--- a/python/paddle/sparse/nn/layer/conv.py
+++ b/python/paddle/sparse/nn/layer/conv.py
@@ -63,9 +63,9 @@ class _Conv3D(Layer):
         backend: Literal['igemm'] | None = None,
     ) -> None:
         super().__init__()
-        assert (
-            weight_attr is not False
-        ), "weight_attr should not be False in Conv."
+        assert weight_attr is not False, (
+            "weight_attr should not be False in Conv."
+        )
         self._param_attr = weight_attr
         self._bias_attr = bias_attr
         self._groups = groups
@@ -76,9 +76,9 @@ class _Conv3D(Layer):
         self._key = key
         self._backend = backend
 
-        assert (
-            padding_mode == 'zeros'
-        ), "Currently, only support padding_mode='zeros'"
+        assert padding_mode == 'zeros', (
+            "Currently, only support padding_mode='zeros'"
+        )
         assert groups == 1, "Currently, only support groups=1"
         assert backend in [
             None,
@@ -195,9 +195,9 @@ class _Conv2D(Layer):
         backend: Literal['igemm'] | None = None,
     ) -> None:
         super().__init__()
-        assert (
-            weight_attr is not False
-        ), "weight_attr should not be False in Conv."
+        assert weight_attr is not False, (
+            "weight_attr should not be False in Conv."
+        )
         self._param_attr = weight_attr
         self._bias_attr = bias_attr
         self._groups = groups
@@ -208,9 +208,9 @@ class _Conv2D(Layer):
         self._key = key
         self._backend = backend
 
-        assert (
-            padding_mode == 'zeros'
-        ), "Currently, only support padding_mode='zeros'"
+        assert padding_mode == 'zeros', (
+            "Currently, only support padding_mode='zeros'"
+        )
         assert groups == 1, "Currently, only support groups=1"
         assert backend in [
             None,

--- a/python/paddle/sparse/unary.py
+++ b/python/paddle/sparse/unary.py
@@ -79,9 +79,9 @@ def sin(x: Tensor, name: str | None = None) -> Tensor:
                 indices=[[0, 2]],
                 values=[-0.90929741,  0.84147102])
     """
-    assert (
-        in_dynamic_or_pir_mode()
-    ), "Currently, Sparse API only support dynamic mode or pir mode."
+    assert in_dynamic_or_pir_mode(), (
+        "Currently, Sparse API only support dynamic mode or pir mode."
+    )
     return _C_ops.sparse_sin(x)
 
 
@@ -114,9 +114,9 @@ def tan(x: Tensor, name: str | None = None) -> Tensor:
                 indices=[[0, 2]],
                 values=[2.18503976, 1.55740774])
     """
-    assert (
-        in_dynamic_or_pir_mode()
-    ), "Currently, Sparse API only support dynamic mode or pir mode."
+    assert in_dynamic_or_pir_mode(), (
+        "Currently, Sparse API only support dynamic mode or pir mode."
+    )
     return _C_ops.sparse_tan(x)
 
 
@@ -149,9 +149,9 @@ def asin(x: Tensor, name: str | None = None) -> Tensor:
                 indices=[[0, 2]],
                 values=[nan       , 1.57079625])
     """
-    assert (
-        in_dynamic_or_pir_mode()
-    ), "Currently, Sparse API only support dynamic mode or pir mode."
+    assert in_dynamic_or_pir_mode(), (
+        "Currently, Sparse API only support dynamic mode or pir mode."
+    )
     return _C_ops.sparse_asin(x)
 
 
@@ -191,9 +191,9 @@ def transpose(
                         [ 1.,  2.]])
 
     """
-    assert (
-        in_dynamic_or_pir_mode()
-    ), "Currently, Sparse API only support dynamic mode or pir mode."
+    assert in_dynamic_or_pir_mode(), (
+        "Currently, Sparse API only support dynamic mode or pir mode."
+    )
     return _C_ops.sparse_transpose(x, perm)
 
 
@@ -334,9 +334,9 @@ def atan(x: Tensor, name: str | None = None) -> Tensor:
                 indices=[[0, 2]],
                 values=[-1.10714877,  0.78539819])
     """
-    assert (
-        in_dynamic_or_pir_mode()
-    ), "Currently, Sparse API only support dynamic mode or pir mode."
+    assert in_dynamic_or_pir_mode(), (
+        "Currently, Sparse API only support dynamic mode or pir mode."
+    )
     return _C_ops.sparse_atan(x)
 
 
@@ -369,9 +369,9 @@ def sinh(x: Tensor, name: str | None = None) -> Tensor:
                 indices=[[0, 2]],
                 values=[-3.62686038,  1.17520118])
     """
-    assert (
-        in_dynamic_or_pir_mode()
-    ), "Currently, Sparse API only support dynamic mode or pir mode."
+    assert in_dynamic_or_pir_mode(), (
+        "Currently, Sparse API only support dynamic mode or pir mode."
+    )
     return _C_ops.sparse_sinh(x)
 
 
@@ -404,9 +404,9 @@ def asinh(x: Tensor, name: str | None = None) -> Tensor:
                 indices=[[0, 2]],
                 values=[-1.44363546,  0.88137358])
     """
-    assert (
-        in_dynamic_or_pir_mode()
-    ), "Currently, Sparse API only support dynamic mode or pir mode."
+    assert in_dynamic_or_pir_mode(), (
+        "Currently, Sparse API only support dynamic mode or pir mode."
+    )
     return _C_ops.sparse_asinh(x)
 
 
@@ -439,9 +439,9 @@ def atanh(x: Tensor, name: str | None = None) -> Tensor:
                 indices=[[0, 2]],
                 values=[nan , inf.])
     """
-    assert (
-        in_dynamic_or_pir_mode()
-    ), "Currently, Sparse API only support dynamic mode or pir mode."
+    assert in_dynamic_or_pir_mode(), (
+        "Currently, Sparse API only support dynamic mode or pir mode."
+    )
     return _C_ops.sparse_atanh(x)
 
 
@@ -474,9 +474,9 @@ def tanh(x: Tensor, name: str | None = None) -> Tensor:
                 indices=[[0, 2]],
                 values=[-0.96402758,  0.76159418])
     """
-    assert (
-        in_dynamic_or_pir_mode()
-    ), "Currently, Sparse API only support dynamic mode or pir mode."
+    assert in_dynamic_or_pir_mode(), (
+        "Currently, Sparse API only support dynamic mode or pir mode."
+    )
     return _C_ops.sparse_tanh(x)
 
 
@@ -509,9 +509,9 @@ def square(x: Tensor, name: str | None = None) -> Tensor:
                 indices=[[0, 2]],
                 values=[4., 1.])
     """
-    assert (
-        in_dynamic_or_pir_mode()
-    ), "Currently, Sparse API only support dynamic mode or pir mode."
+    assert in_dynamic_or_pir_mode(), (
+        "Currently, Sparse API only support dynamic mode or pir mode."
+    )
     return _C_ops.sparse_square(x)
 
 
@@ -544,9 +544,9 @@ def sqrt(x: Tensor, name: str | None = None) -> Tensor:
                 indices=[[0, 2]],
                 values=[nan, 1. ])
     """
-    assert (
-        in_dynamic_or_pir_mode()
-    ), "Currently, Sparse API only support dynamic mode or pir mode."
+    assert in_dynamic_or_pir_mode(), (
+        "Currently, Sparse API only support dynamic mode or pir mode."
+    )
     return _C_ops.sparse_sqrt(x)
 
 
@@ -579,9 +579,9 @@ def log1p(x: Tensor, name: str | None = None) -> Tensor:
                 indices=[[0, 2]],
                 values=[nan       , 0.69314718])
     """
-    assert (
-        in_dynamic_or_pir_mode()
-    ), "Currently, Sparse API only support dynamic mode or pir mode."
+    assert in_dynamic_or_pir_mode(), (
+        "Currently, Sparse API only support dynamic mode or pir mode."
+    )
     return _C_ops.sparse_log1p(x)
 
 
@@ -620,9 +620,9 @@ def cast(
                 indices=[[0, 2]],
                 values=[-2.,  1.])
     """
-    assert (
-        in_dynamic_or_pir_mode()
-    ), "Currently, Sparse API only support dynamic mode or pir mode."
+    assert in_dynamic_or_pir_mode(), (
+        "Currently, Sparse API only support dynamic mode or pir mode."
+    )
     if index_dtype and not isinstance(index_dtype, core.VarDesc.VarType):
         index_dtype = convert_np_dtype_to_dtype_(index_dtype)
     if value_dtype and not isinstance(value_dtype, core.VarDesc.VarType):
@@ -660,9 +660,9 @@ def pow(x: Tensor, factor: float, name: str | None = None) -> Tensor:
                 indices=[[0, 2]],
                 values=[4., 9.])
     """
-    assert (
-        in_dynamic_or_pir_mode()
-    ), "Currently, Sparse API only support dynamic mode or pir mode."
+    assert in_dynamic_or_pir_mode(), (
+        "Currently, Sparse API only support dynamic mode or pir mode."
+    )
     return _C_ops.sparse_pow(x, float(factor))
 
 
@@ -695,9 +695,9 @@ def neg(x: Tensor, name: str | None = None) -> Tensor:
                 indices=[[0, 2]],
                 values=[ 2., -3.])
     """
-    assert (
-        in_dynamic_or_pir_mode()
-    ), "Currently, Sparse API only support dynamic mode or pir mode."
+    assert in_dynamic_or_pir_mode(), (
+        "Currently, Sparse API only support dynamic mode or pir mode."
+    )
     return _C_ops.sparse_scale(x, -1.0, 0.0, True)
 
 
@@ -730,9 +730,9 @@ def abs(x: Tensor, name: str | None = None) -> Tensor:
                 indices=[[0, 2]],
                 values=[2., 3.])
     """
-    assert (
-        in_dynamic_or_pir_mode()
-    ), "Currently, Sparse API only support dynamic mode or pir mode."
+    assert in_dynamic_or_pir_mode(), (
+        "Currently, Sparse API only support dynamic mode or pir mode."
+    )
     return _C_ops.sparse_abs(x)
 
 
@@ -765,9 +765,9 @@ def coalesce(x: Tensor, name: str | None = None) -> Tensor:
             Tensor(shape=[2], dtype=float32, place=Place(cpu), stop_gradient=True,
             [3., 3.])
     """
-    assert (
-        in_dynamic_or_pir_mode()
-    ), "Currently, Sparse API only support dynamic mode or pir mode."
+    assert in_dynamic_or_pir_mode(), (
+        "Currently, Sparse API only support dynamic mode or pir mode."
+    )
     return _C_ops.sparse_coalesce(x)
 
 
@@ -801,9 +801,9 @@ def rad2deg(x: Tensor, name: str | None = None) -> Tensor:
                 indices=[[0, 2]],
                 values=[ 180.02334595, -180.02334595])
     """
-    assert (
-        in_dynamic_or_pir_mode()
-    ), "Currently, Sparse API only support dynamic mode or pir mode."
+    assert in_dynamic_or_pir_mode(), (
+        "Currently, Sparse API only support dynamic mode or pir mode."
+    )
     if x.dtype in _int_dtype_:
         x = _C_ops.sparse_cast(x, None, core.VarDesc.VarType.FP32)
     return _C_ops.sparse_scale(x, 180.0 / np.pi, 0.0, True)
@@ -839,9 +839,9 @@ def deg2rad(x: Tensor, name: str | None = None) -> Tensor:
                 indices=[[0, 2]],
                 values=[-3.14159274,  3.14159274])
     """
-    assert (
-        in_dynamic_or_pir_mode()
-    ), "Currently, Sparse API only support dynamic mode or pir mode."
+    assert in_dynamic_or_pir_mode(), (
+        "Currently, Sparse API only support dynamic mode or pir mode."
+    )
     if x.dtype in _int_dtype_:
         x = _C_ops.sparse_cast(x, None, core.VarDesc.VarType.FP32)
     return _C_ops.sparse_scale(x, np.pi / 180.0, 0.0, True)
@@ -876,9 +876,9 @@ def expm1(x: Tensor, name: str | None = None) -> Tensor:
                 indices=[[0, 2]],
                 values=[-0.86466473,  1.71828187])
     """
-    assert (
-        in_dynamic_or_pir_mode()
-    ), "Currently, Sparse API only support dynamic mode or pir mode."
+    assert in_dynamic_or_pir_mode(), (
+        "Currently, Sparse API only support dynamic mode or pir mode."
+    )
     return _C_ops.sparse_expm1(x)
 
 

--- a/python/paddle/static/amp/amp_nn.py
+++ b/python/paddle/static/amp/amp_nn.py
@@ -132,13 +132,13 @@ def update_loss_scaling(
             'update_loss_scaling',
         )
         if e.dtype in [paddle.float16, paddle.bfloat16]:
-            assert (
-                prev_loss_scaling.dtype == paddle.float32
-            ), "The dtype of prev_loss_scaling should be float32 when the dtype of x is float16 or bfloat16."
+            assert prev_loss_scaling.dtype == paddle.float32, (
+                "The dtype of prev_loss_scaling should be float32 when the dtype of x is float16 or bfloat16."
+            )
         else:
-            assert (
-                prev_loss_scaling.dtype == e.dtype
-            ), "The dtype of prev_loss_scaling should be equal to the dtype of x."
+            assert prev_loss_scaling.dtype == e.dtype, (
+                "The dtype of prev_loss_scaling should be equal to the dtype of x."
+            )
 
     helper = LayerHelper("update_loss_scaling", **locals())
 

--- a/python/paddle/static/amp/bf16/amp_utils.py
+++ b/python/paddle/static/amp/bf16/amp_utils.py
@@ -148,9 +148,9 @@ def _insert_cast_post_op(
     if target_var.type not in _valid_types or target_var.dtype == dest_dtype:
         return num_cast_ops
 
-    assert (
-        target_var.dtype == src_dtype
-    ), f"The real dtype({_dtype_to_str(target_var.dtype)}) is not equal to the src dtype({_dtype_to_str(src_dtype)})"
+    assert target_var.dtype == src_dtype, (
+        f"The real dtype({_dtype_to_str(target_var.dtype)}) is not equal to the src dtype({_dtype_to_str(src_dtype)})"
+    )
 
     cast_name = target_var.name + '.cast_' + _dtype_to_str(dest_dtype)
     cast_var = block.vars.get(cast_name)

--- a/python/paddle/static/amp/bf16/decorator.py
+++ b/python/paddle/static/amp/bf16/decorator.py
@@ -173,9 +173,9 @@ class OptimizerWithMixedPrecision:
                 >>> run_example_code()
 
         """
-        assert (
-            self._train_program is not None
-        ), "Please call the minimize method first."
+        assert self._train_program is not None, (
+            "Please call the minimize method first."
+        )
         if self._use_pure_bf16:
             cast_parameters_to_bf16(
                 place, self._train_program, scope, self._to_bf16_var_names

--- a/python/paddle/static/amp/decorator.py
+++ b/python/paddle/static/amp/decorator.py
@@ -155,9 +155,9 @@ class OptimizerWithMixedPrecision:
 
     def get_loss_scaling(self):
         """Return the real-time loss scaling factor."""
-        assert (
-            self._loss_scaling is not None
-        ), 'Please call minimize() before calling get_loss_scaling().'
+        assert self._loss_scaling is not None, (
+            'Please call minimize() before calling get_loss_scaling().'
+        )
         return self._loss_scaling
 
     def get_scaled_loss(self):
@@ -420,9 +420,9 @@ class OptimizerWithMixedPrecision:
                 >>> if paddle.is_compiled_with_cuda() and len(paddle.static.cuda_places()) > 0:
                 ...     run_example_code()
         """
-        assert (
-            self._train_program is not None
-        ), "Please call the minimize method first."
+        assert self._train_program is not None, (
+            "Please call the minimize method first."
+        )
         if self._use_pure_fp16:
             cast_parameters_to_fp16(
                 place,
@@ -583,9 +583,9 @@ class OptimizerWithMixedPrecision:
             if g.dtype == paddle.float32 or g.dtype == core.DataType.FLOAT32
         ]
         fp16_grads = [g for g in grads if g.dtype == self._amp_vartype]
-        assert len(fp32_grads) + len(fp16_grads) == len(
-            grads
-        ), "Data types of all grads must be either fp16/bf16 or fp32."
+        assert len(fp32_grads) + len(fp16_grads) == len(grads), (
+            "Data types of all grads must be either fp16/bf16 or fp32."
+        )
         return grads, fp32_grads, fp16_grads
 
     def _check_finite_and_unscale(self, params_grads):

--- a/python/paddle/static/amp/function_overload.py
+++ b/python/paddle/static/amp/function_overload.py
@@ -86,9 +86,9 @@ class Namespace:
             fn (function): the native python function handle.
             key (FunctionType): the specified type.
         """
-        assert isinstance(
-            key, FunctionType
-        ), f"The type of  key is expected to be FunctionType, but received {type(key)}."
+        assert isinstance(key, FunctionType), (
+            f"The type of  key is expected to be FunctionType, but received {type(key)}."
+        )
         func = Function(fn)
         self.function_map[key] = fn
         return func

--- a/python/paddle/static/io.py
+++ b/python/paddle/static/io.py
@@ -768,9 +768,9 @@ def deserialize_persistables(
         load_var_map[var_copy.name] = var_copy
 
     if data is None:
-        assert (
-            len(origin_shape_map) == 0
-        ), "Required 'data' shall be not None if program contains parameter, but received 'data' is None."
+        assert len(origin_shape_map) == 0, (
+            "Required 'data' shall be not None if program contains parameter, but received 'data' is None."
+        )
         return
 
     # append load_combine op to load parameters,
@@ -1537,9 +1537,9 @@ def save(
         return save_pir(program, model_path, protocol, **configs)
 
     base_name = os.path.basename(model_path)
-    assert (
-        base_name != ""
-    ), "The input model_path MUST be format of dirname/filename [dirname\\filename in Windows system], but received model_path is empty string."
+    assert base_name != "", (
+        "The input model_path MUST be format of dirname/filename [dirname\\filename in Windows system], but received model_path is empty string."
+    )
     if 'pickle_protocol' in configs:
         protocol = configs['pickle_protocol']
         warnings.warn(
@@ -1790,9 +1790,9 @@ def load(
             load_dict = _safe_load_pickle(f, encoding='latin1')
         load_dict = _pack_loaded_dict(load_dict)
     for v in parameter_list:
-        assert (
-            v.name in load_dict
-        ), f"Can not find [{v.name}] in model file [{parameter_file_name}]"
+        assert v.name in load_dict, (
+            f"Can not find [{v.name}] in model file [{parameter_file_name}]"
+        )
         set_var(v, load_dict[v.name])
 
     optimizer_var_list = list(
@@ -1801,9 +1801,9 @@ def load(
 
     if len(optimizer_var_list) > 0:
         opt_file_name = model_prefix + ".pdopt"
-        assert os.path.exists(
-            opt_file_name
-        ), f"Optimizer file [{opt_file_name}] not exits"
+        assert os.path.exists(opt_file_name), (
+            f"Optimizer file [{opt_file_name}] not exits"
+        )
 
         if executor:
             paddle.base.core._create_loaded_parameter(
@@ -1813,9 +1813,9 @@ def load(
         with open(opt_file_name, 'rb') as f:
             load_dict = _safe_load_pickle(f, encoding='latin1')
         for v in optimizer_var_list:
-            assert (
-                v.name in load_dict
-            ), f"Can not find [{v.name}] in model file [{opt_file_name}]"
+            assert v.name in load_dict, (
+                f"Can not find [{v.name}] in model file [{opt_file_name}]"
+            )
             set_var(v, load_dict[v.name])
 
 
@@ -1869,9 +1869,9 @@ def set_program_state(
     used_para_list = {}
     for para in parameter_list:
         var_temp = paddle.base.global_scope().find_var(para.name)
-        assert (
-            var_temp is not None
-        ), f"Variable [ {para.name} ] Not found, Please make sure run startup program"
+        assert var_temp is not None, (
+            f"Variable [ {para.name} ] Not found, Please make sure run startup program"
+        )
         if para.name in state_dict:
             # set value from state dict
             orig_para_np = np.array(var_temp.get_tensor())
@@ -2101,9 +2101,9 @@ def load_program_state(
 
             return res_dict
 
-    assert os.path.exists(
-        parameter_file_name
-    ), f"Parameter file [{parameter_file_name}] not exits"
+    assert os.path.exists(parameter_file_name), (
+        f"Parameter file [{parameter_file_name}] not exits"
+    )
 
     with open(parameter_file_name, 'rb') as f:
         # When value of dict is lager than 4GB ,there is a Bug on 'MAC python3'

--- a/python/paddle/static/nn/common.py
+++ b/python/paddle/static/nn/common.py
@@ -343,9 +343,9 @@ def instance_norm(
         'instance_norm',
     )
     if param_attr is False:
-        assert (
-            bias_attr is False
-        ), "param_attr and bias_attr must be set to False at the same time in instance_norm"
+        assert bias_attr is False, (
+            "param_attr and bias_attr must be set to False at the same time in instance_norm"
+        )
 
     helper = LayerHelper('instance_norm', **locals())
     dtype = helper.input_dtype()
@@ -716,9 +716,9 @@ def conv2d(
             >>> print(conv2d.shape)
             (-1, 2, 30, 30)
     """
-    assert (
-        not in_pir_mode()
-    ), "paddle.static.nn.conv2d is not supported in pir mode, please set the environment variable FLAGS_enable_pir_api=0 to switch old static mode."
+    assert not in_pir_mode(), (
+        "paddle.static.nn.conv2d is not supported in pir mode, please set the environment variable FLAGS_enable_pir_api=0 to switch old static mode."
+    )
 
     check_variable_and_dtype(
         input, 'input', ['uint16', 'float16', 'float32', 'float64'], 'conv2d'
@@ -1362,9 +1362,9 @@ def conv2d_transpose(
             >>> print(conv2d_transpose.shape)
             (-1, 2, 34, 34)
     """
-    assert (
-        param_attr is not False
-    ), "param_attr should not be False in conv2d_transpose."
+    assert param_attr is not False, (
+        "param_attr should not be False in conv2d_transpose."
+    )
     if len(input.shape) != 4:
         raise ValueError(
             f"Input size should be 4, but received {len(input.shape)}"
@@ -1741,9 +1741,9 @@ def conv3d_transpose(
             >>> print(output)
             [array(0.5148856, dtype=float32)]
     """
-    assert (
-        param_attr is not False
-    ), "param_attr should not be False in conv3d_transpose."
+    assert param_attr is not False, (
+        "param_attr should not be False in conv3d_transpose."
+    )
     if data_format not in ['NCDHW', 'NDHWC']:
         raise ValueError(
             "Param(data_format) of Op(paddle.static.nn.conv3d_transpose) got wrong value: received "
@@ -2547,9 +2547,9 @@ def batch_norm(
             >>> print(hidden2.shape)
             (3, 200)
     """
-    assert (
-        bias_attr is not False
-    ), "bias_attr should not be False in batch_norm."
+    assert bias_attr is not False, (
+        "bias_attr should not be False in batch_norm."
+    )
     helper = LayerHelper('batch_norm', **locals())
 
     check_variable_and_dtype(
@@ -2806,9 +2806,9 @@ def prelu(x, mode, param_attr=None, data_format="NCHW", name=None):
 
         data_format = 'NCHW' if data_format[1] == 'C' else 'NHWC'
 
-        assert (
-            len(x.shape) >= 2
-        ), "The size of input shape should be equal or larger than 2 in prelu() when mode is 'channel'"
+        assert len(x.shape) >= 2, (
+            "The size of input shape should be equal or larger than 2 in prelu() when mode is 'channel'"
+        )
         # NOTE(zhiqiu): The alpha_shape should be [1, channel] + [1] * len(x.shape[2:]).
         # To be consistent with Prelu, it is simplified.
         # NOTE(zhiqiu): Revert shape to [1, channel, 1, 1] for compatibility with saved model of old version.
@@ -2819,9 +2819,9 @@ def prelu(x, mode, param_attr=None, data_format="NCHW", name=None):
             alpha_shape = [1, x.shape[1], 1, 1]
 
     elif mode == 'element':
-        assert (
-            len(x.shape) >= 1
-        ), "The size of input shape should be equal or larger than 1 in prelu() when mode is 'element'"
+        assert len(x.shape) >= 1, (
+            "The size of input shape should be equal or larger than 1 in prelu() when mode is 'element'"
+        )
         alpha_shape = [1, *list(x.shape)[1:]]
     dtype = helper.input_dtype(input_param_name='x')
     alpha = helper.create_parameter(
@@ -3426,9 +3426,9 @@ def layer_norm(
             >>> print(output.shape)
             (8, 32, 32)
     """
-    assert (
-        in_dygraph_mode() is not True
-    ), "please use LayerNorm instead of layer_norm in dygraph mode!"
+    assert in_dygraph_mode() is not True, (
+        "please use LayerNorm instead of layer_norm in dygraph mode!"
+    )
     helper = LayerHelper('layer_norm', **locals())
     check_variable_and_dtype(
         input, 'input', ['float32', 'float64'], 'layer_norm'
@@ -3440,9 +3440,9 @@ def layer_norm(
     input_shape = input.shape
     param_shape = [reduce(lambda x, y: x * y, input_shape[begin_norm_axis:], 1)]
     if scale:
-        assert (
-            param_attr is not False
-        ), "param_attr should not be False when using scale."
+        assert param_attr is not False, (
+            "param_attr should not be False when using scale."
+        )
         scale = helper.create_parameter(
             attr=helper.param_attr,
             shape=param_shape,
@@ -3454,9 +3454,9 @@ def layer_norm(
         if param_attr:
             warnings.warn("param_attr is only available with scale is True.")
     if shift:
-        assert (
-            bias_attr is not False
-        ), "bias_attr should not be False when using shift."
+        assert bias_attr is not False, (
+            "bias_attr should not be False when using shift."
+        )
         bias = helper.create_parameter(
             attr=helper.bias_attr, shape=param_shape, dtype=dtype, is_bias=True
         )
@@ -3624,7 +3624,9 @@ def embedding(
     padding_idx = (
         -1
         if padding_idx is None
-        else padding_idx if padding_idx >= 0 else (size[0] + padding_idx)
+        else padding_idx
+        if padding_idx >= 0
+        else (size[0] + padding_idx)
     )
     helper.append_op(
         type='lookup_table_v2',
@@ -3790,7 +3792,9 @@ def sparse_embedding(
     padding_idx = (
         -1
         if padding_idx is None
-        else padding_idx if padding_idx >= 0 else (size[0] + padding_idx)
+        else padding_idx
+        if padding_idx >= 0
+        else (size[0] + padding_idx)
     )
 
     if table_class not in [

--- a/python/paddle/static/nn/control_flow.py
+++ b/python/paddle/static/nn/control_flow.py
@@ -1469,9 +1469,9 @@ class OutputSelector:
             self.unified_false_output,
             lambda x: isinstance(x, paddle.pir.Value),
         )
-        assert (
-            true_variable_indices == false_variable_indices
-        ), "true_variable_indices and false_variable_indices should be same"
+        assert true_variable_indices == false_variable_indices, (
+            "true_variable_indices and false_variable_indices should be same"
+        )
         return true_variable_indices
 
     @property
@@ -1955,9 +1955,9 @@ def copy_var_to_parent_block(var, layer_helper):
         return var
     prog = layer_helper.main_program
     parent_idx = prog.current_block().parent_idx
-    assert (
-        parent_idx >= 0
-    ), "Got wrong parent block index when assigning var to parent scope in control_flow"
+    assert parent_idx >= 0, (
+        "Got wrong parent block index when assigning var to parent scope in control_flow"
+    )
     parent_block = prog.block(parent_idx)
 
     if (

--- a/python/paddle/static/nn/sequence_lod.py
+++ b/python/paddle/static/nn/sequence_lod.py
@@ -137,12 +137,12 @@ def sequence_conv(
             >>> x_conved = paddle.static.nn.sequence_conv(input=x, num_filters=2, filter_size=3, padding_start=-1)
     """
 
-    assert (
-        not in_dygraph_mode()
-    ), "sequence layer is not supported in dygraph mode yet."
-    assert (
-        not in_pir_mode()
-    ), "sequence layer is not supported in pir mode, please set the environment variable FLAGS_enable_pir_api=0 to switch old static mode."
+    assert not in_dygraph_mode(), (
+        "sequence layer is not supported in dygraph mode yet."
+    )
+    assert not in_pir_mode(), (
+        "sequence layer is not supported in pir mode, please set the environment variable FLAGS_enable_pir_api=0 to switch old static mode."
+    )
     check_variable_and_dtype(
         input, 'input', ['float32', 'float64'], 'sequence_conv'
     )
@@ -251,12 +251,12 @@ def sequence_softmax(input, use_cudnn=False, name=None):
             ...     dtype='float32', lod_level=1)
             >>> x_sequence_softmax_2 = paddle.static.nn.sequence_softmax(input=y)
     """
-    assert (
-        not in_dygraph_mode()
-    ), "sequence layer is not supported in dygraph mode yet."
-    assert (
-        not in_pir_mode()
-    ), "sequence layer is not supported in pir mode, please set the environment variable FLAGS_enable_pir_api=0 to switch old static mode."
+    assert not in_dygraph_mode(), (
+        "sequence layer is not supported in dygraph mode yet."
+    )
+    assert not in_pir_mode(), (
+        "sequence layer is not supported in pir mode, please set the environment variable FLAGS_enable_pir_api=0 to switch old static mode."
+    )
     helper = LayerHelper('sequence_softmax', **locals())
     check_variable_and_dtype(
         input, 'input', ['float32', 'float64'], 'sequence_softmax'
@@ -368,12 +368,12 @@ def sequence_pool(input, pool_type, is_test=False, pad_value=0.0):
             >>> last_x = paddle.static.nn.sequence_pool(input=x, pool_type='last')
             >>> first_x = paddle.static.nn.sequence_pool(input=x, pool_type='first')
     """
-    assert (
-        not in_dygraph_mode()
-    ), "sequence layer is not supported in dygraph mode yet."
-    assert (
-        not in_pir_mode()
-    ), "sequence layer is not supported in pir mode, please set the environment variable FLAGS_enable_pir_api=0 to switch old static mode."
+    assert not in_dygraph_mode(), (
+        "sequence layer is not supported in dygraph mode yet."
+    )
+    assert not in_pir_mode(), (
+        "sequence layer is not supported in pir mode, please set the environment variable FLAGS_enable_pir_api=0 to switch old static mode."
+    )
 
     check_variable_and_dtype(
         input, 'input', ['float32', 'float64'], 'sequence_pool'
@@ -670,12 +670,12 @@ def sequence_expand(x, y, ref_level=-1, name=None):
             - dtype: float32
             - data: [1 2 1 2 3 4 3 4]
     """
-    assert (
-        not in_dygraph_mode()
-    ), "sequence layer is not supported in dygraph mode yet."
-    assert (
-        not in_pir_mode()
-    ), "sequence layer is not supported in pir mode, please set the environment variable FLAGS_enable_pir_api=0 to switch old static mode."
+    assert not in_dygraph_mode(), (
+        "sequence layer is not supported in dygraph mode yet."
+    )
+    assert not in_pir_mode(), (
+        "sequence layer is not supported in pir mode, please set the environment variable FLAGS_enable_pir_api=0 to switch old static mode."
+    )
     check_variable_and_dtype(
         x, 'x', ['float32', 'float64', 'int32', 'int64'], 'sequence_expand'
     )

--- a/python/paddle/static/nn/static_pylayer.py
+++ b/python/paddle/static/nn/static_pylayer.py
@@ -349,9 +349,9 @@ def static_pylayer(forward_fn, inputs, backward_fn=None, name=None):
             >>> print(y)
             [[  2.7182817   7.389056   20.085537   54.59815   148.41316  ]]
     """
-    assert (
-        in_dygraph_mode() is False
-    ), "please use PyLayer instead of static_pylayer in dygraph mode"
+    assert in_dygraph_mode() is False, (
+        "please use PyLayer instead of static_pylayer in dygraph mode"
+    )
 
     assert isinstance(inputs, list)
     if backward_fn is None:
@@ -418,25 +418,27 @@ def static_pylayer(forward_fn, inputs, backward_fn=None, name=None):
                     # NOTE: inp_grad will be None if fwd_input.stop_gradients=True
                     if inp_grad is None:
                         continue
-                    assert (
-                        inp_grad.dtype == fwd_input.dtype
-                    ), f"dtype of inp_grad({inp_grad.dtype}) and fwd_input({fwd_input.dtype}) should be the same"
-                    assert (
-                        inp_grad.shape == fwd_input.shape
-                    ), f"shape of inp_grad({inp_grad.shape}) and fwd_input({fwd_input.shape}) should be the same"
+                    assert inp_grad.dtype == fwd_input.dtype, (
+                        f"dtype of inp_grad({inp_grad.dtype}) and fwd_input({fwd_input.dtype}) should be the same"
+                    )
+                    assert inp_grad.shape == fwd_input.shape, (
+                        f"shape of inp_grad({inp_grad.shape}) and fwd_input({fwd_input.shape}) should be the same"
+                    )
                     if fwd_input.is_dist():
                         # NOTE: placements may be not the same, so do not check it.
-                        assert (
-                            inp_grad.is_dist()
-                        ), "fwd_input and inp_grad should both be distributed"
+                        assert inp_grad.is_dist(), (
+                            "fwd_input and inp_grad should both be distributed"
+                        )
                         assert (
                             fwd_input.dist_attr().process_mesh
                             == inp_grad.dist_attr().process_mesh
-                        ), f"process_mesh of fwd_input({fwd_input.dist_attr().process_mesh}) and inp_grad({inp_grad.dist_attr().process_mesh}) should be the same"
+                        ), (
+                            f"process_mesh of fwd_input({fwd_input.dist_attr().process_mesh}) and inp_grad({inp_grad.dist_attr().process_mesh}) should be the same"
+                        )
                     else:
-                        assert (
-                            inp_grad.type() == fwd_input.type()
-                        ), f"type of inp_grad({inp_grad.type()}) and fwd_input({fwd_input.type()}) should be the same"
+                        assert inp_grad.type() == fwd_input.type(), (
+                            f"type of inp_grad({inp_grad.type()}) and fwd_input({fwd_input.type()}) should be the same"
+                        )
 
                 # 2. Verify the number of `Value` outputs to ``forward_fn``
                 # the same as the number of `Value` inputs to ``backward_fn``
@@ -452,25 +454,27 @@ def static_pylayer(forward_fn, inputs, backward_fn=None, name=None):
                 for out_grad, fwd_output in zip(output_grads, forward_outputs):
                     if out_grad is None:
                         continue
-                    assert (
-                        out_grad.dtype == fwd_output.dtype
-                    ), f"dtype of out_grad({out_grad.dtype}) and fwd_output({fwd_output.dtype}) should be the same"
-                    assert (
-                        out_grad.shape == fwd_output.shape
-                    ), f"shape of out_grad({out_grad.shape}) and fwd_output({fwd_output.shape}) should be the same"
+                    assert out_grad.dtype == fwd_output.dtype, (
+                        f"dtype of out_grad({out_grad.dtype}) and fwd_output({fwd_output.dtype}) should be the same"
+                    )
+                    assert out_grad.shape == fwd_output.shape, (
+                        f"shape of out_grad({out_grad.shape}) and fwd_output({fwd_output.shape}) should be the same"
+                    )
                     if fwd_output.is_dist():
                         # NOTE: placements may be not the same, so do not check it.
-                        assert (
-                            out_grad.is_dist()
-                        ), "fwd_output and out_grad should both be distributed"
+                        assert out_grad.is_dist(), (
+                            "fwd_output and out_grad should both be distributed"
+                        )
                         assert (
                             fwd_output.dist_attr().process_mesh
                             == out_grad.dist_attr().process_mesh
-                        ), f"process_mesh of fwd_output({fwd_output.dist_attr().process_mesh}) and out_grad({out_grad.dist_attr().process_mesh}) should be the same"
+                        ), (
+                            f"process_mesh of fwd_output({fwd_output.dist_attr().process_mesh}) and out_grad({out_grad.dist_attr().process_mesh}) should be the same"
+                        )
                     else:
-                        assert (
-                            out_grad.type() == fwd_output.type()
-                        ), f"type of out_grad({out_grad.type}) and fwd_output({fwd_output.type}) should be the same"
+                        assert out_grad.type() == fwd_output.type(), (
+                            f"type of out_grad({out_grad.type}) and fwd_output({fwd_output.type}) should be the same"
+                        )
 
             bwd_fn = PyLayerBackwardFunction(
                 backward_fn, hook_check_func=hook_inputs_outputs_check_function
@@ -553,10 +557,10 @@ def static_pylayer(forward_fn, inputs, backward_fn=None, name=None):
                 forward_input_names = current_block.ops[
                     pylayer_block_manager.fwd_op_index
                 ].desc.input_arg_names()
-                assert len(forward_input_names) == len(
-                    flat_grad_origin
-                ), f"needs to keep the number of inputs to ``forward_fn`` the same as the number of outputs to ``backward_fn``, \
+                assert len(forward_input_names) == len(flat_grad_origin), (
+                    f"needs to keep the number of inputs to ``forward_fn`` the same as the number of outputs to ``backward_fn``, \
                     but got {len(forward_input_names)} and {len(flat_grad_origin)}"
+                )
 
                 # Step4. Rename var name with suffix of "@GRAD"
                 for bwd_output, fwd_input_name in zip(

--- a/python/paddle/static/pir_io.py
+++ b/python/paddle/static/pir_io.py
@@ -568,9 +568,9 @@ def save_pir(program, model_path, protocol=4, **configs):
     """
 
     base_name = os.path.basename(model_path)
-    assert (
-        base_name != ""
-    ), "The input model_path MUST be format of dirname/filename [dirname\\filename in Windows system], but received model_path is empty string."
+    assert base_name != "", (
+        "The input model_path MUST be format of dirname/filename [dirname\\filename in Windows system], but received model_path is empty string."
+    )
     if 'pickle_protocol' in configs:
         protocol = configs['pickle_protocol']
         warnings.warn(
@@ -672,16 +672,16 @@ def load_pir(program, model_prefix, executor=None, var_list=None):
         load_dict = _pack_loaded_dict(load_dict)
     for var in parameter_list:
         if var.persistable:
-            assert (
-                var.name in load_dict
-            ), f"Can not find [{var.name}] in model file [{parameter_file_name}]"
+            assert var.name in load_dict, (
+                f"Can not find [{var.name}] in model file [{parameter_file_name}]"
+            )
             set_var(var.name, load_dict[var.name])
 
     if len(optimizer_param_list) > 0:
         opt_file_name = model_prefix + ".pdopt"
-        assert os.path.exists(
-            opt_file_name
-        ), f"Optimizer file [{opt_file_name}] not exits"
+        assert os.path.exists(opt_file_name), (
+            f"Optimizer file [{opt_file_name}] not exits"
+        )
 
         if executor:
             paddle.base.libpaddle.pir.create_loaded_parameter(
@@ -692,9 +692,9 @@ def load_pir(program, model_prefix, executor=None, var_list=None):
             load_dict = _safe_load_pickle(f, encoding='latin1')
         for var in optimizer_param_list:
             if var.persistable:
-                assert (
-                    var.name in load_dict
-                ), f"Can not find [{var.name}] in model file [{opt_file_name}]"
+                assert var.name in load_dict, (
+                    f"Can not find [{var.name}] in model file [{opt_file_name}]"
+                )
                 set_var(var.name, load_dict[var.name])
 
 

--- a/python/paddle/static/quantization/post_training_quantization.py
+++ b/python/paddle/static/quantization/post_training_quantization.py
@@ -97,9 +97,9 @@ def _apply_pass(
     if not cpp_graph.has('__param_scope__'):
         cpp_graph.set_not_owned('__param_scope__', scope)
     if attrs:
-        assert attr_values and len(attrs) == len(
-            attr_values
-        ), "Different number of pass attributes and their values."
+        assert attr_values and len(attrs) == len(attr_values), (
+            "Different number of pass attributes and their values."
+        )
         for attr, value in zip(attrs, attr_values):
             ir_pass.set(attr, value)
     ir_pass.apply(cpp_graph)
@@ -312,15 +312,17 @@ class PostTrainingQuantization:
         assert data_loader is not None, "data_loader cannot be None."
 
         assert batch_size > 0, "The batch_size should be greater than 0."
-        assert (
-            algo in self._support_algo_type
-        ), "The algo should be KL, hist, mse, avg, abs_max, min_max or ptf."
+        assert algo in self._support_algo_type, (
+            "The algo should be KL, hist, mse, avg, abs_max, min_max or ptf."
+        )
         assert (
             activation_quantize_type in self._support_activation_quantize_type
-        ), f"The activation_quantize_type ({activation_quantize_type}) should in ({self._support_activation_quantize_type})."
-        assert (
-            weight_quantize_type in self._support_weight_quantize_type
-        ), f"The weight_quantize_type ({weight_quantize_type}) should in ({self._support_weight_quantize_type})."
+        ), (
+            f"The activation_quantize_type ({activation_quantize_type}) should in ({self._support_activation_quantize_type})."
+        )
+        assert weight_quantize_type in self._support_weight_quantize_type, (
+            f"The weight_quantize_type ({weight_quantize_type}) should in ({self._support_weight_quantize_type})."
+        )
 
         # Save input params
         self._bias_correction = bias_correction
@@ -388,9 +390,9 @@ class PostTrainingQuantization:
                 assert op_type in list(SUPPORT_QUANTIZATION_OP_DICT.keys()), (
                     op_type + " is not supported for quantization."
                 )
-        assert (
-            activation_bits == weight_bits
-        ), "activation_bits and weight_bits must be the same, other cases are not supported."
+        assert activation_bits == weight_bits, (
+            "activation_bits and weight_bits must be the same, other cases are not supported."
+        )
         support_deploy_backend = [None, "tensorrt", "mkldnn", "onednn", "arm"]
         if not deploy_backend:
             self.quant_config = BaseQuantizer(
@@ -1043,9 +1045,9 @@ class PostTrainingQuantization:
         '''
         Save input threshold to the quantized op.
         '''
-        assert (
-            self._algo == "min_max"
-        ), "The algo should be min_max to save input threshold."
+        assert self._algo == "min_max", (
+            "The algo should be min_max to save input threshold."
+        )
         for block_id in range(len(self._program.blocks)):
             for op in self._program.blocks[block_id].ops:
                 if (
@@ -1344,9 +1346,9 @@ class PostTrainingQuantization:
                 )
                 return
             else:
-                assert (
-                    out_var_name in threshold_map
-                ), f"The output ({out_var_name}) of {op_node.type} node does not have threshold."
+                assert out_var_name in threshold_map, (
+                    f"The output ({out_var_name}) of {op_node.type} node does not have threshold."
+                )
             if self._onnx_format:
                 # For easy extension, every var_node set a dict to save parameters of quant.
                 self._calibration_scales[out_var_name] = {}
@@ -1622,9 +1624,9 @@ class WeightQuantization:
             8,
             16,
         ], "Input error: weight_bits should be 8 or 16."
-        assert (
-            weight_quantize_type in self._supported_weight_quantize_type
-        ), f"Input error: weight_quantize_type should in {self._supported_weight_quantize_type}"
+        assert weight_quantize_type in self._supported_weight_quantize_type, (
+            f"Input error: weight_quantize_type should in {self._supported_weight_quantize_type}"
+        )
 
         quantized_model_dir = os.path.join(save_model_dir, "quantized_model")
         self._quantize_weight_to_int(

--- a/python/paddle/static/quantization/quant2_int8_onednn_pass.py
+++ b/python/paddle/static/quantization/quant2_int8_onednn_pass.py
@@ -94,9 +94,9 @@ class Quant2Int8OnednnPass:
         self._pass_group = 'int8'
 
     def apply(self, graph):
-        assert isinstance(
-            graph, IrGraph
-        ), 'graph must be the instance of IrGraph.'
+        assert isinstance(graph, IrGraph), (
+            'graph must be the instance of IrGraph.'
+        )
 
         self._reset_pass_idx_and_group('int8')
         graph = self._label_skip_quantized_op(graph)
@@ -115,9 +115,9 @@ class Quant2Int8OnednnPass:
         return graph
 
     def prepare_and_optimize_fp32(self, graph):
-        assert isinstance(
-            graph, IrGraph
-        ), 'graph must be the instance of IrGraph.'
+        assert isinstance(graph, IrGraph), (
+            'graph must be the instance of IrGraph.'
+        )
 
         self._reset_pass_idx_and_group('fp32')
         graph = self._optimize_fp32_graph(graph)
@@ -192,9 +192,9 @@ class Quant2Int8OnednnPass:
         for op in graph.all_op_nodes():
             if op.name() in fake_ops:
                 bit_length = op.op().attr("bit_length")
-                assert (
-                    bit_length == 8
-                ), f'Unsupported number quantization bits ({bit_length}). Only 8 is supported now.'
+                assert bit_length == 8, (
+                    f'Unsupported number quantization bits ({bit_length}). Only 8 is supported now.'
+                )
 
                 input_name = op.input("X")[0]
                 scale_name = op.input("InScale")[0]
@@ -499,9 +499,9 @@ class Quant2Int8OnednnPass:
         if not cpp_graph.has('__param_scope__'):
             cpp_graph.set_not_owned('__param_scope__', self._scope)
         if attrs:
-            assert attr_values and len(attrs) == len(
-                attr_values
-            ), "Different number of pass attributes and their values."
+            assert attr_values and len(attrs) == len(attr_values), (
+                "Different number of pass attributes and their values."
+            )
             for attr, value in zip(attrs, attr_values):
                 ir_pass.set(attr, value)
         ir_pass.apply(cpp_graph)
@@ -606,9 +606,9 @@ class Quant2Int8OnednnPass:
         def _compute_gru_weight_scales(wx_name, wh_name):
             for op in graph.all_op_nodes():
                 if op.op().type() in self._gru_ops:
-                    assert len(op.input(wx_name)) == len(
-                        op.input(wh_name)
-                    ), f'Mismatch in number of weights inputs ({len(op.input(wx_name))} for WeightX vs. {len(op.input(wh_name))} for WeightH).'
+                    assert len(op.input(wx_name)) == len(op.input(wh_name)), (
+                        f'Mismatch in number of weights inputs ({len(op.input(wx_name))} for WeightX vs. {len(op.input(wh_name))} for WeightH).'
+                    )
                     for i, wx_var_name in enumerate(op.input(wx_name)):
                         wh_var_name = op.input(wh_name)[i]
                         use_unsigned_int = False
@@ -634,9 +634,9 @@ class Quant2Int8OnednnPass:
         def _compute_lstm_weight_scales(wx_name, wh_name):
             for op in graph.all_op_nodes():
                 if op.op().type() in self._lstm_ops:
-                    assert len(op.input(wx_name)) == len(
-                        op.input(wh_name)
-                    ), f'Mismatch in number of weights inputs ({len(op.input(wx_name))} for WeightX vs. {len(op.input(wh_name))} for WeightH).'
+                    assert len(op.input(wx_name)) == len(op.input(wh_name)), (
+                        f'Mismatch in number of weights inputs ({len(op.input(wx_name))} for WeightX vs. {len(op.input(wh_name))} for WeightH).'
+                    )
                     for i, wx_var_name in enumerate(op.input(wx_name)):
                         wh_var_name = op.input(wh_name)[i]
                         use_unsigned_int = False

--- a/python/paddle/static/quantization/quant_int8_onednn_pass.py
+++ b/python/paddle/static/quantization/quant_int8_onednn_pass.py
@@ -91,9 +91,9 @@ class QuantInt8OnednnPass:
             graph(IrGraph): the applied graph.
         """
 
-        assert isinstance(
-            graph, IrGraph
-        ), 'graph must be the instance of IrGraph.'
+        assert isinstance(graph, IrGraph), (
+            'graph must be the instance of IrGraph.'
+        )
         ops = graph.all_op_nodes()
 
         persistable_vars = [p.name() for p in graph.all_persistable_nodes()]

--- a/python/paddle/static/quantization/quanter.py
+++ b/python/paddle/static/quantization/quanter.py
@@ -151,41 +151,41 @@ def _parse_configs(user_config):
         weight_types = WEIGHT_QUANTIZATION_TYPES
         activation_types = WEIGHT_QUANTIZATION_TYPES
         platform = 'PaddleLite'
-    assert (
-        configs['weight_quantize_type'] in weight_types
-    ), "Unknown weight_quantize_type: {}. {} only supports {} ".format(
-        configs['weight_quantize_type'], platform, weight_types
+    assert configs['weight_quantize_type'] in weight_types, (
+        "Unknown weight_quantize_type: {}. {} only supports {} ".format(
+            configs['weight_quantize_type'], platform, weight_types
+        )
     )
 
-    assert (
-        configs['activation_quantize_type'] in activation_types
-    ), "Unknown activation_quantize_type: {}. {} only supports {}".format(
-        configs['activation_quantize_type'], platform, activation_types
+    assert configs['activation_quantize_type'] in activation_types, (
+        "Unknown activation_quantize_type: {}. {} only supports {}".format(
+            configs['activation_quantize_type'], platform, activation_types
+        )
     )
 
-    assert isinstance(
-        configs['weight_bits'], int
-    ), "weight_bits must be int value."
+    assert isinstance(configs['weight_bits'], int), (
+        "weight_bits must be int value."
+    )
 
-    assert (
-        configs['weight_bits'] >= 1 and configs['weight_bits'] <= 16
-    ), "weight_bits should be between 1 and 16."
+    assert configs['weight_bits'] >= 1 and configs['weight_bits'] <= 16, (
+        "weight_bits should be between 1 and 16."
+    )
 
-    assert isinstance(
-        configs['activation_bits'], int
-    ), "activation_bits must be int value."
+    assert isinstance(configs['activation_bits'], int), (
+        "activation_bits must be int value."
+    )
 
     assert (
         configs['activation_bits'] >= 1 and configs['activation_bits'] <= 16
     ), "activation_bits should be between 1 and 16."
 
-    assert isinstance(
-        configs['not_quant_pattern'], (list, str)
-    ), "not_quant_pattern must be list or str"
+    assert isinstance(configs['not_quant_pattern'], (list, str)), (
+        "not_quant_pattern must be list or str"
+    )
 
-    assert isinstance(
-        configs['quantize_op_types'], list
-    ), "quantize_op_types must be a list"
+    assert isinstance(configs['quantize_op_types'], list), (
+        "quantize_op_types must be a list"
+    )
 
     if configs['for_tensorrt']:
         configs['quantize_op_types'] = TENSORRT_OP_TYPES
@@ -197,8 +197,10 @@ def _parse_configs(user_config):
         for op_type in configs['quantize_op_types']:
             assert (op_type in QUANT_DEQUANT_PASS_OP_TYPES) or (
                 op_type in TRANSFORM_PASS_OP_TYPES
-            ), f"{op_type} is not support, \
+            ), (
+                f"{op_type} is not support, \
                         now support op types are {TRANSFORM_PASS_OP_TYPES + QUANT_DEQUANT_PASS_OP_TYPES}"
+            )
 
     assert isinstance(configs['dtype'], str), "dtype must be a str."
 
@@ -206,13 +208,13 @@ def _parse_configs(user_config):
         VALID_DTYPES
     )
 
-    assert isinstance(
-        configs['window_size'], int
-    ), "window_size must be int value, window size for 'range_abs_max' quantization, default is 10000."
+    assert isinstance(configs['window_size'], int), (
+        "window_size must be int value, window size for 'range_abs_max' quantization, default is 10000."
+    )
 
-    assert isinstance(
-        configs['moving_rate'], float
-    ), "moving_rate must be float value, The decay coefficient of moving average, default is 0.9."
+    assert isinstance(configs['moving_rate'], float), (
+        "moving_rate must be float value, The decay coefficient of moving average, default is 0.9."
+    )
 
     return configs
 
@@ -519,9 +521,9 @@ def convert(program, place, config=None, scope=None, save_int8=False):
             persistables.extend(_op.input('X'))
             _op.desc.set_input("X", persistables)
 
-    assert not (
-        save_int8 and config['onnx_format']
-    ), "When onnx_format=True, already saved int8 weight,so you can't set save_int8=True."
+    assert not (save_int8 and config['onnx_format']), (
+        "When onnx_format=True, already saved int8 weight,so you can't set save_int8=True."
+    )
     if save_int8:
         convert_int8_pass = ConvertToInt8Pass(scope=scope, place=place)
         for sub_graph in test_graph.all_sub_graphs():

--- a/python/paddle/static/quantization/quantization_pass.py
+++ b/python/paddle/static/quantization/quantization_pass.py
@@ -64,9 +64,9 @@ _SCALE_DEFAULT_VALUE = 0.001
 
 
 def _init_var_node(var_node, value, scope, place):
-    assert isinstance(
-        value, np.ndarray
-    ), 'The type of value should be numpy array.'
+    assert isinstance(value, np.ndarray), (
+        'The type of value should be numpy array.'
+    )
     assert scope is not None, 'The scope cannot be set None.'
     assert place is not None, 'The place cannot be set None.'
     tensor = scope.var(var_node.name()).get_tensor()
@@ -204,9 +204,9 @@ class QuantizationTransformPass:
             'range_abs_max',
             'moving_average_abs_max',
         ]
-        assert (
-            activation_quantize_type != 'channel_wise_abs_max'
-        ), "The activation quantization type does not support 'channel_wise_abs_max'."
+        assert activation_quantize_type != 'channel_wise_abs_max', (
+            "The activation quantization type does not support 'channel_wise_abs_max'."
+        )
         if activation_quantize_type not in quant_type:
             raise ValueError(
                 f"Unknown activation_quantize_type : '{activation_quantize_type}'. It can only be "
@@ -249,9 +249,9 @@ class QuantizationTransformPass:
         Returns:
             None
         """
-        assert isinstance(
-            graph, IrGraph
-        ), 'graph must be the instance of IrGraph.'
+        assert isinstance(graph, IrGraph), (
+            'graph must be the instance of IrGraph.'
+        )
         if self._is_test is None:
             self._is_test = graph.is_test()
         # marked the variable which has been dequantized.
@@ -937,9 +937,9 @@ class QuantizationTransformPass:
             # loss shape must be 1 when minimize
             loss = paddle.mean(out_node)
             if not graph._for_test:
-                assert (
-                    self._optimizer
-                ), "optimizer_func must be set when graph is test graph"
+                assert self._optimizer, (
+                    "optimizer_func must be set when graph is test graph"
+                )
                 in_node.stop_gradient = False
                 optimizer = self._optimizer()
                 optimizer.minimize(loss)
@@ -1266,9 +1266,9 @@ class QuantizationFreezePass:
             original_var_name = self._original_var_name(name)
             scale_v = self._quant_var_scale_map[original_var_name]
             if original_var_name in persistable_vars:
-                assert isinstance(
-                    scale_v, list
-                ), f'The scale of parameter {original_var_name} is not a list.'
+                assert isinstance(scale_v, list), (
+                    f'The scale of parameter {original_var_name} is not a list.'
+                )
                 channel_scale = np.array(scale_v)
             else:
                 assert isinstance(scale_v, IrNode)
@@ -1351,9 +1351,9 @@ class QuantizationFreezePass:
             original_var_name = self._original_var_name(name)
             scale_v = self._quant_var_scale_map[original_var_name]
             if original_var_name in persistable_vars:
-                assert self._is_float(
-                    scale_v
-                ), f'The scale of parameter {original_var_name} is not a float.'
+                assert self._is_float(scale_v), (
+                    f'The scale of parameter {original_var_name} is not a float.'
+                )
                 scale_v = 1e-8 if scale_v == 0.0 else scale_v
                 max_range *= param_range / scale_v
             else:
@@ -1610,9 +1610,9 @@ class OutScaleForTrainingPass:
         Args:
             graph(IrGraph): the target graph.
         """
-        assert isinstance(
-            graph, IrGraph
-        ), 'graph must be the instance of IrGraph.'
+        assert isinstance(graph, IrGraph), (
+            'graph must be the instance of IrGraph.'
+        )
         if self._is_test is None:
             self._is_test = graph.is_test()
         target_ops = []
@@ -1768,9 +1768,9 @@ class OutScaleForInferencePass:
         Args:
             graph(IrGraph): the target graph.
         """
-        assert isinstance(
-            graph, IrGraph
-        ), 'graph must be the instance of IrGraph.'
+        assert isinstance(graph, IrGraph), (
+            'graph must be the instance of IrGraph.'
+        )
         op_nodes = graph.all_op_nodes()
         for op_node in op_nodes:
             if op_node.name() in self._teller_set:
@@ -1791,9 +1791,9 @@ class OutScaleForInferencePass:
 
                     scale_name = self._scale_name(var_name)
                     scale_var = self._scope.find_var(scale_name)
-                    assert (
-                        scale_var is not None
-                    ), f"Can not find {scale_name} variable in the scope"
+                    assert scale_var is not None, (
+                        f"Can not find {scale_name} variable in the scope"
+                    )
                     scale_value = np.array(scale_var.get_tensor())[0]
 
                     # For compatibility, we save output threshold by two methods.
@@ -1888,9 +1888,9 @@ class AddQuantDequantPass:
         Returns:
             None
         """
-        assert isinstance(
-            graph, IrGraph
-        ), 'graph must be the instance of IrGraph.'
+        assert isinstance(graph, IrGraph), (
+            'graph must be the instance of IrGraph.'
+        )
         if self._is_test is None:
             self._is_test = graph.is_test()
         dequantized_vars_map = collections.OrderedDict()
@@ -2471,9 +2471,9 @@ class QuantizationTransformPassV2(QuantizationTransformPass):
             'range_abs_max',
             'moving_average_abs_max',
         ]
-        assert (
-            activation_quantize_type != 'channel_wise_abs_max'
-        ), "The activation quantization type does not support 'channel_wise_abs_max'."
+        assert activation_quantize_type != 'channel_wise_abs_max', (
+            "The activation quantization type does not support 'channel_wise_abs_max'."
+        )
         if activation_quantize_type not in quant_type:
             raise ValueError(
                 f"Unknown activation_quantize_type : '{activation_quantize_type}'. It can only be "
@@ -2733,9 +2733,9 @@ class QuantizationTransformPassV2(QuantizationTransformPass):
         Returns:
             None
         """
-        assert isinstance(
-            graph, IrGraph
-        ), 'graph must be the instance of IrGraph.'
+        assert isinstance(graph, IrGraph), (
+            'graph must be the instance of IrGraph.'
+        )
         if self._is_test is None:
             self._is_test = graph.is_test()
         # marked the variable which has been dequantized.
@@ -2876,9 +2876,9 @@ class AddQuantDequantPassV2:
         Returns:
             None
         """
-        assert isinstance(
-            graph, IrGraph
-        ), 'graph must be the instance of IrGraph.'
+        assert isinstance(graph, IrGraph), (
+            'graph must be the instance of IrGraph.'
+        )
         if self._is_test is None:
             self._is_test = graph.is_test()
         dequantized_vars_map = collections.OrderedDict()
@@ -3033,9 +3033,9 @@ class ReplaceFakeQuantDequantPass:
         assert self._place is not None, "place must not be None."
 
     def apply(self, graph):
-        assert isinstance(
-            graph, IrGraph
-        ), 'graph must be the instance of IrGraph.'
+        assert isinstance(graph, IrGraph), (
+            'graph must be the instance of IrGraph.'
+        )
         fake_quant_dequant_ops = []
         remove_fake_quant_ops = []
         observer_out_node_names = []
@@ -3214,9 +3214,9 @@ class QuantWeightPass:
         self._quantized_ops = set()
 
     def apply(self, graph):
-        assert isinstance(
-            graph, IrGraph
-        ), 'graph must be the instance of IrGraph.'
+        assert isinstance(graph, IrGraph), (
+            'graph must be the instance of IrGraph.'
+        )
         fake_quant_ops_for_weight = []
 
         fake_quant_ops = [
@@ -3343,9 +3343,9 @@ class AddQuantDequantForInferencePass:
         Args:
             graph(IrGraph): the target graph.
         """
-        assert isinstance(
-            graph, IrGraph
-        ), 'graph must be the instance of IrGraph.'
+        assert isinstance(graph, IrGraph), (
+            'graph must be the instance of IrGraph.'
+        )
         dequant_node_map = {}
         dequantized_vars_map = collections.OrderedDict()
         for op_node in graph.all_op_nodes():
@@ -3546,9 +3546,9 @@ class AddQuantDequantForResidual:
         Args:
             graph(IrGraph): the target graph.
         """
-        assert isinstance(
-            graph, IrGraph
-        ), 'graph must be the instance of IrGraph.'
+        assert isinstance(graph, IrGraph), (
+            'graph must be the instance of IrGraph.'
+        )
         weight_var_names = self._all_weight_node_names(graph)
         var_node_names_with_order = self._var_name_order(graph)
         for op in graph.all_op_nodes():

--- a/python/paddle/static/quantization/utils.py
+++ b/python/paddle/static/quantization/utils.py
@@ -35,9 +35,9 @@ def _get_op_input_var_names(op):
     Returns:
         input_var_names or None.
     """
-    assert isinstance(
-        op, (IrNode, Operator)
-    ), "The input op should be IrNode or Operator."
+    assert isinstance(op, (IrNode, Operator)), (
+        "The input op should be IrNode or Operator."
+    )
     var_names = []
     op_name = op.name() if isinstance(op, IrNode) else op.type
     if op_name not in SUPPORT_QUANTIZATION_OP_DICT:
@@ -55,9 +55,9 @@ def _get_op_input_var_names(op):
 
 def _get_op_output_var_names(op):
     """ """
-    assert isinstance(
-        op, (IrNode, Operator)
-    ), "The input op should be IrNode or Operator."
+    assert isinstance(op, (IrNode, Operator)), (
+        "The input op should be IrNode or Operator."
+    )
     var_names = []
     op_name = op.name() if isinstance(op, IrNode) else op.type
     if op_name not in SUPPORT_QUANTIZATION_OP_DICT:
@@ -75,9 +75,9 @@ def _get_op_output_var_names(op):
 
 def _get_input_name_index(op, input_var_name):
     """Get the input name and index of the var_name in the op"""
-    assert isinstance(
-        op, (IrNode, Operator)
-    ), "The input op should be IrNode or Operator."
+    assert isinstance(op, (IrNode, Operator)), (
+        "The input op should be IrNode or Operator."
+    )
     op_name = op.name() if isinstance(op, IrNode) else op.type
     if op_name not in SUPPORT_QUANTIZATION_OP_DICT:
         return None
@@ -93,9 +93,9 @@ def _get_input_name_index(op, input_var_name):
 
 def _get_output_name_index(op, output_var_name):
     """Get the output name and index of the var_name in the op"""
-    assert isinstance(
-        op, (IrNode, Operator)
-    ), "The input op should be IrNode or Operator."
+    assert isinstance(op, (IrNode, Operator)), (
+        "The input op should be IrNode or Operator."
+    )
     op_name = op.name() if isinstance(op, IrNode) else op.type
     if op_name not in SUPPORT_QUANTIZATION_OP_DICT:
         return None
@@ -127,9 +127,9 @@ def set_variable_data(scope, place, var_name, np_value):
     '''
     Set the value of var node by name, if the node exits,
     '''
-    assert isinstance(
-        np_value, np.ndarray
-    ), 'The type of value should be numpy array.'
+    assert isinstance(np_value, np.ndarray), (
+        'The type of value should be numpy array.'
+    )
     var_node = scope.find_var(var_name)
     if var_node is not None:
         tensor = var_node.get_tensor()

--- a/python/paddle/tensor/array.py
+++ b/python/paddle/tensor/array.py
@@ -66,9 +66,9 @@ def array_length(array):
             1
     """
     if in_dynamic_mode():
-        assert isinstance(
-            array, list
-        ), "The 'array' in array_write must be a list in dygraph mode"
+        assert isinstance(array, list), (
+            "The 'array' in array_write must be a list in dygraph mode"
+        )
         return len(array)
     elif in_pir_mode():
         if (
@@ -148,15 +148,15 @@ def array_read(array, i):
             [[5. 5. 5.]]
     """
     if in_dynamic_mode():
-        assert isinstance(
-            array, list
-        ), "The 'array' in array_read must be list in dygraph mode"
-        assert isinstance(
-            i, Variable
-        ), "The index 'i' in array_read must be Variable in dygraph mode"
-        assert i.shape == [
-            1
-        ], "The shape of index 'i' should be [1] in dygraph mode"
+        assert isinstance(array, list), (
+            "The 'array' in array_read must be list in dygraph mode"
+        )
+        assert isinstance(i, Variable), (
+            "The index 'i' in array_read must be Variable in dygraph mode"
+        )
+        assert i.shape == [1], (
+            "The shape of index 'i' should be [1] in dygraph mode"
+        )
         i = i.item(0)
         return array[i]
     elif in_pir_mode():
@@ -240,24 +240,24 @@ def array_write(
             [[5. 5. 5.]]
     """
     if in_dynamic_mode():
-        assert isinstance(
-            x, Variable
-        ), "The input data 'x' in array_write must be Variable in dygraph mode"
-        assert isinstance(
-            i, Variable
-        ), "The index 'i' in array_write must be Variable in dygraph mode"
-        assert i.shape == [
-            1
-        ], "The shape of index 'i' should be [1] in dygraph mode"
+        assert isinstance(x, Variable), (
+            "The input data 'x' in array_write must be Variable in dygraph mode"
+        )
+        assert isinstance(i, Variable), (
+            "The index 'i' in array_write must be Variable in dygraph mode"
+        )
+        assert i.shape == [1], (
+            "The shape of index 'i' should be [1] in dygraph mode"
+        )
         i = i.item(0)
         if array is None:
             array = create_array(x.dtype)
-        assert isinstance(
-            array, list
-        ), "The 'array' in array_write must be a list in dygraph mode"
-        assert i <= len(
-            array
-        ), "The index 'i' should not be greater than the length of 'array' in dygraph mode"
+        assert isinstance(array, list), (
+            "The 'array' in array_write must be a list in dygraph mode"
+        )
+        assert i <= len(array), (
+            "The index 'i' should not be greater than the length of 'array' in dygraph mode"
+        )
         if i < len(array):
             array[i] = x
         else:

--- a/python/paddle/tensor/compat.py
+++ b/python/paddle/tensor/compat.py
@@ -157,9 +157,9 @@ def split(
 
         if isinstance(split_size_or_sections, int):
             # check whether shape is divisible
-            assert (
-                split_size_or_sections > 0
-            ), 'split_size_or_sections must be greater than 0.'
+            assert split_size_or_sections > 0, (
+                'split_size_or_sections must be greater than 0.'
+            )
 
             split_size_or_sections = GetSplitSize(
                 split_size_or_sections, GetShapeOnDimInRange(tensor.shape, dim)
@@ -190,9 +190,9 @@ def split(
                 "The type of 'split_size_or_sections' in split must be int, list or tuple in imperative mode."
             )
         if isinstance(split_size_or_sections, int):
-            assert (
-                split_size_or_sections > 0
-            ), 'split_size_or_sections must be greater than 0.'
+            assert split_size_or_sections > 0, (
+                'split_size_or_sections must be greater than 0.'
+            )
 
             split_size_or_sections = GetSplitSize(
                 split_size_or_sections, GetShapeOnDimInRange(tensor.shape, dim)
@@ -209,9 +209,9 @@ def split(
                 )
         else:
             if isinstance(dim, int) and input_shape[dim] > 0:
-                assert (
-                    len(split_size_or_sections) <= input_shape[dim]
-                ), 'len(split_size_or_sections) must not be more than input.shape[dim].'
+                assert len(split_size_or_sections) <= input_shape[dim], (
+                    'len(split_size_or_sections) must not be more than input.shape[dim].'
+                )
             if paddle.utils._contain_var(split_size_or_sections):
                 split_size_or_sections = paddle.utils.get_int_tensor_list(
                     split_size_or_sections
@@ -370,7 +370,6 @@ class Unfold(nn.Unfold):
         padding: Size2 = 0,
         stride: Size2 = 1,
     ) -> None:
-
         super().__init__(kernel_size, dilation, padding, stride)
 
     def forward(self, input: Tensor) -> Tensor:

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -2541,13 +2541,13 @@ def diag_embed(
             f"But received Input's dimensional: {len(input_shape)}.\n"
         )
 
-        assert np.abs(dim1) <= len(
-            input_shape
-        ), f"Dim1 is out of range (expected to be in range of [{-(len(input_shape) + 1)}, {len(input_shape)}], but got {dim1}).\n"
+        assert np.abs(dim1) <= len(input_shape), (
+            f"Dim1 is out of range (expected to be in range of [{-(len(input_shape) + 1)}, {len(input_shape)}], but got {dim1}).\n"
+        )
 
-        assert np.abs(dim2) <= len(
-            input_shape
-        ), f"Dim2 is out of range (expected to be in range of [{-(len(input_shape) + 1)}, {len(input_shape)}], but got {dim2}).\n"
+        assert np.abs(dim2) <= len(input_shape), (
+            f"Dim2 is out of range (expected to be in range of [{-(len(input_shape) + 1)}, {len(input_shape)}], but got {dim2}).\n"
+        )
 
         dim1_ = dim1 if dim1 >= 0 else len(input_shape) + dim1 + 1
         dim2_ = dim2 if dim2 >= 0 else len(input_shape) + dim2 + 1
@@ -3993,7 +3993,6 @@ def resize_(
 
 
 def dtype_tensor_factory(dtype):
-
     class _DtypeTensorFactory:
         def __new__(cls, *args, **kwargs):
             if len(args) == 0:

--- a/python/paddle/tensor/einsum.py
+++ b/python/paddle/tensor/einsum.py
@@ -60,21 +60,21 @@ def parse_op_labels(labelstr: str, operand: Tensor) -> str:
     '''
     # Sanity checks
     for c in labelstr.replace('.', ''):
-        assert (
-            c.isalpha()
-        ), f"Invalid equation: {c} is not a valid label, which should be letters."
+        assert c.isalpha(), (
+            f"Invalid equation: {c} is not a valid label, which should be letters."
+        )
 
-    assert (
-        labelstr.replace('...', '', 1).find('.') == -1
-    ), "Invalid equation: `.` is found outside of an ellipsis."
+    assert labelstr.replace('...', '', 1).find('.') == -1, (
+        "Invalid equation: `.` is found outside of an ellipsis."
+    )
 
     ndims = len(operand.shape)
 
     full_labelstr = labelstr.replace('...', '.' * (ndims - len(labelstr) + 3))
 
-    assert (
-        len(full_labelstr) == ndims
-    ), f"Invalid equation: the label string '{labelstr}' misses dimensions."
+    assert len(full_labelstr) == ndims, (
+        f"Invalid equation: the label string '{labelstr}' misses dimensions."
+    )
 
     return full_labelstr
 
@@ -112,9 +112,9 @@ def validate_rhs(
     '''
     # Sanity check.
     if n_bcast_dims > 0:
-        assert (
-            '...' in rhs
-        ), "Invalid equation: missing ellipsis in output labels."
+        assert '...' in rhs, (
+            "Invalid equation: missing ellipsis in output labels."
+        )
 
     rhs = rhs.replace('...', '')
     rhs_set = set(rhs)
@@ -129,9 +129,9 @@ def validate_rhs(
         f"output label {sorted(non_input_labels)} not used by any input."
     )
     # Verify that output labels are not duplicate
-    assert len(rhs) == len(
-        rhs_set
-    ), "Invalid equation: duplicate output labels are found."
+    assert len(rhs) == len(rhs_set), (
+        "Invalid equation: duplicate output labels are found."
+    )
 
 
 def build_view(in_labels: str, out_labels: str) -> list[int]:
@@ -320,9 +320,9 @@ def diagonalize(labels: str, operand: Tensor) -> tuple[str, Tensor]:
     --------
     'ijj...i' would be merged into 'ij...'
     '''
-    assert not has_duplicated_labels(
-        labels
-    ), 'Duplicate labels are not supported.'
+    assert not has_duplicated_labels(labels), (
+        'Duplicate labels are not supported.'
+    )
 
     return labels, operand
 
@@ -786,9 +786,9 @@ def preprocess(
     """
     equation = equation.replace(" ", "")
     nop = len(operands)
-    assert (
-        nop > 0
-    ), f"Required at least one operand in Einsum API, but received {nop}"
+    assert nop > 0, (
+        f"Required at least one operand in Einsum API, but received {nop}"
+    )
 
     # Part the equation to left hand side and right hand side
     lhs, *rhs = equation.lower().split('->')
@@ -805,9 +805,9 @@ def preprocess(
         f"but found {len(lhs.split(','))} segments in the label equation."
     )
 
-    assert not (
-        '...' in lhs and '...' not in rhs
-    ), 'Invalid equation: missing ellipsis in output labels.'
+    assert not ('...' in lhs and '...' not in rhs), (
+        'Invalid equation: missing ellipsis in output labels.'
+    )
 
     lhs, rhs, new_operands = replace_ellipsis(lhs, rhs, *operands)
     return lhs, rhs, labels, new_operands
@@ -838,9 +838,9 @@ def parse_fake_shape(
         1. ori_label is the original labels, not aligned by '....'
         2. if the '...' is evaluated to empty list, there is no '.' in label
         """
-        assert len(op.shape) == len(
-            label
-        ), f"length of shape and length of label must be the same, but received {len(op.shape)} != {len(label)}"
+        assert len(op.shape) == len(label), (
+            f"length of shape and length of label must be the same, but received {len(op.shape)} != {len(label)}"
+        )
         fakes = [s for i, (l, s) in enumerate(zip(label, op.shape))]
         fakes = list(map(abs, fakes))  # make -1 -> 1
         if '.' in ori_label:
@@ -904,15 +904,15 @@ def einsum_v2(equation: str, *operands: Tensor) -> Tensor:
     var_list = new_operands
     for path in cons:
         (a, b), _, eq, *__ = path
-        assert (
-            a > b
-        ), "Assume the first var_idx is smaller than the second_idx. opt_einsum can guarantee it."
+        assert a > b, (
+            "Assume the first var_idx is smaller than the second_idx. opt_einsum can guarantee it."
+        )
         var_s = [var_list.pop(a), var_list.pop(b)]
         eq = eq.replace(broadcast_label, "...")
         var_list.append(gen_einsum_op(eq, *var_s))
-    assert (
-        len(var_list) == 1
-    ), f"There must be one elements in list, but received {len(var_list)}."
+    assert len(var_list) == 1, (
+        f"There must be one elements in list, but received {len(var_list)}."
+    )
     return var_list[0]
 
 

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -2349,9 +2349,9 @@ def cholesky(x: Tensor, upper: bool = False, name: str | None = None) -> Tensor:
     """
     if in_dynamic_or_pir_mode():
         x_shape = x.shape
-        assert (
-            len(x_shape) >= 2 and x_shape[-1] == x_shape[-2]
-        ), "Shape must have at least 2 dimensions and last two dimensions must be equal."
+        assert len(x_shape) >= 2 and x_shape[-1] == x_shape[-2], (
+            "Shape must have at least 2 dimensions and last two dimensions must be equal."
+        )
         return _C_ops.cholesky(x, upper)
     else:
         check_variable_and_dtype(x, 'dtype', ['float32', 'float64'], 'cholesky')
@@ -5083,9 +5083,9 @@ def cdist(
         f"But received Input x's last dimension is {x_shape[-1]}, "
         f"Input y's last dimension is {y_shape[-1]}.\n"
     )
-    assert (
-        p >= 0
-    ), f"The p must be greater than or equal to 0, But received p is {p}.\n"
+    assert p >= 0, (
+        f"The p must be greater than or equal to 0, But received p is {p}.\n"
+    )
 
     r1 = x.shape[-2]
     r2 = y.shape[-2]
@@ -5182,9 +5182,9 @@ def householder_product(
         ],
         'householder_product',
     )
-    assert (
-        x.dtype == tau.dtype
-    ), "The input x must have the same dtype with input tau.\n"
+    assert x.dtype == tau.dtype, (
+        "The input x must have the same dtype with input tau.\n"
+    )
     assert (
         len(x.shape) >= 2
         and len(tau.shape) >= 1
@@ -5193,16 +5193,16 @@ def householder_product(
         "The input x must have more than 2 dimensions, and input tau must have more than 1 dimension,"
         "and the dimension of x is 1 larger than the dimension of tau\n"
     )
-    assert (
-        x.shape[-2] >= x.shape[-1]
-    ), "The rows of input x must be greater than or equal to the columns of input x.\n"
-    assert (
-        x.shape[-1] >= tau.shape[-1]
-    ), "The last dim of x must be greater than tau.\n"
+    assert x.shape[-2] >= x.shape[-1], (
+        "The rows of input x must be greater than or equal to the columns of input x.\n"
+    )
+    assert x.shape[-1] >= tau.shape[-1], (
+        "The last dim of x must be greater than tau.\n"
+    )
     for idx, _ in enumerate(x.shape[:-2]):
-        assert (
-            x.shape[idx] == tau.shape[idx]
-        ), "The input x must have the same batch dimensions with input tau.\n"
+        assert x.shape[idx] == tau.shape[idx], (
+            "The input x must have the same batch dimensions with input tau.\n"
+        )
 
     def _householder_product(x, tau):
         m, n = x.shape[-2:]
@@ -5694,9 +5694,9 @@ def histogramdd(
     """
 
     def __check_x(x):
-        assert (
-            len(x.shape) >= 2
-        ), "input x must be a tensor with at least 2 dimensions."
+        assert len(x.shape) >= 2, (
+            "input x must be a tensor with at least 2 dimensions."
+        )
         check_variable_and_dtype(
             x,
             'x',
@@ -5719,9 +5719,9 @@ def histogramdd(
                 ],
                 'histogramdd',
             )
-            assert (
-                bins_tensor.dtype == x.dtype
-            ), "When bins is Tensor[], the dtype of bins must be the same as x.\n"
+            assert bins_tensor.dtype == x.dtype, (
+                "When bins is Tensor[], the dtype of bins must be the same as x.\n"
+            )
 
     def __check_weights(x, weights):
         if weights is None:
@@ -5745,17 +5745,17 @@ def histogramdd(
             ],
             'histogramdd',
         )
-        assert (
-            weights.dtype == x.dtype
-        ), "The dtype of weights must be the same as x.\n"
+        assert weights.dtype == x.dtype, (
+            "The dtype of weights must be the same as x.\n"
+        )
 
     def __check_ranges(D, ranges):
         if ranges is None:
             return
         check_type(ranges, 'ranges', (list, tuple), 'histogramdd')
-        assert D * 2 == len(
-            ranges
-        ), f"The length of ranges list must be {D * 2}\n"
+        assert D * 2 == len(ranges), (
+            f"The length of ranges list must be {D * 2}\n"
+        )
 
     def __compute_flattened_index(index_list, hist_shape):
         strides = paddle.to_tensor(hist_shape[::-1]).cumprod(dim=0).flip(0)[1:]
@@ -5803,9 +5803,9 @@ def histogramdd(
     if isinstance(bins, (int, list)):  # int or int[]
         if isinstance(bins, int):
             bins = [bins] * D
-        assert (
-            len(bins) == D
-        ), f"The length of bins must be {D} when bins is a list.\n"
+        assert len(bins) == D, (
+            f"The length of bins must be {D} when bins is a list.\n"
+        )
         for idx, r in enumerate(ranges):
             if not isinstance(bins[idx], int):
                 raise ValueError(
@@ -5926,38 +5926,40 @@ def ormqr(
     )
     check_type(left, 'left', bool, 'ormqr')
     check_type(transpose, 'transpose', bool, 'ormqr')
-    assert (
-        x.dtype == tau.dtype and x.dtype == y.dtype
-    ), "The input tau and y must have the same dtype with the x.\n"
-    assert (
-        len(x.shape) >= 2 and len(y.shape) >= 2 and len(tau.shape) >= 1
-    ), "The input x and y must have more than 2 dimensions, and input tau must have more than 1 dimension"
+    assert x.dtype == tau.dtype and x.dtype == y.dtype, (
+        "The input tau and y must have the same dtype with the x.\n"
+    )
+    assert len(x.shape) >= 2 and len(y.shape) >= 2 and len(tau.shape) >= 1, (
+        "The input x and y must have more than 2 dimensions, and input tau must have more than 1 dimension"
+    )
     assert len(x.shape) == len(tau.shape) + 1 and len(x.shape) == len(
         y.shape
-    ), "the dimension of x is 1 larger than the dimension of tau\n and the dimension of x is equal to the dimension of input"
-    assert (
-        x.shape[-1] == tau.shape[-1]
-    ), "The innermost dimension of x and tau should be the same"
+    ), (
+        "the dimension of x is 1 larger than the dimension of tau\n and the dimension of x is equal to the dimension of input"
+    )
+    assert x.shape[-1] == tau.shape[-1], (
+        "The innermost dimension of x and tau should be the same"
+    )
     if transpose and left:
-        assert (
-            x.shape[-2] == y.shape[-2]
-        ), "The row dimensions of x and y should be the same"
+        assert x.shape[-2] == y.shape[-2], (
+            "The row dimensions of x and y should be the same"
+        )
     elif not transpose and left:
-        assert (
-            x.shape[-1] == y.shape[-2]
-        ), "The column dimension of x and the row dimension of y should be the same"
+        assert x.shape[-1] == y.shape[-2], (
+            "The column dimension of x and the row dimension of y should be the same"
+        )
     elif transpose and not left:
-        assert (
-            x.shape[-2] == y.shape[-1]
-        ), "The row dimension of x and the column dimension of y should be the same"
+        assert x.shape[-2] == y.shape[-1], (
+            "The row dimension of x and the column dimension of y should be the same"
+        )
     else:
-        assert (
-            x.shape[-1] == y.shape[-1]
-        ), "The column dimensions of Impt and Osser's should be the same"
+        assert x.shape[-1] == y.shape[-1], (
+            "The column dimensions of Impt and Osser's should be the same"
+        )
     if len(x.shape) == 3:
-        assert (
-            x.shape[0] == y.shape[0] and x.shape[0] == tau.shape[0]
-        ), "The input and tau and y parameters should have the same batch"
+        assert x.shape[0] == y.shape[0] and x.shape[0] == tau.shape[0], (
+            "The input and tau and y parameters should have the same batch"
+        )
     Q = householder_product(x, tau)
     if len(x.shape) == 2:
         Q = Q.T if transpose else Q
@@ -6132,13 +6134,13 @@ def diagonal(
             axis1_ = axis1 if axis1 >= 0 else len(input_shape) + axis1
             axis2_ = axis2 if axis2 >= 0 else len(input_shape) + axis2
 
-            assert axis1_ < len(
-                input_shape
-            ), f"The argument axis1 is out of range (expected to be in range of [{-(len(input_shape))}, {len(input_shape) - 1}], but got {axis1}).\n"
+            assert axis1_ < len(input_shape), (
+                f"The argument axis1 is out of range (expected to be in range of [{-(len(input_shape))}, {len(input_shape) - 1}], but got {axis1}).\n"
+            )
 
-            assert axis2_ < len(
-                input_shape
-            ), f"The argument axis2 is out of range (expected to be in range of [{-(len(input_shape))}, {len(input_shape) - 1}], but got {axis2}).\n"
+            assert axis2_ < len(input_shape), (
+                f"The argument axis2 is out of range (expected to be in range of [{-(len(input_shape))}, {len(input_shape) - 1}], but got {axis2}).\n"
+            )
 
             assert axis1_ != axis2_, (
                 "axis1 and axis2 cannot be the same axis."

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -155,9 +155,9 @@ def tensor_array_to_tensor(
             >>> output, output_index = paddle.tensor.manipulation.tensor_array_to_tensor(input=array)
     """
     if in_dynamic_mode():
-        assert isinstance(
-            input, list
-        ), "The 'input' in tensor_array_to_tensor must be list"
+        assert isinstance(input, list), (
+            "The 'input' in tensor_array_to_tensor must be list"
+        )
         from paddle import concat, stack
 
         op = stack if use_stack else concat
@@ -1144,12 +1144,12 @@ def _fill_diagonal_tensor_impl(
     inplace: bool = False,
 ) -> Tensor:
     inshape = x.shape
-    assert dim1 < len(inshape) and dim1 >= -len(
-        inshape
-    ), 'dim1 should between [-rank,rank) in fill_diagonal_tensor_'
-    assert dim2 < len(inshape) and dim2 >= -len(
-        inshape
-    ), 'dim2 should between [-rank,rank) in fill_diagonal_tensor_'
+    assert dim1 < len(inshape) and dim1 >= -len(inshape), (
+        'dim1 should between [-rank,rank) in fill_diagonal_tensor_'
+    )
+    assert dim2 < len(inshape) and dim2 >= -len(inshape), (
+        'dim2 should between [-rank,rank) in fill_diagonal_tensor_'
+    )
     assert len(inshape) >= 2, 'Tensor dims should >= 2 in fill_diagonal_tensor_'
     dim1 %= len(inshape)
     dim2 %= len(inshape)
@@ -1165,9 +1165,9 @@ def _fill_diagonal_tensor_impl(
         inshape[dim2] - offset,
     )
     predshape.append(diaglen)
-    assert tuple(predshape) == tuple(
-        y.shape
-    ), f"the y shape should be {predshape}"
+    assert tuple(predshape) == tuple(y.shape), (
+        f"the y shape should be {predshape}"
+    )
     if len(y.shape) == 1:
         y = y.reshape([1, -1])
 
@@ -2857,9 +2857,9 @@ def split(
             return _C_ops.split_with_num(input, num_or_sections, dim)
         else:
             if isinstance(dim, int) and input_shape[dim] > 0:
-                assert (
-                    len(num_or_sections) <= input_shape[dim]
-                ), 'len(num_or_sections) must not be more than input.shape[dim].'
+                assert len(num_or_sections) <= input_shape[dim], (
+                    'len(num_or_sections) must not be more than input.shape[dim].'
+                )
             if paddle.utils._contain_var(num_or_sections):
                 num_or_sections = paddle.utils.get_int_tensor_list(
                     num_or_sections
@@ -2942,9 +2942,9 @@ def split(
             num = num_or_sections
         else:
             if isinstance(dim, int) and input_shape[dim] > 0:
-                assert (
-                    len(num_or_sections) <= input_shape[dim]
-                ), 'len(num_or_sections) must not be more than input.shape[dim].'
+                assert len(num_or_sections) <= input_shape[dim], (
+                    'len(num_or_sections) must not be more than input.shape[dim].'
+                )
             num = len(num_or_sections)
             attrs['sections'] = [
                 -1 if isinstance(ele, Variable) else ele
@@ -4654,21 +4654,21 @@ def tile(
             'tile',
         )
         if isinstance(repeat_times, (Variable, paddle.pir.Value)):
-            assert (
-                len(repeat_times.shape) == 1
-            ), 'repeat_times must be a Tensor with ndim == 1.'
+            assert len(repeat_times.shape) == 1, (
+                'repeat_times must be a Tensor with ndim == 1.'
+            )
         else:
             for elem in repeat_times:
                 if isinstance(elem, (Variable, paddle.pir.Value)):
                     numel = functools.reduce(lambda x, y: x * y, elem.shape, 1)
-                    assert (
-                        numel == 1
-                    ), 'Elements in repeat_times must be Tensor with one element or integers.'
+                    assert numel == 1, (
+                        'Elements in repeat_times must be Tensor with one element or integers.'
+                    )
                 else:
                     type_tuple = (int, np.int32, np.int64)
-                    assert isinstance(
-                        elem, type_tuple
-                    ), 'Elements in repeat_times must be Tensor with one element or integers.'
+                    assert isinstance(elem, type_tuple), (
+                        'Elements in repeat_times must be Tensor with one element or integers.'
+                    )
 
         check_variable_and_dtype(
             x,
@@ -4695,9 +4695,9 @@ def tile(
 
     if in_dynamic_mode():
         if isinstance(repeat_times, core.eager.Tensor):
-            assert (
-                repeat_times.ndim == 1
-            ), "Only support ndim == 1 while repeat_times is a Tensor."
+            assert repeat_times.ndim == 1, (
+                "Only support ndim == 1 while repeat_times is a Tensor."
+            )
             repeat_times = repeat_times.tolist()
 
         return _C_ops.tile(x, repeat_times)
@@ -4717,9 +4717,9 @@ def tile(
                     attrs_repeat_times.append(-1)
                 else:
                     attrs_repeat_times.append(times)
-                    assert (
-                        times > 0
-                    ), "All elements in repeat_times must be positive for tile."
+                    assert times > 0, (
+                        "All elements in repeat_times must be positive for tile."
+                    )
             return attrs_repeat_times
 
         helper = LayerHelper('tile', **locals())
@@ -5002,14 +5002,14 @@ def expand(x: Tensor, shape: ShapeLike, name: str | None = None) -> Tensor:
         else:
             for elem in shape:
                 if isinstance(elem, Variable):
-                    assert (
-                        elem.numel() == 1
-                    ), 'Elements in shape must be Tensor with one element or integers.'
+                    assert elem.numel() == 1, (
+                        'Elements in shape must be Tensor with one element or integers.'
+                    )
                 else:
                     type_tuple = (int, np.int32, np.int64)
-                    assert isinstance(
-                        elem, type_tuple
-                    ), 'Elements in shape must be Tensor with one element or integers.'
+                    assert isinstance(elem, type_tuple), (
+                        'Elements in shape must be Tensor with one element or integers.'
+                    )
 
         check_variable_and_dtype(
             x,
@@ -5049,9 +5049,9 @@ def expand(x: Tensor, shape: ShapeLike, name: str | None = None) -> Tensor:
                     attrs_expand_shape.append(-2)
                 else:
                     attrs_expand_shape.append(shape)
-                    assert (
-                        shape > 0 or shape == -1
-                    ), "All elements in shape of expand must be positive or -1."
+                    assert shape > 0 or shape == -1, (
+                        "All elements in shape of expand must be positive or -1."
+                    )
             return attrs_expand_shape
 
         if isinstance(shape, Variable):
@@ -5340,18 +5340,18 @@ def masked_scatter(
 
     """
     # make sure the dtype of x and value is the same
-    assert (
-        x.dtype == value.dtype
-    ), f'x and value must have the same dtype, but got x dtype is {x.dtype}, value dtype is {value.dtype}'
+    assert x.dtype == value.dtype, (
+        f'x and value must have the same dtype, but got x dtype is {x.dtype}, value dtype is {value.dtype}'
+    )
     assert mask.dtype == paddle.bool
 
     zeros_like_x = paddle.zeros_like(x, dtype=int)
     mask = paddle.add(paddle.cast(mask, dtype="int"), zeros_like_x)
     mask_prefix = paddle.clip(mask.cumsum() - 1, min=0)
     if in_dynamic_mode() and mask_prefix.numel() != 0:
-        assert (
-            mask_prefix[-1] <= value.numel()
-        ), f'mask true nums must be <= value size, but got mask true nums is {mask_prefix[-1].item()}, value size is {value.numel().item()}'
+        assert mask_prefix[-1] <= value.numel(), (
+            f'mask true nums must be <= value size, but got mask true nums is {mask_prefix[-1].item()}, value size is {value.numel().item()}'
+        )
 
     value = value.flatten()[mask_prefix].reshape(mask.shape)
     mask = paddle.logical_not(mask.astype(bool))
@@ -5366,16 +5366,16 @@ def masked_scatter_(
     Inplace version of ``masked_scatter`` API, the output Tensor will be inplaced with input ``x``.
     Please refer to :ref:`api_paddle_masked_scatter`.
     """
-    assert (
-        x.dtype == value.dtype
-    ), f'x and value must have the same dtype, but got x dtype is {x.dtype}, value dtype is {value.dtype}'
+    assert x.dtype == value.dtype, (
+        f'x and value must have the same dtype, but got x dtype is {x.dtype}, value dtype is {value.dtype}'
+    )
     assert mask.dtype == paddle.bool
     zeros_like_x = paddle.zeros_like(x, dtype=int)
     mask = paddle.add(paddle.cast(mask, dtype="int"), zeros_like_x)
     mask_prefix = paddle.clip(mask.cumsum() - 1, min=0)
-    assert (
-        mask_prefix[-1] <= value.numel()
-    ), f'mask true nums must be <= value size, but got mask true nums is {mask_prefix[-1].item()}, value size is {value.numel().item()}'
+    assert mask_prefix[-1] <= value.numel(), (
+        f'mask true nums must be <= value size, but got mask true nums is {mask_prefix[-1].item()}, value size is {value.numel().item()}'
+    )
 
     value = value.flatten()[mask_prefix].reshape(mask.shape)
     mask = paddle.logical_not(mask.astype(bool))
@@ -6602,9 +6602,9 @@ def moveaxis(
         src = list(source)
     if isinstance(destination, tuple):
         dst = list(destination)
-    assert len(src) == len(
-        dst
-    ), "'source' must have the same number with 'destination'"
+    assert len(src) == len(dst), (
+        "'source' must have the same number with 'destination'"
+    )
 
     if len(src) != len(set(src)):
         raise ValueError("Each element of 'source' must be unique!")
@@ -6619,31 +6619,31 @@ def moveaxis(
     dst_dims = list(range(ndim))
 
     for i, axis in enumerate(zip(src, dst)):
-        assert isinstance(
-            axis[0], int
-        ), "Each element of 'source' must be integer."
+        assert isinstance(axis[0], int), (
+            "Each element of 'source' must be integer."
+        )
         if axis[0] < 0:
-            assert (
-                axis[0] >= -ndim
-            ), f"'source' must be in the range of [-{ndim}, {ndim})"
+            assert axis[0] >= -ndim, (
+                f"'source' must be in the range of [-{ndim}, {ndim})"
+            )
             src[i] += ndim
         else:
-            assert (
-                axis[0] < ndim
-            ), f"'source' must be in the range of [-{ndim}, {ndim})"
+            assert axis[0] < ndim, (
+                f"'source' must be in the range of [-{ndim}, {ndim})"
+            )
 
-        assert isinstance(
-            axis[1], int
-        ), "Each element of 'source' must be integer."
+        assert isinstance(axis[1], int), (
+            "Each element of 'source' must be integer."
+        )
         if axis[1] < 0:
-            assert (
-                axis[1] >= -ndim
-            ), f"'source' must be in the range of [-{ndim}, {ndim})"
+            assert axis[1] >= -ndim, (
+                f"'source' must be in the range of [-{ndim}, {ndim})"
+            )
             dst[i] += ndim
         else:
-            assert (
-                axis[1] < ndim
-            ), f"'source' must be in the range of [-{ndim}, {ndim})"
+            assert axis[1] < ndim, (
+                f"'source' must be in the range of [-{ndim}, {ndim})"
+            )
         perm[dst[i]] = src[i]
         src_dims.remove(src[i])
         dst_dims.remove(dst[i])
@@ -6806,9 +6806,9 @@ def non_negative_axis(arr, axis):
     if axis >= 0:
         assert axis < ndim, f"'axis'  must be in the range of [-{ndim}, {ndim})"
     else:
-        assert (
-            axis >= -ndim
-        ), f"'axis'  must be in the range of [-{ndim}, {ndim})"
+        assert axis >= -ndim, (
+            f"'axis'  must be in the range of [-{ndim}, {ndim})"
+        )
         axis += ndim
 
     return axis

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -1309,15 +1309,17 @@ def multiply_(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
 
 
 def _elementwise_op_with_axis(x, y, axis=-1, name=None, op_type="Undefined"):
-    assert (
-        in_dynamic_or_pir_mode()
-    ), "You can only call `_elementwise_op_with_axis` function within in_dynamic_or_pir_mode"
+    assert in_dynamic_or_pir_mode(), (
+        "You can only call `_elementwise_op_with_axis` function within in_dynamic_or_pir_mode"
+    )
     assert op_type in [
         "add",
         "subtract",
         "multiply",
         "divide",
-    ], f"op_name input error! _elementwise_op_with_axis is an inner function to replace elementwise_add/sub/mul/div. Input op_name={op_type}, Expect op_name=[add|subtract|multiply|divide]\n"
+    ], (
+        f"op_name input error! _elementwise_op_with_axis is an inner function to replace elementwise_add/sub/mul/div. Input op_name={op_type}, Expect op_name=[add|subtract|multiply|divide]\n"
+    )
     op = getattr(_C_ops, op_type)
     x_shape = list(x.shape)
     y_shape = list(y.shape)
@@ -4017,13 +4019,13 @@ def trace(
         axis1_ = axis1 if axis1 >= 0 else len(input_shape) + axis1
         axis2_ = axis2 if axis2 >= 0 else len(input_shape) + axis2
 
-        assert (0 <= axis1_) and (
-            axis1_ < len(input_shape)
-        ), f"The argument axis1 is out of range (expected to be in range of [{-(len(input_shape))}, {len(input_shape) - 1}], but got {axis1}).\n"
+        assert (0 <= axis1_) and (axis1_ < len(input_shape)), (
+            f"The argument axis1 is out of range (expected to be in range of [{-(len(input_shape))}, {len(input_shape) - 1}], but got {axis1}).\n"
+        )
 
-        assert (0 <= axis2_) and (
-            axis2_ < len(input_shape)
-        ), f"The argument axis2 is out of range (expected to be in range of [{-(len(input_shape))}, {len(input_shape) - 1}], but got {axis2}).\n"
+        assert (0 <= axis2_) and (axis2_ < len(input_shape)), (
+            f"The argument axis2 is out of range (expected to be in range of [{-(len(input_shape))}, {len(input_shape) - 1}], but got {axis2}).\n"
+        )
 
         assert axis1_ != axis2_, (
             "axis1 and axis2 cannot be the same axis."
@@ -5710,9 +5712,9 @@ def multigammaln(x: Tensor, p: int, name: str | None = None) -> Tensor:
                 [0.85704780  , 2.46648574  , 3.56509781  , 11.02241898 , 15.84497833 ,
                     26.09257698 , 170.68318176])
     """
-    assert (
-        p >= 1
-    ), f"The p must be greater than or equal to 1, But received p is {p}.\n"
+    assert p >= 1, (
+        f"The p must be greater than or equal to 1, But received p is {p}.\n"
+    )
     c = 0.25 * p * (p - 1) * math.log(math.pi)
     b = 0.5 * paddle.arange(start=(1 - p), end=1, step=1, dtype=x.dtype)
     return paddle.sum(paddle.lgamma(x.unsqueeze(-1) + b), axis=-1) + c
@@ -5724,9 +5726,9 @@ def multigammaln_(x: Tensor, p: int, name: str | None = None) -> Tensor:
     Inplace version of ``multigammaln_`` API, the output Tensor will be inplaced with input ``x``.
     Please refer to :ref:`api_paddle_multigammaln`.
     """
-    assert (
-        p >= 1
-    ), f"The p must be greater than or equal to 1, But received p is {p}.\n"
+    assert p >= 1, (
+        f"The p must be greater than or equal to 1, But received p is {p}.\n"
+    )
     c = 0.25 * p * (p - 1) * math.log(math.pi)
     c = paddle.to_tensor(c, dtype=x.dtype)
     b = 0.5 * paddle.arange(start=(1 - p), end=1, step=1, dtype=x.dtype)

--- a/python/paddle/tensorrt/converter.py
+++ b/python/paddle/tensorrt/converter.py
@@ -519,9 +519,9 @@ class PaddleToTensorRTConverter:
                 config.set_flag(trt.BuilderFlag.PREFER_PRECISION_CONSTRAINTS)
 
         trt_engine = builder.build_serialized_network(network, config)
-        assert (
-            trt_engine is not None
-        ), 'Failed to build engine. please see ERROR log from trt.Logger'
+        assert trt_engine is not None, (
+            'Failed to build engine. please see ERROR log from trt.Logger'
+        )
         trt_params = paddle.base.libpaddle.TRTEngineParams()
         trt_params.min_input_shape = min_shape_map
         trt_params.max_input_shape = max_shape_map

--- a/python/paddle/tensorrt/converter_utils.py
+++ b/python/paddle/tensorrt/converter_utils.py
@@ -97,9 +97,9 @@ def get_axes_for_reduce_op(
         dim = (dim,)
 
     if has_implicit_batch_dimension:
-        assert (
-            0 not in dim
-        ), "Can't reduce over batch dimension when it's implicit."
+        assert 0 not in dim, (
+            "Can't reduce over batch dimension when it's implicit."
+        )
 
     axes = 0
     for d in dim:
@@ -133,9 +133,9 @@ def get_trt_plugin(plugin_name, field_collection, version, plugin_namespace=""):
     plugin_creator = plugin_registry.get_plugin_creator(
         plugin_name, version, plugin_namespace
     )
-    assert (
-        plugin_creator
-    ), f"Unable to found plugin creator with name {plugin_name}"
+    assert plugin_creator, (
+        f"Unable to found plugin creator with name {plugin_name}"
+    )
     plugin = plugin_creator.create_plugin(
         name=plugin_name, field_collection=field_collection
     )
@@ -362,9 +362,9 @@ def resize_to_1d(network, shape_tensor, name=None):
 
 # Get element tensor of 1D shape tensor
 def get_shape_tensor_element(network, x, index, is_scalar=False, name=None):
-    assert (
-        index >= 0
-    ), f"The index should be greater or equal than 0, but got {index}"
+    assert index >= 0, (
+        f"The index should be greater or equal than 0, but got {index}"
+    )
     index_tensor_name = [name[0], "index_tensor"] if name is not None else None
     index_tensor = add_1D_constant_layer(
         network, index, is_scalar=is_scalar, name=index_tensor_name
@@ -632,9 +632,9 @@ def convert_conv2d(network, paddle_op, inputs):
     groups = paddle_op.attrs().get("groups", 1)
 
     if has_dynamic_shape(input_shape):
-        assert (
-            input_shape[1] != -1
-        ), "Channel dim can't be dynamic for transpose convolution."
+        assert input_shape[1] != -1, (
+            "Channel dim can't be dynamic for transpose convolution."
+        )
 
     output_padding = paddle_op.attrs().get("output_padding", [0, 0])
     padding_algorithm = paddle_op.attrs().get("padding_algorithm", "EXPLICIT")
@@ -850,9 +850,9 @@ def add_reduce_layer(network, paddle_op, inputs, op_type):
     input_shape = paddle_op.operands()[0].source().shape
     keepdim = paddle_op.attrs()["keepdim"]
     if network.has_implicit_batch_dimension:
-        assert (
-            axis != 0
-        ), "can't reduce on axis == 0 when network has implicit batch dimension"
+        assert axis != 0, (
+            "can't reduce on axis == 0 when network has implicit batch dimension"
+        )
     output_shape = []
     if len(axis) == 0:
         axis = list(range(len(input_shape)))

--- a/python/paddle/tensorrt/impls/common.py
+++ b/python/paddle/tensorrt/impls/common.py
@@ -67,9 +67,7 @@ def bilinear_interp_converter(network, paddle_op, inputs):
     set_layer_name(input_shape_tensor, paddle_op)
     input_shape_tensor = input_shape_tensor.get_output(0)
 
-    input_rank = (
-        input_shape_tensor.shape
-    )  # The reason is unknown that adding this unused code make input_shape_tensor maintain the correct result.
+    input_rank = input_shape_tensor.shape  # The reason is unknown that adding this unused code make input_shape_tensor maintain the correct result.
     data_format = paddle_op.attrs().get("data_format")
     interp_method = paddle_op.attrs().get("interp_method")
     align_corners = paddle_op.attrs().get("align_corners")
@@ -371,9 +369,7 @@ def nearest_interp_converter(network, paddle_op, inputs):
     input_shape_tensor = network.add_shape(input_tensor)
     set_layer_name(input_shape_tensor, paddle_op)
     input_shape_tensor = input_shape_tensor.get_output(0)
-    input_rank = (
-        input_shape_tensor.shape
-    )  # The reason is unknown that adding this unused code make input_shape_tensor maintain the correct result.
+    input_rank = input_shape_tensor.shape  # The reason is unknown that adding this unused code make input_shape_tensor maintain the correct result.
     data_format = paddle_op.attrs().get("data_format")
     interp_method = paddle_op.attrs().get("interp_method")
     align_corners = paddle_op.attrs().get("align_corners")

--- a/python/paddle/tensorrt/impls/manipulation.py
+++ b/python/paddle/tensorrt/impls/manipulation.py
@@ -225,9 +225,9 @@ def unsqueeze_converter(network, paddle_op, inputs):
     x = inputs[0]
     input_dims = x.shape
     axes = get_input_constant_value(paddle_op, inputs, 1)
-    assert (
-        len(axes) > 0
-    ), f"axes size should be > 0 in when convert unsqueeze op in TensorRT, but received len(axes) = {len(axes)}."
+    assert len(axes) > 0, (
+        f"axes size should be > 0 in when convert unsqueeze op in TensorRT, but received len(axes) = {len(axes)}."
+    )
 
     should_unsqueeze = [False] * (len(input_dims) + len(axes))
     cur_out_rank = len(input_dims)
@@ -464,9 +464,9 @@ def slice_converter(network, paddle_op, inputs):
 
     starts = get_input_constant_value(paddle_op, inputs, 1)
     if starts is not None:
-        assert len(starts) == len(
-            axes
-        ), f"The size of this starts: {len(starts)} must be equal to the axes: {len(axes)}."
+        assert len(starts) == len(axes), (
+            f"The size of this starts: {len(starts)} must be equal to the axes: {len(axes)}."
+        )
         for idx in range(len(axes)):
             if starts[idx] < 0:
                 starts_tensor[axes[idx]] = trt_max(
@@ -521,9 +521,9 @@ def slice_converter(network, paddle_op, inputs):
 
     ends = get_input_constant_value(paddle_op, inputs, 2)
     if ends is not None:
-        assert len(ends) == len(
-            axes
-        ), f"The size of this ends: {len(ends)} must be equal to the axes: {len(axes)}."
+        assert len(ends) == len(axes), (
+            f"The size of this ends: {len(ends)} must be equal to the axes: {len(axes)}."
+        )
         for idx in range(len(axes)):
             if ends[idx] < 0:
                 ends_tensor[axes[idx]] = trt_max(
@@ -1400,9 +1400,9 @@ def pad3d_converter(network, paddle_op, inputs):
     else:
         input_dim = len(input_tensor.shape)
         pad_size = paddings.shape[0]
-        assert (
-            input_dim * 2 - 4 == pad_size
-        ), f"Expected paddings size is {input_dim * 2 - 4}, but received {pad_size}."
+        assert input_dim * 2 - 4 == pad_size, (
+            f"Expected paddings size is {input_dim * 2 - 4}, but received {pad_size}."
+        )
 
         shuffle_index = [4, 2, 0, 5, 3, 1]
         shuffle_inputs = [

--- a/python/paddle/tensorrt/impls/math.py
+++ b/python/paddle/tensorrt/impls/math.py
@@ -159,9 +159,9 @@ def max_converter(network, paddle_op, inputs):
     input_shape = input_tensor.shape
     keepdim = paddle_op.attrs()["keepdim"]
     if network.has_implicit_batch_dimension:
-        assert (
-            axis != 0
-        ), "can't reduce on axis == 0 when network has implicit batch dimension"
+        assert axis != 0, (
+            "can't reduce on axis == 0 when network has implicit batch dimension"
+        )
     output_shape = []
     if len(axis) == 0:
         axis = list(range(len(input_shape)))

--- a/python/paddle/tensorrt/impls/norm.py
+++ b/python/paddle/tensorrt/impls/norm.py
@@ -155,16 +155,16 @@ def batch_norm_converter(network, paddle_op, inputs):
 
     input_tensor_shape = paddle_op.operands()[0].source().shape
     if has_dynamic_shape(input_tensor_shape):
-        assert (
-            input_tensor.shape[1] != -1
-        ), "Channel dim can't be dynamic for batch norm."
+        assert input_tensor.shape[1] != -1, (
+            "Channel dim can't be dynamic for batch norm."
+        )
 
     output_shape = input_tensor_shape
 
     if not network.has_implicit_batch_dimension and len(input_tensor_shape) < 4:
-        assert (
-            len(get_dynamic_dims(input_tensor.shape)) <= 1
-        ), "BatchNorm1D with more than one dynamic dims is not currently supported."
+        assert len(get_dynamic_dims(input_tensor.shape)) <= 1, (
+            "BatchNorm1D with more than one dynamic dims is not currently supported."
+        )
         reshape_layer = network.add_shuffle(input_tensor)
         if len(input_tensor_shape) == 2:
             reshape_layer.reshape_dims = (

--- a/python/paddle/tensorrt/impls/others.py
+++ b/python/paddle/tensorrt/impls/others.py
@@ -263,24 +263,24 @@ def set_value_converter(network, paddle_op, inputs):
 
     # calculate dims
     update_dims = updates.shape
-    assert (
-        update_dims[axes] > 0
-    ), "the update value shape[{axes}] must be greater than 0, but received {update_dims[axes]}"
-    assert (
-        input_dims[axes] > 0
-    ), "the input shape[{axes}] must be greater than 0, but received {input_dims[axes]}"
+    assert update_dims[axes] > 0, (
+        "the update value shape[{axes}] must be greater than 0, but received {update_dims[axes]}"
+    )
+    assert input_dims[axes] > 0, (
+        "the input shape[{axes}] must be greater than 0, but received {input_dims[axes]}"
+    )
     input_dims_rank = len(input_dims)
-    assert (
-        axes <= input_dims_rank
-    ), "The axes {axes} is larger than total axes {input_dims_rank}"
-    assert (
-        starts <= input_dims[axes]
-    ), "The start {starts} of dim {axes} is larger than origin shape {input_dims[axes]}"
+    assert axes <= input_dims_rank, (
+        "The axes {axes} is larger than total axes {input_dims_rank}"
+    )
+    assert starts <= input_dims[axes], (
+        "The start {starts} of dim {axes} is larger than origin shape {input_dims[axes]}"
+    )
 
     target_update_dim = (ends - 1 - starts) / steps + 1
-    assert (
-        update_dims[axes] == target_update_dim
-    ), "the {axes}th axis of update dim error, should be {target_update_dim}, but we got {update_dims[axes]}"
+    assert update_dims[axes] == target_update_dim, (
+        "the {axes}th axis of update dim error, should be {target_update_dim}, but we got {update_dims[axes]}"
+    )
 
     shape_0 = [1] * len(update_dims)
     shape_weight = trt.Weights(np.array([0], dtype=np.float32))

--- a/python/paddle/text/datasets/conll05.py
+++ b/python/paddle/text/datasets/conll05.py
@@ -133,18 +133,18 @@ class Conll05st(Dataset):
     ):
         self.data_file = data_file
         if self.data_file is None:
-            assert (
-                download
-            ), "data_file is not set and downloading automatically is disabled"
+            assert download, (
+                "data_file is not set and downloading automatically is disabled"
+            )
             self.data_file = _check_exists_and_download(
                 data_file, DATA_URL, DATA_MD5, 'conll05st', download
             )
 
         self.word_dict_file = word_dict_file
         if self.word_dict_file is None:
-            assert (
-                download
-            ), "word_dict_file is not set and downloading automatically is disabled"
+            assert download, (
+                "word_dict_file is not set and downloading automatically is disabled"
+            )
             self.word_dict_file = _check_exists_and_download(
                 word_dict_file,
                 WORDDICT_URL,
@@ -155,9 +155,9 @@ class Conll05st(Dataset):
 
         self.verb_dict_file = verb_dict_file
         if self.verb_dict_file is None:
-            assert (
-                download
-            ), "verb_dict_file is not set and downloading automatically is disabled"
+            assert download, (
+                "verb_dict_file is not set and downloading automatically is disabled"
+            )
             self.verb_dict_file = _check_exists_and_download(
                 verb_dict_file,
                 VERBDICT_URL,
@@ -168,9 +168,9 @@ class Conll05st(Dataset):
 
         self.target_dict_file = target_dict_file
         if self.target_dict_file is None:
-            assert (
-                download
-            ), "target_dict_file is not set and downloading automatically is disabled"
+            assert download, (
+                "target_dict_file is not set and downloading automatically is disabled"
+            )
             self.target_dict_file = _check_exists_and_download(
                 target_dict_file,
                 TRGDICT_URL,
@@ -181,9 +181,9 @@ class Conll05st(Dataset):
 
         self.emb_file = emb_file
         if self.emb_file is None:
-            assert (
-                download
-            ), "emb_file is not set and downloading automatically is disabled"
+            assert download, (
+                "emb_file is not set and downloading automatically is disabled"
+            )
             self.emb_file = _check_exists_and_download(
                 emb_file, EMB_URL, EMB_MD5, 'conll05st', download
             )
@@ -293,7 +293,9 @@ class Conll05st(Dataset):
         wf.close()
         tf.close()
 
-    def __getitem__(self, idx: int) -> tuple[
+    def __getitem__(
+        self, idx: int
+    ) -> tuple[
         npt.NDArray[np.int_],
         npt.NDArray[np.int_],
         npt.NDArray[np.int_],

--- a/python/paddle/text/datasets/imdb.py
+++ b/python/paddle/text/datasets/imdb.py
@@ -111,9 +111,9 @@ class Imdb(Dataset):
 
         self.data_file = data_file
         if self.data_file is None:
-            assert (
-                download
-            ), "data_file is not set and downloading automatically is disabled"
+            assert download, (
+                "data_file is not set and downloading automatically is disabled"
+            )
             self.data_file = _check_exists_and_download(
                 data_file, URL, MD5, 'imdb', download
             )

--- a/python/paddle/text/datasets/imikolov.py
+++ b/python/paddle/text/datasets/imikolov.py
@@ -122,9 +122,9 @@ class Imikolov(Dataset):
 
         self.data_file = data_file
         if self.data_file is None:
-            assert (
-                download
-            ), "data_file is not set and downloading automatically disabled"
+            assert download, (
+                "data_file is not set and downloading automatically disabled"
+            )
             self.data_file = _check_exists_and_download(
                 data_file, URL, MD5, 'imikolov', download
             )

--- a/python/paddle/text/datasets/movielens.py
+++ b/python/paddle/text/datasets/movielens.py
@@ -182,9 +182,9 @@ class Movielens(Dataset):
 
         self.data_file = data_file
         if self.data_file is None:
-            assert (
-                download
-            ), "data_file is not set and downloading automatically is disabled"
+            assert download, (
+                "data_file is not set and downloading automatically is disabled"
+            )
             self.data_file = _check_exists_and_download(
                 data_file, URL, MD5, 'sentiment', download
             )

--- a/python/paddle/text/datasets/uci_housing.py
+++ b/python/paddle/text/datasets/uci_housing.py
@@ -120,9 +120,9 @@ class UCIHousing(Dataset):
 
         self.data_file = data_file
         if self.data_file is None:
-            assert (
-                download
-            ), "data_file is not set and downloading automatically is disabled"
+            assert download, (
+                "data_file is not set and downloading automatically is disabled"
+            )
             self.data_file = _check_exists_and_download(
                 data_file, URL, MD5, 'uci_housing', download
             )

--- a/python/paddle/text/datasets/wmt14.py
+++ b/python/paddle/text/datasets/wmt14.py
@@ -125,9 +125,9 @@ class WMT14(Dataset):
 
         self.data_file = data_file
         if self.data_file is None:
-            assert (
-                download
-            ), "data_file is not set and downloading automatically is disabled"
+            assert download, (
+                "data_file is not set and downloading automatically is disabled"
+            )
             self.data_file = _check_exists_and_download(
                 data_file, URL_TRAIN, MD5_TRAIN, 'wmt14', download
             )
@@ -199,7 +199,9 @@ class WMT14(Dataset):
                     self.trg_ids.append(trg_ids)
                     self.trg_ids_next.append(trg_ids_next)
 
-    def __getitem__(self, idx: int) -> tuple[
+    def __getitem__(
+        self, idx: int
+    ) -> tuple[
         npt.NDArray[np.int_],
         npt.NDArray[np.int_],
         npt.NDArray[np.int_],

--- a/python/paddle/text/datasets/wmt16.py
+++ b/python/paddle/text/datasets/wmt16.py
@@ -145,9 +145,9 @@ class WMT16(Dataset):
 
         self.data_file = data_file
         if self.data_file is None:
-            assert (
-                download
-            ), "data_file is not set and downloading automatically is disabled"
+            assert download, (
+                "data_file is not set and downloading automatically is disabled"
+            )
             self.data_file = _check_exists_and_download(
                 data_file, DATA_URL, DATA_MD5, 'wmt16', download
             )
@@ -271,7 +271,9 @@ class WMT16(Dataset):
                 self.trg_ids.append(trg_ids)
                 self.trg_ids_next.append(trg_ids_next)
 
-    def __getitem__(self, idx: int) -> tuple[
+    def __getitem__(
+        self, idx: int
+    ) -> tuple[
         npt.NDArray[np.int_],
         npt.NDArray[np.int_],
         npt.NDArray[np.int_],


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

使用性能更好，格式化效果更佳的 ruff format 替代 black 作为新的 formatter，由于我们很早就已经集成了 ruff lint，因此只是减少依赖而不会增加依赖

<!--

## 核心优势

通过集成 Ruff format，开发者可以享受到以下优势：

- 通过去除 black 对 python 环境依赖，极大降低了升级 formatter 带来的成本，后续无需考虑开发者本地 python 环境即可一键升级
- ruff 由 Rust 驱动，大幅加速 format 时间，降低开发者使用开发工具链的时间成本，减少 CI 时间，提升工程效率
- 格式化后呈现可读性更佳的效果，使得开发者更专注于代码开发而无需关心格式，阅读者也能够更加赏心悦目，极大增加了潜在贡献者的贡献意愿
- ruff 极大程度地兼容了 black 的格式化效果，能够平滑地替换现有的 black 配置
- ruff 更新频次高，能够快速响应社区反馈，持续优化格式化效果
- ruff 团队 Astral 最近开发的 ty 能够提供更强大的类型检查能力，后续可能与 ruff 集成，提供更好的开发体验
- PyTorch 最近已经完成迁移，追平竞品（在代码风格这块，我们一直做到了超越竞品，这次不能落后）

-->