### PR TITLE
[CodeStyle] black -> ruff format migration - part 34

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -95,7 +95,7 @@ repos:
 
             | python/paddle/[u-z].+
 
-            # | python/_.+
+            | python/_.+
 
             # | test/a.+
 
@@ -151,7 +151,7 @@ repos:
 
             # | python/paddle/[u-z].+
 
-            | python/_.+
+            # | python/_.+
 
             | test/a.+
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -93,7 +93,7 @@ repos:
 
             # | python/paddle/[o-t].+
 
-            # | python/paddle/[u-z].+
+            | python/paddle/[u-z].+
 
             # | python/_.+
 
@@ -149,7 +149,7 @@ repos:
 
             | python/paddle/[o-t].+
 
-            | python/paddle/[u-z].+
+            # | python/paddle/[u-z].+
 
             | python/_.+
 

--- a/python/paddle/utils/cpp_extension/cpp_extension.py
+++ b/python/paddle/utils/cpp_extension/cpp_extension.py
@@ -211,17 +211,17 @@ def setup(**attr: Any) -> None:
     if 'name' not in attr:
         raise ValueError(error_msg)
 
-    assert not attr['name'].endswith(
-        'module'
-    ), "Please don't use 'module' as suffix in `name` argument, "
+    assert not attr['name'].endswith('module'), (
+        "Please don't use 'module' as suffix in `name` argument, "
+    )
     "it will be stripped in setuptools.bdist_egg and cause import error."
 
     ext_modules = attr.get('ext_modules', [])
     if not isinstance(ext_modules, list):
         ext_modules = [ext_modules]
-    assert (
-        len(ext_modules) == 1
-    ), f"Required only one Extension, but received {len(ext_modules)}. If you want to compile multi operators, you can include all necessary source files in one Extension."
+    assert len(ext_modules) == 1, (
+        f"Required only one Extension, but received {len(ext_modules)}. If you want to compile multi operators, you can include all necessary source files in one Extension."
+    )
     # replace Extension.name with attr['name] to keep consistent with Package name.
     for ext_module in ext_modules:
         ext_module.name = attr['name']
@@ -458,10 +458,10 @@ class BuildExtension(build_ext):
                 # nvcc or hipcc compile CUDA source
                 if is_cuda_file(src):
                     if core.is_compiled_with_rocm():
-                        assert (
-                            ROCM_HOME is not None
-                        ), "Not found ROCM runtime, \
+                        assert ROCM_HOME is not None, (
+                            "Not found ROCM runtime, \
                             please use `export ROCM_PATH= XXX` to specify it."
+                        )
                         if CCACHE_HOME is not None:
                             hipcc_cmd = os.path.join(ROCM_HOME, 'bin', 'hipcc')
                             hipcc_cmd = f'{CCACHE_HOME} {hipcc_cmd}'
@@ -486,10 +486,10 @@ class BuildExtension(build_ext):
                         if isinstance(cflags, dict):
                             cflags = cflags['nvcc']
                     else:
-                        assert (
-                            CUDA_HOME is not None
-                        ), "Not found CUDA runtime, \
+                        assert CUDA_HOME is not None, (
+                            "Not found CUDA runtime, \
                             please use `export CUDA_HOME= XXX` to specify it."
+                        )
                         if CCACHE_HOME is not None:
                             nvcc_cmd = os.path.join(CUDA_HOME, 'bin', 'nvcc')
                             nvcc_cmd = f'{CCACHE_HOME} {nvcc_cmd}'
@@ -646,10 +646,10 @@ class BuildExtension(build_ext):
                 src = src_list[0]
                 obj = obj_list[0]
                 if is_cuda_file(src):
-                    assert (
-                        CUDA_HOME is not None
-                    ), "Not found CUDA runtime, \
+                    assert CUDA_HOME is not None, (
+                        "Not found CUDA runtime, \
                         please use `export CUDA_HOME= XXX` to specify it."
+                    )
 
                     nvcc_cmd = os.path.join(CUDA_HOME, 'bin', 'nvcc')
                     if isinstance(self.cflags, dict):
@@ -764,9 +764,9 @@ class BuildExtension(build_ext):
         split_str = '.'
         name_items = ext_name.split(split_str)
         if self.no_python_abi_suffix:
-            assert (
-                len(name_items) > 2
-            ), f"Expected len(name_items) > 2, but received {len(name_items)}"
+            assert len(name_items) > 2, (
+                f"Expected len(name_items) > 2, but received {len(name_items)}"
+            )
             name_items.pop(-2)
             ext_name = split_str.join(name_items)
 
@@ -1034,12 +1034,12 @@ def load(
         extra_cxx_cflags = []
     if extra_cuda_cflags is None:
         extra_cuda_cflags = []
-    assert isinstance(
-        extra_cxx_cflags, list
-    ), f"Required type(extra_cxx_cflags) == list[str], but received {extra_cxx_cflags}"
-    assert isinstance(
-        extra_cuda_cflags, list
-    ), f"Required type(extra_cuda_cflags) == list[str], but received {extra_cuda_cflags}"
+    assert isinstance(extra_cxx_cflags, list), (
+        f"Required type(extra_cxx_cflags) == list[str], but received {extra_cxx_cflags}"
+    )
+    assert isinstance(extra_cuda_cflags, list), (
+        f"Required type(extra_cuda_cflags) == list[str], but received {extra_cuda_cflags}"
+    )
 
     log_v(
         "additional extra_cxx_cflags: [{}], extra_cuda_cflags: [{}]".format(

--- a/python/paddle/utils/cpp_extension/extension_utils.py
+++ b/python/paddle/utils/cpp_extension/extension_utils.py
@@ -257,9 +257,9 @@ class CustomOpInfo:
         return cls._instance
 
     def __init__(self):
-        assert not hasattr(
-            self.__class__, '_instance'
-        ), 'Please use `instance()` to get CustomOpInfo object!'
+        assert not hasattr(self.__class__, '_instance'), (
+            'Please use `instance()` to get CustomOpInfo object!'
+        )
         # NOTE(Aurelius84): Use OrderedDict to save more order information
         self.op_info_map = collections.OrderedDict()
 
@@ -522,9 +522,9 @@ def _get_include_dirs_when_compiling(compile_dir):
     include_dirs_file = 'includes.txt'
     path = os.path.abspath(compile_dir)
     include_dirs_file = os.path.join(path, include_dirs_file)
-    assert os.path.isfile(
-        include_dirs_file
-    ), f"File {include_dirs_file} does not exist"
+    assert os.path.isfile(include_dirs_file), (
+        f"File {include_dirs_file} does not exist"
+    )
     with open(include_dirs_file, 'r') as f:
         include_dirs = [line.strip() for line in f if line.strip()]
 

--- a/python/paddle/utils/deprecated.py
+++ b/python/paddle/utils/deprecated.py
@@ -91,9 +91,9 @@ def deprecated(
             msg += f" since {_since}"
         msg += ", and will be removed in future versions."
         if len(_update_to) > 0:
-            assert _update_to.startswith(
-                "paddle."
-            ), f'Argument update_to must start with "paddle.", your value is "{update_to}"'
+            assert _update_to.startswith("paddle."), (
+                f'Argument update_to must start with "paddle.", your value is "{update_to}"'
+            )
             msg += f' Please use "{_update_to}" instead.'
         if len(_reason) > 0:
             msg += f"\n    Reason: {_reason}"

--- a/python/paddle/utils/download.py
+++ b/python/paddle/utils/download.py
@@ -318,9 +318,9 @@ def _uncompress_file_tar(filepath, mode="r:*"):
         file_list_tmp = files.getnames()
         file_list = []
         for file in file_list_tmp:
-            assert (
-                file[0] != "/"
-            ), f"uncompress file path {file} should not start with /"
+            assert file[0] != "/", (
+                f"uncompress file path {file} should not start with /"
+            )
             file_list.append(file.replace("../", ""))
 
         file_dir = os.path.dirname(filepath)

--- a/python/paddle/utils/environments.py
+++ b/python/paddle/utils/environments.py
@@ -106,9 +106,9 @@ class BooleanEnvironmentVariable(EnvironmentVariable[bool]):
 class IntegerEnvironmentVariable(EnvironmentVariable[int]):
     def __init__(self, name: str, default: int):
         super().__init__(name, default)
-        assert isinstance(default, int) and not isinstance(
-            default, bool
-        ), "default must be an integer"
+        assert isinstance(default, int) and not isinstance(default, bool), (
+            "default must be an integer"
+        )
 
     def parse_from_string(self) -> int:
         try:
@@ -117,9 +117,9 @@ class IntegerEnvironmentVariable(EnvironmentVariable[int]):
             return self.default
 
     def convert_to_string(self, value: int) -> str:
-        assert isinstance(value, int) and not isinstance(
-            value, bool
-        ), "value must be an integer"
+        assert isinstance(value, int) and not isinstance(value, bool), (
+            "value must be an integer"
+        )
         return str(value)
 
 
@@ -133,9 +133,9 @@ class StringListEnvironmentVariable(EnvironmentVariable[list[str]]):
 
     def convert_to_string(self, value: list[str]) -> str:
         assert isinstance(value, list), "value must be a list"
-        assert all(
-            isinstance(x, str) for x in value
-        ), "value must be a list of strings"
+        assert all(isinstance(x, str) for x in value), (
+            "value must be a list of strings"
+        )
         return ",".join(value)
 
 

--- a/python/paddle/utils/layers_utils.py
+++ b/python/paddle/utils/layers_utils.py
@@ -558,12 +558,12 @@ def get_inputs_outputs_in_block(block):
     Returns the inputs and outputs variable used in this block but not
     created in this block.
     """
-    assert isinstance(
-        block, Block
-    ), "input non-Block argument for get_inputs_outputs_in_block."
-    assert (
-        block.parent_idx != -1
-    ), "input block should be a sub-block, not main block."
+    assert isinstance(block, Block), (
+        "input non-Block argument for get_inputs_outputs_in_block."
+    )
+    assert block.parent_idx != -1, (
+        "input block should be a sub-block, not main block."
+    )
 
     # Find input/output var names of all ops in block
     inner_inputs = set()

--- a/python/paddle/vision/datasets/cifar.py
+++ b/python/paddle/vision/datasets/cifar.py
@@ -148,9 +148,9 @@ class Cifar10(Dataset[tuple["_ImageDataType", "npt.NDArray[Any]"]]):
 
         self.data_file = data_file
         if self.data_file is None:
-            assert (
-                download
-            ), "data_file is not set and downloading automatically is disabled"
+            assert download, (
+                "data_file is not set and downloading automatically is disabled"
+            )
             self.data_file = _check_exists_and_download(
                 data_file, self.data_url, self.data_md5, 'cifar', download
             )

--- a/python/paddle/vision/datasets/flowers.py
+++ b/python/paddle/vision/datasets/flowers.py
@@ -152,25 +152,25 @@ class Flowers(Dataset[tuple["_ImageDataType", "npt.NDArray[np.int64]"]]):
         flag = MODE_FLAG_MAP[mode.lower()]
 
         if not data_file:
-            assert (
-                download
-            ), "data_file is not set and downloading automatically is disabled"
+            assert download, (
+                "data_file is not set and downloading automatically is disabled"
+            )
             data_file = _check_exists_and_download(
                 data_file, DATA_URL, DATA_MD5, 'flowers', download
             )
 
         if not label_file:
-            assert (
-                download
-            ), "label_file is not set and downloading automatically is disabled"
+            assert download, (
+                "label_file is not set and downloading automatically is disabled"
+            )
             label_file = _check_exists_and_download(
                 label_file, LABEL_URL, LABEL_MD5, 'flowers', download
             )
 
         if not setid_file:
-            assert (
-                download
-            ), "setid_file is not set and downloading automatically is disabled"
+            assert download, (
+                "setid_file is not set and downloading automatically is disabled"
+            )
             setid_file = _check_exists_and_download(
                 setid_file, SETID_URL, SETID_MD5, 'flowers', download
             )

--- a/python/paddle/vision/datasets/folder.py
+++ b/python/paddle/vision/datasets/folder.py
@@ -59,9 +59,9 @@ def has_valid_extension(filename: str, extensions: Sequence[str]) -> bool:
     Returns:
         bool: True if the filename ends with one of given extensions
     """
-    assert isinstance(
-        extensions, (list, tuple)
-    ), "`extensions` must be list or tuple."
+    assert isinstance(extensions, (list, tuple)), (
+        "`extensions` must be list or tuple."
+    )
     extensions = tuple([x.lower() for x in extensions])
     return filename.lower().endswith(extensions)
 

--- a/python/paddle/vision/datasets/mnist.py
+++ b/python/paddle/vision/datasets/mnist.py
@@ -148,9 +148,9 @@ class MNIST(Dataset[tuple["_ImageDataType", "npt.NDArray[np.int64]"]]):
         self.mode = mode.lower()
         self.image_path = image_path
         if self.image_path is None:
-            assert (
-                download
-            ), "image_path is not set and downloading automatically is disabled"
+            assert download, (
+                "image_path is not set and downloading automatically is disabled"
+            )
             image_url = (
                 self.TRAIN_IMAGE_URL if mode == 'train' else self.TEST_IMAGE_URL
             )
@@ -163,9 +163,9 @@ class MNIST(Dataset[tuple["_ImageDataType", "npt.NDArray[np.int64]"]]):
 
         self.label_path = label_path
         if self.label_path is None:
-            assert (
-                download
-            ), "label_path is not set and downloading automatically is disabled"
+            assert download, (
+                "label_path is not set and downloading automatically is disabled"
+            )
             label_url = (
                 self.TRAIN_LABEL_URL
                 if self.mode == 'train'

--- a/python/paddle/vision/datasets/voc2012.py
+++ b/python/paddle/vision/datasets/voc2012.py
@@ -152,9 +152,9 @@ class VOC2012(Dataset[tuple["_ImageDataType", "npt.NDArray[Any]"]]):
 
         self.data_file = data_file
         if self.data_file is None:
-            assert (
-                download
-            ), "data_file is not set and downloading automatically is disabled"
+            assert download, (
+                "data_file is not set and downloading automatically is disabled"
+            )
             self.data_file = _check_exists_and_download(
                 data_file, VOC_URL, VOC_MD5, CACHE_DIR, download
             )

--- a/python/paddle/vision/models/alexnet.py
+++ b/python/paddle/vision/models/alexnet.py
@@ -192,9 +192,9 @@ def _alexnet(
     model = AlexNet(**kwargs)
 
     if pretrained:
-        assert (
-            arch in model_urls
-        ), f"{arch} model do not have a pretrained model now, you should set pretrained=False"
+        assert arch in model_urls, (
+            f"{arch} model do not have a pretrained model now, you should set pretrained=False"
+        )
         weight_path = get_weights_path_from_url(
             model_urls[arch][0], model_urls[arch][1]
         )

--- a/python/paddle/vision/models/densenet.py
+++ b/python/paddle/vision/models/densenet.py
@@ -285,9 +285,9 @@ class DenseNet(nn.Layer):
         self.num_classes = num_classes
         self.with_pool = with_pool
         supported_layers = [121, 161, 169, 201, 264]
-        assert (
-            layers in supported_layers
-        ), f"supported layers are {supported_layers} but input layer is {layers}"
+        assert layers in supported_layers, (
+            f"supported layers are {supported_layers} but input layer is {layers}"
+        )
         densenet_spec = {
             121: (64, 32, [6, 12, 24, 16]),
             161: (96, 48, [6, 12, 36, 24]),
@@ -384,9 +384,9 @@ def _densenet(
 ) -> DenseNet:
     model = DenseNet(layers=layers, **kwargs)
     if pretrained:
-        assert (
-            arch in model_urls
-        ), f"{arch} model do not have a pretrained model now, you should set pretrained=False"
+        assert arch in model_urls, (
+            f"{arch} model do not have a pretrained model now, you should set pretrained=False"
+        )
         weight_path = get_weights_path_from_url(
             model_urls[arch][0], model_urls[arch][1]
         )

--- a/python/paddle/vision/models/googlenet.py
+++ b/python/paddle/vision/models/googlenet.py
@@ -291,9 +291,9 @@ def googlenet(
     model = GoogLeNet(**kwargs)
     arch = "googlenet"
     if pretrained:
-        assert (
-            arch in model_urls
-        ), f"{arch} model do not have a pretrained model now, you should set pretrained=False"
+        assert arch in model_urls, (
+            f"{arch} model do not have a pretrained model now, you should set pretrained=False"
+        )
         weight_path = get_weights_path_from_url(
             model_urls[arch][0], model_urls[arch][1]
         )

--- a/python/paddle/vision/models/inceptionv3.py
+++ b/python/paddle/vision/models/inceptionv3.py
@@ -642,9 +642,9 @@ def inception_v3(
     model = InceptionV3(**kwargs)
     arch = "inception_v3"
     if pretrained:
-        assert (
-            arch in model_urls
-        ), f"{arch} model do not have a pretrained model now, you should set pretrained=False"
+        assert arch in model_urls, (
+            f"{arch} model do not have a pretrained model now, you should set pretrained=False"
+        )
         weight_path = get_weights_path_from_url(
             model_urls[arch][0], model_urls[arch][1]
         )

--- a/python/paddle/vision/models/mobilenetv1.py
+++ b/python/paddle/vision/models/mobilenetv1.py
@@ -277,9 +277,9 @@ def _mobilenet(
 ) -> MobileNetV1:
     model = MobileNetV1(**kwargs)
     if pretrained:
-        assert (
-            arch in model_urls
-        ), f"{arch} model do not have a pretrained model now, you should set pretrained=False"
+        assert arch in model_urls, (
+            f"{arch} model do not have a pretrained model now, you should set pretrained=False"
+        )
         weight_path = get_weights_path_from_url(
             model_urls[arch][0], model_urls[arch][1]
         )

--- a/python/paddle/vision/models/mobilenetv2.py
+++ b/python/paddle/vision/models/mobilenetv2.py
@@ -219,9 +219,9 @@ def _mobilenet(
 ) -> MobileNetV2:
     model = MobileNetV2(**kwargs)
     if pretrained:
-        assert (
-            arch in model_urls
-        ), f"{arch} model do not have a pretrained model now, you should set pretrained=False"
+        assert arch in model_urls, (
+            f"{arch} model do not have a pretrained model now, you should set pretrained=False"
+        )
         weight_path = get_weights_path_from_url(
             model_urls[arch][0], model_urls[arch][1]
         )

--- a/python/paddle/vision/models/mobilenetv3.py
+++ b/python/paddle/vision/models/mobilenetv3.py
@@ -448,9 +448,9 @@ def _mobilenet_v3(
         model = MobileNetV3Small(scale=scale, **kwargs)
     if pretrained:
         arch = f"{arch}_x{scale}"
-        assert (
-            arch in model_urls
-        ), f"{arch} model do not have a pretrained model now, you should set pretrained=False"
+        assert arch in model_urls, (
+            f"{arch} model do not have a pretrained model now, you should set pretrained=False"
+        )
         weight_path = get_weights_path_from_url(
             model_urls[arch][0], model_urls[arch][1]
         )

--- a/python/paddle/vision/models/resnet.py
+++ b/python/paddle/vision/models/resnet.py
@@ -404,9 +404,9 @@ def _resnet(
 ) -> ResNet:
     model = ResNet(Block, depth, **kwargs)
     if pretrained:
-        assert (
-            arch in model_urls
-        ), f"{arch} model do not have a pretrained model now, you should set pretrained=False"
+        assert arch in model_urls, (
+            f"{arch} model do not have a pretrained model now, you should set pretrained=False"
+        )
         weight_path = get_weights_path_from_url(
             model_urls[arch][0], model_urls[arch][1]
         )

--- a/python/paddle/vision/models/shufflenetv2.py
+++ b/python/paddle/vision/models/shufflenetv2.py
@@ -373,9 +373,9 @@ def _shufflenet_v2(
 ) -> ShuffleNetV2:
     model = ShuffleNetV2(scale=scale, **kwargs)
     if pretrained:
-        assert (
-            arch in model_urls
-        ), f"{arch} model do not have a pretrained model now, you should set pretrained=False"
+        assert arch in model_urls, (
+            f"{arch} model do not have a pretrained model now, you should set pretrained=False"
+        )
         weight_path = get_weights_path_from_url(
             model_urls[arch][0], model_urls[arch][1]
         )

--- a/python/paddle/vision/models/squeezenet.py
+++ b/python/paddle/vision/models/squeezenet.py
@@ -143,9 +143,9 @@ class SqueezeNet(nn.Layer):
         self.with_pool = with_pool
 
         supported_versions = ['1.0', '1.1']
-        assert (
-            version in supported_versions
-        ), f"supported versions are {supported_versions} but input version is {version}"
+        assert version in supported_versions, (
+            f"supported versions are {supported_versions} but input version is {version}"
+        )
 
         if self.version == "1.0":
             self._conv = Conv2D(
@@ -236,9 +236,9 @@ def _squeezenet(
 ) -> SqueezeNet:
     model = SqueezeNet(version, **kwargs)
     if pretrained:
-        assert (
-            arch in model_urls
-        ), f"{arch} model do not have a pretrained model now, you should set pretrained=False"
+        assert arch in model_urls, (
+            f"{arch} model do not have a pretrained model now, you should set pretrained=False"
+        )
         weight_path = get_weights_path_from_url(
             model_urls[arch][0], model_urls[arch][1]
         )

--- a/python/paddle/vision/models/vgg.py
+++ b/python/paddle/vision/models/vgg.py
@@ -180,9 +180,9 @@ def _vgg(
     model = VGG(make_layers(cfgs[cfg], batch_norm=batch_norm), **kwargs)
 
     if pretrained:
-        assert (
-            arch in model_urls
-        ), f"{arch} model do not have a pretrained model now, you should set pretrained=False"
+        assert arch in model_urls, (
+            f"{arch} model do not have a pretrained model now, you should set pretrained=False"
+        )
         weight_path = get_weights_path_from_url(
             model_urls[arch][0], model_urls[arch][1]
         )

--- a/python/paddle/vision/ops.py
+++ b/python/paddle/vision/ops.py
@@ -707,9 +707,9 @@ def box_coder(
             )
         elif isinstance(prior_box_var, (list, tuple)):
             prior_box_var = list(prior_box_var)
-            assert (
-                len(prior_box_var) == 4
-            ), "Input prior_box_var must be Variable or list|tuple with 4 elements."
+            assert len(prior_box_var) == 4, (
+                "Input prior_box_var must be Variable or list|tuple with 4 elements."
+            )
             output_box = _C_ops.box_coder(
                 prior_box,
                 None,
@@ -747,9 +747,9 @@ def box_coder(
             inputs['PriorBoxVar'] = prior_box_var
         elif isinstance(prior_box_var, (list, tuple)):
             attrs['variance'] = prior_box_var
-            assert (
-                len(attrs['variance']) == 4
-            ), "Input prior_box_var must be Variable or list|tuple with 4 elements."
+            assert len(attrs['variance']) == 4, (
+                "Input prior_box_var must be Variable or list|tuple with 4 elements."
+            )
         else:
             raise TypeError(
                 "Input prior_box_var must be Variable or list|tuple"
@@ -1128,9 +1128,9 @@ class DeformConv2D(Layer):
         bias_attr: ParamAttrLike | None = None,
     ) -> None:
         super().__init__()
-        assert (
-            weight_attr is not False
-        ), "weight_attr should not be False in Conv."
+        assert weight_attr is not False, (
+            "weight_attr should not be False in Conv."
+        )
         self._weight_attr = weight_attr
         self._bias_attr = bias_attr
         self._deformable_groups = deformable_groups
@@ -1277,20 +1277,20 @@ def distribute_fpn_proposals(
             ...     rois_num=rois_num)
             ...
     """
-    assert (
-        max_level > 0 and min_level > 0
-    ), "min_level and max_level should be greater than 0"
+    assert max_level > 0 and min_level > 0, (
+        "min_level and max_level should be greater than 0"
+    )
 
     num_lvl = max_level - min_level + 1
     assert num_lvl > 1, "max_level should be greater than min_level"
-    assert (
-        num_lvl < 100
-    ), "Only support max to 100 levels, (max_level - min_level + 1 < 100)"
+    assert num_lvl < 100, (
+        "Only support max to 100 levels, (max_level - min_level + 1 < 100)"
+    )
 
     if in_dynamic_or_pir_mode():
-        assert (
-            rois_num is not None
-        ), "rois_num should not be None in dygraph mode."
+        assert rois_num is not None, (
+            "rois_num should not be None in dygraph mode."
+        )
         (
             multi_rois,
             rois_num_per_level,
@@ -1632,9 +1632,9 @@ def roi_pool(
 
     pooled_height, pooled_width = output_size
     if in_dynamic_or_pir_mode():
-        assert (
-            boxes_num is not None
-        ), "boxes_num should not be None in dygraph mode."
+        assert boxes_num is not None, (
+            "boxes_num should not be None in dygraph mode."
+        )
         return _C_ops.roi_pool(
             x, boxes, boxes_num, pooled_height, pooled_width, spatial_scale
         )
@@ -1792,9 +1792,9 @@ def roi_align(
 
     pooled_height, pooled_width = output_size
     if in_dynamic_or_pir_mode():
-        assert (
-            boxes_num is not None
-        ), "boxes_num should not be None in dygraph mode."
+        assert boxes_num is not None, (
+            "boxes_num should not be None in dygraph mode."
+        )
         return _C_ops.roi_align(
             x,
             boxes,
@@ -2050,12 +2050,12 @@ def nms(
         return sorted_global_indices[sorted_keep_boxes_indices]
 
     if top_k is not None:
-        assert (
-            top_k <= scores.shape[0]
-        ), "top_k should be smaller equal than the number of boxes"
-    assert (
-        categories is not None
-    ), "if category_idxs is given, categories which is a list of unique id of all categories is necessary"
+        assert top_k <= scores.shape[0], (
+            "top_k should be smaller equal than the number of boxes"
+        )
+    assert categories is not None, (
+        "if category_idxs is given, categories which is a list of unique id of all categories is necessary"
+    )
 
     mask = paddle.zeros_like(scores, dtype='int32')
 
@@ -2262,9 +2262,9 @@ def generate_proposals(
     """
 
     if in_dygraph_mode():
-        assert (
-            return_rois_num
-        ), "return_rois_num should be True in dygraph mode."
+        assert return_rois_num, (
+            "return_rois_num should be True in dygraph mode."
+        )
         attrs = (
             pre_nms_top_n,
             post_nms_top_n,
@@ -2279,9 +2279,9 @@ def generate_proposals(
 
         return rpn_rois, rpn_roi_probs, rpn_rois_num
     elif in_pir_mode():
-        assert (
-            return_rois_num
-        ), "return_rois_num should be True in PaddlePaddle inner op mode."
+        assert return_rois_num, (
+            "return_rois_num should be True in PaddlePaddle inner op mode."
+        )
         rpn_rois, rpn_roi_probs, rpn_rois_num = _C_ops.generate_proposals(
             scores,
             bbox_deltas,

--- a/python/paddle/vision/transforms/functional_tensor.py
+++ b/python/paddle/vision/transforms/functional_tensor.py
@@ -931,9 +931,9 @@ def adjust_hue(img, hue_factor):
 
     """
     _assert_image_tensor(img, 'CHW')
-    assert (
-        hue_factor >= -0.5 and hue_factor <= 0.5
-    ), "hue_factor should be in range [-0.5, 0.5]"
+    assert hue_factor >= -0.5 and hue_factor <= 0.5, (
+        "hue_factor should be in range [-0.5, 0.5]"
+    )
     channels = _get_image_num_channels(img, 'CHW')
     if channels == 1:
         return img

--- a/python/paddle/vision/transforms/transforms.py
+++ b/python/paddle/vision/transforms/transforms.py
@@ -1902,9 +1902,9 @@ class RandomPerspective(BaseTransform[_InputT, _RetT]):
     ) -> None:
         super().__init__(keys)
         assert 0 <= prob <= 1, "probability must be between 0 and 1"
-        assert (
-            0 <= distortion_scale <= 1
-        ), "distortion_scale must be between 0 and 1"
+        assert 0 <= distortion_scale <= 1, (
+            "distortion_scale must be between 0 and 1"
+        )
         assert interpolation in ['nearest', 'bilinear', 'bicubic']
         assert isinstance(fill, (numbers.Number, str, list, tuple))
 
@@ -2098,24 +2098,24 @@ class RandomErasing(BaseTransform[_InputT, _RetT]):
         keys: _TransformInputKeys | None = None,
     ) -> None:
         super().__init__(keys)
-        assert isinstance(
-            scale, (tuple, list)
-        ), "scale should be a tuple or list"
-        assert (
-            scale[0] >= 0 and scale[1] <= 1 and scale[0] <= scale[1]
-        ), "scale should be of kind (min, max) and in range [0, 1]"
-        assert isinstance(
-            ratio, (tuple, list)
-        ), "ratio should be a tuple or list"
-        assert (
-            ratio[0] >= 0 and ratio[0] <= ratio[1]
-        ), "ratio should be of kind (min, max)"
-        assert (
-            prob >= 0 and prob <= 1
-        ), "The probability should be in range [0, 1]"
-        assert isinstance(
-            value, (numbers.Number, str, tuple, list)
-        ), "value should be a number, tuple, list or str"
+        assert isinstance(scale, (tuple, list)), (
+            "scale should be a tuple or list"
+        )
+        assert scale[0] >= 0 and scale[1] <= 1 and scale[0] <= scale[1], (
+            "scale should be of kind (min, max) and in range [0, 1]"
+        )
+        assert isinstance(ratio, (tuple, list)), (
+            "ratio should be a tuple or list"
+        )
+        assert ratio[0] >= 0 and ratio[0] <= ratio[1], (
+            "ratio should be of kind (min, max)"
+        )
+        assert prob >= 0 and prob <= 1, (
+            "The probability should be in range [0, 1]"
+        )
+        assert isinstance(value, (numbers.Number, str, tuple, list)), (
+            "value should be a number, tuple, list or str"
+        )
         if isinstance(value, str) and value != "random":
             raise ValueError("value must be 'random' when type is str")
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

使用性能更好，格式化效果更佳的 ruff format 替代 black 作为新的 formatter，由于我们很早就已经集成了 ruff lint，因此只是减少依赖而不会增加依赖

<!--

## 核心优势

通过集成 Ruff format，开发者可以享受到以下优势：

- 通过去除 black 对 python 环境依赖，极大降低了升级 formatter 带来的成本，后续无需考虑开发者本地 python 环境即可一键升级
- ruff 由 Rust 驱动，大幅加速 format 时间，降低开发者使用开发工具链的时间成本，减少 CI 时间，提升工程效率
- 格式化后呈现可读性更佳的效果，使得开发者更专注于代码开发而无需关心格式，阅读者也能够更加赏心悦目，极大增加了潜在贡献者的贡献意愿
- ruff 极大程度地兼容了 black 的格式化效果，能够平滑地替换现有的 black 配置
- ruff 更新频次高，能够快速响应社区反馈，持续优化格式化效果
- ruff 团队 Astral 最近开发的 ty 能够提供更强大的类型检查能力，后续可能与 ruff 集成，提供更好的开发体验
- PyTorch 最近已经完成迁移，追平竞品（在代码风格这块，我们一直做到了超越竞品，这次不能落后）

-->