### PR TITLE
[SOT] Fix bug of cuda_graph mode in sot

### DIFF
--- a/paddle/fluid/eager/to_static/run_program_impl.cc
+++ b/paddle/fluid/eager/to_static/run_program_impl.cc
@@ -573,7 +573,7 @@ std::vector<paddle::Tensor> RunProgramImpl(
 #endif
 
     auto passed_kernel_program = paddle::framework::ApplyIrPass(
-        forward_program.get(), place, no_need_buffer_name_set);
+        program.get(), place, no_need_buffer_name_set);
     const auto &new_block = passed_kernel_program->block();
     passed_kernel_program = paddle::framework::ApplyRemoveShadowFeedPass(
         std::move(passed_kernel_program), new_block, place, global_inner_scope);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164

修复 SOT 处理cuda graph子图未正常切分的Bug。