### PR TITLE
op_translator add onednn_data_type [fluid_ops] 

### DIFF
--- a/paddle/fluid/ir_adaptor/translator/op_translator.cc
+++ b/paddle/fluid/ir_adaptor/translator/op_translator.cc
@@ -1076,6 +1076,10 @@ struct CastOpTranscriber : public OpTranscriber {
       attribute_map["mkldnn_data_type"] = pir::StrAttribute::get(
           ctx, op_desc.GetAttrIfExists<std::string>("mkldnn_data_type"));
     }
+    if (op_desc.HasAttr("onednn_data_type")) {  // NOLINT
+      attribute_map["onednn_data_type"] = pir::StrAttribute::get(
+          ctx, op_desc.GetAttrIfExists<std::string>("onednn_data_type"));
+    }
 #endif
     return attribute_map;
   }
@@ -1661,12 +1665,16 @@ struct SplitOpTranscriber : public OpTranscriber {
       return attribute_map;
     }
 #ifdef PADDLE_WITH_DNNL
-    else if (op_desc.HasAttr("mkldnn_data_type")) {  // NOLINT
-      pir::AttributeMap attribute_map = {
-          {"mkldnn_data_type",
-           pir::StrAttribute::get(
-               ctx, op_desc.GetAttrIfExists<std::string>("mkldnn_data_type"))},
-      };
+    else {  // NOLINT
+      pir::AttributeMap attribute_map = {};
+      if (op_desc.HasAttr("mkldnn_data_type")) {
+        attribute_map["mkldnn_data_type"] = pir::StrAttribute::get(
+            ctx, op_desc.GetAttrIfExists<std::string>("mkldnn_data_type"));
+      }
+      if (op_desc.HasAttr("onednn_data_type")) {
+        attribute_map["onednn_data_type"] = pir::StrAttribute::get(
+            ctx, op_desc.GetAttrIfExists<std::string>("onednn_data_type"));
+      }
       return attribute_map;
     }
 #endif


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
paddle/fluid/ir_adaptor/translator/op_translator.cc 增加 onednn_data_type