### PR TITLE
[Make Warning] fix make warning for eager_utils.h

### DIFF
--- a/paddle/fluid/pybind/eager_utils.h
+++ b/paddle/fluid/pybind/eager_utils.h
@@ -479,7 +479,7 @@ class TensorListBufferAllocator {
     bool is_available;
     std::vector<paddle::Tensor> buffer;
     TensorListBuffer() = default;
-    explicit TensorListBuffer(ssize_t len) : buffer(len), is_available(true) {}
+    explicit TensorListBuffer(ssize_t len) : is_available(true), buffer(len) {}
   };
 
   using MapType =


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->

```bash
/home/aistudio/Paddle/paddle/fluid/pybind/eager_utils.h:480:33: warning: ‘paddle::pybind::TensorListBufferAllocator::TensorListBuffer::buffer’ will be initialized after [-Wreorder]
     std::vector<paddle::Tensor> buffer;
                                 ^~~~~~
/home/aistudio/Paddle/paddle/fluid/pybind/eager_utils.h:479:10: warning:   ‘bool paddle::pybind::TensorListBufferAllocator::TensorListBuffer::is_available’ [-Wreorder]
     bool is_available;
          ^~~~~~~~~~~~
/home/aistudio/Paddle/paddle/fluid/pybind/eager_utils.h:482:14: warning:   when initialized here [-Wreorder]
     explicit TensorListBuffer(ssize_t len) : buffer(len), is_available(true) {}
              ^~~~~~~~~~~~~~~~
```
change position between `buffer` and `is_available`