### PR TITLE
[CodeStyle] `black -> ruff format` migration - part 35

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -97,7 +97,7 @@ repos:
 
             # | python/_.+
 
-            # | test/a.+
+            | test/a.+
 
             # | test/[b-h].+
 
@@ -153,7 +153,7 @@ repos:
 
             | python/_.+
 
-            | test/a.+
+            # | test/a.+
 
             | test/[b-h].+
 

--- a/test/auto_parallel/PP_Schedules_demo.py
+++ b/test/auto_parallel/PP_Schedules_demo.py
@@ -508,9 +508,7 @@ class Test_Schedules:
             parameters=self.model.parameters(),
             grad_clip=paddle.nn.ClipGradByGlobalNorm(1.0),
         )
-        if (
-            dist.in_auto_parallel_align_mode()
-        ):  # When in auto parallel align mode, patching the optimizer step function
+        if dist.in_auto_parallel_align_mode():  # When in auto parallel align mode, patching the optimizer step function
             orig_step = (
                 opt.step.__func__ if hasattr(opt.step, "__func__") else opt.step
             )

--- a/test/auto_parallel/custom_op/semi_auto_parallel_for_custom_op.py
+++ b/test/auto_parallel/custom_op/semi_auto_parallel_for_custom_op.py
@@ -40,9 +40,9 @@ class TestCustomOpSemiAutoParallel(SemiAutoParallelTestBase):
         self._seed = eval(os.getenv("seed"))
 
     def check_placements(self, output, expected_placements):
-        assert (
-            output.placements == expected_placements
-        ), f"{output.placements}  vs {expected_placements}"
+        assert output.placements == expected_placements, (
+            f"{output.placements}  vs {expected_placements}"
+        )
 
     def test_custom_relu(self):
         shapes = [16, 4, 4]

--- a/test/auto_parallel/dtensor_from_local_api.py
+++ b/test/auto_parallel/dtensor_from_local_api.py
@@ -63,12 +63,12 @@ class TestDtensorFromLocalAPI:
             if mesh is None and placements is None:
                 assert not grad.is_dist(), "grad.is_dist() is not False"
             else:
-                assert (
-                    grad.process_mesh == mesh
-                ), "grad.process_mesh is not equal to mesh"
-                assert (
-                    grad.placements == placements
-                ), "grad.placements is not equal to placements"
+                assert grad.process_mesh == mesh, (
+                    "grad.process_mesh is not equal to mesh"
+                )
+                assert grad.placements == placements, (
+                    "grad.placements is not equal to placements"
+                )
 
         return _check_mesh
 

--- a/test/auto_parallel/hybrid_strategy/parallel_api.py
+++ b/test/auto_parallel/hybrid_strategy/parallel_api.py
@@ -178,7 +178,9 @@ class TestParallelAPI:
             ) or (
                 self.config.context_parallel is False
                 and self.config.sep_parallel is True
-            ), "when sep > 1, either context_parallel or sep_parallel should be true"
+            ), (
+                "when sep > 1, either context_parallel or sep_parallel should be true"
+            )
         num_hidden_layers = os.getenv("num_hidden_layers")
         if num_hidden_layers:
             self.config.num_hidden_layers = int(num_hidden_layers)
@@ -299,9 +301,9 @@ class TestParallelAPI:
                 ) and not self.share_embedding:
                     assert sub_layer.weight.stop_gradient
                 if 'o_proj' in name:
-                    assert (
-                        sub_layer.weight.stop_gradient
-                    ), f'{name} , {sub_layer.weight.name} , {sub_layer.weight}'
+                    assert sub_layer.weight.stop_gradient, (
+                        f'{name} , {sub_layer.weight.name} , {sub_layer.weight}'
+                    )
                     assert not sub_layer.lora_A.stop_gradient
                     assert not sub_layer.lora_B.stop_gradient
                     # assert sub_layer.bias.stop_gradient is None

--- a/test/auto_parallel/hybrid_strategy/semi_auto_llama.py
+++ b/test/auto_parallel/hybrid_strategy/semi_auto_llama.py
@@ -137,7 +137,9 @@ class TestLlamaAuto:
             assert (
                 self.config.sep_parallel_degree
                 != self.config.context_parallel_degree
-            ), f"only one of the context_parallel and sep_parallel can be True, but get context_parallel_degree = {self.config.context_parallel_degree} and sep_parallel_degree = {self.config.sep_parallel_degree}, please check your env"
+            ), (
+                f"only one of the context_parallel and sep_parallel can be True, but get context_parallel_degree = {self.config.context_parallel_degree} and sep_parallel_degree = {self.config.sep_parallel_degree}, please check your env"
+            )
 
         self.init_dist_env()
 

--- a/test/auto_parallel/hybrid_strategy/semi_auto_llama_acc_align.py
+++ b/test/auto_parallel/hybrid_strategy/semi_auto_llama_acc_align.py
@@ -159,7 +159,9 @@ class TestLlamaAuto:
             assert (
                 self.config.sep_parallel_degree
                 != self.config.context_parallel_degree
-            ), f"only one of the context_parallel and sep_parallel can be True, but get context_parallel_degree = {self.config.context_parallel_degree} and sep_parallel_degree = {self.config.sep_parallel_degree}, please check your env"
+            ), (
+                f"only one of the context_parallel and sep_parallel can be True, but get context_parallel_degree = {self.config.context_parallel_degree} and sep_parallel_degree = {self.config.sep_parallel_degree}, please check your env"
+            )
 
         self.run_step = 10
         self.run_step_dy2static = (

--- a/test/auto_parallel/hybrid_strategy/semi_auto_llama_dataloader.py
+++ b/test/auto_parallel/hybrid_strategy/semi_auto_llama_dataloader.py
@@ -152,7 +152,9 @@ class TestLlamaAuto:
             assert (
                 self.config.sep_parallel_degree
                 != self.config.context_parallel_degree
-            ), f"only one of the context_parallel and sep_parallel can be True, but get context_parallel_degree = {self.config.context_parallel_degree} and sep_parallel_degree = {self.config.sep_parallel_degree}, please check your env"
+            ), (
+                f"only one of the context_parallel and sep_parallel can be True, but get context_parallel_degree = {self.config.context_parallel_degree} and sep_parallel_degree = {self.config.sep_parallel_degree}, please check your env"
+            )
 
         self.init_dist_env()
 

--- a/test/auto_parallel/hybrid_strategy/semi_auto_llama_pp_gradmerge.py
+++ b/test/auto_parallel/hybrid_strategy/semi_auto_llama_pp_gradmerge.py
@@ -133,7 +133,9 @@ class TestLlamaAuto:
             assert (
                 self.config.sep_parallel_degree
                 != self.config.context_parallel_degree
-            ), f"only one of the context_parallel and sep_parallel can be True, but get context_parallel_degree = {self.config.context_parallel_degree} and sep_parallel_degree = {self.config.sep_parallel_degree}, please check your env"
+            ), (
+                f"only one of the context_parallel and sep_parallel can be True, but get context_parallel_degree = {self.config.context_parallel_degree} and sep_parallel_degree = {self.config.sep_parallel_degree}, please check your env"
+            )
 
         self.init_dist_env()
 

--- a/test/auto_parallel/hybrid_strategy/semi_auto_llama_save_load.py
+++ b/test/auto_parallel/hybrid_strategy/semi_auto_llama_save_load.py
@@ -111,7 +111,9 @@ class TestLlamaAuto:
             assert (
                 self.config.sep_parallel_degree
                 != self.config.context_parallel_degree
-            ), f"only one of the context_parallel and sep_parallel can be True, but get context_parallel_degree = {self.config.context_parallel_degree} and sep_parallel_degree = {self.config.sep_parallel_degree}, please check your env"
+            ), (
+                f"only one of the context_parallel and sep_parallel can be True, but get context_parallel_degree = {self.config.context_parallel_degree} and sep_parallel_degree = {self.config.sep_parallel_degree}, please check your env"
+            )
 
         self.init_dist_env()
 
@@ -136,41 +138,43 @@ class TestLlamaAuto:
         random.seed(1024)
 
     def check_program_equal(self, program_a, program_b):
-        assert (
-            program_a.num_ops() == program_b.num_ops()
-        ), f'The number of ops between two programs is different: {program_a.num_ops()} vs {program_b.num_ops()}.'
+        assert program_a.num_ops() == program_b.num_ops(), (
+            f'The number of ops between two programs is different: {program_a.num_ops()} vs {program_b.num_ops()}.'
+        )
         for i in range(program_a.num_ops()):
             a_op = program_a.global_block().ops[i]
             b_op = program_a.global_block().ops[i]
             # check op name
-            assert (
-                a_op.name() == b_op.name()
-            ), f'The name of {i} op in program is different: {a_op.name()} vs {b_op.name()}.'
+            assert a_op.name() == b_op.name(), (
+                f'The name of {i} op in program is different: {a_op.name()} vs {b_op.name()}.'
+            )
             # check op inputs
             for index in range(a_op.num_operands()):
                 assert (
                     a_op.operand(index)
                     .source()
                     .is_same(b_op.operand(index).source())
-                ), f'The type of {index} operand is different: {a_op.operand(index).source()} vs {b_op.operand(index).source()}'
+                ), (
+                    f'The type of {index} operand is different: {a_op.operand(index).source()} vs {b_op.operand(index).source()}'
+                )
             # check op outputs
             for index in range(a_op.num_results()):
-                assert a_op.result(index).is_same(
-                    b_op.result(index)
-                ), f'The type of {index} result is different: {a_op.result(index)} vs {b_op.result(index)}'
+                assert a_op.result(index).is_same(b_op.result(index)), (
+                    f'The type of {index} result is different: {a_op.result(index)} vs {b_op.result(index)}'
+                )
             # check op attrs
             for k, v in a_op.attrs().items():
-                assert (
-                    k in b_op.attrs()
-                ), f'Can not find key of {k} attribute in other program'
+                assert k in b_op.attrs(), (
+                    f'Can not find key of {k} attribute in other program'
+                )
                 if k == 'place':
-                    assert type(v) == type(
-                        b_op.attrs()[k]
-                    ), f'The attribute of {k} is different: {type(v)} vs {type(b_op.attrs()[k])}'
+                    assert type(v) == type(b_op.attrs()[k]), (
+                        f'The attribute of {k} is different: {type(v)} vs {type(b_op.attrs()[k])}'
+                    )
                 else:
-                    assert (
-                        v == b_op.attrs()[k]
-                    ), f'The attribute of {k} is different: {v} vs {b_op.attrs()[k]}'
+                    assert v == b_op.attrs()[k], (
+                        f'The attribute of {k} is different: {v} vs {b_op.attrs()[k]}'
+                    )
 
     def run_dy2static(self, tmp_ckpt_path):
         model = LlamaForCausalLMAuto(self.config)

--- a/test/auto_parallel/hybrid_strategy/semi_auto_parallel_for_llama_decoder_dp_mp.py
+++ b/test/auto_parallel/hybrid_strategy/semi_auto_parallel_for_llama_decoder_dp_mp.py
@@ -229,9 +229,9 @@ class TestLlamaDecoderForSemiAutoParallel:
         )
 
     def check_placements(self, output, expected_placements):
-        assert (
-            output.placements == expected_placements
-        ), f"{output.placements}  vs {expected_placements}"
+        assert output.placements == expected_placements, (
+            f"{output.placements}  vs {expected_placements}"
+        )
 
     def get_shard_check_hook(self, dims_mapping, check_input=False):
         def check_func(layer, input, output=None):

--- a/test/auto_parallel/hybrid_strategy/semi_auto_parallel_llama_model.py
+++ b/test/auto_parallel/hybrid_strategy/semi_auto_parallel_llama_model.py
@@ -990,13 +990,13 @@ def split_sequence_dim(inputs):
 
     if sep_degree > 1:
         assert inputs.is_dist(), "Input tensor must be a distributed tensor."
-        assert (
-            len(inputs.shape) == 2
-        ), f"input_ids should be [batch_size, seq_len], but got {inputs.shape}"
+        assert len(inputs.shape) == 2, (
+            f"input_ids should be [batch_size, seq_len], but got {inputs.shape}"
+        )
         _, seq_len = inputs.shape
-        assert (
-            seq_len % sep_degree == 0
-        ), f"sequence length {seq_len} must be divisible by cp degree {sep_degree}"
+        assert seq_len % sep_degree == 0, (
+            f"sequence length {seq_len} must be divisible by cp degree {sep_degree}"
+        )
         # split sequence dim
         placements[sep_index] = dist.Shard(1)
         split_input = dist.reshard(inputs, process_mesh, placements)

--- a/test/auto_parallel/hybrid_strategy/semi_auto_parallel_mutual_load_between_dynamic_and_static.py
+++ b/test/auto_parallel/hybrid_strategy/semi_auto_parallel_mutual_load_between_dynamic_and_static.py
@@ -130,15 +130,17 @@ class TestSemiAutoParallelMutualLoadBetweenDynamicAndStatic(
         state_dict_to_load = dist_model.state_dict(mode="param")
         assert len(state_dict_to_load) == len(expected_state_dict)
         for k, v in state_dict_to_load.items():
-            assert (
-                k in expected_state_dict
-            ), f"key {k} not in expected_state_dict:{expected_state_dict}"
+            assert k in expected_state_dict, (
+                f"key {k} not in expected_state_dict:{expected_state_dict}"
+            )
             assert np.any(
                 np.not_equal(
                     v._local_value().numpy(),
                     expected_state_dict[k].numpy(),
                 )
-            ), f"key:{k}, v:{v}, expected_state_dict[k]:{expected_state_dict[k]}"
+            ), (
+                f"key:{k}, v:{v}, expected_state_dict[k]:{expected_state_dict[k]}"
+            )
 
         dist.load_state_dict(state_dict_to_load, ckpt_path)
         dist_model.set_state_dict(state_dict_to_load)
@@ -146,9 +148,9 @@ class TestSemiAutoParallelMutualLoadBetweenDynamicAndStatic(
         program_state_dict = dist_model.state_dict(mode="param")
         assert len(expected_state_dict) == len(program_state_dict)
         for k, v in program_state_dict.items():
-            assert (
-                k in expected_state_dict
-            ), f"key {k} not in expected_state_dict:{expected_state_dict}"
+            assert k in expected_state_dict, (
+                f"key {k} not in expected_state_dict:{expected_state_dict}"
+            )
             np.testing.assert_equal(
                 v._local_value().numpy(),
                 expected_state_dict[k].numpy(),
@@ -189,15 +191,17 @@ class TestSemiAutoParallelMutualLoadBetweenDynamicAndStatic(
         state_dict_to_load = dy_layer.state_dict()
         assert len(state_dict_to_load) == len(expected_state_dict)
         for k, v in state_dict_to_load.items():
-            assert (
-                k in expected_state_dict
-            ), f"key {k} not in expected_state_dict:{expected_state_dict}"
+            assert k in expected_state_dict, (
+                f"key {k} not in expected_state_dict:{expected_state_dict}"
+            )
             assert np.any(
                 np.not_equal(
                     v._local_value().numpy(),
                     expected_state_dict[k].numpy(),
                 )
-            ), f"key:{k}, v:{v}, expected_state_dict[k]:{expected_state_dict[k]}"
+            ), (
+                f"key:{k}, v:{v}, expected_state_dict[k]:{expected_state_dict[k]}"
+            )
 
         dist.load_state_dict(state_dict_to_load, ckpt_path)
         dy_layer.set_state_dict(state_dict_to_load)
@@ -205,9 +209,9 @@ class TestSemiAutoParallelMutualLoadBetweenDynamicAndStatic(
         state_dict = dy_layer.state_dict()
         assert len(expected_state_dict) == len(state_dict)
         for k, v in state_dict.items():
-            assert (
-                k in expected_state_dict
-            ), f"key {k} not in expected_state_dict:{expected_state_dict}"
+            assert k in expected_state_dict, (
+                f"key {k} not in expected_state_dict:{expected_state_dict}"
+            )
             np.testing.assert_equal(
                 v._local_value().numpy(),
                 expected_state_dict[k].numpy(),

--- a/test/auto_parallel/hybrid_strategy/semi_auto_parallel_simple_net_dp_mp.py
+++ b/test/auto_parallel/hybrid_strategy/semi_auto_parallel_simple_net_dp_mp.py
@@ -75,9 +75,9 @@ class TestSimpleNetHybridStrategyForSemiAutoParallel(
         for k, v in state_dict.items():
             assert v.numpy().sum() == 0.0, f"state_dict {k} is not zero"
             assert k in need_load_state_dict, f"state_dict {k} is not found"
-            assert (
-                need_load_state_dict[k].numpy().sum() == 0.0
-            ), f"state_dict {k} is not zero"
+            assert need_load_state_dict[k].numpy().sum() == 0.0, (
+                f"state_dict {k} is not zero"
+            )
 
         paddle.distributed.load_state_dict(
             need_load_state_dict, self._ckpt_path

--- a/test/auto_parallel/hybrid_strategy/semi_auto_save_state_dict.py
+++ b/test/auto_parallel/hybrid_strategy/semi_auto_save_state_dict.py
@@ -34,27 +34,27 @@ def check_structure_name_mapping(ckpt_path, state_dict):
     data_file_path = os.path.join(
         ckpt_path, f"{paddle.distributed.get_rank()}_0.distcp"
     )
-    assert os.path.exists(
-        metadata_file_path
-    ), f"metadata file {metadata_file_path} is not found"
-    assert os.path.exists(
-        data_file_path
-    ), f"data file {data_file_path} is not found"
+    assert os.path.exists(metadata_file_path), (
+        f"metadata file {metadata_file_path} is not found"
+    )
+    assert os.path.exists(data_file_path), (
+        f"data file {data_file_path} is not found"
+    )
     metadata = paddle.load(metadata_file_path)
     cur_rank_state_dict = paddle.load(data_file_path, keep_name_table=True)
     local_structure_name_mapping = cur_rank_state_dict.pop(
         "StructuredToParameterName@@"
     )
-    assert isinstance(
-        local_structure_name_mapping, dict
-    ), f"local_structure_name_mapping:{local_structure_name_mapping} is not dict type"
+    assert isinstance(local_structure_name_mapping, dict), (
+        f"local_structure_name_mapping:{local_structure_name_mapping} is not dict type"
+    )
     for structure_name, param_name in local_structure_name_mapping.items():
-        assert (
-            structure_name in state_dict
-        ), f"tensor key:{structure_name} is not found in state dict:{state_dict}"
-        assert (
-            param_name == state_dict[structure_name].name
-        ), f"param name:{param_name} is not equal to param name in state_dict:{state_dict[structure_name].name}"
+        assert structure_name in state_dict, (
+            f"tensor key:{structure_name} is not found in state dict:{state_dict}"
+        )
+        assert param_name == state_dict[structure_name].name, (
+            f"param name:{param_name} is not equal to param name in state_dict:{state_dict[structure_name].name}"
+        )
 
 
 class TestSaveStateDict:

--- a/test/auto_parallel/pipeline_sync_shared_parameters_unittest.py
+++ b/test/auto_parallel/pipeline_sync_shared_parameters_unittest.py
@@ -200,8 +200,7 @@ class TestSharedParameters:
         cur_rank = dist.get_rank()
         stage_layers = SingleStage(
             self.model.linears[
-                cur_rank
-                * num_layers_per_card : (cur_rank + 1)
+                cur_rank * num_layers_per_card : (cur_rank + 1)
                 * num_layers_per_card
             ]
         )

--- a/test/auto_parallel/pir/auto_parallel_recompute_pir_pass_unittest.py
+++ b/test/auto_parallel/pir/auto_parallel_recompute_pir_pass_unittest.py
@@ -109,7 +109,9 @@ class TestRecomputeLlamaAuto:
             assert (
                 self.config.sep_parallel_degree
                 != self.config.context_parallel_degree
-            ), f"only one of the context_parallel and sep_parallel can be True, but get context_parallel_degree = {self.config.context_parallel_degree} and sep_parallel_degree = {self.config.sep_parallel_degree}, please check your env"
+            ), (
+                f"only one of the context_parallel and sep_parallel can be True, but get context_parallel_degree = {self.config.context_parallel_degree} and sep_parallel_degree = {self.config.sep_parallel_degree}, please check your env"
+            )
 
         self.strategy = dist.Strategy()
 

--- a/test/auto_parallel/pir/sharding_tensor_fusion_save_load.py
+++ b/test/auto_parallel/pir/sharding_tensor_fusion_save_load.py
@@ -90,41 +90,43 @@ class TestSimpleNetShardingTensorFusionSaveLoad:
         return loader
 
     def check_program_equal(self, program_a, program_b):
-        assert (
-            program_a.num_ops() == program_b.num_ops()
-        ), f'The number of ops between two programs is different: {program_a.num_ops()} vs {program_b.num_ops()}.'
+        assert program_a.num_ops() == program_b.num_ops(), (
+            f'The number of ops between two programs is different: {program_a.num_ops()} vs {program_b.num_ops()}.'
+        )
         for i in range(program_a.num_ops()):
             a_op = program_a.global_block().ops[i]
             b_op = program_a.global_block().ops[i]
             # check op name
-            assert (
-                a_op.name() == b_op.name()
-            ), f'The name of {i} op in program is different: {a_op.name()} vs {b_op.name()}.'
+            assert a_op.name() == b_op.name(), (
+                f'The name of {i} op in program is different: {a_op.name()} vs {b_op.name()}.'
+            )
             # check op inputs
             for index in range(a_op.num_operands()):
                 assert (
                     a_op.operand(index)
                     .source()
                     .is_same(b_op.operand(index).source())
-                ), f'The type of {index} operand is different: {a_op.operand(index).source()} vs {b_op.operand(index).source()}'
+                ), (
+                    f'The type of {index} operand is different: {a_op.operand(index).source()} vs {b_op.operand(index).source()}'
+                )
             # check op outputs
             for index in range(a_op.num_results()):
-                assert a_op.result(index).is_same(
-                    b_op.result(index)
-                ), f'The type of {index} result is different: {a_op.result(index)} vs {b_op.result(index)}'
+                assert a_op.result(index).is_same(b_op.result(index)), (
+                    f'The type of {index} result is different: {a_op.result(index)} vs {b_op.result(index)}'
+                )
             # check op attrs
             for k, v in a_op.attrs().items():
-                assert (
-                    k in b_op.attrs()
-                ), f'Can not find key of {k} attribute in other program'
+                assert k in b_op.attrs(), (
+                    f'Can not find key of {k} attribute in other program'
+                )
                 if k == 'place':
-                    assert type(v) == type(
-                        b_op.attrs()[k]
-                    ), f'The attribute of {k} is different: {type(v)} vs {type(b_op.attrs()[k])}'
+                    assert type(v) == type(b_op.attrs()[k]), (
+                        f'The attribute of {k} is different: {type(v)} vs {type(b_op.attrs()[k])}'
+                    )
                 else:
-                    assert (
-                        v == b_op.attrs()[k]
-                    ), f'The attribute of {k} is different: {v} vs {b_op.attrs()[k]}'
+                    assert v == b_op.attrs()[k], (
+                        f'The attribute of {k} is different: {v} vs {b_op.attrs()[k]}'
+                    )
 
     def run_dy2static(self):
         paddle.disable_static()

--- a/test/auto_parallel/semi_auto_parallel_checkpoint_flatten_mapping.py
+++ b/test/auto_parallel/semi_auto_parallel_checkpoint_flatten_mapping.py
@@ -56,16 +56,16 @@ class TestSemiautoSaveLoad:
         metadata_path = os.path.join(self._ckpt_path, "0.metadata")
         assert os.path.exists(metadata_path)
         metadata = paddle.load(metadata_path)
-        assert len(metadata.flat_mapping) == len(
-            expected_mapping
-        ), f"expect {len(expected_mapping)}, but got {len(metadata.flat_mapping)}"
+        assert len(metadata.flat_mapping) == len(expected_mapping), (
+            f"expect {len(expected_mapping)}, but got {len(metadata.flat_mapping)}"
+        )
         for key in metadata.flat_mapping:
-            assert (
-                key in expected_mapping
-            ), f"expect {key} in flatten_mapping, but not found"
-            assert (
-                metadata.flat_mapping[key] == expected_mapping[key]
-            ), f"expect {metadata.flat_mapping[key]} == {expected_mapping[key]}, but not equal"
+            assert key in expected_mapping, (
+                f"expect {key} in flatten_mapping, but not found"
+            )
+            assert metadata.flat_mapping[key] == expected_mapping[key], (
+                f"expect {metadata.flat_mapping[key]} == {expected_mapping[key]}, but not equal"
+            )
 
     def run_test_case(self):
         self.test_flatten_mapping()

--- a/test/auto_parallel/semi_auto_parallel_for_concat.py
+++ b/test/auto_parallel/semi_auto_parallel_for_concat.py
@@ -27,9 +27,9 @@ class TestSplitAndConcatSemiAutoParallel(SemiAutoParallelTestBase):
         super().__init__()
 
     def check_placements(self, output, expected_placements):
-        assert (
-            output.placements == expected_placements
-        ), f"{output.placements}  vs {expected_placements}"
+        assert output.placements == expected_placements, (
+            f"{output.placements}  vs {expected_placements}"
+        )
 
     def test_concat_forward(self):
         shapes = [[16, 4, 4], [64, 4, 4]]

--- a/test/auto_parallel/semi_auto_parallel_for_conv2d.py
+++ b/test/auto_parallel/semi_auto_parallel_for_conv2d.py
@@ -24,9 +24,9 @@ class TestConv2dApiForSemiAutoParallel(SemiAutoParallelTestBase):
         super().__init__()
 
     def check_placements(self, output, expected_placements):
-        assert (
-            output.placements == expected_placements
-        ), f"{output.placements}  vs {expected_placements}"
+        assert output.placements == expected_placements, (
+            f"{output.placements}  vs {expected_placements}"
+        )
 
     def test_conv2d_shard(self):
         shapes = ([8, 3, 8, 8], [6, 3, 3, 3], [6])

--- a/test/auto_parallel/semi_auto_parallel_for_flash_attention.py
+++ b/test/auto_parallel/semi_auto_parallel_for_flash_attention.py
@@ -24,9 +24,9 @@ class TestFlashAttentionSemiAutoParallel(SemiAutoParallelTestBase):
         super().__init__()
 
     def check_placements(self, output, expected_placements):
-        assert (
-            output.placements == expected_placements
-        ), f"{output.placements}  vs {expected_placements}"
+        assert output.placements == expected_placements, (
+            f"{output.placements}  vs {expected_placements}"
+        )
 
     def test_flash_att_forward(self, is_gqa=False):
         if is_gqa:

--- a/test/auto_parallel/semi_auto_parallel_for_fused_rope.py
+++ b/test/auto_parallel/semi_auto_parallel_for_fused_rope.py
@@ -47,9 +47,9 @@ class TestFusedRopeApiForSemiAutoParallel(SemiAutoParallelTestBase):
         self._position_ids_shape = [self._bs, self._seq_len]
 
     def check_placements(self, output, expected_placements):
-        assert (
-            output.placements == expected_placements
-        ), f"{output.placements}  vs {expected_placements}"
+        assert output.placements == expected_placements, (
+            f"{output.placements}  vs {expected_placements}"
+        )
 
     def test_only_q_input(self):
         paddle.seed(self._seed)

--- a/test/auto_parallel/semi_auto_parallel_for_layernorm.py
+++ b/test/auto_parallel/semi_auto_parallel_for_layernorm.py
@@ -35,9 +35,9 @@ class TestLayerNormSemiAutoParallel(SemiAutoParallelTestBase):
         np.testing.assert_allclose(np1, np2, rtol=1e-04, verbose=True)
 
     def check_placements(self, output, expected_placements):
-        assert (
-            output.placements == expected_placements
-        ), f"{output.placements}  vs {expected_placements}"
+        assert output.placements == expected_placements, (
+            f"{output.placements}  vs {expected_placements}"
+        )
 
     def test_layernorm_forward(self):
         shapes = ([16, 4, 4], [16], [16])

--- a/test/auto_parallel/semi_auto_parallel_for_llama_attention.py
+++ b/test/auto_parallel/semi_auto_parallel_for_llama_attention.py
@@ -148,9 +148,9 @@ class TestLlamaAttentionForSemiAutoParallel:
         )
 
     def check_dim_mapping(self, output, expected_dim_mapping):
-        assert (
-            output.dist_attr.dims_mapping == expected_dim_mapping
-        ), f"{output.dist_attr.dims_mapping}  vs {expected_dim_mapping}"
+        assert output.dist_attr.dims_mapping == expected_dim_mapping, (
+            f"{output.dist_attr.dims_mapping}  vs {expected_dim_mapping}"
+        )
 
     def get_shard_check_hook(self, dims_mapping, check_input=False):
         def check_func(layer, input, output=None):

--- a/test/auto_parallel/semi_auto_parallel_for_llama_decoder.py
+++ b/test/auto_parallel/semi_auto_parallel_for_llama_decoder.py
@@ -229,9 +229,9 @@ class TestLlamaDecoderForSemiAutoParallel:
         )
 
     def check_dim_mapping(self, output, expected_dim_mapping):
-        assert (
-            output.dist_attr.dims_mapping == expected_dim_mapping
-        ), f"{output.dist_attr.dims_mapping}  vs {expected_dim_mapping}"
+        assert output.dist_attr.dims_mapping == expected_dim_mapping, (
+            f"{output.dist_attr.dims_mapping}  vs {expected_dim_mapping}"
+        )
 
     def get_shard_check_hook(self, dims_mapping, check_input=False):
         def check_func(layer, input, output=None):

--- a/test/auto_parallel/semi_auto_parallel_for_llama_mlp.py
+++ b/test/auto_parallel/semi_auto_parallel_for_llama_mlp.py
@@ -149,9 +149,9 @@ class TestLlamaMlpForSemiAutoParallel:
         )
 
     def check_placements(self, output, expected_placements):
-        assert (
-            output.placements == expected_placements
-        ), f"{output.placements}  vs {expected_placements}"
+        assert output.placements == expected_placements, (
+            f"{output.placements}  vs {expected_placements}"
+        )
 
     def get_shard_check_hook(self, placements, check_input=False):
         def check_func(layer, input, output=None):

--- a/test/auto_parallel/semi_auto_parallel_for_reshape.py
+++ b/test/auto_parallel/semi_auto_parallel_for_reshape.py
@@ -29,9 +29,9 @@ class TestReshapeSemiAutoParallel(SemiAutoParallelTestBase):
         super().__init__()
 
     def check_placements(self, output, expected_placements):
-        assert (
-            output.placements == expected_placements
-        ), f"{output.placements}  vs {expected_placements}"
+        assert output.placements == expected_placements, (
+            f"{output.placements}  vs {expected_placements}"
+        )
 
     def test_reshape_forward(self):
         shape = [200, 30]

--- a/test/auto_parallel/semi_auto_parallel_for_transpose.py
+++ b/test/auto_parallel/semi_auto_parallel_for_transpose.py
@@ -28,9 +28,9 @@ class TestTransposeApiForSemiAutoParallel(SemiAutoParallelTestBase):
         self._mesh = dist.ProcessMesh([0, 1], dim_names=["x"])
 
     def check_placements(self, output, expected_placements):
-        assert (
-            output.placements == expected_placements
-        ), f"{output.placements}  vs {expected_placements}"
+        assert output.placements == expected_placements, (
+            f"{output.placements}  vs {expected_placements}"
+        )
 
     def test_transpose_shard(self):
         x_shape = ([10, 6, 8],)

--- a/test/auto_parallel/semi_auto_parallel_for_triu.py
+++ b/test/auto_parallel/semi_auto_parallel_for_triu.py
@@ -23,9 +23,9 @@ class TestTriuSemiAutoParallel(SemiAutoParallelTestBase):
         super().__init__()
 
     def check_placements(self, output, expected_placements):
-        assert (
-            output.placements == expected_placements
-        ), f"{output.placements}  vs {expected_placements}"
+        assert output.placements == expected_placements, (
+            f"{output.placements}  vs {expected_placements}"
+        )
 
     def test_triu_forward(self):
         shapes = [16, 4, 4]

--- a/test/auto_parallel/semi_auto_parallel_shard_optimizer_api.py
+++ b/test/auto_parallel/semi_auto_parallel_shard_optimizer_api.py
@@ -210,18 +210,18 @@ class TestSemiAutoParallelShardOptimizerAPI:
             if k == "master_weights":
                 assert isinstance(v, dict), v
                 for mk, mv in v.items():
-                    assert (
-                        mv.numpy().sum() == 0.0
-                    ), f"state_dict {k} in master_weights is not zero"
-                    assert (
-                        need_load_state_dict[k][mk].numpy().sum() == 0.0
-                    ), f"state_dict {k} in master_weights is not zero"
+                    assert mv.numpy().sum() == 0.0, (
+                        f"state_dict {k} in master_weights is not zero"
+                    )
+                    assert need_load_state_dict[k][mk].numpy().sum() == 0.0, (
+                        f"state_dict {k} in master_weights is not zero"
+                    )
             else:
                 assert v.numpy().sum() == 0.0, f"state_dict {k} is not zero"
                 assert k in need_load_state_dict, f"state_dict {k} is not found"
-                assert (
-                    need_load_state_dict[k].numpy().sum() == 0.0
-                ), f"state_dict {k} is not zero"
+                assert need_load_state_dict[k].numpy().sum() == 0.0, (
+                    f"state_dict {k} is not zero"
+                )
         dist.load_state_dict(need_load_state_dict, ckpt_path)
         opt.set_state_dict(need_load_state_dict)
         new_state_dict = opt.state_dict()

--- a/test/auto_parallel/semi_auto_parallel_subgraph_embedding.py
+++ b/test/auto_parallel/semi_auto_parallel_subgraph_embedding.py
@@ -67,10 +67,14 @@ class TestEmbeddingSubgraphSemiAutoParallel:
         # The threshold setting refers to Megatron-LM
         assert (
             np.max(np.abs(actual_out.numpy() - desired_out.numpy())) < 1.0e-12
-        ), f'embedding dp forward error. actual: {actual_out}, desired: {desired_out}'
+        ), (
+            f'embedding dp forward error. actual: {actual_out}, desired: {desired_out}'
+        )
         assert (
             np.max(np.abs(actual_grad.numpy() - desired_grad.numpy())) < 1.0e-12
-        ), f'embedding dp backward error. actual: {actual_out}, desired: {desired_out}'
+        ), (
+            f'embedding dp backward error. actual: {actual_out}, desired: {desired_out}'
+        )
 
     def test_mp(self):
         paddle.seed(self._seed)
@@ -109,10 +113,14 @@ class TestEmbeddingSubgraphSemiAutoParallel:
         # The threshold setting refers to Megatron-LM
         assert (
             np.max(np.abs(actual_out.numpy() - desired_out.numpy())) < 1.0e-12
-        ), f'embedding mp forward error. actual: {actual_out}, desired: {desired_out}'
+        ), (
+            f'embedding mp forward error. actual: {actual_out}, desired: {desired_out}'
+        )
         assert (
             np.max(np.abs(actual_grad.numpy() - desired_grad.numpy())) < 1.0e-12
-        ), f'embedding mp backward error. actual: {actual_out}, desired: {desired_out}'
+        ), (
+            f'embedding mp backward error. actual: {actual_out}, desired: {desired_out}'
+        )
 
     def run_test_case(self):
         if self._backend == "cpu":

--- a/test/auto_parallel/test_api_dist_branch.py
+++ b/test/auto_parallel/test_api_dist_branch.py
@@ -46,9 +46,9 @@ class TestDygraphAPIForDistTensorBranch(unittest.TestCase):
         return local_t, dist_t
 
     def create_local_and_dist_tensor_list_pair(self, np_array_list):
-        assert isinstance(
-            np_array_list, list
-        ), "input should be list of np_array!"
+        assert isinstance(np_array_list, list), (
+            "input should be list of np_array!"
+        )
         local_t_list = []
         dist_t_list = []
         for np_array in np_array_list:

--- a/test/auto_parallel/test_static_gradient_sync.py
+++ b/test/auto_parallel/test_static_gradient_sync.py
@@ -207,19 +207,19 @@ class TestGradSync(unittest.TestCase):
                     if dp_ring_id is None:
                         dp_ring_id = int(op.attr("ring_id"))
                     else:
-                        assert dp_ring_id == int(
-                            op.attr("ring_id")
-                        ), "gradient synchronization of dp use different communication group [{}] and [{}]".format(
-                            dp_ring_id, int(op.attr("ring_id"))
+                        assert dp_ring_id == int(op.attr("ring_id")), (
+                            "gradient synchronization of dp use different communication group [{}] and [{}]".format(
+                                dp_ring_id, int(op.attr("ring_id"))
+                            )
                         )
                 elif allreduce_count in sp_sync_indices:
                     if sp_ring_id is None:
                         sp_ring_id = int(op.attr("ring_id"))
                     else:
-                        assert sp_ring_id == int(
-                            op.attr("ring_id")
-                        ), "gradient synchronization of sp use different communication group [{}] and [{}]".format(
-                            sp_ring_id, int(op.attr("ring_id"))
+                        assert sp_ring_id == int(op.attr("ring_id")), (
+                            "gradient synchronization of sp use different communication group [{}] and [{}]".format(
+                                sp_ring_id, int(op.attr("ring_id"))
+                            )
                         )
                 else:
                     raise AssertionError(
@@ -229,16 +229,16 @@ class TestGradSync(unittest.TestCase):
 
             elif is_data_parallel_scale_op(op):
                 if scale_count in dp_sync_indices:
-                    assert dp_scale == float(
-                        op.attr("scale")
-                    ), "gradient synchronization of dp use different scale [{}] and [{}]".format(
-                        dp_scale, int(op.attr("scale"))
+                    assert dp_scale == float(op.attr("scale")), (
+                        "gradient synchronization of dp use different scale [{}] and [{}]".format(
+                            dp_scale, int(op.attr("scale"))
+                        )
                     )
                 elif scale_count in sp_sync_indices:
-                    assert sp_scale == float(
-                        op.attr("scale")
-                    ), "gradient synchronization of sp use different scale [{}] and [{}]".format(
-                        sp_scale, int(op.attr("scale"))
+                    assert sp_scale == float(op.attr("scale")), (
+                        "gradient synchronization of sp use different scale [{}] and [{}]".format(
+                            sp_scale, int(op.attr("scale"))
+                        )
                     )
                 else:
                     raise AssertionError(

--- a/test/auto_parallel/test_static_sequence_parallel_pass.py
+++ b/test/auto_parallel/test_static_sequence_parallel_pass.py
@@ -176,56 +176,56 @@ class TestGradSync(unittest.TestCase):
         for op in ops:
             # check sequence parallel allgather
             if op.type == "all_gather":
-                assert (
-                    int(op.attr("nranks")) == 4
-                ), "sequence parallel allgather error with nranks [{}]".format(
-                    op.attr("nranks")
+                assert int(op.attr("nranks")) == 4, (
+                    "sequence parallel allgather error with nranks [{}]".format(
+                        op.attr("nranks")
+                    )
                 )
                 if sp_ring_id is None:
                     sp_ring_id = int(op.attr("ring_id"))
                 else:
-                    assert sp_ring_id == int(
-                        op.attr("ring_id")
-                    ), "sequence parallel allgather error with ring_id [{}]".format(
-                        op.attr("ring_id")
+                    assert sp_ring_id == int(op.attr("ring_id")), (
+                        "sequence parallel allgather error with ring_id [{}]".format(
+                            op.attr("ring_id")
+                        )
                     )
                 allgather_count += 1
 
             # check sequence parallel reducescatter
             elif op.type == "reduce_scatter":
-                assert (
-                    int(op.attr("nranks")) == 4
-                ), "sequence parallel reducescatter error with nranks [{}]".format(
-                    op.attr("nranks")
+                assert int(op.attr("nranks")) == 4, (
+                    "sequence parallel reducescatter error with nranks [{}]".format(
+                        op.attr("nranks")
+                    )
                 )
-                assert sp_ring_id == int(
-                    op.attr("ring_id")
-                ), "sequence parallel reducescatter error with ring_id [{}]".format(
-                    op.attr("ring_id")
+                assert sp_ring_id == int(op.attr("ring_id")), (
+                    "sequence parallel reducescatter error with ring_id [{}]".format(
+                        op.attr("ring_id")
+                    )
                 )
                 reducescatter_count += 1
 
             # check sequence parallel grad sync
             elif op.type == "c_allreduce_sum":
-                assert (
-                    "layer_norm" in op.output_arg_names[0]
-                ), f"sequence parallel reducescatter error grad sync var [{op.output_arg_names[0]}]"
-                assert sp_ring_id == int(
-                    op.attr("ring_id")
-                ), "sequence parallel reducescatter error with ring_id [{}]".format(
-                    op.attr("ring_id")
+                assert "layer_norm" in op.output_arg_names[0], (
+                    f"sequence parallel reducescatter error grad sync var [{op.output_arg_names[0]}]"
+                )
+                assert sp_ring_id == int(op.attr("ring_id")), (
+                    "sequence parallel reducescatter error with ring_id [{}]".format(
+                        op.attr("ring_id")
+                    )
                 )
                 allreduce_count += 1
 
-        assert (
-            allgather_count == 4
-        ), f"sequence parallel should have 4 allgather, but got [{allgather_count}]"
-        assert (
-            reducescatter_count == 4
-        ), f"sequence parallel should have 4 allgather, but got [{reducescatter_count}]"
-        assert (
-            allreduce_count == 4
-        ), f"sequence parallel should have 4 allgather, but got [{allreduce_count}]"
+        assert allgather_count == 4, (
+            f"sequence parallel should have 4 allgather, but got [{allgather_count}]"
+        )
+        assert reducescatter_count == 4, (
+            f"sequence parallel should have 4 allgather, but got [{reducescatter_count}]"
+        )
+        assert allreduce_count == 4, (
+            f"sequence parallel should have 4 allgather, but got [{allreduce_count}]"
+        )
 
 
 if __name__ == "__main__":

--- a/test/autograd/utils.py
+++ b/test/autograd/utils.py
@@ -30,23 +30,23 @@ def _product(t):
 
 
 def _get_item(t, idx):
-    assert isinstance(
-        t, paddle.base.framework.Variable
-    ), "The first argument t must be Tensor."
-    assert isinstance(
-        idx, int
-    ), "The second argument idx must be an int number."
+    assert isinstance(t, paddle.base.framework.Variable), (
+        "The first argument t must be Tensor."
+    )
+    assert isinstance(idx, int), (
+        "The second argument idx must be an int number."
+    )
     flat_t = paddle.reshape(t, [-1])
     return flat_t.__getitem__(idx)
 
 
 def _set_item(t, idx, value):
-    assert isinstance(
-        t, paddle.base.framework.Variable
-    ), "The first argument t must be Tensor."
-    assert isinstance(
-        idx, int
-    ), "The second argument idx must be an int number."
+    assert isinstance(t, paddle.base.framework.Variable), (
+        "The first argument t must be Tensor."
+    )
+    assert isinstance(idx, int), (
+        "The second argument idx must be an int number."
+    )
     flat_t = paddle.reshape(t, [-1])
     flat_t.__setitem__(idx, value)
     return paddle.reshape(flat_t, t.shape)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

使用性能更好，格式化效果更佳的 ruff format 替代 black 作为新的 formatter，由于我们很早就已经集成了 ruff lint，因此只是减少依赖而不会增加依赖

<!--

## 核心优势

通过集成 Ruff format，开发者可以享受到以下优势：

- 通过去除 black 对 python 环境依赖，极大降低了升级 formatter 带来的成本，后续无需考虑开发者本地 python 环境即可一键升级
- ruff 由 Rust 驱动，大幅加速 format 时间，降低开发者使用开发工具链的时间成本，减少 CI 时间，提升工程效率
- 格式化后呈现可读性更佳的效果，使得开发者更专注于代码开发而无需关心格式，阅读者也能够更加赏心悦目，极大增加了潜在贡献者的贡献意愿
- ruff 极大程度地兼容了 black 的格式化效果，能够平滑地替换现有的 black 配置
- ruff 更新频次高，能够快速响应社区反馈，持续优化格式化效果
- ruff 团队 Astral 最近开发的 ty 能够提供更强大的类型检查能力，后续可能与 ruff 集成，提供更好的开发体验
- PyTorch 最近已经完成迁移，追平竞品（在代码风格这块，我们一直做到了超越竞品，这次不能落后）

-->