### PR TITLE
[CodeStyle] `black -> ruff format` migration - part 36

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -99,7 +99,7 @@ repos:
 
             # | test/a.+
 
-            # | test/[b-h].+
+            | test/[b-h].+
 
             # | test/[i-k].+
 
@@ -155,7 +155,7 @@ repos:
 
             | test/a.+
 
-            | test/[b-h].+
+            # | test/[b-h].+
 
             | test/[i-k].+
 

--- a/test/cinn/utils/testing.py
+++ b/test/cinn/utils/testing.py
@@ -23,6 +23,6 @@ def assert_llir_equal(
     if isinstance(llir1, CinnLowerLevelIrJit):
         llir1_expr = llir1.convert_to_llir().body()
         llir2_expr = llir2.convert_to_llir().body()
-    assert comparer.compare(
-        llir1_expr, llir2_expr
-    ), f'llir1: {llir1} \n llir2: {llir2}'
+    assert comparer.compare(llir1_expr, llir2_expr), (
+        f'llir1: {llir1} \n llir2: {llir2}'
+    )

--- a/test/collective/collective_allgather_api.py
+++ b/test/collective/collective_allgather_api.py
@@ -114,9 +114,9 @@ class TestCollectiveAllgatherAPI(test_base.TestCollectiveAPIRunnerBase):
         indata = test_base.create_test_data(
             shape=(10, 1000), dtype=args["dtype"], seed=os.getpid()
         )
-        assert (
-            args['static_mode'] == 1
-        ), "collective_allgather_api only support static graph mode"
+        assert args['static_mode'] == 1, (
+            "collective_allgather_api only support static graph mode"
+        )
         result = (
             self.get_model_new(
                 train_prog, startup_prog, rank, dtype=args["dtype"]

--- a/test/collective/collective_alltoall_single.py
+++ b/test/collective/collective_alltoall_single.py
@@ -22,13 +22,13 @@ import paddle.distributed as dist
 
 class TestCollectiveAllToAllSingle(unittest.TestCase):
     def setUp(self):
-        assert (
-            not paddle.distributed.is_initialized()
-        ), "The distributed environment has not been initialized."
+        assert not paddle.distributed.is_initialized(), (
+            "The distributed environment has not been initialized."
+        )
         dist.init_parallel_env()
-        assert (
-            paddle.distributed.is_initialized()
-        ), "The distributed environment has been initialized."
+        assert paddle.distributed.is_initialized(), (
+            "The distributed environment has been initialized."
+        )
 
     def test_collective_alltoall_single(self):
         rank = dist.get_rank()
@@ -76,9 +76,9 @@ class TestCollectiveAllToAllSingle(unittest.TestCase):
 
     def tearDown(self):
         dist.destroy_process_group()
-        assert (
-            not paddle.distributed.is_initialized()
-        ), "The distributed environment has been deinitialized."
+        assert not paddle.distributed.is_initialized(), (
+            "The distributed environment has been deinitialized."
+        )
 
 
 if __name__ == '__main__':

--- a/test/collective/fleet/dygraph_group_sharded_stage1_fp16.py
+++ b/test/collective/fleet/dygraph_group_sharded_stage1_fp16.py
@@ -123,13 +123,13 @@ def train_mlp(
             "sharding_degree": 2,
         }
         strategy.hybrid_configs = hybrid_configs
-        strategy.hybrid_configs["sharding_configs"].use_reduce_avg = (
-            sharding_use_reduce_avg
-        )
+        strategy.hybrid_configs[
+            "sharding_configs"
+        ].use_reduce_avg = sharding_use_reduce_avg
         strategy.hybrid_configs["sharding_configs"].comm_overlap = comm_overlap
-        strategy.hybrid_configs["sharding_configs"].tensor_fusion = (
-            tensor_fusion
-        )
+        strategy.hybrid_configs[
+            "sharding_configs"
+        ].tensor_fusion = tensor_fusion
 
     fleet.init(is_collective=True, strategy=strategy)
     model = fleet.distributed_model(model)

--- a/test/collective/fleet/hybrid_parallel_sharding_model.py
+++ b/test/collective/fleet/hybrid_parallel_sharding_model.py
@@ -210,9 +210,9 @@ class TestDistMPTraining(unittest.TestCase):
             "mp_degree": 1,
             "pp_degree": 1,
         }
-        self.strategy.hybrid_configs["sharding_configs"].split_param = (
-            g_shard_split_param
-        )
+        self.strategy.hybrid_configs[
+            "sharding_configs"
+        ].split_param = g_shard_split_param
 
         fleet.init(is_collective=True, strategy=self.strategy)
         self.data = [
@@ -398,9 +398,9 @@ class TestShardingV2AllGather(unittest.TestCase):
             "mp_degree": 1,
             "pp_degree": 1,
         }
-        self.strategy.hybrid_configs["sharding_configs"].split_param = (
-            g_shard_split_param
-        )
+        self.strategy.hybrid_configs[
+            "sharding_configs"
+        ].split_param = g_shard_split_param
         fleet.init(is_collective=True, strategy=self.strategy)
         self.data = [
             np.random.randint(

--- a/test/collective/fleet/hybrid_parallel_sharding_model_with_fuse_optimizer_states_enabled.py
+++ b/test/collective/fleet/hybrid_parallel_sharding_model_with_fuse_optimizer_states_enabled.py
@@ -222,9 +222,9 @@ class TestDistMPTraining(unittest.TestCase):
             "mp_degree": 1,
             "pp_degree": 1,
         }
-        self.strategy.hybrid_configs["sharding_configs"].split_param = (
-            g_shard_split_param
-        )
+        self.strategy.hybrid_configs[
+            "sharding_configs"
+        ].split_param = g_shard_split_param
 
         fleet.init(is_collective=True, strategy=self.strategy)
         self.data = [

--- a/test/collective/fleet/parallel_dygraph_se_resnext.py
+++ b/test/collective/fleet/parallel_dygraph_se_resnext.py
@@ -212,9 +212,9 @@ class SeResNeXt(paddle.nn.Layer):
 
         self.layers = layers
         supported_layers = [50, 101, 152]
-        assert (
-            layers in supported_layers
-        ), f"supported layers are {supported_layers} but input layer is {layers}"
+        assert layers in supported_layers, (
+            f"supported layers are {supported_layers} but input layer is {layers}"
+        )
 
         if layers == 50:
             cardinality = 32

--- a/test/collective/fleet/parallel_dygraph_transformer.py
+++ b/test/collective/fleet/parallel_dygraph_transformer.py
@@ -885,9 +885,9 @@ class TransFormer(Layer):
         self._label_smooth_eps = label_smooth_eps
         self._trg_vocab_size = trg_vocab_size
         if weight_sharing:
-            assert (
-                src_vocab_size == trg_vocab_size
-            ), "Vocabularies in source and target should be same for weight sharing."
+            assert src_vocab_size == trg_vocab_size, (
+                "Vocabularies in source and target should be same for weight sharing."
+            )
         self._wrap_encoder_layer = WrapEncoderLayer(
             src_vocab_size,
             max_length,
@@ -924,9 +924,7 @@ class TransFormer(Layer):
         )
 
         if weight_sharing:
-            self._wrap_decoder_layer._prepare_decoder_layer._input_emb.weight = (
-                self._wrap_encoder_layer._prepare_encoder_layer._input_emb.weight
-            )
+            self._wrap_decoder_layer._prepare_decoder_layer._input_emb.weight = self._wrap_encoder_layer._prepare_encoder_layer._input_emb.weight
 
     def forward(self, enc_inputs, dec_inputs, label, weights):
         enc_output = self._wrap_encoder_layer(enc_inputs)

--- a/test/collective/new_api_per_op_and_group_intranode.py
+++ b/test/collective/new_api_per_op_and_group_intranode.py
@@ -42,9 +42,9 @@ def test_reducescatter(ep_group: Group, mode: str):
         * num_local_ranks
     )
 
-    assert paddle.allclose(
-        recv_tensor, expected_tensor
-    ), f"rank {local_rank}: reduce_scatter validation failed"
+    assert paddle.allclose(recv_tensor, expected_tensor), (
+        f"rank {local_rank}: reduce_scatter validation failed"
+    )
 
     if local_rank == 0:
         print(f'[Algo {mode}] primitive reducescatter... passed')
@@ -73,9 +73,9 @@ def test_alltoall(ep_group: Group, mode: str):
     )
 
     for i in range(num_local_ranks):
-        assert paddle.allclose(
-            recv_tensors[i], expected_tensor
-        ), f"rank {local_rank}: alltoall validation failed"
+        assert paddle.allclose(recv_tensors[i], expected_tensor), (
+            f"rank {local_rank}: alltoall validation failed"
+        )
 
     if local_rank == 0:
         print(f'[Algo {mode}] primitive alltoall... passed')
@@ -102,9 +102,9 @@ def test_scatter(ep_group: Group, mode: str):
     expected = paddle.ones(shape=[m, n], dtype=paddle.float32) * (
         local_rank + 1
     )
-    assert paddle.allclose(
-        recv_tensor, expected
-    ), f"rank {local_rank}: scatter validation failed"
+    assert paddle.allclose(recv_tensor, expected), (
+        f"rank {local_rank}: scatter validation failed"
+    )
 
     if local_rank == 0:
         print(f'[Algo {mode}] primitive scatter... passed')
@@ -126,9 +126,9 @@ def test_reduce(ep_group: Group, mode: str):
         res = paddle.ones(shape=[m, n], dtype=paddle.float32) * (
             num_local_ranks * (num_local_ranks + 1) / 2
         )
-        assert paddle.allclose(
-            gbl_x, res
-        ), f"rank {local_rank}: reduce validation failed"
+        assert paddle.allclose(gbl_x, res), (
+            f"rank {local_rank}: reduce validation failed"
+        )
         print(f'[Algo {mode}] primitive reduce... passed')
 
 
@@ -150,9 +150,9 @@ def test_all_gather(ep_group: Group, mode: str):
 
     for i in range(num_local_ranks):
         expected = paddle.ones(shape=[m, n], dtype=paddle.float32) * (i + 1)
-        assert paddle.allclose(
-            tensor_list[i], expected
-        ), f"rank {local_rank}: allgather validation failed"
+        assert paddle.allclose(tensor_list[i], expected), (
+            f"rank {local_rank}: allgather validation failed"
+        )
 
     if local_rank == 0:
         print(f'[Algo {mode}] primitive allgather... passed')
@@ -174,9 +174,9 @@ def test_broadcast(ep_group: Group, mode: str):
     dist.broadcast(gbl_x, src=0, group=ep_group)
 
     res = paddle.ones(shape=[m, n], dtype=paddle.float32) * 10
-    assert paddle.allclose(
-        gbl_x, res
-    ), f"rank {local_rank}: broadcast validation failed"
+    assert paddle.allclose(gbl_x, res), (
+        f"rank {local_rank}: broadcast validation failed"
+    )
 
     if local_rank == 0:
         print(f'[Algo {mode}] primitive broadcast... passed')
@@ -197,9 +197,9 @@ def test_all_reduce(ep_group: Group, mode: str):
         num_local_ranks * (num_local_ranks + 1) / 2
     )
 
-    assert paddle.allclose(
-        gbl_x, res
-    ), f"rank {local_rank}: all reduce validation failed"
+    assert paddle.allclose(gbl_x, res), (
+        f"rank {local_rank}: all reduce validation failed"
+    )
 
     if local_rank == 0:
         print(f'[Algo {mode}] primitive allreduce... passed')

--- a/test/collective/test_collective_deep_ep_alltoall_intranode.py
+++ b/test/collective/test_collective_deep_ep_alltoall_intranode.py
@@ -292,7 +292,9 @@ def test_main(
                     rank_prefix_matrix = handle[0]
                     assert (
                         gbl_num_tokens_per_rank[rank].item() == recv_x.shape[0]
-                    ), f'{gbl_num_tokens_per_rank[rank].item()} != {recv_x.shape[0]}'
+                    ), (
+                        f'{gbl_num_tokens_per_rank[rank].item()} != {recv_x.shape[0]}'
+                    )
                     assert (
                         gbl_num_tokens_per_expert.view([num_ranks, -1])[
                             rank
@@ -318,15 +320,13 @@ def test_main(
 
                         # Check `topk_weights`
                         if current_x is not x_pure_rand:
-                            recv_topk_weights[
-                                recv_topk_idx.equal(-1)
-                            ] = recv_topk_weights.amax(
-                                axis=1, keepdim=True
-                            ).expand_as(
-                                recv_topk_weights
-                            )[
-                                recv_topk_idx.equal(-1)
-                            ]
+                            recv_topk_weights[recv_topk_idx.equal(-1)] = (
+                                recv_topk_weights.amax(
+                                    axis=1, keepdim=True
+                                ).expand_as(recv_topk_weights)[
+                                    recv_topk_idx.equal(-1)
+                                ]
+                            )
                             # check_data(recv_topk_weights, rank_prefix_matrix)
 
                     # Test cached dispatch (must without top-k staffs)

--- a/test/collective/test_low_latency_all2all.py
+++ b/test/collective/test_low_latency_all2all.py
@@ -47,9 +47,9 @@ def test_main(
 
     # NOTES: the integers greater than 256 exceeds the BF16 precision limit
     rank_offset = 128
-    assert (
-        num_ranks - rank_offset < 257
-    ), 'Too many ranks (exceeding test precision limit)'
+    assert num_ranks - rank_offset < 257, (
+        'Too many ranks (exceeding test precision limit)'
+    )
 
     x = paddle.ones((num_tokens, hidden), dtype="bfloat16") * (
         rank - rank_offset
@@ -242,9 +242,9 @@ def test_loop():
     print("num_ranks: ", num_ranks, flush=True)
 
     num_tokens, hidden, num_topk, num_experts = 128, 7168, 8, 384
-    assert (
-        num_tokens <= num_max_tokens
-    ), "num_tokens must be less equal to num_max_tokens"
+    assert num_tokens <= num_max_tokens, (
+        "num_tokens must be less equal to num_max_tokens"
+    )
     num_rdma_ranks = num_ranks / 8
     num_rdma_bytes = deep_ep.Buffer.get_low_latency_rdma_size_hint(
         num_max_tokens, hidden, num_ranks, num_experts

--- a/test/collective/test_low_latency_all2all_two_stage.py
+++ b/test/collective/test_low_latency_all2all_two_stage.py
@@ -47,9 +47,9 @@ def test_main(
 
     # NOTES: the integers greater than 256 exceeds the BF16 precision limit
     rank_offset = 128
-    assert (
-        num_ranks - rank_offset < 257
-    ), 'Too many ranks (exceeding test precision limit)'
+    assert num_ranks - rank_offset < 257, (
+        'Too many ranks (exceeding test precision limit)'
+    )
 
     x = paddle.ones((num_tokens, hidden), dtype="bfloat16") * (
         rank - rank_offset
@@ -239,9 +239,9 @@ def test_loop():
     print("num_ranks: ", num_ranks, flush=True)
 
     num_tokens, hidden, num_topk, num_experts = 128, 8192, 8, 64
-    assert (
-        num_tokens <= num_max_tokens
-    ), "num_tokens must be less equal to num_max_tokens"
+    assert num_tokens <= num_max_tokens, (
+        "num_tokens must be less equal to num_max_tokens"
+    )
     num_rdma_ranks = num_ranks / 8
     num_local_experts = num_experts / num_ranks
     num_rdma_bytes = deep_ep.Buffer.get_low_latency_rdma_size_hint_two_stage(

--- a/test/cpp_extension/test_cpp_extension_jit.py
+++ b/test/cpp_extension/test_cpp_extension_jit.py
@@ -144,9 +144,9 @@ class TestCppExtensionJITInstall(unittest.TestCase):
 
     def _test_optional_tensor(self):
         x = custom_cpp_extension.optional_tensor(True)
-        assert (
-            x is None
-        ), "Return None when input parameter return_option = True"
+        assert x is None, (
+            "Return None when input parameter return_option = True"
+        )
         x = custom_cpp_extension.optional_tensor(False).numpy()
         x_np = np.ones(shape=[2, 2])
         np.testing.assert_array_equal(

--- a/test/cpp_extension/test_cpp_extension_setup.py
+++ b/test/cpp_extension/test_cpp_extension_setup.py
@@ -42,9 +42,9 @@ class TestCppExtensionSetupInstall(unittest.TestCase):
         custom_egg_path = [
             x for x in os.listdir(site_dir) if 'custom_cpp_extension' in x
         ]
-        assert (
-            len(custom_egg_path) == 1
-        ), f"Matched egg number is {len(custom_egg_path)}."
+        assert len(custom_egg_path) == 1, (
+            f"Matched egg number is {len(custom_egg_path)}."
+        )
         sys.path.append(os.path.join(site_dir, custom_egg_path[0]))
         #################################
 
@@ -139,9 +139,9 @@ class TestCppExtensionSetupInstall(unittest.TestCase):
         import custom_cpp_extension
 
         x = custom_cpp_extension.optional_tensor(True)
-        assert (
-            x is None
-        ), "Return None when input parameter return_option = True"
+        assert x is None, (
+            "Return None when input parameter return_option = True"
+        )
         x = custom_cpp_extension.optional_tensor(False).numpy()
         x_np = np.ones(shape=[2, 2])
         np.testing.assert_array_equal(

--- a/test/cpp_extension/test_mixed_extension_setup.py
+++ b/test/cpp_extension/test_mixed_extension_setup.py
@@ -114,9 +114,9 @@ class TestCppExtensionSetupInstall(unittest.TestCase):
         custom_egg_path = [
             x for x in os.listdir(site_dir) if 'mix_relu_extension' in x
         ]
-        assert (
-            len(custom_egg_path) == 1
-        ), f"Matched egg number is {len(custom_egg_path)}."
+        assert len(custom_egg_path) == 1, (
+            f"Matched egg number is {len(custom_egg_path)}."
+        )
         sys.path.append(os.path.join(site_dir, custom_egg_path[0]))
         #################################
 

--- a/test/custom_op/test_custom_op_relu_model_static_multidevice.py
+++ b/test/custom_op/test_custom_op_relu_model_static_multidevice.py
@@ -84,9 +84,9 @@ class TestCustomOpReluModelStaticMultiDevice(unittest.TestCase):
                 count = paddle.framework.core.get_cuda_device_count()
             elif paddle.framework.core.is_compiled_with_xpu():
                 count = paddle.framework.core.get_xpu_device_count()
-            assert (
-                count > 1
-            ), "TestCustomOpReluModelStaticMultiDevice needs at least two devices"
+            assert count > 1, (
+                "TestCustomOpReluModelStaticMultiDevice needs at least two devices"
+            )
 
             for id in range(count):
                 loss_custom = np.load(

--- a/test/custom_op/test_custom_optional.py
+++ b/test/custom_op/test_custom_optional.py
@@ -142,9 +142,9 @@ def optional_inplace_dynamic_add(custom_func, device, dtype, np_x, np_y):
         else:
             outx = 2 * x
             outy = None
-        assert (
-            outy is None
-        ), "The output `outy` of optional_inplace_dynamic_add should be None"
+        assert outy is None, (
+            "The output `outy` of optional_inplace_dynamic_add should be None"
+        )
 
     out = outx + outy if outy is not None else outx
     out.backward()
@@ -379,9 +379,9 @@ def optional_inplace_vector_dynamic_add(
         else:
             outx = 2 * x
             outy = None
-        assert (
-            outy is None
-        ), "The output `outy` of optional_inplace_dynamic_add should be None"
+        assert outy is None, (
+            "The output `outy` of optional_inplace_dynamic_add should be None"
+        )
 
     if outy is not None:
         out = outx

--- a/test/custom_op/test_custom_relu_op_setup.py
+++ b/test/custom_op/test_custom_relu_op_setup.py
@@ -170,9 +170,9 @@ class TestNewCustomOpSetUpInstall(unittest.TestCase):
         custom_egg_path = [
             x for x in os.listdir(site_dir) if 'custom_relu_module_setup' in x
         ]
-        assert (
-            len(custom_egg_path) == 2
-        ), f"Matched egg number is {len(custom_egg_path)}."
+        assert len(custom_egg_path) == 2, (
+            f"Matched egg number is {len(custom_egg_path)}."
+        )
         sys.path.append(os.path.join(site_dir, custom_egg_path[0]))
 
         # usage: import the package directly

--- a/test/custom_op/test_custom_relu_op_xpu_setup.py
+++ b/test/custom_op/test_custom_relu_op_xpu_setup.py
@@ -77,9 +77,9 @@ class TestNewCustomOpXpuSetUpInstall(unittest.TestCase):
             for x in os.listdir(site_dir)
             if 'custom_relu_xpu_module_setup' in x
         ]
-        assert (
-            len(custom_egg_path) == 1
-        ), f"Matched egg number is {len(custom_egg_path)}."
+        assert len(custom_egg_path) == 1, (
+            f"Matched egg number is {len(custom_egg_path)}."
+        )
         sys.path.append(os.path.join(site_dir, custom_egg_path[0]))
 
         # usage: import the package directly

--- a/test/custom_op/test_inference_gap_setup.py
+++ b/test/custom_op/test_inference_gap_setup.py
@@ -57,9 +57,9 @@ class TestNewCustomOpSetUpInstall(unittest.TestCase):
             custom_egg_path = [
                 x for x in os.listdir(site_dir) if 'gap_op_setup' in x
             ]
-            assert (
-                len(custom_egg_path) == 1
-            ), f"Matched egg number is {len(custom_egg_path)}."
+            assert len(custom_egg_path) == 1, (
+                f"Matched egg number is {len(custom_egg_path)}."
+            )
             sys.path.append(os.path.join(site_dir, custom_egg_path[0]))
 
             # usage: import the package directly

--- a/test/deprecated/auto_parallel/auto_parallel_gpt_model.py
+++ b/test/deprecated/auto_parallel/auto_parallel_gpt_model.py
@@ -71,9 +71,9 @@ class MultiHeadAttention(nn.Layer):
         self.recompute_granularity = recompute_granularity
 
         self.head_dim = embed_dim // num_heads
-        assert (
-            self.head_dim * num_heads == self.embed_dim
-        ), "embed_dim must be divisible by num_heads"
+        assert self.head_dim * num_heads == self.embed_dim, (
+            "embed_dim must be divisible by num_heads"
+        )
         if self.fuse:
             assert self.kdim == embed_dim
             assert self.vdim == embed_dim

--- a/test/deprecated/custom_op/test_custom_raw_op_kernel_op_deprecated.py
+++ b/test/deprecated/custom_op/test_custom_raw_op_kernel_op_deprecated.py
@@ -38,9 +38,9 @@ def prepare_module_path():
     else:
         site_dir = site.getsitepackages()[0]
     custom_egg_path = [x for x in os.listdir(site_dir) if MODULE_NAME in x]
-    assert (
-        len(custom_egg_path) == 2
-    ), f"Matched egg number is {len(custom_egg_path)}."
+    assert len(custom_egg_path) == 2, (
+        f"Matched egg number is {len(custom_egg_path)}."
+    )
     sys.path.append(os.path.join(site_dir, custom_egg_path[0]))
 
 

--- a/test/deprecated/ir/inference/auto_scan_test.py
+++ b/test/deprecated/ir/inference/auto_scan_test.py
@@ -431,9 +431,9 @@ class PassAutoScanTest(AutoScanTest):
             report_multiple_bugs=False,
         )
         settings.load_profile("ci")
-        assert (
-            passes is not None
-        ), "Parameter of passes must be defined in function run_and_statis."
+        assert passes is not None, (
+            "Parameter of passes must be defined in function run_and_statis."
+        )
         self.passes = passes
 
         self.add_ignore_pass_case()

--- a/test/deprecated/ir/inference/program_config.py
+++ b/test/deprecated/ir/inference/program_config.py
@@ -67,9 +67,9 @@ class TensorConfig:
             self.dtype = self.data.dtype
             self.shape = self.data.shape
         else:
-            assert (
-                shape is not None
-            ), "While data_gen is not defined, shape must not be None"
+            assert shape is not None, (
+                "While data_gen is not defined, shape must not be None"
+            )
             self.data = np.random.normal(0.0, 1.0, shape).astype(np.float32)
             self.shape = shape
             self.dtype = self.data.dtype
@@ -291,9 +291,9 @@ class ProgramConfig:
         return log_str
 
     def set_input_type(self, _type: np.dtype) -> None:
-        assert (
-            _type in self.supported_cast_type or _type is None
-        ), "PaddleTRT only supports FP32 / FP16 IO"
+        assert _type in self.supported_cast_type or _type is None, (
+            "PaddleTRT only supports FP32 / FP16 IO"
+        )
 
         ver = paddle.inference.get_trt_compile_version()
         trt_version = ver[0] * 1000 + ver[1] * 100 + ver[2] * 10
@@ -611,9 +611,9 @@ def create_quant_model(
 
     def _get_op_output_var_names(op):
         """ """
-        assert isinstance(
-            op, (IrNode, Operator)
-        ), "The input op should be IrNode or Operator."
+        assert isinstance(op, (IrNode, Operator)), (
+            "The input op should be IrNode or Operator."
+        )
         var_names = []
         op_name = op.name() if isinstance(op, IrNode) else op.type
         if op_name not in op_real_in_out_name:

--- a/test/deprecated/legacy_test/auto_parallel_op_test.py
+++ b/test/deprecated/legacy_test/auto_parallel_op_test.py
@@ -192,12 +192,12 @@ def get_test_info_and_generated_test_path(
 
 
 def check_auto_parallel_info(op_test):
-    assert hasattr(
-        op_test, 'python_api'
-    ), "If you want to check auto parallel, please set python_api in setUp function."
-    assert hasattr(
-        op_test, 'placements'
-    ), "If you want to check auto parallel, please set placements in setUp function."
+    assert hasattr(op_test, 'python_api'), (
+        "If you want to check auto parallel, please set python_api in setUp function."
+    )
+    assert hasattr(op_test, 'placements'), (
+        "If you want to check auto parallel, please set placements in setUp function."
+    )
 
 
 def dump_test_info(
@@ -770,9 +770,9 @@ class AutoParallelGradChecker(AutoParallelForwardChecker):
         return eager_vs
 
     def get_output_dict(self, np_outputs, api_outputs, outputs_sig):
-        assert len(api_outputs) <= len(
-            outputs_sig
-        ), f"forward api outputs length must be the less than or equal to KernelSignature outputs,but receive {len(api_outputs)} and {len(outputs_sig)}"
+        assert len(api_outputs) <= len(outputs_sig), (
+            f"forward api outputs length must be the less than or equal to KernelSignature outputs,but receive {len(api_outputs)} and {len(outputs_sig)}"
+        )
         output_dict = {}
         for i in range(len(api_outputs)):
             output_name = outputs_sig[i]

--- a/test/deprecated/legacy_test/test_auto_parallel_completion_deprecated.py
+++ b/test/deprecated/legacy_test/test_auto_parallel_completion_deprecated.py
@@ -237,9 +237,9 @@ class AttentionLayer(nn.Layer):
         self.vdim = self.embed_dim
         self.num_heads = num_heads
         self.head_dim = self.embed_dim // self.num_heads
-        assert (
-            self.head_dim * self.num_heads == self.embed_dim
-        ), "embed_dim must be divisible by num_heads"
+        assert self.head_dim * self.num_heads == self.embed_dim, (
+            "embed_dim must be divisible by num_heads"
+        )
         self.dropout_ratio = dropout_ratio
         self.initializer_range = initializer_range
         self.training = True
@@ -448,9 +448,9 @@ class DecoderLayer(nn.Layer):
         self.attn_mask = None
 
         self.head_dim = self.embed_dim // self.num_heads
-        assert (
-            self.head_dim * self.num_heads == self.embed_dim
-        ), "embed_dim must be divisible by num_heads"
+        assert self.head_dim * self.num_heads == self.embed_dim, (
+            "embed_dim must be divisible by num_heads"
+        )
         self.word_embeddings = nn.Embedding(
             self.vocab_size,
             self.hidden_size,

--- a/test/deprecated/legacy_test/test_auto_parallel_completion_gpt_deprecated.py
+++ b/test/deprecated/legacy_test/test_auto_parallel_completion_gpt_deprecated.py
@@ -63,9 +63,9 @@ class MultiHeadAttention(nn.Layer):
         self.fuse = fuse
 
         self.head_dim = embed_dim // num_heads
-        assert (
-            self.head_dim * num_heads == self.embed_dim
-        ), "embed_dim must be divisible by num_heads"
+        assert self.head_dim * num_heads == self.embed_dim, (
+            "embed_dim must be divisible by num_heads"
+        )
 
         if topo is None or topo.mp_info.size == 1:
             if self.fuse:

--- a/test/deprecated/legacy_test/test_auto_parallel_partitioner_deprecated.py
+++ b/test/deprecated/legacy_test/test_auto_parallel_partitioner_deprecated.py
@@ -605,9 +605,9 @@ class AttentionLayer(nn.Layer):
         self.vdim = self.embed_dim
         self.num_heads = num_heads
         self.head_dim = self.embed_dim // self.num_heads
-        assert (
-            self.head_dim * self.num_heads == self.embed_dim
-        ), "embed_dim must be divisible by num_heads"
+        assert self.head_dim * self.num_heads == self.embed_dim, (
+            "embed_dim must be divisible by num_heads"
+        )
         self.dropout_ratio = dropout_ratio
         self.initializer_range = initializer_range
         self.training = True
@@ -1019,9 +1019,9 @@ class DecoderLayer(nn.Layer):
         self.attn_mask = None
 
         self.head_dim = self.embed_dim // self.num_heads
-        assert (
-            self.head_dim * self.num_heads == self.embed_dim
-        ), "embed_dim must be divisible by num_heads"
+        assert self.head_dim * self.num_heads == self.embed_dim, (
+            "embed_dim must be divisible by num_heads"
+        )
         self.word_embeddings = nn.Embedding(
             self.vocab_size,
             self.hidden_size,

--- a/test/deprecated/legacy_test/test_auto_parallel_partitioner_gpt_deprecated.py
+++ b/test/deprecated/legacy_test/test_auto_parallel_partitioner_gpt_deprecated.py
@@ -109,9 +109,9 @@ class MultiHeadAttention(nn.Layer):
         self.fuse = fuse
 
         self.head_dim = embed_dim // num_heads
-        assert (
-            self.head_dim * num_heads == self.embed_dim
-        ), "embed_dim must be divisible by num_heads"
+        assert self.head_dim * num_heads == self.embed_dim, (
+            "embed_dim must be divisible by num_heads"
+        )
 
         if topo is None or topo.mp_info.size == 1:
             if self.fuse:

--- a/test/deprecated/legacy_test/test_generator_dataloader_deprecated.py
+++ b/test/deprecated/legacy_test/test_generator_dataloader_deprecated.py
@@ -134,9 +134,9 @@ class TestBase(unittest.TestCase):
                 for _ in range(EPOCH_NUM):
                     step = 0
                     for d in py_reader():
-                        assert len(d) == len(
-                            places
-                        ), f"{len(d)} != {len(places)}"
+                        assert len(d) == len(places), (
+                            f"{len(d)} != {len(places)}"
+                        )
                         for i, item in enumerate(d):
                             image = item['image']
                             label = item['label']

--- a/test/deprecated/legacy_test/test_program_prune_backward_deprecated.py
+++ b/test/deprecated/legacy_test/test_program_prune_backward_deprecated.py
@@ -363,12 +363,12 @@ def optimization_in_pylayer_net(with_optimize=False):
 
 class TestProgramPruneBackward(unittest.TestCase):
     def program_compare(self, program_a, program_b):
-        assert isinstance(
-            program_a, base.framework.Program
-        ), "The first argument should be base.framework.Program."
-        assert isinstance(
-            program_b, base.framework.Program
-        ), "The second argument should be base.framework Program."
+        assert isinstance(program_a, base.framework.Program), (
+            "The first argument should be base.framework.Program."
+        )
+        assert isinstance(program_b, base.framework.Program), (
+            "The second argument should be base.framework Program."
+        )
 
         self.assertEqual(len(program_a.blocks), len(program_b.blocks))
         for idx in range(len(program_a.blocks)):

--- a/test/deprecated/legacy_test/test_py_func_op_deprecated.py
+++ b/test/deprecated/legacy_test/test_py_func_op_deprecated.py
@@ -148,18 +148,18 @@ def simple_fc_net(img, label, use_py_func_op):
             x=(loss, dummy_var),
             out=(loss_out, dummy_var_out),
         )
-        assert (
-            loss == loss_out and dummy_var == dummy_var_out
-        ), "py_func failed with multi input and output"
+        assert loss == loss_out and dummy_var == dummy_var_out, (
+            "py_func failed with multi input and output"
+        )
 
         paddle.static.py_func(
             func=dummy_func_with_multi_input_output,
             x=[loss, dummy_var],
             out=[loss_out, dummy_var_out],
         )
-        assert (
-            loss == loss_out and dummy_var == dummy_var_out
-        ), "py_func failed with multi input and output"
+        assert loss == loss_out and dummy_var == dummy_var_out, (
+            "py_func failed with multi input and output"
+        )
 
     loss = paddle.mean(loss)
     return loss

--- a/test/deprecated/legacy_test/test_weight_normalization_deprecated.py
+++ b/test/deprecated/legacy_test/test_weight_normalization_deprecated.py
@@ -95,9 +95,7 @@ class TestWeightNormalization(unittest.TestCase):
                     low=1,
                     high=5,
                     size=(
-                        self.batch_size
-                        if i == 0
-                        else sum(lod_level_i)  # noqa: F821
+                        self.batch_size if i == 0 else sum(lod_level_i)  # noqa: F821
                     ),
                 ).tolist()
                 data_lod.append(lod_level_i)

--- a/test/deprecated/quantization/test_moving_average_abs_max_scale_op_deprecated.py
+++ b/test/deprecated/quantization/test_moving_average_abs_max_scale_op_deprecated.py
@@ -62,9 +62,9 @@ class TestMovingAverageAbsMaxScaleOp(unittest.TestCase):
             for op in main_program.blocks[0].ops
             if op.type == 'moving_average_abs_max_scale'
         ]
-        assert (
-            len(moving_average_abs_max_scale_ops) == 1
-        ), "The number of moving_average_abs_max_scale_ops should be 1."
+        assert len(moving_average_abs_max_scale_ops) == 1, (
+            "The number of moving_average_abs_max_scale_ops should be 1."
+        )
 
         place = paddle.CUDAPlace(0) if use_cuda else paddle.CPUPlace()
         exe = paddle.static.Executor(place)

--- a/test/deprecated/quantization/test_quantization_pass_deprecated.py
+++ b/test/deprecated/quantization/test_quantization_pass_deprecated.py
@@ -761,9 +761,9 @@ def quant_dequant_residual_block(num, quant_skip_pattern=None):
             pool_add = paddle.add(pool1, pool2)
             pool_add = paddle.nn.functional.relu(pool_add)
     elif isinstance(quant_skip_pattern, list):
-        assert (
-            len(quant_skip_pattern) > 1
-        ), 'test config error: the len of quant_skip_pattern list should be greater than 1.'
+        assert len(quant_skip_pattern) > 1, (
+            'test config error: the len of quant_skip_pattern list should be greater than 1.'
+        )
         with paddle.static.name_scope(quant_skip_pattern[0]):
             pool1 = paddle.nn.functional.avg_pool2d(
                 hidden, kernel_size=2, stride=2

--- a/test/deprecated/quantization/test_weight_quantization_mobilenetv1_deprecated.py
+++ b/test/deprecated/quantization/test_weight_quantization_mobilenetv1_deprecated.py
@@ -38,9 +38,9 @@ def _set_variable_data(scope, place, var_name, np_value):
     '''
     Set the value of var node by name, if the node exits,
     '''
-    assert isinstance(
-        np_value, np.ndarray
-    ), 'The type of value should be numpy array.'
+    assert isinstance(np_value, np.ndarray), (
+        'The type of value should be numpy array.'
+    )
     var_node = scope.find_var(var_name)
     if var_node is not None:
         tensor = var_node.get_tensor()

--- a/test/distributed_passes/dist_pass_test_base.py
+++ b/test/distributed_passes/dist_pass_test_base.py
@@ -153,9 +153,9 @@ class DistPassTestBase(unittest.TestCase):
         with paddle.static.scope_guard(scope):
             exe.run(startup_prog)
             for batch_id, input_data in enumerate(reader()):
-                assert len(input_data) == len(
-                    inputs
-                ), f"{len(input_data)} vs {len(inputs)}"
+                assert len(input_data) == len(inputs), (
+                    f"{len(input_data)} vs {len(inputs)}"
+                )
                 feed = dict(zip(inputs, input_data))
                 fetch_values = exe.run(main_prog, feed=feed, fetch_list=outputs)
                 if paddle.distributed.get_rank() == 0:

--- a/test/dygraph_to_static/test_closure_analysis.py
+++ b/test/dygraph_to_static/test_closure_analysis.py
@@ -38,9 +38,9 @@ class JudgeVisitor(gast.NodeVisitor):
         expected = self.ans.get(node.name, set())
         exp_mod = self.mod.get(node.name, set())
         assert scope.existed_vars() == expected, "Not Equals."
-        assert (
-            scope.modified_vars() == exp_mod
-        ), f"Not Equals in function:{node.name} . expect {exp_mod} , but get {scope.modified_vars()}"
+        assert scope.modified_vars() == exp_mod, (
+            f"Not Equals in function:{node.name} . expect {exp_mod} , but get {scope.modified_vars()}"
+        )
         self.generic_visit(node)
 
 
@@ -51,9 +51,9 @@ class JudgePushPopVisitor(gast.NodeVisitor):
     def visit_FunctionDef(self, node):
         scope = node.pd_scope
         expected = self.pp_var.get(node.name, set())
-        assert (
-            scope.push_pop_vars == expected
-        ), f"Not Equals in function:{node.name} . expect {expected} , but get {scope.push_pop_vars}"
+        assert scope.push_pop_vars == expected, (
+            f"Not Equals in function:{node.name} . expect {expected} , but get {scope.push_pop_vars}"
+        )
         self.generic_visit(node)
 
 

--- a/test/dygraph_to_static/test_pylayer.py
+++ b/test/dygraph_to_static/test_pylayer.py
@@ -292,9 +292,9 @@ class TestPyLayerBase(unittest.TestCase):
         self.to_static: bool = False
 
     def _run(self, *input_args, **input_kwargs):
-        assert getattr(
-            self, "dygraph_func", None
-        ), "Please setting `self.dygraph_func` before calling `self._run`"
+        assert getattr(self, "dygraph_func", None), (
+            "Please setting `self.dygraph_func` before calling `self._run`"
+        )
 
         with enable_to_static_guard(self.to_static):
             paddle.set_device(self.place)
@@ -318,9 +318,9 @@ class TestPyLayerBase(unittest.TestCase):
         dygraph_inp_args = []
         static_inp_args = []
         for v in args:
-            assert isinstance(
-                v, paddle.Tensor
-            ), f"Only Support `paddle.Tensor` now, but got {type(v)}"
+            assert isinstance(v, paddle.Tensor), (
+                f"Only Support `paddle.Tensor` now, but got {type(v)}"
+            )
             stop_gradient = v.stop_gradient
             # detach from the compute graph to turn `dygraph_inp_args` and `static_inp_args` into leaf nodes
             v = v.detach()
@@ -334,9 +334,9 @@ class TestPyLayerBase(unittest.TestCase):
         static_inp_kwargs = {}
         for k, v in kwargs.items():
             stop_gradient = v.stop_gradient
-            assert isinstance(
-                v, paddle.Tensor
-            ), "Only Support `paddle.Tensor` now"
+            assert isinstance(v, paddle.Tensor), (
+                "Only Support `paddle.Tensor` now"
+            )
             # detach from the compute graph to turn `dygraph_inp_kwargs` and `static_inp_kwargs` into leaf nodes
             v = v.detach()
             dygraph_inp_kwargs[k] = v.clone()

--- a/test/dygraph_to_static/test_resnet.py
+++ b/test/dygraph_to_static/test_resnet.py
@@ -151,9 +151,9 @@ class ResNet(paddle.nn.Layer):
 
         self.layers = layers
         supported_layers = [50, 101, 152]
-        assert (
-            layers in supported_layers
-        ), f"supported layers are {supported_layers} but input layer is {layers}"
+        assert layers in supported_layers, (
+            f"supported layers are {supported_layers} but input layer is {layers}"
+        )
 
         if layers == 50:
             depth = [3, 4, 6, 3]

--- a/test/dygraph_to_static/test_se_resnet.py
+++ b/test/dygraph_to_static/test_se_resnet.py
@@ -228,9 +228,9 @@ class SeResNeXt(paddle.nn.Layer):
 
         self.layers = layers
         supported_layers = [50, 101, 152]
-        assert (
-            layers in supported_layers
-        ), f"supported layers are {supported_layers} but input layer is {layers}"
+        assert layers in supported_layers, (
+            f"supported layers are {supported_layers} but input layer is {layers}"
+        )
 
         if layers == 50:
             cardinality = 32

--- a/test/dygraph_to_static/test_warning.py
+++ b/test/dygraph_to_static/test_warning.py
@@ -50,9 +50,9 @@ class TestReturnNoneInIfelse(Dy2StTestBase):
             flag = False
             for warn in w:
                 if (
-                    issubclass(warn.category, UserWarning)
-                ) and "Set var to 'None' in ifelse block might lead to error." in str(
-                    warn.message
+                    (issubclass(warn.category, UserWarning))
+                    and "Set var to 'None' in ifelse block might lead to error."
+                    in str(warn.message)
                 ):
                     flag = True
                     break

--- a/test/dygraph_to_static/transformer_dygraph_model.py
+++ b/test/dygraph_to_static/transformer_dygraph_model.py
@@ -646,9 +646,9 @@ class Transformer(Layer):
             src_word_embedder,
         )
         if weight_sharing:
-            assert (
-                src_vocab_size == trg_vocab_size
-            ), "Vocabularies in source and target should be same for weight sharing."
+            assert src_vocab_size == trg_vocab_size, (
+                "Vocabularies in source and target should be same for weight sharing."
+            )
             trg_word_embedder = src_word_embedder
         else:
             trg_word_embedder = Embedder(

--- a/test/fp8/test_fp8_deep_gemm.py
+++ b/test/fp8/test_fp8_deep_gemm.py
@@ -202,9 +202,9 @@ def test_m_grouped_gemm_masked() -> None:
                         ref_out[j, : masked_m[j].item()],
                     )
                     print("diff:", diff)
-                    assert (
-                        diff < 0.001
-                    ), f"{m=}, {k=}, {n=}, {j=}, masked_m={masked_m[j]}, {num_groups=}, {diff:.5f}"
+                    assert diff < 0.001, (
+                        f"{m=}, {k=}, {n=}, {j=}, masked_m={masked_m[j]}, {num_groups=}, {diff:.5f}"
+                    )
 
     print()
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

使用性能更好，格式化效果更佳的 ruff format 替代 black 作为新的 formatter，由于我们很早就已经集成了 ruff lint，因此只是减少依赖而不会增加依赖

<!--

## 核心优势

通过集成 Ruff format，开发者可以享受到以下优势：

- 通过去除 black 对 python 环境依赖，极大降低了升级 formatter 带来的成本，后续无需考虑开发者本地 python 环境即可一键升级
- ruff 由 Rust 驱动，大幅加速 format 时间，降低开发者使用开发工具链的时间成本，减少 CI 时间，提升工程效率
- 格式化后呈现可读性更佳的效果，使得开发者更专注于代码开发而无需关心格式，阅读者也能够更加赏心悦目，极大增加了潜在贡献者的贡献意愿
- ruff 极大程度地兼容了 black 的格式化效果，能够平滑地替换现有的 black 配置
- ruff 更新频次高，能够快速响应社区反馈，持续优化格式化效果
- ruff 团队 Astral 最近开发的 ty 能够提供更强大的类型检查能力，后续可能与 ruff 集成，提供更好的开发体验
- PyTorch 最近已经完成迁移，追平竞品（在代码风格这块，我们一直做到了超越竞品，这次不能落后）

-->