### PR TITLE
[CodeStyle] `black -> ruff format` migration - part 37

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -101,7 +101,7 @@ repos:
 
             # | test/[b-h].+
 
-            # | test/[i-k].+
+            | test/[i-k].+
 
             # | test/l.+
 
@@ -157,7 +157,7 @@ repos:
 
             | test/[b-h].+
 
-            | test/[i-k].+
+            # | test/[i-k].+
 
             | test/l.+
 

--- a/test/ipu/test_ipu_strategy_ipu.py
+++ b/test/ipu/test_ipu_strategy_ipu.py
@@ -48,9 +48,9 @@ class TestIpuStrategy(unittest.TestCase):
             try:
                 ipu_strategy.set_options({option_name: set_value})
                 new_value = ipu_strategy.get_option(option_name)
-                assert (
-                    new_value == set_value
-                ), f"set {option_name} to {set_value} failed"
+                assert new_value == set_value, (
+                    f"set {option_name} to {set_value} failed"
+                )
             except:
                 raise Exception(f"set {option_name} to {set_value} failed")
 
@@ -78,13 +78,13 @@ class TestIpuStrategy(unittest.TestCase):
         for k, v in options.items():
             ipu_strategy.set_options({k: v})
             if isinstance(v, list):
-                assert (
-                    v.sort() == ipu_strategy.get_option(k).sort()
-                ), f"set {k} to {v} failed "
+                assert v.sort() == ipu_strategy.get_option(k).sort(), (
+                    f"set {k} to {v} failed "
+                )
             else:
-                assert v == ipu_strategy.get_option(
-                    k
-                ), f"set {k} to {v} failed "
+                assert v == ipu_strategy.get_option(k), (
+                    f"set {k} to {v} failed "
+                )
 
         # The custom logger need 2 int as inputs
         logger = lambda progress, total: print(

--- a/test/ir/inference/auto_scan_test.py
+++ b/test/ir/inference/auto_scan_test.py
@@ -465,9 +465,9 @@ class PassAutoScanTest(AutoScanTest):
             report_multiple_bugs=False,
         )
         settings.load_profile("ci")
-        assert (
-            passes is not None
-        ), "Parameter of passes must be defined in function run_and_statis."
+        assert passes is not None, (
+            "Parameter of passes must be defined in function run_and_statis."
+        )
         self.passes = passes
 
         self.add_ignore_pass_case()
@@ -979,7 +979,9 @@ class TrtLayerAutoScanTest(AutoScanTest):
                         assert any(
                             op.name() == "pd_op.tensorrt_engine"
                             for op in trt_program.global_block().ops
-                        ), "trt_program does not contain any tensorrt_engine ops."
+                        ), (
+                            "trt_program does not contain any tensorrt_engine ops."
+                        )
 
                         feed_data = prog_config.get_feed_data()
                         for key, value in feed_data.items():

--- a/test/ir/inference/dist_llama_inference_model.py
+++ b/test/ir/inference/dist_llama_inference_model.py
@@ -191,9 +191,9 @@ class FusedMultiTransformerBase(nn.Layer):
 
         self.embed_dim = config.embed_dim
         self.head_dim = config.embed_dim // config.num_heads
-        assert (
-            self.head_dim * config.num_heads == config.embed_dim
-        ), "embed_dim must be divisible by num_heads"
+        assert self.head_dim * config.num_heads == config.embed_dim, (
+            "embed_dim must be divisible by num_heads"
+        )
 
         # tensor model parallel
         if config.nranks > 1:
@@ -406,9 +406,9 @@ class FusedMultiTransformerBase(nn.Layer):
 
     def get_attr(self, attrs, idx):
         if isinstance(attrs, (list, tuple)):
-            assert (
-                len(attrs) == self.num_layers
-            ), f"length of attrs is {len(attrs)} is not equal to self.num_layers {self.num_layers}"
+            assert len(attrs) == self.num_layers, (
+                f"length of attrs is {len(attrs)} is not equal to self.num_layers {self.num_layers}"
+            )
             return attrs[idx]
         return attrs
 

--- a/test/ir/inference/program_config.py
+++ b/test/ir/inference/program_config.py
@@ -66,9 +66,9 @@ class TensorConfig:
             self.dtype = self.data.dtype
             self.shape = self.data.shape
         else:
-            assert (
-                shape is not None
-            ), "While data_gen is not defined, shape must not be None"
+            assert shape is not None, (
+                "While data_gen is not defined, shape must not be None"
+            )
             self.data = np.random.normal(0.0, 1.0, shape).astype(np.float32)
             self.shape = shape
             self.dtype = self.data.dtype
@@ -291,9 +291,9 @@ class ProgramConfig:
         return log_str
 
     def set_input_type(self, _type: np.dtype) -> None:
-        assert (
-            _type in self.supported_cast_type or _type is None
-        ), "PaddleTRT only supports FP32 / FP16 IO"
+        assert _type in self.supported_cast_type or _type is None, (
+            "PaddleTRT only supports FP32 / FP16 IO"
+        )
 
         ver = paddle.inference.get_trt_compile_version()
         trt_version = ver[0] * 1000 + ver[1] * 100 + ver[2] * 10
@@ -629,9 +629,9 @@ def create_quant_model(
 
     def _get_op_output_var_names(op):
         """ """
-        assert isinstance(
-            op, (IrNode, Operator)
-        ), "The input op should be IrNode or Operator."
+        assert isinstance(op, (IrNode, Operator)), (
+            "The input op should be IrNode or Operator."
+        )
         var_names = []
         op_name = op.name() if isinstance(op, IrNode) else op.type
         if op_name not in op_real_in_out_name:

--- a/test/ir/inference/test_trt_convert_isnan_v2.py
+++ b/test/ir/inference/test_trt_convert_isnan_v2.py
@@ -91,7 +91,9 @@ class TrtConvertIsnanV2Test(TrtLayerAutoScanTest):
 
             yield program_config
 
-    def sample_predictor_configs(self, program_config) -> Generator[
+    def sample_predictor_configs(
+        self, program_config
+    ) -> Generator[
         tuple[
             paddle_infer.Config, tuple[int, int], tuple[float, float] | float
         ],

--- a/test/ir/inference/test_trt_explicit_quantization_resnet.py
+++ b/test/ir/inference/test_trt_explicit_quantization_resnet.py
@@ -33,9 +33,9 @@ class ResNet:
             else self.prefix_name + '_'
         )
         supported_layers = [34, 50, 101, 152]
-        assert (
-            layers in supported_layers
-        ), f"supported layers are {supported_layers} but input layer is {layers}"
+        assert layers in supported_layers, (
+            f"supported layers are {supported_layers} but input layer is {layers}"
+        )
 
         if layers == 34 or layers == 50:
             depth = [3, 4, 6, 3]

--- a/test/ir/pir/cinn/performance/test_cinn_large_shape_reduce.py
+++ b/test/ir/pir/cinn/performance/test_cinn_large_shape_reduce.py
@@ -41,9 +41,9 @@ class TestLayer(unittest.TestCase):
         if to_static:
             paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
-                assert (
-                    with_prim
-                ), "with_cinn=True but with_prim=False is unsupported"
+                assert with_prim, (
+                    "with_cinn=True but with_prim=False is unsupported"
+                )
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)
             else:
                 net = paddle.jit.to_static(net, backend=None, full_graph=True)

--- a/test/ir/pir/cinn/symbolic/test_sub_graph_batch_norm.py
+++ b/test/ir/pir/cinn/symbolic/test_sub_graph_batch_norm.py
@@ -78,9 +78,9 @@ class TestLayer(unittest.TestCase):
         if to_static:
             paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
-                assert (
-                    with_prim
-                ), "with_cinn=True but with_prim=False is unsupported"
+                assert with_prim, (
+                    "with_cinn=True but with_prim=False is unsupported"
+                )
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)
             else:
                 net = paddle.jit.to_static(net, backend=None, full_graph=True)

--- a/test/ir/pir/cinn/symbolic/test_sub_graph_chatglm2_0_st.py
+++ b/test/ir/pir/cinn/symbolic/test_sub_graph_chatglm2_0_st.py
@@ -223,9 +223,9 @@ class TestLayer(unittest.TestCase):
         if to_static:
             paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
-                assert (
-                    with_prim
-                ), "with_cinn=True but with_prim=False is unsupported"
+                assert with_prim, (
+                    "with_cinn=True but with_prim=False is unsupported"
+                )
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)
             else:
                 net = paddle.jit.to_static(net, backend=None, full_graph=True)

--- a/test/ir/pir/cinn/symbolic/test_sub_graph_chatglm2_1_st.py
+++ b/test/ir/pir/cinn/symbolic/test_sub_graph_chatglm2_1_st.py
@@ -93,9 +93,9 @@ class TestLayer(unittest.TestCase):
         if to_static:
             paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
-                assert (
-                    with_prim
-                ), "with_cinn=True but with_prim=False is unsupported"
+                assert with_prim, (
+                    "with_cinn=True but with_prim=False is unsupported"
+                )
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)
             else:
                 net = paddle.jit.to_static(net, backend=None, full_graph=True)

--- a/test/ir/pir/cinn/symbolic/test_sub_graph_chatglm2_2_st.py
+++ b/test/ir/pir/cinn/symbolic/test_sub_graph_chatglm2_2_st.py
@@ -64,9 +64,9 @@ class TestLayer(unittest.TestCase):
         if to_static:
             paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
-                assert (
-                    with_prim
-                ), "with_cinn=True but with_prim=False is unsupported"
+                assert with_prim, (
+                    "with_cinn=True but with_prim=False is unsupported"
+                )
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)
             else:
                 net = paddle.jit.to_static(net, backend=None, full_graph=True)

--- a/test/ir/pir/cinn/symbolic/test_sub_graph_chatglm2_3_st.py
+++ b/test/ir/pir/cinn/symbolic/test_sub_graph_chatglm2_3_st.py
@@ -70,9 +70,9 @@ class TestLayer(unittest.TestCase):
         if to_static:
             paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
-                assert (
-                    with_prim
-                ), "with_cinn=True but with_prim=False is unsupported"
+                assert with_prim, (
+                    "with_cinn=True but with_prim=False is unsupported"
+                )
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)
             else:
                 net = paddle.jit.to_static(net, backend=None, full_graph=True)

--- a/test/ir/pir/cinn/symbolic/test_sub_graph_chatglm2_4_st.py
+++ b/test/ir/pir/cinn/symbolic/test_sub_graph_chatglm2_4_st.py
@@ -87,9 +87,9 @@ class TestLayer(unittest.TestCase):
         if to_static:
             paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
-                assert (
-                    with_prim
-                ), "with_cinn=True but with_prim=False is unsupported"
+                assert with_prim, (
+                    "with_cinn=True but with_prim=False is unsupported"
+                )
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)
             else:
                 net = paddle.jit.to_static(net, backend=None, full_graph=True)

--- a/test/ir/pir/cinn/symbolic/test_sub_graph_chatglm2_5_st.py
+++ b/test/ir/pir/cinn/symbolic/test_sub_graph_chatglm2_5_st.py
@@ -94,9 +94,9 @@ class TestLayer(unittest.TestCase):
         if to_static:
             paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
-                assert (
-                    with_prim
-                ), "with_cinn=True but with_prim=False is unsupported"
+                assert with_prim, (
+                    "with_cinn=True but with_prim=False is unsupported"
+                )
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)
             else:
                 net = paddle.jit.to_static(net, backend=None, full_graph=True)

--- a/test/ir/pir/cinn/symbolic/test_sub_graph_stable_diffusion_0_st.py
+++ b/test/ir/pir/cinn/symbolic/test_sub_graph_stable_diffusion_0_st.py
@@ -86,9 +86,9 @@ class TestLayer(unittest.TestCase):
         if to_static:
             paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
-                assert (
-                    with_prim
-                ), "with_cinn=True but with_prim=False is unsupported"
+                assert with_prim, (
+                    "with_cinn=True but with_prim=False is unsupported"
+                )
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)
             else:
                 net = paddle.jit.to_static(net, backend=None, full_graph=True)

--- a/test/ir/pir/cinn/symbolic/test_sub_graph_stable_diffusion_10_st.py
+++ b/test/ir/pir/cinn/symbolic/test_sub_graph_stable_diffusion_10_st.py
@@ -276,9 +276,9 @@ class TestLayer(unittest.TestCase):
         if to_static:
             paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
-                assert (
-                    with_prim
-                ), "with_cinn=True but with_prim=False is unsupported"
+                assert with_prim, (
+                    "with_cinn=True but with_prim=False is unsupported"
+                )
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)
             else:
                 net = paddle.jit.to_static(net, backend=None, full_graph=True)

--- a/test/ir/pir/cinn/symbolic/test_sub_graph_stable_diffusion_11_st.py
+++ b/test/ir/pir/cinn/symbolic/test_sub_graph_stable_diffusion_11_st.py
@@ -86,9 +86,9 @@ class TestLayer(unittest.TestCase):
         if to_static:
             paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
-                assert (
-                    with_prim
-                ), "with_cinn=True but with_prim=False is unsupported"
+                assert with_prim, (
+                    "with_cinn=True but with_prim=False is unsupported"
+                )
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)
             else:
                 net = paddle.jit.to_static(net, backend=None, full_graph=True)

--- a/test/ir/pir/cinn/symbolic/test_sub_graph_stable_diffusion_12_st.py
+++ b/test/ir/pir/cinn/symbolic/test_sub_graph_stable_diffusion_12_st.py
@@ -53,9 +53,9 @@ class TestLayer(unittest.TestCase):
         if to_static:
             paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
-                assert (
-                    with_prim
-                ), "with_cinn=True but with_prim=False is unsupported"
+                assert with_prim, (
+                    "with_cinn=True but with_prim=False is unsupported"
+                )
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)
             else:
                 net = paddle.jit.to_static(net, backend=None, full_graph=True)

--- a/test/ir/pir/cinn/symbolic/test_sub_graph_stable_diffusion_13_st.py
+++ b/test/ir/pir/cinn/symbolic/test_sub_graph_stable_diffusion_13_st.py
@@ -273,9 +273,9 @@ class TestLayer(unittest.TestCase):
         if to_static:
             paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
-                assert (
-                    with_prim
-                ), "with_cinn=True but with_prim=False is unsupported"
+                assert with_prim, (
+                    "with_cinn=True but with_prim=False is unsupported"
+                )
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)
             else:
                 net = paddle.jit.to_static(net, backend=None, full_graph=True)

--- a/test/ir/pir/cinn/symbolic/test_sub_graph_stable_diffusion_14_st.py
+++ b/test/ir/pir/cinn/symbolic/test_sub_graph_stable_diffusion_14_st.py
@@ -86,9 +86,9 @@ class TestLayer(unittest.TestCase):
         if to_static:
             paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
-                assert (
-                    with_prim
-                ), "with_cinn=True but with_prim=False is unsupported"
+                assert with_prim, (
+                    "with_cinn=True but with_prim=False is unsupported"
+                )
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)
             else:
                 net = paddle.jit.to_static(net, backend=None, full_graph=True)

--- a/test/ir/pir/cinn/symbolic/test_sub_graph_stable_diffusion_15_st.py
+++ b/test/ir/pir/cinn/symbolic/test_sub_graph_stable_diffusion_15_st.py
@@ -73,9 +73,9 @@ class TestLayer(unittest.TestCase):
         if to_static:
             paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
-                assert (
-                    with_prim
-                ), "with_cinn=True but with_prim=False is unsupported"
+                assert with_prim, (
+                    "with_cinn=True but with_prim=False is unsupported"
+                )
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)
             else:
                 net = paddle.jit.to_static(net, backend=None, full_graph=True)

--- a/test/ir/pir/cinn/symbolic/test_sub_graph_stable_diffusion_16_st.py
+++ b/test/ir/pir/cinn/symbolic/test_sub_graph_stable_diffusion_16_st.py
@@ -86,9 +86,9 @@ class TestLayer(unittest.TestCase):
         if to_static:
             paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
-                assert (
-                    with_prim
-                ), "with_cinn=True but with_prim=False is unsupported"
+                assert with_prim, (
+                    "with_cinn=True but with_prim=False is unsupported"
+                )
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)
             else:
                 net = paddle.jit.to_static(net, backend=None, full_graph=True)

--- a/test/ir/pir/cinn/symbolic/test_sub_graph_stable_diffusion_17_st.py
+++ b/test/ir/pir/cinn/symbolic/test_sub_graph_stable_diffusion_17_st.py
@@ -53,9 +53,9 @@ class TestLayer(unittest.TestCase):
         if to_static:
             paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
-                assert (
-                    with_prim
-                ), "with_cinn=True but with_prim=False is unsupported"
+                assert with_prim, (
+                    "with_cinn=True but with_prim=False is unsupported"
+                )
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)
             else:
                 net = paddle.jit.to_static(net, backend=None, full_graph=True)

--- a/test/ir/pir/cinn/symbolic/test_sub_graph_stable_diffusion_18_st.py
+++ b/test/ir/pir/cinn/symbolic/test_sub_graph_stable_diffusion_18_st.py
@@ -273,9 +273,9 @@ class TestLayer(unittest.TestCase):
         if to_static:
             paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
-                assert (
-                    with_prim
-                ), "with_cinn=True but with_prim=False is unsupported"
+                assert with_prim, (
+                    "with_cinn=True but with_prim=False is unsupported"
+                )
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)
             else:
                 net = paddle.jit.to_static(net, backend=None, full_graph=True)

--- a/test/ir/pir/cinn/symbolic/test_sub_graph_stable_diffusion_19_st.py
+++ b/test/ir/pir/cinn/symbolic/test_sub_graph_stable_diffusion_19_st.py
@@ -86,9 +86,9 @@ class TestLayer(unittest.TestCase):
         if to_static:
             paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
-                assert (
-                    with_prim
-                ), "with_cinn=True but with_prim=False is unsupported"
+                assert with_prim, (
+                    "with_cinn=True but with_prim=False is unsupported"
+                )
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)
             else:
                 net = paddle.jit.to_static(net, backend=None, full_graph=True)

--- a/test/ir/pir/cinn/symbolic/test_sub_graph_stable_diffusion_1_st.py
+++ b/test/ir/pir/cinn/symbolic/test_sub_graph_stable_diffusion_1_st.py
@@ -86,9 +86,9 @@ class TestLayer(unittest.TestCase):
         if to_static:
             paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
-                assert (
-                    with_prim
-                ), "with_cinn=True but with_prim=False is unsupported"
+                assert with_prim, (
+                    "with_cinn=True but with_prim=False is unsupported"
+                )
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)
             else:
                 net = paddle.jit.to_static(net, backend=None, full_graph=True)

--- a/test/ir/pir/cinn/symbolic/test_sub_graph_stable_diffusion_20_st.py
+++ b/test/ir/pir/cinn/symbolic/test_sub_graph_stable_diffusion_20_st.py
@@ -75,9 +75,9 @@ class TestLayer(unittest.TestCase):
         if to_static:
             paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
-                assert (
-                    with_prim
-                ), "with_cinn=True but with_prim=False is unsupported"
+                assert with_prim, (
+                    "with_cinn=True but with_prim=False is unsupported"
+                )
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)
             else:
                 net = paddle.jit.to_static(net, backend=None, full_graph=True)

--- a/test/ir/pir/cinn/symbolic/test_sub_graph_stable_diffusion_21_st.py
+++ b/test/ir/pir/cinn/symbolic/test_sub_graph_stable_diffusion_21_st.py
@@ -86,9 +86,9 @@ class TestLayer(unittest.TestCase):
         if to_static:
             paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
-                assert (
-                    with_prim
-                ), "with_cinn=True but with_prim=False is unsupported"
+                assert with_prim, (
+                    "with_cinn=True but with_prim=False is unsupported"
+                )
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)
             else:
                 net = paddle.jit.to_static(net, backend=None, full_graph=True)

--- a/test/ir/pir/cinn/symbolic/test_sub_graph_stable_diffusion_22_st.py
+++ b/test/ir/pir/cinn/symbolic/test_sub_graph_stable_diffusion_22_st.py
@@ -86,9 +86,9 @@ class TestLayer(unittest.TestCase):
         if to_static:
             paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
-                assert (
-                    with_prim
-                ), "with_cinn=True but with_prim=False is unsupported"
+                assert with_prim, (
+                    "with_cinn=True but with_prim=False is unsupported"
+                )
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)
             else:
                 net = paddle.jit.to_static(net, backend=None, full_graph=True)

--- a/test/ir/pir/cinn/symbolic/test_sub_graph_stable_diffusion_23_st.py
+++ b/test/ir/pir/cinn/symbolic/test_sub_graph_stable_diffusion_23_st.py
@@ -65,9 +65,9 @@ class TestLayer(unittest.TestCase):
         if to_static:
             paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
-                assert (
-                    with_prim
-                ), "with_cinn=True but with_prim=False is unsupported"
+                assert with_prim, (
+                    "with_cinn=True but with_prim=False is unsupported"
+                )
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)
             else:
                 net = paddle.jit.to_static(net, backend=None, full_graph=True)

--- a/test/ir/pir/cinn/symbolic/test_sub_graph_stable_diffusion_24_st.py
+++ b/test/ir/pir/cinn/symbolic/test_sub_graph_stable_diffusion_24_st.py
@@ -62,9 +62,9 @@ class TestLayer(unittest.TestCase):
         if to_static:
             paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
-                assert (
-                    with_prim
-                ), "with_cinn=True but with_prim=False is unsupported"
+                assert with_prim, (
+                    "with_cinn=True but with_prim=False is unsupported"
+                )
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)
             else:
                 net = paddle.jit.to_static(net, backend=None, full_graph=True)

--- a/test/ir/pir/cinn/symbolic/test_sub_graph_stable_diffusion_25_st.py
+++ b/test/ir/pir/cinn/symbolic/test_sub_graph_stable_diffusion_25_st.py
@@ -58,9 +58,9 @@ class TestLayer(unittest.TestCase):
         if to_static:
             paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
-                assert (
-                    with_prim
-                ), "with_cinn=True but with_prim=False is unsupported"
+                assert with_prim, (
+                    "with_cinn=True but with_prim=False is unsupported"
+                )
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)
             else:
                 net = paddle.jit.to_static(net, backend=None, full_graph=True)

--- a/test/ir/pir/cinn/symbolic/test_sub_graph_stable_diffusion_2_st.py
+++ b/test/ir/pir/cinn/symbolic/test_sub_graph_stable_diffusion_2_st.py
@@ -122,9 +122,9 @@ class TestLayer(unittest.TestCase):
         if to_static:
             paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
-                assert (
-                    with_prim
-                ), "with_cinn=True but with_prim=False is unsupported"
+                assert with_prim, (
+                    "with_cinn=True but with_prim=False is unsupported"
+                )
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)
             else:
                 net = paddle.jit.to_static(net, backend=None, full_graph=True)

--- a/test/ir/pir/cinn/symbolic/test_sub_graph_stable_diffusion_3_st.py
+++ b/test/ir/pir/cinn/symbolic/test_sub_graph_stable_diffusion_3_st.py
@@ -54,9 +54,9 @@ class TestLayer(unittest.TestCase):
         if to_static:
             paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
-                assert (
-                    with_prim
-                ), "with_cinn=True but with_prim=False is unsupported"
+                assert with_prim, (
+                    "with_cinn=True but with_prim=False is unsupported"
+                )
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)
             else:
                 net = paddle.jit.to_static(net, backend=None, full_graph=True)

--- a/test/ir/pir/cinn/symbolic/test_sub_graph_stable_diffusion_4_st.py
+++ b/test/ir/pir/cinn/symbolic/test_sub_graph_stable_diffusion_4_st.py
@@ -76,9 +76,9 @@ class TestLayer(unittest.TestCase):
         if to_static:
             paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
-                assert (
-                    with_prim
-                ), "with_cinn=True but with_prim=False is unsupported"
+                assert with_prim, (
+                    "with_cinn=True but with_prim=False is unsupported"
+                )
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)
             else:
                 net = paddle.jit.to_static(net, backend=None, full_graph=True)

--- a/test/ir/pir/cinn/symbolic/test_sub_graph_stable_diffusion_5_st.py
+++ b/test/ir/pir/cinn/symbolic/test_sub_graph_stable_diffusion_5_st.py
@@ -82,9 +82,9 @@ class TestLayer(unittest.TestCase):
         if to_static:
             paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
-                assert (
-                    with_prim
-                ), "with_cinn=True but with_prim=False is unsupported"
+                assert with_prim, (
+                    "with_cinn=True but with_prim=False is unsupported"
+                )
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)
             else:
                 net = paddle.jit.to_static(net, backend=None, full_graph=True)

--- a/test/ir/pir/cinn/symbolic/test_sub_graph_stable_diffusion_6_st.py
+++ b/test/ir/pir/cinn/symbolic/test_sub_graph_stable_diffusion_6_st.py
@@ -72,9 +72,9 @@ class TestLayer(unittest.TestCase):
         if to_static:
             paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
-                assert (
-                    with_prim
-                ), "with_cinn=True but with_prim=False is unsupported"
+                assert with_prim, (
+                    "with_cinn=True but with_prim=False is unsupported"
+                )
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)
             else:
                 net = paddle.jit.to_static(net, backend=None, full_graph=True)

--- a/test/ir/pir/cinn/symbolic/test_sub_graph_stable_diffusion_7_st.py
+++ b/test/ir/pir/cinn/symbolic/test_sub_graph_stable_diffusion_7_st.py
@@ -86,9 +86,9 @@ class TestLayer(unittest.TestCase):
         if to_static:
             paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
-                assert (
-                    with_prim
-                ), "with_cinn=True but with_prim=False is unsupported"
+                assert with_prim, (
+                    "with_cinn=True but with_prim=False is unsupported"
+                )
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)
             else:
                 net = paddle.jit.to_static(net, backend=None, full_graph=True)

--- a/test/ir/pir/cinn/symbolic/test_sub_graph_stable_diffusion_8_st.py
+++ b/test/ir/pir/cinn/symbolic/test_sub_graph_stable_diffusion_8_st.py
@@ -73,9 +73,9 @@ class TestLayer(unittest.TestCase):
         if to_static:
             paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
-                assert (
-                    with_prim
-                ), "with_cinn=True but with_prim=False is unsupported"
+                assert with_prim, (
+                    "with_cinn=True but with_prim=False is unsupported"
+                )
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)
             else:
                 net = paddle.jit.to_static(net, backend=None, full_graph=True)

--- a/test/ir/pir/cinn/symbolic/test_sub_graph_stable_diffusion_9_st.py
+++ b/test/ir/pir/cinn/symbolic/test_sub_graph_stable_diffusion_9_st.py
@@ -53,9 +53,9 @@ class TestLayer(unittest.TestCase):
         if to_static:
             paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
-                assert (
-                    with_prim
-                ), "with_cinn=True but with_prim=False is unsupported"
+                assert with_prim, (
+                    "with_cinn=True but with_prim=False is unsupported"
+                )
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)
             else:
                 net = paddle.jit.to_static(net, backend=None, full_graph=True)

--- a/test/ir/pir/test_special_op_translator.py
+++ b/test/ir/pir/test_special_op_translator.py
@@ -564,9 +564,9 @@ class TestShareBufferOpTranscriber(unittest.TestCase):
                     outputs={"Out": y, "XOut": x},
                 )
             l = pir.translate_to_pir(main_program.desc)
-            assert (
-                l.global_block().ops[2].name() == "pd_op.share_data_"
-            ), "share_buffer should be translated to share_data_"
+            assert l.global_block().ops[2].name() == "pd_op.share_data_", (
+                "share_buffer should be translated to share_data_"
+            )
 
 
 class TestDataOp(unittest.TestCase):

--- a/test/ir/pir/translator/test_op_translator.py
+++ b/test/ir/pir/translator/test_op_translator.py
@@ -75,12 +75,12 @@ class TestOpWithBackwardTranslator(unittest.TestCase):
     def check(self):
         self.build_model()
         pir_program = pir.translate_to_pir(self.main_program.desc)
-        assert hasattr(
-            self, "forward_op_type"
-        ), "forward_op_type should be specified!"
-        assert hasattr(
-            self, "backward_op_type"
-        ), "backward_op_type should be specified!"
+        assert hasattr(self, "forward_op_type"), (
+            "forward_op_type should be specified!"
+        )
+        assert hasattr(self, "backward_op_type"), (
+            "backward_op_type should be specified!"
+        )
         serialized_pir_program = str(pir_program)
         assert self.forward_op_type in serialized_pir_program, (
             self.forward_op_type


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

使用性能更好，格式化效果更佳的 ruff format 替代 black 作为新的 formatter，由于我们很早就已经集成了 ruff lint，因此只是减少依赖而不会增加依赖

<!--

## 核心优势

通过集成 Ruff format，开发者可以享受到以下优势：

- 通过去除 black 对 python 环境依赖，极大降低了升级 formatter 带来的成本，后续无需考虑开发者本地 python 环境即可一键升级
- ruff 由 Rust 驱动，大幅加速 format 时间，降低开发者使用开发工具链的时间成本，减少 CI 时间，提升工程效率
- 格式化后呈现可读性更佳的效果，使得开发者更专注于代码开发而无需关心格式，阅读者也能够更加赏心悦目，极大增加了潜在贡献者的贡献意愿
- ruff 极大程度地兼容了 black 的格式化效果，能够平滑地替换现有的 black 配置
- ruff 更新频次高，能够快速响应社区反馈，持续优化格式化效果
- ruff 团队 Astral 最近开发的 ty 能够提供更强大的类型检查能力，后续可能与 ruff 集成，提供更好的开发体验
- PyTorch 最近已经完成迁移，追平竞品（在代码风格这块，我们一直做到了超越竞品，这次不能落后）

-->