### PR TITLE
[CodeStyle] `black -> ruff format` migration - part 38

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -103,7 +103,7 @@ repos:
 
             # | test/[i-k].+
 
-            # | test/l.+
+            | test/l.+
 
             # | test/[m-z].+
 
@@ -159,7 +159,7 @@ repos:
 
             | test/[i-k].+
 
-            | test/l.+
+            # | test/l.+
 
             | test/[m-z].+
 

--- a/test/legacy_test/auto_parallel_op_test.py
+++ b/test/legacy_test/auto_parallel_op_test.py
@@ -191,12 +191,12 @@ def get_test_info_and_generated_test_path(
 
 
 def check_auto_parallel_info(op_test):
-    assert hasattr(
-        op_test, 'python_api'
-    ), "If you want to check auto parallel, please set python_api in setUp function."
-    assert hasattr(
-        op_test, 'placements'
-    ), "If you want to check auto parallel, please set placements in setUp function."
+    assert hasattr(op_test, 'python_api'), (
+        "If you want to check auto parallel, please set python_api in setUp function."
+    )
+    assert hasattr(op_test, 'placements'), (
+        "If you want to check auto parallel, please set placements in setUp function."
+    )
 
 
 def dump_test_info(
@@ -769,9 +769,9 @@ class AutoParallelGradChecker(AutoParallelForwardChecker):
         return eager_vs
 
     def get_output_dict(self, np_outputs, api_outputs, outputs_sig):
-        assert len(api_outputs) <= len(
-            outputs_sig
-        ), f"forward api outputs length must be the less than or equal to KernelSignature outputs,but receive {len(api_outputs)} and {len(outputs_sig)}"
+        assert len(api_outputs) <= len(outputs_sig), (
+            f"forward api outputs length must be the less than or equal to KernelSignature outputs,but receive {len(api_outputs)} and {len(outputs_sig)}"
+        )
         output_dict = {}
         for i in range(len(api_outputs)):
             output_name = outputs_sig[i]

--- a/test/legacy_test/ctr_dataset_reader.py
+++ b/test/legacy_test/ctr_dataset_reader.py
@@ -113,9 +113,9 @@ def prepare_data():
         lines = f.readlines()
     err_info = "wrong meta format"
     assert len(lines) == 2, err_info
-    assert (
-        'dnn_input_dim:' in lines[0] and 'lr_input_dim:' in lines[1]
-    ), err_info
+    assert 'dnn_input_dim:' in lines[0] and 'lr_input_dim:' in lines[1], (
+        err_info
+    )
     res = map(int, [_.split(':')[1] for _ in lines])
     res = list(res)
     dnn_input_dim = res[0]

--- a/test/legacy_test/dist_ctr_reader.py
+++ b/test/legacy_test/dist_ctr_reader.py
@@ -163,9 +163,9 @@ def load_data_meta():
     lines = read_data('data.meta.txt')
     err_info = "wrong meta format"
     assert len(lines) == 2, err_info
-    assert (
-        'dnn_input_dim:' in lines[0] and 'lr_input_dim:' in lines[1]
-    ), err_info
+    assert 'dnn_input_dim:' in lines[0] and 'lr_input_dim:' in lines[1], (
+        err_info
+    )
     res = map(int, [_.split(':')[1] for _ in lines])
     res = list(res)
     logger.info(f'dnn input dim: {res[0]}')

--- a/test/legacy_test/dist_mnist_dgc.py
+++ b/test/legacy_test/dist_mnist_dgc.py
@@ -106,9 +106,9 @@ class TestDistMnistDGC(TestDistRunnerBase):
                 ),
             )
         if use_dgc:
-            assert (
-                build_strategy is not None
-            ), "build_strategy can be None with dgc"
+            assert build_strategy is not None, (
+                "build_strategy can be None with dgc"
+            )
             paddle.distributed.collective._init_parallel_env("nccl")
             _insert_comm_op(opt, avg_cost, build_strategy)
         else:

--- a/test/legacy_test/dist_se_resnext.py
+++ b/test/legacy_test/dist_se_resnext.py
@@ -44,9 +44,9 @@ class SE_ResNeXt:
     def net(self, input, class_dim=1000):
         layers = self.layers
         supported_layers = [50, 101, 152]
-        assert (
-            layers in supported_layers
-        ), f"supported layers are {supported_layers} but input layer is {layers}"
+        assert layers in supported_layers, (
+            f"supported layers are {supported_layers} but input layer is {layers}"
+        )
         if layers == 50:
             cardinality = 32
             reduction_ratio = 16

--- a/test/legacy_test/ernie_utils/moe_layer.py
+++ b/test/legacy_test/ernie_utils/moe_layer.py
@@ -233,8 +233,8 @@ def fuse_logging(gate_logits, combine_weights, token_type_ids):
                 combine_weights, token_type_ids
             )
         else:
-            gate_experts_per_token = paddle.count_nonzero(combine_weights) / (
-                gate_logits.shape[0]
+            gate_experts_per_token = (
+                paddle.count_nonzero(combine_weights) / (gate_logits.shape[0])
             )
 
         return (

--- a/test/legacy_test/op_test.py
+++ b/test/legacy_test/op_test.py
@@ -719,9 +719,9 @@ class OpTest(unittest.TestCase):
             return isinstance(input, (np.ndarray, np.generic))
 
         def infer_dtype(numpy_dict, dtype_set):
-            assert isinstance(
-                numpy_dict, dict
-            ), "self.inputs, self.outputs must be numpy_dict"
+            assert isinstance(numpy_dict, dict), (
+                "self.inputs, self.outputs must be numpy_dict"
+            )
             # the inputs are as follows:
             # case 1: inputs = {'X': x}
             # case 2: inputs = {'X': (x, x_lod)}
@@ -1111,9 +1111,9 @@ class OpTest(unittest.TestCase):
                     inputs_grad_dict[name] = v
                 continue
             if var_proto.duplicable:
-                assert isinstance(
-                    np_list[name], list
-                ), f"Duplicable {name} should be set as list"
+                assert isinstance(np_list[name], list), (
+                    f"Duplicable {name} should be set as list"
+                )
                 var_list = []
                 slot_name = name
                 for name, np_value in np_list[slot_name]:
@@ -1162,9 +1162,9 @@ class OpTest(unittest.TestCase):
         for name in api_outs:
             np_api = np.array(api_outs[name])
             np_dyg = np.array(dygraph_outs[name])
-            assert (
-                np_api.shape == np_dyg.shape
-            ), f"Operator ({self.op_type}) : Output ({name}) shape mismatch, expect shape is {np_dyg.shape}, but actual shape is {np_api.shape}"
+            assert np_api.shape == np_dyg.shape, (
+                f"Operator ({self.op_type}) : Output ({name}) shape mismatch, expect shape is {np_dyg.shape}, but actual shape is {np_api.shape}"
+            )
             np.testing.assert_allclose(
                 np_api,
                 np_dyg,
@@ -1198,9 +1198,9 @@ class OpTest(unittest.TestCase):
                 return {a: [b] for a, b in zip(output_sig, ret_tuple)}
             else:
                 # [assumption]: return multi-Tensor in a single output. such as paddle.split()
-                assert (
-                    len(output_sig) == 1
-                ), "Don't support multi-output with multi-tensor output. (May be you can use set `python_out_sig`, see `test_squeeze2_op` as a example.)"
+                assert len(output_sig) == 1, (
+                    "Don't support multi-output with multi-tensor output. (May be you can use set `python_out_sig`, see `test_squeeze2_op` as a example.)"
+                )
                 return {output_sig[0]: ret_tuple}
 
         def cal_python_api(python_api, args, kernel_sig):
@@ -1273,9 +1273,9 @@ class OpTest(unittest.TestCase):
                 return None
             if not hasattr(self, "python_api"):
                 print(kernel_sig)
-            assert hasattr(
-                self, "python_api"
-            ), f"Detect there is KernelSignature for `{self.op_type}` op, please set the `self.python_api` if you set check_dygraph = True"
+            assert hasattr(self, "python_api"), (
+                f"Detect there is KernelSignature for `{self.op_type}` op, please set the `self.python_api` if you set check_dygraph = True"
+            )
             args = OpTestUtils.prepare_python_api_arguments(
                 self.python_api,
                 dygraph_tensor_inputs,
@@ -1376,9 +1376,9 @@ class OpTest(unittest.TestCase):
                 return None
             if not hasattr(self, "python_api"):
                 print(kernel_sig)
-            assert hasattr(
-                self, "python_api"
-            ), f"Detect there is KernelSignature for `{self.op_type}` op, please set the `self.python_api` if you set check_dygraph = True"
+            assert hasattr(self, "python_api"), (
+                f"Detect there is KernelSignature for `{self.op_type}` op, please set the `self.python_api` if you set check_dygraph = True"
+            )
             return kernel_sig
 
     def get_ir_input_attr_dict_and_feed(self, stop_gradient):
@@ -1442,9 +1442,9 @@ class OpTest(unittest.TestCase):
                 return {a: [b] for a, b in zip(output_sig, ret_tuple)}
             else:
                 # [assumption]: return multi-Tensor in a single output. such as paddle.split()
-                assert (
-                    len(output_sig) == 1
-                ), "Don't support multi-output with multi-tensor output. (May be you can use set `python_out_sig`, see `test_squeeze2_op` as a example.)"
+                assert len(output_sig) == 1, (
+                    "Don't support multi-output with multi-tensor output. (May be you can use set `python_out_sig`, see `test_squeeze2_op` as a example.)"
+                )
                 return {output_sig[0]: ret_tuple}
 
         # get kernel signature
@@ -1570,9 +1570,9 @@ class OpTest(unittest.TestCase):
                 return_numpy=False,
                 scope=new_scope,
             )
-            assert len(outs) == len(
-                ir_outs
-            ), "Fetch result should have same length when executed in pir"
+            assert len(outs) == len(ir_outs), (
+                "Fetch result should have same length when executed in pir"
+            )
 
             check_method = np.testing.assert_array_equal
             if os.getenv("FLAGS_PIR_OPTEST_RELAX_CHECK", None) == "True":
@@ -1842,9 +1842,9 @@ class OpTest(unittest.TestCase):
             # to check inplace result instead of numpy.array_equal.
             expect_out = np.array(expect_outs[i])
             actual_out = np.array(actual_outs[i])
-            assert (
-                actual_out.shape == expect_out.shape
-            ), f"Operator ({self.op_type}) : Output ({name}) shape mismatch, expect shape is {expect_out.shape}, but actual shape is {actual_out.shape}"
+            assert actual_out.shape == expect_out.shape, (
+                f"Operator ({self.op_type}) : Output ({name}) shape mismatch, expect shape is {expect_out.shape}, but actual shape is {actual_out.shape}"
+            )
             if inplace_atol is not None:
                 np.testing.assert_allclose(
                     expect_out,
@@ -2356,9 +2356,9 @@ class OpTest(unittest.TestCase):
 
             def _compare_numpy(self, name, actual_np, expect_np):
                 expect_np = np.array(expect_np)
-                assert (
-                    actual_np.shape == expect_np.shape
-                ), f"Operator ({self.op_type}) : Output ({name}) shape mismatch, expect shape is {expect_np.shape}, but actual shape is {actual_np.shape}"
+                assert actual_np.shape == expect_np.shape, (
+                    f"Operator ({self.op_type}) : Output ({name}) shape mismatch, expect shape is {expect_np.shape}, but actual shape is {actual_np.shape}"
+                )
                 np.testing.assert_allclose(
                     actual_np,
                     expect_np,
@@ -2509,9 +2509,9 @@ class OpTest(unittest.TestCase):
 
             def _compare_numpy(self, name, actual_np, expect_np):
                 expect_np = np.array(expect_np)
-                assert (
-                    actual_np.shape == expect_np.shape
-                ), f"Operator ({self.op_type}) : Output ({name}) shape mismatch, expect shape is {expect_np.shape}, but actual shape is {actual_np.shape}"
+                assert actual_np.shape == expect_np.shape, (
+                    f"Operator ({self.op_type}) : Output ({name}) shape mismatch, expect shape is {expect_np.shape}, but actual shape is {actual_np.shape}"
+                )
                 np.testing.assert_allclose(
                     actual_np,
                     expect_np,
@@ -2603,9 +2603,9 @@ class OpTest(unittest.TestCase):
 
             def _compare_numpy(self, name, actual_np, expect_np):
                 expect_np = np.array(expect_np)
-                assert (
-                    actual_np.shape == expect_np.shape
-                ), f"Operator ({self.op_type}) : Output ({name}) shape mismatch, expect shape is {expect_np.shape}, but actual shape is {actual_np.shape}"
+                assert actual_np.shape == expect_np.shape, (
+                    f"Operator ({self.op_type}) : Output ({name}) shape mismatch, expect shape is {expect_np.shape}, but actual shape is {actual_np.shape}"
+                )
                 np.testing.assert_allclose(
                     actual_np,
                     expect_np,
@@ -3083,9 +3083,9 @@ class OpTest(unittest.TestCase):
         atol=1e-5,
     ):
         for a, b, name in zip(numeric_grads, analytic_grads, names):
-            assert tuple(a.shape) == tuple(
-                b.shape
-            ), f"Operator ({self.op_type}) : Output ({name}) gradient shape mismatch, expect shape is {a.shape}, but actual shape is {b.shape}"
+            assert tuple(a.shape) == tuple(b.shape), (
+                f"Operator ({self.op_type}) : Output ({name}) gradient shape mismatch, expect shape is {a.shape}, but actual shape is {b.shape}"
+            )
             # Used by bfloat16 for now to solve precision problem
             if self.is_bfloat16_op():
                 if a.size == 0:
@@ -3118,12 +3118,12 @@ class OpTest(unittest.TestCase):
                         not in op_threshold_white_list.NEED_FIX_FP64_CHECK_GRAD_THRESHOLD_OP_LIST
                     ):
                         abs_a[abs_a < 1e-10] = 1e-3
-                        abs_a[
-                            np.logical_and(abs_a > 1e-10, abs_a <= 1e-8)
-                        ] *= 1e4
-                        abs_a[
-                            np.logical_and(abs_a > 1e-8, abs_a <= 1e-6)
-                        ] *= 1e2
+                        abs_a[np.logical_and(abs_a > 1e-10, abs_a <= 1e-8)] *= (
+                            1e4
+                        )
+                        abs_a[np.logical_and(abs_a > 1e-8, abs_a <= 1e-6)] *= (
+                            1e2
+                        )
                     elif self.is_bfloat16_op():
                         abs_a[abs_a < 1e-2] = 1
                     else:
@@ -3910,9 +3910,9 @@ class OpTest(unittest.TestCase):
                 )
                 fetch_list = [g for p, g in param_grad_list]
             else:
-                assert (
-                    parallel is False
-                ), "unsupported parallel mode when giving custom grad outputs."
+                assert parallel is False, (
+                    "unsupported parallel mode when giving custom grad outputs."
+                )
                 # user_defined_grad_outputs here are numpy arrays
                 if not isinstance(user_defined_grad_outputs, list):
                     user_defined_grad_outputs = [user_defined_grad_outputs]
@@ -4018,9 +4018,9 @@ class OpTest(unittest.TestCase):
                 return {a: [b] for a, b in zip(output_sig, ret_tuple)}
             else:
                 # [assumption]: return multi-Tensor in a single output. such as paddle.split()
-                assert (
-                    len(output_sig) == 1
-                ), "Don't support multi-output with multi-tensor output. (May be you can use set `python_out_sig`, see `test_squeeze2_op` as a example.)"
+                assert len(output_sig) == 1, (
+                    "Don't support multi-output with multi-tensor output. (May be you can use set `python_out_sig`, see `test_squeeze2_op` as a example.)"
+                )
                 return {output_sig[0]: ret_tuple}
 
         # get kernel signature

--- a/test/legacy_test/prim_op_test.py
+++ b/test/legacy_test/prim_op_test.py
@@ -120,9 +120,9 @@ class OpTestUtils:
             return isinstance(a, Empty)
 
         def get_default(idx, defaults):
-            assert not isinstance(
-                defaults[idx], Empty
-            ), f"{idx}-th params of python api don't have default value."
+            assert not isinstance(defaults[idx], Empty), (
+                f"{idx}-th params of python api don't have default value."
+            )
             return defaults[idx]
 
         def to_defaults_list(params, defaults):
@@ -191,9 +191,9 @@ class OpTestUtils:
         if "one_hot" in str(api):
             api_defaults = [None for x in range(len(api_params))]
 
-        assert len(api_defaults) == len(
-            api_params
-        ), "Error happens. contact xiongkun03 to solve."
+        assert len(api_defaults) == len(api_params), (
+            "Error happens. contact xiongkun03 to solve."
+        )
         inputs_sig, attrs_sig, outputs_sig = kernel_sig
         inputs_and_attrs = inputs_sig + attrs_sig
         input_arguments = [
@@ -256,9 +256,9 @@ class OpTestUtils:
             [inp] if inp is None else inp for inp in args[:inp_num]
         ]  # convert None -> [None]
         for inp in inp_args:
-            assert isinstance(
-                inp, list
-            ), "currently only support `X` is [Tensor], don't support other structure."
+            assert isinstance(inp, list), (
+                "currently only support `X` is [Tensor], don't support other structure."
+            )
         args = [inp[0] if len(inp) == 1 else inp for inp in inp_args] + args[
             inp_num:
         ]
@@ -304,21 +304,21 @@ class PrimForwardChecker:
         pass
 
     def init_checker(self):
-        assert hasattr(
-            self.op_test, 'prim_op_type'
-        ), "If you want to test comp op, please set prim_op_type with 'prim' or 'comp' in setUp function."
+        assert hasattr(self.op_test, 'prim_op_type'), (
+            "If you want to test comp op, please set prim_op_type with 'prim' or 'comp' in setUp function."
+        )
         assert self.op_test.prim_op_type in [
             "comp",
             "prim",
         ], "prim_op_type must be comp or prim in setUp function."
-        assert hasattr(
-            self.op_test, 'dtype'
-        ), "Please set dtype in setUp function."
+        assert hasattr(self.op_test, 'dtype'), (
+            "Please set dtype in setUp function."
+        )
         self.op_type = self.op_test.op_type
         self.prim_op_type = self.op_test.prim_op_type
-        assert hasattr(
-            self.op_test, 'public_python_api'
-        ), "If you want to check prim, please set public_python_api in setUp function."
+        assert hasattr(self.op_test, 'public_python_api'), (
+            "If you want to check prim, please set public_python_api in setUp function."
+        )
         self.public_python_api = self.op_test.public_python_api
         self.dtype = np.dtype(self.op_test.dtype)
         self.inputs = self.op_test.inputs
@@ -674,16 +674,16 @@ class PrimForwardChecker:
                         op.name() for op in main_program.global_block().ops
                     ]
 
-                    assert (
-                        before_ops != after_ops
-                    ), f"For {after_ops} , since op which has been decomposed should not exist, the op list should differ from origin ones."
+                    assert before_ops != after_ops, (
+                        f"For {after_ops} , since op which has been decomposed should not exist, the op list should differ from origin ones."
+                    )
 
                 # ensure the operator not in program if check_prim is True
                 if not in_pir_mode():
                     forward_ops = [op.type for op in main_program.blocks[0].ops]
-                    assert (
-                        self.op_type not in forward_ops
-                    ), f"{self.op_type} shouldn't appear in program when check_prim is True"
+                    assert self.op_type not in forward_ops, (
+                        f"{self.op_type} shouldn't appear in program when check_prim is True"
+                    )
                 exe = paddle.static.Executor(self.place)
                 exe.run(startup_program)
                 ret = exe.run(main_program, feed=feed, fetch_list=ret)
@@ -762,9 +762,9 @@ class PrimForwardChecker:
                     .forward_program.block(0)
                     .ops
                 ]
-                assert (
-                    self.op_type not in forward_ops
-                ), f"{self.op_type} shouldn't appear in program when check_prim is True"
+                assert self.op_type not in forward_ops, (
+                    f"{self.op_type} shouldn't appear in program when check_prim is True"
+                )
             ret = flatten(_as_list(net(args)))
             ret = paddle.utils.map_structure(lambda x: x.numpy(), ret)
             if OpTestUtils.is_bfloat16_type(self.dtype):
@@ -852,9 +852,9 @@ class PrimForwardChecker:
                 .forward_program.block(0)
                 .ops
             ]
-            assert (
-                self.op_type not in forward_ops
-            ), f"{self.op_type} shouldn't appear in program when check_prim is True"
+            assert self.op_type not in forward_ops, (
+                f"{self.op_type} shouldn't appear in program when check_prim is True"
+            )
             ret = flatten(_as_list(net(args)))
             ret = paddle.utils.map_structure(lambda x: x.numpy(), ret)
             if OpTestUtils.is_bfloat16_type(self.dtype):
@@ -931,9 +931,9 @@ class PrimGradChecker(PrimForwardChecker):
                     self.check_jit_comp()
 
     def get_output_dict(self, np_outputs, api_outputs, outputs_sig):
-        assert len(api_outputs) <= len(
-            outputs_sig
-        ), f"forward api outputs length must be the less than or equal to KernelSignature outputs,but receive {len(api_outputs)} and {len(outputs_sig)}"
+        assert len(api_outputs) <= len(outputs_sig), (
+            f"forward api outputs length must be the less than or equal to KernelSignature outputs,but receive {len(api_outputs)} and {len(outputs_sig)}"
+        )
         output_dict = {}
         for i in range(len(api_outputs)):
             output_name = outputs_sig[i]
@@ -1161,17 +1161,17 @@ class PrimGradChecker(PrimForwardChecker):
                 if not in_pir_mode():
                     ops = [op.type for op in main_program.blocks[0].ops]
                     backward_op_type = self.op_type + "_grad"
-                    assert (
-                        backward_op_type not in ops
-                    ), f"{backward_op_type} shouldn't appear in program when check_prim is True"
+                    assert backward_op_type not in ops, (
+                        f"{backward_op_type} shouldn't appear in program when check_prim is True"
+                    )
                 elif self.prim_op_type == "prim":
                     grad_ops = []
                     for op in main_program.global_block().ops:
                         if op.name().endswith("_grad"):
                             grad_ops.append(op.name())
-                    assert (
-                        not grad_ops
-                    ), f"For {grad_ops} , grad op shouldn't appear in program when check_prim is True"
+                    assert not grad_ops, (
+                        f"For {grad_ops} , grad op shouldn't appear in program when check_prim is True"
+                    )
                 exe = paddle.static.Executor(self.place)
                 exe.run(startup_program)
                 actual_ret = exe.run(main_program, feed=feed, fetch_list=ret)
@@ -1257,9 +1257,9 @@ class PrimGradChecker(PrimForwardChecker):
                     .ops
                 ]
                 backward_op_type = self.op_type + "_grad"
-                assert (
-                    backward_op_type not in ops
-                ), f"{backward_op_type} shouldn't appear in program when check_prim is True"
+                assert backward_op_type not in ops, (
+                    f"{backward_op_type} shouldn't appear in program when check_prim is True"
+                )
             out = _as_list(net(args))
             if hasattr(self.op_test, "python_out_sig"):
                 outputs_sig = self.op_test.python_out_sig
@@ -1378,9 +1378,9 @@ class PrimGradChecker(PrimForwardChecker):
                 .ops
             ]
             backward_op_type = self.op_type + "_grad"
-            assert (
-                backward_op_type not in ops
-            ), f"{backward_op_type} shouldn't appear in program when check_prim is True"
+            assert backward_op_type not in ops, (
+                f"{backward_op_type} shouldn't appear in program when check_prim is True"
+            )
 
             out = _as_list(net(args))
             if hasattr(self.op_test, "python_out_sig"):

--- a/test/legacy_test/test_cholesky_solve_op.py
+++ b/test/legacy_test/test_cholesky_solve_op.py
@@ -106,9 +106,7 @@ class TestCholeskySolveOp(OpTest):
         self.y_shape = [15, 15]
         self.x_shape = [15, 5]
         self.upper = False
-        self.dtype = (
-            np.float64
-        )  # Here cholesky_solve Op only supports float64/float32 type, please check others if Op supports more types.
+        self.dtype = np.float64  # Here cholesky_solve Op only supports float64/float32 type, please check others if Op supports more types.
 
     # get scipy result
     def set_output(self):

--- a/test/legacy_test/test_compat_sort.py
+++ b/test/legacy_test/test_compat_sort.py
@@ -21,7 +21,6 @@ from paddle.compat import sort as compat_sort
 
 
 class TestCompatSort(unittest.TestCase):
-
     def _compare_with_origin(
         self, input_tensor, dtype, dim, descending, stable, use_out=False
     ):

--- a/test/legacy_test/test_cumprod_op.py
+++ b/test/legacy_test/test_cumprod_op.py
@@ -125,8 +125,7 @@ class TestCumprod(OpTest):
 
     def prepare_inputs_outputs_attrs(self, dim, zero_num):
         self.x = (
-            np.random.uniform(0.0, 0.5, self.shape).astype(self.val_dtype)
-            + 0.5
+            np.random.uniform(0.0, 0.5, self.shape).astype(self.val_dtype) + 0.5
             # np.ones(self.shape).astype(self.val_dtype)
         )
         if zero_num > 0:

--- a/test/legacy_test/test_dataloader.py
+++ b/test/legacy_test/test_dataloader.py
@@ -85,9 +85,9 @@ class TestDygraphDataLoader(unittest.TestCase):
             self.iter_loader_data(loader)
 
     def test_single_process_loader_filename(self):
-        paddle.base.core.globals()[
-            "FLAGS_dataloader_use_file_descriptor"
-        ] = False
+        paddle.base.core.globals()["FLAGS_dataloader_use_file_descriptor"] = (
+            False
+        )
         with base.dygraph.guard():
             loader = DataLoader(
                 dataset,
@@ -100,9 +100,9 @@ class TestDygraphDataLoader(unittest.TestCase):
             self.iter_loader_data(loader)
 
     def test_multi_process_dataloader_filename(self):
-        paddle.base.core.globals()[
-            "FLAGS_dataloader_use_file_descriptor"
-        ] = False
+        paddle.base.core.globals()["FLAGS_dataloader_use_file_descriptor"] = (
+            False
+        )
         with base.dygraph.guard():
             loader = DataLoader(
                 dataset,

--- a/test/legacy_test/test_dist_base.py
+++ b/test/legacy_test/test_dist_base.py
@@ -690,9 +690,9 @@ class TestParallelDyGraphRunnerBase:
             # the second rank will get [3,4,5].
             # this function is for test sparse_embedding_differ_length
             if hasattr(args, "diff_batch") and args.diff_batch:
-                assert (
-                    len(batch) > 2
-                ), "in differ_batch mode, len(batch) must > 2."
+                assert len(batch) > 2, (
+                    "in differ_batch mode, len(batch) must > 2."
+                )
                 if paddle.distributed.get_rank() == 0:
                     new_batch.append(batch[0])
                 elif paddle.distributed.get_rank() == 1:
@@ -1485,12 +1485,12 @@ class TestDistBase(unittest.TestCase):
     def _run_cluster_gloo(
         self, model, envs, update_method, check_error_log, log_name
     ):
-        assert (
-            update_method == "gloo"
-        ), f"_run_cluster_gloo must have update_method: gloo, but get {update_method}"
-        assert (
-            not self._use_hallreduce
-        ), "_run_cluster_gloo must have _use_hallreduce = false"
+        assert update_method == "gloo", (
+            f"_run_cluster_gloo must have update_method: gloo, but get {update_method}"
+        )
+        assert not self._use_hallreduce, (
+            "_run_cluster_gloo must have _use_hallreduce = false"
+        )
 
         worker_endpoints = self._ps_endpoints.split(",")
 

--- a/test/legacy_test/test_eager_tensor.py
+++ b/test/legacy_test/test_eager_tensor.py
@@ -401,7 +401,9 @@ class TestEagerTensor(unittest.TestCase):
 
         with self.assertRaises(RuntimeError) as context:
             paddle.tensor(
-                self.array, device="cpu", pin_memory=True  # no support
+                self.array,
+                device="cpu",
+                pin_memory=True,  # no support
             )
         self.assertIn(
             "Pinning memory is not supported",

--- a/test/legacy_test/test_full_like_op.py
+++ b/test/legacy_test/test_full_like_op.py
@@ -96,7 +96,6 @@ class TestFullLikeOp(unittest.TestCase):
 
 
 class TestFullLikeOpError(unittest.TestCase):
-
     def test_errors(self):
         with paddle.static.program_guard(
             paddle.static.Program(), paddle.static.Program()

--- a/test/legacy_test/test_fused_attention_pass.py
+++ b/test/legacy_test/test_fused_attention_pass.py
@@ -44,9 +44,9 @@ class MultiHeadAttention(paddle.nn.Layer):
         self.attn_dropout = attn_dropout
 
         self.head_dim = embed_dim // num_heads
-        assert (
-            self.head_dim * num_heads == self.embed_dim
-        ), "embed_dim must be divisible by num_heads"
+        assert self.head_dim * num_heads == self.embed_dim, (
+            "embed_dim must be divisible by num_heads"
+        )
 
         self.norm1 = paddle.nn.LayerNorm(embed_dim, epsilon=1e-5)
         self.norm2 = paddle.nn.LayerNorm(embed_dim, epsilon=1e-5)

--- a/test/legacy_test/test_fused_elemwise_activation_op.py
+++ b/test/legacy_test/test_fused_elemwise_activation_op.py
@@ -306,30 +306,30 @@ def create_test_class(
     globals()[test_case + "_scalar"] = TestFusedElementwiseActivationOp_scalar
     globals()[test_case + "_scalar2"] = TestFusedElementwiseActivationOp_scalar2
     globals()[test_case + "_Vector"] = TestFusedElementwiseActivationOp_Vector
-    globals()[
-        test_case + "_broadcast_0"
-    ] = TestFusedElementwiseActivationOp_broadcast_0
-    globals()[
-        test_case + "_broadcast_1"
-    ] = TestFusedElementwiseActivationOp_broadcast_1
-    globals()[
-        test_case + "_broadcast_2"
-    ] = TestFusedElementwiseActivationOp_broadcast_2
-    globals()[
-        test_case + "_broadcast_3"
-    ] = TestFusedElementwiseActivationOp_broadcast_3
-    globals()[
-        test_case + "_broadcast_4"
-    ] = TestFusedElementwiseActivationOp_broadcast_4
-    globals()[
-        test_case + "_rowwise_add_0"
-    ] = TestFusedElementwiseActivationOp_rowwise_add_0
-    globals()[
-        test_case + "_rowwise_add_1"
-    ] = TestFusedElementwiseActivationOp_rowwise_add_1
-    globals()[
-        test_case + "_channelwise_add"
-    ] = TestFusedElementwiseActivationOp_channelwise_add
+    globals()[test_case + "_broadcast_0"] = (
+        TestFusedElementwiseActivationOp_broadcast_0
+    )
+    globals()[test_case + "_broadcast_1"] = (
+        TestFusedElementwiseActivationOp_broadcast_1
+    )
+    globals()[test_case + "_broadcast_2"] = (
+        TestFusedElementwiseActivationOp_broadcast_2
+    )
+    globals()[test_case + "_broadcast_3"] = (
+        TestFusedElementwiseActivationOp_broadcast_3
+    )
+    globals()[test_case + "_broadcast_4"] = (
+        TestFusedElementwiseActivationOp_broadcast_4
+    )
+    globals()[test_case + "_rowwise_add_0"] = (
+        TestFusedElementwiseActivationOp_rowwise_add_0
+    )
+    globals()[test_case + "_rowwise_add_1"] = (
+        TestFusedElementwiseActivationOp_rowwise_add_1
+    )
+    globals()[test_case + "_channelwise_add"] = (
+        TestFusedElementwiseActivationOp_channelwise_add
+    )
 
 
 def scale_add_func(x, y, x_bcast, y_bcast, scale, mode=0):

--- a/test/legacy_test/test_fused_linear_param_grad_add.py
+++ b/test/legacy_test/test_fused_linear_param_grad_add.py
@@ -97,9 +97,9 @@ def run_fused_linear_param_grad_add(
     if dweight is not None:
         assert dweight_new.data_ptr() == dweight.data_ptr()
     if has_bias and dbias is not None:
-        assert (
-            dbias_new.data_ptr() == dbias.data_ptr()
-        ), f"multi_precision={multi_precision}, has_bias={has_bias}, dbias.dtype={dbias.dtype}."
+        assert dbias_new.data_ptr() == dbias.data_ptr(), (
+            f"multi_precision={multi_precision}, has_bias={has_bias}, dbias.dtype={dbias.dtype}."
+        )
     if has_bias:
         return (
             promote_dtype(dweight_new).numpy(),

--- a/test/legacy_test/test_fused_scale_bias_relu_conv_bn_op.py
+++ b/test/legacy_test/test_fused_scale_bias_relu_conv_bn_op.py
@@ -80,14 +80,10 @@ class TestFusedScaleBiasReluConvBnOp(OpTest):
         if self.fuse_prologue:
             self.x_input_prologue *= self.scale_input.reshape(
                 (1, 1, 1, self.in_channel_num)
-            ).astype(
-                np.float32
-            )  # scale
+            ).astype(np.float32)  # scale
             self.x_input_prologue += self.bias_input.reshape(
                 (1, 1, 1, self.in_channel_num)
-            ).astype(
-                np.float32
-            )  # bias
+            ).astype(np.float32)  # bias
             self.x_input_prologue = np.maximum(self.x_input_prologue, 0)  # relu
         self.x_input_prologue = self.x_input_prologue.astype(self.dtype)
 

--- a/test/legacy_test/test_generate_proposals_v2_op.py
+++ b/test/legacy_test/test_generate_proposals_v2_op.py
@@ -96,9 +96,9 @@ def box_coder(all_anchors, bbox_deltas, variances, pixel_offset=True):
 def clip_tiled_boxes(boxes, im_shape, pixel_offset=True):
     """Clip boxes to image boundaries. im_shape is [height, width] and boxes
     has shape (N, 4 * num_tiled_boxes)."""
-    assert (
-        boxes.shape[1] % 4 == 0
-    ), f'boxes.shape[1] is {boxes.shape[1]:d}, but must be divisible by 4.'
+    assert boxes.shape[1] % 4 == 0, (
+        f'boxes.shape[1] is {boxes.shape[1]:d}, but must be divisible by 4.'
+    )
     offset = 1 if pixel_offset else 0
     # x1 >= 0
     boxes[:, 0::4] = np.maximum(

--- a/test/legacy_test/test_gpu_package_without_gpu_device.py
+++ b/test/legacy_test/test_gpu_package_without_gpu_device.py
@@ -57,12 +57,12 @@ assert x.place.is_gpu_place() is False, "There is no CUDA device, but Tensor's p
             )
             stdout, stderr = ps_proc.communicate()
 
-            assert 'CPU device will be used by default' in str(
-                stderr
-            ), "GPU version Paddle is installed. But CPU device can't be used when CUDA device is not set properly"
-            assert "AssertionError" not in str(
-                stderr
-            ), "There is no CUDA device, but Tensor's place is CUDAPlace"
+            assert 'CPU device will be used by default' in str(stderr), (
+                "GPU version Paddle is installed. But CPU device can't be used when CUDA device is not set properly"
+            )
+            assert "AssertionError" not in str(stderr), (
+                "There is no CUDA device, but Tensor's place is CUDAPlace"
+            )
 
 
 if __name__ == '__main__':

--- a/test/legacy_test/test_hsigmoid_op.py
+++ b/test/legacy_test/test_hsigmoid_op.py
@@ -259,9 +259,7 @@ class TestHSigmoidOpSparse(OpTest):
                 (1, 0, 0, -1, -1),
                 (0, 1, -1, -1, -1),
             ]
-        ).astype(
-            'int64'
-        )  # np.array to store
+        ).astype('int64')  # np.array to store
         bias = np.random.random((num_classes - 1, 1))
         self.attrs = {'num_classes': num_classes, 'is_sparse': True}
         self.inputs = {
@@ -312,9 +310,7 @@ class TestHSigmoidOpWithCustomTree(OpTest):
                 (1, 0, 0, -1, -1),
                 (0, 1, -1, -1, -1),
             ]
-        ).astype(
-            'int64'
-        )  # np.array to store
+        ).astype('int64')  # np.array to store
         bias = np.random.random((num_classes - 1, 1))
         self.attrs = {'num_classes': num_classes, 'is_sparse': False}
         self.inputs = {
@@ -373,9 +369,7 @@ class TestHSigmoidOpWithCustomTreeWithoutBias(OpTest):
                 (1, 0, 0, -1, -1),
                 (0, 1, -1, -1, -1),
             ]
-        ).astype(
-            'int64'
-        )  # np.array to store
+        ).astype('int64')  # np.array to store
         # bias = np.random.random((num_classes - 1, 1)).astype("float32")
         self.attrs = {'num_classes': num_classes, 'is_sparse': False}
         self.inputs = {

--- a/test/legacy_test/test_imperative_resnet.py
+++ b/test/legacy_test/test_imperative_resnet.py
@@ -168,9 +168,9 @@ class ResNet(paddle.nn.Layer):
 
         self.layers = layers
         supported_layers = [50, 101, 152]
-        assert (
-            layers in supported_layers
-        ), f"supported layers are {supported_layers} but input layer is {layers}"
+        assert layers in supported_layers, (
+            f"supported layers are {supported_layers} but input layer is {layers}"
+        )
 
         if layers == 50:
             depth = [3, 4, 6, 3]

--- a/test/legacy_test/test_imperative_se_resnext.py
+++ b/test/legacy_test/test_imperative_se_resnext.py
@@ -197,9 +197,9 @@ class SeResNeXt(paddle.nn.Layer):
 
         self.layers = layers
         supported_layers = [50, 101, 152]
-        assert (
-            layers in supported_layers
-        ), f"supported layers are {supported_layers} but input layer is {layers}"
+        assert layers in supported_layers, (
+            f"supported layers are {supported_layers} but input layer is {layers}"
+        )
 
         if layers == 50:
             cardinality = 32

--- a/test/legacy_test/test_imperative_transformer_sorted_gradient.py
+++ b/test/legacy_test/test_imperative_transformer_sorted_gradient.py
@@ -1066,9 +1066,9 @@ class TransFormer(Layer):
         self._label_smooth_eps = label_smooth_eps
         self._trg_vocab_size = trg_vocab_size
         if weight_sharing:
-            assert (
-                src_vocab_size == trg_vocab_size
-            ), "Vocabularies in source and target should be same for weight sharing."
+            assert src_vocab_size == trg_vocab_size, (
+                "Vocabularies in source and target should be same for weight sharing."
+            )
         self._wrap_encoder_layer = WrapEncoderLayer(
             src_vocab_size,
             max_length,
@@ -1105,9 +1105,7 @@ class TransFormer(Layer):
         )
 
         if weight_sharing:
-            self._wrap_decoder_layer._prepare_decoder_layer._input_emb.weight = (
-                self._wrap_encoder_layer._prepare_encoder_layer._input_emb.weight
-            )
+            self._wrap_decoder_layer._prepare_decoder_layer._input_emb.weight = self._wrap_encoder_layer._prepare_encoder_layer._input_emb.weight
 
     def forward(self, enc_inputs, dec_inputs, label, weights):
         enc_output = self._wrap_encoder_layer(enc_inputs)

--- a/test/legacy_test/test_incubate_expand_modality_expert_id.py
+++ b/test/legacy_test/test_incubate_expand_modality_expert_id.py
@@ -82,9 +82,8 @@ def fused_gate_logits_process_ref(
 
     token_type_ids_float = token_type_ids[:, None].astype("float32")
     weight_and_expert = (
-        (1 - token_type_ids_float) * lm_weight_and_expert_id
-        + token_type_ids_float * mm_weight_and_expert_id
-    )
+        1 - token_type_ids_float
+    ) * lm_weight_and_expert_id + token_type_ids_float * mm_weight_and_expert_id
     return weight_and_expert, prob_lm.reshape([prob_lm.shape[0], -1]), prob_mm
 
 

--- a/test/legacy_test/test_lstm_cudnn_op.py
+++ b/test/legacy_test/test_lstm_cudnn_op.py
@@ -298,9 +298,9 @@ class BiRNN(LayerMixin):
         self, inputs, initial_states=None, sequence_length=None, **kwargs
     ):
         if isinstance(initial_states, (list, tuple)):
-            assert (
-                len(initial_states) == 2
-            ), "length of initial_states should be 2 when it is a list/tuple"
+            assert len(initial_states) == 2, (
+                "length of initial_states should be 2 when it is a list/tuple"
+            )
         else:
             initial_states = [initial_states, initial_states]
 

--- a/test/legacy_test/test_multiprocess_dataloader_exception.py
+++ b/test/legacy_test/test_multiprocess_dataloader_exception.py
@@ -167,9 +167,9 @@ class TestDataLoaderWorkerLoop(unittest.TestCase):
                     places=place,
                     use_shared_memory=use_shared_memory,
                 )
-                assert (
-                    loader.num_workers > 0
-                ), "go to AssertionError and pass in Mac and Windows"
+                assert loader.num_workers > 0, (
+                    "go to AssertionError and pass in Mac and Windows"
+                )
                 loader = iter(loader)
                 print("loader length", len(loader))
                 indices_queue = multiprocessing.Queue()
@@ -224,9 +224,9 @@ class TestDataLoaderWorkerLoop(unittest.TestCase):
                     places=place,
                     use_shared_memory=use_shared_memory,
                 )
-                assert (
-                    loader.num_workers > 0
-                ), "go to AssertionError and pass in Mac and Windows"
+                assert loader.num_workers > 0, (
+                    "go to AssertionError and pass in Mac and Windows"
+                )
                 loader = iter(loader)
                 print("loader length", len(loader))
                 indices_queue = multiprocessing.Queue()

--- a/test/legacy_test/test_nn_init_function.py
+++ b/test/legacy_test/test_nn_init_function.py
@@ -88,7 +88,6 @@ class Test_calculate_gain(unittest.TestCase):
 
 
 class Test_kaiming_uniform_(unittest.TestCase):
-
     def check_kaiming_uniform(
         self, tensor, a=0, mode='fan_in', nonlinearity='leaky_relu'
     ):
@@ -230,7 +229,6 @@ class Test_kaiming_uniform_(unittest.TestCase):
 
 
 class Test_kaiming_normal_(unittest.TestCase):
-
     def check_kaiming_normal(
         self, tensor, a=0, mode='fan_in', nonlinearity='leaky_relu'
     ):
@@ -370,7 +368,6 @@ class Test_kaiming_normal_(unittest.TestCase):
 
 
 class Test_xavier_uniform_(unittest.TestCase):
-
     def check(self, tensor, gain=1.0):
         if len(tensor.shape) == 2:
             # This is the case for simple matrix multiply
@@ -473,7 +470,6 @@ class Test_xavier_uniform_(unittest.TestCase):
 
 
 class Test_xavier_normal_(unittest.TestCase):
-
     def check(self, tensor, gain=1.0):
         if len(tensor.shape) == 2:
             # This is the case for simple matrix multiply
@@ -567,7 +563,6 @@ class Test_xavier_normal_(unittest.TestCase):
 
 
 class Test_uniform_(unittest.TestCase):
-
     def check(self, tensor, a=0.0, b=1.0):
         samples = tensor.flatten().tolist()
         p_value = stats.kstest(samples, "uniform", args=(a, (b - a)))[1]
@@ -646,7 +641,6 @@ class Test_uniform_(unittest.TestCase):
 
 
 class Test_normal_(unittest.TestCase):
-
     def check(self, tensor, mean=0.0, std=1.0):
         samples = tensor.flatten().tolist()
         p_value = stats.kstest(samples, "norm", args=(mean, std))[1]
@@ -727,7 +721,6 @@ class Test_normal_(unittest.TestCase):
 
 
 class Test_trunc_normal_(unittest.TestCase):
-
     def check(self, tensor, mean=0.0, std=1.0, a=-2.0, b=2.0):
         samples = ((tensor.flatten() - mean) / std).tolist()
         a0 = (a - mean) / std
@@ -805,7 +798,6 @@ class Test_trunc_normal_(unittest.TestCase):
 
 
 class Test_constant_(unittest.TestCase):
-
     def check(self, tensor, val):
         if isinstance(tensor, paddle.Tensor):
             diff = (tensor - val).abs().max().item()
@@ -877,7 +869,6 @@ class Test_constant_(unittest.TestCase):
 
 
 class Test_ones_(unittest.TestCase):
-
     def check(self, tensor, eps=1e-6):
         if isinstance(tensor, paddle.Tensor):
             diff = (tensor - 1.0).abs().max().item()
@@ -958,7 +949,6 @@ class Test_ones_(unittest.TestCase):
 
 
 class Test_zeros_(unittest.TestCase):
-
     def check(self, tensor, eps=1e-6):
         if isinstance(tensor, paddle.Tensor):
             diff = tensor.abs().max().item()
@@ -1039,7 +1029,6 @@ class Test_zeros_(unittest.TestCase):
 
 
 class Test_eye_(unittest.TestCase):
-
     def check(self, tensor):
         if not isinstance(tensor, np.ndarray):
             tensor = tensor.numpy()
@@ -1114,12 +1103,10 @@ class Test_eye_(unittest.TestCase):
 
 
 class Test_dirac_(unittest.TestCase):
-
     def test_dygraph(self):
         with dygraph_guard():
             for dims in [3, 4, 5]:
                 for groups in [1, 2, 3]:
-
                     a, c, d, e = (random.randint(1, 5) for _ in range(4))
                     b = random.randint(1, 5 * groups)
                     input_tensor = paddle.randn((a * groups, b, c, d, e)[:dims])
@@ -1179,7 +1166,6 @@ class Test_dirac_(unittest.TestCase):
 
 
 class Test_orthogonal_(unittest.TestCase):
-
     def check(self, tensor, gain):
         if isinstance(tensor, paddle.Tensor):
             tensor = tensor.numpy()

--- a/test/legacy_test/test_npscaler_to_tensor.py
+++ b/test/legacy_test/test_npscaler_to_tensor.py
@@ -51,13 +51,8 @@ class NumpyScaler2Tensor(unittest.TestCase):
         paddle.enable_static()
         x = paddle.to_tensor(self.x_np)
         self.assertEqual(DTYPE_MAP[x.dtype], self.dtype)
-        if (
-            self.dtype
-            in [
-                np.bool_,
-                np.float64,
-            ]
-        ):  # bool is not supported convert to 0D-Tensor and float64 not supported in static mode
+        if self.dtype in [np.bool_, np.float64]:
+            # bool is not supported convert to 0D-Tensor and float64 not supported in static mode
             return
         self.assertEqual(len(x.shape), 0)
 

--- a/test/legacy_test/test_npscaler_to_tensor.py
+++ b/test/legacy_test/test_npscaler_to_tensor.py
@@ -51,10 +51,13 @@ class NumpyScaler2Tensor(unittest.TestCase):
         paddle.enable_static()
         x = paddle.to_tensor(self.x_np)
         self.assertEqual(DTYPE_MAP[x.dtype], self.dtype)
-        if self.dtype in [
-            np.bool_,
-            np.float64,
-        ]:  # bool is not supported convert to 0D-Tensor and float64 not supported in static mode
+        if (
+            self.dtype
+            in [
+                np.bool_,
+                np.float64,
+            ]
+        ):  # bool is not supported convert to 0D-Tensor and float64 not supported in static mode
             return
         self.assertEqual(len(x.shape), 0)
 

--- a/test/legacy_test/test_overlap_add_op.py
+++ b/test/legacy_test/test_overlap_add_op.py
@@ -35,9 +35,9 @@ def overlap_add(x, hop_length, axis=-1):
     frame_length = x.shape[1] if axis == 0 else x.shape[-2]
 
     # Assure no gaps between frames.
-    assert (
-        0 < hop_length <= frame_length
-    ), f'hop_length should be in (0, frame_length({frame_length})], but got {hop_length}.'
+    assert 0 < hop_length <= frame_length, (
+        f'hop_length should be in (0, frame_length({frame_length})], but got {hop_length}.'
+    )
 
     seq_length = (n_frames - 1) * hop_length + frame_length
 

--- a/test/legacy_test/test_parallel_dygraph_dataparallel.py
+++ b/test/legacy_test/test_parallel_dygraph_dataparallel.py
@@ -75,9 +75,9 @@ def start_local_trainers_cpu(
 
         print(f"trainer proc env:{current_env}")
 
-        assert (
-            os.getenv('WITH_COVERAGE', 'OFF') == 'OFF'
-        ), "Gloo don't support WITH_COVERAGE."
+        assert os.getenv('WITH_COVERAGE', 'OFF') == 'OFF', (
+            "Gloo don't support WITH_COVERAGE."
+        )
         cmd = "python -u " + training_script
 
         print(f"start trainer proc:{cmd} env:{proc_env}")

--- a/test/legacy_test/test_psroi_pool_op.py
+++ b/test/legacy_test/test_psroi_pool_op.py
@@ -168,12 +168,20 @@ class TestPSROIPoolOp(OpTest):
 
     def setUp(self):
         self.op_type = 'psroi_pool'
-        self.python_api = lambda x, boxes, boxes_num, pooled_height, pooled_width, output_channels, spatial_scale: paddle.vision.ops.psroi_pool(
-            x,
+        self.python_api = (
+            lambda x,
             boxes,
             boxes_num,
-            (pooled_height, pooled_width),
-            spatial_scale,
+            pooled_height,
+            pooled_width,
+            output_channels,
+            spatial_scale: paddle.vision.ops.psroi_pool(
+                x,
+                boxes,
+                boxes_num,
+                (pooled_height, pooled_width),
+                spatial_scale,
+            )
         )
         self.set_data()
 

--- a/test/legacy_test/test_put_along_axis_op.py
+++ b/test/legacy_test/test_put_along_axis_op.py
@@ -1454,7 +1454,6 @@ class TestPutAlongAxisAPIMinUInt8(TestPutAlongAxisAPIReduceLowBits):
 
 
 class TestPutAlongAxisAPIMaxUInt8(TestPutAlongAxisAPIMinUInt8):
-
     def set_op_to_test(self):
         self.op = "amax"
 

--- a/test/legacy_test/test_randn_op.py
+++ b/test/legacy_test/test_randn_op.py
@@ -75,7 +75,6 @@ class TestRandnOpForDygraph(unittest.TestCase):
 class TestRandnOpError(unittest.TestCase):
     def test_error(self):
         with program_guard(Program(), Program()):
-
             # The argument dtype of randn_op should be float32 or float64.
             self.assertRaises(TypeError, paddle.randn, [1, 2], 'int32')
 
@@ -93,7 +92,6 @@ class TestRandnOpCompatibility(unittest.TestCase):
             for place in self.places:
                 paddle.device.set_device(place)
                 for param_name in ['shape', 'size']:
-
                     tensor = paddle.randn(
                         **{param_name: self.expected_shape}, dtype=self.dtype
                     )

--- a/test/legacy_test/test_randperm_op.py
+++ b/test/legacy_test/test_randperm_op.py
@@ -28,9 +28,9 @@ from paddle.base.framework import in_pir_mode
 
 
 def check_randperm_out(n, data_np):
-    assert isinstance(
-        data_np, np.ndarray
-    ), "The input data_np should be np.ndarray."
+    assert isinstance(data_np, np.ndarray), (
+        "The input data_np should be np.ndarray."
+    )
     gt_sorted = np.arange(n)
     out_sorted = np.sort(data_np)
     return list(gt_sorted == out_sorted)

--- a/test/legacy_test/test_repeat.py
+++ b/test/legacy_test/test_repeat.py
@@ -21,7 +21,6 @@ import paddle
 
 
 class TestRepeatBase(unittest.TestCase):
-
     def setUp(self):
         self.x = paddle.to_tensor([1, 2, 3])
         self.repeats = 3

--- a/test/legacy_test/test_roi_align_op.py
+++ b/test/legacy_test/test_roi_align_op.py
@@ -221,14 +221,23 @@ class TestROIAlignOp(OpTest):
 
     def setUp(self):
         self.op_type = "roi_align"
-        self.python_api = lambda x, boxes, boxes_num, pooled_height, pooled_width, spatial_scale, sampling_ratio, aligned: paddle.vision.ops.roi_align(
-            x,
+        self.python_api = (
+            lambda x,
             boxes,
             boxes_num,
-            (pooled_height, pooled_width),
+            pooled_height,
+            pooled_width,
             spatial_scale,
             sampling_ratio,
-            aligned,
+            aligned: paddle.vision.ops.roi_align(
+                x,
+                boxes,
+                boxes_num,
+                (pooled_height, pooled_width),
+                spatial_scale,
+                sampling_ratio,
+                aligned,
+            )
         )
         self.set_data()
 

--- a/test/legacy_test/test_roi_pool_op.py
+++ b/test/legacy_test/test_roi_pool_op.py
@@ -164,12 +164,19 @@ class TestROIPoolOp(OpTest):
 
     def setUp(self):
         self.op_type = "roi_pool"
-        self.python_api = lambda x, boxes, boxes_num, pooled_height, pooled_width, spatial_scale: paddle.vision.ops.roi_pool(
-            x,
+        self.python_api = (
+            lambda x,
             boxes,
             boxes_num,
-            (pooled_height, pooled_width),
-            spatial_scale,
+            pooled_height,
+            pooled_width,
+            spatial_scale: paddle.vision.ops.roi_pool(
+                x,
+                boxes,
+                boxes_num,
+                (pooled_height, pooled_width),
+                spatial_scale,
+            )
         )
         self.python_out_sig = ["Out"]
         self.set_data()

--- a/test/legacy_test/test_set_value_op.py
+++ b/test/legacy_test/test_set_value_op.py
@@ -1222,9 +1222,7 @@ class TestSetValueValueShape4(TestSetValueApi):
     def set_value(self):
         self.value = np.array(
             [[1, 1, 1, 1], [2, 2, 2, 2], [3, 3, 3, 3]]
-        ).astype(
-            self.dtype
-        )  # shape is (3,4)
+        ).astype(self.dtype)  # shape is (3,4)
 
     def _call_setitem(self, x):
         x[0] = paddle.assign(self.value)  # x is Paddle.Tensor

--- a/test/legacy_test/test_sgd_op_bf16.py
+++ b/test/legacy_test/test_sgd_op_bf16.py
@@ -355,9 +355,7 @@ class TestSGDOpBF16API(unittest.TestCase):
                 weight_attr=base.ParamAttr(
                     name="emb_weight", initializer=self.initializer
                 ),
-            )(
-                x
-            )  # bfloat16
+            )(x)  # bfloat16
             paddle.set_default_dtype(pre_dtype)
             cost = paddle.add(emb, label)
             avg_cost = paddle.mean(cost)

--- a/test/legacy_test/test_signal.py
+++ b/test/legacy_test/test_signal.py
@@ -515,9 +515,9 @@ def overlap_add_for_api_test(x, hop_length, axis=-1):
     frame_length = x.shape[1] if axis == 0 else x.shape[-2]
 
     # Assure no gaps between frames.
-    assert (
-        0 < hop_length <= frame_length
-    ), f'hop_length should be in (0, frame_length({frame_length})], but got {hop_length}.'
+    assert 0 < hop_length <= frame_length, (
+        f'hop_length should be in (0, frame_length({frame_length})], but got {hop_length}.'
+    )
 
     seq_length = (n_frames - 1) * hop_length + frame_length
 

--- a/test/legacy_test/test_static_save_load.py
+++ b/test/legacy_test/test_static_save_load.py
@@ -1017,9 +1017,9 @@ class TestVariableInit(unittest.TestCase):
             load_dict = pickle.load(f)
 
         for v in parameter_list:
-            assert (
-                v.name in load_dict
-            ), f"Can not find [{v.name}] in model file [{parameter_file_name}]"
+            assert v.name in load_dict, (
+                f"Can not find [{v.name}] in model file [{parameter_file_name}]"
+            )
             new_v = new_scope.find_var(v.name)
             set_var(new_v, load_dict[v.name])
 
@@ -1046,9 +1046,9 @@ class TestVariableInit(unittest.TestCase):
             load_dict = pickle.load(f)
 
         for v in opt_list:
-            assert (
-                v.name in load_dict
-            ), f"Can not find [{v.name}] in model file [{opt_file_name}]"
+            assert v.name in load_dict, (
+                f"Can not find [{v.name}] in model file [{opt_file_name}]"
+            )
 
             new_v = new_scope.find_var(v.name)
             set_var(new_v, load_dict[v.name])

--- a/test/legacy_test/test_tdm_sampler_op.py
+++ b/test/legacy_test/test_tdm_sampler_op.py
@@ -155,14 +155,16 @@ class TestTDMSamplerOp(OpTest):
                 if sampling_res_list[0] != 0:
                     assert len(set(sampling_res_list)) == len(
                         sampling_res_list
-                    ), f"len(set(sampling_res_list)): {len(set(sampling_res_list))}, len(sampling_res_list): {len(sampling_res_list)} , sample_res: {sampling_res}, label_res:{label_sampling_res}, mask_res: {mask_sampling_res}"
+                    ), (
+                        f"len(set(sampling_res_list)): {len(set(sampling_res_list))}, len(sampling_res_list): {len(sampling_res_list)} , sample_res: {sampling_res}, label_res:{label_sampling_res}, mask_res: {mask_sampling_res}"
+                    )
                 # check legal
                 layer_node = self.tree_layer[layer_idx]
                 layer_node.append(0)
                 for sample in sampling_res_list:
-                    assert (
-                        sample in layer_node
-                    ), f"sample: {sample}, layer_node: {layer_node} , sample_res: {sampling_res}, label_res: {label_sampling_res}, mask_res:{mask_sampling_res}"
+                    assert sample in layer_node, (
+                        f"sample: {sample}, layer_node: {layer_node} , sample_res: {sampling_res}, label_res: {label_sampling_res}, mask_res:{mask_sampling_res}"
+                    )
 
                 # check label
                 label_flag = 1
@@ -171,9 +173,9 @@ class TestTDMSamplerOp(OpTest):
                 assert label_sampling_res[0] == label_flag
                 # check mask
                 padding_index = np.where(sampling_res == 0)
-                assert not np.sum(
-                    mask_sampling_res[padding_index]
-                ), f"np.sum(mask_sampling_res[padding_index]): {np.sum(mask_sampling_res[padding_index])} "
+                assert not np.sum(mask_sampling_res[padding_index]), (
+                    f"np.sum(mask_sampling_res[padding_index]): {np.sum(mask_sampling_res[padding_index])} "
+                )
                 start_offset = end_offset
             # check travel legal
             assert (

--- a/test/legacy_test/testsuite.py
+++ b/test/legacy_test/testsuite.py
@@ -132,13 +132,13 @@ def append_input_output(
         if (var_name not in np_list) and var_proto.dispensable:
             continue
         if is_input:
-            assert (var_name in np_list) or (
-                var_proto.dispensable
-            ), f"Missing {var_name} as input"
+            assert (var_name in np_list) or (var_proto.dispensable), (
+                f"Missing {var_name} as input"
+            )
         if var_proto.duplicable:
-            assert isinstance(
-                np_list[var_name], list
-            ), f"Duplicable {var_name} should be set as list"
+            assert isinstance(np_list[var_name], list), (
+                f"Duplicable {var_name} should be set as list"
+            )
             var_list = []
             for name, np_value in np_list[var_name]:
                 var_list.append(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

使用性能更好，格式化效果更佳的 ruff format 替代 black 作为新的 formatter，由于我们很早就已经集成了 ruff lint，因此只是减少依赖而不会增加依赖

<!--

## 核心优势

通过集成 Ruff format，开发者可以享受到以下优势：

- 通过去除 black 对 python 环境依赖，极大降低了升级 formatter 带来的成本，后续无需考虑开发者本地 python 环境即可一键升级
- ruff 由 Rust 驱动，大幅加速 format 时间，降低开发者使用开发工具链的时间成本，减少 CI 时间，提升工程效率
- 格式化后呈现可读性更佳的效果，使得开发者更专注于代码开发而无需关心格式，阅读者也能够更加赏心悦目，极大增加了潜在贡献者的贡献意愿
- ruff 极大程度地兼容了 black 的格式化效果，能够平滑地替换现有的 black 配置
- ruff 更新频次高，能够快速响应社区反馈，持续优化格式化效果
- ruff 团队 Astral 最近开发的 ty 能够提供更强大的类型检查能力，后续可能与 ruff 集成，提供更好的开发体验
- PyTorch 最近已经完成迁移，追平竞品（在代码风格这块，我们一直做到了超越竞品，这次不能落后）

-->