### PR TITLE
[CodeStyle] `black -> ruff format` migration - part 39

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -105,7 +105,7 @@ repos:
 
             # | test/l.+
 
-            # | test/[m-z].+
+            | test/[m-z].+
 
             # | tools/.+
           )$
@@ -161,7 +161,7 @@ repos:
 
             | test/l.+
 
-            | test/[m-z].+
+            # | test/[m-z].+
 
             | tools/.+
           )$

--- a/test/prim/model/bert.py
+++ b/test/prim/model/bert.py
@@ -328,12 +328,12 @@ class BertModel(nn.Layer):
             past_key_values_length=past_key_values_length,
         )
         if self.fuse:
-            assert (
-                not output_attentions
-            ), "Not support attentions output currently."
-            assert (
-                past_key_values is None
-            ), "Not support past_key_values currently."
+            assert not output_attentions, (
+                "Not support attentions output currently."
+            )
+            assert past_key_values is None, (
+                "Not support past_key_values currently."
+            )
             hidden_states = embedding_output
             all_hidden_states = [] if output_hidden_states else None
             for layer in self.encoder:

--- a/test/prim/pir_prim/test_batch_norm_shape_check.py
+++ b/test/prim/pir_prim/test_batch_norm_shape_check.py
@@ -75,9 +75,9 @@ class TestBuildOp(unittest.TestCase):
             y_new = decompose(pir_program, y)
             core._set_prim_forward_enabled(False)
             new_shape = y_new[0].shape
-            assert (
-                orig_shape == new_shape
-            ), f"Original shape {orig_shape} is not equal to new shape {new_shape}"
+            assert orig_shape == new_shape, (
+                f"Original shape {orig_shape} is not equal to new shape {new_shape}"
+            )
             op_name_list = [op.name() for op in pir_program.global_block().ops]
             assert "pd_op.batch_norm_" not in op_name_list
 

--- a/test/prim/pir_prim/test_builtin_slice.py
+++ b/test/prim/pir_prim/test_builtin_slice.py
@@ -68,9 +68,9 @@ class TestBuildOp(unittest.TestCase):
             y_new = decompose(pir_program, y)
             core._set_prim_forward_enabled(False)
             new_shape = y_new[0].shape
-            assert (
-                orig_shape == new_shape
-            ), f"Original shape {orig_shape} is not equal to new shape {new_shape}"
+            assert orig_shape == new_shape, (
+                f"Original shape {orig_shape} is not equal to new shape {new_shape}"
+            )
             op_name_list = [op.name() for op in pir_program.global_block().ops]
             assert "pd_op.meshgrid" not in op_name_list
 

--- a/test/prim/pir_prim/test_decomp_op.py
+++ b/test/prim/pir_prim/test_decomp_op.py
@@ -56,9 +56,9 @@ class TestBuildOp(unittest.TestCase):
             y_new = decompose(pir_program, y)
             core._set_prim_forward_enabled(False)
             new_shape = y_new[0].shape
-            assert (
-                orig_shape == new_shape
-            ), f"Original shape {orig_shape} is not equal to new shape {new_shape}"
+            assert orig_shape == new_shape, (
+                f"Original shape {orig_shape} is not equal to new shape {new_shape}"
+            )
             op_name_list = [op.name() for op in pir_program.global_block().ops]
             self.assertEqual(
                 op_name_list,

--- a/test/quantization/quant2_int8_image_classification_comparison.py
+++ b/test/quantization/quant2_int8_image_classification_comparison.py
@@ -350,13 +350,13 @@ class Quant2Int8ImageClassificationComparisonTest(unittest.TestCase):
             return
 
         quant_model_path = test_case_args.quant_model
-        assert (
-            quant_model_path
-        ), 'The Quant model path cannot be empty. Please, use the --quant_model option.'
+        assert quant_model_path, (
+            'The Quant model path cannot be empty. Please, use the --quant_model option.'
+        )
         data_path = test_case_args.infer_data
-        assert (
-            data_path
-        ), 'The dataset path cannot be empty. Please, use the --infer_data option.'
+        assert data_path, (
+            'The dataset path cannot be empty. Please, use the --infer_data option.'
+        )
         fp32_model_path = test_case_args.fp32_model
         batch_size = test_case_args.batch_size
         batch_num = test_case_args.batch_num
@@ -377,9 +377,9 @@ class Quant2Int8ImageClassificationComparisonTest(unittest.TestCase):
             )
 
         self._targets = self._strings_from_csv(test_case_args.targets)
-        assert self._targets.intersection(
-            {'quant', 'int8', 'fp32'}
-        ), 'The --targets option, if used, must contain at least one of the targets: "quant", "int8", "fp32".'
+        assert self._targets.intersection({'quant', 'int8', 'fp32'}), (
+            'The --targets option, if used, must contain at least one of the targets: "quant", "int8", "fp32".'
+        )
 
         _logger.info('Quant & INT8 prediction run.')
         _logger.info(f'Quant model: {quant_model_path}')

--- a/test/quantization/quant2_int8_lstm_model.py
+++ b/test/quantization/quant2_int8_lstm_model.py
@@ -204,17 +204,17 @@ class TestLstmModelPTQ(unittest.TestCase):
             return
 
         fp32_model = test_case_args.fp32_model
-        assert (
-            fp32_model
-        ), 'The FP32 model path cannot be empty. Please, use the --fp32_model option.'
+        assert fp32_model, (
+            'The FP32 model path cannot be empty. Please, use the --fp32_model option.'
+        )
         quant_model = test_case_args.quant_model
-        assert (
-            quant_model
-        ), 'The quant model path cannot be empty. Please, use the --quant_model option.'
+        assert quant_model, (
+            'The quant model path cannot be empty. Please, use the --quant_model option.'
+        )
         infer_data = test_case_args.infer_data
-        assert (
-            infer_data
-        ), 'The dataset path cannot be empty. Please, use the --infer_data option.'
+        assert infer_data, (
+            'The dataset path cannot be empty. Please, use the --infer_data option.'
+        )
         num_threads = test_case_args.num_threads
         onednn_cache_capacity = test_case_args.onednn_cache_capacity
         warmup_iter = test_case_args.warmup_iter

--- a/test/quantization/quant2_int8_nlp_comparison.py
+++ b/test/quantization/quant2_int8_nlp_comparison.py
@@ -110,22 +110,22 @@ class QuantInt8NLPComparisonTest(unittest.TestCase):
             ):
                 data_lines = df.readlines()
                 labels_lines = lf.readlines()
-                assert len(data_lines) == len(
-                    labels_lines
-                ), "The number of labels does not match the length of the dataset."
+                assert len(data_lines) == len(labels_lines), (
+                    "The number of labels does not match the length of the dataset."
+                )
 
                 for i in range(len(data_lines)):
                     data_fields = data_lines[i].split(';')
-                    assert (
-                        len(data_fields) >= 2
-                    ), "The number of data fields in the dataset is less than 2"
+                    assert len(data_fields) >= 2, (
+                        "The number of data fields in the dataset is less than 2"
+                    )
                     buffers = []
                     shape = []
                     for j in range(2):
                         data = data_fields[j].split(':')
-                        assert (
-                            len(data) >= 2
-                        ), "Size of data in the dataset is less than 2"
+                        assert len(data) >= 2, (
+                            "Size of data in the dataset is less than 2"
+                        )
                         # Shape is stored under index 0, while data under 1
                         shape = data[0].split()
                         shape.pop(0)
@@ -287,13 +287,13 @@ class QuantInt8NLPComparisonTest(unittest.TestCase):
             return
 
         quant_model_path = test_case_args.quant_model
-        assert (
-            quant_model_path
-        ), 'The Quant model path cannot be empty. Please, use the --quant_model option.'
+        assert quant_model_path, (
+            'The Quant model path cannot be empty. Please, use the --quant_model option.'
+        )
         data_path = test_case_args.infer_data
-        assert (
-            data_path
-        ), 'The dataset path cannot be empty. Please, use the --infer_data option.'
+        assert data_path, (
+            'The dataset path cannot be empty. Please, use the --infer_data option.'
+        )
         fp32_model_path = test_case_args.fp32_model
         labels_path = test_case_args.labels
         batch_size = test_case_args.batch_size
@@ -315,9 +315,9 @@ class QuantInt8NLPComparisonTest(unittest.TestCase):
             )
 
         self._targets = self._strings_from_csv(test_case_args.targets)
-        assert self._targets.intersection(
-            {'quant', 'int8', 'fp32'}
-        ), 'The --targets option, if used, must contain at least one of the targets: "quant", "int8", "fp32".'
+        assert self._targets.intersection({'quant', 'int8', 'fp32'}), (
+            'The --targets option, if used, must contain at least one of the targets: "quant", "int8", "fp32".'
+        )
 
         _logger.info('Quant & INT8 prediction run.')
         _logger.info(f'Quant model: {quant_model_path}')

--- a/test/quantization/quant_int8_image_classification_comparison.py
+++ b/test/quantization/quant_int8_image_classification_comparison.py
@@ -287,13 +287,13 @@ class QuantInt8ImageClassificationComparisonTest(unittest.TestCase):
             return
 
         quant_model_path = test_case_args.quant_model
-        assert (
-            quant_model_path
-        ), 'The Quant model path cannot be empty. Please, use the --quant_model option.'
+        assert quant_model_path, (
+            'The Quant model path cannot be empty. Please, use the --quant_model option.'
+        )
         data_path = test_case_args.infer_data
-        assert (
-            data_path
-        ), 'The dataset path cannot be empty. Please, use the --infer_data option.'
+        assert data_path, (
+            'The dataset path cannot be empty. Please, use the --infer_data option.'
+        )
         batch_size = test_case_args.batch_size
         batch_num = test_case_args.batch_num
         skip_batch_num = test_case_args.skip_batch_num

--- a/test/rnn/rnn_numpy.py
+++ b/test/rnn/rnn_numpy.py
@@ -423,9 +423,9 @@ class BiRNN(LayerMixin):
         self, inputs, initial_states=None, sequence_length=None, **kwargs
     ):
         if isinstance(initial_states, (list, tuple)):
-            assert (
-                len(initial_states) == 2
-            ), "length of initial_states should be 2 when it is a list/tuple"
+            assert len(initial_states) == 2, (
+                "length of initial_states should be 2 when it is a list/tuple"
+            )
         else:
             initial_states = [initial_states, initial_states]
 

--- a/test/sequence/test_sequence_conv.py
+++ b/test/sequence/test_sequence_conv.py
@@ -58,10 +58,7 @@ def seqconv(
                 )
                 if padding_trainable:
                     sub_w = padding_data[
-                        begin_pad
-                        + context_start
-                        + j
-                        - pad_size : begin_pad
+                        begin_pad + context_start + j - pad_size : begin_pad
                         + context_start
                         + j,
                         :,

--- a/test/sot/test_analysis_inputs.py
+++ b/test/sot/test_analysis_inputs.py
@@ -45,9 +45,9 @@ def assert_inputs_equals(instruction_offset: int, expected_inputs: set[str]):
     reads, writes = analysis_used_names(
         instructions, current_instr_idx + instruction_offset
     )
-    assert (
-        set(reads) == expected_inputs
-    ), f"actual_inputs: {reads}, expected_inputs: {expected_inputs}"
+    assert set(reads) == expected_inputs, (
+        f"actual_inputs: {reads}, expected_inputs: {expected_inputs}"
+    )
 
 
 def case1(x):

--- a/test/sot/test_sot_exception.py
+++ b/test/sot/test_sot_exception.py
@@ -77,9 +77,9 @@ class TestException(unittest.TestCase):
         except Exception as e:
             match_results = re.compile(r'File ".*", line (\d+)').findall(str(e))
             match_results = list(map(int, match_results))
-            assert (
-                match_results == error_lines
-            ), f"{match_results} is not equal {error_lines}"
+            assert match_results == error_lines, (
+                f"{match_results} is not equal {error_lines}"
+            )
 
     def test_all_case(self):
         self.catch_error(case1, paddle.rand([2, 1]), 25)

--- a/test/tokenizer/tokenizer_utils.py
+++ b/test/tokenizer/tokenizer_utils.py
@@ -563,9 +563,9 @@ class PretrainedTokenizer:
                 # reload from save_directory
                 tokenizer = BertTokenizer.from_pretrained('trained_model')
         """
-        assert not os.path.isfile(
-            save_directory
-        ), f"Saving directory ({save_directory}) should be a directory, not a file"
+        assert not os.path.isfile(save_directory), (
+            f"Saving directory ({save_directory}) should be a directory, not a file"
+        )
         os.makedirs(save_directory, exist_ok=True)
 
         tokenizer_config_file = os.path.join(

--- a/test/xpu/collective_allgather_api.py
+++ b/test/xpu/collective_allgather_api.py
@@ -116,9 +116,9 @@ class TestCollectiveAllgatherAPI(test_base.TestCollectiveAPIRunnerBase):
         indata = test_base.create_test_data(
             shape=(10, 1000), dtype=args["dtype"], seed=os.getpid()
         )
-        assert (
-            args['static_mode'] == 1
-        ), "collective_allgather_api only support static graph mode"
+        assert args['static_mode'] == 1, (
+            "collective_allgather_api only support static graph mode"
+        )
         result = (
             self.get_model_new(
                 train_prog, startup_prog, rank, dtype=args["dtype"]

--- a/test/xpu/test_fused_linear_param_grad_add_xpu.py
+++ b/test/xpu/test_fused_linear_param_grad_add_xpu.py
@@ -84,9 +84,9 @@ def run_fused_linear_param_grad_add(
     if dweight is not None:
         assert dweight_new.data_ptr() == dweight.data_ptr()
     if has_bias and dbias is not None:
-        assert (
-            dbias_new.data_ptr() == dbias.data_ptr()
-        ), f"multi_precision={multi_precision}, has_bias={has_bias}, dbias.dtype={dbias.dtype}."
+        assert dbias_new.data_ptr() == dbias.data_ptr(), (
+            f"multi_precision={multi_precision}, has_bias={has_bias}, dbias.dtype={dbias.dtype}."
+        )
     if has_bias:
         return (
             promote_dtype(dweight_new).numpy(),

--- a/test/xpu/test_generate_proposals_v2_op_xpu.py
+++ b/test/xpu/test_generate_proposals_v2_op_xpu.py
@@ -103,9 +103,9 @@ def box_coder(all_anchors, bbox_deltas, variances, pixel_offset=True):
 def clip_tiled_boxes(boxes, im_shape, pixel_offset=True):
     """Clip boxes to image boundaries. im_shape is [height, width] and boxes
     has shape (N, 4 * num_tiled_boxes)."""
-    assert (
-        boxes.shape[1] % 4 == 0
-    ), f'boxes.shape[1] is {boxes.shape[1]:d}, but must be divisible by 4.'
+    assert boxes.shape[1] % 4 == 0, (
+        f'boxes.shape[1] is {boxes.shape[1]:d}, but must be divisible by 4.'
+    )
     offset = 1 if pixel_offset else 0
     # x1 >= 0
     boxes[:, 0::4] = np.maximum(

--- a/test/xpu/test_put_along_axis_op_int_xpu.py
+++ b/test/xpu/test_put_along_axis_op_int_xpu.py
@@ -64,17 +64,17 @@ class XPUTestPutAlongAxisInt(XPUOpTestWrapper):
                                 self.value_broadcast[i, j, k]
                             )
                         elif self.reduce == "add":
-                            self.target[
-                                loc_[0], loc_[1], loc_[2]
-                            ] += self.value_broadcast[i, j, k]
+                            self.target[loc_[0], loc_[1], loc_[2]] += (
+                                self.value_broadcast[i, j, k]
+                            )
                         elif self.reduce == "mul" or self.reduce == "multiply":
-                            self.target[
-                                loc_[0], loc_[1], loc_[2]
-                            ] *= self.value_broadcast[i, j, k]
+                            self.target[loc_[0], loc_[1], loc_[2]] *= (
+                                self.value_broadcast[i, j, k]
+                            )
                         elif self.reduce == "mean":
-                            self.target[
-                                loc_[0], loc_[1], loc_[2]
-                            ] += self.value_broadcast[i, j, k]
+                            self.target[loc_[0], loc_[1], loc_[2]] += (
+                                self.value_broadcast[i, j, k]
+                            )
                             loc = tuple(loc_)
                             if loc in mean_record.keys():
                                 mean_record[loc] += 1

--- a/test/xpu/test_put_along_axis_op_xpu.py
+++ b/test/xpu/test_put_along_axis_op_xpu.py
@@ -64,17 +64,17 @@ class XPUTestPutAlongAxis(XPUOpTestWrapper):
                                 self.value_broadcast[i, j, k]
                             )
                         elif self.reduce == "add":
-                            self.target[
-                                loc_[0], loc_[1], loc_[2]
-                            ] += self.value_broadcast[i, j, k]
+                            self.target[loc_[0], loc_[1], loc_[2]] += (
+                                self.value_broadcast[i, j, k]
+                            )
                         elif self.reduce == "mul" or self.reduce == "multiply":
-                            self.target[
-                                loc_[0], loc_[1], loc_[2]
-                            ] *= self.value_broadcast[i, j, k]
+                            self.target[loc_[0], loc_[1], loc_[2]] *= (
+                                self.value_broadcast[i, j, k]
+                            )
                         elif self.reduce == "mean":
-                            self.target[
-                                loc_[0], loc_[1], loc_[2]
-                            ] += self.value_broadcast[i, j, k]
+                            self.target[loc_[0], loc_[1], loc_[2]] += (
+                                self.value_broadcast[i, j, k]
+                            )
                             loc = tuple(loc_)
                             if loc in mean_record.keys():
                                 mean_record[loc] += 1

--- a/test/xpu/test_randperm_op_xpu.py
+++ b/test/xpu/test_randperm_op_xpu.py
@@ -30,9 +30,9 @@ paddle.enable_static()
 
 
 def check_randperm_out(n, data_np):
-    assert isinstance(
-        data_np, np.ndarray
-    ), "The input data_np should be np.ndarray."
+    assert isinstance(data_np, np.ndarray), (
+        "The input data_np should be np.ndarray."
+    )
     gt_sorted = np.arange(n)
     out_sorted = np.sort(data_np)
     return list(gt_sorted == out_sorted)

--- a/test/xpu/test_sequence_conv_op_xpu.py
+++ b/test/xpu/test_sequence_conv_op_xpu.py
@@ -71,10 +71,7 @@ def seqconv(
                 )
                 if padding_trainable:
                     sub_w = padding_data[
-                        begin_pad
-                        + context_start
-                        + j
-                        - pad_size : begin_pad
+                        begin_pad + context_start + j - pad_size : begin_pad
                         + context_start
                         + j,
                         :,

--- a/test/xpu/test_set_value_op_xpu.py
+++ b/test/xpu/test_set_value_op_xpu.py
@@ -1028,9 +1028,7 @@ class XPUTestSetValueOp(XPUOpTestWrapper):
         def set_value(self):
             self.value = np.array(
                 [[1, 1, 1, 1], [2, 2, 2, 2], [3, 3, 3, 3]]
-            ).astype(
-                self.dtype
-            )  # shape is (3,4)
+            ).astype(self.dtype)  # shape is (3,4)
 
         def _call_setitem(self, x):
             x[0] = paddle.assign(self.value)  # x is Paddle.Tensor

--- a/test/xpu/test_top_k_v2_op_xpu.py
+++ b/test/xpu/test_top_k_v2_op_xpu.py
@@ -32,9 +32,9 @@ def random_unique_float(shape, dtype):
     numel = np.prod(shape)
     arr = np.random.uniform(-10.0, 10.0, numel * 10).astype(dtype)
     arr = np.unique(arr)
-    assert (
-        arr.shape[0] >= numel
-    ), f"failed to create enough unique values: {arr.shape[0]} vs {numel}"
+    assert arr.shape[0] >= numel, (
+        f"failed to create enough unique values: {arr.shape[0]} vs {numel}"
+    )
     arr = arr[:numel]
     np.random.shuffle(arr)
     arr = arr.reshape(shape)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

使用性能更好，格式化效果更佳的 ruff format 替代 black 作为新的 formatter，由于我们很早就已经集成了 ruff lint，因此只是减少依赖而不会增加依赖

<!--

## 核心优势

通过集成 Ruff format，开发者可以享受到以下优势：

- 通过去除 black 对 python 环境依赖，极大降低了升级 formatter 带来的成本，后续无需考虑开发者本地 python 环境即可一键升级
- ruff 由 Rust 驱动，大幅加速 format 时间，降低开发者使用开发工具链的时间成本，减少 CI 时间，提升工程效率
- 格式化后呈现可读性更佳的效果，使得开发者更专注于代码开发而无需关心格式，阅读者也能够更加赏心悦目，极大增加了潜在贡献者的贡献意愿
- ruff 极大程度地兼容了 black 的格式化效果，能够平滑地替换现有的 black 配置
- ruff 更新频次高，能够快速响应社区反馈，持续优化格式化效果
- ruff 团队 Astral 最近开发的 ty 能够提供更强大的类型检查能力，后续可能与 ruff 集成，提供更好的开发体验
- PyTorch 最近已经完成迁移，追平竞品（在代码风格这块，我们一直做到了超越竞品，这次不能落后）

-->