### PR TITLE
[CodeStyle] `black -> ruff format` migration - part 40

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -107,7 +107,7 @@ repos:
 
             # | test/[m-z].+
 
-            # | tools/.+
+            | tools/.+
           )$
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.12.0
@@ -163,7 +163,7 @@ repos:
 
             | test/[m-z].+
 
-            | tools/.+
+            # | tools/.+
           )$
   # For C++ files
   - repo: local

--- a/tools/check_op_benchmark_result.py
+++ b/tools/check_op_benchmark_result.py
@@ -115,9 +115,9 @@ def compare_benchmark_result(
     develop_speed = develop_result.get("speed")
     pr_speed = pr_result.get("speed")
 
-    assert type(develop_speed) == type(
-        pr_speed
-    ), "The types of comparison results need to be consistent."
+    assert type(develop_speed) == type(pr_speed), (
+        "The types of comparison results need to be consistent."
+    )
 
     if isinstance(develop_speed, dict) and isinstance(pr_speed, dict):
         if check_speed_result(case_name, develop_speed, pr_speed, pr_result):

--- a/tools/check_op_desc.py
+++ b/tools/check_op_desc.py
@@ -300,17 +300,17 @@ def compare_op_desc(origin_op_desc, new_op_desc):
             desc_error_message.setdefault(op_type, {})[ATTRS] = attrs_diff
 
         if ins_version_errors:
-            version_error_message.setdefault(op_type, {})[
-                INPUTS
-            ] = ins_version_errors
+            version_error_message.setdefault(op_type, {})[INPUTS] = (
+                ins_version_errors
+            )
         if outs_version_errors:
-            version_error_message.setdefault(op_type, {})[
-                OUTPUTS
-            ] = outs_version_errors
+            version_error_message.setdefault(op_type, {})[OUTPUTS] = (
+                outs_version_errors
+            )
         if attrs_version_errors:
-            version_error_message.setdefault(op_type, {})[
-                ATTRS
-            ] = attrs_version_errors
+            version_error_message.setdefault(op_type, {})[ATTRS] = (
+                attrs_version_errors
+            )
 
     return desc_error_message, version_error_message
 

--- a/tools/gen_pybind11_stub.py
+++ b/tools/gen_pybind11_stub.py
@@ -525,9 +525,9 @@ class OpsYamlBaseAPI:
         inputs = {'names': [], 'input_info': {}}
         attrs = {'names': [], 'attr_info': {}}
         args_str = args_config.strip()
-        assert args_str.startswith('(') and args_str.endswith(
-            ')'
-        ), f"Args declaration should start with '(' and end with ')', please check the args of {api_name} in yaml."
+        assert args_str.startswith('(') and args_str.endswith(')'), (
+            f"Args declaration should start with '(' and end with ')', please check the args of {api_name} in yaml."
+        )
         args_str = args_str[1:-1]
         pattern = re.compile(r',(?![^{]*\})')  # support int[] a={1,3}
         args_list = re.split(pattern, args_str.strip())
@@ -541,12 +541,12 @@ class OpsYamlBaseAPI:
             for in_type_symbol, in_type in INPUT_TYPES_MAP.items():
                 if type_and_name[0] == in_type_symbol:
                     input_name = type_and_name[1].strip()
-                    assert (
-                        len(input_name) > 0
-                    ), f"The input tensor name should not be empty. Please check the args of {api_name} in yaml."
-                    assert (
-                        len(attrs['names']) == 0
-                    ), f"The input Tensor should appear before attributes. please check the position of {api_name}:input({input_name}) in yaml"
+                    assert len(input_name) > 0, (
+                        f"The input tensor name should not be empty. Please check the args of {api_name} in yaml."
+                    )
+                    assert len(attrs['names']) == 0, (
+                        f"The input Tensor should appear before attributes. please check the position of {api_name}:input({input_name}) in yaml"
+                    )
 
                     if input_name in optional_vars:
                         in_type = OPTIONAL_TYPES_TRANS[in_type_symbol]
@@ -562,9 +562,9 @@ class OpsYamlBaseAPI:
             for attr_type_symbol, attr_type in ATTR_TYPES_MAP.items():
                 if type_and_name[0] == attr_type_symbol:
                     attr_name = item[len(attr_type_symbol) :].strip()
-                    assert (
-                        len(attr_name) > 0
-                    ), f"The attribute name should not be empty. Please check the args of {api_name} in yaml."
+                    assert len(attr_name) > 0, (
+                        f"The attribute name should not be empty. Please check the args of {api_name} in yaml."
+                    )
                     default_value = None
                     if '=' in attr_name:
                         attr_infos = attr_name.split('=')
@@ -589,14 +589,14 @@ class OpsYamlBaseAPI:
                 r"(?P<out_type>[a-zA-Z0-9_[\]]+)\s*(?P<name>\([a-zA-Z0-9_@]+\))?\s*(?P<expr>\{[^\}]+\})?",
                 output_item,
             )
-            assert (
-                result is not None
-            ), f"{api_name} : the output config parse error."
+            assert result is not None, (
+                f"{api_name} : the output config parse error."
+            )
             out_type = result.group('out_type')
-            assert (
-                out_type in OUTPUT_TYPE_MAP
-            ), f"{api_name} : Output type error: the output type only support Tensor and Tensor[], \
+            assert out_type in OUTPUT_TYPE_MAP, (
+                f"{api_name} : Output type error: the output type only support Tensor and Tensor[], \
                     but now is {out_type}."
+            )
 
             out_name = (
                 'out'

--- a/tools/gen_ut_cmakelists.py
+++ b/tools/gen_ut_cmakelists.py
@@ -99,11 +99,7 @@ def _process_archs(arch):
         for a in arch.split(";"):
             if '' == a:
                 continue
-            assert a in [
-                "GPU",
-                "ROCM",
-                "XPU",
-            ], (
+            assert a in ["GPU", "ROCM", "XPU"], (
                 f"""Supported arch options are "GPU", "ROCM", and "XPU", but the options is {a}"""
             )
             archs += "WITH_" + a.upper() + " OR "
@@ -129,11 +125,7 @@ def _process_os(os_):
     if len(os_) > 0:
         os_ = os_.upper()
         for p in os_.split(';'):
-            assert p in [
-                "WIN32",
-                "APPLE",
-                "LINUX",
-            ], (
+            assert p in ["WIN32", "APPLE", "LINUX"], (
                 f"""Supported os options are 'WIN32', 'APPLE' and 'LINUX', but the options is {p}"""
             )
         os_ = os_.replace(";", " OR ")

--- a/tools/gen_ut_cmakelists.py
+++ b/tools/gen_ut_cmakelists.py
@@ -103,7 +103,9 @@ def _process_archs(arch):
                 "GPU",
                 "ROCM",
                 "XPU",
-            ], f"""Supported arch options are "GPU", "ROCM", and "XPU", but the options is {a}"""
+            ], (
+                f"""Supported arch options are "GPU", "ROCM", and "XPU", but the options is {a}"""
+            )
             archs += "WITH_" + a.upper() + " OR "
         arch = "(" + archs[:-4] + ")"
     else:
@@ -131,7 +133,9 @@ def _process_os(os_):
                 "WIN32",
                 "APPLE",
                 "LINUX",
-            ], f"""Supported os options are 'WIN32', 'APPLE' and 'LINUX', but the options is {p}"""
+            ], (
+                f"""Supported os options are 'WIN32', 'APPLE' and 'LINUX', but the options is {p}"""
+            )
         os_ = os_.replace(";", " OR ")
         os_ = "(" + os_ + ")"
     else:
@@ -146,7 +150,9 @@ def _process_run_serial(run_serial):
         "1",
         "0",
         "",
-    ], f"""the value of run_serial must be one of 0, 1 or empty. But this value is {rs}"""
+    ], (
+        f"""the value of run_serial must be one of 0, 1 or empty. But this value is {rs}"""
+    )
     if rs == "":
         return ""
     return rs
@@ -175,9 +181,9 @@ def _process_name(name, curdir):
     )
     filepath_prefix = os.path.join(curdir, name)
     suffix = [".py", ".sh"]
-    assert _file_with_extension(
-        filepath_prefix, suffix
-    ), f""" Please ensure the test file with the prefix '{filepath_prefix}' and one of the suffix {suffix} exists, because you specified a unittest named '{name}'"""
+    assert _file_with_extension(filepath_prefix, suffix), (
+        f""" Please ensure the test file with the prefix '{filepath_prefix}' and one of the suffix {suffix} exists, because you specified a unittest named '{name}'"""
+    )
 
     return name
 
@@ -238,7 +244,9 @@ class DistUTPortManager:
             re.compile("^[0-9]+$").search(port_num)
             and int(port_num) > 0
             or port_num.strip() == ""
-        ), f"""port_num must be format as a positive integer or empty, but this port_num is '{port_num}'"""
+        ), (
+            f"""port_num must be format as a positive integer or empty, but this port_num is '{port_num}'"""
+        )
         port_num = port_num.strip()
         if len(port_num) == 0:
             return 0
@@ -272,7 +280,9 @@ class DistUTPortManager:
 
                 # match right tests name format, the name must start with 'test_' followed by at least one char of
                 # '0-9'. 'a-z'. 'A-Z' or '_'
-                assert re.compile("^test_[0-9a-zA-Z_]+").search(
+                assert re.compile(
+                    "^test_[0-9a-zA-Z_]+"
+                ).search(
                     name
                 ), f'''we found a test for initial the latest dist_port but the test name '{name}' seems to be wrong
                     at line {k - 1}, in file {cmake_file_name}
@@ -349,9 +359,9 @@ class DistUTPortManager:
                         if name == self.last_test_name:
                             found = True
                             break
-                assert (
-                    found
-                ), f"no such test named '{self.last_test_name}' in file '{self.last_test_cmake_file}'"
+                assert found, (
+                    f"no such test named '{self.last_test_name}' in file '{self.last_test_cmake_file}'"
+                )
                 if launcher[-2:] == ".sh":
                     self.process_dist_port_num(num_port)
 
@@ -485,9 +495,9 @@ class CMakeGenerator:
             try:
                 run_type = _process_run_type(run_type)
             except Exception as e:
-                assert (
-                    run_type.strip() == ""
-                ), f"{e}\nIf use test_runner.py, the run_type can be ''"
+                assert run_type.strip() == "", (
+                    f"{e}\nIf use test_runner.py, the run_type can be ''"
+                )
             cmd += f'''if({archs} AND {os_})
         py_test_modules(
         {name}
@@ -580,7 +590,9 @@ class CMakeGenerator:
             assert (
                 f"{current_work_dir}/CMakeLists.txt"
                 not in self.modified_or_created_files
-            ), f"the file {current_work_dir}/CMakeLists.txt are modified twice, which may cause some error"
+            ), (
+                f"the file {current_work_dir}/CMakeLists.txt are modified twice, which may cause some error"
+            )
             self.modified_or_created_files.append(
                 f"{current_work_dir}/CMakeLists.txt"
             )
@@ -630,15 +642,15 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    assert not (
-        len(args.files) == 0 and len(args.dirpaths) == 0
-    ), "You must provide at least one file or dirpath"
+    assert not (len(args.files) == 0 and len(args.dirpaths) == 0), (
+        "You must provide at least one file or dirpath"
+    )
     current_work_dirs = []
     if len(args.files) >= 1:
         for p in args.files:
-            assert (
-                os.path.basename(p) == "testslist.csv"
-            ), "you must input file named testslist.csv"
+            assert os.path.basename(p) == "testslist.csv", (
+                "you must input file named testslist.csv"
+            )
         current_work_dirs = current_work_dirs + [
             os.path.dirname(file) for file in args.files
         ]

--- a/tools/test_check_pr_approval.py
+++ b/tools/test_check_pr_approval.py
@@ -68,9 +68,7 @@ class Test_check_approval(unittest.TestCase):
     "author_association": "CONTRIBUTOR"
   }
 ]
-""".encode(
-            self.codeset
-        )
+""".encode(self.codeset)
 
     def test_ids(self):
         cmd = [sys.executable, 'check_pr_approval.py', '1', '26408901']


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

使用性能更好，格式化效果更佳的 ruff format 替代 black 作为新的 formatter，由于我们很早就已经集成了 ruff lint，因此只是减少依赖而不会增加依赖

<!--

## 核心优势

通过集成 Ruff format，开发者可以享受到以下优势：

- 通过去除 black 对 python 环境依赖，极大降低了升级 formatter 带来的成本，后续无需考虑开发者本地 python 环境即可一键升级
- ruff 由 Rust 驱动，大幅加速 format 时间，降低开发者使用开发工具链的时间成本，减少 CI 时间，提升工程效率
- 格式化后呈现可读性更佳的效果，使得开发者更专注于代码开发而无需关心格式，阅读者也能够更加赏心悦目，极大增加了潜在贡献者的贡献意愿
- ruff 极大程度地兼容了 black 的格式化效果，能够平滑地替换现有的 black 配置
- ruff 更新频次高，能够快速响应社区反馈，持续优化格式化效果
- ruff 团队 Astral 最近开发的 ty 能够提供更强大的类型检查能力，后续可能与 ruff 集成，提供更好的开发体验
- PyTorch 最近已经完成迁移，追平竞品（在代码风格这块，我们一直做到了超越竞品，这次不能落后）

-->