### PR TITLE
[AutoParallel] [Cherry-Pick] close a ValueError for shard one tensor dim by many mesh dim case

### DIFF
--- a/python/paddle/distributed/auto_parallel/moe_utils.py
+++ b/python/paddle/distributed/auto_parallel/moe_utils.py
@@ -393,10 +393,11 @@ def get_rank2tensor_indices(sub_mesh_indices_info, sub_mesh_partial_info):
 
 
 def get_local_slices(tensor, mesh, placements):
-    if len(mesh.shape) < len(placements):
-        raise ValueError(
-            f"placements length ({len(placements)}) must be smaller or equal to mesh_shape({len(mesh.shape)})"
-        )
+    # TODO(nieyuntao): Temporarily disable this check to bypass certain special cases (shard one tensor dim by many mesh dim)
+    # if len(mesh.shape) < len(placements):
+    #     raise ValueError(
+    #         f"placements length ({len(placements)}) must be smaller or equal to mesh_shape({len(mesh.shape)})"
+    #     )
     if len(placements) < len(mesh.shape):
         for _ in range(len(mesh.shape) - len(placements)):
             placements.append(dist.Replicate())

--- a/test/auto_parallel/semi_auto_parallel_moe_utils.py
+++ b/test/auto_parallel/semi_auto_parallel_moe_utils.py
@@ -79,13 +79,13 @@ class TestMoEUtils(unittest.TestCase):
             dist_x.grad._local_value().numpy(),
         )
 
-        with np.testing.assert_raises(AssertionError):
-            dist_z = dist.auto_parallel.moe_utils._dist_reshape(
-                dist_x,
-                dist_x.shape,
-                self._mesh1,
-                [dist.Replicate(), dist.Replicate()],
-            )
+        # with np.testing.assert_raises(AssertionError):
+        #     dist_z = dist.auto_parallel.moe_utils._dist_reshape(
+        #         dist_x,
+        #         dist_x.shape,
+        #         self._mesh1,
+        #         [dist.Replicate(), dist.Replicate()],
+        #     )
 
         dist_z = dist.auto_parallel.moe_utils._dist_reshape(
             dist_x, dist_x.shape, self._mesh0, [dist.Shard(1), dist.Shard(1)]
@@ -174,11 +174,11 @@ class TestMoEUtils(unittest.TestCase):
             dist_y_local_slices[1]['slice'], [(2, 4), (0, 4)]
         )
 
-        with self.assertRaises(ValueError):
-            tmp_placements = [dist.Shard(0), dist.Shard(1), dist.Replicate()]
-            dist_y_local_slices = get_local_slices(
-                dist_y, self._mesh0, tmp_placements
-            )
+        # with self.assertRaises(ValueError):
+        #     tmp_placements = [dist.Shard(0), dist.Shard(1), dist.Replicate()]
+        #     dist_y_local_slices = get_local_slices(
+        #         dist_y, self._mesh0, tmp_placements
+        #     )
 
     # python -m paddle.distributed.launch --devices=0,1 semi_auto_parallel_moe_utils.py
     def test_reshard_general_case(self):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
切多刀形态下目前存在一些传入placements的维度大于mesh维度的情况，由于不影响后续执行过程，暂时关闭该检查；后续解决切多刀问题后重新打开
