### PR TITLE
【Hackathon 9th No.4】fix index_add 0-size

### DIFF
--- a/paddle/phi/infermeta/binary.cc
+++ b/paddle/phi/infermeta/binary.cc
@@ -2501,6 +2501,12 @@ void IndexAddInferMeta(const MetaTensor& x,
                        int axis,
                        MetaTensor* output) {
   auto input_dim = x.dims();
+  if (index.dims().size() == 1 && index.dims()[0] == 0) {
+    output->set_dims(input_dim);
+    output->set_dtype(x.dtype());
+    output->set_layout(x.layout());
+    return;
+  }
   auto index_dim = index.dims();
   auto add_value_dim = add_value.dims();
 

--- a/paddle/phi/infermeta/binary.cc
+++ b/paddle/phi/infermeta/binary.cc
@@ -2501,10 +2501,17 @@ void IndexAddInferMeta(const MetaTensor& x,
                        int axis,
                        MetaTensor* output) {
   auto input_dim = x.dims();
+  if (common::product(input_dim) == 0) {
+    output->set_dims(input_dim);
+    output->set_dtype(x.dtype());
+    output->set_layout(x.layout());
+    return;
+  }
   if (index.dims().size() == 1 && index.dims()[0] == 0) {
     output->set_dims(input_dim);
     output->set_dtype(x.dtype());
     output->set_layout(x.layout());
+    output->share_lod(x);
     return;
   }
   auto index_dim = index.dims();
@@ -2530,7 +2537,13 @@ void IndexAddInferMeta(const MetaTensor& x,
                         "the dimension of Input(Index) is [%d].",
                         index_dim,
                         index_dim.size()));
-
+  if (common::product(add_value_dim) == 0) {
+    output->set_dims(input_dim);
+    output->set_dtype(x.dtype());
+    output->set_layout(x.layout());
+    output->share_lod(x);
+    return;
+  }
   // Note, add_value does not support broadcast now.
   PADDLE_ENFORCE_EQ(input_dim.size() == add_value_dim.size(),
                     true,

--- a/paddle/phi/kernels/gpu/index_add_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_add_grad_kernel.cu
@@ -46,7 +46,19 @@ void IndexAddGradKernel(const Context& dev_ctx,
     }
     return;
   }
-
+  if (index.numel() == 0) {
+    if (x_grad) {
+      phi::Copy(dev_ctx, out_grad, dev_ctx.GetPlace(), false, x_grad);
+    }
+    if (add_value_grad) {
+      phi::Full<T, Context>(
+          dev_ctx,
+          phi::IntArray(common::vectorize(add_value_grad->dims())),
+          0,
+          add_value_grad);
+    }
+    return;
+  }
   // x.shape == out.shape in index_grad op
   auto input_dim = out_grad.dims();
   auto add_value_dim = add_value.dims();

--- a/paddle/phi/kernels/gpu/index_add_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_add_grad_kernel.cu
@@ -36,7 +36,9 @@ void IndexAddGradKernel(const Context& dev_ctx,
                         DenseTensor* x_grad,
                         DenseTensor* add_value_grad) {
   if (out_grad.numel() == 0) {
-    dev_ctx.template Alloc<T>(x_grad);
+    if (x_grad) {
+      dev_ctx.template Alloc<T>(x_grad);
+    }
     if (add_value_grad) {
       phi::Full<T, Context>(
           dev_ctx,
@@ -56,6 +58,15 @@ void IndexAddGradKernel(const Context& dev_ctx,
           phi::IntArray(common::vectorize(add_value_grad->dims())),
           0,
           add_value_grad);
+    }
+    return;
+  }
+  if (add_value.numel() == 0) {
+    if (x_grad) {
+      phi::Copy(dev_ctx, out_grad, dev_ctx.GetPlace(), false, x_grad);
+    }
+    if (add_value_grad) {
+      dev_ctx.template Alloc<T>(add_value_grad);
     }
     return;
   }

--- a/paddle/phi/kernels/gpu/index_add_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_add_kernel.cu
@@ -57,9 +57,7 @@ void IndexAddKernel(const Context& dev_ctx,
                     int axis,
                     DenseTensor* output) {
   if (x.numel() == 0) {
-    if (output->numel() > 0) {
-      dev_ctx.template Alloc<T>(output);
-    }
+    phi::Copy(dev_ctx, x, dev_ctx.GetPlace(), false, output);
     return;
   }
   if (index.numel() == 0) {
@@ -68,10 +66,6 @@ void IndexAddKernel(const Context& dev_ctx,
   }
   if (add_value.numel() == 0) {
     phi::Copy(dev_ctx, x, dev_ctx.GetPlace(), false, output);
-    return;
-  }
-  if (output->numel() == 0) {
-    dev_ctx.template Alloc<T>(output);
     return;
   }
   auto input_dim = x.dims();

--- a/paddle/phi/kernels/gpu/index_add_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_add_kernel.cu
@@ -43,6 +43,13 @@ __global__ void index_add_cuda_kernel(const T* input,
     int64_t dim_idx = idx % (stride * size) / stride;
     IndexT src_dim_idx =
         (index[dim_idx] < 0 ? index[dim_idx] + index_dim_size : index[dim_idx]);
+    if (src_dim_idx < 0 || src_dim_idx >= index_dim_size) {
+      printf("Index out of bounds: index[%d] = %d, index_dim_size = %d\n",
+             dim_idx,
+             src_dim_idx,
+             index_dim_size);
+      return;
+    }
     int64_t input_idx =
         idx + (delta * pre_idx + src_dim_idx - dim_idx) * stride;
     phi::CudaAtomicAdd(&output[input_idx], add_value[idx]);
@@ -61,12 +68,8 @@ void IndexAddKernel(const Context& dev_ctx,
     return;
   }
   PADDLE_ENFORCE_NOT_NULL(
-      output, errors::InvalidArgument("The output tensor must not be null."));
-  PADDLE_ENFORCE_GT(
-      output->numel(),
-      0,
-      errors::InvalidArgument(
-          "The output tensor must have a positive number of elements."));
+      output->data<T>(),
+      errors::InvalidArgument("The output tensor memory is not allocated."));
   auto input_dim = x.dims();
   auto output_dim = output->dims();
   auto add_value_dim = add_value.dims();

--- a/paddle/phi/kernels/gpu/index_add_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_add_kernel.cu
@@ -43,13 +43,6 @@ __global__ void index_add_cuda_kernel(const T* input,
     int64_t dim_idx = idx % (stride * size) / stride;
     IndexT src_dim_idx =
         (index[dim_idx] < 0 ? index[dim_idx] + index_dim_size : index[dim_idx]);
-    if (src_dim_idx < 0 || src_dim_idx >= index_dim_size) {
-      printf("Index out of bounds: index[%d] = %d, index_dim_size = %d\n",
-             dim_idx,
-             src_dim_idx,
-             index_dim_size);
-      return;
-    }
     int64_t input_idx =
         idx + (delta * pre_idx + src_dim_idx - dim_idx) * stride;
     phi::CudaAtomicAdd(&output[input_idx], add_value[idx]);
@@ -63,10 +56,6 @@ void IndexAddKernel(const Context& dev_ctx,
                     const DenseTensor& add_value,
                     int axis,
                     DenseTensor* output) {
-  if (output && output->numel() == 0) {
-    dev_ctx.template Alloc<T>(output);
-    return;
-  }
   if (x.numel() == 0) {
     if (output->numel() > 0) {
       dev_ctx.template Alloc<T>(output);
@@ -79,6 +68,10 @@ void IndexAddKernel(const Context& dev_ctx,
   }
   if (add_value.numel() == 0) {
     phi::Copy(dev_ctx, x, dev_ctx.GetPlace(), false, output);
+    return;
+  }
+  if (output->numel() == 0) {
+    dev_ctx.template Alloc<T>(output);
     return;
   }
   auto input_dim = x.dims();
@@ -94,9 +87,6 @@ void IndexAddKernel(const Context& dev_ctx,
 
   auto* in_data = x.data<T>();
   T* out_data = dev_ctx.template Alloc<T>(output);
-  PADDLE_ENFORCE_NOT_NULL(
-      out_data,
-      errors::InvalidArgument("The output tensor memory is not allocated."));
   auto* add_value_data = add_value.data<T>();
 
   int64_t numel = add_value.numel();

--- a/paddle/phi/kernels/gpu/index_add_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_add_kernel.cu
@@ -67,6 +67,20 @@ void IndexAddKernel(const Context& dev_ctx,
     dev_ctx.template Alloc<T>(output);
     return;
   }
+  if (x.numel() == 0) {
+    if (output->numel() > 0) {
+      dev_ctx.template Alloc<T>(output);
+    }
+    return;
+  }
+  if (index.numel() == 0) {
+    phi::Copy(dev_ctx, x, dev_ctx.GetPlace(), false, output);
+    return;
+  }
+  if (add_value.numel() == 0) {
+    phi::Copy(dev_ctx, x, dev_ctx.GetPlace(), false, output);
+    return;
+  }
   auto input_dim = x.dims();
   auto output_dim = output->dims();
   auto add_value_dim = add_value.dims();
@@ -86,9 +100,6 @@ void IndexAddKernel(const Context& dev_ctx,
   auto* add_value_data = add_value.data<T>();
 
   int64_t numel = add_value.numel();
-  if (numel == 0) {
-    return;
-  }
   auto stream = dev_ctx.stream();
 
   unsigned int block_dim = PADDLE_CUDA_NUM_THREADS;
@@ -98,7 +109,6 @@ void IndexAddKernel(const Context& dev_ctx,
   // copy input to output.
   // todo(@limin29): inplace do not need copy.
   phi::Copy(dev_ctx, x, dev_ctx.GetPlace(), false, output);
-  if (index.numel() == 0) return;
 
   if (FLAGS_cudnn_deterministic) {
     VLOG(2) << "Run grad kernel of index_add with single thread.";

--- a/paddle/phi/kernels/gpu/index_add_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_add_kernel.cu
@@ -60,6 +60,13 @@ void IndexAddKernel(const Context& dev_ctx,
     dev_ctx.template Alloc<T>(output);
     return;
   }
+  PADDLE_ENFORCE_NOT_NULL(
+      output, errors::InvalidArgument("The output tensor must not be null."));
+  PADDLE_ENFORCE_GT(
+      output->numel(),
+      0,
+      errors::InvalidArgument(
+          "The output tensor must have a positive number of elements."));
   auto input_dim = x.dims();
   auto output_dim = output->dims();
   auto add_value_dim = add_value.dims();

--- a/paddle/phi/kernels/gpu/index_add_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_add_kernel.cu
@@ -67,9 +67,6 @@ void IndexAddKernel(const Context& dev_ctx,
     dev_ctx.template Alloc<T>(output);
     return;
   }
-  PADDLE_ENFORCE_NOT_NULL(
-      output->data<T>(),
-      errors::InvalidArgument("The output tensor memory is not allocated."));
   auto input_dim = x.dims();
   auto output_dim = output->dims();
   auto add_value_dim = add_value.dims();
@@ -83,6 +80,9 @@ void IndexAddKernel(const Context& dev_ctx,
 
   auto* in_data = x.data<T>();
   T* out_data = dev_ctx.template Alloc<T>(output);
+  PADDLE_ENFORCE_NOT_NULL(
+      out_data,
+      errors::InvalidArgument("The output tensor memory is not allocated."));
   auto* add_value_data = add_value.data<T>();
 
   int64_t numel = add_value.numel();

--- a/test/legacy_test/test_index_add_op.py
+++ b/test/legacy_test/test_index_add_op.py
@@ -513,5 +513,27 @@ class TestIndexAddOp_ZeroSize(OpTest):
         )
 
 
+class TestIndexAdd_ZeroSize2(TestIndexAddOp_ZeroSize):
+    def setUp(self):
+        index_np = np.array([], dtype=self.index_type)
+        x_np = np.random.random(self.x_shape).astype(self.x_type)
+        add_value_np = np.random.random(self.add_value_shape).astype(
+            self.x_type
+        )
+
+        self.inputs = {'X': x_np, 'Index': index_np, 'AddValue': add_value_np}
+        self.attrs = {'axis': self.axis}
+        out = x_np.copy()
+        self.outputs = {'Out': out}
+
+    def init_dtype_type(self):
+        self.x_type = np.float32
+        self.index_type = np.int32
+        self.x_shape = (10,)
+        self.index_size = 0
+        self.axis = 0
+        self.add_value_shape = (0,)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/legacy_test/test_index_add_op.py
+++ b/test/legacy_test/test_index_add_op.py
@@ -515,6 +515,7 @@ class TestIndexAddOp_ZeroSize(OpTest):
 
 class TestIndexAdd_ZeroSize2(TestIndexAddOp_ZeroSize):
     def setUp(self):
+        self.init_dtype_type()
         index_np = np.array([], dtype=self.index_type)
         x_np = np.random.random(self.x_shape).astype(self.x_type)
         add_value_np = np.random.random(self.add_value_shape).astype(

--- a/test/legacy_test/test_index_add_op.py
+++ b/test/legacy_test/test_index_add_op.py
@@ -513,8 +513,12 @@ class TestIndexAddOp_ZeroSize(OpTest):
         )
 
 
-class TestIndexAdd_ZeroSize2(TestIndexAddOp_ZeroSize):
+class TestIndexAdd_ZeroSize2(OpTest):
     def setUp(self):
+        self.python_api = raw_index_add
+        self.op_type = "index_add"
+        self.prim_op_type = "prim"
+        self.public_python_api = raw_index_add
         self.init_dtype_type()
         index_np = np.array([], dtype=self.index_type)
         x_np = np.random.random(self.x_shape).astype(self.x_type)
@@ -534,6 +538,14 @@ class TestIndexAdd_ZeroSize2(TestIndexAddOp_ZeroSize):
         self.index_size = 0
         self.axis = 0
         self.add_value_shape = (0,)
+
+    def test_check_output(self):
+        self.check_output(atol=1e-2, check_pir=True)
+
+    def test_check_grad_normal(self):
+        self.check_grad(
+            ['X', 'AddValue'], 'Out', check_pir=True, check_prim_pir=True
+        )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
```bash
 paddle.index_add(Tensor([10],"float32"), Tensor([0],"int32"), 0, Tensor([4],"float32"), ) 
 (External) CUDA error(700), an illegal memory access was encountered. 
  [Hint: 'cudaErrorIllegalAddress'. The device encountered a load or store instruction on an invalid memory address. This leaves the process in an inconsistentstate and any further CUDA work will return the same error. To continue using CUDA, the process must be terminated and relaunched. ] (at /home/aistudio/Paddle/paddle/fluid/pybind/eager_functions.cc:1435)

terminate called after throwing an instance of 'common::enforce::EnforceNotMet'
  what():  (External) CUDA error(700), an illegal memory access was encountered. 
  [Hint: 'cudaErrorIllegalAddress'. The device encountered a load or store instruction on an invalid memory address. This leaves the process in an inconsistentstate and any further CUDA work will return the same error. To continue using CUDA, the process must be terminated and relaunched. ] (at /home/aistudio/Paddle/paddle/phi/core/platform/device/gpu/gpu_info.cc:348)



--------------------------------------
C++ Traceback (most recent call last):
--------------------------------------
0   std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release()
1   phi::DenseTensor::~DenseTensor()
2   std::_Sp_counted_deleter<phi::Allocation*, std::function<void (phi::Allocation*)>, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>::_M_dispose()
3   paddle::memory::allocation::CUDAAllocator::FreeImpl(phi::Allocation*)

----------------------
Error Message Summary:
----------------------
FatalError: `Process abort signal` is detected by the operating system.
  [TimeInfo: *** Aborted at 1755826917 (unix time) try "date -d @1755826917" if you are using GNU date ***]
  [SignalInfo: *** SIGABRT (@0x3e800000e48) received by PID 3656 (TID 0x7f57ee946740) from PID 3656 ***]

Aborted (core dumped)
```
1. check src_dim_idx in index_add_cuda_kernel
2. add PADDLE_ENFORCE_NOT_NULL