### PR TITLE
Fix Bug for code gen  when generate the code related parameters alias

### DIFF
--- a/paddle/fluid/pir/dialect/op_generator/python_c_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/python_c_gen.py
@@ -230,9 +230,9 @@ MUTABLE_ATTR_OBJ_TEMPLATE = """
         PyObject *{name}_obj = PyTuple_GET_ITEM(args, {index});"""
 
 MUTABLE_ATTR_OBJ_FROM_ARGS_KWARGS_WITH_DEFAULT_VALUE_TEMPLATE = """
-        PyObject *{name}_obj = GetItemFromArgsOrKWArgs(args, {index},kwargs,{keywords}, nargs, &remaining_kwargs,false);"""
-MUTABLE_ATTR_OBJ_FROM_ARGS_KWARGS_TEMPLATE = """
         PyObject *{name}_obj = GetItemFromArgsOrKWArgs(args, {index},kwargs,{keywords}, nargs, &remaining_kwargs);"""
+MUTABLE_ATTR_OBJ_FROM_ARGS_KWARGS_TEMPLATE = """
+        PyObject *{name}_obj = GetItemFromArgsOrKWArgs(args, {index},kwargs,{keywords}, nargs, &remaining_kwargs,false);"""
 
 MUTABLE_ATTR_CAST_TEMPLATE = """
             {type} {name_} = {cast_func}({name}_obj, "{api_name}", {index});"""

--- a/paddle/fluid/pir/dialect/op_generator/python_c_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/python_c_gen.py
@@ -270,7 +270,7 @@ TYPE_TO_FUNC_MAP = {
     "paddle::Place": "CastPyArg2Place",
     "phi::Place": "CastPyArg2Place",
     "Place": "CastPyArg2Place",
-    "phi::DataType": "CastPyArg2DataTypeDirectly",
+    "phi::DataType": "CastPyArg2DataType",
 }
 
 TYPE_TO_PHI_DATATYPE_MAP = {

--- a/paddle/fluid/pir/dialect/op_generator/python_c_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/python_c_gen.py
@@ -436,6 +436,8 @@ class PythonCCodeGen(CodeGen):
         return ret
 
     def _gen_attrs_py_obj_with_mutable(self, op_info, args_alias_map={}):
+        if self.use_custom_args_mapper:
+            return DISABLE_TIPS
         input_size = len(op_info.input_name_list)
         name_list = op_info.attribute_name_list
         default_value_list = op_info.attribute_default_value_list
@@ -475,6 +477,8 @@ class PythonCCodeGen(CodeGen):
         return ret
 
     def _gen_cast_attrs(self, op_info, op_name):
+        if self.use_custom_args_mapper:
+            return DISABLE_TIPS
         input_size = len(op_info.input_name_list)
         attr_name_list = op_info.attribute_name_list
         attr_type_list = op_info.attribute_build_arg_type_list
@@ -649,7 +653,10 @@ class PythonCCodeGen(CodeGen):
             all_params_list.append(name)
         attribute_name_list = op_info.attribute_name_list
         attribute_type_list = op_info.attribute_build_arg_type_list
+        mutable_attr_name_list = op_info.mutable_attribute_name_list
         for name, type in zip(attribute_name_list, attribute_type_list):
+            if name in mutable_attr_name_list:
+                type = OP_INPUT
             custom_args_mapper_str += PARAMS_DECLARE_TEMPLE.format(
                 name=name, type=_trans_dtype(type)
             )


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
 Operator Mechanism 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes 

### Description
<!-- Describe what you’ve done -->
修复静态图代码生成的bug
- 默认值参数取参过程在MUTABLE场景下可能会导致一些参数有默认值但是仍然需要从args中取出。
- MUTABLE场景下 args mapper机制会保留部分重重复的变量声明
- 使用CastPyArg2DataType代替CastPyArg2DataTypeDirectly，实现功能更强的转换。


pcard-67164