### PR TITLE
【Hackathon 9th No.5】Add index check for index_sample gpu kernel

### DIFF
--- a/paddle/phi/kernels/gpu/index_sample_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_sample_kernel.cu
@@ -48,6 +48,12 @@ __global__ void IndexSampleForward(const SampleIndexT* index,
       ElementIndexT index_idx = index_j * index_length + index_i;
       ElementIndexT in_idx = index_j * input_length + index_i;
       SampleIndexT sample_idx = index[index_idx];
+      PADDLE_ENFORCE(sample_idx >= 0 && sample_idx < input_length,
+                     "Variable value (index) of OP(index_sample) "
+                     "expected >= 0 and < %ld, but got %ld. Please check input "
+                     "value.",
+                     input_length,
+                     sample_idx);
       out_data[index_idx] = in_data[in_idx - index_i + sample_idx];
     }
   }

--- a/paddle/phi/kernels/gpu/index_sample_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_sample_kernel.cu
@@ -15,6 +15,7 @@
 #include "paddle/phi/kernels/index_sample_kernel.h"
 
 #include <algorithm>
+#include <limits>
 #include <vector>
 
 #include "paddle/phi/backends/gpu/gpu_context.h"
@@ -31,6 +32,35 @@ namespace {
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
 #define UINT32_MAX std::numeric_limits<uint32_t>::max()
 
+// Helper to check that indices are within [0, input_length) on CPU.
+template <typename IndexT, typename Context>
+inline void CheckIndexOnCPU(const Context& dev_ctx,
+                            const DenseTensor& index,
+                            int64_t input_length) {
+  DenseTensor index_tensor_cpu;
+  phi::Copy(dev_ctx, index, phi::CPUPlace(), true, &index_tensor_cpu);
+  const IndexT* index_data_cpu = index_tensor_cpu.data<IndexT>();
+  for (int64_t i = 0; i < index.numel(); i++) {
+    PADDLE_ENFORCE_GE(
+        index_data_cpu[i],
+        0,
+        errors::InvalidArgument(
+            "Variable value (index) of OP(index_sample) "
+            "expected >= 0 and < %ld, but got %ld. Please check input "
+            "value.",
+            input_length,
+            index_data_cpu[i]));
+    PADDLE_ENFORCE_LT(
+        index_data_cpu[i],
+        input_length,
+        errors::InvalidArgument(
+            "Variable value (index) of OP(index_sample) "
+            "expected >= 0 and < %ld, but got %ld. Please check input "
+            "value.",
+            input_length,
+            index_data_cpu[i]));
+  }
+}
 }  // namespace
 
 template <typename T, typename SampleIndexT = int, typename ElementIndexT>
@@ -48,12 +78,6 @@ __global__ void IndexSampleForward(const SampleIndexT* index,
       ElementIndexT index_idx = index_j * index_length + index_i;
       ElementIndexT in_idx = index_j * input_length + index_i;
       SampleIndexT sample_idx = index[index_idx];
-      PADDLE_ENFORCE(sample_idx >= 0 && sample_idx < input_length,
-                     "Variable value (index) of OP(index_sample) "
-                     "expected >= 0 and < %ld, but got %ld. Please check input "
-                     "value.",
-                     input_length,
-                     sample_idx);
       out_data[index_idx] = in_data[in_idx - index_i + sample_idx];
     }
   }
@@ -86,6 +110,13 @@ void IndexSampleKernel(const Context& dev_ctx,
   size_t batch_size = input_dim[0];
   size_t input_length = input_dim[1];
   size_t index_length = index_dim[1];
+
+  if (index_type == DataType::INT64) {
+    CheckIndexOnCPU<int64_t>(
+        dev_ctx, index, static_cast<int64_t>(input_length));
+  } else if (index_type == DataType::INT32) {
+    CheckIndexOnCPU<int>(dev_ctx, index, static_cast<int64_t>(input_length));
+  }
 
   auto block_width = phi::backends::gpu::RoundToPowerOfTwo(index_length);
   block_width = MIN(block_width, PREDEFINED_BLOCK_SIZE_X);

--- a/test/legacy_test/test_index_sample_op.py
+++ b/test/legacy_test/test_index_sample_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, convert_float_to_uint16
+from op_test import OpTest, convert_float_to_uint16, get_places
 
 import paddle
 from paddle import base
@@ -172,6 +172,41 @@ class TestIndexSampleOp_ZeroSize2(TestIndexSampleOp_ZeroSize):
         self.x_type = "float64"
         self.index_shape = (0, 0)
         self.index_type = "int32"
+
+
+class TestIndexSampleOpError(unittest.TestCase):
+    def test_errors(self):
+        places = get_places()
+        for place in places:
+            with base.dygraph.guard(place):
+                self.assertRaises(
+                    ValueError,
+                    paddle.index_sample,
+                    x=paddle.rand([10, 0], dtype="float32"),
+                    index=paddle.randint(
+                        low=0, high=5, shape=[10, 1], dtype="int32"
+                    ),
+                )
+
+            with base.dygraph.guard(place):
+                self.assertRaises(
+                    ValueError,
+                    paddle.index_sample,
+                    x=paddle.rand([10, 0], dtype="float32"),
+                    index=paddle.randint(
+                        low=0, high=5, shape=[10, 1], dtype="int64"
+                    ),
+                )
+
+            with base.dygraph.guard(place):
+                self.assertRaises(
+                    ValueError,
+                    paddle.index_sample,
+                    x=paddle.to_tensor(
+                        [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype="float32"
+                    ),
+                    index=paddle.to_tensor([[0, 1], [0, 4]], dtype="int64"),
+                )
 
 
 @unittest.skipIf(core.is_compiled_with_xpu(), "complex is not supported on XPU")


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Add index check for index_sample gpu kernel
1. 0-size-cpu（numpy error，生不成 index 值）
<img width="1053" height="516" alt="图片" src="https://github.com/user-attachments/assets/7dea0934-018b-47e0-88db-73422c3da04c" />
<img width="975" height="252" alt="图片" src="https://github.com/user-attachments/assets/14de0fcd-5173-4337-9805-8b64703c179f" />
2. 0-size-gpu（numpy error，生不成 index 值）
<img width="1025" height="466" alt="图片" src="https://github.com/user-attachments/assets/b8e14556-a63b-48b7-9cf6-3e464e293d93" />
3. pr 修改 GPU 和 CPU 一样检查越界，避免出现未知的 codedump