### PR TITLE
【Hackathon 9th No.1】Add running_mean running_var check for batch_norm cpu kernel when needed

### DIFF
--- a/paddle/phi/kernels/cpu/batch_norm_kernel.cc
+++ b/paddle/phi/kernels/cpu/batch_norm_kernel.cc
@@ -170,6 +170,47 @@ void BatchNormKernel(const Context& dev_ctx,
         running_mean_arr * momentum + saved_mean_e * (1. - momentum);
     running_var_arr =
         running_var_arr * momentum + saved_variance_e * (1. - momentum);
+  } else {
+    const auto* est_mean = &mean;
+    const auto* est_var = &variance;
+    PADDLE_ENFORCE_EQ(
+        est_mean->dims().size(),
+        1UL,
+        common::errors::InvalidArgument(
+            "The size of mean's dimensions must equal to 1."
+            "But received: the size of mean's dimensions mean is [%d],"
+            "the dimensions of mean is [%s].",
+            est_mean->dims().size(),
+            est_mean->dims()));
+    PADDLE_ENFORCE_EQ(
+        est_var->dims().size(),
+        1UL,
+        common::errors::InvalidArgument(
+            "The size of variance's dimensions must equal to 1."
+            "But received: the size of variance's dimensions is [%d],"
+            "the dimensions of variance is [%s].",
+            est_var->dims().size(),
+            est_var->dims()));
+    PADDLE_ENFORCE_EQ(
+        est_mean->dims()[0],
+        C,
+        common::errors::InvalidArgument(
+            "The first dimension of mean must equal to the number of "
+            "Channels, which is [%d]. But received: the first dimension"
+            "of mean is [%d], the dimensions of mean is [%s].",
+            C,
+            est_mean->dims()[0],
+            est_mean->dims()));
+    PADDLE_ENFORCE_EQ(
+        est_var->dims()[0],
+        C,
+        common::errors::InvalidArgument(
+            "The first dimension of variance must equal to the number"
+            "of Channels, which is [%d]. But received: the first dimension of"
+            "variance is [%d], the dimensions of variance is [%s].",
+            C,
+            est_var->dims()[0],
+            est_var->dims()));
   }
 
   // use SavedMean and SavedVariance to do normalize

--- a/test/legacy_test/test_batch_norm_op.py
+++ b/test/legacy_test/test_batch_norm_op.py
@@ -646,6 +646,32 @@ class TestBatchNormAPI_ZeroSize(unittest.TestCase):
                 np.testing.assert_allclose(x.grad.shape, x.shape)
 
 
+class TestBatchNormAPI_Error(unittest.TestCase):
+    def setUp(self):
+        self.places = get_places()
+
+    def test_dygraph(self):
+        for place in self.places:
+            with paddle.base.dygraph.guard(place):
+                self.assertRaises(
+                    ValueError,
+                    paddle.nn.functional.batch_norm,
+                    x=paddle.rand([16, 16, 16, 8], dtype="float32"),
+                    running_mean=paddle.rand([0], dtype="float32"),
+                    running_var=paddle.rand([16], dtype="float32"),
+                    use_global_stats=True,
+                )
+            with paddle.base.dygraph.guard(place):
+                self.assertRaises(
+                    ValueError,
+                    paddle.nn.functional.batch_norm,
+                    x=paddle.rand([16, 16, 16, 8], dtype="float32"),
+                    running_mean=paddle.rand([16], dtype="float32"),
+                    running_var=paddle.rand([0], dtype="float32"),
+                    use_global_stats=True,
+                )
+
+
 if __name__ == '__main__':
     paddle.enable_static()
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Add running_mean running_var check for batch_norm cpu kernel when needed
1. 0-size-cpu（Pass）
<img width="1318" height="413" alt="图片" src="https://github.com/user-attachments/assets/99113d74-51d5-4a51-b2f2-0ef79e341485" />
2. 0-size-cpu-paddle-only（Pass，剩余 cpu 不支持 float16）
<img width="1294" height="194" alt="图片" src="https://github.com/user-attachments/assets/b3d3ea32-5966-4b79-aa3c-86918c3e140c" />

<img width="1272" height="72" alt="图片" src="https://github.com/user-attachments/assets/1a9559ee-71c2-4c82-b099-f0321d5e71fb" />

3. 0-size-gpu（都是 torch error，padlle 报错日志对齐的，这个 pr 修改的是 cpu 端也应该报错）
<img width="1253" height="441" alt="图片" src="https://github.com/user-attachments/assets/4e655617-6bfa-48b1-acf5-687fffafc9f2" />
