### PR TITLE
【Hackathon 9th No.3】Add bias check for fused_layer_norm

### DIFF
--- a/paddle/phi/infermeta/multiary.cc
+++ b/paddle/phi/infermeta/multiary.cc
@@ -2647,6 +2647,17 @@ void FusedLayerNormInferMeta(const MetaTensor& x,
                             x_dims_vec[i],
                             residual_dims_vec[i]));
     }
+    if (config.is_runtime && bias && normalized_dims != 0) {
+      PADDLE_ENFORCE_EQ(bias.numel(),
+                        normalized_dims,
+                        common::errors::InvalidArgument(
+                            "The numel of Input(bias) must be equal to "
+                            "the normalized_dims of Input(X), but "
+                            "received numel of Input(bias) is [%d], "
+                            "received normalized_dims of Input(X) is [%d]",
+                            bias.numel(),
+                            normalized_dims));
+    }
   }
 
   int64_t rows = 1;

--- a/paddle/phi/infermeta/multiary.cc
+++ b/paddle/phi/infermeta/multiary.cc
@@ -2647,16 +2647,32 @@ void FusedLayerNormInferMeta(const MetaTensor& x,
                             x_dims_vec[i],
                             residual_dims_vec[i]));
     }
-    if (config.is_runtime && bias && normalized_dims != 0) {
-      PADDLE_ENFORCE_EQ(bias.numel(),
-                        normalized_dims,
-                        common::errors::InvalidArgument(
-                            "The numel of Input(bias) must be equal to "
-                            "the normalized_dims of Input(X), but "
-                            "received numel of Input(bias) is [%d], "
-                            "received normalized_dims of Input(X) is [%d]",
-                            bias.numel(),
-                            normalized_dims));
+    if (bias) {
+      std::vector<int64_t> bias_dims_vec = common::vectorize(bias.dims());
+      PADDLE_ENFORCE_EQ(
+          x_dims_size - begin_norm_axis,
+          bias_dims_vec.size(),
+          common::errors::InvalidArgument(
+              "The normalized size of Input(X) must be equal to the size "
+              "of Bias, but received normalized size of Input(X) is [%d], "
+              "received size of Bias is [%d]",
+              x_dims_size - begin_norm_axis,
+              bias_dims_vec.size()));
+      for (size_t i = begin_norm_axis; i < x_dims_size; ++i) {
+        if (x_dims_vec[i] == -1 || bias_dims_vec[i - begin_norm_axis] == -1 ||
+            x_dims_vec[i] == 0)
+          continue;
+
+        PADDLE_ENFORCE_EQ(x_dims_vec[i],
+                          bias_dims_vec[i - begin_norm_axis],
+                          common::errors::InvalidArgument(
+                              "The normalized dimension of Input(X) and Bias "
+                              "must match at axis %d, but received Input(X) "
+                              "dimension is [%d], Bias dimension is [%d]",
+                              i,
+                              x_dims_vec[i],
+                              bias_dims_vec[i - begin_norm_axis]));
+      }
     }
   }
 
@@ -2676,6 +2692,18 @@ void FusedLayerNormInferMeta(const MetaTensor& x,
               "of Weight is [%d]",
               normalized_dims,
               norm_weight.dims()[0]));
+    }
+    if (norm_bias) {
+      PADDLE_ENFORCE_EQ(
+          normalized_dims,
+          norm_bias.dims()[0],
+          common::errors::InvalidArgument(
+              "The normalized size of Input(X) must equal to be "
+              "the size of Bias, but received "
+              "normalized size of Input(X) is [%d], received size "
+              "of Bias is [%d]",
+              normalized_dims,
+              norm_bias.dims()[0]));
     }
   }
 

--- a/test/legacy_test/test_fused_layernorm_op.py
+++ b/test/legacy_test/test_fused_layernorm_op.py
@@ -1229,5 +1229,28 @@ class TestlayernormOp_ZeroSize(TestlayernormOp):
         self.quant_min_bound = -127
 
 
+@unittest.skipIf(
+    not core.is_compiled_with_cuda() and not paddle.is_compiled_with_rocm(),
+    "core is not compiled with CUDA or ROCM",
+)
+class TestFusedLayerNorm_ZeroSize_Error(unittest.TestCase):
+    def test_bias_error(self):
+        with paddle.base.dygraph.guard():
+            x = paddle.randn([16, 256], dtype="float32")
+            bias = paddle.randn([0], dtype="float32")
+            residual = paddle.rand([16, 256], "float32")
+            self.assertRaises(
+                ValueError,
+                paddle.incubate.nn.functional.fused_layer_norm,
+                x=x,
+                norm_weight=paddle.randn([256], dtype="float32"),
+                norm_bias=paddle.randn([256], dtype="float32"),
+                epsilon=1e-06,
+                begin_norm_axis=1,
+                bias=bias,
+                residual=residual,
+            )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/legacy_test/test_fused_layernorm_op.py
+++ b/test/legacy_test/test_fused_layernorm_op.py
@@ -1251,6 +1251,19 @@ class TestFusedLayerNorm_ZeroSize_Error(unittest.TestCase):
                 residual=residual,
             )
 
+            bias = paddle.randn([256], dtype="float32")
+            self.assertRaises(
+                ValueError,
+                paddle.incubate.nn.functional.fused_layer_norm,
+                x=x,
+                norm_weight=paddle.randn([256], dtype="float32"),
+                norm_bias=paddle.randn([0], dtype="float32"),
+                epsilon=1e-06,
+                begin_norm_axis=1,
+                bias=bias,
+                residual=residual,
+            )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Add bias check for fused_layer_norm
1. 0-size-cpu（Pass）
<img width="1225" height="393" alt="图片" src="https://github.com/user-attachments/assets/d41aca5a-2d7e-4e6b-a708-3d18f036560b" />
2. 0-size-gpu（pass）
<img width="1297" height="412" alt="图片" src="https://github.com/user-attachments/assets/66934db0-726b-4075-9c81-aca3cba89c9e" />
3. 0-size-gpu-paddle-only（torch error，下面是 --paddle_only=True 时结果，现在添加检查修复之前的 coredump）
<img width="1224" height="469" alt="图片" src="https://github.com/user-attachments/assets/ef32fe0d-de7a-42cc-b0dd-759c43e4703e" />

<img width="1551" height="412" alt="图片" src="https://github.com/user-attachments/assets/3e7de73f-6fe0-45d6-9021-86c102fda666" />