### PR TITLE
[AutoParallel] fix pp use in auto_dy

### DIFF
--- a/python/paddle/distributed/auto_parallel/pipelining/schedules.py
+++ b/python/paddle/distributed/auto_parallel/pipelining/schedules.py
@@ -26,6 +26,10 @@ from typing import (
     NamedTuple,
 )
 
+from paddle import nn
+from paddle.distributed import fleet
+from paddle.distributed.auto_parallel.pipelining.stage import PipelineStage
+
 if TYPE_CHECKING:
     from .stage import _PipelineStageBase
 
@@ -42,6 +46,7 @@ from .microbatch import (
 )
 
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 
 class _ActType(Enum):
@@ -526,6 +531,143 @@ class ScheduleFThenB(PipelineScheduleSingle):
 
         # Synchronize the gradients of shared parameters.
         self._stage._sync_shared_param_grads()
+
+
+class PPChunk(nn.Layer):
+    def __init__(self, layers=None, is_first=False, is_last=False):
+        super().__init__()
+        assert not (is_first and is_last)
+        self.layers = layers
+        self.is_first = is_first
+        self.is_last = is_last
+
+    def forward(self, *args, **kwargs):
+        if self.is_first:
+            input_ids = kwargs.get("input_ids")
+            attention_mask = kwargs.get("attention_mask")
+            position_ids = kwargs.get("position_ids")
+            outputs = (input_ids, attention_mask, position_ids)
+            # decoder layers
+            for idx, (decoder_layer) in enumerate(self.layers):
+                outputs = decoder_layer(outputs)
+            return outputs
+        elif self.is_last:
+            outputs = args
+            # decoder layers
+            for idx, (decoder_layer) in enumerate(self.layers):
+                outputs = decoder_layer(outputs)
+            if isinstance(outputs, tuple):
+                outputs = outputs[0]
+        else:
+            outputs = args
+            # decoder layers
+            for idx, (decoder_layer) in enumerate(self.layers):
+                outputs = decoder_layer(outputs)
+        return outputs
+
+
+def _manual_model_split(model, stage_idx, group, mode, pp_degree):
+    num_hidden_layers = model.config.num_hidden_layers
+    virtual_pp_degree = model.config.virtual_pp_degree if mode == "VPP" else 1
+    chunk_size = num_hidden_layers // virtual_pp_degree // pp_degree
+    chunk_num = virtual_pp_degree * pp_degree
+    layer_lists = model.layers
+
+    def _build_stage(model, stage_idx, group):
+        new_model = None
+        if stage_idx == 0:
+            new_model = PPChunk(
+                layer_lists[:chunk_size], is_first=True, is_last=False
+            )
+        elif stage_idx == chunk_num - 1:
+            new_model = PPChunk(
+                layer_lists[
+                    stage_idx * chunk_size : (stage_idx + 1) * chunk_size
+                ],
+                is_first=False,
+                is_last=True,
+            )
+        else:
+            new_model = PPChunk(
+                layer_lists[
+                    stage_idx * chunk_size : (stage_idx + 1) * chunk_size
+                ],
+                is_first=False,
+                is_last=False,
+            )
+        stage = PipelineStage(new_model, stage_idx, chunk_num, group=group)
+        return stage
+
+    stages = []
+    for i in range(virtual_pp_degree):
+        stage = _build_stage(model, stage_idx + i * pp_degree, group)
+        stages.append(stage)
+    return stages
+
+
+def get_pp_schedule(model, n_microbatches, loss_fn, mode, pp_degree, group):
+    assert mode in [
+        "VPP",
+        "1F1B",
+        "FThenB",
+    ], (
+        f"Invalid pipeline schedule mode: {mode}, must be one of ['VPP', '1F1B', 'FThenB']"
+    )
+    stages = _manual_model_split(model, group.rank, group, mode, pp_degree)
+    if mode == "VPP":
+        schedule = ScheduleVPP(
+            stages, n_microbatches=n_microbatches, loss_fn=loss_fn
+        )
+    elif mode == "1F1B":
+        schedule = Schedule1F1B(
+            stages[0], n_microbatches=n_microbatches, loss_fn=loss_fn
+        )
+    else:
+        schedule = ScheduleFThenB(
+            stages[0], n_microbatches=n_microbatches, loss_fn=loss_fn
+        )
+    return schedule
+
+
+def parse_args(args, num=3):
+    trip = tuple([None] * num)
+    if isinstance(args, tuple):
+        for i in range(min(len(args), num)):
+            trip = (*trip[:i], args[i], *trip[i + 1 :])
+    else:
+        trip = (args, *trip[1:])
+    for i in range(1, num):
+        if trip[i] is not None and hasattr(trip[i], 'stop_gradient'):
+            trip[i].stop_gradient = True
+    return trip
+
+
+def return_args(**kwargs):
+    ret = ()
+    for name, value in kwargs.items():
+        if value is not None:
+            ret += (value.clone() if hasattr(value, "clone") else value,)
+    return ret[0] if len(ret) == 1 else ret
+
+
+def build_pp_layers(config, layer_func):
+    layers = nn.LayerList()
+    pp_degree = config.pipeline_parallel_degree
+    chunk_size = (
+        config.num_hidden_layers // pp_degree // config.virtual_pp_degree
+    )
+    current_rank = (
+        fleet.get_hybrid_communicate_group().get_pipe_parallel_group().rank
+        % pp_degree
+    )
+    for idx in range(config.num_hidden_layers):
+        target_stage = (idx // chunk_size) % pp_degree
+        if target_stage == current_rank:
+            stage_id = (idx // chunk_size) % pp_degree
+            layers.append(layer_func(config, idx, stage_id))
+        else:
+            layers.append(nn.Identity())
+    return layers
 
 
 class Schedule1F1B(PipelineScheduleSingle):

--- a/python/paddle/distributed/auto_parallel/pipelining/stage.py
+++ b/python/paddle/distributed/auto_parallel/pipelining/stage.py
@@ -43,6 +43,7 @@ from .utils import (
 )
 
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 
 def _restore_placements_info(args, infos, curr_mesh):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel
### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
For improving pipeline parallel usability

- Migrate pp_split, parse_args, return_args to schedules.py, and improved reusability.

Pcard-70448