### PR TITLE
[API Compatiblity] Add `pin_memory` for 2 API

### DIFF
--- a/python/paddle/base/dygraph/math_op_patch.py
+++ b/python/paddle/base/dygraph/math_op_patch.py
@@ -317,6 +317,7 @@ def monkey_patch_math_tensor():
         dtype: DTypeLike | None = None,
         device: PlaceLike | None = None,
         requires_grad: bool = False,
+        pin_memory: bool = False,
     ) -> Tensor:
         if dtype is None:
             dtype = var.dtype
@@ -328,6 +329,7 @@ def monkey_patch_math_tensor():
             dtype,
             device=device,
             requires_grad=requires_grad,
+            pin_memory=pin_memory,
         )
 
     def _new_ones_(

--- a/python/paddle/pir/math_op_patch.py
+++ b/python/paddle/pir/math_op_patch.py
@@ -691,6 +691,7 @@ def monkey_patch_value():
         dtype: DTypeLike | None = None,
         device: PlaceLike | None = None,
         requires_grad: bool = False,
+        pin_memory: bool = False,
     ):
         """
 
@@ -721,7 +722,11 @@ def monkey_patch_value():
             device = self.place
 
         return paddle.empty(
-            size, dtype=dtype, device=device, requires_grad=requires_grad
+            size,
+            dtype=dtype,
+            device=device,
+            requires_grad=requires_grad,
+            pin_memory=pin_memory,
         )
 
     def _new_ones_(

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -2768,6 +2768,7 @@ def empty(
     out: paddle.Tensor | None = None,
     device: PlaceLike | None = None,
     requires_grad: bool = False,
+    pin_memory: bool = False,
 ) -> paddle.Tensor:
     """
     Returns a Tensor with uninitialized data which size is same as ``shape``.
@@ -2786,6 +2787,7 @@ def empty(
             if None, uses the current device for the default tensor type (see paddle.device.set_device()).
             device will be the CPU for CPU tensor types and the current CUDA device for CUDA tensor types. Default: None.
         requires_grad(bool, optional):  If autograd should record operations on the returned tensor. Default: False.
+        pin_memory(bool, optional): If set, return tensor would be allocated in the pinned memory. Works only for CPU tensors. Default: False
 
     Returns:
         Tensor: Tensor which is created according to ``shape`` and ``dtype``, and is uninitialized.
@@ -2862,16 +2864,34 @@ def empty(
             else:
                 raise TypeError("Shape only supports Value, or list, or tuple.")
 
+        device = (
+            _get_paddle_place(device)
+            if device is not None
+            else _current_expected_place()
+        )
+        if (
+            pin_memory
+            and device is not None
+            and not isinstance(
+                device, (core.CUDAPinnedPlace, core.XPUPinnedPlace)
+            )
+        ):
+            if isinstance(device, core.CUDAPlace):
+                device = core.CUDAPinnedPlace()
+            elif isinstance(device, core.XPUPlace):
+                device = core.XPUPinnedPlace()
+            else:
+                raise RuntimeError(
+                    f"Pinning memory is not supported for {device}."
+                )
         tensor = _C_ops.empty(
             shape,
             convert_np_dtype_to_dtype_(dtype),
-            (
-                _get_paddle_place(device)
-                if device is not None
-                else _current_expected_place()
-            ),
+            device,
             out=out,
         )
+        if pin_memory and in_dynamic_mode():
+            tensor = tensor.pin_memory()
         if requires_grad is True:
             tensor.stop_gradient = False
         return tensor

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -2871,18 +2871,25 @@ def empty(
         )
         if (
             pin_memory
+            and in_dynamic_mode()
             and device is not None
             and not isinstance(
                 device, (core.CUDAPinnedPlace, core.XPUPinnedPlace)
             )
         ):
-            if isinstance(device, core.CUDAPlace):
+            if isinstance(device, core.CUDAPlace) or (
+                isinstance(device, core.Place) and device.is_gpu_place()
+            ):
                 device = core.CUDAPinnedPlace()
-            elif isinstance(device, core.XPUPlace):
+            elif isinstance(device, core.XPUPlace) or (
+                isinstance(device, core.Place) and device.is_xpu_place()
+            ):
                 device = core.XPUPinnedPlace()
             else:
                 raise RuntimeError(
-                    f"Pinning memory is not supported for {device}."
+                    f"Pinning memory is not supported for {device}., "
+                    f"{in_dynamic_mode()}, "
+                    f"device = {device}, {type(device)}"
                 )
         tensor = _C_ops.empty(
             shape,

--- a/test/legacy_test/test_creation.py
+++ b/test/legacy_test/test_creation.py
@@ -30,7 +30,7 @@ class TestTensorCreation(unittest.TestCase):
             self.devices.append("gpu")
             self.devices.append("gpu:0")
         if paddle.device.is_compiled_with_xpu():
-            self.devices.append(paddle.device.XPUPlace(0))
+            self.devices.append(paddle.XPUPlace(0))
         if paddle.device.is_compiled_with_ipu():
             self.devices.append(paddle.device.IPUPlace())
 
@@ -254,6 +254,17 @@ class TestTensorCreation(unittest.TestCase):
             self.dtypes,
             pin_memorys,
         ):
+            if device not in [
+                "gpu",
+                "gpu:0",
+                paddle.CUDAPlace(0)
+                if paddle.device.is_compiled_with_cuda()
+                else None,
+                paddle.XPUPlace(0)
+                if paddle.device.is_compiled_with_xpu()
+                else None,
+            ]:
+                pin_memory = False
             with dygraph_guard():
                 x = paddle.empty(
                     [2],
@@ -262,7 +273,10 @@ class TestTensorCreation(unittest.TestCase):
                     device=device,
                     pin_memory=pin_memory,
                 )
-                if isinstance(device, paddle.framework.core.Place):
+                if (
+                    isinstance(device, paddle.framework.core.Place)
+                    and not pin_memory
+                ):
                     self.assertEqual(x.place, device)
                 self.assertEqual(x.stop_gradient, not requires_grad)
                 if isinstance(dtype, paddle.dtype):
@@ -304,11 +318,6 @@ class TestTensorCreation(unittest.TestCase):
                 self.assertEqual(x.stop_gradient, not requires_grad)
                 if isinstance(dtype, paddle.dtype):
                     self.assertEqual(x.dtype, dtype)
-                if pin_memory:
-                    if paddle.device.is_compiled_with_cuda():
-                        self.assertIsInstance(x.place, paddle.CUDAPinnedPlace)
-                    elif paddle.device.is_compiled_with_cuda():
-                        self.assertIsInstance(x.place, paddle.XPUPinnedPlace)
 
     def test_eye(self):
         for device, requires_grad, dtype in product(
@@ -685,7 +694,7 @@ class TestTensorPatchMethod(unittest.TestCase):
             self.devices.append("gpu")
             self.devices.append("gpu:0")
         if paddle.device.is_compiled_with_xpu():
-            self.devices.append(paddle.device.XPUPlace(0))
+            self.devices.append(paddle.XPUPlace(0))
         if paddle.device.is_compiled_with_ipu():
             self.devices.append(paddle.device.IPUPlace())
 
@@ -845,11 +854,23 @@ class TestTensorPatchMethod(unittest.TestCase):
         ):
             pin_memorys.append(True)
         for shape, device, requires_grad, dtype, pin_memory in product(
+            self.shapes,
             self.devices,
             self.requires_grads,
             self.dtypes,
             pin_memorys,
         ):
+            if device not in [
+                "gpu",
+                "gpu:0",
+                paddle.CUDAPlace(0)
+                if paddle.device.is_compiled_with_cuda()
+                else None,
+                paddle.XPUPlace(0)
+                if paddle.device.is_compiled_with_xpu()
+                else None,
+            ]:
+                pin_memory = False
             with dygraph_guard():
                 x = paddle.empty(
                     [1],
@@ -860,7 +881,10 @@ class TestTensorPatchMethod(unittest.TestCase):
                     device=device,
                     pin_memory=pin_memory,
                 )
-                if isinstance(device, paddle.framework.core.Place):
+                if (
+                    isinstance(device, paddle.framework.core.Place)
+                    and not pin_memory
+                ):
                     self.assertEqual(x.place, device)
                 self.assertEqual(x.stop_gradient, not requires_grad)
                 if isinstance(dtype, paddle.dtype):
@@ -893,11 +917,6 @@ class TestTensorPatchMethod(unittest.TestCase):
                 self.assertEqual(x.stop_gradient, not requires_grad)
                 if isinstance(dtype, paddle.dtype):
                     self.assertEqual(x.dtype, dtype)
-                if pin_memory:
-                    if paddle.device.is_compiled_with_cuda():
-                        self.assertIsInstance(x.place, paddle.CUDAPinnedPlace)
-                    elif paddle.device.is_compiled_with_cuda():
-                        self.assertIsInstance(x.place, paddle.XPUPinnedPlace)
 
 
 class TestCreationOut(unittest.TestCase):

--- a/test/legacy_test/test_creation.py
+++ b/test/legacy_test/test_creation.py
@@ -241,8 +241,18 @@ class TestTensorCreation(unittest.TestCase):
                     self.assertEqual(x.dtype, dtype)
 
     def test_empty(self):
-        for device, requires_grad, dtype in product(
-            self.devices, self.requires_grads, self.dtypes
+        # empty has extra arg: pin_memory
+        pin_memorys = [False]
+        if (
+            paddle.device.is_compiled_with_cuda()
+            or paddle.device.is_compiled_with_xpu()
+        ):
+            pin_memorys.append(True)
+        for device, requires_grad, dtype, pin_memory in product(
+            self.devices,
+            self.requires_grads,
+            self.dtypes,
+            pin_memorys,
         ):
             with dygraph_guard():
                 x = paddle.empty(
@@ -250,6 +260,7 @@ class TestTensorCreation(unittest.TestCase):
                     dtype=dtype,
                     requires_grad=requires_grad,
                     device=device,
+                    pin_memory=pin_memory,
                 )
                 if isinstance(device, paddle.framework.core.Place):
                     self.assertEqual(x.place, device)
@@ -265,6 +276,7 @@ class TestTensorCreation(unittest.TestCase):
                     out=None,
                     device=None,
                     requires_grad=False,
+                    pin_memory=False,
                 ):
                     return paddle.empty(
                         shape,
@@ -273,6 +285,7 @@ class TestTensorCreation(unittest.TestCase):
                         out=out,
                         device=device,
                         requires_grad=requires_grad,
+                        pin_memory=pin_memory,
                     )
 
                 st_f = paddle.jit.to_static(
@@ -284,12 +297,18 @@ class TestTensorCreation(unittest.TestCase):
                     dtype=dtype,
                     requires_grad=requires_grad,
                     device=device,
+                    pin_memory=pin_memory,
                 )
                 if isinstance(device, paddle.framework.core.Place):
                     self.assertEqual(x.place, device)
                 self.assertEqual(x.stop_gradient, not requires_grad)
                 if isinstance(dtype, paddle.dtype):
                     self.assertEqual(x.dtype, dtype)
+                if pin_memory:
+                    if paddle.device.is_compiled_with_cuda():
+                        self.assertIsInstance(x.place, paddle.CUDAPinnedPlace)
+                    elif paddle.device.is_compiled_with_cuda():
+                        self.assertIsInstance(x.place, paddle.XPUPinnedPlace)
 
     def test_eye(self):
         for device, requires_grad, dtype in product(
@@ -818,8 +837,18 @@ class TestTensorPatchMethod(unittest.TestCase):
                 )
 
     def test_Tensor_new_empty(self):
-        for shape, device, requires_grad, dtype in product(
-            self.shapes, self.devices, self.requires_grads, self.dtypes
+        # empty has extra arg: pin_memory
+        pin_memorys = [False]
+        if (
+            paddle.device.is_compiled_with_cuda()
+            or paddle.device.is_compiled_with_xpu()
+        ):
+            pin_memorys.append(True)
+        for shape, device, requires_grad, dtype, pin_memory in product(
+            self.devices,
+            self.requires_grads,
+            self.dtypes,
+            pin_memorys,
         ):
             with dygraph_guard():
                 x = paddle.empty(
@@ -829,6 +858,7 @@ class TestTensorPatchMethod(unittest.TestCase):
                     dtype=dtype,
                     requires_grad=requires_grad,
                     device=device,
+                    pin_memory=pin_memory,
                 )
                 if isinstance(device, paddle.framework.core.Place):
                     self.assertEqual(x.place, device)
@@ -836,12 +866,15 @@ class TestTensorPatchMethod(unittest.TestCase):
                 if isinstance(dtype, paddle.dtype):
                     self.assertEqual(x.dtype, dtype)
 
-                def new_empty(x, shape, dtype, requires_grad, device):
+                def new_empty(
+                    x, shape, dtype, requires_grad, device, pin_memory
+                ):
                     return x.new_empty(
                         shape,
                         dtype=dtype,
                         requires_grad=requires_grad,
                         device=device,
+                        pin_memory=pin_memory,
                     )
 
                 st_f = paddle.jit.to_static(
@@ -853,12 +886,18 @@ class TestTensorPatchMethod(unittest.TestCase):
                     dtype=dtype,
                     requires_grad=requires_grad,
                     device=device,
+                    pin_memory=pin_memory,
                 )
                 if isinstance(device, paddle.framework.core.Place):
                     self.assertEqual(x.place, device)
                 self.assertEqual(x.stop_gradient, not requires_grad)
                 if isinstance(dtype, paddle.dtype):
                     self.assertEqual(x.dtype, dtype)
+                if pin_memory:
+                    if paddle.device.is_compiled_with_cuda():
+                        self.assertIsInstance(x.place, paddle.CUDAPinnedPlace)
+                    elif paddle.device.is_compiled_with_cuda():
+                        self.assertIsInstance(x.place, paddle.XPUPinnedPlace)
 
 
 class TestCreationOut(unittest.TestCase):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
Pcard-75624

给`paddle.empty`和`Tensor.new_empty`新增`pin_memory`参数，并添加单测