### PR TITLE
ncclSuccess support CUDA custom device

### DIFF
--- a/paddle/phi/core/enforce.h
+++ b/paddle/phi/core/enforce.h
@@ -310,10 +310,10 @@ DEFINE_EXTERNAL_API_TYPE(cusolverStatus_t, CUSOLVER_STATUS_SUCCESS);
 DEFINE_EXTERNAL_API_TYPE(cufftResult_t, CUFFT_SUCCESS);
 DEFINE_EXTERNAL_API_TYPE(CUresult, CUDA_SUCCESS);
 
-#if !defined(__APPLE__) && defined(PADDLE_WITH_NCCL)
+#if !defined(__APPLE__) && \
+    (defined(PADDLE_WITH_NCCL) || defined(PADDLE_WITH_XCCL))
 DEFINE_EXTERNAL_API_TYPE(ncclResult_t, ncclSuccess);
 #endif
-
 }  // namespace details
 
 template <typename T>


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Custom Device

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-67164
If PADDLE_WITH_CUDA and PADDLE_WITH_XCCL are both on, ncclSuccess should be supported.
