### PR TITLE
【Hackathon 9th No.6】fix fused_multi_head_attention 0-Size

### DIFF
--- a/paddle/phi/infermeta/fusion.cc
+++ b/paddle/phi/infermeta/fusion.cc
@@ -947,6 +947,111 @@ void FusedAttentionInferMeta(const MetaTensor& x,
                              MetaTensor* out,
                              MetaConfig config) {
   auto x_dim = x.dims();
+  if (x_dim.size() == 3 && (x_dim[0] == 0 || x_dim[1] == 0)) {
+    int64_t bsz_seq = x_dim[0] * x_dim[1];
+    int64_t head_dim = x_dim[2] / num_heads;
+
+    if (ln_mean) {
+      ln_mean->set_dims({bsz_seq});
+      ln_mean->set_dtype(DataType::FLOAT32);
+    }
+    if (ln_var) {
+      ln_var->set_dims({bsz_seq});
+      ln_var->set_dtype(DataType::FLOAT32);
+    }
+    if (ln_out) {
+      ln_out->set_dims(x_dim);
+      ln_out->set_dtype(x.dtype());
+    }
+    if (qkv_out) {
+      auto qkv_dim = common::make_ddim({x_dim[0], x_dim[1], 3 * x_dim[2]});
+      qkv_out->set_dims(qkv_dim);
+      qkv_out->set_dtype(x.dtype());
+    }
+    if (qkv_bias_out) {
+      auto qkv_dim = common::make_ddim({x_dim[0], x_dim[1], 3 * x_dim[2]});
+      qkv_bias_out->set_dims(qkv_dim);
+      qkv_bias_out->set_dtype(x.dtype());
+    }
+    if (transpose_out_2) {
+      auto transpose_dim =
+          common::make_ddim({3, x_dim[0], num_heads, x_dim[1], head_dim});
+      transpose_out_2->set_dims(transpose_dim);
+      transpose_out_2->set_dtype(x.dtype());
+    }
+    if (qk_out) {
+      auto qk_dim =
+          common::make_ddim({x_dim[0], num_heads, x_dim[1], x_dim[1]});
+      qk_out->set_dims(qk_dim);
+      qk_out->set_dtype(x.dtype());
+    }
+    if (qktv_out) {
+      auto qktv_dim =
+          common::make_ddim({x_dim[0], num_heads, x_dim[1], head_dim});
+      qktv_out->set_dims(qktv_dim);
+      qktv_out->set_dtype(x.dtype());
+    }
+    if (softmax_out) {
+      auto softmax_dim =
+          common::make_ddim({x_dim[0], num_heads, x_dim[1], x_dim[1]});
+      softmax_out->set_dims(softmax_dim);
+      softmax_out->set_dtype(x.dtype());
+    }
+    if (attn_dropout_mask_out) {
+      auto attn_dropout_mask_dim =
+          common::make_ddim({x_dim[0], num_heads, x_dim[1], x_dim[1]});
+      attn_dropout_mask_out->set_dims(attn_dropout_mask_dim);
+      attn_dropout_mask_out->set_dtype(DataType::UINT8);
+    }
+    if (attn_dropout_out) {
+      auto attn_dropout_dim =
+          common::make_ddim({x_dim[0], num_heads, x_dim[1], x_dim[1]});
+      attn_dropout_out->set_dims(attn_dropout_dim);
+      attn_dropout_out->set_dtype(x.dtype());
+    }
+    if (src_mask_out) {
+      auto src_mask_dim =
+          common::make_ddim({x_dim[0], num_heads, x_dim[1], x_dim[1]});
+      src_mask_out->set_dims(src_mask_dim);
+      src_mask_out->set_dtype(x.dtype());
+    }
+    if (fmha_out) {
+      auto fmha_dim =
+          common::make_ddim({x_dim[0], x_dim[1], num_heads, head_dim});
+      fmha_out->set_dims(fmha_dim);
+      fmha_out->set_dtype(x.dtype());
+    }
+    if (out_linear_out) {
+      out_linear_out->set_dims(x_dim);
+      out_linear_out->set_dtype(x.dtype());
+    }
+    if (dropout_mask_out) {
+      dropout_mask_out->set_dims(x_dim);
+      dropout_mask_out->set_dtype(DataType::UINT8);
+    }
+    if (ln_mean_2) {
+      ln_mean_2->set_dims({bsz_seq});
+      ln_mean_2->set_dtype(DataType::FLOAT32);
+    }
+    if (ln_var_2) {
+      ln_var_2->set_dims({bsz_seq});
+      ln_var_2->set_dtype(DataType::FLOAT32);
+    }
+    if (bias_dropout_residual_out) {
+      bias_dropout_residual_out->set_dims(x_dim);
+      bias_dropout_residual_out->set_dtype(x.dtype());
+    }
+    if (cache_kv_out && cache_kv) {
+      cache_kv_out->set_dims(cache_kv.dims());
+      cache_kv_out->set_dtype(cache_kv.dtype());
+    }
+    if (out) {
+      out->set_dims(x_dim);
+      out->set_dtype(x.dtype());
+    }
+    return;
+  }
+
   auto y_dim = qkv_weight.dims();
 
   int dim_head = 0;
@@ -1216,6 +1321,96 @@ void FusedAttentionGradInferMeta(const MetaTensor& out_grad,
                     false,
                     common::errors::InvalidArgument(
                         "GradOp is only callable when is_test is false"));
+  auto x_dim = x.dims();
+  if (x_dim.size() == 3 && (x_dim[0] == 0 || x_dim[1] == 0)) {
+    if (x_grad) {
+      x_grad->set_dims(x_dim);
+      x_grad->set_dtype(x.dtype());
+    }
+    if (qkv_weight_grad) {
+      qkv_weight_grad->set_dims(qkv_weight.dims());
+      qkv_weight_grad->set_dtype(qkv_weight.dtype());
+    }
+    if (out_linear_weight_grad) {
+      out_linear_weight_grad->set_dims(out_linear_weight.dims());
+      out_linear_weight_grad->set_dtype(out_linear_weight.dtype());
+    }
+    if (qkv_bias_grad && qkv_bias) {
+      qkv_bias_grad->set_dims(qkv_bias.dims());
+      qkv_bias_grad->set_dtype(qkv_bias.dtype());
+    }
+    if (out_linear_bias_grad && out_linear_bias) {
+      out_linear_bias_grad->set_dims(out_linear_bias.dims());
+      out_linear_bias_grad->set_dtype(out_linear_bias.dtype());
+    }
+    if (ln_scale_grad && ln_scale) {
+      ln_scale_grad->set_dims(ln_scale.dims());
+      ln_scale_grad->set_dtype(DataType::FLOAT32);
+    }
+    if (ln_bias_grad && ln_bias) {
+      ln_bias_grad->set_dims(ln_bias.dims());
+      ln_bias_grad->set_dtype(DataType::FLOAT32);
+    }
+    if (ln_scale_2_grad && ln_scale_2) {
+      ln_scale_2_grad->set_dims(ln_scale_2.dims());
+      ln_scale_2_grad->set_dtype(DataType::FLOAT32);
+    }
+    if (ln_bias_2_grad && ln_bias_2) {
+      ln_bias_2_grad->set_dims(ln_bias_2.dims());
+      ln_bias_2_grad->set_dtype(DataType::FLOAT32);
+    }
+    if (ln_out_grad && ln_out) {
+      ln_out_grad->set_dims(ln_out.dims());
+      ln_out_grad->set_dtype(ln_out.dtype());
+    }
+    if (bias_dropout_residual_out_grad && bias_dropout_residual_out) {
+      bias_dropout_residual_out_grad->set_dims(
+          bias_dropout_residual_out.dims());
+      bias_dropout_residual_out_grad->set_dtype(
+          bias_dropout_residual_out.dtype());
+    }
+    if (qkv_out_grad && qkv_out) {
+      qkv_out_grad->set_dims(qkv_out.dims());
+      qkv_out_grad->set_dtype(qkv_out.dtype());
+    }
+    if (qkv_bias_out_grad && qkv_bias_out) {
+      qkv_bias_out_grad->set_dims(qkv_bias_out.dims());
+      qkv_bias_out_grad->set_dtype(qkv_bias_out.dtype());
+    }
+    if (qktv_out_grad && qktv_out) {
+      qktv_out_grad->set_dims(qktv_out.dims());
+      qktv_out_grad->set_dtype(qktv_out.dtype());
+    }
+    if (transpose_out_2_grad && transpose_out_2) {
+      transpose_out_2_grad->set_dims(transpose_out_2.dims());
+      transpose_out_2_grad->set_dtype(transpose_out_2.dtype());
+    }
+    if (qk_out_grad && qk_out) {
+      qk_out_grad->set_dims(qk_out.dims());
+      qk_out_grad->set_dtype(qk_out.dtype());
+    }
+    if (softmax_out_grad && softmax_out) {
+      softmax_out_grad->set_dims(softmax_out.dims());
+      softmax_out_grad->set_dtype(softmax_out.dtype());
+    }
+    if (attn_dropout_out_grad && attn_dropout_out) {
+      attn_dropout_out_grad->set_dims(attn_dropout_out.dims());
+      attn_dropout_out_grad->set_dtype(attn_dropout_out.dtype());
+    }
+    if (fmha_out_grad && fmha_out) {
+      fmha_out_grad->set_dims(fmha_out.dims());
+      fmha_out_grad->set_dtype(fmha_out.dtype());
+    }
+    if (out_linear_out_grad && out_linear_out) {
+      out_linear_out_grad->set_dims(out_linear_out.dims());
+      out_linear_out_grad->set_dtype(out_linear_out.dtype());
+    }
+    if (src_mask_out_grad && src_mask_out) {
+      src_mask_out_grad->set_dims(src_mask_out.dims());
+      src_mask_out_grad->set_dtype(src_mask_out.dtype());
+    }
+    return;
+  }
 
   if (!pre_layer_norm) {
     if (ln_scale_2_grad && ln_scale_2) {

--- a/test/legacy_test/test_fused_attention_op.py
+++ b/test/legacy_test/test_fused_attention_op.py
@@ -762,32 +762,162 @@ class TestFusedAttentionOp_ZeroSize(TestFusedAttentionOp):
         self.transpose_qkv_wb = False
 
 
-class TestFusedAttentionOp_ZeroSize2(TestFusedAttentionOp):
+class TestFusedAttentionOp_ZeroSize_Batch(TestFusedAttentionOp):
     def config(self):
-        self.x_type = np.float32
-        self.attn_mask_type = np.float64
+        super().config()
+        self.batch_size = 0
+        self.query_length = 128
+        self.has_attn_mask = False
+        self.has_cache_kv = False
+
+    def test_fused_attention_op(self):
+        try:
+            final_out_ref, x_grad_ref = self.GetBaselineOut()
+            final_out, x_grad = self.GetFusedAttentionOut()
+            expected_shape = (
+                self.batch_size,
+                self.query_length,
+                self.embed_dim,
+            )
+            self.assertEqual(final_out.shape, expected_shape)
+            self.assertEqual(final_out_ref.shape, expected_shape)
+            self.assertEqual(final_out.numel(), 0)
+            self.assertEqual(final_out_ref.numel(), 0)
+            if final_out.numel() > 0:
+                np.testing.assert_allclose(
+                    final_out_ref,
+                    final_out.numpy(),
+                    rtol=self.rtol,
+                    atol=self.atol,
+                )
+                np.testing.assert_allclose(
+                    x_grad_ref, x_grad.numpy(), rtol=self.rtol, atol=self.atol
+                )
+        except Exception as e:
+            self.assertIsInstance(e, (RuntimeError, ValueError))
+
+
+class TestFusedAttentionOp_ZeroSize_SeqLen(TestFusedAttentionOp):
+    def config(self):
+        super().config()
+        self.batch_size = 2
+        self.query_length = 0
+        self.key_length = 0
+        self.value_length = 0
+        self.has_attn_mask = False
+        self.has_cache_kv = False
+
+    def test_fused_attention_op(self):
+        try:
+            final_out_ref, x_grad_ref = self.GetBaselineOut()
+            final_out, x_grad = self.GetFusedAttentionOut()
+            expected_shape = (
+                self.batch_size,
+                self.query_length,
+                self.embed_dim,
+            )
+            self.assertEqual(final_out.shape, expected_shape)
+            self.assertEqual(final_out_ref.shape, expected_shape)
+            self.assertEqual(final_out.numel(), 0)
+        except Exception as e:
+            self.assertIsInstance(e, (RuntimeError, ValueError))
+
+
+class TestFusedAttentionOp_ZeroSize_BothDims(TestFusedAttentionOp):
+    def config(self):
+        super().config()
+        self.batch_size = 0
+        self.query_length = 0
+        self.key_length = 0
+        self.value_length = 0
+        self.has_attn_mask = False
+        self.has_cache_kv = False
+
+    def test_fused_attention_op(self):
+        try:
+            final_out_ref, x_grad_ref = self.GetBaselineOut()
+            final_out, x_grad = self.GetFusedAttentionOut()
+            expected_shape = (
+                self.batch_size,
+                self.query_length,
+                self.embed_dim,
+            )
+            self.assertEqual(final_out.shape, expected_shape)
+            self.assertEqual(final_out.numel(), 0)
+        except Exception as e:
+            self.assertIsInstance(e, (RuntimeError, ValueError))
+
+
+class TestFusedAttentionOp_ZeroSize_WithPreLayerNorm(TestFusedAttentionOp):
+    def config(self):
+        super().config()
+        self.batch_size = 0
+        self.query_length = 128
         self.pre_layer_norm = True
         self.has_attn_mask = False
         self.has_cache_kv = False
-        self.training = True
 
-        self.batch_size = 0  # 0-size
+    def test_fused_attention_op(self):
+        try:
+            final_out_ref, x_grad_ref = self.GetBaselineOut()
+            final_out, x_grad = self.GetFusedAttentionOut()
+            expected_shape = (
+                self.batch_size,
+                self.query_length,
+                self.embed_dim,
+            )
+            self.assertEqual(final_out.shape, expected_shape)
+            self.assertEqual(final_out.numel(), 0)
+        except Exception as e:
+            self.assertIsInstance(e, (RuntimeError, ValueError))
+
+
+class TestFusedAttentionOp_ZeroSize_WithBias(TestFusedAttentionOp):
+    def config(self):
+        super().config()
+        self.batch_size = 0
         self.query_length = 128
-        self.cache_length = 128
-        self.head_dim = 64
-        self.num_heads = 16
-        self.embed_dim = self.head_dim * self.num_heads
+        self.bias_attr = True
+        self.has_attn_mask = False
+        self.has_cache_kv = False
 
-        self.dropout_prob = 0.0
-        self.attn_dropout_prob = 0.0
-        self.weight_attr = None
-        self.bias_attr = None
-        self.kdim, self.vdim = self.embed_dim, self.embed_dim
-        self.key_length, self.value_length = (
-            self.query_length,
-            self.query_length,
-        )
-        self.transpose_qkv_wb = False
+    def test_fused_attention_op(self):
+        try:
+            final_out_ref, x_grad_ref = self.GetBaselineOut()
+            final_out, x_grad = self.GetFusedAttentionOut()
+            expected_shape = (
+                self.batch_size,
+                self.query_length,
+                self.embed_dim,
+            )
+            self.assertEqual(final_out.shape, expected_shape)
+            self.assertEqual(final_out.numel(), 0)
+        except Exception as e:
+            self.assertIsInstance(e, (RuntimeError, ValueError))
+
+
+class TestFusedAttentionOp_ZeroSize_TransposeQKVWB(TestFusedAttentionOp):
+    def config(self):
+        super().config()
+        self.batch_size = 0
+        self.query_length = 128
+        self.transpose_qkv_wb = True
+        self.has_attn_mask = False
+        self.has_cache_kv = False
+
+    def test_fused_attention_op(self):
+        try:
+            final_out_ref, x_grad_ref = self.GetBaselineOut()
+            final_out, x_grad = self.GetFusedAttentionOut()
+            expected_shape = (
+                self.batch_size,
+                self.query_length,
+                self.embed_dim,
+            )
+            self.assertEqual(final_out.shape, expected_shape)
+            self.assertEqual(final_out.numel(), 0)
+        except Exception as e:
+            self.assertIsInstance(e, (RuntimeError, ValueError))
 
 
 if __name__ == "__main__":

--- a/test/legacy_test/test_fused_attention_op.py
+++ b/test/legacy_test/test_fused_attention_op.py
@@ -774,15 +774,18 @@ class TestFusedAttentionOp_ZeroSize_Batch(TestFusedAttentionOp):
         try:
             final_out_ref, x_grad_ref = self.GetBaselineOut()
             final_out, x_grad = self.GetFusedAttentionOut()
-            expected_shape = (
+
+            expected_shape = [
                 self.batch_size,
                 self.query_length,
                 self.embed_dim,
-            )
-            self.assertEqual(final_out.shape, expected_shape)
-            self.assertEqual(final_out_ref.shape, expected_shape)
+            ]
+
+            self.assertEqual(list(final_out.shape), expected_shape)
+            self.assertEqual(list(final_out_ref.shape), expected_shape)
             self.assertEqual(final_out.numel(), 0)
             self.assertEqual(final_out_ref.numel(), 0)
+
             if final_out.numel() > 0:
                 np.testing.assert_allclose(
                     final_out_ref,
@@ -794,7 +797,10 @@ class TestFusedAttentionOp_ZeroSize_Batch(TestFusedAttentionOp):
                     x_grad_ref, x_grad.numpy(), rtol=self.rtol, atol=self.atol
                 )
         except Exception as e:
-            self.assertIsInstance(e, (RuntimeError, ValueError))
+            if not isinstance(e, AssertionError):
+                self.assertIsInstance(e, (RuntimeError, ValueError))
+            else:
+                raise
 
 
 class TestFusedAttentionOp_ZeroSize_SeqLen(TestFusedAttentionOp):
@@ -811,16 +817,21 @@ class TestFusedAttentionOp_ZeroSize_SeqLen(TestFusedAttentionOp):
         try:
             final_out_ref, x_grad_ref = self.GetBaselineOut()
             final_out, x_grad = self.GetFusedAttentionOut()
-            expected_shape = (
+
+            expected_shape = [
                 self.batch_size,
                 self.query_length,
                 self.embed_dim,
-            )
-            self.assertEqual(final_out.shape, expected_shape)
-            self.assertEqual(final_out_ref.shape, expected_shape)
+            ]
+
+            self.assertEqual(list(final_out.shape), expected_shape)
+            self.assertEqual(list(final_out_ref.shape), expected_shape)
             self.assertEqual(final_out.numel(), 0)
         except Exception as e:
-            self.assertIsInstance(e, (RuntimeError, ValueError))
+            if not isinstance(e, AssertionError):
+                self.assertIsInstance(e, (RuntimeError, ValueError))
+            else:
+                raise
 
 
 class TestFusedAttentionOp_ZeroSize_BothDims(TestFusedAttentionOp):
@@ -837,15 +848,20 @@ class TestFusedAttentionOp_ZeroSize_BothDims(TestFusedAttentionOp):
         try:
             final_out_ref, x_grad_ref = self.GetBaselineOut()
             final_out, x_grad = self.GetFusedAttentionOut()
-            expected_shape = (
+
+            expected_shape = [
                 self.batch_size,
                 self.query_length,
                 self.embed_dim,
-            )
-            self.assertEqual(final_out.shape, expected_shape)
+            ]
+
+            self.assertEqual(list(final_out.shape), expected_shape)
             self.assertEqual(final_out.numel(), 0)
         except Exception as e:
-            self.assertIsInstance(e, (RuntimeError, ValueError))
+            if not isinstance(e, AssertionError):
+                self.assertIsInstance(e, (RuntimeError, ValueError))
+            else:
+                raise
 
 
 class TestFusedAttentionOp_ZeroSize_WithPreLayerNorm(TestFusedAttentionOp):
@@ -861,15 +877,20 @@ class TestFusedAttentionOp_ZeroSize_WithPreLayerNorm(TestFusedAttentionOp):
         try:
             final_out_ref, x_grad_ref = self.GetBaselineOut()
             final_out, x_grad = self.GetFusedAttentionOut()
-            expected_shape = (
+
+            expected_shape = [
                 self.batch_size,
                 self.query_length,
                 self.embed_dim,
-            )
-            self.assertEqual(final_out.shape, expected_shape)
+            ]
+
+            self.assertEqual(list(final_out.shape), expected_shape)
             self.assertEqual(final_out.numel(), 0)
         except Exception as e:
-            self.assertIsInstance(e, (RuntimeError, ValueError))
+            if not isinstance(e, AssertionError):
+                self.assertIsInstance(e, (RuntimeError, ValueError))
+            else:
+                raise
 
 
 class TestFusedAttentionOp_ZeroSize_WithBias(TestFusedAttentionOp):
@@ -885,15 +906,20 @@ class TestFusedAttentionOp_ZeroSize_WithBias(TestFusedAttentionOp):
         try:
             final_out_ref, x_grad_ref = self.GetBaselineOut()
             final_out, x_grad = self.GetFusedAttentionOut()
-            expected_shape = (
+
+            expected_shape = [
                 self.batch_size,
                 self.query_length,
                 self.embed_dim,
-            )
-            self.assertEqual(final_out.shape, expected_shape)
+            ]
+
+            self.assertEqual(list(final_out.shape), expected_shape)
             self.assertEqual(final_out.numel(), 0)
         except Exception as e:
-            self.assertIsInstance(e, (RuntimeError, ValueError))
+            if not isinstance(e, AssertionError):
+                self.assertIsInstance(e, (RuntimeError, ValueError))
+            else:
+                raise
 
 
 class TestFusedAttentionOp_ZeroSize_TransposeQKVWB(TestFusedAttentionOp):
@@ -909,15 +935,20 @@ class TestFusedAttentionOp_ZeroSize_TransposeQKVWB(TestFusedAttentionOp):
         try:
             final_out_ref, x_grad_ref = self.GetBaselineOut()
             final_out, x_grad = self.GetFusedAttentionOut()
-            expected_shape = (
+
+            expected_shape = [
                 self.batch_size,
                 self.query_length,
                 self.embed_dim,
-            )
-            self.assertEqual(final_out.shape, expected_shape)
+            ]
+
+            self.assertEqual(list(final_out.shape), expected_shape)
             self.assertEqual(final_out.numel(), 0)
         except Exception as e:
-            self.assertIsInstance(e, (RuntimeError, ValueError))
+            if not isinstance(e, AssertionError):
+                self.assertIsInstance(e, (RuntimeError, ValueError))
+            else:
+                raise
 
 
 if __name__ == "__main__":

--- a/test/legacy_test/test_fused_attention_op.py
+++ b/test/legacy_test/test_fused_attention_op.py
@@ -762,5 +762,33 @@ class TestFusedAttentionOp_ZeroSize(TestFusedAttentionOp):
         self.transpose_qkv_wb = False
 
 
+class TestFusedAttentionOp_ZeroSize2(TestFusedAttentionOp):
+    def config(self):
+        self.x_type = np.float32
+        self.attn_mask_type = np.float64
+        self.pre_layer_norm = True
+        self.has_attn_mask = False
+        self.has_cache_kv = False
+        self.training = True
+
+        self.batch_size = 0  # 0-size
+        self.query_length = 128
+        self.cache_length = 128
+        self.head_dim = 64
+        self.num_heads = 16
+        self.embed_dim = self.head_dim * self.num_heads
+
+        self.dropout_prob = 0.0
+        self.attn_dropout_prob = 0.0
+        self.weight_attr = None
+        self.bias_attr = None
+        self.kdim, self.vdim = self.embed_dim, self.embed_dim
+        self.key_length, self.value_length = (
+            self.query_length,
+            self.query_length,
+        )
+        self.transpose_qkv_wb = False
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
```bash
2025-06-06 12:03:45.069180 GPU 7 62860 test begin: paddle.incubate.nn.functional.fused_multi_head_attention(Tensor([0, 128, 1024],"float32"), Tensor([3, 16, 64, 1024],"float32"), Tensor([1024, 1024],"float32"), True, Tensor([1024],"float32"), Tensor([1024],"float32"), Tensor([1024],"float32"), Tensor([1024],"float32"), 1e-05, Tensor([3, 16, 64],"float32"), Tensor([1024],"float32"), None, None, 0.0, 0.0, 1e-05, num_heads=16, transpose_qkv_wb=False, )
One of the differentiated Tensors appears to not have been used in the graph. Set allow_unused=True if this is the desired behavior.


--------------------------------------
C++ Traceback (most recent call last):
--------------------------------------
0   fused_attention_dygraph_function(paddle::Tensor const&, paddle::Tensor const&, paddle::Tensor const&, paddle::Tensor const&, paddle::Tensor const&, paddle::Tensor const&, paddle::Tensor const&, paddle::Tensor const&, paddle::Tensor const&, paddle::Tensor const&, paddle::Tensor const&, std::unordered_map<std::string, paddle::variant<paddle::blank, int, float, std::string, std::vector<int, std::allocator<int> >, std::vector<float, std::allocator<float> >, std::vector<std::string, std::allocator<std::string > >, bool, std::vector<bool, std::allocator<bool> >, paddle::framework::BlockDesc*, long, std::vector<paddle::framework::BlockDesc*, std::allocator<paddle::framework::BlockDesc*> >, std::vector<long, std::allocator<long> >, std::vector<double, std::allocator<double> >, paddle::framework::VarDesc*, std::vector<paddle::framework::VarDesc*, std::allocator<paddle::framework::VarDesc*> >, double, paddle::experimental::ScalarBase<paddle::Tensor>, std::vector<paddle::experimental::ScalarBase<paddle::Tensor>, std::allocator<paddle::experimental::ScalarBase<paddle::Tensor> > >, pir::Block*, std::vector<pir::Value, std::allocator<pir::Value> >, std::shared_ptr<pir::Program> >, std::hash<std::string >, std::equal_to<std::string >, std::allocator<std::pair<std::string const, paddle::variant<paddle::blank, int, float, std::string, std::vector<int, std::allocator<int> >, std::vector<float, std::allocator<float> >, std::vector<std::string, std::allocator<std::string > >, bool, std::vector<bool, std::allocator<bool> >, paddle::framework::BlockDesc*, long, std::vector<paddle::framework::BlockDesc*, std::allocator<paddle::framework::BlockDesc*> >, std::vector<long, std::allocator<long> >, std::vector<double, std::allocator<double> >, paddle::framework::VarDesc*, std::vector<paddle::framework::VarDesc*, std::allocator<paddle::framework::VarDesc*> >, double, paddle::experimental::ScalarBase<paddle::Tensor>, std::vector<paddle::experimental::ScalarBase<paddle::Tensor>, std::allocator<paddle::experimental::ScalarBase<paddle::Tensor> > >, pir::Block*, std::vector<pir::Value, std::allocator<pir::Value> >, std::shared_ptr<pir::Program> > > > > const&)
1   paddle::imperative::Tracer::TraceOp(std::string const&, std::map<std::string, std::vector<std::shared_ptr<egr::EagerVariable>, std::allocator<std::shared_ptr<egr::EagerVariable> > >, std::less<std::string >, std::allocator<std::pair<std::string const, std::vector<std::shared_ptr<egr::EagerVariable>, std::allocator<std::shared_ptr<egr::EagerVariable> > > > > > const&, std::map<std::string, std::vector<std::shared_ptr<egr::EagerVariable>, std::allocator<std::shared_ptr<egr::EagerVariable> > >, std::less<std::string >, std::allocator<std::pair<std::string const, std::vector<std::shared_ptr<egr::EagerVariable>, std::allocator<std::shared_ptr<egr::EagerVariable> > > > > > const&, std::unordered_map<std::string, paddle::variant<paddle::blank, int, float, std::string, std::vector<int, std::allocator<int> >, std::vector<float, std::allocator<float> >, std::vector<std::string, std::allocator<std::string > >, bool, std::vector<bool, std::allocator<bool> >, paddle::framework::BlockDesc*, long, std::vector<paddle::framework::BlockDesc*, std::allocator<paddle::framework::BlockDesc*> >, std::vector<long, std::allocator<long> >, std::vector<double, std::allocator<double> >, paddle::framework::VarDesc*, std::vector<paddle::framework::VarDesc*, std::allocator<paddle::framework::VarDesc*> >, double, paddle::experimental::ScalarBase<paddle::Tensor>, std::vector<paddle::experimental::ScalarBase<paddle::Tensor>, std::allocator<paddle::experimental::ScalarBase<paddle::Tensor> > >, pir::Block*, std::vector<pir::Value, std::allocator<pir::Value> >, std::shared_ptr<pir::Program> >, std::hash<std::string >, std::equal_to<std::string >, std::allocator<std::pair<std::string const, paddle::variant<paddle::blank, int, float, std::string, std::vector<int, std::allocator<int> >, std::vector<float, std::allocator<float> >, std::vector<std::string, std::allocator<std::string > >, bool, std::vector<bool, std::allocator<bool> >, paddle::framework::BlockDesc*, long, std::vector<paddle::framework::BlockDesc*, std::allocator<paddle::framework::BlockDesc*> >, std::vector<long, std::allocator<long> >, std::vector<double, std::allocator<double> >, paddle::framework::VarDesc*, std::vector<paddle::framework::VarDesc*, std::allocator<paddle::framework::VarDesc*> >, double, paddle::experimental::ScalarBase<paddle::Tensor>, std::vector<paddle::experimental::ScalarBase<paddle::Tensor>, std::allocator<paddle::experimental::ScalarBase<paddle::Tensor> > >, pir::Block*, std::vector<pir::Value, std::allocator<pir::Value> >, std::shared_ptr<pir::Program> > > > >&, phi::Place const&, std::unordered_map<std::string, paddle::variant<paddle::blank, int, float, std::string, std::vector<int, std::allocator<int> >, std::vector<float, std::allocator<float> >, std::vector<std::string, std::allocator<std::string > >, bool, std::vector<bool, std::allocator<bool> >, paddle::framework::BlockDesc*, long, std::vector<paddle::framework::BlockDesc*, std::allocator<paddle::framework::BlockDesc*> >, std::vector<long, std::allocator<long> >, std::vector<double, std::allocator<double> >, paddle::framework::VarDesc*, std::vector<paddle::framework::VarDesc*, std::allocator<paddle::framework::VarDesc*> >, double, paddle::experimental::ScalarBase<paddle::Tensor>, std::vector<paddle::experimental::ScalarBase<paddle::Tensor>, std::allocator<paddle::experimental::ScalarBase<paddle::Tensor> > >, pir::Block*, std::vector<pir::Value, std::allocator<pir::Value> >, std::shared_ptr<pir::Program> >, std::hash<std::string >, std::equal_to<std::string >, std::allocator<std::pair<std::string const, paddle::variant<paddle::blank, int, float, std::string, std::vector<int, std::allocator<int> >, std::vector<float, std::allocator<float> >, std::vector<std::string, std::allocator<std::string > >, bool, std::vector<bool, std::allocator<bool> >, paddle::framework::BlockDesc*, long, std::vector<paddle::framework::BlockDesc*, std::allocator<paddle::framework::BlockDesc*> >, std::vector<long, std::allocator<long> >, std::vector<double, std::allocator<double> >, paddle::framework::VarDesc*, std::vector<paddle::framework::VarDesc*, std::allocator<paddle::framework::VarDesc*> >, double, paddle::experimental::ScalarBase<paddle::Tensor>, std::vector<paddle::experimental::ScalarBase<paddle::Tensor>, std::allocator<paddle::experimental::ScalarBase<paddle::Tensor> > >, pir::Block*, std::vector<pir::Value, std::allocator<pir::Value> >, std::shared_ptr<pir::Program> > > > >*, bool, std::map<std::string, std::string, std::less<std::string >, std::allocator<std::pair<std::string const, std::string > > > const&)
2   void paddle::imperative::Tracer::TraceOpImpl<egr::EagerVariable>(std::string const&, paddle::imperative::details::NameVarMapTrait<egr::EagerVariable>::Type const&, paddle::imperative::details::NameVarMapTrait<egr::EagerVariable>::Type const&, std::unordered_map<std::string, paddle::variant<paddle::blank, int, float, std::string, std::vector<int, std::allocator<int> >, std::vector<float, std::allocator<float> >, std::vector<std::string, std::allocator<std::string > >, bool, std::vector<bool, std::allocator<bool> >, paddle::framework::BlockDesc*, long, std::vector<paddle::framework::BlockDesc*, std::allocator<paddle::framework::BlockDesc*> >, std::vector<long, std::allocator<long> >, std::vector<double, std::allocator<double> >, paddle::framework::VarDesc*, std::vector<paddle::framework::VarDesc*, std::allocator<paddle::framework::VarDesc*> >, double, paddle::experimental::ScalarBase<paddle::Tensor>, std::vector<paddle::experimental::ScalarBase<paddle::Tensor>, std::allocator<paddle::experimental::ScalarBase<paddle::Tensor> > >, pir::Block*, std::vector<pir::Value, std::allocator<pir::Value> >, std::shared_ptr<pir::Program> >, std::hash<std::string >, std::equal_to<std::string >, std::allocator<std::pair<std::string const, paddle::variant<paddle::blank, int, float, std::string, std::vector<int, std::allocator<int> >, std::vector<float, std::allocator<float> >, std::vector<std::string, std::allocator<std::string > >, bool, std::vector<bool, std::allocator<bool> >, paddle::framework::BlockDesc*, long, std::vector<paddle::framework::BlockDesc*, std::allocator<paddle::framework::BlockDesc*> >, std::vector<long, std::allocator<long> >, std::vector<double, std::allocator<double> >, paddle::framework::VarDesc*, std::vector<paddle::framework::VarDesc*, std::allocator<paddle::framework::VarDesc*> >, double, paddle::experimental::ScalarBase<paddle::Tensor>, std::vector<paddle::experimental::ScalarBase<paddle::Tensor>, std::allocator<paddle::experimental::ScalarBase<paddle::Tensor> > >, pir::Block*, std::vector<pir::Value, std::allocator<pir::Value> >, std::shared_ptr<pir::Program> > > > >&, phi::Place const&, bool, std::map<std::string, std::string, std::less<std::string >, std::allocator<std::pair<std::string const, std::string > > > const&, std::unordered_map<std::string, paddle::variant<paddle::blank, int, float, std::string, std::vector<int, std::allocator<int> >, std::vector<float, std::allocator<float> >, std::vector<std::string, std::allocator<std::string > >, bool, std::vector<bool, std::allocator<bool> >, paddle::framework::BlockDesc*, long, std::vector<paddle::framework::BlockDesc*, std::allocator<paddle::framework::BlockDesc*> >, std::vector<long, std::allocator<long> >, std::vector<double, std::allocator<double> >, paddle::framework::VarDesc*, std::vector<paddle::framework::VarDesc*, std::allocator<paddle::framework::VarDesc*> >, double, paddle::experimental::ScalarBase<paddle::Tensor>, std::vector<paddle::experimental::ScalarBase<paddle::Tensor>, std::allocator<paddle::experimental::ScalarBase<paddle::Tensor> > >, pir::Block*, std::vector<pir::Value, std::allocator<pir::Value> >, std::shared_ptr<pir::Program> >, std::hash<std::string >, std::equal_to<std::string >, std::allocator<std::pair<std::string const, paddle::variant<paddle::blank, int, float, std::string, std::vector<int, std::allocator<int> >, std::vector<float, std::allocator<float> >, std::vector<std::string, std::allocator<std::string > >, bool, std::vector<bool, std::allocator<bool> >, paddle::framework::BlockDesc*, long, std::vector<paddle::framework::BlockDesc*, std::allocator<paddle::framework::BlockDesc*> >, std::vector<long, std::allocator<long> >, std::vector<double, std::allocator<double> >, paddle::framework::VarDesc*, std::vector<paddle::framework::VarDesc*, std::allocator<paddle::framework::VarDesc*> >, double, paddle::experimental::ScalarBase<paddle::Tensor>, std::vector<paddle::experimental::ScalarBase<paddle::Tensor>, std::allocator<paddle::experimental::ScalarBase<paddle::Tensor> > >, pir::Block*, std::vector<pir::Value, std::allocator<pir::Value> >, std::shared_ptr<pir::Program> > > > >*, bool)
3   paddle::imperative::PreparedOp::Run(std::map<std::string, std::vector<std::shared_ptr<egr::EagerVariable>, std::allocator<std::shared_ptr<egr::EagerVariable> > >, std::less<std::string >, std::allocator<std::pair<std::string const, std::vector<std::shared_ptr<egr::EagerVariable>, std::allocator<std::shared_ptr<egr::EagerVariable> > > > > > const&, std::map<std::string, std::vector<std::shared_ptr<egr::EagerVariable>, std::allocator<std::shared_ptr<egr::EagerVariable> > >, std::less<std::string >, std::allocator<std::pair<std::string const, std::vector<std::shared_ptr<egr::EagerVariable>, std::allocator<std::shared_ptr<egr::EagerVariable> > > > > > const&, std::unordered_map<std::string, paddle::variant<paddle::blank, int, float, std::string, std::vector<int, std::allocator<int> >, std::vector<float, std::allocator<float> >, std::vector<std::string, std::allocator<std::string > >, bool, std::vector<bool, std::allocator<bool> >, paddle::framework::BlockDesc*, long, std::vector<paddle::framework::BlockDesc*, std::allocator<paddle::framework::BlockDesc*> >, std::vector<long, std::allocator<long> >, std::vector<double, std::allocator<double> >, paddle::framework::VarDesc*, std::vector<paddle::framework::VarDesc*, std::allocator<paddle::framework::VarDesc*> >, double, paddle::experimental::ScalarBase<paddle::Tensor>, std::vector<paddle::experimental::ScalarBase<paddle::Tensor>, std::allocator<paddle::experimental::ScalarBase<paddle::Tensor> > >, pir::Block*, std::vector<pir::Value, std::allocator<pir::Value> >, std::shared_ptr<pir::Program> >, std::hash<std::string >, std::equal_to<std::string >, std::allocator<std::pair<std::string const, paddle::variant<paddle::blank, int, float, std::string, std::vector<int, std::allocator<int> >, std::vector<float, std::allocator<float> >, std::vector<std::string, std::allocator<std::string > >, bool, std::vector<bool, std::allocator<bool> >, paddle::framework::BlockDesc*, long, std::vector<paddle::framework::BlockDesc*, std::allocator<paddle::framework::BlockDesc*> >, std::vector<long, std::allocator<long> >, std::vector<double, std::allocator<double> >, paddle::framework::VarDesc*, std::vector<paddle::framework::VarDesc*, std::allocator<paddle::framework::VarDesc*> >, double, paddle::experimental::ScalarBase<paddle::Tensor>, std::vector<paddle::experimental::ScalarBase<paddle::Tensor>, std::allocator<paddle::experimental::ScalarBase<paddle::Tensor> > >, pir::Block*, std::vector<pir::Value, std::allocator<pir::Value> >, std::shared_ptr<pir::Program> > > > > const&, std::unordered_map<std::string, paddle::variant<paddle::blank, int, float, std::string, std::vector<int, std::allocator<int> >, std::vector<float, std::allocator<float> >, std::vector<std::string, std::allocator<std::string > >, bool, std::vector<bool, std::allocator<bool> >, paddle::framework::BlockDesc*, long, std::vector<paddle::framework::BlockDesc*, std::allocator<paddle::framework::BlockDesc*> >, std::vector<long, std::allocator<long> >, std::vector<double, std::allocator<double> >, paddle::framework::VarDesc*, std::vector<paddle::framework::VarDesc*, std::allocator<paddle::framework::VarDesc*> >, double, paddle::experimental::ScalarBase<paddle::Tensor>, std::vector<paddle::experimental::ScalarBase<paddle::Tensor>, std::allocator<paddle::experimental::ScalarBase<paddle::Tensor> > >, pir::Block*, std::vector<pir::Value, std::allocator<pir::Value> >, std::shared_ptr<pir::Program> >, std::hash<std::string >, std::equal_to<std::string >, std::allocator<std::pair<std::string const, paddle::variant<paddle::blank, int, float, std::string, std::vector<int, std::allocator<int> >, std::vector<float, std::allocator<float> >, std::vector<std::string, std::allocator<std::string > >, bool, std::vector<bool, std::allocator<bool> >, paddle::framework::BlockDesc*, long, std::vector<paddle::framework::BlockDesc*, std::allocator<paddle::framework::BlockDesc*> >, std::vector<long, std::allocator<long> >, std::vector<double, std::allocator<double> >, paddle::framework::VarDesc*, std::vector<paddle::framework::VarDesc*, std::allocator<paddle::framework::VarDesc*> >, double, paddle::experimental::ScalarBase<paddle::Tensor>, std::vector<paddle::experimental::ScalarBase<paddle::Tensor>, std::allocator<paddle::experimental::ScalarBase<paddle::Tensor> > >, pir::Block*, std::vector<pir::Value, std::allocator<pir::Value> >, std::shared_ptr<pir::Program> > > > > const&)
4   void phi::KernelImpl<void (*)(phi::GPUContext const&, phi::DenseTensor const&, paddle::optional<phi::DenseTensor> const&, paddle::optional<phi::DenseTensor> const&, phi::DenseTensor const&, paddle::optional<phi::DenseTensor> const&, paddle::optional<phi::DenseTensor> const&, paddle::optional<phi::DenseTensor> const&, phi::DenseTensor const&, paddle::optional<phi::DenseTensor> const&, paddle::optional<phi::DenseTensor> const&, paddle::optional<phi::DenseTensor> const&, int, bool, bool, float, float, bool, bool, int, std::string const&, float, bool, int, std::string const&, float, bool, int, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*), &(void phi::fusion::FusedAttentionKernel<float, phi::GPUContext>(phi::GPUContext const&, phi::DenseTensor const&, paddle::optional<phi::DenseTensor> const&, paddle::optional<phi::DenseTensor> const&, phi::DenseTensor const&, paddle::optional<phi::DenseTensor> const&, paddle::optional<phi::DenseTensor> const&, paddle::optional<phi::DenseTensor> const&, phi::DenseTensor const&, paddle::optional<phi::DenseTensor> const&, paddle::optional<phi::DenseTensor> const&, paddle::optional<phi::DenseTensor> const&, int, bool, bool, float, float, bool, bool, int, std::string const&, float, bool, int, std::string const&, float, bool, int, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*))>::KernelCallHelper<paddle::optional<phi::DenseTensor> const&, paddle::optional<phi::DenseTensor> const&, phi::DenseTensor const&, paddle::optional<phi::DenseTensor> const&, paddle::optional<phi::DenseTensor> const&, paddle::optional<phi::DenseTensor> const&, phi::DenseTensor const&, paddle::optional<phi::DenseTensor> const&, paddle::optional<phi::DenseTensor> const&, paddle::optional<phi::DenseTensor> const&, int, bool, bool, float, float, bool, bool, int, std::string const&, float, bool, int, std::string const&, float, bool, int, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::TypeTag<int> >::Compute<1, 1, 0, 0, phi::GPUContext const, phi::DenseTensor const>(phi::KernelContext*, phi::GPUContext const&, phi::DenseTensor const&)
5   void phi::KernelImpl<void (*)(phi::GPUContext const&, phi::DenseTensor const&, paddle::optional<phi::DenseTensor> const&, paddle::optional<phi::DenseTensor> const&, phi::DenseTensor const&, paddle::optional<phi::DenseTensor> const&, paddle::optional<phi::DenseTensor> const&, paddle::optional<phi::DenseTensor> const&, phi::DenseTensor const&, paddle::optional<phi::DenseTensor> const&, paddle::optional<phi::DenseTensor> const&, paddle::optional<phi::DenseTensor> const&, int, bool, bool, float, float, bool, bool, int, std::string const&, float, bool, int, std::string const&, float, bool, int, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*), &(void phi::fusion::FusedAttentionKernel<float, phi::GPUContext>(phi::GPUContext const&, phi::DenseTensor const&, paddle::optional<phi::DenseTensor> const&, paddle::optional<phi::DenseTensor> const&, phi::DenseTensor const&, paddle::optional<phi::DenseTensor> const&, paddle::optional<phi::DenseTensor> const&, paddle::optional<phi::DenseTensor> const&, phi::DenseTensor const&, paddle::optional<phi::DenseTensor> const&, paddle::optional<phi::DenseTensor> const&, paddle::optional<phi::DenseTensor> const&, int, bool, bool, float, float, bool, bool, int, std::string const&, float, bool, int, std::string const&, float, bool, int, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*))>::KernelCallHelper<paddle::optional<phi::DenseTensor> const&, int, bool, bool, float, float, bool, bool, int, std::string const&, float, bool, int, std::string const&, float, bool, int, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::TypeTag<int> >::Compute<1, 10, 0, 0, phi::GPUContext const, phi::DenseTensor const, paddle::optional<phi::DenseTensor>, paddle::optional<phi::DenseTensor>, phi::DenseTensor const, paddle::optional<phi::DenseTensor>, paddle::optional<phi::DenseTensor>, paddle::optional<phi::DenseTensor>, phi::DenseTensor const, paddle::optional<phi::DenseTensor>, paddle::optional<phi::DenseTensor> >(phi::KernelContext*, phi::GPUContext const&, phi::DenseTensor const&, paddle::optional<phi::DenseTensor>&, paddle::optional<phi::DenseTensor>&, phi::DenseTensor const&, paddle::optional<phi::DenseTensor>&, paddle::optional<phi::DenseTensor>&, paddle::optional<phi::DenseTensor>&, phi::DenseTensor const&, paddle::optional<phi::DenseTensor>&, paddle::optional<phi::DenseTensor>&)
6   void phi::fusion::FusedAttentionKernel<float, phi::GPUContext>(phi::GPUContext const&, phi::DenseTensor const&, paddle::optional<phi::DenseTensor> const&, paddle::optional<phi::DenseTensor> const&, phi::DenseTensor const&, paddle::optional<phi::DenseTensor> const&, paddle::optional<phi::DenseTensor> const&, paddle::optional<phi::DenseTensor> const&, phi::DenseTensor const&, paddle::optional<phi::DenseTensor> const&, paddle::optional<phi::DenseTensor> const&, paddle::optional<phi::DenseTensor> const&, int, bool, bool, float, float, bool, bool, int, std::string const&, float, bool, int, std::string const&, float, bool, int, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*)
7   phi::fusion::FMHARef<float>::ComputeForward(phi::DenseTensor const&, phi::DenseTensor const*, phi::DenseTensor const*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*, phi::DenseTensor*)
8   void phi::funcs::TransposeGPUKernelDriver<float>(phi::GPUContext const&, phi::DenseTensor const&, std::vector<int, std::allocator<int> > const&, phi::DenseTensor*)
9   void phi::funcs::PermuteWithEigen<float>(phi::GPUContext const&, int const&, phi::DenseTensor const&, phi::DenseTensor*, phi::funcs::PermuteDimsSimplifier const&)
10  phi::funcs::Transpose<phi::GPUContext, float, 5>::operator()(phi::GPUContext const&, phi::DenseTensor const&, phi::DenseTensor*, std::vector<int, std::allocator<int> > const&)

----------------------
Error Message Summary:
----------------------
FatalError: `Erroneous arithmetic operation` is detected by the operating system.
  [TimeInfo: *** Aborted at 1749182625 (unix time) try "date -d @1749182625" if you are using GNU date ***]
  [SignalInfo: *** SIGFPE (@0x7fb0eb205543) received by PID 62860 (TID 0x7fb1f4d04740) from PID 18446744073359349059 ***]
```

在infermeta添加限定


PaddleAPITest测试：
```bash
aistudio@jupyter-115720-9209764:~/PaddleAPITest$ python engineV2.py --paddle_only=True --api_config='paddle.incubate.nn.functional.fused_multi_head_attention(Tensor([0, 128, 1024],"float32"), Tensor([3, 16, 64, 1024],"float32"), Tensor([1024, 1024],"float32"), True, Tensor([1024],"float32"), Tensor([1024],"float32"), Tensor([1024],"float32"), Tensor([1024],"float32"), 1e-05, Tensor([3, 16, 64],"float32"), Tensor([1024],"float32"), None, None, 0.0, 0.0, 1e-05, num_heads=16, transpose_qkv_wb=False, )'
Main process id: 389
Options: {'api_config_file': '', 'api_config_file_pattern': '', 'api_config': 'paddle.incubate.nn.functional.fused_multi_head_attention(Tensor([0, 128, 1024],"float32"), Tensor([3, 16, 64, 1024],"float32"), Tensor([1024, 1024],"float32"), True, Tensor([1024],"float32"), Tensor([1024],"float32"), Tensor([1024],"float32"), Tensor([1024],"float32"), 1e-05, Tensor([3, 16, 64],"float32"), Tensor([1024],"float32"), None, None, 0.0, 0.0, 1e-05, num_heads=16, transpose_qkv_wb=False, )', 'paddle_only': True, 'paddle_cinn': False, 'accuracy': False, 'paddle_gpu_performance': False, 'torch_gpu_performance': False, 'paddle_torch_gpu_performance': False, 'accuracy_stable': False, 'test_amp': False, 'num_gpus': -1, 'num_workers_per_gpu': 1, 'gpu_ids': '', 'required_memory': 10.0, 'test_cpu': False, 'use_cached_numpy': False, 'log_dir': '', 'atol': 0.01, 'rtol': 0.01, 'test_tol': False}
2025-08-28 05:15:39.219102 test begin: paddle.incubate.nn.functional.fused_multi_head_attention(Tensor([0, 128, 1024],"float32"), Tensor([3, 16, 64, 1024],"float32"), Tensor([1024, 1024],"float32"), True, Tensor([1024],"float32"), Tensor([1024],"float32"), Tensor([1024],"float32"), Tensor([1024],"float32"), 1e-05, Tensor([3, 16, 64],"float32"), Tensor([1024],"float32"), None, None, 0.0, 0.0, 1e-05, num_heads=16, transpose_qkv_wb=False, )
W0828 05:15:44.641955   389 gpu_resources.cc:114] Please NOTE: device: 0, GPU Compute Capability: 7.0, Driver API Version: 12.0, Runtime API Version: 11.8
[Pass] paddle.incubate.nn.functional.fused_multi_head_attention(Tensor([0, 128, 1024],"float32"), Tensor([3, 16, 64, 1024],"float32"), Tensor([1024, 1024],"float32"), True, Tensor([1024],"float32"), Tensor([1024],"float32"), Tensor([1024],"float32"), Tensor([1024],"float32"), 1e-05, Tensor([3, 16, 64],"float32"), Tensor([1024],"float32"), None, None, 0.0, 0.0, 1e-05, num_heads=16, transpose_qkv_wb=False, )
Done.
```