### PR TITLE
【Hackathon 9th No.14】fix fused_multi_head_attention 精度问题修复

### DIFF
--- a/paddle/phi/infermeta/fusion.cc
+++ b/paddle/phi/infermeta/fusion.cc
@@ -947,6 +947,15 @@ void FusedAttentionInferMeta(const MetaTensor& x,
                              MetaTensor* out,
                              MetaConfig config) {
   auto x_dim = x.dims();
+  bool ln_scale_empty =
+      ln_scale_2 && ln_scale_2.dims().size() == 1 && ln_scale_2.dims()[0] == 0;
+  if (ln_scale_empty) {
+    if (ln_mean_2) ln_mean_2->set_dims({0});
+    if (ln_var_2) ln_var_2->set_dims({0});
+  } else {
+    if (ln_mean_2) ln_mean_2->set_dims({x_dim[0] * x_dim[1]});
+    if (ln_var_2) ln_var_2->set_dims({x_dim[0] * x_dim[1]});
+  }
   auto y_dim = qkv_weight.dims();
 
   int dim_head = 0;

--- a/paddle/phi/kernels/fusion/gpu/fused_attention_grad_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/fused_attention_grad_kernel.cu
@@ -448,7 +448,7 @@ void FusedAttentionGradKernel(
         bias_dropout_residual_out_grad,
         bias_dropout_residual_out_grad->numel() * sizeof(T));
 
-    bool ln_0_size = ln_scale_2_p && ln_scale_2_p->numel() == 0;
+    bool ln_0_size = (ln_scale_2_p == nullptr) || (ln_scale_2_p->numel() == 0);
     if (ln_0_size) {
       fused_dropout_layernorm_helper.ResidualDropoutBiasGrad(
           dev_ctx,

--- a/paddle/phi/kernels/fusion/gpu/fused_attention_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/fused_attention_kernel.cu
@@ -375,30 +375,31 @@ void FusedAttentionKernel(const Context &dev_ctx,
         dev_ctx.template Alloc<U>(ln_var_2, ln_var_2->numel() * sizeof(U));
 
     // 0-size
-    if (ln_scale_2_p && ln_scale_2_p->numel() == 0) {
-      // output = (residual + dropout(input + bias))
+    bool ln_scale_empty =
+        (ln_scale_2_p == nullptr) || (ln_scale_2_p->numel() == 0);
+    if (ln_scale_empty) {
+      // residual + dropout + bias
       fused_dropout_layernorm_helper.ResidualDropoutBias(dev_ctx,
                                                          out_linear_out_data,
                                                          residual_ptr,
                                                          out_linear_bias_data,
                                                          final_out_data,
                                                          dropout_mask_out_data);
-      return;
+    } else {
+      // LayerNorm + residual + dropout + bias
+      fused_dropout_layernorm_helper.LayernormResidualDropoutBias(
+          dev_ctx,
+          out_linear_out_data,
+          residual_ptr,
+          out_linear_bias_data,
+          ln_scale_2_ptr,
+          ln_bias_2_ptr,
+          bias_dropout_residual_out_ptr,
+          dropout_mask_out_data,
+          final_out_data,
+          ln_mean_2_ptr,
+          ln_var_2_ptr);
     }
-
-    // output = layernorm(residual + dropout(input + bias))
-    fused_dropout_layernorm_helper.LayernormResidualDropoutBias(
-        dev_ctx,
-        out_linear_out_data,
-        residual_ptr,
-        out_linear_bias_data,
-        ln_scale_2_ptr,
-        ln_bias_2_ptr,
-        bias_dropout_residual_out_ptr,
-        dropout_mask_out_data,
-        final_out_data,
-        ln_mean_2_ptr,
-        ln_var_2_ptr);
   }
 }
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
```bash
2025-06-06 12:03:47.811877 GPU 4 62808 test begin: paddle.incubate.nn.functional.fused_multi_head_attention(x=Tensor([1, 2, 4],"float32"), qkv_weight=Tensor([3, 2, 2, 4],"float32"), linear_weight=Tensor([4, 4],"float32"), pre_layer_norm=False, pre_ln_scale=None, pre_ln_bias=None, ln_scale=Tensor([0],"float32"), ln_bias=None, pre_ln_epsilon=1e-05, qkv_bias=None, linear_bias=None, cache_kv=None, attn_mask=Tensor([1, 2, 2, 2],"float32"), dropout_rate=0.0, attn_dropout_rate=0.0, ln_epsilon=1e-05, training=True, ring_id=-1, num_heads=2, transpose_qkv_wb=False, name=None, )
One of the differentiated Tensors appears to not have been used in the graph. Set allow_unused=True if this is the desired behavior.
[accuracy error] paddle.incubate.nn.functional.fused_multi_head_attention(x=Tensor([1, 2, 4],"float32"), qkv_weight=Tensor([3, 2, 2, 4],"float32"), linear_weight=Tensor([4, 4],"float32"), pre_layer_norm=False, pre_ln_scale=None, pre_ln_bias=None, ln_scale=Tensor([0],"float32"), ln_bias=None, pre_ln_epsilon=1e-05, qkv_bias=None, linear_bias=None, cache_kv=None, attn_mask=Tensor([1, 2, 2, 2],"float32"), dropout_rate=0.0, attn_dropout_rate=0.0, ln_epsilon=1e-05, training=True, ring_id=-1, num_heads=2, transpose_qkv_wb=False, name=None, ) 
 Not equal to tolerance rtol=0.01, atol=0.01
Tensor-likes are not close!

Mismatched elements: 8 / 8 (100.0%)
Greatest absolute difference: 1.3271503448486328 at index (0, 0, 2) (up to 0.01 allowed)
Greatest relative difference: 11.966778755187988 at index (0, 0, 2) (up to 0.01 allowed)
ACTUAL: (shape=torch.Size([1, 2, 4]), dtype=torch.float32)
tensor([[[-0.4258,  0.8519, -1.4381,  1.0119],
         [-1.1503, -0.7308,  0.5090,  1.3721]]])
DESIRED: (shape=torch.Size([1, 2, 4]), dtype=torch.float32)
tensor([[[ 0.0989,  0.3638, -0.1109,  0.3970],
         [-0.1971, -0.1113,  0.1423,  0.3189]]])
```

maybe wrong logic on [ln_scale=Tensor([0],"float32")]。
when [ln_scale] shape = [0]  logic wrong.


PaddleAPITest测试
```bash
aistudio@jupyter-115720-9209764:~/PaddleAPITest$ python engineV2.py --accuracy=True --api_config='paddle.incubate.nn.functional.fused_multi_head_attention(x=Tensor([1, 2, 4],"float32"), qkv_weight=Tensor([3, 2, 2, 4],"float32"), linear_weight=Tensor([4, 4],"float32"), pre_layer_norm=False, pre_ln_scale=None, pre_ln_bias=None, ln_scale=Tensor([0],"float32"), ln_bias=None, pre_ln_epsilon=1e-05, qkv_bias=None, linear_bias=None, cache_kv=None, attn_mask=Tensor([1, 2, 2, 2],"float32"), dropout_rate=0.0, attn_dropout_rate=0.0, ln_epsilon=1e-05, training=True, ring_id=-1, num_heads=2, transpose_qkv_wb=False, name=None, )'
Main process id: 566
Options: {'api_config_file': '', 'api_config_file_pattern': '', 'api_config': 'paddle.incubate.nn.functional.fused_multi_head_attention(x=Tensor([1, 2, 4],"float32"), qkv_weight=Tensor([3, 2, 2, 4],"float32"), linear_weight=Tensor([4, 4],"float32"), pre_layer_norm=False, pre_ln_scale=None, pre_ln_bias=None, ln_scale=Tensor([0],"float32"), ln_bias=None, pre_ln_epsilon=1e-05, qkv_bias=None, linear_bias=None, cache_kv=None, attn_mask=Tensor([1, 2, 2, 2],"float32"), dropout_rate=0.0, attn_dropout_rate=0.0, ln_epsilon=1e-05, training=True, ring_id=-1, num_heads=2, transpose_qkv_wb=False, name=None, )', 'paddle_only': False, 'paddle_cinn': False, 'accuracy': True, 'paddle_gpu_performance': False, 'torch_gpu_performance': False, 'paddle_torch_gpu_performance': False, 'accuracy_stable': False, 'test_amp': False, 'num_gpus': -1, 'num_workers_per_gpu': 1, 'gpu_ids': '', 'required_memory': 10.0, 'test_cpu': False, 'use_cached_numpy': False, 'log_dir': '', 'atol': 0.01, 'rtol': 0.01, 'test_tol': False}
2025-08-28 05:17:00.929784 test begin: paddle.incubate.nn.functional.fused_multi_head_attention(x=Tensor([1, 2, 4],"float32"), qkv_weight=Tensor([3, 2, 2, 4],"float32"), linear_weight=Tensor([4, 4],"float32"), pre_layer_norm=False, pre_ln_scale=None, pre_ln_bias=None, ln_scale=Tensor([0],"float32"), ln_bias=None, pre_ln_epsilon=1e-05, qkv_bias=None, linear_bias=None, cache_kv=None, attn_mask=Tensor([1, 2, 2, 2],"float32"), dropout_rate=0.0, attn_dropout_rate=0.0, ln_epsilon=1e-05, training=True, ring_id=-1, num_heads=2, transpose_qkv_wb=False, name=None, )
/home/aistudio/external-libraries/lib/python3.10/site-packages/torch/autograd/graph.py:824: UserWarning: Attempting to run cuBLAS, but there was no current CUDA context! Attempting to set the primary context... (Triggered internally at /pytorch/aten/src/ATen/cuda/CublasHandlePool.cpp:181.)
  return Variable._execution_engine.run_backward(  # Calls into the C++ engine to run the backward pass
One of the differentiated Tensors appears to not have been used in the graph. Set allow_unused=True if this is the desired behavior.
W0828 05:17:14.323757   566 gpu_resources.cc:114] Please NOTE: device: 0, GPU Compute Capability: 7.0, Driver API Version: 12.0, Runtime API Version: 11.8
[Pass] paddle.incubate.nn.functional.fused_multi_head_attention(x=Tensor([1, 2, 4],"float32"), qkv_weight=Tensor([3, 2, 2, 4],"float32"), linear_weight=Tensor([4, 4],"float32"), pre_layer_norm=False, pre_ln_scale=None, pre_ln_bias=None, ln_scale=Tensor([0],"float32"), ln_bias=None, pre_ln_epsilon=1e-05, qkv_bias=None, linear_bias=None, cache_kv=None, attn_mask=Tensor([1, 2, 2, 2],"float32"), dropout_rate=0.0, attn_dropout_rate=0.0, ln_epsilon=1e-05, training=True, ring_id=-1, num_heads=2, transpose_qkv_wb=False, name=None, )
Done.
```