### PR TITLE
remove include bfloat16.h in paddle/phi/kernels/cpu [fluid_ops]

### DIFF
--- a/paddle/phi/kernels/cpu/activation_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/activation_grad_kernel.cc
@@ -15,7 +15,6 @@ limitations under the License. */
 #include "paddle/phi/kernels/activation_grad_kernel.h"
 
 #include "paddle/phi/backends/cpu/cpu_context.h"
-#include "paddle/phi/common/float16.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/impl/activation_grad_impl.h"

--- a/paddle/phi/kernels/cpu/adamw_kernel.cc
+++ b/paddle/phi/kernels/cpu/adamw_kernel.cc
@@ -19,7 +19,6 @@
 #include "glog/logging.h"
 
 #include "paddle/phi/backends/cpu/cpu_context.h"
-#include "paddle/phi/common/float16.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/core/tensor_utils.h"
 #include "paddle/phi/kernels/adam_kernel.h"

--- a/paddle/phi/kernels/cpu/broadcast_tensors_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/broadcast_tensors_grad_kernel.cc
@@ -16,7 +16,6 @@
 
 #include <vector>
 
-#include "paddle/phi/common/float16.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/enforce.h"
 #include "paddle/phi/core/kernel_registry.h"

--- a/paddle/phi/kernels/cpu/broadcast_tensors_kernel.cc
+++ b/paddle/phi/kernels/cpu/broadcast_tensors_kernel.cc
@@ -14,7 +14,6 @@
 
 #include "paddle/phi/kernels/broadcast_tensors_kernel.h"
 
-#include "paddle/phi/common/float16.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/impl/broadcast_tensors_kernel_impl.h"
 

--- a/paddle/phi/kernels/cpu/c_concat_kernel.cc
+++ b/paddle/phi/kernels/cpu/c_concat_kernel.cc
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "paddle/phi/common/float16.h"
 #include "paddle/phi/core/kernel_registry.h"
 
 namespace phi {

--- a/paddle/phi/kernels/cpu/concat_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/concat_grad_kernel.cc
@@ -15,7 +15,6 @@
 #include "paddle/phi/kernels/concat_grad_kernel.h"
 
 #include "paddle/phi/backends/cpu/cpu_context.h"
-#include "paddle/phi/common/bfloat16.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/impl/concat_grad_kernel_impl.h"
 

--- a/paddle/phi/kernels/cpu/concat_kernel.cc
+++ b/paddle/phi/kernels/cpu/concat_kernel.cc
@@ -15,7 +15,6 @@
 #include "paddle/phi/kernels/concat_kernel.h"
 
 #include "paddle/phi/backends/cpu/cpu_context.h"
-#include "paddle/phi/common/bfloat16.h"
 #include "paddle/phi/common/scalar.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/kernel_registry.h"

--- a/paddle/phi/kernels/cpu/contiguous_kernel.cc
+++ b/paddle/phi/kernels/cpu/contiguous_kernel.cc
@@ -14,7 +14,6 @@ limitations under the License. */
 #include <vector>
 
 #include "paddle/phi/backends/cpu/cpu_context.h"
-#include "paddle/phi/common/bfloat16.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/math_function.h"
 #include "paddle/phi/kernels/impl/transpose_grad_kernel_impl.h"

--- a/paddle/phi/kernels/cpu/debug_tools_kernel.cc
+++ b/paddle/phi/kernels/cpu/debug_tools_kernel.cc
@@ -15,7 +15,6 @@
 #include <vector>
 
 #include "paddle/phi/backends/cpu/cpu_context.h"
-#include "paddle/phi/common/bfloat16.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/math_function.h"
 #include "paddle/phi/kernels/impl/debug_tools_impl.h"

--- a/paddle/phi/kernels/cpu/elementwise_add_kernel.cc
+++ b/paddle/phi/kernels/cpu/elementwise_add_kernel.cc
@@ -15,7 +15,6 @@
 #include "paddle/phi/kernels/elementwise_add_kernel.h"
 #include "paddle/phi/api/ext/dispatch.h"
 #include "paddle/phi/backends/cpu/cpu_context.h"
-#include "paddle/phi/common/bfloat16.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/cpu/elementwise.h"
 #include "paddle/phi/kernels/impl/elementwise_kernel_impl.h"

--- a/paddle/phi/kernels/cpu/elementwise_divide_kernel.cc
+++ b/paddle/phi/kernels/cpu/elementwise_divide_kernel.cc
@@ -14,7 +14,6 @@
 
 #include "paddle/phi/api/ext/dispatch.h"
 #include "paddle/phi/backends/cpu/cpu_context.h"
-#include "paddle/phi/common/bfloat16.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/cpu/elementwise.h"
 #include "paddle/phi/kernels/impl/elementwise_kernel_impl.h"

--- a/paddle/phi/kernels/cpu/elementwise_multiply_kernel.cc
+++ b/paddle/phi/kernels/cpu/elementwise_multiply_kernel.cc
@@ -14,7 +14,6 @@
 
 #include "paddle/phi/api/ext/dispatch.h"
 #include "paddle/phi/backends/cpu/cpu_context.h"
-#include "paddle/phi/common/bfloat16.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/cpu/elementwise.h"
 #include "paddle/phi/kernels/impl/elementwise_kernel_impl.h"

--- a/paddle/phi/kernels/cpu/elementwise_subtract_kernel.cc
+++ b/paddle/phi/kernels/cpu/elementwise_subtract_kernel.cc
@@ -14,7 +14,6 @@
 
 #include "paddle/phi/api/ext/dispatch.h"
 #include "paddle/phi/backends/cpu/cpu_context.h"
-#include "paddle/phi/common/bfloat16.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/cpu/elementwise.h"
 #include "paddle/phi/kernels/impl/elementwise_kernel_impl.h"

--- a/paddle/phi/kernels/cpu/erf_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/erf_grad_kernel.cc
@@ -15,7 +15,6 @@ limitations under the License. */
 #include "paddle/phi/kernels/erf_grad_kernel.h"
 
 #include "paddle/phi/backends/cpu/cpu_context.h"
-#include "paddle/phi/common/float16.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/impl/erf_grad_kernel_impl.h"
 

--- a/paddle/phi/kernels/cpu/erf_kernel.cc
+++ b/paddle/phi/kernels/cpu/erf_kernel.cc
@@ -15,7 +15,6 @@ limitations under the License. */
 #include "paddle/phi/kernels/erf_kernel.h"
 
 #include "paddle/phi/backends/cpu/cpu_context.h"
-#include "paddle/phi/common/float16.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/impl/erf_kernel_impl.h"
 

--- a/paddle/phi/kernels/cpu/gather_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/gather_grad_kernel.cc
@@ -14,7 +14,6 @@
 
 #include "paddle/phi/kernels/gather_grad_kernel.h"
 
-#include "paddle/phi/common/bfloat16.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/funcs/eigen/common.h"

--- a/paddle/phi/kernels/cpu/gather_kernel.cc
+++ b/paddle/phi/kernels/cpu/gather_kernel.cc
@@ -14,7 +14,6 @@
 
 #include "paddle/phi/kernels/gather_kernel.h"
 
-#include "paddle/phi/common/bfloat16.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/gather.h"
 

--- a/paddle/phi/kernels/cpu/index_elementwise_get_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_elementwise_get_grad_kernel.cc
@@ -14,7 +14,6 @@
 
 #include "paddle/phi/kernels/index_elementwise_get_grad_kernel.h"
 
-#include "paddle/phi/common/bfloat16.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/eigen/common.h"
 #include "paddle/phi/kernels/funcs/index_elementwise.h"

--- a/paddle/phi/kernels/cpu/index_elementwise_get_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_elementwise_get_kernel.cc
@@ -15,7 +15,6 @@
 #include "paddle/phi/kernels/index_elementwise_get_kernel.h"
 
 #include "paddle/phi/backends/cpu/cpu_context.h"
-#include "paddle/phi/common/bfloat16.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/index_elementwise.h"
 #include "paddle/phi/kernels/funcs/stride_utils.h"

--- a/paddle/phi/kernels/cpu/index_elementwise_put_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_elementwise_put_grad_kernel.cc
@@ -15,7 +15,6 @@
 #include "paddle/phi/kernels/index_elementwise_put_grad_kernel.h"
 
 #include "paddle/phi/backends/cpu/cpu_context.h"
-#include "paddle/phi/common/bfloat16.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/cast_kernel.h"
 #include "paddle/phi/kernels/full_kernel.h"

--- a/paddle/phi/kernels/cpu/index_elementwise_put_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_elementwise_put_kernel.cc
@@ -15,7 +15,6 @@
 #include "paddle/phi/kernels/index_elementwise_put_kernel.h"
 
 #include "paddle/phi/backends/cpu/cpu_context.h"
-#include "paddle/phi/common/bfloat16.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/index_elementwise.h"
 #include "paddle/phi/kernels/funcs/stride_utils.h"

--- a/paddle/phi/kernels/cpu/lookup_table_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/lookup_table_grad_kernel.cc
@@ -21,7 +21,6 @@
 #include "paddle/phi/kernels/funcs/eigen/common.h"
 
 #include "paddle/phi/backends/cpu/cpu_context.h"
-#include "paddle/phi/common/bfloat16.h"
 #include "paddle/phi/core/kernel_registry.h"
 
 namespace phi {

--- a/paddle/phi/kernels/cpu/lookup_table_kernel.cc
+++ b/paddle/phi/kernels/cpu/lookup_table_kernel.cc
@@ -21,7 +21,6 @@
 #include "paddle/phi/kernels/funcs/eigen/common.h"
 
 #include "paddle/phi/backends/cpu/cpu_context.h"
-#include "paddle/phi/common/bfloat16.h"
 #include "paddle/phi/core/kernel_registry.h"
 
 namespace phi {

--- a/paddle/phi/kernels/cpu/save_combine_kernel.cc
+++ b/paddle/phi/kernels/cpu/save_combine_kernel.cc
@@ -17,7 +17,6 @@ limitations under the License. */
 #include <string>
 
 #include "paddle/phi/backends/cpu/cpu_context.h"
-#include "paddle/phi/common/bfloat16.h"
 #include "paddle/phi/core/kernel_registry.h"
 
 PD_REGISTER_KERNEL(save_combine_tensor,

--- a/paddle/phi/kernels/cpu/scale_kernel.cc
+++ b/paddle/phi/kernels/cpu/scale_kernel.cc
@@ -20,7 +20,6 @@ limitations under the License. */
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/eigen/common.h"
 
-#include "paddle/phi/common/bfloat16.h"
 #include "paddle/phi/kernels/funcs/eigen/eigen_function.h"
 namespace phi {
 

--- a/paddle/phi/kernels/cpu/sign_kernel.cc
+++ b/paddle/phi/kernels/cpu/sign_kernel.cc
@@ -18,8 +18,6 @@ limitations under the License. */
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/impl/sign_kernel_impl.h"
 
-#include "paddle/phi/common/bfloat16.h"
-
 PD_REGISTER_KERNEL(sign,
                    CPU,
                    ALL_LAYOUT,

--- a/paddle/phi/kernels/cpu/soft_relu_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/soft_relu_grad_kernel.cc
@@ -27,7 +27,6 @@
 
 #include <type_traits>
 
-#include "paddle/phi/common/float16.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/core/tensor_utils.h"
 #include "paddle/phi/kernels/funcs/activation_functor.h"

--- a/paddle/phi/kernels/cpu/soft_relu_kernel.cc
+++ b/paddle/phi/kernels/cpu/soft_relu_kernel.cc
@@ -27,7 +27,6 @@
 
 #include <type_traits>
 
-#include "paddle/phi/common/float16.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/core/tensor_utils.h"
 #include "paddle/phi/kernels/funcs/activation_functor.h"

--- a/paddle/phi/kernels/cpu/split_kernel.cc
+++ b/paddle/phi/kernels/cpu/split_kernel.cc
@@ -14,7 +14,6 @@
 
 #include "paddle/phi/kernels/split_kernel.h"
 
-#include "paddle/phi/common/float16.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/impl/split_kernel_impl.h"
 

--- a/paddle/phi/kernels/cpu/strided_copy_kernel.cc
+++ b/paddle/phi/kernels/cpu/strided_copy_kernel.cc
@@ -14,7 +14,6 @@ limitations under the License. */
 #include <vector>
 
 #include "paddle/phi/backends/cpu/cpu_context.h"
-#include "paddle/phi/common/bfloat16.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/math_function.h"
 #include "paddle/phi/kernels/impl/transpose_grad_kernel_impl.h"

--- a/paddle/phi/kernels/cpu/transpose_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/transpose_grad_kernel.cc
@@ -15,7 +15,6 @@
 #include "paddle/phi/kernels/transpose_grad_kernel.h"
 
 #include "paddle/phi/backends/cpu/cpu_context.h"
-#include "paddle/phi/common/bfloat16.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/impl/transpose_grad_kernel_impl.h"
 

--- a/paddle/phi/kernels/cpu/transpose_kernel.cc
+++ b/paddle/phi/kernels/cpu/transpose_kernel.cc
@@ -17,7 +17,6 @@
 #include <vector>
 
 #include "paddle/phi/backends/cpu/cpu_context.h"
-#include "paddle/phi/common/bfloat16.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/math_function.h"
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
remove include bfloat16.h in paddle/phi/kernels/cpu