### PR TITLE
fix the mixprecision bug when cumulate the grad

### DIFF
--- a/python/paddle/distributed/fleet/utils/mix_precision_utils.py
+++ b/python/paddle/distributed/fleet/utils/mix_precision_utils.py
@@ -64,7 +64,7 @@ class MixPrecisionLayer(nn.Layer):
                         name="main_grad@" + param.name,
                     )
                 else:
-                    param.main_grad.add_(tmp_grad)
+                    param.main_grad.add_(tmp_grad.cast(paddle.float32))
 
                 tmp_grad._clear_data()
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Operator Mechanism

### PR Types
Bug fixes


### Description
![D98F5172A9E802072AAA9658FD227FA4](https://github.com/user-attachments/assets/e397d3c4-16f2-4465-a009-065bc30fb2fc)
![D2A1D9AB15FF97A58A45D15EB3766F88](https://github.com/user-attachments/assets/07ee90f4-f72c-4967-b5a8-b70465556f14)
mix_precision在执行梯度累加时，此处需要将tmp_grad转化为float32，否则会出现精度不一致，导致报错。
