### PR TITLE
[API compatibility]Fix trunc mode in divide op when input x is integer

### DIFF
--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -1043,6 +1043,32 @@ def divide(
     elif rounding_mode == "trunc":
         if in_dynamic_or_pir_mode():
             tmp = _C_ops.divide(x, y)
+
+            if x.dtype in (
+                paddle.uint8,
+                paddle.int8,
+                paddle.int16,
+                paddle.int32,
+                paddle.int64,
+            ) and y.dtype in (
+                paddle.uint8,
+                paddle.int8,
+                paddle.int16,
+                paddle.int32,
+                paddle.int64,
+            ):
+                if x.dtype == paddle.int64 or y.dtype == paddle.int64:
+                    target_dtype = paddle.int64
+                elif x.dtype == paddle.int32 or y.dtype == paddle.int32:
+                    target_dtype = paddle.int32
+                elif x.dtype == paddle.int16 or y.dtype == paddle.int16:
+                    target_dtype = paddle.int16
+                elif x.dtype == paddle.int8 or y.dtype == paddle.int8:
+                    target_dtype = paddle.int8
+                else:
+                    target_dtype = paddle.uint8
+                tmp = _C_ops.cast(tmp, target_dtype)
+
             res = _C_ops.trunc(tmp, out=out)
         else:
             tmp = _elementwise_op(LayerHelper('elementwise_div', **locals()))
@@ -1096,6 +1122,30 @@ def divide_(
         res = _C_ops.divide_(x, y)
     elif rounding_mode == "trunc":
         tmp = _C_ops.divide_(x, y)
+        if x.dtype in (
+            paddle.uint8,
+            paddle.int8,
+            paddle.int16,
+            paddle.int32,
+            paddle.int64,
+        ) and y.dtype in (
+            paddle.uint8,
+            paddle.int8,
+            paddle.int16,
+            paddle.int32,
+            paddle.int64,
+        ):
+            if x.dtype == paddle.int64 or y.dtype == paddle.int64:
+                target_dtype = paddle.int64
+            elif x.dtype == paddle.int32 or y.dtype == paddle.int32:
+                target_dtype = paddle.int32
+            elif x.dtype == paddle.int16 or y.dtype == paddle.int16:
+                target_dtype = paddle.int16
+            elif x.dtype == paddle.int8 or y.dtype == paddle.int8:
+                target_dtype = paddle.int8
+            else:
+                target_dtype = paddle.uint8
+            tmp = _C_ops.cast_(tmp, target_dtype)
         res = _C_ops.trunc_(tmp)
     elif rounding_mode == "floor":
         res = _C_ops.floor_divide_(x, y)

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -1043,6 +1043,7 @@ def divide(
     elif rounding_mode == "trunc":
         if in_dynamic_or_pir_mode():
             tmp = _C_ops.divide(x, y)
+            res = _C_ops.trunc(tmp, out=out)
 
             if x.dtype in (
                 paddle.uint8,
@@ -1067,9 +1068,7 @@ def divide(
                     target_dtype = paddle.int8
                 else:
                     target_dtype = paddle.uint8
-                tmp = _C_ops.cast(tmp, target_dtype)
-
-            res = _C_ops.trunc(tmp, out=out)
+                _C_ops.cast_(res, target_dtype)
         else:
             tmp = _elementwise_op(LayerHelper('elementwise_div', **locals()))
 
@@ -1121,32 +1120,24 @@ def divide_(
     if rounding_mode is None:
         res = _C_ops.divide_(x, y)
     elif rounding_mode == "trunc":
+        x_dtype = x.dtype
+        y_dtype = y.dtype
         tmp = _C_ops.divide_(x, y)
-        if x.dtype in (
+        res = _C_ops.trunc_(tmp)
+        if x_dtype in (
             paddle.uint8,
             paddle.int8,
             paddle.int16,
             paddle.int32,
             paddle.int64,
-        ) and y.dtype in (
+        ) and y_dtype in (
             paddle.uint8,
             paddle.int8,
             paddle.int16,
             paddle.int32,
             paddle.int64,
         ):
-            if x.dtype == paddle.int64 or y.dtype == paddle.int64:
-                target_dtype = paddle.int64
-            elif x.dtype == paddle.int32 or y.dtype == paddle.int32:
-                target_dtype = paddle.int32
-            elif x.dtype == paddle.int16 or y.dtype == paddle.int16:
-                target_dtype = paddle.int16
-            elif x.dtype == paddle.int8 or y.dtype == paddle.int8:
-                target_dtype = paddle.int8
-            else:
-                target_dtype = paddle.uint8
-            tmp = _C_ops.cast_(tmp, target_dtype)
-        res = _C_ops.trunc_(tmp)
+            _C_ops.cast_(res, x_dtype)
     elif rounding_mode == "floor":
         res = _C_ops.floor_divide_(x, y)
     else:

--- a/test/legacy_test/test_div_op.py
+++ b/test/legacy_test/test_div_op.py
@@ -85,31 +85,35 @@ class TestPaddleDivide(unittest.TestCase):
         expected_floor = np.array([2.0, -3.0, 1.0, -2.0])
         np.testing.assert_allclose(out.numpy(), expected_floor, rtol=1e-20)
 
-    # def test_paddle_divide_mixed_dtypes(self):
-    #     """Test paddle.divide with mixed dtypes (int/float combinations)"""
-    #     test_cases = [
-    #         # (x_dtype, y_dtype, expected_dtype)
-    #         ('int8', 'float16', 'float16'),
-    #         ('int16', 'float32', 'float32'),
-    #         ('uint8', 'float64', 'float64'),
-    #         ('int32', 'bfloat16', 'bfloat16'),
-    #         ('float16', 'int64', 'float16'),
-    #         ('bfloat16', 'uint8', 'bfloat16'),
-    #         ('float64', 'int8', 'float64'),
-    #     ]
+    def test_paddle_divide_mixed_dtypes(self):
+        """Test paddle.divide with mixed dtypes (int/float combinations)"""
+        test_cases = [
+            # (x_dtype, y_dtype, expected_dtype, rounding_mode)
+            # ('int8', 'float16', 'float16', None),
+            # ('int16', 'float32', 'float32', None),
+            # ('uint8', 'float64', 'float64', None),
+            # ('int32', 'bfloat16', 'bfloat16', None),
+            # ('float16', 'int64', 'float16', None),
+            # ('bfloat16', 'uint8', 'bfloat16', None),
+            # ('float64', 'int8', 'float64', None),
+            # ('int8', 'int32', 'int32', 'trunc'),
+            # ('int32', 'int64', 'int64', 'trunc'),
+            ('int32', 'int32', 'int32', 'trunc'),
+            ('int64', 'int64', 'int64', 'trunc'),
+        ]
 
-    #     for x_dtype, y_dtype, expected_dtype in test_cases:
-    #         with self.subTest(x_dtype=x_dtype, y_dtype=y_dtype):
-    #             x = paddle.to_tensor([1, 2, 3], dtype=x_dtype)
-    #             y = paddle.to_tensor([2, 1, 3], dtype=y_dtype)
+        for x_dtype, y_dtype, expected_dtype, rounding_mode in test_cases:
+            with self.subTest(x_dtype=x_dtype, y_dtype=y_dtype):
+                x = paddle.to_tensor([1, 2, 3], dtype=x_dtype)
+                y = paddle.to_tensor([2, 1, 3], dtype=y_dtype)
 
-    #             out = paddle.divide(x, y)
+                out = paddle.divide(x, y, rounding_mode=rounding_mode)
 
-    #             self.assertEqual(
-    #                 out.dtype,
-    #                 getattr(paddle, expected_dtype),
-    #                 f'Dtype mismatch: {x_dtype}/{y_dtype} should be {expected_dtype}',
-    #             )
+                self.assertEqual(
+                    out.dtype,
+                    getattr(paddle, expected_dtype),
+                    f'Dtype mismatch: {x_dtype}/{y_dtype} should be {expected_dtype}',
+                )
 
     def test_paddle_divide_static_graph(self):
         """Test paddle.divide in static graph"""

--- a/test/legacy_test/test_div_op.py
+++ b/test/legacy_test/test_div_op.py
@@ -100,6 +100,9 @@ class TestPaddleDivide(unittest.TestCase):
             # ('int32', 'int64', 'int64', 'trunc'),
             ('int32', 'int32', 'int32', 'trunc'),
             ('int64', 'int64', 'int64', 'trunc'),
+            ('int16', 'int16', 'int16', 'trunc'),
+            ('int8', 'int8', 'int8', 'trunc'),
+            ('uint8', 'uint8', 'uint8', 'trunc'),
         ]
 
         for x_dtype, y_dtype, expected_dtype, rounding_mode in test_cases:
@@ -371,6 +374,39 @@ class TestPaddleDivideInplace(unittest.TestCase):
         x_clone.divide_(y, rounding_mode='floor')
         expected2 = np.array([2.0, -3.0, 1.0, -2.0])
         np.testing.assert_allclose(x_clone.numpy(), expected2, rtol=1e-6)
+
+    def test_paddle_divide__mixed_dtypes(self):
+        """Test paddle.divide_ with mixed dtypes (int/float combinations)"""
+        test_cases = [
+            # (x_dtype, y_dtype, expected_dtype, rounding_mode)
+            # ('int8', 'float16', 'float16', None),
+            # ('int16', 'float32', 'float32', None),
+            # ('uint8', 'float64', 'float64', None),
+            # ('int32', 'bfloat16', 'bfloat16', None),
+            # ('float16', 'int64', 'float16', None),
+            # ('bfloat16', 'uint8', 'bfloat16', None),
+            # ('float64', 'int8', 'float64', None),
+            # ('int8', 'int32', 'int32', 'trunc'),
+            # ('int32', 'int64', 'int64', 'trunc'),
+            ('int32', 'int32', 'int32', 'trunc'),
+            ('int64', 'int64', 'int64', 'trunc'),
+            ('int16', 'int16', 'int16', 'trunc'),
+            ('int8', 'int8', 'int8', 'trunc'),
+            ('uint8', 'uint8', 'uint8', 'trunc'),
+        ]
+
+        for x_dtype, y_dtype, expected_dtype, rounding_mode in test_cases:
+            with self.subTest(x_dtype=x_dtype, y_dtype=y_dtype):
+                x = paddle.to_tensor([1, 2, 3], dtype=x_dtype)
+                y = paddle.to_tensor([2, 1, 3], dtype=y_dtype)
+
+                x.divide_(y, rounding_mode=rounding_mode)
+
+                self.assertEqual(
+                    x.dtype,
+                    getattr(paddle, expected_dtype),
+                    f'Dtype mismatch: {x_dtype}/{y_dtype} should be {expected_dtype}',
+                )
 
 
 class TestPaddleDivInplace(unittest.TestCase):


### PR DESCRIPTION
### PR Category
User Experience

### PR Types
New features

### Description
当 rounding_mode 为 trunc 时，_C_ops.divide 在输入 x 和 y 均为 int 类型的情况下，会将类型提升为 float32，实际 trunc 应保持 int 类型，其输出结果也应维持 int 类型。

注：
1. 目前 paddle 不支持整数类型提升，例如int32->int64。

pcard-67164