### PR TITLE
[AutoParallel] Adapt grad clip for moe layer

### DIFF
--- a/python/paddle/nn/clip.py
+++ b/python/paddle/nn/clip.py
@@ -717,7 +717,6 @@ class ClipGradByGlobalNorm(ClipGradBase):
         sum_square_list = []
         sum_square_list_fp16 = []
         sum_square_list_fp32 = []
-        flag_auto_hybrid_pp = True  # Determine whether to use the new dynamic graph semi-automatic parallel pp framework
         if len(params_grads) > 0 and len(params_grads[0]) > 0:
             src_mesh = params_grads[0][0].process_mesh
         else:
@@ -743,7 +742,6 @@ class ClipGradByGlobalNorm(ClipGradBase):
             # if the gradient mesh is not equal to src mesh
             # do reshard to get the result of squared_l2 from other pp stage mesh
             if src_mesh is not None and g.process_mesh != src_mesh:
-                flag_auto_hybrid_pp = False
                 pp_mesh = get_complete_pp_mesh(g.process_mesh)
                 if set(g.process_mesh.process_ids) < set(pp_mesh.process_ids):
                     sum_square = dist.reshard(
@@ -800,7 +798,7 @@ class ClipGradByGlobalNorm(ClipGradBase):
         # then performs pp group communication reduce(sum) to get correct global_norm_var.
         # For complete alignment with old dygraph semi-auto parallel PP logic,
         # refer to NOTE: align ClipGradByGlobalNorm in auto_parallel_align_mode
-        if flag_auto_hybrid_pp and src_mesh is not None:
+        if src_mesh is not None:
             g_mesh = dist.get_mesh()
             if (
                 g_mesh
@@ -884,15 +882,6 @@ class ClipGradByGlobalNorm(ClipGradBase):
                                 "Reshard a sharded tensor from a local mesh to a global mesh is not supported"
                             )
                     else:
-                        pp_mesh = get_complete_pp_mesh(g.process_mesh)
-
-                        if set(g.process_mesh.process_ids) < set(
-                            pp_mesh.process_ids
-                        ):
-                            clip_input = dist.reshard(
-                                clip_input, pp_mesh, clip_input.placements
-                            )
-
                         clip_input = paddle.distributed.reshard(
                             clip_input, g.process_mesh, clip_input.placements
                         )

--- a/python/paddle/nn/clip.py
+++ b/python/paddle/nn/clip.py
@@ -717,6 +717,7 @@ class ClipGradByGlobalNorm(ClipGradBase):
         sum_square_list = []
         sum_square_list_fp16 = []
         sum_square_list_fp32 = []
+        flag_auto_hybrid_pp = True  # Determine whether to use the new dynamic graph semi-automatic parallel pp framework
         if len(params_grads) > 0 and len(params_grads[0]) > 0:
             src_mesh = params_grads[0][0].process_mesh
         else:
@@ -742,8 +743,10 @@ class ClipGradByGlobalNorm(ClipGradBase):
             # if the gradient mesh is not equal to src mesh
             # do reshard to get the result of squared_l2 from other pp stage mesh
             if src_mesh is not None and g.process_mesh != src_mesh:
+                flag_auto_hybrid_pp = False
                 pp_mesh = get_complete_pp_mesh(g.process_mesh)
                 if set(g.process_mesh.process_ids) < set(pp_mesh.process_ids):
+                    flag_auto_hybrid_pp = True
                     sum_square = dist.reshard(
                         sum_square, pp_mesh, sum_square.placements
                     )
@@ -798,7 +801,7 @@ class ClipGradByGlobalNorm(ClipGradBase):
         # then performs pp group communication reduce(sum) to get correct global_norm_var.
         # For complete alignment with old dygraph semi-auto parallel PP logic,
         # refer to NOTE: align ClipGradByGlobalNorm in auto_parallel_align_mode
-        if src_mesh is not None:
+        if flag_auto_hybrid_pp and src_mesh is not None:
             g_mesh = dist.get_mesh()
             if (
                 g_mesh
@@ -882,6 +885,15 @@ class ClipGradByGlobalNorm(ClipGradBase):
                                 "Reshard a sharded tensor from a local mesh to a global mesh is not supported"
                             )
                     else:
+                        pp_mesh = get_complete_pp_mesh(g.process_mesh)
+
+                        if set(g.process_mesh.process_ids) < set(
+                            pp_mesh.process_ids
+                        ):
+                            clip_input = dist.reshard(
+                                clip_input, pp_mesh, clip_input.placements
+                            )
+
                         clip_input = paddle.distributed.reshard(
                             clip_input, g.process_mesh, clip_input.placements
                         )


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
**背景：**
ernie 模型在 `pp2 + num_hidden_layers=4 + moe_layer_start_index=3` 情况下，

- `stage 0` 上不包含 moe 层，所有 grad mesh 都是 [0,1,2,3] ，在 grad clip 中会调用 `allreduce` 求和所有梯度

- `stage 1` 上包含 moe 层，grad 大部分是 [4,5,6,7]；存在 moe softmax 的 grad mesh 是 [current_rank]，这些在 grad clip 会被 reshard 成  [4,5,6,7]，但并不会调用 `allreduce` 求和所有梯度


**解决方法：**
grad clip 中 `flag_auto_hybrid_pp` 控制着是否进行 allreduce 通信
该 PR 修复 `stage 1` 情况下适配 moe ，设置 `flag_auto_hybrid_pp=True`，`stage0` 和 `stage1` 可以进行 `allreduce` 通信
card-92763
