### PR TITLE
[API Compatiblity] support `pin_memory` argument for 14 API

### DIFF
--- a/python/paddle/base/dygraph/math_op_patch.py
+++ b/python/paddle/base/dygraph/math_op_patch.py
@@ -296,6 +296,7 @@ def monkey_patch_math_tensor():
         dtype: DTypeLike | None = None,
         device: PlaceLike | None = None,
         requires_grad: bool = False,
+        pin_memory: bool = False,
     ) -> Tensor:
         if dtype is None:
             dtype = var.dtype
@@ -308,6 +309,7 @@ def monkey_patch_math_tensor():
             dtype=dtype,
             device=device,
             requires_grad=requires_grad,
+            pin_memory=pin_memory,
         )
 
     def _new_empty_(
@@ -339,6 +341,7 @@ def monkey_patch_math_tensor():
         dtype: DTypeLike | None = None,
         device: PlaceLike | None = None,
         requires_grad: bool = False,
+        pin_memory: bool = False,
     ) -> Tensor:
         if dtype is None:
             dtype = var.dtype
@@ -351,6 +354,7 @@ def monkey_patch_math_tensor():
             dtype,
             device=device,
             requires_grad=requires_grad,
+            pin_memory=pin_memory,
         )
 
     def _new_zeros_(
@@ -360,6 +364,7 @@ def monkey_patch_math_tensor():
         dtype: DTypeLike | None = None,
         device: PlaceLike | None = None,
         requires_grad: bool = False,
+        pin_memory: bool = False,
     ) -> Tensor:
         if dtype is None:
             dtype = var.dtype
@@ -372,6 +377,7 @@ def monkey_patch_math_tensor():
             dtype,
             device=device,
             requires_grad=requires_grad,
+            pin_memory=pin_memory,
         )
 
     @property

--- a/python/paddle/base/framework.py
+++ b/python/paddle/base/framework.py
@@ -8280,7 +8280,7 @@ def _get_paddle_place(place):
 
     if not isinstance(place, str):
         raise ValueError(
-            "place only support string which is 'Place' and so on."
+            f"place only support string which is 'Place' and so on, but got {place}"
         )
 
     place = place.lower()

--- a/python/paddle/base/framework.py
+++ b/python/paddle/base/framework.py
@@ -8284,6 +8284,8 @@ def _get_paddle_place(place):
         )
 
     place = place.lower()
+    if place.startswith("cuda"):
+        place = place.replace("cuda", "gpu")
     if place == "cpu":
         return core.CPUPlace()
 

--- a/python/paddle/device/__init__.py
+++ b/python/paddle/device/__init__.py
@@ -222,6 +222,8 @@ def _convert_to_place(device: PlaceLike) -> PlaceLike:
         return device  # return directly if not a string
 
     lower_device = device.lower()
+    if lower_device.startswith("cuda"):
+        lower_device = lower_device.replace("cuda", "gpu")
     if device in core.get_all_custom_device_type():
         selected_devices = os.getenv(f"FLAGS_selected_{device}s", "0").split(
             ","

--- a/python/paddle/pir/math_op_patch.py
+++ b/python/paddle/pir/math_op_patch.py
@@ -647,6 +647,7 @@ def monkey_patch_value():
         dtype: DTypeLike | None = None,
         device: PlaceLike | None = None,
         requires_grad: bool = False,
+        pin_memory: bool = False,
     ):
         """
 
@@ -682,6 +683,7 @@ def monkey_patch_value():
             dtype=dtype,
             device=device,
             requires_grad=requires_grad,
+            pin_memory=pin_memory,
         )
 
     def _new_empty_(
@@ -736,6 +738,7 @@ def monkey_patch_value():
         dtype: DTypeLike | None = None,
         device: PlaceLike | None = None,
         requires_grad: bool = False,
+        pin_memory: bool = False,
     ):
         """
 
@@ -771,6 +774,7 @@ def monkey_patch_value():
             dtype=dtype,
             device=device,
             requires_grad=requires_grad,
+            pin_memory=pin_memory,
         )
 
     def _new_zeros_(
@@ -780,6 +784,7 @@ def monkey_patch_value():
         dtype: DTypeLike | None = None,
         device: PlaceLike | None = None,
         requires_grad: bool = False,
+        pin_memory: bool = False,
     ):
         """
 
@@ -815,6 +820,7 @@ def monkey_patch_value():
             dtype=dtype,
             device=device,
             requires_grad=requires_grad,
+            pin_memory=pin_memory,
         )
 
     def _int_(self):

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -1155,6 +1155,7 @@ def full_like(
     *,
     device: PlaceLike | None = None,
     requires_grad: bool = False,
+    pin_memory: bool = False,
 ) -> paddle.Tensor:
     """
 
@@ -1178,6 +1179,7 @@ def full_like(
             if None, uses the current device for the default tensor type (see paddle.device.set_device()).
             device will be the CPU for CPU tensor types and the current CUDA device for CUDA tensor types. Default: None.
         requires_grad(bool, optional):  If autograd should record operations on the returned tensor. Default: False.
+        pin_memory(bool, optional): If set, return tensor would be allocated in the pinned memory. Works only for CPU tensors. Default: False
 
     Returns:
         Tensor: Tensor which is created according to ``x``, ``fill_value`` and ``dtype``.
@@ -1211,20 +1213,39 @@ def full_like(
     if device is None:
         device = x.place
 
+    device = (
+        _get_paddle_place(device)
+        if device is not None
+        else _current_expected_place()
+    )
+    if (
+        pin_memory
+        and in_dynamic_mode()
+        and device is not None
+        and not isinstance(device, (core.CUDAPinnedPlace, core.XPUPinnedPlace))
+    ):
+        if isinstance(device, core.CUDAPlace) or (
+            isinstance(device, core.Place) and device.is_gpu_place()
+        ):
+            device = core.CUDAPinnedPlace()
+        elif isinstance(device, core.XPUPlace) or (
+            isinstance(device, core.Place) and device.is_xpu_place()
+        ):
+            device = core.XPUPinnedPlace()
+        else:
+            raise RuntimeError(
+                f"Pinning memory is not supported for {device}., "
+                f"{in_dynamic_mode()}, "
+                f"device = {device}, {type(device)}"
+            )
+
     if in_dynamic_or_pir_mode():
         if in_dynamic_mode():
-            tensor = _C_ops.full_like(
-                x, fill_value, dtype, _get_paddle_place(device)
-            )
-        else:
-            tensor = _C_ops.full_like(
-                x,
-                fill_value,
-                dtype,
-                core.Place() if device is None else _get_paddle_place(device),
-            )
+            tensor = _C_ops.full_like(x, fill_value, dtype, device)
         if requires_grad is True:
             tensor.stop_gradient = False
+        if pin_memory and in_dynamic_mode():
+            tensor = tensor.pin_memory()
         return tensor
     else:
         helper = LayerHelper("full_like", **locals())
@@ -1396,6 +1417,7 @@ def ones(
     out: paddle.Tensor | None = None,
     device: PlaceLike | None = None,
     requires_grad: bool = False,
+    pin_memory: bool = False,
 ) -> paddle.Tensor:
     """
     Create a Tensor of specified :attr:`shape` and :attr:`dtype` and fill it with 1.
@@ -1412,6 +1434,7 @@ def ones(
             if None, uses the current device for the default tensor type (see paddle.device.set_device()).
             device will be the CPU for CPU tensor types and the current CUDA device for CUDA tensor types. Default: None.
         requires_grad(bool, optional):  If autograd should record operations on the returned tensor. Default: False.
+        pin_memory(bool, optional): If set, return tensor would be allocated in the pinned memory. Works only for CPU tensors. Default: False
 
     Returns:
         Tensor: A Tensor of data type :attr:`dtype` with shape :attr:`shape` and all elements are 1.
@@ -1451,6 +1474,7 @@ def ones(
         out=out,
         device=device,
         requires_grad=requires_grad,
+        pin_memory=pin_memory,
         name=name,
     )
 
@@ -1463,6 +1487,7 @@ def ones_like(
     *,
     device: PlaceLike | None = None,
     requires_grad: bool = False,
+    pin_memory: bool = False,
 ) -> paddle.Tensor:
     """
     Returns a Tensor filled with the value 1, with the same shape and
@@ -1485,6 +1510,7 @@ def ones_like(
             if None, uses the current device for the default tensor type (see paddle.device.set_device()).
             device will be the CPU for CPU tensor types and the current CUDA device for CUDA tensor types. Default: None.
         requires_grad(bool, optional):  If autograd should record operations on the returned tensor. Default: False.
+        pin_memory(bool, optional): If set, return tensor would be allocated in the pinned memory. Works only for CPU tensors. Default: False
 
     Returns:
         Tensor: A Tensor filled with the value 1, with the same shape and
@@ -1510,6 +1536,7 @@ def ones_like(
         dtype=dtype,
         name=name,
         device=device,
+        pin_memory=pin_memory,
         requires_grad=requires_grad,
     )
 
@@ -1523,6 +1550,7 @@ def zeros(
     out: paddle.Tensor | None = None,
     device: PlaceLike | None = None,
     requires_grad: bool = False,
+    pin_memory: bool = False,
 ) -> paddle.Tensor:
     """
     Creates a tensor of specified :attr:`shape` and :attr:`dtype`, and fills it with 0.
@@ -1549,6 +1577,7 @@ def zeros(
             device will be the CPU for CPU tensor types and the current CUDA device for CUDA tensor types. Default: None.
         requires_grad(bool, optional):  If autograd should record operations on the returned tensor. Default: False.
         name(str|None, optional): The default value is None.  Normally there is no need for user to set this
+        pin_memory(bool, optional): If set, return tensor would be allocated in the pinned memory. Works only for CPU tensors. Default: False
 
     Returns:
         Tensor: A tensor of data type :attr:`dtype` with shape :attr:`shape` and all elements set to 0.
@@ -1588,6 +1617,7 @@ def zeros(
         out=out,
         device=device,
         requires_grad=requires_grad,
+        pin_memory=pin_memory,
         name=name,
     )
 
@@ -1600,6 +1630,7 @@ def zeros_like(
     *,
     device: PlaceLike | None = None,
     requires_grad: bool = False,
+    pin_memory: bool = False,
 ) -> paddle.Tensor:
     """
     Returns a Tensor filled with the value 0, with the same shape and
@@ -1622,6 +1653,7 @@ def zeros_like(
             if None, uses the current device for the default tensor type (see paddle.device.set_device()).
             device will be the CPU for CPU tensor types and the current CUDA device for CUDA tensor types. Default: None.
         requires_grad(bool, optional):  If autograd should record operations on the returned tensor. Default: False.
+        pin_memory(bool, optional): If set, return tensor would be allocated in the pinned memory. Works only for CPU tensors. Default: False
 
     Returns:
         Tensor: A Tensor filled with the value 0, with the same shape and
@@ -1649,6 +1681,7 @@ def zeros_like(
         name=name,
         device=device,
         requires_grad=requires_grad,
+        pin_memory=pin_memory,
     )
 
 
@@ -1662,6 +1695,7 @@ def eye(
     out: paddle.Tensor | None = None,
     device: PlaceLike | None = None,
     requires_grad: bool = False,
+    pin_memory: bool = False,
 ) -> paddle.Tensor:
     """
 
@@ -1686,6 +1720,7 @@ def eye(
             if None, uses the current device for the default tensor type (see paddle.device.set_device()).
             device will be the CPU for CPU tensor types and the current CUDA device for CUDA tensor types. Default: None.
         requires_grad(bool, optional):  If autograd should record operations on the returned tensor. Default: False.
+        pin_memory(bool, optional): If set, return tensor would be allocated in the pinned memory. Works only for CPU tensors. Default: False
 
     Returns:
         Tensor: An identity Tensor or DenseTensor of shape [num_rows, num_columns].
@@ -1725,20 +1760,43 @@ def eye(
     else:
         num_columns = num_rows
 
+    device = (
+        _get_paddle_place(device)
+        if device is not None
+        else _current_expected_place()
+    )
+    if (
+        pin_memory
+        and in_dynamic_mode()
+        and device is not None
+        and not isinstance(device, (core.CUDAPinnedPlace, core.XPUPinnedPlace))
+    ):
+        if isinstance(device, core.CUDAPlace) or (
+            isinstance(device, core.Place) and device.is_gpu_place()
+        ):
+            device = core.CUDAPinnedPlace()
+        elif isinstance(device, core.XPUPlace) or (
+            isinstance(device, core.Place) and device.is_xpu_place()
+        ):
+            device = core.XPUPinnedPlace()
+        else:
+            raise RuntimeError(
+                f"Pinning memory is not supported for {device}., "
+                f"{in_dynamic_mode()}, "
+                f"device = {device}, {type(device)}"
+            )
     if in_dynamic_or_pir_mode():
         tensor = _C_ops.eye(
             num_rows,
             num_columns,
             dtype,
-            (
-                _get_paddle_place(device)
-                if device is not None
-                else _current_expected_place()
-            ),
+            device,
             out=out,
         )
         if requires_grad is True:
             tensor.stop_gradient = False
+        if pin_memory and in_dynamic_mode():
+            tensor = tensor.pin_memory()
         return tensor
     else:
         helper = LayerHelper("eye", **locals())
@@ -1784,6 +1842,7 @@ def full(
     out: paddle.Tensor | None = None,
     device: PlaceLike | None = None,
     requires_grad: bool = False,
+    pin_memory: bool = False,
 ) -> paddle.Tensor:
     """
 
@@ -1809,6 +1868,7 @@ def full(
             if None, uses the current device for the default tensor type (see paddle.device.set_device()).
             device will be the CPU for CPU tensor types and the current CUDA device for CUDA tensor types. Default: None.
         requires_grad(bool, optional):  If autograd should record operations on the returned tensor. Default: False.
+        pin_memory(bool, optional): If set, return tensor would be allocated in the pinned memory. Works only for CPU tensors. Default: False
 
     Returns:
         Tensor: Tensor which is created according to ``shape``, ``fill_value`` and ``dtype``.
@@ -1866,6 +1926,31 @@ def full(
             dtype = "complex128"
         else:
             dtype = paddle.get_default_dtype()
+    device = (
+        _get_paddle_place(device)
+        if device is not None
+        else _current_expected_place()
+    )
+    if (
+        pin_memory
+        and in_dynamic_mode()
+        and device is not None
+        and not isinstance(device, (core.CUDAPinnedPlace, core.XPUPinnedPlace))
+    ):
+        if isinstance(device, core.CUDAPlace) or (
+            isinstance(device, core.Place) and device.is_gpu_place()
+        ):
+            device = core.CUDAPinnedPlace()
+        elif isinstance(device, core.XPUPlace) or (
+            isinstance(device, core.Place) and device.is_xpu_place()
+        ):
+            device = core.XPUPinnedPlace()
+        else:
+            raise RuntimeError(
+                f"Pinning memory is not supported for {device}., "
+                f"{in_dynamic_mode()}, "
+                f"device = {device}, {type(device)}"
+            )
 
     tensor = fill_constant(
         shape=shape,
@@ -1877,6 +1962,8 @@ def full(
     )
     if requires_grad is True:
         tensor.stop_gradient = False
+    if pin_memory and in_dynamic_mode():
+        tensor = tensor.pin_memory()
     return tensor
 
 
@@ -1889,6 +1976,7 @@ def arange(
     out: paddle.Tensor | None = None,
     device: PlaceLike | None = None,
     requires_grad: bool = False,
+    pin_memory: bool = False,
     name: str | None = None,
 ) -> paddle.Tensor:
     """
@@ -1922,6 +2010,7 @@ def arange(
             if None, uses the current device for the default tensor type (see paddle.device.set_device()).
             device will be the CPU for CPU tensor types and the current CUDA device for CUDA tensor types. Default: None.
         requires_grad(bool, optional):  If autograd should record operations on the returned tensor. Default: False.
+        pin_memory(bool, optional): If set, return tensor would be allocated in the pinned memory. Works only for CPU tensors. Default: False
         name(str|None, optional): For details, please refer to :ref:`api_guide_Name`. Generally, no setting is required. Default: None.
 
     Returns:
@@ -1985,20 +2074,44 @@ def arange(
     if not isinstance(dtype, (core.VarDesc.VarType, core.DataType)):
         dtype = convert_np_dtype_to_dtype_(dtype)
 
+    device = (
+        _get_paddle_place(device)
+        if device is not None
+        else _current_expected_place()
+    )
+    if (
+        pin_memory
+        and in_dynamic_mode()
+        and device is not None
+        and not isinstance(device, (core.CUDAPinnedPlace, core.XPUPinnedPlace))
+    ):
+        if isinstance(device, core.CUDAPlace) or (
+            isinstance(device, core.Place) and device.is_gpu_place()
+        ):
+            device = core.CUDAPinnedPlace()
+        elif isinstance(device, core.XPUPlace) or (
+            isinstance(device, core.Place) and device.is_xpu_place()
+        ):
+            device = core.XPUPinnedPlace()
+        else:
+            raise RuntimeError(
+                f"Pinning memory is not supported for {device}., "
+                f"{in_dynamic_mode()}, "
+                f"device = {device}, {type(device)}"
+            )
+
     if is_value_input and in_pir_mode():
         tensor = _C_ops.arange(
             start,
             end,
             step,
             dtype,
-            (
-                _get_paddle_place(device)
-                if device is not None
-                else _current_expected_place()
-            ),
+            device,
             out=out,
         )
         tensor.stop_gradient = not requires_grad
+        if pin_memory and in_dynamic_mode():
+            tensor = tensor.pin_memory()
         return tensor
 
     if not isinstance(start, (Variable, paddle.pir.Value)):
@@ -2049,6 +2162,8 @@ def arange(
             out=out,
         )
         tensor.stop_gradient = not requires_grad
+        if pin_memory and in_dynamic_mode():
+            tensor = tensor.pin_memory()
         return tensor
     else:
         check_dtype(
@@ -2956,6 +3071,7 @@ def empty_like(
     *,
     device: PlaceLike | None = None,
     requires_grad: bool = False,
+    pin_memory: bool = False,
 ) -> paddle.Tensor:
     """
     Returns a Tensor with uninitialized data which has identical shape of ``x`` and ``dtype``.
@@ -2976,6 +3092,7 @@ def empty_like(
             if None, uses the current device for the default tensor type (see paddle.device.set_device()).
             device will be the CPU for CPU tensor types and the current CUDA device for CUDA tensor types. Default: None.
         requires_grad(bool, optional):  If autograd should record operations on the returned tensor. Default: False.
+        pin_memory(bool, optional): If set, return tensor would be allocated in the pinned memory. Works only for CPU tensors. Default: False
 
     Returns:
         Tensor: Tensor which is created according to ``x`` and ``dtype``, and is uninitialized.
@@ -3000,6 +3117,32 @@ def empty_like(
         device = x.place
     dtype = convert_dtype(dtype)
 
+    device = (
+        _get_paddle_place(device)
+        if device is not None
+        else _current_expected_place()
+    )
+    if (
+        pin_memory
+        and in_dynamic_mode()
+        and device is not None
+        and not isinstance(device, (core.CUDAPinnedPlace, core.XPUPinnedPlace))
+    ):
+        if isinstance(device, core.CUDAPlace) or (
+            isinstance(device, core.Place) and device.is_gpu_place()
+        ):
+            device = core.CUDAPinnedPlace()
+        elif isinstance(device, core.XPUPlace) or (
+            isinstance(device, core.Place) and device.is_xpu_place()
+        ):
+            device = core.XPUPinnedPlace()
+        else:
+            raise RuntimeError(
+                f"Pinning memory is not supported for {device}., "
+                f"{in_dynamic_mode()}, "
+                f"device = {device}, {type(device)}"
+            )
+
     if in_dynamic_or_pir_mode():
         if in_dynamic_mode():
             x_shape = x.shape
@@ -3009,14 +3152,12 @@ def empty_like(
         tensor = _C_ops.empty(
             x_shape,
             convert_np_dtype_to_dtype_(dtype),
-            (
-                _get_paddle_place(device)
-                if device is not None
-                else _current_expected_place()
-            ),
+            device,
         )
         if requires_grad is True:
             tensor.stop_gradient = False
+        if pin_memory and in_dynamic_mode():
+            tensor = tensor.pin_memory()
         return tensor
 
     else:

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -1211,29 +1211,33 @@ def full_like(
     if device is None:
         device = x.place
 
-    device = (
-        _get_paddle_place(device)
-        if device is not None
-        else _current_expected_place()
-    )
-    if (
-        pin_memory
-        and in_dynamic_mode()
-        and device is not None
-        and not isinstance(device, (core.CUDAPinnedPlace, core.XPUPinnedPlace))
-    ):
-        if isinstance(device, core.CUDAPlace) or (
-            isinstance(device, core.Place) and device.is_gpu_place()
-        ):
-            device = core.CUDAPinnedPlace()
-        elif isinstance(device, core.XPUPlace) or (
-            isinstance(device, core.Place) and device.is_xpu_place()
-        ):
-            device = core.XPUPinnedPlace()
-        else:
-            raise RuntimeError(f"Pinning memory is not supported for {device}")
-
     if in_dynamic_or_pir_mode():
+        device = (
+            _get_paddle_place(device)
+            if device is not None
+            else _current_expected_place()
+        )
+        if (
+            pin_memory
+            and in_dynamic_mode()
+            and device is not None
+            and not isinstance(
+                device, (core.CUDAPinnedPlace, core.XPUPinnedPlace)
+            )
+        ):
+            if isinstance(device, core.CUDAPlace) or (
+                isinstance(device, core.Place) and device.is_gpu_place()
+            ):
+                device = core.CUDAPinnedPlace()
+            elif isinstance(device, core.XPUPlace) or (
+                isinstance(device, core.Place) and device.is_xpu_place()
+            ):
+                device = core.XPUPinnedPlace()
+            else:
+                raise RuntimeError(
+                    f"Pinning memory is not supported for {device}"
+                )
+
         tensor = _C_ops.full_like(x, fill_value, dtype, device)
         if requires_grad is True:
             tensor.stop_gradient = False
@@ -1753,28 +1757,32 @@ def eye(
     else:
         num_columns = num_rows
 
-    device = (
-        _get_paddle_place(device)
-        if device is not None
-        else _current_expected_place()
-    )
-    if (
-        pin_memory
-        and in_dynamic_mode()
-        and device is not None
-        and not isinstance(device, (core.CUDAPinnedPlace, core.XPUPinnedPlace))
-    ):
-        if isinstance(device, core.CUDAPlace) or (
-            isinstance(device, core.Place) and device.is_gpu_place()
-        ):
-            device = core.CUDAPinnedPlace()
-        elif isinstance(device, core.XPUPlace) or (
-            isinstance(device, core.Place) and device.is_xpu_place()
-        ):
-            device = core.XPUPinnedPlace()
-        else:
-            raise RuntimeError(f"Pinning memory is not supported for {device}")
     if in_dynamic_or_pir_mode():
+        device = (
+            _get_paddle_place(device)
+            if device is not None
+            else _current_expected_place()
+        )
+        if (
+            pin_memory
+            and in_dynamic_mode()
+            and device is not None
+            and not isinstance(
+                device, (core.CUDAPinnedPlace, core.XPUPinnedPlace)
+            )
+        ):
+            if isinstance(device, core.CUDAPlace) or (
+                isinstance(device, core.Place) and device.is_gpu_place()
+            ):
+                device = core.CUDAPinnedPlace()
+            elif isinstance(device, core.XPUPlace) or (
+                isinstance(device, core.Place) and device.is_xpu_place()
+            ):
+                device = core.XPUPinnedPlace()
+            else:
+                raise RuntimeError(
+                    f"Pinning memory is not supported for {device}"
+                )
         tensor = _C_ops.eye(
             num_rows,
             num_columns,
@@ -1915,27 +1923,32 @@ def full(
             dtype = "complex128"
         else:
             dtype = paddle.get_default_dtype()
-    device = (
-        _get_paddle_place(device)
-        if device is not None
-        else _current_expected_place()
-    )
-    if (
-        pin_memory
-        and in_dynamic_mode()
-        and device is not None
-        and not isinstance(device, (core.CUDAPinnedPlace, core.XPUPinnedPlace))
-    ):
-        if isinstance(device, core.CUDAPlace) or (
-            isinstance(device, core.Place) and device.is_gpu_place()
+    if in_dynamic_or_pir_mode():
+        device = (
+            _get_paddle_place(device)
+            if device is not None
+            else _current_expected_place()
+        )
+        if (
+            pin_memory
+            and in_dynamic_mode()
+            and device is not None
+            and not isinstance(
+                device, (core.CUDAPinnedPlace, core.XPUPinnedPlace)
+            )
         ):
-            device = core.CUDAPinnedPlace()
-        elif isinstance(device, core.XPUPlace) or (
-            isinstance(device, core.Place) and device.is_xpu_place()
-        ):
-            device = core.XPUPinnedPlace()
-        else:
-            raise RuntimeError(f"Pinning memory is not supported for {device}")
+            if isinstance(device, core.CUDAPlace) or (
+                isinstance(device, core.Place) and device.is_gpu_place()
+            ):
+                device = core.CUDAPinnedPlace()
+            elif isinstance(device, core.XPUPlace) or (
+                isinstance(device, core.Place) and device.is_xpu_place()
+            ):
+                device = core.XPUPinnedPlace()
+            else:
+                raise RuntimeError(
+                    f"Pinning memory is not supported for {device}"
+                )
 
     tensor = fill_constant(
         shape=shape,
@@ -2059,27 +2072,32 @@ def arange(
     if not isinstance(dtype, (core.VarDesc.VarType, core.DataType)):
         dtype = convert_np_dtype_to_dtype_(dtype)
 
-    device = (
-        _get_paddle_place(device)
-        if device is not None
-        else _current_expected_place()
-    )
-    if (
-        pin_memory
-        and in_dynamic_mode()
-        and device is not None
-        and not isinstance(device, (core.CUDAPinnedPlace, core.XPUPinnedPlace))
-    ):
-        if isinstance(device, core.CUDAPlace) or (
-            isinstance(device, core.Place) and device.is_gpu_place()
+    if in_dynamic_or_pir_mode():
+        device = (
+            _get_paddle_place(device)
+            if device is not None
+            else _current_expected_place()
+        )
+        if (
+            pin_memory
+            and in_dynamic_mode()
+            and device is not None
+            and not isinstance(
+                device, (core.CUDAPinnedPlace, core.XPUPinnedPlace)
+            )
         ):
-            device = core.CUDAPinnedPlace()
-        elif isinstance(device, core.XPUPlace) or (
-            isinstance(device, core.Place) and device.is_xpu_place()
-        ):
-            device = core.XPUPinnedPlace()
-        else:
-            raise RuntimeError(f"Pinning memory is not supported for {device}")
+            if isinstance(device, core.CUDAPlace) or (
+                isinstance(device, core.Place) and device.is_gpu_place()
+            ):
+                device = core.CUDAPinnedPlace()
+            elif isinstance(device, core.XPUPlace) or (
+                isinstance(device, core.Place) and device.is_xpu_place()
+            ):
+                device = core.XPUPinnedPlace()
+            else:
+                raise RuntimeError(
+                    f"Pinning memory is not supported for {device}"
+                )
 
     if is_value_input and in_pir_mode():
         tensor = _C_ops.arange(
@@ -3096,29 +3114,33 @@ def empty_like(
         device = x.place
     dtype = convert_dtype(dtype)
 
-    device = (
-        _get_paddle_place(device)
-        if device is not None
-        else _current_expected_place()
-    )
-    if (
-        pin_memory
-        and in_dynamic_mode()
-        and device is not None
-        and not isinstance(device, (core.CUDAPinnedPlace, core.XPUPinnedPlace))
-    ):
-        if isinstance(device, core.CUDAPlace) or (
-            isinstance(device, core.Place) and device.is_gpu_place()
-        ):
-            device = core.CUDAPinnedPlace()
-        elif isinstance(device, core.XPUPlace) or (
-            isinstance(device, core.Place) and device.is_xpu_place()
-        ):
-            device = core.XPUPinnedPlace()
-        else:
-            raise RuntimeError(f"Pinning memory is not supported for {device}")
-
     if in_dynamic_or_pir_mode():
+        device = (
+            _get_paddle_place(device)
+            if device is not None
+            else _current_expected_place()
+        )
+        if (
+            pin_memory
+            and in_dynamic_mode()
+            and device is not None
+            and not isinstance(
+                device, (core.CUDAPinnedPlace, core.XPUPinnedPlace)
+            )
+        ):
+            if isinstance(device, core.CUDAPlace) or (
+                isinstance(device, core.Place) and device.is_gpu_place()
+            ):
+                device = core.CUDAPinnedPlace()
+            elif isinstance(device, core.XPUPlace) or (
+                isinstance(device, core.Place) and device.is_xpu_place()
+            ):
+                device = core.XPUPinnedPlace()
+            else:
+                raise RuntimeError(
+                    f"Pinning memory is not supported for {device}"
+                )
+
         if in_dynamic_mode():
             x_shape = x.shape
         else:

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -1233,11 +1233,7 @@ def full_like(
         ):
             device = core.XPUPinnedPlace()
         else:
-            raise RuntimeError(
-                f"Pinning memory is not supported for {device}., "
-                f"{in_dynamic_mode()}, "
-                f"device = {device}, {type(device)}"
-            )
+            raise RuntimeError(f"Pinning memory is not supported for {device}")
 
     if in_dynamic_or_pir_mode():
         if in_dynamic_mode():
@@ -1780,11 +1776,7 @@ def eye(
         ):
             device = core.XPUPinnedPlace()
         else:
-            raise RuntimeError(
-                f"Pinning memory is not supported for {device}., "
-                f"{in_dynamic_mode()}, "
-                f"device = {device}, {type(device)}"
-            )
+            raise RuntimeError(f"Pinning memory is not supported for {device}")
     if in_dynamic_or_pir_mode():
         tensor = _C_ops.eye(
             num_rows,
@@ -1946,11 +1938,7 @@ def full(
         ):
             device = core.XPUPinnedPlace()
         else:
-            raise RuntimeError(
-                f"Pinning memory is not supported for {device}., "
-                f"{in_dynamic_mode()}, "
-                f"device = {device}, {type(device)}"
-            )
+            raise RuntimeError(f"Pinning memory is not supported for {device}")
 
     tensor = fill_constant(
         shape=shape,
@@ -2094,11 +2082,7 @@ def arange(
         ):
             device = core.XPUPinnedPlace()
         else:
-            raise RuntimeError(
-                f"Pinning memory is not supported for {device}., "
-                f"{in_dynamic_mode()}, "
-                f"device = {device}, {type(device)}"
-            )
+            raise RuntimeError(f"Pinning memory is not supported for {device}")
 
     if is_value_input and in_pir_mode():
         tensor = _C_ops.arange(
@@ -3002,9 +2986,7 @@ def empty(
                 device = core.XPUPinnedPlace()
             else:
                 raise RuntimeError(
-                    f"Pinning memory is not supported for {device}., "
-                    f"{in_dynamic_mode()}, "
-                    f"device = {device}, {type(device)}"
+                    f"Pinning memory is not supported for {device}"
                 )
         tensor = _C_ops.empty(
             shape,
@@ -3137,11 +3119,7 @@ def empty_like(
         ):
             device = core.XPUPinnedPlace()
         else:
-            raise RuntimeError(
-                f"Pinning memory is not supported for {device}., "
-                f"{in_dynamic_mode()}, "
-                f"device = {device}, {type(device)}"
-            )
+            raise RuntimeError(f"Pinning memory is not supported for {device}")
 
     if in_dynamic_or_pir_mode():
         if in_dynamic_mode():

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -961,8 +961,6 @@ def tensor(
             [[(1+1j), (2+0j)],
              [(3+2j), (4+0j)]])
     """
-    if isinstance(device, str) and "cuda" in device:
-        device = device.replace("cuda", "gpu")
     stop_gradient = not requires_grad
     place = _get_paddle_place(device)
     if place is None:

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -1234,8 +1234,7 @@ def full_like(
             raise RuntimeError(f"Pinning memory is not supported for {device}")
 
     if in_dynamic_or_pir_mode():
-        if in_dynamic_mode():
-            tensor = _C_ops.full_like(x, fill_value, dtype, device)
+        tensor = _C_ops.full_like(x, fill_value, dtype, device)
         if requires_grad is True:
             tensor.stop_gradient = False
         if pin_memory and in_dynamic_mode():

--- a/test/legacy_test/test_creation.py
+++ b/test/legacy_test/test_creation.py
@@ -36,19 +36,48 @@ class TestTensorCreation(unittest.TestCase):
 
         self.requires_grads = [True, False]
         self.dtypes = [None, "float32", paddle.float32, "int32", paddle.int32]
+        self.pin_memorys = [False]
+        if (
+            paddle.device.is_compiled_with_cuda()
+            or paddle.device.is_compiled_with_xpu()
+        ):
+            self.pin_memorys.append(True)
 
     def test_ones(self):
-        for device, requires_grad, dtype in product(
-            self.devices, self.requires_grads, self.dtypes
+        for device, requires_grad, dtype, pin_memory in product(
+            self.devices, self.requires_grads, self.dtypes, self.pin_memorys
         ):
+            if (
+                device
+                not in [
+                    "gpu",
+                    "gpu:0",
+                    paddle.CUDAPlace(0)
+                    if paddle.device.is_compiled_with_cuda()
+                    else None,
+                    paddle.XPUPlace(0)
+                    if paddle.device.is_compiled_with_xpu()
+                    else None,
+                ]
+                and pin_memory
+            ):
+                continue  # skip
+
             with dygraph_guard():
                 x = paddle.ones(
                     [2],
                     dtype=dtype,
                     requires_grad=requires_grad,
                     device=device,
+                    pin_memory=pin_memory,
                 )
-                if isinstance(device, paddle.framework.core.Place):
+                if pin_memory:
+                    self.assertTrue("pinned" in str(x.place))
+                if (
+                    not paddle.device.is_compiled_with_xpu()
+                    and isinstance(device, paddle.framework.core.Place)
+                    and not pin_memory
+                ):
                     self.assertEqual(x.place, device)
                 self.assertEqual(x.stop_gradient, not requires_grad)
                 if isinstance(dtype, paddle.dtype):
@@ -82,24 +111,50 @@ class TestTensorCreation(unittest.TestCase):
                     requires_grad=requires_grad,
                     device=device,
                 )
-                if isinstance(device, paddle.framework.core.Place):
+                if (
+                    isinstance(device, paddle.framework.core.Place)
+                    and not pin_memory
+                ):
                     self.assertEqual(x.place, device)
                 self.assertEqual(x.stop_gradient, not requires_grad)
                 if isinstance(dtype, paddle.dtype):
                     self.assertEqual(x.dtype, dtype)
 
     def test_zeros(self):
-        for device, requires_grad, dtype in product(
-            self.devices, self.requires_grads, self.dtypes
+        for device, requires_grad, dtype, pin_memory in product(
+            self.devices, self.requires_grads, self.dtypes, self.pin_memorys
         ):
+            if (
+                device
+                not in [
+                    "gpu",
+                    "gpu:0",
+                    paddle.CUDAPlace(0)
+                    if paddle.device.is_compiled_with_cuda()
+                    else None,
+                    paddle.XPUPlace(0)
+                    if paddle.device.is_compiled_with_xpu()
+                    else None,
+                ]
+                and pin_memory
+            ):
+                continue  # skip
+
             with dygraph_guard():
                 x = paddle.zeros(
                     [2],
                     dtype=dtype,
                     requires_grad=requires_grad,
                     device=device,
+                    pin_memory=pin_memory,
                 )
-                if isinstance(device, paddle.framework.core.Place):
+                if pin_memory:
+                    self.assertTrue("pinned" in str(x.place))
+                if (
+                    not paddle.device.is_compiled_with_xpu()
+                    and isinstance(device, paddle.framework.core.Place)
+                    and not pin_memory
+                ):
                     self.assertEqual(x.place, device)
                 self.assertEqual(x.stop_gradient, not requires_grad)
                 if isinstance(dtype, paddle.dtype):
@@ -133,21 +188,16 @@ class TestTensorCreation(unittest.TestCase):
                     requires_grad=requires_grad,
                     device=device,
                 )
-                if isinstance(device, paddle.framework.core.Place):
+                if (
+                    isinstance(device, paddle.framework.core.Place)
+                    and not pin_memory
+                ):
                     self.assertEqual(x.place, device)
                 self.assertEqual(x.stop_gradient, not requires_grad)
                 if isinstance(dtype, paddle.dtype):
                     self.assertEqual(x.dtype, dtype)
 
     def test_randn(self):
-        # randn has extra arg: pin_memory
-        pin_memorys = [False]
-        if (
-            paddle.device.is_compiled_with_cuda()
-            or paddle.device.is_compiled_with_xpu()
-        ):
-            pin_memorys.append(True)
-
         types = [
             None,
             "float32",
@@ -156,19 +206,24 @@ class TestTensorCreation(unittest.TestCase):
             paddle.float64,
         ]
         for device, requires_grad, dtype, pin_memory in product(
-            self.devices, self.requires_grads, types, pin_memorys
+            self.devices, self.requires_grads, types, self.pin_memorys
         ):
-            if device not in [
-                "gpu",
-                "gpu:0",
-                paddle.CUDAPlace(0)
-                if paddle.device.is_compiled_with_cuda()
-                else None,
-                paddle.XPUPlace(0)
-                if paddle.device.is_compiled_with_xpu()
-                else None,
-            ]:
-                pin_memory = False
+            if (
+                device
+                not in [
+                    "gpu",
+                    "gpu:0",
+                    paddle.CUDAPlace(0)
+                    if paddle.device.is_compiled_with_cuda()
+                    else None,
+                    paddle.XPUPlace(0)
+                    if paddle.device.is_compiled_with_xpu()
+                    else None,
+                ]
+                and pin_memory
+            ):
+                continue  # skip
+
             with dygraph_guard():
                 x = paddle.randn(
                     [2],
@@ -177,11 +232,10 @@ class TestTensorCreation(unittest.TestCase):
                     device=device,
                     pin_memory=pin_memory,
                 )
-                if (
-                    isinstance(device, paddle.framework.core.Place)
-                    and not pin_memory
-                ):
-                    self.assertEqual(x.stop_gradient, not requires_grad)
+                if pin_memory:
+                    self.assertTrue("pinned" in str(x.place))
+
+                self.assertEqual(x.stop_gradient, not requires_grad)
                 if isinstance(dtype, paddle.dtype):
                     self.assertEqual(x.dtype, dtype)
 
@@ -216,7 +270,10 @@ class TestTensorCreation(unittest.TestCase):
                     device=device,
                     pin_memory=pin_memory,
                 )
-                if isinstance(device, paddle.framework.core.Place):
+                if (
+                    isinstance(device, paddle.framework.core.Place)
+                    and not pin_memory
+                ):
                     self.assertEqual(x.place, device)
                 self.assertEqual(x.stop_gradient, not requires_grad)
                 if isinstance(dtype, paddle.dtype):
@@ -233,9 +290,25 @@ class TestTensorCreation(unittest.TestCase):
                 self.assertEqual(x.data_ptr(), y.data_ptr())
 
     def test_full(self):
-        for device, requires_grad, dtype in product(
-            self.devices, self.requires_grads, self.dtypes
+        for device, requires_grad, dtype, pin_memory in product(
+            self.devices, self.requires_grads, self.dtypes, self.pin_memorys
         ):
+            if (
+                device
+                not in [
+                    "gpu",
+                    "gpu:0",
+                    paddle.CUDAPlace(0)
+                    if paddle.device.is_compiled_with_cuda()
+                    else None,
+                    paddle.XPUPlace(0)
+                    if paddle.device.is_compiled_with_xpu()
+                    else None,
+                ]
+                and pin_memory
+            ):
+                continue  # skip
+
             with dygraph_guard():
                 x = paddle.full(
                     [2],
@@ -243,8 +316,15 @@ class TestTensorCreation(unittest.TestCase):
                     dtype=dtype,
                     requires_grad=requires_grad,
                     device=device,
+                    pin_memory=pin_memory,
                 )
-                if isinstance(device, paddle.framework.core.Place):
+                if pin_memory:
+                    self.assertTrue("pinned" in str(x.place))
+
+                if (
+                    isinstance(device, paddle.framework.core.Place)
+                    and not pin_memory
+                ):
                     self.assertEqual(x.place, device)
                 self.assertEqual(x.stop_gradient, not requires_grad)
                 if isinstance(dtype, paddle.dtype):
@@ -259,37 +339,38 @@ class TestTensorCreation(unittest.TestCase):
                     requires_grad=requires_grad,
                     device=device,
                 )
-                if isinstance(device, paddle.framework.core.Place):
+                if (
+                    isinstance(device, paddle.framework.core.Place)
+                    and not pin_memory
+                ):
                     self.assertEqual(x.place, device)
                 self.assertEqual(x.stop_gradient, not requires_grad)
                 if isinstance(dtype, paddle.dtype):
                     self.assertEqual(x.dtype, dtype)
 
     def test_empty(self):
-        # empty has extra arg: pin_memory
-        pin_memorys = [False]
-        if (
-            paddle.device.is_compiled_with_cuda()
-            or paddle.device.is_compiled_with_xpu()
-        ):
-            pin_memorys.append(True)
         for device, requires_grad, dtype, pin_memory in product(
             self.devices,
             self.requires_grads,
             self.dtypes,
-            pin_memorys,
+            self.pin_memorys,
         ):
-            if device not in [
-                "gpu",
-                "gpu:0",
-                paddle.CUDAPlace(0)
-                if paddle.device.is_compiled_with_cuda()
-                else None,
-                paddle.XPUPlace(0)
-                if paddle.device.is_compiled_with_xpu()
-                else None,
-            ]:
-                pin_memory = False
+            if (
+                device
+                not in [
+                    "gpu",
+                    "gpu:0",
+                    paddle.CUDAPlace(0)
+                    if paddle.device.is_compiled_with_cuda()
+                    else None,
+                    paddle.XPUPlace(0)
+                    if paddle.device.is_compiled_with_xpu()
+                    else None,
+                ]
+                and pin_memory
+            ):
+                continue  # skip
+
             with dygraph_guard():
                 x = paddle.empty(
                     [2],
@@ -298,6 +379,9 @@ class TestTensorCreation(unittest.TestCase):
                     device=device,
                     pin_memory=pin_memory,
                 )
+                if pin_memory:
+                    self.assertTrue("pinned" in str(x.place))
+
                 if (
                     isinstance(device, paddle.framework.core.Place)
                     and not pin_memory
@@ -338,16 +422,35 @@ class TestTensorCreation(unittest.TestCase):
                     device=device,
                     pin_memory=pin_memory,
                 )
-                if isinstance(device, paddle.framework.core.Place):
+                if (
+                    isinstance(device, paddle.framework.core.Place)
+                    and not pin_memory
+                ):
                     self.assertEqual(x.place, device)
                 self.assertEqual(x.stop_gradient, not requires_grad)
                 if isinstance(dtype, paddle.dtype):
                     self.assertEqual(x.dtype, dtype)
 
     def test_eye(self):
-        for device, requires_grad, dtype in product(
-            self.devices, self.requires_grads, self.dtypes
+        for device, requires_grad, dtype, pin_memory in product(
+            self.devices, self.requires_grads, self.dtypes, self.pin_memorys
         ):
+            if (
+                device
+                not in [
+                    "gpu",
+                    "gpu:0",
+                    paddle.CUDAPlace(0)
+                    if paddle.device.is_compiled_with_cuda()
+                    else None,
+                    paddle.XPUPlace(0)
+                    if paddle.device.is_compiled_with_xpu()
+                    else None,
+                ]
+                and pin_memory
+            ):
+                continue  # skip
+
             with dygraph_guard():
                 x = paddle.eye(
                     3,
@@ -355,8 +458,15 @@ class TestTensorCreation(unittest.TestCase):
                     dtype=dtype,
                     requires_grad=requires_grad,
                     device=device,
+                    pin_memory=pin_memory,
                 )
-                if isinstance(device, paddle.framework.core.Place):
+                if pin_memory:
+                    self.assertTrue("pinned" in str(x.place))
+
+                if (
+                    isinstance(device, paddle.framework.core.Place)
+                    and not pin_memory
+                ):
                     self.assertEqual(x.place, device)
                 self.assertEqual(x.stop_gradient, not requires_grad)
                 if isinstance(dtype, paddle.dtype):
@@ -382,17 +492,40 @@ class TestTensorCreation(unittest.TestCase):
                     self.assertEqual(x.dtype, dtype)
 
     def test_ones_like(self):
-        for device, requires_grad, dtype in product(
-            self.devices, self.requires_grads, self.dtypes
+        for device, requires_grad, dtype, pin_memory in product(
+            self.devices, self.requires_grads, self.dtypes, self.pin_memorys
         ):
+            if (
+                device
+                not in [
+                    "gpu",
+                    "gpu:0",
+                    paddle.CUDAPlace(0)
+                    if paddle.device.is_compiled_with_cuda()
+                    else None,
+                    paddle.XPUPlace(0)
+                    if paddle.device.is_compiled_with_xpu()
+                    else None,
+                ]
+                and pin_memory
+            ):
+                continue  # skip
+
             with dygraph_guard():
                 x = paddle.ones_like(
                     paddle.randn([2, 2]),
                     dtype=dtype,
                     requires_grad=requires_grad,
                     device=device,
+                    pin_memory=pin_memory,
                 )
-                if isinstance(device, paddle.framework.core.Place):
+                if pin_memory:
+                    self.assertTrue("pinned" in str(x.place))
+
+                if (
+                    isinstance(device, paddle.framework.core.Place)
+                    and not pin_memory
+                ):
                     self.assertEqual(x.place, device)
                 self.assertEqual(x.stop_gradient, not requires_grad)
                 if isinstance(dtype, paddle.dtype):
@@ -406,24 +539,50 @@ class TestTensorCreation(unittest.TestCase):
                     requires_grad=requires_grad,
                     device=device,
                 )
-                if isinstance(device, paddle.framework.core.Place):
+                if (
+                    isinstance(device, paddle.framework.core.Place)
+                    and not pin_memory
+                ):
                     self.assertEqual(x.place, device)
                 self.assertEqual(x.stop_gradient, not requires_grad)
                 if isinstance(dtype, paddle.dtype):
                     self.assertEqual(x.dtype, dtype)
 
     def test_zeros_like(self):
-        for device, requires_grad, dtype in product(
-            self.devices, self.requires_grads, self.dtypes
+        for device, requires_grad, dtype, pin_memory in product(
+            self.devices, self.requires_grads, self.dtypes, self.pin_memorys
         ):
+            if (
+                device
+                not in [
+                    "gpu",
+                    "gpu:0",
+                    paddle.CUDAPlace(0)
+                    if paddle.device.is_compiled_with_cuda()
+                    else None,
+                    paddle.XPUPlace(0)
+                    if paddle.device.is_compiled_with_xpu()
+                    else None,
+                ]
+                and pin_memory
+            ):
+                continue  # skip
+
             with dygraph_guard():
                 x = paddle.zeros_like(
                     paddle.randn([2, 2]),
                     dtype=dtype,
                     requires_grad=requires_grad,
                     device=device,
+                    pin_memory=pin_memory,
                 )
-                if isinstance(device, paddle.framework.core.Place):
+                if pin_memory:
+                    self.assertTrue("pinned" in str(x.place))
+
+                if (
+                    isinstance(device, paddle.framework.core.Place)
+                    and not pin_memory
+                ):
                     self.assertEqual(x.place, device)
                 self.assertEqual(x.stop_gradient, not requires_grad)
                 if isinstance(dtype, paddle.dtype):
@@ -437,16 +596,35 @@ class TestTensorCreation(unittest.TestCase):
                     requires_grad=requires_grad,
                     device=device,
                 )
-                if isinstance(device, paddle.framework.core.Place):
+                if (
+                    isinstance(device, paddle.framework.core.Place)
+                    and not pin_memory
+                ):
                     self.assertEqual(x.place, device)
                 self.assertEqual(x.stop_gradient, not requires_grad)
                 if isinstance(dtype, paddle.dtype):
                     self.assertEqual(x.dtype, dtype)
 
     def test_full_like(self):
-        for device, requires_grad, dtype in product(
-            self.devices, self.requires_grads, self.dtypes
+        for device, requires_grad, dtype, pin_memory in product(
+            self.devices, self.requires_grads, self.dtypes, self.pin_memorys
         ):
+            if (
+                device
+                not in [
+                    "gpu",
+                    "gpu:0",
+                    paddle.CUDAPlace(0)
+                    if paddle.device.is_compiled_with_cuda()
+                    else None,
+                    paddle.XPUPlace(0)
+                    if paddle.device.is_compiled_with_xpu()
+                    else None,
+                ]
+                and pin_memory
+            ):
+                continue  # skip
+
             with dygraph_guard():
                 x = paddle.full_like(
                     paddle.randn([2, 2]),
@@ -454,8 +632,15 @@ class TestTensorCreation(unittest.TestCase):
                     dtype=dtype,
                     requires_grad=requires_grad,
                     device=device,
+                    pin_memory=pin_memory,
                 )
-                if isinstance(device, paddle.framework.core.Place):
+                if pin_memory:
+                    self.assertTrue("pinned" in str(x.place))
+                if (
+                    not paddle.device.is_compiled_with_xpu()
+                    and isinstance(device, paddle.framework.core.Place)
+                    and not pin_memory
+                ):
                     self.assertEqual(x.place, device)
                 self.assertEqual(x.stop_gradient, not requires_grad)
                 if isinstance(dtype, paddle.dtype):
@@ -470,24 +655,50 @@ class TestTensorCreation(unittest.TestCase):
                     requires_grad=requires_grad,
                     device=device,
                 )
-                if isinstance(device, paddle.framework.core.Place):
+                if (
+                    isinstance(device, paddle.framework.core.Place)
+                    and not pin_memory
+                ):
                     self.assertEqual(x.place, device)
                 self.assertEqual(x.stop_gradient, not requires_grad)
                 if isinstance(dtype, paddle.dtype):
                     self.assertEqual(x.dtype, dtype)
 
     def test_empty_like(self):
-        for device, requires_grad, dtype in product(
-            self.devices, self.requires_grads, self.dtypes
+        for device, requires_grad, dtype, pin_memory in product(
+            self.devices, self.requires_grads, self.dtypes, self.pin_memorys
         ):
+            if (
+                device
+                not in [
+                    "gpu",
+                    "gpu:0",
+                    paddle.CUDAPlace(0)
+                    if paddle.device.is_compiled_with_cuda()
+                    else None,
+                    paddle.XPUPlace(0)
+                    if paddle.device.is_compiled_with_xpu()
+                    else None,
+                ]
+                and pin_memory
+            ):
+                continue  # skip
+
             with dygraph_guard():
                 x = paddle.empty_like(
                     paddle.randn([2, 2]),
                     dtype=dtype,
                     requires_grad=requires_grad,
                     device=device,
+                    pin_memory=pin_memory,
                 )
-                if isinstance(device, paddle.framework.core.Place):
+                if pin_memory:
+                    self.assertTrue("pinned" in str(x.place))
+                if (
+                    not paddle.device.is_compiled_with_xpu()
+                    and isinstance(device, paddle.framework.core.Place)
+                    and not pin_memory
+                ):
                     self.assertEqual(x.place, device)
                 self.assertEqual(x.stop_gradient, not requires_grad)
                 if isinstance(dtype, paddle.dtype):
@@ -501,16 +712,35 @@ class TestTensorCreation(unittest.TestCase):
                     requires_grad=requires_grad,
                     device=device,
                 )
-                if isinstance(device, paddle.framework.core.Place):
+                if (
+                    isinstance(device, paddle.framework.core.Place)
+                    and not pin_memory
+                ):
                     self.assertEqual(x.place, device)
                 self.assertEqual(x.stop_gradient, not requires_grad)
                 if isinstance(dtype, paddle.dtype):
                     self.assertEqual(x.dtype, dtype)
 
     def test_arange(self):
-        for device, requires_grad, dtype in product(
-            self.devices, self.requires_grads, self.dtypes
+        for device, requires_grad, dtype, pin_memory in product(
+            self.devices, self.requires_grads, self.dtypes, self.pin_memorys
         ):
+            if (
+                device
+                not in [
+                    "gpu",
+                    "gpu:0",
+                    paddle.CUDAPlace(0)
+                    if paddle.device.is_compiled_with_cuda()
+                    else None,
+                    paddle.XPUPlace(0)
+                    if paddle.device.is_compiled_with_xpu()
+                    else None,
+                ]
+                and pin_memory
+            ):
+                continue  # skip
+
             with dygraph_guard():
                 x = paddle.arange(
                     3.14,
@@ -519,8 +749,15 @@ class TestTensorCreation(unittest.TestCase):
                     dtype=dtype,
                     requires_grad=requires_grad,
                     device=device,
+                    pin_memory=pin_memory,
                 )
-                if isinstance(device, paddle.framework.core.Place):
+                if pin_memory:
+                    self.assertTrue("pinned" in str(x.place))
+                if (
+                    not paddle.device.is_compiled_with_xpu()
+                    and isinstance(device, paddle.framework.core.Place)
+                    and not pin_memory
+                ):
                     self.assertEqual(x.place, device)
                 self.assertEqual(x.stop_gradient, not requires_grad)
                 if isinstance(dtype, paddle.dtype):
@@ -728,11 +965,36 @@ class TestTensorPatchMethod(unittest.TestCase):
             [4, 4],
         ]
         self.dtypes = ["float32", paddle.float32, "int32", paddle.int32]
+        self.pin_memorys = [False]
+        if (
+            paddle.device.is_compiled_with_cuda()
+            or paddle.device.is_compiled_with_xpu()
+        ):
+            self.pin_memorys.append(True)
 
     def test_Tensor_new_ones(self):
-        for shape, device, requires_grad, dtype in product(
-            self.shapes, self.devices, self.requires_grads, self.dtypes
+        for shape, device, requires_grad, dtype, pin_memory in product(
+            self.shapes,
+            self.devices,
+            self.requires_grads,
+            self.dtypes,
+            self.pin_memorys,
         ):
+            if (
+                device
+                not in [
+                    "gpu",
+                    "gpu:0",
+                    paddle.CUDAPlace(0)
+                    if paddle.device.is_compiled_with_cuda()
+                    else None,
+                    paddle.XPUPlace(0)
+                    if paddle.device.is_compiled_with_xpu()
+                    else None,
+                ]
+                and pin_memory
+            ):
+                continue  # skip
             with dygraph_guard():
                 x = paddle.ones(
                     [1],
@@ -741,19 +1003,29 @@ class TestTensorPatchMethod(unittest.TestCase):
                     dtype=dtype,
                     requires_grad=requires_grad,
                     device=device,
+                    pin_memory=pin_memory,
                 )
-                if isinstance(device, paddle.framework.core.Place):
+                if pin_memory:
+                    self.assertTrue("pinned" in str(x.place))
+                if (
+                    not paddle.device.is_compiled_with_xpu()
+                    and isinstance(device, paddle.framework.core.Place)
+                    and not pin_memory
+                ):
                     self.assertEqual(x.place, device)
                 self.assertEqual(x.stop_gradient, not requires_grad)
                 if isinstance(dtype, paddle.dtype):
                     self.assertEqual(x.dtype, dtype)
 
-                def new_ones(x, shape, dtype, requires_grad, device):
+                def new_ones(
+                    x, shape, dtype, requires_grad, device, pin_memory
+                ):
                     return x.new_ones(
                         shape,
                         dtype=dtype,
                         requires_grad=requires_grad,
                         device=device,
+                        pin_memory=pin_memory,
                     )
 
                 st_f = paddle.jit.to_static(
@@ -765,17 +1037,40 @@ class TestTensorPatchMethod(unittest.TestCase):
                     dtype=dtype,
                     requires_grad=requires_grad,
                     device=device,
+                    pin_memory=pin_memory,
                 )
-                if isinstance(device, paddle.framework.core.Place):
+                if (
+                    isinstance(device, paddle.framework.core.Place)
+                    and not pin_memory
+                ):
                     self.assertEqual(x.place, device)
                 self.assertEqual(x.stop_gradient, not requires_grad)
                 if isinstance(dtype, paddle.dtype):
                     self.assertEqual(x.dtype, dtype)
 
     def test_Tensor_new_zeros(self):
-        for shape, device, requires_grad, dtype in product(
-            self.shapes, self.devices, self.requires_grads, self.dtypes
+        for shape, device, requires_grad, dtype, pin_memory in product(
+            self.shapes,
+            self.devices,
+            self.requires_grads,
+            self.dtypes,
+            self.pin_memorys,
         ):
+            if (
+                device
+                not in [
+                    "gpu",
+                    "gpu:0",
+                    paddle.CUDAPlace(0)
+                    if paddle.device.is_compiled_with_cuda()
+                    else None,
+                    paddle.XPUPlace(0)
+                    if paddle.device.is_compiled_with_xpu()
+                    else None,
+                ]
+                and pin_memory
+            ):
+                continue  # skip
             with dygraph_guard():
                 x = paddle.zeros(
                     [1],
@@ -784,19 +1079,29 @@ class TestTensorPatchMethod(unittest.TestCase):
                     dtype=dtype,
                     requires_grad=requires_grad,
                     device=device,
+                    pin_memory=pin_memory,
                 )
-                if isinstance(device, paddle.framework.core.Place):
+                if pin_memory:
+                    self.assertTrue("pinned" in str(x.place))
+                if (
+                    not paddle.device.is_compiled_with_xpu()
+                    and isinstance(device, paddle.framework.core.Place)
+                    and not pin_memory
+                ):
                     self.assertEqual(x.place, device)
                 self.assertEqual(x.stop_gradient, not requires_grad)
                 if isinstance(dtype, paddle.dtype):
                     self.assertEqual(x.dtype, dtype)
 
-                def new_zeros(x, shape, dtype, requires_grad, device):
+                def new_zeros(
+                    x, shape, dtype, requires_grad, device, pin_memory
+                ):
                     return x.new_zeros(
                         shape,
                         dtype=dtype,
                         requires_grad=requires_grad,
                         device=device,
+                        pin_memory=pin_memory,
                     )
 
                 st_f = paddle.jit.to_static(
@@ -808,17 +1113,40 @@ class TestTensorPatchMethod(unittest.TestCase):
                     dtype=dtype,
                     requires_grad=requires_grad,
                     device=device,
+                    pin_memory=pin_memory,
                 )
-                if isinstance(device, paddle.framework.core.Place):
+                if (
+                    isinstance(device, paddle.framework.core.Place)
+                    and not pin_memory
+                ):
                     self.assertEqual(x.place, device)
                 self.assertEqual(x.stop_gradient, not requires_grad)
                 if isinstance(dtype, paddle.dtype):
                     self.assertEqual(x.dtype, dtype)
 
     def test_Tensor_new_full(self):
-        for shape, device, requires_grad, dtype in product(
-            self.shapes, self.devices, self.requires_grads, self.dtypes
+        for shape, device, requires_grad, dtype, pin_memory in product(
+            self.shapes,
+            self.devices,
+            self.requires_grads,
+            self.dtypes,
+            self.pin_memorys,
         ):
+            if (
+                device
+                not in [
+                    "gpu",
+                    "gpu:0",
+                    paddle.CUDAPlace(0)
+                    if paddle.device.is_compiled_with_cuda()
+                    else None,
+                    paddle.XPUPlace(0)
+                    if paddle.device.is_compiled_with_xpu()
+                    else None,
+                ]
+                and pin_memory
+            ):
+                continue  # skip
             with dygraph_guard():
                 x = paddle.full(
                     [1],
@@ -829,8 +1157,15 @@ class TestTensorPatchMethod(unittest.TestCase):
                     dtype=dtype,
                     requires_grad=requires_grad,
                     device=device,
+                    pin_memory=pin_memory,
                 )
-                if isinstance(device, paddle.framework.core.Place):
+                if pin_memory:
+                    self.assertTrue("pinned" in str(x.place))
+                if (
+                    not paddle.device.is_compiled_with_xpu()
+                    and isinstance(device, paddle.framework.core.Place)
+                    and not pin_memory
+                ):
                     self.assertEqual(x.place, device)
                 self.assertEqual(x.stop_gradient, not requires_grad)
                 if isinstance(dtype, paddle.dtype):
@@ -840,7 +1175,13 @@ class TestTensorPatchMethod(unittest.TestCase):
                 )
 
                 def new_full(
-                    x, shape, fill_value, dtype, requires_grad, device
+                    x,
+                    shape,
+                    fill_value,
+                    dtype,
+                    requires_grad,
+                    device,
+                    pin_memory,
                 ):
                     return x.new_full(
                         shape,
@@ -848,6 +1189,7 @@ class TestTensorPatchMethod(unittest.TestCase):
                         dtype=dtype,
                         requires_grad=requires_grad,
                         device=device,
+                        pin_memory=pin_memory,
                     )
 
                 st_f = paddle.jit.to_static(
@@ -860,8 +1202,12 @@ class TestTensorPatchMethod(unittest.TestCase):
                     dtype=dtype,
                     requires_grad=requires_grad,
                     device=device,
+                    pin_memory=pin_memory,
                 )
-                if isinstance(device, paddle.framework.core.Place):
+                if (
+                    isinstance(device, paddle.framework.core.Place)
+                    and not pin_memory
+                ):
                     self.assertEqual(x.place, device)
                 self.assertEqual(x.stop_gradient, not requires_grad)
                 if isinstance(dtype, paddle.dtype):
@@ -871,31 +1217,29 @@ class TestTensorPatchMethod(unittest.TestCase):
                 )
 
     def test_Tensor_new_empty(self):
-        # empty has extra arg: pin_memory
-        pin_memorys = [False]
-        if (
-            paddle.device.is_compiled_with_cuda()
-            or paddle.device.is_compiled_with_xpu()
-        ):
-            pin_memorys.append(True)
         for shape, device, requires_grad, dtype, pin_memory in product(
             self.shapes,
             self.devices,
             self.requires_grads,
             self.dtypes,
-            pin_memorys,
+            self.pin_memorys,
         ):
-            if device not in [
-                "gpu",
-                "gpu:0",
-                paddle.CUDAPlace(0)
-                if paddle.device.is_compiled_with_cuda()
-                else None,
-                paddle.XPUPlace(0)
-                if paddle.device.is_compiled_with_xpu()
-                else None,
-            ]:
-                pin_memory = False
+            if (
+                device
+                not in [
+                    "gpu",
+                    "gpu:0",
+                    paddle.CUDAPlace(0)
+                    if paddle.device.is_compiled_with_cuda()
+                    else None,
+                    paddle.XPUPlace(0)
+                    if paddle.device.is_compiled_with_xpu()
+                    else None,
+                ]
+                and pin_memory
+            ):
+                continue  # skip
+
             with dygraph_guard():
                 x = paddle.empty(
                     [1],
@@ -906,6 +1250,8 @@ class TestTensorPatchMethod(unittest.TestCase):
                     device=device,
                     pin_memory=pin_memory,
                 )
+                if pin_memory:
+                    self.assertTrue("pinned" in str(x.place))
                 if (
                     isinstance(device, paddle.framework.core.Place)
                     and not pin_memory
@@ -937,7 +1283,10 @@ class TestTensorPatchMethod(unittest.TestCase):
                     device=device,
                     pin_memory=pin_memory,
                 )
-                if isinstance(device, paddle.framework.core.Place):
+                if (
+                    isinstance(device, paddle.framework.core.Place)
+                    and not pin_memory
+                ):
                     self.assertEqual(x.place, device)
                 self.assertEqual(x.stop_gradient, not requires_grad)
                 if isinstance(dtype, paddle.dtype):

--- a/test/legacy_test/test_creation.py
+++ b/test/legacy_test/test_creation.py
@@ -140,6 +140,14 @@ class TestTensorCreation(unittest.TestCase):
                     self.assertEqual(x.dtype, dtype)
 
     def test_randn(self):
+        # randn has extra arg: pin_memory
+        pin_memorys = [False]
+        if (
+            paddle.device.is_compiled_with_cuda()
+            or paddle.device.is_compiled_with_xpu()
+        ):
+            pin_memorys.append(True)
+
         types = [
             None,
             "float32",
@@ -147,19 +155,33 @@ class TestTensorCreation(unittest.TestCase):
             "float64",
             paddle.float64,
         ]
-        for device, requires_grad, dtype in product(
-            self.devices, self.requires_grads, types
+        for device, requires_grad, dtype, pin_memory in product(
+            self.devices, self.requires_grads, types, pin_memorys
         ):
+            if device not in [
+                "gpu",
+                "gpu:0",
+                paddle.CUDAPlace(0)
+                if paddle.device.is_compiled_with_cuda()
+                else None,
+                paddle.XPUPlace(0)
+                if paddle.device.is_compiled_with_xpu()
+                else None,
+            ]:
+                pin_memory = False
             with dygraph_guard():
                 x = paddle.randn(
                     [2],
                     dtype=dtype,
                     requires_grad=requires_grad,
                     device=device,
+                    pin_memory=pin_memory,
                 )
-                if isinstance(device, paddle.framework.core.Place):
-                    self.assertEqual(x.place, device)
-                self.assertEqual(x.stop_gradient, not requires_grad)
+                if (
+                    isinstance(device, paddle.framework.core.Place)
+                    and not pin_memory
+                ):
+                    self.assertEqual(x.stop_gradient, not requires_grad)
                 if isinstance(dtype, paddle.dtype):
                     self.assertEqual(x.dtype, dtype)
 
@@ -171,6 +193,7 @@ class TestTensorCreation(unittest.TestCase):
                     out=None,
                     device=None,
                     requires_grad=False,
+                    pin_memory=False,
                 ):
                     return paddle.randn(
                         shape,
@@ -179,6 +202,7 @@ class TestTensorCreation(unittest.TestCase):
                         out=out,
                         device=device,
                         requires_grad=requires_grad,
+                        pin_memory=pin_memory,
                     )
 
                 st_f = paddle.jit.to_static(
@@ -190,6 +214,7 @@ class TestTensorCreation(unittest.TestCase):
                     dtype=dtype,
                     requires_grad=requires_grad,
                     device=device,
+                    pin_memory=pin_memory,
                 )
                 if isinstance(device, paddle.framework.core.Place):
                     self.assertEqual(x.place, device)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->

Pcard-75624

为以下API新增`pin_memory`参数，并更新对应单测

1. paddle.arange
1. paddle.empty_like
1. paddle.eye
1. paddle.full
1. paddle.full_like
1. paddle.ones
1. paddle.ones_like
1. paddle.randn
1. paddle.zeros
1. paddle.zeros_like
1. paddle.Tensor.new_ones
2. paddle.Tensor.new_full
3. paddle.Tensor.new_empty
4. paddle.Tensor.new_zeros