### PR TITLE
[PHI] Major fix for gather/scatter related CUDA kernels

### DIFF
--- a/paddle/phi/kernels/funcs/gather_scatter_functor.cu
+++ b/paddle/phi/kernels/funcs/gather_scatter_functor.cu
@@ -245,12 +245,12 @@ __global__ void ScatterMeanGPUKernel(tensor_t* self_data,
                                      int64_t self_select_dim_size,
                                      int64_t src_select_dim_size,
                                      int64_t numel,
-                                     int64_t self_numel,
                                      int dim,
                                      int ndim,
                                      const func_t& reduce_op,
                                      bool include_self = true,
-                                     int* aux_buffer = nullptr) {
+                                     int* aux_buffer = nullptr,
+                                     int* atomic_cnt_buffer = nullptr) {
   extern __shared__ int64_t
       smem_shape_strides[];  // no more than 27 int64_t, won't affect occupancy
 
@@ -310,7 +310,7 @@ __global__ void ScatterMeanGPUKernel(tensor_t* self_data,
                                  ndim,
                                  dim,
                                  index);
-  if (include_self) {
+  if (!include_self) {
     self_data[replace_index_self] = 0;
     __syncthreads();
   }
@@ -318,14 +318,15 @@ __global__ void ScatterMeanGPUKernel(tensor_t* self_data,
   reduce_op(static_cast<tensor_t*>(self_data + replace_index_self),
             static_cast<tensor_t*>(src_data + replace_index_src));
 
+  // So this is the culprit
   phi::CudaAtomicMax(aux_buffer + replace_index_self, tid);
-  phi::CudaAtomicAdd(aux_buffer + self_numel + replace_index_self, 1);
+  phi::CudaAtomicAdd(atomic_cnt_buffer + replace_index_self, 1);
   __syncthreads();
 
   if (tid == aux_buffer[replace_index_self]) {
     self_data[replace_index_self] =
         self_data[replace_index_self] /
-        static_cast<tensor_t>(aux_buffer[replace_index_self + self_numel]);
+        static_cast<tensor_t>(atomic_cnt_buffer[replace_index_self]);
   }
 }
 
@@ -446,7 +447,6 @@ struct gpu_gather_scatter_functor {
     for (int64_t i = 0; i < dim; ++i) {
       inner_dim_size *= index_dims[i];
     }
-
     for (int i = dim + 1; i < index_dims.size(); i++) {
       outer_dim_size *= index_dims[i];
     }
@@ -516,12 +516,19 @@ struct gpu_gather_scatter_functor {
     } else if (method_name == "scatter_mean_gpu") {
       // TODO(heqianyue): the original impl is too wasteful, this can be
       // optimized
-      aux_tensor.Resize({self_size * 2});
-      int constant_to_set = include_self ? 1 : 0;
+      DenseTensor atomic_cnt_tensor;
+      aux_tensor.Resize({self_size});
+      atomic_cnt_tensor.Resize({self_size});
       dev_ctx.Alloc<int>(&aux_tensor);
-      phi::funcs::set_constant(dev_ctx, &aux_tensor, constant_to_set);
+      dev_ctx.Alloc<int>(&atomic_cnt_tensor);
+
+      // threadidx must start with 0, otherwise atomicMax will be faulty
+      phi::funcs::set_constant(dev_ctx, &aux_tensor, 0);
+      phi::funcs::set_constant(
+          dev_ctx, &atomic_cnt_tensor, include_self ? 1 : 0);
 
       int* aux_buffer = aux_tensor.data<int>();
+      int* atomic_cnt_buffer = atomic_cnt_tensor.data<int>();
       ScatterMeanGPUKernel<tensor_t, index_t, func_t, is_scatter_like>
           <<<grid, block, shared_mem_bytes, stream>>>(self_data,
                                                       index_data,
@@ -530,12 +537,12 @@ struct gpu_gather_scatter_functor {
                                                       self_select_dim_size,
                                                       src_select_dim_size,
                                                       index_size,
-                                                      self_size,
                                                       dim,
                                                       ndim,
                                                       reduce_op,
                                                       include_self,
-                                                      aux_buffer);
+                                                      aux_buffer,
+                                                      atomic_cnt_buffer);
     } else {
       if (include_self == false) {
         aux_tensor.Resize({self_size});
@@ -1146,6 +1153,9 @@ __global__ void ScatterValueGradGPUKernel(tensor_t* grad_data,
                       dim,
                       index);
 
+  atomicMax(aux_buffer + replace_index_self, tid);
+  __syncthreads();
+
   if (tid == aux_buffer[replace_index_self]) {
     grad_data[replace_index_grad] = self_data[replace_index_self];
   }
@@ -1173,7 +1183,6 @@ void gpu_scatter_value_grad_kernel(phi::DenseTensor self,
   for (int i = dim + 1; i < index_dims.size(); i++) {
     outer_dim_size *= index_dims[i];
   }
-
   DenseTensor aux_tensor;
   aux_tensor.Resize({self.numel()});
   dev_ctx.Alloc<int>(&aux_tensor);

--- a/paddle/phi/kernels/funcs/gather_scatter_functor.cu
+++ b/paddle/phi/kernels/funcs/gather_scatter_functor.cu
@@ -15,6 +15,7 @@ limitations under the License. */
 #include "paddle/phi/kernels/funcs/gather_scatter_functor.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/backends/gpu/gpu_primitives.h"
+#include "paddle/phi/core/tensor_utils.h"
 #include "paddle/phi/kernels/funcs/math_function.h"
 
 namespace phi {
@@ -71,152 +72,108 @@ __global__ void CudaMemsetAsync(int* dest, int value, size_t size) {
   dest[tid] = value;
 }
 
-template <typename tensor_t,
-          typename index_t,
-          typename func_t,
-          bool is_scatter_like = true>
-__global__ void ScatterAssignGPUKernel(tensor_t* self_data,
-                                       int dim,
-                                       const index_t* index_data,
-                                       tensor_t* src_data,
-                                       int64_t select_dim_size,
-                                       int64_t self_select_dim_size,
-                                       int64_t src_select_dim_size,
-                                       int64_t outer_dim_size,
-                                       int64_t outer_dim_size_self,
-                                       int64_t outer_dim_size_src,
-                                       int64_t numel,
-                                       int64_t numel_data,
-                                       const func_t& reduce_op,
-                                       int* thread_ids) {
-  int64_t tid = threadIdx.x + static_cast<int64_t>(blockIdx.x) * blockDim.x;
-  if (tid >= numel) return;
-  int64_t i, j, k;  // The i, j, k here is the index of the 3 layers loop
-                    // squeezed from the N layers loop.
-  /* tid = i * select_dim_size * outer_dim_size + j * outer_dim_size + k */
-  i = tid / (select_dim_size * outer_dim_size);
-  int64_t remind = tid % (select_dim_size * outer_dim_size);
-  j = remind / outer_dim_size;
-  k = remind % outer_dim_size;
-  index_t index = index_data[tid];
-  /*
-    gather computation formula:
+struct DivMod {
+  template <typename T>
+  static __device__ __forceinline__ void divmod(T dividend,
+                                                T divisor,
+                                                T* __restrict__ quotient,
+                                                T* __restrict__ remainder) {
+    *quotient = dividend / divisor;
+    *remainder = dividend % divisor;
+  }
+};
 
-    self[i][j][k] = src[index[i][j][k]][j][k]  # if dim == 0
-    self[i][j][k] = src[i][index[i][j][k]][k]  # if dim == 1
-    self[i][j][k] = src[i][j][index[i][j][k]]  # if dim == 2
-
-    scatter computation formula:
-
-    self[index[i][j][k]][j][k] = src[i][j][k]  # if dim == 0
-    self[i][index[i][j][k]][k] = src[i][j][k]  # if dim == 1
-    self[i][j][index[i][j][k]] = src[i][j][k]  # if dim == 2
-
-  */
-  // index matrix has different shape with self matrix or src matrix.
-  int64_t replace_index_self, replace_index_src;
-  if (is_scatter_like) {
-    // scatter
-    PADDLE_ENFORCE(
-        index >= -self_select_dim_size && index < self_select_dim_size,
-        "The index is out of bounds, "
-        "please check whether the index and "
-        "input's shape meet the requirements. It should "
-        "be greater or equal to [%d] and less than [%d], but received [%ld]",
-        -self_select_dim_size,
-        self_select_dim_size,
-        (int64_t)index);
-    if (index < 0) {
-      index += self_select_dim_size;
-    }
-    replace_index_self = k + index * outer_dim_size_self +
-                         i * outer_dim_size_self * self_select_dim_size;
-
-    replace_index_src = k + j * outer_dim_size_src +
-                        i * outer_dim_size_src * src_select_dim_size;
+// compute two offsets for self tensor and src tensor
+// if compute_self is true, other wise only src_offset is useful
+// TODO(heqianyue): remove force inline?
+// TODO(heqianyue): maybe use int32 to optimize?
+template <bool compute_self>
+__device__ __forceinline__ void ComputeOffset(const int64_t* index_shape,
+                                              const int64_t* src_stride,
+                                              const int64_t* input_stride,
+                                              int64_t* src_offset,
+                                              int64_t* input_offset,
+                                              int64_t tid,
+                                              const int ndim,
+                                              const int dim_to_put,
+                                              const int64_t idx_on_dim = 0) {
+  // TODO(heqianyue): maybe smaller tensors can use int32
+  // TODO(heqianyue): use fast divmod to optimize the speed of div and mod
+  int64_t _input_offset = 0, _src_offset = 0;
+  for (int d = ndim - 1; d > dim_to_put; --d) {
+    // before the put dim
+    int64_t index = 0;
+    DivMod::divmod(tid, index_shape[d], &tid, &index);
+    _src_offset += index * src_stride[d];
+    if constexpr (compute_self) _input_offset += index * input_stride[d];
+  }
+  if constexpr (compute_self) {  // scatter like
+    _src_offset += (tid % index_shape[dim_to_put]) * src_stride[dim_to_put];
+    _input_offset += idx_on_dim * input_stride[dim_to_put];
   } else {
-    // gather
-    PADDLE_ENFORCE(
-        index >= -src_select_dim_size && index < src_select_dim_size,
-        "The index is out of bounds, "
-        "please check whether the index and "
-        "input's shape meet the requirements. It should "
-        "be greater or equal to [%d] and less than [%d], but received [%d]",
-        -src_select_dim_size,
-        src_select_dim_size,
-        (int32_t)index);
-    if (index < 0) {
-      index += src_select_dim_size;
-    }
-    replace_index_self = tid;
-
-    replace_index_src = k + index * outer_dim_size_src +
-                        i * outer_dim_size_src * src_select_dim_size;
+    _src_offset += idx_on_dim * src_stride[dim_to_put];
   }
-
-  atomicMax(thread_ids + replace_index_self, tid);
-  __syncthreads();
-
-  if (tid == thread_ids[replace_index_self]) {
-    reduce_op(static_cast<tensor_t*>(self_data + replace_index_self),
-              static_cast<tensor_t*>(src_data + replace_index_src));
+  tid /= index_shape[dim_to_put];
+  for (int d = dim_to_put - 1; d >= 0; --d) {
+    // after the put dim
+    int64_t index = 0;
+    DivMod::divmod(tid, index_shape[d], &tid, &index);
+    _src_offset += index * src_stride[d];
+    if constexpr (compute_self) _input_offset += index * input_stride[d];
   }
+  *src_offset = _src_offset;
+  if constexpr (compute_self) *input_offset = _input_offset;
 }
 
+/**
+ * The assign / add / mul / min / max kernels can actually be unified
+ *
+ * @param index_shape A reused field, the first `ndim` elements are the shape of
+ * index tensor and the second `ndim` elements are the strides of src tensor the
+ * third `ndim` elements are the strides of input self tensor, these
+ * shape/stride info are necessary to perform correct offset mapping between
+ * different tensors
+ *
+ * We need a ComputeOffset as offset remapper, since both the shape of src
+ * tensor and input self tensor can be bigger than the shape of index tensor
+ */
 template <typename tensor_t,
           typename index_t,
           typename func_t,
-          bool is_scatter_like = true>
+          bool is_scatter_like = true,
+          bool include_self = false>
 __global__ void GatherScatterGPUKernel(tensor_t* self_data,
-                                       int dim,
                                        const index_t* index_data,
+                                       const int64_t* shape_strides,
                                        tensor_t* src_data,
-                                       int64_t select_dim_size,
                                        int64_t self_select_dim_size,
                                        int64_t src_select_dim_size,
-                                       int64_t outer_dim_size,
-                                       int64_t outer_dim_size_self,
-                                       int64_t outer_dim_size_src,
                                        int64_t numel,
-                                       int64_t numel_data,
-                                       bool include_self,
+                                       int dim,
+                                       int ndim,
                                        const func_t& reduce_op,
-                                       int* shared_mem) {
+                                       int* aux_buffer = nullptr) {
+  extern __shared__ int64_t
+      smem_shape_strides[];  // no more than 27 int64_t, won't affect occupancy
+
   int64_t tid = threadIdx.x + static_cast<int64_t>(blockIdx.x) * blockDim.x;
-  if (tid >= numel) return;
-  if (include_self == false) {
-    if (tid == 0) {
-      for (int i = 0; i < numel_data; i++) {
-        shared_mem[i] = numel + 1;  // thread_ids
-      }
-    }
-    __syncthreads();
+  if (threadIdx.x < (3 * ndim)) {
+    *(smem_shape_strides + threadIdx.x) = *(shape_strides + threadIdx.x);
   }
-  int64_t i, j, k;  // The i, j, k here is the index of the 3 layers loop
-                    // squeezed from the N layers loop.
-  /* tid = i * select_dim_size * outer_dim_size + j * outer_dim_size + k */
-  i = tid / (select_dim_size * outer_dim_size);
-  int64_t remind = tid % (select_dim_size * outer_dim_size);
-  j = remind / outer_dim_size;
-  k = remind % outer_dim_size;
+  __syncthreads();
+  // we need threads to complete memory write to smem, even if current thread is
+  // out of bound
+  if (tid >= numel) return;
   index_t index = index_data[tid];
-  /*
-    gather computation formula:
 
-    self[i][j][k] = src[index[i][j][k]][j][k]  # if dim == 0
-    self[i][j][k] = src[i][index[i][j][k]][k]  # if dim == 1
-    self[i][j][k] = src[i][j][index[i][j][k]]  # if dim == 2
+  const int64_t* src_strides = smem_shape_strides + ndim;
+  const int64_t* input_strides = nullptr;
 
-    scatter computation formula:
-
-    self[index[i][j][k]][j][k] = src[i][j][k]  # if dim == 0
-    self[i][index[i][j][k]][k] = src[i][j][k]  # if dim == 1
-    self[i][j][index[i][j][k]] = src[i][j][k]  # if dim == 2
-
-  */
   // index matrix has different shape with self matrix or src matrix.
-  int64_t replace_index_self, replace_index_src;
-  if (is_scatter_like) {
+  int64_t replace_index_self = 0, replace_index_src = 0;
+  if constexpr (is_scatter_like) {
+    input_strides = smem_shape_strides +
+                    ndim * 2;  // gather pass actually does not need this
     // scatter
     PADDLE_ENFORCE(
         index >= -self_select_dim_size && index < self_select_dim_size,
@@ -230,11 +187,6 @@ __global__ void GatherScatterGPUKernel(tensor_t* self_data,
     if (index < 0) {
       index += self_select_dim_size;
     }
-    replace_index_self = k + index * outer_dim_size_self +
-                         i * outer_dim_size_self * self_select_dim_size;
-
-    replace_index_src = k + j * outer_dim_size_src +
-                        i * outer_dim_size_src * src_select_dim_size;
   } else {
     // gather
     PADDLE_ENFORCE(
@@ -250,23 +202,36 @@ __global__ void GatherScatterGPUKernel(tensor_t* self_data,
       index += src_select_dim_size;
     }
     replace_index_self = tid;
-
-    replace_index_src = k + index * outer_dim_size_src +
-                        i * outer_dim_size_src * src_select_dim_size;
   }
-  bool is_op_done = false;
-  if (include_self == false) {
-    phi::CudaAtomicMin(shared_mem + replace_index_self, tid);
+  ComputeOffset<is_scatter_like>(smem_shape_strides,
+                                 src_strides,
+                                 input_strides,
+                                 &replace_index_src,
+                                 &replace_index_self,
+                                 tid,
+                                 ndim,
+                                 dim,
+                                 index);
+  if constexpr (include_self) {
+    // unordered-writes branch has the same behavior as torch's. Strangely,
+    // the old impl performs ordered access for assign (maybe it is because
+    // there was no atomic primitives for assign), and for other ops,
+    // unordered atomic access is used
+    reduce_op(static_cast<tensor_t*>(self_data + replace_index_self),
+              static_cast<tensor_t*>(src_data + replace_index_src));
+  } else {
+    bool is_op_done = false;
+    phi::CudaAtomicMin(aux_buffer + replace_index_self, tid);
     __syncthreads();
-    if (tid == shared_mem[replace_index_self]) {
+    if (tid == aux_buffer[replace_index_self]) {
       self_data[replace_index_self] = src_data[replace_index_src];
       is_op_done = true;
     }
     __syncthreads();
+    if (!is_op_done)
+      reduce_op(static_cast<tensor_t*>(self_data + replace_index_self),
+                static_cast<tensor_t*>(src_data + replace_index_src));
   }
-  if (!is_op_done)
-    reduce_op(static_cast<tensor_t*>(self_data + replace_index_self),
-              static_cast<tensor_t*>(src_data + replace_index_src));
 }
 
 template <typename tensor_t,
@@ -274,48 +239,39 @@ template <typename tensor_t,
           typename func_t,
           bool is_scatter_like = true>
 __global__ void ScatterMeanGPUKernel(tensor_t* self_data,
-                                     int dim,
                                      const index_t* index_data,
+                                     const int64_t* shape_strides,
                                      tensor_t* src_data,
-                                     int64_t select_dim_size,
                                      int64_t self_select_dim_size,
                                      int64_t src_select_dim_size,
-                                     int64_t outer_dim_size,
-                                     int64_t outer_dim_size_self,
-                                     int64_t outer_dim_size_src,
                                      int64_t numel,
-                                     int64_t numel_data,
-                                     bool include_self,
+                                     int64_t self_numel,
+                                     int dim,
+                                     int ndim,
                                      const func_t& reduce_op,
-                                     int* shared_mem) {
+                                     bool include_self = true,
+                                     int* aux_buffer = nullptr) {
+  extern __shared__ int64_t
+      smem_shape_strides[];  // no more than 27 int64_t, won't affect occupancy
+
   int64_t tid = threadIdx.x + static_cast<int64_t>(blockIdx.x) * blockDim.x;
+  if (threadIdx.x < (3 * ndim)) {
+    *(smem_shape_strides + threadIdx.x) = *(shape_strides + threadIdx.x);
+  }
+  __syncthreads();
+  // we need threads to complete memory write to smem, even if current thread is
+  // out of bound
   if (tid >= numel) return;
-
-  int64_t i, j, k;  // The i, j, k here is the index of the 3 layers loop
-                    // squeezed from the N layers loop.
-  /* tid = i * select_dim_size * outer_dim_size + j * outer_dim_size + k */
-  i = tid / (select_dim_size * outer_dim_size);
-  int64_t remind = tid % (select_dim_size * outer_dim_size);
-  j = remind / outer_dim_size;
-  k = remind % outer_dim_size;
   index_t index = index_data[tid];
-  /*
-    gather computation formula:
 
-    self[i][j][k] = src[index[i][j][k]][j][k]  # if dim == 0
-    self[i][j][k] = src[i][index[i][j][k]][k]  # if dim == 1
-    self[i][j][k] = src[i][j][index[i][j][k]]  # if dim == 2
+  const int64_t* src_strides = smem_shape_strides + ndim;
+  const int64_t* input_strides = nullptr;
 
-    scatter computation formula:
-
-    self[index[i][j][k]][j][k] = src[i][j][k]  # if dim == 0
-    self[i][index[i][j][k]][k] = src[i][j][k]  # if dim == 1
-    self[i][j][index[i][j][k]] = src[i][j][k]  # if dim == 2
-
-  */
   // index matrix has different shape with self matrix or src matrix.
-  int64_t replace_index_self, replace_index_src;
-  if (is_scatter_like) {
+  int64_t replace_index_self = 0, replace_index_src = 0;
+  if constexpr (is_scatter_like) {
+    input_strides = smem_shape_strides +
+                    ndim * 2;  // gather pass actually does not need this
     // scatter
     PADDLE_ENFORCE(
         index >= -self_select_dim_size && index < self_select_dim_size,
@@ -329,11 +285,6 @@ __global__ void ScatterMeanGPUKernel(tensor_t* self_data,
     if (index < 0) {
       index += self_select_dim_size;
     }
-    replace_index_self = k + index * outer_dim_size_self +
-                         i * outer_dim_size_self * self_select_dim_size;
-
-    replace_index_src = k + j * outer_dim_size_src +
-                        i * outer_dim_size_src * src_select_dim_size;
   } else {
     // gather
     PADDLE_ENFORCE(
@@ -349,97 +300,114 @@ __global__ void ScatterMeanGPUKernel(tensor_t* self_data,
       index += src_select_dim_size;
     }
     replace_index_self = tid;
-
-    replace_index_src = k + index * outer_dim_size_src +
-                        i * outer_dim_size_src * src_select_dim_size;
   }
-  if (include_self == false) {
+  ComputeOffset<is_scatter_like>(smem_shape_strides,
+                                 src_strides,
+                                 input_strides,
+                                 &replace_index_src,
+                                 &replace_index_self,
+                                 tid,
+                                 ndim,
+                                 dim,
+                                 index);
+  if (include_self) {
     self_data[replace_index_self] = 0;
     __syncthreads();
   }
+
   reduce_op(static_cast<tensor_t*>(self_data + replace_index_self),
             static_cast<tensor_t*>(src_data + replace_index_src));
 
-  phi::CudaAtomicMax(shared_mem + replace_index_self, tid);
-  phi::CudaAtomicAdd(shared_mem + numel_data + replace_index_self, 1);
+  phi::CudaAtomicMax(aux_buffer + replace_index_self, tid);
+  phi::CudaAtomicAdd(aux_buffer + self_numel + replace_index_self, 1);
   __syncthreads();
 
-  if (tid == shared_mem[replace_index_self]) {
+  if (tid == aux_buffer[replace_index_self]) {
     self_data[replace_index_self] =
         self_data[replace_index_self] /
-        static_cast<tensor_t>(shared_mem[replace_index_self + numel_data]);
+        static_cast<tensor_t>(aux_buffer[replace_index_self + self_numel]);
   }
-}
-
-__device__ __forceinline__ void decompose_tid(int64_t tid,
-                                              int64_t select_dim_size,
-                                              int64_t outer_dim_size,
-                                              int64_t* i,
-                                              int64_t* j,
-                                              int64_t* k) {
-  const int64_t ij_span = select_dim_size * outer_dim_size;
-  *i = tid / ij_span;
-  const int64_t r = tid % ij_span;
-  *j = r / outer_dim_size;
-  *k = r % outer_dim_size;
 }
 
 template <typename index_t>
 __global__ void PickWinnersScatterKernel(const index_t* __restrict__ index_data,
-                                         int64_t select_dim_size,
+                                         const int64_t* __restrict__ shape_strides,
+                                         int* __restrict__ winners,
                                          int64_t self_select_dim_size,
-                                         int64_t /*src_select_dim_size*/,
-                                         int64_t /*inner_dim_size*/,
-                                         int64_t outer_dim_size,
-                                         int64_t outer_dim_size_self,
-                                         int64_t /*outer_dim_size_src*/,
-                                         int64_t n,
-                                         int* __restrict__ winners) {
-  const int64_t tid = blockIdx.x * (int64_t)blockDim.x + threadIdx.x;
-  if (tid >= n) return;
+                                         int64_t numel,
+                                         int dim,
+                                         int ndim) {
+  extern __shared__ int64_t
+      smem_shape_strides[];  // no more than 27 int64_t, won't affect occupancy
 
-  int64_t i, j, k;
-  decompose_tid(tid, select_dim_size, outer_dim_size, &i, &j, &k);
+  int64_t tid = threadIdx.x + static_cast<int64_t>(blockIdx.x) * blockDim.x;
+  if (threadIdx.x < (3 * ndim)) {
+    *(smem_shape_strides + threadIdx.x) = *(shape_strides + threadIdx.x);
+  }
+  __syncthreads();
+  // we need threads to complete memory write to smem, even if current thread is
+  // out of bound
+  if (tid >= numel) return;
+  index_t index = index_data[tid];
+  if (index < 0) index += static_cast<index_t>(self_select_dim_size);
 
-  index_t idx = index_data[tid];
-  if (idx < 0) idx += static_cast<index_t>(self_select_dim_size);
-  const int64_t dst = k + static_cast<int64_t>(idx) * outer_dim_size_self +
-                      i * outer_dim_size_self * self_select_dim_size;
+  const int64_t* input_strides = smem_shape_strides + 2 * ndim;
 
-  atomicMax(&winners[dst], static_cast<int>(tid));
+  // index matrix has different shape with self matrix or src matrix.
+  int64_t replace_index_self = 0;
+  ComputeOffset<false>(smem_shape_strides,
+                                 input_strides,
+                                 nullptr,
+                                 &replace_index_self,
+                                 nullptr,
+                                 tid,
+                                 ndim,
+                                 dim,
+                                 index);
+
+  atomicMax(&winners[replace_index_self], static_cast<int>(tid));
 }
 
 template <typename tensor_t, typename index_t, typename func_t>
 __global__ void ScatterWriteByWinnersKernel(
     tensor_t* __restrict__ self_data,
     const index_t* __restrict__ index_data,
-    tensor_t* __restrict__ src_data,
-    int64_t select_dim_size,
+    const tensor_t* __restrict__ src_data,
+    const int64_t* __restrict__ shape_strides,
+    const int* __restrict__ winners,
     int64_t self_select_dim_size,
-    int64_t src_select_dim_size,
-    int64_t /*inner_dim_size*/,
-    int64_t outer_dim_size,
-    int64_t outer_dim_size_self,
-    int64_t outer_dim_size_src,
-    int64_t n,
-    func_t reduce_op,
-    const int* __restrict__ winners) {
-  const int64_t tid = blockIdx.x * (int64_t)blockDim.x + threadIdx.x;
-  if (tid >= n) return;
+    int64_t numel,
+    int dim,
+    int ndim) {
+  extern __shared__ int64_t
+      smem_shape_strides[];  // no more than 27 int64_t, won't affect occupancy
 
-  int64_t i, j, k;
-  decompose_tid(tid, select_dim_size, outer_dim_size, &i, &j, &k);
+  int64_t tid = threadIdx.x + static_cast<int64_t>(blockIdx.x) * blockDim.x;
+  if (threadIdx.x < (3 * ndim)) {
+    *(smem_shape_strides + threadIdx.x) = *(shape_strides + threadIdx.x);
+  }
+  __syncthreads();
+  // we need threads to complete memory write to smem, even if current thread is
+  // out of bound
+  if (tid >= numel) return;
+  index_t index = index_data[tid];
+  if (index < 0) index += static_cast<index_t>(self_select_dim_size);
 
-  index_t idx = index_data[tid];
-  if (idx < 0) idx += static_cast<index_t>(self_select_dim_size);
+  const int64_t* src_strides = smem_shape_strides + ndim;
+  const int64_t* input_strides = smem_shape_strides + 2 * ndim;
 
-  const int64_t dst = k + static_cast<int64_t>(idx) * outer_dim_size_self +
-                      i * outer_dim_size_self * self_select_dim_size;
-
-  const int64_t src_off =
-      k + j * outer_dim_size_src + i * outer_dim_size_src * src_select_dim_size;
-  if (static_cast<int>(tid) == winners[dst]) {
-    reduce_op(self_data + dst, src_data + src_off);
+  int64_t replace_index_self = 0, replace_index_src = 0;
+  ComputeOffset<true>(smem_shape_strides,
+                                 src_strides,
+                                 input_strides,
+                                 &replace_index_src,
+                                 &replace_index_self,
+                                 tid,
+                                 ndim,
+                                 dim,
+                                 index);
+  if (static_cast<int>(tid) == winners[replace_index_self]) {
+    *(self_data + replace_index_self) = *(src_data + replace_index_src);
   }
 }
 
@@ -473,8 +441,6 @@ struct gpu_gather_scatter_functor {
     // index matrix has different shape with self matrix or src matrix.
     int64_t self_select_dim_size = self_dims[dim];
     int64_t src_select_dim_size = src_dims[dim];
-    int64_t outer_dim_size_self = 1;
-    int64_t outer_dim_size_src = 1;
     int64_t inner_dim_size = 1;
     int64_t outer_dim_size = 1;
     for (int64_t i = 0; i < dim; ++i) {
@@ -483,11 +449,9 @@ struct gpu_gather_scatter_functor {
 
     for (int i = dim + 1; i < index_dims.size(); i++) {
       outer_dim_size *= index_dims[i];
-      outer_dim_size_self *= self_dims[i];
-      outer_dim_size_src *= src_dims[i];
     }
 
-    int block = 512;
+    constexpr int block = 512;
     int64_t n = inner_dim_size * select_dim_size * outer_dim_size;
     int64_t grid = (n + block - 1) / block;
     auto stream = reinterpret_cast<const phi::GPUContext&>(dev_ctx).stream();
@@ -496,85 +460,125 @@ struct gpu_gather_scatter_functor {
       shared_mem_tensor.Resize({self_size});
       auto* winners = dev_ctx.Alloc<int>(&shared_mem_tensor);
       phi::funcs::set_constant(dev_ctx, &shared_mem_tensor, 0);
+    }
+
+    int64_t ndim = index.dims().size();
+
+    DenseTensor shape_stride_dev;
+    shape_stride_dev.Resize({3 * ndim});
+    dev_ctx.Alloc<int64_t>(&shape_stride_dev);
+    {  // deallocate host once the copy is done
+      DenseTensor shape_stride_host;
+      shape_stride_host.Resize({3 * ndim});
+      dev_ctx.template HostAlloc<int64_t>(&shape_stride_host);
+      int64_t* host_data = shape_stride_host.data<int64_t>();
+      for (int64_t i = 0; i < ndim; i++) {
+        host_data[i] = index_dims[i];
+        host_data[i + ndim] = src.strides()[i];
+        host_data[i + (ndim << 1)] = self.strides()[i];
+      }
+      phi::Copy(dev_ctx,
+                shape_stride_host,
+                dev_ctx.GetPlace(),
+                false,
+                &shape_stride_dev);
+    }
+    const int64_t* shape_strides = shape_stride_dev.data<int64_t>();
+    const size_t shared_mem_bytes = sizeof(int64_t) * shape_stride_dev.numel();
+
+    DenseTensor aux_tensor;
+    if (method_name == "scatter_assign_gpu") {
+      aux_tensor.Resize({self_size});
+      dev_ctx.Alloc<int>(&aux_tensor);
+      phi::funcs::set_constant(dev_ctx, &aux_tensor, 0);
+
+      int* winners = aux_tensor.data<int>();
       // Stage 1: Get the last index to be assigned the same dst.
       PickWinnersScatterKernel<index_t>
-          <<<grid, block, 0, stream>>>(index_data,
-                                       select_dim_size,
+          <<<grid, block, shared_mem_bytes, stream>>>(index_data,
+                                       shape_strides,
+                                       winners,
                                        self_select_dim_size,
-                                       src_select_dim_size,
-                                       inner_dim_size,
-                                       outer_dim_size,
-                                       outer_dim_size_self,
-                                       outer_dim_size_src,
-                                       n,
-                                       winners);
+                                       index_size,
+                                                      dim,
+                                                      ndim);
       // Stage 2: Only the max tid in stage 1 can write src to dst.
       ScatterWriteByWinnersKernel<tensor_t, index_t, func_t>
-          <<<grid, block, 0, stream>>>(self_data,
+          <<<grid, block, shared_mem_bytes, stream>>>(self_data,
                                        index_data,
                                        src_data,
-                                       select_dim_size,
+                                       shape_strides,
+                                       winners,
                                        self_select_dim_size,
-                                       src_select_dim_size,
-                                       inner_dim_size,
-                                       outer_dim_size,
-                                       outer_dim_size_self,
-                                       outer_dim_size_src,
-                                       n,
-                                       reduce_op,
-                                       winners);
+                                       index_size,
+                                       dim,
+                                       ndim);
     } else if (method_name == "scatter_mean_gpu") {
-      shared_mem_tensor.Resize({self_size * 2});
-      dev_ctx.Alloc<int>(&shared_mem_tensor);
-      if (include_self) {
-        int64_t grid_memset = (self_size * 2 + block - 1) / block;
-        phi::funcs::set_constant(dev_ctx, &shared_mem_tensor, 1);
-      } else {
-        phi::funcs::set_constant(dev_ctx, &shared_mem_tensor, 0);
-      }
+      // TODO(heqianyue): the original impl is too wasteful, this can be
+      // optimized
+      aux_tensor.Resize({self_size * 2});
+      int constant_to_set = include_self ? 1 : 0;
+      dev_ctx.Alloc<int>(&aux_tensor);
+      phi::funcs::set_constant(dev_ctx, &aux_tensor, constant_to_set);
 
-      int* shared_mem = shared_mem_tensor.data<int>();
+      int* aux_buffer = aux_tensor.data<int>();
       ScatterMeanGPUKernel<tensor_t, index_t, func_t, is_scatter_like>
-          <<<grid, block, 0, stream>>>(self_data,
-                                       dim,
-                                       index_data,
-                                       src_data,
-                                       select_dim_size,
-                                       self_select_dim_size,
-                                       src_select_dim_size,
-                                       outer_dim_size,
-                                       outer_dim_size_self,
-                                       outer_dim_size_src,
-                                       index_size,
-                                       self_size,
-                                       include_self,
-                                       reduce_op,
-                                       shared_mem);
+          <<<grid, block, shared_mem_bytes, stream>>>(self_data,
+                                                      index_data,
+                                                      shape_strides,
+                                                      src_data,
+                                                      self_select_dim_size,
+                                                      src_select_dim_size,
+                                                      index_size,
+                                                      self_size,
+                                                      dim,
+                                                      ndim,
+                                                      reduce_op,
+                                                      include_self,
+                                                      aux_buffer);
     } else {
-      int* shared_mem = nullptr;
       if (include_self == false) {
-        shared_mem_tensor.Resize({self_size});
-        dev_ctx.Alloc<int>(&shared_mem_tensor);
-        phi::funcs::set_constant(dev_ctx, &shared_mem_tensor, index_size + 1);
+        aux_tensor.Resize({self_size});
+        dev_ctx.Alloc<int>(&aux_tensor);
+        phi::funcs::set_constant(dev_ctx, &aux_tensor, self_size + 1);
 
-        shared_mem = shared_mem_tensor.data<int>();
+        int* aux_buffer = aux_tensor.data<int>();
+        GatherScatterGPUKernel<tensor_t,
+                               index_t,
+                               func_t,
+                               is_scatter_like,
+                               false,
+                               false>
+            <<<grid, block, shared_mem_bytes, stream>>>(self_data,
+                                                        index_data,
+                                                        shape_strides,
+                                                        src_data,
+                                                        self_select_dim_size,
+                                                        src_select_dim_size,
+                                                        index_size,
+                                                        dim,
+                                                        ndim,
+                                                        reduce_op,
+                                                        aux_buffer);
+      } else {
+        GatherScatterGPUKernel<tensor_t,
+                               index_t,
+                               func_t,
+                               is_scatter_like,
+                               true,
+                               false>
+            <<<grid, block, shared_mem_bytes, stream>>>(self_data,
+                                                        index_data,
+                                                        shape_strides,
+                                                        src_data,
+                                                        self_select_dim_size,
+                                                        src_select_dim_size,
+                                                        index_size,
+                                                        dim,
+                                                        ndim,
+                                                        reduce_op,
+                                                        nullptr);
       }
-      GatherScatterGPUKernel<tensor_t, index_t, func_t, is_scatter_like>
-          <<<grid, block, 0, stream>>>(self_data,
-                                       dim,
-                                       index_data,
-                                       src_data,
-                                       select_dim_size,
-                                       self_select_dim_size,
-                                       src_select_dim_size,
-                                       outer_dim_size,
-                                       outer_dim_size_self,
-                                       outer_dim_size_src,
-                                       index_size,
-                                       self_size,
-                                       include_self,
-                                       reduce_op,
-                                       shared_mem);
     }
   }
 };  // struct gpu_gather_scatter_functor
@@ -715,27 +719,38 @@ void gpu_scatter_min_kernel(phi::DenseTensor self,
 
 template <typename tensor_t, typename index_t>
 __global__ void ScatterInputGradGPUKernel(tensor_t* grad_data,
-                                          int dim,
                                           const index_t* index_data,
-                                          int select_dim_size,
-                                          int grad_select_dim_size,
-                                          int64_t outer_dim_size,
-                                          int64_t outer_dim_size_data,
-                                          int64_t numel,
-                                          int64_t numel_data) {
+                                          const int64_t* shape_strides,
+                                          int dim,
+                                          int ndim,
+                                          int64_t numel) {
+  // no more than 18 int64_t, different from forward kernels
+  // the backward kernel does not require src, so src_strides are not needed
+  extern __shared__ int64_t smem_shape_strides[];
   int64_t tid = threadIdx.x + blockIdx.x * blockDim.x;
-  if (tid >= numel) return;
-  int64_t i, j, k;
-  i = tid / (select_dim_size * outer_dim_size);
-  int64_t remind = tid % (select_dim_size * outer_dim_size);
-  j = remind / outer_dim_size;
-  k = remind % outer_dim_size;
-  index_t index = index_data[tid];
-  int64_t replace_index = k + index * outer_dim_size_data +
-                          i * outer_dim_size_data * grad_select_dim_size;
 
+  if (threadIdx.x < (2 * ndim)) {
+    *(smem_shape_strides + threadIdx.x) = *(shape_strides + threadIdx.x);
+  }
+  __syncthreads();
+  if (tid >= numel) return;
+
+  int64_t replace_index = 0;
+  index_t index = index_data[tid];
+  const int64_t* grad_strides = smem_shape_strides + ndim;
+
+  ComputeOffset<false>(smem_shape_strides,
+                       grad_strides,
+                       nullptr,
+                       &replace_index,
+                       nullptr,
+                       tid,
+                       ndim,
+                       dim,
+                       index);
   grad_data[replace_index] = 0;
 }
+
 template <typename tensor_t, typename index_t>
 void gpu_scatter_input_grad_kernel(phi::DenseTensor self,
                                    int dim,
@@ -747,66 +762,92 @@ void gpu_scatter_input_grad_kernel(phi::DenseTensor self,
   auto* grad_data = grad.data<tensor_t>();
 
   auto index_dims = index.dims();
-  auto grad_dims = grad.dims();
   int64_t index_size = index.numel();
-  int64_t grad_size = grad.numel();
 
   int64_t inner_dim_size = 1;
   int64_t outer_dim_size = 1;
-  int64_t outer_dim_size_data = 1;
   int select_dim_size = index_dims[dim];
-  int grad_select_dim_size = grad_dims[dim];
   for (int64_t i = 0; i < dim; ++i) {
     inner_dim_size *= index_dims[i];
   }
 
   for (int i = dim + 1; i < index_dims.size(); i++) {
     outer_dim_size *= index_dims[i];
-    outer_dim_size_data *= grad_dims[i];
   }
 
-  int block = 512;
+  constexpr int block = 512;
   int64_t n = inner_dim_size * select_dim_size * outer_dim_size;
   int64_t grid = (n + block - 1) / block;
   auto stream = reinterpret_cast<const phi::GPUContext&>(dev_ctx).stream();
+
+  int64_t ndim = index_dims.size();
+
+  DenseTensor shape_stride_dev;
+  shape_stride_dev.Resize({2 * ndim});
+  dev_ctx.Alloc<int64_t>(&shape_stride_dev);
+  {  // deallocate host once the copy is done
+    DenseTensor shape_stride_host;
+    shape_stride_host.Resize({2 * ndim});
+    dev_ctx.template HostAlloc<int64_t>(&shape_stride_host);
+    int64_t* host_data = shape_stride_host.data<int64_t>();
+    for (int64_t i = 0; i < ndim; i++) {
+      host_data[i] = index_dims[i];
+      host_data[i + ndim] = grad.strides()[i];
+    }
+    phi::Copy(dev_ctx,
+              shape_stride_host,
+              dev_ctx.GetPlace(),
+              false,
+              &shape_stride_dev);
+  }
+  const int64_t* shape_strides = shape_stride_dev.data<int64_t>();
+  const size_t shared_mem_bytes = sizeof(int64_t) * shape_stride_dev.numel();
+
   ScatterInputGradGPUKernel<tensor_t, index_t>
-      <<<grid, block, 0, stream>>>(grad_data,
-                                   dim,
-                                   index_data,
-                                   select_dim_size,
-                                   grad_select_dim_size,
-                                   outer_dim_size,
-                                   outer_dim_size_data,
-                                   index_size,
-                                   grad_size);
+      <<<grid, block, shared_mem_bytes, stream>>>(grad_data,
+                                                  index_data,
+                                                  shape_strides,
+                                                  dim,
+                                                  index_dims.size(),
+                                                  index_size);
 }
 
 template <typename tensor_t, typename index_t>
 __global__ void ScatterMulInputGradGPUKernel(tensor_t* grad_data,
-                                             int dim,
                                              const index_t* index_data,
                                              const tensor_t* out_data,
                                              const tensor_t* x_data,
-                                             int select_dim_size,
-                                             int grad_select_dim_size,
-                                             int64_t outer_dim_size,
-                                             int64_t outer_dim_size_grad,
+                                             const int64_t* shape_strides,
+                                             int dim,
+                                             int ndim,
                                              int64_t numel,
-                                             int64_t numel_grad,
-                                             int* thread_ids) {
+                                             int* aux_buffer) {
+  extern __shared__ int64_t smem_shape_strides[];
   int64_t tid = threadIdx.x + blockIdx.x * blockDim.x;
-  if (tid >= numel) return;
-  int64_t i, j, k;
-  i = tid / (select_dim_size * outer_dim_size);
-  int64_t remind = tid % (select_dim_size * outer_dim_size);
-  j = remind / outer_dim_size;
-  k = remind % outer_dim_size;
-  index_t index = index_data[tid];
-  int64_t replace_index = k + index * outer_dim_size_grad +
-                          i * outer_dim_size_grad * grad_select_dim_size;
-  atomicMax(thread_ids + replace_index, tid);
+
+  if (threadIdx.x < (2 * ndim)) {
+    *(smem_shape_strides + threadIdx.x) = *(shape_strides + threadIdx.x);
+  }
   __syncthreads();
-  if (tid == thread_ids[replace_index]) {
+  if (tid >= numel) return;
+
+  int64_t replace_index = 0;
+  index_t index = index_data[tid];
+  // the second `ndim` elements are not used in this kernel
+  const int64_t* grad_strides = smem_shape_strides + ndim;
+
+  ComputeOffset<false>(smem_shape_strides,
+                       grad_strides,
+                       nullptr,
+                       &replace_index,
+                       nullptr,
+                       tid,
+                       ndim,
+                       dim,
+                       index);
+  atomicMax(aux_buffer + replace_index, tid);
+  __syncthreads();
+  if (tid == aux_buffer[replace_index]) {
     grad_data[replace_index] = grad_data[replace_index] *
                                out_data[replace_index] / x_data[replace_index];
   }
@@ -814,43 +855,50 @@ __global__ void ScatterMulInputGradGPUKernel(tensor_t* grad_data,
 
 template <typename tensor_t, typename index_t>
 __global__ void ScatterMinMaxInputGradGPUKernel(tensor_t* grad_data,
-                                                int dim,
                                                 const index_t* index_data,
                                                 const tensor_t* out_data,
                                                 const tensor_t* x_data,
                                                 const tensor_t* value_data,
                                                 const tensor_t* self_data,
-                                                int select_dim_size,
-                                                int grad_select_dim_size,
-                                                int value_select_dim_size,
-                                                int64_t outer_dim_size,
-                                                int64_t outer_dim_size_grad,
-                                                int64_t outer_dim_size_value,
+                                                const int64_t* shape_strides,
+                                                int dim,
+                                                int ndim,
                                                 int64_t numel,
-                                                int64_t numel_grad,
-                                                const std::string& reduce,
-                                                int* shared_mem) {
+                                                int* aux_buffer) {
+  extern __shared__ int64_t smem_shape_strides[];
   int64_t tid = threadIdx.x + blockIdx.x * blockDim.x;
+
+  if (threadIdx.x < (3 * ndim)) {
+    *(smem_shape_strides + threadIdx.x) = *(shape_strides + threadIdx.x);
+  }
+  __syncthreads();
   if (tid >= numel) return;
-  int64_t i, j, k;
-  i = tid / (select_dim_size * outer_dim_size);
-  int64_t remind = tid % (select_dim_size * outer_dim_size);
-  j = remind / outer_dim_size;
-  k = remind % outer_dim_size;
+
   index_t index = index_data[tid];
-  int64_t replace_index = k + index * outer_dim_size_grad +
-                          i * outer_dim_size_grad * grad_select_dim_size;
-  int64_t replace_index_value =
-      k + j * outer_dim_size_value +
-      i * outer_dim_size_value * value_select_dim_size;
+  const int64_t* grad_strides = smem_shape_strides + ndim;
+  const int64_t* src_strides = smem_shape_strides + 2 * ndim;
+
+  int64_t replace_index = 0, replace_index_value = 0;
+  // the ordering of src_strides and grad_strides in the following function
+  // param is correct
+  ComputeOffset<true>(smem_shape_strides,
+                      src_strides,
+                      grad_strides,
+                      &replace_index_value,
+                      &replace_index,
+                      tid,
+                      ndim,
+                      dim,
+                      index);
+
   if (value_data[replace_index_value] == out_data[replace_index])
-    phi::CudaAtomicAdd(shared_mem + replace_index, 1);
+    phi::CudaAtomicAdd(aux_buffer + replace_index, 1);
   __syncthreads();
   if (out_data[replace_index] != x_data[replace_index]) {
     grad_data[replace_index] = 0;
   } else {
     grad_data[replace_index] = self_data[replace_index] /
-                               static_cast<tensor_t>(shared_mem[replace_index]);
+                               static_cast<tensor_t>(aux_buffer[replace_index]);
   }
 }
 
@@ -861,7 +909,7 @@ void gpu_scatter_mul_min_max_input_grad_kernel(
     const phi::DenseTensor& index,
     const phi::DenseTensor& out,
     const phi::DenseTensor& x,
-    const phi::DenseTensor& value UNUSED,
+    const phi::DenseTensor& value,
     phi::DenseTensor grad,
     const std::string& reduce,
     bool include_self UNUSED,
@@ -873,103 +921,123 @@ void gpu_scatter_mul_min_max_input_grad_kernel(
   auto* value_data = value.data<tensor_t>();
   auto* self_data = self.data<tensor_t>();
 
-  int64_t grad_size = grad.numel();
-  int64_t index_size = index.numel();
   auto index_dims = index.dims();
-  auto grad_dims = grad.dims();
-  auto x_dims = x.dims();
-  auto value_dims = value.dims();
 
   int64_t inner_dim_size = 1;
   int64_t outer_dim_size = 1;
-  int64_t outer_dim_size_grad = 1;
-  int64_t outer_dim_size_value = 1;
   int64_t select_dim_size = index_dims[dim];
-  int64_t grad_select_dim_size = grad_dims[dim];
-  int64_t value_select_dim_size = grad_dims[dim];
   for (int i = 0; i < dim; ++i) {
     inner_dim_size *= index_dims[i];
   }
 
   for (int i = dim + 1; i < index_dims.size(); i++) {
     outer_dim_size *= index_dims[i];
-    outer_dim_size_grad *= grad_dims[i];
-    outer_dim_size_value *= value_dims[i];
   }
-  int block = 512;
+  constexpr int block = 512;
   int64_t n = inner_dim_size * select_dim_size * outer_dim_size;
   int64_t grid = (n + block - 1) / block;
   auto stream = reinterpret_cast<const phi::GPUContext&>(dev_ctx).stream();
-  DenseTensor shared_mem_tensor;
-  shared_mem_tensor.Resize({grad_size});
-  dev_ctx.Alloc<int>(&shared_mem_tensor);
-  int* shared_mem = shared_mem_tensor.data<int>();
+  DenseTensor aux_tensor;
+  aux_tensor.Resize({grad.numel()});
+  dev_ctx.Alloc<int>(&aux_tensor);
+  int* aux_buffer = aux_tensor.data<int>();
+
+  int64_t ndim = index_dims.size();
+
+  DenseTensor shape_stride_dev;
+  shape_stride_dev.Resize({3 * ndim});
+  dev_ctx.Alloc<int64_t>(&shape_stride_dev);
+  {  // deallocate host once the copy is done
+    DenseTensor shape_stride_host;
+    shape_stride_host.Resize({3 * ndim});
+    dev_ctx.template HostAlloc<int64_t>(&shape_stride_host);
+    int64_t* host_data = shape_stride_host.data<int64_t>();
+    for (int64_t i = 0; i < ndim; i++) {
+      host_data[i] = index_dims[i];
+      // notice that the ordering is different from forward, since
+      // value.strides() is not used for mul
+      host_data[i + ndim] = grad.strides()[i];
+      host_data[i + (ndim << 1)] = value.strides()[i];
+    }
+    phi::Copy(dev_ctx,
+              shape_stride_host,
+              dev_ctx.GetPlace(),
+              false,
+              &shape_stride_dev);
+  }
+  const int64_t* shape_strides = shape_stride_dev.data<int64_t>();
+  size_t shared_mem_bytes = sizeof(int64_t) * ndim;
+
   if (reduce == "mul" || reduce == "multiply") {
-    phi::funcs::set_constant(dev_ctx, &shared_mem_tensor, 0);
+    phi::funcs::set_constant(dev_ctx, &aux_tensor, 0);
+    shared_mem_bytes *= 2;  // 1 stride, 1 shape
     ScatterMulInputGradGPUKernel<tensor_t, index_t>
-        <<<grid, block, 0, stream>>>(grad_data,
-                                     dim,
-                                     index_data,
-                                     out_data,
-                                     x_data,
-                                     select_dim_size,
-                                     grad_select_dim_size,
-                                     outer_dim_size,
-                                     outer_dim_size_grad,
-                                     index_size,
-                                     grad_size,
-                                     shared_mem);
+        <<<grid, block, shared_mem_bytes, stream>>>(grad_data,
+                                                    index_data,
+                                                    out_data,
+                                                    x_data,
+                                                    shape_strides,
+                                                    dim,
+                                                    ndim,
+                                                    index.numel(),
+                                                    aux_buffer);
   } else if (reduce == "amin" || reduce == "amax") {
-    phi::funcs::set_constant(dev_ctx, &shared_mem_tensor, 1);
+    phi::funcs::set_constant(dev_ctx, &aux_tensor, 1);
+    shared_mem_bytes *= 3;  // two strides, 1 shape
     ScatterMinMaxInputGradGPUKernel<tensor_t, index_t>
         <<<grid, block, 0, stream>>>(grad_data,
-                                     dim,
                                      index_data,
                                      out_data,
                                      x_data,
                                      value_data,
                                      self_data,
-                                     select_dim_size,
-                                     grad_select_dim_size,
-                                     value_select_dim_size,
-                                     outer_dim_size,
-                                     outer_dim_size_grad,
-                                     outer_dim_size_value,
-                                     index_size,
-                                     grad_size,
-                                     reduce,
-                                     shared_mem);
+                                     shape_strides,
+                                     dim,
+                                     ndim,
+                                     index.numel(),
+                                     aux_buffer);
   }
 }
 
 template <typename tensor_t, typename index_t>
 __global__ void ScatterMeanInputGradGPUKernel(tensor_t* grad_data,
-                                              int dim,
                                               const index_t* index_data,
-                                              int select_dim_size,
-                                              int grad_select_dim_size,
-                                              int64_t outer_dim_size,
-                                              int64_t outer_dim_size_grad,
+                                              const int64_t* shape_strides,
+                                              int dim,
+                                              int ndim,
                                               int64_t numel,
-                                              int64_t numel_grad,
-                                              int* shared_mem) {
+                                              int64_t grad_numel,
+                                              int* aux_buffer) {
+  extern __shared__ int64_t smem_shape_strides[];
   int64_t tid = threadIdx.x + blockIdx.x * blockDim.x;
-  if (tid >= numel) return;
-  int64_t i, j, k;
-  i = tid / (select_dim_size * outer_dim_size);
-  int64_t remind = tid % (select_dim_size * outer_dim_size);
-  j = remind / outer_dim_size;
-  k = remind % outer_dim_size;
-  index_t index = index_data[tid];
-  int64_t replace_index = k + index * outer_dim_size_grad +
-                          i * outer_dim_size_grad * grad_select_dim_size;
-  atomicMax(shared_mem + replace_index, tid);
-  phi::CudaAtomicAdd(shared_mem + numel_grad + replace_index, 1);
+
+  if (threadIdx.x < (2 * ndim)) {
+    *(smem_shape_strides + threadIdx.x) = *(shape_strides + threadIdx.x);
+  }
   __syncthreads();
-  if (tid == shared_mem[replace_index]) {
+  if (tid >= numel) return;
+
+  index_t index = index_data[tid];
+  const int64_t* grad_strides = smem_shape_strides + ndim;
+
+  int64_t replace_index = 0;
+  ComputeOffset<false>(smem_shape_strides,
+                       grad_strides,
+                       nullptr,
+                       &replace_index,
+                       nullptr,
+                       tid,
+                       ndim,
+                       dim,
+                       index);
+
+  atomicMax(aux_buffer + replace_index, tid);
+  phi::CudaAtomicAdd(aux_buffer + grad_numel + replace_index, 1);
+  __syncthreads();
+  if (tid == aux_buffer[replace_index]) {
     grad_data[replace_index] =
         grad_data[replace_index] /
-        static_cast<tensor_t>(shared_mem[numel_grad + replace_index]);
+        static_cast<tensor_t>(aux_buffer[grad_numel + replace_index]);
   }
 }
 
@@ -984,86 +1052,105 @@ void gpu_scatter_mean_input_grad_kernel(phi::DenseTensor self,
   auto* grad_data = grad.data<tensor_t>();
 
   auto index_dims = index.dims();
-  auto grad_dims = grad.dims();
-
   int64_t grad_size = grad.numel();
-  int64_t index_size = index.numel();
-
   int64_t inner_dim_size = 1;
   int64_t outer_dim_size = 1;
-  int64_t outer_dim_size_grad = 1;
   int64_t select_dim_size = index_dims[dim];
-  int64_t grad_select_dim_size = grad_dims[dim];
   for (int i = 0; i < dim; ++i) {
     inner_dim_size *= index_dims[i];
   }
-
   for (int i = dim + 1; i < index_dims.size(); i++) {
     outer_dim_size *= index_dims[i];
-    outer_dim_size_grad *= grad_dims[i];
   }
 
-  DenseTensor shared_mem_tensor;
-  shared_mem_tensor.Resize({grad_size * 2});
-  dev_ctx.Alloc<int>(&shared_mem_tensor);
-  phi::funcs::set_constant(dev_ctx, &shared_mem_tensor, 0);
-  int* shared_mem = shared_mem_tensor.data<int>();
+  DenseTensor aux_tensor;
+  aux_tensor.Resize({grad_size * 2});
+  dev_ctx.Alloc<int>(&aux_tensor);
+  phi::funcs::set_constant(dev_ctx, &aux_tensor, 0);
+  int* aux_buffer = aux_tensor.data<int>();
 
-  int block = 512;
+  constexpr int block = 512;
   int64_t grid_memset = (grad_size + block - 1) / block;
   auto stream = reinterpret_cast<const phi::GPUContext&>(dev_ctx).stream();
+  // TODO(heqianyue): This kernel can be fused
   CudaMemsetAsync<<<grid_memset, block, 0, stream>>>(
-      shared_mem + grad_size, 1, sizeof(int) * grad_size);
+      aux_buffer + grad_size, 1, sizeof(int) * grad_size);
 
   int64_t n = inner_dim_size * select_dim_size * outer_dim_size;
   int64_t grid = (n + block - 1) / block;
+
+  int64_t ndim = index_dims.size();
+
+  DenseTensor shape_stride_dev;
+  shape_stride_dev.Resize({2 * ndim});
+  dev_ctx.Alloc<int64_t>(&shape_stride_dev);
+  {  // deallocate host once the copy is done
+    DenseTensor shape_stride_host;
+    shape_stride_host.Resize({2 * ndim});
+    dev_ctx.template HostAlloc<int64_t>(&shape_stride_host);
+    int64_t* host_data = shape_stride_host.data<int64_t>();
+    for (int64_t i = 0; i < ndim; i++) {
+      host_data[i] = index_dims[i];
+      host_data[i + ndim] = grad.strides()[i];
+    }
+    phi::Copy(dev_ctx,
+              shape_stride_host,
+              dev_ctx.GetPlace(),
+              false,
+              &shape_stride_dev);
+  }
+  const int64_t* shape_strides = shape_stride_dev.data<int64_t>();
+  size_t shared_mem_bytes = sizeof(int64_t) * ndim * 2;
+
   ScatterMeanInputGradGPUKernel<tensor_t, index_t>
-      <<<grid, block, 0, stream>>>(grad_data,
-                                   dim,
-                                   index_data,
-                                   select_dim_size,
-                                   grad_select_dim_size,
-                                   outer_dim_size,
-                                   outer_dim_size_grad,
-                                   index_size,
-                                   grad_size,
-                                   shared_mem);
+      <<<grid, block, shared_mem_bytes, stream>>>(grad_data,
+                                                  index_data,
+                                                  shape_strides,
+                                                  dim,
+                                                  ndim,
+                                                  index.numel(),
+                                                  grad_size,
+                                                  aux_buffer);
 }
 
 template <typename tensor_t, typename index_t>
 __global__ void ScatterValueGradGPUKernel(tensor_t* grad_data,
-                                          int dim,
                                           const tensor_t* self_data,
                                           const index_t* index_data,
-                                          int select_dim_size,
-                                          int self_select_dim_size,
-                                          int grad_select_dim_size,
-                                          int64_t outer_dim_size,
-                                          int64_t outer_dim_size_self,
-                                          int64_t outer_dim_size_grad,
+                                          const int64_t* shape_strides,
+                                          int dim,
+                                          int ndim,
                                           int64_t numel,
-                                          int64_t numel_data,
-                                          int* thread_ids) {
+                                          int* aux_buffer) {
+  extern __shared__ int64_t smem_shape_strides[];
   int64_t tid = threadIdx.x + blockIdx.x * blockDim.x;
+
+  if (threadIdx.x < (3 * ndim)) {
+    *(smem_shape_strides + threadIdx.x) = *(shape_strides + threadIdx.x);
+  }
+  __syncthreads();
   if (tid >= numel) return;
 
-  int64_t i, j, k;
-  i = tid / (select_dim_size * outer_dim_size);
-  int64_t remind = tid % (select_dim_size * outer_dim_size);
-  j = remind / outer_dim_size;
-  k = remind % outer_dim_size;
   index_t index = index_data[tid];
-  int64_t replace_index_self = k + index * outer_dim_size_self +
-                               i * outer_dim_size_self * self_select_dim_size;
-  atomicMax(thread_ids + replace_index_self, tid);
-  __syncthreads();
+  const int64_t* grad_strides = smem_shape_strides + ndim;
+  const int64_t* self_strides = smem_shape_strides + 2 * ndim;
 
-  if (tid == thread_ids[replace_index_self]) {
-    int64_t replace_index_grad = k + j * outer_dim_size_grad +
-                                 i * outer_dim_size_grad * grad_select_dim_size;
+  int64_t replace_index_self = 0, replace_index_grad = 0;
+  ComputeOffset<true>(smem_shape_strides,
+                      grad_strides,
+                      self_strides,
+                      &replace_index_grad,
+                      &replace_index_self,
+                      tid,
+                      ndim,
+                      dim,
+                      index);
+
+  if (tid == aux_buffer[replace_index_self]) {
     grad_data[replace_index_grad] = self_data[replace_index_self];
   }
 }
+
 template <typename tensor_t, typename index_t>
 void gpu_scatter_value_grad_kernel(phi::DenseTensor self,
                                    int dim,
@@ -1076,114 +1163,135 @@ void gpu_scatter_value_grad_kernel(phi::DenseTensor self,
   auto* grad_data = grad.data<tensor_t>();
 
   auto index_dims = index.dims();
-  auto self_dims = self.dims();
-  auto grad_dims = grad.dims();
-  int64_t index_size = index.numel();
-  int64_t self_size = self.numel();
 
   int64_t inner_dim_size = 1;
   int64_t outer_dim_size = 1;
-  int64_t outer_dim_size_self = 1;
-  int64_t outer_dim_size_grad = 1;
   int select_dim_size = index_dims[dim];
-  int self_select_dim_size = self_dims[dim];
-  int grad_select_dim_size = grad_dims[dim];
   for (int64_t i = 0; i < dim; ++i) {
     inner_dim_size *= index_dims[i];
   }
-
   for (int i = dim + 1; i < index_dims.size(); i++) {
     outer_dim_size *= index_dims[i];
-    outer_dim_size_self *= self_dims[i];
-    outer_dim_size_grad *= grad_dims[i];
   }
 
-  DenseTensor shared_mem_tensor;
-  shared_mem_tensor.Resize({self_size});
-  dev_ctx.Alloc<int>(&shared_mem_tensor);
-  phi::funcs::set_constant(dev_ctx, &shared_mem_tensor, 0);
-  int* shared_mem = shared_mem_tensor.data<int>();
+  DenseTensor aux_tensor;
+  aux_tensor.Resize({self.numel()});
+  dev_ctx.Alloc<int>(&aux_tensor);
+  phi::funcs::set_constant(dev_ctx, &aux_tensor, 0);
+  int* aux_buffer = aux_tensor.data<int>();
 
-  int block = 512;
+  constexpr int block = 512;
   int64_t n = inner_dim_size * select_dim_size * outer_dim_size;
   int64_t grid = (n + block - 1) / block;
   auto stream = reinterpret_cast<const phi::GPUContext&>(dev_ctx).stream();
+
+  int64_t ndim = index_dims.size();
+
+  DenseTensor shape_stride_dev;
+  shape_stride_dev.Resize({3 * ndim});
+  dev_ctx.Alloc<int64_t>(&shape_stride_dev);
+  {  // deallocate host once the copy is done
+    DenseTensor shape_stride_host;
+    shape_stride_host.Resize({3 * ndim});
+    dev_ctx.template HostAlloc<int64_t>(&shape_stride_host);
+    int64_t* host_data = shape_stride_host.data<int64_t>();
+    for (int64_t i = 0; i < ndim; i++) {
+      host_data[i] = index_dims[i];
+      host_data[i + ndim] = grad.strides()[i];
+      host_data[i + (ndim << 1)] = self.strides()[i];
+    }
+    phi::Copy(dev_ctx,
+              shape_stride_host,
+              dev_ctx.GetPlace(),
+              false,
+              &shape_stride_dev);
+  }
+  const int64_t* shape_strides = shape_stride_dev.data<int64_t>();
+  size_t shared_mem_bytes = sizeof(int64_t) * ndim * 3;
+
   ScatterValueGradGPUKernel<tensor_t, index_t>
-      <<<grid, block, 0, stream>>>(grad_data,
-                                   dim,
-                                   self_data,
-                                   index_data,
-                                   select_dim_size,
-                                   self_select_dim_size,
-                                   grad_select_dim_size,
-                                   outer_dim_size,
-                                   outer_dim_size_self,
-                                   outer_dim_size_grad,
-                                   index_size,
-                                   self_size,
-                                   shared_mem);
+      <<<grid, block, shared_mem_bytes, stream>>>(grad_data,
+                                                  self_data,
+                                                  index_data,
+                                                  shape_strides,
+                                                  dim,
+                                                  ndim,
+                                                  index.numel(),
+                                                  aux_buffer);
 }
 
 template <typename tensor_t, typename index_t>
 __global__ void ScatterMeanValueGradGPUKernel(tensor_t* grad_data,
-                                              int dim,
                                               const tensor_t* self_data,
                                               const index_t* index_data,
-                                              int select_dim_size,
-                                              int self_select_dim_size,
-                                              int grad_select_dim_size,
-                                              int64_t outer_dim_size,
-                                              int64_t outer_dim_size_self,
-                                              int64_t outer_dim_size_grad,
+                                              const int64_t* shape_strides,
+                                              int dim,
+                                              int ndim,
                                               int64_t numel,
-                                              int64_t numel_self,
-                                              int* shared_mem) {
+                                              int* aux_buffer) {
+  extern __shared__ int64_t smem_shape_strides[];
   int64_t tid = threadIdx.x + blockIdx.x * blockDim.x;
+
+  if (threadIdx.x < (3 * ndim)) {
+    *(smem_shape_strides + threadIdx.x) = *(shape_strides + threadIdx.x);
+  }
+  __syncthreads();
   if (tid >= numel) return;
 
-  int64_t i, j, k;
-  i = tid / (select_dim_size * outer_dim_size);
-  int64_t remind = tid % (select_dim_size * outer_dim_size);
-  j = remind / outer_dim_size;
-  k = remind % outer_dim_size;
   index_t index = index_data[tid];
-  int64_t replace_index_self = k + index * outer_dim_size_self +
-                               i * outer_dim_size_self * self_select_dim_size;
+  const int64_t* grad_strides = smem_shape_strides + ndim;
+  const int64_t* self_strides = smem_shape_strides + 2 * ndim;
 
-  phi::CudaAtomicAdd(shared_mem + replace_index_self, 1);
+  int64_t replace_index_self = 0, replace_index_grad = 0;
+  ComputeOffset<true>(smem_shape_strides,
+                      grad_strides,
+                      self_strides,
+                      &replace_index_grad,
+                      &replace_index_self,
+                      tid,
+                      ndim,
+                      dim,
+                      index);
+
+  phi::CudaAtomicAdd(aux_buffer + replace_index_self, 1);
   __syncthreads();
 
-  int64_t replace_index_grad = k + j * outer_dim_size_grad +
-                               i * outer_dim_size_grad * grad_select_dim_size;
   grad_data[replace_index_grad] =
       self_data[replace_index_self] /
-      static_cast<tensor_t>(shared_mem[replace_index_self]);
+      static_cast<tensor_t>(aux_buffer[replace_index_self]);
 }
 
 template <typename tensor_t, typename index_t>
 __global__ void ScatterAddValueGradGPUKernel(tensor_t* grad_data,
-                                             int dim,
                                              const tensor_t* self_data,
                                              const index_t* index_data,
-                                             int select_dim_size,
-                                             int self_select_dim_size,
-                                             int grad_select_dim_size,
-                                             int64_t outer_dim_size,
-                                             int64_t outer_dim_size_self,
-                                             int64_t outer_dim_size_grad,
+                                             const int64_t* shape_strides,
+                                             int dim,
+                                             int ndim,
                                              int64_t numel) {
+  extern __shared__ int64_t smem_shape_strides[];
   int64_t tid = threadIdx.x + blockIdx.x * blockDim.x;
+
+  if (threadIdx.x < (3 * ndim)) {
+    *(smem_shape_strides + threadIdx.x) = *(shape_strides + threadIdx.x);
+  }
+  __syncthreads();
   if (tid >= numel) return;
-  int64_t i, j, k;
-  i = tid / (select_dim_size * outer_dim_size);
-  int64_t remind = tid % (select_dim_size * outer_dim_size);
-  j = remind / outer_dim_size;
-  k = remind % outer_dim_size;
+
   index_t index = index_data[tid];
-  int64_t replace_index_self = k + index * outer_dim_size_self +
-                               i * outer_dim_size_self * self_select_dim_size;
-  int64_t replace_index_grad = k + j * outer_dim_size_grad +
-                               i * outer_dim_size_grad * grad_select_dim_size;
+  const int64_t* grad_strides = smem_shape_strides + ndim;
+  const int64_t* self_strides = smem_shape_strides + 2 * ndim;
+
+  int64_t replace_index_self = 0, replace_index_grad = 0;
+  ComputeOffset<true>(smem_shape_strides,
+                      grad_strides,
+                      self_strides,
+                      &replace_index_grad,
+                      &replace_index_self,
+                      tid,
+                      ndim,
+                      dim,
+                      index);
   grad_data[replace_index_grad] = self_data[replace_index_self];
 }
 
@@ -1204,99 +1312,105 @@ void gpu_scatter_add_mean_value_grad_kernel(
   auto* grad_data = grad.data<tensor_t>();
 
   auto index_dims = index.dims();
-  auto self_dims = self.dims();
-  auto grad_dims = grad.dims();
-
-  int64_t self_size = self.numel();
-  int64_t grad_size = grad.numel();
-  int64_t index_size = index.numel();
 
   int64_t inner_dim_size = 1;
   int64_t outer_dim_size = 1;
-  int64_t outer_dim_size_self = 1;
-  int64_t outer_dim_size_grad = 1;
   int64_t select_dim_size = index_dims[dim];
-  int64_t self_select_dim_size = self_dims[dim];
-  int64_t grad_select_dim_size = grad_dims[dim];
   for (int i = 0; i < dim; ++i) {
     inner_dim_size *= index_dims[i];
   }
-
   for (int i = dim + 1; i < index_dims.size(); i++) {
     outer_dim_size *= index_dims[i];
-    outer_dim_size_self *= self_dims[i];
-    outer_dim_size_grad *= grad_dims[i];
   }
-  int block = 512;
+
+  constexpr int block = 512;
+  int64_t ndim = index_dims.size();
   int64_t n = inner_dim_size * select_dim_size * outer_dim_size;
   int64_t grid = (n + block - 1) / block;
   auto stream = reinterpret_cast<const phi::GPUContext&>(dev_ctx).stream();
-  if (reduce == "mean") {
-    DenseTensor shared_mem_tensor;
-    shared_mem_tensor.Resize({self_size});
-    dev_ctx.Alloc<int>(&shared_mem_tensor);
-    if (include_self) {
-      phi::funcs::set_constant(dev_ctx, &shared_mem_tensor, 1);
-    } else {
-      phi::funcs::set_constant(dev_ctx, &shared_mem_tensor, 0);
+
+  DenseTensor shape_stride_dev;
+  shape_stride_dev.Resize({3 * ndim});
+  dev_ctx.Alloc<int64_t>(&shape_stride_dev);
+  {  // deallocate host once the copy is done
+    DenseTensor shape_stride_host;
+    shape_stride_host.Resize({3 * ndim});
+    dev_ctx.template HostAlloc<int64_t>(&shape_stride_host);
+    int64_t* host_data = shape_stride_host.data<int64_t>();
+    for (int64_t i = 0; i < ndim; i++) {
+      host_data[i] = index_dims[i];
+      host_data[i + ndim] = grad.strides()[i];
+      host_data[i + (ndim << 1)] = self.strides()[i];
     }
-    int* shared_mem = shared_mem_tensor.data<int>();
+    phi::Copy(dev_ctx,
+              shape_stride_host,
+              dev_ctx.GetPlace(),
+              false,
+              &shape_stride_dev);
+  }
+  const int64_t* shape_strides = shape_stride_dev.data<int64_t>();
+  size_t shared_mem_bytes = sizeof(int64_t) * ndim * 3;
+
+  if (reduce == "mean") {
+    DenseTensor aux_tensor;
+    aux_tensor.Resize({self.numel()});
+    dev_ctx.Alloc<int>(&aux_tensor);
+    phi::funcs::set_constant(dev_ctx, &aux_tensor, include_self ? 1 : 0);
+    int* aux_buffer = aux_tensor.data<int>();
     ScatterMeanValueGradGPUKernel<tensor_t, index_t>
-        <<<grid, block, 0, stream>>>(grad_data,
-                                     dim,
-                                     self_data,
-                                     index_data,
-                                     select_dim_size,
-                                     self_select_dim_size,
-                                     grad_select_dim_size,
-                                     outer_dim_size,
-                                     outer_dim_size_self,
-                                     outer_dim_size_grad,
-                                     index_size,
-                                     self_size,
-                                     shared_mem);
+        <<<grid, block, shared_mem_bytes, stream>>>(grad_data,
+                                                    self_data,
+                                                    index_data,
+                                                    shape_strides,
+                                                    dim,
+                                                    ndim,
+                                                    index.numel(),
+                                                    aux_buffer);
   } else if (reduce == "add") {
     ScatterAddValueGradGPUKernel<tensor_t, index_t>
-        <<<grid, block, 0, stream>>>(grad_data,
-                                     dim,
-                                     self_data,
-                                     index_data,
-                                     select_dim_size,
-                                     self_select_dim_size,
-                                     grad_select_dim_size,
-                                     outer_dim_size,
-                                     outer_dim_size_self,
-                                     outer_dim_size_grad,
-                                     index_size);
+        <<<grid, block, shared_mem_bytes, stream>>>(grad_data,
+                                                    self_data,
+                                                    index_data,
+                                                    shape_strides,
+                                                    dim,
+                                                    ndim,
+                                                    index.numel());
   }
 }
 
 template <typename tensor_t, typename index_t>
 __global__ void ScatterMulValueGradGPUKernel(tensor_t* grad_data,
-                                             int dim,
                                              const index_t* index_data,
                                              const tensor_t* self_data,
                                              const tensor_t* value_data,
                                              const tensor_t* out_data,
-                                             int select_dim_size,
-                                             int self_select_dim_size,
-                                             int grad_select_dim_size,
-                                             int64_t outer_dim_size,
-                                             int64_t outer_dim_size_self,
-                                             int64_t outer_dim_size_grad,
+                                             const int64_t* shape_strides,
+                                             int dim,
+                                             int ndim,
                                              int64_t numel) {
+  extern __shared__ int64_t smem_shape_strides[];
   int64_t tid = threadIdx.x + blockIdx.x * blockDim.x;
+
+  if (threadIdx.x < (3 * ndim)) {
+    *(smem_shape_strides + threadIdx.x) = *(shape_strides + threadIdx.x);
+  }
+  __syncthreads();
   if (tid >= numel) return;
-  int64_t i, j, k;
-  i = tid / (select_dim_size * outer_dim_size);
-  int64_t remind = tid % (select_dim_size * outer_dim_size);
-  j = remind / outer_dim_size;
-  k = remind % outer_dim_size;
+
   index_t index = index_data[tid];
-  int64_t replace_index_self = k + index * outer_dim_size_self +
-                               i * outer_dim_size_self * self_select_dim_size;
-  int64_t replace_index_grad = k + j * outer_dim_size_grad +
-                               i * outer_dim_size_grad * grad_select_dim_size;
+  const int64_t* grad_strides = smem_shape_strides + ndim;
+  const int64_t* self_strides = smem_shape_strides + 2 * ndim;
+
+  int64_t replace_index_self = 0, replace_index_grad = 0;
+  ComputeOffset<true>(smem_shape_strides,
+                      grad_strides,
+                      self_strides,
+                      &replace_index_grad,
+                      &replace_index_self,
+                      tid,
+                      ndim,
+                      dim,
+                      index);
   grad_data[replace_index_grad] =
       self_data[replace_index_self] *
       (out_data[replace_index_self] / value_data[replace_index_grad]);
@@ -1304,47 +1418,53 @@ __global__ void ScatterMulValueGradGPUKernel(tensor_t* grad_data,
 
 template <typename tensor_t, typename index_t>
 __global__ void ScatterMinMaxValueGradGPUKernel(tensor_t* grad_data,
-                                                int dim,
                                                 const index_t* index_data,
                                                 const tensor_t* self_data,
                                                 const tensor_t* value_data,
                                                 const tensor_t* out_data,
                                                 const tensor_t* x_data,
-                                                int select_dim_size,
-                                                int self_select_dim_size,
-                                                int grad_select_dim_size,
-                                                int64_t outer_dim_size,
-                                                int64_t outer_dim_size_self,
-                                                int64_t outer_dim_size_grad,
+                                                const int64_t* shape_strides,
+                                                int dim,
+                                                int ndim,
                                                 int64_t numel,
-                                                int64_t numel_self,
                                                 bool include_self,
-                                                int* shared_mem) {
+                                                int* aux_buffer) {
+  extern __shared__ int64_t smem_shape_strides[];
   int64_t tid = threadIdx.x + blockIdx.x * blockDim.x;
+
+  if (threadIdx.x < (3 * ndim)) {
+    *(smem_shape_strides + threadIdx.x) = *(shape_strides + threadIdx.x);
+  }
+  __syncthreads();
   if (tid >= numel) return;
-  int64_t i, j, k;
-  i = tid / (select_dim_size * outer_dim_size);
-  int64_t remind = tid % (select_dim_size * outer_dim_size);
-  j = remind / outer_dim_size;
-  k = remind % outer_dim_size;
+
   index_t index = index_data[tid];
-  int64_t replace_index_self = k + index * outer_dim_size_self +
-                               i * outer_dim_size_self * self_select_dim_size;
-  int64_t replace_index_grad = k + j * outer_dim_size_grad +
-                               i * outer_dim_size_grad * grad_select_dim_size;
+  const int64_t* grad_strides = smem_shape_strides + ndim;
+  const int64_t* self_strides = smem_shape_strides + 2 * ndim;
+
+  int64_t replace_index_self = 0, replace_index_grad = 0;
+  ComputeOffset<true>(smem_shape_strides,
+                      grad_strides,
+                      self_strides,
+                      &replace_index_grad,
+                      &replace_index_self,
+                      tid,
+                      ndim,
+                      dim,
+                      index);
 
   if (include_self &&
       x_data[replace_index_self] == out_data[replace_index_self])
-    phi::CudaAtomicAdd(shared_mem + replace_index_self, 1);
+    phi::CudaAtomicAdd(aux_buffer + replace_index_self, 1);
   __syncthreads();
   grad_data[replace_index_grad] = 0;
   if (value_data[replace_index_grad] == out_data[replace_index_self])
-    phi::CudaAtomicAdd(shared_mem + replace_index_self, 1);
+    phi::CudaAtomicAdd(aux_buffer + replace_index_self, 1);
   __syncthreads();
   if (value_data[replace_index_grad] == out_data[replace_index_self])
     grad_data[replace_index_grad] =
         self_data[replace_index_self] /
-        static_cast<tensor_t>(shared_mem[replace_index_self]);
+        static_cast<tensor_t>(aux_buffer[replace_index_self]);
 }
 
 template <typename tensor_t, typename index_t>
@@ -1367,72 +1487,76 @@ void gpu_scatter_mul_min_max_value_grad_kernel(
   auto* value_data = value.data<tensor_t>();
 
   auto index_dims = index.dims();
-  auto self_dims = self.dims();
-  auto grad_dims = grad.dims();
-
-  int64_t self_size = self.numel();
-  int64_t index_size = index.numel();
 
   int64_t inner_dim_size = 1;
   int64_t outer_dim_size = 1;
-  int64_t outer_dim_size_self = 1;
-  int64_t outer_dim_size_grad = 1;
   int64_t select_dim_size = index_dims[dim];
-  int64_t self_select_dim_size = self_dims[dim];
-  int64_t grad_select_dim_size = grad_dims[dim];
   for (int i = 0; i < dim; ++i) {
     inner_dim_size *= index_dims[i];
   }
-
   for (int i = dim + 1; i < index_dims.size(); i++) {
     outer_dim_size *= index_dims[i];
-    outer_dim_size_self *= self_dims[i];
-    outer_dim_size_grad *= grad_dims[i];
   }
-  int block = 512;
+
+  constexpr int block = 512;
+  int64_t ndim = index_dims.size();
   int64_t n = inner_dim_size * select_dim_size * outer_dim_size;
   int64_t grid = (n + block - 1) / block;
   auto stream = reinterpret_cast<const phi::GPUContext&>(dev_ctx).stream();
+
+  DenseTensor shape_stride_dev;
+  shape_stride_dev.Resize({3 * ndim});
+  dev_ctx.Alloc<int64_t>(&shape_stride_dev);
+  {  // deallocate host once the copy is done
+    DenseTensor shape_stride_host;
+    shape_stride_host.Resize({3 * ndim});
+    dev_ctx.template HostAlloc<int64_t>(&shape_stride_host);
+    int64_t* host_data = shape_stride_host.data<int64_t>();
+    for (int64_t i = 0; i < ndim; i++) {
+      host_data[i] = index_dims[i];
+      host_data[i + ndim] = grad.strides()[i];
+      host_data[i + (ndim << 1)] = self.strides()[i];
+    }
+    phi::Copy(dev_ctx,
+              shape_stride_host,
+              dev_ctx.GetPlace(),
+              false,
+              &shape_stride_dev);
+  }
+  const int64_t* shape_strides = shape_stride_dev.data<int64_t>();
+  size_t shared_mem_bytes = sizeof(int64_t) * ndim * 3;
+
   if (reduce == "mul" || reduce == "multiply") {
     ScatterMulValueGradGPUKernel<tensor_t, index_t>
-        <<<grid, block, 0, stream>>>(grad_data,
-                                     dim,
-                                     index_data,
-                                     self_data,
-                                     value_data,
-                                     out_data,
-                                     select_dim_size,
-                                     self_select_dim_size,
-                                     grad_select_dim_size,
-                                     outer_dim_size,
-                                     outer_dim_size_self,
-                                     outer_dim_size_grad,
-                                     index_size);
+        <<<grid, block, shared_mem_bytes, stream>>>(grad_data,
+                                                    index_data,
+                                                    self_data,
+                                                    value_data,
+                                                    out_data,
+                                                    shape_strides,
+                                                    dim,
+                                                    ndim,
+                                                    index.numel());
   } else if (reduce == "amin" || reduce == "amax") {
-    DenseTensor shared_mem_tensor;
-    shared_mem_tensor.Resize({self_size});
-    dev_ctx.Alloc<int>(&shared_mem_tensor);
-    phi::funcs::set_constant(dev_ctx, &shared_mem_tensor, 0);
+    DenseTensor aux_tensor;
+    aux_tensor.Resize({self.numel()});
+    dev_ctx.Alloc<int>(&aux_tensor);
+    phi::funcs::set_constant(dev_ctx, &aux_tensor, 0);
 
-    int* shared_mem = shared_mem_tensor.data<int>();
+    int* aux_buffer = aux_tensor.data<int>();
     ScatterMinMaxValueGradGPUKernel<tensor_t, index_t>
-        <<<grid, block, 0, stream>>>(grad_data,
-                                     dim,
-                                     index_data,
-                                     self_data,
-                                     value_data,
-                                     out_data,
-                                     x_data,
-                                     select_dim_size,
-                                     self_select_dim_size,
-                                     grad_select_dim_size,
-                                     outer_dim_size,
-                                     outer_dim_size_self,
-                                     outer_dim_size_grad,
-                                     index_size,
-                                     self_size,
-                                     include_self,
-                                     shared_mem);
+        <<<grid, block, shared_mem_bytes, stream>>>(grad_data,
+                                                    index_data,
+                                                    self_data,
+                                                    value_data,
+                                                    out_data,
+                                                    x_data,
+                                                    shape_strides,
+                                                    dim,
+                                                    ndim,
+                                                    index.numel(),
+                                                    include_self,
+                                                    aux_buffer);
   }
 }
 

--- a/paddle/phi/kernels/funcs/gather_scatter_functor.cu
+++ b/paddle/phi/kernels/funcs/gather_scatter_functor.cu
@@ -24,8 +24,8 @@ namespace funcs {
 class TensorAssign {
  public:
   template <typename tensor_t>
-  constexpr void operator()(tensor_t* self_data,
-                            const tensor_t* src_data) const {
+  constexpr void operator()(tensor_t* __restrict__ self_data,
+                            const tensor_t* __restrict__ src_data) const {
     *self_data = *src_data;
   }
 };
@@ -34,8 +34,8 @@ static TensorAssign tensor_assign;
 class ReduceAdd {
  public:
   template <typename tensor_t>
-  __device__ void operator()(tensor_t* self_data,
-                             const tensor_t* src_data) const {
+  __device__ void operator()(tensor_t* __restrict__ self_data,
+                             const tensor_t* __restrict__ src_data) const {
     phi::CudaAtomicAdd(self_data, *src_data);
   }
 };
@@ -54,8 +54,8 @@ static ReduceMul reduce_mul;
 class ReduceMax {
  public:
   template <typename tensor_t>
-  __device__ void operator()(tensor_t* self_data,
-                             const tensor_t* src_data) const {
+  __device__ void operator()(tensor_t* __restrict__ self_data,
+                             const tensor_t* __restrict__ src_data) const {
     phi::CudaAtomicMax(self_data, *src_data);
   }
 };
@@ -64,8 +64,8 @@ static ReduceMax reduce_max;
 class ReduceMin {
  public:
   template <typename tensor_t>
-  __device__ void operator()(tensor_t* self_data,
-                             const tensor_t* src_data) const {
+  __device__ void operator()(tensor_t* __restrict__ self_data,
+                             const tensor_t* __restrict__ src_data) const {
     phi::CudaAtomicMin(self_data, *src_data);
   }
 };
@@ -93,15 +93,16 @@ struct DivMod {
 // TODO(heqianyue): remove force inline?
 // TODO(heqianyue): maybe use int32 to optimize?
 template <bool compute_self>
-__device__ __forceinline__ void ComputeOffset(const int64_t* index_shape,
-                                              const int64_t* src_stride,
-                                              const int64_t* input_stride,
-                                              int64_t* src_offset,
-                                              int64_t* input_offset,
-                                              int64_t tid,
-                                              const int ndim,
-                                              const int dim_to_put,
-                                              const int64_t idx_on_dim = 0) {
+__device__ __forceinline__ void ComputeOffset(
+    const int64_t* __restrict__ index_shape,
+    const int64_t* __restrict__ src_stride,
+    const int64_t* __restrict__ input_stride,
+    int64_t* __restrict__ src_offset,
+    int64_t* __restrict__ input_offset,
+    int64_t tid,
+    const int ndim,
+    const int dim_to_put,
+    const int64_t idx_on_dim = 0) {
   // TODO(heqianyue): maybe smaller tensors can use int32
   // TODO(heqianyue): use fast divmod to optimize the speed of div and mod
   int64_t _input_offset = 0, _src_offset = 0;
@@ -141,23 +142,28 @@ __device__ __forceinline__ void ComputeOffset(const int64_t* index_shape,
  *
  * We need a ComputeOffset as offset remapper, since both the shape of src
  * tensor and input self tensor can be bigger than the shape of index tensor
+ *
+ * @note these kernels are all marked with __restrict__, since inherently
+ * there will be no pointer aliases for normal uses. Therefore, please
+ * avoid using the following kernels for INPLACE ops
  */
 template <typename tensor_t,
           typename index_t,
           typename func_t,
           bool is_scatter_like = true,
           bool include_self = false>
-__global__ void GatherScatterGPUKernel(tensor_t* self_data,
-                                       const index_t* index_data,
-                                       const int64_t* shape_strides,
-                                       const tensor_t* src_data,
-                                       int64_t self_select_dim_size,
-                                       int64_t src_select_dim_size,
-                                       int64_t numel,
-                                       int dim,
-                                       int ndim,
-                                       const func_t& reduce_op,
-                                       int* aux_buffer = nullptr) {
+__global__ void GatherScatterGPUKernel(
+    tensor_t* __restrict__ self_data,
+    const index_t* __restrict__ index_data,
+    const int64_t* __restrict__ shape_strides,
+    const tensor_t* __restrict__ src_data,
+    int64_t self_select_dim_size,
+    int64_t src_select_dim_size,
+    int64_t numel,
+    int dim,
+    int ndim,
+    const func_t& reduce_op,
+    int* __restrict__ aux_buffer = nullptr) {
   extern __shared__ int64_t
       smem_shape_strides[];  // no more than 27 int64_t, won't affect occupancy
 
@@ -243,19 +249,20 @@ template <typename tensor_t,
           typename index_t,
           typename func_t,
           bool is_scatter_like = true>
-__global__ void ScatterMeanGPUKernel(tensor_t* self_data,
-                                     const index_t* index_data,
-                                     const int64_t* shape_strides,
-                                     const tensor_t* src_data,
-                                     int64_t self_select_dim_size,
-                                     int64_t src_select_dim_size,
-                                     int64_t numel,
-                                     int dim,
-                                     int ndim,
-                                     const func_t& reduce_op,
-                                     bool include_self = true,
-                                     int* aux_buffer = nullptr,
-                                     int* atomic_cnt_buffer = nullptr) {
+__global__ void ScatterMeanGPUKernel(
+    tensor_t* __restrict__ self_data,
+    const index_t* __restrict__ index_data,
+    const int64_t* __restrict__ shape_strides,
+    const tensor_t* __restrict__ src_data,
+    int64_t self_select_dim_size,
+    int64_t src_select_dim_size,
+    int64_t numel,
+    int dim,
+    int ndim,
+    const func_t& reduce_op,
+    bool include_self = true,
+    int* __restrict__ aux_buffer = nullptr,
+    int* __restrict__ atomic_cnt_buffer = nullptr) {
   extern __shared__ int64_t
       smem_shape_strides[];  // no more than 27 int64_t, won't affect occupancy
 
@@ -725,12 +732,13 @@ void gpu_scatter_min_kernel(phi::DenseTensor self,
 }
 
 template <typename tensor_t, typename index_t>
-__global__ void ScatterInputGradGPUKernel(tensor_t* grad_data,
-                                          const index_t* index_data,
-                                          const int64_t* shape_strides,
-                                          int dim,
-                                          int ndim,
-                                          int64_t numel) {
+__global__ void ScatterInputGradGPUKernel(
+    tensor_t* __restrict__ grad_data,
+    const index_t* __restrict__ index_data,
+    const int64_t* __restrict__ shape_strides,
+    int dim,
+    int ndim,
+    int64_t numel) {
   // no more than 18 int64_t, different from forward kernels
   // the backward kernel does not require src, so src_strides are not needed
   extern __shared__ int64_t smem_shape_strides[];
@@ -820,15 +828,16 @@ void gpu_scatter_input_grad_kernel(phi::DenseTensor self,
 }
 
 template <typename tensor_t, typename index_t>
-__global__ void ScatterMulInputGradGPUKernel(tensor_t* grad_data,
-                                             const index_t* index_data,
-                                             const tensor_t* out_data,
-                                             const tensor_t* x_data,
-                                             const int64_t* shape_strides,
-                                             int dim,
-                                             int ndim,
-                                             int64_t numel,
-                                             int* aux_buffer) {
+__global__ void ScatterMulInputGradGPUKernel(
+    tensor_t* __restrict__ grad_data,
+    const index_t* __restrict__ index_data,
+    const tensor_t* __restrict__ out_data,
+    const tensor_t* __restrict__ x_data,
+    const int64_t* __restrict__ shape_strides,
+    int dim,
+    int ndim,
+    int64_t numel,
+    int* __restrict__ aux_buffer) {
   extern __shared__ int64_t smem_shape_strides[];
   int64_t tid = threadIdx.x + blockIdx.x * blockDim.x;
 
@@ -861,17 +870,18 @@ __global__ void ScatterMulInputGradGPUKernel(tensor_t* grad_data,
 }
 
 template <typename tensor_t, typename index_t>
-__global__ void ScatterMinMaxInputGradGPUKernel(tensor_t* grad_data,
-                                                const index_t* index_data,
-                                                const tensor_t* out_data,
-                                                const tensor_t* x_data,
-                                                const tensor_t* value_data,
-                                                const tensor_t* self_data,
-                                                const int64_t* shape_strides,
-                                                int dim,
-                                                int ndim,
-                                                int64_t numel,
-                                                int* aux_buffer) {
+__global__ void ScatterMinMaxInputGradGPUKernel(
+    tensor_t* __restrict__ grad_data,
+    const index_t* __restrict__ index_data,
+    const tensor_t* __restrict__ out_data,
+    const tensor_t* __restrict__ x_data,
+    const tensor_t* __restrict__ value_data,
+    const tensor_t* __restrict__ self_data,
+    const int64_t* __restrict__ shape_strides,
+    int dim,
+    int ndim,
+    int64_t numel,
+    int* __restrict__ aux_buffer) {
   extern __shared__ int64_t smem_shape_strides[];
   int64_t tid = threadIdx.x + blockIdx.x * blockDim.x;
 
@@ -921,12 +931,12 @@ void gpu_scatter_mul_min_max_input_grad_kernel(
     const std::string& reduce,
     bool include_self UNUSED,
     const phi::DeviceContext& dev_ctx) {
-  auto* index_data = index.data<index_t>();
   auto* grad_data = grad.data<tensor_t>();
+  auto* index_data = index.data<index_t>();
   auto* out_data = out.data<tensor_t>();
   auto* x_data = x.data<tensor_t>();
   auto* value_data = value.data<tensor_t>();
-  auto* self_data = self.data<tensor_t>();
+  const auto* self_data = self.data<tensor_t>();
 
   auto index_dims = index.dims();
 
@@ -1007,14 +1017,15 @@ void gpu_scatter_mul_min_max_input_grad_kernel(
 }
 
 template <typename tensor_t, typename index_t>
-__global__ void ScatterMeanInputGradGPUKernel(tensor_t* grad_data,
-                                              const index_t* index_data,
-                                              const int64_t* shape_strides,
-                                              int dim,
-                                              int ndim,
-                                              int64_t numel,
-                                              int64_t grad_numel,
-                                              int* aux_buffer) {
+__global__ void ScatterMeanInputGradGPUKernel(
+    tensor_t* __restrict__ grad_data,
+    const index_t* __restrict__ index_data,
+    const int64_t* __restrict__ shape_strides,
+    int dim,
+    int ndim,
+    int64_t numel,
+    int64_t grad_numel,
+    int* __restrict__ aux_buffer) {
   extern __shared__ int64_t smem_shape_strides[];
   int64_t tid = threadIdx.x + blockIdx.x * blockDim.x;
 
@@ -1121,14 +1132,15 @@ void gpu_scatter_mean_input_grad_kernel(phi::DenseTensor self,
 }
 
 template <typename tensor_t, typename index_t>
-__global__ void ScatterValueGradGPUKernel(tensor_t* grad_data,
-                                          const tensor_t* self_data,
-                                          const index_t* index_data,
-                                          const int64_t* shape_strides,
-                                          int dim,
-                                          int ndim,
-                                          int64_t numel,
-                                          int* aux_buffer) {
+__global__ void ScatterValueGradGPUKernel(
+    tensor_t* __restrict__ grad_data,
+    const tensor_t* __restrict__ self_data,
+    const index_t* __restrict__ index_data,
+    const int64_t* __restrict__ shape_strides,
+    int dim,
+    int ndim,
+    int64_t numel,
+    int* __restrict__ aux_buffer) {
   extern __shared__ int64_t smem_shape_strides[];
   int64_t tid = threadIdx.x + blockIdx.x * blockDim.x;
 
@@ -1230,14 +1242,15 @@ void gpu_scatter_value_grad_kernel(phi::DenseTensor self,
 }
 
 template <typename tensor_t, typename index_t>
-__global__ void ScatterMeanValueGradGPUKernel(tensor_t* grad_data,
-                                              const tensor_t* self_data,
-                                              const index_t* index_data,
-                                              const int64_t* shape_strides,
-                                              int dim,
-                                              int ndim,
-                                              int64_t numel,
-                                              int* aux_buffer) {
+__global__ void ScatterMeanValueGradGPUKernel(
+    tensor_t* __restrict__ grad_data,
+    const tensor_t* __restrict__ self_data,
+    const index_t* __restrict__ index_data,
+    const int64_t* __restrict__ shape_strides,
+    int dim,
+    int ndim,
+    int64_t numel,
+    int* __restrict__ aux_buffer) {
   extern __shared__ int64_t smem_shape_strides[];
   int64_t tid = threadIdx.x + blockIdx.x * blockDim.x;
 
@@ -1271,13 +1284,14 @@ __global__ void ScatterMeanValueGradGPUKernel(tensor_t* grad_data,
 }
 
 template <typename tensor_t, typename index_t>
-__global__ void ScatterAddValueGradGPUKernel(tensor_t* grad_data,
-                                             const tensor_t* self_data,
-                                             const index_t* index_data,
-                                             const int64_t* shape_strides,
-                                             int dim,
-                                             int ndim,
-                                             int64_t numel) {
+__global__ void ScatterAddValueGradGPUKernel(
+    tensor_t* __restrict__ grad_data,
+    const tensor_t* __restrict__ self_data,
+    const index_t* __restrict__ index_data,
+    const int64_t* __restrict__ shape_strides,
+    int dim,
+    int ndim,
+    int64_t numel) {
   extern __shared__ int64_t smem_shape_strides[];
   int64_t tid = threadIdx.x + blockIdx.x * blockDim.x;
 
@@ -1316,7 +1330,7 @@ void gpu_scatter_add_mean_value_grad_kernel(
     const std::string& reduce,
     bool include_self,
     const phi::DeviceContext& dev_ctx UNUSED) {
-  auto* self_data = self.data<tensor_t>();
+  const auto* self_data = self.data<tensor_t>();
   auto* index_data = index.data<index_t>();
   auto* grad_data = grad.data<tensor_t>();
 
@@ -1388,15 +1402,16 @@ void gpu_scatter_add_mean_value_grad_kernel(
 }
 
 template <typename tensor_t, typename index_t>
-__global__ void ScatterMulValueGradGPUKernel(tensor_t* grad_data,
-                                             const index_t* index_data,
-                                             const tensor_t* self_data,
-                                             const tensor_t* value_data,
-                                             const tensor_t* out_data,
-                                             const int64_t* shape_strides,
-                                             int dim,
-                                             int ndim,
-                                             int64_t numel) {
+__global__ void ScatterMulValueGradGPUKernel(
+    tensor_t* __restrict__ grad_data,
+    const index_t* __restrict__ index_data,
+    const tensor_t* __restrict__ self_data,
+    const tensor_t* __restrict__ value_data,
+    const tensor_t* __restrict__ out_data,
+    const int64_t* __restrict__ shape_strides,
+    int dim,
+    int ndim,
+    int64_t numel) {
   extern __shared__ int64_t smem_shape_strides[];
   int64_t tid = threadIdx.x + blockIdx.x * blockDim.x;
 
@@ -1426,18 +1441,19 @@ __global__ void ScatterMulValueGradGPUKernel(tensor_t* grad_data,
 }
 
 template <typename tensor_t, typename index_t>
-__global__ void ScatterMinMaxValueGradGPUKernel(tensor_t* grad_data,
-                                                const index_t* index_data,
-                                                const tensor_t* self_data,
-                                                const tensor_t* value_data,
-                                                const tensor_t* out_data,
-                                                const tensor_t* x_data,
-                                                const int64_t* shape_strides,
-                                                int dim,
-                                                int ndim,
-                                                int64_t numel,
-                                                bool include_self,
-                                                int* aux_buffer) {
+__global__ void ScatterMinMaxValueGradGPUKernel(
+    tensor_t* __restrict__ grad_data,
+    const index_t* __restrict__ index_data,
+    const tensor_t* __restrict__ self_data,
+    const tensor_t* __restrict__ value_data,
+    const tensor_t* __restrict__ out_data,
+    const tensor_t* __restrict__ x_data,
+    const int64_t* __restrict__ shape_strides,
+    int dim,
+    int ndim,
+    int64_t numel,
+    bool include_self,
+    int* __restrict__ aux_buffer) {
   extern __shared__ int64_t smem_shape_strides[];
   int64_t tid = threadIdx.x + blockIdx.x * blockDim.x;
 
@@ -1488,7 +1504,7 @@ void gpu_scatter_mul_min_max_value_grad_kernel(
     const std::string& reduce,
     bool include_self,
     const phi::DeviceContext& dev_ctx) {
-  auto* self_data = self.data<tensor_t>();
+  const auto* self_data = self.data<tensor_t>();
   auto* index_data = index.data<index_t>();
   auto* grad_data = grad.data<tensor_t>();
   auto* out_data = out.data<tensor_t>();

--- a/paddle/phi/kernels/funcs/gather_scatter_functor.cu
+++ b/paddle/phi/kernels/funcs/gather_scatter_functor.cu
@@ -24,7 +24,8 @@ namespace funcs {
 class TensorAssign {
  public:
   template <typename tensor_t>
-  constexpr void operator()(tensor_t* self_data, tensor_t* src_data) const {
+  constexpr void operator()(tensor_t* self_data,
+                            const tensor_t* src_data) const {
     *self_data = *src_data;
   }
 };
@@ -33,7 +34,8 @@ static TensorAssign tensor_assign;
 class ReduceAdd {
  public:
   template <typename tensor_t>
-  __device__ void operator()(tensor_t* self_data, tensor_t* src_data) const {
+  __device__ void operator()(tensor_t* self_data,
+                             const tensor_t* src_data) const {
     phi::CudaAtomicAdd(self_data, *src_data);
   }
 };
@@ -42,7 +44,8 @@ static ReduceAdd reduce_add;
 class ReduceMul {
  public:
   template <typename tensor_t>
-  __device__ void operator()(tensor_t* self_data, tensor_t* src_data) const {
+  __device__ void operator()(tensor_t* self_data,
+                             const tensor_t* src_data) const {
     phi::CudaAtomicMul(self_data, *src_data);
   }
 };
@@ -51,7 +54,8 @@ static ReduceMul reduce_mul;
 class ReduceMax {
  public:
   template <typename tensor_t>
-  __device__ void operator()(tensor_t* self_data, tensor_t* src_data) const {
+  __device__ void operator()(tensor_t* self_data,
+                             const tensor_t* src_data) const {
     phi::CudaAtomicMax(self_data, *src_data);
   }
 };
@@ -60,7 +64,8 @@ static ReduceMax reduce_max;
 class ReduceMin {
  public:
   template <typename tensor_t>
-  __device__ void operator()(tensor_t* self_data, tensor_t* src_data) const {
+  __device__ void operator()(tensor_t* self_data,
+                             const tensor_t* src_data) const {
     phi::CudaAtomicMin(self_data, *src_data);
   }
 };
@@ -145,7 +150,7 @@ template <typename tensor_t,
 __global__ void GatherScatterGPUKernel(tensor_t* self_data,
                                        const index_t* index_data,
                                        const int64_t* shape_strides,
-                                       tensor_t* src_data,
+                                       const tensor_t* src_data,
                                        int64_t self_select_dim_size,
                                        int64_t src_select_dim_size,
                                        int64_t numel,
@@ -230,7 +235,7 @@ __global__ void GatherScatterGPUKernel(tensor_t* self_data,
     __syncthreads();
     if (!is_op_done)
       reduce_op(static_cast<tensor_t*>(self_data + replace_index_self),
-                static_cast<tensor_t*>(src_data + replace_index_src));
+                static_cast<const tensor_t*>(src_data + replace_index_src));
   }
 }
 
@@ -241,7 +246,7 @@ template <typename tensor_t,
 __global__ void ScatterMeanGPUKernel(tensor_t* self_data,
                                      const index_t* index_data,
                                      const int64_t* shape_strides,
-                                     tensor_t* src_data,
+                                     const tensor_t* src_data,
                                      int64_t self_select_dim_size,
                                      int64_t src_select_dim_size,
                                      int64_t numel,
@@ -316,7 +321,7 @@ __global__ void ScatterMeanGPUKernel(tensor_t* self_data,
   }
 
   reduce_op(static_cast<tensor_t*>(self_data + replace_index_self),
-            static_cast<tensor_t*>(src_data + replace_index_src));
+            static_cast<const tensor_t*>(src_data + replace_index_src));
 
   // So this is the culprit
   phi::CudaAtomicMax(aux_buffer + replace_index_self, tid);
@@ -429,8 +434,8 @@ struct gpu_gather_scatter_functor {
       return;
     }
     auto* self_data = self.data<tensor_t>();
-    auto* index_data = index.data<index_t>();
-    auto* src_data = src.data<tensor_t>();
+    const auto* index_data = index.data<index_t>();
+    const auto* src_data = src.data<tensor_t>();
     int64_t self_size = self.numel();
     int64_t index_size = index.numel();
     int64_t src_size = src.numel();
@@ -544,17 +549,33 @@ struct gpu_gather_scatter_functor {
                                                       aux_buffer,
                                                       atomic_cnt_buffer);
     } else {
-      if (include_self == false) {
+      if (include_self) {
+        GatherScatterGPUKernel<tensor_t,
+                               index_t,
+                               func_t,
+                               is_scatter_like,
+                               true>
+            <<<grid, block, shared_mem_bytes, stream>>>(self_data,
+                                                        index_data,
+                                                        shape_strides,
+                                                        src_data,
+                                                        self_select_dim_size,
+                                                        src_select_dim_size,
+                                                        index_size,
+                                                        dim,
+                                                        ndim,
+                                                        reduce_op,
+                                                        nullptr);
+      } else {
         aux_tensor.Resize({self_size});
         dev_ctx.Alloc<int>(&aux_tensor);
-        phi::funcs::set_constant(dev_ctx, &aux_tensor, self_size + 1);
+        phi::funcs::set_constant(dev_ctx, &aux_tensor, index_size + 1);
 
         int* aux_buffer = aux_tensor.data<int>();
         GatherScatterGPUKernel<tensor_t,
                                index_t,
                                func_t,
                                is_scatter_like,
-                               false,
                                false>
             <<<grid, block, shared_mem_bytes, stream>>>(self_data,
                                                         index_data,
@@ -567,24 +588,6 @@ struct gpu_gather_scatter_functor {
                                                         ndim,
                                                         reduce_op,
                                                         aux_buffer);
-      } else {
-        GatherScatterGPUKernel<tensor_t,
-                               index_t,
-                               func_t,
-                               is_scatter_like,
-                               true,
-                               false>
-            <<<grid, block, shared_mem_bytes, stream>>>(self_data,
-                                                        index_data,
-                                                        shape_strides,
-                                                        src_data,
-                                                        self_select_dim_size,
-                                                        src_select_dim_size,
-                                                        index_size,
-                                                        dim,
-                                                        ndim,
-                                                        reduce_op,
-                                                        nullptr);
       }
     }
   }

--- a/paddle/phi/kernels/funcs/gather_scatter_functor.cu
+++ b/paddle/phi/kernels/funcs/gather_scatter_functor.cu
@@ -1002,17 +1002,17 @@ void gpu_scatter_mul_min_max_input_grad_kernel(
     phi::funcs::set_constant(dev_ctx, &aux_tensor, 1);
     shared_mem_bytes *= 3;  // two strides, 1 shape
     ScatterMinMaxInputGradGPUKernel<tensor_t, index_t>
-        <<<grid, block, 0, stream>>>(grad_data,
-                                     index_data,
-                                     out_data,
-                                     x_data,
-                                     value_data,
-                                     self_data,
-                                     shape_strides,
-                                     dim,
-                                     ndim,
-                                     index.numel(),
-                                     aux_buffer);
+        <<<grid, block, shared_mem_bytes, stream>>>(grad_data,
+                                                    index_data,
+                                                    out_data,
+                                                    x_data,
+                                                    value_data,
+                                                    self_data,
+                                                    shape_strides,
+                                                    dim,
+                                                    ndim,
+                                                    index.numel(),
+                                                    aux_buffer);
   }
 }
 

--- a/paddle/phi/kernels/funcs/gather_scatter_functor.cu
+++ b/paddle/phi/kernels/funcs/gather_scatter_functor.cu
@@ -223,7 +223,7 @@ __global__ void GatherScatterGPUKernel(tensor_t* self_data,
     // there was no atomic primitives for assign), and for other ops,
     // unordered atomic access is used
     reduce_op(static_cast<tensor_t*>(self_data + replace_index_self),
-              static_cast<tensor_t*>(src_data + replace_index_src));
+              static_cast<const tensor_t*>(src_data + replace_index_src));
   } else {
     bool is_op_done = false;
     phi::CudaAtomicMin(aux_buffer + replace_index_self, tid);
@@ -336,13 +336,14 @@ __global__ void ScatterMeanGPUKernel(tensor_t* self_data,
 }
 
 template <typename index_t>
-__global__ void PickWinnersScatterKernel(const index_t* __restrict__ index_data,
-                                         const int64_t* __restrict__ shape_strides,
-                                         int* __restrict__ winners,
-                                         int64_t self_select_dim_size,
-                                         int64_t numel,
-                                         int dim,
-                                         int ndim) {
+__global__ void PickWinnersScatterKernel(
+    const index_t* __restrict__ index_data,
+    const int64_t* __restrict__ shape_strides,
+    int* __restrict__ winners,
+    int64_t self_select_dim_size,
+    int64_t numel,
+    int dim,
+    int ndim) {
   extern __shared__ int64_t
       smem_shape_strides[];  // no more than 27 int64_t, won't affect occupancy
 
@@ -362,14 +363,14 @@ __global__ void PickWinnersScatterKernel(const index_t* __restrict__ index_data,
   // index matrix has different shape with self matrix or src matrix.
   int64_t replace_index_self = 0;
   ComputeOffset<false>(smem_shape_strides,
-                                 input_strides,
-                                 nullptr,
-                                 &replace_index_self,
-                                 nullptr,
-                                 tid,
-                                 ndim,
-                                 dim,
-                                 index);
+                       input_strides,
+                       nullptr,
+                       &replace_index_self,
+                       nullptr,
+                       tid,
+                       ndim,
+                       dim,
+                       index);
 
   atomicMax(&winners[replace_index_self], static_cast<int>(tid));
 }
@@ -404,14 +405,14 @@ __global__ void ScatterWriteByWinnersKernel(
 
   int64_t replace_index_self = 0, replace_index_src = 0;
   ComputeOffset<true>(smem_shape_strides,
-                                 src_strides,
-                                 input_strides,
-                                 &replace_index_src,
-                                 &replace_index_self,
-                                 tid,
-                                 ndim,
-                                 dim,
-                                 index);
+                      src_strides,
+                      input_strides,
+                      &replace_index_src,
+                      &replace_index_self,
+                      tid,
+                      ndim,
+                      dim,
+                      index);
   if (static_cast<int>(tid) == winners[replace_index_self]) {
     *(self_data + replace_index_self) = *(src_data + replace_index_src);
   }
@@ -501,23 +502,23 @@ struct gpu_gather_scatter_functor {
       // Stage 1: Get the last index to be assigned the same dst.
       PickWinnersScatterKernel<index_t>
           <<<grid, block, shared_mem_bytes, stream>>>(index_data,
-                                       shape_strides,
-                                       winners,
-                                       self_select_dim_size,
-                                       index_size,
+                                                      shape_strides,
+                                                      winners,
+                                                      self_select_dim_size,
+                                                      index_size,
                                                       dim,
                                                       ndim);
       // Stage 2: Only the max tid in stage 1 can write src to dst.
       ScatterWriteByWinnersKernel<tensor_t, index_t, func_t>
           <<<grid, block, shared_mem_bytes, stream>>>(self_data,
-                                       index_data,
-                                       src_data,
-                                       shape_strides,
-                                       winners,
-                                       self_select_dim_size,
-                                       index_size,
-                                       dim,
-                                       ndim);
+                                                      index_data,
+                                                      src_data,
+                                                      shape_strides,
+                                                      winners,
+                                                      self_select_dim_size,
+                                                      index_size,
+                                                      dim,
+                                                      ndim);
     } else if (method_name == "scatter_mean_gpu") {
       // TODO(heqianyue): the original impl is too wasteful, this can be
       // optimized
@@ -550,11 +551,7 @@ struct gpu_gather_scatter_functor {
                                                       atomic_cnt_buffer);
     } else {
       if (include_self) {
-        GatherScatterGPUKernel<tensor_t,
-                               index_t,
-                               func_t,
-                               is_scatter_like,
-                               true>
+        GatherScatterGPUKernel<tensor_t, index_t, func_t, is_scatter_like, true>
             <<<grid, block, shared_mem_bytes, stream>>>(self_data,
                                                         index_data,
                                                         shape_strides,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Operator Mechanism


### PR Types
Improvements


### Description
`put_along_axis` / `take_along_axis` 底层 kernel gather / scatter 具有非常严重的错误，13 个 kernel 全部重写。

- [x] 13 个 kernel 包括所有 reduce 方法的 forward 及 backward kernel。
- [x] 增加了一种适用于各种 ndim 的 offset 映射方法，引入了不超过27个int64（每个kernel）的 smem 使用（不影响occupancy）
- [x] 保持了原有的 paddle 的行为：多线程竞争性写入时部分 reduce 方法是 ordered 写入，与 PyTorch 的乱序atomic写入不同。
- [x] 部分输入情况下删除了 aux_tensor (原 shared_mem_tensor) 的使用，减少显存消耗（最高可达50%）
- [x] 修正了 reduce = amin/amax 的行为：此前的计算模式会导致参与 amin/amax 的线程最小 ID 为 1，导致部分维度的第一个元素计算错误而无法与 PyTorch 对齐。
- [x]  CUDA 代码规范性修正。
- [ ] 单测在之后的 PR 补充，目前的改动在现有的单测下能覆盖。
- [ ] CPU 端未修改，请勿调用 CPU 算子以免引起问题！后续将补充 CPU 改动。

Pcard-89620