### PR TITLE
fix flashmask_attention when startend_row_indices is None

### DIFF
--- a/python/paddle/nn/functional/flash_attention.py
+++ b/python/paddle/nn/functional/flash_attention.py
@@ -2287,87 +2287,82 @@ def flashmask_attention(
                     f"Invalid shape of startend_row_indices, when causal is False, the last dimension should be either 2 or 4 but got {startend_row_indices.shape[-1]}"
                 )
 
-    if "xpu" in paddle.get_device():
-        fa_version = 2
-    elif paddle.get_flags(["FLAGS_cudnn_deterministic"])[
-        "FLAGS_cudnn_deterministic"
-    ]:
-        fa_version = 2
-    else:
-        fa_version = paddle.base.framework.get_flags(
-            ["FLAGS_flash_attn_version"]
-        )["FLAGS_flash_attn_version"]
-
-    if fa_version == 2:
-        assert softmax_scale is None, (
-            "flashmask_attention does not support setting softmax_scale, use flashmask_attention_v2 instead"
-        )
-
-        (
-            out,
-            result_softmax,
-            result_softmax_lse,
-            result_seed_offset,
-        ) = _C_ops.flashmask_attention(
-            query,
-            key,
-            value,
-            startend_row_indices,
-            fixed_seed_offset,
-            dropout,
-            causal,
-            False,
-            not training,
-            rng_name,
-        )
-
-        outputs = [out]
-        if return_softmax_lse:
-            outputs += [result_softmax_lse]
-        if return_seed_offset:
-            outputs += [result_seed_offset]
-        if len(outputs) == 1:
-            return outputs[0]
+        if "xpu" in paddle.get_device():
+            fa_version = 2
+        elif paddle.get_flags(["FLAGS_cudnn_deterministic"])[
+            "FLAGS_cudnn_deterministic"
+        ]:
+            fa_version = 2
         else:
-            return outputs
-    elif fa_version == 3:
-        assert dropout == 0.0, "flashmask_attention_v2 does not support dropout"
-        assert not return_seed_offset, (
-            "flashmask_attention_v2 does not support return seed_offset"
-        )
-        assert fixed_seed_offset is None, (
-            "flashmask_attention_v2 does not support setting seed_offset"
-        )
-        assert rng_name == "", (
-            "flashmask_attention_v2 does not support setting rng_name"
-        )
-        assert training, (
-            "flashmask_attention_v2 does not support setting training to False"
-        )
+            fa_version = paddle.base.framework.get_flags(
+                ["FLAGS_flash_attn_version"]
+            )["FLAGS_flash_attn_version"]
 
-        assert name is None, (
-            "flashmask_attention_v2 does not support setting name"
-        )
+        if fa_version == 2:
+            assert softmax_scale is None, (
+                "flashmask_attention does not support setting softmax_scale, use flashmask_attention_v2 instead"
+            )
 
-        if softmax_scale is None:
-            softmax_scale = query.shape[-1] ** (-0.5)
+            (
+                out,
+                result_softmax,
+                result_softmax_lse,
+                result_seed_offset,
+            ) = _C_ops.flashmask_attention(
+                query,
+                key,
+                value,
+                startend_row_indices,
+                fixed_seed_offset,
+                dropout,
+                causal,
+                False,
+                not training,
+                rng_name,
+            )
 
-        (
-            out,
-            softmax_lse,
-        ) = _C_ops.flashmask_attention_v2(
-            query, key, value, startend_row_indices, softmax_scale, causal
-        )
+        elif fa_version == 3:
+            assert dropout == 0.0, (
+                "flashmask_attention_v2 does not support dropout"
+            )
+            assert not return_seed_offset, (
+                "flashmask_attention_v2 does not support return seed_offset"
+            )
+            assert fixed_seed_offset is None, (
+                "flashmask_attention_v2 does not support setting seed_offset"
+            )
+            assert rng_name == "", (
+                "flashmask_attention_v2 does not support setting rng_name"
+            )
+            assert training, (
+                "flashmask_attention_v2 does not support setting training to False"
+            )
 
-        outputs = [out]
-        if return_softmax_lse:
-            outputs += [softmax_lse]
-        if len(outputs) == 1:
-            return outputs[0]
+            assert name is None, (
+                "flashmask_attention_v2 does not support setting name"
+            )
+
+            if softmax_scale is None:
+                softmax_scale = query.shape[-1] ** (-0.5)
+
+            (
+                out,
+                result_softmax_lse,
+            ) = _C_ops.flashmask_attention_v2(
+                query, key, value, startend_row_indices, softmax_scale, causal
+            )
         else:
-            return outputs
+            raise ValueError(f"Invalid flash attention version: {fa_version}")
+
+    outputs = [out]
+    if return_softmax_lse:
+        outputs += [result_softmax_lse]
+    if return_seed_offset:
+        outputs += [result_seed_offset]
+    if len(outputs) == 1:
+        return outputs[0]
     else:
-        raise ValueError(f"Invalid flash attention version: {fa_version}")
+        return outputs
 
 
 def calc_reduced_attention_scores(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-70459
fix flashmask_attention when startend_row_indices is None
