### PR TITLE
[API Compatibilities] add return_type for `topk`

### DIFF
--- a/python/paddle/tensor/compat.py
+++ b/python/paddle/tensor/compat.py
@@ -836,7 +836,9 @@ def max(
     return ret
 
 
-MedianRetType = MinMaxRetType
+class MedianRetType(NamedTuple):
+    values: Tensor
+    indices: Tensor
 
 
 @ForbidKeywordsDecorator(

--- a/python/paddle/tensor/search.py
+++ b/python/paddle/tensor/search.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, NamedTuple
 
 import numpy as np
 from typing_extensions import overload
@@ -1043,6 +1043,11 @@ def masked_select(x: Tensor, mask: Tensor, name: str | None = None) -> Tensor:
         return out
 
 
+class TopKRetType(NamedTuple):
+    values: Tensor
+    indices: Tensor
+
+
 @param_two_alias(["x", "input"], ["axis", "dim"])
 def topk(
     x: Tensor,
@@ -1053,7 +1058,7 @@ def topk(
     name: str | None = None,
     *,
     out: tuple[Tensor, Tensor] | None = None,
-) -> tuple[Tensor, Tensor]:
+) -> TopKRetType:
     """
     Return values and indices of the k largest or smallest at the optional axis.
     If the input is a 1-D Tensor, finds the k largest or smallest values and indices.
@@ -1129,8 +1134,8 @@ def topk(
             out_values, out_indices = out
             out_values = paddle.assign(values, output=out_values)
             out_indices = paddle.assign(indices, output=out_indices)
-            return out_values, out_indices
-        return values, indices
+            return TopKRetType(values=out_values, indices=out_indices)
+        return TopKRetType(values=values, indices=indices)
     else:
         helper = LayerHelper("top_k_v2", **locals())
         inputs = {"X": [x]}

--- a/test/legacy_test/test_top_k_op.py
+++ b/test/legacy_test/test_top_k_op.py
@@ -93,6 +93,10 @@ class TestTopkOutAPI(unittest.TestCase):
             elif case == 'both_input_out':
                 _ = paddle.topk(x, k, out=(out_values, out_indices))
                 values, indices = out_values, out_indices
+            elif case == 'struct_return':
+                res = paddle.topk(x, k)
+                values = res.values
+                indices = res.indices
             else:
                 raise AssertionError
 
@@ -108,7 +112,7 @@ class TestTopkOutAPI(unittest.TestCase):
             loss.backward()
             return values.numpy(), indices.numpy(), x.grad.numpy()
 
-        # run four scenarios
+        # run five scenarios
         v1, i1, g1 = run_case('return')
         x.clear_gradient()
         v2, i2, g2 = run_case('input_out')
@@ -116,16 +120,21 @@ class TestTopkOutAPI(unittest.TestCase):
         v3, i3, g3 = run_case('both_return')
         x.clear_gradient()
         v4, i4, g4 = run_case('both_input_out')
+        x.clear_gradient()
+        v5, i5, g5 = run_case('struct_return')
 
         np.testing.assert_allclose(v1, v2, rtol=1e-6, atol=1e-6)
         np.testing.assert_allclose(v1, v3, rtol=1e-6, atol=1e-6)
         np.testing.assert_allclose(v1, v4, rtol=1e-6, atol=1e-6)
+        np.testing.assert_allclose(v1, v5, rtol=1e-6, atol=1e-6)
         np.testing.assert_allclose(i1, i2, rtol=1e-6, atol=1e-6)
         np.testing.assert_allclose(i1, i3, rtol=1e-6, atol=1e-6)
         np.testing.assert_allclose(i1, i4, rtol=1e-6, atol=1e-6)
+        np.testing.assert_allclose(i1, i5, rtol=1e-6, atol=1e-6)
         np.testing.assert_allclose(g1, g2, rtol=1e-6, atol=1e-6)
         np.testing.assert_allclose(g1, g3, rtol=1e-6, atol=1e-6)
         np.testing.assert_allclose(g1, g4, rtol=1e-6, atol=1e-6)
+        np.testing.assert_allclose(g1, g5, rtol=1e-6, atol=1e-6)
 
         paddle.enable_static()
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
add return_type for `topk` and fix `compat.median` 's return_type
cc @zhwesky2010 
pcard-71500