### PR TITLE
[API compatibility] support paddle.norm and paddle.linalg.norm with out param

### DIFF
--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -1178,12 +1178,13 @@ def matrix_norm(
         )
 
 
-@ParamAliasDecorator({"x": ["input"], "axis": ["dim"]})
+@ParamAliasDecorator({"x": ["input", "A"], "p": ["ord"], "axis": ["dim"]})
 def norm(
     x: Tensor,
     p: float | _POrder | None = None,
     axis: int | list[int] | tuple[int, int] | None = None,
     keepdim: bool = False,
+    *,
     out: paddle.Tensor | None = None,
     dtype: paddle._typing.DTypeLike | None = None,
     name: str | None = None,

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -1253,6 +1253,7 @@ def norm(
             output Tensor. The result tensor will have fewer dimension
             than the :attr:`input` unless :attr:`keepdim` is true, default
             value is False.
+        out (Tensor, optional): The output tensor. Ignored out = None.
         dtype (DTypeLike | None, optional): The data type of the output tensor. If specified, the input tensor is casted to `dtype` while performing the operation. Default value is None.
         name (str|None, optional): The default value is None. Normally there is no need for
             user to set this property. For more information, please refer to :ref:`api_guide_Name`.

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -1184,6 +1184,7 @@ def norm(
     p: float | _POrder | None = None,
     axis: int | list[int] | tuple[int, int] | None = None,
     keepdim: bool = False,
+    out: paddle.Tensor | None = None,
     dtype: paddle._typing.DTypeLike | None = None,
     name: str | None = None,
 ) -> Tensor:
@@ -1328,28 +1329,36 @@ def norm(
         x = x.astype(dtype)
     if isinstance(p, str):
         if p == "fro" and (axis is None or isinstance(axis, int)):
-            return vector_norm(
+            output = vector_norm(
                 x,
                 p=2,
                 axis=axis,
                 keepdim=keepdim,
                 name=name,
             )
-        if axis is None:
-            axis = list(range(x.ndim))
-        return matrix_norm(x=x, p=p, axis=axis, keepdim=keepdim, name=name)
+        else:
+            if axis is None:
+                axis = list(range(x.ndim))
+            output = matrix_norm(
+                x=x, p=p, axis=axis, keepdim=keepdim, name=name
+            )
     else:
         p = 2.0 if p is None else p
         if isinstance(axis, list) and len(axis) == 2:
-            return matrix_norm(x=x, p=p, axis=axis, keepdim=keepdim, name=name)
+            output = matrix_norm(
+                x=x, p=p, axis=axis, keepdim=keepdim, name=name
+            )
         else:
-            return vector_norm(
+            output = vector_norm(
                 x,
                 p=p,
                 axis=axis,
                 keepdim=keepdim,
                 name=name,
             )
+    if out is not None:
+        paddle.assign(output, out=out)
+    return output
 
 
 def dist(x: Tensor, y: Tensor, p: float = 2, name: str | None = None) -> Tensor:

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -1358,7 +1358,7 @@ def norm(
                 name=name,
             )
     if out is not None:
-        paddle.assign(output, out=out)
+        paddle.assign(output, output=out)
     return output
 
 

--- a/test/legacy_test/test_norm_all.py
+++ b/test/legacy_test/test_norm_all.py
@@ -773,6 +773,52 @@ class NormTestForNUCAndDtype(unittest.TestCase):
         )
         self.assertEqual(res_paddle.dtype, paddle.float64)
 
+    def test_with_out(self):
+        # matrix
+        x = np.random.randn(10, 20).astype("float32")
+
+        res_numpy = np.linalg.norm(x, ord='nuc')
+        res_out = paddle.zeros(res_numpy.shape, dtype="float32")
+        res_paddle = paddle.tensor(x).norm(p='nuc', out=res_out)
+        np.testing.assert_allclose(
+            res_numpy, res_out.numpy(), rtol=1e-6, atol=1e-6
+        )
+        np.testing.assert_allclose(
+            res_out.numpy(), res_paddle.numpy(), rtol=1e-6, atol=1e-6
+        )
+
+        res_numpy = np.linalg.norm(x, ord=2, axis=(0, 1))
+        res_out = paddle.zeros(res_numpy.shape, dtype="float32")
+        res_paddle = paddle.tensor(x).norm(p=2, axis=[0, 1], out=res_out)
+        np.testing.assert_allclose(
+            res_out.numpy(), res_paddle.numpy(), rtol=1e-6, atol=1e-6
+        )
+        np.testing.assert_allclose(
+            res_numpy, res_out.numpy(), rtol=1e-5, atol=1e-6
+        )
+
+        # vector
+        x = np.random.randn(10).astype("float32")
+        res_numpy = np.linalg.norm(x, ord=2, axis=0)
+        res_out = paddle.zeros(res_numpy.shape, dtype="float32")
+        res_paddle = paddle.tensor(x).norm(p='fro', axis=0, out=res_out)
+        np.testing.assert_allclose(
+            res_numpy, res_out.numpy(), rtol=1e-6, atol=1e-6
+        )
+        np.testing.assert_allclose(
+            res_out.numpy(), res_paddle.numpy(), rtol=1e-6, atol=1e-6
+        )
+
+        res_numpy = np.linalg.norm(x, ord=2, axis=0)
+        res_out = paddle.zeros(res_numpy.shape, dtype="float32")
+        res_paddle = paddle.tensor(x).norm(p=2, axis=0, out=res_out)
+        np.testing.assert_allclose(
+            res_numpy, res_out.numpy(), rtol=1e-6, atol=1e-6
+        )
+        np.testing.assert_allclose(
+            res_out.numpy(), res_paddle.numpy(), rtol=1e-6, atol=1e-6
+        )
+
 
 class API_NormTest(unittest.TestCase):
     def test_basic(self):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

New features

### Description
<!-- Describe what you’ve done -->

为paddle.norm添加out参数，使其对齐torch.norm()。

对齐paddle.linalg.norm与torch.linalg.norm

在PaConvert下自测，paddle.norm()与torch.norm()对齐, paddle.linalg.norm与torch.linalg.norm对齐。

pcard-71500

paddle.norm
![image](https://github.com/user-attachments/assets/425ce367-f74e-49c4-8ffe-235885dfd9b3)

paddle.linalg.norm
![image](https://github.com/user-attachments/assets/6dae9da9-2d17-44a3-bdae-b07de07acfcf)

