### PR TITLE
[API Compatiblity] Fix bug for code gen

### DIFF
--- a/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
@@ -891,7 +891,9 @@ class PythonCGenerator(GeneratorBase):
             f_generator = PythonCSingleFunctionGenerator(
                 forward_api_content, namespace
             )
-            status = f_generator.run(no_input_out_tensor)
+            status = f_generator.run(
+                no_input_out_tensor, no_parse_python_api_info
+            )
 
             if status:
                 self.python_c_functions_str += (

--- a/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
@@ -836,7 +836,7 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
             self.need_parse_python_api_args = True
             self.ParsePythonAPIInfo()
 
-    def run(self, no_input_out_tensor=False):
+    def run(self, no_input_out_tensor=False, no_parse_python_api_info=False):
         # Initialized is_forward_only
         self.CollectIsForwardOnly()
 
@@ -848,7 +848,8 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
 
         # Initialized orig_forward_inputs_list, orig_forward_returns_list, orig_forward_attrs_list
         self.CollectOriginalForwardInfo()
-        self.InitAndParsePythonAPIInfo()
+        if not no_parse_python_api_info:
+            self.InitAndParsePythonAPIInfo()
         if SkipAPIGeneration(self.forward_api_name):
             return False
 
@@ -876,7 +877,9 @@ class PythonCGenerator(GeneratorBase):
         self.python_c_functions_reg_str = ""
         self.python_c_function_declare_str = ""
 
-    def GeneratePythonCFunctions(self, no_input_out_tensor=False):
+    def GeneratePythonCFunctions(
+        self, no_input_out_tensor=False, no_parse_python_api_info=False
+    ):
         namespace = self.namespace
 
         forward_api_list = self.forward_api_list
@@ -916,7 +919,7 @@ class PythonCGenerator(GeneratorBase):
                 )
             )
 
-    def run(self, no_input_out_tensor=False):
+    def run(self, no_input_out_tensor=False, no_parse_python_api_info=False):
         # Infer namespace from yaml_path
         self.InferNameSpace()
 
@@ -924,7 +927,9 @@ class PythonCGenerator(GeneratorBase):
         self.ParseForwardYamlContents()
 
         # Code Generation
-        self.GeneratePythonCFunctions(no_input_out_tensor)
+        self.GeneratePythonCFunctions(
+            no_input_out_tensor, no_parse_python_api_info
+        )
 
         # Wrap with namespace
         self.AttachNamespace()
@@ -991,9 +996,10 @@ if __name__ == "__main__":
             or "strings" in api_yaml_path
             or "sparse" in api_yaml_path
         )
+        no_parse_python_api_info = "sparse" in api_yaml_path
 
         py_c_generator = PythonCGenerator(api_yaml_path)
-        py_c_generator.run(no_input_out_tensor)
+        py_c_generator.run(no_input_out_tensor, no_parse_python_api_info)
 
         generated_python_c_functions += (
             py_c_generator.python_c_functions_str + "\n"

--- a/paddle/fluid/pir/dialect/op_generator/python_c_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/python_c_gen.py
@@ -722,8 +722,10 @@ class PythonCCodeGen(CodeGen):
         need_check_params_count = False
         self.need_parse_python_api_args = False
         self.use_custom_args_mapper = False
-
-        if op_name in python_api_info_from_yaml.keys():
+        # Do not parse sparse op's python_api_info
+        if (
+            not op_info.is_sparse_op
+        ) and op_name in python_api_info_from_yaml.keys():
             python_api_info = python_api_info_from_yaml[op_name]
         if python_api_info is not None:
             self.need_parse_python_api_args = True

--- a/paddle/fluid/pybind/eager_utils.cc
+++ b/paddle/fluid/pybind/eager_utils.cc
@@ -196,10 +196,12 @@ phi::DataType StrDtype2TensorDtype(const std::string& np_dtype) {
 bool PyObject_CheckStr(PyObject* obj) { return PyUnicode_Check(obj); }
 
 bool PyObject_CheckIRValue(PyObject* obj) {
+  if (obj == nullptr) return false;
   return PyObject_TypeCheck(obj, g_ir_value_pytype);
 }
 
 bool PyObject_CheckIRVectorOfValue(PyObject* obj) {
+  if (obj == nullptr) return false;
   if (PyList_Check(obj)) {
     Py_ssize_t len = PyList_Size(obj);
     PyObject* item = nullptr;
@@ -235,6 +237,7 @@ bool PyObject_CheckIRVectorOfValue(PyObject* obj) {
 }
 
 bool PyObject_CheckIRVectorOfValueOrLong(PyObject* obj) {
+  if (obj == nullptr) return false;
   if (!PyList_Check(obj) && !PyTuple_Check(obj)) {
     return false;
   }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Operator Mechanism
### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes 
### Description
<!-- Describe what you’ve done -->
- 静态图中被解析为Value的attribute，在使用默认值时可能引起段错误。
```
MUTABLE_ATTR_LIST_TEMPLATE = """
        if (PyObject_CheckIRValue({name}_obj)){{
           {mutable_cast_attrs}
        }}else if (PyObject_CheckIRVectorOfValue({name}_obj)){{
           {mutable_vector_cast_attrs}
        }}else if (PyObject_CheckIRVectorOfValueOrLong({name}_obj)){{
           {mix_vector_cast_attrs}
        }}else{{
           {no_mutable_cast_attrs}
        }}"""

```
默认值的处理是在最后一个else，PyObject_CheckIRValue等类型检查函数遇到空指针可能会报段错误
- python_api_info.yaml 中描述的变量别名等信息不应该适用于sparse类型的api


pcard-67164