### PR TITLE
[API Compatibility][BUG Fix]  Compatible with paddle.norm and paddle.linalg.norm

### DIFF
--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -1184,7 +1184,6 @@ def norm(
     p: float | _POrder | None = None,
     axis: int | list[int] | tuple[int, int] | None = None,
     keepdim: bool = False,
-    *,
     out: paddle.Tensor | None = None,
     dtype: paddle._typing.DTypeLike | None = None,
     name: str | None = None,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

当前paddle.norm和paddle.linalg.norm对齐了torch.linalg.norm的函数签名，但是torch.norm的签名允许out和dtype直接赋值。这里对paddle.linalg的函数签名进行了一些调整，使其同时兼容torch.linalg.norm和torch.norm的签名。

pcard-71500