### PR TITLE
【FlexCP】fix memory bug

### DIFF
--- a/python/paddle/distributed/flex_checkpoint/dcp/load_state_dict.py
+++ b/python/paddle/distributed/flex_checkpoint/dcp/load_state_dict.py
@@ -1130,8 +1130,11 @@ def _load_state_dict(
                 or idx + 1 == len(read_items)
             ):
                 paddle.assign(
-                    copied_target_state_dict[key].cpu(), state_dict_in_cpu[key]
+                    copied_target_state_dict[key].cpu(), target_state_dict[key]
                 )
+                t = copied_target_state_dict[key]
+                copied_target_state_dict[key] = t.cpu()
+                del t
             idx = idx + 1
 
             if use_dist:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-67164

load_merge_state_dict 过程中将tensor拷贝到显存后没有及时释放，导致显存爆增

todo:
当前每处理一次数据就会同步给cpu, 然后再拷贝到gpu, 合并一个参数有几份就会构造几次显存，存在冗余