### PR TITLE
[PIR] Cleanup some PT usage in PIR uts

### DIFF
--- a/test/ir/pir/test_build_op.py
+++ b/test/ir/pir/test_build_op.py
@@ -22,20 +22,18 @@ paddle.enable_static()
 
 def get_ir_program():
     paddle.enable_static()
-    with paddle.pir_utils.OldIrGuard():
-        x = paddle.randn([4, 4])
-        main_program, start_program = (
-            paddle.static.Program(),
-            paddle.static.Program(),
-        )
-        with paddle.static.program_guard(main_program, start_program):
-            x_s = paddle.static.data('x', [4, 4], x.dtype)
-            x_s.stop_gradient = False
-            y_s = paddle.matmul(x_s, x_s)
-            y_s = paddle.add(x_s, y_s)
-            y_s = paddle.tanh(y_s)
-        pir_program = pir.translate_to_pir(main_program.desc)
-        return pir_program
+    x = paddle.randn([4, 4])
+    main_program, start_program = (
+        paddle.static.Program(),
+        paddle.static.Program(),
+    )
+    with paddle.static.program_guard(main_program, start_program):
+        x_s = paddle.static.data('x', [4, 4], x.dtype)
+        x_s.stop_gradient = False
+        y_s = paddle.matmul(x_s, x_s)
+        y_s = paddle.add(x_s, y_s)
+        y_s = paddle.tanh(y_s)
+    return main_program
 
 
 class TestBuildOp(unittest.TestCase):
@@ -101,7 +99,6 @@ class TestBuildOp3(unittest.TestCase):
                 out = paddle.mean(sum_out)
                 tanh_operand.set_source(out)
 
-            print(pir_program)
             self.assertEqual(
                 tanh_operand.source().get_defining_op().name(), "pd_op.mean"
             )
@@ -205,14 +202,14 @@ class TestGetValueByOpId(unittest.TestCase):
             )
             pred = paddle.less_than(y, x)
             out = paddle.static.nn.cond(pred, true_func, false_func)
-            value1 = main_program.get_value_by_op_id(69)
+            value1 = main_program.get_value_by_op_id(87)
             self.assertEqual(
                 out.get_defining_op().id(),
                 value1[0].get_defining_op().id(),
             )
-            value2 = main_program.get_value_by_op_id([58, 69])
+            value2 = main_program.get_value_by_op_id([58, 87])
             self.assertEqual(
-                69,
+                87,
                 value2[0].get_defining_op().id(),
             )
 

--- a/test/ir/pir/test_ir_pybind.py
+++ b/test/ir/pir/test_ir_pybind.py
@@ -22,22 +22,19 @@ paddle.enable_static()
 
 
 def get_ir_program():
-    with paddle.pir_utils.OldIrGuard():
-        x = paddle.randn([4, 4])
-        main_program, start_program = (
-            paddle.static.Program(),
-            paddle.static.Program(),
-        )
-        with paddle.static.program_guard(main_program, start_program):
-            x_s = paddle.static.data('x', [4, 4], x.dtype)
-            x_s.stop_gradient = False
-            y_s = paddle.matmul(x_s, x_s)
-            z_s = paddle.add(y_s, y_s)
-            k_s = paddle.tanh(z_s)
-            q_s = paddle.unsqueeze(k_s, [2])
-
-        pir_program = pir.translate_to_pir(main_program.desc)
-        return pir_program
+    x = paddle.randn([4, 4])
+    main_program, start_program = (
+        paddle.static.Program(),
+        paddle.static.Program(),
+    )
+    with paddle.static.program_guard(main_program, start_program):
+        x_s = paddle.static.data('x', [4, 4], x.dtype)
+        x_s.stop_gradient = False
+        y_s = paddle.matmul(x_s, x_s)
+        z_s = paddle.add(y_s, y_s)
+        k_s = paddle.tanh(z_s)
+        q_s = paddle.unsqueeze(k_s, [2])
+    return main_program
 
 
 class TestPybind(unittest.TestCase):
@@ -165,42 +162,40 @@ class TestPybind(unittest.TestCase):
         self.assertEqual(add_op.result(0).is_selected_row_type(), True)
 
     def test_attr(self):
-        with paddle.pir_utils.OldIrGuard():
-            main_program, start_program = (
-                paddle.static.Program(),
-                paddle.static.Program(),
+        main_program, start_program = (
+            paddle.static.Program(),
+            paddle.static.Program(),
+        )
+        with paddle.static.program_guard(main_program, start_program):
+            conv = paddle.nn.Conv2D(
+                in_channels=3,
+                out_channels=2,
+                kernel_size=3,
+                stride=3,
+                padding=0,
+                data_format="NCHW",
             )
-            with paddle.static.program_guard(main_program, start_program):
-                conv_data = paddle.static.data(
-                    'conv_data', [None, 3, 32, 32], dtype='float32'
-                )
-                conv2d_out = paddle.static.nn.conv2d(
-                    input=conv_data,
-                    num_filters=2,
-                    filter_size=3,
-                    stride=3,
-                    act="relu",
-                )
-                full_out = paddle.tensor.fill_constant(
-                    shape=[4, 4], dtype="float32", value=2
-                )
-
-            pir_program = pir.translate_to_pir(main_program.desc)
-            conv_attr = pir_program.global_block().ops[3].attrs()
-            full_attr = pir_program.global_block().ops[8].attrs()
-            self.assertEqual(conv_attr["stop_gradient"], [False])
-            self.assertEqual(conv_attr["dilations"], [1, 1])
-            self.assertEqual(conv_attr["data_format"], "NCHW")
-            self.assertEqual(conv_attr["strides"], [3, 3])
-            self.assertEqual(conv_attr["paddings"], [0, 0])
-            self.assertEqual(conv_attr["padding_algorithm"], "EXPLICIT")
-            self.assertEqual(conv_attr["groups"], 1)
-            self.assertEqual(
-                full_attr["dtype"], paddle.base.core.DataType.FLOAT32
+            conv_data = paddle.static.data(
+                'conv_data', [None, 3, 32, 32], dtype='float32'
             )
-            self.assertTrue(
-                isinstance(full_attr["place"], paddle.base.core.Place)
+            conv2d_out = conv(
+                conv_data,
             )
+            relu_out = paddle.nn.functional.relu(conv2d_out)
+            full_out = paddle.tensor.fill_constant(
+                shape=[4, 4], dtype="float32", value=2
+            )
+        conv_attr = main_program.global_block().ops[3].attrs()
+        full_attr = main_program.global_block().ops[8].attrs()
+        self.assertEqual(conv_attr["stop_gradient"], [False])
+        self.assertEqual(conv_attr["dilations"], [1, 1])
+        self.assertEqual(conv_attr["data_format"], "NCHW")
+        self.assertEqual(conv_attr["strides"], [3, 3])
+        self.assertEqual(conv_attr["paddings"], [0, 0])
+        self.assertEqual(conv_attr["padding_algorithm"], "EXPLICIT")
+        self.assertEqual(conv_attr["groups"], 1)
+        self.assertEqual(full_attr["dtype"], paddle.base.core.DataType.FLOAT32)
+        self.assertTrue(isinstance(full_attr["place"], paddle.base.core.Place))
 
     def test_operands(self):
         pir_program = get_ir_program()

--- a/test/ir/pir/test_ir_vjp.py
+++ b/test/ir/pir/test_ir_vjp.py
@@ -90,7 +90,6 @@ class TestTanhVjp(unittest.TestCase):
 
 class TestMeanVjp(unittest.TestCase):
     def test_mean_vjp1(self):
-        # with paddle.pir_utils.OldIrGuard():
         main_program, start_program = (
             paddle.static.Program(),
             paddle.static.Program(),

--- a/test/ir/pir/test_ir_vjp.py
+++ b/test/ir/pir/test_ir_vjp.py
@@ -15,27 +15,22 @@
 import unittest
 
 import paddle
-from paddle import pir
 from paddle.base.core import call_vjp, has_vjp
 
 paddle.enable_static()
 
 
 def get_ir_program():
-    with paddle.pir_utils.OldIrGuard():
-        main_program, start_program = (
-            paddle.static.Program(),
-            paddle.static.Program(),
-        )
-        with paddle.static.program_guard(main_program, start_program):
-            x = paddle.static.data('x', [4, 4], 'float32')
-            x.stop_gradient = False
-            paddle.tanh(x)
-            paddle.tensor.fill_constant(
-                shape=[4, 4], dtype='float32', value=2.0
-            )
-        pir_program = pir.translate_to_pir(main_program.desc)
-        return pir_program
+    main_program, start_program = (
+        paddle.static.Program(),
+        paddle.static.Program(),
+    )
+    with paddle.static.program_guard(main_program, start_program):
+        x = paddle.static.data('x', [4, 4], 'float32')
+        x.stop_gradient = False
+        paddle.tanh(x)
+        paddle.tensor.fill_constant(shape=[4, 4], dtype='float32', value=2.0)
+    return main_program
 
 
 class TestTanhVjp(unittest.TestCase):
@@ -95,24 +90,21 @@ class TestTanhVjp(unittest.TestCase):
 
 class TestMeanVjp(unittest.TestCase):
     def test_mean_vjp1(self):
-        with paddle.pir_utils.OldIrGuard():
-            main_program, start_program = (
-                paddle.static.Program(),
-                paddle.static.Program(),
-            )
-            with paddle.static.program_guard(main_program, start_program):
-                x = paddle.static.data('x', [4, 4], 'float32')
-                x.stop_gradient = False
-                paddle.mean(x, axis=[0, 1])
-                paddle.tensor.fill_constant(
-                    shape=[1], dtype='float32', value=2.0
-                )
-            pir_program = pir.translate_to_pir(main_program.desc)
-            fill_constant_op = pir_program.global_block().ops[-1]
-            mean_op = pir_program.global_block().ops[-2]
-            out_grads = [[fill_constant_op.result(0)]]
-            stop_gradients = [[False]]
-        with paddle.pir.core.program_guard(pir_program):
+        # with paddle.pir_utils.OldIrGuard():
+        main_program, start_program = (
+            paddle.static.Program(),
+            paddle.static.Program(),
+        )
+        with paddle.static.program_guard(main_program, start_program):
+            x = paddle.static.data('x', [4, 4], 'float32')
+            x.stop_gradient = False
+            paddle.mean(x, axis=[0, 1])
+            paddle.tensor.fill_constant(shape=[1], dtype='float32', value=2.0)
+        fill_constant_op = main_program.global_block().ops[-1]
+        mean_op = main_program.global_block().ops[-2]
+        out_grads = [[fill_constant_op.result(0)]]
+        stop_gradients = [[False]]
+        with paddle.pir.core.program_guard(main_program):
             grad_outs = call_vjp(
                 mean_op,
                 [[mean_op.operand_source(0)], [mean_op.operand_source(1)]],
@@ -141,27 +133,23 @@ class TestMeanVjp(unittest.TestCase):
                 .name(),
                 "pd_op.full",
             )
-            self.assertEqual(len(pir_program.global_block().ops), 5)
+            self.assertEqual(len(main_program.global_block().ops), 5)
 
     def test_mean_vjp2(self):
-        with paddle.pir_utils.OldIrGuard():
-            main_program, start_program = (
-                paddle.static.Program(),
-                paddle.static.Program(),
-            )
-            with paddle.static.program_guard(main_program, start_program):
-                x = paddle.static.data('x', [4, 4], 'float32')
-                x.stop_gradient = False
-                paddle.mean(x, axis=[0, 1])
-                paddle.tensor.fill_constant(
-                    shape=[1], dtype='float32', value=2.0
-                )
-            pir_program = pir.translate_to_pir(main_program.desc)
-            fill_constant_op = pir_program.global_block().ops[-1]
-            mean_op = pir_program.global_block().ops[-2]
-            out_grads = [[fill_constant_op.result(0)]]
-            stop_gradients = [[True]]
-        with paddle.pir.core.program_guard(pir_program):
+        main_program, start_program = (
+            paddle.static.Program(),
+            paddle.static.Program(),
+        )
+        with paddle.static.program_guard(main_program, start_program):
+            x = paddle.static.data('x', [4, 4], 'float32')
+            x.stop_gradient = False
+            paddle.mean(x, axis=[0, 1])
+            paddle.tensor.fill_constant(shape=[1], dtype='float32', value=2.0)
+        fill_constant_op = main_program.global_block().ops[-1]
+        mean_op = main_program.global_block().ops[-2]
+        out_grads = [[fill_constant_op.result(0)]]
+        stop_gradients = [[True]]
+        with paddle.pir.core.program_guard(main_program):
             grad_outs = call_vjp(
                 mean_op,
                 [[mean_op.operand_source(0)], [mean_op.operand_source(1)]],
@@ -174,23 +162,19 @@ class TestMeanVjp(unittest.TestCase):
 
 class TesthasVjp(unittest.TestCase):
     def test_has_vjp(self):
-        with paddle.pir_utils.OldIrGuard():
-            main_program, start_program = (
-                paddle.static.Program(),
-                paddle.static.Program(),
-            )
-            with paddle.static.program_guard(main_program, start_program):
-                x = paddle.static.data('x', [4, 4], 'float32')
-                x.stop_gradient = False
-                paddle.mean(x, axis=[0, 1])
-                paddle.tensor.fill_constant(
-                    shape=[1], dtype='float32', value=2.0
-                )
-            pir_program = pir.translate_to_pir(main_program.desc)
-            fill_constant_op = pir_program.global_block().ops[-1]
-            mean_op = pir_program.global_block().ops[-2]
-            self.assertEqual(has_vjp(fill_constant_op), False)
-            self.assertEqual(has_vjp(mean_op), True)
+        main_program, start_program = (
+            paddle.static.Program(),
+            paddle.static.Program(),
+        )
+        with paddle.static.program_guard(main_program, start_program):
+            x = paddle.static.data('x', [4, 4], 'float32')
+            x.stop_gradient = False
+            paddle.mean(x, axis=[0, 1])
+            paddle.tensor.fill_constant(shape=[1], dtype='float32', value=2.0)
+        fill_constant_op = main_program.global_block().ops[-1]
+        mean_op = main_program.global_block().ops[-2]
+        self.assertEqual(has_vjp(fill_constant_op), False)
+        self.assertEqual(has_vjp(mean_op), True)
 
 
 if __name__ == "__main__":

--- a/test/prim/pir_prim/test_batch_norm_shape_check.py
+++ b/test/prim/pir_prim/test_batch_norm_shape_check.py
@@ -17,7 +17,6 @@ import unittest
 import numpy as np
 
 import paddle
-from paddle import pir
 from paddle.decomposition import decompose
 from paddle.framework import core
 
@@ -48,23 +47,21 @@ class TestBuildOp(unittest.TestCase):
 
     def get_ir_program(self):
         paddle.enable_static()
-        with paddle.pir_utils.OldIrGuard():
-            x = paddle.randn([4, 4])
-            main_program, start_program = (
-                paddle.static.Program(),
-                paddle.static.Program(),
-            )
-            with paddle.static.program_guard(main_program, start_program):
-                x = paddle.static.data('x', self.x_shape, x.dtype)
-                x.stop_gradients = False
-                r_m = paddle.static.data('r_m', self.c_shape, x.dtype)
-                r_v = paddle.static.data('r_v', self.c_shape, x.dtype)
-                w = paddle.static.data('w', self.c_shape, x.dtype)
-                b = paddle.static.data('b', self.c_shape, x.dtype)
-                y = batch_norm_net1(x, r_m, r_v, w, b)
-                res = paddle.tanh(y)
-            pir_program = pir.translate_to_pir(main_program.desc)
-            return pir_program
+        x = paddle.randn([4, 4])
+        main_program, start_program = (
+            paddle.static.Program(),
+            paddle.static.Program(),
+        )
+        with paddle.static.program_guard(main_program, start_program):
+            x = paddle.static.data('x', self.x_shape, x.dtype)
+            x.stop_gradient = False
+            r_m = paddle.static.data('r_m', self.c_shape, x.dtype)
+            r_v = paddle.static.data('r_v', self.c_shape, x.dtype)
+            w = paddle.static.data('w', self.c_shape, x.dtype)
+            b = paddle.static.data('b', self.c_shape, x.dtype)
+            y = batch_norm_net1(x, r_m, r_v, w, b)
+            res = paddle.tanh(y)
+        return main_program
 
     def test_build_op(self):
         pir_program = self.get_ir_program()

--- a/test/prim/pir_prim/test_custom_vjp_trait.py
+++ b/test/prim/pir_prim/test_custom_vjp_trait.py
@@ -15,38 +15,34 @@
 import unittest
 
 import paddle
-from paddle import nn, pir
+from paddle import nn
 from paddle.base.core import has_custom_vjp
 
 paddle.enable_static()
 
 
 def get_gelu_program_pir():
-    with paddle.pir_utils.OldIrGuard():
-        main_program, start_program = (
-            paddle.static.Program(),
-            paddle.static.Program(),
-        )
-        with paddle.static.program_guard(main_program, start_program):
-            x = paddle.static.data('x', [2, 3, 3], dtype='float32')
-            net = nn.GELU()
-            out = net(x)
-        pir_program = pir.translate_to_pir(main_program.desc)
-        return pir_program
+    main_program, start_program = (
+        paddle.static.Program(),
+        paddle.static.Program(),
+    )
+    with paddle.static.program_guard(main_program, start_program):
+        x = paddle.static.data('x', [2, 3, 3], dtype='float32')
+        net = nn.GELU()
+        out = net(x)
+    return main_program
 
 
 def get_multiply_program_pir():
-    with paddle.pir_utils.OldIrGuard():
-        main_program, start_program = (
-            paddle.static.Program(),
-            paddle.static.Program(),
-        )
-        with paddle.static.program_guard(main_program, start_program):
-            x = paddle.static.data('x', [2, 3, 3], dtype='float32')
-            y = paddle.static.data('y', [2, 3, 3], dtype='float32')
-            out = paddle.multiply(x, y)
-        pir_program = pir.translate_to_pir(main_program.desc)
-        return pir_program
+    main_program, start_program = (
+        paddle.static.Program(),
+        paddle.static.Program(),
+    )
+    with paddle.static.program_guard(main_program, start_program):
+        x = paddle.static.data('x', [2, 3, 3], dtype='float32')
+        y = paddle.static.data('y', [2, 3, 3], dtype='float32')
+        out = paddle.multiply(x, y)
+    return main_program
 
 
 class TestCustomVjpTrait(unittest.TestCase):

--- a/test/prim/pir_prim/test_decomp_op.py
+++ b/test/prim/pir_prim/test_decomp_op.py
@@ -15,7 +15,6 @@
 import unittest
 
 import paddle
-from paddle import pir
 from paddle.decomposition import decompose
 from paddle.framework import core
 
@@ -24,26 +23,25 @@ paddle.enable_static()
 
 def get_ir_program():
     paddle.enable_static()
-    with paddle.pir_utils.OldIrGuard():
-        x = paddle.randn([4, 4])
-        main_program, start_program = (
-            paddle.static.Program(),
-            paddle.static.Program(),
-        )
-        with paddle.static.program_guard(main_program, start_program):
-            x_s = paddle.static.data('x', [4, 4], x.dtype)
-            x_s.stop_gradient = False
-            y_s = paddle.matmul(x_s, x_s)
-            y_s = paddle.add(x_s, y_s)
-            y_s = paddle.mean(y_s)
-            y_s = paddle.tanh(y_s)
-        pir_program = pir.translate_to_pir(main_program.desc)
+    x = paddle.randn([4, 4])
+    main_program, start_program = (
+        paddle.static.Program(),
+        paddle.static.Program(),
+    )
+    with paddle.static.program_guard(main_program, start_program):
+        x_s = paddle.static.data('x', [4, 4], x.dtype)
+        x_s.stop_gradient = False
+        y_s = paddle.matmul(x_s, x_s)
+        y_s = paddle.add(x_s, y_s)
+        y_s = paddle.mean(y_s)
+        y_s = paddle.tanh(y_s)
+    pir_program = main_program
 
-        all_ops = pir_program.global_block().ops
-        for op in all_ops:
-            op.op_role = 1
+    all_ops = pir_program.global_block().ops
+    for op in all_ops:
+        op.op_role = 1
 
-        return pir_program
+    return pir_program
 
 
 class TestBuildOp(unittest.TestCase):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Deprecations

### Description
<!-- Describe what you’ve done -->

#74945 发现有一些早期 PIR 组网还不完善时期，为了验证 PIR 组件，使用老 IR 组网后 PT 转换为 PIR 来验证的单测，之前这些 case 直接使用了 OldIrGuard，为避免被误删，本 PR 统一将相关单测调整为纯 PIR 组网，这些单测还是有意义的，应当保留

<!-- PCard-66972 -->