### PR TITLE
use phi::complex64 in as_real_kernel to reduce code [fluid_ops]

### DIFF
--- a/paddle/phi/kernels/cpu/as_real_kernel.cc
+++ b/paddle/phi/kernels/cpu/as_real_kernel.cc
@@ -19,10 +19,11 @@
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/impl/as_real_impl.h"
 
-using complex64 = ::phi::dtype::complex<float>;
-using complex128 = ::phi::dtype::complex<double>;
-
-PD_REGISTER_KERNEL(
-    as_real, CPU, ALL_LAYOUT, phi::AsRealKernel, complex64, complex128) {
+PD_REGISTER_KERNEL(as_real,
+                   CPU,
+                   ALL_LAYOUT,
+                   phi::AsRealKernel,
+                   phi::complex64,
+                   phi::complex128) {
   kernel->OutputAt(0).SetDataType(phi::DataType::UNDEFINED);
 }

--- a/paddle/phi/kernels/cpu/dot_kernel.cc
+++ b/paddle/phi/kernels/cpu/dot_kernel.cc
@@ -61,9 +61,6 @@ void DotKernel(const Context& dev_ctx,
 
 }  // namespace phi
 
-using complex64 = ::phi::dtype::complex<float>;
-using complex128 = ::phi::dtype::complex<double>;
-
 PD_REGISTER_KERNEL(dot,
                    CPU,
                    ALL_LAYOUT,
@@ -72,5 +69,5 @@ PD_REGISTER_KERNEL(dot,
                    double,
                    int,
                    int64_t,
-                   complex64,
-                   complex128) {}
+                   phi::complex64,
+                   phi::complex128) {}

--- a/paddle/phi/kernels/cpu/reduce_all_kernel.cc
+++ b/paddle/phi/kernels/cpu/reduce_all_kernel.cc
@@ -20,9 +20,6 @@
 #include "paddle/phi/kernels/cpu/reduce.h"
 #include "paddle/phi/kernels/funcs/reduce_functor.h"
 
-using complex64 = ::phi::dtype::complex<float>;
-using complex128 = ::phi::dtype::complex<double>;
-
 namespace phi {
 
 template <typename T, typename Context>
@@ -48,7 +45,7 @@ PD_REGISTER_KERNEL(all_raw,
                    int,
                    int64_t,
                    bool,
-                   complex64,
-                   complex128) {
+                   phi::complex64,
+                   phi::complex128) {
   kernel->OutputAt(0).SetDataType(phi::DataType::BOOL);
 }

--- a/paddle/phi/kernels/cpu/reduce_any_kernel.cc
+++ b/paddle/phi/kernels/cpu/reduce_any_kernel.cc
@@ -22,9 +22,6 @@
 #include "paddle/phi/kernels/cpu/reduce.h"
 #include "paddle/phi/kernels/funcs/reduce_functor.h"
 
-using complex64 = ::phi::dtype::complex<float>;
-using complex128 = ::phi::dtype::complex<double>;
-
 namespace phi {
 
 template <typename T, typename Context>
@@ -50,7 +47,7 @@ PD_REGISTER_KERNEL(any_raw,
                    int,
                    int64_t,
                    bool,
-                   complex64,
-                   complex128) {
+                   phi::complex64,
+                   phi::complex128) {
   kernel->OutputAt(0).SetDataType(phi::DataType::BOOL);
 }

--- a/paddle/phi/kernels/cpu/reduce_sum_kernel.cc
+++ b/paddle/phi/kernels/cpu/reduce_sum_kernel.cc
@@ -95,9 +95,6 @@ void SumRawKernel(const Context& dev_ctx,
 
 }  // namespace phi
 
-using complex64 = ::phi::dtype::complex<float>;
-using complex128 = ::phi::dtype::complex<double>;
-
 PD_REGISTER_KERNEL(sum_raw,
                    CPU,
                    ALL_LAYOUT,
@@ -112,7 +109,7 @@ PD_REGISTER_KERNEL(sum_raw,
                    uint8_t,
                    int,
                    int64_t,
-                   complex64,
-                   complex128) {
+                   phi::complex64,
+                   phi::complex128) {
   kernel->OutputAt(0).SetDataType(phi::DataType::UNDEFINED);
 }

--- a/paddle/phi/kernels/legacy/gpu/int_bincount.cu
+++ b/paddle/phi/kernels/legacy/gpu/int_bincount.cu
@@ -96,7 +96,7 @@ void IntBincount(const Context &dev_ctx,
 
   auto bins_dtype = TransToDataType(out_dtype);
 
-  // auto x_dytpe = x.dtype();
+  // auto x_dtype = x.dtype();
   auto low_v = static_cast<T>(low);
   auto high_v = static_cast<T>(high);
   PD_CHECK(static_cast<int64_t>(low_v) == low);

--- a/paddle/phi/kernels/legacy/gpu/moe_ops_partial_nosoftmaxtopk_grad_kernel.cu
+++ b/paddle/phi/kernels/legacy/gpu/moe_ops_partial_nosoftmaxtopk_grad_kernel.cu
@@ -62,7 +62,7 @@ void apply_moe_dispatch_bwd(const T* y_grad,
   // topk_grad_with_mask_launcher<float>(combine_weights_grad,
   //                                     expert_id,
   //                                     combine_weights,
-  //                                     gate_logtis_grad,
+  //                                     gate_logits_grad,
   //                                     num_rows, k, num_experts, stream);
 }
 

--- a/paddle/phi/kernels/reduce_sum_kernel.cc
+++ b/paddle/phi/kernels/reduce_sum_kernel.cc
@@ -34,9 +34,6 @@ void SumKernel(const Context& dev_ctx,
 
 }  // namespace phi
 
-using complex64 = ::phi::dtype::complex<float>;
-using complex128 = ::phi::dtype::complex<double>;
-
 PD_REGISTER_KERNEL(sum,
                    CPU,
                    ALL_LAYOUT,
@@ -51,8 +48,8 @@ PD_REGISTER_KERNEL(sum,
                    int64_t,
                    uint8_t,
                    int8_t,
-                   complex64,
-                   complex128) {
+                   phi::complex64,
+                   phi::complex128) {
   kernel->OutputAt(0).SetDataType(phi::DataType::UNDEFINED);
 }
 
@@ -71,8 +68,8 @@ PD_REGISTER_KERNEL(sum,
                    int64_t,
                    uint8_t,
                    int8_t,
-                   complex64,
-                   complex128) {
+                   phi::complex64,
+                   phi::complex128) {
   kernel->OutputAt(0).SetDataType(phi::DataType::UNDEFINED);
 }
 #endif

--- a/paddle/phi/kernels/selected_rows/elementwise_multiply_kernel.cc
+++ b/paddle/phi/kernels/selected_rows/elementwise_multiply_kernel.cc
@@ -54,9 +54,6 @@ void MultiplyKernel(const Context& dev_ctx,
 
 }  // namespace phi::sr
 
-using complex64 = ::phi::dtype::complex<float>;
-using complex128 = ::phi::dtype::complex<double>;
-
 PD_REGISTER_KERNEL(multiply_raw_sr,
                    CPU,
                    ALL_LAYOUT,
@@ -66,9 +63,9 @@ PD_REGISTER_KERNEL(multiply_raw_sr,
                    int,
                    int64_t,
                    bool,
-                   phi::dtype::bfloat16,
-                   complex64,
-                   complex128) {}
+                   phi::bfloat16,
+                   phi::complex64,
+                   phi::complex128) {}
 PD_REGISTER_KERNEL(multiply_sr,
                    CPU,
                    ALL_LAYOUT,
@@ -78,9 +75,9 @@ PD_REGISTER_KERNEL(multiply_sr,
                    int,
                    int64_t,
                    bool,
-                   phi::dtype::bfloat16,
-                   complex64,
-                   complex128) {}
+                   phi::bfloat16,
+                   phi::complex64,
+                   phi::complex128) {}
 
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
 PD_REGISTER_KERNEL(multiply_raw_sr,
@@ -92,10 +89,10 @@ PD_REGISTER_KERNEL(multiply_raw_sr,
                    int,
                    int64_t,
                    bool,
-                   phi::dtype::bfloat16,
-                   phi::dtype::float16,
-                   complex64,
-                   complex128) {}
+                   phi::bfloat16,
+                   phi::float16,
+                   phi::complex64,
+                   phi::complex128) {}
 PD_REGISTER_KERNEL(multiply_sr,
                    GPU,
                    ALL_LAYOUT,
@@ -105,8 +102,8 @@ PD_REGISTER_KERNEL(multiply_sr,
                    int,
                    int64_t,
                    bool,
-                   phi::dtype::bfloat16,
-                   phi::dtype::float16,
-                   complex64,
-                   complex128) {}
+                   phi::bfloat16,
+                   phi::float16,
+                   phi::complex64,
+                   phi::complex128) {}
 #endif

--- a/paddle/phi/kernels/xpu/as_real_kernel.cc
+++ b/paddle/phi/kernels/xpu/as_real_kernel.cc
@@ -21,7 +21,6 @@
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/core/tensor_utils.h"
 
-using complex64 = ::phi::dtype::complex<float>;
 namespace phi {
 
 template <typename T, typename Context>
@@ -39,7 +38,8 @@ void AsRealKernel(const Context& dev_ctx,
 
 }  // namespace phi
 
-PD_REGISTER_KERNEL(as_real, XPU, ALL_LAYOUT, phi::AsRealKernel, complex64) {
+PD_REGISTER_KERNEL(
+    as_real, XPU, ALL_LAYOUT, phi::AsRealKernel, phi::complex64) {
   kernel->OutputAt(0).SetDataType(phi::DataType::UNDEFINED);
 }
 #endif  // PADDLE_WITH_XPU_FFT


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
use phi::complex64 in as_real_kernel to reduce code