### PR TITLE
[PHI] CPU scatter/gather with fast CoordinateManager

### DIFF
--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/binary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/binary_infer_sym.cc
@@ -2226,11 +2226,11 @@ bool TakeAlongAxisOpInferSymbolicShape(
   const auto &out_sym_shape = [&] {
     std::vector<symbol::DimExpr> out_sym_shape;
     for (int i = 0; i < axis; ++i) {
-      out_sym_shape.push_back(arr_sym_shape[i]);
+      out_sym_shape.push_back(indices_sym_shape[i]);
     }
     out_sym_shape.push_back(indices_sym_shape[axis]);
     for (size_t i = axis + 1; i < arr_sym_shape.size(); ++i) {
-      out_sym_shape.push_back(arr_sym_shape[i]);
+      out_sym_shape.push_back(indices_sym_shape[i]);
     }
     return out_sym_shape;
   }();

--- a/paddle/phi/kernels/funcs/gather_scatter_functor.cc
+++ b/paddle/phi/kernels/funcs/gather_scatter_functor.cc
@@ -13,10 +13,9 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 #include "paddle/phi/kernels/funcs/gather_scatter_functor.h"
-
 #include "glog/logging.h"
-
 #include "paddle/common/macros.h"
+#include "paddle/phi/kernels/funcs/math_function.h"
 
 namespace phi::funcs {
 
@@ -65,6 +64,176 @@ class ReduceMin {
 };
 static ReduceMin reduce_min;
 
+/**
+ * A divmod free solution for faster offset mapping. This class only do the
+ * necessary multiplication, therefore the computation and memory access should
+ * be lower than divmod and naive index mapping. Usage:
+ *
+ * \code
+ * CoordinateManager<true> cm(index_shape, self_strides, ndim,
+ * axis_to_put, &src_strides);
+ *
+ * for (int i = 0; i < index_shape.numel(); i++) {
+ *    index_t index = index_data[i];
+ *    cm.CalculateOffset(index_t);
+ *    int64_t replace_self_index = cm.offset1;
+ *    int64_t replace_src_index = cm.offset2;
+ *    ...
+ * }
+ * \endcode
+ */
+template <bool compute_both = false>
+class CoordinateManager {
+ private:
+  const phi::DDim& shape;
+  const phi::DDim& strides1;
+  const int ndim;
+  const int src_dim;
+  int64_t last_offset;
+  std::vector<int64_t> indices;
+  const phi::DDim* strides2;
+
+ public:
+  int64_t offset1;
+  int64_t offset2;
+
+  CoordinateManager(const phi::DDim& _shape,
+                    const phi::DDim& _strides1,
+                    int _ndim,
+                    int _src_dim,
+                    const phi::DDim* _strides2 = nullptr)
+      : shape(_shape),
+        strides1(_strides1),
+        ndim(_ndim),
+        src_dim(_src_dim),
+        last_offset(0),
+        strides2(_strides2),
+        offset1(0),
+        offset2(0) {
+    indices.resize(ndim, 0);
+    // calculate correct starting offsets
+    if (ndim - 1 != _src_dim) offset1 = -strides1[ndim - 1];
+    if constexpr (compute_both) offset2 = -strides2->operator[](ndim - 1);
+  }
+
+  template <typename index_t>
+  void CalculateOffset(index_t index) {
+    int change_dim = ndim - 1;
+    // step 1: calculate the carry or borrow dim
+    for (int dim = ndim - 1; dim > 0; dim--) {
+      if (indices[dim] >= shape[dim]) {
+        indices[dim] = 0;
+        change_dim = dim - 1;
+        // carry or borrow operation: we do not check boundaries here, please
+        // make sure that do not call map_offset more than index.numel(),
+        // otherwise we will have illegal access
+        ++indices[change_dim];
+      }
+    }
+
+    // step 2: update the axis to put/take offset
+    offset1 -= last_offset;
+    last_offset = index * strides1[src_dim];
+    offset1 += last_offset;
+
+    // step 3: clear the offset due to carry using minimum number of `mul`s.
+    // skip all src_dim related computation, since they have independent
+    // logics. Also, if strides2 (compute both) is available, compute the
+    // offset (usually for src tensor).
+
+    if (change_dim != src_dim) offset1 += strides1[change_dim];
+    if constexpr (compute_both) offset2 += strides2->operator[](change_dim);
+    for (int dim = change_dim + 1; dim < ndim; dim++) {
+      int dim_max_index = shape[dim] - 1;
+      // clear the tail elements after the carrying dim
+      if constexpr (compute_both)
+        offset2 -= strides2->operator[](dim) * dim_max_index;
+      if (dim == src_dim) continue;
+      offset1 -= strides1[dim] * dim_max_index;
+    }
+    ++indices.back();
+  }
+};
+
+/**
+ * Used in some of the value grad calculation, since those compute indices in a
+ * back-to-front order. Decide not to fuse with CoordinateManager via
+ * templating, otherwise the readability will be bad.
+ */
+template <bool compute_both = false>
+class ReversedCoordinateManager {
+ private:
+  const phi::DDim& shape;
+  const phi::DDim& strides1;
+  const int ndim;
+  const int src_dim;
+  int64_t last_offset;
+  std::vector<int64_t> indices;
+  const phi::DDim* strides2;
+
+ public:
+  int64_t offset1;
+  int64_t offset2;
+
+  ReversedCoordinateManager(const phi::DDim& _shape,
+                            const phi::DDim& _strides1,
+                            int _ndim,
+                            int _src_dim,
+                            const phi::DDim* _strides2 = nullptr)
+      : shape(_shape),
+        strides1(_strides1),
+        ndim(_ndim),
+        src_dim(_src_dim),
+        last_offset(0),
+        strides2(_strides2),
+        offset1(0),
+        offset2(0) {
+    indices.resize(ndim, 0);
+    // reversed should have an extra stride.back()
+    if (ndim - 1 != _src_dim) offset1 = strides1[ndim - 1];
+    if constexpr (compute_both) offset2 = strides2->operator[](ndim - 1);
+    for (int i = 0; i < _ndim; i++) {
+      indices[i] = _shape[i] - 1;
+      if constexpr (compute_both)
+        offset2 += strides2->operator[](i) * indices[i];
+      if (i == src_dim) continue;
+      offset1 += strides1[i] * indices[i];
+    }
+  }
+
+  template <typename index_t>
+  void CalculateOffset(index_t index) {
+    int change_dim = ndim - 1;
+    // step 1: calculate the borrow dim
+    for (int dim = ndim - 1; dim > 0; dim--) {
+      if (indices[dim] < 0) {
+        indices[dim] = shape[dim] - 1;
+        change_dim = dim - 1;
+        --indices[change_dim];
+      }
+    }
+
+    // step 2: update the axis to put/take offset
+    offset1 -= last_offset;
+    last_offset = index * strides1[src_dim];
+    offset1 += last_offset;
+
+    // step 3: clear the offset due to borrow using minimum number of `mul`s.
+
+    if (change_dim != src_dim) offset1 -= strides1[change_dim];
+    if constexpr (compute_both) offset2 -= strides2->operator[](change_dim);
+    for (int dim = change_dim + 1; dim < ndim; dim++) {
+      int dim_max_index = shape[dim] - 1;
+      // clear the tail elements after the carrying dim
+      if constexpr (compute_both)
+        offset2 += strides2->operator[](dim) * dim_max_index;
+      if (dim == src_dim) continue;
+      offset1 += strides1[dim] * dim_max_index;
+    }
+    --indices.back();
+  }
+};
+
 template <typename tensor_t,
           typename index_t = int64_t,
           bool is_scatter_like = true>
@@ -88,143 +257,93 @@ struct cpu_gather_scatter_functor {
     int64_t index_size = index.numel();
     int64_t src_size = src.numel();
     auto self_dims = self.dims();
-    auto index_dims = index.dims();
     auto src_dims = src.dims();
+
+    const bool is_gather_or_scatter_assign =
+        method_name == "gather" || method_name == "assign";
+
     if (self_size == 0 || src_size == 0 || index_size == 0) {
       VLOG(3) << "zero size input found";
       common::errors::InvalidArgument(
           "self_size, src_size, index_size cannot be 0");
       return;
     }
-    int64_t select_dim_size = index_dims[dim];
-    // index matrix has different shape with self matrix or src matrix.
     int self_select_dim_size = self_dims[dim];
     int src_select_dim_size = src_dims[dim];
-    int64_t outer_dim_size_self = 1;
-    int64_t outer_dim_size_src = 1;
-    int64_t inner_dim_size = 1;
-    int64_t outer_dim_size = 1;
-    for (int i = 0; i < dim; ++i) {
-      inner_dim_size *= index_dims[i];
-    }
 
-    for (int i = dim + 1; i < index_dims.size(); i++) {
-      outer_dim_size *= index_dims[i];
-      outer_dim_size_self *= self_dims[i];
-      outer_dim_size_src *= src_dims[i];
-    }
-    int64_t index_idx = 0;
-    std::vector<int> nums_of_elements(self.numel(), 0);
-    // N layer loop squeezed into 3 layers loop
-    for (int64_t i = 0; i < inner_dim_size; i++) {
-      for (int64_t j = 0; j < select_dim_size; j++) {
-        for (int64_t k = 0; k < outer_dim_size; k++) {
-          int64_t index = index_data[index_idx];
+    // gather and assign do not need nums_of_elements
+    std::vector<int> nums_of_elements;
+    if (!is_gather_or_scatter_assign) nums_of_elements.resize(self.numel(), 0);
 
-          /*
-            gather computation formula:
+    const int ndim = index.dims().size();
 
-            self[i][j][k] = src[index[i][j][k]][j][k]  # if dim == 0
-            self[i][j][k] = src[i][index[i][j][k]][k]  # if dim == 1
-            self[i][j][k] = src[i][j][index[i][j][k]]  # if dim == 2
+    CoordinateManager<is_scatter_like> cm(
+        index.dims(),
+        is_scatter_like ? self.strides() : src.strides(),
+        ndim,
+        dim,
+        &src.strides());
 
-            scatter computation formula:
+    for (int64_t i = 0; i < index_size; i++) {
+      int64_t index = index_data[i];
 
-            self[index[i][j][k]][j][k] = src[i][j][k]  # if dim == 0
-            self[i][index[i][j][k]][k] = src[i][j][k]  # if dim == 1
-            self[i][j][index[i][j][k]] = src[i][j][k]  # if dim == 2
-
-          */
-
-          // This index might out of bound of index matrix's index, so here
-          // multiply the replaced_select_dim_size.
-          int64_t replace_index_self, replace_index_src;
-          if (is_scatter_like) {
-            // scatter
-            PADDLE_ENFORCE_GE(
-                index,
+      int64_t replace_index_self = 0, replace_index_src = 0;
+      // offset1 is always related to index
+      if constexpr (is_scatter_like) {
+        PADDLE_ENFORCE_EQ(
+            (index >= -self_select_dim_size) && (index < self_select_dim_size),
+            true,
+            common::errors::OutOfRange(
+                "Variable value (index) of scatter cpu kernel, "
+                "expected >= %d and < %d, but got %ld."
+                "Please check the input value.",
                 -self_select_dim_size,
-                common::errors::OutOfRange(
-                    "Variable value (index) of OP(take_along_axis) "
-                    "expected >= %d and < %d, but got %ld."
-                    "Please check the input "
-                    "value.",
-                    -self_select_dim_size,
-                    self_select_dim_size,
-                    index));
-            PADDLE_ENFORCE_LT(
-                index,
                 self_select_dim_size,
-                common::errors::OutOfRange(
-                    "Variable value (index) of OP(take_along_axis) "
-                    "expected >= %d and < %d, but got %ld."
-                    "Please check the input "
-                    "value.",
-                    -self_select_dim_size,
-                    self_select_dim_size,
-                    index));
-            if (index < 0) {
-              index += self_select_dim_size;
-            }
-            replace_index_self = k + index * outer_dim_size_self +
-                                 i * outer_dim_size_self * self_select_dim_size;
-
-            replace_index_src = k + j * outer_dim_size_src +
-                                i * outer_dim_size_src * src_select_dim_size;
-          } else {
-            // gather
-            PADDLE_ENFORCE_GE(
-                index,
+                index));
+        if (index < 0) index += self_select_dim_size;
+        cm.CalculateOffset(index);
+        replace_index_self = cm.offset1;
+        replace_index_src = cm.offset2;
+      } else {
+        PADDLE_ENFORCE_EQ(
+            (index >= -src_select_dim_size) && (index < src_select_dim_size),
+            true,
+            common::errors::OutOfRange(
+                "Variable value (index) of gather cpu kernel, "
+                "expected >= %d and < %d, but got %ld."
+                "Please check the input value.",
                 -src_select_dim_size,
-                common::errors::OutOfRange(
-                    "Variable value (index) of OP(take_along_axis) "
-                    "expected >= %ld and < %ld, but got %ld. "
-                    "Please check the input "
-                    "value.",
-                    -src_select_dim_size,
-                    src_select_dim_size,
-                    index));
-            PADDLE_ENFORCE_LT(
-                index,
                 src_select_dim_size,
-                common::errors::OutOfRange(
-                    "Variable value (index) of OP(take_along_axis) "
-                    "expected >= %ld and < %ld, but got %ld. "
-                    "Please check the input "
-                    "value.",
-                    -src_select_dim_size,
-                    src_select_dim_size,
-                    index));
-            if (index < 0) {
-              index += src_select_dim_size;
-            }
-            replace_index_self = index_idx;
-
-            replace_index_src = k + index * outer_dim_size_src +
-                                i * outer_dim_size_src * src_select_dim_size;
-          }
-          if (include_self == false &&
-              nums_of_elements[replace_index_self] == 0) {
-            self_data[replace_index_self] = src_data[replace_index_src];
-          } else {
-            reduce_op((tensor_t*)(self_data + replace_index_self),  // NOLINT
-                      (tensor_t*)(src_data + replace_index_src));   // NOLINT
-          }
-          nums_of_elements[replace_index_self] += 1;
-          index_idx++;
-        }
+                index));
+        if (index < 0) index += src_select_dim_size;
+        cm.CalculateOffset(index);
+        replace_index_self = i;
+        replace_index_src = cm.offset1;
       }
+
+      if (include_self == false && is_gather_or_scatter_assign == false &&
+          nums_of_elements[replace_index_self] == 0) {
+        self_data[replace_index_self] = src_data[replace_index_src];
+      } else {
+        reduce_op((tensor_t*)(self_data + replace_index_self),  // NOLINT
+                  (tensor_t*)(src_data + replace_index_src));   // NOLINT
+      }
+      if (!is_gather_or_scatter_assign)
+        nums_of_elements[replace_index_self] += 1;
     }
-    if (method_name == "scatter_mean_cpu") {
-      for (int i = 0; i < self_size; i++) {
-        if (nums_of_elements[i]) {
-          if (include_self) {
-            self_data[i] =
-                self_data[i] / static_cast<tensor_t>(nums_of_elements[i] + 1);
-          } else {
-            self_data[i] =
-                self_data[i] / static_cast<tensor_t>(nums_of_elements[i]);
-          }
+
+    if (method_name == "mean") {
+      if (include_self) {
+        for (int i = 0; i < self_size; i++) {
+          if (!nums_of_elements[i]) continue;
+          self_data[i] =
+              self_data[i] / static_cast<tensor_t>(nums_of_elements[i] + 1);
+        }
+      } else {
+        for (int i = 0; i < self_size; i++) {
+          if (!nums_of_elements[i]) continue;
+          self_data[i] =
+              self_data[i] / static_cast<tensor_t>(nums_of_elements[i]);
         }
       }
     }
@@ -240,14 +359,8 @@ void cpu_gather_kernel(phi::DenseTensor self,
                        const phi::DeviceContext& dev_ctx) {
   cpu_gather_scatter_functor<tensor_t,
                              index_t,
-                             /*is_scatter_like=*/false>()(result,
-                                                          dim,
-                                                          index,
-                                                          self,
-                                                          "gather_out_cpu",
-                                                          tensor_assign,
-                                                          include_self,
-                                                          dev_ctx);
+                             /*is_scatter_like=*/false>()(
+      result, dim, index, self, "gather", tensor_assign, include_self, dev_ctx);
 }
 
 template <typename tensor_t, typename index_t>
@@ -259,14 +372,8 @@ void cpu_scatter_assign_kernel(phi::DenseTensor self,
                                const phi::DeviceContext& dev_ctx) {
   cpu_gather_scatter_functor<tensor_t,
                              index_t,
-                             /*is_scatter_like=*/true>()(self,
-                                                         dim,
-                                                         index,
-                                                         src,
-                                                         "scatter_assign_cpu",
-                                                         tensor_assign,
-                                                         include_self,
-                                                         dev_ctx);
+                             /*is_scatter_like=*/true>()(
+      self, dim, index, src, "assign", tensor_assign, include_self, dev_ctx);
 }
 
 template <typename tensor_t, typename index_t>
@@ -278,14 +385,8 @@ void cpu_scatter_add_kernel(phi::DenseTensor self,
                             const phi::DeviceContext& dev_ctx) {
   cpu_gather_scatter_functor<tensor_t,
                              index_t,
-                             /*is_scatter_like=*/true>()(self,
-                                                         dim,
-                                                         index,
-                                                         src,
-                                                         "scatter_add_cpu",
-                                                         reduce_add,
-                                                         include_self,
-                                                         dev_ctx);
+                             /*is_scatter_like=*/true>()(
+      self, dim, index, src, "add", reduce_add, include_self, dev_ctx);
 }
 
 template <typename tensor_t, typename index_t>
@@ -297,14 +398,8 @@ void cpu_scatter_mul_kernel(phi::DenseTensor self,
                             const phi::DeviceContext& dev_ctx) {
   cpu_gather_scatter_functor<tensor_t,
                              index_t,
-                             /*is_scatter_like=*/true>()(self,
-                                                         dim,
-                                                         index,
-                                                         src,
-                                                         "scatter_mul_cpu",
-                                                         reduce_mul,
-                                                         include_self,
-                                                         dev_ctx);
+                             /*is_scatter_like=*/true>()(
+      self, dim, index, src, "mul", reduce_mul, include_self, dev_ctx);
 }
 
 template <typename tensor_t, typename index_t>
@@ -316,14 +411,8 @@ void cpu_scatter_mean_kernel(phi::DenseTensor self,
                              const phi::DeviceContext& dev_ctx) {
   cpu_gather_scatter_functor<tensor_t,
                              index_t,
-                             /*is_scatter_like=*/true>()(self,
-                                                         dim,
-                                                         index,
-                                                         src,
-                                                         "scatter_mean_cpu",
-                                                         reduce_add,
-                                                         include_self,
-                                                         dev_ctx);
+                             /*is_scatter_like=*/true>()(
+      self, dim, index, src, "mean", reduce_add, include_self, dev_ctx);
 }
 
 template <typename tensor_t, typename index_t>
@@ -335,14 +424,8 @@ void cpu_scatter_max_kernel(phi::DenseTensor self,
                             const phi::DeviceContext& dev_ctx) {
   cpu_gather_scatter_functor<tensor_t,
                              index_t,
-                             /*is_scatter_like=*/true>()(self,
-                                                         dim,
-                                                         index,
-                                                         src,
-                                                         "scatter_max_cpu",
-                                                         reduce_max,
-                                                         include_self,
-                                                         dev_ctx);
+                             /*is_scatter_like=*/true>()(
+      self, dim, index, src, "max", reduce_max, include_self, dev_ctx);
 }
 
 template <typename tensor_t, typename index_t>
@@ -354,14 +437,8 @@ void cpu_scatter_min_kernel(phi::DenseTensor self,
                             const phi::DeviceContext& dev_ctx) {
   cpu_gather_scatter_functor<tensor_t,
                              index_t,
-                             /*is_scatter_like=*/true>()(self,
-                                                         dim,
-                                                         index,
-                                                         src,
-                                                         "scatter_min_cpu",
-                                                         reduce_min,
-                                                         include_self,
-                                                         dev_ctx);
+                             /*is_scatter_like=*/true>()(
+      self, dim, index, src, "min", reduce_min, include_self, dev_ctx);
 }
 
 template <typename tensor_t, typename index_t>
@@ -374,34 +451,15 @@ void cpu_scatter_input_grad_kernel(phi::DenseTensor self UNUSED,
   auto* index_data = index.data<index_t>();
   auto* grad_data = grad.data<tensor_t>();
 
-  auto index_dims = index.dims();
-  auto grad_dims = grad.dims();
+  const int ndim = index.dims().size();
+  const int64_t index_size = index.numel();
+  CoordinateManager<false> cm(index.dims(), grad.strides(), ndim, dim, nullptr);
 
-  int64_t inner_dim_size = 1;
-  int64_t outer_dim_size = 1;
-  int64_t outer_dim_size_data = 1;
-  int64_t select_dim_size = index_dims[dim];
-  int64_t grad_select_dim_size = grad_dims[dim];
-  for (int i = 0; i < dim; ++i) {
-    inner_dim_size *= index_dims[i];
-  }
-
-  for (int i = dim + 1; i < index_dims.size(); i++) {
-    outer_dim_size *= index_dims[i];
-    outer_dim_size_data *= grad_dims[i];
-  }
-
-  int64_t index_idx = 0;
-  for (int64_t i = 0; i < inner_dim_size; i++) {
-    for (int64_t j = 0; j < select_dim_size; j++) {
-      for (int64_t k = 0; k < outer_dim_size; k++) {
-        int64_t index = index_data[index_idx];
-        int64_t replace_index = k + index * outer_dim_size_data +
-                                i * outer_dim_size_data * grad_select_dim_size;
-        grad_data[replace_index] = 0;
-        index_idx++;
-      }
-    }
+  for (int64_t i = 0; i < index_size; i++) {
+    int64_t index = index_data[i];
+    cm.CalculateOffset(index);
+    int64_t replace_index = cm.offset1;
+    grad_data[replace_index] = 0;
   }
 }
 
@@ -423,59 +481,39 @@ void cpu_scatter_mul_min_max_input_grad_kernel(
   auto* x_data = x.data<tensor_t>();
   auto* value_data = value.data<tensor_t>();
 
-  int64_t grad_size = grad.numel();
-  auto index_dims = index.dims();
-  auto grad_dims = grad.dims();
-  auto value_dims = value.dims();
+  const int ndim = index.dims().size();
+  const int64_t index_size = index.numel();
+  const int64_t grad_size = grad.numel();
+  // only amin/amax needs the offset2, but we compute together anyway.
+  CoordinateManager<true> cm(
+      index.dims(), grad.strides(), ndim, dim, &value.strides());
 
-  int64_t inner_dim_size = 1;
-  int64_t outer_dim_size = 1;
-  int64_t outer_dim_size_grad = 1;
-  int64_t outer_dim_size_value = 1;
-  int64_t select_dim_size = index_dims[dim];
-  int64_t grad_select_dim_size = grad_dims[dim];
-  int64_t value_select_dim_size = value_dims[dim];
-  for (int i = 0; i < dim; ++i) {
-    inner_dim_size *= index_dims[i];
-  }
-
-  for (int i = dim + 1; i < index_dims.size(); i++) {
-    outer_dim_size *= index_dims[i];
-    outer_dim_size_grad *= grad_dims[i];
-    outer_dim_size_value *= value_dims[i];
-  }
-
-  int64_t index_idx = 0;
-  std::vector<int> num_elements(grad_size, 0);
-  for (int64_t i = 0; i < inner_dim_size; i++) {
-    for (int64_t j = 0; j < select_dim_size; j++) {
-      for (int64_t k = 0; k < outer_dim_size; k++) {
-        int64_t index = index_data[index_idx];
-        int64_t replace_index_grad =
-            k + index * outer_dim_size_grad +
-            i * outer_dim_size_grad * grad_select_dim_size;
-        if ((reduce == "multiply" || reduce == "mul") &&
-            num_elements[replace_index_grad] == 0) {
-          grad_data[replace_index_grad] = static_cast<tensor_t>(
-              grad_data[replace_index_grad] * out_data[replace_index_grad] /
-              x_data[replace_index_grad]);
+  // make sure that reduce in {'mul', 'multiply', 'amin', 'amax'}
+  const bool is_mul = reduce == "multiply" || reduce == "mul";
+  std::vector<int> num_elements(grad.numel(), 0);
+  for (int64_t i = 0; i < index_size; i++) {
+    int64_t index = index_data[i];
+    cm.CalculateOffset(index);
+    int64_t replace_index_grad = cm.offset1;
+    if (is_mul && num_elements[replace_index_grad] == 0) {
+      grad_data[replace_index_grad] = static_cast<tensor_t>(
+          grad_data[replace_index_grad] * out_data[replace_index_grad] /
+          x_data[replace_index_grad]);
+      num_elements[replace_index_grad] += 1;
+    } else if (!is_mul) {
+      if (out_data[replace_index_grad] != x_data[replace_index_grad]) {
+        grad_data[replace_index_grad] = 0;
+      } else {
+        int64_t replace_index_value = cm.offset2;
+        if (out_data[replace_index_grad] == value_data[replace_index_value])
           num_elements[replace_index_grad] += 1;
-        } else if (reduce == "amin" || reduce == "amax") {
-          if (out_data[replace_index_grad] != x_data[replace_index_grad]) {
-            grad_data[replace_index_grad] = 0;
-          } else {
-            int64_t replace_index_value =
-                k + j * outer_dim_size_value +
-                i * outer_dim_size_value * value_select_dim_size;
-            if (out_data[replace_index_grad] == value_data[replace_index_value])
-              num_elements[replace_index_grad] += 1;
-          }
-        }
-        index_idx++;
       }
     }
   }
-  if (reduce == "amin" || reduce == "amax") {
+
+  // TODO(heqianyue): I don't think the origin impl is correct, what about
+  // include_self = False?
+  if (!is_mul) {
     for (int64_t i = 0; i < grad_size; i++) {
       grad_data[i] = grad_data[i] / static_cast<tensor_t>(num_elements[i] + 1);
     }
@@ -493,37 +531,17 @@ void cpu_scatter_mean_input_grad_kernel(phi::DenseTensor self UNUSED,
   auto* index_data = index.data<index_t>();
   auto* grad_data = grad.data<tensor_t>();
 
-  auto index_dims = index.dims();
-  auto grad_dims = grad.dims();
-
   int64_t grad_size = grad.numel();
 
-  int64_t inner_dim_size = 1;
-  int64_t outer_dim_size = 1;
-  int64_t outer_dim_size_data = 1;
-  int64_t select_dim_size = index_dims[dim];
-  int64_t grad_select_dim_size = grad_dims[dim];
-  for (int i = 0; i < dim; ++i) {
-    inner_dim_size *= index_dims[i];
-  }
-
-  for (int i = dim + 1; i < index_dims.size(); i++) {
-    outer_dim_size *= index_dims[i];
-    outer_dim_size_data *= grad_dims[i];
-  }
-
-  int64_t index_idx = 0;
+  const int ndim = index.dims().size();
+  const int64_t index_size = index.numel();
+  CoordinateManager<false> cm(index.dims(), grad.strides(), ndim, dim, nullptr);
   std::vector<int> num_elements(grad_size, 0);
-  for (int64_t i = 0; i < inner_dim_size; i++) {
-    for (int64_t j = 0; j < select_dim_size; j++) {
-      for (int64_t k = 0; k < outer_dim_size; k++) {
-        int64_t index = index_data[index_idx];
-        int64_t replace_index = k + index * outer_dim_size_data +
-                                i * outer_dim_size_data * grad_select_dim_size;
-        num_elements[replace_index] += 1;
-        index_idx++;
-      }
-    }
+  for (int64_t i = 0; i < index_size; i++) {
+    int64_t index = index_data[i];
+    cm.CalculateOffset(index);
+    int64_t replace_index = cm.offset1;
+    num_elements[replace_index] += 1;
   }
   for (int64_t i = 0; i < grad_size; i++)
     if (num_elements[i])
@@ -537,139 +555,79 @@ void cpu_scatter_value_grad_kernel(phi::DenseTensor self,
                                    phi::DenseTensor grad,
                                    bool include_self UNUSED,
                                    const phi::DeviceContext& dev_ctx UNUSED) {
-  auto* self_data = self.data<tensor_t>();
+  const auto* self_data = self.data<tensor_t>();
   auto* index_data = index.data<index_t>();
   auto* grad_data = grad.data<tensor_t>();
 
-  auto index_dims = index.dims();
-  auto self_dims = self.dims();
-  auto grad_dims = grad.dims();
+  std::vector<bool> is_self_grad_used(self.numel(), false);
 
-  int64_t self_size = self.numel();
-  std::vector<bool> is_self_grad_used(self_size, false);
+  const int ndim = index.dims().size();
+  ReversedCoordinateManager<true> cm(
+      index.dims(), self.strides(), ndim, dim, &grad.strides());
 
-  int64_t inner_dim_size = 1;
-  int64_t outer_dim_size = 1;
-  int64_t outer_dim_size_self = 1;
-  int64_t outer_dim_size_grad = 1;
-  int64_t select_dim_size = index_dims[dim];
-  int64_t self_select_dim_size = self_dims[dim];
-  int64_t grad_select_dim_size = grad_dims[dim];
-  for (int i = 0; i < dim; ++i) {
-    inner_dim_size *= index_dims[i];
-  }
-
-  for (int i = dim + 1; i < index_dims.size(); i++) {
-    outer_dim_size *= index_dims[i];
-    outer_dim_size_self *= self_dims[i];
-    outer_dim_size_grad *= grad_dims[i];
-  }
-  int64_t index_idx = index.numel() - 1;
-  for (int64_t i = inner_dim_size - 1; i >= 0; i--) {
-    for (int64_t j = select_dim_size - 1; j >= 0; j--) {
-      for (int64_t k = outer_dim_size - 1; k >= 0; k--) {
-        int64_t index = index_data[index_idx];
-        int64_t replace_index_self =
-            k + index * outer_dim_size_self +
-            i * outer_dim_size_self * self_select_dim_size;
-        int64_t replace_index_grad =
-            k + j * outer_dim_size_grad +
-            i * outer_dim_size_grad * grad_select_dim_size;
-        if (!is_self_grad_used[replace_index_self]) {
-          grad_data[replace_index_grad] = self_data[replace_index_self];
-          is_self_grad_used[replace_index_self] = true;
-        }
-        index_idx--;
-      }
+  for (int64_t i = index.numel() - 1; i >= 0; i--) {
+    int64_t index = index_data[i];
+    cm.CalculateOffset(index);
+    int64_t replace_index_self = cm.offset1;
+    int64_t replace_index_grad = cm.offset2;
+    if (!is_self_grad_used[replace_index_self]) {
+      grad_data[replace_index_grad] = self_data[replace_index_self];
+      is_self_grad_used[replace_index_self] = true;
     }
   }
 }
 
 template <typename tensor_t, typename index_t>
-void cpu_scatter_add_mean_value_grad_kernel(
-    phi::DenseTensor self,
-    int dim,
-    const phi::DenseTensor& index,
-    const phi::DenseTensor& out UNUSED,
-    const phi::DenseTensor& x UNUSED,
-    const phi::DenseTensor& value UNUSED,
-    phi::DenseTensor grad,
-    const std::string& reduce,
-    bool include_self,
-    const phi::DeviceContext& dev_ctx UNUSED) {
-  auto* self_data = self.data<tensor_t>();
+void cpu_scatter_add_mean_value_grad_kernel(phi::DenseTensor self,
+                                            int dim,
+                                            const phi::DenseTensor& index,
+                                            const phi::DenseTensor& out UNUSED,
+                                            const phi::DenseTensor& x UNUSED,
+                                            const phi::DenseTensor& value
+                                                UNUSED,
+                                            phi::DenseTensor grad,
+                                            const std::string& reduce,
+                                            bool include_self,
+                                            const phi::DeviceContext& dev_ctx) {
+  const auto* self_data = self.data<tensor_t>();
   auto* index_data = index.data<index_t>();
   auto* grad_data = grad.data<tensor_t>();
 
-  auto index_dims = index.dims();
-  auto self_dims = self.dims();
-  auto grad_dims = grad.dims();
-
   int64_t self_size = self.numel();
-  int64_t grad_size = grad.numel();
+
+  phi::funcs::set_constant(dev_ctx, &grad, 0);
+
   std::vector<int> num_elements;
-  if (reduce == "mean") {
-    for (int i = 0; i < self_size; i++) {
-      if (include_self)
-        num_elements.push_back(1);
-      else
-        num_elements.push_back(0);
+  const int ndim = index.dims().size();
+
+  // Note: make sure that `reduce` in {'mean', 'add'}.
+  const bool is_mean = reduce == "mean";
+  if (is_mean) {
+    num_elements.resize(self_size, static_cast<int>(include_self));
+    ReversedCoordinateManager<false> cm(
+        index.dims(), self.strides(), ndim, dim, nullptr);
+
+    for (int64_t i = index.numel() - 1; i >= 0; i--) {
+      int64_t index = index_data[i];
+      cm.CalculateOffset(index);
+      int64_t replace_index_self = cm.offset1;
+      num_elements[replace_index_self] += 1;
     }
   }
 
-  int64_t inner_dim_size = 1;
-  int64_t outer_dim_size = 1;
-  int64_t outer_dim_size_self = 1;
-  int64_t outer_dim_size_grad = 1;
-  int64_t select_dim_size = index_dims[dim];
-  int64_t self_select_dim_size = self_dims[dim];
-  int64_t grad_select_dim_size = grad_dims[dim];
-  for (int i = 0; i < dim; ++i) {
-    inner_dim_size *= index_dims[i];
-  }
-
-  for (int i = dim + 1; i < index_dims.size(); i++) {
-    outer_dim_size *= index_dims[i];
-    outer_dim_size_self *= self_dims[i];
-    outer_dim_size_grad *= grad_dims[i];
-  }
-  for (int i = 0; i < grad_size; i++) {
-    grad_data[i] = static_cast<tensor_t>(0);
-  }
-  int64_t index_idx = index.numel() - 1;
-  if (reduce == "mean") {
-    for (int64_t i = inner_dim_size - 1; i >= 0; i--) {
-      for (int64_t j = select_dim_size - 1; j >= 0; j--) {
-        for (int64_t k = outer_dim_size - 1; k >= 0; k--) {
-          int64_t index = index_data[index_idx];
-          int64_t replace_index_self =
-              k + index * outer_dim_size_self +
-              i * outer_dim_size_self * self_select_dim_size;
-          num_elements[replace_index_self] += 1;
-          index_idx--;
-        }
-      }
-    }
-    index_idx = index.numel() - 1;
-  }
-  for (int64_t i = inner_dim_size - 1; i >= 0; i--) {
-    for (int64_t j = select_dim_size - 1; j >= 0; j--) {
-      for (int64_t k = outer_dim_size - 1; k >= 0; k--) {
-        int64_t index = index_data[index_idx];
-        int64_t replace_index_self =
-            k + index * outer_dim_size_self +
-            i * outer_dim_size_self * self_select_dim_size;
-        int64_t replace_index_grad =
-            k + j * outer_dim_size_grad +
-            i * outer_dim_size_grad * grad_select_dim_size;
-        if (reduce == "add")
-          grad_data[replace_index_grad] = self_data[replace_index_self];
-        else if (reduce == "mean")
-          grad_data[replace_index_grad] =
-              self_data[replace_index_self] /
-              static_cast<tensor_t>(num_elements[replace_index_self]);
-        index_idx--;
-      }
+  ReversedCoordinateManager<true> cm(
+      index.dims(), self.strides(), ndim, dim, &grad.strides());
+  for (int64_t i = index.numel() - 1; i >= 0; i--) {
+    int64_t index = index_data[i];
+    cm.CalculateOffset(index);
+    int64_t replace_index_self = cm.offset1;
+    int64_t replace_index_grad = cm.offset2;
+    if (is_mean) {
+      grad_data[replace_index_grad] =
+          self_data[replace_index_self] /
+          static_cast<tensor_t>(num_elements[replace_index_self]);
+    } else {
+      grad_data[replace_index_grad] = self_data[replace_index_self];
     }
   }
 }
@@ -686,87 +644,55 @@ void cpu_scatter_mul_min_max_value_grad_kernel(
     const std::string& reduce,
     bool include_self,
     const phi::DeviceContext& dev_ctx) {
-  auto* self_data = self.data<tensor_t>();
+  const auto* self_data = self.data<tensor_t>();
   auto* index_data = index.data<index_t>();
   auto* grad_data = grad.data<tensor_t>();
   auto* out_data = out.data<tensor_t>();
   auto* x_data = x.data<tensor_t>();
   auto* value_data = value.data<tensor_t>();
 
-  auto index_dims = index.dims();
-  auto self_dims = self.dims();
-  auto grad_dims = grad.dims();
-
-  int64_t self_size = self.numel();
   std::vector<int> num_elements;
-  if (reduce == "amin" || reduce == "amax") {
-    for (int i = 0; i < self_size; i++) {
-      num_elements.push_back(0);
-    }
-  }
-  int64_t inner_dim_size = 1;
-  int64_t outer_dim_size = 1;
-  int64_t outer_dim_size_self = 1;
-  int64_t outer_dim_size_grad = 1;
-  int64_t select_dim_size = index_dims[dim];
-  int64_t self_select_dim_size = self_dims[dim];
-  int64_t grad_select_dim_size = grad_dims[dim];
-  for (int i = 0; i < dim; ++i) {
-    inner_dim_size *= index_dims[i];
-  }
+  const bool is_min_max = reduce == "amin" || reduce == "amax";
+  if (is_min_max) num_elements.resize(self.numel(), 0);
 
-  for (int i = dim + 1; i < index_dims.size(); i++) {
-    outer_dim_size *= index_dims[i];
-    outer_dim_size_self *= self_dims[i];
-    outer_dim_size_grad *= grad_dims[i];
-  }
-  int64_t index_idx = 0;
-  for (int64_t i = 0; i < inner_dim_size; i++) {
-    for (int64_t j = 0; j < select_dim_size; j++) {
-      for (int64_t k = 0; k < outer_dim_size; k++) {
-        int64_t index = index_data[index_idx];
-        int64_t replace_index_self =
-            k + index * outer_dim_size_self +
-            i * outer_dim_size_self * self_select_dim_size;
-        int64_t replace_index_grad =
-            k + j * outer_dim_size_grad +
-            i * outer_dim_size_grad * grad_select_dim_size;
-        if ((reduce == "amin" || reduce == "amax") &&
-            out_data[replace_index_self] == value_data[replace_index_grad]) {
-          num_elements[replace_index_self] += 1;
-        } else if (reduce == "mul" || reduce == "multiply") {
-          grad_data[replace_index_grad] =
-              self_data[replace_index_self] *
-              (out_data[replace_index_self] / value_data[replace_index_grad]);
-        }
-        index_idx++;
+  const int ndim = index.dims().size();
+  const int64_t index_size = index.numel();
+  {  // `cm` should be destroyed once the computation is done, no reuse
+    CoordinateManager<true> cm(
+        index.dims(), self.strides(), ndim, dim, &grad.strides());
+    for (int64_t i = 0; i < index_size; i++) {
+      int64_t index = index_data[i];
+      cm.CalculateOffset(index);
+      int64_t replace_index_self = cm.offset1;
+      int64_t replace_index_grad = cm.offset2;
+      if (is_min_max &&
+          out_data[replace_index_self] == value_data[replace_index_grad]) {
+        num_elements[replace_index_self] += 1;
+      } else if (!is_min_max) {
+        grad_data[replace_index_grad] =
+            self_data[replace_index_self] *
+            (out_data[replace_index_self] / value_data[replace_index_grad]);
       }
     }
   }
-  if (reduce == "amin" || reduce == "amax") {
-    index_idx = 0;
-    for (int64_t i = 0; i < inner_dim_size; i++) {
-      for (int64_t j = 0; j < select_dim_size; j++) {
-        for (int64_t k = 0; k < outer_dim_size; k++) {
-          int64_t index = index_data[index_idx];
-          int64_t replace_index_self =
-              k + index * outer_dim_size_self +
-              i * outer_dim_size_self * self_select_dim_size;
-          int64_t replace_index_grad =
-              k + j * outer_dim_size_grad +
-              i * outer_dim_size_grad * grad_select_dim_size;
-          if (out_data[replace_index_self] == value_data[replace_index_grad]) {
-            if (out_data[replace_index_self] == x_data[replace_index_self])
-              grad_data[replace_index_grad] =
-                  self_data[replace_index_self] /
-                  static_cast<tensor_t>(num_elements[replace_index_self] + 1);
-            else
-              grad_data[replace_index_grad] =
-                  self_data[replace_index_self] /
-                  static_cast<tensor_t>(num_elements[replace_index_self]);
-          }
-          index_idx++;
-        }
+
+  if (is_min_max) {
+    CoordinateManager<true> cm(
+        index.dims(), self.strides(), ndim, dim, &grad.strides());
+    for (int64_t i = 0; i < index_size; i++) {
+      int64_t index = index_data[i];
+      cm.CalculateOffset(index);
+      int64_t replace_index_self = cm.offset1;
+      int64_t replace_index_grad = cm.offset2;
+      if (out_data[replace_index_self] == value_data[replace_index_grad]) {
+        if (out_data[replace_index_self] == x_data[replace_index_self])
+          grad_data[replace_index_grad] =
+              self_data[replace_index_self] /
+              static_cast<tensor_t>(num_elements[replace_index_self] + 1);
+        else
+          grad_data[replace_index_grad] =
+              self_data[replace_index_self] /
+              static_cast<tensor_t>(num_elements[replace_index_self]);
       }
     }
   }

--- a/paddle/pir/src/dialect/shape/transforms/shape_optimization_pass.cc
+++ b/paddle/pir/src/dialect/shape/transforms/shape_optimization_pass.cc
@@ -206,8 +206,8 @@ void CheckInferSymWithInferMeta(
             print_stream << "Warning : Check InferSymbolicShape for "
                          << op->name() << " [id:" << op->id() << "] "
                          << " carefully! "
-                         << "infer_sym_shape is [" << infer_meta_shape[i]
-                         << "], but infer_meta_shape is ["
+                         << "infer_meta_shape is [" << infer_meta_shape[i]
+                         << "], but infer_sym_shape is ["
                          << infer_sym_shape[i].dyn_cast<int64_t>() << "].";
             LOG(ERROR) << print_stream.str();
           }

--- a/test/ir/pir/cinn/symbolic/test_infer_sym_shape_multinary_op.py
+++ b/test/ir/pir/cinn/symbolic/test_infer_sym_shape_multinary_op.py
@@ -205,11 +205,8 @@ class TakeAlongAxisNet(paddle.nn.Layer):
         super().__init__()
 
     def forward(self, x, indices):
-        out = paddle.take_along_axis(x, indices, axis=0)
-        out = paddle.take_along_axis(x, indices, axis=1)
-        out = paddle.take_along_axis(x, indices, axis=-1)
-        out = paddle.take_along_axis(x, indices, axis=-2)
-        return out
+        out1 = paddle.take_along_axis(x, indices, axis=0)
+        return out1
 
 
 class TakeAlongAxisOpInferSymbolicShapeTest(TestBase):
@@ -222,14 +219,10 @@ class TakeAlongAxisOpInferSymbolicShapeTest(TestBase):
         ]
         self.expected = [
             [
-                'shape[S3, S1, S2], data[NULL]',
-                'shape[S0, S4, S2], data[NULL]',
-                'shape[S0, S1, S5], data[NULL]',
-                'shape[S0, S4, S2], data[NULL]',
+                'shape[S3, S4, S5], data[NULL]',
             ],
         ]
 
-    @unittest.skip("TODO: xiongkun")
     def test_eval_symbolic(self):
         net = TakeAlongAxisNet()
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Operator Mechanism


### PR Types
Improvements


### Description
修复了7个 CPU 端 scatter/gather 相关的 kernels。

尝试使用了一种无div/mod，尽可能少的乘法以及load的offset映射方法，见 `CoordinateManager` 与 `ReversedCoordinateManager`（后者没有与前者通过模板化进行融合，因为考虑到虽然两者代码非常相似，融合会使得可读性很差）。Naive 的实现思路有两种：
- method 1: 类似 #74922 中针对 SIMT 模型实现的 divmod
- method 2: 无 divmod，通过一种简单的逻辑实现（见此 gist [CalculateOffsetSimple](https://gist.github.com/Enigmatisms/0a01f6a8c99aa8e82cf6c73e805420ce)）

本 PR 的计算速度 > method 2 > method 1。method 2 > method 1 是无需验证的：divmod 版本的乘法使用数量与 method 2 一致，但还额外使用了 div 和 mod。如果追求开发效率，直接把 GPU PR 的结果搬运过来改改，是可行的，但是我不喜欢这种代码（谁喜欢一坨的性能呢？）。

本PR简单优化了一下 method 2，消除了一些不必要的 load 和乘法，利用了 CPU 上 offset 计算是串行的特点来重用一些计算。ndim越大，或者大维度集中在tensor末尾，比如[1, 2, 3, 30, 300] 时优化效果更为显著。在10种不同的 input shapes 测试下（每种shape有多种input输入测试），500次 system_clock 计时统计，**相比于 naive 实现可以达到 43%+ 的提速**。

此外，PR 的内容有：
- 优化了 `gather_scatter_functor.cc` 实现不好的地方（比如内存使用，初始化方法等等）。
- 修正了 `TakeAlongAxisOp` 的 symbolic shape infer 逻辑：out tensor 应该与 index tensor 一致，而不是和 input tensor 一致。
- 增加了 `TakeAlongAxisOp` 的 symbolic shape infer 单测，取消了原有的 skip。
- 修正了 `shape_optimization_pass.cc` 中 infer meta 和 infer sym 搞反的问题。

大规模验证（7000+测试）脚本：[scatter_test_case.py](https://gist.github.com/Enigmatisms/90ba9302aa3ee248f529273b0753e326)

Pcard-89620
