### PR TITLE
Fix eager python c code gen when sink api into c++

### DIFF
--- a/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
@@ -90,7 +90,7 @@ PARSE_PYTHON_C_TENSORS_TEMPLATE = (
 PARSE_PYTHON_C_TENSOR_REF_TEMPLATE = (
     '    auto& {} = {}("{}", "{}", args, {}, {});\n'
 )
-PARSE_PYTHON_C_TENSORS_FROM_ARGS_OR_KWARGS_TEMPLATE = '    auto {} = GetTensorFromArgsOrKWArgs("{}", "{}", args, {}, kwargs,{},nargs,&remaining_kwargs,{});\n'
+PARSE_PYTHON_C_TENSORS_FROM_ARGS_OR_KWARGS_TEMPLATE = '    auto& {} = GetTensorFromArgsOrKWArgs("{}", "{}", args, {}, kwargs,{},nargs,&remaining_kwargs,{});\n'
 PARSE_PYTHON_C_OPTIONAL_TENSORS_FROM_ARGS_OR_KWARGS_TEMPLATE = '    auto {} = GetOptionalTensorFromArgsOrKWArgs("{}", "{}", args, {}, kwargs,{},nargs,&remaining_kwargs,{});\n'
 CONVERT_TO_DISTTENSOR_AND_PARSE_PYTHON_C_TENSORS_TEMPLATE = (
     '    {} = {}("{}", "{}", args, {}, {}, mesh);\n'

--- a/paddle/fluid/pir/dialect/op_generator/python_c_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/python_c_gen.py
@@ -894,5 +894,3 @@ if __name__ == '__main__':
         python_c_def_h_file,
         python_c_def_cc_file,
     )
-
-#

--- a/paddle/phi/ops/yaml/ops.yaml
+++ b/paddle/phi/ops/yaml/ops.yaml
@@ -342,10 +342,6 @@
 
 - op : argmax
   args : (Tensor x, Scalar(int64_t) axis, bool keepdims = false, bool flatten = false, DataType dtype = DataType::INT64)
-  python_api :
-    name : [paddle.argmax, paddle.Tensor.argmax]
-    args_mapper :
-      func : ArgMaxMinMapper
   output : Tensor(out)
   infer_meta :
     func : ArgMinMaxInferMeta
@@ -358,10 +354,6 @@
 
 - op : argmin
   args : (Tensor x, Scalar(int64_t) axis, bool keepdims = false, bool flatten = false, DataType dtype = DataType::INT64)
-  python_api :
-    name : [paddle.argmin, paddle.Tensor.argmin]
-    args_mapper :
-      func : ArgMaxMinMapper
   output : Tensor(out)
   infer_meta :
     func : ArgMinMaxInferMeta

--- a/paddle/phi/ops/yaml/python_api_info.yaml
+++ b/paddle/phi/ops/yaml/python_api_info.yaml
@@ -8,10 +8,10 @@
   args_alias :
     use_default_mapping : True
 
-# - op : matmul
-#   name : [paddle.matmul,paddle.Tensor.matmul]
-#   args_alias :
-#     use_default_mapping : True
+- op : matmul
+  name : [paddle.matmul,paddle.Tensor.matmul]
+  args_alias :
+    use_default_mapping : True
 - op : multiply
   name : [paddle.multiply,paddle.Tensor.multiply]
   args_alias :

--- a/python/paddle/_paddle_docs.py
+++ b/python/paddle/_paddle_docs.py
@@ -522,111 +522,111 @@ add_doc_and_signature(
     """,
 )
 
-# add_doc_and_signature(
-#     "matmul",
-#     """
-#     Applies matrix multiplication to two tensors. `matmul` follows
-#     the complete broadcast rules,
-#     and its behavior is consistent with `np.matmul`.
+add_doc_and_signature(
+    "matmul",
+    """
+    Applies matrix multiplication to two tensors. `matmul` follows
+    the complete broadcast rules,
+    and its behavior is consistent with `np.matmul`.
 
-#     Currently, the input tensors' number of dimensions can be any, `matmul` can be used to
-#     achieve the `dot`, `matmul` and `batchmatmul`.
+    Currently, the input tensors' number of dimensions can be any, `matmul` can be used to
+    achieve the `dot`, `matmul` and `batchmatmul`.
 
-#     The actual behavior depends on the shapes of :math:`x`, :math:`y` and the
-#     flag values of :attr:`transpose_x`, :attr:`transpose_y`. Specifically:
+    The actual behavior depends on the shapes of :math:`x`, :math:`y` and the
+    flag values of :attr:`transpose_x`, :attr:`transpose_y`. Specifically:
 
-#     - If a transpose flag is specified, the last two dimensions of the tensor
-#       are transposed. If the tensor is ndim-1 of shape, the transpose is invalid. If the tensor
-#       is ndim-1 of shape :math:`[D]`, then for :math:`x` it is treated as :math:`[1, D]`, whereas
-#       for :math:`y` it is the opposite: It is treated as :math:`[D, 1]`.
+    - If a transpose flag is specified, the last two dimensions of the tensor
+      are transposed. If the tensor is ndim-1 of shape, the transpose is invalid. If the tensor
+      is ndim-1 of shape :math:`[D]`, then for :math:`x` it is treated as :math:`[1, D]`, whereas
+      for :math:`y` it is the opposite: It is treated as :math:`[D, 1]`.
 
-#     The multiplication behavior depends on the dimensions of `x` and `y`. Specifically:
+    The multiplication behavior depends on the dimensions of `x` and `y`. Specifically:
 
-#     - If both tensors are 1-dimensional, the dot product result is obtained.
+    - If both tensors are 1-dimensional, the dot product result is obtained.
 
-#     - If both tensors are 2-dimensional, the matrix-matrix product is obtained.
+    - If both tensors are 2-dimensional, the matrix-matrix product is obtained.
 
-#     - If the `x` is 1-dimensional and the `y` is 2-dimensional,
-#       a `1` is prepended to its dimension in order to conduct the matrix multiply.
-#       After the matrix multiply, the prepended dimension is removed.
+    - If the `x` is 1-dimensional and the `y` is 2-dimensional,
+      a `1` is prepended to its dimension in order to conduct the matrix multiply.
+      After the matrix multiply, the prepended dimension is removed.
 
-#     - If the `x` is 2-dimensional and `y` is 1-dimensional,
-#       the matrix-vector product is obtained.
+    - If the `x` is 2-dimensional and `y` is 1-dimensional,
+      the matrix-vector product is obtained.
 
-#     - If both arguments are at least 1-dimensional and at least one argument
-#       is N-dimensional (where N > 2), then a batched matrix multiply is obtained.
-#       If the first argument is 1-dimensional, a 1 is prepended to its dimension
-#       in order to conduct the batched matrix multiply and removed after.
-#       If the second argument is 1-dimensional, a 1 is appended to its
-#       dimension for the purpose of the batched matrix multiple and removed after.
-#       The non-matrix (exclude the last two dimensions) dimensions are
-#       broadcasted according the broadcast rule.
-#       For example, if input is a (j, 1, n, m) tensor and the other is a (k, m, p) tensor,
-#       out will be a (j, k, n, p) tensor.
+    - If both arguments are at least 1-dimensional and at least one argument
+      is N-dimensional (where N > 2), then a batched matrix multiply is obtained.
+      If the first argument is 1-dimensional, a 1 is prepended to its dimension
+      in order to conduct the batched matrix multiply and removed after.
+      If the second argument is 1-dimensional, a 1 is appended to its
+      dimension for the purpose of the batched matrix multiple and removed after.
+      The non-matrix (exclude the last two dimensions) dimensions are
+      broadcasted according the broadcast rule.
+      For example, if input is a (j, 1, n, m) tensor and the other is a (k, m, p) tensor,
+      out will be a (j, k, n, p) tensor.
 
-#     Args:
-#         x (Tensor): The input tensor which is a Tensor.
-#         y (Tensor): The input tensor which is a Tensor.
-#         transpose_x (bool, optional): Whether to transpose :math:`x` before multiplication. Default is False.
-#         transpose_y (bool, optional): Whether to transpose :math:`y` before multiplication. Default is False.
-#         name (str|None, optional): If set None, the layer will be named automatically. For more information, please refer to :ref:`api_guide_Name`. Default is None.
-#         out (Tensor, optional): The output tensor. If set, the result will be stored in this tensor. Default is None.
+    Args:
+        x (Tensor): The input tensor which is a Tensor.
+        y (Tensor): The input tensor which is a Tensor.
+        transpose_x (bool, optional): Whether to transpose :math:`x` before multiplication. Default is False.
+        transpose_y (bool, optional): Whether to transpose :math:`y` before multiplication. Default is False.
+        name (str|None, optional): If set None, the layer will be named automatically. For more information, please refer to :ref:`api_guide_Name`. Default is None.
+        out (Tensor, optional): The output tensor. If set, the result will be stored in this tensor. Default is None.
 
-#     Returns:
-#         Tensor: The output Tensor.
+    Returns:
+        Tensor: The output Tensor.
 
-#     Examples:
+    Examples:
 
-#         .. code-block:: python
+        .. code-block:: python
 
-#             >>> import paddle
+            >>> import paddle
 
-#             >>> # vector * vector
-#             >>> x = paddle.rand([10])
-#             >>> y = paddle.rand([10])
-#             >>> z = paddle.matmul(x, y)
-#             >>> print(z.shape)
-#             []
+            >>> # vector * vector
+            >>> x = paddle.rand([10])
+            >>> y = paddle.rand([10])
+            >>> z = paddle.matmul(x, y)
+            >>> print(z.shape)
+            []
 
-#             >>> # matrix * vector
-#             >>> x = paddle.rand([10, 5])
-#             >>> y = paddle.rand([5])
-#             >>> z = paddle.matmul(x, y)
-#             >>> print(z.shape)
-#             [10]
+            >>> # matrix * vector
+            >>> x = paddle.rand([10, 5])
+            >>> y = paddle.rand([5])
+            >>> z = paddle.matmul(x, y)
+            >>> print(z.shape)
+            [10]
 
-#             >>> # batched matrix * broadcasted vector
-#             >>> x = paddle.rand([10, 5, 2])
-#             >>> y = paddle.rand([2])
-#             >>> z = paddle.matmul(x, y)
-#             >>> print(z.shape)
-#             [10, 5]
+            >>> # batched matrix * broadcasted vector
+            >>> x = paddle.rand([10, 5, 2])
+            >>> y = paddle.rand([2])
+            >>> z = paddle.matmul(x, y)
+            >>> print(z.shape)
+            [10, 5]
 
-#             >>> # batched matrix * batched matrix
-#             >>> x = paddle.rand([10, 5, 2])
-#             >>> y = paddle.rand([10, 2, 5])
-#             >>> z = paddle.matmul(x, y)
-#             >>> print(z.shape)
-#             [10, 5, 5]
+            >>> # batched matrix * batched matrix
+            >>> x = paddle.rand([10, 5, 2])
+            >>> y = paddle.rand([10, 2, 5])
+            >>> z = paddle.matmul(x, y)
+            >>> print(z.shape)
+            [10, 5, 5]
 
-#             >>> # batched matrix * broadcasted matrix
-#             >>> x = paddle.rand([10, 1, 5, 2])
-#             >>> y = paddle.rand([1, 3, 2, 5])
-#             >>> z = paddle.matmul(x, y)
-#             >>> print(z.shape)
-#             [10, 3, 5, 5]
+            >>> # batched matrix * broadcasted matrix
+            >>> x = paddle.rand([10, 1, 5, 2])
+            >>> y = paddle.rand([1, 3, 2, 5])
+            >>> z = paddle.matmul(x, y)
+            >>> print(z.shape)
+            [10, 3, 5, 5]
 
-#     """,
-#     """    def matmul(
-#     x: Tensor,
-#     y: Tensor,
-#     transpose_x: bool = False,
-#     transpose_y: bool = False,
-#     name: str | None = None,
-#     *,
-#     out: Tensor | None = None,
-# ) -> Tensor""",
-# )
+    """,
+    """    def matmul(
+    x: Tensor,
+    y: Tensor,
+    transpose_x: bool = False,
+    transpose_y: bool = False,
+    name: str | None = None,
+    *,
+    out: Tensor | None = None,
+) -> Tensor""",
+)
 add_doc_and_signature(
     "multiply",
     """

--- a/python/paddle/tensor/search.py
+++ b/python/paddle/tensor/search.py
@@ -30,9 +30,10 @@ from paddle.utils.decorator_utils import (
 )
 from paddle.utils.inplace_utils import inplace_apis_in_dygraph_only
 
-from ..base.data_feeder import check_variable_and_dtype
+from ..base.data_feeder import check_dtype, check_variable_and_dtype
 from ..framework import (
     LayerHelper,
+    convert_np_dtype_to_dtype_,
     core,
     in_dynamic_mode,
     in_dynamic_or_pir_mode,
@@ -42,8 +43,8 @@ from .creation import assign
 
 if TYPE_CHECKING:
     from paddle import Tensor
+    from paddle._typing import DTypeLike
 
-from paddle._C_ops import argmax, argmin  # noqa: F401
 from paddle.utils.decorator_utils import ForbidKeywordsDecorator
 
 # from ..base.layers import has_inf  #DEFINE_ALIAS
@@ -185,6 +186,210 @@ def argsort(
             attrs={'axis': axis, 'descending': descending, 'stable': stable},
         )
         return ids
+
+
+@param_two_alias(["x", "input"], ["axis", "dim"])
+def argmax(
+    x: Tensor,
+    axis: int | None = None,
+    keepdim: bool = False,
+    dtype: DTypeLike = "int64",
+    name: str | None = None,
+) -> Tensor:
+    """
+    Computes the indices of the max elements of the input tensor's
+    element along the provided axis.
+
+    Args:
+        x (Tensor): An input N-D Tensor with type float16, float32, float64, int16,
+            int32, int64, uint8.
+        axis (int|None, optional): Axis to compute indices along. The effective range
+            is [-R, R), where R is x.ndim. when axis < 0, it works the same way
+            as axis + R. Default is None, the input `x` will be into the flatten tensor, and selecting the min value index.
+        keepdim (bool, optional): Whether to keep the given axis in output. If it is True, the dimensions will be same as input x and with size one in the axis. Otherwise the output dimensions is one fewer than x since the axis is squeezed. Default is False.
+        dtype (str|np.dtype, optional): Data type of the output tensor which can
+                    be int32, int64. The default value is ``int64`` , and it will
+                    return the int64 indices.
+        name (str|None, optional): For details, please refer to :ref:`api_guide_Name`. Generally, no setting is required. Default: None.
+
+    Returns:
+        Tensor, return the tensor of int32 if set :attr:`dtype` is int32, otherwise return the tensor of int64.
+
+    Examples:
+        .. code-block:: python
+
+            >>> import paddle
+
+            >>> x = paddle.to_tensor([[5,8,9,5],
+            ...                       [0,0,1,7],
+            ...                       [6,9,2,4]])
+            >>> out1 = paddle.argmax(x)
+            >>> print(out1.numpy())
+            2
+            >>> out2 = paddle.argmax(x, axis=0)
+            >>> print(out2.numpy())
+            [2 2 0 1]
+            >>> out3 = paddle.argmax(x, axis=-1)
+            >>> print(out3.numpy())
+            [2 3 1]
+            >>> out4 = paddle.argmax(x, axis=0, keepdim=True)
+            >>> print(out4.numpy())
+            [[2 2 0 1]]
+    """
+    if axis is not None and not isinstance(
+        axis, (int, Variable, paddle.pir.Value)
+    ):
+        raise TypeError(
+            f"The type of 'axis'  must be int or Tensor or None in argmax, but received {type(axis)}."
+        )
+
+    if dtype is None:
+        raise ValueError(
+            "the value of 'dtype' in argmax could not be None, but received None"
+        )
+
+    var_dtype = convert_np_dtype_to_dtype_(dtype)
+    flatten = False
+    if axis is None:
+        flatten = True
+        axis = 0
+
+    if in_dynamic_mode():
+        return _C_ops.argmax(x, axis, keepdim, flatten, var_dtype)
+    elif in_pir_mode():
+        check_dtype(var_dtype, 'dtype', ['int32', 'int64'], 'argmax')
+        return _C_ops.argmax(x, axis, keepdim, flatten, var_dtype)
+    else:
+        helper = LayerHelper("argmax", **locals())
+        check_variable_and_dtype(
+            x,
+            'x',
+            [
+                'uint16',
+                'float16',
+                'float32',
+                'float64',
+                'int16',
+                'int32',
+                'int64',
+                'uint8',
+            ],
+            'paddle.argmax',
+        )
+        check_dtype(var_dtype, 'dtype', ['int32', 'int64'], 'argmax')
+        attrs = {}
+        out = helper.create_variable_for_type_inference(var_dtype)
+        attrs['keepdims'] = keepdim
+        attrs['axis'] = axis
+        attrs['flatten'] = flatten
+        attrs['dtype'] = var_dtype
+        helper.append_op(
+            type='arg_max', inputs={'X': x}, outputs={'Out': [out]}, attrs=attrs
+        )
+        out.stop_gradient = True
+        return out
+
+
+@param_two_alias(["x", "input"], ["axis", "dim"])
+def argmin(
+    x: Tensor,
+    axis: int | None = None,
+    keepdim: bool = False,
+    dtype: DTypeLike = "int64",
+    name: str | None = None,
+) -> Tensor:
+    """
+    Computes the indices of the min elements of the input tensor's
+    element along the provided axis.
+
+    Args:
+        x (Tensor): An input N-D Tensor with type float16, float32, float64, int16,
+            int32, int64, uint8.
+        axis (int|None, optional): Axis to compute indices along. The effective range
+            is [-R, R), where R is x.ndim. when axis < 0, it works the same way
+            as axis + R. Default is None, the input `x` will be into the flatten tensor, and selecting the min value index.
+        keepdim (bool, optional): Whether to keep the given axis in output. If it is True, the dimensions will be same as input x and with size one in the axis. Otherwise the output dimensions is one fewer than x since the axis is squeezed. Default is False.
+        dtype (str|np.dtype, optional): Data type of the output tensor which can
+                    be int32, int64. The default value is 'int64', and it will
+                    return the int64 indices.
+        name (str|None, optional): For details, please refer to :ref:`api_guide_Name`. Generally, no setting is required. Default: None.
+
+    Returns:
+        Tensor, return the tensor of `int32` if set :attr:`dtype` is `int32`, otherwise return the tensor of `int64`.
+
+    Examples:
+        .. code-block:: python
+
+            >>> import paddle
+
+            >>> x =  paddle.to_tensor([[5,8,9,5],
+            ...                        [0,0,1,7],
+            ...                        [6,9,2,4]])
+            >>> out1 = paddle.argmin(x)
+            >>> print(out1.numpy())
+            4
+            >>> out2 = paddle.argmin(x, axis=0)
+            >>> print(out2.numpy())
+            [1 1 1 2]
+            >>> out3 = paddle.argmin(x, axis=-1)
+            >>> print(out3.numpy())
+            [0 0 2]
+            >>> out4 = paddle.argmin(x, axis=0, keepdim=True)
+            >>> print(out4.numpy())
+            [[1 1 1 2]]
+    """
+    if axis is not None and not isinstance(
+        axis, (int, Variable, paddle.pir.Value)
+    ):
+        raise TypeError(
+            f"The type of 'axis'  must be int or Tensor or None in argmin, but received {type(axis)}."
+        )
+
+    if dtype is None:
+        raise ValueError(
+            "the value of 'dtype' in argmin could not be None, but received None"
+        )
+
+    var_dtype = convert_np_dtype_to_dtype_(dtype)
+    flatten = False
+    if axis is None:
+        flatten = True
+        axis = 0
+
+    if in_dynamic_mode():
+        return _C_ops.argmin(x, axis, keepdim, flatten, var_dtype)
+    elif in_pir_mode():
+        check_dtype(var_dtype, 'dtype', ['int32', 'int64'], 'argmin')
+        return _C_ops.argmin(x, axis, keepdim, flatten, var_dtype)
+    else:
+        helper = LayerHelper("argmin", **locals())
+        check_variable_and_dtype(
+            x,
+            'x',
+            [
+                'uint16',
+                'float16',
+                'float32',
+                'float64',
+                'int16',
+                'int32',
+                'int64',
+                'uint8',
+            ],
+            'paddle.argmin',
+        )
+        check_dtype(var_dtype, 'dtype', ['int32', 'int64'], 'argmin')
+        out = helper.create_variable_for_type_inference(var_dtype)
+        attrs = {}
+        attrs['keepdims'] = keepdim
+        attrs['axis'] = axis
+        attrs['flatten'] = flatten
+        attrs['dtype'] = var_dtype
+        helper.append_op(
+            type='arg_min', inputs={'X': x}, outputs={'Out': [out]}, attrs=attrs
+        )
+        out.stop_gradient = True
+        return out
 
 
 @index_select_decorator()

--- a/test/legacy_test/test_arg_min_max_v2_op.py
+++ b/test/legacy_test/test_arg_min_max_v2_op.py
@@ -320,7 +320,7 @@ class TestArgMinMaxOpError(unittest.TestCase):
                 )
                 output = paddle.argmax(x=data, dtype="float32")
 
-            self.assertRaises(ValueError, test_argmax_attr_type)
+            self.assertRaises(TypeError, test_argmax_attr_type)
 
             def test_argmin_attr_type():
                 data = paddle.static.data(
@@ -328,7 +328,7 @@ class TestArgMinMaxOpError(unittest.TestCase):
                 )
                 output = paddle.argmin(x=data, dtype="float32")
 
-            self.assertRaises(ValueError, test_argmin_attr_type)
+            self.assertRaises(TypeError, test_argmin_attr_type)
 
             def test_argmax_axis_type():
                 data = paddle.static.data(
@@ -436,7 +436,6 @@ class TestArgmaxAPI_Compatibility(unittest.TestCase):
         np_api = eval(f"np.{api_name}")
         ref_out = np_api(self.np_input, 1)
         # Check
-        count = 1
         for out in paddle_dygraph_out:
             np.testing.assert_allclose(ref_out, out.numpy())
         paddle.enable_static()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Operator Mechanism
### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes 

### Description
<!-- Describe what you’ve done -->
修复python c code gen生成时的bug
- 改变动态图中从``` GetTensorFromArgsOrKWArgs ``` 返回值获取Tensor的方式。从原来的copy变成引用，确保往下传递的Tensor和Python向C++传递的Tensor是同一个。
- 将argmax、argmin的改为用装饰器代替下沉，避免args mapper导致的Tensor拷贝。
- 将matmul改为下沉实现