### PR TITLE
[API compatibility]  prod and sum add out

### DIFF
--- a/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
@@ -90,7 +90,7 @@ PARSE_PYTHON_C_TENSORS_TEMPLATE = (
 PARSE_PYTHON_C_TENSOR_REF_TEMPLATE = (
     '    auto& {} = {}("{}", "{}", args, {}, {});\n'
 )
-PARSE_PYTHON_C_TENSORS_FROM_ARGS_OR_KWARGS_TEMPLATE = '    auto {} = GetTensorFromArgsOrKWArgs("{}", "{}", args, {}, kwargs,{},nargs,&remaining_kwargs,{});\n'
+PARSE_PYTHON_C_TENSORS_FROM_ARGS_OR_KWARGS_TEMPLATE = '    auto& {} = GetTensorFromArgsOrKWArgs("{}", "{}", args, {}, kwargs,{},nargs,&remaining_kwargs,{});\n'
 PARSE_PYTHON_C_OPTIONAL_TENSORS_FROM_ARGS_OR_KWARGS_TEMPLATE = '    auto {} = GetOptionalTensorFromArgsOrKWArgs("{}", "{}", args, {}, kwargs,{},nargs,&remaining_kwargs,{});\n'
 CONVERT_TO_DISTTENSOR_AND_PARSE_PYTHON_C_TENSORS_TEMPLATE = (
     '    {} = {}("{}", "{}", args, {}, {}, mesh);\n'

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -4546,6 +4546,7 @@ def prod(
     axis: int | Sequence[int] | None = None,
     keepdim: bool = False,
     dtype: DTypeLike | None = None,
+    out: Tensor | None = None,
     name: str | None = None,
 ) -> Tensor:
     """
@@ -4569,6 +4570,7 @@ def prod(
             float16, float32, float64, int32, int64. If specified, the input tensor is casted to dtype before
             operator performed. This is very useful for avoiding data type overflows. The default value is None,
             the dtype of output is the same as input Tensor `x`.
+        out (Tensor|None, optional): The output tensor. Default: None.
         name (str|None, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
 
     Returns:
@@ -4646,7 +4648,7 @@ def prod(
 
     reduce_all, axis = _get_reduce_axis_with_tensor(axis, x)
     if in_dynamic_or_pir_mode():
-        return _C_ops.prod(x, axis, keepdim, reduce_all)
+        return _C_ops.prod(x, axis, keepdim, reduce_all, out=out)
     else:
         helper = LayerHelper('reduce_prod', **locals())
         check_variable_and_dtype(

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -1532,6 +1532,7 @@ def sum(
     axis: int | Sequence[int] | None = None,
     dtype: DTypeLike | None = None,
     keepdim: bool = False,
+    out: Tensor | None = None,
     name: str | None = None,
 ) -> Tensor:
     """
@@ -1559,6 +1560,7 @@ def sum(
             output Tensor. The result Tensor will have one fewer dimension
             than the :attr:`x` unless :attr:`keepdim` is true, default
             value is False.
+        out (Tensor|None, optional): The output tensor. Default: None.
         name (str|None, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
 
     Returns:
@@ -1637,11 +1639,11 @@ def sum(
             dtype = convert_np_dtype_to_dtype_(dtype)
 
     if in_dynamic_mode():
-        return _C_ops.sum(x, axis, dtype, keepdim)
+        return _C_ops.sum(x, axis, dtype, keepdim, out=out)
     else:
         reduce_all, axis = _get_reduce_axis_with_tensor(axis, x)
         if in_pir_mode():
-            return _C_ops.sum(x, axis, dtype, keepdim)
+            return _C_ops.sum(x, axis, dtype, keepdim, out=out)
         else:
             attrs = {'dim': axis, 'keep_dim': keepdim}
 

--- a/test/dygraph_to_static/test_error.py
+++ b/test/dygraph_to_static/test_error.py
@@ -353,7 +353,7 @@ class TestKeyError(unittest.TestCase):
 @paddle.jit.to_static(full_graph=True)
 def NpApiErr():
     a = paddle.to_tensor([1, 2])
-    b = np.sum(a.numpy())
+    b = np.count_nonzero(a.numpy())
     print(b)
 
 

--- a/test/legacy_test/test_sum_decorator.py
+++ b/test/legacy_test/test_sum_decorator.py
@@ -96,6 +96,23 @@ class TestSumOp_Compatibility(unittest.TestCase):
                 paddle_result10 = paddle.sum(x_paddle, self.axis, dtype_input)
                 np.testing.assert_allclose(paddle_result10, numpy_result)
 
+                paddle_result11 = paddle.empty(
+                    numpy_result.shape, dtype=dtype_input
+                )
+                paddle.sum(
+                    x_paddle, self.axis, dtype_input, False, out=paddle_result11
+                )
+                np.testing.assert_allclose(paddle_result11, numpy_result)
+
+                paddle_result12 = paddle.empty(
+                    numpy_result.shape, dtype=dtype_input
+                )
+                paddle_result13 = paddle.sum(
+                    x_paddle, self.axis, dtype_input, out=paddle_result12
+                )
+                np.testing.assert_allclose(paddle_result12, numpy_result)
+                np.testing.assert_allclose(paddle_result13, numpy_result)
+
     def test_static(self):
         self.test_dtypes = [
             paddle.int32,
@@ -175,6 +192,27 @@ class TestSumOp_Compatibility(unittest.TestCase):
                         x_paddle, self.axis, dtype_input
                     )
                     self.assertEqual(paddle_result10.dtype, dtype_input)
+
+                    paddle_result11 = paddle.empty(
+                        self.shape, dtype=dtype_input
+                    )
+                    paddle.sum(
+                        x_paddle,
+                        self.axis,
+                        dtype_input,
+                        False,
+                        out=paddle_result11,
+                    )
+                    self.assertEqual(paddle_result11.dtype, dtype_input)
+
+                    paddle_result12 = paddle.empty(
+                        self.shape, dtype=dtype_input
+                    )
+                    paddle_result13 = paddle.sum(
+                        x_paddle, self.axis, dtype_input, out=paddle_result12
+                    )
+                    self.assertEqual(paddle_result12.dtype, dtype_input)
+                    self.assertEqual(paddle_result13.dtype, dtype_input)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
给 prod、sum 增加 out

单测修改：test/dygraph_to_static/test_error.py 中 NpApiErr()调用的np.sum()，替换成np.count_nonzero()。补充说明：
本单测用于测试动转静能够正确捕获 numpy error，但是本 PR 为 paddle.sum/paddle.Tensor.sum 添加了参数 out，使得这里不再报错，因为 np.sum 的 dispatch 逻辑如下：
<img width="1372" height="682" alt="image" src="https://github.com/user-attachments/assets/8dbcab1d-1267-4971-95a1-6f9bf1b72d94" />
即对于非 np 数据 x，np.sum(x) 会转发到 x.sum()，但是会传递 kwarg out，而此前 sum 是不支持的，因此报错
本 PR 支持后不再报错，因此调整 API 为 np.count_nonzero

pcard-67164