### PR TITLE
[Bug Fix] fix the bug in constrcut Tensor with diference place

### DIFF
--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -128,18 +128,24 @@ else:
         device = framework._get_paddle_place(device)
         if len(args) == 0 and len(kwargs) == 0:  # case 1, 2
             original_init(
-                self, paddle.empty(shape=[0], dtype='float32'), place=device
+                self,
+                paddle.empty(shape=[0], dtype='float32', device=device),
+                place=device,
             )
             return
         if 'data' in kwargs:  # case 7,8
             data = kwargs.pop('data')
             original_init(
-                self, paddle.tensor(data, dtype='float32'), place=device
+                self,
+                paddle.tensor(data, dtype='float32', device=device),
+                place=device,
             )
         elif len(args) == 1 and isinstance(args[0], (list, tuple)):
             # case 5, 6
             original_init(
-                self, paddle.tensor(args[0], dtype='float32'), place=device
+                self,
+                paddle.tensor(args[0], dtype='float32', device=device),
+                place=device,
             )
         elif (
             builtins.all(isinstance(arg, int) for arg in args)
@@ -148,7 +154,7 @@ else:
             # case 3, 4
             original_init(
                 self,
-                paddle.empty(shape=list(args), dtype='float32'),
+                paddle.empty(shape=list(args), dtype='float32', device=device),
                 place=device,
             )
         else:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

**问题描述**：
当前paddle.Tensor的构造函数中新增了4种构造方式，他们都是依赖于paddle.empty或paddle.tensor去实现的。这两个API会自己检测当前的设备从而去确定设置到哪个place上。但新增的paddle.Tensor()构造方法其实都是希望在不指定device时，创建在CPU上的。

在实现过程中，其实只有在调original_init()的时候设置了device，而在用paddle.empty或paddle.tensor创建Tensor时没有设置device，这就导致了GPU环境下paddle.Tensor()执行时，会先创建GPU的paddle.empty([0])，然后再通过original_init()转化成cpu的Tensor存在拷贝开销。

此外在python/paddle/incubate/multiprocessing/reductions.py中，
![image](https://github.com/user-attachments/assets/26f383fa-ec72-4a93-b8e0-c4a85dc98866)
这个位置会走一步先empty构造成GPU Tensor再用original_init构造成CPU Tensor的操作。

如果这个函数在multiprocess创建的子进程中调用，则会出现cuda环境初始化失败的现象，进而导致Tensor创建失败。
![image](https://github.com/user-attachments/assets/6f68714a-3538-480d-b6fc-f9a24de8fdbc)

**解决方案**：
对于新增的几个构造方法，除了给original_init添加place参数外，还给paddle.empty()和paddle.tensor()里添加device参数，确保创建Tensor的过程中，place保持一致。

pcard-71500