### PR TITLE
Support customizable dataloader reader‘s buffersize

### DIFF
--- a/paddle/fluid/pybind/reader_py.cc
+++ b/paddle/fluid/pybind/reader_py.cc
@@ -143,7 +143,8 @@ class MultiDeviceFeedReader {
       const std::vector<phi::Place> &dst_places,
       bool use_double_buffer,
       bool drop_last,
-      bool pin_memory = false)
+      bool pin_memory = false,
+      int reader_buffer_size = 2)
       : queue_(queue),
         names_(names),
         pool_(new ::ThreadPool(dst_places.size())),
@@ -152,7 +153,8 @@ class MultiDeviceFeedReader {
         exceptions_(),
         ret_(),
         drop_last_(drop_last),
-        pin_memory_(pin_memory) {
+        pin_memory_(pin_memory),
+        reader_buffer_size_(reader_buffer_size) {
     std::vector<phi::DDim> dims;
     for (auto &shape : shapes) {
       dims.push_back(common::make_ddim(shape));
@@ -172,15 +174,18 @@ class MultiDeviceFeedReader {
     };
 
     readers_.reserve(dst_places.size());
+    if (reader_buffer_size_ <= 2) {
+      reader_buffer_size_ = 2;
+    }
     for (size_t i = 0; i < dst_places.size(); ++i) {
       auto &p = dst_places[i];
       auto *holder = new framework::ReaderHolder();
       auto reader = create_or_get_reader(i);
       if (use_double_buffer) {
-        VLOG(10) << "Creating " << i << "-th BufferedReader";
+        VLOG(3) << "Creating " << i << "-th BufferedReader" << " with buffer_size: " << reader_buffer_size_;
         holder->Reset(
             framework::MakeDecoratedReader<operators::reader::BufferedReader>(
-                reader, p, 2, pin_memory_));
+                reader, p, reader_buffer_size_, pin_memory_));
       } else {
         if (phi::is_gpu_place(p)) {
           PADDLE_THROW(common::errors::PermissionDenied(
@@ -349,6 +354,7 @@ class MultiDeviceFeedReader {
   std::vector<phi::TensorArray> ret_;
   bool drop_last_;
   bool pin_memory_;
+  int reader_buffer_size_;
 };
 
 template <typename QueueType>
@@ -501,7 +507,8 @@ void BindReader(py::module *module) {
          const std::vector<phi::Place> &dst_places,
          bool use_double_buffer,
          bool drop_last,
-         bool pin_memory) {
+         bool pin_memory,
+         int reader_buffer_size = 2) {
         return new MultiDeviceFeedReader<reader::DenseTensorBlockingQueue>(
             queue,
             names,
@@ -511,7 +518,8 @@ void BindReader(py::module *module) {
             dst_places,
             use_double_buffer,
             drop_last,
-            pin_memory);
+            pin_memory,
+            reader_buffer_size);
       },
       py::return_value_policy::take_ownership);
 
@@ -526,7 +534,8 @@ void BindReader(py::module *module) {
          const std::vector<phi::Place> &dst_places,
          bool use_double_buffer,
          bool drop_last,
-         bool pin_memory) {
+         bool pin_memory,
+         int reader_buffer_size = 2) {
         queue->SetDeviceCount(dst_places.size());
         return new MultiDeviceFeedReader<
             reader::OrderedMultiDeviceDenseTensorBlockingQueue>(
@@ -538,7 +547,8 @@ void BindReader(py::module *module) {
             dst_places,
             use_double_buffer,
             drop_last,
-            pin_memory);
+            pin_memory,
+            reader_buffer_size);
       },
       py::return_value_policy::take_ownership);
 }

--- a/paddle/fluid/pybind/reader_py.cc
+++ b/paddle/fluid/pybind/reader_py.cc
@@ -182,7 +182,8 @@ class MultiDeviceFeedReader {
       auto *holder = new framework::ReaderHolder();
       auto reader = create_or_get_reader(i);
       if (use_double_buffer) {
-        VLOG(3) << "Creating " << i << "-th BufferedReader" << " with buffer_size: " << reader_buffer_size_;
+        VLOG(3) << "Creating " << i << "-th BufferedReader"
+                << " with buffer_size: " << reader_buffer_size_;
         holder->Reset(
             framework::MakeDecoratedReader<operators::reader::BufferedReader>(
                 reader, p, reader_buffer_size_, pin_memory_));

--- a/paddle/fluid/pybind/reader_py.cc
+++ b/paddle/fluid/pybind/reader_py.cc
@@ -509,7 +509,7 @@ void BindReader(py::module *module) {
          bool use_double_buffer,
          bool drop_last,
          bool pin_memory,
-         int reader_buffer_size = 2) {
+         int reader_buffer_size) {
         return new MultiDeviceFeedReader<reader::DenseTensorBlockingQueue>(
             queue,
             names,
@@ -522,6 +522,16 @@ void BindReader(py::module *module) {
             pin_memory,
             reader_buffer_size);
       },
+      py::arg("queue"),
+      py::arg("names"),
+      py::arg("shapes"),
+      py::arg("dtypes"),
+      py::arg("need_check_feed"),
+      py::arg("dst_places"),
+      py::arg("use_double_buffer"),
+      py::arg("drop_last"),
+      py::arg("pin_memory"),
+      py::arg("reader_buffer_size") = 2,
       py::return_value_policy::take_ownership);
 
   m.def(
@@ -536,7 +546,7 @@ void BindReader(py::module *module) {
          bool use_double_buffer,
          bool drop_last,
          bool pin_memory,
-         int reader_buffer_size = 2) {
+         int reader_buffer_size) {
         queue->SetDeviceCount(dst_places.size());
         return new MultiDeviceFeedReader<
             reader::OrderedMultiDeviceDenseTensorBlockingQueue>(
@@ -551,6 +561,16 @@ void BindReader(py::module *module) {
             pin_memory,
             reader_buffer_size);
       },
+      py::arg("queue"),
+      py::arg("names"),
+      py::arg("shapes"),
+      py::arg("dtypes"),
+      py::arg("need_check_feed"),
+      py::arg("dst_places"),
+      py::arg("use_double_buffer"),
+      py::arg("drop_last"),
+      py::arg("pin_memory"),
+      py::arg("reader_buffer_size") = 2,
       py::return_value_policy::take_ownership);
 }
 

--- a/python/paddle/io/dataloader/dataloader_iter.py
+++ b/python/paddle/io/dataloader/dataloader_iter.py
@@ -97,6 +97,7 @@ class _DataLoaderIterBase:
         self._auto_collate_batch = loader.auto_collate_batch
         self._num_workers = loader.num_workers
         self._use_buffer_reader = loader.use_buffer_reader
+        self._reader_buffer_size = loader.reader_buffer_size
         self._prefetch_factor = loader.prefetch_factor
         self._use_shared_memory = loader.use_shared_memory
         self._timeout = (
@@ -222,6 +223,7 @@ class _DataLoaderIterSingleProcess(_DataLoaderIterBase):
             self._use_buffer_reader,
             True,
             self._pin_memory,
+            self._reader_buffer_size,
         )
 
         self._thread = threading.Thread(
@@ -530,6 +532,7 @@ class _DataLoaderIterMultiProcess(_DataLoaderIterBase):
             self._use_buffer_reader,
             True,
             self._pin_memory,
+            self._reader_buffer_size,
         )
 
         self._thread_done_event = threading.Event()

--- a/python/paddle/io/reader.py
+++ b/python/paddle/io/reader.py
@@ -347,6 +347,11 @@ class DataLoader:
             batch data asynchronously, so it would speed up data feeding
             and occupies a little more CPU or GPU memory, i.e., the memory
             of one batch input data. Default True.
+        reader_buffer_size (int, optional): This option takes effect onl
+            when use_buffer_reader is set to True. It specifies the number of
+            batches the buffer reader prefetches in advance. Note that 
+            Increasing this value will result in a linear increase in CPU or GPU memory usage.
+            Default 2.
         prefetch_factor (int, optional): Number of batch data the DataLoader would prefetch
             if use_buffer_reader=True. Default 2.
         use_shared_memory (bool, optional): whether to use shared memory to speed up
@@ -435,6 +440,7 @@ class DataLoader:
     return_list: bool
     collate_fn: _CollateFn | None
     use_buffer_reader: bool
+    reader_buffer_size: int
     prefetch_factor: int
     worker_init_fn: Callable[[int], None] | None
     dataset: Dataset[Any]
@@ -461,6 +467,7 @@ class DataLoader:
         collate_fn: _CollateFn | None = None,
         num_workers: int = 0,
         use_buffer_reader: bool = True,
+        reader_buffer_size: int = 2,
         prefetch_factor: int = 2,
         use_shared_memory: bool = True,
         timeout: int = 0,
@@ -470,6 +477,7 @@ class DataLoader:
         self.return_list = return_list
         self.collate_fn = collate_fn
         self.use_buffer_reader = use_buffer_reader
+        self.reader_buffer_size = reader_buffer_size
         self.prefetch_factor = prefetch_factor
         self.worker_init_fn = worker_init_fn
 

--- a/python/paddle/io/reader.py
+++ b/python/paddle/io/reader.py
@@ -347,9 +347,9 @@ class DataLoader:
             batch data asynchronously, so it would speed up data feeding
             and occupies a little more CPU or GPU memory, i.e., the memory
             of one batch input data. Default True.
-        reader_buffer_size (int, optional): This option takes effect onl
+        reader_buffer_size (int, optional): This option takes effect only
             when use_buffer_reader is set to True. It specifies the number of
-            batches the buffer reader prefetches in advance. Note that 
+            batches the buffer reader prefetches in advance. Note that
             Increasing this value will result in a linear increase in CPU or GPU memory usage.
             Default 2.
         prefetch_factor (int, optional): Number of batch data the DataLoader would prefetch


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
Dataloader 支持自定义 reader_buffer_size，用于控制buffer区的大小（调用一次 __next__ 方法获取的全量数据的size为1）。该功能用于适配PP的数据流，便于上层代码多次读取 micro batch 组成batch 一次性送入组网训练。

Pcard-76459