### PR TITLE
[PHI] PyTorch aligned scatter reduce kernels for integer mean

### DIFF
--- a/test/legacy_test/test_higher_dim_scatter.py
+++ b/test/legacy_test/test_higher_dim_scatter.py
@@ -591,23 +591,7 @@ class TestPutAlongAxisFP16MulDuplicatedIndices(unittest.TestCase):
 
 class TestPutAlongAxisIntegerMean(unittest.TestCase):
     def setUp(self):
-        self.input = paddle.arange(-16, 16, 1, dtype=paddle.int32).reshape(
-            [4, 4, 2]
-        )
-        self.src = paddle.full([4, 4, 2], -3, dtype=paddle.int32)
-        self.index = paddle.zeros([4, 4, 2], dtype=paddle.int64)
-        self.dim = 1
-
-    def test_mean_int(self):
-        result = paddle.put_along_axis(
-            self.input,
-            indices=self.index,
-            values=self.src,
-            axis=self.dim,
-            reduce='mean',
-            include_self=True,
-        )
-        gt_result = np.array(
+        self.gt_result = np.array(
             [
                 [[-6, -6], [-14, -13], [-12, -11], [-10, -9]],
                 [[-4, -4], [-6, -5], [-4, -3], [-2, -1]],
@@ -616,7 +600,35 @@ class TestPutAlongAxisIntegerMean(unittest.TestCase):
             ],
             dtype='int32',
         )
-        np.testing.assert_array_equal(result.numpy(), gt_result)
+
+    def _make_static_mean_int(self, place):
+        paddle.enable_static()
+        with paddle.static.program_guard(paddle.static.Program()):
+            input_ = paddle.arange(-16, 16, 1, dtype=paddle.int32).reshape(
+                [4, 4, 2]
+            )
+            src = paddle.full([4, 4, 2], -3, dtype=paddle.int32)
+            index = paddle.zeros([4, 4, 2], dtype=paddle.int64)
+            result = paddle.put_along_axis(
+                input_,
+                indices=index,
+                values=src,
+                axis=1,
+                reduce='mean',
+                include_self=True,
+            )
+
+            exe = paddle.static.Executor(place)
+            result_np = exe.run(fetch_list=[result])
+            np.testing.assert_array_equal(result_np[0], self.gt_result)
+        paddle.disable_static()
+
+    def test_mean_int(self):
+        # try testing with both CPU and GPU places
+        if paddle.is_compiled_with_cuda():
+            self._make_static_mean_int(paddle.CUDAPlace(0))
+            paddle.CUDAPlace(0)
+        self._make_static_mean_int(paddle.CPUPlace())
 
 
 if __name__ == '__main__':

--- a/test/legacy_test/test_higher_dim_scatter.py
+++ b/test/legacy_test/test_higher_dim_scatter.py
@@ -20,10 +20,6 @@ import paddle
 from paddle import core
 
 
-@unittest.skipIf(
-    not core.is_compiled_with_cuda(),
-    "CPU scatter/gather kernel is not yet modified, coming soon and this skipping will be removed.",
-)
 class TestNonBroadcastableMismatchedShapeCase(unittest.TestCase):
     """Unittest from PyTorch comparison and handcrafted backward result
     Note that this unit test might fail, if you modify the implementation
@@ -428,10 +424,6 @@ class TestNonBroadcastableMismatchedShapeCase(unittest.TestCase):
         )
 
 
-@unittest.skipIf(
-    not core.is_compiled_with_cuda(),
-    "CPU scatter/gather kernel is not yet modified, coming soon and this skipping will be removed.",
-)
 class TestPutAlongAxisNonIncludeSelf2ndGrad(unittest.TestCase):
     """Test case from issue 72803"""
 
@@ -572,6 +564,59 @@ class TestPutAlongAxisNonIncludeSelf2ndGrad(unittest.TestCase):
         np.testing.assert_allclose(dx.numpy(), self.gt_dx, 1e-6, 1e-6)
         np.testing.assert_allclose(dv.numpy(), self.gt_dv, 1e-6, 1e-6)
         np.testing.assert_allclose(ddout.numpy(), self.gt_ddout, 1e-6, 1e-6)
+
+
+@unittest.skipIf(
+    not core.is_compiled_with_cuda(),
+    "CPU FP16 is not supported",
+)
+class TestPutAlongAxisFP16MulDuplicatedIndices(unittest.TestCase):
+    def setUp(self):
+        self.input = paddle.ones(16, dtype=paddle.float16)
+        self.src = paddle.arange(
+            0.9, 0.9 + 0.02 * 16, 0.02, dtype=paddle.float16
+        )
+        self.index = paddle.zeros(16, dtype=paddle.int64)
+
+    def test_fp16_mul_reduce(self):
+        res = paddle.put_along_axis(
+            self.input, self.index, self.src, axis=0, reduce='mul'
+        )
+        gt = np.ones(16, dtype=np.float64)
+        gt[0] = np.arange(0.9, 0.9 + 16 * 0.02, 0.02).prod()
+        np.testing.assert_allclose(
+            res.numpy().astype(np.float64), gt, rtol=1e-2, atol=1e-2
+        )
+
+
+class TestPutAlongAxisIntegerMean(unittest.TestCase):
+    def setUp(self):
+        self.input = paddle.arange(-16, 16, 1, dtype=paddle.int32).reshape(
+            [4, 4, 2]
+        )
+        self.src = paddle.full([4, 4, 2], -3, dtype=paddle.int32)
+        self.index = paddle.zeros([4, 4, 2], dtype=paddle.int64)
+        self.dim = 1
+
+    def test_mean_int(self):
+        result = paddle.put_along_axis(
+            self.input,
+            indices=self.index,
+            values=self.src,
+            axis=self.dim,
+            reduce='mean',
+            include_self=True,
+        )
+        gt_result = np.array(
+            [
+                [[-6, -6], [-14, -13], [-12, -11], [-10, -9]],
+                [[-4, -4], [-6, -5], [-4, -3], [-2, -1]],
+                [[-3, -3], [2, 3], [4, 5], [6, 7]],
+                [[-1, -1], [10, 11], [12, 13], [14, 15]],
+            ],
+            dtype='int32',
+        )
+        np.testing.assert_array_equal(result.numpy(), gt_result)
 
 
 if __name__ == '__main__':

--- a/test/legacy_test/test_higher_dim_scatter.py
+++ b/test/legacy_test/test_higher_dim_scatter.py
@@ -591,44 +591,62 @@ class TestPutAlongAxisFP16MulDuplicatedIndices(unittest.TestCase):
 
 class TestPutAlongAxisIntegerMean(unittest.TestCase):
     def setUp(self):
-        self.gt_result = np.array(
+        self.gt_include_self = np.array(
             [
-                [[-6, -6], [-14, -13], [-12, -11], [-10, -9]],
-                [[-4, -4], [-6, -5], [-4, -3], [-2, -1]],
-                [[-3, -3], [2, 3], [4, 5], [6, 7]],
-                [[-1, -1], [10, 11], [12, 13], [14, 15]],
+                [[-8, -7, -7, -7], [-12, -11, -10, -9]],
+                [[-5, -5, -4, -4], [-4, -3, -2, -1]],
+                [[-2, -2, -2, -1], [4, 5, 6, 7]],
+                [[0, 1, 1, 1], [12, 13, 14, 15]],
+            ],
+            dtype='int32',
+        )
+        self.gt_exclude_self = np.array(
+            [
+                [[-3, -3, -3, -3], [-12, -11, -10, -9]],
+                [[-3, -3, -3, -3], [-4, -3, -2, -1]],
+                [[-3, -3, -3, -3], [4, 5, 6, 7]],
+                [[-3, -3, -3, -3], [12, 13, 14, 15]],
             ],
             dtype='int32',
         )
 
-    def _make_static_mean_int(self, place):
+    def _make_static_mean_int(self, gt, include_self, place):
         paddle.enable_static()
         with paddle.static.program_guard(paddle.static.Program()):
             input_ = paddle.arange(-16, 16, 1, dtype=paddle.int32).reshape(
-                [4, 4, 2]
+                [4, 2, 4]
             )
-            src = paddle.full([4, 4, 2], -3, dtype=paddle.int32)
-            index = paddle.zeros([4, 4, 2], dtype=paddle.int64)
+            src = paddle.full([4, 2, 4], -3, dtype=paddle.int32)
+            index = paddle.zeros([4, 2, 4], dtype=paddle.int64)
             result = paddle.put_along_axis(
                 input_,
                 indices=index,
                 values=src,
                 axis=1,
                 reduce='mean',
-                include_self=True,
+                include_self=include_self,
             )
 
             exe = paddle.static.Executor(place)
             result_np = exe.run(fetch_list=[result])
-            np.testing.assert_array_equal(result_np[0], self.gt_result)
+            np.testing.assert_array_equal(result_np[0], gt)
         paddle.disable_static()
 
     def test_mean_int(self):
         # try testing with both CPU and GPU places
         if paddle.is_compiled_with_cuda():
-            self._make_static_mean_int(paddle.CUDAPlace(0))
-            paddle.CUDAPlace(0)
-        self._make_static_mean_int(paddle.CPUPlace())
+            self._make_static_mean_int(
+                self.gt_include_self, True, paddle.CUDAPlace(0)
+            )
+            self._make_static_mean_int(
+                self.gt_exclude_self, False, paddle.CUDAPlace(0)
+            )
+        self._make_static_mean_int(
+            self.gt_include_self, True, paddle.CPUPlace()
+        )
+        self._make_static_mean_int(
+            self.gt_exclude_self, False, paddle.CPUPlace()
+        )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Operator Mechanism


### PR Types
Improvements


### Description

- 修改了 scatter kernels 的行为，主要影响调用 `gather_scatter_kernel.cc/cu` 中，reduce=mean 且输入为 int 类型情况下的 API（比如 `put_along_axis`）。原始行为是向零取整，现改为向下取整（`-4.5` -> `-5`）。CPU/GPU 均修改。
- 增加了 FP16 reduce mul 的测试（修复见 #75015 )，增加了 integer scatter reduce mean 的测试（本 PR）。取消了 `test/legacy_test/test_higher_dim_scatter.py` 原有单测的 skipIf，因为目前 CPU 修复 #74995 已经合入。


Pcard-89620