### PR TITLE
[Compat] Add some `paddle.library` APIs

### DIFF
--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -194,6 +194,7 @@ from . import (
     compat as compat,
     fft as fft,
     hub as hub,
+    library as library,
     linalg as linalg,
     signal as signal,
     special as special,

--- a/python/paddle/_classes.py
+++ b/python/paddle/_classes.py
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+#  #The file has been adapted from pytorch project
+#  #Licensed under  BSD-style license -
+#  https://github.com/pytorch/pytorch/blob/main/LICENSE
+
 from __future__ import annotations
 
 import types

--- a/python/paddle/library.py
+++ b/python/paddle/library.py
@@ -141,11 +141,8 @@ def custom_op(
     return inner(fn)
 
 
-_op_identifier = str | CustomOpDef
-
-
 def register_fake(
-    op: _op_identifier,
+    op: str | CustomOpDef,
     func: Callable[..., object] | None = None,
     /,
     *,

--- a/python/paddle/library.py
+++ b/python/paddle/library.py
@@ -20,11 +20,13 @@ from __future__ import annotations
 
 import warnings
 from collections.abc import Callable, Iterable, Sequence
-from typing import Literal, overload
+from typing import Literal, Union, overload
+
+from typing_extensions import TypeAlias
 
 from ._ops import PYTHON_OP_REGISTRY
 
-device_types_t = str | Sequence[str] | None
+_DeviceTypes: TypeAlias = Union[str, Sequence[str], None]
 
 
 def warn_about_unimplemented_torch_features(feature: str, fn_name: str) -> None:
@@ -76,7 +78,7 @@ def custom_op(
     /,
     *,
     mutates_args: str | Iterable[str],
-    device_types: device_types_t = None,
+    device_types: _DeviceTypes = None,
     schema: str | None = None,
     tags: Sequence[Tag] | None = None,
 ) -> Callable[[Callable[..., object]], CustomOpDef]: ...
@@ -89,7 +91,7 @@ def custom_op(
     /,
     *,
     mutates_args: str | Iterable[str],
-    device_types: device_types_t = None,
+    device_types: _DeviceTypes = None,
     schema: str | None = None,
     tags: Sequence[Tag] | None = None,
 ) -> CustomOpDef: ...
@@ -101,7 +103,7 @@ def custom_op(
     /,
     *,
     mutates_args: str | Iterable[str],
-    device_types: device_types_t = None,
+    device_types: _DeviceTypes = None,
     schema: str | None = None,
     tags: Sequence[Tag] | None = None,
 ) -> Callable[[Callable[..., object]], CustomOpDef] | CustomOpDef:

--- a/python/paddle/library.py
+++ b/python/paddle/library.py
@@ -1,0 +1,156 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#  #The file has been adapted from pytorch project
+#  #Licensed under  BSD-style license -
+#  https://github.com/pytorch/pytorch/blob/main/LICENSE
+
+from __future__ import annotations
+
+import warnings
+from collections.abc import Callable, Iterable, Sequence
+from typing import Literal, overload
+
+from ._ops import PYTHON_OP_REGISTRY
+
+device_types_t = str | Sequence[str] | None
+
+
+def warn_about_unimplemented_torch_features(feature: str, fn_name: str) -> None:
+    warnings.warn(
+        f"The feature '{feature}' in function '{fn_name}' is not implemented in PaddlePaddle's custom operator interface.",
+        UserWarning,
+        stacklevel=2,
+    )
+
+
+class Tag: ...
+
+
+class CustomOpDef:
+    def __init__(
+        self,
+        namespace: str,
+        name: str,
+        schema: str,
+        fn: Callable,
+        tags: Sequence[Tag] | None = None,
+    ) -> None:
+        self._namespace = namespace
+        self._name = name
+        self._schema = schema
+        self._fn = fn
+        self._tags = tags if tags is not None else []
+
+    @property
+    def _qualname(self) -> str:
+        return f"{self._namespace}::{self._name}"
+
+    def __repr__(self) -> str:
+        return f"<CustomOpDef({self._qualname})>"
+
+    def register_fake(
+        self, fn: Callable[..., object], /
+    ) -> Callable[..., object]:
+        warn_about_unimplemented_torch_features(
+            "register_fake", "torch.library.CustomOpDef"
+        )
+        return fn
+
+
+@overload
+def custom_op(
+    name: str,
+    fn: Literal[None] = None,
+    /,
+    *,
+    mutates_args: str | Iterable[str],
+    device_types: device_types_t = None,
+    schema: str | None = None,
+    tags: Sequence[Tag] | None = None,
+) -> Callable[[Callable[..., object]], CustomOpDef]: ...
+
+
+@overload
+def custom_op(
+    name: str,
+    fn: Callable[..., object],
+    /,
+    *,
+    mutates_args: str | Iterable[str],
+    device_types: device_types_t = None,
+    schema: str | None = None,
+    tags: Sequence[Tag] | None = None,
+) -> CustomOpDef: ...
+
+
+def custom_op(
+    name: str,
+    fn: Callable[..., object] | None = None,
+    /,
+    *,
+    mutates_args: str | Iterable[str],
+    device_types: device_types_t = None,
+    schema: str | None = None,
+    tags: Sequence[Tag] | None = None,
+) -> Callable[[Callable[..., object]], CustomOpDef] | CustomOpDef:
+    if device_types:
+        warn_about_unimplemented_torch_features(
+            "device_types", "torch.library.custom_op"
+        )
+    if schema:
+        warn_about_unimplemented_torch_features(
+            "schema", "torch.library.custom_op"
+        )
+    if tags:
+        warn_about_unimplemented_torch_features(
+            "tags", "torch.library.custom_op"
+        )
+
+    assert "::" in name, (
+        "The custom operator name should be qualified with a namespace, "
+        "like 'my_namespace::my_op'."
+    )
+    namespace, op_name = name.split("::", 1)
+
+    def inner(fn: Callable[..., object]) -> CustomOpDef:
+        PYTHON_OP_REGISTRY.register(name, fn)
+        return CustomOpDef(
+            namespace=namespace,
+            name=op_name,
+            schema=schema if schema is not None else "",
+            fn=fn,
+            tags=tags,
+        )
+
+    if fn is None:
+        return inner
+    return inner(fn)
+
+
+_op_identifier = str | CustomOpDef
+
+
+def register_fake(
+    op: _op_identifier,
+    func: Callable[..., object] | None = None,
+    /,
+    *,
+    lib: None = None,
+    _stacklevel: int = 1,
+    allow_override: bool = False,
+):
+    warn_about_unimplemented_torch_features(
+        "register_fake", "torch.library.register_fake"
+    )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -322,3 +322,4 @@ set_pir_tests_properties()
 
 add_subdirectory(deprecated)
 add_subdirectory(flex_checkpoint)
+add_subdirectory(compat)

--- a/test/compat/CMakeLists.txt
+++ b/test/compat/CMakeLists.txt
@@ -1,0 +1,9 @@
+file(
+  GLOB TEST_OPS
+  RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}"
+  "test_*.py")
+string(REPLACE ".py" "" TEST_OPS "${TEST_OPS}")
+
+foreach(TEST_OP ${TEST_OPS})
+  py_test_modules(${TEST_OP} MODULES ${TEST_OP})
+endforeach()

--- a/test/compat/test_library.py
+++ b/test/compat/test_library.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import paddle
+
+
+@paddle.library.custom_op(
+    "test_namespace::add_one",
+    mutates_args=(),
+)
+def add_one(x):
+    return x + 1
+
+
+@add_one.register_fake
+def add_one_fake_fn(x):
+    return x
+
+
+@paddle.library.custom_op(
+    "test_namespace::add_two",
+    mutates_args=(),
+)
+def add_two(x):
+    return x + 2
+
+
+class TestCallCustomOp(unittest.TestCase):
+    def test_call_custom_op(self):
+        self.assertEqual(paddle.ops.test_namespace.add_one(1), 2)
+
+
+class TestRegisterFake(unittest.TestCase):
+    def test_register_fake(self):
+        paddle.library.register_fake(
+            "test_namespace::add_two",
+            lambda x: x,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

New features

### Description
<!-- Describe what you’ve done -->

添加如下接口以实现 PyTorch 接口层兼容

- `torch.library.custom_op`
- `torch.ops.<namespace>.<py_op>`
- `torch.library.register_fake`

<!-- PCard-66972 -->