### PR TITLE
[DeepEP] Remove num_nvl_bytes limit under low-latency mode

### DIFF
--- a/paddle/fluid/distributed/collective/deep_ep/deep_ep.cpp
+++ b/paddle/fluid/distributed/collective/deep_ep/deep_ep.cpp
@@ -90,9 +90,10 @@ Buffer::Buffer(int rank,
   int64_t barrier_signal_ptr_bytes = NUM_MAX_NVL_PEERS * sizeof(int*);
 
   // Common checks
-  EP_HOST_ASSERT(num_nvl_bytes % NUM_BUFFER_ALIGNMENT_BYTES == 0 &&
-                 (num_nvl_bytes <= std::numeric_limits<int>::max() ||
-                  num_rdma_bytes == 0));
+  EP_HOST_ASSERT(
+      num_nvl_bytes % NUM_BUFFER_ALIGNMENT_BYTES == 0 &&
+      ((low_latency_mode || num_nvl_bytes <= std::numeric_limits<int>::max()) ||
+       num_rdma_bytes == 0));
   EP_HOST_ASSERT(
       num_rdma_bytes % NUM_BUFFER_ALIGNMENT_BYTES == 0 &&
       (low_latency_mode || num_rdma_bytes <= std::numeric_limits<int>::max()));


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Communication Library


### PR Types
Bug fixes


### Description
low-latency 模式下不用检查 num_nvl_bytes 的大小，因为我们的 low-latency 模式已经支持超过 INT_MAX 的 buffer

上次迁移新版的时候没注意覆盖了，这个地方不在 low-latency 文件内但也属于 low-latency 的领域，不能随便改，下次迁移要注意

Pcard-85711