### PR TITLE
new cuda api

### DIFF
--- a/python/paddle/cuda/__inti__.py
+++ b/python/paddle/cuda/__inti__.py
@@ -1,0 +1,156 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# paddle/cuda/__init__.py
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Union
+
+import paddle
+from paddle import CUDAPlace, CustomPlace
+from paddle.device import (
+    Stream as _PaddleStream,
+    stream_guard as _PaddleStreamGuard,
+)
+
+if TYPE_CHECKING:
+    from paddle.base import core
+
+DeviceLike = Union[CUDAPlace, CustomPlace, int, str, None]
+
+
+def _device_to_paddle(device: DeviceLike) -> str:
+    """
+    Convert a device spec (int, str, None) to Paddle device string 'gpu:X'.
+    Args:
+        device: None, int, or str like 'cuda:0' / 'gpu:0'
+    Returns:
+        str: Paddle device string
+    """
+    if isinstance(device, (CUDAPlace, CustomPlace)) or device is None:
+        return device
+    elif isinstance(device, int):
+        return f"gpu:{device}"
+    elif isinstance(device, str):
+        return device.replace("cuda", "gpu")
+    else:
+        raise TypeError(f"Unsupported device type: {type(device)}")
+
+
+def is_available() -> bool:
+    """
+    Mimics torch.cuda.is_available()
+    Returns True if CUDA is available and Paddle was built with CUDA support.
+    """
+    return paddle.device.cuda.device_count() >= 1
+
+
+def synchronize(device: DeviceLike = None) -> None:
+    """
+    Mimics torch.cuda.synchronize()
+    Args:
+        device (int | str | None): Device to synchronize.
+            - None: synchronize current device
+            - int: device index (e.g., 2 -> 'gpu:2')
+            - str: device string (e.g., 'cuda:0' or 'gpu:0')
+    """
+    dev = _device_to_paddle(device)
+    paddle.device.synchronize(dev)
+
+
+def current_stream(device: DeviceLike = None) -> core.CUDAStream:
+    """
+    Mimics torch.cuda.current_stream()
+    Returns the current stream for the specified device.
+    """
+    dev = _device_to_paddle(device)
+    return paddle.device.current_stream(dev)
+
+
+def get_device_properties(device: DeviceLike = None):
+    """
+    Mimics torch.cuda.get_device_properties()
+    Returns the properties of a given device.
+    """
+    dev = _device_to_paddle(device)
+    return paddle.device.cuda.get_device_properties(dev)
+
+
+def get_device_name(device: int | None = None) -> str:
+    """
+    Mimics torch.cuda.get_device_name()
+    Returns the name of a given CUDA device.
+    """
+    return paddle.device.cuda.get_device_name(device)
+
+
+def get_device_capability(device: int | None = None) -> tuple[int, int]:
+    """
+    Mimics torch.cuda.get_device_capability()
+    Returns the major and minor compute capability of a given device.
+    """
+    return paddle.device.cuda.get_device_capability(device)
+
+
+class StreamContext(_PaddleStreamGuard):
+    """
+    Torch style Stream context manager, inherited from Paddle's stream_guard.
+    """
+
+    def __init__(self, stream: _PaddleStream):
+        super().__init__(stream)
+
+
+def stream(stream_obj: paddle.device.Stream | None) -> StreamContext:
+    """
+    Mimics torch.cuda.stream()
+    A context manager that sets a given stream as the current stream.
+    """
+    return StreamContext(stream_obj)
+
+
+class Stream(_PaddleStream):
+    """
+    Torch API: torch.cuda.Stream -> Paddle: paddle.device.Stream
+    """
+
+    # PyTorch priority -> Paddle priority
+    _priority_map = {-1: 1, 0: 2}
+
+    def __init__(self, device=None, priority=0, *args, **kwargs):
+        """
+        Args:
+            device (int | str | None): device id/str/None
+            priority (int): PyTorch priority (-1, 0)
+        """
+        paddle_device = _device_to_paddle(device)
+
+        paddle_priority = self._priority_map.get(priority, 2)
+
+        super().__init__(
+            device=paddle_device, priority=paddle_priority, *args, **kwargs
+        )
+
+
+__all__ = [
+    "is_available",
+    "synchronize",
+    "current_stream",
+    "get_device_properties",
+    "get_device_name",
+    "get_device_capability",
+    "stream",
+    "Stream",
+]

--- a/test/cuda/test_cuda_unittest.py
+++ b/test/cuda/test_cuda_unittest.py
@@ -1,0 +1,124 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# test_cuda_unittest.py
+import unittest
+
+import paddle
+from paddle.cuda import (
+    Stream,
+    StreamContext,
+    _device_to_paddle,
+    current_stream,
+    get_device_capability,
+    get_device_name,
+    get_device_properties,
+    is_available,
+    stream,
+    synchronize,
+)
+
+
+class TestCudaCompat(unittest.TestCase):
+    # ---------------------
+    # _device_to_paddle test
+    # ---------------------
+    def test_device_to_paddle_none(self):
+        self.assertIsNone(_device_to_paddle(None))
+
+    def test_device_to_paddle_int(self):
+        self.assertEqual(_device_to_paddle(0), 'gpu:0')
+        self.assertEqual(_device_to_paddle(2), 'gpu:2')
+
+    def test_device_to_paddle_str(self):
+        self.assertEqual(_device_to_paddle('cuda:0'), 'gpu:0')
+        self.assertEqual(_device_to_paddle('gpu:1'), 'gpu:1')
+
+    def test_device_to_paddle_invalid(self):
+        with self.assertRaises(TypeError):
+            _device_to_paddle(1.5)
+
+    # ---------------------
+    # is_available test
+    # ---------------------
+    def test_is_available(self):
+        self.assertIsInstance(is_available(), bool)
+
+    # ---------------------
+    # synchronize test
+    # ---------------------
+    def test_synchronize(self):
+        try:
+            synchronize(None)
+            synchronize(0)
+            synchronize('cuda:0')
+            synchronize('gpu:0')
+        except Exception as e:
+            self.fail(f"synchronize raised Exception {e}")
+
+    # ---------------------
+    # current_stream test
+    # ---------------------
+    def test_current_stream(self):
+        stream = current_stream(None)
+        self.assertIsNotNone(stream)
+        stream = current_stream(0)
+        self.assertIsNotNone(stream)
+
+    # ---------------------
+    # get_device_properties test
+    # ---------------------
+    def test_get_device_properties(self):
+        props = get_device_properties(0)
+        self.assertTrue(hasattr(props, 'name'))
+        self.assertTrue(hasattr(props, 'total_memory'))
+
+    # ---------------------
+    # get_device_name / get_device_capability test
+    # ---------------------
+    def test_device_name_and_capability(self):
+        name = get_device_name(0)
+        self.assertIsInstance(name, str)
+
+        cap = get_device_capability(0)
+        self.assertIsInstance(cap, tuple)
+        self.assertEqual(len(cap), 2)
+
+    def test_stream_creation(self):
+        s = Stream()
+        s1 = paddle.Stream()  # test paddle.Stream
+        self.assertIsInstance(s, paddle.device.Stream)
+        self.assertIsInstance(s1, paddle.device.Stream)
+
+    def test_stream_context(self):
+        s = Stream(device='gpu', priority=2)
+        with stream(s):
+            ctx = stream(s)
+            self.assertIsInstance(ctx, StreamContext)
+            current = current_stream()
+            self.assertEqual(current.stream_base, s.stream_base)
+
+    def test_nested_streams(self):
+        s1 = Stream()
+        s2 = Stream()
+        with stream(s1):
+            with stream(s2):
+                current = paddle.cuda.current_stream()
+                self.assertEqual(current.stream_base, s2.stream_base)
+            current = paddle.cuda.current_stream()
+            self.assertEqual(current.stream_base, s1.stream_base)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->

本 PR 新增若干与 PyTorch 兼容的 API，并补充对应单元测试。
目标是提升用户从 PyTorch 迁移至 Paddle 的便利性，降低适配成本，改善整体使用体验。

torch.cuda.synchronize
torch.cuda.current_stream
torch.cuda.get_device_properties
torch.cuda.Stream
torch.cuda.get_device_capability
torch.cuda.is_available
torch.cuda.stream
torch.cuda.get_device_name


pcard-67164
