### PR TITLE
[Bug Fix]fix the bug in isinstance(arg, int) failed

### DIFF
--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -148,7 +148,7 @@ else:
                 place=device,
             )
         elif (
-            builtins.all(isinstance(arg, int) for arg in args)
+            builtins.all(isinstance(arg, builtins.int) for arg in args)
             and len(kwargs) == 0
         ):
             # case 3, 4


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

pcard-71500

**问题分析**：
在speech套件中，有重载构造构造Layer层如Conv2D这样的操作（可能关系不大），导致了进入到Tensor构建时，python的intl类型不再是一个class而是一个str，因此导致了isinstance(arg, int)这个检查时报错。~~int被改写成字符串的原因未知~~。

触发报错时执行`print(f"_____{int=}_____{type(int)=}")`
<img width="1112" height="621" alt="image" src="https://github.com/user-attachments/assets/7d866548-734b-4e74-adf2-9b0518312671" />

speech本身有这个设置
<img width="366" height="186" alt="6d2c7c5f238619847de47cec0a6e971c" src="https://github.com/user-attachments/assets/b665b083-0e59-468d-9ee1-f8475f04f273" />

**解决方案**：
使用`builtins.int`替换`int`

