### PR TITLE
[API-Compat] Inplace compatible upgrade for paddle.scatter

### DIFF
--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import functools
+import inspect
 import math
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -4294,14 +4295,191 @@ def unbind(input: Tensor, axis: int = 0) -> list[Tensor]:
         return outs
 
 
-def scatter(
+def _put_along_axis_inplace_wrapper(
+    input: Tensor,
+    dim: int,
+    index: Tensor,
+    src: Tensor | None = None,
+    reduce: str | None = None,
+    value: Tensor | None = None,
+) -> Tensor:
+    """Wrapper for inplace version of put_along_axis
+    This API is not directly available for users. One can only call this API via torch.Tensor.scatter_ or torch.scatter_
+    """
+    if src is None:
+        src = value
+        if src is None:
+            raise TypeError(
+                "'paddle.Tensor.scatter_' expect one of the following input pattern: \n"
+                " - (int dim, Tensor index, Tensor src (alias value), *, str reduce)\n"
+                " - (Tensor index, Tensor updates, bool overwrite, str name = None)\n"
+                "However, the input pattern does not match, please check."
+            )
+    elif value is not None:
+        raise TypeError(
+            "`value` is useless when `src` is specified. Be careful for conflicting parameters."
+        )
+    if reduce is None:
+        reduce = 'assign'
+
+    if len(input.shape) != len(index.shape):
+        raise ValueError(
+            "`index` and `input` must have the same number of dimensions!"
+        )
+    axis = non_negative_axis(input, dim)
+
+    if isinstance(src, (paddle.Tensor, paddle.pir.Value)):
+        if len(index.shape) != len(src.shape):
+            raise ValueError(
+                "`index` and `src` must have the same number of dimensions!"
+            )
+        for i in range(len(input.shape)):
+            if (i != axis and input.shape[i] < index.shape[i]) or index.shape[
+                i
+            ] > src.shape[i]:
+                raise RuntimeError(
+                    f"Size does not match at dimension {i} expected index {index.shape} to be smaller than self {input.shape} apart from dimension {axis} and to be smaller size than src {src.shape}"
+                )
+    else:
+        src = paddle.to_tensor(src).astype(input.dtype)
+        elements = 1
+        for num in src.shape:
+            elements *= num
+        if elements == 1:  # paddle.pir.Value has no attribute 'size'
+            src = paddle.broadcast_to(src, index.shape)
+    axis_max_size = input.shape[axis]
+    if not (index < axis_max_size).all():
+        raise RuntimeError(
+            f"one of element of index is out of bounds for dimension {axis} with size {axis_max_size}"
+        )
+
+    if convert_dtype(index.dtype) not in ['int32', 'int64']:
+        raise TypeError(
+            f"The data type of index should be one of ['int32', 'int64'], but got {convert_dtype(index.dtype)}"
+        )
+    return _C_ops.put_along_axis_(input, index, src, axis, reduce, True)
+
+
+def _scatter_inplace_wrapper(
     x: Tensor,
     index: Tensor,
     updates: Tensor,
     overwrite: bool = True,
     name: str | None = None,
 ) -> Tensor:
+    """Wrapper for inplace origin scatter"""
+    return _C_ops.scatter_(x, index, updates, overwrite)
+
+
+@inplace_apis_in_dygraph_only
+def scatter_(*args: Any, **kwargs: Any) -> Tensor:
     """
+    Inplace version of ``scatter`` API, the output Tensor will be inplaced with input.
+    Please refer to :ref:`api_paddle_tensor_scatter`.
+    """
+    len_args = len(args)
+    if len_args + len(kwargs) < 2:
+        raise TypeError(
+            f"Too few arguments in the function call: {len_args}, {len(kwargs)}. Expect one of: \n"
+            " - (int dim, Tensor index, Tensor src, *, str reduce, Tensor out = None)\n"
+            " - (Tensor index, Tensor updates, bool overwrite, str name = None)"
+        )
+    is_put_along_axis = False
+    # put_along_axis (torch.scatter) must have 'dim' in either args or kwargs
+    if len_args >= 2:
+        is_put_along_axis = isinstance(args[1], int)
+    else:
+        is_put_along_axis = 'dim' in kwargs
+    if is_put_along_axis:
+        return _put_along_axis_inplace_wrapper(*args, **kwargs)
+    else:
+        return _scatter_inplace_wrapper(*args, **kwargs)
+
+
+scatter_.signature = inspect.signature(_scatter_inplace_wrapper)
+
+
+def _scatter_wrapper(
+    x: Tensor,
+    index: Tensor,
+    updates: Tensor,
+    overwrite: bool = True,
+    name: str | None = None,
+    out: Tensor | None = None,
+) -> Tensor:
+    """Wrapper for original scatter
+    This API is not directly available for users. One can only call this API via torch.Tensor.scatter or torch.scatter
+    """
+    if in_dynamic_or_pir_mode():
+        res = _C_ops.scatter(x, index, updates, overwrite)
+    else:
+        check_variable_and_dtype(
+            x,
+            'dtype',
+            ['float32', 'float64', 'float16', 'int32', 'int64', 'uint16'],
+            'scatter',
+        )
+        check_type(overwrite, 'overwrite', bool, 'scatter')
+        helper = LayerHelper('scatter', **locals())
+        output = helper.create_variable_for_type_inference(x.dtype)
+        helper.append_op(
+            type="scatter",
+            inputs={"X": x, "Ids": index, "Updates": updates},
+            attrs={'overwrite': overwrite},
+            outputs={"Out": output},
+        )
+        res = output
+    if out is not None:
+        paddle.assign(res, out)
+    return res
+
+
+def _put_along_axis_wrapper(
+    input: Tensor,
+    dim: int,
+    index: Tensor,
+    src: Tensor | None = None,
+    reduce: str | None = None,
+    out: Tensor | None = None,
+    value: Tensor | None = None,
+):
+    """A PyTorch Compatible wrapper for put_along_axis
+    This API is not directly available for users. One can only call this API via torch.Tensor.scatter or torch.scatter
+    """
+    if src is None:
+        src = value
+        if src is None:
+            raise TypeError(
+                "'paddle.scatter' expect one of the following input pattern: \n"
+                " - (Tensor input, int dim, Tensor index, Tensor src (alias value), *, str reduce, Tensor out = None)\n"
+                " - (Tensor x, Tensor index, Tensor updates, bool overwrite, str name = None)\n"
+                "However, the input pattern does not match, please check."
+            )
+    elif value is not None:
+        raise TypeError(
+            "`value` is useless when `src` is specified. Be careful for conflicting parameters."
+        )
+    if reduce is None:
+        reduce = 'assign'
+    res = paddle.put_along_axis(input, index, src, dim, reduce, broadcast=False)
+    if out is not None:
+        paddle.assign(res, out)
+    return res
+
+
+def scatter(*args: Any, **kwargs: Any) -> Tensor:
+    """
+
+    This function has two functionalities, depending on the parameters passed:
+
+    1. ``scatter(Tensor input, int dim, Tensor index, Tensor src (alias value), *, str reduce = None, Tensor out = None)``:
+        PyTorch compatible scatter, calls a non-broadcast `paddle.put_along_axis`.
+        Check out :ref:`api_paddle_put_along_axis` and also `[torch has more parameters] torch.scatter <https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/guides/model_convert/convert_from_pytorch/api_difference/torch/torch.scatter.html>`_
+
+    2. ``scatter(Tensor x, Tensor index, Tensor updates, bool overwrite, str name = None)``:
+        The original paddle.scatter, see the following docs.
+
+
     **Scatter Layer**
     Output is obtained by updating the input on selected indices based on updates.
 
@@ -4380,40 +4558,26 @@ def scatter(
             >>> #  [2., 2.],
             >>> #  [1., 1.]]
     """
-    if in_dynamic_or_pir_mode():
-        return _C_ops.scatter(x, index, updates, overwrite)
+    len_args = len(args)
+    if len_args + len(kwargs) < 2:
+        raise TypeError(
+            f"Too few arguments in the function call: {len_args}, {len(kwargs)}. Expect one of: \n"
+            " - (Tensor input, int dim, Tensor index, Tensor src, *, str reduce, Tensor out = None)\n"
+            " - (Tensor x, Tensor index, Tensor updates, bool overwrite, str name = None)"
+        )
+    is_put_along_axis = False
+    # put_along_axis (torch.scatter) must have 'dim' in either args or kwargs. index can never be int.
+    if len_args >= 2:
+        is_put_along_axis = isinstance(args[1], int)
     else:
-        check_variable_and_dtype(
-            x,
-            'dtype',
-            ['float32', 'float64', 'float16', 'int32', 'int64', 'uint16'],
-            'scatter',
-        )
-        check_type(overwrite, 'overwrite', bool, 'scatter')
-        helper = LayerHelper('scatter', **locals())
-        out = helper.create_variable_for_type_inference(x.dtype)
-        helper.append_op(
-            type="scatter",
-            inputs={"X": x, "Ids": index, "Updates": updates},
-            attrs={'overwrite': overwrite},
-            outputs={"Out": out},
-        )
-        return out
+        is_put_along_axis = 'dim' in kwargs
+    if is_put_along_axis:
+        return _put_along_axis_wrapper(*args, **kwargs)
+    else:
+        return _scatter_wrapper(*args, **kwargs)
 
 
-@inplace_apis_in_dygraph_only
-def scatter_(
-    x: Tensor,
-    index: Tensor,
-    updates: Tensor,
-    overwrite: bool = True,
-    name: str | None = None,
-) -> Tensor:
-    """
-    Inplace version of ``scatter`` API, the output Tensor will be inplaced with input ``x``.
-    Please refer to :ref:`api_paddle_tensor_scatter`.
-    """
-    return _C_ops.scatter_(x, index, updates, overwrite)
+scatter.__signature__ = inspect.signature(_scatter_wrapper)
 
 
 def scatter_nd_add(

--- a/test/legacy_test/test_scatter_compatible.py
+++ b/test/legacy_test/test_scatter_compatible.py
@@ -41,13 +41,11 @@ class TestScatterCompatible(unittest.TestCase):
             [[0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0], [1.0, 1.0, 1.0, 1.0]],
             dtype=np.float32,
         )
-        gt_update_grad = np.ones([2, 4], dtype=np.float32)
         np.testing.assert_allclose(x.grad.numpy(), gt_x_grad)
-        np.testing.assert_allclose(updates.grad.numpy(), gt_update_grad)
 
     def test_inplace_origin_scatter(self):
         x = paddle.zeros([4, 4])
-        index = paddle.ones([3], dtype=paddle.int64)
+        index = paddle.to_tensor([0, 1, 3], dtype=paddle.int64)
         updates = paddle.arange(16, dtype=x.dtype).reshape([4, 4])
         x.stop_gradient = False
         updates.stop_gradient = False
@@ -55,21 +53,19 @@ class TestScatterCompatible(unittest.TestCase):
         res = y.scatter_(updates=updates, index=index, overwrite=True)
         gt = np.array(
             [
-                [-1.0, -1.0, -1.0, -1.0],
                 [0.0, 1.0, 2.0, 3.0],
+                [4.0, 5.0, 6.0, 7.0],
                 [-1.0, -1.0, -1.0, -1.0],
-                [-1.0, -1.0, -1.0, -1.0],
+                [8.0, 9.0, 10.0, 11.0],
             ],
             dtype=np.float32,
         )
         np.testing.assert_allclose(y.numpy(), gt)
         np.testing.assert_allclose(res.numpy(), gt)
         res.backward()
-        gt_x_grad = np.full([4, 4], 2, dtype=np.float32)
-        gt_x_grad[1, :] = 0
-        gt_update_grad = np.ones([3, 4], dtype=np.float32)
+        gt_x_grad = np.zeros([4, 4], dtype=np.float32)
+        gt_x_grad[2, :] = 2
         np.testing.assert_allclose(x.grad.numpy(), gt_x_grad)
-        np.testing.assert_allclose(updates.grad.numpy(), gt_update_grad)
 
     def test_put_along_axis_pass(self):
         inputs = paddle.arange(0, 12, dtype=paddle.float64).reshape([3, 4])
@@ -118,6 +114,8 @@ class TestScatterCompatible(unittest.TestCase):
             dtype=np.float64,
         )
         np.testing.assert_allclose(res.numpy(), gt)
+        inputs.scatter_(src=-3, reduce=None, index=index, dim=1)
+        np.testing.assert_allclose(inputs.numpy(), gt)
 
     def test_error_handling_and_special_cases(self):
         inplace_too_few_args = (

--- a/test/legacy_test/test_scatter_compatible.py
+++ b/test/legacy_test/test_scatter_compatible.py
@@ -1,0 +1,242 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+
+import paddle
+
+
+class TestScatterCompatible(unittest.TestCase):
+    def test_non_inplace_origin_scatter(self):
+        x = paddle.zeros([3, 4])
+        index = paddle.arange(0, 2, dtype=paddle.int64)
+        updates = paddle.arange(12, dtype=x.dtype).reshape([3, 4])
+        x.stop_gradient = False
+        updates.stop_gradient = False
+        res_out = paddle.to_tensor(0)
+        res = paddle.scatter(
+            updates=updates, x=x, overwrite=True, index=index, out=res_out
+        )
+        gt = np.array(
+            [[0.0, 1.0, 2.0, 3.0], [4.0, 5.0, 6.0, 7.0], [0.0, 0.0, 0.0, 0.0]],
+            dtype=np.float32,
+        )
+        np.testing.assert_allclose(res.numpy(), gt)
+        np.testing.assert_allclose(res_out.numpy(), gt)
+        res.backward()
+        gt_x_grad = np.array(
+            [[0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0], [1.0, 1.0, 1.0, 1.0]],
+            dtype=np.float32,
+        )
+        gt_update_grad = np.ones([2, 4], dtype=np.float32)
+        np.testing.assert_allclose(x.grad.numpy(), gt_x_grad)
+        np.testing.assert_allclose(updates.grad.numpy(), gt_update_grad)
+
+    def test_inplace_origin_scatter(self):
+        x = paddle.zeros([4, 4])
+        index = paddle.ones([3], dtype=paddle.int64)
+        updates = paddle.arange(16, dtype=x.dtype).reshape([4, 4])
+        x.stop_gradient = False
+        updates.stop_gradient = False
+        y = x * x + 2 * x - 1
+        res = y.scatter_(updates=updates, index=index, overwrite=True)
+        gt = np.array(
+            [
+                [-1.0, -1.0, -1.0, -1.0],
+                [0.0, 1.0, 2.0, 3.0],
+                [-1.0, -1.0, -1.0, -1.0],
+                [-1.0, -1.0, -1.0, -1.0],
+            ],
+            dtype=np.float32,
+        )
+        np.testing.assert_allclose(y.numpy(), gt)
+        np.testing.assert_allclose(res.numpy(), gt)
+        res.backward()
+        gt_x_grad = np.full([4, 4], 2, dtype=np.float32)
+        gt_x_grad[1, :] = 0
+        gt_update_grad = np.ones([3, 4], dtype=np.float32)
+        np.testing.assert_allclose(x.grad.numpy(), gt_x_grad)
+        np.testing.assert_allclose(updates.grad.numpy(), gt_update_grad)
+
+    def test_put_along_axis_pass(self):
+        inputs = paddle.arange(0, 12, dtype=paddle.float64).reshape([3, 4])
+        src = paddle.full_like(inputs, -3)
+        index = paddle.ones([3, 3], dtype=paddle.int64)
+        gt = np.array(
+            [
+                [0.0, -8.0, 2.0, 3.0],
+                [4.0, -4.0, 6.0, 7.0],
+                [8.0, 0.0, 10.0, 11.0],
+            ],
+            dtype=np.float64,
+        )
+
+        arg_cases = [
+            [
+                1,
+            ],
+            [],
+            [1, index],
+            [1, index, src, 'add'],
+        ]
+        kwarg_cases = [
+            {'src': src, 'index': index, 'reduce': 'add'},
+            {'src': src, 'index': index, 'reduce': 'add', 'dim': 1},
+            {'src': src, 'reduce': 'add'},
+            {},
+        ]
+        for args, kwargs in zip(arg_cases, kwarg_cases):
+            res1 = paddle.scatter(inputs, *args, **kwargs)
+            res2 = inputs.clone().scatter_(*args, **kwargs)
+            np.testing.assert_allclose(res1.numpy(), gt)
+            np.testing.assert_allclose(res2.numpy(), gt)
+
+    def test_special_cases_put_along_axis_scatter(self):
+        # special case: src is scalar and reduce is None
+        inputs = paddle.arange(0, 12, dtype=paddle.float64).reshape([3, 4])
+        index = paddle.ones([3, 3], dtype=paddle.int64)
+        res = paddle.scatter(inputs, src=-3, reduce=None, index=index, dim=1)
+        gt = np.array(
+            [
+                [0.0, -3.0, 2.0, 3.0],
+                [4.0, -3.0, 6.0, 7.0],
+                [8.0, -3.0, 10.0, 11.0],
+            ],
+            dtype=np.float64,
+        )
+        np.testing.assert_allclose(res.numpy(), gt)
+
+    def test_error_handling_and_special_cases(self):
+        inplace_too_few_args = (
+            "Too few arguments in the function call: {p1}, {p2}. Expect one of: \n"
+            " - (int dim, Tensor index, Tensor src, *, str reduce, Tensor out = None)\n"
+            " - (Tensor index, Tensor updates, bool overwrite, str name = None)"
+        )
+        non_inplace_too_few_args = (
+            "Too few arguments in the function call: {p1}, {p2}. Expect one of: \n"
+            " - (Tensor input, int dim, Tensor index, Tensor src, *, str reduce, Tensor out = None)\n"
+            " - (Tensor x, Tensor index, Tensor updates, bool overwrite, str name = None)"
+        )
+        conflicting_params = "`value` is useless when `src` is specified. Be careful for conflicting parameters."
+
+        inplace_put_no_src_or_value = (
+            "'paddle.Tensor.scatter_' expect one of the following input pattern: \n"
+            " - (int dim, Tensor index, Tensor src (alias value), *, str reduce)\n"
+            " - (Tensor index, Tensor updates, bool overwrite, str name = None)\n"
+            "However, the input pattern does not match, please check."
+        )
+        non_inplace_put_no_src_or_value = (
+            "'paddle.scatter' expect one of the following input pattern: \n"
+            " - (Tensor input, int dim, Tensor index, Tensor src (alias value), *, str reduce, Tensor out = None)\n"
+            " - (Tensor x, Tensor index, Tensor updates, bool overwrite, str name = None)\n"
+            "However, the input pattern does not match, please check."
+        )
+
+        inplace_put_index_input_mismatch = (
+            "`index` and `input` must have the same number of dimensions!"
+        )
+        inplace_put_index_src_mismatch = (
+            "`index` and `src` must have the same number of dimensions!"
+        )
+        put_index_shape_out_of_bound_prefix = "Size does not match at dimension"
+        put_index_value_out_of_bound_prefix = (
+            "one of element of index is out of bounds"
+        )
+        dtype_error_prefix = (
+            "The data type of index should be one of ['int32', 'int64']"
+        )
+
+        dummy_input = paddle.arange(0, 12, dtype=paddle.float64).reshape([3, 4])
+        dummy_src = paddle.full_like(dummy_input, -3)
+        dummy_index = paddle.ones([3, 3], dtype=paddle.int64)
+        dummy_dim = 1
+        with self.assertRaises(TypeError) as cm:
+            dummy_input.scatter_()
+        self.assertEqual(
+            str(cm.exception), inplace_too_few_args.format(p1=1, p2=0)
+        )
+
+        with self.assertRaises(TypeError) as cm:
+            paddle.scatter(input=dummy_input)
+        self.assertEqual(
+            str(cm.exception), non_inplace_too_few_args.format(p1=0, p2=1)
+        )
+
+        with self.assertRaises(TypeError) as cm:
+            paddle.scatter(
+                dummy_input, dummy_dim, dummy_index, dummy_src, value=dummy_src
+            )
+        self.assertEqual(str(cm.exception), conflicting_params)
+
+        with self.assertRaises(TypeError) as cm:
+            dummy_input.scatter_(
+                dummy_dim, dummy_index, dummy_src, value=dummy_src
+            )
+        self.assertEqual(str(cm.exception), conflicting_params)
+
+        with self.assertRaises(TypeError) as cm:
+            paddle.scatter(dummy_input, dummy_dim, dummy_index)
+        self.assertEqual(str(cm.exception), non_inplace_put_no_src_or_value)
+
+        with self.assertRaises(TypeError) as cm:
+            dummy_input.scatter_(dummy_dim, dummy_index)
+        self.assertEqual(str(cm.exception), inplace_put_no_src_or_value)
+
+        with self.assertRaises(ValueError) as cm:
+            dummy_input.scatter_(
+                dummy_dim,
+                paddle.zeros([3, 4, 5], dtype=paddle.int64),
+                dummy_src,
+            )
+        self.assertEqual(str(cm.exception), inplace_put_index_input_mismatch)
+
+        with self.assertRaises(ValueError) as cm:
+            dummy_input.scatter_(
+                dummy_dim,
+                dummy_index,
+                paddle.zeros([1], dtype=dummy_input.dtype),
+            )
+        self.assertEqual(str(cm.exception), inplace_put_index_src_mismatch)
+
+        with self.assertRaises(RuntimeError) as cm:
+            dummy_input.scatter_(
+                dummy_dim, paddle.zeros([3, 7], dtype=paddle.int64), dummy_src
+            )
+        self.assertEqual(
+            str(cm.exception).startswith(put_index_shape_out_of_bound_prefix),
+            True,
+        )
+
+        with self.assertRaises(RuntimeError) as cm:
+            dummy_input.scatter_(
+                dummy_dim,
+                paddle.full_like(dummy_input, 7).to(paddle.int64),
+                dummy_src,
+            )
+        self.assertEqual(
+            str(cm.exception).startswith(put_index_value_out_of_bound_prefix),
+            True,
+        )
+
+        with self.assertRaises(TypeError) as cm:
+            dummy_input.scatter_(
+                dummy_dim, paddle.full_like(dummy_input, 2), dummy_src
+            )
+        self.assertEqual(str(cm.exception).startswith(dtype_error_prefix), True)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Operator Mechanism


### PR Types
Improvements


### Description
scatter 增加了对齐 PyTorch `torch.scatter` 行为的功能，属于对 `paddle.scatter`, `paddle.Tensor.scatter_` 的原地升级，兼容原有 scatter 的行为。新增 scatter 行为与 `paddle.put_along_axis` 一致。

`paddle.scatter` 在本 PR 后有两套行为：
```python 
paddle.scatter(x, index, updates)       # 原始行为
paddle.scatter(x, dim, index, src(或value))  # 新增行为
# 新增行为等同于：
paddle.put_along_axis(x, index, src, axis=dim, broadcast=False)    # 与 PyTorch scatter 对齐
```



注意⚠️！`scatter` 与 `scatter_` 有两套相互冲突的函数签名：这是由于我们需要在同一个函数下支持两种不同的功能，两个功能依赖输入参数之间的区别进行选择、区分。输入混淆的参数将会导致报错。

相互冲突的函数签名将会导致：在 OpTest 中进行测试时，被调用的函数必须设置正确的函数签名。举例来说：
- 如果测试 `put_along_axis` 功能，那么 `paddle.scatter` 的函数签名必须与 `put_along_axis` (的 wrapper) 一致。
- 如果测试原始 `scatter` 功能，那么 `paddle.scatter` 的函数签名必须与 `scatter` (的 wrapper) 一致。

但一个函数不能有两套相互冲突的签名（__signature__）来进行动态选择。故默认我们将 `scatter` 与 `scatter_` 的 signature 设置为与原有 scatter/scatter_ 一致，`put_along_axis` 的 signature 会被忽略。原因：
- `paddle.scatter` 的原有功能是原始 scatter，`put_along_axis` 的功能只是兼容功能，故应该保留原有的签名。
- `scatter` 本身有 OpTest，如果不保留 `scatter` 原有签名，将会报错。

所以！不要尝试对 `put_along_axis` pass (scatter 内部) 设计 OpTest。静态图 OpTest 测试请单独测 `put_along_axis`，不要测试 `scatter` 的 `put_along_axis` 功能。

代码中强制设置函数签名的方式：
```python
scatter_.signature = inspect.signature(_scatter_inplace_wrapper)
scatter.__signature__ = inspect.signature(_scatter_wrapper)
```

Pcard-89620
