### PR TITLE
torch.version.cuda<--->paddle.version.cuda

### DIFF
--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -296,23 +296,27 @@ def nccl() -> str:
     """
     return nccl_version
 
-def cuda() -> str:
-    """Get cuda version of paddle package.
+class CudaVersion:
+    def __init__(self, version: str):
+        self.version = version
 
-    Returns:
-        string: Return the version information of cuda. If paddle package is CPU version, it will return False.
+    def __call__(self) -> str:
+        return self.version
 
-    Examples:
-        .. code-block:: python
+    def __str__(self) -> str:
+        return self.version
 
-            >>> import paddle
+    def __repr__(self) -> str:
+        return f"CudaVersion('{self.version}')"
 
-            >>> paddle.version.cuda()
-            >>> # doctest: +SKIP('Different environments yield different output.')
-            '10.2'
+    def __eq__(self, other) -> bool:
+        if isinstance(other, str):
+            return self.version == other
+        if isinstance(other, CudaVersion):
+            return self.version == other.version
+        return NotImplemented
 
-    """
-    return cuda_version
+cuda = CudaVersion(cuda_version)
 
 def cudnn() -> str:
     """Get cudnn version of paddle package.

--- a/setup.py
+++ b/setup.py
@@ -615,23 +615,27 @@ def nccl() -> str:
     """
     return nccl_version
 
-def cuda() -> str:
-    """Get cuda version of paddle package.
+class CudaVersion:
+    def __init__(self, version: str):
+        self.version = version
 
-    Returns:
-        string: Return the version information of cuda. If paddle package is CPU version, it will return False.
+    def __call__(self) -> str:
+        return self.version
 
-    Examples:
-        .. code-block:: python
+    def __str__(self) -> str:
+        return self.version
 
-            >>> import paddle
+    def __repr__(self) -> str:
+        return f"CudaVersion('{self.version}')"
 
-            >>> paddle.version.cuda()
-            >>> # doctest: +SKIP('Different environments yield different output.')
-            '10.2'
+    def __eq__(self, other) -> bool:
+        if isinstance(other, str):
+            return self.version == other
+        if isinstance(other, CudaVersion):
+            return self.version == other.version
+        return NotImplemented
 
-    """
-    return cuda_version
+cuda = CudaVersion(cuda_version)
 
 def cudnn() -> str:
     """Get cudnn version of paddle package.

--- a/test/cuda/test_cuda_unittest.py
+++ b/test/cuda/test_cuda_unittest.py
@@ -119,6 +119,11 @@ class TestCudaCompat(unittest.TestCase):
             current = paddle.cuda.current_stream()
             self.assertEqual(current.stream_base, s1.stream_base)
 
+    def test_version_cuda(self):
+        cudaVersion = paddle.version.cuda()
+        cudaVersionClass = paddle.version.cuda
+        assert cudaVersion == cudaVersionClass
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/cuda/test_cuda_unittest.py
+++ b/test/cuda/test_cuda_unittest.py
@@ -124,6 +124,9 @@ class TestCudaCompat(unittest.TestCase):
         cudaVersionClass = paddle.version.cuda
         assert cudaVersion == cudaVersionClass
 
+    def test_error(self):
+        assert 1 == 0
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/cuda/test_cuda_unittest.py
+++ b/test/cuda/test_cuda_unittest.py
@@ -124,9 +124,6 @@ class TestCudaCompat(unittest.TestCase):
         cudaVersionClass = paddle.version.cuda
         assert cudaVersion == cudaVersionClass
 
-    def test_error(self):
-        assert 1 == 0
-
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->

本 PR 新增若干与 PyTorch 兼容的 API，并补充对应单元测试。
目标是提升用户从 PyTorch 迁移至 Paddle 的便利性，降低适配成本，改善整体使用体验。
torch.version.cuda<--->paddle.version.cuda
paddle.version.cuda()原本是一个函数，torch.version.cuda是一个变量，所以把paddle.version.cuda改成带有call方法的类，重写equa方法
pcard-67164
