### PR TITLE
[AutoParallel] fix intermediate api pipe hook tuple object bug

### DIFF
--- a/python/paddle/distributed/auto_parallel/intermediate/pipeline_parallel.py
+++ b/python/paddle/distributed/auto_parallel/intermediate/pipeline_parallel.py
@@ -94,7 +94,7 @@ class PipelineParallel(ParallelModel):
                         self.get_mesh(pipeline_stage_index + 1),
                         tensor.placements,
                     )
-            elif isinstance(output, (list, tuple)):
+            elif isinstance(output, list):
                 for i in range(len(output)):
                     assert is_tensor(output[i])
                     output[i] = dist.reshard(
@@ -102,6 +102,16 @@ class PipelineParallel(ParallelModel):
                         self.get_mesh(pipeline_stage_index + 1),
                         output[i].placements,
                     )
+            elif isinstance(output, tuple):
+                output = list(output)
+                for i in range(len(output)):
+                    assert is_tensor(output[i])
+                    output[i] = dist.reshard(
+                        output[i],
+                        self.get_mesh(pipeline_stage_index + 1),
+                        output[i].placements,
+                    )
+                output = tuple(output)
             elif is_tensor(output):
                 output = dist.reshard(
                     output,
@@ -110,7 +120,7 @@ class PipelineParallel(ParallelModel):
                 )
             else:
                 raise ValueError(
-                    f"output should be a dict of tensors or list of tensors or tensor, but {type(output)}"
+                    f"output should be a dict/tensors/list of tensors/tuple of tensor/tensor, but {type(output)}"
                 )
             return output
 

--- a/python/paddle/distributed/auto_parallel/intermediate/pipeline_parallel.py
+++ b/python/paddle/distributed/auto_parallel/intermediate/pipeline_parallel.py
@@ -120,7 +120,7 @@ class PipelineParallel(ParallelModel):
                 )
             else:
                 raise ValueError(
-                    f"output should be a dict/tensors/list of tensors/tuple of tensor/tensor, but {type(output)}"
+                    f"output between pp stages should be a dict of tensors or list of tensors or tuple of tensors or tensor, but {type(output)}"
                 )
             return output
 

--- a/test/auto_parallel/hybrid_strategy/single_llama_model.py
+++ b/test/auto_parallel/hybrid_strategy/single_llama_model.py
@@ -172,7 +172,7 @@ class LlamaDecoderLayer(nn.Layer):
         hidden_states, _ = self.mlp(hidden_states, "ONLY_FOR_TEST")
         hidden_states = residual + hidden_states
 
-        return hidden_states
+        return (hidden_states,)
 
 
 class GlobalOutputNet(nn.Layer):
@@ -230,9 +230,10 @@ class LlamaModel(nn.Layer):
         global_tensor = self.global_layer(None)
 
         for idx, (decoder_layer) in enumerate(self.layers):
-            hidden_states = decoder_layer(
+            tuple_hidden_states = decoder_layer(
                 hidden_states=hidden_states, global_tensor=global_tensor
             )
+            hidden_states = tuple_hidden_states[0]
 
         hidden_states = self.norm(hidden_states)
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
在使用中层api进行pipeline时，会使用pipe_hook插入在不同的pipe stage之间传输数据的层，当该数据（output）为tuple时，会触发 'tuple' object does not support item assignment；该pr针对tuple output单独处理来解决该bug