### PR TITLE
[CustomOp] Relax output count checks for inplace outputs

### DIFF
--- a/paddle/fluid/framework/custom_operator_utils.h
+++ b/paddle/fluid/framework/custom_operator_utils.h
@@ -480,6 +480,11 @@ static std::vector<std::vector<int64_t>> RunInferShape(
           }
           complete_result.push_back(input_shapes[index]);
         } else {
+          PADDLE_ENFORCE_LE(
+              infershape_result.size(),
+              infershape_result_index,
+              common::errors::Unavailable("The index must be less than the "
+                                          "size of infershape_result."));
           complete_result.push_back(infershape_result[infershape_result_index]);
           infershape_result_index++;
         }

--- a/paddle/fluid/framework/custom_operator_utils.h
+++ b/paddle/fluid/framework/custom_operator_utils.h
@@ -480,9 +480,9 @@ static std::vector<std::vector<int64_t>> RunInferShape(
           }
           complete_result.push_back(input_shapes[index]);
         } else {
-          PADDLE_ENFORCE_LE(
-              infershape_result.size(),
+          PADDLE_ENFORCE_LT(
               infershape_result_index,
+              infershape_result.size(),
               common::errors::Unavailable("The index must be less than the "
                                           "size of infershape_result."));
           complete_result.push_back(infershape_result[infershape_result_index]);

--- a/paddle/phi/api/ext/op_meta_info.h
+++ b/paddle/phi/api/ext/op_meta_info.h
@@ -177,8 +177,8 @@ class PADDLE_API CustomOpKernelContext {
   std::vector<std::pair<size_t, size_t>> input_range_;
   std::vector<std::pair<size_t, size_t>> output_range_;
 
-  const std::vector<std::string>* inputs_names_;
-  const std::vector<std::string>* outputs_names_;
+  std::vector<std::string>* inputs_names_;
+  std::vector<std::string>* outputs_names_;
 };
 
 ////////////////////// Kernel Function (PD_KERNEL) ////////////////////////

--- a/paddle/phi/api/ext/op_meta_info.h
+++ b/paddle/phi/api/ext/op_meta_info.h
@@ -159,8 +159,7 @@ class PADDLE_API CustomOpKernelContext {
   std::vector<Tensor*>* AllMutablePlainOutput();
   std::unordered_map<size_t, size_t> GetInplaceIndexMap() const;
   std::unordered_map<size_t, size_t> GetInplaceReverseIndexMap() const;
-  void ValidateAndAssignOutputs(CustomOpKernelContext* ctx,
-                                const std::vector<Tensor>& outs);
+  void ValidateAndAssignOutputs(const std::vector<Tensor>& outs);
 
  private:
   // TODO(chenweihang): replaced be SmallVector
@@ -405,7 +404,7 @@ struct KernelFuncImpl<Return (*)(Args...), impl_fn> {
                     "If return std::vector<Tensor> in Custom OpKernel, "
                     "you cannot pass output by kernel function argument.");
       auto outs = impl_fn(args...);
-      ValidateAndAssignOutputs(ctx, outs);
+      ctx->ValidateAndAssignOutputs(outs);
     }
   };
 

--- a/paddle/phi/api/ext/op_meta_info.h
+++ b/paddle/phi/api/ext/op_meta_info.h
@@ -159,9 +159,8 @@ class PADDLE_API CustomOpKernelContext {
   std::vector<Tensor*>* AllMutablePlainOutput();
   std::unordered_map<size_t, size_t> GetInplaceIndexMap() const;
   std::unordered_map<size_t, size_t> GetInplaceReverseIndexMap() const;
-
-  const std::vector<std::string>* inputs_names_;
-  const std::vector<std::string>* outputs_names_;
+  void ValidateAndAssignOutputs(CustomOpKernelContext* ctx,
+                                const std::vector<Tensor>& outs);
 
  private:
   // TODO(chenweihang): replaced be SmallVector
@@ -177,6 +176,9 @@ class PADDLE_API CustomOpKernelContext {
 
   std::vector<std::pair<size_t, size_t>> input_range_;
   std::vector<std::pair<size_t, size_t>> output_range_;
+
+  const std::vector<std::string>* inputs_names_;
+  const std::vector<std::string>* outputs_names_;
 };
 
 ////////////////////// Kernel Function (PD_KERNEL) ////////////////////////
@@ -202,9 +204,6 @@ struct TypeTag {};
 
 template <typename F, F f>
 struct KernelFuncImpl;
-
-void ValidateAndAssignOutputs(CustomOpKernelContext* ctx,
-                              std::vector<Tensor> outs);
 
 template <typename Return, typename... Args, Return (*impl_fn)(Args...)>
 struct KernelFuncImpl<Return (*)(Args...), impl_fn> {

--- a/paddle/phi/api/ext/op_meta_info.h
+++ b/paddle/phi/api/ext/op_meta_info.h
@@ -160,6 +160,9 @@ class PADDLE_API CustomOpKernelContext {
   std::unordered_map<size_t, size_t> GetInplaceIndexMap() const;
   std::unordered_map<size_t, size_t> GetInplaceReverseIndexMap() const;
 
+  const std::vector<std::string>* inputs_names_;
+  const std::vector<std::string>* outputs_names_;
+
  private:
   // TODO(chenweihang): replaced be SmallVector
   std::vector<Tensor> inputs_;
@@ -199,6 +202,9 @@ struct TypeTag {};
 
 template <typename F, F f>
 struct KernelFuncImpl;
+
+void ValidateAndAssignOutputs(CustomOpKernelContext* ctx,
+                              std::vector<Tensor> outs);
 
 template <typename Return, typename... Args, Return (*impl_fn)(Args...)>
 struct KernelFuncImpl<Return (*)(Args...), impl_fn> {
@@ -400,17 +406,7 @@ struct KernelFuncImpl<Return (*)(Args...), impl_fn> {
                     "If return std::vector<Tensor> in Custom OpKernel, "
                     "you cannot pass output by kernel function argument.");
       auto outs = impl_fn(args...);
-      auto* orig_outs = ctx->AllMutablePlainOutput();
-      PD_CHECK(orig_outs->size() == outs.size(),
-               "The number of element in custom operator outputs is wrong, "
-               "expected contains ",
-               orig_outs->size(),
-               " Tensors, but actually contains ",
-               outs.size(),
-               " Tensors.");
-      for (size_t i = 0; i < outs.size(); ++i) {
-        AssignTensorImpl(outs.at(i), orig_outs->at(i));
-      }
+      ValidateAndAssignOutputs(ctx, outs);
     }
   };
 

--- a/paddle/phi/api/ext/op_meta_info.h
+++ b/paddle/phi/api/ext/op_meta_info.h
@@ -177,8 +177,8 @@ class PADDLE_API CustomOpKernelContext {
   std::vector<std::pair<size_t, size_t>> input_range_;
   std::vector<std::pair<size_t, size_t>> output_range_;
 
-  std::vector<std::string>* inputs_names_;
-  std::vector<std::string>* outputs_names_;
+  std::vector<std::string> inputs_names_;
+  std::vector<std::string> outputs_names_;
 };
 
 ////////////////////// Kernel Function (PD_KERNEL) ////////////////////////

--- a/paddle/phi/api/lib/op_meta_info.cc
+++ b/paddle/phi/api/lib/op_meta_info.cc
@@ -242,8 +242,8 @@ void CustomOpKernelContext::ConstructInplaceIndex(
     return;
   }
 
-  this->inputs_names_ = &inputs;
-  this->outputs_names_ = &outputs;
+  this->inputs_names_ = inputs;
+  this->outputs_names_ = outputs;
 
   for (size_t in_idx = 0; in_idx < inputs.size(); ++in_idx) {
     auto& input = inputs[in_idx];

--- a/paddle/phi/api/lib/op_meta_info.cc
+++ b/paddle/phi/api/lib/op_meta_info.cc
@@ -397,14 +397,11 @@ void CustomOpKernelContext::ValidateAndAssignOutputs(
     const int num_outputs = ctx->outputs_names_->size();
 
     PADDLE_THROW(common::errors::PreconditionNotMet(
-        "Output tensor count mismatch. "
-        "Expected outputs: [%s] (including %d in-place), "
-        "or [%s] (excluding in-place). "
-        "Returned %d outputs. "
+        "Output tensor count mismatch. Expected outputs: [%s] (including %d "
+        "in-place), or [%s] (excluding in-place), but returned %d outputs. "
         "Please ensure your outputs match the operator definition "
-        "(PD_BUILD_OP), "
-        "or the count of non-inplace outputs, and that in-place outputs share "
-        "the same memory address as their corresponding inputs.",
+        "(PD_BUILD_OP), or the count of non-inplace outputs, and that in-place "
+        "outputs share the same memory address as their corresponding inputs.",
         output_str_with_inplace,
         num_inplace_outputs,
         output_str_wo_inplace,

--- a/paddle/phi/api/lib/op_meta_info.cc
+++ b/paddle/phi/api/lib/op_meta_info.cc
@@ -388,10 +388,11 @@ void CustomOpKernelContext::ValidateAndAssignOutputs(
       }
     }
     const std::string output_str_wo_inplace =
-        join_strings<std::vector<std::string>>(outputs_names_wo_inplace, ", ");
+        paddle::string::join_strings<std::vector<std::string>>(
+            outputs_names_wo_inplace, ", ");
     const std::string output_str_with_inplace =
-        join_strings<std::vector<std::string>>(outputs_names_with_inplace,
-                                               ", ");
+        paddle::string::join_strings<std::vector<std::string>>(
+            outputs_names_with_inplace, ", ");
     const int num_inplace_outputs = ctx->GetInplaceIndexMap().size();
     const int num_outputs = ctx->outputs_names_->size();
 

--- a/paddle/phi/api/lib/op_meta_info.cc
+++ b/paddle/phi/api/lib/op_meta_info.cc
@@ -363,9 +363,9 @@ void CustomOpKernelContext::ValidateAndAssignOutputs(
                             "In-place output tensor `%s` at index %d does not "
                             "share the same address as "
                             "the input tensor `%s` at index %d.",
-                            ctx->outputs_names_->at(outputs_idx),
+                            ctx->outputs_names_.at(outputs_idx),
                             outputs_idx,
-                            ctx->inputs_names_->at(inputs_idx),
+                            ctx->inputs_names_.at(inputs_idx),
                             inputs_idx));
     }
     // Copy non-in-place outputs as usual
@@ -378,13 +378,13 @@ void CustomOpKernelContext::ValidateAndAssignOutputs(
     std::vector<std::string> outputs_names_wo_inplace;
     std::vector<std::string> outputs_names_with_inplace;
 
-    for (size_t i = 0; i < ctx->outputs_names_->size(); ++i) {
+    for (size_t i = 0; i < ctx->outputs_names_.size(); ++i) {
       if (ctx->GetInplaceIndexMap().count(i)) {
-        outputs_names_with_inplace.push_back(ctx->outputs_names_->at(i) +
+        outputs_names_with_inplace.push_back(ctx->outputs_names_.at(i) +
                                              "(inplaced)");
       } else {
-        outputs_names_with_inplace.push_back(ctx->outputs_names_->at(i));
-        outputs_names_wo_inplace.push_back(ctx->outputs_names_->at(i));
+        outputs_names_with_inplace.push_back(ctx->outputs_names_.at(i));
+        outputs_names_wo_inplace.push_back(ctx->outputs_names_.at(i));
       }
     }
     const std::string output_str_wo_inplace =
@@ -394,7 +394,7 @@ void CustomOpKernelContext::ValidateAndAssignOutputs(
         paddle::string::join_strings<std::vector<std::string>>(
             outputs_names_with_inplace, ", ");
     const int num_inplace_outputs = ctx->GetInplaceIndexMap().size();
-    const int num_outputs = ctx->outputs_names_->size();
+    const int num_outputs = ctx->outputs_names_.size();
 
     PADDLE_THROW(common::errors::PreconditionNotMet(
         "Output tensor count mismatch. Expected outputs: [%s] (including %d "

--- a/paddle/phi/api/lib/op_meta_info.cc
+++ b/paddle/phi/api/lib/op_meta_info.cc
@@ -58,6 +58,64 @@ std::vector<std::string> ParseAttrStr(const std::string& attr) {
   return rlt;
 }
 
+void ValidateAndAssignOutputs(CustomOpKernelContext* ctx,
+                              std::vector<Tensor> outs) {
+  auto* orig_outs = ctx->AllMutablePlainOutput();  // without inplaced outputs
+
+  // NOTE: This logic contains three branches:
+  // 1) If the number of returned tensors equals the number of non-inplace
+  // outputs, directly assign the returned tensors to
+  // ctx->AllMutablePlainOutput().
+  // 2) If the number of returned tensors equals the total number of outputs
+  // (including in-place outputs), validate that the addresses of in-place
+  // outputs match their corresponding inputs.
+  // 3) Otherwise, throw an error.
+  if (orig_outs->size() == outs.size()) {
+    // Case 1: Returned tensor count matches non-inplace output count; assign
+    // directly.
+    for (size_t i = 0; i < outs.size(); ++i) {
+      AssignTensorImpl(outs.at(i), orig_outs->at(i));
+    }
+  } else if (outs.size() == ctx->AllMutableOutput()->size()) {
+    // Case 2: Returned tensor count matches total output count (including
+    // in-place outputs).
+    if (!ctx->GetInplaceIndexMap().empty()) {
+      LOG(WARNING) << "[CustomOp] In-place outputs detected, "
+                   << "but the number of returned outputs matches the declared "
+                      "output count.";
+    }
+    // Ensure in-place output tensors share memory with their corresponding
+    // inputs
+    for (auto& [inputs_idx, outputs_idx] : ctx->GetInplaceIndexMap()) {
+      PADDLE_ENFORCE_EQ(ctx->InputAt(inputs_idx).impl().get(),
+                        outs.at(outputs_idx).impl().get(),
+                        common::errors::PreconditionNotMet(
+                            "In-place output tensor `%s` at index %d does not "
+                            "share the same address as "
+                            "the input tensor `%s` at index %d.",
+                            (*ctx->outputs_names_)[outputs_idx],
+                            outputs_idx,
+                            (*ctx->inputs_names_)[inputs_idx],
+                            inputs_idx));
+    }
+    // Copy non-in-place outputs as usual
+    for (size_t i = 0; i < outs.size(); ++i) {
+      if (ctx->GetInplaceIndexMap().find(i) ==
+          ctx->GetInplaceIndexMap().end()) {
+        AssignTensorImpl(outs.at(i), &(ctx->AllMutableOutput()->at(i)));
+      }
+    }
+  } else {
+    // Case 3: Output count mismatch; throw an error.
+    PADDLE_THROW(common::errors::PreconditionNotMet(
+        "The number of output tensors does not match the expected number. "
+        "Please ensure that the number of outputs matches the definition in "
+        "the PD_BUILD_OP macro, or equals the number of non-inplace outputs.")
+
+    );
+  }
+}
+
 PADDLE_API void AssignTensorImpl(const Tensor& src, Tensor* dst) {
   if (!src.has_allocation() || !dst->defined()) {
     VLOG(3) << "Custom operator assigns non-initialized tensor, this only "
@@ -241,6 +299,10 @@ void CustomOpKernelContext::ConstructInplaceIndex(
     VLOG(4) << "Custom operator ConstructInplaceIndex no need to recompute.";
     return;
   }
+
+  this->inputs_names_ = &inputs;
+  this->outputs_names_ = &outputs;
+
   for (size_t in_idx = 0; in_idx < inputs.size(); ++in_idx) {
     auto& input = inputs[in_idx];
     if (inplace_map.find(input) == inplace_map.end()) {

--- a/paddle/phi/api/lib/op_meta_info.cc
+++ b/paddle/phi/api/lib/op_meta_info.cc
@@ -349,9 +349,10 @@ void CustomOpKernelContext::ValidateAndAssignOutputs(
     // Case 2: Returned tensor count matches total output count (including
     // in-place outputs).
     if (!GetInplaceIndexMap().empty()) {
-      LOG(WARNING) << "[CustomOp] In-place outputs detected, "
-                   << "but the number of returned outputs matches the declared "
-                      "output count.";
+      LOG_FIRST_N(WARNING, 1)
+          << "[CustomOp] In-place outputs detected, "
+          << "but the number of returned outputs matches the declared "
+             "output count.";
     }
     // Ensure in-place output tensors share memory with their corresponding
     // inputs
@@ -369,7 +370,7 @@ void CustomOpKernelContext::ValidateAndAssignOutputs(
     }
     // Copy non-in-place outputs as usual
     for (size_t i = 0; i < outs.size(); ++i) {
-      if (GetInplaceIndexMap().count(i)) continue;
+      if (GetInplaceReverseIndexMap().count(i)) continue;
       AssignTensorImpl(outs.at(i), &(all_outs->at(i)));
     }
   } else {
@@ -377,8 +378,10 @@ void CustomOpKernelContext::ValidateAndAssignOutputs(
     std::vector<std::string> outputs_names_wo_inplace;
     std::vector<std::string> outputs_names_with_inplace;
 
-    for (size_t i = 0; i < this->outputs_names_.size(); ++i) {
-      if (GetInplaceIndexMap().count(i)) {
+    const int num_outputs = this->outputs_names_.size();
+
+    for (size_t i = 0; i < num_outputs; ++i) {
+      if (GetInplaceReverseIndexMap().count(i)) {
         outputs_names_with_inplace.push_back(this->outputs_names_.at(i) +
                                              "(inplaced)");
       } else {
@@ -393,7 +396,6 @@ void CustomOpKernelContext::ValidateAndAssignOutputs(
         paddle::string::join_strings<std::vector<std::string>>(
             outputs_names_with_inplace, ", ");
     const int num_inplace_outputs = GetInplaceIndexMap().size();
-    const int num_outputs = outputs_names_.size();
 
     PADDLE_THROW(common::errors::PreconditionNotMet(
         "Output tensor count mismatch. Expected outputs: [%s] (including %d "

--- a/paddle/phi/api/lib/op_meta_info.cc
+++ b/paddle/phi/api/lib/op_meta_info.cc
@@ -23,7 +23,7 @@ limitations under the License. */
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/distributed/auto_parallel/dist_tensor.h"
 #include "paddle/phi/core/enforce.h"
-
+#include "paddle/utils/string/string_helper.h"
 namespace paddle {
 
 // remove leading and tailing spaces
@@ -363,9 +363,9 @@ void CustomOpKernelContext::ValidateAndAssignOutputs(
                             "In-place output tensor `%s` at index %d does not "
                             "share the same address as "
                             "the input tensor `%s` at index %d.",
-                            (*ctx->outputs_names_)[outputs_idx],
+                            ctx->outputs_names_->at(outputs_idx),
                             outputs_idx,
-                            (*ctx->inputs_names_)[inputs_idx],
+                            ctx->inputs_names_->at(inputs_idx),
                             inputs_idx));
     }
     // Copy non-in-place outputs as usual
@@ -375,12 +375,39 @@ void CustomOpKernelContext::ValidateAndAssignOutputs(
     }
   } else {
     // Case 3: Output count mismatch; throw an error.
-    PADDLE_THROW(common::errors::PreconditionNotMet(
-        "The number of output tensors does not match the expected number. "
-        "Please ensure that the number of outputs matches the definition in "
-        "the PD_BUILD_OP macro, or equals the number of non-inplace outputs.")
+    std::vector<std::string> outputs_names_wo_inplace;
+    std::vector<std::string> outputs_names_with_inplace;
 
-    );
+    for (size_t i = 0; i < ctx->outputs_names_->size(); ++i) {
+      if (ctx->GetInplaceIndexMap().count(i)) {
+        outputs_names_with_inplace.push_back(ctx->outputs_names_->at(i) +
+                                             "(inplaced)");
+      } else {
+        outputs_names_with_inplace.push_back(ctx->outputs_names_->at(i));
+        outputs_names_wo_inplace.push_back(ctx->outputs_names_->at(i));
+      }
+    }
+    const std::string output_str_wo_inplace =
+        join_strings<std::vector<std::string>>(outputs_names_wo_inplace, ", ");
+    const std::string output_str_with_inplace =
+        join_strings<std::vector<std::string>>(outputs_names_with_inplace,
+                                               ", ");
+    const int num_inplace_outputs = ctx->GetInplaceIndexMap().size();
+    const int num_outputs = ctx->outputs_names_->size();
+
+    PADDLE_THROW(common::errors::PreconditionNotMet(
+        "Output tensor count mismatch. "
+        "Expected outputs: [%s] (including %d in-place), "
+        "or [%s] (excluding in-place). "
+        "Returned %d outputs. "
+        "Please ensure your outputs match the operator definition "
+        "(PD_BUILD_OP), "
+        "or the count of non-inplace outputs, and that in-place outputs share "
+        "the same memory address as their corresponding inputs.",
+        output_str_with_inplace,
+        num_inplace_outputs,
+        output_str_wo_inplace,
+        outs.size()));
   }
 }
 

--- a/paddle/phi/api/lib/op_meta_info.cc
+++ b/paddle/phi/api/lib/op_meta_info.cc
@@ -58,64 +58,6 @@ std::vector<std::string> ParseAttrStr(const std::string& attr) {
   return rlt;
 }
 
-void ValidateAndAssignOutputs(CustomOpKernelContext* ctx,
-                              std::vector<Tensor> outs) {
-  auto* orig_outs = ctx->AllMutablePlainOutput();  // without inplaced outputs
-
-  // NOTE: This logic contains three branches:
-  // 1) If the number of returned tensors equals the number of non-inplace
-  // outputs, directly assign the returned tensors to
-  // ctx->AllMutablePlainOutput().
-  // 2) If the number of returned tensors equals the total number of outputs
-  // (including in-place outputs), validate that the addresses of in-place
-  // outputs match their corresponding inputs.
-  // 3) Otherwise, throw an error.
-  if (orig_outs->size() == outs.size()) {
-    // Case 1: Returned tensor count matches non-inplace output count; assign
-    // directly.
-    for (size_t i = 0; i < outs.size(); ++i) {
-      AssignTensorImpl(outs.at(i), orig_outs->at(i));
-    }
-  } else if (outs.size() == ctx->AllMutableOutput()->size()) {
-    // Case 2: Returned tensor count matches total output count (including
-    // in-place outputs).
-    if (!ctx->GetInplaceIndexMap().empty()) {
-      LOG(WARNING) << "[CustomOp] In-place outputs detected, "
-                   << "but the number of returned outputs matches the declared "
-                      "output count.";
-    }
-    // Ensure in-place output tensors share memory with their corresponding
-    // inputs
-    for (auto& [inputs_idx, outputs_idx] : ctx->GetInplaceIndexMap()) {
-      PADDLE_ENFORCE_EQ(ctx->InputAt(inputs_idx).impl().get(),
-                        outs.at(outputs_idx).impl().get(),
-                        common::errors::PreconditionNotMet(
-                            "In-place output tensor `%s` at index %d does not "
-                            "share the same address as "
-                            "the input tensor `%s` at index %d.",
-                            (*ctx->outputs_names_)[outputs_idx],
-                            outputs_idx,
-                            (*ctx->inputs_names_)[inputs_idx],
-                            inputs_idx));
-    }
-    // Copy non-in-place outputs as usual
-    for (size_t i = 0; i < outs.size(); ++i) {
-      if (ctx->GetInplaceIndexMap().find(i) ==
-          ctx->GetInplaceIndexMap().end()) {
-        AssignTensorImpl(outs.at(i), &(ctx->AllMutableOutput()->at(i)));
-      }
-    }
-  } else {
-    // Case 3: Output count mismatch; throw an error.
-    PADDLE_THROW(common::errors::PreconditionNotMet(
-        "The number of output tensors does not match the expected number. "
-        "Please ensure that the number of outputs matches the definition in "
-        "the PD_BUILD_OP macro, or equals the number of non-inplace outputs.")
-
-    );
-  }
-}
-
 PADDLE_API void AssignTensorImpl(const Tensor& src, Tensor* dst) {
   if (!src.has_allocation() || !dst->defined()) {
     VLOG(3) << "Custom operator assigns non-initialized tensor, this only "
@@ -384,6 +326,64 @@ std::unordered_map<size_t, size_t>
 CustomOpKernelContext::GetInplaceReverseIndexMap() const {
   return inplace_reverse_idx_map_;
 }
+
+void CustomOpKernelContext::ValidateAndAssignOutputs(
+    CustomOpKernelContext* ctx, const std::vector<Tensor>& outs) {
+  auto* orig_outs = ctx->AllMutablePlainOutput();  // without inplaced outputs
+  auto* all_outs = ctx->AllMutableOutput();
+
+  // NOTE: This logic contains three branches:
+  // 1) If the number of returned tensors equals the number of non-inplace
+  // outputs, directly assign the returned tensors to
+  // ctx->AllMutablePlainOutput().
+  // 2) If the number of returned tensors equals the total number of outputs
+  // (including in-place outputs), validate that the addresses of in-place
+  // outputs match their corresponding inputs.
+  // 3) Otherwise, throw an error.
+  if (orig_outs->size() == outs.size()) {
+    // Case 1: Returned tensor count matches non-inplace output count; assign
+    // directly.
+    for (size_t i = 0; i < outs.size(); ++i) {
+      AssignTensorImpl(outs.at(i), orig_outs->at(i));
+    }
+  } else if (outs.size() == all_outs->size()) {
+    // Case 2: Returned tensor count matches total output count (including
+    // in-place outputs).
+    if (!ctx->GetInplaceIndexMap().empty()) {
+      LOG(WARNING) << "[CustomOp] In-place outputs detected, "
+                   << "but the number of returned outputs matches the declared "
+                      "output count.";
+    }
+    // Ensure in-place output tensors share memory with their corresponding
+    // inputs
+    for (auto& [inputs_idx, outputs_idx] : ctx->GetInplaceIndexMap()) {
+      PADDLE_ENFORCE_EQ(ctx->InputAt(inputs_idx).impl().get(),
+                        outs.at(outputs_idx).impl().get(),
+                        common::errors::PreconditionNotMet(
+                            "In-place output tensor `%s` at index %d does not "
+                            "share the same address as "
+                            "the input tensor `%s` at index %d.",
+                            (*ctx->outputs_names_)[outputs_idx],
+                            outputs_idx,
+                            (*ctx->inputs_names_)[inputs_idx],
+                            inputs_idx));
+    }
+    // Copy non-in-place outputs as usual
+    for (size_t i = 0; i < outs.size(); ++i) {
+      if (ctx->GetInplaceIndexMap().count(i)) continue;
+      AssignTensorImpl(outs.at(i), &(all_outs->at(i)));
+    }
+  } else {
+    // Case 3: Output count mismatch; throw an error.
+    PADDLE_THROW(common::errors::PreconditionNotMet(
+        "The number of output tensors does not match the expected number. "
+        "Please ensure that the number of outputs matches the definition in "
+        "the PD_BUILD_OP macro, or equals the number of non-inplace outputs.")
+
+    );
+  }
+}
+
 ////////////////////// Op Meta Info //////////////////////
 
 OpMetaInfo& OpMetaInfo::Inputs(std::vector<std::string>&& inputs) {

--- a/paddle/phi/api/lib/op_meta_info.cc
+++ b/paddle/phi/api/lib/op_meta_info.cc
@@ -328,14 +328,13 @@ CustomOpKernelContext::GetInplaceReverseIndexMap() const {
 }
 
 void CustomOpKernelContext::ValidateAndAssignOutputs(
-    CustomOpKernelContext* ctx, const std::vector<Tensor>& outs) {
-  auto* orig_outs = ctx->AllMutablePlainOutput();  // without inplaced outputs
-  auto* all_outs = ctx->AllMutableOutput();
+    const std::vector<Tensor>& outs) {
+  auto* orig_outs = AllMutablePlainOutput();  // without inplaced outputs
+  auto* all_outs = AllMutableOutput();
 
   // NOTE: This logic contains three branches:
   // 1) If the number of returned tensors equals the number of non-inplace
-  // outputs, directly assign the returned tensors to
-  // ctx->AllMutablePlainOutput().
+  // outputs, directly assign the returned tensors to AllMutablePlainOutput().
   // 2) If the number of returned tensors equals the total number of outputs
   // (including in-place outputs), validate that the addresses of in-place
   // outputs match their corresponding inputs.
@@ -349,28 +348,28 @@ void CustomOpKernelContext::ValidateAndAssignOutputs(
   } else if (outs.size() == all_outs->size()) {
     // Case 2: Returned tensor count matches total output count (including
     // in-place outputs).
-    if (!ctx->GetInplaceIndexMap().empty()) {
+    if (!GetInplaceIndexMap().empty()) {
       LOG(WARNING) << "[CustomOp] In-place outputs detected, "
                    << "but the number of returned outputs matches the declared "
                       "output count.";
     }
     // Ensure in-place output tensors share memory with their corresponding
     // inputs
-    for (auto& [inputs_idx, outputs_idx] : ctx->GetInplaceIndexMap()) {
-      PADDLE_ENFORCE_EQ(ctx->InputAt(inputs_idx).impl().get(),
+    for (auto& [inputs_idx, outputs_idx] : GetInplaceIndexMap()) {
+      PADDLE_ENFORCE_EQ(InputAt(inputs_idx).impl().get(),
                         outs.at(outputs_idx).impl().get(),
                         common::errors::PreconditionNotMet(
                             "In-place output tensor `%s` at index %d does not "
                             "share the same address as "
                             "the input tensor `%s` at index %d.",
-                            ctx->outputs_names_.at(outputs_idx),
+                            this->outputs_names_.at(outputs_idx),
                             outputs_idx,
-                            ctx->inputs_names_.at(inputs_idx),
+                            this->inputs_names_.at(inputs_idx),
                             inputs_idx));
     }
     // Copy non-in-place outputs as usual
     for (size_t i = 0; i < outs.size(); ++i) {
-      if (ctx->GetInplaceIndexMap().count(i)) continue;
+      if (GetInplaceIndexMap().count(i)) continue;
       AssignTensorImpl(outs.at(i), &(all_outs->at(i)));
     }
   } else {
@@ -378,13 +377,13 @@ void CustomOpKernelContext::ValidateAndAssignOutputs(
     std::vector<std::string> outputs_names_wo_inplace;
     std::vector<std::string> outputs_names_with_inplace;
 
-    for (size_t i = 0; i < ctx->outputs_names_.size(); ++i) {
-      if (ctx->GetInplaceIndexMap().count(i)) {
-        outputs_names_with_inplace.push_back(ctx->outputs_names_.at(i) +
+    for (size_t i = 0; i < this->outputs_names_.size(); ++i) {
+      if (GetInplaceIndexMap().count(i)) {
+        outputs_names_with_inplace.push_back(this->outputs_names_.at(i) +
                                              "(inplaced)");
       } else {
-        outputs_names_with_inplace.push_back(ctx->outputs_names_.at(i));
-        outputs_names_wo_inplace.push_back(ctx->outputs_names_.at(i));
+        outputs_names_with_inplace.push_back(this->outputs_names_.at(i));
+        outputs_names_wo_inplace.push_back(this->outputs_names_.at(i));
       }
     }
     const std::string output_str_wo_inplace =
@@ -393,8 +392,8 @@ void CustomOpKernelContext::ValidateAndAssignOutputs(
     const std::string output_str_with_inplace =
         paddle::string::join_strings<std::vector<std::string>>(
             outputs_names_with_inplace, ", ");
-    const int num_inplace_outputs = ctx->GetInplaceIndexMap().size();
-    const int num_outputs = ctx->outputs_names_.size();
+    const int num_inplace_outputs = GetInplaceIndexMap().size();
+    const int num_outputs = outputs_names_.size();
 
     PADDLE_THROW(common::errors::PreconditionNotMet(
         "Output tensor count mismatch. Expected outputs: [%s] (including %d "


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->

原来的自定义算子中，函数只需要返回非 inplace 的输出即可，比如如下声明，`fmha_out` 既是输入，又是输出：

```
PD_BUILD_STATIC_OP(append_attention_with_output)
    .Inputs({"qkv", "key_cache", "fmha_out"})
    .Outputs({"fmha_out_out"})
    .SetInplaceMap({{"fmha_out", "fmha_out_out"}})      # <----------
    .Attrs({"rms_norm_eps: float"})
    .SetKernelFn(PD_KERNEL(AppendAttentionWithOutput))
	......
```

由于只需要返回非 inplace 的输出，所以 `AppendAttentionWithOutput` 函数返回值为 void 即可

```
void AppendAttentionWithOutput(
	const paddle::Tensor& qkv, 
	const paddle::Tensor& key_cache, 
	paddle::Tensor& fmha_out){...}
```

在 FastDeploy 中，由于 C++ 扩展的需要，要求返回值为 `vector<Tensor>`，将`fmha_out`返回，否则存在动静不统一的问题

而要将 `fmha_out` 返回的话，就必须删除 `SetInplaceMap({{"fmha_out", "fmha_out_out"}})` 的申明，这样会丢失自定义算的子inplace 信息，使算子依赖关系乱掉

既加 SetInplaceMap 申明，又直接 `return fmha_out` 的话，这部分会报错：
https://github.com/PaddlePaddle/Paddle/blob/ae95cca58704aa6240897f6c9844f7fcb7af9060/paddle/phi/api/ext/op_meta_info.h#L402-L410

----

本 PR 放宽 ValidateAndAssignOutputs 的校验逻辑：
- 当 **函数返回值数量 == 注册时总输出数量（含 inplace）** 时，只额外做一次「地址一致性」校验，**不再抛异常**。
- 非 inplace 输出仍走拷贝；inplace 输出只要地址匹配即通过。

因此可以同时满足：
```c++
PD_BUILD_STATIC_OP(append_attention_with_output)
    .Inputs({"qkv", "key_cache", "fmha_out"})
    .Outputs({"fmha_out_out"})
    .SetInplaceMap({{"fmha_out", "fmha_out_out"}})   // ✅ 保留 inplace 信息
    .Attrs({"rms_norm_eps: float"})
    .SetKernelFn(PD_KERNEL(AppendAttentionWithOutput));


std::vector<Tensor> AppendAttentionWithOutput(
    const Tensor& qkv,
    const Tensor& key_cache,
    Tensor& fmha_out) {          // inplace 输出
  // ... 计算 ...
  return {fmha_out};             // ✅ 现在允许直接返回 inplace Tensor
}
```

<!-- PCard-92901 -->