### PR TITLE
Refine warning message for `ForbidKeywordsDecorator`

### DIFF
--- a/python/paddle/utils/decorator_utils.py
+++ b/python/paddle/utils/decorator_utils.py
@@ -400,7 +400,12 @@ class ForbidKeywordsDecorator(DecoratorBase):
         self.correct_name = correct_name
         self.warn_msg = None
         if url_suffix:
-            self.warn_msg = f"\nNon compatible API. Please refer to https://www.paddlepaddle.org.cn/documentation/docs/en/develop/guides/model_convert/convert_from_pytorch/api_difference/{url_suffix}.html first."
+            self.warn_msg = (
+                f"The API '{func_name}' may behave differently from its PyTorch counterpart. "
+                f"Refer to the compatibility guide for details:\n"
+                f"https://www.paddlepaddle.org.cn/documentation/docs/en/develop/guides/model_convert/"
+                f"convert_from_pytorch/api_difference/{url_suffix}.html"
+            )
 
     def process(
         self, args: tuple[Any, ...], kwargs: dict[str, Any]
@@ -419,7 +424,7 @@ class ForbidKeywordsDecorator(DecoratorBase):
         if self.warn_msg is not None:
             warnings.warn(
                 self.warn_msg,
-                category=Warning,
+                category=UserWarning,
             )
             self.warn_msg = None
         return args, kwargs

--- a/test/legacy_test/test_decorator.py
+++ b/test/legacy_test/test_decorator.py
@@ -183,5 +183,17 @@ class TestMultiProcessReader(unittest.TestCase):
             self.reader_test(use_pipe=True)
 
 
+class test_ForbidKeywordsDecorator(unittest.TestCase):
+    def test(self):
+        x = paddle.randn([2, 2])
+        self.assertWarnsRegex(
+            UserWarning,
+            "may behave differently from its PyTorch counterpart",
+            paddle.split,
+            x,
+            2,
+        )
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->

Pcard-75624

修复前警告信息展示不明确，且不告知具体调用位置
<img width="1391" height="166" alt="image" src="https://github.com/user-attachments/assets/a0b3c13c-12db-4356-bbcd-29aa484bf2e7" />


修复后可正常显示存在行为差异的API名字及其调用位置：
<img width="1304" height="130" alt="image" src="https://github.com/user-attachments/assets/50256905-1ad3-4468-830c-eee037dc85d3" />

