### PR TITLE
[API-Compat] paddle.gather inplace compatible upgrade

### DIFF
--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import functools
+import inspect
 import math
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -4109,13 +4110,94 @@ def unsqueeze_(
     return _C_ops.unsqueeze_(input, axes)
 
 
-def gather(
+def _take_along_axis_wrapper(
+    input: Tensor,
+    dim: int,
+    index: Tensor,
+    out: Tensor | None = None,
+):
+    """Wrapper for take_along_axis"""
+    res = paddle.take_along_axis(input, index, dim, broadcast=False)
+    if out is not None:
+        paddle.assign(res, out)
+    return res
+
+
+def _gather_wrapper(
     x: Tensor,
     index: Tensor,
     axis: Tensor | int | None = None,
     name: str | None = None,
+    out: Tensor | None = None,
 ) -> Tensor:
+    """Wrapper for original gather"""
+    if axis is None:
+        axis = 0
+
+    if in_dynamic_or_pir_mode():
+        res = _C_ops.gather(x, index, axis)
+    else:
+        check_variable_and_dtype(
+            x,
+            'x',
+            [
+                'bool',
+                'float16',
+                'float32',
+                'float64',
+                'int16',
+                'int32',
+                'int64',
+                'uint8',
+                'uint16',
+                'complex64',
+                'complex128',
+            ],
+            'gather',
+        )
+        check_variable_and_dtype(index, 'index', ['int32', 'int64'], 'gather')
+
+        if isinstance(axis, Variable):
+            check_variable_and_dtype(axis, 'axis', ['int32', 'int64'], 'gather')
+
+        helper = LayerHelper('gather', **locals())
+        dtype = helper.input_dtype('x')
+        output = helper.create_variable_for_type_inference(dtype)
+        if not isinstance(axis, Variable):
+            helper.append_op(
+                type="gather",
+                inputs={"X": x, "Index": index},
+                attrs={'axis': axis, 'overwrite': False},
+                outputs={"Out": output},
+            )
+        else:
+            helper.append_op(
+                type="gather",
+                inputs={"X": x, "Index": index, "Axis": axis},
+                attrs={"overwrite": False},
+                outputs={"Out": output},
+            )
+
+        res = output
+    if out is not None:
+        paddle.assign(res, out)
+    return res
+
+
+def gather(*args: Any, **kwargs: Any) -> Tensor:
     """
+    This function has two functionalities, depending on the parameters passed:
+
+    1. ``gather(Tensor input, int dim, Tensor index, Tensor out = None)``:
+        PyTorch compatible gather, calls a non-broadcast `paddle.take_along_axis`.
+        Check out :ref:`api_paddle_take_along_axis` and also `[torch has more parameters] torch.scatter <https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/guides/model_convert/convert_from_pytorch/api_difference/torch/torch.gather.html>`_
+        Note that ``sparse_grad`` param of PyTorch is currently not supported by Paddle, therefore do not pass this param (behavior is equivalent to ``sparse_grad = False``).
+        Also, dim allows for Tensor input, the same as PyTorch. However, when the first 3 params are all of Tensor types, there will be ambiguity between these two functionalities.
+        Currently, original gather pass is more actively selected. Try avoiding using Tensor dim as input therefore.
+
+    2. ``gather(Tensor x, Tensor index, int axis, str name = None, Tensor out = None)``:
+        The original paddle.gather, see the following docs.
+
     Output is obtained by gathering entries of ``axis``
     of ``x`` indexed by ``index`` and concatenate them together.
 
@@ -4162,54 +4244,28 @@ def gather(
             [[1, 2],
              [3, 4]])
     """
-    if axis is None:
-        axis = 0
-
-    if in_dynamic_or_pir_mode():
-        return _C_ops.gather(x, index, axis)
-    else:
-        check_variable_and_dtype(
-            x,
-            'x',
-            [
-                'bool',
-                'float16',
-                'float32',
-                'float64',
-                'int16',
-                'int32',
-                'int64',
-                'uint8',
-                'uint16',
-                'complex64',
-                'complex128',
-            ],
-            'gather',
+    len_args = len(args)
+    if len_args + len(kwargs) < 2:
+        raise TypeError(
+            f"Too few arguments in the function call: {len_args}, {len(kwargs)}. Expect one of: \n"
+            " - (Tensor input, int dim, Tensor index, *, Tensor out = None)\n"
+            " - (Tensor x, Tensor index, int axis, str name = None, Tensor out = None)"
         )
-        check_variable_and_dtype(index, 'index', ['int32', 'int64'], 'gather')
 
-        if isinstance(axis, Variable):
-            check_variable_and_dtype(axis, 'axis', ['int32', 'int64'], 'gather')
+    is_take_along_axis = False
+    if len_args >= 2:
+        # gather index cannot be int, yet take_along_axis dim can be
+        is_take_along_axis |= isinstance(args[1], int)
+    else:
+        is_take_along_axis |= 'dim' in kwargs
 
-        helper = LayerHelper('gather', **locals())
-        dtype = helper.input_dtype('x')
-        out = helper.create_variable_for_type_inference(dtype)
-        if not isinstance(axis, Variable):
-            helper.append_op(
-                type="gather",
-                inputs={"X": x, "Index": index},
-                attrs={'axis': axis, 'overwrite': False},
-                outputs={"Out": out},
-            )
-        else:
-            helper.append_op(
-                type="gather",
-                inputs={"X": x, "Index": index, "Axis": axis},
-                attrs={"overwrite": False},
-                outputs={"Out": out},
-            )
+    if is_take_along_axis:
+        return _take_along_axis_wrapper(*args, **kwargs)
+    else:
+        return _gather_wrapper(*args, **kwargs)
 
-        return out
+
+gather.__signature__ = inspect.signature(_gather_wrapper)
 
 
 @param_one_alias(['axis', 'dim'])

--- a/test/legacy_test/test_gather_compatible.py
+++ b/test/legacy_test/test_gather_compatible.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+
+import paddle
+
+
+class TestGatherCompatible(unittest.TestCase):
+    def test_non_inplace_origin_gather(self):
+        x = paddle.arange(12, dtype=paddle.float32).reshape([3, 4])
+        index = paddle.to_tensor([0, 1, 1], dtype=paddle.int64)
+        x.stop_gradient = False
+        res_out = paddle.to_tensor(0)
+        res = paddle.gather(x, axis=1, index=index, out=res_out)
+        gt = np.array(
+            [[0.0, 1.0, 1.0], [4.0, 5.0, 5.0], [8.0, 9.0, 9.0]],
+            dtype=np.float32,
+        )
+        np.testing.assert_allclose(res.numpy(), gt)
+        np.testing.assert_allclose(res_out.numpy(), gt)
+        res.backward()
+        gt_x_grad = np.array(
+            [[1.0, 2.0, 0.0, 0.0], [1.0, 2.0, 0.0, 0.0], [1.0, 2.0, 0.0, 0.0]],
+            dtype=np.float32,
+        )
+        np.testing.assert_allclose(x.grad.numpy(), gt_x_grad)
+
+    def test_take_along_axis_pass(self):
+        inputs = paddle.arange(0, 12, dtype=paddle.float64).reshape([3, 4])
+        index = paddle.ones([2, 4], dtype=paddle.int64)
+        gt = np.array(
+            [[1.0, 1.0, 1.0, 1.0], [5.0, 5.0, 5.0, 5.0]],
+            dtype=np.float64,
+        )
+
+        arg_cases = [
+            [1],
+            [],
+            [1, index],
+        ]
+        kwarg_cases = [
+            {
+                'index': index,
+            },
+            {'index': index, 'dim': 1},
+            {},
+        ]
+        for args, kwargs in zip(arg_cases, kwarg_cases):
+            res = paddle.gather(inputs, *args, **kwargs)
+            np.testing.assert_allclose(res.numpy(), gt)
+
+    def test_error_handling_and_special_cases(self):
+        too_few_args = (
+            "Too few arguments in the function call: {p1}, {p2}. Expect one of: \n"
+            " - (Tensor input, int dim, Tensor index, *, Tensor out = None)\n"
+            " - (Tensor x, Tensor index, int axis, str name = None, Tensor out = None)"
+        )
+
+        dummy_input = paddle.arange(0, 12, dtype=paddle.float64).reshape([3, 4])
+        dummy_index = paddle.ones([3, 3], dtype=paddle.int64)
+        dummy_dim = 1
+        with self.assertRaises(TypeError) as cm:
+            paddle.gather(dummy_input)
+        self.assertEqual(str(cm.exception), too_few_args.format(p1=1, p2=0))
+
+        with self.assertRaises(TypeError) as cm:
+            paddle.gather(input=dummy_input)
+        self.assertEqual(str(cm.exception), too_few_args.format(p1=0, p2=1))
+
+
+if __name__ == '__main__':
+    paddle.set_device('cpu')
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Operator Mechanism


### PR Types
Improvements


### Description
gather 增加了对齐 PyTorch `torch.gather` 行为的功能，属于对 `paddle.gather` 的原地升级，兼容原有 gather 的行为。新增 gather 行为与 `paddle.take_along_axis` 一致。

`paddle.gather` 在本 PR 后有两套行为：
```python 
paddle.gather(x, index, axis, name, out)       # 原始行为
paddle.gather(x, dim, index, out)  # 新增行为
# 新增行为等同于：
paddle.take_along_axis(x, index, axis=dim, broadcast=False)    # 与 PyTorch gather 对齐
```

注意⚠️！`gather` 有两套相互冲突的函数签名：这是由于我们需要在同一个函数下支持两种不同的功能，两个功能依赖输入参数之间的区别进行选择、区分。输入混淆的参数将会导致报错。

相互冲突的函数签名将会导致：在 OpTest 中进行测试时，被调用的函数必须设置正确的函数签名。举例来说：
- 如果测试 `take_along_axis` 功能，那么 `paddle.gather` 的函数签名必须与 `take_along_axis` (的 wrapper) 一致。
- 如果测试原始 `gather` 功能，那么 `paddle.gather` 的函数签名必须与 `gather` (的 wrapper) 一致。

但一个函数不能有两套相互冲突的签名（__signature__）来进行动态选择。故默认我们将 `gather` 的 signature 设置为与原有 gather 一致，`take_along_axis` 的 signature 会被忽略。原因：
- `paddle.gather` 的原有功能是原始 gather，`take_along_axis` 的功能只是兼容功能，故应该保留原有的签名。
- `gather` 本身有 OpTest，如果不保留 `gather` 原有签名，将会报错。

所以！不要尝试对 `take_along_axis` pass (gather 内部) 设计 OpTest。静态图 OpTest 测试请单独测 `take_along_axis`，不要测试 `gather` 的 `take_along_axis` 功能。

代码中强制设置函数签名的方式：
```python
gather.__signature__ = inspect.signature(_gather_wrapper)
```

Pcard-89620