### PR TITLE
[Compat] Add torch compatible `paddle.device(...)` support

### DIFF
--- a/test/legacy_test/test_paddle_device.py
+++ b/test/legacy_test/test_paddle_device.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# test_cuda_unittest.py
+import unittest
+
+import paddle
+
+
+class TestCudaCompat(unittest.TestCase):
+    # ---------------------
+    # paddle.device compatibility tests
+    # ---------------------
+    def test_paddle_device_cpu(self):
+        d = paddle.device("cpu")
+        self.assertTrue(d == "cpu")
+
+    def test_paddle_device_gpu(self):
+        d1 = paddle.device("cuda", 2)
+        self.assertEqual(d1, "gpu:2")
+
+        d2 = paddle.device("cuda:3")
+        self.assertEqual(d2, "gpu:3")
+
+        d3 = paddle.device(4)
+        self.assertEqual(d3, "gpu:4")
+
+    def test_paddle_device_copy(self):
+        d1 = paddle.device("gpu:1")
+        d2 = paddle.device(d1)
+        self.assertEqual(d1, d2)
+
+    def test_paddle_device_invalid(self):
+        with self.assertRaises(ValueError):
+            paddle.device("tpu")
+        with self.assertRaises(TypeError):
+            paddle.device(3.14)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/legacy_test/test_paddle_device.py
+++ b/test/legacy_test/test_paddle_device.py
@@ -22,19 +22,37 @@ class TestCudaCompat(unittest.TestCase):
     # ---------------------
     # paddle.device compatibility tests
     # ---------------------
+
     def test_paddle_device_cpu(self):
         d = paddle.device("cpu")
         self.assertTrue(d == "cpu")
+        self.assertEqual(str(d), "cpu")
+        self.assertEqual(d(), "cpu")
 
-    def test_paddle_device_gpu(self):
-        d1 = paddle.device("cuda", 2)
-        self.assertEqual(d1, "gpu:2")
+    def test_paddle_device_gpu_variants(self):
+        cases = [
+            (("cuda", 2), "gpu:2"),
+            (("gpu", 1), "gpu:1"),
+            (("cuda:3",), "gpu:3"),
+            (("gpu:4",), "gpu:4"),
+            ((5,), "gpu:5"),  # int -> gpu
+            (("gpu", None), "gpu:0"),  # None index defaults to 0
+        ]
+        for args, expected in cases:
+            d = paddle.device(*args)
+            self.assertEqual(str(d), expected)
+            self.assertEqual(d(), expected)  # __call__ path
+            self.assertTrue(d == expected)  # __eq__ with str
 
-        d2 = paddle.device("cuda:3")
-        self.assertEqual(d2, "gpu:3")
-
-        d3 = paddle.device(4)
-        self.assertEqual(d3, "gpu:4")
+    def test_paddle_device_xpu_variants(self):
+        cases = [
+            (("xpu", 2), "xpu:2"),
+            (("xpu:3",), "xpu:3"),
+            (("xpu", None), "xpu:0"),
+        ]
+        for args, expected in cases:
+            d = paddle.device(*args)
+            self.assertEqual(str(d), expected)
 
     def test_paddle_device_copy(self):
         d1 = paddle.device("gpu:1")
@@ -43,9 +61,29 @@ class TestCudaCompat(unittest.TestCase):
 
     def test_paddle_device_invalid(self):
         with self.assertRaises(ValueError):
+            paddle.device("cpu", 2)
+
+        with self.assertRaises(ValueError):
             paddle.device("tpu")
+
         with self.assertRaises(TypeError):
             paddle.device(3.14)
+
+    def test_device_eq(self):
+        d1 = paddle.device("cuda:1")
+        d2 = paddle.device("gpu:1")
+        d3 = paddle.device("gpu:2")
+        self.assertTrue(d1 == d2)
+        self.assertFalse(d1 == d3)
+        self.assertFalse(d1 == "gpu:2")  # mismatch
+
+    def test_device_module_getattr_success(self):
+        mod = paddle.device.cuda
+        self.assertIs(mod, paddle.device.cuda)
+
+    def test_device_module_getattr_fail(self):
+        with self.assertRaises(AttributeError):
+            _ = paddle.device.foobar
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->

新增torch.device<-->paddle.device的映射
通过 自定义模块 _DeviceModule 并替换当前模块 来实现同时保留paddle.device的子模块的属性：
	•	_DeviceModule 继承自 types.ModuleType，在其中重写了 __call__ 方法，使模块本身可以像函数一样被调用，返回 Device 对象。
	•	同时重写 __getattr__，在访问 paddle.device.<子模块> 时才动态导入对应子模块，实现延迟加载。
	•	最后用 sys.modules[__name__] = _proxy 把原来的模块替换为这个可调用、支持子模块的 _DeviceModule 实例，从而 paddle.device 既能被调用，又能访问子模块。

pcard-67164

