### PR TITLE
[Compat] Support use `paddle.version.cuda` as str

### DIFF
--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -317,6 +317,8 @@ class CudaVersion(str):
         return super().__new__(cls, version)
 
     def __call__(self) -> str:
+        # When users check for GPU devices using paddle.version.cuda is None, we cannot align this behavior with other frameworks .
+        # Note: This discrepancy arises because the is operator checks for object identity (memory address equality) rather than value equality.
         return str(self)
 
     def __repr__(self) -> str:

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -296,6 +296,22 @@ def nccl() -> str:
     """
     return nccl_version
 
+import inspect
+CUDA_FUNC_DOC = """Get cuda version of paddle package.
+
+    Returns:
+        string: Return the version information of cuda. If paddle package is CPU version, it will return False.
+
+    Examples:
+        .. code-block:: python
+
+            >>> import paddle
+
+            >>> paddle.version.cuda()
+            >>> # doctest: +SKIP('Different environments yield different output.')
+            '10.2'
+
+    """
 class CudaVersion(str):
     def __new__(cls, version: str):
         return super().__new__(cls, version)
@@ -305,6 +321,17 @@ class CudaVersion(str):
 
     def __repr__(self) -> str:
         return f"CudaVersion('{self}')"
+
+    @property
+    def __doc__(self):
+        return CUDA_FUNC_DOC
+
+    @property
+    def __signature__(self):
+        return inspect.Signature(
+            parameters=[],
+            return_annotation=str
+        )
 
 cuda = CudaVersion(cuda_version)
 

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -296,25 +296,15 @@ def nccl() -> str:
     """
     return nccl_version
 
-class CudaVersion:
-    def __init__(self, version: str):
-        self.version = version
+class CudaVersion(str):
+    def __new__(cls, version: str):
+        return super().__new__(cls, version)
 
     def __call__(self) -> str:
-        return self.version
-
-    def __str__(self) -> str:
-        return self.version
+        return str(self)
 
     def __repr__(self) -> str:
-        return f"CudaVersion('{self.version}')"
-
-    def __eq__(self, other) -> bool:
-        if isinstance(other, str):
-            return self.version == other
-        if isinstance(other, CudaVersion):
-            return self.version == other.version
-        return NotImplemented
+        return f"CudaVersion('{self}')"
 
 cuda = CudaVersion(cuda_version)
 

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -296,23 +296,27 @@ def nccl() -> str:
     """
     return nccl_version
 
-def cuda() -> str:
-    """Get cuda version of paddle package.
+class CudaVersion:
+    def __init__(self, version: str):
+        self.version = version
 
-    Returns:
-        string: Return the version information of cuda. If paddle package is CPU version, it will return False.
+    def __call__(self) -> str:
+        return self.version
 
-    Examples:
-        .. code-block:: python
+    def __str__(self) -> str:
+        return self.version
 
-            >>> import paddle
+    def __repr__(self) -> str:
+        return f"CudaVersion('{self.version}')"
 
-            >>> paddle.version.cuda()
-            >>> # doctest: +SKIP('Different environments yield different output.')
-            '10.2'
+    def __eq__(self, other) -> bool:
+        if isinstance(other, str):
+            return self.version == other
+        if isinstance(other, CudaVersion):
+            return self.version == other.version
+        return NotImplemented
 
-    """
-    return cuda_version
+cuda = CudaVersion(cuda_version)
 
 def cudnn() -> str:
     """Get cudnn version of paddle package.

--- a/setup.py
+++ b/setup.py
@@ -615,23 +615,27 @@ def nccl() -> str:
     """
     return nccl_version
 
-def cuda() -> str:
-    """Get cuda version of paddle package.
+class CudaVersion:
+    def __init__(self, version: str):
+        self.version = version
 
-    Returns:
-        string: Return the version information of cuda. If paddle package is CPU version, it will return False.
+    def __call__(self) -> str:
+        return self.version
 
-    Examples:
-        .. code-block:: python
+    def __str__(self) -> str:
+        return self.version
 
-            >>> import paddle
+    def __repr__(self) -> str:
+        return f"CudaVersion('{self.version}')"
 
-            >>> paddle.version.cuda()
-            >>> # doctest: +SKIP('Different environments yield different output.')
-            '10.2'
+    def __eq__(self, other) -> bool:
+        if isinstance(other, str):
+            return self.version == other
+        if isinstance(other, CudaVersion):
+            return self.version == other.version
+        return NotImplemented
 
-    """
-    return cuda_version
+cuda = CudaVersion(cuda_version)
 
 def cudnn() -> str:
     """Get cudnn version of paddle package.

--- a/setup.py
+++ b/setup.py
@@ -636,6 +636,8 @@ class CudaVersion(str):
         return super().__new__(cls, version)
 
     def __call__(self) -> str:
+        # When users check for GPU devices using paddle.version.cuda is None, we cannot align this behavior with other frameworks .
+        # Note: This discrepancy arises because the is operator checks for object identity (memory address equality) rather than value equality.
         return str(self)
 
     def __repr__(self) -> str:

--- a/setup.py
+++ b/setup.py
@@ -615,6 +615,22 @@ def nccl() -> str:
     """
     return nccl_version
 
+import inspect
+CUDA_FUNC_DOC = """Get cuda version of paddle package.
+
+    Returns:
+        string: Return the version information of cuda. If paddle package is CPU version, it will return False.
+
+    Examples:
+        .. code-block:: python
+
+            >>> import paddle
+
+            >>> paddle.version.cuda()
+            >>> # doctest: +SKIP('Different environments yield different output.')
+            '10.2'
+
+    """
 class CudaVersion(str):
     def __new__(cls, version: str):
         return super().__new__(cls, version)
@@ -624,6 +640,17 @@ class CudaVersion(str):
 
     def __repr__(self) -> str:
         return f"CudaVersion('{self}')"
+
+    @property
+    def __doc__(self):
+        return CUDA_FUNC_DOC
+
+    @property
+    def __signature__(self):
+        return inspect.Signature(
+            parameters=[],
+            return_annotation=str
+        )
 
 cuda = CudaVersion(cuda_version)
 

--- a/setup.py
+++ b/setup.py
@@ -615,25 +615,15 @@ def nccl() -> str:
     """
     return nccl_version
 
-class CudaVersion:
-    def __init__(self, version: str):
-        self.version = version
+class CudaVersion(str):
+    def __new__(cls, version: str):
+        return super().__new__(cls, version)
 
     def __call__(self) -> str:
-        return self.version
-
-    def __str__(self) -> str:
-        return self.version
+        return str(self)
 
     def __repr__(self) -> str:
-        return f"CudaVersion('{self.version}')"
-
-    def __eq__(self, other) -> bool:
-        if isinstance(other, str):
-            return self.version == other
-        if isinstance(other, CudaVersion):
-            return self.version == other.version
-        return NotImplemented
+        return f"CudaVersion('{self}')"
 
 cuda = CudaVersion(cuda_version)
 

--- a/test/compat/test_version_cuda.py
+++ b/test/compat/test_version_cuda.py
@@ -23,12 +23,19 @@ class TestCudaVariable(unittest.TestCase):
             self.assertIsInstance(cuda, str)
             self.assertTrue(len(cuda) > 0)
             self.assertEqual(str(cuda), cuda)
-            self.assertTrue(float(cuda) > 0)
-
             self.assertTrue(callable(cuda))
+            self.assertTrue(
+                hasattr(cuda, 'startswith'),
+                "Return value of cuda does not have 'startswith' attribute",
+            )
             result = cuda()
             self.assertIsInstance(result, str)
             self.assertEqual(result, cuda)
+            self.assertTrue(
+                hasattr(result, 'startswith'),
+                "Return value of cuda() does not have 'startswith' attribute",
+            )
+
         else:
             print("no CUDA ")
 

--- a/test/compat/test_version_cuda.py
+++ b/test/compat/test_version_cuda.py
@@ -12,32 +12,43 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
 import unittest
 
 from paddle.version import cuda
 
 
 class TestCudaVariable(unittest.TestCase):
-    def test_cuda_functionality(self):
-        if cuda:
-            self.assertIsInstance(cuda, str)
-            self.assertTrue(len(cuda) > 0)
-            self.assertEqual(str(cuda), cuda)
-            self.assertTrue(callable(cuda))
-            self.assertTrue(
-                hasattr(cuda, 'startswith'),
-                "Return value of cuda does not have 'startswith' attribute",
-            )
-            result = cuda()
-            self.assertIsInstance(result, str)
-            self.assertEqual(result, cuda)
-            self.assertTrue(
-                hasattr(result, 'startswith'),
-                "Return value of cuda() does not have 'startswith' attribute",
-            )
+    def test_has_signature(self):
+        self.assertTrue(hasattr(cuda, '__signature__'))
+        self.assertIsInstance(cuda.__signature__, inspect.Signature)
+        self.assertEqual(len(cuda.__signature__.parameters), 0)
 
-        else:
-            print("no CUDA ")
+    def test_has_doc(self):
+        self.assertTrue(hasattr(cuda, '__doc__'))
+        self.assertIsInstance(cuda.__doc__, str)
+        self.assertTrue(len(cuda.__doc__.strip()) > 0)
+
+    def test_inspect_recognizes(self):
+        self.assertTrue(inspect.getdoc(cuda))
+        self.assertIsInstance(inspect.signature(cuda), inspect.Signature)
+
+    def test_cuda_functionality(self):
+        self.assertIsInstance(cuda, str)
+        self.assertTrue(len(cuda) > 0)
+        self.assertEqual(str(cuda), cuda)
+        self.assertTrue(callable(cuda))
+        self.assertTrue(
+            hasattr(cuda, 'startswith'),
+            "Return value of cuda does not have 'startswith' attribute",
+        )
+        result = cuda()
+        self.assertIsInstance(result, str)
+        self.assertEqual(result, cuda)
+        self.assertTrue(
+            hasattr(result, 'startswith'),
+            "Return value of cuda() does not have 'startswith' attribute",
+        )
 
 
 if __name__ == "__main__":

--- a/test/compat/test_version_cuda.py
+++ b/test/compat/test_version_cuda.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from paddle.version import cuda
+
+
+class TestCudaVariable(unittest.TestCase):
+    def test_cuda_functionality(self):
+        if cuda:
+            self.assertIsInstance(cuda, str)
+            self.assertTrue(len(cuda) > 0)
+            self.assertEqual(str(cuda), cuda)
+            self.assertTrue(float(cuda) > 0)
+
+            self.assertTrue(callable(cuda))
+            result = cuda()
+            self.assertIsInstance(result, str)
+            self.assertEqual(result, cuda)
+        else:
+            print("no CUDA ")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
torch.version.cuda是一个变量，paddle.version.cuda是一个函数，因此修改paddle.version.cuda成一个可以call的类，保持paddle本身的功能，还可以直接paddle.version.cuda使用,测试如下
>>> paddle.version.cuda()
'11.8'
>>> print(paddle.version.cuda)
11.8
>>> print(float(paddle.version.cuda()) < 11.0)
False


pcard-67164

