### PR TITLE
dygraph support input multi out Tensor

### DIFF
--- a/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
@@ -1870,69 +1870,25 @@ class DygraphForwardFunctionGenerator(DygraphFunctionGeneratorBase):
             forward_outputs_position_list = list(
                 self.forward_outputs_position_map.values()
             )
-            if (
-                len(forward_outputs_position_list) == 1
-                and forward_outputs_position_list[0][0] == "Tensor"
-            ):
-                inputs_args_declaration_str = (
-                    inputs_args_declaration_str
-                    + ", paddle::optional<paddle::Tensor*> predefined_out = paddle::none"
-                )
-                inputs_args_definition_str = (
-                    inputs_args_definition_str
-                    + ", paddle::optional<paddle::Tensor*> predefined_out"
-                )
-            elif (
-                len(forward_outputs_position_list) == 2
-                and forward_outputs_position_list[0][0] == "Tensor"
-                and forward_outputs_position_list[1][0] == "Tensor"
-            ):
-                inputs_args_declaration_str = (
-                    inputs_args_declaration_str
-                    + ", paddle::optional<std::tuple<paddle::Tensor*, paddle::Tensor*>> predefined_out = paddle::none"
-                )
-                inputs_args_definition_str = (
-                    inputs_args_definition_str
-                    + ", paddle::optional<std::tuple<paddle::Tensor*, paddle::Tensor*>> predefined_out"
-                )
-            elif (
-                len(forward_outputs_position_list) == 3
-                and forward_outputs_position_list[0][0] == "Tensor"
-                and forward_outputs_position_list[1][0] == "Tensor"
-                and forward_outputs_position_list[2][0] == "Tensor"
-            ):
-                inputs_args_declaration_str = (
-                    inputs_args_declaration_str
-                    + ", paddle::optional<std::tuple<paddle::Tensor*, paddle::Tensor*, paddle::Tensor*>> predefined_out = paddle::none"
-                )
-                inputs_args_definition_str = (
-                    inputs_args_definition_str
-                    + ", paddle::optional<std::tuple<paddle::Tensor*, paddle::Tensor*, paddle::Tensor*>> predefined_out"
-                )
-            elif (
-                len(forward_outputs_position_list) == 4
-                and forward_outputs_position_list[0][0] == "Tensor"
-                and forward_outputs_position_list[1][0] == "Tensor"
-                and forward_outputs_position_list[2][0] == "Tensor"
-                and forward_outputs_position_list[3][0] == "Tensor"
-            ):
-                inputs_args_declaration_str = (
-                    inputs_args_declaration_str
-                    + ", paddle::optional<std::tuple<paddle::Tensor*, paddle::Tensor*, paddle::Tensor*, paddle::Tensor*>> predefined_out = paddle::none"
-                )
-                inputs_args_definition_str = (
-                    inputs_args_definition_str
-                    + ", paddle::optional<std::tuple<paddle::Tensor*, paddle::Tensor*, paddle::Tensor*, paddle::Tensor*>> predefined_out"
-                )
+            is_all_tensor = all(
+                item[0] == "Tensor" for item in forward_outputs_position_list
+            )
+            length = len(forward_outputs_position_list)
+
+            if is_all_tensor and 1 <= length <= 4:
+                if length == 1:
+                    type_str = "paddle::Tensor*"
+                else:
+                    ptrs = ", ".join(["paddle::Tensor*"] * length)
+                    type_str = f"std::tuple<{ptrs}>"
+                optional_str = f"paddle::optional<{type_str}>"
             else:
-                inputs_args_declaration_str = (
-                    inputs_args_declaration_str
-                    + ", paddle::optional<void*> predefined_out = paddle::none"
-                )
-                inputs_args_definition_str = (
-                    inputs_args_definition_str
-                    + ", paddle::optional<void*> predefined_out"
-                )
+                optional_str = "paddle::optional<void*>"
+
+            inputs_args_declaration_str += (
+                f", {optional_str} predefined_out = paddle::none"
+            )
+            inputs_args_definition_str += f", {optional_str} predefined_out"
             inputs_call_list.append("predefined_out")
 
         inputs_call_args_str = ", ".join(inputs_call_list)

--- a/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
@@ -1875,21 +1875,19 @@ class DygraphForwardFunctionGenerator(DygraphFunctionGeneratorBase):
             )
             length = len(forward_outputs_position_list)
 
-            if is_all_tensor and 1 <= length <= 4:
+            if is_all_tensor and 1 <= length <= 7:
                 if length == 1:
                     type_str = "paddle::Tensor*"
                 else:
                     ptrs = ", ".join(["paddle::Tensor*"] * length)
                     type_str = f"std::tuple<{ptrs}>"
                 optional_str = f"paddle::optional<{type_str}>"
-            else:
-                optional_str = "paddle::optional<void*>"
 
-            inputs_args_declaration_str += (
-                f", {optional_str} predefined_out = paddle::none"
-            )
-            inputs_args_definition_str += f", {optional_str} predefined_out"
-            inputs_call_list.append("predefined_out")
+                inputs_args_declaration_str += (
+                    f", {optional_str} predefined_out = paddle::none"
+                )
+                inputs_args_definition_str += f", {optional_str} predefined_out"
+                inputs_call_list.append("predefined_out")
 
         inputs_call_args_str = ", ".join(inputs_call_list)
         self.inputs_call_list = inputs_call_list
@@ -2151,9 +2149,19 @@ class DygraphForwardFunctionGenerator(DygraphFunctionGeneratorBase):
             and not is_inplaced
             and forward_api_name != "empty_like"
         ):
-            amp_inputs_call_args_str = (
-                amp_inputs_call_args_str + ", predefined_out"
+            forward_outputs_position_list = list(
+                self.forward_outputs_position_map.values()
             )
+            is_all_tensor = all(
+                item[0] == "Tensor" for item in forward_outputs_position_list
+            )
+            length = len(forward_outputs_position_list)
+
+            if is_all_tensor and 1 <= length <= 7:
+                amp_inputs_call_args_str = (
+                    amp_inputs_call_args_str + ", predefined_out"
+                )
+
         amp_call_str = (
             f"return {forward_ad_function_name}({amp_inputs_call_args_str});"
         )
@@ -2183,9 +2191,19 @@ class DygraphForwardFunctionGenerator(DygraphFunctionGeneratorBase):
                 and not is_inplaced
                 and forward_api_name != "empty_like"
             ):
-                type_promote_inputs_call_args_str = (
-                    type_promote_inputs_call_args_str + ", predefined_out"
+                forward_outputs_position_list = list(
+                    self.forward_outputs_position_map.values()
                 )
+                is_all_tensor = all(
+                    item[0] == "Tensor"
+                    for item in forward_outputs_position_list
+                )
+                length = len(forward_outputs_position_list)
+                if is_all_tensor and 1 <= length <= 7:
+                    type_promote_inputs_call_args_str = (
+                        type_promote_inputs_call_args_str + ", predefined_out"
+                    )
+
             type_promote_call_list = f"return {forward_ad_function_name}({type_promote_inputs_call_args_str});"
 
             x_cast = (
@@ -2214,9 +2232,19 @@ class DygraphForwardFunctionGenerator(DygraphFunctionGeneratorBase):
                 and not is_inplaced
                 and forward_api_name != "empty_like"
             ):
-                type_promote_inputs_call_args_str = (
-                    type_promote_inputs_call_args_str + ", predefined_out"
+                forward_outputs_position_list = list(
+                    self.forward_outputs_position_map.values()
                 )
+                is_all_tensor = all(
+                    item[0] == "Tensor"
+                    for item in forward_outputs_position_list
+                )
+                length = len(forward_outputs_position_list)
+
+                if is_all_tensor and 1 <= length <= 7:
+                    type_promote_inputs_call_args_str = (
+                        type_promote_inputs_call_args_str + ", predefined_out"
+                    )
 
             type_promote_call_list = f"return {forward_ad_function_name}({type_promote_inputs_call_args_str});"
 

--- a/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
@@ -1865,20 +1865,76 @@ class DygraphForwardFunctionGenerator(DygraphFunctionGeneratorBase):
             append_predefined_out
             and not grad_flag
             and not is_inplaced
-            and len(self.forward_outputs_position_map) == 1
-            and next(iter(self.forward_outputs_position_map.values()))[0]
-            == "Tensor"
             and forward_api_name != "empty_like"
         ):
-            inputs_args_declaration_str = (
-                inputs_args_declaration_str
-                + ", paddle::optional<paddle::Tensor*> predefined_out = paddle::none"
+            forward_outputs_position_list = list(
+                self.forward_outputs_position_map.values()
             )
-            inputs_args_definition_str = (
-                inputs_args_definition_str
-                + ", paddle::optional<paddle::Tensor*> predefined_out"
-            )
+            if (
+                len(forward_outputs_position_list) == 1
+                and forward_outputs_position_list[0][0] == "Tensor"
+            ):
+                inputs_args_declaration_str = (
+                    inputs_args_declaration_str
+                    + ", paddle::optional<paddle::Tensor*> predefined_out = paddle::none"
+                )
+                inputs_args_definition_str = (
+                    inputs_args_definition_str
+                    + ", paddle::optional<paddle::Tensor*> predefined_out"
+                )
+            elif (
+                len(forward_outputs_position_list) == 2
+                and forward_outputs_position_list[0][0] == "Tensor"
+                and forward_outputs_position_list[1][0] == "Tensor"
+            ):
+                inputs_args_declaration_str = (
+                    inputs_args_declaration_str
+                    + ", paddle::optional<std::tuple<paddle::Tensor*, paddle::Tensor*>> predefined_out = paddle::none"
+                )
+                inputs_args_definition_str = (
+                    inputs_args_definition_str
+                    + ", paddle::optional<std::tuple<paddle::Tensor*, paddle::Tensor*>> predefined_out"
+                )
+            elif (
+                len(forward_outputs_position_list) == 3
+                and forward_outputs_position_list[0][0] == "Tensor"
+                and forward_outputs_position_list[1][0] == "Tensor"
+                and forward_outputs_position_list[2][0] == "Tensor"
+            ):
+                inputs_args_declaration_str = (
+                    inputs_args_declaration_str
+                    + ", paddle::optional<std::tuple<paddle::Tensor*, paddle::Tensor*, paddle::Tensor*>> predefined_out = paddle::none"
+                )
+                inputs_args_definition_str = (
+                    inputs_args_definition_str
+                    + ", paddle::optional<std::tuple<paddle::Tensor*, paddle::Tensor*, paddle::Tensor*>> predefined_out"
+                )
+            elif (
+                len(forward_outputs_position_list) == 4
+                and forward_outputs_position_list[0][0] == "Tensor"
+                and forward_outputs_position_list[1][0] == "Tensor"
+                and forward_outputs_position_list[2][0] == "Tensor"
+                and forward_outputs_position_list[3][0] == "Tensor"
+            ):
+                inputs_args_declaration_str = (
+                    inputs_args_declaration_str
+                    + ", paddle::optional<std::tuple<paddle::Tensor*, paddle::Tensor*, paddle::Tensor*, paddle::Tensor*>> predefined_out = paddle::none"
+                )
+                inputs_args_definition_str = (
+                    inputs_args_definition_str
+                    + ", paddle::optional<std::tuple<paddle::Tensor*, paddle::Tensor*, paddle::Tensor*, paddle::Tensor*>> predefined_out"
+                )
+            else:
+                inputs_args_declaration_str = (
+                    inputs_args_declaration_str
+                    + ", paddle::optional<void*> predefined_out = paddle::none"
+                )
+                inputs_args_definition_str = (
+                    inputs_args_definition_str
+                    + ", paddle::optional<void*> predefined_out"
+                )
             inputs_call_list.append("predefined_out")
+
         inputs_call_args_str = ", ".join(inputs_call_list)
         self.inputs_call_list = inputs_call_list
 
@@ -2137,9 +2193,6 @@ class DygraphForwardFunctionGenerator(DygraphFunctionGeneratorBase):
             append_predefined_out
             and not grad_flag
             and not is_inplaced
-            and len(self.forward_outputs_position_map) == 1
-            and next(iter(self.forward_outputs_position_map.values()))[0]
-            == "Tensor"
             and forward_api_name != "empty_like"
         ):
             amp_inputs_call_args_str = (
@@ -2172,9 +2225,6 @@ class DygraphForwardFunctionGenerator(DygraphFunctionGeneratorBase):
                 append_predefined_out
                 and not grad_flag
                 and not is_inplaced
-                and len(self.forward_outputs_position_map) == 1
-                and next(iter(self.forward_outputs_position_map.values()))[0]
-                == "Tensor"
                 and forward_api_name != "empty_like"
             ):
                 type_promote_inputs_call_args_str = (
@@ -2206,9 +2256,6 @@ class DygraphForwardFunctionGenerator(DygraphFunctionGeneratorBase):
                 append_predefined_out
                 and not grad_flag
                 and not is_inplaced
-                and len(self.forward_outputs_position_map) == 1
-                and next(iter(self.forward_outputs_position_map.values()))[0]
-                == "Tensor"
                 and forward_api_name != "empty_like"
             ):
                 type_promote_inputs_call_args_str = (

--- a/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
@@ -700,19 +700,43 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
         dygraph_function_call_str = ",".join(dygraph_function_call_list)
 
         get_predefined_out_str = ""
-        if (
-            not no_predefined_out_tensor
-            and len(self.forward_outputs_position_map) == 1
-            and next(iter(self.forward_outputs_position_map.values()))[0]
-            == "Tensor"
-            and forward_api_name != "empty_like"
-        ):
+        if not no_predefined_out_tensor and forward_api_name != "empty_like":
             dygraph_function_call_str = (
                 dygraph_function_call_str + ", predefined_out"
             )
-            get_predefined_out_str = (
-                "    auto predefined_out = GetInputOutTensorFromKwargs(kwargs);"
+            forward_outputs_position_list = list(
+                self.forward_outputs_position_map.values()
             )
+            if (
+                len(forward_outputs_position_list) == 1
+                and forward_outputs_position_list[0][0] == "Tensor"
+            ):
+                get_predefined_out_str = "    auto predefined_out = GetInputOutTensorFromKwargs(kwargs);"
+            elif (
+                len(forward_outputs_position_list) == 2
+                and forward_outputs_position_list[0][0] == "Tensor"
+                and forward_outputs_position_list[1][0] == "Tensor"
+            ):
+                get_predefined_out_str = "    auto predefined_out = GetPredefinedOutTupleTensorFromKwargs_2(kwargs);"
+            elif (
+                len(forward_outputs_position_list) == 3
+                and forward_outputs_position_list[0][0] == "Tensor"
+                and forward_outputs_position_list[1][0] == "Tensor"
+                and forward_outputs_position_list[2][0] == "Tensor"
+            ):
+                get_predefined_out_str = "    auto predefined_out = GetPredefinedOutTupleTensorFromKwargs_3(kwargs);"
+            elif (
+                len(forward_outputs_position_list) == 4
+                and forward_outputs_position_list[0][0] == "Tensor"
+                and forward_outputs_position_list[1][0] == "Tensor"
+                and forward_outputs_position_list[2][0] == "Tensor"
+                and forward_outputs_position_list[3][0] == "Tensor"
+            ):
+                get_predefined_out_str = "    auto predefined_out = GetPredefinedOutTupleTensorFromKwargs_4(kwargs);"
+            else:
+                get_predefined_out_str = (
+                    "    auto predefined_out = paddle::none;"
+                )
 
         # Generate Python-C Function Definitions
         fwd_function_name = FUNCTION_NAME_TEMPLATE.format(

--- a/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
@@ -701,10 +701,6 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
 
         get_predefined_out_str = ""
         if not no_predefined_out_tensor and forward_api_name != "empty_like":
-            dygraph_function_call_str = (
-                dygraph_function_call_str + ", predefined_out"
-            )
-
             forward_outputs_position_list = list(
                 self.forward_outputs_position_map.values()
             )
@@ -713,14 +709,14 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
             )
             length = len(forward_outputs_position_list)
 
-            if all_tensor and 1 <= length <= 4:
+            if all_tensor and 1 <= length <= 7:
                 if length == 1:
                     get_predefined_out_str = "    auto predefined_out = GetInputOutTensorFromKwargs(kwargs);"
                 else:
                     get_predefined_out_str = f"    auto predefined_out = GetPredefinedOutTupleTensorFromKwargs_{length}(kwargs);"
-            else:
-                get_predefined_out_str = (
-                    "    auto predefined_out = paddle::none;"
+
+                dygraph_function_call_str = (
+                    dygraph_function_call_str + ", predefined_out"
                 )
 
         # Generate Python-C Function Definitions

--- a/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
@@ -704,35 +704,20 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
             dygraph_function_call_str = (
                 dygraph_function_call_str + ", predefined_out"
             )
+
             forward_outputs_position_list = list(
                 self.forward_outputs_position_map.values()
             )
-            if (
-                len(forward_outputs_position_list) == 1
-                and forward_outputs_position_list[0][0] == "Tensor"
-            ):
-                get_predefined_out_str = "    auto predefined_out = GetInputOutTensorFromKwargs(kwargs);"
-            elif (
-                len(forward_outputs_position_list) == 2
-                and forward_outputs_position_list[0][0] == "Tensor"
-                and forward_outputs_position_list[1][0] == "Tensor"
-            ):
-                get_predefined_out_str = "    auto predefined_out = GetPredefinedOutTupleTensorFromKwargs_2(kwargs);"
-            elif (
-                len(forward_outputs_position_list) == 3
-                and forward_outputs_position_list[0][0] == "Tensor"
-                and forward_outputs_position_list[1][0] == "Tensor"
-                and forward_outputs_position_list[2][0] == "Tensor"
-            ):
-                get_predefined_out_str = "    auto predefined_out = GetPredefinedOutTupleTensorFromKwargs_3(kwargs);"
-            elif (
-                len(forward_outputs_position_list) == 4
-                and forward_outputs_position_list[0][0] == "Tensor"
-                and forward_outputs_position_list[1][0] == "Tensor"
-                and forward_outputs_position_list[2][0] == "Tensor"
-                and forward_outputs_position_list[3][0] == "Tensor"
-            ):
-                get_predefined_out_str = "    auto predefined_out = GetPredefinedOutTupleTensorFromKwargs_4(kwargs);"
+            all_tensor = all(
+                pos[0] == "Tensor" for pos in forward_outputs_position_list
+            )
+            length = len(forward_outputs_position_list)
+
+            if all_tensor and 1 <= length <= 4:
+                if length == 1:
+                    get_predefined_out_str = "    auto predefined_out = GetInputOutTensorFromKwargs(kwargs);"
+                else:
+                    get_predefined_out_str = f"    auto predefined_out = GetPredefinedOutTupleTensorFromKwargs_{length}(kwargs);"
             else:
                 get_predefined_out_str = (
                     "    auto predefined_out = paddle::none;"

--- a/paddle/fluid/pybind/eager_utils.cc
+++ b/paddle/fluid/pybind/eager_utils.cc
@@ -3431,6 +3431,66 @@ paddle::optional<Tensor*> GetInputOutTensorFromKwargs(PyObject* kwargs) {
   return paddle::none;
 }
 
+paddle::optional<std::tuple<Tensor*, Tensor*>>
+GetPredefinedOutTupleTensorFromKwargs_2(PyObject* kwargs) {
+  if (!kwargs) {
+    return paddle::none;
+  }
+  PyObject* obj = PyDict_GetItemString(kwargs, "out");
+  if (obj && PyTuple_Check(obj)) {
+    if (PyTuple_Size(obj) != 2) {
+      return paddle::none;
+    }
+    PyObject* py_t0 = PyTuple_GetItem(obj, 0);
+    PyObject* py_t1 = PyTuple_GetItem(obj, 1);
+    return std::make_tuple(&(reinterpret_cast<TensorObject*>(py_t0)->tensor),
+                           &(reinterpret_cast<TensorObject*>(py_t1)->tensor));
+  }
+  return paddle::none;
+}
+
+paddle::optional<std::tuple<Tensor*, Tensor*, Tensor*>>
+GetPredefinedOutTupleTensorFromKwargs_3(PyObject* kwargs) {
+  if (!kwargs) {
+    return paddle::none;
+  }
+  PyObject* obj = PyDict_GetItemString(kwargs, "out");
+  if (obj && PyTuple_Check(obj)) {
+    if (PyTuple_Size(obj) != 3) {
+      return paddle::none;
+    }
+    PyObject* py_t0 = PyTuple_GetItem(obj, 0);
+    PyObject* py_t1 = PyTuple_GetItem(obj, 1);
+    PyObject* py_t2 = PyTuple_GetItem(obj, 2);
+    return std::make_tuple(&(reinterpret_cast<TensorObject*>(py_t0)->tensor),
+                           &(reinterpret_cast<TensorObject*>(py_t1)->tensor),
+                           &(reinterpret_cast<TensorObject*>(py_t2)->tensor));
+  }
+  return paddle::none;
+}
+
+paddle::optional<std::tuple<Tensor*, Tensor*, Tensor*, Tensor*>>
+GetPredefinedOutTupleTensorFromKwargs_4(PyObject* kwargs) {
+  if (!kwargs) {
+    return paddle::none;
+  }
+  PyObject* obj = PyDict_GetItemString(kwargs, "out");
+  if (obj && PyTuple_Check(obj)) {
+    if (PyTuple_Size(obj) != 4) {
+      return paddle::none;
+    }
+    PyObject* py_t0 = PyTuple_GetItem(obj, 0);
+    PyObject* py_t1 = PyTuple_GetItem(obj, 1);
+    PyObject* py_t2 = PyTuple_GetItem(obj, 2);
+    PyObject* py_t3 = PyTuple_GetItem(obj, 3);
+    return std::make_tuple(&(reinterpret_cast<TensorObject*>(py_t0)->tensor),
+                           &(reinterpret_cast<TensorObject*>(py_t1)->tensor),
+                           &(reinterpret_cast<TensorObject*>(py_t2)->tensor),
+                           &(reinterpret_cast<TensorObject*>(py_t3)->tensor));
+  }
+  return paddle::none;
+}
+
 void Check_PIR_not_support_out(PyObject* kwargs) {
   if (!kwargs) {
     return;

--- a/paddle/fluid/pybind/eager_utils.cc
+++ b/paddle/fluid/pybind/eager_utils.cc
@@ -3449,6 +3449,22 @@ struct TensorTupleType<4> {
   using type = std::tuple<Tensor*, Tensor*, Tensor*, Tensor*>;
 };
 
+template <>
+struct TensorTupleType<5> {
+  using type = std::tuple<Tensor*, Tensor*, Tensor*, Tensor*, Tensor*>;
+};
+
+template <>
+struct TensorTupleType<6> {
+  using type = std::tuple<Tensor*, Tensor*, Tensor*, Tensor*, Tensor*, Tensor*>;
+};
+
+template <>
+struct TensorTupleType<7> {
+  using type =
+      std::tuple<Tensor*, Tensor*, Tensor*, Tensor*, Tensor*, Tensor*, Tensor*>;
+};
+
 template <size_t... Is>
 paddle::optional<typename TensorTupleType<sizeof...(Is)>::type>
 GetPredefinedOutTupleTensorFromKwargs_Impl(PyObject* kwargs,
@@ -3456,8 +3472,12 @@ GetPredefinedOutTupleTensorFromKwargs_Impl(PyObject* kwargs,
   if (!kwargs) return paddle::none;
 
   PyObject* obj = PyDict_GetItemString(kwargs, "out");
-  if (!obj || !PyTuple_Check(obj)) return paddle::none;
-  if (PyTuple_Size(obj) != sizeof...(Is)) return paddle::none;
+  if (!obj || obj == Py_None) return paddle::none;
+  if (!PyTuple_Check(obj) || PyTuple_Size(obj) != sizeof...(Is)) {
+    PADDLE_THROW(common::errors::InvalidArgument(
+        "The out argument must be a tuple with %d elements.", sizeof...(Is)));
+    return paddle::none;
+  }
 
   return std::make_tuple(
       &(reinterpret_cast<TensorObject*>(PyTuple_GetItem(obj, Is))->tensor)...);
@@ -3479,6 +3499,26 @@ paddle::optional<std::tuple<Tensor*, Tensor*, Tensor*, Tensor*>>
 GetPredefinedOutTupleTensorFromKwargs_4(PyObject* kwargs) {
   return GetPredefinedOutTupleTensorFromKwargs_Impl<0, 1, 2, 3>(
       kwargs, std::make_index_sequence<4>{});
+}
+
+paddle::optional<std::tuple<Tensor*, Tensor*, Tensor*, Tensor*, Tensor*>>
+GetPredefinedOutTupleTensorFromKwargs_5(PyObject* kwargs) {
+  return GetPredefinedOutTupleTensorFromKwargs_Impl<0, 1, 2, 3, 4>(
+      kwargs, std::make_index_sequence<5>{});
+}
+
+paddle::optional<
+    std::tuple<Tensor*, Tensor*, Tensor*, Tensor*, Tensor*, Tensor*>>
+GetPredefinedOutTupleTensorFromKwargs_6(PyObject* kwargs) {
+  return GetPredefinedOutTupleTensorFromKwargs_Impl<0, 1, 2, 3, 4, 5>(
+      kwargs, std::make_index_sequence<6>{});
+}
+
+paddle::optional<
+    std::tuple<Tensor*, Tensor*, Tensor*, Tensor*, Tensor*, Tensor*, Tensor*>>
+GetPredefinedOutTupleTensorFromKwargs_7(PyObject* kwargs) {
+  return GetPredefinedOutTupleTensorFromKwargs_Impl<0, 1, 2, 3, 4, 5, 6>(
+      kwargs, std::make_index_sequence<7>{});
 }
 
 void Check_PIR_not_support_out(PyObject* kwargs) {

--- a/paddle/fluid/pybind/eager_utils.cc
+++ b/paddle/fluid/pybind/eager_utils.cc
@@ -3431,64 +3431,54 @@ paddle::optional<Tensor*> GetInputOutTensorFromKwargs(PyObject* kwargs) {
   return paddle::none;
 }
 
+template <size_t N>
+struct TensorTupleType;
+
+template <>
+struct TensorTupleType<2> {
+  using type = std::tuple<Tensor*, Tensor*>;
+};
+
+template <>
+struct TensorTupleType<3> {
+  using type = std::tuple<Tensor*, Tensor*, Tensor*>;
+};
+
+template <>
+struct TensorTupleType<4> {
+  using type = std::tuple<Tensor*, Tensor*, Tensor*, Tensor*>;
+};
+
+template <size_t... Is>
+paddle::optional<typename TensorTupleType<sizeof...(Is)>::type>
+GetPredefinedOutTupleTensorFromKwargs_Impl(PyObject* kwargs,
+                                           std::index_sequence<Is...>) {
+  if (!kwargs) return paddle::none;
+
+  PyObject* obj = PyDict_GetItemString(kwargs, "out");
+  if (!obj || !PyTuple_Check(obj)) return paddle::none;
+  if (PyTuple_Size(obj) != sizeof...(Is)) return paddle::none;
+
+  return std::make_tuple(
+      &(reinterpret_cast<TensorObject*>(PyTuple_GetItem(obj, Is))->tensor)...);
+}
+
 paddle::optional<std::tuple<Tensor*, Tensor*>>
 GetPredefinedOutTupleTensorFromKwargs_2(PyObject* kwargs) {
-  if (!kwargs) {
-    return paddle::none;
-  }
-  PyObject* obj = PyDict_GetItemString(kwargs, "out");
-  if (obj && PyTuple_Check(obj)) {
-    if (PyTuple_Size(obj) != 2) {
-      return paddle::none;
-    }
-    PyObject* py_t0 = PyTuple_GetItem(obj, 0);
-    PyObject* py_t1 = PyTuple_GetItem(obj, 1);
-    return std::make_tuple(&(reinterpret_cast<TensorObject*>(py_t0)->tensor),
-                           &(reinterpret_cast<TensorObject*>(py_t1)->tensor));
-  }
-  return paddle::none;
+  return GetPredefinedOutTupleTensorFromKwargs_Impl<0, 1>(
+      kwargs, std::make_index_sequence<2>{});
 }
 
 paddle::optional<std::tuple<Tensor*, Tensor*, Tensor*>>
 GetPredefinedOutTupleTensorFromKwargs_3(PyObject* kwargs) {
-  if (!kwargs) {
-    return paddle::none;
-  }
-  PyObject* obj = PyDict_GetItemString(kwargs, "out");
-  if (obj && PyTuple_Check(obj)) {
-    if (PyTuple_Size(obj) != 3) {
-      return paddle::none;
-    }
-    PyObject* py_t0 = PyTuple_GetItem(obj, 0);
-    PyObject* py_t1 = PyTuple_GetItem(obj, 1);
-    PyObject* py_t2 = PyTuple_GetItem(obj, 2);
-    return std::make_tuple(&(reinterpret_cast<TensorObject*>(py_t0)->tensor),
-                           &(reinterpret_cast<TensorObject*>(py_t1)->tensor),
-                           &(reinterpret_cast<TensorObject*>(py_t2)->tensor));
-  }
-  return paddle::none;
+  return GetPredefinedOutTupleTensorFromKwargs_Impl<0, 1, 2>(
+      kwargs, std::make_index_sequence<3>{});
 }
 
 paddle::optional<std::tuple<Tensor*, Tensor*, Tensor*, Tensor*>>
 GetPredefinedOutTupleTensorFromKwargs_4(PyObject* kwargs) {
-  if (!kwargs) {
-    return paddle::none;
-  }
-  PyObject* obj = PyDict_GetItemString(kwargs, "out");
-  if (obj && PyTuple_Check(obj)) {
-    if (PyTuple_Size(obj) != 4) {
-      return paddle::none;
-    }
-    PyObject* py_t0 = PyTuple_GetItem(obj, 0);
-    PyObject* py_t1 = PyTuple_GetItem(obj, 1);
-    PyObject* py_t2 = PyTuple_GetItem(obj, 2);
-    PyObject* py_t3 = PyTuple_GetItem(obj, 3);
-    return std::make_tuple(&(reinterpret_cast<TensorObject*>(py_t0)->tensor),
-                           &(reinterpret_cast<TensorObject*>(py_t1)->tensor),
-                           &(reinterpret_cast<TensorObject*>(py_t2)->tensor),
-                           &(reinterpret_cast<TensorObject*>(py_t3)->tensor));
-  }
-  return paddle::none;
+  return GetPredefinedOutTupleTensorFromKwargs_Impl<0, 1, 2, 3>(
+      kwargs, std::make_index_sequence<4>{});
 }
 
 void Check_PIR_not_support_out(PyObject* kwargs) {

--- a/paddle/fluid/pybind/eager_utils.h
+++ b/paddle/fluid/pybind/eager_utils.h
@@ -558,6 +558,13 @@ void EagerSetDeviceId();
 
 paddle::optional<Tensor*> GetInputOutTensorFromKwargs(PyObject* kwargs);
 
+paddle::optional<std::tuple<Tensor*, Tensor*>>
+GetPredefinedOutTupleTensorFromKwargs_2(PyObject* kwargs);
+paddle::optional<std::tuple<Tensor*, Tensor*, Tensor*>>
+GetPredefinedOutTupleTensorFromKwargs_3(PyObject* kwargs);
+paddle::optional<std::tuple<Tensor*, Tensor*, Tensor*, Tensor*>>
+GetPredefinedOutTupleTensorFromKwargs_4(PyObject* kwargs);
+
 void Check_PIR_not_support_out(PyObject* kwargs);
 
 /*----------------------for arg parse-----------------------------*/

--- a/paddle/fluid/pybind/eager_utils.h
+++ b/paddle/fluid/pybind/eager_utils.h
@@ -564,6 +564,14 @@ paddle::optional<std::tuple<Tensor*, Tensor*, Tensor*>>
 GetPredefinedOutTupleTensorFromKwargs_3(PyObject* kwargs);
 paddle::optional<std::tuple<Tensor*, Tensor*, Tensor*, Tensor*>>
 GetPredefinedOutTupleTensorFromKwargs_4(PyObject* kwargs);
+paddle::optional<std::tuple<Tensor*, Tensor*, Tensor*, Tensor*, Tensor*>>
+GetPredefinedOutTupleTensorFromKwargs_5(PyObject* kwargs);
+paddle::optional<
+    std::tuple<Tensor*, Tensor*, Tensor*, Tensor*, Tensor*, Tensor*>>
+GetPredefinedOutTupleTensorFromKwargs_6(PyObject* kwargs);
+paddle::optional<
+    std::tuple<Tensor*, Tensor*, Tensor*, Tensor*, Tensor*, Tensor*, Tensor*>>
+GetPredefinedOutTupleTensorFromKwargs_7(PyObject* kwargs);
 
 void Check_PIR_not_support_out(PyObject* kwargs);
 

--- a/paddle/phi/api/generator/api_base.py
+++ b/paddle/phi/api/generator/api_base.py
@@ -259,7 +259,7 @@ class BaseAPI:
             types = self.outputs['types']
             length = len(self.outputs['names'])
 
-            if all(t == "Tensor" for t in types) and 1 <= length <= 4:
+            if all(t == "Tensor" for t in types) and 1 <= length <= 7:
                 if length == 1:
                     type_str = "paddle::Tensor*"
                 else:
@@ -268,10 +268,6 @@ class BaseAPI:
                     )
                 declare_args.append(
                     f"paddle::optional<{type_str}> predefined_out = paddle::none"
-                )
-            else:
-                declare_args.append(
-                    "paddle::optional<void*> predefined_out = paddle::none"
                 )
 
         return ", ".join(declare_args)
@@ -292,7 +288,7 @@ class BaseAPI:
             types = self.outputs['types']
             length = len(self.outputs['names'])
 
-            if all(t == "Tensor" for t in types) and 1 <= length <= 4:
+            if all(t == "Tensor" for t in types) and 1 <= length <= 7:
                 if length == 1:
                     type_str = "paddle::Tensor*"
                 else:
@@ -302,8 +298,6 @@ class BaseAPI:
                 define_args.append(
                     f"paddle::optional<{type_str}> predefined_out"
                 )
-            else:
-                define_args.append("paddle::optional<void*> predefined_out")
 
         return ", ".join(define_args)
 

--- a/paddle/phi/api/generator/api_base.py
+++ b/paddle/phi/api/generator/api_base.py
@@ -256,39 +256,18 @@ class BaseAPI:
             and append_predefined_out
             and self.api != "empty_like"
         ):
-            if (
-                len(self.outputs['names']) == 1
-                and self.outputs['types'][0] == "Tensor"
-            ):
+            types = self.outputs['types']
+            length = len(self.outputs['names'])
+
+            if all(t == "Tensor" for t in types) and 1 <= length <= 4:
+                if length == 1:
+                    type_str = "paddle::Tensor*"
+                else:
+                    type_str = (
+                        f"std::tuple<{', '.join(['paddle::Tensor*'] * length)}>"
+                    )
                 declare_args.append(
-                    "paddle::optional<Tensor*> predefined_out = paddle::none"
-                )
-            elif (
-                len(self.outputs['names']) == 2
-                and self.outputs['types'][0] == "Tensor"
-                and self.outputs['types'][1] == "Tensor"
-            ):
-                declare_args.append(
-                    "paddle::optional<std::tuple<paddle::Tensor*, paddle::Tensor*>> predefined_out = paddle::none"
-                )
-            elif (
-                len(self.outputs['names']) == 3
-                and self.outputs['types'][0] == "Tensor"
-                and self.outputs['types'][1] == "Tensor"
-                and self.outputs['types'][2] == "Tensor"
-            ):
-                declare_args.append(
-                    "paddle::optional<std::tuple<paddle::Tensor*, paddle::Tensor*, paddle::Tensor*>> predefined_out = paddle::none"
-                )
-            elif (
-                len(self.outputs['names']) == 4
-                and self.outputs['types'][0] == "Tensor"
-                and self.outputs['types'][1] == "Tensor"
-                and self.outputs['types'][2] == "Tensor"
-                and self.outputs['types'][3] == "Tensor"
-            ):
-                declare_args.append(
-                    "paddle::optional<std::tuple<paddle::Tensor*, paddle::Tensor*, paddle::Tensor*, paddle::Tensor*>> predefined_out = paddle::none"
+                    f"paddle::optional<{type_str}> predefined_out = paddle::none"
                 )
             else:
                 declare_args.append(
@@ -310,37 +289,18 @@ class BaseAPI:
             and append_predefined_out
             and self.api != "empty_like"
         ):
-            if (
-                len(self.outputs['names']) == 1
-                and self.outputs['types'][0] == "Tensor"
-            ):
-                define_args.append("paddle::optional<Tensor*> predefined_out")
-            elif (
-                len(self.outputs['names']) == 2
-                and self.outputs['types'][0] == "Tensor"
-                and self.outputs['types'][1] == "Tensor"
-            ):
+            types = self.outputs['types']
+            length = len(self.outputs['names'])
+
+            if all(t == "Tensor" for t in types) and 1 <= length <= 4:
+                if length == 1:
+                    type_str = "paddle::Tensor*"
+                else:
+                    type_str = (
+                        f"std::tuple<{', '.join(['paddle::Tensor*'] * length)}>"
+                    )
                 define_args.append(
-                    "paddle::optional<std::tuple<paddle::Tensor*, paddle::Tensor*>> predefined_out"
-                )
-            elif (
-                len(self.outputs['names']) == 3
-                and self.outputs['types'][0] == "Tensor"
-                and self.outputs['types'][1] == "Tensor"
-                and self.outputs['types'][2] == "Tensor"
-            ):
-                define_args.append(
-                    "paddle::optional<std::tuple<paddle::Tensor*, paddle::Tensor*, paddle::Tensor*>> predefined_out"
-                )
-            elif (
-                len(self.outputs['names']) == 4
-                and self.outputs['types'][0] == "Tensor"
-                and self.outputs['types'][1] == "Tensor"
-                and self.outputs['types'][2] == "Tensor"
-                and self.outputs['types'][3] == "Tensor"
-            ):
-                define_args.append(
-                    "paddle::optional<std::tuple<paddle::Tensor*, paddle::Tensor*, paddle::Tensor*, paddle::Tensor*>> predefined_out"
+                    f"paddle::optional<{type_str}> predefined_out"
                 )
             else:
                 define_args.append("paddle::optional<void*> predefined_out")

--- a/paddle/phi/api/generator/api_base.py
+++ b/paddle/phi/api/generator/api_base.py
@@ -254,13 +254,46 @@ class BaseAPI:
             not grad_flag
             and not inplace_flag
             and append_predefined_out
-            and len(self.outputs['names']) == 1
-            and self.outputs['types'][0] == "Tensor"
             and self.api != "empty_like"
         ):
-            declare_args.append(
-                "paddle::optional<Tensor*> predefined_out = paddle::none"
-            )
+            if (
+                len(self.outputs['names']) == 1
+                and self.outputs['types'][0] == "Tensor"
+            ):
+                declare_args.append(
+                    "paddle::optional<Tensor*> predefined_out = paddle::none"
+                )
+            elif (
+                len(self.outputs['names']) == 2
+                and self.outputs['types'][0] == "Tensor"
+                and self.outputs['types'][1] == "Tensor"
+            ):
+                declare_args.append(
+                    "paddle::optional<std::tuple<paddle::Tensor*, paddle::Tensor*>> predefined_out = paddle::none"
+                )
+            elif (
+                len(self.outputs['names']) == 3
+                and self.outputs['types'][0] == "Tensor"
+                and self.outputs['types'][1] == "Tensor"
+                and self.outputs['types'][2] == "Tensor"
+            ):
+                declare_args.append(
+                    "paddle::optional<std::tuple<paddle::Tensor*, paddle::Tensor*, paddle::Tensor*>> predefined_out = paddle::none"
+                )
+            elif (
+                len(self.outputs['names']) == 4
+                and self.outputs['types'][0] == "Tensor"
+                and self.outputs['types'][1] == "Tensor"
+                and self.outputs['types'][2] == "Tensor"
+                and self.outputs['types'][3] == "Tensor"
+            ):
+                declare_args.append(
+                    "paddle::optional<std::tuple<paddle::Tensor*, paddle::Tensor*, paddle::Tensor*, paddle::Tensor*>> predefined_out = paddle::none"
+                )
+            else:
+                declare_args.append(
+                    "paddle::optional<void*> predefined_out = paddle::none"
+                )
 
         return ", ".join(declare_args)
 
@@ -275,11 +308,42 @@ class BaseAPI:
             not grad_flag
             and not inplace_flag
             and append_predefined_out
-            and len(self.outputs['names']) == 1
-            and self.outputs['types'][0] == "Tensor"
             and self.api != "empty_like"
         ):
-            define_args.append("paddle::optional<Tensor*> predefined_out")
+            if (
+                len(self.outputs['names']) == 1
+                and self.outputs['types'][0] == "Tensor"
+            ):
+                define_args.append("paddle::optional<Tensor*> predefined_out")
+            elif (
+                len(self.outputs['names']) == 2
+                and self.outputs['types'][0] == "Tensor"
+                and self.outputs['types'][1] == "Tensor"
+            ):
+                define_args.append(
+                    "paddle::optional<std::tuple<paddle::Tensor*, paddle::Tensor*>> predefined_out"
+                )
+            elif (
+                len(self.outputs['names']) == 3
+                and self.outputs['types'][0] == "Tensor"
+                and self.outputs['types'][1] == "Tensor"
+                and self.outputs['types'][2] == "Tensor"
+            ):
+                define_args.append(
+                    "paddle::optional<std::tuple<paddle::Tensor*, paddle::Tensor*, paddle::Tensor*>> predefined_out"
+                )
+            elif (
+                len(self.outputs['names']) == 4
+                and self.outputs['types'][0] == "Tensor"
+                and self.outputs['types'][1] == "Tensor"
+                and self.outputs['types'][2] == "Tensor"
+                and self.outputs['types'][3] == "Tensor"
+            ):
+                define_args.append(
+                    "paddle::optional<std::tuple<paddle::Tensor*, paddle::Tensor*, paddle::Tensor*, paddle::Tensor*>> predefined_out"
+                )
+            else:
+                define_args.append("paddle::optional<void*> predefined_out")
 
         return ", ".join(define_args)
 

--- a/paddle/phi/api/generator/api_gen.py
+++ b/paddle/phi/api/generator/api_gen.py
@@ -216,56 +216,23 @@ class ForwardAPI(BaseAPI):
                 if inplace_flag and self.outputs['names'][0] in self.inplace_map
                 else ""
             )
+
             if (
-                not (
+                len(self.outputs['names']) == 1
+                and self.outputs['types'][0] == "Tensor"
+                and not (
                     inplace_flag
                     and self.outputs['names'][0].split('@')[0]
                     in self.inplace_map
                 )
                 and self.api != "empty_like"
             ):
-                if (
-                    len(self.outputs['names']) == 1
-                    and self.outputs['types'][0] == "Tensor"
-                ):
-                    output_create = f"""
+                output_create = f"""
 {code_indent}  Tensor out_tmp; Tensor& api_output = predefined_out ? **predefined_out : out_tmp;"""
-                elif (
-                    len(self.outputs['names']) == 2
-                    and self.outputs['types'][0] == "Tensor"
-                    and self.outputs['types'][1] == "Tensor"
-                ):
-                    output_create = f"""
-{code_indent}  std::tuple<Tensor, Tensor> out_tmp;paddle::optional<std::tuple<Tensor, Tensor>> predefined_out_value;
-{code_indent}  if(predefined_out) {{predefined_out_value = std::make_tuple(*std::get<0>(*predefined_out), *std::get<1>(*predefined_out));}}
-{code_indent}  std::tuple<Tensor, Tensor, Tensor>& api_output = predefined_out_value ? *predefined_out_value : out_tmp;"""
-                elif (
-                    len(self.outputs['names']) == 3
-                    and self.outputs['types'][0] == "Tensor"
-                    and self.outputs['types'][1] == "Tensor"
-                    and self.outputs['types'][2] == "Tensor"
-                ):
-                    output_create = f"""
-{code_indent}  std::tuple<Tensor, Tensor, Tensor> out_tmp;paddle::optional<std::tuple<Tensor, Tensor, Tensor>> predefined_out_value;
-{code_indent}  if(predefined_out) {{predefined_out_value = std::make_tuple(*std::get<0>(*predefined_out), *std::get<1>(*predefined_out), *std::get<2>(*predefined_out));}}
-{code_indent}  std::tuple<Tensor, Tensor, Tensor>& api_output = predefined_out_value ? *predefined_out_value : out_tmp;"""
-                elif (
-                    len(self.outputs['names']) == 4
-                    and self.outputs['types'][0] == "Tensor"
-                    and self.outputs['types'][1] == "Tensor"
-                    and self.outputs['types'][2] == "Tensor"
-                    and self.outputs['types'][3] == "Tensor"
-                ):
-                    output_create = f"""
-{code_indent}  std::tuple<Tensor, Tensor, Tensor, Tensor> out_tmp;paddle::optional<std::tuple<Tensor, Tensor, Tensor, Tensor>> predefined_out_value;
-{code_indent}  if(predefined_out) {{predefined_out_value = std::make_tuple(*std::get<0>(*predefined_out), *std::get<1>(*predefined_out), *std::get<2>(*predefined_out), *std::get<3>(*predefined_out));}}
-{code_indent}  std::tuple<Tensor, Tensor, Tensor, Tensor>& api_output = predefined_out_value ? *predefined_out_value : out_tmp;"""
-                else:
-                    output_create = f"""
-{code_indent}  {return_type} api_output{inplace_assign};"""
             else:
                 output_create = f"""
 {code_indent}  {return_type} api_output{inplace_assign};"""
+
             set_out_func = (
                 'SetKernelOutput'
                 if out_tensor_type_list is None
@@ -330,52 +297,30 @@ class ForwardAPI(BaseAPI):
             if (
                 not (
                     inplace_flag
-                    and self.outputs['names'][0].split('@')[0]
-                    in self.inplace_map
+                    and any(
+                        name.split('@')[0] in self.inplace_map
+                        for name in self.outputs['names']
+                    )
                 )
                 and self.api != "empty_like"
             ):
-                print(
-                    "2-len(self.outputs['names']) = ",
-                    len(self.outputs['names']),
-                )
-
-                if (
-                    len(self.outputs['names']) == 1
-                    and self.outputs['types'][0] == "Tensor"
-                ):
-                    output_create = f"""
+                types = self.outputs['types']
+                names_len = len(self.outputs['names'])
+                if all(t == "Tensor" for t in types) and 1 <= names_len <= 4:
+                    if names_len == 1:
+                        output_create = f"""
 {code_indent}  Tensor out_tmp; Tensor& api_output = predefined_out ? **predefined_out : out_tmp;"""
-                elif (
-                    len(self.outputs['names']) == 2
-                    and self.outputs['types'][0] == "Tensor"
-                    and self.outputs['types'][1] == "Tensor"
-                ):
-                    output_create = f"""
-{code_indent}  std::tuple<Tensor, Tensor> out_tmp;paddle::optional<std::tuple<Tensor, Tensor>> predefined_out_value;
-{code_indent}  if(predefined_out) {{predefined_out_value = std::make_tuple(*std::get<0>(*predefined_out), *std::get<1>(*predefined_out));}}
-{code_indent}  std::tuple<Tensor, Tensor>& api_output = predefined_out_value ? *predefined_out_value : out_tmp;"""
-                elif (
-                    len(self.outputs['names']) == 3
-                    and self.outputs['types'][0] == "Tensor"
-                    and self.outputs['types'][1] == "Tensor"
-                    and self.outputs['types'][2] == "Tensor"
-                ):
-                    output_create = f"""
-{code_indent}  std::tuple<Tensor, Tensor, Tensor> out_tmp;paddle::optional<std::tuple<Tensor, Tensor, Tensor>> predefined_out_value;
-{code_indent}  if(predefined_out) {{predefined_out_value = std::make_tuple(*std::get<0>(*predefined_out), *std::get<1>(*predefined_out), *std::get<2>(*predefined_out));}}
-{code_indent}  std::tuple<Tensor, Tensor, Tensor>& api_output = predefined_out_value ? *predefined_out_value : out_tmp;"""
-                elif (
-                    len(self.outputs['names']) == 4
-                    and self.outputs['types'][0] == "Tensor"
-                    and self.outputs['types'][1] == "Tensor"
-                    and self.outputs['types'][2] == "Tensor"
-                    and self.outputs['types'][3] == "Tensor"
-                ):
-                    output_create = f"""
-{code_indent}  std::tuple<Tensor, Tensor, Tensor, Tensor> out_tmp;paddle::optional<std::tuple<Tensor, Tensor, Tensor, Tensor>> predefined_out_value;
-{code_indent}  if(predefined_out) {{predefined_out_value = std::make_tuple(*std::get<0>(*predefined_out), *std::get<1>(*predefined_out), *std::get<2>(*predefined_out), *std::get<3>(*predefined_out));}}
-{code_indent}  std::tuple<Tensor, Tensor, Tensor, Tensor>& api_output = predefined_out_value ? *predefined_out_value : out_tmp;"""
+                    else:
+                        tuple_types = ", ".join(["Tensor"] * names_len)
+                        get_indices = ", ".join(
+                            f"*std::get<{i}>(*predefined_out)"
+                            for i in range(names_len)
+                        )
+                        output_create = f"""
+{code_indent}  std::tuple<{tuple_types}> out_tmp;
+{code_indent}  paddle::optional<std::tuple<{tuple_types}>> predefined_out_value;
+{code_indent}  if(predefined_out) {{ predefined_out_value = std::make_tuple({get_indices}); }}
+{code_indent}  std::tuple<{tuple_types}>& api_output = predefined_out_value ? *predefined_out_value : out_tmp;"""
                 else:
                     output_create = f"""
 {code_indent}  {return_type} api_output;"""

--- a/paddle/phi/api/generator/api_gen.py
+++ b/paddle/phi/api/generator/api_gen.py
@@ -306,7 +306,7 @@ class ForwardAPI(BaseAPI):
             ):
                 types = self.outputs['types']
                 names_len = len(self.outputs['names'])
-                if all(t == "Tensor" for t in types) and 1 <= names_len <= 4:
+                if all(t == "Tensor" for t in types) and 1 <= names_len <= 7:
                     if names_len == 1:
                         output_create = f"""
 {code_indent}  Tensor out_tmp; Tensor& api_output = predefined_out ? **predefined_out : out_tmp;"""

--- a/paddle/phi/api/generator/api_gen.py
+++ b/paddle/phi/api/generator/api_gen.py
@@ -217,17 +217,52 @@ class ForwardAPI(BaseAPI):
                 else ""
             )
             if (
-                len(self.outputs['names']) == 1
-                and self.outputs['types'][0] == "Tensor"
-                and not (
+                not (
                     inplace_flag
                     and self.outputs['names'][0].split('@')[0]
                     in self.inplace_map
                 )
                 and self.api != "empty_like"
             ):
-                output_create = f"""
+                if (
+                    len(self.outputs['names']) == 1
+                    and self.outputs['types'][0] == "Tensor"
+                ):
+                    output_create = f"""
 {code_indent}  Tensor out_tmp; Tensor& api_output = predefined_out ? **predefined_out : out_tmp;"""
+                elif (
+                    len(self.outputs['names']) == 2
+                    and self.outputs['types'][0] == "Tensor"
+                    and self.outputs['types'][1] == "Tensor"
+                ):
+                    output_create = f"""
+{code_indent}  std::tuple<Tensor, Tensor> out_tmp;paddle::optional<std::tuple<Tensor, Tensor>> predefined_out_value;
+{code_indent}  if(predefined_out) {{predefined_out_value = std::make_tuple(*std::get<0>(*predefined_out), *std::get<1>(*predefined_out));}}
+{code_indent}  std::tuple<Tensor, Tensor, Tensor>& api_output = predefined_out_value ? *predefined_out_value : out_tmp;"""
+                elif (
+                    len(self.outputs['names']) == 3
+                    and self.outputs['types'][0] == "Tensor"
+                    and self.outputs['types'][1] == "Tensor"
+                    and self.outputs['types'][2] == "Tensor"
+                ):
+                    output_create = f"""
+{code_indent}  std::tuple<Tensor, Tensor, Tensor> out_tmp;paddle::optional<std::tuple<Tensor, Tensor, Tensor>> predefined_out_value;
+{code_indent}  if(predefined_out) {{predefined_out_value = std::make_tuple(*std::get<0>(*predefined_out), *std::get<1>(*predefined_out), *std::get<2>(*predefined_out));}}
+{code_indent}  std::tuple<Tensor, Tensor, Tensor>& api_output = predefined_out_value ? *predefined_out_value : out_tmp;"""
+                elif (
+                    len(self.outputs['names']) == 4
+                    and self.outputs['types'][0] == "Tensor"
+                    and self.outputs['types'][1] == "Tensor"
+                    and self.outputs['types'][2] == "Tensor"
+                    and self.outputs['types'][3] == "Tensor"
+                ):
+                    output_create = f"""
+{code_indent}  std::tuple<Tensor, Tensor, Tensor, Tensor> out_tmp;paddle::optional<std::tuple<Tensor, Tensor, Tensor, Tensor>> predefined_out_value;
+{code_indent}  if(predefined_out) {{predefined_out_value = std::make_tuple(*std::get<0>(*predefined_out), *std::get<1>(*predefined_out), *std::get<2>(*predefined_out), *std::get<3>(*predefined_out));}}
+{code_indent}  std::tuple<Tensor, Tensor, Tensor, Tensor>& api_output = predefined_out_value ? *predefined_out_value : out_tmp;"""
+                else:
+                    output_create = f"""
+{code_indent}  {return_type} api_output{inplace_assign};"""
             else:
                 output_create = f"""
 {code_indent}  {return_type} api_output{inplace_assign};"""
@@ -292,7 +327,60 @@ class ForwardAPI(BaseAPI):
                 )
 
         elif len(out_dtype_list) > 1:
-            output_create = f"""
+            if (
+                not (
+                    inplace_flag
+                    and self.outputs['names'][0].split('@')[0]
+                    in self.inplace_map
+                )
+                and self.api != "empty_like"
+            ):
+                print(
+                    "2-len(self.outputs['names']) = ",
+                    len(self.outputs['names']),
+                )
+
+                if (
+                    len(self.outputs['names']) == 1
+                    and self.outputs['types'][0] == "Tensor"
+                ):
+                    output_create = f"""
+{code_indent}  Tensor out_tmp; Tensor& api_output = predefined_out ? **predefined_out : out_tmp;"""
+                elif (
+                    len(self.outputs['names']) == 2
+                    and self.outputs['types'][0] == "Tensor"
+                    and self.outputs['types'][1] == "Tensor"
+                ):
+                    output_create = f"""
+{code_indent}  std::tuple<Tensor, Tensor> out_tmp;paddle::optional<std::tuple<Tensor, Tensor>> predefined_out_value;
+{code_indent}  if(predefined_out) {{predefined_out_value = std::make_tuple(*std::get<0>(*predefined_out), *std::get<1>(*predefined_out));}}
+{code_indent}  std::tuple<Tensor, Tensor>& api_output = predefined_out_value ? *predefined_out_value : out_tmp;"""
+                elif (
+                    len(self.outputs['names']) == 3
+                    and self.outputs['types'][0] == "Tensor"
+                    and self.outputs['types'][1] == "Tensor"
+                    and self.outputs['types'][2] == "Tensor"
+                ):
+                    output_create = f"""
+{code_indent}  std::tuple<Tensor, Tensor, Tensor> out_tmp;paddle::optional<std::tuple<Tensor, Tensor, Tensor>> predefined_out_value;
+{code_indent}  if(predefined_out) {{predefined_out_value = std::make_tuple(*std::get<0>(*predefined_out), *std::get<1>(*predefined_out), *std::get<2>(*predefined_out));}}
+{code_indent}  std::tuple<Tensor, Tensor, Tensor>& api_output = predefined_out_value ? *predefined_out_value : out_tmp;"""
+                elif (
+                    len(self.outputs['names']) == 4
+                    and self.outputs['types'][0] == "Tensor"
+                    and self.outputs['types'][1] == "Tensor"
+                    and self.outputs['types'][2] == "Tensor"
+                    and self.outputs['types'][3] == "Tensor"
+                ):
+                    output_create = f"""
+{code_indent}  std::tuple<Tensor, Tensor, Tensor, Tensor> out_tmp;paddle::optional<std::tuple<Tensor, Tensor, Tensor, Tensor>> predefined_out_value;
+{code_indent}  if(predefined_out) {{predefined_out_value = std::make_tuple(*std::get<0>(*predefined_out), *std::get<1>(*predefined_out), *std::get<2>(*predefined_out), *std::get<3>(*predefined_out));}}
+{code_indent}  std::tuple<Tensor, Tensor, Tensor, Tensor>& api_output = predefined_out_value ? *predefined_out_value : out_tmp;"""
+                else:
+                    output_create = f"""
+{code_indent}  {return_type} api_output;"""
+            else:
+                output_create = f"""
 {code_indent}  {return_type} api_output;"""
 
             if inplace_flag:

--- a/paddle/phi/api/generator/dist_api_gen.py
+++ b/paddle/phi/api/generator/dist_api_gen.py
@@ -1146,49 +1146,12 @@ class DistForwardAPI(ForwardAPI):
                     return_type, inplace_assign_code
                 )
             else:
-                if self.api != "empty_like":
-                    if (
-                        len(self.outputs['names']) == 1
-                        and self.outputs['types'][0] == "Tensor"
-                    ):
-                        output_creation_code += "Tensor out_tmp; Tensor& api_output = predefined_out ? **predefined_out : out_tmp;"
-                    elif (
-                        len(self.outputs['names']) == 2
-                        and self.outputs['types'][0] == "Tensor"
-                        and self.outputs['types'][1] == "Tensor"
-                    ):
-                        output_creation_code += (
-                            "std::tuple<Tensor, Tensor> out_tmp;paddle::optional<std::tuple<Tensor, Tensor>> predefined_out_value;"
-                            + "if(predefined_out) {{predefined_out_value = std::make_tuple(*std::get<0>(*predefined_out), *std::get<1>(*predefined_out));}}"
-                            + "std::tuple<Tensor, Tensor>& api_output = predefined_out_value ? *predefined_out_value : out_tmp;"
-                        )
-                    elif (
-                        len(self.outputs['names']) == 3
-                        and self.outputs['types'][0] == "Tensor"
-                        and self.outputs['types'][1] == "Tensor"
-                        and self.outputs['types'][2] == "Tensor"
-                    ):
-                        output_creation_code += (
-                            "std::tuple<Tensor, Tensor, Tensor> out_tmp;paddle::optional<std::tuple<Tensor, Tensor, Tensor>> predefined_out_value;"
-                            + "if(predefined_out) {{predefined_out_value = std::make_tuple(*std::get<0>(*predefined_out), *std::get<1>(*predefined_out), *std::get<2>(*predefined_out));}}"
-                            + "std::tuple<Tensor, Tensor, Tensor>& api_output = predefined_out_value ? *predefined_out_value : out_tmp;"
-                        )
-                    elif (
-                        len(self.outputs['names']) == 4
-                        and self.outputs['types'][0] == "Tensor"
-                        and self.outputs['types'][1] == "Tensor"
-                        and self.outputs['types'][2] == "Tensor"
-                        and self.outputs['types'][3] == "Tensor"
-                    ):
-                        output_creation_code += (
-                            "std::tuple<Tensor, Tensor, Tensor, Tensor> out_tmp;paddle::optional<std::tuple<Tensor, Tensor, Tensor, Tensor>> predefined_out_value;"
-                            + "if(predefined_out) {{predefined_out_value = std::make_tuple(*std::get<0>(*predefined_out), *std::get<1>(*predefined_out), *std::get<2>(*predefined_out), *std::get<3>(*predefined_out));}}"
-                            + "std::tuple<Tensor, Tensor, Tensor, Tensor>& api_output = predefined_out_value ? *predefined_out_value : out_tmp;"
-                        )
-                    else:
-                        output_creation_code += (
-                            API_OUT_CREATION_TEMPLATE.format(return_type, "")
-                        )
+                if (
+                    len(self.outputs['names']) == 1
+                    and self.outputs['types'][0] == "Tensor"
+                    and self.api != "empty_like"
+                ):
+                    output_creation_code += "Tensor out_tmp; Tensor& api_output = predefined_out ? **predefined_out : out_tmp;"
                 else:
                     output_creation_code += API_OUT_CREATION_TEMPLATE.format(
                         return_type, ""
@@ -1265,44 +1228,26 @@ class DistForwardAPI(ForwardAPI):
                 )
             else:
                 if self.api != "empty_like":
+                    names_len = len(self.outputs['names'])
+                    types = self.outputs['types']
                     if (
-                        len(self.outputs['names']) == 1
-                        and self.outputs['types'][0] == "Tensor"
+                        all(t == "Tensor" for t in types)
+                        and 1 <= names_len <= 4
                     ):
-                        output_creation_code += "Tensor out_tmp; Tensor& api_output = predefined_out ? **predefined_out : out_tmp;"
-                    elif (
-                        len(self.outputs['names']) == 2
-                        and self.outputs['types'][0] == "Tensor"
-                        and self.outputs['types'][1] == "Tensor"
-                    ):
-                        output_creation_code += (
-                            "std::tuple<Tensor, Tensor> out_tmp;paddle::optional<std::tuple<Tensor, Tensor>> predefined_out_value;"
-                            + "\n    if(predefined_out) {{predefined_out_value = std::make_tuple(*std::get<0>(*predefined_out), *std::get<1>(*predefined_out));}}"
-                            + "\n    std::tuple<Tensor, Tensor>& api_output = predefined_out_value ? *predefined_out_value : out_tmp;"
-                        )
-                    elif (
-                        len(self.outputs['names']) == 3
-                        and self.outputs['types'][0] == "Tensor"
-                        and self.outputs['types'][1] == "Tensor"
-                        and self.outputs['types'][2] == "Tensor"
-                    ):
-                        output_creation_code += (
-                            "std::tuple<Tensor, Tensor, Tensor> out_tmp;paddle::optional<std::tuple<Tensor, Tensor, Tensor>> predefined_out_value;"
-                            + "\n    if(predefined_out) {{predefined_out_value = std::make_tuple(*std::get<0>(*predefined_out), *std::get<1>(*predefined_out), *std::get<2>(*predefined_out));}}"
-                            + "\n    std::tuple<Tensor, Tensor, Tensor>& api_output = predefined_out_value ? *predefined_out_value : out_tmp;"
-                        )
-                    elif (
-                        len(self.outputs['names']) == 4
-                        and self.outputs['types'][0] == "Tensor"
-                        and self.outputs['types'][1] == "Tensor"
-                        and self.outputs['types'][2] == "Tensor"
-                        and self.outputs['types'][3] == "Tensor"
-                    ):
-                        output_creation_code += (
-                            "std::tuple<Tensor, Tensor, Tensor, Tensor> out_tmp;paddle::optional<std::tuple<Tensor, Tensor, Tensor, Tensor>> predefined_out_value;"
-                            + "\n    if(predefined_out) {{predefined_out_value = std::make_tuple(*std::get<0>(*predefined_out), *std::get<1>(*predefined_out), *std::get<2>(*predefined_out), *std::get<3>(*predefined_out));}}"
-                            + "\n    std::tuple<Tensor, Tensor, Tensor, Tensor>& api_output = predefined_out_value ? *predefined_out_value : out_tmp;"
-                        )
+                        if names_len == 1:
+                            output_creation_code += "Tensor out_tmp; Tensor& api_output = predefined_out ? **predefined_out : out_tmp;"
+                        else:
+                            tuple_types = ", ".join(["Tensor"] * names_len)
+                            get_calls = ", ".join(
+                                f"*std::get<{i}>(*predefined_out)"
+                                for i in range(names_len)
+                            )
+                            output_creation_code += (
+                                f"std::tuple<{tuple_types}> out_tmp;"
+                                f"paddle::optional<std::tuple<{tuple_types}>> predefined_out_value;"
+                                f"\n    if(predefined_out) {{ predefined_out_value = std::make_tuple({get_calls}); }}"
+                                f"\n    std::tuple<{tuple_types}>& api_output = predefined_out_value ? *predefined_out_value : out_tmp;"
+                            )
                     else:
                         output_creation_code += (
                             API_OUT_CREATION_TEMPLATE.format(return_type, "")

--- a/paddle/phi/api/generator/dist_api_gen.py
+++ b/paddle/phi/api/generator/dist_api_gen.py
@@ -1146,12 +1146,49 @@ class DistForwardAPI(ForwardAPI):
                     return_type, inplace_assign_code
                 )
             else:
-                if (
-                    len(self.outputs['names']) == 1
-                    and self.outputs['types'][0] == "Tensor"
-                    and self.api != "empty_like"
-                ):
-                    output_creation_code += "Tensor out_tmp; Tensor& api_output = predefined_out ? **predefined_out : out_tmp;"
+                if self.api != "empty_like":
+                    if (
+                        len(self.outputs['names']) == 1
+                        and self.outputs['types'][0] == "Tensor"
+                    ):
+                        output_creation_code += "Tensor out_tmp; Tensor& api_output = predefined_out ? **predefined_out : out_tmp;"
+                    elif (
+                        len(self.outputs['names']) == 2
+                        and self.outputs['types'][0] == "Tensor"
+                        and self.outputs['types'][1] == "Tensor"
+                    ):
+                        output_creation_code += (
+                            "std::tuple<Tensor, Tensor> out_tmp;paddle::optional<std::tuple<Tensor, Tensor>> predefined_out_value;"
+                            + "if(predefined_out) {{predefined_out_value = std::make_tuple(*std::get<0>(*predefined_out), *std::get<1>(*predefined_out));}}"
+                            + "std::tuple<Tensor, Tensor>& api_output = predefined_out_value ? *predefined_out_value : out_tmp;"
+                        )
+                    elif (
+                        len(self.outputs['names']) == 3
+                        and self.outputs['types'][0] == "Tensor"
+                        and self.outputs['types'][1] == "Tensor"
+                        and self.outputs['types'][2] == "Tensor"
+                    ):
+                        output_creation_code += (
+                            "std::tuple<Tensor, Tensor, Tensor> out_tmp;paddle::optional<std::tuple<Tensor, Tensor, Tensor>> predefined_out_value;"
+                            + "if(predefined_out) {{predefined_out_value = std::make_tuple(*std::get<0>(*predefined_out), *std::get<1>(*predefined_out), *std::get<2>(*predefined_out));}}"
+                            + "std::tuple<Tensor, Tensor, Tensor>& api_output = predefined_out_value ? *predefined_out_value : out_tmp;"
+                        )
+                    elif (
+                        len(self.outputs['names']) == 4
+                        and self.outputs['types'][0] == "Tensor"
+                        and self.outputs['types'][1] == "Tensor"
+                        and self.outputs['types'][2] == "Tensor"
+                        and self.outputs['types'][3] == "Tensor"
+                    ):
+                        output_creation_code += (
+                            "std::tuple<Tensor, Tensor, Tensor, Tensor> out_tmp;paddle::optional<std::tuple<Tensor, Tensor, Tensor, Tensor>> predefined_out_value;"
+                            + "if(predefined_out) {{predefined_out_value = std::make_tuple(*std::get<0>(*predefined_out), *std::get<1>(*predefined_out), *std::get<2>(*predefined_out), *std::get<3>(*predefined_out));}}"
+                            + "std::tuple<Tensor, Tensor, Tensor, Tensor>& api_output = predefined_out_value ? *predefined_out_value : out_tmp;"
+                        )
+                    else:
+                        output_creation_code += (
+                            API_OUT_CREATION_TEMPLATE.format(return_type, "")
+                        )
                 else:
                     output_creation_code += API_OUT_CREATION_TEMPLATE.format(
                         return_type, ""
@@ -1227,9 +1264,53 @@ class DistForwardAPI(ForwardAPI):
                     )
                 )
             else:
-                output_creation_code += API_OUT_CREATION_TEMPLATE.format(
-                    return_type, ""
-                )
+                if self.api != "empty_like":
+                    if (
+                        len(self.outputs['names']) == 1
+                        and self.outputs['types'][0] == "Tensor"
+                    ):
+                        output_creation_code += "Tensor out_tmp; Tensor& api_output = predefined_out ? **predefined_out : out_tmp;"
+                    elif (
+                        len(self.outputs['names']) == 2
+                        and self.outputs['types'][0] == "Tensor"
+                        and self.outputs['types'][1] == "Tensor"
+                    ):
+                        output_creation_code += (
+                            "std::tuple<Tensor, Tensor> out_tmp;paddle::optional<std::tuple<Tensor, Tensor>> predefined_out_value;"
+                            + "\n    if(predefined_out) {{predefined_out_value = std::make_tuple(*std::get<0>(*predefined_out), *std::get<1>(*predefined_out));}}"
+                            + "\n    std::tuple<Tensor, Tensor>& api_output = predefined_out_value ? *predefined_out_value : out_tmp;"
+                        )
+                    elif (
+                        len(self.outputs['names']) == 3
+                        and self.outputs['types'][0] == "Tensor"
+                        and self.outputs['types'][1] == "Tensor"
+                        and self.outputs['types'][2] == "Tensor"
+                    ):
+                        output_creation_code += (
+                            "std::tuple<Tensor, Tensor, Tensor> out_tmp;paddle::optional<std::tuple<Tensor, Tensor, Tensor>> predefined_out_value;"
+                            + "\n    if(predefined_out) {{predefined_out_value = std::make_tuple(*std::get<0>(*predefined_out), *std::get<1>(*predefined_out), *std::get<2>(*predefined_out));}}"
+                            + "\n    std::tuple<Tensor, Tensor, Tensor>& api_output = predefined_out_value ? *predefined_out_value : out_tmp;"
+                        )
+                    elif (
+                        len(self.outputs['names']) == 4
+                        and self.outputs['types'][0] == "Tensor"
+                        and self.outputs['types'][1] == "Tensor"
+                        and self.outputs['types'][2] == "Tensor"
+                        and self.outputs['types'][3] == "Tensor"
+                    ):
+                        output_creation_code += (
+                            "std::tuple<Tensor, Tensor, Tensor, Tensor> out_tmp;paddle::optional<std::tuple<Tensor, Tensor, Tensor, Tensor>> predefined_out_value;"
+                            + "\n    if(predefined_out) {{predefined_out_value = std::make_tuple(*std::get<0>(*predefined_out), *std::get<1>(*predefined_out), *std::get<2>(*predefined_out), *std::get<3>(*predefined_out));}}"
+                            + "\n    std::tuple<Tensor, Tensor, Tensor, Tensor>& api_output = predefined_out_value ? *predefined_out_value : out_tmp;"
+                        )
+                    else:
+                        output_creation_code += (
+                            API_OUT_CREATION_TEMPLATE.format(return_type, "")
+                        )
+                else:
+                    output_creation_code += API_OUT_CREATION_TEMPLATE.format(
+                        return_type, ""
+                    )
 
             # kernel output generate
             for i, out_type in enumerate(self.outputs['types']):

--- a/paddle/phi/api/generator/dist_api_gen.py
+++ b/paddle/phi/api/generator/dist_api_gen.py
@@ -1232,7 +1232,7 @@ class DistForwardAPI(ForwardAPI):
                     types = self.outputs['types']
                     if (
                         all(t == "Tensor" for t in types)
-                        and 1 <= names_len <= 4
+                        and 1 <= names_len <= 7
                     ):
                         if names_len == 1:
                             output_creation_code += "Tensor out_tmp; Tensor& api_output = predefined_out ? **predefined_out : out_tmp;"
@@ -1244,7 +1244,7 @@ class DistForwardAPI(ForwardAPI):
                             )
                             output_creation_code += (
                                 f"std::tuple<{tuple_types}> out_tmp;"
-                                f"paddle::optional<std::tuple<{tuple_types}>> predefined_out_value;"
+                                f"\n    paddle::optional<std::tuple<{tuple_types}>> predefined_out_value;"
                                 f"\n    if(predefined_out) {{ predefined_out_value = std::make_tuple({get_calls}); }}"
                                 f"\n    std::tuple<{tuple_types}>& api_output = predefined_out_value ? *predefined_out_value : out_tmp;"
                             )

--- a/python/paddle/tensor/compat.py
+++ b/python/paddle/tensor/compat.py
@@ -900,11 +900,9 @@ def median(
     else:
         _check_out_status(out, True)
         values, indices = paddle.median(
-            input, axis=dim, keepdim=keepdim, mode='min'
+            input, axis=dim, keepdim=keepdim, mode='min', out=out
         )
         if out is not None:
-            paddle.assign(values, out[0])
-            paddle.assign(indices, out[1])
             return MedianRetType(values=out[0], indices=out[1])
         return MedianRetType(values=values, indices=indices)
 

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -2724,7 +2724,11 @@ def slogdet(x: Tensor, name: str | None = None) -> Tensor:
 
 
 def svd(
-    x: Tensor, full_matrices: bool = False, name: str | None = None
+    x: Tensor,
+    full_matrices: bool = False,
+    name: str | None = None,
+    *,
+    out: tuple[Tensor, Tensor, Tensor] | None = None,
 ) -> tuple[Tensor, Tensor, Tensor]:
     r"""
     Computes the singular value decomposition of one matrix or a batch of regular matrices.
@@ -2784,7 +2788,7 @@ def svd(
     """
 
     if in_dynamic_or_pir_mode():
-        return _C_ops.svd(x, full_matrices)
+        return _C_ops.svd(x, full_matrices, out=out)
     else:
         check_variable_and_dtype(
             x, 'dtype', ['float32', 'float64', 'complex64', 'complex128'], 'svd'

--- a/python/paddle/tensor/search.py
+++ b/python/paddle/tensor/search.py
@@ -1129,12 +1129,9 @@ def topk(
     if in_dynamic_or_pir_mode():
         if axis is None:
             axis = -1
-        values, indices = _C_ops.topk(x, k, axis, largest, sorted)
+        values, indices = _C_ops.topk(x, k, axis, largest, sorted, out=out)
         if out is not None:
-            out_values, out_indices = out
-            out_values = paddle.assign(values, output=out_values)
-            out_indices = paddle.assign(indices, output=out_indices)
-            return TopKRetType(values=out_values, indices=out_indices)
+            return TopKRetType(values=out[0], indices=out[1])
         return TopKRetType(values=values, indices=indices)
     else:
         helper = LayerHelper("top_k_v2", **locals())

--- a/python/paddle/tensor/stat.py
+++ b/python/paddle/tensor/stat.py
@@ -536,6 +536,8 @@ def median(
     keepdim: bool = ...,
     mode: Literal['min'] = ...,
     name: str | None = ...,
+    *,
+    out: tuple[Tensor, Tensor] | None = ...,
 ) -> tuple[Tensor, Tensor]: ...
 
 
@@ -556,6 +558,8 @@ def median(
     keepdim=False,
     mode='avg',
     name=None,
+    *,
+    out=None,
 ):
     """
     Compute the median along the specified axis.
@@ -697,13 +701,13 @@ def median(
     if mode == "avg" and not x.dtype == paddle.float64:
         x = x.astype(paddle.float32)
 
-    out, indices = _C_ops.median(x, axis, keepdim, mode)
+    values, indices = _C_ops.median(x, axis, keepdim, mode, out=out)
     indices.stop_gradient = True
 
     if mode == 'min' and need_idx:
-        return out, indices
+        return values, indices
     else:
-        return out
+        return values
 
 
 def _compute_quantile(

--- a/test/legacy_test/test_svd_op.py
+++ b/test/legacy_test/test_svd_op.py
@@ -12,461 +12,619 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import itertools
 import unittest
 
 import numpy as np
-from op_test import OpTest, skip_check_grad_ci
-from utils import dygraph_guard, static_guard
 
 import paddle
-from paddle import base
 from paddle.base import core
 
+# class TestSvdOp(OpTest):
+#     def setUp(self):
+#         with static_guard():
+#             self.python_api = paddle.linalg.svd
+#             self.generate_input()
+#             self.generate_output()
+#             self.op_type = "svd"
+#             assert hasattr(self, "_output_data")
+#             self.inputs = {"X": self._input_data}
+#             self.attrs = {'full_matrices': self.get_full_matrices_option()}
+#             self.outputs = {
+#                 "U": self._output_data[0],
+#                 "S": self._output_data[1],
+#                 "VH": self._output_data[2],
+#             }
 
-class TestSvdOp(OpTest):
-    def setUp(self):
-        with static_guard():
-            self.python_api = paddle.linalg.svd
-            self.generate_input()
-            self.generate_output()
-            self.op_type = "svd"
-            assert hasattr(self, "_output_data")
-            self.inputs = {"X": self._input_data}
-            self.attrs = {'full_matrices': self.get_full_matrices_option()}
-            self.outputs = {
-                "U": self._output_data[0],
-                "S": self._output_data[1],
-                "VH": self._output_data[2],
-            }
+#     def _get_places(self):
+#         places = [base.CPUPlace()]
+#         if core.is_compiled_with_cuda():
+#             places.append(base.CUDAPlace(0))
+#         return places
 
-    def _get_places(self):
-        places = [base.CPUPlace()]
-        if core.is_compiled_with_cuda():
-            places.append(base.CUDAPlace(0))
-        return places
+#     def generate_input(self):
+#         """return a input_data and input_shape"""
+#         self._input_shape = (100, 1)
+#         self._input_data = np.random.random(self._input_shape).astype("float64")
 
-    def generate_input(self):
-        """return a input_data and input_shape"""
-        self._input_shape = (100, 1)
-        self._input_data = np.random.random(self._input_shape).astype("float64")
+#     def get_full_matrices_option(self):
+#         return False
 
-    def get_full_matrices_option(self):
-        return False
+#     def generate_output(self):
+#         assert hasattr(self, "_input_data")
+#         self._output_data = np.linalg.svd(self._input_data)
 
-    def generate_output(self):
-        assert hasattr(self, "_input_data")
-        self._output_data = np.linalg.svd(self._input_data)
+#     def test_check_output(self):
+#         self.check_output(no_check_set=['U', 'VH'], check_pir=True)
 
-    def test_check_output(self):
-        self.check_output(no_check_set=['U', 'VH'], check_pir=True)
+#     def test_svd_forward(self):
+#         """u matmul diag(s) matmul vt must become X"""
+#         single_input = self._input_data.reshape(
+#             [-1, self._input_shape[-2], self._input_shape[-1]]
+#         )[0]
+#         with dygraph_guard():
+#             dy_x = paddle.to_tensor(single_input)
+#             dy_u, dy_s, dy_vt = paddle.linalg.svd(dy_x)
+#             dy_out_x = dy_u.matmul(paddle.diag(dy_s)).matmul(dy_vt)
+#             if (paddle.abs(dy_out_x - dy_x) < 1e-5).all():
+#                 ...
+#             else:
+#                 raise RuntimeError("Check SVD Failed")
 
-    def test_svd_forward(self):
-        """u matmul diag(s) matmul vt must become X"""
-        single_input = self._input_data.reshape(
-            [-1, self._input_shape[-2], self._input_shape[-1]]
-        )[0]
-        with dygraph_guard():
-            dy_x = paddle.to_tensor(single_input)
-            dy_u, dy_s, dy_vt = paddle.linalg.svd(dy_x)
-            dy_out_x = dy_u.matmul(paddle.diag(dy_s)).matmul(dy_vt)
-            if (paddle.abs(dy_out_x - dy_x) < 1e-5).all():
-                ...
-            else:
-                raise RuntimeError("Check SVD Failed")
+#     def check_S_grad(self):
+#         self.check_grad(['X'], ['S'], numeric_grad_delta=0.001, check_pir=True)
 
-    def check_S_grad(self):
-        self.check_grad(['X'], ['S'], numeric_grad_delta=0.001, check_pir=True)
+#     def check_U_grad(self):
+#         self.check_grad(['X'], ['U'], numeric_grad_delta=0.001, check_pir=True)
 
-    def check_U_grad(self):
-        self.check_grad(['X'], ['U'], numeric_grad_delta=0.001, check_pir=True)
+#     def check_V_grad(self):
+#         self.check_grad(['X'], ['VH'], numeric_grad_delta=0.001, check_pir=True)
 
-    def check_V_grad(self):
-        self.check_grad(['X'], ['VH'], numeric_grad_delta=0.001, check_pir=True)
-
-    def test_check_grad(self):
-        """
-        remember the input matrix must be the full rank matrix, otherwise the gradient will stochatic because the u / v 's  (n-k) freedom  vectors
-        """
-        self.check_S_grad()
-        self.check_U_grad()
-        self.check_V_grad()
-
-
-@unittest.skipIf(
-    core.is_compiled_with_xpu(),
-    "Skip XPU for complex dtype is not fully supported",
-)
-class TestSvdOpComplexCase1(TestSvdOp):
-    def generate_input(self):
-        """return a input_data and input_shape"""
-        self._input_shape = (5, 3)
-        real_part = np.random.rand(*self._input_shape).astype("float32")
-        imag_part = np.random.rand(*self._input_shape).astype("float32")
-        self._input_data = real_part + 1j * imag_part
-
-    def test_check_grad(self):
-        places = self._get_places()
-        with dygraph_guard():
-            for place in places:
-                x = paddle.to_tensor(
-                    self._input_data, place=place, stop_gradient=False
-                )
-                U, s, Vh = paddle.linalg.svd(x, self.get_full_matrices_option())
-                loss = (
-                    paddle.sum(paddle.abs(U))
-                    + paddle.sum(paddle.abs(s))
-                    + paddle.sum(paddle.abs(Vh))
-                )
-                x_grad = paddle.grad(outputs=[loss], inputs=[x])
+#     def test_check_grad(self):
+#         """
+#         remember the input matrix must be the full rank matrix, otherwise the gradient will stochatic because the u / v 's  (n-k) freedom  vectors
+#         """
+#         self.check_S_grad()
+#         self.check_U_grad()
+#         self.check_V_grad()
 
 
-@unittest.skipIf(
-    core.is_compiled_with_xpu(),
-    "Skip XPU for complex dtype is not fully supported",
-)
-class TestSvdOpComplexCase2(TestSvdOpComplexCase1):
-    def generate_input(self):
-        """return a input_data and input_shape"""
-        self._input_shape = (3, 30)
-        real_part = np.random.rand(*self._input_shape).astype("float32")
-        imag_part = np.random.rand(*self._input_shape).astype("float32")
-        self._input_data = real_part + 1j * imag_part
+# @unittest.skipIf(
+#     core.is_compiled_with_xpu(),
+#     "Skip XPU for complex dtype is not fully supported",
+# )
+# class TestSvdOpComplexCase1(TestSvdOp):
+#     def generate_input(self):
+#         """return a input_data and input_shape"""
+#         self._input_shape = (5, 3)
+#         real_part = np.random.rand(*self._input_shape).astype("float32")
+#         imag_part = np.random.rand(*self._input_shape).astype("float32")
+#         self._input_data = real_part + 1j * imag_part
+
+#     def test_check_grad(self):
+#         places = self._get_places()
+#         with dygraph_guard():
+#             for place in places:
+#                 x = paddle.to_tensor(
+#                     self._input_data, place=place, stop_gradient=False
+#                 )
+#                 U, s, Vh = paddle.linalg.svd(x, self.get_full_matrices_option())
+#                 loss = (
+#                     paddle.sum(paddle.abs(U))
+#                     + paddle.sum(paddle.abs(s))
+#                     + paddle.sum(paddle.abs(Vh))
+#                 )
+#                 x_grad = paddle.grad(outputs=[loss], inputs=[x])
 
 
-@unittest.skipIf(
-    core.is_compiled_with_xpu(),
-    "Skip XPU for complex dtype is not fully supported",
-)
-class TestSvdOpComplexCase3(TestSvdOpComplexCase1):
-    def generate_input(self):
-        """return a input_data and input_shape"""
-        self._input_shape = (100, 40)
-        real_part = np.random.rand(*self._input_shape).astype("float64")
-        imag_part = np.random.rand(*self._input_shape).astype("float64")
-        self._input_data = real_part + 1j * imag_part
+# @unittest.skipIf(
+#     core.is_compiled_with_xpu(),
+#     "Skip XPU for complex dtype is not fully supported",
+# )
+# class TestSvdOpComplexCase2(TestSvdOpComplexCase1):
+#     def generate_input(self):
+#         """return a input_data and input_shape"""
+#         self._input_shape = (3, 30)
+#         real_part = np.random.rand(*self._input_shape).astype("float32")
+#         imag_part = np.random.rand(*self._input_shape).astype("float32")
+#         self._input_data = real_part + 1j * imag_part
 
 
-@unittest.skipIf(
-    core.is_compiled_with_xpu(),
-    "Skip XPU for complex dtype is not fully supported",
-)
-class TestSvdOpComplexCase4(TestSvdOpComplexCase1):
-    def generate_input(self):
-        """return a input_data and input_shape"""
-        self._input_shape = (100, 200)
-        real_part = np.random.rand(*self._input_shape).astype("float64")
-        imag_part = np.random.rand(*self._input_shape).astype("float64")
-        self._input_data = real_part + 1j * imag_part
-
-    def get_full_matrices_option(self):
-        return True
+# @unittest.skipIf(
+#     core.is_compiled_with_xpu(),
+#     "Skip XPU for complex dtype is not fully supported",
+# )
+# class TestSvdOpComplexCase3(TestSvdOpComplexCase1):
+#     def generate_input(self):
+#         """return a input_data and input_shape"""
+#         self._input_shape = (100, 40)
+#         real_part = np.random.rand(*self._input_shape).astype("float64")
+#         imag_part = np.random.rand(*self._input_shape).astype("float64")
+#         self._input_data = real_part + 1j * imag_part
 
 
-class TestSvdCheckGrad2(TestSvdOp):
-    # NOTE(xiongkun03): because we want to construct some full rank matrices,
-    #                   so we can't specifize matrices which numel() > 100
+# @unittest.skipIf(
+#     core.is_compiled_with_xpu(),
+#     "Skip XPU for complex dtype is not fully supported",
+# )
+# class TestSvdOpComplexCase4(TestSvdOpComplexCase1):
+#     def generate_input(self):
+#         """return a input_data and input_shape"""
+#         self._input_shape = (100, 200)
+#         real_part = np.random.rand(*self._input_shape).astype("float64")
+#         imag_part = np.random.rand(*self._input_shape).astype("float64")
+#         self._input_data = real_part + 1j * imag_part
 
-    no_need_check_grad = True
-
-    def generate_input(self):
-        """return a deterministic  matrix, the range matrix;
-        vander matrix must be a full rank matrix.
-        """
-        self._input_shape = (5, 5)
-        self._input_data = (
-            np.vander([2, 3, 4, 5, 6])
-            .astype("float64")
-            .reshape(self._input_shape)
-        )
+#     def get_full_matrices_option(self):
+#         return True
 
 
-class TestSvdNormalMatrixSmall(TestSvdCheckGrad2):
-    def generate_input(self):
-        """small matrix SVD."""
-        self._input_shape = (1, 1)
-        self._input_data = np.random.random(self._input_shape).astype("float64")
+# class TestSvdCheckGrad2(TestSvdOp):
+#     # NOTE(xiongkun03): because we want to construct some full rank matrices,
+#     #                   so we can't specifize matrices which numel() > 100
+
+#     no_need_check_grad = True
+
+#     def generate_input(self):
+#         """return a deterministic  matrix, the range matrix;
+#         vander matrix must be a full rank matrix.
+#         """
+#         self._input_shape = (5, 5)
+#         self._input_data = (
+#             np.vander([2, 3, 4, 5, 6])
+#             .astype("float64")
+#             .reshape(self._input_shape)
+#         )
 
 
-class TestSvdNormalMatrix6x3(TestSvdCheckGrad2):
-    def generate_input(self):
-        """return a deterministic  matrix, the range matrix;
-        vander matrix must be a full rank matrix.
-        """
-        self._input_shape = (6, 3)
-        self._input_data = np.array(
-            [
-                [1.0, 2.0, 3.0],
-                [0.0, 1.0, 5.0],
-                [0.0, 0.0, 6.0],
-                [2.0, 4.0, 9.0],
-                [3.0, 6.0, 8.0],
-                [3.0, 1.0, 0.0],
-            ]
-        ).astype("float64")
+# class TestSvdNormalMatrixSmall(TestSvdCheckGrad2):
+#     def generate_input(self):
+#         """small matrix SVD."""
+#         self._input_shape = (1, 1)
+#         self._input_data = np.random.random(self._input_shape).astype("float64")
 
 
-class TestSvdNormalMatrix3x6(TestSvdCheckGrad2):
-    def generate_input(self):
-        """return a deterministic  matrix, the range matrix;
-        vander matrix must be a full rank matrix.
-        """
-        self._input_shape = (3, 6)
-        self._input_data = np.array(
-            [
-                [1.0, 2.0, 3.0],
-                [0.0, 1.0, 5.0],
-                [0.0, 0.0, 6.0],
-                [2.0, 4.0, 9.0],
-                [3.0, 6.0, 8.0],
-                [3.0, 1.0, 0.0],
-            ]
-        ).astype("float64")
-        self._input_data = self._input_data.transpose((-1, -2))
+# class TestSvdNormalMatrix6x3(TestSvdCheckGrad2):
+#     def generate_input(self):
+#         """return a deterministic  matrix, the range matrix;
+#         vander matrix must be a full rank matrix.
+#         """
+#         self._input_shape = (6, 3)
+#         self._input_data = np.array(
+#             [
+#                 [1.0, 2.0, 3.0],
+#                 [0.0, 1.0, 5.0],
+#                 [0.0, 0.0, 6.0],
+#                 [2.0, 4.0, 9.0],
+#                 [3.0, 6.0, 8.0],
+#                 [3.0, 1.0, 0.0],
+#             ]
+#         ).astype("float64")
 
 
-class TestSvdNormalMatrix6x3Batched(TestSvdOp):
-    def generate_input(self):
-        self._input_shape = (10, 6, 3)
-        self._input_data = np.array(
-            [
-                [1.0, 2.0, 3.0],
-                [0.0, 1.0, 5.0],
-                [0.0, 0.0, 6.0],
-                [2.0, 4.0, 9.0],
-                [3.0, 6.0, 8.0],
-                [3.0, 1.0, 0.0],
-            ]
-        ).astype("float64")
-        self._input_data = np.stack([self._input_data] * 10, axis=0)
-
-    def test_svd_forward(self):
-        """test_svd_forward not support batched input, so disable this test."""
-        pass
-
-
-class TestSvdNormalMatrix3x6Batched(TestSvdOp):
-    def generate_input(self):
-        """return a deterministic  matrix, the range matrix;
-        vander matrix must be a full rank matrix.
-        """
-        self._input_shape = (10, 3, 6)
-        self._input_data = np.array(
-            [
-                [1.0, 2.0, 3.0],
-                [0.0, 1.0, 5.0],
-                [0.0, 0.0, 6.0],
-                [2.0, 4.0, 9.0],
-                [3.0, 6.0, 8.0],
-                [3.0, 1.0, 0.0],
-            ]
-        ).astype("float64")
-        self._input_data = self._input_data.transpose((-1, -2))
-        self._input_data = np.stack([self._input_data] * 10, axis=0)
-
-    def test_svd_forward(self):
-        """test_svd_forward not support batched input, so disable this test."""
-        pass
+# class TestSvdNormalMatrix3x6(TestSvdCheckGrad2):
+#     def generate_input(self):
+#         """return a deterministic  matrix, the range matrix;
+#         vander matrix must be a full rank matrix.
+#         """
+#         self._input_shape = (3, 6)
+#         self._input_data = np.array(
+#             [
+#                 [1.0, 2.0, 3.0],
+#                 [0.0, 1.0, 5.0],
+#                 [0.0, 0.0, 6.0],
+#                 [2.0, 4.0, 9.0],
+#                 [3.0, 6.0, 8.0],
+#                 [3.0, 1.0, 0.0],
+#             ]
+#         ).astype("float64")
+#         self._input_data = self._input_data.transpose((-1, -2))
 
 
-class TestSvdNormalMatrix3x3x3x6Batched(TestSvdOp):
-    def generate_input(self):
-        """return a deterministic  matrix, the range matrix;
-        vander matrix must be a full rank matrix.
-        """
-        self._input_shape = (3, 3, 3, 6)
-        self._input_data = np.array(
-            [
-                [1.0, 2.0, 3.0],
-                [0.0, 1.0, 5.0],
-                [0.0, 0.0, 6.0],
-                [2.0, 4.0, 9.0],
-                [3.0, 6.0, 8.0],
-                [3.0, 1.0, 0.0],
-            ]
-        ).astype("float64")
-        self._input_data = self._input_data.transpose((-1, -2))
-        self._input_data = np.stack(
-            [self._input_data, self._input_data, self._input_data], axis=0
-        )
-        self._input_data = np.stack(
-            [self._input_data, self._input_data, self._input_data], axis=0
-        )
+# class TestSvdNormalMatrix6x3Batched(TestSvdOp):
+#     def generate_input(self):
+#         self._input_shape = (10, 6, 3)
+#         self._input_data = np.array(
+#             [
+#                 [1.0, 2.0, 3.0],
+#                 [0.0, 1.0, 5.0],
+#                 [0.0, 0.0, 6.0],
+#                 [2.0, 4.0, 9.0],
+#                 [3.0, 6.0, 8.0],
+#                 [3.0, 1.0, 0.0],
+#             ]
+#         ).astype("float64")
+#         self._input_data = np.stack([self._input_data] * 10, axis=0)
 
-    def test_svd_forward(self):
-        """test_svd_forward not support batched input, so disable this test."""
-        pass
+#     def test_svd_forward(self):
+#         """test_svd_forward not support batched input, so disable this test."""
+#         pass
 
 
-@skip_check_grad_ci(
-    reason="'check_grad' on large inputs is too slow, "
-    + "however it is desirable to cover the forward pass"
-)
-class TestSvdNormalMatrixBig(TestSvdOp):
-    def generate_input(self):
-        """big matrix SVD."""
-        self._input_shape = (2, 200, 300)
-        self._input_data = np.random.random(self._input_shape).astype("float64")
+# class TestSvdNormalMatrix3x6Batched(TestSvdOp):
+#     def generate_input(self):
+#         """return a deterministic  matrix, the range matrix;
+#         vander matrix must be a full rank matrix.
+#         """
+#         self._input_shape = (10, 3, 6)
+#         self._input_data = np.array(
+#             [
+#                 [1.0, 2.0, 3.0],
+#                 [0.0, 1.0, 5.0],
+#                 [0.0, 0.0, 6.0],
+#                 [2.0, 4.0, 9.0],
+#                 [3.0, 6.0, 8.0],
+#                 [3.0, 1.0, 0.0],
+#             ]
+#         ).astype("float64")
+#         self._input_data = self._input_data.transpose((-1, -2))
+#         self._input_data = np.stack([self._input_data] * 10, axis=0)
 
-    def test_svd_forward(self):
-        """test_svd_forward not support batched input, so disable this test."""
-        pass
-
-    def test_check_grad(self):
-        pass
+#     def test_svd_forward(self):
+#         """test_svd_forward not support batched input, so disable this test."""
+#         pass
 
 
-class TestSvdNormalMatrixBig2(TestSvdOp):
-    def generate_input(self):
-        """big matrix SVD."""
-        self._input_shape = (1, 100)
-        self._input_data = np.random.random(self._input_shape).astype("float64")
+# class TestSvdNormalMatrix3x3x3x6Batched(TestSvdOp):
+#     def generate_input(self):
+#         """return a deterministic  matrix, the range matrix;
+#         vander matrix must be a full rank matrix.
+#         """
+#         self._input_shape = (3, 3, 3, 6)
+#         self._input_data = np.array(
+#             [
+#                 [1.0, 2.0, 3.0],
+#                 [0.0, 1.0, 5.0],
+#                 [0.0, 0.0, 6.0],
+#                 [2.0, 4.0, 9.0],
+#                 [3.0, 6.0, 8.0],
+#                 [3.0, 1.0, 0.0],
+#             ]
+#         ).astype("float64")
+#         self._input_data = self._input_data.transpose((-1, -2))
+#         self._input_data = np.stack(
+#             [self._input_data, self._input_data, self._input_data], axis=0
+#         )
+#         self._input_data = np.stack(
+#             [self._input_data, self._input_data, self._input_data], axis=0
+#         )
+
+#     def test_svd_forward(self):
+#         """test_svd_forward not support batched input, so disable this test."""
+#         pass
 
 
-class TestSvdNormalMatrixFullMatrices(unittest.TestCase):
+# @skip_check_grad_ci(
+#     reason="'check_grad' on large inputs is too slow, "
+#     + "however it is desirable to cover the forward pass"
+# )
+# class TestSvdNormalMatrixBig(TestSvdOp):
+#     def generate_input(self):
+#         """big matrix SVD."""
+#         self._input_shape = (2, 200, 300)
+#         self._input_data = np.random.random(self._input_shape).astype("float64")
+
+#     def test_svd_forward(self):
+#         """test_svd_forward not support batched input, so disable this test."""
+#         pass
+
+#     def test_check_grad(self):
+#         pass
+
+
+# class TestSvdNormalMatrixBig2(TestSvdOp):
+#     def generate_input(self):
+#         """big matrix SVD."""
+#         self._input_shape = (1, 100)
+#         self._input_data = np.random.random(self._input_shape).astype("float64")
+
+
+# class TestSvdNormalMatrixFullMatrices(unittest.TestCase):
+#     def setUp(self):
+#         paddle.disable_static()
+
+#     def tearDown(self):
+#         paddle.enable_static()
+
+#     def test_full_matrices(self):
+#         mat_shape = (2, 3)
+#         mat = np.random.random(mat_shape).astype("float64")
+#         x = paddle.to_tensor(mat)
+#         u, s, vh = paddle.linalg.svd(x, full_matrices=True)
+#         assert u.shape == [2, 2]
+#         assert vh.shape == [3, 3]
+#         x_recover = u.matmul(paddle.diag(s)).matmul(vh[0:2])
+#         if (paddle.abs(x_recover - x) > 1e-4).any():
+#             raise RuntimeError("mat can't be recovered\n")
+
+
+# class TestSvdFullMatriceGrad(TestSvdNormalMatrix6x3):
+#     def get_full_matrices_option(self):
+#         return True
+
+#     def test_svd_forward(self):
+#         """test_svd_forward not support full matrices, so disable this test."""
+#         pass
+
+#     def test_check_grad(self):
+#         """
+#         remember the input matrix must be the full rank matrix, otherwise the gradient will stochatic because the u / v 's  (n-k) freedom  vectors
+#         """
+#         self.check_S_grad()
+#         # self.check_U_grad() // don't check U grad, because U have freedom vector
+#         self.check_V_grad()
+
+
+# class TestSvdAPI(unittest.TestCase):
+#     def test_dygraph(self):
+#         def run_svd_dygraph(shape, dtype):
+#             if dtype == "float32":
+#                 np_dtype = np.float32
+#             elif dtype == "float64":
+#                 np_dtype = np.float64
+#             elif dtype == "complex64":
+#                 np_dtype = np.complex64
+#             elif dtype == "complex128":
+#                 np_dtype = np.complex128
+#             if np.issubdtype(np_dtype, np.complexfloating):
+#                 a_dtype = np.float32 if np_dtype == np.complex64 else np.float64
+#                 a_real = np.random.rand(*shape).astype(a_dtype)
+#                 a_imag = np.random.rand(*shape).astype(a_dtype)
+#                 a = a_real + 1j * a_imag
+#             else:
+#                 a = np.random.rand(*shape).astype(np_dtype)
+
+#             places = []
+#             places.append(base.CPUPlace())
+#             if core.is_compiled_with_cuda():
+#                 places.append(base.CUDAPlace(0))
+#             for place in places:
+#                 x = paddle.to_tensor(a, place=place)
+#                 u, s, vh = paddle.linalg.svd(x)
+#                 gt_u, gt_s, gt_vh = np.linalg.svd(a, full_matrices=False)
+#                 np.testing.assert_allclose(s, gt_s, rtol=1e-05)
+
+#         with dygraph_guard():
+#             np.random.seed(7)
+#             tensor_shapes = [
+#                 (0, 3),
+#                 (3, 5),
+#                 (5, 5),
+#                 (5, 3),  # 2-dim Tensors
+#                 (0, 3, 5),
+#                 (4, 0, 5),
+#                 (5, 4, 0),
+#                 (4, 5, 3),  # 3-dim Tensors
+#                 (0, 5, 3, 5),
+#                 (2, 5, 3, 5),
+#                 (3, 5, 5, 5),
+#                 (4, 5, 5, 3),  # 4-dim Tensors
+#             ]
+#             dtypes = ["float32", "float64", 'complex64', 'complex128']
+#             for tensor_shape, dtype in itertools.product(tensor_shapes, dtypes):
+#                 run_svd_dygraph(tensor_shape, dtype)
+
+#     def test_static(self):
+#         def run_svd_static(shape, dtype):
+#             if dtype == "float32":
+#                 np_dtype = np.float32
+#             elif dtype == "float64":
+#                 np_dtype = np.float64
+#             elif dtype == "complex64":
+#                 np_dtype = np.complex64
+#             elif dtype == "complex128":
+#                 np_dtype = np.complex128
+#             if np.issubdtype(np_dtype, np.complexfloating):
+#                 a_dtype = np.float32 if np_dtype == np.complex64 else np.float64
+#                 a_real = np.random.rand(*shape).astype(a_dtype)
+#                 a_imag = np.random.rand(*shape).astype(a_dtype)
+#                 a = a_real + 1j * a_imag
+#             else:
+#                 a = np.random.rand(*shape).astype(np_dtype)
+
+#             places = []
+#             places.append(base.CPUPlace())
+#             if core.is_compiled_with_cuda():
+#                 places.append(base.CUDAPlace(0))
+#             for place in places:
+#                 with paddle.static.program_guard(
+#                     paddle.static.Program(), paddle.static.Program()
+#                 ):
+#                     x = paddle.static.data(
+#                         name="input", shape=shape, dtype=dtype
+#                     )
+#                     u, s, vh = paddle.linalg.svd(x)
+#                     exe = paddle.static.Executor(place)
+#                     gt_u, gt_s, gt_vh = np.linalg.svd(a, full_matrices=False)
+#                     fetches = exe.run(
+#                         feed={"input": a},
+#                         fetch_list=[s],
+#                     )
+#                     np.testing.assert_allclose(fetches[0], gt_s, rtol=1e-05)
+
+#             with static_guard():
+#                 np.random.seed(7)
+#                 tensor_shapes = [
+#                     (0, 3),
+#                     (3, 5),
+#                     (5, 5),
+#                     (5, 3),  # 2-dim Tensors
+#                     (0, 3, 5),
+#                     (4, 0, 5),
+#                     (5, 4, 0),
+#                     (4, 5, 3),  # 3-dim Tensors
+#                     (0, 5, 3, 5),
+#                     (2, 5, 3, 5),
+#                     (3, 5, 5, 5),
+#                     (4, 5, 5, 3),  # 4-dim Tensors
+#                 ]
+#                 dtypes = ["float32", "float64", 'complex64', 'complex128']
+#                 for tensor_shape, dtype in itertools.product(
+#                     tensor_shapes, dtypes
+#                 ):
+#                     run_svd_static(tensor_shape, dtype)
+
+
+class SvdOutTest(unittest.TestCase):
     def setUp(self):
         paddle.disable_static()
+        if core.is_compiled_with_cuda():
+            self.place = core.CUDAPlace(0)
+        else:
+            self.place = core.CPUPlace()
 
-    def tearDown(self):
-        paddle.enable_static()
+    def test_svd_api(self):
+        def run_svd(test_type):
+            x = paddle.to_tensor(
+                [[1.0, 2.0], [1.0, 3.0], [4.0, 6.0]], dtype='float64'
+            )
+            a = paddle.ones([3, 2], dtype="float64")
+            b = paddle.ones([2], dtype="float64")
+            c = paddle.ones([2, 2], dtype="float64")
+            x.stop_gradient = False
+            a.stop_gradient = False
+            b.stop_gradient = False
+            c.stop_gradient = False
 
-    def test_full_matrices(self):
-        mat_shape = (2, 3)
-        mat = np.random.random(mat_shape).astype("float64")
-        x = paddle.to_tensor(mat)
-        u, s, vh = paddle.linalg.svd(x, full_matrices=True)
-        assert u.shape == [2, 2]
-        assert vh.shape == [3, 3]
-        x_recover = u.matmul(paddle.diag(s)).matmul(vh[0:2])
-        if (paddle.abs(x_recover - x) > 1e-4).any():
-            raise RuntimeError("mat can't be recovered\n")
+            input = x + x
+            u = a + a
+            s = b + b
+            vh = c + c
+            out = (u, s, vh)
 
+            if test_type == "return":
+                out = paddle.linalg.svd(input, False)
+            elif test_type == "input_out":
+                paddle.linalg.svd(input, False, out=out)
+            elif test_type == "both_return":
+                out = paddle.linalg.svd(input, False, out=out)
+            elif test_type == "both_input_out":
+                tmp = paddle.linalg.svd(input, False, out=out)
 
-class TestSvdFullMatriceGrad(TestSvdNormalMatrix6x3):
-    def get_full_matrices_option(self):
-        return True
+            ref_out = paddle._C_ops.svd(input, False)
+            np.testing.assert_allclose(
+                ref_out[0].numpy(),
+                out[0].numpy(),
+                1e-20,
+                1e-20,
+            )
+            np.testing.assert_allclose(
+                ref_out[1].numpy(),
+                out[1].numpy(),
+                1e-20,
+                1e-20,
+            )
+            np.testing.assert_allclose(
+                ref_out[2].numpy(),
+                out[2].numpy(),
+                1e-20,
+                1e-20,
+            )
 
-    def test_svd_forward(self):
-        """test_svd_forward not support full matrices, so disable this test."""
-        pass
+            out_0 = out[0] + out[0]
+            out_1 = out[1] + out[1]
+            out_2 = out[2] + out[2]
+            (
+                paddle.sum(paddle.abs(out_0))
+                + paddle.sum(paddle.abs(out_1))
+                + paddle.sum(paddle.abs(out_2))
+            ).backward()
 
-    def test_check_grad(self):
-        """
-        remember the input matrix must be the full rank matrix, otherwise the gradient will stochatic because the u / v 's  (n-k) freedom  vectors
-        """
-        self.check_S_grad()
-        # self.check_U_grad() // don't check U grad, because U have freedom vector
-        self.check_V_grad()
+            return out[0], out[1], out[2], x.grad, a.grad, b.grad, c.grad
 
+        paddle.disable_static()
+        u1, s1, vh1, gx1, ga1, gb1, gc1 = run_svd("return")
+        u2, s2, vh2, gx2, ga2, gb2, gc2 = run_svd("input_out")
+        u3, s3, vh3, gx3, ga3, gb3, gc3 = run_svd("both_return")
+        u4, s4, vh4, gx4, ga4, gb4, gc4 = run_svd("both_input_out")
 
-class TestSvdAPI(unittest.TestCase):
-    def test_dygraph(self):
-        def run_svd_dygraph(shape, dtype):
-            if dtype == "float32":
-                np_dtype = np.float32
-            elif dtype == "float64":
-                np_dtype = np.float64
-            elif dtype == "complex64":
-                np_dtype = np.complex64
-            elif dtype == "complex128":
-                np_dtype = np.complex128
-            if np.issubdtype(np_dtype, np.complexfloating):
-                a_dtype = np.float32 if np_dtype == np.complex64 else np.float64
-                a_real = np.random.rand(*shape).astype(a_dtype)
-                a_imag = np.random.rand(*shape).astype(a_dtype)
-                a = a_real + 1j * a_imag
-            else:
-                a = np.random.rand(*shape).astype(np_dtype)
+        np.testing.assert_allclose(
+            u1.numpy(),
+            u2.numpy(),
+            1e-20,
+            1e-20,
+        )
+        np.testing.assert_allclose(
+            u1.numpy(),
+            u3.numpy(),
+            1e-20,
+            1e-20,
+        )
+        np.testing.assert_allclose(
+            u1.numpy(),
+            u4.numpy(),
+            1e-20,
+            1e-20,
+        )
 
-            places = []
-            places.append(base.CPUPlace())
-            if core.is_compiled_with_cuda():
-                places.append(base.CUDAPlace(0))
-            for place in places:
-                x = paddle.to_tensor(a, place=place)
-                u, s, vh = paddle.linalg.svd(x)
-                gt_u, gt_s, gt_vh = np.linalg.svd(a, full_matrices=False)
-                np.testing.assert_allclose(s, gt_s, rtol=1e-05)
+        np.testing.assert_allclose(
+            s1.numpy(),
+            s2.numpy(),
+            1e-20,
+            1e-20,
+        )
+        np.testing.assert_allclose(
+            s1.numpy(),
+            s3.numpy(),
+            1e-20,
+            1e-20,
+        )
+        np.testing.assert_allclose(
+            s1.numpy(),
+            s4.numpy(),
+            1e-20,
+            1e-20,
+        )
 
-        with dygraph_guard():
-            np.random.seed(7)
-            tensor_shapes = [
-                (0, 3),
-                (3, 5),
-                (5, 5),
-                (5, 3),  # 2-dim Tensors
-                (0, 3, 5),
-                (4, 0, 5),
-                (5, 4, 0),
-                (4, 5, 3),  # 3-dim Tensors
-                (0, 5, 3, 5),
-                (2, 5, 3, 5),
-                (3, 5, 5, 5),
-                (4, 5, 5, 3),  # 4-dim Tensors
-            ]
-            dtypes = ["float32", "float64", 'complex64', 'complex128']
-            for tensor_shape, dtype in itertools.product(tensor_shapes, dtypes):
-                run_svd_dygraph(tensor_shape, dtype)
+        np.testing.assert_allclose(
+            vh1.numpy(),
+            vh2.numpy(),
+            1e-20,
+            1e-20,
+        )
+        np.testing.assert_allclose(
+            vh1.numpy(),
+            vh3.numpy(),
+            1e-20,
+            1e-20,
+        )
+        np.testing.assert_allclose(
+            vh1.numpy(),
+            vh4.numpy(),
+            1e-20,
+            1e-20,
+        )
 
-    def test_static(self):
-        def run_svd_static(shape, dtype):
-            if dtype == "float32":
-                np_dtype = np.float32
-            elif dtype == "float64":
-                np_dtype = np.float64
-            elif dtype == "complex64":
-                np_dtype = np.complex64
-            elif dtype == "complex128":
-                np_dtype = np.complex128
-            if np.issubdtype(np_dtype, np.complexfloating):
-                a_dtype = np.float32 if np_dtype == np.complex64 else np.float64
-                a_real = np.random.rand(*shape).astype(a_dtype)
-                a_imag = np.random.rand(*shape).astype(a_dtype)
-                a = a_real + 1j * a_imag
-            else:
-                a = np.random.rand(*shape).astype(np_dtype)
+        np.testing.assert_allclose(
+            gx1.numpy(),
+            gx2.numpy(),
+            1e-20,
+            1e-20,
+        )
+        np.testing.assert_allclose(
+            gx1.numpy(),
+            gx3.numpy(),
+            1e-20,
+            1e-20,
+        )
+        np.testing.assert_allclose(
+            gx1.numpy(),
+            gx4.numpy(),
+            1e-20,
+            1e-20,
+        )
 
-            places = []
-            places.append(base.CPUPlace())
-            if core.is_compiled_with_cuda():
-                places.append(base.CUDAPlace(0))
-            for place in places:
-                with paddle.static.program_guard(
-                    paddle.static.Program(), paddle.static.Program()
-                ):
-                    x = paddle.static.data(
-                        name="input", shape=shape, dtype=dtype
-                    )
-                    u, s, vh = paddle.linalg.svd(x)
-                    exe = paddle.static.Executor(place)
-                    gt_u, gt_s, gt_vh = np.linalg.svd(a, full_matrices=False)
-                    fetches = exe.run(
-                        feed={"input": a},
-                        fetch_list=[s],
-                    )
-                    np.testing.assert_allclose(fetches[0], gt_s, rtol=1e-05)
-
-            with static_guard():
-                np.random.seed(7)
-                tensor_shapes = [
-                    (0, 3),
-                    (3, 5),
-                    (5, 5),
-                    (5, 3),  # 2-dim Tensors
-                    (0, 3, 5),
-                    (4, 0, 5),
-                    (5, 4, 0),
-                    (4, 5, 3),  # 3-dim Tensors
-                    (0, 5, 3, 5),
-                    (2, 5, 3, 5),
-                    (3, 5, 5, 5),
-                    (4, 5, 5, 3),  # 4-dim Tensors
-                ]
-                dtypes = ["float32", "float64", 'complex64', 'complex128']
-                for tensor_shape, dtype in itertools.product(
-                    tensor_shapes, dtypes
-                ):
-                    run_svd_static(tensor_shape, dtype)
+        np.testing.assert_equal(ga1, None)
+        np.testing.assert_equal(ga2, None)
+        np.testing.assert_equal(ga3, None)
+        np.testing.assert_equal(ga4, None)
+        np.testing.assert_equal(gb1, None)
+        np.testing.assert_equal(gb2, None)
+        np.testing.assert_equal(gb3, None)
+        np.testing.assert_equal(gb4, None)
+        np.testing.assert_equal(gc1, None)
+        np.testing.assert_equal(gc2, None)
+        np.testing.assert_equal(gc3, None)
+        np.testing.assert_equal(gc4, None)
 
 
 if __name__ == "__main__":

--- a/test/legacy_test/test_svd_op.py
+++ b/test/legacy_test/test_svd_op.py
@@ -12,456 +12,461 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import itertools
 import unittest
 
 import numpy as np
+from op_test import OpTest, skip_check_grad_ci
+from utils import dygraph_guard, static_guard
 
 import paddle
+from paddle import base
 from paddle.base import core
 
-# class TestSvdOp(OpTest):
-#     def setUp(self):
-#         with static_guard():
-#             self.python_api = paddle.linalg.svd
-#             self.generate_input()
-#             self.generate_output()
-#             self.op_type = "svd"
-#             assert hasattr(self, "_output_data")
-#             self.inputs = {"X": self._input_data}
-#             self.attrs = {'full_matrices': self.get_full_matrices_option()}
-#             self.outputs = {
-#                 "U": self._output_data[0],
-#                 "S": self._output_data[1],
-#                 "VH": self._output_data[2],
-#             }
 
-#     def _get_places(self):
-#         places = [base.CPUPlace()]
-#         if core.is_compiled_with_cuda():
-#             places.append(base.CUDAPlace(0))
-#         return places
+class TestSvdOp(OpTest):
+    def setUp(self):
+        with static_guard():
+            self.python_api = paddle.linalg.svd
+            self.generate_input()
+            self.generate_output()
+            self.op_type = "svd"
+            assert hasattr(self, "_output_data")
+            self.inputs = {"X": self._input_data}
+            self.attrs = {'full_matrices': self.get_full_matrices_option()}
+            self.outputs = {
+                "U": self._output_data[0],
+                "S": self._output_data[1],
+                "VH": self._output_data[2],
+            }
 
-#     def generate_input(self):
-#         """return a input_data and input_shape"""
-#         self._input_shape = (100, 1)
-#         self._input_data = np.random.random(self._input_shape).astype("float64")
+    def _get_places(self):
+        places = [base.CPUPlace()]
+        if core.is_compiled_with_cuda():
+            places.append(base.CUDAPlace(0))
+        return places
 
-#     def get_full_matrices_option(self):
-#         return False
+    def generate_input(self):
+        """return a input_data and input_shape"""
+        self._input_shape = (100, 1)
+        self._input_data = np.random.random(self._input_shape).astype("float64")
 
-#     def generate_output(self):
-#         assert hasattr(self, "_input_data")
-#         self._output_data = np.linalg.svd(self._input_data)
+    def get_full_matrices_option(self):
+        return False
 
-#     def test_check_output(self):
-#         self.check_output(no_check_set=['U', 'VH'], check_pir=True)
+    def generate_output(self):
+        assert hasattr(self, "_input_data")
+        self._output_data = np.linalg.svd(self._input_data)
 
-#     def test_svd_forward(self):
-#         """u matmul diag(s) matmul vt must become X"""
-#         single_input = self._input_data.reshape(
-#             [-1, self._input_shape[-2], self._input_shape[-1]]
-#         )[0]
-#         with dygraph_guard():
-#             dy_x = paddle.to_tensor(single_input)
-#             dy_u, dy_s, dy_vt = paddle.linalg.svd(dy_x)
-#             dy_out_x = dy_u.matmul(paddle.diag(dy_s)).matmul(dy_vt)
-#             if (paddle.abs(dy_out_x - dy_x) < 1e-5).all():
-#                 ...
-#             else:
-#                 raise RuntimeError("Check SVD Failed")
+    def test_check_output(self):
+        self.check_output(no_check_set=['U', 'VH'], check_pir=True)
 
-#     def check_S_grad(self):
-#         self.check_grad(['X'], ['S'], numeric_grad_delta=0.001, check_pir=True)
+    def test_svd_forward(self):
+        """u matmul diag(s) matmul vt must become X"""
+        single_input = self._input_data.reshape(
+            [-1, self._input_shape[-2], self._input_shape[-1]]
+        )[0]
+        with dygraph_guard():
+            dy_x = paddle.to_tensor(single_input)
+            dy_u, dy_s, dy_vt = paddle.linalg.svd(dy_x)
+            dy_out_x = dy_u.matmul(paddle.diag(dy_s)).matmul(dy_vt)
+            if (paddle.abs(dy_out_x - dy_x) < 1e-5).all():
+                ...
+            else:
+                raise RuntimeError("Check SVD Failed")
 
-#     def check_U_grad(self):
-#         self.check_grad(['X'], ['U'], numeric_grad_delta=0.001, check_pir=True)
+    def check_S_grad(self):
+        self.check_grad(['X'], ['S'], numeric_grad_delta=0.001, check_pir=True)
 
-#     def check_V_grad(self):
-#         self.check_grad(['X'], ['VH'], numeric_grad_delta=0.001, check_pir=True)
+    def check_U_grad(self):
+        self.check_grad(['X'], ['U'], numeric_grad_delta=0.001, check_pir=True)
 
-#     def test_check_grad(self):
-#         """
-#         remember the input matrix must be the full rank matrix, otherwise the gradient will stochatic because the u / v 's  (n-k) freedom  vectors
-#         """
-#         self.check_S_grad()
-#         self.check_U_grad()
-#         self.check_V_grad()
+    def check_V_grad(self):
+        self.check_grad(['X'], ['VH'], numeric_grad_delta=0.001, check_pir=True)
 
-
-# @unittest.skipIf(
-#     core.is_compiled_with_xpu(),
-#     "Skip XPU for complex dtype is not fully supported",
-# )
-# class TestSvdOpComplexCase1(TestSvdOp):
-#     def generate_input(self):
-#         """return a input_data and input_shape"""
-#         self._input_shape = (5, 3)
-#         real_part = np.random.rand(*self._input_shape).astype("float32")
-#         imag_part = np.random.rand(*self._input_shape).astype("float32")
-#         self._input_data = real_part + 1j * imag_part
-
-#     def test_check_grad(self):
-#         places = self._get_places()
-#         with dygraph_guard():
-#             for place in places:
-#                 x = paddle.to_tensor(
-#                     self._input_data, place=place, stop_gradient=False
-#                 )
-#                 U, s, Vh = paddle.linalg.svd(x, self.get_full_matrices_option())
-#                 loss = (
-#                     paddle.sum(paddle.abs(U))
-#                     + paddle.sum(paddle.abs(s))
-#                     + paddle.sum(paddle.abs(Vh))
-#                 )
-#                 x_grad = paddle.grad(outputs=[loss], inputs=[x])
+    def test_check_grad(self):
+        """
+        remember the input matrix must be the full rank matrix, otherwise the gradient will stochatic because the u / v 's  (n-k) freedom  vectors
+        """
+        self.check_S_grad()
+        self.check_U_grad()
+        self.check_V_grad()
 
 
-# @unittest.skipIf(
-#     core.is_compiled_with_xpu(),
-#     "Skip XPU for complex dtype is not fully supported",
-# )
-# class TestSvdOpComplexCase2(TestSvdOpComplexCase1):
-#     def generate_input(self):
-#         """return a input_data and input_shape"""
-#         self._input_shape = (3, 30)
-#         real_part = np.random.rand(*self._input_shape).astype("float32")
-#         imag_part = np.random.rand(*self._input_shape).astype("float32")
-#         self._input_data = real_part + 1j * imag_part
+@unittest.skipIf(
+    core.is_compiled_with_xpu(),
+    "Skip XPU for complex dtype is not fully supported",
+)
+class TestSvdOpComplexCase1(TestSvdOp):
+    def generate_input(self):
+        """return a input_data and input_shape"""
+        self._input_shape = (5, 3)
+        real_part = np.random.rand(*self._input_shape).astype("float32")
+        imag_part = np.random.rand(*self._input_shape).astype("float32")
+        self._input_data = real_part + 1j * imag_part
+
+    def test_check_grad(self):
+        places = self._get_places()
+        with dygraph_guard():
+            for place in places:
+                x = paddle.to_tensor(
+                    self._input_data, place=place, stop_gradient=False
+                )
+                U, s, Vh = paddle.linalg.svd(x, self.get_full_matrices_option())
+                loss = (
+                    paddle.sum(paddle.abs(U))
+                    + paddle.sum(paddle.abs(s))
+                    + paddle.sum(paddle.abs(Vh))
+                )
+                x_grad = paddle.grad(outputs=[loss], inputs=[x])
 
 
-# @unittest.skipIf(
-#     core.is_compiled_with_xpu(),
-#     "Skip XPU for complex dtype is not fully supported",
-# )
-# class TestSvdOpComplexCase3(TestSvdOpComplexCase1):
-#     def generate_input(self):
-#         """return a input_data and input_shape"""
-#         self._input_shape = (100, 40)
-#         real_part = np.random.rand(*self._input_shape).astype("float64")
-#         imag_part = np.random.rand(*self._input_shape).astype("float64")
-#         self._input_data = real_part + 1j * imag_part
+@unittest.skipIf(
+    core.is_compiled_with_xpu(),
+    "Skip XPU for complex dtype is not fully supported",
+)
+class TestSvdOpComplexCase2(TestSvdOpComplexCase1):
+    def generate_input(self):
+        """return a input_data and input_shape"""
+        self._input_shape = (3, 30)
+        real_part = np.random.rand(*self._input_shape).astype("float32")
+        imag_part = np.random.rand(*self._input_shape).astype("float32")
+        self._input_data = real_part + 1j * imag_part
 
 
-# @unittest.skipIf(
-#     core.is_compiled_with_xpu(),
-#     "Skip XPU for complex dtype is not fully supported",
-# )
-# class TestSvdOpComplexCase4(TestSvdOpComplexCase1):
-#     def generate_input(self):
-#         """return a input_data and input_shape"""
-#         self._input_shape = (100, 200)
-#         real_part = np.random.rand(*self._input_shape).astype("float64")
-#         imag_part = np.random.rand(*self._input_shape).astype("float64")
-#         self._input_data = real_part + 1j * imag_part
-
-#     def get_full_matrices_option(self):
-#         return True
+@unittest.skipIf(
+    core.is_compiled_with_xpu(),
+    "Skip XPU for complex dtype is not fully supported",
+)
+class TestSvdOpComplexCase3(TestSvdOpComplexCase1):
+    def generate_input(self):
+        """return a input_data and input_shape"""
+        self._input_shape = (100, 40)
+        real_part = np.random.rand(*self._input_shape).astype("float64")
+        imag_part = np.random.rand(*self._input_shape).astype("float64")
+        self._input_data = real_part + 1j * imag_part
 
 
-# class TestSvdCheckGrad2(TestSvdOp):
-#     # NOTE(xiongkun03): because we want to construct some full rank matrices,
-#     #                   so we can't specifize matrices which numel() > 100
+@unittest.skipIf(
+    core.is_compiled_with_xpu(),
+    "Skip XPU for complex dtype is not fully supported",
+)
+class TestSvdOpComplexCase4(TestSvdOpComplexCase1):
+    def generate_input(self):
+        """return a input_data and input_shape"""
+        self._input_shape = (100, 200)
+        real_part = np.random.rand(*self._input_shape).astype("float64")
+        imag_part = np.random.rand(*self._input_shape).astype("float64")
+        self._input_data = real_part + 1j * imag_part
 
-#     no_need_check_grad = True
-
-#     def generate_input(self):
-#         """return a deterministic  matrix, the range matrix;
-#         vander matrix must be a full rank matrix.
-#         """
-#         self._input_shape = (5, 5)
-#         self._input_data = (
-#             np.vander([2, 3, 4, 5, 6])
-#             .astype("float64")
-#             .reshape(self._input_shape)
-#         )
+    def get_full_matrices_option(self):
+        return True
 
 
-# class TestSvdNormalMatrixSmall(TestSvdCheckGrad2):
-#     def generate_input(self):
-#         """small matrix SVD."""
-#         self._input_shape = (1, 1)
-#         self._input_data = np.random.random(self._input_shape).astype("float64")
+class TestSvdCheckGrad2(TestSvdOp):
+    # NOTE(xiongkun03): because we want to construct some full rank matrices,
+    #                   so we can't specifize matrices which numel() > 100
+
+    no_need_check_grad = True
+
+    def generate_input(self):
+        """return a deterministic  matrix, the range matrix;
+        vander matrix must be a full rank matrix.
+        """
+        self._input_shape = (5, 5)
+        self._input_data = (
+            np.vander([2, 3, 4, 5, 6])
+            .astype("float64")
+            .reshape(self._input_shape)
+        )
 
 
-# class TestSvdNormalMatrix6x3(TestSvdCheckGrad2):
-#     def generate_input(self):
-#         """return a deterministic  matrix, the range matrix;
-#         vander matrix must be a full rank matrix.
-#         """
-#         self._input_shape = (6, 3)
-#         self._input_data = np.array(
-#             [
-#                 [1.0, 2.0, 3.0],
-#                 [0.0, 1.0, 5.0],
-#                 [0.0, 0.0, 6.0],
-#                 [2.0, 4.0, 9.0],
-#                 [3.0, 6.0, 8.0],
-#                 [3.0, 1.0, 0.0],
-#             ]
-#         ).astype("float64")
+class TestSvdNormalMatrixSmall(TestSvdCheckGrad2):
+    def generate_input(self):
+        """small matrix SVD."""
+        self._input_shape = (1, 1)
+        self._input_data = np.random.random(self._input_shape).astype("float64")
 
 
-# class TestSvdNormalMatrix3x6(TestSvdCheckGrad2):
-#     def generate_input(self):
-#         """return a deterministic  matrix, the range matrix;
-#         vander matrix must be a full rank matrix.
-#         """
-#         self._input_shape = (3, 6)
-#         self._input_data = np.array(
-#             [
-#                 [1.0, 2.0, 3.0],
-#                 [0.0, 1.0, 5.0],
-#                 [0.0, 0.0, 6.0],
-#                 [2.0, 4.0, 9.0],
-#                 [3.0, 6.0, 8.0],
-#                 [3.0, 1.0, 0.0],
-#             ]
-#         ).astype("float64")
-#         self._input_data = self._input_data.transpose((-1, -2))
+class TestSvdNormalMatrix6x3(TestSvdCheckGrad2):
+    def generate_input(self):
+        """return a deterministic  matrix, the range matrix;
+        vander matrix must be a full rank matrix.
+        """
+        self._input_shape = (6, 3)
+        self._input_data = np.array(
+            [
+                [1.0, 2.0, 3.0],
+                [0.0, 1.0, 5.0],
+                [0.0, 0.0, 6.0],
+                [2.0, 4.0, 9.0],
+                [3.0, 6.0, 8.0],
+                [3.0, 1.0, 0.0],
+            ]
+        ).astype("float64")
 
 
-# class TestSvdNormalMatrix6x3Batched(TestSvdOp):
-#     def generate_input(self):
-#         self._input_shape = (10, 6, 3)
-#         self._input_data = np.array(
-#             [
-#                 [1.0, 2.0, 3.0],
-#                 [0.0, 1.0, 5.0],
-#                 [0.0, 0.0, 6.0],
-#                 [2.0, 4.0, 9.0],
-#                 [3.0, 6.0, 8.0],
-#                 [3.0, 1.0, 0.0],
-#             ]
-#         ).astype("float64")
-#         self._input_data = np.stack([self._input_data] * 10, axis=0)
-
-#     def test_svd_forward(self):
-#         """test_svd_forward not support batched input, so disable this test."""
-#         pass
-
-
-# class TestSvdNormalMatrix3x6Batched(TestSvdOp):
-#     def generate_input(self):
-#         """return a deterministic  matrix, the range matrix;
-#         vander matrix must be a full rank matrix.
-#         """
-#         self._input_shape = (10, 3, 6)
-#         self._input_data = np.array(
-#             [
-#                 [1.0, 2.0, 3.0],
-#                 [0.0, 1.0, 5.0],
-#                 [0.0, 0.0, 6.0],
-#                 [2.0, 4.0, 9.0],
-#                 [3.0, 6.0, 8.0],
-#                 [3.0, 1.0, 0.0],
-#             ]
-#         ).astype("float64")
-#         self._input_data = self._input_data.transpose((-1, -2))
-#         self._input_data = np.stack([self._input_data] * 10, axis=0)
-
-#     def test_svd_forward(self):
-#         """test_svd_forward not support batched input, so disable this test."""
-#         pass
+class TestSvdNormalMatrix3x6(TestSvdCheckGrad2):
+    def generate_input(self):
+        """return a deterministic  matrix, the range matrix;
+        vander matrix must be a full rank matrix.
+        """
+        self._input_shape = (3, 6)
+        self._input_data = np.array(
+            [
+                [1.0, 2.0, 3.0],
+                [0.0, 1.0, 5.0],
+                [0.0, 0.0, 6.0],
+                [2.0, 4.0, 9.0],
+                [3.0, 6.0, 8.0],
+                [3.0, 1.0, 0.0],
+            ]
+        ).astype("float64")
+        self._input_data = self._input_data.transpose((-1, -2))
 
 
-# class TestSvdNormalMatrix3x3x3x6Batched(TestSvdOp):
-#     def generate_input(self):
-#         """return a deterministic  matrix, the range matrix;
-#         vander matrix must be a full rank matrix.
-#         """
-#         self._input_shape = (3, 3, 3, 6)
-#         self._input_data = np.array(
-#             [
-#                 [1.0, 2.0, 3.0],
-#                 [0.0, 1.0, 5.0],
-#                 [0.0, 0.0, 6.0],
-#                 [2.0, 4.0, 9.0],
-#                 [3.0, 6.0, 8.0],
-#                 [3.0, 1.0, 0.0],
-#             ]
-#         ).astype("float64")
-#         self._input_data = self._input_data.transpose((-1, -2))
-#         self._input_data = np.stack(
-#             [self._input_data, self._input_data, self._input_data], axis=0
-#         )
-#         self._input_data = np.stack(
-#             [self._input_data, self._input_data, self._input_data], axis=0
-#         )
+class TestSvdNormalMatrix6x3Batched(TestSvdOp):
+    def generate_input(self):
+        self._input_shape = (10, 6, 3)
+        self._input_data = np.array(
+            [
+                [1.0, 2.0, 3.0],
+                [0.0, 1.0, 5.0],
+                [0.0, 0.0, 6.0],
+                [2.0, 4.0, 9.0],
+                [3.0, 6.0, 8.0],
+                [3.0, 1.0, 0.0],
+            ]
+        ).astype("float64")
+        self._input_data = np.stack([self._input_data] * 10, axis=0)
 
-#     def test_svd_forward(self):
-#         """test_svd_forward not support batched input, so disable this test."""
-#         pass
+    def test_svd_forward(self):
+        """test_svd_forward not support batched input, so disable this test."""
+        pass
 
 
-# @skip_check_grad_ci(
-#     reason="'check_grad' on large inputs is too slow, "
-#     + "however it is desirable to cover the forward pass"
-# )
-# class TestSvdNormalMatrixBig(TestSvdOp):
-#     def generate_input(self):
-#         """big matrix SVD."""
-#         self._input_shape = (2, 200, 300)
-#         self._input_data = np.random.random(self._input_shape).astype("float64")
+class TestSvdNormalMatrix3x6Batched(TestSvdOp):
+    def generate_input(self):
+        """return a deterministic  matrix, the range matrix;
+        vander matrix must be a full rank matrix.
+        """
+        self._input_shape = (10, 3, 6)
+        self._input_data = np.array(
+            [
+                [1.0, 2.0, 3.0],
+                [0.0, 1.0, 5.0],
+                [0.0, 0.0, 6.0],
+                [2.0, 4.0, 9.0],
+                [3.0, 6.0, 8.0],
+                [3.0, 1.0, 0.0],
+            ]
+        ).astype("float64")
+        self._input_data = self._input_data.transpose((-1, -2))
+        self._input_data = np.stack([self._input_data] * 10, axis=0)
 
-#     def test_svd_forward(self):
-#         """test_svd_forward not support batched input, so disable this test."""
-#         pass
-
-#     def test_check_grad(self):
-#         pass
-
-
-# class TestSvdNormalMatrixBig2(TestSvdOp):
-#     def generate_input(self):
-#         """big matrix SVD."""
-#         self._input_shape = (1, 100)
-#         self._input_data = np.random.random(self._input_shape).astype("float64")
-
-
-# class TestSvdNormalMatrixFullMatrices(unittest.TestCase):
-#     def setUp(self):
-#         paddle.disable_static()
-
-#     def tearDown(self):
-#         paddle.enable_static()
-
-#     def test_full_matrices(self):
-#         mat_shape = (2, 3)
-#         mat = np.random.random(mat_shape).astype("float64")
-#         x = paddle.to_tensor(mat)
-#         u, s, vh = paddle.linalg.svd(x, full_matrices=True)
-#         assert u.shape == [2, 2]
-#         assert vh.shape == [3, 3]
-#         x_recover = u.matmul(paddle.diag(s)).matmul(vh[0:2])
-#         if (paddle.abs(x_recover - x) > 1e-4).any():
-#             raise RuntimeError("mat can't be recovered\n")
+    def test_svd_forward(self):
+        """test_svd_forward not support batched input, so disable this test."""
+        pass
 
 
-# class TestSvdFullMatriceGrad(TestSvdNormalMatrix6x3):
-#     def get_full_matrices_option(self):
-#         return True
+class TestSvdNormalMatrix3x3x3x6Batched(TestSvdOp):
+    def generate_input(self):
+        """return a deterministic  matrix, the range matrix;
+        vander matrix must be a full rank matrix.
+        """
+        self._input_shape = (3, 3, 3, 6)
+        self._input_data = np.array(
+            [
+                [1.0, 2.0, 3.0],
+                [0.0, 1.0, 5.0],
+                [0.0, 0.0, 6.0],
+                [2.0, 4.0, 9.0],
+                [3.0, 6.0, 8.0],
+                [3.0, 1.0, 0.0],
+            ]
+        ).astype("float64")
+        self._input_data = self._input_data.transpose((-1, -2))
+        self._input_data = np.stack(
+            [self._input_data, self._input_data, self._input_data], axis=0
+        )
+        self._input_data = np.stack(
+            [self._input_data, self._input_data, self._input_data], axis=0
+        )
 
-#     def test_svd_forward(self):
-#         """test_svd_forward not support full matrices, so disable this test."""
-#         pass
-
-#     def test_check_grad(self):
-#         """
-#         remember the input matrix must be the full rank matrix, otherwise the gradient will stochatic because the u / v 's  (n-k) freedom  vectors
-#         """
-#         self.check_S_grad()
-#         # self.check_U_grad() // don't check U grad, because U have freedom vector
-#         self.check_V_grad()
+    def test_svd_forward(self):
+        """test_svd_forward not support batched input, so disable this test."""
+        pass
 
 
-# class TestSvdAPI(unittest.TestCase):
-#     def test_dygraph(self):
-#         def run_svd_dygraph(shape, dtype):
-#             if dtype == "float32":
-#                 np_dtype = np.float32
-#             elif dtype == "float64":
-#                 np_dtype = np.float64
-#             elif dtype == "complex64":
-#                 np_dtype = np.complex64
-#             elif dtype == "complex128":
-#                 np_dtype = np.complex128
-#             if np.issubdtype(np_dtype, np.complexfloating):
-#                 a_dtype = np.float32 if np_dtype == np.complex64 else np.float64
-#                 a_real = np.random.rand(*shape).astype(a_dtype)
-#                 a_imag = np.random.rand(*shape).astype(a_dtype)
-#                 a = a_real + 1j * a_imag
-#             else:
-#                 a = np.random.rand(*shape).astype(np_dtype)
+@skip_check_grad_ci(
+    reason="'check_grad' on large inputs is too slow, "
+    + "however it is desirable to cover the forward pass"
+)
+class TestSvdNormalMatrixBig(TestSvdOp):
+    def generate_input(self):
+        """big matrix SVD."""
+        self._input_shape = (2, 200, 300)
+        self._input_data = np.random.random(self._input_shape).astype("float64")
 
-#             places = []
-#             places.append(base.CPUPlace())
-#             if core.is_compiled_with_cuda():
-#                 places.append(base.CUDAPlace(0))
-#             for place in places:
-#                 x = paddle.to_tensor(a, place=place)
-#                 u, s, vh = paddle.linalg.svd(x)
-#                 gt_u, gt_s, gt_vh = np.linalg.svd(a, full_matrices=False)
-#                 np.testing.assert_allclose(s, gt_s, rtol=1e-05)
+    def test_svd_forward(self):
+        """test_svd_forward not support batched input, so disable this test."""
+        pass
 
-#         with dygraph_guard():
-#             np.random.seed(7)
-#             tensor_shapes = [
-#                 (0, 3),
-#                 (3, 5),
-#                 (5, 5),
-#                 (5, 3),  # 2-dim Tensors
-#                 (0, 3, 5),
-#                 (4, 0, 5),
-#                 (5, 4, 0),
-#                 (4, 5, 3),  # 3-dim Tensors
-#                 (0, 5, 3, 5),
-#                 (2, 5, 3, 5),
-#                 (3, 5, 5, 5),
-#                 (4, 5, 5, 3),  # 4-dim Tensors
-#             ]
-#             dtypes = ["float32", "float64", 'complex64', 'complex128']
-#             for tensor_shape, dtype in itertools.product(tensor_shapes, dtypes):
-#                 run_svd_dygraph(tensor_shape, dtype)
+    def test_check_grad(self):
+        pass
 
-#     def test_static(self):
-#         def run_svd_static(shape, dtype):
-#             if dtype == "float32":
-#                 np_dtype = np.float32
-#             elif dtype == "float64":
-#                 np_dtype = np.float64
-#             elif dtype == "complex64":
-#                 np_dtype = np.complex64
-#             elif dtype == "complex128":
-#                 np_dtype = np.complex128
-#             if np.issubdtype(np_dtype, np.complexfloating):
-#                 a_dtype = np.float32 if np_dtype == np.complex64 else np.float64
-#                 a_real = np.random.rand(*shape).astype(a_dtype)
-#                 a_imag = np.random.rand(*shape).astype(a_dtype)
-#                 a = a_real + 1j * a_imag
-#             else:
-#                 a = np.random.rand(*shape).astype(np_dtype)
 
-#             places = []
-#             places.append(base.CPUPlace())
-#             if core.is_compiled_with_cuda():
-#                 places.append(base.CUDAPlace(0))
-#             for place in places:
-#                 with paddle.static.program_guard(
-#                     paddle.static.Program(), paddle.static.Program()
-#                 ):
-#                     x = paddle.static.data(
-#                         name="input", shape=shape, dtype=dtype
-#                     )
-#                     u, s, vh = paddle.linalg.svd(x)
-#                     exe = paddle.static.Executor(place)
-#                     gt_u, gt_s, gt_vh = np.linalg.svd(a, full_matrices=False)
-#                     fetches = exe.run(
-#                         feed={"input": a},
-#                         fetch_list=[s],
-#                     )
-#                     np.testing.assert_allclose(fetches[0], gt_s, rtol=1e-05)
+class TestSvdNormalMatrixBig2(TestSvdOp):
+    def generate_input(self):
+        """big matrix SVD."""
+        self._input_shape = (1, 100)
+        self._input_data = np.random.random(self._input_shape).astype("float64")
 
-#             with static_guard():
-#                 np.random.seed(7)
-#                 tensor_shapes = [
-#                     (0, 3),
-#                     (3, 5),
-#                     (5, 5),
-#                     (5, 3),  # 2-dim Tensors
-#                     (0, 3, 5),
-#                     (4, 0, 5),
-#                     (5, 4, 0),
-#                     (4, 5, 3),  # 3-dim Tensors
-#                     (0, 5, 3, 5),
-#                     (2, 5, 3, 5),
-#                     (3, 5, 5, 5),
-#                     (4, 5, 5, 3),  # 4-dim Tensors
-#                 ]
-#                 dtypes = ["float32", "float64", 'complex64', 'complex128']
-#                 for tensor_shape, dtype in itertools.product(
-#                     tensor_shapes, dtypes
-#                 ):
-#                     run_svd_static(tensor_shape, dtype)
+
+class TestSvdNormalMatrixFullMatrices(unittest.TestCase):
+    def setUp(self):
+        paddle.disable_static()
+
+    def tearDown(self):
+        paddle.enable_static()
+
+    def test_full_matrices(self):
+        mat_shape = (2, 3)
+        mat = np.random.random(mat_shape).astype("float64")
+        x = paddle.to_tensor(mat)
+        u, s, vh = paddle.linalg.svd(x, full_matrices=True)
+        assert u.shape == [2, 2]
+        assert vh.shape == [3, 3]
+        x_recover = u.matmul(paddle.diag(s)).matmul(vh[0:2])
+        if (paddle.abs(x_recover - x) > 1e-4).any():
+            raise RuntimeError("mat can't be recovered\n")
+
+
+class TestSvdFullMatriceGrad(TestSvdNormalMatrix6x3):
+    def get_full_matrices_option(self):
+        return True
+
+    def test_svd_forward(self):
+        """test_svd_forward not support full matrices, so disable this test."""
+        pass
+
+    def test_check_grad(self):
+        """
+        remember the input matrix must be the full rank matrix, otherwise the gradient will stochatic because the u / v 's  (n-k) freedom  vectors
+        """
+        self.check_S_grad()
+        # self.check_U_grad() // don't check U grad, because U have freedom vector
+        self.check_V_grad()
+
+
+class TestSvdAPI(unittest.TestCase):
+    def test_dygraph(self):
+        def run_svd_dygraph(shape, dtype):
+            if dtype == "float32":
+                np_dtype = np.float32
+            elif dtype == "float64":
+                np_dtype = np.float64
+            elif dtype == "complex64":
+                np_dtype = np.complex64
+            elif dtype == "complex128":
+                np_dtype = np.complex128
+            if np.issubdtype(np_dtype, np.complexfloating):
+                a_dtype = np.float32 if np_dtype == np.complex64 else np.float64
+                a_real = np.random.rand(*shape).astype(a_dtype)
+                a_imag = np.random.rand(*shape).astype(a_dtype)
+                a = a_real + 1j * a_imag
+            else:
+                a = np.random.rand(*shape).astype(np_dtype)
+
+            places = []
+            places.append(base.CPUPlace())
+            if core.is_compiled_with_cuda():
+                places.append(base.CUDAPlace(0))
+            for place in places:
+                x = paddle.to_tensor(a, place=place)
+                u, s, vh = paddle.linalg.svd(x)
+                gt_u, gt_s, gt_vh = np.linalg.svd(a, full_matrices=False)
+                np.testing.assert_allclose(s, gt_s, rtol=1e-05)
+
+        with dygraph_guard():
+            np.random.seed(7)
+            tensor_shapes = [
+                (0, 3),
+                (3, 5),
+                (5, 5),
+                (5, 3),  # 2-dim Tensors
+                (0, 3, 5),
+                (4, 0, 5),
+                (5, 4, 0),
+                (4, 5, 3),  # 3-dim Tensors
+                (0, 5, 3, 5),
+                (2, 5, 3, 5),
+                (3, 5, 5, 5),
+                (4, 5, 5, 3),  # 4-dim Tensors
+            ]
+            dtypes = ["float32", "float64", 'complex64', 'complex128']
+            for tensor_shape, dtype in itertools.product(tensor_shapes, dtypes):
+                run_svd_dygraph(tensor_shape, dtype)
+
+    def test_static(self):
+        def run_svd_static(shape, dtype):
+            if dtype == "float32":
+                np_dtype = np.float32
+            elif dtype == "float64":
+                np_dtype = np.float64
+            elif dtype == "complex64":
+                np_dtype = np.complex64
+            elif dtype == "complex128":
+                np_dtype = np.complex128
+            if np.issubdtype(np_dtype, np.complexfloating):
+                a_dtype = np.float32 if np_dtype == np.complex64 else np.float64
+                a_real = np.random.rand(*shape).astype(a_dtype)
+                a_imag = np.random.rand(*shape).astype(a_dtype)
+                a = a_real + 1j * a_imag
+            else:
+                a = np.random.rand(*shape).astype(np_dtype)
+
+            places = []
+            places.append(base.CPUPlace())
+            if core.is_compiled_with_cuda():
+                places.append(base.CUDAPlace(0))
+            for place in places:
+                with paddle.static.program_guard(
+                    paddle.static.Program(), paddle.static.Program()
+                ):
+                    x = paddle.static.data(
+                        name="input", shape=shape, dtype=dtype
+                    )
+                    u, s, vh = paddle.linalg.svd(x)
+                    exe = paddle.static.Executor(place)
+                    gt_u, gt_s, gt_vh = np.linalg.svd(a, full_matrices=False)
+                    fetches = exe.run(
+                        feed={"input": a},
+                        fetch_list=[s],
+                    )
+                    np.testing.assert_allclose(fetches[0], gt_s, rtol=1e-05)
+
+            with static_guard():
+                np.random.seed(7)
+                tensor_shapes = [
+                    (0, 3),
+                    (3, 5),
+                    (5, 5),
+                    (5, 3),  # 2-dim Tensors
+                    (0, 3, 5),
+                    (4, 0, 5),
+                    (5, 4, 0),
+                    (4, 5, 3),  # 3-dim Tensors
+                    (0, 5, 3, 5),
+                    (2, 5, 3, 5),
+                    (3, 5, 5, 5),
+                    (4, 5, 5, 3),  # 4-dim Tensors
+                ]
+                dtypes = ["float32", "float64", 'complex64', 'complex128']
+                for tensor_shape, dtype in itertools.product(
+                    tensor_shapes, dtypes
+                ):
+                    run_svd_static(tensor_shape, dtype)
 
 
 class SvdOutTest(unittest.TestCase):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->

**在 https://github.com/PaddlePaddle/Paddle/pull/74484 的基础上 支持多out机制！**

**主要改动如下：**
1. python_c_gen.py   ->  eager_op_function.cc

2. eager_gen.py   ->  dygraph_functions.h、dygraph_functions.cc

3. api_base.py + api_gen.py +  dist_api_gen.py  ->  api.h、api.cc

4. 工具函数：eager_utils.cc

5. 增加测试验证多out支持的正向与反向梯度计算的正确性。
6. 使用median、topk验证多out支持机制。

pcard-67164