### PR TITLE
Improve `forward inplace` and `backward no_need_buffer` api generation logic

### DIFF
--- a/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
@@ -1276,47 +1276,8 @@ class DygraphFunctionGeneratorBase(FunctionGeneratorBase):
             is_fwd_input,
             pos,
         ) in backward_forward_inputs_map.items():
-            is_optional = name in optional_inputs
-            is_inplace_input = is_inplaced and name in self.forward_inplace_map
-            if is_fwd_input:
-                if is_optional:
-                    if is_inplace_input:
-                        set_tensor_wrappers = """{indent}if ({name}) {
-                                                            auto {name}_clone = paddle::experimental::assign({name});
-                                                            grad_node->SetTensorWrapper_{name}(*{name}_clone);}""".format_map(
-                            {"indent": indent, "name": name}
-                        )
-                    else:
-                        if (
-                            (forward_api_name in strided_op_list)
-                            or for_backward
-                            or IsVectorTensorType(atype)
-                            or (name in self.optional_inputs)
-                        ):
-                            if for_backward is False:
-                                set_tensor_wrappers = f"{indent}if ({name}) grad_node->SetTensorWrapper_{name}(*{name});"
-                            else:
-                                set_tensor_wrappers = f"{indent}if ({name}_optional) grad_node->SetTensorWrapper_{name}(*{name}_optional);"
-
-                        else:
-                            need_pre_contiguous_set.add(name)
-                            set_tensor_wrappers = f"{indent}if ({name}) grad_node->SetTensorWrapper_{name}(*{name}_tmp);"
-                else:
-                    if is_inplace_input:
-                        set_tensor_wrappers = f"{indent}auto {name}_clone = paddle::experimental::assign({name});\n{indent}grad_node->SetTensorWrapper_{name}({name}_clone);"
-                    else:
-                        if (
-                            (forward_api_name in strided_op_list)
-                            or for_backward
-                            or IsVectorTensorType(atype)
-                            or (name in self.optional_inputs)
-                        ):
-                            set_tensor_wrappers = f"{indent}grad_node->SetTensorWrapper_{name}({name});"
-                        else:
-                            need_pre_contiguous_set.add(name)
-                            set_tensor_wrappers = f"{indent}grad_node->SetTensorWrapper_{name}({name}_tmp);"
-                set_input_tensor_wrappers_list.append(set_tensor_wrappers)
-            else:  # Forward's output as backward's input
+            if not is_fwd_input:
+                # Forward's output as backward's input
                 if num_fwd_outputs > 1:
                     # Aligned with forward output position
                     assert name in forward_outputs_position_map, AssertMessage(
@@ -1327,6 +1288,45 @@ class DygraphFunctionGeneratorBase(FunctionGeneratorBase):
                     f"{indent}grad_node->SetTensorWrapper_{name}({name});"
                 )
                 set_output_tensor_wrappers_list.append(set_tensor_wrappers)
+                continue
+
+            is_optional = name in optional_inputs
+            is_inplace_input = is_inplaced and name in self.forward_inplace_map
+            no_need_buffer = name in self.no_need_buffers
+            set_tensor_wrappers_body = ""
+            var_name = name
+            if is_inplace_input:
+                if not no_need_buffer:
+                    var_name += "_clone"
+                    set_tensor_wrappers_body += f"{indent}auto {name}_clone = paddle::experimental::assign({name});\n"
+            elif not (
+                (forward_api_name in strided_op_list)
+                or IsVectorTensorType(atype)
+                or for_backward
+                or is_optional
+            ):
+                var_name += "_tmp"
+                need_pre_contiguous_set.add(name)
+
+            if is_optional:
+                check_name = name
+                var_name = f"*{var_name}"
+                if not is_inplace_input and for_backward:
+                    check_name += "_optional"
+                    var_name += "_optional"
+                set_tensor_wrappers_body += (
+                    f"{indent}grad_node->SetTensorWrapper_{name}({var_name});\n"
+                )
+                set_tensor_wrappers = (
+                    f"{indent}if ({check_name}){{\n{set_tensor_wrappers_body}}}"
+                )
+            else:
+                set_tensor_wrappers_body += (
+                    f"{indent}grad_node->SetTensorWrapper_{name}({var_name});\n"
+                )
+                set_tensor_wrappers = set_tensor_wrappers_body
+            set_input_tensor_wrappers_list.append(set_tensor_wrappers)
+
         set_input_tensor_wrappers_str = "\n".join(
             set_input_tensor_wrappers_list
         )

--- a/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
@@ -1283,22 +1283,22 @@ class DygraphFunctionGeneratorBase(FunctionGeneratorBase):
                     assert name in forward_outputs_position_map, AssertMessage(
                         name, forward_outputs_position_map.keys()
                     )
-
-                set_tensor_wrappers = (
+                set_output_tensor_wrappers_list.append(
                     f"{indent}grad_node->SetTensorWrapper_{name}({name});"
                 )
-                set_output_tensor_wrappers_list.append(set_tensor_wrappers)
                 continue
 
             is_optional = name in optional_inputs
             is_inplace_input = is_inplaced and name in self.forward_inplace_map
             no_need_buffer = name in self.no_need_buffers
-            set_tensor_wrappers_body = ""
+            set_tensor_wrappers_body: list[str] = []
             var_name = name
             if is_inplace_input:
                 if not no_need_buffer:
                     var_name += "_clone"
-                    set_tensor_wrappers_body += f"{indent}auto {name}_clone = paddle::experimental::assign({name});\n"
+                    set_tensor_wrappers_body.append(
+                        f"auto {name}_clone = paddle::experimental::assign({name});"
+                    )
             elif not (
                 (forward_api_name in strided_op_list)
                 or IsVectorTensorType(atype)
@@ -1314,17 +1314,23 @@ class DygraphFunctionGeneratorBase(FunctionGeneratorBase):
                 if not is_inplace_input and for_backward:
                     check_name += "_optional"
                     var_name += "_optional"
-                set_tensor_wrappers_body += (
-                    f"{indent}grad_node->SetTensorWrapper_{name}({var_name});\n"
+                set_tensor_wrappers_body.append(
+                    f"grad_node->SetTensorWrapper_{name}({var_name});"
                 )
-                set_tensor_wrappers = (
-                    f"{indent}if ({check_name}){{\n{set_tensor_wrappers_body}}}"
-                )
+                if len(set_tensor_wrappers_body) == 1:
+                    set_tensor_wrappers = f"{indent}if ({check_name}) {set_tensor_wrappers_body[0]}"
+                else:
+                    set_tensor_wrappers_body_str = "\n".join(
+                        f"{indent}  {s}" for s in set_tensor_wrappers_body
+                    )
+                    set_tensor_wrappers = f"{indent}if ({check_name}){{\n{set_tensor_wrappers_body_str}\n{indent}}}"
             else:
-                set_tensor_wrappers_body += (
-                    f"{indent}grad_node->SetTensorWrapper_{name}({var_name});\n"
+                set_tensor_wrappers_body.append(
+                    f"grad_node->SetTensorWrapper_{name}({var_name});"
                 )
-                set_tensor_wrappers = set_tensor_wrappers_body
+                set_tensor_wrappers = "\n".join(
+                    f"{indent}{s}" for s in set_tensor_wrappers_body
+                )
             set_input_tensor_wrappers_list.append(set_tensor_wrappers)
 
         set_input_tensor_wrappers_str = "\n".join(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->

#### 问题背景
Inplace机制在实现时，对于反向需要使用被Inplace的Tensor的场景，当前实现通过备份一份Tensor保留给反向使用。
但是，在https://github.com/PaddlePaddle/Paddle/pull/54683 实现中没有考虑 no_need_buffe的场景。如果反向只需要使用Tensor的meta信息。额外的备份和显存申请是没有必要的。这里的优化可以提升性能、降低显存。

#### 修改内容
- 重新梳理逻辑，简化if嵌套层数。
- 增加对 no_need_buffer 的处理，no_need_buffer 的情况下不进行clone
```python
if not no_need_buffer:
      var_name += "_clone"
      set_tensor_wrappers_body += f"{indent}auto {name}_clone = paddle::experimental::assign({name});\n"
```

相关单测已在 legacy_test/test_inplace.py 存在。

#### dygraph_functions.cc 全部diff

```diff
--- dygraph_functions_old.cc	2025-09-16 07:41:11.132765569 +0000
+++ paddle/fluid/eager/api/generated/eager_generated/forwards/tmp_dygraph_functions.cc	2025-09-16 08:19:59.512761957 +0000
@@ -13984,8 +13984,7 @@ TEST_API paddle::Tensor& cast__ad_func(p
     // SetAttributes if needed
 
     // Set TensorWrappers for Forward Inputs if needed
-    auto x_clone = paddle::experimental::assign(x);
-    grad_node->SetTensorWrapper_x(x_clone);
+    grad_node->SetTensorWrapper_x(x);
   }
 
 
@@ -33741,8 +33740,7 @@ TEST_API paddle::Tensor& flatten__ad_fun
     // SetAttributes if needed
 
     // Set TensorWrappers for Forward Inputs if needed
-    auto x_clone = paddle::experimental::assign(x);
-    grad_node->SetTensorWrapper_x(x_clone);
+    grad_node->SetTensorWrapper_x(x);
   }
 
 
@@ -45206,8 +45204,7 @@ TEST_API paddle::Tensor& index_put__ad_f
     // SetAttributes if needed
     grad_node->SetAttribute_accumulate(accumulate);
     // Set TensorWrappers for Forward Inputs if needed
-    auto x_clone = paddle::experimental::assign(x);
-    grad_node->SetTensorWrapper_x(x_clone);
+    grad_node->SetTensorWrapper_x(x);
     grad_node->SetTensorWrapper_indices(indices);
     grad_node->SetTensorWrapper_value(value_tmp);
   }
@@ -54951,8 +54948,7 @@ TEST_API paddle::Tensor& masked_fill__ad
     // SetAttributes if needed
 
     // Set TensorWrappers for Forward Inputs if needed
-    auto x_clone = paddle::experimental::assign(x);
-    grad_node->SetTensorWrapper_x(x_clone);
+    grad_node->SetTensorWrapper_x(x);
     grad_node->SetTensorWrapper_mask(mask_tmp);
     grad_node->SetTensorWrapper_value(value_tmp);
   }
@@ -71485,8 +71481,7 @@ TEST_API paddle::Tensor& reshape__ad_fun
     // SetAttributes if needed
 
     // Set TensorWrappers for Forward Inputs if needed
-    auto x_clone = paddle::experimental::assign(x);
-    grad_node->SetTensorWrapper_x(x_clone);
+    grad_node->SetTensorWrapper_x(x);
   }
 
 
@@ -82785,8 +82780,7 @@ TEST_API paddle::Tensor& squeeze__ad_fun
     // SetAttributes if needed
     grad_node->SetAttribute_axis(axis);
     // Set TensorWrappers for Forward Inputs if needed
-    auto x_clone = paddle::experimental::assign(x);
-    grad_node->SetTensorWrapper_x(x_clone);
+    grad_node->SetTensorWrapper_x(x);
   }
 
 
@@ -90357,8 +90351,7 @@ TEST_API paddle::Tensor& unsqueeze__ad_f
     // SetAttributes if needed
     grad_node->SetAttribute_axis(axis);
     // Set TensorWrappers for Forward Inputs if needed
-    auto x_clone = paddle::experimental::assign(x);
-    grad_node->SetTensorWrapper_x(x_clone);
+    grad_node->SetTensorWrapper_x(x);
   }
 
 
@@ -92494,8 +92487,7 @@ TEST_API paddle::Tensor& where__ad_func(
 
     // Set TensorWrappers for Forward Inputs if needed
     grad_node->SetTensorWrapper_condition(condition_tmp);
-    auto x_clone = paddle::experimental::assign(x);
-    grad_node->SetTensorWrapper_x(x_clone);
+    grad_node->SetTensorWrapper_x(x);
     grad_node->SetTensorWrapper_y(y_tmp);
   }
 
@@ -94462,8 +94454,7 @@ TEST_API paddle::Tensor& add__ad_func(pa
     // SetAttributes if needed
     grad_node->SetAttribute_axis(-1);
     // Set TensorWrappers for Forward Inputs if needed
-    auto x_clone = paddle::experimental::assign(x);
-    grad_node->SetTensorWrapper_x(x_clone);
+    grad_node->SetTensorWrapper_x(x);
     grad_node->SetTensorWrapper_y(y_tmp);
   }
 
@@ -100877,8 +100868,7 @@ TEST_API paddle::Tensor& subtract__ad_fu
     // SetAttributes if needed
     grad_node->SetAttribute_axis(-1);
     // Set TensorWrappers for Forward Inputs if needed
-    auto x_clone = paddle::experimental::assign(x);
-    grad_node->SetTensorWrapper_x(x_clone);
+    grad_node->SetTensorWrapper_x(x);
     grad_node->SetTensorWrapper_y(y_tmp);
   }
```

#### 性能影响
| API | 新方法耗时 | 旧方法耗时 | 提升比 |
|------|-----------|-----------|--------|
| squeeze_ | 1.442981 | 2.981225 | 51.60% |
| subtract_ | 5.684337 | 6.590459 | 13.75% |
| add_ | 5.592483 | 6.784562 | 17.57% |
| where_ | 2.007736 | 3.384913 | 40.69% |
| cast_ | 0.793757 | 1.660807 | 52.21% |
| flatten_ | 0.729683 | 1.593869 | 54.22% |
| index_put_ | 2.647053 | 3.487675 | 24.10% |
| masked_fill_ | 4.950967 | 5.582273 | 11.31% |


Pcard-67164