### PR TITLE
use onednn_data_type in params_quantization_onednn_pass_tester

### DIFF
--- a/paddle/fluid/framework/ir/onednn/params_quantization_onednn_pass.cc
+++ b/paddle/fluid/framework/ir/onednn/params_quantization_onednn_pass.cc
@@ -74,7 +74,7 @@ void QuantizeConvInput(Scope* scope,
 
 }  // namespace
 
-ParamsQuantizationMkldnnPass::ParamsQuantizationMkldnnPass() {  // NOLINT
+ParamsQuantizationOnednnPass::ParamsQuantizationOnednnPass() {  // NOLINT
   AddOpCompat(OpCompat("fused_conv2d"))
       .AddInput("Input")
       .IsTensor()
@@ -114,7 +114,7 @@ ParamsQuantizationMkldnnPass::ParamsQuantizationMkldnnPass() {  // NOLINT
       .End();
 }
 
-void ParamsQuantizationMkldnnPass::QuantizeConv(ir::Graph* graph,
+void ParamsQuantizationOnednnPass::QuantizeConv(ir::Graph* graph,
                                                 const std::string& conv_type,
                                                 bool with_residual_data) const {
   GraphPatternDetector gpd;
@@ -164,7 +164,7 @@ void ParamsQuantizationMkldnnPass::QuantizeConv(ir::Graph* graph,
   paddle::string::PrettyLogDetail(msg_ss.str().c_str());
 }
 
-void ParamsQuantizationMkldnnPass::ApplyImpl(ir::Graph* graph) const {
+void ParamsQuantizationOnednnPass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(graph,
                           common::errors::InvalidArgument(
                               "Pointer to graph argument should not be NULL."));
@@ -176,7 +176,7 @@ void ParamsQuantizationMkldnnPass::ApplyImpl(ir::Graph* graph) const {
 }  // namespace paddle::framework::ir
 
 REGISTER_PASS(params_quantization_onednn_pass,
-              paddle::framework::ir::ParamsQuantizationMkldnnPass);
+              paddle::framework::ir::ParamsQuantizationOnednnPass);
 REGISTER_PASS_CAPABILITY(params_quantization_onednn_pass)
     .AddCombination(
         paddle::framework::compatible::OpVersionComparatorCombination().LE(

--- a/paddle/fluid/framework/ir/onednn/params_quantization_onednn_pass.h
+++ b/paddle/fluid/framework/ir/onednn/params_quantization_onednn_pass.h
@@ -24,10 +24,10 @@ class Graph;
 /*
  * Quantize parameters of ops
  */
-class ParamsQuantizationMkldnnPass : public FusePassBase {
+class ParamsQuantizationOnednnPass : public FusePassBase {
  public:
-  ParamsQuantizationMkldnnPass();
-  virtual ~ParamsQuantizationMkldnnPass() = default;
+  ParamsQuantizationOnednnPass();
+  virtual ~ParamsQuantizationOnednnPass() = default;
 
  protected:
   void ApplyImpl(ir::Graph* graph) const override;

--- a/paddle/fluid/framework/ir/onednn/params_quantization_onednn_pass_tester.cc
+++ b/paddle/fluid/framework/ir/onednn/params_quantization_onednn_pass_tester.cc
@@ -142,7 +142,7 @@ struct ConvProgramStrategy : public ProgramStrategy {
     op->SetType("fused_conv2d");
     op->SetAttr("use_onednn", true);
     op->SetAttr("name", conv_name);
-    op->SetAttr("mkldnn_data_type", std::string{"int8"});
+    op->SetAttr("onednn_data_type", std::string{"int8"});
     op->SetAttr("data_format", std::string{"NCHW"});
     op->SetAttr("dilations", std::vector<int>({1, 1}));
     op->SetAttr("paddings", std::vector<int>({1, 1}));
@@ -239,7 +239,7 @@ struct ConvProgramStrategy : public ProgramStrategy {
   const bool share_weight;
 };
 
-struct ParamsQuantizationMkldnnPassTestFixture : public ::testing::Test {
+struct ParamsQuantizationOnednnPassTestFixture : public ::testing::Test {
   void RunPassTest(std::unique_ptr<ProgramStrategy> program) {
     auto graph = program->CreateGraph();
 
@@ -253,7 +253,7 @@ struct ParamsQuantizationMkldnnPassTestFixture : public ::testing::Test {
 Data GenericInput() { return Data({1, 4, 1, 1}, {1.5f, 1.5f, 1.5f, 1.5f}); }
 Data GenericOutput() { return GenericInput(); }
 
-TEST_F(ParamsQuantizationMkldnnPassTestFixture, conv_without_bias_o1i1h1w1) {
+TEST_F(ParamsQuantizationOnednnPassTestFixture, conv_without_bias_o1i1h1w1) {
   auto program =
       std::make_unique<ConvProgramStrategy>(GenericInput(),
                                             Data({1, 1, 1, 1}, {1.5f}),
@@ -262,7 +262,7 @@ TEST_F(ParamsQuantizationMkldnnPassTestFixture, conv_without_bias_o1i1h1w1) {
   RunPassTest(std::move(program));
 }
 
-TEST_F(ParamsQuantizationMkldnnPassTestFixture, conv_without_bias_2o1i1h1w) {
+TEST_F(ParamsQuantizationOnednnPassTestFixture, conv_without_bias_2o1i1h1w) {
   auto program =
       std::make_unique<ConvProgramStrategy>(GenericInput(),
                                             Data({2, 1, 1, 1}, {1.5f, 1.5f}),
@@ -271,7 +271,7 @@ TEST_F(ParamsQuantizationMkldnnPassTestFixture, conv_without_bias_2o1i1h1w) {
   RunPassTest(std::move(program));
 }
 
-TEST_F(ParamsQuantizationMkldnnPassTestFixture, conv_without_bias_2o2i2h2w) {
+TEST_F(ParamsQuantizationOnednnPassTestFixture, conv_without_bias_2o2i2h2w) {
   auto program =
       std::make_unique<ConvProgramStrategy>(GenericInput(),
                                             Data({2, 2, 2, 2},
@@ -296,7 +296,7 @@ TEST_F(ParamsQuantizationMkldnnPassTestFixture, conv_without_bias_2o2i2h2w) {
   RunPassTest(std::move(program));
 }
 
-TEST_F(ParamsQuantizationMkldnnPassTestFixture, conv_without_bias_2g2o2i1h1w) {
+TEST_F(ParamsQuantizationOnednnPassTestFixture, conv_without_bias_2g2o2i1h1w) {
   auto program = std::make_unique<ConvProgramStrategy>(
       GenericInput(),
       Data({2, 2, 2, 1, 1}, {1.5f, 1.5f, 1.5f, 1.5f, 1.5f, 1.5f, 1.5f, 1.5f}),
@@ -306,7 +306,7 @@ TEST_F(ParamsQuantizationMkldnnPassTestFixture, conv_without_bias_2g2o2i1h1w) {
   RunPassTest(std::move(program));
 }
 
-TEST_F(ParamsQuantizationMkldnnPassTestFixture, conv_without_bias_2g2o1i1h1w) {
+TEST_F(ParamsQuantizationOnednnPassTestFixture, conv_without_bias_2g2o1i1h1w) {
   auto program = std::make_unique<ConvProgramStrategy>(
       GenericInput(),
       Data({2, 2, 1, 1, 1}, {1.5f, 1.5f, 1.5f, 1.5f}),
@@ -316,7 +316,7 @@ TEST_F(ParamsQuantizationMkldnnPassTestFixture, conv_without_bias_2g2o1i1h1w) {
   RunPassTest(std::move(program));
 }
 
-TEST_F(ParamsQuantizationMkldnnPassTestFixture, conv_with_bias_1o1i1h1w) {
+TEST_F(ParamsQuantizationOnednnPassTestFixture, conv_with_bias_1o1i1h1w) {
   auto program =
       std::make_unique<ConvProgramStrategy>(GenericInput(),
                                             Data({1, 1, 1, 1}, {1.5f}),
@@ -328,7 +328,7 @@ TEST_F(ParamsQuantizationMkldnnPassTestFixture, conv_with_bias_1o1i1h1w) {
   RunPassTest(std::move(program));
 }
 
-TEST_F(ParamsQuantizationMkldnnPassTestFixture, conv_with_bias_2o1i1h1w) {
+TEST_F(ParamsQuantizationOnednnPassTestFixture, conv_with_bias_2o1i1h1w) {
   auto program =
       std::make_unique<ConvProgramStrategy>(GenericInput(),
                                             Data({2, 1, 1, 1}, {1.5f, 1.5f}),
@@ -340,7 +340,7 @@ TEST_F(ParamsQuantizationMkldnnPassTestFixture, conv_with_bias_2o1i1h1w) {
   RunPassTest(std::move(program));
 }
 
-TEST_F(ParamsQuantizationMkldnnPassTestFixture, conv_with_bias_2g2o1i1h1w) {
+TEST_F(ParamsQuantizationOnednnPassTestFixture, conv_with_bias_2g2o1i1h1w) {
   auto program = std::make_unique<ConvProgramStrategy>(
       GenericInput(),
       Data({4, 1, 1, 1}, {1.5f, 1.5f, 1.5f, 1.5f}),
@@ -352,7 +352,7 @@ TEST_F(ParamsQuantizationMkldnnPassTestFixture, conv_with_bias_2g2o1i1h1w) {
   RunPassTest(std::move(program));
 }
 
-TEST_F(ParamsQuantizationMkldnnPassTestFixture, conv_with_bias_2g2o2i1h1w) {
+TEST_F(ParamsQuantizationOnednnPassTestFixture, conv_with_bias_2g2o2i1h1w) {
   auto program = std::make_unique<ConvProgramStrategy>(
       GenericInput(),
       Data({2, 2, 2, 1, 1}, {1.5f, 1.5f, 1.5f, 1.5f, 1.5f, 1.5f, 1.5f, 1.5f}),
@@ -364,7 +364,7 @@ TEST_F(ParamsQuantizationMkldnnPassTestFixture, conv_with_bias_2g2o2i1h1w) {
   RunPassTest(std::move(program));
 }
 
-TEST_F(ParamsQuantizationMkldnnPassTestFixture, conv_with_bias_2g2o2i1h1ws) {
+TEST_F(ParamsQuantizationOnednnPassTestFixture, conv_with_bias_2g2o2i1h1ws) {
   auto program = std::make_unique<ConvProgramStrategy>(
       GenericInput(),
       Data({2, 2, 2, 1, 1}, {1.5f, 1.5f, 1.5f, 1.5f, 1.5f, 1.5f, 1.5f, 1.5f}),


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
use onednn_data_type in params_quantization_onednn_pass_tester
