### PR TITLE
reduce_all_kernel.cc remove include complex.h

### DIFF
--- a/paddle/phi/kernels/cpu/elementwise_add_kernel.cc
+++ b/paddle/phi/kernels/cpu/elementwise_add_kernel.cc
@@ -72,9 +72,6 @@ INSTANTIATE_ADD_KERNEL(phi::complex128, CPUContext)
 #endif
 }  // namespace phi
 
-using complex64 = ::phi::complex64;
-using complex128 = ::phi::complex128;
-
 // NOTE(chenweihang): using bfloat16 will cause redefine with xpu bfloat16
 // using bfloat16 = ::phi::bfloat16;
 
@@ -90,8 +87,8 @@ PD_REGISTER_KERNEL(add,
                    uint8_t,
                    int8_t,
                    int64_t,
-                   complex64,
-                   complex128) {}
+                   phi::complex64,
+                   phi::complex128) {}
 
 PD_REGISTER_KERNEL(grad_add,
                    CPU,
@@ -105,5 +102,5 @@ PD_REGISTER_KERNEL(grad_add,
                    uint8_t,
                    int8_t,
                    int64_t,
-                   complex64,
-                   complex128) {}
+                   phi::complex64,
+                   phi::complex128) {}

--- a/paddle/phi/kernels/cpu/elementwise_divide_kernel.cc
+++ b/paddle/phi/kernels/cpu/elementwise_divide_kernel.cc
@@ -49,9 +49,6 @@ void DivideKernel(const Context& dev_ctx,
 
 }  // namespace phi
 
-using complex64 = ::phi::complex64;
-using complex128 = ::phi::complex128;
-
 // NOTE(chenweihang): using bfloat16 will cause redefine with xpu bfloat16
 // using bfloat16 = ::phi::bfloat16;
 
@@ -67,5 +64,5 @@ PD_REGISTER_KERNEL(divide,
                    int,
                    int64_t,
                    bool,
-                   complex64,
-                   complex128) {}
+                   phi::complex64,
+                   phi::complex128) {}

--- a/paddle/phi/kernels/cpu/elementwise_kernel.cc
+++ b/paddle/phi/kernels/cpu/elementwise_kernel.cc
@@ -127,9 +127,6 @@ void NextafterKernel(const Context& dev_ctx,
 
 }  // namespace phi
 
-using complex64 = ::phi::complex64;
-using complex128 = ::phi::complex128;
-
 // NOTE(chenweihang): using bfloat16 will cause redefine with xpu bfloat16
 // using bfloat16 = ::phi::bfloat16;
 

--- a/paddle/phi/kernels/cpu/elementwise_multiply_kernel.cc
+++ b/paddle/phi/kernels/cpu/elementwise_multiply_kernel.cc
@@ -49,9 +49,6 @@ void MultiplyKernel(const Context& dev_ctx,
 
 }  // namespace phi
 
-using complex64 = ::phi::complex64;
-using complex128 = ::phi::complex128;
-
 // NOTE(chenweihang): using bfloat16 will cause redefine with xpu bfloat16
 // using bfloat16 = ::phi::bfloat16;
 
@@ -64,6 +61,6 @@ PD_REGISTER_KERNEL(multiply,
                    int,
                    int64_t,
                    bool,
-                   complex64,
-                   complex128,
+                   phi::complex64,
+                   phi::complex128,
                    phi::bfloat16) {}

--- a/paddle/phi/kernels/cpu/elementwise_subtract_kernel.cc
+++ b/paddle/phi/kernels/cpu/elementwise_subtract_kernel.cc
@@ -48,9 +48,6 @@ void SubtractKernel(const Context& dev_ctx,
 }
 }  // namespace phi
 
-using complex64 = ::phi::complex64;
-using complex128 = ::phi::complex128;
-
 // NOTE(chenweihang): using bfloat16 will cause redefine with xpu bfloat16
 // using bfloat16 = ::phi::bfloat16;
 
@@ -63,6 +60,6 @@ PD_REGISTER_KERNEL(subtract,
                    int16_t,
                    int,
                    int64_t,
-                   complex64,
-                   complex128,
+                   phi::complex64,
+                   phi::complex128,
                    phi::bfloat16) {}

--- a/paddle/phi/kernels/empty_kernel.cc
+++ b/paddle/phi/kernels/empty_kernel.cc
@@ -14,7 +14,6 @@
 #include "paddle/phi/kernels/empty_kernel.h"
 #include "paddle/common/macros.h"
 #include "paddle/phi/backends/all_context.h"
-#include "paddle/phi/common/complex.h"
 #include "paddle/phi/core/kernel_registry.h"
 
 namespace phi {

--- a/paddle/phi/kernels/funcs/fft.cc
+++ b/paddle/phi/kernels/funcs/fft.cc
@@ -371,12 +371,12 @@ struct FFTC2RFunctor<phi::CPUContext, Ti, To> {
 };
 #endif
 
-using complex64_t = phi::complex64;
-using complex128_t = phi::complex128;
-template struct FFTC2CFunctor<phi::CPUContext, complex64_t, complex64_t>;
-template struct FFTC2CFunctor<phi::CPUContext, complex128_t, complex128_t>;
-template struct FFTC2RFunctor<phi::CPUContext, complex64_t, float>;
-template struct FFTC2RFunctor<phi::CPUContext, complex128_t, double>;
-template struct FFTR2CFunctor<phi::CPUContext, float, complex64_t>;
-template struct FFTR2CFunctor<phi::CPUContext, double, complex128_t>;
+template struct FFTC2CFunctor<phi::CPUContext, phi::complex64, phi::complex64>;
+template struct FFTC2CFunctor<phi::CPUContext,
+                              phi::complex128,
+                              phi::complex128>;
+template struct FFTC2RFunctor<phi::CPUContext, phi::complex64, float>;
+template struct FFTC2RFunctor<phi::CPUContext, phi::complex128, double>;
+template struct FFTR2CFunctor<phi::CPUContext, float, phi::complex64>;
+template struct FFTR2CFunctor<phi::CPUContext, double, phi::complex128>;
 }  // namespace phi::funcs

--- a/paddle/phi/kernels/funcs/fft_xpu.cc
+++ b/paddle/phi/kernels/funcs/fft_xpu.cc
@@ -293,10 +293,9 @@ struct FFTR2CFunctor<phi::XPUContext, Ti, To> {
   }
 };
 
-using complex64_t = phi::complex64;
-template struct FFTC2CFunctor<phi::XPUContext, complex64_t, complex64_t>;
-template struct FFTC2RFunctor<phi::XPUContext, complex64_t, float>;
-template struct FFTR2CFunctor<phi::XPUContext, float, complex64_t>;
+template struct FFTC2CFunctor<phi::XPUContext, phi::complex64, phi::complex64>;
+template struct FFTC2RFunctor<phi::XPUContext, phi::complex64, float>;
+template struct FFTR2CFunctor<phi::XPUContext, float, phi::complex64>;
 }  // namespace funcs
 }  // namespace phi
 #endif

--- a/paddle/phi/kernels/gpudnn/conv_gpudnn.h
+++ b/paddle/phi/kernels/gpudnn/conv_gpudnn.h
@@ -27,9 +27,6 @@
 #include "paddle/phi/kernels/gpudnn/conv_cudnn_v7.h"
 #endif
 
-#include "paddle/phi/common/bfloat16.h"
-#include "paddle/phi/common/float16.h"
-
 #ifdef PADDLE_WITH_CUDNN_FRONTEND
 // clang-format off
 #include "paddle/phi/backends/dynload/cudnn_frontend.h"

--- a/paddle/phi/kernels/primitive/functor_primitives.h
+++ b/paddle/phi/kernels/primitive/functor_primitives.h
@@ -16,7 +16,6 @@
 
 #include <type_traits>
 #include "paddle/phi/common/amp_type_traits.h"
-#include "paddle/phi/common/float16.h"
 #include "paddle/phi/core/enforce.h"
 #include "paddle/phi/kernels/funcs/eigen/extensions.h"
 

--- a/paddle/phi/kernels/reduce_all_kernel.cc
+++ b/paddle/phi/kernels/reduce_all_kernel.cc
@@ -19,9 +19,6 @@
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/full_kernel.h"
 
-using complex64 = ::phi::complex64;
-using complex128 = ::phi::complex128;
-
 namespace phi {
 
 template <typename T, typename Context>
@@ -61,8 +58,8 @@ PD_REGISTER_KERNEL(all,
                    int,
                    int64_t,
                    bool,
-                   complex64,
-                   complex128) {
+                   phi::complex64,
+                   phi::complex128) {
   kernel->OutputAt(0).SetDataType(phi::DataType::BOOL);
 }
 
@@ -76,8 +73,8 @@ PD_REGISTER_KERNEL(all,
                    int,
                    int64_t,
                    bool,
-                   complex64,
-                   complex128) {
+                   phi::complex64,
+                   phi::complex128) {
   kernel->OutputAt(0).SetDataType(phi::DataType::BOOL);
 }
 #endif

--- a/paddle/phi/kernels/reduce_all_kernel.cc
+++ b/paddle/phi/kernels/reduce_all_kernel.cc
@@ -15,7 +15,6 @@
 #include "paddle/phi/kernels/reduce_all_kernel.h"
 #include "glog/logging.h"
 #include "paddle/phi/backends/all_context.h"
-#include "paddle/phi/common/complex.h"
 #include "paddle/phi/common/int_array.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/full_kernel.h"

--- a/paddle/phi/kernels/stride/bitwise_kernel.cu
+++ b/paddle/phi/kernels/stride/bitwise_kernel.cu
@@ -199,10 +199,7 @@ void BitwiseNotStrideKernel(const Context &dev_ctx,
 }
 
 }  // namespace phi
-using float16 = phi::float16;
-using bfloat16 = phi::bfloat16;
-using complex64 = ::phi::complex64;
-using complex128 = ::phi::complex128;
+
 PD_REGISTER_KERNEL(bitwise_and,
                    GPU,
                    STRIDED,

--- a/paddle/phi/kernels/stride/compare_kernel.cu
+++ b/paddle/phi/kernels/stride/compare_kernel.cu
@@ -117,11 +117,6 @@ DEFINE_CUDA_COMPARE_STRIDE_OP(NotEqual, NotEqual)
 
 }  // namespace phi
 
-using float16 = phi::float16;
-using bfloat16 = phi::bfloat16;
-using complex64 = ::phi::complex64;
-using complex128 = ::phi::complex128;
-
 #define REGISTER_STRIDE_COMPLEX_COMPARE_KERNEL(less_than, func) \
   PD_REGISTER_KERNEL(less_than,                                 \
                      GPU,                                       \

--- a/paddle/phi/kernels/stride/indexing_kernel.cu
+++ b/paddle/phi/kernels/stride/indexing_kernel.cu
@@ -250,11 +250,6 @@ void IndexPutKernel_V2(const Context& dev_ctx,
 
 }  // namespace phi
 
-using float16 = phi::float16;
-using bfloat16 = phi::bfloat16;
-using complex64 = ::phi::complex64;
-using complex128 = ::phi::complex128;
-
 PD_REGISTER_KERNEL(index_put,
                    GPU,
                    STRIDED,

--- a/paddle/phi/kernels/stride/logical_kernel.cu
+++ b/paddle/phi/kernels/stride/logical_kernel.cu
@@ -160,10 +160,7 @@ void LogicalNotStrideKernel(const Context &dev_ctx,
 }
 
 }  // namespace phi
-using float16 = phi::float16;
-using bfloat16 = phi::bfloat16;
-using complex64 = ::phi::complex64;
-using complex128 = ::phi::complex128;
+
 #define REGISTER_LOGICAL_CUDA_STRIDE_KERNEL(logical_and, func_type) \
   PD_REGISTER_KERNEL(logical_and,                                   \
                      GPU,                                           \


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
reduce_all_kernel.cc等文件删除头文件包含 complex.h, float16.h，data_type.h中已包含
部分 using complex64 引用较少删除
