### PR TITLE
【Hackathon 9th No.17、18】 Fix accuracy diff for conv2d_transpose API with NHWC format

### DIFF
--- a/paddle/phi/kernels/funcs/im2col_cfo_cpu.h
+++ b/paddle/phi/kernels/funcs/im2col_cfo_cpu.h
@@ -210,11 +210,15 @@ inline void im2col_sh1sw1dh1dw1ph1pw1(const phi::DenseTensor& im,
             std::memcpy(dst_data + plw, src_data, copy_size);
           } else {
             for (int kow = 0; kow < output_width - plw - prw; ++kow) {
-              dst_data[plw + kow] =
-                  im_data[(((oh - plh > 0 ? oh - plh : 0) + kh) * im_width +
-                           kow) *
-                              im_channels +
-                          ic];
+              int im_row = oh - plh + kh;
+              int im_col = kow;
+              if (im_row >= 0 && im_row < im_height && im_col >= 0 &&
+                  im_col < im_width) {
+                dst_data[plw + kow] =
+                    im_data[(im_row * im_width + im_col) * im_channels + ic];
+              } else {
+                dst_data[plw + kow] = static_cast<T>(0);
+              }
             }
           }
           dst_data = dst_data + col_matrix_width;
@@ -269,11 +273,15 @@ inline void im2col_sh1sw1dh1dw1ph1pw1(const phi::DenseTensor& im,
                         sizeof(T) * (output_width - (plw - kw)));
           } else {
             for (int kow = 0; kow < output_width - (plw - kw); ++kow) {
-              dst_data[plw - kw + kow] =
-                  im_data[(((oh - plh > 0 ? oh - plh : 0) + kh) * im_width +
-                           kow) *
-                              im_channels +
-                          ic];
+              int im_row = oh - plh + kh;
+              int im_col = kow;
+              if (im_row >= 0 && im_row < im_height && im_col >= 0 &&
+                  im_col < im_width) {
+                dst_data[plw - kw + kow] =
+                    im_data[(im_row * im_width + im_col) * im_channels + ic];
+              } else {
+                dst_data[plw - kw + kow] = static_cast<T>(0);
+              }
             }
           }
           dst_data = dst_data + col_matrix_width;
@@ -284,11 +292,15 @@ inline void im2col_sh1sw1dh1dw1ph1pw1(const phi::DenseTensor& im,
                 dst_data, src_data + (kw - plw), sizeof(T) * output_width);
           } else {
             for (int kow = 0; kow < output_width; ++kow) {
-              dst_data[kow] =
-                  im_data[(((oh - plh > 0 ? oh - plh : 0) + kh) * im_width +
-                           kw - plw + kow) *
-                              im_channels +
-                          ic];
+              int im_row = oh - plh + kh;
+              int im_col = kw - plw + kow;
+              if (im_row >= 0 && im_row < im_height && im_col >= 0 &&
+                  im_col < im_width) {
+                dst_data[kow] =
+                    im_data[(im_row * im_width + im_col) * im_channels + ic];
+              } else {
+                dst_data[kow] = static_cast<T>(0);
+              }
             }
           }
           dst_data = dst_data + col_matrix_width;
@@ -301,11 +313,15 @@ inline void im2col_sh1sw1dh1dw1ph1pw1(const phi::DenseTensor& im,
                         sizeof(T) * (output_width - i));
           } else {
             for (int kow = 0; kow < output_width - i; ++kow) {
-              dst_data[kow] =
-                  im_data[(((oh - plh > 0 ? oh - plh : 0) + kh) * im_width +
-                           kw - plw + kow) *
-                              im_channels +
-                          ic];
+              int im_row = oh - plh + kh;
+              int im_col = kw - plw + kow;
+              if (im_row >= 0 && im_row < im_height && im_col >= 0 &&
+                  im_col < im_width) {
+                dst_data[kow] =
+                    im_data[(im_row * im_width + im_col) * im_channels + ic];
+              } else {
+                dst_data[kow] = static_cast<T>(0);
+              }
             }
           }
           dst_data = dst_data + col_matrix_width;

--- a/test/legacy_test/test_conv2d_transpose_op.py
+++ b/test/legacy_test/test_conv2d_transpose_op.py
@@ -1575,5 +1575,29 @@ class TestFunctionalConv2DTranspose_ZeroSize2(
         self.np_out = np.zeros([4, 0, 6, 6])
 
 
+class TestWithSAMEPad_NHWC(TestConv2DTransposeOp):
+    def init_test_case(self):
+        self.stride = [1, 1]
+        self.dilations = [1, 1]
+        self.groups = 1
+        self.input_size = [1, 3, 3, 1]  # NHWC
+        f_c = self.input_size[-1]
+        self.filter_size = [f_c, 2, 3, 3]
+        self.data_format = 'NHWC'
+        self.padding_algorithm = 'SAME'
+
+
+class TestWithSAMEPadGroups_NHWC(TestConv2DTransposeOp):
+    def init_test_case(self):
+        self.stride = [1, 1]
+        self.dilations = [1, 1]
+        self.groups = 2
+        self.input_size = [1, 3, 3, 2]  # NHWC
+        f_c = self.input_size[-1]
+        self.filter_size = [f_c, 1, 3, 3]
+        self.data_format = 'NHWC'
+        self.padding_algorithm = 'SAME'
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug Fixes

### Description

#### 问题描述
  - 5_accuracy/accuracy_gpu_error.txt 中，No.17 paddle.nn.functional.conv2d这个接口所有测试用例都无法复现，可能已经被别人修复？
  - 5_accuracy/accuracy_cpu_error.txt 中， No.18 paddle.nn.functional.conv2d_transpose这个接口，同样大多数测试用例无法复现。但少数使用 `data_format="NHWC"` 且 `padding >0` 的用例仍存在问题。
  - 修复 `conv2d_transpose` API 在 NHWC 数据格式下的梯度计算错误。当使用 `data_format="NHWC"` 且 `padding > 0` 时，反向传播的梯度会出现错误的行偏移，导致梯度传播到错误的位置。

#### 根本原因
  问题出现在 `paddle/phi/kernels/funcs/im2col_cfo_cpu.h` 文件的 `im2col_sh1sw1dh1dw1ph1pw1` 函数中。NHWC
  分支使用了错误的索引计算：

  ```cpp
  // 错误的代码
  im_data[(((oh - plh > 0 ? oh - plh : 0) + kh) * im_width + ...) * im_channels + ic]

  当 oh - plh < 0 时（padding 区域），表达式 (oh - plh > 0 ? oh - plh : 0) 会错误地将负索引映射到
  0，导致梯度传播到错误的位置。

  修复方案：直接计算正确的索引并进行边界检查：

  // 修复后的代码
  int im_row = oh - plh + kh;
  int im_col = kw - plw + kow;
  if (im_row >= 0 && im_row < im_height && im_col >= 0 && im_col < im_width) {
      dst_data[...] = im_data[(im_row * im_width + im_col) * im_channels + ic];
  } else {
      dst_data[...] = static_cast<T>(0);
  }

  修改细节的说明：
  1. 修改文件: paddle/phi/kernels/funcs/im2col_cfo_cpu.h
  2. 修改位置: im2col_sh1sw1dh1dw1ph1pw1 函数中的 4 个 NHWC 分支
  3. 修改内容: 将错误的三元运算符索引计算替换为直接计算加边界检查
  4. 影响范围: 仅影响 CPU 上 NHWC 格式的 conv2d_transpose 反向传播
  5. 新增测试: 添加 TestWithSAMEPad_NHWC 和 TestWithSAMEPadGroups_NHWC 测试用例
```
 单测以及PaddleAPITest回测的结果

  单元测试结果：
  - 运行 python test_conv2d_transpose_op.py: 195个测试中194个通过（self.assertRaises(AssertionError, error_0_filter_number) 这个断言未通过，但似乎与本问题无关）
  - 核心测试 TestWithGroups_NHWC: ✅ 通过
  - 新增测试 TestWithSAMEPad_NHWC: ✅ 通过
  - 新增测试 TestWithSAMEPadGroups_NHWC: ✅ 通过
  - 所有NHWC相关测试均通过，无功能回归

  PaddleAPITest回测结果：
  - 测试文件: 5_accuracy/accuracy_cpu_error.txt 中所有conv2d_transpose用例
  - 修复前: NHWC + padding > 0 的配置失败
  - 修复后: 所有测试配置通过

<img width="541" height="305" alt="2da511ae88e78187fbafd08f344cced" src="https://github.com/user-attachments/assets/5be4f998-aeb1-4e61-a181-1b1fc042f6d0" />


