### PR TITLE
[Compat] Add compatible API `_C._cuda_getCurrentRawStream`

### DIFF
--- a/paddle/fluid/pybind/cuda_streams_py.cc
+++ b/paddle/fluid/pybind/cuda_streams_py.cc
@@ -116,6 +116,22 @@ void BindCudaStream(py::module *m_ptr) {
 #endif
   });
 
+  m.def("_get_current_raw_stream", [](int device_index) -> uintptr_t {
+    if (device_index == -1) {
+      PADDLE_THROW(common::errors::InvalidArgument(
+          "The device index must be a non-negative integer."));
+    }
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP) || \
+    defined(PADDLE_WITH_CUSTOM_DEVICE)
+    auto *current_stream = platform::get_current_stream(device_index);
+    return reinterpret_cast<std::uintptr_t>(current_stream->raw_stream());
+#else
+        PADDLE_THROW(common::errors::Unavailable(
+            "Paddle do not support _get_current_raw_stream "
+            "Cannot visit device synchronize."));
+#endif
+  });
+
   py::class_<phi::CUDAStream>(m, "CUDAStream", R"DOC(
       The handle of the CUDA stream.
 

--- a/python/paddle/_C.py
+++ b/python/paddle/_C.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from paddle.base.libpaddle import (
+    _get_current_raw_stream as _cuda_getCurrentRawStream,  # noqa: F401
+)

--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -194,6 +194,7 @@ from paddle import (
 
 # high-level api
 from . import (
+    _C as _C,
     _pir_ops as _pir_ops,
     _typing as _typing,
     callbacks as callbacks,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

New features

### Description
<!-- Describe what you’ve done -->

Add a new PyTorch compatible API `torch._C._cuda_getCurrentRawStream` for TVM FFI stream detection.

<!-- PCard-66972 -->