### PR TITLE
[Typing] Fix missing generic type arg in decorator caused type propagation break

### DIFF
--- a/python/paddle/base/dygraph/math_op_patch.py
+++ b/python/paddle/base/dygraph/math_op_patch.py
@@ -389,7 +389,7 @@ def monkey_patch_math_tensor():
 
                 >>> import paddle
                 >>> x = paddle.ones([2, 2])
-                >>> y = x.new_empty(3, 3)
+                >>> y = x.new_empty(3, 3)  # type: ignore
                 >>> y.shape
                 [3, 3]
         """
@@ -436,7 +436,7 @@ def monkey_patch_math_tensor():
 
                 >>> import paddle
                 >>> x = paddle.zeros([2, 2])
-                >>> y = x.new_ones(3, 3)
+                >>> y = x.new_ones(3, 3)  # type: ignore
                 >>> y.numpy()
                 array([[1., 1., 1.],
                        [1., 1., 1.],
@@ -486,7 +486,7 @@ def monkey_patch_math_tensor():
 
             >>> import paddle
             >>> x = paddle.ones([2, 2])
-            >>> y = x.new_zeros(3, 3)
+            >>> y = x.new_zeros(3, 3)  # type: ignore
             >>> y.numpy()
             array([[0., 0., 0.],
                    [0., 0., 0.],

--- a/python/paddle/nn/functional/common.py
+++ b/python/paddle/nn/functional/common.py
@@ -2639,7 +2639,7 @@ def class_center_sample(
         >>> # num_classes of each GPU can be different, e.g num_classes_list = [10, 8]
         >>> num_classes_list = [10, 10]
         >>> num_classes = paddle.sum(paddle.to_tensor(num_classes_list))
-        >>> label = paddle.randint(low=0, high=num_classes.item(), shape=[batch_size], dtype='int64')
+        >>> label = paddle.randint(low=0, high=num_classes.item(), shape=[batch_size], dtype='int64')  # type: ignore[arg-type]
         >>> label_list = [] # type: ignore
         >>> dist.all_gather(label_list, label)
         >>> label = paddle.concat(label_list, axis=0)

--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -2343,7 +2343,7 @@ def margin_cross_entropy(
             >>> num_class_per_card = [4, 8]
             >>> num_classes = paddle.sum(paddle.to_tensor(num_class_per_card))
 
-            >>> label = paddle.randint(low=0, high=num_classes.item(), shape=[batch_size], dtype='int64')
+            >>> label = paddle.randint(low=0, high=num_classes.item(), shape=[batch_size], dtype='int64')  # type: ignore[arg-type]
             >>> label_list: List[paddle.Tensor] = []
             >>> dist.all_gather(label_list, label)
             >>> label = paddle.concat(label_list, axis=0)

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -3470,7 +3470,7 @@ def clone(x: paddle.Tensor, name: str | None = None) -> paddle.Tensor:
             >>> y.backward()
             >>> print(clone_x.grad.numpy())  # type: ignore
             [3. 3.]
-            >>> print(x.grad.numpy())
+            >>> print(x.grad.numpy())  # type: ignore
             [3. 3.]
     """
     return x.clone()

--- a/python/paddle/utils/decorator_utils.py
+++ b/python/paddle/utils/decorator_utils.py
@@ -175,7 +175,9 @@ def softmax_param_alias(
     return cast("Callable[_InputT, _RetT]", wrapper)
 
 
-def param_one_alias(alias_list):
+def param_one_alias(
+    alias_list,
+) -> Callable[[Callable[_InputT, _RetT]], Callable[_InputT, _RetT]]:
     def decorator(func: Callable[_InputT, _RetT]) -> Callable[_InputT, _RetT]:
         @functools.wraps(func)
         def wrapper(*args: _InputT.args, **kwargs: _InputT.kwargs) -> _RetT:
@@ -191,7 +193,9 @@ def param_one_alias(alias_list):
     return decorator
 
 
-def param_two_alias(alias_list1, alias_list2):
+def param_two_alias(
+    alias_list1: list[str], alias_list2: list[str]
+) -> Callable[[Callable[_InputT, _RetT]], Callable[_InputT, _RetT]]:
     def decorator(func: Callable[_InputT, _RetT]) -> Callable[_InputT, _RetT]:
         @functools.wraps(func)
         def wrapper(*args: _InputT.args, **kwargs: _InputT.kwargs) -> _RetT:
@@ -246,7 +250,9 @@ def tensor_split_decorator(
     return wrapper
 
 
-def param_two_alias_one_default(alias_list1, alias_list2, default_param):
+def param_two_alias_one_default(
+    alias_list1: list[str], alias_list2: list[str], default_param: list[str]
+) -> Callable[[Callable[_InputT, _RetT]], Callable[_InputT, _RetT]]:
     def decorator(func: Callable[_InputT, _RetT]) -> Callable[_InputT, _RetT]:
         @functools.wraps(func)
         def wrapper(*args: _InputT.args, **kwargs: _InputT.kwargs) -> _RetT:
@@ -303,7 +309,9 @@ class SizeArgsDecorator(DecoratorBase):
         return args, kwargs
 
 
-def size_args_decorator(func: Callable) -> Callable:
+def size_args_decorator(
+    func: Callable[_InputT, _RetT],
+) -> Callable[_InputT, _RetT]:
     """
     A decorator that normalizes the 'size' argument to 'shape'.
 
@@ -332,7 +340,9 @@ def size_args_decorator(func: Callable) -> Callable:
     return wrapped_func
 
 
-def size_args_decorator_patch(method: Callable) -> Callable:
+def size_args_decorator_patch(
+    method: Callable[_InputT, _RetT],
+) -> Callable[_InputT, _RetT]:
     """
     A decorator that allow *size for patching method to Tensor.
     e.g. Tensor.method(*size, *, ...).
@@ -377,7 +387,9 @@ class VariableArgsDecorator(DecoratorBase):
         return args, kwargs
 
 
-def view_decorator():
+def view_decorator() -> Callable[
+    [Callable[_InputT, _RetT]], Callable[_InputT, _RetT]
+]:
     """
     Usage Example:
     paddle.view(x=tensor_x, shape_or_dtype=[-1, 1, 3], name=None)
@@ -510,7 +522,9 @@ class ForbidKeywordsIgnoreOneParamDecorator(ForbidKeywordsDecorator):
         return args, kwargs
 
 
-def reshape_decorator():
+def reshape_decorator() -> Callable[
+    [Callable[_InputT, _RetT]], Callable[_InputT, _RetT]
+]:
     """
     Usage Example:
     paddle.reshape(x=tensor_x, shape=[-1, 1, 3], name=None)
@@ -537,7 +551,9 @@ def reshape_decorator():
     return decorator
 
 
-def transpose_decorator():
+def transpose_decorator() -> Callable[
+    [Callable[_InputT, _RetT]], Callable[_InputT, _RetT]
+]:
     """
     Usage Example:
     PyTorch:
@@ -576,7 +592,9 @@ def transpose_decorator():
     return decorator
 
 
-def expand_decorator():
+def expand_decorator() -> Callable[
+    [Callable[_InputT, _RetT]], Callable[_InputT, _RetT]
+]:
     """
     Usage Example:
     paddle.expand(x=tensor_x, shape=[3, 4], name=None)
@@ -605,7 +623,9 @@ def expand_decorator():
     return decorator
 
 
-def index_select_decorator():
+def index_select_decorator() -> Callable[
+    [Callable[_InputT, _RetT]], Callable[_InputT, _RetT]
+]:
     """
     Usage Example:
     PyTorch: index_select(input, dim, index)
@@ -647,7 +667,9 @@ def index_select_decorator():
     return decorator
 
 
-def sum_decorator():
+def sum_decorator() -> Callable[
+    [Callable[_InputT, _RetT]], Callable[_InputT, _RetT]
+]:
     def decorator(func: Callable[_InputT, _RetT]) -> Callable[_InputT, _RetT]:
         @functools.wraps(func)
         def wrapper(*args: _InputT.args, **kwargs: _InputT.kwargs) -> _RetT:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

修复装饰器上只写明 `Callable` 而不写具体泛型参数导致类型无法传播，进而导致类型提示检查错误通过的问题

<!-- PCard-66972 -->