### PR TITLE
[API compatibility]The remainder api supports parameter aliases and the input type of y is Scalar

### DIFF
--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -1184,6 +1184,7 @@ def floor_divide_(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
     return _C_ops.floor_divide_(x, y)
 
 
+@param_two_alias(["x", "input"], ["y", "other"])
 def remainder(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
     r"""
     Mod two tensors element-wise. The equation is:
@@ -1232,6 +1233,8 @@ def remainder(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
 
     """
     if in_dynamic_or_pir_mode():
+        if isinstance(y, (int, float)):
+            y = paddle.to_tensor(y, dtype=x.dtype)
         return _C_ops.remainder(x, y)
     else:
         return _elementwise_op(LayerHelper('elementwise_mod', **locals()))

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -1237,7 +1237,7 @@ def remainder(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
     """
     if in_dynamic_or_pir_mode():
         if isinstance(y, (int, float)):
-            y = paddle.to_tensor(y, dtype=x.dtype)
+            y = paddle.full([], y, dtype=x.dtype)
         return _C_ops.remainder(x, y)
     else:
         return _elementwise_op(LayerHelper('elementwise_mod', **locals()))

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -1193,6 +1193,9 @@ def remainder(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
 
         out = x \% y
 
+    .. note::
+        Alias Support: The parameter name ``input`` can be used as an alias for ``x``, and ``other`` can be used as an alias for ``y``.
+
     Note:
         ``paddle.remainder`` supports broadcasting. If you want know more about broadcasting, please refer to `Introduction to Tensor`_ .
 

--- a/test/legacy_test/test_elementwise_mod_op.py
+++ b/test/legacy_test/test_elementwise_mod_op.py
@@ -638,6 +638,162 @@ class TestElementwiseModOp_Stride(OpTest):
         pass
 
 
+class TestRemainderAPICompatibility(unittest.TestCase):
+    def setUp(self):
+        np.random.seed(123)
+        paddle.enable_static()
+        self.x_shape = [5, 6]
+        self.y_shape = [5, 6]
+        self.dtype = 'float32'
+        self.init_data()
+
+    def init_data(self):
+        self.np_x_input = np.random.randint(0, 8, self.x_shape).astype(
+            self.dtype
+        )
+        self.np_y_input = np.random.randint(3, 9, self.y_shape).astype(
+            self.dtype
+        )
+
+    def test_dygraph_Compatibility(self):
+        paddle.disable_static()
+        x = paddle.to_tensor(self.np_x_input)
+        y = paddle.to_tensor(self.np_y_input)
+        paddle_dygraph_out = []
+        # Position args (args)
+        out1 = paddle.remainder(x, y)
+        paddle_dygraph_out.append(out1)
+        # Key words args (kwargs) for paddle
+        out2 = paddle.remainder(x=x, y=y)
+        paddle_dygraph_out.append(out2)
+        # Key words args for torch
+        out3 = paddle.remainder(input=x, other=y)
+        paddle_dygraph_out.append(out3)
+        # Combined args and kwargs
+        out4 = paddle.remainder(x, other=y)
+        paddle_dygraph_out.append(out4)
+        # Tensor method args
+        out5 = x.remainder(y)
+        paddle_dygraph_out.append(out5)
+        # Tensor method kwargs
+        out6 = x.remainder(other=y)
+        paddle_dygraph_out.append(out6)
+        # Numpy reference  out
+        ref_out = self.np_x_input % self.np_y_input
+        # Check
+        for out in paddle_dygraph_out:
+            np.testing.assert_allclose(ref_out, out.numpy())
+        paddle.enable_static()
+
+    def test_static_Compatibility(self):
+        main = paddle.static.Program()
+        startup = paddle.static.Program()
+        with base.program_guard(main, startup):
+            x = paddle.static.data(
+                name="x", shape=self.x_shape, dtype=self.dtype
+            )
+            y = paddle.static.data(
+                name="y", shape=self.y_shape, dtype=self.dtype
+            )
+            # Position args (args)
+            out1 = paddle.remainder(x, y)
+            # Key words args (kwargs) for paddle
+            out2 = paddle.remainder(x=x, y=y)
+            # Key words args for torch
+            out3 = paddle.remainder(input=x, other=y)
+            # Combined args and kwargs
+            out4 = paddle.remainder(x, other=y)
+            # Tensor method args
+            out5 = x.remainder(y)
+            # Tensor method kwargs
+            out6 = x.remainder(other=y)
+            exe = base.Executor(paddle.CPUPlace())
+            fetches = exe.run(
+                main,
+                feed={"x": self.np_x_input, "y": self.np_y_input},
+                fetch_list=[out1, out2, out3, out4, out5, out6],
+            )
+            ref_out = self.np_x_input % self.np_y_input
+            for out in fetches:
+                np.testing.assert_allclose(out, ref_out)
+
+
+# test y is a scalar
+class TestRemainderAPICompatibility1(unittest.TestCase):
+    def setUp(self):
+        np.random.seed(123)
+        paddle.enable_static()
+        self.x_shape = [5, 6]
+        self.dtype = 'float32'
+        self.init_data()
+
+    def init_data(self):
+        self.np_x_input = np.random.randint(0, 8, self.x_shape).astype(
+            self.dtype
+        )
+        self.np_y_input = 2
+
+    def test_dygraph_Compatibility(self):
+        paddle.disable_static()
+        x = paddle.to_tensor(self.np_x_input)
+        y = self.np_y_input
+        paddle_dygraph_out = []
+        # Position args (args)
+        out1 = paddle.remainder(x, y)
+        paddle_dygraph_out.append(out1)
+        # Key words args (kwargs) for paddle
+        out2 = paddle.remainder(x=x, y=y)
+        paddle_dygraph_out.append(out2)
+        # Key words args for torch
+        out3 = paddle.remainder(input=x, other=y)
+        paddle_dygraph_out.append(out3)
+        # Combined args and kwargs
+        out4 = paddle.remainder(x, other=y)
+        paddle_dygraph_out.append(out4)
+        # Tensor method args
+        out5 = x.remainder(y)
+        paddle_dygraph_out.append(out5)
+        # Tensor method kwargs
+        out6 = x.remainder(other=y)
+        paddle_dygraph_out.append(out6)
+        # Numpy reference  out
+        ref_out = self.np_x_input % self.np_y_input
+        # Check
+        for out in paddle_dygraph_out:
+            np.testing.assert_allclose(ref_out, out.numpy())
+        paddle.enable_static()
+
+    def test_static_Compatibility(self):
+        main = paddle.static.Program()
+        startup = paddle.static.Program()
+        with base.program_guard(main, startup):
+            x = paddle.static.data(
+                name="x", shape=self.x_shape, dtype=self.dtype
+            )
+            y = self.np_y_input
+            # Position args (args)
+            out1 = paddle.remainder(x, y)
+            # Key words args (kwargs) for paddle
+            out2 = paddle.remainder(x=x, y=y)
+            # Key words args for torch
+            out3 = paddle.remainder(input=x, other=y)
+            # Combined args and kwargs
+            out4 = paddle.remainder(x, other=y)
+            # Tensor method args
+            out5 = x.remainder(y)
+            # Tensor method kwargs
+            out6 = x.remainder(other=y)
+            exe = base.Executor(paddle.CPUPlace())
+            fetches = exe.run(
+                main,
+                feed={"x": self.np_x_input, "y": self.np_y_input},
+                fetch_list=[out1, out2, out3, out4, out5, out6],
+            )
+            ref_out = self.np_x_input % self.np_y_input
+            for out in fetches:
+                np.testing.assert_allclose(out, ref_out)
+
+
 class TestElementwiseModOp_Stride1(TestElementwiseModOp_Stride):
     def init_input_output(self):
         self.strided_input_type = "transpose"


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Operator Mechanism 
### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Improvements
### Description
<!-- Describe what you’ve done -->

paddle.remainder 支持别名以及y为int / float等非tensor类型的输入。

pcard-67164
