### PR TITLE
[FP8] Fix fp8 Tensor display

### DIFF
--- a/python/paddle/tensor/to_string.py
+++ b/python/paddle/tensor/to_string.py
@@ -293,12 +293,11 @@ def mask_xpu_bf16_tensor(np_tensor):
 
 def _format_dense_tensor(tensor, indent):
     dtype = tensor.dtype
-    if (
-        dtype == paddle.bfloat16
-        or dtype == core.VarDesc.VarType.BF16
-        or dtype == core.VarDesc.VarType.FP8_E4M3FN
-        or dtype == core.VarDesc.VarType.FP8_E5M2
-    ):
+    if dtype in {
+        paddle.bfloat16,
+        paddle.float8_e4m3fn,
+        paddle.float8_e5m2,
+    }:
         if not tensor.place.is_cpu_place():
             paddle.device.synchronize()
         tensor = tensor.astype('float32')

--- a/test/legacy_test/test_eager_tensor.py
+++ b/test/legacy_test/test_eager_tensor.py
@@ -1311,6 +1311,32 @@ class TestEagerTensor(unittest.TestCase):
 
         self.assertEqual(a_str, expected)
 
+    def test_tensor_str_fp8_e4m3fn(self):
+        paddle.disable_static(paddle.CPUPlace())
+        a = paddle.to_tensor([[1.5, 1.0], [0, 0]])
+        a = paddle.cast(a, dtype=paddle.float8_e4m3fn)
+        paddle.set_printoptions(precision=4)
+        a_str = str(a)
+
+        expected = """Tensor(shape=[2, 2], dtype=float8_e4m3fn, place=Place(cpu), stop_gradient=True,
+       [[1.5000, 1.    ],
+        [0.    , 0.    ]])"""
+
+        self.assertEqual(a_str, expected)
+
+    def test_tensor_str_fp8_e5m2(self):
+        paddle.disable_static(paddle.CPUPlace())
+        a = paddle.to_tensor([[1.5, 1.0], [0, 0]])
+        a = paddle.cast(a, dtype=paddle.float8_e5m2)
+        paddle.set_printoptions(precision=4)
+        a_str = str(a)
+
+        expected = """Tensor(shape=[2, 2], dtype=float8_e5m2, place=Place(cpu), stop_gradient=True,
+       [[1.5000, 1.    ],
+        [0.    , 0.    ]])"""
+
+        self.assertEqual(a_str, expected)
+
     def test_print_tensor_dtype(self):
         paddle.disable_static(paddle.CPUPlace())
         a = paddle.rand([1])


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

`tensor.dtype` 是 `DataType` 而不是 `VarType`，因此对于 FP8 而言不会走 cast，进而导致展示的数值是错误的，十分影响 debug

```pycon
>>> paddle.tensor(52.).cast(paddle.float8_e4m3fn)
Tensor(shape=[], dtype=float8_e4m3fn, place=Place(cpu), stop_gradient=True,
       101)
```

修复后一切正常

```pycon
>>> import paddle
>>> paddle.tensor(52.).cast(paddle.float8_e4m3fn)
Tensor(shape=[], dtype=float8_e4m3fn, place=Place(cpu), stop_gradient=True,
       52.)
```

FP8 搞了大半年，都是靠什么 debug 的？？？？？

<!-- PCard-66972 -->