### PR TITLE
[TVM FFI] Support `__tvm_ffi_env_stream__` protocol

### DIFF
--- a/python/paddle/base/dygraph/tensor_patch_methods.py
+++ b/python/paddle/base/dygraph/tensor_patch_methods.py
@@ -1538,6 +1538,7 @@ def monkey_patch_tensor():
         ("__cuda_array_interface__", __cuda_array_interface__),
         ("__dlpack__", __dlpack__),
         ("__dlpack_device__", __dlpack_device__),
+        ("__tvm_ffi_env_stream__", __tvm_ffi_env_stream__),
     ):
         setattr(core.eager.Tensor, method_name, method)
 

--- a/python/paddle/base/dygraph/tensor_patch_methods.py
+++ b/python/paddle/base/dygraph/tensor_patch_methods.py
@@ -1476,6 +1476,21 @@ def monkey_patch_tensor():
 
         return paddle.to_dlpack(self)
 
+    def __tvm_ffi_env_stream__(self) -> int:
+        """
+        Returns the raw stream pointer of the current tensor's device context.
+        This is used for TVM FFI environment integration.
+        """
+        if self.place.is_gpu_place():
+            return paddle.base.libpaddle._get_current_raw_stream(
+                self.place.gpu_device_id()
+            )
+        else:
+            # TODO: Add XPU and custom device support.
+            raise RuntimeError(
+                "Currently, the __tvm_ffi_env_stream__ method is only supported for GPU tensors."
+            )
+
     if not hasattr(core, "eager"):
         return
 

--- a/test/dygraph_to_static/test_tensor_attr_consistency.py
+++ b/test/dygraph_to_static/test_tensor_attr_consistency.py
@@ -80,6 +80,7 @@ DYGRAPH_ONLY_TENSOR_ATTRS_ALLOW_LIST = OrderedSet(
         "__cuda_array_interface__",
         '__dlpack__',
         "__dlpack_device__",
+        "__tvm_ffi_env_stream__",
     ]
 )
 STATIC_ONLY_TENSOR_ATTRS_ALLOW_LIST = OrderedSet(

--- a/test/legacy_test/test_tvm_ffi.py
+++ b/test/legacy_test/test_tvm_ffi.py
@@ -18,13 +18,20 @@ import paddle
 
 
 class TestTVMFFI(unittest.TestCase):
-    def test_tvm_ffi_env_stream(self):
+    def test_tvm_ffi_env_stream_for_gpu_tensor(self):
         if not paddle.is_compiled_with_cuda():
             return
-        tensor = paddle.to_tensor([1.0, 2.0, 3.0])
+        tensor = paddle.to_tensor([1.0, 2.0, 3.0]).cuda()
         current_raw_stream_ptr = tensor.__tvm_ffi_env_stream__()
         self.assertIsInstance(current_raw_stream_ptr, int)
         self.assertNotEqual(current_raw_stream_ptr, 0)
+
+    def test_tvm_ffi_env_stream_for_cpu_tensor(self):
+        tensor = paddle.to_tensor([1.0, 2.0, 3.0]).cpu()
+        with self.assertRaisesRegex(
+            RuntimeError, r"the __tvm_ffi_env_stream__ method"
+        ):
+            tensor.__tvm_ffi_env_stream__()
 
 
 if __name__ == '__main__':

--- a/test/legacy_test/test_tvm_ffi.py
+++ b/test/legacy_test/test_tvm_ffi.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import paddle
+
+
+class TestTVMFFI(unittest.TestCase):
+    def test_tvm_ffi_env_stream(self):
+        if not paddle.is_compiled_with_cuda():
+            return
+        tensor = paddle.to_tensor([1.0, 2.0, 3.0])
+        current_raw_stream_ptr = tensor.__tvm_ffi_env_stream__()
+        self.assertIsInstance(current_raw_stream_ptr, int)
+        self.assertNotEqual(current_raw_stream_ptr, 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

New features

### Description
<!-- Describe what you’ve done -->

Add `__tvm_ffi_env_stream__` protocol support. This interface was proposed at apache/tvm#18293 and implemented at apache/tvm#18295 to enable TVM FFI to retrieve stream context from Tensor.

This PR has been tested on https://github.com/apache/tvm/blob/485a309dcdd9044d252b52aee81c07fa1c62dfa7/ffi/examples/quick_start/run_example.py#L54

<!-- PCard-66972 -->