### PR TITLE
[API-Compat] Added paddle.compat.pad and unittests

### DIFF
--- a/python/paddle/compat.py
+++ b/python/paddle/compat.py
@@ -26,6 +26,7 @@ from .tensor.compat import (
     median,
     min,
     nanmedian,
+    pad,
     slogdet,
     sort,
     split,
@@ -42,6 +43,7 @@ __all__ = [
     'max',
     'median',
     'nanmedian',
+    'pad',
 ]
 
 

--- a/python/paddle/tensor/compat.py
+++ b/python/paddle/tensor/compat.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, NamedTuple
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple
 
 import paddle
 from paddle import _C_ops
@@ -27,10 +27,17 @@ from ..framework import (
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+    from typing_extensions import TypeAlias
+
     from paddle import Tensor
     from paddle._typing import (
+        ShapeLike,
         Size2,
     )
+
+    _PaddingTensorMode: TypeAlias = Literal[
+        "zeros", "constant", "reflect", "replicate", "circular"
+    ]
 
 from paddle import nn
 from paddle.utils.decorator_utils import ForbidKeywordsDecorator
@@ -1032,3 +1039,155 @@ def nanmedian(
             paddle.assign(indices, out[1])
             return MedianRetType(values=out[0], indices=out[1])
         return MedianRetType(values=values, indices=indices)
+
+
+def _check_valid_pad_len(pad_len, x_dim, is_constant):
+    if pad_len > 6 or pad_len < 0:
+        raise ValueError(f"Expect len(pad) <= 6 and not -1, got: {pad_len}")
+    max_dim = 2 * x_dim - (0 if is_constant else 2)
+    if pad_len > max_dim:
+        raise ValueError(
+            f"len(pad) is bounded by input.ndim: expect len(pad) <= {max_dim}, got: {pad_len}"
+        )
+
+
+@ForbidKeywordsDecorator(
+    illegal_keys={"x", "name", "data_format", "pad_from_left_axis"},
+    func_name="paddle.compat.pad",
+    correct_name="paddle.nn.functional.pad",
+)
+def pad(
+    input: Tensor,
+    pad: ShapeLike,
+    mode: _PaddingTensorMode = 'constant',
+    value: float = 0.0,
+) -> Tensor:
+    """
+
+    PyTorch compatible version of :ref:`api_paddle_nn_functional_pad`. For the original API, see :ref:`api_paddle_nn_functional_pad` for more details.
+
+    Pad tensor according to ``'pad'`` and ``'mode'``. All the padding operations under the hood starts from the **right** (last dim) of the tensor.
+
+    Args:
+        input (Tensor): The input tensor with data type float32, float64, int32, int64, complex64 or complex128.
+        pad (Tensor|list[int]|tuple[int]): The padding size with data type int. Refer to Note for details.
+        mode (str, optional): Four modes: ``'constant'`` (default), ``'reflect'``, ``'replicate'``, ``'circular'``. Default is ``'constant'``.
+
+           - 'constant' mode, uses a constant value to pad the input tensor.
+           - 'reflect' mode, uses reflection of the input boundaries to pad the input tensor.
+           - 'replicate' mode, uses input boundaries to pad the input tensor.
+           - 'circular' mode, uses circular input to pad the input tensor.
+
+        value (float, optional): The value to fill the padded areas in 'constant' mode . Default is :math:`0.0`.
+
+    Note:
+        For non ``'constant'`` mode, padding size can not be greater than ``min(2 * input.ndim - 2, 6)``.
+        Only 2D, 3D, 4D and 5D tensors are supported with up to the last 3 dims (if ndim >= 3) can be padded.
+
+    Returns:
+        Tensor, a Tensor padded according to pad and mode and data type is same as input.
+
+    Examples:
+        .. code-block:: python
+
+            >>> import paddle
+
+            >>> input_shape = (1, 1, 3)
+            >>> input_ = paddle.arange(paddle.prod(paddle.to_tensor(input_shape)), dtype="float32").reshape(input_shape) + 1
+            >>> y = paddle.compat.pad(input_, [1, 0, 0, 1], value=0, mode='constant')
+            >>> print(y)
+            Tensor(shape=[1, 2, 4], dtype=float32, place=Place(cpu), stop_gradient=True,
+                [[[0., 1., 2., 3.],
+                  [0., 0., 0., 0.]]])
+
+            >>> # reflect 2D padding
+            >>> input_ = paddle.arange(6).reshape([2, 3])
+            >>> y = paddle.compat.pad(input=input_, pad=(1, 1), mode='reflect')
+            >>> print(y)
+            Tensor(shape=[2, 5], dtype=int64, place=Place(cpu), stop_gradient=True,
+                [[1, 0, 1, 2, 1],
+                 [4, 3, 4, 5, 4]])
+    """
+
+    assert mode in [
+        'reflect',
+        'replicate',
+        'constant',
+        'circular',
+    ], (
+        f"mode should be one of constant, reflect, replicate, circular, but got {mode}."
+    )
+
+    x_dim = len(input.shape)
+    if in_dynamic_mode():
+        if isinstance(pad, (Variable, paddle.Tensor)) and pad.size == 0:
+            return input.clone()
+
+    if (
+        mode == "constant"
+        and isinstance(pad, (list, tuple))
+        and len(pad) != (x_dim - 2) * 2
+    ):
+        paddings = pad
+        pad_value = value
+
+        padding_len = len(paddings)
+        # pad the length of paddings to 2*x_dim
+        if padding_len < 2 * x_dim:
+            pad_len_for_paddings = 2 * x_dim - padding_len
+            paddings = paddings + ([0] if isinstance(pad, list) else (0,)) * (
+                pad_len_for_paddings
+            )
+
+        # since the kernel pad from left axis, if we want to pad from right axis, we need to reverse the paddings
+        paddings = [
+            paddings[i - 1] if i % 2 == 1 else paddings[i + 1]
+            for i in range(2 * x_dim - 1, -1, -1)
+        ]
+        pad_val = (
+            pad_value
+            if isinstance(pad_value, paddle.pir.Value)
+            else float(pad_value)
+        )
+        return _C_ops.pad(input, paddings, pad_val)
+
+    assert x_dim >= 1 and x_dim <= 5, (
+        f"Input tensor dimension must be in [1-5] but got {x_dim}"
+    )
+
+    is_constant_mode = mode == 'constant'
+    if (not is_constant_mode) and x_dim < 2:
+        raise ValueError(
+            f"Only 2D, 3D, 4D, 5D padding with non-constant padding are supported for now, got ndim: {x_dim}"
+        )
+
+    # pad the `pad` to be length = 6 (right padding), for example [1, 2] -> [1, 2, 0, 0, 0, 0]
+    if isinstance(pad, (Variable, paddle.pir.Value)):
+        pad_len = pad.shape[0]
+        _check_valid_pad_len(pad_len, x_dim, is_constant_mode)
+        pad = paddle.concat(
+            [
+                pad,
+                paddle.zeros((6 - pad_len,), dtype="int32"),
+            ],
+            axis=0,
+        )
+    else:
+        pad = list(pad)
+        pad_len = len(pad)
+        _check_valid_pad_len(pad_len, x_dim, is_constant_mode)
+        pad.extend([0] * (6 - pad_len))
+
+    ndim_to_unsqueeze = list(range(5 - x_dim))
+    input = input.unsqueeze(axis=ndim_to_unsqueeze)
+
+    out = _C_ops.pad3d(
+        input,
+        pad.tolist() if isinstance(pad, Variable) else pad,
+        mode,
+        value,
+        "NCDHW",
+    )
+    if ndim_to_unsqueeze:
+        return out.squeeze(axis=ndim_to_unsqueeze)
+    return out

--- a/test/legacy_test/test_compat_pad.py
+++ b/test/legacy_test/test_compat_pad.py
@@ -1,0 +1,254 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+
+import paddle
+import paddle.compat as F
+
+
+class TestCompatPad(unittest.TestCase):
+    def test_basic_pad(self):
+        """Test basic splitting with integer size"""
+        gt = np.array(
+            [
+                [[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]],
+                [[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]],
+                [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [0.0, 0.0]],
+                [[7.0, 8.0], [9.0, 10.0], [11.0, 12.0], [0.0, 0.0]],
+                [[13.0, 14.0], [15.0, 16.0], [17.0, 18.0], [0.0, 0.0]],
+                [[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]],
+                [[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]],
+                [[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]],
+            ],
+            dtype=np.float32,
+        )
+        x_shape = (3, 3, 2)
+        x = (
+            paddle.arange(
+                paddle.prod(paddle.Tensor(x_shape)), dtype=paddle.float32
+            ).reshape(x_shape)
+            + 1
+        )
+        result = F.pad(
+            input=x, pad=[0, 0, 0, 1, 2, 3], mode='constant', value=0
+        )
+
+        np.testing.assert_allclose(result.numpy(), gt)
+
+    def test_constant_fast_pass(self):
+        gt_res = np.array(
+            [
+                [[-1, -1, -1, -1, -1], [-1, 0, 1, -1, -1], [-1, 2, 3, -1, -1]],
+                [[-1, -1, -1, -1, -1], [-1, 4, 5, -1, -1], [-1, 6, 7, -1, -1]],
+                [
+                    [-1, -1, -1, -1, -1],
+                    [-1, 8, 9, -1, -1],
+                    [-1, 10, 11, -1, -1],
+                ],
+            ],
+            dtype=np.int64,
+        )
+
+        def const_pad_dy(x, pad_shape):
+            return F.pad(input=x, pad=pad_shape, mode='constant', value=-1)
+
+        @paddle.jit.to_static(full_graph=True)
+        def const_pad_st(x, pad_shape):
+            return F.pad(
+                input=x,
+                pad=pad_shape,
+                mode='constant',
+                value=paddle.to_tensor(-1),
+            )
+
+        x = paddle.arange(12).reshape(3, 2, 2)
+        res_dy = const_pad_dy(x, [1, 2, 1])
+        res_st = const_pad_st(x, [1, 2, 1])
+
+        np.testing.assert_array_equal(res_dy.numpy(), gt_res)
+        np.testing.assert_array_equal(res_st.numpy(), gt_res)
+
+    def test_single_dim(self):
+        gt = np.array([0, 0, 1, 2], dtype=np.float64)
+        x_shape = 2
+        x = paddle.arange(2, dtype=paddle.float64) + 1
+        result = F.pad(x, mode='constant', pad=[2])
+        np.testing.assert_allclose(result.numpy(), gt)
+
+    def test_no_pad(self):
+        gt = np.array(
+            [
+                [
+                    [
+                        [[0.0, 0.0, 1.0], [2.0, 2.0, 3.0], [2.0, 2.0, 3.0]],
+                        [[4.0, 4.0, 5.0], [6.0, 6.0, 7.0], [6.0, 6.0, 7.0]],
+                    ],
+                    [
+                        [
+                            [8.0, 8.0, 9.0],
+                            [10.0, 10.0, 11.0],
+                            [10.0, 10.0, 11.0],
+                        ],
+                        [
+                            [12.0, 12.0, 13.0],
+                            [14.0, 14.0, 15.0],
+                            [14.0, 14.0, 15.0],
+                        ],
+                    ],
+                ],
+                [
+                    [
+                        [
+                            [16.0, 16.0, 17.0],
+                            [18.0, 18.0, 19.0],
+                            [18.0, 18.0, 19.0],
+                        ],
+                        [
+                            [20.0, 20.0, 21.0],
+                            [22.0, 22.0, 23.0],
+                            [22.0, 22.0, 23.0],
+                        ],
+                    ],
+                    [
+                        [
+                            [24.0, 24.0, 25.0],
+                            [26.0, 26.0, 27.0],
+                            [26.0, 26.0, 27.0],
+                        ],
+                        [
+                            [28.0, 28.0, 29.0],
+                            [30.0, 30.0, 31.0],
+                            [30.0, 30.0, 31.0],
+                        ],
+                    ],
+                ],
+            ],
+            dtype=np.float64,
+        )
+        x = paddle.arange(32, dtype=paddle.float64).reshape([2] * 5)
+        result = F.pad(x, mode='replicate', pad=[1, 0, 0, 1, 0, 0])
+        np.testing.assert_allclose(result.numpy(), gt)
+
+    def test_static_graph_circular(self):
+        cir_gt = np.array(
+            [
+                [
+                    [10.0, 11.0, 8.0, 9.0, 10.0, 11.0, 8.0],
+                    [2.0, 3.0, 0.0, 1.0, 2.0, 3.0, 0.0],
+                    [6.0, 7.0, 4.0, 5.0, 6.0, 7.0, 4.0],
+                    [10.0, 11.0, 8.0, 9.0, 10.0, 11.0, 8.0],
+                ],
+                [
+                    [22.0, 23.0, 20.0, 21.0, 22.0, 23.0, 20.0],
+                    [14.0, 15.0, 12.0, 13.0, 14.0, 15.0, 12.0],
+                    [18.0, 19.0, 16.0, 17.0, 18.0, 19.0, 16.0],
+                    [22.0, 23.0, 20.0, 21.0, 22.0, 23.0, 20.0],
+                ],
+            ],
+            dtype=np.float32,
+        )
+        paddle.enable_static()
+        with paddle.static.program_guard(paddle.static.Program()):
+            input_tensor = paddle.arange(24, dtype=paddle.float32).reshape(
+                [2, 3, 4]
+            )
+
+            pad = paddle.to_tensor([2, 1, 1], dtype="int32")
+            result = F.pad(input_tensor, pad=pad, mode='circular')
+
+            place = (
+                paddle.CUDAPlace(0)
+                if paddle.base.is_compiled_with_cuda()
+                else paddle.CPUPlace()
+            )
+            exe = paddle.static.Executor(place)
+            cir_res = exe.run(fetch_list=[result])
+            np.testing.assert_allclose(cir_res[0], cir_gt)
+        paddle.disable_static()
+
+    def test_dyn_graph_reflect(self):
+        x = paddle.full([10, 10], 2, dtype=paddle.float64)
+        result = F.pad(x, mode='reflect', pad=(1,))
+        np.testing.assert_allclose(
+            result.numpy(), np.full([10, 11], 2, dtype=np.float64)
+        )
+
+    def test_special_cases(self):
+        # empty padding tensor
+        x = paddle.randn([10, 7], dtype=paddle.float64)
+        result = F.pad(x, mode='replicate', pad=paddle.tensor([]))
+        np.testing.assert_allclose(result.numpy(), x.numpy())
+
+    def test_error_handling(self):
+        dummy_x = paddle.arange(3)
+
+        wrong_api_used = (
+            "paddle.compat.pad() received unexpected keyword arguments 'name', 'x'. "
+            "\nDid you mean to use paddle.nn.functional.pad() instead?"
+        )
+        ndim_no_impl = "Input tensor dimension must be in [1-5] but got {x_dim}"
+        non_const_ndim_no_impl = "Only 2D, 3D, 4D, 5D padding with non-constant padding are supported for now, got ndim: {x_dim}"
+        mode_no_impl = "mode should be one of constant, reflect, replicate, circular, but got mirror."
+        pad_len_invalid1 = "Expect len(pad) <= 6 and not -1, got: {pad_len}"
+        pad_len_invalid2 = "len(pad) is bounded by input.ndim: expect len(pad) <= {max_dim}, got: {pad_len}"
+
+        with self.assertRaises(TypeError) as cm:
+            tensors = F.pad(
+                x=dummy_x,
+                mode='constant',
+                pad=paddle.to_tensor(2),
+                name='pad_layer',
+            )
+        self.assertEqual(str(cm.exception), wrong_api_used)
+
+        with self.assertRaises(AssertionError) as cm:
+            tensors = F.pad(
+                paddle.arange(64).reshape([2] * 6),
+                mode='constant',
+                pad=paddle.to_tensor(2),
+            )
+        self.assertEqual(str(cm.exception), ndim_no_impl.format(x_dim=6))
+
+        with self.assertRaises(ValueError) as cm:
+            tensors = F.pad(paddle.arange(2), mode='circular', pad=[0, 1])
+        self.assertEqual(
+            str(cm.exception), non_const_ndim_no_impl.format(x_dim=1)
+        )
+
+        with self.assertRaises(AssertionError) as cm:
+            tensors = F.pad(paddle.arange(2), mode='mirror', pad=[0, 1])
+        self.assertEqual(str(cm.exception), mode_no_impl)
+
+        with self.assertRaises(ValueError) as cm:
+            tensors = F.pad(
+                paddle.ones([2, 3, 4]),
+                mode='replicate',
+                pad=[0, 1, 1, 1, 1, 1, 1, 1],
+            )
+        self.assertEqual(str(cm.exception), pad_len_invalid1.format(pad_len=8))
+
+        with self.assertRaises(ValueError) as cm:
+            tensors = F.pad(
+                paddle.ones([2, 3]), mode='replicate', pad=[0, 1, 1, 1, 1]
+            )
+        self.assertEqual(
+            str(cm.exception), pad_len_invalid2.format(max_dim=2, pad_len=5)
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Operator Mechanism


### PR Types
New features


### Description

增加了 `paddle.compat.pad`，行为兼容 `torch.nn.functional.pad`。已过 PaConvert 测试（包含新增的7个测试）。

Pcard-89620
