### PR TITLE
warpctc cuda arch

### DIFF
--- a/cmake/external/warpctc.cmake
+++ b/cmake/external/warpctc.cmake
@@ -28,9 +28,8 @@ set(WARPCTC_PATCH_COMMAND "")
 set(WARPCTC_CCBIN_OPTION "")
 if(WIN32)
   set(WARPCTC_PATCH_CUDA_COMMAND
-      ${CMAKE_COMMAND} -E copy_if_different
-      ${PADDLE_SOURCE_DIR}/patches/warpctc/CMakeLists.txt.cuda.patch
-      "<SOURCE_DIR>/")
+      git checkout -- . && git checkout ${WARPCTC_TAG} && git apply
+      ${PADDLE_SOURCE_DIR}/patches/warpctc/CMakeLists.txt.cuda.patch)
 else()
   set(WARPCTC_PATCH_CUDA_COMMAND
       git checkout -- . && git checkout ${WARPCTC_TAG} && patch -Nd

--- a/paddle/phi/backends/CMakeLists.txt
+++ b/paddle/phi/backends/CMakeLists.txt
@@ -15,7 +15,7 @@ if(WITH_GPU OR WITH_ROCM)
       nv_library(
         cuda_graph_lib static
         SRCS gpu/cuda/cuda_graph.cc
-        DEPS dynload_cuda)
+        DEPS dynload_cuda onednn)
       list(APPEND BACKENDS_SRCS gpu/cuda/cuda_info.cc)
     else()
       list(APPEND BACKENDS_SRCS gpu/cuda/cuda_info.cc gpu/cuda/cuda_graph.cc)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
pcard-67164
OCR文本识别模型在windows平台50显卡环境下训练报错，原因是对第三方库warpctc的patch没有在windows平台生效，导致cmake参数指定显卡架构时没有传入warpctc，所以在windows下没有编译89 120架构