### PR TITLE
[Infra] Refine Linux-build re-run condition

### DIFF
--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -209,7 +209,7 @@ jobs:
           JOB_NAME: 'Distribute-stable / Test'
 
       - name: Rerun build
-        if: ${{ contains(github.event.comment.body, 'build') }}
+        if: ${{ contains(github.event.comment.body, 'linux') && contains(github.event.comment.body, 'build') }}
         uses: ./.github/actions/rerun-workflow
         with:
           PR_ID: ${{ github.event.issue.number }}


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
我只想 re-run xpu build 的时候，`/re-run xpu build` 的时候 linux build 也被 re-run 了，触发了后续很多 CI

> 刚刚测试了一下，linux build 也跑了，猜测可能是出于安全性，得合入或者什么条件才会跑本 pr 的 action 吗