### PR TITLE
add scatter commOp wwhen compiled with FlagCX

### DIFF
--- a/cmake/third_party.cmake
+++ b/cmake/third_party.cmake
@@ -457,14 +457,6 @@ if(TARGET extern_libuv)
   list(APPEND third_party_deps extern_libuv)
 endif()
 
-if(WITH_FLAGCX)
-  include(external/flagcx)
-  list(APPEND third_party_deps flagcx)
-  if(WITH_XPU)
-    add_dependencies(flagcx_ep extern_xpu)
-  endif()
-endif()
-
 if(WITH_ONNXRUNTIME)
   include(external/onnxruntime
   )# download, build, install onnxruntime、paddle2onnx
@@ -510,6 +502,14 @@ endif()
 if(WITH_XPU)
   include(external/xpu) # download, build, install xpu
   list(APPEND third_party_deps extern_xpu)
+endif()
+
+if(WITH_FLAGCX)
+  include(external/flagcx)
+  list(APPEND third_party_deps flagcx)
+  if(WITH_XPU)
+    add_dependencies(flagcx_ep extern_xpu)
+  endif()
 endif()
 
 if(NOT WIN32 AND NOT APPLE)

--- a/paddle/fluid/distributed/collective/process_group_bkcl.h
+++ b/paddle/fluid/distributed/collective/process_group_bkcl.h
@@ -136,6 +136,13 @@ class ProcessGroupBKCL : public ProcessGroupWithStream {
       const ReduceScatterOptions& opts,
       bool sync_op,
       bool use_calc_stream) override;
+#if defined(PADDLE_WITH_FLAGCX)
+  std::shared_ptr<ProcessGroup::Task> Scatter(phi::DenseTensor* out_tensor,
+                                              const phi::DenseTensor& in_tensor,
+                                              const ScatterOptions& opts,
+                                              bool sync_op,
+                                              bool use_calc_stream) override;
+#endif
 
   std::shared_ptr<ProcessGroup::Task> Recv(phi::DenseTensor* tensor,
                                            int src_rank,

--- a/paddle/phi/backends/dynload/flagcx.h
+++ b/paddle/phi/backends/dynload/flagcx.h
@@ -37,28 +37,29 @@ extern void* flagcx_dso_handle;
   };                                                                 \
   extern struct DynLoad__##__name __name
 
-#define FLAGCX_RAND_ROUTINE_EACH(__macro)                  \
-  __macro(flagcxGetUniqueId);                              \
-  __macro(flagcxCommInitRank);                             \
-  __macro(flagcxGetVersion);                               \
-  __macro(flagcxCommAbort);                                \
-  __macro(flagcxCommDestroy);                              \
-  __macro(flagcxCommCount);                                \
-  __macro(flagcxCommUserRank);                             \
-  __macro(flagcxAllReduce);                                \
-  __macro(flagcxBroadcast);                                \
-  __macro(flagcxAllGather);                                \
-  __macro(flagcxAlltoAll);                                 \
-  __macro(flagcxAlltoAllv);                                \
-  __macro(flagcxGroupStart);                               \
-  __macro(flagcxGroupEnd);                                 \
-  __macro(flagcxReduce);                                   \
-  __macro(flagcxReduceScatter);                            \
-  __macro(flagcxScatter) __macro(flagcxCommGetAsyncError); \
-  __macro(flagcxSend);                                     \
-  __macro(flagcxRecv);                                     \
-  __macro(flagcxHandleInit);                               \
-  __macro(flagcxHandleFree);                               \
+#define FLAGCX_RAND_ROUTINE_EACH(__macro) \
+  __macro(flagcxGetUniqueId);             \
+  __macro(flagcxCommInitRank);            \
+  __macro(flagcxGetVersion);              \
+  __macro(flagcxCommAbort);               \
+  __macro(flagcxCommDestroy);             \
+  __macro(flagcxCommCount);               \
+  __macro(flagcxCommUserRank);            \
+  __macro(flagcxAllReduce);               \
+  __macro(flagcxBroadcast);               \
+  __macro(flagcxAllGather);               \
+  __macro(flagcxAlltoAll);                \
+  __macro(flagcxAlltoAllv);               \
+  __macro(flagcxGroupStart);              \
+  __macro(flagcxGroupEnd);                \
+  __macro(flagcxReduce);                  \
+  __macro(flagcxReduceScatter);           \
+  __macro(flagcxScatter);                 \
+  __macro(flagcxCommGetAsyncError);       \
+  __macro(flagcxSend);                    \
+  __macro(flagcxRecv);                    \
+  __macro(flagcxHandleInit);              \
+  __macro(flagcxHandleFree);              \
   __macro(flagcxGetErrorString);
 
 FLAGCX_RAND_ROUTINE_EACH(DECLARE_DYNAMIC_LOAD_FLAGCX_WRAP)

--- a/paddle/phi/backends/dynload/flagcx.h
+++ b/paddle/phi/backends/dynload/flagcx.h
@@ -37,28 +37,28 @@ extern void* flagcx_dso_handle;
   };                                                                 \
   extern struct DynLoad__##__name __name
 
-#define FLAGCX_RAND_ROUTINE_EACH(__macro) \
-  __macro(flagcxGetUniqueId);             \
-  __macro(flagcxCommInitRank);            \
-  __macro(flagcxGetVersion);              \
-  __macro(flagcxCommAbort);               \
-  __macro(flagcxCommDestroy);             \
-  __macro(flagcxCommCount);               \
-  __macro(flagcxCommUserRank);            \
-  __macro(flagcxAllReduce);               \
-  __macro(flagcxBroadcast);               \
-  __macro(flagcxAllGather);               \
-  __macro(flagcxAlltoAll);                \
-  __macro(flagcxAlltoAllv);               \
-  __macro(flagcxGroupStart);              \
-  __macro(flagcxGroupEnd);                \
-  __macro(flagcxReduce);                  \
-  __macro(flagcxReduceScatter);           \
-  __macro(flagcxCommGetAsyncError);       \
-  __macro(flagcxSend);                    \
-  __macro(flagcxRecv);                    \
-  __macro(flagcxHandleInit);              \
-  __macro(flagcxHandleFree);              \
+#define FLAGCX_RAND_ROUTINE_EACH(__macro)                  \
+  __macro(flagcxGetUniqueId);                              \
+  __macro(flagcxCommInitRank);                             \
+  __macro(flagcxGetVersion);                               \
+  __macro(flagcxCommAbort);                                \
+  __macro(flagcxCommDestroy);                              \
+  __macro(flagcxCommCount);                                \
+  __macro(flagcxCommUserRank);                             \
+  __macro(flagcxAllReduce);                                \
+  __macro(flagcxBroadcast);                                \
+  __macro(flagcxAllGather);                                \
+  __macro(flagcxAlltoAll);                                 \
+  __macro(flagcxAlltoAllv);                                \
+  __macro(flagcxGroupStart);                               \
+  __macro(flagcxGroupEnd);                                 \
+  __macro(flagcxReduce);                                   \
+  __macro(flagcxReduceScatter);                            \
+  __macro(flagcxScatter) __macro(flagcxCommGetAsyncError); \
+  __macro(flagcxSend);                                     \
+  __macro(flagcxRecv);                                     \
+  __macro(flagcxHandleInit);                               \
+  __macro(flagcxHandleFree);                               \
   __macro(flagcxGetErrorString);
 
 FLAGCX_RAND_ROUTINE_EACH(DECLARE_DYNAMIC_LOAD_FLAGCX_WRAP)

--- a/paddle/phi/core/distributed/bkcl_comm_context.h
+++ b/paddle/phi/core/distributed/bkcl_comm_context.h
@@ -72,6 +72,13 @@ class BKCLCommContext final : public CommContext {
                      BKCLOp reduce_type,
                      XPUStream stream);
 
+#if defined(PADDLE_WITH_FLAGCX)
+  void Scatter(phi::DenseTensor* out_tensor,
+               const phi::DenseTensor& in_tensor,
+               int root,
+               XPUStream stream);
+#endif
+
   void AllGather(phi::DenseTensor* out_tensor,
                  const phi::DenseTensor& in_tensor,
                  XPUStream stream);

--- a/tools/flagcx/build_flagcx_xpu.sh
+++ b/tools/flagcx/build_flagcx_xpu.sh
@@ -40,5 +40,5 @@ else
 fi
 
 cd "${FLAGCX_SOURCE_PATH}"
-make clean
-make USE_KUNLUNXIN=1
+make -j1 clean
+make -j1 USE_KUNLUNXIN=1


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Communication Library

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
Add Scatter commOp in XPU environment when compiled with FlagCX