### PR TITLE
fix comparison warning

### DIFF
--- a/paddle/phi/api/lib/op_meta_info.cc
+++ b/paddle/phi/api/lib/op_meta_info.cc
@@ -380,7 +380,7 @@ void CustomOpKernelContext::ValidateAndAssignOutputs(
 
     const int num_outputs = this->outputs_names_.size();
 
-    for (size_t i = 0; i < num_outputs; ++i) {
+    for (int i = 0; i < num_outputs; ++i) {
       if (GetInplaceReverseIndexMap().count(i)) {
         outputs_names_with_inplace.push_back(this->outputs_names_.at(i) +
                                              "(inplaced)");


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
修复比较警告信息, num_outputs 是 int 类型, i需要使用int
```
paddle/phi/api/lib/op_meta_info.cc:383:26: warning: comparison of integer expressions of different signedness: ‘size_t’ {aka ‘long unsigned int’} and ‘const int’ [-Wsign-compare]
  383 |     for (size_t i = 0; i < num_outputs; ++i) {
      |                        ~~^~~~~~~~~~~~~
```
