### PR TITLE
remove Tensor(const Place &place) as indicated in the message

### DIFF
--- a/paddle/phi/api/lib/tensor.cc
+++ b/paddle/phi/api/lib/tensor.cc
@@ -69,40 +69,6 @@ Tensor::Tensor(std::shared_ptr<phi::TensorBase> tensor_impl,
                               "TensorImpl with nullptr is not supported"));
 }
 
-Tensor::Tensor(const Place &place) {
-  LOG_FIRST_N(WARNING, 1)
-      << "The Tensor(place) constructor is deprecated since version "
-         "2.3, and will be removed in version 2.4! Please use "
-         "`paddle::empty/full` method to create a new "
-         "Tensor instead. "
-         "Reason: A legal tensor cannot be constructed only based on "
-         "the `place`, and datatype, shape, layout, etc. is also "
-         "required.";
-  DefaultAllocator alloc(place);
-  impl_ = std::make_shared<phi::DenseTensor>(
-      &alloc,
-      phi::DenseTensorMeta(phi::DataType::FLOAT32,
-                           common::make_ddim({}),
-                           phi::DataLayout::NCHW));
-}
-
-Tensor::Tensor(const Place &place, const std::vector<int64_t> &shape) {
-  LOG_FIRST_N(WARNING, 1)
-      << "The Tensor(place, shape) constructor is deprecated since "
-         "version 2.3, and will be removed in version 2.4! Please use "
-         "`paddle::empty/full` method to create a new "
-         "Tensor instead. "
-         "Reason: A legal tensor cannot be constructed only based on "
-         "the `place` and `shape`, and datatype, layout, etc. is also "
-         "required.";
-  DefaultAllocator alloc(place);
-  impl_ = std::make_shared<phi::DenseTensor>(
-      &alloc,
-      phi::DenseTensorMeta(phi::DataType::FLOAT32,
-                           common::make_ddim({shape}),
-                           phi::DataLayout::NCHW));
-}
-
 Tensor::Tensor(std::shared_ptr<phi::TensorBase> tensor_impl,
                const std::string &name)
     : impl_(std::move(tensor_impl)), name_(name) {}

--- a/test/cpp/phi/api/test_phi_tensor.cc
+++ b/test/cpp/phi/api/test_phi_tensor.cc
@@ -408,16 +408,6 @@ void TestDataInterface() {
                                       const_tensor_ptr));
 }
 
-void TestJudgeTensorType() {
-  Tensor test_tensor(phi::CPUPlace(), {1, 1});
-  PADDLE_ENFORCE_EQ(
-      test_tensor.is_dense_tensor(),
-      true,
-      common::errors::InvalidArgument("test_tensor should be a dense tensor, "
-                                      "but got %s",
-                                      test_tensor.is_dense_tensor()));
-}
-
 TEST(PhiTensor, All) {
   VLOG(2) << "TestCopy";
   GroupTestCopy();
@@ -435,8 +425,6 @@ TEST(PhiTensor, All) {
   TestInitialized();
   VLOG(2) << "TestDataInterface";
   TestDataInterface();
-  VLOG(2) << "TestJudgeTensorType";
-  TestJudgeTensorType();
 }
 
 }  // namespace tests


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
```
      << "The Tensor(place) constructor is deprecated since version "
         "2.3, and will be removed in version 2.4! Please use "
         "`paddle::empty/full` method to create a new "
         "Tensor instead. "
         "Reason: A legal tensor cannot be constructed only based on "
         "the `place`, and datatype, shape, layout, etc. is also "
         "required.";
  DefaultAllocator alloc(pla
```
代码提示信息是移除 Tensor(const Place &place) 
同时移除 test/cpp/phi/api/test_phi_tensor.cc 中单测
