### PR TITLE
python3 use sys.maxsize to replace sys.maxint

### DIFF
--- a/python/paddle/base/incubate/checkpoint/auto_checkpoint.py
+++ b/python/paddle/base/incubate/checkpoint/auto_checkpoint.py
@@ -444,7 +444,7 @@ class TrainEpochRange(SerializableBase):
         _thread_checker()
 
         if self._max_epoch_num < 0:
-            self._max_epoch_num = sys.maxint
+            self._max_epoch_num = sys.maxsize
 
         assert self._epoch_no >= -1, (
             f"self._epoch_no:{self._epoch_no} must >=-1"
@@ -608,7 +608,7 @@ def _get_checker():
 
 def _normal_yield(max_epoch_num):
     if max_epoch_num < 0:
-        max_epoch_num = sys.maxint
+        max_epoch_num = sys.maxsize
     yield from range(0, max_epoch_num)
 
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
python3 使用 sys.maxsize 替换 sys.maxint
```
>>> import sys
>>> sys.maxint
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'sys' has no attribute 'maxint'
>>> sys.maxsize
9223372036854775807
>>> 
```
