### PR TITLE
fix comparison warning in add_norm_fuse_pass.cc

### DIFF
--- a/paddle/fluid/pir/transforms/gpu/add_norm_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/gpu/add_norm_fuse_pass.cc
@@ -250,7 +250,7 @@ class AddLayerNormFusePattern : public paddle::drr::DrrPatternBase {
       auto x_shape = pir::GetShapeFromValue(match_ctx.Tensor("x"));
       auto r_shape = pir::GetShapeFromValue(match_ctx.Tensor("residual"));
       if (x_shape.size() != r_shape.size()) return false;
-      for (int i = 0; i < x_shape.size(); i++) {
+      for (size_t i = 0; i < x_shape.size(); i++) {
         if (x_shape[i] != r_shape[i]) return false;
       }
       return true;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
修复编译比较int类型和size类型警告信息
<img width="1451" height="108" alt="image" src="https://github.com/user-attachments/assets/c5c79d76-2b94-4459-8bd4-c2430825f5e4" />
