### PR TITLE
CallScalarFunction uses the dtype of 'self' as the type of 'other' when opotype is 'div' 

### DIFF
--- a/paddle/phi/core/visit_type.h
+++ b/paddle/phi/core/visit_type.h
@@ -337,6 +337,42 @@ namespace phi {
     }                                                                         \
   }()
 
+///////// Bool, Floating, Integral and Complex Dispatch Marco ///////////
+
+#define PD_VISIT_BOOL_AND_FLOATING_AND_INTEGRAL_AND_COMPLEX_TYPES(            \
+    TYPE, NAME, ...)                                                          \
+  [&] {                                                                       \
+    const auto& __dtype__ = TYPE;                                             \
+    switch (__dtype__) {                                                      \
+      PD_PRIVATE_CASE_TYPE(NAME, ::phi::DataType::BOOL, bool, __VA_ARGS__)    \
+      PD_PRIVATE_CASE_TYPE(                                                   \
+          NAME, ::paddle::DataType::FLOAT32, float, __VA_ARGS__)              \
+      PD_PRIVATE_CASE_TYPE(                                                   \
+          NAME, ::paddle::DataType::FLOAT64, double, __VA_ARGS__)             \
+      PD_PRIVATE_CASE_TYPE(NAME, ::paddle::DataType::INT32, int, __VA_ARGS__) \
+      PD_PRIVATE_CASE_TYPE(                                                   \
+          NAME, ::paddle::DataType::INT64, int64_t, __VA_ARGS__)              \
+      PD_PRIVATE_CASE_TYPE(                                                   \
+          NAME, ::paddle::DataType::INT8, int8_t, __VA_ARGS__)                \
+      PD_PRIVATE_CASE_TYPE(                                                   \
+          NAME, ::paddle::DataType::UINT8, uint8_t, __VA_ARGS__)              \
+      PD_PRIVATE_CASE_TYPE(                                                   \
+          NAME, ::paddle::DataType::INT16, int16_t, __VA_ARGS__)              \
+      PD_PRIVATE_CASE_TYPE(NAME,                                              \
+                           ::paddle::DataType::COMPLEX64,                     \
+                           ::paddle::complex64,                               \
+                           __VA_ARGS__)                                       \
+      PD_PRIVATE_CASE_TYPE(NAME,                                              \
+                           ::paddle::DataType::COMPLEX128,                    \
+                           ::paddle::complex128,                              \
+                           __VA_ARGS__)                                       \
+      default:                                                                \
+        PD_THROW("function " #NAME " is not implemented for data type `",     \
+                 __dtype__,                                                   \
+                 "`");                                                        \
+    }                                                                         \
+  }()
+
 #ifdef PADDLE_WITH_XPU_FFT
 #define PD_XPU_COMPLEX64_CASE(NAME, ...) \
   PD_PRIVATE_CASE_TYPE(                  \


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->
原本paddle的逻辑近似可以表示为
cast<MPT>(a) * (cast<MPT>(1)/ cast<MPT>(b))

torch的逻辑近似可以表示为
cast<MPT>(a) * cast<MPT>(cast<double>(1)/ cast<double>(b))

#### 受影响的 API：
- `paddle.Tensor.__truediv__` 对齐132 个case，剩余2792个（有随机性对齐个数并不一定准确）

#### 修改内容
- 添加了 PD_VISIT_BOOL_AND_FLOATING_AND_INTEGRAL_AND_COMPLEX_TYPES 宏，与其他宏类似。
- 对 CallScalarFunction 函数修改，当op_type为div时，使用 self 的 dtype 作为 other 的 dtype。

#### 剩余已知问题
- kernel 第一个输入是常数或0d的情况 PyTorch 也单独写了一个kernel，Paddle目前无法对齐，需要新增kernel。`paddle.Tensor.__rtruediv__` 全是这种情况。
- a b 的shape不一致时，广播可能产生随机性。
- a b 的 dtype 不一致时反向存在问题，待排查。


Pcard-67164