### PR TITLE
LinspaceKernel uses the dtype of 'self' as the type of 'step' when tensor is floating

### DIFF
--- a/paddle/phi/infermeta/ternary.cc
+++ b/paddle/phi/infermeta/ternary.cc
@@ -1483,10 +1483,11 @@ void LerpInferMeta(const MetaTensor& x,
   out->share_lod(x);
 }
 
-void LinspaceRawInferMeta(const MetaTensor& start,
-                          const MetaTensor& stop,
-                          const MetaTensor& number,
-                          MetaTensor* out) {
+void LinspaceInferMeta(const MetaTensor& start,
+                       const MetaTensor& stop,
+                       const MetaTensor& number,
+                       DataType dtype,
+                       MetaTensor* out) {
   PADDLE_ENFORCE_EQ(
       common::product(start.dims()),
       1,
@@ -1509,15 +1510,7 @@ void LinspaceRawInferMeta(const MetaTensor& start,
                                       common::product(number.dims())));
 
   out->set_dims(common::make_ddim({-1}));
-  out->set_dtype(start.dtype());
-}
-
-void LinspaceInferMeta(const MetaTensor& start,
-                       const MetaTensor& stop,
-                       const MetaTensor& number,
-                       DataType dtype,
-                       MetaTensor* out) {
-  LinspaceRawInferMeta(start, stop, number, out);
+  out->set_dtype(dtype);
 }
 
 void MatchMatrixTensorInferMeta(const MetaTensor& x,

--- a/paddle/phi/kernels/cpu/linspace_kernel.cc
+++ b/paddle/phi/kernels/cpu/linspace_kernel.cc
@@ -44,6 +44,7 @@ void LinspaceKernel(const Context& dev_ctx,
     dev_ctx.template Alloc<T>(out);
     return;
   }
+  using StepT = std::conditional_t<std::is_integral_v<T>, double, T>;
   auto start_t = phi::funcs::TransDataType(dev_ctx, start, dtype);
   auto stop_t = phi::funcs::TransDataType(dev_ctx, stop, dtype);
 
@@ -55,7 +56,9 @@ void LinspaceKernel(const Context& dev_ctx,
 
   if (num > 1) {
     // step should be of double type for all types
-    double step = (static_cast<double>(stop_data - start_data)) / (num - 1);
+    StepT step =
+        (static_cast<StepT>(stop_data) - static_cast<StepT>(start_data)) /
+        (num - 1);
     int half_num = num / 2;
     for (int i = 0; i < num; ++i) {
       if (i < half_num) {

--- a/paddle/phi/kernels/cpu/linspace_kernel.cc
+++ b/paddle/phi/kernels/cpu/linspace_kernel.cc
@@ -55,7 +55,7 @@ void LinspaceKernel(const Context& dev_ctx,
   T* out_data = dev_ctx.template Alloc<T>(out);
 
   if (num > 1) {
-    // step should be of double type for all types
+    // step should be of StepT type
     StepT step =
         (static_cast<StepT>(stop_data) - static_cast<StepT>(start_data)) /
         (num - 1);

--- a/paddle/phi/kernels/gpu/linspace_kernel.cu
+++ b/paddle/phi/kernels/gpu/linspace_kernel.cu
@@ -24,15 +24,29 @@ namespace phi {
 
 template <typename T>
 __global__ void LinspaceKernelInner(
-    T start, T stop, float step, int64_t size, T* out) {
+    T start, T stop, T step, int64_t size, T* out) {
   int64_t index = blockIdx.x * blockDim.x + threadIdx.x;
 
   for (; index < size; index += blockDim.x * gridDim.x) {
     if (index < size / 2) {
-      out[index] = static_cast<T>(static_cast<float>(start) + step * index);
+      out[index] = start + step * static_cast<T>(index);
+    } else {
+      out[index] = stop - step * static_cast<T>(size - index - 1);
+    }
+  }
+}
+
+template <typename T, typename StepT>
+__global__ void LinspaceKernelInnerForInt(
+    T start, T stop, StepT step, int64_t size, T* out) {
+  int64_t index = blockIdx.x * blockDim.x + threadIdx.x;
+
+  for (; index < size; index += blockDim.x * gridDim.x) {
+    if (index < size / 2) {
+      out[index] = static_cast<T>(static_cast<StepT>(start) + step * index);
     } else {
       out[index] =
-          static_cast<T>(static_cast<float>(stop) - step * (size - index - 1));
+          static_cast<T>(static_cast<StepT>(stop) - step * (size - index - 1));
     }
   }
 }
@@ -111,7 +125,7 @@ void LinspaceKernel(const Context& dev_ctx,
     float step =
         (static_cast<float>(stop_value) - static_cast<float>(start_value)) /
         (num - 1);
-    LinspaceKernelInner<T><<<grid, block, 0, stream>>>(
+    LinspaceKernelInnerForInt<T, float><<<grid, block, 0, stream>>>(
         start_value, stop_value, step, num, out_data);
   } else {
     int block = 512;

--- a/paddle/phi/kernels/gpu/linspace_kernel.cu
+++ b/paddle/phi/kernels/gpu/linspace_kernel.cu
@@ -24,15 +24,15 @@ namespace phi {
 
 template <typename T>
 __global__ void LinspaceKernelInner(
-    T start, T stop, double step, int64_t size, T* out) {
+    T start, T stop, float step, int64_t size, T* out) {
   int64_t index = blockIdx.x * blockDim.x + threadIdx.x;
 
   for (; index < size; index += blockDim.x * gridDim.x) {
     if (index < size / 2) {
-      out[index] = static_cast<T>(static_cast<double>(start) + step * index);
+      out[index] = static_cast<T>(static_cast<float>(start) + step * index);
     } else {
       out[index] =
-          static_cast<T>(static_cast<double>(stop) - step * (size - index - 1));
+          static_cast<T>(static_cast<float>(stop) - step * (size - index - 1));
     }
   }
 }
@@ -70,6 +70,15 @@ T GetValueOfExpectedType(const Context& dev_ctx, const DenseTensor& x) {
   }
 }
 
+inline bool isIntegralType(DataType t, bool includeBool) {
+  bool isIntegral =
+      (t == DataType::UINT8 || t == DataType::INT8 || t == DataType::UINT16 ||
+       t == DataType::INT16 || t == DataType::UINT32 || t == DataType::INT32 ||
+       t == DataType::UINT64 || t == DataType::INT64);
+
+  return isIntegral || (includeBool && t == DataType::BOOL);
+}
+
 template <typename T, typename Context>
 void LinspaceKernel(const Context& dev_ctx,
                     const DenseTensor& start,
@@ -93,14 +102,25 @@ void LinspaceKernel(const Context& dev_ctx,
     return;
   }
   auto stream = dev_ctx.stream();
-  if (num != 1) {
+  if (num == 1) {
+    LinspaceSpecialKernel<T><<<1, 1, 0, stream>>>(start_value, out_data);
+  } else if (isIntegralType(dtype, true)) {
     int block = 512;
     int grid = (num + block - 1) / block;
-    double step = (static_cast<double>(stop_value - start_value)) / (num - 1);
+
+    float step =
+        (static_cast<float>(stop_value) - static_cast<float>(start_value)) /
+        (num - 1);
     LinspaceKernelInner<T><<<grid, block, 0, stream>>>(
         start_value, stop_value, step, num, out_data);
   } else {
-    LinspaceSpecialKernel<T><<<1, 1, 0, stream>>>(start_value, out_data);
+    int block = 512;
+    int grid = (num + block - 1) / block;
+
+    T step = (static_cast<T>(stop_value) - static_cast<T>(start_value)) /
+             static_cast<T>(num - 1);
+    LinspaceKernelInner<T><<<grid, block, 0, stream>>>(
+        start_value, stop_value, step, num, out_data);
   }
 }
 

--- a/paddle/phi/kernels/gpu/linspace_kernel.cu
+++ b/paddle/phi/kernels/gpu/linspace_kernel.cu
@@ -22,6 +22,21 @@
 
 namespace phi {
 
+template <typename T, typename StepT>
+__global__ void LinspaceKernelInner(
+    T start, T stop, StepT step, int64_t size, T* out) {
+  int64_t index = blockIdx.x * blockDim.x + threadIdx.x;
+
+  for (; index < size; index += blockDim.x * gridDim.x) {
+    if (index < size / 2) {
+      out[index] = static_cast<T>(static_cast<StepT>(start) + step * index);
+    } else {
+      out[index] =
+          static_cast<T>(static_cast<StepT>(stop) - step * (size - index - 1));
+    }
+  }
+}
+
 template <typename T>
 __global__ void LinspaceKernelInner(
     T start, T stop, T step, int64_t size, T* out) {
@@ -32,21 +47,6 @@ __global__ void LinspaceKernelInner(
       out[index] = start + step * static_cast<T>(index);
     } else {
       out[index] = stop - step * static_cast<T>(size - index - 1);
-    }
-  }
-}
-
-template <typename T, typename StepT>
-__global__ void LinspaceKernelInnerForInt(
-    T start, T stop, StepT step, int64_t size, T* out) {
-  int64_t index = blockIdx.x * blockDim.x + threadIdx.x;
-
-  for (; index < size; index += blockDim.x * gridDim.x) {
-    if (index < size / 2) {
-      out[index] = static_cast<T>(static_cast<StepT>(start) + step * index);
-    } else {
-      out[index] =
-          static_cast<T>(static_cast<StepT>(stop) - step * (size - index - 1));
     }
   }
 }
@@ -125,7 +125,7 @@ void LinspaceKernel(const Context& dev_ctx,
     float step =
         (static_cast<float>(stop_value) - static_cast<float>(start_value)) /
         (num - 1);
-    LinspaceKernelInnerForInt<T, float><<<grid, block, 0, stream>>>(
+    LinspaceKernelInner<T, float><<<grid, block, 0, stream>>>(
         start_value, stop_value, step, num, out_data);
   } else {
     int block = 512;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->

```python
import torch
import paddle

dtype = torch.float32
start = torch.tensor(1.0)
stop = torch.tensor(-1.0)

# paddle
dx = ((stop - start).to(dtype=torch.float64) / 28)
(start + dx*6).to(dtype).tolist()

# torch
dx = ((stop.to(dtype=dtype) - stop.to(dtype=dtype)) / 28)
(start + dx.to(dtype)*6).tolist()
```

#### 受影响的 API：
- `paddle.linspace` 对齐全部case（共 85 个）

#### 修改内容
- 计算 step 时，始终将 start和end转换为 double 再进行计算，以确保获取到最高精度的step。
- 改为先对stop和start进行cast在计算，可以避免溢出。
- 当 tensor的dtype为整数时且为GPU kernel时，将 step type 转换为float （原本为double）。
- 当 tensor的dtype为浮点数时，将 step type 转换为 tensor 的 dtype进行后续计算。


#### 其他说明
GPU Kernel 在T为整数时，使用float比double性能更好，可以对齐PyTorch。
- paddle float32 forward 5.1293089389801025
- paddle float64 forward 8.464366674423218

性能测试代码
```python
import paddle
import time

test_loop = 2**10

paddle.linspace(
    -1,
    1,
    2 ** 30,
    dtype="float32",
)
paddle.linspace(
    -1,
    1,
    2 ** 30,
    dtype="float64",
)
with paddle.no_grad():
    paddle.base.core._cuda_synchronize(paddle.CUDAPlace(0))
    start = time.time()
    for i in range(test_loop):
        paddle.linspace(
            -1,
            1,
            2 ** 30,
            dtype="float32",
        )
    start2 = time.time()
    paddle.base.core._cuda_synchronize(paddle.CUDAPlace(0))
    end = time.time()
    timeused = end - start
    print("paddle float32 forward", timeused)

with paddle.no_grad():
    paddle.base.core._cuda_synchronize(paddle.CUDAPlace(0))
    start = time.time()
    for i in range(test_loop):
        paddle.linspace(
            -1,
            1,
            2** 30,
            dtype="float64",
        )
    start2 = time.time()
    paddle.base.core._cuda_synchronize(paddle.CUDAPlace(0))
    end = time.time()
    timeused = end - start
    print("paddle float64 forward", timeused)
    print("end - start2", end - start2)

```

TODO:
- GPU kernel 有性能提升空间，一个线程可以计算多个值，降低调度开销。


Pcard-67164