### PR TITLE
fix negative -1 in ir_backward

### DIFF
--- a/python/paddle/autograd/ir_backward.py
+++ b/python/paddle/autograd/ir_backward.py
@@ -218,6 +218,18 @@ def prepare_grad_outputs(grad_outputs, outputs, state):
         raise ValueError(
             "grad_outputs should have the same length of as outputs."
         )
+
+    def _check_shape(output, grad) -> bool:
+        if len(output.shape) != len(grad.shape):
+            return False
+        for o_dim, g_dim in zip(output.shape, grad.shape):
+            if o_dim == -1 or g_dim == -1:
+                # Skip comparison if any dimension is -1 (wildcard for dynamic shape)
+                continue
+            if o_dim != g_dim:
+                return False
+        return True
+
     backward_ops = []
     for i, grad in enumerate(grad_outputs):
         output = outputs[i]
@@ -229,7 +241,7 @@ def prepare_grad_outputs(grad_outputs, outputs, state):
             )
             grad_outputs[i] = grad_value
         else:
-            if output.shape != grad.shape:
+            if not _check_shape(output, grad):
                 raise ValueError(
                     f"The shape of grad_output[{i}] {grad.shape} should be the same as the shape of output[{i}] {output.shape}"
                 )

--- a/test/ir/pir/test_ir_backward.py
+++ b/test/ir/pir/test_ir_backward.py
@@ -20,8 +20,21 @@ import paddle
 from paddle import pir
 from paddle.autograd.backward_utils import ValueDict, ValueSet
 from paddle.autograd.ir_backward import grad
+from paddle.base.wrapped_decorator import signature_safe_contextmanager
 
 paddle.enable_static()
+
+
+@signature_safe_contextmanager
+def dygraph_guard():
+    in_dygraph_outside = paddle.base.framework.in_dygraph_mode()
+    try:
+        if not in_dygraph_outside:
+            paddle.disable_static()
+        yield
+    finally:
+        if not in_dygraph_outside:
+            paddle.enable_static()
 
 
 def get_ir_program_0():
@@ -310,6 +323,29 @@ class TestBackward_5(unittest.TestCase):
                 relu_grad_number += 1
 
         self.assertEqual(relu_grad_number, 1)
+
+
+class TestBackward_6(unittest.TestCase):
+    def test_negative_shape(self):
+        with dygraph_guard():
+            model = paddle.nn.Linear(2, 3)
+
+            def f(x):
+                y = model(x)
+                y = paddle.tanh(y)
+                return paddle.grad(
+                    y, x, create_graph=True, grad_outputs=paddle.randn_like(y)
+                )[0]
+
+            f = paddle.jit.to_static(
+                f,
+                full_graph=True,
+                backend=None,
+                input_spec=[paddle.static.InputSpec([-1, -1], dtype="float32")],
+            )
+            x = paddle.randn(4, 2, requires_grad=True)
+            y = f(x)
+            self.assertEqual(x.shape, y.shape)
 
 
 class TestValueSet(unittest.TestCase):

--- a/test/ir/pir/test_ir_backward.py
+++ b/test/ir/pir/test_ir_backward.py
@@ -347,6 +347,58 @@ class TestBackward_6(unittest.TestCase):
             y = f(x)
             self.assertEqual(x.shape, y.shape)
 
+    def test_negative_shape_error1(self):
+        with dygraph_guard():
+            model = paddle.nn.Linear(2, 3)
+
+            def f(x):
+                y = model(x)
+                y = paddle.tanh(y)
+                return paddle.grad(
+                    y, x, create_graph=True, grad_outputs=paddle.randn(1, 3)
+                )[0]
+
+            with self.assertRaisesRegex(
+                ValueError,
+                r"The shape of grad_output\[0\] \[1, 3\] should be the same as the shape of output\[0\] \[4, 3\]",
+            ):
+                x = paddle.randn(4, 2, requires_grad=True)
+                f = paddle.jit.to_static(
+                    f,
+                    full_graph=True,
+                    backend=None,
+                    input_spec=[
+                        paddle.static.InputSpec(x.shape, dtype="float32")
+                    ],
+                )
+                y = f(x)
+
+    def test_negative_shape_error2(self):
+        with dygraph_guard():
+            model = paddle.nn.Linear(2, 3)
+
+            def f(x):
+                y = model(x)
+                y = paddle.tanh(y)
+                return paddle.grad(
+                    y, x, create_graph=True, grad_outputs=paddle.randn(4)
+                )[0]
+
+            with self.assertRaisesRegex(
+                ValueError,
+                r"The shape of grad_output\[0\] \[4\] should be the same as the shape of output\[0\] \[4, 3\]",
+            ):
+                x = paddle.randn(4, 2, requires_grad=True)
+                f = paddle.jit.to_static(
+                    f,
+                    full_graph=True,
+                    backend=None,
+                    input_spec=[
+                        paddle.static.InputSpec(x.shape, dtype="float32")
+                    ],
+                )
+                y = f(x)
+
 
 class TestValueSet(unittest.TestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes 

### Description
<!-- Describe what you’ve done -->

Pcard-75624

This pull request improves the robustness of gradient shape checking in the autograd IR backward implementation, especially for dynamic shapes, and adds a new test to validate this behavior. The most important changes are:

**Autograd shape checking improvements:**

* Added a helper function `_check_shape` in `python/paddle/autograd/ir_backward.py` to compare output and gradient shapes, allowing dimensions with `-1` (wildcards for dynamic shapes) to be considered compatible. This prevents false negatives when working with dynamic shapes.
* Updated the gradient shape validation logic to use `_check_shape` instead of strict equality, improving support for dynamic shape scenarios.

**Testing enhancements:**

* Introduced a `dygraph_guard` context manager in `test/ir/pir/test_ir_backward.py` to safely switch between static and dynamic graph modes during tests.
* Added a new test case `TestBackward_6.test_negative_shape` to verify that gradient computation works correctly with dynamic input shapes (i.e., shapes containing `-1`). This helps ensure the new shape checking logic is effective.