### PR TITLE
[API compatibility] paddle.nn.functional.layer_norm to support parameter alias

### DIFF
--- a/python/paddle/nn/functional/norm.py
+++ b/python/paddle/nn/functional/norm.py
@@ -24,6 +24,9 @@ from paddle.base.framework import (
     in_dynamic_or_pir_mode,
     in_pir_mode,
 )
+from paddle.utils.decorator_utils import (
+    param_two_alias,
+)
 
 from ...base.data_feeder import check_type, check_variable_and_dtype
 from ...base.layer_helper import LayerHelper
@@ -317,6 +320,7 @@ def batch_norm(
         return helper.append_activation(batch_norm_out)
 
 
+@param_two_alias(["x", "input"], ["epsilon", "eps"])
 def layer_norm(
     x: Tensor,
     normalized_shape: int | Sequence[int],
@@ -328,9 +332,13 @@ def layer_norm(
     """
     nn.LayerNorm is recommended.
     For more information, please refer to :ref:`api_paddle_nn_LayerNorm` .
+     .. note::
+        Alias Support: The parameter name ``input`` can be used as an alias for ``x`` and the parameter name ``eps`` can be used as an alias for ``epsilon``.
+        For example, ``layer_norm(input=tensor_x, eps=1e-5)`` is equivalent to ``layer_norm(x=tensor_x, epsilon=1e-5)``.
 
     Parameters:
         x(Tensor): Input Tensor. It's data type should be bfloat16, float16, float32, float64.
+            alias: ``input``.
         normalized_shape(int|list|tuple): Input shape from an expected input of
             size :math:`[*, normalized_shape[0], normalized_shape[1], ..., normalized_shape[-1]]`.
             If it is a single integer, this module will normalize over the last dimension
@@ -339,6 +347,7 @@ def layer_norm(
         bias(Tensor, optional): The bias tensor of layer_norm. Default: None.
         epsilon(float, optional): The small value added to the variance to prevent
             division by zero. Default: 1e-05.
+            alias: ``eps``.
         name(str, optional): Name for the LayerNorm, default is None. For more information, please refer to :ref:`api_guide_Name` .
 
     Returns:

--- a/test/legacy_test/test_layer_norm_op.py
+++ b/test/legacy_test/test_layer_norm_op.py
@@ -121,6 +121,58 @@ def layer_norm_wrapper(
     )
 
 
+def layer_norm_wrapper_compatibility_1(
+    x, scale=None, bias=None, epsilon=1e-05, begin_norm_axis=1
+):
+    input_shape = list(x.shape)
+    normalized_shape = input_shape[begin_norm_axis:]
+    return paddle.nn.functional.layer_norm(
+        x, normalized_shape, weight=scale, bias=bias, eps=epsilon
+    )
+
+
+def layer_norm_wrapper_compatibility_2(
+    x, scale=None, bias=None, epsilon=1e-05, begin_norm_axis=1
+):
+    input_shape = list(x.shape)
+    normalized_shape = input_shape[begin_norm_axis:]
+    return paddle.nn.functional.layer_norm(
+        input=x,
+        normalized_shape=normalized_shape,
+        weight=scale,
+        bias=bias,
+        eps=epsilon,
+    )
+
+
+def layer_norm_wrapper_compatibility_3(
+    x, scale=None, bias=None, epsilon=1e-05, begin_norm_axis=1
+):
+    input_shape = list(x.shape)
+    normalized_shape = input_shape[begin_norm_axis:]
+    return paddle.nn.functional.layer_norm(
+        weight=scale,
+        eps=epsilon,
+        input=x,
+        normalized_shape=normalized_shape,
+        bias=bias,
+    )
+
+
+def layer_norm_wrapper_compatibility_4(
+    x, scale=None, bias=None, epsilon=1e-05, begin_norm_axis=1
+):
+    input_shape = list(x.shape)
+    normalized_shape = input_shape[begin_norm_axis:]
+    return paddle.nn.functional.layer_norm(
+        weight=scale,
+        eps=epsilon,
+        x=x,
+        normalized_shape=normalized_shape,
+        bias=bias,
+    )
+
+
 @unittest.skipIf(
     paddle.is_compiled_with_rocm(),
     "ROCm doesn't support fp64 LayerNormOpByOp currently",
@@ -577,6 +629,50 @@ class TestLayerNormOpByOpTestFP32_case4(TestLayerNormOpByOpTest):
         self.check_prim = False
         self.check_prim_pir = False
         self.check_pir = True
+
+
+class TestLayerNormOpByOpTestFP32_compatibility_1(TestLayerNormOpByOpTest):
+    def setUp(self):
+        self.python_api = layer_norm_wrapper_compatibility_1
+        self.public_python_api = layer_norm_wrapper_compatibility_1
+        self.op_type = "layer_norm"
+        self.prim_op_type = "comp"
+        self.python_out_sig = ["Y"]
+        self.initConfig()
+        self.initTestCase()
+
+
+class TestLayerNormOpByOpTestFP32_compatibility_2(TestLayerNormOpByOpTest):
+    def setUp(self):
+        self.python_api = layer_norm_wrapper_compatibility_2
+        self.public_python_api = layer_norm_wrapper_compatibility_2
+        self.op_type = "layer_norm"
+        self.prim_op_type = "comp"
+        self.python_out_sig = ["Y"]
+        self.initConfig()
+        self.initTestCase()
+
+
+class TestLayerNormOpByOpTestFP32_compatibility_3(TestLayerNormOpByOpTest):
+    def setUp(self):
+        self.python_api = layer_norm_wrapper_compatibility_3
+        self.public_python_api = layer_norm_wrapper_compatibility_3
+        self.op_type = "layer_norm"
+        self.prim_op_type = "comp"
+        self.python_out_sig = ["Y"]
+        self.initConfig()
+        self.initTestCase()
+
+
+class TestLayerNormOpByOpTestFP32_compatibility_4(TestLayerNormOpByOpTest):
+    def setUp(self):
+        self.python_api = layer_norm_wrapper_compatibility_4
+        self.public_python_api = layer_norm_wrapper_compatibility_4
+        self.op_type = "layer_norm"
+        self.prim_op_type = "comp"
+        self.python_out_sig = ["Y"]
+        self.initConfig()
+        self.initTestCase()
 
 
 class TestDygraphLayerNormAPIError(unittest.TestCase):


### PR DESCRIPTION
### PR Category
Operator Mechanism


### PR Types
New features


### Description
layer_norm 支持 Torch 的传参方法。

Paddle 原 API 签名：
`paddle.nn.functional.layer_norm(x, normalized_shape, weight=None, bias=None, epsilon=1e-05, name=None)`

Torch API 签名：
`torch.nn.functional.layer_norm(input, normalized_shape, weight=None, bias=None, eps=1e-05)`

此 PR 添加以下特性：

1. `x` 支持别名 `input`
1. `epsilon` 支持别名 `eps`

pcard-67164
