### PR TITLE
[Auto Parallel] Add co_shard spmd_rules for ElementwiseUnary Grad

### DIFF
--- a/test/auto_parallel/end_to_end/elementwise_co_shard.py
+++ b/test/auto_parallel/end_to_end/elementwise_co_shard.py
@@ -21,34 +21,20 @@ import paddle.distributed as dist
 class TestElementWiseCoShard:
     def run_unary_case_0(self):
         mesh = dist.ProcessMesh([[0, 1], [2, 3]], dim_names=['x', 'y'])
-        x = paddle.to_tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [7.0, 8.0]])
-
         placements = [
             dist.Shard(0, shard_order=0),
             dist.Shard(0, shard_order=1),
         ]
-        x = dist.shard_tensor(x, mesh, placements)
-        out = paddle.pow(x, 2)
-        np.testing.assert_equal(out.shape, [4, 2])
-        np.testing.assert_equal(
-            out.placements[0], dist.Shard(dim=0, shard_order=0)
-        )
-        np.testing.assert_equal(
-            out.placements[1], dist.Shard(dim=0, shard_order=1)
-        )
 
-    def run_unary_case_1(self):
-        mesh = dist.ProcessMesh([[0, 1], [2, 3]], dim_names=['x', 'y'])
-        x = paddle.to_tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [7.0, 8]])
-        y = paddle.to_tensor([2], dtype='float32')
-
-        placements = [
-            dist.Shard(0, shard_order=0),
-            dist.Shard(0, shard_order=1),
-        ]
+        x = paddle.to_tensor(
+            [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [7.0, 8.0]], dtype="float32"
+        )
         x = dist.shard_tensor(x, mesh, placements)
-        out = paddle.pow(x, y)
+        # paddle.round
+        out = paddle.round(x)
+
         np.testing.assert_equal(out.shape, [4, 2])
+        assert out.placements, "The output should be a DistTensor"
         np.testing.assert_equal(
             out.placements[0], dist.Shard(dim=0, shard_order=0)
         )
@@ -58,28 +44,34 @@ class TestElementWiseCoShard:
 
     def run_unary_case_with_partial(self):
         mesh = dist.ProcessMesh([[0, 1], [2, 3]], dim_names=['x', 'y'])
-        x = paddle.to_tensor([[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]])
-        y = paddle.to_tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [7.0, 8.0]])
-
         # TODO(ooooo): Test co_shard when matmul is supported.
         x_placements = [
             dist.Shard(0),
             dist.Shard(1),
         ]
+
+        x = paddle.to_tensor(
+            [[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]], dtype="float32"
+        )
+        y = paddle.to_tensor(
+            [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [7.0, 8.0]], dtype="float32"
+        )
         x = dist.shard_tensor(x, mesh, x_placements)
         y = dist.shard_tensor(
             y, mesh, [dist.Replicate() for _ in range(mesh.ndim)]
         )
-
+        # Generate partial placement
         matmul_out = paddle.matmul(x, y)
+        # paddle.cast
         out = paddle.cast(matmul_out, 'float64')
+
         np.testing.assert_equal(out.shape, [2, 2])
+        assert out.placements, "The output should be a DistTensor"
         np.testing.assert_equal(out.placements[0], dist.Shard(0))
         np.testing.assert_equal(out.placements[1], dist.Partial())
 
     def run_test_case_main(self):
         self.run_unary_case_0()
-        self.run_unary_case_1()
         self.run_unary_case_with_partial()
 
 

--- a/test/auto_parallel/end_to_end/elementwise_co_shard.py
+++ b/test/auto_parallel/end_to_end/elementwise_co_shard.py
@@ -20,15 +20,15 @@ import paddle.distributed as dist
 
 class TestElementWiseCoShard:
     def run_unary_case_0(self):
-        a = paddle.to_tensor([[1, 2], [3, 4], [5, 6], [7, 8]])
         mesh = dist.ProcessMesh([[0, 1], [2, 3]], dim_names=['x', 'y'])
+        x = paddle.to_tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [7.0, 8.0]])
 
         placements = [
             dist.Shard(0, shard_order=0),
             dist.Shard(0, shard_order=1),
         ]
-        input = dist.shard_tensor(a, mesh, placements)
-        out = paddle.pow(input, 2)
+        x = dist.shard_tensor(x, mesh, placements)
+        out = paddle.pow(x, 2)
         np.testing.assert_equal(out.shape, [4, 2])
         np.testing.assert_equal(
             out.placements[0], dist.Shard(dim=0, shard_order=0)
@@ -38,16 +38,16 @@ class TestElementWiseCoShard:
         )
 
     def run_unary_case_1(self):
-        a = paddle.to_tensor([[1, 2], [3, 4], [5, 6], [7, 8]])
         mesh = dist.ProcessMesh([[0, 1], [2, 3]], dim_names=['x', 'y'])
+        x = paddle.to_tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [7.0, 8]])
         y = paddle.to_tensor([2], dtype='float32')
 
         placements = [
             dist.Shard(0, shard_order=0),
             dist.Shard(0, shard_order=1),
         ]
-        input = dist.shard_tensor(a, mesh, placements)
-        out = paddle.pow(input, y)
+        x = dist.shard_tensor(x, mesh, placements)
+        out = paddle.pow(x, y)
         np.testing.assert_equal(out.shape, [4, 2])
         np.testing.assert_equal(
             out.placements[0], dist.Shard(dim=0, shard_order=0)
@@ -63,8 +63,8 @@ class TestElementWiseCoShard:
 
         # TODO(ooooo): Test co_shard when matmul is supported.
         x_placements = [
+            dist.Shard(0),
             dist.Shard(1),
-            dist.Replicate(),
         ]
         x = dist.shard_tensor(x, mesh, x_placements)
         y = dist.shard_tensor(
@@ -74,8 +74,8 @@ class TestElementWiseCoShard:
         matmul_out = paddle.matmul(x, y)
         out = paddle.cast(matmul_out, 'float64')
         np.testing.assert_equal(out.shape, [2, 2])
-        np.testing.assert_equal(out.placements[0], dist.Partial())
-        np.testing.assert_equal(out.placements[1], dist.Replicate())
+        np.testing.assert_equal(out.placements[0], dist.Shard(0))
+        np.testing.assert_equal(out.placements[1], dist.Partial())
 
     def run_test_case_main(self):
         self.run_unary_case_0()

--- a/test/auto_parallel/end_to_end/elementwise_co_shard.py
+++ b/test/auto_parallel/end_to_end/elementwise_co_shard.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+
+import paddle
+import paddle.distributed as dist
+
+
+class TestElementWiseCoShard:
+    def run_unary_case_0(self):
+        a = paddle.to_tensor([[1, 2], [3, 4], [5, 6], [7, 8]])
+        mesh = dist.ProcessMesh([[0, 1], [2, 3]], dim_names=['x', 'y'])
+
+        placements = [
+            dist.Shard(0, shard_order=0),
+            dist.Shard(0, shard_order=1),
+        ]
+        input = dist.shard_tensor(a, mesh, placements)
+        out = paddle.pow(input, 2)
+        np.testing.assert_equal(out.shape, [4, 2])
+        np.testing.assert_equal(
+            out.placements[0], dist.Shard(dim=0, shard_order=0)
+        )
+        np.testing.assert_equal(
+            out.placements[1], dist.Shard(dim=0, shard_order=1)
+        )
+
+    def run_unary_case_1(self):
+        a = paddle.to_tensor([[1, 2], [3, 4], [5, 6], [7, 8]])
+        mesh = dist.ProcessMesh([[0, 1], [2, 3]], dim_names=['x', 'y'])
+        y = paddle.to_tensor([2], dtype='float32')
+
+        placements = [
+            dist.Shard(0, shard_order=0),
+            dist.Shard(0, shard_order=1),
+        ]
+        input = dist.shard_tensor(a, mesh, placements)
+        out = paddle.pow(input, y)
+        np.testing.assert_equal(out.shape, [4, 2])
+        np.testing.assert_equal(
+            out.placements[0], dist.Shard(dim=0, shard_order=0)
+        )
+        np.testing.assert_equal(
+            out.placements[1], dist.Shard(dim=0, shard_order=1)
+        )
+
+    def run_unary_case_with_partial(self):
+        mesh = dist.ProcessMesh([[0, 1], [2, 3]], dim_names=['x', 'y'])
+        x = paddle.to_tensor([[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]])
+        y = paddle.to_tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [7.0, 8.0]])
+
+        # TODO(ooooo): Test co_shard when matmul is supported.
+        x_placements = [
+            dist.Shard(1),
+            dist.Replicate(),
+        ]
+        x = dist.shard_tensor(x, mesh, x_placements)
+        y = dist.shard_tensor(
+            y, mesh, [dist.Replicate() for _ in range(mesh.ndim)]
+        )
+
+        matmul_out = paddle.matmul(x, y)
+        out = paddle.cast(matmul_out, 'float64')
+        np.testing.assert_equal(out.shape, [2, 2])
+        np.testing.assert_equal(out.placements[0], dist.Partial())
+        np.testing.assert_equal(out.placements[1], dist.Replicate())
+
+    def run_test_case_main(self):
+        self.run_unary_case_0()
+        self.run_unary_case_1()
+        self.run_unary_case_with_partial()
+
+
+if __name__ == '__main__':
+    TestElementWiseCoShard().run_test_case_main()

--- a/test/auto_parallel/end_to_end/test_e2e_co_shard.py
+++ b/test/auto_parallel/end_to_end/test_e2e_co_shard.py
@@ -30,6 +30,9 @@ class TestReshardE2E(test_base.CommunicationTestDistBase):
     def test_transpose_co_shard(self):
         self.run_test_case("transpose_co_shard.py")
 
+    def test_elementwise_co_shard(self):
+        self.run_test_case("elementwise_co_shard.py")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/cpp/auto_parallel/spmd_rule_test.cc
+++ b/test/cpp/auto_parallel/spmd_rule_test.cc
@@ -1738,13 +1738,13 @@ TEST(Reshape, Ctor) {
 }
 
 TEST(ElementwiseUnaryLike, Ctor) {
-  std::vector<int64_t> mesh_shape = {2, 2};
-  std::vector<int64_t> process_ids = {0, 1, 2, 3};
-  std::vector<std::string> dim_names = {"x", "y"};
+  std::vector<int64_t> mesh_shape = {2, 2, 2};
+  std::vector<int64_t> process_ids = {0, 1, 2, 3, 4, 5, 6, 7};
+  std::vector<std::string> dim_names = {"x", "y", "z"};
   ProcessMesh process_mesh(mesh_shape, process_ids, dim_names);
 
   std::vector<int64_t> shape = {16, 16, 16};
-  std::vector<int64_t> dims_mapping = {0, -1, 1};
+  std::vector<std::vector<int64_t>> dims_mapping = {{0, 1}, {}, {2}};
 
   auto t_dist_attr = TensorDistAttr();
   t_dist_attr.set_process_mesh(process_mesh);
@@ -1754,8 +1754,8 @@ TEST(ElementwiseUnaryLike, Ctor) {
   auto check_element_unary_like = [&dims_mapping](auto& spmd_info) {
     EXPECT_EQ(spmd_info.first.size(), static_cast<size_t>(1));
     EXPECT_EQ(spmd_info.second.size(), static_cast<size_t>(1));
-    check_dim_mapping(spmd_info.first[0], dims_mapping);
-    check_dim_mapping(spmd_info.second[0], dims_mapping);
+    check_multi_dims_mapping(spmd_info.first[0], dims_mapping);
+    check_multi_dims_mapping(spmd_info.second[0], dims_mapping);
     check_partial_dims(spmd_info.second[0], {});
   };
 
@@ -1763,9 +1763,9 @@ TEST(ElementwiseUnaryLike, Ctor) {
     EXPECT_GT(spmd_info.first.size(), static_cast<size_t>(1));
     EXPECT_EQ(spmd_info.second.size(), static_cast<size_t>(1));
     for (auto& dim_mapping : spmd_info.first) {
-      check_dim_mapping(dim_mapping, dims_mapping);
+      check_multi_dims_mapping(dim_mapping, dims_mapping);
     }
-    check_dim_mapping(spmd_info.second[0], dims_mapping);
+    check_multi_dims_mapping(spmd_info.second[0], dims_mapping);
     check_partial_dims(spmd_info.second[0], {});
   };
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
Add co_shard spmd_rules for ElementwiseUnary Grad