### PR TITLE
【UnitTestFix No.11】fix test_stack_op

### DIFF
--- a/test/legacy_test/test_stack_op.py
+++ b/test/legacy_test/test_stack_op.py
@@ -465,8 +465,8 @@ class TestStackAPI_ZeroSizedTensor(unittest.TestCase):
         out.backward()
 
         np.testing.assert_equal(out.shape, [2, 1, 0])
-        # np.testing.assert_equal(x1.grad, None)
-        # np.testing.assert_equal(x2.grad, None)
+        np.testing.assert_equal(x1.grad.shape, [1, 0])
+        np.testing.assert_equal(x2.grad.shape, [1, 0])
         np.testing.assert_equal(out, np.ones([2, 1, 0]))
 
         paddle.enable_static()
@@ -485,8 +485,8 @@ class TestStackAPI_ZeroSizedTensor(unittest.TestCase):
             out.backward()
 
             np.testing.assert_equal(out.shape, [2, 1, 0])
-            np.testing.assert_equal(x1.grad, None)
-            np.testing.assert_equal(x2.grad, None)
+            np.testing.assert_equal(x1.grad.shape, [1, 0])
+            np.testing.assert_equal(x2.grad.shape, [1, 0])
             np.testing.assert_equal(out, np.ones([2, 1, 0]))
 
             paddle.enable_static()
@@ -604,6 +604,7 @@ class TestStackOutAndParamDecorator(unittest.TestCase):
             np.testing.assert_allclose(out.numpy(), out_std.numpy(), rtol=1e-20)
             for g, g_std in zip(grads, grads_std):
                 np.testing.assert_allclose(g.numpy(), g_std.numpy(), rtol=1e-20)
+        paddle.enable_static()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
全局静态图的时候，临时动态图要及时关上
<img width="1358" height="335" alt="图片" src="https://github.com/user-attachments/assets/5ed39313-2808-4208-b4ea-714eb8f4fe1b" />
