### PR TITLE
[CodeStyle][Ruff] Bump ruff to v0.13.0, fix some `B017` - part 3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,7 +56,7 @@ repos:
         args: [--force-exclude]
   # For Python files
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.0
+    rev: v0.13.0
     hooks:
       - id: ruff-check
         args: [--fix, --exit-non-zero-on-fix, --no-cache]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,8 +135,6 @@ ignore = [
     "F841",
     # It not met the "Explicit is better than implicit" rule
     "UP015",
-    # It will cause the performance regression on python3.10
-    "UP038",
     # collections.namedtuple can be quickly created a inlined class
     "PYI024",
     # `__all__.append` is a common pattern in Paddle

--- a/test/collective/fleet/test_distributed_strategy.py
+++ b/test/collective/fleet/test_distributed_strategy.py
@@ -54,12 +54,18 @@ class TestStrategyFactor(unittest.TestCase):
 
         # test set_program_config exception
         program_config_dict['unknown'] = None
-        self.assertRaises(
-            Exception, strategy.set_program_config, program_config_dict
+        self.assertRaisesRegex(
+            ValueError,
+            "DistributeTranspilerConfig doesn't have key",
+            strategy.set_program_config,
+            program_config_dict,
         )
         program_config_illegal = None
-        self.assertRaises(
-            Exception, strategy.set_program_config, program_config_illegal
+        self.assertRaisesRegex(
+            TypeError,
+            "input type: dict or DistributeTranspilerConfig",
+            strategy.set_program_config,
+            program_config_illegal,
         )
 
         trainer_runtime_config = strategy.get_trainer_runtime_config()
@@ -97,12 +103,18 @@ class TestStrategyFactor(unittest.TestCase):
 
         # test set_build_strategy exception
         build_strategy_dict['unknown'] = None
-        self.assertRaises(
-            Exception, strategy.set_build_strategy, build_strategy_dict
+        self.assertRaisesRegex(
+            ValueError,
+            "BuildStrategy doesn't have key",
+            strategy.set_build_strategy,
+            build_strategy_dict,
         )
         build_strategy_illegal = None
-        self.assertRaises(
-            Exception, strategy.set_build_strategy, build_strategy_illegal
+        self.assertRaisesRegex(
+            TypeError,
+            "input type: dict or BuildStrategy",
+            strategy.set_build_strategy,
+            build_strategy_illegal,
         )
 
         os.environ["CPU_NUM"] = '100'
@@ -147,14 +159,16 @@ class TestStrategyFactor(unittest.TestCase):
 
         # test set_trainer_runtime_config exception
         trainer_runtime_config_dict['unknown'] = None
-        self.assertRaises(
-            Exception,
+        self.assertRaisesRegex(
+            ValueError,
+            "TrainerRuntimeConfig doesn't have key",
             strategy.set_trainer_runtime_config,
             trainer_runtime_config_dict,
         )
         trainer_runtime_config_illegal = None
-        self.assertRaises(
-            Exception,
+        self.assertRaisesRegex(
+            TypeError,
+            "input type: dict or TrainerRuntimeConfig",
             strategy.set_trainer_runtime_config,
             trainer_runtime_config_illegal,
         )
@@ -181,14 +195,16 @@ class TestStrategyFactor(unittest.TestCase):
 
         # test set_server_runtime_config exception
         server_runtime_config_dict['unknown'] = None
-        self.assertRaises(
-            Exception,
+        self.assertRaisesRegex(
+            ValueError,
+            "ServerRuntimeConfig doesn't have key",
             strategy.set_server_runtime_config,
             server_runtime_config_dict,
         )
         server_runtime_config_illegal = None
-        self.assertRaises(
-            Exception,
+        self.assertRaisesRegex(
+            TypeError,
+            "input type: dict or ServerRuntimeConfig",
             strategy.set_server_runtime_config,
             server_runtime_config_illegal,
         )

--- a/test/deprecated/legacy_test/test_fleet_base.py
+++ b/test/deprecated/legacy_test/test_fleet_base.py
@@ -146,7 +146,7 @@ class TestFleetBase(unittest.TestCase):
     def test_exception(self):
         from paddle.distributed import fleet
 
-        self.assertRaises(Exception, fleet.init_worker)
+        self.assertRaises(Exception, fleet.init_worker)  # noqa: B017
 
 
 class TestFleetDygraph(unittest.TestCase):

--- a/test/deprecated/legacy_test/test_fleet_util.py
+++ b/test/deprecated/legacy_test/test_fleet_util.py
@@ -105,7 +105,7 @@ class TestFleetUtil(unittest.TestCase):
     def test_get_file_shard(self):
         from paddle.distributed import fleet
 
-        self.assertRaises(Exception, fleet.util.get_file_shard, "files")
+        self.assertRaises(Exception, fleet.util.get_file_shard, "files")  # noqa: B017
 
         role = role_maker.UserDefinedRoleMaker(
             is_collective=False,
@@ -174,7 +174,7 @@ class TestFleetUtil(unittest.TestCase):
             "pruned_main_program.save_var_shape_not_match"
         )
 
-        self.assertRaises(Exception, fleet.util._params_check)
+        self.assertRaises(Exception, fleet.util._params_check)  # noqa: B017
 
         # test program.proto without feed_op and fetch_op
         conf.dump_program_filename = "pruned_main_program.no_feed_fetch"
@@ -188,7 +188,7 @@ class TestFleetUtil(unittest.TestCase):
         conf.dump_program_filename = (
             "pruned_main_program.feed_var_shape_not_match"
         )
-        self.assertRaises(Exception, fleet.util._params_check)
+        self.assertRaises(Exception, fleet.util._params_check)  # noqa: B017
 
         # test correct case with feed_vars_filelist
         conf.dump_program_filename = "pruned_main_program.pbtxt"
@@ -202,7 +202,7 @@ class TestFleetUtil(unittest.TestCase):
         conf.feed_config.feeded_vars_filelist = None
         # test feed var with lod_level >= 2
         conf.dump_program_filename = "pruned_main_program.feed_lod2"
-        self.assertRaises(Exception, fleet.util._params_check)
+        self.assertRaises(Exception, fleet.util._params_check)  # noqa: B017
 
         conf.dump_program_filename = "pruned_main_program.pbtxt"
         results = fleet.util._params_check(conf)

--- a/test/deprecated/legacy_test/test_prune_deprecated.py
+++ b/test/deprecated/legacy_test/test_prune_deprecated.py
@@ -459,7 +459,7 @@ class TestExecutorRunAutoPrune(unittest.TestCase):
             exe.run(startup_program)
             x_np = np.random.random(size=(10, 2)).astype('float32')
             label_np = np.random.randint(1, size=(10, 1)).astype('int64')
-            self.assertRaises(
+            self.assertRaises(  # noqa: B017
                 Exception,
                 exe.run,
                 program,

--- a/test/legacy_test/test_activation_op.py
+++ b/test/legacy_test/test_activation_op.py
@@ -3777,7 +3777,9 @@ class TestELUInplaceAPI(TestELUAPI):
     def test_alpha_error(self):
         with dynamic_guard():
             x = paddle.to_tensor(self.x_np)
-            self.assertRaises(Exception, F.elu_, x, -0.2)
+            self.assertRaisesRegex(
+                AssertionError, "elu_ only support alpha >= 0", F.elu_, x, -0.2
+            )
 
 
 def celu(x, alpha):

--- a/test/legacy_test/test_dot_op.py
+++ b/test/legacy_test/test_dot_op.py
@@ -181,7 +181,13 @@ class TestDotOpError(unittest.TestCase):
             # float16 only can be set on GPU place
             x1 = paddle.static.data(name='x1', shape=[-1, 120], dtype="uint8")
             y1 = paddle.static.data(name='y1', shape=[-1, 120], dtype="uint8")
-            self.assertRaises(Exception, paddle.dot, x1, y1)
+            self.assertRaisesRegex(
+                TypeError,
+                r"Check data type error for op: dot",
+                paddle.dot,
+                x1,
+                y1,
+            )
 
             x2 = paddle.static.data(
                 name='x2', shape=[-1, 2, 3], dtype="float32"
@@ -189,13 +195,25 @@ class TestDotOpError(unittest.TestCase):
             y2 = paddle.static.data(
                 name='y2', shape=[-1, 2, 3], dtype="float32"
             )
-            self.assertRaises(Exception, paddle.dot, x2, y2)
+            self.assertRaisesRegex(
+                RuntimeError,
+                r"ShapeError: The dimensions of input ",
+                paddle.dot,
+                x2,
+                y2,
+            )
 
             x3 = paddle.static.data(name='x3', shape=[-1, 3], dtype="float32")
             y3 = paddle.static.data(
                 name='y3', shape=[-1, 2, 3], dtype="float32"
             )
-            self.assertRaises(Exception, paddle.dot, x2, y3)
+            self.assertRaisesRegex(
+                RuntimeError,
+                r"ShapeError: The dimensions of input",
+                paddle.dot,
+                x2,
+                y3,
+            )
 
 
 class TestDygraph(unittest.TestCase):

--- a/test/legacy_test/test_dot_op_0d.py
+++ b/test/legacy_test/test_dot_op_0d.py
@@ -48,7 +48,7 @@ class DotOpEmptyInput(unittest.TestCase):
 
         self.assertRaisesRegex(
             RuntimeError,
-            r"(.|)+ShapeError: The dimensions of input tensor X \(\[0, 0, 0\]\) should be 1 or 2",
+            r"ShapeError: The dimensions of input tensor X \(\[0, 0, 0\]\) should be 1 or 2",
             paddle.dot,
             x,
             y,

--- a/test/legacy_test/test_identity_loss_op.py
+++ b/test/legacy_test/test_identity_loss_op.py
@@ -167,7 +167,7 @@ class TestIdentityLossAPI(unittest.TestCase):
         paddle.disable_static()
         x = np.random.uniform(-1, 1, [10, 12]).astype('float32')
         x = paddle.to_tensor(x)
-        err_msg = r".+reduction should be 0, 1 and 2\. But get"
+        err_msg = r"reduction should be 0, 1 and 2\. But get"
         self.assertRaisesRegex(
             ValueError, err_msg, paddle.incubate.identity_loss, x, -1
         )

--- a/test/legacy_test/test_incubate_cross_entropy_with_softmax_bwd_w_downcast.py
+++ b/test/legacy_test/test_incubate_cross_entropy_with_softmax_bwd_w_downcast.py
@@ -37,7 +37,6 @@ def create_test_data(
 
 
 class TestCustomCrossEntropyBwd(unittest.TestCase):
-
     def compute_losses(self, preds, labels):
         loss_func = paddle.nn.CrossEntropyLoss(
             reduction="none", ignore_index=-100

--- a/test/legacy_test/test_inner.py
+++ b/test/legacy_test/test_inner.py
@@ -145,7 +145,7 @@ class TestMultiplyError(unittest.TestCase):
         y = paddle.to_tensor(y_data)
         self.assertRaisesRegex(
             ValueError,
-            r"(.|)+After performing an optional transpose",
+            "After performing an optional transpose",
             paddle.inner,
             x,
             y,
@@ -157,7 +157,7 @@ class TestMultiplyError(unittest.TestCase):
         y_data = np.random.randn(200).astype(np.float64)
         y = paddle.to_tensor(y_data)
         self.assertRaisesRegex(
-            Exception, r"(.|)+matmul\(\): argument", paddle.inner, x_data, y
+            Exception, r"matmul\(\): argument", paddle.inner, x_data, y
         )
 
     def test_errors_dynamic_case3(self):
@@ -166,7 +166,7 @@ class TestMultiplyError(unittest.TestCase):
         y_data = np.random.randn(200).astype(np.float64)
         x = paddle.to_tensor(x_data)
         self.assertRaisesRegex(
-            Exception, r"(.|)+matmul\(\): argument", paddle.inner, x, y_data
+            Exception, r"matmul\(\): argument", paddle.inner, x, y_data
         )
 
     def test_errors_dynamic_case4(self):
@@ -175,7 +175,7 @@ class TestMultiplyError(unittest.TestCase):
         y_data = np.random.randn(200).astype(np.float32)
         self.assertRaisesRegex(
             Exception,
-            r"(.|)+matmul\(\): argument",
+            r"matmul\(\): argument",
             paddle.inner,
             x_data,
             y_data,

--- a/test/legacy_test/test_lu_unpack_op.py
+++ b/test/legacy_test/test_lu_unpack_op.py
@@ -412,7 +412,7 @@ class TestLU_UnpackAPIError(unittest.TestCase):
 
             self.assertRaisesRegex(
                 ValueError,
-                r"(.|)+The data in Pivot must be between",
+                "The data in Pivot must be between",
                 test_y_data,
             )
 

--- a/test/legacy_test/test_normalize.py
+++ b/test/legacy_test/test_normalize.py
@@ -54,7 +54,7 @@ class TestNNFunctionalNormalize(unittest.TestCase):
 
         self.assertRaisesRegex(
             ValueError,
-            r"(.|)+Attr\(axis\) value should be in range \[-R, R-1\]",
+            r"Attr\(axis\) value should be in range \[-R, R-1\]",
             F.normalize,
             x,
         )

--- a/test/legacy_test/test_outer.py
+++ b/test/legacy_test/test_outer.py
@@ -180,7 +180,7 @@ class TestMultiplyError(unittest.TestCase):
         y = paddle.to_tensor(y_data)
         self.assertRaisesRegex(
             ValueError,
-            r"(.|)+multiply\(\): argument 'x' \(position 0\) must be Tensor, but got numpy.ndarray ",
+            r"multiply\(\): argument 'x' \(position 0\) must be Tensor, but got numpy.ndarray ",
             paddle.outer,
             x_data,
             y,
@@ -192,7 +192,7 @@ class TestMultiplyError(unittest.TestCase):
         x = paddle.to_tensor(x_data)
         self.assertRaisesRegex(
             ValueError,
-            r"(.|)+multiply\(\): argument 'y' \(position 1\) must be Tensor, but got numpy.ndarray ",
+            r"multiply\(\): argument 'y' \(position 1\) must be Tensor, but got numpy.ndarray ",
             paddle.outer,
             x,
             y_data,
@@ -203,7 +203,7 @@ class TestMultiplyError(unittest.TestCase):
         y_data = np.random.randn(200).astype(np.float32)
         self.assertRaisesRegex(
             ValueError,
-            r"(.|)+multiply\(\): argument 'x' \(position 0\) must be Tensor, but got numpy.ndarray",
+            r"multiply\(\): argument 'x' \(position 0\) must be Tensor, but got numpy.ndarray",
             paddle.outer,
             x_data,
             y_data,

--- a/test/legacy_test/test_pad3d_op.py
+++ b/test/legacy_test/test_pad3d_op.py
@@ -1202,22 +1202,22 @@ class TestPad3dOpError(unittest.TestCase):
         for _ in self.places:
             self.assertRaisesRegex(
                 ValueError,
-                r"(.|)+pad3d\(\): argument 'x' \(position 0\) must be Tensor, but got numpy.ndarray",
+                r"pad3d\(\): argument 'x' \(position 0\) must be Tensor, but got numpy.ndarray",
                 test_variable,
             )
             self.assertRaisesRegex(
                 ValueError,
-                r"(.|)+The width of Input\(X\)'s dimension should be greater than pad_left in reflect mode",
+                r"The width of Input\(X\)'s dimension should be greater than pad_left in reflect mode",
                 test_reflect_1,
             )
             self.assertRaisesRegex(
                 ValueError,
-                r"(.|)+The height of Input\(X\)'s dimension should be greater than pad_top in reflect mode",
+                r"The height of Input\(X\)'s dimension should be greater than pad_top in reflect mode",
                 test_reflect_2,
             )
             self.assertRaisesRegex(
                 ValueError,
-                r"(.|)+The depth of Input\(X\)'s dimension should be greater than pad_back in reflect mode",
+                r"The depth of Input\(X\)'s dimension should be greater than pad_back in reflect mode",
                 test_reflect_3,
             )
             # comment out because pad3d support 0-size now.

--- a/test/legacy_test/test_sum_op.py
+++ b/test/legacy_test/test_sum_op.py
@@ -605,12 +605,12 @@ class TestSumOpError(unittest.TestCase):
 
         self.assertRaisesRegex(
             ValueError,
-            r"(.|)+sum\(\): argument 'X' \(position 0\) must be list of Tensors",
+            r"sum\(\): argument 'X' \(position 0\) must be list of Tensors",
             test_empty_list_input,
         )
         self.assertRaisesRegex(
             ValueError,
-            r"(.|)+sum\(\): argument 'X' \(position 0\) must be list of Tensors",
+            r"sum\(\): argument 'X' \(position 0\) must be list of Tensors",
             test_list_of_none_input,
         )
 

--- a/test/xpu/test_pad3d_op_xpu.py
+++ b/test/xpu/test_pad3d_op_xpu.py
@@ -831,11 +831,27 @@ class XPUTestPad3dOp(XPUOpTestWrapper):
                 )
 
             paddle.disable_static()
-            for place in self.places:
-                self.assertRaises(ValueError, test_variable)
-                self.assertRaises(Exception, test_reflect_1)
-                self.assertRaises(Exception, test_reflect_2)
-                self.assertRaises(Exception, test_reflect_3)
+            for _ in self.places:
+                self.assertRaisesRegex(
+                    ValueError,
+                    r"pad3d\(\): argument 'x' \(position 0\) must be Tensor, but got numpy.ndarray",
+                    test_variable,
+                )
+                self.assertRaisesRegex(
+                    ValueError,
+                    r"The width of Input\(X\)'s dimension should be greater than pad_left in reflect mode",
+                    test_reflect_1,
+                )
+                self.assertRaisesRegex(
+                    ValueError,
+                    r"The height of Input\(X\)'s dimension should be greater than pad_top in reflect mode",
+                    test_reflect_2,
+                )
+                self.assertRaisesRegex(
+                    ValueError,
+                    r"The depth of Input\(X\)'s dimension should be greater than pad_back in reflect mode",
+                    test_reflect_3,
+                )
                 # comment out because pad3d support 0-size now.
                 # self.assertRaises(Exception, test_replicate_1)
             paddle.enable_static()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->

修复一些 B017 让单测异常拦截更准确

> [!NOTE]
> 有一些 noqa 是我本地跑不了的，先丢上来 ci 测测
