### PR TITLE
【FlexCheckpoint】Upgrade some macros and optimize load_state_dict communication

### DIFF
--- a/python/paddle/distributed/fleet/meta_optimizers/dygraph_optimizer/dygraph_sharding_optimizer.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/dygraph_optimizer/dygraph_sharding_optimizer.py
@@ -1343,9 +1343,13 @@ class DygraphShardingOptimizerV2:
         master_weights = optim_state_dict.pop("master_weights", None)
         optim_state_dict.pop("LR_Scheduler", None)
 
-        static_to_struct = {
-            v.local_tensor.name: k for k, v in model_sharded_state_dict.items()
-        }
+        static_to_struct = {}
+        model_sharded_state_dict = dict(
+            sorted(model_sharded_state_dict.items())
+        )
+        for k, v in model_sharded_state_dict.items():
+            if v.local_tensor.name not in static_to_struct:
+                static_to_struct[v.local_tensor.name] = k
 
         sharded_state = {}
 

--- a/python/paddle/distributed/flex_checkpoint/aoa/aoa_engine.py
+++ b/python/paddle/distributed/flex_checkpoint/aoa/aoa_engine.py
@@ -89,13 +89,13 @@ class AOAShardInfoContext:
             )
         prefix, suffix = name_with_layer_id.split(layer_id_macro_tag, 1)
         pattern = re.compile(rf"{re.escape(prefix)}(\d+){re.escape(suffix)}")
-        max_layer = 0
+        match_layer_id = set()
         for key in self.get_all_dst_state_keys():
             match = pattern.fullmatch(key)
             if match:
                 layer_num = int(match.group(1))
-                max_layer = max(max_layer, layer_num)
-        return max_layer + 1
+                match_layer_id.add(layer_num)
+        return match_layer_id
 
     def get_src_state_shard_num(self, src_state_key: str) -> int:
         if src_state_key not in self.source_state_shard_info:

--- a/python/paddle/optimizer/adamw.py
+++ b/python/paddle/optimizer/adamw.py
@@ -775,9 +775,14 @@ class AdamW(Optimizer):
         optimizer_sharded_state_dict = {}
         optimizer_state_dict = self.state_dict()
         # Build name mapping and remove non-tensor entries from optimizer state
-        static_to_struct_mapping = {
-            v.local_tensor.name: k for k, v in model_sharded_state_dict.items()
-        }
+        static_to_struct_mapping = {}
+        model_sharded_state_dict = dict(
+            sorted(model_sharded_state_dict.items())
+        )
+        for k, v in model_sharded_state_dict.items():
+            if v.local_tensor.name not in static_to_struct_mapping:
+                static_to_struct_mapping[v.local_tensor.name] = k
+
         master_weights = optimizer_state_dict.pop("master_weights", None)
         optimizer_state_dict.pop("LR_Scheduler", None)
 

--- a/test/auto_parallel/hybrid_strategy/semi_auto_load_state_dict.py
+++ b/test/auto_parallel/hybrid_strategy/semi_auto_load_state_dict.py
@@ -779,4 +779,4 @@ class TestLoadShardedStateDictWithAOA:
 if __name__ == '__main__':
     TestLoadStateDict().run_test_case()
     TestLoadShardedStateDict().run_test_case()
-    # TestLoadShardedStateDictWithAOA().run_test_case()
+    TestLoadShardedStateDictWithAOA().run_test_case()

--- a/test/flex_checkpoint/test_macros.py
+++ b/test/flex_checkpoint/test_macros.py
@@ -64,13 +64,13 @@ class MacroContext:
             )
         prefix, suffix = name_with_layer_id.split(layer_id_macro_tag, 1)
         pattern = re.compile(rf"{re.escape(prefix)}(\d+){re.escape(suffix)}")
-        max_layer = 0
+        match_layer_id = set()
         for key in self.get_all_dst_state_keys():
             match = pattern.fullmatch(key)
             if match:
                 layer_num = int(match.group(1))
-                max_layer = max(max_layer, layer_num)
-        return max_layer + 1
+                match_layer_id.add(layer_num)
+        return match_layer_id
 
     def get_src_state_shard_num(self, src_state_key: str) -> int:
         return 2

--- a/test/flex_checkpoint/test_macros.py
+++ b/test/flex_checkpoint/test_macros.py
@@ -45,6 +45,8 @@ class MacroContext:
             "layers.0.experts.1.weight",
             "layers.1.experts.0.weight",
             "layers.1.experts.1.weight",
+            "layers.1.self_attn.qkv_proj.bias",
+            "layers.0.mlp.gate_up_fused_proj.bias",
         }
 
     def get_all_dst_state_keys(self) -> Iterable[str]:
@@ -316,6 +318,40 @@ class TestFusedFfnMacro3(TestMacro):
             'layers.0.mlp.gate_up_fused_proj.weight  -> fused_ffn_tmp.GATE_0,fused_ffn_tmp.UP_0,fused_ffn_tmp.GATE_1,fused_ffn_tmp.UP_1, axis=1',
             'fused_ffn_tmp.GATE_0,fused_ffn_tmp.GATE_1 -> layers.0.mlp.gate_proj.weight, axis=1',
             'fused_ffn_tmp.UP_0,fused_ffn_tmp.UP_1 -> layers.0.mlp.up_proj.weight, axis=1',
+        ]
+
+    def test(self):
+        self.start_macro_test()
+
+
+class TestFusedQkvOldMacro5(TestMacro):
+    def macro_name(self):
+        return "fused_qkv_old_macro"
+
+    def source_code(self):
+        return "layers.1.self_attn.qkv_proj.bias -> layers.1.self_attn.qkv_proj.bias, fused_qkv_old, num_heads = 8, num_key_value_groups = 4, axis = 0"
+
+    def expected(self):
+        return [
+            'layers.1.self_attn.qkv_proj.bias -> fused_qkv_old_tmp.Q_0,fused_qkv_old_tmp.Q_1,fused_qkv_old_tmp.Q_2,fused_qkv_old_tmp.Q_3,fused_qkv_old_tmp.K_0,fused_qkv_old_tmp.K_1,fused_qkv_old_tmp.V_0,fused_qkv_old_tmp.V_1,fused_qkv_old_tmp.Q_4,fused_qkv_old_tmp.Q_5,fused_qkv_old_tmp.Q_6,fused_qkv_old_tmp.Q_7,fused_qkv_old_tmp.K_2,fused_qkv_old_tmp.K_3,fused_qkv_old_tmp.V_2,fused_qkv_old_tmp.V_3, axis=0',
+            'fused_qkv_old_tmp.Q_0,fused_qkv_old_tmp.Q_1,fused_qkv_old_tmp.K_0,fused_qkv_old_tmp.V_0,fused_qkv_old_tmp.Q_2,fused_qkv_old_tmp.Q_3,fused_qkv_old_tmp.K_1,fused_qkv_old_tmp.V_1,fused_qkv_old_tmp.Q_4,fused_qkv_old_tmp.Q_5,fused_qkv_old_tmp.K_2,fused_qkv_old_tmp.V_2,fused_qkv_old_tmp.Q_6,fused_qkv_old_tmp.Q_7,fused_qkv_old_tmp.K_3,fused_qkv_old_tmp.V_3 -> layers.1.self_attn.qkv_proj.bias, axis=0',
+        ]
+
+    def test(self):
+        self.start_macro_test()
+
+
+class TestFusedFfnMacro4(TestMacro):
+    def macro_name(self):
+        return "fused_ffn_macro"
+
+    def source_code(self):
+        return "layers.1.mlp.gate_up_fused_proj.bias -> layers.1.mlp.gate_up_fused_proj.bias, fused_ffn, axis=0"
+
+    def expected(self):
+        return [
+            'layers.1.mlp.gate_up_fused_proj.bias  -> fused_ffn_tmp.GATE_0,fused_ffn_tmp.GATE_1,fused_ffn_tmp.UP_0,fused_ffn_tmp.UP_1,fused_ffn_tmp.GATE_2,fused_ffn_tmp.GATE_3,fused_ffn_tmp.UP_2,fused_ffn_tmp.UP_3, axis=0',
+            'fused_ffn_tmp.GATE_0,fused_ffn_tmp.UP_0,fused_ffn_tmp.GATE_1,fused_ffn_tmp.UP_1,fused_ffn_tmp.GATE_2,fused_ffn_tmp.UP_2,fused_ffn_tmp.GATE_3,fused_ffn_tmp.UP_3 -> layers.1.mlp.gate_up_fused_proj.bias, axis=0',
         ]
 
     def test(self):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Upgrade some macros and optimize load_state_dict communication
- save_state_dict时如果有多个文件均包含同一个tensor分片，将该分片分发给目前保存tensor分片数最少的文件存储。
- 对layer_id macro做了修改，匹配source_state_dict中所有的layer_id，返回set，而不是直接返回layer_id的最大值。
- fused_qkv, fused_ffn支持传入axis属性，默认为1，描述bias时，传入axis=0。
- 重新设计read_item格式，方便对read_item进行编排以及后续支持多通信group。
- read_item任务合并。减少实际broadcast任务数。
        将tensor_name相同的read_items合并成一个task，当tensor不在Gpu上时，只用一次搬运。
        如果read_item1和read_item2中的字段仅有destination_rank不一致，则将read_item1和read_item2合并，只发起一起 
                broadcast即可。合并后可以显著减少多路sharding、训推转换等场景的通信任务量。

pcard-73263