### PR TITLE
[CMake4] Set cmake_policy CMP0026 to New

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ else()
 endif()
 # use to get_property location of static lib
 # https://cmake.org/cmake/help/v3.0/policy/CMP0026.html?highlight=cmp0026
-cmake_policy(SET CMP0026 OLD)
+cmake_policy(SET CMP0026 NEW)
 cmake_policy(SET CMP0079 NEW)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 set(PADDLE_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,8 +20,9 @@ else()
   cmake_minimum_required(VERSION 3.15)
   cmake_policy(VERSION 3.10)
 endif()
-# use to get_property location of static lib
-# https://cmake.org/cmake/help/v3.0/policy/CMP0026.html?highlight=cmp0026
+# use modern CMake target handling, disable deprecated LOCATION property
+# use $<TARGET_FILE> generator expression instead of get_property LOCATION
+# https://cmake.org/cmake/help/v4.0/policy/CMP0026.html#cmp0026
 cmake_policy(SET CMP0026 NEW)
 cmake_policy(SET CMP0079 NEW)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake")

--- a/cmake/generic.cmake
+++ b/cmake/generic.cmake
@@ -276,19 +276,25 @@ function(merge_static_libs TARGET_NAME)
     set(mri_file
         ${CMAKE_CURRENT_BINARY_DIR}/${TARGET_NAME}.mri
         CACHE INTERNAL "phi_static.mri file")
-    file(WRITE ${mri_file} "create $<TARGET_FILE:${TARGET_NAME}>\n")
 
+    set(mri_content "create $<TARGET_FILE:${TARGET_NAME}>\n")
     foreach(lib ${libs})
-      file(APPEND ${mri_file} "addlib $<TARGET_FILE:${lib}>\n")
+      string(APPEND mri_content "addlib $<TARGET_FILE:${lib}>\n")
     endforeach()
-    file(APPEND ${mri_file} "save\nend\n")
+    string(APPEND mri_content "save\nend\n")
+    file(
+      GENERATE
+      OUTPUT ${mri_file}
+      CONTENT "${mri_content}")
 
     add_custom_command(
       TARGET ${TARGET_NAME}
       POST_BUILD
       COMMENT "Merge and generate static lib: lib${TARGET_NAME}.a"
       COMMAND ${CMAKE_AR} -M < ${mri_file}
-      COMMAND ${CMAKE_RANLIB} "$<TARGET_FILE:${TARGET_NAME}>")
+      COMMAND ${CMAKE_RANLIB} "$<TARGET_FILE:${TARGET_NAME}>" DEPENDS
+              ${mri_file}
+      VERBATIM)
   endif()
 
   # Windows do not support gcc/nvcc combined compiling. Use msvc 'lib.exe' to merge libs.

--- a/cmake/generic.cmake
+++ b/cmake/generic.cmake
@@ -276,18 +276,10 @@ function(merge_static_libs TARGET_NAME)
     set(mri_file
         ${CMAKE_CURRENT_BINARY_DIR}/${TARGET_NAME}.mri
         CACHE INTERNAL "phi_static.mri file")
-    get_property(
-      ABS_MERGE_LIB_PATH
-      TARGET ${TARGET_NAME}
-      PROPERTY LOCATION)
-    file(WRITE ${mri_file} "create ${ABS_MERGE_LIB_PATH}\n")
+    file(WRITE ${mri_file} "create $<TARGET_FILE:${TARGET_NAME}>\n")
 
     foreach(lib ${libs})
-      get_property(
-        ABS_LIB_PATH
-        TARGET ${lib}
-        PROPERTY LOCATION)
-      file(APPEND ${mri_file} "addlib ${ABS_LIB_PATH}\n")
+      file(APPEND ${mri_file} "addlib $<TARGET_FILE:${lib}>\n")
     endforeach()
     file(APPEND ${mri_file} "save\nend\n")
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
fix CMP0026 when cmake version ge 4