### PR TITLE
[Stride] Avoid invalid offset validation

### DIFF
--- a/paddle/phi/kernels/stride/activation_kernel.cu
+++ b/paddle/phi/kernels/stride/activation_kernel.cu
@@ -55,8 +55,8 @@ void LaunchUnaryElementwiseStrideKernel(const Context &dev_ctx,
           "be called, something wrong has happened!"));                       \
     }                                                                         \
     DenseTensor x_;                                                           \
-    if (!FLAGS_use_stride_compute_kernel || x.offset() != 0) {                \
-      if (!x.meta().is_contiguous() || x.offset() != 0) {                     \
+    if (!FLAGS_use_stride_compute_kernel) {                                   \
+      if (!x.meta().is_contiguous()) {                                        \
         x_ = Tensor2Contiguous<Context>(dev_ctx, x);                          \
       } else {                                                                \
         x_ = x;                                                               \
@@ -115,8 +115,8 @@ DEFINE_CUDA_ACTIVATION_STRIDE_OP(Ceil, CudaCeilFunctor)
           "be called, something wrong has happened!"));                       \
     }                                                                         \
     DenseTensor x_;                                                           \
-    if (!FLAGS_use_stride_compute_kernel || x.offset() != 0) {                \
-      if (!x.meta().is_contiguous() || x.offset() != 0) {                     \
+    if (!FLAGS_use_stride_compute_kernel) {                                   \
+      if (!x.meta().is_contiguous()) {                                        \
         x_ = Tensor2Contiguous<Context>(dev_ctx, x);                          \
       } else {                                                                \
         x_ = x;                                                               \
@@ -163,8 +163,8 @@ DEFINE_CUDA_ACTIVATION_WITH_INT_IN_FLOAT_OUT_STRIDE_OP(Expm1, CudaExpm1Functor)
           "be called, something wrong has happened!"));                        \
     }                                                                          \
     DenseTensor x_;                                                            \
-    if (!FLAGS_use_stride_compute_kernel || x.offset() != 0) {                 \
-      if (!x.meta().is_contiguous() || x.offset() != 0) {                      \
+    if (!FLAGS_use_stride_compute_kernel) {                                    \
+      if (!x.meta().is_contiguous()) {                                         \
         x_ = Tensor2Contiguous<Context>(dev_ctx, x);                           \
       } else {                                                                 \
         x_ = x;                                                                \
@@ -218,8 +218,8 @@ DEFINE_CUDA_ACTIVATION_STRIDE_WITH_ONE_ATTRS(Mish, CudaMishFunctor, threshold)
           "be called, something wrong has happened!"));                        \
     }                                                                          \
     DenseTensor x_;                                                            \
-    if (!FLAGS_use_stride_compute_kernel || x.offset() != 0) {                 \
-      if (!x.meta().is_contiguous() || x.offset() != 0) {                      \
+    if (!FLAGS_use_stride_compute_kernel) {                                    \
+      if (!x.meta().is_contiguous()) {                                         \
         x_ = Tensor2Contiguous<Context>(dev_ctx, x);                           \
       } else {                                                                 \
         x_ = x;                                                                \
@@ -275,8 +275,8 @@ void RoundStrideKernel(const Context &dev_ctx,
         "be called, something wrong has happened!"));
   }
   DenseTensor x_;
-  if (!FLAGS_use_stride_compute_kernel || x.offset() != 0) {
-    if (!x.meta().is_contiguous() || x.offset() != 0) {
+  if (!FLAGS_use_stride_compute_kernel) {
+    if (!x.meta().is_contiguous()) {
       x_ = Tensor2Contiguous<Context>(dev_ctx, x);
     } else {
       x_ = x;
@@ -312,8 +312,8 @@ void HardSwishStrideKernel(const Context &dev_ctx,
         "be called, something wrong has happened!"));
   }
   DenseTensor x_;
-  if (!FLAGS_use_stride_compute_kernel || x.offset() != 0) {
-    if (!x.meta().is_contiguous() || x.offset() != 0) {
+  if (!FLAGS_use_stride_compute_kernel) {
+    if (!x.meta().is_contiguous()) {
       x_ = Tensor2Contiguous<Context>(dev_ctx, x);
     } else {
       x_ = x;
@@ -378,8 +378,8 @@ void AbsStrideKernel(const Context &dev_ctx,
         "be called, something wrong has happened!"));
   }
   DenseTensor x_;
-  if (!FLAGS_use_stride_compute_kernel || x.offset() != 0) {
-    if (!x.meta().is_contiguous() || x.offset() != 0) {
+  if (!FLAGS_use_stride_compute_kernel) {
+    if (!x.meta().is_contiguous()) {
       x_ = Tensor2Contiguous<Context>(dev_ctx, x);
     } else {
       x_ = x;

--- a/paddle/phi/kernels/stride/bitwise_kernel.cu
+++ b/paddle/phi/kernels/stride/bitwise_kernel.cu
@@ -64,14 +64,13 @@ void LaunchUnaryElementwiseStrideKernel(const Context &dev_ctx,
     }                                                                         \
     DenseTensor x_;                                                           \
     DenseTensor y_;                                                           \
-    if (!FLAGS_use_stride_compute_kernel || x.offset() != 0 ||                \
-        y.offset() != 0) {                                                    \
-      if (!x.meta().is_contiguous() || x.offset() != 0) {                     \
+    if (!FLAGS_use_stride_compute_kernel) {                                   \
+      if (!x.meta().is_contiguous()) {                                        \
         x_ = Tensor2Contiguous<Context>(dev_ctx, x);                          \
       } else {                                                                \
         x_ = x;                                                               \
       }                                                                       \
-      if (!y.meta().is_contiguous() || y.offset() != 0) {                     \
+      if (!y.meta().is_contiguous()) {                                        \
         y_ = Tensor2Contiguous<Context>(dev_ctx, y);                          \
       } else {                                                                \
         y_ = y;                                                               \
@@ -114,14 +113,13 @@ DEFINE_CUDA_BINARY_ELEMENTWISE_STRIDE_OP(BitwiseXor)
     }                                                                         \
     DenseTensor x_;                                                           \
     DenseTensor y_;                                                           \
-    if (!FLAGS_use_stride_compute_kernel || x.offset() != 0 ||                \
-        y.offset() != 0) {                                                    \
-      if (!x.meta().is_contiguous() || x.offset() != 0) {                     \
+    if (!FLAGS_use_stride_compute_kernel) {                                   \
+      if (!x.meta().is_contiguous()) {                                        \
         x_ = Tensor2Contiguous<Context>(dev_ctx, x);                          \
       } else {                                                                \
         x_ = x;                                                               \
       }                                                                       \
-      if (!y.meta().is_contiguous() || y.offset() != 0) {                     \
+      if (!y.meta().is_contiguous()) {                                        \
         y_ = Tensor2Contiguous<Context>(dev_ctx, y);                          \
       } else {                                                                \
         y_ = y;                                                               \
@@ -172,8 +170,8 @@ void BitwiseNotStrideKernel(const Context &dev_ctx,
         "be called, something wrong has happened!"));
   }
   DenseTensor x_;
-  if (!FLAGS_use_stride_compute_kernel || x.offset() != 0) {
-    if (!x.meta().is_contiguous() || x.offset() != 0) {
+  if (!FLAGS_use_stride_compute_kernel) {
+    if (!x.meta().is_contiguous()) {
       x_ = Tensor2Contiguous<Context>(dev_ctx, x);
     } else {
       x_ = x;

--- a/paddle/phi/kernels/stride/compare_kernel.cu
+++ b/paddle/phi/kernels/stride/compare_kernel.cu
@@ -66,14 +66,13 @@ void LaunchCompareStrideKernel(const Context &dev_ctx,
     }                                                                         \
     DenseTensor x_;                                                           \
     DenseTensor y_;                                                           \
-    if (!FLAGS_use_stride_compute_kernel || x.offset() != 0 ||                \
-        y.offset() != 0) {                                                    \
-      if (!x.meta().is_contiguous() || x.offset() != 0) {                     \
+    if (!FLAGS_use_stride_compute_kernel) {                                   \
+      if (!x.meta().is_contiguous()) {                                        \
         x_ = Tensor2Contiguous<Context>(dev_ctx, x);                          \
       } else {                                                                \
         x_ = x;                                                               \
       }                                                                       \
-      if (!y.meta().is_contiguous() || y.offset() != 0) {                     \
+      if (!y.meta().is_contiguous()) {                                        \
         y_ = Tensor2Contiguous<Context>(dev_ctx, y);                          \
       } else {                                                                \
         y_ = y;                                                               \

--- a/paddle/phi/kernels/stride/elementwise_kernel.cu
+++ b/paddle/phi/kernels/stride/elementwise_kernel.cu
@@ -68,14 +68,13 @@ void LaunchBinaryElementwiseStrideKernel(const Context &dev_ctx,
     }                                                                         \
     DenseTensor x_;                                                           \
     DenseTensor y_;                                                           \
-    if (!FLAGS_use_stride_compute_kernel || x.offset() != 0 ||                \
-        y.offset() != 0) {                                                    \
-      if (!x.meta().is_contiguous() || x.offset() != 0) {                     \
+    if (!FLAGS_use_stride_compute_kernel) {                                   \
+      if (!x.meta().is_contiguous()) {                                        \
         x_ = Tensor2Contiguous<Context>(dev_ctx, x);                          \
       } else {                                                                \
         x_ = x;                                                               \
       }                                                                       \
-      if (!y.meta().is_contiguous() || y.offset() != 0) {                     \
+      if (!y.meta().is_contiguous()) {                                        \
         y_ = Tensor2Contiguous<Context>(dev_ctx, y);                          \
       } else {                                                                \
         y_ = y;                                                               \
@@ -126,13 +125,13 @@ void AddStrideKernel(const Context &dev_ctx,
   }
   DenseTensor x_;
   DenseTensor y_;
-  if (!FLAGS_use_stride_compute_kernel || x.offset() != 0 || y.offset() != 0) {
-    if (!x.meta().is_contiguous() || x.offset() != 0) {
+  if (!FLAGS_use_stride_compute_kernel) {
+    if (!x.meta().is_contiguous()) {
       x_ = Tensor2Contiguous<Context>(dev_ctx, x);
     } else {
       x_ = x;
     }
-    if (!y.meta().is_contiguous() || y.offset() != 0) {
+    if (!y.meta().is_contiguous()) {
       y_ = Tensor2Contiguous<Context>(dev_ctx, y);
     } else {
       y_ = y;

--- a/paddle/phi/kernels/stride/indexing_kernel.cu
+++ b/paddle/phi/kernels/stride/indexing_kernel.cu
@@ -104,7 +104,7 @@ void LaunchIndexPutKernel_V2(const Context& dev_ctx,
   out->set_meta(meta);
   T* out_data = dev_ctx.template Alloc<T>(out);
   if (!is_initialized) {
-    if (!x.meta().is_contiguous() || x.offset() != 0) {
+    if (!x.meta().is_contiguous()) {
       StridedTensorCopy<T>(x,
                            common::vectorize<int64_t>(out->dims()),
                            common::vectorize<int64_t>(out->strides()),
@@ -120,12 +120,12 @@ void LaunchIndexPutKernel_V2(const Context& dev_ctx,
   if (!CheckIsDimsMatchBool(ad.src.dims(), value.dims())) {
     DenseTensor x_;
     DenseTensor value_;
-    if (!x.meta().is_contiguous() || x.offset() != 0) {
+    if (!x.meta().is_contiguous()) {
       x_ = Tensor2Contiguous<Context>(dev_ctx, x);
     } else {
       x_ = x;
     }
-    if (!value.meta().is_contiguous() || value.offset() != 0) {
+    if (!value.meta().is_contiguous()) {
       value_ = Tensor2Contiguous<Context>(dev_ctx, value);
     } else {
       value_ = value;
@@ -217,14 +217,13 @@ void IndexPutKernel_V2(const Context& dev_ctx,
                           "Indices in Index_put must be contiguous."));
   }
 
-  if (!FLAGS_use_stride_compute_kernel || x.offset() != 0 ||
-      value.offset() != 0) {
-    if (!x.meta().is_contiguous() || x.offset() != 0) {
+  if (!FLAGS_use_stride_compute_kernel) {
+    if (!x.meta().is_contiguous()) {
       x_ = Tensor2Contiguous<Context>(dev_ctx, x);
     } else {
       x_ = x;
     }
-    if (!value.meta().is_contiguous() || value.offset() != 0) {
+    if (!value.meta().is_contiguous()) {
       value_ = Tensor2Contiguous<Context>(dev_ctx, value);
     } else {
       value_ = value;

--- a/paddle/phi/kernels/stride/logical_kernel.cu
+++ b/paddle/phi/kernels/stride/logical_kernel.cu
@@ -77,14 +77,13 @@ void InplaceLogicalKernelStrideImpl(const Context &dev_ctx,
     }                                                                         \
     DenseTensor x_;                                                           \
     DenseTensor y_;                                                           \
-    if (!FLAGS_use_stride_compute_kernel || x.offset() != 0 ||                \
-        y.offset() != 0) {                                                    \
-      if (!x.meta().is_contiguous() || x.offset() != 0) {                     \
+    if (!FLAGS_use_stride_compute_kernel) {                                   \
+      if (!x.meta().is_contiguous()) {                                        \
         x_ = Tensor2Contiguous<Context>(dev_ctx, x);                          \
       } else {                                                                \
         x_ = x;                                                               \
       }                                                                       \
-      if (!y.meta().is_contiguous() || y.offset() != 0) {                     \
+      if (!y.meta().is_contiguous()) {                                        \
         y_ = Tensor2Contiguous<Context>(dev_ctx, y);                          \
       } else {                                                                \
         y_ = y;                                                               \
@@ -131,8 +130,8 @@ void LogicalNotStrideKernel(const Context &dev_ctx,
         "be called, something wrong has happened!"));
   }
   DenseTensor x_;
-  if (!FLAGS_use_stride_compute_kernel || x.offset() != 0) {
-    if (!x.meta().is_contiguous() || x.offset() != 0) {
+  if (!FLAGS_use_stride_compute_kernel) {
+    if (!x.meta().is_contiguous()) {
       x_ = Tensor2Contiguous<Context>(dev_ctx, x);
     } else {
       x_ = x;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
pcard-67164

修复offset判断导致的对连续Tensor进行多余转连续操作导致的性能下降