### PR TITLE
[API Compatiblity] fix py::enum conflict with torch

### DIFF
--- a/paddle/fluid/pybind/cudart_py.cc
+++ b/paddle/fluid/pybind/cudart_py.cc
@@ -41,16 +41,19 @@ void BindCudaRt(py::module* m) {
 #if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION < 12000
   // cudaOutputMode_t is used in cudaProfilerInitialize only. The latter is gone
   // in CUDA 12.
-  py::enum_<cudaOutputMode_t>(cudart,
-                              "cuda"
-                              "OutputMode")
+  py::enum_<cudaOutputMode_t>(
+      cudart,
+      "cuda"
+      "OutputMode_")  // Appended '_' to prevent duplicate registration across
+                      // DL frameworks.
       .value("KeyValuePair", cudaKeyValuePair)
       .value("CSV", cudaCSV);
 #endif
 
   py::enum_<cudaError_t>(cudart,
                          "cuda"
-                         "Error")
+                         "Error_")  // Appended '_' to prevent duplicate
+                                    // registration across DL frameworks.
       .value("success", cudaSuccess);
 
   cudart.def(

--- a/python/paddle/cuda/__init__.py
+++ b/python/paddle/cuda/__init__.py
@@ -150,7 +150,7 @@ def cudart():
 class CudaError(RuntimeError):
     def __init__(self, code: int) -> None:
         msg = base.libpaddle._cudart.cudaGetErrorString(
-            base.libpaddle._cudart.cudaError(code)
+            base.libpaddle._cudart.cudaError_(code)
         )
         super().__init__(f"{msg} ({code})")
 
@@ -160,7 +160,7 @@ def check_error(res: int) -> None:
 
     This function validates whether the given result code from a CUDA
     runtime call indicates success. If the result code is not
-    :data:`base.libpaddle._cudart.cudaError.success`, it raises a
+    :data:`base.libpaddle._cudart.cudaError_.success`, it raises a
     :class:`CudaError`.
 
     Args:
@@ -175,7 +175,7 @@ def check_error(res: int) -> None:
             >>> # check_error(1) # check for cuda error code 1(invalid argument), will raise Error
             >>> # check_error(2) # check for cuda error code 2(out of memory), will raise Error
     """
-    if res != base.libpaddle._cudart.cudaError.success:
+    if res != base.libpaddle._cudart.cudaError_.success:
         raise CudaError(res)
 
 

--- a/test/legacy_test/test_cuda_unittest.py
+++ b/test/legacy_test/test_cuda_unittest.py
@@ -147,16 +147,16 @@ class TestCudaCompat(unittest.TestCase):
 
         cuda_version = paddle.version.cuda()
         if int(cuda_version.split(".")[0]) < 12:
-            self.assertTrue(hasattr(cuda_rt_module, "cudaOutputMode"))
+            self.assertTrue(hasattr(cuda_rt_module, "cudaOutputMode_"))
             self.assertTrue(hasattr(cuda_rt_module, "cudaProfilerInitialize"))
 
             self.assertTrue(
-                hasattr(cuda_rt_module.cudaOutputMode, "KeyValuePair")
+                hasattr(cuda_rt_module.cudaOutputMode_, "KeyValuePair")
             )
-            self.assertEqual(cuda_rt_module.cudaOutputMode.KeyValuePair, 0)
+            self.assertEqual(cuda_rt_module.cudaOutputMode_.KeyValuePair, 0)
 
-            self.assertTrue(hasattr(cuda_rt_module.cudaOutputMode, "CSV"))
-            self.assertEqual(cuda_rt_module.cudaOutputMode.CSV, 1)
+            self.assertTrue(hasattr(cuda_rt_module.cudaOutputMode_, "CSV"))
+            self.assertEqual(cuda_rt_module.cudaOutputMode_.CSV, 1)
 
         self.assertTrue(hasattr(cuda_rt_module, "cudaError_"))
         self.assertTrue(hasattr(cuda_rt_module.cudaError_, "success"))

--- a/test/legacy_test/test_cuda_unittest.py
+++ b/test/legacy_test/test_cuda_unittest.py
@@ -158,9 +158,9 @@ class TestCudaCompat(unittest.TestCase):
             self.assertTrue(hasattr(cuda_rt_module.cudaOutputMode, "CSV"))
             self.assertEqual(cuda_rt_module.cudaOutputMode.CSV, 1)
 
-        self.assertTrue(hasattr(cuda_rt_module, "cudaError"))
-        self.assertTrue(hasattr(cuda_rt_module.cudaError, "success"))
-        self.assertEqual(cuda_rt_module.cudaError.success, 0)
+        self.assertTrue(hasattr(cuda_rt_module, "cudaError_"))
+        self.assertTrue(hasattr(cuda_rt_module.cudaError_, "success"))
+        self.assertEqual(cuda_rt_module.cudaError_.success, 0)
 
         func_list = [
             "cudaGetErrorString",
@@ -187,7 +187,7 @@ class TestCudaCompat(unittest.TestCase):
 
         # cudaGetErrorString
         err_str = cuda_rt_module.cudaGetErrorString(
-            cuda_rt_module.cudaError.success
+            cuda_rt_module.cudaError_.success
         )
         self.assertIsInstance(err_str, str)
 
@@ -202,22 +202,22 @@ class TestCudaCompat(unittest.TestCase):
         buf = np.zeros(1024, dtype=np.float32)
         ptr = buf.ctypes.data
         err = cuda_rt_module.cudaHostRegister(ptr, buf.nbytes, 0)
-        self.assertEqual(err, cuda_rt_module.cudaError.success)
+        self.assertEqual(err, cuda_rt_module.cudaError_.success)
         err = cuda_rt_module.cudaHostUnregister(ptr)
-        self.assertEqual(err, cuda_rt_module.cudaError.success)
+        self.assertEqual(err, cuda_rt_module.cudaError_.success)
 
         # cudaStreamCreate / cudaStreamDestroy
         stream = ctypes.c_size_t(0)
         err = cuda_rt_module.cudaStreamCreate(ctypes.addressof(stream))
-        assert err == cuda_rt_module.cudaError.success
+        assert err == cuda_rt_module.cudaError_.success
 
         err = cuda_rt_module.cudaStreamDestroy(stream.value)
-        assert err == cuda_rt_module.cudaError.success
+        assert err == cuda_rt_module.cudaError_.success
 
         err = cuda_rt_module.cudaProfilerStart()
-        self.assertEqual(err, cuda_rt_module.cudaError.success)
+        self.assertEqual(err, cuda_rt_module.cudaError_.success)
         err = cuda_rt_module.cudaProfilerStop()
-        self.assertEqual(err, cuda_rt_module.cudaError.success)
+        self.assertEqual(err, cuda_rt_module.cudaError_.success)
 
     @unittest.skipIf(
         (


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

Pcard-75624


This pull request updates the CUDA Python bindings and related error handling to avoid enum name conflicts across deep learning frameworks. The main changes involve renaming the CUDA error and output mode enums and updating their usage in the Python wrapper code.

**Enum registration and usage updates:**

* Renamed the CUDA output mode enum to `OutputMode_` and the CUDA error enum to `Error_` in `cudart_py.cc` to prevent duplicate registration across DL frameworks.
* Updated all references in `python/paddle/cuda/__init__.py` to use the new enum names (`cudaError_` instead of `cudaError`) for error handling and validation. [[1]](diffhunk://#diff-45b228d10b8565d244d6fa2acab2380a240c90523cb79f39adcafc09a0c06f87L153-R153) [[2]](diffhunk://#diff-45b228d10b8565d244d6fa2acab2380a240c90523cb79f39adcafc09a0c06f87L163-R163) [[3]](diffhunk://#diff-45b228d10b8565d244d6fa2acab2380a240c90523cb79f39adcafc09a0c06f87L178-R178)