### PR TITLE
[INFERENCE]make internode_ll_two_stages supports clear_buffer when mixed_infer

### DIFF
--- a/paddle/fluid/distributed/collective/deep_ep/deep_ep.cpp
+++ b/paddle/fluid/distributed/collective/deep_ep/deep_ep.cpp
@@ -1654,8 +1654,6 @@ void Buffer::clean_low_latency_two_stage_buffer(
     bool use_fp8) {
 #ifdef PADDLE_WITH_NVSHMEM
   EP_HOST_ASSERT(low_latency_mode);
-  CUDA_CHECK(
-      cudaMemsetAsync(rdma_buffer_ptr, 0, num_rdma_bytes, calc_ctx->stream()));
 
   const int num_local_experts = num_experts / num_ranks;
   const int num_rdma_experts = num_local_experts * NUM_MAX_NVL_PEERS;

--- a/paddle/fluid/distributed/collective/deep_ep/deep_ep.cpp
+++ b/paddle/fluid/distributed/collective/deep_ep/deep_ep.cpp
@@ -1645,6 +1645,43 @@ void Buffer::clean_low_latency_buffer(int num_max_dispatch_tokens_per_rank,
 #endif
 }
 
+void Buffer::clean_low_latency_two_stage_buffer(
+    int num_max_dispatch_tokens_per_rank,
+    int hidden,
+    int num_experts,
+    int num_topk) {
+#ifdef PADDLE_WITH_NVSHMEM
+  EP_HOST_ASSERT(low_latency_mode);
+
+  auto layout = LowLatencyTwoStageLayout(rdma_buffer_ptr,
+                                         num_max_dispatch_tokens_per_rank,
+                                         hidden,
+                                         num_ranks,
+                                         num_experts,
+                                         num_topk);
+  auto clean_meta_0 = layout.buffers[0].clean_meta();
+  auto clean_meta_1 = layout.buffers[1].clean_meta();
+
+  auto check_boundary = [=](void* ptr, size_t num_bytes) {
+    auto offset = reinterpret_cast<int64_t>(ptr) -
+                  reinterpret_cast<int64_t>(rdma_buffer_ptr);
+    EP_HOST_ASSERT(0 <= offset &&
+                   offset + static_cast<int64_t>(num_bytes) <= num_rdma_bytes);
+  };
+  check_boundary(clean_meta_0.first, clean_meta_0.second * sizeof(int));
+  check_boundary(clean_meta_1.first, clean_meta_1.second * sizeof(int));
+
+  internode_ll::clean_low_latency_buffer(clean_meta_0.first,
+                                         clean_meta_0.second,
+                                         clean_meta_1.first,
+                                         clean_meta_1.second,
+                                         calc_ctx->stream());
+#else
+  LOG(ERROR) << "NVSHMEM is not enabled. You can enable it by setting cmake "
+                "option WITH_NVSHMEM=ON.";
+#endif
+}
+
 void Buffer::barrier_all() {
 #ifdef PADDLE_WITH_NVSHMEM
   internode_ll::barrier_all(calc_ctx->stream());

--- a/paddle/fluid/distributed/collective/deep_ep/deep_ep.cpp
+++ b/paddle/fluid/distributed/collective/deep_ep/deep_ep.cpp
@@ -1649,9 +1649,36 @@ void Buffer::clean_low_latency_two_stage_buffer(
     int num_max_dispatch_tokens_per_rank,
     int hidden,
     int num_experts,
-    int num_topk) {
+    int num_topk,
+    int num_ranks,
+    bool use_fp8) {
 #ifdef PADDLE_WITH_NVSHMEM
   EP_HOST_ASSERT(low_latency_mode);
+  CUDA_CHECK(
+      cudaMemsetAsync(rdma_buffer_ptr, 0, num_rdma_bytes, calc_ctx->stream()));
+
+  const int num_local_experts = num_experts / num_ranks;
+  const int num_rdma_experts = num_local_experts * NUM_MAX_NVL_PEERS;
+  const int num_scales = hidden / 128;
+  const int num_rdma_ranks = num_ranks / NUM_MAX_NVL_PEERS;
+  const size_t dispatch_num_bytes_per_msg =
+      sizeof(int4) + (use_fp8 ? (hidden + num_scales * sizeof(float))
+                              : (hidden * sizeof(nv_bfloat16)));
+  auto dispatch_nvl_num_bytes = num_local_experts * num_ranks *
+                                num_max_dispatch_tokens_per_rank *
+                                dispatch_num_bytes_per_msg;
+  const size_t combine_num_bytes_per_msg = hidden * sizeof(nv_bfloat16);
+  auto combine_nvl_num_bytes = num_rdma_experts * num_rdma_ranks *
+                               num_max_dispatch_tokens_per_rank *
+                               combine_num_bytes_per_msg;
+  const size_t signal_bytes = (num_local_experts * num_ranks * sizeof(int) +
+                               NUM_BUFFER_ALIGNMENT_BYTES - 1) /
+                              NUM_BUFFER_ALIGNMENT_BYTES *
+                              NUM_BUFFER_ALIGNMENT_BYTES;
+  auto max_nvl_num_bytes =
+      (std::max(dispatch_nvl_num_bytes, combine_nvl_num_bytes) +
+       NUM_BUFFER_ALIGNMENT_BYTES - 1) /
+      NUM_BUFFER_ALIGNMENT_BYTES * NUM_BUFFER_ALIGNMENT_BYTES;
 
   auto layout = LowLatencyTwoStageLayout(rdma_buffer_ptr,
                                          num_max_dispatch_tokens_per_rank,
@@ -1671,11 +1698,17 @@ void Buffer::clean_low_latency_two_stage_buffer(
   check_boundary(clean_meta_0.first, clean_meta_0.second * sizeof(int));
   check_boundary(clean_meta_1.first, clean_meta_1.second * sizeof(int));
 
-  internode_ll::clean_low_latency_buffer(clean_meta_0.first,
-                                         clean_meta_0.second,
-                                         clean_meta_1.first,
-                                         clean_meta_1.second,
-                                         calc_ctx->stream());
+  internode_ll_two_stage::clean_low_latency_buffer_two_stage(
+      buffer_ptrs_gpu,
+      max_nvl_num_bytes,
+      signal_bytes,
+      nvl_rank,
+      num_experts,
+      clean_meta_0.first,
+      clean_meta_0.second,
+      clean_meta_1.first,
+      clean_meta_1.second,
+      calc_ctx->stream());
 #else
   LOG(ERROR) << "NVSHMEM is not enabled. You can enable it by setting cmake "
                 "option WITH_NVSHMEM=ON.";

--- a/paddle/fluid/distributed/collective/deep_ep/deep_ep.hpp
+++ b/paddle/fluid/distributed/collective/deep_ep/deep_ep.hpp
@@ -247,6 +247,10 @@ struct Buffer {
   void clean_low_latency_buffer(int num_max_dispatch_tokens_per_rank,
                                 int hidden,
                                 int num_experts);
+  void clean_low_latency_two_stage_buffer(int num_max_dispatch_tokens_per_rank,
+                                          int hidden,
+                                          int num_experts,
+                                          int num_topk);
   void barrier_all();
 
 #ifdef PADDLE_WITH_NVSHMEM

--- a/paddle/fluid/distributed/collective/deep_ep/deep_ep.hpp
+++ b/paddle/fluid/distributed/collective/deep_ep/deep_ep.hpp
@@ -250,7 +250,9 @@ struct Buffer {
   void clean_low_latency_two_stage_buffer(int num_max_dispatch_tokens_per_rank,
                                           int hidden,
                                           int num_experts,
-                                          int num_topk);
+                                          int num_topk,
+                                          int num_ranks,
+                                          bool use_fp8);
   void barrier_all();
 
 #ifdef PADDLE_WITH_NVSHMEM

--- a/paddle/fluid/distributed/collective/deep_ep/kernels/api.cuh
+++ b/paddle/fluid/distributed/collective/deep_ep/kernels/api.cuh
@@ -408,6 +408,17 @@ void combine(void* combined_x,
              bool dispatch_use_fp8,
              int next_buffer_id);
 
+void clean_low_latency_buffer_two_stage(void** buffer_ptrs_gpu,
+                                        const size_t max_nvl_num_bytes,
+                                        const size_t signal_bytes,
+                                        const int nvl_rank,
+                                        const int num_experts,
+                                        int* clean_0,
+                                        int num_clean_int_0,
+                                        int* clean_1,
+                                        int num_clean_int_1,
+                                        cudaStream_t stream);
+
 }  // namespace internode_ll_two_stage
 
 #endif  // PADDLE_WITH_NVSHMEM

--- a/paddle/fluid/distributed/collective/deep_ep/kernels/launch.cuh
+++ b/paddle/fluid/distributed/collective/deep_ep/kernels/launch.cuh
@@ -129,7 +129,13 @@
   while (false)
 
 #define DISPATCH_HIDDEN_SIZE(hidden, kHidden, ...) \
-  if (hidden == 7168) {                            \
+  if (hidden == 1536) {                            \
+    constexpr size_t kHidden = 1536;               \
+    __VA_ARGS__                                    \
+  } else if (hidden == 4096) {                     \
+    constexpr size_t kHidden = 4096;               \
+    __VA_ARGS__                                    \
+  } else if (hidden == 7168) {                     \
     constexpr size_t kHidden = 7168;               \
     __VA_ARGS__                                    \
   } else if (hidden == 8192) {                     \

--- a/paddle/fluid/pybind/deep_ep_api.cc
+++ b/paddle/fluid/pybind/deep_ep_api.cc
@@ -99,6 +99,8 @@ void BindDeepEPApi(pybind11::module *m) {
       .def("barrier_all", &deep_ep::Buffer::barrier_all)
       .def("clean_low_latency_buffer",
            &deep_ep::Buffer::clean_low_latency_buffer)
+      .def("clean_low_latency_two_stage_buffer",
+           &deep_ep::Buffer::clean_low_latency_two_stage_buffer)
       .def("low_latency_dispatch", &deep_ep::Buffer::low_latency_dispatch_api)
       .def("low_latency_combine", &deep_ep::Buffer::low_latency_combine_api)
       .def("low_latency_dispatch_two_stage",

--- a/python/paddle/distributed/communication/deep_ep/buffer.py
+++ b/python/paddle/distributed/communication/deep_ep/buffer.py
@@ -831,6 +831,8 @@ class Buffer:
         hidden: int,
         num_experts: int,
         num_topk: int,
+        num_ranks: int,
+        use_fp8: bool,
     ) -> None:
         """
         As low-latency two-stage kernels require part of the buffer to be zero-initialized, so it is vital to clean the buffer
@@ -845,7 +847,12 @@ class Buffer:
             num_topk: the number of moe topk.
         """
         self.runtime.clean_low_latency_two_stage_buffer(
-            num_max_dispatch_tokens_per_rank, hidden, num_experts, num_topk
+            num_max_dispatch_tokens_per_rank,
+            hidden,
+            num_experts,
+            num_topk,
+            num_ranks,
+            use_fp8,
         )
 
     # noinspection PyTypeChecker

--- a/python/paddle/distributed/communication/deep_ep/buffer.py
+++ b/python/paddle/distributed/communication/deep_ep/buffer.py
@@ -825,6 +825,29 @@ class Buffer:
             num_max_dispatch_tokens_per_rank, hidden, num_experts
         )
 
+    def clean_low_latency_two_stage_buffer(
+        self,
+        num_max_dispatch_tokens_per_rank: int,
+        hidden: int,
+        num_experts: int,
+        num_topk: int,
+    ) -> None:
+        """
+        As low-latency two-stage kernels require part of the buffer to be zero-initialized, so it is vital to clean the buffer
+            if the buffer is dirty at some time.
+        For example, after running the normal dispatch/combine, you must run this function before executing any
+            low-latency kernel.
+
+        Arguments:
+            num_max_dispatch_tokens_per_rank: the maximum number of tokens to dispatch, all the ranks must hold the same value.
+            hidden: the hidden dimension of each token.
+            num_experts: the number of all experts.
+            num_topk: the number of moe topk.
+        """
+        self.runtime.clean_low_latency_two_stage_buffer(
+            num_max_dispatch_tokens_per_rank, hidden, num_experts, num_topk
+        )
+
     # noinspection PyTypeChecker
     def low_latency_dispatch(
         self,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
card-71500
make internode_ll_two_stages supports clear_buffer when mixed_infer