### PR TITLE
Add no_need_buffer for index_elementwise get/put grad kernel

### DIFF
--- a/paddle/phi/ops/yaml/backward.yaml
+++ b/paddle/phi/ops/yaml/backward.yaml
@@ -1733,6 +1733,7 @@
   kernel :
     func : index_elementwise_get_grad
   backward: index_elementwise_get_double_grad
+  no_need_buffer: x
 
 - backward_op : index_elementwise_put_grad
   forward : index_elementwise_put (Tensor x, Tensor[] index, Scalar value, int64_t[] input_dims, int64_t[] input_strides, int64_t[] index_dims, int64_t[] index_strides, int64_t slice_offset) -> Tensor(out)
@@ -1745,6 +1746,7 @@
     data_type : out_grad
   data_transform :
     skip_transform : index
+  no_need_buffer: x
 
 - backward_op : index_elementwise_put_with_tensor_grad
   forward : index_elementwise_put_with_tensor (Tensor x, Tensor[] index, Tensor value, int64_t[] input_dims, int64_t[] input_strides, int64_t[] index_dims, int64_t[] index_strides, int64_t slice_offset) -> Tensor(out)
@@ -1757,6 +1759,7 @@
     data_type : out_grad
   data_transform :
     skip_transform : index
+  no_need_buffer: x, value
 
 - backward_op : index_put_double_grad
   forward : index_put_grad (Tensor x, Tensor[] indices, Tensor value, Tensor grad_out, bool accumulate=false) -> Tensor(grad_x), Tensor(grad_value)


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Improvements

### Description
index_elementwise_get_grad,index_elementwise_put_grad,index_elementwise_put_with_tensor_grad 算子 yaml 增加no_need_buffer，跳过 inplace version 的检查。
pcard-67164