### PR TITLE
[AutoParallel] Modify order of DataLoader init params

### DIFF
--- a/python/paddle/io/reader.py
+++ b/python/paddle/io/reader.py
@@ -467,12 +467,12 @@ class DataLoader:
         collate_fn: _CollateFn | None = None,
         num_workers: int = 0,
         use_buffer_reader: bool = True,
-        reader_buffer_size: int = 2,
         prefetch_factor: int = 2,
         use_shared_memory: bool = True,
         timeout: int = 0,
         worker_init_fn: Callable[[int], None] | None = None,
         persistent_workers: bool = False,
+        reader_buffer_size: int = 2,
     ) -> None:
         self.return_list = return_list
         self.collate_fn = collate_fn


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
在 https://github.com/PaddlePaddle/Paddle/pull/75023 中，为 Dataloader 新增 reader_buffer_size 参数
但在 paddleformers 中调用 Dataloader 构造函数时，并没有使用关键词初始化，这会导致出现参数错位的情况
该PR 将 reader_buffer_size 参数调整到最后，以适配没有使用关键词初始化的情况
Pcard-93113
