### PR TITLE
2nd-batch-03-函数原型与定义返回类型不匹配

### DIFF
--- a/paddle/fluid/inference/capi/pd_config.cc
+++ b/paddle/fluid/inference/capi/pd_config.cc
@@ -431,6 +431,6 @@ void PD_DisableGlogInfo(PD_AnalysisConfig* config) {
 }
 
 void PD_DeletePass(PD_AnalysisConfig* config, char* pass_name) {
-  return config->config.pass_builder()->DeletePass(std::string(pass_name));
+  config->config.pass_builder()->DeletePass(std::string(pass_name));
 }
 }  // extern "C"


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
第二批-编号03(共1处)
PD_DeletePass` 函数定义为返回 `void`，但函数体内使用了 `return` 语句返回一个 `PassStrategy*` 类型的值，违反了 C++ 类型系统规则，构成类型不匹配缺陷。
将 `return` 语句改为普通表达式调用，去掉 `return` 关键字，仅执行删除操作。因为该函数设计为不返回值（`void`），不应返回任何表达式。这样既符合类型安全，也符合 API 封装意图。