### PR TITLE
[Precision Depth Alignment] paddle.tan reverse calculation: dx = dout *(1 + tan(x)^2)

### DIFF
--- a/paddle/phi/kernels/funcs/activation_functor.h
+++ b/paddle/phi/kernels/funcs/activation_functor.h
@@ -3865,12 +3865,22 @@ template <typename T>
 struct CudaTanGradFunctor : public BaseActivationFunctor<T> {
   using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
 
-  // dx = dout / cos(x)^2
+  // dx = dout *(1 + tan(x)^2)
   __device__ __forceinline__ T operator()(const T arg_dout,
                                           const T arg_x) const {
     MPType dout = static_cast<MPType>(arg_dout);
     MPType x = static_cast<MPType>(arg_x);
-    return static_cast<T>(dout / (cos(x) * cos(x)));
+    if constexpr (std::is_same<MPType, double>::value) {
+      double td = ::tan(x);
+      double tsq = __dmul_rn(td, td);
+      double y = __dadd_rn(tsq, 1.0);
+      return static_cast<T>(dout * y);
+    } else {
+      float tf = ::tanf(x);
+      float tsq = __fmul_rn(tf, tf);
+      float y = __fadd_rn(tsq, 1.0f);
+      return static_cast<T>(dout * y);
+    }
   }
 
   static constexpr ActBwdOpFwdDeps FwdDeps() { return ActBwdOpFwdDeps::kDepX; }
@@ -3879,13 +3889,16 @@ struct CudaTanGradFunctor : public BaseActivationFunctor<T> {
 template <typename T>
 struct CudaTanGradFunctor<ComplexType<T>>
     : public BaseActivationFunctor<ComplexType<T>> {
-  // dx = dout / cos(x)^2
+  // dx = dout *(1 + tan(x)^2)
   __device__ __forceinline__ ComplexType<T> operator()(
       const ComplexType<T> dout, const ComplexType<T> x) const {
-    return static_cast<ComplexType<T>>(dout / conj(cos(x) * cos(x)));
+    ComplexType<T> one = static_cast<ComplexType<T>>(1.0f);
+    return static_cast<ComplexType<T>>(dout * conj(tan(x) * tan(x) + one));
   }
 
-  static constexpr ActBwdOpFwdDeps FwdDeps() { return ActBwdOpFwdDeps::kDepX; }
+  static constexpr ActBwdOpFwdDeps FwdDeps() {
+    return ActBwdOpFwdDeps::kDepOut;
+  }
 };
 
 template <typename T>

--- a/paddle/phi/kernels/funcs/activation_functor.h
+++ b/paddle/phi/kernels/funcs/activation_functor.h
@@ -3896,9 +3896,7 @@ struct CudaTanGradFunctor<ComplexType<T>>
     return static_cast<ComplexType<T>>(dout * conj(tan(x) * tan(x) + one));
   }
 
-  static constexpr ActBwdOpFwdDeps FwdDeps() {
-    return ActBwdOpFwdDeps::kDepOut;
-  }
+  static constexpr ActBwdOpFwdDeps FwdDeps() { return ActBwdOpFwdDeps::kDepX; }
 };
 
 template <typename T>


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->

**主要改动点（相对老代码）：**

**数学公式切换**
1. 实数：由 dx = dout / cos(x)^2 改为 dx = dout * (1 + tan(x)^2)。
2. 复数：由 dx = dout / conj(cos(x) * cos(x)) 改为 dx = dout * conj(tan(x) * tan(x) + 1)。
目的：避免在 cos(x)≈0 时的数值不稳定与放大误差，更贴近 PyTorch 的实现与精度表现。

**精度与舍入控制**
1. 拆分 double / float 两条路径，分别用 ::tan 和 ::tanf 计算。
2. 使用 __dmul_rn/__dadd_rn 与 __fmul_rn/__fadd_rn 显式“先乘后加”，禁止 FMA，保证与 PyTorch 更一致的舍入行为。

**复测结果：**
paddle.tan 对齐case（16 个）
未对齐case（1个float16类型的case）

**遗留问题：**
1. flaot16还是存在精度误差。

pcard-67164