### PR TITLE
2nd-batch-09-条件判断冗余

### DIFF
--- a/tools/get_pr_ut.py
+++ b/tools/get_pr_ut.py
@@ -207,7 +207,7 @@ class PRChecker:
         filetype = ''
         if f.endswith('.h') or f.endswith('.cc') or f.endswith('.cu'):
             filetype = 'cc'
-        if f.endswith('.py'):
+        elif f.endswith('.py'):
             filetype = 'py'
         else:
             return []


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
第二批-编号09(共1处)
变量名 `filetype` 在两个独立的 `if` 语句中被赋值，但由于缺少 `elif`，当文件以 `.py` 结尾时，`filetype` 会被错误地重新赋值为 `'py'`，即使它已经是 `'cc'`，应使用 `elif` 确保文件类型判断逻辑互斥，避免覆盖