### PR TITLE
2nd-batch-12-越界访问和资源泄漏

### DIFF
--- a/paddle/utils/small_vector.h
+++ b/paddle/utils/small_vector.h
@@ -609,7 +609,6 @@ class small_vector_template_base<T, true>
       this->set_size(this->size() - 1);
     }
   }
-
 };
 
 /// This class consists of common code factored out of the small_vector class to

--- a/paddle/utils/small_vector.h
+++ b/paddle/utils/small_vector.h
@@ -603,7 +603,13 @@ class small_vector_template_base<T, true>
     this->set_size(this->size() + 1);
   }
 
-  void pop_back() { this->set_size(this->size() - 1); }
+  void pop_back() {
+    if (this->size() > 0) {
+      this->at(this->size() - 1).~T();
+      this->set_size(this->size() - 1);
+    }
+  }
+
 };
 
 /// This class consists of common code factored out of the small_vector class to


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
第二批-编号12(共1处)
当 `size()` 为 0 时，`this->size() - 1` 会变成 -1，可能导致 `set_size` 内部越界或访问非法内存。此外，对于非 POD 类型的 `T`，该操作未调用对象的析构函数，导致未释放的资源残留。