### PR TITLE
[Precision Depth Alignment] fix CudaSigmoidGradFunctor and CudaSiluGradFunctor

### DIFF
--- a/paddle/phi/kernels/funcs/activation_functor.h
+++ b/paddle/phi/kernels/funcs/activation_functor.h
@@ -4881,7 +4881,7 @@ struct CudaSiluGradFunctor : public BaseActivationFunctor<T> {
     MPType dout = static_cast<MPType>(arg_dout);
     MPType x = static_cast<MPType>(arg_x);
     MPType temp = one / (one + exp(-x));
-    return static_cast<T>(dout * (temp * (one + x * (one - temp))));
+    return static_cast<T>(dout * temp * (one + x * (one - temp)));
   }
 
   static constexpr ActBwdOpFwdDeps FwdDeps() { return ActBwdOpFwdDeps::kDepX; }
@@ -4975,7 +4975,7 @@ struct CudaSigmoidGradFunctor : public BaseActivationFunctor<T> {
 
   // dx = dout * out * (1 - out)
   __device__ __forceinline__ T operator()(const T dout, const T out) const {
-    return dout * out * (one - out);
+    return dout * (one - out) * out;
   }
 
   static constexpr ActBwdOpFwdDeps FwdDeps() {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->

#### 受影响的 API：
- `paddle.nn.functional.silu` 对齐全部case（共 238 个）
- `paddle.nn.functional.sigmoid` 对齐全部case（共 3665 个）
- `paddle.Tensor.sigmoid` 对齐全部case（共 10 个）

#### 修改内容
- 计算silu 梯度时，dout * (temp * (one + x * (one - temp)))的计算顺序改为dout * temp * (one + x * (one - temp))。
- 计算 sigmoid 梯度时， dout * out * (one - out) 改为 dout * (one - out) * out


#### 其他说明



Pcard-67164