### PR TITLE
[Compat] Support `register_fake` with call

### DIFF
--- a/python/paddle/library.py
+++ b/python/paddle/library.py
@@ -153,3 +153,11 @@ def register_fake(
     warn_about_unimplemented_torch_features(
         "register_fake", "torch.library.register_fake"
     )
+
+    def register(func):
+        return func
+
+    if func is None:
+        return register
+    else:
+        return register(func)

--- a/test/compat/test_library.py
+++ b/test/compat/test_library.py
@@ -44,10 +44,15 @@ class TestCallCustomOp(unittest.TestCase):
 
 
 class TestRegisterFake(unittest.TestCase):
-    def test_register_fake(self):
+    def test_register_fake_without_call(self):
         paddle.library.register_fake(
             "test_namespace::add_two",
-            lambda x: x,
+            lambda x: x + 2,
+        )
+
+    def test_register_fake_with_call(self):
+        paddle.library.register_fake("test_namespace::add_three")(
+            lambda x: x + 3,
         )
 
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

`register_fake` 支持 `register_fake(...)(fn)` 的形式

<!-- PCard-66972 -->