### PR TITLE
[CMake4] Add `CMAKE_POLICY_VERSION_MINIMUM=3.5` to some third_party (linux cpu)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ if(APPLE AND WITH_ARM)
   cmake_minimum_required(VERSION 3.19.2)
   cmake_policy(VERSION 3.19.2)
 else()
-  cmake_minimum_required(VERSION 3.15)
+  cmake_minimum_required(VERSION 3.18)
   cmake_policy(VERSION 3.10)
 endif()
 # use to get_property location of static lib

--- a/cmake/external/cryptopp.cmake
+++ b/cmake/external/cryptopp.cmake
@@ -59,6 +59,15 @@ set(CRYPTOPP_CMAKE_ARGS
     -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
     -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER})
 
+# For CMake >= 4.0.0, set policy compatibility for cryptopp's CMake.
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.0.0")
+  message(
+    WARNING
+      "cryptopp: forcing CMake policy compatibility for CMake >= 4.0 (CMAKE_POLICY_VERSION_MINIMUM=3.5)"
+  )
+  list(APPEND CRYPTOPP_CMAKE_ARGS -DCMAKE_POLICY_VERSION_MINIMUM=3.5)
+endif()
+
 include_directories(${CRYPTOPP_INCLUDE_DIR})
 
 ExternalProject_Add(

--- a/cmake/external/gflags.cmake
+++ b/cmake/external/gflags.cmake
@@ -35,6 +35,16 @@ endif()
 
 include_directories(${GFLAGS_INCLUDE_DIR})
 
+# For CMake >= 4.0.0, set policy compatibility for third-party gflags' CMake.
+set(GFLAGS_POLICY_ARGS "")
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.0.0")
+  message(
+    WARNING
+      "gflags: forcing CMake policy compatibility for CMake >= 4.0 (CMAKE_POLICY_VERSION_MINIMUM=3.5)"
+  )
+  set(GFLAGS_POLICY_ARGS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
+endif()
+
 ExternalProject_Add(
   extern_gflags
   ${EXTERNAL_PROJECT_LOG_ARGS}
@@ -51,6 +61,7 @@ ExternalProject_Add(
              -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
              -DCMAKE_C_FLAGS_DEBUG=${CMAKE_C_FLAGS_DEBUG}
              -DCMAKE_C_FLAGS_RELEASE=${CMAKE_C_FLAGS_RELEASE}
+             ${GFLAGS_POLICY_ARGS}
              -DBUILD_STATIC_LIBS=ON
              -DCMAKE_INSTALL_PREFIX=${GFLAGS_INSTALL_DIR}
              -DCMAKE_POSITION_INDEPENDENT_CODE=ON

--- a/cmake/external/glog.cmake
+++ b/cmake/external/glog.cmake
@@ -38,6 +38,16 @@ endif()
 
 include_directories(${GLOG_INCLUDE_DIR})
 
+# For CMake >= 4.0.0, set policy compatibility for glog's CMake.
+set(GLOG_POLICY_ARGS "")
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.0.0")
+  message(
+    WARNING
+      "glog: forcing CMake policy compatibility for CMake >= 4.0 (CMAKE_POLICY_VERSION_MINIMUM=3.5)"
+  )
+  set(GLOG_POLICY_ARGS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
+endif()
+
 ExternalProject_Add(
   extern_glog
   ${EXTERNAL_PROJECT_LOG_ARGS} ${SHALLOW_CLONE}
@@ -53,6 +63,7 @@ ExternalProject_Add(
              -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
              -DCMAKE_C_FLAGS_DEBUG=${CMAKE_C_FLAGS_DEBUG}
              -DCMAKE_C_FLAGS_RELEASE=${CMAKE_C_FLAGS_RELEASE}
+             ${GLOG_POLICY_ARGS}
              -DCMAKE_INSTALL_PREFIX=${GLOG_INSTALL_DIR}
              -DCMAKE_INSTALL_LIBDIR=${GLOG_INSTALL_DIR}/lib
              -DCMAKE_POSITION_INDEPENDENT_CODE=ON

--- a/cmake/external/gloo.cmake
+++ b/cmake/external/gloo.cmake
@@ -51,6 +51,16 @@ list(APPEND GLOO_PATCH_COMMAND
 set(GLOO_CMAKE_C_FLAGS "-O3 -fPIC")
 set(GLOO_CMAKE_CXX_FLAGS "-O3 -fPIC")
 
+# For CMake >= 4.0.0, set policy compatibility for gloo's CMake.
+set(GLOO_POLICY_ARGS "")
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.0.0")
+  message(
+    WARNING
+      "gloo: forcing CMake policy compatibility for CMake >= 4.0 (CMAKE_POLICY_VERSION_MINIMUM=3.5)"
+  )
+  set(GLOO_POLICY_ARGS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
+endif()
+
 ExternalProject_Add(
   ${GLOO_PROJECT}
   ${EXTERNAL_PROJECT_LOG_ARGS}
@@ -63,6 +73,7 @@ ExternalProject_Add(
              -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
              -DCMAKE_C_FLAGS=${GLOO_CMAKE_C_FLAGS}
              -DCMAKE_CXX_FLAGS=${GLOO_CMAKE_CXX_FLAGS}
+             ${GLOO_POLICY_ARGS}
   BUILD_BYPRODUCTS ${GLOO_LIBRARIES})
 
 add_library(gloo STATIC IMPORTED GLOBAL)

--- a/cmake/external/onednn.cmake
+++ b/cmake/external/onednn.cmake
@@ -38,6 +38,16 @@ set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_RPATH}"
 include_directories(${ONEDNN_INC_DIR}
 )# For oneDNN code to include internal headers.
 
+# For CMake >= 4.0.0, set policy compatibility for oneDNN's CMake.
+set(ONEDNN_POLICY_ARGS "")
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.0.0")
+  message(
+    WARNING
+      "oneDNN: forcing CMake policy compatibility for CMake >= 4.0 (CMAKE_POLICY_VERSION_MINIMUM=3.5)"
+  )
+  set(ONEDNN_POLICY_ARGS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
+endif()
+
 if(NOT WIN32)
   set(ONEDNN_FLAG
       "-Wno-error=strict-overflow -Wno-error=unused-result -Wno-error=array-bounds"
@@ -87,6 +97,7 @@ ExternalProject_Add(
              -DCMAKE_POSITION_INDEPENDENT_CODE=ON
              -DDNNL_BUILD_TESTS=OFF
              -DDNNL_BUILD_EXAMPLES=OFF
+             ${ONEDNN_POLICY_ARGS}
   CMAKE_CACHE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=${ONEDNN_INSTALL_DIR}
   BUILD_BYPRODUCTS ${BUILD_BYPRODUCTS_ARGS})
 

--- a/cmake/external/utf8proc.cmake
+++ b/cmake/external/utf8proc.cmake
@@ -28,6 +28,16 @@ endif()
 
 include_directories(${UTF8PROC_INSTALL_DIR}/include)
 
+# For CMake >= 4.0.0, set policy compatibility for utf8proc's CMake.
+set(UTF8PROC_POLICY_ARGS "")
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.0.0")
+  message(
+    WARNING
+      "utf8proc: forcing CMake policy compatibility for CMake >= 4.0 (CMAKE_POLICY_VERSION_MINIMUM=3.5)"
+  )
+  set(UTF8PROC_POLICY_ARGS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
+endif()
+
 ExternalProject_Add(
   extern_utf8proc
   ${EXTERNAL_PROJECT_LOG_ARGS}
@@ -40,6 +50,7 @@ ExternalProject_Add(
              -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
              -DCMAKE_INSTALL_PREFIX:PATH=${UTF8PROC_INSTALL_DIR}
              -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
+             ${UTF8PROC_POLICY_ARGS}
   BUILD_BYPRODUCTS ${UTF8PROC_LIBRARIES})
 
 add_library(utf8proc STATIC IMPORTED GLOBAL)

--- a/cmake/external/warpctc.cmake
+++ b/cmake/external/warpctc.cmake
@@ -101,6 +101,16 @@ else()
   set(WARPCTC_CXX_FLAGS_DEBUG ${CMAKE_CXX_FLAGS_DEBUG})
 endif()
 
+# For CMake >= 4.0.0, force policy compatibility for third-party warpctc's CMake.
+set(WARPCTC_POLICY_ARGS "")
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.0.0")
+  message(
+    WARNING
+      "warpctc: forcing CMake policy compatibility for CMake >= 4.0 (CMAKE_POLICY_VERSION_MINIMUM=3.5)"
+  )
+  set(WARPCTC_POLICY_ARGS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
+endif()
+
 ExternalProject_Add(
   extern_warpctc
   ${EXTERNAL_PROJECT_LOG_ARGS}
@@ -133,6 +143,7 @@ ExternalProject_Add(
              -DCMAKE_BUILD_TYPE=${THIRD_PARTY_BUILD_TYPE}
              -DCUDA_TOOLKIT_ROOT_DIR=${CUDA_TOOLKIT_ROOT_DIR}
              ${EXTERNAL_OPTIONAL_ARGS}
+             ${WARPCTC_POLICY_ARGS}
              ${WARPCTC_CCBIN_OPTION}
   CMAKE_CACHE_ARGS
     -DCMAKE_BUILD_TYPE:STRING=${THIRD_PARTY_BUILD_TYPE}

--- a/cmake/external/warprnnt.cmake
+++ b/cmake/external/warprnnt.cmake
@@ -97,6 +97,16 @@ else()
   set(WARPRNNT_CXX_FLAGS_RELEASE ${CMAKE_CXX_FLAGS_RELEASE})
   set(WARPRNNT_CXX_FLAGS_DEBUG ${CMAKE_CXX_FLAGS_DEBUG})
 endif()
+
+# For CMake >= 4.0.0, force policy compatibility for third-party warprnnt's CMake.
+set(WARPRNNT_POLICY_ARGS "")
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.0.0")
+  message(
+    WARNING
+      "warprnnt: forcing CMake policy compatibility for CMake >= 4.0 (CMAKE_POLICY_VERSION_MINIMUM=3.5)"
+  )
+  set(WARPRNNT_POLICY_ARGS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
+endif()
 ExternalProject_Add(
   extern_warprnnt
   ${EXTERNAL_PROJECT_LOG_ARGS}
@@ -125,6 +135,7 @@ ExternalProject_Add(
              -DCMAKE_POSITION_INDEPENDENT_CODE=ON
              -DCMAKE_BUILD_TYPE=${THIRD_PARTY_BUILD_TYPE}
              ${EXTERNAL_OPTIONAL_ARGS}
+             ${WARPRNNT_POLICY_ARGS}
              ${WARPCTC_CCBIN_OPTION}
   CMAKE_CACHE_ARGS
     -DCMAKE_BUILD_TYPE:STRING=${THIRD_PARTY_BUILD_TYPE}

--- a/cmake/external/xbyak.cmake
+++ b/cmake/external/xbyak.cmake
@@ -31,6 +31,16 @@ add_definitions(-DPADDLE_WITH_XBYAK)
 add_definitions(-DXBYAK64)
 add_definitions(-DXBYAK_NO_OP_NAMES)
 
+# For CMake >= 4.0.0, set policy compatibility for xbyak's CMake.
+set(XBYAK_POLICY_ARGS "")
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.0.0")
+  message(
+    WARNING
+      "xbyak: forcing CMake policy compatibility for CMake >= 4.0 (CMAKE_POLICY_VERSION_MINIMUM=3.5)"
+  )
+  set(XBYAK_POLICY_ARGS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
+endif()
+
 ExternalProject_Add(
   ${XBYAK_PROJECT}
   ${EXTERNAL_PROJECT_LOG_ARGS} ${SHALLOW_CLONE}
@@ -38,7 +48,7 @@ ExternalProject_Add(
   DEPENDS ""
   PREFIX ${XBYAK_PREFIX_DIR}
   UPDATE_COMMAND ""
-  CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${XBYAK_INSTALL_ROOT}
+  CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${XBYAK_INSTALL_ROOT} ${XBYAK_POLICY_ARGS}
   CMAKE_CACHE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=${XBYAK_INSTALL_ROOT})
 
 add_library(xbyak INTERFACE)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
cmake4 不再支持那些为CMake 3.5以下版本编写的项目，然后它也给了推荐的解决方案，最后一种 -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway 可以在不修改第三方库本身 cmake_minimum_required 的时候支持 cmake 4，我选的就是在 cmake/external/xxx.cmake 里面如果 4.0 版本，cmake 参数就加上，当前只在 Linux CPU 的时候本地验证通过
<img width="723" height="235" alt="image" src="https://github.com/user-attachments/assets/15e0e523-3b8c-4690-8d8e-710db52c47c9" />