### PR TITLE
[AutoParallel] Adapt full_like for p_norm dynamic parallel backward

### DIFF
--- a/paddle/fluid/prim/api/composite_backward/composite_backward_api.h
+++ b/paddle/fluid/prim/api/composite_backward/composite_backward_api.h
@@ -2096,8 +2096,16 @@ void p_norm_grad(const Tensor& x,
         // dx = dy * (x / y)
         x_grad_tmp = x / expand_out;
         // fill zero to avoid division by zero
-        auto _zero_tensor =
-            full<T>(common::vectorize(x.dims()), 0.0, x.dtype(), x.place());
+
+
+        // Tensor _zero_tensor;
+        // if (x.is_dist_tensor()) {
+        //   _zero_tensor = full_like<T>(x, 0.0f);
+        // } else {
+        //   _zero_tensor = full<T>(common::vectorize(x.dims()), 0.0, x.dtype(), x.place());
+        // }
+        
+        auto _zero_tensor = x - x;
         auto finite_mask = isfinite<T>(x_grad_tmp);
         x_grad_tmp = where<T>(finite_mask, x_grad_tmp, _zero_tensor);
         x_grad_tmp = expand_out_grad * (x_grad_tmp);

--- a/paddle/fluid/prim/api/manual_prim/eager_prim_api.cc
+++ b/paddle/fluid/prim/api/manual_prim/eager_prim_api.cc
@@ -28,6 +28,16 @@ Tensor full<Tensor>(const IntArray& shape,
 }
 
 template <>
+Tensor full_like<Tensor>(const Tensor& x,
+                    const Scalar& value,
+                    DataType dtype,
+                    const Place& place) {
+  VLOG(4) << "Eager Prim API full_like_ad_func call";
+  return ::full_like_ad_func(x, value, dtype, place);
+}
+
+
+template <>
 Tensor cast<Tensor>(const Tensor& x, DataType dtype) {
   return ::cast_ad_func(x, dtype);
 }

--- a/paddle/fluid/prim/api/manual_prim/prim_manual_api.h
+++ b/paddle/fluid/prim/api/manual_prim/prim_manual_api.h
@@ -36,6 +36,12 @@ Tensor full(const IntArray& shape,
             const Place& place = CPUPlace());
 
 template <typename T>
+Tensor full_like(const Tensor& x,
+            const Scalar& value,
+            DataType dtype = DataType::FLOAT32,
+            const Place& place = CPUPlace());
+
+template <typename T>
 Tensor cast(const Tensor& x, DataType dtype);
 
 template <typename T>


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes 

### Description
<!-- Describe what you’ve done -->
