### PR TITLE
2nd-batch-23-对end()迭代器解引用

### DIFF
--- a/paddle/cinn/ir/group_schedule/search/config_searcher.cc
+++ b/paddle/cinn/ir/group_schedule/search/config_searcher.cc
@@ -222,7 +222,7 @@ std::pair<ScoreType, CandidateType> ScheduleConfigSearcher::Search(
     VLOG(6) << "Score = " << score;
     records_[score] = candidate;
   }
-  return is_search_minimum ? *records_.begin() : *(records_.end()--);
+  return is_search_minimum ? *records_.begin() : *records_.rbegin();
 }
 
 }  // namespace search


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
第二批-编号23(共1处)

` records_.end()` 指向容器末尾之后的位置，不能被解引用。表达式 `records_.end()--` 返回 `end()` 的副本（即指向末尾之后），然后对该副本进行递减操作，但由于是后缀自减，表达式值仍是递减前的 `end()`。因此 `*(records_.end()--)` 实际上是对 `end()` 迭代器解引用，这是未定义行为，可能导致崩溃。