### PR TITLE
[Precision Depth Alignment] Add support for CUDNN to paddle.nn.functional.grid_sample to align with torch accuracy. 

### DIFF
--- a/paddle/phi/kernels/gpu/grid_sample_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/grid_sample_grad_kernel.cu
@@ -14,7 +14,7 @@
 
 #include "paddle/phi/kernels/grid_sample_grad_kernel.h"
 
-#include "paddle/phi/backends/gpu/cudnn_desc.h"
+#include "paddle/phi/backends/dynload/cudnn.h"
 #include "paddle/phi/backends/gpu/gpu_device_function.h"
 #include "paddle/phi/backends/gpu/gpu_info.h"
 #include "paddle/phi/backends/gpu/gpu_launch_config.h"

--- a/paddle/phi/kernels/gpu/grid_sample_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/grid_sample_grad_kernel.cu
@@ -14,6 +14,7 @@
 
 #include "paddle/phi/kernels/grid_sample_grad_kernel.h"
 
+#include "paddle/phi/backends/gpu/cudnn_desc.h"
 #include "paddle/phi/backends/gpu/gpu_device_function.h"
 #include "paddle/phi/backends/gpu/gpu_info.h"
 #include "paddle/phi/backends/gpu/gpu_launch_config.h"
@@ -611,6 +612,122 @@ void GridSampleGradKernel(const Context& dev_ctx,
   } else {
     enum_mode = Mode::bilinear;
   }
+
+#ifndef PADDLE_WITH_HIP
+  if (condCudnnGridSampler<T>(x, grid) &&
+      enum_padding_mode == PaddingMode::zeros && enum_mode == Mode::bilinear &&
+      align_corners) {
+    const int64_t N = x.dims()[0];
+    const int64_t C = x.dims()[1];
+    const int64_t H_in = x.dims()[2];
+    const int64_t W_in = x.dims()[3];
+    const int64_t H_out = grid.dims()[1];
+    const int64_t W_out = grid.dims()[2];
+
+    // cuDNN handle
+    cudnnHandle_t handle = dev_ctx.cudnn_handle();
+
+    // Create and set Tensor descriptors (NCHW) for x/y
+    cudnnTensorDescriptor_t x_desc, dx_desc, y_desc;
+    PADDLE_ENFORCE_GPU_SUCCESS(
+        phi::dynload::cudnnCreateTensorDescriptor(&x_desc));
+    PADDLE_ENFORCE_GPU_SUCCESS(
+        phi::dynload::cudnnCreateTensorDescriptor(&dx_desc));
+    PADDLE_ENFORCE_GPU_SUCCESS(
+        phi::dynload::cudnnCreateTensorDescriptor(&y_desc));
+
+    const cudnnDataType_t cudnn_dtype =
+        std::is_same<T, float>::value ? CUDNN_DATA_FLOAT : CUDNN_DATA_DOUBLE;
+
+    PADDLE_ENFORCE_GPU_SUCCESS(
+        phi::dynload::cudnnSetTensor4dDescriptor(x_desc,
+                                                 CUDNN_TENSOR_NCHW,
+                                                 cudnn_dtype,
+                                                 static_cast<int>(N),
+                                                 static_cast<int>(C),
+                                                 static_cast<int>(H_in),
+                                                 static_cast<int>(W_in)));
+
+    // The shape of dx is consistent with that of x
+    PADDLE_ENFORCE_GPU_SUCCESS(
+        phi::dynload::cudnnSetTensor4dDescriptor(dx_desc,
+                                                 CUDNN_TENSOR_NCHW,
+                                                 cudnn_dtype,
+                                                 static_cast<int>(N),
+                                                 static_cast<int>(C),
+                                                 static_cast<int>(H_in),
+                                                 static_cast<int>(W_in)));
+
+    // The shape of y is consistent with out_grad
+    PADDLE_ENFORCE_GPU_SUCCESS(
+        phi::dynload::cudnnSetTensor4dDescriptor(y_desc,
+                                                 CUDNN_TENSOR_NCHW,
+                                                 cudnn_dtype,
+                                                 static_cast<int>(N),
+                                                 static_cast<int>(C),
+                                                 static_cast<int>(H_out),
+                                                 static_cast<int>(W_out)));
+
+    // Spatial Transformer descriptor: specifies sampler type and output
+    // dimension (N, C, H_out, W_out)
+    cudnnSpatialTransformerDescriptor_t st_desc;
+    PADDLE_ENFORCE_GPU_SUCCESS(
+        phi::dynload::cudnnCreateSpatialTransformerDescriptor(&st_desc));
+    int st_dims[4] = {static_cast<int>(N),
+                      static_cast<int>(C),
+                      static_cast<int>(H_out),
+                      static_cast<int>(W_out)};
+    PADDLE_ENFORCE_GPU_SUCCESS(
+        phi::dynload::cudnnSetSpatialTransformerNdDescriptor(
+            st_desc, CUDNN_SAMPLER_BILINEAR, cudnn_dtype, 4, st_dims));
+
+    // data pointer
+    const T* x_data = x.data<T>();
+    const T* grid_data = grid.data<T>();
+    const T* dy_data = out_grad.data<T>();
+
+    T* dx_data = dev_ctx.template Alloc<T>(x_grad);
+    phi::funcs::SetConstant<Context, T>()(dev_ctx, x_grad, static_cast<T>(0));
+
+    T* dgrid_data = nullptr;
+    if (grid_grad) {
+      dgrid_data = dev_ctx.template Alloc<T>(grid_grad);
+    }
+
+    // alpha/beta
+    using AlphaBetaT = typename std::
+        conditional<std::is_same<T, float>::value, float, double>::type;
+    const AlphaBetaT one = static_cast<AlphaBetaT>(1.0);
+    const AlphaBetaT zero = static_cast<AlphaBetaT>(0.0);
+
+    PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::cudnnSpatialTfSamplerBackward(
+        handle,
+        st_desc,
+        static_cast<const void*>(&one),  // alpha (for dx)
+        x_desc,
+        static_cast<const void*>(x_data),
+        static_cast<const void*>(&zero),  // beta (for dx)
+        dx_desc,
+        static_cast<void*>(dx_data),
+        static_cast<const void*>(&one),  // alpha (for dgrid)
+        y_desc,
+        static_cast<const void*>(dy_data),
+        static_cast<const void*>(grid_data),
+        static_cast<const void*>(&zero),  // beta (for dgrid)
+        static_cast<void*>(dgrid_data)));
+
+    // resource release
+    PADDLE_ENFORCE_GPU_SUCCESS(
+        phi::dynload::cudnnDestroySpatialTransformerDescriptor(st_desc));
+    PADDLE_ENFORCE_GPU_SUCCESS(
+        phi::dynload::cudnnDestroyTensorDescriptor(x_desc));
+    PADDLE_ENFORCE_GPU_SUCCESS(
+        phi::dynload::cudnnDestroyTensorDescriptor(dx_desc));
+    PADDLE_ENFORCE_GPU_SUCCESS(
+        phi::dynload::cudnnDestroyTensorDescriptor(y_desc));
+    return;
+  }
+#endif
 
   bool use_int32_index = x.numel() <= std::numeric_limits<int>::max() &&
                          grid.numel() <= std::numeric_limits<int>::max() &&


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->

#### 背景说明

在 `padding_mode == zeros` 且 `mode == bilinear` 且 `align_corners == true` 的配置下，Paddle 的原始实现与 PyTorch 存在一定数值差异。通过调用 cuDNN 提供的 `Spatial Transformer` API，可以在该配置下与 PyTorch 实现精度对齐。

该逻辑通过 `condCudnnGridSampler<T>` 进行适配判断，确保仅在支持的设备和数据类型（如 float / double）下调用 cuDNN。


本 PR 对 `grid_sample` 在 GPU 上的实现进行了优化与精度对齐处理。当满足以下特定条件时：
- `padding_mode == zeros`
- `mode == bilinear`
- `align_corners == true`
- `condCudnnGridSampler<T>(x, grid) == true`（即当前环境支持调用 cuDNN 的 grid sampler）

将启用 cuDNN 的 `cudnnSpatialTfSamplerForward` 和 `cudnnSpatialTfSamplerBackward` 接口来计算前向和反向传播，以提高性能并与 PyTorch 在该配置下的行为保持数值一致性。


#### 主要改动

##### ✅ 前向部分

在 `phi::grid_sample` 前向实现中增加判断逻辑，当满足上述条件时：

- 创建 cuDNN tensor 描述符 `x_desc` 与 `y_desc`
- 创建 cuDNN 空间变换描述符 `st_desc`
- 调用 `cudnnSpatialTfSamplerForward` 实现 bilinear 采样
- 自动释放相关资源（`x_desc` / `y_desc` / `st_desc`）

##### ✅ 反向部分

在反向传播中增加相应逻辑：

- 创建 `x_desc` / `dx_desc` / `y_desc` 描述符
- 创建空间变换描述符 `st_desc`
- 调用 `cudnnSpatialTfSamplerBackward` 计算 `dx` 和 `dgrid`
- 自动释放资源

#### 测试
【前向】：与torch完全对齐。(195个case)
【反向】：存在atomicAdd，在并行计算时，原子操作先后顺序不同导致了结果的随机性。（torch运行两次，都无法对齐）

pcard-67164