### PR TITLE
[Precision Depth Alignment] paddle.sqrt and paddle.rsqrt accuracy and torch alignment

### DIFF
--- a/paddle/phi/kernels/funcs/activation_functor.h
+++ b/paddle/phi/kernels/funcs/activation_functor.h
@@ -4322,11 +4322,11 @@ struct CudaSqrtFunctor : public BaseActivationFunctor<T> {
 
 template <typename T>
 struct CudaSqrtGradFunctor : public BaseActivationFunctor<T> {
-  T one_half = static_cast<T>(0.5f);
+  T two = static_cast<T>(2);
 
-  // dx = dout * 0.5 / out
+  // dx = dout / (2 * out)
   __device__ __forceinline__ T operator()(const T dout, const T out) const {
-    return one_half * dout / out;
+    return dout / (two * out);
   }
 
   static constexpr ActBwdOpFwdDeps FwdDeps() {
@@ -4413,7 +4413,7 @@ struct CudaRsqrtGradFunctor : public BaseActivationFunctor<T> {
                                           const T arg_out) const {
     MPType dout = static_cast<MPType>(arg_dout);
     MPType out = static_cast<MPType>(arg_out);
-    return static_cast<T>(minus_one_half * dout * out * out * out);
+    return static_cast<T>(minus_one_half * dout * (out * out * out));
   }
 
   static constexpr ActBwdOpFwdDeps FwdDeps() {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->


**简要改动总结**

1. **sqrt 反向**：由 `one_half * dout / out` 改为  `dout / (two * out)`。常量从 0.5 改为 2，等价重写但计算顺序不同，和 PyTorch 表达一致，可能带来更接近 PyTorch 的舍入结果（尤其在半精度/bfloat16）。

2. **rsqrt 反向**：公式不变`（-0.5 * dout * out^3）`，仅将连乘写成 `(out * out * out) `的分组形式，逻辑与之前相同。

**复测结果：**
paddle.sqrt  对齐全部case（共460个）
paddle.rqrt  对齐全部case（共130个）

pcard-67164