### PR TITLE
Add  paddle.base.core.set_vlog_level api 

### DIFF
--- a/paddle/fluid/eager/utils.cc
+++ b/paddle/fluid/eager/utils.cc
@@ -1235,15 +1235,18 @@ void SaveDebugInfo(std::string dir_path,
   if (serialized_forward_graph.empty() == false) {
     std::string forward_graph_file_path =
         file_path_prefix + "_ref_forward_graph" + ".dot";
+    VLOG(4) << "Save forward graph to file : " << forward_graph_file_path;
     SaveStringToFile(forward_graph_file_path, serialized_forward_graph);
   }
   if (call_stack.empty() == false) {
     std::string call_stack_file = file_path_prefix + "_call_stack" + ".log";
+    VLOG(4) << "Save call stack to file : " << call_stack_file;
     SaveStringToFile(call_stack_file, call_stack);
   }
   if (serialized_backward_graph.empty() == false) {
     std::string backward_graph_file_path =
         file_path_prefix + "_backward_graph" + ".dot";
+    VLOG(4) << "Save backward graph to file : " << backward_graph_file_path;
     SaveStringToFile(backward_graph_file_path, serialized_backward_graph);
   }
 }

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -25,6 +25,7 @@ limitations under the License. */
 #endif
 #include <Python.h>
 
+#include <glog/logging.h>
 #include <algorithm>
 #include <cctype>
 #include <cstdlib>
@@ -3196,6 +3197,44 @@ All parameter, weight, gradient are variables in Paddle.
             Scope *,
             const phi::DenseTensor &,
             const std::string &)>(&framework::SetVariable));
+  m.def(
+      "set_vlog_level",
+      [](const py::dict &module_levels) {
+        for (auto &item : module_levels) {
+          auto module_name = item.first.cast<std::string>();
+          auto level = item.second.cast<int>();
+          if (module_name == "*") {
+            // Do not using google::SetVLOGLevel("*", level);
+            // It may cause configuration effects for a single module
+            FLAGS_v = level;
+          } else {
+            google::SetVLOGLevel(module_name.c_str(), level);
+          }
+        }
+      },
+      py::arg("dict"),
+      R"DOC(
+    Set the verbosity logging level for specified modules.
+
+    This function allows setting the VLOG level for specific modules or for all modules ('*').
+    The VLOG level controls the verbosity of logging output, with higher levels producing more
+    detailed logs.
+
+    Parameters:
+      module_levels (dict): A dictionary where keys are module names (str) and values are the
+                          corresponding verbosity levels (int). If a key is '*', the verbosity
+                          level is set globally for all modules.
+
+    Example:
+        .. code-block:: python
+
+            >>> import paddle
+            >>> # case1: set GLOG_v=1
+            >>> paddle.base.core.set_vlog_level({"*": 1}).
+            >>> # case2: set GLOG_vmodule=dygraph_functions=4,nodes=5
+            >>> paddle.base.core.set_vlog_level({"dygraph_functions": 4, "nodes": 5})
+
+)DOC");
   m.def("set_feed_variable",
         static_cast<void (*)(  // NOLINT
             Scope *,

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -3235,7 +3235,7 @@ All parameter, weight, gradient are variables in Paddle.
       module_levels (dict|int): A dictionary where the keys are module names (str) and
                                 the values are the corresponding verbosity levels (int),
                                 or an int variable that represents the verbosity level set globally for all modules.
-‘
+
     Example:
         .. code-block:: python
 

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -3232,9 +3232,9 @@ All parameter, weight, gradient are variables in Paddle.
     detailed logs.
 
     Parameters:
-      module_levels (dict|int): A dictionary where keys are module names (str) and values are the
-                          corresponding verbosity levels (int), or an int variable that represents the verbosity
-                          level is set globally for all modules.
+      module_levels (dict|int): A dictionary where the keys are module names (str) and
+                                the values are the corresponding verbosity levels (int),
+                                or an int variable that represents the verbosity level set globally for all modules.
 ‘
     Example:
         .. code-block:: python

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -3199,39 +3199,52 @@ All parameter, weight, gradient are variables in Paddle.
             const std::string &)>(&framework::SetVariable));
   m.def(
       "set_vlog_level",
-      [](const py::dict &module_levels) {
-        for (auto &item : module_levels) {
-          auto module_name = item.first.cast<std::string>();
-          auto level = item.second.cast<int>();
-          if (module_name == "*") {
-            // Do not using google::SetVLOGLevel("*", level);
-            // It may cause configuration effects for a single module
-            FLAGS_v = level;
-          } else {
-            google::SetVLOGLevel(module_name.c_str(), level);
+      [](py::object module_levels) {
+        if (py::isinstance<py::int_>(module_levels)) {
+          auto level = module_levels.cast<int>();
+          // Do not using google::SetVLOGLevel("*", level);
+          // It may cause configuration effects for a single module
+          VLOG(3) << "Set the VLOG level of all modules to " << level;
+          FLAGS_v = level;
+        } else if (py::isinstance<py::dict>(module_levels)) {
+          auto module_levels_dict = module_levels.cast<py::dict>();
+          for (auto &item : module_levels_dict) {
+            auto module_name = item.first.cast<std::string>();
+            auto level = item.second.cast<int>();
+            if (module_name == "*") {
+              VLOG(3) << "Set the VLOG level of all modules to " << level;
+              FLAGS_v = level;
+            } else {
+              google::SetVLOGLevel(module_name.c_str(), level);
+            }
           }
+        } else {
+          PADDLE_THROW(common::errors::InvalidArgument(
+              "The parameters of set_vlog_level must be int or dict! "));
         }
       },
-      py::arg("dict"),
+      py::arg("obj"),
       R"DOC(
     Set the verbosity logging level for specified modules.
 
-    This function allows setting the VLOG level for specific modules or for all modules ('*').
+    This function allows setting the VLOG level for specific modules or for all modules.
     The VLOG level controls the verbosity of logging output, with higher levels producing more
     detailed logs.
 
     Parameters:
-      module_levels (dict): A dictionary where keys are module names (str) and values are the
-                          corresponding verbosity levels (int). If a key is '*', the verbosity
+      module_levels (dict|int): A dictionary where keys are module names (str) and values are the
+                          corresponding verbosity levels (int), or an int variable that represents the verbosity
                           level is set globally for all modules.
-
+‘
     Example:
         .. code-block:: python
 
             >>> import paddle
-            >>> # case1: set GLOG_v=1
-            >>> paddle.base.core.set_vlog_level({"*": 1}).
-            >>> # case2: set GLOG_vmodule=dygraph_functions=4,nodes=5
+            >>> # case1: Set GLOG_v=1
+            >>> paddle.base.core.set_vlog_level(1)
+            >>> # case2: Another way to set GLOG_v=1
+            >>> paddle.base.core.set_vlog_level({"*": 1})
+            >>> # case3: Set GLOG_vmodule=dygraph_functions=4,nodes=5
             >>> paddle.base.core.set_vlog_level({"dygraph_functions": 4, "nodes": 5})
 
 )DOC");

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -3223,7 +3223,7 @@ All parameter, weight, gradient are variables in Paddle.
               "The parameters of set_vlog_level must be int or dict! "));
         }
       },
-      py::arg("obj"),
+      py::arg("module_levels"),
       R"DOC(
     Set the verbosity logging level for specified modules.
 

--- a/python/paddle/autograd/backward_mode.py
+++ b/python/paddle/autograd/backward_mode.py
@@ -35,6 +35,7 @@ def backward(
     tensors: Tensor | Sequence[Tensor],
     grad_tensors: Tensor | Sequence[Tensor | None] | None = None,
     retain_graph: bool = False,
+    *,
     dump_backward_graph_path: str | None = None,
 ) -> None:
     """

--- a/python/paddle/base/dygraph/base.py
+++ b/python/paddle/base/dygraph/base.py
@@ -682,6 +682,7 @@ def grad(
     only_inputs: bool = True,
     allow_unused: bool = False,
     no_grad_vars: Tensor | Sequence[Tensor] | set[Tensor] | None = None,
+    *,
     dump_backward_graph_path: str | None = None,
 ) -> list[Tensor]:
     '''

--- a/python/paddle/base/dygraph/tensor_patch_methods.py
+++ b/python/paddle/base/dygraph/tensor_patch_methods.py
@@ -286,6 +286,7 @@ def monkey_patch_tensor():
         self: Tensor,
         grad_tensor: Tensor | None = None,
         retain_graph: bool = False,
+        *,
         dump_backward_graph_path: str | None = None,
     ) -> None:
         """

--- a/test/legacy_test/test_backward_dump_debug_info.py
+++ b/test/legacy_test/test_backward_dump_debug_info.py
@@ -121,6 +121,7 @@ grads = paddle.autograd.backward(
     [x, y],
     [None, None],
 )
+paddle.base.core.set_vlog_level(4)
         """
         process = subprocess.run(
             [sys.executable, '-c', code.format(glog_level=4)],
@@ -241,6 +242,12 @@ loss.backward(dump_backward_graph_path="./backward")
             "Create '/path/to/create' failed : Mocked exception"
             in str(context.exception)
         )
+
+
+class TestSetVlogLevelError(unittest.TestCase):
+    def test_input_invalid(self):
+        with self.assertRaises(ValueError):
+            paddle.base.core.set_vlog_level("3")
 
 
 if __name__ == "__main__":

--- a/test/legacy_test/test_backward_dump_debug_info.py
+++ b/test/legacy_test/test_backward_dump_debug_info.py
@@ -154,6 +154,7 @@ import paddle
 import paddle.nn.functional as F
 import paddle.nn as nn
 
+paddle.base.core.set_vlog_level({"backward":6, "*": 7})
 
 x = paddle.randn([3,3],dtype='float16')
 y = paddle.randn([3,3],dtype='float32')
@@ -186,6 +187,7 @@ if paddle.is_compiled_with_cuda():
     hidden1 = sync_batch_norm(sync_bn_input)
 loss = out1 + out2 + out3 + out4 + out5 + out6.sum()+hidden1.sum()
 loss.backward(dump_backward_graph_path="./backward")
+
 
     """
         process = subprocess.run(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
- 修改backward/grad 中``` dump_backward_graph_path ``` 为仅关键字参数
- 增加保存backward debug 文件时的提示信息
- 新增 ``` paddle.base.core.set_vlog_level  ``` API，支持在运行时设置不同module或者全局的VLOG等级。
### API介绍：
```
   Set the verbosity logging level for specified modules.

    This function allows setting the VLOG level for specific modules or for all modules.
    The VLOG level controls the verbosity of logging output, with higher levels producing more
    detailed logs.

    Parameters:
      module_levels (dict|int): A dictionary where the keys are module names (str) and
                                the values are the corresponding verbosity levels (int),
                                or an int variable that represents the verbosity level set globally for all modules.

    Example:
        .. code-block:: python

            >>> import paddle
            >>> # case1: Set GLOG_v=1
            >>> paddle.base.core.set_vlog_level(1)
            >>> # case2: Another way to set GLOG_v=1
            >>> paddle.base.core.set_vlog_level({"*": 1})
            >>> # case3: Set GLOG_vmodule=dygraph_functions=4,nodes=5
            >>> paddle.base.core.set_vlog_level({"dygraph_functions": 4, "nodes": 5})


```

pcard-67164
