### PR TITLE
[CMake4] Add `CMAKE_POLICY_VERSION_MINIMUM=3.5` to some third_party

### DIFF
--- a/cmake/external/arm_brpc.cmake
+++ b/cmake/external/arm_brpc.cmake
@@ -59,7 +59,7 @@ file(
 
 file(
   WRITE ${ARM_BRPC_DOWNLOAD_DIR}/CMakeLists.txt
-  "PROJECT(ARM_BRPC)\n" "cmake_minimum_required(VERSION 3.0)\n"
+  "PROJECT(ARM_BRPC)\n" "cmake_minimum_required(VERSION 3.5)\n"
   "install(DIRECTORY ${ARM_BRPC_DST_DIR} ${ARM_BRPC_DST_DIR} \n"
   "        DESTINATION ${ARM_BRPC_NAME})\n")
 

--- a/cmake/external/box_ps.cmake
+++ b/cmake/external/box_ps.cmake
@@ -52,7 +52,7 @@ file(
 
 file(
   WRITE ${BOX_PS_DOWNLOAD_DIR}/CMakeLists.txt
-  "PROJECT(BOX_PS)\n" "cmake_minimum_required(VERSION 3.0)\n"
+  "PROJECT(BOX_PS)\n" "cmake_minimum_required(VERSION 3.5)\n"
   "install(DIRECTORY ./include ./lib \n"
   "        DESTINATION ${BOX_PS_DST_DIR})\n")
 ExternalProject_Add(

--- a/cmake/external/gtest.cmake
+++ b/cmake/external/gtest.cmake
@@ -31,6 +31,16 @@ set(GTEST_TAG release-1.8.1)
 set(GTEST_SOURCE_DIR ${THIRD_PARTY_PATH}/gtest/src/extern_gtest)
 include_directories(${GTEST_INCLUDE_DIR})
 
+# For CMake >= 4.0.0, set policy compatibility for gtest's CMake.
+set(GTEST_POLICY_ARGS "")
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.0.0")
+  message(
+    WARNING
+      "gtest: forcing CMake policy compatibility for CMake >= 4.0 (CMAKE_POLICY_VERSION_MINIMUM=3.5)"
+  )
+  set(GTEST_POLICY_ARGS -DCMAKE_POLICY_VERSION_MINIMUM=3.5)
+endif()
+
 if(WIN32)
   set(GTEST_LIBRARIES
       "${GTEST_INSTALL_DIR}/${CMAKE_INSTALL_LIBDIR}/gtest.lib"
@@ -100,6 +110,7 @@ if(WIN32)
                -Dgtest_disable_pthreads=ON
                -Dgtest_force_shared_crt=ON
                -DCMAKE_BUILD_TYPE=${THIRD_PARTY_BUILD_TYPE}
+               ${GTEST_POLICY_ARGS}
                ${EXTERNAL_OPTIONAL_ARGS}
     CMAKE_CACHE_ARGS
       -DCMAKE_INSTALL_PREFIX:PATH=${GTEST_INSTALL_DIR}
@@ -132,6 +143,7 @@ else()
                -Dgtest_disable_pthreads=ON
                -Dgtest_force_shared_crt=ON
                -DCMAKE_BUILD_TYPE=${THIRD_PARTY_BUILD_TYPE}
+               ${GTEST_POLICY_ARGS}
                ${EXTERNAL_OPTIONAL_ARGS}
     CMAKE_CACHE_ARGS
       -DCMAKE_INSTALL_PREFIX:PATH=${GTEST_INSTALL_DIR}

--- a/cmake/external/libmct.cmake
+++ b/cmake/external/libmct.cmake
@@ -78,7 +78,7 @@ endif()
 
 file(
   WRITE ${LIBMCT_DOWNLOAD_DIR}/CMakeLists.txt
-  "PROJECT(LIBMCT)\n" "cmake_minimum_required(VERSION 3.0)\n"
+  "PROJECT(LIBMCT)\n" "cmake_minimum_required(VERSION 3.5)\n"
   "install(DIRECTORY ./include ./lib \n"
   "        DESTINATION ${LIBMCT_DST_DIR})\n")
 

--- a/cmake/external/openblas.cmake
+++ b/cmake/external/openblas.cmake
@@ -39,7 +39,8 @@ if(WITH_LOONGARCH)
 endif()
 
 # For CMake >= 4.0.0, set policy compatibility for OpenBLAS's CMake.
-if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.0.0")
+# Only for Windows builds that use CMAKE_ARGS
+if(WIN32 AND CMAKE_VERSION VERSION_GREATER_EQUAL "4.0.0")
   message(
     WARNING
       "OpenBLAS: forcing CMake policy compatibility for CMake >= 4.0 (CMAKE_POLICY_VERSION_MINIMUM=3.5)"

--- a/cmake/external/openblas.cmake
+++ b/cmake/external/openblas.cmake
@@ -38,6 +38,15 @@ if(WITH_LOONGARCH)
   set(CBLAS_TAG v0.3.18)
 endif()
 
+# For CMake >= 4.0.0, set policy compatibility for OpenBLAS's CMake.
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.0.0")
+  message(
+    WARNING
+      "OpenBLAS: forcing CMake policy compatibility for CMake >= 4.0 (CMAKE_POLICY_VERSION_MINIMUM=3.5)"
+  )
+  set(OPENBLAS_POLICY_ARGS -DCMAKE_POLICY_VERSION_MINIMUM=3.5)
+endif()
+
 file(GLOB CBLAS_SOURCE_FILE_LIST ${CBLAS_SOURCE_DIR})
 list(LENGTH CBLAS_SOURCE_FILE_LIST RES_LEN)
 if(RES_LEN EQUAL 0)
@@ -117,6 +126,7 @@ else()
                -DBUILD_SHARED_LIBS=ON
                -DCMAKE_VERBOSE_MAKEFILE=OFF
                -DMSVC_STATIC_CRT=${MSVC_STATIC_CRT}
+               ${OPENBLAS_POLICY_ARGS}
                ${EXTERNAL_OPTIONAL_ARGS}
     CMAKE_CACHE_ARGS
       -DCMAKE_INSTALL_PREFIX:PATH=${CBLAS_INSTALL_DIR}

--- a/cmake/external/pslib_brpc.cmake
+++ b/cmake/external/pslib_brpc.cmake
@@ -47,7 +47,7 @@ include_directories(${PSLIB_BRPC_INC_DIR})
 
 file(
   WRITE ${PSLIB_BRPC_DOWNLOAD_DIR}/CMakeLists.txt
-  "PROJECT(PSLIB_BRPC)\n" "cmake_minimum_required(VERSION 3.0)\n"
+  "PROJECT(PSLIB_BRPC)\n" "cmake_minimum_required(VERSION 3.5)\n"
   "install(DIRECTORY ${PSLIB_BRPC_NAME}/include ${PSLIB_BRPC_NAME}/lib \n"
   "        DESTINATION ${PSLIB_BRPC_DST_DIR})\n")
 

--- a/cmake/external/xpu.cmake
+++ b/cmake/external/xpu.cmake
@@ -190,7 +190,7 @@ set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_RPATH}" "${XPU_INSTALL_DIR}/lib")
 
 file(
   WRITE ${XPU_DOWNLOAD_DIR}/CMakeLists.txt
-  "PROJECT(XPU)\n" "cmake_minimum_required(VERSION 3.0)\n"
+  "PROJECT(XPU)\n" "cmake_minimum_required(VERSION 3.5)\n"
   "install(DIRECTORY xpu/include xpu/lib \n"
   "        DESTINATION ${XPU_INSTALL_DIR})\n")
 

--- a/cmake/external/xxhash.cmake
+++ b/cmake/external/xxhash.cmake
@@ -21,6 +21,16 @@ set(XXHASH_INCLUDE_DIR "${XXHASH_INSTALL_DIR}/include")
 set(XXHASH_TAG v0.6.5)
 set(SOURCE_DIR ${PADDLE_SOURCE_DIR}/third_party/xxhash)
 
+# For CMake >= 4.0.0, set policy compatibility for xxhash's CMake.
+# Only for Windows builds that use CMAKE_ARGS
+if(WIN32 AND CMAKE_VERSION VERSION_GREATER_EQUAL "4.0.0")
+  message(
+    WARNING
+      "xxhash: forcing CMake policy compatibility for CMake >= 4.0 (CMAKE_POLICY_VERSION_MINIMUM=3.5)"
+  )
+  set(XXHASH_POLICY_ARGS -DCMAKE_POLICY_VERSION_MINIMUM=3.5)
+endif()
+
 include_directories(${XXHASH_INCLUDE_DIR})
 
 if(APPLE)
@@ -75,7 +85,8 @@ if(WIN32)
       -DCMAKE_CXX_FLAGS_DEBUG=${CMAKE_CXX_FLAGS_DEBUG}
       -DCMAKE_C_FLAGS=${XXHASH_CMAKE_C_FLAGS}
       -DCMAKE_C_FLAGS_DEBUG=${CMAKE_C_FLAGS_DEBUG}
-      -DCMAKE_C_FLAGS_RELEASE=${CMAKE_C_FLAGS_RELEASE} ${OPTIONAL_CACHE_ARGS}
+      -DCMAKE_C_FLAGS_RELEASE=${CMAKE_C_FLAGS_RELEASE} ${XXHASH_POLICY_ARGS}
+      ${OPTIONAL_CACHE_ARGS}
     TEST_COMMAND ""
     BUILD_BYPRODUCTS ${XXHASH_LIBRARIES})
 else()

--- a/cmake/generic.cmake
+++ b/cmake/generic.cmake
@@ -292,8 +292,7 @@ function(merge_static_libs TARGET_NAME)
       POST_BUILD
       COMMENT "Merge and generate static lib: lib${TARGET_NAME}.a"
       COMMAND ${CMAKE_AR} -M < ${mri_file}
-      COMMAND ${CMAKE_RANLIB} "$<TARGET_FILE:${TARGET_NAME}>" DEPENDS
-              ${mri_file}
+      COMMAND ${CMAKE_RANLIB} "$<TARGET_FILE:${TARGET_NAME}>"
       VERBATIM)
   endif()
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Add CMAKE_POLICY_VERSION_MINIMUM=3.5 to some third_party