### PR TITLE
[Bug] 修复Log算子复数共轭操作导致梯度测试失败

### DIFF
--- a/paddle/phi/infermeta/spmd_rules/spmd_rule_macro_define.h
+++ b/paddle/phi/infermeta/spmd_rules/spmd_rule_macro_define.h
@@ -16,10 +16,13 @@ limitations under the License. */
 
 using phi::distributed::auto_parallel::str_join;
 
+#define EXTRACT_SHAPE_AND_DIST_ATTR_BASE(x)  \
+  auto x##_shape = phi::vectorize(x.dims()); \
+  int x##_ndim = x##_shape.size();           \
+  const auto& x##_dist_attr_src = x.dist_attr();
+
 #define EXTRACT_SHAPE_AND_DIST_ATTR(x)                                 \
-  auto x##_shape = phi::vectorize(x.dims());                           \
-  int x##_ndim = x##_shape.size();                                     \
-  const auto& x##_dist_attr_src = x.dist_attr();                       \
+  EXTRACT_SHAPE_AND_DIST_ATTR_BASE(x)                                  \
   const auto& x##_dims_mapping_src = x##_dist_attr_src.dims_mapping(); \
   PADDLE_ENFORCE_EQ(x##_ndim,                                          \
                     x##_dims_mapping_src.size(),                       \
@@ -30,6 +33,20 @@ using phi::distributed::auto_parallel::str_join;
                         __LINE__,                                      \
                         #x,                                            \
                         x##_ndim,                                      \
+                        x##_dims_mapping_src.size()))
+
+#define EXTRACT_SHAPE_AND_DIST_ATTR_CO_SHARD(x)                              \
+  EXTRACT_SHAPE_AND_DIST_ATTR_BASE(x)                                        \
+  const auto& x##_dims_mapping_src = x##_dist_attr_src.multi_dims_mapping(); \
+  PADDLE_ENFORCE_EQ(x##_ndim,                                                \
+                    x##_dims_mapping_src.size(),                             \
+                    common::errors::InvalidArgument(                         \
+                        "[%d] [%d] The Tensor [%d]'s rank [%d] and "         \
+                        "dims_mapping size [%d] are not matched.",           \
+                        __FILE__,                                            \
+                        __LINE__,                                            \
+                        #x,                                                  \
+                        x##_ndim,                                            \
                         x##_dims_mapping_src.size()))
 
 #define EXTRACT_SHAPE_AND_DIST_ATTR_WITH_DIM_CK(x)                   \

--- a/paddle/phi/ops/yaml/backward.yaml
+++ b/paddle/phi/ops/yaml/backward.yaml
@@ -2046,7 +2046,6 @@
     param : [x, x]
   kernel :
     func : log_double_grad
-  composite : log_double_grad(x, grad_out, grad_x_grad, x_grad, grad_out_grad)
   inplace : (grad_x_grad -> grad_out_grad)
 
 - backward_op : log_grad
@@ -2060,7 +2059,6 @@
   kernel :
     func : log_grad
   backward : log_double_grad
-  composite : log_grad(x, out_grad, x_grad)
   inplace : (out_grad -> x_grad)
 
 - backward_op : log_loss_grad

--- a/test/auto_parallel/end_to_end/index_select_co_shard.py
+++ b/test/auto_parallel/end_to_end/index_select_co_shard.py
@@ -1,0 +1,334 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+import numpy as np
+
+import paddle
+import paddle.distributed as dist
+
+
+class IndexSelectTestCase:
+    def __init__(
+        self,
+        x_shape: list[int],
+        x_placements: list[dist.Placement],
+        index_shape: list[int],
+        index_placements: list[dist.Placement],
+        axis: int,
+        out_shape: list[int],
+        out_placements: list[dist.Placement],
+    ):
+        self.x_shape = x_shape
+        self.x_placements = x_placements
+        self.index_shape = index_shape
+        self.index_placements = index_placements
+        self.axis = axis
+        self.out_shape = out_shape
+        self.out_placements = out_placements
+
+
+class IndexSelectGradTestCase:
+    def __init__(
+        self,
+        x_shape: list[int],
+        x_placements: list[dist.Placement],
+        index_shape: list[int],
+        index_placements: list[dist.Placement],
+        axis: int,
+        out_grad_shape: list[int],
+        out_grad_placements: list[dist.Placement],
+        x_grad_placements: list[dist.Placement],
+    ):
+        self.x_shape = x_shape
+        self.x_placements = x_placements
+        self.index_shape = index_shape
+        self.index_placements = index_placements
+        self.axis = axis
+        self.out_grad_shape = out_grad_shape
+        self.out_grad_placements = out_grad_placements
+        self.x_grad_placements = x_grad_placements
+
+
+class TestIndexSelectCoShard:
+    def setUp(self):
+        self.mesh = dist.ProcessMesh(
+            [[[0, 1], [2, 3]], [[4, 5], [6, 7]]], dim_names=['x', 'y', 'z']
+        )
+        self.test_cases_forward = [
+            IndexSelectTestCase(
+                [8, 16, 32],
+                [
+                    dist.Shard(0, shard_order=0),
+                    dist.Shard(0, shard_order=1),
+                    dist.Shard(1),
+                ],
+                [8],
+                [dist.Replicate(), dist.Replicate(), dist.Replicate()],
+                1,
+                [8, 8, 32],
+                [
+                    dist.Shard(0, shard_order=0),
+                    dist.Shard(0, shard_order=1),
+                    dist.Replicate(),
+                ],
+            ),
+            IndexSelectTestCase(
+                [8, 16, 32],
+                [
+                    dist.Shard(0, shard_order=0),
+                    dist.Shard(0, shard_order=1),
+                    dist.Shard(1),
+                ],
+                [8],
+                [dist.Replicate(), dist.Replicate(), dist.Shard(0)],
+                1,
+                [8, 8, 32],
+                [
+                    dist.Shard(0, shard_order=0),
+                    dist.Shard(0, shard_order=1),
+                    dist.Shard(1),
+                ],
+            ),
+            IndexSelectTestCase(
+                [8, 16, 32],
+                [
+                    dist.Shard(0, shard_order=0),
+                    dist.Shard(0, shard_order=1),
+                    dist.Shard(1),
+                ],
+                [8],
+                [dist.Shard(0), dist.Replicate(), dist.Replicate()],
+                1,
+                [8, 8, 32],
+                [
+                    dist.Shard(0, shard_order=0),
+                    dist.Shard(0, shard_order=1),
+                    dist.Replicate(),
+                ],
+            ),
+            IndexSelectTestCase(
+                [8, 16, 32],
+                [dist.Replicate(), dist.Replicate(), dist.Shard(0)],
+                [8],
+                [
+                    dist.Shard(0, shard_order=0),
+                    dist.Shard(0, shard_order=1),
+                    dist.Replicate(),
+                ],
+                1,
+                [8, 8, 32],
+                [
+                    dist.Shard(1, shard_order=0),
+                    dist.Shard(1, shard_order=1),
+                    dist.Shard(0),
+                ],
+            ),
+            IndexSelectTestCase(
+                [8, 16, 32],
+                [dist.Shard(0), dist.Replicate(), dist.Replicate()],
+                [8],
+                [
+                    dist.Shard(0, shard_order=0),
+                    dist.Shard(0, shard_order=1),
+                    dist.Replicate(),
+                ],
+                1,
+                [8, 8, 32],
+                [dist.Shard(0), dist.Shard(1), dist.Replicate()],
+            ),
+        ]
+        self.test_cases_backward = [
+            IndexSelectGradTestCase(
+                [8, 16, 32],
+                [
+                    dist.Shard(0, shard_order=0),
+                    dist.Shard(0, shard_order=1),
+                    dist.Shard(1),
+                ],
+                [8],
+                [dist.Replicate(), dist.Replicate(), dist.Replicate()],
+                1,
+                [8, 8, 32],
+                [
+                    dist.Shard(0, shard_order=0),
+                    dist.Shard(0, shard_order=1),
+                    dist.Replicate(),
+                ],
+                [
+                    dist.Shard(0, shard_order=0),
+                    dist.Shard(0, shard_order=1),
+                    dist.Replicate(),
+                ],
+            ),
+            IndexSelectGradTestCase(
+                [8, 16, 32],
+                [
+                    dist.Shard(0, shard_order=0),
+                    dist.Shard(0, shard_order=1),
+                    dist.Shard(1),
+                ],
+                [8],
+                [dist.Replicate(), dist.Replicate(), dist.Shard(0)],
+                1,
+                [8, 8, 32],
+                [
+                    dist.Shard(0, shard_order=0),
+                    dist.Shard(0, shard_order=1),
+                    dist.Shard(1),
+                ],
+                [
+                    dist.Shard(0, shard_order=0),
+                    dist.Shard(0, shard_order=1),
+                    dist.Partial(),
+                ],
+            ),
+            IndexSelectGradTestCase(
+                [8, 16, 32],
+                [
+                    dist.Shard(0, shard_order=0),
+                    dist.Shard(0, shard_order=1),
+                    dist.Shard(1),
+                ],
+                [8],
+                [dist.Shard(0), dist.Replicate(), dist.Replicate()],
+                1,
+                [8, 8, 32],
+                [
+                    dist.Shard(0, shard_order=0),
+                    dist.Shard(0, shard_order=1),
+                    dist.Replicate(),
+                ],
+                [
+                    dist.Shard(0, shard_order=0),
+                    dist.Shard(0, shard_order=1),
+                    dist.Replicate(),
+                ],
+            ),
+            IndexSelectGradTestCase(
+                [8, 16, 32],
+                [dist.Replicate(), dist.Replicate(), dist.Shard(0)],
+                [8],
+                [
+                    dist.Shard(0, shard_order=0),
+                    dist.Shard(0, shard_order=1),
+                    dist.Replicate(),
+                ],
+                1,
+                [8, 8, 32],
+                [
+                    dist.Shard(1, shard_order=0),
+                    dist.Shard(1, shard_order=1),
+                    dist.Shard(0),
+                ],
+                [dist.Partial(), dist.Partial(), dist.Shard(0)],
+            ),
+            IndexSelectGradTestCase(
+                [8, 16, 32],
+                [dist.Shard(0), dist.Replicate(), dist.Replicate()],
+                [8],
+                [
+                    dist.Shard(0, shard_order=0),
+                    dist.Shard(0, shard_order=1),
+                    dist.Replicate(),
+                ],
+                1,
+                [8, 8, 32],
+                [dist.Shard(0), dist.Shard(1), dist.Replicate()],
+                [dist.Shard(0), dist.Partial(), dist.Replicate()],
+            ),
+        ]
+
+    def run_test_case_forward(self, test_case: IndexSelectTestCase):
+        x = paddle.rand(test_case.x_shape, "float32")
+        x_placements = test_case.x_placements
+        x = dist.shard_tensor(x, self.mesh, x_placements)
+        index = paddle.randint(
+            0,
+            test_case.x_shape[test_case.axis],
+            test_case.index_shape,
+            dtype="int32",
+        )
+        index_placements = test_case.index_placements
+        index = dist.shard_tensor(index, self.mesh, index_placements)
+
+        out = paddle.index_select(x, index, test_case.axis)
+        case_info = f"x_shape: {test_case.x_shape}, x_placements: {x_placements}, index_shape: {test_case.index_shape}, index_placements: {index_placements}, axis: {test_case.axis}"
+        # Verify output shape
+        np.testing.assert_equal(
+            out.shape,
+            test_case.out_shape,
+            err_msg=f"Output shape mismatch when {case_info}. Expected: {test_case.out_shape}, Actual: {out.shape}",
+        )
+
+        # Verify placements
+        assert out.placements
+        for actual, expected in zip(out.placements, test_case.out_placements):
+            np.testing.assert_equal(
+                actual,
+                expected,
+                err_msg=f"Output placements mismatch when {case_info}. Expected: {test_case.out_placements}, Actual: {out.placements}",
+            )
+
+    def run_test_case_backward(self, test_case: IndexSelectGradTestCase):
+        x = paddle.rand(test_case.x_shape, "float32")
+        x.stop_gradient = False
+        x_placements = test_case.x_placements
+        x = dist.shard_tensor(x, self.mesh, x_placements)
+
+        index = paddle.randint(
+            0,
+            test_case.x_shape[test_case.axis],
+            test_case.index_shape,
+            dtype="int32",
+        )
+        index_placements = test_case.index_placements
+        index = dist.shard_tensor(index, self.mesh, index_placements)
+
+        out = paddle.index_select(x, index, test_case.axis)
+
+        out_grad = paddle.ones(out.shape, "float32")
+        out_grad = dist.shard_tensor(
+            out_grad, self.mesh, test_case.out_grad_placements
+        )
+
+        (x_grad,) = paddle.grad([out], x, [out_grad])
+
+        case_info = f"x_shape: {test_case.x_shape}, x_placements: {test_case.x_placements}, index_shape: {test_case.index_shape}, index_placements: {test_case.index_placements}, axis: {test_case.axis}, out_grad_shape: {test_case.out_grad_shape}, out_grad_placements: {test_case.out_grad_placements}"
+        # Verify output shape
+        np.testing.assert_equal(
+            x_grad.shape,
+            test_case.x_shape,
+            err_msg=f"Output shape mismatch when {case_info}. Expected: {test_case.x_shape}, Actual: {x_grad.shape}",
+        )
+
+        # Verify placements
+        assert x_grad.placements
+        for actual, expected in zip(
+            x_grad.placements, test_case.x_grad_placements
+        ):
+            np.testing.assert_equal(
+                actual,
+                expected,
+                err_msg=f"Output placements mismatch when {case_info}. Expected: {test_case.x_grad_placements}, Actual: {x_grad.placements}",
+            )
+
+    def run_all_tests(self):
+        self.setUp()
+        for test_case in self.test_cases_forward:
+            self.run_test_case_forward(test_case)
+
+
+if __name__ == '__main__':
+    TestIndexSelectCoShard().run_all_tests()

--- a/test/auto_parallel/end_to_end/test_e2e_co_shard_8cards.py
+++ b/test/auto_parallel/end_to_end/test_e2e_co_shard_8cards.py
@@ -21,6 +21,9 @@ class TestReshardE2E(test_base.CommunicationTestDistBase):
     def setUp(self):
         super().setUp(num_of_devices=8, timeout=120, nnode=1)
 
+    def test_index_select_shard(self):
+        self.run_test_case("index_select_co_shard.py")
+
     def test_softmax_shard(self):
         self.run_test_case("softmax_co_shard.py")
 

--- a/test/cpp/auto_parallel/CMakeLists.txt
+++ b/test/cpp/auto_parallel/CMakeLists.txt
@@ -64,6 +64,10 @@ if(WITH_DISTRIBUTE)
   paddle_test(softmax_co_shard_spmd_rule_test SRCS
               softmax_co_shard_spmd_rule_test.cc DEPS spmd_rule_test_util phi)
 
+  paddle_test(
+    index_select_co_shard_spmd_rule_test SRCS
+    index_select_co_shard_spmd_rule_test.cc DEPS spmd_rule_test_util phi)
+
   paddle_test(reshape_co_shard_spmd_rule_test SRCS
               reshape_co_shard_spmd_rule_test.cc DEPS spmd_rule_test_util phi)
 

--- a/test/cpp/auto_parallel/index_select_co_shard_spmd_rule_test.cc
+++ b/test/cpp/auto_parallel/index_select_co_shard_spmd_rule_test.cc
@@ -1,0 +1,286 @@
+/* Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include <set>
+#include "test/cpp/auto_parallel/spmd_rule_test_util.h"
+
+namespace paddle {
+namespace distributed {
+namespace auto_parallel {
+
+struct IndexSelectTestCase {
+  // input
+  std::vector<int64_t> x_shape;
+  std::vector<std::vector<int64_t>> x_dims_mapping;
+  std::vector<int64_t> index_shape;
+  std::vector<std::vector<int64_t>> index_dims_mapping;
+
+  // axis attribute
+  int axis;
+
+  // output
+  std::vector<std::vector<int64_t>> expected_x_dims_mapping;
+  std::vector<std::vector<int64_t>> expected_index_dims_mapping;
+  std::vector<std::vector<int64_t>> expected_out_dims_mapping;
+};
+
+struct IndexSelectGradTestCase {
+  // input
+  std::vector<int64_t> x_shape;
+  std::vector<std::vector<int64_t>> x_dims_mapping;
+  std::vector<int64_t> index_shape;
+  std::vector<std::vector<int64_t>> index_dims_mapping;
+  std::vector<int64_t> out_grad_shape;
+  std::vector<std::vector<int64_t>> out_grad_dims_mapping;
+
+  // axis attribute
+  int axis;
+
+  // output
+  std::vector<std::vector<int64_t>> expected_x_dims_mapping;
+  std::vector<std::vector<int64_t>> expected_index_dims_mapping;
+  std::vector<std::vector<int64_t>> expected_out_grad_dims_mapping;
+
+  std::vector<std::vector<int64_t>> expected_x_grad_dims_mapping;
+  std::set<int64_t> partial_dims;
+};
+
+TEST(IndexSelectInferSpmd, Ctor) {
+  std::vector<int64_t> mesh_shape = {2, 2, 2};
+  std::vector<int64_t> process_ids = {0, 1, 2, 3, 4, 5, 6, 7};
+  std::vector<std::string> dim_names = {"x", "y", "z"};
+  ProcessMesh process_mesh(mesh_shape, process_ids, dim_names);
+
+  std::vector<IndexSelectTestCase> test_cases = {
+      // [8, 16, 32], [8], axis = 1
+      // [[0,1],[2],[]], [[]] -> [[0,1],[],[]], [[]], [[0,1],[],[]]
+      {{8, 16, 32},
+       {{0, 1}, {2}, {}},
+       {8},
+       {{}},
+       1,
+       {{0, 1}, {}, {}},
+       {{}},
+       {{0, 1}, {}, {}}},
+
+      // [8, 16, 32], [8], axis = 1
+      // [[0,1],[2],[]], [[2]] -> [[0,1],[],[]], [[2]], [[0,1],[2],[]]
+      {{8, 16, 32},
+       {{0, 1}, {2}, {}},
+       {8},
+       {{2}},
+       1,
+       {{0, 1}, {}, {}},
+       {{2}},
+       {{0, 1}, {2}, {}}},
+
+      // [8, 16, 32], [8], axis = 1
+      // [[0,1],[2],[]], [[0]] -> [[0,1],[],[]], [[]], [[0,1],[],[]]
+      {{8, 16, 32},
+       {{0, 1}, {2}, {}},
+       {8},
+       {{0}},
+       1,
+       {{0, 1}, {}, {}},
+       {{}},
+       {{0, 1}, {}, {}}},
+
+      // [8, 16, 32], [8], axis = 1
+      // [[2],[],[]], [[0,1]] -> [[2],[],[]], [[0,1]], [[2],[0,1],[]]
+      {{8, 16, 32},
+       {{2}, {}, {}},
+       {8},
+       {{0, 1}},
+       1,
+       {{2}, {}, {}},
+       {{0, 1}},
+       {{2}, {0, 1}, {}}},
+
+      // [8, 16, 32], [8], axis = 1
+      // [[0],[],[]], [[0,1]] -> [[0],[],[]], [[1]], [[0],[1],[]]
+      {{8, 16, 32},
+       {{0}, {}, {}},
+       {8},
+       {{0, 1}},
+       1,
+       {{0}, {}, {}},
+       {{1}},
+       {{0}, {1}, {}}},
+  };
+
+  for (const auto& tc : test_cases) {
+    TensorDistAttr x_dist_attr = TensorDistAttr();
+    x_dist_attr.set_process_mesh(process_mesh);
+    x_dist_attr.set_dims_mapping(tc.x_dims_mapping);
+    x_dist_attr.set_dynamic_dims(std::vector<bool>(tc.x_shape.size(), false));
+    phi::distributed::DistMetaTensor x = phi::distributed::DistMetaTensor(
+        common::make_ddim(tc.x_shape), x_dist_attr);
+
+    TensorDistAttr index_dist_attr = TensorDistAttr();
+    index_dist_attr.set_process_mesh(process_mesh);
+    index_dist_attr.set_dims_mapping(tc.index_dims_mapping);
+    index_dist_attr.set_dynamic_dims(
+        std::vector<bool>(tc.index_shape.size(), false));
+    phi::distributed::DistMetaTensor index = phi::distributed::DistMetaTensor(
+        common::make_ddim(tc.index_shape), index_dist_attr);
+
+    // test forward
+    phi::distributed::SpmdInfo forward_spmd_info =
+        phi::distributed::IndexSelectInferSpmd(x, index, tc.axis);
+    EXPECT_EQ(forward_spmd_info.first.size(), static_cast<size_t>(2));
+    EXPECT_EQ(forward_spmd_info.second.size(), static_cast<size_t>(1));
+    check_multi_dims_mapping(forward_spmd_info.first[0],
+                             tc.expected_x_dims_mapping);
+    check_multi_dims_mapping(forward_spmd_info.first[1],
+                             tc.expected_index_dims_mapping);
+    check_multi_dims_mapping(forward_spmd_info.second[0],
+                             tc.expected_out_dims_mapping);
+  }
+}
+
+TEST(IndexSelectGradInferSpmd, Ctor) {
+  std::vector<int64_t> mesh_shape = {2, 2, 2};
+  std::vector<int64_t> process_ids = {0, 1, 2, 3, 4, 5, 6, 7};
+  std::vector<std::string> dim_names = {"x", "y", "z"};
+  ProcessMesh process_mesh(mesh_shape, process_ids, dim_names);
+
+  std::vector<IndexSelectGradTestCase> test_cases = {
+      // [8, 16, 32], [8], [8, 8, 32], axis = 1
+      // [[0,1],[2],[]], [[]], [[0,1], [], []] -> [[0,1],[],[]], [[]],
+      // [[0,1],[],[]], [[0,1],[],[]]
+      {{8, 16, 32},
+       {{0, 1}, {2}, {}},
+       {8},
+       {{}},
+       {8, 8, 32},
+       {{0, 1}, {2}, {}},
+       1,
+       {{0, 1}, {}, {}},
+       {{}},
+       {{0, 1}, {}, {}},
+       {{0, 1}, {}, {}},
+       {}},
+
+      // [8, 16, 32], [8], [8, 8, 32], axis = 1
+      // [[0,1],[2],[]], [[2]], [[0,1],[2],[]] -> [[0,1],[],[]], [[2]],
+      // [[0,1],[2],[]], [[0,1],[],[]]
+      {{8, 16, 32},
+       {{0, 1}, {2}, {}},
+       {8},
+       {{2}},
+       {8, 8, 32},
+       {{0, 1}, {2}, {}},
+       1,
+       {{0, 1}, {}, {}},
+       {{2}},
+       {{0, 1}, {2}, {}},
+       {{0, 1}, {}, {}},
+       {2}},
+
+      // [8, 16, 32], [8], [8, 8, 32], axis = 1
+      // [[0,1],[2],[]], [[0]], [[0,1],[],[]] -> [[0,1],[],[]], [[]],
+      // [[0,1],[],[]], [[0,1],[],[]]
+      {{8, 16, 32},
+       {{0, 1}, {2}, {}},
+       {8},
+       {{0}},
+       {8, 8, 32},
+       {{0, 1}, {}, {}},
+       1,
+       {{0, 1}, {}, {}},
+       {{}},
+       {{0, 1}, {}, {}},
+       {{0, 1}, {}, {}},
+       {}},
+
+      // [8, 16, 32], [8], [8, 8, 32], axis = 1
+      // [[2],[],[]], [[0,1]], [[2],[0,1],[]] -> [[2],[],[]], [[0,1]],
+      // [[2],[0,1],[]], [[2],[],[]]
+      {{8, 16, 32},
+       {{2}, {}, {}},
+       {8},
+       {{0, 1}},
+       {8, 8, 32},
+       {{2}, {0, 1}, {}},
+       1,
+       {{2}, {}, {}},
+       {{0, 1}},
+       {{2}, {0, 1}, {}},
+       {{2}, {}, {}},
+       {0, 1}},
+
+      // [8, 16, 32], [8], [8, 8, 32],  axis = 1
+      // [[0],[],[]], [[0,1]], [[0],[1],[]] -> [[0],[],[]], [[1]], [[0],[1],[]],
+      // [[0],[],[]]
+      {{8, 16, 32},
+       {{0}, {}, {}},
+       {8},
+       {{0, 1}},
+       {8, 8, 32},
+       {{0}, {1}, {}},
+       1,
+       {{0}, {}, {}},
+       {{1}},
+       {{0}, {1}, {}},
+       {{0}, {}, {}},
+       {1}},
+  };
+  for (const auto& tc : test_cases) {
+    TensorDistAttr x_dist_attr = TensorDistAttr();
+    x_dist_attr.set_process_mesh(process_mesh);
+    x_dist_attr.set_dims_mapping(tc.x_dims_mapping);
+    x_dist_attr.set_dynamic_dims(std::vector<bool>(tc.x_shape.size(), false));
+    phi::distributed::DistMetaTensor x = phi::distributed::DistMetaTensor(
+        common::make_ddim(tc.x_shape), x_dist_attr);
+
+    TensorDistAttr index_dist_attr = TensorDistAttr();
+    index_dist_attr.set_process_mesh(process_mesh);
+    index_dist_attr.set_dims_mapping(tc.index_dims_mapping);
+    index_dist_attr.set_dynamic_dims(
+        std::vector<bool>(tc.index_shape.size(), false));
+    phi::distributed::DistMetaTensor index = phi::distributed::DistMetaTensor(
+        common::make_ddim(tc.index_shape), index_dist_attr);
+
+    TensorDistAttr out_grad_dist_attr = TensorDistAttr();
+    out_grad_dist_attr.set_process_mesh(process_mesh);
+    out_grad_dist_attr.set_dims_mapping(tc.out_grad_dims_mapping);
+    out_grad_dist_attr.set_dynamic_dims(
+        std::vector<bool>(tc.out_grad_shape.size(), false));
+    phi::distributed::DistMetaTensor out_grad =
+        phi::distributed::DistMetaTensor(common::make_ddim(tc.out_grad_shape),
+                                         out_grad_dist_attr);
+
+    // test backward
+    phi::distributed::SpmdInfo backward_spmd_info =
+        phi::distributed::IndexSelectGradInferSpmd(x, index, out_grad, tc.axis);
+    EXPECT_EQ(backward_spmd_info.first.size(), static_cast<size_t>(3));
+    EXPECT_EQ(backward_spmd_info.second.size(), static_cast<size_t>(1));
+    check_multi_dims_mapping(backward_spmd_info.first[0],
+                             tc.expected_x_dims_mapping);
+    check_multi_dims_mapping(backward_spmd_info.first[1],
+                             tc.expected_index_dims_mapping);
+    check_multi_dims_mapping(backward_spmd_info.first[2],
+                             tc.expected_out_grad_dims_mapping);
+    check_multi_dims_mapping(backward_spmd_info.second[0],
+                             tc.expected_x_grad_dims_mapping);
+    if (!tc.partial_dims.empty()) {
+      EXPECT_EQ(is_partial(backward_spmd_info.second[0]), true);
+      check_partial_dims(backward_spmd_info.second[0], tc.partial_dims);
+    }
+  }
+}
+
+}  // namespace auto_parallel
+}  // namespace distributed
+}  // namespace paddle


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description

修复了 `LogGradGradFunctor<ComplexType<T>>` 中复数共轭操作缺失导致的二阶梯度测试失败问题。

**问题描述：**
在运行 `test_activation_op.TestLog_Complex128.test_grad_grad` 时，二阶梯度检查失败，实际结果与期望值在实部完全一致，但虚部符号相反。

**根本原因：**
当前内核实现中，`Conj<T>` functor 在 `Eigen::Tensor` 场景下没有正确执行复共轭操作，导致结果实际上等价于 `-1 / (x^2)`，而不是期望的 `conj(-1 / (x^2))`。

**修复方案：**
- 将 `unaryExpr(Conj<T>())` 应用到整个表达式上，而不是只应用到部分项
- 确保正确计算 `conj(-1/x^2)` 而不是 `-1/conj(x^2)`
- 修复了虚部符号相反的问题

**相关Issue：**
[#75393](https://github.com/PaddlePaddle/Paddle/issues/75393)

**修改文件：**
- `paddle/phi/kernels/funcs/activation_functor.h`