### PR TITLE
[Auto Parallel] Add co_shard spmd_rule for elementwise_binary ops and layernorm.

### DIFF
--- a/paddle/phi/infermeta/spmd_rules/elementwise.cc
+++ b/paddle/phi/infermeta/spmd_rules/elementwise.cc
@@ -252,8 +252,10 @@ SpmdInfo ElementwiseBinaryInferSpmd(const DistMetaTensor& x,
   int y_ndim = static_cast<int>(y_shape.size());
   TensorDistAttr x_dist_attr_src = x.dist_attr();
   TensorDistAttr y_dist_attr_src = y.dist_attr();
-  std::vector<int64_t> x_dims_mapping = x_dist_attr_src.dims_mapping();
-  std::vector<int64_t> y_dims_mapping = y_dist_attr_src.dims_mapping();
+  std::vector<std::vector<int64_t>> x_dims_mapping =
+      x_dist_attr_src.multi_dims_mapping();
+  std::vector<std::vector<int64_t>> y_dims_mapping =
+      y_dist_attr_src.multi_dims_mapping();
   PADDLE_ENFORCE_EQ(x_ndim,
                     x_dims_mapping.size(),
                     common::errors::InvalidArgument(
@@ -275,12 +277,17 @@ SpmdInfo ElementwiseBinaryInferSpmd(const DistMetaTensor& x,
 
   // Step2: Sharding Propagation
   // Step2.1: Merge input shardings
-  std::unordered_map<std::string, int64_t> axis_to_dim_map =
-      ShardingMergeForTensors(
-          {{x_axes, x_dims_mapping}, {y_axes, y_dims_mapping}});
+  const auto& axes_size =
+      GetAxesSizes({{x_axes, x_shape}, {y_axes, y_shape}}, true);
+  const auto& mesh_shape = x.dist_attr().process_mesh().shape();
+  std::unordered_map<std::string, std::vector<int64_t>> axis_to_dim_map =
+      ShardingMergeForTensorsElementWise(
+          {{x_axes, x_dims_mapping}, {y_axes, y_dims_mapping}},
+          axes_size,
+          mesh_shape);
 
   // Step2.2: Infer output dims mapping from merged input dims mapping
-  std::vector<int64_t> out_dims_mapping =
+  std::vector<std::vector<int64_t>> out_dims_mapping =
       GetDimsMappingForAxes(out_axes, axis_to_dim_map);
 
   // initialize output dist_attr's process_mesh, batch_dim and dynamic dims with
@@ -301,12 +308,12 @@ SpmdInfo ElementwiseBinaryInferSpmd(const DistMetaTensor& x,
   VLOG(4) << "ElementwiseSPMDRule InferForward:";
   VLOG(4) << "Input0 shape: [" << str_join(x_shape) << "] "
           << "src_dims_mapping: [" << str_join(x_dims_mapping) << "] "
-          << "dst_dims_mapping: [" << str_join(x_dist_attr_dst.dims_mapping())
-          << "]";
+          << "dst_dims_mapping: ["
+          << str_join(x_dist_attr_dst.multi_dims_mapping()) << "]";
   VLOG(4) << "Input1 shape: [" << str_join(y_shape) << "] "
           << "src_dims_mapping: [" << str_join(y_dims_mapping) << "] "
-          << "dst_dims_mapping: [" << str_join(y_dist_attr_dst.dims_mapping())
-          << "]";
+          << "dst_dims_mapping: ["
+          << str_join(y_dist_attr_dst.multi_dims_mapping()) << "]";
   VLOG(4) << "Output dims_mapping: [" + str_join(out_dims_mapping) + "]\n\n";
 
   return {{x_dist_attr_dst, y_dist_attr_dst}, {out_dist_attr}};
@@ -566,7 +573,7 @@ SpmdInfo ElementwiseBinaryGradInferSpmd(const DistMetaTensor& x,
             << ". The global dim of out_grad is " << out_grad.dims();
     // Step 1: remove the useless dimensions which is not appear in input x.
     int64_t diff = out_grad.dims().size() - x.dims().size();
-    auto dims_mapping = out_grad_dist_attr.dims_mapping();
+    auto dims_mapping = out_grad_dist_attr.multi_dims_mapping();
     dims_mapping.erase(dims_mapping.begin(), dims_mapping.begin() + diff);
     // Step 2: get the explicit reduce dimensions
     std::vector<int64_t> explicit_reduce_dims =
@@ -575,12 +582,12 @@ SpmdInfo ElementwiseBinaryGradInferSpmd(const DistMetaTensor& x,
             << " elements.";
     for (const auto& dim : explicit_reduce_dims) {
       VLOG(4) << "Explicit reduce dims is " << dim;
-      dims_mapping[dim] = -1;
+      dims_mapping[dim] = std::vector<int64_t>{};
     }
     x_dist_attr.set_dims_mapping(dims_mapping);
-    x_dist_attr.set_default_dynamic_dims(dims_mapping);
+    x_dist_attr.set_default_dynamic_dims(dims_mapping.size());
     x_grad_dist_attr.set_dims_mapping(dims_mapping);
-    x_grad_dist_attr.set_default_dynamic_dims(dims_mapping);
+    x_grad_dist_attr.set_default_dynamic_dims(dims_mapping.size());
     // Step 3: set partial dimension
     for (int64_t i = 0; i < diff; ++i) {
       if (out_grad.dist_attr().dims_mapping()[i] != -1) {
@@ -601,7 +608,7 @@ SpmdInfo ElementwiseBinaryGradInferSpmd(const DistMetaTensor& x,
             << ". The global dim of out_grad is " << out_grad.dims();
     // Step 1: remove the useless dimensions which is not appear in input y.
     int64_t diff = out_grad.dims().size() - y.dims().size();
-    auto dims_mapping = out_grad_dist_attr.dims_mapping();
+    auto dims_mapping = out_grad_dist_attr.multi_dims_mapping();
     dims_mapping.erase(dims_mapping.begin(), dims_mapping.begin() + diff);
     // Step 2: get the explicit reduce dimensions
     std::vector<int64_t> explicit_reduce_dims =
@@ -610,12 +617,12 @@ SpmdInfo ElementwiseBinaryGradInferSpmd(const DistMetaTensor& x,
             << " elements.";
     for (const auto& dim : explicit_reduce_dims) {
       VLOG(4) << "Explicit reduce dims is " << dim;
-      dims_mapping[dim] = -1;
+      dims_mapping[dim] = std::vector<int64_t>{};
     }
     y_dist_attr.set_dims_mapping(dims_mapping);
-    y_dist_attr.set_default_dynamic_dims(dims_mapping);
+    y_dist_attr.set_default_dynamic_dims(dims_mapping.size());
     y_grad_dist_attr.set_dims_mapping(dims_mapping);
-    y_grad_dist_attr.set_default_dynamic_dims(dims_mapping);
+    y_grad_dist_attr.set_default_dynamic_dims(dims_mapping.size());
     // Step 3: set partial dimension
     for (int64_t i = 0; i < diff; ++i) {
       if (out_grad.dist_attr().dims_mapping()[i] != -1) {

--- a/paddle/phi/infermeta/spmd_rules/layer_norm.cc
+++ b/paddle/phi/infermeta/spmd_rules/layer_norm.cc
@@ -38,7 +38,8 @@ SpmdInfo LayerNormInferSpmd(const DistMetaTensor& x,
   int scale_ndim = static_cast<int>(scale_shape.size());
   int bias_ndim = static_cast<int>(bias_shape.size());
   TensorDistAttr x_dist_attr_src = x.dist_attr();
-  std::vector<int64_t> x_dims_mapping = x_dist_attr_src.dims_mapping();
+  std::vector<std::vector<int64_t>> x_dims_mapping =
+      x_dist_attr_src.multi_dims_mapping();
   std::vector<int64_t> scale_dims_mapping = scale.dist_attr().dims_mapping();
   std::vector<int64_t> bias_dims_mapping = bias.dist_attr().dims_mapping();
 
@@ -65,12 +66,11 @@ SpmdInfo LayerNormInferSpmd(const DistMetaTensor& x,
   // Because the mean and variance is 'flattened' from
   // x[0:begin_norm_axis], only the first axis of x can
   // be sharded
-  std::string x_axes(x_ndim, '1');
+  std::string x_axes = alphabet.substr(0, x_ndim);
   std::string mean_axes(begin_norm_axis, '1');
   std::string variance_axes(begin_norm_axis, '1');
   // allow axis before begin_norm_axis be sharded
   for (int i = 0; i < begin_norm_axis; ++i) {
-    x_axes[i] = alphabet[i];
     mean_axes[i] = alphabet[i];
     variance_axes[i] = alphabet[i];
   }
@@ -86,9 +86,14 @@ SpmdInfo LayerNormInferSpmd(const DistMetaTensor& x,
   // As the mean and variance in outputs are `flattened` from
   // x[0:begin_norm_axis], only the first axis can be sharded,
   // the axes 1 to begin_norm_axis-1 are set to be replicated.
-  std::fill(x_dims_mapping.begin() + begin_norm_axis, x_dims_mapping.end(), -1);
-  std::unordered_map<std::string, int64_t> axis_to_dim_map =
-      ShardingMergeForTensors({{x_axes, x_dims_mapping}});
+  std::fill(x_dims_mapping.begin() + begin_norm_axis,
+            x_dims_mapping.end(),
+            std::vector<int64_t>{});
+  const auto& axes_size = GetAxesSizes({{x_axes, x_shape}});
+  const auto& mesh_shape = x.dist_attr().process_mesh().shape();
+  std::unordered_map<std::string, std::vector<int64_t>> axis_to_dim_map =
+      ShardingMergeForTensors(
+          {{x_axes, x_dims_mapping}}, axes_size, mesh_shape);
 
   // Step2.2: infer output dims mapping
   TensorDistAttr out_dist_attr = CopyTensorDistAttrForOutput(x_dist_attr_src);
@@ -364,23 +369,29 @@ SpmdInfo LayerNormGradInferSpmd(const DistMetaTensor& x,
         BuildLayerNormGradEinsum(x_shape.size(), begin_norm_axis);
 
     // Sharding Propagation
-    std::vector<std::pair<std::string, std::vector<int64_t>>>
+    std::vector<std::pair<std::string, std::vector<std::vector<int64_t>>>>
         axes_sharding_info;
-    auto x_dims_mapping = dist_attrs[0].dims_mapping();
-    auto out_grad_dims_mapping = dist_attrs[3].dims_mapping();
-    std::fill(
-        x_dims_mapping.begin() + begin_norm_axis, x_dims_mapping.end(), -1);
+    auto x_dims_mapping = dist_attrs[0].multi_dims_mapping();
+    auto out_grad_dims_mapping = dist_attrs[3].multi_dims_mapping();
+    std::fill(x_dims_mapping.begin() + begin_norm_axis,
+              x_dims_mapping.end(),
+              std::vector<int64_t>{});
     std::fill(out_grad_dims_mapping.begin() + begin_norm_axis,
               out_grad_dims_mapping.end(),
-              -1);
+              std::vector<int64_t>{});
     axes_sharding_info.emplace_back(annotations[0], x_dims_mapping);
     axes_sharding_info.emplace_back(annotations[1],
-                                    dist_attrs[1].dims_mapping());
+                                    dist_attrs[1].multi_dims_mapping());
     axes_sharding_info.emplace_back(annotations[2],
-                                    dist_attrs[2].dims_mapping());
+                                    dist_attrs[2].multi_dims_mapping());
     axes_sharding_info.emplace_back(annotations[3], out_grad_dims_mapping);
-    std::unordered_map<std::string, int64_t> axis_to_dim_map =
-        ShardingMergeForTensors(axes_sharding_info);
+    const auto& axes_size = GetAxesSizes({{annotations[0], shapes[0]},
+                                          {annotations[1], shapes[1]},
+                                          {annotations[2], shapes[2]},
+                                          {annotations[3], shapes[3]}});
+    const auto& mesh_shape = x.dist_attr().process_mesh().shape();
+    std::unordered_map<std::string, std::vector<int64_t>> axis_to_dim_map =
+        ShardingMergeForTensors(axes_sharding_info, axes_size, mesh_shape);
 
     x_dist_attr = std::move(dist_attrs[0]);
     x_dist_attr.set_dims_mapping(
@@ -409,11 +420,11 @@ SpmdInfo LayerNormGradInferSpmd(const DistMetaTensor& x,
   TensorDistAttr bias_grad_dist_attr = GetReplicatedDistAttr(bias.dist_attr());
   // partial grad dim
   std::vector<int64_t> partial_on_dims;
-  const auto& dim_mapping = x_dist_attr.dims_mapping();
+  const auto& dim_mapping = x_dist_attr.multi_dims_mapping();
   for (int i = 0; i < begin_norm_axis; ++i) {
     auto mapping = dim_mapping[i];
-    if (mapping != -1) {
-      partial_on_dims.push_back(mapping);
+    if (mapping.size() != 0) {
+      for (auto mp : mapping) partial_on_dims.push_back(mp);
     }
   }
   if (!scale_grad_dist_attr.empty()) {
@@ -466,9 +477,9 @@ SpmdInfo FastLnGradInferSpmd(const DistMetaTensor& x,
                              float epsilon) {
   int begin_norm_axis = x.dims().size() - 1;
   const DistMetaTensor& bias(scale);  // bias is not used in FastLnGrad
-  VLOG(4)
-      << "FastLnGradInferSpmd call LayerNormGradInferSpmd with begin_norm_axis="
-      << begin_norm_axis << ", the input 'bias' will be ignored.";
+  VLOG(4) << "FastLnGradInferSpmd call LayerNormGradInferSpmd with "
+             "begin_norm_axis="
+          << begin_norm_axis << ", the input 'bias' will be ignored.";
   SpmdInfo spmd_info = LayerNormGradInferSpmd(
       x, scale, bias, mean, invvar, y_grad, epsilon, begin_norm_axis);
   spmd_info.first.erase(spmd_info.first.begin() + 2);  // remove bias_dist_attr

--- a/paddle/phi/infermeta/spmd_rules/utils.cc
+++ b/paddle/phi/infermeta/spmd_rules/utils.cc
@@ -143,9 +143,10 @@ std::unordered_map<std::string, int64_t> GetAxesSizes(
         // Get the max size for axis and check broadcastable.
         if (axis_to_size_map.find(axis) == axis_to_size_map.end()) {
           axis_to_size_map[axis] = pair.second[i];
-        } else if (axis_to_size_map[axis] == 1) {
+        } else if (axis_to_size_map[axis] == 1 ||
+                   axis_to_size_map[axis] == -1) {
           axis_to_size_map[axis] = pair.second[i];
-        } else if (pair.second[i] == 1) {
+        } else if (pair.second[i] == 1 || pair.second[i] == -1) {
           continue;
         } else {
           PADDLE_ENFORCE_EQ(

--- a/paddle/phi/infermeta/spmd_rules/utils.cc
+++ b/paddle/phi/infermeta/spmd_rules/utils.cc
@@ -841,7 +841,7 @@ std::vector<std::vector<int64_t>> GetDimsMappingForAxes(
           dims_mapping.emplace_back(std::vector<int64_t>{});
         } else {
           common::errors::InvalidArgument(
-              "Tensor axis [%s] of not in axis_to_dim_map.", axis);
+              "Tensor axis [%s] is not in axis_to_dim_map.", axis);
         }
       } else {
         dims_mapping.emplace_back(iter->second);
@@ -850,7 +850,6 @@ std::vector<std::vector<int64_t>> GetDimsMappingForAxes(
   }
   return dims_mapping;
 }
-
 void DebugInfoForInferSpmd(const std::string& rule_name,
                            const SpmdInfo& infer_result) {
   VLOG(4) << "The infer spmd result of " << rule_name << " is as below:";

--- a/test/auto_parallel/end_to_end/elementwise_binary_co_shard.py
+++ b/test/auto_parallel/end_to_end/elementwise_binary_co_shard.py
@@ -1,0 +1,146 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+import paddle
+import paddle.distributed as dist
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+class BinaryElementwiseTestCase:
+    """
+    A data class to hold parameters for a binary elementwise operation test case.
+    """
+
+    def __init__(
+        self,
+        shape: list[int],
+        placements_x: Sequence[dist.Placement],
+        placements_y: Sequence[dist.Placement],
+        expected_placements_x: Sequence[dist.Placement],
+        expected_placements_y: Sequence[dist.Placement],
+        expected_placements_out: Sequence[dist.Placement],
+    ):
+        self.shape = shape
+        self.placements_x = placements_x
+        self.placements_y = placements_y
+        self.expected_placements_x = expected_placements_x
+        self.expected_placements_y = expected_placements_y
+        self.expected_placements_out = expected_placements_out
+
+
+class TestAddCoShard:
+    """
+    Unit tests for co_shard SPMD rule on binary elementwise operations.
+    """
+
+    def setUp(self):
+        """
+        Initializes the process mesh and defines the test cases.
+        """
+        self.mesh = dist.ProcessMesh([[0, 1], [2, 3]], dim_names=['x', 'y'])
+        # The expected placements for inputs and output are the same after co-sharding.
+        expected_placements = [
+            dist.Shard(dim=0, shard_order=0),
+            dist.Shard(dim=0, shard_order=1),
+        ]
+        self.test_cases = [
+            # Test Case 1: [[0],[1]],[[0,1],[]] -> [[0,1],[]], [[0,1],[]], [[0,1],[]]
+            BinaryElementwiseTestCase(
+                shape=[64, 64],
+                placements_x=[dist.Shard(0), dist.Shard(1)],
+                placements_y=[
+                    dist.Shard(dim=0, shard_order=0),
+                    dist.Shard(dim=0, shard_order=1),
+                ],
+                expected_placements_x=expected_placements,
+                expected_placements_y=expected_placements,
+                expected_placements_out=expected_placements,
+            ),
+            # Test Case 2: [[0],[]], [[1],[]] -> [[0,1],[]], [[0,1],[]], [[0,1],[]]
+            BinaryElementwiseTestCase(
+                shape=[64, 64],
+                placements_x=[dist.Shard(0), dist.Replicate()],
+                placements_y=[dist.Shard(1), dist.Replicate()],
+                expected_placements_x=expected_placements,
+                expected_placements_y=expected_placements,
+                expected_placements_out=expected_placements,
+            ),
+        ]
+
+    def run_test_case(self, test_case: BinaryElementwiseTestCase):
+        # Prepare inputs
+        a = paddle.randn(test_case.shape, dtype='float32')
+        b = paddle.randn(test_case.shape, dtype='float32')
+
+        # Shard tensors
+        x = dist.shard_tensor(a, self.mesh, test_case.placements_x)
+        y = dist.shard_tensor(b, self.mesh, test_case.placements_y)
+
+        # Perform operation
+        out = paddle.add(x, y)
+
+        case_info = f"placements_x: {test_case.placements_x}, placements_y: {test_case.placements_y}"
+
+        # Verify placements of inputs (post-operation due to potential resharding)
+        assert x.placements and y.placements
+        for actual, expected in zip(
+            x.placements, test_case.expected_placements_x
+        ):
+            np.testing.assert_equal(
+                actual,
+                expected,
+                err_msg=f"Input 'x' placements mismatch when {case_info}. Expected: {test_case.expected_placements_x}, Actual: {x.placements}",
+            )
+        for actual, expected in zip(
+            y.placements, test_case.expected_placements_y
+        ):
+            np.testing.assert_equal(
+                actual,
+                expected,
+                err_msg=f"Input 'y' placements mismatch when {case_info}. Expected: {test_case.expected_placements_y}, Actual: {y.placements}",
+            )
+
+        # Verify output shape
+        np.testing.assert_equal(
+            out.shape,
+            test_case.shape,
+            err_msg=f"Output shape mismatch when {case_info}. Expected: {test_case.shape}, Actual: {out.shape}",
+        )
+
+        # Verify output placements
+        assert out.placements
+        for actual, expected in zip(
+            out.placements, test_case.expected_placements_out
+        ):
+            np.testing.assert_equal(
+                actual,
+                expected,
+                err_msg=f"Output placements mismatch when {case_info}. Expected: {test_case.expected_placements_out}, Actual: {out.placements}",
+            )
+
+    def run_all_tests(self):
+        self.setUp()
+        for test_case in self.test_cases:
+            self.run_test_case(test_case)
+
+
+if __name__ == '__main__':
+    TestAddCoShard().run_all_tests()

--- a/test/auto_parallel/end_to_end/layernorm_co_shard.py
+++ b/test/auto_parallel/end_to_end/layernorm_co_shard.py
@@ -1,0 +1,129 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+import paddle
+import paddle.distributed as dist
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+class LayerNormTestCase:
+    """
+    A data class to hold parameters for a LayerNorm operation test case.
+    """
+
+    def __init__(
+        self,
+        input_shape: list[int],
+        normalized_shape: list[int] | int,
+        input_placements: Sequence[dist.Placement],
+        expected_input_placements: Sequence[dist.Placement],
+        expected_output_placements: Sequence[dist.Placement],
+    ):
+        self.input_shape = input_shape
+        self.normalized_shape = normalized_shape
+        self.input_placements = input_placements
+        self.expected_input_placements = expected_input_placements
+        self.expected_output_placements = expected_output_placements
+
+
+class TestLayerNormCoShard:
+    """
+    Unit tests for co_shard SPMD rule on LayerNorm operation.
+    """
+
+    def setUp(self):
+        """
+        Initializes the process mesh and defines the test cases.
+        """
+        self.mesh = dist.ProcessMesh([[0, 1], [2, 3]], dim_names=['x', 'y'])
+
+        # After resharding, the input and output are expected to be sharded on dimension 0
+        # across the flattened mesh.
+        expected_placements = [
+            dist.Shard(dim=0, shard_order=0),
+            dist.Shard(dim=0, shard_order=1),
+        ]
+
+        self.test_cases = [
+            LayerNormTestCase(
+                input_shape=[64, 32, 128, 128],
+                normalized_shape=[32, 128, 128],
+                input_placements=[
+                    dist.Shard(dim=0, shard_order=0),
+                    dist.Shard(dim=0, shard_order=1),
+                ],
+                expected_input_placements=expected_placements,
+                expected_output_placements=expected_placements,
+            )
+        ]
+
+    def run_test_case(self, test_case: LayerNormTestCase):
+        # Prepare inputs and model
+        x = paddle.rand(test_case.input_shape, dtype="float32")
+        layer_norm = paddle.nn.LayerNorm(test_case.normalized_shape)
+
+        # Shard tensor
+        input_tensor = dist.shard_tensor(
+            x, self.mesh, test_case.input_placements
+        )
+
+        # Perform operation
+        out = layer_norm(input_tensor)
+
+        case_info = f"input_placements: {test_case.input_placements}"
+
+        # Verify placements of the input tensor (post-operation, due to resharding)
+        assert input_tensor.placements
+        for actual, expected in zip(
+            input_tensor.placements, test_case.expected_input_placements
+        ):
+            np.testing.assert_equal(
+                actual,
+                expected,
+                err_msg=f"Input placements mismatch when {case_info}. Expected: {test_case.expected_input_placements}, Actual: {input_tensor.placements}",
+            )
+
+        # Verify output shape
+        np.testing.assert_equal(
+            out.shape,
+            test_case.input_shape,
+            err_msg=f"Output shape mismatch when {case_info}. Expected: {test_case.input_shape}, Actual: {out.shape}",
+        )
+
+        # Verify output placements
+        assert out.placements
+        for actual, expected in zip(
+            out.placements, test_case.expected_output_placements
+        ):
+            np.testing.assert_equal(
+                actual,
+                expected,
+                err_msg=f"Output placements mismatch when {case_info}. Expected: {test_case.expected_output_placements}, Actual: {out.placements}",
+            )
+
+    def run_all_tests(self):
+        self.setUp()
+        for test_case in self.test_cases:
+            self.run_test_case(test_case)
+
+
+if __name__ == '__main__':
+    TestLayerNormCoShard().run_all_tests()

--- a/test/auto_parallel/end_to_end/test_e2e_co_shard.py
+++ b/test/auto_parallel/end_to_end/test_e2e_co_shard.py
@@ -27,6 +27,12 @@ class TestReshardE2E(test_base.CommunicationTestDistBase):
     def test_reshape_co_shard(self):
         self.run_test_case("reshape_co_shard.py")
 
+    def test_binary_elementwise_co_shard(self):
+        self.run_test_case("elementwise_binary_co_shard.py")
+
+    def test_layernorm_co_shard(self):
+        self.run_test_case("layernorm_co_shard.py")
+
     def test_transpose_co_shard(self):
         self.run_test_case("transpose_co_shard.py")
 

--- a/test/auto_parallel/spmd_rules/test_elementwise_rule.py
+++ b/test/auto_parallel/spmd_rules/test_elementwise_rule.py
@@ -252,7 +252,7 @@ class TestElementwiseSPMDRule(unittest.TestCase):
         self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [0, 1, -1])
         self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0, 1, -1])
 
-        # [0, -1, -1], [-1, 1, 0] --> [0, 1, -1], [0, 1, -1], [0, 1, -1]
+        # [0, -1, -1], [-1, 1, 0] --> [-1, 1, 0],  [-1, 1, 0], [-1, 1, 0]
         self.x_dist_tensor_spec.set_dims_mapping([0, -1, -1])
         self.y_dist_tensor_spec.set_dims_mapping([-1, 1, 0])
         resulted_dist_attrs = self.binary_rule.infer_forward(
@@ -261,9 +261,9 @@ class TestElementwiseSPMDRule(unittest.TestCase):
         inferred_input_dist_attrs = resulted_dist_attrs[0]
         inferred_output_dist_attrs = resulted_dist_attrs[1]
 
-        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [0, 1, -1])
-        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [0, 1, -1])
-        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [0, 1, -1])
+        self.assertEqual(inferred_input_dist_attrs[0].dims_mapping, [-1, 1, 0])
+        self.assertEqual(inferred_input_dist_attrs[1].dims_mapping, [-1, 1, 0])
+        self.assertEqual(inferred_output_dist_attrs[0].dims_mapping, [-1, 1, 0])
 
     def test_multi_mesh_dim_broadcast(self):
         process_mesh = auto.ProcessMesh([[0, 1, 2], [3, 4, 5]])

--- a/test/auto_parallel/spmd_rules/test_layer_norm_rule.py
+++ b/test/auto_parallel/spmd_rules/test_layer_norm_rule.py
@@ -33,7 +33,7 @@ class TestLayerNormSPMDRule(unittest.TestCase):
     def setUp(self):
         self.rule = core.get_phi_spmd_rule("layer_norm")
 
-        x_shape = [64, 32, 1024]
+        x_shape = [48, 32, 1024]
         scale_shape = [1024]
         bias_shape = [1024]
         process_mesh = auto.ProcessMesh(mesh=[[0, 1, 2], [3, 4, 5]])

--- a/test/cpp/auto_parallel/spmd_rule_test.cc
+++ b/test/cpp/auto_parallel/spmd_rule_test.cc
@@ -394,7 +394,7 @@ TEST(InstanceNorm, Ctor) {
 }
 TEST(LayerNormSPMDRule, Ctor) {
   // build input data class
-  std::vector<int64_t> x_shape = {64, 32, 1024};
+  std::vector<int64_t> x_shape = {48, 32, 1024};
   std::vector<int64_t> scale_shape = {1024};
   std::vector<int64_t> bias_shape = {1024};
 
@@ -496,6 +496,29 @@ TEST(LayerNormSPMDRule, Ctor) {
   check_dim_mapping(inferred_dist_attrs.second[1], {0});
   check_dim_mapping(inferred_dist_attrs.second[2], {0});
   VLOG(4) << "test3 done.";
+
+  // {{0, 1}, {}, {}} {{}} {{}} -> {{0, 1}, {}, {}} {{0, 1}, {}} {{0, 1}, {}}
+  begin_norm_axis = 2;
+  std::vector<std::vector<int64_t>> dims_mapping = {{0, 1}, {}, {}};
+  x_dist_attr.set_dims_mapping(dims_mapping);
+  scale_dist_attr.set_dims_mapping(std::vector<int64_t>{-1});
+  bias_dist_attr.set_dims_mapping(std::vector<int64_t>{-1});
+  x = phi::distributed::DistMetaTensor(common::make_ddim(x_shape), x_dist_attr);
+  scale = phi::distributed::DistMetaTensor(common::make_ddim(scale_shape),
+                                           scale_dist_attr);
+  bias = phi::distributed::DistMetaTensor(common::make_ddim(bias_shape),
+                                          bias_dist_attr);
+  ctx = phi::distributed::InferSpmdContext({x, scale, bias},
+                                           {epsilon, begin_norm_axis});
+  inferred_dist_attrs = layer_norm_rule.InferForward(ctx);
+
+  check_multi_dims_mapping(inferred_dist_attrs.first[0], {{0, 1}, {}, {}});
+  check_multi_dims_mapping(inferred_dist_attrs.first[1], {{}});
+  check_multi_dims_mapping(inferred_dist_attrs.first[2], {{}});
+  check_multi_dims_mapping(inferred_dist_attrs.second[0], {{0, 1}, {}, {}});
+  check_multi_dims_mapping(inferred_dist_attrs.second[1], {{0, 1}, {}});
+  check_multi_dims_mapping(inferred_dist_attrs.second[2], {{0, 1}, {}});
+  VLOG(4) << "test4 done.";
 }
 
 TEST(MatmulSPMDRuleInferBackward, Ctor) {
@@ -1412,6 +1435,31 @@ TEST(LayerNorm, Ctor) {
   check_dim_mapping(spmd2.second[2], {-1, -1});
   check_partial_dims(spmd2.second[1], {0});
   check_partial_dims(spmd2.second[2], {0});
+  // test 3
+  std::vector<std::vector<int64_t>> dim_mapping = {{0, 1}, {}, {}};
+  auto t_dist_attr = TensorDistAttr();
+  t_dist_attr.set_process_mesh(process_mesh);
+  t_dist_attr.set_dims_mapping(dim_mapping);
+  t_dist_attr.set_dynamic_dims({false, false, false});
+  x = phi::distributed::DistMetaTensor(common::make_ddim(x_shapes),
+                                       t_dist_attr);
+  out_grad = phi::distributed::DistMetaTensor(common::make_ddim(x_shapes),
+                                              t_dist_attr);
+  auto spmd3 =
+      LayerNormGradInferSpmd(x, scale, bias, mean, variance, out_grad, 1.0, 1);
+  EXPECT_EQ(spmd3.first.size(), static_cast<size_t>(6));
+  EXPECT_EQ(spmd3.second.size(), static_cast<size_t>(3));
+  check_multi_dims_mapping(spmd3.first[0], {{0, 1}, {}, {}});
+  check_multi_dims_mapping(spmd3.first[1], {{}, {}});
+  check_multi_dims_mapping(spmd3.first[2], {{}, {}});
+  check_multi_dims_mapping(spmd3.first[3], {{0, 1}});
+  check_multi_dims_mapping(spmd3.first[4], {{0, 1}});
+  check_multi_dims_mapping(spmd3.first[5], {{0, 1}, {}, {}});
+  check_multi_dims_mapping(spmd3.second[0], {{0, 1}, {}, {}});
+  check_multi_dims_mapping(spmd3.second[1], {{}, {}});
+  check_multi_dims_mapping(spmd3.second[2], {{}, {}});
+  check_partial_dims(spmd3.second[1], {0, 1});
+  check_partial_dims(spmd3.second[2], {0, 1});
 }
 
 TEST(FlashAtt, Ctor) {
@@ -1932,6 +1980,92 @@ TEST(ElementwiseUnaryLike, Ctor) {
       phi::distributed::DistMetaTensor(common::make_ddim(shape), t_dist_attr);
   inferred_dist_attrs = phi::distributed::LogitGradInfoSpmd(input, input, 1.0);
   check_element_unary_like_backward(inferred_dist_attrs);
+}
+
+TEST(ElementwiseBinaryLike, Ctor) {
+  // build input data class
+  std::vector<int64_t> x_shape = {64, 64, 64};
+  std::vector<int64_t> y_shape = {64, 64, 64};
+  std::vector<int64_t> mesh_shape = {2, 2};
+  std::vector<int64_t> process_ids = {0, 1, 2, 3};
+  std::vector<std::string> dim_names = {"x", "y"};
+  ProcessMesh process_mesh(mesh_shape, process_ids, dim_names);
+
+  TensorDistAttr x_dist_attr = TensorDistAttr();
+  x_dist_attr.set_process_mesh(process_mesh);
+  x_dist_attr.set_dims_mapping(
+      std::vector<std::vector<int64_t>>({{}, {0, 1}, {}}));
+  x_dist_attr.set_dynamic_dims(std::vector<bool>({false, false, false}));
+
+  TensorDistAttr y_dist_attr = TensorDistAttr();
+  y_dist_attr.set_process_mesh(process_mesh);
+  y_dist_attr.set_dims_mapping(
+      std::vector<std::vector<int64_t>>({{0}, {1}, {}}));
+  y_dist_attr.set_dynamic_dims(std::vector<bool>({false, false, false}));
+
+  // Test forward.
+  // [-1 , [0,1], -1], [0, 1, -1] --> input: [-1, [0,1], -1], [-1,[0,1],-1]
+  // output: [-1,[0,1],-1]
+
+  phi::distributed::DistMetaTensor x(common::make_ddim(x_shape), x_dist_attr);
+  phi::distributed::DistMetaTensor y(common::make_ddim(y_shape), y_dist_attr);
+  phi::distributed::SpmdInfo forward_info =
+      phi::distributed::ElementwiseBinaryInferSpmd(x, y);
+  size_t input_size = 2;
+  size_t output_size = 1;
+  EXPECT_EQ(forward_info.first.size(), input_size);
+  EXPECT_EQ(forward_info.second.size(), output_size);
+  check_multi_dims_mapping(forward_info.first[0], {{}, {0, 1}, {}});
+  check_multi_dims_mapping(forward_info.first[1], {{}, {0, 1}, {}});
+  check_multi_dims_mapping(forward_info.second[0], {{}, {0, 1}, {}});
+
+  VLOG(4) << "test forward done.";
+
+  // build input data class
+  y_shape = {48};
+  x_dist_attr.set_dims_mapping(
+      std::vector<std::vector<int64_t>>({{0}, {}, {}}));
+  x_dist_attr.set_dynamic_dims(std::vector<bool>({false, false, false}));
+  y_dist_attr.set_dims_mapping(std::vector<std::vector<int64_t>>({{1}}));
+  y_dist_attr.set_dynamic_dims(std::vector<bool>({false}));
+
+  // Test forward 2.
+  // [0, -1, -1], [1] --> input: [0, -1, 1], [1]
+  // output: [0,-1,1]
+
+  phi::distributed::DistMetaTensor x2(common::make_ddim(x_shape), x_dist_attr);
+  phi::distributed::DistMetaTensor y2(common::make_ddim(y_shape), y_dist_attr);
+  forward_info = phi::distributed::ElementwiseBinaryInferSpmd(x2, y2);
+  EXPECT_EQ(forward_info.first.size(), input_size);
+  EXPECT_EQ(forward_info.second.size(), output_size);
+  check_multi_dims_mapping(forward_info.first[0], {{0}, {}, {1}});
+  check_multi_dims_mapping(forward_info.first[1], {{1}});
+  check_multi_dims_mapping(forward_info.second[0], {{0}, {}, {1}});
+
+  VLOG(4) << "test forward 2 done.";
+
+  // Test backward.
+  // [-1 , [0,1], -1], [0, 1, -1],[-1,-1,[0,1]] --> input: [-1, -1, [0,1]],
+  // [-1, -1, [0,1]],[-1, -1, [0,1]] output: [-1, -1, [0,1]],[-1, -1, [0,1]]
+  TensorDistAttr out_grad_dist_attr = TensorDistAttr();
+  out_grad_dist_attr.set_process_mesh(process_mesh);
+  out_grad_dist_attr.set_dims_mapping(
+      std::vector<std::vector<int64_t>>({{}, {}, {0, 1}}));
+  out_grad_dist_attr.set_dynamic_dims(std::vector<bool>({false, false, false}));
+  phi::distributed::DistMetaTensor out_grad(common::make_ddim(x_shape),
+                                            out_grad_dist_attr);
+  phi::distributed::SpmdInfo backward_info =
+      phi::distributed::ElementwiseBinaryGradInferSpmd(x, y, out_grad);
+  input_size = 3;
+  output_size = 2;
+  EXPECT_EQ(backward_info.first.size(), input_size);
+  EXPECT_EQ(backward_info.second.size(), output_size);
+  check_multi_dims_mapping(backward_info.first[0], {{}, {}, {0, 1}});
+  check_multi_dims_mapping(backward_info.first[1], {{}, {}, {0, 1}});
+  check_multi_dims_mapping(backward_info.first[2], {{}, {}, {0, 1}});
+  check_multi_dims_mapping(backward_info.second[0], {{}, {}, {0, 1}});
+  check_multi_dims_mapping(backward_info.second[1], {{}, {}, {0, 1}});
+  VLOG(4) << "test backward done.";
 }
 
 TEST(EmbeddingGradInferSpmd, Ctor) {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
为LayerNorm 和elementwise_binary（例如：Add）的算子添加切多刀机制的推导规则。

对于elementwise_binary 类的算子如：Add(x,y) ，切分推导策略为，解决x和y的切分策略冲突，并合并x和y的切分策略，作为算子输出的output的张量的output。相应的，其反向算子的切分策略推导与上面一致。（```ShardingMergeForTensors``` 函数在PR#74829当中，等待该P合入之后，该PR可以合入）

对于LayerNorm算子，在原来的切分策略不变的基础上，需要保证在做layernorm之前的维度上（即：```dim< begin_norm_axis```），支持多刀切机制。
