### PR TITLE
[CI] Pin cmake version to `3.27.7` in mac_cpu workflow

### DIFF
--- a/.github/workflows/_Mac.yml
+++ b/.github/workflows/_Mac.yml
@@ -87,6 +87,8 @@ jobs:
           set -x
           cd ${work_dir}/Paddle
           source ~/.zshrc
+          python3.10 -m pip uninstall cmake -y || true
+          python3.10 -m pip install cmake==3.27.7
           bash -x ${work_dir}/Paddle/ci/run_setup.sh bdist_wheel ${parallel_number:-""}
           EXCODE=$?
           exit $EXCODE


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
Force cmake version 3.27.7 in mac_cpu CI