### PR TITLE
[AutoParallel] Fix DistTensorConverter overloading

### DIFF
--- a/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
@@ -397,6 +397,8 @@ TEST_API {} {}({}) {{
     egr::CUDAErrorCheck(\"{} begin\");
   }}
 {}
+  // Convert All Inputs to DistTensor
+{}
   // Dygraph Record Event
 {}
   // AMP Logic
@@ -1722,7 +1724,9 @@ class DygraphForwardFunctionGenerator(DygraphFunctionGeneratorBase):
         layout_autotune_optional_list = []
         layout_tensors_vector_optional_list = []
         record_inplace_original_dist_attr_list = []
+        grad_inputs_names = []
         for name, (ttype, pos) in forward_inputs_position_map.items():
+            grad_inputs_names.append(f"{name}")
             inputs_call_list[pos] = f"{name}"
             amp_inputs_call_list[pos] = f"new_{name}"
             is_optional = name in optional_inputs
@@ -2304,6 +2308,14 @@ class DygraphForwardFunctionGenerator(DygraphFunctionGeneratorBase):
         ):
             strided_flags_check = STRIDED_FLAGS_CHECK_TEMPLATE
         # Generate forward_definition_str and forward_declaration_str
+
+        convert_input_to_dist_tensor_str = (
+            CONVERT_INPUT_TENSORS_TO_DIST_TENSOR_TEMPLATE.format(
+                grad_inputs_names=", " + ", ".join(grad_inputs_names),
+                wrapper_inputs_names=", " + ", ".join(grad_inputs_names),
+            )
+        )
+
         if self.is_forward_only:
             if len(amp_tensors_vector_list) == 0:
                 amp_logic_str = f'\n VLOG(7) << " No AMP for {forward_ad_function_name} because it has no input. "; '
@@ -2342,6 +2354,7 @@ class DygraphForwardFunctionGenerator(DygraphFunctionGeneratorBase):
                 forward_api_name,
                 forward_ad_function_name,
                 strided_flags_check,
+                convert_input_to_dist_tensor_str,
                 dygraph_event_str,
                 amp_logic_str,
                 type_promotion_logic_str,

--- a/paddle/fluid/eager/grad_tensor_holder.cc
+++ b/paddle/fluid/eager/grad_tensor_holder.cc
@@ -185,14 +185,18 @@ void GradTensorHolder::add(size_t slot_id,
           paddle::imperative::TensorAdd<paddle::Tensor>(t, &buffer_tensor);
         }
       } else {
-        // TODO(jiabin): Support Other TensorBase later
-        // TODO(zhanlve): Replace SelectedRowsAddTensor with
-        // add_dygraph_function once it's supported
-        paddle::Tensor new_buffer(std::make_shared<phi::DenseTensor>(),
-                                  "tmp_accumulator");
-        paddle::imperative::SelectedRowsAddTensor(
-            buffer_tensor, t, &new_buffer);
-        buffer_tensor.set_impl(new_buffer.impl());
+        if (buffer_tensor.is_dist_tensor()) {
+          buffer_tensor = add_ad_func(t, buffer_tensor);
+        } else {
+          // TODO(jiabin): Support Other TensorBase later
+          // TODO(zhanlve): Replace SelectedRowsAddTensor with
+          // add_dygraph_function once it's supported
+          paddle::Tensor new_buffer(std::make_shared<phi::DenseTensor>(),
+                                    "tmp_accumulator");
+          paddle::imperative::SelectedRowsAddTensor(
+              buffer_tensor, t, &new_buffer);
+          buffer_tensor.set_impl(new_buffer.impl());
+        }
       }
     } else if (t.is_sparse_coo_tensor()) {
       auto t_sparse = std::dynamic_pointer_cast<phi::SparseCooTensor>(t.impl());

--- a/paddle/fluid/eager/grad_tensor_holder.cc
+++ b/paddle/fluid/eager/grad_tensor_holder.cc
@@ -184,19 +184,17 @@ void GradTensorHolder::add(size_t slot_id,
         } else {
           paddle::imperative::TensorAdd<paddle::Tensor>(t, &buffer_tensor);
         }
+      } else if (buffer_tensor.is_dist_tensor()) {
+        buffer_tensor = add_ad_func(t, buffer_tensor);
       } else {
-        if (buffer_tensor.is_dist_tensor()) {
-          buffer_tensor = add_ad_func(t, buffer_tensor);
-        } else {
-          // TODO(jiabin): Support Other TensorBase later
-          // TODO(zhanlve): Replace SelectedRowsAddTensor with
-          // add_dygraph_function once it's supported
-          paddle::Tensor new_buffer(std::make_shared<phi::DenseTensor>(),
-                                    "tmp_accumulator");
-          paddle::imperative::SelectedRowsAddTensor(
-              buffer_tensor, t, &new_buffer);
-          buffer_tensor.set_impl(new_buffer.impl());
-        }
+        // TODO(jiabin): Support Other TensorBase later
+        // TODO(zhanlve): Replace SelectedRowsAddTensor with
+        // add_dygraph_function once it's supported
+        paddle::Tensor new_buffer(std::make_shared<phi::DenseTensor>(),
+                                  "tmp_accumulator");
+        paddle::imperative::SelectedRowsAddTensor(
+            buffer_tensor, t, &new_buffer);
+        buffer_tensor.set_impl(new_buffer.impl());
       }
     } else if (t.is_sparse_coo_tensor()) {
       auto t_sparse = std::dynamic_pointer_cast<phi::SparseCooTensor>(t.impl());

--- a/paddle/fluid/eager/utils.cc
+++ b/paddle/fluid/eager/utils.cc
@@ -1019,20 +1019,14 @@ void DistTensorConverter::operator()(paddle::Tensor* x) {
 }
 
 void DistTensorConverter::operator()(const paddle::Tensor* x) {
-  DistTensorConverter::convert(x);
+  if (x) {
+    DistTensorConverter::convert(x);
+  }
 }
 
 void DistTensorConverter::operator()(const paddle::Tensor& x) {
   DistTensorConverter::convert(&x);
 }
-
-void DistTensorConverter::operator()(
-    const paddle::optional<paddle::Tensor>* x) {
-  if (*x) {
-    DistTensorConverter::convert(x->get_ptr());
-  }
-}
-
 void DistTensorConverter::operator()(std::vector<paddle::Tensor>* x) {
   if (!x->empty()) {
     for (auto& t : *x) {
@@ -1042,10 +1036,8 @@ void DistTensorConverter::operator()(std::vector<paddle::Tensor>* x) {
 }
 
 void DistTensorConverter::operator()(const std::vector<paddle::Tensor> x) {
-  if (!x.empty()) {
-    for (auto& t : x) {
-      DistTensorConverter::convert(&t);
-    }
+  for (auto& t : x) {
+    DistTensorConverter::convert(&t);
   }
 }
 

--- a/paddle/fluid/eager/utils.cc
+++ b/paddle/fluid/eager/utils.cc
@@ -1010,12 +1010,24 @@ void DistTensorTypeParser::operator()(
   }
 }
 
-void DistTensorConverter::convert(paddle::Tensor* x) {
+void DistTensorConverter::convert(const paddle::Tensor* x) {
   ConvertToDistTensor(x, mesh);
 }
 
 void DistTensorConverter::operator()(paddle::Tensor* x) {
   DistTensorConverter::convert(x);
+}
+
+void DistTensorConverter::operator()(const paddle::Tensor* x) {
+  DistTensorConverter::convert(x);
+}
+
+void DistTensorConverter::operator()(paddle::Tensor& x) {
+  DistTensorConverter::convert(&x);
+}
+
+void DistTensorConverter::operator()(const paddle::Tensor& x) {
+  DistTensorConverter::convert(&x);
 }
 
 void DistTensorConverter::operator()(paddle::optional<paddle::Tensor>* x) {
@@ -1024,9 +1036,32 @@ void DistTensorConverter::operator()(paddle::optional<paddle::Tensor>* x) {
   }
 }
 
+void DistTensorConverter::operator()(
+    const paddle::optional<paddle::Tensor>* x) {
+  if (*x) {
+    DistTensorConverter::convert(x->get_ptr());
+  }
+}
+
 void DistTensorConverter::operator()(std::vector<paddle::Tensor>* x) {
   if (!x->empty()) {
     for (auto& t : *x) {
+      DistTensorConverter::convert(&t);
+    }
+  }
+}
+
+void DistTensorConverter::operator()(const std::vector<paddle::Tensor>* x) {
+  if (!x->empty()) {
+    for (auto& t : *x) {
+      DistTensorConverter::convert(&t);
+    }
+  }
+}
+
+void DistTensorConverter::operator()(const std::vector<paddle::Tensor> x) {
+  if (!x.empty()) {
+    for (auto& t : x) {
       DistTensorConverter::convert(&t);
     }
   }
@@ -1045,7 +1080,20 @@ void DistTensorConverter::operator()(
   }
 }
 
-void ConvertToDistTensor(paddle::Tensor* x,
+void DistTensorConverter::operator()(
+    const paddle::optional<std::vector<paddle::Tensor>>* x) {
+  if (*x) {
+    if (!(x->get_ptr()->empty())) {
+      for (auto& t : *(x->get_ptr())) {
+        if (!t.is_dist_tensor()) {
+          DistTensorConverter::convert(&t);
+        }
+      }
+    }
+  }
+}
+
+void ConvertToDistTensor(const paddle::Tensor* x,
                          const phi::distributed::ProcessMesh* mesh) {
   if (!x->defined()) {
     return;
@@ -1092,8 +1140,9 @@ void ConvertToDistTensor(paddle::Tensor* x,
     if (!dense_t->meta().is_contiguous()) {
       *dense_t = paddle::experimental::Trans2Contiguous(*dense_t);
     }
-    x->set_impl(std::make_shared<phi::distributed::DistTensor>(
-        dense_t, *mesh, placements));
+    const_cast<paddle::Tensor*>(x)->set_impl(
+        std::make_shared<phi::distributed::DistTensor>(
+            dense_t, *mesh, placements));
   }
 }
 }  // namespace egr

--- a/paddle/fluid/eager/utils.cc
+++ b/paddle/fluid/eager/utils.cc
@@ -1022,18 +1022,8 @@ void DistTensorConverter::operator()(const paddle::Tensor* x) {
   DistTensorConverter::convert(x);
 }
 
-void DistTensorConverter::operator()(paddle::Tensor& x) {
-  DistTensorConverter::convert(&x);
-}
-
 void DistTensorConverter::operator()(const paddle::Tensor& x) {
   DistTensorConverter::convert(&x);
-}
-
-void DistTensorConverter::operator()(paddle::optional<paddle::Tensor>* x) {
-  if (*x) {
-    DistTensorConverter::convert(x->get_ptr());
-  }
 }
 
 void DistTensorConverter::operator()(
@@ -1051,14 +1041,6 @@ void DistTensorConverter::operator()(std::vector<paddle::Tensor>* x) {
   }
 }
 
-void DistTensorConverter::operator()(const std::vector<paddle::Tensor>* x) {
-  if (!x->empty()) {
-    for (auto& t : *x) {
-      DistTensorConverter::convert(&t);
-    }
-  }
-}
-
 void DistTensorConverter::operator()(const std::vector<paddle::Tensor> x) {
   if (!x.empty()) {
     for (auto& t : x) {
@@ -1069,19 +1051,6 @@ void DistTensorConverter::operator()(const std::vector<paddle::Tensor> x) {
 
 void DistTensorConverter::operator()(
     paddle::optional<std::vector<paddle::Tensor>>* x) {
-  if (*x) {
-    if (!(x->get_ptr()->empty())) {
-      for (auto& t : *(x->get_ptr())) {
-        if (!t.is_dist_tensor()) {
-          DistTensorConverter::convert(&t);
-        }
-      }
-    }
-  }
-}
-
-void DistTensorConverter::operator()(
-    const paddle::optional<std::vector<paddle::Tensor>>* x) {
   if (*x) {
     if (!(x->get_ptr()->empty())) {
       for (auto& t : *(x->get_ptr())) {

--- a/paddle/fluid/eager/utils.h
+++ b/paddle/fluid/eager/utils.h
@@ -327,19 +327,11 @@ struct DistTensorConverter : ArgsIterator<DistTensorConverter> {
 
   void operator()(paddle::Tensor* x);
   void operator()(const paddle::Tensor* x);
-
-  void operator()(paddle::Tensor& x);
   void operator()(const paddle::Tensor& x);
-
-  void operator()(paddle::optional<paddle::Tensor>* x);
   void operator()(const paddle::optional<paddle::Tensor>* x);
-
   void operator()(std::vector<paddle::Tensor>* x);
-  void operator()(const std::vector<paddle::Tensor>* x);
   void operator()(const std::vector<paddle::Tensor> x);
-
   void operator()(paddle::optional<std::vector<paddle::Tensor>>* x);
-  void operator()(const paddle::optional<std::vector<paddle::Tensor>>* x);
 
   // skip other type args, these args don't used in kernel selection
   template <typename T>

--- a/paddle/fluid/eager/utils.h
+++ b/paddle/fluid/eager/utils.h
@@ -323,11 +323,23 @@ struct DistTensorConverter : ArgsIterator<DistTensorConverter> {
     mesh = m;
   }
 
-  void convert(paddle::Tensor* x);
+  void convert(const paddle::Tensor* x);
+
   void operator()(paddle::Tensor* x);
+  void operator()(const paddle::Tensor* x);
+
+  void operator()(paddle::Tensor& x);
+  void operator()(const paddle::Tensor& x);
+
   void operator()(paddle::optional<paddle::Tensor>* x);
+  void operator()(const paddle::optional<paddle::Tensor>* x);
+
   void operator()(std::vector<paddle::Tensor>* x);
+  void operator()(const std::vector<paddle::Tensor>* x);
+  void operator()(const std::vector<paddle::Tensor> x);
+
   void operator()(paddle::optional<std::vector<paddle::Tensor>>* x);
+  void operator()(const paddle::optional<std::vector<paddle::Tensor>>* x);
 
   // skip other type args, these args don't used in kernel selection
   template <typename T>
@@ -352,7 +364,7 @@ void ConvertAllInputsToDistTensor(const phi::distributed::ProcessMesh* mesh,
   DistTensorConverter(mesh).apply(&args...);
 }
 
-void ConvertToDistTensor(paddle::Tensor* x,
+void ConvertToDistTensor(const paddle::Tensor* x,
                          const phi::distributed::ProcessMesh* mesh);
 
 void inline CUDAErrorCheck(const std::string& check_tag) {

--- a/paddle/fluid/eager/utils.h
+++ b/paddle/fluid/eager/utils.h
@@ -328,7 +328,6 @@ struct DistTensorConverter : ArgsIterator<DistTensorConverter> {
   void operator()(paddle::Tensor* x);
   void operator()(const paddle::Tensor* x);
   void operator()(const paddle::Tensor& x);
-  void operator()(const paddle::optional<paddle::Tensor>* x);
   void operator()(std::vector<paddle::Tensor>* x);
   void operator()(const std::vector<paddle::Tensor> x);
   void operator()(paddle::optional<std::vector<paddle::Tensor>>* x);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
 Bug fixes

### Description
<!-- Describe what you’ve done -->
非 dsit tensor 跑反向的时候出现段错误
这里修复：
1、在自动代码生成 op_ad_func 中添加 dense2dist 转换
2、 DistTensorConverter 补全一些 const 类型的重载，避免优先调用模版函数
3、梯度累积 调用 add_ad_func 时补全对 dist 和 dense tensor 的支持
Pcard-90697
