### PR TITLE
修复fix_any.h在cpplint上的报错

### DIFF
--- a/paddle/utils/any.h
+++ b/paddle/utils/any.h
@@ -36,7 +36,7 @@ class any {
   any() : content(0) {}
 
   template <typename ValueType>
-  explicit any(const ValueType &value)
+  any(const ValueType &value)  // NOLINT(runtime/explicit)
       : content(new holder<ValueType>(value)) {}
 
   any(const any &other) : content(other.content ? other.content->clone() : 0) {}

--- a/paddle/utils/any.h
+++ b/paddle/utils/any.h
@@ -51,7 +51,7 @@ class any {
 
   template <typename ValueType>
   any &operator=(const ValueType &rhs) {
-    explicit any(rhs).swap(*this);
+    any(rhs).swap(*this);  // NOLINT(runtime/explicit)
     return *this;
   }
 

--- a/paddle/utils/any.h
+++ b/paddle/utils/any.h
@@ -127,20 +127,18 @@ inline const ValueType *any_cast(const any *operand) {
 
 template <typename ValueType>
 ValueType any_cast(const any &operand) {
-  typedef typename std::remove_reference<ValueType>::type nonref;
+  using nonref = typename std::remove_reference<ValueType>::type;
 
-  // If 'nonref' is still reference type, it means the user has not
-  // specialized 'remove_reference'.
-
-  // Please use BOOST_BROKEN_COMPILER_TYPE_TRAITS_SPECIALIZATION macro
-  // to generate specialization of remove_reference for your class
-  // See type traits library documentation for details
   static_assert(!std::is_reference<nonref>::value,
                 "!std::is_reference<nonref>::value");
 
-  nonref *result = any_cast<nonref>(&operand);
-  if (!result) throw bad_any_cast();
-  return *result;
+  if constexpr (std::is_pointer_v<nonref>) {
+    return unsafe_any_cast<nonref>(&operand);
+  } else {
+    nonref *result = unsafe_any_cast<nonref>(&operand);
+    if (!result) throw bad_any_cast();
+    return *result;
+  }
 }
 
 // Note: The "unsafe" versions of any_cast are not part of the

--- a/paddle/utils/any.h
+++ b/paddle/utils/any.h
@@ -1,3 +1,4 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
 // This file copy from boost/any.hpp and boost version: 1.41.0
 // Modified the following points:
 // 1. modify namespace from boost::any to paddle::any
@@ -20,7 +21,7 @@
 #include <typeinfo>
 
 // See boost/python/type_id.hpp
-// TODO: add BOOST_TYPEID_COMPARE_BY_NAME to config.hpp
+// TODO(name): add BOOST_TYPEID_COMPARE_BY_NAME to config.hpp
 #if (defined(__GNUC__) && __GNUC__ >= 3) || defined(_AIX) || \
     (defined(__sgi) && defined(__host_mips)) ||              \
     (defined(__hpux) && defined(__HP_aCC)) ||                \
@@ -35,7 +36,8 @@ class any {
   any() : content(0) {}
 
   template <typename ValueType>
-  any(const ValueType &value) : content(new holder<ValueType>(value)) {}
+  explicit any(const ValueType &value)
+      : content(new holder<ValueType>(value)) {}
 
   any(const any &other) : content(other.content ? other.content->clone() : 0) {}
 
@@ -49,7 +51,7 @@ class any {
 
   template <typename ValueType>
   any &operator=(const ValueType &rhs) {
-    any(rhs).swap(*this);
+    explicit any(rhs).swap(*this);
     return *this;
   }
 
@@ -79,7 +81,7 @@ class any {
   template <typename ValueType>
   class holder : public placeholder {
    public:  // structors
-    holder(const ValueType &value) : held(value) {}
+    explicit holder(const ValueType &value) : held(value) {}
 
    public:  // queries
     virtual const std::type_info &type() const { return typeid(ValueType); }
@@ -114,7 +116,7 @@ ValueType *any_cast(any *operand) {
 #else
                  operand->type() == typeid(ValueType)
 #endif
-             ? &static_cast<any::holder<ValueType> *>(operand->content)->held
+             ? &(static_cast<any::holder<ValueType> *>(operand->content)->held)
              : 0;
 }
 
@@ -124,7 +126,7 @@ inline const ValueType *any_cast(const any *operand) {
 }
 
 template <typename ValueType>
-ValueType any_cast(any &operand) {
+ValueType any_cast(const any &operand) {
   typedef typename std::remove_reference<ValueType>::type nonref;
 
   // If 'nonref' is still reference type, it means the user has not
@@ -160,7 +162,7 @@ inline ValueType any_cast(const any &operand) {
 // different shared libraries.
 template <typename ValueType>
 inline ValueType *unsafe_any_cast(any *operand) {
-  return &static_cast<any::holder<ValueType> *>(operand->content)->held;
+  return &(static_cast<any::holder<ValueType> *>(operand->content)->held);
 }
 
 template <typename ValueType>

--- a/paddle/utils/any.h
+++ b/paddle/utils/any.h
@@ -143,18 +143,6 @@ ValueType any_cast(const any &operand) {
   return *result;
 }
 
-template <typename ValueType>
-inline ValueType any_cast(const any &operand) {
-  typedef typename std::remove_reference<ValueType>::type nonref;
-
-  // The comment in the above version of 'any_cast' explains when this
-  // assert is fired and what to do.
-  static_assert(!std::is_reference<nonref>::value,
-                "!std::is_reference<nonref>::value");
-
-  return any_cast<const nonref &>(const_cast<any &>(operand));
-}
-
 // Note: The "unsafe" versions of any_cast are not part of the
 // public interface and may be removed at any time. They are
 // required where we know what type is stored in the any and can't

--- a/paddle/utils/any.h
+++ b/paddle/utils/any.h
@@ -126,19 +126,34 @@ inline const ValueType *any_cast(const any *operand) {
 }
 
 template <typename ValueType>
-ValueType any_cast(const any &operand) {
-  using nonref = typename std::remove_reference<ValueType>::type;
+// NOLINTNEXTLINE(runtime/references)
+ValueType any_cast(any &operand) {
+  typedef typename std::remove_reference<ValueType>::type nonref;
 
+  // If 'nonref' is still reference type, it means the user has not
+  // specialized 'remove_reference'.
+
+  // Please use BOOST_BROKEN_COMPILER_TYPE_TRAITS_SPECIALIZATION macro
+  // to generate specialization of remove_reference for your class
+  // See type traits library documentation for details
   static_assert(!std::is_reference<nonref>::value,
                 "!std::is_reference<nonref>::value");
 
-  if constexpr (std::is_pointer_v<nonref>) {
-    return unsafe_any_cast<nonref>(&operand);
-  } else {
-    nonref *result = unsafe_any_cast<nonref>(&operand);
-    if (!result) throw bad_any_cast();
-    return *result;
-  }
+  nonref *result = any_cast<nonref>(&operand);
+  if (!result) throw bad_any_cast();
+  return *result;
+}
+
+template <typename ValueType>
+inline ValueType any_cast(const any &operand) {
+  typedef typename std::remove_reference<ValueType>::type nonref;
+
+  // The comment in the above version of 'any_cast' explains when this
+  // assert is fired and what to do.
+  static_assert(!std::is_reference<nonref>::value,
+                "!std::is_reference<nonref>::value");
+
+  return any_cast<const nonref &>(const_cast<any &>(operand));
 }
 
 // Note: The "unsafe" versions of any_cast are not part of the


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修复fix_any.h当前文件在cpplint上的报错，主要涉及到：
- 版权声明
- TODO 注释必须带责任人
- explicit 修饰单参数构造函数
- 对解引用的值再取地址添加括号逻辑清晰
- 不推荐函数参数是非 const 引用，添加const引用

注：
- 由于54行工具误报，添加了`// NOLINT(runtime/explicit)`
- 24行`// TODO(name): add BOOST_TYPEID_COMPARE_BY_NAME to config.hpp`中的(name)请改为实际id
- 129行添加了`// NOLINT(runtime/explicit)`，`boost::any `的设计就是按值返回，按照cpplint如果修改成const会导致和下面函数定义重复，如果改成指针，会改变接口语义，调用处全都要改
