### PR TITLE
2nd-batch-24-修复函数命名和预期语义

### DIFF
--- a/paddle/cinn/ir/intrinsic_ops.h
+++ b/paddle/cinn/ir/intrinsic_ops.h
@@ -67,7 +67,7 @@ class IntrinsicOp : public IrNode {
     return input_types_;
   }
   const llvm::SmallVectorImpl<Type>& output_types() const {
-    return input_types_;
+    return output_types_;
   }
 
   //! Verify the \p input_types and \p output_types matches the signature of


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
第二批-编号24(共1处)
将返回值从 `input_types_` 更正为 `output_types_`，确保 `output_types()` 正确返回对象中存储的输出类型列表，符合函数命名和预期语义。
