### PR TITLE
2nd-batch-25-修复条件判断的语法错误

### DIFF
--- a/paddle/cinn/ir/ir_analyzer/data_dependency_graph.cc
+++ b/paddle/cinn/ir/ir_analyzer/data_dependency_graph.cc
@@ -258,7 +258,7 @@ bool DataDependencyGraph::HasEdge(unsigned src_id, unsigned dst_id) {
     return false;
   };
 
-  if (out_edges_.count(src_id == 0) || in_edges_.count(dst_id) == 0) {
+  if (out_edges_.count(src_id) == 0 || in_edges_.count(dst_id) == 0) {
     return false;
   }
   return CheckEdges(dst_id, out_edges_[src_id]) &&


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
第二批-编号25(共1处)
该条件本应判断 `src_id` 是否在 `out_edges_` 映射中（即是否有从 `src_id` 出发的边），但错误地写成了 `out_edges_.count(src_id == 0)`。由于 `src_id == 0` 是一个布尔表达式，其结果为 `true`（1）或 `false`（0），因此实际查询的是 `out_edges_` 是否包含键 `0` 或 `1`，完全偏离了原意。
将 `out_edges_.count(src_id == 0)` 修正为 `out_edges_.count(src_id) == 0`，正确判断 `src_id` 是否存在于 `out_edges_` 的键集合中。