### PR TITLE
2nd-batch-26to29-修复数值类型和精度的错误问题

### DIFF
--- a/paddle/cinn/ir/ir_base.cc
+++ b/paddle/cinn/ir/ir_base.cc
@@ -222,10 +222,10 @@ bfloat16 Expr::as_bfloat16() const {
   return bfloat16(As<FloatImm>()->value);
 }
 float16 Expr::as_float16() const {
-  PADDLE_ENFORCE_EQ(type().is_bfloat16(),
+  PADDLE_ENFORCE_EQ(type().is_float16(),
                     true,
                     ::common::errors::InvalidArgument(
-                        "Invalid type. The type must be bfloat16() type."));
+                        "Invalid type. The type must be float16() type."));
   return float16(As<FloatImm>()->value);
 }
 float Expr::as_float() const {

--- a/paddle/cinn/lang/builtin.cc
+++ b/paddle/cinn/lang/builtin.cc
@@ -204,8 +204,8 @@ Expr max_value(const Type& type) {
   FOR_CASE(float)
   FOR_CASE(double)
 #undef FOR_CASE
-
-  CINN_NOT_IMPLEMENTED
+  PADDLE_THROW(::common::errors::InvalidArgument(
+      "Unsupported type for max_value: %s", type));
   return Expr();
 }
 

--- a/paddle/cinn/runtime/cinn_runtime.cc
+++ b/paddle/cinn/runtime/cinn_runtime.cc
@@ -663,23 +663,23 @@ cinn_type_t cinn_type_of<double>() {
 
 template <>
 cinn_type_t cinn_type_of<float*>() {
-  return cinn_float64_t();
+  return cinn_float32_t(1);
 }
 template <>
 cinn_type_t cinn_type_of<double*>() {
-  return cinn_float64_t();
+  return cinn_float64_t(1);
 }
 template <>
 cinn_type_t cinn_type_of<bfloat16*>() {
-  return cinn_float64_t();
+  return cinn_bfloat16_t(1);
 }
 template <>
 cinn_type_t cinn_type_of<float8e4m3*>() {
-  return cinn_float64_t();
+  return cinn_float8e4m3_t(1);
 }
 template <>
 cinn_type_t cinn_type_of<float16*>() {
-  return cinn_float64_t();
+  return cinn_float16_t(1);
 }
 
 #include "paddle/cinn/runtime/cinn_x86_device_impl.cc"

--- a/paddle/cinn/runtime/cinn_runtime.cc
+++ b/paddle/cinn/runtime/cinn_runtime.cc
@@ -677,7 +677,6 @@ template <>
 cinn_type_t cinn_type_of<float8e4m3*>() {
   return cinn_float8e4m3_t(1);
 }
-//
 template <>
 cinn_type_t cinn_type_of<float16*>() {
   return cinn_float16_t(1);

--- a/paddle/cinn/runtime/cinn_runtime.cc
+++ b/paddle/cinn/runtime/cinn_runtime.cc
@@ -677,6 +677,7 @@ template <>
 cinn_type_t cinn_type_of<float8e4m3*>() {
   return cinn_float8e4m3_t(1);
 }
+//
 template <>
 cinn_type_t cinn_type_of<float16*>() {
   return cinn_float16_t(1);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
第二批-编号26、27、28、29(共4处)

- 函数名为 `as_float16`，意图是将表达式转换为 `float16` 类型的值。但是其类型检查调用的是 `type().is_bfloat16()`
- 移除 `CINN_NOT_IMPLEMENTED`，替换为明确的异常抛出，确保所有不支持的类型都给出清晰错误信息。
- 根据原始数据类型的位宽和类型构造对应的 `cinn_type_t`，并传入正确的 `num_asterisks=1` 表示一级指针。
- 修复 `cinn_type_of<bfloat16*>()` 的返回值从错误的 `cinn_float64_t()` 为正确的 `cinn_bfloat16_t(1)`