### PR TITLE
2nd-batch-31-移除重复的函数声明

### DIFF
--- a/paddle/ap/include/axpr/builtin_functions.h
+++ b/paddle/ap/include/axpr/builtin_functions.h
@@ -89,9 +89,6 @@ Result<axpr::Value> Max(const axpr::Value&,
 Result<axpr::Value> Min(const axpr::Value&,
                         const std::vector<axpr::Value>& args);
 
-Result<axpr::Value> Min(const axpr::Value&,
-                        const std::vector<axpr::Value>& args);
-
 Result<axpr::Value> GetAttr(axpr::InterpreterBase<axpr::Value>* interpreter,
                             const axpr::Value&,
                             const std::vector<axpr::Value>& args);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
第二批-编号31（共1处)
在命名空间 `ap::axpr` 中，函数 `Min` 被完全相同地声明了两次。这两个声明具有相同的函数名、参数类型和返回类型，属于重复声明，在 C++ 中是非法的，会触发编译错误。