### PR TITLE
2nd-batch-32-提取虚部浮点值错误

### DIFF
--- a/paddle/ap/include/axpr/data_value_method_class.h
+++ b/paddle/ap/include/axpr/data_value_method_class.h
@@ -334,7 +334,7 @@ struct MethodClassImpl<ValueT, TypeImpl<DataValue>> {
                "the argument 2 of DataValue.complex64() should be a DataValue, "
                "but a " +
                axpr::GetTypeName(args.at(1)) + " were given"};
-    ADT_LET_CONST_REF(imag, real_val.template TryGet<float>())
+    ADT_LET_CONST_REF(imag, imag_val.template TryGet<float>())
         << adt::errors::TypeError{
                std::string() +
                "the argument 2 of DataValue.complex64() should be a float32, "


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
第二批-编号32（共1处)
此处试图从 `real_val`（第一个参数）中提取虚部浮点值，而不是从 `imag_val`（第二个参数）中提取，这导致了对虚部值的来源错误引用。错误消息中也提到了 `imag_val.GetType()`，但实际提取的是 `real_val` 的值，造成逻辑不一致。