### PR TITLE
[Distributed] Add PipelineDatasetPreprocessor to aviod mem leaks in pipeline parallel

### DIFF
--- a/python/paddle/distributed/fleet/meta_parallel/__init__.py
+++ b/python/paddle/distributed/fleet/meta_parallel/__init__.py
@@ -31,6 +31,7 @@ from .pipeline_parallel import (  # noqa: F401
     PipelineParallelMicroStepLocations,
     PipelineParallelWithInterleave,
     PipelineParallelWithInterleaveFthenB,
+    PipelineDatasetPreprocessor,
     VPPFhenBInBalancedMemory,
     register_global_pipeline_parallel_hook,
 )


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Distributed Strategy

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
Pass a local function to forward_backward_pipeline instead of the dataset itself. This prevents the dataset from being passed as a direct argument to forward_backward_pipeline, which would create additional reference counts that cannot be cleared, leading to GPU memory leaks.

pcard-76459

