### PR TITLE
2nd-batch-35-修复代码语法错误

### DIFF
--- a/paddle/ap/include/axpr/global_environment.h
+++ b/paddle/ap/include/axpr/global_environment.h
@@ -43,7 +43,7 @@ class GlobalEnvironment : public Environment<ValueT> {
         ADT_CHECK(SerializableValue::IsSerializable(val)) << [&] {
           std::ostringstream ss;
           ss << "Only serializable values are supported insert into global "
-                "environment. " ss
+                "environment. "
              << "Builtin serializable types are: ";
           ss << SerializableValue::SerializableTypeNames();
           ss << " (not include '" << axpr::GetTypeName(val) << "').";

--- a/paddle/ap/include/axpr/global_environment.h
+++ b/paddle/ap/include/axpr/global_environment.h
@@ -41,7 +41,7 @@ class GlobalEnvironment : public Environment<ValueT> {
       static std::string tmp_var_prefix("__");
       if (var.substr(0, tmp_var_prefix.size()) != tmp_var_prefix) {
         ADT_CHECK(SerializableValue::IsSerializable(val)) << [&] {
-          std::ostringstream ss;
+          std::ostringstream ss;  //
           ss << "Only serializable values are supported insert into global "
                 "environment. "
              << "Builtin serializable types are: ";

--- a/paddle/ap/include/axpr/global_environment.h
+++ b/paddle/ap/include/axpr/global_environment.h
@@ -41,7 +41,7 @@ class GlobalEnvironment : public Environment<ValueT> {
       static std::string tmp_var_prefix("__");
       if (var.substr(0, tmp_var_prefix.size()) != tmp_var_prefix) {
         ADT_CHECK(SerializableValue::IsSerializable(val)) << [&] {
-          std::ostringstream ss;  //
+          std::ostringstream ss;
           ss << "Only serializable values are supported insert into global "
                 "environment. "
              << "Builtin serializable types are: ";


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
第二批-编号35（共1处)
在 lambda 表达式内部，`ss` 流对象被用于构建错误信息字符串。但在 `"environment. " ss` 这一部分，字符串字面量和变量 `ss` 之间缺少 `<<` 操作符，导致 C++ 编译器无法解析，产生语法错误。
删除错误拼接语法 `"environment. " ss` 中多余的 `ss`，并在字符串后使用 `<<` 操作符继续追加后续内容。