### PR TITLE
2nd-batch-36-修复特殊情况检查缺失

### DIFF
--- a/paddle/ap/include/axpr/string_method_class.h
+++ b/paddle/ap/include/axpr/string_method_class.h
@@ -92,12 +92,19 @@ struct StringMethodClass {
   std::string Replace(std::string self,
                       const std::string& pattern,
                       const std::string& replacement) {
-    while (true) {
-      std::size_t pos = self.find(pattern);
-      if (pos == std::string::npos) {
-        break;
+    if (pattern.empty()) {
+      std::string result;
+      for (char c : self) {
+        result += replacement;
+        result += c;
       }
-      self = self.replace(pos, pattern.size(), replacement);
+      result += replacement;
+      return result;
+    }
+    std::size_t pos = 0;
+    while ((pos = self.find(pattern, pos)) != std::string::npos) {
+      self.replace(pos, pattern.size(), replacement);
+      pos += replacement.size();
     }
     return self;
   }

--- a/paddle/ap/include/code_module/api_wrapper_project_maker.h
+++ b/paddle/ap/include/code_module/api_wrapper_project_maker.h
@@ -165,7 +165,7 @@ struct ApiWrapperProjectMaker {
         },
         [&](axpr::CppDataType<adt::Undefined>) -> RetT { return "void"; });
   }
-  //
+
   adt::Result<std::string> GenCode4PointerType(
       const axpr::PointerType& pointer_type) {
     using RetT = adt::Result<std::string>;

--- a/paddle/ap/include/code_module/api_wrapper_project_maker.h
+++ b/paddle/ap/include/code_module/api_wrapper_project_maker.h
@@ -165,7 +165,7 @@ struct ApiWrapperProjectMaker {
         },
         [&](axpr::CppDataType<adt::Undefined>) -> RetT { return "void"; });
   }
-
+  //
   adt::Result<std::string> GenCode4PointerType(
       const axpr::PointerType& pointer_type) {
     using RetT = adt::Result<std::string>;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
第二批-编号36（共1处)
当 `pattern` 为空字符串时，`self.find(pattern)` 永远返回 `0`（C++ 标准允许此行为），然后调用 `self.replace(0, 0, replacement)` 相当于在字符串开头插入 `replacement`。由于未更新搜索起始位置，下一轮 `find` 依然从头开始并再次匹配空串，导致无限循环，持续在开头插入 `replacement`，造成性能退化甚至崩溃。
- 首先特判 `pattern.empty()` 的情况，按照常见语言（如 Python）语义处理：在每个字符前后插入 `replacement`。
- 对非空 `pattern`，使用 `find(pattern, pos)` 从当前位置继续搜索，避免回退。
- 替换后将 `pos` 增加 `replacement.size()`，确保不会重新匹配刚刚插入的内容，防止无限循环。