### PR TITLE
2nd-batch-39to40-代码条件判断逻辑错误

### DIFF
--- a/paddle/ap/include/code_module/project_compile_helper.h
+++ b/paddle/ap/include/code_module/project_compile_helper.h
@@ -55,7 +55,12 @@ struct ProjectCompileHelper {
       const Directory<File>& directory, const std::string& relative_dir_path) {
     std::string dir_path = this->workspace_dir + "/" + relative_dir_path;
     std::string cmd = std::string() + "mkdir -p " + dir_path;
-    ADT_CHECK(WEXITSTATUS(std::system(cmd.c_str())) == 0);
+    std::string cmd = std::string() + "mkdir -p " + dir_path;
+    int ret = std::system(cmd.c_str());
+    ADT_CHECK(ret != -1 && WIFEXITED(ret) && WEXITSTATUS(ret) == 0)
+        << adt::errors::RuntimeError{std::string() +
+                                     "mkdir failed. dir_path: " + dir_path +
+                                     ", system return: " + std::to_string(ret)};
     using Ok = adt::Result<adt::Ok>;
     for (const auto& [dentry, file] : directory.dentry2file->storage) {
       ADT_RETURN_IF_ERR(file.Match(

--- a/paddle/ap/include/code_module/project_compile_helper.h
+++ b/paddle/ap/include/code_module/project_compile_helper.h
@@ -55,7 +55,6 @@ struct ProjectCompileHelper {
       const Directory<File>& directory, const std::string& relative_dir_path) {
     std::string dir_path = this->workspace_dir + "/" + relative_dir_path;
     std::string cmd = std::string() + "mkdir -p " + dir_path;
-    std::string cmd = std::string() + "mkdir -p " + dir_path;
     int ret = std::system(cmd.c_str());
     ADT_CHECK(ret != -1 && WIFEXITED(ret) && WEXITSTATUS(ret) == 0)
         << adt::errors::RuntimeError{std::string() +

--- a/paddle/ap/include/drr/source_pattern_ctx.h
+++ b/paddle/ap/include/drr/source_pattern_ctx.h
@@ -29,7 +29,7 @@ struct SourcePatternCtxImpl {
   TensorPatternCtx tensor_pattern_ctx;
 
   bool operator==(const SourcePatternCtxImpl& other) const {
-    return this != &other;
+    return this == &other;
   }
 };
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
第二批-编号39、40（共2处)

- 应先判断 `std::system` 是否返回 -1（表示系统调用失败），再通过 `WIFEXITED` 确保进程正常退出，最后使用 `WEXITSTATUS` 获取退出码。原代码跳过了前两步，存在逻辑漏洞，可能导致错误被掩盖或误判。修复后增强了健壮性和可读性，确保真正检查了命令执行结果。
- 该函数本应判断两个 `SourcePatternCtxImpl` 对象的地址是否相等，但实际实现为 `this != &other`，即判断当前对象与参数对象的地址是否不同。
