### PR TITLE
[Stride] Support Matmul Kernel with Transposed Input

### DIFF
--- a/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
@@ -216,6 +216,7 @@ strided_op_list = {
     "unsqueeze",
     "view_shape",
     "view_dtype",
+    "matmul",
 }
 
 strided_op_need_flags_check_list = {
@@ -233,6 +234,7 @@ strided_op_need_flags_check_list = {
     "unbind_",
     "view_shape_",
     "view_dtype_",
+    "matmul_",
 }
 
 

--- a/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
@@ -216,7 +216,6 @@ strided_op_list = {
     "unsqueeze",
     "view_shape",
     "view_dtype",
-    "matmul",
 }
 
 strided_op_need_flags_check_list = {
@@ -234,7 +233,6 @@ strided_op_need_flags_check_list = {
     "unbind_",
     "view_shape_",
     "view_dtype_",
-    "matmul_",
 }
 
 
@@ -651,6 +649,7 @@ COMMON_DECLARE_bool(check_nan_inf);
 COMMON_DECLARE_int32(call_stack_level);
 COMMON_DECLARE_string(tensor_operants_mode);
 COMMON_DECLARE_bool(use_stride_kernel);
+COMMON_DECLARE_bool(use_stride_compute_kernel);
 COMMON_DECLARE_bool(check_cuda_error);
 static std::string separator = "==========================";
 {}
@@ -1358,7 +1357,7 @@ class DygraphFunctionGeneratorBase(FunctionGeneratorBase):
             for name, (ttype, pos) in forward_inputs_position_map.items():
                 if name in need_pre_contiguous_set:
                     pre_contiguous_list.append(
-                        f"{indent}const auto& {name}_tmp = (require_any_grad && {name}.is_dense_tensor() && !std::dynamic_pointer_cast<phi::DenseTensor>({name}.impl())->meta().is_contiguous()) ? paddle::Tensor(std::make_shared<phi::DenseTensor>(paddle::experimental::Trans2Contiguous(*(std::dynamic_pointer_cast<phi::DenseTensor>({name}.impl())))), {name}.mutable_autograd_meta(), {name}.name()) : {name};"
+                        f"{indent}const auto& {name}_tmp = (!FLAGS_use_stride_compute_kernel && require_any_grad && {name}.is_dense_tensor() && !std::dynamic_pointer_cast<phi::DenseTensor>({name}.impl())->meta().is_contiguous()) ? paddle::Tensor(std::make_shared<phi::DenseTensor>(paddle::experimental::Trans2Contiguous(*(std::dynamic_pointer_cast<phi::DenseTensor>({name}.impl())))), {name}.mutable_autograd_meta(), {name}.name()) : {name};"
                     )
                     self.inputs_call_list_tmp[pos] = (
                         self.inputs_call_list_tmp[pos] + '_tmp'

--- a/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
@@ -216,6 +216,7 @@ strided_op_list = {
     "unsqueeze",
     "view_shape",
     "view_dtype",
+    "matmul",
 }
 
 strided_op_need_flags_check_list = {
@@ -233,6 +234,7 @@ strided_op_need_flags_check_list = {
     "unbind_",
     "view_shape_",
     "view_dtype_",
+    "matmul_",
 }
 
 
@@ -649,7 +651,6 @@ COMMON_DECLARE_bool(check_nan_inf);
 COMMON_DECLARE_int32(call_stack_level);
 COMMON_DECLARE_string(tensor_operants_mode);
 COMMON_DECLARE_bool(use_stride_kernel);
-COMMON_DECLARE_bool(use_stride_compute_kernel);
 COMMON_DECLARE_bool(check_cuda_error);
 static std::string separator = "==========================";
 {}
@@ -1357,7 +1358,7 @@ class DygraphFunctionGeneratorBase(FunctionGeneratorBase):
             for name, (ttype, pos) in forward_inputs_position_map.items():
                 if name in need_pre_contiguous_set:
                     pre_contiguous_list.append(
-                        f"{indent}const auto& {name}_tmp = (!FLAGS_use_stride_compute_kernel && require_any_grad && {name}.is_dense_tensor() && !std::dynamic_pointer_cast<phi::DenseTensor>({name}.impl())->meta().is_contiguous()) ? paddle::Tensor(std::make_shared<phi::DenseTensor>(paddle::experimental::Trans2Contiguous(*(std::dynamic_pointer_cast<phi::DenseTensor>({name}.impl())))), {name}.mutable_autograd_meta(), {name}.name()) : {name};"
+                        f"{indent}const auto& {name}_tmp = (require_any_grad && {name}.is_dense_tensor() && !std::dynamic_pointer_cast<phi::DenseTensor>({name}.impl())->meta().is_contiguous()) ? paddle::Tensor(std::make_shared<phi::DenseTensor>(paddle::experimental::Trans2Contiguous(*(std::dynamic_pointer_cast<phi::DenseTensor>({name}.impl())))), {name}.mutable_autograd_meta(), {name}.name()) : {name};"
                     )
                     self.inputs_call_list_tmp[pos] = (
                         self.inputs_call_list_tmp[pos] + '_tmp'

--- a/paddle/phi/kernels/stride/matmul_stride_kernel.cu
+++ b/paddle/phi/kernels/stride/matmul_stride_kernel.cu
@@ -15,6 +15,7 @@
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
 
 #include <limits>
+#include <set>
 #include "paddle/common/flags.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
@@ -46,6 +47,51 @@ phi::DenseTensor Tensor2Contiguous(const Context &dev_ctx,
   return dense_out;
 }
 
+bool is_only_transposed(const DDim &shape,
+                        const DDim &stride,
+                        uint64_t offset,
+                        DDim &src_shape,           // NOLINT
+                        DDim &src_stride,          // NOLINT
+                        std::vector<int> &axis) {  // NOLINT
+  if (offset != 0) {
+    return false;
+  }
+  std::set<int> visited_idx;
+  axis.resize(stride.size());
+  for (int i = 0; i < stride.size(); i++) {
+    int64_t max_num = 0;
+    int max_idx = -1;
+    for (int j = 0; j < stride.size(); j++) {
+      if (visited_idx.count(j)) {
+        continue;
+      }
+      if (stride[j] < 1) {
+        return false;
+      }
+      if (stride[j] > max_num) {
+        max_num = stride[j];
+        max_idx = j;
+      }
+    }
+    if (max_idx == -1) {
+      return false;
+    }
+    if (i != 0 && src_stride[i - 1] == max_num) {
+      return false;
+    }
+    visited_idx.insert(max_idx);
+    src_stride[i] = max_num;
+    src_shape[i] = shape[max_idx];
+    axis[max_idx] = i;
+  }
+
+  if (DenseTensorMeta::calc_strides(src_shape) == src_stride) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
 template <typename T, typename Context>
 void MatmulStrideKernel(const Context &dev_ctx,
                         const DenseTensor &x,
@@ -60,6 +106,76 @@ void MatmulStrideKernel(const Context &dev_ctx,
   }
   DenseTensor x_;
   DenseTensor y_;
+
+  //   auto y_meta = y.meta();
+  //   DDim y_stride = y_meta.strides;
+  //   DDim y_shape = y_meta.dims;
+  //   std::vector<int> y_axis;
+
+  //   if (is_only_transposed(x_meta.dims, x_meta.strides, x_meta.offset,
+  //   x_shape, x_stride, x_axis)) {
+  //     printf("x only transposed\n");
+  //     printf("x_shape\n");
+  //     for (int i=0; i<x_shape.size(); i++) {
+  //       printf("%d ", x_shape[i]);
+  //     }
+  //     printf("\n");
+  //     printf("x_stride\n");
+  //     for (int i=0; i<x_stride.size(); i++) {
+  //       printf("%d ", x_stride[i]);
+  //     }
+  //     printf("\n");
+  //     printf("x_axis\n");
+  //     for (int i=0; i<x_axis.size(); i++) {
+  //       printf("%d ", x_axis[i]);
+  //     }
+  //     printf("\n");
+  //   } else {
+  //     printf("x not transposed\n");
+  //     printf("x_shape\n");
+  //     for (int i=0; i<x.dims().size(); i++) {
+  //       printf("%d ", x.dims()[i]);
+  //     }
+  //     printf("\n");
+  //     printf("x_stride\n");
+  //     for (int i=0; i<x.strides().size(); i++) {
+  //       printf("%d ", x.strides()[i]);
+  //     }
+  //     printf("\n");
+  //   }
+
+  // if (is_only_transposed(y_meta.dims, y_meta.strides, y_meta.offset, y_shape,
+  // y_stride, y_axis)) {
+  //     printf("y only transposed\n");
+  //     printf("y_shape\n");
+  //     for (int i=0; i<y_shape.size(); i++) {
+  //       printf("%d ", y_shape[i]);
+  //     }
+  //     printf("\n");
+  //     printf("y_stride\n");
+  //     for (int i=0; i<y_stride.size(); i++) {
+  //       printf("%d ", y_stride[i]);
+  //     }
+  //     printf("\n");
+  //     printf("y_axis\n");
+  //     for (int i=0; i<y_axis.size(); i++) {
+  //       printf("%d ", y_axis[i]);
+  //     }
+  //     printf("\n");
+  //   } else {
+  //     printf("y not transposed\n");
+  //     printf("y_shape\n");
+  //     for (int i=0; i<y.dims().size(); i++) {
+  //       printf("%d ", y.dims()[i]);
+  //     }
+  //     printf("\n");
+  //     printf("y_stride\n");
+  //     for (int i=0; i<y.strides().size(); i++) {
+  //       printf("%d ", y.strides()[i]);
+  //     }
+  //     printf("\n");
+  //   }
+
   if (!FLAGS_use_stride_compute_kernel) {
     if (!x.meta().is_contiguous()) {
       x_ = Tensor2Contiguous<Context>(dev_ctx, x);
@@ -83,6 +199,63 @@ void MatmulStrideKernel(const Context &dev_ctx,
         dev_ctx, x_, y_, transpose_x, transpose_y, out);
     return;
   }
+
+  auto x_meta = x.meta();
+  DDim x_stride = x_meta.strides;
+  DDim x_shape = x_meta.dims;
+  std::vector<int> x_axis;
+  auto y_meta = y.meta();
+  DDim y_stride = y_meta.strides;
+  DDim y_shape = y_meta.dims;
+  std::vector<int> y_axis;
+
+  if (!x.meta().is_contiguous() && is_only_transposed(x_meta.dims,
+                                                      x_meta.strides,
+                                                      x_meta.offset,
+                                                      x_shape,
+                                                      x_stride,
+                                                      x_axis)) {
+    auto x_trans_dims = x_axis.size();
+    if (x_axis[x_trans_dims - 1] == x_trans_dims - 2 &&
+        x_axis[x_trans_dims - 2] == x_trans_dims - 1) {
+      transpose_x = !transpose_x;
+      x_meta.dims = x_shape;
+      x_meta.strides = x_stride;
+      x_meta.offset = x.offset();
+      x_.set_meta(x_meta);
+    }
+  }
+
+  if (!x_.meta().is_contiguous()) {
+    x_ = Tensor2Contiguous<Context>(dev_ctx, x);
+  }
+
+  if (!y.meta().is_contiguous() && is_only_transposed(y_meta.dims,
+                                                      y_meta.strides,
+                                                      y_meta.offset,
+                                                      y_shape,
+                                                      y_stride,
+                                                      y_axis)) {
+    auto y_trans_dims = y_axis.size();
+    if (y_axis[y_trans_dims - 1] == y_trans_dims - 2 &&
+        y_axis[y_trans_dims - 2] == y_trans_dims - 1) {
+      transpose_y = !transpose_y;
+      y_meta.dims = y_shape;
+      y_meta.strides = y_stride;
+      y_meta.offset = y.offset();
+      y_.set_meta(y_meta);
+    }
+  }
+
+  if (!y_.meta().is_contiguous()) {
+    y_ = Tensor2Contiguous<Context>(dev_ctx, y);
+  }
+
+  auto meta = out->meta();
+  meta.strides = meta.calc_strides(out->dims());
+  out->set_meta(meta);
+  phi::MatmulKernel<T, Context>(dev_ctx, x_, y_, transpose_x, transpose_y, out);
+
   if (!FLAGS_use_stride_compute_kernel) {
     PADDLE_THROW(
         common::errors::Fatal("FLAGS_use_stride_compute_kernel is closed. "

--- a/paddle/phi/kernels/stride/matmul_stride_kernel.cu
+++ b/paddle/phi/kernels/stride/matmul_stride_kernel.cu
@@ -47,6 +47,10 @@ phi::DenseTensor Tensor2Contiguous(const Context &dev_ctx,
   return dense_out;
 }
 
+/**
+ * Check if tensor is only transposed and return the original
+ * contiguous shape/stride and transpose axis mapping.
+ */
 inline bool is_only_transposed_tensor(const DDim &shape,
                                       const DDim &stride,
                                       const uint64_t &offset,

--- a/paddle/phi/kernels/stride/matmul_stride_kernel.cu
+++ b/paddle/phi/kernels/stride/matmul_stride_kernel.cu
@@ -1,0 +1,134 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+
+#include <limits>
+#include "paddle/common/flags.h"
+#include "paddle/phi/backends/gpu/gpu_context.h"
+#include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/core/visit_type.h"
+#include "paddle/phi/kernels/contiguous_kernel.h"
+#include "paddle/phi/kernels/matmul_kernel.h"
+
+#if defined(__NVCC__) || defined(__HIPCC__) || defined(__xpu__)
+#include "paddle/phi/kernels/funcs/dims_simplifier.h"
+
+#endif
+
+COMMON_DECLARE_bool(use_stride_kernel);
+COMMON_DECLARE_bool(use_stride_compute_kernel);
+
+namespace phi {
+
+template <typename Context>
+phi::DenseTensor Tensor2Contiguous(const Context &dev_ctx,
+                                   const phi::DenseTensor &tensor) {
+  phi::DenseTensor dense_out;
+  phi::MetaTensor meta_input(tensor);
+  phi::MetaTensor meta_out(&dense_out);
+  UnchangedInferMeta(meta_input, &meta_out);
+  PD_VISIT_ALL_TYPES(tensor.dtype(), "Tensor2Contiguous", ([&] {
+                       phi::ContiguousKernel<data_t, Context>(
+                           dev_ctx, tensor, &dense_out);
+                     }));
+  return dense_out;
+}
+
+template <typename T, typename Context>
+void MatmulStrideKernel(const Context &dev_ctx,
+                        const DenseTensor &x,
+                        const DenseTensor &y,
+                        bool transpose_x,
+                        bool transpose_y,
+                        DenseTensor *out) {
+  if (!FLAGS_use_stride_kernel) {
+    PADDLE_THROW(common::errors::Fatal(
+        "FLAGS_use_stride_kernel is closed. Strided kernel "
+        "be called, something wrong has happened!"));
+  }
+  DenseTensor x_;
+  DenseTensor y_;
+  if (!FLAGS_use_stride_compute_kernel) {
+    if (!x.meta().is_contiguous()) {
+      x_ = Tensor2Contiguous<Context>(dev_ctx, x);
+    } else {
+      x_ = x;
+    }
+    if (!y.meta().is_contiguous()) {
+      y_ = Tensor2Contiguous<Context>(dev_ctx, y);
+    } else {
+      y_ = y;
+    }
+  } else {
+    x_ = x;
+    y_ = y;
+  }
+  if (x_.meta().is_contiguous() && y_.meta().is_contiguous()) {
+    auto meta = out->meta();
+    meta.strides = meta.calc_strides(out->dims());
+    out->set_meta(meta);
+    phi::MatmulKernel<T, Context>(
+        dev_ctx, x_, y_, transpose_x, transpose_y, out);
+    return;
+  }
+  if (!FLAGS_use_stride_compute_kernel) {
+    PADDLE_THROW(
+        common::errors::Fatal("FLAGS_use_stride_compute_kernel is closed. "
+                              "Kernel using DenseTensorIterator "
+                              "be called, something wrong has happened!"));
+  }
+}
+
+}  // namespace phi
+
+#if CUDA_VERSION >= 12010 && defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 890
+PD_REGISTER_KERNEL(matmul,
+                   GPU,
+                   STRIDED,
+                   phi::MatmulStrideKernel,
+                   float,
+                   double,
+                   int32_t,
+                   int64_t,
+                   phi::float8_e4m3fn,
+                   phi::float16,
+                   phi::bfloat16,
+                   phi::complex64,
+                   phi::complex128,
+                   int8_t) {
+#else
+PD_REGISTER_KERNEL(matmul,
+                   GPU,
+                   STRIDED,
+                   phi::MatmulStrideKernel,
+                   float,
+                   double,
+                   int32_t,
+                   int64_t,
+                   phi::float16,
+                   phi::bfloat16,
+                   phi::complex64,
+                   phi::complex128,
+                   int8_t) {
+#endif
+  if (kernel_key.dtype() == phi::DataType::INT8) {
+    kernel->OutputAt(0).SetDataType(phi::DataType::INT32);
+  }
+  if (kernel_key.dtype() == phi::DataType::FLOAT8_E4M3FN) {
+    kernel->OutputAt(0).SetDataType(phi::DataType::FLOAT16);
+  }
+}
+
+#endif

--- a/paddle/phi/kernels/stride/matmul_stride_kernel.cu
+++ b/paddle/phi/kernels/stride/matmul_stride_kernel.cu
@@ -132,6 +132,13 @@ void MatmulStrideKernel(const Context &dev_ctx,
     return;
   }
 
+  if (!FLAGS_use_stride_compute_kernel) {
+    PADDLE_THROW(
+        common::errors::Fatal("FLAGS_use_stride_compute_kernel is closed. "
+                              "Kernel using DenseTensorIterator "
+                              "be called, something wrong has happened!"));
+  }
+
   auto x_meta = x.meta();
   DDim x_stride = x_meta.strides;
   DDim x_shape = x_meta.dims;
@@ -187,13 +194,6 @@ void MatmulStrideKernel(const Context &dev_ctx,
   meta.strides = meta.calc_strides(out->dims());
   out->set_meta(meta);
   phi::MatmulKernel<T, Context>(dev_ctx, x_, y_, transpose_x, transpose_y, out);
-
-  if (!FLAGS_use_stride_compute_kernel) {
-    PADDLE_THROW(
-        common::errors::Fatal("FLAGS_use_stride_compute_kernel is closed. "
-                              "Kernel using DenseTensorIterator "
-                              "be called, something wrong has happened!"));
-  }
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/stride/matmul_stride_kernel.cu
+++ b/paddle/phi/kernels/stride/matmul_stride_kernel.cu
@@ -107,75 +107,6 @@ void MatmulStrideKernel(const Context &dev_ctx,
   DenseTensor x_;
   DenseTensor y_;
 
-  //   auto y_meta = y.meta();
-  //   DDim y_stride = y_meta.strides;
-  //   DDim y_shape = y_meta.dims;
-  //   std::vector<int> y_axis;
-
-  //   if (is_only_transposed(x_meta.dims, x_meta.strides, x_meta.offset,
-  //   x_shape, x_stride, x_axis)) {
-  //     printf("x only transposed\n");
-  //     printf("x_shape\n");
-  //     for (int i=0; i<x_shape.size(); i++) {
-  //       printf("%d ", x_shape[i]);
-  //     }
-  //     printf("\n");
-  //     printf("x_stride\n");
-  //     for (int i=0; i<x_stride.size(); i++) {
-  //       printf("%d ", x_stride[i]);
-  //     }
-  //     printf("\n");
-  //     printf("x_axis\n");
-  //     for (int i=0; i<x_axis.size(); i++) {
-  //       printf("%d ", x_axis[i]);
-  //     }
-  //     printf("\n");
-  //   } else {
-  //     printf("x not transposed\n");
-  //     printf("x_shape\n");
-  //     for (int i=0; i<x.dims().size(); i++) {
-  //       printf("%d ", x.dims()[i]);
-  //     }
-  //     printf("\n");
-  //     printf("x_stride\n");
-  //     for (int i=0; i<x.strides().size(); i++) {
-  //       printf("%d ", x.strides()[i]);
-  //     }
-  //     printf("\n");
-  //   }
-
-  // if (is_only_transposed(y_meta.dims, y_meta.strides, y_meta.offset, y_shape,
-  // y_stride, y_axis)) {
-  //     printf("y only transposed\n");
-  //     printf("y_shape\n");
-  //     for (int i=0; i<y_shape.size(); i++) {
-  //       printf("%d ", y_shape[i]);
-  //     }
-  //     printf("\n");
-  //     printf("y_stride\n");
-  //     for (int i=0; i<y_stride.size(); i++) {
-  //       printf("%d ", y_stride[i]);
-  //     }
-  //     printf("\n");
-  //     printf("y_axis\n");
-  //     for (int i=0; i<y_axis.size(); i++) {
-  //       printf("%d ", y_axis[i]);
-  //     }
-  //     printf("\n");
-  //   } else {
-  //     printf("y not transposed\n");
-  //     printf("y_shape\n");
-  //     for (int i=0; i<y.dims().size(); i++) {
-  //       printf("%d ", y.dims()[i]);
-  //     }
-  //     printf("\n");
-  //     printf("y_stride\n");
-  //     for (int i=0; i<y.strides().size(); i++) {
-  //       printf("%d ", y.strides()[i]);
-  //     }
-  //     printf("\n");
-  //   }
-
   if (!FLAGS_use_stride_compute_kernel) {
     if (!x.meta().is_contiguous()) {
       x_ = Tensor2Contiguous<Context>(dev_ctx, x);
@@ -191,6 +122,7 @@ void MatmulStrideKernel(const Context &dev_ctx,
     x_ = x;
     y_ = y;
   }
+
   if (x_.meta().is_contiguous() && y_.meta().is_contiguous()) {
     auto meta = out->meta();
     meta.strides = meta.calc_strides(out->dims());

--- a/paddle/phi/kernels/stride/matmul_stride_kernel.cu
+++ b/paddle/phi/kernels/stride/matmul_stride_kernel.cu
@@ -47,17 +47,17 @@ phi::DenseTensor Tensor2Contiguous(const Context &dev_ctx,
   return dense_out;
 }
 
-bool is_only_transposed(const DDim &shape,
-                        const DDim &stride,
-                        uint64_t offset,
-                        DDim &src_shape,           // NOLINT
-                        DDim &src_stride,          // NOLINT
-                        std::vector<int> &axis) {  // NOLINT
+inline bool is_only_transposed_tensor(const DDim &shape,
+                                      const DDim &stride,
+                                      const uint64_t &offset,
+                                      DDim *src_shape,
+                                      DDim *src_stride,
+                                      std::vector<int> *axis) {
   if (offset != 0) {
     return false;
   }
   std::set<int> visited_idx;
-  axis.resize(stride.size());
+  axis->resize(stride.size());
   for (int i = 0; i < stride.size(); i++) {
     int64_t max_num = 0;
     int max_idx = -1;
@@ -76,16 +76,16 @@ bool is_only_transposed(const DDim &shape,
     if (max_idx == -1) {
       return false;
     }
-    if (i != 0 && src_stride[i - 1] == max_num) {
+    if (i != 0 && (*src_stride)[i - 1] == max_num) {
       return false;
     }
     visited_idx.insert(max_idx);
-    src_stride[i] = max_num;
-    src_shape[i] = shape[max_idx];
-    axis[max_idx] = i;
+    (*src_stride)[i] = max_num;
+    (*src_shape)[i] = shape[max_idx];
+    (*axis)[max_idx] = i;
   }
 
-  if (DenseTensorMeta::calc_strides(src_shape) == src_stride) {
+  if (DenseTensorMeta::calc_strides(*src_shape) == *src_stride) {
     return true;
   } else {
     return false;
@@ -148,12 +148,12 @@ void MatmulStrideKernel(const Context &dev_ctx,
   DDim y_shape = y_meta.dims;
   std::vector<int> y_axis;
 
-  if (!x.meta().is_contiguous() && is_only_transposed(x_meta.dims,
-                                                      x_meta.strides,
-                                                      x_meta.offset,
-                                                      x_shape,
-                                                      x_stride,
-                                                      x_axis)) {
+  if (!x.meta().is_contiguous() && is_only_transposed_tensor(x_meta.dims,
+                                                             x_meta.strides,
+                                                             x_meta.offset,
+                                                             &x_shape,
+                                                             &x_stride,
+                                                             &x_axis)) {
     auto x_trans_dims = x_axis.size();
     if (x_axis[x_trans_dims - 1] == x_trans_dims - 2 &&
         x_axis[x_trans_dims - 2] == x_trans_dims - 1) {
@@ -169,12 +169,12 @@ void MatmulStrideKernel(const Context &dev_ctx,
     x_ = Tensor2Contiguous<Context>(dev_ctx, x);
   }
 
-  if (!y.meta().is_contiguous() && is_only_transposed(y_meta.dims,
-                                                      y_meta.strides,
-                                                      y_meta.offset,
-                                                      y_shape,
-                                                      y_stride,
-                                                      y_axis)) {
+  if (!y.meta().is_contiguous() && is_only_transposed_tensor(y_meta.dims,
+                                                             y_meta.strides,
+                                                             y_meta.offset,
+                                                             &y_shape,
+                                                             &y_stride,
+                                                             &y_axis)) {
     auto y_trans_dims = y_axis.size();
     if (y_axis[y_trans_dims - 1] == y_trans_dims - 2 &&
         y_axis[y_trans_dims - 2] == y_trans_dims - 1) {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->
pcard-67164

之前由于Matmul一直被注册为不支持非连续的算子，因此transposed的输入在进入matmul时会自动被转为连续。
在一般情况下这是正常的，然而如果输入本身是倒数1/2维被transpose，此时可以直接调用cublas nt格式的api，因此转连续是冗余的。

例如：A x B^T = C
当B为transposed输入且转置维度为倒数1/2维时，将直接使用B^T进行矩阵乘，省去了B^T转为B的开销

本PR可以解决这个问题，在处理108, 64, 2000 float32数据量的输入时可使matmul性能提升约10%