### PR TITLE
2nd-batch-42to43-代码执行流逻辑错误

### DIFF
--- a/paddle/phi/api/lib/api_gen_utils.cc
+++ b/paddle/phi/api/lib/api_gen_utils.cc
@@ -596,7 +596,7 @@ void TransStride(phi::DeviceContext* dev_ctx,
                         to[i]->offset(),
                         to[i]);
         delete from[i];
-        return;
+        continue;
       }
 #endif
     }

--- a/paddle/phi/api/lib/kernel_dispatch.h
+++ b/paddle/phi/api/lib/kernel_dispatch.h
@@ -189,17 +189,17 @@ struct DistTensorTypeParser : ArgsIterator<DistTensorTypeParser> {
   void operator()(const std::vector<Tensor>& x) {
     if (!x.empty()) {
       for (auto& t : x) {
-        result = t.is_dist_tensor();
+        result = result || t.is_dist_tensor();
+        if (short_circuit()) break;
       }
     }
   }
 
   void operator()(const paddle::optional<std::vector<Tensor>>& x) {
-    if (x) {
-      if (!(x.get_ptr()->empty())) {
-        for (auto& t : *(x.get_ptr())) {
-          result = t.is_dist_tensor();
-        }
+    if (x && !x->empty()) {
+      for (auto& t : *(x.get_ptr())) {
+        result = result || t.is_dist_tensor();
+        if (short_circuit()) break;
       }
     }
   }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
第二批-编号42、43（共2处)

- `api_gen_utils.cc`中，当 `dev_ctx` 是 `CustomContext` 时，处理完当前 `i` 索引的 tensor 后，执行 `return;` 会直接退出整个 `TransStride` 函数，导致 `for` 循环无法继续处理后续的 tensor，而其他设备分支使用 `continue;` 会继续下一次循环迭代。将 `return;` 改为 `continue;`，使得在成功处理当前 tensor 后，循环继续执行下一次迭代，处理下一个 tensor，从而保证所有非空的 `to[i]` 都能被正确处理，行为与其他设备分支保持一致。

- `kernel_dispatch.h`中，两个重载函数在遍历 `vector<Tensor>` 时，直接将 `result` 赋值为当前 Tensor 的 `is_dist_tensor()` 结果，未进行逻辑合并（如 `||=`），导致前面 Tensor 的判断结果被覆盖，最终 `result` 仅由容器中最后一个 Tensor 决定，无法正确反映是否存在或全部为分布式 Tensor 的语义。使用 `result = result || t.is_dist_tensor()` 替代直接赋值，确保只要有一个 Tensor 是 `DistTensor`，`result` 就为 `true`。同时加入 `if (short_circuit()) break;` 以保持与 `ArgsIterator` 短路机制的一致性，提升性能。此外，简化了 `x.get_ptr()->empty()` 为 `!x->empty()`，提高可读性。