### PR TITLE
[Precision Depth Alignment] paddle.tanh reverse gradient calculation and Torch accuracy alignment.

### DIFF
--- a/paddle/phi/kernels/funcs/activation_functor.h
+++ b/paddle/phi/kernels/funcs/activation_functor.h
@@ -4483,7 +4483,13 @@ struct CudaTanhGradFunctor : public BaseActivationFunctor<T> {
 
   // dx = dout * (1 - out^2)
   __device__ __forceinline__ T operator()(const T dout, const T out) const {
-    return dout * (one - out * out);
+    if constexpr (std::is_same<T, phi::float16>::value) {
+      __half out_half = __float2half_rn(static_cast<float>(out));
+      __half tmp_half = __hmul(out_half, out_half);
+      return dout * (one - static_cast<T>(__half2float(tmp_half)));
+    } else {
+      return dout * (one - out * out);
+    }
   }
 
   static constexpr ActBwdOpFwdDeps FwdDeps() {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

**主要修改点如下：**
1. 增加对 float16 类型的分支处理，其它类型走原逻辑不变。
2. 在 float16 分支中使用 CUDA half ：将 out 显式转换为半精度，用 __hmul 计算 out^2，显式“先乘”，避免被融合为 FMA。
3. 非 float16 类型保持原实现：dout * (one - out * out)。

**测试结果：**
1. paddle.nn.functional.tanh 全部与torch对齐（共120个case）；
2. paddle.tanh 全部与torch对齐（共142个case）；

pcard-67164