### PR TITLE
Fleety 12

### DIFF
--- a/python/paddle/distributed/fleet/meta_parallel/parallel_layers/pp_layers.py
+++ b/python/paddle/distributed/fleet/meta_parallel/parallel_layers/pp_layers.py
@@ -709,9 +709,11 @@ class PipelineLayer(nn.Layer):
                                 self.shared_layers[layer_name], weight_attr
                             )
                             hcg = fleet.get_hybrid_communicate_group()
+                            # shared_weight_name is set by the user, must be unique globally
                             shared_param.color = {
                                 "color": f"{SHARED_WEIGHT_SYNC_PREFIX}_{comm_key}",
                                 "group": hcg.get_sharding_parallel_group(),
+                                "shared_weight_name": weight_attr,
                                 "broadcast_group": group,
                             }
         return shared_comm

--- a/test/collective/fleet/hybrid_parallel_shared_weight.py
+++ b/test/collective/fleet/hybrid_parallel_shared_weight.py
@@ -29,7 +29,7 @@ from paddle.distributed.fleet.meta_parallel import (
 )
 from paddle.nn import Layer
 
-os.environ['FLAGS_profile_optimizer_details_steps'] = 1
+os.environ['FLAGS_profile_optimizer_details_steps'] = "1"
 
 
 def print_hook_fn(grad):

--- a/test/collective/fleet/hybrid_parallel_shared_weight.py
+++ b/test/collective/fleet/hybrid_parallel_shared_weight.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import random
 import unittest
 
@@ -27,6 +28,8 @@ from paddle.distributed.fleet.meta_parallel import (
     SharedLayerDesc,
 )
 from paddle.nn import Layer
+
+os.environ['FLAGS_profile_optimizer_details_steps'] = 1
 
 
 def print_hook_fn(grad):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Distributed Strategy

### PR Types
<!-- One of [ New features |  | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
当开启流水并行并且在pp_configs中配置sync_param sync_moment时，会在每一个流水步之后，从pp_stage 0向与其共享参数另外的pp_stage 进行参数和优化器状态的同步（broadcast）。

本PR在"参数和优化器状态的同步"过程的多个通信（broadcast）按照global的名称进行排序，避免使用local的名称进行排序导致出现通信交叉而出现hang的问题
pcard-73263

develop PR：https://github.com/PaddlePaddle/Paddle/pull/75365
