### PR TITLE
[CMake4] Fix cmake CMP0175 warning and update cmake_policy version to 3.12

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -10,4 +10,4 @@ coverage:
         threshold: 1% # Allow the coverage to drop by 1%, and posting a success status.
     patch:
       default:
-        target: 90% # lines adjusted  Coverage < 80%  CI will fail
+        target: 90% # lines adjusted  Coverage < 90%  CI will fail

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,10 @@ if(APPLE AND WITH_ARM)
   cmake_policy(VERSION 3.19.2)
 else()
   cmake_minimum_required(VERSION 3.18)
-  cmake_policy(VERSION 3.10)
+  cmake_policy(VERSION 3.12)
 endif()
+# use legacy _LIB_DEPENDS cache entries
+cmake_policy(SET CMP0073 OLD)
 # use modern CMake target handling, disable deprecated LOCATION property
 # use $<TARGET_FILE> generator expression instead of get_property LOCATION
 # https://cmake.org/cmake/help/v4.0/policy/CMP0026.html#cmp0026

--- a/ci/windows/test_fluid_library.bat
+++ b/ci/windows/test_fluid_library.bat
@@ -11,11 +11,7 @@ echo    ========================================
 cd %BUILD_DIR%
 echo %vcvars64_dir%
 call "%vcvars64_dir%"
-
-:: Switch the console codepage to UTF-8 to prevent garbled text
-chcp 65001 >nul 2>&1
 tree /F %cd%\paddle_inference_install_dir\paddle
-
 %cache_dir%\tools\busybox64.exe du -h -d 0 %cd%\paddle_inference_install_dir > lib_size.txt
 type lib_size.txt
 set /p libsize=< lib_size.txt

--- a/ci/windows/test_fluid_library.bat
+++ b/ci/windows/test_fluid_library.bat
@@ -11,7 +11,11 @@ echo    ========================================
 cd %BUILD_DIR%
 echo %vcvars64_dir%
 call "%vcvars64_dir%"
+
+:: Switch the console codepage to UTF-8 to prevent garbled text
+chcp 65001 >nul 2>&1
 tree /F %cd%\paddle_inference_install_dir\paddle
+
 %cache_dir%\tools\busybox64.exe du -h -d 0 %cd%\paddle_inference_install_dir > lib_size.txt
 type lib_size.txt
 set /p libsize=< lib_size.txt

--- a/cmake/cinn.cmake
+++ b/cmake/cinn.cmake
@@ -298,7 +298,7 @@ if(PUBLISH_LIBS)
       TARGET cinnapi
       POST_BUILD
       COMMENT "copy generated proto header '${relname}' to dist"
-      COMMAND cmake -E copy ${proto_header} ${target_name} DEPENDS cinnapi)
+      COMMAND cmake -E copy ${proto_header} ${target_name})
   endforeach()
 
   add_custom_command(
@@ -307,7 +307,7 @@ if(PUBLISH_LIBS)
     COMMAND cmake -E copy ${CMAKE_BINARY_DIR}/libcinnapi.so
             ${CMAKE_BINARY_DIR}/dist/cinn/lib/libcinnapi.so
     COMMAND cmake -E copy_directory ${CINN_THIRD_PARTY_PATH}/install
-            ${CMAKE_BINARY_DIR}/dist/third_party DEPENDS cinnapi)
+            ${CMAKE_BINARY_DIR}/dist/third_party)
   add_custom_command(
     TARGET cinncore_static
     POST_BUILD
@@ -320,8 +320,7 @@ if(PUBLISH_LIBS)
       cmake -E copy
       ${CMAKE_BINARY_DIR}/paddle/cinn/ir/schedule/libschedule_desc_proto.a
       ${CMAKE_BINARY_DIR}/dist/cinn/lib/libschedule_desc_proto.a
-    COMMENT "distribute libcinncore_static.a and related header files." DEPENDS
-            cinncore_static)
+    COMMENT "distribute libcinncore_static.a and related header files.")
 endif()
 # --------distribute cinncore lib and include end--------
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
fix cmake CMP0175 warning && update cmake_policy version to 3.12
1. fix cmake CMP0175 warning 

  add_custom_command 有两种形式，如果是 TARGET，就没有 DEPENDS 关键字，之前会默认忽略，3.31 发出警告
  https://cmake.org/cmake/help/latest/policy/CMP0175.html#policy:CMP0175

2. update cmake_policy version to 3.12（最小支持 cmake 是 3.18，但是策略设置为 3.10 肯定是为了兼容某些旧策略行为，但是兼容的策略行为具体是什么，并没有注释说明，所以先尝试升级到 3.12，找到具体要兼容的旧行为，先手动设置为 OLD，这样以后要修改也更清晰明确）

  提高 cmake_policy VERSION 到 3.12，手动设置 CMP0073 策略行为为 OLD，因为 3.12 提出的 CMP0073 建议取消<tgt>_LIB_DEPENDS 缓存设置，但是目前还是使用了（如果设置了 3.12 ，那么 3.12 以及之前引入的策略都会设置为 NEW）https://github.com/PaddlePaddle/Paddle/blob/a8b4de5f6260e598d6426f7778364d1277b2ad76/cmake/generic.cmake#L235

