### PR TITLE
2nd-batch-54-代码获取参数逻辑错误

### DIFF
--- a/paddle/phi/capi/include/wrapper_base.h
+++ b/paddle/phi/capi/include/wrapper_base.h
@@ -551,7 +551,7 @@ class Kernel : WrapperBase<PD_Kernel> {
 
   TensorArgDef InputAt(size_t idx) { return args_def().input_defs()[idx]; }
 
-  TensorArgDef OutputAt(size_t idx) { return args_def().input_defs()[idx]; }
+  TensorArgDef OutputAt(size_t idx) { return args_def().output_defs()[idx]; }
 };
 
 class MetaTensor : WrapperBase<PD_MetaTensor> {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
第二批-编号54（共1处)
代码在 `Kernel` 类中定义了 `OutputAt` 方法，根据索引 `idx` 获取当前 kernel 的输出参数定义。它错误地从 `input_defs()`（输入参数定义）中获取，而不是 `output_defs()`（输出参数定义）。将 `OutputAt` 方法中返回的 `args_def().input_defs()[idx]` 修改为 `args_def().output_defs()[idx]`，