### PR TITLE
FlashMask v2: add support for head dimension in (64, 96]

### DIFF
--- a/paddle/phi/kernels/gpu/flash_attn_v3_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/flash_attn_v3_grad_kernel.cu
@@ -833,7 +833,7 @@ void FlashMaskV2GradBaseKernel(
       head_size % 8,
       0,
       common::errors::InvalidArgument("head_size should be a multiple of 8"));
-  int const max_headdim = get_max_headdim();
+  int const max_headdim = flashmaskv2_get_max_headdim();
   PADDLE_ENFORCE_LE(
       head_size,
       max_headdim,
@@ -864,26 +864,25 @@ void FlashMaskV2GradBaseKernel(
   is_causal = window_size_left < 0 && window_size_right == 0;
 
   int const arch = dprops.major * 10 + dprops.minor;
-  int const head_size_rounded = round_up_headdim(head_size);
+  int const head_size_rounded = flashmaskv2_round_up_headdim(head_size);
   // Very important that these match the kernel configs
   bool const is_local =
       (window_size_left >= 0 || window_size_right >= 0) && !is_causal;
   bool const is_flashmask = startend_row_indices_.is_initialized();
+
   int const kBlockM_sm90 =
       head_size_rounded <= 64
           ? (is_flashmask && !is_causal)
                 ? 64
                 : (is_causal && softcap || is_flashmask > 0.0 ? 96 : 128)
-          : (head_size_rounded <= 96
-                 ? 64
-                 : (head_size_rounded <= 128
-                        ? (is_flashmask && !is_causal)
+          : (head_size_rounded <= 128
+                 ? (is_flashmask && !is_causal)
+                       ? 64
+                       : (is_causal || is_local || is_flashmask || softcap > 0.0
                               ? 64
-                              : (is_causal || is_local || is_flashmask ||
-                                         softcap > 0.0
-                                     ? 64
-                                     : 80)
-                        : 64));
+                              : 80)
+                 : 64);
+
   int const kBlockM_sm80 = head_size_rounded <= 64 ? 128 : 64;
   int const kBlockM_sm86 = head_size_rounded <= 192 ? 64 : 32;
   int const kBlockM =
@@ -1190,7 +1189,8 @@ void FlashMaskV2GradBaseKernel(
     // TODO(umiswing): refine this block constraint (kBlockN % 32), since some
     // of kBlockN is not divisible by 32 flashmask_maxmin_shape[2] =
     // (flashmask_maxmin_shape[2] + 31) / 32 * 8;
-    flashmask_maxmin_shape[2] = ((flashmask_maxmin_shape[2] + 31) / 32 + 3) / 4 * 4;
+    flashmask_maxmin_shape[2] =
+        ((flashmask_maxmin_shape[2] + 31) / 32 + 3) / 4 * 4;
     flashmask_maxmin_shape[3] = 8;
 
     flashmask_maxmin.set_type(phi::DataType::INT32);

--- a/paddle/phi/kernels/gpu/flash_attn_v3_kernel.cu
+++ b/paddle/phi/kernels/gpu/flash_attn_v3_kernel.cu
@@ -1271,7 +1271,7 @@ void FlashMaskV2BaseKernel(
                       common::errors::InvalidArgument(
                           "batch_size must be equal to batch_size_k"));
   }
-  int const max_headdim = std::min(get_max_headdim(), 128);
+  int const max_headdim = std::min(flashmaskv2_get_max_headdim(), 128);
   PADDLE_ENFORCE_LE(
       head_size,
       max_headdim,
@@ -1441,8 +1441,8 @@ void FlashMaskV2BaseKernel(
   }
 
   auto round_multiple = [](int x, int m) { return (x + m - 1) / m * m; };
-  int const head_size_rounded = round_up_headdim(head_size);
-  int const head_size_v_rounded = round_up_headdim(head_size_v);
+  int const head_size_rounded = flashmaskv2_round_up_headdim(head_size);
+  int const head_size_v_rounded = flashmaskv2_round_up_headdim(head_size_v);
   int const seqlen_q_rounded = round_multiple(seqlen_q, 128);
   int const seqlen_k_rounded = round_multiple(seqlen_k, 128);
 
@@ -1965,7 +1965,8 @@ void FlashMaskV2BaseKernel(
     // TODO(umiswing): refine this block constraint (kBlockN % 32), since some
     // of kBlockN is not divisible by 32 flashmask_maxmin_shape[2] =
     // (flashmask_maxmin_shape[2] + 31) / 32 * 8;
-    flashmask_maxmin_shape[2] = ((flashmask_maxmin_shape[2] + 31) / 32 + 3) / 4 * 4;
+    flashmask_maxmin_shape[2] =
+        ((flashmask_maxmin_shape[2] + 31) / 32 + 3) / 4 * 4;
     flashmask_maxmin_shape[3] = 8;
 
     flashmask_maxmin.set_type(phi::DataType::INT32);

--- a/paddle/phi/kernels/gpu/flash_attn_v3_utils.h
+++ b/paddle/phi/kernels/gpu/flash_attn_v3_utils.h
@@ -68,7 +68,7 @@ inline int get_max_headdim() {
   return 0;
 }
 
-inline int flashmask_v2_get_max_headdim() { return 128; }
+inline int flashmaskv2_get_max_headdim() { return 128; }
 
 inline int round_up_headdim(int head_size) {
 #ifndef FLASHATTENTION_DISABLE_HDIM64

--- a/paddle/phi/kernels/gpu/flash_attn_v3_utils.h
+++ b/paddle/phi/kernels/gpu/flash_attn_v3_utils.h
@@ -68,6 +68,8 @@ inline int get_max_headdim() {
   return 0;
 }
 
+inline int flashmask_v2_get_max_headdim() { return 128; }
+
 inline int round_up_headdim(int head_size) {
 #ifndef FLASHATTENTION_DISABLE_HDIM64
   if (head_size <= 64) {
@@ -92,6 +94,20 @@ inline int round_up_headdim(int head_size) {
 #ifndef FLASHATTENTION_DISABLE_HDIM256
   if (head_size <= 256) {
     return 256;
+  }
+#endif
+  return 256;
+}
+
+inline int flashmaskv2_round_up_headdim(int head_size) {
+#ifndef FLASHATTENTION_DISABLE_HDIM64
+  if (head_size <= 64) {
+    return 64;
+  }
+#endif
+#ifndef FLASHATTENTION_DISABLE_HDIM128
+  if (head_size <= 128) {
+    return 128;
   }
 #endif
   return 256;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
https://github.com/PaddlePaddle/Paddle/pull/75307
add support for head dimension in (64, 96] in flashmask v2