### PR TITLE
Disable NVIDIA_TF32_OVERRIDE by default for better precision.

### DIFF
--- a/python/paddle/base/__init__.py
+++ b/python/paddle/base/__init__.py
@@ -164,6 +164,9 @@ def __bootstrap__():
 
     os.environ['OMP_NUM_THREADS'] = str(num_threads)
 
+    if os.getenv('NVIDIA_TF32_OVERRIDE', None) is None:
+        os.environ['NVIDIA_TF32_OVERRIDE'] = '0'
+
     flag_prefix = "FLAGS_"
     read_env_flags = [
         key[len(flag_prefix) :]


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
默认不开启cublas中的tf32 策略。
修改前flag NVIDIA_TF32_OVERRIDE在CUBLAS等库里默认为1，会引入tf32来加速fp32，牺牲精度。
现与torch行为对齐，参考链接如下:

- https://github.com/pytorch/pytorch/blob/5d749ceb92c2c28bcfbdf918b4ab99b1a91fcb50/docs/source/notes/cuda.rst#L75
- https://github.com/pytorch/pytorch/blob/5d749ceb92c2c28bcfbdf918b4ab99b1a91fcb50/torch/__init__.py#L1610

监控结果：
<img width="1762" height="1286" alt="8c80be03a73f52bbf7c6f4fc9" src="https://github.com/user-attachments/assets/cafbb2a7-86e9-4536-a219-5d0618ab27d6" />


避免FP32 gemm或不带bias的linear 中，13位尾数裁剪带来的大幅精度损失。后续需要进行更细粒度的类型管控。

pcard-93348