### PR TITLE
[fix] 修复softplus激活函数的复数支持

### DIFF
--- a/paddle/phi/kernels/funcs/activation_functor.h
+++ b/paddle/phi/kernels/funcs/activation_functor.h
@@ -860,6 +860,27 @@ struct SoftplusFunctor : public BaseActivationFunctor<T> {
   }
 };
 
+template <typename T>
+struct SoftplusFunctor<ComplexType<T>>
+    : public BaseActivationFunctor<ComplexType<T>> {
+  float beta;
+  float threshold;
+
+  typename BaseActivationFunctor<ComplexType<T>>::AttrPair GetAttrs() {
+    return {{"beta", &beta}, {"threshold", &threshold}};
+  }
+
+  template <typename Device, typename X, typename Out>
+  void operator()(Device d, X x, Out out) const {
+    auto x_beta = static_cast<ComplexType<T>>(beta) * x;
+    out.device(d) =
+        (x_beta > static_cast<ComplexType<T>>(threshold))
+            .select(x,
+                    (static_cast<ComplexType<T>>(1) + x_beta.exp()).log() /
+                        static_cast<ComplexType<T>>(beta));
+  }
+};
+
 // For numerical stability, using the following formula instead of
 // d(softplus(x))/dx = 1 / (1 + exp(-x))
 // d(softplus(x))/dx = 1 / (1 + exp(-beta * x)) when beta * x <= threshold(beta
@@ -4225,6 +4246,30 @@ struct CudaSoftplusFunctor : public BaseActivationFunctor<T> {
     MPType t = static_cast<MPType>(threshold);
     MPType x_beta = x * static_cast<MPType>(beta);
     return static_cast<T>(x_beta > t ? x : log(one + exp(x_beta)) / b);
+  }
+};
+
+template <typename T>
+struct CudaSoftplusFunctor<ComplexType<T>>
+    : public BaseActivationFunctor<ComplexType<T>> {
+  using MPType = typename phi::dtype::MPTypeTrait<ComplexType<T>>::Type;
+  MPType one = static_cast<MPType>(1.0f);
+  float beta;
+  float threshold;
+
+  typename BaseActivationFunctor<ComplexType<T>>::AttrPair GetAttrs() {
+    return {{"beta", &beta}, {"threshold", &threshold}};
+  }
+
+  // softplus(x) = beta * x > threshold ? x : log(1 + exp(beta * x)) / beta
+  __device__ __forceinline__ ComplexType<T> operator()(
+      const ComplexType<T> arg_x) const {
+    MPType x = static_cast<MPType>(arg_x);
+    MPType b = static_cast<MPType>(beta);
+    MPType t = static_cast<MPType>(threshold);
+    MPType x_beta = x * static_cast<MPType>(beta);
+    return static_cast<ComplexType<T>>(x_beta > t ? x
+                                                  : log(one + exp(x_beta)) / b);
   }
 };
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you've done -->
[used AI Studio]
本PR通过实现缺失的复数特化来修复softplus激活函数复数输入的失败测试用例。

Fixes #75483

- 为ComplexType<T>实现了SoftplusFunctor和CudaSoftplusFunctor。
- 为两个functor添加了beta和threshold属性。
- 增强了operator()方法以处理softplus激活的复数计算。


**问题描述:**
- `TestSoftplus_Complex64` 和 `TestSoftplus_Complex128` 测试用例失败
- 缺少 `SoftplusFunctor` 和 `CudaSoftplusFunctor` 的复数特化实现
- 复数输入被使用实数实现处理，导致结果错误

**解决方案:**
- 为CPU实现添加了 `SoftplusFunctor<ComplexType<T>>` 特化
- 为GPU实现添加了 `CudaSoftplusFunctor<ComplexType<T>>` 特化
- 两个特化都正确处理复数运算，使用正确的数学公式：当 `x_beta <= threshold` 时为 `log(1 + exp(x_beta)) / beta`，否则为 `x`

**修改内容:**
- 在 `paddle/phi/kernels/funcs/activation_functor.h` 中添加了复数支持
- 与代码库中现有的复数特化保持一致
- 遵循与其他具有复数支持的激活函数相同的模式
