### PR TITLE
Replace deprecated `paddle.dataset.uci_housing` with `paddle.text.datasets.UCIHousing` in unittests

### DIFF
--- a/test/legacy_test/test_adadelta_op.py
+++ b/test/legacy_test/test_adadelta_op.py
@@ -194,14 +194,12 @@ class TestAdadeltaV2(unittest.TestCase):
             rms_optimizer.minimize(avg_cost)
 
             fetch_list = [avg_cost]
-            train_reader = paddle.batch(
-                paddle.dataset.uci_housing.train(), batch_size=1
-            )
             feeder = base.DataFeeder(place=place, feed_list=[x, y])
             exe = base.Executor(place)
             exe.run(base.default_startup_program())
-            for data in train_reader():
-                exe.run(main, feed=feeder.feed(data), fetch_list=fetch_list)
+            uci_housing = paddle.text.datasets.UCIHousing(mode='train')
+            for data in uci_housing:
+                exe.run(main, feed=feeder.feed([data]), fetch_list=fetch_list)
 
     def test_raise_error(self):
         self.assertRaises(ValueError, paddle.optimizer.Adadelta, None)

--- a/test/legacy_test/test_adam_optimizer_fp32_fp64.py
+++ b/test/legacy_test/test_adam_optimizer_fp32_fp64.py
@@ -41,14 +41,12 @@ def main_test_func(place, dtype):
             adam_optimizer.minimize(avg_cost)
 
             fetch_list = [avg_cost]
-            train_reader = paddle.batch(
-                paddle.dataset.uci_housing.train(), batch_size=1
-            )
             feeder = base.DataFeeder(place=place, feed_list=[x, y])
             exe = base.Executor(place)
             exe.run(base.default_startup_program())
-            for data in train_reader():
-                exe.run(main, feed=feeder.feed(data), fetch_list=fetch_list)
+            uci_housing = paddle.text.datasets.UCIHousing(mode='train')
+            for data in uci_housing:
+                exe.run(main, feed=feeder.feed([data]), fetch_list=fetch_list)
 
 
 class AdamFp32Test(unittest.TestCase):

--- a/test/legacy_test/test_momentum_op.py
+++ b/test/legacy_test/test_momentum_op.py
@@ -578,17 +578,15 @@ class TestMomentumV2(unittest.TestCase):
             rms_optimizer.minimize(avg_cost)
 
             fetch_list = [avg_cost]
-            train_reader = paddle.batch(
-                paddle.dataset.uci_housing.train(), batch_size=1
-            )
             exe = base.Executor(place)
             exe.run(startup)
-            for data in train_reader():
+            uci_housing = paddle.text.datasets.UCIHousing(mode='train')
+            for data in uci_housing:
                 exe.run(
                     main,
                     feed={
-                        'x': data[0][0].astype('float32'),
-                        'y': data[0][1].astype('float32'),
+                        'x': data[0].astype('float32'),
+                        'y': data[1].astype('float32'),
                     },
                     fetch_list=fetch_list,
                 )
@@ -740,17 +738,15 @@ class TestMomentumOpWithDecayAPI(unittest.TestCase):
             momentum_optimizer.minimize(avg_cost)
 
             fetch_list = [avg_cost]
-            train_reader = paddle.batch(
-                paddle.dataset.uci_housing.train(), batch_size=1
-            )
             exe = base.Executor(place)
             exe.run(startup)
-            for data in train_reader():
+            uci_housing = paddle.text.datasets.UCIHousing(mode='train')
+            for data in uci_housing:
                 exe.run(
                     main,
                     feed={
-                        'x': data[0][0].astype('float32'),
-                        'y': data[0][1].astype('float32'),
+                        'x': data[0].astype('float32'),
+                        'y': data[1].astype('float32'),
                     },
                     fetch_list=fetch_list,
                 )

--- a/test/legacy_test/test_network_with_dtype.py
+++ b/test/legacy_test/test_network_with_dtype.py
@@ -28,6 +28,7 @@ class TestNetWithDtype(unittest.TestCase):
         self.init_dtype()
 
     def run_net_on_place(self, place):
+        paddle.enable_static()
         main = base.Program()
         startup = base.Program()
         with base.program_guard(main, startup):
@@ -42,14 +43,12 @@ class TestNetWithDtype(unittest.TestCase):
             sgd_optimizer.minimize(avg_cost)
 
         fetch_list = [avg_cost]
-        train_reader = paddle.batch(
-            paddle.dataset.uci_housing.train(), batch_size=BATCH_SIZE
-        )
         feeder = base.DataFeeder(place=place, feed_list=[x, y])
         exe = base.Executor(place)
         exe.run(startup)
-        for data in train_reader():
-            exe.run(main, feed=feeder.feed(data), fetch_list=fetch_list)
+        uci_housing = paddle.text.datasets.UCIHousing(mode='train')
+        for data in uci_housing:
+            exe.run(main, feed=feeder.feed([data]), fetch_list=fetch_list)
             # the main program is runnable, the datatype is fully supported
             break
 

--- a/test/legacy_test/test_rmsprop_op.py
+++ b/test/legacy_test/test_rmsprop_op.py
@@ -297,14 +297,12 @@ class TestRMSPropV2(unittest.TestCase):
             rms_optimizer.minimize(avg_cost)
 
             fetch_list = [avg_cost]
-            train_reader = paddle.batch(
-                paddle.dataset.uci_housing.train(), batch_size=1
-            )
             feeder = base.DataFeeder(place=place, feed_list=[x, y])
             exe = base.Executor(place)
             exe.run(startup)
-            for data in train_reader():
-                exe.run(main, feed=feeder.feed(data), fetch_list=fetch_list)
+            uci_housing = paddle.text.datasets.UCIHousing(mode='train')
+            for data in uci_housing:
+                exe.run(main, feed=feeder.feed([data]), fetch_list=fetch_list)
 
     def test_raise_error(self):
         self.assertRaises(ValueError, paddle.optimizer.RMSProp, None)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience

### PR Types
Others 

### Description
<!-- Describe what you’ve done -->
paddle.dataset.uci_housing.train 已废弃
<img width="965" height="404" alt="image" src="https://github.com/user-attachments/assets/e24739af-cb6d-46e6-a756-094079169745" />

修改为 paddle.text.datasets.UCIHousing