### PR TITLE
3rd-batch-01-未显式检查是否包含有效张量

### DIFF
--- a/paddle/phi/core/distributed/auto_parallel/reshard/r_to_p_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/r_to_p_reshard_function.cc
@@ -23,7 +23,7 @@
 #include "paddle/phi/core/distributed/store/store_utils.h"
 #include "paddle/phi/kernels/assign_kernel.h"
 #include "paddle/phi/kernels/full_kernel.h"
-//
+
 namespace phi::distributed {
 
 bool RToPReshardFunction::IsSuitable(const DistTensor& in,

--- a/paddle/phi/core/distributed/auto_parallel/reshard/r_to_p_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/r_to_p_reshard_function.cc
@@ -23,7 +23,7 @@
 #include "paddle/phi/core/distributed/store/store_utils.h"
 #include "paddle/phi/kernels/assign_kernel.h"
 #include "paddle/phi/kernels/full_kernel.h"
-
+//
 namespace phi::distributed {
 
 bool RToPReshardFunction::IsSuitable(const DistTensor& in,

--- a/paddle/phi/kernels/xpu/deformable_conv_kernel.cc
+++ b/paddle/phi/kernels/xpu/deformable_conv_kernel.cc
@@ -65,7 +65,7 @@ void DeformableConvKernel(const Context& dev_ctx,
   const T* input_ptr = x.data<T>();
   const T* filter_ptr = filter.data<T>();
   const float* offset_ptr = offset.data<T>();
-  const float* mask_ptr = mask->data<T>();
+  const float* mask_ptr = mask.has_value() ? mask->data<T>() : nullptr;
   T* output_prt = out->data<T>();
 
   // set zeros for d_table_data

--- a/paddle/phi/kernels/xpu/deformable_conv_kernel.cc
+++ b/paddle/phi/kernels/xpu/deformable_conv_kernel.cc
@@ -65,7 +65,7 @@ void DeformableConvKernel(const Context& dev_ctx,
   const T* input_ptr = x.data<T>();
   const T* filter_ptr = filter.data<T>();
   const float* offset_ptr = offset.data<T>();
-  const float* mask_ptr = mask.has_value() ? mask->data<T>() : nullptr;
+  const float* mask_ptr = mask ? mask->data<T>() : nullptr;
   T* output_prt = out->data<T>();
 
   // set zeros for d_table_data


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
第三批-编号01（共1处)
代码试图从一个 `paddle::optional<DenseTensor>` 类型的 `mask` 中获取数据指针，但未通过 `mask.has_value()` 判断其是否包含有效张量。如果调用方未提供 `mask`，`mask` 将为空，此时 `mask->data<T>()` 等价于对空 `optional` 解引用，触发未定义行为，极可能导致空指针异常或段错误。通过 `has_value()` 显式检查 `mask` 是否存在，若不存在则将 `mask_ptr` 设为 `nullptr`