### PR TITLE
[API compatibility] add _cur_sdpa_kernel_backends for testing

### DIFF
--- a/python/paddle/nn/attention/__init__.py
+++ b/python/paddle/nn/attention/__init__.py
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .sdpa import SDPBackend, sdpa_kernel
+from .sdpa import SDPBackend, _cur_sdpa_kernel_backends, sdpa_kernel
 
-__all__ = ["SDPBackend", "sdpa_kernel"]
+__all__ = ["SDPBackend", "sdpa_kernel", "_cur_sdpa_kernel_backends"]

--- a/python/paddle/nn/attention/__init__.py
+++ b/python/paddle/nn/attention/__init__.py
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .sdpa import SDPBackend, _cur_sdpa_kernel_backends, sdpa_kernel
+from .sdpa import (  # noqa: F401
+    SDPBackend,
+    _cur_sdpa_kernel_backends,
+    sdpa_kernel,
+)
 
-__all__ = ["SDPBackend", "sdpa_kernel", "_cur_sdpa_kernel_backends"]
+__all__ = ["SDPBackend", "sdpa_kernel"]

--- a/test/legacy_test/test_sdpa_kernel.py
+++ b/test/legacy_test/test_sdpa_kernel.py
@@ -19,7 +19,11 @@ from op_test import is_custom_device
 
 import paddle
 import paddle.nn.functional as F
-from paddle.nn.attention import SDPBackend, sdpa_kernel
+from paddle.nn.attention import (
+    SDPBackend,
+    _cur_sdpa_kernel_backends,
+    sdpa_kernel,
+)
 from paddle.nn.functional import scaled_dot_product_attention
 
 
@@ -167,6 +171,10 @@ class TestSDPAKernelBasic(unittest.TestCase):
     def setUp(self):
         self.shape = (2, 128, 8, 16)
         self.dtype = 'float32'
+
+    def test_cur_sdpa_kernel_backends(self):
+        result = _cur_sdpa_kernel_backends()
+        self.assertIsInstance(result, list)
 
     def test_single_backend(self):
         """Test with single backend."""


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience


### PR Types
New features


### Description
Add API `_cur_sdpa_kernel_backends` for `paddle.nn.attention`, which will be used in PaConvert.
