### PR TITLE
[Metax] fix 'python/paddle/base/framework.py/_get_paddle_place' api bug

### DIFF
--- a/paddle/phi/kernels/funcs/multi_tensor_apply.h
+++ b/paddle/phi/kernels/funcs/multi_tensor_apply.h
@@ -85,7 +85,8 @@ void LaunchMultiTensorApplyKernel(
           "input_vector[0].size() is not > 0, please cheack params."));
   auto dev_ctx_place = dev_ctx.GetPlace();
   PADDLE_ENFORCE_EQ(
-      dev_ctx_place.GetType() == AllocationType::GPU,
+      dev_ctx_place.GetType() == AllocationType::GPU ||
+          dev_ctx_place.GetType() == AllocationType::CUSTOM,
       true,
       errors::PreconditionNotMet(
           "Context place error, excepted GPUPlace, but actually %s.",

--- a/python/paddle/base/framework.py
+++ b/python/paddle/base/framework.py
@@ -8366,9 +8366,12 @@ def _get_paddle_place(place):
     place_info_list = place.split(":", 1)
     device_type = place_info_list[0]
     if device_type in core.get_all_custom_device_type():
-        device_id = place_info_list[1]
-        device_id = int(device_id)
-        return core.CustomPlace(device_type, device_id)
+        if len(place_info_list) == 1:
+            return core.CustomPlace(device_type, 0)
+        else:
+            device_id = place_info_list[1]
+            device_id = int(device_id)
+            return core.CustomPlace(device_type, device_id)
 
     raise ValueError(
         f"Paddle supports CPUPlace, CUDAPlace, CUDAPinnedPlace, XPUPlace, XPUPinnedPlace, IPUPlace and CustomPlace, but received {place}."


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Custom Device

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Place did not consider the situation where “device_id” is not included in 'python/paddle/base/framework.py/_get_paddle_place' & add custom AllocationType in "paddle/phi/kernels/funcs/multi_tensor_apply.h"