### PR TITLE
[Compat] Allow register fake interface when torch proxy enabled

### DIFF
--- a/test/compat/test_torch_proxy.py
+++ b/test/compat/test_torch_proxy.py
@@ -73,5 +73,14 @@ class TestTorchProxy(unittest.TestCase):
         )
 
 
+class TestTorchOverriddenClass(unittest.TestCase):
+    def test_overridden_class(self):
+        self.assertRaises(AttributeError, lambda: paddle.Generator)
+        with paddle.compat.use_torch_proxy_guard():
+            import torch
+
+            gen = torch.Generator()
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

New features

### Description
<!-- Describe what you’ve done -->

允许在开启 torch proxy 时自定义 overrides，并添加首个 overrides `torch.Generator`

<!-- PCard-66972 -->