### PR TITLE
[Precision Depth Alignment] paddle.sin and paddle.cos aligns with torch precision.

### DIFF
--- a/paddle/phi/kernels/funcs/activation_functor.h
+++ b/paddle/phi/kernels/funcs/activation_functor.h
@@ -3853,7 +3853,11 @@ struct CudaSinGradFunctor : public BaseActivationFunctor<T> {
                                           const T arg_x) const {
     MPType dout = static_cast<MPType>(arg_dout);
     MPType x = static_cast<MPType>(arg_x);
-    return static_cast<T>(dout * cos(x));
+    if constexpr (std::is_same<T, phi::float16>::value) {
+      return static_cast<T>(arg_dout * static_cast<T>(cos(x)));
+    } else {
+      return static_cast<T>(dout * cos(x));
+    }
   }
 
   static constexpr ActBwdOpFwdDeps FwdDeps() { return ActBwdOpFwdDeps::kDepX; }

--- a/paddle/phi/kernels/funcs/activation_functor.h
+++ b/paddle/phi/kernels/funcs/activation_functor.h
@@ -3518,7 +3518,11 @@ struct CudaCosGradFunctor : public BaseActivationFunctor<T> {
                                           const T arg_x) const {
     MPType dout = static_cast<MPType>(arg_dout);
     MPType x = static_cast<MPType>(arg_x);
-    return static_cast<T>(-dout * sin(x));
+    if constexpr (std::is_same<T, phi::float16>::value) {
+      return static_cast<T>(-arg_dout * static_cast<T>(sin(x)));
+    } else {
+      return static_cast<T>(-dout * sin(x));
+    }
   }
 
   static constexpr ActBwdOpFwdDeps FwdDeps() { return ActBwdOpFwdDeps::kDepX; }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
**主要修改：**
1. 新增了针对 T=phi::float16 的分支处理：使用 arg_dout，并将 sin(x)/cos(x) 显式转换为 T 后再参与运算。
2. 对非 float16 情况，保持原有逻辑不变（仍使用 dout * sin/cos）。

**测试情况：**
1. paddle.sin与torch完全对齐（共187个测试case）
2. paddle.Tensor.sin与torch完全对齐（共83个测试case）
3. paddle.cos 与torch完全对齐（共150个测试case）
4. paddle.Tensor.cos 与torch完全对齐（共79个测试case）

pcard-67164
