### PR TITLE
[Compat] Support `tuple` or `vector` output in torch library and add missing interfaces in compat module

### DIFF
--- a/paddle/fluid/pybind/torch_compat.h
+++ b/paddle/fluid/pybind/torch_compat.h
@@ -126,8 +126,9 @@ inline py::object OperationInvoker::to_py_object(const torch::IValue& value) {
     return py_tuple;
   } else {
     PADDLE_THROW(common::errors::Unimplemented(
-        "Conversion of torch::IValue to Python object for this type is not "
-        "implemented yet."));
+        "Conversion of torch::IValue to Python object for type %s is not "
+        "implemented yet.",
+        value.type_string()));
   }
 }
 

--- a/paddle/fluid/pybind/torch_compat.h
+++ b/paddle/fluid/pybind/torch_compat.h
@@ -109,6 +109,21 @@ inline py::object OperationInvoker::to_py_object(const torch::IValue& value) {
   } else if (value.is_tensor()) {
     return py::reinterpret_borrow<py::object>(
         paddle::pybind::ToPyObject(value.to_tensor()._PD_GetInner()));
+  } else if (value.is_list()) {
+    auto ivalue_list = value.to_list();
+    py::list py_list;
+    for (const auto& item : ivalue_list) {
+      py_list.append(to_py_object(item));
+    }
+    return py_list;
+  } else if (value.is_tuple()) {
+    auto ivalue_tuple = value.to_tuple();
+    size_t size = ivalue_tuple.size();
+    py::tuple py_tuple(size);
+    for (size_t i = 0; i < size; ++i) {
+      py_tuple[i] = to_py_object(ivalue_tuple[i]);
+    }
+    return py_tuple;
   } else {
     PADDLE_THROW(common::errors::Unimplemented(
         "Conversion of torch::IValue to Python object for this type is not "

--- a/paddle/phi/api/include/compat/ATen/ATen.h
+++ b/paddle/phi/api/include/compat/ATen/ATen.h
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include <ATen/Device.h>
+#include <ATen/Functions.h>
+#include <ATen/Tensor.h>
 #include <c10/core/Device.h>
 #include <c10/core/DeviceType.h>
 #include <c10/core/MemoryFormat.h>

--- a/paddle/phi/api/include/compat/ATen/Functions.h
+++ b/paddle/phi/api/include/compat/ATen/Functions.h
@@ -13,13 +13,11 @@
 // limitations under the License.
 
 #pragma once
-#include <ATen/ops/from_blob.h>
 
-#include <ATen/ATen.h>
-#include <ATen/core/TensorBody.h>
 #include <ATen/ops/abs.h>
 #include <ATen/ops/empty.h>
 #include <ATen/ops/empty_like.h>
+#include <ATen/ops/from_blob.h>
 #include <ATen/ops/full.h>
 #include <ATen/ops/ones.h>
 #include <ATen/ops/reshape.h>

--- a/paddle/phi/api/include/compat/ATen/core/TensorBase.h
+++ b/paddle/phi/api/include/compat/ATen/core/TensorBase.h
@@ -14,9 +14,9 @@
 
 #pragma once
 
-#include <ATen/ATen.h>
 #include <c10/core/Device.h>
 #include <c10/core/MemoryFormat.h>
+#include <c10/core/Scalar.h>
 #include <c10/core/ScalarType.h>
 #include <c10/core/TensorOptions.h>
 #include <utils/int_array_ref_conversion.h>

--- a/paddle/phi/api/include/compat/ATen/core/ivalue.h
+++ b/paddle/phi/api/include/compat/ATen/core/ivalue.h
@@ -455,6 +455,8 @@ class IValue {
         return "Tensor";
       case TypeTag::GenericList:
         return "List";
+      case TypeTag::Tuple:
+        return "Tuple";
       case TypeTag::CustomClass:
         return "CustomClass(" + get_custom_class_name() + ")";
       default:
@@ -486,6 +488,17 @@ class IValue {
           result += list[i].to_repr();
         }
         result += "]";
+        return result;
+      }
+      case TypeTag::Tuple: {
+        const auto& tuple = std::get<GenericTuple>(value_);
+        std::string result = "(";
+        for (size_t i = 0; i < tuple.size(); ++i) {
+          if (i > 0) result += ", ";
+          result += tuple[i].to_repr();
+        }
+        if (tuple.size() == 1) result += ",";  // Single element tuple
+        result += ")";
         return result;
       }
       case TypeTag::CustomClass: {

--- a/paddle/phi/api/include/compat/ATen/ops/abs.h
+++ b/paddle/phi/api/include/compat/ATen/ops/abs.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <ATen/core/Tensor.h>
 #include <c10/core/TensorOptions.h>
 #include <optional>
 #include <string_view>

--- a/paddle/phi/api/include/compat/ATen/ops/empty.h
+++ b/paddle/phi/api/include/compat/ATen/ops/empty.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <ATen/core/Tensor.h>
 #include <c10/core/TensorOptions.h>
 #include <optional>
 #include <string_view>

--- a/paddle/phi/api/include/compat/ATen/ops/empty_like.h
+++ b/paddle/phi/api/include/compat/ATen/ops/empty_like.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <ATen/core/Tensor.h>
 #include <c10/core/TensorOptions.h>
 #include <optional>
 #include <string_view>

--- a/paddle/phi/api/include/compat/ATen/ops/full.h
+++ b/paddle/phi/api/include/compat/ATen/ops/full.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <ATen/core/Tensor.h>
+#include <c10/core/SymIntArrayRef.h>
 #include <c10/core/TensorOptions.h>
 #include <optional>
 #include <string_view>

--- a/paddle/phi/api/include/compat/ATen/ops/ones.h
+++ b/paddle/phi/api/include/compat/ATen/ops/ones.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <ATen/core/Tensor.h>
 #include <c10/core/TensorOptions.h>
 #include <optional>
 #include <string_view>

--- a/paddle/phi/api/include/compat/ATen/ops/reshape.h
+++ b/paddle/phi/api/include/compat/ATen/ops/reshape.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <ATen/core/Tensor.h>
 #include <c10/core/TensorOptions.h>
 #include <optional>
 #include <string_view>

--- a/paddle/phi/api/include/compat/ATen/ops/sum.h
+++ b/paddle/phi/api/include/compat/ATen/ops/sum.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <ATen/core/Tensor.h>
 #include <c10/core/TensorOptions.h>
 #include <optional>
 #include <string_view>

--- a/paddle/phi/api/include/compat/ATen/ops/zeros.h
+++ b/paddle/phi/api/include/compat/ATen/ops/zeros.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <ATen/core/Tensor.h>
 #include <c10/core/TensorOptions.h>
 #include <optional>
 #include <string_view>

--- a/paddle/phi/api/include/compat/ATen/ops/zeros_like.h
+++ b/paddle/phi/api/include/compat/ATen/ops/zeros_like.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <ATen/core/Tensor.h>
 #include <c10/core/TensorOptions.h>
 #include <optional>
 #include <string_view>

--- a/paddle/phi/api/include/compat/c10/core/Device.h
+++ b/paddle/phi/api/include/compat/c10/core/Device.h
@@ -28,6 +28,10 @@ struct Device final {
 
   DeviceType type() const { return inner_.GetType(); }
 
+  bool is_cuda() const noexcept { return phi::is_gpu_place(inner_); }
+
+  bool is_cpu() const noexcept { return phi::is_cpu_place(inner_); }
+
   phi::Place _PD_GetInner() const { return inner_; }
 
  private:

--- a/paddle/phi/api/include/compat/c10/cuda/CUDAGuard.h
+++ b/paddle/phi/api/include/compat/c10/cuda/CUDAGuard.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <c10/core/Device.h>
+#include <optional>
 #include "paddle/phi/core/platform/cuda_device_guard.h"
 
 namespace c10::cuda {

--- a/paddle/phi/api/include/compat/c10/util/Exception.h
+++ b/paddle/phi/api/include/compat/c10/util/Exception.h
@@ -21,6 +21,7 @@
 #include <cstdint>
 #include <exception>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <variant>
 #include <vector>

--- a/paddle/phi/api/include/compat/c10/util/Exception.h
+++ b/paddle/phi/api/include/compat/c10/util/Exception.h
@@ -33,6 +33,25 @@
 namespace c10 {
 #define TORCH_CHECK(COND, ...) PD_CHECK(COND, ##__VA_ARGS__);
 #define TORCH_INTERNAL_ASSERT(COND, ...) PD_CHECK(COND, ##__VA_ARGS__);
+#define TORCH_CHECK_OP(val1, val2, op)                                    \
+  do {                                                                    \
+    auto&& _val1 = (val1);                                                \
+    auto&& _val2 = (val2);                                                \
+    if (!(_val1 op _val2)) {                                              \
+      std::ostringstream _result;                                         \
+      _result << "Expected " #val1 " " #op " " #val2 " (" << _val1 << " " \
+              << #op << " " << _val2 << "), but got false";               \
+      PD_THROW(_result.str());                                            \
+    }                                                                     \
+  } while (false);
+
+// TORCH_CHECK_OP macro definitions
+#define TORCH_CHECK_EQ(val1, val2) TORCH_CHECK_OP(val1, val2, ==)
+#define TORCH_CHECK_NE(val1, val2) TORCH_CHECK_OP(val1, val2, !=)
+#define TORCH_CHECK_LE(val1, val2) TORCH_CHECK_OP(val1, val2, <=)
+#define TORCH_CHECK_LT(val1, val2) TORCH_CHECK_OP(val1, val2, <)
+#define TORCH_CHECK_GE(val1, val2) TORCH_CHECK_OP(val1, val2, >=)
+#define TORCH_CHECK_GT(val1, val2) TORCH_CHECK_OP(val1, val2, >)
 }  // namespace c10
 
 enum class C10ErrorType {

--- a/test/cpp/compat/compat_basic_test.cc
+++ b/test/cpp/compat/compat_basic_test.cc
@@ -258,3 +258,43 @@ TEST(compat_basic_test, BasicCase) {
               << std::endl;
   }
 }
+
+TEST(TestDevice, DeviceAPIsOnCUDA) {
+  // Test device related APIs on CUDA if available
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+  if (at::cuda::is_available()) {
+    at::TensorBase cuda_tensor = at::ones(
+        {2, 3}, c10::TensorOptions().dtype(at::kFloat).device(at::kCUDA));
+
+    // Test device()
+    ASSERT_EQ(cuda_tensor.device().type(), at::DeviceType::CUDA);
+
+    // Test get_device()
+    ASSERT_EQ(cuda_tensor.get_device(), 0);  // Assuming single GPU with index 0
+
+    // Test is_cpu()/is_cuda()
+    ASSERT_FALSE(cuda_tensor.is_cpu());
+    ASSERT_TRUE(cuda_tensor.is_cuda());
+
+    // Test options()
+    auto options = cuda_tensor.options();
+    ASSERT_EQ(options.device().type(), at::DeviceType::CUDA);
+  }
+#endif
+}
+
+TEST(TestDevice, DeviceAPIsOnCPU) {
+  // Test device related APIs on CPU
+  at::TensorBase cpu_tensor = at::ones({2, 3}, at::kFloat);
+
+  // Test device()
+  ASSERT_EQ(cpu_tensor.device().type(), at::DeviceType::CPU);
+
+  // Test is_cpu()/is_cuda()
+  ASSERT_TRUE(cpu_tensor.is_cpu());
+  ASSERT_FALSE(cpu_tensor.is_cuda());
+
+  // Test options()
+  auto options = cpu_tensor.options();
+  ASSERT_EQ(options.device().type(), at::DeviceType::CPU);
+}

--- a/test/cpp/compat/torch_library_test.cc
+++ b/test/cpp/compat/torch_library_test.cc
@@ -626,3 +626,60 @@ TEST(test_torch_library, TestLibraryPrintInfo) {
   torch::Library lib("example_library_test_print_info");
   lib.print_info();
 }
+
+TEST(test_torch_library, TestIValueNone) {
+  torch::IValue ival = torch::IValue();
+  ASSERT_TRUE(ival.is_none());
+  ASSERT_EQ(ival.to_repr(), "None");
+  ASSERT_EQ(ival.type_string(), "None");
+}
+
+TEST(test_torch_library, TestIValueBool) {
+  torch::IValue ival = true;
+  ASSERT_TRUE(ival.is_bool());
+  ASSERT_EQ(ival.to_repr(), "true");
+  ASSERT_EQ(ival.type_string(), "Bool");
+}
+
+TEST(test_torch_library, TestIValueInt) {
+  torch::IValue ival = 42;
+  ASSERT_TRUE(ival.is_int());
+  ASSERT_EQ(ival.to_repr(), "42");
+  ASSERT_EQ(ival.type_string(), "Int");
+}
+
+TEST(test_torch_library, TestIValueDouble) {
+  torch::IValue ival = 3.14;
+  ASSERT_TRUE(ival.is_double());
+  ASSERT_EQ(ival.to_repr(), "3.14");
+  ASSERT_EQ(ival.type_string(), "Float");
+}
+
+TEST(test_torch_library, TestIValueString) {
+  torch::IValue ival = std::string("hello");
+  ASSERT_TRUE(ival.is_string());
+  ASSERT_EQ(ival.to_repr(), "\"hello\"");
+  ASSERT_EQ(ival.type_string(), "String");
+}
+
+TEST(test_torch_library, TestIValueTensor) {
+  at::Tensor tensor = at::ones({2, 2}, at::kFloat);
+  torch::IValue ival = tensor;
+  ASSERT_TRUE(ival.is_tensor());
+  ASSERT_EQ(ival.type_string(), "Tensor");
+}
+
+TEST(test_torch_library, TestIValueList) {
+  std::vector<torch::IValue> vec = {1, 2, 3};
+  torch::IValue ival = torch::IValue(vec);
+  ASSERT_TRUE(ival.is_list());
+  ASSERT_EQ(ival.to_repr(), "[1, 2, 3]");
+  ASSERT_EQ(ival.type_string(), "List");
+}
+
+TEST(test_torch_library, TestIValueTuple) {
+  torch::IValue ival = torch::IValue(std::make_tuple(1, 2.0, "three"));
+  ASSERT_TRUE(ival.is_tuple());
+  ASSERT_EQ(ival.to_repr(), "(1, 2.0, \"three\")");
+  ASSERT_EQ(ival.type_string(), "Tuple");
+}

--- a/test/cpp/compat/torch_library_test.cc
+++ b/test/cpp/compat/torch_library_test.cc
@@ -652,7 +652,7 @@ TEST(test_torch_library, TestIValueDouble) {
   torch::IValue ival = 3.14;
   ASSERT_TRUE(ival.is_double());
   ASSERT_TRUE(ival.to_repr().find("3.14") != std::string::npos);
-  ASSERT_EQ(ival.type_string(), "Float");
+  ASSERT_EQ(ival.type_string(), "Double");
 }
 
 TEST(test_torch_library, TestIValueString) {

--- a/test/cpp/compat/torch_library_test.cc
+++ b/test/cpp/compat/torch_library_test.cc
@@ -651,7 +651,7 @@ TEST(test_torch_library, TestIValueInt) {
 TEST(test_torch_library, TestIValueDouble) {
   torch::IValue ival = 3.14;
   ASSERT_TRUE(ival.is_double());
-  ASSERT_EQ(ival.to_repr(), "3.14");
+  ASSERT_TRUE(ival.to_repr().find("3.14") != std::string::npos);
   ASSERT_EQ(ival.type_string(), "Float");
 }
 
@@ -678,8 +678,8 @@ TEST(test_torch_library, TestIValueList) {
 }
 
 TEST(test_torch_library, TestIValueTuple) {
-  torch::IValue ival = torch::IValue(std::make_tuple(1, 2.0, "three"));
+  torch::IValue ival = torch::IValue(std::make_tuple(1, true, "three"));
   ASSERT_TRUE(ival.is_tuple());
-  ASSERT_EQ(ival.to_repr(), "(1, 2.0, \"three\")");
+  ASSERT_EQ(ival.to_repr(), "(1, true, \"three\")");
   ASSERT_EQ(ival.type_string(), "Tuple");
 }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

- torch library 注册的 OP 在 pybind 层支持 tuple/vector 输出
- 补全缺失的 `TORCH_CHECK_LT` 等 macros
- 补全 `Device.is_cuda/is_cpu`
- 调整 include 关系，确保 `ATen/Aten.h` 在 ATen 里是一个最上层的 header

<!-- PCard-66972 -->