### PR TITLE
3rd-batch-02to03-判断分支不全

### DIFF
--- a/test/cpp/pir/cinn/tile_config_performance_test.cc
+++ b/test/cpp/pir/cinn/tile_config_performance_test.cc
@@ -285,6 +285,10 @@ int get_tile_size_config_in_small_area(int dimension_lower) {
     return 1024;
   } else if (dimension_lower <= 2048) {
     return 2048;
+  } else {
+    PADDLE_THROW(phi::errors::InvalidArgument(
+        "dimension_lower (%d) exceeds the supported range (<=2048).",
+        dimension_lower));
   }
 }
 
@@ -299,6 +303,10 @@ int get_tile_size_config_in_large_area(int dimension_lower) {
     return 8192;
   } else if (dimension_lower <= 16384) {
     return 16384;
+  } else {
+    PADDLE_THROW(phi::errors::InvalidArgument(
+        "dimension_lower (%d) exceeds the supported range (<=16384).",
+        dimension_lower));
   }
 }
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
第三批-编号02、03（共2处)
函数根据输入的 `dimension_lower` 返回对应的 tile 大小，但所有 `if-else` 条件仅覆盖到 `<= 2048`和`<= 16384`，当输入值大于设定值时，无法命中任一分支，函数执行完最后一个 `else if` 后直接结束，未提供返回值，造成控制流脱离函数体而无返回值。使用`else PADDLE_THROW`返回