### PR TITLE
3rd-batch-04-插桩系统回调函数错误

### DIFF
--- a/paddle/pir/src/pass/pass.cc
+++ b/paddle/pir/src/pass/pass.cc
@@ -284,7 +284,7 @@ void PassInstrumentor::RunAfterAnalysis(const std::string& name,
   for (auto it = impl_->instrumentations.rbegin();
        it != impl_->instrumentations.rend();
        ++it) {
-    (*it)->RunBeforeAnalysis(name, id, op);
+    (*it)->RunAfterAnalysis(name, id, op);
   }
 }
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
第三批-编号04（共1处)
函数本应通知所有插桩对象“某个分析已结束”，因此应在逆序中调用 `RunAfterAnalysis`。当前实现错误地调用了 `RunBeforeAnalysis`，将 `RunBeforeAnalysis` 修改为 `RunAfterAnalysis`，确保在分析完成后正确调用对应的“分析后”回调函数