### PR TITLE
3rd-batch-09-修改void函数的return语句

### DIFF
--- a/paddle/phi/kernels/cpu/clip_by_norm_kernel.cc
+++ b/paddle/phi/kernels/cpu/clip_by_norm_kernel.cc
@@ -25,7 +25,7 @@ void ClipByNormKernel(const Context& dev_ctx,
                       const DenseTensor& in,
                       float max_norm,
                       DenseTensor* output) {
-  return ClipByNormFunctor<T, Context>(dev_ctx, in, max_norm, output);
+  ClipByNormFunctor<T, Context>(dev_ctx, in, max_norm, output);
 }
 
 }  // namespace phi


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
第三批-编号09（共1处)
函数声明返回 `void`，但使用 `return` 返回了一个 `ClipByNormFunctor` 的临时实例。虽然该 functor 的构造函数可能包含执行逻辑（如运算调度），但 `return` 表达式在 `void` 函数中返回非 `void` 值是不合适的。正确做法应是直接调用该 functor 而不通过 `return`