### PR TITLE
3rd-batch-08-函数语义错误导致提前结束

### DIFF
--- a/paddle/fluid/pir/dialect/distributed/ir/dist_tools.cc
+++ b/paddle/fluid/pir/dialect/distributed/ir/dist_tools.cc
@@ -197,7 +197,7 @@ bool HasDistInput(const std::vector<pir::Value>& inputs,
           return true;
         }
       }
-      return false;
+      continue;
     }
   }
   return false;

--- a/paddle/fluid/pir/dialect/distributed/ir/dist_tools.cc
+++ b/paddle/fluid/pir/dialect/distributed/ir/dist_tools.cc
@@ -197,7 +197,6 @@ bool HasDistInput(const std::vector<pir::Value>& inputs,
           return true;
         }
       }
-      continue;
     }
   }
   return false;

--- a/paddle/phi/core/distributed/auto_parallel/reshard/r_to_p_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/r_to_p_reshard_function.cc
@@ -57,7 +57,7 @@ void RToPReshardFunction::Eval(phi::DeviceContext* dev_ctx,
   const auto& out_process_mesh = out_dist_attr.process_mesh();
   int64_t local_rank = GetCurRankCoordInMesh(out_process_mesh)[0];
   const auto& in_reduce_type = out_dist_attr.partial_status().at(0);
-  //
+
   if (local_rank != 0) {
     if (in_reduce_type == ReduceType::kRedAvg) {
       // assign the input value to output

--- a/paddle/phi/core/distributed/auto_parallel/reshard/r_to_p_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/r_to_p_reshard_function.cc
@@ -57,7 +57,7 @@ void RToPReshardFunction::Eval(phi::DeviceContext* dev_ctx,
   const auto& out_process_mesh = out_dist_attr.process_mesh();
   int64_t local_rank = GetCurRankCoordInMesh(out_process_mesh)[0];
   const auto& in_reduce_type = out_dist_attr.partial_status().at(0);
-
+  //
   if (local_rank != 0) {
     if (in_reduce_type == ReduceType::kRedAvg) {
       // assign the input value to output


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
第三批-编号08（共1处)
当输入 `value` 的类型是 `VectorType` 但其所有元素都不是 `DistTypeInterface` 时，函数执行到末尾的 `return false`，导致整个函数返回 `false`，而不再检查 `inputs` 中的后续值。
将 `return false` 修改为 `continue`，确保当某个 `VectorType` 输入不包含分布式类型时，函数继续检查后续输入，而不是提前返回 `false`