### PR TITLE
3rd-batch-07-数组越界导致可能的缓冲区溢出

### DIFF
--- a/paddle/phi/kernels/cpu/set_value_kernel.cc
+++ b/paddle/phi/kernels/cpu/set_value_kernel.cc
@@ -96,7 +96,7 @@ void SetValueImpl(const Context& dev_ctx,
   value_tensor.Resize(phi::make_ddim(value_shape));
 
   auto expand_shape = phi::vectorize<int64_t>(slice_dims_for_assign);
-  for (size_t i = 0; i <= expand_shape.size(); i++) {
+  for (size_t i = 0; i < expand_shape.size(); i++) {
     if (expand_shape[i] == 0) expand_shape[i] = 1;
   }
   if (expand_shape.empty()) expand_shape.push_back(1);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
第三批-编号07（共1处)
循环条件为 `i <= expand_shape.size()`，当 `i == expand_shape.size()` 时，`expand_shape[i]` 访问越界，造成未定义行为（缓冲区溢出）。将循环条件从 `i <= expand_shape.size()` 修改为 `i < expand_shape.size()`，确保索引始终在合法范围内，避免越界访问