### PR TITLE
[Precision Depth Alignment] fix precision for float16 of paddle.tan backward

### DIFF
--- a/paddle/phi/kernels/funcs/activation_functor.h
+++ b/paddle/phi/kernels/funcs/activation_functor.h
@@ -3902,10 +3902,13 @@ struct CudaTanGradFunctor : public BaseActivationFunctor<T> {
       float tsq = __fmul_rn(tf, tf);
       float y = __fadd_rn(tsq, 1.0f);
       return static_cast<T>(dout * y);
-    } else {
+    } else if constexpr (std::is_same<T, phi::float16>::value) {
       __half tf = __float2half_rn(::tanf(x));
       __half tmp_half = __hmul(tf, tf);
       return arg_dout * (one + static_cast<T>(__half2float(tmp_half)));
+    } else {
+      return static_cast<T>(dout *
+                            (static_cast<MPType>(1.0f) + ::tan(x) * ::tan(x)));
     }
   }
 

--- a/paddle/phi/kernels/funcs/activation_functor.h
+++ b/paddle/phi/kernels/funcs/activation_functor.h
@@ -3885,22 +3885,27 @@ struct CudaTanFunctor : public BaseActivationFunctor<T> {
 template <typename T>
 struct CudaTanGradFunctor : public BaseActivationFunctor<T> {
   using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
+  T one = static_cast<T>(1.0f);
 
   // dx = dout *(1 + tan(x)^2)
   __device__ __forceinline__ T operator()(const T arg_dout,
                                           const T arg_x) const {
     MPType dout = static_cast<MPType>(arg_dout);
     MPType x = static_cast<MPType>(arg_x);
-    if constexpr (std::is_same<MPType, double>::value) {
+    if constexpr (std::is_same<T, double>::value) {
       double td = ::tan(x);
       double tsq = __dmul_rn(td, td);
       double y = __dadd_rn(tsq, 1.0);
       return static_cast<T>(dout * y);
-    } else {
+    } else if constexpr (std::is_same<T, float>::value) {
       float tf = ::tanf(x);
       float tsq = __fmul_rn(tf, tf);
       float y = __fadd_rn(tsq, 1.0f);
       return static_cast<T>(dout * y);
+    } else {
+      __half tf = __float2half_rn(::tanf(x));
+      __half tmp_half = __hmul(tf, tf);
+      return arg_dout * (one + static_cast<T>(__half2float(tmp_half)));
     }
   }
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

**PR描述：**
修复PR https://github.com/PaddlePaddle/Paddle/pull/75335 中遗留了float16 类型未能与torch对齐。

**测试结果：**
paddle.tan 全部与torch对齐（测试case 17 个）

pcard-67164