### PR TITLE
【CUDA Kernel No.7】fused_seqpool_cvm_grad算子Kernel修复 -part

### DIFF
--- a/paddle/phi/kernels/affine_channel_grad_kernel.h
+++ b/paddle/phi/kernels/affine_channel_grad_kernel.h
@@ -1,0 +1,35 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+#include "paddle/phi/backends/gpu/gpu_context.h"
+#include "paddle/phi/core/dense_tensor.h"
+#include "paddle/phi/core/kernel_registry.h"
+
+namespace phi {
+
+template <typename T, typename Context>
+void AffineChannelGradCUDAKernel(const Context& dev_ctx,
+                                 const DenseTensor& x_in,
+                                 const DenseTensor& scale_in,
+                                 const DenseTensor& bias_in,
+                                 const DenseTensor& out_grad,
+                                 const std::string& data_layout,
+                                 DenseTensor* x_grad,
+                                 DenseTensor* scale_grad,
+                                 DenseTensor* bias_grad);
+
+}  // namespace phi

--- a/paddle/phi/kernels/affine_channel_kernel.h
+++ b/paddle/phi/kernels/affine_channel_kernel.h
@@ -1,0 +1,32 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+#include "paddle/phi/backends/gpu/gpu_context.h"
+#include "paddle/phi/core/dense_tensor.h"
+#include "paddle/phi/core/kernel_registry.h"
+
+namespace phi {
+
+template <typename T, typename Context>
+void AffineChannelCUDAKernel(const Context& dev_ctx,
+                             const DenseTensor& x_in,
+                             const DenseTensor& scale_in,
+                             const DenseTensor& bias_in,
+                             const std::string& data_layout,
+                             DenseTensor* out);
+
+}  // namespace phi

--- a/paddle/phi/kernels/ap_facade_kernel.h
+++ b/paddle/phi/kernels/ap_facade_kernel.h
@@ -12,11 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "paddle/phi/kernels/ap_facade_kernel.h"
-#include "paddle/common/enforce.h"
-#include "paddle/phi/backends/gpu/gpu_context.h"
+#pragma once
+
+#include <string>
+#include <vector>
+
 #include "paddle/phi/core/dense_tensor.h"
-#include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/core/macros.h"
 
 namespace phi {
 
@@ -28,22 +30,6 @@ void ApFacadeKernel(const Context& dev_ctx,
                     const std::string& infer_meta_func_name,
                     const std::string& infer_symbolic_func_name,
                     const std::string& serialized_attributes,
-                    std::vector<DenseTensor*> outs) {
-  PADDLE_THROW(
-      common::errors::Unimplemented("ap_facade has no kernel registered."));
-}
+                    std::vector<DenseTensor*> outs);
 
 }  // namespace phi
-
-PD_REGISTER_KERNEL(ap_facade,
-                   GPU,
-                   ALL_LAYOUT,
-                   phi::ApFacadeKernel,
-                   float,
-                   double,
-                   int,
-                   phi::bfloat16,
-                   phi::float16,
-                   int64_t,
-                   phi::complex64,
-                   phi::complex128) {}

--- a/paddle/phi/kernels/ap_trivial_fusion_begin_kernel.h
+++ b/paddle/phi/kernels/ap_trivial_fusion_begin_kernel.h
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "paddle/phi/kernels/ap_trivial_fusion_begin_kernel.h"
-#include "paddle/common/enforce.h"
-#include "paddle/phi/backends/gpu/gpu_context.h"
+#pragma once
+
+#include <vector>
+
 #include "paddle/phi/core/dense_tensor.h"
-#include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/core/macros.h"
 
 namespace phi {
 
@@ -24,22 +25,6 @@ template <typename T, typename Context>
 void ApTrivialFusionBeginKernel(
     const Context& dev_ctx,
     const paddle::optional<std::vector<const DenseTensor*>>& xs,
-    DenseTensor* out) {
-  PADDLE_THROW(common::errors::Unimplemented(
-      "pd_op.ap_trivial_fusion_begin has no kernel registered."));
-}
+    DenseTensor* out);
 
 }  // namespace phi
-
-PD_REGISTER_KERNEL(ap_trivial_fusion_begin,
-                   GPU,
-                   ALL_LAYOUT,
-                   phi::ApTrivialFusionBeginKernel,
-                   float,
-                   double,
-                   int,
-                   phi::bfloat16,
-                   phi::float16,
-                   int64_t,
-                   phi::complex64,
-                   phi::complex128) {}

--- a/paddle/phi/kernels/ap_trivial_fusion_end_kernel.h
+++ b/paddle/phi/kernels/ap_trivial_fusion_end_kernel.h
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "paddle/phi/kernels/gpu/ap_trivial_fusion_end_kernel.cu"
-#include "paddle/common/enforce.h"
-#include "paddle/phi/backends/gpu/gpu_context.h"
+#pragma once
+
+#include <vector>
+
 #include "paddle/phi/core/dense_tensor.h"
-#include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/core/macros.h"
 
 namespace phi {
 
@@ -24,22 +25,6 @@ template <typename T, typename Context>
 void ApTrivialFusionEndKernel(
     const Context& dev_ctx,
     const paddle::optional<std::vector<const DenseTensor*>>& xs,
-    DenseTensor* out) {
-  PADDLE_THROW(common::errors::Unimplemented(
-      "pd_op.ap_trivial_fusion_end has no kernel registered."));
-}
+    DenseTensor* out);
 
 }  // namespace phi
-
-PD_REGISTER_KERNEL(ap_trivial_fusion_end,
-                   GPU,
-                   ALL_LAYOUT,
-                   phi::ApTrivialFusionEndKernel,
-                   float,
-                   double,
-                   int,
-                   phi::bfloat16,
-                   phi::float16,
-                   int64_t,
-                   phi::complex64,
-                   phi::complex128) {}

--- a/paddle/phi/kernels/cpu/affine_channel_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/affine_channel_grad_kernel.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "paddle/phi/kernels/affine_channel_grad_kernel.h"
 #include <string>
 #include <unordered_map>
-
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/eigen/common.h"
 

--- a/paddle/phi/kernels/cpu/affine_channel_kernel.cc
+++ b/paddle/phi/kernels/cpu/affine_channel_kernel.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "paddle/phi/kernels/affine_channel_kernel.h"
 #include <string>
 #include <unordered_map>
-
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/eigen/common.h"
 

--- a/paddle/phi/kernels/fused_seqpool_cvm_grad_kernel.h
+++ b/paddle/phi/kernels/fused_seqpool_cvm_grad_kernel.h
@@ -12,36 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <memory>
-#include <vector>
+#pragma once
 
-#include "paddle/phi/core/kernel_registry.h"
-#include "paddle/phi/core/tensor_utils.h"
-#include "Paddle/paddle/phi/kernels/fused_seqpool_cvm_grad_kernel.h"
+#include <vector>
+#include <string>
+#include "paddle/phi/core/dense_tensor.h"
+#include "paddle/phi/backends/gpu/gpu_context.h"
 
 namespace phi {
+namespace fusion {
 
 template <typename T, typename Context>
-void FusedSeqpoolCVMGradOpCPUKernel(
+void FusedSeqpoolCVMGradCUDAKernel(
     const Context &dev_ctx,
     const std::vector<const DenseTensor *> &x,
-    const DenseTensor &cvm,
+    const DenseTensor &cvm_in,
     const std::vector<const DenseTensor *> &out_grad,
     const std::string &pooltype,
     float pad_value,
     bool use_cvm,
     int cvm_offset,
     std::vector<DenseTensor *> x_grad,
-    DenseTensor *cvm_grad) {
-  PADDLE_THROW(common::errors::Unimplemented(
-      "Unimplemented CPU kernel for FusedSeqpoolCVMGradOp, only support GPU "
-      "now."));
-}
+    DenseTensor *cvm_grad);
 
+}  // namespace fusion
 }  // namespace phi
-
-PD_REGISTER_KERNEL(fused_seqpool_cvm_grad,
-                   CPU,
-                   ALL_LAYOUT,
-                   phi::FusedSeqpoolCVMGradOpCPUKernel,
-                   float) {}

--- a/paddle/phi/kernels/fused_seqpool_cvm_kernel.h
+++ b/paddle/phi/kernels/fused_seqpool_cvm_kernel.h
@@ -1,0 +1,36 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND.
+
+#pragma once
+
+#include <vector>
+#include <string>
+#include "paddle/phi/core/dense_tensor.h"
+#include "paddle/phi/backends/gpu/gpu_context.h"
+
+namespace phi {
+namespace fusion {
+
+// CUDA kernel interface for FusedSeqpoolCVM
+template <typename T, typename Context>
+void FusedSeqpoolCVMCUDAKernel(
+    const Context &dev_ctx,
+    const std::vector<const DenseTensor *> &x,
+    const DenseTensor &cvm,
+    const std::string &pooltype,
+    float pad_value,
+    bool use_cvm,
+    int cvm_offset,
+    std::vector<DenseTensor *> out);
+
+}  // namespace fusion
+}  // namespace phi

--- a/paddle/phi/kernels/fused_softmax_mask_grad_kernel.h
+++ b/paddle/phi/kernels/fused_softmax_mask_grad_kernel.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND.
+
+#pragma once
+
+#include "paddle/phi/core/dense_tensor.h"
+#include "paddle/phi/backends/gpu/gpu_context.h"
+
+namespace phi {
+namespace fusion {
+
+template <typename T, typename Context>
+void FusedSoftmaxMaskGradKernel(const Context& dev_ctx,
+                                const DenseTensor& out,
+                                const DenseTensor& out_grad,
+                                DenseTensor* x_grad);
+
+}  // namespace fusion
+}  // namespace phi

--- a/paddle/phi/kernels/fused_stack_transpose_quant_kernel.h
+++ b/paddle/phi/kernels/fused_stack_transpose_quant_kernel.h
@@ -1,0 +1,33 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND.
+
+#pragma once
+#include <vector>
+#include "paddle/phi/core/dense_tensor.h"
+
+namespace phi {
+namespace fusion {
+
+template <typename T, typename Context>
+void FusedStackQuantKernel(const Context& dev_ctx,
+                           const std::vector<const DenseTensor*>& x,
+                           DenseTensor* out,
+                           DenseTensor* scale);
+
+template <typename T, typename Context>
+void FusedStackTransposeQuantKernel(const Context& dev_ctx,
+                                    const std::vector<const DenseTensor*>& x,
+                                    DenseTensor* out,
+                                    DenseTensor* scale);
+
+}  // namespace fusion
+}  // namespace phi

--- a/paddle/phi/kernels/fused_transpose_split_quant_kernel.h
+++ b/paddle/phi/kernels/fused_transpose_split_quant_kernel.h
@@ -1,0 +1,33 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <vector>
+#include "paddle/phi/core/dense_tensor.h"
+#include "paddle/utils/optional.h"
+
+namespace phi {
+
+template <typename T, typename Context>
+void FusedTransposeSplitQuantKernel(
+    const Context& dev_ctx,
+    const DenseTensor& x,
+    const paddle::optional<DenseTensor>& input_scales,
+    const std::vector<int64_t>& tokens_per_expert,
+    bool pow_2_scales,
+    std::vector<DenseTensor*> outs,
+    std::vector<DenseTensor*> output_scales);
+
+}  // namespace phi

--- a/paddle/phi/kernels/fused_transpose_wlch_split_quant_kernel.h
+++ b/paddle/phi/kernels/fused_transpose_wlch_split_quant_kernel.h
@@ -1,0 +1,33 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <vector>
+#include "paddle/phi/core/dense_tensor.h"
+
+namespace phi {
+namespace fusion {
+
+template <typename T, typename Context>
+void FusedTransposeWLCHSplitQuantKernel(
+    const Context& dev_ctx,
+    const DenseTensor& x,
+    const std::vector<int64_t>& tokens_per_expert,
+    bool pow_2_scales,
+    std::vector<DenseTensor*> outs,
+    std::vector<DenseTensor*> scales);
+
+}  // namespace fusion
+}  // namespace phi

--- a/paddle/phi/kernels/fusion/cpu/fused_seqpool_cvm_grad_kernel.cc
+++ b/paddle/phi/kernels/fusion/cpu/fused_seqpool_cvm_grad_kernel.cc
@@ -12,12 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "paddle/phi/kernels/fused_seqpool_cvm_grad_kernel.h"
 #include <memory>
 #include <vector>
-
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/core/tensor_utils.h"
-#include "Paddle/paddle/phi/kernels/fused_seqpool_cvm_grad_kernel.h"
 
 namespace phi {
 

--- a/paddle/phi/kernels/fusion/cpu/fused_seqpool_cvm_kernel.cc
+++ b/paddle/phi/kernels/fusion/cpu/fused_seqpool_cvm_kernel.cc
@@ -17,6 +17,7 @@
 
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/core/tensor_utils.h"
+#include "Paddle/paddle/phi/kernels/fused_seqpool_cvm_kernel.h"
 
 namespace phi {
 

--- a/paddle/phi/kernels/fusion/cpu/fused_seqpool_cvm_kernel.cc
+++ b/paddle/phi/kernels/fusion/cpu/fused_seqpool_cvm_kernel.cc
@@ -12,12 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "paddle/phi/kernels/fused_seqpool_cvm_kernel.h"
 #include <memory>
 #include <vector>
-
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/core/tensor_utils.h"
-#include "Paddle/paddle/phi/kernels/fused_seqpool_cvm_kernel.h"
 
 namespace phi {
 

--- a/paddle/phi/kernels/fusion/cpu/fused_softmax_mask_grad_kernel.cc
+++ b/paddle/phi/kernels/fusion/cpu/fused_softmax_mask_grad_kernel.cc
@@ -14,6 +14,7 @@
 
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/softmax_grad_kernel.h"
+#include "Paddle/paddle/phi/kernels/fused_softmax_mask_grad_kernel.h"
 
 namespace phi::fusion {
 

--- a/paddle/phi/kernels/fusion/cpu/fused_softmax_mask_grad_kernel.cc
+++ b/paddle/phi/kernels/fusion/cpu/fused_softmax_mask_grad_kernel.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "paddle/phi/kernels/fused_softmax_mask_grad_kernel.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/softmax_grad_kernel.h"
-#include "Paddle/paddle/phi/kernels/fused_softmax_mask_grad_kernel.h"
 
 namespace phi::fusion {
 

--- a/paddle/phi/kernels/fusion/gpu/fused_seqpool_cvm_grad_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/fused_seqpool_cvm_grad_kernel.cu
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "paddle/phi/kernels/fused_seqpool_cvm_grad_kernel.h"
 #include <string>
 #include "paddle/phi/backends/gpu/gpu_info.h"
 #include "paddle/phi/backends/gpu/gpu_launch_config.h"
 #include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/core/mixed_vector.h"
-#include "Paddle/paddle/phi/kernels/fused_seqpool_cvm_grad_kernel.h"
 
 namespace phi {
 namespace fusion {

--- a/paddle/phi/kernels/fusion/gpu/fused_seqpool_cvm_grad_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/fused_seqpool_cvm_grad_kernel.cu
@@ -18,6 +18,7 @@
 #include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/core/mixed_vector.h"
+#include "Paddle/paddle/phi/kernels/fused_seqpool_cvm_grad_kernel.h"
 
 namespace phi {
 namespace fusion {

--- a/paddle/phi/kernels/fusion/gpu/fused_seqpool_cvm_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/fused_seqpool_cvm_kernel.cu
@@ -18,6 +18,7 @@
 #include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/core/mixed_vector.h"
+#include "Paddle/paddle/phi/kernels/fused_seqpool_cvm_kernel.h"
 
 namespace phi {
 namespace fusion {

--- a/paddle/phi/kernels/fusion/gpu/fused_seqpool_cvm_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/fused_seqpool_cvm_kernel.cu
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "paddle/phi/kernels/fused_seqpool_cvm_kernel.h"
 #include <string>
 #include "paddle/phi/backends/gpu/gpu_info.h"
 #include "paddle/phi/backends/gpu/gpu_launch_config.h"
 #include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/core/mixed_vector.h"
-#include "Paddle/paddle/phi/kernels/fused_seqpool_cvm_kernel.h"
 
 namespace phi {
 namespace fusion {

--- a/paddle/phi/kernels/fusion/gpu/fused_softmax_mask_grad_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/fused_softmax_mask_grad_kernel.cu
@@ -16,8 +16,8 @@
 
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/full_kernel.h"
+#include "paddle/phi/kernels/fused_softmax_mask_grad_kernel.h"
 #include "paddle/phi/kernels/fusion/gpu/fused_softmax_mask_utils.h"
-#include "Paddle/paddle/phi/kernels/fused_softmax_mask_grad_kernel.h"
 
 namespace phi {
 namespace fusion {

--- a/paddle/phi/kernels/fusion/gpu/fused_softmax_mask_grad_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/fused_softmax_mask_grad_kernel.cu
@@ -17,6 +17,7 @@
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/fusion/gpu/fused_softmax_mask_utils.h"
+#include "Paddle/paddle/phi/kernels/fused_softmax_mask_grad_kernel.h"
 
 namespace phi {
 namespace fusion {

--- a/paddle/phi/kernels/fusion/gpu/fused_stack_transpose_quant_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/fused_stack_transpose_quant_kernel.cu
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "Paddle/paddle/phi/kernels/fused_stack_transpose_quant_kernel.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/kernel_registry.h"

--- a/paddle/phi/kernels/fusion/gpu/fused_stack_transpose_quant_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/fused_stack_transpose_quant_kernel.cu
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "Paddle/paddle/phi/kernels/fused_stack_transpose_quant_kernel.h"
+#include "paddle/phi/kernels/fused_stack_transpose_quant_kernel.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/kernel_registry.h"

--- a/paddle/phi/kernels/fusion/gpu/fused_transpose_split_quant_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/fused_transpose_split_quant_kernel.cu
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "paddle/phi/kernels/fused_transpose_split_quant_kernel.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/core/tensor_utils.h"

--- a/paddle/phi/kernels/fusion/gpu/fused_transpose_wlch_split_quant_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/fused_transpose_wlch_split_quant_kernel.cu
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "paddle/phi/kernels/fused_transpose_wlch_split_quant_kernel.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/kernel_registry.h"

--- a/paddle/phi/kernels/fusion/gpu/fusion_group_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/fusion_group_kernel.cu
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "paddle/phi/kernels/fusion_group_kernel.h"
 #include "glog/logging.h"
 
 #include "paddle/phi/backends/device_code.h"

--- a/paddle/phi/kernels/fusion/gpu/skip_layernorm_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/skip_layernorm_kernel.cu
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "paddle/phi/kernels/skip_layernorm_kernel.h"
 #include "paddle/common/errors.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/core/tensor_utils.h"

--- a/paddle/phi/kernels/fusion/xpu/fused_softmax_mask_grad_kernel.cc
+++ b/paddle/phi/kernels/fusion/xpu/fused_softmax_mask_grad_kernel.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "paddle/phi/kernels/fused_softmax_mask_grad_kernel.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/softmax_grad_kernel.h"
-#include "Paddle/paddle/phi/kernels/fused_softmax_mask_grad_kernel.h"
 
 namespace phi {
 namespace fusion {

--- a/paddle/phi/kernels/fusion/xpu/fused_softmax_mask_grad_kernel.cc
+++ b/paddle/phi/kernels/fusion/xpu/fused_softmax_mask_grad_kernel.cc
@@ -14,6 +14,7 @@
 
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/softmax_grad_kernel.h"
+#include "Paddle/paddle/phi/kernels/fused_softmax_mask_grad_kernel.h"
 
 namespace phi {
 namespace fusion {

--- a/paddle/phi/kernels/fusion_group_kernel.h
+++ b/paddle/phi/kernels/fusion_group_kernel.h
@@ -1,0 +1,34 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+#include <vector>
+#include "paddle/phi/core/dense_tensor.h"
+
+namespace phi {
+namespace fusion {
+
+template <typename T, typename Context>
+void FusionGroupKernel(const Context& dev_ctx,
+                       const std::vector<const DenseTensor*>& ins,
+                       const std::vector<int>& outs_dtype,
+                       const std::vector<int>& inputs_dtype,
+                       const std::string& func_name,
+                       int type,
+                       std::vector<DenseTensor*> outs);
+
+}  // namespace fusion
+}  // namespace phi

--- a/paddle/phi/kernels/gpu/affine_channel_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/affine_channel_grad_kernel.cu
@@ -24,6 +24,7 @@ namespace cub = hipcub;
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/backends/gpu/gpu_primitives.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/affine_channel_grad_kernel.h"
 
 namespace phi {
 

--- a/paddle/phi/kernels/gpu/affine_channel_kernel.cu
+++ b/paddle/phi/kernels/gpu/affine_channel_kernel.cu
@@ -24,6 +24,7 @@ namespace cub = hipcub;
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/backends/gpu/gpu_primitives.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/affine_channel_kernel.h"
 
 namespace phi {
 

--- a/paddle/phi/kernels/skip_layernorm_kernel.h
+++ b/paddle/phi/kernels/skip_layernorm_kernel.h
@@ -1,0 +1,34 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "paddle/phi/core/dense_tensor.h"
+#include "paddle/phi/core/kernel_registry.h"
+
+namespace phi {
+namespace fusion {
+
+template <typename T, typename Context>
+void SkipLayerNormKernel(const Context& dev_ctx,
+                         const DenseTensor& x,
+                         const DenseTensor& y,
+                         const DenseTensor& scale,
+                         const DenseTensor& bias,
+                         const float epsilon,
+                         const int begin_norm_axis,
+                         DenseTensor* out);
+
+}  // namespace fusion
+}  // namespace phi

--- a/paddle/phi/kernels/xpu/affine_channel_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/affine_channel_grad_kernel.cc
@@ -18,6 +18,7 @@
 
 #include "paddle/phi/backends/xpu/enforce_xpu.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/affine_channel_grad_kernel.h"
 #include "paddle/phi/kernels/funcs/eigen/common.h"
 
 namespace phi {

--- a/paddle/phi/kernels/xpu/affine_channel_kernel.cc
+++ b/paddle/phi/kernels/xpu/affine_channel_kernel.cc
@@ -18,6 +18,7 @@
 
 #include "paddle/phi/backends/xpu/enforce_xpu.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/affine_channel_kernel.h"
 #include "paddle/phi/kernels/funcs/eigen/common.h"
 
 namespace phi {


### PR DESCRIPTION
### PR Category
Performance Optimization

### PR Types
Bug fixes

### Description
在paddle/phi/kernels/文件夹下新增fused_seqpool_cvm_grad_kernel.h,并在fused_seqpool_cvm_grad_kernel.cc和fused_seqpool_cvm_grad_kernel.cu声明