### PR TITLE
【CUDA Kernel No.8】fused_seqpool_cvm算子Kernel修复 -part

### DIFF
--- a/paddle/phi/kernels/fused_seqpool_cvm_kernel.h
+++ b/paddle/phi/kernels/fused_seqpool_cvm_kernel.h
@@ -1,0 +1,34 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND.
+
+#pragma once
+
+#include <string>
+#include <vector>
+#include "paddle/phi/backends/gpu/gpu_context.h"
+#include "paddle/phi/core/dense_tensor.h"
+
+namespace phi {
+namespace fusion {
+
+template <typename T, typename Context>
+void FusedSeqpoolCVMCUDAKernel(const Context &dev_ctx,
+                               const std::vector<const DenseTensor *> &x,
+                               const DenseTensor &cvm,
+                               const std::string &pooltype,
+                               float pad_value,
+                               bool use_cvm,
+                               int cvm_offset,
+                               std::vector<DenseTensor *> out);
+
+}  // namespace fusion
+}  // namespace phi

--- a/paddle/phi/kernels/fusion/cpu/fused_seqpool_cvm_kernel.cc
+++ b/paddle/phi/kernels/fusion/cpu/fused_seqpool_cvm_kernel.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "paddle/phi/kernels/fused_seqpool_cvm_kernel.h"
 #include <memory>
 #include <vector>
 

--- a/paddle/phi/kernels/fusion/gpu/fused_seqpool_cvm_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/fused_seqpool_cvm_kernel.cu
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "paddle/phi/kernels/fused_seqpool_cvm_kernel.h"
 #include <string>
 #include "paddle/phi/backends/gpu/gpu_info.h"
 #include "paddle/phi/backends/gpu/gpu_launch_config.h"


### PR DESCRIPTION
### PR Category
Performance Optimization


### PR Types
Bug fixes


### Description
在paddle/phi/kernels/文件夹下新增fused_seqpool_cvm_kernel.h,并在fused_seqpool_cvm_kernel.cc和fused_seqpool_cvm_kernel.cu声明
