### PR TITLE
【CUDA Kernel No.20】affine_channel算子Kernel修复 -part

### DIFF
--- a/paddle/phi/kernels/affine_channel_kernel.h
+++ b/paddle/phi/kernels/affine_channel_kernel.h
@@ -1,0 +1,33 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+#include "paddle/phi/backends/gpu/gpu_context.h"
+#include "paddle/phi/core/dense_tensor.h"
+#include "paddle/phi/core/kernel_registry.h"
+
+namespace phi {
+
+// AffineChannel CUDA kernel wrapper
+template <typename T, typename Context>
+void AffineChannelCUDAKernel(const Context& dev_ctx,
+                             const DenseTensor& x_in,
+                             const DenseTensor& scale_in,
+                             const DenseTensor& bias_in,
+                             const std::string& data_layout,
+                             DenseTensor* out);
+
+}  // namespace phi

--- a/paddle/phi/kernels/cpu/affine_channel_kernel.cc
+++ b/paddle/phi/kernels/cpu/affine_channel_kernel.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "paddle/phi/kernels/affine_channel_kernel.h"
 #include <string>
 #include <unordered_map>
-
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/eigen/common.h"
 

--- a/paddle/phi/kernels/gpu/affine_channel_kernel.cu
+++ b/paddle/phi/kernels/gpu/affine_channel_kernel.cu
@@ -20,10 +20,10 @@
 #include <hipcub/hipcub.hpp>
 namespace cub = hipcub;
 #endif
-
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/backends/gpu/gpu_primitives.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/affine_channel_kernel.h"
 
 namespace phi {
 

--- a/paddle/phi/kernels/xpu/affine_channel_kernel.cc
+++ b/paddle/phi/kernels/xpu/affine_channel_kernel.cc
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "paddle/phi/kernels/affine_channel_kernel.h"
 #include <string>
 #include <unordered_map>
 #include <vector>
-
 #include "paddle/phi/backends/xpu/enforce_xpu.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/eigen/common.h"


### PR DESCRIPTION
### PR Category
Performance Optimization


### PR Types
Bug fixes


### Description
在paddle/phi/kernels/文件夹下新增affine_channel_kernel.h,并在affine_channel_kernel.cc（xpu和cpu）和affine_channel_kernel.cu声明