### PR TITLE
Contiguous input tensor in getitem

### DIFF
--- a/paddle/fluid/pybind/eager_method.cc
+++ b/paddle/fluid/pybind/eager_method.cc
@@ -1579,6 +1579,9 @@ static PyObject* tensor__getitem_dygraph(TensorObject* self,
           "tensor please init it first with numpy or other tensor.",
           self->tensor.name()));
 
+  if (!self->tensor.is_contiguous()) {
+    self->tensor = self->tensor.contiguous();
+  }
   auto tensor = self->tensor;
   const int rank = tensor.shape().size();
   std::vector<int64_t> slice_starts, slice_ends, slice_strides;


### PR DESCRIPTION
### PR Category
Performance Optimization

### PR Types
Improvements

### Description
getitem输入增加contiguous转换，以支持非连续输入

```python
import paddle
import torch

base = torch.tensor([5., 5., 6., 5., 5., 6.], dtype=torch.float64)
foo_strided = torch.as_strided(base, size=(2,1), stride=(2,1))

base2 = torch.tensor([0, 0, 1, 0, 1, 0,0,5,5,5,5], dtype=torch.int64)
atype = torch.as_strided(base2, size=(2,3), stride=(4,1))

result = foo_strided[atype]
print("result:", result)

base = paddle.to_tensor([5., 5., 6., 5., 5., 6.], dtype=paddle.float64)
foo_strided = paddle.as_strided(base, shape=(2,1), stride=(2,1))

base2 = paddle.to_tensor([0, 0, 1, 0, 1, 0,0,5,5,5,5], dtype=paddle.int64)
atype = paddle.as_strided(base2, shape=(2,3), stride=(4,1))

result = foo_strided[atype]
print("result:", result)

``` 
输出
```python
result: tensor([[[5.],
         [5.],
         [6.]],

        [[6.],
         [5.],
         [5.]]], dtype=torch.float64)
result: Tensor(shape=[2, 3, 1], dtype=float64, place=Place(gpu:0), stop_gradient=True,
       [[[5.],
         [5.],
         [6.]],

        [[5.],
         [6.],
         [5.]]])
``` 


pcard-67164
