### PR TITLE
[Precision Depth Alignment] fix precision for  paddle.expm1

### DIFF
--- a/paddle/phi/kernels/funcs/activation_functor.h
+++ b/paddle/phi/kernels/funcs/activation_functor.h
@@ -3782,36 +3782,39 @@ struct CudaReciprocalGradDepXFunctor<ComplexType<T>>
 
 template <typename T>
 struct CudaExpm1Functor : public BaseActivationFunctor<T> {
-  using U = typename std::conditional_t<std::is_integral<T>::value, float, T>;
-
-  // expm1(x) = expm1f(x)
-  __device__ __forceinline__ U operator()(const T x) const {
-    return static_cast<U>(::expm1f(static_cast<float>(x)));
-  }
-};
-
-template <>
-struct CudaExpm1Functor<double> : public BaseActivationFunctor<double> {
+  using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
   // expm1(x) = expm1(x)
-  __device__ __forceinline__ double operator()(const double x) const {
-    return ::expm1(x);
+  __device__ __forceinline__ T operator()(const T arg_x) const {
+    MPType x = static_cast<MPType>(arg_x);
+    return static_cast<T>(expm1(x));
   }
 };
+
+template <typename T>
+__device__ __forceinline__ ComplexType<T> local_expm1(const ComplexType<T>& z) {
+  T x = z.real;
+  T y = z.imag;
+  T a = std::sin(y / 2);
+  T er = std::expm1(x) * std::cos(y) - T(2) * a * a;
+  T ei = std::exp(x) * std::sin(y);
+  return {er, ei};
+}
 
 template <typename T>
 struct CudaExpm1Functor<ComplexType<T>>
     : public BaseActivationFunctor<ComplexType<T>> {
   __device__ __forceinline__ ComplexType<T> operator()(
       const ComplexType<T> x) const {
-    return static_cast<ComplexType<T>>(Expm1<ComplexType<T>>()(x));
+    return static_cast<ComplexType<T>>(local_expm1(x));
   }
 };
 
 template <typename T>
 struct CudaExpm1GradFunctor : public BaseActivationFunctor<T> {
+  T one = static_cast<T>(1.0f);
   // dx = dout * out
   __device__ __forceinline__ T operator()(const T dout, const T out) const {
-    return dout * out + dout;
+    return dout * (out + one);
   }
 
   static constexpr ActBwdOpFwdDeps FwdDeps() {
@@ -3822,10 +3825,11 @@ struct CudaExpm1GradFunctor : public BaseActivationFunctor<T> {
 template <typename T>
 struct CudaExpm1GradFunctor<ComplexType<T>>
     : public BaseActivationFunctor<ComplexType<T>> {
+  ComplexType<T> one = static_cast<ComplexType<T>>(1.0f);
   // dx = dout * exp(x)
   __device__ __forceinline__ ComplexType<T> operator()(
       const ComplexType<T> dout, const ComplexType<T> out) const {
-    return static_cast<ComplexType<T>>(dout * conj(out) + dout);
+    return static_cast<ComplexType<T>>(dout * (conj(out) + one));
   }
 
   static constexpr ActBwdOpFwdDeps FwdDeps() {

--- a/paddle/phi/kernels/funcs/activation_functor.h
+++ b/paddle/phi/kernels/funcs/activation_functor.h
@@ -3782,11 +3782,19 @@ struct CudaReciprocalGradDepXFunctor<ComplexType<T>>
 
 template <typename T>
 struct CudaExpm1Functor : public BaseActivationFunctor<T> {
-  using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
+  using U = typename std::conditional_t<std::is_integral<T>::value, float, T>;
+
+  // expm1(x) = expm1f(x)
+  __device__ __forceinline__ U operator()(const T x) const {
+    return static_cast<U>(::expm1f(static_cast<float>(x)));
+  }
+};
+
+template <>
+struct CudaExpm1Functor<double> : public BaseActivationFunctor<double> {
   // expm1(x) = expm1(x)
-  __device__ __forceinline__ T operator()(const T arg_x) const {
-    MPType x = static_cast<MPType>(arg_x);
-    return static_cast<T>(expm1(x));
+  __device__ __forceinline__ double operator()(const double x) const {
+    return ::expm1(x);
   }
 };
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
**PR描述：**

1. **复数 `expm1` 实现优化**
   - **旧版**：调用通用的 `Expm1<ComplexType<T>>()(x)`
   - **新版**：实现了专门的 `local_expm1` 函数，使用数学公式：
     ```cpp
     // expm1(z) = expm1(x+iy) 的优化实现
     er = expm1(x) * cos(y) - 2 * sin²(y/2)
     ei = exp(x) * sin(y)
     ```

2. **梯度计算修正**
从 `dout * out + dout` 改为 `dout * (out + 1)` ✓

**测试结果：**
paddle.expm1 全部与torch对齐（测试case 18 个）

pcard-93269