### PR TITLE
【CUDA Kernel No.102】row_conv算子Kernel修复 -part 

### DIFF
--- a/paddle/phi/kernels/cpu/row_conv_kernel.cc
+++ b/paddle/phi/kernels/cpu/row_conv_kernel.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "paddle/phi/kernels/row_conv_kernel.h"
 #include <memory>
 #include <string>
 #include <vector>

--- a/paddle/phi/kernels/gpu/row_conv_kernel.cu
+++ b/paddle/phi/kernels/gpu/row_conv_kernel.cu
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "paddle/phi/kernels/row_conv_kernel.h"
 #include "paddle/phi/backends/gpu/gpu_device_function.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/core/mixed_vector.h"
 #include "paddle/phi/kernels/funcs/math_function.h"
+
 namespace phi {
 
 namespace {

--- a/paddle/phi/kernels/row_conv_kernel.h
+++ b/paddle/phi/kernels/row_conv_kernel.h
@@ -1,0 +1,37 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "paddle/phi/backends/gpu/gpu_context.h"
+#include "paddle/phi/core/dense_tensor.h"
+#include "paddle/phi/core/kernel_registry.h"
+
+namespace phi {
+
+template <typename T, typename Context>
+void RowConvKernel(const Context& dev_ctx,
+                   const DenseTensor& x,
+                   const DenseTensor& filter,
+                   DenseTensor* out);
+
+template <typename T, typename Context>
+void RowConvGradKernel(const Context& dev_ctx,
+                       const DenseTensor& x,
+                       const DenseTensor& filter,
+                       const DenseTensor& out_grad,
+                       DenseTensor* x_grad,
+                       DenseTensor* filter_grad);
+
+}  // namespace phi

--- a/paddle/phi/kernels/row_conv_kernel.h
+++ b/paddle/phi/kernels/row_conv_kernel.h
@@ -26,12 +26,4 @@ void RowConvKernel(const Context& dev_ctx,
                    const DenseTensor& filter,
                    DenseTensor* out);
 
-template <typename T, typename Context>
-void RowConvGradKernel(const Context& dev_ctx,
-                       const DenseTensor& x,
-                       const DenseTensor& filter,
-                       const DenseTensor& out_grad,
-                       DenseTensor* x_grad,
-                       DenseTensor* filter_grad);
-
 }  // namespace phi


### PR DESCRIPTION
### PR Category
Performance Optimization

### PR Types
Bug fixes

### Description
在paddle/phi/kernels/文件夹下新增row_conv_kernel.h
在row_conv_kernel.cc和row_conv_kernel.cu中加入#include
