### PR TITLE
Replace deprecated `paddle.dataset.uci_housing` with `paddle.text.datasets.UCIHousing` in test_fit_a_line_deprecated

### DIFF
--- a/test/deprecated/book/test_fit_a_line_deprecated.py
+++ b/test/deprecated/book/test_fit_a_line_deprecated.py
@@ -180,11 +180,15 @@ def infer(use_cuda, save_dirname=None, use_bf16=False):
         # The input data should be >= 0
         batch_size = 10
 
-        test_reader = paddle.batch(
-            paddle.dataset.uci_housing.test(), batch_size=batch_size
-        )
+        test_data = []
+        uci_housing = paddle.text.datasets.UCIHousing(mode='train')
+        count = 0
+        for data in uci_housing:
+            test_data.append(data)
+            count = count + 1
+            if count >= batch_size:
+                break
 
-        test_data = next(test_reader())
         test_feat = numpy.array([data[0] for data in test_data]).astype(
             "float32"
         )


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience

### PR Types
Others 

### Description
<!-- Describe what you’ve done -->
paddle.dataset.uci_housing.train 已废弃，修改为 paddle.text.datasets.UCIHousing
