### PR TITLE
[深度对齐] mod

### DIFF
--- a/paddle/phi/kernels/funcs/elementwise_functor.h
+++ b/paddle/phi/kernels/funcs/elementwise_functor.h
@@ -315,11 +315,7 @@ template <typename T, typename Enable = void>
 struct FloorDivideFunctor {
   inline HOSTDEVICE T operator()(const T a, const T b) const {
 #ifndef PADDLE_WITH_XPU_KP
-    PADDLE_ENFORCE_NE(
-        b,
-        0,
-        "InvalidArgumentError: Integer division by zero encountered in "
-        "(floor/trunc) divide. Please check the input value.");
+    PADDLE_ENFORCE(b != 0, DIV_ERROR_INFO);
 #endif
 
     if (phi::is_negative(a) != phi::is_negative(b)) {
@@ -433,11 +429,7 @@ template <typename T, typename Enable = void>
 struct InverseFloorDivideFunctor {
   inline HOSTDEVICE T operator()(const T a, const T b) const {
 #ifndef PADDLE_WITH_XPU_KP
-    PADDLE_ENFORCE_NE(
-        a,
-        0,
-        "InvalidArgumentError: Integer division by zero encountered in "
-        "(floor/trunc) divide. Please check the input value.");
+    PADDLE_ENFORCE(a != 0, DIV_ERROR_INFO);
 #endif
     if (phi::is_negative(a) != phi::is_negative(b)) {
       // Subtracts one from the results of truncation division if the

--- a/paddle/phi/kernels/funcs/elementwise_functor.h
+++ b/paddle/phi/kernels/funcs/elementwise_functor.h
@@ -315,7 +315,11 @@ template <typename T, typename Enable = void>
 struct FloorDivideFunctor {
   inline HOSTDEVICE T operator()(const T a, const T b) const {
 #ifndef PADDLE_WITH_XPU_KP
-    PADDLE_ENFORCE_NE(b, 0, DIV_ERROR_INFO);
+    PADDLE_ENFORCE_NE(
+        b,
+        0,
+        "InvalidArgumentError: Integer division by zero encountered in "
+        "(floor/trunc) divide. Please check the input value.");
 #endif
 
     if (phi::is_negative(a) != phi::is_negative(b)) {
@@ -429,7 +433,11 @@ template <typename T, typename Enable = void>
 struct InverseFloorDivideFunctor {
   inline HOSTDEVICE T operator()(const T a, const T b) const {
 #ifndef PADDLE_WITH_XPU_KP
-    PADDLE_ENFORCE_NE(a, 0, DIV_ERROR_INFO);
+    PADDLE_ENFORCE_NE(
+        a,
+        0,
+        "InvalidArgumentError: Integer division by zero encountered in "
+        "(floor/trunc) divide. Please check the input value.");
 #endif
     if (phi::is_negative(a) != phi::is_negative(b)) {
       // Subtracts one from the results of truncation division if the

--- a/paddle/phi/kernels/funcs/elementwise_functor.h
+++ b/paddle/phi/kernels/funcs/elementwise_functor.h
@@ -1128,7 +1128,7 @@ struct RemainderGradYFunctor<
     auto x_ = static_cast<MPType>(x);
     auto y_ = static_cast<MPType>(y);
     FloorDivideFunctor<MPType> floor_div;
-    return static_cast<T>(-static_cast<MPType>(dout) * (floor_div(x_ / y_)));
+    return static_cast<T>(-static_cast<MPType>(dout) * (floor_div(x_, y_)));
   }
 };
 template <typename T>

--- a/paddle/phi/kernels/funcs/elementwise_functor.h
+++ b/paddle/phi/kernels/funcs/elementwise_functor.h
@@ -310,6 +310,234 @@ struct DivGradYFunctor<ComplexType<T>> {
     return -a * out_div_c_conj;
   }
 };
+// Floor divide
+template <typename T, typename Enable = void>
+struct FloorDivideFunctor {
+  inline HOSTDEVICE T operator()(const T a, const T b) const {
+#ifndef PADDLE_WITH_XPU_KP
+    PADDLE_ENFORCE_NE(b, 0, DIV_ERROR_INFO);
+#endif
+
+    if (phi::is_negative(a) != phi::is_negative(b)) {
+      // Subtracts one from the results of truncation division if the
+      // divisor and dividend have different sign(bit)s and the remainder of
+      // the division is nonzero
+      const auto quot = a / b;
+      const auto rem = a % b;
+      auto ret = rem ? quot - 1 : quot;
+      return static_cast<T>(ret);
+    }
+
+    return static_cast<T>(a / b);
+  }
+};
+
+template <typename T>
+struct FloorDivideFunctor<
+    T,
+    typename std::enable_if_t<std::is_floating_point<T>::value>> {
+  inline HOSTDEVICE T operator()(const T a, const T b) const {
+    if (UNLIKELY(b == 0)) {
+      // Divide by zero: return standard IEEE result
+      return static_cast<T>(a / b);
+    }
+
+    auto mod = std::fmod(a, b);
+    auto div = (a - mod) / b;
+    if ((mod != 0) && (b < 0) != (mod < 0)) {
+      div -= T(1);
+    }
+
+    T floordiv;
+    if (div != 0) {
+      floordiv = std::floor(div);
+      if (div - floordiv > T(0.5)) {
+        floordiv += T(1.0);
+      }
+    } else {
+      floordiv = phi::copysign(T(0), a / b);
+    }
+    return floordiv;
+  }
+};
+
+template <>
+struct FloorDivideFunctor<dtype::float16> {
+  inline HOSTDEVICE dtype::float16 operator()(const dtype::float16 a,
+                                              const dtype::float16 b) const {
+    float b_float = static_cast<float>(b);
+    float a_float = static_cast<float>(a);
+
+    if (UNLIKELY(b_float == 0)) {
+      // Divide by zero: return standard IEEE result
+      return static_cast<dtype::float16>(a_float / b_float);
+    }
+
+    auto mod = std::fmod(a_float, b_float);
+    auto div = (a_float - mod) / b_float;
+    if ((mod != 0) && (b_float < 0) != (mod < 0)) {
+      div -= static_cast<float>(1);
+    }
+
+    float floordiv;
+    if (div != 0) {
+      floordiv = std::floor(div);
+      if (div - floordiv > static_cast<float>(0.5)) {
+        floordiv += static_cast<float>(1.0);
+      }
+    } else {
+      floordiv = phi::copysign(static_cast<float>(0), a_float / b_float);
+    }
+
+    return static_cast<dtype::float16>(floordiv);
+  }
+};
+
+template <>
+struct FloorDivideFunctor<dtype::bfloat16> {
+  inline HOSTDEVICE dtype::bfloat16 operator()(const dtype::bfloat16 a,
+                                               const dtype::bfloat16 b) const {
+    float b_float = static_cast<float>(b);
+    float a_float = static_cast<float>(a);
+
+    if (UNLIKELY(b_float == 0)) {
+      // Divide by zero: return standard IEEE result
+      return static_cast<dtype::bfloat16>(a_float / b_float);
+    }
+
+    auto mod = std::fmod(a_float, b_float);
+    auto div = (a_float - mod) / b_float;
+    if ((mod != 0) && (b_float < 0) != (mod < 0)) {
+      div -= static_cast<float>(1);
+    }
+
+    float floordiv;
+    if (div != 0) {
+      floordiv = std::floor(div);
+      if (div - floordiv > static_cast<float>(0.5)) {
+        floordiv += static_cast<float>(1.0);
+      }
+    } else {
+      floordiv = phi::copysign(static_cast<float>(0), a_float / b_float);
+    }
+
+    return static_cast<dtype::bfloat16>(floordiv);
+  }
+};
+
+template <typename T, typename Enable = void>
+struct InverseFloorDivideFunctor {
+  inline HOSTDEVICE T operator()(const T a, const T b) const {
+#ifndef PADDLE_WITH_XPU_KP
+    PADDLE_ENFORCE_NE(a, 0, DIV_ERROR_INFO);
+#endif
+    if (phi::is_negative(a) != phi::is_negative(b)) {
+      // Subtracts one from the results of truncation division if the
+      // divisor and dividend have different sign(bit)s and the remainder of
+      // the division is nonzero
+      const auto quot = b / a;
+      const auto rem = b % a;
+      auto ret = rem ? quot - 1 : quot;
+      return static_cast<T>(ret);
+    }
+
+    return static_cast<T>(b / a);
+  }
+};
+
+template <typename T>
+struct InverseFloorDivideFunctor<
+    T,
+    typename std::enable_if_t<std::is_floating_point<T>::value>> {
+  inline HOSTDEVICE T operator()(const T a, const T b) const {
+    if (UNLIKELY(a == 0)) {
+      // Divide by zero: return standard IEEE result
+      return static_cast<T>(b / a);
+    }
+
+    auto mod = std::fmod(b, a);
+    auto div = (b - mod) / a;
+    if ((mod != 0) && (a < 0) != (mod < 0)) {
+      div -= T(1);
+    }
+
+    T floordiv;
+    if (div != 0) {
+      floordiv = std::floor(div);
+      if (div - floordiv > T(0.5)) {
+        floordiv += T(1.0);
+      }
+    } else {
+      floordiv = phi::copysign(T(0), b / a);
+    }
+    return floordiv;
+  }
+};
+
+template <>
+struct InverseFloorDivideFunctor<dtype::float16> {
+  inline HOSTDEVICE dtype::float16 operator()(const dtype::float16 a,
+                                              const dtype::float16 b) const {
+    float b_float = static_cast<float>(a);
+    float a_float = static_cast<float>(b);
+
+    if (UNLIKELY(b_float == 0)) {
+      // Divide by zero: return standard IEEE result
+      return static_cast<dtype::float16>(a_float / b_float);
+    }
+
+    auto mod = std::fmod(a_float, b_float);
+    auto div = (a_float - mod) / b_float;
+    if ((mod != 0) && (b_float < 0) != (mod < 0)) {
+      div -= static_cast<float>(1);
+    }
+
+    float floordiv;
+    if (div != 0) {
+      floordiv = std::floor(div);
+      if (div - floordiv > static_cast<float>(0.5)) {
+        floordiv += static_cast<float>(1.0);
+      }
+    } else {
+      floordiv = phi::copysign(static_cast<float>(0), a_float / b_float);
+    }
+
+    return static_cast<dtype::float16>(floordiv);
+  }
+};
+
+template <>
+struct InverseFloorDivideFunctor<dtype::bfloat16> {
+  inline HOSTDEVICE dtype::bfloat16 operator()(const dtype::bfloat16 a,
+                                               const dtype::bfloat16 b) const {
+    float b_float = static_cast<float>(a);
+    float a_float = static_cast<float>(b);
+
+    if (UNLIKELY(b_float == 0)) {
+      // Divide by zero: return standard IEEE result
+      return static_cast<dtype::bfloat16>(a_float / b_float);
+    }
+
+    auto mod = std::fmod(a_float, b_float);
+    auto div = (a_float - mod) / b_float;
+    if ((mod != 0) && (b_float < 0) != (mod < 0)) {
+      div -= static_cast<float>(1);
+    }
+
+    float floordiv;
+    if (div != 0) {
+      floordiv = std::floor(div);
+      if (div - floordiv > static_cast<float>(0.5)) {
+        floordiv += static_cast<float>(1.0);
+      }
+    } else {
+      floordiv = phi::copysign(static_cast<float>(0), a_float / b_float);
+    }
+
+    return static_cast<dtype::bfloat16>(floordiv);
+  }
+};
+
 // Fmin
 template <typename T>
 struct FMinFunctor {
@@ -899,7 +1127,8 @@ struct RemainderGradYFunctor<
     // dy = -dout * (floor_div(x, y))
     auto x_ = static_cast<MPType>(x);
     auto y_ = static_cast<MPType>(y);
-    return static_cast<T>(-static_cast<MPType>(dout) * (std::floor((x_ / y_))));
+    FloorDivideFunctor<MPType> floor_div;
+    return static_cast<T>(-static_cast<MPType>(dout) * (floor_div(x_ / y_)));
   }
 };
 template <typename T>
@@ -931,7 +1160,8 @@ struct RemainderGradXYFunctor {
     // dx = dout
     outs[0] = static_cast<OutT>(dout);
     // dy = -dout * (floor_div(x, y))
-    outs[1] = static_cast<OutT>(dout * static_cast<InT>(std::floor(x / y)));
+    FloorDivideFunctor<InT> floor_div;
+    outs[1] = static_cast<OutT>(dout * static_cast<InT>(floor_div(x, y)));
     return outs;
   }
 };
@@ -950,8 +1180,8 @@ struct RemainderGradXYFunctor<
     using MPType = typename phi::dtype::MPTypeTrait<InT>::Type;
     auto x_ = static_cast<MPType>(x);
     auto y_ = static_cast<MPType>(y);
-    outs[1] =
-        static_cast<OutT>(static_cast<MPType>(-dout) * std::floor(x_ / y_));
+    FloorDivideFunctor<MPType> floor_div;
+    outs[1] = static_cast<OutT>(static_cast<MPType>(-dout) * floor_div(x_, y_));
     return outs;
   }
 };
@@ -1097,233 +1327,6 @@ template <typename T>
 struct ElementwiseInverseHeavisideFunctor {
   inline HOSTDEVICE T operator()(const T a, const T b) const {
     return b == static_cast<T>(0) ? a : static_cast<T>(b > static_cast<T>(0));
-  }
-};
-
-template <typename T, typename Enable = void>
-struct FloorDivideFunctor {
-  inline HOSTDEVICE T operator()(const T a, const T b) const {
-#ifndef PADDLE_WITH_XPU_KP
-    PADDLE_ENFORCE(b != 0, DIV_ERROR_INFO);
-#endif
-
-    if (phi::is_negative(a) != phi::is_negative(b)) {
-      // Subtracts one from the results of truncation division if the
-      // divisor and dividend have different sign(bit)s and the remainder of
-      // the division is nonzero
-      const auto quot = a / b;
-      const auto rem = a % b;
-      auto ret = rem ? quot - 1 : quot;
-      return static_cast<T>(ret);
-    }
-
-    return static_cast<T>(a / b);
-  }
-};
-
-template <typename T>
-struct FloorDivideFunctor<
-    T,
-    typename std::enable_if_t<std::is_floating_point<T>::value>> {
-  inline HOSTDEVICE T operator()(const T a, const T b) const {
-    if (UNLIKELY(b == 0)) {
-      // Divide by zero: return standard IEEE result
-      return static_cast<T>(a / b);
-    }
-
-    auto mod = std::fmod(a, b);
-    auto div = (a - mod) / b;
-    if ((mod != 0) && (b < 0) != (mod < 0)) {
-      div -= T(1);
-    }
-
-    T floordiv;
-    if (div != 0) {
-      floordiv = std::floor(div);
-      if (div - floordiv > T(0.5)) {
-        floordiv += T(1.0);
-      }
-    } else {
-      floordiv = phi::copysign(T(0), a / b);
-    }
-    return floordiv;
-  }
-};
-
-template <>
-struct FloorDivideFunctor<dtype::float16> {
-  inline HOSTDEVICE dtype::float16 operator()(const dtype::float16 a,
-                                              const dtype::float16 b) const {
-    float b_float = static_cast<float>(b);
-    float a_float = static_cast<float>(a);
-
-    if (UNLIKELY(b_float == 0)) {
-      // Divide by zero: return standard IEEE result
-      return static_cast<dtype::float16>(a_float / b_float);
-    }
-
-    auto mod = std::fmod(a_float, b_float);
-    auto div = (a_float - mod) / b_float;
-    if ((mod != 0) && (b_float < 0) != (mod < 0)) {
-      div -= static_cast<float>(1);
-    }
-
-    float floordiv;
-    if (div != 0) {
-      floordiv = std::floor(div);
-      if (div - floordiv > static_cast<float>(0.5)) {
-        floordiv += static_cast<float>(1.0);
-      }
-    } else {
-      floordiv = phi::copysign(static_cast<float>(0), a_float / b_float);
-    }
-
-    return static_cast<dtype::float16>(floordiv);
-  }
-};
-
-template <>
-struct FloorDivideFunctor<dtype::bfloat16> {
-  inline HOSTDEVICE dtype::bfloat16 operator()(const dtype::bfloat16 a,
-                                               const dtype::bfloat16 b) const {
-    float b_float = static_cast<float>(b);
-    float a_float = static_cast<float>(a);
-
-    if (UNLIKELY(b_float == 0)) {
-      // Divide by zero: return standard IEEE result
-      return static_cast<dtype::bfloat16>(a_float / b_float);
-    }
-
-    auto mod = std::fmod(a_float, b_float);
-    auto div = (a_float - mod) / b_float;
-    if ((mod != 0) && (b_float < 0) != (mod < 0)) {
-      div -= static_cast<float>(1);
-    }
-
-    float floordiv;
-    if (div != 0) {
-      floordiv = std::floor(div);
-      if (div - floordiv > static_cast<float>(0.5)) {
-        floordiv += static_cast<float>(1.0);
-      }
-    } else {
-      floordiv = phi::copysign(static_cast<float>(0), a_float / b_float);
-    }
-
-    return static_cast<dtype::bfloat16>(floordiv);
-  }
-};
-
-template <typename T, typename Enable = void>
-struct InverseFloorDivideFunctor {
-  inline HOSTDEVICE T operator()(const T a, const T b) const {
-#ifndef PADDLE_WITH_XPU_KP
-    PADDLE_ENFORCE(a != 0, DIV_ERROR_INFO);
-#endif
-    if (phi::is_negative(a) != phi::is_negative(b)) {
-      // Subtracts one from the results of truncation division if the
-      // divisor and dividend have different sign(bit)s and the remainder of
-      // the division is nonzero
-      const auto quot = b / a;
-      const auto rem = b % a;
-      auto ret = rem ? quot - 1 : quot;
-      return static_cast<T>(ret);
-    }
-
-    return static_cast<T>(b / a);
-  }
-};
-
-template <typename T>
-struct InverseFloorDivideFunctor<
-    T,
-    typename std::enable_if_t<std::is_floating_point<T>::value>> {
-  inline HOSTDEVICE T operator()(const T a, const T b) const {
-    if (UNLIKELY(a == 0)) {
-      // Divide by zero: return standard IEEE result
-      return static_cast<T>(b / a);
-    }
-
-    auto mod = std::fmod(b, a);
-    auto div = (b - mod) / a;
-    if ((mod != 0) && (a < 0) != (mod < 0)) {
-      div -= T(1);
-    }
-
-    T floordiv;
-    if (div != 0) {
-      floordiv = std::floor(div);
-      if (div - floordiv > T(0.5)) {
-        floordiv += T(1.0);
-      }
-    } else {
-      floordiv = phi::copysign(T(0), b / a);
-    }
-    return floordiv;
-  }
-};
-
-template <>
-struct InverseFloorDivideFunctor<dtype::float16> {
-  inline HOSTDEVICE dtype::float16 operator()(const dtype::float16 a,
-                                              const dtype::float16 b) const {
-    float b_float = static_cast<float>(a);
-    float a_float = static_cast<float>(b);
-
-    if (UNLIKELY(b_float == 0)) {
-      // Divide by zero: return standard IEEE result
-      return static_cast<dtype::float16>(a_float / b_float);
-    }
-
-    auto mod = std::fmod(a_float, b_float);
-    auto div = (a_float - mod) / b_float;
-    if ((mod != 0) && (b_float < 0) != (mod < 0)) {
-      div -= static_cast<float>(1);
-    }
-
-    float floordiv;
-    if (div != 0) {
-      floordiv = std::floor(div);
-      if (div - floordiv > static_cast<float>(0.5)) {
-        floordiv += static_cast<float>(1.0);
-      }
-    } else {
-      floordiv = phi::copysign(static_cast<float>(0), a_float / b_float);
-    }
-
-    return static_cast<dtype::float16>(floordiv);
-  }
-};
-
-template <>
-struct InverseFloorDivideFunctor<dtype::bfloat16> {
-  inline HOSTDEVICE dtype::bfloat16 operator()(const dtype::bfloat16 a,
-                                               const dtype::bfloat16 b) const {
-    float b_float = static_cast<float>(a);
-    float a_float = static_cast<float>(b);
-
-    if (UNLIKELY(b_float == 0)) {
-      // Divide by zero: return standard IEEE result
-      return static_cast<dtype::bfloat16>(a_float / b_float);
-    }
-
-    auto mod = std::fmod(a_float, b_float);
-    auto div = (a_float - mod) / b_float;
-    if ((mod != 0) && (b_float < 0) != (mod < 0)) {
-      div -= static_cast<float>(1);
-    }
-
-    float floordiv;
-    if (div != 0) {
-      floordiv = std::floor(div);
-      if (div - floordiv > static_cast<float>(0.5)) {
-        floordiv += static_cast<float>(1.0);
-      }
-    } else {
-      floordiv = phi::copysign(static_cast<float>(0), a_float / b_float);
-    }
-
-    return static_cast<dtype::bfloat16>(floordiv);
   }
 };
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
对mod反向梯度进行修复
原本的梯度计算公式是: return static_cast<T>(-static_cast<MPType>(dout) * (std::floor((x_ / y_))));
这里直接使用std::floor((x_ / y_))缺乏稳定性 
本pr将原本的FloorDivideFunctor提前 并使用FloorDivideFunctor来代替std::floor((x_ / y_)) 保证计算方式一致

修复后paddle.mod(Tensor([],"float64"), Tensor([2, 3, 4],"float64"), )这种维度不一致的case还有几率出错 可能是reduce的问题，其余case均可通过

torch的FloorDivide实现:https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/native/cuda/BinaryDivFloorKernel.cu
```
template <typename scalar_t>
inline C10_HOST_DEVICE scalar_t div_floor_floating(scalar_t a, scalar_t b)
    __ubsan_ignore_float_divide_by_zero__ {
  if (C10_UNLIKELY(b == 0)) {
    // Divide by zero: return standard IEEE result
    return a / b;
  }

  auto mod = std::fmod(a, b);
  auto div = (a - mod) / b;
  if ((mod != 0) && (b < 0) != (mod < 0)) {
    div -= scalar_t(1);
  }

  scalar_t floordiv;
  if (div != 0) {
    floordiv = std::floor(div);
    if (div - floordiv > scalar_t(0.5)) {
      floordiv += scalar_t(1.0);
    }
  } else {
    floordiv = C10_COMPAT_COPYSIGN(scalar_t(0), a / b);
  }
  return floordiv;
}
```