### PR TITLE
Fix FusedLayerNormKernel namespace

### DIFF
--- a/paddle/phi/kernels/fused_layernorm_kernel.h
+++ b/paddle/phi/kernels/fused_layernorm_kernel.h
@@ -18,6 +18,8 @@
 
 namespace phi {
 
+namespace fusion {
+
 template <typename T, typename Context>
 void FusedLayerNormKernel(const Context& dev_ctx,
                           const DenseTensor& x,
@@ -36,4 +38,6 @@ void FusedLayerNormKernel(const Context& dev_ctx,
                           DenseTensor* residual_out,
                           DenseTensor* mean,
                           DenseTensor* variance);
+
+}  // namespace fusion
 }  // namespace phi


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
This PR fixes FusedLayerNormKernel's namespace. It should be phi::fusion.

pcard-66952