### PR TITLE
fix input strided tensor in getitem

### DIFF
--- a/paddle/fluid/pybind/slice_utils.h
+++ b/paddle/fluid/pybind/slice_utils.h
@@ -802,7 +802,7 @@ static paddle::Tensor getValueForBoolTensor(const paddle::Tensor& tensor,
   }
 
   auto bool_2_idx = nonzero_ad_func(bool_index);
-  if (FLAGS_use_stride_kernel) {
+  if (FLAGS_use_stride_kernel && self_tensor.is_contiguous()) {
     std::vector<paddle::Tensor> indices =
         PrepareIndices(tensor, bool_2_idx, bool_index);
     for (int i = 0; i < pos_of_new_dim; ++i) {
@@ -1302,7 +1302,8 @@ static void ApplyGetitem(const int index_size,
       }
     }
 
-    if (FLAGS_use_stride_kernel && !has_empty_index) {
+    if (FLAGS_use_stride_kernel && !has_empty_index &&
+        self_tensor->is_contiguous()) {
       const phi::distributed::ProcessMesh* mesh = nullptr;
       if (InputsContainDistTensor(
               &mesh, *self_tensor, *transed_tensor, *transed_index)) {

--- a/test/indexing/test_getitem.py
+++ b/test/indexing/test_getitem.py
@@ -409,6 +409,24 @@ class TestGetitemInDygraph(unittest.TestCase):
 
         np.testing.assert_allclose(y.numpy(), np_res)
 
+    def test_input_strided_tensor(self):
+        base = paddle.to_tensor(
+            [5.0, 5.0, 6.0, 5.0, 5.0, 6.0], dtype=paddle.float64
+        )
+        foo_strided = paddle.as_strided(base, shape=(2, 1), stride=(2, 1))
+
+        base2 = paddle.to_tensor(
+            [0, 0, 1, 0, 1, 0, 0, 5, 5, 5, 5], dtype=paddle.int64
+        )
+        atype = paddle.as_strided(base2, shape=(2, 3), stride=(4, 1))
+
+        result = foo_strided[atype]
+        expected_result = paddle.to_tensor(
+            [[[5.0], [5.0], [6.0]], [[6.0], [5.0], [5.0]]], dtype=paddle.float64
+        )
+
+        np.testing.assert_allclose(result.numpy(), expected_result.numpy())
+
 
 class TestMultipleIndexing(TestGetitemInDygraph):
     def test_indexing_with_all_possible_start_end_step_dygraph(self):


### PR DESCRIPTION
### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
修复gettiem输入非连续tensor

```python
import paddle
import torch

base = torch.tensor([5., 5., 6., 5., 5., 6.], dtype=torch.float64)
foo_strided = torch.as_strided(base, size=(2,1), stride=(2,1))

base2 = torch.tensor([0, 0, 1, 0, 1, 0,0,5,5,5,5], dtype=torch.int64)
atype = torch.as_strided(base2, size=(2,3), stride=(4,1))

result = foo_strided[atype]
print("result:", result)

base = paddle.to_tensor([5., 5., 6., 5., 5., 6.], dtype=paddle.float64)
foo_strided = paddle.as_strided(base, shape=(2,1), stride=(2,1))

base2 = paddle.to_tensor([0, 0, 1, 0, 1, 0,0,5,5,5,5], dtype=paddle.int64)
atype = paddle.as_strided(base2, shape=(2,3), stride=(4,1))

result = foo_strided[atype]
print("result:", result)

``` 
输出
```python
result: tensor([[[5.],
         [5.],
         [6.]],

        [[6.],
         [5.],
         [5.]]], dtype=torch.float64)
result: Tensor(shape=[2, 3, 1], dtype=float64, place=Place(gpu:0), stop_gradient=True,
       [[[5.],
         [5.],
         [6.]],

        [[5.],
         [6.],
         [5.]]])
``` 

pcard-67164
