### PR TITLE
clean get_cuda_version() < 11020 in test_variable_length_memory_efficient_attention.py

### DIFF
--- a/test/legacy_test/test_variable_length_memory_efficient_attention.py
+++ b/test/legacy_test/test_variable_length_memory_efficient_attention.py
@@ -96,8 +96,7 @@ def naive_attention_impl(query, key, value, mask, scale):
 
 
 @unittest.skipIf(
-    not (core.is_compiled_with_cuda() or is_custom_device())
-    or get_cuda_version() < 11020,
+    not (core.is_compiled_with_cuda() or is_custom_device()),
     "core is not compiled with CUDA and cuda version need larger than or equal to 11.2",
 )
 class TestMemEffAttentionVariableAPI(unittest.TestCase):
@@ -263,8 +262,7 @@ class TestMemEffAPIVariableDtypeBF16(TestMemEffAttentionVariableAPI):
 
 
 @unittest.skipIf(
-    not (core.is_compiled_with_cuda() or is_custom_device())
-    or get_cuda_version() < 11020,
+    not (core.is_compiled_with_cuda() or is_custom_device()),
     "core is not compiled with CUDA and cuda version need larger than or equal to 11.2",
 )
 class TestMemEffAPIVariableDtypeFP16Static(unittest.TestCase):
@@ -358,8 +356,7 @@ class TestMemEffAPIVariableDtypeFP16Static(unittest.TestCase):
 
 
 @unittest.skipIf(
-    not (core.is_compiled_with_cuda() or is_custom_device())
-    or get_cuda_version() < 11020,
+    not (core.is_compiled_with_cuda() or is_custom_device()),
     "core is not compiled with CUDA and cuda version need larger than or equal to 11.2",
 )
 class TestMemEffAttentionVariableAPI_ZeroSize(unittest.TestCase):

--- a/test/legacy_test/test_variable_length_memory_efficient_attention.py
+++ b/test/legacy_test/test_variable_length_memory_efficient_attention.py
@@ -96,8 +96,9 @@ def naive_attention_impl(query, key, value, mask, scale):
 
 
 @unittest.skipIf(
-    not (core.is_compiled_with_cuda() or is_custom_device()),
-    "core is not compiled with CUDA and cuda version need larger than or equal to 11.2",
+    not (core.is_compiled_with_cuda() or is_custom_device())
+    or core.is_compiled_with_rocm(),
+    "core is not compiled with CUDA",
 )
 class TestMemEffAttentionVariableAPI(unittest.TestCase):
     def setUp(self):
@@ -217,9 +218,9 @@ class TestMemEffAPIVariableDtypeFP16(TestMemEffAttentionVariableAPI):
 
 @unittest.skipIf(
     not (core.is_compiled_with_cuda() or is_custom_device())
-    or get_cuda_version() < 11020
+    or core.is_compiled_with_rocm()
     or get_cuda_arch() < 8,
-    "MemEffAPIVariableDtypeBF16 requires CUDA >= 11.2 and CUDA_ARCH >= 8",
+    "MemEffAPIVariableDtypeBF16 requires CUDA_ARCH >= 8",
 )
 class TestMemEffAPIVariableDtypeBF16(TestMemEffAttentionVariableAPI):
     def setUp(self):
@@ -262,8 +263,9 @@ class TestMemEffAPIVariableDtypeBF16(TestMemEffAttentionVariableAPI):
 
 
 @unittest.skipIf(
-    not (core.is_compiled_with_cuda() or is_custom_device()),
-    "core is not compiled with CUDA and cuda version need larger than or equal to 11.2",
+    not (core.is_compiled_with_cuda() or is_custom_device())
+    or core.is_compiled_with_rocm(),
+    "core is not compiled with CUDA",
 )
 class TestMemEffAPIVariableDtypeFP16Static(unittest.TestCase):
     def setUp(self):
@@ -356,8 +358,9 @@ class TestMemEffAPIVariableDtypeFP16Static(unittest.TestCase):
 
 
 @unittest.skipIf(
-    not (core.is_compiled_with_cuda() or is_custom_device()),
-    "core is not compiled with CUDA and cuda version need larger than or equal to 11.2",
+    not (core.is_compiled_with_cuda() or is_custom_device())
+    or core.is_compiled_with_rocm(),
+    "core is not compiled with CUDA",
 )
 class TestMemEffAttentionVariableAPI_ZeroSize(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience

### PR Types
Others 

### Description
<!-- Describe what you’ve done -->
清理 test_variable_length_memory_efficient_attention.py 中 get_cuda_version() < 11020，增加跳过 ROCM，is_compiled_with_rocm，ROCM没有CUDA版本
