### PR TITLE
[深度对齐] paddle.nn.functional.gelu

### DIFF
--- a/paddle/phi/kernels/gpu/gelu_kernel.cu
+++ b/paddle/phi/kernels/gpu/gelu_kernel.cu
@@ -37,10 +37,10 @@ struct GeluWithApproximateFunctor {
     MPType x = static_cast<MPType>(arg_x);
     MPType one = static_cast<MPType>(1);
     MPType half = static_cast<MPType>(0.5);
-    MPType kAlpha = static_cast<MPType>(M_2_SQRTPI * M_SQRT1_2);
+    MPType kAlpha = M_SQRT2 * M_2_SQRTPI * MPType(0.5);
     auto tanh_out =
-        tanh(kAlpha * x * (one + static_cast<MPType>(GELU_CONSTANT) * x * x));
-    MPType out = x * half * (one + tanh_out);
+        tanh(kAlpha * (x + static_cast<MPType>(GELU_CONSTANT) * (x * x * x)));
+    MPType out = half * x * (one + tanh_out);
     return static_cast<T>(out);
   }
 };
@@ -51,7 +51,9 @@ struct GeluWithoutApproximateFunctor {
   inline HOSTDEVICE T operator()(T arg_x) {
     // actual gelu with approximation = false
     MPType x = static_cast<MPType>(arg_x);
-    return static_cast<T>(x * normcdf(x));
+    // return static_cast<T>(x * normcdf(x));
+    constexpr MPType kAlpha = M_SQRT1_2;
+    return static_cast<T>(x * MPType(0.5) * (MPType(1) + std::erf(x * kAlpha)));
   }
 };
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
pytorch公式计算位置：[pytorch/aten/src/ATen/native/cuda/ActivationGeluKernel.cu](https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/native/cuda/ActivationGeluKernel.cu)

官网公式描述：
<img width="695" height="458" alt="截屏2025-10-13 14 02 29" src="https://github.com/user-attachments/assets/94250509-f69a-4b1c-acb7-bbaf3099af99" />

paddle修改前后公式分别为：
- 前向近似计算
> $\displaystyle kAlpha = 2/\sqrt{\pi} \times 1/\sqrt{2}$  
$\displaystyle kBeta = kAlpha \times GELUCONSTANT \times 3$
$\displaystyle cubeX = x^3$  
$\displaystyle tanhOut = \tanh(kAlpha \times (GELUCONSTANT \times cubeX + x))$
$$ansA = \tfrac{1}{2}\Big[(1 + tanhOut) + (1 - tanhOut^2)\times (x\times kAlpha + cubeX\times kBeta)\Big]$$

---转化为--->
> $\displaystyle kAlpha = \sqrt{2} \times 2/\sqrt{\pi} \times 0.5$  
$\displaystyle kBeta = GELUCONSTANT$
$\displaystyle xSeq = x^2$  
$\displaystyle cubeX = x^3$  
$\displaystyle tanhOut = \tanh(kAlpha \times (kBeta \times cubeX + x))$
$$ansB = \tfrac{1}{2}(1 + tanhOut) + \tfrac{1}{2}x(1 - tanhOut^2)\times (kAlpha \times (1 + 3kBeta xSeq))$$

- 前向不做近似计算
>$kBeta = \left(\frac{2}{\sqrt{\pi}}\right)\left(\frac{1}{\sqrt{2}}\right)\times 0.5$
$cdf = \mathrm{normcdf}(x)$
$pdf = \exp\big(-0.5\times x\times x\big)\times kBeta$

---转化为--->
>$kBeta = \left(\frac{2}{\sqrt{\pi}}\right)\left(\frac{1}{\sqrt{2}}\right)\times 0.5$
$kAlpha = \frac{1}{\sqrt{2}}$
cdf = 0.5 * (1 + erf(x * kAlpha))
$pdf = \exp\big(-0.5\times x\times x\big)\times kBeta$

paddle 修改后公式为：
- 反向近似计算
>$kAlpha = sqrt(1/2) * (2 / sqrt(pi))$
$tanhout = tanh(kAlpha * x * (1 + GELUCONSTANT * x * x))$
$out = x * 0.5 * (1 + tanhout)$

---转化为--->
>$kAlpha = sqrt(2) * (2 / sqrt(pi)) * 0.5$
$tanhout = tanh(kAlpha * (x + GELUCONSTANT * (x * x * x)))$
$out = 0.5 * x * (1 + tanhout)$

- 反向不做近似计算
>$out = x * normcdf(x)$

---转化为--->
>$kAlpha = 1 / sqrt(2)$
$out = x * 0.5 * (1 + erf(x * kAlpha))$

修改gelu的前向和反向计算公式 使得计算过程与pytorch保持对齐，修改后 所有测试均可通过
<img width="483" height="336" alt="截屏2025-09-29 16 19 18" src="https://github.com/user-attachments/assets/850f86ad-6ed6-4be5-bd84-c4ef75126722" />
