### PR TITLE
Fix moe_permute and moe_unpermute INT32 overflow error

### DIFF
--- a/paddle/phi/kernels/gpu/moe_unpermute_kernel.cu
+++ b/paddle/phi/kernels/gpu/moe_unpermute_kernel.cu
@@ -243,10 +243,11 @@ void MoeUnpermuteKernel(const Context &dev_ctx,
   if (unzipped_tokens.numel() == 0) return;  // 0-size tensor
   void *zipped_probs_topk_ptr =
       reinterpret_cast<void *>(zipped_probs_topk->data<float>());
-  cudaMemsetAsync(zipped_probs_topk_ptr,
-                  0,
-                  sizeof(float) * total_zipped_tokens_num * topk,
-                  dev_ctx.stream());
+  PADDLE_ENFORCE_GPU_SUCCESS(
+      cudaMemsetAsync(zipped_probs_topk_ptr,
+                      0,
+                      sizeof(float) * int64_t(total_zipped_tokens_num) * topk,
+                      dev_ctx.stream()));
 
   dispatch_tokens_zip<T, Context>(dev_ctx,
                                   unzipped_tokens,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
Fix moe_permute and moe_unpermute INT32 overflow error.

pcard-67164