### PR TITLE
【CUDA Kernel No.107】shuffle_channel算子Kernel修复 -part 

### DIFF
--- a/paddle/phi/kernels/gpu/shuffle_channel_kernel.cu
+++ b/paddle/phi/kernels/gpu/shuffle_channel_kernel.cu
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "paddle/phi/kernels/gpu/shuffle_channel_kernel.h"
 #include "paddle/phi/backends/gpu/gpu_primitives.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/kernel_registry.h"
@@ -20,10 +21,10 @@
 namespace phi {
 
 template <typename T, typename Context>
-void ShuffleChannelOpKernel(const Context& dev_ctx,
-                            const DenseTensor& x,
-                            int group,
-                            DenseTensor* out) {
+void ShuffleChannelOpCUDAKernel(const Context& dev_ctx,
+                                const DenseTensor& x,
+                                int group,
+                                DenseTensor* out) {
   auto input_dims = x.dims();
   auto num = input_dims[0];
   auto channel = input_dims[1];
@@ -56,6 +57,6 @@ void ShuffleChannelOpKernel(const Context& dev_ctx,
 PD_REGISTER_KERNEL(shuffle_channel,
                    GPU,
                    ALL_LAYOUT,
-                   phi::ShuffleChannelOpKernel,
+                   phi::ShuffleChannelOpCUDAKernel,
                    float,
                    double) {}

--- a/paddle/phi/kernels/gpu/shuffle_channel_kernel.cu
+++ b/paddle/phi/kernels/gpu/shuffle_channel_kernel.cu
@@ -20,10 +20,10 @@
 namespace phi {
 
 template <typename T, typename Context>
-void ShuffleChannelOpCUDAKernel(const Context& dev_ctx,
-                                const DenseTensor& x,
-                                int group,
-                                DenseTensor* out) {
+void ShuffleChannelOpKernel(const Context& dev_ctx,
+                            const DenseTensor& x,
+                            int group,
+                            DenseTensor* out) {
   auto input_dims = x.dims();
   auto num = input_dims[0];
   auto channel = input_dims[1];
@@ -56,6 +56,6 @@ void ShuffleChannelOpCUDAKernel(const Context& dev_ctx,
 PD_REGISTER_KERNEL(shuffle_channel,
                    GPU,
                    ALL_LAYOUT,
-                   phi::ShuffleChannelOpCUDAKernel,
+                   phi::ShuffleChannelOpKernel,
                    float,
                    double) {}

--- a/paddle/phi/kernels/gpu/shuffle_channel_kernel.h
+++ b/paddle/phi/kernels/gpu/shuffle_channel_kernel.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "paddle/phi/core/dense_tensor.h"
+#include "paddle/phi/core/device_context.h"
+
+namespace phi {
+
+template <typename T, typename Context>
+void ShuffleChannelOpCUDAKernel(const Context& dev_ctx,
+                                const DenseTensor& x,
+                                int group,
+                                DenseTensor* out);
+
+}  // namespace phi


### PR DESCRIPTION
### PR Category
Performance Optimization

### PR Types
Bug fixes

### Description
在Paddle中将ShuffleChannelOpCUDAKernel修改为ShuffleChannelOpKernel，从而使GPU和CPU共用一个声明