### PR TITLE
【UnitTestFix No.6】test_gather_op 单测 优化及新增特性

### DIFF
--- a/test/legacy_test/test_gather_op.py
+++ b/test/legacy_test/test_gather_op.py
@@ -102,6 +102,29 @@ class TestGatherOpFP16(TestGatherOp):
 
 
 @unittest.skipIf(
+    not (core.is_compiled_with_cuda() or is_custom_device()),
+    "only support compiled with CUDA.",
+)
+class TestGatherGPUCPUConsistency(unittest.TestCase):
+    def test_gpu_cpu_consistency(self):
+        with paddle.base.dygraph.guard():
+            np.random.seed(42)
+            x = np.random.rand(1000, 128).astype("float32")
+            index = np.random.randint(0, 1000, size=(100,))
+            cpu_out = paddle.gather(
+                paddle.to_tensor(x, place=paddle.CPUPlace()),
+                paddle.to_tensor(index),
+            )
+            gpu_out = paddle.gather(
+                paddle.to_tensor(x, place=paddle.CUDAPlace(0)),
+                paddle.to_tensor(index),
+            )
+            np.testing.assert_allclose(
+                cpu_out.numpy(), gpu_out.numpy(), rtol=1e-6
+            )
+
+
+@unittest.skipIf(
     not (core.is_compiled_with_cuda() or is_custom_device())
     or core.cudnn_version() < 8100
     or paddle.device.cuda.get_device_capability()[0] < 8,
@@ -749,39 +772,36 @@ class API_TestGather(unittest.TestCase):
 
 class API_TestDygraphGather(unittest.TestCase):
     def test_out1(self):
-        paddle.disable_static()
-        input_1 = np.array([[1, 2], [3, 4], [5, 6]])
-        index_1 = np.array([1, 2])
-        input = paddle.to_tensor(input_1)
-        index = paddle.to_tensor(index_1)
-        output = paddle.gather(input, index)
-        output_np = output.numpy()
-        expected_output = np.array([[3, 4], [5, 6]])
-        np.testing.assert_allclose(output_np, expected_output, rtol=1e-05)
-        paddle.enable_static()
+        with paddle.base.dygraph.guard():
+            input_1 = np.array([[1, 2], [3, 4], [5, 6]])
+            index_1 = np.array([1, 2])
+            input = paddle.to_tensor(input_1)
+            index = paddle.to_tensor(index_1)
+            output = paddle.gather(input, index)
+            output_np = output.numpy()
+            expected_output = np.array([[3, 4], [5, 6]])
+            np.testing.assert_allclose(output_np, expected_output, rtol=1e-05)
 
     def test_out12(self):
-        paddle.disable_static()
-        input_1 = np.array([[1, 2], [3, 4], [5, 6]])
-        index_1 = np.array([1, 2])
-        x = paddle.to_tensor(input_1)
-        index = paddle.to_tensor(index_1)
-        output = paddle.gather(x, index, axis=0)
-        output_np = output.numpy()
-        expected_output = gather_numpy(input_1, index_1, axis=0)
-        np.testing.assert_allclose(output_np, expected_output, rtol=1e-05)
-        paddle.enable_static()
+        with paddle.base.dygraph.guard():
+            input_1 = np.array([[1, 2], [3, 4], [5, 6]])
+            index_1 = np.array([1, 2])
+            x = paddle.to_tensor(input_1)
+            index = paddle.to_tensor(index_1)
+            output = paddle.gather(x, index, axis=0)
+            output_np = output.numpy()
+            expected_output = gather_numpy(input_1, index_1, axis=0)
+            np.testing.assert_allclose(output_np, expected_output, rtol=1e-05)
 
     def test_zero_index(self):
-        paddle.disable_static()
-        x = paddle.to_tensor([[1, 2], [3, 4]])
-        index = paddle.to_tensor(np.array([]).astype('int64'))
-        for axis in range(len(x.shape)):
-            out = paddle.gather(x, index, axis)
-            expected_shape = list(x.shape)
-            expected_shape[axis] = 0
-            self.assertEqual(list(out.shape), expected_shape)
-        paddle.enable_static()
+        with paddle.base.dygraph.guard():
+            x = paddle.to_tensor([[1, 2], [3, 4]])
+            index = paddle.to_tensor(np.array([]).astype('int64'))
+            for axis in range(len(x.shape)):
+                out = paddle.gather(x, index, axis)
+                expected_shape = list(x.shape)
+                expected_shape[axis] = 0
+                self.assertEqual(list(out.shape), expected_shape)
 
     def test_large_data(self):
         if not (paddle.is_compiled_with_cuda() or is_custom_device()):

--- a/test/legacy_test/test_gather_op.py
+++ b/test/legacy_test/test_gather_op.py
@@ -102,29 +102,6 @@ class TestGatherOpFP16(TestGatherOp):
 
 
 @unittest.skipIf(
-    not (core.is_compiled_with_cuda() or is_custom_device()),
-    "only support compiled with CUDA.",
-)
-class TestGatherGPUCPUConsistency(unittest.TestCase):
-    def test_gpu_cpu_consistency(self):
-        with paddle.base.dygraph.guard():
-            np.random.seed(42)
-            x = np.random.rand(1000, 128).astype("float32")
-            index = np.random.randint(0, 1000, size=(100,))
-            cpu_out = paddle.gather(
-                paddle.to_tensor(x, place=paddle.CPUPlace()),
-                paddle.to_tensor(index),
-            )
-            gpu_out = paddle.gather(
-                paddle.to_tensor(x, place=paddle.CUDAPlace(0)),
-                paddle.to_tensor(index),
-            )
-            np.testing.assert_allclose(
-                cpu_out.numpy(), gpu_out.numpy(), rtol=1e-6
-            )
-
-
-@unittest.skipIf(
     not (core.is_compiled_with_cuda() or is_custom_device())
     or core.cudnn_version() < 8100
     or paddle.device.cuda.get_device_capability()[0] < 8,
@@ -770,38 +747,65 @@ class API_TestGather(unittest.TestCase):
         np.testing.assert_allclose(result, expected_output, rtol=1e-05)
 
 
+@unittest.skipIf(
+    not (core.is_compiled_with_cuda() or is_custom_device()),
+    "only support compiled with CUDA.",
+)
+class TestGatherGPUCPUConsistency(unittest.TestCase):
+    def test_gpu_cpu_consistency(self):
+        paddle.disable_static()
+        np.random.seed(42)
+        x = np.random.rand(1000, 128).astype("float32")
+        index = np.random.randint(0, 1000, size=(100,))
+        cpu_out = paddle.gather(
+            paddle.to_tensor(x, place=paddle.CPUPlace()),
+            paddle.to_tensor(index),
+        )
+        gpu_out = paddle.gather(
+            paddle.to_tensor(x, place=paddle.CUDAPlace(0)),
+            paddle.to_tensor(index),
+        )
+        np.testing.assert_allclose(
+            cpu_out.numpy(), gpu_out.numpy(), rtol=1e-6
+        )
+        paddle.enable_static()
+
+
 class API_TestDygraphGather(unittest.TestCase):
     def test_out1(self):
-        with paddle.base.dygraph.guard():
-            input_1 = np.array([[1, 2], [3, 4], [5, 6]])
-            index_1 = np.array([1, 2])
-            input = paddle.to_tensor(input_1)
-            index = paddle.to_tensor(index_1)
-            output = paddle.gather(input, index)
-            output_np = output.numpy()
-            expected_output = np.array([[3, 4], [5, 6]])
-            np.testing.assert_allclose(output_np, expected_output, rtol=1e-05)
+        paddle.disable_static()
+        input_1 = np.array([[1, 2], [3, 4], [5, 6]])
+        index_1 = np.array([1, 2])
+        input = paddle.to_tensor(input_1)
+        index = paddle.to_tensor(index_1)
+        output = paddle.gather(input, index)
+        output_np = output.numpy()
+        expected_output = np.array([[3, 4], [5, 6]])
+        np.testing.assert_allclose(output_np, expected_output, rtol=1e-05)
+        paddle.enable_static()
 
     def test_out12(self):
-        with paddle.base.dygraph.guard():
-            input_1 = np.array([[1, 2], [3, 4], [5, 6]])
-            index_1 = np.array([1, 2])
-            x = paddle.to_tensor(input_1)
-            index = paddle.to_tensor(index_1)
-            output = paddle.gather(x, index, axis=0)
-            output_np = output.numpy()
-            expected_output = gather_numpy(input_1, index_1, axis=0)
-            np.testing.assert_allclose(output_np, expected_output, rtol=1e-05)
+        paddle.disable_static()
+        input_1 = np.array([[1, 2], [3, 4], [5, 6]])
+        index_1 = np.array([1, 2])
+        x = paddle.to_tensor(input_1)
+        index = paddle.to_tensor(index_1)
+        output = paddle.gather(x, index, axis=0)
+        output_np = output.numpy()
+        expected_output = gather_numpy(input_1, index_1, axis=0)
+        np.testing.assert_allclose(output_np, expected_output, rtol=1e-05)
+        paddle.enable_static()
 
     def test_zero_index(self):
-        with paddle.base.dygraph.guard():
-            x = paddle.to_tensor([[1, 2], [3, 4]])
-            index = paddle.to_tensor(np.array([]).astype('int64'))
-            for axis in range(len(x.shape)):
-                out = paddle.gather(x, index, axis)
-                expected_shape = list(x.shape)
-                expected_shape[axis] = 0
-                self.assertEqual(list(out.shape), expected_shape)
+        paddle.disable_static()
+        x = paddle.to_tensor([[1, 2], [3, 4]])
+        index = paddle.to_tensor(np.array([]).astype('int64'))
+        for axis in range(len(x.shape)):
+            out = paddle.gather(x, index, axis)
+            expected_shape = list(x.shape)
+            expected_shape[axis] = 0
+            self.assertEqual(list(out.shape), expected_shape)
+        paddle.enable_static()
 
     def test_large_data(self):
         if not (paddle.is_compiled_with_cuda() or is_custom_device()):

--- a/test/legacy_test/test_gather_op.py
+++ b/test/legacy_test/test_gather_op.py
@@ -765,9 +765,7 @@ class TestGatherGPUCPUConsistency(unittest.TestCase):
             paddle.to_tensor(x, place=paddle.CUDAPlace(0)),
             paddle.to_tensor(index),
         )
-        np.testing.assert_allclose(
-            cpu_out.numpy(), gpu_out.numpy(), rtol=1e-6
-        )
+        np.testing.assert_allclose(cpu_out.numpy(), gpu_out.numpy(), rtol=1e-6)
         paddle.enable_static()
 
 


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
New features

### Description
> 由于PR Types只给选择一个类型，其实我建议可以改成两个，具体直接在下面标注了
> 增强特性

将所有 `paddle.disable_static()` 以及 `paddle.enable_static()` 以 `with paddle.base.dygraph.guard()` 代替，同时建议在后续可能存在的新feature采用自动的 `disable` + `enable`，避免意外。

> 新增特性

新增了 `GPU` + `CPU` 的一致性检查。
```
@unittest.skipIf(
    not (core.is_compiled_with_cuda() or is_custom_device()),
    "only support compiled with CUDA.",
)
class TestGatherGPUCPUConsistency(unittest.TestCase):
    def test_gpu_cpu_consistency(self):
        with paddle.base.dygraph.guard():
            np.random.seed(42)
            x = np.random.rand(1000, 128).astype("float32")
            index = np.random.randint(0, 1000, size=(100,))
            cpu_out = paddle.gather(
                paddle.to_tensor(x, place=paddle.CPUPlace()),
                paddle.to_tensor(index),
            )
            gpu_out = paddle.gather(
                paddle.to_tensor(x, place=paddle.CUDAPlace(0)),
                paddle.to_tensor(index),
            )
            np.testing.assert_allclose(
                cpu_out.numpy(), gpu_out.numpy(), rtol=1e-6
            )
```

### Result

```
/opt/conda/envs/python35-paddle120-env/lib/python3.10/site-packages/paddle/base/framework.py:722: VisibleDeprecationWarning: 
Warning:
API "paddle.base.dygraph.tensor_patch_methods.gradient" is deprecated since 2.1.0, and will be removed in future versions.
    Reason: Please use tensor.grad, which returns the tensor value of the gradient. 
  return func(*args, **kwargs)
...........
----------------------------------------------------------------------
Ran 129 tests in 84.951s

OK
```
As a result, OK nya~

@luotao1 @YqGe585 