### PR TITLE
[Test] Use `dygraph.guard` to switch to dygraph mode in `legacy_test`

### DIFF
--- a/test/legacy_test/test_elementwise_add_op.py
+++ b/test/legacy_test/test_elementwise_add_op.py
@@ -770,14 +770,15 @@ class TestAddInplaceBroadcastSuccess(unittest.TestCase):
         self.y_numpy = np.random.rand(3, 4).astype('float')
 
     def test_broadcast_success(self):
-        paddle.disable_static()
-        self.init_data()
-        x = paddle.to_tensor(self.x_numpy)
-        y = paddle.to_tensor(self.y_numpy)
-        inplace_result = x.add_(y)
-        numpy_result = self.x_numpy + self.y_numpy
-        self.assertEqual((inplace_result.numpy() == numpy_result).all(), True)
-        paddle.enable_static()
+        with paddle.base.dygraph.guard():
+            self.init_data()
+            x = paddle.to_tensor(self.x_numpy)
+            y = paddle.to_tensor(self.y_numpy)
+            inplace_result = x.add_(y)
+            numpy_result = self.x_numpy + self.y_numpy
+            self.assertEqual(
+                (inplace_result.numpy() == numpy_result).all(), True
+            )
 
 
 class TestAddInplaceBroadcastSuccess2(TestAddInplaceBroadcastSuccess):
@@ -798,16 +799,15 @@ class TestAddInplaceBroadcastError(unittest.TestCase):
         self.y_numpy = np.random.rand(2, 3, 4).astype('float')
 
     def test_broadcast_errors(self):
-        paddle.disable_static()
-        self.init_data()
-        x = paddle.to_tensor(self.x_numpy)
-        y = paddle.to_tensor(self.y_numpy)
+        with paddle.base.dygraph.guard():
+            self.init_data()
+            x = paddle.to_tensor(self.x_numpy)
+            y = paddle.to_tensor(self.y_numpy)
 
-        def broadcast_shape_error():
-            x.add_(y)
+            def broadcast_shape_error():
+                x.add_(y)
 
-        self.assertRaises(ValueError, broadcast_shape_error)
-        paddle.enable_static()
+            self.assertRaises(ValueError, broadcast_shape_error)
 
 
 class TestAddInplaceBroadcastError2(TestAddInplaceBroadcastError):
@@ -885,57 +885,52 @@ class TestBoolAddFloatElementwiseAddop(unittest.TestCase):
             self.assertTrue(c.dtype == core.DataType.FLOAT32)
 
     def test_dygraph_add(self):
-        paddle.disable_static()
-        a = 1.5
-        b = paddle.full([2], True, dtype='bool')
-        # special case: scalar + tensor(bool)
-        c = a + b
-        self.assertTrue(c.dtype == paddle.float32)
+        with paddle.base.dygraph.guard():
+            a = 1.5
+            b = paddle.full([2], True, dtype='bool')
+            # special case: scalar + tensor(bool)
+            c = a + b
+            self.assertTrue(c.dtype == paddle.float32)
 
-        np_a = np.random.random((2, 3, 4)).astype(np.float64)
-        np_b = np.random.random((2, 3, 4)).astype(np.float64)
+            np_a = np.random.random((2, 3, 4)).astype(np.float64)
+            np_b = np.random.random((2, 3, 4)).astype(np.float64)
 
-        tensor_a = paddle.to_tensor(np_a, dtype="float32")
-        tensor_b = paddle.to_tensor(np_b, dtype="float32")
+            tensor_a = paddle.to_tensor(np_a, dtype="float32")
+            tensor_b = paddle.to_tensor(np_b, dtype="float32")
 
-        # normal case: tensor + tensor
-        expect_out = np_a + np_b
-        actual_out = tensor_a + tensor_b
-        np.testing.assert_allclose(actual_out, expect_out)
+            # normal case: tensor + tensor
+            expect_out = np_a + np_b
+            actual_out = tensor_a + tensor_b
+            np.testing.assert_allclose(actual_out, expect_out)
 
-        # normal case: tensor + scalar
-        expect_out = np_a + 1
-        actual_out = tensor_a + 1
-        np.testing.assert_allclose(actual_out, expect_out)
+            # normal case: tensor + scalar
+            expect_out = np_a + 1
+            actual_out = tensor_a + 1
+            np.testing.assert_allclose(actual_out, expect_out)
 
-        # normal case: scalar + tenor
-        expect_out = 1 + np_a
-        actual_out = 1 + tensor_a
-        np.testing.assert_allclose(actual_out, expect_out)
-
-        paddle.enable_static()
+            # normal case: scalar + tenor
+            expect_out = 1 + np_a
+            actual_out = 1 + tensor_a
+            np.testing.assert_allclose(actual_out, expect_out)
 
 
 class TestElementwiseAddop1(unittest.TestCase):
     def test_dygraph_add(self):
-        paddle.disable_static()
+        with paddle.base.dygraph.guard():
+            np_a = np.random.random((2, 3, 4)).astype(np.float32)
+            np_b = np.random.random((2, 3, 4)).astype(np.float32)
 
-        np_a = np.random.random((2, 3, 4)).astype(np.float32)
-        np_b = np.random.random((2, 3, 4)).astype(np.float32)
+            tensor_a = paddle.to_tensor(np_a, dtype="float32")
+            tensor_b = paddle.to_tensor(np_b, dtype="float32")
 
-        tensor_a = paddle.to_tensor(np_a, dtype="float32")
-        tensor_b = paddle.to_tensor(np_b, dtype="float32")
+            # normal case: nparray + tenor
+            expect_out = np_a + np_b
+            actual_out = np_a + tensor_b
+            np.testing.assert_allclose(actual_out, expect_out)
 
-        # normal case: nparray + tenor
-        expect_out = np_a + np_b
-        actual_out = np_a + tensor_b
-        np.testing.assert_allclose(actual_out, expect_out)
-
-        # normal case: tensor + nparray
-        actual_out = tensor_a + np_b
-        np.testing.assert_allclose(actual_out, expect_out)
-
-        paddle.enable_static()
+            # normal case: tensor + nparray
+            actual_out = tensor_a + np_b
+            np.testing.assert_allclose(actual_out, expect_out)
 
 
 class TestTensorAddNumpyScalar(unittest.TestCase):

--- a/test/legacy_test/test_elementwise_sub_op.py
+++ b/test/legacy_test/test_elementwise_sub_op.py
@@ -1050,14 +1050,15 @@ class TestSubtractInplaceBroadcastSuccess(unittest.TestCase):
         self.y_numpy = np.random.rand(3, 4).astype('float')
 
     def test_broadcast_success(self):
-        paddle.disable_static()
-        self.init_data()
-        x = paddle.to_tensor(self.x_numpy)
-        y = paddle.to_tensor(self.y_numpy)
-        inplace_result = x.subtract_(y)
-        numpy_result = self.x_numpy - self.y_numpy
-        self.assertEqual((inplace_result.numpy() == numpy_result).all(), True)
-        paddle.enable_static()
+        with paddle.base.dygraph.guard():
+            self.init_data()
+            x = paddle.to_tensor(self.x_numpy)
+            y = paddle.to_tensor(self.y_numpy)
+            inplace_result = x.subtract_(y)
+            numpy_result = self.x_numpy - self.y_numpy
+            self.assertEqual(
+                (inplace_result.numpy() == numpy_result).all(), True
+            )
 
 
 class TestSubtractInplaceBroadcastSuccess2(TestSubtractInplaceBroadcastSuccess):
@@ -1078,16 +1079,15 @@ class TestSubtractInplaceBroadcastError(unittest.TestCase):
         self.y_numpy = np.random.rand(2, 3, 4).astype('float')
 
     def test_broadcast_errors(self):
-        paddle.disable_static()
-        self.init_data()
-        x = paddle.to_tensor(self.x_numpy)
-        y = paddle.to_tensor(self.y_numpy)
+        with paddle.base.dygraph.guard():
+            self.init_data()
+            x = paddle.to_tensor(self.x_numpy)
+            y = paddle.to_tensor(self.y_numpy)
 
-        def broadcast_shape_error():
-            x.subtract_(y)
+            def broadcast_shape_error():
+                x.subtract_(y)
 
-        self.assertRaises(ValueError, broadcast_shape_error)
-        paddle.enable_static()
+            self.assertRaises(ValueError, broadcast_shape_error)
 
 
 class TestSubtractInplaceBroadcastError2(TestSubtractInplaceBroadcastError):
@@ -1104,62 +1104,56 @@ class TestSubtractInplaceBroadcastError3(TestSubtractInplaceBroadcastError):
 
 class TestFloatElementwiseSubop(unittest.TestCase):
     def test_dygraph_sub(self):
-        paddle.disable_static()
+        with paddle.base.dygraph.guard():
+            np_a = np.random.random((2, 3, 4)).astype(np.float64)
+            np_b = np.random.random((2, 3, 4)).astype(np.float64)
 
-        np_a = np.random.random((2, 3, 4)).astype(np.float64)
-        np_b = np.random.random((2, 3, 4)).astype(np.float64)
+            tensor_a = paddle.to_tensor(np_a, dtype="float32")
+            tensor_b = paddle.to_tensor(np_b, dtype="float32")
 
-        tensor_a = paddle.to_tensor(np_a, dtype="float32")
-        tensor_b = paddle.to_tensor(np_b, dtype="float32")
+            # normal case: tensor - tensor
+            expect_out = np_a - np_b
+            actual_out = tensor_a - tensor_b
+            np.testing.assert_allclose(
+                actual_out, expect_out, rtol=1e-07, atol=1e-07
+            )
 
-        # normal case: tensor - tensor
-        expect_out = np_a - np_b
-        actual_out = tensor_a - tensor_b
-        np.testing.assert_allclose(
-            actual_out, expect_out, rtol=1e-07, atol=1e-07
-        )
+            # normal case: tensor - scalar
+            expect_out = np_a - 1
+            actual_out = tensor_a - 1
+            np.testing.assert_allclose(
+                actual_out, expect_out, rtol=1e-07, atol=1e-07
+            )
 
-        # normal case: tensor - scalar
-        expect_out = np_a - 1
-        actual_out = tensor_a - 1
-        np.testing.assert_allclose(
-            actual_out, expect_out, rtol=1e-07, atol=1e-07
-        )
-
-        # normal case: scalar - tenor
-        expect_out = 1 - np_a
-        actual_out = 1 - tensor_a
-        np.testing.assert_allclose(
-            actual_out, expect_out, rtol=1e-07, atol=1e-07
-        )
-
-        paddle.enable_static()
+            # normal case: scalar - tenor
+            expect_out = 1 - np_a
+            actual_out = 1 - tensor_a
+            np.testing.assert_allclose(
+                actual_out, expect_out, rtol=1e-07, atol=1e-07
+            )
 
 
 class TestFloatElementwiseSubop1(unittest.TestCase):
     def test_dygraph_sub(self):
-        paddle.disable_static()
+        with paddle.base.dygraph.guard():
+            np_a = np.random.random((2, 3, 4)).astype(np.float32)
+            np_b = np.random.random((2, 3, 4)).astype(np.float32)
 
-        np_a = np.random.random((2, 3, 4)).astype(np.float32)
-        np_b = np.random.random((2, 3, 4)).astype(np.float32)
+            tensor_a = paddle.to_tensor(np_a, dtype="float32")
+            tensor_b = paddle.to_tensor(np_b, dtype="float32")
 
-        tensor_a = paddle.to_tensor(np_a, dtype="float32")
-        tensor_b = paddle.to_tensor(np_b, dtype="float32")
+            # normal case: nparray - tenor
+            expect_out = np_a - np_b
+            actual_out = np_a - tensor_b
+            np.testing.assert_allclose(
+                actual_out, expect_out, rtol=1e-07, atol=1e-07
+            )
 
-        # normal case: nparray - tenor
-        expect_out = np_a - np_b
-        actual_out = np_a - tensor_b
-        np.testing.assert_allclose(
-            actual_out, expect_out, rtol=1e-07, atol=1e-07
-        )
-
-        # normal case: tenor - nparray
-        actual_out = tensor_a - np_b
-        np.testing.assert_allclose(
-            actual_out, expect_out, rtol=1e-07, atol=1e-07
-        )
-
-        paddle.enable_static()
+            # normal case: tenor - nparray
+            actual_out = tensor_a - np_b
+            np.testing.assert_allclose(
+                actual_out, expect_out, rtol=1e-07, atol=1e-07
+            )
 
 
 class TestElementwiseOpZeroSize(TestElementwiseOp):

--- a/test/legacy_test/test_frac_api.py
+++ b/test/legacy_test/test_frac_api.py
@@ -54,12 +54,11 @@ class TestFracAPI(unittest.TestCase):
         np.testing.assert_allclose(out_ref, out.numpy(), rtol=1e-05)
 
     def test_api_eager(self):
-        paddle.disable_static(self.place)
-        x_tensor = paddle.to_tensor(self.x_np)
-        out = paddle.frac(x_tensor)
-        out_ref = ref_frac(self.x_np)
-        np.testing.assert_allclose(out_ref, out.numpy(), rtol=1e-05)
-        paddle.enable_static()
+        with paddle.base.dygraph.guard(self.place):
+            x_tensor = paddle.to_tensor(self.x_np)
+            out = paddle.frac(x_tensor)
+            out_ref = ref_frac(self.x_np)
+            np.testing.assert_allclose(out_ref, out.numpy(), rtol=1e-05)
 
 
 class TestFracInt32(TestFracAPI):

--- a/test/legacy_test/test_mul.py
+++ b/test/legacy_test/test_mul.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#   Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,155 +15,151 @@
 import unittest
 
 import numpy as np
-from op_test import get_device_place
+from op_test import OpTest, get_places
+from scipy import special
 
 import paddle
-from paddle import static
+
+np.random.seed(100)
+paddle.seed(100)
 
 
-class TestMulApi(unittest.TestCase):
+def output_i0e(x):
+    return special.i0e(x)
+
+
+def ref_i0e_grad(x, dout):
+    eps = np.finfo(x.dtype).eps
+    not_tiny = abs(x) > eps
+    safe_x = np.where(not_tiny, x, eps)
+    gradx = special.i1e(x) - np.sign(x) * output_i0e(safe_x)
+    gradx = np.where(not_tiny, gradx, -1.0)
+    return dout * gradx
+
+
+class TestI0eAPI(unittest.TestCase):
+    DTYPE = "float64"
+    DATA = [0, 1, 2, 3, 4, 5]
+
+    def setUp(self):
+        self.x = np.array(self.DATA).astype(self.DTYPE)
+        self.out_ref = output_i0e(self.x)
+        self.place = get_places()
+
+    def test_api_static(self):
+        def run(place):
+            with paddle.static.program_guard(paddle.static.Program()):
+                x = paddle.static.data(
+                    name="x", shape=self.x.shape, dtype=self.DTYPE
+                )
+                y = paddle.i0e(x)
+                exe = paddle.static.Executor(place)
+                res = exe.run(
+                    paddle.static.default_main_program(),
+                    feed={"x": self.x},
+                    fetch_list=[y],
+                )
+                np.testing.assert_allclose(self.out_ref, res[0], rtol=1e-5)
+
+        for place in self.place:
+            run(place)
+
+    def test_api_dygraph(self):
+        def run(place):
+            paddle.disable_static(place)
+            x = paddle.to_tensor(self.x)
+            out = paddle.i0e(x)
+
+            out_ref = output_i0e(self.x)
+            np.testing.assert_allclose(out_ref, out.numpy(), rtol=1e-5)
+            paddle.enable_static()
+
+        for place in self.place:
+            run(place)
+
+    def test_empty_input_error(self):
+        for place in self.place:
+            paddle.disable_static(place)
+            x = None
+            self.assertRaises(ValueError, paddle.i0e, x)
+            paddle.enable_static()
+
+
+class TestI0eFloat32Zero2EightCase(TestI0eAPI):
+    DTYPE = "float32"
+    DATA = [0, 1, 2, 3, 4, 5, 6, 7, 8]
+
+
+class TestI0eFloat32OverEightCase(TestI0eAPI):
+    DTYPE = "float32"
+    DATA = [9, 10, 11, 12]
+
+
+class TestI0eFloat64Zero2EightCase(TestI0eAPI):
+    DTYPE = "float64"
+    DATA = [0, 1, 2, 3, 4, 5, 6, 7, 8]
+
+
+class TestI0eFloat64OverEightCase(TestI0eAPI):
+    DTYPE = "float64"
+    DATA = [9, 10, 11, 12]
+
+
+class TestI0eOp(OpTest):
     def setUp(self) -> None:
-        self.shape = [2, 3]
-        self.dtype = 'float32'
-        self.place = get_device_place()
+        self.op_type = "i0e"
+        self.python_api = paddle.i0e
+        self.init_config()
+        self.outputs = {"out": self.target}
 
-    def test_static_api(self):
-        paddle.enable_static()
-        x_np = np.random.rand(*self.shape).astype(self.dtype)
-        other2_np = np.random.rand(*self.shape).astype(self.dtype)
-        other3_np = np.random.rand(self.shape[0], 1).astype(self.dtype)
-        with static.program_guard(static.Program()):
-            x = paddle.static.data(name='x', shape=self.shape, dtype=self.dtype)
-            # other1 = 3.0
-            other2 = paddle.static.data(
-                name='other', shape=self.shape, dtype=self.dtype
-            )
-            other3 = paddle.static.data(
-                name='other3', shape=[self.shape[0], 1], dtype=self.dtype
-            )
-            # out1 = x.mul(other1)
-            out2 = x.mul(other2)
-            out3 = x.mul(other3)
-            exe = static.Executor(self.place)
-            outs = exe.run(
-                feed={'x': x_np, 'other': other2_np, 'other3': other3_np},
-                # fetch_list=[out1, out2, out3],
-                fetch_list=[out2, out3],
-            )
-            # np.testing.assert_allclose(
-            #     outs[0], np.multiply(x_np, other1), rtol=1e-05
-            # )
-            np.testing.assert_allclose(
-                outs[0], np.multiply(x_np, other2_np), rtol=1e-05
-            )
-            np.testing.assert_allclose(
-                outs[1], np.multiply(x_np, other3_np), rtol=1e-05
-            )
-
-    def test_dyn_api(self):
-        paddle.disable_static()
-        x_np = np.random.rand(*self.shape).astype(self.dtype)
-        other2_np = np.random.rand(*self.shape).astype(self.dtype)
-        other3_np = np.random.rand(self.shape[0], 1).astype(self.dtype)
-        x = paddle.to_tensor(x_np, place=self.place)
-        # other1 = 3.0
-        other2 = paddle.to_tensor(other2_np, place=self.place)
-        other3 = paddle.to_tensor(other3_np, place=self.place)
-        # out1 = x.mul(other1)
-        out2 = x.mul(other2)
-        out3 = x.mul(other3)
-
-        # np.testing.assert_allclose(
-        #     out1.numpy(), np.multiply(x_np, other1), rtol=1e-05
-        # )
-        np.testing.assert_allclose(
-            out2.numpy(), np.multiply(x_np, other2_np), rtol=1e-05
+    def init_config(self):
+        self.dtype = np.float64
+        zero_case = np.zeros(1).astype(self.dtype)
+        rand_case = np.random.randn(100).astype(self.dtype)
+        one2eight_case = np.random.uniform(low=1, high=8, size=100).astype(
+            self.dtype
         )
-        np.testing.assert_allclose(
-            out3.numpy(), np.multiply(x_np, other3_np), rtol=1e-05
+        over_eight_case = np.random.uniform(low=9, high=15, size=100).astype(
+            self.dtype
+        )
+        self.case = np.concatenate(
+            [zero_case, rand_case, one2eight_case, over_eight_case]
+        )
+        self.inputs = {'x': self.case}
+        self.target = output_i0e(self.inputs['x'])
+
+    def test_check_output(self):
+        self.check_output(check_pir=True, check_symbol_infer=False)
+
+    def test_check_grad(self):
+        self.check_grad(
+            ['x'],
+            'out',
+            user_defined_grads=[ref_i0e_grad(self.case, 1 / self.case.size)],
+            check_pir=True,
         )
 
 
-class TestMulInplaceApi(unittest.TestCase):
+class TestI0eOp_ZeroSize(OpTest):
     def setUp(self) -> None:
-        self.shape = [2, 3]
-        self.dtype = 'float32'
+        self.__class__.op_type = "i0e"
+        self.op_type = "i0e"
+        self.python_api = paddle.i0e
+        self.init_config()
+        x = np.random.randn(3, 4, 0)
+        self.inputs = {'x': x.astype(self.dtype)}
+        self.attrs = {}
+        self.outputs = {'out': special.i0e(x)}
 
-    def test_dyn_api(self):
-        paddle.disable_static()
-        others = [
-            # 3.0,
-            paddle.to_tensor(np.random.rand(*self.shape).astype('float32')),
-            paddle.to_tensor(np.random.rand(*self.shape).astype('float32'))[
-                :, -1
-            ].unsqueeze(-1),
-        ]
-        for other in others:
-            x_np = np.random.rand(*self.shape).astype('float32')
-            x = paddle.to_tensor(x_np)
-            x.mul_(other)
-            np.testing.assert_allclose(
-                x.numpy(),
-                np.multiply(
-                    x_np,
-                    (
-                        other.numpy()
-                        if isinstance(other, paddle.Tensor)
-                        else other
-                    ),
-                ),
-                rtol=1e-05,
-            )
+    def init_config(self):
+        self.dtype = np.float32
+
+    def test_check_output(self):
+        self.check_output()
+
+    def test_check_grad(self):
+        self.check_grad(['x'], 'out')
 
 
-class TestMulInplaceError(unittest.TestCase):
-    def test_errors(self):
-        paddle.disable_static()
-        # test dynamic computation graph: inputs must be broadcastable
-        x_data = np.random.rand(3, 4)
-        y_data = np.random.rand(2, 3, 4)
-        x = paddle.to_tensor(x_data)
-        y = paddle.to_tensor(y_data)
-
-        def multiply_shape_error():
-            with paddle.no_grad():
-                x.mul_(y)
-
-        self.assertRaises(ValueError, multiply_shape_error)
-        paddle.enable_static()
-
-
-class TestMulInplaceParamDecoratorApi(unittest.TestCase):
-    def setUp(self) -> None:
-        self.shape = [2, 3]
-        self.dtype = 'float32'
-
-    def test_dyn_api(self):
-        paddle.disable_static()
-        others = [
-            # 3.0,
-            paddle.to_tensor(np.random.rand(*self.shape).astype('float32')),
-            paddle.to_tensor(np.random.rand(*self.shape).astype('float32'))[
-                :, -1
-            ].unsqueeze(-1),
-        ]
-        for other in others:
-            x_np = np.random.rand(*self.shape).astype('float32')
-            x = paddle.to_tensor(x_np)
-            x.mul_(other=other)
-            np.testing.assert_allclose(
-                x.numpy(),
-                np.multiply(
-                    x_np,
-                    (
-                        other.numpy()
-                        if isinstance(other, paddle.Tensor)
-                        else other
-                    ),
-                ),
-                rtol=1e-05,
-            )
-
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/test/legacy_test/test_mul.py
+++ b/test/legacy_test/test_mul.py
@@ -1,4 +1,4 @@
-#   Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,151 +15,154 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, get_places
-from scipy import special
+from op_test import get_device_place
 
 import paddle
-
-np.random.seed(100)
-paddle.seed(100)
+from paddle import static
 
 
-def output_i0e(x):
-    return special.i0e(x)
-
-
-def ref_i0e_grad(x, dout):
-    eps = np.finfo(x.dtype).eps
-    not_tiny = abs(x) > eps
-    safe_x = np.where(not_tiny, x, eps)
-    gradx = special.i1e(x) - np.sign(x) * output_i0e(safe_x)
-    gradx = np.where(not_tiny, gradx, -1.0)
-    return dout * gradx
-
-
-class TestI0eAPI(unittest.TestCase):
-    DTYPE = "float64"
-    DATA = [0, 1, 2, 3, 4, 5]
-
-    def setUp(self):
-        self.x = np.array(self.DATA).astype(self.DTYPE)
-        self.out_ref = output_i0e(self.x)
-        self.place = get_places()
-
-    def test_api_static(self):
-        def run(place):
-            with paddle.static.program_guard(paddle.static.Program()):
-                x = paddle.static.data(
-                    name="x", shape=self.x.shape, dtype=self.DTYPE
-                )
-                y = paddle.i0e(x)
-                exe = paddle.static.Executor(place)
-                res = exe.run(
-                    paddle.static.default_main_program(),
-                    feed={"x": self.x},
-                    fetch_list=[y],
-                )
-                np.testing.assert_allclose(self.out_ref, res[0], rtol=1e-5)
-
-        for place in self.place:
-            run(place)
-
-    def test_api_dygraph(self):
-        def run(place):
-            paddle.disable_static(place)
-            x = paddle.to_tensor(self.x)
-            out = paddle.i0e(x)
-
-            out_ref = output_i0e(self.x)
-            np.testing.assert_allclose(out_ref, out.numpy(), rtol=1e-5)
-            paddle.enable_static()
-
-        for place in self.place:
-            run(place)
-
-    def test_empty_input_error(self):
-        for place in self.place:
-            paddle.disable_static(place)
-            x = None
-            self.assertRaises(ValueError, paddle.i0e, x)
-            paddle.enable_static()
-
-
-class TestI0eFloat32Zero2EightCase(TestI0eAPI):
-    DTYPE = "float32"
-    DATA = [0, 1, 2, 3, 4, 5, 6, 7, 8]
-
-
-class TestI0eFloat32OverEightCase(TestI0eAPI):
-    DTYPE = "float32"
-    DATA = [9, 10, 11, 12]
-
-
-class TestI0eFloat64Zero2EightCase(TestI0eAPI):
-    DTYPE = "float64"
-    DATA = [0, 1, 2, 3, 4, 5, 6, 7, 8]
-
-
-class TestI0eFloat64OverEightCase(TestI0eAPI):
-    DTYPE = "float64"
-    DATA = [9, 10, 11, 12]
-
-
-class TestI0eOp(OpTest):
+class TestMulApi(unittest.TestCase):
     def setUp(self) -> None:
-        self.op_type = "i0e"
-        self.python_api = paddle.i0e
-        self.init_config()
-        self.outputs = {"out": self.target}
+        self.shape = [2, 3]
+        self.dtype = 'float32'
+        self.place = get_device_place()
 
-    def init_config(self):
-        self.dtype = np.float64
-        zero_case = np.zeros(1).astype(self.dtype)
-        rand_case = np.random.randn(100).astype(self.dtype)
-        one2eight_case = np.random.uniform(low=1, high=8, size=100).astype(
-            self.dtype
+    def test_static_api(self):
+        paddle.enable_static()
+        x_np = np.random.rand(*self.shape).astype(self.dtype)
+        other2_np = np.random.rand(*self.shape).astype(self.dtype)
+        other3_np = np.random.rand(self.shape[0], 1).astype(self.dtype)
+        with static.program_guard(static.Program()):
+            x = paddle.static.data(name='x', shape=self.shape, dtype=self.dtype)
+            # other1 = 3.0
+            other2 = paddle.static.data(
+                name='other', shape=self.shape, dtype=self.dtype
+            )
+            other3 = paddle.static.data(
+                name='other3', shape=[self.shape[0], 1], dtype=self.dtype
+            )
+            # out1 = x.mul(other1)
+            out2 = x.mul(other2)
+            out3 = x.mul(other3)
+            exe = static.Executor(self.place)
+            outs = exe.run(
+                feed={'x': x_np, 'other': other2_np, 'other3': other3_np},
+                # fetch_list=[out1, out2, out3],
+                fetch_list=[out2, out3],
+            )
+            # np.testing.assert_allclose(
+            #     outs[0], np.multiply(x_np, other1), rtol=1e-05
+            # )
+            np.testing.assert_allclose(
+                outs[0], np.multiply(x_np, other2_np), rtol=1e-05
+            )
+            np.testing.assert_allclose(
+                outs[1], np.multiply(x_np, other3_np), rtol=1e-05
+            )
+
+    def test_dyn_api(self):
+        paddle.disable_static()
+        x_np = np.random.rand(*self.shape).astype(self.dtype)
+        other2_np = np.random.rand(*self.shape).astype(self.dtype)
+        other3_np = np.random.rand(self.shape[0], 1).astype(self.dtype)
+        x = paddle.to_tensor(x_np, place=self.place)
+        # other1 = 3.0
+        other2 = paddle.to_tensor(other2_np, place=self.place)
+        other3 = paddle.to_tensor(other3_np, place=self.place)
+        # out1 = x.mul(other1)
+        out2 = x.mul(other2)
+        out3 = x.mul(other3)
+
+        # np.testing.assert_allclose(
+        #     out1.numpy(), np.multiply(x_np, other1), rtol=1e-05
+        # )
+        np.testing.assert_allclose(
+            out2.numpy(), np.multiply(x_np, other2_np), rtol=1e-05
         )
-        over_eight_case = np.random.uniform(low=9, high=15, size=100).astype(
-            self.dtype
-        )
-        self.case = np.concatenate(
-            [zero_case, rand_case, one2eight_case, over_eight_case]
-        )
-        self.inputs = {'x': self.case}
-        self.target = output_i0e(self.inputs['x'])
-
-    def test_check_output(self):
-        self.check_output(check_pir=True, check_symbol_infer=False)
-
-    def test_check_grad(self):
-        self.check_grad(
-            ['x'],
-            'out',
-            user_defined_grads=[ref_i0e_grad(self.case, 1 / self.case.size)],
-            check_pir=True,
+        np.testing.assert_allclose(
+            out3.numpy(), np.multiply(x_np, other3_np), rtol=1e-05
         )
 
 
-class TestI0eOp_ZeroSize(OpTest):
+class TestMulInplaceApi(unittest.TestCase):
     def setUp(self) -> None:
-        self.__class__.op_type = "i0e"
-        self.op_type = "i0e"
-        self.python_api = paddle.i0e
-        self.init_config()
-        x = np.random.randn(3, 4, 0)
-        self.inputs = {'x': x.astype(self.dtype)}
-        self.attrs = {}
-        self.outputs = {'out': special.i0e(x)}
+        self.shape = [2, 3]
+        self.dtype = 'float32'
 
-    def init_config(self):
-        self.dtype = np.float32
+    def test_dyn_api(self):
+        paddle.disable_static()
+        others = [
+            # 3.0,
+            paddle.to_tensor(np.random.rand(*self.shape).astype('float32')),
+            paddle.to_tensor(np.random.rand(*self.shape).astype('float32'))[
+                :, -1
+            ].unsqueeze(-1),
+        ]
+        for other in others:
+            x_np = np.random.rand(*self.shape).astype('float32')
+            x = paddle.to_tensor(x_np)
+            x.mul_(other)
+            np.testing.assert_allclose(
+                x.numpy(),
+                np.multiply(
+                    x_np,
+                    (
+                        other.numpy()
+                        if isinstance(other, paddle.Tensor)
+                        else other
+                    ),
+                ),
+                rtol=1e-05,
+            )
 
-    def test_check_output(self):
-        self.check_output()
 
-    def test_check_grad(self):
-        self.check_grad(['x'], 'out')
+class TestMulInplaceError(unittest.TestCase):
+    def test_errors(self):
+        with paddle.base.dygraph.guard():
+            # test dynamic computation graph: inputs must be broadcastable
+            x_data = np.random.rand(3, 4)
+            y_data = np.random.rand(2, 3, 4)
+            x = paddle.to_tensor(x_data)
+            y = paddle.to_tensor(y_data)
+
+            def multiply_shape_error():
+                with paddle.no_grad():
+                    x.mul_(y)
+
+            self.assertRaises(ValueError, multiply_shape_error)
 
 
-if __name__ == "__main__":
+class TestMulInplaceParamDecoratorApi(unittest.TestCase):
+    def setUp(self) -> None:
+        self.shape = [2, 3]
+        self.dtype = 'float32'
+
+    def test_dyn_api(self):
+        paddle.disable_static()
+        others = [
+            # 3.0,
+            paddle.to_tensor(np.random.rand(*self.shape).astype('float32')),
+            paddle.to_tensor(np.random.rand(*self.shape).astype('float32'))[
+                :, -1
+            ].unsqueeze(-1),
+        ]
+        for other in others:
+            x_np = np.random.rand(*self.shape).astype('float32')
+            x = paddle.to_tensor(x_np)
+            x.mul_(other=other)
+            np.testing.assert_allclose(
+                x.numpy(),
+                np.multiply(
+                    x_np,
+                    (
+                        other.numpy()
+                        if isinstance(other, paddle.Tensor)
+                        else other
+                    ),
+                ),
+                rtol=1e-05,
+            )
+
+
+if __name__ == '__main__':
     unittest.main()

--- a/test/legacy_test/test_reshape_op.py
+++ b/test/legacy_test/test_reshape_op.py
@@ -618,7 +618,6 @@ class TestReshapeOpError(unittest.TestCase):
         self.reshape = paddle.reshape
 
     def _test_errors(self):
-        paddle.enable_static()
         with program_guard(Program(), Program()):
             # The x type of reshape_op must be Variable.
             def test_x_type():
@@ -662,7 +661,6 @@ class TestReshapeOpError(unittest.TestCase):
                 self.reshape(x3, [-1, -2, 5])
 
             self.assertRaises(AssertionError, test_shape_3)
-        paddle.disable_static()
 
     def test_paddle_api_error(self):
         self._set_paddle_api()
@@ -725,34 +723,32 @@ class TestReshapeZeroTensor(unittest.TestCase):
 
 class TestReshapeAPI_ZeroDim(unittest.TestCase):
     def test_dygraph(self):
-        paddle.disable_static()
-        x = paddle.rand([])
-        x.stop_gradient = False
+        with paddle.base.dygraph.guard():
+            x = paddle.rand([])
+            x.stop_gradient = False
 
-        out = paddle.reshape(x, [1])
-        out.retain_grads()
-        out.backward()
-        self.assertEqual(x.grad.shape, [])
-        self.assertEqual(out.shape, [1])
-        self.assertEqual(out.grad.shape, [1])
+            out = paddle.reshape(x, [1])
+            out.retain_grads()
+            out.backward()
+            self.assertEqual(x.grad.shape, [])
+            self.assertEqual(out.shape, [1])
+            self.assertEqual(out.grad.shape, [1])
 
-        out = paddle.reshape(x, [-1, 1])
-        out.retain_grads()
-        out.backward()
-        self.assertEqual(x.grad.shape, [])
-        self.assertEqual(out.shape, [1, 1])
-        self.assertEqual(out.grad.shape, [1, 1])
+            out = paddle.reshape(x, [-1, 1])
+            out.retain_grads()
+            out.backward()
+            self.assertEqual(x.grad.shape, [])
+            self.assertEqual(out.shape, [1, 1])
+            self.assertEqual(out.grad.shape, [1, 1])
 
-        x = paddle.rand([1])
-        x.stop_gradient = False
-        out = paddle.reshape(x, [])
-        out.retain_grads()
-        out.backward()
-        self.assertEqual(x.grad.shape, [1])
-        self.assertEqual(out.shape, [])
-        self.assertEqual(out.grad.shape, [])
-
-        paddle.enable_static()
+            x = paddle.rand([1])
+            x.stop_gradient = False
+            out = paddle.reshape(x, [])
+            out.retain_grads()
+            out.backward()
+            self.assertEqual(x.grad.shape, [1])
+            self.assertEqual(out.shape, [])
+            self.assertEqual(out.grad.shape, [])
 
     def test_static(self):
         main_prog = base.Program()

--- a/test/legacy_test/test_scale_op.py
+++ b/test/legacy_test/test_scale_op.py
@@ -242,12 +242,11 @@ class TestScaleApiDygraph(unittest.TestCase):
         return paddle.scale(x, scale, bias)
 
     def test_api(self):
-        paddle.disable_static()
-        input = np.random.random([2, 25]).astype("float32")
-        x = paddle.to_tensor(input)
-        out = self._executed_api(x, scale=2.0, bias=3.0)
-        np.testing.assert_array_equal(out.numpy(), input * 2.0 + 3.0)
-        paddle.enable_static()
+        with paddle.base.dygraph.guard():
+            input = np.random.random([2, 25]).astype("float32")
+            x = paddle.to_tensor(input)
+            out = self._executed_api(x, scale=2.0, bias=3.0)
+            np.testing.assert_array_equal(out.numpy(), input * 2.0 + 3.0)
 
 
 class TestScaleInplaceApiDygraph(TestScaleApiDygraph):

--- a/test/legacy_test/test_searchsorted_op.py
+++ b/test/legacy_test/test_searchsorted_op.py
@@ -235,15 +235,14 @@ class TestSearchSortedAPI(unittest.TestCase):
 
     def test_dygraph_api(self):
         def run(place):
-            paddle.disable_static(place)
-            sorted_sequence = paddle.to_tensor(self.sorted_sequence)
-            values = paddle.to_tensor(self.values)
-            out = paddle.searchsorted(sorted_sequence, values, right=True)
-            out_ref = np.searchsorted(
-                self.sorted_sequence, self.values, side='right'
-            )
-            np.testing.assert_allclose(out_ref, out.numpy(), rtol=1e-05)
-            paddle.enable_static()
+            with paddle.base.dygraph.guard():
+                sorted_sequence = paddle.to_tensor(self.sorted_sequence)
+                values = paddle.to_tensor(self.values)
+                out = paddle.searchsorted(sorted_sequence, values, right=True)
+                out_ref = np.searchsorted(
+                    self.sorted_sequence, self.values, side='right'
+                )
+                np.testing.assert_allclose(out_ref, out.numpy(), rtol=1e-05)
 
         for place in self.place:
             run(place)

--- a/test/legacy_test/test_sort_op.py
+++ b/test/legacy_test/test_sort_op.py
@@ -94,20 +94,20 @@ class TestSortDygraph(unittest.TestCase):
             self.place = core.CPUPlace()
 
     def test_api_0(self):
-        paddle.disable_static(self.place)
-        var_x = paddle.to_tensor(self.input_data)
-        out = paddle.sort(var_x)
-        self.assertEqual((np.sort(self.input_data) == out.numpy()).all(), True)
-        paddle.enable_static()
+        with paddle.base.dygraph.guard(self.place):
+            var_x = paddle.to_tensor(self.input_data)
+            out = paddle.sort(var_x)
+            self.assertEqual(
+                (np.sort(self.input_data) == out.numpy()).all(), True
+            )
 
     def test_api_1(self):
-        paddle.disable_static(self.place)
-        var_x = paddle.to_tensor(self.input_data)
-        out = paddle.sort(var_x, axis=-1)
-        self.assertEqual(
-            (np.sort(self.input_data, axis=-1) == out.numpy()).all(), True
-        )
-        paddle.enable_static()
+        with paddle.base.dygraph.guard(self.place):
+            var_x = paddle.to_tensor(self.input_data)
+            out = paddle.sort(var_x, axis=-1)
+            self.assertEqual(
+                (np.sort(self.input_data, axis=-1) == out.numpy()).all(), True
+            )
 
     def test_api_2(self):
         paddle.disable_static(self.place)

--- a/test/legacy_test/test_strided_slice_op.py
+++ b/test/legacy_test/test_strided_slice_op.py
@@ -24,8 +24,6 @@ from op_test import (
 import paddle
 from paddle import base
 
-paddle.enable_static()
-
 
 def strided_slice_native_forward(input, axes, starts, ends, strides):
     dim = input.ndim
@@ -1169,17 +1167,16 @@ class TestStridedSliceFloat16(unittest.TestCase):
         self.infer_flags = [1, 1, 1, 1, 1]
 
     def check_main(self, x_np, dtype):
-        paddle.disable_static()
-        x_np = x_np.astype(dtype)
-        x = paddle.to_tensor(x_np)
-        x.stop_gradient = False
-        output = strided_slice_native_forward(
-            x, self.axes, self.starts, self.ends, self.strides
-        )
-        x_grad = paddle.grad(output, x)
-        output_np = output[0].numpy().astype('float32')
-        x_grad_np = x_grad[0].numpy().astype('float32')
-        paddle.enable_static()
+        with paddle.base.dygraph.guard():
+            x_np = x_np.astype(dtype)
+            x = paddle.to_tensor(x_np)
+            x.stop_gradient = False
+            output = strided_slice_native_forward(
+                x, self.axes, self.starts, self.ends, self.strides
+            )
+            x_grad = paddle.grad(output, x)
+            output_np = output[0].numpy().astype('float32')
+            x_grad_np = x_grad[0].numpy().astype('float32')
         return output_np, x_grad_np
 
     def test_check(self):
@@ -1195,4 +1192,5 @@ class TestStridedSliceFloat16(unittest.TestCase):
 
 
 if __name__ == "__main__":
+    paddle.enable_static()
     unittest.main()


### PR DESCRIPTION
### PR Category
Operator Mechanism


### PR Types
Improvements 


### Description
> 优化
因为不是很多，都是小更改，就都放一个PR了优化。

主要对 自动动态图管理 进行优化，发现大量直接 `disable_static()` 以及 `enable_static()` 组合，建议改为 `with paddle.base.dygraph.guard()` 以及 `with paddle.static.program_guard()`，避免意外。