### PR TITLE
[CI] Fix framework unittests exit with code `0xc000007b` on windows inference

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -320,3 +320,15 @@ set_pir_tests_properties()
 add_subdirectory(deprecated)
 add_subdirectory(flex_checkpoint)
 add_subdirectory(compat)
+
+if(WIN32 AND WITH_ONNXRUNTIME)
+  add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/cpp/onnxruntime.dll
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${ONNXRUNTIME_SHARED_LIB}"
+            "${CMAKE_CURRENT_BINARY_DIR}/cpp/onnxruntime.dll"
+    DEPENDS onnxruntime
+    COMMENT "Copying onnxruntime.dll to build/test/cpp")
+
+  add_custom_target(copy_onnxruntime ALL
+                    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/cpp/onnxruntime.dll)
+endif()

--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -16,15 +16,3 @@ add_subdirectory(compat)
 if(WITH_CINN)
   add_subdirectory(cinn)
 endif()
-
-if(WIN32 AND WITH_ONNXRUNTIME)
-  add_custom_command(
-    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/onnxruntime.dll
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${ONNXRUNTIME_SHARED_LIB}"
-            "${CMAKE_CURRENT_BINARY_DIR}/onnxruntime.dll"
-    DEPENDS onnxruntime
-    COMMENT "Copying onnxruntime.dll to build/test/cpp")
-
-  add_custom_target(copy_onnxruntime ALL
-                    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/onnxruntime.dll)
-endif()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
pcard-67164
当未修改C++文件时，不会执行test/cpp/CMakeLists.txt的逻辑，不会复制onnxruntime到build/test/cpp目录下，但是paddle\fluid\framework\ir仍会定义一些单测，这些单测需要依赖onnxruntime（指定路径不生效）