### PR TITLE
【CUDA Kernel No.42】correlation_grad_kernel算子Kernel修复-part

### DIFF
--- a/paddle/phi/kernels/gpu/correlation_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/correlation_grad_kernel.cu
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "paddle/phi/kernels/gpu/correlation_grad_kernel.h"
 #include "paddle/phi/backends/context_pool.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/kernel_registry.h"

--- a/paddle/phi/kernels/gpu/correlation_grad_kernel.h
+++ b/paddle/phi/kernels/gpu/correlation_grad_kernel.h
@@ -19,7 +19,7 @@
 namespace phi {
 
 template <typename T, typename Context>
-void CorrelationGradKernel(const Context &dev_ctx,
+void CorrelationCUDAGradKernel(const Context &dev_ctx,
                            const DenseTensor &input1,
                            const DenseTensor &input2,
                            const DenseTensor &out_grad,

--- a/paddle/phi/kernels/gpu/correlation_grad_kernel.h
+++ b/paddle/phi/kernels/gpu/correlation_grad_kernel.h
@@ -20,15 +20,15 @@ namespace phi {
 
 template <typename T, typename Context>
 void CorrelationCUDAGradKernel(const Context &dev_ctx,
-                           const DenseTensor &input1,
-                           const DenseTensor &input2,
-                           const DenseTensor &out_grad,
-                           int pad_size,
-                           int kernel_size,
-                           int max_displacement,
-                           int stride1,
-                           int stride2,
-                           int corr_type_multiply,
-                           DenseTensor *input1_grad,
-                           DenseTensor *input2_grad);
+                               const DenseTensor &input1,
+                               const DenseTensor &input2,
+                               const DenseTensor &out_grad,
+                               int pad_size,
+                               int kernel_size,
+                               int max_displacement,
+                               int stride1,
+                               int stride2,
+                               int corr_type_multiply,
+                               DenseTensor *input1_grad,
+                               DenseTensor *input2_grad);
 }  // namespace phi

--- a/paddle/phi/kernels/gpu/correlation_grad_kernel.h
+++ b/paddle/phi/kernels/gpu/correlation_grad_kernel.h
@@ -1,0 +1,34 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include "paddle/phi/core/dense_tensor.h"
+#include "paddle/phi/core/device_context.h"
+
+namespace phi {
+
+template <typename T, typename Context>
+void CorrelationGradKernel(const Context &dev_ctx,
+                           const DenseTensor &input1,
+                           const DenseTensor &input2,
+                           const DenseTensor &out_grad,
+                           int pad_size,
+                           int kernel_size,
+                           int max_displacement,
+                           int stride1,
+                           int stride2,
+                           int corr_type_multiply,
+                           DenseTensor *input1_grad,
+                           DenseTensor *input2_grad);
+}  // namespace phi


### PR DESCRIPTION
### PR Category
Performance Optimization

### PR Types
Bug fixes

### Description
在paddle/phi/kernels/gpu 下新增correlation_grad_kernel.h,并在correlation_grad_kernel.cu声明