### PR TITLE
【Features】`on_static_mode`

### DIFF
--- a/python/paddle/base/framework.py
+++ b/python/paddle/base/framework.py
@@ -202,24 +202,24 @@ def get_flags(flags: str | Sequence[str]) -> dict[str, bool | str | float]:
 
 
 @contextmanager
-def on_static_mode():
+def on_static_mode(*, force_static: bool = False):
     is_in_dygraph_mode = in_dygraph_mode()
     paddle.enable_static()
     try:
         yield
     finally:
-        if is_in_dygraph_mode:
+        if is_in_dygraph_mode or force_static:
             paddle.disable_static()
 
 
 @contextmanager
-def on_dygraph_mode():
+def on_dygraph_mode(*, force_dygraph: bool = False):
     is_in_dygraph_mode = in_dygraph_mode()
     paddle.disable_static()
     try:
         yield
     finally:
-        if not is_in_dygraph_mode:
+        if not is_in_dygraph_mode or force_dygraph:
             paddle.enable_static()
 
 

--- a/python/paddle/base/framework.py
+++ b/python/paddle/base/framework.py
@@ -202,6 +202,28 @@ def get_flags(flags: str | Sequence[str]) -> dict[str, bool | str | float]:
 
 
 @contextmanager
+def on_static_mode():
+    is_in_dygraph_mode = in_dygraph_mode()
+    paddle.enable_static()
+    try:
+        yield
+    finally:
+        if is_in_dygraph_mode:
+            paddle.disable_static()
+
+
+@contextmanager
+def on_dygraph_mode():
+    is_in_dygraph_mode = in_dygraph_mode()
+    paddle.disable_static()
+    try:
+        yield
+    finally:
+        if not is_in_dygraph_mode:
+            paddle.enable_static()
+
+
+@contextmanager
 def flag_guard(flag_name, flag_value):
     old_value = paddle.get_flags(flag_name)[flag_name]
     paddle.set_flags({flag_name: flag_value})

--- a/python/paddle/base/framework.py
+++ b/python/paddle/base/framework.py
@@ -213,17 +213,6 @@ def on_static_mode(*, force_static: bool = False):
 
 
 @contextmanager
-def on_dygraph_mode(*, force_dygraph: bool = False):
-    is_in_dygraph_mode = in_dygraph_mode()
-    paddle.disable_static()
-    try:
-        yield
-    finally:
-        if not is_in_dygraph_mode or force_dygraph:
-            paddle.enable_static()
-
-
-@contextmanager
 def flag_guard(flag_name, flag_value):
     old_value = paddle.get_flags(flag_name)[flag_name]
     paddle.set_flags({flag_name: flag_value})

--- a/python/paddle/base/framework.py
+++ b/python/paddle/base/framework.py
@@ -208,7 +208,7 @@ def on_static_mode(*, force_static: bool = False):
     try:
         yield
     finally:
-        if is_in_dygraph_mode or force_static:
+        if not force_static or is_in_dygraph_mode:
             paddle.disable_static()
 
 

--- a/test/legacy_test/test_framework_mode_switch.py
+++ b/test/legacy_test/test_framework_mode_switch.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # test/legacy_test/test_framework_mode_switch.py
 import unittest
 

--- a/test/legacy_test/test_framework_mode_switch.py
+++ b/test/legacy_test/test_framework_mode_switch.py
@@ -1,8 +1,12 @@
 # test/legacy_test/test_framework_mode_switch.py
 import unittest
+
 import paddle
-from paddle.base.framework import in_dygraph_mode
-from paddle.base.framework import on_static_mode, on_dygraph_mode
+from paddle.base.framework import (
+    in_dygraph_mode,
+    on_dygraph_mode,
+    on_static_mode,
+)
 
 
 class TestModeSwitchCtx(unittest.TestCase):

--- a/test/legacy_test/test_framework_mode_switch.py
+++ b/test/legacy_test/test_framework_mode_switch.py
@@ -1,0 +1,60 @@
+# test/legacy_test/test_framework_mode_switch.py
+import unittest
+import paddle
+from paddle.base.framework import in_dygraph_mode
+from paddle.base.framework import on_static_mode, on_dygraph_mode
+
+
+class TestModeSwitchCtx(unittest.TestCase):
+    def setUp(self):
+        self._was_dygraph = in_dygraph_mode()
+
+    def tearDown(self):
+        if self._was_dygraph:
+            paddle.disable_static()
+        else:
+            paddle.enable_static()
+
+    def test_on_static_mode_from_dygraph(self):
+        paddle.disable_static()
+        self.assertTrue(in_dygraph_mode())
+        with on_static_mode():
+            self.assertFalse(in_dygraph_mode())
+        self.assertTrue(in_dygraph_mode())
+
+    def test_on_static_mode_from_static(self):
+        paddle.enable_static()
+        self.assertFalse(in_dygraph_mode())
+        with on_static_mode():
+            self.assertFalse(in_dygraph_mode())
+        self.assertFalse(in_dygraph_mode())
+
+    def test_on_static_mode_force_static(self):
+        paddle.disable_static()
+        with on_static_mode(force_static=True):
+            self.assertFalse(in_dygraph_mode())
+        self.assertFalse(in_dygraph_mode())
+
+    def test_on_dygraph_mode_from_static(self):
+        paddle.enable_static()
+        self.assertFalse(in_dygraph_mode())
+        with on_dygraph_mode():
+            self.assertTrue(in_dygraph_mode())
+        self.assertFalse(in_dygraph_mode())
+
+    def test_on_dygraph_mode_from_dygraph(self):
+        paddle.disable_static()
+        self.assertTrue(in_dygraph_mode())
+        with on_dygraph_mode():
+            self.assertTrue(in_dygraph_mode())
+        self.assertTrue(in_dygraph_mode())
+
+    def test_on_dygraph_mode_force_dygraph(self):
+        paddle.enable_static()
+        with on_dygraph_mode(force_dygraph=True):
+            self.assertTrue(in_dygraph_mode())
+        self.assertTrue(in_dygraph_mode())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/legacy_test/test_framework_mode_switch.py
+++ b/test/legacy_test/test_framework_mode_switch.py
@@ -18,31 +18,19 @@ import unittest
 import paddle
 from paddle.base.framework import (
     in_dygraph_mode,
-    on_dygraph_mode,
     on_static_mode,
 )
 
 
 class TestModeSwitchCtx(unittest.TestCase):
-    def setUp(self):
-        self._was_dygraph = in_dygraph_mode()
-
-    def tearDown(self):
-        if self._was_dygraph:
-            paddle.disable_static()
-        else:
-            paddle.enable_static()
-
     def test_on_static_mode_from_dygraph(self):
         paddle.disable_static()
-        self.assertTrue(in_dygraph_mode())
         with on_static_mode():
             self.assertFalse(in_dygraph_mode())
         self.assertTrue(in_dygraph_mode())
 
     def test_on_static_mode_from_static(self):
         paddle.enable_static()
-        self.assertFalse(in_dygraph_mode())
         with on_static_mode():
             self.assertFalse(in_dygraph_mode())
         self.assertFalse(in_dygraph_mode())
@@ -52,26 +40,6 @@ class TestModeSwitchCtx(unittest.TestCase):
         with on_static_mode(force_static=True):
             self.assertFalse(in_dygraph_mode())
         self.assertFalse(in_dygraph_mode())
-
-    def test_on_dygraph_mode_from_static(self):
-        paddle.enable_static()
-        self.assertFalse(in_dygraph_mode())
-        with on_dygraph_mode():
-            self.assertTrue(in_dygraph_mode())
-        self.assertFalse(in_dygraph_mode())
-
-    def test_on_dygraph_mode_from_dygraph(self):
-        paddle.disable_static()
-        self.assertTrue(in_dygraph_mode())
-        with on_dygraph_mode():
-            self.assertTrue(in_dygraph_mode())
-        self.assertTrue(in_dygraph_mode())
-
-    def test_on_dygraph_mode_force_dygraph(self):
-        paddle.enable_static()
-        with on_dygraph_mode(force_dygraph=True):
-            self.assertTrue(in_dygraph_mode())
-        self.assertTrue(in_dygraph_mode())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
New features

### Description
> 可以更加方便的说~

如你所见这是所添加特性:
```
@contextmanager
def on_static_mode(*, force_static: bool = False):
    is_in_dygraph_mode = in_dygraph_mode()
    paddle.enable_static()
    try:
        yield
    finally:
        if is_in_dygraph_mode or force_static:
            paddle.disable_static()
```
```
@contextmanager
def on_dygraph_mode(*, force_dygraph: bool = False):
    is_in_dygraph_mode = in_dygraph_mode()
    paddle.disable_static()
    try:
        yield
    finally:
        if not is_in_dygraph_mode or force_dygraph:
            paddle.enable_static()
```
> 如果将`disable_static()` + `enable_static()` 替换为 `@paddle.base.dygraph.guard()` 可能会有一些问题，有时会导致一些错误，这个接口似乎并不能直接作为 `disable_static()` + `enable_static()` 替换使用。

`on_dygraph_mode` 以及 `on_static_mode` 给出了一个 `force_static` 以及 `force_dygraph` 选项，可以避免不必要的判断问题。

### Explaination
> force_static

无需在运行前就保持动态图模式，运行完成后可直接强制切回动态图。

> force_dygraph

无需在运行前就保持静态图模式，运行完成后可直接强制切回静态图。