### PR TITLE
【CUDA Kernel No.81】moe_unpermute算子Kernel修复 -part 

### DIFF
--- a/paddle/phi/kernels/gpu/moe_unpermute_kernel.cu
+++ b/paddle/phi/kernels/gpu/moe_unpermute_kernel.cu
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
+#include "paddle/phi/kernels/gpu/moe_unpermute_kernel.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/full_kernel.h"

--- a/paddle/phi/kernels/gpu/moe_unpermute_kernel.h
+++ b/paddle/phi/kernels/gpu/moe_unpermute_kernel.h
@@ -14,8 +14,8 @@
 
 #pragma once
 
-#include "paddle/phi/core/enforce.h"
-#include "paddle/phi/core/p.h"
+#include "paddle/phi/core/dense_tensor.h"
+#include "paddle/phi/core/device_context.h"
 
 namespace phi {
 

--- a/paddle/phi/kernels/gpu/moe_unpermute_kernel.h
+++ b/paddle/phi/kernels/gpu/moe_unpermute_kernel.h
@@ -1,0 +1,34 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "paddle/phi/core/enforce.h"
+#include "paddle/phi/core/p.h"
+
+namespace phi {
+
+template <typename T, typename Context>
+void MoeUnpermuteKernel(const Context &dev_ctx,
+                        const DenseTensor &unzipped_tokens,
+                        const DenseTensor &zipped_expertwise_rowmap,
+                        const DenseTensor &expert_routemap_topk,
+                        const DenseTensor &unzipped_token_probs,
+                        const int total_zipped_tokens_num,
+                        const int num_experts,
+                        const bool MP,
+                        DenseTensor *zipped_tokens,
+                        DenseTensor *zipped_probs_topk);
+
+}  // namespace phi


### PR DESCRIPTION
### PR Category
Performance Optimization

### PR Types
Bug fixes

### Description
Add paddle/phi/kernels/gpu/moe_unpermute_kernel.h