### PR TITLE
【CUDA Kernel No.33】Add c_concat_kernel.h -part

### DIFF
--- a/paddle/phi/kernels/c_concat_kernel.h
+++ b/paddle/phi/kernels/c_concat_kernel.h
@@ -1,0 +1,29 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "paddle/phi/core/dense_tensor.h"
+
+namespace phi {
+template <typename T, typename Context>
+void CConcatKernel(const Context& dev_ctx,
+                   const DenseTensor& x_in,
+                   int rank,
+                   int nranks,
+                   int ring_id,
+                   bool use_calc_stream,
+                   bool use_model_parallel,
+                   DenseTensor* out);
+}  // namespace phi

--- a/paddle/phi/kernels/cpu/c_concat_kernel.cc
+++ b/paddle/phi/kernels/cpu/c_concat_kernel.cc
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "paddle/phi/kernels/c_concat_kernel.h"
 #include "paddle/phi/core/kernel_registry.h"
 
 namespace phi {

--- a/paddle/phi/kernels/custom/c_concat_kernel.cc
+++ b/paddle/phi/kernels/custom/c_concat_kernel.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "paddle/phi/kernels/c_concat_kernel.h"
 #include "paddle/phi/api/backward/backward_api.h"
 #include "paddle/phi/api/include/api.h"
 #include "paddle/phi/backends/all_context.h"

--- a/paddle/phi/kernels/gpu/c_concat_kernel.cu
+++ b/paddle/phi/kernels/gpu/c_concat_kernel.cu
@@ -17,6 +17,7 @@
 #include "paddle/phi/api/include/tensor.h"
 #include "paddle/phi/backends/context_pool.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/c_concat_kernel.h"
 #include "paddle/phi/kernels/funcs/concat_and_split_functor.h"
 
 #if defined(PADDLE_WITH_NCCL) || defined(PADDLE_WITH_RCCL)

--- a/paddle/phi/kernels/xpu/c_concat_kernel.cc
+++ b/paddle/phi/kernels/xpu/c_concat_kernel.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "paddle/phi/kernels/c_concat_kernel.h"
 #include <vector>
 #include "paddle/phi/api/include/tensor.h"
 #include "paddle/phi/core/kernel_registry.h"


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Custom Device


### PR Types
Improvements


### Description
- Add c_concat_kernel.h
- Include the .h file for cpu&gpu&xpu&custom implementations
