### PR TITLE
[API compatibility] fix bugs when compile with cuda13 on Windows

### DIFF
--- a/paddle/phi/backends/dynload/dynamic_loader.cc
+++ b/paddle/phi/backends/dynload/dynamic_loader.cc
@@ -449,9 +449,15 @@ void* GetCublasDsoHandle() {
     return GetDsoHandleFromSearchPath(
         FLAGS_cuda_dir, win_cublas_lib, true, {cuda_lib_path});
 #endif
+  } else if (CUDA_VERSION >= 13000 && CUDA_VERSION < 14000) {
+#ifdef PADDLE_WITH_PIP_CUDA_LIBRARIES
+    return GetDsoHandleFromSearchPath(FLAGS_cublas_dir, "libcublasLt.so.13");
+#else
+    return GetDsoHandleFromSearchPath(FLAGS_cublas_dir, "libcublasLt.so");
+#endif
   } else {
     std::string warning_msg(
-        "Your CUDA_VERSION is less than 11 or greater than 13, paddle "
+        "Your CUDA_VERSION is less than 11 or greater than 14, paddle "
         "temporarily no longer supports");
     return nullptr;
   }


### PR DESCRIPTION
### PR Category
Environment Adaptation


### PR Types
Bug fixes


### Description
在Windows上编译的GPU版本的wheel包无法链接cublas的问题已解决，在Linux上存在同样的问题，已在 https://github.com/PaddlePaddle/Paddle/pull/75509 中解决，cmake命令cmake .. -GNinja -DWITH_GPU=ON -DWITH_UNITY_BUILD=ON -DCUDA_ARCH_NAME=Auto -DWITH_TENSORRT=ON -DTENSORRT_ROOT=D:\TensorRT-10.13.3.9，在RTX3070上编译，驱动程序版本581.29，paddle.utils.run_check()可以正常跑通
