### PR TITLE
[Compat] Allow user temporary disable torch proxy by guard

### DIFF
--- a/python/paddle/compat.py
+++ b/python/paddle/compat.py
@@ -184,9 +184,19 @@ def disable_torch_proxy():
 
 
 @contextmanager
-def use_torch_proxy_guard():
-    enable_torch_proxy()
-    try:
-        yield
-    finally:
+def use_torch_proxy_guard(enable: bool = True):
+    already_has_torch_proxy = TORCH_PROXY_FINDER in sys.meta_path
+    if enable == already_has_torch_proxy:
+        return
+    if enable:
+        enable_torch_proxy()
+        try:
+            yield
+        finally:
+            disable_torch_proxy()
+    else:
         disable_torch_proxy()
+        try:
+            yield
+        finally:
+            enable_torch_proxy()

--- a/test/compat/test_torch_proxy.py
+++ b/test/compat/test_torch_proxy.py
@@ -64,6 +64,19 @@ class TestTorchProxy(unittest.TestCase):
         with self.assertRaises(ModuleNotFoundError):
             import torch
 
+        with paddle.compat.use_torch_proxy_guard():
+            import torch
+
+            self.assertIs(torch.cos, paddle.cos)
+            with paddle.compat.use_torch_proxy_guard(enable=False):
+                with self.assertRaises(ModuleNotFoundError):
+                    import torch
+                with paddle.compat.use_torch_proxy_guard(enable=True):
+                    import torch
+
+        with self.assertRaises(ModuleNotFoundError):
+            import torch
+
     @paddle.compat.use_torch_proxy_guard()
     def test_use_torch_inside_inner_function(self):
         result = use_torch_inside_inner_function()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Improvements

### Description
<!-- Describe what you’ve done -->

Sometimes we need to temporarily disable the torch proxy. For example, in flashinfer, we need to disable the proxy when importing tvm-ffi.

```python
with paddle.compat.use_torch_proxy_guard(enable=False):
    import tvm_ffi
```

tvm-ffi contains code like:

```python
try:
    import torch
except ModuleNotFoundError:
    torch = None
```

We do not want tvm-ffi to recognize PaddlePaddle as torch, so we need to temporarily disable this proxy during that import.

<!-- PCard-66972 -->