### PR TITLE
【CUDA Kernel No.35】Add c_scatter_kernel.h -part

### DIFF
--- a/paddle/phi/kernels/gpu/c_scatter_kernel.cu
+++ b/paddle/phi/kernels/gpu/c_scatter_kernel.cu
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "paddle/phi/kernels/gpu/c_scatter_kernel.h"
 #include "glog/logging.h"
 #include "paddle/phi/core/distributed/comm_context_manager.h"
 

--- a/paddle/phi/kernels/gpu/c_scatter_kernel.h
+++ b/paddle/phi/kernels/gpu/c_scatter_kernel.h
@@ -1,0 +1,29 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "paddle/phi/core/dense_tensor.h"
+
+namespace phi {
+
+template <typename T, typename Context>
+void CScatterOpCUDAKernel(const Context& dev_ctx,
+                          const DenseTensor& input,
+                          int ring_id,
+                          int root,
+                          int nranks,
+                          bool use_calc_stream,
+                          DenseTensor* out);
+}  // namespace phi


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Custom Device


### PR Types
Improvements


### Description
- Add c_scatter_kernel.h
- Include the .h file for gpu implementation
