### PR TITLE
【CUDA Kernel No.22】ap_trivial_fusion_begin算子Kernel修复 -part

### DIFF
--- a/paddle/phi/kernels/gpu/ap_trivial_fusion_begin_kernel.h
+++ b/paddle/phi/kernels/gpu/ap_trivial_fusion_begin_kernel.h
@@ -12,11 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "paddle/phi/kernels/gpu/ap_trivial_fusion_begin_kernel.h"
-#include "paddle/common/enforce.h"
-#include "paddle/phi/backends/gpu/gpu_context.h"
+#pragma once
+
+#include <vector>
 #include "paddle/phi/core/dense_tensor.h"
-#include "paddle/phi/core/kernel_registry.h"
 
 namespace phi {
 
@@ -24,22 +23,6 @@ template <typename T, typename Context>
 void ApTrivialFusionBeginKernel(
     const Context& dev_ctx,
     const paddle::optional<std::vector<const DenseTensor*>>& xs,
-    DenseTensor* out) {
-  PADDLE_THROW(common::errors::Unimplemented(
-      "pd_op.ap_trivial_fusion_begin has no kernel registered."));
-}
+    DenseTensor* out);
 
 }  // namespace phi
-
-PD_REGISTER_KERNEL(ap_trivial_fusion_begin,
-                   GPU,
-                   ALL_LAYOUT,
-                   phi::ApTrivialFusionBeginKernel,
-                   float,
-                   double,
-                   int,
-                   phi::bfloat16,
-                   phi::float16,
-                   int64_t,
-                   phi::complex64,
-                   phi::complex128) {}


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Performance Optimization

### PR Types
Bug fixes


### Description
新增ap_trivial_fusion_begin_kernel.h