### PR TITLE
【CUDA Kernel No.36】c_softmax_with_cross_entropy_grad算子Kernel修复 -part

### DIFF
--- a/paddle/phi/kernels/c_softmax_with_cross_entropy_grad_kernel.h
+++ b/paddle/phi/kernels/c_softmax_with_cross_entropy_grad_kernel.h
@@ -1,0 +1,29 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "paddle/phi/core/dense_tensor.h"
+
+namespace phi {
+template <typename T, typename Context>
+void CSoftmaxWithCrossEntropyGradKernel(const Context& dev_ctx,
+                                        const DenseTensor& softmax_in,
+                                        const DenseTensor& label_in,
+                                        const DenseTensor& loss_grad_in,
+                                        int64_t ignore_index,
+                                        int rank,
+                                        int nranks,
+                                        DenseTensor* logits_grad);
+}  // namespace phi

--- a/paddle/phi/kernels/gpu/c_softmax_with_cross_entropy_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/c_softmax_with_cross_entropy_grad_kernel.cu
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "paddle/phi/kernels/c_softmax_with_cross_entropy_grad_kernel.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/axis_utils.h"

--- a/paddle/phi/kernels/xpu/c_softmax_with_cross_entropy_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/c_softmax_with_cross_entropy_grad_kernel.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "paddle/phi/kernels/c_softmax_with_cross_entropy_grad_kernel.h"
 #include "paddle/phi/backends/xpu/xpu_context.h"
 #include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/core/kernel_registry.h"


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Performance Optimization


### PR Types
Bug fixes


### Description
新增c_softmax_with_cross_entropy_grad_kernel.h
