### PR TITLE
[Stride] Support Strided Grad Functions

### DIFF
--- a/paddle/phi/kernels/elementwise_multiply_kernel.h
+++ b/paddle/phi/kernels/elementwise_multiply_kernel.h
@@ -37,6 +37,12 @@ DenseTensor Multiply(const Context& dev_ctx,
 }
 
 template <typename T, typename Context>
+void MultiplyStrideKernel(const Context& dev_ctx,
+                          const DenseTensor& x,
+                          const DenseTensor& y,
+                          DenseTensor* out);
+
+template <typename T, typename Context>
 void Multiply(const Context& dev_ctx,
               const DenseTensor& x,
               const DenseTensor& y,

--- a/paddle/phi/kernels/scale_kernel.h
+++ b/paddle/phi/kernels/scale_kernel.h
@@ -29,6 +29,14 @@ void ScaleKernel(const Context& dev_ctx,
                  DenseTensor* out);
 
 template <typename T, typename Context>
+void ScaleStrideKernel(const Context& dev_ctx,
+                       const DenseTensor& x,
+                       const Scalar& scale,
+                       const Scalar& bias,
+                       bool bias_after_scale,
+                       DenseTensor* out);
+
+template <typename T, typename Context>
 DenseTensor Scale(const Context& dev_ctx,
                   const DenseTensor& x,
                   const Scalar& scale,

--- a/paddle/phi/kernels/stride/activation_kernel.cu
+++ b/paddle/phi/kernels/stride/activation_kernel.cu
@@ -35,16 +35,6 @@
 COMMON_DECLARE_bool(use_stride_kernel);
 COMMON_DECLARE_bool(use_stride_compute_kernel);
 namespace phi {
-template <typename T, typename Context, typename Functor>
-void LaunchUnaryElementwiseStrideKernel(const Context &dev_ctx,
-                                        const DenseTensor &x,
-                                        Functor func,
-                                        DenseTensor *out) {
-  std::vector<const DenseTensor *> inputs = {&x};
-  std::vector<DenseTensor *> outputs = {out};
-  dev_ctx.template Alloc<T>(out);
-  UnaryStrideElementwiseKernel<T, Context>(dev_ctx, inputs, &outputs, func);
-}
 #define DEFINE_CUDA_ACTIVATION_STRIDE_OP(name, functor_class)                 \
   template <typename T, typename Context>                                     \
   void name##StrideKernel(                                                    \

--- a/paddle/phi/kernels/stride/bitwise_kernel.cu
+++ b/paddle/phi/kernels/stride/bitwise_kernel.cu
@@ -25,32 +25,6 @@
 COMMON_DECLARE_bool(use_stride_kernel);
 COMMON_DECLARE_bool(use_stride_compute_kernel);
 namespace phi {
-
-template <typename T, typename Context, typename Functor>
-void LaunchBinaryElementwiseStrideKernel(const Context &dev_ctx,
-                                         const DenseTensor &x,
-                                         const DenseTensor &y,
-                                         Functor func,
-                                         int axis,
-                                         DenseTensor *out) {
-  std::vector<const DenseTensor *> inputs = {&x, &y};
-  std::vector<DenseTensor *> outputs = {out};
-  dev_ctx.template Alloc<T>(out);
-  BinaryStrideBroadcastKernel<T, Context>(
-      dev_ctx, inputs, &outputs, func, axis);
-}
-
-template <typename T, typename Context, typename Functor>
-void LaunchUnaryElementwiseStrideKernel(const Context &dev_ctx,
-                                        const DenseTensor &x,
-                                        Functor func,
-                                        DenseTensor *out) {
-  std::vector<const DenseTensor *> inputs = {&x};
-  std::vector<DenseTensor *> outputs = {out};
-  dev_ctx.template Alloc<T>(out);
-  UnaryStrideElementwiseKernel<T, Context>(dev_ctx, inputs, &outputs, func);
-}
-
 #define DEFINE_CUDA_BINARY_ELEMENTWISE_STRIDE_OP(name)                        \
   template <typename T, typename Context>                                     \
   void name##StrideKernel(const Context &dev_ctx,                             \

--- a/paddle/phi/kernels/stride/elementwise_grad_stride_kernel.cu
+++ b/paddle/phi/kernels/stride/elementwise_grad_stride_kernel.cu
@@ -1,0 +1,323 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+
+#include "paddle/common/flags.h"
+#include "paddle/phi/backends/gpu/gpu_context.h"
+#include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/core/visit_type.h"
+#include "paddle/phi/kernels/contiguous_kernel.h"
+#include "paddle/phi/kernels/elementwise_add_grad_kernel.h"
+#include "paddle/phi/kernels/elementwise_multiply_grad_kernel.h"
+#include "paddle/phi/kernels/elementwise_multiply_kernel.h"
+#include "paddle/phi/kernels/elementwise_subtract_grad_kernel.h"
+#include "paddle/phi/kernels/funcs/elementwise_base.h"
+#include "paddle/phi/kernels/funcs/elementwise_functor.h"
+#include "paddle/phi/kernels/gpu/elementwise_grad.h"
+#include "paddle/phi/kernels/scale_kernel.h"
+
+#if defined(__NVCC__) || defined(__HIPCC__) || defined(__xpu__)
+#include "paddle/phi/kernels/funcs/dims_simplifier.h"
+
+#endif
+
+COMMON_DECLARE_bool(use_stride_kernel);
+COMMON_DECLARE_bool(use_stride_compute_kernel);
+
+namespace phi {
+
+template <typename Context>
+phi::DenseTensor Tensor2Contiguous(const Context& dev_ctx,
+                                   const phi::DenseTensor& tensor) {
+  phi::DenseTensor dense_out;
+  phi::MetaTensor meta_input(tensor);
+  phi::MetaTensor meta_out(&dense_out);
+  UnchangedInferMeta(meta_input, &meta_out);
+  PD_VISIT_ALL_TYPES(tensor.dtype(), "Tensor2Contiguous", ([&] {
+                       phi::ContiguousKernel<data_t, Context>(
+                           dev_ctx, tensor, &dense_out);
+                     }));
+  return dense_out;
+}
+
+template <typename T, typename Context>
+void AddGradStrideKernel(const Context& dev_ctx,
+                         const DenseTensor& x,
+                         const DenseTensor& y,
+                         const DenseTensor& dout,
+                         int axis,
+                         DenseTensor* dx,
+                         DenseTensor* dy) {
+  if (!FLAGS_use_stride_kernel) {
+    PADDLE_THROW(common::errors::Fatal(
+        "FLAGS_use_stride_kernel is closed. Strided kernel "
+        "be called, something wrong has happened!"));
+  }
+
+  DenseTensor x_;
+  DenseTensor y_;
+  DenseTensor dout_;
+
+  // avoid inplace
+  bool inplace_add = false;
+  if (dx && dx->IsSharedBufferWith(dout)) inplace_add = true;
+
+  if (FLAGS_use_stride_compute_kernel && !inplace_add) {
+    auto meta = dout.meta();
+    if (dx != nullptr && dy != nullptr && dx->dims() == dout.dims() &&
+        dy->dims() == dout.dims()) {
+      dx->set_meta(meta);
+      dx->ResetHolder(dout.Holder());
+      dx->ShareInplaceVersionCounterWith(dout);
+      dy->set_meta(meta);
+      dy->ResetHolder(dout.Holder());
+      dy->ShareInplaceVersionCounterWith(dout);
+      return;
+    }
+    if (dx != nullptr && dy == nullptr && dx->dims() == dout.dims()) {
+      dx->set_meta(meta);
+      dx->ResetHolder(dout.Holder());
+      dx->ShareInplaceVersionCounterWith(dout);
+      return;
+    }
+    if (dy != nullptr && dx == nullptr && dy->dims() == dout.dims()) {
+      dy->set_meta(meta);
+      dy->ResetHolder(dout.Holder());
+      dy->ShareInplaceVersionCounterWith(dout);
+      return;
+    }
+  }
+
+  if (x.initialized() && !x.meta().is_contiguous()) {
+    x_ = Tensor2Contiguous<Context>(dev_ctx, x);
+  } else {
+    x_ = x;
+  }
+  if (y.initialized() && !y.meta().is_contiguous()) {
+    y_ = Tensor2Contiguous<Context>(dev_ctx, y);
+  } else {
+    y_ = y;
+  }
+  if (dout.initialized() && !dout.meta().is_contiguous()) {
+    dout_ = Tensor2Contiguous<Context>(dev_ctx, dout);
+  } else {
+    dout_ = dout;
+  }
+
+  if (dx) {
+    auto dx_meta = dx->meta();
+    dx_meta.strides = dx_meta.calc_strides(dx->dims());
+    dx->set_meta(dx_meta);
+  }
+
+  if (dy) {
+    auto dy_meta = dy->meta();
+    dy_meta.strides = dy_meta.calc_strides(dy->dims());
+    dy->set_meta(dy_meta);
+  }
+  phi::AddGradKernel<T>(dev_ctx, x_, y_, dout_, axis, dx, dy);
+}
+
+template <typename T, typename Context>
+void SubtractGradStrideKernel(const Context& dev_ctx,
+                              const DenseTensor& x,
+                              const DenseTensor& y,
+                              const DenseTensor& dout,
+                              int axis,
+                              DenseTensor* dx,
+                              DenseTensor* dy) {
+  if (!FLAGS_use_stride_kernel) {
+    PADDLE_THROW(common::errors::Fatal(
+        "FLAGS_use_stride_kernel is closed. Strided kernel "
+        "be called, something wrong has happened!"));
+  }
+
+  DenseTensor x_;
+  DenseTensor y_;
+  DenseTensor dout_;
+
+  if (FLAGS_use_stride_compute_kernel) {
+    auto meta = dout.meta();
+    if (dx != nullptr && dy != nullptr && dx->dims() == dout.dims() &&
+        dy->dims() == dout.dims()) {
+      dx->set_meta(meta);
+      dx->ResetHolder(dout.Holder());
+      dx->ShareInplaceVersionCounterWith(dout);
+      phi::ScaleStrideKernel<T, Context>(dev_ctx, dout, -1, 0, false, dy);
+      return;
+    }
+    if (dx != nullptr && dy == nullptr && dx->dims() == dout.dims()) {
+      dx->set_meta(meta);
+      dx->ResetHolder(dout.Holder());
+      dx->ShareInplaceVersionCounterWith(dout);
+      return;
+    }
+    if (dy != nullptr && dx == nullptr && dy->dims() == dout.dims()) {
+      phi::ScaleStrideKernel<T, Context>(dev_ctx, dout, -1, 0, false, dy);
+      return;
+    }
+  }
+
+  if (x.initialized() && !x.meta().is_contiguous()) {
+    x_ = Tensor2Contiguous<Context>(dev_ctx, x);
+  } else {
+    x_ = x;
+  }
+  if (y.initialized() && !y.meta().is_contiguous()) {
+    y_ = Tensor2Contiguous<Context>(dev_ctx, y);
+  } else {
+    y_ = y;
+  }
+  if (dout.initialized() && !dout.meta().is_contiguous()) {
+    dout_ = Tensor2Contiguous<Context>(dev_ctx, dout);
+  } else {
+    dout_ = dout;
+  }
+
+  if (dx) {
+    auto dx_meta = dx->meta();
+    dx_meta.strides = dx_meta.calc_strides(dx->dims());
+    dx->set_meta(dx_meta);
+  }
+
+  if (dy) {
+    auto dy_meta = dy->meta();
+    dy_meta.strides = dy_meta.calc_strides(dy->dims());
+    dy->set_meta(dy_meta);
+  }
+  phi::SubtractGradKernel<T>(dev_ctx, x_, y_, dout_, axis, dx, dy);
+}
+
+template <typename T, typename Context>
+void MultiplyGradStrideKernel(const Context& dev_ctx,
+                              const DenseTensor& x,
+                              const DenseTensor& y,
+                              const DenseTensor& dout,
+                              int axis,
+                              DenseTensor* dx,
+                              DenseTensor* dy) {
+  if (!FLAGS_use_stride_kernel) {
+    PADDLE_THROW(common::errors::Fatal(
+        "FLAGS_use_stride_kernel is closed. Strided kernel "
+        "be called, something wrong has happened!"));
+  }
+
+  DenseTensor x_;
+  DenseTensor y_;
+  DenseTensor dout_;
+
+  if (FLAGS_use_stride_compute_kernel && dout.initialized() &&
+      dout.numel() != 0) {
+    auto broadcast_dim = dout.dims();
+    if (x.initialized() && y.initialized() && dx != nullptr && dy != nullptr &&
+        broadcast_dim == dx->dims() && broadcast_dim == dy->dims()) {
+      phi::MultiplyStrideKernel<T, Context>(dev_ctx, dout, y, dx);
+      phi::MultiplyStrideKernel<T, Context>(dev_ctx, dout, x, dy);
+      return;
+    }
+
+    if (y.initialized() && dx != nullptr && dy == nullptr &&
+        broadcast_dim == dx->dims()) {
+      phi::MultiplyStrideKernel<T, Context>(dev_ctx, dout, y, dx);
+      return;
+    }
+
+    if (x.initialized() && dy != nullptr && dx == nullptr &&
+        broadcast_dim == dy->dims()) {
+      phi::MultiplyStrideKernel<T, Context>(dev_ctx, dout, x, dy);
+      return;
+    }
+  }
+
+  if (x.initialized() && !x.meta().is_contiguous()) {
+    x_ = Tensor2Contiguous<Context>(dev_ctx, x);
+  } else {
+    x_ = x;
+  }
+
+  if (y.initialized() && !y.meta().is_contiguous()) {
+    y_ = Tensor2Contiguous<Context>(dev_ctx, y);
+  } else {
+    y_ = y;
+  }
+
+  if (dout.initialized() && !dout.meta().is_contiguous()) {
+    dout_ = Tensor2Contiguous<Context>(dev_ctx, dout);
+  } else {
+    dout_ = dout;
+  }
+
+  if (dx) {
+    auto dx_meta = dx->meta();
+    dx_meta.strides = dx_meta.calc_strides(dx->dims());
+    dx->set_meta(dx_meta);
+  }
+
+  if (dy) {
+    auto dy_meta = dy->meta();
+    dy_meta.strides = dy_meta.calc_strides(dy->dims());
+    dy->set_meta(dy_meta);
+  }
+  phi::MultiplyGradKernel<T>(dev_ctx, x_, y_, dout_, axis, dx, dy);
+}
+
+}  // namespace phi
+
+using float16 = phi::float16;
+using bfloat16 = phi::bfloat16;
+using complex64 = ::phi::complex64;
+using complex128 = ::phi::complex128;
+
+PD_REGISTER_KERNEL(add_grad,
+                   GPU,
+                   STRIDED,
+                   phi::AddGradStrideKernel,
+                   float,
+                   double,
+                   int,
+                   int64_t,
+                   phi::float16,
+                   phi::bfloat16,
+                   phi::complex64,
+                   phi::complex128) {}
+
+PD_REGISTER_KERNEL(subtract_grad,
+                   GPU,
+                   STRIDED,
+                   phi::SubtractGradStrideKernel,
+                   float,
+                   double,
+                   int,
+                   int64_t,
+                   phi::float16,
+                   phi::bfloat16,
+                   phi::complex64,
+                   phi::complex128) {}
+
+PD_REGISTER_KERNEL(multiply_grad,
+                   GPU,
+                   STRIDED,
+                   phi::MultiplyGradStrideKernel,
+                   float,
+                   phi::float16,
+                   double,
+                   int,
+                   int64_t,
+                   bool,
+                   phi::bfloat16,
+                   phi::complex64,
+                   phi::complex128) {}
+
+#endif

--- a/paddle/phi/kernels/stride/elementwise_kernel.cu
+++ b/paddle/phi/kernels/stride/elementwise_kernel.cu
@@ -42,21 +42,6 @@ COMMON_DECLARE_bool(use_stride_kernel);
 COMMON_DECLARE_bool(use_stride_compute_kernel);
 
 namespace phi {
-
-template <typename T, typename Context, typename Functor>
-void LaunchBinaryElementwiseStrideKernel(const Context &dev_ctx,
-                                         const DenseTensor &x,
-                                         const DenseTensor &y,
-                                         Functor func,
-                                         int axis,
-                                         DenseTensor *out) {
-  std::vector<const DenseTensor *> inputs = {&x, &y};
-  std::vector<DenseTensor *> outputs = {out};
-  dev_ctx.template Alloc<T>(out);
-  BinaryStrideBroadcastKernel<T, Context>(
-      dev_ctx, inputs, &outputs, func, axis);
-}
-
 #define DEFINE_CUDA_BINARY_ELEMENTWISE_STRIDE_OP(name, functor_name)          \
   template <typename T, typename Context>                                     \
   void name##StrideKernel(const Context &dev_ctx,                             \
@@ -240,12 +225,6 @@ void ScaleStrideKernel(const Context &dev_ctx,
   if (x.numel() <= 0 || (!x.IsInitialized())) {
     dev_ctx.template Alloc<T>(out);
     return;
-  }
-
-  if (FLAGS_force_stride_compute_kernel_out_con) {
-    auto meta = out->meta();
-    meta.strides = meta.calc_strides(out->dims());
-    out->set_meta(meta);
   }
 
   using MT = typename phi::dtype::MPTypeTrait<T>::Type;

--- a/paddle/phi/kernels/stride/elementwise_kernel.cu
+++ b/paddle/phi/kernels/stride/elementwise_kernel.cu
@@ -23,12 +23,14 @@
 #include "paddle/phi/kernels/elementwise_divide_kernel.h"
 #include "paddle/phi/kernels/elementwise_multiply_kernel.h"
 #include "paddle/phi/kernels/elementwise_subtract_kernel.h"
+#include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/funcs/broadcast_function.h"
 #include "paddle/phi/kernels/funcs/dense_tensor_iterator.h"
 #include "paddle/phi/kernels/funcs/elementwise_base.h"
 #include "paddle/phi/kernels/funcs/elementwise_functor.h"
 #include "paddle/phi/kernels/funcs/index_elementwise.cu.h"
 #include "paddle/phi/kernels/impl/elementwise_kernel_impl.h"
+#include "paddle/phi/kernels/scale_kernel.h"
 #include "paddle/phi/kernels/stride/elementwise_stride_base.cu.h"
 
 #if defined(__NVCC__) || defined(__HIPCC__) || defined(__xpu__)
@@ -178,12 +180,174 @@ void AddStrideKernel(const Context &dev_ctx,
   }
 }
 
+template <typename DataT, typename ParamT>
+struct ScaleFunctor {
+  ParamT bias;
+  ParamT scale;
+  bool bias_after_scale;
+
+  ScaleFunctor(ParamT scale_data, ParamT bias_data, bool is_bias_after_scale)
+      : bias(bias_data),
+        scale(scale_data),
+        bias_after_scale(is_bias_after_scale) {}
+
+  __device__ __forceinline__ DataT operator()(const DataT x) const {
+    if (bias_after_scale) {
+      return static_cast<DataT>(scale * static_cast<ParamT>(x) + bias);
+    } else {
+      return static_cast<DataT>(scale * (static_cast<ParamT>(x) + bias));
+    }
+  }
+};
+
+template <typename T, typename Context>
+void ScaleStrideKernel(const Context &dev_ctx,
+                       const DenseTensor &x,
+                       const Scalar &scale,
+                       const Scalar &bias,
+                       bool bias_after_scale,
+                       DenseTensor *out) {
+  if (!FLAGS_use_stride_kernel) {
+    PADDLE_THROW(common::errors::Fatal(
+        "FLAGS_use_stride_kernel is closed. Strided kernel "
+        "be called, something wrong has happened!"));
+  }
+  DenseTensor x_;
+  if (!FLAGS_use_stride_compute_kernel) {
+    if (!x.meta().is_contiguous()) {
+      x_ = Tensor2Contiguous<Context>(dev_ctx, x);
+    } else {
+      x_ = x;
+    }
+  } else {
+    x_ = x;
+  }
+  if (x_.meta().is_contiguous()) {
+    auto meta = out->meta();
+    meta.strides = meta.calc_strides(out->dims());
+    out->set_meta(meta);
+    phi::ScaleKernel<T, Context>(
+        dev_ctx, x_, scale, bias, bias_after_scale, out);
+    return;
+  }
+  if (!FLAGS_use_stride_compute_kernel) {
+    PADDLE_THROW(
+        common::errors::Fatal("FLAGS_use_stride_compute_kernel is closed. "
+                              "Kernel using DenseTensorIterator "
+                              "be called, something wrong has happened!"));
+  }
+
+  if (x.numel() <= 0 || (!x.IsInitialized())) {
+    dev_ctx.template Alloc<T>(out);
+    return;
+  }
+
+  if (FLAGS_force_stride_compute_kernel_out_con) {
+    auto meta = out->meta();
+    meta.strides = meta.calc_strides(out->dims());
+    out->set_meta(meta);
+  }
+
+  using MT = typename phi::dtype::MPTypeTrait<T>::Type;
+  LaunchUnaryElementwiseStrideKernel<T, Context>(
+      dev_ctx,
+      x_,
+      ScaleFunctor<T, MT>(scale.to<MT>(), bias.to<MT>(), bias_after_scale),
+      out);
+}
+
+template <typename T, typename Context>
+void FullStrideKernel(const Context &dev_ctx,
+                      const IntArray &shape,
+                      const Scalar &val,
+                      DataType dtype,
+                      DenseTensor *out) {
+  auto meta = out->meta();
+  meta.strides = meta.calc_strides(out->dims());
+  out->set_meta(meta);
+  FullKernel<T, Context>(dev_ctx, shape, val, dtype, out);
+}
+
+template <typename T, typename Context>
+void FullLikeStrideKernel(const Context &dev_ctx,
+                          const DenseTensor &x,
+                          const Scalar &val,
+                          DataType dtype,
+                          DenseTensor *out) {
+  // Is this correct?
+  // In fact, both ones_like and full_like can only generate contiguous tensors,
+  // which differs from common sense, where both strides and shapes are
+  // considered.
+  auto meta = out->meta();
+  meta.strides = meta.calc_strides(out->dims());
+  out->set_meta(meta);
+  FullLikeKernel<T, Context>(dev_ctx, x, val, dtype, out);
+}
+
 }  // namespace phi
 
 using float16 = phi::float16;
 using bfloat16 = phi::bfloat16;
 using complex64 = phi::complex64;
 using complex128 = phi::complex128;
+
+PD_REGISTER_KERNEL(scale,
+                   GPU,
+                   STRIDED,
+                   phi::ScaleStrideKernel,
+                   bool,
+                   float,
+                   double,
+                   phi::float16,
+                   phi::bfloat16,
+                   phi::float8_e4m3fn,
+                   phi::float8_e5m2,
+                   uint8_t,
+                   int8_t,
+                   int16_t,
+                   int,
+                   int64_t,
+                   phi::complex64,
+                   phi::complex128) {}
+
+PD_REGISTER_KERNEL(full,
+                   GPU,
+                   STRIDED,
+                   phi::FullStrideKernel,
+                   float,
+                   double,
+                   int8_t,
+                   uint8_t,
+                   int16_t,
+                   int,
+                   int64_t,
+                   bool,
+                   phi::float8_e4m3fn,
+                   phi::float8_e5m2,
+                   phi::float16,
+                   phi::bfloat16,
+                   phi::complex64,
+                   phi::complex128) {}
+
+PD_REGISTER_KERNEL(full_like,
+                   GPU,
+                   STRIDED,
+                   phi::FullLikeStrideKernel,
+                   bool,
+                   float,
+                   double,
+                   int,
+                   int8_t,
+                   int64_t,
+                   int16_t,
+                   uint8_t,
+                   phi::float8_e4m3fn,
+                   phi::float16,
+                   phi::bfloat16,
+                   phi::complex64,
+                   phi::complex128) {
+  kernel->InputAt(0).SetBackend(phi::Backend::ALL_BACKEND);
+}
 
 PD_REGISTER_KERNEL(add,
                    GPU,

--- a/paddle/phi/kernels/stride/elementwise_stride_base.cu.h
+++ b/paddle/phi/kernels/stride/elementwise_stride_base.cu.h
@@ -314,6 +314,31 @@ void UnaryStrideElementwiseKernel(const Context &dev_ctx,
                                        offset_calc);
 }
 
+template <typename T, typename Context, typename Functor>
+void LaunchUnaryElementwiseStrideKernel(const Context &dev_ctx,
+                                        const DenseTensor &x,
+                                        Functor func,
+                                        DenseTensor *out) {
+  std::vector<const DenseTensor *> inputs = {&x};
+  std::vector<DenseTensor *> outputs = {out};
+  dev_ctx.template Alloc<T>(out);
+  UnaryStrideElementwiseKernel<T, Context>(dev_ctx, inputs, &outputs, func);
+}
+
+template <typename T, typename Context, typename Functor>
+void LaunchBinaryElementwiseStrideKernel(const Context &dev_ctx,
+                                         const DenseTensor &x,
+                                         const DenseTensor &y,
+                                         Functor func,
+                                         int axis,
+                                         DenseTensor *out) {
+  std::vector<const DenseTensor *> inputs = {&x, &y};
+  std::vector<DenseTensor *> outputs = {out};
+  dev_ctx.template Alloc<T>(out);
+  BinaryStrideBroadcastKernel<T, Context>(
+      dev_ctx, inputs, &outputs, func, axis);
+}
+
 template <typename Context>
 phi::DenseTensor Tensor2Contiguous(const Context &dev_ctx,
                                    const phi::DenseTensor &tensor) {

--- a/paddle/phi/kernels/stride/reduce_grad_stride_kernel.cu
+++ b/paddle/phi/kernels/stride/reduce_grad_stride_kernel.cu
@@ -1,0 +1,240 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+
+#include "paddle/common/flags.h"
+#include "paddle/phi/backends/gpu/gpu_context.h"
+#include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/core/visit_type.h"
+#include "paddle/phi/kernels/as_strided_kernel.h"
+#include "paddle/phi/kernels/contiguous_kernel.h"
+#include "paddle/phi/kernels/funcs/elementwise_base.h"
+#include "paddle/phi/kernels/funcs/elementwise_functor.h"
+#include "paddle/phi/kernels/reduce_sum_grad_kernel.h"
+#include "paddle/phi/kernels/unsqueeze_kernel.h"
+
+COMMON_DECLARE_bool(use_stride_kernel);
+COMMON_DECLARE_bool(use_stride_compute_kernel);
+
+namespace phi {
+
+template <typename Context>
+phi::DenseTensor Tensor2Contiguous(const Context& dev_ctx,
+                                   const phi::DenseTensor& tensor) {
+  phi::DenseTensor dense_out;
+  phi::MetaTensor meta_input(tensor);
+  phi::MetaTensor meta_out(&dense_out);
+  UnchangedInferMeta(meta_input, &meta_out);
+  PD_VISIT_ALL_TYPES(tensor.dtype(), "Tensor2Contiguous", ([&] {
+                       phi::ContiguousKernel<data_t, Context>(
+                           dev_ctx, tensor, &dense_out);
+                     }));
+  return dense_out;
+}
+
+template <typename Context>
+phi::DenseTensor CheckMultipleUnsqueeze(const Context& dev_ctx,
+                                        const DenseTensor& out_grad,
+                                        const IntArray& dims,
+                                        const int ndim,
+                                        bool keep_dim) {
+  phi::DenseTensor res = out_grad;
+  if (dims.size() == 0 || keep_dim || ndim == 0) return res;
+  std::vector<bool> axes(ndim, false);
+
+  for (int i = 0; i < dims.size(); i++) {
+    int tmp_dim = dims[i] >= 0 ? dims[i] : ndim + dims[i];
+    axes[tmp_dim] = true;
+  }
+
+  for (int i = 0; i < axes.size(); i++) {
+    phi::DenseTensor tmp;
+    if (axes[i]) {
+      UnsqueezeStridedKernel(dev_ctx, res, IntArray({i}), &tmp);
+      res = tmp;
+    }
+  }
+
+  return res;
+}
+
+void ExpandStrideKernel(const std::vector<int64_t>& self_dims,
+                        const std::vector<int64_t>& self_strides,
+                        const std::vector<int64_t>& expand_sizes,
+                        std::vector<int64_t>* out_dims,
+                        std::vector<int64_t>* out_strides) {
+  int64_t ndim = static_cast<int64_t>(expand_sizes.size());
+  int64_t tensor_dim = static_cast<int64_t>(self_dims.size());
+
+  if (tensor_dim == 0) {
+    *out_dims = expand_sizes;
+    *out_strides = std::vector<int64_t>(ndim, 0);
+    return;
+  }
+
+  std::vector<int64_t> expandedSizes(ndim, 0);
+  std::vector<int64_t> expandedStrides(ndim, 0);
+
+  // create a new geometry for the tensors
+  for (int64_t i = ndim - 1; i >= 0; --i) {
+    int64_t offset = ndim - 1 - i;
+    int64_t dim = tensor_dim - 1 - offset;
+    int64_t size = (dim >= 0) ? self_dims[dim] : 1;
+    int64_t stride = (dim >= 0) ? self_strides[dim]
+                                : expandedSizes[i + 1] * expandedStrides[i + 1];
+    int64_t targetSize = expand_sizes[i];
+    if (targetSize == -1) {
+      targetSize = size;
+    }
+    if (size != targetSize) {
+      size = targetSize;
+      stride = 0;
+    }
+    expandedSizes[i] = size;
+    expandedStrides[i] = stride;
+  }
+
+  *out_dims = expandedSizes;
+  *out_strides = expandedStrides;
+}
+
+template <typename T, typename Context>
+void ReduceSumGradStrideKernel(const Context& dev_ctx,
+                               const DenseTensor& x,
+                               const DenseTensor& out_grad,
+                               const IntArray& dims,
+                               bool keep_dim,
+                               bool reduce_all,
+                               DenseTensor* x_grad) {
+  if (!FLAGS_use_stride_kernel) {
+    PADDLE_THROW(common::errors::Fatal(
+        "FLAGS_use_stride_kernel is closed. Strided kernel "
+        "be called, something wrong has happened!"));
+  }
+
+  DenseTensor out_grad_;
+
+  if (FLAGS_use_stride_compute_kernel && out_grad.dims().size() > 0) {
+    // printf("out grad shape\n");
+    // for (int i = 0; i < out_grad.dims().size(); i++) {
+    //   printf("%d ", out_grad.dims()[i]);
+    // }
+    // printf("\n");
+
+    // printf("x shape\n");
+    // for (int i = 0; i < x.dims().size(); i++) {
+    //   printf("%d ", x.dims()[i]);
+    // }
+    // printf("\n");
+
+    // printf("x_grad shape\n");
+    // for (int i = 0; i < x_grad->dims().size(); i++) {
+    //   printf("%d ", x_grad->dims()[i]);
+    // }
+    // printf("\n");
+
+    // printf("dims\n");
+    // for (int i = 0; i < dims.size(); i++) {
+    //   printf("%d ", dims[i]);
+    // }
+    // printf("\n");
+
+    phi::DenseTensor out_tmp = CheckMultipleUnsqueeze<Context>(
+        dev_ctx, out_grad, dims, x.dims().size(), keep_dim);
+
+    std::vector<int64_t> out_dims;
+    std::vector<int64_t> out_strides;
+
+    // printf("out tmp shape\n");
+    // for (int i = 0; i < out_tmp.dims().size(); i++) {
+    //   printf("%d ", out_tmp.dims()[i]);
+    // }
+    // printf("\n");
+
+    ExpandStrideKernel(common::vectorize<int64_t>(out_tmp.dims()),
+                       common::vectorize<int64_t>(out_tmp.strides()),
+                       common::vectorize<int64_t>(x.dims()),
+                       &out_dims,
+                       &out_strides);
+
+    // printf("after expand dims\n");
+    // for (int i = 0; i < out_dims.size(); i++) {
+    //   printf("%d ", out_dims[i]);
+    // }
+    // printf("\n");
+
+    // printf("after expand strides\n");
+    // for (int i = 0; i < out_strides.size(); i++) {
+    //   printf("%d ", out_strides[i]);
+    // }
+    // printf("\n");
+
+    auto meta = out_grad.meta();
+    meta.dims = DDim(out_dims.data(), static_cast<int>(out_dims.size()));
+    meta.strides =
+        DDim(out_strides.data(), static_cast<int>(out_strides.size()));
+
+    x_grad->set_meta(meta);
+    x_grad->ResetHolder(out_grad.Holder());
+    x_grad->ShareInplaceVersionCounterWith(out_grad);
+
+    return;
+  }
+
+  // if x is contiguous is not relevant to sum_grad computation
+
+  if (!out_grad.meta().is_contiguous()) {
+    out_grad_ = Tensor2Contiguous<Context>(dev_ctx, out_grad);
+  } else {
+    out_grad_ = out_grad;
+  }
+
+  // printf("enter sum grad conti\n");
+
+  auto x_grad_meta = x_grad->meta();
+  x_grad_meta.strides = x_grad_meta.calc_strides(x_grad->dims());
+  x_grad->set_meta(x_grad_meta);
+  phi::ReduceSumGradKernel<T>(
+      dev_ctx, x, out_grad_, dims, keep_dim, reduce_all, x_grad);
+
+  // printf("out sum grad conti\n");
+}
+
+}  // namespace phi
+
+using float16 = phi::float16;
+using bfloat16 = phi::bfloat16;
+using complex64 = ::phi::complex64;
+using complex128 = ::phi::complex128;
+
+PD_REGISTER_KERNEL(sum_grad,
+                   GPU,
+                   STRIDED,
+                   phi::ReduceSumGradStrideKernel,
+                   bool,
+                   float,
+                   double,
+                   phi::float16,
+                   phi::bfloat16,
+                   int8_t,
+                   uint8_t,
+                   int16_t,
+                   int,
+                   int64_t,
+                   phi::complex64,
+                   phi::complex128) {
+  kernel->OutputAt(0).SetDataType(phi::DataType::UNDEFINED);
+}
+#endif

--- a/paddle/phi/kernels/stride/reduce_grad_stride_kernel.cu
+++ b/paddle/phi/kernels/stride/reduce_grad_stride_kernel.cu
@@ -87,7 +87,6 @@ void ExpandStrideKernel(const std::vector<int64_t>& self_dims,
   std::vector<int64_t> expandedSizes(ndim, 0);
   std::vector<int64_t> expandedStrides(ndim, 0);
 
-  // create a new geometry for the tensors
   for (int64_t i = ndim - 1; i >= 0; --i) {
     int64_t offset = ndim - 1 - i;
     int64_t dim = tensor_dim - 1 - offset;
@@ -127,59 +126,17 @@ void ReduceSumGradStrideKernel(const Context& dev_ctx,
   DenseTensor out_grad_;
 
   if (FLAGS_use_stride_compute_kernel && out_grad.dims().size() > 0) {
-    // printf("out grad shape\n");
-    // for (int i = 0; i < out_grad.dims().size(); i++) {
-    //   printf("%d ", out_grad.dims()[i]);
-    // }
-    // printf("\n");
-
-    // printf("x shape\n");
-    // for (int i = 0; i < x.dims().size(); i++) {
-    //   printf("%d ", x.dims()[i]);
-    // }
-    // printf("\n");
-
-    // printf("x_grad shape\n");
-    // for (int i = 0; i < x_grad->dims().size(); i++) {
-    //   printf("%d ", x_grad->dims()[i]);
-    // }
-    // printf("\n");
-
-    // printf("dims\n");
-    // for (int i = 0; i < dims.size(); i++) {
-    //   printf("%d ", dims[i]);
-    // }
-    // printf("\n");
-
     phi::DenseTensor out_tmp = CheckMultipleUnsqueeze<Context>(
         dev_ctx, out_grad, dims, x.dims().size(), keep_dim);
 
     std::vector<int64_t> out_dims;
     std::vector<int64_t> out_strides;
 
-    // printf("out tmp shape\n");
-    // for (int i = 0; i < out_tmp.dims().size(); i++) {
-    //   printf("%d ", out_tmp.dims()[i]);
-    // }
-    // printf("\n");
-
     ExpandStrideKernel(common::vectorize<int64_t>(out_tmp.dims()),
                        common::vectorize<int64_t>(out_tmp.strides()),
                        common::vectorize<int64_t>(x.dims()),
                        &out_dims,
                        &out_strides);
-
-    // printf("after expand dims\n");
-    // for (int i = 0; i < out_dims.size(); i++) {
-    //   printf("%d ", out_dims[i]);
-    // }
-    // printf("\n");
-
-    // printf("after expand strides\n");
-    // for (int i = 0; i < out_strides.size(); i++) {
-    //   printf("%d ", out_strides[i]);
-    // }
-    // printf("\n");
 
     auto meta = out_grad.meta();
     meta.dims = DDim(out_dims.data(), static_cast<int>(out_dims.size()));
@@ -194,22 +151,17 @@ void ReduceSumGradStrideKernel(const Context& dev_ctx,
   }
 
   // if x is contiguous is not relevant to sum_grad computation
-
   if (!out_grad.meta().is_contiguous()) {
     out_grad_ = Tensor2Contiguous<Context>(dev_ctx, out_grad);
   } else {
     out_grad_ = out_grad;
   }
 
-  // printf("enter sum grad conti\n");
-
   auto x_grad_meta = x_grad->meta();
   x_grad_meta.strides = x_grad_meta.calc_strides(x_grad->dims());
   x_grad->set_meta(x_grad_meta);
   phi::ReduceSumGradKernel<T>(
       dev_ctx, x, out_grad_, dims, keep_dim, reduce_all, x_grad);
-
-  // printf("out sum grad conti\n");
 }
 
 }  // namespace phi


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
本PR包含add, subtract, multiply, sum等四个函数的反向支持strided算子的实现
当设置FLAGS_share_tensor_for_grad_tensor_holder=1以及FLAGS_use_stride_compute_kernel=1时即可开启
开启后，部分情况下，以上算子反向将复用out_grad的holder以避免冗余的拷贝或复杂操作

pcard-67164