### PR TITLE
fix cuda kernel test for windows on cuda13

### DIFF
--- a/paddle/phi/kernels/cpu/isfinite_kernel.cc
+++ b/paddle/phi/kernels/cpu/isfinite_kernel.cc
@@ -81,5 +81,12 @@ INSTANTIATE_ISFINITE_KERNEL_Isinf(int, CPUContext);
 INSTANTIATE_ISFINITE_KERNEL_Isinf(int64_t, CPUContext);
 INSTANTIATE_ISFINITE_KERNEL_Isinf(phi::float16, CPUContext);
 INSTANTIATE_ISFINITE_KERNEL_Isinf(phi::bfloat16, CPUContext);
+
+INSTANTIATE_ISFINITE_KERNEL_Isfinite(float, CPUContext);
+INSTANTIATE_ISFINITE_KERNEL_Isfinite(double, CPUContext);
+INSTANTIATE_ISFINITE_KERNEL_Isfinite(int, CPUContext);
+INSTANTIATE_ISFINITE_KERNEL_Isfinite(int64_t, CPUContext);
+INSTANTIATE_ISFINITE_KERNEL_Isfinite(phi::float16, CPUContext);
+INSTANTIATE_ISFINITE_KERNEL_Isfinite(phi::bfloat16, CPUContext);
 }  // namespace phi
 #endif

--- a/paddle/phi/kernels/gpu/isfinite_kernel.cu
+++ b/paddle/phi/kernels/gpu/isfinite_kernel.cu
@@ -81,5 +81,12 @@ INSTANTIATE_ISFINITE_KERNEL_Isinf(int, GPUContext);
 INSTANTIATE_ISFINITE_KERNEL_Isinf(int64_t, GPUContext);
 INSTANTIATE_ISFINITE_KERNEL_Isinf(phi::float16, GPUContext);
 INSTANTIATE_ISFINITE_KERNEL_Isinf(phi::bfloat16, GPUContext);
+
+INSTANTIATE_ISFINITE_KERNEL_Isfinite(float, GPUContext);
+INSTANTIATE_ISFINITE_KERNEL_Isfinite(double, GPUContext);
+INSTANTIATE_ISFINITE_KERNEL_Isfinite(int, GPUContext);
+INSTANTIATE_ISFINITE_KERNEL_Isfinite(int64_t, GPUContext);
+INSTANTIATE_ISFINITE_KERNEL_Isfinite(phi::float16, GPUContext);
+INSTANTIATE_ISFINITE_KERNEL_Isfinite(phi::bfloat16, GPUContext);
 }  // namespace phi
 #endif

--- a/paddle/phi/kernels/isfinite_kernel.h
+++ b/paddle/phi/kernels/isfinite_kernel.h
@@ -36,5 +36,9 @@ DEFINE_ISFINITE_KERNEL(IsfiniteKernel)
 #define INSTANTIATE_ISFINITE_KERNEL_Isnan(type, context) \
   template PADDLE_API void IsnanKernel<type, context>(   \
       const context&, const DenseTensor&, DenseTensor*)
+
+#define INSTANTIATE_ISFINITE_KERNEL_Isfinite(type, context) \
+  template PADDLE_API void IsfiniteKernel<type, context>(   \
+      const context&, const DenseTensor&, DenseTensor*)
 #endif
 }  // namespace phi

--- a/test/cpp/fluid/platform/enforce_test.cc
+++ b/test/cpp/fluid/platform/enforce_test.cc
@@ -422,13 +422,21 @@ TEST(enforce, cuda_success) {
   EXPECT_TRUE(CheckCudaStatusFailure(CUFFT_SETUP_FAILED, "CUFFT error"));
   EXPECT_TRUE(CheckCudaStatusFailure(CUFFT_INVALID_SIZE, "CUFFT error"));
   EXPECT_TRUE(CheckCudaStatusFailure(CUFFT_UNALIGNED_DATA, "CUFFT error"));
+
+#ifdef CUFFT_INCOMPLETE_PARAMETER_LIST
   EXPECT_TRUE(
       CheckCudaStatusFailure(CUFFT_INCOMPLETE_PARAMETER_LIST, "CUFFT error"));
+#endif
   EXPECT_TRUE(CheckCudaStatusFailure(CUFFT_INVALID_DEVICE, "CUFFT error"));
+
+#ifdef CUFFT_PARSE_ERROR
   EXPECT_TRUE(CheckCudaStatusFailure(CUFFT_PARSE_ERROR, "CUFFT error"));
+#endif
   EXPECT_TRUE(CheckCudaStatusFailure(CUFFT_NO_WORKSPACE, "CUFFT error"));
   EXPECT_TRUE(CheckCudaStatusFailure(CUFFT_NOT_IMPLEMENTED, "CUFFT error"));
+#ifdef CUFFT_LICENSE_ERROR
   EXPECT_TRUE(CheckCudaStatusFailure(CUFFT_LICENSE_ERROR, "CUFFT error"));
+#endif
   EXPECT_TRUE(CheckCudaStatusFailure(CUFFT_NOT_SUPPORTED, "CUFFT error"));
 
 #if !defined(__APPLE__) && defined(PADDLE_WITH_NCCL)

--- a/test/cpp/inference/tensorrt/test_tensorrt_engine_instruction.cc
+++ b/test/cpp/inference/tensorrt/test_tensorrt_engine_instruction.cc
@@ -89,21 +89,29 @@ TEST(TensorRTEngineInstructionTest, test_tensorrt_engine_instruction) {
   PADDLE_ENFORCE_NOT_NULL(
       flatten_layer,
       common::errors::InvalidArgument(
-          "TRT shuffle layer building failed when preparing input."));
+          "Unable to build the TensorRT shuffle layer for the input tensor "
+          "'x'. "
+          "This usually indicates the TensorRT network failed to allocate the "
+          "intermediate reshape layer."));
   flatten_layer->setReshapeDimensions(nvinfer1::Dims2{-1, 1});
 
   auto *weight_layer = TRT_ENGINE_ADD_LAYER(
       engine, Constant, nvinfer1::Dims2{1, 1}, weight.get());
   PADDLE_ENFORCE_NOT_NULL(
       weight_layer,
-      common::errors::InvalidArgument(
-          "TRT constant layer building failed for weight."));
+      common::errors::InvalidArgument("TensorRT failed to create the constant "
+                                      "layer for parameter 'weight'. "
+                                      "Please confirm the TensorRT builder "
+                                      "supports constant initialisation "
+                                      "for the provided weight shape."));
 
   auto *bias_layer =
       TRT_ENGINE_ADD_LAYER(engine, Constant, nvinfer1::Dims2{1, 1}, bias.get());
-  PADDLE_ENFORCE_NOT_NULL(bias_layer,
-                          common::errors::InvalidArgument(
-                              "TRT constant layer building failed for bias."));
+  PADDLE_ENFORCE_NOT_NULL(
+      bias_layer,
+      common::errors::InvalidArgument(
+          "TensorRT failed to create the constant layer for parameter 'bias'. "
+          "Check whether the provided bias data matches the expected shape."));
 
   auto *matmul_layer = TRT_ENGINE_ADD_LAYER(engine,
                                             MatrixMultiply,
@@ -111,24 +119,31 @@ TEST(TensorRTEngineInstructionTest, test_tensorrt_engine_instruction) {
                                             nvinfer1::MatrixOperation::kNONE,
                                             *weight_layer->getOutput(0),
                                             nvinfer1::MatrixOperation::kNONE);
-  PADDLE_ENFORCE_NOT_NULL(matmul_layer,
-                          common::errors::InvalidArgument(
-                              "TRT matrix multiply layer building failed."));
+  PADDLE_ENFORCE_NOT_NULL(
+      matmul_layer,
+      common::errors::InvalidArgument(
+          "TensorRT returned a null matrix-multiply layer while fusing the "
+          "fully-connected op. Verify the network input ranks and TensorRT "
+          "version."));
 
   auto *add_layer = TRT_ENGINE_ADD_LAYER(engine,
                                          ElementWise,
                                          *matmul_layer->getOutput(0),
                                          *bias_layer->getOutput(0),
                                          nvinfer1::ElementWiseOperation::kSUM);
-  PADDLE_ENFORCE_NOT_NULL(add_layer,
-                          common::errors::InvalidArgument(
-                              "TRT elementwise add layer building failed."));
+  PADDLE_ENFORCE_NOT_NULL(
+      add_layer,
+      common::errors::InvalidArgument(
+          "TensorRT could not construct the elementwise-add layer for bias "
+          "fusion. Ensure the bias tensor uses broadcastable dimensions."));
 
   auto *reshape_layer = engine->network()->addShuffle(*add_layer->getOutput(0));
   PADDLE_ENFORCE_NOT_NULL(
       reshape_layer,
       common::errors::InvalidArgument(
-          "TRT shuffle layer building failed when restoring output shape."));
+          "TensorRT could not emit the final shuffle layer to restore the "
+          "output shape. Confirm the shape tensor and inferred dimensions are "
+          "valid."));
   reshape_layer->setReshapeDimensions(nvinfer1::Dims4{-1, 1, 1, 1});
 
   engine->DeclareOutput(reshape_layer, 0, "y");
@@ -264,7 +279,10 @@ TEST(TensorRTEngineInstructionTest, test_tensorrt_engine_instruction_dynamic) {
   layer->setInput(1, *shape);
   PADDLE_ENFORCE_NOT_NULL(
       layer,
-      common::errors::InvalidArgument("TRT shuffle layer building failed."));
+      common::errors::InvalidArgument(
+          "TensorRT failed to construct the dynamic shuffle layer that "
+          "consumes the runtime shape tensor. Please check the provided "
+          "shape binding."));
   engine->DeclareOutput(layer, 0, "y");
   engine->FreezeNetwork();
 
@@ -445,14 +463,19 @@ TEST(PluginTest, test_generic_plugin) {
       creator->createPlugin("pir_generic_plugin", plugin_collection.get());
   PADDLE_ENFORCE_NOT_NULL(
       generic_plugin,
-      common::errors::InvalidArgument("TRT create generic plugin failed."));
+      common::errors::InvalidArgument(
+          "TensorRT plugin registry returned nullptr while creating "
+          "'pir_generic_plugin'. Verify the plugin has been registered before "
+          "building the engine."));
   std::vector<nvinfer1::ITensor *> plugin_inputs;
   plugin_inputs.emplace_back(x);
   auto plugin_layer = engine->network()->addPluginV2(
       plugin_inputs.data(), plugin_inputs.size(), *generic_plugin);
-  PADDLE_ENFORCE_NOT_NULL(plugin_layer,
-                          common::errors::InvalidArgument(
-                              "TRT generic plugin layer building failed."));
+  PADDLE_ENFORCE_NOT_NULL(
+      plugin_layer,
+      common::errors::InvalidArgument(
+          "TensorRT failed to add the generic plugin layer to the network. "
+          "Ensure the plugin inputs match the expected TensorRT types."));
 
   engine->DeclareOutput(plugin_layer, 0, "y");
   std::vector<std::string> input_names = {"x"};

--- a/test/cpp/inference/tensorrt/test_tensorrt_engine_instruction.cc
+++ b/test/cpp/inference/tensorrt/test_tensorrt_engine_instruction.cc
@@ -85,20 +85,64 @@ TEST(TensorRTEngineInstructionTest, test_tensorrt_engine_instruction) {
       nvinfer1::DataType::kFLOAT, raw_bias, size);
   auto *x = engine->DeclareInput(
       "x", nvinfer1::DataType::kFLOAT, nvinfer1::Dims4{-1, 1, 1, 1});
-  auto *fc_layer = TRT_ENGINE_ADD_LAYER(
-      engine, FullyConnected, *x, size, weight.get(), bias.get());
-  PADDLE_ENFORCE_NOT_NULL(fc_layer,
-                          common::errors::InvalidArgument(
-                              "TRT fully connected layer building failed."));
+  auto *flatten_layer = engine->network()->addShuffle(*x);
+  PADDLE_ENFORCE_NOT_NULL(
+      flatten_layer,
+      common::errors::InvalidArgument(
+          "TRT shuffle layer building failed when preparing input."));
+  flatten_layer->setReshapeDimensions(nvinfer1::Dims2{-1, 1});
 
-  engine->DeclareOutput(fc_layer, 0, "y");
+  auto *weight_layer = TRT_ENGINE_ADD_LAYER(
+      engine, Constant, nvinfer1::Dims2{1, 1}, weight.get());
+  PADDLE_ENFORCE_NOT_NULL(
+      weight_layer,
+      common::errors::InvalidArgument(
+          "TRT constant layer building failed for weight."));
+
+  auto *bias_layer =
+      TRT_ENGINE_ADD_LAYER(engine, Constant, nvinfer1::Dims2{1, 1}, bias.get());
+  PADDLE_ENFORCE_NOT_NULL(bias_layer,
+                          common::errors::InvalidArgument(
+                              "TRT constant layer building failed for bias."));
+
+  auto *matmul_layer = TRT_ENGINE_ADD_LAYER(engine,
+                                            MatrixMultiply,
+                                            *flatten_layer->getOutput(0),
+                                            nvinfer1::MatrixOperation::kNONE,
+                                            *weight_layer->getOutput(0),
+                                            nvinfer1::MatrixOperation::kNONE);
+  PADDLE_ENFORCE_NOT_NULL(matmul_layer,
+                          common::errors::InvalidArgument(
+                              "TRT matrix multiply layer building failed."));
+
+  auto *add_layer = TRT_ENGINE_ADD_LAYER(engine,
+                                         ElementWise,
+                                         *matmul_layer->getOutput(0),
+                                         *bias_layer->getOutput(0),
+                                         nvinfer1::ElementWiseOperation::kSUM);
+  PADDLE_ENFORCE_NOT_NULL(add_layer,
+                          common::errors::InvalidArgument(
+                              "TRT elementwise add layer building failed."));
+
+  auto *reshape_layer = engine->network()->addShuffle(*add_layer->getOutput(0));
+  PADDLE_ENFORCE_NOT_NULL(
+      reshape_layer,
+      common::errors::InvalidArgument(
+          "TRT shuffle layer building failed when restoring output shape."));
+  reshape_layer->setReshapeDimensions(nvinfer1::Dims4{-1, 1, 1, 1});
+
+  engine->DeclareOutput(reshape_layer, 0, "y");
   std::vector<std::string> input_names = {"x", ""};
   std::vector<std::string> output_names = {"y"};
   std::vector<std::vector<int64_t>> outputs_shape = {{1}};
   std::vector<phi::DataType> outputs_dtype = {phi::DataType::FLOAT32};
   LOG(INFO) << "freeze network";
   engine->FreezeNetwork();
+#if IS_TRT_VERSION_GE(8600)
+  ASSERT_EQ(engine->engine()->getNbIOTensors(), 2);
+#else
   ASSERT_EQ(engine->engine()->getNbBindings(), 2);
+#endif
   nvinfer1::IHostMemory *serialized_engine_data = engine->Serialize();
 
   std::ofstream outFile("engine_serialized_data.bin", std::ios::binary);
@@ -417,7 +461,11 @@ TEST(PluginTest, test_generic_plugin) {
   std::vector<phi::DataType> outputs_dtype = {phi::DataType::FLOAT32};
   LOG(INFO) << "freeze network";
   engine->FreezeNetwork();
+#if IS_TRT_VERSION_GE(8600)
+  ASSERT_EQ(engine->engine()->getNbIOTensors(), 2);
+#else
   ASSERT_EQ(engine->engine()->getNbBindings(), 2);
+#endif
   nvinfer1::IHostMemory *serialized_engine_data = engine->Serialize();
   std::ofstream outFile("engine_serialized_data.bin", std::ios::binary);
   outFile.write(static_cast<const char *>(serialized_engine_data->data()),


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Environment Adaptation


### PR Types
Bug fixes


### Description
## 修改内容
- isfinite_kernel.h：新增 `INSTANTIATE_ISFINITE_KERNEL_Isfinite` 宏，补全 Windows 显式模板实例化。
- isfinite_kernel.cc 与 isfinite_kernel.cu：为 CPU/GPU 上的 float、double、整型及半精度类型补上 `Isfinite` 实例化。
- enforce_test.cc：对 `CUFFT_INCOMPLETE_PARAMETER_LIST`、`CUFFT_PARSE_ERROR`、`CUFFT_LICENSE_ERROR` 加 `#ifdef` 防护。
- test_tensorrt_engine_instruction.cc：改用 `Shuffle + MatrixMultiply + ElementWise` 来构建等价的全连接层，并根据 TensorRT 版本选择 `getNbIOTensors` 或 `getNbBindings`。
## 覆盖情况
- 修复 `tensor_util_test` 中 phi::IsfiniteKernel 未解析符号。
- 修复 `enforce_test` 中缺失 CUFFT 枚举导致的编译错误。
- 修复 TensorRT 单测对已移除 API 的调用。
