### PR TITLE
change to python3.10 in tools/externalError/start.sh

### DIFF
--- a/tools/externalError/start.sh
+++ b/tools/externalError/start.sh
@@ -31,5 +31,5 @@ else
 fi
 protobuf/bin/protoc -I../../paddle/phi/core/ --python_out . ../../paddle/phi/core/external_error.proto
 
-python3.8 spider.py
+python3.9 spider.py
 tar czvf externalErrorMsg_$(date +'%Y%m%d').tar.gz externalErrorMsg.pb

--- a/tools/externalError/start.sh
+++ b/tools/externalError/start.sh
@@ -31,5 +31,5 @@ else
 fi
 protobuf/bin/protoc -I../../paddle/phi/core/ --python_out . ../../paddle/phi/core/external_error.proto
 
-python3.9 spider.py
+python3.10 spider.py
 tar czvf externalErrorMsg_$(date +'%Y%m%d').tar.gz externalErrorMsg.pb


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience

### PR Types
Others 

### Description
<!-- Describe what you’ve done -->
python3.8已不支持，python3.9 即将EOL，所以修改为python3.10
