### PR TITLE
[Compat] add device.XXX and cuda.XXX

### DIFF
--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -234,6 +234,7 @@ from .autograd import (
     set_grad_enabled,
 )
 from .device import (  # noqa: F401
+    Event,
     Stream,
     device_guard,
     get_cudnn_version,
@@ -247,6 +248,7 @@ from .device import (  # noqa: F401
     is_compiled_with_ipu,
     is_compiled_with_rocm,
     is_compiled_with_xpu,
+    set_default_device,
     set_device,
 )
 from .distributed import DataParallel
@@ -932,6 +934,7 @@ if __is_metainfo_generated and is_compiled_with_cuda():
                         err.strerror += f' Error loading "{dll}" or one of its dependencies.'
                         raise err
             kernel32.SetErrorMode(prev_error_mode)
+
 
 disable_static()
 

--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -234,7 +234,7 @@ from .autograd import (
     set_grad_enabled,
 )
 from .device import (  # noqa: F401
-    PaddleStream as Stream,
+    Stream,
     device_guard,
     get_cudnn_version,
     get_default_device,

--- a/python/paddle/cuda/__init__.py
+++ b/python/paddle/cuda/__init__.py
@@ -25,7 +25,7 @@ from paddle.device import (
     _device_to_paddle as _device_to_paddle,
     device,
     is_available as _device_is_available,
-    is_bf16_supported as is_bf16_supported,
+    is_bf16_supported,
     is_current_stream_capturing as _is_current_stream_capturing,
     manual_seed,
     manual_seed_all as device_manual_seed_all,
@@ -647,6 +647,36 @@ def memory_allocated(device: DeviceLike = None) -> int:
     return paddle_device.memory_allocated(device)
 
 
+def max_memory_allocated(device: DeviceLike = None) -> int:
+    '''
+    Return the peak size of memory that is allocated to tensor of the given device.
+
+    Note:
+        The size of memory allocated to tensor is 256-byte aligned in Paddle, which may larger than the memory size that tensor actually need.
+        For instance, a float32 0-D Tensor with shape [] will take up 256 bytes memory, even though storing a float32 data requires only 4 bytes.
+
+    Args:
+        device(paddle.CUDAPlace|int|str|None, optional): The device, the id of the device or
+            the string name of device like 'gpu:x'. If device is None, the device is the current device.
+            Default: None.
+
+    Return:
+        int: The peak size of memory that is allocated to tensor of the given device, in bytes.
+
+    Examples:
+        .. code-block:: python
+
+            >>> # doctest: +REQUIRES(env:GPU)
+            >>> import paddle
+            >>> paddle.device.set_device('gpu')  # or '<custom_device>'
+
+            >>> max_memory_allocated_size = paddle.cuda.max_memory_allocated(paddle.CUDAPlace(0))
+            >>> max_memory_allocated_size = paddle.cuda.max_memory_allocated(0)
+            >>> max_memory_allocated_size = paddle.cuda.max_memory_allocated("gpu:0")
+    '''
+    return paddle_device.max_memory_allocated(device)
+
+
 def memory_reserved(device: DeviceLike = None) -> int:
     """
     Return the current device memory managed by the caching allocator in bytes for a given device.
@@ -805,4 +835,5 @@ __all__ = [
     "device",
     "is_bf16_supported",
     "manual_seed",
+    "max_memory_allocated",
 ]

--- a/python/paddle/cuda/__init__.py
+++ b/python/paddle/cuda/__init__.py
@@ -23,10 +23,11 @@ from paddle import base, core, device as paddle_device, framework
 from paddle.device import (
     PaddleStream as Stream,
     _device_to_paddle as _device_to_paddle,
-    device as device,
+    device,
     is_available as _device_is_available,
     is_bf16_supported as is_bf16_supported,
     is_current_stream_capturing as _is_current_stream_capturing,
+    manual_seed,
     manual_seed_all as device_manual_seed_all,
     stream_guard as _PaddleStreamGuard,
 )
@@ -803,4 +804,5 @@ __all__ = [
     "set_rng_state",
     "device",
     "is_bf16_supported",
+    "manual_seed",
 ]

--- a/python/paddle/cuda/__init__.py
+++ b/python/paddle/cuda/__init__.py
@@ -23,6 +23,7 @@ from paddle import base, core, device as paddle_device, framework
 from paddle.device import (
     PaddleStream as Stream,
     _device_to_paddle as _device_to_paddle,
+    device as device,
     is_available as _device_is_available,
     is_current_stream_capturing as _is_current_stream_capturing,
     manual_seed_all as device_manual_seed_all,
@@ -799,4 +800,5 @@ __all__ = [
     "manual_seed_all",
     "get_rng_state",
     "set_rng_state",
+    "device",
 ]

--- a/python/paddle/cuda/__init__.py
+++ b/python/paddle/cuda/__init__.py
@@ -677,6 +677,79 @@ def max_memory_allocated(device: DeviceLike = None) -> int:
     return paddle_device.max_memory_allocated(device)
 
 
+def max_memory_reserved(device: DeviceLike = None) -> int:
+    '''
+    Return the peak size of memory that is held by the allocator of the given device.
+
+    Args:
+        device(paddle.Place|int|str|None, optional): The device, the id of the device or
+            the string name of device like 'gpu:x'. If device is None, the device is the current device.
+            Default: None.
+
+    Return:
+        int: The peak size of memory that is held by the allocator of the given device, in bytes.
+
+    Examples:
+        .. code-block:: python
+
+            >>> # doctest: +REQUIRES(env:GPU)
+            >>> import paddle
+            >>> paddle.device.set_device('gpu')  # or '<custom_device>'
+
+            >>> max_memory_reserved_size = paddle.cuda.max_memory_reserved(paddle.CUDAPlace(0))
+            >>> max_memory_reserved_size = paddle.cuda.max_memory_reserved(0)
+            >>> max_memory_reserved_size = paddle.cuda.max_memory_reserved("gpu:0")
+    '''
+    return paddle_device.max_memory_reserved(device)
+
+
+def reset_max_memory_allocated(device: DeviceLike | None = None) -> None:
+    '''
+    Reset the peak size of memory that is allocated to tensor of the given device.
+
+    Args:
+        device(paddle.Place|int|str|None, optional): The device, the id of the device or
+            the string name of device like 'gpu:x'. If device is None, the device is the current device.
+            Default: None.
+
+    Examples:
+        .. code-block:: python
+
+            >>> # doctest: +REQUIRES(env:GPU)
+            >>> import paddle
+            >>> paddle.device.set_device('gpu')  # or '<custom_device>'
+
+            >>> paddle.cuda.reset_max_memory_allocated(paddle.CUDAPlace(0))
+            >>> paddle.cuda.reset_max_memory_allocated(0)
+            >>> paddle.cuda.reset_max_memory_allocated("gpu:0")
+    '''
+
+    return paddle_device.reset_max_memory_allocated(device)
+
+
+def reset_max_memory_reserved(device: DeviceLike | None = None) -> None:
+    '''
+    Reset the peak size of memory that is held by the allocator of the given device.
+
+    Args:
+        device(paddle.Place|int|str|None, optional): The device, the id of the device or
+            the string name of device like 'gpu:x'. If device is None, the device is the current device.
+            Default: None.
+
+    Examples:
+        .. code-block:: python
+
+            >>> # doctest: +REQUIRES(env:GPU)
+            >>> import paddle
+            >>> paddle.device.set_device('gpu')  # or '<custom_device>'
+
+            >>> paddle.cuda.reset_max_memory_reserved(paddle.CUDAPlace(0))
+            >>> paddle.cuda.reset_max_memory_reserved(0)
+            >>> paddle.cuda.reset_max_memory_reserved("gpu:0")
+    '''
+    return paddle_device.reset_max_memory_reserved(device)
+
+
 def memory_reserved(device: DeviceLike = None) -> int:
     """
     Return the current device memory managed by the caching allocator in bytes for a given device.

--- a/python/paddle/cuda/__init__.py
+++ b/python/paddle/cuda/__init__.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Union
 import paddle
 from paddle import base, core, device as paddle_device, framework
 from paddle.device import (
+    Event,
     Stream,
     _device_to_paddle as _device_to_paddle,
     device,
@@ -913,4 +914,5 @@ __all__ = [
     "manual_seed",
     "max_memory_allocated",
     "reset_peak_memory_stats",
+    "Event",
 ]

--- a/python/paddle/cuda/__init__.py
+++ b/python/paddle/cuda/__init__.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING, Union
 import paddle
 from paddle import base, core, device as paddle_device, framework
 from paddle.device import (
-    PaddleStream as Stream,
+    Stream,
     _device_to_paddle as _device_to_paddle,
     device,
     is_available as _device_is_available,
@@ -30,6 +30,7 @@ from paddle.device import (
     manual_seed,
     manual_seed_all as device_manual_seed_all,
     reset_peak_memory_stats,
+    set_stream,
     stream_guard as _PaddleStreamGuard,
 )
 
@@ -903,6 +904,7 @@ __all__ = [
     "memory_allocated",
     "memory_reserved",
     "set_device",
+    "set_stream",
     "manual_seed_all",
     "get_rng_state",
     "set_rng_state",

--- a/python/paddle/cuda/__init__.py
+++ b/python/paddle/cuda/__init__.py
@@ -25,6 +25,7 @@ from paddle.device import (
     _device_to_paddle as _device_to_paddle,
     device as device,
     is_available as _device_is_available,
+    is_bf16_supported as is_bf16_supported,
     is_current_stream_capturing as _is_current_stream_capturing,
     manual_seed_all as device_manual_seed_all,
     stream_guard as _PaddleStreamGuard,
@@ -801,4 +802,5 @@ __all__ = [
     "get_rng_state",
     "set_rng_state",
     "device",
+    "is_bf16_supported",
 ]

--- a/python/paddle/cuda/__init__.py
+++ b/python/paddle/cuda/__init__.py
@@ -29,6 +29,7 @@ from paddle.device import (
     is_current_stream_capturing as _is_current_stream_capturing,
     manual_seed,
     manual_seed_all as device_manual_seed_all,
+    reset_peak_memory_stats,
     stream_guard as _PaddleStreamGuard,
 )
 
@@ -909,4 +910,5 @@ __all__ = [
     "is_bf16_supported",
     "manual_seed",
     "max_memory_allocated",
+    "reset_peak_memory_stats",
 ]

--- a/python/paddle/device/__init__.py
+++ b/python/paddle/device/__init__.py
@@ -126,6 +126,7 @@ else:
             device_count,
             get_rng_state,
             manual_seed,
+            max_memory_allocated,
             set_rng_state,
         )
 

--- a/python/paddle/device/__init__.py
+++ b/python/paddle/device/__init__.py
@@ -442,7 +442,41 @@ def _convert_to_place(device: PlaceLike) -> Place:
     return place
 
 
-def set_device(device: str) -> PlaceLike:
+class device:
+    r"""Context-manager that changes the selected device.
+
+    Args:
+        device (paddle.Place, int or str): device index to select.
+
+    Examples:
+        .. code-block:: python
+            >>> import
+
+            >>> print(paddle.device.get_device())  # gpu:0
+            >>> with device("cpu"):
+            ...     print(paddle.device.get_device())  # cpu
+            >>> print(paddle.device.get_device())
+    """
+
+    def __init__(self, device: Place | int | str | None = None):
+        self.place = device_to_place(device)
+        self.prev_place_str = "-1"
+
+    def __enter__(self):
+        self.prev_place_str = get_device()
+        set_device(self.place)
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: types.TracebackType | None,
+    ) -> bool | None:
+        set_device(self.prev_place_str)
+        return False
+
+
+def set_device(device: PlaceLike | int) -> PlaceLike:
     """
 
     Paddle supports running calculations on various types of devices, including CPU, GPU, XPU, NPU and IPU.
@@ -450,7 +484,7 @@ def set_device(device: str) -> PlaceLike:
     which the OP will run.
 
     Args:
-        device(str): This parameter determines the specific running device.
+        device(str, Place or int): This parameter determines the specific running device.
             It can be ``cpu``, ``gpu``, ``xpu``, ``npu``, ``gpu:x``, ``xpu:x``, ``npu:x`` and ``ipu``,
             where ``x`` is the index of the GPUs, XPUs or NPUs.
 
@@ -469,7 +503,7 @@ def set_device(device: str) -> PlaceLike:
             >>> data = paddle.stack([x1,x2], axis=1)
 
     """
-    place = _convert_to_place(device)
+    place = device_to_place(device)
     framework._set_expected_place(place)
     return place
 

--- a/python/paddle/device/__init__.py
+++ b/python/paddle/device/__init__.py
@@ -563,7 +563,7 @@ def set_device(device: PlaceLike | int) -> PlaceLike:
     return place
 
 
-def get_device() -> str:
+def get_device(input: paddle.Tensor = None) -> str | int:
     """
 
     This function can get the current global device of the program is running.
@@ -571,6 +571,18 @@ def get_device() -> str:
     set, it will return a string which is 'gpu:x' when cuda is available or it
     will return a string which is 'cpu' when cuda is not available.
 
+    Returns:
+        if input is Tensor, this function will return the device ID where the given Tensor is located.
+        int:
+            - -1, if the Tensor is on CPU.
+            - The device ID (e.g., 0, 1, ...) if the Tensor is on GPU.
+
+        if input is not Tensor, this function will return the device name where the program is running.
+        str:
+            - 'cpu': If the program is running on CPU.
+            - 'gpu:x': If the program is running on GPU, where `x` is the index of the GPU.
+            - 'xpu:x': If the program is running on XPU, where `x` is the index of the XPU.
+            - 'npu:x': If the program is running on NPU, where `x` is the index of
     Examples:
 
         .. code-block:: python
@@ -578,7 +590,16 @@ def get_device() -> str:
             >>> import paddle
             >>> device = paddle.device.get_device()
 
+            >>> x_cpu = paddle.to_tensor([1, 2, 3], place=paddle.CPUPlace())
+            >>> id = paddle.get_device(x_cpu) # -1
+
+
+
     """
+    if isinstance(input, paddle.Tensor):
+        if 'cpu' in str(input.place):
+            return -1
+        return input.place.gpu_device_id()
     device = ''
     place = framework._current_expected_place_()
     if isinstance(place, core.CPUPlace):
@@ -612,6 +633,25 @@ def get_default_device() -> paddle.device:
             print(paddle.get_default_device())
     """
     return paddle.device(get_device().replace("gpu", "cuda"))
+
+
+def set_default_device(device: PlaceLike | int) -> None:
+    """
+    Paddle supports running calculations on various types of devices, including CPU, GPU, XPU, NPU and IPU.
+    This function can specify the global device which the OP will run.
+
+    Args:
+        device(str, Place or int): This parameter determines the specific running device.
+            It can be ``cpu``, ``gpu``, ``xpu``, ``npu``, ``gpu:x``, ``xpu:x``, ``npu:x`` and ``ipu``,
+            where ``x`` is the index of the GPUs, XPUs or NPUs.
+
+    Examples:
+        .. code-block:: python
+
+            >>> import paddle
+            >>> paddle.device.set_device("cpu")
+    """
+    set_device(device)
 
 
 def get_all_device_type() -> list[str]:

--- a/python/paddle/device/__init__.py
+++ b/python/paddle/device/__init__.py
@@ -127,6 +127,9 @@ else:
             get_rng_state,
             manual_seed,
             max_memory_allocated,
+            max_memory_reserved,
+            reset_max_memory_allocated,
+            reset_max_memory_reserved,
             set_rng_state,
         )
 

--- a/python/paddle/device/__init__.py
+++ b/python/paddle/device/__init__.py
@@ -513,22 +513,10 @@ def is_bf16_supported(including_emulation: bool = True) -> bool:
             >>> paddle.cuda.is_bf16_supported()
 
     """
-    if not (
-        is_available()
-        or is_compiled_with_cuda()
-        or is_compiled_with_xpu()
-        or is_compiled_with_custom_device()
-    ):
-        return False
-    if core.is_bfloat16_supported(paddle.framework._current_expected_place()):
-        return True
-    if not including_emulation:
-        return False
-    try:
-        paddle.ones(shape=[1], dtype='bfloat16')
-        return True
-    except Exception:
-        return False
+    # including_emulation is not used here, but kept for compatibility with the original implementation
+    return core.is_bfloat16_supported(
+        paddle.framework._current_expected_place()
+    )
 
 
 def set_device(device: PlaceLike | int) -> PlaceLike:

--- a/python/paddle/device/__init__.py
+++ b/python/paddle/device/__init__.py
@@ -1138,13 +1138,14 @@ class Stream:
     '''
 
     A device stream wrapper around StreamBase.
+    paddle.cuda.Stream() is equivalent to paddle.device.Stream().
 
     Args:
         device(str|paddle.CUDAPlace(n)|paddle.CustomPlace(n)|None): Which device the stream run on. If device is None, the device is the current device. Default: None.
             It can be ``gpu``, ``gpu:x``, ``custom_device``, ``custom_device:x``, where ``custom_device`` is the name of CustomDevice,
             where ``x`` is the index of the GPUs, XPUs. And it can be paddle.CUDAPlace(n) or paddle.CustomPlace(n).
         priority(int, optional): priority of the CUDA stream. Can be either
-            1 (high priority) or 2 (low priority). By default, streams have
+            1 or -1 (high priority) or 0 or 2 (low priority). By default, streams have
             priority 2.
 
     Returns:
@@ -1165,11 +1166,12 @@ class Stream:
     '''
 
     stream_base: _InitStreamBase
-    device: PlaceLike
+    device: PlaceLike | int
+    _priority_map: dict[int, int] = {-1: 1, 0: 2, 1: 1, 2: 2}
 
     def __init__(
         self,
-        device: PlaceLike | None = None,
+        device: PlaceLike | int | None = None,
         priority: int = 2,
         stream_base: _InitStreamBase | None = None,
     ) -> None:
@@ -1185,13 +1187,7 @@ class Stream:
                     "stream_base should be CUDAStream, XPUStream, CustomDeviceStream"
                 )
             return
-
-        if device is None:
-            self.device = paddle.framework._current_expected_place_()
-        elif isinstance(device, str):
-            self.device = paddle.device._convert_to_place(device)
-        else:
-            self.device = device
+        self.device = device_to_place(device)
 
         device_id = (
             self.device.get_device_id()
@@ -1203,7 +1199,7 @@ class Stream:
             if hasattr(self.device, 'get_device_type')
             else None
         )
-
+        priority = self._priority_map.get(priority, 2)
         self.stream_base = _create_stream_base(
             device_id=device_id,
             priority=priority,
@@ -1385,40 +1381,6 @@ def _device_to_paddle(
         return dev
 
 
-class PaddleStream(Stream):
-    """Wrapper class for Paddle CUDA/XPU Stream, supporting standard device/priority handling.
-
-    This class inherits from the base `Stream` (renamed to `StreamBase` to avoid naming conflict)
-    and adds:
-    1. Unified device string conversion via `_device_to_paddle`
-    2. Priority mapping for user-friendly priority values
-    3. Clear parameter validation and error handling
-
-    Attributes:
-        _priority_map (dict[int, int]): Mapping from user-facing priority values to Paddle internal priority codes.
-            - User input: -1 (high priority), 0/2 (low priority), 1 (high priority)
-            - Internal code: 1 (high), 2 (low)
-    """
-
-    _priority_map: dict[int, int] = {-1: 1, 0: 2, 1: 1, 2: 2}
-
-    def __init__(
-        self,
-        device: paddle.CUDAPlace | paddle.CustomPlace | int | str | None = None,
-        priority: int = 0,
-        *args,
-        **kwargs,
-    ):
-        paddle_device = _device_to_paddle(device)
-        paddle_priority = self._priority_map.get(priority, 2)
-        super().__init__(
-            device=paddle_device,
-            priority=paddle_priority,
-            *args,
-            **kwargs,
-        )
-
-
 def current_stream(device: PlaceLike | None = None) -> Stream:
     '''
 
@@ -1493,6 +1455,7 @@ def set_stream(stream: Stream) -> Stream:
 
             >>> paddle.set_device('custom_cpu')
             >>> s = paddle.device.Stream()
+            >>> # paddle.cuda.set_stream(s) is equivalent to paddle.device.set_stream(s)
             >>> paddle.device.set_stream(s)
 
     '''

--- a/python/paddle/device/__init__.py
+++ b/python/paddle/device/__init__.py
@@ -165,6 +165,7 @@ __all__ = [
     'get_device_capability',
     'get_rng_state',
     'set_rng_state',
+    'device',
 ]
 
 _cudnn_version = None

--- a/python/paddle/device/__init__.py
+++ b/python/paddle/device/__init__.py
@@ -166,6 +166,7 @@ __all__ = [
     'get_rng_state',
     'set_rng_state',
     'device',
+    'is_bf16_supported',
 ]
 
 _cudnn_version = None
@@ -451,10 +452,14 @@ class device:
 
     Examples:
         .. code-block:: python
-            >>> import
+            >>> import paddle
 
             >>> print(paddle.device.get_device())  # gpu:0
-            >>> with device("cpu"):
+            >>> with paddle.device.device("cpu"):
+            ...     print(paddle.device.get_device())  # cpu
+
+            >>> # paddle.cuda.device is an alias of paddle.device.device
+            >>> with paddle.cuda.device("cpu"):
             ...     print(paddle.device.get_device())  # cpu
             >>> print(paddle.device.get_device())
     """
@@ -474,6 +479,40 @@ class device:
         traceback: types.TracebackType | None,
     ) -> bool | None:
         set_device(self.prev_place_str)
+        return False
+
+
+def is_bf16_supported(including_emulation: bool = True) -> bool:
+    """
+    Return a bool indicating if the current CUDA/ROCm device supports dtype bfloat16.
+
+    Args:
+        including_emulation (bool = True): Whether to treat software-emulated BF16 as supported; if False, only native hardware BF16 support is considered.
+
+    Returns:
+        bool: A boolean value which indicates whether the current CUDA/ROCm device supports dtype bfloat16.
+
+    Examples:
+
+        .. code-block:: python
+
+            >>> import paddle
+
+            >>> paddle.device.is_bf16_supported()
+            >>> # paddle.cuda.is_bf16_supported() is an alias of paddle.device.is_bf16_supported()
+            >>> paddle.cuda.is_bf16_supported()
+
+    """
+    if not is_available() or not core.is_compiled_with_cuda():
+        return False
+    if core.is_bfloat16_supported(paddle.framework._current_expected_place()):
+        return True
+    if not including_emulation:
+        return False
+    try:
+        paddle.ones(shape=[1], dtype='bfloat16')
+        return True
+    except Exception:
         return False
 
 

--- a/python/paddle/device/__init__.py
+++ b/python/paddle/device/__init__.py
@@ -176,6 +176,7 @@ __all__ = [
     'device',
     'is_bf16_supported',
     'manual_seed',
+    'reset_peak_memory_stats',
 ]
 
 _cudnn_version = None
@@ -512,7 +513,12 @@ def is_bf16_supported(including_emulation: bool = True) -> bool:
             >>> paddle.cuda.is_bf16_supported()
 
     """
-    if not is_available() or not core.is_compiled_with_cuda():
+    if not (
+        is_available()
+        or is_compiled_with_cuda()
+        or is_compiled_with_xpu()
+        or is_compiled_with_custom_device()
+    ):
         return False
     if core.is_bfloat16_supported(paddle.framework._current_expected_place()):
         return True
@@ -1756,6 +1762,27 @@ def manual_seed_all(seed: int) -> None:
 
     """
     paddle.seed(seed)
+
+
+def reset_peak_memory_stats(device: PlaceLike | int | None = None) -> None:
+    """
+    Resets all devices' peak memory statistics.
+
+    This method resets the peak memory usage recorded for each device during the execution of the program.
+    It sets the peak memory usage back to zero for all devices.
+
+    Example:
+        >>> # doctest: +REQUIRES(env:GPU)
+        >>> import paddle
+        >>> paddle.device.set_device('gpu')  # or '<custom_device>'
+
+        >>> # paddle.cuda.reset_max_memory_allocated() is equivalent to paddle.device.reset_max_memory_allocated()
+
+        >>> paddle.device.reset_max_memory_allocated(paddle.CUDAPlace(0))
+        >>> paddle.device.reset_max_memory_allocated(0)
+        >>> paddle.device.reset_max_memory_allocated("gpu:0")
+    """
+    reset_max_memory_allocated()
 
 
 class Device(str):

--- a/python/paddle/device/__init__.py
+++ b/python/paddle/device/__init__.py
@@ -73,6 +73,7 @@ if core.is_compiled_with_cuda():
         empty_cache,
         get_device_properties as _get_device_properties,
         get_rng_state,
+        manual_seed,
         max_memory_allocated,
         max_memory_reserved,
         memory_allocated,
@@ -88,6 +89,7 @@ elif core.is_compiled_with_xpu():
         device_count,
         empty_cache,
         get_rng_state,
+        manual_seed,
         max_memory_allocated,
         max_memory_reserved,
         memory_allocated,
@@ -109,6 +111,7 @@ else:
             empty_cache,
             get_device_properties as _get_device_properties,
             get_rng_state,
+            manual_seed,
             max_memory_allocated,
             max_memory_reserved,
             memory_allocated,
@@ -122,6 +125,7 @@ else:
         from .cpu import (
             device_count,
             get_rng_state,
+            manual_seed,
             set_rng_state,
         )
 
@@ -167,6 +171,7 @@ __all__ = [
     'set_rng_state',
     'device',
     'is_bf16_supported',
+    'manual_seed',
 ]
 
 _cudnn_version = None

--- a/python/paddle/device/cpu.py
+++ b/python/paddle/device/cpu.py
@@ -146,3 +146,36 @@ def max_memory_allocated(device: _CPUPlaceLike | None = None) -> int:
         "The API paddle.device.max_memory_allocated is not supported in CPU PaddlePaddle. "
         "Please reinstall PaddlePaddle with GPU or XPU support to call this API."
     )
+
+
+def max_memory_reserved(device: _CPUPlaceLike | None = None) -> int:
+    r"""
+    The API max_memory_reserved is not supported in CPU PaddlePaddle.
+    Please reinstall PaddlePaddle with GPU or XPU support to call this API.
+    """
+    raise ValueError(
+        "The API paddle.device.max_memory_reserved is not supported in CPU PaddlePaddle. "
+        "Please reinstall PaddlePaddle with GPU or XPU support to call this API."
+    )
+
+
+def reset_max_memory_allocated(device: _CPUPlaceLike | None = None) -> None:
+    r"""
+    The API reset_max_memory_allocated is not supported in CPU PaddlePaddle.
+    Please reinstall PaddlePaddle with GPU or XPU support to call this API.
+    """
+    raise ValueError(
+        "The API paddle.device.reset_max_memory_allocated is not supported in CPU PaddlePaddle. "
+        "Please reinstall PaddlePaddle with GPU or XPU support to call this API."
+    )
+
+
+def reset_max_memory_reserved(device: _CPUPlaceLike | None = None) -> None:
+    r"""
+    The API reset_max_memory_reserved is not supported in CPU PaddlePaddle.
+    Please reinstall PaddlePaddle with GPU or XPU support to call this API.
+    """
+    raise ValueError(
+        "The API paddle.device.reset_max_memory_reserved is not supported in CPU PaddlePaddle. "
+        "Please reinstall PaddlePaddle with GPU or XPU support to call this API."
+    )

--- a/python/paddle/device/cpu.py
+++ b/python/paddle/device/cpu.py
@@ -135,3 +135,14 @@ def manual_seed(seed: int) -> None:
     """
     seed = int(seed)
     core.default_cpu_generator().manual_seed(seed)
+
+
+def max_memory_allocated(device: _CPUPlaceLike | None = None) -> int:
+    r"""
+    The API max_memory_allocated is not supported in CPU PaddlePaddle.
+    Please reinstall PaddlePaddle with GPU or XPU support to call this API.
+    """
+    raise ValueError(
+        "The API paddle.device.max_memory_allocated is not supported in CPU PaddlePaddle. "
+        "Please reinstall PaddlePaddle with GPU or XPU support to call this API."
+    )

--- a/python/paddle/device/cpu.py
+++ b/python/paddle/device/cpu.py
@@ -107,3 +107,31 @@ def set_rng_state(
             >>> paddle.device.set_rng_state(state)
     """
     core.default_cpu_generator().set_state(new_state)
+
+
+def manual_seed(seed: int) -> None:
+    r"""Set the seed for generating random numbers for the current Device.
+
+    .. warning::
+        If you are working with a multi-Device model, this function is insufficient
+        to get determinism.  To seed all Devices, use :func:`manual_seed_all`.
+
+    Sets the seed for global default generator, which manages the random number generation.
+
+    Args:
+        seed(int): The random seed to set.
+
+    Returns:
+        None
+
+    Examples:
+        .. code-block:: python
+
+            >>> import paddle
+            >>> paddle.device.manual_seed(102)
+            >>> # paddle.cuda.manual_seed(102) is equivalent to paddle.device.manual_seed(102)
+            >>> paddle.cuda.manual_seed(102)
+
+    """
+    seed = int(seed)
+    core.default_cpu_generator().manual_seed(seed)

--- a/python/paddle/device/cuda/__init__.py
+++ b/python/paddle/device/cuda/__init__.py
@@ -795,7 +795,7 @@ def manual_seed(seed: int) -> None:
 
     Examples:
         .. code-block:: python
-
+            >>> # doctest: +REQUIRES(env:GPU)
             >>> import paddle
             >>> paddle.device.manual_seed(102)
             >>> # paddle.cuda.manual_seed(102) is equivalent to paddle.device.manual_seed(102)

--- a/python/paddle/device/cuda/__init__.py
+++ b/python/paddle/device/cuda/__init__.py
@@ -776,3 +776,32 @@ def set_rng_state(
         core.default_cpu_generator().set_state(new_state)
     else:
         core.default_cuda_generator(place.get_device_id()).set_state(new_state)
+
+
+def manual_seed(seed: int) -> None:
+    r"""Set the seed for generating random numbers for the current Device.
+
+    .. warning::
+        If you are working with a multi-Device model, this function is insufficient
+        to get determinism.  To seed all Devices, use :func:`manual_seed_all`.
+
+    Sets the seed for global default generator, which manages the random number generation.
+
+    Args:
+        seed(int): The random seed to set.
+
+    Returns:
+        None
+
+    Examples:
+        .. code-block:: python
+
+            >>> import paddle
+            >>> paddle.device.manual_seed(102)
+            >>> # paddle.cuda.manual_seed(102) is equivalent to paddle.device.manual_seed(102)
+            >>> paddle.cuda.manual_seed(102)
+
+    """
+    seed = int(seed)
+    id = int(paddle.device.get_device().split(':')[1])
+    core.default_cuda_generator(id).manual_seed(seed)

--- a/python/paddle/device/cuda/__init__.py
+++ b/python/paddle/device/cuda/__init__.py
@@ -779,7 +779,7 @@ def set_rng_state(
 
 
 def manual_seed(seed: int) -> None:
-    r"""Set the seed for generating random numbers for the current Device.
+    """Set the seed for generating random numbers for the current Device.
 
     .. warning::
         If you are working with a multi-Device model, this function is insufficient

--- a/python/paddle/device/cuda/__init__.py
+++ b/python/paddle/device/cuda/__init__.py
@@ -784,6 +784,7 @@ def manual_seed(seed: int) -> None:
     .. warning::
         If you are working with a multi-Device model, this function is insufficient
         to get determinism.  To seed all Devices, use :func:`manual_seed_all`.
+        If current Device is CPU, this function will set the seed of the default CPU generator.
 
     Sets the seed for global default generator, which manages the random number generation.
 
@@ -795,7 +796,7 @@ def manual_seed(seed: int) -> None:
 
     Examples:
         .. code-block:: python
-            >>> # doctest: +REQUIRES(env:GPU)
+            >>> # doctest: +REQUIRES(env:CUSTOM_DEVICE)
             >>> import paddle
             >>> paddle.device.manual_seed(102)
             >>> # paddle.cuda.manual_seed(102) is equivalent to paddle.device.manual_seed(102)
@@ -803,5 +804,8 @@ def manual_seed(seed: int) -> None:
 
     """
     seed = int(seed)
-    id = int(paddle.device.get_device().split(':')[1])
-    core.default_cuda_generator(id).manual_seed(seed)
+    place = paddle.framework._current_expected_place_()
+    if isinstance(place, core.CPUPlace):
+        core.default_cpu_generator().manual_seed(seed)
+    else:
+        core.default_cuda_generator(place.get_device_id()).manual_seed(seed)

--- a/python/paddle/device/custom_device.py
+++ b/python/paddle/device/custom_device.py
@@ -589,11 +589,10 @@ def manual_seed(seed: int) -> None:
 
     Examples:
         .. code-block:: python
-
+            >>> # doctest: +REQUIRES(env:CUSTOM_DEVICE)
             >>> import paddle
             >>> paddle.device.manual_seed(102)
             >>> # paddle.cuda.manual_seed(102) is equivalent to paddle.device.manual_seed(102)
-            >>> paddle.cuda.manual_seed(102)
 
     """
     seed = int(seed)

--- a/python/paddle/device/custom_device.py
+++ b/python/paddle/device/custom_device.py
@@ -578,6 +578,7 @@ def manual_seed(seed: int) -> None:
     .. warning::
         If you are working with a multi-Device model, this function is insufficient
         to get determinism.  To seed all Devices, use :func:`manual_seed_all`.
+        If current Device is CPU, this function will set the seed of the default CPU generator.
 
     Sets the seed for global default generator, which manages the random number generation.
 
@@ -597,4 +598,7 @@ def manual_seed(seed: int) -> None:
     """
     seed = int(seed)
     place = paddle.framework._current_expected_place()
-    core.default_custom_device_generator(place).manual_seed(seed)
+    if isinstance(place, core.CPUPlace):
+        core.default_cpu_generator().manual_seed(seed)
+    else:
+        core.default_custom_device_generator(place).manual_seed(seed)

--- a/python/paddle/device/custom_device.py
+++ b/python/paddle/device/custom_device.py
@@ -570,3 +570,32 @@ def set_rng_state(
         core.default_cpu_generator().set_state(new_state)
     else:
         core.default_custom_device_generator(place).set_state(new_state)
+
+
+def manual_seed(seed: int) -> None:
+    r"""Set the seed for generating random numbers for the current Device.
+
+    .. warning::
+        If you are working with a multi-Device model, this function is insufficient
+        to get determinism.  To seed all Devices, use :func:`manual_seed_all`.
+
+    Sets the seed for global default generator, which manages the random number generation.
+
+    Args:
+        seed(int): The random seed to set.
+
+    Returns:
+        None
+
+    Examples:
+        .. code-block:: python
+
+            >>> import paddle
+            >>> paddle.device.manual_seed(102)
+            >>> # paddle.cuda.manual_seed(102) is equivalent to paddle.device.manual_seed(102)
+            >>> paddle.cuda.manual_seed(102)
+
+    """
+    seed = int(seed)
+    place = paddle.framework._current_expected_place()
+    core.default_custom_device_generator(place).manual_seed(seed)

--- a/python/paddle/device/xpu/__init__.py
+++ b/python/paddle/device/xpu/__init__.py
@@ -579,3 +579,32 @@ def set_rng_state(
         core.default_cpu_generator().set_state(new_state)
     else:
         core.default_xpu_generator(place.get_device_id()).set_state(new_state)
+
+
+def manual_seed(seed: int) -> None:
+    r"""Set the seed for generating random numbers for the current Device.
+
+    .. warning::
+        If you are working with a multi-Device model, this function is insufficient
+        to get determinism.  To seed all Devices, use :func:`manual_seed_all`.
+
+    Sets the seed for global default generator, which manages the random number generation.
+
+    Args:
+        seed(int): The random seed to set.
+
+    Returns:
+        None
+
+    Examples:
+        .. code-block:: python
+
+            >>> import paddle
+            >>> paddle.device.manual_seed(102)
+            >>> # paddle.cuda.manual_seed(102) is equivalent to paddle.device.manual_seed(102)
+            >>> paddle.cuda.manual_seed(102)
+
+    """
+    seed = int(seed)
+    id = int(paddle.device.get_device().split(':')[1])
+    core.default_xpu_generator(id).manual_seed(seed)

--- a/python/paddle/device/xpu/__init__.py
+++ b/python/paddle/device/xpu/__init__.py
@@ -587,6 +587,7 @@ def manual_seed(seed: int) -> None:
     .. warning::
         If you are working with a multi-Device model, this function is insufficient
         to get determinism.  To seed all Devices, use :func:`manual_seed_all`.
+        If current Device is CPU, this function will set the seed of the default CPU generator.
 
     Sets the seed for global default generator, which manages the random number generation.
 
@@ -606,5 +607,8 @@ def manual_seed(seed: int) -> None:
 
     """
     seed = int(seed)
-    id = int(paddle.device.get_device().split(':')[1])
-    core.default_xpu_generator(id).manual_seed(seed)
+    place = paddle.framework._current_expected_place_()
+    if isinstance(place, core.CPUPlace):
+        core.default_cpu_generator().manual_seed(seed)
+    else:
+        core.default_xpu_generator(place.get_device_id()).manual_seed(seed)

--- a/python/paddle/device/xpu/__init__.py
+++ b/python/paddle/device/xpu/__init__.py
@@ -598,7 +598,7 @@ def manual_seed(seed: int) -> None:
 
     Examples:
         .. code-block:: python
-
+            >>> # doctest: +REQUIRES(env:XPU)
             >>> import paddle
             >>> paddle.device.manual_seed(102)
             >>> # paddle.cuda.manual_seed(102) is equivalent to paddle.device.manual_seed(102)

--- a/test/compat/test_device_apis.py
+++ b/test/compat/test_device_apis.py
@@ -27,6 +27,25 @@ def is_custom_device():
     return False
 
 
+class TestMaxMemoryAllocatedCPU(unittest.TestCase):
+    def test_max_memory_allocated_raises_on_cpu(self):
+        if (
+            core.is_compiled_with_cuda()
+            or is_custom_device()
+            or core.is_compiled_with_xpu()
+        ):
+            pass
+        else:
+            with self.assertRaisesRegex(
+                ValueError, "not supported in CPU PaddlePaddle"
+            ):
+                paddle.cuda.max_memory_allocated()
+            with self.assertRaisesRegex(
+                ValueError, "not supported in CPU PaddlePaddle"
+            ):
+                paddle.device.max_memory_allocated()
+
+
 class TestDeviceAPIs(unittest.TestCase):
     """Test paddle.device APIs across different hardware types."""
 
@@ -161,6 +180,23 @@ class TestDeviceAPIs(unittest.TestCase):
         self.assertGreaterEqual(mem3, 0)
 
         mem7 = paddle.device.max_memory_allocated(paddle.CUDAPlace(0))
+        self.assertIsInstance(mem7, int)
+        self.assertGreaterEqual(mem7, 0)
+
+        # Test max_memory_allocated with different input types
+        mem1 = paddle.cuda.max_memory_allocated()
+        self.assertIsInstance(mem1, int)
+        self.assertGreaterEqual(mem1, 0)
+
+        mem2 = paddle.cuda.max_memory_allocated('gpu:0')
+        self.assertIsInstance(mem2, int)
+        self.assertGreaterEqual(mem2, 0)
+
+        mem3 = paddle.cuda.max_memory_allocated(0)
+        self.assertIsInstance(mem3, int)
+        self.assertGreaterEqual(mem3, 0)
+
+        mem7 = paddle.cuda.max_memory_allocated(paddle.CUDAPlace(0))
         self.assertIsInstance(mem7, int)
         self.assertGreaterEqual(mem7, 0)
 

--- a/test/compat/test_device_apis.py
+++ b/test/compat/test_device_apis.py
@@ -578,19 +578,35 @@ class TestDeviceAPIs(unittest.TestCase):
         paddle.device.reset_max_memory_allocated(0)
         paddle.device.reset_max_memory_allocated(paddle.CUDAPlace(0))
 
+        # Test reset functions with different input types
+        paddle.device.reset_peak_memory_stats()
+        paddle.device.reset_peak_memory_stats('gpu:0')
+        paddle.device.reset_peak_memory_stats('cuda:0')
+        paddle.device.reset_peak_memory_stats(0)
+        paddle.device.reset_peak_memory_stats(paddle.CUDAPlace(0))
+
+        # Test reset functions with different input types
+        paddle.cuda.reset_peak_memory_stats()
+        paddle.cuda.reset_peak_memory_stats('gpu:0')
+        paddle.cuda.reset_peak_memory_stats(0)
+        paddle.cuda.reset_peak_memory_stats(paddle.CUDAPlace(0))
+
         paddle.device.reset_max_memory_reserved()
         paddle.device.reset_max_memory_reserved('gpu:0')
+        paddle.device.reset_max_memory_reserved('cuda:0')
         paddle.device.reset_max_memory_reserved(0)
         paddle.device.reset_max_memory_reserved(paddle.CUDAPlace(0))
 
         # Test reset functions with different input types
         paddle.cuda.reset_max_memory_allocated()
         paddle.cuda.reset_max_memory_allocated('gpu:0')
+        paddle.cuda.reset_max_memory_allocated('cuda:0')
         paddle.cuda.reset_max_memory_allocated(0)
         paddle.cuda.reset_max_memory_allocated(paddle.CUDAPlace(0))
 
         paddle.cuda.reset_max_memory_reserved()
         paddle.cuda.reset_max_memory_reserved('gpu:0')
+        paddle.cuda.reset_max_memory_reserved('cuda:0')
         paddle.cuda.reset_max_memory_reserved(0)
         paddle.cuda.reset_max_memory_reserved(paddle.CUDAPlace(0))
 

--- a/test/compat/test_device_apis.py
+++ b/test/compat/test_device_apis.py
@@ -27,15 +27,17 @@ def is_custom_device():
     return False
 
 
-class TestMaxMemoryAllocatedCPU(unittest.TestCase):
+def only_has_cpu():
+    return (
+        not core.is_compiled_with_cuda()
+        and not core.is_compiled_with_xpu()
+        and not is_custom_device()
+    )
+
+
+class TestErrorCPU(unittest.TestCase):
     def test_max_memory_allocated_raises_on_cpu(self):
-        if (
-            core.is_compiled_with_cuda()
-            or is_custom_device()
-            or core.is_compiled_with_xpu()
-        ):
-            pass
-        else:
+        if only_has_cpu():
             with self.assertRaisesRegex(
                 ValueError, "not supported in CPU PaddlePaddle"
             ):
@@ -44,6 +46,30 @@ class TestMaxMemoryAllocatedCPU(unittest.TestCase):
                 ValueError, "not supported in CPU PaddlePaddle"
             ):
                 paddle.device.max_memory_allocated()
+            with self.assertRaisesRegex(
+                ValueError, "not supported in CPU PaddlePaddle"
+            ):
+                paddle.cuda.max_memory_reserved()
+            with self.assertRaisesRegex(
+                ValueError, "not supported in CPU PaddlePaddle"
+            ):
+                paddle.device.max_memory_reserved()
+            with self.assertRaisesRegex(
+                ValueError, "not supported in CPU PaddlePaddle"
+            ):
+                paddle.cuda.reset_max_memory_allocated()
+            with self.assertRaisesRegex(
+                ValueError, "not supported in CPU PaddlePaddle"
+            ):
+                paddle.device.reset_max_memory_allocated()
+            with self.assertRaisesRegex(
+                ValueError, "not supported in CPU PaddlePaddle"
+            ):
+                paddle.cuda.reset_max_memory_reserved()
+            with self.assertRaisesRegex(
+                ValueError, "not supported in CPU PaddlePaddle"
+            ):
+                paddle.device.reset_max_memory_reserved()
 
 
 class TestDeviceAPIs(unittest.TestCase):
@@ -206,6 +232,14 @@ class TestDeviceAPIs(unittest.TestCase):
         self.assertGreaterEqual(mem4, 0)
 
         mem8 = paddle.device.max_memory_reserved('gpu:0')
+        self.assertIsInstance(mem8, int)
+        self.assertGreaterEqual(mem8, 0)
+
+        mem4 = paddle.cuda.max_memory_reserved()
+        self.assertIsInstance(mem4, int)
+        self.assertGreaterEqual(mem4, 0)
+
+        mem8 = paddle.cuda.max_memory_reserved('gpu:0')
         self.assertIsInstance(mem8, int)
         self.assertGreaterEqual(mem8, 0)
 
@@ -548,6 +582,17 @@ class TestDeviceAPIs(unittest.TestCase):
         paddle.device.reset_max_memory_reserved('gpu:0')
         paddle.device.reset_max_memory_reserved(0)
         paddle.device.reset_max_memory_reserved(paddle.CUDAPlace(0))
+
+        # Test reset functions with different input types
+        paddle.cuda.reset_max_memory_allocated()
+        paddle.cuda.reset_max_memory_allocated('gpu:0')
+        paddle.cuda.reset_max_memory_allocated(0)
+        paddle.cuda.reset_max_memory_allocated(paddle.CUDAPlace(0))
+
+        paddle.cuda.reset_max_memory_reserved()
+        paddle.cuda.reset_max_memory_reserved('gpu:0')
+        paddle.cuda.reset_max_memory_reserved(0)
+        paddle.cuda.reset_max_memory_reserved(paddle.CUDAPlace(0))
 
         # Check that max memory has been reset
         max_allocated_after_reset = paddle.device.max_memory_allocated()

--- a/test/compat/test_event_stream_apis.py
+++ b/test/compat/test_event_stream_apis.py
@@ -116,6 +116,9 @@ class TestEventStreamAPIs(unittest.TestCase):
         prev_stream = paddle.device.set_stream(stream1)
         self.assertIsInstance(prev_stream, paddle.device.Stream)
 
+        prev_stream = paddle.cuda.set_stream(stream1)
+        self.assertIsInstance(prev_stream, paddle.cuda.Stream)
+
         # Test Event.record() with default stream
         event1.record()
         # Query result may be True immediately for some devices

--- a/test/compat/test_event_stream_apis.py
+++ b/test/compat/test_event_stream_apis.py
@@ -353,5 +353,58 @@ class TestEventStreamTimingFunctionality(unittest.TestCase):
             self.assertGreater(elapsed_time, 0)  # Should take some time
 
 
+class TestEventAPIs(unittest.TestCase):
+    """Unified test for paddle.Event, paddle.device.Event, and paddle.cuda.Event."""
+
+    def setUp(self):
+        if not paddle.device.is_compiled_with_cuda():
+            self.skipTest("This test requires CUDA.")
+        self.device = "gpu:0"
+        paddle.device.set_device(self.device)
+
+        # 所有待测 Event API
+        self.event_classes = [
+            ("paddle.Event", paddle.Event),
+            ("paddle.cuda.Event", paddle.cuda.Event),
+        ]
+
+    def test_event_timing_consistency(self):
+        """Check timing consistency across different Event APIs."""
+        for name, EventCls in self.event_classes:
+            with self.subTest(api=name):
+                start = EventCls(enable_timing=True)
+                end = EventCls(enable_timing=True)
+
+                # 记录起始时间
+                start.record()
+
+                # 模拟 GPU 工作负载
+                x = paddle.randn([2048, 2048], dtype="float32")
+                y = paddle.randn([2048, 2048], dtype="float32")
+                z = paddle.matmul(x, y)
+                _ = z.mean()
+
+                # 记录结束时间
+                end.record()
+                end.synchronize()
+
+                elapsed = start.elapsed_time(end)
+                self.assertIsInstance(elapsed, (int, float))
+                self.assertGreater(
+                    elapsed,
+                    0.0,
+                    f"{name} should measure positive elapsed time.",
+                )
+
+    def test_event_methods_available(self):
+        """Ensure all Event variants expose expected methods."""
+        for name, EventCls in self.event_classes:
+            with self.subTest(api=name):
+                e = EventCls(enable_timing=True)
+                self.assertTrue(hasattr(e, "record"))
+                self.assertTrue(hasattr(e, "synchronize"))
+                self.assertTrue(hasattr(e, "elapsed_time"))
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/compat/test_event_stream_apis.py
+++ b/test/compat/test_event_stream_apis.py
@@ -362,7 +362,6 @@ class TestEventAPIs(unittest.TestCase):
         self.device = "gpu:0"
         paddle.device.set_device(self.device)
 
-        # 所有待测 Event API
         self.event_classes = [
             ("paddle.Event", paddle.Event),
             ("paddle.cuda.Event", paddle.cuda.Event),
@@ -375,16 +374,13 @@ class TestEventAPIs(unittest.TestCase):
                 start = EventCls(enable_timing=True)
                 end = EventCls(enable_timing=True)
 
-                # 记录起始时间
                 start.record()
 
-                # 模拟 GPU 工作负载
                 x = paddle.randn([2048, 2048], dtype="float32")
                 y = paddle.randn([2048, 2048], dtype="float32")
                 z = paddle.matmul(x, y)
                 _ = z.mean()
 
-                # 记录结束时间
                 end.record()
                 end.synchronize()
 

--- a/test/compat/test_paddle_cuda_apis.py
+++ b/test/compat/test_paddle_cuda_apis.py
@@ -477,5 +477,47 @@ class TestBf16Supported(unittest.TestCase):
             self.assertFalse(paddle.device.is_bf16_supported())
 
 
+class TestManualSeed(unittest.TestCase):
+    def test_device_manual_seed(self):
+        paddle.device.manual_seed(102)
+        x1 = paddle.randn([2, 3])
+
+        paddle.device.manual_seed(999)
+        x2 = paddle.randn([2, 3])
+
+        paddle.device.manual_seed(102)
+        x3 = paddle.randn([2, 3])
+
+        self.assertTrue(
+            paddle.equal_all(x1, x3),
+            "Random outputs should be identical with the same seed",
+        )
+
+        self.assertFalse(
+            paddle.equal_all(x1, x2),
+            "Random outputs should differ with different seeds",
+        )
+
+    def test_cuda_manual_seed(self):
+        paddle.cuda.manual_seed(102)
+        x1 = paddle.randn([2, 3], dtype='float32')
+
+        paddle.cuda.manual_seed(999)
+        x2 = paddle.randn([2, 3], dtype='float32')
+
+        paddle.cuda.manual_seed(102)
+        x3 = paddle.randn([2, 3], dtype='float32')
+
+        self.assertTrue(
+            paddle.equal_all(x1, x3),
+            "Random outputs should be identical with the same seed",
+        )
+
+        self.assertFalse(
+            paddle.equal_all(x1, x2),
+            "Random outputs should differ with different seeds",
+        )
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/compat/test_paddle_cuda_apis.py
+++ b/test/compat/test_paddle_cuda_apis.py
@@ -464,5 +464,18 @@ class TestSetDevice(TestCase):
         self.assertIn("Unsupported device type", str(context.exception))
 
 
+class TestBf16Supported(unittest.TestCase):
+    def test_is_bf16_supported(self):
+        self.assertIsInstance(paddle.cuda.is_bf16_supported(), bool)
+        self.assertIsInstance(paddle.device.is_bf16_supported(), bool)
+        self.assertIsInstance(paddle.device.is_bf16_supported(True), bool)
+        self.assertIsInstance(paddle.cuda.is_bf16_supported(False), bool)
+        if not (
+            paddle.cuda.is_available() and paddle.core.is_compiled_with_cuda()
+        ):
+            self.assertFalse(paddle.cuda.is_bf16_supported())
+            self.assertFalse(paddle.device.is_bf16_supported())
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/compat/test_paddle_cuda_apis.py
+++ b/test/compat/test_paddle_cuda_apis.py
@@ -470,9 +470,7 @@ class TestBf16Supported(unittest.TestCase):
         self.assertIsInstance(paddle.device.is_bf16_supported(), bool)
         self.assertIsInstance(paddle.device.is_bf16_supported(True), bool)
         self.assertIsInstance(paddle.cuda.is_bf16_supported(False), bool)
-        if not (
-            paddle.cuda.is_available() and paddle.core.is_compiled_with_cuda()
-        ):
+        if should_skip_tests():
             self.assertFalse(paddle.cuda.is_bf16_supported())
             self.assertFalse(paddle.device.is_bf16_supported())
 

--- a/test/legacy_test/test_cuda_unittest.py
+++ b/test/legacy_test/test_cuda_unittest.py
@@ -151,6 +151,22 @@ class TestCudaCompat(unittest.TestCase):
         if paddle.is_compiled_with_cuda():
             self.assertEqual(paddle.get_default_device(), paddle.device('cuda'))
 
+    def test_get_device(self):
+        x_cpu = paddle.to_tensor([1, 2, 3], place=paddle.CPUPlace())
+        self.assertEqual(paddle.get_device(x_cpu), -1)
+        if paddle.device.is_compiled_with_cuda():
+            x_gpu = paddle.to_tensor([1, 2, 3], place=paddle.CUDAPlace(0))
+            self.assertEqual(paddle.get_device(x_gpu), 0)
+
+    def test_set_default_device(self):
+        if paddle.is_compiled_with_cuda():
+            paddle.set_default_device("gpu")
+            self.assertEqual(paddle.get_default_device(), paddle.device('cuda'))
+
+        if paddle.is_compiled_with_xpu():
+            paddle.set_default_device("xpu")
+            self.assertEqual(paddle.get_default_device(), paddle.device('xpu'))
+
     @unittest.skipIf(
         (
             not paddle.device.is_compiled_with_cuda()

--- a/test/legacy_test/test_cuda_unittest.py
+++ b/test/legacy_test/test_cuda_unittest.py
@@ -347,5 +347,21 @@ class TestExternalStream(unittest.TestCase):
         )
 
 
+class TestDeviceDvice(unittest.TestCase):
+    def test_device_device(self):
+        current = paddle.device.get_device()
+        with paddle.device.device("cpu"):
+            self.assertEqual(paddle.device.get_device(), 'cpu')
+        self.assertEqual(paddle.device.get_device(), current)
+
+
+class TestCudaDvice(unittest.TestCase):
+    def test_device_device(self):
+        current = paddle.device.get_device()
+        with paddle.cuda.device("cpu"):
+            self.assertEqual(paddle.device.get_device(), 'cpu')
+        self.assertEqual(paddle.device.get_device(), current)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
对齐torch的api和paddle的api
| New API (under `paddle.device`) | Equivalent API (under `paddle.cuda`) | Description |
|---------------------------------|--------------------------------------|--------------|
| `paddle.device.device`          | `paddle.cuda.device`                 | Context manager for setting and restoring CUDA device. |
| `paddle.device.is_bf16_supported` | `paddle.cuda.is_bf16_supported`     | Check whether the current CUDA device supports `bfloat16` (BF16) dtype. 注意新增的参数including_emulation,|
| `paddle.device.manual_seed`     | `paddle.cuda.manual_seed`            | Set the random seed for CUDA devices to ensure reproducible results. |
|`paddle.device.max_memory_allocated`|`paddle.cuda.max_memory_allocated`|弥补cpu下没有这个函数的问题，但cpu下直接报错并给出报错提示|
|`paddle.device.reset_peak_memory_stats`|`paddle.cuda.reset_peak_memory_stats`|Reset the peak size of memory that is allocated to tensor of the given device.|
|`paddle.cuda.set_stream`|`paddle.cuda.set_stream`|顺手修改了paddle.device.Stream的不太合理的一处，规范化使得paddle.device.Stream和paddle.cuda.Stream等价|
| `paddle.device.Event` |`paddle.cuda.Event`|并补充paddle.Event,这三个类等价，和torch的对比应该还缺少两个成员函数，有待进一步的修改|

paddle.get_device的输入兼容torch的张量输入，输出张量的设备id


card-67164