### PR TITLE
[Precision Depth Alignment] fix beta and threshold of Softplus to double

### DIFF
--- a/paddle/fluid/framework/infershape_utils.cc
+++ b/paddle/fluid/framework/infershape_utils.cc
@@ -795,21 +795,13 @@ CompatInferMetaContext BuildInferMetaContext(InferShapeContext* ctx,
               infer_meta_context.EmplaceBackAttr(PADDLE_GET_CONST(float, attr));
               break;
             case phi::AttributeType::FLOAT64:
-              switch (AttrTypeID(attr)) {
-                case framework::proto::AttrType::FLOAT64:
-                  infer_meta_context.EmplaceBackAttr(
-                      PADDLE_GET_CONST(double, attr));
-                  break;
-                case framework::proto::AttrType::FLOAT: {
-                  const auto val = PADDLE_GET_CONST(float, attr);
-                  infer_meta_context.EmplaceBackAttr(static_cast<double>(val));
-                } break;
-                default:
-                  PADDLE_THROW(common::errors::Unimplemented(
-                      "Unsupported cast op attribute `%s` to double when "
-                      "construct InferMetaContext.",
-                      attr_names[i]));
+              if (AttrTypeID(attr) == framework::proto::AttrType::FLOAT) {
+                const auto val = PADDLE_GET_CONST(float, attr);
+                infer_meta_context.EmplaceBackAttr(static_cast<double>(val));
+                break;
               }
+              infer_meta_context.EmplaceBackAttr(
+                  PADDLE_GET_CONST(double, attr));
               break;
             case phi::AttributeType::INT32:
               infer_meta_context.EmplaceBackAttr(PADDLE_GET_CONST(int, attr));

--- a/paddle/fluid/framework/infershape_utils.cc
+++ b/paddle/fluid/framework/infershape_utils.cc
@@ -795,8 +795,21 @@ CompatInferMetaContext BuildInferMetaContext(InferShapeContext* ctx,
               infer_meta_context.EmplaceBackAttr(PADDLE_GET_CONST(float, attr));
               break;
             case phi::AttributeType::FLOAT64:
-              infer_meta_context.EmplaceBackAttr(
-                  PADDLE_GET_CONST(double, attr));
+              switch (AttrTypeID(attr)) {
+                case framework::proto::AttrType::FLOAT64:
+                  infer_meta_context.EmplaceBackAttr(
+                      PADDLE_GET_CONST(double, attr));
+                  break;
+                case framework::proto::AttrType::FLOAT: {
+                  const auto val = PADDLE_GET_CONST(float, attr);
+                  infer_meta_context.EmplaceBackAttr(static_cast<double>(val));
+                } break;
+                default:
+                  PADDLE_THROW(common::errors::Unimplemented(
+                      "Unsupported cast op attribute `%s` to double when "
+                      "construct InferMetaContext.",
+                      attr_names[i]));
+              }
               break;
             case phi::AttributeType::INT32:
               infer_meta_context.EmplaceBackAttr(PADDLE_GET_CONST(int, attr));

--- a/paddle/fluid/framework/new_executor/instruction/onednn/onednn_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/onednn/onednn_instruction.cc
@@ -53,6 +53,8 @@ static phi::Attribute ConvertPirAttribute2RuntimeAttribute(
     return attr.dyn_cast<pir::Int32Attribute>().data();
   } else if (attr_type_name == "pir::FloatAttribute") {
     return attr.dyn_cast<pir::FloatAttribute>().data();
+  } else if (attr_type_name == "pir::DoubleAttribute") {
+    return attr.dyn_cast<pir::DoubleAttribute>().data();
   } else if (attr_type_name == "pir::BoolAttribute") {
     return attr.dyn_cast<pir::BoolAttribute>().data();
   } else if (attr_type_name == "pir::StrAttribute") {

--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -3514,8 +3514,21 @@ void OperatorWithKernel::BuildPhiKernelContext(
                 PADDLE_GET_CONST(float, attr_iter->second));
             break;
           case phi::AttributeType::FLOAT64:
-            phi_kernel_context->EmplaceBackAttr(
-                PADDLE_GET_CONST(double, attr_iter->second));
+            switch (AttrTypeID(attr_iter->second)) {
+              case proto::AttrType::FLOAT64:
+                phi_kernel_context->EmplaceBackAttr(
+                    PADDLE_GET_CONST(double, attr_iter->second));
+                break;
+              case proto::AttrType::FLOAT: {
+                const auto val = PADDLE_GET_CONST(float, attr_iter->second);
+                phi_kernel_context->EmplaceBackAttr(static_cast<double>(val));
+              } break;
+              default:
+                PADDLE_THROW(common::errors::Unimplemented(
+                    "Unsupported cast op attribute `%s` to double when "
+                    "construct KernelContext.",
+                    attr_names[i]));
+            }
             break;
           case phi::AttributeType::INT32:
             phi_kernel_context->EmplaceBackAttr(

--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -3514,21 +3514,14 @@ void OperatorWithKernel::BuildPhiKernelContext(
                 PADDLE_GET_CONST(float, attr_iter->second));
             break;
           case phi::AttributeType::FLOAT64:
-            switch (AttrTypeID(attr_iter->second)) {
-              case proto::AttrType::FLOAT64:
-                phi_kernel_context->EmplaceBackAttr(
-                    PADDLE_GET_CONST(double, attr_iter->second));
-                break;
-              case proto::AttrType::FLOAT: {
-                const auto val = PADDLE_GET_CONST(float, attr_iter->second);
-                phi_kernel_context->EmplaceBackAttr(static_cast<double>(val));
-              } break;
-              default:
-                PADDLE_THROW(common::errors::Unimplemented(
-                    "Unsupported cast op attribute `%s` to double when "
-                    "construct KernelContext.",
-                    attr_names[i]));
+            if (AttrTypeID(attr_iter->second) ==
+                framework::proto::AttrType::FLOAT) {
+              const auto val = PADDLE_GET_CONST(float, attr_iter->second);
+              phi_kernel_context->EmplaceBackAttr(static_cast<double>(val));
+              break;
             }
+            phi_kernel_context->EmplaceBackAttr(
+                PADDLE_GET_CONST(double, attr_iter->second));
             break;
           case phi::AttributeType::INT32:
             phi_kernel_context->EmplaceBackAttr(

--- a/paddle/fluid/inference/tensorrt/convert/activation_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/activation_op.cc
@@ -42,13 +42,14 @@ class ActivationOpConverter : public OpConverter {
     auto op_pair = ops.find(op_type_);
     nvinfer1::IActivationLayer* layer = nullptr;
     if (op_type_ == "softplus") {
-      const float beta = op_desc.HasAttr("beta")
-                             ? PADDLE_GET_CONST(float, op_desc.GetAttr("beta"))
-                             : 1.0f;
-      const float threshold =
+      const double beta =
+          op_desc.HasAttr("beta")
+              ? PADDLE_GET_CONST(double, op_desc.GetAttr("beta"))
+              : 1.0;
+      const double threshold =
           op_desc.HasAttr("threshold")
-              ? PADDLE_GET_CONST(float, op_desc.GetAttr("threshold"))
-              : 20.0f;
+              ? PADDLE_GET_CONST(double, op_desc.GetAttr("threshold"))
+              : 20.0;
       auto* layer_clip = TRT_ENGINE_ADD_LAYER(
           engine_, Activation, *input_tensor, nvinfer1::ActivationType::kCLIP);
       layer_clip->setAlpha(-3.40282e+038);

--- a/paddle/fluid/inference/tensorrt/convert/activation_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/activation_op.cc
@@ -42,14 +42,13 @@ class ActivationOpConverter : public OpConverter {
     auto op_pair = ops.find(op_type_);
     nvinfer1::IActivationLayer* layer = nullptr;
     if (op_type_ == "softplus") {
-      const double beta =
-          op_desc.HasAttr("beta")
-              ? PADDLE_GET_CONST(double, op_desc.GetAttr("beta"))
-              : 1.0;
-      const double threshold =
+      const float beta = op_desc.HasAttr("beta")
+                             ? PADDLE_GET_CONST(float, op_desc.GetAttr("beta"))
+                             : 1.0f;
+      const float threshold =
           op_desc.HasAttr("threshold")
-              ? PADDLE_GET_CONST(double, op_desc.GetAttr("threshold"))
-              : 20.0;
+              ? PADDLE_GET_CONST(float, op_desc.GetAttr("threshold"))
+              : 20.0f;
       auto* layer_clip = TRT_ENGINE_ADD_LAYER(
           engine_, Activation, *input_tensor, nvinfer1::ActivationType::kCLIP);
       layer_clip->setAlpha(-3.40282e+038);

--- a/paddle/fluid/ir_adaptor/translator/op_translator.cc
+++ b/paddle/fluid/ir_adaptor/translator/op_translator.cc
@@ -3939,25 +3939,28 @@ struct SoftPlusOpTranscriber : public OpTranscriber {
       }
       auto legacy_attr_name =
           op_normalizer.GetLegacyAttrName(op_desc.Type(), info.name);
-      VLOG(10) << "[op: " << op_desc.Type()
-               << "][attr] from: " << legacy_attr_name << " to: " << info.name;
+      std::cout << "[op: " << op_desc.Type()
+                << "][attr] from: " << legacy_attr_name << " to: " << info.name
+                << std::endl;
       if (op_desc.HasAttr(legacy_attr_name)) {
         paddle::framework::Attribute legacy_attr =
             op_desc.GetAttr(legacy_attr_name);
-        VLOG(10) << "attribute in " << op_desc.Type()
-                 << " name: " << legacy_attr_name << " " << legacy_attr.index();
+        std::cout << "attribute in " << op_desc.Type()
+                  << " name: " << legacy_attr_name << " " << legacy_attr.index()
+                  << std::endl;
         pir::Attribute new_attr =
             attribute_translator(info.type_name, legacy_attr);
         if (legacy_attr_name == "beta" || legacy_attr_name == "threshold") {
-          new_attr = pir::DoubleAttribute::get(
+          attribute_map[info.name] = pir::DoubleAttribute::get(
               ctx,
               static_cast<double>(
                   new_attr.dyn_cast<pir::FloatAttribute>().data()));
-        }
-        attribute_map[info.name] = new_attr;
-        if (!new_attr) {
-          VLOG(0) << "empty attribute in " << op_desc.Type()
-                  << " name: " << info.name;
+        } else {
+          attribute_map[info.name] = new_attr;
+          if (!new_attr) {
+            VLOG(0) << "empty attribute in " << op_desc.Type()
+                    << " name: " << info.name;
+          }
         }
       } else {
         VLOG(10) << "attribute in " << op_desc.Type()

--- a/paddle/fluid/ir_adaptor/translator/op_translator.cc
+++ b/paddle/fluid/ir_adaptor/translator/op_translator.cc
@@ -4086,5 +4086,6 @@ OpTranslator::OpTranslator() {
 
   special_handlers["c_sync_comm_stream"] = SyncCommStreamOpTranscriber();
   special_handlers["softplus"] = SoftPlusOpTranscriber();
+  special_handlers["softplus_grad"] = SoftPlusOpTranscriber();
 }
 }  // namespace paddle::translator

--- a/paddle/fluid/ir_adaptor/translator/op_translator.cc
+++ b/paddle/fluid/ir_adaptor/translator/op_translator.cc
@@ -3932,11 +3932,6 @@ struct SoftPlusOpTranscriber : public OpTranscriber {
     pir::AttributeMap attribute_map = {};
 
     for (const auto& info : op_attr_infos) {
-      if (auto handler = this->GetSpecialAttributeHandlers(info.name)) {
-        auto new_attr = handler(ctx, op_desc, info);
-        attribute_map[info.name] = new_attr;
-        continue;
-      }
       auto legacy_attr_name =
           op_normalizer.GetLegacyAttrName(op_desc.Type(), info.name);
       std::cout << "[op: " << op_desc.Type()
@@ -3951,17 +3946,12 @@ struct SoftPlusOpTranscriber : public OpTranscriber {
         pir::Attribute new_attr =
             attribute_translator(info.type_name, legacy_attr);
         if (legacy_attr_name == "beta" || legacy_attr_name == "threshold") {
-          attribute_map[info.name] = pir::DoubleAttribute::get(
+          new_attr = pir::DoubleAttribute::get(
               ctx,
               static_cast<double>(
                   new_attr.dyn_cast<pir::FloatAttribute>().data()));
-        } else {
-          attribute_map[info.name] = new_attr;
-          if (!new_attr) {
-            VLOG(0) << "empty attribute in " << op_desc.Type()
-                    << " name: " << info.name;
-          }
         }
+        attribute_map[info.name] = new_attr;
       } else {
         VLOG(10) << "attribute in " << op_desc.Type()
                  << " name: " << legacy_attr_name << " doesn't exist";

--- a/paddle/fluid/ir_adaptor/translator/op_translator.cc
+++ b/paddle/fluid/ir_adaptor/translator/op_translator.cc
@@ -3921,6 +3921,55 @@ struct SyncCommStreamOpTranscriber : public OpTranscriber {
   }
 };
 
+struct SoftPlusOpTranscriber : public OpTranscriber {
+  pir::AttributeMap TranslateOpAttribute(
+      pir::IrContext* ctx,
+      const std::string& normalized_op_name,
+      const OpAttributeInfoList& op_attr_infos,
+      const OpDesc& op_desc) override {
+    auto& attribute_translator = AttributeTranslator::instance();
+    auto& op_normalizer = OpNameNormalizer::instance();
+    pir::AttributeMap attribute_map = {};
+
+    for (const auto& info : op_attr_infos) {
+      if (auto handler = this->GetSpecialAttributeHandlers(info.name)) {
+        auto new_attr = handler(ctx, op_desc, info);
+        attribute_map[info.name] = new_attr;
+        continue;
+      }
+      auto legacy_attr_name =
+          op_normalizer.GetLegacyAttrName(op_desc.Type(), info.name);
+      VLOG(10) << "[op: " << op_desc.Type()
+               << "][attr] from: " << legacy_attr_name << " to: " << info.name;
+      if (op_desc.HasAttr(legacy_attr_name)) {
+        paddle::framework::Attribute legacy_attr =
+            op_desc.GetAttr(legacy_attr_name);
+        VLOG(10) << "attribute in " << op_desc.Type()
+                 << " name: " << legacy_attr_name << " " << legacy_attr.index();
+        pir::Attribute new_attr =
+            attribute_translator(info.type_name, legacy_attr);
+        if (legacy_attr_name == "beta" || legacy_attr_name == "threshold") {
+          new_attr = pir::DoubleAttribute::get(
+              ctx,
+              static_cast<double>(
+                  new_attr.dyn_cast<pir::FloatAttribute>().data()));
+        }
+        attribute_map[info.name] = new_attr;
+        if (!new_attr) {
+          VLOG(0) << "empty attribute in " << op_desc.Type()
+                  << " name: " << info.name;
+        }
+      } else {
+        VLOG(10) << "attribute in " << op_desc.Type()
+                 << " name: " << legacy_attr_name << " doesn't exist";
+        this->HandleNonexistentAttribute(ctx, &attribute_map, info);
+      }
+    }
+
+    return attribute_map;
+  }
+};
+
 OpTranslator::OpTranslator() {
   pir::IrContext* ctx = pir::IrContext::Instance();
   ctx->GetOrRegisterDialect<paddle::dialect::OperatorDialect>();
@@ -4033,5 +4082,6 @@ OpTranslator::OpTranslator() {
       WithXShapeAndAxisGradOpTranscriber<dialect::UnsqueezeGradOp>();
 
   special_handlers["c_sync_comm_stream"] = SyncCommStreamOpTranscriber();
+  special_handlers["softplus"] = SoftPlusOpTranscriber();
 }
 }  // namespace paddle::translator

--- a/paddle/fluid/ir_adaptor/translator/op_translator.cc
+++ b/paddle/fluid/ir_adaptor/translator/op_translator.cc
@@ -3953,12 +3953,9 @@ struct SoftPlusOpTranscriber : public OpTranscriber {
         }
         attribute_map[info.name] = new_attr;
       } else {
-        VLOG(10) << "attribute in " << op_desc.Type()
-                 << " name: " << legacy_attr_name << " doesn't exist";
         this->HandleNonexistentAttribute(ctx, &attribute_map, info);
       }
     }
-
     return attribute_map;
   }
 };

--- a/paddle/fluid/operators/activation_op.cc
+++ b/paddle/fluid/operators/activation_op.cc
@@ -337,7 +337,7 @@ REGISTER_OP_VERSION(softplus).AddCheckpoint(
          " softplus(x) = \\frac{1}{beta} * \\log(1 + e^{beta * x}) \\\\ \\text{For numerical"
          " stability, the implementation reverts to the linear function when: beta * x > threshold.})ROC",
     paddle::framework::compatible::OpVersionDesc()
-        .NewAttr("beta", "The beta value of the new formula", 1.0)
-        .NewAttr("threshold", "The threshold value of the new formula", 20.0));
+        .NewAttr("beta", "The beta value of the new formula", 1.0f)
+        .NewAttr("threshold", "The threshold value of the new formula", 20.0f));
 
 /* ========================================================================== */

--- a/paddle/fluid/operators/activation_op.cc
+++ b/paddle/fluid/operators/activation_op.cc
@@ -337,7 +337,7 @@ REGISTER_OP_VERSION(softplus).AddCheckpoint(
          " softplus(x) = \\frac{1}{beta} * \\log(1 + e^{beta * x}) \\\\ \\text{For numerical"
          " stability, the implementation reverts to the linear function when: beta * x > threshold.})ROC",
     paddle::framework::compatible::OpVersionDesc()
-        .NewAttr("beta", "The beta value of the new formula", 1.0f)
-        .NewAttr("threshold", "The threshold value of the new formula", 20.0f));
+        .NewAttr("beta", "The beta value of the new formula", 1.0)
+        .NewAttr("threshold", "The threshold value of the new formula", 20.0));
 
 /* ========================================================================== */

--- a/paddle/fluid/pir/drr/include/drr_pattern_context.h
+++ b/paddle/fluid/pir/drr/include/drr_pattern_context.h
@@ -297,6 +297,8 @@ class TEST_API ResultPattern {
 
   Attribute Float32Attr(float value) const;
 
+  Attribute DoubleAttr(double value) const;
+
   Attribute VectorInt64Attr(const std::vector<int64_t>& value) const;
 
   Attribute VectorInt32Attr(const std::vector<int32_t>& value) const;

--- a/paddle/fluid/pir/drr/src/pattern_context.cc
+++ b/paddle/fluid/pir/drr/src/pattern_context.cc
@@ -205,6 +205,11 @@ Attribute ResultPattern::Float32Attr(float value) const {
       [=](const MatchContext& match_ctx) -> float { return value; });
 }
 
+Attribute ResultPattern::DoubleAttr(double value) const {
+  return ComputeAttr(
+      [=](const MatchContext& match_ctx) -> double { return value; });
+}
+
 Attribute ResultPattern::VectorInt64Attr(
     const std::vector<int64_t>& value) const {
   return ComputeAttr(

--- a/paddle/fluid/pir/serialize_deserialize/0.yaml
+++ b/paddle/fluid/pir/serialize_deserialize/0.yaml
@@ -1,0 +1,29 @@
+op_patches:
+  - op_name : pd_op.softplus
+    actions:
+      - action : modify_attr
+        object : beta
+        type : pir::DoubleAttribute
+        data : 1.0
+      - action : modify_attr
+        object : threshold
+        type : pir::DoubleAttribute
+        data : 20.0
+  - op_name : onednn_op.fused_softplus
+    actions:
+      - action : modify_attr
+        object : beta
+        type : pir::DoubleAttribute
+        data : 1.0
+      - action : modify_attr
+        object : threshold
+        type : pir::DoubleAttribute
+        data : 20.0
+      - action : modify_attr
+        object : fuse_alpha
+        type : pir::DoubleAttribute
+        data : 0.0
+      - action : modify_attr
+        object : fuse_beta
+        type : pir::DoubleAttribute
+        data : 0.0

--- a/paddle/fluid/pir/serialize_deserialize/CMakeLists.txt
+++ b/paddle/fluid/pir/serialize_deserialize/CMakeLists.txt
@@ -13,7 +13,7 @@ endif()
 
 file(GLOB_RECURSE YAML_PATCH_FILES "*.yaml")
 # change pir version when new patches are added
-add_definitions(-DDEVELOP_VERSION=3)
+add_definitions(-DDEVELOP_VERSION=0)
 add_definitions(-DRELEASE_VERSION=3)
 set(TEMPLATE_FILE ${CMAKE_CURRENT_SOURCE_DIR}/patch/template.h.in)
 set(PATCH_HEADER ${CMAKE_CURRENT_BINARY_DIR}/patch/patch.h)

--- a/paddle/fluid/pir/transforms/onednn/softplus_activation_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/softplus_activation_fuse_pass.cc
@@ -120,24 +120,36 @@ class SoftplusActivationFusePattern : public paddle::drr::DrrPatternBase {
         {"beta", pat.Attr("beta")}, {"threshold", pat.Attr("threshold")}};
 
     if (act_type_ == paddle::dialect::HardswishOp::name()) {
-      fused_attrs.emplace("fuse_alpha", res.Float32Attr(1.0f / 6.0f));
-      fused_attrs.emplace("fuse_beta", res.Float32Attr(1.0f / 2.0f));
+      fused_attrs.emplace("fuse_alpha", res.DoubleAttr(1.0f / 6.0));
+      fused_attrs.emplace("fuse_beta", res.DoubleAttr(1.0f / 2.0));
     } else if (act_type_ == paddle::dialect::HardsigmoidOp::name()) {
-      fused_attrs.emplace("fuse_alpha", pat.Attr("fuse_alpha"));
-      fused_attrs.emplace("fuse_beta", pat.Attr("fuse_beta"));
+      const auto &fuse_alpha = res.ComputeAttr(
+          [](const paddle::drr::MatchContext &match_ctx) -> double {
+            return static_cast<double>(match_ctx.Attr<float>("fuse_alpha"));
+          });
+      const auto &fuse_beta = res.ComputeAttr(
+          [](const paddle::drr::MatchContext &match_ctx) -> double {
+            return static_cast<double>(match_ctx.Attr<float>("fuse_beta"));
+          });
+      fused_attrs.emplace("fuse_alpha", fuse_alpha);
+      fused_attrs.emplace("fuse_beta", fuse_beta);
     } else if (act_type_ == paddle::dialect::LeakyRelu_Op::name() ||
                act_type_ == paddle::dialect::LeakyReluOp::name()) {
-      fused_attrs.emplace("fuse_alpha", pat.Attr("fuse_alpha"));
+      const auto &fuse_alpha = res.ComputeAttr(
+          [](const paddle::drr::MatchContext &match_ctx) -> double {
+            return static_cast<double>(match_ctx.Attr<float>("fuse_alpha"));
+          });
+      fused_attrs.emplace("fuse_alpha", fuse_alpha);
     } else if (act_type_ == paddle::dialect::SwishOp::name()) {
-      fused_attrs.emplace("fuse_alpha", res.Float32Attr(1.0f));
+      fused_attrs.emplace("fuse_alpha", res.DoubleAttr(1.0));
     } else if (act_type_ == paddle::dialect::Relu6Op::name()) {
-      fused_attrs.emplace("fuse_beta", res.Float32Attr(6.0f));
+      fused_attrs.emplace("fuse_beta", res.DoubleAttr(6.0));
     }
 
     fused_attrs.insert(std::make_pair("fuse_activation",
                                       res.StrAttr(activation_type[act_type_])));
-    fused_attrs.insert(std::make_pair("fuse_alpha", res.Float32Attr(0.0f)));
-    fused_attrs.insert(std::make_pair("fuse_beta", res.Float32Attr(0.0f)));
+    fused_attrs.insert(std::make_pair("fuse_alpha", res.DoubleAttr(0.0)));
+    fused_attrs.insert(std::make_pair("fuse_beta", res.DoubleAttr(0.0)));
 
     const auto &fused_softplus = res.Op(fused_softplus_name_, fused_attrs);
 
@@ -188,8 +200,8 @@ class SoftplusGeluTanhFusePattern : public paddle::drr::DrrPatternBase {
         {"beta", pat.Attr("beta")},
         {"threshold", pat.Attr("threshold")},
         {"fuse_activation", res.StrAttr("gelu_tanh")},
-        {"fuse_alpha", res.Float32Attr(0.0f)},
-        {"fuse_beta", res.Float32Attr(0.0f)}};
+        {"fuse_alpha", res.DoubleAttr(0.0)},
+        {"fuse_beta", res.DoubleAttr(0.0)}};
 
     const auto &fused_softplus = res.Op(fused_softplus_name_, fused_attrs);
 
@@ -244,11 +256,11 @@ class SoftplusClipFusePattern : public paddle::drr::DrrPatternBase {
     paddle::drr::ResultPattern res = pat.ResultPattern();
 
     const auto &fuse_alpha = res.ComputeAttr(
-        [](const paddle::drr::MatchContext &match_ctx) -> float {
+        [](const paddle::drr::MatchContext &match_ctx) -> double {
           return match_ctx.Attr<double>("value1");
         });
     const auto &fuse_beta = res.ComputeAttr(
-        [](const paddle::drr::MatchContext &match_ctx) -> float {
+        [](const paddle::drr::MatchContext &match_ctx) -> double {
           return match_ctx.Attr<double>("value2");
         });
 

--- a/paddle/fluid/pybind/pir.cc
+++ b/paddle/fluid/pybind/pir.cc
@@ -3287,6 +3287,12 @@ void BindDrrPatternContext(pybind11::module *m) {
           },
           pybind11::arg("value"))
       .def(
+          "DoubleAttr",
+          [](drr::ResultPattern &self, double value) {
+            return self.DoubleAttr(value);
+          },
+          pybind11::arg("value"))
+      .def(
           "VectorInt32Attr",
           [](drr::ResultPattern &self, const std::vector<int32_t> &value) {
             return self.VectorInt32Attr(value);

--- a/paddle/phi/infermeta/spmd_rules/elementwise.cc
+++ b/paddle/phi/infermeta/spmd_rules/elementwise.cc
@@ -708,15 +708,15 @@ SpmdInfo StanhGradInfoSpmd(const DistMetaTensor& x,
 
 // softplus
 SpmdInfo SoftplusInfoSpmd(const DistMetaTensor& x,
-                          const float beta,
-                          const float threshold) {
+                          const double beta,
+                          const double threshold) {
   return ElementwiseUnaryInferSpmd(x);
 }
 
 SpmdInfo SoftplusGradInfoSpmd(const DistMetaTensor& x,
                               const DistMetaTensor& out_grad,
-                              const float beta,
-                              const float threshold) {
+                              const double beta,
+                              const double threshold) {
   return ElementwiseUnaryGradInferSpmd(x, out_grad);
 }
 

--- a/paddle/phi/infermeta/spmd_rules/elementwise.h
+++ b/paddle/phi/infermeta/spmd_rules/elementwise.h
@@ -104,12 +104,12 @@ SpmdInfo StanhGradInfoSpmd(const DistMetaTensor& x,
                            const float scale_b);
 
 SpmdInfo SoftplusInfoSpmd(const DistMetaTensor& x,
-                          const float beta,
-                          const float threshold);
+                          const double beta,
+                          const double threshold);
 SpmdInfo SoftplusGradInfoSpmd(const DistMetaTensor& x,
                               const DistMetaTensor& out_grad,
-                              const float beta,
-                              const float threshold);
+                              const double beta,
+                              const double threshold);
 
 SpmdInfo SoftshrinkInfoSpmd(const DistMetaTensor& x, const float threshold);
 SpmdInfo SoftshrinkGradInfoSpmd(const DistMetaTensor& x,

--- a/paddle/phi/kernels/activation_grad_kernel.h
+++ b/paddle/phi/kernels/activation_grad_kernel.h
@@ -45,6 +45,15 @@ namespace phi {
                         float attr2,                                    \
                         DenseTensor* dx);
 
+#define DECLARE_ACT_GRAD_KERNEL_WITH_TWO_DOUBLE_ATTRS_DEPX(name, attr1, attr2) \
+  template <typename T, typename Context>                                      \
+  void name##GradKernel(const Context& dev_ctx,                                \
+                        const DenseTensor& x,                                  \
+                        const DenseTensor& dout,                               \
+                        double attr1,                                          \
+                        double attr2,                                          \
+                        DenseTensor* dx);
+
 #define DECLARE_ACTIVATION_GRAD_KERNEL_DEPOUT(name) \
   template <typename T, typename Context>           \
   void name##GradKernel(const Context& dev_ctx,     \
@@ -271,13 +280,6 @@ void SoftplusDoubleGradKernel(const Context& dev_ctx,
                               DenseTensor* dx,
                               DenseTensor* ddout);
 
-template <typename T, typename Context>
-void SoftplusGradKernel(const Context& dev_ctx,
-                        const DenseTensor& x,
-                        const DenseTensor& dout,
-                        double beta,
-                        double threshold,
-                        DenseTensor* dx);
 DECLARE_ACTIVATION_GRAD_KERNEL_DEPX(Cos);
 DECLARE_ACTIVATION_GRAD_KERNEL_DEPX(Tan);
 DECLARE_ACTIVATION_GRAD_KERNEL_DEPX(Acos);
@@ -324,6 +326,7 @@ DECLARE_ACT_GRAD_KERNEL_WITH_ONE_ATTRS_DEPOUT(LogitCUDA, eps);
 
 DECLARE_ACT_GRAD_KERNEL_WITH_TWO_ATTRS_DEPX(HardTanh, t_min, t_max);
 DECLARE_ACT_GRAD_KERNEL_WITH_TWO_ATTRS_DEPX(STanh, scale_a, scale_b);
+DECLARE_ACT_GRAD_KERNEL_WITH_TWO_DOUBLE_ATTRS_DEPX(Softplus, beta, threshold);
 DECLARE_ACT_GRAD_KERNEL_WITH_TWO_ATTRS_DEPOUT(HardSigmoid, slope, offset);
 DECLARE_ACT_GRAD_KERNEL_WITH_TWO_ATTRS_DEPX(ThresholdedRelu, threshold, value);
 

--- a/paddle/phi/kernels/activation_grad_kernel.h
+++ b/paddle/phi/kernels/activation_grad_kernel.h
@@ -266,11 +266,18 @@ void SoftplusDoubleGradKernel(const Context& dev_ctx,
                               const DenseTensor& x,
                               const DenseTensor& dout,
                               const DenseTensor& ddx,
-                              float beta,
-                              float threshold,
+                              double beta,
+                              double threshold,
                               DenseTensor* dx,
                               DenseTensor* ddout);
 
+template <typename T, typename Context>
+void SoftplusGradKernel(const Context& dev_ctx,
+                        const DenseTensor& x,
+                        const DenseTensor& dout,
+                        double beta,
+                        double threshold,
+                        DenseTensor* dx);
 DECLARE_ACTIVATION_GRAD_KERNEL_DEPX(Cos);
 DECLARE_ACTIVATION_GRAD_KERNEL_DEPX(Tan);
 DECLARE_ACTIVATION_GRAD_KERNEL_DEPX(Acos);
@@ -317,7 +324,6 @@ DECLARE_ACT_GRAD_KERNEL_WITH_ONE_ATTRS_DEPOUT(LogitCUDA, eps);
 
 DECLARE_ACT_GRAD_KERNEL_WITH_TWO_ATTRS_DEPX(HardTanh, t_min, t_max);
 DECLARE_ACT_GRAD_KERNEL_WITH_TWO_ATTRS_DEPX(STanh, scale_a, scale_b);
-DECLARE_ACT_GRAD_KERNEL_WITH_TWO_ATTRS_DEPX(Softplus, beta, threshold);
 DECLARE_ACT_GRAD_KERNEL_WITH_TWO_ATTRS_DEPOUT(HardSigmoid, slope, offset);
 DECLARE_ACT_GRAD_KERNEL_WITH_TWO_ATTRS_DEPX(ThresholdedRelu, threshold, value);
 

--- a/paddle/phi/kernels/activation_kernel.h
+++ b/paddle/phi/kernels/activation_kernel.h
@@ -40,6 +40,14 @@ namespace phi {
                     float attr2,                                     \
                     DenseTensor* out);
 
+#define DECLARE_ACTIVATION_KERNEL_WITH_TWO_DOUBLE_ATTRS(name, attr1, attr2) \
+  template <typename T, typename Context>                                   \
+  void name##Kernel(const Context& dev_ctx,                                 \
+                    const DenseTensor& x,                                   \
+                    double attr1,                                           \
+                    double attr2,                                           \
+                    DenseTensor* out);
+
 DECLARE_ACTIVATION_KERNEL(Sin)
 DECLARE_ACTIVATION_KERNEL(Cos)
 DECLARE_ACTIVATION_KERNEL(Tan)
@@ -83,15 +91,9 @@ DECLARE_ACTIVATION_KERNEL_WITH_ONE_ATTRS(Logit, eps)
 
 DECLARE_ACTIVATION_KERNEL_WITH_TWO_ATTRS(HardTanh, t_min, t_max)
 DECLARE_ACTIVATION_KERNEL_WITH_TWO_ATTRS(STanh, scale_a, scale_b)
+DECLARE_ACTIVATION_KERNEL_WITH_TWO_DOUBLE_ATTRS(Softplus, beta, threshold)
 DECLARE_ACTIVATION_KERNEL_WITH_TWO_ATTRS(HardSigmoid, slope, offset)
 DECLARE_ACTIVATION_KERNEL_WITH_TWO_ATTRS(ThresholdedRelu, threshold, value)
-
-template <typename T, typename Context>
-void SoftplusKernel(const Context& dev_ctx,
-                    const DenseTensor& x,
-                    double beta,
-                    double threshold,
-                    DenseTensor* out);
 
 template <typename T, typename Context>
 void HardSwishKernel(const Context& dev_ctx,

--- a/paddle/phi/kernels/activation_kernel.h
+++ b/paddle/phi/kernels/activation_kernel.h
@@ -83,9 +83,15 @@ DECLARE_ACTIVATION_KERNEL_WITH_ONE_ATTRS(Logit, eps)
 
 DECLARE_ACTIVATION_KERNEL_WITH_TWO_ATTRS(HardTanh, t_min, t_max)
 DECLARE_ACTIVATION_KERNEL_WITH_TWO_ATTRS(STanh, scale_a, scale_b)
-DECLARE_ACTIVATION_KERNEL_WITH_TWO_ATTRS(Softplus, beta, threshold)
 DECLARE_ACTIVATION_KERNEL_WITH_TWO_ATTRS(HardSigmoid, slope, offset)
 DECLARE_ACTIVATION_KERNEL_WITH_TWO_ATTRS(ThresholdedRelu, threshold, value)
+
+template <typename T, typename Context>
+void SoftplusKernel(const Context& dev_ctx,
+                    const DenseTensor& x,
+                    double beta,
+                    double threshold,
+                    DenseTensor* out);
 
 template <typename T, typename Context>
 void HardSwishKernel(const Context& dev_ctx,

--- a/paddle/phi/kernels/cpu/activation_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/activation_grad_kernel.cc
@@ -64,6 +64,23 @@ namespace phi {
         dev_ctx, &x, nullptr, &dout, dx, functor);           \
   }
 
+#define DEFINE_CPU_ACT_GRAD_KERNEL_WITH_TWO_DOUBLE_ATTRS_DEPX( \
+    name, functor_class, attr1, attr2)                         \
+  template <typename T, typename Context>                      \
+  void name##GradKernel(const Context& dev_ctx,                \
+                        const DenseTensor& x,                  \
+                        const DenseTensor& dout,               \
+                        double attr1,                          \
+                        double attr2,                          \
+                        DenseTensor* dx) {                     \
+    funcs::functor_class<T> functor;                           \
+    auto attrs = functor.GetAttrs();                           \
+    *(attrs[0].second) = attr1;                                \
+    *(attrs[1].second) = attr2;                                \
+    ActivationGradImpl<T, Context, funcs::functor_class<T>>(   \
+        dev_ctx, &x, nullptr, &dout, dx, functor);             \
+  }
+
 #define DEFINE_CPU_ACTIVATION_GRAD_KERNEL_DEPOUT(name, functor_class) \
   template <typename T, typename Context>                             \
   void name##GradKernel(const Context& dev_ctx,                       \
@@ -178,7 +195,10 @@ DEFINE_CPU_ACT_GRAD_KERNEL_WITH_TWO_ATTRS_DEPX(STanh,
                                                STanhGradFunctor,
                                                scale_a,
                                                scale_b);
-
+DEFINE_CPU_ACT_GRAD_KERNEL_WITH_TWO_DOUBLE_ATTRS_DEPX(Softplus,
+                                                      SoftplusGradFunctor,
+                                                      beta,
+                                                      threshold);
 DEFINE_CPU_ACT_GRAD_KERNEL_WITH_TWO_ATTRS_DEPOUT(HardSigmoid,
                                                  HardSigmoidGradFunctor,
                                                  slope,
@@ -187,21 +207,6 @@ DEFINE_CPU_ACT_GRAD_KERNEL_WITH_TWO_ATTRS_DEPX(ThresholdedRelu,
                                                ThresholdedReluGradFunctor,
                                                threshold,
                                                value);
-
-template <typename T, typename Context>
-void SoftplusGradKernel(const Context& dev_ctx,
-                        const DenseTensor& x,
-                        const DenseTensor& dout,
-                        double beta,
-                        double threshold,
-                        DenseTensor* dx) {
-  funcs::SoftplusGradFunctor<T> functor;
-  auto attrs = functor.GetAttrs();
-  *(attrs[0].second) = beta;
-  *(attrs[1].second) = threshold;
-  ActivationGradImpl<T, Context, funcs::SoftplusGradFunctor<T>>(
-      dev_ctx, &x, nullptr, &dout, dx, functor);
-}
 
 template <typename T, typename Context>
 void SiluGradKernel(const Context& dev_ctx,

--- a/paddle/phi/kernels/cpu/activation_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/activation_grad_kernel.cc
@@ -179,10 +179,6 @@ DEFINE_CPU_ACT_GRAD_KERNEL_WITH_TWO_ATTRS_DEPX(STanh,
                                                scale_a,
                                                scale_b);
 
-DEFINE_CPU_ACT_GRAD_KERNEL_WITH_TWO_ATTRS_DEPX(Softplus,
-                                               SoftplusGradFunctor,
-                                               beta,
-                                               threshold);
 DEFINE_CPU_ACT_GRAD_KERNEL_WITH_TWO_ATTRS_DEPOUT(HardSigmoid,
                                                  HardSigmoidGradFunctor,
                                                  slope,
@@ -191,6 +187,21 @@ DEFINE_CPU_ACT_GRAD_KERNEL_WITH_TWO_ATTRS_DEPX(ThresholdedRelu,
                                                ThresholdedReluGradFunctor,
                                                threshold,
                                                value);
+
+template <typename T, typename Context>
+void SoftplusGradKernel(const Context& dev_ctx,
+                        const DenseTensor& x,
+                        const DenseTensor& dout,
+                        double beta,
+                        double threshold,
+                        DenseTensor* dx) {
+  funcs::SoftplusGradFunctor<T> functor;
+  auto attrs = functor.GetAttrs();
+  *(attrs[0].second) = beta;
+  *(attrs[1].second) = threshold;
+  ActivationGradImpl<T, Context, funcs::SoftplusGradFunctor<T>>(
+      dev_ctx, &x, nullptr, &dout, dx, functor);
+}
 
 template <typename T, typename Context>
 void SiluGradKernel(const Context& dev_ctx,

--- a/paddle/phi/kernels/cpu/activation_kernel.cc
+++ b/paddle/phi/kernels/cpu/activation_kernel.cc
@@ -115,7 +115,6 @@ DEFINE_CPU_ACT_KERNEL_WITH_ONE_ATTRS(Celu, CELUFunctor, alpha)
 
 DEFINE_CPU_ACT_KERNEL_WITH_TWO_ATTRS(HardTanh, HardTanhFunctor, t_min, t_max)
 DEFINE_CPU_ACT_KERNEL_WITH_TWO_ATTRS(STanh, STanhFunctor, scale_a, scale_b)
-DEFINE_CPU_ACT_KERNEL_WITH_TWO_ATTRS(Softplus, SoftplusFunctor, beta, threshold)
 DEFINE_CPU_ACT_KERNEL_WITH_TWO_ATTRS(HardSigmoid,
                                      HardSigmoidFunctor,
                                      slope,
@@ -124,6 +123,20 @@ DEFINE_CPU_ACT_KERNEL_WITH_TWO_ATTRS(ThresholdedRelu,
                                      ThresholdedReluFunctor,
                                      threshold,
                                      value)
+
+template <typename T, typename Context>
+void SoftplusKernel(const Context& dev_ctx,
+                    const DenseTensor& x,
+                    double beta,
+                    double threshold,
+                    DenseTensor* out) {
+  funcs::SoftplusFunctor<T> functor;
+  auto attrs = functor.GetAttrs();
+  *(attrs[0].second) = beta;
+  *(attrs[1].second) = threshold;
+  ActivationImpl<T, T, Context, funcs::SoftplusFunctor<T>>(
+      dev_ctx, x, out, functor);
+}
 
 template <typename T, typename Context>
 void HardSwishKernel(const Context& dev_ctx,

--- a/paddle/phi/kernels/cpu/activation_kernel.cc
+++ b/paddle/phi/kernels/cpu/activation_kernel.cc
@@ -72,6 +72,22 @@ namespace phi {
         dev_ctx, x, out, functor);                          \
   }
 
+#define DEFINE_CPU_ACT_KERNEL_WITH_TWO_DOUBLE_ATTRS(        \
+    name, functor_class, attr1, attr2)                      \
+  template <typename T, typename Context>                   \
+  void name##Kernel(const Context& dev_ctx,                 \
+                    const DenseTensor& x,                   \
+                    double attr1,                           \
+                    double attr2,                           \
+                    DenseTensor* out) {                     \
+    funcs::functor_class<T> functor;                        \
+    auto attrs = functor.GetAttrs();                        \
+    *(attrs[0].second) = attr1;                             \
+    *(attrs[1].second) = attr2;                             \
+    ActivationImpl<T, T, Context, funcs::functor_class<T>>( \
+        dev_ctx, x, out, functor);                          \
+  }
+
 DEFINE_CPU_ACTIVATION_KERNEL(Sin, SinFunctor)
 DEFINE_CPU_ACTIVATION_KERNEL(Cos, CosFunctor)
 DEFINE_CPU_ACTIVATION_KERNEL(Tan, TanFunctor)
@@ -115,6 +131,10 @@ DEFINE_CPU_ACT_KERNEL_WITH_ONE_ATTRS(Celu, CELUFunctor, alpha)
 
 DEFINE_CPU_ACT_KERNEL_WITH_TWO_ATTRS(HardTanh, HardTanhFunctor, t_min, t_max)
 DEFINE_CPU_ACT_KERNEL_WITH_TWO_ATTRS(STanh, STanhFunctor, scale_a, scale_b)
+DEFINE_CPU_ACT_KERNEL_WITH_TWO_DOUBLE_ATTRS(Softplus,
+                                            SoftplusFunctor,
+                                            beta,
+                                            threshold)
 DEFINE_CPU_ACT_KERNEL_WITH_TWO_ATTRS(HardSigmoid,
                                      HardSigmoidFunctor,
                                      slope,
@@ -123,20 +143,6 @@ DEFINE_CPU_ACT_KERNEL_WITH_TWO_ATTRS(ThresholdedRelu,
                                      ThresholdedReluFunctor,
                                      threshold,
                                      value)
-
-template <typename T, typename Context>
-void SoftplusKernel(const Context& dev_ctx,
-                    const DenseTensor& x,
-                    double beta,
-                    double threshold,
-                    DenseTensor* out) {
-  funcs::SoftplusFunctor<T> functor;
-  auto attrs = functor.GetAttrs();
-  *(attrs[0].second) = beta;
-  *(attrs[1].second) = threshold;
-  ActivationImpl<T, T, Context, funcs::SoftplusFunctor<T>>(
-      dev_ctx, x, out, functor);
-}
 
 template <typename T, typename Context>
 void HardSwishKernel(const Context& dev_ctx,

--- a/paddle/phi/kernels/funcs/activation_functor.h
+++ b/paddle/phi/kernels/funcs/activation_functor.h
@@ -843,10 +843,11 @@ struct RsqrtGradFunctor : public BaseActivationFunctor<T> {
 
 template <typename T>
 struct SoftplusFunctor : public BaseActivationFunctor<T> {
-  float beta;
-  float threshold;
+  using AttrPair = std::vector<std::pair<const char*, double*>>;
+  double beta;
+  double threshold;
 
-  typename BaseActivationFunctor<T>::AttrPair GetAttrs() {
+  typename SoftplusFunctor<T>::AttrPair GetAttrs() {
     return {{"beta", &beta}, {"threshold", &threshold}};
   }
 
@@ -888,9 +889,10 @@ struct SoftplusFunctor<ComplexType<T>>
 
 template <typename T>
 struct SoftplusGradFunctor : public BaseActivationFunctor<T> {
-  float beta;
-  float threshold;
-  typename BaseActivationFunctor<T>::AttrPair GetAttrs() {
+  using AttrPair = std::vector<std::pair<const char*, double*>>;
+  double beta;
+  double threshold;
+  typename SoftplusGradFunctor<T>::AttrPair GetAttrs() {
     return {{"beta", &beta}, {"threshold", &threshold}};
   }
   template <typename Device,
@@ -911,9 +913,10 @@ struct SoftplusGradFunctor : public BaseActivationFunctor<T> {
 template <typename T>
 struct SoftplusGradFunctor<ComplexType<T>>
     : public BaseActivationFunctor<ComplexType<T>> {
-  float beta;
-  float threshold;
-  typename BaseActivationFunctor<ComplexType<T>>::AttrPair GetAttrs() {
+  using AttrPair = std::vector<std::pair<const char*, double*>>;
+  double beta;
+  double threshold;
+  typename SoftplusGradFunctor<ComplexType<T>>::AttrPair GetAttrs() {
     return {{"beta", &beta}, {"threshold", &threshold}};
   }
   template <typename Device,
@@ -935,9 +938,10 @@ struct SoftplusGradFunctor<ComplexType<T>>
 
 template <typename T>
 struct SoftplusDoubleGradFunctor : public BaseActivationFunctor<T> {
-  float beta;
-  float threshold;
-  typename BaseActivationFunctor<T>::AttrPair GetAttrs() {
+  using AttrPair = std::vector<std::pair<const char*, double*>>;
+  double beta;
+  double threshold;
+  typename SoftplusDoubleGradFunctor<T>::AttrPair GetAttrs() {
     return {{"beta", &beta}, {"threshold", &threshold}};
   }
   template <typename Device>
@@ -4279,11 +4283,12 @@ __device__ __forceinline__ ComplexType<T> log1p_local(ComplexType<T> x) {
 
 template <typename T>
 struct CudaSoftplusFunctor : public BaseActivationFunctor<T> {
+  using AttrPair = std::vector<std::pair<const char*, double*>>;
   using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
-  float beta;
-  float threshold;
+  double beta;
+  double threshold;
 
-  typename BaseActivationFunctor<T>::AttrPair GetAttrs() {
+  typename CudaSoftplusFunctor<T>::AttrPair GetAttrs() {
     return {{"beta", &beta}, {"threshold", &threshold}};
   }
 
@@ -4322,12 +4327,13 @@ struct CudaSoftplusFunctor<ComplexType<T>>
 
 template <typename T>
 struct CudaSoftplusGradFunctor : public BaseActivationFunctor<T> {
+  using AttrPair = std::vector<std::pair<const char*, double*>>;
   using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
   MPType one = static_cast<MPType>(1.0f);
-  float beta;
-  float threshold;
+  double beta;
+  double threshold;
 
-  typename BaseActivationFunctor<T>::AttrPair GetAttrs() {
+  typename CudaSoftplusGradFunctor<T>::AttrPair GetAttrs() {
     return {{"beta", &beta}, {"threshold", &threshold}};
   }
 
@@ -4348,12 +4354,13 @@ struct CudaSoftplusGradFunctor : public BaseActivationFunctor<T> {
 template <typename T>
 struct CudaSoftplusGradFunctor<ComplexType<T>>
     : public BaseActivationFunctor<ComplexType<T>> {
+  using AttrPair = std::vector<std::pair<const char*, double*>>;
   using MPType = typename phi::dtype::MPTypeTrait<ComplexType<T>>::Type;
   MPType one = static_cast<MPType>(1.0f);
-  float beta;
-  float threshold;
+  double beta;
+  double threshold;
 
-  typename BaseActivationFunctor<ComplexType<T>>::AttrPair GetAttrs() {
+  typename CudaSoftplusGradFunctor<ComplexType<T>>::AttrPair GetAttrs() {
     return {{"beta", &beta}, {"threshold", &threshold}};
   }
 

--- a/paddle/phi/kernels/fusion/onednn/fused_softplus_kernel.cc
+++ b/paddle/phi/kernels/fusion/onednn/fused_softplus_kernel.cc
@@ -22,17 +22,21 @@ namespace phi::fusion {
 template <typename T, typename Context>
 void FusedSoftplusKernel(const Context& dev_ctx,
                          const DenseTensor& x,
-                         float beta,
-                         float threshold UNUSED,
+                         double beta,
+                         double threshold UNUSED,
                          const std::string& fuse_activation,
-                         const float fuse_alpha,
-                         const float fuse_beta,
+                         const double fuse_alpha,
+                         const double fuse_beta,
                          DenseTensor* out) {
+  float beta_f = static_cast<float>(beta);
+  float fuse_alpha_f = static_cast<float>(fuse_alpha);
+  float fuse_beta_f = static_cast<float>(fuse_beta);
+
   funcs::SoftplusOneDNNHandler<T> handler(
-      dev_ctx, &x, beta, fuse_activation, fuse_alpha, fuse_beta);
+      dev_ctx, &x, beta_f, fuse_activation, fuse_alpha_f, fuse_beta_f);
 
   auto src_memory_p = handler.AcquireSrcMemory(&x);
-  auto beta_memory_p = handler.AcquireBetaMemory(&beta);
+  auto beta_memory_p = handler.AcquireBetaMemory(&beta_f);
   std::shared_ptr<dnnl::memory> dst_memory_p = nullptr;
   if (x.IsSharedBufferWith(*out)) {
     dst_memory_p = src_memory_p;

--- a/paddle/phi/kernels/gpu/activation_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/activation_grad_kernel.cu
@@ -120,6 +120,23 @@ void ActivationGradGPUImpl(const Context& dev_ctx,
         dev_ctx, &x, nullptr, &dout, dx, functor);              \
   }
 
+#define DEFINE_GPU_ACT_GRAD_KERNEL_WITH_TWO_DOUBLE_ATTRS_DEPX(  \
+    name, functor_class, attr1, attr2)                          \
+  template <typename T, typename Context>                       \
+  void name##GradKernel(const Context& dev_ctx,                 \
+                        const DenseTensor& x,                   \
+                        const DenseTensor& dout,                \
+                        double attr1,                           \
+                        double attr2,                           \
+                        DenseTensor* dx) {                      \
+    funcs::functor_class<T> functor;                            \
+    auto attrs = functor.GetAttrs();                            \
+    *(attrs[0].second) = attr1;                                 \
+    *(attrs[1].second) = attr2;                                 \
+    ActivationGradGPUImpl<T, Context, funcs::functor_class<T>>( \
+        dev_ctx, &x, nullptr, &dout, dx, functor);              \
+  }
+
 #define DEFINE_GPU_ACTIVATION_GRAD_KERNEL_DEPOUT(name, functor_class) \
   template <typename T, typename Context>                             \
   void name##GradKernel(const Context& dev_ctx,                       \
@@ -239,6 +256,10 @@ DEFINE_GPU_ACT_GRAD_KERNEL_WITH_TWO_ATTRS_DEPX(STanh,
                                                scale_a,
                                                scale_b);
 
+DEFINE_GPU_ACT_GRAD_KERNEL_WITH_TWO_DOUBLE_ATTRS_DEPX(Softplus,
+                                                      CudaSoftplusGradFunctor,
+                                                      beta,
+                                                      threshold);
 DEFINE_GPU_ACT_GRAD_KERNEL_WITH_TWO_ATTRS_DEPOUT(HardSigmoid,
                                                  CudaHardSigmoidGradFunctor,
                                                  slope,
@@ -248,20 +269,6 @@ DEFINE_GPU_ACT_GRAD_KERNEL_WITH_TWO_ATTRS_DEPX(ThresholdedRelu,
                                                threshold,
                                                value);
 
-template <typename T, typename Context>
-void SoftplusGradKernel(const Context& dev_ctx,
-                        const DenseTensor& x,
-                        const DenseTensor& dout,
-                        double beta,
-                        double threshold,
-                        DenseTensor* dx) {
-  funcs::CudaSoftplusGradFunctor<T> functor;
-  auto attrs = functor.GetAttrs();
-  *(attrs[0].second) = beta;
-  *(attrs[1].second) = threshold;
-  ActivationGradGPUImpl<T, Context, funcs::CudaSoftplusGradFunctor<T>>(
-      dev_ctx, &x, nullptr, &dout, dx, functor);
-}
 template <typename T, typename Context>
 void SiluGradKernel(const Context& dev_ctx,
                     const DenseTensor& x,

--- a/paddle/phi/kernels/gpu/activation_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/activation_grad_kernel.cu
@@ -239,10 +239,6 @@ DEFINE_GPU_ACT_GRAD_KERNEL_WITH_TWO_ATTRS_DEPX(STanh,
                                                scale_a,
                                                scale_b);
 
-DEFINE_GPU_ACT_GRAD_KERNEL_WITH_TWO_ATTRS_DEPX(Softplus,
-                                               CudaSoftplusGradFunctor,
-                                               beta,
-                                               threshold);
 DEFINE_GPU_ACT_GRAD_KERNEL_WITH_TWO_ATTRS_DEPOUT(HardSigmoid,
                                                  CudaHardSigmoidGradFunctor,
                                                  slope,
@@ -251,6 +247,21 @@ DEFINE_GPU_ACT_GRAD_KERNEL_WITH_TWO_ATTRS_DEPX(ThresholdedRelu,
                                                CudaThresholdedReluGradFunctor,
                                                threshold,
                                                value);
+
+template <typename T, typename Context>
+void SoftplusGradKernel(const Context& dev_ctx,
+                        const DenseTensor& x,
+                        const DenseTensor& dout,
+                        double beta,
+                        double threshold,
+                        DenseTensor* dx) {
+  funcs::CudaSoftplusGradFunctor<T> functor;
+  auto attrs = functor.GetAttrs();
+  *(attrs[0].second) = beta;
+  *(attrs[1].second) = threshold;
+  ActivationGradGPUImpl<T, Context, funcs::CudaSoftplusGradFunctor<T>>(
+      dev_ctx, &x, nullptr, &dout, dx, functor);
+}
 template <typename T, typename Context>
 void SiluGradKernel(const Context& dev_ctx,
                     const DenseTensor& x,

--- a/paddle/phi/kernels/gpu/activation_kernel.cu
+++ b/paddle/phi/kernels/gpu/activation_kernel.cu
@@ -138,10 +138,6 @@ DEFINE_GPU_ACT_KERNEL_WITH_TWO_ATTRS(HardTanh,
                                      t_min,
                                      t_max)
 DEFINE_GPU_ACT_KERNEL_WITH_TWO_ATTRS(Stanh, CudaSTanhFunctor, scale_a, scale_b)
-DEFINE_GPU_ACT_KERNEL_WITH_TWO_ATTRS(Softplus,
-                                     CudaSoftplusFunctor,
-                                     beta,
-                                     threshold)
 DEFINE_GPU_ACT_KERNEL_WITH_TWO_ATTRS(HardSigmoid,
                                      CudaHardSigmoidFunctor,
                                      slope,
@@ -152,6 +148,19 @@ DEFINE_GPU_ACT_KERNEL_WITH_TWO_ATTRS(ThresholdedRelu,
                                      threshold,
                                      value)
 
+template <typename T, typename Context>
+void SoftplusKernel(const Context& dev_ctx,
+                    const DenseTensor& x,
+                    double beta,
+                    double threshold,
+                    DenseTensor* out) {
+  funcs::CudaSoftplusFunctor<T> functor;
+  auto attrs = functor.GetAttrs();
+  *(attrs[0].second) = beta;
+  *(attrs[1].second) = threshold;
+  ActivationGPUImpl<T, Context, funcs::CudaSoftplusFunctor<T>>(
+      dev_ctx, x, out, functor);
+}
 template <typename T, typename Context>
 void HardSwishKernel(const Context& dev_ctx,
                      const DenseTensor& x,

--- a/paddle/phi/kernels/gpu/activation_kernel.cu
+++ b/paddle/phi/kernels/gpu/activation_kernel.cu
@@ -90,6 +90,22 @@ void ActivationGPUImpl(const Context& dev_ctx,
         dev_ctx, x, out, functor);                          \
   }
 
+#define DEFINE_GPU_ACT_KERNEL_WITH_TWO_DOUBLE_ATTRS(        \
+    name, functor_class, attr1, attr2)                      \
+  template <typename T, typename Context>                   \
+  void name##Kernel(const Context& dev_ctx,                 \
+                    const DenseTensor& x,                   \
+                    double attr1,                           \
+                    double attr2,                           \
+                    DenseTensor* out) {                     \
+    funcs::functor_class<T> functor;                        \
+    auto attrs = functor.GetAttrs();                        \
+    *(attrs[0].second) = attr1;                             \
+    *(attrs[1].second) = attr2;                             \
+    ActivationGPUImpl<T, Context, funcs::functor_class<T>>( \
+        dev_ctx, x, out, functor);                          \
+  }
+
 DEFINE_GPU_ACTIVATION_KERNEL(Cos, CudaCosFunctor)
 DEFINE_GPU_ACTIVATION_KERNEL(Tan, CudaTanFunctor)
 DEFINE_GPU_ACTIVATION_KERNEL(Acos, CudaAcosFunctor)
@@ -138,6 +154,10 @@ DEFINE_GPU_ACT_KERNEL_WITH_TWO_ATTRS(HardTanh,
                                      t_min,
                                      t_max)
 DEFINE_GPU_ACT_KERNEL_WITH_TWO_ATTRS(Stanh, CudaSTanhFunctor, scale_a, scale_b)
+DEFINE_GPU_ACT_KERNEL_WITH_TWO_DOUBLE_ATTRS(Softplus,
+                                            CudaSoftplusFunctor,
+                                            beta,
+                                            threshold)
 DEFINE_GPU_ACT_KERNEL_WITH_TWO_ATTRS(HardSigmoid,
                                      CudaHardSigmoidFunctor,
                                      slope,
@@ -148,19 +168,6 @@ DEFINE_GPU_ACT_KERNEL_WITH_TWO_ATTRS(ThresholdedRelu,
                                      threshold,
                                      value)
 
-template <typename T, typename Context>
-void SoftplusKernel(const Context& dev_ctx,
-                    const DenseTensor& x,
-                    double beta,
-                    double threshold,
-                    DenseTensor* out) {
-  funcs::CudaSoftplusFunctor<T> functor;
-  auto attrs = functor.GetAttrs();
-  *(attrs[0].second) = beta;
-  *(attrs[1].second) = threshold;
-  ActivationGPUImpl<T, Context, funcs::CudaSoftplusFunctor<T>>(
-      dev_ctx, x, out, functor);
-}
 template <typename T, typename Context>
 void HardSwishKernel(const Context& dev_ctx,
                      const DenseTensor& x,

--- a/paddle/phi/kernels/impl/activation_grad_impl.h
+++ b/paddle/phi/kernels/impl/activation_grad_impl.h
@@ -607,8 +607,8 @@ void SoftplusDoubleGradKernel(const Context& dev_ctx,
                               const DenseTensor& x,
                               const DenseTensor& dout,
                               const DenseTensor& ddx,
-                              float beta,
-                              float threshold,
+                              double beta,
+                              double threshold,
                               DenseTensor* dx,
                               DenseTensor* ddout) {
   if (dx) {

--- a/paddle/phi/kernels/onednn/softplus_kernel.cc
+++ b/paddle/phi/kernels/onednn/softplus_kernel.cc
@@ -22,13 +22,14 @@ namespace phi {
 template <typename T, typename Context>
 void SoftplusKernel(const Context& dev_ctx,
                     const DenseTensor& x,
-                    float beta,
-                    float threshold UNUSED,
+                    double beta,
+                    double threshold UNUSED,
                     DenseTensor* out) {
-  funcs::SoftplusOneDNNHandler<T> handler(dev_ctx, &x, beta);
+  float beta_f = static_cast<float>(beta);
+  funcs::SoftplusOneDNNHandler<T> handler(dev_ctx, &x, beta_f);
 
   auto src_memory_p = handler.AcquireSrcMemory(&x);
-  auto beta_memory_p = handler.AcquireBetaMemory(&beta);
+  auto beta_memory_p = handler.AcquireBetaMemory(&beta_f);
   std::shared_ptr<dnnl::memory> dst_memory_p = nullptr;
   if (x.IsSharedBufferWith(*out)) {
     dst_memory_p = src_memory_p;

--- a/paddle/phi/kernels/stride/activation_kernel.cu
+++ b/paddle/phi/kernels/stride/activation_kernel.cu
@@ -251,10 +251,6 @@ DEFINE_CUDA_ACTIVATION_STRIDE_WITH_TWO_ATTRS(HardTanh,
                                              CudaHardTanhFunctor,
                                              t_min,
                                              t_max)
-DEFINE_CUDA_ACTIVATION_STRIDE_WITH_TWO_ATTRS(Softplus,
-                                             CudaSoftplusFunctor,
-                                             beta,
-                                             threshold)
 DEFINE_CUDA_ACTIVATION_STRIDE_WITH_TWO_ATTRS(HardSigmoid,
                                              CudaHardSigmoidFunctor,
                                              slope,
@@ -264,6 +260,47 @@ DEFINE_CUDA_ACTIVATION_STRIDE_WITH_TWO_ATTRS(Selu,
                                              scale,
                                              alpha)
 #undef DEFINE_CUDA_ACTIVATION_STRIDE_WITH_ONE_ATTRS
+
+template <typename T, typename Context>
+void SoftplusStrideKernel(const Context &dev_ctx,
+                          const DenseTensor &x,
+                          double beta,
+                          double threshold,
+                          DenseTensor *out) {
+  if (!FLAGS_use_stride_kernel) {
+    PADDLE_THROW(common::errors::Fatal(
+        "FLAGS_use_stride_kernel is closed. Strided kernel be called, "
+        "something wrong has happened!"));
+  }
+  DenseTensor x_;
+  if (!FLAGS_use_stride_compute_kernel) {
+    if (!x.meta().is_contiguous()) {
+      x_ = Tensor2Contiguous<Context>(dev_ctx, x);
+    } else {
+      x_ = x;
+    }
+  } else {
+    x_ = x;
+  }
+  if (x_.meta().is_contiguous()) {
+    auto meta = out->meta();
+    meta.strides = meta.calc_strides(out->dims());
+    out->set_meta(meta);
+    phi::SoftplusKernel<T, Context>(dev_ctx, x_, beta, threshold, out);
+    return;
+  }
+  if (!FLAGS_use_stride_compute_kernel) {
+    PADDLE_THROW(common::errors::Fatal(
+        "FLAGS_use_stride_compute_kernel is closed. Kernel using "
+        "DenseTensorIterator be called, something wrong has happened!"));
+  }
+  funcs::CudaSoftplusFunctor<T> functor;
+  auto attrs = functor.GetAttrs();
+  *(attrs[0].second) = beta;
+  *(attrs[1].second) = threshold;
+  LaunchUnaryElementwiseStrideKernel<T, Context>(dev_ctx, x_, functor, out);
+}
+
 template <typename T, typename Context>
 void RoundStrideKernel(const Context &dev_ctx,
                        const DenseTensor &x,

--- a/paddle/phi/kernels/xpu/activation_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/activation_grad_kernel.cc
@@ -664,15 +664,25 @@ DEFINE_XPU_ACT_GRAD_KERNEL_WITH_ONE_ATTRS_DEPX(LeakyRelu,
                                                XPULeakyReluGradFunctor,
                                                alpha);
 
-DEFINE_XPU_ACT_GRAD_KERNEL_WITH_TWO_ATTRS_DEPX(Softplus,
-                                               XPUSoftPlusGradFunctor,
-                                               beta,
-                                               threshold)
 DEFINE_XPU_ACT_GRAD_KERNEL_WITH_TWO_ATTRS_DEPOUT(HardSigmoid,
                                                  XPUHardSigmoidGradFunctor,
                                                  slope,
                                                  offset)
 
+template <typename T, typename Context>
+void SoftplusGradKernel(const Context& dev_ctx,
+                        const DenseTensor& x,
+                        const DenseTensor& dout,
+                        double beta,
+                        double threshold,
+                        DenseTensor* dx) {
+  XPUSoftPlusGradFunctor<T> functor;
+  auto attrs = functor.GetAttrs();
+  *(attrs[0].second) = static_cast<float>(beta);
+  *(attrs[1].second) = static_cast<float>(threshold);
+  ActivationGradXPUImpl<T, Context, XPUSoftPlusGradFunctor<T>>(
+      dev_ctx, &x, nullptr, &dout, dx, functor);
+}
 template <typename T, typename Context>
 void HardSwishGradKernel(const Context& dev_ctx,
                          const DenseTensor& x,

--- a/paddle/phi/kernels/xpu/activation_kernel.cc
+++ b/paddle/phi/kernels/xpu/activation_kernel.cc
@@ -595,15 +595,24 @@ DEFINE_XPU_ACTIVATION_KERNEL_WITH_ONE_ATTRS(Mish, XPUMishFunctor, threshold)
 DEFINE_XPU_ACTIVATION_KERNEL_WITH_ONE_ATTRS(LeakyRelu,
                                             XPULeakyReluFunctor,
                                             alpha)
-DEFINE_XPU_ACTIVATION_KERNEL_WITH_TWO_ATTRS(Softplus,
-                                            XPUSoftplusFunctor,
-                                            beta,
-                                            threshold)
 DEFINE_XPU_ACTIVATION_KERNEL_WITH_TWO_ATTRS(HardSigmoid,
                                             XPUHardSigmoidFunctor,
                                             slope,
                                             offset)
 
+template <typename T, typename Context>
+void SoftplusKernel(const Context& dev_ctx,
+                    const DenseTensor& x,
+                    double beta,
+                    double threshold,
+                    DenseTensor* out) {
+  XPUSoftplusFunctor<T> functor;
+  auto attrs = functor.GetAttrs();
+  *(attrs[0].second) = static_cast<float>(beta);
+  *(attrs[1].second) = static_cast<float>(threshold);
+  ActivationXPUImpl<T, Context, XPUSoftplusFunctor<T>>(
+      dev_ctx, x, out, functor);
+}
 template <typename T, typename Context>
 void HardSwishKernel(const Context& dev_ctx,
                      const DenseTensor& x,

--- a/paddle/phi/ops/yaml/backward.yaml
+++ b/paddle/phi/ops/yaml/backward.yaml
@@ -3425,8 +3425,8 @@
     func : slogdet_v2_grad
 
 - backward_op : softplus_double_grad
-  forward : softplus_grad (Tensor x, Tensor grad_out, float beta, float threshold) -> Tensor(grad_x)
-  args : (Tensor x, Tensor grad_out, Tensor grad_x_grad, float beta, float threshold)
+  forward : softplus_grad (Tensor x, Tensor grad_out, double beta, double threshold) -> Tensor(grad_x)
+  args : (Tensor x, Tensor grad_out, Tensor grad_x_grad, double beta, double threshold)
   output : Tensor(x_grad), Tensor(grad_out_grad)
   infer_meta :
     func : GeneralBinaryGradInferMeta
@@ -3436,8 +3436,8 @@
   inplace : (grad_x_grad -> grad_out_grad)
 
 - backward_op : softplus_grad
-  forward : softplus (Tensor x, float beta, float threshold) -> Tensor(out)
-  args : (Tensor x, Tensor out_grad, float beta, float threshold)
+  forward : softplus (Tensor x, double beta, double threshold) -> Tensor(out)
+  args : (Tensor x, Tensor out_grad, double beta, double threshold)
   output : Tensor(x_grad)
   infer_meta :
     func : UnchangedInferMeta

--- a/paddle/phi/ops/yaml/inconsistent/onednn_static.yaml
+++ b/paddle/phi/ops/yaml/inconsistent/onednn_static.yaml
@@ -89,7 +89,7 @@
   optional : residual_data
 
 - op : fused_softplus
-  args : (Tensor x, float beta=1.0, float threshold=20.0, str fuse_activation="", float fuse_alpha=0.0, float fuse_beta=0.0)
+  args : (Tensor x, double beta=1.0, double threshold=20.0, str fuse_activation="", double fuse_alpha=0.0, double fuse_beta=0.0)
   output : Tensor(out)
   infer_meta :
     func : UnchangedExceptDtypeInferMeta

--- a/paddle/phi/ops/yaml/legacy/backward_exclude.yaml
+++ b/paddle/phi/ops/yaml/legacy/backward_exclude.yaml
@@ -23,6 +23,8 @@
 - fused_softmax_mask_grad
 - fused_softmax_mask_upper_triangle_grad
 - hsigmoid_loss_grad
+- softplus_grad
+- softplus_double_grad
 - kthvalue_grad
 - lp_pool2d_grad
 - max_grad

--- a/paddle/phi/ops/yaml/legacy/ops_exclude.yaml
+++ b/paddle/phi/ops/yaml/legacy/ops_exclude.yaml
@@ -44,8 +44,10 @@
 - fused_bn_add_activation
 - fused_softmax_mask
 - fused_softmax_mask_upper_triangle
+- fused_softplus
 - gaussian
 - hsigmoid_loss
+- softplus
 - increment
 - kthvalue
 - linspace

--- a/paddle/phi/ops/yaml/legacy/static_backward.yaml
+++ b/paddle/phi/ops/yaml/legacy/static_backward.yaml
@@ -478,6 +478,30 @@
     func : softmax_grad
   composite : softmax_grad(out, out_grad, axis, x_grad)
 
+- backward_op : softplus_double_grad
+  forward : softplus_grad (Tensor x, Tensor grad_out, float beta, float threshold) -> Tensor(grad_x)
+  args : (Tensor x, Tensor grad_out, Tensor grad_x_grad, float beta, float threshold)
+  output : Tensor(x_grad), Tensor(grad_out_grad)
+  infer_meta :
+    func : GeneralBinaryGradInferMeta
+    param : [x, x]
+  kernel :
+    func : softplus_double_grad
+  inplace : (grad_x_grad -> grad_out_grad)
+
+- backward_op : softplus_grad
+  forward : softplus (Tensor x, float beta, float threshold) -> Tensor(out)
+  args : (Tensor x, Tensor out_grad, float beta, float threshold)
+  output : Tensor(x_grad)
+  infer_meta :
+    func : UnchangedInferMeta
+    param : [x]
+    spmd_rule : SoftplusGradInfoSpmd
+  kernel :
+    func : softplus_grad
+  backward : softplus_double_grad
+  inplace : (out_grad -> x_grad)
+
 - backward_op : squeeze_double_grad
   forward : squeeze_grad(Tensor xshape, Tensor grad_out, IntArray axis) -> Tensor(grad_x)
   args : (Tensor grad_x_grad, IntArray axis)

--- a/paddle/phi/ops/yaml/legacy/static_ops.yaml
+++ b/paddle/phi/ops/yaml/legacy/static_ops.yaml
@@ -342,6 +342,15 @@
     data_type : dtype > x
   traits : paddle::dialect::ForwardOnlyTrait
 
+- op : fused_softplus
+  args : (Tensor x, float beta=1.0, float threshold=20.0, str fuse_activation="", float fuse_alpha=0.0, float fuse_beta=0.0)
+  output : Tensor(out)
+  infer_meta :
+    func : UnchangedExceptDtypeInferMeta
+    param : [x]
+  kernel :
+    func : fused_softplus
+
 - op : gaussian
   args : (IntArray shape = {}, float mean = .0f, float std = 1.0f, int seed = 0, DataType dtype = DataType::FLOAT32)
   output: Tensor(out)
@@ -852,6 +861,19 @@
     func : softmax
   inplace : (x -> out)
   backward : softmax_grad
+
+- op : softplus
+  args : (Tensor x, float beta = 1.0, float threshold = 20.0f)
+  output : Tensor
+  infer_meta :
+    func : UnchangedInferMeta
+    param : [x]
+    spmd_rule : SoftplusInfoSpmd
+  kernel :
+    func : softplus
+  backward : softplus_grad
+  interfaces : paddle::dialect::InferSymbolicShapeInterface, paddle::dialect::LayoutTransformationInterface
+  traits: pir::UnaryElementWiseTrait
 
 - op : sparse_momentum
   args: (Tensor param, Tensor grad, Tensor velocity, Tensor index, Tensor learning_rate, Tensor master_param,float mu, Scalar axis=0, bool use_nesterov=false,str regularization_method="", float regularization_coeff=0.0f, bool multi_precision=false, float rescale_grad=1.0f)

--- a/paddle/phi/ops/yaml/ops.yaml
+++ b/paddle/phi/ops/yaml/ops.yaml
@@ -5087,7 +5087,7 @@
   interfaces : paddle::dialect::InferSymbolicShapeInterface
 
 - op : softplus
-  args : (Tensor x, float beta = 1.0, float threshold = 20.0f)
+  args : (Tensor x, double beta = 1.0, double threshold = 20.0f)
   output : Tensor
   infer_meta :
     func : UnchangedInferMeta

--- a/paddle/pir/src/core/builtin_attribute.cc
+++ b/paddle/pir/src/core/builtin_attribute.cc
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "paddle/pir/include/core/builtin_attribute.h"
-#include <iostream>
 
 namespace pir {
 
@@ -21,11 +20,7 @@ bool BoolAttribute::data() const { return storage()->data(); }
 
 float FloatAttribute::data() const { return storage()->data(); }
 
-double DoubleAttribute::data() const {
-  std::cout << "DoubleAttribute::data()" << std::endl;
-  std::cout << "testtest: " << storage()->data() << std::endl;
-  return storage()->data();
-}
+double DoubleAttribute::data() const { return storage()->data(); }
 
 int32_t Int32Attribute::data() const { return storage()->data(); }
 

--- a/paddle/pir/src/core/builtin_attribute.cc
+++ b/paddle/pir/src/core/builtin_attribute.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "paddle/pir/include/core/builtin_attribute.h"
+#include <iostream>
 
 namespace pir {
 
@@ -20,7 +21,11 @@ bool BoolAttribute::data() const { return storage()->data(); }
 
 float FloatAttribute::data() const { return storage()->data(); }
 
-double DoubleAttribute::data() const { return storage()->data(); }
+double DoubleAttribute::data() const {
+  std::cout << "DoubleAttribute::data()" << std::endl;
+  std::cout << "testtest: " << storage()->data() << std::endl;
+  return storage()->data();
+}
 
 int32_t Int32Attribute::data() const { return storage()->data(); }
 

--- a/test/legacy_test/test_activation_op.py
+++ b/test/legacy_test/test_activation_op.py
@@ -5038,6 +5038,20 @@ class TestSoftplus(TestActivation):
             ['X'], 'Out', check_pir=True, check_pir_onednn=self.check_pir_onednn
         )
 
+    def test_check_output_2(self):
+        self.check_output_with_place(paddle.CPUPlace(), check_pir=True)
+        if core.is_compiled_with_cuda():
+            self.check_output_with_place(core.CUDAPlace(0), check_pir=True)
+
+    def test_check_grad_2(self):
+        self.check_grad_with_place(
+            paddle.CPUPlace(), ['X'], 'Out', check_pir=True
+        )
+        if core.is_compiled_with_cuda():
+            self.check_grad_with_place(
+                core.CUDAPlace(0), ['X'], 'Out', check_pir=True
+            )
+
 
 class TestSoftplus_Complex64(TestSoftplus):
     def init_dtype(self):

--- a/test/legacy_test/test_activation_op.py
+++ b/test/legacy_test/test_activation_op.py
@@ -5039,17 +5039,29 @@ class TestSoftplus(TestActivation):
         )
 
     def test_check_output_2(self):
-        self.check_output_with_place(paddle.CPUPlace(), check_pir=True)
+        self.check_output_with_place(
+            paddle.CPUPlace(), check_pir=True, check_pir_onednn=True
+        )
         if core.is_compiled_with_cuda():
-            self.check_output_with_place(core.CUDAPlace(0), check_pir=True)
+            self.check_output_with_place(
+                core.CUDAPlace(0), check_pir=True, check_pir_onednn=True
+            )
 
     def test_check_grad_2(self):
         self.check_grad_with_place(
-            paddle.CPUPlace(), ['X'], 'Out', check_pir=True
+            paddle.CPUPlace(),
+            ['X'],
+            'Out',
+            check_pir=True,
+            check_pir_onednn=True,
         )
         if core.is_compiled_with_cuda():
             self.check_grad_with_place(
-                core.CUDAPlace(0), ['X'], 'Out', check_pir=True
+                core.CUDAPlace(0),
+                ['X'],
+                'Out',
+                check_pir=True,
+                check_pir_onednn=True,
             )
 
 
@@ -5065,6 +5077,25 @@ class TestSoftplus_Complex64(TestSoftplus):
             check_pir=True,
             check_pir_onednn=self.check_pir_onednn,
         )
+
+    def test_check_grad_2(self):
+        self.check_grad_with_place(
+            paddle.CPUPlace(),
+            ['X'],
+            'Out',
+            max_relative_error=0.06,
+            check_pir=True,
+            check_pir_onednn=True,
+        )
+        if core.is_compiled_with_cuda():
+            self.check_grad_with_place(
+                core.CUDAPlace(0),
+                ['X'],
+                'Out',
+                max_relative_error=0.06,
+                check_pir=True,
+                check_pir_onednn=True,
+            )
 
 
 class TestSoftplus_Complex128(TestSoftplus):

--- a/test/legacy_test/test_activation_op_zero_size.py
+++ b/test/legacy_test/test_activation_op_zero_size.py
@@ -12,50 +12,65 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
+os.environ["FLAGS_print_ir"] = "1"
+
+import paddle
+
+paddle.base.core.set_vlog_level(
+    {
+        "phi_kernel_instruction": 10,
+        "constant_folding_pass": 10,
+        "pd_op_to_kernel_pass": 10,
+        "pir_adaptor_util": 10,
+        "op_translator": 10,
+    }
+)
 import unittest
 
 import numpy as np
 from test_activation_op import (
-    TestAcos,
-    TestAcosh,
-    TestAsin,
-    TestAsinh,
-    TestAtan,
-    TestAtanh,
-    TestCeil,
-    TestCELU,
-    TestCos,
-    TestCosh,
-    TestELU,
-    TestExpFp32_Prim,
-    TestExpm1,
-    TestFloor,
-    TestHardShrink,
-    TestHardSigmoid,
-    TestHardSwish,
-    TestLeakyRelu,
-    TestLogSigmoid,
-    TestMish,
-    TestReciprocal,
-    TestRelu,
-    TestRelu6,
-    TestRound,
-    TestRsqrt,
-    TestSigmoid,
-    TestSilu,
-    TestSin,
-    TestSinh,
+    # TestAcos,
+    # TestAcosh,
+    # TestAsin,
+    # TestAsinh,
+    # TestAtan,
+    # TestAtanh,
+    # TestCeil,
+    # TestCELU,
+    # TestCos,
+    # TestCosh,
+    # TestELU,
+    # TestExpFp32_Prim,
+    # TestExpm1,
+    # TestFloor,
+    # TestHardShrink,
+    # TestHardSigmoid,
+    # TestHardSwish,
+    # TestLeakyRelu,
+    # TestLogSigmoid,
+    # TestMish,
+    # TestReciprocal,
+    # TestRelu,
+    # TestRelu6,
+    # TestRound,
+    # TestRsqrt,
+    # TestSigmoid,
+    # TestSilu,
+    # TestSin,
+    # TestSinh,
     TestSoftplus,
-    TestSoftshrink,
-    TestSoftsign,
-    TestSqrt,
-    TestSquare,
-    TestSTanh,
-    TestSwish,
-    TestTan,
-    TestTanh,
-    TestTanhshrink,
-    TestThresholdedRelu,
+    # TestSoftshrink,
+    # TestSoftsign,
+    # TestSqrt,
+    # TestSquare,
+    # TestSTanh,
+    # TestSwish,
+    # TestTan,
+    # TestTanh,
+    # TestTanhshrink,
+    # TestThresholdedRelu,
 )
 
 
@@ -88,46 +103,46 @@ def create_test_zero_size_class(parent):
     globals()[cls_name] = TestActZeroSize
 
 
-create_test_zero_size_class(TestSin)
-create_test_zero_size_class(TestCos)
-create_test_zero_size_class(TestTan)
-create_test_zero_size_class(TestAsin)
-create_test_zero_size_class(TestAtan)
-create_test_zero_size_class(TestAcos)
-create_test_zero_size_class(TestSinh)
-create_test_zero_size_class(TestCosh)
-create_test_zero_size_class(TestAsinh)
-create_test_zero_size_class(TestAcosh)
-create_test_zero_size_class(TestAtanh)
-create_test_zero_size_class(TestRelu)
-create_test_zero_size_class(TestTanh)
-create_test_zero_size_class(TestTanhshrink)
-create_test_zero_size_class(TestSilu)
-create_test_zero_size_class(TestReciprocal)
-create_test_zero_size_class(TestSquare)
-create_test_zero_size_class(TestSqrt)
-create_test_zero_size_class(TestRsqrt)
-create_test_zero_size_class(TestSoftsign)
-create_test_zero_size_class(TestSigmoid)
-create_test_zero_size_class(TestLogSigmoid)
-create_test_zero_size_class(TestFloor)
-create_test_zero_size_class(TestCeil)
-create_test_zero_size_class(TestELU)
-create_test_zero_size_class(TestCELU)
-create_test_zero_size_class(TestHardShrink)
-create_test_zero_size_class(TestHardSigmoid)
-create_test_zero_size_class(TestMish)
+# create_test_zero_size_class(TestSin)
+# create_test_zero_size_class(TestCos)
+# create_test_zero_size_class(TestTan)
+# create_test_zero_size_class(TestAsin)
+# create_test_zero_size_class(TestAtan)
+# create_test_zero_size_class(TestAcos)
+# create_test_zero_size_class(TestSinh)
+# create_test_zero_size_class(TestCosh)
+# create_test_zero_size_class(TestAsinh)
+# create_test_zero_size_class(TestAcosh)
+# create_test_zero_size_class(TestAtanh)
+# create_test_zero_size_class(TestRelu)
+# create_test_zero_size_class(TestTanh)
+# create_test_zero_size_class(TestTanhshrink)
+# create_test_zero_size_class(TestSilu)
+# create_test_zero_size_class(TestReciprocal)
+# create_test_zero_size_class(TestSquare)
+# create_test_zero_size_class(TestSqrt)
+# create_test_zero_size_class(TestRsqrt)
+# create_test_zero_size_class(TestSoftsign)
+# create_test_zero_size_class(TestSigmoid)
+# create_test_zero_size_class(TestLogSigmoid)
+# create_test_zero_size_class(TestFloor)
+# create_test_zero_size_class(TestCeil)
+# create_test_zero_size_class(TestELU)
+# create_test_zero_size_class(TestCELU)
+# create_test_zero_size_class(TestHardShrink)
+# create_test_zero_size_class(TestHardSigmoid)
+# create_test_zero_size_class(TestMish)
 create_test_zero_size_class(TestSoftplus)
-create_test_zero_size_class(TestSoftshrink)
-create_test_zero_size_class(TestSTanh)
-create_test_zero_size_class(TestThresholdedRelu)
-create_test_zero_size_class(TestExpFp32_Prim)
-create_test_zero_size_class(TestExpm1)
-create_test_zero_size_class(TestLeakyRelu)
-create_test_zero_size_class(TestRelu6)
-create_test_zero_size_class(TestHardSwish)
-create_test_zero_size_class(TestSwish)
-create_test_zero_size_class(TestRound)
+# create_test_zero_size_class(TestSoftshrink)
+# create_test_zero_size_class(TestSTanh)
+# create_test_zero_size_class(TestThresholdedRelu)
+# create_test_zero_size_class(TestExpFp32_Prim)
+# create_test_zero_size_class(TestExpm1)
+# create_test_zero_size_class(TestLeakyRelu)
+# create_test_zero_size_class(TestRelu6)
+# create_test_zero_size_class(TestHardSwish)
+# create_test_zero_size_class(TestSwish)
+# create_test_zero_size_class(TestRound)
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/legacy_test/test_activation_op_zero_size.py
+++ b/test/legacy_test/test_activation_op_zero_size.py
@@ -31,46 +31,46 @@ import unittest
 
 import numpy as np
 from test_activation_op import (
-    # TestAcos,
-    # TestAcosh,
-    # TestAsin,
-    # TestAsinh,
-    # TestAtan,
-    # TestAtanh,
-    # TestCeil,
-    # TestCELU,
-    # TestCos,
-    # TestCosh,
-    # TestELU,
-    # TestExpFp32_Prim,
-    # TestExpm1,
-    # TestFloor,
-    # TestHardShrink,
-    # TestHardSigmoid,
-    # TestHardSwish,
-    # TestLeakyRelu,
-    # TestLogSigmoid,
-    # TestMish,
-    # TestReciprocal,
-    # TestRelu,
-    # TestRelu6,
-    # TestRound,
-    # TestRsqrt,
-    # TestSigmoid,
-    # TestSilu,
-    # TestSin,
-    # TestSinh,
+    TestAcos,
+    TestAcosh,
+    TestAsin,
+    TestAsinh,
+    TestAtan,
+    TestAtanh,
+    TestCeil,
+    TestCELU,
+    TestCos,
+    TestCosh,
+    TestELU,
+    TestExpFp32_Prim,
+    TestExpm1,
+    TestFloor,
+    TestHardShrink,
+    TestHardSigmoid,
+    TestHardSwish,
+    TestLeakyRelu,
+    TestLogSigmoid,
+    TestMish,
+    TestReciprocal,
+    TestRelu,
+    TestRelu6,
+    TestRound,
+    TestRsqrt,
+    TestSigmoid,
+    TestSilu,
+    TestSin,
+    TestSinh,
     TestSoftplus,
-    # TestSoftshrink,
-    # TestSoftsign,
-    # TestSqrt,
-    # TestSquare,
-    # TestSTanh,
-    # TestSwish,
-    # TestTan,
-    # TestTanh,
-    # TestTanhshrink,
-    # TestThresholdedRelu,
+    TestSoftshrink,
+    TestSoftsign,
+    TestSqrt,
+    TestSquare,
+    TestSTanh,
+    TestSwish,
+    TestTan,
+    TestTanh,
+    TestTanhshrink,
+    TestThresholdedRelu,
 )
 
 
@@ -103,46 +103,46 @@ def create_test_zero_size_class(parent):
     globals()[cls_name] = TestActZeroSize
 
 
-# create_test_zero_size_class(TestSin)
-# create_test_zero_size_class(TestCos)
-# create_test_zero_size_class(TestTan)
-# create_test_zero_size_class(TestAsin)
-# create_test_zero_size_class(TestAtan)
-# create_test_zero_size_class(TestAcos)
-# create_test_zero_size_class(TestSinh)
-# create_test_zero_size_class(TestCosh)
-# create_test_zero_size_class(TestAsinh)
-# create_test_zero_size_class(TestAcosh)
-# create_test_zero_size_class(TestAtanh)
-# create_test_zero_size_class(TestRelu)
-# create_test_zero_size_class(TestTanh)
-# create_test_zero_size_class(TestTanhshrink)
-# create_test_zero_size_class(TestSilu)
-# create_test_zero_size_class(TestReciprocal)
-# create_test_zero_size_class(TestSquare)
-# create_test_zero_size_class(TestSqrt)
-# create_test_zero_size_class(TestRsqrt)
-# create_test_zero_size_class(TestSoftsign)
-# create_test_zero_size_class(TestSigmoid)
-# create_test_zero_size_class(TestLogSigmoid)
-# create_test_zero_size_class(TestFloor)
-# create_test_zero_size_class(TestCeil)
-# create_test_zero_size_class(TestELU)
-# create_test_zero_size_class(TestCELU)
-# create_test_zero_size_class(TestHardShrink)
-# create_test_zero_size_class(TestHardSigmoid)
-# create_test_zero_size_class(TestMish)
+create_test_zero_size_class(TestSin)
+create_test_zero_size_class(TestCos)
+create_test_zero_size_class(TestTan)
+create_test_zero_size_class(TestAsin)
+create_test_zero_size_class(TestAtan)
+create_test_zero_size_class(TestAcos)
+create_test_zero_size_class(TestSinh)
+create_test_zero_size_class(TestCosh)
+create_test_zero_size_class(TestAsinh)
+create_test_zero_size_class(TestAcosh)
+create_test_zero_size_class(TestAtanh)
+create_test_zero_size_class(TestRelu)
+create_test_zero_size_class(TestTanh)
+create_test_zero_size_class(TestTanhshrink)
+create_test_zero_size_class(TestSilu)
+create_test_zero_size_class(TestReciprocal)
+create_test_zero_size_class(TestSquare)
+create_test_zero_size_class(TestSqrt)
+create_test_zero_size_class(TestRsqrt)
+create_test_zero_size_class(TestSoftsign)
+create_test_zero_size_class(TestSigmoid)
+create_test_zero_size_class(TestLogSigmoid)
+create_test_zero_size_class(TestFloor)
+create_test_zero_size_class(TestCeil)
+create_test_zero_size_class(TestELU)
+create_test_zero_size_class(TestCELU)
+create_test_zero_size_class(TestHardShrink)
+create_test_zero_size_class(TestHardSigmoid)
+create_test_zero_size_class(TestMish)
 create_test_zero_size_class(TestSoftplus)
-# create_test_zero_size_class(TestSoftshrink)
-# create_test_zero_size_class(TestSTanh)
-# create_test_zero_size_class(TestThresholdedRelu)
-# create_test_zero_size_class(TestExpFp32_Prim)
-# create_test_zero_size_class(TestExpm1)
-# create_test_zero_size_class(TestLeakyRelu)
-# create_test_zero_size_class(TestRelu6)
-# create_test_zero_size_class(TestHardSwish)
-# create_test_zero_size_class(TestSwish)
-# create_test_zero_size_class(TestRound)
+create_test_zero_size_class(TestSoftshrink)
+create_test_zero_size_class(TestSTanh)
+create_test_zero_size_class(TestThresholdedRelu)
+create_test_zero_size_class(TestExpFp32_Prim)
+create_test_zero_size_class(TestExpm1)
+create_test_zero_size_class(TestLeakyRelu)
+create_test_zero_size_class(TestRelu6)
+create_test_zero_size_class(TestHardSwish)
+create_test_zero_size_class(TestSwish)
+create_test_zero_size_class(TestRound)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
PR https://github.com/PaddlePaddle/Paddle/pull/75363 中遗留了doule类型未能与torch对齐。
本Pr主要将beta和threshold两个参数的类型从float改为double，这样就可以完全与torch的精度对齐。

pcard-93269