### PR TITLE
【CUDA Kernel No.123】ext_build_src_rank_and_local_expert_id算子Kernel修复 -part 

### DIFF
--- a/paddle/phi/kernels/legacy/gpu/ext_build_src_rank_and_local_expert_id_kernel.cu
+++ b/paddle/phi/kernels/legacy/gpu/ext_build_src_rank_and_local_expert_id_kernel.cu
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "paddle/phi/kernels/legacy/gpu/ext_build_src_rank_and_local_expert_id_kernel.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
 

--- a/paddle/phi/kernels/legacy/gpu/ext_build_src_rank_and_local_expert_id_kernel.h
+++ b/paddle/phi/kernels/legacy/gpu/ext_build_src_rank_and_local_expert_id_kernel.h
@@ -1,0 +1,31 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "paddle/phi/core/dense_tensor.h"
+#include "paddle/phi/core/kernel_registry.h"
+
+namespace phi {
+
+template <typename T, typename Context>
+void BuildSrcRankAndLocalExpertIdKernel(
+    const Context& dev_ctx,
+    const DenseTensor& expert_num_global_tensor,
+    const std::vector<int64_t>& expert_num_global,
+    int64_t num_local_experts,
+    DenseTensor* src_rank,
+    DenseTensor* local_expert_id);
+
+}  // namespace phi


### PR DESCRIPTION
### PR Category
Performance Optimization

### PR Types
Bug fixes

### Description
在legacy/gpu目录下新增头文件ext_build_src_rank_and_local_expert_id_kernel.h
