### PR TITLE
【CUDA Kernel No.133】moe_gate_dispatch_permute算子Kernel修复-part

### DIFF
--- a/paddle/phi/kernels/legacy/gpu/moe_gate_dispatch_permute_kernel.cu
+++ b/paddle/phi/kernels/legacy/gpu/moe_gate_dispatch_permute_kernel.cu
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "paddle/phi/kernels/legacy/gpu/moe_gate_dispatch_permute_kernel.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/legacy/gpu/moe_fuse_op.h"

--- a/paddle/phi/kernels/legacy/gpu/moe_gate_dispatch_permute_kernel.h
+++ b/paddle/phi/kernels/legacy/gpu/moe_gate_dispatch_permute_kernel.h
@@ -1,0 +1,36 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "paddle/phi/core/dense_tensor.h"
+#include "paddle/phi/core/kernel_registry.h"
+
+namespace phi {
+
+template <typename T, typename Context>
+void MoEDispatchPermuteKernel(const Context& dev_ctx,
+                              const DenseTensor& x,
+                              const DenseTensor& gate_logits,
+                              const paddle::optional<DenseTensor>& corr_bias,
+                              int64_t k,
+                              int64_t capacity,
+                              int64_t world_size,
+                              DenseTensor* y,
+                              DenseTensor* combine_weights,
+                              DenseTensor* scatter_index,
+                              DenseTensor* expert_offset,
+                              DenseTensor* expert_id);
+
+}  // namespace phi


### PR DESCRIPTION
### PR Category
Performance Optimization

### PR Types
Bug fixes

### Description
在legacy/gpu目录下新增moe_gate_dispatch_permute_kernel.h