### PR TITLE
【CUDA Kernel No.135】moe_ops_partial_nosoftmaxtopk算子Kernel修复-part

### DIFF
--- a/paddle/phi/kernels/legacy/gpu/moe_ops_partial_nosoftmaxtopk_kernel.cu
+++ b/paddle/phi/kernels/legacy/gpu/moe_ops_partial_nosoftmaxtopk_kernel.cu
@@ -18,6 +18,7 @@
  *     https://github.com/NVIDIA/apex
  *     with minor changes. */
 
+#include "paddle/phi/kernels/legacy/gpu/moe_ops_partial_nosoftmaxtopk_kernel.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/kernel_registry.h"

--- a/paddle/phi/kernels/legacy/gpu/moe_ops_partial_nosoftmaxtopk_kernel.h
+++ b/paddle/phi/kernels/legacy/gpu/moe_ops_partial_nosoftmaxtopk_kernel.h
@@ -1,0 +1,42 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "paddle/phi/core/dense_tensor.h"
+#include "paddle/phi/core/kernel_registry.h"
+
+namespace phi {
+
+template <typename T, typename Context>
+void MoeGateDispatchPartialNoSoftMaxTopkKernel(
+    const Context& dev_ctx,
+    const DenseTensor& x,
+    const DenseTensor& combine_weights,
+    const DenseTensor& expert_id,
+    int64_t k,
+    int64_t capacity,
+    int64_t num_experts,
+    bool use_pad,
+    int64_t expert_start_index,
+    int64_t expert_end_index,
+    bool reverse_token_drop,
+    DenseTensor* y,
+    DenseTensor* combine_weights_out,
+    DenseTensor* scatter_index,
+    DenseTensor* scatter_index_rev,
+    DenseTensor* expert_offset,
+    DenseTensor* expert_nums_local);
+
+}  // namespace phi


### PR DESCRIPTION
### PR Category
Performance Optimization

### PR Types
Bug fixes

### Description
在legacy/gpu目录下新增头文件moe_ops_partial_nosoftmaxtopk_kernel.h