### PR TITLE
[Fix] Fix segmentation fault in im2col fast path due to unsafe memcpy over-read

### DIFF
--- a/paddle/phi/kernels/funcs/im2col_cfo_cpu.h
+++ b/paddle/phi/kernels/funcs/im2col_cfo_cpu.h
@@ -196,7 +196,6 @@ inline void im2col_sh1sw1dh1dw1ph1pw1(const phi::DenseTensor& im,
       dst_data_ic = dst_data_ic + col_block_ic;
     }
     // fill core
-    size_t copy_size = sizeof(T) * (output_width - plw - prw);
     for (int oh = 0; oh < output_height; ++oh) {
       const T* im_data_start =
           im_data + (oh - plh > 0 ? oh - plh : 0) * im_width;
@@ -210,7 +209,18 @@ inline void im2col_sh1sw1dh1dw1ph1pw1(const phi::DenseTensor& im,
             continue;
           }
           if (data_layout != DataLayout::kNHWC) {
-            std::memcpy(dst_data + plw, src_data, copy_size);
+            // Safe memcpy for filter_width == 1 case
+            int want = output_width - plw - prw;
+            int avail = im_width;
+            int n = std::max(0, std::min(want, avail));
+            if (n > 0) {
+              std::memcpy(dst_data + plw, src_data, sizeof(T) * n);
+            }
+            // Zero any shortfall
+            int shortfall = want - n;
+            if (shortfall > 0) {
+              std::memset(dst_data + plw + n, 0, sizeof(T) * shortfall);
+            }
           } else {
             for (int kow = 0; kow < output_width - plw - prw; ++kow) {
               int im_row = oh - plh + kh;

--- a/paddle/phi/kernels/funcs/im2col_cfo_cpu.h
+++ b/paddle/phi/kernels/funcs/im2col_cfo_cpu.h
@@ -271,9 +271,21 @@ inline void im2col_sh1sw1dh1dw1ph1pw1(const phi::DenseTensor& im,
         // try to unify
         for (int kw = 0; kw < plw; ++kw) {
           if (data_layout != DataLayout::kNHWC) {
-            std::memcpy(dst_data + (plw - kw),
-                        src_data,
-                        sizeof(T) * (output_width - (plw - kw)));
+            // Left band: clamp memcpy to avoid over-read
+            int want = output_width - (plw - kw);
+            int src_col_start = 0;
+            int avail = im_width - src_col_start;
+            int n = std::max(0, std::min(want, avail));
+            if (n > 0) {
+              std::memcpy(dst_data + (plw - kw),
+                          src_data + src_col_start,
+                          sizeof(T) * n);
+            }
+            // Zero any shortfall
+            int shortfall = want - n;
+            if (shortfall > 0) {
+              std::memset(dst_data + (plw - kw) + n, 0, sizeof(T) * shortfall);
+            }
           } else {
             for (int kow = 0; kow < output_width - (plw - kw); ++kow) {
               int im_row = oh - plh + kh;
@@ -291,8 +303,17 @@ inline void im2col_sh1sw1dh1dw1ph1pw1(const phi::DenseTensor& im,
         }
         for (int kw = plw; kw < filter_width - prw; ++kw) {
           if (data_layout != DataLayout::kNHWC) {
-            std::memcpy(
-                dst_data, src_data + (kw - plw), sizeof(T) * output_width);
+            // Middle band: clamp memcpy to avoid over-read
+            int src_col_start = kw - plw;
+            int want = output_width;
+            int avail = im_width - src_col_start;
+            int n = std::max(0, std::min(want, avail));
+            if (n > 0) {
+              std::memcpy(dst_data, src_data + src_col_start, sizeof(T) * n);
+            }
+            if (n < want) {
+              std::memset(dst_data + n, 0, sizeof(T) * (want - n));
+            }
           } else {
             for (int kow = 0; kow < output_width; ++kow) {
               int im_row = oh - plh + kh;
@@ -311,9 +332,17 @@ inline void im2col_sh1sw1dh1dw1ph1pw1(const phi::DenseTensor& im,
         int i = 1;
         for (int kw = filter_width - prw; kw < filter_width; ++kw, ++i) {
           if (data_layout != DataLayout::kNHWC) {
-            std::memcpy(dst_data,
-                        src_data + (kw - plw),
-                        sizeof(T) * (output_width - i));
+            // Right band: clamp memcpy to avoid over-read
+            int src_col_start = kw - plw;
+            int want = output_width - i;
+            int avail = im_width - src_col_start;
+            int n = std::max(0, std::min(want, avail));
+            if (n > 0) {
+              std::memcpy(dst_data, src_data + src_col_start, sizeof(T) * n);
+            }
+            if (n < want) {
+              std::memset(dst_data + n, 0, sizeof(T) * (want - n));
+            }
           } else {
             for (int kow = 0; kow < output_width - i; ++kow) {
               int im_row = oh - plh + kh;


### PR DESCRIPTION
### PR Category

Operator Mechanism

### PR Types

Bug fixes

### Description

**Fix segmentation fault in im2col operations due to unsafe memcpy over-read**
**修复im2col操作中因不安全memcpy越界读取导致的段错误**

This PR addresses critical memory safety issues in the `im2col_sh1sw1dh1dw1ph1pw1` function that were causing segmentation faults in PaddleOCR ConvKernel operations.

本PR解决了`im2col_sh1sw1dh1dw1ph1pw1`函数中的关键内存安全问题，这些问题导致PaddleOCR ConvKernel操作出现段错误。

The specialized fast path for im2col operations (stride=1, dilation=1, padding=1) contained unsafe `memcpy` operations in NCHW branches that could over-read past source row boundaries. This occurred when `output_width` exceeded the available in-bounds width for a given filter position, causing:

im2col操作的专用快速路径（stride=1, dilation=1, padding=1）在NCHW分支中包含不安全的`memcpy`操作，可能越界读取源行边界。当`output_width`超过给定滤波器位置的可用边界内宽度时，会导致：

1. **Segmentation faults** in PaddleOCR scenarios with large padding and `filter_width > 1`
   在具有大填充和`filter_width > 1`的PaddleOCR场景中出现段错误

2. **Memory corruption** from reading past allocated tensor boundaries
   从读取超出分配的张量边界导致内存损坏

3. **Undefined behavior** from negative size_t conversions
   负size_t转换导致的未定义行为

The NCHW branches used bulk `memcpy` operations without bounds checking, unlike the NHWC branches which use element-by-element operations with explicit bounds checks. Three critical locations were vulnerable:

NCHW分支使用批量`memcpy`操作而不进行边界检查，与使用逐元素操作并具有显式边界检查的NHWC分支不同。三个关键位置存在漏洞：

* **Left band** (`kw` in `[0, plw)`)
  **左带**：`memcpy`可能读取超过行开始位置

* **Middle band** (`kw` in `[plw, filter_width - prw)`)
  **中间带**：`memcpy`可能读取超过行结束位置

* **Right band** (`kw` in `[filter_width - prw, filter_width)`)
  **右带**：`memcpy`可能读取超过行结束位置

* **Filter width == 1 case**
  **滤波器宽度==1的情况**：存在负size_t转换和越界读取漏洞

---

### Solution

**解决方案**

Added comprehensive bounds checking and safe memory operations:

添加了全面的边界检查和安全内存操作：

* **Bounds clamping**: Calculate available source span and limit memcpy size accordingly
  **边界限制**：计算可用源跨度并相应限制memcpy大小

* **Zero-fill**: Fill any shortfall with zeros to ensure complete output tensor coverage
  **零填充**：用零填充任何不足以确保完整的输出张量覆盖

* **Negative value protection**: Prevent negative size_t conversions that cause undefined behavior
  **负值保护**：防止导致未定义行为的负size_t转换

* **Performance preservation**: Maintain fast path performance by using memcpy when safe
  **性能保持**：在安全时使用memcpy保持快速路径性能

---

### Code Changes

**代码变更**

#### Before (Unsafe)

**修复前（不安全）**

```cpp
// Left band - unsafe memcpy
std::memcpy(dst_data + (plw - kw),
            src_data,
            sizeof(T) * (output_width - (plw - kw)));

// Middle band - unsafe memcpy  
std::memcpy(dst_data, src_data + (kw - plw), sizeof(T) * output_width);

// Right band - unsafe memcpy
std::memcpy(dst_data, src_data + (kw - plw), sizeof(T) * (output_width - i));

// Filter width == 1 - unsafe with negative size_t
size_t copy_size = sizeof(T) * (output_width - plw - prw);  // Can be negative!
std::memcpy(dst_data + plw, src_data, copy_size);
```

#### After (Safe)

**修复后（安全）**

```cpp
// Left band - safe memcpy with bounds checking
int want = output_width - (plw - kw);
int src_col_start = 0;
int avail = im_width - src_col_start;
int n = std::max(0, std::min(want, avail));
if (n > 0) {
  std::memcpy(dst_data + (plw - kw), src_data + src_col_start, sizeof(T) * n);
}
int shortfall = want - n;
if (shortfall > 0) {
  std::memset(dst_data + (plw - kw) + n, 0, sizeof(T) * shortfall);
}

// Middle band - safe memcpy with bounds checking
int src_col_start = kw - plw;
int want = output_width;
int avail = im_width - src_col_start;
int n = std::max(0, std::min(want, avail));
if (n > 0) {
  std::memcpy(dst_data, src_data + src_col_start, sizeof(T) * n);
}
if (n < want) {
  std::memset(dst_data + n, 0, sizeof(T) * (want - n));
}

// Right band - safe memcpy with bounds checking
int src_col_start = kw - plw;
int want = output_width - i;
int avail = im_width - src_col_start;
int n = std::max(0, std::min(want, avail));
if (n > 0) {
  std::memcpy(dst_data, src_data + src_col_start, sizeof(T) * n);
}
if (n < want) {
  std::memset(dst_data + n, 0, sizeof(T) * (want - n));
}

// Filter width == 1 - safe with bounds checking
int want = output_width - plw - prw;
int avail = im_width;
int n = std::max(0, std::min(want, avail));
if (n > 0) {
  std::memcpy(dst_data + plw, src_data, sizeof(T) * n);
}
int shortfall = want - n;
if (shortfall > 0) {
  std::memset(dst_data + plw + n, 0, sizeof(T) * shortfall);
}
```

---

### Technical Changes

**技术变更**

* Fixed unsafe `memcpy` operations in all three filter width bands
  修复了所有三个滤波器宽度带中的不安全`memcpy`操作

* Added bounds checking for `filter_width == 1` case to prevent negative size_t conversion
  为`filter_width == 1`情况添加边界检查以防止负size_t转换

* Implemented safe memory operations that clamp to available source span
  实现了限制到可用源跨度的安全内存操作

* Added zero-fill for shortfall cases to ensure complete output coverage
  为不足情况添加零填充以确保完整的输出覆盖

> **Note**: This fix builds upon the existing bounds-checking improvements in `im2col_common` from PR #75261, extending the safety guarantees to the specialized fast paths.
> **注意**：此修复基于PR #75261中`im2col_common`的现有边界检查改进，将安全保证扩展到专用快速路径。