### PR TITLE
time string format for progress bar

### DIFF
--- a/python/paddle/hapi/progressbar.py
+++ b/python/paddle/hapi/progressbar.py
@@ -147,7 +147,7 @@ class ProgressBar:
                         info += f' {v}'
 
             if self._num is not None and current_num < self._num:
-                eta = time_per_unit * (self._num - current_num)
+                eta = int(time_per_unit * (self._num - current_num))
                 if eta > 3600:
                     eta_format = (
                         f'{eta // 3600}:{(eta % 3600) // 60:02}:{eta % 60:02}'


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
Model.fit 的进度条ETA时间的秒位小数太长，控制台宽度经常不够，是否可以忽略小数部分。
修改前运行截图：
<img width="768" height="76" alt="image" src="https://github.com/user-attachments/assets/666bd336-b0d0-496c-8d0b-382125e1db57" />
修改后运行截图：
<img width="691" height="68" alt="image" src="https://github.com/user-attachments/assets/19a5828a-c6e4-47a6-a3a4-1880fa747110" />

