### PR TITLE
clean py3.8 in Dockerfile.develop.dtk 

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -103,6 +103,9 @@ jobs:
           for name in "${!docker_files[@]}"
           do
             md5_value=`md5sum tools/dockerfile/${docker_files[$name]} | awk '{print $1}'`
+            if [ $name == "docker_dcu" ]; then
+                md5_value="76937a563116f6008c8ca4cb4f592759"
+            fi
             if [ $name == "docker_npu" ]; then
                 md5_value="a3793bdeea5ae881a0c1eaf4d7c30c64"
             fi

--- a/tools/dockerfile/Dockerfile.develop.dtk
+++ b/tools/dockerfile/Dockerfile.develop.dtk
@@ -59,23 +59,19 @@ ENV PATH=/opt/py310/bin:/opt/py39/bin:/opt/py38/bin:$PATH
 
 # upgrade pip
 RUN pip3.10 install --upgrade pip setuptools wheel && \
-    pip3.9 install --upgrade pip setuptools wheel && \
-    pip3.8 install --upgrade pip setuptools wheel
+    pip3.9 install --upgrade pip setuptools wheel
 
 # install pylint and pre-commit
 RUN pip3.10 install pre-commit==2.17.0 pylint pytest astroid isort coverage qtconsole distro && \
-    pip3.9 install pre-commit==2.17.0 pylint pytest astroid isort coverage qtconsole distro && \
-    pip3.8 install pre-commit==2.17.0 pylint pytest astroid isort coverage qtconsole distro
+    pip3.9 install pre-commit==2.17.0 pylint pytest astroid isort coverage qtconsole distro
 
 RUN pip3.10 install attrs pyyaml pathlib2 scipy requests psutil Cython clang-format==13.0.0 PyGithub && \
-    pip3.9 install attrs pyyaml pathlib2 scipy requests psutil Cython clang-format==13.0.0 PyGithub  && \
-    pip3.8  install attrs pyyaml pathlib2 scipy requests psutil Cython clang-format==13.0.0 PyGithub
+    pip3.9 install attrs pyyaml pathlib2 scipy requests psutil Cython clang-format==13.0.0 PyGithub
 
 # install Paddle requirement
 RUN wget https://raw.githubusercontent.com/PaddlePaddle/Paddle/develop/python/requirements.txt -O requirements.txt && \
     pip3.10 install -r requirements.txt && \
-    pip3.9 install -r requirements.txt && \
-    pip3.8 install -r requirements.txt && rm -rf requirements.txt
+    pip3.9 install -r requirements.txt && rm -rf requirements.txt
 
 RUN wget https://raw.githubusercontent.com/PaddlePaddle/Paddle/develop/python/unittest_py/requirements.txt -O requirements.txt && \
     pip3.10 install -r requirements.txt && \


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience

### PR Types
Others 

### Description
<!-- Describe what you’ve done -->
clean py3.8 in Dockerfile.develop.dtk

同 https://github.com/PaddlePaddle/Paddle/pull/75893 
流水线中使用镜像名称是使用md5sum计算， md5sum Dockerfile.develop.dtk，但因为文件已改动，名称也同样会变化，Docker镜像不存在，如果构建写入会失败，所以修改.github/workflows/docker.yml，设置镜像名称为原名称
