### PR TITLE
[SOT] Support builtin dispatch for `is_compiled_with_onednn`

### DIFF
--- a/python/paddle/jit/sot/utils/paddle_api_config.py
+++ b/python/paddle/jit/sot/utils/paddle_api_config.py
@@ -149,6 +149,7 @@ def is_directly_run_api(api):
         paddle.base.libpaddle.is_compiled_with_ipu,
         paddle.base.libpaddle.is_compiled_with_xpu,
         paddle.base.libpaddle.is_compiled_with_mkldnn,
+        paddle.base.libpaddle.is_compiled_with_onednn,
         paddle.base.libpaddle.is_compiled_with_nccl,
         paddle.base.libpaddle.is_compiled_with_mpi,
         paddle.base.libpaddle.is_compiled_with_mpi_aware,

--- a/test/sot/test_builtin_dispatch.py
+++ b/test/sot/test_builtin_dispatch.py
@@ -460,7 +460,7 @@ def test_native_code_function():
     res7 = paddle.base.libpaddle.is_compiled_with_xpu()
     res8_deprecated = (
         paddle.base.libpaddle.is_compiled_with_mkldnn()
-    )  # Paddle 4.0 deprecated
+    )  # Paddle 3.3 deprecated
     res8 = paddle.base.libpaddle.is_compiled_with_onednn()
     res9 = paddle.base.libpaddle.is_compiled_with_nccl()
     res10 = paddle.base.libpaddle.is_compiled_with_mpi()

--- a/test/sot/test_builtin_dispatch.py
+++ b/test/sot/test_builtin_dispatch.py
@@ -458,7 +458,7 @@ def test_native_code_function():
     res5 = paddle.base.libpaddle.is_compiled_with_custom_device("npu")
     res6 = paddle.base.libpaddle.is_compiled_with_ipu()
     res7 = paddle.base.libpaddle.is_compiled_with_xpu()
-    res8 = paddle.base.libpaddle.is_compiled_with_mkldnn()
+    res8 = paddle.base.core.is_compiled_with_onednn()
     res9 = paddle.base.libpaddle.is_compiled_with_nccl()
     res10 = paddle.base.libpaddle.is_compiled_with_mpi()
     res11 = paddle.base.libpaddle.is_compiled_with_mpi_aware()

--- a/test/sot/test_builtin_dispatch.py
+++ b/test/sot/test_builtin_dispatch.py
@@ -458,7 +458,10 @@ def test_native_code_function():
     res5 = paddle.base.libpaddle.is_compiled_with_custom_device("npu")
     res6 = paddle.base.libpaddle.is_compiled_with_ipu()
     res7 = paddle.base.libpaddle.is_compiled_with_xpu()
-    res8 = paddle.base.core.is_compiled_with_onednn()
+    res8_deprecated = (
+        paddle.base.libpaddle.is_compiled_with_mkldnn()
+    )  # Paddle 4.0 deprecated
+    res8 = paddle.base.libpaddle.is_compiled_with_onednn()
     res9 = paddle.base.libpaddle.is_compiled_with_nccl()
     res10 = paddle.base.libpaddle.is_compiled_with_mpi()
     res11 = paddle.base.libpaddle.is_compiled_with_mpi_aware()
@@ -474,6 +477,7 @@ def test_native_code_function():
         res5,
         res6,
         res7,
+        res8_deprecated,
         res8,
         res9,
         res10,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience

### PR Types
Others 

### Description
<!-- Describe what you’ve done -->
replace mkldnn in test_builtin_dispatch.py
