### PR TITLE
【UnitTestFix No.15】test_allgather 单测 修复

### DIFF
--- a/test/collective/collective_allgather_api.py
+++ b/test/collective/collective_allgather_api.py
@@ -14,6 +14,8 @@
 
 import os
 
+os.environ['FLAGS_enable_pir_api'] = '0'
+
 import legacy_test.test_collective_api_base as test_base
 
 import paddle

--- a/test/collective/collective_allgather_api_dygraph.py
+++ b/test/collective/collective_allgather_api_dygraph.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import test_collective_api_base as test_base
+import legacy_test.test_collective_api_base as test_base
 
 import paddle
 import paddle.distributed as dist


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
test_collective_api_base 的导入改成 import legacy_test.test_collective_api_base as test_base，让它从 test/legacy_test/ 包中被正确解析。
同时在导入 Paddle 之前加上 os.environ['FLAGS_enable_pir_api'] = '0' 关闭 PIR，使静态图的 all_gather 走旧的 Variable/Operator 路径，消除 Value 类型不兼容。
<img width="796" height="278" alt="0ff3876a04c4ad28866cb667a5eb2d94" src="https://github.com/user-attachments/assets/e8ceb810-7987-4487-868a-bde77d550d85" />

