### PR TITLE
4th-batch-139-容器返回值比较错误

### DIFF
--- a/paddle/fluid/framework/fleet/heter_ps/graph_gpu_wrapper.cu
+++ b/paddle/fluid/framework/fleet/heter_ps/graph_gpu_wrapper.cu
@@ -155,7 +155,7 @@ void GraphGpuWrapper::init_conf(const std::string &first_node_type_str,
         PADDLE_ENFORCE_NE(src_iter,
                           node_to_id.end(),
                           common::errors::NotFound(
-                              "(%s) is not found in edge_to_id.", edge_src));
+                              "(%s) is not found in node_to_id.", edge_src));
         auto &edge_dst = nodes[1];
         auto dst_iter = node_to_id.find(edge_dst);
         PADDLE_ENFORCE_NE(dst_iter,

--- a/paddle/fluid/framework/fleet/heter_ps/graph_gpu_wrapper.cu
+++ b/paddle/fluid/framework/fleet/heter_ps/graph_gpu_wrapper.cu
@@ -153,7 +153,7 @@ void GraphGpuWrapper::init_conf(const std::string &first_node_type_str,
         auto &edge_src = nodes[0];
         auto src_iter = node_to_id.find(edge_src);
         PADDLE_ENFORCE_NE(src_iter,
-                          edge_to_id.end(),
+                          node_to_id.end(),
                           common::errors::NotFound(
                               "(%s) is not found in edge_to_id.", edge_src));
         auto &edge_dst = nodes[1];


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
第四批-编号139(共1处)
 '`src_iter` 是 `node_to_id.find(edge_src)` 的返回值，应与 `node_to_id.end()` 比较以判断是否查找成功。但此处却与 `edge_to_id.end()` 比较，由于两个容器不同，其 `end()` 迭代器不相等，导致即使 `src_iter` 无效（等于 `node_to_id.end()`），条件仍可能为真
'将比较对象从 `edge_to_id.end()` 改为 `node_to_id.end()`，确保判断的是当前查找操作是否成功。同时错误信息中提到的 `"not found in edge_to_id"` 也应改为 `"not found in node_to_id"`，保持一致性。'