### PR TITLE
4th-batch-132to133-内存越界风险

### DIFF
--- a/paddle/fluid/distributed/ps/table/graph/graph_node.h
+++ b/paddle/fluid/distributed/ps/table/graph/graph_node.h
@@ -142,7 +142,7 @@ class FeatureNode : public Node {
                                 "get_feature_ids res should not be null"));
     errno = 0;
     for (auto &feature_item : feature) {
-      const uint64_t *feas = (const uint64_t *)(feature_item.c_str());
+      const char *data = feature_item.c_str();
       size_t num = feature_item.length() / sizeof(uint64_t);
       PADDLE_ENFORCE_EQ((feature_item.length() % sizeof(uint64_t)),
                         0,
@@ -151,7 +151,8 @@ class FeatureNode : public Node {
       size_t n = res->size();
       res->resize(n + num);
       for (size_t i = 0; i < num; ++i) {
-        (*res)[n + i] = feas[i];
+        std::memcpy(&val, data + i * sizeof(uint64_t), sizeof(uint64_t));
+        (*res)[n + i] = val;
       }
     }
     PADDLE_ENFORCE_EQ(

--- a/paddle/fluid/distributed/ps/table/memory_sparse_table.cc
+++ b/paddle/fluid/distributed/ps/table/memory_sparse_table.cc
@@ -93,6 +93,12 @@ int32_t MemorySparseTable::InitializeValue() {
             "equal to '_avg_local_shard_num' (%d).",
             _m_avg_local_shard_num,
             _avg_local_shard_num));
+    PADDLE_ENFORCE_LE(
+        _shard_merge_rate,
+        1.0f,
+        common::errors::InvalidArgument(
+            "The '_shard_merge_rate' (%f) must be less than or equal to 1.0.",
+            _shard_merge_rate));
 
     _m_real_local_shard_num =
         static_cast<int>(std::ceil(_real_local_shard_num * _shard_merge_rate));


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
第四批-编号132、133(共2处)
`graph_node.h`中未验证 `c_str()` 返回的指针对 `uint64_t` 是否对齐。C++标准规定，访问 `uint64_t` 类型的数据需要地址对齐到8字节边界，若原始字符串内存未对齐，则通过 `feas[i]` 访问可能引发未定义行为（UB），使用 `std::memcpy` 从原始字节缓冲区复制 `uint64_t` 数据，避免直接指针类型转换带来的对齐问题。`std::memcpy` 是处理非对齐内存访问的安全方式，能保证在所有平台上正确读取数据

`memory_sparse_table.cc`中先使用 `_shard_merge_rate` 对 `_real_local_shard_num` 进行浮点乘法并向上取整得到 `_m_real_local_shard_num`，然后才进行断言检查其是否小于等于原值。应在任何计算前对 `_shard_merge_rate` 的取值范围进行有效性校验，确保其不超过 1.0。