### PR TITLE
4th-batch-13-统计代码逻辑错误

### DIFF
--- a/test/amp/test_collect_operator_stats.py
+++ b/test/amp/test_collect_operator_stats.py
@@ -37,7 +37,7 @@ class TestOpStatsEager(unittest.TestCase):
         conv_num = 0
         for i in range(4):
             add_num += int(add_called[i])
-            conv_num += int(add_called[i])
+            conv_num += int(conv2d_called[i])
 
         self.assertTrue(conv_num == 1)
         self.assertTrue(add_num == 1)

--- a/test/amp/test_collect_operator_stats.py
+++ b/test/amp/test_collect_operator_stats.py
@@ -23,6 +23,7 @@ from amp_base_models import build_while_model
 import paddle
 
 
+#
 class TestOpStatsEager(unittest.TestCase):
     def _check_result(self, dtype):
         # Returned the dict.

--- a/test/amp/test_collect_operator_stats.py
+++ b/test/amp/test_collect_operator_stats.py
@@ -23,7 +23,6 @@ from amp_base_models import build_while_model
 import paddle
 
 
-#
 class TestOpStatsEager(unittest.TestCase):
     def _check_result(self, dtype):
         # Returned the dict.


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
第四批-编号13（共1处）
`conv_num` 本应累加 `conv2d_called` 数组中的卷积算子调用次数，但错误地重复使用了 `add_called` 数组，导致卷积调用次数被错误统计为与 `add` 相同的值，违背了测试本意。
将 `conv_num += int(add_called[i])` 修改为 `conv_num += int(conv2d_called[i])`，确保卷积操作的调用次数从正确的 `conv2d_called` 数组中累加，保证统计逻辑正确。