### PR TITLE
4th-batch-14-条件判断代码逻辑错误

### DIFF
--- a/test/amp/test_amp_promote.py
+++ b/test/amp/test_amp_promote.py
@@ -322,7 +322,7 @@ class TestPirAmpPromoteStats(AmpTestBase):
 )
 @unittest.skipIf(
     core.is_compiled_with_cuda()
-    and not paddle.device.cuda.get_device_capability()[0] < 7.0,
+    and paddle.device.cuda.get_device_capability()[0] < 7.0,
     "run test when gpu's compute capability is at least 7.0.",
 )
 @unittest.skipIf(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
代码使用了双重否定逻辑 `not ... < 7.0`，等价于 `>= 7.0`，表示当 GPU 算力大于等于 7.0 时跳过测试。但测试目的恰恰是要在算力 >= 7.0 时才运行，因此该条件导致符合要求的设备被错误跳过，违背了测试意图。将 `not ... < 7.0` 改为直接判断 `< 7.0`，使条件变为“当 GPU 算力小于 7.0 时跳过”，从而确保只有算力 >= 7.0 的设备才会执行该测试，与注释和业务需求一致。