### PR TITLE
4th-batch-15-获取参数缺乏条件判断可能导致错误

### DIFF
--- a/test/auto_parallel/dtensor_to_local_api.py
+++ b/test/auto_parallel/dtensor_to_local_api.py
@@ -55,8 +55,11 @@ class TestDtensorToLocalAPI:
 
     def check_grad_mesh(self, org_mesh, org_placements):
         def _check_mesh(grad):
-            assert grad.process_mesh == org_mesh
-            assert grad.placements == org_placements
+            if hasattr(grad, "process_mesh") and hasattr(grad, "placements"):
+                assert grad.process_mesh == org_mesh
+                assert grad.placements == org_placements
+            else:
+                assert org_mesh is None and org_placements is None
 
         return _check_mesh
 

--- a/test/auto_parallel/dtensor_to_local_api.py
+++ b/test/auto_parallel/dtensor_to_local_api.py
@@ -53,7 +53,6 @@ class TestDtensorToLocalAPI:
         tensor3.register_hook(self.check_grad_mesh(None, None))
         tensor3.backward()
 
-    #
     def check_grad_mesh(self, org_mesh, org_placements):
         def _check_mesh(grad):
             if hasattr(grad, "process_mesh") and hasattr(grad, "placements"):

--- a/test/auto_parallel/dtensor_to_local_api.py
+++ b/test/auto_parallel/dtensor_to_local_api.py
@@ -53,6 +53,7 @@ class TestDtensorToLocalAPI:
         tensor3.register_hook(self.check_grad_mesh(None, None))
         tensor3.backward()
 
+    #
     def check_grad_mesh(self, org_mesh, org_placements):
         def _check_mesh(grad):
             if hasattr(grad, "process_mesh") and hasattr(grad, "placements"):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
代码`_check_mesh` 函数由 `check_grad_mesh(None, None)` 返回，当 `tensor3.backward()` 触发时，`grad` 是本地张量（非分布式），不具有 `process_mesh` 和 `placements` 属性，访问这些属性将导致 `AttributeError`。
增加对 `grad` 是否具有分布式属性的判断，避免对本地张量直接访问 `process_mesh` 或 `placements`。当 `org_mesh` 和 `org_placements` 为 `None` 时，应允许 `grad` 为本地张量，仅在存在分布式属性时进行比对。