### PR TITLE
4th-batch-16-函数变量未被使用

### DIFF
--- a/test/auto_parallel/high_order_grad.py
+++ b/test/auto_parallel/high_order_grad.py
@@ -89,7 +89,7 @@ class LaplaceDataset(paddle.io.Dataset):
     def __getitem__(self, index):
         x = np.linspace(0, 0.9, 10)
         y = np.linspace(0, 0.9, 10)
-        np.random.seed(index)  # 可选：确保可重复性
+        np.random.seed(index)  # Optional: Ensure reproducibility
         bc_value = np.random.rand(36).reshape(36, 1).astype('float32')
 
         domain_space = []
@@ -101,7 +101,7 @@ class LaplaceDataset(paddle.io.Dataset):
                     bc_index.append(i + 10 * j)
         domain_space = np.array(domain_space, dtype='float32')
         bc_index = np.array(bc_index, dtype='int64')
-        # 根据 index 返回单个输入点及其相关信息（示例：返回第 index % 100 个点）
+        # Return a single input point and its related information based on the index
         idx = index % len(domain_space)
         return domain_space[idx], bc_index, bc_value
 

--- a/test/auto_parallel/high_order_grad.py
+++ b/test/auto_parallel/high_order_grad.py
@@ -89,6 +89,7 @@ class LaplaceDataset(paddle.io.Dataset):
     def __getitem__(self, index):
         x = np.linspace(0, 0.9, 10)
         y = np.linspace(0, 0.9, 10)
+        np.random.seed(index)  # 可选：确保可重复性
         bc_value = np.random.rand(36).reshape(36, 1).astype('float32')
 
         domain_space = []
@@ -100,8 +101,9 @@ class LaplaceDataset(paddle.io.Dataset):
                     bc_index.append(i + 10 * j)
         domain_space = np.array(domain_space, dtype='float32')
         bc_index = np.array(bc_index, dtype='int64')
-
-        return domain_space, bc_index, bc_value
+        # 根据 index 返回单个输入点及其相关信息（示例：返回第 index % 100 个点）
+        idx = index % len(domain_space)
+        return domain_space[idx], bc_index, bc_value
 
     def __len__(self):
         return self.num_sample


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
第四批-编号16（共1个）
`__getitem__` 方法本应根据传入的 `index` 返回对应的一个样本或一组数据切片，但当前实现中完全忽略 `index` 参数，每次都重新生成整个网格空间（共100个点）以及边界条件索引（36个点）。这意味着无论 `index` 是多少，返回的数据都是完整且相同的结构，导致数据加载逻辑错误，破坏了 Dataset 的迭代机制。
修复后的 `__getitem__` 使用 `index` 来选择具体的输入点（例如 domain 中的某个坐标点），同时保留共享的边界信息（bc_index 和 bc_value）。这样每个样本可以独立访问，符合 `Dataset` 接口要求。此外，可通过种子控制随机性以保证可复现性。若需更复杂的采样策略，可在初始化时预生成所有样本。