### PR TITLE
4th-batch-17-代码限制多设备场景

### DIFF
--- a/test/auto_parallel/custom_op/custom_relu_op.cu
+++ b/test/auto_parallel/custom_op/custom_relu_op.cu
@@ -14,10 +14,10 @@
 
 #include "paddle/extension.h"
 
-#define CHECK_GPU_INPUT(x) \
-  PADDLE_ENFORCE_EQ(       \
-      x.is_gpu(),          \
-      true,                \
+#define CHECK_GPU_INPUT(x)                                         \
+  PADDLE_ENFORCE_EQ(                                               \
+      x.is_gpu(),                                                  \
+      true,                                                        \
       common::errors::InvalidArgument("Input tensor `x` must be a" \
                                       "GPU Tensor."));
 

--- a/test/auto_parallel/custom_op/custom_relu_op.cu
+++ b/test/auto_parallel/custom_op/custom_relu_op.cu
@@ -16,7 +16,10 @@
 
 #define CHECK_GPU_INPUT(x) \
   PADDLE_ENFORCE_EQ(       \
-      x.is_gpu(), true, common::errors::Fatal(#x " must be a GPU Tensor."))
+      x.is_gpu(),          \
+      true,                \
+      common::errors::InvalidArgument("Input tensor `x` must be a" \
+                                      "GPU Tensor."));
 
 template <typename data_t>
 __global__ void relu_cuda_forward_kernel(const data_t* x,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
第四批-编号17（共1处）
代码强制要求输入 Tensor 的设备位置必须等于 `DefaultGPUPlace()`，即默认的 CUDA:0 设备。然而，只要 Tensor 在任意 GPU 上（例如 CUDA:1、CUDA:2），就应能合法参与 CUDA 计算。此判断未考虑多设备情况，属于对设备位置的不合理限制。
已通过 `CHECK_GPU_INPUT(x)` 确保输入为 GPU Tensor，后续无需再限定具体设备位置。删除对 `DefaultGPUPlace()` 的硬编码比较，仅保留 `is_gpu()` 判断即可正确支持所有 GPU 设备。CUDA 内核执行依赖的是 Tensor 自身的 stream 和 device context，不依赖于是否为默认设备。