### PR TITLE
4th-batch-21-代码未正确验证变量

### DIFF
--- a/test/auto_parallel/hybrid_strategy/semi_auto_parallel_nd_cross_mesh_reshard.py
+++ b/test/auto_parallel/hybrid_strategy/semi_auto_parallel_nd_cross_mesh_reshard.py
@@ -298,9 +298,11 @@ class TestSemiAutoParallelNdCrossMeshReshard:
         if dist.get_rank() in self._dst_rank:
             assert np.equal(out.shape, input_tensor.shape).all()
             assert np.equal(out._local_shape, expect_out_shape).all()
+            local_rank_in_mesh = dist.get_rank() - 4
+            shard_idx = local_rank_in_mesh % 2
             np.testing.assert_equal(
                 out._local_value().numpy(),
-                expect_out[dist.get_rank() % 2].numpy(),
+                expect_out[shard_idx].numpy(),
             )
 
     def test_sr_to_rp(self):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
第四批-编号21（共1个）
该函数测试从 Shard(0)+Replicate 到 Replicate+Shard(1) 的跨 mesh 重分片操作。虽然代码中通过 `expect_out[dist.get_rank() % 2]` 获取了期望的局部值并进行比较，但此逻辑隐含假设了 rank 4~7 的数据分布与 `%2` 索引一致，缺乏显式校验和容错，且未充分验证重分片后数值的一致性传播过程，存在测试逻辑脆弱风险。更重要的是，该测试依赖于 `paddle.split` 的切分顺序与实际 reshard 行为一致，但未明确注释说明，容易导致维护误解。
引入 `local_rank_in_mesh` 显式计算当前 rank 在目标 mesh 中的相对位置，明确 `shard_idx` 来源，增强代码可读性和可维护性；确保数值验证基于清晰的拓扑映射关系，而非隐式模运算假设，提升测试可靠性。