### PR TITLE
4th-batch-28-代码变量赋值逻辑错误

### DIFF
--- a/test/auto_parallel/spmd_rules/test_flash_attention_rule.py
+++ b/test/auto_parallel/spmd_rules/test_flash_attention_rule.py
@@ -50,7 +50,7 @@ class TestFlashAttentionSPMDRule(unittest.TestCase):
         v_tensor_dist_attr.process_mesh = process_mesh
         v_tensor_dist_attr.dims_mapping = [0, -1, -1, -1]
         v_shape = [2, 1024, 64, 512]
-        v_spec = DistTensorSpec(v_shape, k_tensor_dist_attr)
+        v_spec = DistTensorSpec(v_shape, v_tensor_dist_attr)
         self.v_spec = v_spec
 
         out_tensor_dist_attr = TensorDistAttr()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
代码在创建 `v_spec` 时却错误地传入了 `k_tensor_dist_attr` 而不是 `v_tensor_dist_attr`。虽然 `k_tensor_dist_attr` 和 `v_tensor_dist_attr` 当前具有相同的 `dims_mapping` 值（均为 `[0, -1, -1, -1]`），但它们是两个独立对象，逻辑上应各自绑定对应的 tensor。此错误属于明显的编码疏忽，若未来 `k_tensor_dist_attr` 或 `v_tensor_dist_attr` 的配置发生变化，将直接导致 `v_spec` 使用错误的分布属性，破坏程序正确性。'
将 `DistTensorSpec` 构造函数中的 `k_tensor_dist_attr` 改为 `v_tensor_dist_attr`，确保 `v_spec` 正确绑定其对应张量的分布属性。该修复保证了代码逻辑的一致性和可维护性，避免潜在的分布式计算不一致问题。