### PR TITLE
4th-batch-29-变量名拼写错误

### DIFF
--- a/test/auto_parallel/spmd_rules/test_einsum_rule.py
+++ b/test/auto_parallel/spmd_rules/test_einsum_rule.py
@@ -46,13 +46,13 @@ class TestEinsumSPMDRule(unittest.TestCase):
         self.y_grad_partial_dims = {}
 
         # forward
-        self.excepted_forward = [
+        self.expected_forward = [
             [[0, -1, -1], [0, -1, -1]],  # input_dims_mapping
             [0, -1, -1],  # output_dims_mapping
         ]
 
         # backward
-        self.excepted_backward = [
+        self.expected_backward = [
             [[0, -1, -1], [0, -1, -1]],  # input_dims_mapping
             [0, -1, -1],  # output_grad_dims_mapping
             [[0, -1, -1], [0, -1, -1]],  # input_grad_dims_mapping
@@ -89,14 +89,14 @@ class TestEinsumSPMDRule(unittest.TestCase):
 
         # inputs
         for input_dist_attr, excepted_dims_mapping in zip(
-            inferred_input_dist_attrs[0], self.excepted_forward[0]
+            inferred_input_dist_attrs[0], self.expected_forward[0]
         ):
             self.assertEqual(
                 input_dist_attr.dims_mapping, excepted_dims_mapping
             )
         # output
         self.assertEqual(
-            inferred_output_dist_attrs[0].dims_mapping, self.excepted_forward[1]
+            inferred_output_dist_attrs[0].dims_mapping, self.expected_forward[1]
         )
         if self.is_output_partial:
             self.assertEqual(inferred_output_dist_attrs[0]._is_partial(), True)
@@ -126,7 +126,7 @@ class TestEinsumSPMDRule(unittest.TestCase):
 
         # inputs
         for input_dist_attr, excepted_dims_mapping in zip(
-            inferred_input_dist_attrs[0], self.excepted_backward[0]
+            inferred_input_dist_attrs[0], self.expected_backward[0]
         ):
             self.assertEqual(
                 input_dist_attr.dims_mapping, excepted_dims_mapping
@@ -134,11 +134,11 @@ class TestEinsumSPMDRule(unittest.TestCase):
         # output_grad
         self.assertEqual(
             inferred_input_dist_attrs[1].dims_mapping,
-            self.excepted_backward[1],
+            self.expected_backward[1],
         )
         # input_grad
         for input_grad_dist_attr, excepted_dims_mapping in zip(
-            inferred_output_dist_attrs[0], self.excepted_backward[2]
+            inferred_output_dist_attrs[0], self.expected_backward[2]
         ):
             self.assertEqual(
                 input_grad_dist_attr.dims_mapping, excepted_dims_mapping
@@ -184,13 +184,13 @@ class TestEinsumBMMSPMDRule2(TestEinsumSPMDRule):
         self.y_grad_partial_dims = {0}
 
         # forward
-        self.excepted_forward = [
+        self.expected_forward = [
             [[-1, 0, -1], [-1, -1, -1]],  # input_dims_mapping
             [-1, 0, -1],  # output_dims_mapping
         ]
 
         # backward
-        self.excepted_backward = [
+        self.expected_backward = [
             [[-1, 0, -1], [-1, -1, -1]],  # input_dims_mapping
             [-1, 0, -1],  # output_grad_dims_mapping
             [[-1, 0, -1], [-1, -1, -1]],  # input_grad_dims_mapping
@@ -209,13 +209,13 @@ class TestEinsumBMMSPMDRule3(TestEinsumSPMDRule):
         self.y_grad_partial_dims = {}
 
         # forward
-        self.excepted_forward = [
+        self.expected_forward = [
             [[-1, -1, 1], [-1, 1, -1]],  # input_dims_mapping
             [-1, -1, -1],  # output_dims_mapping
         ]
 
         # backward
-        self.excepted_backward = [
+        self.expected_backward = [
             [[-1, -1, 1], [-1, 1, -1]],  # input_dims_mapping
             [-1, -1, -1],  # output_grad_dims_mapping
             [[-1, -1, 1], [-1, 1, -1]],  # input_grad_dims_mapping
@@ -234,13 +234,13 @@ class TestEinsumBMMSPMDRule4(TestEinsumSPMDRule):
         self.y_grad_partial_dims = {}
 
         # forward
-        self.excepted_forward = [
+        self.expected_forward = [
             [[-1, -1, -1], [-1, -1, 1]],  # input_dims_mapping
             [-1, -1, 1],  # output_dims_mapping
         ]
 
         # backward
-        self.excepted_backward = [
+        self.expected_backward = [
             [[-1, -1, -1], [-1, -1, 1]],  # input_dims_mapping
             [-1, -1, 1],  # output_grad_dims_mapping
             [[-1, -1, -1], [-1, -1, 1]],  # input_grad_dims_mapping
@@ -266,13 +266,13 @@ class TestEinsumSumSPMDRule(TestEinsumSPMDRule):
         self.y_grad_partial_dims = {}
 
         # forward
-        self.excepted_forward = [
+        self.expected_forward = [
             [[-1, 0]],  # input_dims_mapping
             [],  # output_dims_mapping
         ]
 
         # backward
-        self.excepted_backward = [
+        self.expected_backward = [
             [[-1, 0]],  # input_dims_mapping
             [],  # output_grad_dims_mapping
             [[-1, 0]],  # input_grad_dims_mapping
@@ -298,13 +298,13 @@ class TestEinsumSumSPMDRule2(TestEinsumSPMDRule):
         self.y_grad_partial_dims = {}
 
         # forward
-        self.excepted_forward = [
+        self.expected_forward = [
             [[1, 0]],  # input_dims_mapping
             [1],  # output_dims_mapping
         ]
 
         # backward
-        self.excepted_backward = [
+        self.expected_backward = [
             [[1, 0]],  # input_dims_mapping
             [1],  # output_grad_dims_mapping
             [[1, 0]],  # input_grad_dims_mapping
@@ -330,13 +330,13 @@ class TestEinsumPermutationSPMDRule(TestEinsumSPMDRule):
         self.y_grad_partial_dims = {}
 
         # forward
-        self.excepted_forward = [
+        self.expected_forward = [
             [[-1, 0]],  # input_dims_mapping
             [0, -1],  # output_dims_mapping
         ]
 
         # backward
-        self.excepted_backward = [
+        self.expected_backward = [
             [[-1, 0]],  # input_dims_mapping
             [0, -1],  # output_grad_dims_mapping
             [[-1, 0]],  # input_grad_dims_mapping
@@ -362,13 +362,13 @@ class TestEinsumDiagonalSPMDRule(TestEinsumSPMDRule):
         self.y_grad_partial_dims = {}
 
         # forward
-        self.excepted_forward = [
+        self.expected_forward = [
             [[-1, 1]],  # input_dims_mapping
             [-1, -1],  # output_dims_mapping
         ]
 
         # backward
-        self.excepted_backward = [
+        self.expected_backward = [
             [[-1, 1]],  # input_dims_mapping
             [-1, -1],  # output_grad_dims_mapping
             [[-1, 1]],  # input_grad_dims_mapping
@@ -394,13 +394,13 @@ class TestEinsumTraceSPMDRule(TestEinsumSPMDRule):
         self.y_grad_partial_dims = {}
 
         # forward
-        self.excepted_forward = [
+        self.expected_forward = [
             [[-1, 1, -1]],  # input_dims_mapping
             [-1],  # output_dims_mapping
         ]
 
         # backward
-        self.excepted_backward = [
+        self.expected_backward = [
             [[-1, 1, -1]],  # input_dims_mapping
             [-1],  # output_grad_dims_mapping
             [[-1, 1, -1]],  # input_grad_dims_mapping
@@ -426,13 +426,13 @@ class TestEinsumDotSPMDRule(TestEinsumSPMDRule):
         self.y_grad_partial_dims = {}
 
         # forward
-        self.excepted_forward = [
+        self.expected_forward = [
             [[0, 1], [0, 1]],  # input_dims_mapping
             [0],  # output_dims_mapping
         ]
 
         # backward
-        self.excepted_backward = [
+        self.expected_backward = [
             [[0, 1], [0, 1]],  # input_dims_mapping
             [0],  # output_grad_dims_mapping
             [[0, 1], [0, 1]],  # input_grad_dims_mapping
@@ -458,13 +458,13 @@ class TestEinsumMulPMDRule(TestEinsumSPMDRule):
         self.y_grad_partial_dims = {}
 
         # forward
-        self.excepted_forward = [
+        self.expected_forward = [
             [[0, 1], [0, 1]],  # input_dims_mapping
             [0, 1],  # output_dims_mapping
         ]
 
         # backward
-        self.excepted_backward = [
+        self.expected_backward = [
             [[0, 1], [0, 1]],  # input_dims_mapping
             [0, 1],  # output_grad_dims_mapping
             [[0, 1], [0, 1]],  # input_grad_dims_mapping
@@ -490,13 +490,13 @@ class TestEinsumOuterPMDRule(TestEinsumSPMDRule):
         self.y_grad_partial_dims = {0}
 
         # forward
-        self.excepted_forward = [
+        self.expected_forward = [
             [[-1, 0], [-1, -1]],  # input_dims_mapping
             [-1, 0, -1, -1],  # output_dims_mapping
         ]
 
         # backward
-        self.excepted_backward = [
+        self.expected_backward = [
             [[-1, 0], [-1, -1]],  # input_dims_mapping
             [-1, 0, -1, -1],  # output_grad_dims_mapping
             [[-1, 0], [-1, -1]],  # input_grad_dims_mapping
@@ -515,13 +515,13 @@ class TestEinsumOuterPMDRule2(TestEinsumOuterPMDRule):
         self.y_grad_partial_dims = {}
 
         # forward
-        self.excepted_forward = [
+        self.expected_forward = [
             [[-1, -1], [1, -1]],  # input_dims_mapping
             [-1, -1, 1, -1],  # output_dims_mapping
         ]
 
         # backward
-        self.excepted_backward = [
+        self.expected_backward = [
             [[-1, -1], [1, -1]],  # input_dims_mapping
             [-1, -1, 1, -1],  # output_grad_dims_mapping
             [[-1, -1], [1, -1]],  # input_grad_dims_mapping
@@ -549,13 +549,13 @@ class TestEinsumBroadcastPMDRule(TestEinsumSPMDRule):
         self.y_grad_partial_dims = {0}
 
         # forward
-        self.excepted_forward = [
+        self.expected_forward = [
             [[0, -1, -1, 1], [-1, 1, -1]],  # input_dims_mapping
             [-1, -1, -1],  # output_dims_mapping
         ]
 
         # backward
-        self.excepted_backward = [
+        self.expected_backward = [
             [[0, -1, -1, 1], [-1, 1, -1]],  # input_dims_mapping
             [-1, -1, -1],  # output_grad_dims_mapping
             [[0, -1, -1, 1], [-1, 1, -1]],  # input_grad_dims_mapping


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
第四批-编号29（共1个）
在基类 `TestEinsumSPMDRule` 及其多个子类中，用于存储预期前向传播和反向传播的分布属性的成员变量被错误地命名为 `excepted_xxx`，其中 "excepted" 是 “expected” 的拼写错误。此命名贯穿所有继承类，形成系统性命名缺陷
将所有 `self.excepted_backward` 和 `self.excepted_forward` 的定义与引用统一更正为 `self.expected_backward` 和 `self.expected_forward`，以符合正确语义。同时建议对相关测试方法中的局部变量 `excepted_dims_mapping` 等进行同步检查和修正，确保命名一致性。