### PR TITLE
4th-batch-117-可能的静默失败

### DIFF
--- a/python/paddle/distributed/auto_parallel/static/tuner/storable.py
+++ b/python/paddle/distributed/auto_parallel/static/tuner/storable.py
@@ -28,9 +28,12 @@ class Storable:
     def save(self, path):
         state = self.get_state()
         state_json = json.dumps(state)
-        with open(path, "w") as f:
-            f.write(state_json)
-        return str(path)
+        try:
+            with open(path, "w") as f:
+                f.write(state_json)
+            return str(path)
+        except OSError as e:
+            raise OSError(f"Failed to save file at {path}: {e}") from e
 
     def load(self, path):
         with open(path, "r") as f:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
第四批-编号117（共1处)
一旦 `open` 或 `write` 操作失败，异常会直接抛出，但当前方法没有提供任何异常处理机制，可能导致调用者无法正确处理写入失败的情况，甚至造成数据不一致或静默失败
添加 `try-except` 块捕获所有与文件操作相关的 I/O 异常（包括 `OSError` 和 `IOError`），并在捕获后重新抛出带有上下文信息的异常