### PR TITLE
4th-batch-125-多线程析构问题

### DIFF
--- a/paddle/fluid/distributed/ps/service/brpc_ps_client.cc
+++ b/paddle/fluid/distributed/ps/service/brpc_ps_client.cc
@@ -723,8 +723,12 @@ void BrpcPsClient::FinalizeWorker() {
   Flush();
   VLOG(0) << "BrpcPsClient::FinalizeWorker begin join thread";
   _running = false;
-  _async_push_dense_thread.join();
-  _async_push_sparse_thread.join();
+  if (_async_push_sparse_thread.joinable()) {
+    _async_push_sparse_thread.join();
+  }
+  if (_async_push_dense_thread.joinable()) {
+    _async_push_dense_thread.join();
+  }
   // _print_thread.join();
   VLOG(0) << "BrpcPsClient::FinalizeWorker begin join server";
   _server.Stop(1000);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
第四批-编号125（共1处)
两个线程在 `Initialize()` 函数中被创建，用于异步处理稀疏和稠密梯度推送任务。然而，创建后既未显式 `join()` 等待其结束，也未 `detach()` 将其设为后台线程。这意味着当 `BrpcPsClient` 对象析构或线程对象生命周期结束时，若线程仍在运行，`std::thread` 的析构函数会调用 `std::terminate()`，导致程序崩溃。更安全的做法是添加 `joinable()` 判断