### PR TITLE
4th-batch-31-代码检测对象错误

### DIFF
--- a/test/auto_parallel/test_dist_tensor.py
+++ b/test/auto_parallel/test_dist_tensor.py
@@ -117,19 +117,21 @@ class TestDistTensorFromFn(unittest.TestCase):
         )
         if paddle.in_dynamic_mode():
             dist_attr.dynamic_dims = []
-            self.assertIsInstance(result, paddle.Tensor)
-            self.assertEqual(result.shape, [16])
-            self.assertEqual(result.placements, placements)
+            self.assertIsInstance(result_random, paddle.Tensor)
+            self.assertEqual(result_random.shape, [16])
+            self.assertEqual(result_random.placements, placements)
         else:
             dist_attr.dynamic_dims = [0]
             dist_attr.chunk_id = 0
-            self.assertIsInstance(result, paddle.base.libpaddle.pir.Value)
-            self.assertEqual(result.shape, [16])
+            self.assertIsInstance(
+                result_random, paddle.base.libpaddle.pir.Value
+            )
+            self.assertEqual(result_random.shape, [16])
             self.assertEqual(
-                result.dist_attr().dims_mapping, dist_attr.dims_mapping
+                result_random.dist_attr().dims_mapping, dist_attr.dims_mapping
             )
             self.assertEqual(
-                result.dist_attr().process_mesh, dist_attr.process_mesh
+                result_random.dist_attr().process_mesh, dist_attr.process_mesh
             )
 
     def test_dynamic_mode(self):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
第四批-编号31（共1个）
在 `run_dtensor_from_fn` 方法中，对 `result_random` 的测试逻辑错误地复用了 `result` 变量进行类型和属性检查，而未直接检查 `result_random`本身，导致测试无法真实反映其类型和分布属性是否正确。
对 `result_random` 的测试应使用 `result_random` 变量进行验证。