### PR TITLE
4th-batch-111to113-修复一些代码逻辑问题

### DIFF
--- a/python/paddle/distributed/auto_parallel/static/process_mesh_v2.py
+++ b/python/paddle/distributed/auto_parallel/static/process_mesh_v2.py
@@ -56,16 +56,15 @@ class ProcessMesh(core.ProcessMesh):
         self._shape = list(self._mesh.shape)
 
         self._process_ids = self._mesh.flatten().tolist()
-        assert all(isinstance(p, int) for p in self._process_ids), (
-            "All elements of the mesh must be integer"
-        )
-        assert min(self._process_ids) >= 0, (
-            'All elements of the mesh must be >= 0.'
-        )
+        if not all(isinstance(p, int) for p in self._process_ids):
+            raise ValueError("All elements of the mesh must be integer")
+
+        if min(self._process_ids) < 0:
+            raise ValueError('All elements of the mesh must be >= 0.')
+
         unique_process_ids = set(self._process_ids)
-        assert len(unique_process_ids) == len(self._process_ids), (
-            'All elements of the mesh must be unique.'
-        )
+        if len(unique_process_ids) != len(self._process_ids):
+            raise ValueError('All elements of the mesh must be unique.')
 
         if dim_names is not None:
             assert len(dim_names) == len(self._shape), (

--- a/python/paddle/distributed/auto_parallel/static/tuner/algorithms.py
+++ b/python/paddle/distributed/auto_parallel/static/tuner/algorithms.py
@@ -124,8 +124,8 @@ class ShardingStageAlgorithm(AlgorithmBase):
             )
             stage_range.sort(reverse=True)
         else:
-            stage_range = list(range(self._max_stage + 1)).sort(reverse=True)
-
+            stage_range = list(range(self._max_stage + 1))
+            stage_range.sort(reverse=True)
         self._stage_range = stage_range[:]
         self._total_num_trial = len(self._stage_range)
 
@@ -173,8 +173,8 @@ class RecomputeCheckpointAlgorithm(AlgorithmBase):
 
         self._total_num_trial = len(segments)
         self._tuning_segments = list(range(len(segments)))
-        self._trail_left = 0
-        self._trail_right = len(segments) - 1
+        self._trial_left = 0
+        self._trial_right = len(segments) - 1
         self._trial_idx = int(0 + (len(segments) - 1) / 2)
 
     def _init_spaces(self):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
第四批-编号111、112、113（共3处)

- `static\tuner\algorithms.py`中正确初始化了 `_trial_idx` 为二分中点，并设置了左右边界变量 `_trail_left` 和 `_trail_right`。但是变量名称拼写错误（应为 `_trial_left` 和 `_trial_right`）。后续在 `update` 方法中使用了正确的逻辑结构进行二分更新，但因变量名不一致，实际读写的变量未被正确定义或持续维护，导致二分逻辑无法正确收敛。
- `static\tuner\algorithms.py`中，`list.sort()` 是原地排序方法，返回值为 `None`。因此 `stage_range` 被赋值为 `None`，后续对其执行切片操作 `[:]` 将导致 `TypeError: 'NoneType' object is not subscriptable`。先创建列表并赋值给 `stage_range`，再调用其 `sort(reverse=True)` 进行原地排序
- `static\process_mesh_v2.py`中将依赖 `assert` 的校验替换为显式的 `if` 判断并抛出 `ValueError`，确保无论是否启用 Python 优化模式，输入校验逻辑始终生效，保障关键安全属性不被绕过。