### PR TITLE
4th-batch-36-代码方法使用不当

### DIFF
--- a/test/cinn/conv2d_utils.py
+++ b/test/cinn/conv2d_utils.py
@@ -66,11 +66,11 @@ def conv2d_native(inputs_data, input_shape, filter_size, attrs, is_depthwise):
         if data_format == "NHWC":
             filter_hw = list(filter_size_new[1:3])
         if isinstance(stride, int):
-            stride = [stride.copy(), stride.copy()]
+            stride = [stride, stride]
         if isinstance(padding, int):
-            padding = [padding.copy(), padding.copy()]
+            padding = [padding, padding]
         if isinstance(dilation, int):
-            dilation = [dilation.copy(), dilation.copy()]
+            dilation = [dilation, dilation]
 
         c_index = 1 if data_format == "NCHW" else 3
         res = paddle.nn.Conv2D(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
第四批-编号36（共1个）
当 `stride`、`padding` 或 `dilation` 为整数时，代码试图调用 `int.copy()` 方法将其复制到列表中。但 Python 内置的 `int` 类型没有 `copy()` 方法（`copy` 是某些容器对象如 list、dict 的方法），因此这会导致 `AttributeError: 'int' object has no attribute 'copy'`。
移除 `.copy()` 调用，直接使用整数构造 `[value, value]` 形式的列表，避免非法方法调用。