### PR TITLE
4th-batch-110-未结合具体算子语义进行正确性校验，可能导致非法分布策略被接受

### DIFF
--- a/python/paddle/distributed/auto_parallel/static/planner.py
+++ b/python/paddle/distributed/auto_parallel/static/planner.py
@@ -90,23 +90,60 @@ class PlanFilter:
 
     @staticmethod
     def check_dims_mapping_for_special_op(op, op_dist_attr, vars):
-        # NOTE: Those ops has some partition limits, and will be solved when corresponding dist op implemented in the future.
-        if (
-            op.type == "elementwise_add"
-            or op.type == 'layer_norm'
-            or op.type == "softmax_with_cross_entropy"
-        ):
-            for name in op.input_arg_names:
-                for item in op_dist_attr.get_input_dims_mapping(name):
-                    if item != -1:
+        if op.type == "elementwise_add":
+            input_names = op.input_arg_names
+            if len(input_names) == 2:
+                in0_shape = vars[input_names[0]].shape
+                in1_shape = vars[input_names[1]].shape
+                dim_offset = len(in0_shape) - len(in1_shape)
+                for i in range(len(in1_shape)):
+                    idx0 = i + dim_offset
+                    idx1 = i
+                    dm0 = op_dist_attr.get_input_dims_mapping(input_names[0])[
+                        idx0
+                    ]
+                    dm1 = op_dist_attr.get_input_dims_mapping(input_names[1])[
+                        idx1
+                    ]
+                    if (
+                        in0_shape[idx0] != in1_shape[idx1]
+                        and dm0 != -1
+                        and dm1 != -1
+                        and dm0 == dm1
+                    ):
                         return False
-            for name in op.output_arg_names:
-                for item in op_dist_attr.get_output_dims_mapping(name):
-                    if item != -1:
-                        return False
-        if op.type == "lookup_table_v2":
+            return True
+
+        elif op.type == "layer_norm":
+            normalized_shape = op.attr("begin_norm_axis")
+            x_shape = vars[op.input("X")[0]].shape
+            reduce_dim_start = len(x_shape) - normalized_shape
+            dims_mapping = op_dist_attr.get_input_dims_mapping(op.input("X")[0])
+            output_dims_mapping = op_dist_attr.get_output_dims_mapping(
+                op.output("Y")[0]
+            )
+            for i in range(reduce_dim_start, len(x_shape)):
+                if dims_mapping[i] != -1:
+                    return False
+            for i in range(reduce_dim_start):
+                if dims_mapping[i] != output_dims_mapping[i]:
+                    return False
+            return True
+
+        elif op.type == "softmax_with_cross_entropy":
+            label_shape = vars[op.input("Label")[0]].shape
+            logits_shape = vars[op.input("Logits")[0]].shape
+            class_dim = len(logits_shape) - 1
+            dims_mapping = op_dist_attr.get_input_dims_mapping(
+                op.input("Logits")[0]
+            )
+            if dims_mapping[class_dim] != -1:
+                return False
+            return True
+
+        elif op.type == "lookup_table_v2":
             for name in op.input_arg_names:
-                if name == 'pos_embeddings':
+                if name == "pos_embeddings":
                     for item in op_dist_attr.get_input_dims_mapping(name):
                         if item != -1:
                             return False


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
第四批-编号110（共1处)
方法试图对特定算子施加分布约束，例如 `elementwise_add`、`layer_norm`、`softmax_with_cross_entropy` 要求所有输入输出 tensor 的 dims_mapping 全为 -1（即不并行化）。然而这种“一刀切”式的检查忽略了这些算子在真实场景中**允许部分维度并行**的情况。
修复后的代码针对每个特殊算子实施符合其语义的分布约束：
- `elementwise_add`：基于广播规则判断是否允许并行，避免在不可广播的维度上使用相同 process mesh dim；
- `layer_norm`：禁止在归一化维度上切分，并确保输入输出在非归一化维度上分布一致；
- `softmax_with_cross_entropy`：禁止在 class 维度（logits 的最后一维）上切分；
- 保留对 `lookup_table_v2` 中 `pos_embeddings` 的限制。