### PR TITLE
4th-batch-109-增加长度检查

### DIFF
--- a/python/paddle/distributed/auto_parallel/static/operators/dist_matmul.py
+++ b/python/paddle/distributed/auto_parallel/static/operators/dist_matmul.py
@@ -1004,10 +1004,10 @@ class DistributedMatmulImpl1(DistributedOperatorImpl):
             return False
         if is_dim_shard(out_dims_mapping[-1]):
             return False
-        if is_valid_list_index(out_dims_mapping, -2) and is_dim_shard(
-            out_dims_mapping[-2]
-        ):
-            return False
+        # Other dimensions must be replicate except the batch dimension
+        for mapping in out_dims_mapping[1:-1]:
+            if is_dim_shard(mapping):
+                return False
         return True
 
     def is_auto_compatible(self, dist_op):

--- a/python/paddle/distributed/auto_parallel/static/operators/dist_matmul.py
+++ b/python/paddle/distributed/auto_parallel/static/operators/dist_matmul.py
@@ -1000,12 +1000,14 @@ class DistributedMatmulImpl1(DistributedOperatorImpl):
         op_dist_attr = dist_op.dist_attr
         out_name = op_desc.output('Out')[0]
         out_dims_mapping = op_dist_attr.get_output_dims_mapping(out_name)
+        if len(out_dims_mapping) < 1:
+            return False
         if is_dim_shard(out_dims_mapping[-1]):
             return False
-        # Other dimensions must be replicate except the batch dimension
-        for mapping in out_dims_mapping[1:-1]:
-            if is_dim_shard(mapping):
-                return False
+        if is_valid_list_index(out_dims_mapping, -2) and is_dim_shard(
+            out_dims_mapping[-2]
+        ):
+            return False
         return True
 
     def is_auto_compatible(self, dist_op):

--- a/test/auto_parallel/hybrid_strategy/semi_auto_llama_save_load.py
+++ b/test/auto_parallel/hybrid_strategy/semi_auto_llama_save_load.py
@@ -148,7 +148,7 @@ class TestLlamaAuto:
             assert a_op.name() == b_op.name(), (
                 f'The name of {i} op in program is different: {a_op.name()} vs {b_op.name()}.'
             )
-            # check op inputs
+            # check op inputs1
             for index in range(a_op.num_operands()):
                 assert (
                     a_op.operand(index)

--- a/test/auto_parallel/hybrid_strategy/semi_auto_llama_save_load.py
+++ b/test/auto_parallel/hybrid_strategy/semi_auto_llama_save_load.py
@@ -148,7 +148,7 @@ class TestLlamaAuto:
             assert a_op.name() == b_op.name(), (
                 f'The name of {i} op in program is different: {a_op.name()} vs {b_op.name()}.'
             )
-            # check op inputs1
+            # check op inputs
             for index in range(a_op.num_operands()):
                 assert (
                     a_op.operand(index)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
第四批-编号109（共1处)
在访问 `out_dims_mapping[-1]` 前增加长度检查，确保列表至少有一个元素。这防止了当 `out_dims_mapping` 为空时发生索引越界异常，提高了函数鲁棒性。