### PR TITLE
4th-batch-37-代码逻辑错误

### DIFF
--- a/test/cinn/pool_utils.py
+++ b/test/cinn/pool_utils.py
@@ -162,25 +162,29 @@ def pool2d(np_data, attrs, dtype="float32"):
                         ) / np.maximum(pad_count, 1)
                 else:
                     if data_format == "NCHW":
-                        ret_np[:, :, i, j] = np.mean(
+                        window = (
                             pad_np[
                                 :,
                                 :,
                                 i * s_h : i * s_h + k_h,
                                 j * s_w : j * s_w + k_w,
                             ],
-                            axis=(height_axis, width_axis),
                         )
+                        ret_np[:, :, i, j] = np.sum(
+                            window, axis=(height_axis, width_axis)
+                        ) / (k_h * k_w)
                     else:
-                        ret_np[:, i, j, :] = np.mean(
+                        window = (
                             pad_np[
                                 :,
                                 i * s_h : i * s_h + k_h,
                                 j * s_w : j * s_w + k_w,
                                 :,
                             ],
-                            axis=(height_axis, width_axis),
                         )
+                        ret_np[:, i, j, :] = np.sum(
+                            window, axis=(height_axis, width_axis)
+                        ) / (k_h * k_w)
     elif pool_type == 'max':
         for i in range(out_shape[height_axis]):
             for j in range(out_shape[width_axis]):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
第四批-编号37（共1个）
该段代码在 `exclusive=False` 且 `pool_type='avg'` 时，直接对填充后的张量窗口使用 `np.mean` 计算平均值。`np.mean` 会将所有元素（包括填充区域）一并纳入求平均过程，但其行为等价于“总和 / 实际元素个数”，而这里的“实际元素个数”始终是 `k_h * k_w`。然而，关键问题是：**如果填充值不为零，则该平均值会被污染**。更重要的是，主流框架（如 PyTorch）在 `exclusive=False` 时的行为是：**无论填充值是否为零，都用总和除以 `k_h * k_w`**，即固定分母。而 `np.mean` 在数值上只有在填充值为零时才等效。因此，此实现与主流框架不一致，存在逻辑缺陷。
将 `np.mean(...)` 替换为显式的 `sum / (k_h * k_w)`，确保即使填充值非零，也严格按照标准 avg pool 的定义进行计算：每个输出元素是输入窗口（含填充）的总和除以窗口面积。这种实现方式与 PyTorch、PaddlePaddle 等主流框架在 `exclusive=False` 时的行为完全对齐，避免了因 `np.mean` 隐含假设填充值为零而导致的偏差。