### PR TITLE
4th-batch-38-日志信息错误

### DIFF
--- a/test/cinn/test_mobilenetv1.py
+++ b/test/cinn/test_mobilenetv1.py
@@ -57,7 +57,7 @@ class TestLoadMobilenetV1Model(unittest.TestCase):
         start = time.time()
         x_data = np.random.random(self.x_shape).astype("float32")
         self.executor = Interpreter([self.input_tensor], [self.x_shape])
-        print("self.mode_dir is:", self.model_dir)
+        print("self.model_dir is:", self.model_dir)
         # True means load combined model
         self.executor.load_paddle_model(
             self.model_dir, self.target, False, "mobilenetv1"


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
第四批-编号38（共1个）
虽然实际访问的是正确的属性 `self.model_dir`（拼写正确），但字符串字面量中写的是 `"self.mode_dir"`，这是一个明显的拼写错误，容易误导开发者认为该变量名为 `mode_dir`，造成维护困惑和调试困难。
将打印日志中的字符串 `"self.mode_dir"` 修正为 `"self.model_dir"`，与实际使用的对象属性名一致，保证日志输出的准确性和可读性，避免后续维护人员误解。