### PR TITLE
4th-batch-39-代码使用了已被弃置地函数

### DIFF
--- a/test/xpu/collective_broadcast_api_dygraph.py
+++ b/test/xpu/collective_broadcast_api_dygraph.py
@@ -16,7 +16,6 @@ import test_collective_api_base as test_base
 
 import paddle
 import paddle.distributed as dist
-from paddle import base
 
 
 class TestCollectiveBroadcastAPI(test_base.TestCollectiveAPIRunnerBase):
@@ -24,7 +23,7 @@ class TestCollectiveBroadcastAPI(test_base.TestCollectiveAPIRunnerBase):
         self.global_ring_id = 0
 
     def get_model(self, main_prog, startup_program, rank, indata=None):
-        with base.program_guard(main_prog, startup_program):
+        with paddle.static.program_guard(main_prog, startup_program):
             # NOTE: this is a hack relying on an undocumented behavior that `to_tensor` uses uint16 to replace bfloat16
             if indata.dtype == "bfloat16":
                 tindata = paddle.to_tensor(indata, "float32").cast("uint16")


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
第四批-编号39（共1个）
代码使用了 `paddle.fluid` 模块下的 `program_guard` 上下文管理器，通过别名 `base` 引用。这是旧版动态图前编程范式的典型用法，在当前 PaddlePaddle 主流版本（2.0+）中已被弃用。
将 `base.program_guard` 替换为 `paddle.static.program_guard`，以符合当前 PaddlePaddle 官方推荐的静态图编程方式，提升代码可维护性和未来兼容性。`paddle.static` 是 `paddle.fluid` 中静态图相关功能的官方迁移路径。