### PR TITLE
4th-batch-107-查询逻辑错误

### DIFF
--- a/python/paddle/distributed/auto_parallel/static/dist_context.py
+++ b/python/paddle/distributed/auto_parallel/static/dist_context.py
@@ -495,19 +495,12 @@ class DistributedContext:
         self._dist_ops_for_program[inner_serial_op_id] = dist_op
 
     def get_dist_tensor_for_program(self, serial_tensor):
-        serial_tensor_id = serial_tensor.desc.id()
+        serial_tensor_id = serial_tensor.desc.original_id()
         dist_tensor = self._dist_tensors_for_program.get(serial_tensor_id, None)
         if dist_tensor:
             return dist_tensor
         else:
-            serial_tensor_id = serial_tensor.desc.original_id()
-            dist_tensor = self._dist_tensors_for_program.get(
-                serial_tensor_id, None
-            )
-            if dist_tensor:
-                return dist_tensor
-            else:
-                return None
+            return None
 
     def get_dist_tensor_for_graph(self, serial_tensor_node):
         serial_tensor_node_id = _node_id(serial_tensor_node)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
第四批-编号107（共1处)
设计本意是以 `original_id()` 为唯一标识。因此优先查 `id()` 是无效操作。直接使用 `original_id()` 进行查询，与插入时保持一致，避免因 `id()` 和 `original_id()` 不一致导致的查找失败或不必要的二次查询。