### PR TITLE
4th-batch-41-代码运算逻辑错误

### DIFF
--- a/test/collective/fleet/dygraph_group_sharded_stage3_bf16.py
+++ b/test/collective/fleet/dygraph_group_sharded_stage3_bf16.py
@@ -83,7 +83,7 @@ def train_mlp(
             param.set_value(t)
 
     if sharding_stage == 3:
-        segment_size = 2 ^ 10  # threshold of each param
+        segment_size = 2**10  # threshold of each param
         model = GroupShardedStage3(
             model, optimizer, group=group, segment_size=segment_size
         )


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
第四批-编号41（共1个）
该行代码的意图是设置每个参数分段的阈值为 2 的 10 次方（即 1024），但错误地使用了按位异或运算符 `^`，Python 中幂运算应使用 `**`。因此 `2 ^ 10` 实际执行的是二进制异或操作：`0b10 ^ 0b1010 = 0b1000 = 8`，导致分段大小仅为 8，远小于合理值
将位运算符 `^` 替换为幂运算符 `**`，确保 `segment_size` 正确计算为 1024，符合分段内存管理的设计需求。