### PR TITLE
4th-batch-43-代码参数定义存在冲突

### DIFF
--- a/test/collective/fleet/hybrid_parallel_mp_amp.py
+++ b/test/collective/fleet/hybrid_parallel_mp_amp.py
@@ -27,13 +27,12 @@ class TestMPClipGrad(TestDistMPTraining):
             learning_rate=0.001, gamma=0.999, verbose=True
         )
         optimizer = paddle.optimizer.SGD(
-            scheduler,
+            learning_rate=scheduler,
             grad_clip=grad_clip,
             parameters=[
                 {
                     'params': model.parameters(),
                     'weight_decay': 0.001,
-                    'learning_rate': 0.1,
                 }
             ],
         )


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
第四批-编号43（共1个）
paddle.optimizer.SGD` 的第一个参数 `learning_rate` 要求是浮点数或 `LearningRateDecay` 类的实例（如 `ExponentialDecay`），但此处虽然传入的是 `ExponentialDecay` 实例，在参数位置上看似合法，然而后续又在 `parameters` 字典中显式指定了 `'learning_rate': 0.1`，这会造成学习率配置冲突。更重要的是，当使用 `scheduler` 作为 `learning_rate` 参数时，不应再在 `parameters` 中通过 `'learning_rate'` 覆盖，且实际训练中应由 `scheduler` 控制学习率变化。但当前用法中 `scheduler` 被当作 `learning_rate` 参数传入，而 `parameters` 中又设置了 `learning_rate=0.1`，这会覆盖 `scheduler` 的初始学习率，导致调度器失效。此外，PaddlePaddle 的 `SGD` 构造函数中若传入 `LearningRateDecay` 类型对象作为 `learning_rate`，则学习率应完全由该对象管理。但在此处，`scheduler` 的初始学习率为 `0.001`，而 `parameters` 中设置为 `0.1`，存在明显矛盾，导致行为不可预期。

修改后显式通过 `learning_rate=scheduler` 将调度器传入，并移除 `parameters` 中的 `'learning_rate': 0.1` 配置，避免覆盖调度器的学习率。这样 `ExponentialDecay` 才能正确从 `0.001` 开始按 `gamma=0.999` 衰减学习率。同时确保参数命名清晰，符合 PaddlePaddle API 规范。"