### PR TITLE
4th-batch-47-代码存在多进程独立性问题

### DIFF
--- a/test/collective/multinode/dygraph_hybrid_fp16.py
+++ b/test/collective/multinode/dygraph_hybrid_fp16.py
@@ -24,8 +24,8 @@ from paddle.distributed import fleet
 
 
 def weight_init(mp, shape, col=True, seed=1024):
-    np.random.seed(seed)
-    w = np.random.normal(0, 0.02, size=shape)
+    rng = np.random.RandomState(seed)
+    w = rng.normal(0, 0.02, size=shape)
     if mp is None:
         _w = w
     else:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
第四批-编号47（共1个）
代码调用 `weight_init` 函数为 `ColumnParallelLinear` 初始化权重。`weight_init` 内部使用 `np.random.seed(seed)` 设置随机种子，并基于当前 rank 对完整权重矩阵进行切片。但由于 `numpy` 的随机种子设置具有全局性且在多进程中易被覆盖，若多个进程同时执行此函数（如在不同 GPU 上），无法保证每个 rank 都独立、确定地生成相同的原始权重矩阵后再切分，导致不同卡上的参数初始化值不一致。
修改后将全局 `np.random.seed(seed)` 改为局部 `RandomState(seed)` 实例，避免多进程/多卡环境下因共享状态导致的随机数序列冲突。每个 rank 使用相同种子生成完全一致的原始权重矩阵，再按列或行切分，确保并行初始化的一致性和可重复性。