### PR TITLE
4th-batch-49-代码存在梯度暂存与恢复问题

### DIFF
--- a/test/collective/fleet/test_zero_bubble_utils.py
+++ b/test/collective/fleet/test_zero_bubble_utils.py
@@ -107,6 +107,8 @@ class TestZuroBubble(unittest.TestCase):
         o = splitbw_linear(input)
         o.mean().backward()
 
+        np.testing.assert_equal(splitbw_linear.weight.grad, None)
+
         zero_bubble_utils.WeightGradStore.flush()
         zero_bubble_utils.WeightGradStore.pop()
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
第四批-编号49(共1个)
代码在调用 `backward()` 后，`splitbw_linear.weight.grad` 尚未被恢复（因为 `WeightGradStore` 被启用），必须通过 `flush` 和 `pop` 才能恢复梯度。然而，断言发生在 `flush` 和 `pop` 之后，**但对 `splitbw_linear.weight.grad` 的访问却在 `pop` 之后**，这看似正确，但实际上 `test_zero_bubble_utils` 中对应逻辑明确检查了 `pop` 后梯度是否恢复，并做了 `is None` 判断，而本测试中直接访问 `.grad._md5sum()`，若 `grad` 仍为 `None` 会抛出异常。然而实际运行中未报错，说明 `grad` 并非 `None`，但关键问题是：**该测试没有验证“无 bias 时梯度暂存与恢复”的核心机制是否生效**，即缺少对 `weight.grad` 在 `flush/pop` 前为 `None` 的验证，导致测试覆盖不完整，本质上是测试逻辑缺失。
修改后在 `flush` 和 `pop` 之前添加对 `splitbw_linear.weight.grad` 是否为 `None` 的断言，以验证梯度确实被暂存；在恢复之后再进行梯度值的比对，确保测试完整覆盖了 `SplitBWLinear` 在无 bias 场景下的梯度暂存与恢复行为，从而真正测试目标功能。