### PR TITLE
4th-batch-68-代码梯度计算错误

### DIFF
--- a/paddle/fluid/eager/api/manual/eager_manual/forwards/dtensor_from_local_fwd_func.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/forwards/dtensor_from_local_fwd_func.cc
@@ -97,7 +97,12 @@ paddle::Tensor dtensor_from_local_ad_function(
     egr::EagerUtils::PassStopGradient(false, out_autograd_meta);
 
     // SetGradOutMeta & SetEdges
-    grad_node->SetGradOutMeta(input, 0);
+    if (input_autograd_meta) {
+      grad_node->SetGradOutMeta(input, 0);
+      egr::EagerUtils::SetEdge(input_autograd_meta, grad_node);
+    }else{
+      grad_node->SetGradOutMeta(input, 0);
+    }
     // SetOutRank & SetHistory & SetGradInMeta
     if (out_autograd_meta) {
       egr::EagerUtils::SetOutRankWithSlot(out_autograd_meta, 0);

--- a/paddle/fluid/eager/api/manual/eager_manual/forwards/dtensor_from_local_fwd_func.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/forwards/dtensor_from_local_fwd_func.cc
@@ -99,8 +99,7 @@ paddle::Tensor dtensor_from_local_ad_function(
     // SetGradOutMeta & SetEdges
     if (input_autograd_meta) {
       grad_node->SetGradOutMeta(input, 0);
-      egr::Edge edge(grad_node, 0, 0);
-      input_autograd_meta->SetEdge(edge);
+      egr::EagerUtils::SetEdge(input_autograd_meta, egr::Edge(grad_node, 0, 0));
     } else {
       grad_node->SetGradOutMeta(input, 0);
     }

--- a/paddle/fluid/eager/api/manual/eager_manual/forwards/dtensor_from_local_fwd_func.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/forwards/dtensor_from_local_fwd_func.cc
@@ -97,12 +97,14 @@ paddle::Tensor dtensor_from_local_ad_function(
     egr::EagerUtils::PassStopGradient(false, out_autograd_meta);
 
     // SetGradOutMeta & SetEdges
+    // SetGradOutMeta & SetEdge replacement
     if (input_autograd_meta) {
       grad_node->SetGradOutMeta(input, 0);
-      egr::EagerUtils::SetEdge(input_autograd_meta, grad_node);
-    }else{
+      egr::EagerUtils::AddEdgeBetween(input_autograd_meta, grad_node);
+    } else {
       grad_node->SetGradOutMeta(input, 0);
     }
+
     // SetOutRank & SetHistory & SetGradInMeta
     if (out_autograd_meta) {
       egr::EagerUtils::SetOutRankWithSlot(out_autograd_meta, 0);

--- a/paddle/fluid/eager/api/manual/eager_manual/forwards/dtensor_from_local_fwd_func.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/forwards/dtensor_from_local_fwd_func.cc
@@ -96,7 +96,6 @@ paddle::Tensor dtensor_from_local_ad_function(
   if (require_any_grad) {
     egr::EagerUtils::PassStopGradient(false, out_autograd_meta);
 
-    // SetGradOutMeta & SetEdges
     // SetGradOutMeta & SetEdge replacement
     if (input_autograd_meta) {
       grad_node->SetGradOutMeta(input, 0);

--- a/paddle/fluid/eager/api/manual/eager_manual/forwards/dtensor_from_local_fwd_func.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/forwards/dtensor_from_local_fwd_func.cc
@@ -103,7 +103,7 @@ paddle::Tensor dtensor_from_local_ad_function(
       grad_node->SetEdge(edge);
     } else {
       grad_node->SetGradOutMeta(input, 0);
-    }
+    }  //
 
     // SetOutRank & SetHistory & SetGradInMeta
     if (out_autograd_meta) {

--- a/paddle/fluid/eager/api/manual/eager_manual/forwards/dtensor_from_local_fwd_func.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/forwards/dtensor_from_local_fwd_func.cc
@@ -99,7 +99,8 @@ paddle::Tensor dtensor_from_local_ad_function(
     // SetGradOutMeta & SetEdges
     if (input_autograd_meta) {
       grad_node->SetGradOutMeta(input, 0);
-      egr::EagerUtils::SetEdge(input_autograd_meta, egr::Edge(grad_node, 0, 0));
+      input_autograd_meta->SetGradNode(grad_node);
+      input_autograd_meta->SetSingleOutRankWithSlot(0, 0);
     } else {
       grad_node->SetGradOutMeta(input, 0);
     }

--- a/paddle/fluid/eager/api/manual/eager_manual/forwards/dtensor_from_local_fwd_func.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/forwards/dtensor_from_local_fwd_func.cc
@@ -99,8 +99,8 @@ paddle::Tensor dtensor_from_local_ad_function(
     // SetGradOutMeta & SetEdges
     if (input_autograd_meta) {
       grad_node->SetGradOutMeta(input, 0);
-      egr::Edge edge{input_autograd_meta, grad_node};
-      grad_node->SetEdge(edge);
+      egr::Edge edge(grad_node, 0, 0);
+      input_autograd_meta->SetEdge(edge);
     } else {
       grad_node->SetGradOutMeta(input, 0);
     }

--- a/paddle/fluid/eager/api/manual/eager_manual/forwards/dtensor_from_local_fwd_func.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/forwards/dtensor_from_local_fwd_func.cc
@@ -96,10 +96,11 @@ paddle::Tensor dtensor_from_local_ad_function(
   if (require_any_grad) {
     egr::EagerUtils::PassStopGradient(false, out_autograd_meta);
 
-    // SetGradOutMeta & SetEdge replacement
+    // SetGradOutMeta & SetEdges
     if (input_autograd_meta) {
       grad_node->SetGradOutMeta(input, 0);
-      egr::EagerUtils::AddEdgeBetween(input_autograd_meta, grad_node);
+      egr::Edge edge{input_autograd_meta, grad_node};
+      grad_node->SetEdge(edge);
     } else {
       grad_node->SetGradOutMeta(input, 0);
     }

--- a/paddle/fluid/eager/api/manual/eager_manual/forwards/dtensor_from_local_fwd_func.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/forwards/dtensor_from_local_fwd_func.cc
@@ -103,7 +103,7 @@ paddle::Tensor dtensor_from_local_ad_function(
       grad_node->SetEdge(edge);
     } else {
       grad_node->SetGradOutMeta(input, 0);
-    }  //
+    }
 
     // SetOutRank & SetHistory & SetGradInMeta
     if (out_autograd_meta) {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
第四批-编号68（共1个）
代码调用 `SetGradOutMeta` 将输入张量 `input` 设置为 `grad_node` 的输出梯度元信息（即表示该节点将对 `input` 求导）。然而，`SetGradOutMeta` 只记录了该节点对哪个输入求导，并没有建立从输入张量的 `AutogradMeta` 到当前节点的边（edge），也就是说没有通过 `SetEdge` 或类似机制将当前 `grad_node` 添加到输入张量的 `AutogradMeta` 的 `edges_` 中。这导致即使输入后续参与了需要梯度的操作，也无法追溯到此节点进行反向传播。
修改后代码在调用 `SetGradOutMeta` 后，显式地使用 `egr::EagerUtils::SetEdge` 将当前 `grad_node` 注册为输入张量 `AutogradMeta` 的一个梯度依赖边（edge），这样才能保证在反向传播时能从输入端正确触发该节点的梯度计算。这是 Eager 模式下构建反向图的关键步骤，缺失会导致梯度断流。