### PR TITLE
4th-batch-70-代码数值精度错误

### DIFF
--- a/paddle/fluid/framework/attribute.h
+++ b/paddle/fluid/framework/attribute.h
@@ -106,7 +106,7 @@ struct ExtractAttribute<int64_t> {
       int val = PADDLE_GET_CONST(int, attr);
       attr = static_cast<int64_t>(val);
     } else if (attr.type() == typeid(float)) {  // NOLINT
-      int val = PADDLE_GET_CONST(float, attr);
+      float val = PADDLE_GET_CONST(float, attr);
       attr = static_cast<int64_t>(val);
     }
     int64_t* attr_value = nullptr;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
第四批-编号70（共1个）
代码此处将 `float` 类型的属性值通过 `PADDLE_GET_CONST(float, attr)` 取出后，错误地赋值给 `int` 类型变量 `val`，而不是直接转换为 `int64_t`。由于 `int` 通常为 32 位，最大表示约 `2.1e9`，而 `float` 可表示更大范围的整数值（如 `3e9`），此时会发生溢出或向零截断，导致最终转换为 `int64_t` 的值不正确。
修改后将 `float` 类型的原始值直接读取到 `float` 变量中，然后显式转换为 `int64_t`，避免经过 `int` 中间类型造成溢出或精度损失。这样可以确保从 `float` 到 `int64_t` 的转换是完整且语义正确的。