### PR TITLE
4th-batch-72-描述文本错误

### DIFF
--- a/paddle/fluid/framework/custom_operator.h
+++ b/paddle/fluid/framework/custom_operator.h
@@ -71,7 +71,8 @@ class CustomOpMaker : public OpProtoAndCheckerMaker {
         AddAttr<int64_t>(attr_name, "custom operator int64_t attribute.")
             .SetDefault(1);
       } else if (attr_type_str == "std::string") {
-        AddAttr<std::string>(attr_name, "custom operator int attribute.")
+        AddAttr<std::string>(attr_name,
+                             "custom operator std::string attribute.")
             .SetDefault("");
       } else if (attr_type_str == "std::vector<int>") {
         AddAttr<std::vector<int>>(attr_name,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
第四批-编号72（共1个）
当属性类型为 `"std::string"` 时，调用 `AddAttr<std::string>` 添加字符串类型的属性，但其描述字符串却写成了 `"custom operator int attribute."`，明显是复制粘贴其他分支（如 `int` 类型）时未修改注释内容，导致语义错误。
修改后将错误的描述 `"custom operator int attribute."` 修改为准确反映类型的 `"custom operator std::string attribute."`，使注释与实际数据类型一致，提升代码可读性和维护性，避免使用者误解。