### PR TITLE
4th-batch-73-代码存在逻辑缺失

### DIFF
--- a/paddle/fluid/framework/custom_operator.cc
+++ b/paddle/fluid/framework/custom_operator.cc
@@ -161,6 +161,8 @@ static void RunKernelFunc(
       kernel_ctx.EmplaceBackAttr(ctx.Attr<int>(attr_name));
     } else if (attr_type_str == "float") {
       kernel_ctx.EmplaceBackAttr(ctx.Attr<float>(attr_name));
+    } else if (attr_type_str == "double") {
+      kernel_ctx.EmplaceBackAttr(ctx.Attr<double>(attr_name));
     } else if (attr_type_str == "int64_t") {
       kernel_ctx.EmplaceBackAttr(ctx.Attr<int64_t>(attr_name));
     } else if (attr_type_str == "std::string") {
@@ -169,6 +171,8 @@ static void RunKernelFunc(
       kernel_ctx.EmplaceBackAttr(ctx.Attr<std::vector<int>>(attr_name));
     } else if (attr_type_str == "std::vector<float>") {
       kernel_ctx.EmplaceBackAttr(ctx.Attr<std::vector<float>>(attr_name));
+    } else if (attr_type_str == "std::vector<double>") {
+      kernel_ctx.EmplaceBackAttr(ctx.Attr<std::vector<double>>(attr_name));
     } else if (attr_type_str == "std::vector<int64_t>") {
       kernel_ctx.EmplaceBackAttr(ctx.Attr<std::vector<int64_t>>(attr_name));
     } else if (attr_type_str == "std::vector<std::string>") {
@@ -178,8 +182,9 @@ static void RunKernelFunc(
           "Unsupported `%s` type value as custom attribute now. "
           "Supported data types include `bool`, `int`, `float`, `double`, "
           "`int64_t`, `std::string`, `std::vector<int>`, "
-          "`std::vector<float>`, `std::vector<int64_t>`, "
-          "`std::vector<std::string>`, Please check whether "
+          "`std::vector<float>`, `std::vector<double>`, "
+          "`std::vector<int64_t>`,`std::vector<std::string>`, Please check "
+          "whether "
           "the attribute data type and data type string are matched.",
           attr_type_str));
     }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
第四批-编号73（共1个）
代码在 `RunKernelFunc` 函数中，遍历自定义算子的属性并根据字符串类型 `attr_type_str` 进行分发处理。尽管错误消息明确列出 `double` 是支持的类型，但在所有 `else if` 分支中并没有对 `"double"` 或 `attr_type_str == "double"` 的判断逻辑，因此当属性类型为 `double` 时会进入 `else` 分支并抛出 `Unimplemented` 错误。
修改后增加了对 `attr_type_str == "double"` 的分支处理，调用 `ctx.Attr<double>(attr_name)` 将其添加到 `kernel_ctx`。
   '- 增加了对 `std::vector<double>` 的支持（可选但建议），以保持与其它浮点类型的对称性。
      '- 更新错误提示信息中的类型列表，加入 `std::vector<double>`，避免误导用户。
      '- 此修复确保了文档/错误提示中声称支持的 `double` 类型真正被实现。