### PR TITLE
4th-batch-74-链接存在安全和失效风险

### DIFF
--- a/python/paddle/_paddle_docs.py
+++ b/python/paddle/_paddle_docs.py
@@ -1208,7 +1208,7 @@ add_doc_and_signature(
 
     The following diagram illustrates how a one-dimensional tensor is transformed into a tensor with a shape of [2,3] through the expand_as operation. The target tensor has a shape of [2,3], and through expand_as, the one-dimensional tensor is expanded into a tensor with a shape of [2,3].
 
-    .. image:: https://githubraw.cdn.bcebos.com/PaddlePaddle/docs/develop/docs/images/api_legend/expand_as.png
+    .. image:: https://raw.githubusercontent.com/PaddlePaddle/docs/develop/docs/images/api_legend/expand_as.png
         :width: 800
         :alt: expand_as API
         :align: center


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
第四批-编号74（共1个）
代码在 `expand_as` 函数的文档字符串中嵌入了一张示意图，使用了第三方 CDN 域名 `githubraw.cdn.bcebos.com` 来加载图片。该域名并非 GitHub 官方域名，也非 PaddlePaddle 官方托管域名，属于百度云加速服务的反向代理，可能导致内容被篡改、缓存污染或未来服务中断，从而影响文档的完整性与安全性。
修复后将图片链接从非官方CDN域名替换为GitHub官方原始内容地址（`raw.githubusercontent.com`），确保资源来源可信、稳定且不受第三方控制，消除安全与可用性风险。