### PR TITLE
4th-batch-80-反向传播查找梯度时可能缺失关键映射

### DIFF
--- a/python/paddle/autograd/ir_backward.py
+++ b/python/paddle/autograd/ir_backward.py
@@ -282,6 +282,8 @@ def prepare_grad_outputs(grad_outputs, outputs, state):
                     visited_output.add(opresult)
 
                     complete_outputs.append(opresult)
+                    if opresult not in state.value_to_valuegrad:
+                        state.value_to_valuegrad[opresult] = [[grad_value]]
 
     return grad_outputs, complete_outputs, backward_ops
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
第四批-编号80（共1处)
如果 `append_full_like` 因某种原因未成功注册（例如早期 return），则 `opresult` 将不会被加入 `value_to_valuegrad` 映射中，在调用后增加显式检查和赋值，可防止因函数提前返回、条件分支遗漏或未来修改导致注册失败的风险。