### PR TITLE
[Bug fix] fix

### DIFF
--- a/paddle/phi/common/bfloat16.h
+++ b/paddle/phi/common/bfloat16.h
@@ -325,7 +325,7 @@ HOSTDEVICE inline bool(isnan)(const bfloat16& a) {
 }
 
 HOSTDEVICE inline bool(isinf)(const bfloat16& a) {
-  return (a.x & 0x7F80) == 0x7F80;
+  return (a.x & 0x7FFF) == 0x7F80;
 }
 
 HOSTDEVICE inline bool(isfinite)(const bfloat16& a) {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Operator Mechanism


### PR Types
Bug fixes


### Description
更新把 bfloat16.h 中 `isinf` 的判定从 `(a.x & 0x7F80) == 0x7F80` 改成 `(a.x & 0x7FFF) == 0x7F80`，意义在于：

- 旧实现只屏蔽掉最高位的符号位，同时也在掩码里清除了 7 位尾数。当遇到 NaN（指数全 1、尾数非 0）时 `(a.x & 0x7F80)` 仍然等于 `0x7F80`，误把 NaN 判断成 Inf。
- 新实现在保留尾数位的情况下再比较，当尾数非零时与 `0x7F80` 不相等，因此能正确地区分 NaN 与 Inf。这让 `isinf` 只在尾数为 0 的 ±∞ 上返回 true，不会再误报 NaN。

这个改动修复了 bfloat16 类型上 `isinf` 对 NaN 的误判，提高了数值检查的准确性。
