### PR TITLE
[Bug Fix] Allow float16/bfloat16 Scalar to be converted to complex types

### DIFF
--- a/paddle/phi/common/scalar.h
+++ b/paddle/phi/common/scalar.h
@@ -148,9 +148,21 @@ class ScalarBase {
       case DataType::FLOAT64:
         return static_cast<RT>(data_.f64);
       case DataType::FLOAT16:
-        return static_cast<RT>(data_.f16);
+        if constexpr (std::is_same<RT, ::phi::complex64>::value) {
+          return ::phi::complex64(static_cast<float>(data_.f16));
+        } else if constexpr (std::is_same<RT, ::phi::complex128>::value) {
+          return ::phi::complex128(static_cast<double>(data_.f16));
+        } else {
+          return static_cast<RT>(data_.f16);
+        }
       case DataType::BFLOAT16:
-        return static_cast<RT>(data_.bf16);
+        if constexpr (std::is_same<RT, ::phi::complex64>::value) {
+          return ::phi::complex64(static_cast<float>(data_.bf16));
+        } else if constexpr (std::is_same<RT, ::phi::complex128>::value) {
+          return ::phi::complex128(static_cast<double>(data_.bf16));
+        } else {
+          return static_cast<RT>(data_.bf16);
+        }
       case DataType::INT32:
         return static_cast<RT>(data_.i32);
       case DataType::INT64:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Operator Mechanism


### PR Types
Bug fixes


### Description
- 针对 `ScalarBase::to<RT>()` 的 `FLOAT16` 和 `BFLOAT16` 分支加了特判。
- 原来这两个分支直接 `static_cast<RT>(data_.f16/bf16)`，当 `RT` 是 `phi::complex64/128` 时既不合法也会丢掉虚部信息，编译和运行都会出问题。
- 现在先把半精/脑浮点数转成对应精度的实数，再用 `phi::complex64/128` 构造出实部正确、虚部为 0 的复数；其它目标类型仍走原来的 `static_cast`。
- 效果是让半精度 / bfloat16 的标量能安全地转换成复数标量，后面像数据类型转换、新增的 Cast/测试代码才能顺利通过编译并得到预期数值。

issue: https://github.com/PaddlePaddle/Paddle/issues/75848