### PR TITLE
[Bug fix] Fix CastDataTypeFunctor for float8/float16/bfloat16 to complex on CPU/GPU

### DIFF
--- a/paddle/fluid/framework/data_type_transform.cc
+++ b/paddle/fluid/framework/data_type_transform.cc
@@ -32,6 +32,78 @@ struct CastDataTypeFunctor {
   }
 };
 
+template <>
+struct CastDataTypeFunctor<::phi::dtype::float8_e5m2,
+                           ::phi::dtype::complex<float>> {
+  HOSTDEVICE ::phi::dtype::complex<float> operator()(
+      ::phi::dtype::float8_e5m2 in) const {
+    return ::phi::dtype::complex<float>(static_cast<float>(in));
+  }
+};
+
+template <>
+struct CastDataTypeFunctor<::phi::dtype::float8_e5m2,
+                           ::phi::dtype::complex<double>> {
+  HOSTDEVICE ::phi::dtype::complex<double> operator()(
+      ::phi::dtype::float8_e5m2 in) const {
+    return ::phi::dtype::complex<double>(static_cast<double>(in));
+  }
+};
+
+template <>
+struct CastDataTypeFunctor<::phi::dtype::float8_e4m3fn,
+                           ::phi::dtype::complex<float>> {
+  HOSTDEVICE ::phi::dtype::complex<float> operator()(
+      ::phi::dtype::float8_e4m3fn in) const {
+    return ::phi::dtype::complex<float>(static_cast<float>(in));
+  }
+};
+
+template <>
+struct CastDataTypeFunctor<::phi::dtype::float8_e4m3fn,
+                           ::phi::dtype::complex<double>> {
+  HOSTDEVICE ::phi::dtype::complex<double> operator()(
+      ::phi::dtype::float8_e4m3fn in) const {
+    return ::phi::dtype::complex<double>(static_cast<double>(in));
+  }
+};
+
+template <>
+struct CastDataTypeFunctor<::phi::dtype::float16,
+                           ::phi::dtype::complex<float>> {
+  HOSTDEVICE ::phi::dtype::complex<float> operator()(
+      ::phi::dtype::float16 in) const {
+    return ::phi::dtype::complex<float>(static_cast<float>(in));
+  }
+};
+
+template <>
+struct CastDataTypeFunctor<::phi::dtype::float16,
+                           ::phi::dtype::complex<double>> {
+  HOSTDEVICE ::phi::dtype::complex<double> operator()(
+      ::phi::dtype::float16 in) const {
+    return ::phi::dtype::complex<double>(static_cast<double>(in));
+  }
+};
+
+template <>
+struct CastDataTypeFunctor<::phi::dtype::bfloat16,
+                           ::phi::dtype::complex<float>> {
+  HOSTDEVICE ::phi::dtype::complex<float> operator()(
+      ::phi::dtype::bfloat16 in) const {
+    return ::phi::dtype::complex<float>(static_cast<float>(in));
+  }
+};
+
+template <>
+struct CastDataTypeFunctor<::phi::dtype::bfloat16,
+                           ::phi::dtype::complex<double>> {
+  HOSTDEVICE ::phi::dtype::complex<double> operator()(
+      ::phi::dtype::bfloat16 in) const {
+    return ::phi::dtype::complex<double>(static_cast<double>(in));
+  }
+};
+
 #if defined(PADDLE_WITH_XPU)
 
 template <typename InType, typename OutType>

--- a/paddle/phi/core/framework/data_type_transform.cc
+++ b/paddle/phi/core/framework/data_type_transform.cc
@@ -34,6 +34,74 @@ struct CastDataTypeFunctor {
   }
 };
 
+template <>
+struct CastDataTypeFunctor<::phi::dtype::float8_e5m2, ::phi::complex64> {
+  HOSTDEVICE inline ::phi::complex64 operator()(
+      ::phi::dtype::float8_e5m2 in) const {
+    return ::phi::complex64(static_cast<float>(in));
+  }
+};
+
+template <>
+struct CastDataTypeFunctor<::phi::dtype::float8_e5m2, ::phi::complex128> {
+  HOSTDEVICE inline ::phi::complex128 operator()(
+      ::phi::dtype::float8_e5m2 in) const {
+    return ::phi::complex128(static_cast<double>(in));
+  }
+};
+
+template <>
+struct CastDataTypeFunctor<::phi::dtype::float8_e4m3fn, ::phi::complex64> {
+  HOSTDEVICE inline ::phi::complex64 operator()(
+      ::phi::dtype::float8_e4m3fn in) const {
+    return ::phi::complex64(static_cast<float>(in));
+  }
+};
+
+template <>
+struct CastDataTypeFunctor<::phi::dtype::float8_e4m3fn, ::phi::complex128> {
+  HOSTDEVICE inline ::phi::complex128 operator()(
+      ::phi::dtype::float8_e4m3fn in) const {
+    return ::phi::complex128(static_cast<double>(in));
+  }
+};
+
+template <>
+struct CastDataTypeFunctor<::phi::dtype::bfloat16,
+                           ::phi::dtype::complex<float>> {
+  HOSTDEVICE inline ::phi::dtype::complex<float> operator()(
+      ::phi::dtype::bfloat16 in) const {
+    return ::phi::dtype::complex<float>(static_cast<float>(in));
+  }
+};
+
+template <>
+struct CastDataTypeFunctor<::phi::dtype::bfloat16,
+                           ::phi::dtype::complex<double>> {
+  HOSTDEVICE inline ::phi::dtype::complex<double> operator()(
+      ::phi::dtype::bfloat16 in) const {
+    return ::phi::dtype::complex<double>(static_cast<double>(in));
+  }
+};
+
+template <>
+struct CastDataTypeFunctor<::phi::dtype::float16,
+                           ::phi::dtype::complex<float>> {
+  HOSTDEVICE inline ::phi::dtype::complex<float> operator()(
+      ::phi::dtype::float16 in) const {
+    return ::phi::dtype::complex<float>(static_cast<float>(in));
+  }
+};
+
+template <>
+struct CastDataTypeFunctor<::phi::dtype::float16,
+                           ::phi::dtype::complex<double>> {
+  HOSTDEVICE inline ::phi::dtype::complex<double> operator()(
+      ::phi::dtype::float16 in) const {
+    return ::phi::dtype::complex<double>(static_cast<double>(in));
+  }
+};
+
 #if defined(PADDLE_WITH_XPU)
 
 template <typename InType, typename OutType>

--- a/test/cpp/fluid/framework/data_type_transform_test.cc
+++ b/test/cpp/fluid/framework/data_type_transform_test.cc
@@ -14,7 +14,14 @@ limitations under the License. */
 
 #include "paddle/fluid/framework/data_type_transform.h"
 
+#include <vector>
+
 #include "gtest/gtest.h"
+#include "paddle/phi/common/bfloat16.h"
+#include "paddle/phi/common/complex.h"
+#include "paddle/phi/common/float16.h"
+#include "paddle/phi/common/float8_e4m3fn.h"
+#include "paddle/phi/common/float8_e5m2.h"
 
 TEST(DataTypeTransform, CPUTransform) {
   auto place = phi::CPUPlace();
@@ -39,6 +46,18 @@ TEST(DataTypeTransform, CPUTransform) {
 
   auto kernel_bool =
       phi::KernelKey(place, phi::DataLayout::ALL_LAYOUT, phi::DataType::BOOL);
+
+  auto kernel_fp8_e4m3 = phi::KernelKey(
+      place, phi::DataLayout::ALL_LAYOUT, phi::DataType::FLOAT8_E4M3FN);
+
+  auto kernel_fp8_e5m2 = phi::KernelKey(
+      place, phi::DataLayout::ALL_LAYOUT, phi::DataType::FLOAT8_E5M2);
+
+  auto kernel_complex64 = phi::KernelKey(
+      place, phi::DataLayout::ALL_LAYOUT, phi::DataType::COMPLEX64);
+
+  auto kernel_complex128 = phi::KernelKey(
+      place, phi::DataLayout::ALL_LAYOUT, phi::DataType::COMPLEX128);
 
   // data type transform from float32
   {
@@ -107,6 +126,21 @@ TEST(DataTypeTransform, CPUTransform) {
     bool* out_data_bool = out.data<bool>();
     for (int i = 0; i < data_number; ++i) {
       EXPECT_EQ(out_data_bool[i], static_cast<bool>(ptr[i]));
+    }
+
+    paddle::framework::TransDataType(kernel_fp16, kernel_complex64, in, &out);
+    auto* out_data_complex64 = out.data<phi::dtype::complex<float>>();
+    for (int i = 0; i < data_number; ++i) {
+      EXPECT_FLOAT_EQ(out_data_complex64[i].real(), static_cast<float>(ptr[i]));
+      EXPECT_FLOAT_EQ(out_data_complex64[i].imag(), 0.0f);
+    }
+
+    paddle::framework::TransDataType(kernel_fp16, kernel_complex128, in, &out);
+    auto* out_data_complex128 = out.data<phi::dtype::complex<double>>();
+    for (int i = 0; i < data_number; ++i) {
+      EXPECT_DOUBLE_EQ(out_data_complex128[i].real(),
+                       static_cast<double>(ptr[i]));
+      EXPECT_DOUBLE_EQ(out_data_complex128[i].imag(), 0.0);
     }
 
     // transform float to float16
@@ -219,6 +253,21 @@ TEST(DataTypeTransform, CPUTransform) {
       EXPECT_EQ(out_data_bool[i], static_cast<bool>(ptr[i]));
     }
 
+    paddle::framework::TransDataType(kernel_bf16, kernel_complex64, in, &out);
+    auto* out_data_complex64 = out.data<phi::dtype::complex<float>>();
+    for (int i = 0; i < data_number; ++i) {
+      EXPECT_FLOAT_EQ(out_data_complex64[i].real(), static_cast<float>(ptr[i]));
+      EXPECT_FLOAT_EQ(out_data_complex64[i].imag(), 0.0f);
+    }
+
+    paddle::framework::TransDataType(kernel_bf16, kernel_complex128, in, &out);
+    auto* out_data_complex128 = out.data<phi::dtype::complex<double>>();
+    for (int i = 0; i < data_number; ++i) {
+      EXPECT_DOUBLE_EQ(out_data_complex128[i].real(),
+                       static_cast<double>(ptr[i]));
+      EXPECT_DOUBLE_EQ(out_data_complex128[i].imag(), 0.0);
+    }
+
     // transform float to bfloat16
     float* in_data_float =
         in.mutable_data<float>(common::make_ddim({2, 3}), place);
@@ -284,6 +333,60 @@ TEST(DataTypeTransform, CPUTransform) {
     ptr = out.data<phi::dtype::bfloat16>();
     for (int i = 0; i < data_number; ++i) {
       EXPECT_EQ(ptr[i].x, static_cast<phi::dtype::bfloat16>(in_data_bool[i]).x);
+    }
+  }
+
+  // data type transform from float8
+  {
+    phi::DenseTensor in;
+    phi::DenseTensor out;
+
+    auto* ptr_e4m3 = in.mutable_data<phi::dtype::float8_e4m3fn>(
+        common::make_ddim({2, 3}), place);
+    int data_number = 2 * 3;
+
+    for (int i = 0; i < data_number; ++i) {
+      ptr_e4m3[i] = phi::dtype::float8_e4m3fn(static_cast<float>(i));
+    }
+
+    paddle::framework::TransDataType(
+        kernel_fp8_e4m3, kernel_complex64, in, &out);
+    auto* out_complex64 = out.data<phi::dtype::complex<float>>();
+    for (int i = 0; i < data_number; ++i) {
+      EXPECT_FLOAT_EQ(out_complex64[i].real(), static_cast<float>(ptr_e4m3[i]));
+      EXPECT_FLOAT_EQ(out_complex64[i].imag(), 0.0f);
+    }
+
+    paddle::framework::TransDataType(
+        kernel_fp8_e4m3, kernel_complex128, in, &out);
+    auto* out_complex128 = out.data<phi::dtype::complex<double>>();
+    for (int i = 0; i < data_number; ++i) {
+      EXPECT_DOUBLE_EQ(out_complex128[i].real(),
+                       static_cast<double>(static_cast<float>(ptr_e4m3[i])));
+      EXPECT_DOUBLE_EQ(out_complex128[i].imag(), 0.0);
+    }
+
+    auto* ptr_e5m2 = in.mutable_data<phi::dtype::float8_e5m2>(
+        common::make_ddim({2, 3}), place);
+    for (int i = 0; i < data_number; ++i) {
+      ptr_e5m2[i] = phi::dtype::float8_e5m2(static_cast<float>(i));
+    }
+
+    paddle::framework::TransDataType(
+        kernel_fp8_e5m2, kernel_complex64, in, &out);
+    out_complex64 = out.data<phi::dtype::complex<float>>();
+    for (int i = 0; i < data_number; ++i) {
+      EXPECT_FLOAT_EQ(out_complex64[i].real(), static_cast<float>(ptr_e5m2[i]));
+      EXPECT_FLOAT_EQ(out_complex64[i].imag(), 0.0f);
+    }
+
+    paddle::framework::TransDataType(
+        kernel_fp8_e5m2, kernel_complex128, in, &out);
+    out_complex128 = out.data<phi::dtype::complex<double>>();
+    for (int i = 0; i < data_number; ++i) {
+      EXPECT_DOUBLE_EQ(out_complex128[i].real(),
+                       static_cast<double>(static_cast<float>(ptr_e5m2[i])));
+      EXPECT_DOUBLE_EQ(out_complex128[i].imag(), 0.0);
     }
   }
 
@@ -393,6 +496,136 @@ TEST(DataTypeTransform, CPUTransform) {
     ptr = out.data<int32_t>();
     for (int i = 0; i < data_number; ++i) {
       EXPECT_EQ(ptr[i], static_cast<int32_t>(in_data_bool[i]));
+    }
+  }
+
+  // transform float8 to complex
+  {
+    phi::DenseTensor in;
+    phi::DenseTensor out;
+
+    auto* ptr = in.mutable_data<phi::dtype::float8_e5m2>(
+        common::make_ddim({2, 3}), place);
+    const int data_number = 2 * 3;
+    std::vector<float> stored_values(data_number);
+
+    for (int i = 0; i < data_number; ++i) {
+      ptr[i] = phi::dtype::float8_e5m2(static_cast<float>(i) - 2.5f);
+      stored_values[i] = static_cast<float>(ptr[i]);
+    }
+
+    paddle::framework::TransDataType(
+        kernel_fp8_e5m2, kernel_complex64, in, &out);
+    auto* out_data_complex64 = out.data<phi::dtype::complex<float>>();
+    for (int i = 0; i < data_number; ++i) {
+      EXPECT_FLOAT_EQ(out_data_complex64[i].real, stored_values[i]);
+      EXPECT_FLOAT_EQ(out_data_complex64[i].imag, 0.0f);
+    }
+
+    paddle::framework::TransDataType(
+        kernel_fp8_e5m2, kernel_complex128, in, &out);
+    auto* out_data_complex128 = out.data<phi::dtype::complex<double>>();
+    for (int i = 0; i < data_number; ++i) {
+      EXPECT_DOUBLE_EQ(out_data_complex128[i].real,
+                       static_cast<double>(stored_values[i]));
+      EXPECT_DOUBLE_EQ(out_data_complex128[i].imag, 0.0);
+    }
+  }
+
+  // transform float8_e4m3 to complex
+  {
+    phi::DenseTensor in;
+    phi::DenseTensor out;
+
+    auto* ptr = in.mutable_data<phi::dtype::float8_e4m3fn>(
+        common::make_ddim({2, 3}), place);
+    const int data_number = 2 * 3;
+    std::vector<float> stored_values(data_number);
+
+    for (int i = 0; i < data_number; ++i) {
+      ptr[i] = phi::dtype::float8_e4m3fn(static_cast<float>(i) - 1.75f);
+      stored_values[i] = static_cast<float>(ptr[i]);
+    }
+
+    paddle::framework::TransDataType(
+        kernel_fp8_e4m3, kernel_complex64, in, &out);
+    auto* out_data_complex64 = out.data<phi::dtype::complex<float>>();
+    for (int i = 0; i < data_number; ++i) {
+      EXPECT_FLOAT_EQ(out_data_complex64[i].real, stored_values[i]);
+      EXPECT_FLOAT_EQ(out_data_complex64[i].imag, 0.0f);
+    }
+
+    paddle::framework::TransDataType(
+        kernel_fp8_e4m3, kernel_complex128, in, &out);
+    auto* out_data_complex128 = out.data<phi::dtype::complex<double>>();
+    for (int i = 0; i < data_number; ++i) {
+      EXPECT_DOUBLE_EQ(out_data_complex128[i].real,
+                       static_cast<double>(stored_values[i]));
+      EXPECT_DOUBLE_EQ(out_data_complex128[i].imag, 0.0);
+    }
+  }
+
+  // transform float16 to complex
+  {
+    phi::DenseTensor in;
+    phi::DenseTensor out;
+
+    auto* ptr =
+        in.mutable_data<phi::dtype::float16>(common::make_ddim({2, 3}), place);
+    const int data_number = 2 * 3;
+    std::vector<float> stored_values(data_number);
+    std::vector<double> stored_values_double(data_number);
+
+    for (int i = 0; i < data_number; ++i) {
+      ptr[i] = static_cast<phi::dtype::float16>(static_cast<float>(i) - 3.0f);
+      stored_values[i] = static_cast<float>(ptr[i]);
+      stored_values_double[i] = static_cast<double>(ptr[i]);
+    }
+
+    paddle::framework::TransDataType(kernel_fp16, kernel_complex64, in, &out);
+    auto* out_data_complex64 = out.data<phi::dtype::complex<float>>();
+    for (int i = 0; i < data_number; ++i) {
+      EXPECT_FLOAT_EQ(out_data_complex64[i].real, stored_values[i]);
+      EXPECT_FLOAT_EQ(out_data_complex64[i].imag, 0.0f);
+    }
+
+    paddle::framework::TransDataType(kernel_fp16, kernel_complex128, in, &out);
+    auto* out_data_complex128 = out.data<phi::dtype::complex<double>>();
+    for (int i = 0; i < data_number; ++i) {
+      EXPECT_DOUBLE_EQ(out_data_complex128[i].real, stored_values_double[i]);
+      EXPECT_DOUBLE_EQ(out_data_complex128[i].imag, 0.0);
+    }
+  }
+
+  // transform bfloat16 to complex
+  {
+    phi::DenseTensor in;
+    phi::DenseTensor out;
+
+    auto* ptr =
+        in.mutable_data<phi::dtype::bfloat16>(common::make_ddim({2, 3}), place);
+    const int data_number = 2 * 3;
+    std::vector<float> stored_values(data_number);
+    std::vector<double> stored_values_double(data_number);
+
+    for (int i = 0; i < data_number; ++i) {
+      ptr[i] = static_cast<phi::dtype::bfloat16>(static_cast<float>(i) - 1.5f);
+      stored_values[i] = static_cast<float>(ptr[i]);
+      stored_values_double[i] = static_cast<double>(ptr[i]);
+    }
+
+    paddle::framework::TransDataType(kernel_bf16, kernel_complex64, in, &out);
+    auto* out_data_complex64 = out.data<phi::dtype::complex<float>>();
+    for (int i = 0; i < data_number; ++i) {
+      EXPECT_FLOAT_EQ(out_data_complex64[i].real, stored_values[i]);
+      EXPECT_FLOAT_EQ(out_data_complex64[i].imag, 0.0f);
+    }
+
+    paddle::framework::TransDataType(kernel_bf16, kernel_complex128, in, &out);
+    auto* out_data_complex128 = out.data<phi::dtype::complex<double>>();
+    for (int i = 0; i < data_number; ++i) {
+      EXPECT_DOUBLE_EQ(out_data_complex128[i].real, stored_values_double[i]);
+      EXPECT_DOUBLE_EQ(out_data_complex128[i].imag, 0.0);
     }
   }
 }

--- a/test/cpp/fluid/framework/data_type_transform_test.cu
+++ b/test/cpp/fluid/framework/data_type_transform_test.cu
@@ -15,6 +15,9 @@ limitations under the License. */
 #include "paddle/fluid/framework/data_type_transform.h"
 #include "gtest/gtest.h"
 #include "paddle/fluid/framework/tensor_util.h"
+#include "paddle/phi/common/complex.h"
+#include "paddle/phi/common/float8_e4m3fn.h"
+#include "paddle/phi/common/float8_e5m2.h"
 
 TEST(DataTypeTransform, GPUTransform) {
   auto cpu_place = phi::CPUPlace();
@@ -42,6 +45,18 @@ TEST(DataTypeTransform, GPUTransform) {
 
   auto kernel_bool = phi::KernelKey(
       gpu_place, phi::DataLayout::ALL_LAYOUT, phi::DataType::BOOL);
+
+  auto kernel_fp8_e4m3 = phi::KernelKey(
+      gpu_place, phi::DataLayout::ALL_LAYOUT, phi::DataType::FLOAT8_E4M3FN);
+
+  auto kernel_fp8_e5m2 = phi::KernelKey(
+      gpu_place, phi::DataLayout::ALL_LAYOUT, phi::DataType::FLOAT8_E5M2);
+
+  auto kernel_complex64 = phi::KernelKey(
+      gpu_place, phi::DataLayout::ALL_LAYOUT, phi::DataType::COMPLEX64);
+
+  auto kernel_complex128 = phi::KernelKey(
+      gpu_place, phi::DataLayout::ALL_LAYOUT, phi::DataType::COMPLEX128);
 
   // data type transform from float32
   {
@@ -76,6 +91,87 @@ TEST(DataTypeTransform, GPUTransform) {
     int* out_data_int = out.data<int>();
     for (int i = 0; i < data_number; ++i) {
       EXPECT_EQ(out_data_int[i], static_cast<int>(arr[i]));
+    }
+  }
+
+  // data type transform from float8
+  {
+    phi::DenseTensor in_cpu;
+    phi::DenseTensor in_gpu;
+    phi::DenseTensor out_gpu;
+    phi::DenseTensor out_cpu;
+
+    auto* ptr_e4m3 = in_cpu.mutable_data<phi::dtype::float8_e4m3fn>(
+        common::make_ddim({2, 3}), cpu_place);
+    int data_number = 2 * 3;
+    for (int i = 0; i < data_number; ++i) {
+      ptr_e4m3[i] = phi::dtype::float8_e4m3fn(static_cast<float>(i));
+    }
+
+    paddle::framework::TensorCopy(in_cpu, gpu_place, context, &in_gpu);
+    context.Wait();
+
+    paddle::framework::TransDataType(
+        kernel_fp8_e4m3, kernel_complex64, in_gpu, &out_gpu);
+    paddle::framework::TensorCopy(out_gpu, cpu_place, context, &out_cpu);
+    context.Wait();
+
+    auto* out_complex64 = out_cpu.data<phi::dtype::complex<float>>();
+    for (int i = 0; i < data_number; ++i) {
+      EXPECT_FLOAT_EQ(out_complex64[i].real(), static_cast<float>(ptr_e4m3[i]));
+      EXPECT_FLOAT_EQ(out_complex64[i].imag(), 0.0f);
+    }
+
+    paddle::framework::TransDataType(
+        kernel_fp8_e4m3, kernel_complex128, in_gpu, &out_gpu);
+    paddle::framework::TensorCopy(out_gpu, cpu_place, context, &out_cpu);
+    context.Wait();
+
+    auto* out_complex128 = out_cpu.data<phi::dtype::complex<double>>();
+    for (int i = 0; i < data_number; ++i) {
+      EXPECT_DOUBLE_EQ(out_complex128[i].real(),
+                       static_cast<double>(static_cast<float>(ptr_e4m3[i])));
+      EXPECT_DOUBLE_EQ(out_complex128[i].imag(), 0.0);
+    }
+  }
+
+  {
+    phi::DenseTensor in_cpu;
+    phi::DenseTensor in_gpu;
+    phi::DenseTensor out_gpu;
+    phi::DenseTensor out_cpu;
+
+    auto* ptr_e5m2 = in_cpu.mutable_data<phi::dtype::float8_e5m2>(
+        common::make_ddim({2, 3}), cpu_place);
+    int data_number = 2 * 3;
+    for (int i = 0; i < data_number; ++i) {
+      ptr_e5m2[i] = phi::dtype::float8_e5m2(static_cast<float>(i));
+    }
+
+    paddle::framework::TensorCopy(in_cpu, gpu_place, context, &in_gpu);
+    context.Wait();
+
+    paddle::framework::TransDataType(
+        kernel_fp8_e5m2, kernel_complex64, in_gpu, &out_gpu);
+    paddle::framework::TensorCopy(out_gpu, cpu_place, context, &out_cpu);
+    context.Wait();
+
+    auto* out_complex64 = out_cpu.data<phi::dtype::complex<float>>();
+    for (int i = 0; i < data_number; ++i) {
+      EXPECT_FLOAT_EQ(out_complex64[i].real(), static_cast<float>(ptr_e5m2[i]));
+      EXPECT_FLOAT_EQ(out_complex64[i].imag(), 0.0f);
+    }
+
+    paddle::framework::TransDataType(
+        kernel_fp8_e5m2, kernel_complex128, in_gpu, &out_gpu);
+    paddle::framework::TensorCopy(out_gpu, cpu_place, context, &out_cpu);
+    context.Wait();
+
+    auto* out_complex128 = out_cpu.data<phi::dtype::complex<double>>();
+    for (int i = 0; i < data_number; ++i) {
+      EXPECT_DOUBLE_EQ(out_complex128[i].real(),
+                       static_cast<double>(static_cast<float>(ptr_e5m2[i])));
+      EXPECT_DOUBLE_EQ(out_complex128[i].imag(), 0.0);
     }
   }
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Operator Mechanism


### PR Types
Bug fixes


### Description
**修改说明**
- data_type_transform.cc：补充了多组 `CastDataTypeFunctor` 模板特化，使 `float8_e4m3fn`、`float8_e5m2`、`float16` 和 `bfloat16` 在执行 `TransDataType` 时可以直接转成 `complex<float>` 与 `complex<double>`，从而让前向/反向在遇到复数 kernel 时不再报 “未实现” 的错误。
- data_type_transform.cc：在 PHI 层做同样的特化，保持底层算子框架与 Fluid 层逻辑一致，确保无论是老框架还是新框架都能处理上述低精度实数到复数的 cast。
- data_type_transform_test.cc：CPU 端单测新增对应覆盖，先构造多种精度的输入，再调用 `TransDataType` 转成 `complex64/complex128`，逐个断言实部保持值、虚部为 0，验证新增 cast 分支的正确性并防止回归。
- data_type_transform.h：接口声明保持不变，仅伴随实现侧更新继续复用同一套 API，无需额外改动。
- data_type_transform_test.cu：GPU 端单测同步扩展，通过把 `float8` 系列数据拷到 GPU 上再 cast 成复数，再拷回 CPU 校验，确保 GPU 端的新增特化在 XPU/GPU 设备上也能稳定工作。