### PR TITLE
clean get_cuda_version() < 11020 in tests

### DIFF
--- a/test/ir/pir/fused_pass/test_fused_weight_only_linear_pass.py
+++ b/test/ir/pir/fused_pass/test_fused_weight_only_linear_pass.py
@@ -39,8 +39,8 @@ def get_cuda_version():
 
 
 @unittest.skipIf(
-    not core.is_compiled_with_cuda() or get_cuda_version() < 11020,
-    "weight_only_linear requires CUDA >= 11.2",
+    not core.is_compiled_with_cuda(),
+    "weight_only_linear requires compiled with CUDA",
 )
 class TestFusedWeightOnlyLinearPass_WithBias(PassTest):
     def is_config_valid(self, w_shape, bias_shape):
@@ -146,8 +146,8 @@ class TestFusedWeightOnlyLinearPass_WithBias(PassTest):
 
 
 @unittest.skipIf(
-    not core.is_compiled_with_cuda() or get_cuda_version() < 11020,
-    "weight_only_linear requires CUDA >= 11.2",
+    not core.is_compiled_with_cuda(),
+    "weight_only_linear requires compiled with CUDA",
 )
 class TestFusedWeightOnlyLinearPass_NoBias(PassTest):
     def get_valid_op_map(self, dtype, w_shape):
@@ -233,8 +233,8 @@ class TestFusedWeightOnlyLinearPass_NoBias(PassTest):
 
 
 @unittest.skipIf(
-    not core.is_compiled_with_cuda() or get_cuda_version() < 11020,
-    "weight_only_linear requires CUDA >= 11.2",
+    not core.is_compiled_with_cuda(),
+    "weight_only_linear requires compiled with CUDA",
 )
 class TestFusedWeightOnlyLinearPass_Weight_Only_Int8(
     TestFusedWeightOnlyLinearPass_NoBias
@@ -252,8 +252,8 @@ class TestFusedWeightOnlyLinearPass_Weight_Only_Int8(
 
 
 @unittest.skipIf(
-    not core.is_compiled_with_cuda() or get_cuda_version() < 11020,
-    "weight_only_linear requires CUDA >= 11.2",
+    not core.is_compiled_with_cuda(),
+    "weight_only_linear requires compiled with CUDA",
 )
 class TestFusedWeightOnlyLinearPass_Weight_Only_Int8_WithBias(
     TestFusedWeightOnlyLinearPass_WithBias

--- a/test/legacy_test/test_fused_multi_transformer_int8_op.py
+++ b/test/legacy_test/test_fused_multi_transformer_int8_op.py
@@ -15,7 +15,6 @@ import unittest
 
 import numpy as np
 from op_test import get_device_place, is_custom_device
-from test_sparse_attention_op import get_cuda_version
 
 import paddle
 import paddle.nn.functional as F
@@ -131,9 +130,8 @@ def fused_multi_transformer_int8(
 
 @unittest.skipIf(
     not (core.is_compiled_with_cuda() or is_custom_device())
-    or get_cuda_version() < 11020
     or paddle.device.cuda.get_device_capability()[0] < 8,
-    "FusedMultiTransformerInt8 requires CUDA >= 11.2 and CUDA_ARCH >= 8",
+    "FusedMultiTransformerInt8 requires CUDA_ARCH >= 8",
 )
 class TestFusedMultiTransformerInt8Op(unittest.TestCase):
     def setUp(self):
@@ -788,9 +786,8 @@ class TestFusedMultiTransformerInt8Op(unittest.TestCase):
 
 @unittest.skipIf(
     not (core.is_compiled_with_cuda() or is_custom_device())
-    or get_cuda_version() < 11020
     or paddle.device.cuda.get_device_capability()[0] < 8,
-    "FusedMultiTransformerInt8 requires CUDA >= 11.2 and CUDA_ARCH >= 8",
+    "FusedMultiTransformerInt8 requires CUDA_ARCH >= 8",
 )
 class TestFusedMultiTransformerInt8OpFp16(TestFusedMultiTransformerInt8Op):
     def config(self):
@@ -801,9 +798,8 @@ class TestFusedMultiTransformerInt8OpFp16(TestFusedMultiTransformerInt8Op):
 
 @unittest.skipIf(
     not (core.is_compiled_with_cuda() or is_custom_device())
-    or get_cuda_version() < 11020
     or paddle.device.cuda.get_device_capability()[0] < 8,
-    "FusedMultiTransformerInt8 requires CUDA >= 11.2 and CUDA_ARCH >= 8",
+    "FusedMultiTransformerInt8 requires CUDA_ARCH >= 8",
 )
 class TestFusedMultiTransformerInt8OpCacheKV(TestFusedMultiTransformerInt8Op):
     def config(self):
@@ -817,9 +813,8 @@ class TestFusedMultiTransformerInt8OpCacheKV(TestFusedMultiTransformerInt8Op):
 
 @unittest.skipIf(
     not (core.is_compiled_with_cuda() or is_custom_device())
-    or get_cuda_version() < 11020
     or paddle.device.cuda.get_device_capability()[0] < 8,
-    "FusedMultiTransformerInt8 requires CUDA >= 11.2 and CUDA_ARCH >= 8",
+    "FusedMultiTransformerInt8 requires CUDA_ARCH >= 8",
 )
 class TestFusedMultiTransformerInt8OpCacheKVFp16(
     TestFusedMultiTransformerInt8Op
@@ -834,9 +829,8 @@ class TestFusedMultiTransformerInt8OpCacheKVFp16(
 
 @unittest.skipIf(
     not (core.is_compiled_with_cuda() or is_custom_device())
-    or get_cuda_version() < 11020
     or paddle.device.cuda.get_device_capability()[0] < 8,
-    "FusedMultiTransformerInt8 requires CUDA >= 11.2 and CUDA_ARCH >= 8",
+    "FusedMultiTransformerInt8 requires CUDA_ARCH >= 8",
 )
 class TestFusedMultiTransformerInt8OpGenCacheKV(
     TestFusedMultiTransformerInt8Op
@@ -849,9 +843,8 @@ class TestFusedMultiTransformerInt8OpGenCacheKV(
 
 @unittest.skipIf(
     not (core.is_compiled_with_cuda() or is_custom_device())
-    or get_cuda_version() < 11020
     or paddle.device.cuda.get_device_capability()[0] < 8,
-    "FusedMultiTransformerInt8 requires CUDA >= 11.2 and CUDA_ARCH >= 8",
+    "FusedMultiTransformerInt8 requires CUDA_ARCH >= 8",
 )
 class TestFusedMultiTransformerInt8OpGenCacheKVFp16(
     TestFusedMultiTransformerInt8Op
@@ -866,9 +859,8 @@ class TestFusedMultiTransformerInt8OpGenCacheKVFp16(
 
 @unittest.skipIf(
     not (core.is_compiled_with_cuda() or is_custom_device())
-    or get_cuda_version() < 11020
     or paddle.device.cuda.get_device_capability()[0] < 8,
-    "FusedMultiTransformerInt8 requires CUDA >= 11.2 and CUDA_ARCH >= 8",
+    "FusedMultiTransformerInt8 requires CUDA_ARCH >= 8",
 )
 class TestFusedMultiTransformerInt8OpPostLayerNormFp16(
     TestFusedMultiTransformerInt8Op
@@ -882,9 +874,8 @@ class TestFusedMultiTransformerInt8OpPostLayerNormFp16(
 
 @unittest.skipIf(
     not (core.is_compiled_with_cuda() or is_custom_device())
-    or get_cuda_version() < 11020
     or paddle.device.cuda.get_device_capability()[0] < 8,
-    "FusedMultiTransformerInt8 requires CUDA >= 11.2 and CUDA_ARCH >= 8",
+    "FusedMultiTransformerInt8 requires CUDA_ARCH >= 8",
 )
 class TestFusedMultiTransformerInt8OpCacheKVPostLayerNorm(
     TestFusedMultiTransformerInt8Op
@@ -900,9 +891,8 @@ class TestFusedMultiTransformerInt8OpCacheKVPostLayerNorm(
 
 @unittest.skipIf(
     not (core.is_compiled_with_cuda() or is_custom_device())
-    or get_cuda_version() < 11020
     or paddle.device.cuda.get_device_capability()[0] < 8,
-    "FusedMultiTransformerInt8 requires CUDA >= 11.2 and CUDA_ARCH >= 8",
+    "FusedMultiTransformerInt8 requires CUDA_ARCH >= 8",
 )
 class TestFusedMultiTransformerInt8OpCacheKVPostLayerNormFp16(
     TestFusedMultiTransformerInt8Op
@@ -918,9 +908,8 @@ class TestFusedMultiTransformerInt8OpCacheKVPostLayerNormFp16(
 
 @unittest.skipIf(
     not (core.is_compiled_with_cuda() or is_custom_device())
-    or get_cuda_version() < 11020
     or paddle.device.cuda.get_device_capability()[0] < 8,
-    "FusedMultiTransformerInt8 requires CUDA >= 11.2 and CUDA_ARCH >= 8",
+    "FusedMultiTransformerInt8 requires CUDA_ARCH >= 8",
 )
 class TestFusedMultiTransformerInt8OpGenCacheKVPostLayerNorm(
     TestFusedMultiTransformerInt8Op
@@ -934,9 +923,8 @@ class TestFusedMultiTransformerInt8OpGenCacheKVPostLayerNorm(
 
 @unittest.skipIf(
     not (core.is_compiled_with_cuda() or is_custom_device())
-    or get_cuda_version() < 11020
     or paddle.device.cuda.get_device_capability()[0] < 8,
-    "FusedMultiTransformerInt8 requires CUDA >= 11.2 and CUDA_ARCH >= 8",
+    "FusedMultiTransformerInt8 requires CUDA_ARCH >= 8",
 )
 class TestFusedMultiTransformerInt8OpGenCacheKVPostLayerNormFp16(
     TestFusedMultiTransformerInt8Op

--- a/test/legacy_test/test_variable_length_memory_efficient_attention.py
+++ b/test/legacy_test/test_variable_length_memory_efficient_attention.py
@@ -96,8 +96,9 @@ def naive_attention_impl(query, key, value, mask, scale):
 
 
 @unittest.skipIf(
-    not (core.is_compiled_with_cuda() or is_custom_device()),
-    "core is not compiled with CUDA",
+    not (core.is_compiled_with_cuda() or is_custom_device())
+    or get_cuda_version() < 11020,
+    "core is not compiled with CUDA and cuda version need larger than or equal to 11.2",
 )
 class TestMemEffAttentionVariableAPI(unittest.TestCase):
     def setUp(self):
@@ -217,6 +218,7 @@ class TestMemEffAPIVariableDtypeFP16(TestMemEffAttentionVariableAPI):
 
 @unittest.skipIf(
     not (core.is_compiled_with_cuda() or is_custom_device())
+    or get_cuda_version() < 11020
     or get_cuda_arch() < 8,
     "MemEffAPIVariableDtypeBF16 requires CUDA >= 11.2 and CUDA_ARCH >= 8",
 )
@@ -261,8 +263,9 @@ class TestMemEffAPIVariableDtypeBF16(TestMemEffAttentionVariableAPI):
 
 
 @unittest.skipIf(
-    not (core.is_compiled_with_cuda() or is_custom_device()),
-    "core is not compiled with CUDA",
+    not (core.is_compiled_with_cuda() or is_custom_device())
+    or get_cuda_version() < 11020,
+    "core is not compiled with CUDA and cuda version need larger than or equal to 11.2",
 )
 class TestMemEffAPIVariableDtypeFP16Static(unittest.TestCase):
     def setUp(self):
@@ -355,8 +358,9 @@ class TestMemEffAPIVariableDtypeFP16Static(unittest.TestCase):
 
 
 @unittest.skipIf(
-    not (core.is_compiled_with_cuda() or is_custom_device()),
-    "core is not compiled with CUDA",
+    not (core.is_compiled_with_cuda() or is_custom_device())
+    or get_cuda_version() < 11020,
+    "core is not compiled with CUDA and cuda version need larger than or equal to 11.2",
 )
 class TestMemEffAttentionVariableAPI_ZeroSize(unittest.TestCase):
     def setUp(self):

--- a/test/legacy_test/test_variable_length_memory_efficient_attention.py
+++ b/test/legacy_test/test_variable_length_memory_efficient_attention.py
@@ -96,9 +96,8 @@ def naive_attention_impl(query, key, value, mask, scale):
 
 
 @unittest.skipIf(
-    not (core.is_compiled_with_cuda() or is_custom_device())
-    or get_cuda_version() < 11020,
-    "core is not compiled with CUDA and cuda version need larger than or equal to 11.2",
+    not (core.is_compiled_with_cuda() or is_custom_device()),
+    "core is not compiled with CUDA",
 )
 class TestMemEffAttentionVariableAPI(unittest.TestCase):
     def setUp(self):
@@ -218,7 +217,6 @@ class TestMemEffAPIVariableDtypeFP16(TestMemEffAttentionVariableAPI):
 
 @unittest.skipIf(
     not (core.is_compiled_with_cuda() or is_custom_device())
-    or get_cuda_version() < 11020
     or get_cuda_arch() < 8,
     "MemEffAPIVariableDtypeBF16 requires CUDA >= 11.2 and CUDA_ARCH >= 8",
 )
@@ -263,9 +261,8 @@ class TestMemEffAPIVariableDtypeBF16(TestMemEffAttentionVariableAPI):
 
 
 @unittest.skipIf(
-    not (core.is_compiled_with_cuda() or is_custom_device())
-    or get_cuda_version() < 11020,
-    "core is not compiled with CUDA and cuda version need larger than or equal to 11.2",
+    not (core.is_compiled_with_cuda() or is_custom_device()),
+    "core is not compiled with CUDA",
 )
 class TestMemEffAPIVariableDtypeFP16Static(unittest.TestCase):
     def setUp(self):
@@ -358,9 +355,8 @@ class TestMemEffAPIVariableDtypeFP16Static(unittest.TestCase):
 
 
 @unittest.skipIf(
-    not (core.is_compiled_with_cuda() or is_custom_device())
-    or get_cuda_version() < 11020,
-    "core is not compiled with CUDA and cuda version need larger than or equal to 11.2",
+    not (core.is_compiled_with_cuda() or is_custom_device()),
+    "core is not compiled with CUDA",
 )
 class TestMemEffAttentionVariableAPI_ZeroSize(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience

### PR Types
Others 

### Description
<!-- Describe what you’ve done -->
CUDA 版本已大于11.2，移除测试中判断 get_cuda_version() < 11020 
