### PR TITLE
4th-batch-92-防止因配置错误或状态不同步导致的梯度缓冲区错配问题

### DIFF
--- a/python/paddle/distributed/auto_parallel/api.py
+++ b/python/paddle/distributed/auto_parallel/api.py
@@ -1549,7 +1549,10 @@ class _ShardOptimizer(Optimizer):
         for layer in self._layers.sublayers():
             for p in layer.parameters(include_sublayers=False):
                 param2layer[id(p)] = layer
-
+        if len(self.fuse_param_view) != len(self.grad_storage):
+            raise RuntimeError(
+                f"Length mismatch: fuse_param_view ({len(self.fuse_param_view)}) vs grad_storage ({len(self.grad_storage)})"
+            )
         for i in range(len(self.fuse_param_view)):
             self._reduce_scatter_gradients(self.grad_storage[i])
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
第四批-编号92（共1处)
循环假设 `self.fuse_param_view` 与 `self.grad_storage` 按索引一一对应，但代码中无任何约束或校验机制。若两者长度不同或顺序错位（如因动态网络结构、参数冻结等），将导致对错误梯度缓冲区执行 `reduce_scatter`，破坏模型收敛性。
增加长度一致性校验，防止因配置错误或状态不同步导致的缓冲区错配问题，提升系统鲁棒性。