### PR TITLE
4th-batch-93to94-未校验数据有效性

### DIFF
--- a/python/paddle/distributed/auto_parallel/api.py
+++ b/python/paddle/distributed/auto_parallel/api.py
@@ -2399,11 +2399,17 @@ def shard_scaler(scaler: GradScaler) -> GradScaler:
                             tgt_grad, '_is_initialized', lambda: False
                         )()
                     ):
-                        if src_mesh is None:
+                        if (
+                            src_mesh is None
+                            and tgt_grad.process_mesh is not None
+                        ):
                             src_mesh = tgt_grad.process_mesh
+                        else:
+                            pass
                         if (
                             current_process_mesh is None
                             and tgt_grad._is_initialized()
+                            and tgt_grad.process_mesh is not None
                         ):
                             current_process_mesh = tgt_grad.process_mesh
                         if tgt_grad.process_mesh not in mesh2param_grads:
@@ -2506,6 +2512,12 @@ def shard_scaler(scaler: GradScaler) -> GradScaler:
                     self._found_inf, process_mesh, self._found_inf.placements
                 )
         else:
+            if current_process_mesh is None or not hasattr(
+                current_process_mesh, "ranks"
+            ):
+                raise ValueError(
+                    "Invalid current_process_mesh: must be a valid ProcessMesh."
+                )
             # The rank of other mesh, should overwrite the original variable `self._found_inf`
             self._found_inf = dist.reshard(
                 self._found_inf,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
第四批-编号93、94（共2处)

- 当 `self._found_inf.process_mesh` 不等于 `current_process_mesh` 时，直接使用 `current_process_mesh` 对 `self._found_inf` 进行 reshard 并赋值，但未验证 `current_process_mesh` 是否有效或是否在预期的设备集合中，也未判断 `dist.reshard` 是否支持该 mesh 变换。若 `current_process_mesh` 非法或不兼容，可能引发运行时错误或数据错乱。
- 修复代码增加了对 `current_process_mesh` 的合法性检查，确保其非空且具有 `ranks` 属性（典型 ProcessMesh 特征），防止传入无效 mesh 导致 `dist.reshard` 失败或产生未定义行为
- `tgt_grad.process_mesh` 可能为 None 或不同设备上的无效 mesh，直接赋值给 `src_mesh` 或 `current_process_mesh` 会导致后续 `dist.reshard(temp_found_inf, src_mesh, ...)` 使用非法 mesh 引发运行时错误或逻辑错误。此外，未对多个梯度间 `process_mesh` 是否一致做检查，可能导致混合不同并行策略的 mesh。
- 增加 `tgt_grad.process_mesh is not None` 的显式判断，防止将 None 赋值给 `src_mesh` 或 `current_process_mesh`。可在外部设置默认 mesh 或报错提示，提升鲁棒性。避免后续使用 None mesh 进行 reshard 导致崩溃。