### PR TITLE
clean CUDA_VERSION >= 11020 in cusparseLt.h

### DIFF
--- a/paddle/phi/backends/dynload/cusparseLt.h
+++ b/paddle/phi/backends/dynload/cusparseLt.h
@@ -48,7 +48,6 @@ extern void *cusparselt_dso_handle;
   };                                                                    \
   extern DynLoad__##__name __name
 #if defined(PADDLE_WITH_CUDA)
-#if CUDA_VERSION >= 11020
 #define CUSPARSELT_ROUTINE_EACH(__macro)       \
   __macro(cusparseLtInit);                     \
   __macro(cusparseLtDestroy);                  \
@@ -70,7 +69,6 @@ extern void *cusparselt_dso_handle;
   __macro(cusparseGetErrorString);
 
 CUSPARSELT_ROUTINE_EACH(DECLARE_DYNAMIC_LOAD_CUSPARSELT_WRAP);
-#endif
 #endif
 
 #undef DECLARE_DYNAMIC_LOAD_CUSPARSELT_WRAP

--- a/paddle/phi/backends/dynload/dynamic_loader.cc
+++ b/paddle/phi/backends/dynload/dynamic_loader.cc
@@ -1070,7 +1070,8 @@ void* GetMKLRTDsoHandle() {
 void* GetCusparseLtDsoHandle() {
 #if defined(PADDLE_WITH_CUSTOM_DEVICE)
   return GetDsoHandleFromSearchPath(FLAGS_cusparselt_dir, SPARSELT_LIB_NAME);
-#elif defined(PADDLE_WITH_CUDA)
+// APIs available after CUDA 11.2
+#elif defined(PADDLE_WITH_CUDA) && CUDA_VERSION >= 11020
   return GetDsoHandleFromSearchPath(FLAGS_cusparselt_dir, "libcusparseLt.so");
 #else
   std::string warning_msg(

--- a/paddle/phi/backends/dynload/dynamic_loader.cc
+++ b/paddle/phi/backends/dynload/dynamic_loader.cc
@@ -1070,8 +1070,7 @@ void* GetMKLRTDsoHandle() {
 void* GetCusparseLtDsoHandle() {
 #if defined(PADDLE_WITH_CUSTOM_DEVICE)
   return GetDsoHandleFromSearchPath(FLAGS_cusparselt_dir, SPARSELT_LIB_NAME);
-// APIs available after CUDA 11.2
-#elif defined(PADDLE_WITH_CUDA) && CUDA_VERSION >= 11020
+#elif defined(PADDLE_WITH_CUDA)
   return GetDsoHandleFromSearchPath(FLAGS_cusparselt_dir, "libcusparseLt.so");
 #else
   std::string warning_msg(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience

### PR Types
Others 

### Description
<!-- Describe what you’ve done -->
清理 paddle/phi/backends/dynload/cusparseLt.h 中 CUDA_VERSION >= 11020，CUDA当前安装版本为>=11.8
