### PR TITLE
4th-batch-95-逻辑等价但对象不同的 mesh 可能会误判

### DIFF
--- a/python/paddle/distributed/auto_parallel/api.py
+++ b/python/paddle/distributed/auto_parallel/api.py
@@ -614,9 +614,17 @@ class _moe_sub_mesh_tensors(PyLayer):
                         "the args global_mesh and global_placements should be set together"
                     )
                 ori_mesh = dist_tensor.process_mesh
-                if global_mesh != dist_tensor.process_mesh:
+                if not (
+                    global_mesh.shape == dist_tensor.process_mesh.shape
+                    and np.array_equal(
+                        global_mesh.process_ids,
+                        dist_tensor.process_mesh.process_ids,
+                    )
+                    and global_mesh.dim_names
+                    == dist_tensor.process_mesh.dim_names
+                ):
                     raise ValueError(
-                        "the global_mesh should be the same as dist_tensor's process_mesh."
+                        "the global_mesh should have the same shape, process_ids and dim_names as dist_tensor's process_mesh."
                     )
                 assert check_placements_equal(
                     global_placements, dist_tensor.placements


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
第四批-编号95（共1处)
直接使用 `!=` 可能比较的是对象引用而非内容，导致两个内容相同但不同实例的 mesh 被误判为不等
修复代码显式比较 `ProcessMesh` 的核心属性（shape、process_ids、dim_names），确保内容一致性而非引用一致性，避免因对象不同实例导致的误判。