### PR TITLE
4th-batch-97-变量命名失误

### DIFF
--- a/python/paddle/distributed/auto_parallel/auto_dp_utils.py
+++ b/python/paddle/distributed/auto_parallel/auto_dp_utils.py
@@ -39,8 +39,8 @@ def _fake_replicate_grad_to_partial(grad, partial_axis):
 
 def _convert_fake_replicate_grad_to_partial(params_grads):
     # skip non-parallel cases
-    word_size = paddle.distributed.get_world_size()
-    if word_size == 1:
+    world_size = paddle.distributed.get_world_size()
+    if world_size == 1:
         return
 
     if isinstance(params_grads, list):
@@ -55,7 +55,7 @@ def _convert_fake_replicate_grad_to_partial(params_grads):
                     dist.Partial(dist.ReduceType.kRedSum)
                 ]
                 default_grad_mesh = dist.ProcessMesh(
-                    list(range(0, word_size)), dim_names=["dp"]
+                    list(range(0, world_size)), dim_names=["dp"]
                 )
                 grad = dist.auto_parallel.api.dtensor_from_local(
                     grad, default_grad_mesh, default_grad_placements
@@ -73,7 +73,7 @@ def _convert_fake_replicate_grad_to_partial(params_grads):
                     dist.Partial(dist.ReduceType.kRedSum)
                 ]
                 default_grad_mesh = dist.ProcessMesh(
-                    list(range(0, word_size)), dim_names=["dp"]
+                    list(range(0, world_size)), dim_names=["dp"]
                 )
                 grad = dist.auto_parallel.api.dtensor_from_local(
                     grad, default_grad_mesh, default_grad_placements
@@ -82,8 +82,8 @@ def _convert_fake_replicate_grad_to_partial(params_grads):
 
 
 def in_auto_dp_mode():
-    word_size = paddle.distributed.get_world_size()
-    if word_size <= 1:
+    world_size = paddle.distributed.get_world_size()
+    if world_size <= 1:
         return False
 
     global _enable_auto_dp_mode


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
第四批-编号97（共1处)
该行代码获取当前分布式训练的进程数（即 world size），但变量名与函数名 `word_size`不一致，推测变量命名时错误输入或者函数命名有误。尽量保持变量名称与函数使用一致，逻辑正确。