### PR TITLE
4th-batch-98-字典语法使用错误

### DIFF
--- a/python/paddle/distributed/auto_parallel/api.py
+++ b/python/paddle/distributed/auto_parallel/api.py
@@ -4088,7 +4088,7 @@ class ShardDataloader:
                         self.dense_tensor_idx is not None
                         and self.dense_tensor_idx[i] != []
                     ):
-                        dist_batch_data.append(input_data)
+                        dist_batch_data[key] = input_data
                     else:
                         mesh, placements = self._get_mesh_and_placement(i)
                         dist_batch_data[key] = dtensor_from_local(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes


### Description
<!-- Describe what you’ve done -->
第四批-编号98（共1处)
当 `batch_data` 是字典类型时，`dist_batch_data` 被初始化为字典（`{}`），但在处理 `paddle.Tensor` 类型输入且满足 `dense_tensor_idx` 条件时，却调用了 `dist_batch_data.append(input_data)`
将 `dist_batch_data.append(input_data)` 替换为 `dist_batch_data[key] = input_data`，保持与字典类型的写入方式一致，避免调用不存在的 `append` 方法