### PR TITLE
use getTensorIOMode to fix bind_index

### DIFF
--- a/paddle/fluid/framework/new_executor/instruction/tensorrt_engine_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/tensorrt_engine_instruction.cc
@@ -605,6 +605,18 @@ void TensorRTEngineInstruction::BindOutputTensor(
       break;
     }
   }
+  // output_name and getIOTensorName may be different, use output_index
+  if (bind_index < 0) {
+    for (int i = 0; i < trt_engine_->engine()->getNbIOTensors(); ++i) {
+      const char *name = trt_engine_->engine()->getIOTensorName(i);
+      nvinfer1::TensorIOMode mode =
+          trt_engine_->engine()->getTensorIOMode(name);
+      if (mode == nvinfer1::TensorIOMode::kOUTPUT) {
+        bind_index = i + output_index + binding_offset;
+        break;
+      }
+    }
+  }
   PADDLE_ENFORCE_GE(
       bind_index,
       0,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience

### PR Types
Others 

### Description
<!-- Describe what you’ve done -->
TensorRT 10.13环境，运行单测 test/tensorrt/test_converter_linalg.py 失败，增加输出信息显示
<img width="1445" height="320" alt="image" src="https://github.com/user-attachments/assets/b3904454-c6a6-4a49-a217-98f91cfbe857" />

output_name 和 getIOTensorName(i) 获取到的输出变量名称不一致，修改为使用 getTensorIOMode  判断是否为输出，然后bind_index为i + output_index + binding_offset，修改后可以运行测试