### PR TITLE
[Cherry-Pick] [CustomOp] Relax output count checks for inplace outputs (#75086)

### DIFF
--- a/paddle/fluid/framework/custom_operator_utils.h
+++ b/paddle/fluid/framework/custom_operator_utils.h
@@ -480,6 +480,11 @@ static std::vector<std::vector<int64_t>> RunInferShape(
           }
           complete_result.push_back(input_shapes[index]);
         } else {
+          PADDLE_ENFORCE_LT(
+              infershape_result_index,
+              infershape_result.size(),
+              common::errors::Unavailable("The index must be less than the "
+                                          "size of infershape_result."));
           complete_result.push_back(infershape_result[infershape_result_index]);
           infershape_result_index++;
         }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
Cherry-Pick https://github.com/PaddlePaddle/Paddle/pull/75086 to fix xpu ci