### PR TITLE
Cherry-Pick accuracy_stable_sqrt (#75367)

### DIFF
--- a/paddle/phi/kernels/funcs/activation_functor.h
+++ b/paddle/phi/kernels/funcs/activation_functor.h
@@ -4325,11 +4325,11 @@ struct CudaSqrtFunctor : public BaseActivationFunctor<T> {
 
 template <typename T>
 struct CudaSqrtGradFunctor : public BaseActivationFunctor<T> {
-  T one_half = static_cast<T>(0.5f);
+  T two = static_cast<T>(2);
 
-  // dx = dout * 0.5 / out
+  // dx = dout / (2 * out)
   __device__ __forceinline__ T operator()(const T dout, const T out) const {
-    return one_half * dout / out;
+    return dout / (two * out);
   }
 
   static constexpr ActBwdOpFwdDeps FwdDeps() {
@@ -4416,7 +4416,7 @@ struct CudaRsqrtGradFunctor : public BaseActivationFunctor<T> {
                                           const T arg_out) const {
     MPType dout = static_cast<MPType>(arg_dout);
     MPType out = static_cast<MPType>(arg_out);
-    return static_cast<T>(minus_one_half * dout * out * out * out);
+    return static_cast<T>(minus_one_half * dout * (out * out * out));
   }
 
   static constexpr ActBwdOpFwdDeps FwdDeps() {


### PR DESCRIPTION
paddle.sqrt and paddle.rsqrt accuracy and torch alignment

<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
PR75367合入之后，导致精度发生变化，因此Nlp代码库更新了baseline，nlp的PR链接如下：
https://github.com/PaddlePaddle/PaddleNLP/pull/11106