### PR TITLE
【CUDA Kernel No.60】Add gru_kernel.h -part

### DIFF
--- a/paddle/phi/kernels/gpu/gru_kernel.cu
+++ b/paddle/phi/kernels/gpu/gru_kernel.cu
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "paddle/phi/kernels/gpu/gru_kernel.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/impl/gru_kernel_impl.h"
 

--- a/paddle/phi/kernels/gpu/gru_kernel.h
+++ b/paddle/phi/kernels/gpu/gru_kernel.h
@@ -1,0 +1,36 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "paddle/phi/core/dense_tensor.h"
+
+namespace phi {
+
+template <typename T, typename Context>
+void GRUKernel(const Context &dev_ctx,
+               const DenseTensor &input,
+               const paddle::optional<DenseTensor> &h0,
+               const DenseTensor &weight,
+               const paddle::optional<DenseTensor> &bias,
+               const std::string &activation,
+               const std::string &gate_activation,
+               bool is_reverse,
+               bool origin_mode,
+               bool is_test,
+               DenseTensor *param_batch_gate,
+               DenseTensor *param_batch_reset_hidden_prev,
+               DenseTensor *param_batch_hidden,
+               DenseTensor *hidden);
+}  // namespace phi


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Custom Device


### PR Types
Improvements


### Description
- Add gru_kernel.h
- Include the .h file for gpu implementation