### PR TITLE
[SOT][3.14] support eval_frame

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -85,8 +85,7 @@ repos:
         # Exclude third-party libraries
         exclude: |
           (?x)^(
-            paddle/utils/flat_hash_map\.h |
-            paddle/fluid/pybind/sot/macros.h
+            paddle/utils/flat_hash_map\.h
           )$
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -85,7 +85,8 @@ repos:
         # Exclude third-party libraries
         exclude: |
           (?x)^(
-            paddle/utils/flat_hash_map\.h
+            paddle/utils/flat_hash_map\.h |
+            paddle/fluid/pybind/sot/macros.h
           )$
   - repo: local
     hooks:

--- a/paddle/fluid/pybind/sot/cpython_internals.h
+++ b/paddle/fluid/pybind/sot/cpython_internals.h
@@ -36,9 +36,11 @@ int Internal_PyUnstable_InterpreterFrame_GetLine(_PyInterpreterFrame *frame);
 #else
 int Internal_PyInterpreterFrame_GetLine(_PyInterpreterFrame *frame);
 #endif
+#if !PY_3_14_PLUS
 static int Internal_PyFrame_OpAlreadyRan(_PyInterpreterFrame *frame,
                                          int opcode,
                                          int oparg);
+#endif
 #if PY_3_13_PLUS
 PyObject *get_framelocals_mapping(_PyInterpreterFrame *frame);
 #else

--- a/paddle/fluid/pybind/sot/eval_frame_tools.cc
+++ b/paddle/fluid/pybind/sot/eval_frame_tools.cc
@@ -24,6 +24,9 @@
 
 #if SOT_IS_SUPPORTED
 #define END_OF_STRING '\0'
+#if PY_3_14_PLUS
+#include <internal/pycore_interpframe.h>
+#endif
 
 /*============================ Dict Tree ================================*/
 

--- a/paddle/fluid/pybind/sot/frame_proxy.c
+++ b/paddle/fluid/pybind/sot/frame_proxy.c
@@ -17,6 +17,9 @@ limitations under the License. */
 
 #if SOT_IS_SUPPORTED
 #include <Python.h>
+#if PY_3_14_PLUS
+#include <internal/pycore_interpframe.h>
+#endif
 
 #if PY_3_11_PLUS
 
@@ -32,7 +35,12 @@ limitations under the License. */
   { #property_name, (getter)PyInterpreterFrameProxy_property_##func_name, NULL, NULL, NULL }
 // clang-format on
 
-#if PY_3_13_PLUS
+#if PY_3_14_PLUS
+static PyObject *PyInterpreterFrameProxy_property_f_executable(
+    PyInterpreterFrameProxy *self, void *closure) {
+  return PyStackRef_AsPyObjectNew(self->frame->f_executable);
+}
+#elif PY_3_13_PLUS
 DECLARE_PROXY_PROPERTY(f_executable)
 #else
 DECLARE_PROXY_PROPERTY(f_code)

--- a/paddle/fluid/pybind/sot/guards.cc
+++ b/paddle/fluid/pybind/sot/guards.cc
@@ -22,6 +22,9 @@ limitations under the License. */
 #include <frameobject.h>
 #include <object.h>
 #include "pybind11/numpy.h"
+#if PY_3_14_PLUS
+#include <internal/pycore_interpframe.h>
+#endif
 
 #if !PY_3_10_PLUS
 #define Py_IsNone(x) ((x) == Py_None)

--- a/paddle/fluid/pybind/sot/macros.h
+++ b/paddle/fluid/pybind/sot/macros.h
@@ -26,6 +26,7 @@ extern "C" {
 #define PY_3_12_0_HEX 0x030C0000
 #define PY_3_13_0_HEX 0x030D0000
 #define PY_3_14_0_HEX 0x030E0000
+#define PY_3_15_0_HEX 0x030F0000
 
 #define PY_3_9_PLUS (PY_VERSION_HEX >= PY_3_9_0_HEX)
 #define PY_3_10_PLUS (PY_VERSION_HEX >= PY_3_10_0_HEX)
@@ -33,11 +34,18 @@ extern "C" {
 #define PY_3_12_PLUS (PY_VERSION_HEX >= PY_3_12_0_HEX)
 #define PY_3_13_PLUS (PY_VERSION_HEX >= PY_3_13_0_HEX)
 #define PY_3_14_PLUS (PY_VERSION_HEX >= PY_3_14_0_HEX)
+#define PY_3_15_PLUS (PY_VERSION_HEX >= PY_3_15_0_HEX)
 
-#define SOT_NOT_SUPPORTED_VERSION PY_3_14_0_HEX
+#define SOT_NOT_SUPPORTED_VERSION PY_3_15_0_HEX
 #define SOT_IS_SUPPORTED (PY_VERSION_HEX < SOT_NOT_SUPPORTED_VERSION)
 
-#if PY_3_13_PLUS
+#if PY_3_14_PLUS && !defined(_WIN32)
+#define PyFrame_GET_CODE(frame) \
+  ((PyCodeObject*)PyStackRef_AsPyObjectBorrow((frame)->f_executable))
+#elif PY_3_14_PLUS && defined(_WIN32)
+#define PyFrame_GET_CODE(frame) \
+  ((PyCodeObject*)((frame)->f_executable.bits))  // NOLINT(readability/casting)
+#elif PY_3_13_PLUS
 #define PyFrame_GET_CODE(frame) _PyFrame_GetCode(frame)
 #else
 #define PyFrame_GET_CODE(frame) (frame->f_code)

--- a/paddle/fluid/pybind/sot/macros.h
+++ b/paddle/fluid/pybind/sot/macros.h
@@ -41,10 +41,10 @@ extern "C" {
 
 #if PY_3_14_PLUS && !defined(_WIN32)
 #define PyFrame_GET_CODE(frame) \
-  ((PyCodeObject*)PyStackRef_AsPyObjectBorrow((frame)->f_executable))
+  ((PyCodeObject*)PyStackRef_AsPyObjectBorrow((frame)->f_executable))  // NOLINT
 #elif PY_3_14_PLUS && defined(_WIN32)
 #define PyFrame_GET_CODE(frame) \
-  ((PyCodeObject*)((frame)->f_executable.bits))  // NOLINT(readability/casting)
+  ((PyCodeObject*)((frame)->f_executable.bits))  // NOLINT
 #elif PY_3_13_PLUS
 #define PyFrame_GET_CODE(frame) _PyFrame_GetCode(frame)
 #else

--- a/python/paddle/jit/api.py
+++ b/python/paddle/jit/api.py
@@ -301,9 +301,9 @@ def to_static(
             flag = ENV_ENABLE_SOT.get()
             full_graph = not flag
 
-        if sys.version_info >= (3, 14) and not full_graph:
+        if sys.version_info >= (3, 15) and not full_graph:
             warnings.warn(
-                "full_graph=False is not supported in Python 3.14+. Set full_graph=True automatically"
+                "full_graph=False is not supported in Python 3.15+. Set full_graph=True automatically"
             )
             full_graph = True
 

--- a/python/paddle/jit/sot/opcode_translator/instruction_utils/opcode_info.py
+++ b/python/paddle/jit/sot/opcode_translator/instruction_utils/opcode_info.py
@@ -103,7 +103,31 @@ def _get_pyopcode_cache_size() -> dict[str, int]:
             "CALL": 3,
             "BINARY_OP": 1,
         }
-    elif sys.version_info >= (3, 14):
+    elif sys.version_info >= (3, 14) and sys.version_info < (3, 15):
+        # Cache for some opcodes, it's for Python 3.14
+        # https://github.com/python/cpython/blob/3.14/Include/internal/pycore_opcode_metadata.h#L1764-L1784
+        return {
+            "TO_BOOL": 3,
+            "STORE_SUBSCR": 1,
+            "SEND": 1,
+            "UNPACK_SEQUENCE": 1,
+            "STORE_ATTR": 4,
+            "LOAD_GLOBAL": 4,
+            "LOAD_SUPER_ATTR": 1,
+            "LOAD_ATTR": 9,
+            "COMPARE_OP": 1,
+            "CONTAINS_OP": 1,
+            "JUMP_BACKWARD": 1,
+            "POP_JUMP_IF_TRUE": 1,
+            "POP_JUMP_IF_FALSE": 1,
+            "POP_JUMP_IF_NONE": 1,
+            "POP_JUMP_IF_NOT_NONE": 1,
+            "FOR_ITER": 1,
+            "CALL": 3,
+            "CALL_KW": 3,
+            "BINARY_OP": 5,
+        }
+    elif sys.version_info >= (3, 15):
         raise NotImplementedError(
             f"Need to supplement cache operation code, for Python {sys.version_info}"
         )

--- a/test/dygraph_to_static/test_eval_frame.py
+++ b/test/dygraph_to_static/test_eval_frame.py
@@ -28,8 +28,8 @@ class TestEvalFrame(unittest.TestCase):
         pass
 
     def test_eval_frame(self):
-        if not (sys.version_info >= (3, 9) and sys.version_info < (3, 14)):
-            # skip test_eval_frame, current only support 3.9 - 3.13
+        if not (sys.version_info >= (3, 9) and sys.version_info < (3, 15)):
+            # skip test_eval_frame, current only support 3.9 - 3.14
             return
 
         CustomCode = collections.namedtuple(

--- a/tools/get_pr_title.py
+++ b/tools/get_pr_title.py
@@ -25,7 +25,7 @@ SKIP_COVERAGE_CHECKING_LABELS = [
     "typing",
     "codestyle",
     "fluid_ops",
-    "3.13",  # SOT Python 3.13 support
+    r"3.1\d",  # SOT Python 3.13 support
 ]
 
 SKIP_DISTRIBUTE_TEST_CHECKING_LABELS = [


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->


- 其实这个 pr 应该要等 ci 完备了再来提的
- 适配了 sot 的 eval_frame, 并在 debug 版本的 python 中验证通过（没有段错误， 仅限 `test/dygraph_to_static/test_eval_frame.py` 单测）

> [!NOTE]
> 在下个版本中重构一下现有的 `cpython_internals` 引入逻辑，现有逻辑导致各种编译条件有点看不过来，并且维护也开始逐步变为史诗级难度。

link:
- https://github.com/PaddlePaddle/community/pull/1161
