### PR TITLE
Implement `__cuda_stream__` protocol

### DIFF
--- a/python/paddle/device/__init__.py
+++ b/python/paddle/device/__init__.py
@@ -1382,6 +1382,15 @@ class Stream:
     def __repr__(self) -> str:
         return f'<paddle.device.Stream device={self.device} stream={self._as_parameter_.value:#x}>'
 
+    def __cuda_stream__(self):
+        """
+        CUDA Stream protocol described at
+        https://nvidia.github.io/cuda-python/cuda-core/latest/interoperability.html#cuda-stream-protocol
+
+        Returns a tuple of (protocol_version, cudaStream_t)
+        """
+        return (0, self.stream_base.raw_stream)
+
 
 def _device_to_paddle(
     dev: Place | int | str | None = None,

--- a/python/paddle/device/__init__.py
+++ b/python/paddle/device/__init__.py
@@ -1371,6 +1371,15 @@ class Stream:
         else:
             return ctypes.c_void_p(self.stream_base.raw_stream)
 
+    def __cuda_stream__(self):
+        """
+        CUDA Stream protocol described at
+        https://nvidia.github.io/cuda-python/cuda-core/latest/interoperability.html#cuda-stream-protocol
+
+        Returns a tuple of (protocol_version, cudaStream_t)
+        """
+        return (0, self.stream_base.raw_stream)
+
     def __eq__(self, o: Stream | None) -> bool:
         if isinstance(o, Stream):
             return super().__eq__(o)
@@ -1381,15 +1390,6 @@ class Stream:
 
     def __repr__(self) -> str:
         return f'<paddle.device.Stream device={self.device} stream={self._as_parameter_.value:#x}>'
-
-    def __cuda_stream__(self):
-        """
-        CUDA Stream protocol described at
-        https://nvidia.github.io/cuda-python/cuda-core/latest/interoperability.html#cuda-stream-protocol
-
-        Returns a tuple of (protocol_version, cudaStream_t)
-        """
-        return (0, self.stream_base.raw_stream)
 
 
 def _device_to_paddle(

--- a/test/legacy_test/test_cuda_stream_event.py
+++ b/test/legacy_test/test_cuda_stream_event.py
@@ -87,6 +87,25 @@ class TestCUDAStream(unittest.TestCase):
 
             self.assertTrue(e1.query() and s1.query() and s2.query())
 
+    def test_cuda_stream_protocol(self):
+        if paddle.cuda.is_available() and paddle.is_compiled_with_cuda():
+            stream = paddle.cuda.Stream()
+
+            self.assertTrue(hasattr(stream, "__cuda_stream__"))
+
+            result = stream.__cuda_stream__()
+
+            self.assertIsInstance(result, tuple)
+            self.assertEqual(len(result), 2)
+            self.assertEqual(result[0], 0)  # Protocol version
+            self.assertEqual(
+                result[1], stream.stream_base.cuda_stream
+            )  # Stream handle
+
+            external_stream = paddle.cuda.get_stream_from_external(result[1], 0)
+            external_result = external_stream.__cuda_stream__()
+            self.assertEqual(result, external_result)
+
 
 class TestCUDAEvent(unittest.TestCase):
     def test_cuda_event(self):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

New features

### Description
<!-- Describe what you’ve done -->

Implement the CUDA Stream protocol described at <https://nvidia.github.io/cuda-python/cuda-core/latest/interoperability.html#cuda-stream-protocol>.

<!-- PCard-66972 -->