### PR TITLE
Flashmask v3 support headdim in the range (128, 256].

### DIFF
--- a/paddle/phi/kernels/gpu/flash_attn_v3_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/flash_attn_v3_grad_kernel.cu
@@ -1041,7 +1041,7 @@ void FlashMaskV2GradBaseKernel(
   int const kBlockN_sm90 =
       head_size_rounded <= 64 && (is_flashmask && !is_causal) ? 96
       : head_size_rounded <= 128 ? (is_flashmask && !is_causal) ? 64 : 128
-                                 : (head_size_rounded <= 192 ? 96 : 80);
+                                 : (head_size_rounded <= 192 ? 96 : 64);
   int const kBlockN_sm80 =
       head_size_rounded <= 128 ? 128 : (head_size_rounded <= 192 ? 80 : 64);
   int const kBlockN_sm86 =

--- a/paddle/phi/kernels/gpu/flash_attn_v3_kernel.cu
+++ b/paddle/phi/kernels/gpu/flash_attn_v3_kernel.cu
@@ -1394,7 +1394,7 @@ void FlashMaskV2BaseKernel(
                       common::errors::InvalidArgument(
                           "batch_size must be equal to batch_size_k"));
   }
-  int const max_headdim = std::min(flashmaskv2_get_max_headdim(), 128);
+  int const max_headdim = flashmaskv2_get_max_headdim();
   PADDLE_ENFORCE_LE(
       head_size,
       max_headdim,

--- a/paddle/phi/kernels/gpu/flash_attn_v3_utils.h
+++ b/paddle/phi/kernels/gpu/flash_attn_v3_utils.h
@@ -68,7 +68,7 @@ inline int get_max_headdim() {
   return 0;
 }
 
-inline int flashmaskv2_get_max_headdim() { return 128; }
+inline int flashmaskv2_get_max_headdim() { return 256; }
 
 inline int round_up_headdim(int head_size) {
 #ifndef FLASHATTENTION_DISABLE_HDIM64


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Performance Optimization


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Performance


### Description
<!-- Describe what you’ve done -->
Pcard-89071
支持 flashmask v2 headdim (128, 256] 的情况
