### PR TITLE
[XPU] update xpti to support xprofiler

### DIFF
--- a/cmake/external/xpu.cmake
+++ b/cmake/external/xpu.cmake
@@ -50,7 +50,7 @@ if(NOT DEFINED XPU_XRE_BASE_VERSION)
 endif()
 
 if(WITH_XPU_XRE5)
-  set(XPU_XPTI_BASE_VERSION "0.2.0")
+  set(XPU_XPTI_BASE_VERSION "0.3.0")
 else()
   set(XPU_XPTI_BASE_VERSION "0.0.1")
 endif()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Custom Device

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
update xpti to 0.3.0, which is compatible with xprofiler （the successor of xpu-prof）.