### PR TITLE
[CppExtension] Keep hirachey in build directory

### DIFF
--- a/python/paddle/utils/cpp_extension/cpp_extension.py
+++ b/python/paddle/utils/cpp_extension/cpp_extension.py
@@ -724,7 +724,7 @@ class BuildExtension(build_ext):
                     # if user set build_directory, output objects there.
                     if build_directory is not None:
                         objects = [
-                            os.path.join(build_directory, os.path.basename(obj))
+                            os.path.join(build_directory, obj)
                             for obj in objects
                         ]
                     # ensure to use abspath


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

在 `build_directory` 生成 `.o` 时保持与源码一样的目录结构，避免在不同目录相同的文件名最后生成相同的 `.o`，导致链接时挂掉

如 FlashMLA 里的 3 个 `splitkv_mla.cu`

https://github.com/deepseek-ai/FlashMLA/blob/1408756a88e52a25196b759eaf8db89d2b51b5a1/setup.py#L65-L75

<!-- PCard-66972 -->