### PR TITLE
Add exception message to error logging in interpreter

### DIFF
--- a/paddle/fluid/framework/new_executor/pir_interpreter.cc
+++ b/paddle/fluid/framework/new_executor/pir_interpreter.cc
@@ -2038,7 +2038,7 @@ void PirInterpreter::RunInstructionBase(InstructionBase* instr_node) {
     exception_holder_.Catch(std::current_exception());
   } catch (std::exception& ex) {
     LOG(WARNING) << instr_node->Name() << " raises an exception "
-                 << common::demangle(typeid(ex).name());
+                 << common::demangle(typeid(ex).name()) << ": " << ex.what();
     exception_holder_.Catch(std::current_exception());
   } catch (...) {
     LOG(WARNING) << instr_node->Name() << " raises an unknown exception";


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->

原有log会打印出：

```
I1016 10:46:21.901674 70984 pir_interpreter.cc:2040] pd_op.weight_only_linear raises an exception std::runtime_error
I1016 10:46:21.901698 70984 pir_interpreter.cc:1746] Exception caught
I1016 10:46:21.901703 70984 pir_interpreter.cc:1752] Exception caught BaseException
I1016 10:46:21.901708 70984 pir_interpreter.cc:1758] clear ok
terminate called after throwing an instance of 'std::exception'
  what():  std::exception
```

没办法看到 exception 的具体信息，此PR合入后，能打印出异常信息：

```diff
W1016 11:02:40.381685 88175 pir_interpreter.cc:2040] pd_op.weight_only_linear raises an exception std::runtime_error: 
+    [fpA_intB Runner] Failed to run cutlass fpA_intB gemm. Error: Error Internal
I1016 11:02:40.381711 88175 pir_interpreter.cc:1746] Exception caught
I1016 11:02:40.381714 88175 pir_interpreter.cc:1752] Exception caught BaseException
I1016 11:02:40.381722 88175 pir_interpreter.cc:1758] clear ok
terminate called after throwing an instance of 'std::exception'
  what():  std::exception
```

<!-- Pcard-92901 -->