### PR TITLE
【cherry-pick stride】Set value when dstplace != srcplace and one tenosr is not con…

### DIFF
--- a/test/legacy_test/test_set_value_op.py
+++ b/test/legacy_test/test_set_value_op.py
@@ -1788,5 +1788,36 @@ class TestSetValueWithScalarInDygraph(unittest.TestCase):
         np.testing.assert_array_equal(x.grad, expected_x_grad)
 
 
+@unittest.skipIf(
+    not (core.is_compiled_with_cuda() or is_custom_device()),
+    "core is not compiled with CUDA",
+)
+class TestSetValueWithStrideError(unittest.TestCase):
+    def test_same_place(self):
+        x = paddle.rand([5, 10], device=paddle.CUDAPlace(0))
+        y = paddle.rand([10, 5], device=paddle.CUDAPlace(0))
+        y.transpose_([1, 0])
+        x.set_value(y)
+        assert x.is_contiguous()
+
+    def test_different_place1(self):
+        # src place != dst place && src is not contiguous
+        x = paddle.rand([5, 10], device=paddle.CUDAPlace(0))
+        y = paddle.rand([10, 5], device=paddle.CPUPlace())
+        y.transpose_([1, 0])
+        x.set_value(y)
+        assert not x.is_contiguous()
+
+    def test_different_place2(self):
+        # src place != dst place && dst is not contiguous
+        with self.assertRaises(SystemError):
+            x = paddle.ones([5, 4], device=paddle.CUDAPlace(0))
+            x.transpose_([1, 0])
+            y = paddle.rand([4, 2], device=paddle.CPUPlace())
+            assert not x.is_contiguous()
+
+            x[:, 1:3].set_value(y)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/legacy_test/test_set_value_op.py
+++ b/test/legacy_test/test_set_value_op.py
@@ -1789,21 +1789,21 @@ class TestSetValueWithScalarInDygraph(unittest.TestCase):
 
 
 @unittest.skipIf(
-    not (core.is_compiled_with_cuda() or is_custom_device()),
+    not core.is_compiled_with_cuda(),
     "core is not compiled with CUDA",
 )
 class TestSetValueWithStrideError(unittest.TestCase):
     def test_same_place(self):
-        x = paddle.rand([5, 10], device=paddle.CUDAPlace(0))
-        y = paddle.rand([10, 5], device=paddle.CUDAPlace(0))
+        x = paddle.ones([5, 10], device=paddle.CUDAPlace(0))
+        y = paddle.zeros([10, 5], device=paddle.CUDAPlace(0))
         y.transpose_([1, 0])
         x.set_value(y)
         assert x.is_contiguous()
 
     def test_different_place1(self):
         # src place != dst place && src is not contiguous
-        x = paddle.rand([5, 10], device=paddle.CUDAPlace(0))
-        y = paddle.rand([10, 5], device=paddle.CPUPlace())
+        x = paddle.ones([5, 10], device=paddle.CUDAPlace(0))
+        y = paddle.zeros([10, 5], device=paddle.CPUPlace())
         y.transpose_([1, 0])
         x.set_value(y)
         assert not x.is_contiguous()
@@ -1813,7 +1813,7 @@ class TestSetValueWithStrideError(unittest.TestCase):
         with self.assertRaises(SystemError):
             x = paddle.ones([5, 4], device=paddle.CUDAPlace(0))
             x.transpose_([1, 0])
-            y = paddle.rand([4, 2], device=paddle.CPUPlace())
+            y = paddle.zeros([4, 2], device=paddle.CPUPlace())
             assert not x.is_contiguous()
 
             x[:, 1:3].set_value(y)


### PR DESCRIPTION
…tiguous should add check (#75794)

* add log

* fix bug

* fix

* delete

* fix conflict

* fix test

<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-67164