### PR TITLE
clean pip3.8 in Dockerfile.develop.npu

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -103,7 +103,7 @@ jobs:
           for name in "${!docker_files[@]}"
           do
             md5_value=`md5sum tools/dockerfile/${docker_files[$name]} | awk '{print $1}'`
-            if [ $name == "docker_npu"]; then
+            if [ $name == "docker_npu" ]; then
                 md5_value="a3793bdeea5ae881a0c1eaf4d7c30c64"
             fi
             docker_image="ccr-2vdh3abv-pub.cnc.bj.baidubce.com/ci/paddle:${md5_value}"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -103,6 +103,9 @@ jobs:
           for name in "${!docker_files[@]}"
           do
             md5_value=`md5sum tools/dockerfile/${docker_files[$name]} | awk '{print $1}'`
+            if [ $name == "docker_npu"]; then
+                md5_value="a3793bdeea5ae881a0c1eaf4d7c30c64"
+            fi
             docker_image="ccr-2vdh3abv-pub.cnc.bj.baidubce.com/ci/paddle:${md5_value}"
             declare "${name}_image=${docker_image}"
             echo "${name}_image=${docker_image}" >> $GITHUB_OUTPUT

--- a/tools/dockerfile/Dockerfile.develop.npu
+++ b/tools/dockerfile/Dockerfile.develop.npu
@@ -19,16 +19,13 @@ WORKDIR /usr/local/Ascend
 RUN apt-get update -y && apt-get install -y zlib1g zlib1g-dev libsqlite3-dev openssl libssl-dev libffi-dev libbz2-dev \
     libxslt1-dev unzip pciutils net-tools libblas-dev gfortran libblas3 liblapack-dev liblapack3 libopenblas-dev zstd
 
-RUN pip3.8 install --upgrade pip setuptools wheel && \
-    pip3.9 install --upgrade pip setuptools wheel && \
+RUN pip3.9 install --upgrade pip setuptools wheel && \
     pip3.10 install --upgrade pip setuptools wheel
 
-RUN pip3.8 install 'numpy>=1.19.2' 'decorator>=4.4.0' 'sympy>=1.5.1' 'cffi>=1.12.3' 'protobuf>=3.13.0' && \
-    pip3.9 install 'numpy>=1.19.2' 'decorator>=4.4.0' 'sympy>=1.5.1' 'cffi>=1.12.3' 'protobuf>=3.13.0' && \
+RUN pip3.9 install 'numpy>=1.19.2' 'decorator>=4.4.0' 'sympy>=1.5.1' 'cffi>=1.12.3' 'protobuf>=3.13.0' && \
     pip3.10 install 'numpy>=1.19.2' 'decorator>=4.4.0' 'sympy>=1.5.1' 'cffi>=1.12.3' 'protobuf>=3.13.0'
 
-RUN pip3.8 install attrs pyyaml pathlib2 scipy requests psutil absl-py && \
-    pip3.9 install attrs pyyaml pathlib2 scipy requests psutil absl-py && \
+RUN pip3.9 install attrs pyyaml pathlib2 scipy requests psutil absl-py && \
     pip3.10 install attrs pyyaml pathlib2 scipy requests psutil absl-py
 
 # update envs for driver


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience

### PR Types
Others 

### Description
<!-- Describe what you’ve done -->
clean pip3.8 in Dockerfile.develop.npu

NPU流水线中使用镜像名称是使用md5sum计算， md5sum Dockerfile.develop.npu，但因为文件已改动，名称也同样会变化，Docker镜像不存在，如果构建写入会失败，所以修改.github/workflows/docker.yml，设置镜像名称为原名称

构建写入失败
https://github.com/PaddlePaddle/Paddle/actions/runs/18553983847/job/52987957316?pr=75893
<img width="1433" height="355" alt="image" src="https://github.com/user-attachments/assets/4c276ebe-d697-4732-8185-089db8278b5e" />
