### PR TITLE
[Precision Depth Alignment] paddle.log_sigmoid

### DIFF
--- a/test/legacy_test/test_activation_stride_op.py
+++ b/test/legacy_test/test_activation_stride_op.py
@@ -280,7 +280,7 @@ create_test_act_stride_class(
 
 
 def ref_log_sigmoid(x):
-    out = np.log(1 / (1 + np.exp(-x)))
+    out = -np.log1p(np.exp(-x))
     return out
 
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->
**torch实现** ： aten/src/ATen/native/cuda/ActivationLogSigmoidKernel.cu
```
void launch_log_sigmoid_forward_kernel(TensorIteratorBase& iter) {
  AT_DISPATCH_FLOATING_TYPES_AND2(
      kHalf, kBFloat16, iter.common_dtype(), "log_sigmoid_forward_cuda", [&] {
        using opmath_t = at::opmath_type<scalar_t>;

        gpu_kernel(iter, [] GPU_LAMBDA(scalar_t in_) -> scalar_t {
          const opmath_t in = in_;
          const auto min = std::min(opmath_t(0), in);
          const auto z = std::exp(-std::abs(in));
          return min - std::log1p(z);
        });
      });
}
```

**主要修改：**
1. 前向计算 (CudaLogSigmoidFunctor)
旧实现： `- (max(-x, 0) + log(exp(-max(-x, 0)) + exp(-x - max(-x, 0)))) `；
新实现： `log_sigmoid(x) = min(0,x) - log1p(exp(-|x|)) `；
 2. 反向计算 (CudaLogSigmoidGradFunctor)
旧实现： `dx = dout * exp(-x - max(-x, 0)) / (exp(-max(-x, 0)) + exp(-x - max(-x,0)))  `；
新实现：`grad = dout * (max_deriv - sign * (z / (1 + z))) `; `z = exp(-abs(x))`; `max_deriv = (x < 0) ? 1 : 0, sign = (x < 0) ? 1 : -1 `;

**测试结果：**
paddle.nn.functional.log_sigmoid 对齐case（共16 个）

pcard-93269