### PR TITLE
[Compat] Fix `transpose` implementation and add negative indexing support for `size`

### DIFF
--- a/paddle/phi/api/include/compat/ATen/core/TensorBase.h
+++ b/paddle/phi/api/include/compat/ATen/core/TensorBase.h
@@ -66,6 +66,9 @@ class PADDLE_API TensorBase {
   }
 
   int64_t size(int64_t dim) const {
+    if (dim < 0) {
+      dim += tensor_.dims().size();
+    }
     return tensor_.dims()[static_cast<int>(dim)];
   }
 

--- a/paddle/phi/api/include/compat/ATen/core/TensorBody.h
+++ b/paddle/phi/api/include/compat/ATen/core/TensorBody.h
@@ -53,9 +53,6 @@ class Tensor : public TensorBase {
   }
 
   using TensorBase::size;
-  //   int64_t size(int64_t dim) const {
-  //     return tensor_.dims()[static_cast<int>(dim)];
-  //   }
 
   c10::IntArrayRef sizes() const {
     return compat::_PD_PhiDDimToIntArrayRef(tensor_.dims());

--- a/paddle/phi/api/include/compat/ATen/core/TensorBody.h
+++ b/paddle/phi/api/include/compat/ATen/core/TensorBody.h
@@ -119,8 +119,12 @@ class Tensor : public TensorBase {
   }
 
   at::Tensor transpose(int64_t dim0, int64_t dim1) const {
-    return Tensor(paddle::experimental::transpose(
-        tensor_, {static_cast<int>(dim0), static_cast<int>(dim1)}));
+    std::vector<int> perm(tensor_.dims().size());
+    for (size_t i = 0; i < perm.size(); i++) {
+      perm[i] = static_cast<int>(i);
+    }
+    std::swap(perm[dim0], perm[dim1]);
+    return Tensor(paddle::experimental::transpose(tensor_, perm));
   }
 
   at::Tensor& copy_(const at::Tensor& src, bool non_blocking = false) const {

--- a/test/cpp/compat/compat_basic_test.cc
+++ b/test/cpp/compat/compat_basic_test.cc
@@ -298,3 +298,17 @@ TEST(TestDevice, DeviceAPIsOnCPU) {
   auto options = cpu_tensor.options();
   ASSERT_EQ(options.device().type(), at::DeviceType::CPU);
 }
+
+TEST(TestTranspose, TransposeAPI) {
+  at::Tensor a = at::ones({4, 5, 6, 7, 8}, at::kFloat);
+  at::Tensor b = a.transpose(2, 3);
+  ASSERT_EQ(b.sizes(), c10::IntArrayRef({4, 5, 7, 6, 8}));
+}
+
+TEST(TestSize, SizeNegativeIndex) {
+  at::Tensor tensor = at::ones({2, 3, 4, 5}, at::kFloat);
+  ASSERT_EQ(tensor.size(-1), 5);
+  ASSERT_EQ(tensor.size(-2), 4);
+  ASSERT_EQ(tensor.size(-3), 3);
+  ASSERT_EQ(tensor.size(-4), 2);
+}


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

- 修复 `transpose` 实现，torch 的两个 index 不应该直接传递给 `paddle::experimental::transpose`，应该转换成 perm 形式
- 为 `size` 支持负数索引

<!-- PCard-66972 -->