### PR TITLE
[TVM FFI] Bump tvm ffi to `0.1.0b20` in unittests

### DIFF
--- a/python/unittest_py/requirements.txt
+++ b/python/unittest_py/requirements.txt
@@ -20,4 +20,4 @@ xdoctest==1.3.0
 ubelt==1.3.3 # just for xdoctest
 mypy==1.17.1
 soundfile
-apache-tvm-ffi==0.1.0b16
+apache-tvm-ffi==0.1.0b19

--- a/python/unittest_py/requirements.txt
+++ b/python/unittest_py/requirements.txt
@@ -20,4 +20,4 @@ xdoctest==1.3.0
 ubelt==1.3.3 # just for xdoctest
 mypy==1.17.1
 soundfile
-apache-tvm-ffi==0.1.0b19
+apache-tvm-ffi==0.1.0b20

--- a/test/legacy_test/test_tvm_ffi.py
+++ b/test/legacy_test/test_tvm_ffi.py
@@ -49,14 +49,14 @@ class TestCDLPackExchangeAPI(unittest.TestCase):
         cpp_source = r"""
             void add_one_cpu(tvm::ffi::TensorView x, tvm::ffi::TensorView y) {
                 // implementation of a library function
-                TVM_FFI_ICHECK(x->ndim == 1) << "x must be a 1D tensor";
+                TVM_FFI_ICHECK(x.ndim() == 1) << "x must be a 1D tensor";
                 DLDataType f32_dtype{kDLFloat, 32, 1};
-                TVM_FFI_ICHECK(x->dtype == f32_dtype) << "x must be a float tensor";
-                TVM_FFI_ICHECK(y->ndim == 1) << "y must be a 1D tensor";
-                TVM_FFI_ICHECK(y->dtype == f32_dtype) << "y must be a float tensor";
-                TVM_FFI_ICHECK(x->shape[0] == y->shape[0]) << "x and y must have the same shape";
-                for (int i = 0; i < x->shape[0]; ++i) {
-                    static_cast<float*>(y->data)[i] = static_cast<float*>(x->data)[i] + 1;
+                TVM_FFI_ICHECK(x.dtype() == f32_dtype) << "x must be a float tensor";
+                TVM_FFI_ICHECK(y.ndim() == 1) << "y must be a 1D tensor";
+                TVM_FFI_ICHECK(y.dtype() == f32_dtype) << "y must be a float tensor";
+                TVM_FFI_ICHECK(x.size(0) == y.size(0)) << "x and y must have the same shape";
+                for (int i = 0; i < x.size(0); ++i) {
+                    static_cast<float*>(y.data_ptr())[i] = static_cast<float*>(x.data_ptr())[i] + 1;
                 }
             }
         """
@@ -92,22 +92,22 @@ class TestCDLPackExchangeAPI(unittest.TestCase):
 
             void add_one_cuda(tvm::ffi::TensorView x, tvm::ffi::TensorView y) {
               // implementation of a library function
-              TVM_FFI_ICHECK(x->ndim == 1) << "x must be a 1D tensor";
+              TVM_FFI_ICHECK(x.ndim() == 1) << "x must be a 1D tensor";
               DLDataType f32_dtype{kDLFloat, 32, 1};
-              TVM_FFI_ICHECK(x->dtype == f32_dtype) << "x must be a float tensor";
-              TVM_FFI_ICHECK(y->ndim == 1) << "y must be a 1D tensor";
-              TVM_FFI_ICHECK(y->dtype == f32_dtype) << "y must be a float tensor";
-              TVM_FFI_ICHECK(x->shape[0] == y->shape[0]) << "x and y must have the same shape";
+              TVM_FFI_ICHECK(x.dtype() == f32_dtype) << "x must be a float tensor";
+              TVM_FFI_ICHECK(y.ndim() == 1) << "y must be a 1D tensor";
+              TVM_FFI_ICHECK(y.dtype() == f32_dtype) << "y must be a float tensor";
+              TVM_FFI_ICHECK(x.size(0) == y.size(0)) << "x and y must have the same shape";
 
-              int64_t n = x->shape[0];
+              int64_t n = x.size(0);
               int64_t nthread_per_block = 256;
               int64_t nblock = (n + nthread_per_block - 1) / nthread_per_block;
               // Obtain the current stream from the environment by calling TVMFFIEnvGetStream
               cudaStream_t stream = static_cast<cudaStream_t>(
-                  TVMFFIEnvGetStream(x->device.device_type, x->device.device_id));
+                  TVMFFIEnvGetStream(x.device().device_type, x.device().device_id));
               // launch the kernel
-              AddOneKernel<<<nblock, nthread_per_block, 0, stream>>>(static_cast<float*>(x->data),
-                                                                     static_cast<float*>(y->data), n);
+              AddOneKernel<<<nblock, nthread_per_block, 0, stream>>>(static_cast<float*>(x.data_ptr()),
+                                                                     static_cast<float*>(y.data_ptr()), n);
             }
         """
         mod: Module = tvm_ffi.cpp.load_inline(
@@ -123,23 +123,18 @@ class TestCDLPackExchangeAPI(unittest.TestCase):
         np.testing.assert_allclose(y.numpy(), [2.0, 2.0, 2.0])
 
     def test_c_dlpack_exchange_api_alloc_tensor(self):
-        if platform.system() == "Windows":
-            # Temporary skip this test case on windows because return owned tensor created by
-            # TVMFFIEnvGetTensorAllocator will cause double free error
-            return
         cpp_source = r"""
             inline tvm::ffi::Tensor alloc_tensor(tvm::ffi::Shape shape, DLDataType dtype, DLDevice device) {
-                return tvm::ffi::Tensor::FromDLPackAlloc(TVMFFIEnvGetTensorAllocator(), shape, dtype, device);
+                return tvm::ffi::Tensor::FromEnvAlloc(TVMFFIEnvTensorAlloc, shape, dtype, device);
             }
 
             tvm::ffi::Tensor add_one_cpu(tvm::ffi::TensorView x) {
-                TVM_FFI_ICHECK(x->ndim == 1) << "x must be a 1D tensor";
+                TVM_FFI_ICHECK(x.ndim() == 1) << "x must be a 1D tensor";
                 DLDataType f32_dtype{kDLFloat, 32, 1};
-                TVM_FFI_ICHECK(x->dtype == f32_dtype) << "x must be a float tensor";
-                tvm::ffi::Shape x_shape(x->shape, x->shape + x->ndim);
-                tvm::ffi::Tensor y = alloc_tensor(x_shape, f32_dtype, x->device);
-                for (int i = 0; i < x->shape[0]; ++i) {
-                    static_cast<float*>(y->data)[i] = static_cast<float*>(x->data)[i] + 1;
+                TVM_FFI_ICHECK(x.dtype() == f32_dtype) << "x must be a float tensor";
+                tvm::ffi::Tensor y = alloc_tensor(x.shape(), f32_dtype, x.device());
+                for (int i = 0; i < x.size(0); ++i) {
+                    static_cast<float*>(y.data_ptr())[i] = static_cast<float*>(x.data_ptr())[i] + 1;
                 }
                 return y;
             }

--- a/test/legacy_test/test_tvm_ffi.py
+++ b/test/legacy_test/test_tvm_ffi.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-import platform
 import unittest
 from typing import TYPE_CHECKING
 
@@ -75,9 +74,6 @@ class TestCDLPackExchangeAPI(unittest.TestCase):
             return
         if paddle.is_compiled_with_rocm():
             # Skip on DCU because CUDA_HOME is not available
-            return
-        if platform.system() == "Windows":
-            # Temporary skip this test case on windows because compile bug on TVM FFI
             return
         cpp_sources = r"""
             void add_one_cuda(tvm::ffi::TensorView x, tvm::ffi::TensorView y);

--- a/test/legacy_test/test_tvm_ffi.py
+++ b/test/legacy_test/test_tvm_ffi.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import platform
 import unittest
 from typing import TYPE_CHECKING
 
@@ -74,6 +75,9 @@ class TestCDLPackExchangeAPI(unittest.TestCase):
             return
         if paddle.is_compiled_with_rocm():
             # Skip on DCU because CUDA_HOME is not available
+            return
+        if platform.system() == "Windows":
+            # Temporary skip this test case on windows because compile bug on TVM FFI
             return
         cpp_sources = r"""
             void add_one_cuda(tvm::ffi::TensorView x, tvm::ffi::TensorView y);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

Bump TVM FFI to 0.1.0b20 in CI.

<!-- PCard-66972 -->