### PR TITLE
[Slice]fix value_grad ele_size error

### DIFF
--- a/paddle/phi/kernels/gpu/index_elementwise_put_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_elementwise_put_grad_kernel.cu
@@ -57,9 +57,12 @@ void GPUIndexElementwisePutGradKernel(
   std::array<std::vector<int64_t>, 3> strides_vec;
   std::vector<int64_t> value_dims;
   std::vector<int64_t> value_strides;
+  // default value_ele_size when value_grad is nullptr
+  int64_t value_ele_size = 4;
   if (value_grad) {
     value_dims = common::vectorize<int64_t>(value_grad->dims());
     value_strides = common::vectorize<int64_t>(value_grad->strides());
+    value_ele_size = phi::SizeOf(value_grad->dtype());
   }
 
   funcs::IndexPutStride<3>(input_dims,
@@ -67,7 +70,7 @@ void GPUIndexElementwisePutGradKernel(
                            phi::SizeOf(out_grad.dtype()),
                            value_dims,
                            value_strides,
-                           4,
+                           value_ele_size,
                            shape_tmp,
                            stride_tmp,
                            phi::SizeOf(index[0]->dtype()),


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-67164
Fix value_grad ele_size error:
index_elementwise_put_with_tensor反向kernel中，value类型的ele_size应该根据value_type进行计算。否则产生put越界，造成cuda700 error。