### PR TITLE
【UnitTestFix No.14】fix test_matmul_v2_op.py

### DIFF
--- a/paddle/fluid/primitive/decomp_rule/decomp_vjp/details.h
+++ b/paddle/fluid/primitive/decomp_rule/decomp_vjp/details.h
@@ -1390,6 +1390,16 @@ void matmul_grad(const Tensor& x,
     } else {
       set_output<T>(x_grad_out, x_grad);
     }
+
+    // Ensure output shape matches original input shape for 1-D inputs
+    if (x_rank == 1 && x_grad_out.dims().size() == 2) {
+      if (x_grad_out.dims()[1] == 1) {
+        x_grad_out = squeeze<T>(x_grad_out, {1});
+      } else if (x_grad_out.dims()[0] == 1) {
+        x_grad_out = squeeze<T>(x_grad_out, {0});
+      }
+      set_output<T>(x_grad_out, x_grad);
+    }
   }
 
   if (y_grad) {
@@ -1413,6 +1423,16 @@ void matmul_grad(const Tensor& x,
       y_grad_out = reduce_as<T>(y_grad_out, temp_y_unsqueeze);
       set_output<T>(y_grad_out, y_grad);
     } else {
+      set_output<T>(y_grad_out, y_grad);
+    }
+
+    // Ensure output shape matches original input shape for 1-D inputs
+    if (y_rank == 1 && y_grad_out.dims().size() == 2) {
+      if (y_grad_out.dims()[1] == 1) {
+        y_grad_out = squeeze<T>(y_grad_out, {1});
+      } else if (y_grad_out.dims()[0] == 1) {
+        y_grad_out = squeeze<T>(y_grad_out, {0});
+      }
       set_output<T>(y_grad_out, y_grad);
     }
   }

--- a/paddle/phi/kernels/impl/matmul_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/matmul_grad_kernel_impl.h
@@ -333,10 +333,26 @@ void MatmulGradKernel(const Context& dev_ctx,
       if (dx_dims != x_help.dims()) {
         dx->Resize(dx_dims);
       }
+      // Ensure output shape matches original input shape
+      if (x.dims().size() == 1 && dx->dims().size() == 2) {
+        if (dx->dims()[1] == 1) {
+          dx->Resize({dx->dims()[0]});
+        } else if (dx->dims()[0] == 1) {
+          dx->Resize({dx->dims()[1]});
+        }
+      }
     }
     if (dy) {
       if (dy_dims != y_help.dims()) {
         dy->Resize(dy_dims);
+      }
+      // Ensure output shape matches original input shape
+      if (y.dims().size() == 1 && dy->dims().size() == 2) {
+        if (dy->dims()[1] == 1) {
+          dy->Resize({dy->dims()[0]});
+        } else if (dy->dims()[0] == 1) {
+          dy->Resize({dy->dims()[1]});
+        }
       }
     }
   } else {
@@ -476,6 +492,14 @@ void MatmulGradKernel(const Context& dev_ctx,
             dev_ctx, dx_help, dx, dx_reduce_dims);
       }
       dx->Resize(x.dims());
+      // Ensure output shape matches original input shape
+      if (x.dims().size() == 1 && dx->dims().size() == 2) {
+        if (dx->dims()[1] == 1) {
+          dx->Resize({dx->dims()[0]});
+        } else if (dx->dims()[0] == 1) {
+          dx->Resize({dx->dims()[1]});
+        }
+      }
     }
     if (dy) {
       if (dy_reduce_dims.empty()) {
@@ -485,6 +509,14 @@ void MatmulGradKernel(const Context& dev_ctx,
             dev_ctx, dy_help, dy, dy_reduce_dims);
       }
       dy->Resize(y.dims());
+      // Ensure output shape matches original input shape
+      if (y.dims().size() == 1 && dy->dims().size() == 2) {
+        if (dy->dims()[1] == 1) {
+          dy->Resize({dy->dims()[0]});
+        } else if (dy->dims()[0] == 1) {
+          dy->Resize({dy->dims()[1]});
+        }
+      }
     }
     // Get the OutputGrad(out)
   }


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
This PR fixes a critical issue where the `matmul_v2` gradient operation produces **inconsistent gradient shapes between eager mode and static compilation mode** when the inputs are 1-D tensors.

#### Problem
- **Eager mode** correctly returns 1-D gradients `(n,)` for 1-D inputs.
- **Static compilation mode** (with `check_prim_pir=True`) incorrectly returns 2-D gradients `(n, 1)` or `(1, n)` for 1-D inputs.
- This inconsistency causes test failures with shape mismatch errors like:
```text
  AssertionError: Not equal to tolerance rtol=1e-15, atol=1e-15
  Check static comp grad out failed. Mismatch between static comp and eager on Place(gpu:0)
  static comp grad out tensor: [[-0.01653409 -0.33412735 ...]]  # shape (1, 100)
  eager grad out tensor: [-0.01653409 -0.33412735 ...]        # shape (100,)
```

#### Root Cause

The shape inconsistency occurs in **two places**:

1. **Composite implementation** (`paddle/fluid/primitive/decomp_rule/decomp_vjp/details.h`):
   When `check_prim_pir=True`, the composite `matmul_grad` function **unsqueezes 1-D inputs** to 2-D for computation but **does not convert the resulting 2-D gradients back** to 1-D.

2. **Kernel implementation** (`paddle/phi/kernels/impl/matmul_grad_kernel_impl.h`):
   Internal matrix operations produce 2-D gradients that are not reshaped back to 1-D for 1-D inputs.

#### Fix

* In **composite implementation**, added shape handling logic to **squeeze 2-D gradients back to 1-D** if the original input was 1-D.
* In **kernel implementation**, applied the same logic for consistency.
* Both paths now check whether the original input was 1-D and squeeze the appropriate dimension to ensure consistent gradient shapes.

#### Changes

1. Modified `matmul_grad` in `details.h` to handle 1-D gradient shapes.
2. Modified `MatmulGradKernel` in `matmul_grad_kernel_impl.h` for consistency.

This fix ensures **consistent behavior between eager and static compilation modes**, resolving gradient shape mismatch errors in `matmul_v2` backpropagation.

---

#### 问题描述
- **动态图模式**：对 1 维输入，正确返回 1 维梯度 `(n,)`。
- **静态编译模式**（`check_prim_pir=True`）：错误地返回 2 维梯度 `(n,1)` 或 `(1,n)`。
- 这种不一致会导致测试失败，报出形状不匹配错误，例如：
```text
  AssertionError: Not equal to tolerance rtol=1e-15, atol=1e-15
  Check static comp grad out failed. Mismatch between static comp and eager on Place(gpu:0)
  static comp grad out tensor: [[-0.01653409 -0.33412735 ...]]  # shape (1, 100)
  eager grad out tensor: [-0.01653409 -0.33412735 ...]        # shape (100,)
```

#### 根本原因

问题出现在 **两个地方**：

1. **复合实现**（`paddle/fluid/primitive/decomp_rule/decomp_vjp/details.h`）：
   当 `check_prim_pir=True` 时，`matmul_grad` 复合函数会将 1 维输入 **unsqueeze 为 2 维** 来进行矩阵运算，但 **没有在梯度返回时再 squeeze 回 1 维**。

2. **内核实现**（`paddle/phi/kernels/impl/matmul_grad_kernel_impl.h`）：
   内部矩阵计算同样会生成 2 维梯度，**未根据原始输入形状进行还原**。

#### 解决方案

* **复合实现**：添加形状处理逻辑，如果原始输入是 1 维，则将 2 维梯度 squeeze 回 1 维。
* **内核实现**：添加相同的逻辑，保证一致性。
* 现在两个路径都会检查原始输入维度，并在必要时对梯度进行 squeeze 处理。

#### 修改内容

1. 修改 `details.h` 中的 `matmul_grad` 复合函数，支持 1 维梯度形状处理。
2. 修改 `matmul_grad_kernel_impl.h` 中的 `MatmulGradKernel`，保证与复合逻辑一致。

此修复确保了 eager 与静态编译模式下梯度计算行为一致，彻底解决了 `matmul_v2` 反向传播中的形状不匹配问题。


<img width="566" height="135" alt="Screenshot 2025-10-16 at 10 03 25 PM" src="https://github.com/user-attachments/assets/6ddfe75f-f34c-4b01-a1d3-7c3e20e1e43a" />

@luotao1 @YqGe585 