### PR TITLE
[Bug Fix] Support casting lightweight float formats to complex types

### DIFF
--- a/paddle/phi/core/framework/data_type_transform.cc
+++ b/paddle/phi/core/framework/data_type_transform.cc
@@ -34,6 +34,78 @@ struct CastDataTypeFunctor {
   }
 };
 
+template <>
+struct CastDataTypeFunctor<::phi::dtype::float8_e5m2,
+                           ::phi::dtype::complex<float>> {
+  HOSTDEVICE inline ::phi::dtype::complex<float> operator()(
+      ::phi::dtype::float8_e5m2 in) const {
+    return ::phi::dtype::complex<float>(static_cast<float>(in));
+  }
+};
+
+template <>
+struct CastDataTypeFunctor<::phi::dtype::float8_e5m2,
+                           ::phi::dtype::complex<double>> {
+  HOSTDEVICE inline ::phi::dtype::complex<double> operator()(
+      ::phi::dtype::float8_e5m2 in) const {
+    return ::phi::dtype::complex<double>(static_cast<double>(in));
+  }
+};
+
+template <>
+struct CastDataTypeFunctor<::phi::dtype::float8_e4m3fn,
+                           ::phi::dtype::complex<float>> {
+  HOSTDEVICE inline ::phi::dtype::complex<float> operator()(
+      ::phi::dtype::float8_e4m3fn in) const {
+    return ::phi::dtype::complex<float>(static_cast<float>(in));
+  }
+};
+
+template <>
+struct CastDataTypeFunctor<::phi::dtype::float8_e4m3fn,
+                           ::phi::dtype::complex<double>> {
+  HOSTDEVICE inline ::phi::dtype::complex<double> operator()(
+      ::phi::dtype::float8_e4m3fn in) const {
+    return ::phi::dtype::complex<double>(static_cast<double>(in));
+  }
+};
+
+template <>
+struct CastDataTypeFunctor<::phi::dtype::bfloat16,
+                           ::phi::dtype::complex<float>> {
+  HOSTDEVICE inline ::phi::dtype::complex<float> operator()(
+      ::phi::dtype::bfloat16 in) const {
+    return ::phi::dtype::complex<float>(static_cast<float>(in));
+  }
+};
+
+template <>
+struct CastDataTypeFunctor<::phi::dtype::bfloat16,
+                           ::phi::dtype::complex<double>> {
+  HOSTDEVICE inline ::phi::dtype::complex<double> operator()(
+      ::phi::dtype::bfloat16 in) const {
+    return ::phi::dtype::complex<double>(static_cast<double>(in));
+  }
+};
+
+template <>
+struct CastDataTypeFunctor<::phi::dtype::float16,
+                           ::phi::dtype::complex<float>> {
+  HOSTDEVICE inline ::phi::dtype::complex<float> operator()(
+      ::phi::dtype::float16 in) const {
+    return ::phi::dtype::complex<float>(static_cast<float>(in));
+  }
+};
+
+template <>
+struct CastDataTypeFunctor<::phi::dtype::float16,
+                           ::phi::dtype::complex<double>> {
+  HOSTDEVICE inline ::phi::dtype::complex<double> operator()(
+      ::phi::dtype::float16 in) const {
+    return ::phi::dtype::complex<double>(static_cast<double>(in));
+  }
+};
+
 #if defined(PADDLE_WITH_XPU)
 
 template <typename InType, typename OutType>

--- a/test/cpp/fluid/framework/data_type_transform_test.cc
+++ b/test/cpp/fluid/framework/data_type_transform_test.cc
@@ -395,4 +395,164 @@ TEST(DataTypeTransform, CPUTransform) {
       EXPECT_EQ(ptr[i], static_cast<int32_t>(in_data_bool[i]));
     }
   }
+
+  // data type transform from lightweight float formats to complex types
+  {
+    auto kernel_float8_e5m2 = phi::KernelKey(
+        place, phi::DataLayout::ALL_LAYOUT, phi::DataType::FLOAT8_E5M2);
+    auto kernel_float8_e4m3fn = phi::KernelKey(
+        place, phi::DataLayout::ALL_LAYOUT, phi::DataType::FLOAT8_E4M3FN);
+    auto kernel_complex64 = phi::KernelKey(
+        place, phi::DataLayout::ALL_LAYOUT, phi::DataType::COMPLEX64);
+    auto kernel_complex128 = phi::KernelKey(
+        place, phi::DataLayout::ALL_LAYOUT, phi::DataType::COMPLEX128);
+
+    phi::DenseTensor in;
+    phi::DenseTensor out;
+    int data_number = 2 * 3;
+
+    // Test float16 to complex64
+    {
+      phi::dtype::float16* ptr = in.mutable_data<phi::dtype::float16>(
+          common::make_ddim({2, 3}), place);
+      for (int i = 0; i < data_number; ++i) {
+        ptr[i] = static_cast<phi::dtype::float16>(i);
+      }
+
+      paddle::framework::TransDataType(kernel_fp16, kernel_complex64, in, &out);
+      phi::dtype::complex<float>* out_data =
+          out.data<phi::dtype::complex<float>>();
+      for (int i = 0; i < data_number; ++i) {
+        EXPECT_EQ(out_data[i].real, static_cast<float>(ptr[i]));
+        EXPECT_EQ(out_data[i].imag, 0.0f);
+      }
+    }
+
+    // Test float16 to complex128
+    {
+      phi::dtype::float16* ptr = in.mutable_data<phi::dtype::float16>(
+          common::make_ddim({2, 3}), place);
+      for (int i = 0; i < data_number; ++i) {
+        ptr[i] = static_cast<phi::dtype::float16>(i);
+      }
+
+      paddle::framework::TransDataType(
+          kernel_fp16, kernel_complex128, in, &out);
+      phi::dtype::complex<double>* out_data =
+          out.data<phi::dtype::complex<double>>();
+      for (int i = 0; i < data_number; ++i) {
+        EXPECT_EQ(out_data[i].real, static_cast<double>(ptr[i]));
+        EXPECT_EQ(out_data[i].imag, 0.0);
+      }
+    }
+
+    // Test bfloat16 to complex64
+    {
+      phi::dtype::bfloat16* ptr = in.mutable_data<phi::dtype::bfloat16>(
+          common::make_ddim({2, 3}), place);
+      for (int i = 0; i < data_number; ++i) {
+        ptr[i] = static_cast<phi::dtype::bfloat16>(i);
+      }
+
+      paddle::framework::TransDataType(kernel_bf16, kernel_complex64, in, &out);
+      phi::dtype::complex<float>* out_data =
+          out.data<phi::dtype::complex<float>>();
+      for (int i = 0; i < data_number; ++i) {
+        EXPECT_EQ(out_data[i].real, static_cast<float>(ptr[i]));
+        EXPECT_EQ(out_data[i].imag, 0.0f);
+      }
+    }
+
+    // Test bfloat16 to complex128
+    {
+      phi::dtype::bfloat16* ptr = in.mutable_data<phi::dtype::bfloat16>(
+          common::make_ddim({2, 3}), place);
+      for (int i = 0; i < data_number; ++i) {
+        ptr[i] = static_cast<phi::dtype::bfloat16>(i);
+      }
+
+      paddle::framework::TransDataType(
+          kernel_bf16, kernel_complex128, in, &out);
+      phi::dtype::complex<double>* out_data =
+          out.data<phi::dtype::complex<double>>();
+      for (int i = 0; i < data_number; ++i) {
+        EXPECT_EQ(out_data[i].real, static_cast<double>(ptr[i]));
+        EXPECT_EQ(out_data[i].imag, 0.0);
+      }
+    }
+
+    // Test float8_e4m3fn to complex64
+    {
+      phi::dtype::float8_e4m3fn* ptr =
+          in.mutable_data<phi::dtype::float8_e4m3fn>(common::make_ddim({2, 3}),
+                                                     place);
+      for (int i = 0; i < data_number; ++i) {
+        ptr[i] = static_cast<phi::dtype::float8_e4m3fn>(i);
+      }
+
+      paddle::framework::TransDataType(
+          kernel_float8_e4m3fn, kernel_complex64, in, &out);
+      phi::dtype::complex<float>* out_data =
+          out.data<phi::dtype::complex<float>>();
+      for (int i = 0; i < data_number; ++i) {
+        EXPECT_EQ(out_data[i].real, static_cast<float>(ptr[i]));
+        EXPECT_EQ(out_data[i].imag, 0.0f);
+      }
+    }
+
+    // Test float8_e4m3fn to complex128
+    {
+      phi::dtype::float8_e4m3fn* ptr =
+          in.mutable_data<phi::dtype::float8_e4m3fn>(common::make_ddim({2, 3}),
+                                                     place);
+      for (int i = 0; i < data_number; ++i) {
+        ptr[i] = static_cast<phi::dtype::float8_e4m3fn>(i);
+      }
+
+      paddle::framework::TransDataType(
+          kernel_float8_e4m3fn, kernel_complex128, in, &out);
+      phi::dtype::complex<double>* out_data =
+          out.data<phi::dtype::complex<double>>();
+      for (int i = 0; i < data_number; ++i) {
+        EXPECT_EQ(out_data[i].real, static_cast<double>(ptr[i]));
+        EXPECT_EQ(out_data[i].imag, 0.0);
+      }
+    }
+
+    // Test float8_e5m2 to complex64
+    {
+      phi::dtype::float8_e5m2* ptr = in.mutable_data<phi::dtype::float8_e5m2>(
+          common::make_ddim({2, 3}), place);
+      for (int i = 0; i < data_number; ++i) {
+        ptr[i] = static_cast<phi::dtype::float8_e5m2>(i);
+      }
+
+      paddle::framework::TransDataType(
+          kernel_float8_e5m2, kernel_complex64, in, &out);
+      phi::dtype::complex<float>* out_data =
+          out.data<phi::dtype::complex<float>>();
+      for (int i = 0; i < data_number; ++i) {
+        EXPECT_EQ(out_data[i].real, static_cast<float>(ptr[i]));
+        EXPECT_EQ(out_data[i].imag, 0.0f);
+      }
+    }
+
+    // Test float8_e5m2 to complex128
+    {
+      phi::dtype::float8_e5m2* ptr = in.mutable_data<phi::dtype::float8_e5m2>(
+          common::make_ddim({2, 3}), place);
+      for (int i = 0; i < data_number; ++i) {
+        ptr[i] = static_cast<phi::dtype::float8_e5m2>(i);
+      }
+
+      paddle::framework::TransDataType(
+          kernel_float8_e5m2, kernel_complex128, in, &out);
+      phi::dtype::complex<double>* out_data =
+          out.data<phi::dtype::complex<double>>();
+      for (int i = 0; i < data_number; ++i) {
+        EXPECT_EQ(out_data[i].real, static_cast<double>(ptr[i]));
+        EXPECT_EQ(out_data[i].imag, 0.0);
+      }
+    }
+  }
 }

--- a/test/legacy_test/test_complex_cast.py
+++ b/test/legacy_test/test_complex_cast.py
@@ -18,6 +18,9 @@ import numpy as np
 
 import paddle
 
+# This test file covers casting operations between different data types,
+# including lightweight float formats (float8, float16, bfloat16) and complex types.
+
 
 class TestComplexCastOp(unittest.TestCase):
     def test_complex_to_real(self):

--- a/test/legacy_test/test_complex_cast.py
+++ b/test/legacy_test/test_complex_cast.py
@@ -79,6 +79,116 @@ class TestComplexCastOp(unittest.TestCase):
             c_128.cast('complex128').numpy(), c_64.numpy(), rtol=1e-05
         )
 
+    @unittest.skipIf(
+        not paddle.is_compiled_with_cuda(),
+        "float16/bfloat16/float8 test runs only on CUDA",
+    )
+    def test_float16_bfloat16_to_complex(self):
+        # Test float16 to complex64/complex128
+        r_fp16 = np.random.random(size=[10, 10]).astype('float16')
+        r_fp16_t = paddle.to_tensor(r_fp16, dtype='float16')
+
+        self.assertEqual(r_fp16_t.cast('complex64').dtype, paddle.complex64)
+        self.assertEqual(r_fp16_t.cast('complex128').dtype, paddle.complex128)
+
+        np.testing.assert_allclose(
+            r_fp16_t.cast('complex64').real().numpy(),
+            r_fp16.astype('float32'),
+            rtol=1e-03,
+        )
+        np.testing.assert_allclose(
+            r_fp16_t.cast('complex128').real().numpy(),
+            r_fp16.astype('float64'),
+            rtol=1e-03,
+        )
+
+        # Test bfloat16 to complex64/complex128
+        r_bf16 = np.random.random(size=[10, 10]).astype('float32')
+        r_bf16_t = paddle.to_tensor(r_bf16, dtype='bfloat16')
+
+        self.assertEqual(r_bf16_t.cast('complex64').dtype, paddle.complex64)
+        self.assertEqual(r_bf16_t.cast('complex128').dtype, paddle.complex128)
+
+        np.testing.assert_allclose(
+            r_bf16_t.cast('complex64').real().numpy(),
+            r_bf16_t.cast('float32').numpy(),
+            rtol=1e-02,
+        )
+        np.testing.assert_allclose(
+            r_bf16_t.cast('complex128').real().numpy(),
+            r_bf16_t.cast('float64').numpy(),
+            rtol=1e-02,
+        )
+
+    @unittest.skipIf(
+        not paddle.is_compiled_with_cuda(),
+        "float8 test runs only on CUDA",
+    )
+    def test_float8_to_complex(self):
+        # Test float8_e4m3fn to complex64/complex128
+        r_fp32 = np.random.uniform(1.0, 10.0, size=[10, 10]).astype('float32')
+        r_fp32_t = paddle.to_tensor(r_fp32)
+        r_fp8_e4m3fn_t = r_fp32_t.astype('float8_e4m3fn')
+
+        self.assertEqual(
+            r_fp8_e4m3fn_t.cast('complex64').dtype, paddle.complex64
+        )
+        self.assertEqual(
+            r_fp8_e4m3fn_t.cast('complex128').dtype, paddle.complex128
+        )
+
+        # Verify the real part matches the float32 version
+        np.testing.assert_allclose(
+            r_fp8_e4m3fn_t.cast('complex64').real().numpy(),
+            r_fp8_e4m3fn_t.cast('float32').numpy(),
+            rtol=1e-02,
+        )
+        np.testing.assert_allclose(
+            r_fp8_e4m3fn_t.cast('complex128').real().numpy(),
+            r_fp8_e4m3fn_t.cast('float64').numpy(),
+            rtol=1e-02,
+        )
+
+        # Verify the imaginary part is zero
+        np.testing.assert_array_equal(
+            r_fp8_e4m3fn_t.cast('complex64').imag().numpy(),
+            np.zeros([10, 10], dtype='float32'),
+        )
+        np.testing.assert_array_equal(
+            r_fp8_e4m3fn_t.cast('complex128').imag().numpy(),
+            np.zeros([10, 10], dtype='float64'),
+        )
+
+        # Test float8_e5m2 to complex64/complex128
+        r_fp8_e5m2_t = r_fp32_t.astype('float8_e5m2')
+
+        self.assertEqual(r_fp8_e5m2_t.cast('complex64').dtype, paddle.complex64)
+        self.assertEqual(
+            r_fp8_e5m2_t.cast('complex128').dtype, paddle.complex128
+        )
+
+        # Verify the real part matches the float32 version
+        np.testing.assert_allclose(
+            r_fp8_e5m2_t.cast('complex64').real().numpy(),
+            r_fp8_e5m2_t.cast('float32').numpy(),
+            rtol=1e-02,
+        )
+        np.testing.assert_allclose(
+            r_fp8_e5m2_t.cast('complex128').real().numpy(),
+            r_fp8_e5m2_t.cast('float64').numpy(),
+            rtol=1e-02,
+        )
+
+        # Verify the imaginary part is zero
+        np.testing.assert_array_equal(
+            r_fp8_e5m2_t.cast('complex64').imag().numpy(),
+            np.zeros([10, 10], dtype='float32'),
+        )
+        np.testing.assert_array_equal(
+            r_fp8_e5m2_t.cast('complex128').imag().numpy(),
+            np.zeros([10, 10], dtype='float64'),
+        )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/legacy_test/test_complex_cast.py
+++ b/test/legacy_test/test_complex_cast.py
@@ -18,9 +18,6 @@ import numpy as np
 
 import paddle
 
-# This test file covers casting operations between different data types,
-# including lightweight float formats (float8, float16, bfloat16) and complex types.
-
 
 class TestComplexCastOp(unittest.TestCase):
     def test_complex_to_real(self):
@@ -80,116 +77,6 @@ class TestComplexCastOp(unittest.TestCase):
         )
         np.testing.assert_allclose(
             c_128.cast('complex128').numpy(), c_64.numpy(), rtol=1e-05
-        )
-
-    @unittest.skipIf(
-        not paddle.is_compiled_with_cuda(),
-        "float16/bfloat16/float8 test runs only on CUDA",
-    )
-    def test_float16_bfloat16_to_complex(self):
-        # Test float16 to complex64/complex128
-        r_fp16 = np.random.random(size=[10, 10]).astype('float16')
-        r_fp16_t = paddle.to_tensor(r_fp16, dtype='float16')
-
-        self.assertEqual(r_fp16_t.cast('complex64').dtype, paddle.complex64)
-        self.assertEqual(r_fp16_t.cast('complex128').dtype, paddle.complex128)
-
-        np.testing.assert_allclose(
-            r_fp16_t.cast('complex64').real().numpy(),
-            r_fp16.astype('float32'),
-            rtol=1e-03,
-        )
-        np.testing.assert_allclose(
-            r_fp16_t.cast('complex128').real().numpy(),
-            r_fp16.astype('float64'),
-            rtol=1e-03,
-        )
-
-        # Test bfloat16 to complex64/complex128
-        r_bf16 = np.random.random(size=[10, 10]).astype('float32')
-        r_bf16_t = paddle.to_tensor(r_bf16, dtype='bfloat16')
-
-        self.assertEqual(r_bf16_t.cast('complex64').dtype, paddle.complex64)
-        self.assertEqual(r_bf16_t.cast('complex128').dtype, paddle.complex128)
-
-        np.testing.assert_allclose(
-            r_bf16_t.cast('complex64').real().numpy(),
-            r_bf16_t.cast('float32').numpy(),
-            rtol=1e-02,
-        )
-        np.testing.assert_allclose(
-            r_bf16_t.cast('complex128').real().numpy(),
-            r_bf16_t.cast('float64').numpy(),
-            rtol=1e-02,
-        )
-
-    @unittest.skipIf(
-        not paddle.is_compiled_with_cuda(),
-        "float8 test runs only on CUDA",
-    )
-    def test_float8_to_complex(self):
-        # Test float8_e4m3fn to complex64/complex128
-        r_fp32 = np.random.uniform(1.0, 10.0, size=[10, 10]).astype('float32')
-        r_fp32_t = paddle.to_tensor(r_fp32)
-        r_fp8_e4m3fn_t = r_fp32_t.astype('float8_e4m3fn')
-
-        self.assertEqual(
-            r_fp8_e4m3fn_t.cast('complex64').dtype, paddle.complex64
-        )
-        self.assertEqual(
-            r_fp8_e4m3fn_t.cast('complex128').dtype, paddle.complex128
-        )
-
-        # Verify the real part matches the float32 version
-        np.testing.assert_allclose(
-            r_fp8_e4m3fn_t.cast('complex64').real().numpy(),
-            r_fp8_e4m3fn_t.cast('float32').numpy(),
-            rtol=1e-02,
-        )
-        np.testing.assert_allclose(
-            r_fp8_e4m3fn_t.cast('complex128').real().numpy(),
-            r_fp8_e4m3fn_t.cast('float64').numpy(),
-            rtol=1e-02,
-        )
-
-        # Verify the imaginary part is zero
-        np.testing.assert_array_equal(
-            r_fp8_e4m3fn_t.cast('complex64').imag().numpy(),
-            np.zeros([10, 10], dtype='float32'),
-        )
-        np.testing.assert_array_equal(
-            r_fp8_e4m3fn_t.cast('complex128').imag().numpy(),
-            np.zeros([10, 10], dtype='float64'),
-        )
-
-        # Test float8_e5m2 to complex64/complex128
-        r_fp8_e5m2_t = r_fp32_t.astype('float8_e5m2')
-
-        self.assertEqual(r_fp8_e5m2_t.cast('complex64').dtype, paddle.complex64)
-        self.assertEqual(
-            r_fp8_e5m2_t.cast('complex128').dtype, paddle.complex128
-        )
-
-        # Verify the real part matches the float32 version
-        np.testing.assert_allclose(
-            r_fp8_e5m2_t.cast('complex64').real().numpy(),
-            r_fp8_e5m2_t.cast('float32').numpy(),
-            rtol=1e-02,
-        )
-        np.testing.assert_allclose(
-            r_fp8_e5m2_t.cast('complex128').real().numpy(),
-            r_fp8_e5m2_t.cast('float64').numpy(),
-            rtol=1e-02,
-        )
-
-        # Verify the imaginary part is zero
-        np.testing.assert_array_equal(
-            r_fp8_e5m2_t.cast('complex64').imag().numpy(),
-            np.zeros([10, 10], dtype='float32'),
-        )
-        np.testing.assert_array_equal(
-            r_fp8_e5m2_t.cast('complex128').imag().numpy(),
-            np.zeros([10, 10], dtype='float64'),
         )
 
 

--- a/test/legacy_test/test_lightweight_float_to_complex.py
+++ b/test/legacy_test/test_lightweight_float_to_complex.py
@@ -1,0 +1,175 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+
+import paddle
+
+
+class TestLightweightFloatToComplex(unittest.TestCase):
+    """Test casting from lightweight float formats (float8, float16, bfloat16) to complex types."""
+
+    @unittest.skipIf(
+        not paddle.is_compiled_with_cuda(),
+        "float16/bfloat16 test runs only on CUDA",
+    )
+    def test_float16_to_complex(self):
+        """Test float16 to complex64/complex128 conversion."""
+        r_fp16 = np.random.random(size=[10, 10]).astype('float16')
+        r_fp16_t = paddle.to_tensor(r_fp16, dtype='float16')
+
+        # Test dtype conversion
+        self.assertEqual(r_fp16_t.cast('complex64').dtype, paddle.complex64)
+        self.assertEqual(r_fp16_t.cast('complex128').dtype, paddle.complex128)
+
+        # Verify the real part is correct
+        np.testing.assert_allclose(
+            r_fp16_t.cast('complex64').real().numpy(),
+            r_fp16.astype('float32'),
+            rtol=1e-03,
+        )
+        np.testing.assert_allclose(
+            r_fp16_t.cast('complex128').real().numpy(),
+            r_fp16.astype('float64'),
+            rtol=1e-03,
+        )
+
+        # Verify the imaginary part is zero
+        np.testing.assert_array_equal(
+            r_fp16_t.cast('complex64').imag().numpy(),
+            np.zeros([10, 10], dtype='float32'),
+        )
+        np.testing.assert_array_equal(
+            r_fp16_t.cast('complex128').imag().numpy(),
+            np.zeros([10, 10], dtype='float64'),
+        )
+
+    @unittest.skipIf(
+        not paddle.is_compiled_with_cuda(),
+        "bfloat16 test runs only on CUDA",
+    )
+    def test_bfloat16_to_complex(self):
+        """Test bfloat16 to complex64/complex128 conversion."""
+        r_bf16 = np.random.random(size=[10, 10]).astype('float32')
+        r_bf16_t = paddle.to_tensor(r_bf16, dtype='bfloat16')
+
+        # Test dtype conversion
+        self.assertEqual(r_bf16_t.cast('complex64').dtype, paddle.complex64)
+        self.assertEqual(r_bf16_t.cast('complex128').dtype, paddle.complex128)
+
+        # Verify the real part is correct
+        np.testing.assert_allclose(
+            r_bf16_t.cast('complex64').real().numpy(),
+            r_bf16_t.cast('float32').numpy(),
+            rtol=1e-02,
+        )
+        np.testing.assert_allclose(
+            r_bf16_t.cast('complex128').real().numpy(),
+            r_bf16_t.cast('float64').numpy(),
+            rtol=1e-02,
+        )
+
+        # Verify the imaginary part is zero
+        np.testing.assert_array_equal(
+            r_bf16_t.cast('complex64').imag().numpy(),
+            np.zeros([10, 10], dtype='float32'),
+        )
+        np.testing.assert_array_equal(
+            r_bf16_t.cast('complex128').imag().numpy(),
+            np.zeros([10, 10], dtype='float64'),
+        )
+
+    @unittest.skipIf(
+        not paddle.is_compiled_with_cuda(),
+        "float8 test runs only on CUDA",
+    )
+    def test_float8_e4m3fn_to_complex(self):
+        """Test float8_e4m3fn to complex64/complex128 conversion."""
+        r_fp32 = np.random.uniform(1.0, 10.0, size=[10, 10]).astype('float32')
+        r_fp32_t = paddle.to_tensor(r_fp32)
+        r_fp8_e4m3fn_t = r_fp32_t.astype('float8_e4m3fn')
+
+        # Test dtype conversion
+        self.assertEqual(
+            r_fp8_e4m3fn_t.cast('complex64').dtype, paddle.complex64
+        )
+        self.assertEqual(
+            r_fp8_e4m3fn_t.cast('complex128').dtype, paddle.complex128
+        )
+
+        # Verify the real part matches the float32 version
+        np.testing.assert_allclose(
+            r_fp8_e4m3fn_t.cast('complex64').real().numpy(),
+            r_fp8_e4m3fn_t.cast('float32').numpy(),
+            rtol=1e-02,
+        )
+        np.testing.assert_allclose(
+            r_fp8_e4m3fn_t.cast('complex128').real().numpy(),
+            r_fp8_e4m3fn_t.cast('float64').numpy(),
+            rtol=1e-02,
+        )
+
+        # Verify the imaginary part is zero
+        np.testing.assert_array_equal(
+            r_fp8_e4m3fn_t.cast('complex64').imag().numpy(),
+            np.zeros([10, 10], dtype='float32'),
+        )
+        np.testing.assert_array_equal(
+            r_fp8_e4m3fn_t.cast('complex128').imag().numpy(),
+            np.zeros([10, 10], dtype='float64'),
+        )
+
+    @unittest.skipIf(
+        not paddle.is_compiled_with_cuda(),
+        "float8 test runs only on CUDA",
+    )
+    def test_float8_e5m2_to_complex(self):
+        """Test float8_e5m2 to complex64/complex128 conversion."""
+        r_fp32 = np.random.uniform(1.0, 10.0, size=[10, 10]).astype('float32')
+        r_fp32_t = paddle.to_tensor(r_fp32)
+        r_fp8_e5m2_t = r_fp32_t.astype('float8_e5m2')
+
+        # Test dtype conversion
+        self.assertEqual(r_fp8_e5m2_t.cast('complex64').dtype, paddle.complex64)
+        self.assertEqual(
+            r_fp8_e5m2_t.cast('complex128').dtype, paddle.complex128
+        )
+
+        # Verify the real part matches the float32 version
+        np.testing.assert_allclose(
+            r_fp8_e5m2_t.cast('complex64').real().numpy(),
+            r_fp8_e5m2_t.cast('float32').numpy(),
+            rtol=1e-02,
+        )
+        np.testing.assert_allclose(
+            r_fp8_e5m2_t.cast('complex128').real().numpy(),
+            r_fp8_e5m2_t.cast('float64').numpy(),
+            rtol=1e-02,
+        )
+
+        # Verify the imaginary part is zero
+        np.testing.assert_array_equal(
+            r_fp8_e5m2_t.cast('complex64').imag().numpy(),
+            np.zeros([10, 10], dtype='float32'),
+        )
+        np.testing.assert_array_equal(
+            r_fp8_e5m2_t.cast('complex128').imag().numpy(),
+            np.zeros([10, 10], dtype='float64'),
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/legacy_test/test_lightweight_float_to_complex.py
+++ b/test/legacy_test/test_lightweight_float_to_complex.py
@@ -22,12 +22,10 @@ import paddle
 class TestLightweightFloatToComplex(unittest.TestCase):
     """Test casting from lightweight float formats (float8, float16, bfloat16) to complex types."""
 
-    @unittest.skipIf(
-        not paddle.is_compiled_with_cuda(),
-        "float16/bfloat16 test runs only on CUDA",
-    )
     def test_float16_to_complex(self):
         """Test float16 to complex64/complex128 conversion."""
+        paddle.set_device('cpu')
+
         r_fp16 = np.random.random(size=[10, 10]).astype('float16')
         r_fp16_t = paddle.to_tensor(r_fp16, dtype='float16')
 
@@ -57,12 +55,10 @@ class TestLightweightFloatToComplex(unittest.TestCase):
             np.zeros([10, 10], dtype='float64'),
         )
 
-    @unittest.skipIf(
-        not paddle.is_compiled_with_cuda(),
-        "bfloat16 test runs only on CUDA",
-    )
     def test_bfloat16_to_complex(self):
         """Test bfloat16 to complex64/complex128 conversion."""
+        paddle.set_device('cpu')
+
         r_bf16 = np.random.random(size=[10, 10]).astype('float32')
         r_bf16_t = paddle.to_tensor(r_bf16, dtype='bfloat16')
 
@@ -92,12 +88,10 @@ class TestLightweightFloatToComplex(unittest.TestCase):
             np.zeros([10, 10], dtype='float64'),
         )
 
-    @unittest.skipIf(
-        not paddle.is_compiled_with_cuda(),
-        "float8 test runs only on CUDA",
-    )
     def test_float8_e4m3fn_to_complex(self):
         """Test float8_e4m3fn to complex64/complex128 conversion."""
+        paddle.set_device('cpu')
+
         r_fp32 = np.random.uniform(1.0, 10.0, size=[10, 10]).astype('float32')
         r_fp32_t = paddle.to_tensor(r_fp32)
         r_fp8_e4m3fn_t = r_fp32_t.astype('float8_e4m3fn')
@@ -132,12 +126,10 @@ class TestLightweightFloatToComplex(unittest.TestCase):
             np.zeros([10, 10], dtype='float64'),
         )
 
-    @unittest.skipIf(
-        not paddle.is_compiled_with_cuda(),
-        "float8 test runs only on CUDA",
-    )
     def test_float8_e5m2_to_complex(self):
         """Test float8_e5m2 to complex64/complex128 conversion."""
+        paddle.set_device('cpu')
+
         r_fp32 = np.random.uniform(1.0, 10.0, size=[10, 10]).astype('float32')
         r_fp32_t = paddle.to_tensor(r_fp32)
         r_fp8_e5m2_t = r_fp32_t.astype('float8_e5m2')


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Environment Adaptation


### PR Types
Bug fixes


### Description
- 加入了 `CastDataTypeFunctor` 对 `float8_e4m3fn`、`float8_e5m2`、`bfloat16`、`float16` 到 `complex64/complex128` 的专门实现；这些组合之前没有合法的 `static_cast`，会在模版实例化时报错或导致转换缺失。编译时的错误日志如下：
```shell
[283/3505] Building CXX object paddle\phi\CMakeFiles\phi.dir\core\framework\data_type_transform.cc.obj
FAILED: paddle/phi/CMakeFiles/phi.dir/core/framework/data_type_transform.cc.obj
"D:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\bin\Hostx64\x64\cl.exe"  /nologo /TP -DCUDA_TOOLKIT_ROOT_DIR="\"C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v13.0\"" -DCUDA_VERSION_MAJOR=\"13\" -DCUDA_VERSION_MINOR=\"0\" -DCUDNN_MAJOR_VERSION=\"9\" -DEIGEN_STRONG_INLINE=inline -DEIGEN_USE_GPU -DGLOG_NO_ABBREVIATED_SEVERITIES -DGOOGLE_GLOG_DLL_DECL="" -DLAPACK_FOUND -DNOMINMAX -DPADDLE_DISABLE_PROFILER -DPADDLE_DLL_EXPORT -DPADDLE_DLL_INFERENCE -DPADDLE_ON_INFERENCE -DPADDLE_VERSION=0.0.0 -DPADDLE_VERSION_INTEGER=0 -DPADDLE_WITH_AVX -DPADDLE_WITH_CCCL -DPADDLE_WITH_CRYPTO -DPADDLE_WITH_CUDA -DPADDLE_WITH_DNNL -DPADDLE_WITH_MKLML -DPADDLE_WITH_PIP_CUDA_LIBRARIES -DPADDLE_WITH_POCKETFFT -DPADDLE_WITH_SSE3 -DPADDLE_WITH_TENSORRT -DPHI_INNER -DPHI_SHARED -DSTATIC_IR -DTRT_PLUGIN_FP16_AVAILABLE -DUTF8PROC_STATIC -DWIN32_LEAN_AND_MEAN -DYAML_CPP_STATIC_DEFINE -D_XKEYCHECK_H -Dphi_EXPORTS -ID:\Paddle\third_party\cccl\thrust -ID:\Paddle\third_party\cccl\libcudacxx\include -ID:\Paddle\third_party\cccl\cub -ID:\Paddle\build -ID:\Paddle\paddle\fluid\framework\io -ID:\Paddle\patches\thrust -ID:\TensorRT-10.13.3.9\include -ID:\Paddle\build\third_party\install\zlib\include -ID:\Paddle\build\third_party\install -ID:\Paddle\build\third_party\install\gflags\include -ID:\Paddle\build\third_party\install\glog\include -ID:\Paddle\third_party\eigen3 -ID:\Paddle\third_party\threadpool -ID:\Paddle\third_party\dlpack\include -ID:\Paddle\build\third_party\install\xxhash\include -ID:\Paddle\build\third_party\install\warpctc\include -ID:\Paddle\build\third_party\install\warprnnt\include -ID:\Paddle\build\third_party\install\utf8proc\include -ID:\Paddle\build\third_party\install\mklml\include -ID:\Paddle\build\third_party\install\onednn\include -ID:\Paddle\build\third_party\install\protobuf\include -ID:\Paddle\third_party\nlohmann_json\include -ID:\Paddle\build\third_party\install\yaml-cpp\include -ID:\Users\Lenovo\AppData\Local\Programs\Python\Python310\include -ID:\Users\Lenovo\AppData\Local\Programs\Python\Python310\Lib\site-packages\numpy\core\include -ID:\Paddle\build\third_party\pybind\src\extern_pybind\include -ID:\Paddle\build\third_party\install\libuv\include -ID:\Paddle\third_party\cccl -ID:\Paddle\build\third_party\install\cryptopp\include -ID:\Paddle\build\third_party\pocketfft\src -ID:\Paddle\build\third_party\dirent\src\extern_dirent\include -I"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\include" -ID:\Paddle -ID:\Paddle\paddle\phi\api\include\compat -ID:\Paddle\paddle\phi\api\include\compat\torch\csrc\api\include -ID:\Paddle\build\..\paddle\fluid\framework\io /DWIN32 /D_WINDOWS  /W0  /GR /EHsc /w /wd4068 /wd4129 /wd4244 /wd4267 /wd4297 /wd4530 /wd4577 /wd4819 /wd4838  /arch:AVX /MT /O2 /Ob2 /DNDEBUG /bigobj /Zc:inline -std:c++17 /showIncludes /Fopaddle\phi\CMakeFiles\phi.dir\core\framework\data_type_transform.cc.obj /Fdpaddle\phi\CMakeFiles\phi.dir\ /FS -c D:\Paddle\paddle\phi\core\framework\data_type_transform.cc
D:\Paddle\paddle\phi\core\framework\data_type_transform.cc(33): error C2440: 'static_cast': cannot convert from 'InType' to 'OutType'
        with
        [
            InType=phi::dtype::float8_e5m2
        ]
        and
        [
            OutType=phi::dtype::complex<double>
        ]
D:\Paddle\paddle\phi\core\framework\data_type_transform.cc(33): note: 'phi::dtype::complex<double>::complex': no overloaded function could convert all the argument types
D:\Paddle\paddle/phi/common/complex.h(127): note: could be 'phi::dtype::complex<double>::complex<T>(const phi::dtype::complex<float> &)'
        with
        [
            T=double
        ]
D:\Paddle\paddle\phi\core\framework\data_type_transform.cc(33): note: 'phi::dtype::complex<double>::complex<T>(const phi::dtype::complex<float> &)': cannot convert argument 1 from 'InType' to 'const phi::dtype::complex<float> &'
        with
        [
            T=double
        ]
        and
        [
            InType=phi::dtype::float8_e5m2
        ]
D:\Paddle\paddle\phi\core\framework\data_type_transform.cc(33): note: Reason: cannot convert from 'InType' to 'const phi::dtype::complex<float>'
        with
        [
            InType=phi::dtype::float8_e5m2
        ]
D:\Paddle\paddle\phi\core\framework\data_type_transform.cc(33): note: No user-defined-conversion operator available that can perform this conversion, or the operator cannot be called
D:\Paddle\paddle/phi/common/complex.h(140): note: or       'phi::dtype::complex<double>::complex(const std::complex<_Other> &)'
D:\Paddle\paddle/phi/common/complex.h(119): note: or       'phi::dtype::complex<double>::complex(const std::enable_if<std::is_same<T1,float>::value,phi::dtype::complex<double>>::type &)'
D:\Paddle\paddle/phi/common/complex.h(113): note: or       'phi::dtype::complex<double>::complex(const T1 &)'
D:\Paddle\paddle/phi/common/complex.h(79): note: or       'phi::dtype::complex<double>::complex(const cuda::std::__4::complex<_Xp> &)'
D:\Paddle\paddle/phi/common/complex.h(72): note: or       'phi::dtype::complex<double>::complex(const thrust::THRUST_200200___CUDA_ARCH_LIST___NS::complex<U> &)'
D:\Paddle\paddle\phi\core\framework\data_type_transform.cc(33): note: while trying to match the argument list '(InType)'
        with
        [
            InType=phi::dtype::float8_e5m2
        ]
D:\Paddle\paddle\phi\core\framework\data_type_transform.cc(33): note: the template instantiation context (the oldest one first) is
D:\Paddle\paddle\phi\core\framework\data_type_transform.cc(207): note: see reference to function template instantiation 'void phi::VisitDataType<phi::CastDataType<phi::dtype::float8_e5m2>>(paddle::framework::proto::VarType::Type,Visitor)' being compiled
        with
        [
            Visitor=phi::CastDataType<phi::dtype::float8_e5m2>
        ]
D:\Paddle\paddle/phi/core/framework/var_type_helper.h(156): note: see reference to function template instantiation 'void phi::CastDataType<phi::dtype::float8_e5m2>::apply<phi::dtype::complex<double>>(void)' being compiled
D:\Paddle\paddle\phi\core\framework\data_type_transform.cc(106): note: see reference to class template instantiation 'phi::CastDataTypeFunctor<InType,OutType>' being compiled
        with
        [
            InType=phi::dtype::float8_e5m2,
            OutType=phi::dtype::complex<double>
        ]
D:\Paddle\paddle\phi\core\framework\data_type_transform.cc(32): note: while compiling class template member function 'OutType phi::CastDataTypeFunctor<InType,OutType>::operator ()(InType) const'
        with
        [
            OutType=phi::dtype::complex<double>,
            InType=phi::dtype::float8_e5m2
        ]
D:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\include\algorithm(3799): note: see the first reference to 'phi::CastDataTypeFunctor<InType,OutType>::operator ()' in 'std::transform'
        with
        [
            InType=phi::dtype::float8_e5m2,
            OutType=phi::dtype::complex<double>
        ]
D:\Paddle\paddle/phi/common/transform.h(78): note: see the first reference to 'std::transform' in 'phi::Transform<phi::CPUContext>::operator ()'
D:\Paddle\paddle\phi\core\framework\data_type_transform.cc(102): note: see the first reference to 'phi::Transform<phi::CPUContext>::operator ()' in 'phi::CastDataType<phi::dtype::float8_e5m2>::apply'
D:\Paddle\paddle/phi/core/framework/var_type_helper.h(156): note: see the first reference to 'phi::CastDataType<phi::dtype::float8_e5m2>::apply' in 'phi::VisitDataType'
[290/3505] Building CXX object paddle\phi\CMakeFiles\phi.dir\core\vocab\string_array.cc.obj
ninja: build stopped: subcommand failed.
```
- issue: https://github.com/PaddlePaddle/Paddle/issues/75848
- 拆分自 https://github.com/PaddlePaddle/Paddle/pull/75611
- 前置pr https://github.com/PaddlePaddle/Paddle/pull/75930