### PR TITLE
【UnitTestFix No.3】fix test_conv3d_transpose_op.py

### DIFF
--- a/test/legacy_test/op_test.py
+++ b/test/legacy_test/op_test.py
@@ -3833,7 +3833,7 @@ class OpTest(unittest.TestCase):
 
                 fetch_list_grad = []
                 for inputs_to_check_name in inputs_to_check:
-                    a = inputs_grad_dict[inputs_to_check_name].gradient()
+                    a = np.array(inputs_grad_dict[inputs_to_check_name].grad)
                     fetch_list_grad.append(a)
                 return fetch_list_grad
             else:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

This PR addresses a **deprecation warning** observed during the execution of `test_conv3d_transpose_op`:

```
Warning:
API "paddle.base.dygraph.tensor_patch_methods.gradient" is deprecated since 2.1.0, and will be removed in future versions.
```

Although the test itself runs correctly, the warning originates from legacy code in `test/legacy_test/op_test.py`, which still invokes outdated APIs.
To resolve this issue, the deprecated API usage in `op_test.py` has been updated to align with the latest Paddle API standards, ensuring cleaner test logs and improved forward compatibility.

---

该 PR 修复了在执行 `test_conv3d_transpose_op` 时出现的 **API 弃用警告**：

```
Warning:
API "paddle.base.dygraph.tensor_patch_methods.gradient" is deprecated since 2.1.0, and will be removed in future versions.
```

虽然该单测本身不会报错，但警告源于 `test/legacy_test/op_test.py` 中仍使用了已弃用的旧接口。
本次修改更新了相关 API 调用，使其符合最新 Paddle 框架规范，从而消除警告信息并提升代码的向前兼容性。

@luotao1 @YqGe585 

