### PR TITLE
[Fix] log sigmoid complex

### DIFF
--- a/paddle/phi/kernels/funcs/activation_functor.h
+++ b/paddle/phi/kernels/funcs/activation_functor.h
@@ -2453,12 +2453,11 @@ struct LogSigmoidFunctor<ComplexType<T>>
     : public BaseActivationFunctor<ComplexType<T>> {
   template <typename Device, typename X, typename Out>
   void operator()(Device d, X x, Out out) const {
-    // For complex numbers, use the direct formula: log(1 / (1 + exp(-x)))
-    // This is mathematically correct for complex numbers
+    // For complex numbers, use log σ(x) = -log(1 + exp(-x))
     ComplexType<T> one = ComplexType<T>(T(1), T(0));
     // Cache exp(-x) to avoid redundant computation
     auto exp_neg_x = (-x).exp();
-    out.device(d) = (one / (one + exp_neg_x)).log();
+    out.device(d) = -(one + exp_neg_x).log();
   }
 };
 
@@ -2490,8 +2489,8 @@ struct LogSigmoidGradFunctor<ComplexType<T>>
             typename dOut,
             typename dX>
   void operator()(Device d, X x, Out out UNUSED, dOut dout, dX dx) const {
-    // For complex numbers, use the direct formula: d/dx log(1/(1+exp(-x))) =
-    // exp(-x)/(1+exp(-x))
+    // For complex numbers, use the direct formula:
+    // d/dx log(1/(1+exp(-x))) = exp(-x)/(1+exp(-x))
     ComplexType<T> one = ComplexType<T>(T(1), T(0));
     // Cache exp(-x) to avoid redundant computation
     auto exp_neg_x = (-x).exp();
@@ -5143,12 +5142,13 @@ struct CudaLogSigmoidFunctor<ComplexType<T>>
     : public BaseActivationFunctor<ComplexType<T>> {
   ComplexType<T> one = ComplexType<T>(T(1), T(0));
 
-  // For complex numbers, use the direct formula: log(1 / (1 + exp(-x)))
+  // For complex numbers, use log σ(x) = -log(1 + exp(-x))
   __device__ __forceinline__ ComplexType<T> operator()(
       const ComplexType<T> arg_x) const {
     ComplexType<T> x = static_cast<ComplexType<T>>(arg_x);
-    auto exp_neg_x = exp(-x);  // Cache exp(-x) to avoid redundant computation
-    return log(one / (one + exp_neg_x));
+
+    // LogSigmoid formula: log σ(x) = -log(1 + exp(-x))
+    return -log(one + exp(-x));
   }
 };
 
@@ -5185,12 +5185,12 @@ struct CudaLogSigmoidGradFunctor<ComplexType<T>>
     : public BaseActivationFunctor<ComplexType<T>> {
   ComplexType<T> one = ComplexType<T>(T(1), T(0));
 
-  // For complex numbers, use the direct formula: d/dx log(1/(1+exp(-x))) =
-  // exp(-x)/(1+exp(-x))
+  // For complex numbers, gradient of log σ(x) is σ(-x) = exp(-x)/(1+exp(-x))
   __device__ __forceinline__ ComplexType<T> operator()(
       const ComplexType<T> arg_dout, const ComplexType<T> arg_x) const {
     ComplexType<T> dout = static_cast<ComplexType<T>>(arg_dout);
     ComplexType<T> x = static_cast<ComplexType<T>>(arg_x);
+    // Gradient of log σ(x) is σ(-x) = exp(-x)/(1+exp(-x))
     auto exp_neg_x = exp(-x);  // Cache exp(-x) to avoid redundant computation
     return dout * conj(exp_neg_x / (one + exp_neg_x));
   }

--- a/paddle/phi/kernels/funcs/activation_functor.h
+++ b/paddle/phi/kernels/funcs/activation_functor.h
@@ -2455,8 +2455,10 @@ struct LogSigmoidFunctor<ComplexType<T>>
   void operator()(Device d, X x, Out out) const {
     // For complex numbers, use the direct formula: log(1 / (1 + exp(-x)))
     // This is mathematically correct for complex numbers
-    ComplexType<T> one = static_cast<ComplexType<T>>(1);
-    out.device(d) = (one / (one + (-x).exp())).log();
+    ComplexType<T> one = ComplexType<T>(T(1), T(0));
+    // Cache exp(-x) to avoid redundant computation
+    auto exp_neg_x = (-x).exp();
+    out.device(d) = (one / (one + exp_neg_x)).log();
   }
 };
 
@@ -2490,9 +2492,10 @@ struct LogSigmoidGradFunctor<ComplexType<T>>
   void operator()(Device d, X x, Out out UNUSED, dOut dout, dX dx) const {
     // For complex numbers, use the direct formula: d/dx log(1/(1+exp(-x))) =
     // exp(-x)/(1+exp(-x))
-    ComplexType<T> one = static_cast<ComplexType<T>>(1);
-    dx.device(d) =
-        dout * ((-x).exp() / (one + (-x).exp())).unaryExpr(Conj<T>());
+    ComplexType<T> one = ComplexType<T>(T(1), T(0));
+    // Cache exp(-x) to avoid redundant computation
+    auto exp_neg_x = (-x).exp();
+    dx.device(d) = dout * (exp_neg_x / (one + exp_neg_x)).unaryExpr(Conj<T>());
   }
 
   static constexpr ActBwdOpFwdDeps FwdDeps() { return ActBwdOpFwdDeps::kDepX; }
@@ -5138,13 +5141,14 @@ struct CudaLogSigmoidFunctor : public BaseActivationFunctor<T> {
 template <typename T>
 struct CudaLogSigmoidFunctor<ComplexType<T>>
     : public BaseActivationFunctor<ComplexType<T>> {
-  ComplexType<T> one = static_cast<ComplexType<T>>(1.0f);
+  ComplexType<T> one = ComplexType<T>(T(1), T(0));
 
   // For complex numbers, use the direct formula: log(1 / (1 + exp(-x)))
   __device__ __forceinline__ ComplexType<T> operator()(
       const ComplexType<T> arg_x) const {
     ComplexType<T> x = static_cast<ComplexType<T>>(arg_x);
-    return log(one / (one + exp(-x)));
+    auto exp_neg_x = exp(-x);  // Cache exp(-x) to avoid redundant computation
+    return log(one / (one + exp_neg_x));
   }
 };
 
@@ -5179,7 +5183,7 @@ struct CudaLogSigmoidGradFunctor : public BaseActivationFunctor<T> {
 template <typename T>
 struct CudaLogSigmoidGradFunctor<ComplexType<T>>
     : public BaseActivationFunctor<ComplexType<T>> {
-  ComplexType<T> one = static_cast<ComplexType<T>>(1.0f);
+  ComplexType<T> one = ComplexType<T>(T(1), T(0));
 
   // For complex numbers, use the direct formula: d/dx log(1/(1+exp(-x))) =
   // exp(-x)/(1+exp(-x))
@@ -5187,7 +5191,8 @@ struct CudaLogSigmoidGradFunctor<ComplexType<T>>
       const ComplexType<T> arg_dout, const ComplexType<T> arg_x) const {
     ComplexType<T> dout = static_cast<ComplexType<T>>(arg_dout);
     ComplexType<T> x = static_cast<ComplexType<T>>(arg_x);
-    return dout * conj(exp(-x) / (one + exp(-x)));
+    auto exp_neg_x = exp(-x);  // Cache exp(-x) to avoid redundant computation
+    return dout * conj(exp_neg_x / (one + exp_neg_x));
   }
 
   static constexpr ActBwdOpFwdDeps FwdDeps() { return ActBwdOpFwdDeps::kDepX; }

--- a/paddle/phi/kernels/funcs/activation_functor.h
+++ b/paddle/phi/kernels/funcs/activation_functor.h
@@ -2447,6 +2447,19 @@ struct LogSigmoidFunctor : public BaseActivationFunctor<T> {
   }
 };
 
+// Specialized implementation for complex numbers
+template <typename T>
+struct LogSigmoidFunctor<ComplexType<T>>
+    : public BaseActivationFunctor<ComplexType<T>> {
+  template <typename Device, typename X, typename Out>
+  void operator()(Device d, X x, Out out) const {
+    // For complex numbers, use the direct formula: log(1 / (1 + exp(-x)))
+    // This is mathematically correct for complex numbers
+    ComplexType<T> one = static_cast<ComplexType<T>>(1);
+    out.device(d) = (one / (one + (-x).exp())).log();
+  }
+};
+
 // Originally: f' = exp(-x) / (1 + exp(-x))
 // For numerical stability: f' = exp(-x - max(-x, 0)) / (exp(-max(-x, 0)) +
 // exp(-x - max(-x, 0)))
@@ -2475,11 +2488,11 @@ struct LogSigmoidGradFunctor<ComplexType<T>>
             typename dOut,
             typename dX>
   void operator()(Device d, X x, Out out UNUSED, dOut dout, dX dx) const {
-    auto temp =
-        (-x).cwiseMax(static_cast<ComplexType<T>>(0));  // temp = max(-x, 0)
+    // For complex numbers, use the direct formula: d/dx log(1/(1+exp(-x))) =
+    // exp(-x)/(1+exp(-x))
+    ComplexType<T> one = static_cast<ComplexType<T>>(1);
     dx.device(d) =
-        dout * ((-x - temp).exp() / ((-temp).exp() + (-x - temp).exp()))
-                   .unaryExpr(Conj<T>());
+        dout * ((-x).exp() / (one + (-x).exp())).unaryExpr(Conj<T>());
   }
 
   static constexpr ActBwdOpFwdDeps FwdDeps() { return ActBwdOpFwdDeps::kDepX; }
@@ -5121,6 +5134,20 @@ struct CudaLogSigmoidFunctor : public BaseActivationFunctor<T> {
   }
 };
 
+// Specialized CUDA implementation for complex numbers
+template <typename T>
+struct CudaLogSigmoidFunctor<ComplexType<T>>
+    : public BaseActivationFunctor<ComplexType<T>> {
+  ComplexType<T> one = static_cast<ComplexType<T>>(1.0f);
+
+  // For complex numbers, use the direct formula: log(1 / (1 + exp(-x)))
+  __device__ __forceinline__ ComplexType<T> operator()(
+      const ComplexType<T> arg_x) const {
+    ComplexType<T> x = static_cast<ComplexType<T>>(arg_x);
+    return log(one / (one + exp(-x)));
+  }
+};
+
 template <typename T>
 struct CudaLogSigmoidGradFunctor : public BaseActivationFunctor<T> {
   using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
@@ -5152,26 +5179,15 @@ struct CudaLogSigmoidGradFunctor : public BaseActivationFunctor<T> {
 template <typename T>
 struct CudaLogSigmoidGradFunctor<ComplexType<T>>
     : public BaseActivationFunctor<ComplexType<T>> {
-  ComplexType<T> zero = static_cast<ComplexType<T>>(0.0f);
   ComplexType<T> one = static_cast<ComplexType<T>>(1.0f);
 
-  // dx = dout * exp(-x) / (1 + exp(-x))
-  // Use stable backward:
-  // grad = dout * (max_deriv - sign * (z / (1 + z)))
-  // where z = exp(-abs(x)), max_deriv = (x < 0) ? 1 : 0, sign = (x < 0) ? 1 :
-  // -1
+  // For complex numbers, use the direct formula: d/dx log(1/(1+exp(-x))) =
+  // exp(-x)/(1+exp(-x))
   __device__ __forceinline__ ComplexType<T> operator()(
       const ComplexType<T> arg_dout, const ComplexType<T> arg_x) const {
     ComplexType<T> dout = static_cast<ComplexType<T>>(arg_dout);
     ComplexType<T> x = static_cast<ComplexType<T>>(arg_x);
-
-    // in_negative, max_deriv, sign
-    const bool in_negative = (x < zero);
-    const ComplexType<T> max_deriv = in_negative ? one : zero;
-    const ComplexType<T> sign = in_negative ? one : -one;
-
-    ComplexType<T> z = exp(-abs(x));
-    return static_cast<T>(dout * conj(max_deriv - sign * (z / (one + z))));
+    return dout * conj(exp(-x) / (one + exp(-x)));
   }
 
   static constexpr ActBwdOpFwdDeps FwdDeps() { return ActBwdOpFwdDeps::kDepX; }


### PR DESCRIPTION
### PR Category

Operator Mechanism

### PR Types

Bug fixes

### Description

**Fix incorrect complex-number implementation of `LogSigmoid` operator**

This PR fixes a critical issue introduced by https://github.com/PaddlePaddle/Paddle/commit/37f7dbe00a3b2dbbc6634cd7842a2b06f9883a6d, where the complex-number branch of the logsigmoid operator reused the **real-valued stable formula** involving abs(x), x < 0, and sign(x). These operations are not mathematically valid for complex inputs (no total ordering on ℂ), which caused:

* **Forward output:** imaginary parts being truncated to zero.
* **Backward gradient:** incorrect conjugation and real-only derivatives.

This PR introduces a mathematically correct complex implementation consistent with the analytic definition:

```
logσ(x) = -log(1 + exp(-x))
d/dx logσ(x) = exp(-x) / (1 + exp(-x))
```

---

**中文说明：**

本 PR 修复了在 commit https://github.com/PaddlePaddle/Paddle/commit/37f7dbe00a3b2dbbc6634cd7842a2b06f9883a6d 中引入的 `LogSigmoid` 算子复数实现错误。
原实现错误地复用了实数稳定计算公式（如 `abs(x)`、`x < 0`、`sign(x)`），但这些操作在复数域上无数学定义，导致：

* 前向输出虚部被截断为 0；
* 反向梯度未对整体雅可比取共轭，仅保留实部。

本 PR 重新实现了符合复数解析定义的版本：

```
logσ(x) = -log(1 + exp(-x))
d/dx logσ(x) = exp(-x) / (1 + exp(-x))
```

复数分支采用解析表达式替代原实数稳定路径，前后向计算均移除无效比较与取模逻辑，并在反向中对完整雅可比取共轭以确保梯度正确。

---

### Changes

* **Forward (CPU & CUDA):** use analytic expression `-log(1 + exp(-x))` for `ComplexType`.
* **Backward (CPU & CUDA):** implement gradient as `exp(-x) / (1 + exp(-x))` and apply `conj()` to the full local Jacobian.
* **Removed:** invalid comparisons (`x < 0`), `abs(x)`, `sign(x)` from complex branch.
* **Constants:** unify complex constant construction to avoid precision narrowing.
* **Comments:** added notes explaining why real-number stability tricks are invalid for complex inputs.

**中文说明：**

* **前向（CPU & CUDA）**：复数类型采用解析表达式 `-log(1 + exp(-x))`，取代实数稳定路径。
* **反向（CPU & CUDA）**：使用梯度公式 `exp(-x) / (1 + exp(-x))`，并对完整雅可比矩阵取共轭。
* **删除**：复数分支中不合法的比较与取模操作（`x < 0`、`abs(x)`、`sign(x)`）。
* **常量**：统一 `ComplexType` 常量构造方式，避免精度截断。
* **注释**：新增说明，解释为何实数稳定技巧不适用于复数输入。

@luotao1 
