### PR TITLE
[CUDAGraph] Remove CUDAGraph replay after capture and use the same device context in CUDA Graph

### DIFF
--- a/paddle/fluid/framework/new_executor/instruction/cuda_graph_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/cuda_graph_instruction.cc
@@ -232,8 +232,6 @@ void CudaGraphInstruction::Run() {
     cuda_graph_ = platform::EndCUDAGraphCapture();
     VLOG(4) << "Finish capturing cuda graph @" << cuda_graph_.get();
 
-    // compute the right result
-    cuda_graph_->Replay();
   } else {
     VLOG(4) << "Run interpreter without cuda graph";
     interpreter_->Run({}, false);

--- a/paddle/fluid/framework/new_executor/instruction/instruction_util.cc
+++ b/paddle/fluid/framework/new_executor/instruction/instruction_util.cc
@@ -161,7 +161,7 @@ phi::DeviceContext* ParseDeviceContext(pir::Operation* op,
               ->GetDevContext());
       return dev_ctx;
     }
-
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
     // If the current OP is inside a CUDAGraphOp,
     // we must use the same device context as the parent CUDAGraphOp,
     // mainly to ensure that cuda_graph_allocator_ is not nullptr.
@@ -175,6 +175,7 @@ phi::DeviceContext* ParseDeviceContext(pir::Operation* op,
               "origin_dev_ctx->cuda_graph_allocator_ is nullptr."));
       return origin_dev_ctx;
     }
+#endif
     // handle comm op
     if (op_attributes.count("ring_id") != 0) {
       int ring_id =

--- a/paddle/fluid/framework/new_executor/instruction/instruction_util.cc
+++ b/paddle/fluid/framework/new_executor/instruction/instruction_util.cc
@@ -168,11 +168,6 @@ phi::DeviceContext* ParseDeviceContext(pir::Operation* op,
     // This is necessary for correct CUDA Graph capture and memory allocation.
     if (op->GetParentOp()->isa<paddle::dialect::CudaGraphOp>()) {
       VLOG(4) << "CudaGraphOp detected, using original device context";
-      PADDLE_ENFORCE_EQ(
-          origin_dev_ctx->IsCUDAGraphAllocatorValid(),
-          true,
-          ::common::errors::Fatal(
-              "origin_dev_ctx->cuda_graph_allocator_ is nullptr."));
       return origin_dev_ctx;
     }
 #endif

--- a/paddle/fluid/framework/new_executor/instruction/instruction_util.cc
+++ b/paddle/fluid/framework/new_executor/instruction/instruction_util.cc
@@ -162,9 +162,17 @@ phi::DeviceContext* ParseDeviceContext(pir::Operation* op,
       return dev_ctx;
     }
 
-    // for cudagraph op
+    // If the current OP is inside a CUDAGraphOp,
+    // we must use the same device context as the parent CUDAGraphOp,
+    // mainly to ensure that cuda_graph_allocator_ is not nullptr.
+    // This is necessary for correct CUDA Graph capture and memory allocation.
     if (op->GetParentOp()->isa<paddle::dialect::CudaGraphOp>()) {
       VLOG(4) << "CudaGraphOp detected, using original device context";
+      PADDLE_ENFORCE_EQ(
+          origin_dev_ctx->IsCUDAGraphAllocatorValid(),
+          true,
+          ::common::errors::Fatal(
+              "origin_dev_ctx->cuda_graph_allocator_ is nullptr."));
       return origin_dev_ctx;
     }
     // handle comm op

--- a/paddle/fluid/framework/new_executor/instruction/instruction_util.cc
+++ b/paddle/fluid/framework/new_executor/instruction/instruction_util.cc
@@ -162,6 +162,11 @@ phi::DeviceContext* ParseDeviceContext(pir::Operation* op,
       return dev_ctx;
     }
 
+    // for cudagraph op
+    if (op->GetParentOp()->isa<paddle::dialect::CudaGraphOp>()) {
+      VLOG(4) << "CudaGraphOp detected, using original device context";
+      return origin_dev_ctx;
+    }
     // handle comm op
     if (op_attributes.count("ring_id") != 0) {
       int ring_id =


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
<!-- Pcard-92901 -->
支持 `FastDeploy` SOT + CUDAGraph + 开启子图切分推理：https://github.com/PaddlePaddle/FastDeploy/pull/4386

- 移除 Capture 过程中的 Replay 以避免 CUDA700 错误
- 另外，当使用 CUDAGraph 时，ParseDeviceContext 在转换 DeviceContext 的过程中会丢失 cuda_graph_allocator_。现修改为，如果检测到CUDAGraph Op的子Op，则直接返回原始的DeviceContext