### PR TITLE
[Precision Depth Alignment] implement torch compatible max_pool2d grad kernel

### DIFF
--- a/paddle/common/flags.cc
+++ b/paddle/common/flags.cc
@@ -2250,13 +2250,13 @@ PHI_DEFINE_EXPORTED_bool(
     "Whether force Stride_Compute_Kernel output contiguous.");
 
 /**
- * Stride_Compute_Kernel related FLAG
- * Name: FLAGS_torch_compatible_pool_grad
- * Since Version: 3.2.1
+ * Torch Compatible related FLAG
+ * Name: FLAGS_torch_compatible_kernel_implementation
+ * Since Version: 3.2.2
  * Value Range: bool, default=false
  * Example:
- * Note: Whether use torch compatible version pool grad.
+ * Note: Whether use torch compatible version kernel.
  */
-PHI_DEFINE_EXPORTED_bool(torch_compatible_pool_grad,
+PHI_DEFINE_EXPORTED_bool(torch_compatible_kernel_implementation,
                          false,
-                         "Whether use torch compatible version pool grad.");
+                         "Whether use torch compatible version kernel.");

--- a/paddle/common/flags.cc
+++ b/paddle/common/flags.cc
@@ -2251,12 +2251,12 @@ PHI_DEFINE_EXPORTED_bool(
 
 /**
  * Torch Compatible related FLAG
- * Name: FLAGS_torch_compatible_kernel_implementation
+ * Name: FLAGS_torch_compatible_kernel
  * Since Version: 3.2.2
  * Value Range: bool, default=false
  * Example:
  * Note: Whether use torch compatible version kernel.
  */
-PHI_DEFINE_EXPORTED_bool(torch_compatible_kernel_implementation,
+PHI_DEFINE_EXPORTED_bool(torch_compatible_kernel,
                          false,
                          "Whether use torch compatible version kernel.");

--- a/paddle/common/flags.cc
+++ b/paddle/common/flags.cc
@@ -2248,3 +2248,15 @@ PHI_DEFINE_EXPORTED_bool(
     force_stride_compute_contig_out,
     false,
     "Whether force Stride_Compute_Kernel output contiguous.");
+
+/**
+ * Stride_Compute_Kernel related FLAG
+ * Name: FLAGS_torch_compatible_pool_grad
+ * Since Version: 3.2.1
+ * Value Range: bool, default=false
+ * Example:
+ * Note: Whether use torch compatible version pool grad.
+ */
+PHI_DEFINE_EXPORTED_bool(torch_compatible_pool_grad,
+                         false,
+                         "Whether use torch compatible version pool grad.");

--- a/paddle/phi/kernels/funcs/pooling.cu
+++ b/paddle/phi/kernels/funcs/pooling.cu
@@ -31,7 +31,7 @@ limitations under the License. */
 #include "paddle/phi/kernels/funcs/random.cuh"
 #include "paddle/phi/kernels/funcs/reduce_function.h"
 
-COMMON_DECLARE_bool(torch_compatible_kernel_implementation);
+COMMON_DECLARE_bool(torch_compatible_kernel);
 
 namespace phi {
 namespace funcs {
@@ -988,7 +988,7 @@ class MaxPool2dGradFunctor<phi::GPUContext, T> {
         output.numel() <= std::numeric_limits<int>::max()) {
       auto pool_divmods = FastDivModForPooling<int>(
           input_channels, output_width, output_height);
-      if (FLAGS_torch_compatible_kernel_implementation) {
+      if (FLAGS_torch_compatible_kernel) {
         int64_t blocks =
             (input_width * input_height + kBlockThreads - 1) / kBlockThreads;
         dim3 grid(blocks, batch_size, input_channels);
@@ -1042,7 +1042,7 @@ class MaxPool2dGradFunctor<phi::GPUContext, T> {
     } else {
       auto pool_divmods = FastDivModForPooling<int64_t>(
           input_channels, output_width, output_height);
-      if (FLAGS_torch_compatible_kernel_implementation) {
+      if (FLAGS_torch_compatible_kernel) {
         int64_t blocks =
             (input_width * input_height + kBlockThreads - 1) / kBlockThreads;
         dim3 grid(blocks, batch_size, input_channels);

--- a/paddle/phi/kernels/funcs/pooling.cu
+++ b/paddle/phi/kernels/funcs/pooling.cu
@@ -22,6 +22,7 @@ limitations under the License. */
 #include <hiprand_kernel.h>
 #endif
 
+#include "paddle/common/flags.h"
 #include "paddle/phi/backends/gpu/gpu_launch_config.h"
 #include "paddle/phi/backends/gpu/gpu_primitives.h"
 #include "paddle/phi/kernels/funcs/distribution_helper.h"
@@ -29,6 +30,8 @@ limitations under the License. */
 #include "paddle/phi/kernels/funcs/pooling.h"
 #include "paddle/phi/kernels/funcs/random.cuh"
 #include "paddle/phi/kernels/funcs/reduce_function.h"
+
+COMMON_DECLARE_bool(torch_compatible_pool_grad);
 
 namespace phi {
 namespace funcs {
@@ -91,6 +94,20 @@ struct FastDivModForPoolingWithMoreStaff {
         stride_w(stride_width),
         stride_h(stride_height) {}
 };
+
+static __device__ inline int p_start(int size,
+                                     int pad,
+                                     int kernel,
+                                     int stride) {
+  return (size + pad < kernel) ? 0 : (size + pad - kernel) / stride + 1;
+}
+
+static __device__ inline int p_end(int size,
+                                   int pad,
+                                   int pooled_size,
+                                   int stride) {
+  return std::min((size + pad) / stride + 1, pooled_size);
+}
 
 template <typename FastDivModForPooling, typename IndexT>
 __device__ void OffsetPreparationFor4Dimension(IndexT index,
@@ -470,6 +487,59 @@ __global__ void KernelMaxPool2DGrad(const IndexT nthreads,
     if (maxIndex != -1) {
       // atomic add
       phi::CudaAtomicAdd(input_grad + maxIndex, output_grad[index]);
+    }
+  }
+}
+
+template <typename T, typename IndexT>
+__global__ void KernelMaxPool2DGradCompatible(
+    const T* input_data,
+    const T* output_data,
+    const T* output_grad,
+    const IndexT batch_size,
+    const IndexT channels,
+    const IndexT input_height,
+    const IndexT input_width,
+    const IndexT output_height,
+    const IndexT output_width,
+    const IndexT ksize_height,
+    const IndexT ksize_width,
+    const IndexT stride_height,
+    const IndexT stride_width,
+    const IndexT padding_height,
+    const IndexT padding_width,
+    T* input_grad,
+    FastDivModForPooling<IndexT> divmods,
+    bool channel_last = false) {
+  using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
+
+  const IndexT start_index =
+      static_cast<IndexT>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const IndexT step = static_cast<IndexT>(blockDim.x) * gridDim.x;
+  CUDA_KERNEL_LOOP(index, input_height * input_width) {
+    IndexT h = index / input_width;
+    IndexT w = index - h * input_width;
+    IndexT phstart = p_start(h, padding_height, ksize_height, stride_height);
+    IndexT phend = p_end(h, padding_height, output_height, stride_height);
+    IndexT pwstart = p_start(w, padding_width, ksize_width, stride_width);
+    IndexT pwend = p_end(w, padding_width, output_width, stride_width);
+    T input_data_value = input_data[h * input_width + w];
+    for (IndexT n = blockIdx.y; n < batch_size; n += gridDim.y) {
+      for (IndexT c = blockIdx.z; c < channels; c += gridDim.z) {
+        MPType gradient = static_cast<MPType>(0.0f);
+        IndexT offset = (n * channels + c) * output_height * output_width;
+        for (int ph = phstart; ph < phend; ++ph) {
+          for (int pw = pwstart; pw < pwend; ++pw) {
+            T output_data_value = output_data[ph * output_width + pw + offset];
+            if (output_data_value == input_data_value) {
+              gradient += static_cast<MPType>(
+                  output_grad[ph * output_width + pw + offset]);
+            }
+          }
+        }
+        input_grad[(n * channels + c) * input_height * input_width + index] =
+            static_cast<MPType>(gradient);
+      }
     }
   }
 }
@@ -913,55 +983,106 @@ class MaxPool2dGradFunctor<phi::GPUContext, T> {
 
     int64_t nthreads =
         batch_size * output_channels * output_height * output_width;
-    int64_t blocks = (nthreads + 1024 - 1) / 1024;
     dim3 threads(1024, 1);
-    dim3 grid(blocks, 1);
 
     if (input.numel() <= std::numeric_limits<int>::max() &&
         output.numel() <= std::numeric_limits<int>::max()) {
       auto pool_divmods = FastDivModForPooling<int>(
           input_channels, output_width, output_height);
-      KernelMaxPool2DGrad<T, int>
-          <<<grid, threads, 0, dev_ctx.stream()>>>(nthreads,
-                                                   input_data,
-                                                   output_data,
-                                                   output_grad_data,
-                                                   input_channels,
-                                                   input_height,
-                                                   input_width,
-                                                   output_height,
-                                                   output_width,
-                                                   ksize_height,
-                                                   ksize_width,
-                                                   stride_height,
-                                                   stride_width,
-                                                   padding_height,
-                                                   padding_width,
-                                                   input_grad_data,
-                                                   pool_divmods,
-                                                   channel_last);
+      if (FLAGS_torch_compatible_pool_grad) {
+        int64_t blocks = (input_width * input_height + 1024 - 1) / 1024;
+        dim3 grid(blocks, batch_size, input_channels);
+        KernelMaxPool2DGradCompatible<T, int>
+            <<<grid, threads, 0, dev_ctx.stream()>>>(input_data,
+                                                     output_data,
+                                                     output_grad_data,
+                                                     batch_size,
+                                                     input_channels,
+                                                     input_height,
+                                                     input_width,
+                                                     output_height,
+                                                     output_width,
+                                                     ksize_height,
+                                                     ksize_width,
+                                                     stride_height,
+                                                     stride_width,
+                                                     padding_height,
+                                                     padding_width,
+                                                     input_grad_data,
+                                                     pool_divmods,
+                                                     channel_last);
+      } else {
+        int64_t blocks = (nthreads + 1024 - 1) / 1024;
+        dim3 grid(blocks, 1);
+        KernelMaxPool2DGrad<T, int>
+            <<<grid, threads, 0, dev_ctx.stream()>>>(nthreads,
+                                                     input_data,
+                                                     output_data,
+                                                     output_grad_data,
+                                                     input_channels,
+                                                     input_height,
+                                                     input_width,
+                                                     output_height,
+                                                     output_width,
+                                                     ksize_height,
+                                                     ksize_width,
+                                                     stride_height,
+                                                     stride_width,
+                                                     padding_height,
+                                                     padding_width,
+                                                     input_grad_data,
+                                                     pool_divmods,
+                                                     channel_last);
+      }
+
     } else {
       auto pool_divmods = FastDivModForPooling<int64_t>(
           input_channels, output_width, output_height);
-      KernelMaxPool2DGrad<T, int64_t>
-          <<<grid, threads, 0, dev_ctx.stream()>>>(nthreads,
-                                                   input_data,
-                                                   output_data,
-                                                   output_grad_data,
-                                                   input_channels,
-                                                   input_height,
-                                                   input_width,
-                                                   output_height,
-                                                   output_width,
-                                                   ksize_height,
-                                                   ksize_width,
-                                                   stride_height,
-                                                   stride_width,
-                                                   padding_height,
-                                                   padding_width,
-                                                   input_grad_data,
-                                                   pool_divmods,
-                                                   channel_last);
+      if (FLAGS_torch_compatible_pool_grad) {
+        int64_t blocks = (input_width * input_height + 1024 - 1) / 1024;
+        dim3 grid(blocks, batch_size, input_channels);
+        KernelMaxPool2DGradCompatible<T, int64_t>
+            <<<grid, threads, 0, dev_ctx.stream()>>>(input_data,
+                                                     output_data,
+                                                     output_grad_data,
+                                                     batch_size,
+                                                     input_channels,
+                                                     input_height,
+                                                     input_width,
+                                                     output_height,
+                                                     output_width,
+                                                     ksize_height,
+                                                     ksize_width,
+                                                     stride_height,
+                                                     stride_width,
+                                                     padding_height,
+                                                     padding_width,
+                                                     input_grad_data,
+                                                     pool_divmods,
+                                                     channel_last);
+      } else {
+        int64_t blocks = (nthreads + 1024 - 1) / 1024;
+        dim3 grid(blocks, 1);
+        KernelMaxPool2DGrad<T, int64_t>
+            <<<grid, threads, 0, dev_ctx.stream()>>>(nthreads,
+                                                     input_data,
+                                                     output_data,
+                                                     output_grad_data,
+                                                     input_channels,
+                                                     input_height,
+                                                     input_width,
+                                                     output_height,
+                                                     output_width,
+                                                     ksize_height,
+                                                     ksize_width,
+                                                     stride_height,
+                                                     stride_width,
+                                                     padding_height,
+                                                     padding_width,
+                                                     input_grad_data,
+                                                     pool_divmods,
+                                                     channel_last);
+      }
     }
   }
 };

--- a/paddle/phi/kernels/funcs/pooling.cu
+++ b/paddle/phi/kernels/funcs/pooling.cu
@@ -31,7 +31,7 @@ limitations under the License. */
 #include "paddle/phi/kernels/funcs/random.cuh"
 #include "paddle/phi/kernels/funcs/reduce_function.h"
 
-COMMON_DECLARE_bool(torch_compatible_pool_grad);
+COMMON_DECLARE_bool(torch_compatible_kernel_implementation);
 
 namespace phi {
 namespace funcs {
@@ -513,9 +513,6 @@ __global__ void KernelMaxPool2DGradCompatible(
     bool channel_last = false) {
   using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
 
-  const IndexT start_index =
-      static_cast<IndexT>(blockIdx.x) * blockDim.x + threadIdx.x;
-  const IndexT step = static_cast<IndexT>(blockDim.x) * gridDim.x;
   CUDA_KERNEL_LOOP(index, input_height * input_width) {
     IndexT h = index / input_width;
     IndexT w = index - h * input_width;
@@ -949,6 +946,8 @@ class MaxPool2dGradFunctor<phi::GPUContext, T> {
                   const std::vector<int64_t>& paddings,
                   const std::string data_format,
                   DenseTensor* input_grad) {
+    static const int kBlockThreads = 1024;
+
     bool channel_last = (data_format == "NHWC");
 
     const int64_t batch_size = input.dims()[0];
@@ -983,15 +982,18 @@ class MaxPool2dGradFunctor<phi::GPUContext, T> {
 
     int64_t nthreads =
         batch_size * output_channels * output_height * output_width;
-    dim3 threads(1024, 1);
+    dim3 threads(kBlockThreads, 1);
 
     if (input.numel() <= std::numeric_limits<int>::max() &&
         output.numel() <= std::numeric_limits<int>::max()) {
       auto pool_divmods = FastDivModForPooling<int>(
           input_channels, output_width, output_height);
-      if (FLAGS_torch_compatible_pool_grad) {
-        int64_t blocks = (input_width * input_height + 1024 - 1) / 1024;
+      if (FLAGS_torch_compatible_kernel_implementation) {
+        int64_t blocks =
+            (input_width * input_height + kBlockThreads - 1) / kBlockThreads;
         dim3 grid(blocks, batch_size, input_channels);
+        // NOTE: input.numel() <= std::numeric_limits<int>::max() &&
+        // output.numel() <= std::numeric_limits<int>::max()
         KernelMaxPool2DGradCompatible<T, int>
             <<<grid, threads, 0, dev_ctx.stream()>>>(input_data,
                                                      output_data,
@@ -1012,8 +1014,10 @@ class MaxPool2dGradFunctor<phi::GPUContext, T> {
                                                      pool_divmods,
                                                      channel_last);
       } else {
-        int64_t blocks = (nthreads + 1024 - 1) / 1024;
+        int64_t blocks = (nthreads + kBlockThreads - 1) / kBlockThreads;
         dim3 grid(blocks, 1);
+        // NOTE: input.numel() <= std::numeric_limits<int>::max() &&
+        // output.numel() <= std::numeric_limits<int>::max()
         KernelMaxPool2DGrad<T, int>
             <<<grid, threads, 0, dev_ctx.stream()>>>(nthreads,
                                                      input_data,
@@ -1038,8 +1042,9 @@ class MaxPool2dGradFunctor<phi::GPUContext, T> {
     } else {
       auto pool_divmods = FastDivModForPooling<int64_t>(
           input_channels, output_width, output_height);
-      if (FLAGS_torch_compatible_pool_grad) {
-        int64_t blocks = (input_width * input_height + 1024 - 1) / 1024;
+      if (FLAGS_torch_compatible_kernel_implementation) {
+        int64_t blocks =
+            (input_width * input_height + kBlockThreads - 1) / kBlockThreads;
         dim3 grid(blocks, batch_size, input_channels);
         KernelMaxPool2DGradCompatible<T, int64_t>
             <<<grid, threads, 0, dev_ctx.stream()>>>(input_data,
@@ -1061,7 +1066,7 @@ class MaxPool2dGradFunctor<phi::GPUContext, T> {
                                                      pool_divmods,
                                                      channel_last);
       } else {
-        int64_t blocks = (nthreads + 1024 - 1) / 1024;
+        int64_t blocks = (nthreads + kBlockThreads - 1) / kBlockThreads;
         dim3 grid(blocks, 1);
         KernelMaxPool2DGrad<T, int64_t>
             <<<grid, threads, 0, dev_ctx.stream()>>>(nthreads,

--- a/test/legacy_test/test_pool2d_api.py
+++ b/test/legacy_test/test_pool2d_api.py
@@ -770,7 +770,7 @@ class TestPool2D_API(unittest.TestCase):
         paddle.disable_static()
 
     def test_torch_compatible(self):
-        paddle.set_flags({'FLAGS_torch_compatible_pool_grad': 1})
+        paddle.set_flags({'FLAGS_torch_compatible_kernel_implementation': 1})
         paddle.enable_static()
         for place in self.places:
             self.check_max_static_results(place)

--- a/test/legacy_test/test_pool2d_api.py
+++ b/test/legacy_test/test_pool2d_api.py
@@ -770,7 +770,7 @@ class TestPool2D_API(unittest.TestCase):
         paddle.disable_static()
 
     def test_torch_compatible(self):
-        paddle.set_flags({'FLAGS_torch_compatible_kernel_implementation': 1})
+        paddle.set_flags({'FLAGS_torch_compatible_kernel': 1})
         paddle.enable_static()
         for place in self.places:
             self.check_max_static_results(place)

--- a/test/legacy_test/test_pool2d_api.py
+++ b/test/legacy_test/test_pool2d_api.py
@@ -769,6 +769,13 @@ class TestPool2D_API(unittest.TestCase):
             self.check_lp_float16_static(place)
         paddle.disable_static()
 
+    def test_torch_compatible(self):
+        paddle.set_flags({'FLAGS_torch_compatible_pool_grad': 1})
+        paddle.enable_static()
+        for place in self.places:
+            self.check_max_static_results(place)
+        paddle.disable_static()
+
     def test_pool2d(self):
         for place in self.places:
             self.check_max_dygraph_results(place)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->

#### 受影响的 API：
- `paddle.nn.functional.max_pool2d ` 对齐全部case（共 2034 个）

#### 修改内容
- 由于paddle现有实现具有明显的性能优势，所以添加了 FLAGS_torch_compatible_pool_grad，用于开启和关闭兼容 torch 模式。
- 实现了一套新的兼容 torch 模式的 kernel，主要区别如下：
  - 对于 f32 精度以下的数据进行精度提升。
  - 从遍历输出维度改成了遍历输入维度。
- 添加了额外的单测。

Pcard-67164