### PR TITLE
[Storage]Add destructor for MmapStorage

### DIFF
--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -1216,6 +1216,16 @@ struct MmapStorage {
     }
 #endif
   }
+  ~MmapStorage() {
+    if (base_ptr_) {
+#if defined(_WIN32)
+      UnmapViewOfFile(base_ptr_);
+#else
+      munmap(base_ptr_, size);
+#endif
+      base_ptr_ = nullptr;
+    }
+  }
   void *base_ptr_;
   int64_t size;
 };
@@ -1782,12 +1792,11 @@ PYBIND11_MODULE(libpaddle, m) {
   py::class_<MmapStorage>(m, "MmapStorage")  // class attr: base_ptr_, size_
       .def(py::init<const std::string &, int64_t>())  // filename_, nbytes
       .def("get_slice",
-           [](py::object self_obj,
+           [](MmapStorage &self,
               proto::VarType::Type dtype,
               int64_t start,
               int64_t stop,
               int64_t step) {
-             MmapStorage &self = self_obj.cast<MmapStorage &>();
              if (stop < 0) {
                stop = start + 1;  // default: get the start element.
              }
@@ -1799,16 +1808,11 @@ PYBIND11_MODULE(libpaddle, m) {
                  PySlice_AdjustIndices(size_py, &start_py, &stop_py, step_py);
              auto data = static_cast<uint8_t *>(self.base_ptr_) + start;
              auto dtype_phi = phi::TransToPhiDataType(dtype);
-             return from_blob(
-                 data,
-                 phi::IntArray({slicelength}),
-                 dtype_phi,
-                 phi::DataLayout::NCHW,
-                 phi::CPUPlace(),
-                 [self_obj = std::move(self_obj)](void *ptr) mutable {
-                   pybind11::gil_scoped_acquire gil;
-                   self_obj.dec_ref();
-                 });
+             return from_blob(data,
+                              phi::IntArray({slicelength}),
+                              dtype_phi,
+                              phi::DataLayout::NCHW,
+                              phi::CPUPlace());
            });
   m.def(
       "frombuffer",

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -1782,11 +1782,12 @@ PYBIND11_MODULE(libpaddle, m) {
   py::class_<MmapStorage>(m, "MmapStorage")  // class attr: base_ptr_, size_
       .def(py::init<const std::string &, int64_t>())  // filename_, nbytes
       .def("get_slice",
-           [](MmapStorage &self,
+           [](py::object self_obj,
               proto::VarType::Type dtype,
               int64_t start,
               int64_t stop,
               int64_t step) {
+             MmapStorage &self = self_obj.cast<MmapStorage &>();
              if (stop < 0) {
                stop = start + 1;  // default: get the start element.
              }
@@ -1798,11 +1799,16 @@ PYBIND11_MODULE(libpaddle, m) {
                  PySlice_AdjustIndices(size_py, &start_py, &stop_py, step_py);
              auto data = static_cast<uint8_t *>(self.base_ptr_) + start;
              auto dtype_phi = phi::TransToPhiDataType(dtype);
-             return from_blob(data,
-                              phi::IntArray({slicelength}),
-                              dtype_phi,
-                              phi::DataLayout::NCHW,
-                              phi::CPUPlace());
+             return from_blob(
+                 data,
+                 phi::IntArray({slicelength}),
+                 dtype_phi,
+                 phi::DataLayout::NCHW,
+                 phi::CPUPlace(),
+                 [self_obj = std::move(self_obj)](void *ptr) mutable {
+                   pybind11::gil_scoped_acquire gil;
+                   self_obj.dec_ref();
+                 });
            });
   m.def(
       "frombuffer",

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -1218,7 +1218,7 @@ struct MmapStorage {
   }
   ~MmapStorage() {
     if (base_ptr_) {
-#if defined(_WIN32)
+#if defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN6)
       UnmapViewOfFile(base_ptr_);
 #else
       munmap(base_ptr_, size);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
pcard-67164
Add destructor for MmapStorage：
之前的MmapStorage实现未声明析构函数，导致使用safetensors的safe_open接口时无法释放内存。
现增加析构函数，本地测试内存可以正常释放。