### PR TITLE
[Precision Depth Alignment] Change the pad_value parameter of pad3d from float to double

### DIFF
--- a/paddle/fluid/inference/tensorrt/pir/generic_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/pir/generic_plugin.cu
@@ -14,6 +14,7 @@
 
 #include <map>
 
+#include "paddle/ap/include/paddle/pir/attribute.h"
 #include "paddle/common/macros.h"
 #include "paddle/fluid/inference/tensorrt/pir/dynamic_shape_infermeta_factory.h"
 #include "paddle/fluid/inference/tensorrt/pir/dynamic_shape_infermeta_registry.h"
@@ -30,6 +31,7 @@
 #include "paddle/phi/common/place.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/device_context.h"
+#include "paddle/phi/core/framework/framework.pb.h"
 #include "paddle/phi/core/kernel_context.h"
 #include "paddle/phi/core/memory/memcpy.h"
 #include "paddle/phi/kernels/funcs/data_type_transform.h"

--- a/paddle/fluid/inference/tensorrt/pir/generic_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/pir/generic_plugin.cu
@@ -704,8 +704,14 @@ int GenericPlugin::enqueue(const nvinfer1::PluginTensorDesc* input_desc,
       phi_kernel_contexts_[data_type]->EmplaceBackAttr(
           attrs_map_[t].dyn_cast<::pir::FloatAttribute>().data());
     } else if (attr_type_name == "pir::DoubleAttribute") {
-      phi_kernel_contexts_[data_type]->EmplaceBackAttr(
-          attrs_map_[t].dyn_cast<::pir::DoubleAttribute>().data());
+      if (AttrTypeID(attrs_map_[t]) == framework::proto::AttrType::FLOAT) {
+        const auto val = attrs_map_[t].dyn_cast<::pir::FloatAttribute>().data();
+        phi_kernel_contexts_[data_type]->EmplaceBackAttr(
+            static_cast<double>(val));
+      } else {
+        phi_kernel_contexts_[data_type]->EmplaceBackAttr(
+            attrs_map_[t].dyn_cast<::pir::DoubleAttribute>().data());
+      }
     } else if (attr_type_name == "pir::BoolAttribute") {
       phi_kernel_contexts_[data_type]->EmplaceBackAttr(
           attrs_map_[t].dyn_cast<::pir::BoolAttribute>().data());

--- a/paddle/fluid/inference/tensorrt/pir/generic_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/pir/generic_plugin.cu
@@ -14,7 +14,6 @@
 
 #include <map>
 
-#include "paddle/ap/include/paddle/pir/attribute.h"
 #include "paddle/common/macros.h"
 #include "paddle/fluid/inference/tensorrt/pir/dynamic_shape_infermeta_factory.h"
 #include "paddle/fluid/inference/tensorrt/pir/dynamic_shape_infermeta_registry.h"
@@ -31,7 +30,6 @@
 #include "paddle/phi/common/place.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/device_context.h"
-#include "paddle/phi/core/framework/framework.pb.h"
 #include "paddle/phi/core/kernel_context.h"
 #include "paddle/phi/core/memory/memcpy.h"
 #include "paddle/phi/kernels/funcs/data_type_transform.h"
@@ -706,7 +704,7 @@ int GenericPlugin::enqueue(const nvinfer1::PluginTensorDesc* input_desc,
       phi_kernel_contexts_[data_type]->EmplaceBackAttr(
           attrs_map_[t].dyn_cast<::pir::FloatAttribute>().data());
     } else if (attr_type_name == "pir::DoubleAttribute") {
-      if (AttrTypeID(attrs_map_[t]) == framework::proto::AttrType::FLOAT) {
+      if (attrs_map_[t].type_id() == ::pir::FloatAttribute::type_id()) {
         const auto val = attrs_map_[t].dyn_cast<::pir::FloatAttribute>().data();
         phi_kernel_contexts_[data_type]->EmplaceBackAttr(
             static_cast<double>(val));

--- a/paddle/fluid/ir_adaptor/translator/op_translator.cc
+++ b/paddle/fluid/ir_adaptor/translator/op_translator.cc
@@ -4031,6 +4031,43 @@ struct LogitOpTranscriber : public OpTranscriber {
   }
 };
 
+struct Pad3dOpTranscriber : public OpTranscriber {
+  pir::AttributeMap TranslateOpAttribute(
+      pir::IrContext* ctx,
+      const std::string& normalized_op_name,
+      const OpAttributeInfoList& op_attr_infos,
+      const OpDesc& op_desc) override {
+    auto& attribute_translator = AttributeTranslator::instance();
+    auto& op_normalizer = OpNameNormalizer::instance();
+    pir::AttributeMap attribute_map = {};
+
+    for (const auto& info : op_attr_infos) {
+      auto legacy_attr_name =
+          op_normalizer.GetLegacyAttrName(op_desc.Type(), info.name);
+      VLOG(10) << "[op: " << op_desc.Type()
+               << "][attr] from: " << legacy_attr_name << " to: " << info.name;
+      if (op_desc.HasAttr(legacy_attr_name)) {
+        paddle::framework::Attribute legacy_attr =
+            op_desc.GetAttr(legacy_attr_name);
+        VLOG(10) << "attribute in " << op_desc.Type()
+                 << " name: " << legacy_attr_name << " " << legacy_attr.index();
+        pir::Attribute new_attr =
+            attribute_translator(info.type_name, legacy_attr);
+        if (legacy_attr_name == "pad_value") {
+          new_attr = pir::DoubleAttribute::get(
+              ctx,
+              static_cast<double>(
+                  new_attr.dyn_cast<pir::FloatAttribute>().data()));
+        }
+        attribute_map[info.name] = new_attr;
+      } else {
+        this->HandleNonexistentAttribute(ctx, &attribute_map, info);
+      }
+    }
+    return attribute_map;
+  }
+};
+
 OpTranslator::OpTranslator() {
   pir::IrContext* ctx = pir::IrContext::Instance();
   ctx->GetOrRegisterDialect<paddle::dialect::OperatorDialect>();
@@ -4149,5 +4186,7 @@ OpTranslator::OpTranslator() {
   special_handlers["softplus_grad"] = SoftPlusOpTranscriber();
   special_handlers["logit"] = LogitOpTranscriber();
   special_handlers["logit_grad"] = LogitOpTranscriber();
+  special_handlers["pad3d"] = Pad3dOpTranscriber();
+  special_handlers["pad3d_grad"] = Pad3dOpTranscriber();
 }
 }  // namespace paddle::translator

--- a/paddle/fluid/ir_adaptor/translator/op_translator.cc
+++ b/paddle/fluid/ir_adaptor/translator/op_translator.cc
@@ -4053,7 +4053,7 @@ struct Pad3dOpTranscriber : public OpTranscriber {
                  << " name: " << legacy_attr_name << " " << legacy_attr.index();
         pir::Attribute new_attr =
             attribute_translator(info.type_name, legacy_attr);
-        if (legacy_attr_name == "pad_value") {
+        if (info.name == "pad_value") {
           new_attr = pir::DoubleAttribute::get(
               ctx,
               static_cast<double>(

--- a/paddle/fluid/pir/serialize_deserialize/patch/0.yaml
+++ b/paddle/fluid/pir/serialize_deserialize/patch/0.yaml
@@ -31,3 +31,8 @@ op_patches:
       - action : modify_attr
         object : eps
         type : pir::DoubleAttribute
+  - op_name : pd_op.pad3d
+    actions:
+      - action : modify_attr
+        object : pad_value
+        type : pir::DoubleAttribute

--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -3428,7 +3428,7 @@ void PadInferMeta(const MetaTensor& input,
 void Pad3dInferMeta(const MetaTensor& x,
                     const IntArray& paddings_int_array,
                     const std::string& mode,
-                    float value,
+                    double value,
                     const std::string& data_format,
                     MetaTensor* out,
                     MetaConfig config) {

--- a/paddle/phi/infermeta/unary.h
+++ b/paddle/phi/infermeta/unary.h
@@ -559,7 +559,7 @@ PADDLE_API void PadInferMeta(const MetaTensor& input,
 PADDLE_API void Pad3dInferMeta(const MetaTensor& x,
                                const IntArray& paddings,
                                const std::string& mode,
-                               float value,
+                               double value,
                                const std::string& data_format,
                                MetaTensor* out,
                                MetaConfig config = MetaConfig());

--- a/paddle/phi/kernels/cpu/pad3d_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/pad3d_grad_kernel.cc
@@ -364,7 +364,7 @@ void Pad3dGradKernel(const Context& dev_ctx,
                      const DenseTensor& out_grad,
                      const IntArray& paddings,
                      const std::string& mode,
-                     float pad_value UNUSED,
+                     double pad_value UNUSED,
                      const std::string& data_format,
                      DenseTensor* x_grad) {
   std::vector<int64_t> pads = paddings.GetData();

--- a/paddle/phi/kernels/cpu/pad3d_kernel.cc
+++ b/paddle/phi/kernels/cpu/pad3d_kernel.cc
@@ -381,7 +381,7 @@ void Pad3dKernel(const Context& dev_ctx,
                  const DenseTensor& x,
                  const IntArray& paddings,
                  const std::string& mode,
-                 float pad_value,
+                 double pad_value,
                  const std::string& data_format,
                  DenseTensor* out) {
   T value = static_cast<T>(pad_value);

--- a/paddle/phi/kernels/gpu/pad3d_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/pad3d_grad_kernel.cu
@@ -343,7 +343,7 @@ void Pad3dGradKernel(const Context& dev_ctx,
                      const DenseTensor& out_grad,
                      const IntArray& paddings,
                      const std::string& mode,
-                     float pad_value,
+                     double pad_value,
                      const std::string& data_format,
                      DenseTensor* x_grad) {
   std::vector<int64_t> pads = paddings.GetData();

--- a/paddle/phi/kernels/gpu/pad3d_kernel.cu
+++ b/paddle/phi/kernels/gpu/pad3d_kernel.cu
@@ -333,7 +333,7 @@ void Pad3dKernel(const Context& dev_ctx,
                  const DenseTensor& x,
                  const IntArray& paddings,
                  const std::string& mode,
-                 float pad_value,
+                 double pad_value,
                  const std::string& data_format,
                  DenseTensor* out) {
   std::vector<int64_t> pads = paddings.GetData();

--- a/paddle/phi/kernels/onednn/pad3d_kernel.cc
+++ b/paddle/phi/kernels/onednn/pad3d_kernel.cc
@@ -52,7 +52,7 @@ void Pad3dKernel(const Context& dev_ctx,
                  const DenseTensor& x,
                  const IntArray& paddings,
                  const std::string& mode UNUSED,
-                 float pad_value,
+                 double pad_value,
                  const std::string& data_format UNUSED,
                  DenseTensor* out) {
   PadOpKernel<T, Context>(dev_ctx, x, paddings.GetData(), pad_value, out);

--- a/paddle/phi/kernels/onednn/pad_kernel_impl.h
+++ b/paddle/phi/kernels/onednn/pad_kernel_impl.h
@@ -107,7 +107,7 @@ template <typename T, typename Context>
 void PadOpKernel(const Context& dev_ctx,
                  const DenseTensor& x,
                  const std::vector<int64_t>& paddings,
-                 float pad_value,
+                 double pad_value,
                  DenseTensor* out) {
   const auto& onednn_engine = dev_ctx.GetEngine();
   auto& astream = OneDNNContext::tls().get_stream();

--- a/paddle/phi/kernels/pad3d_grad_kernel.h
+++ b/paddle/phi/kernels/pad3d_grad_kernel.h
@@ -25,7 +25,7 @@ void Pad3dGradKernel(const Context& dev_ctx,
                      const DenseTensor& out_grad,
                      const IntArray& paddings,
                      const std::string& mode,
-                     float pad_value,
+                     double pad_value,
                      const std::string& data_format,
                      DenseTensor* x_grad);
 

--- a/paddle/phi/kernels/pad3d_kernel.h
+++ b/paddle/phi/kernels/pad3d_kernel.h
@@ -24,7 +24,7 @@ void Pad3dKernel(const Context& dev_ctx,
                  const DenseTensor& x,
                  const IntArray& paddings,
                  const std::string& mode,
-                 float pad_value,
+                 double pad_value,
                  const std::string& data_format,
                  DenseTensor* out);
 

--- a/paddle/phi/kernels/xpu/pad3d_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/pad3d_grad_kernel.cc
@@ -26,7 +26,7 @@ void Pad3dGradKernel(const Context& dev_ctx,
                      const DenseTensor& out_grad,
                      const IntArray& paddings,
                      const std::string& mode,
-                     float pad_value,
+                     double pad_value,
                      const std::string& data_format,
                      DenseTensor* x_grad) {
   T value = static_cast<T>(pad_value);

--- a/paddle/phi/kernels/xpu/pad3d_kernel.cc
+++ b/paddle/phi/kernels/xpu/pad3d_kernel.cc
@@ -26,7 +26,7 @@ void Pad3dKernel(const Context& dev_ctx,
                  const DenseTensor& x,
                  const IntArray& paddings,
                  const std::string& mode,
-                 float pad_value,
+                 double pad_value,
                  const std::string& data_format,
                  DenseTensor* out) {
   std::vector<int64_t> pads = paddings.GetData();

--- a/paddle/phi/ops/yaml/backward.yaml
+++ b/paddle/phi/ops/yaml/backward.yaml
@@ -2584,8 +2584,8 @@
   composite: p_norm_grad(x, out, out_grad, porder, axis, epsilon, keepdim, asvector, x_grad)
 
 - backward_op : pad3d_double_grad
-  forward : pad3d_grad(Tensor x, Tensor grad_out, IntArray paddings, str mode="constant", float pad_value=0.0, str data_format="NCDHW") -> Tensor(grad_x)
-  args : (Tensor grad_x_grad, IntArray paddings, str mode, float pad_value, str data_format)
+  forward : pad3d_grad(Tensor x, Tensor grad_out, IntArray paddings, str mode="constant", double pad_value=0.0, str data_format="NCDHW") -> Tensor(grad_x)
+  args : (Tensor grad_x_grad, IntArray paddings, str mode, double pad_value, str data_format)
   output : Tensor(grad_out_grad)
   infer_meta :
     func : Pad3dInferMeta
@@ -2593,8 +2593,8 @@
     func : pad3d
 
 - backward_op : pad3d_grad
-  forward : pad3d(Tensor x, IntArray paddings, str mode="constant", float pad_value=0.0, str data_format="NCDHW") -> Tensor(out)
-  args : (Tensor x, Tensor out_grad, IntArray paddings, str mode, float pad_value, str data_format)
+  forward : pad3d(Tensor x, IntArray paddings, str mode="constant", double pad_value=0.0, str data_format="NCDHW") -> Tensor(out)
+  args : (Tensor x, Tensor out_grad, IntArray paddings, str mode, double pad_value, str data_format)
   output : Tensor(x_grad)
   infer_meta :
     func : UnchangedInferMeta

--- a/paddle/phi/ops/yaml/legacy/backward_exclude.yaml
+++ b/paddle/phi/ops/yaml/legacy/backward_exclude.yaml
@@ -65,3 +65,5 @@
 - unpool_grad
 - unsqueeze_grad
 - logit_grad
+- pad3d_grad
+- pad3d_double_grad

--- a/paddle/phi/ops/yaml/legacy/ops_exclude.yaml
+++ b/paddle/phi/ops/yaml/legacy/ops_exclude.yaml
@@ -100,3 +100,4 @@
 - zeros
 - zeros_like
 - logit
+- pad3d

--- a/paddle/phi/ops/yaml/legacy/static_backward.yaml
+++ b/paddle/phi/ops/yaml/legacy/static_backward.yaml
@@ -404,8 +404,8 @@
     func : norm_grad
 
 - backward_op : pad3d_double_grad
-  forward : pad3d_grad(Tensor x, Tensor grad_out, IntArray paddings, str mode="constant", double pad_value=0.0, str data_format="NCDHW") -> Tensor(grad_x)
-  args : (Tensor grad_x_grad, IntArray paddings, str mode, double pad_value, str data_format)
+  forward : pad3d_grad(Tensor x, Tensor grad_out, IntArray paddings, str mode="constant", float pad_value=0.0, str data_format="NCDHW") -> Tensor(grad_x)
+  args : (Tensor grad_x_grad, IntArray paddings, str mode, float pad_value, str data_format)
   output : Tensor(grad_out_grad)
   infer_meta :
     func : Pad3dInferMeta
@@ -413,8 +413,8 @@
     func : pad3d
 
 - backward_op : pad3d_grad
-  forward : pad3d(Tensor x, IntArray paddings, str mode="constant", double pad_value=0.0, str data_format="NCDHW") -> Tensor(out)
-  args : (Tensor x, Tensor out_grad, IntArray paddings, str mode, double pad_value, str data_format)
+  forward : pad3d(Tensor x, IntArray paddings, str mode="constant", float pad_value=0.0, str data_format="NCDHW") -> Tensor(out)
+  args : (Tensor x, Tensor out_grad, IntArray paddings, str mode, float pad_value, str data_format)
   output : Tensor(x_grad)
   infer_meta :
     func : UnchangedInferMeta

--- a/paddle/phi/ops/yaml/legacy/static_backward.yaml
+++ b/paddle/phi/ops/yaml/legacy/static_backward.yaml
@@ -403,6 +403,27 @@
   kernel :
     func : norm_grad
 
+- backward_op : pad3d_double_grad
+  forward : pad3d_grad(Tensor x, Tensor grad_out, IntArray paddings, str mode="constant", double pad_value=0.0, str data_format="NCDHW") -> Tensor(grad_x)
+  args : (Tensor grad_x_grad, IntArray paddings, str mode, double pad_value, str data_format)
+  output : Tensor(grad_out_grad)
+  infer_meta :
+    func : Pad3dInferMeta
+  kernel :
+    func : pad3d
+
+- backward_op : pad3d_grad
+  forward : pad3d(Tensor x, IntArray paddings, str mode="constant", double pad_value=0.0, str data_format="NCDHW") -> Tensor(out)
+  args : (Tensor x, Tensor out_grad, IntArray paddings, str mode, double pad_value, str data_format)
+  output : Tensor(x_grad)
+  infer_meta :
+    func : UnchangedInferMeta
+    param: [x]
+  kernel :
+    func : pad3d_grad
+  no_need_buffer : x
+  backward : pad3d_double_grad
+
 - backward_op : pool2d_double_grad
   forward : pool2d_grad(Tensor x, Tensor out, Tensor grad_out, IntArray kernel_size, int[] strides, int[] paddings, bool ceil_mode, bool exclusive, str data_format, str pooling_type, bool global_pooling, bool adaptive, str padding_algorithm) -> Tensor(grad_x)
   args : (Tensor grad_x_grad, IntArray kernel_size, int[] strides, int[] paddings, bool ceil_mode, bool exclusive, str data_format, str pooling_type, bool global_pooling, bool adaptive, str padding_algorithm)

--- a/paddle/phi/ops/yaml/legacy/static_ops.yaml
+++ b/paddle/phi/ops/yaml/legacy/static_ops.yaml
@@ -725,7 +725,7 @@
   traits : paddle::dialect::ForwardOnlyTrait
 
 - op : pad3d
-  args : (Tensor x, IntArray paddings, str mode = "constant", double pad_value = 0.0, str data_format = "NCDHW")
+  args : (Tensor x, IntArray paddings, str mode = "constant", float pad_value = 0.0, str data_format = "NCDHW")
   output : Tensor(out)
   infer_meta :
     func : Pad3dInferMeta

--- a/paddle/phi/ops/yaml/legacy/static_ops.yaml
+++ b/paddle/phi/ops/yaml/legacy/static_ops.yaml
@@ -724,6 +724,16 @@
     data_type : x
   traits : paddle::dialect::ForwardOnlyTrait
 
+- op : pad3d
+  args : (Tensor x, IntArray paddings, str mode = "constant", double pad_value = 0.0, str data_format = "NCDHW")
+  output : Tensor(out)
+  infer_meta :
+    func : Pad3dInferMeta
+  kernel :
+    func : pad3d
+  backward : pad3d_grad
+  interfaces : paddle::dialect::InferSymbolicShapeInterface
+
 - op : pool2d
   args : (Tensor x, IntArray kernel_size, int[] strides = {1,1}, int[] paddings = {0,0}, bool ceil_mode = false, bool exclusive = true, str data_format = "NCHW", str pooling_type = "", bool global_pooling = false, bool adaptive = false, str padding_algorithm = "EXPLICIT", bool use_cudnn = false)
   output : Tensor(out)

--- a/paddle/phi/ops/yaml/ops.yaml
+++ b/paddle/phi/ops/yaml/ops.yaml
@@ -4110,7 +4110,7 @@
   interfaces : paddle::dialect::InferSymbolicShapeInterface
 
 - op : pad3d
-  args : (Tensor x, IntArray paddings, str mode = "constant", float pad_value = 0.0, str data_format = "NCDHW")
+  args : (Tensor x, IntArray paddings, str mode = "constant", double pad_value = 0.0, str data_format = "NCDHW")
   output : Tensor(out)
   infer_meta :
     func : Pad3dInferMeta


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->
**修改描述：**
将pad3d的pad_value参数的数据类型从float改为double,使得精度可以与torch对齐。

**测试结果：**
pad 前向：
1. paddle.nn.functional.pad  对齐全部 case（1852个）
2. paddle.compat.pad  对齐全部case （1828个）

**pad反向：由于实现逻辑中存在CudaAtomicAdd（原子加）操作，从而计算结果会出现随机性，torch实现同样存在该问题。**

pcard-93269