### PR TITLE
Reopen "Disable NVIDIA_TF32_OVERRIDE by default for better precision."

### DIFF
--- a/python/paddle/base/__init__.py
+++ b/python/paddle/base/__init__.py
@@ -164,6 +164,9 @@ def __bootstrap__():
 
     os.environ['OMP_NUM_THREADS'] = str(num_threads)
 
+    if os.getenv('NVIDIA_TF32_OVERRIDE', None) is None:
+        os.environ['NVIDIA_TF32_OVERRIDE'] = '0'
+
     if os.getenv('MKL_NUM_THREADS', None) is None:
         os.environ['MKL_NUM_THREADS'] = str(int(0.8 * os.cpu_count()))
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
Reopen "Disable NVIDIA_TF32_OVERRIDE by default for better precision."
pcard-91067