### PR TITLE
[DLPack] Implement dtype and device exchange protocol

### DIFF
--- a/paddle/fluid/pybind/place.cc
+++ b/paddle/fluid/pybind/place.cc
@@ -34,6 +34,7 @@ limitations under the License. */
 #include "paddle/fluid/framework/data_layout.h"
 #include "paddle/fluid/framework/data_type_transform.h"
 #include "paddle/fluid/framework/dense_tensor_array.h"
+#include "paddle/fluid/framework/dlpack_tensor.h"
 #include "paddle/fluid/framework/executor.h"
 #include "paddle/fluid/framework/executor_cache.h"
 #include "paddle/fluid/framework/executor_gc_helper.h"
@@ -267,6 +268,12 @@ void BindPlace(pybind11::module &m) {  // NOLINT
       .def("set_place",
            [](phi::Place &self, const phi::CustomPlace &plug_place) {
              self = plug_place;
+           })
+      .def("__dlpack_device__",
+           [](const phi::Place &self) {
+             ::DLDevice dl_device = paddle::framework::PlaceToDLDevice(self);
+             return py::make_tuple(static_cast<int32_t>(dl_device.device_type),
+                                   dl_device.device_id);
            })
       .def("__repr__", string::to_string<const phi::Place &>)
       .def("__str__", string::to_string<const phi::Place &>);

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -4199,7 +4199,12 @@ All parameter, weight, gradient are variables in Paddle.
       .value("FLOAT8_E5M2", phi::DataType::FLOAT8_E5M2)
       .value("PSTRING", phi::DataType::PSTRING)
       .value("ALL_DTYPE", phi::DataType::ALL_DTYPE)
-      .export_values();
+      .export_values()
+      .def("__dlpack_data_type__", [](const phi::DataType &self) {
+        ::DLDataType dl_dtype =
+            paddle::framework::PhiDataTypeToDLDataType(self);
+        return py::make_tuple(dl_dtype.code, dl_dtype.bits, dl_dtype.lanes);
+      });
 
   py::class_<paddle::platform::EngineParams> engine_params(m,
                                                            "TRTEngineParams");

--- a/python/paddle/device/__init__.py
+++ b/python/paddle/device/__init__.py
@@ -1939,6 +1939,19 @@ class Device(str):
     def index(self):
         return self._index
 
+    def _to_place(self) -> core.Place:
+        if self.type == "cpu":
+            return core.CPUPlace()
+        elif self.type in {"gpu", "cuda"}:
+            return core.CUDAPlace(self.index)
+        elif self.type == "xpu":
+            return core.XPUPlace(self.index)
+        else:
+            raise ValueError(f"Unsupported device type: {self.type}")
+
+    def __dlpack_device__(self) -> tuple[int, int]:
+        return self._to_place().__dlpack_device__()
+
     def __enter__(self):
         current_device = paddle.get_device()
         Device._DEFAULT_DEVICE_STACK.append(current_device)

--- a/python/unittest_py/requirements.txt
+++ b/python/unittest_py/requirements.txt
@@ -20,4 +20,4 @@ xdoctest==1.3.0
 ubelt==1.3.3 # just for xdoctest
 mypy==1.17.1
 soundfile
-apache-tvm-ffi==0.1.0b20
+apache-tvm-ffi==0.1.0

--- a/test/legacy_test/test_tvm_ffi.py
+++ b/test/legacy_test/test_tvm_ffi.py
@@ -188,15 +188,16 @@ class TestDLPackDeviceType(unittest.TestCase):
             (DLDeviceType.kDLCPU.value, 0),
         )
 
-        self.assertEqual(
-            paddle.CUDAPlace(0).__dlpack_device__(),
-            (DLDeviceType.kDLCUDA.value, 0),
-        )
+        if paddle.is_compiled_with_cuda():
+            self.assertEqual(
+                paddle.CUDAPlace(0).__dlpack_device__(),
+                (DLDeviceType.kDLCUDA.value, 0),
+            )
 
-        self.assertEqual(
-            paddle.CUDAPinnedPlace().__dlpack_device__(),
-            (DLDeviceType.kDLCUDAHost.value, 0),
-        )
+            self.assertEqual(
+                paddle.CUDAPinnedPlace().__dlpack_device__(),
+                (DLDeviceType.kDLCUDAHost.value, 0),
+            )
 
     def test_dlpack_device_type_base_protocol_from_device(self):
         self.assertEqual(
@@ -204,15 +205,16 @@ class TestDLPackDeviceType(unittest.TestCase):
             (DLDeviceType.kDLCPU.value, 0),
         )
 
-        self.assertEqual(
-            paddle.device('cuda:0').__dlpack_device__(),
-            (DLDeviceType.kDLCUDA.value, 0),
-        )
+        if paddle.is_compiled_with_cuda():
+            self.assertEqual(
+                paddle.device('cuda:0').__dlpack_device__(),
+                (DLDeviceType.kDLCUDA.value, 0),
+            )
 
-        self.assertEqual(
-            paddle.device('gpu:0').__dlpack_device__(),
-            (DLDeviceType.kDLCUDA.value, 0),
-        )
+            self.assertEqual(
+                paddle.device('gpu:0').__dlpack_device__(),
+                (DLDeviceType.kDLCUDA.value, 0),
+            )
 
     # TODO(SigureMo): add e2e test case pass a paddle.base.core.Place to TVM FFI Function
     # in tvm_ffi next release

--- a/test/legacy_test/test_tvm_ffi.py
+++ b/test/legacy_test/test_tvm_ffi.py
@@ -214,7 +214,7 @@ class TestDLPackDeviceType(unittest.TestCase):
             (DLDeviceType.kDLCUDA.value, 0),
         )
 
-    # TODO(SigureMo): add e2e test case pass a paddle.dtype to TVM FFI Function
+    # TODO(SigureMo): add e2e test case pass a paddle.base.core.Place to TVM FFI Function
     # in tvm_ffi next release
 
 

--- a/test/legacy_test/test_tvm_ffi.py
+++ b/test/legacy_test/test_tvm_ffi.py
@@ -22,6 +22,7 @@ import numpy as np
 import tvm_ffi.cpp
 
 import paddle
+from paddle.utils.dlpack import DLDeviceType
 
 if TYPE_CHECKING:
     from tvm_ffi import Module
@@ -145,6 +146,76 @@ class TestCDLPackExchangeAPI(unittest.TestCase):
         x = paddle.full((3,), 1.0, dtype='float32').cpu()
         y = mod.add_one_cpu(x)
         np.testing.assert_allclose(y.numpy(), [2.0, 2.0, 2.0])
+
+
+class TestDLPackDataType(unittest.TestCase):
+    @staticmethod
+    def _paddle_dtype_to_tvm_ffi_dtype(paddle_dtype: paddle.dtype):
+        dtype_str = str(paddle_dtype).split('.')[-1]
+        return tvm_ffi.dtype(dtype_str)
+
+    def test_dlpack_data_type_base_protocol(self):
+        for dtype in [
+            paddle.uint8,
+            paddle.int16,
+            paddle.int32,
+            paddle.int64,
+            paddle.float32,
+            paddle.float64,
+            paddle.float16,
+            paddle.bfloat16,
+        ]:
+            tvm_ffi_dtype = TestDLPackDataType._paddle_dtype_to_tvm_ffi_dtype(
+                dtype
+            )
+            self.assertEqual(
+                dtype.__dlpack_data_type__(),
+                (
+                    tvm_ffi_dtype.type_code,
+                    tvm_ffi_dtype.bits,
+                    tvm_ffi_dtype.lanes,
+                ),
+            )
+
+    # TODO(SigureMo): add e2e test case pass a paddle.dtype to TVM FFI Function
+    # in tvm_ffi next release
+
+
+class TestDLPackDeviceType(unittest.TestCase):
+    def test_dlpack_device_type_base_protocol_from_place(self):
+        self.assertEqual(
+            paddle.CPUPlace().__dlpack_device__(),
+            (DLDeviceType.kDLCPU.value, 0),
+        )
+
+        self.assertEqual(
+            paddle.CUDAPlace(0).__dlpack_device__(),
+            (DLDeviceType.kDLCUDA.value, 0),
+        )
+
+        self.assertEqual(
+            paddle.CUDAPinnedPlace().__dlpack_device__(),
+            (DLDeviceType.kDLCUDAHost.value, 0),
+        )
+
+    def test_dlpack_device_type_base_protocol_from_device(self):
+        self.assertEqual(
+            paddle.device('cpu').__dlpack_device__(),
+            (DLDeviceType.kDLCPU.value, 0),
+        )
+
+        self.assertEqual(
+            paddle.device('cuda:0').__dlpack_device__(),
+            (DLDeviceType.kDLCUDA.value, 0),
+        )
+
+        self.assertEqual(
+            paddle.device('gpu:0').__dlpack_device__(),
+            (DLDeviceType.kDLCUDA.value, 0),
+        )
+
+    # TODO(SigureMo): add e2e test case pass a paddle.dtype to TVM FFI Function
+    # in tvm_ffi next release
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

New features

### Description
<!-- Describe what you’ve done -->

Implement `__dlpack_data_type__` and `__dlpack_device__` protocol to support dtype and device exchange via TVM FFI.

This protocol was proposed in data-apis/array-api#972 and is currently in the RFC stage. It has been implemented in TVM FFI in apache/tvm-ffi#178 and apache/tvm-ffi#179 (not included in the latest release v0.1.0). Although the protocol has not been finalized, enabling downstream projects to start using it early is beneficial.

<!-- PCard-66972 -->