### PR TITLE
[CppExtension] Support `os.PathLike` in `CppExtension`/`CUDAExtension` and expose `IS_WINDOWS` to `paddle.utils.cpp_extension`

### DIFF
--- a/python/paddle/utils/cpp_extension/__init__.py
+++ b/python/paddle/utils/cpp_extension/__init__.py
@@ -14,6 +14,7 @@
 
 from .cpp_extension import (
     CUDA_HOME,  # noqa: F401
+    IS_WINDOWS,  # noqa: F401
     BuildExtension,  # noqa: F401
     CppExtension,
     CUDAExtension,

--- a/python/paddle/utils/cpp_extension/cpp_extension.py
+++ b/python/paddle/utils/cpp_extension/cpp_extension.py
@@ -176,9 +176,9 @@ def setup(**attr: Any) -> None:
         ext_modules(Extension): Specify the Extension instance including customized operator source files, compiling flags et.al.
                                 If only compile operator supporting CPU device, please use ``CppExtension`` ; If compile operator
                                 supporting CPU and GPU devices, please use ``CUDAExtension`` .
-        include_dirs(list[str], optional): Specify the extra include directories to search head files. The interface will automatically
-                                add ``site-package/paddle/include``. Please add the corresponding directory path if including third-party
-                                head files. Default is None.
+        include_dirs(list[str], optional): Specify the extra include directories to search head files. The interface will automatically add
+                                 ``site-package/paddle/include`` . Please add the corresponding directory path if including third-party
+                                 head files. Default is None.
         extra_compile_args(list[str] | dict, optional): Specify the extra compiling flags such as ``-O3`` . If set ``list[str]`` , all these flags
                                 will be applied for ``cc`` and ``nvcc`` compiler. It supports specify flags only applied ``cc`` or ``nvcc``
                                 compiler using dict type with ``{'cxx': [...], 'nvcc': [...]}`` . Default is None.

--- a/python/paddle/utils/cpp_extension/cpp_extension.py
+++ b/python/paddle/utils/cpp_extension/cpp_extension.py
@@ -176,9 +176,9 @@ def setup(**attr: Any) -> None:
         ext_modules(Extension): Specify the Extension instance including customized operator source files, compiling flags et.al.
                                 If only compile operator supporting CPU device, please use ``CppExtension`` ; If compile operator
                                 supporting CPU and GPU devices, please use ``CUDAExtension`` .
-        include_dirs(list[os.PathLike[str] | str], optional): Specify the extra include directories to search head files. The interface
-                                will automatically add ``site-package/paddle/include``. Please add the corresponding directory path if
-                                including third-party head files. Default is None.
+        include_dirs(list[str], optional): Specify the extra include directories to search head files. The interface will automatically
+                                add ``site-package/paddle/include``. Please add the corresponding directory path if including third-party
+                                head files. Default is None.
         extra_compile_args(list[str] | dict, optional): Specify the extra compiling flags such as ``-O3`` . If set ``list[str]`` , all these flags
                                 will be applied for ``cc`` and ``nvcc`` compiler. It supports specify flags only applied ``cc`` or ``nvcc``
                                 compiler using dict type with ``{'cxx': [...], 'nvcc': [...]}`` . Default is None.

--- a/python/paddle/utils/cpp_extension/cpp_extension.py
+++ b/python/paddle/utils/cpp_extension/cpp_extension.py
@@ -176,9 +176,9 @@ def setup(**attr: Any) -> None:
         ext_modules(Extension): Specify the Extension instance including customized operator source files, compiling flags et.al.
                                 If only compile operator supporting CPU device, please use ``CppExtension`` ; If compile operator
                                 supporting CPU and GPU devices, please use ``CUDAExtension`` .
-        include_dirs(list[str], optional): Specify the extra include directories to search head files. The interface will automatically add
-                                 ``site-package/paddle/include`` . Please add the corresponding directory path if including third-party
-                                 head files. Default is None.
+        include_dirs(list[os.PathLike[str] | str], optional): Specify the extra include directories to search head files. The interface
+                                will automatically add ``site-package/paddle/include``. Please add the corresponding directory path if
+                                including third-party head files. Default is None.
         extra_compile_args(list[str] | dict, optional): Specify the extra compiling flags such as ``-O3`` . If set ``list[str]`` , all these flags
                                 will be applied for ``cc`` and ``nvcc`` compiler. It supports specify flags only applied ``cc`` or ``nvcc``
                                 compiler using dict type with ``{'cxx': [...], 'nvcc': [...]}`` . Default is None.

--- a/python/paddle/utils/cpp_extension/extension_utils.py
+++ b/python/paddle/utils/cpp_extension/extension_utils.py
@@ -555,6 +555,7 @@ def normalize_extension_kwargs(kwargs, use_cuda=False):
 
     # append necessary include dir path of paddle
     include_dirs = list(kwargs.get('include_dirs', []))
+    include_dirs = [os.fsdecode(include_dir) for include_dir in include_dirs]
     include_dirs.extend(compile_include_dirs)
     include_dirs.extend(find_paddle_includes(use_cuda))
     include_dirs.extend(find_python_includes())
@@ -821,7 +822,9 @@ def find_rocm_includes():
     return [os.path.join(rocm_home, 'include')]
 
 
-def _get_all_paddle_includes_from_include_root(include_root: str) -> list[str]:
+def _get_all_paddle_includes_from_include_root(
+    include_root: os.PathLike[str] | str,
+) -> list[str]:
     """
     Get all paddle include directories from include root (packaged in wheel)
     """

--- a/test/cpp_extension/cpp_extension_setup.py
+++ b/test/cpp_extension/cpp_extension_setup.py
@@ -28,7 +28,7 @@ paddle_includes = []
 for site_packages_path in getsitepackages():
     paddle_include_dir = Path(site_packages_path) / "paddle/include"
     paddle_includes.extend(
-        _get_all_paddle_includes_from_include_root(str(paddle_include_dir))
+        _get_all_paddle_includes_from_include_root(paddle_include_dir)
     )
 
 # Add current dir, search custom_power.h

--- a/test/cpp_extension/mix_relu_and_extension_setup.py
+++ b/test/cpp_extension/mix_relu_and_extension_setup.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
+from pathlib import Path
 
 from utils import paddle_includes
 
@@ -24,7 +24,7 @@ setup(
         sources=["mix_relu_and_extension.cc"],
         include_dirs=[
             *paddle_includes,
-            os.path.dirname(os.path.abspath(__file__)),
+            Path(__file__).parent.resolve(),
         ],
         extra_compile_args={'cc': ['-w', '-g']},
         verbose=True,

--- a/test/custom_op/utils.py
+++ b/test/custom_op/utils.py
@@ -37,7 +37,7 @@ for site_packages_path in getsitepackages():
         _get_all_paddle_includes_from_include_root(str(paddle_include_dir))
     )
 
-    paddle_libraries.append(str(Path(site_packages_path) / 'paddle' / 'libs'))
+    paddle_libraries.append(Path(site_packages_path) / 'paddle' / 'libs')
 
 # Test for extra compile args
 extra_cc_args = ['-w', '-g'] if not IS_WINDOWS else ['/w']


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Improvements

### Description
<!-- Describe what you’ve done -->

- Support `os.PathLike`[^1] objects for C++ extension `CppExtension`/`CUDAExtension` `include_dirs`
- Expose `paddle.utils.cpp_extension.IS_WINDOWS`

[^1]: https://docs.python.org/3/library/os.html#os.PathLike

<!-- PCard-66972 -->