### PR TITLE
[API] Fix `shape=int` for `size_args_decorator`

### DIFF
--- a/python/paddle/utils/decorator_utils.py
+++ b/python/paddle/utils/decorator_utils.py
@@ -333,6 +333,9 @@ def size_args_decorator(
             kwargs['shape'] = list(args)
             args = ()
 
+        if 'shape' in kwargs and isinstance(kwargs['shape'], int):
+            kwargs['shape'] = [kwargs['shape']]
+
         return func(*args, **kwargs)
 
     wrapped_func.__signature__ = inspect.signature(func)

--- a/test/legacy_test/test_int_shape.py
+++ b/test/legacy_test/test_int_shape.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from utils import dygraph_guard
+
+import paddle
+
+
+class TestIntShape(unittest.TestCase):
+    def test_eager(self):
+        with dygraph_guard():
+            for shape in [
+                2,
+                0,
+                10,
+            ]:
+                for func in [paddle.rand]:
+                    x = func(shape=shape)
+                    self.assertEqual(x.shape, [shape])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-75624

This pull request improves the handling of integer values passed to the `shape` argument in PaddlePaddle utility functions, ensuring consistency and robustness. It also adds a dedicated unit test to verify the correct behavior when `shape` is provided as an integer.

**Enhancements to shape argument handling:**

* Updated the `wrapped_func` in `decorator_utils.py` to automatically convert an integer `shape` argument to a single-element list, ensuring downstream code always receives a list for `shape`.

**Testing improvements:**

* Added a new unit test `test_int_shape.py` to verify that functions like `paddle.rand` correctly handle integer `shape` arguments in eager (dynamic) mode, asserting that the resulting tensor shape matches expectations.