### PR TITLE
revert MKL_NUM_THREADS

### DIFF
--- a/python/paddle/base/__init__.py
+++ b/python/paddle/base/__init__.py
@@ -164,9 +164,6 @@ def __bootstrap__():
 
     os.environ['OMP_NUM_THREADS'] = str(num_threads)
 
-    if os.getenv('MKL_NUM_THREADS', None) is None:
-        os.environ['MKL_NUM_THREADS'] = str(int(0.8 * os.cpu_count()))
-
     flag_prefix = "FLAGS_"
     read_env_flags = [
         key[len(flag_prefix) :]


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes


### Description
<!-- Describe what you’ve done -->
revert https://github.com/PaddlePaddle/Paddle/pull/75880 , MKL_NUM_THREADS的设置
原因是PR导致EB流水线DataLoader崩溃，暂无时间分析原因，暂时Revert。

<img width="1804" height="850" alt="d5ca30d9-2b7b-4dc7-8654-ab3a7f345654" src="https://github.com/user-attachments/assets/d2e5137f-a598-444b-b6da-50b9ae9e4319" />


pcard-93348