### PR TITLE
fix to_tensor bug

### DIFF
--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -716,7 +716,24 @@ def _to_tensor_non_static(
         if np.isscalar(data) and not isinstance(data, str):
             data = np.array(data)
         elif isinstance(data, (list, tuple)):
-            data = np.array(data)
+            has_tensor = False
+            for d in data:
+                if isinstance(d, paddle.Tensor):
+                    has_tensor = True
+                    break
+            if has_tensor:
+                if (
+                    len(data) == 1
+                    and isinstance(data[0], paddle.Tensor)
+                    and data[0].dtype == paddle.bfloat16
+                ):
+                    data = np.array([data[0].numpy()])
+                else:
+                    data = np.array(data)
+                if not dtype:
+                    dtype = data.dtype
+            else:
+                data = np.array(data)
             if data.dtype == np.object_:
                 raise ValueError(
                     "\n\tFailed to convert input data to a regular ndarray :\n\t - Usually "

--- a/test/legacy_test/test_eager_tensor.py
+++ b/test/legacy_test/test_eager_tensor.py
@@ -2179,5 +2179,39 @@ class TestSetDynamicAttributeToEagerTensorInstance(unittest.TestCase):
         self.assertEqual(tensor_instance.__dict__["_custom_flag"], True)
 
 
+class TestListToTensor(unittest.TestCase):
+    def test_list_to_tensor_bfloat16(self):
+        a = [paddle.to_tensor(2, dtype=paddle.bfloat16)]
+        b = paddle.to_tensor(a)
+        self.assertEqual(b.dtype, paddle.bfloat16)
+        self.assertEqual(b[0], 2.0)
+
+    def test_list_to_tensor_float16(self):
+        a = [paddle.to_tensor(2, dtype=paddle.float16)]
+        b = paddle.to_tensor(a)
+        self.assertEqual(b.dtype, paddle.float16)
+        self.assertEqual(b[0], 2.0)
+
+    def test_list_to_tensor_bfloat16_float32(self):
+        a = [
+            paddle.to_tensor(2, dtype=paddle.bfloat16),
+            paddle.to_tensor(2, dtype=paddle.float32),
+        ]
+        b = paddle.to_tensor(a)
+        self.assertEqual(b.dtype, paddle.float32)
+        self.assertEqual(b[0], 2.0)
+        self.assertEqual(b[1], 2.0)
+
+    def test_list_to_tensor_float16_float32(self):
+        a = [
+            paddle.to_tensor(2, dtype=paddle.float16),
+            paddle.to_tensor(2, dtype=paddle.float32),
+        ]
+        b = paddle.to_tensor(a)
+        self.assertEqual(b.dtype, paddle.float32)
+        self.assertEqual(b[0], 2.0)
+        self.assertEqual(b[1], 2.0)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
to_tensor存在如下两个bug：

```
import paddle
import numpy as np
a = [paddle.to_tensor(2,dtype=paddle.bfloat16)]
print(a)
b = paddle.to_tensor(a)
print(b)

a = [paddle.to_tensor(2,dtype=paddle.float16)]
print(a)
b = paddle.to_tensor(a)
print(b)
```

```
[Tensor(shape=[], dtype=bfloat16, place=Place(gpu:0), stop_gradient=True,
       2.)]
Tensor(shape=[1], dtype=bfloat16, place=Place(gpu:0), stop_gradient=True,
       [0.00000000]) #数值错误
[Tensor(shape=[], dtype=float16, place=Place(gpu:0), stop_gradient=True,
       2.)]
Tensor(shape=[1], dtype=float32, place=Place(gpu:0), stop_gradient=True,  #dtype错误
       [2.])
```

- bfloat16问题分析：
首先，原则上bfloat16的Tensor是不应该转成numpy的，因为numpy没有bfloat16这个类型，因此早期开发者在转换成numpy时使用numpy.uint16替代。
bfloat16的bug的原因是当to_tensor的data是list of Tensor，dtype=bfloat16，数据值为2.0时，`data = np.array(data)`会将现将Tensor转成numpy.uint16类型的numpy对象数值为2。`a.numpy()`则会将Tensor转换成numpy.uint16类型的numpy对象数值为16384。我们期望的是后者。为什么呢？因为16384存储的正是bfloat16 Tensor真正的“内存布局”，而2是Tensor的值而非”内存布局”。使用值为2的uint16 numpy构造core.eager.Tensor时，会得到Tensor的值为0.00000，而使用值为16384的uint16 numpy构造core.eager.Tensor时，会得到Tensor的值为2.0。
还有另一种组合：
```
a = [paddle.to_tensor(2,dtype=paddle.float16), paddle.to_tensor(2,dtype=paddle.float32)]
print(a)
b = paddle.to_tensor(a)
print(b)
```
在以上case中，我们需要先把list of Tensor转换为float32的numpy，再构造core.eager.Tensor，此时，numpy的值需要存2.0而非16384。
因此，bfloat16的bug本质是Paddle的bfloat16与numpy转换处理不恰当导致的。

- float16问题分析：
float16的问题在于，由于_to_tensor_non_static传入的dtype为None，在代码中有一段逻辑会将None分配一个默认值float32，导致了后面构造了float32的Tensor。解决办法是：
```
            if not dtype:
                dtype = data.dtype
```