### PR TITLE
[API] Remove dtype check in static branch to allow pass bf16 data to `outer`

### DIFF
--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -2883,21 +2883,7 @@ def outer(
     else:
         ny = y.reshape((1, -1))
 
-    if in_dynamic_mode():
-        return _C_ops.multiply(nx, ny, out=out)
-
-    def __check_input(x, y):
-        var_names = {'x': x, 'y': y}
-        for name, val in var_names.items():
-            check_variable_and_dtype(
-                val,
-                name,
-                ['float16', 'float32', 'float64', 'int32', 'int64'],
-                'outer',
-            )
-
-    __check_input(nx, ny)
-    if in_pir_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.multiply(nx, ny, out=out)
     else:
         helper = LayerHelper('outer', **locals())

--- a/test/legacy_test/test_outer.py
+++ b/test/legacy_test/test_outer.py
@@ -307,13 +307,13 @@ class TestOuterAlias(unittest.TestCase):
             [2, 4, 8],
         ]
         dtype_cases = [
-            "float16",
-            "bfloat16",
             "float32",
             "float64",
             "int32",
             "int64",
         ]
+        if paddle.is_compiled_with_cuda():
+            dtype_cases.extend(["float16", "bfloat16"])
 
         for shape in shape_cases:
             for dtype in dtype_cases:

--- a/test/legacy_test/test_outer.py
+++ b/test/legacy_test/test_outer.py
@@ -15,7 +15,11 @@
 import unittest
 
 import numpy as np
-from op_test import get_device_place
+from op_test import (
+    convert_float_to_uint16,
+    convert_uint16_to_float,
+    get_device_place,
+)
 
 import paddle
 
@@ -161,16 +165,6 @@ class TestMultiplyApi(unittest.TestCase):
 
 
 class TestMultiplyError(unittest.TestCase):
-    def test_errors_static(self):
-        # test static computation graph: dtype can not be int8
-        paddle.enable_static()
-        with paddle.static.program_guard(
-            paddle.static.Program(), paddle.static.Program()
-        ):
-            x = paddle.static.data(name='x', shape=[100], dtype=np.int8)
-            y = paddle.static.data(name='y', shape=[100], dtype=np.int8)
-            self.assertRaises(TypeError, paddle.outer, x, y)
-
     def test_errors_dynamic(self):
         np.random.seed(7)
 
@@ -313,6 +307,8 @@ class TestOuterAlias(unittest.TestCase):
             [2, 4, 8],
         ]
         dtype_cases = [
+            "float16",
+            "bfloat16",
             "float32",
             "float64",
             "int32",
@@ -332,14 +328,22 @@ class TestOuterAlias(unittest.TestCase):
                     {"input": x, "vec2": y},
                 ]
 
+                x_numpy = x.numpy()
+                y_numpy = y.numpy()
+
                 # Get baseline result
-                expected = np.outer(x.numpy(), y.numpy())
+                if dtype == "bfloat16":
+                    x_numpy = convert_uint16_to_float(x_numpy)
+                    y_numpy = convert_uint16_to_float(y_numpy)
+                expected = np.outer(x_numpy, y_numpy)
+                if dtype == "bfloat16":
+                    expected = convert_float_to_uint16(expected)
+
+                rtol = 1e-5 if dtype != "bfloat16" else 1e-4
 
                 for params in combinations:
                     out = paddle.outer(**params)
-                    np.testing.assert_allclose(
-                        out.numpy(), expected, rtol=1e-05
-                    )
+                    np.testing.assert_allclose(out.numpy(), expected, rtol=rtol)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

移除 `paddle.outer` 静态图分支的 check dtype，避免传入 bf16 这种 multiply 明显支持的 dtype 报错

另外，现在写 bf16 的单测好麻烦，将来如果集成 [ml_dtypes](https://github.com/jax-ml/ml_dtypes) 应当可以彻底解决该问题

<!-- PCard-66972 -->