### PR TITLE
clean CUDA_ARCH_FP16_SUPPORTED - part

### DIFF
--- a/paddle/phi/kernels/funcs/math/bert_encoder_functor.cu
+++ b/paddle/phi/kernels/funcs/math/bert_encoder_functor.cu
@@ -31,7 +31,7 @@ template <typename T>
 __device__ __forceinline__ T local_rsqrt(T num) {
   return rsqrt(static_cast<float>(num));
 }
-#if CUDA_ARCH_FP16_SUPPORTED(__CUDA_ARCH__)
+#if defined(PADDLE_WITH_CUDA)
 __device__ __forceinline__ half local_rsqrt(half num) { return hrsqrt(num); }
 #endif
 
@@ -162,7 +162,7 @@ __global__ void SkipLayerNormSmallKernel<half, 32>(int num,
                                                    const half *scale,
                                                    const half *bias,
                                                    half eps) {
-#if CUDA_ARCH_FP16_SUPPORTED(__CUDA_ARCH__)
+#if defined(PADDLE_WITH_CUDA)
   const half rld = half(1) / half(hidden);
   const int offset = blockIdx.x * hidden;
   cub::Sum pair_sum;
@@ -189,7 +189,7 @@ __global__ void SkipLayerNormSmallKernel<half, 128>(int num,
                                                     const half *scale,
                                                     const half *bias,
                                                     half eps) {
-#if CUDA_ARCH_FP16_SUPPORTED(__CUDA_ARCH__)
+#if defined(PADDLE_WITH_CUDA)
   const half rld = half(1) / half(hidden);
   const int offset = blockIdx.x * hidden;
   cub::Sum pair_sum;
@@ -216,7 +216,7 @@ __global__ void SkipLayerNormSmallKernel<half, 384>(int num,
                                                     const half *scale,
                                                     const half *bias,
                                                     half eps) {
-#if CUDA_ARCH_FP16_SUPPORTED(__CUDA_ARCH__)
+#if defined(PADDLE_WITH_CUDA)
   const half rld = half(1) / half(hidden);
   const int offset = blockIdx.x * hidden;
   cub::Sum pair_sum;
@@ -271,7 +271,7 @@ __global__ void SkipLayerNormKernel<half, 256>(int num,
                                                const half *scale,
                                                const half *bias,
                                                half eps) {
-#if CUDA_ARCH_FP16_SUPPORTED(__CUDA_ARCH__)
+#if defined(PADDLE_WITH_CUDA)
   const half rld = half(1) / half(hidden);
   const int offset = blockIdx.x * hidden;
   cub::Sum pair_sum;
@@ -327,7 +327,7 @@ __global__ void SkipLayerNormKernel2<half, half2, 256>(int num,
                                                        const half2 *scale,
                                                        const half2 *bias,
                                                        float eps) {
-#if CUDA_ARCH_FP16_SUPPORTED(__CUDA_ARCH__)
+#if defined(PADDLE_WITH_CUDA)
   const half rld = half(0.5f / hidden);  // because hidden is hidden/2
   const int offset = blockIdx.x * hidden;
   cub::Sum pair_sum;

--- a/paddle/phi/kernels/funcs/skip_layernorm_functor.cu
+++ b/paddle/phi/kernels/funcs/skip_layernorm_functor.cu
@@ -21,7 +21,7 @@ template <typename T>
 __device__ __forceinline__ T local_rsqrt(T num) {
   return rsqrt(static_cast<float>(num));
 }
-#if CUDA_ARCH_FP16_SUPPORTED(__CUDA_ARCH__)
+#if defined(PADDLE_WITH_CUDA)
 __device__ __forceinline__ half local_rsqrt(half num) { return hrsqrt(num); }
 #endif
 
@@ -91,7 +91,7 @@ __global__ void SkipLayerNormKernel<half, 256>(int num,
                                                const half *scale,
                                                const half *bias,
                                                half eps) {
-#if CUDA_ARCH_FP16_SUPPORTED(__CUDA_ARCH__)
+#if defined(PADDLE_WITH_CUDA)
   const half rld = half(1) / half(hidden);
   const int offset = blockIdx.x * hidden;
   cub::Sum pair_sum;
@@ -179,7 +179,7 @@ __global__ void SkipLayerNormKernel2<half, half2, 256>(int num,
                                                        const half2 *scale,
                                                        const half2 *bias,
                                                        float eps) {
-#if CUDA_ARCH_FP16_SUPPORTED(__CUDA_ARCH__)
+#if defined(PADDLE_WITH_CUDA)
   const half rld = half(0.5f / hidden);  // because hidden is hidden/2
   const int offset = blockIdx.x * hidden;
   cub::Sum pair_sum;
@@ -265,7 +265,7 @@ __global__ void SkipLayerNormSmallKernel<half, 32>(int num,
                                                    const half *scale,
                                                    const half *bias,
                                                    half eps) {
-#if CUDA_ARCH_FP16_SUPPORTED(__CUDA_ARCH__)
+#if defined(PADDLE_WITH_CUDA)
   const half rld = half(1) / half(hidden);
   const int offset = blockIdx.x * hidden;
   cub::Sum pair_sum;
@@ -292,7 +292,7 @@ __global__ void SkipLayerNormSmallKernel<half, 128>(int num,
                                                     const half *scale,
                                                     const half *bias,
                                                     half eps) {
-#if CUDA_ARCH_FP16_SUPPORTED(__CUDA_ARCH__)
+#if defined(PADDLE_WITH_CUDA)
   const half rld = half(1) / half(hidden);
   const int offset = blockIdx.x * hidden;
   cub::Sum pair_sum;
@@ -319,7 +319,7 @@ __global__ void SkipLayerNormSmallKernel<half, 384>(int num,
                                                     const half *scale,
                                                     const half *bias,
                                                     half eps) {
-#if CUDA_ARCH_FP16_SUPPORTED(__CUDA_ARCH__)
+#if defined(PADDLE_WITH_CUDA)
   const half rld = half(1) / half(hidden);
   const int offset = blockIdx.x * hidden;
   cub::Sum pair_sum;

--- a/paddle/phi/kernels/fusion/gpu/masked_multihead_attention_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/masked_multihead_attention_kernel.cu
@@ -89,7 +89,7 @@ __global__ void masked_multihead_attention_kernel(
     Masked_multihead_attention_params<T> params,
     LoadFunc load_func,
     StoreFunc store_func) {
-#if CUDA_ARCH_FP16_SUPPORTED(__CUDA_ARCH__)
+#if defined(PADDLE_WITH_CUDA)
   const int bi = blockIdx.z;
   // params.sequence_lengths[bi] means how many k and v we have cached in
   // cache_kv.

--- a/paddle/phi/kernels/fusion/gpu/qkv_unpack_mha_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/qkv_unpack_mha_kernel.cu
@@ -60,7 +60,7 @@ template <typename T,
 __global__ void qkv_attention_kernel(QkvUnpackMhaParams<T> params,
                                      LoadFunc load_func,
                                      StoreFunc store_func) {
-#if CUDA_ARCH_FP16_SUPPORTED(__CUDA_ARCH__)
+#if defined(PADDLE_WITH_CUDA)
   const int bi = blockIdx.y;
 
   typedef PDDataTypeTraits<T> traits_;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience

### PR Types
Others 

### Description
<!-- Describe what you’ve done -->
```
    #define CUDA_ARCH_FP16_SUPPORTED(CUDA_ARCH) (CUDA_ARCH >= 600)
```
CUDA\_ARCH\_FP16\_SUPPORTED 是判断 CUDA\_ARCH 大于等于600，当前支持版本范围大于等于600不用判断
非CUDA环境也可能执行代码，
修改为
```
#if defined(PADDLE_WITH_CUDA)
```