### PR TITLE
 clean CUDA_ARCH_FP16_SUPPORTED - part 

### DIFF
--- a/paddle/phi/kernels/funcs/multihead_matmul_functor.cu
+++ b/paddle/phi/kernels/funcs/multihead_matmul_functor.cu
@@ -79,7 +79,7 @@ __global__ void SoftmaxKernelWithEltadd<half>(
     const int head_num,
     const int seq_len,
     const phi::funcs::warp_mask_t mask) {
-#if defined(PADDLE_WITH_CUDA) && CUDA_ARCH_FP16_SUPPORTED(__CUDA_ARCH__)
+#if defined(PADDLE_WITH_CUDA)
   int qk_offset = blockIdx.x * seq_len;
   assert(blockDim.x % WARP_SIZE == 0);
 
@@ -133,9 +133,9 @@ __global__ void SoftmaxKernelWithEltadd2<half2>(
     const int head_num,
     const int seq_len,
     const phi::funcs::warp_mask_t mask) {
-// operator "+" of half only suppotted after cuda version 10.0
+// operator "+" of half only supported after cuda version 10.0
 // HIP defined __HIP_NO_HALF_CONVERSIONS__ in hip.cmake
-#if defined(PADDLE_WITH_CUDA) && CUDA_ARCH_FP16_SUPPORTED(__CUDA_ARCH__)
+#if defined(PADDLE_WITH_CUDA)
   int qk_offset = blockIdx.x * seq_len;
   int idx = threadIdx.x;
   assert(blockDim.x % WARP_SIZE == 0);
@@ -203,7 +203,7 @@ __global__ void SoftmaxKernelWithEltaddForLarge(
     const int head_num,
     const int seq_len,
     const phi::funcs::warp_mask_t mask) {
-#if defined(PADDLE_WITH_CUDA) && CUDA_ARCH_FP16_SUPPORTED(__CUDA_ARCH__)
+#if defined(PADDLE_WITH_CUDA)
   int qk_offset = blockIdx.x * seq_len;
   assert(blockDim.x % WARP_SIZE == 0);
 
@@ -283,7 +283,7 @@ __global__ void SoftmaxKernelWithEltaddForLarge2(
     const int seq_len,
     const phi::funcs::warp_mask_t mask) {
 // HIP defined __HIP_NO_HALF_CONVERSIONS__ in hip.cmake
-#if defined(PADDLE_WITH_CUDA) && CUDA_ARCH_FP16_SUPPORTED(__CUDA_ARCH__)
+#if defined(PADDLE_WITH_CUDA)
 
   int qk_offset = blockIdx.x * seq_len;
   assert(blockDim.x % WARP_SIZE == 0);

--- a/paddle/phi/kernels/impl/llm_int8_matmul_kernel_impl.h
+++ b/paddle/phi/kernels/impl/llm_int8_matmul_kernel_impl.h
@@ -225,7 +225,7 @@ __global__ void ReduceAbsMaxKernel(const T* x,
                                    const int32_t cols,
                                    float* row_ranges,
                                    int32_t* outlier_idx) {
-#if CUDA_ARCH_FP16_SUPPORTED(__CUDA_ARCH__)
+#if defined(PADDLE_WITH_CUDA)
   using InVec = phi::AlignedVector<T, VecSize>;
   using ComputeVec = phi::AlignedVector<ComputeType, VecSize>;
 
@@ -420,7 +420,7 @@ __global__ void DequantMergeKernel(const int32_t* x,
                                    T* y,
                                    int m,
                                    int n) {
-#if CUDA_ARCH_FP16_SUPPORTED(__CUDA_ARCH__)
+#if defined(PADDLE_WITH_CUDA)
   using FpVec = phi::AlignedVector<T, VecSize>;
   using IntVec = phi::AlignedVector<int32_t, VecSize>;
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience

### PR Types
Others 

### Description
<!-- Describe what you’ve done -->
CUDA_ARCH_FP16_SUPPORTED 是判断 CUDA_ARCH 大于等于600，当前支持版本范围大于等于600不用判断
修改为
```
#if defined(PADDLE_WITH_CUDA)
```
