### PR TITLE
[CINN]:Fix ComparePriority to satisfy strict weak ordering for std::sort

### DIFF
--- a/paddle/cinn/ir/ir_visitor.cc
+++ b/paddle/cinn/ir/ir_visitor.cc
@@ -31,8 +31,8 @@ static bool CompareExpressions(const ir::IndexExpr& a, const ir::IndexExpr& b) {
   auto aPart = optim::GetFlattenExprs<T>(a);
   auto bPart = optim::GetFlattenExprs<T>(b);
 
-  std::sort(aPart.begin(), aPart.end(), optim::ComparePriority);
-  std::sort(bPart.begin(), bPart.end(), optim::ComparePriority);
+  std::sort(aPart.begin(), aPart.end(), optim::SortComparePriority);
+  std::sort(bPart.begin(), bPart.end(), optim::SortComparePriority);
 
   if (aPart.size() != bPart.size()) return false;
 

--- a/paddle/cinn/ir/op/ir_operators.cc
+++ b/paddle/cinn/ir/op/ir_operators.cc
@@ -377,7 +377,7 @@ static IndexExpr SimplifyAdd(const IndexExpr &lhs, const IndexExpr &rhs) {
 
   // 3 + d0 ===> d0 + 3.
   // d0 + (d1 + d2) ===> (d1 + d2) + d0.
-  if (!optim::ComparePriority(lhs, rhs)) {
+  if (optim::ComparePriority(lhs, rhs) == -1) {
     return rhs + lhs;
   }
 
@@ -525,7 +525,7 @@ static IndexExpr SimplifyMul(const IndexExpr &lhs, const IndexExpr &rhs) {
 
   // 3 * d0 ===> d0 * 3.
   // d0 * (d1 + d2) ===> (d1 + d2) * d0.
-  if (!optim::ComparePriority(lhs, rhs)) {
+  if (optim::ComparePriority(lhs, rhs) == -1) {
     return rhs * lhs;
   }
 

--- a/paddle/cinn/optim/simplify_util.h
+++ b/paddle/cinn/optim/simplify_util.h
@@ -62,29 +62,54 @@ inline std::vector<ir::IndexExpr> GetFlattenExprs(const ir::IndexExpr &expr) {
 }
 
 /*!
- * \brief Compare the priority of the two expressions. this func follows the
+ * \brief Compare the priority of the two expressions. This function follows the
  * above rules:
- * 1. if lhs = var, rhs = const,    return true;
- * 2. if lhs = const, rhs = var,    return false;
- * 3. if lhs = var, rhs = var,      return lhs_var_name <= lhs_var_name;
- * 4. if lhs.length > rhs.length,   return true;
- * 5. if lhs.length == rhs.length,  return lhs_type <= rhs_type; (Add < Mul <
- * Div < Mod)
- * 6. if lhs.length < rhs.length    return false;
+ * 1. if lhs = var, rhs = const,    return 1 (lhs > rhs);
+ * 2. if lhs = const, rhs = var,    return -1 (lhs < rhs);
+ * 3. if lhs = var, rhs = var,      return comparison result of lhs_var_name and
+ * rhs_var_name (0 if equal, -1 if lhs < rhs, 1 if lhs > rhs);
+ * 4. if lhs.length > rhs.length,   return 1 (lhs > rhs);
+ * 5. if lhs.length == rhs.length,  return comparison result of lhs_type and
+ * rhs_type (Add < Mul < Div < Mod, 0 if equal, -1 if lhs < rhs, 1 if lhs >
+ * rhs);
+ * 6. if lhs.length < rhs.length    return -1 (lhs < rhs);
  *
  * For example:
- * 1. `ComparePriority(S0, 2)` return true;
- * 2. `ComparePriority(S0, S0)` return true;
- * 2. `ComparePriority(S0, S1)` return false;
- * 3. `ComparePriority(S0, S1 + 1)` return false;
- * 4. `ComparePriority(S0 % 2, S1 + 1)` return false;
+ * 1. `ComparePriority(S0, 2)` return 1 (lhs > rhs);
+ * 2. `ComparePriority(S0, S0)` return 0 (equal);
+ * 3. `ComparePriority(S0, S1)` return -1 (lhs < rhs) if S0 < S1;
+ * 4. `ComparePriority(S0, S1 + 1)` return -1 (lhs < rhs);
+ * 5. `ComparePriority(S0 % 2, S1 + 1)` return -1 (lhs < rhs);
  *
  * \param lhs The left hand side expression to be compared.
  * \param rhs The right hand side expression to be compared.
- * \return A boolean value indicating whether the priority of `lhs` is higher
- * than `rhs`.
+ * \return An integer value indicating the comparison result:
+ *         - 1: lhs has strictly higher priority than rhs
+ *         - 0: lhs and rhs have equal priority
+ *         - -1: lhs has strictly lower priority than rhs
  */
-bool ComparePriority(const ir::IndexExpr &lhs, const ir::IndexExpr &rhs);
+int ComparePriority(const ir::IndexExpr &lhs, const ir::IndexExpr &rhs);
+
+/*!
+ * \brief Comparison function for sorting expressions by priority. This function
+ * follows the strict weak ordering requirement for std::sort by calling
+ * ComparePriority and converting its result to a boolean.
+ *
+ * This function implements the ordering such that:
+ * - If ComparePriority(lhs, rhs) returns 1, returns true (lhs should come
+ * before rhs)
+ * - If ComparePriority(lhs, rhs) returns 0 or -1, returns false (lhs should not
+ * come before rhs)
+ *
+ * This ensures that expressions are sorted in descending priority order, with
+ * higher priority expressions coming first in the sorted sequence.
+ *
+ * \param lhs The left hand side expression to be compared.
+ * \param rhs The right hand side expression to be compared.
+ * \return A boolean value indicating whether lhs should come before rhs in the
+ *         sorted sequence according to the priority rules.
+ */
+bool SortComparePriority(const ir::IndexExpr &lhs, const ir::IndexExpr &rhs);
 
 /*!
  * \brief Determines whether there are sub-parts in the `expr` that can be


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
`std::sort` 要求其比较函数满足**严格弱序**关系，即对于任意对象 `a`，`compare(a, a)` 必须返回 `false`。

原始的 `ComparePriority` 函数返回 `bool` 类型，难以正确表达相等情形，存在违反该规则的风险。
为此，将 `ComparePriority(lhs, rhs)` 的返回类型由 `bool` 修改为 `int`，语义如下：

- 返回 -1 表示` lhs < rhs`
- 返回 0 表示 `lhs == rhs`
- 返回 1 表示 `lhs > rhs`

同时引入包装函数 `SortComparePriority(lhs, rhs)`，专用于 `std::sort`。该函数内部调用 `ComparePriority`，仅当返回值为 1 时返回 true，其余情况返回 false，从而确保满足严格弱序要求。