### PR TITLE
Support capture backward subgraph

### DIFF
--- a/paddle/fluid/eager/api/manual/eager_manual/forwards/add_n_fwd_func.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/forwards/add_n_fwd_func.cc
@@ -112,6 +112,15 @@ paddle::Tensor add_n_ad_func(const std::vector<paddle::Tensor>& x,
     if (FLAGS_check_nan_inf) {
       grad_node->SetForwardTrace(egr::Controller::Instance().GetPythonStack());
     }
+    // Set for Record Subgraph
+    if (egr::EagerBackwardSubGraphNodeRecorder::Instance()
+            .NeedCaptureSubGraph()) {
+      VLOG(3) << "Capture the grad node" << grad_node->name() << "("
+              << grad_node.get() << ")"
+              << "for subgraph.";
+      egr::EagerBackwardSubGraphNodeRecorder::Instance().AddGradNode(
+          grad_node.get());
+    }
 
     // SetAttributes if needed
 

--- a/paddle/fluid/eager/api/manual/eager_manual/forwards/conv2d_fwd_function.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/forwards/conv2d_fwd_function.cc
@@ -167,7 +167,15 @@ paddle::Tensor conv2d_ad_func(
     if (FLAGS_check_nan_inf) {
       grad_node->SetForwardTrace(egr::Controller::Instance().GetPythonStack());
     }
-
+    // Set for Record Subgraph
+    if (egr::EagerBackwardSubGraphNodeRecorder::Instance()
+            .NeedCaptureSubGraph()) {
+      VLOG(3) << "Capture the grad node" << grad_node->name() << "("
+              << grad_node.get() << ")"
+              << "for subgraph.";
+      egr::EagerBackwardSubGraphNodeRecorder::Instance().AddGradNode(
+          grad_node.get());
+    }
     // SetAttributes if needed
     grad_node->SetAttribute_strides(strides);
     grad_node->SetAttribute_paddings(paddings);

--- a/paddle/fluid/eager/api/manual/eager_manual/forwards/multiply_fwd_func.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/forwards/multiply_fwd_func.cc
@@ -191,6 +191,15 @@ paddle::Tensor multiply_ad_func(
     if (FLAGS_check_nan_inf || FLAGS_call_stack_level == 3) {
       grad_node->SetForwardTrace(egr::Controller::Instance().GetPythonStack());
     }
+    // Set for Record Subgraph
+    if (egr::EagerBackwardSubGraphNodeRecorder::Instance()
+            .NeedCaptureSubGraph()) {
+      VLOG(3) << "Capture the grad node" << grad_node->name() << "("
+              << grad_node.get() << ")"
+              << "for subgraph.";
+      egr::EagerBackwardSubGraphNodeRecorder::Instance().AddGradNode(
+          grad_node.get());
+    }
     // SetAttributes if needed
     grad_node->SetAttribute_axis(-1);
 #ifdef PADDLE_WITH_CUSTOM_DEVICE
@@ -359,6 +368,15 @@ paddle::Tensor& multiply__ad_func(
     // Set for forward trace
     if (FLAGS_check_nan_inf) {
       grad_node->SetForwardTrace(egr::Controller::Instance().GetPythonStack());
+    }
+    // Set for Record Subgraph
+    if (egr::EagerBackwardSubGraphNodeRecorder::Instance()
+            .NeedCaptureSubGraph()) {
+      VLOG(3) << "Capture the grad node" << grad_node->name() << "("
+              << grad_node.get() << ")"
+              << "for subgraph.";
+      egr::EagerBackwardSubGraphNodeRecorder::Instance().AddGradNode(
+          grad_node.get());
     }
     // SetAttributes if needed
     grad_node->SetAttribute_axis(-1);

--- a/paddle/fluid/eager/api/manual/eager_manual/forwards/sync_batch_norm_fwd_func.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/forwards/sync_batch_norm_fwd_func.cc
@@ -253,6 +253,15 @@ sync_batch_norm__ad_func(const paddle::Tensor& x,
     if (FLAGS_check_nan_inf) {
       grad_node->SetForwardTrace(egr::Controller::Instance().GetPythonStack());
     }
+    // Set for Record Subgraph
+    if (egr::EagerBackwardSubGraphNodeRecorder::Instance()
+            .NeedCaptureSubGraph()) {
+      VLOG(3) << "Capture the grad node" << grad_node->name() << "("
+              << grad_node.get() << ")"
+              << "for subgraph.";
+      egr::EagerBackwardSubGraphNodeRecorder::Instance().AddGradNode(
+          grad_node.get());
+    }
 
     egr::Controller::Instance().PushBackForceSequentialNodes(grad_node.get());
     // SetAttributes if needed

--- a/paddle/fluid/eager/api/utils/global_utils.h
+++ b/paddle/fluid/eager/api/utils/global_utils.h
@@ -195,19 +195,16 @@ class EagerBackwardSubGraphNodeRecorder {
   }
 
  public:
-  void AddGradNode(GradNodeBase* node) { set_.insert(node); }
-  void RemoveGradNode(GradNodeBase* node) { set_.erase(node); }
-  bool ContainsGradNode(GradNodeBase* node) { return set_.count(node); }
+  void AddGradNode(const GradNodeBase* node) { set_.insert(node); }
+  void RemoveGradNode(const GradNodeBase* node) { set_.erase(node); }
+  bool ContainsGradNode(const GradNodeBase* node) { return set_.count(node); }
   bool NeedCaptureSubGraph() { return need_capture_subgraph_; }
   void StartCaptureSubGraph() { need_capture_subgraph_ = true; }
   void EndCaptureSubGraph() { need_capture_subgraph_ = false; }
-  bool HasCapturedSubgraph() {
-    std::cout << "set size" << set_.size() << std::endl;
-    return !set_.empty();
-  }
+  bool HasCapturedSubgraph() { return !set_.empty(); }
 
  private:
-  std::unordered_set<GradNodeBase*> set_;
+  std::unordered_set<const GradNodeBase*> set_;
   bool need_capture_subgraph_ = false;
 };
 

--- a/paddle/fluid/eager/api/utils/global_utils.h
+++ b/paddle/fluid/eager/api/utils/global_utils.h
@@ -201,10 +201,18 @@ class EagerBackwardSubGraphNodeRecorder {
   bool NeedCaptureSubGraph() { return need_capture_subgraph_; }
   void StartCaptureSubGraph() { need_capture_subgraph_ = true; }
   void EndCaptureSubGraph() { need_capture_subgraph_ = false; }
+  void SetDumpDirPath(const std::string& path) { dump_dir_path_ = path; }
+  const std::string& GetDumpDirPath() { return dump_dir_path_; }
+  void SetNeedDumpGradTensors(bool need_dump) {
+    need_dump_grad_tensors_ = need_dump;
+  }
+  bool GetNeedDumpGradTensors() { return need_dump_grad_tensors_; }
   bool HasCapturedSubgraph() { return !set_.empty(); }
 
  private:
   std::unordered_set<const GradNodeBase*> set_;
+  std::string dump_dir_path_;
+  bool need_dump_grad_tensors_ = false;
   bool need_capture_subgraph_ = false;
 };
 

--- a/paddle/fluid/eager/api/utils/global_utils.h
+++ b/paddle/fluid/eager/api/utils/global_utils.h
@@ -18,6 +18,7 @@
 #include <atomic>
 #include <memory>
 
+#include "paddle/fluid/eager/grad_node_info.h"
 #include "paddle/fluid/eager/hooks.h"
 #include "paddle/fluid/eager/type_defs.h"
 #include "paddle/fluid/imperative/tracer.h"
@@ -177,6 +178,37 @@ class EagerBackwardStateGuard {
   EagerBackwardStateGuard() { Controller::Instance().SetIsInBackward(true); }
 
   ~EagerBackwardStateGuard() { Controller::Instance().SetIsInBackward(false); }
+};
+class EagerBackwardSubGraphNodeRecorder {
+ public:
+  /**
+   * @brief Get the singleton instance of EagerBackwardSubGraphNodeRecorder
+   * @return Reference to the singleton instance
+   *
+   * Uses static local variable for thread-safe singleton initialization
+   * (C++11 guarantee). The instance is created on first call and destroyed
+   * automatically at program termination.
+   */
+  static EagerBackwardSubGraphNodeRecorder& Instance() {
+    static EagerBackwardSubGraphNodeRecorder instance;
+    return instance;
+  }
+
+ public:
+  void AddGradNode(GradNodeBase* node) { set_.insert(node); }
+  void RemoveGradNode(GradNodeBase* node) { set_.erase(node); }
+  bool ContainsGradNode(GradNodeBase* node) { return set_.count(node); }
+  bool NeedCaptureSubGraph() { return need_capture_subgraph_; }
+  void StartCaptureSubGraph() { need_capture_subgraph_ = true; }
+  void EndCaptureSubGraph() { need_capture_subgraph_ = false; }
+  bool HasCapturedSubgraph() {
+    std::cout << "set size" << set_.size() << std::endl;
+    return !set_.empty();
+  }
+
+ private:
+  std::unordered_set<GradNodeBase*> set_;
+  bool need_capture_subgraph_ = false;
 };
 
 }  // namespace egr

--- a/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
@@ -669,6 +669,11 @@ FORWARD_BODY_BEFORE_API_CALL_TEMPLATE = """  if (require_any_grad) {{
   if (FLAGS_check_nan_inf || FLAGS_call_stack_level == 3) {{
     grad_node->SetForwardTrace(egr::Controller::Instance().GetPythonStack());
   }}
+   // Set for Record Subgraph
+   if(egr::EagerBackwardSubGraphNodeRecorder::Instance().NeedCaptureSubGraph()){{
+       VLOG(3)<<"Capture the grad node"<<grad_node->name()<<"("<<grad_node.get()<<")"<<"for subgraph.";
+       egr::EagerBackwardSubGraphNodeRecorder::Instance().AddGradNode(grad_node.get());
+   }}
     // SetAttributes if needed
 {}
     // Set TensorWrappers for Forward Inputs if needed

--- a/paddle/fluid/eager/backward.cc
+++ b/paddle/fluid/eager/backward.cc
@@ -579,7 +579,11 @@ std::vector<paddle::Tensor> RunBackward(
                                              grad_output_tensor,
                                              dot_node_label,
                                              need_dump_backward_subgraph);
-            if (need_dump_grad_tensors) {
+            if (need_dump_grad_tensors &&
+                (egr::EagerBackwardSubGraphNodeRecorder::Instance()
+                     .ContainsGradNode(node) ||
+                 egr::EagerBackwardSubGraphNodeRecorder::Instance()
+                     .ContainsGradNode(next_node))) {
               debug_grad_tensors_str += egr::FormatTensor(grad_output_tensor);
             }
           }

--- a/paddle/fluid/eager/backward.cc
+++ b/paddle/fluid/eager/backward.cc
@@ -196,7 +196,11 @@ std::vector<paddle::Tensor> RunBackward(
     const std::vector<paddle::Tensor>& no_grad_vars = {},
     std::string dump_backward_graph_path = "") {
   VLOG(3) << "=================RunBackward: Start Backward =================";
-  bool need_debug_backward_graph = !dump_backward_graph_path.empty();
+
+  bool need_dump_backward_subgraph =
+      egr::EagerBackwardSubGraphNodeRecorder::Instance().HasCapturedSubgraph();
+  bool need_debug_backward_graph =
+      !dump_backward_graph_path.empty() || need_dump_backward_subgraph;
   bool need_dump_forward_stack =
       !FLAGS_dump_grad_node_forward_stack_path.empty();
   egr::EagerBackwardStateGuard guard;
@@ -387,12 +391,20 @@ std::vector<paddle::Tensor> RunBackward(
       // Construct backward graph for debug
       std::string dot_node_label = "";
       if (need_debug_backward_graph) {
-        dot_node_label = CreateNodeLabelInDot(node);
-        if (!dot.ContainsNode(dot_node_label)) {
-          dot.AddNode(dot_node_label,
-                      paddle::inference::analysis::grey_box_attrs,
-                      dot_node_label,
-                      false);
+        // if we need capture subgraph, the gradnode not related subgraph will
+        // not be captured
+        if (need_dump_backward_subgraph &&
+            !egr::EagerBackwardSubGraphNodeRecorder::Instance()
+                 .ContainsGradNode(node)) {
+          // no need to add node to dot graph
+        } else {
+          dot_node_label = CreateNodeLabelInDot(node);
+          if (!dot.ContainsNode(dot_node_label)) {
+            dot.AddNode(dot_node_label,
+                        paddle::inference::analysis::grey_box_attrs,
+                        dot_node_label,
+                        false);
+          }
         }
       }
 
@@ -510,23 +522,32 @@ std::vector<paddle::Tensor> RunBackward(
           // Construct backward graph for debug
           if (need_debug_backward_graph && grad_output_tensor.defined() &&
               grad_output_tensor.has_allocation()) {
-            std::string dot_next_node_label = CreateNodeLabelInDot(next_node);
-            if (!dot.ContainsNode(dot_next_node_label)) {
-              if (next_node->name() == "GradNodeAccumulation") {
-                dot.AddNode(dot_next_node_label,
-                            paddle::inference::analysis::teal_box_attrs,
-                            dot_next_node_label,
-                            false);
-              } else {
-                dot.AddNode(dot_next_node_label,
-                            paddle::inference::analysis::grey_box_attrs,
-                            dot_next_node_label,
-                            false);
+            if (need_dump_backward_subgraph &&
+                !egr::EagerBackwardSubGraphNodeRecorder::Instance()
+                     .ContainsGradNode(node)) {
+              // if we need capture subgraph, the gradnode not related subgraph
+              // will not be captured
+            } else {
+              std::string dot_next_node_label = CreateNodeLabelInDot(next_node);
+              if (!dot.ContainsNode(dot_next_node_label)) {
+                if (next_node->name() == "GradNodeAccumulation") {
+                  dot.AddNode(dot_next_node_label,
+                              paddle::inference::analysis::teal_box_attrs,
+                              dot_next_node_label,
+                              false);
+                } else {
+                  dot.AddNode(dot_next_node_label,
+                              paddle::inference::analysis::grey_box_attrs,
+                              dot_next_node_label,
+                              false);
+                }
               }
-            }
 
-            std::string tensor_label = CreateEdgeLabelInDot(grad_output_tensor);
-            dot.AddEdge(dot_node_label, dot_next_node_label, {}, tensor_label);
+              std::string tensor_label =
+                  CreateEdgeLabelInDot(grad_output_tensor);
+              dot.AddEdge(
+                  dot_node_label, dot_next_node_label, {}, tensor_label);
+            }
           }
 
           if (!node_input_buffers_dict.count(next_node)) {

--- a/paddle/fluid/eager/backward.cc
+++ b/paddle/fluid/eager/backward.cc
@@ -130,6 +130,7 @@ void ConstructForwardDebugDotGraph(const std::deque<GradNodeBase*>& init_queue,
                  .ContainsGradNode(node) &&
             !egr::EagerBackwardSubGraphNodeRecorder::Instance()
                  .ContainsGradNode(next_node)) {
+          queue.push_back(next_node);
           continue;
         }
         std::string dot_next_node_label =
@@ -240,12 +241,23 @@ std::vector<paddle::Tensor> RunBackward(
     std::string dump_backward_graph_path = "") {
   VLOG(3) << "=================RunBackward: Start Backward =================";
 
+  // Control variables related to debugging
   bool need_dump_backward_subgraph =
       egr::EagerBackwardSubGraphNodeRecorder::Instance().HasCapturedSubgraph();
   bool need_debug_backward_graph =
       !dump_backward_graph_path.empty() || need_dump_backward_subgraph;
+  //
+  if (need_dump_backward_subgraph) {
+    dump_backward_graph_path =
+        egr::EagerBackwardSubGraphNodeRecorder::Instance().GetDumpDirPath();
+  }
   bool need_dump_forward_stack =
       !FLAGS_dump_grad_node_forward_stack_path.empty();
+  bool need_dump_grad_tensors =
+      egr::EagerBackwardSubGraphNodeRecorder::Instance()
+          .GetNeedDumpGradTensors();
+  std::string debug_grad_tensors_str = "";
+
   egr::EagerBackwardStateGuard guard;
   auto place = egr::Controller::Instance().GetExpectedPlace();
 
@@ -387,6 +399,13 @@ std::vector<paddle::Tensor> RunBackward(
                                   &forward_debug_dot_graph,
                                   need_dump_backward_subgraph,
                                   &debug_call_stack);
+
+  // Dump the all call stack into
+  // FLAGS_dump_grad_node_forward_stack_path
+  if (need_dump_forward_stack) {
+    SaveStringToFile(
+        FLAGS_dump_grad_node_forward_stack_path, debug_call_stack, "append");
+  }
   std::deque<GradNodeBase*> ready_queue;
   for (GradNodeBase* item : queue) {
     if (!node_in_degree_map.count(item)) {
@@ -560,6 +579,9 @@ std::vector<paddle::Tensor> RunBackward(
                                              grad_output_tensor,
                                              dot_node_label,
                                              need_dump_backward_subgraph);
+            if (need_dump_grad_tensors) {
+              debug_grad_tensors_str += egr::FormatTensor(grad_output_tensor);
+            }
           }
 
           if (!node_input_buffers_dict.count(next_node)) {
@@ -641,7 +663,8 @@ std::vector<paddle::Tensor> RunBackward(
         SaveDebugInfo(dump_backward_graph_path,
                       forward_debug_dot_graph.Build(),
                       debug_call_stack,
-                      dot.Build());
+                      dot.Build(),
+                      debug_grad_tensors_str);
       }
       throw ex;
     } catch (std::exception& ex) {
@@ -658,7 +681,8 @@ std::vector<paddle::Tensor> RunBackward(
         SaveDebugInfo(dump_backward_graph_path,
                       forward_debug_dot_graph.Build(),
                       debug_call_stack,
-                      dot.Build());
+                      dot.Build(),
+                      debug_grad_tensors_str);
       }
       std::rethrow_exception(std::current_exception());
     } catch (...) {
@@ -674,7 +698,8 @@ std::vector<paddle::Tensor> RunBackward(
         SaveDebugInfo(dump_backward_graph_path,
                       forward_debug_dot_graph.Build(),
                       debug_call_stack,
-                      dot.Build());
+                      dot.Build(),
+                      debug_grad_tensors_str);
       }
 
       std::rethrow_exception(std::current_exception());
@@ -685,14 +710,10 @@ std::vector<paddle::Tensor> RunBackward(
     SaveDebugInfo(dump_backward_graph_path,
                   forward_debug_dot_graph.Build(),
                   debug_call_stack,
-                  dot.Build());
+                  dot.Build(),
+                  debug_grad_tensors_str);
   }
-  // Dump the all call stack into
-  // FLAGS_dump_grad_node_forward_stack_path
-  if (need_dump_forward_stack) {
-    SaveStringToFile(
-        FLAGS_dump_grad_node_forward_stack_path, debug_call_stack, "append");
-  }
+
   VLOG(4) << "RunBackward: Final hook size: "
           << egr::Controller::Instance().FinalBackwardHooks().size();
   for (auto& hook : egr::Controller::Instance().FinalBackwardHooks()) {

--- a/paddle/fluid/eager/backward.cc
+++ b/paddle/fluid/eager/backward.cc
@@ -75,6 +75,7 @@ std::unordered_map<GradNodeBase*, int> getInDegreeMap(
 // graph
 void ConstructForwardDebugDotGraph(const std::deque<GradNodeBase*>& init_queue,
                                    Dot* dot,
+                                   bool need_dump_backward_subgraph,
                                    std::string* call_stack) {
   std::deque<GradNodeBase*> queue = init_queue;
   std::unordered_set<GradNodeBase*> visited;
@@ -89,14 +90,21 @@ void ConstructForwardDebugDotGraph(const std::deque<GradNodeBase*>& init_queue,
       continue;
     }
     visited.insert(node);
-
-    if (!dot->ContainsNode(dot_node_label)) {
-      dot->AddNode(dot_node_label,
-                   paddle::inference::analysis::grey_box_attrs,
-                   dot_node_label,
-                   false);
+    if (need_dump_backward_subgraph &&
+        !egr::EagerBackwardSubGraphNodeRecorder::Instance().ContainsGradNode(
+            node)) {
+      // if we enable the need_dump_backward_subgraph the gradnode which is not
+      // related to subgraph will not be recorded
+    } else {
+      if (!dot->ContainsNode(dot_node_label)) {
+        dot->AddNode(dot_node_label,
+                     paddle::inference::analysis::grey_box_attrs,
+                     dot_node_label,
+                     false);
+      }
+      call_stack_map[node] = node->GetForwardTrace();
     }
-    call_stack_map[node] = node->GetForwardTrace();
+
     PADDLE_ENFORCE_NOT_NULL(
         node,
         common::errors::Fatal(
@@ -115,6 +123,15 @@ void ConstructForwardDebugDotGraph(const std::deque<GradNodeBase*>& init_queue,
         if (!next_node) {
           continue;
         }
+        // need_dump_backward_subgraph but the node and next node is not in
+        // subgraph
+        if (need_dump_backward_subgraph &&
+            !egr::EagerBackwardSubGraphNodeRecorder::Instance()
+                 .ContainsGradNode(node) &&
+            !egr::EagerBackwardSubGraphNodeRecorder::Instance()
+                 .ContainsGradNode(next_node)) {
+          continue;
+        }
         std::string dot_next_node_label =
             CreateForwardNodeLabelInDot(next_node);
         auto& tm = meta.GetTensorMeta();
@@ -126,9 +143,35 @@ void ConstructForwardDebugDotGraph(const std::deque<GradNodeBase*>& init_queue,
                          dot_next_node_label,
                          false);
           } else {
-            dot->AddNode(dot_next_node_label,
-                         paddle::inference::analysis::grey_box_attrs,
-                         dot_next_node_label,
+            if (need_dump_backward_subgraph &&
+                !egr::EagerBackwardSubGraphNodeRecorder::Instance()
+                     .ContainsGradNode(next_node)) {
+              dot->AddNode(dot_next_node_label,
+                           paddle::inference::analysis::orange_box_attrs,
+                           dot_next_node_label,
+                           false);
+            } else {
+              dot->AddNode(dot_next_node_label,
+                           paddle::inference::analysis::grey_box_attrs,
+                           dot_next_node_label,
+                           false);
+            }
+          }
+        }
+        // if need_dump_backward_subgraph but next_node is in subgraph and node
+        // is not in subgraph we will add node in subgraph and add edge
+        if (need_dump_backward_subgraph &&
+            egr::EagerBackwardSubGraphNodeRecorder::Instance().ContainsGradNode(
+                next_node) &&
+            !egr::EagerBackwardSubGraphNodeRecorder::Instance()
+                 .ContainsGradNode(node)) {
+          dot_node_label = CreateNodeLabelInDot(node);
+          // The node is not in subgraph but the node_next node is in subgraph
+          // we use orange_box to mark it too
+          if (!dot->ContainsNode(dot_node_label)) {
+            dot->AddNode(dot_node_label,
+                         paddle::inference::analysis::orange_box_attrs,
+                         dot_node_label,
                          false);
           }
         }
@@ -340,8 +383,10 @@ std::vector<paddle::Tensor> RunBackward(
   Dot forward_debug_dot_graph;
   std::string debug_call_stack = "";
   if (need_debug_backward_graph || need_dump_forward_stack)
-    ConstructForwardDebugDotGraph(
-        queue, &forward_debug_dot_graph, &debug_call_stack);
+    ConstructForwardDebugDotGraph(queue,
+                                  &forward_debug_dot_graph,
+                                  need_dump_backward_subgraph,
+                                  &debug_call_stack);
   std::deque<GradNodeBase*> ready_queue;
   for (GradNodeBase* item : queue) {
     if (!node_in_degree_map.count(item)) {
@@ -391,21 +436,8 @@ std::vector<paddle::Tensor> RunBackward(
       // Construct backward graph for debug
       std::string dot_node_label = "";
       if (need_debug_backward_graph) {
-        // if we need capture subgraph, the gradnode not related subgraph will
-        // not be captured
-        if (need_dump_backward_subgraph &&
-            !egr::EagerBackwardSubGraphNodeRecorder::Instance()
-                 .ContainsGradNode(node)) {
-          // no need to add node to dot graph
-        } else {
-          dot_node_label = CreateNodeLabelInDot(node);
-          if (!dot.ContainsNode(dot_node_label)) {
-            dot.AddNode(dot_node_label,
-                        paddle::inference::analysis::grey_box_attrs,
-                        dot_node_label,
-                        false);
-          }
-        }
+        dot_node_label = egr::AddNodeToDebugBackwardGraph(
+            &dot, node, need_dump_backward_subgraph);
       }
 
       // Run node: This is where Hook happens
@@ -522,32 +554,12 @@ std::vector<paddle::Tensor> RunBackward(
           // Construct backward graph for debug
           if (need_debug_backward_graph && grad_output_tensor.defined() &&
               grad_output_tensor.has_allocation()) {
-            if (need_dump_backward_subgraph &&
-                !egr::EagerBackwardSubGraphNodeRecorder::Instance()
-                     .ContainsGradNode(node)) {
-              // if we need capture subgraph, the gradnode not related subgraph
-              // will not be captured
-            } else {
-              std::string dot_next_node_label = CreateNodeLabelInDot(next_node);
-              if (!dot.ContainsNode(dot_next_node_label)) {
-                if (next_node->name() == "GradNodeAccumulation") {
-                  dot.AddNode(dot_next_node_label,
-                              paddle::inference::analysis::teal_box_attrs,
-                              dot_next_node_label,
-                              false);
-                } else {
-                  dot.AddNode(dot_next_node_label,
-                              paddle::inference::analysis::grey_box_attrs,
-                              dot_next_node_label,
-                              false);
-                }
-              }
-
-              std::string tensor_label =
-                  CreateEdgeLabelInDot(grad_output_tensor);
-              dot.AddEdge(
-                  dot_node_label, dot_next_node_label, {}, tensor_label);
-            }
+            egr::AddEdgeToDebugBackwardGraph(&dot,
+                                             node,
+                                             next_node,
+                                             grad_output_tensor,
+                                             dot_node_label,
+                                             need_dump_backward_subgraph);
           }
 
           if (!node_input_buffers_dict.count(next_node)) {

--- a/paddle/fluid/eager/utils.cc
+++ b/paddle/fluid/eager/utils.cc
@@ -38,6 +38,7 @@
 COMMON_DECLARE_bool(enable_unique_name);
 COMMON_DECLARE_int32(tensor_md5_checksum_precision);
 namespace egr {
+using paddle::inference::analysis::Dot;
 
 void SetGradOutputDistAttrIter::visit_element(paddle::Tensor* element,
                                               const GradSlotMeta& meta) {
@@ -1483,7 +1484,7 @@ TEST_API void SetTensorName(const std::string& unique_api_name,
 TEST_API void SetTensorName(const std::string& unique_api_name,
                             const std::string& var_name,
                             std::vector<paddle::Tensor>* tensors) {
-  for (int i = 0; i < tensors->size(); i++) {
+  for (size_t i = 0; i < tensors->size(); i++) {
     auto& t = (*tensors)[i];
     if (t.defined() && t.has_allocation()) {
       t.set_name(egr::GenerateUniqueTensorName(
@@ -1520,12 +1521,97 @@ TEST_API void SetGradTensorName(
     const paddle::small_vector<std::vector<GradSlotMeta>, kSlotSmallVectorSize>
         bwd_out_meta) {
   const auto& metas = bwd_out_meta[slot];
-  for (int i = 0; i < tensors->size(); i++) {
+  for (size_t i = 0; i < tensors->size(); i++) {
     auto& t = (*tensors)[i];
     if (t.defined() && t.has_allocation()) {
       std::string name = GenerateGradTensorName(metas[i]);
       t.set_name(name);
     }
+  }
+}
+std::string AddNodeToDebugBackwardGraph(Dot* dot,
+                                        GradNodeBase* node,
+                                        bool need_dump_backward_subgraph) {
+  std::string dot_node_label = "";
+  // If need_dump_backward_subgraph is true,it means that we should capture
+  // gradnode in subgraph which to be stored in
+  // EagerBackwardSubGraphNodeRecorder. If we need capture subgraph, the
+  // gradnode not related subgraph will not be captured
+  if (need_dump_backward_subgraph &&
+      !egr::EagerBackwardSubGraphNodeRecorder::Instance().ContainsGradNode(
+          node)) {
+    // no need to add node to dot graph
+  } else {
+    dot_node_label = CreateNodeLabelInDot(node);
+    if (!dot->ContainsNode(dot_node_label)) {
+      dot->AddNode(dot_node_label,
+                   paddle::inference::analysis::grey_box_attrs,
+                   dot_node_label,
+                   false);
+    }
+  }
+  return dot_node_label;
+}
+void AddEdgeToDebugBackwardGraph(Dot* dot,
+                                 GradNodeBase* node,
+                                 GradNodeBase* next_node,
+                                 const paddle::Tensor& t,
+                                 const std::string& node_label,
+                                 bool need_dump_backward_subgraph) {
+  std::string dot_node_label = node_label;
+  if (need_dump_backward_subgraph &&
+      !egr::EagerBackwardSubGraphNodeRecorder::Instance().ContainsGradNode(
+          node) &&
+      !egr::EagerBackwardSubGraphNodeRecorder::Instance().ContainsGradNode(
+          next_node)) {
+    // if we need capture subgraph, the gradnode not related subgraph
+    // will not be captured
+  } else {
+    std::string dot_next_node_label = CreateNodeLabelInDot(next_node);
+    if (!dot->ContainsNode(dot_next_node_label)) {
+      if (next_node->name() == "GradNodeAccumulation") {
+        dot->AddNode(dot_next_node_label,
+                     paddle::inference::analysis::teal_box_attrs,
+                     dot_next_node_label,
+                     false);
+      } else {
+        if (need_dump_backward_subgraph == false ||
+            egr::EagerBackwardSubGraphNodeRecorder::Instance().ContainsGradNode(
+                next_node)) {
+          dot->AddNode(dot_next_node_label,
+                       paddle::inference::analysis::grey_box_attrs,
+                       dot_next_node_label,
+                       false);
+        } else {
+          // The next node is not in subgraph but the node is in subgraph,
+          // we use orange_box to mark it
+          dot->AddNode(dot_next_node_label,
+                       paddle::inference::analysis::orange_box_attrs,
+                       dot_next_node_label,
+                       false);
+        }
+      }
+    }
+    // if need_dump_backward_subgraph but next_node is in subgraph and node is
+    // not in subgraph we will add node in subgraph and add edge
+    if (need_dump_backward_subgraph &&
+        egr::EagerBackwardSubGraphNodeRecorder::Instance().ContainsGradNode(
+            next_node) &&
+        !egr::EagerBackwardSubGraphNodeRecorder::Instance().ContainsGradNode(
+            node)) {
+      dot_node_label = CreateNodeLabelInDot(node);
+      // The node is not in subgraph but the node_next node is in subgraph
+      // we use orange_box to mark it too
+      if (!dot->ContainsNode(dot_node_label)) {
+        dot->AddNode(dot_node_label,
+                     paddle::inference::analysis::orange_box_attrs,
+                     dot_node_label,
+                     false);
+      }
+    }
+
+    std::string tensor_label = CreateEdgeLabelInDot(t);
+    dot->AddEdge(dot_node_label, dot_next_node_label, {}, tensor_label);
   }
 }
 }  // namespace egr

--- a/paddle/fluid/eager/utils.cc
+++ b/paddle/fluid/eager/utils.cc
@@ -1406,7 +1406,8 @@ TEST_API void SaveTensorMD5CheckSumToFile(
 void SaveDebugInfo(std::string dir_path,
                    const std::string& serialized_forward_graph,
                    const std::string& call_stack,
-                   const std::string& serialized_backward_graph) {
+                   const std::string& serialized_backward_graph,
+                   const std::string& debug_grad_tensors) {
   // Use timestamps to distinguish multiple logs
   auto now = std::chrono::system_clock::now();
   auto now_time_t = std::chrono::system_clock::to_time_t(now);
@@ -1448,6 +1449,13 @@ void SaveDebugInfo(std::string dir_path,
         file_path_prefix + "_backward_graph" + ".dot";
     VLOG(4) << "Save backward graph to file : " << backward_graph_file_path;
     SaveStringToFile(backward_graph_file_path, serialized_backward_graph);
+  }
+  if (debug_grad_tensors.empty() == false) {
+    std::string grad_tensors_file_path =
+        file_path_prefix + "_grad_tensors" + ".log";
+    VLOG(4) << "Save grad tensors for debug to file : "
+            << grad_tensors_file_path;
+    SaveStringToFile(grad_tensors_file_path, debug_grad_tensors);
   }
 }
 const std::string GenerateUniqueTensorName(const std::string& unique_api_name,
@@ -1614,4 +1622,24 @@ void AddEdgeToDebugBackwardGraph(Dot* dot,
     dot->AddEdge(dot_node_label, dot_next_node_label, {}, tensor_label);
   }
 }
+const std::string FormatTensor(const paddle::Tensor& t) {
+  if (!t.defined() || !t.has_allocation()) {
+    return "None";
+  }
+  // only data
+  phi::funcs::TensorFormatter formatter;
+
+  phi::DenseTensor* dense_tensor_ptr = nullptr;
+  if (t.is_dist_tensor()) {
+    auto dist_t =
+        std::static_pointer_cast<phi::distributed::DistTensor>(t.impl());
+    dense_tensor_ptr = dist_t->unsafe_mutable_value();
+  } else {
+    dense_tensor_ptr = dynamic_cast<phi::DenseTensor*>(t.impl().get());
+  }
+  auto& dense_tensor = *(dense_tensor_ptr);
+
+  return formatter.Format(dense_tensor, t.name());
+}
+
 }  // namespace egr

--- a/paddle/fluid/eager/utils.h
+++ b/paddle/fluid/eager/utils.h
@@ -429,7 +429,8 @@ std::string CreateForwardNodeLabelInDot(GradNodeBase* node);
 void SaveDebugInfo(std::string dir_path,
                    const std::string& serialized_forward_graph,
                    const std::string& call_stack,
-                   const std::string& serialized_backward_graph);
+                   const std::string& serialized_backward_graph,
+                   const std::string& debug_grad_tensors);
 
 void SaveStringToFile(const std::string& file_path,
                       const std::string& str,
@@ -480,4 +481,6 @@ void AddEdgeToDebugBackwardGraph(paddle::inference::analysis::Dot* dot,
                                  const paddle::Tensor& t,
                                  const std::string& node_label,
                                  bool need_dump_backward_subgraph);
+
+const std::string FormatTensor(const paddle::Tensor& t);
 }  // namespace egr

--- a/paddle/fluid/eager/utils.h
+++ b/paddle/fluid/eager/utils.h
@@ -17,11 +17,11 @@
 #include "paddle/fluid/eager/autograd_meta.h"
 #include "paddle/fluid/eager/eager_tensor.h"
 #include "paddle/fluid/eager/grad_node_info.h"
+#include "paddle/fluid/inference/analysis/dot.h"
 #include "paddle/phi/api/all.h"
 #include "paddle/phi/api/lib/kernel_dispatch.h"
 #include "paddle/phi/core/distributed/auto_parallel/dist_tensor.h"
 #include "paddle/utils/test_macros.h"
-
 namespace egr {
 
 class TensorWrapper;
@@ -471,4 +471,13 @@ TEST_API void SetGradTensorName(
     const int slot,
     const paddle::small_vector<std::vector<GradSlotMeta>, kSlotSmallVectorSize>&
         bwd_out_meta);
+std::string AddNodeToDebugBackwardGraph(paddle::inference::analysis::Dot* dot,
+                                        GradNodeBase* node,
+                                        bool need_dump_backward_subgraph);
+void AddEdgeToDebugBackwardGraph(paddle::inference::analysis::Dot* dot,
+                                 GradNodeBase* node,
+                                 GradNodeBase* next_node,
+                                 const paddle::Tensor& t,
+                                 const std::string& node_label,
+                                 bool need_dump_backward_subgraph);
 }  // namespace egr

--- a/paddle/fluid/inference/analysis/dot.h
+++ b/paddle/fluid/inference/analysis/dot.h
@@ -227,6 +227,15 @@ const std::vector<Dot::Attr> teal_box_attrs({
     Dot::Attr("color", "#148b97"),              //
     Dot::Attr("fontcolor", "#ffffff"),          //
 });
+const std::vector<Dot::Attr> orange_box_attrs({
+    Dot::Attr("style", "rounded,filled,bold"),  //
+    Dot::Attr("shape", "box"),                  //
+    Dot::Attr("color", "#FFE4B5"),              //
+    Dot::Attr("fontcolor", "#ffffff"),          //
+    Dot::Attr("width", "1.3"),                  //
+    Dot::Attr("height", "0.84"),                //
+    Dot::Attr("fontname", "Arial"),             //
+});
 
 }  // namespace analysis
 }  // namespace inference

--- a/paddle/fluid/pybind/eager_functions.cc
+++ b/paddle/fluid/pybind/eager_functions.cc
@@ -1478,6 +1478,22 @@ PyObject* eager__end_capture_debug_backward_subgraph(PyObject* self,
   RETURN_PY_NONE
   EAGER_CATCH_AND_THROW_RETURN_NULL
 }
+PyObject* eager__init_backward_subgraph_recorder(PyObject* self,
+                                                 PyObject* args,
+                                                 PyObject* kwargs) {
+  EAGER_TRY
+  std::string dump_dir_path =
+      CastPyArg2AttrString(PyTuple_GET_ITEM(args, 0), 0);
+  bool need_dump_grad_tensors =
+      CastPyArg2AttrBoolean(PyTuple_GET_ITEM(args, 1), 1);
+  egr::EagerBackwardSubGraphNodeRecorder::Instance().SetDumpDirPath(
+      dump_dir_path);
+  egr::EagerBackwardSubGraphNodeRecorder::Instance().SetNeedDumpGradTensors(
+      need_dump_grad_tensors);
+  RETURN_PY_NONE
+
+  EAGER_CATCH_AND_THROW_RETURN_NULL
+}
 
 PyMethodDef variable_functions[] = {  // NOLINT
     // TODO(jiabin): Remove scale when we have final state tests
@@ -1571,6 +1587,10 @@ PyMethodDef variable_functions[] = {  // NOLINT
      nullptr},
     {"_end_capture_debug_backward_subgraph",
      (PyCFunction)(void (*)())eager__end_capture_debug_backward_subgraph,
+     METH_VARARGS,
+     nullptr},
+    {"_init_backward_subgraph_recorder",
+     (PyCFunction)(void (*)())eager__init_backward_subgraph_recorder,
      METH_VARARGS,
      nullptr},
 /**sparse functions**/

--- a/paddle/fluid/pybind/eager_functions.cc
+++ b/paddle/fluid/pybind/eager_functions.cc
@@ -1459,6 +1459,25 @@ PyObject* eager__for_test_check_cuda_error(PyObject* self,
 
   EAGER_CATCH_AND_THROW_RETURN_NULL
 }
+PyObject* eager__start_capture_debug_backward_subgraph(PyObject* self,
+                                                       PyObject* args,
+                                                       PyObject* kwargs) {
+  EAGER_TRY
+
+  egr::EagerBackwardSubGraphNodeRecorder::Instance().StartCaptureSubGraph();
+  RETURN_PY_NONE
+
+  EAGER_CATCH_AND_THROW_RETURN_NULL
+}
+
+PyObject* eager__end_capture_debug_backward_subgraph(PyObject* self,
+                                                     PyObject* args,
+                                                     PyObject* kwargs) {
+  EAGER_TRY
+  egr::EagerBackwardSubGraphNodeRecorder::Instance().EndCaptureSubGraph();
+  RETURN_PY_NONE
+  EAGER_CATCH_AND_THROW_RETURN_NULL
+}
 
 PyMethodDef variable_functions[] = {  // NOLINT
     // TODO(jiabin): Remove scale when we have final state tests
@@ -1544,6 +1563,14 @@ PyMethodDef variable_functions[] = {  // NOLINT
 
     {"_add_docstr",
      (PyCFunction)(void (*)())eager__add_doc_str,
+     METH_VARARGS,
+     nullptr},
+    {"_start_capture_debug_backward_subgraph",
+     (PyCFunction)(void (*)())eager__start_capture_debug_backward_subgraph,
+     METH_VARARGS | METH_KEYWORDS,
+     nullptr},
+    {"_end_capture_debug_backward_subgraph",
+     (PyCFunction)(void (*)())eager__end_capture_debug_backward_subgraph,
      METH_VARARGS,
      nullptr},
 /**sparse functions**/

--- a/python/paddle/base/framework.py
+++ b/python/paddle/base/framework.py
@@ -37,6 +37,7 @@ from typing_extensions import ParamSpec
 import paddle
 
 from .. import pir
+from ..utils.download import check_and_create_dir
 from . import core, unique_name
 from .libpaddle import DataType
 from .proto import (
@@ -8609,7 +8610,14 @@ def pir_op_name_guard(op_name: str) -> Generator[None, None, None]:
 
 
 @signature_safe_contextmanager
-def capture_backward_subgraph_guard() -> Generator[None, None, None]:
+def capture_backward_subgraph_guard(
+    dump_dir_path: str, need_dump_grad_tensors: bool = False
+) -> Generator[None, None, None]:
+    assert dump_dir_path is not None, "The dump_dir_path should not be None"
+    check_and_create_dir(dump_dir_path)
+    paddle.base.core.eager._init_backward_subgraph_recorder(
+        dump_dir_path, need_dump_grad_tensors
+    )
     paddle.base.core.eager._start_capture_debug_backward_subgraph()
     try:
         yield

--- a/python/paddle/base/framework.py
+++ b/python/paddle/base/framework.py
@@ -8617,6 +8617,7 @@ def capture_backward_subgraph_guard() -> Generator[None, None, None]:
         paddle.base.core.eager._end_capture_debug_backward_subgraph()
 
 
+@signature_safe_contextmanager
 def vlog_guard(module_levels: int | dict) -> Generator[None, None, None]:
     if not isinstance(module_levels, (int, dict)):
         raise TypeError(

--- a/python/paddle/base/framework.py
+++ b/python/paddle/base/framework.py
@@ -8606,3 +8606,12 @@ def pir_op_name_guard(op_name: str) -> Generator[None, None, None]:
     finally:
         if paddle.framework.in_pir_mode() and core._is_bwd_prim_enabled():
             pir.set_comp_op_name(original_comp_op_name)
+
+
+@signature_safe_contextmanager
+def capture_backward_subgraph_guard() -> Generator[None, None, None]:
+    paddle.base.core.eager._start_capture_debug_backward_subgraph()
+    try:
+        yield
+    finally:
+        paddle.base.core.eager._end_capture_debug_backward_subgraph()

--- a/test/legacy_test/test_capture_backward_subgraph.py
+++ b/test/legacy_test/test_capture_backward_subgraph.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import platform
 import shutil
 import unittest
 
@@ -22,6 +23,9 @@ import paddle
 class TestCaptureBackwardSubGraphGuard(unittest.TestCase):
     # Just run it for coverage ci and don't check the res
     def test_guard(self):
+        # windows ci may have some permission issues
+        if 'Windows' == platform.system():
+            return
         import paddle.nn.functional as F
         from paddle import nn
 

--- a/test/legacy_test/test_capture_backward_subgraph.py
+++ b/test/legacy_test/test_capture_backward_subgraph.py
@@ -24,7 +24,7 @@ class TestCaptureBackwardSubGraphGuard(unittest.TestCase):
     # Just run it for coverage ci and don't check the res
     def test_guard(self):
         # windows ci may have some permission issues
-        if 'Windows' == platform.system():
+        if 'Windows' == platform.system() or not paddle.is_compiled_with_cuda():
             return
         import paddle.nn.functional as F
         from paddle import nn
@@ -53,7 +53,6 @@ class TestCaptureBackwardSubGraphGuard(unittest.TestCase):
             conv_x.stop_gradient = False
             conv_w.stop_gradient = False
             sync_bn_input.stop_gradient = False
-
             with paddle.amp.auto_cast(enable=True):
                 out1 = paddle.add_n([x, y])
                 out2 = paddle.multiply(x, y)

--- a/test/legacy_test/test_capture_backward_subgraph.py
+++ b/test/legacy_test/test_capture_backward_subgraph.py
@@ -1,0 +1,92 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import shutil
+import unittest
+
+import paddle
+
+
+class TestCaptureBackwardSubGraphGuard(unittest.TestCase):
+    # Just run it for coverage ci and don't check the res
+    def test_guard(self):
+        import paddle.nn.functional as F
+        from paddle import nn
+
+        dump_dir_path = "_test/"
+
+        x = paddle.randn([3, 3], dtype='float16')
+        y = paddle.randn([3, 3], dtype='float32')
+        z = paddle.randn([3, 3], dtype='float64')
+        w = paddle.randn([3, 3], dtype='float64')
+        x.stop_gradient = False
+        y.stop_gradient = False
+        z.stop_gradient = False
+        w.stop_gradient = True
+        y = y + y
+        with paddle.base.framework.capture_backward_subgraph_guard(
+            dump_dir_path, True
+        ):
+            conv_x = paddle.randn((2, 3, 8, 8), dtype='float32')
+            conv_w = paddle.randn((6, 3, 3, 3), dtype='float16')
+
+            sync_bn_input = paddle.to_tensor(
+                [[[[0.3, 0.4], [0.3, 0.07]], [[0.83, 0.37], [0.18, 0.93]]]]
+            ).astype('float32')
+
+            conv_x.stop_gradient = False
+            conv_w.stop_gradient = False
+            sync_bn_input.stop_gradient = False
+
+            with paddle.amp.auto_cast(enable=True):
+                out1 = paddle.add_n([x, y])
+                out2 = paddle.multiply(x, y)
+                out6 = F.conv2d(conv_x, conv_w)
+
+            out3 = paddle.add_n([out1, y])
+            out4 = paddle.multiply(out2, z)
+            out5 = paddle.multiply_(w, y)
+            if paddle.is_compiled_with_cuda():
+                sync_batch_norm = nn.SyncBatchNorm(2)
+                hidden1 = sync_batch_norm(sync_bn_input)
+            out7 = out6.sum() + hidden1.sum()
+        loss = out1 + out2 + out3 + out4 + out5 + out7
+        loss.backward()
+        self._check_files_in_directory(dump_dir_path)
+        shutil.rmtree(dump_dir_path)
+
+    def _check_files_in_directory(self, directory):
+        # Check whether the expected file exists in the directory
+        entries = os.listdir(directory)
+        files = [
+            entry
+            for entry in entries
+            if os.path.isfile(os.path.join(directory, entry))
+        ]
+        expect_keywards_in_file_name = [
+            "backward_graph.dot",
+            "ref_forward_graph.dot",
+            "call_stack.log",
+            "grad_tensors.log",
+        ]
+        for keywords in expect_keywards_in_file_name:
+            if not any(keywords in f for f in files):
+                raise AssertionError(
+                    f"Error: File '{keywords}' not found in directory '{directory}'! "
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features
### Description
<!-- Describe what you’ve done -->
支持捕获反向的子图
### 用法：
```
import paddle
from paddle.base.framework import capture_backward_subgraph_guard
x = paddle.randn([2,3],dtype="float32")
y = paddle.randn([2,3],dtype="float64")
x.stop_gradient = False
y.stop_gradient = False
z1 = x - y
z2 = x + y
# 只捕获guard中的前向所对应的反向图子图，而且需要导出子图中的Grad 
with capture_backward_subgraph_guard(dump_dir_path="./debug",need_dump_grad_tensors =True):
    z3 = z1 * z2
    z4 = z3.sum()
    z5 = z2.mean()
loss = z4 + z5
loss.sum().backward()
print(x.grad)
```
```dump_dir_path``` 表示要输出的反向图、前向图、调用栈、所有的梯度Tensor所输出的路径
```need_dump_grad_tensors ``` 表示是否需要导出梯度（反向图中的边）

导出的反向图子图：
- 其中灰色的GradNode是指在反向图子图中的节点
- 橙色高亮的GradNode是指和捕获的子图输入/输出相关的GradNode，它并不在子图中但是和子图梯度传播有关（通常是子图的输入和输出）

<img width="1308" height="1066" alt="image" src="https://github.com/user-attachments/assets/a95b139a-8068-455c-9c62-13d3f43029f8" />

反向图子图的梯度信息：
```
Variable: sum1_out_float64_@Grad
  - lod: {}
  - place: Place(gpu:0)
  - shape: []
  - layout: NCHW
  - dtype: float64
  - data: [1.000000]
Variable: mean1_out_float64_@Grad
  - lod: {}
  - place: Place(gpu:0)
  - shape: []
  - layout: NCHW
  - dtype: float64
  - data: [1.000000]
Variable: multiply1_out_float64_2x3@Grad
  - lod: {}
  - place: Place(gpu:0)
  - shape: [2, 3]
  - layout: NCHW
  - dtype: float64
  - data: [1.000000 1.000000 1.000000 1.000000 1.000000 1.000000]
Variable: add1_out_float64_2x3@Grad
  - lod: {}
  - place: Place(gpu:0)
  - shape: [2, 3]
  - layout: NCHW
  - dtype: float64
  - data: [0.166667 0.166667 0.166667 0.166667 0.166667 0.166667]
Variable: subtract1_out_float64_2x3@Grad
  - lod: {}
  - place: Place(gpu:0)
  - shape: [2, 3]
  - layout: NCHW
  - dtype: float64
  - data: [-2.869025 0.629349 -0.607799 -0.698559 1.029199 -3.619529]
Variable: add1_out_float64_2x3@Grad
  - lod: {}
  - place: Place(gpu:0)
  - shape: [2, 3]
  - layout: NCHW
  - dtype: float64
  - data: [1.843187 -2.461634 -0.024330 0.309245 1.282574 1.534915]

```

### 注意事项
- 使用了capture_backward_subgraph_guard之后，backward、grad的dump_backward_graph_path参数将不再发挥作用。也就是说使用了capture_backward_subgraph_guard之后导出整张反向图的功能会暂时失效。
- capture_backward_subgraph_guard 在运行过程中只能使用一次，如果调用了两次guard可能会导致输出的文件错乱（通常会输出到最后一次调用guard指定的dir中）
- 建议export FLAGS_enable_unique_name=True，Tensor会有唯一命名，让梯度信息更直观

