### PR TITLE
Fix cross_entropy mean reduction incorrect when using ignore_index

### DIFF
--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -2834,8 +2834,8 @@ def cross_entropy(
             If given, has to be a Tensor of size C and the data type is float32, float64.
             Default is ``'None'`` .
         ignore_index (int64, optional): Specifies a target value that is ignored
-            and does not contribute to the loss. A negative value means that no label
-            value needs to be ignored. Only valid when soft_label = False.
+            and does not contribute to the loss. When reduction='mean', the loss is
+            averaged over non-ignored targets.  Only valid when soft_label = False.
             Default is ``-100`` .
         reduction (str, optional): Indicate how to average the loss by batch_size,
             the candidates are ``'none'`` | ``'mean'`` | ``'sum'``.
@@ -2972,7 +2972,7 @@ def cross_entropy(
             "The value of 'reduction' in softmax_cross_entropy"
             f"should be 'sum', 'mean' or 'none', but received {reduction}, which is not allowed."
         )
-    if ignore_index > 0 and soft_label:
+    if ignore_index >= 0 and soft_label:
         raise ValueError(
             "When soft_label == True, the value of 'ignore_index' in softmax_cross_entropy"
             f"should be '-100', but received {ignore_index}, which is not allowed."
@@ -3097,7 +3097,7 @@ def cross_entropy(
             # 2. else
             #     numerator: loss's weighted sum
             #     denominator: cal the sum of weight where the sample's class_index!=ignore_index
-            if ignore_index >= 0:  # ignore label
+            if not soft_label:
                 if out.dtype == paddle.float16:
                     out_sum = _C_ops.sum(out, [], paddle.float32, False)
                 else:
@@ -3253,7 +3253,7 @@ def cross_entropy(
         if reduction == "sum":
             return paddle.sum(out, name=name)
         elif reduction == "mean":
-            if ignore_index >= 0:
+            if not soft_label:
                 out_sum = paddle.sum(out, name=name)
                 # for each label[i],set 1 or 0, according to ignore_index
                 # mask[i]=0, if label[i]==ignore_index

--- a/test/legacy_test/test_cross_entropy_loss.py
+++ b/test/legacy_test/test_cross_entropy_loss.py
@@ -1819,6 +1819,59 @@ class CrossEntropyLoss(unittest.TestCase):
 
         np.testing.assert_allclose(dy_ret_value, expected, rtol=1e-05)
 
+    def test_cross_entropy_loss_1d_with_mean_ignore_negative_100(self):
+        N = 100
+        C = 200
+        ignore_index = -100
+        input_np = np.random.random([N, C]).astype(self.dtype)
+
+        valid_labels = np.random.randint(0, C, size=(N // 2)).astype(np.int64)
+        ignored_labels = np.full((N - (N // 2),), ignore_index).astype(np.int64)
+        label_np = np.concatenate((valid_labels, ignored_labels))
+
+        paddle.enable_static()
+        prog = base.Program()
+        startup_prog = base.Program()
+        place = get_device_place()
+        with base.program_guard(prog, startup_prog):
+            input = paddle.static.data(
+                name='input', shape=[N, C], dtype=self.dtype
+            )
+            label = paddle.static.data(name='label', shape=[N], dtype='int64')
+            cross_entropy_loss = paddle.nn.loss.CrossEntropyLoss(
+                ignore_index=ignore_index
+            )
+            ret = cross_entropy_loss(input, label)
+            exe = base.Executor(place)
+            static_ret = exe.run(
+                prog,
+                feed={
+                    'input': input_np,
+                    'label': label_np,
+                },
+                fetch_list=[ret],
+            )
+            self.assertIsNotNone(static_ret)
+
+        with base.dygraph.guard():
+            cross_entropy_loss = paddle.nn.loss.CrossEntropyLoss(
+                axis=1, ignore_index=ignore_index
+            )
+            dy_ret = cross_entropy_loss(
+                paddle.to_tensor(input_np),
+                paddle.to_tensor(label_np),
+            )
+            dy_ret_value = dy_ret.numpy()
+            self.assertIsNotNone(dy_ret_value)
+
+        expected = cross_entropy_loss_1d(
+            input_np, label_np, ignore_index=ignore_index
+        )[0]
+
+        np.testing.assert_allclose(static_ret[0], dy_ret_value, rtol=1e-05)
+        np.testing.assert_allclose(static_ret[0], expected, rtol=1e-05)
+        np.testing.assert_allclose(dy_ret_value, expected, rtol=1e-05)
+
     def test_cross_entropy_loss_1d_with_weight_mean(self):
         input_np = np.random.random([2, 4]).astype(self.dtype)
         label_np = np.random.randint(0, 4, size=(2)).astype(np.int64)
@@ -2771,6 +2824,23 @@ class TestCrossEntropyFAPIError(unittest.TestCase):
                     self.assertIsNotNone(static_ret)
 
             self.assertRaises(ValueError, static_test_WeightLength_NotEqual)
+
+            def test_IgnoreIndex_SoftTarget():
+                input_data = paddle.rand(shape=[20, 100])
+                label_data = paddle.rand_like(input_data)
+                label_data = label_data / paddle.sum(
+                    label_data, axis=-1, keepdim=True
+                )
+                weight_data = paddle.rand([100])
+                paddle.nn.functional.cross_entropy(
+                    input=input_data,
+                    label=label_data,
+                    soft_label=True,
+                    weight=weight_data,
+                    ignore_index=19,
+                )
+
+            self.assertRaises(ValueError, test_IgnoreIndex_SoftTarget)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience


### PR Types
Bug fixes


### Description
修复 paddle.nn.functional.cross_entropy (以及 paddle.nn.CrossEntropyLoss) 在 reduction='mean' 和 soft_label=False 时，对 ignore_index 处理不当的 bug。

Bug 详情： 当 soft_label=False 且 ignore_index 为负值（例如默认的-100）时，reduction='mean' 的逻辑错误地跳过了计算“有效样本数”的分支，导致 loss 总是除以总样本数（N），而不是正确的有效样本数。这会导致计算出的 loss 值偏小。
