### PR TITLE
[Cherry-pick Fleety_12] [Precision Depth Alignment] implement torch compatible max_pool2d grad kernel

### DIFF
--- a/paddle/common/flags.cc
+++ b/paddle/common/flags.cc
@@ -2225,3 +2225,15 @@ PHI_DEFINE_EXPORTED_bool(use_stride_compute_kernel,
 PHI_DEFINE_EXPORTED_int64(deep_ep_comm_prealloc_in_mb,
                           0,
                           "Whether use prealloc for deepep communication.");
+
+/**
+ * Torch Compatible related FLAG
+ * Name: FLAGS_torch_compatible_kernel
+ * Since Version: 3.2.2
+ * Value Range: bool, default=false
+ * Example:
+ * Note: Whether use torch compatible version kernel.
+ */
+PHI_DEFINE_EXPORTED_bool(torch_compatible_kernel,
+                         false,
+                         "Whether use torch compatible version kernel.");

--- a/test/legacy_test/test_pool2d_api.py
+++ b/test/legacy_test/test_pool2d_api.py
@@ -772,6 +772,13 @@ class TestPool2D_API(unittest.TestCase):
             self.check_lp_float16_static(place)
         paddle.disable_static()
 
+    def test_torch_compatible(self):
+        paddle.set_flags({'FLAGS_torch_compatible_kernel': 1})
+        paddle.enable_static()
+        for place in self.places:
+            self.check_max_static_results(place)
+        paddle.disable_static()
+
     def test_pool2d(self):
         for place in self.places:
             self.check_max_dygraph_results(place)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
**将该pr：https://github.com/PaddlePaddle/Paddle/pull/75965 ([Precision Depth Alignment] implement torch compatible max_pool2d grad kernel)，cherry-pick 到 Fleety_12**

该pr的修改描述：
>由于paddle现有实现具有明显的性能优势，所以添加了 FLAGS_torch_compatible_pool_grad，用于开启和关闭兼容 torch 模式。
实现了一套新的兼容 torch 模式的 kernel，主要区别如下：
对于 f32 精度以下的数据进行精度提升。
从遍历输出维度改成了遍历输入维度。
添加了额外的单测。

由于cherry-pick时存在冲突，所以单独提一个PR