### PR TITLE
[Bug Fix]修复断言的格式化字符串错误

### DIFF
--- a/test/amp/amp_base_models.py
+++ b/test/amp/amp_base_models.py
@@ -418,7 +418,7 @@ class AmpTestBase(unittest.TestCase):
             self.assertEqual(
                 actual_value,
                 expected_value,
-                f"[debug_info] The number of fp16 calls of operator < {op_type} > is expected to be {expected_value}, but received {actual_value}.",
+                f"[{debug_info}] The number of fp16 calls of operator < {op_type} > is expected to be {expected_value}, but received {actual_value}.",
             )
 
     def run_program(

--- a/test/amp/test_pir_amp.py
+++ b/test/amp/test_pir_amp.py
@@ -209,7 +209,7 @@ class TestPirAMPProgram(unittest.TestCase):
                     out = linear(x)
                     loss = paddle.mean(out)
                 optimizer.minimize(loss)
-            cast_op_count = 0
+            cast_op_count = 0  #
             for op in main.global_block().ops:
                 if op.name() == 'pd_op.cast':
                     cast_op_count += 1

--- a/test/amp/test_pir_amp.py
+++ b/test/amp/test_pir_amp.py
@@ -95,7 +95,7 @@ class TestPirAMPProgram(unittest.TestCase):
             np.testing.assert_equal(len(_white_list), 0)
             np.testing.assert_equal(len(_black_list), 0)
 
-    def test_linear_amp_o2_without_scaler(self):  #
+    def test_linear_amp_o2_without_scaler(self):
         if not core.is_compiled_with_cuda():
             return
         with paddle.pir_utils.IrGuard():

--- a/test/amp/test_pir_amp.py
+++ b/test/amp/test_pir_amp.py
@@ -209,7 +209,7 @@ class TestPirAMPProgram(unittest.TestCase):
                     out = linear(x)
                     loss = paddle.mean(out)
                 optimizer.minimize(loss)
-            cast_op_count = 0  #
+            cast_op_count = 0
             for op in main.global_block().ops:
                 if op.name() == 'pd_op.cast':
                     cast_op_count += 1

--- a/test/amp/test_pir_amp.py
+++ b/test/amp/test_pir_amp.py
@@ -95,7 +95,7 @@ class TestPirAMPProgram(unittest.TestCase):
             np.testing.assert_equal(len(_white_list), 0)
             np.testing.assert_equal(len(_black_list), 0)
 
-    def test_linear_amp_o2_without_scaler(self):
+    def test_linear_amp_o2_without_scaler(self):  #
         if not core.is_compiled_with_cuda():
             return
         with paddle.pir_utils.IrGuard():


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
代码构建断言失败时的提示消息，但硬编码了字符串 `[debug_info]`，而没有使用传入的 `debug_info` 参数，导致无法正确反映当前测试上下文，与 BF16 分支中使用 `{debug_info}` 不一致。
