### PR TITLE
[Bug Fix]提前检查op_stats_dict是否包含待查 op_type，防止测试中断

### DIFF
--- a/test/amp/amp_base_models.py
+++ b/test/amp/amp_base_models.py
@@ -400,7 +400,12 @@ class AmpTestBase(unittest.TestCase):
 
         for op_type, expected_value in expected_bf16_calls.items():
             # print(f"[BF16] op_type={op_type}, value={value}")
-            if isinstance(op_stats_dict[op_type], str):
+            if op_type not in op_stats_dict:
+                self.fail(
+                    f"[{debug_info}] Operator '{op_type}' not found in op_stats_dict."
+                )
+            item = op_stats_dict[op_type]
+            if isinstance(item, str):
                 actual_value = _extract_op_call(op_stats_dict[op_type], 1)
             else:
                 actual_value = op_stats_dict[op_type].bf16_calls

--- a/test/amp/test_pir_amp.py
+++ b/test/amp/test_pir_amp.py
@@ -95,7 +95,7 @@ class TestPirAMPProgram(unittest.TestCase):
             np.testing.assert_equal(len(_white_list), 0)
             np.testing.assert_equal(len(_black_list), 0)
 
-    def test_linear_amp_o2_without_scaler(self):  #
+    def test_linear_amp_o2_without_scaler(self):
         if not core.is_compiled_with_cuda():
             return
         with paddle.pir_utils.IrGuard():

--- a/test/amp/test_pir_amp.py
+++ b/test/amp/test_pir_amp.py
@@ -95,7 +95,7 @@ class TestPirAMPProgram(unittest.TestCase):
             np.testing.assert_equal(len(_white_list), 0)
             np.testing.assert_equal(len(_black_list), 0)
 
-    def test_linear_amp_o2_without_scaler(self):
+    def test_linear_amp_o2_without_scaler(self):  #
         if not core.is_compiled_with_cuda():
             return
         with paddle.pir_utils.IrGuard():


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
在未确认 `op_type` 是否存在于 `op_stats_dict` 的情况下直接访问其值，若缺失则引发 `KeyError`，应改为安全访问方式如 `.get()` 或先判断是否存在。这样会避免测试中断并报告问题