### PR TITLE
[Bug Fix]LayerNorm2D 构造函数参数未正确解包

### DIFF
--- a/test/amp/test_amp_decorate.py
+++ b/test/amp/test_amp_decorate.py
@@ -80,7 +80,7 @@ class Model(paddle.nn.Layer):
 
 class LayerNorm2D(paddle.nn.LayerNorm):
     def __init__(self, *args, **kwargs):
-        super().__init__(args, *kwargs)
+        super().__init__(*args, **kwargs)
 
     def forward(self, x):
         x = x.transpose([0, 2, 3, 1])


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
`super().__init__(args, *kwargs)` 中，`args` 是一个元组，但 `paddle.nn.LayerNorm` 的构造函数期望第一个参数为 `normalized_shape`（如 int 或 list），而此处将整个 `*args` 打包成一个元组又未正确解包，导致实际传入的是 `(args,)`，即嵌套元组，造成维度不匹配或类型错误。