### PR TITLE
[Bug Fix]错误使用 add_called 数组统计 conv_num 导致逻辑错误

### DIFF
--- a/test/amp/test_collect_operator_stats.py
+++ b/test/amp/test_collect_operator_stats.py
@@ -87,7 +87,7 @@ class TestOpStatsPir(unittest.TestCase):
         conv_num = 0
         for i in range(4):
             add_num += int(add_called[i])
-            conv_num += int(add_called[i])
+            conv_num += int(conv2d_called[i])
 
         self.assertTrue(conv_num == 1)
         self.assertTrue(add_num == 1)

--- a/test/amp/test_pir_amp.py
+++ b/test/amp/test_pir_amp.py
@@ -95,7 +95,6 @@ class TestPirAMPProgram(unittest.TestCase):
             np.testing.assert_equal(len(_white_list), 0)
             np.testing.assert_equal(len(_black_list), 0)
 
-    #
     def test_linear_amp_o2_without_scaler(self):
         if not core.is_compiled_with_cuda():
             return

--- a/test/amp/test_pir_amp.py
+++ b/test/amp/test_pir_amp.py
@@ -95,6 +95,7 @@ class TestPirAMPProgram(unittest.TestCase):
             np.testing.assert_equal(len(_white_list), 0)
             np.testing.assert_equal(len(_black_list), 0)
 
+    #
     def test_linear_amp_o2_without_scaler(self):
         if not core.is_compiled_with_cuda():
             return


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
代码将 `conv_num` 累加 `add_called[i]` 的值，但 `add_called` 是 `pd_op.add` 的调用记录，而 `conv_num` 应该统计的是 `pd_op.conv2d` 的调用次数，此处明显误用了变量，应使用 `conv2d_called[i]`。