### PR TITLE
[Bug Fix]minimize未在auto_cast上下文中执行

### DIFF
--- a/test/amp/test_pir_amp.py
+++ b/test/amp/test_pir_amp.py
@@ -120,7 +120,7 @@ class TestPirAMPProgram(unittest.TestCase):
                 ):
                     out = linear(x)
                     loss = paddle.mean(out)
-                optimizer.minimize(loss)
+                    optimizer.minimize(loss)
             cast_op_count = 0
             for op in main.global_block().ops:
                 if op.name() == 'pd_op.cast':
@@ -208,7 +208,7 @@ class TestPirAMPProgram(unittest.TestCase):
                 ):
                     out = linear(x)
                     loss = paddle.mean(out)
-                optimizer.minimize(loss)
+                    optimizer.minimize(loss)
             cast_op_count = 0
             for op in main.global_block().ops:
                 if op.name() == 'pd_op.cast':


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
`minimize` 包含反向传播和参数更新，应在 `auto_cast` 上下文中执行以确保 FP16/BF16 类型转换正确应用，否则可能丢失精度优势或引发类型错误。