### PR TITLE
replace TRT_PLUGIN_FP16_AVAILABLE with PADDLE_WITH_CUDA in test_tracer

### DIFF
--- a/test/cpp/inference/api/trt_dynamic_shape_ernie_test.cc
+++ b/test/cpp/inference/api/trt_dynamic_shape_ernie_test.cc
@@ -148,7 +148,7 @@ TEST(AnalysisPredictor, no_fp16) {
 }
 
 TEST(AnalysisPredictor, fp16) {
-#ifdef TRT_PLUGIN_FP16_AVAILABLE
+#ifdef PADDLE_WITH_CUDA
   std::vector<float> result = {0.598, 0.219, 0.182};
   trt_ernie(true, result, 4e-3);
 #endif
@@ -161,7 +161,7 @@ TEST(AnalysisPredictor, no_fp16_bs2) {
 }
 
 TEST(AnalysisPredictor, fp16_bs2) {
-#ifdef TRT_PLUGIN_FP16_AVAILABLE
+#ifdef PADDLE_WITH_CUDA
   std::vector<float> result = {0.598, 0.219, 0.182, 0.598, 0.219, 0.182};
   trt_ernie(true, result, 4e-3, 2);
 #endif


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience

### PR Types
Others 

### Description
<!-- Describe what you’ve done -->
 test_tracer 使用PADDLE_WITH_CUDA 替换TRT_PLUGIN_FP16_AVAILABLE，逐步移除 TRT_PLUGIN_FP16_AVAILABLE
TRT_PLUGIN_FP16_AVAILABLE 是用于判断CUDA 是否为10版本，当前CUDA版本为10以上
cmake/cuda.cmake
<img width="508" height="80" alt="image" src="https://github.com/user-attachments/assets/0e61100e-526a-412a-9ef1-81c45c583e02" />
