### PR TITLE
[Precision Depth Alignment] Fix paddle.nn.functional.affine_grid forward and backward gradient calculation

### DIFF
--- a/paddle/phi/kernels/funcs/affine_grid_utils.cu
+++ b/paddle/phi/kernels/funcs/affine_grid_utils.cu
@@ -1,0 +1,168 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "paddle/phi/kernels/funcs/affine_grid_utils.h"
+
+#include "paddle/phi/backends/gpu/gpu_context.h"
+#include "paddle/phi/backends/gpu/gpu_device_function.h"
+#include "paddle/phi/backends/gpu/gpu_launch_config.h"
+#include "paddle/phi/backends/gpu/gpu_primitives.h"
+
+namespace phi {
+namespace funcs {
+
+template <typename T>
+__global__ void CreateBaseGridKernel_4D(
+    T* base_grid_data, int64_t n, int64_t h, int64_t w, bool align_corners) {
+  int64_t total_elements = n * h * w;
+  CUDA_KERNEL_LOOP(idx, total_elements) {
+    int64_t w_idx = idx % w;
+    int64_t h_idx = (idx / w) % h;
+    int64_t n_idx = idx / (h * w);
+
+    int64_t grid_idx = n_idx * h * w + h_idx * w + w_idx;
+
+    T x, y;
+    T start_data = static_cast<T>(-1);
+    T stop_data = static_cast<T>(1);
+
+    if (w > 1) {
+      T step = (stop_data - start_data) / (w - 1);
+      int64_t w_half = w / 2;
+      if (w_idx < w_half) {
+        x = static_cast<T>(start_data + step * w_idx);
+      } else {
+        x = static_cast<T>(stop_data - step * (w - w_idx - 1));
+      }
+      if (!align_corners) {
+        x = (x * static_cast<T>(w - 1)) *
+            (static_cast<T>(1) / static_cast<T>(w));
+      }
+    } else {
+      x = static_cast<T>(0);
+    }
+
+    if (h > 1) {
+      T step = (stop_data - start_data) / (h - 1);
+      int64_t h_half = h / 2;
+      if (h_idx < h_half) {
+        y = static_cast<T>(start_data + step * h_idx);
+      } else {
+        y = static_cast<T>(stop_data - step * (h - h_idx - 1));
+      }
+      if (!align_corners) {
+        y = (y * static_cast<T>(h - 1)) *
+            (static_cast<T>(1) / static_cast<T>(h));
+      }
+    } else {
+      y = static_cast<T>(0);
+    }
+
+    base_grid_data[grid_idx * 3 + 0] = x;
+    base_grid_data[grid_idx * 3 + 1] = y;
+    base_grid_data[grid_idx * 3 + 2] = static_cast<T>(1);
+  }
+}
+
+template <typename T>
+__global__ void CreateBaseGridKernel_5D(T* base_grid_data,
+                                        int64_t n,
+                                        int64_t d,
+                                        int64_t h,
+                                        int64_t w,
+                                        bool align_corners) {
+  int64_t total_elements = n * d * h * w;
+  CUDA_KERNEL_LOOP(idx, total_elements) {
+    int64_t w_idx = idx % w;
+    int64_t h_idx = (idx / w) % h;
+    int64_t d_idx = (idx / (w * h)) % d;
+    int64_t n_idx = idx / (d * h * w);
+
+    int64_t grid_idx = n_idx * d * h * w + d_idx * h * w + h_idx * w + w_idx;
+
+    T x, y, z;
+    T start_data = static_cast<T>(-1);
+    T stop_data = static_cast<T>(1);
+
+    // X coordinate (W dimension)
+    if (w > 1) {
+      T step = (stop_data - start_data) / (w - 1);
+      int64_t w_half = w / 2;
+      if (w_idx < w_half) {
+        x = static_cast<T>(start_data + step * w_idx);
+      } else {
+        x = static_cast<T>(stop_data - step * (w - w_idx - 1));
+      }
+      if (!align_corners) {
+        x = (x * static_cast<T>(w - 1)) *
+            (static_cast<T>(1) / static_cast<T>(w));
+      }
+    } else {
+      x = static_cast<T>(0);
+    }
+
+    // Y coordinate (H dimension)
+    if (h > 1) {
+      T step = (stop_data - start_data) / (h - 1);
+      int64_t h_half = h / 2;
+      if (h_idx < h_half) {
+        y = static_cast<T>(start_data + step * h_idx);
+      } else {
+        y = static_cast<T>(stop_data - step * (h - h_idx - 1));
+      }
+      if (!align_corners) {
+        y = (y * static_cast<T>(h - 1)) *
+            (static_cast<T>(1) / static_cast<T>(h));
+      }
+    } else {
+      y = static_cast<T>(0);
+    }
+
+    // Z coordinate (D dimension)
+    if (d > 1) {
+      T step = (stop_data - start_data) / (d - 1);
+      int64_t d_half = d / 2;
+      if (d_idx < d_half) {
+        z = static_cast<T>(start_data + step * d_idx);
+      } else {
+        z = static_cast<T>(stop_data - step * (d - d_idx - 1));
+      }
+      if (!align_corners) {
+        z = (z * static_cast<T>(d - 1)) *
+            (static_cast<T>(1) / static_cast<T>(d));
+      }
+    } else {
+      z = static_cast<T>(0);
+    }
+
+    base_grid_data[grid_idx * 4 + 0] = x;
+    base_grid_data[grid_idx * 4 + 1] = y;
+    base_grid_data[grid_idx * 4 + 2] = z;
+    base_grid_data[grid_idx * 4 + 3] = static_cast<T>(1);
+  }
+}
+
+template __global__ void CreateBaseGridKernel_4D<float>(
+    float*, int64_t, int64_t, int64_t, bool);
+template __global__ void CreateBaseGridKernel_4D<double>(
+    double*, int64_t, int64_t, int64_t, bool);
+
+template __global__ void CreateBaseGridKernel_5D<float>(
+    float*, int64_t, int64_t, int64_t, int64_t, bool);
+template __global__ void CreateBaseGridKernel_5D<double>(
+    double*, int64_t, int64_t, int64_t, int64_t, bool);
+}  // namespace funcs
+}  // namespace phi

--- a/paddle/phi/kernels/funcs/affine_grid_utils.h
+++ b/paddle/phi/kernels/funcs/affine_grid_utils.h
@@ -183,7 +183,7 @@ inline void GetIdxMap5D(int n,
 }
 
 namespace funcs {
-#if defined(PADDLE_WITH_CUDA)
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
 template <typename T>
 __global__ void CreateBaseGridKernel_4D(
     T* base_grid_data, int64_t n, int64_t h, int64_t w, bool align_corners);

--- a/paddle/phi/kernels/funcs/affine_grid_utils.h
+++ b/paddle/phi/kernels/funcs/affine_grid_utils.h
@@ -182,4 +182,19 @@ inline void GetIdxMap5D(int n,
                              .broadcast(Array5(n, 1, 1, 1, 1));
 }
 
+namespace funcs {
+#if defined(PADDLE_WITH_CUDA)
+template <typename T>
+__global__ void CreateBaseGridKernel_4D(
+    T* base_grid_data, int64_t n, int64_t h, int64_t w, bool align_corners);
+template <typename T>
+__global__ void CreateBaseGridKernel_5D(T* base_grid_data,
+                                        int64_t n,
+                                        int64_t d,
+                                        int64_t h,
+                                        int64_t w,
+                                        bool align_corners);
+#endif
+}  // namespace funcs
+
 }  // namespace phi

--- a/paddle/phi/kernels/gpu/affine_grid_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/affine_grid_grad_kernel.cu
@@ -23,115 +23,12 @@
 #include "paddle/phi/backends/gpu/gpu_primitives.h"
 #include "paddle/phi/common/int_array.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/bmm_kernel.h"
+#include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/funcs/affine_grid_utils.h"
+#include "paddle/phi/kernels/transpose_kernel.h"
 
 namespace phi {
-
-template <typename T>
-__global__ void LinspaceKernel(T start, T step, int64_t size, T* out) {
-  CUDA_KERNEL_LOOP_TYPE(index, size, int64_t) {
-    out[index] = start + step * index;
-  }
-}
-
-template <typename T>
-struct Linspace<phi::GPUContext, T> {
-  void operator()(T start,
-                  T end,
-                  int count,
-                  bool align_corners,
-                  DenseTensor* numbers,
-                  const phi::GPUContext& dev_ctx) {
-    numbers->Resize(common::make_ddim({count}));
-    T* number_data = dev_ctx.template Alloc<T>(numbers);
-    T slice = (end - start) / (T)(count - 1);
-    if (!align_corners) {
-      slice = (end - start) / (T)count;
-      start *= (T)(count - 1) / (T)count;
-    }
-    auto stream = dev_ctx.stream();
-    int block = 512;
-    int grid = (count + block - 1) / block;
-    LinspaceKernel<T>
-        <<<grid, block, 0, stream>>>(start, slice, count, number_data);
-  }
-};
-
-template <typename T>
-__global__ void affine_grid_grad_kernel_4d(const int64_t count,
-                                           int n,
-                                           int out_h,
-                                           int out_w,
-                                           T h_start,
-                                           T w_start,
-                                           T h_step,
-                                           T w_step,
-                                           const T* out_grad,  // N, H, W, 2
-                                           T* theta_grad) {    // N, 2, 3
-  CUDA_KERNEL_LOOP_TYPE(index, count, int64_t) {
-    int w = index % out_w;
-    int h = (index / out_w) % out_h;
-    int n = index / (out_w * out_h);
-    T h_coor = h_step * static_cast<T>(h) + static_cast<T>(h_start);
-    T w_coor = w_step * static_cast<T>(w) + static_cast<T>(w_start);
-
-    int theta_offset = n * 6;  // 2 * 3;
-    T out_grad_x = out_grad[index * 2];
-    phi::CudaAtomicAdd(theta_grad + theta_offset, out_grad_x * w_coor);
-    phi::CudaAtomicAdd(theta_grad + theta_offset + 1, out_grad_x * h_coor);
-    phi::CudaAtomicAdd(theta_grad + theta_offset + 2, out_grad_x);
-
-    T out_grad_y = out_grad[index * 2 + 1];
-    phi::CudaAtomicAdd(theta_grad + theta_offset + 3, out_grad_y * w_coor);
-    phi::CudaAtomicAdd(theta_grad + theta_offset + 4, out_grad_y * h_coor);
-    phi::CudaAtomicAdd(theta_grad + theta_offset + 5, out_grad_y);
-  }
-}
-
-template <typename T>
-__global__ void affine_grid_grad_kernel_5d(const int64_t count,
-                                           int n,
-                                           int out_d,
-                                           int out_h,
-                                           int out_w,
-                                           T d_start,
-                                           T h_start,
-                                           T w_start,
-                                           T d_step,
-                                           T h_step,
-                                           T w_step,
-                                           const T* out_grad,  // N, D, H, W, 3
-                                           T* theta_grad) {    // N, 3, 4
-  CUDA_KERNEL_LOOP_TYPE(index, count, int64_t) {
-    int w = index % out_w;
-    int h = (index / out_w) % out_h;
-    int d = (index / (out_w * out_h)) % out_d;
-    int n = index / (out_w * out_h * out_d);
-
-    T d_coor = d_step * static_cast<T>(d) + static_cast<T>(d_start);
-    T h_coor = h_step * static_cast<T>(h) + static_cast<T>(h_start);
-    T w_coor = w_step * static_cast<T>(w) + static_cast<T>(w_start);
-
-    int theta_offset = n * 12;  // 3 * 4;
-    T out_grad_x = out_grad[index * 3];
-    phi::CudaAtomicAdd(theta_grad + theta_offset, out_grad_x * w_coor);
-    phi::CudaAtomicAdd(theta_grad + theta_offset + 1, out_grad_x * h_coor);
-    phi::CudaAtomicAdd(theta_grad + theta_offset + 2, out_grad_x * d_coor);
-    phi::CudaAtomicAdd(theta_grad + theta_offset + 3, out_grad_x);
-
-    T out_grad_y = out_grad[index * 3 + 1];
-    phi::CudaAtomicAdd(theta_grad + theta_offset + 4, out_grad_y * w_coor);
-    phi::CudaAtomicAdd(theta_grad + theta_offset + 5, out_grad_y * h_coor);
-    phi::CudaAtomicAdd(theta_grad + theta_offset + 6, out_grad_y * d_coor);
-    phi::CudaAtomicAdd(theta_grad + theta_offset + 7, out_grad_y);
-
-    T out_grad_z = out_grad[index * 3 + 2];
-    phi::CudaAtomicAdd(theta_grad + theta_offset + 8, out_grad_z * w_coor);
-    phi::CudaAtomicAdd(theta_grad + theta_offset + 9, out_grad_z * h_coor);
-    phi::CudaAtomicAdd(theta_grad + theta_offset + 10, out_grad_z * d_coor);
-    phi::CudaAtomicAdd(theta_grad + theta_offset + 11, out_grad_z);
-  }
-}
 
 template <typename T, typename Context>
 void AffineGridGrad4DCUDAKernel(const Context& dev_ctx,
@@ -139,51 +36,64 @@ void AffineGridGrad4DCUDAKernel(const Context& dev_ctx,
                                 const IntArray& outputShape,
                                 bool align_corners,
                                 DenseTensor* input_grad) {
-  auto& theta_grad = input_grad;
-  int n = output_grad.dims()[0];
-  auto& size_attr = outputShape.GetData();
-  int h = 0;
-  int w = 0;
-  h = size_attr[2];
-  w = size_attr[3];
-  theta_grad->Resize(common::make_ddim({n, 2, 3}));
-  T* theta_grad_data = dev_ctx.template Alloc<T>(theta_grad);
-  phi::funcs::SetConstant<phi::GPUContext, T>()(
-      dev_ctx, theta_grad, static_cast<T>(0));
+  // The shape of the output grad is [N, H, W, 2]
+  auto grad_grid_dims = output_grad.dims();
+  int64_t n = grad_grid_dims[0];
+  int64_t h = grad_grid_dims[1];
+  int64_t w = grad_grid_dims[2];
 
-  T h_step;
-  T w_step;
-  T h_start = -1;
-  T w_start = -1;
-  if (align_corners) {
-    h_step = static_cast<T>(2) / static_cast<T>(h - 1);
-    w_step = static_cast<T>(2) / static_cast<T>(w - 1);
-  } else {
-    h_step = static_cast<T>(2) / static_cast<T>(h);
-    w_step = static_cast<T>(2) / static_cast<T>(w);
+  // The shape of input_grad (theta gradient) should be [N, 2, 3]
+  input_grad->Resize(common::make_ddim({n, 2, 3}));
+  T* grad_theta_data = dev_ctx.template Alloc<T>(input_grad);
 
-    h_start *= static_cast<T>(h - 1) / static_cast<T>(h);
-    w_start *= static_cast<T>(w - 1) / static_cast<T>(w);
+  if (output_grad.numel() == 0) {
+    phi::Full<T, Context>(dev_ctx,
+                          phi::IntArray(common::vectorize(input_grad->dims())),
+                          0,
+                          input_grad);
+    return;
   }
-  const int64_t count = n * h * w;
-  VLOG(3) << "count: " << count << "; h_step: " << h_step
-          << "; w_step: " << w_step << "; h_start: " << h_start
-          << "; w_start: " << w_start;
-  int block = 512;
-  int64_t max_grid = dev_ctx.GetCUDAMaxGridDimSize()[0];
-  int grid = std::min((count + block - 1) / block, max_grid);
-  auto cu_stream = dev_ctx.stream();
-  affine_grid_grad_kernel_4d<<<grid, block, 0, cu_stream>>>(
-      count,
-      n,
-      h,
-      w,
-      h_start,
-      w_start,
-      h_step,
-      w_step,
-      output_grad.data<T>(),
-      theta_grad_data);
+
+  // 1. Directly create the basic grid using the same kernel as the forward
+  // direction
+  DenseTensor base_grid;
+  base_grid.Resize(common::make_ddim({n, h, w, 3}));
+  T* base_grid_data = dev_ctx.template Alloc<T>(&base_grid);
+
+  int64_t total_elements = n * h * w;
+  auto stream = dev_ctx.stream();
+  int64_t block_size = 512;
+  int64_t grid_size = (total_elements + block_size - 1) / block_size;
+
+  phi::funcs::CreateBaseGridKernel_4D<T><<<grid_size, block_size, 0, stream>>>(
+      base_grid_data, n, h, w, align_corners);
+
+  // 2. Reshaping base_grid to [N, H * W, 3]
+  DenseTensor base_grid_reshaped;
+  base_grid_reshaped.ShareDataWith(base_grid);
+  base_grid_reshaped.Resize(common::make_ddim({n, h * w, 3}));
+
+  // 3. Transposition base_grid: [N, H * W, 3] ->[N, 3, H * W]
+  DenseTensor base_grid_transposed;
+  base_grid_transposed.Resize(common::make_ddim({n, 3, h * w}));
+  phi::TransposeKernel<T, Context>(
+      dev_ctx, base_grid_reshaped, {0, 2, 1}, &base_grid_transposed);
+
+  // 4. Reshaping Output_grad to [N, H * W, 2]
+  DenseTensor grad_grid_reshaped;
+  grad_grid_reshaped.ShareDataWith(output_grad);
+  grad_grid_reshaped.Resize(common::make_ddim({n, h * w, 2}));
+
+  // 5. Batch matrix multiplication: [N, 3, H * W] x [N, H * W, 2]=[N, 3, 2]
+  DenseTensor grad_theta_temp;
+  grad_theta_temp.Resize(common::make_ddim({n, 3, 2}));
+
+  phi::BmmKernel<T, Context>(
+      dev_ctx, base_grid_transposed, grad_grid_reshaped, &grad_theta_temp);
+
+  // 6. Transposition yields the final result: [N, 3, 2] ->[N, 2, 3]
+  phi::TransposeKernel<T, Context>(
+      dev_ctx, grad_theta_temp, {0, 2, 1}, input_grad);
 }
 
 template <typename T, typename Context>
@@ -192,58 +102,66 @@ void AffineGridGrad5DCUDAKernel(const Context& dev_ctx,
                                 const IntArray& outputShape,
                                 bool align_corners,
                                 DenseTensor* input_grad) {
-  // VLOG(0) << "in affine grid backward 5D";
-  auto& theta_grad = input_grad;
-  int n = output_grad.dims()[0];
-  auto& size_attr = outputShape.GetData();
-  int d = 0;
-  int h = 0;
-  int w = 0;
-  d = size_attr[2];
-  h = size_attr[3];
-  w = size_attr[4];
-  theta_grad->Resize(common::make_ddim({n, 3, 4}));
-  T* theta_grad_data = dev_ctx.template Alloc<T>(theta_grad);
-  phi::funcs::SetConstant<phi::GPUContext, T>()(
-      dev_ctx, theta_grad, static_cast<T>(0));
+  // The shape of the output grad is [N, D, H, W, 3]
+  auto grad_grid_dims = output_grad.dims();
+  int64_t n = grad_grid_dims[0];
+  int64_t d = grad_grid_dims[1];
+  int64_t h = grad_grid_dims[2];
+  int64_t w = grad_grid_dims[3];
 
-  T d_step;
-  T h_step;
-  T w_step;
-  T d_start = -1;
-  T h_start = -1;
-  T w_start = -1;
-  if (align_corners) {
-    d_step = static_cast<T>(2) / static_cast<T>(d - 1);
-    h_step = static_cast<T>(2) / static_cast<T>(h - 1);
-    w_step = static_cast<T>(2) / static_cast<T>(w - 1);
-  } else {
-    d_step = static_cast<T>(2) / static_cast<T>(d);
-    h_step = static_cast<T>(2) / static_cast<T>(h);
-    w_step = static_cast<T>(2) / static_cast<T>(w);
+  // The shape of input_grad (theta gradient) should be [N, 3, 4]
+  input_grad->Resize(common::make_ddim({n, 3, 4}));
+  T* grad_theta_data = dev_ctx.template Alloc<T>(input_grad);
 
-    d_start *= static_cast<T>(d - 1) / static_cast<T>(d);
-    h_start *= static_cast<T>(h - 1) / static_cast<T>(h);
-    w_start *= static_cast<T>(w - 1) / static_cast<T>(w);
+  if (output_grad.numel() == 0) {
+    phi::Full<T, Context>(dev_ctx,
+                          phi::IntArray(common::vectorize(input_grad->dims())),
+                          0,
+                          input_grad);
+    return;
   }
-  const int count = n * d * h * w;
-  int block = 512;
-  int grid = (count + block - 1) / block;
-  auto cu_stream = dev_ctx.stream();
-  affine_grid_grad_kernel_5d<<<grid, block, 0, cu_stream>>>(
-      count,
-      n,
-      d,
-      h,
-      w,
-      d_start,
-      h_start,
-      w_start,
-      d_step,
-      h_step,
-      w_step,
-      output_grad.data<T>(),
-      theta_grad_data);
+
+  // 1. Directly create the basic grid using the same kernel as the forward
+  // direction
+  DenseTensor base_grid;
+  base_grid.Resize(common::make_ddim({n, d, h, w, 4}));
+  T* base_grid_data = dev_ctx.template Alloc<T>(&base_grid);
+
+  int64_t total_elements = n * d * h * w;
+  auto stream = dev_ctx.stream();
+  int64_t block_size = 512;
+  int64_t grid_size = (total_elements + block_size - 1) / block_size;
+
+  phi::funcs::CreateBaseGridKernel_5D<T><<<grid_size, block_size, 0, stream>>>(
+      base_grid_data, n, d, h, w, align_corners);
+
+  // 2. Reshaping base_grid to [N, D * H * W, 4]
+  DenseTensor base_grid_reshaped;
+  base_grid_reshaped.ShareDataWith(base_grid);
+  base_grid_reshaped.Resize(common::make_ddim({n, d * h * w, 4}));
+
+  // 3. 转置 base_grid:[N，D*H*W，4]->[N，4，D*H*W]
+  DenseTensor base_grid_transposed;
+  base_grid_transposed.Resize(common::make_ddim({n, 4, d * h * w}));
+  phi::TransposeKernel<T, Context>(
+      dev_ctx, base_grid_reshaped, {0, 2, 1}, &base_grid_transposed);
+
+  // 4. Reshaping Output_grad to [N, D * H * W, 3]
+  DenseTensor grad_grid_reshaped;
+  grad_grid_reshaped.ShareDataWith(output_grad);
+  grad_grid_reshaped.Resize(common::make_ddim({n, d * h * w, 3}));
+
+  // 5. Batch matrix multiplication: [N, 4, D * H * W] x [N, D * H * W, 3]=[N,
+  // 4, 3]
+  DenseTensor grad_theta_temp;
+  grad_theta_temp.Resize(common::make_ddim({n, 4, 3}));
+
+  phi::BmmKernel<T, Context>(
+      dev_ctx, base_grid_transposed, grad_grid_reshaped, &grad_theta_temp);
+
+  // 6. Transposition yields the final result: [N, 4, 3] ->[N, 3, 4]
+  phi::TransposeKernel<T, Context>(
+      dev_ctx, grad_theta_temp, {0, 2, 1}, input_grad);
 }
 
 template <typename T, typename Context>

--- a/paddle/phi/kernels/gpu/affine_grid_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/affine_grid_grad_kernel.cu
@@ -140,7 +140,7 @@ void AffineGridGrad5DCUDAKernel(const Context& dev_ctx,
   base_grid_reshaped.ShareDataWith(base_grid);
   base_grid_reshaped.Resize(common::make_ddim({n, d * h * w, 4}));
 
-  // 3. 转置 base_grid:[N，D*H*W，4]->[N，4，D*H*W]
+  // 3. Transpose base_grid:[N，D*H*W，4]->[N，4，D*H*W]
   DenseTensor base_grid_transposed;
   base_grid_transposed.Resize(common::make_ddim({n, 4, d * h * w}));
   phi::TransposeKernel<T, Context>(

--- a/paddle/phi/kernels/gpu/affine_grid_kernel.cu
+++ b/paddle/phi/kernels/gpu/affine_grid_kernel.cu
@@ -41,9 +41,8 @@ void AffineGrid4DCUDAKernel(const Context& dev_ctx,
   int64_t h = size_attr[2];
   int64_t w = size_attr[3];
 
-  output->Resize(common::make_ddim({n, h, w, 2}));
-  T* out_data = dev_ctx.template Alloc<T>(output);
   if (input.numel() == 0) {
+    output->Resize(common::make_ddim({n, h, w, 2}));
     phi::Full<T, Context>(
         dev_ctx, phi::IntArray(common::vectorize(output->dims())), 0, output);
     return;
@@ -73,7 +72,14 @@ void AffineGrid4DCUDAKernel(const Context& dev_ctx,
   phi::TransposeKernel<T, Context>(
       dev_ctx, input, {0, 2, 1}, &theta_transposed);
 
-  phi::BmmKernel<T, Context>(dev_ctx, base_grid_new, theta_transposed, output);
+  DenseTensor grid_flat;
+  grid_flat.Resize(common::make_ddim({n, h * w, 2}));
+  phi::BmmKernel<T, Context>(
+      dev_ctx, base_grid_new, theta_transposed, &grid_flat);
+
+  // Reshaping Output
+  output->ShareDataWith(grid_flat);
+  output->Resize(common::make_ddim({n, h, w, 2}));
 }
 
 template <typename T, typename Context>
@@ -89,9 +95,8 @@ void AffineGrid5DCUDAKernel(const Context& dev_ctx,
   int64_t h = size_attr[3];  // height
   int64_t w = size_attr[4];  // width
 
-  output->Resize(common::make_ddim({n, d, h, w, 3}));
-  T* out_data = dev_ctx.template Alloc<T>(output);
   if (input.numel() == 0) {
+    output->Resize(common::make_ddim({n, d, h, w, 3}));
     phi::Full<T, Context>(
         dev_ctx, phi::IntArray(common::vectorize(output->dims())), 0, output);
     return;
@@ -122,7 +127,14 @@ void AffineGrid5DCUDAKernel(const Context& dev_ctx,
       dev_ctx, input, {0, 2, 1}, &theta_transposed);
 
   // Perform batch matrix multiplication
-  phi::BmmKernel<T, Context>(dev_ctx, base_grid_new, theta_transposed, output);
+  DenseTensor grid_flat;
+  grid_flat.Resize(common::make_ddim({n, d * h * w, 3}));
+  phi::BmmKernel<T, Context>(
+      dev_ctx, base_grid_new, theta_transposed, &grid_flat);
+
+  // Reshaping Output
+  output->ShareDataWith(grid_flat);
+  output->Resize(common::make_ddim({n, d, h, w, 3}));
 }
 
 template <typename T, typename Context>

--- a/paddle/phi/kernels/gpu/affine_grid_kernel.cu
+++ b/paddle/phi/kernels/gpu/affine_grid_kernel.cu
@@ -22,106 +22,12 @@
 #include "paddle/phi/backends/gpu/gpu_primitives.h"
 #include "paddle/phi/common/int_array.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/bmm_kernel.h"
 #include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/funcs/affine_grid_utils.h"
+#include "paddle/phi/kernels/transpose_kernel.h"
 
 namespace phi {
-
-template <typename T>
-__global__ void LinspaceKernel(T start, T step, int64_t size, T* out) {
-  CUDA_KERNEL_LOOP(index, size) { out[index] = start + step * index; }
-}
-
-template <typename T>
-struct Linspace<phi::GPUContext, T> {
-  void operator()(T start,
-                  T end,
-                  int count,
-                  bool align_corners,
-                  DenseTensor* numbers,
-                  const phi::GPUContext& dev_ctx) {
-    numbers->Resize(common::make_ddim({count}));
-    T* number_data = dev_ctx.template Alloc<T>(numbers);
-    T slice = (end - start) / (T)(count - 1);
-    if (!align_corners) {
-      slice = (end - start) / (T)count;
-      start *= (T)(count - 1) / (T)count;
-    }
-    auto stream = dev_ctx.stream();
-    int block = 512;
-    int grid = (count + block - 1) / block;
-    LinspaceKernel<T>
-        <<<grid, block, 0, stream>>>(start, slice, count, number_data);
-  }
-};
-
-template <typename T>
-__global__ void affine_grid_kernel_4d(const int count,
-                                      int n,
-                                      int out_h,
-                                      int out_w,
-                                      T h_start,
-                                      T w_start,
-                                      T h_step,
-                                      T w_step,
-                                      const T* theta,  // N, 2, 3
-                                      T* output) {
-  CUDA_KERNEL_LOOP(index, count) {
-    int w = index % out_w;
-    int h = (index / out_w) % out_h;
-    int n = index / (out_w * out_h);
-
-    T h_coor = h_step * static_cast<T>(h) + static_cast<T>(h_start);
-    T w_coor = w_step * static_cast<T>(w) + static_cast<T>(w_start);
-
-    int theta_offset = n * 6;  // 2 * 3;
-    // affine from (h_coor, w_coor) to (x, y)
-    output[index * 2] = theta[theta_offset] * w_coor +
-                        theta[theta_offset + 1] * h_coor +
-                        theta[theta_offset + 2];
-    output[index * 2 + 1] = theta[theta_offset + 3] * w_coor +
-                            theta[theta_offset + 4] * h_coor +
-                            theta[theta_offset + 5];
-  }
-}
-
-template <typename T>
-__global__ void affine_grid_kernel_5d(const int count,
-                                      int n,
-                                      int out_d,
-                                      int out_h,
-                                      int out_w,
-                                      T d_start,
-                                      T h_start,
-                                      T w_start,
-                                      T d_step,
-                                      T h_step,
-                                      T w_step,
-                                      const T* theta,  // N, 3, 4
-                                      T* output) {
-  CUDA_KERNEL_LOOP(index, count) {
-    int w = index % out_w;
-    int h = (index / out_w) % out_h;
-    int d = (index / (out_w * out_h)) % out_d;
-    int n = index / (out_w * out_h * out_d);
-
-    T d_coor = d_step * static_cast<T>(d) + static_cast<T>(d_start);
-    T h_coor = h_step * static_cast<T>(h) + static_cast<T>(h_start);
-    T w_coor = w_step * static_cast<T>(w) + static_cast<T>(w_start);
-
-    int theta_offset = n * 12;  // 3 * 4
-    // affine from (h_coor, w_coor) to (x, y)
-    output[index * 3] =
-        theta[theta_offset] * w_coor + theta[theta_offset + 1] * h_coor +
-        theta[theta_offset + 2] * d_coor + theta[theta_offset + 3];
-    output[index * 3 + 1] =
-        theta[theta_offset + 4] * w_coor + theta[theta_offset + 5] * h_coor +
-        theta[theta_offset + 6] * d_coor + theta[theta_offset + 7];
-    output[index * 3 + 2] =
-        theta[theta_offset + 8] * w_coor + theta[theta_offset + 9] * h_coor +
-        theta[theta_offset + 10] * d_coor + theta[theta_offset + 11];
-  }
-}
 
 template <typename T, typename Context>
 void AffineGrid4DCUDAKernel(const Context& dev_ctx,
@@ -129,14 +35,12 @@ void AffineGrid4DCUDAKernel(const Context& dev_ctx,
                             const IntArray& outputShape,
                             bool align_corners,
                             DenseTensor* output) {
-  // VLOG(0) << "in affine grid 4d forward";
   auto* theta = &input;
-  int n = theta->dims()[0];
+  int64_t n = theta->dims()[0];
   auto& size_attr = outputShape.GetData();
-  int h = 0;
-  int w = 0;
-  h = size_attr[2];
-  w = size_attr[3];
+  int64_t h = size_attr[2];
+  int64_t w = size_attr[3];
+
   output->Resize(common::make_ddim({n, h, w, 2}));
   T* out_data = dev_ctx.template Alloc<T>(output);
   if (input.numel() == 0) {
@@ -145,36 +49,31 @@ void AffineGrid4DCUDAKernel(const Context& dev_ctx,
     return;
   }
 
-  T h_step;
-  T w_step;
-  T h_start = -1;
-  T w_start = -1;
-  if (align_corners) {
-    h_step = static_cast<T>(2) / static_cast<T>(h - 1);
-    w_step = static_cast<T>(2) / static_cast<T>(w - 1);
-  } else {
-    h_step = static_cast<T>(2) / static_cast<T>(h);
-    w_step = static_cast<T>(2) / static_cast<T>(w);
+  // Directly create the base mesh
+  DenseTensor base_grid;
+  base_grid.Resize(common::make_ddim({n, h, w, 3}));
+  T* base_grid_data = dev_ctx.template Alloc<T>(&base_grid);
 
-    h_start *= static_cast<T>(h - 1) / static_cast<T>(h);
-    w_start *= static_cast<T>(w - 1) / static_cast<T>(w);
-  }
+  int64_t total_elements = n * h * w;
+  auto stream = dev_ctx.stream();
+  int64_t block_size = 512;
+  int64_t grid_size = (total_elements + block_size - 1) / block_size;
 
-  const int count = n * h * w;
-  int block = 512;
-  int grid = (count + block - 1) / block;
-  auto cu_stream = dev_ctx.stream();
-  affine_grid_kernel_4d<<<grid, block, 0, cu_stream>>>(
-      count,
-      n,
-      h,
-      w,
-      h_start,
-      w_start,
-      h_step,
-      w_step,
-      theta->data<T>(),  // N, 2, 3
-      out_data);
+  phi::funcs::CreateBaseGridKernel_4D<T><<<grid_size, block_size, 0, stream>>>(
+      base_grid_data, n, h, w, align_corners);
+
+  // Apply affine transformation
+  DenseTensor base_grid_new;
+  base_grid_new.ShareDataWith(base_grid);
+  base_grid_new.Resize(common::make_ddim({n, h * w, 3}));
+
+  // Transpose theta: [N, 2, 3] -> [N, 3, 2]
+  DenseTensor theta_transposed;
+  theta_transposed.Resize(common::make_ddim({n, 3, 2}));
+  phi::TransposeKernel<T, Context>(
+      dev_ctx, input, {0, 2, 1}, &theta_transposed);
+
+  phi::BmmKernel<T, Context>(dev_ctx, base_grid_new, theta_transposed, output);
 }
 
 template <typename T, typename Context>
@@ -184,14 +83,12 @@ void AffineGrid5DCUDAKernel(const Context& dev_ctx,
                             bool align_corners,
                             DenseTensor* output) {
   auto* theta = &input;
-  int n = theta->dims()[0];
+  int64_t n = theta->dims()[0];
   auto& size_attr = outputShape.GetData();
-  int d = 0;
-  int h = 0;
-  int w = 0;
-  d = size_attr[2];
-  h = size_attr[3];
-  w = size_attr[4];
+  int64_t d = size_attr[2];  // depth
+  int64_t h = size_attr[3];  // height
+  int64_t w = size_attr[4];  // width
+
   output->Resize(common::make_ddim({n, d, h, w, 3}));
   T* out_data = dev_ctx.template Alloc<T>(output);
   if (input.numel() == 0) {
@@ -200,44 +97,32 @@ void AffineGrid5DCUDAKernel(const Context& dev_ctx,
     return;
   }
 
-  T d_step;
-  T h_step;
-  T w_step;
-  T d_start = -1;
-  T h_start = -1;
-  T w_start = -1;
-  if (align_corners) {
-    d_step = static_cast<T>(2) / static_cast<T>(d - 1);
-    h_step = static_cast<T>(2) / static_cast<T>(h - 1);
-    w_step = static_cast<T>(2) / static_cast<T>(w - 1);
-  } else {
-    d_step = static_cast<T>(2) / static_cast<T>(d);
-    h_step = static_cast<T>(2) / static_cast<T>(h);
-    w_step = static_cast<T>(2) / static_cast<T>(w);
+  // Create a basic grid
+  DenseTensor base_grid;
+  base_grid.Resize(common::make_ddim({n, d, h, w, 4}));
+  T* base_grid_data = dev_ctx.template Alloc<T>(&base_grid);
 
-    d_start *= static_cast<T>(d - 1) / static_cast<T>(d);
-    h_start *= static_cast<T>(h - 1) / static_cast<T>(h);
-    w_start *= static_cast<T>(w - 1) / static_cast<T>(w);
-  }
+  int64_t total_elements = n * d * h * w;
+  auto stream = dev_ctx.stream();
+  int64_t block_size = 512;
+  int64_t grid_size = (total_elements + block_size - 1) / block_size;
 
-  const int count = n * d * h * w;
-  int block = 512;
-  int grid = (count + block - 1) / block;
-  auto cu_stream = dev_ctx.stream();
-  affine_grid_kernel_5d<<<grid, block, 0, cu_stream>>>(
-      count,
-      n,
-      d,
-      h,
-      w,
-      d_start,
-      h_start,
-      w_start,
-      d_step,
-      h_step,
-      w_step,
-      theta->data<T>(),  // N, 3, 4
-      out_data);
+  phi::funcs::CreateBaseGridKernel_5D<T><<<grid_size, block_size, 0, stream>>>(
+      base_grid_data, n, d, h, w, align_corners);
+
+  // Apply affine transformation
+  DenseTensor base_grid_new;
+  base_grid_new.ShareDataWith(base_grid);
+  base_grid_new.Resize(common::make_ddim({n, d * h * w, 4}));
+
+  // Transpose theta: [N, 3, 4] -> [N, 4, 3]
+  DenseTensor theta_transposed;
+  theta_transposed.Resize(common::make_ddim({n, 4, 3}));
+  phi::TransposeKernel<T, Context>(
+      dev_ctx, input, {0, 2, 1}, &theta_transposed);
+
+  // Perform batch matrix multiplication
+  phi::BmmKernel<T, Context>(dev_ctx, base_grid_new, theta_transposed, output);
 }
 
 template <typename T, typename Context>
@@ -247,7 +132,7 @@ void AffineGridCUDAKernel(const Context& dev_ctx,
                           bool align_corners,
                           DenseTensor* output) {
   auto* theta = &input;
-  int theta_h = theta->dims()[1];
+  int64_t theta_h = theta->dims()[1];
   if (theta_h == 2) {
     AffineGrid4DCUDAKernel<T, Context>(
         dev_ctx, input, outputShape, align_corners, output);

--- a/python/paddle/nn/functional/vision.py
+++ b/python/paddle/nn/functional/vision.py
@@ -88,17 +88,7 @@ def affine_grid(
     if not isinstance(theta, (Variable, paddle.pir.Value)):
         raise TypeError("The theta should be a Tensor.")
 
-    cudnn_version = get_cudnn_version()
-    if cudnn_version is not None and cudnn_version >= 6000 and align_corners:
-        use_cudnn = True
-    else:
-        use_cudnn = False
-    if theta.shape[1] == 3:
-        use_cudnn = False
-    if is_compiled_with_rocm():
-        use_cudnn = (
-            False  # ROCM platform do not have MIOPEN kernel for affine_grid
-        )
+    use_cudnn = False
 
     if in_dynamic_mode():
         _out_shape = (

--- a/python/paddle/nn/functional/vision.py
+++ b/python/paddle/nn/functional/vision.py
@@ -88,7 +88,22 @@ def affine_grid(
     if not isinstance(theta, (Variable, paddle.pir.Value)):
         raise TypeError("The theta should be a Tensor.")
 
-    use_cudnn = False
+    cudnn_version = get_cudnn_version()
+    if cudnn_version is not None and cudnn_version >= 6000 and align_corners:
+        use_cudnn = True
+    else:
+        use_cudnn = False
+    if theta.shape[1] == 3:
+        use_cudnn = False
+    if is_compiled_with_rocm():
+        use_cudnn = (
+            False  # ROCM platform do not have MIOPEN kernel for affine_grid
+        )
+
+    if paddle.get_flags(["FLAGS_torch_compatible_kernel"]).get(
+        "FLAGS_torch_compatible_kernel", False
+    ):
+        use_cudnn = False
 
     if in_dynamic_mode():
         _out_shape = (

--- a/test/legacy_test/test_affine_grid_op.py
+++ b/test/legacy_test/test_affine_grid_op.py
@@ -251,6 +251,26 @@ class TestAffineGridAPI_ZeroSize(unittest.TestCase):
             run(place)
 
 
+class TestAffineGridOpTorchCompatible1(TestAffineGridOp):
+    def initTestCase(self):
+        paddle.set_flags({'FLAGS_torch_compatible_kernel': 1})
+        self.theta_shape = (20, 2, 3)
+        self.output_shape = np.array([20, 2, 5, 7]).astype("int32")
+        self.dynamic_shape = True
+        self.use_cudnn = False
+        self.align_corners = True
+
+
+class TestAffineGridOpTorchCompatible2(TestAffineGridOp):
+    def initTestCase(self):
+        paddle.set_flags({'FLAGS_torch_compatible_kernel': 1})
+        self.theta_shape = (20, 3, 4)
+        self.output_shape = np.array([20, 1, 2, 5, 7]).astype("int32")
+        self.dynamic_shape = True
+        self.use_cudnn = False
+        self.align_corners = False
+
+
 if __name__ == '__main__':
     paddle.enable_static()
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features 

### Description
<!-- Describe what you’ve done -->
**修改内容：**
1. 分别对4D和5D手写了对应的cuda kernel实现，由于新增的Cuda实现性能相比之前要差，所以通过FLAGS_torch_compatible_kernel 来控制是否启用精度对齐方案，默认是关闭的；
2. 增加单元测试


**前向传播**
1. 生成基础网格：
   - 4D: 为每个(H, W)位置生成归一化坐标(x, y, 1)
   - 5D: 为每个(D, H, W)位置生成归一化坐标(x, y, z, 1)

2. 仿射变换：
   - 4D: `[N, H×W, 3] × [N, 3, 2] = [N, H×W, 2]`
   - 5D: `[N, D×H×W, 4] × [N, 4, 3] = [N, D×H×W, 3]`

**反向传播**
1. 梯度计算：
   - 4D: `[N, 3, H×W] × [N, H×W, 2] = [N, 3, 2]` → 转置为 [N, 2, 3]
   - 5D: `[N, 4, D×H×W] × [N, D×H×W, 3] = [N, 4, 3]` → 转置为 [N, 3, 4]

两者遵循相同的计算模式：生成基础网格 → 应用仿射变换 → 输出变换后的网格坐标。

**测试结果：**
1.  测试集的 paddle.nn.functional.affine_grid 的4D case 全部对齐（10个）；
4. 新增 10 个 5D的测试case全部通过（10个）；

Pcard-67164