### PR TITLE
[SOT][3.14] support `LOAD_FAST_BORROW`、`NOT_TAKEN`、`POP_ITER`、`LOAD_FAST_BORROW_LOAD_FAST_BORROW` op code

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
@@ -1001,6 +1001,11 @@ class OpcodeExecutorBase:
     def LOAD_FAST_CHECK(self, instr: Instruction):
         self.LOAD_FAST(instr)
 
+    # 3.14 opcodes
+    LOAD_FAST_BORROW = LOAD_FAST
+    NOT_TAKEN = NOP
+    POP_ITER = POP_TOP
+
     def DELETE_FAST(self, instr: Instruction):
         varname = self.vframe.code.co_varnames[instr.arg]
         del self.vframe.locals[varname]

--- a/python/paddle/jit/sot/opcode_translator/instruction_utils/instruction_utils.py
+++ b/python/paddle/jit/sot/opcode_translator/instruction_utils/instruction_utils.py
@@ -121,6 +121,10 @@ def expand_super_instrs(instructions: list[Instruction]) -> list[Instruction]:
 
     FUSED_INSTS: dict[str, tuple[str, str]] = {
         "LOAD_FAST_LOAD_FAST": ("LOAD_FAST", "LOAD_FAST"),
+        "LOAD_FAST_BORROW_LOAD_FAST_BORROW": (
+            "LOAD_FAST_BORROW",
+            "LOAD_FAST_BORROW",
+        ),
         "STORE_FAST_STORE_FAST": ("STORE_FAST", "STORE_FAST"),
         "STORE_FAST_LOAD_FAST": ("STORE_FAST", "LOAD_FAST"),
     }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->

支持 `LOAD_FAST_BORROW`、`NOT_TAKEN`、`POP_ITER`、`LOAD_FAST_BORROW_LOAD_FAST_BORROW`  字节码

通过的单测(有一些`Eval Frame`支持了就通过的也被算到这里面了)

- `test_01_basic.py`
- `test_builtin_bool.py`
- `test_envs.py`
- `test_error_handling.py`
- `test_faster_guard.py`
- `test_guard_fastpath_strategy.py`
- `test_guard_outputs.py`
- `test_guard_tree.py`
- `test_info_collect.py`
- `test_model_switch_training.py`
- `test_multiple_args.py`
- `test_mutable_data.py`
- `test_segment_linear.py`
- `test_sot_cache.py`
- `test_sot_call.py`
- `test_sot_distributed.py`
- `test_sot_stop_gradient.py`
- `test_specialization.py`
- `test_stack.py`
- `test_tensor_dtype_in_guard.py`
- `test_tensor_slice.py`
- `test_unsupported_function.py`

Link:
* https://github.com/PaddlePaddle/Paddle/pull/75853
