### PR TITLE
fix OpMetaInfoBuilder type [fluid_ops]

### DIFF
--- a/paddle/phi/api/lib/op_meta_info.cc
+++ b/paddle/phi/api/lib/op_meta_info.cc
@@ -608,7 +608,8 @@ OpMetaInfoBuilder& OpMetaInfoBuilder::Attrs(std::vector<std::string>&& attrs) {
        "std::vector<int>",
        "std::vector<float>",
        "std::vector<int64_t>",
-       "std::vector<std::string>"});
+       "std::vector<std::string>",
+       "std::vector<bool>"});
   for (const auto& attr : attrs) {
     auto attr_type_str = ParseAttrStr(attr)[1];
     if (custom_attrs_type.find(attr_type_str) == custom_attrs_type.end()) {
@@ -617,7 +618,7 @@ OpMetaInfoBuilder& OpMetaInfoBuilder::Attrs(std::vector<std::string>&& attrs) {
           "Supported data types include `bool`, `int`, `float`, `double`,  "
           "`int64_t`, `std::string`, `std::vector<int>`, "
           "`std::vector<float>`, `std::vector<int64_t>`, "
-          "`std::vector<std::string>`, "
+          "`std::vector<std::string>`, `std::vector<bool>`, "
           "Please check whether the attribute data type and "
           "data type string are matched.",
           attr_type_str));


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience

### PR Types
Others 

### Description
<!-- Describe what you’ve done -->
fix OpMetaInfoBuilder type

修复 https://github.com/PaddlePaddle/Paddle/pull/76026 中流水线 https://github.com/PaddlePaddle/Paddle/actions/runs/18774607330/job/53751996497?pr=76026 错误，增加 std::vector<bool>类型
<img width="1431" height="200" alt="image" src="https://github.com/user-attachments/assets/a4b9ee90-f440-4118-8e4c-41faa5e9a414" />


