### PR TITLE
[API Compatiblity] Support `paddle.cumprod`

### DIFF
--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -4193,15 +4193,17 @@ def logcumsumexp(
 def cumprod(
     x: Tensor,
     dim: int | None = None,
+    *,
     dtype: DTypeLike | None = None,
-    out: Tensor | None = None,
     name: str | None = None,
+    out: Tensor | None = None,
 ) -> Tensor:
     """
     Compute the cumulative product of the input tensor x along a given dimension dim.
 
-    Note:
+    .. note::
         The first element of the result is the same as the first element of the input.
+        Alias Support: The parameter name ``input`` can be used as an alias for ``x``.
 
     Args:
         x (Tensor): the input tensor need to be cumproded.
@@ -4295,13 +4297,11 @@ def cumprod(
         return out
 
 
-@param_one_alias(["x", "input"])
 @inplace_apis_in_dygraph_only
 def cumprod_(
     x: Tensor,
     dim: int | None = None,
     dtype: DTypeLike | None = None,
-    out: Tensor | None = None,
     name: str | None = None,
 ) -> Tensor:
     r"""
@@ -4318,7 +4318,7 @@ def cumprod_(
             x = cast_(x, dtype)
 
     if in_dynamic_mode():
-        return _C_ops.cumprod_(x, dim, False, False, out=out)
+        return _C_ops.cumprod_(x, dim, False, False)
 
 
 @param_two_alias(["x", "input"], ["axis", "dim"])

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -4189,10 +4189,12 @@ def logcumsumexp(
         return out
 
 
+@param_one_alias(["x", "input"])
 def cumprod(
     x: Tensor,
     dim: int | None = None,
     dtype: DTypeLike | None = None,
+    out: Tensor | None = None,
     name: str | None = None,
 ) -> Tensor:
     """
@@ -4208,6 +4210,7 @@ def cumprod(
         dtype (str|core.VarDesc.VarType|core.DataType|np.dtype, optional): The data type of the output tensor, can be bfloat16, float16, float32, float64, int32, int64,
                     complex64, complex128. If specified, the input tensor is casted to dtype before the operation is performed.
                     This is useful for preventing data type overflows. The default value is None.
+        out (Tensor|None, optional): The output tensor. Default: None.
         name (str|None, optional): Name for the operation (optional, default is None). For more information,
                     please refer to :ref:`api_guide_Name`.
 
@@ -4262,7 +4265,7 @@ def cumprod(
             x = cast(x, dtype)
 
     if in_dynamic_or_pir_mode():
-        return _C_ops.cumprod(x, dim, False, False)
+        return _C_ops.cumprod(x, dim, False, False, out=out)
     else:
         check_variable_and_dtype(
             x,
@@ -4292,11 +4295,13 @@ def cumprod(
         return out
 
 
+@param_one_alias(["x", "input"])
 @inplace_apis_in_dygraph_only
 def cumprod_(
     x: Tensor,
     dim: int | None = None,
     dtype: DTypeLike | None = None,
+    out: Tensor | None = None,
     name: str | None = None,
 ) -> Tensor:
     r"""
@@ -4313,7 +4318,7 @@ def cumprod_(
             x = cast_(x, dtype)
 
     if in_dynamic_mode():
-        return _C_ops.cumprod_(x, dim, False, False)
+        return _C_ops.cumprod_(x, dim, False, False, out=out)
 
 
 @param_two_alias(["x", "input"], ["axis", "dim"])

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -3775,9 +3775,9 @@ def cumsum(
     x: Tensor,
     axis: int | None = None,
     dtype: DTypeLike | None = None,
+    name: str | None = None,
     *,
     out: Tensor | None = None,
-    name: str | None = None,
 ) -> Tensor:
     """
     The cumulative sum of the elements along a given axis.
@@ -4195,8 +4195,8 @@ def cumprod(
     dim: int | None = None,
     *,
     dtype: DTypeLike | None = None,
-    name: str | None = None,
     out: Tensor | None = None,
+    name: str | None = None,
 ) -> Tensor:
     """
     Compute the cumulative product of the input tensor x along a given dimension dim.

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -3775,9 +3775,9 @@ def cumsum(
     x: Tensor,
     axis: int | None = None,
     dtype: DTypeLike | None = None,
-    name: str | None = None,
     *,
     out: Tensor | None = None,
+    name: str | None = None,
 ) -> Tensor:
     """
     The cumulative sum of the elements along a given axis.

--- a/test/legacy_test/test_cumprod_op.py
+++ b/test/legacy_test/test_cumprod_op.py
@@ -1170,5 +1170,73 @@ class TestCumprodAPI_WithFlatten(unittest.TestCase):
             run(place)
 
 
+class TestCumprodAPI_Compatibility(unittest.TestCase):
+    def setUp(self):
+        np.random.seed(2025)
+        self.places = ['cpu', get_device_place()]
+        self.shape = [2, 3, 4]
+        self.dtype = "float32"
+        self.init_data()
+
+    def init_data(self):
+        self.np_x = np.random.rand(*self.shape).astype(self.dtype)
+        self.dim = 1
+
+    def test_dygraph_Compatibility(self):
+        paddle.disable_static()
+        x = paddle.to_tensor(self.np_x)
+        paddle_dygraph_out = []
+        # Position args (args)
+        out1 = paddle.cumprod(x, self.dim)
+        paddle_dygraph_out.append(out1)
+        # Key words args (kwargs) for paddle
+        out2 = paddle.cumprod(x=x, dim=self.dim)
+        paddle_dygraph_out.append(out2)
+        # Key words args for torch compatibility
+        out3 = paddle.cumprod(input=x, dim=self.dim)
+        paddle_dygraph_out.append(out3)
+        # Tensor method args
+        out4 = x.cumprod(dim=self.dim)
+        paddle_dygraph_out.append(out4)
+        # Test 'out' parameter for torch compatibility
+        out5 = paddle.empty_like(x)
+        paddle.cumprod(x, dim=self.dim, out=out5)
+        paddle_dygraph_out.append(out5)
+        # Numpy reference output
+        ref_out = np.cumprod(self.np_x, axis=self.dim)
+
+        for out in paddle_dygraph_out:
+            np.testing.assert_allclose(ref_out, out.numpy(), rtol=1e-05)
+        paddle.enable_static()
+
+    def test_static_Compatibility(self):
+        paddle.enable_static()
+        main = paddle.static.Program()
+        startup = paddle.static.Program()
+        with paddle.base.program_guard(main, startup):
+            x = paddle.static.data(name="x", shape=self.shape, dtype=self.dtype)
+            # Position args (args)
+            out1 = paddle.cumprod(x, self.dim)
+            # Key words args (kwargs) for paddle
+            out2 = paddle.cumprod(x=x, dim=self.dim)
+            # Key words args for torch compatibility
+            out3 = paddle.cumprod(input=x, dim=self.dim)
+            # Tensor method args
+            out4 = x.cumprod(dim=self.dim)
+            # Numpy reference output
+            ref_out = np.cumprod(self.np_x, axis=self.dim)
+
+            fetch_list = [out1, out2, out3, out4]
+            for place in self.places:
+                exe = paddle.base.Executor(place)
+                fetches = exe.run(
+                    main,
+                    feed={"x": self.np_x},
+                    fetch_list=fetch_list,
+                )
+                for out in fetches:
+                    np.testing.assert_allclose(out, ref_out, rtol=1e-05)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

New features

### Description
<!-- Describe what you’ve done -->

Support compatibility for `paddle.cumprod` and `paddle.Tensor.cumprod` 
<img width="1007" height="295" alt="截屏2025-10-28 09 01 44" src="https://github.com/user-attachments/assets/744867f3-3477-49c3-9c88-50de5b3e89cc" />

