### PR TITLE
[Bug Fix]未显式指定参数名造成 NumPy 断言语义不明确

### DIFF
--- a/test/autograd/test_autograd_dynamic.py
+++ b/test/autograd/test_autograd_dynamic.py
@@ -329,7 +329,9 @@ class TestHessianNoBatch(unittest.TestCase):
 
         expected = expected + 1.0
         actual = H + 1.0
-        np.testing.assert_allclose(actual, expected, self.rtol, self.atol)
+        np.testing.assert_allclose(
+            actual, expected, rtol=self.rtol, atol=self.atol
+        )
 
     def func_sub(self):
         def func(x):
@@ -340,7 +342,9 @@ class TestHessianNoBatch(unittest.TestCase):
 
         expected = expected - 1.0
         actual = H - 1.0
-        np.testing.assert_allclose(actual, expected, self.rtol, self.atol)
+        np.testing.assert_allclose(
+            actual, expected, rtol=self.rtol, atol=self.atol
+        )
 
     def func_mul(self):
         def func(x):
@@ -351,7 +355,9 @@ class TestHessianNoBatch(unittest.TestCase):
 
         expected = expected * 2.0
         actual = H * 2.0
-        np.testing.assert_allclose(actual, expected, self.rtol, self.atol)
+        np.testing.assert_allclose(
+            actual, expected, rtol=self.rtol, atol=self.atol
+        )
 
     def func_div(self):
         def func(x):
@@ -362,7 +368,9 @@ class TestHessianNoBatch(unittest.TestCase):
 
         expected = expected / 2.0
         actual = H / 2.0
-        np.testing.assert_allclose(actual, expected, self.rtol, self.atol)
+        np.testing.assert_allclose(
+            actual, expected, rtol=self.rtol, atol=self.atol
+        )
 
     def func_truediv(self):
         def func(x):
@@ -373,7 +381,9 @@ class TestHessianNoBatch(unittest.TestCase):
 
         expected = expected / 2.0
         actual = H / 2.0
-        np.testing.assert_allclose(actual, expected, self.rtol, self.atol)
+        np.testing.assert_allclose(
+            actual, expected, rtol=self.rtol, atol=self.atol
+        )
 
     def func_pow(self):
         def func(x):
@@ -384,7 +394,9 @@ class TestHessianNoBatch(unittest.TestCase):
 
         expected = expected**3.0
         actual = H**3.0
-        np.testing.assert_allclose(actual, expected, self.rtol, self.atol)
+        np.testing.assert_allclose(
+            actual, expected, rtol=self.rtol, atol=self.atol
+        )
 
     def func_mod(self):
         def func(x):
@@ -395,7 +407,9 @@ class TestHessianNoBatch(unittest.TestCase):
 
         expected = expected % 1.2
         actual = H % 1.2
-        np.testing.assert_allclose(actual, expected, self.rtol, self.atol)
+        np.testing.assert_allclose(
+            actual, expected, rtol=self.rtol, atol=self.atol
+        )
 
     def func_matmul(self):
         def func(x):
@@ -406,7 +420,9 @@ class TestHessianNoBatch(unittest.TestCase):
 
         expected = expected @ expected
         actual = H @ H
-        np.testing.assert_allclose(actual, expected, self.rtol, self.atol)
+        np.testing.assert_allclose(
+            actual, expected, rtol=self.rtol, atol=self.atol
+        )
 
     def func_eq(self):
         def func(x):
@@ -417,7 +433,9 @@ class TestHessianNoBatch(unittest.TestCase):
 
         expected = expected == expected
         actual = H == H
-        np.testing.assert_allclose(actual, expected, self.rtol, self.atol)
+        np.testing.assert_allclose(
+            actual, expected, rtol=self.rtol, atol=self.atol
+        )
 
     def func_ne(self):
         def func(x):
@@ -428,7 +446,9 @@ class TestHessianNoBatch(unittest.TestCase):
 
         expected = expected != expected
         actual = H != H
-        np.testing.assert_allclose(actual, expected, self.rtol, self.atol)
+        np.testing.assert_allclose(
+            actual, expected, rtol=self.rtol, atol=self.atol
+        )
 
     def func_lt(self):
         def func(x):
@@ -439,7 +459,9 @@ class TestHessianNoBatch(unittest.TestCase):
 
         expected = expected < expected
         actual = H < H
-        np.testing.assert_allclose(actual, expected, self.rtol, self.atol)
+        np.testing.assert_allclose(
+            actual, expected, rtol=self.rtol, atol=self.atol
+        )
 
     def func_le(self):
         def func(x):
@@ -450,7 +472,9 @@ class TestHessianNoBatch(unittest.TestCase):
 
         expected = expected <= expected
         actual = H <= H
-        np.testing.assert_allclose(actual, expected, self.rtol, self.atol)
+        np.testing.assert_allclose(
+            actual, expected, rtol=self.rtol, atol=self.atol
+        )
 
     def func_gt(self):
         def func(x):
@@ -461,7 +485,9 @@ class TestHessianNoBatch(unittest.TestCase):
 
         expected = expected > expected
         actual = H > H
-        np.testing.assert_allclose(actual, expected, self.rtol, self.atol)
+        np.testing.assert_allclose(
+            actual, expected, rtol=self.rtol, atol=self.atol
+        )
 
     def func_ge(self):
         def func(x):
@@ -472,7 +498,9 @@ class TestHessianNoBatch(unittest.TestCase):
 
         expected = expected >= expected
         actual = H >= H
-        np.testing.assert_allclose(actual, expected, self.rtol, self.atol)
+        np.testing.assert_allclose(
+            actual, expected, rtol=self.rtol, atol=self.atol
+        )
 
     def func_0Dtensor_index(self):
         x_0d = self.x[0].reshape([])


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
使用 `np.testing.assert_allclose` 时直接按位置顺序传入参数，未命名 `rtol` 和 `atol`，可能在 NumPy 版本更新后导致语义错误或警告，降低代码稳定性和可维护性。
显式命名 `rtol` 和 `atol` 参数可以避免因 NumPy 参数位置改动或用户误读导致的问题，增强代码语义清晰度和兼容性。