### PR TITLE
[Bug Fix]setUpClass错误地作为实例方法调用

### DIFF
--- a/test/autograd/test_autograd_dynamic.py
+++ b/test/autograd/test_autograd_dynamic.py
@@ -638,7 +638,7 @@ class TestHessianBatchFirst(unittest.TestCase):
             H = paddle.autograd.hessian(func(x), x, batch_axis=0)[..., 1]
 
     def test_all_cases(self):
-        self.setUpClass()
+        self.__class__.setUpClass()
         self.func_allow_unused()
         self.func_stop_gradient()
         self.func_out_not_single()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
`self.setUpClass()` 是一个类方法，应该用类的上下文调用而不是用实例进行调用。此处用 `self` 调用会导致 Python 报错，因为 `self` 是实例而非类对象。