### PR TITLE
[CINN] Fix CINN 0size dynamic shape bug in H20

### DIFF
--- a/paddle/fluid/framework/new_executor/instruction/cinn_jit_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/cinn_jit_instruction.cc
@@ -175,8 +175,11 @@ class CinnJitInstruction::FnPtrImpl {
     // Define an array of Pointers to hold the output tensor shape
     std::vector<int64_t*> output_tensor_shapes(output_tensor_size);
     for (int i = 0; i < output_tensor_size; ++i) {
+      // For 0-size tensors, if the shape buffer is not explicitly initialized,
+      // it may contain garbage values from memory, resulting in incorrect
+      // shapes.
       output_tensor_shapes[i] = reinterpret_cast<int64_t*>(
-          malloc(kernel_tensor_args[input_tensor_size + i]->dims().size() *
+          calloc(kernel_tensor_args[input_tensor_size + i]->dims().size(),
                  sizeof(int64_t*)));
     }
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- PCard-92901 -->

目前 CINN 中生成 kernel host 代码和 infer shape 代码实现保持相同的分支逻辑，如下 `fn_sum_` 与 `fn_sum__infer_shape`:

```c
function fn_sum_ (kernel_args, kernel_args_num, kernel_stream)
{
  int64 S0 = cinn_get_value_in_kernel_args(kernel_args, 3)
  if (((S0 >= 1025ll) and ((S0 * 128ll) > 2147483647ll))) {
    cinn_call_cuda_cooperative_kernel(fn_sum__COND__FPA__FPA_S0GE1025ll_BPA_AND_FPA__FPA_S0MUL128ll_BPA_GT2147483647ll_BPA__BPA___kernel, kernel_args, kernel_args_num, 4ll, 16ll, 1ll, 32ll, 16ll, 1ll, 2048ll, kernel_stream)
  } else {
    if (((S0 >= 1025ll) and ((S0 * 128ll) <= 2147483647ll))) {
      cinn_call_cuda_cooperative_kernel(fn_sum__COND__FPA__FPA_S0GE1025ll_BPA_AND_FPA__FPA_S0MUL128ll_BPA_LE2147483647ll_BPA__BPA___kernel, kernel_args, kernel_args_num, 4ll, 16ll, 1ll, 32ll, 16ll, 1ll, 2048ll, kernel_stream)
    } else {
      if ((((S0 >= 1ll) and (S0 <= 1024ll)) and ((S0 * 128ll) > 2147483647ll))) {
        cinn_call_cuda_kernel(fn_sum__COND__FPA__FPA__FPA_S0GE1ll_BPA_AND_FPA_S0LE1024ll_BPA__BPA_AND_FPA__FPA_S0MUL128ll_BPA_GT2147483647ll_BPA__BPA___kernel, kernel_args, kernel_args_num, 4ll, 1ll, 1ll, 32ll, 16ll, 1ll, 2048ll, kernel_stream)
      } else {
        if ((((S0 >= 1ll) and (S0 <= 1024ll)) and ((S0 * 128ll) <= 2147483647ll))) {
          cinn_call_cuda_kernel(fn_sum__COND__FPA__FPA__FPA_S0GE1ll_BPA_AND_FPA_S0LE1024ll_BPA__BPA_AND_FPA__FPA_S0MUL128ll_BPA_LE2147483647ll_BPA__BPA___kernel, kernel_args, kernel_args_num, 4ll, 1ll, 1ll, 32ll, 16ll, 1ll, 2048ll, kernel_stream)
        }
      }
    }
  }
}
```

```c
function fn_sum__infer_shape (kernel_args, kernel_args_num, tensor_shape_args)
{
  int64 S0 = cinn_get_value_in_kernel_args(kernel_args, 3)
  infer_shape_set_value(0, 0, 128ll, tensor_shape_args)
  if (((S0 >= 1025ll) and ((S0 * 128ll) > 2147483647ll))) {
    infer_shape_set_value(1, 0, 8192ll, tensor_shape_args)
  } else {
    if (((S0 >= 1025ll) and ((S0 * 128ll) <= 2147483647ll))) {
      infer_shape_set_value(1, 0, 8192ll, tensor_shape_args)
    } else {
      if ((((S0 >= 1ll) and (S0 <= 1024ll)) and ((S0 * 128ll) > 2147483647ll))) {
        infer_shape_set_value(1, 0, 0ll, tensor_shape_args)
      } else {
        if ((((S0 >= 1ll) and (S0 <= 1024ll)) and ((S0 * 128ll) <= 2147483647ll))) {
          infer_shape_set_value(1, 0, 0ll, tensor_shape_args)
        }
      }
    }
  }
}
```

在 0-size 情况下，kernel 的 host 代码以及 infer shape 实现均为 no-op，不会进入 kernel 执行实际计算

然而，如果在 infer shape 阶段不对 shape 进行初始化，结果的 shape 可能会是随机值，进而导致后续 shape 推导错误，甚至使执行器分配异常大小的内存，出现 OOM (在H20上可以复现)：

```
I1028 09:33 cinn_jit_instruction.cc:174] Start InferShape: fn_sum_
I1028 09:33 cinn_jit_instruction.cc:198] Inferred shape 0 for fn_sum_: [128]
I1028 09:33 cinn_jit_instruction.cc:198] Inferred shape 1 for fn_sum_: [94315284899319] 👈 这里直接导致 OOM
I1028 09:33 cinn_jit_instruction.cc:203] End InferShape: fn_sum_
```

因此，我们采用 0 来初始化输出的 shape，确保 0-size 场景下推导出的 shape 是有效的（为0）