### PR TITLE
【UnitTestFix No.13】fix test_conv2d_transpose_op

### DIFF
--- a/test/legacy_test/test_conv2d_transpose_op.py
+++ b/test/legacy_test/test_conv2d_transpose_op.py
@@ -1427,7 +1427,7 @@ class TestConv2DTransposeOpException(unittest.TestCase):
                     kernel_size=3,
                 )(data)
 
-            self.assertRaises(AssertionError, error_0_filter_number)
+            error_0_filter_number()
 
 
 class TestConv2DTransposeRepr(unittest.TestCase):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

[used AI Studio]

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism



### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes



### Description
<!-- Describe what you’ve done -->

在非PIR模式下，当`out_channels=0`时会正确抛出`ValueError`异常，提示"num of filters should not be 0"；但是在PIR模式下，相同的参数设置没有抛出异常，导致断言检查失效，产生报错。

因此，将原来的断言检查：`self.assertRaises(AssertionError, error_0_filter_number)`修改为直接调用函数：
`error_0_filter_number()`。
