### PR TITLE
[SOT] Fallback when breakgraph in for loop

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
@@ -2212,7 +2212,6 @@ class OpcodeExecutor(OpcodeExecutorBase):
             restore_names: the names used in resume functions.
             end_idx: instruction index where simulation get break.
             stack: current stack
-            extra_store_vars: for iterator, we need store the holder if it is a Tensor
         """
         store_vars = list(OrderedSet(stack))
         store_var_info = {var.id: [] for var in stack}

--- a/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
@@ -45,7 +45,6 @@ from ...utils import (
     UnsupportedIteratorBreak,
     UnsupportedOperationBreak,
     get_static_function,
-    is_comprehensive_name,
     log,
     log_do,
 )
@@ -62,7 +61,6 @@ from ..instruction_utils.opcode_info import (
     RETURN,
     ExceptionHandler,
     JumpDirection,
-    PopJumpCond,
 )
 from .dispatch_functions import (
     operator_BAD,
@@ -139,10 +137,7 @@ COMPARE_OP_NAME_TO_FN = {
 
 # In Python 3.13, the method layout is changed, and a NULL will be pushed after the value.
 CALL_METHOD_LAYOUT_NULL_AFTER_VALUE = sys.version_info >= (3, 13)
-ALREADY_SUPPORTED_EXCEPTION = sys.version_info < (
-    3,
-    11,
-)
+ALREADY_SUPPORTED_EXCEPTION = sys.version_info < (3, 11)
 
 
 @dataclass
@@ -2161,6 +2156,7 @@ class OpcodeExecutor(OpcodeExecutorBase):
                     )
                 )
 
+            # TODO(SigureMo): Remove inline call logic
             self._inline_call_for_loop(iterator, instr)
             self.vframe.lasti = self.indexof(instr.jump_to)
             if sys.version_info >= (3, 12):
@@ -2173,16 +2169,9 @@ class OpcodeExecutor(OpcodeExecutorBase):
                 self.vframe.lasti += skip_n_instrs
         except BreakGraphError as e:
             log(3, f"[BreakGraph] FOR_ITER sim for loop failed for: {e}\n")
-            self._graph.remove_global_guarded_variable(iterator)
-            self.stack.push(iterator)
-            if is_comprehensive_name(self.vframe.code.co_name):
-                # NOTE(SigureMo): The loop body of comprehensive will access the
-                # value out of the loop, so we simply fallback it now.
-                raise FallbackError(
-                    "Comprehensive for loop break graph is not supported."
-                )
-            self._break_graph_when_for_loop(iterator, instr)
-            return Stop(state="BreakGraph")
+            raise FallbackError(
+                "Encountered BreakGraphError during FOR_ITER simulation, falling back."
+            )
 
     def RETURN_VALUE(self, instr: Instruction):
         assert len(self.stack) == 1, (
@@ -2208,7 +2197,7 @@ class OpcodeExecutor(OpcodeExecutorBase):
         return Stop(state="Return")
 
     def get_compute_fn_and_update_changed_vars(
-        self, restore_names, stack, end_idx, extra_store_vars
+        self, restore_names, stack, end_idx
     ):
         """
         this function will:
@@ -2225,7 +2214,7 @@ class OpcodeExecutor(OpcodeExecutorBase):
             stack: current stack
             extra_store_vars: for iterator, we need store the holder if it is a Tensor
         """
-        store_vars = list(OrderedSet(list(stack) + extra_store_vars))
+        store_vars = list(OrderedSet(stack))
         store_var_info = {var.id: [] for var in stack}
 
         for name in restore_names:
@@ -2358,7 +2347,7 @@ class OpcodeExecutor(OpcodeExecutorBase):
         # 4. compile codes before if
         update_var_names = list(true_fn_read_names | false_fn_read_names)
         var_loader = self.get_compute_fn_and_update_changed_vars(
-            update_var_names, self.stack, cur_index, []
+            update_var_names, self.stack, cur_index
         )
 
         # 5. create if structure and call true_fn and false_fn
@@ -2486,7 +2475,7 @@ class OpcodeExecutor(OpcodeExecutorBase):
 
         # 3. compile sub graph before call
         var_loader = self.get_compute_fn_and_update_changed_vars(
-            read_names, self.stack, cur_index, []
+            read_names, self.stack, cur_index
         )
 
         # 4. recover stack
@@ -2524,256 +2513,6 @@ class OpcodeExecutor(OpcodeExecutorBase):
             )
         # gen RETURN_VALUE
         self._graph.pycode_gen.gen_return()
-        self.new_code = self._graph.pycode_gen.gen_pycode()
-        self.guard_fn = self._graph.guard_fn
-        self.guard_chain = self._graph.guard_chain
-
-    @fallback_when_occur_error
-    def _break_graph_when_for_loop(
-        self, iterator: VariableBase, for_iter: Instruction
-    ):
-        self.fallback_when_block_stack_is_not_empty()
-        # 1. find the range of loop body
-        assert for_iter.jump_to is not None
-        for_iter_idx = self.indexof(for_iter)
-        loop_body_start_idx = for_iter_idx + 1
-        loop_body_end_idx = self.indexof(for_iter.jump_to)
-        current_stack = 1
-
-        while True:
-            if loop_body_start_idx >= len(self._instructions):
-                raise InnerError("Can not balance stack in loop body.")
-            cur_instr = self._instructions[loop_body_start_idx]
-            # do not consider jump instr
-            stack_effect = calc_stack_effect(cur_instr, jump=False)
-            current_stack += stack_effect
-            loop_body_start_idx += 1
-            if current_stack == 0:
-                break
-
-        # 2. create loop body function
-        loop_body_read_names, loop_body_write_names = analysis_used_names(
-            self._instructions, loop_body_start_idx, loop_body_end_idx
-        )
-        loop_body_inputs = [
-            *self._find_names_in_space(
-                loop_body_read_names | loop_body_write_names,
-                (Space.locals, Space.cells),
-            ),
-            "_break_flag",
-        ]
-        loop_body_outputs = [*list(loop_body_write_names), "_break_flag"]
-
-        def create_loop_body():
-            cache_key = (
-                ResumeFunctionType.LOOP_BODY_RESUME,
-                self.vframe.code,
-                loop_body_start_idx,
-                loop_body_end_idx,
-            )
-            resume_fn_creator = ResumeFunctionCreator(
-                self._graph.pycode_gen._origin_code,
-                self._graph.pycode_gen._real_globals,
-            )
-            if (
-                maybe_resume_fn := resume_fn_creator.lookup(cache_key)
-            ) is not None:
-                return maybe_resume_fn
-            pycode_gen = resume_fn_creator.codegen
-
-            resume_fn_creator.set_inputs(loop_body_inputs, stack_size=0)
-
-            origin_instrs = get_instructions(pycode_gen._origin_code)
-            for_iter = origin_instrs[for_iter_idx]
-
-            # for balance the stack (the loop body will pop iter first before break or return)
-            # this None is used for replace the iterator obj in stack top
-            pycode_gen.gen_load_const(None)
-
-            # extend loop body main logic
-            pycode_gen.extend_instrs(
-                origin_instrs[loop_body_start_idx:loop_body_end_idx]
-            )
-
-            # break should jump to this nop
-            nop_for_break = pycode_gen.add_instr("NOP")
-
-            # need do additional operates when break
-            pycode_gen.gen_load_const(False)
-            pycode_gen.gen_store_fast(loop_body_inputs[-1])
-            pycode_gen.gen_load_const(None)  # keep stack balance
-
-            # continue should jump to this nop
-            nop_for_continue = pycode_gen.add_instr("NOP")
-            pycode_gen.gen_pop_top()
-
-            # relocate jump
-            out_loop = for_iter.jump_to
-            for instr in pycode_gen._instructions:
-                if instr.jump_to == for_iter:
-                    instr.jump_to = nop_for_continue
-                if instr.jump_to == out_loop:
-                    instr.jump_to = nop_for_break
-
-            # outputs is the same as inputs
-            resume_fn_creator.set_outputs(loop_body_outputs)
-            loop_body_fn = resume_fn_creator.generate(cache_key=cache_key)
-
-            log(
-                3,
-                "[Resumed Function] break graph in loop create loop body as\n",
-            )
-            log_do(3, lambda: dis.dis(loop_body_fn))
-
-            return loop_body_fn
-
-        loop_body_fn = create_loop_body()
-
-        # 3. create after loop part function, stack size minus 1 for iterator
-        after_loop_read_names, _ = analysis_used_names(
-            self._instructions, loop_body_end_idx, len(self._instructions)
-        )
-        after_loop_fn_inputs = self._find_names_in_space(
-            after_loop_read_names, (Space.locals, Space.cells)
-        )
-
-        def create_after_loop_fn():
-            if self._instructions[loop_body_end_idx].opname == "RETURN_VALUE":
-                return None
-            cache_key = (
-                ResumeFunctionType.AFTER_LOOP_RESUME,
-                self.vframe.code,
-                loop_body_end_idx,
-            )
-            resume_fn_creator = ResumeFunctionCreator(
-                self._graph.pycode_gen._origin_code,
-                self._graph.pycode_gen._real_globals,
-            )
-            if (
-                maybe_resume_fn := resume_fn_creator.lookup(cache_key)
-            ) is not None:
-                return maybe_resume_fn
-            pycode_gen = resume_fn_creator.codegen
-            origin_instrs = get_instructions(pycode_gen._origin_code)
-            resume_fn_end_idx = loop_body_end_idx
-
-            # skip resume END_FOR in python3.12
-            if sys.version_info >= (3, 12):
-                assert origin_instrs[loop_body_end_idx].opname == "END_FOR"
-                skip_n_instrs = 2 if sys.version_info >= (3, 13) else 1
-                resume_fn_end_idx += skip_n_instrs
-
-            resume_fn_creator.set_inputs(
-                after_loop_fn_inputs, stack_size=len(self.stack) - 1
-            )
-            pycode_gen.extend_instrs(origin_instrs[resume_fn_end_idx:])
-            # the resume_fn contains return code, so we don't need set output here
-            # global vars are updated correctly, and need local vars will return
-            after_loop_fn = resume_fn_creator.generate(cache_key=cache_key)
-            return after_loop_fn
-
-        after_loop_fn = create_after_loop_fn()
-
-        # 4. setup vars which is created in loop as Undefined
-        for name in loop_body_inputs[:-1]:
-            if not self.has_var(name):
-                self._graph.pycode_gen.gen_load_const(SotUndefinedVar())
-                self._graph.pycode_gen.gen_store(name, self.vframe.code)
-        for name in after_loop_fn_inputs:
-            if not self.has_var(name):
-                self._graph.pycode_gen.gen_load_const(SotUndefinedVar())
-                self._graph.pycode_gen.gen_store(name, self.vframe.code)
-
-        # 5. compile sub graph before for-loop
-        update_names = list(
-            OrderedSet(loop_body_inputs[:-1]) | after_loop_read_names
-        )
-        extra_store_vars = (
-            [
-                item
-                for item in iterator.flatten_inner_vars()
-                if isinstance(item, (TensorVariable, SymbolicVariable))
-            ]
-            if isinstance(iterator, IterVariable)
-            else []
-        )
-        var_loader = self.get_compute_fn_and_update_changed_vars(
-            update_names,
-            self.stack,
-            self.indexof(for_iter),
-            extra_store_vars,
-        )
-
-        # 6. prepare a new loop and call loop body
-        # 6.1. load iterator, it is in stack, so we can load it with var_loader
-        var_loader.load(iterator)
-        self.stack.pop()
-
-        # 6.2. copy FOR_ITER and unpack logic
-        self._graph.pycode_gen.extend_instrs(
-            self._instructions[for_iter_idx:loop_body_start_idx]
-        )
-
-        # 6.3 load loop body, prepare inputs and call
-        self._graph.pycode_gen.gen_load_object(
-            loop_body_fn, loop_body_fn.__code__.co_name
-        )
-
-        for name in loop_body_inputs[:-1]:
-            self._graph.pycode_gen.gen_load(name)
-
-        # this is the _break_flag
-        self._graph.pycode_gen.gen_load_const(True)
-
-        self._graph.pycode_gen.gen_call_function(
-            argc=loop_body_fn.__code__.co_argcount
-        )
-
-        # 7. unpack and update changed vars, keep break_flag in stack
-        self._graph.pycode_gen.gen_unpack_sequence(len(loop_body_outputs))
-
-        for name in loop_body_outputs[:-1]:
-            self._graph.pycode_gen.gen_store(name, self.vframe.code)
-
-        # 8. create the tail of a for loop, jump back to FOR_ITER
-        #    and process case if break
-        jump_if_break = self._graph.pycode_gen.gen_pop_jump(
-            direction=JumpDirection.FORWARD, suffix=PopJumpCond.FALSE
-        )
-
-        self._graph.pycode_gen.gen_jump(
-            for_iter, direction=JumpDirection.BACKWARD
-        )
-
-        if sys.version_info >= (3, 12):
-            end_for = self._graph.pycode_gen.add_instr("END_FOR")
-            if sys.version_info >= (3, 13):
-                self._graph.pycode_gen.gen_pop_top()
-
-        nop = self._graph.pycode_gen.add_instr("NOP")
-
-        for_iter.jump_to = end_for if sys.version_info >= (3, 12) else nop
-        jump_if_break.jump_to = nop
-
-        # 9. prepare inputs and call after_loop_fn
-        if after_loop_fn is not None:
-            self._graph.pycode_gen.gen_load_object(
-                after_loop_fn, after_loop_fn.__code__.co_name
-            )
-
-            for stack_arg in self.stack:
-                var_loader.load(stack_arg)
-
-            for name in after_loop_fn_inputs:
-                self._graph.pycode_gen.gen_load(name)
-
-            self._graph.pycode_gen.gen_call_function(
-                argc=after_loop_fn.__code__.co_argcount
-            )
-
-        # return what after_loop_fn return
-        self._graph.pycode_gen.gen_return()
-
         self.new_code = self._graph.pycode_gen.gen_pycode()
         self.guard_fn = self._graph.guard_fn
         self.guard_chain = self._graph.guard_chain

--- a/python/paddle/jit/sot/opcode_translator/executor/pycode_generator.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/pycode_generator.py
@@ -998,11 +998,8 @@ class ResumeFunctionType(Enum):
     IF_RESUME = 0
     # Call breakgraph
     CALL_RESUME = 1
-    # Loop breakgraph
-    LOOP_BODY_RESUME = 2
-    AFTER_LOOP_RESUME = 3
     # Loop inline call
-    LOOP_BODY_INLINE_CALL = 4
+    LOOP_BODY_INLINE_CALL = 2
 
 
 class ResumeFunctionCreator:

--- a/test/sot/test_12_for_loop.py
+++ b/test/sot/test_12_for_loop.py
@@ -135,7 +135,6 @@ def for_without_zero_iter(self_res_dict, output):
     return res_dict
 
 
-@sot.psdb.check_no_fallback
 def for_reconstruct_range_iter():
     for i in range(3):
         sot.psdb.breakgraph()
@@ -160,6 +159,7 @@ def for_layer_list(layer_list, x):
 
 
 class TestForLoop(TestCaseBase):
+    @strict_mode_guard(False)
     def test_list(self):
         a = paddle.to_tensor(1)
         self.assert_results(for_list_1, a)
@@ -172,6 +172,7 @@ class TestForLoop(TestCaseBase):
         a = paddle.to_tensor(1)
         self.assert_results(for_dict, a)
 
+    @strict_mode_guard(False)
     def test_fallback(self):
         a = paddle.to_tensor(1)
 
@@ -179,7 +180,8 @@ class TestForLoop(TestCaseBase):
         paddle_output = for_iter(a, gener())
         self.assert_nest_match(sym_output, paddle_output)
 
-    def test_for_for_fallback(self):
+    @strict_mode_guard(False)
+    def test_for_iter_fallback(self):
         a = paddle.to_tensor(1)
 
         sym_output = symbolic_translate(for_iter)(a, gener())
@@ -193,17 +195,14 @@ class TestForLoop(TestCaseBase):
         paddle_output = for_break(a, gener())
         self.assert_nest_match(sym_output, paddle_output)
 
+    @strict_mode_guard(False)
     def test_for_continue(self):
         a = paddle.to_tensor(1)
         sym_output = symbolic_translate(for_continue)(a, gener())
         paddle_output = for_continue(a, gener())
         self.assert_nest_match(sym_output, paddle_output)
 
-    # TODO(zmh): support range for tensor
-    # def test_resume_stack(self):
-    #     a = [1, 2, 3]
-    #     self.assert_results(for_enumerate_var_with_nested_range, a)
-
+    @strict_mode_guard(False)
     def test_create_var_in_loop(self):
         x = paddle.to_tensor(1, dtype="float32")
         a = [1, 2, 3]
@@ -213,6 +212,7 @@ class TestForLoop(TestCaseBase):
         paddle_output = for_create_tmp_in_loop(x, iter(a))
         self.assert_nest_match(sym_output, paddle_output)
 
+    @strict_mode_guard(False)
     def test_create_var_in_loop_with_same_name_as_global(self):
         self.assert_results(for_tmp_var_with_same_name_as_global_var)
 
@@ -221,6 +221,7 @@ class TestForLoop(TestCaseBase):
         output = paddle.to_tensor(2)
         self.assert_results(for_without_zero_iter, self_res_dict, output)
 
+    @strict_mode_guard(False)
     def test_reconstruct_range_iter(self):
         self.assert_results(for_reconstruct_range_iter)
 
@@ -289,9 +290,11 @@ def undefined_var_case_1():
 
 
 class TestUndefinedVarInRiskyCodes(TestCaseBase):
+    @strict_mode_guard(False)
     def test_undefined_var_case_0(self):
         self.assert_results(undefined_var_case_0)
 
+    @strict_mode_guard(False)
     def test_undefined_var_case_1(self):
         self.assert_results(undefined_var_case_1)
 
@@ -335,6 +338,7 @@ def for_break_with_load_same_consts(x: paddle.Tensor):
 
 
 class TestForBreakWithLoadSameConsts(TestCaseBase):
+    @strict_mode_guard(False)
     def test_for_break_with_load_same_consts(self):
         x = paddle.to_tensor(1)
         self.assert_results(for_break_with_load_same_consts, x)
@@ -349,6 +353,7 @@ def for_break_with_write_pre_defined_name(x: paddle.Tensor):
 
 
 class TestForBreakWithWritePreDefinedName(TestCaseBase):
+    @strict_mode_guard(False)
     def test_for_break_with_write_pre_defined_name(self):
         x = paddle.to_tensor(1)
         self.assert_results(for_break_with_write_pre_defined_name, x)

--- a/test/sot/test_builtin_zip.py
+++ b/test/sot/test_builtin_zip.py
@@ -93,6 +93,7 @@ class TestZip(TestCaseBase):
         self.assert_results(test_zip_7, layer_list, paddle.randn((10,)))
 
     @min_graph_size_guard(0)
+    @strict_mode_guard(False)
     def test_reconstruct(self):
         self.assert_results(test_zip_8, [1, 2, 3], [4, 5, 6])
 

--- a/test/sot/test_inplace_api.py
+++ b/test/sot/test_inplace_api.py
@@ -18,6 +18,7 @@ from test_case_base import TestCaseBase
 
 import paddle
 from paddle.jit.sot import symbolic_translate
+from paddle.jit.sot.utils import strict_mode_guard
 
 
 def simple(x, y):
@@ -126,6 +127,7 @@ class TestInplaceApi(TestCaseBase):
             paddle.to_tensor(1),
         )
 
+    @strict_mode_guard(False)
     def test_loop(self):
         self.assert_results(
             inplace_in_loop,

--- a/test/sot/test_min_graph_size.py
+++ b/test/sot/test_min_graph_size.py
@@ -20,7 +20,7 @@ from test_case_base import TestCaseBase
 
 import paddle
 from paddle.jit import sot
-from paddle.jit.sot.utils import min_graph_size_guard
+from paddle.jit.sot.utils import min_graph_size_guard, strict_mode_guard
 
 
 def case_for(x, vars):
@@ -94,6 +94,7 @@ def restore_same_arg_when_fallback(x):
 
 
 class TestMinGraphSize(TestCaseBase):
+    @strict_mode_guard(False)
     @min_graph_size_guard(10)
     def test_cases(self):
         x = paddle.to_tensor(1)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Performance

### Description
<!-- Describe what you’ve done -->

SOT 移除针对 for-loop 的 break graph 处理，在 for-loop 中产生的 break graph 往往会产生大量的碎子图，反而会导致性能降低

此外，for-loop 的实现不再需要抽取函数并 inline call，后续移除

<!-- PCard-66972 -->