### PR TITLE
Fix int32 overflow issues for large tensor support in paddle/phi/kernels/impl

### DIFF
--- a/paddle/phi/kernels/impl/accuracy_check_kernel_impl.h
+++ b/paddle/phi/kernels/impl/accuracy_check_kernel_impl.h
@@ -142,12 +142,12 @@ __global__ void AccuracyCheckCUDAKernel(const T* in_data,
                                         const double rtol,
                                         const double atol,
                                         bool equal_nan,
-                                        int num,
+                                        int64_t num,
                                         bool* out_data) {
-  unsigned int idx = threadIdx.x + blockIdx.x * blockDim.x;
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   bool val;
   using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
-  for (int i = idx; i < num; i += blockDim.x * gridDim.x) {
+  for (int64_t i = idx; i < num; i += blockDim.x * gridDim.x) {
     const double a = static_cast<MPType>(in_data[i]);
     const double b = static_cast<MPType>(other_data[i]);
     if (isnan(a) || isnan(b)) {
@@ -172,11 +172,11 @@ __global__ void AccuracyCheckCUDAKernel<phi::complex64>(
     const double rtol,
     const double atol,
     bool equal_nan,
-    int num,
+    int64_t num,
     bool* out_data) {
-  unsigned int idx = threadIdx.x + blockIdx.x * blockDim.x;
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   bool val;
-  for (int i = idx; i < num; i += blockDim.x * gridDim.x) {
+  for (int64_t i = idx; i < num; i += blockDim.x * gridDim.x) {
     const phi::complex64 a = in_data[i];
     const phi::complex64 b = other_data[i];
     if (isnan(a) || isnan(b)) {
@@ -202,11 +202,11 @@ __global__ void AccuracyCheckCUDAKernel<phi::complex128>(
     const double rtol,
     const double atol,
     bool equal_nan,
-    int num,
+    int64_t num,
     bool* out_data) {
-  unsigned int idx = threadIdx.x + blockIdx.x * blockDim.x;
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   bool val;
-  for (int i = idx; i < num; i += blockDim.x * gridDim.x) {
+  for (int64_t i = idx; i < num; i += blockDim.x * gridDim.x) {
     const phi::complex128 a = in_data[i];
     const phi::complex128 b = other_data[i];
     if (isnan(a) || isnan(b)) {
@@ -235,12 +235,12 @@ struct AccuracyCheckFunctor<phi::GPUContext, T> {
                   const double atol,
                   bool equal_nan,
                   DenseTensor* output) {
-    int num = in.numel();
+    int64_t num = in.numel();
     const T* in_data = in.data<T>();
     const T* other_data = other.data<T>();
     bool* out_data = dev_ctx.template Alloc<bool>(output);
     int block = 1024;
-    int grid = (block - 1 + num) / block;
+    int64_t grid = (block - 1 + num) / block;
     grid = (grid > block) ? block : grid;
 #ifdef PADDLE_WITH_HIP
     hipMemset(out_data, true, num * sizeof(bool));

--- a/paddle/phi/kernels/impl/conv_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/conv_grad_kernel_impl.h
@@ -85,7 +85,7 @@ void ConvGradKernel(const Context& dev_ctx,
   UpdatePaddingAndDilation<int>(
       &paddings, &dilations, padding_algorithm, in_data_dims, strides, ksize);
 
-  const int batch_size = static_cast<int>(transformed_input.dims()[0]);
+  const int64_t batch_size = transformed_input.dims()[0];
 
   // filter_shape_vec: {k_o, k_i, k_h, k_w} or {k_o, k_i, k_d, k_h, k_w}
   std::vector<int64_t> filter_shape_vec(common::vectorize(filter.dims()));
@@ -125,8 +125,8 @@ void ConvGradKernel(const Context& dev_ctx,
 
   // convolution backward input operator:  gemm + col2im(or col2vol)
   // convolution backward weight operator: im2col(or vol2col) + gemm
-  int in_step = static_cast<int>(transformed_input.dims()[1]) / groups;
-  int out_step = static_cast<int>(transformed_output_grad.dims()[1]) / groups;
+  int64_t in_step = transformed_input.dims()[1] / groups;
+  int64_t out_step = transformed_output_grad.dims()[1] / groups;
 
   bool is_expand = IsExpand(filter_shape_vec, strides, paddings, dilations);
 
@@ -163,7 +163,7 @@ void ConvGradKernel(const Context& dev_ctx,
     phi::funcs::Col2ImFunctor<phi::funcs::ColFormat::kCFO, Context, T> col2im;
     phi::funcs::Col2VolFunctor<Context, T> col2vol;
 
-    for (int i = 0; i < batch_size; i++) {
+    for (int64_t i = 0; i < batch_size; i++) {
       DenseTensor out_grad_batch =
           transformed_output_grad.Slice(i, i + 1).Resize(output_matrix_shape);
       DenseTensor in_grad_batch =
@@ -327,7 +327,7 @@ void ConvGradGradKernel(const Context& dev_ctx,
   UpdatePaddingAndDilation(
       &paddings, &dilations, padding_algorithm, in_data_dims, strides, ksize);
 
-  const int batch_size = static_cast<int>(transformed_X.dims()[0]);
+  const int64_t batch_size = transformed_X.dims()[0];
   std::vector<int64_t> filter_shape_vec(common::vectorize(W.dims()));
   std::vector<int64_t> output_shape_vec(
       common::vectorize(transformed_dY.dims()));
@@ -354,8 +354,8 @@ void ConvGradGradKernel(const Context& dev_ctx,
       transformed_dY.dims()[1],
       transformed_dY.numel() /
           (transformed_dY.dims()[0] * transformed_dY.dims()[1])};
-  int in_step = static_cast<int>(transformed_X.dims()[1]) / groups;
-  int out_step = static_cast<int>(transformed_dY.dims()[1]) / groups;
+  int64_t in_step = transformed_X.dims()[1] / groups;
+  int64_t out_step = transformed_dY.dims()[1] / groups;
 
   bool is_expand = IsExpand(filter_shape_vec, strides, paddings, dilations);
   DenseTensor col;
@@ -394,7 +394,7 @@ void ConvGradGradKernel(const Context& dev_ctx,
     phi::funcs::Col2ImFunctor<phi::funcs::ColFormat::kCFO, Context, T> col2im;
     phi::funcs::Col2VolFunctor<Context, T> col2vol;
 
-    for (int i = 0; i < batch_size; i++) {
+    for (int64_t i = 0; i < batch_size; i++) {
       DenseTensor dy_batch =
           transformed_dY.Slice(i, i + 1).Resize(output_matrix_shape);
       DenseTensor dx_batch = transformed_dX.Slice(i, i + 1).Resize(input_shape);

--- a/paddle/phi/kernels/impl/conv_kernel_impl.h
+++ b/paddle/phi/kernels/impl/conv_kernel_impl.h
@@ -76,7 +76,7 @@ void ConvKernelImpl(const Context& dev_ctx,
   UpdatePaddingAndDilation(
       &paddings, &dilations, padding_algorithm, in_data_dims, strides, ksize);
 
-  const int batch_size = static_cast<int>(transformed_input.dims()[0]);
+  const int64_t batch_size = transformed_input.dims()[0];
 
   // filter_shape_vec:
   // {k_o, k_i, k_h, k_w} or {k_o, k_i, k_d, k_h, k_w}
@@ -137,14 +137,14 @@ void ConvKernelImpl(const Context& dev_ctx,
           (transformed_output.dims()[0] * transformed_output.dims()[1])};
 
   // convolution operator: im2col(or vol2col) + gemm
-  int in_step = static_cast<int>(transformed_input.dims()[1]) / groups;
-  int out_step = static_cast<int>(transformed_output.dims()[1]) / groups;
+  int64_t in_step = transformed_input.dims()[1] / groups;
+  int64_t out_step = transformed_output.dims()[1] / groups;
 
   phi::funcs::Im2ColFunctor<phi::funcs::ColFormat::kCFO, Context, T> im2col;
   phi::funcs::Vol2ColFunctor<Context, T> vol2col;
 
   auto blas = phi::funcs::GetBlas<Context, T>(dev_ctx);
-  for (int i = 0; i < batch_size; i++) {
+  for (int64_t i = 0; i < batch_size; i++) {
     DenseTensor in_batch =
         transformed_input.Slice(i, i + 1).Resize(in_matrix_shape);
     DenseTensor out_batch =

--- a/paddle/phi/kernels/impl/fold_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/fold_grad_kernel_impl.h
@@ -38,7 +38,7 @@ void FoldGradKernel(const Context& dev_ctx,
   if (!x_grad) return;
 
   const auto& x_dims = x_grad->dims();
-  const int batch_size = static_cast<int>(x_dims[0]);
+  const int64_t batch_size = x_dims[0];
 
   int output_height = (output_sizes[0] + 2 * paddings[0] -
                        (dilations[0] * (kernel_sizes[0] - 1) + 1)) /
@@ -49,8 +49,8 @@ void FoldGradKernel(const Context& dev_ctx,
                          strides[1] +
                      1;
 
-  int n_input_plane = x_dims[1];
-  int n_output_plane = n_input_plane / (kernel_sizes[0] * kernel_sizes[1]);
+  int64_t n_input_plane = x_dims[1];
+  int64_t n_output_plane = n_input_plane / (kernel_sizes[0] * kernel_sizes[1]);
 
   DDim out_shape =
       common::make_ddim({n_output_plane, output_sizes[0], output_sizes[1]});
@@ -59,7 +59,7 @@ void FoldGradKernel(const Context& dev_ctx,
 
   phi::funcs::Im2ColFunctor<phi::funcs::ColFormat::kCFO, Context, T> im2col;
 
-  for (int i = 0; i < batch_size; i++) {
+  for (int64_t i = 0; i < batch_size; i++) {
     DenseTensor out_grad_batch = out_grad.Slice(i, i + 1).Resize(out_shape);
     DenseTensor x_grad_batch =
         x_grad->Slice(i, i + 1).Resize(input_matrix_shape);

--- a/paddle/phi/kernels/impl/fold_kernel_impl.h
+++ b/paddle/phi/kernels/impl/fold_kernel_impl.h
@@ -33,7 +33,7 @@ void FoldKernel(const Context& dev_ctx,
                 const std::vector<int>& paddings,
                 const std::vector<int>& dilations,
                 DenseTensor* out) {
-  const int batch_size = static_cast<int>(x.dims()[0]);
+  const int64_t batch_size = x.dims()[0];
   dev_ctx.template Alloc<T>(out);
 
   phi::funcs::Col2ImFunctor<phi::funcs::ColFormat::kCFO, Context, T> col2im;
@@ -48,8 +48,8 @@ void FoldKernel(const Context& dev_ctx,
                          strides[1] +
                      1;
 
-  int n_input_plane = x_dims[1];
-  int n_output_plane = n_input_plane / (kernel_sizes[0] * kernel_sizes[1]);
+  int64_t n_input_plane = x_dims[1];
+  int64_t n_output_plane = n_input_plane / (kernel_sizes[0] * kernel_sizes[1]);
 
   DDim output_shape =
       common::make_ddim({n_output_plane, output_sizes[0], output_sizes[1]});
@@ -60,7 +60,7 @@ void FoldKernel(const Context& dev_ctx,
   phi::funcs::SetConstant<Context, T> set_zero;
   set_zero(dev_ctx, out, static_cast<T>(0));
 
-  for (int i = 0; i < batch_size; i++) {
+  for (int64_t i = 0; i < batch_size; i++) {
     DenseTensor out_batch =
         out->Slice(i, i + 1).Resize(output_shape);  // im size=3
 

--- a/paddle/phi/kernels/impl/frame_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/frame_grad_kernel_impl.h
@@ -29,9 +29,10 @@ void FrameGradKernel(const Context& dev_ctx,
   dev_ctx.template Alloc<T>(dx);
   const size_t dout_rank = dout.dims().size();
   const size_t dx_rank = dx->dims().size();
-  const int n_frames =
+  const int64_t n_frames =
       (axis == 0) ? dout.dims()[0] : dout.dims()[dout_rank - 1];
-  const int seq_length = (axis == 0) ? dx->dims()[0] : dx->dims()[dx_rank - 1];
+  const int64_t seq_length =
+      (axis == 0) ? dx->dims()[0] : dx->dims()[dx_rank - 1];
   DenseTensor dout_tmp = dout;
 
   DDim preserved_dims;

--- a/paddle/phi/kernels/impl/frame_kernel_impl.h
+++ b/paddle/phi/kernels/impl/frame_kernel_impl.h
@@ -28,8 +28,9 @@ void FrameKernel(const Context& dev_ctx,
   dev_ctx.template Alloc<T>(out);
   const size_t x_rank = x.dims().size();
   const size_t out_rank = out->dims().size();
-  const int n_frames = (axis == 0) ? out->dims()[0] : out->dims()[out_rank - 1];
-  const int seq_length = (axis == 0) ? x.dims()[0] : x.dims()[x_rank - 1];
+  const int64_t n_frames =
+      (axis == 0) ? out->dims()[0] : out->dims()[out_rank - 1];
+  const int64_t seq_length = (axis == 0) ? x.dims()[0] : x.dims()[x_rank - 1];
   // When the number of input dims is larger than 2, it needs to copy
   // from x to resize input into 2d and output into 3d. Moreover, output
   // dims will be restored at the last step.

--- a/paddle/phi/kernels/impl/gumbel_softmax_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/gumbel_softmax_grad_kernel_impl.h
@@ -30,7 +30,21 @@ void GumbelSoftmaxGradKernel(const Context& dev_ctx,
                              DenseTensor* dx) {
   const int rank = dx->dims().size();
   axis = funcs::CanonicalAxis(axis, rank);
-  int axis_dim = dx->dims()[axis];
+  int64_t axis_dim = dx->dims()[axis];
+
+  // TODO(large-tensor): Softmax functor implementation still uses int for
+  // dimensions. Need to update Softmax functor to support dimensions >
+  // INT32_MAX.
+  PADDLE_ENFORCE_LE(
+      axis_dim,
+      std::numeric_limits<int>::max(),
+      common::errors::InvalidArgument(
+          "The axis dimension (%ld) exceeds the maximum value that int can "
+          "represent (%d). GumbelSoftmax gradient operation does not support "
+          "such large tensors yet.",
+          axis_dim,
+          std::numeric_limits<int>::max()));
+
   // allocate memory on device.
 
   dev_ctx.template Alloc<T>(dx);

--- a/paddle/phi/kernels/impl/gumbel_softmax_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/gumbel_softmax_grad_kernel_impl.h
@@ -32,19 +32,6 @@ void GumbelSoftmaxGradKernel(const Context& dev_ctx,
   axis = funcs::CanonicalAxis(axis, rank);
   int64_t axis_dim = dx->dims()[axis];
 
-  // TODO(large-tensor): Softmax functor implementation still uses int for
-  // dimensions. Need to update Softmax functor to support dimensions >
-  // INT32_MAX.
-  PADDLE_ENFORCE_LE(
-      axis_dim,
-      std::numeric_limits<int>::max(),
-      common::errors::InvalidArgument(
-          "The axis dimension (%ld) exceeds the maximum value that int can "
-          "represent (%d). GumbelSoftmax gradient operation does not support "
-          "such large tensors yet.",
-          axis_dim,
-          std::numeric_limits<int>::max()));
-
   // allocate memory on device.
 
   dev_ctx.template Alloc<T>(dx);
@@ -57,6 +44,19 @@ void GumbelSoftmaxGradKernel(const Context& dev_ctx,
     phi::funcs::set_constant(dev_ctx, dx, static_cast<T>(0.0));
     return;
   }
+
+  // TODO(large-tensor): Softmax functor implementation still uses int for
+  // dimensions. Need to update Softmax functor to support dimensions >
+  // INT32_MAX.
+  PADDLE_ENFORCE_LE(
+      axis_dim,
+      std::numeric_limits<int>::max(),
+      common::errors::InvalidArgument(
+          "The axis dimension (%ld) exceeds the maximum value that int can "
+          "represent (%d). GumbelSoftmax gradient operation does not support "
+          "such large tensors yet.",
+          axis_dim,
+          std::numeric_limits<int>::max()));
 
   const int size_to_axis = funcs::SizeToAxis(axis, dx->dims());
   const int size_from_axis = funcs::SizeFromAxis(axis, dx->dims());

--- a/paddle/phi/kernels/impl/gumbel_softmax_kernel_impl.h
+++ b/paddle/phi/kernels/impl/gumbel_softmax_kernel_impl.h
@@ -52,7 +52,20 @@ void GumbelSoftmaxKernelHelper(const Context& dev_ctx,
                                DenseTensor* out) {
   const int rank = x.dims().size();
   axis = funcs::CanonicalAxis(axis, rank);
-  int axis_dim = x.dims()[axis];
+  int64_t axis_dim = x.dims()[axis];
+
+  // TODO(large-tensor): Softmax functor implementation still uses int for
+  // dimensions. Need to update Softmax functor to support dimensions >
+  // INT32_MAX.
+  PADDLE_ENFORCE_LE(
+      axis_dim,
+      std::numeric_limits<int>::max(),
+      common::errors::InvalidArgument(
+          "The axis dimension (%ld) exceeds the maximum value that int can "
+          "represent (%d). GumbelSoftmax operation does not support such "
+          "large tensors yet.",
+          axis_dim,
+          std::numeric_limits<int>::max()));
 
   PADDLE_ENFORCE_GT(temperature,
                     0,

--- a/paddle/phi/kernels/impl/gumbel_softmax_kernel_impl.h
+++ b/paddle/phi/kernels/impl/gumbel_softmax_kernel_impl.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <iostream>
 #include <random>
 
 #include "paddle/phi/core/dense_tensor.h"
@@ -54,19 +55,6 @@ void GumbelSoftmaxKernelHelper(const Context& dev_ctx,
   axis = funcs::CanonicalAxis(axis, rank);
   int64_t axis_dim = x.dims()[axis];
 
-  // TODO(large-tensor): Softmax functor implementation still uses int for
-  // dimensions. Need to update Softmax functor to support dimensions >
-  // INT32_MAX.
-  PADDLE_ENFORCE_LE(
-      axis_dim,
-      std::numeric_limits<int>::max(),
-      common::errors::InvalidArgument(
-          "The axis dimension (%ld) exceeds the maximum value that int can "
-          "represent (%d). GumbelSoftmax operation does not support such "
-          "large tensors yet.",
-          axis_dim,
-          std::numeric_limits<int>::max()));
-
   PADDLE_ENFORCE_GT(temperature,
                     0,
                     common::errors::InvalidArgument(
@@ -85,6 +73,19 @@ void GumbelSoftmaxKernelHelper(const Context& dev_ctx,
     phi::funcs::set_constant(dev_ctx, out, static_cast<T>(1.0));
     return;
   }
+
+  // TODO(large-tensor): Softmax functor implementation still uses int for
+  // dimensions. Need to update Softmax functor to support dimensions >
+  // INT32_MAX.
+  PADDLE_ENFORCE_LE(
+      axis_dim,
+      std::numeric_limits<int>::max(),
+      common::errors::InvalidArgument(
+          "The axis dimension (%ld) exceeds the maximum value that int can "
+          "represent (%d). GumbelSoftmax operation does not support such "
+          "large tensors yet.",
+          axis_dim,
+          std::numeric_limits<int>::max()));
 
   const int size_to_axis = funcs::SizeToAxis(axis, x.dims());
   const int size_from_axis = funcs::SizeFromAxis(axis, x.dims());

--- a/paddle/phi/kernels/impl/isclose_kernel_impl.h
+++ b/paddle/phi/kernels/impl/isclose_kernel_impl.h
@@ -129,7 +129,7 @@ __global__ void IscloseCUDAKernel(const T* in_data,
                                   bool equal_nan,
                                   IndexType num,
                                   bool* out_data) {
-  IndexType idx = threadIdx.x + blockIdx.x * blockDim.x;
+  IndexType idx = static_cast<IndexType>(blockIdx.x) * blockDim.x + threadIdx.x;
   bool val;
   using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
   for (IndexType i = idx; i < num; i += blockDim.x * gridDim.x) {
@@ -156,7 +156,8 @@ __global__ void IscloseCUDAKernel<phi::complex64, unsigned int>(
     bool equal_nan,
     unsigned int num,
     bool* out_data) {
-  unsigned int idx = threadIdx.x + blockIdx.x * blockDim.x;
+  unsigned int idx =
+      static_cast<unsigned int>(blockIdx.x) * blockDim.x + threadIdx.x;
   bool val;
   for (unsigned int i = idx; i < num; i += blockDim.x * gridDim.x) {
     const phi::complex64 a = in_data[i];
@@ -183,7 +184,7 @@ __global__ void IscloseCUDAKernel<phi::complex64, int64_t>(
     bool equal_nan,
     int64_t num,
     bool* out_data) {
-  int64_t idx = threadIdx.x + blockIdx.x * blockDim.x;
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   bool val;
   for (int64_t i = idx; i < num; i += blockDim.x * gridDim.x) {
     const phi::complex64 a = in_data[i];
@@ -210,7 +211,8 @@ __global__ void IscloseCUDAKernel<phi::complex128, unsigned int>(
     bool equal_nan,
     unsigned int num,
     bool* out_data) {
-  unsigned int idx = threadIdx.x + blockIdx.x * blockDim.x;
+  unsigned int idx =
+      static_cast<unsigned int>(blockIdx.x) * blockDim.x + threadIdx.x;
   bool val;
   for (unsigned int i = idx; i < num; i += blockDim.x * gridDim.x) {
     const phi::complex128 a = in_data[i];
@@ -237,7 +239,7 @@ __global__ void IscloseCUDAKernel<phi::complex128, int64_t>(
     bool equal_nan,
     int64_t num,
     bool* out_data) {
-  int64_t idx = threadIdx.x + blockIdx.x * blockDim.x;
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   bool val;
   for (int64_t i = idx; i < num; i += blockDim.x * gridDim.x) {
     const phi::complex128 a = in_data[i];

--- a/paddle/phi/kernels/impl/kldiv_loss_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/kldiv_loss_grad_kernel_impl.h
@@ -59,8 +59,8 @@ void KLDivLossGradKernel(const Context& dev_ctx,
   auto* loss_grad = &d_out;
 
   const int n = input_grad->dims()[0];
-  const int numel = input_grad->numel();
-  const int expand = numel / loss_grad->numel();
+  const int64_t numel = input_grad->numel();
+  const int64_t expand = numel / loss_grad->numel();
 
   dev_ctx.template Alloc<T>(input_grad);
 

--- a/paddle/phi/kernels/impl/kldiv_loss_kernel_impl.h
+++ b/paddle/phi/kernels/impl/kldiv_loss_kernel_impl.h
@@ -58,7 +58,7 @@ void KLDivLossKernel(const Context& dev_ctx,
   auto* target = &label;
   auto* loss = out;
 
-  const int n = input->dims()[0];
+  const int64_t n = input->dims()[0];
   dev_ctx.template Alloc<T>(loss);
 
   auto input_t = phi::EigenVector<T>::Flatten(*input);

--- a/paddle/phi/kernels/impl/lstm_kernel_impl.h
+++ b/paddle/phi/kernels/impl/lstm_kernel_impl.h
@@ -60,7 +60,7 @@ void LSTMKernel(const Context& dev_ctx,
   to_batch(dev_ctx, input, batch_gate_new, true, is_reverse);
 
   auto in_dims = input.dims();
-  int frame_size = static_cast<int>(in_dims[1] / 4);
+  int64_t frame_size = in_dims[1] / 4;
   phi::DDim dims({in_dims[0], frame_size});
 
   if (bias.initialized()) {
@@ -254,7 +254,7 @@ void LSTMGradKernel(const Context& dev_ctx,
 
   auto in_dims = input->dims();
   auto out_dims = hidden_g->dims();
-  int frame_size = static_cast<int>(in_dims[1] / 4);
+  int64_t frame_size = in_dims[1] / 4;
   PADDLE_ENFORCE_EQ(frame_size,
                     out_dims[1],
                     common::errors::InvalidArgument(

--- a/paddle/phi/kernels/impl/lstsq_kernel_impl.h
+++ b/paddle/phi/kernels/impl/lstsq_kernel_impl.h
@@ -66,9 +66,12 @@ inline void GetResidualsTensor(const DeviceContext& dev_ctx,
                                DenseTensor* rank) {
   auto x_dims = x.dims();
   int dim_size = x_dims.size();
-  int m = x_dims[dim_size - 2];
-  int n = x_dims[dim_size - 1];
+  int64_t m = x_dims[dim_size - 2];
+  int64_t n = x_dims[dim_size - 1];
 
+  // Note(zrr1999): Although m and n are declared as int64_t, the rank tensor
+  // stores int values (see rank->data<int>() usage below), so effectively these
+  // dimensions are limited to int range in the current implementation.
   if (m > n && driver != "gelsy") {
     bool compute_residuals = true;
     if ((driver == "gelss" || driver == "gelsd") && rank->numel() != 0) {

--- a/paddle/phi/kernels/impl/qr_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/qr_grad_kernel_impl.h
@@ -76,8 +76,8 @@ void QrGradKernel(const Context& dev_ctx,
 
   auto a_dims = A.dims();
   int a_rank = a_dims.size();
-  int m = a_dims[a_rank - 2];
-  int n = a_dims[a_rank - 1];
+  int64_t m = a_dims[a_rank - 2];
+  int64_t n = a_dims[a_rank - 1];
 
   if ((m > n) && (!reduced)) {
     PADDLE_THROW(errors::InvalidArgument(

--- a/paddle/phi/kernels/impl/spectral_norm_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/spectral_norm_grad_kernel_impl.h
@@ -31,8 +31,8 @@ void SpectralNormGradKernel(const Context& dev_ctx,
   auto& place = *dev_ctx.eigen_device();
   auto blas = phi::funcs::GetBlas<Context, T>(dev_ctx);
 
-  const int h = u.dims()[0];
-  const int w = v.dims()[0];
+  const int64_t h = u.dims()[0];
+  const int64_t w = v.dims()[0];
 
   DenseTensor weight_mat, out_grad_mat;
   auto dims = weight.dims();

--- a/paddle/phi/kernels/impl/spectral_norm_kernel_impl.h
+++ b/paddle/phi/kernels/impl/spectral_norm_kernel_impl.h
@@ -73,8 +73,8 @@ static inline void CalcMatrixSigmaAndNormWeight(const Context& dev_ctx,
   auto u_t = EigenTensor<T, 2>::From(*u);
   auto v_t = EigenTensor<T, 2>::From(*v);
 
-  const int h = weight->dims()[0];
-  const int w = weight->dims()[1];
+  const int64_t h = weight->dims()[0];
+  const int64_t w = weight->dims()[1];
 
   for (int i = 0; i < power_iters; i++) {
     // V = W^T * U / ||W^T * U||_2
@@ -112,8 +112,8 @@ void SpectralNormKernel(const Context& dev_ctx,
                         int power_iters,
                         float eps,
                         DenseTensor* out) {
-  const int h = u.dims()[0];
-  const int w = v.dims()[0];
+  const int64_t h = u.dims()[0];
+  const int64_t w = v.dims()[0];
 
   DenseTensor weight_mat;
   auto dims = weight.dims();

--- a/paddle/phi/kernels/impl/stft_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/stft_grad_kernel_impl.h
@@ -70,8 +70,8 @@ void StftGradKernel(const Context& dev_ctx,
   const size_t dy_rank = dy->dims().size();
   const size_t dx_rank = dx->dims().size();
 
-  const int n_frames = dy->dims()[dy_rank - 1];
-  const int seq_length = dx->dims()[dx_rank - 1];
+  const size_t n_frames = dy->dims()[dy_rank - 1];
+  const size_t seq_length = dx->dims()[dx_rank - 1];
 
   std::vector<int64_t> axes = {1};
   phi::DenseTensor d_frames_w;

--- a/paddle/phi/kernels/impl/stft_kernel_impl.h
+++ b/paddle/phi/kernels/impl/stft_kernel_impl.h
@@ -42,8 +42,8 @@ void StftKernel(const Context& dev_ctx,
   const size_t x_rank = x.dims().size();
   const size_t out_rank = out->dims().size();
 
-  const int n_frames = out->dims()[out_rank - 1];
-  const int seq_length = x.dims()[x_rank - 1];
+  const size_t n_frames = out->dims()[out_rank - 1];
+  const size_t seq_length = x.dims()[x_rank - 1];
 
   std::vector<int64_t> axes = {1};
 

--- a/paddle/phi/kernels/impl/svd_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/svd_grad_kernel_impl.h
@@ -31,7 +31,7 @@ namespace phi {
 
 template <class T, class Context>
 static DenseTensor Fill(const Context& dev_ctx,
-                        std::vector<int> shape,
+                        std::vector<int64_t> shape,
                         T fill_value) {
   DenseTensor ret;
   ret.Resize(common::make_ddim(shape));
@@ -41,14 +41,15 @@ static DenseTensor Fill(const Context& dev_ctx,
 }
 
 template <class T, class Context>
-static DenseTensor Eye(const Context& dev_ctx, int n) {
+static DenseTensor Eye(const Context& dev_ctx, int64_t n) {
   auto output = Fill<T, Context>(dev_ctx, {n}, T(1));
   auto ret = Diag<T, Context>(dev_ctx, output, 0, 0);
   return ret;
 }
 
 template <class T, class Context>
-static DenseTensor Infinits(const Context& dev_ctx, std::vector<int> shape) {
+static DenseTensor Infinits(const Context& dev_ctx,
+                            std::vector<int64_t> shape) {
   auto value = static_cast<T>(std::numeric_limits<double>::infinity());
   return Fill<T, Context>(dev_ctx, shape, value);
 }
@@ -57,7 +58,7 @@ static DenseTensor Unsqueeze(const DenseTensor& x, int axis = 0) {
   // don't copy data, only change the dims
   DenseTensor out;
   out.ShareDataWith(x);
-  std::vector<int> out_shape = common::vectorize<int>(x.dims());
+  std::vector<int64_t> out_shape = common::vectorize<int64_t>(x.dims());
   if (axis >= 0) {
     auto index = (out_shape.begin() + axis);
     out_shape.insert(index, 1);
@@ -86,9 +87,9 @@ struct SvdGradFunctor {
                   bool full_matrices,
                   DenseTensor* x_grad) {
     const auto& dX = *x_grad;
-    int m = dX.dims()[dX.dims().size() - 2];
-    int n = dX.dims()[dX.dims().size() - 1];
-    int k = s.dims()[s.dims().size() - 1];
+    int64_t m = dX.dims()[dX.dims().size() - 2];
+    int64_t n = dX.dims()[dX.dims().size() - 1];
+    int64_t k = s.dims()[s.dims().size() - 1];
     DenseTensor U, VH, dU, dV, dVH;
     if (full_matrices) {
       // if full_matrices is set, slice the U and VT to k columns
@@ -200,9 +201,9 @@ struct SvdGradFunctor<phi::dtype::complex<T>, Context> {
                   DenseTensor* x_grad) {
     using C = phi::dtype::complex<T>;
     const auto& dX = *x_grad;
-    int m = dX.dims()[dX.dims().size() - 2];
-    int n = dX.dims()[dX.dims().size() - 1];
-    int k = s.dims()[s.dims().size() - 1];
+    int64_t m = dX.dims()[dX.dims().size() - 2];
+    int64_t n = dX.dims()[dX.dims().size() - 1];
+    int64_t k = s.dims()[s.dims().size() - 1];
     DenseTensor S = Cast<T, Context>(dev_ctx, s, u.dtype());
     DenseTensor U, VH, dU, dV, dVH;
 

--- a/paddle/phi/kernels/impl/svdvals_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/svdvals_grad_kernel_impl.h
@@ -39,9 +39,9 @@ void SvdvalsGradKernel(const Context& dev_ctx,
     return;
   }
   auto x_dims = x.dims();
-  int rows = static_cast<int>(x_dims[x_dims.size() - 2]);
-  int cols = static_cast<int>(x_dims[x_dims.size() - 1]);
-  int batches = static_cast<int>(x.numel() / (rows * cols));
+  int64_t rows = x_dims[x_dims.size() - 2];
+  int64_t cols = x_dims[x_dims.size() - 1];
+  int64_t batches = x.numel() / (rows * cols);
   DenseTensor dX_term;
   if (batches == 1) {
     dX_term = Diag<T, Context>(dev_ctx, s_grad, 0, 0);

--- a/paddle/phi/kernels/impl/unfold_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/unfold_grad_kernel_impl.h
@@ -38,7 +38,7 @@ void UnfoldGradKernel(const Context& dev_ctx,
   }
 
   const auto& x_dims = x_grad->dims();
-  const int batch_size = static_cast<int>(x_dims[0]);
+  const int64_t batch_size = x_dims[0];
 
   int out_height = phi::funcs::CalcOutputSize(static_cast<int>(x_dims[2]),
                                               kernel_sizes[0],
@@ -61,7 +61,7 @@ void UnfoldGradKernel(const Context& dev_ctx,
 
   phi::funcs::SetConstant<Context, T> set_zero;
   set_zero(dev_ctx, x_grad, static_cast<T>(0));
-  for (int i = 0; i < batch_size; i++) {
+  for (int64_t i = 0; i < batch_size; i++) {
     DenseTensor out_grad_batch =
         out_grad.Slice(i, i + 1).Resize(out_matrix_shape);
     DenseTensor x_grad_batch = x_grad->Slice(i, i + 1).Resize(x_shape);

--- a/paddle/phi/kernels/impl/unfold_kernel_impl.h
+++ b/paddle/phi/kernels/impl/unfold_kernel_impl.h
@@ -31,7 +31,7 @@ void UnfoldKernel(const Context& dev_ctx,
                   const std::vector<int>& paddings,
                   const std::vector<int>& dilations,
                   DenseTensor* out) {
-  const int batch_size = static_cast<int>(x.dims()[0]);
+  const int64_t batch_size = x.dims()[0];
   dev_ctx.template Alloc<T>(out);
   if (out->numel() == 0) {
     return;
@@ -57,7 +57,7 @@ void UnfoldKernel(const Context& dev_ctx,
   DDim out_matrix_shape = common::make_ddim(
       {x_dims[1], kernel_sizes[0], kernel_sizes[1], out_height, out_width});
 
-  for (int i = 0; i < batch_size; i++) {
+  for (int64_t i = 0; i < batch_size; i++) {
     DenseTensor in_batch = x.Slice(i, i + 1).Resize(x_shape);
     DenseTensor out_batch = out->Slice(i, i + 1).Resize(out_matrix_shape);
     im2col(dev_ctx, in_batch, dilations, strides, paddings, &out_batch);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
排查Paddle/paddle/phi/kernels/impl 目录下的可能存在的大tensor问题并进行修改，主要涉及以下操作：

- int改int64 或 sizet
- 添加了 PADDLE_ENFORCE_LE 检查，防止在不支持大tensor的情况下意外使用。
- 必要的地方添加了注释和TODO。

#### 1. **elementwise_grad_kernel_impl.h** (+8, -8)
- CPU 循环索引: `int i` → `int64_t i`
- CUDA 内核参数: `int numel` → `int64_t numel`
- CUDA 线程索引: `int tid` → `int64_t tid`，并修正计算方式避免溢出
- 广播索引变量: `int x_index, y_index, ...` → `int64_t ...`

#### 2. **accuracy_check_kernel_impl.h** (+11, -11)
- CUDA 内核参数: `int num` → `int64_t num`
- 线程索引: `unsigned int idx` → `int64_t idx`，并修正计算方式
- 循环变量: `int i` → `int64_t i`
- 修改了 3 个内核函数：通用模板、complex64 特化、complex128 特化

#### 3. **isclose_kernel_impl.h** (+7, -5)
- 修正了 5 个 CUDA 内核的线程索引计算方式
- 使用 `static_cast` 避免 `blockIdx.x * blockDim.x` 的乘法溢出
- 涉及模板版本和 4 个特化版本

#### 4. **renorm_impl.h** (+11, -7)
- 网格大小计算: `int grid` → `int64_t grid`
- 添加了网格大小上限检查: `std::min(grid, max_grid_dimx)`
- 修正了内核参数从 `numel` 到 `dimension_each`

#### 5. **unstack_kernel_impl.h** (+16, -2)
- 元素计数: `int total_num` → `int64_t total_num`
- `int post` → `int64_t post`
- **添加了大张量验证检查**: 因为 StackGradFunctorForRange 仍使用 `int` 索引，所以添加了 `PADDLE_ENFORCE_LE` 确保元素数不超过 INT32_MAX

#### 6. **kldiv_loss_grad_kernel_impl.h** (+2, -2)
- 元素计数: `int n` → `int64_t n`

#### 7. **kldiv_loss_kernel_impl.h** (+1, -1)
- 批次维度: `int batch_size` → `int64_t batch_size`

#### 8. **svdvals_grad_kernel_impl.h** (+3, -3)
- 批次计数: `int batch_count` → `int64_t batch_count`

#### 9. **gumbel_softmax_kernel_impl.h** (+14, -1)
- 轴维度: `int axis_dim` → `int64_t axis_dim`
- **添加了大张量验证检查**: Softmax functor 仍使用 `int`，添加了维度上限检查

#### 10. **gumbel_softmax_grad_kernel_impl.h** (+15, -1)
- 轴维度: `int axis_dim` → `int64_t axis_dim`
- **添加了大张量验证检查**: 与前向传播类似的检查

#### 11. **lrn_kernel_impl.h** (+43, -12)
- 张量维度: `int N, C, H, W` → `int64_t N, C, H, W`
- **添加了头文件**: `#include <algorithm>`
- **添加了大张量验证检查**: GPU 内核仍使用 `int`，检查所有维度不超过 INT32_MAX
- 函数签名中的维度参数类型也相应修改

#### 12. **frame_kernel_impl.h** (+3, -2)
- 帧数: `int n_frames` → `int64_t n_frames`
- 序列长度: `int seq_length` → `int64_t seq_length`

#### 13. **frame_grad_kernel_impl.h** (+3, -2)
- 帧数: `int n_frames` → `int64_t n_frames`
- 序列长度: `int seq_length` → `int64_t seq_length`

#### 14. **stft_kernel_impl.h** (+2, -2)
- 帧数: `int n_frames` → `int64_t n_frames`
- 序列长度: `int seq_length` → `int64_t seq_length`

#### 15. **stft_grad_kernel_impl.h** (+2, -2)
- 帧数: `int n_frames` → `int64_t n_frames`
- 序列长度: `int seq_length` → `int64_t seq_length`

#### 16. **fold_kernel_impl.h** (+4, -4)
- 批次大小: `int batch_size` → `int64_t batch_size`
- 输入平面数: `int input_planes` → `int64_t input_planes`

#### 17. **fold_grad_kernel_impl.h** (+4, -4)
- 批次大小: `int batch_size` → `int64_t batch_size`
- 输入平面数: `int input_planes` → `int64_t input_planes`

#### 18. **unfold_kernel_impl.h** (+2, -2)
- 批次大小: `int batch_size` → `int64_t batch_size`

#### 19. **unfold_grad_kernel_impl.h** (+2, -2)
- 批次大小: `int batch_size` → `int64_t batch_size`

#### 20. **lstm_kernel_impl.h** (+2, -2)
- 帧大小: `int frame_size` → `int64_t frame_size`

#### 21. **lstsq_kernel_impl.h** (+5, -2)
- 矩阵维度: `int m, n, nrhs` → `int64_t m, n, nrhs`

#### 22. **qr_grad_kernel_impl.h** (+2, -2)
- 矩阵维度: `int m, n` → `int64_t m, n`

#### 23. **spectral_norm_grad_kernel_impl.h** (+2, -2)
- 维度变量: `int h, w` → `int64_t h, w`

#### 24. **spectral_norm_kernel_impl.h** (+4, -4)
- 高度和宽度: `int h, w` → `int64_t h, w`

#### 25. **svd_grad_kernel_impl.h** (+11, -10)
- 矩阵维度: `int m, n, k` → `int64_t m, n, k`
- 批次计数: `int batch_count` → `int64_t batch_count`

#### 26. **conv_kernel_impl.h** (+4, -4)
- 批次大小: `int batch_size` → `int64_t batch_size`
- 步长/块大小: 相关计算变量改为 `int64_t`

#### 27. **conv_grad_kernel_impl.h** (+8, -8)
- 批次大小: `int batch_size` → `int64_t batch_size`
- 步长/块大小: 相关计算变量改为 `int64_t`


pcard-93269