### PR TITLE
[API Compatibility] Fix tensor `__eq__` and  `__ne__` for unsupported type

### DIFF
--- a/paddle/fluid/pybind/eager_math_op_patch.cc
+++ b/paddle/fluid/pybind/eager_math_op_patch.cc
@@ -2283,8 +2283,16 @@ static PyObject* tensor__eq__method(TensorObject* self,
       other_tensor = paddle::empty({}, phi::DataType::FLOAT32, place);
       InitTensorWithNumpyValue(numpy_value, place, &other_tensor);
     } else {
-      paddle::experimental::Scalar value =
-          CastPyArg2Scalar(other_obj, "__eq__", 0);
+      paddle::experimental::Scalar value;
+
+      // return False if other_obj is unsupported type
+      try {
+        value = CastPyArg2Scalar(other_obj, "__eq__", 0);
+      } catch (const ::common::enforce::EnforceNotMet& e) {
+        Py_INCREF(Py_False);
+        return Py_False;
+      }
+
       if (PyComplex_Check(other_obj)) {
         eager_gil_scoped_release guard;
         other_tensor =

--- a/paddle/fluid/pybind/eager_math_op_patch.cc
+++ b/paddle/fluid/pybind/eager_math_op_patch.cc
@@ -2190,8 +2190,16 @@ static PyObject* tensor__ne__method(TensorObject* self,
       other_tensor = paddle::empty({}, phi::DataType::FLOAT32, place);
       InitTensorWithNumpyValue(numpy_value, place, &other_tensor);
     } else {
-      paddle::experimental::Scalar value =
-          CastPyArg2Scalar(other_obj, "__ne__", 0);
+      paddle::experimental::Scalar value;
+
+      // return True if other_obj is unsupported type
+      try {
+        value = CastPyArg2Scalar(other_obj, "__ne__", 0);
+      } catch (const ::common::enforce::EnforceNotMet& e) {
+        Py_INCREF(Py_True);
+        return Py_True;
+      }
+
       if (PyComplex_Check(other_obj)) {
         eager_gil_scoped_release guard;
         other_tensor =

--- a/python/paddle/pir/math_op_patch.py
+++ b/python/paddle/pir/math_op_patch.py
@@ -533,7 +533,7 @@ def monkey_patch_value():
                             lhs_dtype,
                             other_var,
                         )
-                elif other_var is not None:
+                else:
                     # add fill_op to current_block
                     other_var = paddle.tensor.creation.fill_constant(
                         [],

--- a/python/paddle/pir/math_op_patch.py
+++ b/python/paddle/pir/math_op_patch.py
@@ -504,6 +504,13 @@ def monkey_patch_value():
                 # but only +, -, *, / can use this method
                 if scalar_method is not None:
                     return scalar_method(self, other_var)
+            elif other_var is None:
+                if method_name == "__eq__":
+                    return False
+                elif method_name == "__ne__":
+                    return True
+                else:
+                    pass
             else:
                 # do nothing
                 pass

--- a/python/paddle/pir/math_op_patch.py
+++ b/python/paddle/pir/math_op_patch.py
@@ -526,7 +526,7 @@ def monkey_patch_value():
                             lhs_dtype,
                             other_var,
                         )
-                else:
+                elif other_var is not None:
                     # add fill_op to current_block
                     other_var = paddle.tensor.creation.fill_constant(
                         [],

--- a/python/paddle/tensor/logic.py
+++ b/python/paddle/tensor/logic.py
@@ -584,8 +584,6 @@ def equal(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
     if not isinstance(
         y, (int, bool, float, Variable, complex, paddle.pir.Value)
     ):
-        if y is None:
-            return False
         raise TypeError(
             f"Type of input args must be float, bool, complex, int or Tensor, but received type {type(y)}"
         )
@@ -1113,8 +1111,6 @@ def not_equal(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
             Tensor(shape=[3], dtype=bool, place=Place(cpu), stop_gradient=True,
             [False, True , True ])
     """
-    if y is None:
-        return True
     if in_dynamic_or_pir_mode():
         return _C_ops.not_equal(x, y)
     else:

--- a/python/paddle/tensor/logic.py
+++ b/python/paddle/tensor/logic.py
@@ -584,6 +584,8 @@ def equal(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
     if not isinstance(
         y, (int, bool, float, Variable, complex, paddle.pir.Value)
     ):
+        if y is None:
+            return False
         raise TypeError(
             f"Type of input args must be float, bool, complex, int or Tensor, but received type {type(y)}"
         )
@@ -1111,6 +1113,8 @@ def not_equal(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
             Tensor(shape=[3], dtype=bool, place=Place(cpu), stop_gradient=True,
             [False, True , True ])
     """
+    if y is None:
+        return True
     if in_dynamic_or_pir_mode():
         return _C_ops.not_equal(x, y)
     else:

--- a/test/legacy_test/test_eager_tensor.py
+++ b/test/legacy_test/test_eager_tensor.py
@@ -401,7 +401,9 @@ class TestEagerTensor(unittest.TestCase):
 
         with self.assertRaises(RuntimeError) as context:
             paddle.tensor(
-                self.array, device="cpu", pin_memory=True  # no support
+                self.array,
+                device="cpu",
+                pin_memory=True,  # no support
             )
         self.assertIn(
             "Pinning memory is not supported",
@@ -1529,9 +1531,18 @@ class TestEagerTensor(unittest.TestCase):
         paddle_scalar = paddle.uniform([], min=-100, max=100)
         self.assertRaises(ValueError, paddle_scalar.__format__, "3d")
 
-    def test_tensor_eq_none(self):
+    def test_tensor_eq_unsupported_type(self):
         a = paddle.empty([2])
-        self.assertFalse(a is None)
+
+        # Compare with None
+        self.assertFalse(a == None)  # noqa: E711
+        self.assertTrue(a != None)  # noqa: E711
+
+        # Compare with other obj
+        self.assertFalse(a == "a string")
+        self.assertTrue(a != "a string")
+        self.assertFalse(a == object())
+        self.assertTrue(a != object())
 
 
 class TestEagerTensorSetitem(unittest.TestCase):

--- a/test/legacy_test/test_eager_tensor.py
+++ b/test/legacy_test/test_eager_tensor.py
@@ -1539,8 +1539,6 @@ class TestEagerTensor(unittest.TestCase):
         self.assertTrue(a != None)  # noqa: E711
 
         # Compare with other obj
-        self.assertFalse(a == "a string")
-        self.assertTrue(a != "a string")
         self.assertFalse(a == object())
         self.assertTrue(a != object())
 

--- a/test/legacy_test/test_eager_tensor.py
+++ b/test/legacy_test/test_eager_tensor.py
@@ -1529,6 +1529,10 @@ class TestEagerTensor(unittest.TestCase):
         paddle_scalar = paddle.uniform([], min=-100, max=100)
         self.assertRaises(ValueError, paddle_scalar.__format__, "3d")
 
+    def test_tensor_eq_none(self):
+        a = paddle.empty([2])
+        self.assertFalse(a is None)
+
 
 class TestEagerTensorSetitem(unittest.TestCase):
     def func_setUp(self):

--- a/test/legacy_test/test_math_op_patch_pir.py
+++ b/test/legacy_test/test_math_op_patch_pir.py
@@ -451,6 +451,8 @@ class TestMathOpPatchesPir(unittest.TestCase):
                     e = x != y
                     f = x.not_equal(y)
                     g = x.__ne__(y)
+                    self.assertFalse(x == None)  # noqa: E711
+                    self.assertTrue(x != None)  # noqa: E711
                     (e_np, f_np, g_np) = exe.run(
                         main_program,
                         feed={"x": x_np, "y": y_np},


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
支持 `paddle.Tensor` 和 `pir.Value` 类型的 var 和 `None` 的 `__eq__` 和 `__ne__` 操作

示例：
``` python
import paddle
x = paddle.tensor(1.)
if x == None:  # get False in all case
    pass
if x != None:  # get True in all case
    pass
```