### PR TITLE
[Auto-Parallel] Fix test_semi_auto_parallel_for_llama_subnet

### DIFF
--- a/test/auto_parallel/semi_auto_parallel_for_llama_attention.py
+++ b/test/auto_parallel/semi_auto_parallel_for_llama_attention.py
@@ -147,21 +147,21 @@ class TestLlamaAttentionForSemiAutoParallel:
             np1, np2, rtol=rtol, atol=atol, verbose=verbose
         )
 
-    def check_dim_mapping(self, output, expected_dim_mapping):
-        assert output.dist_attr.dims_mapping == expected_dim_mapping, (
-            f"{output.dist_attr.dims_mapping}  vs {expected_dim_mapping}"
+    def check_placements(self, output, expected_placements):
+        assert output.placements == expected_placements, (
+            f"{output.placements}  vs {expected_placements}"
         )
 
-    def get_shard_check_hook(self, dims_mapping, check_input=False):
+    def get_shard_check_hook(self, placements, check_input=False):
         def check_func(layer, input, output=None):
             if check_input:
                 if isinstance(input, tuple):
                     input = input[0]
-                self.check_dim_mapping(input, dims_mapping)
+                self.check_placements(input, placements)
             else:
                 if isinstance(output, tuple):
                     output = output[0]
-                self.check_dim_mapping(output, dims_mapping)
+                self.check_placements(output, placements)
 
         return check_func
 
@@ -169,10 +169,10 @@ class TestLlamaAttentionForSemiAutoParallel:
         self.set_random_seed(self._seed)
 
         dp_layer = LlamaAttention("dp_demo_weight")
-        qkv_proj_pre_hook = self.get_shard_check_hook([0, -1, -1], True)
-        qkv_proj_post_hook = self.get_shard_check_hook([0, -1, -1])
-        o_proj_pre_hook = self.get_shard_check_hook([0, -1, -1], True)
-        o_proj_post_hook = self.get_shard_check_hook([0, -1, -1])
+        qkv_proj_pre_hook = self.get_shard_check_hook([Shard(0)], True)
+        qkv_proj_post_hook = self.get_shard_check_hook([Shard(0)])
+        o_proj_pre_hook = self.get_shard_check_hook([Shard(0)], True)
+        o_proj_post_hook = self.get_shard_check_hook([Shard(0)])
 
         dp_layer.qkv_proj.register_forward_pre_hook(qkv_proj_pre_hook)
         dp_layer.qkv_proj.register_forward_post_hook(qkv_proj_post_hook)
@@ -196,9 +196,9 @@ class TestLlamaAttentionForSemiAutoParallel:
             LlamaAttention("mp_demo_weight"), self._mesh, self.mp_shard_fn
         )
 
-        qkv_proj_post_hook = self.get_shard_check_hook([-1, -1, 0])
-        o_proj_pre_hook = self.get_shard_check_hook([-1, -1, 0], True)
-        o_proj_post_hook = self.get_shard_check_hook([-1, -1, -1])
+        qkv_proj_post_hook = self.get_shard_check_hook([Shard(2)])
+        o_proj_pre_hook = self.get_shard_check_hook([Shard(2)], True)
+        o_proj_post_hook = self.get_shard_check_hook([Replicate()])
 
         mp_layer.qkv_proj.register_forward_post_hook(qkv_proj_post_hook)
         mp_layer.o_proj.register_forward_pre_hook(o_proj_pre_hook)
@@ -218,9 +218,9 @@ class TestLlamaAttentionForSemiAutoParallel:
             LlamaAttention("mp_demo_weight"), dp_mp_mesh, self.dp_mp_shard_fn
         )
 
-        qkv_proj_post_hook = self.get_shard_check_hook([0, -1, 1])
-        o_proj_pre_hook = self.get_shard_check_hook([0, -1, 1], True)
-        o_proj_post_hook = self.get_shard_check_hook([0, -1, -1])
+        qkv_proj_post_hook = self.get_shard_check_hook([Shard(0), Shard(2)])
+        o_proj_pre_hook = self.get_shard_check_hook([Shard(0), Shard(2)], True)
+        o_proj_post_hook = self.get_shard_check_hook([Shard(0), Replicate()])
 
         dp_mp_layer.qkv_proj.register_forward_post_hook(qkv_proj_post_hook)
         dp_mp_layer.o_proj.register_forward_pre_hook(o_proj_pre_hook)

--- a/test/auto_parallel/semi_auto_parallel_for_llama_decoder.py
+++ b/test/auto_parallel/semi_auto_parallel_for_llama_decoder.py
@@ -21,7 +21,7 @@ import paddle
 import paddle.distributed as dist
 import paddle.nn.functional as F
 from paddle import nn
-from paddle.distributed import Shard
+from paddle.distributed import Replicate, Shard
 from paddle.nn.functional.flash_attention import flash_attention
 
 BATCH_NUM = 4
@@ -228,21 +228,21 @@ class TestLlamaDecoderForSemiAutoParallel:
             np1, np2, rtol=rtol, atol=atol, verbose=verbose
         )
 
-    def check_dim_mapping(self, output, expected_dim_mapping):
-        assert output.dist_attr.dims_mapping == expected_dim_mapping, (
-            f"{output.dist_attr.dims_mapping}  vs {expected_dim_mapping}"
+    def check_placements(self, output, expected_placements):
+        assert output.placements == expected_placements, (
+            f"{output.placements}  vs {expected_placements}"
         )
 
-    def get_shard_check_hook(self, dims_mapping, check_input=False):
+    def get_shard_check_hook(self, placements, check_input=False):
         def check_func(layer, input, output=None):
             if check_input:
                 if isinstance(input, tuple):
                     input = input[0]
-                self.check_dim_mapping(input, dims_mapping)
+                self.check_placements(input, placements)
             else:
                 if isinstance(output, tuple):
                     output = output[0]
-                self.check_dim_mapping(output, dims_mapping)
+                self.check_placements(output, placements)
 
         return check_func
 
@@ -250,16 +250,16 @@ class TestLlamaDecoderForSemiAutoParallel:
         self.set_random_seed(self._seed)
 
         dp_layer = LlamaLayerDecoder("dp_demo_weight")
-        input_layer_norm_pre_hook = self.get_shard_check_hook([0, -1, -1], True)
-        input_layer_norm_post_hook = self.get_shard_check_hook([0, -1, -1])
-        attn_pre_hook = self.get_shard_check_hook([0, -1, -1], True)
-        attn_post_hook = self.get_shard_check_hook([0, -1, -1])
+        input_layer_norm_pre_hook = self.get_shard_check_hook([Shard(0)], True)
+        input_layer_norm_post_hook = self.get_shard_check_hook([Shard(0)])
+        attn_pre_hook = self.get_shard_check_hook([Shard(0)], True)
+        attn_post_hook = self.get_shard_check_hook([Shard(0)])
         post_attn_layer_norm_pre_hook = self.get_shard_check_hook(
-            [0, -1, -1], True
+            [Shard(0)], True
         )
-        post_attn_layer_norm_post_hook = self.get_shard_check_hook([0, -1, -1])
-        mlp_pre_hook = self.get_shard_check_hook([0, -1, -1], True)
-        mlp_post_hook = self.get_shard_check_hook([0, -1, -1])
+        post_attn_layer_norm_post_hook = self.get_shard_check_hook([Shard(0)])
+        mlp_pre_hook = self.get_shard_check_hook([Shard(0)], True)
+        mlp_post_hook = self.get_shard_check_hook([Shard(0)])
 
         dp_layer.input_layernorm.register_forward_pre_hook(
             input_layer_norm_pre_hook
@@ -298,15 +298,17 @@ class TestLlamaDecoderForSemiAutoParallel:
             LlamaLayerDecoder("mp_demo_weight"), self._mesh, self.mp_shard_fn
         )
 
-        input_layer_norm_post_hook = self.get_shard_check_hook([-1, -1, -1])
-        attn_pre_hook = self.get_shard_check_hook([-1, -1, -1], True)
-        attn_post_hook = self.get_shard_check_hook([-1, -1, -1])
+        input_layer_norm_post_hook = self.get_shard_check_hook([Replicate()])
+        attn_pre_hook = self.get_shard_check_hook([Replicate()], True)
+        attn_post_hook = self.get_shard_check_hook([Replicate()])
         post_attn_layer_norm_pre_hook = self.get_shard_check_hook(
-            [-1, -1, -1], True
+            [Replicate()], True
         )
-        post_attn_layer_norm_post_hook = self.get_shard_check_hook([-1, -1, -1])
-        mlp_pre_hook = self.get_shard_check_hook([-1, -1, -1], True)
-        mlp_post_hook = self.get_shard_check_hook([-1, -1, -1])
+        post_attn_layer_norm_post_hook = self.get_shard_check_hook(
+            [Replicate()]
+        )
+        mlp_pre_hook = self.get_shard_check_hook([Replicate()], True)
+        mlp_post_hook = self.get_shard_check_hook([Replicate()])
 
         mp_layer.input_layernorm.register_forward_post_hook(
             input_layer_norm_post_hook


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
问题：
单测test_semi_auto_parallel_for_llama_subnet，从V卡迁移到H卡，报错输出tensor没有dist_attr属性。
分析：
由于单测中device_prop_main >= 8的存在，一些样例只会在A卡以上执行，V卡上会直接跳过，之前其实一直没验到。
由于现在的dist_tensor没有dist_attr和dim_mapping属性，可以使用类似属性placements作为替代，验证切分正确性。
修复：
将测试中检查dim_mapping的部分，等效修改为检查placements。
card-92763