### PR TITLE
[CI] Skip PIR version validation on non release branch and forked repo

### DIFF
--- a/.github/workflows/validate-pir-versions.yml
+++ b/.github/workflows/validate-pir-versions.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   check-version-and-create-issue:
     runs-on: ubuntu-latest
-    if: github.ref_type == 'branch' && startsWith(github.ref, 'refs/heads/release/')
+    if: ${{ github.ref_type == 'branch' && startsWith(github.ref, 'refs/heads/release/') && github.repository_owner == 'PaddlePaddle' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/validate-pir-versions.yml
+++ b/.github/workflows/validate-pir-versions.yml
@@ -2,14 +2,12 @@ name: Check version equality on release branch
 
 on:
   create:
-    branches:
-      - 'release/**'
   workflow_dispatch:
 
 jobs:
   check-version-and-create-issue:
     runs-on: ubuntu-latest
-    if: github.ref_type == 'branch'
+    if: github.ref_type == 'branch' && startsWith(github.ref, 'refs/heads/release/')
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/validate-pir-versions.yml
+++ b/.github/workflows/validate-pir-versions.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   check-version-and-create-issue:
     runs-on: ubuntu-latest
-    if: ${{ github.ref_type == 'branch' && startsWith(github.ref, 'refs/heads/release/') && github.repository_owner == 'PaddlePaddle' }}
+    if: github.ref_type == 'branch' && startsWith(github.ref, 'refs/heads/release/') && github.repository_owner == 'PaddlePaddle'
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

现在 `validate-pir-versions` 会产生大量误报

- 「问题一」所有在 upstream PaddlePaddle/Paddle 创建的分支都会创建一个 issue https://github.com/PaddlePaddle/Paddle/issues?q=sort%3Aupdated-desc%20is%3Aissue%20DEVELOP_VERSION ，不过所幸在主 repo 创建分支的不多
- 「问题二」所有在 forked repo 里创建的分支都会创建一个 issue https://github.com/cattidea/Paddle/issues?q=sort%3Aupdated-desc%20is%3Aissue%20DEVELOP_VERSION ，这个就多了，基本上每个 PR 都会触发一个

因此本 PR 分两个 commit 对该问题修复和测试：

- 5f20de848830fc656e78c869090bd5925115d176 用于修复「问题一」，因为 `branches` 在 create 事件下不是有效字段，只能通过 if
   - 测试项 1：在 forked repo 创建 `xxx` 分支不会创建 issue https://github.com/cattidea/Paddle/actions/runs/18915063102
   - 测试项 2：在 forked repo 创建 `release/xxx` 分支会创建 issue https://github.com/cattidea/Paddle/actions/runs/18915075511 cattidea/Paddle#981
- a36910069a9eddd8580a2b54107f85ac76001718 用于修复「问题二」
   - 测试项：在 forked repo 创建 `release/yyy` 分支不会创建 issue https://github.com/cattidea/Paddle/actions/runs/18915140510

<!-- PCard-66972 -->