### PR TITLE
Fix CUDA12.9 Hopper Test

### DIFF
--- a/.github/workflows/_Doc-Preview.yml
+++ b/.github/workflows/_Doc-Preview.yml
@@ -55,7 +55,7 @@ jobs:
           AGILE_COMPILE_BRANCH: ${{ github.event.pull_request.base.ref }}
           BOS_CREDENTIAL_AK: "paddle"
           BOS_CREDENTIAL_SK: "paddle"
-          PADDLE_WHL: https://paddle-github-action.cdn.bcebos.com/PR/build/${{ github.event.pull_request.number }}/${{ github.event.pull_request.head.sha }}/paddlepaddle_gpu-0.0.0-cp310-cp310-linux_x86_64.whl
+          PADDLE_WHL: https://paddle-github-action.bj.bcebos.com/PR/build/${{ github.event.pull_request.number }}/${{ github.event.pull_request.head.sha }}/paddlepaddle_gpu-0.0.0-cp310-cp310-linux_x86_64.whl
         run: |
           container_name=${TASK}-$(date +%Y%m%d-%H%M%S)
           echo "container_name=${container_name}" >> ${{ github.env }}

--- a/paddle/phi/backends/dynload/dynamic_loader.cc
+++ b/paddle/phi/backends/dynload/dynamic_loader.cc
@@ -1005,6 +1005,10 @@ void* GetNvtxDsoHandle() {
   PADDLE_THROW(
       common::errors::Unimplemented("Nvtx do not support without CUDA."));
 #else
+  if (CUDA_VERSION >= 12090) {
+    return GetDsoHandleFromSearchPath(FLAGS_cuda_dir, "libnvtx3interop.so.1");
+  }
+#endif
   return GetDsoHandleFromSearchPath(FLAGS_cuda_dir, "libnvToolsExt.so");
 #endif
 }

--- a/paddle/phi/backends/dynload/dynamic_loader.cc
+++ b/paddle/phi/backends/dynload/dynamic_loader.cc
@@ -1008,7 +1008,6 @@ void* GetNvtxDsoHandle() {
   if (CUDA_VERSION >= 12090) {
     return GetDsoHandleFromSearchPath(FLAGS_cuda_dir, "libnvtx3interop.so.1");
   }
-#endif
   return GetDsoHandleFromSearchPath(FLAGS_cuda_dir, "libnvToolsExt.so");
 #endif
 }

--- a/test/quantization/CMakeLists.txt
+++ b/test/quantization/CMakeLists.txt
@@ -247,6 +247,11 @@ if(NOT WITH_GPU)
   list(REMOVE_ITEM TEST_OPS test_apply_per_channel_scale)
 endif()
 
+#
+if(${CUDA_ARCH_NAME} STREQUAL "Hopper")
+  list(REMOVE_ITEM TEST_OPS test_weight_only_linear)
+endif()
+
 if(LINUX AND WITH_ONEDNN)
 
   #### Image classification dataset: ImageNet (small)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
test_cuda_unittest: CUDA12.9 不默认安装libnvToolsExt.so
test_weight_only_linear: weight_only_linear 算子未支持 SM90
有人反馈 PADDLE_WHL 使用cdn下载有问题，切换原网站