### PR TITLE
Support Dump forward api python call stack

### DIFF
--- a/paddle/common/flags.cc
+++ b/paddle/common/flags.cc
@@ -740,7 +740,7 @@ PHI_DEFINE_EXPORTED_int32(
 /**
  * Debug related FLAG
  * Name: dump_grad_node_forward_stack_path
- * Since Version: 3.2.1
+ * Since Version: 3.3
  * Value Range: string, default=""
  * Example:
  * Note: Dump grad node forward call stack to the dir path.
@@ -748,25 +748,37 @@ PHI_DEFINE_EXPORTED_int32(
 PHI_DEFINE_EXPORTED_string(dump_grad_node_forward_stack_path,
                            "",
                            "Dump grad node forward call stack to the dir path");
+/**
+ * Debug related FLAG
+ * Name: dump_api_python_stack_path
+ * Since Version: 3.3
+ * Value Range: string, default=""
+ * Example:
+ * Note: Dump api forward python call stack to the dir path.
+ */
+PHI_DEFINE_EXPORTED_string(
+    dump_api_python_stack_path,
+    "",
+    "Dump api forward python call stack to the dir path");
 
 /**
  * Debug related FLAG
- * Name: tensor_md5_checksum_output_dir
- * Since Version: 3.2.1
+ * Name: tensor_md5_checksum_output_path
+ * Since Version: 3.3
  * Value Range: string, default=""
  * Example:
- * Note: Export all API output tensors to the specified directory.
- * If tensor_md5_checksum_output_dir is "", this flag will not take effect.
+ * Note: Export all API output tensors to the specified file.
+ * If tensor_md5_checksum_output_path is "", this flag will not take effect.
  */
 PHI_DEFINE_EXPORTED_string(
-    tensor_md5_checksum_output_dir,
+    tensor_md5_checksum_output_path,
     "",
-    "Export all API output tensors to the specified directory.");
+    "Export all API output tensors to the specified file.");
 
 /**
  * Debug related FLAG
  * Name: enable_unique_name
- * Since Version: 3.2.1
+ * Since Version: 3.3
  * Value Range: bool, default=false
  * Example:
  * Note: If True,the Tensor, C++ API and GradNode will has unique name,such as

--- a/paddle/common/flags.h
+++ b/paddle/common/flags.h
@@ -127,6 +127,9 @@ PADDLE_API void AllowUndefinedFlags();
  */
 bool SetFlagValue(const std::string& name, const std::string& value);
 
+PADDLE_API bool UpdateLinkedFlags(const std::string& name,
+                                  const std::string& value);
+
 /**
  * @brief Find flag by name, return true if found.
  */
@@ -170,6 +173,15 @@ inline bool SetFlagValue(const char* name, const char* value) {
 }
 #else
 using paddle::flags::SetFlagValue;
+#endif
+#ifdef PADDLE_WITH_GFLAGS
+inline bool UpdateLinkedFlags(const std::string& name,
+                              const std::string& value) {
+  // Gflags does not support this feature.
+  return false;
+}
+#else
+using paddle::flags::UpdateLinkedFlags;
 #endif
 
 #ifdef PADDLE_WITH_GFLAGS

--- a/paddle/fluid/eager/api/manual/eager_manual/forwards/conv2d_fwd_function.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/forwards/conv2d_fwd_function.cc
@@ -212,6 +212,27 @@ paddle::Tensor conv2d_ad_func(
     grad_node->SetGradInMeta(out, 0);
     // Set TensorWrappers for Forward Outputs if needed
   }
+  if (VLOG_IS_ON(6)) {
+    const char* INPUT_PRINT_TEMPLATE =
+        "\nForward Debug Info {\nAPI_Name: %s \nInput: [%s]  \nOutput: [%s] } ";
+
+    std::string input_str = "";
+    std::string output_str = "";
+    const char* TENSOR_INPUT_TEMPLATE = " \n( input , %s), ";
+    std::string input_input_str = paddle::string::Sprintf(
+        TENSOR_INPUT_TEMPLATE, egr::EagerUtils::TensorStr(input));
+    input_str += input_input_str;
+    const char* TENSOR_FILTER_TEMPLATE = " \n( filter , %s), ";
+    std::string input_filter_str = paddle::string::Sprintf(
+        TENSOR_FILTER_TEMPLATE, egr::EagerUtils::TensorStr(filter));
+    input_str += input_filter_str;
+    const char* TENSOR_OUT_TEMPLATE = " \n( out , %s), ";
+    std::string output_out_str = paddle::string::Sprintf(
+        TENSOR_OUT_TEMPLATE, egr::EagerUtils::TensorStr(out));
+    output_str += output_out_str;
+    VLOG(6) << paddle::string::Sprintf(
+        INPUT_PRINT_TEMPLATE, unique_api_name, input_str, output_str);
+  }
 
   if (FLAGS_check_cuda_error) [[unlikely]] {
     egr::CUDAErrorCheck("conv2d_ad_func finish");

--- a/paddle/fluid/eager/api/manual/eager_manual/forwards/conv2d_fwd_function.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/forwards/conv2d_fwd_function.cc
@@ -25,6 +25,8 @@
 COMMON_DECLARE_bool(check_nan_inf);
 COMMON_DECLARE_bool(check_cuda_error);
 COMMON_DECLARE_bool(enable_unique_name);
+COMMON_DECLARE_string(tensor_md5_checksum_output_path);
+COMMON_DECLARE_string(dump_api_python_stack_path);
 
 paddle::Tensor conv2d_ad_func(
     const paddle::Tensor& input,
@@ -118,6 +120,12 @@ paddle::Tensor conv2d_ad_func(
     call_count++;
     unique_api_name = egr::GenerateUniqueApiName("conv2d", call_count);
   }
+  // Save forward call stack to file for debug
+  if (FLAGS_call_stack_level == 3 &&
+      !FLAGS_dump_api_python_stack_path.empty()) {
+    egr::SavePythonCallStackToFile(FLAGS_dump_api_python_stack_path,
+                                   unique_api_name);
+  }
   VLOG(3) << "\n"
           << SEPARATOR << "Running_C++_API: " << unique_api_name << SEPARATOR;
   auto api_result = paddle::experimental::conv2d(input,
@@ -139,6 +147,11 @@ paddle::Tensor conv2d_ad_func(
   auto& out = api_result;
   if (VLOG_IS_ON(6) || FLAGS_enable_unique_name) {
     egr::SetTensorName(unique_api_name, "out", &out);
+  }
+  // Save the tensors checksum to file_path
+  if (!FLAGS_tensor_md5_checksum_output_path.empty()) {
+    egr::SaveTensorMD5CheckSumToFile(FLAGS_tensor_md5_checksum_output_path,
+                                     out);
   }
 
   // Get Output AutoGradMeta

--- a/paddle/fluid/eager/api/manual/eager_manual/forwards/multiply_fwd_func.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/forwards/multiply_fwd_func.cc
@@ -28,6 +28,8 @@
 COMMON_DECLARE_bool(check_nan_inf);
 COMMON_DECLARE_bool(check_cuda_error);
 COMMON_DECLARE_bool(enable_unique_name);
+COMMON_DECLARE_string(tensor_md5_checksum_output_path);
+COMMON_DECLARE_string(dump_api_python_stack_path);
 
 #define SEPARATOR "=========================="
 bool check_if_support_elementwise_mul_mem_opt(const std::string& device_type) {
@@ -148,6 +150,12 @@ paddle::Tensor multiply_ad_func(
     call_count++;
     unique_api_name = egr::GenerateUniqueApiName("multiply", call_count);
   }
+  // Save forward call stack to file for debug
+  if (FLAGS_call_stack_level == 3 &&
+      !FLAGS_dump_api_python_stack_path.empty()) {
+    egr::SavePythonCallStackToFile(FLAGS_dump_api_python_stack_path,
+                                   unique_api_name);
+  }
   VLOG(3) << "\n"
           << SEPARATOR << "Running_C++_API: " << unique_api_name << SEPARATOR;
   // Forward API Call
@@ -163,6 +171,11 @@ paddle::Tensor multiply_ad_func(
   auto& out = api_result;
   if (VLOG_IS_ON(6) || FLAGS_enable_unique_name) {
     egr::SetTensorName(unique_api_name, "out", &out);
+  }
+  // Save the tensors checksum to file_path
+  if (!FLAGS_tensor_md5_checksum_output_path.empty()) {
+    egr::SaveTensorMD5CheckSumToFile(FLAGS_tensor_md5_checksum_output_path,
+                                     out);
   }
 
   // Get Output AutoGradMeta
@@ -393,6 +406,12 @@ paddle::Tensor& multiply__ad_func(
     call_count++;
     unique_api_name = egr::GenerateUniqueApiName("multiply_", call_count);
   }
+  // Save forward call stack to file for debug
+  if (FLAGS_call_stack_level == 3 &&
+      !FLAGS_dump_api_python_stack_path.empty()) {
+    egr::SavePythonCallStackToFile(FLAGS_dump_api_python_stack_path,
+                                   unique_api_name);
+  }
   VLOG(3) << "\n"
           << SEPARATOR << "Running_C++_API: " << unique_api_name << SEPARATOR;
   auto& api_result = paddle::experimental::multiply_(x, y);
@@ -409,6 +428,11 @@ paddle::Tensor& multiply__ad_func(
   auto& out = api_result;
   if (VLOG_IS_ON(6) || FLAGS_enable_unique_name) {
     egr::SetTensorName(unique_api_name, "out", &out);
+  }
+  // Save the tensors checksum to file_path
+  if (!FLAGS_tensor_md5_checksum_output_path.empty()) {
+    egr::SaveTensorMD5CheckSumToFile(FLAGS_tensor_md5_checksum_output_path,
+                                     out);
   }
 
   // Get Output AutoGradMeta

--- a/paddle/fluid/eager/api/manual/eager_manual/forwards/multiply_fwd_func.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/forwards/multiply_fwd_func.cc
@@ -255,8 +255,10 @@ paddle::Tensor multiply_ad_func(
   VLOG(4) << "\n" << SEPARATOR << "Finish_AD_API: multiply" << SEPARATOR;
   // LOG IF DEBUG
 
-  if (VLOG_IS_ON(4)) {
-    const char* INPUT_PRINT_TEMPLATE = "{ Input: [%s],  \n Output: [%s] } ";
+  if (VLOG_IS_ON(6)) {
+    const char* INPUT_PRINT_TEMPLATE =
+        "\nForward Debug Info {\nAPI_Name: [%s] : \n Input: [%s]  \n Output: "
+        "[%s] } ";
 
     std::string input_str = "";
     std::string output_str = "";
@@ -273,7 +275,7 @@ paddle::Tensor multiply_ad_func(
         TENSOR_OUT_TEMPLATE, egr::EagerUtils::TensorStr(out));
     output_str += output_out_str;
     VLOG(4) << paddle::string::Sprintf(
-        INPUT_PRINT_TEMPLATE, input_str, output_str);
+        INPUT_PRINT_TEMPLATE, unique_api_name, input_str, output_str);
   }
   if (FLAGS_check_cuda_error) [[unlikely]] {
     egr::CUDAErrorCheck("multiply_ad_func finish");
@@ -468,8 +470,10 @@ paddle::Tensor& multiply__ad_func(
 
   // LOG IF DEBUG
 
-  if (VLOG_IS_ON(4)) {
-    const char* INPUT_PRINT_TEMPLATE = "{ Input: [%s],  \n Output: [%s] } ";
+  if (VLOG_IS_ON(6)) {
+    const char* INPUT_PRINT_TEMPLATE =
+        "\nForward Debug Info {\nAPI_Name: [%s] : \n Input: [%s]  \n Output: "
+        "[%s] } ";
 
     std::string input_str = "";
     std::string output_str = "";
@@ -486,7 +490,7 @@ paddle::Tensor& multiply__ad_func(
         TENSOR_OUT_TEMPLATE, egr::EagerUtils::TensorStr(out));
     output_str += output_out_str;
     VLOG(4) << paddle::string::Sprintf(
-        INPUT_PRINT_TEMPLATE, input_str, output_str);
+        INPUT_PRINT_TEMPLATE, unique_api_name, input_str, output_str);
   }
 
   if (FLAGS_check_cuda_error) [[unlikely]] {

--- a/paddle/fluid/eager/api/manual/eager_manual/forwards/sync_batch_norm_fwd_func.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/forwards/sync_batch_norm_fwd_func.cc
@@ -353,8 +353,9 @@ sync_batch_norm__ad_func(const paddle::Tensor& x,
 
   // LOG IF DEBUG
 
-  if (VLOG_IS_ON(4)) {
-    const char* INPUT_PRINT_TEMPLATE = "{ Input: [%s],  \n Output: [%s] } ";
+  if (VLOG_IS_ON(6)) {
+    const char* INPUT_PRINT_TEMPLATE =
+        "\nForward Debug Info {\nAPI_Name: %s \nInput: [%s]  \nOutput: [%s] } ";
 
     std::string input_str = "";
     std::string output_str = "";
@@ -406,7 +407,7 @@ sync_batch_norm__ad_func(const paddle::Tensor& x,
                                 egr::EagerUtils::TensorStr(reserve_space));
     output_str += output_reserve_space_str;
     VLOG(4) << paddle::string::Sprintf(
-        INPUT_PRINT_TEMPLATE, input_str, output_str);
+        INPUT_PRINT_TEMPLATE, unique_api_name, input_str, output_str);
   }
   if (FLAGS_check_cuda_error) [[unlikely]] {
     egr::CUDAErrorCheck("sync_batch_norm__ad_func finish");

--- a/paddle/fluid/eager/api/manual/eager_manual/forwards/sync_batch_norm_fwd_func.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/forwards/sync_batch_norm_fwd_func.cc
@@ -26,6 +26,8 @@ COMMON_DECLARE_bool(check_nan_inf);
 COMMON_DECLARE_string(tensor_operants_mode);
 COMMON_DECLARE_bool(check_cuda_error);
 COMMON_DECLARE_bool(enable_unique_name);
+COMMON_DECLARE_string(tensor_md5_checksum_output_path);
+COMMON_DECLARE_string(dump_api_python_stack_path);
 
 std::tuple<paddle::Tensor,
            paddle::Tensor&,
@@ -167,6 +169,12 @@ sync_batch_norm__ad_func(const paddle::Tensor& x,
     unique_api_name =
         egr::GenerateUniqueApiName("sync_batch_norm_", call_count);
   }
+  // Save forward call stack to file for debug
+  if (FLAGS_call_stack_level == 3 &&
+      !FLAGS_dump_api_python_stack_path.empty()) {
+    egr::SavePythonCallStackToFile(FLAGS_dump_api_python_stack_path,
+                                   unique_api_name);
+  }
   VLOG(3) << "\n"
           << SEPARATOR << "Running_C++_API: " << unique_api_name << SEPARATOR;
   // Forward API Call
@@ -203,6 +211,21 @@ sync_batch_norm__ad_func(const paddle::Tensor& x,
     egr::SetTensorName(unique_api_name, "saved_mean", &saved_mean);
     egr::SetTensorName(unique_api_name, "saved_variance", &saved_variance);
     egr::SetTensorName(unique_api_name, "reserve_space", &reserve_space);
+  }
+  // Save the tensors checksum to file_path
+  if (!FLAGS_tensor_md5_checksum_output_path.empty()) {
+    egr::SaveTensorMD5CheckSumToFile(FLAGS_tensor_md5_checksum_output_path,
+                                     out);
+    egr::SaveTensorMD5CheckSumToFile(FLAGS_tensor_md5_checksum_output_path,
+                                     mean_out);
+    egr::SaveTensorMD5CheckSumToFile(FLAGS_tensor_md5_checksum_output_path,
+                                     variance_out);
+    egr::SaveTensorMD5CheckSumToFile(FLAGS_tensor_md5_checksum_output_path,
+                                     saved_mean);
+    egr::SaveTensorMD5CheckSumToFile(FLAGS_tensor_md5_checksum_output_path,
+                                     saved_variance);
+    egr::SaveTensorMD5CheckSumToFile(FLAGS_tensor_md5_checksum_output_path,
+                                     reserve_space);
   }
   // Get Output AutoGradMeta
   egr::AutogradMeta* out_autograd_meta = egr::EagerUtils::autograd_meta(&out);

--- a/paddle/fluid/eager/api/manual/eager_manual/nodes/conv2d_nodes.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/nodes/conv2d_nodes.cc
@@ -33,7 +33,7 @@ using egr::InputsContainDistTensor;
 COMMON_DECLARE_bool(check_nan_inf);
 COMMON_DECLARE_bool(check_cuda_error);
 COMMON_DECLARE_bool(enable_unique_name);
-COMMON_DECLARE_string(tensor_md5_checksum_output_dir);
+COMMON_DECLARE_string(tensor_md5_checksum_output_path);
 
 #define SEPARATOR "=========================="
 
@@ -170,10 +170,10 @@ Conv2dGradNodeFinal::operator()(
     egr::SetGradTensorName(&grad_filter, 1, out_metas);
   }
   // Save the tensors checksum to file_path
-  if (!FLAGS_tensor_md5_checksum_output_dir.empty()) {
-    egr::SaveTensorMD5CheckSumToFile(FLAGS_tensor_md5_checksum_output_dir,
+  if (!FLAGS_tensor_md5_checksum_output_path.empty()) {
+    egr::SaveTensorMD5CheckSumToFile(FLAGS_tensor_md5_checksum_output_path,
                                      grad_input);
-    egr::SaveTensorMD5CheckSumToFile(FLAGS_tensor_md5_checksum_output_dir,
+    egr::SaveTensorMD5CheckSumToFile(FLAGS_tensor_md5_checksum_output_path,
                                      grad_filter);
   }
 

--- a/paddle/fluid/eager/api/manual/eager_manual/nodes/multiply_node.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/nodes/multiply_node.cc
@@ -37,7 +37,7 @@ COMMON_DECLARE_bool(check_cuda_error);
 
 COMMON_DECLARE_bool(check_nan_inf);
 COMMON_DECLARE_bool(enable_unique_name);
-COMMON_DECLARE_string(tensor_md5_checksum_output_dir);
+COMMON_DECLARE_string(tensor_md5_checksum_output_path);
 
 #define SEPARATOR "=========================="
 paddle::small_vector<std::vector<paddle::Tensor>, egr::kSlotSmallVectorSize>
@@ -200,10 +200,10 @@ MultiplyGradNode::operator()(
   }
 
   // Save the tensors checksum to file_path
-  if (!FLAGS_tensor_md5_checksum_output_dir.empty()) {
-    egr::SaveTensorMD5CheckSumToFile(FLAGS_tensor_md5_checksum_output_dir,
+  if (!FLAGS_tensor_md5_checksum_output_path.empty()) {
+    egr::SaveTensorMD5CheckSumToFile(FLAGS_tensor_md5_checksum_output_path,
                                      grad_x);
-    egr::SaveTensorMD5CheckSumToFile(FLAGS_tensor_md5_checksum_output_dir,
+    egr::SaveTensorMD5CheckSumToFile(FLAGS_tensor_md5_checksum_output_path,
                                      grad_y);
   }
 

--- a/paddle/fluid/eager/api/manual/eager_manual/nodes/sync_batch_norm_node.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/nodes/sync_batch_norm_node.cc
@@ -31,7 +31,7 @@
 COMMON_DECLARE_bool(check_nan_inf);
 COMMON_DECLARE_bool(check_cuda_error);
 COMMON_DECLARE_bool(enable_unique_name);
-COMMON_DECLARE_string(tensor_md5_checksum_output_dir);
+COMMON_DECLARE_string(tensor_md5_checksum_output_path);
 #define SEPARATOR "=========================="
 paddle::small_vector<std::vector<paddle::Tensor>, egr::kSlotSmallVectorSize>
 SyncBatchNormGradNode::operator()(
@@ -215,12 +215,12 @@ SyncBatchNormGradNode::operator()(
   }
 
   // Save the tensors checksum to file_path
-  if (!FLAGS_tensor_md5_checksum_output_dir.empty()) {
-    egr::SaveTensorMD5CheckSumToFile(FLAGS_tensor_md5_checksum_output_dir,
+  if (!FLAGS_tensor_md5_checksum_output_path.empty()) {
+    egr::SaveTensorMD5CheckSumToFile(FLAGS_tensor_md5_checksum_output_path,
                                      x_grad);
-    egr::SaveTensorMD5CheckSumToFile(FLAGS_tensor_md5_checksum_output_dir,
+    egr::SaveTensorMD5CheckSumToFile(FLAGS_tensor_md5_checksum_output_path,
                                      scale_grad);
-    egr::SaveTensorMD5CheckSumToFile(FLAGS_tensor_md5_checksum_output_dir,
+    egr::SaveTensorMD5CheckSumToFile(FLAGS_tensor_md5_checksum_output_path,
                                      bias_grad);
   }
 

--- a/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
@@ -597,6 +597,14 @@ AFTER_LOG_PRINT_TEMPLATE = """
   }}
 """
 
+FORWARD_AFTER_LOG_PRINT_TEMPLATE = """
+  if (VLOG_IS_ON(6)) {{
+    const char* INPUT_PRINT_TEMPLATE = \"\\nForward Debug Info {{\\nAPI_Name: %s \\nInput: [%s]  \\nOutput: [%s] }} \";
+{}
+    VLOG(6) << paddle::string::Sprintf(INPUT_PRINT_TEMPLATE, unique_api_name, input_str, output_str);
+  }}
+"""
+
 BEFORE_LOG_PRINT_TEMPLATE = """
   if (VLOG_IS_ON(5)) {{
     const char* INPUT_PRINT_TEMPLATE = \"{{ Input: [%s]}} \";
@@ -2514,7 +2522,7 @@ class DygraphForwardFunctionGenerator(DygraphFunctionGeneratorBase):
             var_str += f"\n{indent}  std::string output_{name}_str = paddle::string::Sprintf(TENSOR_{name.upper()}_TEMPLATE, egr::EagerUtils::TensorStr({name}));"
             var_str += f"\n{indent}  output_str += output_{name}_str;"
 
-        log_str = AFTER_LOG_PRINT_TEMPLATE.format(var_str)
+        log_str = FORWARD_AFTER_LOG_PRINT_TEMPLATE.format(var_str)
 
         strided_flags_check = ""
         if is_inplaced and (

--- a/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
@@ -386,7 +386,7 @@ SET_ATTR_METHOD_TEMPLATE = """  void SetAttribute_{}({} {}) {{
 """
 SAVE_TENSOR_MD5_CHECKSUM_TEMPLATE = """
   // Save the tensors checksum to file_path
-  if(!FLAGS_tensor_md5_checksum_output_dir.empty()){{
+  if(!FLAGS_tensor_md5_checksum_output_path.empty()){{
 {}
   }}
 """
@@ -443,7 +443,7 @@ GRAD_FUNCTION_TEMPLATE = """
 paddle::small_vector<std::vector<paddle::Tensor>, egr::kSlotSmallVectorSize> {}::operator()(paddle::small_vector<std::vector<paddle::Tensor>, egr::kSlotSmallVectorSize>& grads, bool create_graph, bool is_new_grad) {{
   VLOG(3) << \"\\n\"<<separator<< \"Running_AD_API_GRAD: \" << \"{}\"<<separator;
   if (FLAGS_check_cuda_error) [[unlikely]] {{
-    egr::CUDAErrorCheck(\"{} begin\");
+    egr::CUDAErrorCheck(\"{} (\"+egr::GetGradNodeHexAddress(this)+\") begin\");
   }}
 
    // This 'Local_XXXGradNode' record event is different with 'Global_XXXGradNode' event.
@@ -501,7 +501,7 @@ paddle::small_vector<std::vector<paddle::Tensor>, egr::kSlotSmallVectorSize> {}:
   }}
 
   if (FLAGS_check_cuda_error) [[unlikely]] {{
-    egr::CUDAErrorCheck(\"{} finish\");
+    egr::CUDAErrorCheck(\"{} (\"+egr::GetGradNodeHexAddress(this)+\") finish\");
   }}
     VLOG(4) << \"\\n\"<<separator<<\"Finish_AD_API_GRAD: {}\"<<separator;
 
@@ -556,6 +556,11 @@ TEST_API {} {}({}) {{
     call_count ++;
     unique_api_name = egr::GenerateUniqueApiName(\"{}\", call_count);
   }}
+  // Save forward call stack to file for debug
+  if( FLAGS_call_stack_level == 3 && !FLAGS_dump_api_python_stack_path.empty()){{
+    egr::SavePythonCallStackToFile(FLAGS_dump_api_python_stack_path, unique_api_name);
+  }}
+
   VLOG(3) << \"\\n\"<<separator<<\"Running_C++_API: \" << unique_api_name << separator;
   // Forward API Call
 {}
@@ -634,7 +639,10 @@ TEST_API {} {}({}) {{
     call_count ++;
     unique_api_name = egr::GenerateUniqueApiName(\"{}\", call_count);
   }}
-
+  // Save forward call stack to file for debug
+  if( FLAGS_call_stack_level == 3 && !FLAGS_dump_api_python_stack_path.empty()){{
+    egr::SavePythonCallStackToFile(FLAGS_dump_api_python_stack_path, unique_api_name);
+  }}
   VLOG(3) << \"\\n\"<<separator<<\"Running_C++_API: \" << unique_api_name <<separator;
   // Forward API Call
 {}
@@ -755,7 +763,7 @@ NODE_CC_FILE_TEMPLATE = """
 COMMON_DECLARE_bool(check_nan_inf);
 COMMON_DECLARE_bool(check_cuda_error);
 COMMON_DECLARE_bool(enable_unique_name);
-COMMON_DECLARE_string(tensor_md5_checksum_output_dir);
+COMMON_DECLARE_string(tensor_md5_checksum_output_path);
 static std::string separator = "==========================";
 {}
 """
@@ -804,7 +812,8 @@ COMMON_DECLARE_bool(use_stride_kernel);
 COMMON_DECLARE_bool(use_stride_compute_kernel);
 COMMON_DECLARE_bool(check_cuda_error);
 COMMON_DECLARE_bool(enable_unique_name);
-COMMON_DECLARE_string(tensor_md5_checksum_output_dir);
+COMMON_DECLARE_string(tensor_md5_checksum_output_path);
+COMMON_DECLARE_string(dump_api_python_stack_path);
 static std::string separator = "==========================";
 {}
 {}
@@ -2158,7 +2167,7 @@ class DygraphForwardFunctionGenerator(DygraphFunctionGeneratorBase):
                     f"{indent}auto& {name} = std::get<{pos}>(api_result);\n"
                 )
             set_tensor_name_str += f'{indent}{indent}egr::SetTensorName(unique_api_name, "{name}", &{name});\n'
-            save_md5_checksum_str += f"{indent}{indent}egr::SaveTensorMD5CheckSumToFile(FLAGS_tensor_md5_checksum_output_dir, {name});\n"
+            save_md5_checksum_str += f"{indent}{indent}egr::SaveTensorMD5CheckSumToFile(FLAGS_tensor_md5_checksum_output_path, {name});\n"
 
         get_outputs_str += SET_TENSOR_NAME_TEMPLATE.format(set_tensor_name_str)
         get_outputs_str += SAVE_TENSOR_MD5_CHECKSUM_TEMPLATE.format(
@@ -3418,7 +3427,7 @@ if (paddle::prim::PrimCommonUtils::IsEagerPrimEnabled() && !need_skip) {{
     }}
 """
             set_tensor_name_str += f"""    egr::SetGradTensorName(&{transformed_tensor_name}, {pos}, out_metas);\n"""
-            save_md5_checksum_str += f"    egr::SaveTensorMD5CheckSumToFile(FLAGS_tensor_md5_checksum_output_dir, {transformed_tensor_name});\n"
+            save_md5_checksum_str += f"    egr::SaveTensorMD5CheckSumToFile(FLAGS_tensor_md5_checksum_output_path, {transformed_tensor_name});\n"
             outputs_autograd_meta_list.append(output_autograd_meta)
 
         outputs_autograd_meta_str = "\n".join(outputs_autograd_meta_list)

--- a/paddle/fluid/eager/utils.cc
+++ b/paddle/fluid/eager/utils.cc
@@ -17,6 +17,11 @@
 #include <ctime>
 #include <iomanip>
 #include <ostream>
+#ifdef _WIN32
+#include <Windows.h>
+#else
+#include <unistd.h>
+#endif
 #include "paddle/fluid/eager/accumulation/accumulation_node.h"
 #include "paddle/fluid/eager/api/utils/global_utils.h"
 #include "paddle/fluid/eager/api/utils/hook_utils.h"
@@ -37,6 +42,13 @@
 #include "paddle/utils/md5.h"
 COMMON_DECLARE_bool(enable_unique_name);
 COMMON_DECLARE_int32(tensor_md5_checksum_precision);
+
+#ifdef _WIN32
+#define getprocessid GetCurrentProcessId
+typedef int pid_t;
+#else
+#define getprocessid getpid
+#endif
 namespace egr {
 using paddle::inference::analysis::Dot;
 
@@ -1641,10 +1653,11 @@ const std::string FormatTensor(const paddle::Tensor& t) {
 
   return formatter.Format(dense_tensor, t.name());
 }
+
 void SaveStringToFileWithPID(const std::string& filename,
                              const std::string& content,
                              const std::string& mode = "trunc") {
-  pid_t pid = getpid();
+  pid_t pid = getprocessid();
   // Create the new filename with PID suffix
   std::string newFilename = filename + "." + std::to_string(pid);
   SaveStringToFile(newFilename, content, mode);

--- a/paddle/fluid/eager/utils.cc
+++ b/paddle/fluid/eager/utils.cc
@@ -1641,5 +1641,20 @@ const std::string FormatTensor(const paddle::Tensor& t) {
 
   return formatter.Format(dense_tensor, t.name());
 }
+void SaveStringToFileWithPID(const std::string& filename,
+                             const std::string& content,
+                             const std::string& mode = "trunc") {
+  pid_t pid = getpid();
+  // Create the new filename with PID suffix
+  std::string newFilename = filename + "." + std::to_string(pid);
+  SaveStringToFile(newFilename, content, mode);
+}
+void SavePythonCallStackToFile(const std::string& file_name,
+                               const std::string& api_name) {
+  SaveStringToFileWithPID(
+      file_name,
+      api_name + " : \n" + egr::Controller::Instance().GetPythonStack(),
+      "append");
+}
 
 }  // namespace egr

--- a/paddle/fluid/eager/utils.h
+++ b/paddle/fluid/eager/utils.h
@@ -483,4 +483,13 @@ void AddEdgeToDebugBackwardGraph(paddle::inference::analysis::Dot* dot,
                                  bool need_dump_backward_subgraph);
 
 const std::string FormatTensor(const paddle::Tensor& t);
+static inline std::string GetGradNodeHexAddress(GradNodeBase* ptr) {
+  std::ostringstream oss;
+  // Use std::hex to output in hexadecimal format
+  // std::showbase to include the 0x prefix
+  oss << std::showbase << std::hex << reinterpret_cast<std::uintptr_t>(ptr);
+  return oss.str();
+}
+void SavePythonCallStackToFile(const std::string& file_name,
+                               const std::string& api_name);
 }  // namespace egr

--- a/paddle/fluid/pybind/global_value_getter_setter.cc
+++ b/paddle/fluid/pybind/global_value_getter_setter.cc
@@ -191,6 +191,22 @@ class PYBIND11_HIDDEN GlobalVarGetterSetterRegistry {
     VLOG(7) << "set " << name << " to " << value;
     SetterMethod(name)(value);
   }
+  /**
+   * Update the value of linked variables
+   *
+   * @param name Name of the variable currently being modified
+   * @param value New value of the variable being modified
+   *
+   * This function updates the values of variables linked to the current
+   * modified variable by calling paddle::flags::UpdateLinkedFlags method.
+   */
+  void UpdateLinkedVars(const std::string &name, const std::string &value) {
+    bool is_updated = paddle::flags::UpdateLinkedFlags(name, value);
+    if (!is_updated) {
+      LOG(WARNING) << "Failed to update linked flags for variable name: "
+                   << name << " value " << value;
+    }
+  }
 
   bool HasGetterMethod(const std::string &name) const {
     return var_infos_.count(name) > 0;
@@ -240,7 +256,11 @@ void BindGlobalValueGetterSetter(pybind11::module *module) {
       .def("get",
            &GlobalVarGetterSetterRegistry::GetOrReturnDefaultValue,
            py::arg("key"),
-           py::arg("default") = py::cast<py::none>(Py_None));
+           py::arg("default") = py::cast<py::none>(Py_None))
+      .def("update_linked_vars",
+           &GlobalVarGetterSetterRegistry::UpdateLinkedVars,
+           py::arg("key"),
+           py::arg("value"));
 
   module->def("globals",
               &GlobalVarGetterSetterRegistry::Instance,

--- a/python/paddle/base/framework.py
+++ b/python/paddle/base/framework.py
@@ -150,6 +150,11 @@ def set_flags(flags: dict[str, bool | str | float]) -> None:
     for key, value in flags.items():
         if _global_flags().is_public(key):
             _global_flags()[key] = value
+            prefix = "FLAGS_"
+            if key.startswith(prefix):
+                _global_flags().update_linked_vars(
+                    key[len(prefix) :], str(value)
+                )
         else:
             raise ValueError(
                 f"Flag {key} cannot set its value through this function."

--- a/test/legacy_test/test_backward_dump_debug_info.py
+++ b/test/legacy_test/test_backward_dump_debug_info.py
@@ -151,6 +151,9 @@ paddle.base.core.set_vlog_level(4)
 import os
 os.environ['GLOG_v'] = '6'
 os.environ['FLAGS_dump_grad_node_forward_stack_path']="call_stack.log"
+os.environ['FLAGS_call_stack_level']='3'
+os.environ['FLAGS_dump_api_python_stack_path']="forward_call_stack"
+
 import paddle
 import paddle.nn.functional as F
 import paddle.nn as nn


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features 

### Description
<!-- Describe what you’ve done -->
支持根据唯一的api name导出前向api
### 新增功能：
通过设置``` FLAGS_dump_api_python_stack_path ```  指定一个文件路径，来导出所有前向API对应的调用栈。
输出的文件会以 FLAGS_dump_api_python_stack_path中指定的文件路径``` + .xxxx```的格式，xxxx是进程的pid。
```
gaussian1 : 
  File "/workspace/code/test/test_add.py", line 3, in <module>
    x = paddle.randn([2,3],dtype="float32")
  File "/usr/local/lib/python3.10/dist-packages/paddle/utils/decorator_utils.py", line 349, in wrapped_func
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/paddle/tensor/random.py", line 1079, in randn
    tensor = standard_normal(
  File "/usr/local/lib/python3.10/dist-packages/paddle/tensor/random.py", line 945, in standard_normal
    return gaussian(
  File "/usr/local/lib/python3.10/dist-packages/paddle/tensor/random.py", line 747, in gaussian
    tensor = _C_ops.gaussian(
cast1 : 
  File "/workspace/code/test/test_add.py", line 7, in <module>
    z1 = x - y
subtract1 : 
  File "/workspace/code/test/test_add.py", line 7, in <module>
    z1 = x - y
cast2 : 
  File "/workspace/code/test/test_add.py", line 8, in <module>
    z2 = x + y
add1 : 
  File "/workspace/code/test/test_add.py", line 8, in <module>
    z2 = x + y
sum1 : 
  File "/workspace/code/test/test_add.py", line 11, in <module>
    z4 = z3.sum()
  File "/usr/local/lib/python3.10/dist-packages/paddle/base/dygraph/generated_tensor_methods_patch.py", line 115, in _sum
    return _C_ops.sum(*args, **kwargs)
mean1 : 
  File "/workspace/code/test/test_add.py", line 12, in <module>
    z5 = z2.mean()
  File "/usr/local/lib/python3.10/dist-packages/paddle/utils/decorator_utils.py", line 213, in wrapper
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/paddle/tensor/stat.py", line 133, in mean
    return _C_ops.mean(x, axis, keepdim, out=out)
add2 : 
  File "/workspace/code/test/test_add.py", line 14, in <module>
    loss = z4 + z5
```

### 修复之前存在的问题：
- ``` tensor_md5_checksum_output_dir ```命名错误，应该是描述一个文件路径而非目录的路径
-  修复一些手写的前向ad_func中 漏掉的``` md5_checksum ```功能
-  ad_func 在最后打印输入输出Tensor时添加一些特殊的提示性前缀，比如``` Forward Debug Info ```，用于以后根据GLOG的输出构造前向图时使用。
- 反向GradNode中check_cuda_error的提示信息中可以打印this指针
- 添加FLAGS联动的功能，支持设置一个FLAGS的同时自动设置其依赖的FLAGS
``` linked_flags_["dump_api_python_stack_path"] = {{"enable_unique_name", "true"}, {"call_stack_level", "3"}};  ```
