### PR TITLE
[API compatibility] update paddle group_norm api

### DIFF
--- a/python/paddle/nn/functional/norm.py
+++ b/python/paddle/nn/functional/norm.py
@@ -14,8 +14,11 @@
 
 from __future__ import annotations
 
+import inspect
 import numbers
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
+
+from typing_extensions import overload
 
 import paddle
 from paddle import _C_ops, in_dynamic_mode
@@ -681,34 +684,52 @@ def local_response_norm(
     return res
 
 
-@param_two_alias(["x", "input"], ["epsilon", "eps"])
+@overload
 def group_norm(
     x: Tensor,
     num_groups: int,
+    epsilon: float = 1e-05,
     weight: Tensor | None = None,
     bias: Tensor | None = None,
-    epsilon: float = 1e-05,
     data_format: DataLayout1D | DataLayout2D | DataLayout3D = 'NCHW',
     name: str | None = None,
-) -> Tensor:
+) -> Tensor: ...
+
+
+@overload
+def group_norm(
+    input: Tensor,
+    num_groups: int,
+    weight: Tensor | None = None,
+    bias: Tensor | None = None,
+    eps: float = 1e-05,
+) -> Tensor: ...
+
+
+def group_norm(*args: Any, **kwargs: Any) -> Tensor:
     """
     nn.GroupNorm is recommended.
     For more information, please refer to :ref:`api_paddle_nn_GroupNorm` .
 
-    .. note::
-        Alias Support: The parameter name ``input`` can be used as an alias for ``x``.
-        For example, ``group_norm(input=tensor_x, ...)`` is equivalent to ``group_norm(x=tensor_x, ...)``.
+    This function has two functionalities, depending on the parameters passed:
+
+    1. ``group_norm(Tensor input, int num_groups, Tensor weight = None, Tensor bias = None, float eps = 1e-05)``:
+        PyTorch compatible group_norm.
+
+    2. ``group_norm(Tensor x, int num_groups, float epsilon = 1e-05, Tensor weight = None, Tensor bias = None,
+        DataLayout1D | DataLayout2D | DataLayout3D data_format = 'NCHW', str | None name = None)``:
+        The original paddle.nn.functional.group_norm, see the following docs.
 
     Parameters:
         x(Tensor): Input Tensor with shape: attr:`(batch, num_features, *)`.
             alias: ``input``.
         num_groups(int): The number of groups that divided from channels.
+        epsilon(float, optional): The small value added to the variance to prevent
+            division by zero. Default: 1e-05.
         weight(Tensor, optional): The weight Tensor of group_norm, with shape: attr:`[num_channels]`.
             Default: None.
         bias(Tensor, optional): The bias Tensor of group_norm, with shape: attr:`[num_channels]`.
             Default: None.
-        epsilon(float, optional): The small value added to the variance to prevent
-            division by zero. Default: 1e-05.
         data_format(str, optional): Specify the input data format. Support "NCL", "NCHW", "NCDHW", "NLC", "NHWC" or "NDHWC". Default: "NCHW".
         name(str|None, optional): Name for the GroupNorm, default is None. For more information, please refer to :ref:`api_guide_Name`..
 
@@ -750,6 +771,43 @@ def group_norm(
               [[-1.34163547, -0.44721183],
                [ 0.44721183,  1.34163547]]]])
     """
+
+    len_args = len(args)
+    if len_args + len(kwargs) < 2:
+        raise TypeError(
+            f"Too few arguments in the function call: {len_args}, {len(kwargs)}. Expect one of: \n"
+            " - (Tensor input, int num_groups, Tensor weight = None, Tensor bias = None, float eps = 1e-05)\n"
+            " - (Tensor x, int num_groups, float epsilon = 1e-05, Tensor weight = None, Tensor bias = None, "
+            "DataLayout1D | DataLayout2D | DataLayout3D data_format = 'NCHW', str | None name = None)"
+        )
+
+    is_origin_format = False
+    if len_args >= 3:
+        is_origin_format |= isinstance(args[2], float)
+
+    if is_origin_format:
+        return _group_norm_wrapper(*args, **kwargs)
+    else:
+        # transform params from (input,num_groups,weight,bias,eps) to (x,num_groups,epsilon,weight,bias)
+        param_keys = ['input', 'num_groups', 'weight', 'bias', 'eps']
+        for idx, arg in enumerate(args):
+            key = param_keys[idx]
+            if key in kwargs:
+                raise TypeError(f"got multiple values for argument '{key}'")
+            kwargs[key] = arg
+        return _group_norm_wrapper(**kwargs)
+
+
+@param_two_alias(["x", "input"], ["epsilon", "eps"])
+def _group_norm_wrapper(
+    x: Tensor,
+    num_groups: int,
+    epsilon: float = 1e-05,
+    weight: Tensor | None = None,
+    bias: Tensor | None = None,
+    data_format: DataLayout1D | DataLayout2D | DataLayout3D = 'NCHW',
+    name: str | None = None,
+) -> Tensor:
     if data_format not in ['NCL', 'NCHW', 'NCDHW', 'NLC', 'NHWC', 'NDHWC']:
         raise ValueError("unsupported data layout:" + data_format)
 
@@ -800,3 +858,6 @@ def group_norm(
         )
 
         return helper.append_activation(group_norm_out)
+
+
+group_norm.__signature__ = inspect.signature(_group_norm_wrapper)

--- a/python/paddle/nn/functional/norm.py
+++ b/python/paddle/nn/functional/norm.py
@@ -726,6 +726,7 @@ def group_norm(*args: Any, **kwargs: Any) -> Tensor:
         num_groups(int): The number of groups that divided from channels.
         epsilon(float, optional): The small value added to the variance to prevent
             division by zero. Default: 1e-05.
+            alias: ``eps``.
         weight(Tensor, optional): The weight Tensor of group_norm, with shape: attr:`[num_channels]`.
             Default: None.
         bias(Tensor, optional): The bias Tensor of group_norm, with shape: attr:`[num_channels]`.
@@ -781,24 +782,25 @@ def group_norm(*args: Any, **kwargs: Any) -> Tensor:
             "DataLayout1D | DataLayout2D | DataLayout3D data_format = 'NCHW', str | None name = None)"
         )
 
-    is_origin_format = False
-    if len_args >= 3:
-        is_origin_format |= isinstance(args[2], float)
+    def safe_set_param(key: str, value: Any):
+        if key in kwargs:
+            raise TypeError(f"got multiple values for argument '{key}'")
+        kwargs[key] = value
 
-    if is_origin_format:
-        return _group_norm_wrapper(*args, **kwargs)
-    else:
-        # transform params from (input,num_groups,weight,bias,eps) to (x,num_groups,epsilon,weight,bias)
-        param_keys = ['input', 'num_groups', 'weight', 'bias', 'eps']
-        for idx, arg in enumerate(args):
-            key = param_keys[idx]
-            if key in kwargs:
-                raise TypeError(f"got multiple values for argument '{key}'")
-            kwargs[key] = arg
-        return _group_norm_wrapper(**kwargs)
+    if 'input' in kwargs:
+        safe_set_param('x', kwargs.pop('input'))
+
+    if 'eps' in kwargs:
+        safe_set_param('epsilon', kwargs.pop('eps'))
+
+    if len_args >= 3 and not isinstance(args[2], float):
+        param_keys = ["weight", "bias", "epsilon"]
+        for idx in range(min(len_args - 2, len(param_keys))):
+            safe_set_param(param_keys[idx], args[idx + 2])
+        args = args[:2]
+    return _group_norm_wrapper(*args, **kwargs)
 
 
-@param_two_alias(["x", "input"], ["epsilon", "eps"])
 def _group_norm_wrapper(
     x: Tensor,
     num_groups: int,

--- a/python/paddle/nn/functional/norm.py
+++ b/python/paddle/nn/functional/norm.py
@@ -681,12 +681,13 @@ def local_response_norm(
     return res
 
 
+@param_two_alias(["x", "input"], ["epsilon", "eps"])
 def group_norm(
     x: Tensor,
     num_groups: int,
-    epsilon: float = 1e-05,
     weight: Tensor | None = None,
     bias: Tensor | None = None,
+    epsilon: float = 1e-05,
     data_format: DataLayout1D | DataLayout2D | DataLayout3D = 'NCHW',
     name: str | None = None,
 ) -> Tensor:
@@ -694,15 +695,20 @@ def group_norm(
     nn.GroupNorm is recommended.
     For more information, please refer to :ref:`api_paddle_nn_GroupNorm` .
 
+    .. note::
+        Alias Support: The parameter name ``input`` can be used as an alias for ``x``.
+        For example, ``group_norm(input=tensor_x, ...)`` is equivalent to ``group_norm(x=tensor_x, ...)``.
+
     Parameters:
         x(Tensor): Input Tensor with shape: attr:`(batch, num_features, *)`.
+            alias: ``input``.
         num_groups(int): The number of groups that divided from channels.
-        epsilon(float, optional): The small value added to the variance to prevent
-            division by zero. Default: 1e-05.
         weight(Tensor, optional): The weight Tensor of group_norm, with shape: attr:`[num_channels]`.
             Default: None.
         bias(Tensor, optional): The bias Tensor of group_norm, with shape: attr:`[num_channels]`.
             Default: None.
+        epsilon(float, optional): The small value added to the variance to prevent
+            division by zero. Default: 1e-05.
         data_format(str, optional): Specify the input data format. Support "NCL", "NCHW", "NCDHW", "NLC", "NHWC" or "NDHWC". Default: "NCHW".
         name(str|None, optional): Name for the GroupNorm, default is None. For more information, please refer to :ref:`api_guide_Name`..
 

--- a/python/paddle/nn/layer/norm.py
+++ b/python/paddle/nn/layer/norm.py
@@ -562,9 +562,9 @@ class GroupNorm(Layer):
         return group_norm(
             input,
             self._num_groups,
+            self._epsilon,
             self.weight,
             self.bias,
-            self._epsilon,
             self._data_format,
         )
 

--- a/python/paddle/nn/layer/norm.py
+++ b/python/paddle/nn/layer/norm.py
@@ -562,9 +562,9 @@ class GroupNorm(Layer):
         return group_norm(
             input,
             self._num_groups,
-            self._epsilon,
             self.weight,
             self.bias,
+            self._epsilon,
             self._data_format,
         )
 

--- a/test/legacy_test/test_group_norm_op_v2.py
+++ b/test/legacy_test/test_group_norm_op_v2.py
@@ -618,5 +618,56 @@ class TestGroupNormWithOptionalgradX(unittest.TestCase):
             np.testing.assert_equal(dx.numpy(), dx_ref.numpy())
 
 
+class TestGroupNormParam(unittest.TestCase):
+    def setUp(self):
+        np.random.seed(42)
+        self.x_np = np.random.randn(2, 6, 4, 4).astype('float32')
+        self.weight_np = np.random.randn(6).astype('float32')
+        self.bias_np = np.random.randn(6).astype('float32')
+
+    def test_alias_input_for_x(self):
+        """test parameter alias input/x"""
+        x_tensor = paddle.to_tensor(self.x_np)
+        weight_tensor = paddle.to_tensor(self.weight_np)
+        bias_tensor = paddle.to_tensor(self.bias_np)
+
+        out_with_input = paddle.nn.functional.group_norm(
+            input=x_tensor,
+            num_groups=3,
+            weight=weight_tensor,
+            bias=bias_tensor,
+            eps=1e-5,
+        )
+        out_with_x = paddle.nn.functional.group_norm(
+            x=x_tensor,
+            num_groups=3,
+            weight=weight_tensor,
+            bias=bias_tensor,
+            eps=1e-5,
+        )
+
+        np.testing.assert_array_equal(
+            out_with_input.numpy(), out_with_x.numpy()
+        )
+
+    def test_param_order(self):
+        """test order of parameters"""
+        x_tensor = paddle.to_tensor(self.x_np)
+        weight_tensor = paddle.to_tensor(self.weight_np)
+        bias_tensor = paddle.to_tensor(self.bias_np)
+
+        try:
+            out = paddle.nn.functional.group_norm(
+                x_tensor,  # x
+                3,  # num_groups
+                weight_tensor,  # weight
+                bias_tensor,  # bias
+                1e-5,  # epsilon
+            )
+            self.assertTrue(True, "Function call succeeded without error")
+        except Exception as e:
+            self.fail(f"Function raised an unexpected exception: {e}")
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/legacy_test/test_group_norm_op_v2.py
+++ b/test/legacy_test/test_group_norm_op_v2.py
@@ -620,29 +620,24 @@ class TestGroupNormWithOptionalgradX(unittest.TestCase):
 
 class TestGroupNormParam(unittest.TestCase):
     def setUp(self):
-        np.random.seed(42)
-        self.x_np = np.random.randn(2, 6, 4, 4).astype('float32')
-        self.weight_np = np.random.randn(6).astype('float32')
-        self.bias_np = np.random.randn(6).astype('float32')
+        self.x_tensor = paddle.randn([2, 6, 4, 4], dtype='float32')
+        self.weight_tensor = paddle.randn([6], dtype='float32')
+        self.bias_tensor = paddle.randn([6], dtype='float32')
 
     def test_alias_input_for_x(self):
         """test parameter alias input/x"""
-        x_tensor = paddle.to_tensor(self.x_np)
-        weight_tensor = paddle.to_tensor(self.weight_np)
-        bias_tensor = paddle.to_tensor(self.bias_np)
-
         out_with_input = paddle.nn.functional.group_norm(
-            input=x_tensor,
+            input=self.x_tensor,
             num_groups=3,
-            weight=weight_tensor,
-            bias=bias_tensor,
+            weight=self.weight_tensor,
+            bias=self.bias_tensor,
             eps=1e-5,
         )
         out_with_x = paddle.nn.functional.group_norm(
-            x=x_tensor,
+            x=self.x_tensor,
             num_groups=3,
-            weight=weight_tensor,
-            bias=bias_tensor,
+            weight=self.weight_tensor,
+            bias=self.bias_tensor,
             eps=1e-5,
         )
 
@@ -650,23 +645,102 @@ class TestGroupNormParam(unittest.TestCase):
             out_with_input.numpy(), out_with_x.numpy()
         )
 
-    def test_param_order(self):
-        """test order of parameters"""
-        x_tensor = paddle.to_tensor(self.x_np)
-        weight_tensor = paddle.to_tensor(self.weight_np)
-        bias_tensor = paddle.to_tensor(self.bias_np)
+    def test_params_consistency(self):
+        """test both paddle and torch formats works."""
+        out_old = paddle.nn.functional.group_norm(
+            self.x_tensor,
+            3,
+            1e-5,
+            weight=self.weight_tensor,
+            bias=self.bias_tensor,
+        )
 
+        out_new = paddle.nn.functional.group_norm(
+            x=self.x_tensor,
+            num_groups=3,
+            weight=self.weight_tensor,
+            bias=self.bias_tensor,
+            eps=1e-5,
+        )
+
+        np.testing.assert_array_equal(out_old.numpy(), out_new.numpy())
+
+    def test_params_1(self):
+        """test all args with torch format"""
         try:
             out = paddle.nn.functional.group_norm(
-                x_tensor,  # x
-                3,  # num_groups
-                weight_tensor,  # weight
-                bias_tensor,  # bias
-                1e-5,  # epsilon
+                self.x_tensor,
+                3,
+                self.weight_tensor,
+                self.bias_tensor,
+                1e-5,
             )
             self.assertTrue(True, "Function call succeeded without error")
         except Exception as e:
             self.fail(f"Function raised an unexpected exception: {e}")
+
+    def test_params_2(self):
+        """test all kwargs with torch format"""
+        try:
+            out = paddle.nn.functional.group_norm(
+                input=self.x_tensor,
+                num_groups=3,
+                weight=self.weight_tensor,
+                bias=self.bias_tensor,
+                epsilon=1e-5,
+            )
+            self.assertTrue(True, "Function call succeeded without error")
+        except Exception as e:
+            self.fail(f"Function raised an unexpected exception: {e}")
+
+    def test_params_3(self):
+        """test of passing both args and kwargs parameters"""
+        try:
+            out1 = paddle.nn.functional.group_norm(
+                self.x_tensor,
+                3,
+                weight=self.weight_tensor,
+                bias=self.bias_tensor,
+                epsilon=1e-5,
+            )
+            out2 = paddle.nn.functional.group_norm(
+                self.x_tensor,
+                3,
+                1e-5,
+                weight=self.weight_tensor,
+                bias=self.bias_tensor,
+            )
+            self.assertTrue(True, "Function call succeeded without error")
+        except Exception as e:
+            self.fail(f"Function raised an unexpected exception: {e}")
+
+    def test_params_4(self):
+        """test default parameters"""
+        try:
+            out1 = paddle.nn.functional.group_norm(
+                self.x_tensor,
+                3,
+                self.weight_tensor,
+            )
+            out2 = paddle.nn.functional.group_norm(self.x_tensor, 3, 1e-5)
+            self.assertTrue(True, "Function call succeeded without error")
+        except Exception as e:
+            self.fail(f"Function raised an unexpected exception: {e}")
+
+    def test_params_5(self):
+        """test duplicate parameters"""
+        with self.assertRaises(TypeError):
+            out_1 = paddle.nn.functional.group_norm(
+                x=self.x_tensor,
+                input=self.x_tensor,
+                num_groups=3,
+            )
+        with self.assertRaises(TypeError):
+            out_2 = paddle.nn.functional.group_norm(
+                self.x_tensor,
+                input=self.x_tensor,
+                num_groups=3,
+            )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
pcard-67164

paddle.nn.functional.group_norm
1. 增加输入映射 x：input, epsilon: eps
2. 兼容原始的参数和torch.nn.functional.group_norm的参数
3. 增加相应单测
5. 修改docstring

PaConvert 测试
<img width="428" height="158" alt="image" src="https://github.com/user-attachments/assets/6f5316cd-5f17-4a58-8363-080574d1837c" />


