### PR TITLE
[AutoParallel] fix sp test accuracy for H20

### DIFF
--- a/test/auto_parallel/hybrid_strategy/semi_auto_parallel_simple_net_sp.py
+++ b/test/auto_parallel/hybrid_strategy/semi_auto_parallel_simple_net_sp.py
@@ -121,7 +121,7 @@ class DemoNet(nn.Layer):
         if self.is_sp:
             out = dist.reshard(out, self.pp0_mesh, self.sp_reshard_placement0)
 
-        # out = out + tgt
+        out = out + tgt
         out = self.norm(out)
 
         out = dist.reshard(out, self.pp1_mesh, self.sp_reshard_placement1)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes 

### Description
<!-- Describe what you’ve done -->
test_semi_auto_parallel_for_llama_subnet 在 H20 卡上存在精度问题：测试 DemoNet 跑 dp+mp+pp 时，开关 sp 是否可以精度 rtol=1e-7 对齐，在 H20 上时精度不能对齐的
分析：
1、开关 sp 前反向的切分状态和通信都是符合预期的

2、开关 sp 操作是在 layer norm 前操作的，这造成了 精度 diff
     关 sp 时，layer norm 的输入是 partial 状态，输入会先经过 SPMD 的allreduce 成 replicate 状态，结果也是 replicate，这个计算的结果是 global 的
     开 sp 时，partial 状态被 sp 的 reduce_scatter 成 shard 状态，layer norm 的输入是 shard 状态，这时 SPMD 的结果是 shard 状态，这个结果是 local 的
    所以这两个结果是有差异的，正常情况下，diff 是很小的，最终是不影响收敛性的
    但是，这个DemoNet 的 loss 是1e5级别且不收敛的，对微小的精度 diff 很敏感，小的精度差异会经过传播逐渐扩大，造成单测试精度对不齐

3、hack 确认：开 sp 后，在 norm 前进行 reshard 成 replcitae，此时 开关 sp 是可以精度对齐的

修复：
diff 是当前组网方式造成的，paddle 机制是没问题的，改一下组网方式比较好
它组网中在 norm 前有 out = out + tgt 残差，将这行不注释，开 sp 时，这里因为 shard(0) + shard(1)相加，引入 allreduce，使得 norm 计算的是 global 的值，开关 sp 精度可以对齐

PCard-93779 
