### PR TITLE
[API Compatibility] paddle.bucketize and paddle.searchsorted

### DIFF
--- a/test/legacy_test/test_bucketize_api.py
+++ b/test/legacy_test/test_bucketize_api.py
@@ -110,5 +110,149 @@ class TestBucketizeAPI(unittest.TestCase):
             self.assertRaises(AttributeError, paddle.bucketize, x, None)
 
 
+class TestBucketizeAPI_Extended(unittest.TestCase):
+    def setUp(self):
+        self.sorted_sequence = np.array([2, 4, 8, 16]).astype("float64")
+        self.x2d = np.array([[0, 8, 4, 16], [-1, 2, 8, 4]]).astype("float64")
+        self.x1d = np.array([0, 8, 4, 16]).astype("float64")
+        self.sorted_dup = np.array([1, 2, 2, 2, 3]).astype("float64")
+        self.x_dup = np.array([2, 2, 1, 3]).astype("float64")
+        self.place = get_places()
+
+    def test_dygraph_out_and_out_int32_and_name(self):
+        # Dynamic diagram: Testing the out parameter (inplace write) and out_int32
+        paddle.disable_static()
+        for place in self.place:
+            with paddle.base.dygraph.guard():
+                seq = paddle.to_tensor(self.sorted_sequence)
+                x = paddle.to_tensor(self.x2d)
+
+                res32 = paddle.bucketize(
+                    x, seq, out_int32=True, name="test_name"
+                )
+                self.assertEqual(res32.dtype, paddle.int32)
+                ref32 = np.searchsorted(self.sorted_sequence, self.x2d)
+                np.testing.assert_allclose(
+                    ref32, res32.numpy().astype("int64"), rtol=1e-05
+                )
+
+                # out parameter: supply existing tensor, should be written and returned
+                out_tensor = paddle.empty(shape=self.x2d.shape, dtype="int64")
+                ret = paddle.bucketize(x, seq, out=out_tensor)
+                ref = np.searchsorted(self.sorted_sequence, self.x2d)
+                np.testing.assert_allclose(ref, out_tensor.numpy(), rtol=1e-05)
+        paddle.enable_static()
+
+    def test_static_out_int32_and_right(self):
+        # Static image: Testing out_int32 and right=True/False
+        paddle.enable_static()
+        for place in self.place:
+            with paddle.static.program_guard(paddle.static.Program()):
+                seq = paddle.static.data(
+                    name="seq",
+                    shape=self.sorted_sequence.shape,
+                    dtype="float64",
+                )
+                x = paddle.static.data(
+                    name="x", shape=self.x2d.shape, dtype="float64"
+                )
+
+                out_left = paddle.bucketize(
+                    x, seq, right=False, out_int32=False
+                )
+                out_right = paddle.bucketize(x, seq, right=True, out_int32=True)
+
+                exe = paddle.static.Executor(place)
+                res_left, res_right = exe.run(
+                    feed={"seq": self.sorted_sequence, "x": self.x2d},
+                    fetch_list=[out_left, out_right],
+                )
+                ref_left = np.searchsorted(
+                    self.sorted_sequence, self.x2d, side="left"
+                )
+                ref_right = np.searchsorted(
+                    self.sorted_sequence, self.x2d, side="right"
+                )
+                np.testing.assert_allclose(ref_left, res_left, rtol=1e-05)
+                # out_int32 True -> numpy result must be cast-compatible to int32
+                self.assertEqual(res_right.dtype, np.int32)
+                np.testing.assert_allclose(
+                    ref_right, res_right.astype("int64"), rtol=1e-05
+                )
+        paddle.disable_static()
+
+    def test_dygraph_1d_input(self):
+        # Dynamic image: 1D x test
+        paddle.disable_static()
+        for place in self.place:
+            with paddle.base.dygraph.guard():
+                seq = paddle.to_tensor(self.sorted_sequence)
+                x = paddle.to_tensor(self.x1d)
+
+                out = paddle.bucketize(x, seq)
+                ref = np.searchsorted(self.sorted_sequence, self.x1d)
+                np.testing.assert_allclose(ref, out.numpy(), rtol=1e-05)
+        paddle.enable_static()
+
+    def test_dup_elements_side_behavior(self):
+        # Left/right difference when testing duplicate elements
+        paddle.disable_static()
+        for place in self.place:
+            with paddle.base.dygraph.guard():
+                seq = paddle.to_tensor(self.sorted_dup)
+                x = paddle.to_tensor(self.x_dup)
+
+                out_left = paddle.bucketize(x, seq, right=False)
+                out_right = paddle.bucketize(x, seq, right=True)
+
+                ref_left = np.searchsorted(
+                    self.sorted_dup, self.x_dup, side="left"
+                )
+                ref_right = np.searchsorted(
+                    self.sorted_dup, self.x_dup, side="right"
+                )
+
+                np.testing.assert_allclose(
+                    ref_left, out_left.numpy(), rtol=1e-05
+                )
+                np.testing.assert_allclose(
+                    ref_right, out_right.numpy(), rtol=1e-05
+                )
+        paddle.enable_static()
+
+    def test_static_and_dygraph_sort_of_api_stability(self):
+        # Simple coverage: Both static and dynamic calls can succeed (without checking for duplicate results)
+        paddle.enable_static()
+        for place in self.place:
+            with paddle.static.program_guard(paddle.static.Program()):
+                seq = paddle.static.data(
+                    name="seq",
+                    shape=self.sorted_sequence.shape,
+                    dtype="float64",
+                )
+                x = paddle.static.data(
+                    name="x", shape=self.x2d.shape, dtype="float64"
+                )
+                _ = paddle.bucketize(
+                    x, seq, out_int32=False, right=False, name="static_case"
+                )
+                exe = paddle.static.Executor(place)
+                exe.run(
+                    feed={"seq": self.sorted_sequence, "x": self.x2d},
+                    fetch_list=[],
+                )
+        paddle.disable_static()
+
+        paddle.disable_static()
+        for place in self.place:
+            with paddle.base.dygraph.guard():
+                seq = paddle.to_tensor(self.sorted_sequence)
+                x = paddle.to_tensor(self.x2d)
+                _ = paddle.bucketize(
+                    x, seq, out_int32=False, right=False, name="dy_case"
+                )
+        paddle.enable_static()
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
**PR描述：**
**paddle. searchsorted：**
searchsorted新增side、out、sorter三个参数 和装饰器。
1. side：side (str|None, optional): The same as right but preferred. `left` corresponds to False for right and `right` corresponds to True for right. It will error if this is set to `left` while right is True. Default value is None.
2.  sorter (Tensor|None, optional): if provided, a tensor matching the shape of the unsorted `sorted_sequence` containing a sequence of indices that sort it in the ascending order on the innermost dimension.

**paddle.bucketize：**
bucketize加装饰器和out；

<img width="1366" height="654" alt="image" src="https://github.com/user-attachments/assets/de31d3d5-c25e-42de-b5e3-bcc5e4def03c" />
