### PR TITLE
[API Compatibility] Support tensor dtype compare using `is`

### DIFF
--- a/paddle/fluid/pybind/eager_utils.cc
+++ b/paddle/fluid/pybind/eager_utils.cc
@@ -1088,10 +1088,10 @@ PyObject* ToPyObject(const phi::DenseTensor* value) {
 
 PyObject* ToPyObject(const phi::DataType& dtype) {
   static const std::vector<std::string> dtype_names = {
-      "UNDEFINED", "BOOL",          "UINT8",       "INT8",       "UINT16",
-      "INT16",     "UINT32",        "INT32",       "UINT64",     "INT64",
-      "FLOAT32",   "FLOAT64",       "COMPLEX64",   "COMPLEX128", "FLOAT16",
-      "BFLOAT16",  "FLOAT8_E4M3FN", "FLOAT8_E5M2", "PSTRING",
+      "UNDEFINED", "BOOL",     "UINT8",         "INT8",        "UINT16",
+      "INT16",     "UINT32",   "INT32",         "UINT64",      "INT64",
+      "FLOAT32",   "FLOAT64",  "COMPLEX64",     "COMPLEX128",  "PSTRING",
+      "FLOAT16",   "BFLOAT16", "FLOAT8_E4M3FN", "FLOAT8_E5M2",
   };
   return PyObject_GetAttrString(reinterpret_cast<PyObject*>(g_data_type_pytype),
                                 dtype_names[static_cast<int>(dtype)].c_str());

--- a/paddle/fluid/pybind/eager_utils.cc
+++ b/paddle/fluid/pybind/eager_utils.cc
@@ -1087,9 +1087,14 @@ PyObject* ToPyObject(const phi::DenseTensor* value) {
 }
 
 PyObject* ToPyObject(const phi::DataType& dtype) {
-  auto obj = ::pybind11::cast(dtype);
-  obj.inc_ref();
-  return obj.ptr();
+  static const std::vector<std::string> dtype_names = {
+      "UNDEFINED", "BOOL",          "UINT8",       "INT8",       "UINT16",
+      "INT16",     "UINT32",        "INT32",       "UINT64",     "INT64",
+      "FLOAT32",   "FLOAT64",       "COMPLEX64",   "COMPLEX128", "FLOAT16",
+      "BFLOAT16",  "FLOAT8_E4M3FN", "FLOAT8_E5M2", "PSTRING",
+  };
+  return PyObject_GetAttrString(reinterpret_cast<PyObject*>(g_data_type_pytype),
+                                dtype_names[static_cast<int>(dtype)].c_str());
 }
 
 PyObject* ToPyObject(const std::vector<phi::DataType>& dtypes) {

--- a/test/legacy_test/test_eager_tensor.py
+++ b/test/legacy_test/test_eager_tensor.py
@@ -1283,6 +1283,20 @@ class TestEagerTensor(unittest.TestCase):
 
         self.assertEqual(a_str, expected)
 
+    def test_tensor_dtype_compare(self):
+        a = paddle.randn([2], dtype="float32")
+        b = paddle.randn([2], dtype="float32")
+        c = paddle.randn([2], dtype="float64")
+
+        self.assertTrue(a.dtype == paddle.float32)
+        self.assertTrue(a.dtype == b.dtype)
+        self.assertTrue(a.dtype != paddle.float64)
+        self.assertTrue(a.dtype != c.dtype)
+        self.assertTrue(a.dtype is paddle.float32)
+        self.assertTrue(a.dtype is b.dtype)
+        self.assertTrue(a.dtype is not paddle.float64)
+        self.assertTrue(a.dtype is not c.dtype)
+
     def test___cuda_array_interface__(self):
         """test Tensor.__cuda_array_interface__"""
         with dygraph_guard():


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
支持 tensor dtype 用 `is` 进行比较，`is` 底层是对象指针的比较，之前用 `is` 比较有问题是因为每次获取 tensor dtype 都会创建一个类型为对应 dtype 的新 python 对象，本次 PR 通过返回 Python 枚举对象单例来解决该问题

示例代码：
``` python
import paddle
a = paddle.tensor(1, dtype="float32")
if a.dtype is paddle.float32:
	pass
```