### PR TITLE
[API] Move the `zero_infinity` parameter of `CTCLoss` from the forward function to the constructor

### DIFF
--- a/python/paddle/nn/layer/loss.py
+++ b/python/paddle/nn/layer/loss.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable, Optional
+from typing import TYPE_CHECKING, Callable
 
 import paddle
 from paddle import base, in_dynamic_mode

--- a/python/paddle/nn/layer/loss.py
+++ b/python/paddle/nn/layer/loss.py
@@ -1358,19 +1358,7 @@ class CTCLoss(Layer):
         input_lengths: Tensor,
         label_lengths: Tensor,
         norm_by_times: bool = False,
-        zero_infinity: bool | None = None,
     ) -> Tensor:
-        if zero_infinity is None:
-            return paddle.nn.functional.ctc_loss(
-                log_probs,
-                labels,
-                input_lengths,
-                label_lengths,
-                self.blank,
-                self.reduction,
-                norm_by_times=norm_by_times,
-                zero_infinity=self.zero_infinity,
-            )
         return paddle.nn.functional.ctc_loss(
             log_probs,
             labels,
@@ -1379,7 +1367,7 @@ class CTCLoss(Layer):
             self.blank,
             self.reduction,
             norm_by_times=norm_by_times,
-            zero_infinity=zero_infinity,
+            zero_infinity=self.zero_infinity,
         )
 
 

--- a/python/paddle/nn/layer/loss.py
+++ b/python/paddle/nn/layer/loss.py
@@ -1340,7 +1340,8 @@ class CTCLoss(Layer):
     blank: int
     reduction: _ReduceMode
 
-    def __init__(self,
+    def __init__(
+        self,
         blank: int = 0,
         reduction: _ReduceMode = 'mean',
         zero_infinity: bool = True,

--- a/python/paddle/nn/layer/loss.py
+++ b/python/paddle/nn/layer/loss.py
@@ -1344,7 +1344,7 @@ class CTCLoss(Layer):
         self,
         blank: int = 0,
         reduction: _ReduceMode = 'mean',
-        zero_infinity: bool | None = None,
+        zero_infinity: bool = False,
     ) -> None:
         super().__init__()
         self.blank = blank
@@ -1358,7 +1358,7 @@ class CTCLoss(Layer):
         input_lengths: Tensor,
         label_lengths: Tensor,
         norm_by_times: bool = False,
-        zero_infinity: Optional[bool] = None,
+        zero_infinity: bool | None = None,
     ) -> Tensor:
         if zero_infinity is None:
             return paddle.nn.functional.ctc_loss(

--- a/python/paddle/nn/layer/loss.py
+++ b/python/paddle/nn/layer/loss.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING, Callable, Optional
 
 import paddle
 from paddle import base, in_dynamic_mode
@@ -1340,10 +1340,15 @@ class CTCLoss(Layer):
     blank: int
     reduction: _ReduceMode
 
-    def __init__(self, blank: int = 0, reduction: _ReduceMode = 'mean') -> None:
+    def __init__(self,
+        blank: int = 0,
+        reduction: _ReduceMode = 'mean',
+        zero_infinity: bool = True,
+    ) -> None:
         super().__init__()
         self.blank = blank
         self.reduction = reduction
+        self.zero_infinity = zero_infinity
 
     def forward(
         self,
@@ -1352,8 +1357,19 @@ class CTCLoss(Layer):
         input_lengths: Tensor,
         label_lengths: Tensor,
         norm_by_times: bool = False,
-        zero_infinity: bool = False,
+        zero_infinity: Optional[bool] = None,
     ) -> Tensor:
+        if zero_infinity is None:
+            return paddle.nn.functional.ctc_loss(
+                log_probs,
+                labels,
+                input_lengths,
+                label_lengths,
+                self.blank,
+                self.reduction,
+                norm_by_times=norm_by_times,
+                zero_infinity=self.zero_infinity,
+            )
         return paddle.nn.functional.ctc_loss(
             log_probs,
             labels,

--- a/python/paddle/nn/layer/loss.py
+++ b/python/paddle/nn/layer/loss.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING, Callable, Optional
 
 import paddle
 from paddle import base, in_dynamic_mode

--- a/python/paddle/nn/layer/loss.py
+++ b/python/paddle/nn/layer/loss.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable, Optional
+from typing import TYPE_CHECKING, Callable
 
 import paddle
 from paddle import base, in_dynamic_mode
@@ -1344,7 +1344,7 @@ class CTCLoss(Layer):
         self,
         blank: int = 0,
         reduction: _ReduceMode = 'mean',
-        zero_infinity: bool = True,
+        zero_infinity: bool | None = None,
     ) -> None:
         super().__init__()
         self.blank = blank


### PR DESCRIPTION
### PR Category
User Experience

### PR Types
Bug fixes

### Description

将在 #75742 中错误添加到 `paddle.nn.CTCLoss` 中 `forward` 函数参数 `zero_infinity` 移到 `__init__` 上，以保持接口和 PyTorch `torch.nn.CTCLoss`[^1] 一致

#75742 刚刚合入且未发版，尚无需考虑兼容性

[^1]: https://docs.pytorch.org/docs/stable/generated/torch.nn.CTCLoss.html