### PR TITLE
Fix cmake error in `test/quantization/CMakeLists.txt` when `WITH_GPU=OFF`

### DIFF
--- a/test/quantization/CMakeLists.txt
+++ b/test/quantization/CMakeLists.txt
@@ -248,7 +248,7 @@ if(NOT WITH_GPU)
 endif()
 
 #
-if(NOT WITH_XPU)
+if(WITH_GPU)
   if(${CUDA_ARCH_NAME} STREQUAL "Hopper")
     list(REMOVE_ITEM TEST_OPS test_weight_only_linear)
   endif()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
fix compile error in test/quantization/CMakeLists.txt

fixes #76154