### PR TITLE
clean repeated get_cuda_version - part

### DIFF
--- a/test/collective/test_collective_deep_ep_alltoall_intranode.py
+++ b/test/collective/test_collective_deep_ep_alltoall_intranode.py
@@ -12,13 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import re
 import time
 import unittest
 
 import numpy as np
 from legacy_test.test_collective_api_base import TestDistBase
+from op_test import get_cuda_version
 
 import paddle
 import paddle.distributed as dist
@@ -27,19 +26,6 @@ from paddle.base import core
 from paddle.base.core import Config
 from paddle.distributed import fleet
 from paddle.distributed.communication.group import Group
-
-
-def get_cuda_version():
-    result = os.popen("nvcc --version").read()
-    regex = r'release (\S+),'
-    match = re.search(regex, result)
-    if match:
-        num = str(match.group(1))
-        integer, decimal = num.split('.')
-        return int(integer) * 1000 + int(float(decimal) * 10)
-    else:
-        return -1
-
 
 is_sm90 = (
     core.is_compiled_with_cuda()

--- a/test/legacy_test/test_sparse_matmul_op.py
+++ b/test/legacy_test/test_sparse_matmul_op.py
@@ -67,8 +67,8 @@ class TestMatmulSparseDense(unittest.TestCase):
 
     @unittest.skipIf(
         not (paddle.is_compiled_with_cuda() or is_custom_device())
-        or get_cuda_version() < 11000,
-        "only support cuda>=11.0",
+        or paddle.is_compiled_with_rocm(),
+        "only support cuda",
     )
     def test_matmul_2d(self):
         self.check_result([16, 12], [12, 10], 'coo')
@@ -125,8 +125,8 @@ class TestMatmulSparseSparseInt64Index(unittest.TestCase):
 
     @unittest.skipIf(
         not (paddle.is_compiled_with_cuda() or is_custom_device())
-        or get_cuda_version() < 11000,
-        "only support cuda>=11.0",
+        or paddle.is_compiled_with_rocm(),
+        "only support cuda",
     )
     def test_matmul_2d(self):
         self.check_result([16, 12], [12, 10], 'coo')
@@ -134,8 +134,8 @@ class TestMatmulSparseSparseInt64Index(unittest.TestCase):
 
     @unittest.skipIf(
         not (paddle.is_compiled_with_cuda() or is_custom_device())
-        or get_cuda_version() < 11000,
-        "only support cuda>=11.0",
+        or paddle.is_compiled_with_rocm(),
+        "only support cuda",
     )
     def test_matmul_3d(self):
         self.check_result([8, 16, 12], [8, 12, 10], 'coo')
@@ -206,8 +206,8 @@ class TestMatmulSparseSparseInt32Index(unittest.TestCase):
 
     @unittest.skipIf(
         not (paddle.is_compiled_with_cuda() or is_custom_device())
-        or get_cuda_version() < 11000,
-        "only support cuda>=11.0",
+        or paddle.is_compiled_with_rocm(),
+        "only support cuda",
     )
     def test_matmul_2d(self):
         self.check_result([16, 12], [12, 10], 'coo')
@@ -215,8 +215,8 @@ class TestMatmulSparseSparseInt32Index(unittest.TestCase):
 
     @unittest.skipIf(
         not (paddle.is_compiled_with_cuda() or is_custom_device())
-        or get_cuda_version() < 11000,
-        "only support cuda>=11.0",
+        or paddle.is_compiled_with_rocm(),
+        "only support cuda",
     )
     def test_matmul_3d(self):
         self.check_result([8, 16, 12], [8, 12, 10], 'coo')
@@ -367,8 +367,8 @@ class TestMatmulSparseDenseStatic(unittest.TestCase):
 
     @unittest.skipIf(
         not (paddle.is_compiled_with_cuda() or is_custom_device())
-        or get_cuda_version() < 11000,
-        "only support cuda>=11.0",
+        or paddle.is_compiled_with_rocm(),
+        "only support cuda",
     )
     def test_matmul_2d(self):
         if in_pir_mode():
@@ -462,8 +462,8 @@ class TestMatmulSparseSparseStatic(unittest.TestCase):
 
     @unittest.skipIf(
         not (paddle.is_compiled_with_cuda() or is_custom_device())
-        or get_cuda_version() < 11000,
-        "only support cuda>=11.0",
+        or paddle.is_compiled_with_rocm(),
+        "only support cuda",
     )
     def test_matmul_2d(self):
         if in_pir_mode():
@@ -471,8 +471,8 @@ class TestMatmulSparseSparseStatic(unittest.TestCase):
 
     @unittest.skipIf(
         not (paddle.is_compiled_with_cuda() or is_custom_device())
-        or get_cuda_version() < 11000,
-        "only support cuda>=11.0",
+        or paddle.is_compiled_with_rocm(),
+        "only support cuda",
     )
     def test_matmul_3d(self):
         if in_pir_mode():


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience

### PR Types
Others 

### Description
<!-- Describe what you’ve done -->
使用op_test.get_cuda_version 替代单测中的 get_cuda_version
get_cuda_version() < 11000 修改， is_compiled_with_cuda 包含 is_compiled_with_rocm，修改为增加 or paddle.is_compiled_with_rocm()
