### PR TITLE
use op_test.get_cuda_version - part

### DIFF
--- a/test/legacy_test/test_flash_attention.py
+++ b/test/legacy_test/test_flash_attention.py
@@ -12,12 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
-import os
-import re
 import unittest
 
 import numpy as np
-from op_test import get_device_place, is_custom_device
+from op_test import get_cuda_version, get_device_place, is_custom_device
 
 import paddle
 import paddle.nn.functional as F
@@ -36,18 +34,6 @@ from paddle.nn.functional.flash_attention import (
 )
 
 logging.basicConfig(format="%(asctime)s - %(levelname)s - %(message)s")
-
-
-def get_cuda_version():
-    result = os.popen("nvcc --version").read()
-    regex = r'release (\S+),'
-    match = re.search(regex, result)
-    if match:
-        num = str(match.group(1))
-        integer, decimal = num.split('.')
-        return int(integer) * 1000 + int(float(decimal) * 10)
-    else:
-        return -1
 
 
 def attention_naive(q, k, v, causal=False):

--- a/test/legacy_test/test_fused_multi_transformer_op.py
+++ b/test/legacy_test/test_fused_multi_transformer_op.py
@@ -16,8 +16,7 @@ import random
 import unittest
 
 import numpy as np
-from op_test import OpTest, get_device_place, is_custom_device
-from test_sparse_attention_op import get_cuda_version
+from op_test import OpTest, get_cuda_version, get_device_place, is_custom_device
 
 import paddle
 import paddle.nn.functional as F

--- a/test/legacy_test/test_matmul_fp8_op.py
+++ b/test/legacy_test/test_matmul_fp8_op.py
@@ -14,8 +14,7 @@
 import unittest
 
 import numpy as np
-from op_test import is_custom_device
-from test_sparse_attention_op import get_cuda_version
+from op_test import get_cuda_version, is_custom_device
 
 import paddle
 from paddle.base import core

--- a/test/legacy_test/test_mul_op.py
+++ b/test/legacy_test/test_mul_op.py
@@ -18,7 +18,7 @@ import unittest
 import numpy as np
 
 sys.path.append("../../legacy_test")
-from test_sparse_attention_op import get_cuda_version
+from op_test import get_cuda_version
 
 from paddle.base import core
 

--- a/test/legacy_test/test_sparse_attention_op.py
+++ b/test/legacy_test/test_sparse_attention_op.py
@@ -13,34 +13,15 @@
 # limitations under the License.
 
 import copy
-import os
-import re
 import unittest
 
 import numpy as np
-from op_test import OpTest, get_device_place, is_custom_device
+from op_test import OpTest, get_cuda_version, get_device_place, is_custom_device
 
 import paddle
 import paddle.nn.functional as F
 from paddle import base
 from paddle.base import core
-
-
-def get_cuda_version():
-    if paddle.is_compiled_with_cuda():
-        result = os.popen("nvcc --version").read()
-        regex = r'release (\S+),'
-        match = re.search(regex, result)
-        if match:
-            num = str(match.group(1))
-            integer, decimal = num.split('.')
-            return int(integer) * 1000 + int(float(decimal) * 10)
-        else:
-            return -1
-    elif is_custom_device():
-        return 13000
-    else:
-        return -1
 
 
 def masked_fill(x):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience

### PR Types
Others 

### Description
<!-- Describe what you’ve done -->
使用 op_test 中已有 get_cuda_version 定义
