### PR TITLE
[CI] Add CI for auto remove `skip-ci` label after commit

### DIFF
--- a/.github/workflows/remove-skip-ci-labels.yml
+++ b/.github/workflows/remove-skip-ci-labels.yml
@@ -1,8 +1,7 @@
 name: Remove Skip-CI Labels
 
-#
 on:
-  pull_request:
+  pull_request_target:
     types: [synchronize]
 
 permissions:

--- a/.github/workflows/remove-skip-ci-labels.yml
+++ b/.github/workflows/remove-skip-ci-labels.yml
@@ -1,0 +1,53 @@
+name: Remove Skip-CI Labels
+
+on:
+  pull_request:
+    types: [synchronize]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  remove-skip-ci-labels:
+    name: Remove skip-ci labels on new commits
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get PR labels
+        id: get-labels
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            });
+
+            const skipCiLabels = labels
+              .filter(label => label.name.startsWith('skip-ci:'))
+              .map(label => label.name);
+
+            console.log('Found skip-ci labels:', skipCiLabels);
+            core.setOutput('skip-ci-labels', JSON.stringify(skipCiLabels));
+            core.setOutput('has-skip-ci-labels', skipCiLabels.length > 0 ? 'true' : 'false');
+
+      - name: Remove skip-ci labels
+        if: steps.get-labels.outputs.has-skip-ci-labels == 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const skipCiLabels = JSON.parse('${{ steps.get-labels.outputs.skip-ci-labels }}');
+
+            for (const label of skipCiLabels) {
+              console.log(`Removing label: ${label}`);
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                name: label
+              });
+            }
+
+            console.log(`Successfully removed ${skipCiLabels.length} skip-ci label(s)`);

--- a/.github/workflows/remove-skip-ci-labels.yml
+++ b/.github/workflows/remove-skip-ci-labels.yml
@@ -1,5 +1,6 @@
 name: Remove Skip-CI Labels
 
+#
 on:
   pull_request:
     types: [synchronize]


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Improvements

### Description
<!-- Describe what you’ve done -->

增加流水线自动移除 `skip-ci` label，一旦开发者在 PR 里提交了新的 commit，则移除 `skip-ci:` 开头的 label，确保豁免只生效一次

<sub>Co-authored by GitHub Copilot</sub>

<!-- PCard-66972 -->