### PR TITLE
[CINN] Fix test_bert_cinn to directly compare CINN and PIR results

### DIFF
--- a/test/prim/model/test_bert_cinn.py
+++ b/test/prim/model/test_bert_cinn.py
@@ -32,21 +32,6 @@ MODULE_NAME = 'test_bert_prim_cinn'
 MD5SUM = '71e730ee8d7aa77a215b7e898aa089af'
 SAVE_NAME = 'bert_training_data.npz'
 
-
-DY2ST_CINN_GT = [
-    10.649632453918457,
-    10.333406448364258,
-    10.33541202545166,
-    10.260543823242188,
-    10.219606399536133,
-    10.176884651184082,
-    10.124699592590332,
-    10.072620391845703,
-    10.112163543701172,
-    9.969393730163574,
-]
-
-
 if core.is_compiled_with_cuda():
     paddle.set_flags({'FLAGS_cudnn_deterministic': True})
 
@@ -133,7 +118,8 @@ class TestBert(unittest.TestCase):
     def test_cinn(self):
         paddle.set_flags({'FLAGS_deny_cinn_ops': "dropout"})
         dy2st_cinn = train(to_static=True, enable_prim=False, enable_cinn=True)
-        np.testing.assert_allclose(dy2st_cinn, DY2ST_CINN_GT, rtol=1e-5)
+        dy2st_pir = train(to_static=True, enable_prim=False, enable_cinn=False)
+        np.testing.assert_allclose(dy2st_cinn, dy2st_pir, rtol=1e-5)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
CINN


### PR Types
Bug fixes


### Description

改进 test_bert_cinn 里的结果比较方法，不再使用一个写死的 Ground Truth，而是将 CINN 的结果与动态跑出的 PIR 结果比较

<b>原因：</b>paddle 的随机数生成器在不同卡上生成的序列是不同的（torch 也一样），因此不同卡上模型的初始状态不同，生成的结果必然不同，没有一个统一的 GT；目前 CINN 和 PIR 的对齐程度已经很高了，完全可以直接比较两者的结果

实测 dy2st_cinn 和 dy2st_pir 可以做到 atol=1e-6 rtol=1e-7 的容忍度，当然为了保持兼容性这里仍然用了原来的 rtol=1e-5 设置

Pcard-85711
