### PR TITLE
[API compatibility] update paddle GroupNorm api

### DIFF
--- a/python/paddle/nn/layer/norm.py
+++ b/python/paddle/nn/layer/norm.py
@@ -22,6 +22,7 @@ import numpy as np
 
 from paddle import _C_ops, in_dynamic_mode, pir_utils
 from paddle.device import get_all_custom_device_type
+from paddle.utils.decorator_utils import param_one_alias
 
 from ...base import dygraph_utils
 from ...base.data_feeder import check_variable_and_dtype
@@ -51,6 +52,7 @@ if TYPE_CHECKING:
         DataLayoutND,
         DTypeLike,
         ParamAttrLike,
+        PlaceLike,
         ShapeLike,
     )
 
@@ -432,12 +434,26 @@ class GroupNorm(Layer):
         num_channels(int): The number of channels of input.
         epsilon(float, optional): The small value added to the variance to prevent
             division by zero. Default: 1e-05.
-        weight_attr(ParamAttr|bool|None, optional): The parameter attribute for the learnable
-            scale :math:`g`. If it is set to False, no scale will be added to the output units.
-            If it is set to None, the scale is initialized one. Default: None.
-        bias_attr(ParamAttr|bool|None, optional): The parameter attribute for the learnable
-            bias :math:`b`. If it is set to False, no bias will be added to the output units.
-            If it is set to None, the bias is initialized zero. Default: None.
+            alias: ``eps``.
+        affine(bool, optional): Whether this module has learnable affine parameters (weight and bias).
+            If set to ``False``, no learnable parameters will be created, regardless of the settings of
+            `weight_attr` and `bias_attr`. Defaults to True.
+        device(PlaceLike, optional): Device where the computation takes place. Default: None
+        dtype(DTypeLike, optional): Data type of the weights and bias. Default: None.
+        weight_attr(ParamAttr|bool|None, optional): The parameter attribute for the learnable scale :math:`g`.
+            This setting only takes effect when `affine` is ``True``.
+            - If set to ``False``, no scale parameter will be created.
+            - If set to ``True`` or a `ParamAttr` object, a learnable scale parameter will be created.
+              When set to ``True``, it is equivalent to ``ParamAttr()`` with default initialization.
+            - If set to ``None``, a learnable scale parameter will be created and initialized to one.
+            Default: None.
+        bias_attr (ParamAttr|bool|None, optional): The parameter attribute for the learnable bias :math:`b`.
+            This setting only takes effect when `affine` is ``True``.
+            - If set to ``False``, no bias parameter will be created.
+            - If set to ``True`` or a `ParamAttr` object, a learnable bias parameter will be created.
+              When set to ``True``, it is equivalent to ``ParamAttr()`` with default initialization.
+            - If set to ``None``, a learnable bias parameter will be created and initialized to zero.
+            Default: None.
         data_format(str, optional): Specify the input data format. Support "NCL", "NCHW", "NCDHW", "NLC", "NHWC" or "NDHWC". Default: "NCHW".
         name(str|None, optional): Name for the GroupNorm, default is None. For more information, please refer to :ref:`api_guide_Name`..
 
@@ -488,11 +504,16 @@ class GroupNorm(Layer):
     weight: Tensor
     bias: Tensor
 
+    @param_one_alias(["epsilon", "eps"])
     def __init__(
         self,
         num_groups: int,
         num_channels: int,
         epsilon: float = 1e-5,
+        affine: bool = True,
+        device: PlaceLike | None = None,
+        dtype: DTypeLike | None = None,
+        *,
         weight_attr: bool | ParamAttr | None = None,
         bias_attr: bool | ParamAttr | None = None,
         data_format: DataLayout1D | DataLayout2D | DataLayout3D = 'NCHW',
@@ -504,6 +525,11 @@ class GroupNorm(Layer):
         self._epsilon = epsilon
         self._num_channels = num_channels
         self._num_groups = num_groups
+        self._device = device
+        self._dtype = (
+            self._helper.get_default_dtype() if dtype is None else dtype
+        )
+
         if data_format not in ['NCL', 'NCHW', 'NCDHW', 'NLC', 'NHWC', 'NDHWC']:
             raise ValueError("unsupported data layout:" + data_format)
 
@@ -512,16 +538,19 @@ class GroupNorm(Layer):
 
         param_shape = [self._num_channels]
 
+        if not affine:
+            weight_attr = False
+            bias_attr = False
+
         if weight_attr is False:
-            self.weight = self.create_parameter(
-                attr=None, shape=param_shape, default_initializer=Constant(1.0)
-            )
-            self.weight.stop_gradient = True
+            self.weight = None
         else:
             self.weight = self.create_parameter(
                 attr=self._weight_attr,
                 shape=param_shape,
+                dtype=self._dtype,
                 default_initializer=Constant(1.0),
+                device=self._device,
             )
             self.weight.stop_gradient = self._weight_attr is not None and (
                 hasattr(self._weight_attr, "learning_rate")
@@ -529,16 +558,14 @@ class GroupNorm(Layer):
             )
 
         if bias_attr is False:
-            self.bias = self.create_parameter(
-                attr=None,
-                shape=param_shape,
-                default_initializer=Constant(0.0),
-                is_bias=True,
-            )
-            self.bias.stop_gradient = True
+            self.bias = None
         else:
             self.bias = self.create_parameter(
-                attr=self._bias_attr, shape=param_shape, is_bias=True
+                attr=self._bias_attr,
+                shape=param_shape,
+                dtype=self._dtype,
+                is_bias=True,
+                device=self._device,
             )
             self.bias.stop_gradient = self._bias_attr is not None and (
                 hasattr(self._bias_attr, "learning_rate")

--- a/python/paddle/nn/layer/norm.py
+++ b/python/paddle/nn/layer/norm.py
@@ -422,8 +422,7 @@ class InstanceNorm3D(_InstanceNormBase):
 
 
 class GroupNorm(Layer):
-    """
-
+    r"""
     This interface is used to construct a callable object of the ``GroupNorm`` class.
     For more details, refer to code examples.
     It implements the function of the Group Normalization Layer.
@@ -438,8 +437,11 @@ class GroupNorm(Layer):
         affine(bool, optional): Whether this module has learnable affine parameters (weight and bias).
             If set to ``False``, no learnable parameters will be created, regardless of the settings of
             `weight_attr` and `bias_attr`. Defaults to True.
-        device(PlaceLike, optional): Device where the computation takes place. Default: None
+            **Note: This argument must be passed as a keyword argument.**
+        device(PlaceLike, optional): Device where the computation takes place. Default: None.
+            **Note: This argument must be passed as a keyword argument.**
         dtype(DTypeLike, optional): Data type of the weights and bias. Default: None.
+            **Note: This argument must be passed as a keyword argument.**
         weight_attr(ParamAttr|bool|None, optional): The parameter attribute for the learnable scale :math:`g`.
             This setting only takes effect when `affine` is ``True``.
             - If set to ``False``, no scale parameter will be created.
@@ -447,6 +449,7 @@ class GroupNorm(Layer):
               When set to ``True``, it is equivalent to ``ParamAttr()`` with default initialization.
             - If set to ``None``, a learnable scale parameter will be created and initialized to one.
             Default: None.
+            **Note: This argument must be passed as a keyword argument.**
         bias_attr (ParamAttr|bool|None, optional): The parameter attribute for the learnable bias :math:`b`.
             This setting only takes effect when `affine` is ``True``.
             - If set to ``False``, no bias parameter will be created.
@@ -454,8 +457,11 @@ class GroupNorm(Layer):
               When set to ``True``, it is equivalent to ``ParamAttr()`` with default initialization.
             - If set to ``None``, a learnable bias parameter will be created and initialized to zero.
             Default: None.
+            **Note: This argument must be passed as a keyword argument.**
         data_format(str, optional): Specify the input data format. Support "NCL", "NCHW", "NCDHW", "NLC", "NHWC" or "NDHWC". Default: "NCHW".
-        name(str|None, optional): Name for the GroupNorm, default is None. For more information, please refer to :ref:`api_guide_Name`..
+            **Note: This argument must be passed as a keyword argument.**
+        name(str|None, optional): Name for the GroupNorm, default is None. For more information, please refer to :ref:`api_guide_Name`.
+            **Note: This argument must be passed as a keyword argument.**
 
     Shape:
         - x: Tensor with shape: attr:`(batch, num_features, *)`.
@@ -510,18 +516,16 @@ class GroupNorm(Layer):
         num_groups: int,
         num_channels: int,
         epsilon: float = 1e-5,
+        *,
         affine: bool = True,
         device: PlaceLike | None = None,
         dtype: DTypeLike | None = None,
-        *,
         weight_attr: bool | ParamAttr | None = None,
         bias_attr: bool | ParamAttr | None = None,
         data_format: DataLayout1D | DataLayout2D | DataLayout3D = 'NCHW',
         name: str | None = None,
     ) -> None:
         super().__init__()
-        self._weight_attr = weight_attr
-        self._bias_attr = bias_attr
         self._epsilon = epsilon
         self._num_channels = num_channels
         self._num_groups = num_groups
@@ -541,6 +545,9 @@ class GroupNorm(Layer):
         if not affine:
             weight_attr = False
             bias_attr = False
+
+        self._weight_attr = weight_attr
+        self._bias_attr = bias_attr
 
         if weight_attr is False:
             self.weight = None
@@ -564,6 +571,7 @@ class GroupNorm(Layer):
                 attr=self._bias_attr,
                 shape=param_shape,
                 dtype=self._dtype,
+                default_initializer=Constant(0.0),
                 is_bias=True,
                 device=self._device,
             )

--- a/test/legacy_test/test_group_norm_op_v2.py
+++ b/test/legacy_test/test_group_norm_op_v2.py
@@ -743,14 +743,14 @@ class TestGroupNormParam(unittest.TestCase):
             )
 
 
-class TestGroupNormAffine(unittest.TestCase):
+class TestGroupNormAPIV2_Param(unittest.TestCase):
     def setUp(self):
         self.num_groups = 8
         self.num_channels = 16
         self.x_tensor = paddle.randn([2, self.num_channels, 4, 4])
 
     def test_affine_true(self):
-        """Test that when affine=True, weight and bias parameters are created."""
+        """test that when affine=True, weight and bias parameters are created."""
         layer = paddle.nn.GroupNorm(
             num_groups=self.num_groups,
             num_channels=self.num_channels,
@@ -770,8 +770,27 @@ class TestGroupNormAffine(unittest.TestCase):
             paddle.allclose(layer.bias, paddle.zeros([self.num_channels]))
         )
 
+        layer_old = paddle.nn.GroupNorm(
+            num_groups=self.num_groups,
+            num_channels=self.num_channels,
+            epsilon=1e-05,
+        )
+
+        self.assertIsNotNone(layer_old.weight)
+        self.assertIsNotNone(layer_old.bias)
+
+        self.assertEqual(layer_old.weight.shape, [self.num_channels])
+        self.assertEqual(layer_old.bias.shape, [self.num_channels])
+
+        self.assertTrue(
+            paddle.allclose(layer_old.weight, paddle.ones([self.num_channels]))
+        )
+        self.assertTrue(
+            paddle.allclose(layer_old.bias, paddle.zeros([self.num_channels]))
+        )
+
     def test_affine_false(self):
-        """Test that when affine=False, no learnable parameters are created."""
+        """test that when affine=False, no learnable parameters are created."""
         layer = paddle.nn.GroupNorm(
             num_groups=self.num_groups,
             num_channels=self.num_channels,
@@ -781,8 +800,19 @@ class TestGroupNormAffine(unittest.TestCase):
         self.assertIsNone(layer.weight)
         self.assertIsNone(layer.bias)
 
+        layer_old = paddle.nn.GroupNorm(
+            num_groups=self.num_groups,
+            num_channels=self.num_channels,
+            epsilon=1e-05,
+            weight_attr=False,
+            bias_attr=False,
+        )
+
+        self.assertIsNone(layer_old.weight)
+        self.assertIsNone(layer_old.bias)
+
     def test_overrides_with_affine(self):
-        """Test that weight_attr and bias_attr can override the default initialization when affine=True."""
+        """test that weight_attr and bias_attr can override the default initialization when affine=True."""
         weight_attr = paddle.nn.initializer.Constant(value=2.0)
         bias_attr = paddle.nn.initializer.Constant(value=3.0)
         layer = paddle.nn.GroupNorm(
@@ -799,7 +829,7 @@ class TestGroupNormAffine(unittest.TestCase):
         self.assertTrue(paddle.allclose(layer.bias, expected_bias))
 
     def test_shape_with_affine(self):
-        """Test the forward pass when affine."""
+        """test the forward pass when affine."""
         layer = paddle.nn.GroupNorm(
             num_groups=self.num_groups,
             num_channels=self.num_channels,
@@ -817,6 +847,20 @@ class TestGroupNormAffine(unittest.TestCase):
         out = layer(self.x_tensor)
 
         self.assertEqual(out.shape, self.x_tensor.shape)
+
+    def test_errors(self):
+        """test parameters with errors"""
+        with self.assertRaises(TypeError):
+            layer = paddle.nn.GroupNorm(
+                self.num_groups,
+                self.num_channels,
+                2,
+                2,
+                1e-05,
+                True,
+                "cpu",
+                paddle.float32,
+            )
 
 
 if __name__ == '__main__':

--- a/test/legacy_test/test_group_norm_op_v2.py
+++ b/test/legacy_test/test_group_norm_op_v2.py
@@ -1016,7 +1016,6 @@ class TestGroupNormAPIV2_Param_Static(unittest.TestCase):
                     )
                 exe = base.Executor(p)
                 exe.run(start)
-                paddle.device.synchronize()
                 weight_np, bias_np = exe.run(
                     main, fetch_list=[layer.weight, layer.bias]
                 )

--- a/test/legacy_test/test_group_norm_op_v2.py
+++ b/test/legacy_test/test_group_norm_op_v2.py
@@ -16,7 +16,7 @@ import unittest
 
 import numpy as np
 from op_test import get_device_place, get_places, is_custom_device
-from utils import dygraph_guard
+from utils import dygraph_guard, static_guard
 
 import paddle
 from paddle import base
@@ -743,12 +743,22 @@ class TestGroupNormParam(unittest.TestCase):
             )
 
 
-class TestGroupNormAPIV2_Param(unittest.TestCase):
+class TestGroupNormAPIV2_Param_Dygraph(unittest.TestCase):
     def setUp(self):
+        paddle.disable_static()
         self.num_groups = 8
         self.num_channels = 16
         self.x_shape = [2, self.num_channels, 4, 4]
+        self.param_shape = [self.num_channels]
         self.places = get_places()
+
+    def check_params(self, weight, bias, expected_weight, expected_bias):
+        self.assertIsNotNone(weight)
+        self.assertIsNotNone(bias)
+        self.assertEqual(weight.shape, self.param_shape)
+        self.assertEqual(bias.shape, self.param_shape)
+        self.assertTrue(paddle.allclose(weight, expected_weight).item())
+        self.assertTrue(paddle.allclose(bias, expected_bias).item())
 
     def test_affine_true(self):
         """test that when affine=True, weight and bias parameters are created."""
@@ -757,24 +767,8 @@ class TestGroupNormAPIV2_Param(unittest.TestCase):
                 layer = paddle.nn.GroupNorm(
                     num_groups=self.num_groups,
                     num_channels=self.num_channels,
+                    epsilon=1e-05,
                     affine=True,
-                )
-
-                self.assertIsNotNone(layer.weight)
-                self.assertIsNotNone(layer.bias)
-
-                self.assertEqual(layer.weight.shape, [self.num_channels])
-                self.assertEqual(layer.bias.shape, [self.num_channels])
-
-                self.assertTrue(
-                    paddle.allclose(
-                        layer.weight, paddle.ones([self.num_channels])
-                    )
-                )
-                self.assertTrue(
-                    paddle.allclose(
-                        layer.bias, paddle.zeros([self.num_channels])
-                    )
                 )
 
                 layer_old = paddle.nn.GroupNorm(
@@ -783,50 +777,61 @@ class TestGroupNormAPIV2_Param(unittest.TestCase):
                     epsilon=1e-05,
                 )
 
-                self.assertIsNotNone(layer_old.weight)
-                self.assertIsNotNone(layer_old.bias)
+                expected_weight = paddle.ones(self.param_shape)
+                expected_bias = paddle.zeros(self.param_shape)
 
-                self.assertEqual(layer_old.weight.shape, [self.num_channels])
-                self.assertEqual(layer_old.bias.shape, [self.num_channels])
+                self.check_params(
+                    layer.weight, layer.bias, expected_weight, expected_bias
+                )
+                self.check_params(
+                    layer_old.weight,
+                    layer_old.bias,
+                    expected_weight,
+                    expected_bias,
+                )
 
-                self.assertTrue(
-                    paddle.allclose(
-                        layer_old.weight, paddle.ones([self.num_channels])
-                    )
-                )
-                self.assertTrue(
-                    paddle.allclose(
-                        layer_old.bias, paddle.zeros([self.num_channels])
-                    )
-                )
+                x_tensor = paddle.randn(self.x_shape)
+                out = layer(x_tensor)
+                out_old = layer_old(x_tensor)
+                self.assertTrue(paddle.allclose(out, out_old).item())
 
     def test_affine_false(self):
         """test that when affine=False, no learnable parameters are created."""
-        layer = paddle.nn.GroupNorm(
-            num_groups=self.num_groups,
-            num_channels=self.num_channels,
-            affine=False,
-        )
+        for p in self.places:
+            with base.dygraph.guard(p):
+                layer = paddle.nn.GroupNorm(
+                    num_groups=self.num_groups,
+                    num_channels=self.num_channels,
+                    affine=False,
+                )
 
-        self.assertIsNone(layer.weight)
-        self.assertIsNone(layer.bias)
+                self.assertIsNone(layer.weight)
+                self.assertIsNone(layer.bias)
 
-        layer_old = paddle.nn.GroupNorm(
-            num_groups=self.num_groups,
-            num_channels=self.num_channels,
-            weight_attr=False,
-            bias_attr=False,
-        )
+                layer_old = paddle.nn.GroupNorm(
+                    num_groups=self.num_groups,
+                    num_channels=self.num_channels,
+                    weight_attr=False,
+                    bias_attr=False,
+                )
 
-        self.assertIsNone(layer_old.weight)
-        self.assertIsNone(layer_old.bias)
+                self.assertIsNone(layer_old.weight)
+                self.assertIsNone(layer_old.bias)
+
+                x_tensor = paddle.randn(self.x_shape)
+                out = layer(x_tensor)
+                out_old = layer_old(x_tensor)
+                self.assertTrue(paddle.allclose(out, out_old).item())
 
     def test_overrides_with_affine(self):
         """test that weight_attr and bias_attr can override the default initialization when affine=True."""
         for p in self.places:
             with base.dygraph.guard(p):
-                weight_attr = paddle.nn.initializer.Constant(value=2.0)
-                bias_attr = paddle.nn.initializer.Constant(value=3.0)
+                weight_val = 2.0
+                bias_val = 3.0
+                weight_attr = paddle.nn.initializer.Constant(value=weight_val)
+                bias_attr = paddle.nn.initializer.Constant(value=bias_val)
+
                 layer = paddle.nn.GroupNorm(
                     num_groups=self.num_groups,
                     num_channels=self.num_channels,
@@ -835,35 +840,16 @@ class TestGroupNormAPIV2_Param(unittest.TestCase):
                     bias_attr=bias_attr,
                 )
 
-                expected_weight = paddle.full([self.num_channels], 2.0)
-                expected_bias = paddle.full([self.num_channels], 3.0)
-                self.assertTrue(paddle.allclose(layer.weight, expected_weight))
-                self.assertTrue(paddle.allclose(layer.bias, expected_bias))
-
-    def test_shape_with_affine(self):
-        """test the forward pass when affine."""
-        x_tensor = paddle.randn(self.x_shape)
-        layer = paddle.nn.GroupNorm(
-            num_groups=self.num_groups,
-            num_channels=self.num_channels,
-            affine=True,
-        )
-        out = layer(x_tensor)
-        self.assertEqual(out.shape, self.x_shape)
-
-        layer = paddle.nn.GroupNorm(
-            num_groups=self.num_groups,
-            num_channels=self.num_channels,
-            affine=False,
-        )
-        out = layer(x_tensor)
-        self.assertEqual(out.shape, self.x_shape)
+                expected_weight = paddle.full(self.param_shape, weight_val)
+                expected_bias = paddle.full(self.param_shape, bias_val)
+                self.check_params(
+                    layer.weight, layer.bias, expected_weight, expected_bias
+                )
 
     def test_alias(self):
         """test parameter alias epsilon/eps"""
         for p in self.places:
             with base.dygraph.guard(p):
-                x_tensor = paddle.randn(self.x_shape)
                 layer_epsilon = paddle.nn.GroupNorm(
                     num_groups=self.num_groups,
                     num_channels=self.num_channels,
@@ -875,24 +861,207 @@ class TestGroupNormAPIV2_Param(unittest.TestCase):
                     eps=1e-5,
                 )
 
+                x_tensor = paddle.randn(self.x_shape)
                 out_epsilon = layer_epsilon(x_tensor)
                 out_eps = layer_eps(x_tensor)
-
-                np.testing.assert_array_equal(
-                    out_epsilon.numpy(), out_eps.numpy()
-                )
+                self.assertTrue(paddle.allclose(out_epsilon, out_eps).item())
 
     def test_errors(self):
         """test parameters with errors"""
-        with self.assertRaises(TypeError):
-            layer = paddle.nn.GroupNorm(
-                self.num_groups,
-                self.num_channels,
-                1e-05,
-                True,
-                "cpu",
-                paddle.float32,
+        for p in self.places:
+            with base.dygraph.guard(p), self.assertRaises(TypeError):
+                layer = paddle.nn.GroupNorm(
+                    self.num_groups,
+                    self.num_channels,
+                    1e-05,
+                    True,
+                    "cpu",
+                    paddle.float32,
+                )
+
+
+class TestGroupNormAPIV2_Param_Static(unittest.TestCase):
+    def setUp(self):
+        paddle.enable_static()
+        self.num_groups = 8
+        self.num_channels = 16
+        self.x_shape = [2, self.num_channels, 4, 4]
+        self.param_shape = [self.num_channels]
+        self.places = get_places()
+
+    def _run_group_norm_static(self, device, **kwargs):
+        expected_w = kwargs.pop('expected_w', True)
+        expected_b = kwargs.pop('expected_b', True)
+        expected_out = kwargs.pop('expected_out', True)
+        x_np = kwargs.pop('x_np', None)
+
+        with static_guard():
+            main = base.Program()
+            start = base.Program()
+            with (
+                base.unique_name.guard(),
+                base.program_guard(main, start),
+            ):
+                layer = paddle.nn.GroupNorm(
+                    num_groups=self.num_groups,
+                    num_channels=self.num_channels,
+                    **kwargs,
+                )
+                if expected_w:
+                    assert layer.weight is not None
+                else:
+                    assert layer.weight is None
+                if expected_b:
+                    assert layer.bias is not None
+                else:
+                    assert layer.bias is None
+
+                y_var = None
+                if expected_out:
+                    x_var = paddle.static.data("input", self.x_shape)
+                    y_var = layer(x_var)
+
+            exe = base.Executor(device)
+            exe.run(start)
+
+            fetch_list = []
+            if expected_w:
+                fetch_list.append(layer.weight)
+            if expected_b:
+                fetch_list.append(layer.bias)
+            if expected_out:
+                fetch_list.append(y_var)
+            fetched_arrays = exe.run(
+                main,
+                feed={'input': x_np} if expected_out else {},
+                fetch_list=fetch_list,
             )
+            return fetched_arrays
+
+    def _check_params(self, weight_np, bias_np, expected_weight, expected_bias):
+        assert weight_np.shape == tuple(self.param_shape)
+        assert bias_np.shape == tuple(self.param_shape)
+        np.testing.assert_allclose(weight_np, expected_weight)
+        np.testing.assert_allclose(bias_np, expected_bias)
+
+    def _check_outs(self, out1_np, out2_np):
+        assert out1_np.shape == tuple(self.x_shape)
+        assert out2_np.shape == tuple(self.x_shape)
+        np.testing.assert_allclose(out1_np, out2_np)
+
+    def test_static_affine_true(self):
+        """test that when affine=True, weight and bias parameters are created."""
+        for p in self.places:
+            x_np = np.random.randn(*self.x_shape).astype("float32")
+            w_new, b_new, out_new = self._run_group_norm_static(
+                device=p,
+                epsilon=1e-05,
+                affine=True,
+                x_np=x_np,
+            )
+            w_old, b_old, out_old = self._run_group_norm_static(
+                device=p,
+                epsilon=1e-05,
+                x_np=x_np,
+            )
+            expected_weight = np.ones(self.param_shape)
+            expected_bias = np.zeros(self.param_shape)
+            self._check_params(w_new, b_new, expected_weight, expected_bias)
+            self._check_params(w_old, b_old, expected_weight, expected_bias)
+            self._check_outs(out_new, out_old)
+
+    def test_static_affine_false(self):
+        """test that when affine=False, no learnable parameters are created."""
+        for p in self.places:
+            x_np = np.random.randn(*self.x_shape).astype("float32")
+            (out_new,) = self._run_group_norm_static(
+                device=p,
+                affine=False,
+                expected_w=False,
+                expected_b=False,
+                x_np=x_np,
+            )
+            (out_old,) = self._run_group_norm_static(
+                device=p,
+                weight_attr=False,
+                bias_attr=False,
+                expected_w=False,
+                expected_b=False,
+                x_np=x_np,
+            )
+            self._check_outs(out_new, out_old)
+
+    def test_static_overrides_with_affine(self):
+        """test that weight_attr and bias_attr can override the default initialization when affine=True."""
+        for p in self.places:
+            with static_guard():
+                main = base.Program()
+                start = base.Program()
+                with (
+                    base.unique_name.guard(),
+                    base.program_guard(main, start),
+                ):
+                    weight_val = 2.0
+                    bias_val = 3.0
+                    weight_attr = paddle.nn.initializer.Constant(
+                        value=weight_val
+                    )
+                    bias_attr = paddle.nn.initializer.Constant(value=bias_val)
+                    layer = paddle.nn.GroupNorm(
+                        num_groups=self.num_groups,
+                        num_channels=self.num_channels,
+                        affine=True,
+                        weight_attr=weight_attr,
+                        bias_attr=bias_attr,
+                    )
+                exe = base.Executor(p)
+                exe.run(start)
+                paddle.device.synchronize()
+                weight_np, bias_np = exe.run(
+                    main, fetch_list=[layer.weight, layer.bias]
+                )
+
+                expected_weight = np.full(self.param_shape, weight_val)
+                expected_bias = np.full(self.param_shape, bias_val)
+                self._check_params(
+                    weight_np, bias_np, expected_weight, expected_bias
+                )
+
+    def test_static_alias(self):
+        """test parameter alias epsilon/eps"""
+        for p in self.places:
+            x_np = np.random.randn(*self.x_shape).astype("float32")
+            w_new, b_new, out_new = self._run_group_norm_static(
+                device=p,
+                eps=1e-05,
+                x_np=x_np,
+            )
+            w_old, b_old, out_old = self._run_group_norm_static(
+                device=p,
+                epsilon=1e-05,
+                x_np=x_np,
+            )
+            self._check_outs(out_new, out_old)
+
+    def test_static_errors(self):
+        """test parameters with errors"""
+        for p in self.places:
+            with static_guard():
+                main = base.Program()
+                start = base.Program()
+                with (
+                    base.unique_name.guard(),
+                    base.program_guard(main, start),
+                    self.assertRaises(TypeError),
+                ):
+                    paddle.nn.GroupNorm(
+                        self.num_groups,
+                        self.num_channels,
+                        1e-05,
+                        True,
+                        "cpu",
+                        paddle.float32,
+                    )
 
 
 if __name__ == '__main__':

--- a/test/legacy_test/test_group_norm_op_v2.py
+++ b/test/legacy_test/test_group_norm_op_v2.py
@@ -749,6 +749,9 @@ class TestGroupNormAPIV2_Param(unittest.TestCase):
         self.num_channels = 16
         self.x_tensor = paddle.randn([2, self.num_channels, 4, 4])
 
+    @unittest.skipIf(
+        not paddle.in_dynamic_mode(), "Test is only for dynamic mode"
+    )
     def test_affine_true(self):
         """test that when affine=True, weight and bias parameters are created."""
         layer = paddle.nn.GroupNorm(
@@ -763,17 +766,12 @@ class TestGroupNormAPIV2_Param(unittest.TestCase):
         self.assertEqual(layer.weight.shape, [self.num_channels])
         self.assertEqual(layer.bias.shape, [self.num_channels])
 
-        if paddle.in_dynamic_mode():
-            self.assertTrue(
-                paddle.allclose(
-                    layer.weight, paddle.ones([self.num_channels])
-                ).item()
-            )
-            self.assertTrue(
-                paddle.allclose(
-                    layer.bias, paddle.zeros([self.num_channels])
-                ).item()
-            )
+        self.assertTrue(
+            paddle.allclose(layer.weight, paddle.ones([self.num_channels]))
+        )
+        self.assertTrue(
+            paddle.allclose(layer.bias, paddle.zeros([self.num_channels]))
+        )
 
         layer_old = paddle.nn.GroupNorm(
             num_groups=self.num_groups,
@@ -787,17 +785,12 @@ class TestGroupNormAPIV2_Param(unittest.TestCase):
         self.assertEqual(layer_old.weight.shape, [self.num_channels])
         self.assertEqual(layer_old.bias.shape, [self.num_channels])
 
-        if paddle.in_dynamic_mode():
-            self.assertTrue(
-                paddle.allclose(
-                    layer_old.weight, paddle.ones([self.num_channels])
-                ).item()
-            )
-            self.assertTrue(
-                paddle.allclose(
-                    layer_old.bias, paddle.zeros([self.num_channels])
-                ).item()
-            )
+        self.assertTrue(
+            paddle.allclose(layer_old.weight, paddle.ones([self.num_channels]))
+        )
+        self.assertTrue(
+            paddle.allclose(layer_old.bias, paddle.zeros([self.num_channels]))
+        )
 
     def test_affine_false(self):
         """test that when affine=False, no learnable parameters are created."""
@@ -820,6 +813,9 @@ class TestGroupNormAPIV2_Param(unittest.TestCase):
         self.assertIsNone(layer_old.weight)
         self.assertIsNone(layer_old.bias)
 
+    @unittest.skipIf(
+        not paddle.in_dynamic_mode(), "Test is only for dynamic mode"
+    )
     def test_overrides_with_affine(self):
         """test that weight_attr and bias_attr can override the default initialization when affine=True."""
         weight_attr = paddle.nn.initializer.Constant(value=2.0)
@@ -834,11 +830,8 @@ class TestGroupNormAPIV2_Param(unittest.TestCase):
 
         expected_weight = paddle.full([self.num_channels], 2.0)
         expected_bias = paddle.full([self.num_channels], 3.0)
-        if paddle.in_dynamic_mode():
-            self.assertTrue(
-                paddle.allclose(layer.weight, expected_weight).item()
-            )
-            self.assertTrue(paddle.allclose(layer.bias, expected_bias).item())
+        self.assertTrue(paddle.allclose(layer.weight, expected_weight))
+        self.assertTrue(paddle.allclose(layer.bias, expected_bias))
 
     def test_shape_with_affine(self):
         """test the forward pass when affine."""
@@ -860,6 +853,9 @@ class TestGroupNormAPIV2_Param(unittest.TestCase):
 
         self.assertEqual(out.shape, self.x_tensor.shape)
 
+    @unittest.skipIf(
+        not paddle.in_dynamic_mode(), "Test is only for dynamic mode"
+    )
     def test_alias(self):
         """test parameter alias epsilon/eps"""
         layer_epsilon = paddle.nn.GroupNorm(

--- a/test/legacy_test/test_group_norm_op_v2.py
+++ b/test/legacy_test/test_group_norm_op_v2.py
@@ -743,5 +743,81 @@ class TestGroupNormParam(unittest.TestCase):
             )
 
 
+class TestGroupNormAffine(unittest.TestCase):
+    def setUp(self):
+        self.num_groups = 8
+        self.num_channels = 16
+        self.x_tensor = paddle.randn([2, self.num_channels, 4, 4])
+
+    def test_affine_true(self):
+        """Test that when affine=True, weight and bias parameters are created."""
+        layer = paddle.nn.GroupNorm(
+            num_groups=self.num_groups,
+            num_channels=self.num_channels,
+            affine=True,
+        )
+
+        self.assertIsNotNone(layer.weight)
+        self.assertIsNotNone(layer.bias)
+
+        self.assertEqual(layer.weight.shape, [self.num_channels])
+        self.assertEqual(layer.bias.shape, [self.num_channels])
+
+        self.assertTrue(
+            paddle.allclose(layer.weight, paddle.ones([self.num_channels]))
+        )
+        self.assertTrue(
+            paddle.allclose(layer.bias, paddle.zeros([self.num_channels]))
+        )
+
+    def test_affine_false(self):
+        """Test that when affine=False, no learnable parameters are created."""
+        layer = paddle.nn.GroupNorm(
+            num_groups=self.num_groups,
+            num_channels=self.num_channels,
+            affine=False,
+        )
+
+        self.assertIsNone(layer.weight)
+        self.assertIsNone(layer.bias)
+
+    def test_overrides_with_affine(self):
+        """Test that weight_attr and bias_attr can override the default initialization when affine=True."""
+        weight_attr = paddle.nn.initializer.Constant(value=2.0)
+        bias_attr = paddle.nn.initializer.Constant(value=3.0)
+        layer = paddle.nn.GroupNorm(
+            num_groups=self.num_groups,
+            num_channels=self.num_channels,
+            affine=True,
+            weight_attr=weight_attr,
+            bias_attr=bias_attr,
+        )
+
+        expected_weight = paddle.full([self.num_channels], 2.0)
+        expected_bias = paddle.full([self.num_channels], 3.0)
+        self.assertTrue(paddle.allclose(layer.weight, expected_weight))
+        self.assertTrue(paddle.allclose(layer.bias, expected_bias))
+
+    def test_shape_with_affine(self):
+        """Test the forward pass when affine."""
+        layer = paddle.nn.GroupNorm(
+            num_groups=self.num_groups,
+            num_channels=self.num_channels,
+            affine=True,
+        )
+        out = layer(self.x_tensor)
+
+        self.assertEqual(out.shape, self.x_tensor.shape)
+
+        layer = paddle.nn.GroupNorm(
+            num_groups=self.num_groups,
+            num_channels=self.num_channels,
+            affine=False,
+        )
+        out = layer(self.x_tensor)
+
+        self.assertEqual(out.shape, self.x_tensor.shape)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/legacy_test/test_group_norm_op_v2.py
+++ b/test/legacy_test/test_group_norm_op_v2.py
@@ -763,12 +763,17 @@ class TestGroupNormAPIV2_Param(unittest.TestCase):
         self.assertEqual(layer.weight.shape, [self.num_channels])
         self.assertEqual(layer.bias.shape, [self.num_channels])
 
-        self.assertTrue(
-            paddle.allclose(layer.weight, paddle.ones([self.num_channels]))
-        )
-        self.assertTrue(
-            paddle.allclose(layer.bias, paddle.zeros([self.num_channels]))
-        )
+        if paddle.in_dynamic_mode():
+            self.assertTrue(
+                paddle.allclose(
+                    layer.weight, paddle.ones([self.num_channels])
+                ).item()
+            )
+            self.assertTrue(
+                paddle.allclose(
+                    layer.bias, paddle.zeros([self.num_channels])
+                ).item()
+            )
 
         layer_old = paddle.nn.GroupNorm(
             num_groups=self.num_groups,
@@ -782,12 +787,17 @@ class TestGroupNormAPIV2_Param(unittest.TestCase):
         self.assertEqual(layer_old.weight.shape, [self.num_channels])
         self.assertEqual(layer_old.bias.shape, [self.num_channels])
 
-        self.assertTrue(
-            paddle.allclose(layer_old.weight, paddle.ones([self.num_channels]))
-        )
-        self.assertTrue(
-            paddle.allclose(layer_old.bias, paddle.zeros([self.num_channels]))
-        )
+        if paddle.in_dynamic_mode():
+            self.assertTrue(
+                paddle.allclose(
+                    layer_old.weight, paddle.ones([self.num_channels])
+                ).item()
+            )
+            self.assertTrue(
+                paddle.allclose(
+                    layer_old.bias, paddle.zeros([self.num_channels])
+                ).item()
+            )
 
     def test_affine_false(self):
         """test that when affine=False, no learnable parameters are created."""
@@ -825,8 +835,11 @@ class TestGroupNormAPIV2_Param(unittest.TestCase):
 
         expected_weight = paddle.full([self.num_channels], 2.0)
         expected_bias = paddle.full([self.num_channels], 3.0)
-        self.assertTrue(paddle.allclose(layer.weight, expected_weight))
-        self.assertTrue(paddle.allclose(layer.bias, expected_bias))
+        if paddle.in_dynamic_mode():
+            self.assertTrue(
+                paddle.allclose(layer.weight, expected_weight).item()
+            )
+            self.assertTrue(paddle.allclose(layer.bias, expected_bias).item())
 
     def test_shape_with_affine(self):
         """test the forward pass when affine."""

--- a/test/legacy_test/test_group_norm_op_v2.py
+++ b/test/legacy_test/test_group_norm_op_v2.py
@@ -747,50 +747,58 @@ class TestGroupNormAPIV2_Param(unittest.TestCase):
     def setUp(self):
         self.num_groups = 8
         self.num_channels = 16
-        self.x_tensor = paddle.randn([2, self.num_channels, 4, 4])
+        self.x_shape = [2, self.num_channels, 4, 4]
+        self.places = get_places()
 
-    @unittest.skipIf(
-        not paddle.in_dynamic_mode(), "Test is only for dynamic mode"
-    )
     def test_affine_true(self):
         """test that when affine=True, weight and bias parameters are created."""
-        layer = paddle.nn.GroupNorm(
-            num_groups=self.num_groups,
-            num_channels=self.num_channels,
-            affine=True,
-        )
+        for p in self.places:
+            with base.dygraph.guard(p):
+                layer = paddle.nn.GroupNorm(
+                    num_groups=self.num_groups,
+                    num_channels=self.num_channels,
+                    affine=True,
+                )
 
-        self.assertIsNotNone(layer.weight)
-        self.assertIsNotNone(layer.bias)
+                self.assertIsNotNone(layer.weight)
+                self.assertIsNotNone(layer.bias)
 
-        self.assertEqual(layer.weight.shape, [self.num_channels])
-        self.assertEqual(layer.bias.shape, [self.num_channels])
+                self.assertEqual(layer.weight.shape, [self.num_channels])
+                self.assertEqual(layer.bias.shape, [self.num_channels])
 
-        self.assertTrue(
-            paddle.allclose(layer.weight, paddle.ones([self.num_channels]))
-        )
-        self.assertTrue(
-            paddle.allclose(layer.bias, paddle.zeros([self.num_channels]))
-        )
+                self.assertTrue(
+                    paddle.allclose(
+                        layer.weight, paddle.ones([self.num_channels])
+                    )
+                )
+                self.assertTrue(
+                    paddle.allclose(
+                        layer.bias, paddle.zeros([self.num_channels])
+                    )
+                )
 
-        layer_old = paddle.nn.GroupNorm(
-            num_groups=self.num_groups,
-            num_channels=self.num_channels,
-            epsilon=1e-05,
-        )
+                layer_old = paddle.nn.GroupNorm(
+                    num_groups=self.num_groups,
+                    num_channels=self.num_channels,
+                    epsilon=1e-05,
+                )
 
-        self.assertIsNotNone(layer_old.weight)
-        self.assertIsNotNone(layer_old.bias)
+                self.assertIsNotNone(layer_old.weight)
+                self.assertIsNotNone(layer_old.bias)
 
-        self.assertEqual(layer_old.weight.shape, [self.num_channels])
-        self.assertEqual(layer_old.bias.shape, [self.num_channels])
+                self.assertEqual(layer_old.weight.shape, [self.num_channels])
+                self.assertEqual(layer_old.bias.shape, [self.num_channels])
 
-        self.assertTrue(
-            paddle.allclose(layer_old.weight, paddle.ones([self.num_channels]))
-        )
-        self.assertTrue(
-            paddle.allclose(layer_old.bias, paddle.zeros([self.num_channels]))
-        )
+                self.assertTrue(
+                    paddle.allclose(
+                        layer_old.weight, paddle.ones([self.num_channels])
+                    )
+                )
+                self.assertTrue(
+                    paddle.allclose(
+                        layer_old.bias, paddle.zeros([self.num_channels])
+                    )
+                )
 
     def test_affine_false(self):
         """test that when affine=False, no learnable parameters are created."""
@@ -813,66 +821,66 @@ class TestGroupNormAPIV2_Param(unittest.TestCase):
         self.assertIsNone(layer_old.weight)
         self.assertIsNone(layer_old.bias)
 
-    @unittest.skipIf(
-        not paddle.in_dynamic_mode(), "Test is only for dynamic mode"
-    )
     def test_overrides_with_affine(self):
         """test that weight_attr and bias_attr can override the default initialization when affine=True."""
-        weight_attr = paddle.nn.initializer.Constant(value=2.0)
-        bias_attr = paddle.nn.initializer.Constant(value=3.0)
-        layer = paddle.nn.GroupNorm(
-            num_groups=self.num_groups,
-            num_channels=self.num_channels,
-            affine=True,
-            weight_attr=weight_attr,
-            bias_attr=bias_attr,
-        )
+        for p in self.places:
+            with base.dygraph.guard(p):
+                weight_attr = paddle.nn.initializer.Constant(value=2.0)
+                bias_attr = paddle.nn.initializer.Constant(value=3.0)
+                layer = paddle.nn.GroupNorm(
+                    num_groups=self.num_groups,
+                    num_channels=self.num_channels,
+                    affine=True,
+                    weight_attr=weight_attr,
+                    bias_attr=bias_attr,
+                )
 
-        expected_weight = paddle.full([self.num_channels], 2.0)
-        expected_bias = paddle.full([self.num_channels], 3.0)
-        self.assertTrue(paddle.allclose(layer.weight, expected_weight))
-        self.assertTrue(paddle.allclose(layer.bias, expected_bias))
+                expected_weight = paddle.full([self.num_channels], 2.0)
+                expected_bias = paddle.full([self.num_channels], 3.0)
+                self.assertTrue(paddle.allclose(layer.weight, expected_weight))
+                self.assertTrue(paddle.allclose(layer.bias, expected_bias))
 
     def test_shape_with_affine(self):
         """test the forward pass when affine."""
+        x_tensor = paddle.randn(self.x_shape)
         layer = paddle.nn.GroupNorm(
             num_groups=self.num_groups,
             num_channels=self.num_channels,
             affine=True,
         )
-        out = layer(self.x_tensor)
-
-        self.assertEqual(out.shape, self.x_tensor.shape)
+        out = layer(x_tensor)
+        self.assertEqual(out.shape, self.x_shape)
 
         layer = paddle.nn.GroupNorm(
             num_groups=self.num_groups,
             num_channels=self.num_channels,
             affine=False,
         )
-        out = layer(self.x_tensor)
+        out = layer(x_tensor)
+        self.assertEqual(out.shape, self.x_shape)
 
-        self.assertEqual(out.shape, self.x_tensor.shape)
-
-    @unittest.skipIf(
-        not paddle.in_dynamic_mode(), "Test is only for dynamic mode"
-    )
     def test_alias(self):
         """test parameter alias epsilon/eps"""
-        layer_epsilon = paddle.nn.GroupNorm(
-            num_groups=self.num_groups,
-            num_channels=self.num_channels,
-            epsilon=1e-5,
-        )
-        layer_eps = paddle.nn.GroupNorm(
-            num_groups=self.num_groups,
-            num_channels=self.num_channels,
-            eps=1e-5,
-        )
+        for p in self.places:
+            with base.dygraph.guard(p):
+                x_tensor = paddle.randn(self.x_shape)
+                layer_epsilon = paddle.nn.GroupNorm(
+                    num_groups=self.num_groups,
+                    num_channels=self.num_channels,
+                    epsilon=1e-5,
+                )
+                layer_eps = paddle.nn.GroupNorm(
+                    num_groups=self.num_groups,
+                    num_channels=self.num_channels,
+                    eps=1e-5,
+                )
 
-        out_epsilon = layer_epsilon(self.x_tensor)
-        out_eps = layer_eps(self.x_tensor)
+                out_epsilon = layer_epsilon(x_tensor)
+                out_eps = layer_eps(x_tensor)
 
-        np.testing.assert_array_equal(out_epsilon.numpy(), out_eps.numpy())
+                np.testing.assert_array_equal(
+                    out_epsilon.numpy(), out_eps.numpy()
+                )
 
     def test_errors(self):
         """test parameters with errors"""

--- a/test/legacy_test/test_group_norm_op_v2.py
+++ b/test/legacy_test/test_group_norm_op_v2.py
@@ -752,7 +752,7 @@ class TestGroupNormAPIV2_Param_Dygraph(unittest.TestCase):
         self.param_shape = [self.num_channels]
         self.places = get_places()
 
-    def check_params(self, weight, bias, expected_weight, expected_bias):
+    def _check_params(self, weight, bias, expected_weight, expected_bias):
         self.assertIsNotNone(weight)
         self.assertIsNotNone(bias)
         self.assertEqual(weight.shape, self.param_shape)
@@ -780,10 +780,10 @@ class TestGroupNormAPIV2_Param_Dygraph(unittest.TestCase):
                 expected_weight = paddle.ones(self.param_shape)
                 expected_bias = paddle.zeros(self.param_shape)
 
-                self.check_params(
+                self._check_params(
                     layer.weight, layer.bias, expected_weight, expected_bias
                 )
-                self.check_params(
+                self._check_params(
                     layer_old.weight,
                     layer_old.bias,
                     expected_weight,
@@ -822,29 +822,6 @@ class TestGroupNormAPIV2_Param_Dygraph(unittest.TestCase):
                 out = layer(x_tensor)
                 out_old = layer_old(x_tensor)
                 self.assertTrue(paddle.allclose(out, out_old).item())
-
-    def test_overrides_with_affine(self):
-        """test that weight_attr and bias_attr can override the default initialization when affine=True."""
-        for p in self.places:
-            with base.dygraph.guard(p):
-                weight_val = 2.0
-                bias_val = 3.0
-                weight_attr = paddle.nn.initializer.Constant(value=weight_val)
-                bias_attr = paddle.nn.initializer.Constant(value=bias_val)
-
-                layer = paddle.nn.GroupNorm(
-                    num_groups=self.num_groups,
-                    num_channels=self.num_channels,
-                    affine=True,
-                    weight_attr=weight_attr,
-                    bias_attr=bias_attr,
-                )
-
-                expected_weight = paddle.full(self.param_shape, weight_val)
-                expected_bias = paddle.full(self.param_shape, bias_val)
-                self.check_params(
-                    layer.weight, layer.bias, expected_weight, expected_bias
-                )
 
     def test_alias(self):
         """test parameter alias epsilon/eps"""
@@ -990,41 +967,6 @@ class TestGroupNormAPIV2_Param_Static(unittest.TestCase):
                 x_np=x_np,
             )
             self._check_outs(out_new, out_old)
-
-    def test_static_overrides_with_affine(self):
-        """test that weight_attr and bias_attr can override the default initialization when affine=True."""
-        for p in self.places:
-            with static_guard():
-                main = base.Program()
-                start = base.Program()
-                with (
-                    base.unique_name.guard(),
-                    base.program_guard(main, start),
-                ):
-                    weight_val = 2.0
-                    bias_val = 3.0
-                    weight_attr = paddle.nn.initializer.Constant(
-                        value=weight_val
-                    )
-                    bias_attr = paddle.nn.initializer.Constant(value=bias_val)
-                    layer = paddle.nn.GroupNorm(
-                        num_groups=self.num_groups,
-                        num_channels=self.num_channels,
-                        affine=True,
-                        weight_attr=weight_attr,
-                        bias_attr=bias_attr,
-                    )
-                exe = base.Executor(p)
-                exe.run(start)
-                weight_np, bias_np = exe.run(
-                    main, fetch_list=[layer.weight, layer.bias]
-                )
-
-                expected_weight = np.full(self.param_shape, weight_val)
-                expected_bias = np.full(self.param_shape, bias_val)
-                self._check_params(
-                    weight_np, bias_np, expected_weight, expected_bias
-                )
 
     def test_static_alias(self):
         """test parameter alias epsilon/eps"""

--- a/test/legacy_test/test_group_norm_op_v2.py
+++ b/test/legacy_test/test_group_norm_op_v2.py
@@ -813,7 +813,6 @@ class TestGroupNormAPIV2_Param(unittest.TestCase):
         layer_old = paddle.nn.GroupNorm(
             num_groups=self.num_groups,
             num_channels=self.num_channels,
-            epsilon=1e-05,
             weight_attr=False,
             bias_attr=False,
         )
@@ -861,14 +860,30 @@ class TestGroupNormAPIV2_Param(unittest.TestCase):
 
         self.assertEqual(out.shape, self.x_tensor.shape)
 
+    def test_alias(self):
+        """test parameter alias epsilon/eps"""
+        layer_epsilon = paddle.nn.GroupNorm(
+            num_groups=self.num_groups,
+            num_channels=self.num_channels,
+            epsilon=1e-5,
+        )
+        layer_eps = paddle.nn.GroupNorm(
+            num_groups=self.num_groups,
+            num_channels=self.num_channels,
+            eps=1e-5,
+        )
+
+        out_epsilon = layer_epsilon(self.x_tensor)
+        out_eps = layer_eps(self.x_tensor)
+
+        np.testing.assert_array_equal(out_epsilon.numpy(), out_eps.numpy())
+
     def test_errors(self):
         """test parameters with errors"""
         with self.assertRaises(TypeError):
             layer = paddle.nn.GroupNorm(
                 self.num_groups,
                 self.num_channels,
-                2,
-                2,
                 1e-05,
                 True,
                 "cpu",

--- a/test/legacy_test/test_group_norm_op_v2_init.py
+++ b/test/legacy_test/test_group_norm_op_v2_init.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+from utils import dygraph_guard, static_guard
+
+import paddle
+from paddle import base
+
+
+class TestGroupNormAPIV2_ParamInit(unittest.TestCase):
+    def setUp(self):
+        self.num_groups = 8
+        self.num_channels = 16
+        self.x_shape = [2, self.num_channels, 4, 4]
+        self.param_shape = [self.num_channels]
+
+    def _check_params(self, weight_np, bias_np, expected_weight, expected_bias):
+        assert tuple(weight_np.shape) == tuple(self.param_shape)
+        assert tuple(bias_np.shape) == tuple(self.param_shape)
+        np.testing.assert_allclose(weight_np, expected_weight)
+        np.testing.assert_allclose(bias_np, expected_bias)
+
+    def test_dygraph(self):
+        """test that weight_attr and bias_attr can override the default initialization when affine=True."""
+        paddle.disable_static()
+        with dygraph_guard():
+            weight_val = 2.0
+            bias_val = 3.0
+            weight_attr = paddle.nn.initializer.Constant(value=weight_val)
+            bias_attr = paddle.nn.initializer.Constant(value=bias_val)
+
+            layer = paddle.nn.GroupNorm(
+                num_groups=self.num_groups,
+                num_channels=self.num_channels,
+                affine=True,
+                weight_attr=weight_attr,
+                bias_attr=bias_attr,
+            )
+
+            expected_weight = np.full(self.param_shape, weight_val)
+            expected_bias = np.full(self.param_shape, bias_val)
+            self._check_params(
+                layer.weight.numpy(),
+                layer.bias.numpy(),
+                expected_weight,
+                expected_bias,
+            )
+
+    def test_static(self):
+        """test that weight_attr and bias_attr can override the default initialization when affine=True."""
+        paddle.enable_static()
+        with static_guard():
+            main = base.Program()
+            start = base.Program()
+            with (
+                base.unique_name.guard(),
+                base.program_guard(main, start),
+            ):
+                weight_val = 2.0
+                bias_val = 3.0
+                weight_attr = paddle.nn.initializer.Constant(value=weight_val)
+                bias_attr = paddle.nn.initializer.Constant(value=bias_val)
+                layer = paddle.nn.GroupNorm(
+                    num_groups=self.num_groups,
+                    num_channels=self.num_channels,
+                    affine=True,
+                    weight_attr=weight_attr,
+                    bias_attr=bias_attr,
+                )
+            exe = base.Executor()
+            exe.run(start)
+            weight_np, bias_np = exe.run(
+                main, fetch_list=[layer.weight, layer.bias]
+            )
+
+            expected_weight = np.full(self.param_shape, weight_val)
+            expected_bias = np.full(self.param_shape, bias_val)
+            self._check_params(
+                weight_np, bias_np, expected_weight, expected_bias
+            )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
pcard-67164

paddle.nn.GroupNorm

1. 增加输入映射 epsilon: eps
2. 增加affine、device和dtype参数
3. 增加相应单测
4. 修改docstring

**注意：修改后affine、device、dtype和weight_attr、bias_attr、data_format、name都是关键字参数，下面的PaConvert 测试中会出现失败case是正常的**

PaConvert 测试

<img width="390" height="230" alt="image" src="https://github.com/user-attachments/assets/df1dde31-1ef7-49bf-8246-9dde5deb9146" />
<img width="530" height="152" alt="image" src="https://github.com/user-attachments/assets/09eb23f0-2a03-4f46-a782-997523feec9a" />
<img width="656" height="36" alt="image" src="https://github.com/user-attachments/assets/1c6dc132-6d26-404f-abfc-945c2c39873f" />

**该失败case已被该PR中新增的单测覆盖：**
<img width="288" height="206" alt="106e762e9caf479453bd69bfbfe01b77" src="https://github.com/user-attachments/assets/9be9b675-d3d1-435e-acd2-5cb2556a0e8e" />
