### PR TITLE
[Dy2St] Move `builtin.parameter` to top in IR when ast dy2static

### DIFF
--- a/paddle/fluid/framework/new_executor/instruction/control_flow/if_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/control_flow/if_instruction.cc
@@ -63,7 +63,6 @@ IfInstruction::IfInstruction(size_t id,
                  common::errors::PreconditionNotMet(
                      "Cond instruction only support if op"));
   auto if_op = op->dyn_cast<paddle::dialect::IfOp>();
-  op_ = op;
 
   SetKernelType(AnalyseOpFuncType(op, place));
   VLOG(6) << "finish process analyse kernel type";

--- a/python/paddle/jit/sot/translate.py
+++ b/python/paddle/jit/sot/translate.py
@@ -100,10 +100,10 @@ def symbolic_translate(fn: Callable[P, R], **kwargs) -> Callable[P, R]:
         return eval_frame_callback(frame, **kwargs)
 
     def impl(*args: P.args, **kwargs: P.kwargs) -> R:
+        assert hasattr(fn, "__code__"), (
+            "Target function doesn't have code for simulating."
+        )
         with StepInfoManager().step_guard(fn.__code__), SotStepProfilerGuard():
-            assert hasattr(fn, "__code__"), (
-                "Target function doesn't have code for simulating."
-            )
             InfoCollector().clear_step_info()
             paddle.framework.core.set_eval_frame(callback)
             try:

--- a/test/dygraph_to_static/test_ifelse.py
+++ b/test/dygraph_to_static/test_ifelse.py
@@ -656,7 +656,6 @@ class Net(nn.Layer):
 
 
 class TestBuiltinParameter(Dy2StTestBase):
-    @test_ast_only
     def test_move_builtin_parameter2top(self):
         x = paddle.randn([8, 8])
         static_fn = paddle.jit.to_static(Net())

--- a/test/dygraph_to_static/test_ifelse.py
+++ b/test/dygraph_to_static/test_ifelse.py
@@ -47,6 +47,7 @@ from ifelse_simple_func import (
 
 import paddle
 import paddle.nn.functional as F
+from paddle import nn
 from paddle.jit.dy2static.utils import Dygraph2StaticException
 
 np.random.seed(1)
@@ -632,6 +633,34 @@ class TestDynamicShapeWithConstantPromotion(Dy2StTestBase):
         )
         out = static_fn(x)
         self.assertEqual(out, 3)
+
+
+salt = paddle.rand([8])
+
+
+class Net(nn.Layer):
+    def __init__(self):
+        super().__init__()
+        self.layer = nn.Linear(8, 8)
+
+    def fn(self, x):
+        global salt
+        if x.sum() > 0:
+            x = self.layer(x) + salt
+        else:
+            x += salt
+        return x
+
+    def forward(self, x):
+        return self.fn(x)
+
+
+class TestBuiltinParameter(Dy2StTestBase):
+    @test_ast_only
+    def test_move_builtin_parameter2top(self):
+        x = paddle.randn([8, 8])
+        static_fn = paddle.jit.to_static(Net())
+        out = static_fn(x)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

在 FastDeploy Deepseek V3 动转静过程中，存在 if block 中有 `builtin.parameter` Op 的问题，导致后面的 if block（子Block） 在使用
%605、%606 和 %607 时，无法访问到的问题，`builtin.parameter` 应该放到 `global block` 中

```shell
    (%603) = "multiply_(phi_kernel)" (%602, %223) {is_inplace:true,kernel_key:<backend:GPU|layout:NCHW|dtype:bfloat16>,kernel_name:"multiply",op_name:"pd_op.multiply_",origin_id:3780,stop_gradient:[false]} : (gpu_tensor<-1x2048xbf16>, gpu_tensor<-1x1xbf16>) -> gpu_tensor<-1x2048xbf16>
    (%604) = "pd_op.if" [id:3781] (%225) {} -> gpu_tensor<-1x2048xbf16> {
        (%605) = "builtin.parameter" [id:3782] () {is_distributed:[false],is_parameter:[true],need_clip:[true],origin_id:3190,parameter_name:"eager_tmp_11",persistable:[true],stop_gradient:[true],trainable:[false]} : () -> gpu_tensor<16x512x128xbf16>
        (%606) = "builtin.parameter" [id:3783] () {is_distributed:[false],is_parameter:[true],need_clip:[true],origin_id:3191,parameter_name:"eager_tmp_10",persistable:[true],stop_gradient:[true],trainable:[false]} : () -> gpu_tensor<16x128x512xbf16>
        (%607) = "transpose(phi_kernel)" (%564) {kernel_key:<backend:GPU|layout:NCHW|dtype:bfloat16>,kernel_name:"transpose",op_name:"pd_op.transpose",origin_id:3784,perm:[1,0,2],stop_gradient:[false]} : (gpu_tensor<-1x16x128xbf16>) -> gpu_tensor<16x-1x128xbf16>
        ......
        (%623) = "add(phi_kernel)" (%603, %622) {kernel_key:<backend:GPU|layout:NCHW|dtype:bfloat16>,kernel_name:"add",op_name:"pd_op.add",origin_id:3800,stop_gradient:[false]} : (gpu_tensor<-1x2048xbf16>, gpu_tensor<-1x2048xbf16>) -> gpu_tensor<-1x2048xbf16>
        () = "cf.yield" [id:3801] (%623) {origin_id:3210} : (gpu_tensor<-1x2048xbf16>) -> 
    } else {
        ......
        (%626) = "add(phi_kernel)" (%603, %625) {kernel_key:<backend:GPU|layout:NCHW|dtype:bfloat16>,kernel_name:"add",op_name:"pd_op.add",origin_id:3804,stop_gradient:[false]} : (gpu_tensor<-1x2048xbf16>, gpu_tensor<-1x2048xbf16>) -> gpu_tensor<-1x2048xbf16>
        () = "cf.yield" [id:3805] (%626) {origin_id:3214} : (gpu_tensor<-1x2048xbf16>) -> 
    }
    (%627) = "matmul(phi_kernel)" (%604, %13) {kernel_key:<backend:GPU|layout:NCHW|dtype:bfloat16>,kernel_name:"matmul",op_name:"pd_op.matmul",origin_id:3806,stop_gradient:[false],transpose_x:false,transpose_y:false} : (gpu_tensor<-1x2048xbf16>, gpu_tensor<2048x7168xbf16>) -> gpu_tensor<-1x7168xbf16>
```

报错内容：
```shell
PreconditionNotMetError: input 0x41614b70 should be in name map
  [Hint: Expected value_exec_info.HasValue(value) == true, but received value_exec_info.HasValue(value):0 != true:1.] (at /workspace/Paddle/paddle/fluid/framework/new_executor/instruction/instruction_util.cc:458)
  [operator < run_program > error]
```

改动部分：给 `builtin.parameter` 的创建过程加一个 Guard：
https://github.com/PaddlePaddle/Paddle/blob/3a94489dd56d74646bc3fe7a441fb6a2ebdd2842/python/paddle/jit/pir_dy2static/parameter_recorder.py#L44-L53

在该 Guard 下，则将 OP 追加到 `global_block`，否则照旧

```python
@contextmanager
def append_op_in_top_block():
    current_insertion_point = paddle.pir.get_current_insertion_point()
    top_block = paddle.static.default_main_program().global_block()
    paddle.pir.set_insertion_point_to_block_end(top_block)
    try:
        yield
    finally:
        paddle.pir.set_insertion_point(current_insertion_point)
```

- [ ] TODO：后面给这个上下文管理器加个注释

<!-- pcard-92901 -->