### PR TITLE
[API Compatibility] Improve `compat.nn.Linear` init and param reset

### DIFF
--- a/python/paddle/compat/nn/__init__.py
+++ b/python/paddle/compat/nn/__init__.py
@@ -250,20 +250,11 @@ class Linear(nn.Layer):
         Resets parameters based on their initialization used in ``__init__``.
         """
 
-        # KaimingUniform initializer should be more flexible: user should be able to specify place
-        expected_place = paddle.base.framework._current_expected_place()
-        original_place = self.weight.place
         nn.init.kaiming_uniform_(self.weight, a=sqrt(5))
-
-        place_mismatch = expected_place != original_place
-        if place_mismatch and in_dynamic_mode():
-            self.weight = self.weight.to(original_place)
         if self.bias is not None:
             # nn.init._calculate_fan_in_and_fan_out(self.weight) for 2D array
             # is equivalent to returning (weight.shape[1], weight.shape[0])
+            # TODO(heqianyue): use _calculate_fan_in_and_fan_out when available
             fan_in = self.weight.shape[1]
             bound = 1 / sqrt(fan_in) if fan_in > 0 else 0
             nn.init.uniform_(self.bias, -bound, bound)
-
-            if place_mismatch and in_dynamic_mode():
-                self.bias = self.bias.to(original_place)

--- a/python/paddle/nn/initializer/kaiming.py
+++ b/python/paddle/nn/initializer/kaiming.py
@@ -173,12 +173,19 @@ class MSRAInitializer(Initializer):
                     -limit,
                     limit,
                     self._seed,
-                    _current_expected_place(),
+                    var.place
+                    if var.place._type()
+                    else _current_expected_place(),
                 )
             else:
                 gain = calculate_gain(self._nonlinearity, self._negative_slope)
                 std = gain / math.sqrt(float(fan_in))
-                place = _current_expected_place()
+                # var.place._type() means undefined, happens when initializer is specified in ParamAttr
+                place = (
+                    var.place
+                    if var.place._type()
+                    else _current_expected_place()
+                )
                 out_var = _C_ops.gaussian(
                     out_var.shape, 0.0, std, self._seed, out_dtype, place
                 )

--- a/python/paddle/nn/initializer/uniform.py
+++ b/python/paddle/nn/initializer/uniform.py
@@ -126,7 +126,7 @@ class UniformInitializer(Initializer):
                 self._low,
                 self._high,
                 self._seed,
-                _current_expected_place(),
+                var.place if var.place._type() else _current_expected_place(),
             )
             if var.dtype == core.VarDesc.VarType.FP16:
                 var_tmp = _C_ops.cast(out_var, var.dtype)

--- a/test/legacy_test/test_compat_nn_linear.py
+++ b/test/legacy_test/test_compat_nn_linear.py
@@ -347,6 +347,18 @@ class TestCompatLinearLayer(unittest.TestCase):
 
         np.testing.assert_allclose(y_pd.numpy(), expected, rtol=1e-5, atol=1e-8)
 
+    def test_reset_parameters(self):
+        if not paddle.base.is_compiled_with_cuda():
+            return
+        devices = ['cpu', None]  # None means the default device
+        for device_ in devices:
+            dummy_tensor = paddle.zeros(1, device=device_)
+            lin = paddle.compat.nn.Linear(4, 8, bias=True, device=device_)
+            expected_device = dummy_tensor.place
+            lin.reset_parameters()
+            self.assertEqual(lin.weight.place, expected_device)
+            self.assertEqual(lin.bias.place, expected_device)
+
     def test_error_handling(self):
         """Test error handling for invalid inputs"""
         # Shape mismatch between input and weight


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Operator Mechanism


### PR Types
Improvements


### Description

优化了
- #76169 

中引入的 `compat.nn.Linear` 的初始化和 reset 函数。reset 函数中，`nn.Initializer.Uniform` 与 `nn.Initializer.KaimingUniform` 的行为都被修改:
- 当 `nn.initializer.XXX` 被直接实例化然后用 forward 形式初始化参数时，原始的行为如下代码块所示：
```python
>>> a = paddle.nn.Linear(3, 4).to('cpu')
>>> a
Linear(in_features=3, out_features=4, dtype=None)
>>> a.weight
Parameter containing:
Tensor(shape=[3, 4], dtype=float32, place=Place(cpu), stop_gradient=False,
       [[-0.45837218, -0.32479179, -0.47977936,  0.04010978],
        [-0.36938468,  0.12928823,  0.82120913, -0.60326314],
        [ 0.89723587, -0.30610302,  0.82338744, -0.04669143]])
>>> init = paddle.nn.initializer.XavierNormal()
>>> init(a.weight)
>>> a.weight
Parameter containing:
Tensor(shape=[3, 4], dtype=float32, place=Place(gpu:0), stop_gradient=False,
       [[ 0.06874870, -0.84757495,  1.06253850, -0.43288031],
        [ 0.54353887, -0.06623430, -0.98724484, -0.62573409],
        [ 0.52956545,  0.14853251, -0.45487842, -0.41272211]])
```
可以看到，place 从 `cpu` 变成了 `gpu:0`。这是因为 initializer 在动态图执行时，传入的 place 是 `_current_expected_place()`，而不是输入 tensor 的 place。而如果强行将所有 initializer 对应位置修改为 `var.place` 也会引起问题：如果 initializer 实例传入 ParamAttr 中，ParamAttr 辅助创建 parameters 时，tensor 的 place 是 undefined:0，此时必须使用 `_current_expected_place()`。

本 PR 只修改了与 `compat.nn.Linear` 有关的 initializer（kaiming_uniform 以及 uniform），其他 initializer 行为未变（个人觉得原始行为是不合理的，很显然，如果确实不合理，**对应的initializer都需要修改**，则需要一个新的PR完成对所有的 initializer 行为的‘修正’）。基于此，修正了 `compat.nn.Linear` 的初始化行为：不再手动进行 place 一致性检查以及 to 操作。

Pcard-89620