### PR TITLE
[Bug Fix] Skip set weight[padding_idx] to zero for Embedding when weight is not initialized

### DIFF
--- a/python/paddle/nn/layer/common.py
+++ b/python/paddle/nn/layer/common.py
@@ -1868,7 +1868,11 @@ class Embedding(Layer):
             if self._weight_attr is None:
                 self.weight.stop_gradient = _freeze
 
-        if in_dynamic_mode() and padding_idx != -1:
+        if (
+            in_dynamic_mode()
+            and padding_idx != -1
+            and self.weight._is_initialized()
+        ):
             with paddle.no_grad():
                 self.weight[padding_idx] = 0.0
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
当 paddleformers 使用 low_cpu_mem_usage 模式加载模型时，会跳过对权重的初始化，此时若尝试 self.weight[padding_idx] 设为 0，将引发异常。

本 PR 在设置 self.weight[padding_idx] = 0.0 前判断 weight 是否初始化过以避免对未初始化的权重赋值。