### PR TITLE
[TVM FFI] Bump test dependency `tvm-ffi` to `v0.1.1` and add e2e test cases for dtype and device protocol

### DIFF
--- a/python/unittest_py/requirements.txt
+++ b/python/unittest_py/requirements.txt
@@ -20,4 +20,4 @@ xdoctest==1.3.0
 ubelt==1.3.3 # just for xdoctest
 mypy==1.17.1
 soundfile
-apache-tvm-ffi==0.1.0
+apache-tvm-ffi==0.1.1

--- a/test/legacy_test/test_tvm_ffi.py
+++ b/test/legacy_test/test_tvm_ffi.py
@@ -177,8 +177,28 @@ class TestDLPackDataType(unittest.TestCase):
                 ),
             )
 
-    # TODO(SigureMo): add e2e test case pass a paddle.dtype to TVM FFI Function
-    # in tvm_ffi next release
+    def test_data_type_as_input(self):
+        cpp_source = r"""
+            void check_dtype(tvm::ffi::TensorView x, DLDataType expected_dtype) {
+                TVM_FFI_ICHECK(x.dtype() == expected_dtype) << "dtype mismatch";
+            }
+        """
+        mod: Module = tvm_ffi.cpp.load_inline(
+            name='mod', cpp_sources=cpp_source, functions='check_dtype'
+        )
+        for dtype in [
+            paddle.bool,
+            paddle.uint8,
+            paddle.int16,
+            paddle.int32,
+            paddle.int64,
+            paddle.float32,
+            paddle.float64,
+            paddle.float16,
+            paddle.bfloat16,
+        ]:
+            x = paddle.zeros((10,), dtype=dtype)
+            mod.check_dtype(x, dtype)
 
 
 class TestDLPackDeviceType(unittest.TestCase):
@@ -216,8 +236,23 @@ class TestDLPackDeviceType(unittest.TestCase):
                 (DLDeviceType.kDLCUDA.value, 0),
             )
 
-    # TODO(SigureMo): add e2e test case pass a paddle.base.core.Place to TVM FFI Function
-    # in tvm_ffi next release
+    def test_dlpack_device_type_as_input(self):
+        cpp_source = r"""
+            void check_device(tvm::ffi::TensorView x, DLDevice expected_device) {
+                TVM_FFI_ICHECK(x.device().device_type == expected_device.device_type) << "device type mismatch";
+                TVM_FFI_ICHECK(x.device().device_id == expected_device.device_id) << "device id mismatch";
+            }
+        """
+        mod: Module = tvm_ffi.cpp.load_inline(
+            name='mod', cpp_sources=cpp_source, functions='check_device'
+        )
+
+        x_cpu = paddle.zeros((10,), dtype='float32').cpu()
+        mod.check_device(x_cpu, x_cpu.place)
+
+        if paddle.is_compiled_with_cuda():
+            x_gpu = paddle.zeros((10,), dtype='float32').cuda()
+            mod.check_device(x_gpu, x_gpu.place)
 
 
 if __name__ == '__main__':

--- a/test/legacy_test/test_tvm_ffi.py
+++ b/test/legacy_test/test_tvm_ffi.py
@@ -197,7 +197,7 @@ class TestDLPackDataType(unittest.TestCase):
             paddle.float16,
             paddle.bfloat16,
         ]:
-            x = paddle.zeros((10,), dtype=dtype)
+            x = paddle.zeros((10,), dtype=dtype).cpu()
             mod.check_dtype(x, dtype)
 
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

Bump TVM FFI to v0.1.1 and add missing test cases in #75973

<!-- PCard-66972 -->