### PR TITLE
[Precision Depth Alignment] add FLAGS_torch_compatible_kernel for AffineGridOp

### DIFF
--- a/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
+++ b/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
@@ -74,6 +74,7 @@ COMMON_DECLARE_bool(use_onednn);
 
 COMMON_DECLARE_bool(print_ir);
 COMMON_DECLARE_bool(enable_collect_shape);
+COMMON_DECLARE_bool(torch_compatible_kernel);
 REGISTER_FILE_SYMBOLS(pd_op_to_kernel_pass);
 namespace paddle::dialect {
 

--- a/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
+++ b/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
@@ -282,6 +282,9 @@ static bool NeedFallBackFromGPUDNN2GPU(pir::Operation* op,
     }
   } else if ((op->isa<AffineGridOp>() || op->isa<AffineGridGradOp>()) &&
              kernel_key.backend() == phi::Backend::GPUDNN) {
+    if (FLAGS_torch_compatible_kernel) {
+      return true;
+    }
     bool use_cudnn = true;
     int version = -1;
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

在静态图下，希望affine_grid与Torch深度精度对齐时，通过FLAGS_torch_compatible_kernel 使得fallback到不适用cudnn的版本。

Pcard-67164