### PR TITLE
[0-size ] Fix paddle.outer 0-size error

### DIFF
--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -2875,11 +2875,11 @@ def outer(
     xshape = x.shape
     yshape = y.shape
     if math.prod(xshape) == 0:  # If the size is 0
-        nx = x.reshape((0, 0))
+        nx = x.reshape((0, 1))
     else:
         nx = x.reshape((-1, 1))
     if math.prod(yshape) == 0:  # If the size is 0
-        ny = y.reshape((0, 0))
+        ny = y.reshape((1, 0))
     else:
         ny = y.reshape((1, -1))
 

--- a/test/legacy_test/test_outer.py
+++ b/test/legacy_test/test_outer.py
@@ -221,6 +221,16 @@ class TestMultiplyApi_ZeroSize(unittest.TestCase):
         loss.backward()
         np.testing.assert_allclose(x.grad.shape, x.shape)
 
+    def test_multiply_dynamic1(self):
+        x_data = np.random.rand(0).astype(np.float32)
+        y_data = np.random.rand(1).astype(np.float32)
+        paddle.disable_static()
+        x = paddle.to_tensor(x_data)
+        y = paddle.to_tensor(y_data)
+        res = paddle.outer(x, y)
+        np_res = np.outer(x_data, y_data)
+        np.testing.assert_allclose(res.numpy(), np_res, rtol=1e-05)
+
 
 class TestOuterOutAndParamDecorator(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

修复paddle.outer存在的0-size问题，该问题由于 https://github.com/PaddlePaddle/Paddle/pull/74182  的更改导致。
报错case：
<img width="968" height="168" alt="image" src="https://github.com/user-attachments/assets/36cc7d4b-6817-444c-8642-10f951d41158" />

修复后的测试结果：
<img width="1294" height="876" alt="image" src="https://github.com/user-attachments/assets/54bab972-4d65-4395-ab83-27bd882d34f2" />
