### PR TITLE
[Distributed] Add PipelineDatasetPreprocessor to aviod mem leaks in pipeline parallel

### DIFF
--- a/python/paddle/distributed/fleet/meta_parallel/__init__.py
+++ b/python/paddle/distributed/fleet/meta_parallel/__init__.py
@@ -31,6 +31,7 @@ from .pipeline_parallel import (  # noqa: F401
     PipelineParallelMicroStepLocations,
     PipelineParallelWithInterleave,
     PipelineParallelWithInterleaveFthenB,
+    PipelineDatasetPreprocessor,
     VPPFhenBInBalancedMemory,
     register_global_pipeline_parallel_hook,
 )

--- a/python/paddle/distributed/fleet/meta_parallel/dualpipev.py
+++ b/python/paddle/distributed/fleet/meta_parallel/dualpipev.py
@@ -34,6 +34,7 @@ from ..utils.log_util import logger
 from .pipeline_parallel import (
     FakeMicroDataset,
     HybridParallelOptimizer,
+    PipelineDatasetPreprocessor,
     PipelineParallel,
 )
 from .pp_utils.batch_comm_helper import BatchCommHelper
@@ -634,6 +635,9 @@ class DualPipeVParallel(PipelineParallel):
         """
         for backward compatibility, wrap data to Fake FakeMicroDataset if it is of type list or tuple
         """
+        if isinstance(data, PipelineDatasetPreprocessor):
+            data = data()
+
         if (not isinstance(data, tuple)) and (not isinstance(data, list)):
             return data
 

--- a/python/paddle/distributed/fleet/meta_parallel/pipeline_parallel.py
+++ b/python/paddle/distributed/fleet/meta_parallel/pipeline_parallel.py
@@ -110,6 +110,10 @@ class FakeMicroDataset:
         assert self._is_first_stage or self._is_last_stage
         micro_batch_data = self._load_micro_batch(self._index)
         self._index += 1
+
+        if self._index >= self._acc_steps:
+            self._data = None  # clearup
+
         return micro_batch_data
 
     def _load_micro_batch(self, micro_step):
@@ -184,6 +188,15 @@ class FakeMicroDataset:
             "batch_size needs to be divisible by micro_batch_size. Currently, "
             f"batch_size = {batch_size}, micro_batch_size = {self._micro_batch_size}, accumulate_steps = {self._acc_steps}."
         )
+
+
+# A wrapper for pipeline dataser, to avoid GPU memory leaks.
+class PipelineDatasetPreprocessor:
+    def __init__(self, function):
+        self.function = function
+
+    def __call__(self):
+        return self.function()
 
 
 # Enum for specifying the pipeline parallel micro-step locations.
@@ -999,6 +1012,9 @@ class PipelineParallel(MetaParallelBase):
         """
         for backward compatibility, wrap data to Fake FakeMicroDataset if it is of type list or tuple
         """
+        if isinstance(data, PipelineDatasetPreprocessor):
+            data = data()
+
         if (not isinstance(data, tuple)) and (not isinstance(data, list)):
             return data
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Distributed Strategy

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Pass a local function to forward_backward_pipeline instead of the dataset itself. This prevents the dataset from being passed as a direct argument to forward_backward_pipeline, which would create additional reference counts that cannot be cleared, leading to GPU memory leaks.

pcard-76459

cp from https://github.com/PaddlePaddle/Paddle/pull/75446 https://github.com/PaddlePaddle/Paddle/pull/76212/