### PR TITLE
support dynamic quant for w4afp8 in deepep

### DIFF
--- a/paddle/fluid/distributed/collective/deep_ep/deep_ep.cpp
+++ b/paddle/fluid/distributed/collective/deep_ep/deep_ep.cpp
@@ -1769,7 +1769,8 @@ Buffer::low_latency_dispatch(
 
   auto num_tokens = static_cast<int>(x.size(0)),
        hidden = static_cast<int>(x.size(1));
-  auto num_scales = num_per_channel == -1 ? 1 : hidden / 128, num_topk = static_cast<int>(topk_idx.size(1));
+  auto num_scales = num_per_channel == -1 ? 1 : hidden / 128,
+       num_topk = static_cast<int>(topk_idx.size(1));
   int num_local_experts = num_experts / num_ranks;
 
   // Buffer control

--- a/paddle/fluid/distributed/collective/deep_ep/deep_ep.cpp
+++ b/paddle/fluid/distributed/collective/deep_ep/deep_ep.cpp
@@ -1752,7 +1752,8 @@ Buffer::low_latency_dispatch(
     int num_experts,
     bool use_fp8,
     bool async,
-    bool return_recv_hook) {
+    bool return_recv_hook,
+    int num_per_channel) {
   EP_HOST_ASSERT(low_latency_mode);
 
   // Tensor checks
@@ -1768,7 +1769,7 @@ Buffer::low_latency_dispatch(
 
   auto num_tokens = static_cast<int>(x.size(0)),
        hidden = static_cast<int>(x.size(1));
-  auto num_scales = hidden / 128, num_topk = static_cast<int>(topk_idx.size(1));
+  auto num_scales = num_per_channel == -1 ? 1 : hidden / 128, num_topk = static_cast<int>(topk_idx.size(1));
   int num_local_experts = num_experts / num_ranks;
 
   // Buffer control
@@ -1872,7 +1873,8 @@ Buffer::low_latency_dispatch(
                            use_fp8,
                            workspace,
                            launch_stream,
-                           phases);
+                           phases,
+                           num_per_channel);
   };
   launcher(return_recv_hook
                ? LOW_LATENCY_SEND_PHASE
@@ -2976,7 +2978,8 @@ Buffer::low_latency_dispatch_api(
     int num_experts,
     bool use_fp8,
     bool async,
-    bool return_recv_hook) {
+    bool return_recv_hook,
+    int num_per_channel) {
 #ifdef PADDLE_WITH_NVSHMEM
   const auto& x_ = ConvertPaddleTensorToDetailTensor(x);
   const auto& topk_idx_ = ConvertPaddleTensorToDetailTensor(topk_idx);
@@ -2994,7 +2997,8 @@ Buffer::low_latency_dispatch_api(
                                   num_experts,
                                   use_fp8,
                                   async,
-                                  return_recv_hook);
+                                  return_recv_hook,
+                                  num_per_channel);
 
   auto packed_recv_x_ = ConvertDetailTensorToPaddleTensor(std::get<0>(res));
 

--- a/paddle/fluid/distributed/collective/deep_ep/deep_ep.hpp
+++ b/paddle/fluid/distributed/collective/deep_ep/deep_ep.hpp
@@ -279,7 +279,8 @@ struct Buffer {
       int num_experts,
       bool use_fp8,
       bool async,
-      bool return_recv_hook);
+      bool return_recv_hook,
+      int num_per_channel);
 
   std::tuple<deep_ep::detail::Tensor,
              std::optional<EventHandle>,
@@ -452,7 +453,8 @@ struct Buffer {
       int num_experts,
       bool use_fp8,
       bool async,
-      bool return_recv_hook);
+      bool return_recv_hook,
+      int num_per_channel);
 
   std::tuple<paddle::Tensor,
              std::optional<EventHandle>,

--- a/paddle/fluid/distributed/collective/deep_ep/kernels/api.cuh
+++ b/paddle/fluid/distributed/collective/deep_ep/kernels/api.cuh
@@ -318,7 +318,8 @@ void dispatch(void* packed_recv_x,
               bool use_fp8,
               void* workspace,
               cudaStream_t stream,
-              int phases);
+              int phases,
+              int num_per_channel);
 
 void combine(void* combined_x,
              void* rdma_recv_x,

--- a/paddle/fluid/distributed/collective/deep_ep/kernels/internode_ll.cu
+++ b/paddle/fluid/distributed/collective/deep_ep/kernels/internode_ll.cu
@@ -78,7 +78,11 @@ void clean_low_latency_buffer(int* clean_0,
                 num_clean_int_1);
 }
 
-template <bool kUseFP8, int kNumWarpGroups, int kNumWarpsPerGroup, int kHidden, int kNumPerChannels = 128>
+template <bool kUseFP8,
+          int kNumWarpGroups,
+          int kNumWarpsPerGroup,
+          int kHidden,
+          int kNumPerChannels = 128>
 __global__ __launch_bounds__(
     kNumWarpGroups* kNumWarpsPerGroup * 32,
     1) void dispatch(void* packed_recv_x,
@@ -130,8 +134,9 @@ __global__ __launch_bounds__(
   // NOTES: currently we have 3 reserved int fields for future use
   using vec_t = typename std::conditional<kUseFP8, int2, int4>::type;
   size_t num_bytes_per_msg =
-      sizeof(int4) + (kUseFP8 ? (kHidden + (num_scales + 3) / 4 * 4 * sizeof(float))
-                              : (kHidden * sizeof(nv_bfloat16)));
+      sizeof(int4) + (kUseFP8
+                          ? (kHidden + (num_scales + 3) / 4 * 4 * sizeof(float))
+                          : (kHidden * sizeof(nv_bfloat16)));
   if (use_expertwise_scale) num_bytes_per_msg = sizeof(int4) + kHidden;
 
   const size_t num_int4_per_msg = num_bytes_per_msg / sizeof(int4);
@@ -148,7 +153,7 @@ __global__ __launch_bounds__(
   // 2. The last warp for reading `topk_idx` and count for per-expert
   // information
   if (warp_id < num_warps - 1) {
-    constexpr int kNumElemsPerRead = sizeof(int4) / sizeof(nv_bfloat16); // 8
+    constexpr int kNumElemsPerRead = sizeof(int4) / sizeof(nv_bfloat16);  // 8
     EP_DEVICE_ASSERT(kHidden % kNumElemsPerRead == 0);
     EP_STATIC_ASSERT(kNumElemsPerRead * 32 % kNumPerChannels == 0,
                      "Invalid vectorization");
@@ -242,29 +247,30 @@ __global__ __launch_bounds__(
         }
       }
 
-
-// FP8 cast
-      if (kUseFP8 && !use_expertwise_scale && kNumPerChannels == -1) { // fp8 per-token dynamic quant
+      // FP8 cast
+      if (kUseFP8 && !use_expertwise_scale &&
+          kNumPerChannels == -1) {  // fp8 per-token dynamic quant
         __shared__ float amax_cache[num_warps - 1];
         float amax = kFP8Margin, scale, scale_inv;
-        #pragma unroll
+#pragma unroll
         for (int i = thread_id; i < hidden_bf16_int4; i += num_threads) {
           auto int4_value = __ldg(x_int4 + i);
           auto bf16_values = reinterpret_cast<nv_bfloat16*>(&int4_value);
           float fp32_values[kNumElemsPerRead];
-    #pragma unroll
+#pragma unroll
           for (int j = 0; j < kNumElemsPerRead; ++j) {
             fp32_values[j] = static_cast<float>(bf16_values[j]);
             amax = fmaxf(amax, fabsf(fp32_values[j]));
           }
-          #pragma unroll
+#pragma unroll
           for (int j = 0; j < kNumElemsPerRead; ++j) {
             fp32_values[j] = static_cast<float>(bf16_values[j]);
-            amax = fmaxf(amax, fabsf(fp32_values[j]));              
+            amax = fmaxf(amax, fabsf(fp32_values[j]));
           }
           // Reduce amax and scale
-          EP_STATIC_ASSERT((kNumPerChannels == -1) || (kNumElemsPerRead * 32 / kNumPerChannels == 2),
-                          "Invalid vectorization");
+          EP_STATIC_ASSERT((kNumPerChannels == -1) ||
+                               (kNumElemsPerRead * 32 / kNumPerChannels == 2),
+                           "Invalid vectorization");
           amax = warp_reduce_max(amax);
           if (lane_id == 0) {
             amax_cache[warp_id] = amax;
@@ -272,7 +278,8 @@ __global__ __launch_bounds__(
         }
         asm volatile("bar.sync 1, %0;" ::"r"(num_threads));
         if (warp_id == 0) {
-          float thread_amax = lane_id < (num_warps - 1) ? amax_cache[lane_id] : 0.0f;
+          float thread_amax =
+              lane_id < (num_warps - 1) ? amax_cache[lane_id] : 0.0f;
           thread_amax = warp_reduce_max(thread_amax);
           if (lane_id == 0) {
             amax_cache[0] = thread_amax;
@@ -297,19 +304,19 @@ __global__ __launch_bounds__(
           vec_t int2_value;
           auto fp8x2_values =
               reinterpret_cast<__nv_fp8x2_storage_t*>(&int2_value);
-  #pragma unroll
+#pragma unroll
           for (int j = 0; j < kNumElemsPerRead; j += 2) {
             float2 fp32x2 = {fp32_values[j] * scale,
-                            fp32_values[j + 1] * scale};
+                             fp32_values[j + 1] * scale};
             fp8x2_values[j / 2] =
                 __nv_cvt_float2_to_fp8x2(fp32x2, __NV_SATFINITE, __NV_E4M3);
           }
-          rdma_x_vec[i] = int2_value;          
+          rdma_x_vec[i] = int2_value;
         }
-      } else { // groupwise fp8
-  #pragma unroll
+      } else {  // groupwise fp8
+#pragma unroll
         for (int i = thread_id; i < hidden_bf16_int4 * run_deepep_loop;
-            i += num_threads) {
+             i += num_threads) {
           // Read
           auto int4_value = __ldg(x_int4 + i);
 
@@ -318,15 +325,16 @@ __global__ __launch_bounds__(
             auto bf16_values = reinterpret_cast<nv_bfloat16*>(&int4_value);
             float fp32_values[kNumElemsPerRead];
             float amax = kFP8Margin, scale, scale_inv;
-  #pragma unroll
+#pragma unroll
             for (int j = 0; j < kNumElemsPerRead; ++j) {
               fp32_values[j] = static_cast<float>(bf16_values[j]);
               amax = fmaxf(amax, fabsf(fp32_values[j]));
             }
 
             // Reduce amax and scale
-            EP_STATIC_ASSERT((kNumPerChannels == -1) || (kNumElemsPerRead * 32 / kNumPerChannels == 2),
-                            "Invalid vectorization");
+            EP_STATIC_ASSERT((kNumPerChannels == -1) ||
+                                 (kNumElemsPerRead * 32 / kNumPerChannels == 2),
+                             "Invalid vectorization");
             amax = half_warp_reduce_max(amax), scale = kFP8Amax / amax,
             scale_inv = amax * kFP8AmaxInv;
             if (lane_id == 0 || lane_id == 16)
@@ -336,10 +344,10 @@ __global__ __launch_bounds__(
             vec_t int2_value;
             auto fp8x2_values =
                 reinterpret_cast<__nv_fp8x2_storage_t*>(&int2_value);
-  #pragma unroll
+#pragma unroll
             for (int j = 0; j < kNumElemsPerRead; j += 2) {
               float2 fp32x2 = {fp32_values[j] * scale,
-                              fp32_values[j + 1] * scale};
+                               fp32_values[j + 1] * scale};
               fp8x2_values[j / 2] =
                   __nv_cvt_float2_to_fp8x2(fp32x2, __NV_SATFINITE, __NV_E4M3);
             }
@@ -348,7 +356,7 @@ __global__ __launch_bounds__(
             // Reinterpret-cast is for C++14 compatibility
             rdma_x_vec[i] = *reinterpret_cast<vec_t*>(&int4_value);
           }
-        }        
+        }
       }
 
       asm volatile("bar.sync 1, %0;" ::"r"(num_threads));
@@ -598,7 +606,7 @@ LOW_LATENCY_DISPATCH_RECV:
             reinterpret_cast<uint8_t*>(src_data) + hidden_bytes);
         const auto dst_scales =
             reinterpret_cast<float*>(recv_x_scales + recv_token_begin_idx + i);
-        const auto scale_stride = num_ranks * num_max_dispatch_tokens_per_rank;        
+        const auto scale_stride = num_ranks * num_max_dispatch_tokens_per_rank;
         if constexpr (kNumPerChannels == -1) {
           if (lane_id == 0) {
             auto scale = ld_nc_global(src_scales);
@@ -608,13 +616,13 @@ LOW_LATENCY_DISPATCH_RECV:
           auto scale_0 =
               lane_id < num_scales ? ld_nc_global(src_scales + lane_id) : 0;
           auto scale_1 = (lane_id + 32) < num_scales
-                            ? ld_nc_global(src_scales + lane_id + 32)
-                            : 0;
+                             ? ld_nc_global(src_scales + lane_id + 32)
+                             : 0;
           lane_id < num_scales ? dst_scales[lane_id * scale_stride] = scale_0
-                              : 0.0f;
+                               : 0.0f;
           (lane_id + 32) < num_scales
               ? dst_scales[(lane_id + 32) * scale_stride] = scale_1
-              : 0.0f;          
+              : 0.0f;
         }
       }
     }
@@ -665,44 +673,50 @@ void dispatch(void* packed_recv_x,
       hidden,
       kHidden,
       {DISPATCH_NUM_PER_CHANNEL(
-        num_per_channel, 
-        kNumPerChannels, 
-        {DISPATCH_NUM_WARP_GROUPS(num_warp_groups, kNumWarpGroups, { // 1
-        constexpr int kNumWarpsPerGroup = NUM_WARPS / kNumWarpGroups; // 32
-        EP_STATIC_ASSERT(kNumMaxTopK + 1 <= kNumWarpGroups * kNumWarpsPerGroup,
-                         "Too many top-k selections");
-        auto dispatch_func =
-            use_fp8
-                ? dispatch<true, kNumWarpGroups, kNumWarpsPerGroup, kHidden, kNumPerChannels>
-                : dispatch<false, kNumWarpGroups, kNumWarpsPerGroup, kHidden, kNumPerChannels>;
-        SETUP_LAUNCH_CONFIG(
-            num_sms, kNumWarpGroups * kNumWarpsPerGroup * 32, stream);
-        LAUNCH_KERNEL(&cfg,
-                      dispatch_func,
-                      packed_recv_x,
-                      packed_recv_x_scales,
-                      packed_recv_src_info,
-                      packed_recv_layout_range,
-                      packed_recv_count,
-                      rdma_recv_x,
-                      rdma_recv_count,
-                      rdma_x,
-                      x,
-                      topk_idx,
-                      expertwise_scale,
-                      atomic_counter_per_expert,
-                      atomic_finish_counter_per_expert,
-                      next_clean,
-                      num_next_clean_int,
-                      num_tokens,
-                      num_max_dispatch_tokens_per_rank,
-                      num_topk,
-                      num_experts,
-                      rank,
-                      num_ranks,
-                      phases);
-      })})}
-)
+          num_per_channel,
+          kNumPerChannels,
+          {DISPATCH_NUM_WARP_GROUPS(num_warp_groups, kNumWarpGroups, {     // 1
+            constexpr int kNumWarpsPerGroup = NUM_WARPS / kNumWarpGroups;  // 32
+            EP_STATIC_ASSERT(
+                kNumMaxTopK + 1 <= kNumWarpGroups * kNumWarpsPerGroup,
+                "Too many top-k selections");
+            auto dispatch_func = use_fp8 ? dispatch<true,
+                                                    kNumWarpGroups,
+                                                    kNumWarpsPerGroup,
+                                                    kHidden,
+                                                    kNumPerChannels>
+                                         : dispatch<false,
+                                                    kNumWarpGroups,
+                                                    kNumWarpsPerGroup,
+                                                    kHidden,
+                                                    kNumPerChannels>;
+            SETUP_LAUNCH_CONFIG(
+                num_sms, kNumWarpGroups * kNumWarpsPerGroup * 32, stream);
+            LAUNCH_KERNEL(&cfg,
+                          dispatch_func,
+                          packed_recv_x,
+                          packed_recv_x_scales,
+                          packed_recv_src_info,
+                          packed_recv_layout_range,
+                          packed_recv_count,
+                          rdma_recv_x,
+                          rdma_recv_count,
+                          rdma_x,
+                          x,
+                          topk_idx,
+                          expertwise_scale,
+                          atomic_counter_per_expert,
+                          atomic_finish_counter_per_expert,
+                          next_clean,
+                          num_next_clean_int,
+                          num_tokens,
+                          num_max_dispatch_tokens_per_rank,
+                          num_topk,
+                          num_experts,
+                          rank,
+                          num_ranks,
+                          phases);
+          })})})
 }
 
 template <int kNumWarpGroups,

--- a/paddle/fluid/distributed/collective/deep_ep/kernels/internode_ll.cu
+++ b/paddle/fluid/distributed/collective/deep_ep/kernels/internode_ll.cu
@@ -78,7 +78,7 @@ void clean_low_latency_buffer(int* clean_0,
                 num_clean_int_1);
 }
 
-template <bool kUseFP8, int kNumWarpGroups, int kNumWarpsPerGroup, int kHidden>
+template <bool kUseFP8, int kNumWarpGroups, int kNumWarpsPerGroup, int kHidden, int kNumPerChannels = 128>
 __global__ __launch_bounds__(
     kNumWarpGroups* kNumWarpsPerGroup * 32,
     1) void dispatch(void* packed_recv_x,
@@ -116,10 +116,9 @@ __global__ __launch_bounds__(
   const bool use_expertwise_scale = expertwise_scale;
 
   // FP8 staffs
-  constexpr int kNumPerChannels = 128;
   constexpr float kFP8Margin = 1e-4, kFP8Amax = 448,
                   kFP8AmaxInv = 1.0f / 448.0f;
-  const int num_scales = kHidden / kNumPerChannels;
+  const int num_scales = kNumPerChannels == -1 ? 1 : kHidden / kNumPerChannels;
   size_t hidden_bytes =
       kHidden * (kUseFP8 ? sizeof(__nv_fp8_storage_t) : sizeof(nv_bfloat16));
 
@@ -131,7 +130,7 @@ __global__ __launch_bounds__(
   // NOTES: currently we have 3 reserved int fields for future use
   using vec_t = typename std::conditional<kUseFP8, int2, int4>::type;
   size_t num_bytes_per_msg =
-      sizeof(int4) + (kUseFP8 ? (kHidden + num_scales * sizeof(float))
+      sizeof(int4) + (kUseFP8 ? (kHidden + (num_scales + 3) / 4 * 4 * sizeof(float))
                               : (kHidden * sizeof(nv_bfloat16)));
   if (use_expertwise_scale) num_bytes_per_msg = sizeof(int4) + kHidden;
 
@@ -149,7 +148,7 @@ __global__ __launch_bounds__(
   // 2. The last warp for reading `topk_idx` and count for per-expert
   // information
   if (warp_id < num_warps - 1) {
-    constexpr int kNumElemsPerRead = sizeof(int4) / sizeof(nv_bfloat16);
+    constexpr int kNumElemsPerRead = sizeof(int4) / sizeof(nv_bfloat16); // 8
     EP_DEVICE_ASSERT(kHidden % kNumElemsPerRead == 0);
     EP_STATIC_ASSERT(kNumElemsPerRead * 32 % kNumPerChannels == 0,
                      "Invalid vectorization");
@@ -190,11 +189,11 @@ __global__ __launch_bounds__(
       // Note(zkk)
       // create a run_deepep_loop, so I need not modify Deepep's code any more.
       int run_deepep_loop = 1;
-      if (use_expertwise_scale && kUseFP8) {  // w4afp8
+      if (use_expertwise_scale && kUseFP8) {  // w4afp8 static quant
         run_deepep_loop = 0;
         for (int ii = 0; ii < num_topk; ii++) {
-          int tmp_id = topk_idx[ii + token_idx * num_topk];
-          float scale = expertwise_scale[tmp_id];
+          int64_t tmp_id = __ldg(&topk_idx[ii + token_idx * num_topk]);
+          float scale = __ldg(&expertwise_scale[tmp_id]);
           for (int i = thread_id; i < hidden_bf16_int4; i += num_threads) {
             auto int4_value = __ldg(x_int4 + i);
             auto bf16_values = reinterpret_cast<nv_bfloat16*>(&int4_value);
@@ -215,7 +214,7 @@ __global__ __launch_bounds__(
                            sizeof(int4) + i * sizeof(res_vec));
           }
         }
-      } else if (use_expertwise_scale) {  // w4aint8
+      } else if (use_expertwise_scale) {  // w4aint8 static quant
         run_deepep_loop = 0;
         for (int ii = 0; ii < num_topk; ii++) {
           int tmp_id = topk_idx[ii + token_idx * num_topk];
@@ -243,49 +242,115 @@ __global__ __launch_bounds__(
         }
       }
 
-// FP8 cast
-#pragma unroll
-      for (int i = thread_id; i < hidden_bf16_int4 * run_deepep_loop;
-           i += num_threads) {
-        // Read
-        auto int4_value = __ldg(x_int4 + i);
 
-        if (kUseFP8 && !use_expertwise_scale) {
-          // Calculate local amax
+// FP8 cast
+      if (kUseFP8 && !use_expertwise_scale && kNumPerChannels == -1) { // fp8 per-token dynamic quant
+        __shared__ float amax_cache[num_warps - 1];
+        float amax = kFP8Margin, scale, scale_inv;
+        #pragma unroll
+        for (int i = thread_id; i < hidden_bf16_int4; i += num_threads) {
+          auto int4_value = __ldg(x_int4 + i);
           auto bf16_values = reinterpret_cast<nv_bfloat16*>(&int4_value);
           float fp32_values[kNumElemsPerRead];
-          float amax = kFP8Margin, scale, scale_inv;
-#pragma unroll
+    #pragma unroll
           for (int j = 0; j < kNumElemsPerRead; ++j) {
             fp32_values[j] = static_cast<float>(bf16_values[j]);
             amax = fmaxf(amax, fabsf(fp32_values[j]));
           }
-
+          #pragma unroll
+          for (int j = 0; j < kNumElemsPerRead; ++j) {
+            fp32_values[j] = static_cast<float>(bf16_values[j]);
+            amax = fmaxf(amax, fabsf(fp32_values[j]));              
+          }
           // Reduce amax and scale
-          EP_STATIC_ASSERT(kNumElemsPerRead * 32 / kNumPerChannels == 2,
-                           "Invalid vectorization");
-          amax = half_warp_reduce_max(amax), scale = kFP8Amax / amax,
-          scale_inv = amax * kFP8AmaxInv;
-          if (lane_id == 0 || lane_id == 16)
-            rdma_x_scales[i * kNumElemsPerRead / 128] = scale_inv;
+          EP_STATIC_ASSERT((kNumPerChannels == -1) || (kNumElemsPerRead * 32 / kNumPerChannels == 2),
+                          "Invalid vectorization");
+          amax = warp_reduce_max(amax);
+          if (lane_id == 0) {
+            amax_cache[warp_id] = amax;
+          }
+        }
+        asm volatile("bar.sync 1, %0;" ::"r"(num_threads));
+        if (warp_id == 0) {
+          float thread_amax = lane_id < (num_warps - 1) ? amax_cache[lane_id] : 0.0f;
+          thread_amax = warp_reduce_max(thread_amax);
+          if (lane_id == 0) {
+            amax_cache[0] = thread_amax;
+          }
+        }
+        asm volatile("bar.sync 1, %0;" ::"r"(num_threads));
+        amax = amax_cache[0];
+        scale = 440.f / amax;
+        // scale_inv = amax * kFP8AmaxInv;
+        if (threadIdx.x == 0) {
+          rdma_x_scales[0] = amax;
+        }
 
+        for (int i = thread_id; i < hidden_bf16_int4; i += num_threads) {
+          auto int4_value = __ldg(x_int4 + i);
+          auto bf16_values = reinterpret_cast<nv_bfloat16*>(&int4_value);
+          float fp32_values[kNumElemsPerRead];
+          for (int j = 0; j < kNumElemsPerRead; ++j) {
+            fp32_values[j] = static_cast<float>(bf16_values[j]);
+          }
           // Cast into send buffer
           vec_t int2_value;
           auto fp8x2_values =
               reinterpret_cast<__nv_fp8x2_storage_t*>(&int2_value);
-#pragma unroll
+  #pragma unroll
           for (int j = 0; j < kNumElemsPerRead; j += 2) {
             float2 fp32x2 = {fp32_values[j] * scale,
-                             fp32_values[j + 1] * scale};
+                            fp32_values[j + 1] * scale};
             fp8x2_values[j / 2] =
                 __nv_cvt_float2_to_fp8x2(fp32x2, __NV_SATFINITE, __NV_E4M3);
           }
-          rdma_x_vec[i] = int2_value;
-        } else {
-          // Reinterpret-cast is for C++14 compatibility
-          rdma_x_vec[i] = *reinterpret_cast<vec_t*>(&int4_value);
+          rdma_x_vec[i] = int2_value;          
         }
+      } else { // groupwise fp8
+  #pragma unroll
+        for (int i = thread_id; i < hidden_bf16_int4 * run_deepep_loop;
+            i += num_threads) {
+          // Read
+          auto int4_value = __ldg(x_int4 + i);
+
+          if (kUseFP8 && !use_expertwise_scale) {
+            // Calculate local amax
+            auto bf16_values = reinterpret_cast<nv_bfloat16*>(&int4_value);
+            float fp32_values[kNumElemsPerRead];
+            float amax = kFP8Margin, scale, scale_inv;
+  #pragma unroll
+            for (int j = 0; j < kNumElemsPerRead; ++j) {
+              fp32_values[j] = static_cast<float>(bf16_values[j]);
+              amax = fmaxf(amax, fabsf(fp32_values[j]));
+            }
+
+            // Reduce amax and scale
+            EP_STATIC_ASSERT((kNumPerChannels == -1) || (kNumElemsPerRead * 32 / kNumPerChannels == 2),
+                            "Invalid vectorization");
+            amax = half_warp_reduce_max(amax), scale = kFP8Amax / amax,
+            scale_inv = amax * kFP8AmaxInv;
+            if (lane_id == 0 || lane_id == 16)
+              rdma_x_scales[i * kNumElemsPerRead / 128] = scale_inv;
+
+            // Cast into send buffer
+            vec_t int2_value;
+            auto fp8x2_values =
+                reinterpret_cast<__nv_fp8x2_storage_t*>(&int2_value);
+  #pragma unroll
+            for (int j = 0; j < kNumElemsPerRead; j += 2) {
+              float2 fp32x2 = {fp32_values[j] * scale,
+                              fp32_values[j + 1] * scale};
+              fp8x2_values[j / 2] =
+                  __nv_cvt_float2_to_fp8x2(fp32x2, __NV_SATFINITE, __NV_E4M3);
+            }
+            rdma_x_vec[i] = int2_value;
+          } else {
+            // Reinterpret-cast is for C++14 compatibility
+            rdma_x_vec[i] = *reinterpret_cast<vec_t*>(&int4_value);
+          }
+        }        
       }
+
       asm volatile("bar.sync 1, %0;" ::"r"(num_threads));
 
       // Issue IBGDA sends
@@ -533,17 +598,24 @@ LOW_LATENCY_DISPATCH_RECV:
             reinterpret_cast<uint8_t*>(src_data) + hidden_bytes);
         const auto dst_scales =
             reinterpret_cast<float*>(recv_x_scales + recv_token_begin_idx + i);
-        const auto scale_stride = num_ranks * num_max_dispatch_tokens_per_rank;
-        auto scale_0 =
-            lane_id < num_scales ? ld_nc_global(src_scales + lane_id) : 0;
-        auto scale_1 = (lane_id + 32) < num_scales
-                           ? ld_nc_global(src_scales + lane_id + 32)
-                           : 0;
-        lane_id < num_scales ? dst_scales[lane_id * scale_stride] = scale_0
-                             : 0.0f;
-        (lane_id + 32) < num_scales
-            ? dst_scales[(lane_id + 32) * scale_stride] = scale_1
-            : 0.0f;
+        const auto scale_stride = num_ranks * num_max_dispatch_tokens_per_rank;        
+        if constexpr (kNumPerChannels == -1) {
+          if (lane_id == 0) {
+            auto scale = ld_nc_global(src_scales);
+            dst_scales[0] = scale;
+          }
+        } else {
+          auto scale_0 =
+              lane_id < num_scales ? ld_nc_global(src_scales + lane_id) : 0;
+          auto scale_1 = (lane_id + 32) < num_scales
+                            ? ld_nc_global(src_scales + lane_id + 32)
+                            : 0;
+          lane_id < num_scales ? dst_scales[lane_id * scale_stride] = scale_0
+                              : 0.0f;
+          (lane_id + 32) < num_scales
+              ? dst_scales[(lane_id + 32) * scale_stride] = scale_1
+              : 0.0f;          
+        }
       }
     }
   }
@@ -572,7 +644,8 @@ void dispatch(void* packed_recv_x,
               bool use_fp8,
               void* workspace,
               cudaStream_t stream,
-              int phases) {
+              int phases,
+              int num_per_channel) {
   constexpr int kNumMaxTopK = 9;
   constexpr int NUM_WARPS = 32;
   const int dev_id = 0;
@@ -591,14 +664,17 @@ void dispatch(void* packed_recv_x,
   DISPATCH_HIDDEN_SIZE(
       hidden,
       kHidden,
-      {DISPATCH_NUM_WARP_GROUPS(num_warp_groups, kNumWarpGroups, {
-        constexpr int kNumWarpsPerGroup = NUM_WARPS / kNumWarpGroups;
+      {DISPATCH_NUM_PER_CHANNEL(
+        num_per_channel, 
+        kNumPerChannels, 
+        {DISPATCH_NUM_WARP_GROUPS(num_warp_groups, kNumWarpGroups, { // 1
+        constexpr int kNumWarpsPerGroup = NUM_WARPS / kNumWarpGroups; // 32
         EP_STATIC_ASSERT(kNumMaxTopK + 1 <= kNumWarpGroups * kNumWarpsPerGroup,
                          "Too many top-k selections");
         auto dispatch_func =
             use_fp8
-                ? dispatch<true, kNumWarpGroups, kNumWarpsPerGroup, kHidden>
-                : dispatch<false, kNumWarpGroups, kNumWarpsPerGroup, kHidden>;
+                ? dispatch<true, kNumWarpGroups, kNumWarpsPerGroup, kHidden, kNumPerChannels>
+                : dispatch<false, kNumWarpGroups, kNumWarpsPerGroup, kHidden, kNumPerChannels>;
         SETUP_LAUNCH_CONFIG(
             num_sms, kNumWarpGroups * kNumWarpsPerGroup * 32, stream);
         LAUNCH_KERNEL(&cfg,
@@ -625,7 +701,8 @@ void dispatch(void* packed_recv_x,
                       rank,
                       num_ranks,
                       phases);
-      })})
+      })})}
+)
 }
 
 template <int kNumWarpGroups,

--- a/paddle/fluid/distributed/collective/deep_ep/kernels/launch.cuh
+++ b/paddle/fluid/distributed/collective/deep_ep/kernels/launch.cuh
@@ -136,6 +136,17 @@
     EP_HOST_ASSERT(false && "Unsupported hidden"); \
   }
 
+#define DISPATCH_NUM_PER_CHANNEL(num_per_channel, kNumPerChannels, ...) \
+  if (num_per_channel == -1) {                                          \
+    constexpr int kNumPerChannels = -1;                                 \
+    __VA_ARGS__                                                         \
+  } else if (num_per_channel == 128) {                                  \
+    constexpr int kNumPerChannels = 128;                                \
+    __VA_ARGS__                                                         \
+  } else {                                                              \
+    EP_HOST_ASSERT(false && "Unsupported num_per_channel");             \
+  }
+
 #define DISPATCH_NUM_TOPK(num_topk, kTopk, ...)      \
   if (num_topk == 8) {                               \
     constexpr int kTopk = 8;                         \

--- a/paddle/fluid/distributed/collective/deep_ep/kernels/utils.cuh
+++ b/paddle/fluid/distributed/collective/deep_ep/kernels/utils.cuh
@@ -476,6 +476,15 @@ __forceinline__ __device__ int warp_reduce_sum(int value) {
   return value;
 }
 
+__forceinline__ __device__ float warp_reduce_max(float value) {
+  value = max(value, __shfl_xor_sync(0xffffffff, value, 8));
+  value = max(value, __shfl_xor_sync(0xffffffff, value, 8));
+  value = max(value, __shfl_xor_sync(0xffffffff, value, 4));
+  value = max(value, __shfl_xor_sync(0xffffffff, value, 2));
+  value = max(value, __shfl_xor_sync(0xffffffff, value, 1));
+  return value;
+}
+
 __forceinline__ __device__ float half_warp_reduce_max(float value) {
   auto mask = __activemask();
   // The mask be in `{0xffffffff, 0xffff}`

--- a/python/paddle/distributed/communication/deep_ep/buffer.py
+++ b/python/paddle/distributed/communication/deep_ep/buffer.py
@@ -879,6 +879,7 @@ class Buffer:
         use_fp8: bool = True,
         async_finish: bool = False,
         return_recv_hook: bool = False,
+        num_per_channel: int = 128,
     ) -> tuple[
         tuple[paddle.Tensor, paddle.Tensor],
         paddle.Tensor,
@@ -906,6 +907,8 @@ class Buffer:
             return_recv_hook: return a receiving hook if set. If set, the kernel will just do the RDMA request issues,
                 but **without actually receiving the data**. You must call the received hook to make sure the data's arrival.
                 If you not set this flag, the kernel will ensure the data's arrival.
+            num_per_channel: the number of tokens per channel used in dynamic quantization to fp8. 
+                Now we support 128 for per group quantization and -1 for per token quantization.
 
         Returns:
             recv_x: a tuple with received tokens for each expert. The first element is a `paddle.Tensor` shaped as
@@ -938,6 +941,7 @@ class Buffer:
             use_fp8,
             async_finish,
             return_recv_hook,
+            num_per_channel
         )
         handle = (
             packed_recv_src_info,

--- a/python/paddle/distributed/communication/deep_ep/buffer.py
+++ b/python/paddle/distributed/communication/deep_ep/buffer.py
@@ -907,7 +907,7 @@ class Buffer:
             return_recv_hook: return a receiving hook if set. If set, the kernel will just do the RDMA request issues,
                 but **without actually receiving the data**. You must call the received hook to make sure the data's arrival.
                 If you not set this flag, the kernel will ensure the data's arrival.
-            num_per_channel: the number of tokens per channel used in dynamic quantization to fp8. 
+            num_per_channel: the number of tokens per channel used in dynamic quantization to fp8.
                 Now we support 128 for per group quantization and -1 for per token quantization.
 
         Returns:
@@ -941,7 +941,7 @@ class Buffer:
             use_fp8,
             async_finish,
             return_recv_hook,
-            num_per_channel
+            num_per_channel,
         )
         handle = (
             packed_recv_src_info,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
card-71500
支持W4AFP8推理：在EP并行中将w4afp8的FFN1动态量化融合在deep ep low_latency_dispatch中，量化粒度为per-token