### PR TITLE
[Docs] Fix `auto_cast` path in docstring

### DIFF
--- a/python/paddle/amp/auto_cast.py
+++ b/python/paddle/amp/auto_cast.py
@@ -1096,14 +1096,14 @@ def autocast(
             >>> conv2d = paddle.nn.Conv2D(3, 2, 3, bias_attr=False)
             >>> data = paddle.rand([10, 3, 32, 32])
 
-            >>> with paddle.device.amp.auto_cast():
+            >>> with paddle.amp.auto_cast():
             ...     conv = conv2d(data)
             ...     print(conv.dtype)
             >>> # doctest: +SKIP("This has diff in xdoctest env")
             paddle.float16
             >>> # doctest: -SKIP
 
-            >>> with paddle.device.amp.auto_cast(enable=False):
+            >>> with paddle.amp.auto_cast(enable=False):
             ...     conv = conv2d(data)
             ...     print(conv.dtype)
             >>> # doctest: +SKIP("This has diff in xdoctest env")


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Docs


### Description
**Fix:** This PR fixes the CI `AttributeError` caused by the refactoring of AMP API paths. After the AMP module restructuring, the correct entry became `paddle.amp.autocast()`.
<img width="1368" height="675" alt="image" src="https://github.com/user-attachments/assets/50b9b8dc-4871-4271-90e2-b8df5bf8cb65" />

**Bug Reproduction**
**paddle.device.amp.auto_cast:**
<img width="1066" height="412" alt="image" src="https://github.com/user-attachments/assets/d15954db-b82e-42ba-bd2d-3d58809361c2" />

**paddle.amp.auto_cast:**
<img width="1037" height="329" alt="image" src="https://github.com/user-attachments/assets/e0e28930-993b-495f-b258-c29392a7ced5" />
