### PR TITLE
[Cherry-pick Fleety_12] Fix int32 overflow issues for large tensor support in paddle/phi/kernels/impl(#76107)

### DIFF
--- a/paddle/phi/kernels/impl/accuracy_check_kernel_impl.h
+++ b/paddle/phi/kernels/impl/accuracy_check_kernel_impl.h
@@ -143,12 +143,12 @@ __global__ void AccuracyCheckCUDAKernel(const T* in_data,
                                         const double rtol,
                                         const double atol,
                                         bool equal_nan,
-                                        int num,
+                                        int64_t num,
                                         bool* out_data) {
-  unsigned int idx = threadIdx.x + blockIdx.x * blockDim.x;
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   bool val;
   using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
-  for (int i = idx; i < num; i += blockDim.x * gridDim.x) {
+  for (int64_t i = idx; i < num; i += blockDim.x * gridDim.x) {
     const double a = static_cast<MPType>(in_data[i]);
     const double b = static_cast<MPType>(other_data[i]);
     if (isnan(a) || isnan(b)) {
@@ -173,11 +173,11 @@ __global__ void AccuracyCheckCUDAKernel<phi::complex64>(
     const double rtol,
     const double atol,
     bool equal_nan,
-    int num,
+    int64_t num,
     bool* out_data) {
-  unsigned int idx = threadIdx.x + blockIdx.x * blockDim.x;
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   bool val;
-  for (int i = idx; i < num; i += blockDim.x * gridDim.x) {
+  for (int64_t i = idx; i < num; i += blockDim.x * gridDim.x) {
     const phi::complex64 a = in_data[i];
     const phi::complex64 b = other_data[i];
     if (isnan(a) || isnan(b)) {
@@ -203,11 +203,11 @@ __global__ void AccuracyCheckCUDAKernel<phi::complex128>(
     const double rtol,
     const double atol,
     bool equal_nan,
-    int num,
+    int64_t num,
     bool* out_data) {
-  unsigned int idx = threadIdx.x + blockIdx.x * blockDim.x;
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   bool val;
-  for (int i = idx; i < num; i += blockDim.x * gridDim.x) {
+  for (int64_t i = idx; i < num; i += blockDim.x * gridDim.x) {
     const phi::complex128 a = in_data[i];
     const phi::complex128 b = other_data[i];
     if (isnan(a) || isnan(b)) {
@@ -236,12 +236,12 @@ struct AccuracyCheckFunctor<phi::GPUContext, T> {
                   const double atol,
                   bool equal_nan,
                   DenseTensor* output) {
-    int num = in.numel();
+    int64_t num = in.numel();
     const T* in_data = in.data<T>();
     const T* other_data = other.data<T>();
     bool* out_data = dev_ctx.template Alloc<bool>(output);
     int block = 1024;
-    int grid = (block - 1 + num) / block;
+    int64_t grid = (block - 1 + num) / block;
     grid = (grid > block) ? block : grid;
 #ifdef PADDLE_WITH_HIP
     hipMemset(out_data, true, num * sizeof(bool));

--- a/paddle/phi/kernels/impl/conv_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/conv_grad_kernel_impl.h
@@ -85,7 +85,7 @@ void ConvGradKernel(const Context& dev_ctx,
   UpdatePaddingAndDilation<int>(
       &paddings, &dilations, padding_algorithm, in_data_dims, strides, ksize);
 
-  const int batch_size = static_cast<int>(transformed_input.dims()[0]);
+  const int64_t batch_size = transformed_input.dims()[0];
 
   // filter_shape_vec: {k_o, k_i, k_h, k_w} or {k_o, k_i, k_d, k_h, k_w}
   std::vector<int64_t> filter_shape_vec(common::vectorize(filter.dims()));
@@ -125,8 +125,8 @@ void ConvGradKernel(const Context& dev_ctx,
 
   // convolution backward input operator:  gemm + col2im(or col2vol)
   // convolution backward weight operator: im2col(or vol2col) + gemm
-  int in_step = static_cast<int>(transformed_input.dims()[1]) / groups;
-  int out_step = static_cast<int>(transformed_output_grad.dims()[1]) / groups;
+  int64_t in_step = transformed_input.dims()[1] / groups;
+  int64_t out_step = transformed_output_grad.dims()[1] / groups;
 
   bool is_expand = IsExpand(filter_shape_vec, strides, paddings, dilations);
 
@@ -163,7 +163,7 @@ void ConvGradKernel(const Context& dev_ctx,
     phi::funcs::Col2ImFunctor<phi::funcs::ColFormat::kCFO, Context, T> col2im;
     phi::funcs::Col2VolFunctor<Context, T> col2vol;
 
-    for (int i = 0; i < batch_size; i++) {
+    for (int64_t i = 0; i < batch_size; i++) {
       DenseTensor out_grad_batch =
           transformed_output_grad.Slice(i, i + 1).Resize(output_matrix_shape);
       DenseTensor in_grad_batch =
@@ -327,7 +327,7 @@ void ConvGradGradKernel(const Context& dev_ctx,
   UpdatePaddingAndDilation(
       &paddings, &dilations, padding_algorithm, in_data_dims, strides, ksize);
 
-  const int batch_size = static_cast<int>(transformed_X.dims()[0]);
+  const int64_t batch_size = transformed_X.dims()[0];
   std::vector<int64_t> filter_shape_vec(common::vectorize(W.dims()));
   std::vector<int64_t> output_shape_vec(
       common::vectorize(transformed_dY.dims()));
@@ -354,8 +354,8 @@ void ConvGradGradKernel(const Context& dev_ctx,
       transformed_dY.dims()[1],
       transformed_dY.numel() /
           (transformed_dY.dims()[0] * transformed_dY.dims()[1])};
-  int in_step = static_cast<int>(transformed_X.dims()[1]) / groups;
-  int out_step = static_cast<int>(transformed_dY.dims()[1]) / groups;
+  int64_t in_step = transformed_X.dims()[1] / groups;
+  int64_t out_step = transformed_dY.dims()[1] / groups;
 
   bool is_expand = IsExpand(filter_shape_vec, strides, paddings, dilations);
   DenseTensor col;
@@ -394,7 +394,7 @@ void ConvGradGradKernel(const Context& dev_ctx,
     phi::funcs::Col2ImFunctor<phi::funcs::ColFormat::kCFO, Context, T> col2im;
     phi::funcs::Col2VolFunctor<Context, T> col2vol;
 
-    for (int i = 0; i < batch_size; i++) {
+    for (int64_t i = 0; i < batch_size; i++) {
       DenseTensor dy_batch =
           transformed_dY.Slice(i, i + 1).Resize(output_matrix_shape);
       DenseTensor dx_batch = transformed_dX.Slice(i, i + 1).Resize(input_shape);

--- a/paddle/phi/kernels/impl/conv_kernel_impl.h
+++ b/paddle/phi/kernels/impl/conv_kernel_impl.h
@@ -76,7 +76,7 @@ void ConvKernelImpl(const Context& dev_ctx,
   UpdatePaddingAndDilation(
       &paddings, &dilations, padding_algorithm, in_data_dims, strides, ksize);
 
-  const int batch_size = static_cast<int>(transformed_input.dims()[0]);
+  const int64_t batch_size = transformed_input.dims()[0];
 
   // filter_shape_vec:
   // {k_o, k_i, k_h, k_w} or {k_o, k_i, k_d, k_h, k_w}
@@ -137,14 +137,14 @@ void ConvKernelImpl(const Context& dev_ctx,
           (transformed_output.dims()[0] * transformed_output.dims()[1])};
 
   // convolution operator: im2col(or vol2col) + gemm
-  int in_step = static_cast<int>(transformed_input.dims()[1]) / groups;
-  int out_step = static_cast<int>(transformed_output.dims()[1]) / groups;
+  int64_t in_step = transformed_input.dims()[1] / groups;
+  int64_t out_step = transformed_output.dims()[1] / groups;
 
   phi::funcs::Im2ColFunctor<phi::funcs::ColFormat::kCFO, Context, T> im2col;
   phi::funcs::Vol2ColFunctor<Context, T> vol2col;
 
   auto blas = phi::funcs::GetBlas<Context, T>(dev_ctx);
-  for (int i = 0; i < batch_size; i++) {
+  for (int64_t i = 0; i < batch_size; i++) {
     DenseTensor in_batch =
         transformed_input.Slice(i, i + 1).Resize(in_matrix_shape);
     DenseTensor out_batch =

--- a/paddle/phi/kernels/impl/elementwise_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/elementwise_grad_kernel_impl.h
@@ -259,7 +259,7 @@ void ComputeDDoutWithoutBroadcast(const CPUContext& dev_ctx UNUSED,
   auto* y_data = y.data<T>();
   auto* out_data = out.data<T>();
   auto* ddout_data = ddout->data<T>();
-  for (int i = 0; i < out_numel; i++) {
+  for (int64_t i = 0; i < out_numel; i++) {
     ddout_data[i] = dout_op(ddx_data[i], ddy_data[i], y_data[i], out_data[i]);
   }
 }
@@ -283,7 +283,7 @@ void ComputeDDoutWithBroadcast(const CPUContext& dev_ctx UNUSED,
   auto* out_data = out.data<T>();
   auto* ddout_data = ddout->data<T>();
   std::vector<int> index_array(max_dim, 0);
-  for (int i = 0; i < out_numel; i++) {
+  for (int64_t i = 0; i < out_numel; i++) {
     int x_index = phi::funcs::GetElementwiseIndex(
         x_dims_array, max_dim, index_array.data());
     int y_index = phi::funcs::GetElementwiseIndex(
@@ -381,9 +381,9 @@ __global__ void ComputeDDoutWithoutBroadcastGPUKernel(const T* ddx_data,
                                                       const T* y_data,
                                                       const T* out_data,
                                                       T* ddout_data,
-                                                      int numel,
+                                                      int64_t numel,
                                                       DDout_OP dout_op) {
-  int tid = threadIdx.x + blockIdx.x * blockDim.x;
+  int64_t tid = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   if (tid >= numel) return;
   ddout_data[tid] =
       dout_op(ddx_data[tid], ddy_data[tid], y_data[tid], out_data[tid]);
@@ -418,16 +418,16 @@ __global__ void ComputeDDoutWithBroadcastGPUKernel(
     const T* y_data,
     const T* out_data,
     T* ddout_data,
-    int numel,
+    int64_t numel,
     const CudaIntArray x_dims_array,
     const CudaIntArray y_dims_array,
     const CudaIntArray out_dims_array,
     const int max_dim,
     DDout_OP dout_op) {
-  int tid = threadIdx.x + blockIdx.x * blockDim.x;
+  int64_t tid = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   if (tid >= numel) return;
-  int x_index = 0, y_index = 0, x_index_prod = 1, y_index_prod = 1,
-      out_index = tid, dim_index;
+  int64_t x_index = 0, y_index = 0, x_index_prod = 1, y_index_prod = 1,
+          out_index = tid, dim_index;
   for (int64_t i = max_dim - 1; i >= 0; i--) {
     if (out_index == 0) break;
     dim_index = out_index % out_dims_array[i];

--- a/paddle/phi/kernels/impl/fold_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/fold_grad_kernel_impl.h
@@ -38,7 +38,7 @@ void FoldGradKernel(const Context& dev_ctx,
   if (!x_grad) return;
 
   const auto& x_dims = x_grad->dims();
-  const int batch_size = static_cast<int>(x_dims[0]);
+  const int64_t batch_size = x_dims[0];
 
   int output_height = (output_sizes[0] + 2 * paddings[0] -
                        (dilations[0] * (kernel_sizes[0] - 1) + 1)) /
@@ -49,8 +49,8 @@ void FoldGradKernel(const Context& dev_ctx,
                          strides[1] +
                      1;
 
-  int n_input_plane = x_dims[1];
-  int n_output_plane = n_input_plane / (kernel_sizes[0] * kernel_sizes[1]);
+  int64_t n_input_plane = x_dims[1];
+  int64_t n_output_plane = n_input_plane / (kernel_sizes[0] * kernel_sizes[1]);
 
   DDim out_shape =
       common::make_ddim({n_output_plane, output_sizes[0], output_sizes[1]});
@@ -59,7 +59,7 @@ void FoldGradKernel(const Context& dev_ctx,
 
   phi::funcs::Im2ColFunctor<phi::funcs::ColFormat::kCFO, Context, T> im2col;
 
-  for (int i = 0; i < batch_size; i++) {
+  for (int64_t i = 0; i < batch_size; i++) {
     DenseTensor out_grad_batch = out_grad.Slice(i, i + 1).Resize(out_shape);
     DenseTensor x_grad_batch =
         x_grad->Slice(i, i + 1).Resize(input_matrix_shape);

--- a/paddle/phi/kernels/impl/fold_kernel_impl.h
+++ b/paddle/phi/kernels/impl/fold_kernel_impl.h
@@ -33,7 +33,7 @@ void FoldKernel(const Context& dev_ctx,
                 const std::vector<int>& paddings,
                 const std::vector<int>& dilations,
                 DenseTensor* out) {
-  const int batch_size = static_cast<int>(x.dims()[0]);
+  const int64_t batch_size = x.dims()[0];
   dev_ctx.template Alloc<T>(out);
 
   phi::funcs::Col2ImFunctor<phi::funcs::ColFormat::kCFO, Context, T> col2im;
@@ -48,8 +48,8 @@ void FoldKernel(const Context& dev_ctx,
                          strides[1] +
                      1;
 
-  int n_input_plane = x_dims[1];
-  int n_output_plane = n_input_plane / (kernel_sizes[0] * kernel_sizes[1]);
+  int64_t n_input_plane = x_dims[1];
+  int64_t n_output_plane = n_input_plane / (kernel_sizes[0] * kernel_sizes[1]);
 
   DDim output_shape =
       common::make_ddim({n_output_plane, output_sizes[0], output_sizes[1]});
@@ -60,7 +60,7 @@ void FoldKernel(const Context& dev_ctx,
   phi::funcs::SetConstant<Context, T> set_zero;
   set_zero(dev_ctx, out, static_cast<T>(0));
 
-  for (int i = 0; i < batch_size; i++) {
+  for (int64_t i = 0; i < batch_size; i++) {
     DenseTensor out_batch =
         out->Slice(i, i + 1).Resize(output_shape);  // im size=3
 

--- a/paddle/phi/kernels/impl/frame_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/frame_grad_kernel_impl.h
@@ -29,9 +29,10 @@ void FrameGradKernel(const Context& dev_ctx,
   dev_ctx.template Alloc<T>(dx);
   const size_t dout_rank = dout.dims().size();
   const size_t dx_rank = dx->dims().size();
-  const int n_frames =
+  const int64_t n_frames =
       (axis == 0) ? dout.dims()[0] : dout.dims()[dout_rank - 1];
-  const int seq_length = (axis == 0) ? dx->dims()[0] : dx->dims()[dx_rank - 1];
+  const int64_t seq_length =
+      (axis == 0) ? dx->dims()[0] : dx->dims()[dx_rank - 1];
   DenseTensor dout_tmp = dout;
 
   DDim preserved_dims;

--- a/paddle/phi/kernels/impl/frame_kernel_impl.h
+++ b/paddle/phi/kernels/impl/frame_kernel_impl.h
@@ -28,8 +28,9 @@ void FrameKernel(const Context& dev_ctx,
   dev_ctx.template Alloc<T>(out);
   const size_t x_rank = x.dims().size();
   const size_t out_rank = out->dims().size();
-  const int n_frames = (axis == 0) ? out->dims()[0] : out->dims()[out_rank - 1];
-  const int seq_length = (axis == 0) ? x.dims()[0] : x.dims()[x_rank - 1];
+  const int64_t n_frames =
+      (axis == 0) ? out->dims()[0] : out->dims()[out_rank - 1];
+  const int64_t seq_length = (axis == 0) ? x.dims()[0] : x.dims()[x_rank - 1];
   // When the number of input dims is larger than 2, it needs to copy
   // from x to resize input into 2d and output into 3d. Moreover, output
   // dims will be restored at the last step.

--- a/paddle/phi/kernels/impl/isclose_kernel_impl.h
+++ b/paddle/phi/kernels/impl/isclose_kernel_impl.h
@@ -130,7 +130,7 @@ __global__ void IscloseCUDAKernel(const T* in_data,
                                   bool equal_nan,
                                   IndexType num,
                                   bool* out_data) {
-  IndexType idx = threadIdx.x + blockIdx.x * blockDim.x;
+  IndexType idx = static_cast<IndexType>(blockIdx.x) * blockDim.x + threadIdx.x;
   bool val;
   using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
   for (IndexType i = idx; i < num; i += blockDim.x * gridDim.x) {
@@ -157,7 +157,8 @@ __global__ void IscloseCUDAKernel<phi::complex64, unsigned int>(
     bool equal_nan,
     unsigned int num,
     bool* out_data) {
-  unsigned int idx = threadIdx.x + blockIdx.x * blockDim.x;
+  unsigned int idx =
+      static_cast<unsigned int>(blockIdx.x) * blockDim.x + threadIdx.x;
   bool val;
   for (unsigned int i = idx; i < num; i += blockDim.x * gridDim.x) {
     const phi::complex64 a = in_data[i];
@@ -184,7 +185,7 @@ __global__ void IscloseCUDAKernel<phi::complex64, int64_t>(
     bool equal_nan,
     int64_t num,
     bool* out_data) {
-  int64_t idx = threadIdx.x + blockIdx.x * blockDim.x;
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   bool val;
   for (int64_t i = idx; i < num; i += blockDim.x * gridDim.x) {
     const phi::complex64 a = in_data[i];
@@ -211,7 +212,8 @@ __global__ void IscloseCUDAKernel<phi::complex128, unsigned int>(
     bool equal_nan,
     unsigned int num,
     bool* out_data) {
-  unsigned int idx = threadIdx.x + blockIdx.x * blockDim.x;
+  unsigned int idx =
+      static_cast<unsigned int>(blockIdx.x) * blockDim.x + threadIdx.x;
   bool val;
   for (unsigned int i = idx; i < num; i += blockDim.x * gridDim.x) {
     const phi::complex128 a = in_data[i];
@@ -238,7 +240,7 @@ __global__ void IscloseCUDAKernel<phi::complex128, int64_t>(
     bool equal_nan,
     int64_t num,
     bool* out_data) {
-  int64_t idx = threadIdx.x + blockIdx.x * blockDim.x;
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   bool val;
   for (int64_t i = idx; i < num; i += blockDim.x * gridDim.x) {
     const phi::complex128 a = in_data[i];

--- a/paddle/phi/kernels/impl/kldiv_loss_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/kldiv_loss_grad_kernel_impl.h
@@ -59,8 +59,8 @@ void KLDivLossGradKernel(const Context& dev_ctx,
   auto* loss_grad = &d_out;
 
   const int n = input_grad->dims()[0];
-  const int numel = input_grad->numel();
-  const int expand = numel / loss_grad->numel();
+  const int64_t numel = input_grad->numel();
+  const int64_t expand = numel / loss_grad->numel();
 
   dev_ctx.template Alloc<T>(input_grad);
 

--- a/paddle/phi/kernels/impl/kldiv_loss_kernel_impl.h
+++ b/paddle/phi/kernels/impl/kldiv_loss_kernel_impl.h
@@ -58,7 +58,7 @@ void KLDivLossKernel(const Context& dev_ctx,
   auto* target = &label;
   auto* loss = out;
 
-  const int n = input->dims()[0];
+  const int64_t n = input->dims()[0];
   dev_ctx.template Alloc<T>(loss);
 
   auto input_t = phi::EigenVector<T>::Flatten(*input);

--- a/paddle/phi/kernels/impl/lstm_kernel_impl.h
+++ b/paddle/phi/kernels/impl/lstm_kernel_impl.h
@@ -60,7 +60,7 @@ void LSTMKernel(const Context& dev_ctx,
   to_batch(dev_ctx, input, batch_gate_new, true, is_reverse);
 
   auto in_dims = input.dims();
-  int frame_size = static_cast<int>(in_dims[1] / 4);
+  int64_t frame_size = in_dims[1] / 4;
   phi::DDim dims({in_dims[0], frame_size});
 
   if (bias.initialized()) {
@@ -254,7 +254,7 @@ void LSTMGradKernel(const Context& dev_ctx,
 
   auto in_dims = input->dims();
   auto out_dims = hidden_g->dims();
-  int frame_size = static_cast<int>(in_dims[1] / 4);
+  int64_t frame_size = in_dims[1] / 4;
   PADDLE_ENFORCE_EQ(frame_size,
                     out_dims[1],
                     common::errors::InvalidArgument(

--- a/paddle/phi/kernels/impl/lstsq_kernel_impl.h
+++ b/paddle/phi/kernels/impl/lstsq_kernel_impl.h
@@ -66,9 +66,12 @@ inline void GetResidualsTensor(const DeviceContext& dev_ctx,
                                DenseTensor* rank) {
   auto x_dims = x.dims();
   int dim_size = x_dims.size();
-  int m = x_dims[dim_size - 2];
-  int n = x_dims[dim_size - 1];
+  int64_t m = x_dims[dim_size - 2];
+  int64_t n = x_dims[dim_size - 1];
 
+  // Note(zrr1999): Although m and n are declared as int64_t, the rank tensor
+  // stores int values (see rank->data<int>() usage below), so effectively these
+  // dimensions are limited to int range in the current implementation.
   if (m > n && driver != "gelsy") {
     bool compute_residuals = true;
     if ((driver == "gelss" || driver == "gelsd") && rank->numel() != 0) {

--- a/paddle/phi/kernels/impl/qr_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/qr_grad_kernel_impl.h
@@ -77,8 +77,8 @@ void QrGradKernel(const Context& dev_ctx,
 
   auto a_dims = A.dims();
   int a_rank = a_dims.size();
-  int m = a_dims[a_rank - 2];
-  int n = a_dims[a_rank - 1];
+  int64_t m = a_dims[a_rank - 2];
+  int64_t n = a_dims[a_rank - 1];
 
   if ((m > n) && (!reduced)) {
     PADDLE_THROW(errors::InvalidArgument(

--- a/paddle/phi/kernels/impl/spectral_norm_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/spectral_norm_grad_kernel_impl.h
@@ -31,8 +31,8 @@ void SpectralNormGradKernel(const Context& dev_ctx,
   auto& place = *dev_ctx.eigen_device();
   auto blas = phi::funcs::GetBlas<Context, T>(dev_ctx);
 
-  const int h = u.dims()[0];
-  const int w = v.dims()[0];
+  const int64_t h = u.dims()[0];
+  const int64_t w = v.dims()[0];
 
   DenseTensor weight_mat, out_grad_mat;
   auto dims = weight.dims();

--- a/paddle/phi/kernels/impl/spectral_norm_kernel_impl.h
+++ b/paddle/phi/kernels/impl/spectral_norm_kernel_impl.h
@@ -73,8 +73,8 @@ static inline void CalcMatrixSigmaAndNormWeight(const Context& dev_ctx,
   auto u_t = EigenTensor<T, 2>::From(*u);
   auto v_t = EigenTensor<T, 2>::From(*v);
 
-  const int h = weight->dims()[0];
-  const int w = weight->dims()[1];
+  const int64_t h = weight->dims()[0];
+  const int64_t w = weight->dims()[1];
 
   for (int i = 0; i < power_iters; i++) {
     // V = W^T * U / ||W^T * U||_2
@@ -112,8 +112,8 @@ void SpectralNormKernel(const Context& dev_ctx,
                         int power_iters,
                         float eps,
                         DenseTensor* out) {
-  const int h = u.dims()[0];
-  const int w = v.dims()[0];
+  const int64_t h = u.dims()[0];
+  const int64_t w = v.dims()[0];
 
   DenseTensor weight_mat;
   auto dims = weight.dims();

--- a/paddle/phi/kernels/impl/stft_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/stft_grad_kernel_impl.h
@@ -70,8 +70,8 @@ void StftGradKernel(const Context& dev_ctx,
   const size_t dy_rank = dy->dims().size();
   const size_t dx_rank = dx->dims().size();
 
-  const int n_frames = dy->dims()[dy_rank - 1];
-  const int seq_length = dx->dims()[dx_rank - 1];
+  const size_t n_frames = dy->dims()[dy_rank - 1];
+  const size_t seq_length = dx->dims()[dx_rank - 1];
 
   std::vector<int64_t> axes = {1};
   phi::DenseTensor d_frames_w;

--- a/paddle/phi/kernels/impl/stft_kernel_impl.h
+++ b/paddle/phi/kernels/impl/stft_kernel_impl.h
@@ -43,8 +43,8 @@ void StftKernel(const Context& dev_ctx,
   const size_t x_rank = x.dims().size();
   const size_t out_rank = out->dims().size();
 
-  const int n_frames = out->dims()[out_rank - 1];
-  const int seq_length = x.dims()[x_rank - 1];
+  const size_t n_frames = out->dims()[out_rank - 1];
+  const size_t seq_length = x.dims()[x_rank - 1];
 
   std::vector<int64_t> axes = {1};
 

--- a/paddle/phi/kernels/impl/svd_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/svd_grad_kernel_impl.h
@@ -31,7 +31,7 @@ namespace phi {
 
 template <class T, class Context>
 static DenseTensor Fill(const Context& dev_ctx,
-                        std::vector<int> shape,
+                        std::vector<int64_t> shape,
                         T fill_value) {
   DenseTensor ret;
   ret.Resize(common::make_ddim(shape));
@@ -41,14 +41,15 @@ static DenseTensor Fill(const Context& dev_ctx,
 }
 
 template <class T, class Context>
-static DenseTensor Eye(const Context& dev_ctx, int n) {
+static DenseTensor Eye(const Context& dev_ctx, int64_t n) {
   auto output = Fill<T, Context>(dev_ctx, {n}, T(1));
   auto ret = Diag<T, Context>(dev_ctx, output, 0, 0);
   return ret;
 }
 
 template <class T, class Context>
-static DenseTensor Infinits(const Context& dev_ctx, std::vector<int> shape) {
+static DenseTensor Infinits(const Context& dev_ctx,
+                            std::vector<int64_t> shape) {
   auto value = static_cast<T>(std::numeric_limits<double>::infinity());
   return Fill<T, Context>(dev_ctx, shape, value);
 }
@@ -57,7 +58,7 @@ static DenseTensor Unsqueeze(const DenseTensor& x, int axis = 0) {
   // don't copy data, only change the dims
   DenseTensor out;
   out.ShareDataWith(x);
-  std::vector<int> out_shape = common::vectorize<int>(x.dims());
+  std::vector<int64_t> out_shape = common::vectorize<int64_t>(x.dims());
   if (axis >= 0) {
     auto index = (out_shape.begin() + axis);
     out_shape.insert(index, 1);
@@ -86,9 +87,9 @@ struct SvdGradFunctor {
                   bool full_matrices,
                   DenseTensor* x_grad) {
     const auto& dX = *x_grad;
-    int m = dX.dims()[dX.dims().size() - 2];
-    int n = dX.dims()[dX.dims().size() - 1];
-    int k = s.dims()[s.dims().size() - 1];
+    int64_t m = dX.dims()[dX.dims().size() - 2];
+    int64_t n = dX.dims()[dX.dims().size() - 1];
+    int64_t k = s.dims()[s.dims().size() - 1];
     DenseTensor U, VH, dU, dV, dVH;
     if (full_matrices) {
       // if full_matrices is set, slice the U and VT to k columns
@@ -200,9 +201,9 @@ struct SvdGradFunctor<phi::dtype::complex<T>, Context> {
                   DenseTensor* x_grad) {
     using C = phi::dtype::complex<T>;
     const auto& dX = *x_grad;
-    int m = dX.dims()[dX.dims().size() - 2];
-    int n = dX.dims()[dX.dims().size() - 1];
-    int k = s.dims()[s.dims().size() - 1];
+    int64_t m = dX.dims()[dX.dims().size() - 2];
+    int64_t n = dX.dims()[dX.dims().size() - 1];
+    int64_t k = s.dims()[s.dims().size() - 1];
     DenseTensor S = Cast<T, Context>(dev_ctx, s, u.dtype());
     DenseTensor U, VH, dU, dV, dVH;
 

--- a/paddle/phi/kernels/impl/svdvals_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/svdvals_grad_kernel_impl.h
@@ -39,9 +39,9 @@ void SvdvalsGradKernel(const Context& dev_ctx,
     return;
   }
   auto x_dims = x.dims();
-  int rows = static_cast<int>(x_dims[x_dims.size() - 2]);
-  int cols = static_cast<int>(x_dims[x_dims.size() - 1]);
-  int batches = static_cast<int>(x.numel() / (rows * cols));
+  int64_t rows = x_dims[x_dims.size() - 2];
+  int64_t cols = x_dims[x_dims.size() - 1];
+  int64_t batches = x.numel() / (rows * cols);
   DenseTensor dX_term;
   if (batches == 1) {
     dX_term = Diag<T, Context>(dev_ctx, s_grad, 0, 0);

--- a/paddle/phi/kernels/impl/unfold_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/unfold_grad_kernel_impl.h
@@ -38,7 +38,7 @@ void UnfoldGradKernel(const Context& dev_ctx,
   }
 
   const auto& x_dims = x_grad->dims();
-  const int batch_size = static_cast<int>(x_dims[0]);
+  const int64_t batch_size = x_dims[0];
 
   int out_height = phi::funcs::CalcOutputSize(static_cast<int>(x_dims[2]),
                                               kernel_sizes[0],
@@ -61,7 +61,7 @@ void UnfoldGradKernel(const Context& dev_ctx,
 
   phi::funcs::SetConstant<Context, T> set_zero;
   set_zero(dev_ctx, x_grad, static_cast<T>(0));
-  for (int i = 0; i < batch_size; i++) {
+  for (int64_t i = 0; i < batch_size; i++) {
     DenseTensor out_grad_batch =
         out_grad.Slice(i, i + 1).Resize(out_matrix_shape);
     DenseTensor x_grad_batch = x_grad->Slice(i, i + 1).Resize(x_shape);

--- a/paddle/phi/kernels/impl/unfold_kernel_impl.h
+++ b/paddle/phi/kernels/impl/unfold_kernel_impl.h
@@ -31,7 +31,7 @@ void UnfoldKernel(const Context& dev_ctx,
                   const std::vector<int>& paddings,
                   const std::vector<int>& dilations,
                   DenseTensor* out) {
-  const int batch_size = static_cast<int>(x.dims()[0]);
+  const int64_t batch_size = x.dims()[0];
   dev_ctx.template Alloc<T>(out);
   if (out->numel() == 0) {
     return;
@@ -57,7 +57,7 @@ void UnfoldKernel(const Context& dev_ctx,
   DDim out_matrix_shape = common::make_ddim(
       {x_dims[1], kernel_sizes[0], kernel_sizes[1], out_height, out_width});
 
-  for (int i = 0; i < batch_size; i++) {
+  for (int64_t i = 0; i < batch_size; i++) {
     DenseTensor in_batch = x.Slice(i, i + 1).Resize(x_shape);
     DenseTensor out_batch = out->Slice(i, i + 1).Resize(out_matrix_shape);
     im2col(dev_ctx, in_batch, dilations, strides, paddings, &out_batch);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
将下面PR https://github.com/PaddlePaddle/Paddle/pull/76107 cherry-pick到 fleety_12

**PR描述：**
>排查Paddle/paddle/phi/kernels/impl 目录下的可能存在的大tensor问题并进行修改

devPR:https://github.com/PaddlePaddle/Paddle/pull/76107

cherry-pick过程中无异常，未发生冲突，未发生需要一起前置依赖PR。