### PR TITLE
[Cherry-pick Fleety_12] Slice fix (#75596、#75794、#76004)

### DIFF
--- a/paddle/fluid/pybind/slice_utils.h
+++ b/paddle/fluid/pybind/slice_utils.h
@@ -802,7 +802,7 @@ static paddle::Tensor getValueForBoolTensor(const paddle::Tensor& tensor,
   }
 
   auto bool_2_idx = nonzero_ad_func(bool_index);
-  if (FLAGS_use_stride_kernel) {
+  if (FLAGS_use_stride_kernel && self_tensor.is_contiguous()) {
     std::vector<paddle::Tensor> indices =
         PrepareIndices(tensor, bool_2_idx, bool_index);
     for (int i = 0; i < pos_of_new_dim; ++i) {
@@ -1302,7 +1302,8 @@ static void ApplyGetitem(const int index_size,
       }
     }
 
-    if (FLAGS_use_stride_kernel && !has_empty_index) {
+    if (FLAGS_use_stride_kernel && !has_empty_index &&
+        self_tensor->is_contiguous()) {
       const phi::distributed::ProcessMesh* mesh = nullptr;
       if (InputsContainDistTensor(
               &mesh, *self_tensor, *transed_tensor, *transed_index)) {

--- a/paddle/phi/kernels/funcs/stride_utils.h
+++ b/paddle/phi/kernels/funcs/stride_utils.h
@@ -330,7 +330,7 @@ static inline void CopyStride(
 
   coalesce_dimensions<N>(ndim, strides_array, &stride_size, desired_shape);
 
-  int num = 1;
+  int64_t num = 1;
   for (size_t i = 0; i < desired_shape->size(); i++) {
     num *= (*desired_shape)[i];
   }
@@ -385,7 +385,7 @@ static inline void IndexPutStride(
 
   coalesce_dimensions<N>(ndim, strides_array, &stride_size, desired_shape);
 
-  int num = 1;
+  int64_t num = 1;
   for (size_t i = 0; i < desired_shape->size(); i++) {
     num *= (*desired_shape)[i];
   }
@@ -444,7 +444,7 @@ static inline void IndexGetStride(
 
   coalesce_dimensions<N>(ndim, strides_array, &stride_size, desired_shape);
 
-  int num = 1;
+  int64_t num = 1;
   for (size_t i = 0; i < desired_shape->size(); i++) {
     num *= (*desired_shape)[i];
   }
@@ -539,8 +539,8 @@ static inline void ScatterAddStride(
 
   coalesce_dimensions<N>(ndim, strides_array, &stride_size, desired_shape);
 
-  int num = 1;
-  for (int i = 0; i < desired_shape->size(); i++) {
+  int64_t num = 1;
+  for (size_t i = 0; i < desired_shape->size(); i++) {
     num *= (*desired_shape)[i];
   }
   *numel = num;

--- a/test/indexing/test_getitem.py
+++ b/test/indexing/test_getitem.py
@@ -409,6 +409,24 @@ class TestGetitemInDygraph(unittest.TestCase):
 
         np.testing.assert_allclose(y.numpy(), np_res)
 
+    def test_input_strided_tensor(self):
+        base = paddle.to_tensor(
+            [5.0, 5.0, 6.0, 5.0, 5.0, 6.0], dtype=paddle.float64
+        )
+        foo_strided = paddle.as_strided(base, shape=(2, 1), stride=(2, 1))
+
+        base2 = paddle.to_tensor(
+            [0, 0, 1, 0, 1, 0, 0, 5, 5, 5, 5], dtype=paddle.int64
+        )
+        atype = paddle.as_strided(base2, shape=(2, 3), stride=(4, 1))
+
+        result = foo_strided[atype]
+        expected_result = paddle.to_tensor(
+            [[[5.0], [5.0], [6.0]], [[6.0], [5.0], [5.0]]], dtype=paddle.float64
+        )
+
+        np.testing.assert_allclose(result.numpy(), expected_result.numpy())
+
 
 class TestMultipleIndexing(TestGetitemInDygraph):
     def test_indexing_with_all_possible_start_end_step_dygraph(self):

--- a/test/legacy_test/test_set_value_op.py
+++ b/test/legacy_test/test_set_value_op.py
@@ -17,7 +17,12 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, convert_float_to_uint16, get_devices
+from op_test import (
+    OpTest,
+    convert_float_to_uint16,
+    get_devices,
+    is_custom_device,
+)
 
 import paddle
 from paddle.base import core

--- a/test/legacy_test/test_set_value_op.py
+++ b/test/legacy_test/test_set_value_op.py
@@ -21,7 +21,6 @@ from op_test import (
     OpTest,
     convert_float_to_uint16,
     get_devices,
-    is_custom_device,
 )
 
 import paddle
@@ -1791,37 +1790,6 @@ class TestSetValueWithScalarInDygraph(unittest.TestCase):
 
         np.testing.assert_array_equal(out, np_data)
         np.testing.assert_array_equal(x.grad, expected_x_grad)
-
-
-@unittest.skipIf(
-    not (core.is_compiled_with_cuda() or is_custom_device()),
-    "core is not compiled with CUDA",
-)
-class TestSetValueWithStrideError(unittest.TestCase):
-    def test_same_place(self):
-        x = paddle.rand([5, 10], device=paddle.CUDAPlace(0))
-        y = paddle.rand([10, 5], device=paddle.CUDAPlace(0))
-        y.transpose_([1, 0])
-        x.set_value(y)
-        assert x.is_contiguous()
-
-    def test_different_place1(self):
-        # src place != dst place && src is not contiguous
-        x = paddle.rand([5, 10], device=paddle.CUDAPlace(0))
-        y = paddle.rand([10, 5], device=paddle.CPUPlace())
-        y.transpose_([1, 0])
-        x.set_value(y)
-        assert not x.is_contiguous()
-
-    def test_different_place2(self):
-        # src place != dst place && dst is not contiguous
-        with self.assertRaises(SystemError):
-            x = paddle.ones([5, 4], device=paddle.CUDAPlace(0))
-            x.transpose_([1, 0])
-            y = paddle.rand([4, 2], device=paddle.CPUPlace())
-            assert not x.is_contiguous()
-
-            x[:, 1:3].set_value(y)
 
 
 if __name__ == '__main__':

--- a/test/legacy_test/test_set_value_op.py
+++ b/test/legacy_test/test_set_value_op.py
@@ -1788,5 +1788,36 @@ class TestSetValueWithScalarInDygraph(unittest.TestCase):
         np.testing.assert_array_equal(x.grad, expected_x_grad)
 
 
+@unittest.skipIf(
+    not (core.is_compiled_with_cuda() or is_custom_device()),
+    "core is not compiled with CUDA",
+)
+class TestSetValueWithStrideError(unittest.TestCase):
+    def test_same_place(self):
+        x = paddle.rand([5, 10], device=paddle.CUDAPlace(0))
+        y = paddle.rand([10, 5], device=paddle.CUDAPlace(0))
+        y.transpose_([1, 0])
+        x.set_value(y)
+        assert x.is_contiguous()
+
+    def test_different_place1(self):
+        # src place != dst place && src is not contiguous
+        x = paddle.rand([5, 10], device=paddle.CUDAPlace(0))
+        y = paddle.rand([10, 5], device=paddle.CPUPlace())
+        y.transpose_([1, 0])
+        x.set_value(y)
+        assert not x.is_contiguous()
+
+    def test_different_place2(self):
+        # src place != dst place && dst is not contiguous
+        with self.assertRaises(SystemError):
+            x = paddle.ones([5, 4], device=paddle.CUDAPlace(0))
+            x.transpose_([1, 0])
+            y = paddle.rand([4, 2], device=paddle.CPUPlace())
+            assert not x.is_contiguous()
+
+            x[:, 1:3].set_value(y)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->

将下面PR cherry-pick到 fleety_12
devPR:https://github.com/PaddlePaddle/Paddle/pull/75596
devPR:https://github.com/PaddlePaddle/Paddle/pull/75794
devPR:https://github.com/PaddlePaddle/Paddle/pull/76004

**暂时删掉TestSetValueWithStrideError单测说明：**
由于cherry-pick后，下面单测出现device参数未定义，这是因为需要前置兼容性适配的pr，为了不引入额外的麻烦，这里暂时去掉该单测。

```
@unittest.skipIf(
    not (core.is_compiled_with_cuda() or is_custom_device()),
    "core is not compiled with CUDA",
)
class TestSetValueWithStrideError(unittest.TestCase):
    def test_same_place(self):
        x = paddle.rand([5, 10], device=paddle.CUDAPlace(0))
        y = paddle.rand([10, 5], device=paddle.CUDAPlace(0))
        y.transpose_([1, 0])
        x.set_value(y)
        assert x.is_contiguous()

    def test_different_place1(self):
        # src place != dst place && src is not contiguous
        x = paddle.rand([5, 10], device=paddle.CUDAPlace(0))
        y = paddle.rand([10, 5], device=paddle.CPUPlace())
        y.transpose_([1, 0])
        x.set_value(y)
        assert not x.is_contiguous()

    def test_different_place2(self):
        # src place != dst place && dst is not contiguous
        with self.assertRaises(SystemError):
            x = paddle.ones([5, 4], device=paddle.CUDAPlace(0))
            x.transpose_([1, 0])
            y = paddle.rand([4, 2], device=paddle.CPUPlace())
            assert not x.is_contiguous()

            x[:, 1:3].set_value(y)
```
