### PR TITLE
Fix int32 overflow issues for large tensor support in paddle/phi/kernels/cpu

### DIFF
--- a/paddle/phi/kernels/cpu/affine_channel_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/affine_channel_grad_kernel.cc
@@ -53,10 +53,10 @@ void AffineChannelGradKernel(const Context& dev_ctx,
   const phi::DataLayout layout = common::StringToDataLayout(data_layout);
 
   auto dims = x->dims();
-  int N = static_cast<int>(dims[0]);
-  int C = static_cast<int>(
-      layout == phi::DataLayout::kNCHW ? dims[1] : dims[dims.size() - 1]);
-  int HxW = static_cast<int>(x->numel() / N / C);
+  int64_t N = dims[0];
+  int64_t C =
+      layout == phi::DataLayout::kNCHW ? dims[1] : dims[dims.size() - 1];
+  int64_t HxW = x->numel() / N / C;
 
   auto* dy_d = dy->data<T>();
   auto* scale_d = scale->data<T>();

--- a/paddle/phi/kernels/cpu/affine_channel_kernel.cc
+++ b/paddle/phi/kernels/cpu/affine_channel_kernel.cc
@@ -49,10 +49,10 @@ void AffineChannelKernel(const Context& dev_ctx,
   const phi::DataLayout layout = common::StringToDataLayout(data_layout);
 
   auto dims = x->dims();
-  int N = static_cast<int>(dims[0]);
-  int C = static_cast<int>(
-      layout == phi::DataLayout::kNCHW ? dims[1] : dims[dims.size() - 1]);
-  int HxW = static_cast<int>(x->numel() / N / C);
+  int64_t N = dims[0];
+  int64_t C =
+      layout == phi::DataLayout::kNCHW ? dims[1] : dims[dims.size() - 1];
+  int64_t HxW = static_cast<int64_t>(x->numel() / N / C);
 
   auto* scale_d = scale->data<T>();
   auto* bias_d = bias->data<T>();

--- a/paddle/phi/kernels/cpu/affine_grid_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/affine_grid_grad_kernel.cc
@@ -49,7 +49,7 @@ void AffineGridGrad4DKernel(const Context& dev_ctx,
                             bool align_corners,
                             DenseTensor* input_grad) {
   auto& theta_grad = input_grad;
-  int n = static_cast<int>(output_grad.dims()[0]);
+  int64_t n = output_grad.dims()[0];
   auto& size_attr = outputShape.GetData();
   int h = 0;
   int w = 0;
@@ -86,7 +86,7 @@ void AffineGridGrad5DKernel(const Context& dev_ctx,
                             bool align_corners,
                             DenseTensor* input_grad) {
   auto& theta_grad = input_grad;
-  int n = static_cast<int>(output_grad.dims()[0]);
+  int64_t n = output_grad.dims()[0];
   auto& size_attr = outputShape.GetData();
   int d = 0;
   int h = 0;

--- a/paddle/phi/kernels/cpu/affine_grid_kernel.cc
+++ b/paddle/phi/kernels/cpu/affine_grid_kernel.cc
@@ -49,7 +49,7 @@ void AffineGrid4DKernel(const Context& dev_ctx,
                         bool align_corners,
                         DenseTensor* output) {
   auto* theta = &input;
-  int n = static_cast<int>(theta->dims()[0]);
+  int64_t n = theta->dims()[0];
   auto& size_attr = outputShape.GetData();
   int h = 0;
   int w = 0;
@@ -81,7 +81,7 @@ void AffineGrid5DKernel(const Context& dev_ctx,
                         bool align_corners,
                         DenseTensor* output) {
   auto* theta = &input;
-  int n = static_cast<int>(theta->dims()[0]);
+  int64_t n = theta->dims()[0];
   auto& size_attr = outputShape.GetData();
   int d = 0;
   int h = 0;

--- a/paddle/phi/kernels/cpu/all_to_all_kernel.cc
+++ b/paddle/phi/kernels/cpu/all_to_all_kernel.cc
@@ -41,7 +41,7 @@ void AllToAllKernel(const phi::CustomContext& dev_ctx,
 
   int nranks = comm_ctx->GetSize();
   int rank = comm_ctx->GetRank();
-  int send_numel = x.numel() / nranks;
+  int64_t send_numel = x.numel() / nranks;
 
   std::vector<void*> sendbuf, recvbuf;
   std::vector<size_t> sendsize(send_numel, nranks);

--- a/paddle/phi/kernels/cpu/attention_lstm_kernel.cc
+++ b/paddle/phi/kernels/cpu/attention_lstm_kernel.cc
@@ -92,12 +92,12 @@ void AttentionLSTMKernel(
   const int N = static_cast<int>(x_lod[0].size() - 1);  // batch size
   auto x_dims = x->dims();                              // T x M
   auto w_dims = lstm_w->dims();                         // (D+M) x 4D
-  const int total_T = static_cast<int>(x_dims[0]);
-  const int M = static_cast<int>(x_dims[1]);      // x frame size
-  const int D = static_cast<int>(w_dims[1] / 4);  // gate frame size
+  const int64_t total_T = x_dims[0];
+  const int64_t M = x_dims[1];                            // x frame size
+  const int64_t D = static_cast<int64_t>(w_dims[1] / 4);  // gate frame size
   const int D2 = static_cast<int>(D * 2);
   const int D3 = static_cast<int>(D * 3);
-  const int D4 = static_cast<int>(w_dims[1]);
+  const int64_t D4 = w_dims[1];
   int max_seq_len = static_cast<int>(x_lod[0][1]);
   for (int i = 1; i < N; ++i) {
     int len = static_cast<int>(x_lod[0][i + 1] - x_lod[0][i]);

--- a/paddle/phi/kernels/cpu/batch_norm_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/batch_norm_grad_kernel.cc
@@ -105,10 +105,10 @@ void BatchNormGradFunctor(const Context& dev_ctx,
           "The size of input X's dimensions should be less than 6."
           "But received: the size of input X's dimensions is [%d]",
           x_dims.size()));
-  const int N = static_cast<int>(x_dims[0]);
-  const int C = static_cast<int>(
+  const int64_t N = x_dims[0];
+  const int64_t C = static_cast<int64_t>(
       data_layout == DataLayout::kNCHW ? x_dims[1] : x_dims[x_dims.size() - 1]);
-  const int sample_size = static_cast<int>(x.numel() / N / C);
+  const int64_t sample_size = static_cast<int64_t>(x.numel() / N / C);
 
   // input dimension is 2 and the format is NCHW. The input can be regarded as
   // NHWC format
@@ -412,9 +412,9 @@ void BatchNormDoubleGradKernel(
   dev_ctx.template Alloc<T>(ddY);
 
   const auto& x_dims = X->dims();
-  const int C = static_cast<int>(
+  const int64_t C = static_cast<int64_t>(
       data_layout == DataLayout::kNCHW ? x_dims[1] : x_dims[x_dims.size() - 1]);
-  const int sample_size = static_cast<int>(X->numel() / C);
+  const int64_t sample_size = static_cast<int64_t>(X->numel() / C);
   phi::funcs::SetConstant<Context, T> set_constant;
 
   const T* mean_data = Saved_mean->data<T>();

--- a/paddle/phi/kernels/cpu/batch_norm_kernel.cc
+++ b/paddle/phi/kernels/cpu/batch_norm_kernel.cc
@@ -85,10 +85,10 @@ void BatchNormKernel(const Context& dev_ctx,
           "The size of input X's dimensions should be less than 6."
           "But received: the size of input X's dimensions is [%d]",
           x_dims.size()));
-  const int N = static_cast<int>(x_dims[0]);
-  const int C = static_cast<int>(
+  const int64_t N = x_dims[0];
+  const int64_t C = static_cast<int64_t>(
       data_layout == DataLayout::kNCHW ? x_dims[1] : x_dims[x_dims.size() - 1]);
-  const int sample_size = static_cast<int>(x.numel() / N / C);
+  const int64_t sample_size = static_cast<int64_t>(x.numel() / N / C);
 
   // alloc memory
   dev_ctx.template Alloc<T>(y);

--- a/paddle/phi/kernels/cpu/bce_loss_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/bce_loss_grad_kernel.cc
@@ -32,10 +32,10 @@ void BCELossGradKernel(const Context& dev_ctx,
   auto x_data = input.data<T>();
   auto label_data = label.data<T>();
 
-  int x_numel = static_cast<int>(input.numel());
+  int64_t x_numel = static_cast<int64_t>(input.numel());
 
   // dx = dout * ((x - label)/(x - x^2))
-  for (int i = 0; i < x_numel; ++i) {
+  for (int64_t i = 0; i < x_numel; ++i) {
     dx_data[i] =
         dout_data[i] * ((x_data[i] - label_data[i]) /
                         std::max((static_cast<T>(1) - x_data[i]) * x_data[i],

--- a/paddle/phi/kernels/cpu/conv_util.h
+++ b/paddle/phi/kernels/cpu/conv_util.h
@@ -29,7 +29,7 @@ inline void UpdatePaddingAndDilation(std::vector<T>* paddings,
   // set padding size == data_dims.size() * 2
   auto data_shape = common::vectorize<T>(data_dims);
   if (static_cast<int>(paddings->size()) == data_dims.size()) {
-    for (int i = 0; i < data_dims.size(); ++i) {
+    for (int64_t i = 0; i < data_dims.size(); ++i) {
       T copy_pad = *(paddings->begin() + 2 * i);
       paddings->insert(paddings->begin() + 2 * i + 1, copy_pad);
     }
@@ -50,7 +50,7 @@ inline void UpdatePaddingAndDilation(std::vector<T>* paddings,
 
   // when padding_algorithm is "VALID" or "SAME"
   if (padding_algorithm == "SAME") {
-    for (int i = 0; i < data_dims.size(); ++i) {
+    for (int64_t i = 0; i < data_dims.size(); ++i) {
       T out_size = (data_dims[i] + strides[i] - 1) / strides[i];
       T pad_sum =
           std::max((out_size - 1) * strides[i] + ksize[i] - data_shape[i],
@@ -245,7 +245,7 @@ inline std::vector<int64_t> ComputeOutputShape(
   if (!channel_last) {
     output_shape.push_back(filter_dims[0]);
   }
-  for (int i = 0; i < in_data_dims.size(); ++i) {
+  for (int64_t i = 0; i < in_data_dims.size(); ++i) {
     if (!config.is_runtime &&
         (in_data_dims[i] <= 0 || filter_dims[i + 2] <= 0)) {
       output_shape.push_back(-1);

--- a/paddle/phi/kernels/cpu/cross_entropy_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/cross_entropy_grad_kernel.cc
@@ -46,9 +46,9 @@ void CrossEntropyWithSoftmaxGradCPUKernel(const CPUContext& dev_ctx,
     phi::Copy(dev_ctx, softmax, dev_ctx.GetPlace(), false, logit_grad);
   }
 
-  const int rank = logit_grad->dims().size();
+  const int64_t rank = logit_grad->dims().size();
   const int axis_v = phi::funcs::CanonicalAxis(axis, rank);
-  int axis_dim = static_cast<int>(logit_grad->dims()[axis_v]);
+  int64_t axis_dim = logit_grad->dims()[axis_v];
   PADDLE_ENFORCE_GT(
       axis_dim,
       0,
@@ -57,7 +57,7 @@ void CrossEntropyWithSoftmaxGradCPUKernel(const CPUContext& dev_ctx,
           "axis dimension is %d.",
           axis_dim));
 
-  const int n = phi::funcs::SizeToAxis(axis_v, logit_grad->dims());
+  const int64_t n = phi::funcs::SizeToAxis(axis_v, logit_grad->dims());
   PADDLE_ENFORCE_GT(
       n,
       0,
@@ -66,7 +66,7 @@ void CrossEntropyWithSoftmaxGradCPUKernel(const CPUContext& dev_ctx,
           "SizeToAxis of logit_grad is %d.",
           n));
 
-  const int d = phi::funcs::SizeFromAxis(axis_v, logit_grad->dims());
+  const int64_t d = phi::funcs::SizeFromAxis(axis_v, logit_grad->dims());
   DenseTensor logit_grad_2d(*logit_grad);
   logit_grad_2d.Resize({n, d});
   DenseTensor labels_2d(label);

--- a/paddle/phi/kernels/cpu/cross_entropy_kernel.cc
+++ b/paddle/phi/kernels/cpu/cross_entropy_kernel.cc
@@ -35,7 +35,7 @@ void CrossEntropy(const CPUContext& dev_ctx,
                   DenseTensor* out) {
   const int rank = x.dims().size();
   const int axis_v = phi::funcs::CanonicalAxis(axis, rank);
-  int axis_dim = static_cast<int>(x.dims()[axis_v]);
+  int64_t axis_dim = x.dims()[axis_v];
 
   PADDLE_ENFORCE_GT(
       axis_dim,

--- a/paddle/phi/kernels/cpu/cum_kernel.cc
+++ b/paddle/phi/kernels/cpu/cum_kernel.cc
@@ -86,7 +86,7 @@ void ScanKernel(const Context& dev_ctx,
 
   int pre = 1;
   int post = 1;
-  int mid = static_cast<int>(out_dims[axis]);
+  int64_t mid = out_dims[axis];
   for (int i = 0; i < axis; ++i) {
     pre *= static_cast<int>(out_dims[i]);
   }

--- a/paddle/phi/kernels/cpu/dequantize_abs_max_kernel.cc
+++ b/paddle/phi/kernels/cpu/dequantize_abs_max_kernel.cc
@@ -28,7 +28,7 @@ void DequantizeAbsMaxKernel(const Context& dev_ctx,
   const float* scale_factor = scale.data<float>();
   const T* input_data = x.data<T>();
   float* output_data = dev_ctx.template Alloc<float>(out);
-  int ind = static_cast<int>(x.numel());
+  int64_t ind = static_cast<int64_t>(x.numel());
   for (size_t i = 0; i < (unsigned)ind; i++) {
     output_data[i] = scale_factor[0] * input_data[i] / max_range;
   }

--- a/paddle/phi/kernels/cpu/dequantize_log_kernel.cc
+++ b/paddle/phi/kernels/cpu/dequantize_log_kernel.cc
@@ -27,7 +27,7 @@ void DequantizeLogKernel(const Context& dev_ctx,
   const float* dict_data = dict.data<float>();
   const T* input_data = x.data<T>();
   float* output_data = dev_ctx.template Alloc<float>(out);
-  int ind = static_cast<int>(x.numel());
+  int64_t ind = static_cast<int64_t>(x.numel());
   for (size_t i = 0; i < (unsigned)ind; i++) {
     if (input_data[i] < 0) {
       output_data[i] = -dict_data[input_data[i] + 128];

--- a/paddle/phi/kernels/cpu/distribute_fpn_proposals_kernel.cc
+++ b/paddle/phi/kernels/cpu/distribute_fpn_proposals_kernel.cc
@@ -62,7 +62,7 @@ void DistributeFpnProposalsKernel(
     auto fpn_rois_slice = fpn_rois.Slice(static_cast<int>(fpn_rois_lod[i]),
                                          static_cast<int>(fpn_rois_lod[i + 1]));
     const T* rois_data = fpn_rois_slice.data<T>();
-    for (int j = 0; j < fpn_rois_slice.dims()[0]; ++j) {
+    for (int64_t j = 0; j < fpn_rois_slice.dims()[0]; ++j) {
       // get the target level of current rois
       T roi_scale = std::sqrt(funcs::BBoxArea(rois_data, pixel_offset));
       int tgt_lvl = std::floor(std::log2(roi_scale / refer_scale + (T)1e-6) +
@@ -101,7 +101,7 @@ void DistributeFpnProposalsKernel(
     for (int j = 0; j < num_level; j++) {
       multi_fpn_rois_lod0[j].push_back(multi_fpn_rois_lod0[j][i]);
     }
-    for (int j = 0; j < fpn_rois_slice.dims()[0]; ++j) {
+    for (int64_t j = 0; j < fpn_rois_slice.dims()[0]; ++j) {
       int lvl = target_level[cur_offset + j];
       memcpy(multi_fpn_rois_data[lvl - min_level],
              rois_data,

--- a/paddle/phi/kernels/cpu/dropout_kernel.cc
+++ b/paddle/phi/kernels/cpu/dropout_kernel.cc
@@ -34,7 +34,7 @@ void ComputeDropoutInference(const Context& dev_ctx,
 #ifdef PADDLE_WITH_MKLML
 #pragma omp parallel for
 #endif
-    for (int i = 0; i < x.numel(); i++) {
+    for (int64_t i = 0; i < x.numel(); i++) {
       Y_data[i] = X_data[i];
     }
   } else {
@@ -178,7 +178,7 @@ void DropoutNdKernel(const Context& dev_ctx,
     T* broadcast_mask_data = dev_ctx.template Alloc<T>(&broadcast_mask);
 
     std::vector<int64_t> mask_bst_dims_vec;
-    for (int i = 0; i < x_dims.size(); i++) {
+    for (int64_t i = 0; i < x_dims.size(); i++) {
       mask_bst_dims_vec.emplace_back(x_dims[i]);
     }
     IntArray mask_bst_dims(mask_bst_dims_vec);

--- a/paddle/phi/kernels/cpu/eig.h
+++ b/paddle/phi/kernels/cpu/eig.h
@@ -129,8 +129,8 @@ void LapackEig(DenseTensor* input,
                const Context& dev_ctx) {
   char jobvl = 'N';
   char jobvr = 'V';  // only right eigenvectors are computed
-  int num_dims = input->dims().size();
-  int order = input->dims()[num_dims - 1];
+  int64_t num_dims = input->dims().size();
+  int64_t order = input->dims()[num_dims - 1];
 
   T* input_data = input->data<T>();
   int lda = std::max<int>(1, order);
@@ -144,7 +144,7 @@ void LapackEig(DenseTensor* input,
 
   int batch_count = BatchCount(*input);
   int matrix_stride = MatrixStride(*input);
-  int values_stride = values->dims()[values->dims().size() - 1];
+  int64_t values_stride = values->dims()[values->dims().size() - 1];
 
   DenseTensor rwork;
   phi::dtype::Real<T>* rwork_data = nullptr;
@@ -321,12 +321,17 @@ void ComputeBackwardForComplexInput(const DenseTensor& L,
   // Vh: matrix with shape [m,m]
   // rhs: rhs with shape [m,k]
   // x_grad: out
-  int m = Vh.dims()[Vh.dims().size() - 1];
-  int k = rhs.dims()[rhs.dims().size() - 1];
+  int64_t m = Vh.dims()[Vh.dims().size() - 1];
+  int64_t k = rhs.dims()[rhs.dims().size() - 1];
   auto* matrix_data = Vh.data<T>();
   auto* rhs_data = rhs.data<T>();
 
-  SolveLinearSystem<T>(matrix_data, rhs_data, x_grad_data, m, k, batch_count);
+  SolveLinearSystem<T>(matrix_data,
+                       rhs_data,
+                       x_grad_data,
+                       static_cast<int>(m),
+                       static_cast<int>(k),
+                       batch_count);
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/cpu/eig_kernel.cc
+++ b/paddle/phi/kernels/cpu/eig_kernel.cc
@@ -33,7 +33,7 @@ void EigKernel(const Context& dev_ctx,
     dev_ctx.template Alloc<phi::dtype::Complex<T>>(out_v);
 
     int batch_count = BatchCount(x);
-    int order = static_cast<int>(x.dims()[x.dims().size() - 1]);
+    int64_t order = x.dims()[x.dims().size() - 1];
 
     PADDLE_ENFORCE_LT(0,
                       order,
@@ -69,7 +69,7 @@ void EigKernel(const Context& dev_ctx,
     // 2. construct complex values
     auto* real_part_data = real_part.data<phi::dtype::Real<T>>();
     auto* imag_part_data = imag_part.data<phi::dtype::Real<T>>();
-    int out_w_numel = static_cast<int>(out_w->numel());
+    int64_t out_w_numel = static_cast<int64_t>(out_w->numel());
 
     phi::funcs::ForRange<Context> for_range(dev_ctx, out_w_numel);
     phi::funcs::RealImagToComplexFunctor<phi::dtype::Complex<T>> functor(

--- a/paddle/phi/kernels/cpu/eigvals_kernel.cc
+++ b/paddle/phi/kernels/cpu/eigvals_kernel.cc
@@ -184,7 +184,7 @@ void SpiltBatchSquareMatrix(const DenseTensor& input,
                             std::vector<DenseTensor>* output) {
   DDim input_dims = input.dims();
   int last_dim = input_dims.size() - 1;
-  int n_dim = static_cast<int>(input_dims[last_dim]);
+  int64_t n_dim = input_dims[last_dim];
 
   DDim flattened_input_dims, flattened_output_dims;
   if (input_dims.size() > 2) {

--- a/paddle/phi/kernels/cpu/fill_diagonal_tensor_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/fill_diagonal_tensor_grad_kernel.cc
@@ -33,7 +33,7 @@ void FillDiagonalTensorGradKernel(const Context& dev_ctx,
     auto* data = dev_ctx.template Alloc<T>(x_grad);
 
     auto dx_dims = x_grad->dims();
-    for (int i = 0; i < dx_dims.size(); i++) {
+    for (int64_t i = 0; i < dx_dims.size(); i++) {
       if (i != dim1 && i != dim2) {
         matrows *= static_cast<int>(dx_dims[i]);
       }

--- a/paddle/phi/kernels/cpu/fusion_seqpool_concat_kernel.cc
+++ b/paddle/phi/kernels/cpu/fusion_seqpool_concat_kernel.cc
@@ -40,7 +40,7 @@ void FusionSeqPoolConcatKernel(const Context& dev_ctx,
   out->set_lod(y_lod);
   T* y_data = dev_ctx.template Alloc<T>(out);
 
-  int w = static_cast<int>(ins[0]->numel() / x0_dims[0]);
+  int64_t w = static_cast<int64_t>(ins[0]->numel() / x0_dims[0]);
   PADDLE_ENFORCE_EQ(y_dims[1] % w,
                     0,
                     common::errors::InvalidArgument(

--- a/paddle/phi/kernels/cpu/generate_proposals_kernel.cc
+++ b/paddle/phi/kernels/cpu/generate_proposals_kernel.cc
@@ -79,7 +79,7 @@ void FilterBoxes(const phi::CPUContext& dev_ctx,
   T offset = pixel_offset ? static_cast<T>(1.0) : 0;
 
   int keep_len = 0;
-  for (int i = 0; i < boxes->dims()[0]; ++i) {
+  for (int64_t i = 0; i < boxes->dims()[0]; ++i) {
     T ws = boxes_data[4 * i + 2] - boxes_data[4 * i] + offset;
     T hs = boxes_data[4 * i + 3] - boxes_data[4 * i + 1] + offset;
     if (pixel_offset) {
@@ -191,7 +191,7 @@ std::pair<DenseTensor, DenseTensor> ProposalForOneImage(
   DenseTensor index_t;
   index_t.Resize(common::make_ddim({scores_slice.numel()}));
   int* index = dev_ctx.template Alloc<int>(&index_t);
-  for (int i = 0; i < scores_slice.numel(); ++i) {
+  for (int64_t i = 0; i < scores_slice.numel(); ++i) {
     index[i] = i;
   }
   auto compare = [scores_data](const int64_t& i, const int64_t& j) {

--- a/paddle/phi/kernels/cpu/graph_khop_sampler_kernel.cc
+++ b/paddle/phi/kernels/cpu/graph_khop_sampler_kernel.cc
@@ -231,7 +231,7 @@ void GraphKhopSamplerKernel(const Context& dev_ctx,
   const T* src_data = row.data<T>();
   const T* dst_count_data = col_ptr.data<T>();
   const T* p_vertices = x.data<T>();
-  int bs = static_cast<int>(x.dims()[0]);
+  int64_t bs = x.dims()[0];
   // 2. Get unique input nodes(X).
   std::vector<T> inputs(bs);
   std::copy(p_vertices, p_vertices + bs, inputs.begin());

--- a/paddle/phi/kernels/cpu/graph_reindex_kernel.cc
+++ b/paddle/phi/kernels/cpu/graph_reindex_kernel.cc
@@ -35,8 +35,8 @@ void GraphReindexKernel(const Context& dev_ctx,
   const T* x_data = x.data<T>();
   const T* neighbors_data = neighbors.data<T>();
   const int* count_data = count.data<int>();
-  const int bs = static_cast<int>(x.dims()[0]);
-  const int num_edges = static_cast<int>(neighbors.dims()[0]);
+  const int64_t bs = x.dims()[0];
+  const int64_t num_edges = neighbors.dims()[0];
 
   std::unordered_map<T, T> node_map;
   std::vector<T> unique_nodes;
@@ -63,9 +63,9 @@ void GraphReindexKernel(const Context& dev_ctx,
   }
   // Reindex Dst
   // Add support for multi-type edges reindex
-  int num_edge_types = static_cast<int>(count.dims()[0] / bs);
+  int64_t num_edge_types = static_cast<int64_t>(count.dims()[0] / bs);
   int cnt = 0;
-  for (int i = 0; i < num_edge_types; i++) {
+  for (int64_t i = 0; i < num_edge_types; i++) {
     for (int j = 0; j < bs; j++) {
       for (int k = 0; k < count_data[i * bs + j]; k++) {
         T node = x_data[j];

--- a/paddle/phi/kernels/cpu/graph_sample_neighbors_kernel.cc
+++ b/paddle/phi/kernels/cpu/graph_sample_neighbors_kernel.cc
@@ -178,7 +178,7 @@ void GraphSampleNeighborsKernel(
   const T* row_data = row.data<T>();
   const T* col_ptr_data = col_ptr.data<T>();
   const T* x_data = x.data<T>();
-  int bs = static_cast<int>(x.dims()[0]);
+  int64_t bs = x.dims()[0];
 
   std::vector<T> output;
   std::vector<int> output_count;

--- a/paddle/phi/kernels/cpu/grid_sample_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/grid_sample_grad_kernel.cc
@@ -154,9 +154,9 @@ static void CalcGridLocationsWithGrad(const CPUContext& dev_ctx,
                                       DenseTensor* grid_y,
                                       DenseTensor* grid_x_scale,
                                       DenseTensor* grid_y_scale) {
-  const int n = static_cast<int>(grid.dims()[0]);
-  const int out_h = static_cast<int>(grid.dims()[1]);
-  const int out_w = static_cast<int>(grid.dims()[2]);
+  const int64_t n = grid.dims()[0];
+  const int64_t out_h = grid.dims()[1];
+  const int64_t out_w = grid.dims()[2];
 
   // split grid with shape (n, h, w, 2) into (x, y) by the 3rd Dim
   grid_x->Resize({n, out_h, out_w});
@@ -193,10 +193,10 @@ static void Calc3DGridLocationsWithGrad(const CPUContext& dev_ctx,
                                         DenseTensor* grid_x_scale,
                                         DenseTensor* grid_y_scale,
                                         DenseTensor* grid_z_scale) {
-  const int n = static_cast<int>(grid.dims()[0]);
-  const int out_d = static_cast<int>(grid.dims()[1]);
-  const int out_h = static_cast<int>(grid.dims()[2]);
-  const int out_w = static_cast<int>(grid.dims()[3]);
+  const int64_t n = grid.dims()[0];
+  const int64_t out_d = grid.dims()[1];
+  const int64_t out_h = grid.dims()[2];
+  const int64_t out_w = grid.dims()[3];
 
   // split grid with shape (n, d, h, w, 3) into (x, y, z) by the 3rd Dim
   grid_x->Resize({n, out_d, out_h, out_w});
@@ -232,12 +232,12 @@ static void GatherOutputGradToInputGrad(const DenseTensor& output_grad,
                                         const DenseTensor& y,
                                         const DenseTensor& d1,
                                         const DenseTensor& d2) {
-  const int n = static_cast<int>(output_grad.dims()[0]);
-  const int c = static_cast<int>(output_grad.dims()[1]);
-  const int out_h = static_cast<int>(output_grad.dims()[2]);
-  const int out_w = static_cast<int>(output_grad.dims()[3]);
-  const int in_h = static_cast<int>(input_grad->dims()[2]);
-  const int in_w = static_cast<int>(input_grad->dims()[3]);
+  const int64_t n = output_grad.dims()[0];
+  const int64_t c = output_grad.dims()[1];
+  const int64_t out_h = output_grad.dims()[2];
+  const int64_t out_w = output_grad.dims()[3];
+  const int64_t in_h = input_grad->dims()[2];
+  const int64_t in_w = input_grad->dims()[3];
   auto x_t = EigenTensor<T, 3>::From(x);
   auto y_t = EigenTensor<T, 3>::From(y);
   auto d1_t = EigenTensor<T, 3>::From(d1);
@@ -274,14 +274,14 @@ static void Gather3DOutputGradToInputGrad(const DenseTensor& output_grad,
                                           const DenseTensor& d1,
                                           const DenseTensor& d2,
                                           const DenseTensor& d3) {
-  const int n = static_cast<int>(output_grad.dims()[0]);
-  const int c = static_cast<int>(output_grad.dims()[1]);
-  const int out_d = static_cast<int>(output_grad.dims()[2]);
-  const int out_h = static_cast<int>(output_grad.dims()[3]);
-  const int out_w = static_cast<int>(output_grad.dims()[4]);
-  const int in_d = static_cast<int>(input_grad->dims()[2]);
-  const int in_h = static_cast<int>(input_grad->dims()[3]);
-  const int in_w = static_cast<int>(input_grad->dims()[4]);
+  const int64_t n = output_grad.dims()[0];
+  const int64_t c = output_grad.dims()[1];
+  const int64_t out_d = output_grad.dims()[2];
+  const int64_t out_h = output_grad.dims()[3];
+  const int64_t out_w = output_grad.dims()[4];
+  const int64_t in_d = input_grad->dims()[2];
+  const int64_t in_h = input_grad->dims()[3];
+  const int64_t in_w = input_grad->dims()[4];
   auto x_t = EigenTensor<T, 4>::From(x);
   auto y_t = EigenTensor<T, 4>::From(y);
   auto z_t = EigenTensor<T, 4>::From(z);
@@ -327,10 +327,10 @@ static void GatherBilinearGrad(const CPUContext& dev_ctx,
                                DenseTensor* grid_y_scale,
                                DenseTensor* input_grad,
                                DenseTensor* grid_grad) {
-  const int n = static_cast<int>(grid_x->dims()[0]);
-  const int out_h = static_cast<int>(grid_x->dims()[1]);
-  const int out_w = static_cast<int>(grid_x->dims()[2]);
-  const int c = static_cast<int>(input.dims()[1]);
+  const int64_t n = grid_x->dims()[0];
+  const int64_t out_h = grid_x->dims()[1];
+  const int64_t out_w = grid_x->dims()[2];
+  const int64_t c = input.dims()[1];
 
   DenseTensor x_w, x_e, y_n, y_s;
   DenseTensor d_w, d_e, d_n, d_s;
@@ -429,11 +429,11 @@ static void Gather3DBilinearGrad(const CPUContext& dev_ctx,
                                  DenseTensor* grid_z_scale,
                                  DenseTensor* input_grad,
                                  DenseTensor* grid_grad) {
-  const int n = static_cast<int>(grid_x->dims()[0]);
-  const int out_d = static_cast<int>(grid_x->dims()[1]);
-  const int out_h = static_cast<int>(grid_x->dims()[2]);
-  const int out_w = static_cast<int>(grid_x->dims()[3]);
-  const int c = static_cast<int>(input.dims()[1]);
+  const int64_t n = grid_x->dims()[0];
+  const int64_t out_d = grid_x->dims()[1];
+  const int64_t out_h = grid_x->dims()[2];
+  const int64_t out_w = grid_x->dims()[3];
+  const int64_t c = input.dims()[1];
 
   DenseTensor x_w, x_e, y_n, y_s, z_t, z_b;
   DenseTensor d_w, d_e, d_n, d_s, d_t, d_b;
@@ -579,12 +579,12 @@ static void GatherOutputGradToInputGrad(const DenseTensor& output_grad,
                                         DenseTensor* input_grad,
                                         const DenseTensor& x,
                                         const DenseTensor& y) {
-  const int n = static_cast<int>(output_grad.dims()[0]);
-  const int c = static_cast<int>(output_grad.dims()[1]);
-  const int out_h = static_cast<int>(output_grad.dims()[2]);
-  const int out_w = static_cast<int>(output_grad.dims()[3]);
-  const int in_h = static_cast<int>(input_grad->dims()[2]);
-  const int in_w = static_cast<int>(input_grad->dims()[3]);
+  const int64_t n = output_grad.dims()[0];
+  const int64_t c = output_grad.dims()[1];
+  const int64_t out_h = output_grad.dims()[2];
+  const int64_t out_w = output_grad.dims()[3];
+  const int64_t in_h = input_grad->dims()[2];
+  const int64_t in_w = input_grad->dims()[3];
   auto x_t = EigenTensor<T, 3>::From(x);
   auto y_t = EigenTensor<T, 3>::From(y);
   auto input_grad_t = EigenTensor<T, 4>::From(*input_grad);
@@ -615,14 +615,14 @@ static void Gather3DOutputGradToInputGrad(const DenseTensor& output_grad,
                                           const DenseTensor& x,
                                           const DenseTensor& y,
                                           const DenseTensor& z) {
-  const int n = static_cast<int>(output_grad.dims()[0]);
-  const int c = static_cast<int>(output_grad.dims()[1]);
-  const int out_d = static_cast<int>(output_grad.dims()[2]);
-  const int out_h = static_cast<int>(output_grad.dims()[3]);
-  const int out_w = static_cast<int>(output_grad.dims()[4]);
-  const int in_d = static_cast<int>(input_grad->dims()[2]);
-  const int in_h = static_cast<int>(input_grad->dims()[3]);
-  const int in_w = static_cast<int>(input_grad->dims()[4]);
+  const int64_t n = output_grad.dims()[0];
+  const int64_t c = output_grad.dims()[1];
+  const int64_t out_d = output_grad.dims()[2];
+  const int64_t out_h = output_grad.dims()[3];
+  const int64_t out_w = output_grad.dims()[4];
+  const int64_t in_d = input_grad->dims()[2];
+  const int64_t in_h = input_grad->dims()[3];
+  const int64_t in_w = input_grad->dims()[4];
   auto x_t = EigenTensor<T, 4>::From(x);
   auto y_t = EigenTensor<T, 4>::From(y);
   auto z_t = EigenTensor<T, 4>::From(z);
@@ -686,12 +686,12 @@ void GridSampleGradKernel(const Context& dev_ctx,
   }
 
   if (x.dims().size() == 4) {
-    const int n = static_cast<int>(grid.dims()[0]);
-    const int out_h = static_cast<int>(grid.dims()[1]);
-    const int out_w = static_cast<int>(grid.dims()[2]);
-    const int c = static_cast<int>(x.dims()[1]);
-    const int in_h = static_cast<int>(x.dims()[2]);
-    const int in_w = static_cast<int>(x.dims()[3]);
+    const int64_t n = grid.dims()[0];
+    const int64_t out_h = grid.dims()[1];
+    const int64_t out_w = grid.dims()[2];
+    const int64_t c = x.dims()[1];
+    const int64_t in_h = x.dims()[2];
+    const int64_t in_w = x.dims()[3];
 
     x_grad->Resize({n, c, in_h, in_w});
     dev_ctx.template Alloc<T>(x_grad);
@@ -731,14 +731,14 @@ void GridSampleGradKernel(const Context& dev_ctx,
                             grid_grad);
     }
   } else {
-    const int n = static_cast<int>(grid.dims()[0]);
-    const int out_d = static_cast<int>(grid.dims()[1]);
-    const int out_h = static_cast<int>(grid.dims()[2]);
-    const int out_w = static_cast<int>(grid.dims()[3]);
-    const int c = static_cast<int>(x.dims()[1]);
-    const int in_d = static_cast<int>(x.dims()[2]);
-    const int in_h = static_cast<int>(x.dims()[3]);
-    const int in_w = static_cast<int>(x.dims()[4]);
+    const int64_t n = grid.dims()[0];
+    const int64_t out_d = grid.dims()[1];
+    const int64_t out_h = grid.dims()[2];
+    const int64_t out_w = grid.dims()[3];
+    const int64_t c = x.dims()[1];
+    const int64_t in_d = x.dims()[2];
+    const int64_t in_h = x.dims()[3];
+    const int64_t in_w = x.dims()[4];
 
     x_grad->Resize({n, c, in_d, in_h, in_w});
     dev_ctx.template Alloc<T>(x_grad);

--- a/paddle/phi/kernels/cpu/grid_sample_kernel.cc
+++ b/paddle/phi/kernels/cpu/grid_sample_kernel.cc
@@ -97,9 +97,9 @@ static void CalcGridLocations(const CPUContext& dev_ctx,
                               std::string padding_mode,
                               DenseTensor* grid_x,
                               DenseTensor* grid_y) {
-  const int n = static_cast<int>(grid.dims()[0]);
-  const int out_h = static_cast<int>(grid.dims()[1]);
-  const int out_w = static_cast<int>(grid.dims()[2]);
+  const int64_t n = grid.dims()[0];
+  const int64_t out_h = grid.dims()[1];
+  const int64_t out_w = grid.dims()[2];
 
   // split grid with shape (n, h, w, 2) into (x, y) by the 3rd Dim
   grid_x->Resize({n, out_h, out_w});
@@ -130,10 +130,10 @@ static void Calc3DGridLocations(const CPUContext& dev_ctx,
                                 DenseTensor* grid_x,
                                 DenseTensor* grid_y,
                                 DenseTensor* grid_z) {
-  const int n = static_cast<int>(grid.dims()[0]);
-  const int out_d = static_cast<int>(grid.dims()[1]);
-  const int out_h = static_cast<int>(grid.dims()[2]);
-  const int out_w = static_cast<int>(grid.dims()[3]);
+  const int64_t n = grid.dims()[0];
+  const int64_t out_d = grid.dims()[1];
+  const int64_t out_h = grid.dims()[2];
+  const int64_t out_w = grid.dims()[3];
 
   // split grid with shape (n, d, h, w, 3) into (x, y, z) by the 3rd Dim
   grid_x->Resize({n, out_d, out_h, out_w});
@@ -165,10 +165,10 @@ static void BilinearInter(const CPUContext& dev_ctx,
                           DenseTensor* grid_y,
                           DenseTensor* out) {
   auto& place = *dev_ctx.eigen_device();
-  const int n = static_cast<int>(grid_x->dims()[0]);
-  const int out_h = static_cast<int>(grid_x->dims()[1]);
-  const int out_w = static_cast<int>(grid_x->dims()[2]);
-  const int c = static_cast<int>(input.dims()[1]);
+  const int64_t n = grid_x->dims()[0];
+  const int64_t out_h = grid_x->dims()[1];
+  const int64_t out_w = grid_x->dims()[2];
+  const int64_t c = input.dims()[1];
 
   DenseTensor x_w, x_e, y_n, y_s;
   DenseTensor d_w, d_e, d_n, d_s;
@@ -224,11 +224,11 @@ static void Bilinear3DInter(const CPUContext& dev_ctx,
                             DenseTensor* grid_z,
                             DenseTensor* out) {
   auto& place = *dev_ctx.eigen_device();
-  const int n = static_cast<int>(grid_x->dims()[0]);
-  const int out_d = static_cast<int>(grid_x->dims()[1]);
-  const int out_h = static_cast<int>(grid_x->dims()[2]);
-  const int out_w = static_cast<int>(grid_x->dims()[3]);
-  const int c = static_cast<int>(input.dims()[1]);
+  const int64_t n = grid_x->dims()[0];
+  const int64_t out_d = grid_x->dims()[1];
+  const int64_t out_h = grid_x->dims()[2];
+  const int64_t out_w = grid_x->dims()[3];
+  const int64_t c = input.dims()[1];
 
   // get corner pixel values from (x, y, z)
   // for 4d, we used north-east-south-west
@@ -325,12 +325,12 @@ void GridSampleKernel(const Context& dev_ctx,
   }
 
   if (x.dims().size() == 4) {
-    const int n = static_cast<int>(grid.dims()[0]);
-    const int out_h = static_cast<int>(grid.dims()[1]);
-    const int out_w = static_cast<int>(grid.dims()[2]);
-    const int c = static_cast<int>(x.dims()[1]);
-    const int in_h = static_cast<int>(x.dims()[2]);
-    const int in_w = static_cast<int>(x.dims()[3]);
+    const int64_t n = grid.dims()[0];
+    const int64_t out_h = grid.dims()[1];
+    const int64_t out_w = grid.dims()[2];
+    const int64_t c = x.dims()[1];
+    const int64_t in_h = x.dims()[2];
+    const int64_t in_w = x.dims()[3];
 
     out->Resize(common::make_ddim({n, c, out_h, out_w}));
     dev_ctx.template Alloc<T>(out);
@@ -352,14 +352,14 @@ void GridSampleKernel(const Context& dev_ctx,
       GetGridPointValue_nearest<T>(x, out, grid_x, grid_y);
     }
   } else {
-    const int n = static_cast<int>(grid.dims()[0]);
-    const int out_d = static_cast<int>(grid.dims()[1]);
-    const int out_h = static_cast<int>(grid.dims()[2]);
-    const int out_w = static_cast<int>(grid.dims()[3]);
-    const int c = static_cast<int>(x.dims()[1]);
-    const int in_d = static_cast<int>(x.dims()[2]);
-    const int in_h = static_cast<int>(x.dims()[3]);
-    const int in_w = static_cast<int>(x.dims()[4]);
+    const int64_t n = grid.dims()[0];
+    const int64_t out_d = grid.dims()[1];
+    const int64_t out_h = grid.dims()[2];
+    const int64_t out_w = grid.dims()[3];
+    const int64_t c = x.dims()[1];
+    const int64_t in_d = x.dims()[2];
+    const int64_t in_h = x.dims()[3];
+    const int64_t in_w = x.dims()[4];
 
     out->Resize(common::make_ddim({n, c, out_d, out_h, out_w}));
     dev_ctx.template Alloc<T>(out);

--- a/paddle/phi/kernels/cpu/grid_sample_utils.h
+++ b/paddle/phi/kernels/cpu/grid_sample_utils.h
@@ -75,12 +75,12 @@ void GetGridPointValue(const DenseTensor& input,
                        DenseTensor* output,
                        const DenseTensor& x,
                        const DenseTensor& y) {
-  const int n = input.dims()[0];
-  const int c = input.dims()[1];
-  const int in_h = input.dims()[2];
-  const int in_w = input.dims()[3];
-  const int out_h = x.dims()[1];
-  const int out_w = x.dims()[2];
+  const int64_t n = input.dims()[0];
+  const int64_t c = input.dims()[1];
+  const int64_t in_h = input.dims()[2];
+  const int64_t in_w = input.dims()[3];
+  const int64_t out_h = x.dims()[1];
+  const int64_t out_w = x.dims()[2];
   auto x_t = EigenTensor<T, 3>::From(x);
   auto y_t = EigenTensor<T, 3>::From(y);
   auto output_t = EigenTensor<T, 4>::From(*output).setConstant((T)0);
@@ -110,12 +110,12 @@ void GetGridPointValue_nearest(const DenseTensor& input,
                                DenseTensor* output,
                                const DenseTensor& x,
                                const DenseTensor& y) {
-  const int n = input.dims()[0];
-  const int c = input.dims()[1];
-  const int in_h = input.dims()[2];
-  const int in_w = input.dims()[3];
-  const int out_h = x.dims()[1];
-  const int out_w = x.dims()[2];
+  const int64_t n = input.dims()[0];
+  const int64_t c = input.dims()[1];
+  const int64_t in_h = input.dims()[2];
+  const int64_t in_w = input.dims()[3];
+  const int64_t out_h = x.dims()[1];
+  const int64_t out_w = x.dims()[2];
   auto x_t = EigenTensor<T, 3>::From(x);
   auto y_t = EigenTensor<T, 3>::From(y);
   auto output_t = EigenTensor<T, 4>::From(*output).setConstant((T)0);
@@ -160,10 +160,10 @@ void AllNeighbors(const CPUContext& dev_ctx,
                   DenseTensor* v_es) {  // values
   auto& place = *dev_ctx.eigen_device();
 
-  const int c = input.dims()[1];
-  const int n = grid_x->dims()[0];
-  const int out_h = grid_x->dims()[1];
-  const int out_w = grid_x->dims()[2];
+  const int64_t c = input.dims()[1];
+  const int64_t n = grid_x->dims()[0];
+  const int64_t out_h = grid_x->dims()[1];
+  const int64_t out_w = grid_x->dims()[2];
   // calculate coords of 4 corner points
   x_w->Resize({n, out_h, out_w});
   x_e->Resize({n, out_h, out_w});
@@ -225,14 +225,14 @@ void Get3DGridPointValue(const DenseTensor& input,
                          const DenseTensor& x,
                          const DenseTensor& y,
                          const DenseTensor& z) {
-  const int n = input.dims()[0];
-  const int c = input.dims()[1];
-  const int in_d = input.dims()[2];
-  const int in_h = input.dims()[3];
-  const int in_w = input.dims()[4];
-  const int out_d = x.dims()[1];
-  const int out_h = x.dims()[2];
-  const int out_w = x.dims()[3];
+  const int64_t n = input.dims()[0];
+  const int64_t c = input.dims()[1];
+  const int64_t in_d = input.dims()[2];
+  const int64_t in_h = input.dims()[3];
+  const int64_t in_w = input.dims()[4];
+  const int64_t out_d = x.dims()[1];
+  const int64_t out_h = x.dims()[2];
+  const int64_t out_w = x.dims()[3];
   auto x_t = EigenTensor<T, 4>::From(x);
   auto y_t = EigenTensor<T, 4>::From(y);
   auto z_t = EigenTensor<T, 4>::From(z);
@@ -271,14 +271,14 @@ void Get3DGridPointValue_nearest(const DenseTensor& input,
                                  const DenseTensor& x,
                                  const DenseTensor& y,
                                  const DenseTensor& z) {
-  const int n = input.dims()[0];
-  const int c = input.dims()[1];
-  const int in_d = input.dims()[2];
-  const int in_h = input.dims()[3];
-  const int in_w = input.dims()[4];
-  const int out_d = x.dims()[1];
-  const int out_h = x.dims()[2];
-  const int out_w = x.dims()[3];
+  const int64_t n = input.dims()[0];
+  const int64_t c = input.dims()[1];
+  const int64_t in_d = input.dims()[2];
+  const int64_t in_h = input.dims()[3];
+  const int64_t in_w = input.dims()[4];
+  const int64_t out_d = x.dims()[1];
+  const int64_t out_h = x.dims()[2];
+  const int64_t out_w = x.dims()[3];
   auto x_t = EigenTensor<T, 4>::From(x);
   auto y_t = EigenTensor<T, 4>::From(y);
   auto z_t = EigenTensor<T, 4>::From(z);
@@ -340,11 +340,11 @@ void All3DNeighbors(const CPUContext& dev_ctx,
                     DenseTensor* v_bes) {  // values
   auto& place = *dev_ctx.eigen_device();
 
-  const int c = input.dims()[1];
-  const int n = grid_x->dims()[0];
-  const int out_d = grid_x->dims()[1];
-  const int out_h = grid_x->dims()[2];
-  const int out_w = grid_x->dims()[3];
+  const int64_t c = input.dims()[1];
+  const int64_t n = grid_x->dims()[0];
+  const int64_t out_d = grid_x->dims()[1];
+  const int64_t out_h = grid_x->dims()[2];
+  const int64_t out_w = grid_x->dims()[3];
   // calculate coords of 6 corner points
   x_w->Resize({n, out_d, out_h, out_w});
   x_e->Resize({n, out_d, out_h, out_w});

--- a/paddle/phi/kernels/cpu/group_norm_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/group_norm_grad_kernel.cc
@@ -71,7 +71,7 @@ void GroupNormGradKernel(const Context& dev_ctx,
   const auto scale_ptr = scale.get_ptr();
   const auto bias_ptr = bias.get_ptr();
   const auto& x_dims = y.dims();
-  const int C = static_cast<int>(
+  const int64_t C = static_cast<int64_t>(
       data_layout == DataLayout::kNCHW ? x_dims[1] : x_dims[x_dims.size() - 1]);
   const int group_size = C / groups;
 
@@ -119,7 +119,7 @@ void GroupNormGradKernel(const Context& dev_ctx,
   auto* iter_x_data = x_data;
   auto* iter_d_x_data = d_x_data;
   auto* iter_y_data = y_data;
-  for (int bid = 0; bid < x_dims[0]; bid++) {
+  for (int64_t bid = 0; bid < x_dims[0]; bid++) {
     for (int gid = 0; gid < groups; gid++) {
       T x_var = var_data[bid * groups + gid];
       T var_inv = 1.0 / sqrt(x_var + epsilon);

--- a/paddle/phi/kernels/cpu/group_norm_kernel.cc
+++ b/paddle/phi/kernels/cpu/group_norm_kernel.cc
@@ -59,7 +59,7 @@ void GroupNormKernel(const Context& dev_ctx,
   const auto bias_ptr = bias.get_ptr();
 
   const auto x_dims = x.dims();
-  const int C = static_cast<int>(
+  const int64_t C = static_cast<int64_t>(
       data_layout == DataLayout::kNCHW ? x_dims[1] : x_dims[x_dims.size() - 1]);
   const int group_size = C / groups;
 
@@ -89,7 +89,7 @@ void GroupNormKernel(const Context& dev_ctx,
   }
   auto* iter_x_data = x_data;
   auto* iter_y_data = y_data;
-  for (int bid = 0; bid < x_dims[0]; bid++) {
+  for (int64_t bid = 0; bid < x_dims[0]; bid++) {
     for (int gid = 0; gid < groups; gid++) {
       const int64_t M = 8;
       std::array<T, M> x_mean_arr;

--- a/paddle/phi/kernels/cpu/gru_kernel.cc
+++ b/paddle/phi/kernels/cpu/gru_kernel.cc
@@ -77,7 +77,7 @@ void GRUCPUKernel(const Context &dev_ctx,
     add_bias(dev_ctx, *batch_gate, bias.get(), batch_gate);
   }
 
-  int frame_size = static_cast<int>(hidden_dims[1]);
+  int64_t frame_size = hidden_dims[1];
   phi::funcs::GRUMetaValue<T> gru_value;
   gru_value.gate_weight = const_cast<T *>(weight_data);
   gru_value.state_weight =

--- a/paddle/phi/kernels/cpu/instance_norm_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/instance_norm_grad_kernel.cc
@@ -69,10 +69,10 @@ void InstanceNormGradKernel(const Context& dev_ctx,
 
   const auto& x_dims = x.dims();
 
-  const int N = static_cast<int>(x_dims[0]);
-  const int C = static_cast<int>(x_dims[1]);
+  const int64_t N = x_dims[0];
+  const int64_t C = x_dims[1];
   const int NxC = N * C;
-  const int sample_size = static_cast<int>(x.numel() / N / C);
+  const int64_t sample_size = static_cast<int64_t>(x.numel() / N / C);
 
   auto* place = dev_ctx.eigen_device();
 
@@ -183,7 +183,7 @@ void InstanceNormDoubleGradKernel(const Context& dev_ctx,
   const auto& x_dims = x.dims();
   int N = 0, C = 0, H = 0, W = 0, D = 0;
   funcs::ExtractNCWHD(x_dims, DataLayout::kNCHW, &N, &C, &H, &W, &D);
-  const int sample_size = static_cast<int>(x.numel() / N / C);
+  const int64_t sample_size = static_cast<int64_t>(x.numel() / N / C);
   const int NxC = N * C;
 
   const T* mean_data = saved_mean.data<T>();

--- a/paddle/phi/kernels/cpu/instance_norm_kernel.cc
+++ b/paddle/phi/kernels/cpu/instance_norm_kernel.cc
@@ -56,10 +56,10 @@ void InstanceNormKernel(const Context& dev_ctx,
 
   const auto& x_dims = x.dims();
   T epsilon = static_cast<T>(epsilon_f);
-  const int N = static_cast<int>(x_dims[0]);
-  const int C = static_cast<int>(x_dims[1]);
+  const int64_t N = x_dims[0];
+  const int64_t C = x_dims[1];
   const int NxC = N * C;
-  const int sample_size = static_cast<int>(x.numel() / N / C);
+  const int64_t sample_size = static_cast<int64_t>(x.numel() / N / C);
   auto* place = dev_ctx.eigen_device();
 
   Eigen::DSizes<int, 2> shape(NxC, sample_size);

--- a/paddle/phi/kernels/cpu/log_softmax_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/log_softmax_grad_kernel.cc
@@ -38,15 +38,15 @@ struct LogSoftmaxGradFunctor {
     constexpr int kBatchDim = 0;
     constexpr int kClassDim = 1;
 
-    const int n = funcs::SizeToAxis(axis, Y->dims());
-    const int d = funcs::SizeFromAxis(axis, Y->dims());
+    const int64_t n = funcs::SizeToAxis(axis, Y->dims());
+    const int64_t d = funcs::SizeFromAxis(axis, Y->dims());
     phi::DDim dim_2d{n, d};
 
     auto y = EigenMatrixTemplate<T>::From(*Y, dim_2d);
     auto dy = EigenMatrixTemplate<T>::From(*dY, dim_2d);
     auto dx = EigenMatrixTemplate<T>::From(*dX, dim_2d);
 
-    const int axis_dim = static_cast<int>(Y->dims()[axis]);
+    const int64_t axis_dim = Y->dims()[axis];
     const int batch_size = y.dimension(kBatchDim);
     const int num_classes = y.dimension(kClassDim);
     const int num_remain = num_classes / axis_dim;

--- a/paddle/phi/kernels/cpu/log_softmax_kernel.cc
+++ b/paddle/phi/kernels/cpu/log_softmax_kernel.cc
@@ -46,9 +46,9 @@ struct LogSoftmaxFunctor {
     constexpr int kClassDim = 1;
     constexpr int kAxisDim = 1;
 
-    int axis_dim = static_cast<int>(X->dims()[axis]);
-    const int n = funcs::SizeToAxis(axis, X->dims());
-    const int d = funcs::SizeFromAxis(axis, X->dims());
+    int64_t axis_dim = X->dims()[axis];
+    const int64_t n = funcs::SizeToAxis(axis, X->dims());
+    const int64_t d = funcs::SizeFromAxis(axis, X->dims());
     phi::DDim dim_2d{n, d};
 
     auto logits = EigenMatrixTemplate<T>::From(*X, dim_2d);

--- a/paddle/phi/kernels/cpu/lrn_kernel.cc
+++ b/paddle/phi/kernels/cpu/lrn_kernel.cc
@@ -76,7 +76,7 @@ struct LRNFunctor<phi::CPUContext, T> {
     squared.Resize({1, C + n - 1, H, W});
     T* sdata = dev_ctx.Alloc<T>(&squared);
     std::memset(sdata, 0, sizeof(T) * squared.numel());
-    for (int i = 0; i < mid->numel(); ++i) {
+    for (int64_t i = 0; i < mid->numel(); ++i) {
       mdata[i] = k;
     }
     int img_size = H * W;

--- a/paddle/phi/kernels/cpu/lstsq_kernel.cc
+++ b/paddle/phi/kernels/cpu/lstsq_kernel.cc
@@ -83,9 +83,28 @@ void LstsqKernel(const Context& dev_ctx,
   // lapack is a column-major storage, transpose make the input to
   // have a continuous memory layout
   int info = 0;
-  int m = static_cast<int>(x_dims[dim_size - 2]);
-  int n = static_cast<int>(x_dims[dim_size - 1]);
-  int nrhs = static_cast<int>(y_dims[dim_size - 1]);
+  int64_t m_64 = x_dims[dim_size - 2];
+  int64_t n_64 = x_dims[dim_size - 1];
+  int64_t nrhs_64 = y_dims[dim_size - 1];
+
+  // LAPACK uses int parameters, check for overflow
+  PADDLE_ENFORCE_LE(m_64,
+                    std::numeric_limits<int>::max(),
+                    common::errors::InvalidArgument(
+                        "The matrix row dimension exceeds LAPACK int limit."));
+  PADDLE_ENFORCE_LE(
+      n_64,
+      std::numeric_limits<int>::max(),
+      common::errors::InvalidArgument(
+          "The matrix column dimension exceeds LAPACK int limit."));
+  PADDLE_ENFORCE_LE(nrhs_64,
+                    std::numeric_limits<int>::max(),
+                    common::errors::InvalidArgument(
+                        "The number of RHS exceeds LAPACK int limit."));
+
+  int m = static_cast<int>(m_64);
+  int n = static_cast<int>(n_64);
+  int nrhs = static_cast<int>(nrhs_64);
   int lda = std::max<int>(m, 1);
   int ldb = std::max<int>(1, std::max(m, n));
 

--- a/paddle/phi/kernels/cpu/lu_kernel.cc
+++ b/paddle/phi/kernels/cpu/lu_kernel.cc
@@ -55,8 +55,21 @@ void LUKernel(const Context& dev_ctx,
   auto outdims = out->dims();
   auto outrank = outdims.size();
 
-  int m = static_cast<int>(outdims[outrank - 1]);
-  int n = static_cast<int>(outdims[outrank - 2]);
+  int64_t m_64 = outdims[outrank - 1];
+  int64_t n_64 = outdims[outrank - 2];
+
+  // LAPACK uses int parameters, check for overflow
+  PADDLE_ENFORCE_LE(m_64,
+                    std::numeric_limits<int>::max(),
+                    common::errors::InvalidArgument(
+                        "The matrix dimension m exceeds LAPACK int limit."));
+  PADDLE_ENFORCE_LE(n_64,
+                    std::numeric_limits<int>::max(),
+                    common::errors::InvalidArgument(
+                        "The matrix dimension n exceeds LAPACK int limit."));
+
+  int m = static_cast<int>(m_64);
+  int n = static_cast<int>(n_64);
   int lda = std::max(1, m);
 
   auto ipiv_dims = common::slice_ddim(outdims, 0, outrank - 1);

--- a/paddle/phi/kernels/cpu/lu_solve_kernel.cc
+++ b/paddle/phi/kernels/cpu/lu_solve_kernel.cc
@@ -40,8 +40,8 @@ void LuSolveKernel(const Context& dev_ctx,
 
   // Prepare LAPACK parameters
   char trans_char = (trans == "N") ? 'N' : ((trans == "T") ? 'T' : 'C');
-  int n_int = lu_dims[lu_dims.size() - 1];
-  int nrhs_int = x_dims[x_dims.size() - 1];
+  int64_t n_int = lu_dims[lu_dims.size() - 1];
+  int64_t nrhs_int = x_dims[x_dims.size() - 1];
   int lda = std::max(1, n_int);  // Leading dimension of A (LU matrix)
   int ldb = std::max(1, n_int);  // Leading dimension of B (RHS/solution matrix)
   int info = 0;

--- a/paddle/phi/kernels/cpu/masked_fill_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/masked_fill_grad_kernel.cc
@@ -96,7 +96,7 @@ void MaskedFillGradKernel(const Context& dev_ctx,
       x_grad_tmp = &x_grad_expand;
     }
     auto* dx = x_grad_tmp->data<T>();
-    for (int i = 0; i < numel; i++) {
+    for (int64_t i = 0; i < numel; i++) {
       dx[i] = mask_data[i] ? T{} : dout[i];
     }
 
@@ -117,13 +117,13 @@ void MaskedFillGradKernel(const Context& dev_ctx,
     auto* dv = value_grad_tmp->data<T>();
     if (v_grad->numel() == 1) {
       dv[0] = 0;
-      for (int i = 0; i < numel; i++) {
+      for (int64_t i = 0; i < numel; i++) {
         if (mask_data[i]) {
           dv[0] += dout[i];
         }
       }
     } else {
-      for (int i = 0; i < numel; i++) {
+      for (int64_t i = 0; i < numel; i++) {
         if (mask_data[i]) {
           dv[i] = dout[i];
         }

--- a/paddle/phi/kernels/cpu/masked_select_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/masked_select_grad_kernel.cc
@@ -64,7 +64,7 @@ void MaskedSelectGradKernel(const Context& dev_ctx,
 
   auto* mask_data = mask_expand.data<bool>();
   auto* input_data = out_grad.data<T>();
-  int mask_size = static_cast<int>(mask_expand.numel());
+  int64_t mask_size = static_cast<int64_t>(mask_expand.numel());
 
   int index = 0;
   for (int i = 0; i < mask_size; i++) {

--- a/paddle/phi/kernels/cpu/matrix_nms_kernel.cc
+++ b/paddle/phi/kernels/cpu/matrix_nms_kernel.cc
@@ -234,7 +234,7 @@ size_t MultiClassMatrixNMS(const DenseTensor& scores,
     (*indices).push_back(start + idx);
     (*out).push_back(cls);
     (*out).push_back(score);
-    for (int j = 0; j < bboxes.dims()[1]; j++) {
+    for (int64_t j = 0; j < bboxes.dims()[1]; j++) {
       (*out).push_back(bbox[j]);
     }
   }
@@ -277,7 +277,7 @@ void MatrixNMSKernel(const Context& dev_ctx,
     scores_slice.Resize({score_dims[1], score_dims[2]});
     boxes_slice = bboxes.Slice(i, i + 1);
     boxes_slice.Resize({score_dims[2], box_dim});
-    int start = i * score_dims[2];
+    int64_t start = i * score_dims[2];
     num_out = MultiClassMatrixNMS(scores_slice,
                                   boxes_slice,
                                   &detections,

--- a/paddle/phi/kernels/cpu/matrix_rank_tol_kernel.cc
+++ b/paddle/phi/kernels/cpu/matrix_rank_tol_kernel.cc
@@ -112,7 +112,7 @@ void MatrixRankTolKernel(const Context& dev_ctx,
     return;
   }
   int k = std::min(rows, cols);
-  int batches = static_cast<int>(x.numel() / (rows * cols));
+  int64_t batches = static_cast<int64_t>(x.numel() / (rows * cols));
 
   RealType rtol_T = 0;
 
@@ -221,7 +221,7 @@ void MatrixRankAtolRtolKernel(const Context& dev_ctx,
     return;
   }
   int k = std::min(rows, cols);
-  int batches = static_cast<int>(x.numel() / (rows * cols));
+  int64_t batches = static_cast<int64_t>(x.numel() / (rows * cols));
 
   DenseTensor eigenvalue_tensor;
   eigenvalue_tensor.Resize(detail::GetEigenvalueDim(dim_x, k));

--- a/paddle/phi/kernels/cpu/median_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/median_grad_kernel.cc
@@ -99,7 +99,7 @@ void CalcMedianGradKernel_CPU(const Context& dev_ctx,
   int64_t numel = x.numel();
   auto x_dim = x.dims();
   int64_t rank = x_dim.size();
-  int64_t stride = x_dim[static_cast<int>(rank - 1)];
+  int64_t stride = x_dim[rank - 1];
   int64_t pre_dim = numel / stride;
   if (!evenly) {
     CalcMedianMinGrad(pre_dim, stride, m_index, dx_data, dout_data);

--- a/paddle/phi/kernels/cpu/median_kernel.cc
+++ b/paddle/phi/kernels/cpu/median_kernel.cc
@@ -159,7 +159,7 @@ void ProcessMedianKernel(const Context& dev_ctx,
   int64_t numel = x.numel();
   auto x_dim = x.dims();
   int64_t x_rank = x_dim.size();
-  int64_t stride = x_dim[static_cast<int>(x_rank - 1)];
+  int64_t stride = x_dim[x_rank - 1];
 
   PADDLE_ENFORCE_NE(stride,
                     0,

--- a/paddle/phi/kernels/cpu/mode_kernel.cc
+++ b/paddle/phi/kernels/cpu/mode_kernel.cc
@@ -29,7 +29,7 @@ void ModeKernel(const Context& dev_ctx,
                 DenseTensor* out,
                 DenseTensor* indices) {
   const auto& in_dims = x.dims();
-  for (int i = 0; i < in_dims.size(); i++) {
+  for (int64_t i = 0; i < in_dims.size(); i++) {
     PADDLE_ENFORCE_LE(
         0,
         in_dims[i],

--- a/paddle/phi/kernels/cpu/multiclass_nms3_kernel.cc
+++ b/paddle/phi/kernels/cpu/multiclass_nms3_kernel.cc
@@ -246,7 +246,7 @@ inline std::vector<size_t> GetNmsLodFromRoisNum(const DenseTensor* rois_num) {
   } else if (rois_num->dtype() == phi::DataType::INT32) {
     auto* rois_num_data = rois_num->data<int>();
     rois_lod.push_back(static_cast<size_t>(0));
-    for (int i = 0; i < rois_num->numel(); ++i) {
+    for (int64_t i = 0; i < rois_num->numel(); ++i) {
       rois_lod.push_back(rois_lod.back() +
                          static_cast<size_t>(rois_num_data[i]));
     }
@@ -262,9 +262,9 @@ void SliceOneClass(const Context& dev_ctx,
   T* item_data = dev_ctx.template Alloc<T>(one_class_item);
   const T* items_data = items.data<T>();
   const int64_t num_item = items.dims()[0];
-  const int class_num = static_cast<int>(items.dims()[1]);
+  const int64_t class_num = items.dims()[1];
   if (items.dims().size() == 3) {
-    int item_size = static_cast<int>(items.dims()[2]);
+    int64_t item_size = items.dims()[2];
     for (int i = 0; i < num_item; ++i) {
       std::memcpy(item_data + i * item_size,
                   items_data + i * class_num * item_size + class_id * item_size,

--- a/paddle/phi/kernels/cpu/nanmedian_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/nanmedian_grad_kernel.cc
@@ -99,7 +99,7 @@ void CalcNanMedianGradKernel_CPU(const Context& dev_ctx,
   int64_t numel = x.numel();
   auto x_dim = x.dims();
   int64_t rank = x_dim.size();
-  int64_t stride = x_dim[static_cast<int>(rank - 1)];
+  int64_t stride = x_dim[rank - 1];
   int64_t pre_dim = numel / stride;
   if (!evenly) {
     CalcNanMedianMinGrad(pre_dim, stride, m_index, dx_data, dout_data);

--- a/paddle/phi/kernels/cpu/nanmedian_kernel.cc
+++ b/paddle/phi/kernels/cpu/nanmedian_kernel.cc
@@ -159,7 +159,7 @@ void ProcessMedianKernel(const Context& dev_ctx,
   int64_t numel = x.numel();
   auto x_dim = x.dims();
   int64_t x_rank = x_dim.size();
-  int64_t stride = x_dim[static_cast<int>(x_rank - 1)];
+  int64_t stride = x_dim[x_rank - 1];
 
   PADDLE_ENFORCE_NE(stride,
                     0,

--- a/paddle/phi/kernels/cpu/nce_kernel.cc
+++ b/paddle/phi/kernels/cpu/nce_kernel.cc
@@ -43,7 +43,7 @@ static void inline PrepareSamples(const Context &dev_ctx,
   auto sample_labels_dims = sample_labels->dims();
   int64_t *sample_labels_data = dev_ctx.template Alloc<int64_t>(sample_labels);
 
-  int num_label = label_dims.size() == 2 ? label_dims[1] : 1;
+  int64_t num_label = label_dims.size() == 2 ? label_dims[1] : 1;
   int index = 0;
   for (int64_t i = 0; i < label_dims[0]; ++i) {
     int j = 0;
@@ -159,7 +159,7 @@ void NCEKernel(const Context &dev_ctx,
   phi::DenseTensor sample_labels_tmp, sample_out_tmp;
   if (is_test) {
     // set dims of output(SampleOut)
-    int num_true_classes = label->dims().size() == 2 ? label->dims()[1] : 1;
+    int64_t num_true_classes = label->dims().size() == 2 ? label->dims()[1] : 1;
     sample_out_dims.push_back(input_in.dims()[0]);
     sample_out_dims.push_back(
         (num_true_classes == -1) ? -1 : (num_neg_samples + num_true_classes));
@@ -178,7 +178,7 @@ void NCEKernel(const Context &dev_ctx,
       dev_ctx, sampler, sample_labels, label_in, custom_neg_classes);
   const int64_t *sample_labels_data = sample_labels->data<int64_t>();
 
-  for (int x = 0; x < sample_labels->numel(); x++) {
+  for (int64_t x = 0; x < sample_labels->numel(); x++) {
     PADDLE_ENFORCE_GE(sample_labels_data[x],
                       0,
                       common::errors::InvalidArgument(

--- a/paddle/phi/kernels/cpu/one_hot_kernel.cc
+++ b/paddle/phi/kernels/cpu/one_hot_kernel.cc
@@ -40,7 +40,7 @@ struct OneHotV2OpFunctor {
     auto* p_out_data = dev_ctx_.template Alloc<OutT>(out_);
     funcs::set_constant(dev_ctx_, out_, static_cast<OutT>(0.0));
 
-    for (int i = 0; i < numel; ++i) {
+    for (int64_t i = 0; i < numel; ++i) {
       PADDLE_ENFORCE_GE(
           p_in_data[i],
           0,
@@ -79,7 +79,7 @@ void OneHotKernel(const Context& dev_ctx,
   auto* p_out_data = dev_ctx.template Alloc<float>(out);
   funcs::set_constant(dev_ctx, out, 0.0f);
 
-  for (int i = 0; i < numel; ++i) {
+  for (int64_t i = 0; i < numel; ++i) {
     PADDLE_ENFORCE_GE(
         p_in_data[i],
         0,

--- a/paddle/phi/kernels/cpu/overlap_add_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/overlap_add_grad_kernel.cc
@@ -79,7 +79,7 @@ void OverlapAddGradKernel(const Context& dev_ctx,
 
       std::vector<int> perm_x_grad{1, 0};
       auto x_grad_dims_vec = common::vectorize(x_grad->dims());
-      for (int i = 0; i < x_grad->dims().size(); ++i) {
+      for (int64_t i = 0; i < x_grad->dims().size(); ++i) {
         x_grad_dims_vec[i] = x_grad->dims()[perm_x_grad[i]];
       }
       trans_x_grad.Resize(common::make_ddim(x_grad_dims_vec));
@@ -99,7 +99,7 @@ void OverlapAddGradKernel(const Context& dev_ctx,
 
       std::vector<int> perm_x_grad{2, 1, 0};
       auto x_grad_dims_vec = common::vectorize(x_grad->dims());
-      for (int i = 0; i < x_grad->dims().size(); ++i) {
+      for (int64_t i = 0; i < x_grad->dims().size(); ++i) {
         x_grad_dims_vec[i] = x_grad->dims()[perm_x_grad[i]];
       }
       trans_x_grad.Resize(common::make_ddim(x_grad_dims_vec));
@@ -138,7 +138,7 @@ void OverlapAddGradKernel(const Context& dev_ctx,
   if (out_grad_rank > 2) {
     std::vector<int64_t> restored_x_grad_shape;
     restored_x_grad_shape.reserve(preserved_dims.size());
-    for (int i = 0; i < preserved_dims.size(); i++) {
+    for (int64_t i = 0; i < preserved_dims.size(); i++) {
       restored_x_grad_shape.push_back(preserved_dims[i]);
     }
 

--- a/paddle/phi/kernels/cpu/overlap_add_kernel.cc
+++ b/paddle/phi/kernels/cpu/overlap_add_kernel.cc
@@ -85,7 +85,7 @@ void OverlapAddKernel(const Context& dev_ctx,
     } else {
       std::vector<int> perm_out{1, 0};
       auto out_dims_vec = common::vectorize(out->dims());
-      for (int i = 0; i < out->dims().size(); ++i) {
+      for (int64_t i = 0; i < out->dims().size(); ++i) {
         out_dims_vec[i] = out->dims()[perm_out[i]];
       }
       trans_out.Resize(common::make_ddim(out_dims_vec));
@@ -128,7 +128,7 @@ void OverlapAddKernel(const Context& dev_ctx,
   if (out_rank > 2) {
     std::vector<int64_t> restored_out_shape;
     restored_out_shape.reserve(preserved_dims.size());
-    for (int i = 0; i < preserved_dims.size(); i++) {
+    for (int64_t i = 0; i < preserved_dims.size(); i++) {
       restored_out_shape.push_back(preserved_dims[i]);
     }
 

--- a/paddle/phi/kernels/cpu/pad3d_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/pad3d_grad_kernel.cc
@@ -381,15 +381,15 @@ void Pad3dGradKernel(const Context& dev_ctx,
   const int pad_left = static_cast<int>(pads[0]);
   const int pad_top = static_cast<int>(pads[2]);
   const int pad_front = static_cast<int>(pads[4]);
-  const int num = static_cast<int>(d_in_dims[0]);
+  const int64_t num = d_in_dims[0];
   if (data_format == "NCDHW") {
-    const int channels = static_cast<int>(d_in_dims[1]);
-    const int in_depth = static_cast<int>(d_in_dims[2]);
-    const int in_height = static_cast<int>(d_in_dims[3]);
-    const int in_width = static_cast<int>(d_in_dims[4]);
-    const int out_depth = static_cast<int>(d_out_dims[2]);
-    const int out_height = static_cast<int>(d_out_dims[3]);
-    const int out_width = static_cast<int>(d_out_dims[4]);
+    const int64_t channels = d_in_dims[1];
+    const int64_t in_depth = d_in_dims[2];
+    const int64_t in_height = d_in_dims[3];
+    const int64_t in_width = d_in_dims[4];
+    const int64_t out_depth = d_out_dims[2];
+    const int64_t out_height = d_out_dims[3];
+    const int64_t out_width = d_out_dims[4];
 
     std::map<std::string,
              void (*)(T*,
@@ -428,13 +428,13 @@ void Pad3dGradKernel(const Context& dev_ctx,
                    d_out_data,
                    func_map[mode]);
   } else {
-    const int channels = static_cast<int>(d_in_dims[4]);
-    const int in_depth = static_cast<int>(d_in_dims[1]);
-    const int in_height = static_cast<int>(d_in_dims[2]);
-    const int in_width = static_cast<int>(d_in_dims[3]);
-    const int out_depth = static_cast<int>(d_out_dims[1]);
-    const int out_height = static_cast<int>(d_out_dims[2]);
-    const int out_width = static_cast<int>(d_out_dims[3]);
+    const int64_t channels = d_in_dims[4];
+    const int64_t in_depth = d_in_dims[1];
+    const int64_t in_height = d_in_dims[2];
+    const int64_t in_width = d_in_dims[3];
+    const int64_t out_depth = d_out_dims[1];
+    const int64_t out_height = d_out_dims[2];
+    const int64_t out_width = d_out_dims[3];
 
     std::map<std::string,
              void (*)(T*,

--- a/paddle/phi/kernels/cpu/pad3d_kernel.cc
+++ b/paddle/phi/kernels/cpu/pad3d_kernel.cc
@@ -412,13 +412,13 @@ void Pad3dKernel(const Context& dev_ctx,
     return;
   }
 
-  int channels = static_cast<int>(in_dims[1]);
-  int in_depth = static_cast<int>(in_dims[2]);
-  int in_height = static_cast<int>(in_dims[3]);
-  int in_width = static_cast<int>(in_dims[4]);
-  int out_depth = static_cast<int>(out_dims[2]);
-  int out_height = static_cast<int>(out_dims[3]);
-  int out_width = static_cast<int>(out_dims[4]);
+  int64_t channels = in_dims[1];
+  int64_t in_depth = in_dims[2];
+  int64_t in_height = in_dims[3];
+  int64_t in_width = in_dims[4];
+  int64_t out_depth = out_dims[2];
+  int64_t out_height = out_dims[3];
+  int64_t out_width = out_dims[4];
   if (data_format == "NDHWC") {
     channels = static_cast<int>(in_dims[4]);
     in_depth = static_cast<int>(in_dims[1]);
@@ -497,7 +497,7 @@ void Pad3dKernel(const Context& dev_ctx,
   const int pad_left = static_cast<int>(pads[0]);
   const int pad_top = static_cast<int>(pads[2]);
   const int pad_front = static_cast<int>(pads[4]);
-  const int num = static_cast<int>(in_dims[0]);
+  const int64_t num = in_dims[0];
   if (data_format == "NCDHW") {
     std::map<std::string,
              void (*)(const T*,

--- a/paddle/phi/kernels/cpu/prelu_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/prelu_grad_kernel.cc
@@ -42,7 +42,7 @@ void PReluGradKernel(const Context& dev_ctx,
   const T* alpha_ptr = alpha.data<T>();
   const T* x_ptr = x.data<T>();
   const T* out_grad_ptr = out_grad.data<T>();
-  int numel = static_cast<int>(x.numel());
+  int64_t numel = static_cast<int64_t>(x.numel());
   auto dim = x.dims();
   int index = 0;
   int i = 0;

--- a/paddle/phi/kernels/cpu/prelu_kernel.cc
+++ b/paddle/phi/kernels/cpu/prelu_kernel.cc
@@ -33,7 +33,7 @@ void PReluKernel(const Context& dev_ctx,
     return;
   }
 
-  int numel = static_cast<int>(x.numel());
+  int64_t numel = static_cast<int64_t>(x.numel());
   auto dim = x.dims();
   int index = 0;
   int i = 0;

--- a/paddle/phi/kernels/cpu/psroi_pool_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/psroi_pool_grad_kernel.cc
@@ -34,10 +34,10 @@ void PsroiPoolGradKernel(const Context& dev_ctx,
                          DenseTensor* dx) {
   if (dx) {
     const auto& in_dims = x.dims();
-    int input_channels = static_cast<int>(in_dims[1]);
-    int height = static_cast<int>(in_dims[2]);
-    int width = static_cast<int>(in_dims[3]);
-    int rois_num_t = static_cast<int>(rois.dims()[0]);
+    int64_t input_channels = in_dims[1];
+    int64_t height = in_dims[2];
+    int64_t width = in_dims[3];
+    int64_t rois_num_t = rois.dims()[0];
 
     // set roi batch id
     DenseTensor rois_batch_id_list;
@@ -73,7 +73,7 @@ void PsroiPoolGradKernel(const Context& dev_ctx,
     set_zero(dev_ctx, dx, static_cast<T>(0));
 
     // backpropagate gradient per output pixel
-    int dout_size = static_cast<int>(dout.numel());
+    int64_t dout_size = static_cast<int64_t>(dout.numel());
     for (int i = 0; i < dout_size; ++i) {
       // The output is in order (n, c, ph, pw)
       int pw = i % pooled_width;

--- a/paddle/phi/kernels/cpu/psroi_pool_kernel.cc
+++ b/paddle/phi/kernels/cpu/psroi_pool_kernel.cc
@@ -31,11 +31,11 @@ void PsroiPoolKernel(const Context& dev_ctx,
                      float spatial_scale,
                      DenseTensor* out) {
   auto in_dims = x.dims();
-  int batch_size = static_cast<int>(in_dims[0]);
-  int input_channels = static_cast<int>(in_dims[1]);
-  int height = static_cast<int>(in_dims[2]);
-  int width = static_cast<int>(in_dims[3]);
-  int rois_num_t = static_cast<int>(rois.dims()[0]);
+  int64_t batch_size = in_dims[0];
+  int64_t input_channels = in_dims[1];
+  int64_t height = in_dims[2];
+  int64_t width = in_dims[3];
+  int64_t rois_num_t = rois.dims()[0];
 
   PADDLE_ENFORCE_EQ(input_channels,
                     output_channels * pooled_height * pooled_width,
@@ -133,8 +133,8 @@ void PsroiPoolKernel(const Context& dev_ctx,
       int out_plane_offset =
           static_cast<int>(out_roi_offset + c * out_stride[1]);
       for (int ph = 0; ph < pooled_height; ++ph) {
-        int out_row_offset =
-            static_cast<int>(out_plane_offset + ph * out_stride[2]);
+        int64_t out_row_offset =
+            static_cast<int64_t>(out_plane_offset + ph * out_stride[2]);
         for (int pw = 0; pw < pooled_width; ++pw) {
           // calculate w and h at input feature map
           int hstart = floor(static_cast<T>(ph) * bin_size_h + roi_start_h);
@@ -147,7 +147,7 @@ void PsroiPoolKernel(const Context& dev_ctx,
           hend = std::min(std::max(hend, 0), height);
           wend = std::min(std::max(wend, 0), width);
 
-          int output_index = out_row_offset + pw;
+          int64_t output_index = out_row_offset + pw;
           int input_channel = (c * pooled_height + ph) * pooled_width + pw;
           int input_plane_offset = static_cast<int>(
               roi_batch_id * in_stride[0] + input_channel * in_stride[1]);

--- a/paddle/phi/kernels/cpu/pyramid_hash_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/pyramid_hash_grad_kernel.cc
@@ -72,7 +72,7 @@ void CPUPyramidHashOPGradKernel(const Context& dev_ctx,
   auto* buff = &x_temp_out;
   auto* bottom_data = buff->data<T>();
 
-  int _slot_len = static_cast<int>(bottom->dims()[0]);
+  int64_t _slot_len = bottom->dims()[0];
   if (static_cast<size_t>(_slot_len) == bottom->lod()[0].size() - 1 &&
       std::count(bottom_data, bottom_data + _slot_len, -1) == _slot_len) {
     return;
@@ -89,8 +89,9 @@ void CPUPyramidHashOPGradKernel(const Context& dev_ctx,
   const int* iter = drop_pos_p->data<int>();
   int top_counter = 0;
   for (size_t i = 0; i < offset.size() - 1; ++i) {
-    int w = static_cast<int>(offset[i + 1] - offset[i]);
-    int w_drop = static_cast<int>(drop_pos_offset[i + 1] - drop_pos_offset[i]);
+    int64_t w = static_cast<int64_t>(offset[i + 1] - offset[i]);
+    int64_t w_drop =
+        static_cast<int64_t>(drop_pos_offset[i + 1] - drop_pos_offset[i]);
     if (w_drop == 0) {
       top_counter++;
     }

--- a/paddle/phi/kernels/cpu/pyramid_hash_kernel.cc
+++ b/paddle/phi/kernels/cpu/pyramid_hash_kernel.cc
@@ -101,7 +101,7 @@ void CPUPyramidHashOPKernel(const Context& dev_ctx,
   auto* buff = x_temp_out;
   buff->Resize(common::make_ddim({bottom->dims()[0], bottom->dims()[1]}));
   float* bottom_data = dev_ctx.template Alloc<float>(buff);
-  for (int i = 0; i < bottom->dims()[0]; i++) {
+  for (int64_t i = 0; i < bottom->dims()[0]; i++) {
     bottom_data[i] = bottom_data_ori[i];  // NOLINT
   }
 
@@ -145,7 +145,7 @@ void CPUPyramidHashOPKernel(const Context& dev_ctx,
   int* iter_end = iter;
 
   for (size_t i = 0; i < top_offset.size() - 1; ++i) {
-    int w = static_cast<int>(offset[i + 1] - offset[i]);
+    int64_t w = static_cast<int64_t>(offset[i + 1] - offset[i]);
     int nsentense_with_pyramid = 0;
     if (w < 2) {
       nsentense_with_pyramid = 0;
@@ -177,7 +177,7 @@ void CPUPyramidHashOPKernel(const Context& dev_ctx,
         (nsentense_with_pyramid == 0 ? 1 : nsentense_with_pyramid);
   }
 
-  int top_l = static_cast<int>(top_offset[top_offset.size() - 1]);
+  int64_t top_l = static_cast<int64_t>(top_offset[top_offset.size() - 1]);
 
   phi::LegacyLoD top_lod;
   top_lod.push_back(top_offset);
@@ -192,8 +192,9 @@ void CPUPyramidHashOPKernel(const Context& dev_ctx,
   iter = dev_ctx.template Alloc<int>(drop_pos);
   int top_counter = 0;
   for (size_t i = 0; i < offset.size() - 1; ++i) {
-    int w_drop = static_cast<int>(drop_pos_offset[i + 1] - drop_pos_offset[i]);
-    int w = static_cast<int>(offset[i + 1] - offset[i]);
+    int64_t w_drop =
+        static_cast<int64_t>(drop_pos_offset[i + 1] - drop_pos_offset[i]);
+    int64_t w = static_cast<int64_t>(offset[i + 1] - offset[i]);
     if (w_drop == 0) {
       if (w >= 2) {
         for (int ilayer = 1; ilayer < _pyramid_layer && ilayer < w; ++ilayer) {

--- a/paddle/phi/kernels/cpu/qr_kernel.cc
+++ b/paddle/phi/kernels/cpu/qr_kernel.cc
@@ -64,8 +64,8 @@ struct QrFunctor {
                   DenseTensor* r) {
     auto x_dims = x.dims();
     int x_rank = x_dims.size();
-    int m = static_cast<int>(x_dims[x_rank - 2]);
-    int n = static_cast<int>(x_dims[x_rank - 1]);
+    int64_t m = x_dims[x_rank - 2];
+    int64_t n = x_dims[x_rank - 1];
     int min_mn = std::min(m, n);
     int k = reduced_mode ? min_mn : m;
     int64_t batch_size = static_cast<int64_t>(x.numel() / (m * n));
@@ -130,11 +130,11 @@ struct QrFunctor<phi::dtype::complex<T>, Context> {
                   DenseTensor* r) {
     auto x_dims = x.dims();
     int x_rank = x_dims.size();
-    int m = static_cast<int>(x_dims[x_rank - 2]);
-    int n = static_cast<int>(x_dims[x_rank - 1]);
+    int64_t m = x_dims[x_rank - 2];
+    int64_t n = x_dims[x_rank - 1];
     int min_mn = std::min(m, n);
     int k = reduced_mode ? min_mn : m;
-    int batch_size = static_cast<int>(x.numel() / (m * n));
+    int64_t batch_size = static_cast<int64_t>(x.numel() / (m * n));
     int x_stride = m * n;
     int q_stride = m * k;
     int r_stride = k * n;

--- a/paddle/phi/kernels/cpu/repeat_interleave_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/repeat_interleave_grad_kernel.cc
@@ -94,7 +94,7 @@ void RepeatInterleaveGradKernel(const Context& dev_ctx,
   DenseTensor index;
   int64_t index_size = x_grad->dims()[dim] * repeats;
   std::vector<int> index_vec(index_size);
-  for (int i = 0; i < x_grad->dims()[dim]; i++) {
+  for (int64_t i = 0; i < x_grad->dims()[dim]; i++) {
     std::fill_n(index_vec.begin() + i * repeats, repeats, i);
   }
   index.Resize(common::make_ddim({index_size}));

--- a/paddle/phi/kernels/cpu/rnn_functor.h
+++ b/paddle/phi/kernels/cpu/rnn_functor.h
@@ -47,7 +47,7 @@ void CreateMaskMatrix(const CPUContext& dev_ctx,
                       const bool& is_reverse,
                       int* min_seq_len) {
   const auto& seq_len_vec = phi::GetVectorFromTensor<int>(sequence_length);
-  const int table_width = mask_matrix->dims()[0];
+  const int64_t table_width = mask_matrix->dims()[0];
   DenseTensor temp =
       Empty<T>(dev_ctx, {mask_matrix->dims()[1], mask_matrix->dims()[0]});
   T* data_temp = temp.data<T>();
@@ -215,8 +215,8 @@ void AllocateReserveData(const Context& dev_ctx,
                          DenseTensor* hidden_data,
                          const DenseTensor* input) {
   int direction_num = is_bidirec ? 2 : 1;
-  int time_step = input->dims()[0];
-  int batch_size = input->dims()[1];
+  int64_t time_step = input->dims()[0];
+  int64_t batch_size = input->dims()[1];
   int block_size = direction_num * time_step * batch_size * hidden_size;
   int hidden_data_idx = (num_layers - 1);
   if (is_lstm(mode)) {

--- a/paddle/phi/kernels/cpu/rnn_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/rnn_grad_kernel.cc
@@ -717,8 +717,8 @@ struct SingleGradLayer : GradLayer<T, GradCellType> {
     phi::funcs::SetConstant<CPUContext, T> zero;
     zero(dev_ctx, input_grad, static_cast<T>(0.0));
 
-    int time_step = static_cast<int>(input->dims()[0]);
-    int batch_size = static_cast<int>(input->dims()[1]);
+    int64_t time_step = input->dims()[0];
+    int64_t batch_size = input->dims()[1];
     int direction_num = is_bidirec ? 2 : 1;
 
     // in this section, create the gate_state_grad for the postprocess calculate
@@ -827,8 +827,8 @@ struct BidirGradLayer : GradLayer<T, GradCellType> {
                   int hidden_size,
                   const std::string& mode,
                   int gate_num) {
-    int time_step = static_cast<int>(input->dims()[0]);
-    int batch_size = static_cast<int>(input->dims()[1]);
+    int64_t time_step = input->dims()[0];
+    int64_t batch_size = input->dims()[1];
     int direction_num = is_bidirec ? 2 : 1;
     // split the output two tensor to output_forward, output_backward
     phi::funcs::SetConstant<CPUContext, T> zero;
@@ -1011,8 +1011,8 @@ void RnnGradFunc(const CPUContext& dev_ctx,
   }
 
   // get the input_size, batch_size, time_step
-  const int time_step = static_cast<int>(x.dims()[0]);
-  const int batch_size = static_cast<int>(x.dims()[1]);
+  const int64_t time_step = x.dims()[0];
+  const int64_t batch_size = x.dims()[1];
   const int direction_num = is_bidirec ? 2 : 1;
 
   // allocate the memory and initization the x_grad

--- a/paddle/phi/kernels/cpu/rnn_kernel.cc
+++ b/paddle/phi/kernels/cpu/rnn_kernel.cc
@@ -332,7 +332,7 @@ struct Layer {
         is_reverse = true;
       }
     }
-    const int time_step = static_cast<int>(input->dims()[0]);
+    const int64_t time_step = input->dims()[0];
     this->preprocess(dev_ctx,
                      *input,
                      vec[0 + offset * 4],
@@ -532,7 +532,7 @@ struct Layer {
         is_reverse = true;
       }
     }
-    const int time_step = static_cast<int>(input->dims()[0]);
+    const int64_t time_step = input->dims()[0];
     this->preprocess(dev_ctx,
                      *input,
                      vec[0 + offset * 4],
@@ -749,9 +749,9 @@ struct BidirLayer : public Layer<T, CellType> {
     std::vector<DenseTensor> output_vec(2);
     DenseTensor forward_input_w, forward_cell_value, forward_cell_act_value;
     DenseTensor backward_input_w, backward_cell_value, backward_cell_act_value;
-    int time_step = static_cast<int>(input->dims()[0]);
-    int batch_size = static_cast<int>(input->dims()[1]);
-    int hidden_size = static_cast<int>(output->dims()[2]);
+    int64_t time_step = input->dims()[0];
+    int64_t batch_size = input->dims()[1];
+    int64_t hidden_size = output->dims()[2];
     for (int i = 0; i < 2; ++i) {
       output_vec[i].Resize({time_step, batch_size, hidden_size / 2});
       dev_ctx.Alloc<T>(&output_vec[i]);

--- a/paddle/phi/kernels/cpu/roi_align_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/roi_align_grad_kernel.cc
@@ -83,10 +83,10 @@ void RoiAlignGradKernel(const Context& dev_ctx,
                         bool aligned,
                         DenseTensor* dx) {
   const auto& in_dims = common::vectorize<int>(x.dims());
-  int channels = in_dims[1];
-  int height = in_dims[2];
-  int width = in_dims[3];
-  int rois_num = static_cast<int>(boxes.dims()[0]);
+  int64_t channels = in_dims[1];
+  int64_t height = in_dims[2];
+  int64_t width = in_dims[3];
+  int64_t rois_num = boxes.dims()[0];
 
   if (!dx) {
     return;
@@ -135,7 +135,7 @@ void RoiAlignGradKernel(const Context& dev_ctx,
   phi::funcs::SetConstant<Context, T> set_zero;
   set_zero(dev_ctx, dx, static_cast<T>(0));
 
-  int output_grad_size = static_cast<int>(out_grad.numel());
+  int64_t output_grad_size = static_cast<int64_t>(out_grad.numel());
 
   if ((!out_grad.IsInitialized()) || (output_grad_size <= 0)) {
     return;

--- a/paddle/phi/kernels/cpu/roi_align_kernel.cc
+++ b/paddle/phi/kernels/cpu/roi_align_kernel.cc
@@ -188,11 +188,11 @@ void RoiAlignKernel(const Context& dev_ctx,
                     bool aligned,
                     DenseTensor* out) {
   auto in_dims = x.dims();
-  int batch_size = static_cast<int>(in_dims[0]);
-  int channels = static_cast<int>(in_dims[1]);
-  int height = static_cast<int>(in_dims[2]);
-  int width = static_cast<int>(in_dims[3]);
-  int rois_num = static_cast<int>(boxes.dims()[0]);
+  int64_t batch_size = in_dims[0];
+  int64_t channels = in_dims[1];
+  int64_t height = in_dims[2];
+  int64_t width = in_dims[3];
+  int64_t rois_num = boxes.dims()[0];
 
   if (x.numel() == 0 || boxes.numel() == 0) {
     phi::Full<T, Context>(

--- a/paddle/phi/kernels/cpu/roi_pool_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/roi_pool_grad_kernel.cc
@@ -40,7 +40,7 @@ void RoiPoolGradKernel(const Context& dev_ctx,
   }
 
   if (dx) {
-    int rois_num = static_cast<int>(boxes.dims()[0]);
+    int64_t rois_num = boxes.dims()[0];
     DenseTensor box_batch_id_list = Empty<int>(dev_ctx, {rois_num});
     int* box_batch_id_data = box_batch_id_list.data<int>();
 
@@ -78,7 +78,7 @@ void RoiPoolGradKernel(const Context& dev_ctx,
     auto roi_stride = common::stride(boxes.dims());
     auto out_stride = common::stride(out_grad.dims());
 
-    int channels = static_cast<int>(x.dims()[1]);
+    int64_t channels = x.dims()[1];
 
     for (int n = 0; n < rois_num; ++n) {
       int roi_batch_idx = box_batch_id_data[n];

--- a/paddle/phi/kernels/cpu/roi_pool_kernel.cc
+++ b/paddle/phi/kernels/cpu/roi_pool_kernel.cc
@@ -32,11 +32,11 @@ void RoiPoolKernel(const Context& dev_ctx,
                    DenseTensor* out,
                    DenseTensor* arg_max) {
   auto x_dims = x.dims();
-  int batch_size = static_cast<int>(x_dims[0]);
-  int channels = static_cast<int>(x_dims[1]);
-  int height = static_cast<int>(x_dims[2]);
-  int width = static_cast<int>(x_dims[3]);
-  int rois_num = static_cast<int>(boxes.dims()[0]);
+  int64_t batch_size = x_dims[0];
+  int64_t channels = x_dims[1];
+  int64_t height = x_dims[2];
+  int64_t width = x_dims[3];
+  int64_t rois_num = boxes.dims()[0];
 
   if (x.numel() == 0 || boxes.numel() == 0) {
     phi::Full<T, Context>(

--- a/paddle/phi/kernels/cpu/rprop_kernel.cc
+++ b/paddle/phi/kernels/cpu/rprop_kernel.cc
@@ -71,7 +71,7 @@ void RpropKernelCPUImpl(const Context& dev_ctx,
   T* eta_data = eta_tensor.data<T>();
   T zero = static_cast<T>(0);
   T one = static_cast<T>(1);
-  for (int i = 0, n = product_tensor.numel(); i < n; i++) {
+  for (int64_t i = 0, n = product_tensor.numel(); i < n; i++) {
     if (product_data[i] > zero) {
       eta_data[i] = eta_positive;
     } else if (product_data[i] == zero) {
@@ -84,7 +84,7 @@ void RpropKernelCPUImpl(const Context& dev_ctx,
 
   learning_rate_eigen = learning_rate_eigen * eta_eigen;
   T* learning_rate_data = learning_rate_tensor.data<T>();
-  for (int i = 0, n = learning_rate_tensor.numel(); i < n; i++) {
+  for (int64_t i = 0, n = learning_rate_tensor.numel(); i < n; i++) {
     if (learning_rate_data[i] > learning_rate_max) {
       learning_rate_data[i] = learning_rate_max;
     } else if (learning_rate_data[i] < learning_rate_min) {

--- a/paddle/phi/kernels/cpu/rrelu_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/rrelu_grad_kernel.cc
@@ -28,7 +28,7 @@ void RReluGradKernel(const Context& dev_ctx,
   const T* n_ptr = noise.data<T>();
   const T* x_ptr = x.data<T>();
   const T* out_grad_ptr = out_grad.data<T>();
-  int numel = static_cast<int>(x.numel());
+  int64_t numel = static_cast<int64_t>(x.numel());
   if (!x_grad) return;
 
   int i = 0;

--- a/paddle/phi/kernels/cpu/rrelu_kernel.cc
+++ b/paddle/phi/kernels/cpu/rrelu_kernel.cc
@@ -32,7 +32,7 @@ void RReluKernel(const Context& dev_ctx,
   T* o_ptr = dev_ctx.template Alloc<T>(out);
   T* n_ptr = dev_ctx.template Alloc<T>(noise);
   T zero = static_cast<T>(0);
-  int numel = static_cast<int>(x.numel());
+  int64_t numel = static_cast<int64_t>(x.numel());
   int i = 0;
 
   if (is_test) {

--- a/paddle/phi/kernels/cpu/send_u_recv_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/send_u_recv_grad_kernel.cc
@@ -87,7 +87,7 @@ void GraphSendRecvGradOpKernelLaunchHelper(
   T* p_output = x_grad->data<T>();
   const auto& src_dims = x.dims();
   int64_t memset_size = 1;
-  for (int i = 0; i < src_dims.size(); ++i) memset_size *= src_dims[i];
+  for (int64_t i = 0; i < src_dims.size(); ++i) memset_size *= src_dims[i];
   const size_t& memset_bytes = memset_size * sizeof(T);
   memset(p_output, 0, memset_bytes);
 

--- a/paddle/phi/kernels/cpu/send_u_recv_kernel.cc
+++ b/paddle/phi/kernels/cpu/send_u_recv_kernel.cc
@@ -93,7 +93,7 @@ void GraphSendRecvOpKernelLaunchHelper(const Context& dev_ctx,
   int64_t memset_size = 1;
   if (out_size <= 0) {
     out->Resize(src_dims);
-    for (int i = 0; i < src_dims.size(); ++i) {
+    for (int64_t i = 0; i < src_dims.size(); ++i) {
       memset_size *= src_dims[i];
     }
   } else {

--- a/paddle/phi/kernels/cpu/send_ue_recv_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/send_ue_recv_grad_kernel.cc
@@ -379,10 +379,10 @@ void GraphSendUERecvGradOpKernelLaunchHelper(
   const auto& x_dims = x.dims();
   const auto& y_dims = y.dims();
   int64_t memset_size_x = 1, memset_size_y = 1;
-  for (int i = 0; i < x_dims.size(); i++) {
+  for (int64_t i = 0; i < x_dims.size(); i++) {
     memset_size_x *= x_dims[i];
   }
-  for (int i = 0; i < y_dims.size(); i++) {
+  for (int64_t i = 0; i < y_dims.size(); i++) {
     memset_size_y *= y_dims[i];
   }
   const size_t& memset_bytes_x = memset_size_x * sizeof(T);

--- a/paddle/phi/kernels/cpu/send_uv_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/send_uv_grad_kernel.cc
@@ -186,11 +186,11 @@ void GraphSendUVGradOpKernelLaunchHelper(const Context& dev_ctx,
   const auto& y_grad_dims = y_grad->dims();
   int64_t memset_size_x = 1, memset_size_y = 1;
   int64_t slice_size_x = 1, slice_size_y = 1;
-  for (int i = 0; i < x_grad_dims.size(); i++) {
+  for (int64_t i = 0; i < x_grad_dims.size(); i++) {
     memset_size_x *= x_grad_dims[i];
     if (i > 0) slice_size_x *= x_grad_dims[i];
   }
-  for (int i = 0; i < y_grad_dims.size(); i++) {
+  for (int64_t i = 0; i < y_grad_dims.size(); i++) {
     memset_size_y *= y_grad_dims[i];
     if (i > 0) slice_size_y *= y_grad_dims[i];
   }

--- a/paddle/phi/kernels/cpu/sequence_expand_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/sequence_expand_grad_kernel.cc
@@ -46,7 +46,7 @@ struct SequenceExpandGradFunctor<phi::CPUContext, T> {
         if (x_seq_len == 0) continue;
         auto dx_sub = dx->Slice(x_start, x_end);
         dx_sub.Resize(common::flatten_to_1d(dx_sub.dims()));
-        int dout_end = dout_offset + repeat_num * x_seq_len;
+        int64_t dout_end = dout_offset + repeat_num * x_seq_len;
         auto dout_sub = dout.Slice(dout_offset, dout_end);
         dout_sub.Resize({repeat_num, dx_sub.dims()[0]});
         phi::funcs::ColwiseSum<phi::CPUContext, T> col_sum;

--- a/paddle/phi/kernels/cpu/sequence_expand_kernel.cc
+++ b/paddle/phi/kernels/cpu/sequence_expand_kernel.cc
@@ -25,7 +25,7 @@ struct SequenceExpandFunctor<phi::CPUContext, T> {
                   const phi::Vector<size_t>& ref_lod, /*expand referenced lod*/
                   phi::DenseTensor* out) {
     int out_offset = 0;
-    int x_item_length = x.numel() / x.dims()[0];
+    int64_t x_item_length = x.numel() / x.dims()[0];
     auto out_data = out->data<T>();
     auto x_data = x.data<T>();
     for (size_t i = 1; i < ref_lod.size(); ++i) {
@@ -34,13 +34,13 @@ struct SequenceExpandFunctor<phi::CPUContext, T> {
       int x_end = x_lod[i];
       int x_seq_len = x_end - x_start;
       if (repeat_num > 0) {
-        int out_start = out_offset;
+        int64_t out_start = out_offset;
         if (out->lod().size() == 1) {
           out_start = out->lod()[0][out_offset];
         }
         for (int j = 0; j < repeat_num; j++) {
           for (int k = 0; k < x_seq_len; k++) {
-            for (int l = 0; l < x_item_length; l++) {
+            for (int64_t l = 0; l < x_item_length; l++) {
               out_data[(out_start + j * x_seq_len + k) * x_item_length + l] =
                   x_data[(x_start + k) * x_item_length + l];
             }

--- a/paddle/phi/kernels/cpu/set_value_kernel.cc
+++ b/paddle/phi/kernels/cpu/set_value_kernel.cc
@@ -62,7 +62,7 @@ void SetValueImpl(const Context& dev_ctx,
     std::vector<int64_t> slice_dims_with_none;
 
     size_t none_axes_cur = 0, decrease_axes_cur = 0;
-    for (int i = 0; i < slice_dims.size(); ++i) {
+    for (int64_t i = 0; i < slice_dims.size(); ++i) {
       while (none_axes_cur < none_axes.size() &&
              none_axes[none_axes_cur] <= i) {
         slice_dims_with_none.push_back(1);

--- a/paddle/phi/kernels/cpu/shape_broadcast_kernel.cc
+++ b/paddle/phi/kernels/cpu/shape_broadcast_kernel.cc
@@ -69,7 +69,7 @@ void ShapeBroadcastKernel(const Context& dev_ctx,
           : ComputeBroadcastShape(y_shape_data, x_shape_data);
   T* out_data = dev_ctx.template HostAlloc<T>(out);
   int64_t out_numel = out->numel();
-  for (int i = 0; i < out_numel; ++i) {
+  for (int64_t i = 0; i < out_numel; ++i) {
     out_data[i] = output_data[i];
   }
 }

--- a/paddle/phi/kernels/cpu/shuffle_batch_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/shuffle_batch_grad_kernel.cc
@@ -29,7 +29,7 @@ void ShuffleBatchGradKernel(const Context& dev_ctx,
   auto embed_size = out_grad.dims()[out_grad.dims().size() - 1];
   auto elem_size = 1;
   for (auto i = 0; i < out_grad.dims().size() - 1; i++)
-    elem_size *= static_cast<int>(out_grad.dims()[i]);
+    elem_size *= out_grad.dims()[i];
 
   std::vector<int> idx_vec_grad(elem_size);
   auto* shuffleidx_data = shuffleidx.data<int64_t>();

--- a/paddle/phi/kernels/cpu/shuffle_batch_kernel.cc
+++ b/paddle/phi/kernels/cpu/shuffle_batch_kernel.cc
@@ -28,8 +28,7 @@ void ShuffleBatchKernel(const Context& dev_ctx,
                         DenseTensor* seed_out) {
   auto x_embed_size = x.dims()[x.dims().size() - 1];
   int elem_size = 1;
-  for (auto i = 0; i < x.dims().size() - 1; i++)
-    elem_size *= static_cast<int>(x.dims()[i]);
+  for (auto i = 0; i < x.dims().size() - 1; i++) elem_size *= x.dims()[i];
 
   std::vector<int64_t> idx_vec;  // record shuffled order
   idx_vec.reserve(elem_size);

--- a/paddle/phi/kernels/cpu/sigmoid_cross_entropy_with_logits_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/sigmoid_cross_entropy_with_logits_grad_kernel.cc
@@ -31,7 +31,7 @@ void SigmoidCrossEntropyWithLogitsGradKernel(
     DenseTensor* in_grad) {
   auto dx_data = dev_ctx.template Alloc<T>(in_grad);
 
-  int limit = static_cast<int>(in_grad->numel());
+  int64_t limit = static_cast<int64_t>(in_grad->numel());
   auto x_data = x.data<T>();
   auto label_data = label.data<T>();
   auto dout_data = out_grad.data<T>();

--- a/paddle/phi/kernels/cpu/sigmoid_cross_entropy_with_logits_kernel.cc
+++ b/paddle/phi/kernels/cpu/sigmoid_cross_entropy_with_logits_kernel.cc
@@ -32,7 +32,7 @@ void SigmoidCrossEntropyWithLogitsKernel(
     int ignore_index,
     DenseTensor* out) {
   auto out_data = dev_ctx.template Alloc<T>(out);
-  int limit = static_cast<int>(out->numel());
+  int64_t limit = static_cast<int64_t>(out->numel());
   auto x_data = x.data<T>();
   auto label_data = label.data<T>();
   auto pos_weight_data =

--- a/paddle/phi/kernels/cpu/stack_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/stack_grad_kernel.cc
@@ -26,7 +26,7 @@ void StackGradKernel(const Context& dev_ctx,
                      int axis,
                      std::vector<DenseTensor*> x_grad) {
   if (axis < 0) axis += out.dims().size();
-  int n = static_cast<int>(out.dims()[axis]);
+  int64_t n = out.dims()[axis];
   std::vector<T*> dx_datas(n);  // NOLINT
 
   for (int i = 0; i < n; i++) {
@@ -47,10 +47,10 @@ void StackGradKernel(const Context& dev_ctx,
     return;
   }
 
-  int pre = 1;
-  for (int i = 0; i < axis; ++i) pre *= static_cast<int>(out.dims()[i]);
-  int total_num = static_cast<int>(out.numel());
-  int post = total_num / (n * pre);
+  int64_t pre = 1;
+  for (int64_t i = 0; i < axis; ++i) pre *= out.dims()[i];
+  int64_t total_num = static_cast<int64_t>(out.numel());
+  int64_t post = total_num / (n * pre);
   auto dx_data_arr = dx_datas.data();
   phi::funcs::StackGradFunctorForRange(
       dev_ctx, dx_data_arr, dy_data, total_num, n, post);

--- a/paddle/phi/kernels/cpu/stack_kernel.cc
+++ b/paddle/phi/kernels/cpu/stack_kernel.cc
@@ -27,7 +27,7 @@ void StackKernel(const Context& dev_ctx,
   if (axis < 0) axis += (x[0]->dims().size() + 1);
 
   auto x_dims = x[0]->dims();
-  for (int i = 0; i < x_dims.size(); i++) {
+  for (int64_t i = 0; i < x_dims.size(); i++) {
     PADDLE_ENFORCE_GE(
         x_dims[i],
         0,

--- a/paddle/phi/kernels/cpu/svd_kernel.cc
+++ b/paddle/phi/kernels/cpu/svd_kernel.cc
@@ -115,8 +115,22 @@ void SvdKernel(const Context& dev_ctx,
   DenseTensor trans_x =
       ::phi::TransposeLast2Dim<T>(dev_ctx, Conj<T, Context>(dev_ctx, X));
   auto x_dims = X.dims();
-  int rows = static_cast<int>(x_dims[x_dims.size() - 2]);
-  int cols = static_cast<int>(x_dims[x_dims.size() - 1]);
+  int64_t rows_64 = x_dims[x_dims.size() - 2];
+  int64_t cols_64 = x_dims[x_dims.size() - 1];
+
+  // LAPACK uses int parameters, check for overflow
+  PADDLE_ENFORCE_LE(rows_64,
+                    std::numeric_limits<int>::max(),
+                    common::errors::InvalidArgument(
+                        "The matrix row dimension exceeds LAPACK int limit."));
+  PADDLE_ENFORCE_LE(
+      cols_64,
+      std::numeric_limits<int>::max(),
+      common::errors::InvalidArgument(
+          "The matrix column dimension exceeds LAPACK int limit."));
+
+  int rows = static_cast<int>(rows_64);
+  int cols = static_cast<int>(cols_64);
   // int k = std::min(rows, cols);
   // int col_u = full ? rows : k;
   // int col_v = full ? cols : k;

--- a/paddle/phi/kernels/cpu/svdvals_kernel.cc
+++ b/paddle/phi/kernels/cpu/svdvals_kernel.cc
@@ -78,11 +78,10 @@ void LapackSvdvals(const T* X, T* S, int rows, int cols) {
 }
 
 template <typename T>
-void BatchSvdvals(
-    const T* X, T* S, int64_t rows, int64_t cols, int64_t batches) {
-  int64_t stride = rows * cols;
-  int64_t stride_s = std::min(rows, cols);
-  for (int64_t i = 0; i < batches; i++) {
+void BatchSvdvals(const T* X, T* S, int rows, int cols, int batches) {
+  int stride = rows * cols;
+  int stride_s = std::min(rows, cols);
+  for (int i = 0; i < batches; i++) {
     LapackSvdvals<T>(X + i * stride, S + i * stride_s, rows, cols);
   }
 }
@@ -96,8 +95,8 @@ void SvdvalsKernel(const Context& dev_ctx,
     return;
   }
   auto x_dims = X.dims();
-  int64_t rows = static_cast<int64_t>(x_dims[x_dims.size() - 2]);
-  int64_t cols = static_cast<int64_t>(x_dims[x_dims.size() - 1]);
+  int64_t rows = x_dims[x_dims.size() - 2];
+  int64_t cols = x_dims[x_dims.size() - 1];
   PADDLE_ENFORCE_LT(rows * cols,
                     std::numeric_limits<int32_t>::max(),
                     common::errors::InvalidArgument(
@@ -113,6 +112,18 @@ void SvdvalsKernel(const Context& dev_ctx,
       cols,
       0,
       common::errors::InvalidArgument("The column of Input(X) must be > 0."));
+
+  // LAPACK uses int parameters, check for overflow
+  PADDLE_ENFORCE_LE(rows,
+                    std::numeric_limits<int>::max(),
+                    common::errors::InvalidArgument(
+                        "The matrix row dimension exceeds LAPACK int limit."));
+  PADDLE_ENFORCE_LE(
+      cols,
+      std::numeric_limits<int>::max(),
+      common::errors::InvalidArgument(
+          "The matrix column dimension exceeds LAPACK int limit."));
+
   int64_t k = std::min(rows, cols);
   int64_t batches = static_cast<int64_t>(X.numel() / (rows * cols));
   PADDLE_ENFORCE_GT(batches,
@@ -133,7 +144,10 @@ void SvdvalsKernel(const Context& dev_ctx,
   DenseTensor trans_x = ::phi::TransposeLast2Dim<T>(dev_ctx, X);
   auto* x_data = trans_x.data<T>();
   // Perform batch SVD computation for singular values
-  BatchSvdvals<T>(x_data, S_out, rows, cols, batches);
+  int rows_int = static_cast<int>(rows);
+  int cols_int = static_cast<int>(cols);
+  int batches_int = static_cast<int>(batches);
+  BatchSvdvals<T>(x_data, S_out, rows_int, cols_int, batches_int);
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/cpu/tdm_child_kernel.cc
+++ b/paddle/phi/kernels/cpu/tdm_child_kernel.cc
@@ -33,10 +33,10 @@ void TDMChildInner(const Context &dev_ctx,
                    phi::DenseTensor *child,
                    phi::DenseTensor *mask) {
   auto info_dims = tree_info.dims();
-  int node_nums = info_dims[0];
-  int length = info_dims[1];
+  int64_t node_nums = info_dims[0];
+  int64_t length = info_dims[1];
 
-  int input_ids_num = input.numel();
+  int64_t input_ids_num = input.numel();
   VLOG(4) << "TDM child op: input numel ->  " << input_ids_num;
 
   std::vector<OutT> child_vec{};

--- a/paddle/phi/kernels/cpu/tdm_sampler_kernel.cc
+++ b/paddle/phi/kernels/cpu/tdm_sampler_kernel.cc
@@ -43,7 +43,7 @@ void TDMSamplerInner(const Context &dev_ctx,
                      phi::DenseTensor *label,
                      phi::DenseTensor *mask) {
   // get dimension
-  int input_ids_num = input_tensor.numel();
+  int64_t input_ids_num = input_tensor.numel();
   VLOG(3) << "TDM: input ids nums: " << input_ids_num;
   auto layer_nums = neg_samples_num_list.size();
   VLOG(3) << "TDM: tree layer nums: " << layer_nums;
@@ -112,7 +112,7 @@ void TDMSamplerInner(const Context &dev_ctx,
       int sample_num = neg_samples_num_list[layer_idx];
       VLOG(3) << "TDM: Sample num: " << sample_num;
 
-      int node_nums = layer_offset[layer_idx + 1] - layer_offset[layer_idx];
+      int64_t node_nums = layer_offset[layer_idx + 1] - layer_offset[layer_idx];
       VLOG(3) << "TDM: layer - " << layer_idx + 1
               << " - has node_nums: " << node_nums;
 
@@ -127,8 +127,8 @@ void TDMSamplerInner(const Context &dev_ctx,
               node_nums,
               sample_num));
 
-      int node_id_min = layer_offset[layer_idx];
-      int node_id_max = layer_offset[layer_idx + 1];
+      int64_t node_id_min = layer_offset[layer_idx];
+      int64_t node_id_max = layer_offset[layer_idx + 1];
 
       OutT positive_node_id =
           static_cast<OutT>(travel_data[start_offset + layer_idx]);

--- a/paddle/phi/kernels/cpu/temporal_shift_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/temporal_shift_grad_kernel.cc
@@ -98,7 +98,7 @@ void TemporalShiftGradKernel(const Context& dev_ctx,
   int t = seg_num;
   const DataLayout data_layout = common::StringToDataLayout(data_format_str);
 
-  const int nt = static_cast<int>(output_grad->dims()[0]);
+  const int64_t nt = output_grad->dims()[0];
   const int c = static_cast<int>(data_layout == DataLayout::kNCHW
                                      ? output_grad->dims()[1]
                                      : output_grad->dims()[3]);

--- a/paddle/phi/kernels/cpu/temporal_shift_kernel.cc
+++ b/paddle/phi/kernels/cpu/temporal_shift_kernel.cc
@@ -98,7 +98,7 @@ void TemporalShiftKernel(const Context& dev_ctx,
   int t = seg_num;
   const DataLayout data_layout = common::StringToDataLayout(data_format_str);
 
-  const int nt = static_cast<int>(input->dims()[0]);
+  const int64_t nt = input->dims()[0];
   const int c = static_cast<int>(
       data_layout == DataLayout::kNCHW ? input->dims()[1] : input->dims()[3]);
   const int h = static_cast<int>(

--- a/paddle/phi/kernels/cpu/unpool_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/unpool_grad_kernel.cc
@@ -35,19 +35,19 @@ void UnpoolGrad(const Context& dev_ctx,
   const T* output_grad_data = out_grad.data<T>();
   phi::funcs::SetConstant<Context, T> zero;
   zero(dev_ctx, x_grad, static_cast<T>(0));
-  const int batch_size = static_cast<int>(x.dims()[0]);
-  const int input_height = static_cast<int>(x.dims()[2]);
-  const int input_width = static_cast<int>(x.dims()[3]);
-  const int output_channels = static_cast<int>(out.dims()[1]);
-  const int output_height = static_cast<int>(out.dims()[2]);
-  const int output_width = static_cast<int>(out.dims()[3]);
-  int input_feasize = input_height * input_width;
-  int output_feasize = output_height * output_width;
+  const int64_t batch_size = x.dims()[0];
+  const int64_t input_height = x.dims()[2];
+  const int64_t input_width = x.dims()[3];
+  const int64_t output_channels = out.dims()[1];
+  const int64_t output_height = out.dims()[2];
+  const int64_t output_width = out.dims()[3];
+  int64_t input_feasize = input_height * input_width;
+  int64_t output_feasize = output_height * output_width;
   const IndT* indices_data = indices.data<IndT>();
 
-  for (int b = 0; b < batch_size; ++b) {
-    for (int c = 0; c < output_channels; ++c) {
-      for (int i = 0; i < input_feasize; ++i) {
+  for (int64_t b = 0; b < batch_size; ++b) {
+    for (int64_t c = 0; c < output_channels; ++c) {
+      for (int64_t i = 0; i < input_feasize; ++i) {
         IndT index = indices_data[i];
         PADDLE_ENFORCE_LT(
             index,
@@ -105,21 +105,21 @@ void Unpool3dGrad(const Context& dev_ctx,
   phi::funcs::SetConstant<Context, T> zero;
   zero(dev_ctx, x_grad, static_cast<T>(0));
 
-  const int batch_size = static_cast<int>(x.dims()[0]);
-  const int input_depth = static_cast<int>(x.dims()[2]);
-  const int input_height = static_cast<int>(x.dims()[3]);
-  const int input_width = static_cast<int>(x.dims()[4]);
-  const int output_channels = static_cast<int>(out.dims()[1]);
-  const int output_depth = static_cast<int>(out.dims()[2]);
-  const int output_height = static_cast<int>(out.dims()[3]);
-  const int output_width = static_cast<int>(out.dims()[4]);
-  int input_feasize = input_depth * input_height * input_width;
-  int output_feasize = output_depth * output_height * output_width;
+  const int64_t batch_size = x.dims()[0];
+  const int64_t input_depth = x.dims()[2];
+  const int64_t input_height = x.dims()[3];
+  const int64_t input_width = x.dims()[4];
+  const int64_t output_channels = out.dims()[1];
+  const int64_t output_depth = out.dims()[2];
+  const int64_t output_height = out.dims()[3];
+  const int64_t output_width = out.dims()[4];
+  int64_t input_feasize = input_depth * input_height * input_width;
+  int64_t output_feasize = output_depth * output_height * output_width;
   const IndT* indices_data = indices.data<IndT>();
 
-  for (int b = 0; b < batch_size; ++b) {
-    for (int c = 0; c < output_channels; ++c) {
-      for (int i = 0; i < input_feasize; ++i) {
+  for (int64_t b = 0; b < batch_size; ++b) {
+    for (int64_t c = 0; c < output_channels; ++c) {
+      for (int64_t i = 0; i < input_feasize; ++i) {
         IndT index = indices_data[i];
         PADDLE_ENFORCE_LT(
             index,

--- a/paddle/phi/kernels/cpu/unpool_kernel.cc
+++ b/paddle/phi/kernels/cpu/unpool_kernel.cc
@@ -33,19 +33,19 @@ void Unpool(const Context& dev_ctx,
     phi::funcs::SetConstant<Context, T> set_zero;
     set_zero(dev_ctx, out, static_cast<T>(0));
   }
-  const int batch_size = static_cast<int>(x.dims()[0]);
-  const int input_height = static_cast<int>(x.dims()[2]);
-  const int input_width = static_cast<int>(x.dims()[3]);
-  const int output_channels = static_cast<int>(out->dims()[1]);
-  const int output_height = static_cast<int>(out->dims()[2]);
-  const int output_width = static_cast<int>(out->dims()[3]);
-  int input_feasize = input_height * input_width;
-  int output_feasize = output_height * output_width;
+  const int64_t batch_size = x.dims()[0];
+  const int64_t input_height = x.dims()[2];
+  const int64_t input_width = x.dims()[3];
+  const int64_t output_channels = out->dims()[1];
+  const int64_t output_height = out->dims()[2];
+  const int64_t output_width = out->dims()[3];
+  int64_t input_feasize = input_height * input_width;
+  int64_t output_feasize = output_height * output_width;
   const T* input_data = x.data<T>();
   const IndT* indices_data = indices.data<IndT>();
-  for (int b = 0; b < batch_size; ++b) {
-    for (int c = 0; c < output_channels; ++c) {
-      for (int i = 0; i < input_feasize; ++i) {
+  for (int64_t b = 0; b < batch_size; ++b) {
+    for (int64_t c = 0; c < output_channels; ++c) {
+      for (int64_t i = 0; i < input_feasize; ++i) {
         IndT index = indices_data[i];
         PADDLE_ENFORCE_LT(
             index,
@@ -99,21 +99,21 @@ void Unpool3d(const Context& dev_ctx,
     phi::funcs::SetConstant<Context, T> set_zero;
     set_zero(dev_ctx, out, static_cast<T>(0));
   }
-  const int batch_size = static_cast<int>(x.dims()[0]);
-  const int input_depth = static_cast<int>(x.dims()[2]);
-  const int input_height = static_cast<int>(x.dims()[3]);
-  const int input_width = static_cast<int>(x.dims()[4]);
-  const int output_channels = static_cast<int>(out->dims()[1]);
-  const int output_depth = static_cast<int>(out->dims()[2]);
-  const int output_height = static_cast<int>(out->dims()[3]);
-  const int output_width = static_cast<int>(out->dims()[4]);
-  int input_feasize = input_depth * input_height * input_width;
-  int output_feasize = output_depth * output_height * output_width;
+  const int64_t batch_size = x.dims()[0];
+  const int64_t input_depth = x.dims()[2];
+  const int64_t input_height = x.dims()[3];
+  const int64_t input_width = x.dims()[4];
+  const int64_t output_channels = out->dims()[1];
+  const int64_t output_depth = out->dims()[2];
+  const int64_t output_height = out->dims()[3];
+  const int64_t output_width = out->dims()[4];
+  int64_t input_feasize = input_depth * input_height * input_width;
+  int64_t output_feasize = output_depth * output_height * output_width;
   const T* input_data = x.data<T>();
   const IndT* indices_data = indices.data<IndT>();
-  for (int b = 0; b < batch_size; ++b) {
-    for (int c = 0; c < output_channels; ++c) {
-      for (int i = 0; i < input_feasize; ++i) {
+  for (int64_t b = 0; b < batch_size; ++b) {
+    for (int64_t c = 0; c < output_channels; ++c) {
+      for (int64_t i = 0; i < input_feasize; ++i) {
         IndT index = indices_data[i];
         PADDLE_ENFORCE_LT(
             index,

--- a/paddle/phi/kernels/cpu/weight_quantize_kernel.cc
+++ b/paddle/phi/kernels/cpu/weight_quantize_kernel.cc
@@ -116,7 +116,7 @@ void quant_compute(const DeviceContext& dev_ctx,
       funcs::Transpose<DeviceContext, int8_t, 2> trans;
       trans(dev_ctx, x_int, out, axis);
     } else {
-      for (int i = 0; i < out->numel(); ++i) {
+      for (int64_t i = 0; i < out->numel(); ++i) {
         x_int_tmp_data[i] = x_int_data[i];
       }
       std::vector<int> axis = {1, 0};
@@ -130,7 +130,7 @@ void quant_compute(const DeviceContext& dev_ctx,
       add_bias_and_interleave_inplace<bits>(x_int_data, num);
       // phi::Copy break the shape of int4 output, use naive copy;
       // only left half of x_int data is valid in int4 mode
-      for (int i = 0; i < out->numel(); ++i) {
+      for (int64_t i = 0; i < out->numel(); ++i) {
         out_data[i] = x_int_data[i];
       }
     } else if ((arch == 90) || (arch == 89) || (arch == 86) || (arch == 80) ||

--- a/paddle/phi/kernels/cpu/weighted_sample_neighbors_kernel.cc
+++ b/paddle/phi/kernels/cpu/weighted_sample_neighbors_kernel.cc
@@ -227,7 +227,7 @@ void WeightedSampleNeighborsKernel(const Context& dev_ctx,
   const T* x_data = x.data<T>();
   const T* eids_data =
       (eids.get_ptr() == nullptr ? nullptr : eids.get_ptr()->data<T>());
-  int bs = static_cast<int>(x.dims()[0]);
+  int64_t bs = x.dims()[0];
 
   std::vector<T> output;
   std::vector<int> output_count;

--- a/paddle/phi/kernels/cpu/where_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/where_grad_kernel.cc
@@ -47,13 +47,13 @@ void WhereGradKernel(const Context& dev_ctx,
 
   if (x_grad != nullptr) {
     auto* dx = dev_ctx.template Alloc<T>(x_grad);
-    for (int i = 0; i < numel; i++) {
+    for (int64_t i = 0; i < numel; i++) {
       dx[i] = cond_data[i] ? dout[i] : T{};
     }
   }
   if (y_grad != nullptr) {
     auto* dy = dev_ctx.template Alloc<T>(y_grad);
-    for (int i = 0; i < numel; i++) {
+    for (int64_t i = 0; i < numel; i++) {
       dy[i] = cond_data[i] ? T{} : dout[i];
     }
   }

--- a/paddle/phi/kernels/cpu/where_kernel.cc
+++ b/paddle/phi/kernels/cpu/where_kernel.cc
@@ -34,7 +34,7 @@ void WhereKernel(const Context& dev_ctx,
     return;
   }
 
-  for (int i = 0; i < x_numel; i++) {
+  for (int64_t i = 0; i < x_numel; i++) {
     out_data[i] = cond_data[i] ? x_data[i] : y_data[i];
   }
 }

--- a/paddle/phi/kernels/cpu/yolo_box_kernel.cc
+++ b/paddle/phi/kernels/cpu/yolo_box_kernel.cc
@@ -49,10 +49,10 @@ void YoloBoxKernel(const Context& dev_ctx,
   float scale = scale_x_y;
   float bias = -0.5f * (scale - 1.f);
 
-  const int n = static_cast<int>(input->dims()[0]);
-  const int h = static_cast<int>(input->dims()[2]);
-  const int w = static_cast<int>(input->dims()[3]);
-  const int box_num = static_cast<int>(boxes->dims()[1]);
+  const int64_t n = input->dims()[0];
+  const int64_t h = input->dims()[2];
+  const int64_t w = input->dims()[3];
+  const int64_t box_num = boxes->dims()[1];
   const int an_num = static_cast<int>(anchors.size() / 2);
   int input_size_h = downsample_ratio * h;
   int input_size_w = downsample_ratio * w;

--- a/paddle/phi/kernels/cpu/yolo_loss_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/yolo_loss_grad_kernel.cc
@@ -140,16 +140,16 @@ void YoloLossGradKernel(const Context& dev_ctx,
   auto input_grad = x_grad;
   auto* objness_mask = &objectness_mask;
 
-  const int n = static_cast<int>(input_grad->dims()[0]);
-  const int c = static_cast<int>(input_grad->dims()[1]);
-  const int h = static_cast<int>(input_grad->dims()[2]);
-  const int w = static_cast<int>(input_grad->dims()[3]);
+  const int64_t n = input_grad->dims()[0];
+  const int64_t c = input_grad->dims()[1];
+  const int64_t h = input_grad->dims()[2];
+  const int64_t w = input_grad->dims()[3];
   const int mask_num = static_cast<int>(anchor_mask.size());
-  const int b = static_cast<int>(gt_match_mask.dims()[1]);
-  int input_size = downsample_ratio * h;
+  const int64_t b = gt_match_mask.dims()[1];
+  int64_t input_size = downsample_ratio * h;
 
-  const int stride = h * w;
-  const int an_stride = (class_num + 5) * stride;
+  const int64_t stride = h * w;
+  const int64_t an_stride = (class_num + 5) * stride;
 
   T label_pos = 1.0;
   T label_neg = 0.0;

--- a/paddle/phi/kernels/cpu/yolo_loss_kernel.cc
+++ b/paddle/phi/kernels/cpu/yolo_loss_kernel.cc
@@ -199,16 +199,16 @@ void YoloLossKernel(const Context& dev_ctx,
   float scale = scale_x_y;
   float bias = -0.5f * (scale - 1.f);
 
-  const int n = static_cast<int>(input->dims()[0]);
-  const int h = static_cast<int>(input->dims()[2]);
-  const int w = static_cast<int>(input->dims()[3]);
+  const int64_t n = input->dims()[0];
+  const int64_t h = input->dims()[2];
+  const int64_t w = input->dims()[3];
   const int an_num = static_cast<int>(anchors.size() / 2);
   const int mask_num = static_cast<int>(anchor_mask.size());
-  const int b = static_cast<int>(gt_box.dims()[1]);
-  int input_size = downsample_ratio * h;
+  const int64_t b = gt_box.dims()[1];
+  int64_t input_size = downsample_ratio * h;
 
-  const int stride = h * w;
-  const int an_stride = (class_num + 5) * stride;
+  const int64_t stride = h * w;
+  const int64_t an_stride = (class_num + 5) * stride;
 
   T label_pos = 1.0;
   T label_neg = 0.0;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
https://github.com/PaddlePaddle/Paddle/pull/76107 使用的方法是检索代码->llm 修改代码->人工校对，目前发现这种方法存在两个弊端：
- 漏改情况较多，很多情况下只会改匹配到的部分，不会修改临近相关代码，而且会出现错误用法。
- 每一行都需要人工校对，因为llm生成的代码实际上是不能保证语法正确的，也不能保证语义一致。

由于cpu目录检索到的内容过多，漏改和错改属于普遍现象（LLM修改方案），因此本 PR 尝试了一种新的方案，使用 ast-grep 检索和替换代码，这种方法可以通过编写rule，保证语法和语义正确，同时可以大大提高复用性。

原本的方案中为了方便修改和review，采用了文件夹作为基本单位进行修改（因为同目录代码相似度相对较高），但是如果采用编写rule来修改的话，使用模式作为单位修改更利于review。

#### 修改内容
应用下列rule
```yaml
id: int32-type-dims
language: cpp
rule:
  any:
    - pattern: int $VAR = $DIMS[$INDEX]
    - pattern: int32_t $VAR = $DIMS[$INDEX]
constraints: 
  DIMS:
    any:
      - pattern: $EXPR.dims
      - pattern: $EXPR.dims()
      - pattern: $EXPR->dims
      - pattern: $EXPR->dims()
      - pattern: dims[$INDEX]
      - pattern: dims()[$INDEX]
message: Use int64_t instead of int/int32_t for dims (large tensor support)
severity: warning
note: dims returns int64_t values
fix:
  int64_t $VAR = $DIMS[$INDEX];
```


pcard-93269