### PR TITLE
[API Compatibility] Modified `paddle.compat` warning behavior and update url

### DIFF
--- a/python/paddle/nn/layer/common.py
+++ b/python/paddle/nn/layer/common.py
@@ -202,7 +202,7 @@ class Linear(Layer):
         illegal_keys={"bias", "device", "dtype"},
         func_name="paddle.nn.Linear",
         correct_name="paddle.compat.nn.Linear",
-        url_suffix="nn/torch.nn.Linear",
+        url_suffix="torch.nn.Linear",
     )
     def __init__(
         self,
@@ -2544,7 +2544,7 @@ class Unfold(Layer):
         illegal_keys={"kernel_size", "dilation", "padding", "stride"},
         func_name="paddle.nn.Unfold",
         correct_name="paddle.compat.nn.Unfold",
-        url_suffix="nn/torch.nn.Unfold",
+        url_suffix="torch.nn.Unfold",
     )
     def __init__(
         self,

--- a/python/paddle/tensor/compat_softmax.py
+++ b/python/paddle/tensor/compat_softmax.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
     ignore_param=('_stacklevel', 2, int),
     func_name="paddle.compat.nn.functional.softmax",
     correct_name="paddle.nn.functional.softmax",
+    url_suffix="torch.nn.functional.softmax",
 )
 def softmax(
     input: Tensor,

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -2744,7 +2744,7 @@ def row_stack(x: Sequence[Tensor], name: str | None = None) -> Tensor:
     illegal_keys={"tensor", "split_size_or_sections", "dim"},
     func_name="paddle.split",
     correct_name="paddle.compat.split",
-    url_suffix="torch/torch.split",
+    url_suffix="torch.split",
 )
 def split(
     x: Tensor,

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -2955,7 +2955,7 @@ def inverse(x: Tensor, name: str | None = None) -> Tensor:
     illegal_keys={"input", "dim", "other"},
     func_name="paddle.max",
     correct_name="paddle.compat.max",
-    url_suffix="torch/torch.max",
+    url_suffix="torch.max",
 )
 def max(
     x: Tensor,
@@ -3120,7 +3120,7 @@ def max(
     illegal_keys={"input", "dim", "other"},
     func_name="paddle.min",
     correct_name="paddle.compat.min",
-    url_suffix="torch/torch.min",
+    url_suffix="torch.min",
 )
 def min(
     x: Tensor,

--- a/python/paddle/tensor/search.py
+++ b/python/paddle/tensor/search.py
@@ -465,7 +465,7 @@ def _restrict_nonzero(condition: Tensor, total_true_num: int) -> Tensor:
     illegal_keys={'input', 'dim'},
     func_name='paddle.sort',
     correct_name='paddle.compat.sort',
-    url_suffix="torch/torch.sort",
+    url_suffix="torch.sort",
 )
 def sort(
     x: Tensor,

--- a/python/paddle/utils/decorator_utils.py
+++ b/python/paddle/utils/decorator_utils.py
@@ -452,7 +452,7 @@ class ForbidKeywordsDecorator(DecoratorBase):
                 will emit a warning upon the first call, warning the users about the API difference and points to Docs.
                 Please correctly specifying the `url_suffix`, this should be the suffix of the api-difference doc. For example:
 
-                (prefix omitted)/docs/zh/develop/guides/model_convert/convert_from_pytorch/api_difference/**torch/torch.nn.Unfold**.html
+                (prefix omitted)/docs/zh/develop/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/**torch.nn.Unfold**.html
 
                 In this example, the correct `url_suffix` should be 'torch/torch.nn.Unfold'. Defaults to an empty str.
         """
@@ -465,8 +465,8 @@ class ForbidKeywordsDecorator(DecoratorBase):
             self.warn_msg = (
                 f"The API '{func_name}' may behave differently from its PyTorch counterpart. "
                 "Refer to the compatibility guide for details:\n"
-                "https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/guides/model_convert/"
-                "convert_from_pytorch/pytorch_api_mapping_cn.html#api"
+                "https://www.paddlepaddle.org.cn/documentation/docs/en/develop/guides/model_convert/"
+                f"convert_from_pytorch/api_difference/invok_only_diff/{url_suffix}.html"
             )
 
     def process(
@@ -479,17 +479,19 @@ class ForbidKeywordsDecorator(DecoratorBase):
             keys_str = ", ".join(f"'{key}'" for key in found_keys)
             plural = "s" if len(found_keys) > 1 else ""
 
+            if (
+                self.warn_msg is not None
+            ):  # warn the users only when the API is mis-used
+                warnings.warn(
+                    self.warn_msg,
+                    category=UserWarning,
+                    stacklevel=3,
+                )
+                self.warn_msg = None
             raise TypeError(
                 f"{self.func_name}() received unexpected keyword argument{plural} {keys_str}. "
                 f"\nDid you mean to use {self.correct_name}() instead?"
             )
-        if self.warn_msg is not None:
-            warnings.warn(
-                self.warn_msg,
-                category=UserWarning,
-                stacklevel=3,
-            )
-            self.warn_msg = None
         return args, kwargs
 
 
@@ -514,7 +516,7 @@ class ForbidKeywordsIgnoreOneParamDecorator(ForbidKeywordsDecorator):
                 will emit a warning upon the first call, warning the users about the API difference and points to Docs.
                 Please correctly specifying the `url_suffix`, this should be the suffix of the api-difference doc. For example:
 
-                (prefix omitted)/docs/zh/develop/guides/model_convert/convert_from_pytorch/api_difference/**torch/torch.nn.Unfold**.html
+                (prefix omitted)/docs/zh/develop/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/**torch.nn.Unfold**.html
 
                 In this example, the correct `url_suffix` should be 'torch/torch.nn.Unfold'. Defaults to an empty str.
         """

--- a/test/compat/test_compat_warn.py
+++ b/test/compat/test_compat_warn.py
@@ -14,19 +14,18 @@
 
 import unittest
 
-import paddle.reader
+import paddle
 
 
 class TestForbidKeywordsDecorator(unittest.TestCase):
     def test(self):
-        x = paddle.randn([2, 2])
-        self.assertWarnsRegex(
-            UserWarning,
-            "may behave differently from its PyTorch counterpart",
-            paddle.split,
-            x,
-            2,
-        )
+        with self.assertRaises(TypeError) as cm:
+            self.assertWarnsRegex(
+                UserWarning,
+                "may behave differently from its PyTorch counterpart",
+                paddle.sort,
+            )
+            paddle.sort(input=paddle.to_tensor([2, 1, 3]), axis=0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Operator Mechanism


### PR Types
Improvements


### Description
修改了 `paddle.compat` 系列模块以及原 API 对应的 warning 行为：
- 调用原始 paddle API 不再弹出 warning，除非用户传入了错误的参数，会在第一次报错之后warn。
- 更新了 warning 展示的 URL。

更新后行为如下，测试对 `paddle.sort` 进行一个错误的输入（torch 的 kwarg `input`）：
```
>>> paddle.sort(input=paddle.to_tensor([2, 1, 3]), axis=0)
<stdin>:1: UserWarning: The API 'paddle.sort' may behave differently from its PyTorch counterpart. Refer to the compatibility guide for details:
https://www.paddlepaddle.org.cn/documentation/docs/en/develop/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torch.sort.html
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "~/Paddle/build/python/paddle/utils/decorator_utils.py", line 59, in wrapper
    processed_args, processed_kwargs = self.process(args, kwargs)
  File "~/Paddle/build/python/paddle/utils/decorator_utils.py", line 491, in process
    raise TypeError(
TypeError: paddle.sort() received unexpected keyword argument 'input'. 
Did you mean to use paddle.compat.sort() instead?
```

Pcard-89620
