### PR TITLE
[SOT][3.14] Replace `BINARY_SUBSCR` codegen with `BINARY_OP` in Python 3.14

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/pycode_generator.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/pycode_generator.py
@@ -805,7 +805,11 @@ class PyCodeGen:
         return self.add_instr("STORE_SUBSCR")
 
     def gen_subscribe(self):
-        return self.add_instr("BINARY_SUBSCR")
+        if sys.version_info < (3, 14):
+            return self.add_instr("BINARY_SUBSCR")
+        # see: https://docs.python.org/3.14/library/dis.html#opcode-BINARY_OP and
+        # https://github.com/python/cpython/blob/0e46c0499413bc5f9f8336fe76e2e67cf93f64d8/Include/opcode.h#L36
+        return self.add_instr("BINARY_OP", arg=26)
 
     def gen_build_tuple(self, count):
         return self.add_instr("BUILD_TUPLE", arg=count, argval=count)

--- a/python/paddle/jit/sot/opcode_translator/executor/pycode_generator.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/pycode_generator.py
@@ -49,6 +49,7 @@ from ..instruction_utils import (
 )
 from ..instruction_utils.opcode_info import (
     ALL_JUMP,
+    BINARY_OP_ARG_MAP,
     RETURN,
     UNCONDITIONAL_JUMP,
     JumpDirection,
@@ -809,7 +810,7 @@ class PyCodeGen:
             return self.add_instr("BINARY_SUBSCR")
         # see: https://docs.python.org/3.14/library/dis.html#opcode-BINARY_OP and
         # https://github.com/python/cpython/blob/0e46c0499413bc5f9f8336fe76e2e67cf93f64d8/Include/opcode.h#L36
-        return self.add_instr("BINARY_OP", arg=26)
+        return self.add_instr("BINARY_OP", arg=BINARY_OP_ARG_MAP["NB_SUBSCR"])
 
     def gen_build_tuple(self, count):
         return self.add_instr("BUILD_TUPLE", arg=count, argval=count)

--- a/python/paddle/jit/sot/opcode_translator/instruction_utils/opcode_info.py
+++ b/python/paddle/jit/sot/opcode_translator/instruction_utils/opcode_info.py
@@ -143,12 +143,13 @@ class ExceptionHandler:
     opname = "EXCEPT_HANDLER"
 
 
-BINARY_OP_ARG_MAP: dict[str, int] = {}
-
-
-@lambda func: func()
-def _get_binary_op_arg_map():
+def _get_binary_op_arg_map() -> dict[str, int]:
     if sys.version_info < (3, 11):
-        return
+        return {}
+    res = {}
     for i, op in enumerate(opcode._nb_ops):
-        BINARY_OP_ARG_MAP[op[0]] = i
+        res[op[0]] = i
+    return res
+
+
+BINARY_OP_ARG_MAP: dict[str, int] = _get_binary_op_arg_map()

--- a/python/paddle/jit/sot/opcode_translator/instruction_utils/opcode_info.py
+++ b/python/paddle/jit/sot/opcode_translator/instruction_utils/opcode_info.py
@@ -141,3 +141,12 @@ PYOPCODE_CACHE_SIZE = _get_pyopcode_cache_size()
 class ExceptionHandler:
     opcode = 257
     opname = "EXCEPT_HANDLER"
+
+
+BINARY_OP_ARG_MAP: dict[str, int] = {}
+
+
+@lambda func: func()
+def _get_binary_op_arg_map():
+    for i, op in enumerate(opcode._nb_ops):
+        BINARY_OP_ARG_MAP[op[0]] = i

--- a/python/paddle/jit/sot/opcode_translator/instruction_utils/opcode_info.py
+++ b/python/paddle/jit/sot/opcode_translator/instruction_utils/opcode_info.py
@@ -148,5 +148,7 @@ BINARY_OP_ARG_MAP: dict[str, int] = {}
 
 @lambda func: func()
 def _get_binary_op_arg_map():
+    if sys.version_info < (3, 11):
+        return
     for i, op in enumerate(opcode._nb_ops):
         BINARY_OP_ARG_MAP[op[0]] = i


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

New features

### Description
<!-- Describe what you’ve done -->

使用 `NB_SUBSCR` 替换 `BINARY_SUBSCR`

新通过的单测

* `test_03_tuple.py`
* `test_04_list.py`
* `test_05_dict.py`
* `test_07_unpack.py`
* `test_21_global.py`
* `test_collections_namedtuple.py`
* `test_enum.py`
* `test_sot_dynamic_shape.py`
* `test_trace_list_arg.py`

剩余单测 46