### PR TITLE
[large tensor] Use int64_t instead of int/int32_t for dims

### DIFF
--- a/ci/rule-tests/__snapshots__/no-int32-type-dims-snapshot.yml
+++ b/ci/rule-tests/__snapshots__/no-int32-type-dims-snapshot.yml
@@ -1,0 +1,42 @@
+id: no-int32-type-dims
+snapshots:
+  int class_num = prob->dims()[1];:
+    fixed: |
+      int64_t class_num = prob->dims()[1];
+      // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+      PADDLE_ENFORCE_LE_INT_MAX(class_num, "class_num");
+    labels:
+      - source: int class_num = prob->dims()[1];
+        style: primary
+        start: 0
+        end: 32
+  int input_ids_num = input.numel();:
+    fixed: |
+      int64_t input_ids_num = input.numel();
+      // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+      PADDLE_ENFORCE_LE_INT_MAX(input_ids_num, "input_ids_num");
+    labels:
+      - source: int input_ids_num = input.numel();
+        style: primary
+        start: 0
+        end: 34
+  int row_size = x.dims()[ndim - 1];:
+    fixed: |
+      int64_t row_size = x.dims()[ndim - 1];
+      // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+      PADDLE_ENFORCE_LE_INT_MAX(row_size, "row_size");
+    labels:
+      - source: int row_size = x.dims()[ndim - 1];
+        style: primary
+        start: 0
+        end: 34
+  int32_t input_ids_num = input.numel();:
+    fixed: |
+      int64_t input_ids_num = input.numel();
+      // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+      PADDLE_ENFORCE_LE_INT_MAX(input_ids_num, "input_ids_num");
+    labels:
+      - source: int32_t input_ids_num = input.numel();
+        style: primary
+        start: 0
+        end: 38

--- a/ci/rule-tests/__snapshots__/no-int32-type-dims-snapshot.yml
+++ b/ci/rule-tests/__snapshots__/no-int32-type-dims-snapshot.yml
@@ -4,7 +4,6 @@ snapshots:
     fixed: |
       int64_t class_num = prob->dims()[1];
       // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
-      PADDLE_ENFORCE_LE_INT_MAX(class_num, "class_num");
     labels:
       - source: int class_num = prob->dims()[1];
         style: primary
@@ -24,7 +23,6 @@ snapshots:
     fixed: |
       int64_t row_size = x.dims()[ndim - 1];
       // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
-      PADDLE_ENFORCE_LE_INT_MAX(row_size, "row_size");
     labels:
       - source: int row_size = x.dims()[ndim - 1];
         style: primary
@@ -34,7 +32,6 @@ snapshots:
     fixed: |
       int64_t input_ids_num = input.numel();
       // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
-      PADDLE_ENFORCE_LE_INT_MAX(input_ids_num, "input_ids_num");
     labels:
       - source: int32_t input_ids_num = input.numel();
         style: primary

--- a/ci/rule-tests/no-int32-type-dims.yml
+++ b/ci/rule-tests/no-int32-type-dims.yml
@@ -1,0 +1,9 @@
+id: no-int32-type-dims
+valid:
+  - int64_t input_ids_num = input.numel();
+  - int64_t class_num = prob->dims()[1];
+  - int64_t row_size = x.dims()[ndim - 1];
+invalid:
+  - int32_t input_ids_num = input.numel();
+  - int class_num = prob->dims()[1];
+  - int row_size = x.dims()[ndim - 1];

--- a/ci/rules/no-int32-type-dims.yml
+++ b/ci/rules/no-int32-type-dims.yml
@@ -30,25 +30,21 @@ constraints:
       - pattern: $E.dims()[$INDEX]
       - pattern: $E->dims[$INDEX]
       - pattern: $E->dims()[$INDEX]
-      - pattern: dims[$INDEX]
-      - pattern: dims()[$INDEX]
       # shape[...] / expr.shape()[...] / expr->shape()[...]
       - pattern: $E.shape[$INDEX]
       - pattern: $E.shape()[$INDEX]
       - pattern: $E->shape[$INDEX]
       - pattern: $E->shape()[$INDEX]
-      - pattern: shape[$INDEX]
-      - pattern: shape()[$INDEX]
       # strides[...] / expr.strides()[...] / expr->strides()[...]
       - pattern: $E.strides[$INDEX]
       - pattern: $E.strides()[$INDEX]
       - pattern: $E->strides[$INDEX]
       - pattern: $E->strides()[$INDEX]
-      - pattern: strides[$INDEX]
-      - pattern: strides()[$INDEX]
       # numel / numel()
       - pattern: $E.numel
       - pattern: $E.numel()
+      - pattern: $E->numel()
+      - pattern: $E->numel()
         # offset / offset()
         # unsafe
         # - pattern: $E.offset
@@ -56,4 +52,3 @@ constraints:
 fix: |
   int64_t $VAR = $RIGHT;
   // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX($VAR, "$VAR");

--- a/ci/rules/no-int32-type-dims.yml
+++ b/ci/rules/no-int32-type-dims.yml
@@ -1,0 +1,57 @@
+id: no-int32-type-dims
+language: cpp
+files:
+  - paddle/phi/kernels/**
+ignores:
+  - paddle/phi/kernels/legacy/**
+  - paddle/phi/kernels/xpu/**
+  - paddle/phi/kernels/custom/**
+  - paddle/phi/kernels/sparse/**
+severity: warning
+message: Use int64_t instead of int/int32_t for dims/shape/strides/numel/offset (large tensor support)
+note: dims/shape/strides/numel/offset may be >= INT32_MAX; dims()/numel() return int64_t
+rule:
+  any:
+    # int x = <RIGHT>;
+    - pattern: int $VAR = $RIGHT
+    # int32_t x = <RIGHT>;
+    - pattern: int32_t $VAR = $RIGHT
+    # direct-initializer: int x(<RIGHT>);
+    - pattern: int $VAR($RIGHT)
+    # direct-initializer: int32_t x(<RIGHT>);
+    - pattern: int32_t $VAR($RIGHT)
+constraints:
+  RIGHT:
+    any:
+      # dims[...] / expr.dims()[...] / expr->dims()[...]
+      - pattern: $E.dims[$INDEX]
+      - pattern: $E.dims()[$INDEX]
+      - pattern: $E->dims[$INDEX]
+      - pattern: $E->dims()[$INDEX]
+      - pattern: dims[$INDEX]
+      - pattern: dims()[$INDEX]
+      # shape[...] / expr.shape()[...] / expr->shape()[...]
+      - pattern: $E.shape[$INDEX]
+      - pattern: $E.shape()[$INDEX]
+      - pattern: $E->shape[$INDEX]
+      - pattern: $E->shape()[$INDEX]
+      - pattern: shape[$INDEX]
+      - pattern: shape()[$INDEX]
+      # strides[...] / expr.strides()[...] / expr->strides()[...]
+      - pattern: $E.strides[$INDEX]
+      - pattern: $E.strides()[$INDEX]
+      - pattern: $E->strides[$INDEX]
+      - pattern: $E->strides()[$INDEX]
+      - pattern: strides[$INDEX]
+      - pattern: strides()[$INDEX]
+      # numel / numel()
+      - pattern: $E.numel
+      - pattern: $E.numel()
+        # offset / offset()
+        # unsafe
+        # - pattern: $E.offset
+        # - pattern: $E.offset()
+fix: |
+  int64_t $VAR = $RIGHT;
+  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX($VAR, "$VAR");

--- a/ci/rules/no-int32-type-dims.yml
+++ b/ci/rules/no-int32-type-dims.yml
@@ -7,8 +7,10 @@ ignores:
   - paddle/phi/kernels/xpu/**
   - paddle/phi/kernels/custom/**
   - paddle/phi/kernels/sparse/**
-severity: warning
-message: Use int64_t instead of int/int32_t for dims/shape/strides/numel/offset (large tensor support)
+severity: error
+message: |
+  Use int64_t instead of int/int32_t for dims/shape/strides/numel/offset (large tensor support).
+  If it is a false positive, please contact zrr1999 (Recommend), wanghuancoder for more information.
 note: dims/shape/strides/numel/offset may be >= INT32_MAX; dims()/numel() return int64_t
 rule:
   any:

--- a/paddle/common/enforce.h
+++ b/paddle/common/enforce.h
@@ -335,6 +335,16 @@ using CommonType2 = typename std::add_lvalue_reference<
 #define PADDLE_ENFORCE_LE(__VAL0, __VAL1, ...) \
   __PADDLE_BINARY_COMPARE(__VAL0, __VAL1, <=, >, __VA_ARGS__)
 
+#define PADDLE_ENFORCE_LE_INT_MAX(var, var_name)                             \
+  PADDLE_ENFORCE_LE(var,                                                     \
+                    std::numeric_limits<int>::max(),                         \
+                    common::errors::InvalidArgument(                         \
+                        "Tensor dimension %s=%ld exceeds the maximum value " \
+                        "that int can represent (%d).",                      \
+                        var_name,                                            \
+                        var,                                                 \
+                        std::numeric_limits<int>::max()))
+
 TEST_API bool RegisterLogSimplyStr(const std::string& type,
                                    const std::string& simply);
 template <typename T>

--- a/paddle/phi/kernels/cpu/tdm_child_kernel.cc
+++ b/paddle/phi/kernels/cpu/tdm_child_kernel.cc
@@ -36,7 +36,11 @@ void TDMChildInner(const Context &dev_ctx,
   int node_nums = info_dims[0];
   int length = info_dims[1];
 
-  int input_ids_num = input.numel();
+  int64_t input_ids_num = input.numel();
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(input_ids_num, "input_ids_num");
+
   VLOG(4) << "TDM child op: input numel ->  " << input_ids_num;
 
   std::vector<OutT> child_vec{};

--- a/paddle/phi/kernels/cpu/tdm_child_kernel.cc
+++ b/paddle/phi/kernels/cpu/tdm_child_kernel.cc
@@ -39,7 +39,6 @@ void TDMChildInner(const Context &dev_ctx,
   int64_t input_ids_num = input.numel();
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(input_ids_num, "input_ids_num");
 
   VLOG(4) << "TDM child op: input numel ->  " << input_ids_num;
 

--- a/paddle/phi/kernels/cpu/tdm_sampler_kernel.cc
+++ b/paddle/phi/kernels/cpu/tdm_sampler_kernel.cc
@@ -43,7 +43,11 @@ void TDMSamplerInner(const Context &dev_ctx,
                      phi::DenseTensor *label,
                      phi::DenseTensor *mask) {
   // get dimension
-  int input_ids_num = input_tensor.numel();
+  int64_t input_ids_num = input_tensor.numel();
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(input_ids_num, "input_ids_num");
+
   VLOG(3) << "TDM: input ids nums: " << input_ids_num;
   auto layer_nums = neg_samples_num_list.size();
   VLOG(3) << "TDM: tree layer nums: " << layer_nums;

--- a/paddle/phi/kernels/cpu/tdm_sampler_kernel.cc
+++ b/paddle/phi/kernels/cpu/tdm_sampler_kernel.cc
@@ -46,7 +46,6 @@ void TDMSamplerInner(const Context &dev_ctx,
   int64_t input_ids_num = input_tensor.numel();
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(input_ids_num, "input_ids_num");
 
   VLOG(3) << "TDM: input ids nums: " << input_ids_num;
   auto layer_nums = neg_samples_num_list.size();

--- a/paddle/phi/kernels/funcs/cross_entropy.cu
+++ b/paddle/phi/kernels/funcs/cross_entropy.cu
@@ -125,12 +125,10 @@ void CrossEntropyFunctor<DeviceContext, T>::operator()(
   int64_t batch_size = prob->dims()[0];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(batch_size, "batch_size");
 
   int64_t class_num = prob->dims()[1];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(class_num, "class_num");
 
   constexpr int kMaxBlockDim = 512;
 

--- a/paddle/phi/kernels/funcs/cross_entropy.cu
+++ b/paddle/phi/kernels/funcs/cross_entropy.cu
@@ -122,8 +122,16 @@ void CrossEntropyFunctor<DeviceContext, T>::operator()(
   T* loss_data = dev_ctx.template Alloc<T>(out);
   const T* prob_data = prob->data<T>();
 
-  int batch_size = prob->dims()[0];
-  int class_num = prob->dims()[1];
+  int64_t batch_size = prob->dims()[0];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(batch_size, "batch_size");
+
+  int64_t class_num = prob->dims()[1];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(class_num, "class_num");
+
   constexpr int kMaxBlockDim = 512;
 
   // big tensor currently not supported

--- a/paddle/phi/kernels/funcs/fake_dequantize_functor.cu
+++ b/paddle/phi/kernels/funcs/fake_dequantize_functor.cu
@@ -142,7 +142,11 @@ void ChannelDequantizeFunctor<Context, T>::operator()(
     // quantized on. `x_num_col_dims` is -1 for operator in ['matmul',
     // 'matmul_v2', 'mul'] and is 1 for other operators.
     int64_t num = in->numel();
-    int n_scales = in->dims()[x_num_col_dims];
+    int64_t n_scales = in->dims()[x_num_col_dims];
+    // TODO(large-tensor): downstream functors may still use int; guard until
+    // upgraded.
+    PADDLE_ENFORCE_LE_INT_MAX(n_scales, "n_scales");
+
     const T* scale_one = scales[0]->data<T>();
     const T* scale_two = scales[1]->data<T>();
 

--- a/paddle/phi/kernels/funcs/fake_dequantize_functor.cu
+++ b/paddle/phi/kernels/funcs/fake_dequantize_functor.cu
@@ -145,7 +145,6 @@ void ChannelDequantizeFunctor<Context, T>::operator()(
     int64_t n_scales = in->dims()[x_num_col_dims];
     // TODO(large-tensor): downstream functors may still use int; guard until
     // upgraded.
-    PADDLE_ENFORCE_LE_INT_MAX(n_scales, "n_scales");
 
     const T* scale_one = scales[0]->data<T>();
     const T* scale_two = scales[1]->data<T>();

--- a/paddle/phi/kernels/funcs/im2col.cu
+++ b/paddle/phi/kernels/funcs/im2col.cu
@@ -124,22 +124,18 @@ class Im2ColFunctor<phi::funcs::ColFormat::kCFO, DeviceContext, T> {
     int64_t filter_height = col->dims()[1];
     // TODO(large-tensor): downstream functors may still use int; guard until
     // upgraded.
-    PADDLE_ENFORCE_LE_INT_MAX(filter_height, "filter_height");
 
     int64_t filter_width = col->dims()[2];
     // TODO(large-tensor): downstream functors may still use int; guard until
     // upgraded.
-    PADDLE_ENFORCE_LE_INT_MAX(filter_width, "filter_width");
 
     int64_t col_height = col->dims()[3];
     // TODO(large-tensor): downstream functors may still use int; guard until
     // upgraded.
-    PADDLE_ENFORCE_LE_INT_MAX(col_height, "col_height");
 
     int64_t col_width = col->dims()[4];
     // TODO(large-tensor): downstream functors may still use int; guard until
     // upgraded.
-    PADDLE_ENFORCE_LE_INT_MAX(col_width, "col_width");
 
     int num_outputs = im_channels * col_height * col_width;
     int num_thread = 1024;
@@ -274,22 +270,18 @@ class Col2ImFunctor<phi::funcs::ColFormat::kCFO, DeviceContext, T> {
     int64_t filter_height = col.dims()[1];
     // TODO(large-tensor): downstream functors may still use int; guard until
     // upgraded.
-    PADDLE_ENFORCE_LE_INT_MAX(filter_height, "filter_height");
 
     int64_t filter_width = col.dims()[2];
     // TODO(large-tensor): downstream functors may still use int; guard until
     // upgraded.
-    PADDLE_ENFORCE_LE_INT_MAX(filter_width, "filter_width");
 
     int64_t col_height = col.dims()[3];
     // TODO(large-tensor): downstream functors may still use int; guard until
     // upgraded.
-    PADDLE_ENFORCE_LE_INT_MAX(col_height, "col_height");
 
     int64_t col_width = col.dims()[4];
     // TODO(large-tensor): downstream functors may still use int; guard until
     // upgraded.
-    PADDLE_ENFORCE_LE_INT_MAX(col_width, "col_width");
 
     PADDLE_ENFORCE_EQ(
         (im_height + padding[0] + padding[2] -
@@ -439,37 +431,30 @@ class Im2ColFunctor<phi::funcs::ColFormat::kOCF, DeviceContext, T> {
     int64_t im_channels = im.dims()[0];
     // TODO(large-tensor): downstream functors may still use int; guard until
     // upgraded.
-    PADDLE_ENFORCE_LE_INT_MAX(im_channels, "im_channels");
 
     int64_t im_height = im.dims()[1];
     // TODO(large-tensor): downstream functors may still use int; guard until
     // upgraded.
-    PADDLE_ENFORCE_LE_INT_MAX(im_height, "im_height");
 
     int64_t im_width = im.dims()[2];
     // TODO(large-tensor): downstream functors may still use int; guard until
     // upgraded.
-    PADDLE_ENFORCE_LE_INT_MAX(im_width, "im_width");
 
     int64_t filter_height = col->dims()[3];
     // TODO(large-tensor): downstream functors may still use int; guard until
     // upgraded.
-    PADDLE_ENFORCE_LE_INT_MAX(filter_height, "filter_height");
 
     int64_t filter_width = col->dims()[4];
     // TODO(large-tensor): downstream functors may still use int; guard until
     // upgraded.
-    PADDLE_ENFORCE_LE_INT_MAX(filter_width, "filter_width");
 
     int64_t col_height = col->dims()[0];
     // TODO(large-tensor): downstream functors may still use int; guard until
     // upgraded.
-    PADDLE_ENFORCE_LE_INT_MAX(col_height, "col_height");
 
     int64_t col_width = col->dims()[1];
     // TODO(large-tensor): downstream functors may still use int; guard until
     // upgraded.
-    PADDLE_ENFORCE_LE_INT_MAX(col_width, "col_width");
 
     int block_dim_x = 0;
     int block_dim_y = 0;
@@ -578,37 +563,30 @@ class Col2ImFunctor<phi::funcs::ColFormat::kOCF, DeviceContext, T> {
     int64_t im_channels = im->dims()[0];
     // TODO(large-tensor): downstream functors may still use int; guard until
     // upgraded.
-    PADDLE_ENFORCE_LE_INT_MAX(im_channels, "im_channels");
 
     int64_t im_height = im->dims()[1];
     // TODO(large-tensor): downstream functors may still use int; guard until
     // upgraded.
-    PADDLE_ENFORCE_LE_INT_MAX(im_height, "im_height");
 
     int64_t im_width = im->dims()[2];
     // TODO(large-tensor): downstream functors may still use int; guard until
     // upgraded.
-    PADDLE_ENFORCE_LE_INT_MAX(im_width, "im_width");
 
     int64_t filter_height = col.dims()[3];
     // TODO(large-tensor): downstream functors may still use int; guard until
     // upgraded.
-    PADDLE_ENFORCE_LE_INT_MAX(filter_height, "filter_height");
 
     int64_t filter_width = col.dims()[4];
     // TODO(large-tensor): downstream functors may still use int; guard until
     // upgraded.
-    PADDLE_ENFORCE_LE_INT_MAX(filter_width, "filter_width");
 
     int64_t col_height = col.dims()[0];
     // TODO(large-tensor): downstream functors may still use int; guard until
     // upgraded.
-    PADDLE_ENFORCE_LE_INT_MAX(col_height, "col_height");
 
     int64_t col_width = col.dims()[1];
     // TODO(large-tensor): downstream functors may still use int; guard until
     // upgraded.
-    PADDLE_ENFORCE_LE_INT_MAX(col_width, "col_width");
 
     PADDLE_ENFORCE_EQ(
         (im_height + padding[0] + padding[2] -

--- a/paddle/phi/kernels/funcs/im2col.cu
+++ b/paddle/phi/kernels/funcs/im2col.cu
@@ -488,7 +488,9 @@ class Im2ColFunctor<phi::funcs::ColFormat::kOCF, DeviceContext, T> {
     }
 
     int block_dim_z = 1024 / block_dim_x / block_dim_y;
-    dim3 threads(block_dim_x, block_dim_y, std::min(block_dim_z, im_channels));
+    dim3 threads(block_dim_x,
+                 block_dim_y,
+                 std::min(block_dim_z, static_cast<int>(im_channels)));
     dim3 grid(col_width, col_height);
     im2colOCF<T><<<grid, threads, 0, dev_ctx.stream()>>>(im.data<T>(),
                                                          im_channels,
@@ -642,7 +644,9 @@ class Col2ImFunctor<phi::funcs::ColFormat::kOCF, DeviceContext, T> {
     }
 
     int block_dim_z = 1024 / block_dim_x / block_dim_y;
-    dim3 threads(block_dim_x, block_dim_y, std::min(block_dim_z, im_channels));
+    dim3 threads(block_dim_x,
+                 block_dim_y,
+                 std::min(block_dim_z, static_cast<int>(im_channels)));
     dim3 grid(col_width, col_height);
     col2imOCF<T><<<grid, threads, 0, dev_ctx.stream()>>>(col.data<T>(),
                                                          im_channels,

--- a/paddle/phi/kernels/funcs/im2col.cu
+++ b/paddle/phi/kernels/funcs/im2col.cu
@@ -121,10 +121,25 @@ class Im2ColFunctor<phi::funcs::ColFormat::kCFO, DeviceContext, T> {
         (data_layout != DataLayout::kNHWC ? im.dims()[1] : im.dims()[0]);
     int im_width =
         (data_layout != DataLayout::kNHWC ? im.dims()[2] : im.dims()[1]);
-    int filter_height = col->dims()[1];
-    int filter_width = col->dims()[2];
-    int col_height = col->dims()[3];
-    int col_width = col->dims()[4];
+    int64_t filter_height = col->dims()[1];
+    // TODO(large-tensor): downstream functors may still use int; guard until
+    // upgraded.
+    PADDLE_ENFORCE_LE_INT_MAX(filter_height, "filter_height");
+
+    int64_t filter_width = col->dims()[2];
+    // TODO(large-tensor): downstream functors may still use int; guard until
+    // upgraded.
+    PADDLE_ENFORCE_LE_INT_MAX(filter_width, "filter_width");
+
+    int64_t col_height = col->dims()[3];
+    // TODO(large-tensor): downstream functors may still use int; guard until
+    // upgraded.
+    PADDLE_ENFORCE_LE_INT_MAX(col_height, "col_height");
+
+    int64_t col_width = col->dims()[4];
+    // TODO(large-tensor): downstream functors may still use int; guard until
+    // upgraded.
+    PADDLE_ENFORCE_LE_INT_MAX(col_width, "col_width");
 
     int num_outputs = im_channels * col_height * col_width;
     int num_thread = 1024;
@@ -256,10 +271,25 @@ class Col2ImFunctor<phi::funcs::ColFormat::kCFO, DeviceContext, T> {
         (data_layout != DataLayout::kNHWC ? im->dims()[1] : im->dims()[0]);
     int im_width =
         (data_layout != DataLayout::kNHWC ? im->dims()[2] : im->dims()[1]);
-    int filter_height = col.dims()[1];
-    int filter_width = col.dims()[2];
-    int col_height = col.dims()[3];
-    int col_width = col.dims()[4];
+    int64_t filter_height = col.dims()[1];
+    // TODO(large-tensor): downstream functors may still use int; guard until
+    // upgraded.
+    PADDLE_ENFORCE_LE_INT_MAX(filter_height, "filter_height");
+
+    int64_t filter_width = col.dims()[2];
+    // TODO(large-tensor): downstream functors may still use int; guard until
+    // upgraded.
+    PADDLE_ENFORCE_LE_INT_MAX(filter_width, "filter_width");
+
+    int64_t col_height = col.dims()[3];
+    // TODO(large-tensor): downstream functors may still use int; guard until
+    // upgraded.
+    PADDLE_ENFORCE_LE_INT_MAX(col_height, "col_height");
+
+    int64_t col_width = col.dims()[4];
+    // TODO(large-tensor): downstream functors may still use int; guard until
+    // upgraded.
+    PADDLE_ENFORCE_LE_INT_MAX(col_width, "col_width");
 
     PADDLE_ENFORCE_EQ(
         (im_height + padding[0] + padding[2] -
@@ -406,13 +436,40 @@ class Im2ColFunctor<phi::funcs::ColFormat::kOCF, DeviceContext, T> {
                           "the dims of tensor 'col' is [%s].",
                           col->dims()));
 
-    int im_channels = im.dims()[0];
-    int im_height = im.dims()[1];
-    int im_width = im.dims()[2];
-    int filter_height = col->dims()[3];
-    int filter_width = col->dims()[4];
-    int col_height = col->dims()[0];
-    int col_width = col->dims()[1];
+    int64_t im_channels = im.dims()[0];
+    // TODO(large-tensor): downstream functors may still use int; guard until
+    // upgraded.
+    PADDLE_ENFORCE_LE_INT_MAX(im_channels, "im_channels");
+
+    int64_t im_height = im.dims()[1];
+    // TODO(large-tensor): downstream functors may still use int; guard until
+    // upgraded.
+    PADDLE_ENFORCE_LE_INT_MAX(im_height, "im_height");
+
+    int64_t im_width = im.dims()[2];
+    // TODO(large-tensor): downstream functors may still use int; guard until
+    // upgraded.
+    PADDLE_ENFORCE_LE_INT_MAX(im_width, "im_width");
+
+    int64_t filter_height = col->dims()[3];
+    // TODO(large-tensor): downstream functors may still use int; guard until
+    // upgraded.
+    PADDLE_ENFORCE_LE_INT_MAX(filter_height, "filter_height");
+
+    int64_t filter_width = col->dims()[4];
+    // TODO(large-tensor): downstream functors may still use int; guard until
+    // upgraded.
+    PADDLE_ENFORCE_LE_INT_MAX(filter_width, "filter_width");
+
+    int64_t col_height = col->dims()[0];
+    // TODO(large-tensor): downstream functors may still use int; guard until
+    // upgraded.
+    PADDLE_ENFORCE_LE_INT_MAX(col_height, "col_height");
+
+    int64_t col_width = col->dims()[1];
+    // TODO(large-tensor): downstream functors may still use int; guard until
+    // upgraded.
+    PADDLE_ENFORCE_LE_INT_MAX(col_width, "col_width");
 
     int block_dim_x = 0;
     int block_dim_y = 0;
@@ -516,13 +573,40 @@ class Col2ImFunctor<phi::funcs::ColFormat::kOCF, DeviceContext, T> {
                           "the dims of tensor 'col' is [%s].",
                           col.dims()));
 
-    int im_channels = im->dims()[0];
-    int im_height = im->dims()[1];
-    int im_width = im->dims()[2];
-    int filter_height = col.dims()[3];
-    int filter_width = col.dims()[4];
-    int col_height = col.dims()[0];
-    int col_width = col.dims()[1];
+    int64_t im_channels = im->dims()[0];
+    // TODO(large-tensor): downstream functors may still use int; guard until
+    // upgraded.
+    PADDLE_ENFORCE_LE_INT_MAX(im_channels, "im_channels");
+
+    int64_t im_height = im->dims()[1];
+    // TODO(large-tensor): downstream functors may still use int; guard until
+    // upgraded.
+    PADDLE_ENFORCE_LE_INT_MAX(im_height, "im_height");
+
+    int64_t im_width = im->dims()[2];
+    // TODO(large-tensor): downstream functors may still use int; guard until
+    // upgraded.
+    PADDLE_ENFORCE_LE_INT_MAX(im_width, "im_width");
+
+    int64_t filter_height = col.dims()[3];
+    // TODO(large-tensor): downstream functors may still use int; guard until
+    // upgraded.
+    PADDLE_ENFORCE_LE_INT_MAX(filter_height, "filter_height");
+
+    int64_t filter_width = col.dims()[4];
+    // TODO(large-tensor): downstream functors may still use int; guard until
+    // upgraded.
+    PADDLE_ENFORCE_LE_INT_MAX(filter_width, "filter_width");
+
+    int64_t col_height = col.dims()[0];
+    // TODO(large-tensor): downstream functors may still use int; guard until
+    // upgraded.
+    PADDLE_ENFORCE_LE_INT_MAX(col_height, "col_height");
+
+    int64_t col_width = col.dims()[1];
+    // TODO(large-tensor): downstream functors may still use int; guard until
+    // upgraded.
+    PADDLE_ENFORCE_LE_INT_MAX(col_width, "col_width");
 
     PADDLE_ENFORCE_EQ(
         (im_height + padding[0] + padding[2] -

--- a/paddle/phi/kernels/funcs/vol2col.cu
+++ b/paddle/phi/kernels/funcs/vol2col.cu
@@ -138,32 +138,26 @@ void Vol2ColFunctor<DeviceContext, T>::operator()(
   int64_t filter_depth = col->dims()[1];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(filter_depth, "filter_depth");
 
   int64_t filter_height = col->dims()[2];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(filter_height, "filter_height");
 
   int64_t filter_width = col->dims()[3];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(filter_width, "filter_width");
 
   int64_t output_depth = col->dims()[4];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(output_depth, "output_depth");
 
   int64_t output_height = col->dims()[5];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(output_height, "output_height");
 
   int64_t output_width = col->dims()[6];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(output_width, "output_width");
 
   bool paddings_size_is_6 = (paddings.size() == 6);
   int pad_d_forth = paddings_size_is_6 ? paddings[0] : paddings[0];
@@ -370,32 +364,26 @@ void Col2VolFunctor<DeviceContext, T>::operator()(
   int64_t filter_depth = col.dims()[1];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(filter_depth, "filter_depth");
 
   int64_t filter_height = col.dims()[2];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(filter_height, "filter_height");
 
   int64_t filter_width = col.dims()[3];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(filter_width, "filter_width");
 
   int64_t output_depth = col.dims()[4];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(output_depth, "output_depth");
 
   int64_t output_height = col.dims()[5];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(output_height, "output_height");
 
   int64_t output_width = col.dims()[6];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(output_width, "output_width");
 
   bool paddings_size_is_6 = (paddings.size() == 6);
   int pad_d_forth = paddings_size_is_6 ? paddings[0] : paddings[0];

--- a/paddle/phi/kernels/funcs/vol2col.cu
+++ b/paddle/phi/kernels/funcs/vol2col.cu
@@ -135,12 +135,35 @@ void Vol2ColFunctor<DeviceContext, T>::operator()(
       (data_layout != DataLayout::kNHWC ? vol.dims()[2] : vol.dims()[1]);
   int input_width =
       (data_layout != DataLayout::kNHWC ? vol.dims()[3] : vol.dims()[2]);
-  int filter_depth = col->dims()[1];
-  int filter_height = col->dims()[2];
-  int filter_width = col->dims()[3];
-  int output_depth = col->dims()[4];
-  int output_height = col->dims()[5];
-  int output_width = col->dims()[6];
+  int64_t filter_depth = col->dims()[1];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(filter_depth, "filter_depth");
+
+  int64_t filter_height = col->dims()[2];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(filter_height, "filter_height");
+
+  int64_t filter_width = col->dims()[3];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(filter_width, "filter_width");
+
+  int64_t output_depth = col->dims()[4];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(output_depth, "output_depth");
+
+  int64_t output_height = col->dims()[5];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(output_height, "output_height");
+
+  int64_t output_width = col->dims()[6];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(output_width, "output_width");
 
   bool paddings_size_is_6 = (paddings.size() == 6);
   int pad_d_forth = paddings_size_is_6 ? paddings[0] : paddings[0];
@@ -344,12 +367,35 @@ void Col2VolFunctor<DeviceContext, T>::operator()(
       (data_layout != DataLayout::kNHWC ? vol->dims()[2] : vol->dims()[1]);
   int input_width =
       (data_layout != DataLayout::kNHWC ? vol->dims()[3] : vol->dims()[2]);
-  int filter_depth = col.dims()[1];
-  int filter_height = col.dims()[2];
-  int filter_width = col.dims()[3];
-  int output_depth = col.dims()[4];
-  int output_height = col.dims()[5];
-  int output_width = col.dims()[6];
+  int64_t filter_depth = col.dims()[1];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(filter_depth, "filter_depth");
+
+  int64_t filter_height = col.dims()[2];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(filter_height, "filter_height");
+
+  int64_t filter_width = col.dims()[3];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(filter_width, "filter_width");
+
+  int64_t output_depth = col.dims()[4];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(output_depth, "output_depth");
+
+  int64_t output_height = col.dims()[5];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(output_height, "output_height");
+
+  int64_t output_width = col.dims()[6];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(output_width, "output_width");
 
   bool paddings_size_is_6 = (paddings.size() == 6);
   int pad_d_forth = paddings_size_is_6 ? paddings[0] : paddings[0];

--- a/paddle/phi/kernels/funcs/weight_only_gemv.cu
+++ b/paddle/phi/kernels/funcs/weight_only_gemv.cu
@@ -1357,9 +1357,20 @@ void WeightOnlyGemvKernel(const Context& dev_ctx,
   const T* bias_data = bias ? bias.get().data<T>() : nullptr;
   const T* weight_scale_data = weight_scale.data<T>();
   T* out_data = dev_ctx.template Alloc<T>(out);
-  int m = x.dims()[0];
-  int k = x.dims()[1];
-  int n = weight.dims()[0];
+  int64_t m = x.dims()[0];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(m, "m");
+
+  int64_t k = x.dims()[1];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(k, "k");
+
+  int64_t n = weight.dims()[0];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(n, "n");
 
   WeightOnlyGemvWrapper<T>(dev_ctx,
                            x_data,

--- a/paddle/phi/kernels/funcs/weight_only_gemv.cu
+++ b/paddle/phi/kernels/funcs/weight_only_gemv.cu
@@ -1360,17 +1360,14 @@ void WeightOnlyGemvKernel(const Context& dev_ctx,
   int64_t m = x.dims()[0];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(m, "m");
 
   int64_t k = x.dims()[1];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(k, "k");
 
   int64_t n = weight.dims()[0];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(n, "n");
 
   WeightOnlyGemvWrapper<T>(dev_ctx,
                            x_data,

--- a/paddle/phi/kernels/fusion/gpu/block_multi_head_attention_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/block_multi_head_attention_kernel.cu
@@ -811,15 +811,11 @@ void DispatchWithDtype(
   // VLOGMatrix(
   //     fmha_buf.data<T>(), fmha_buf.numel(), "fmha_buf", fmha_buf.numel());
   if (out_scale > 0) {
-    int64_t m = fmha_out->dims()[0];
-    // TODO(large-tensor): downstream functors may still use int; guard until
-    // upgraded.
-    PADDLE_ENFORCE_LE_INT_MAX(m, "m");
+    int m = static_cast<int>(fmha_out->dims()[0]);
+    // TODO(large-tensor): use static_cast<int> for some test
 
-    int64_t n = fmha_out->dims()[1];
-    // TODO(large-tensor): downstream functors may still use int; guard until
-    // upgraded.
-    PADDLE_ENFORCE_LE_INT_MAX(n, "n");
+    int n = static_cast<int>(fmha_out->dims()[1]);
+    // TODO(large-tensor): use static_cast<int> for some test
 
 #ifdef PADDLE_WITH_HIP
     dim3 grid(((n >> 2) + 63) / 64, (m + 7) / 8);

--- a/paddle/phi/kernels/fusion/gpu/block_multi_head_attention_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/block_multi_head_attention_kernel.cu
@@ -811,8 +811,16 @@ void DispatchWithDtype(
   // VLOGMatrix(
   //     fmha_buf.data<T>(), fmha_buf.numel(), "fmha_buf", fmha_buf.numel());
   if (out_scale > 0) {
-    int m = fmha_out->dims()[0];
-    int n = fmha_out->dims()[1];
+    int64_t m = fmha_out->dims()[0];
+    // TODO(large-tensor): downstream functors may still use int; guard until
+    // upgraded.
+    PADDLE_ENFORCE_LE_INT_MAX(m, "m");
+
+    int64_t n = fmha_out->dims()[1];
+    // TODO(large-tensor): downstream functors may still use int; guard until
+    // upgraded.
+    PADDLE_ENFORCE_LE_INT_MAX(n, "n");
+
 #ifdef PADDLE_WITH_HIP
     dim3 grid(((n >> 2) + 63) / 64, (m + 7) / 8);
     dim3 block(64, 8);

--- a/paddle/phi/kernels/fusion/gpu/fused_multi_transformer_int8_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/fused_multi_transformer_int8_kernel.cu
@@ -386,7 +386,6 @@ void FusedMultiTransformerINT8OpKernel(
       int64_t max_seq_len = cache_kv->dims()[3];
       // TODO(large-tensor): downstream functors may still use int; guard until
       // upgraded.
-      PADDLE_ENFORCE_LE_INT_MAX(max_seq_len, "max_seq_len");
 
       phi::fusion::fmha<T>(dev_ctx,
                            qkv_out,
@@ -433,7 +432,6 @@ void FusedMultiTransformerINT8OpKernel(
       int64_t max_seq_len = cache_kv_out->dims()[3];
       // TODO(large-tensor): downstream functors may still use int; guard until
       // upgraded.
-      PADDLE_ENFORCE_LE_INT_MAX(max_seq_len, "max_seq_len");
 
       T *cache_kv_data = cache_kv_out->data<T>();
       int64_t cache_k_size = bsz * num_head * max_seq_len * dim_head;

--- a/paddle/phi/kernels/fusion/gpu/fused_multi_transformer_int8_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/fused_multi_transformer_int8_kernel.cu
@@ -383,7 +383,11 @@ void FusedMultiTransformerINT8OpKernel(
 
     if (time_step) {  // generation decoder stage
       // [2, batch_size, num_head, max_seq_len, head_size]
-      int max_seq_len = cache_kv->dims()[3];
+      int64_t max_seq_len = cache_kv->dims()[3];
+      // TODO(large-tensor): downstream functors may still use int; guard until
+      // upgraded.
+      PADDLE_ENFORCE_LE_INT_MAX(max_seq_len, "max_seq_len");
+
       phi::fusion::fmha<T>(dev_ctx,
                            qkv_out,
                            *qkv_bias,
@@ -426,7 +430,11 @@ void FusedMultiTransformerINT8OpKernel(
       const T *v_ptr = k_ptr + k_size;
 
       // [2, bsz, num_head, max_seq_len, head_dim]
-      int max_seq_len = cache_kv_out->dims()[3];
+      int64_t max_seq_len = cache_kv_out->dims()[3];
+      // TODO(large-tensor): downstream functors may still use int; guard until
+      // upgraded.
+      PADDLE_ENFORCE_LE_INT_MAX(max_seq_len, "max_seq_len");
+
       T *cache_kv_data = cache_kv_out->data<T>();
       int64_t cache_k_size = bsz * num_head * max_seq_len * dim_head;
 

--- a/paddle/phi/kernels/fusion/gpu/fused_multi_transformer_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/fused_multi_transformer_kernel.cu
@@ -562,7 +562,6 @@ void FusedMultiTransformerOpKernel(
         int64_t max_seq_len = cache_kv->dims()[3];
         // TODO(large-tensor): downstream functors may still use int; guard
         // until upgraded.
-        PADDLE_ENFORCE_LE_INT_MAX(max_seq_len, "max_seq_len");
 
         phi::fusion::mbfmha<T>(dev_ctx,
                                qkv_out,
@@ -595,7 +594,6 @@ void FusedMultiTransformerOpKernel(
         int64_t max_seq_len = cache_kv->dims()[3];
         // TODO(large-tensor): downstream functors may still use int; guard
         // until upgraded.
-        PADDLE_ENFORCE_LE_INT_MAX(max_seq_len, "max_seq_len");
 
         phi::fusion::fmha<T>(dev_ctx,
                              qkv_out,

--- a/paddle/phi/kernels/fusion/gpu/fused_multi_transformer_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/fused_multi_transformer_kernel.cu
@@ -559,7 +559,11 @@ void FusedMultiTransformerOpKernel(
 
     if (time_step) {  // generation decoder stage
       if (FLAGS_fused_multi_transformer_op_use_mbfmha) {
-        int max_seq_len = cache_kv->dims()[3];
+        int64_t max_seq_len = cache_kv->dims()[3];
+        // TODO(large-tensor): downstream functors may still use int; guard
+        // until upgraded.
+        PADDLE_ENFORCE_LE_INT_MAX(max_seq_len, "max_seq_len");
+
         phi::fusion::mbfmha<T>(dev_ctx,
                                qkv_out,
                                *qkv_bias,
@@ -588,7 +592,10 @@ void FusedMultiTransformerOpKernel(
 
       } else {
         // [2, batch_size, num_head, max_seq_len, head_size]
-        int max_seq_len = cache_kv->dims()[3];
+        int64_t max_seq_len = cache_kv->dims()[3];
+        // TODO(large-tensor): downstream functors may still use int; guard
+        // until upgraded.
+        PADDLE_ENFORCE_LE_INT_MAX(max_seq_len, "max_seq_len");
 
         phi::fusion::fmha<T>(dev_ctx,
                              qkv_out,

--- a/paddle/phi/kernels/fusion/gpu/masked_multihead_attention_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/masked_multihead_attention_kernel.cu
@@ -1012,17 +1012,14 @@ void DispatchWithDtype(const Context &dev_ctx,
   int64_t cache_bsz = cache_kv.dims()[1];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(cache_bsz, "cache_bsz");
 
   int64_t max_seq_len = cache_kv.dims()[3];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(max_seq_len, "max_seq_len");
 
   int64_t dim_head = cache_kv.dims()[4];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(dim_head, "dim_head");
 
   int timestep = max_seq_len;
   float inv_sqrt_dh = 1. / sqrt(dim_head);
@@ -1030,7 +1027,6 @@ void DispatchWithDtype(const Context &dev_ctx,
   int64_t k_num_head = cache_kv.dims()[2];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(k_num_head, "k_num_head");
 
   int v_num_head = k_num_head;
   // this num_head means query's head

--- a/paddle/phi/kernels/fusion/gpu/masked_multihead_attention_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/masked_multihead_attention_kernel.cu
@@ -1009,13 +1009,29 @@ void DispatchWithDtype(const Context &dev_ctx,
                        NormalVersion) {
   const auto &x_dims = x.dims();
   int bsz = x_dims[0];
-  int cache_bsz = cache_kv.dims()[1];
-  int max_seq_len = cache_kv.dims()[3];
-  int dim_head = cache_kv.dims()[4];
+  int64_t cache_bsz = cache_kv.dims()[1];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(cache_bsz, "cache_bsz");
+
+  int64_t max_seq_len = cache_kv.dims()[3];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(max_seq_len, "max_seq_len");
+
+  int64_t dim_head = cache_kv.dims()[4];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(dim_head, "dim_head");
+
   int timestep = max_seq_len;
   float inv_sqrt_dh = 1. / sqrt(dim_head);
 
-  int k_num_head = cache_kv.dims()[2];
+  int64_t k_num_head = cache_kv.dims()[2];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(k_num_head, "k_num_head");
+
   int v_num_head = k_num_head;
   // this num_head means query's head
   int num_head =

--- a/paddle/phi/kernels/fusion/gpu/qkv_unpack_mha_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/qkv_unpack_mha_kernel.cu
@@ -461,16 +461,35 @@ void QKVDispatchWithDtype(const Context &dev_ctx,
                           DenseTensor *out) {
   const auto &q_dims = q.dims();
   int bsz = q_dims[0];
-  int cache_bsz = q.dims()[0];
-  int max_seq_len = v.dims()[1];
-  int dim_head = v.dims()[3];
+  int64_t cache_bsz = q.dims()[0];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(cache_bsz, "cache_bsz");
+
+  int64_t max_seq_len = v.dims()[1];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(max_seq_len, "max_seq_len");
+
+  int64_t dim_head = v.dims()[3];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(dim_head, "dim_head");
+
   int timestep = max_seq_len;
   float inv_sqrt_dh = 1. / sqrt(dim_head);
 
-  int k_num_head = k.dims()[2];
+  int64_t k_num_head = k.dims()[2];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(k_num_head, "k_num_head");
+
   int v_num_head = k_num_head;
   // this num_head means query's head
-  int num_head = q.dims()[2];
+  int64_t num_head = q.dims()[2];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(num_head, "num_head");
 
   QkvUnpackMhaParams<T> params;
 

--- a/paddle/phi/kernels/fusion/gpu/qkv_unpack_mha_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/qkv_unpack_mha_kernel.cu
@@ -464,17 +464,14 @@ void QKVDispatchWithDtype(const Context &dev_ctx,
   int64_t cache_bsz = q.dims()[0];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(cache_bsz, "cache_bsz");
 
   int64_t max_seq_len = v.dims()[1];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(max_seq_len, "max_seq_len");
 
   int64_t dim_head = v.dims()[3];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(dim_head, "dim_head");
 
   int timestep = max_seq_len;
   float inv_sqrt_dh = 1. / sqrt(dim_head);
@@ -482,14 +479,12 @@ void QKVDispatchWithDtype(const Context &dev_ctx,
   int64_t k_num_head = k.dims()[2];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(k_num_head, "k_num_head");
 
   int v_num_head = k_num_head;
   // this num_head means query's head
   int64_t num_head = q.dims()[2];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(num_head, "num_head");
 
   QkvUnpackMhaParams<T> params;
 

--- a/paddle/phi/kernels/fusion/gpu/skip_layernorm_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/skip_layernorm_kernel.cu
@@ -42,7 +42,11 @@ void SkipLayerNormKernel(const Context &dev_ctx,
   for (size_t i = 0; i < x.dims().size(); i++) {
     num *= x.dims()[i];
   }
-  int hidden = x.dims()[2];
+  int64_t hidden = x.dims()[2];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(hidden, "hidden");
+
   phi::funcs::SkipLayerNormFunctor<T> skip_layer_norm_func;
 
   if (std::is_same<T, phi::float16>::value) {

--- a/paddle/phi/kernels/fusion/gpu/skip_layernorm_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/skip_layernorm_kernel.cu
@@ -45,7 +45,6 @@ void SkipLayerNormKernel(const Context &dev_ctx,
   int64_t hidden = x.dims()[2];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(hidden, "hidden");
 
   phi::funcs::SkipLayerNormFunctor<T> skip_layer_norm_func;
 

--- a/paddle/phi/kernels/fusion/xpu/cross_attention_xpu_kernel.cc
+++ b/paddle/phi/kernels/fusion/xpu/cross_attention_xpu_kernel.cc
@@ -69,17 +69,14 @@ void CrossAttentionXPUKernelImpl(
   int64_t batch = input_q.dims()[0];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(batch, "batch");
 
   int64_t max_q_len = input_q.dims()[1];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(max_q_len, "max_q_len");
 
   int64_t max_kv_len = input_kv.dims()[1];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(max_kv_len, "max_kv_len");
 
   int max_seq_len = std::max(max_q_len, max_kv_len);
   int qkv_shape = 0;  // B x L x H x D

--- a/paddle/phi/kernels/fusion/xpu/cross_attention_xpu_kernel.cc
+++ b/paddle/phi/kernels/fusion/xpu/cross_attention_xpu_kernel.cc
@@ -66,9 +66,21 @@ void CrossAttentionXPUKernelImpl(
     fc_bias_data.emplace_back(fc_bias[i]->data<float>());
   }
 
-  int batch = input_q.dims()[0];
-  int max_q_len = input_q.dims()[1];
-  int max_kv_len = input_kv.dims()[1];
+  int64_t batch = input_q.dims()[0];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(batch, "batch");
+
+  int64_t max_q_len = input_q.dims()[1];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(max_q_len, "max_q_len");
+
+  int64_t max_kv_len = input_kv.dims()[1];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(max_kv_len, "max_kv_len");
+
   int max_seq_len = std::max(max_q_len, max_kv_len);
   int qkv_shape = 0;  // B x L x H x D
   int hidden_dim = head_num * head_dim;

--- a/paddle/phi/kernels/fusion/xpu/embedding_with_eltwise_add_xpu_kernel.cc
+++ b/paddle/phi/kernels/fusion/xpu/embedding_with_eltwise_add_xpu_kernel.cc
@@ -107,7 +107,11 @@ void MultiEmbeddingKernel(const Context& dev_ctx,
   std::vector<xpu::VectorParam<TID>> arg_ids;
   auto* mask_tensor = mask.get_ptr();
   if (mask_tensor != nullptr) {
-    int batch_size = mask_tensor->dims()[0];
+    int64_t batch_size = mask_tensor->dims()[0];
+    // TODO(large-tensor): downstream functors may still use int; guard until
+    // upgraded.
+    PADDLE_ENFORCE_LE_INT_MAX(batch_size, "batch_size");
+
     auto pad_seq_len = mask_tensor->dims()[1];
     max_seq_len->Resize({1});
     dev_ctx.template HostAlloc<int>(max_seq_len)[0] = pad_seq_len;

--- a/paddle/phi/kernels/fusion/xpu/embedding_with_eltwise_add_xpu_kernel.cc
+++ b/paddle/phi/kernels/fusion/xpu/embedding_with_eltwise_add_xpu_kernel.cc
@@ -110,7 +110,6 @@ void MultiEmbeddingKernel(const Context& dev_ctx,
     int64_t batch_size = mask_tensor->dims()[0];
     // TODO(large-tensor): downstream functors may still use int; guard until
     // upgraded.
-    PADDLE_ENFORCE_LE_INT_MAX(batch_size, "batch_size");
 
     auto pad_seq_len = mask_tensor->dims()[1];
     max_seq_len->Resize({1});

--- a/paddle/phi/kernels/fusion/xpu/fc_xpu_kernel.cc
+++ b/paddle/phi/kernels/fusion/xpu/fc_xpu_kernel.cc
@@ -57,7 +57,6 @@ void FcXPUKernelImpl(const Context& dev_ctx,
   int64_t n = w.dims()[0];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(n, "n");
 
   auto* x_data = reinterpret_cast<const XPUTypeX*>(x.data<T_X>());
   const float* x_max_data =

--- a/paddle/phi/kernels/fusion/xpu/fc_xpu_kernel.cc
+++ b/paddle/phi/kernels/fusion/xpu/fc_xpu_kernel.cc
@@ -54,7 +54,11 @@ void FcXPUKernelImpl(const Context& dev_ctx,
   auto in_mat_dims = flatten_to_2d(x.dims(), in_num_col_dims);
   int m = in_mat_dims[0];
   int k = in_mat_dims[1];
-  int n = w.dims()[0];
+  int64_t n = w.dims()[0];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(n, "n");
+
   auto* x_data = reinterpret_cast<const XPUTypeX*>(x.data<T_X>());
   const float* x_max_data =
       x_max.get_ptr() == nullptr ? nullptr : x_max.get_ptr()->data<float>();

--- a/paddle/phi/kernels/fusion/xpu/fused_bias_act_kernel.cc
+++ b/paddle/phi/kernels/fusion/xpu/fused_bias_act_kernel.cc
@@ -46,8 +46,16 @@ static void ComputeImpl(const phi::XPUContext *xpu_ctx,
                         const std::string &act_method,
                         DenseTensor *out) {
   using XPUType = typename XPUTypeTrait<T>::Type;
-  int rows = x.dims()[0];
-  int cols = x.dims()[1];
+  int64_t rows = x.dims()[0];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(rows, "rows");
+
+  int64_t cols = x.dims()[1];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(cols, "cols");
+
   int r = 0;
   if (bias) {
     r = baidu::xpu::api::broadcast_add<XPUType>(

--- a/paddle/phi/kernels/fusion/xpu/fused_bias_act_kernel.cc
+++ b/paddle/phi/kernels/fusion/xpu/fused_bias_act_kernel.cc
@@ -49,12 +49,10 @@ static void ComputeImpl(const phi::XPUContext *xpu_ctx,
   int64_t rows = x.dims()[0];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(rows, "rows");
 
   int64_t cols = x.dims()[1];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(cols, "cols");
 
   int r = 0;
   if (bias) {

--- a/paddle/phi/kernels/fusion/xpu/multi_encoder_xpu_kernel.cc
+++ b/paddle/phi/kernels/fusion/xpu/multi_encoder_xpu_kernel.cc
@@ -71,7 +71,11 @@ void MultiEncoderXPUKernel(
   const int* max_seq_len_data = max_seq_len.get_ptr() == nullptr
                                     ? nullptr
                                     : max_seq_len.get_ptr()->data<int>();
-  int batch_size = x.dims()[0];
+  int64_t batch_size = x.dims()[0];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(batch_size, "batch_size");
+
   int seq_len = 1;
   int head_dim;
   if (x.dims().size() == 2) {
@@ -174,7 +178,11 @@ void MultiEncoderXPUKernel(
 
   xpu::Activation_t qkv_act(static_cast<xpu::Activation_t::act_enum>(act_type));
 
-  int batch = x.dims()[0];
+  int64_t batch = x.dims()[0];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(batch, "batch");
+
   // matmul_size * layer_num
   if (seq_lod_data) {
     xpu::VectorParam<int> query_lod = {
@@ -229,7 +237,11 @@ void MultiEncoderXPUKernel(
     auto mask_dims = mask.get_ptr()->dims();
     std::vector<int> mask_shape(mask_dims.Get(),
                                 mask_dims.Get() + mask_dims.size());
-    int max_seq_len_value = x.dims()[1];
+    int64_t max_seq_len_value = x.dims()[1];
+    // TODO(large-tensor): downstream functors may still use int; guard until
+    // upgraded.
+    PADDLE_ENFORCE_LE_INT_MAX(max_seq_len_value, "max_seq_len_value");
+
     xpu::QKVAttnParam qkv_attn_param(batch,
                                      max_seq_len_value,
                                      head_num,
@@ -275,7 +287,11 @@ void MultiEncoderXPUKernel(
     }
   } else {
     // When no mask input, like VIT, create LOD to act as vsl.
-    int max_seq_len_value = x.dims()[1];
+    int64_t max_seq_len_value = x.dims()[1];
+    // TODO(large-tensor): downstream functors may still use int; guard until
+    // upgraded.
+    PADDLE_ENFORCE_LE_INT_MAX(max_seq_len_value, "max_seq_len_value");
+
     std::vector<int> lod;
     for (int i = 0; i < batch + 1; i++) {
       lod.push_back(i * max_seq_len_value);

--- a/paddle/phi/kernels/fusion/xpu/multi_encoder_xpu_kernel.cc
+++ b/paddle/phi/kernels/fusion/xpu/multi_encoder_xpu_kernel.cc
@@ -74,7 +74,6 @@ void MultiEncoderXPUKernel(
   int64_t batch_size = x.dims()[0];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(batch_size, "batch_size");
 
   int seq_len = 1;
   int head_dim;
@@ -181,7 +180,6 @@ void MultiEncoderXPUKernel(
   int64_t batch = x.dims()[0];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(batch, "batch");
 
   // matmul_size * layer_num
   if (seq_lod_data) {
@@ -240,7 +238,6 @@ void MultiEncoderXPUKernel(
     int64_t max_seq_len_value = x.dims()[1];
     // TODO(large-tensor): downstream functors may still use int; guard until
     // upgraded.
-    PADDLE_ENFORCE_LE_INT_MAX(max_seq_len_value, "max_seq_len_value");
 
     xpu::QKVAttnParam qkv_attn_param(batch,
                                      max_seq_len_value,
@@ -290,7 +287,6 @@ void MultiEncoderXPUKernel(
     int64_t max_seq_len_value = x.dims()[1];
     // TODO(large-tensor): downstream functors may still use int; guard until
     // upgraded.
-    PADDLE_ENFORCE_LE_INT_MAX(max_seq_len_value, "max_seq_len_value");
 
     std::vector<int> lod;
     for (int i = 0; i < batch + 1; i++) {

--- a/paddle/phi/kernels/fusion/xpu/qkv_attention_xpu_kernel.cc
+++ b/paddle/phi/kernels/fusion/xpu/qkv_attention_xpu_kernel.cc
@@ -64,12 +64,10 @@ void QKVAttentionXPUKernelImpl(const Context& dev_ctx,
   int64_t batch = q.dims()[0];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(batch, "batch");
 
   int64_t max_seq_len = q.dims()[1];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(max_seq_len, "max_seq_len");
 
   int qkv_shape = 0;  // B x L x H x D
   int hidden_dim = head_num * head_dim;

--- a/paddle/phi/kernels/fusion/xpu/qkv_attention_xpu_kernel.cc
+++ b/paddle/phi/kernels/fusion/xpu/qkv_attention_xpu_kernel.cc
@@ -61,8 +61,16 @@ void QKVAttentionXPUKernelImpl(const Context& dev_ctx,
   auto* qkv_data =
       reinterpret_cast<XPUTypeOut*>(dev_ctx.template Alloc<T_QKV>(qkv));
   float* tmp_mask = nullptr;
-  int batch = q.dims()[0];
-  int max_seq_len = q.dims()[1];
+  int64_t batch = q.dims()[0];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(batch, "batch");
+
+  int64_t max_seq_len = q.dims()[1];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(max_seq_len, "max_seq_len");
+
   int qkv_shape = 0;  // B x L x H x D
   int hidden_dim = head_num * head_dim;
   // no mask input, construct a fake LOD to compute via vsl

--- a/paddle/phi/kernels/fusion/xpu/spatial_transformer_resblock_xpu_kernel.cc
+++ b/paddle/phi/kernels/fusion/xpu/spatial_transformer_resblock_xpu_kernel.cc
@@ -113,10 +113,26 @@ void SpatialTransformerResblockXPUKernel(
   std::vector<std::vector<int>> kernel_dims_2d;
   // prepare conv params
   for (size_t i = 0; i < conv_filter.size(); i++) {
-    int xn = conv_filter[i]->dims()[0];
-    int nc = conv_filter[i]->dims()[1];
-    int nh = conv_filter[i]->dims()[2];
-    int nw = conv_filter[i]->dims()[3];
+    int64_t xn = conv_filter[i]->dims()[0];
+    // TODO(large-tensor): downstream functors may still use int; guard until
+    // upgraded.
+    PADDLE_ENFORCE_LE_INT_MAX(xn, "xn");
+
+    int64_t nc = conv_filter[i]->dims()[1];
+    // TODO(large-tensor): downstream functors may still use int; guard until
+    // upgraded.
+    PADDLE_ENFORCE_LE_INT_MAX(nc, "nc");
+
+    int64_t nh = conv_filter[i]->dims()[2];
+    // TODO(large-tensor): downstream functors may still use int; guard until
+    // upgraded.
+    PADDLE_ENFORCE_LE_INT_MAX(nh, "nh");
+
+    int64_t nw = conv_filter[i]->dims()[3];
+    // TODO(large-tensor): downstream functors may still use int; guard until
+    // upgraded.
+    PADDLE_ENFORCE_LE_INT_MAX(nw, "nw");
+
     xft_conv_weights_.emplace_back(
         const_cast<int16_t*>(
             reinterpret_cast<const int16_t*>(conv_filter[i]->data<int16_t>())),

--- a/paddle/phi/kernels/fusion/xpu/spatial_transformer_resblock_xpu_kernel.cc
+++ b/paddle/phi/kernels/fusion/xpu/spatial_transformer_resblock_xpu_kernel.cc
@@ -116,22 +116,18 @@ void SpatialTransformerResblockXPUKernel(
     int64_t xn = conv_filter[i]->dims()[0];
     // TODO(large-tensor): downstream functors may still use int; guard until
     // upgraded.
-    PADDLE_ENFORCE_LE_INT_MAX(xn, "xn");
 
     int64_t nc = conv_filter[i]->dims()[1];
     // TODO(large-tensor): downstream functors may still use int; guard until
     // upgraded.
-    PADDLE_ENFORCE_LE_INT_MAX(nc, "nc");
 
     int64_t nh = conv_filter[i]->dims()[2];
     // TODO(large-tensor): downstream functors may still use int; guard until
     // upgraded.
-    PADDLE_ENFORCE_LE_INT_MAX(nh, "nh");
 
     int64_t nw = conv_filter[i]->dims()[3];
     // TODO(large-tensor): downstream functors may still use int; guard until
     // upgraded.
-    PADDLE_ENFORCE_LE_INT_MAX(nw, "nw");
 
     xft_conv_weights_.emplace_back(
         const_cast<int16_t*>(

--- a/paddle/phi/kernels/fusion/xpu/weight_only_linear_kernel_xpu.cc
+++ b/paddle/phi/kernels/fusion/xpu/weight_only_linear_kernel_xpu.cc
@@ -38,8 +38,16 @@ void WeightOnlyLinearXpuKernel(const Context& dev_ctx,
   switch (x.dtype()) {
     case phi::DataType::FLOAT16: {
       using XPUType = typename XPUTypeTrait<phi::float16>::Type;
-      int n = weight.dims()[0];
-      int k = weight.dims()[1];
+      int64_t n = weight.dims()[0];
+      // TODO(large-tensor): downstream functors may still use int; guard until
+      // upgraded.
+      PADDLE_ENFORCE_LE_INT_MAX(n, "n");
+
+      int64_t k = weight.dims()[1];
+      // TODO(large-tensor): downstream functors may still use int; guard until
+      // upgraded.
+      PADDLE_ENFORCE_LE_INT_MAX(k, "k");
+
       int m = x.numel() / k;
       DenseTensor max_value;
       max_value.Resize(weight_scale.dims());

--- a/paddle/phi/kernels/fusion/xpu/weight_only_linear_kernel_xpu.cc
+++ b/paddle/phi/kernels/fusion/xpu/weight_only_linear_kernel_xpu.cc
@@ -41,12 +41,10 @@ void WeightOnlyLinearXpuKernel(const Context& dev_ctx,
       int64_t n = weight.dims()[0];
       // TODO(large-tensor): downstream functors may still use int; guard until
       // upgraded.
-      PADDLE_ENFORCE_LE_INT_MAX(n, "n");
 
       int64_t k = weight.dims()[1];
       // TODO(large-tensor): downstream functors may still use int; guard until
       // upgraded.
-      PADDLE_ENFORCE_LE_INT_MAX(k, "k");
 
       int m = x.numel() / k;
       DenseTensor max_value;

--- a/paddle/phi/kernels/gpu/affine_channel_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/affine_channel_grad_kernel.cu
@@ -109,7 +109,11 @@ void AffineChannelGradCUDAKernel(const Context& dev_ctx,
 
   auto dims = dy->dims();
   const int64_t num = dy->numel();
-  int N = dims[0];
+  int64_t N = dims[0];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(N, "N");
+
   int C = layout == phi::DataLayout::kNCHW ? dims[1] : dims[dims.size() - 1];
   int64_t HxW = num / N / C;
 

--- a/paddle/phi/kernels/gpu/affine_channel_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/affine_channel_grad_kernel.cu
@@ -112,7 +112,6 @@ void AffineChannelGradCUDAKernel(const Context& dev_ctx,
   int64_t N = dims[0];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(N, "N");
 
   int C = layout == phi::DataLayout::kNCHW ? dims[1] : dims[dims.size() - 1];
   int64_t HxW = num / N / C;

--- a/paddle/phi/kernels/gpu/affine_channel_kernel.cu
+++ b/paddle/phi/kernels/gpu/affine_channel_kernel.cu
@@ -67,7 +67,11 @@ void AffineChannelCUDAKernel(const Context& dev_ctx,
 
   auto dims = x->dims();
   const int64_t num = x->numel();
-  int N = dims[0];
+  int64_t N = dims[0];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(N, "N");
+
   int C = layout == phi::DataLayout::kNCHW ? dims[1] : dims[dims.size() - 1];
   int64_t HxW = num / N / C;
 

--- a/paddle/phi/kernels/gpu/affine_channel_kernel.cu
+++ b/paddle/phi/kernels/gpu/affine_channel_kernel.cu
@@ -70,7 +70,6 @@ void AffineChannelCUDAKernel(const Context& dev_ctx,
   int64_t N = dims[0];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(N, "N");
 
   int C = layout == phi::DataLayout::kNCHW ? dims[1] : dims[dims.size() - 1];
   int64_t HxW = num / N / C;

--- a/paddle/phi/kernels/gpu/apply_per_channel_scale_kernel.cu
+++ b/paddle/phi/kernels/gpu/apply_per_channel_scale_kernel.cu
@@ -154,8 +154,16 @@ void ApplyPerChannelScaleKernel(const Context& dev_ctx,
                                 DenseTensor* out) {
 #ifdef PADDLE_WITH_CUDA
   using DataType = typename PDDataTypeTraits<T>::DataType;
-  int rows = x.dims()[0];
-  int cols = x.dims()[1];
+  int64_t rows = x.dims()[0];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(rows, "rows");
+
+  int64_t cols = x.dims()[1];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(cols, "cols");
+
   int elems = rows * cols;
   const T* x_data = x.data<T>();
   const T* scales_data = scales.data<T>();

--- a/paddle/phi/kernels/gpu/apply_per_channel_scale_kernel.cu
+++ b/paddle/phi/kernels/gpu/apply_per_channel_scale_kernel.cu
@@ -157,12 +157,10 @@ void ApplyPerChannelScaleKernel(const Context& dev_ctx,
   int64_t rows = x.dims()[0];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(rows, "rows");
 
   int64_t cols = x.dims()[1];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(cols, "cols");
 
   int elems = rows * cols;
   const T* x_data = x.data<T>();

--- a/paddle/phi/kernels/gpu/c_concat_kernel.cu
+++ b/paddle/phi/kernels/gpu/c_concat_kernel.cu
@@ -93,7 +93,11 @@ void CConcatKernel(const Context& dev_ctx,
   int axis = x->dims().size() - 1;
   auto out_dims = x->dims();
   out_dims[out_dims.size() - 1] *= nranks;
-  int rows_per_tensor = x->dims()[0];
+  int64_t rows_per_tensor = x->dims()[0];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(rows_per_tensor, "rows_per_tensor");
+
   int offset = 0;
   for (int i = 0; i < nranks; i++) {
     phi::DenseTensor temp = temp_out.Slice(offset, offset + rows_per_tensor);

--- a/paddle/phi/kernels/gpu/c_concat_kernel.cu
+++ b/paddle/phi/kernels/gpu/c_concat_kernel.cu
@@ -96,7 +96,6 @@ void CConcatKernel(const Context& dev_ctx,
   int64_t rows_per_tensor = x->dims()[0];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(rows_per_tensor, "rows_per_tensor");
 
   int offset = 0;
   for (int i = 0; i < nranks; i++) {

--- a/paddle/phi/kernels/gpu/cholesky_kernel.cu
+++ b/paddle/phi/kernels/gpu/cholesky_kernel.cu
@@ -179,7 +179,6 @@ void CholeskyKernel(const Context& dev_ctx,
   int64_t m = dims[dims.size() - 1];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(m, "m");
 
   int64_t tensor_size = batch_count * static_cast<int64_t>(m) * m;
 

--- a/paddle/phi/kernels/gpu/cholesky_kernel.cu
+++ b/paddle/phi/kernels/gpu/cholesky_kernel.cu
@@ -176,7 +176,11 @@ void CholeskyKernel(const Context& dev_ctx,
   for (int i = 0; i < dims.size() - 2; i++) {
     batch_count *= dims[i];
   }
-  int m = dims[dims.size() - 1];
+  int64_t m = dims[dims.size() - 1];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(m, "m");
+
   int64_t tensor_size = batch_count * static_cast<int64_t>(m) * m;
 
   const auto* x_data = x.data<T>();

--- a/paddle/phi/kernels/gpu/class_center_sample_kernel.cu
+++ b/paddle/phi/kernels/gpu/class_center_sample_kernel.cu
@@ -335,7 +335,6 @@ void ClassCenterSampleKernel(const Context& dev_ctx,
   int64_t batch_size = label.numel();
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(batch_size, "batch_size");
 
   PADDLE_ENFORCE_LE(
       label.numel(),

--- a/paddle/phi/kernels/gpu/class_center_sample_kernel.cu
+++ b/paddle/phi/kernels/gpu/class_center_sample_kernel.cu
@@ -381,7 +381,7 @@ void ClassCenterSampleKernel(const Context& dev_ctx,
 #endif
 
   // step 2: Determine temporary device storage requirements
-  int num_buffer_ele = std::max(batch_size, num_classes);
+  int num_buffer_ele = std::max(static_cast<int>(batch_size), num_classes);
   size_t cub_sort_temp_store_size = 0;
   PADDLE_ENFORCE_GPU_SUCCESS(
       (cub::DeviceRadixSort::SortPairs<T, T>(nullptr,

--- a/paddle/phi/kernels/gpu/class_center_sample_kernel.cu
+++ b/paddle/phi/kernels/gpu/class_center_sample_kernel.cu
@@ -332,7 +332,11 @@ void ClassCenterSampleKernel(const Context& dev_ctx,
 
   auto place = dev_ctx.GetPlace();
 
-  int batch_size = label.numel();
+  int64_t batch_size = label.numel();
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(batch_size, "batch_size");
+
   PADDLE_ENFORCE_LE(
       label.numel(),
       std::numeric_limits<int>::max(),

--- a/paddle/phi/kernels/gpu/cross_entropy_bwd_w_downcast.cu
+++ b/paddle/phi/kernels/gpu/cross_entropy_bwd_w_downcast.cu
@@ -241,7 +241,10 @@ void CrossEntropyWithSoftmaxBwdWithDowncastGPUKernel(
 
   const int rank = logit_grad->dims().size();
   const int axis_v = phi::funcs::CanonicalAxis(axis, rank);
-  int axis_dim = logit_grad->dims()[axis_v];
+  int64_t axis_dim = logit_grad->dims()[axis_v];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(axis_dim, "axis_dim");
 
   const int64_t n = phi::funcs::SizeToAxis(axis_v, logit_grad->dims());
   const int64_t d = phi::funcs::SizeFromAxis(axis_v, logit_grad->dims());

--- a/paddle/phi/kernels/gpu/cross_entropy_bwd_w_downcast.cu
+++ b/paddle/phi/kernels/gpu/cross_entropy_bwd_w_downcast.cu
@@ -244,7 +244,6 @@ void CrossEntropyWithSoftmaxBwdWithDowncastGPUKernel(
   int64_t axis_dim = logit_grad->dims()[axis_v];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(axis_dim, "axis_dim");
 
   const int64_t n = phi::funcs::SizeToAxis(axis_v, logit_grad->dims());
   const int64_t d = phi::funcs::SizeFromAxis(axis_v, logit_grad->dims());

--- a/paddle/phi/kernels/gpu/cross_entropy_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/cross_entropy_grad_kernel.cu
@@ -171,7 +171,6 @@ void CrossEntropyWithSoftmaxGradGPUKernel(const GPUContext& dev_ctx,
   int64_t axis_dim = logit_grad->dims()[axis_v];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(axis_dim, "axis_dim");
 
   const int64_t n = phi::funcs::SizeToAxis(axis_v, logit_grad->dims());
   const int64_t d = phi::funcs::SizeFromAxis(axis_v, logit_grad->dims());

--- a/paddle/phi/kernels/gpu/cross_entropy_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/cross_entropy_grad_kernel.cu
@@ -168,7 +168,10 @@ void CrossEntropyWithSoftmaxGradGPUKernel(const GPUContext& dev_ctx,
 
   const int rank = logit_grad->dims().size();
   const int axis_v = phi::funcs::CanonicalAxis(axis, rank);
-  int axis_dim = logit_grad->dims()[axis_v];
+  int64_t axis_dim = logit_grad->dims()[axis_v];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(axis_dim, "axis_dim");
 
   const int64_t n = phi::funcs::SizeToAxis(axis_v, logit_grad->dims());
   const int64_t d = phi::funcs::SizeFromAxis(axis_v, logit_grad->dims());

--- a/paddle/phi/kernels/gpu/cudnn_lstm_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/cudnn_lstm_grad_kernel.cu
@@ -119,12 +119,10 @@ void CudnnLSTMGradKernel(
   int64_t batch_size = x.dims()[1];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(batch_size, "batch_size");
 
   int64_t input_size = x.dims()[2];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(input_size, "input_size");
 
   size_t workspace_size;
   size_t reserve_size;

--- a/paddle/phi/kernels/gpu/cudnn_lstm_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/cudnn_lstm_grad_kernel.cu
@@ -116,8 +116,15 @@ void CudnnLSTMGradKernel(
   }
 
   int seq_length = input_dims[0];
-  int batch_size = x.dims()[1];
-  int input_size = x.dims()[2];
+  int64_t batch_size = x.dims()[1];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(batch_size, "batch_size");
+
+  int64_t input_size = x.dims()[2];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(input_size, "input_size");
 
   size_t workspace_size;
   size_t reserve_size;

--- a/paddle/phi/kernels/gpu/cudnn_lstm_kernel.cu
+++ b/paddle/phi/kernels/gpu/cudnn_lstm_kernel.cu
@@ -203,17 +203,14 @@ void CudnnLSTMKernel(
   int64_t seq_length = x.dims()[0];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(seq_length, "seq_length");
 
   int64_t batch_size = x.dims()[1];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(batch_size, "batch_size");
 
   int64_t input_size = x.dims()[2];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(input_size, "input_size");
 
   bool state_initialized = state_out->initialized() ? true : false;
 

--- a/paddle/phi/kernels/gpu/cudnn_lstm_kernel.cu
+++ b/paddle/phi/kernels/gpu/cudnn_lstm_kernel.cu
@@ -200,9 +200,21 @@ void CudnnLSTMKernel(
 
   auto handle = dev_ctx.cudnn_handle();
 
-  int seq_length = x.dims()[0];
-  int batch_size = x.dims()[1];
-  int input_size = x.dims()[2];
+  int64_t seq_length = x.dims()[0];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(seq_length, "seq_length");
+
+  int64_t batch_size = x.dims()[1];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(batch_size, "batch_size");
+
+  int64_t input_size = x.dims()[2];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(input_size, "input_size");
+
   bool state_initialized = state_out->initialized() ? true : false;
 
   size_t workspace_size;

--- a/paddle/phi/kernels/gpu/cum_maxmin_kernel.cu
+++ b/paddle/phi/kernels/gpu/cum_maxmin_kernel.cu
@@ -266,7 +266,11 @@ void ScanWithIndicesKernel(const Context& dev_ctx,
   T2* indices_data = indices->data<T2>();
   if (axis == out_dims.size() - 1) {
     int ndim = x.dims().size();
-    int row_size = x.dims()[ndim - 1];
+    int64_t row_size = x.dims()[ndim - 1];
+    // TODO(large-tensor): downstream functors may still use int; guard until
+    // upgraded.
+    PADDLE_ENFORCE_LE_INT_MAX(row_size, "row_size");
+
     int num_rows = x.numel() / row_size;
 
     dim3 threads(16, 32);

--- a/paddle/phi/kernels/gpu/cum_maxmin_kernel.cu
+++ b/paddle/phi/kernels/gpu/cum_maxmin_kernel.cu
@@ -269,7 +269,6 @@ void ScanWithIndicesKernel(const Context& dev_ctx,
     int64_t row_size = x.dims()[ndim - 1];
     // TODO(large-tensor): downstream functors may still use int; guard until
     // upgraded.
-    PADDLE_ENFORCE_LE_INT_MAX(row_size, "row_size");
 
     int num_rows = x.numel() / row_size;
 

--- a/paddle/phi/kernels/gpu/dist_concat_kernel.cu
+++ b/paddle/phi/kernels/gpu/dist_concat_kernel.cu
@@ -55,7 +55,11 @@ void DistConcatKernel(const Context& dev_ctx,
   int axis = x.dims().size() - 1;
   auto out_dims = x.dims();
   out_dims[out_dims.size() - 1] *= nranks;
-  int rows_per_tensor = x.dims()[0];
+  int64_t rows_per_tensor = x.dims()[0];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(rows_per_tensor, "rows_per_tensor");
+
   int offset = 0;
   for (int i = 0; i < nranks; i++) {
     DenseTensor temp =

--- a/paddle/phi/kernels/gpu/dist_concat_kernel.cu
+++ b/paddle/phi/kernels/gpu/dist_concat_kernel.cu
@@ -58,7 +58,6 @@ void DistConcatKernel(const Context& dev_ctx,
   int64_t rows_per_tensor = x.dims()[0];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(rows_per_tensor, "rows_per_tensor");
 
   int offset = 0;
   for (int i = 0; i < nranks; i++) {

--- a/paddle/phi/kernels/gpu/flash_attn_v3_kernel.cu
+++ b/paddle/phi/kernels/gpu/flash_attn_v3_kernel.cu
@@ -215,7 +215,11 @@ void FlashAttnV3BaseKernel(
   const int batch_size = !is_varlen_q ? sizes[0] : cu_seqlens_q.dims()[0] - 1;
   int seqlen_q = !is_varlen_q ? sizes[1] : max_seqlen_q_;
   int total_q = !is_varlen_q ? batch_size * sizes[1] : sizes[0];
-  int num_heads = q.dims()[q.dims().size() - 2];
+  int64_t num_heads = q.dims()[q.dims().size() - 2];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(num_heads, "num_heads");
+
   int const head_size = q.dims()[q.dims().size() - 1];
   int const head_size_v = v.dims()[v.dims().size() - 1];
   int const max_num_pages_per_seq = !paged_KV ? 0 : page_table.dims()[1];
@@ -1375,7 +1379,11 @@ void FlashMaskV2BaseKernel(
   const int batch_size = !is_varlen_q ? sizes[0] : cu_seqlens_q.dims()[0] - 1;
   int seqlen_q = !is_varlen_q ? sizes[1] : max_seqlen_q_;
   int total_q = !is_varlen_q ? batch_size * sizes[1] : sizes[0];
-  int num_heads = q.dims()[q.dims().size() - 2];
+  int64_t num_heads = q.dims()[q.dims().size() - 2];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(num_heads, "num_heads");
+
   int const head_size = q.dims()[q.dims().size() - 1];
   int const head_size_v = v.dims()[v.dims().size() - 1];
   int const max_num_pages_per_seq = !paged_KV ? 0 : page_table.dims()[1];

--- a/paddle/phi/kernels/gpu/flash_attn_v3_kernel.cu
+++ b/paddle/phi/kernels/gpu/flash_attn_v3_kernel.cu
@@ -218,7 +218,6 @@ void FlashAttnV3BaseKernel(
   int64_t num_heads = q.dims()[q.dims().size() - 2];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(num_heads, "num_heads");
 
   int const head_size = q.dims()[q.dims().size() - 1];
   int const head_size_v = v.dims()[v.dims().size() - 1];
@@ -1382,7 +1381,6 @@ void FlashMaskV2BaseKernel(
   int64_t num_heads = q.dims()[q.dims().size() - 2];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(num_heads, "num_heads");
 
   int const head_size = q.dims()[q.dims().size() - 1];
   int const head_size_v = v.dims()[v.dims().size() - 1];

--- a/paddle/phi/kernels/gpu/generate_proposals_kernel.cu
+++ b/paddle/phi/kernels/gpu/generate_proposals_kernel.cu
@@ -294,7 +294,6 @@ static void NMS(const phi::GPUContext &dev_ctx,
   int64_t boxes_num = proposals.dims()[0];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(boxes_num, "boxes_num");
 
   const int col_blocks = DIVUP(boxes_num, kThreadsPerBlock);
   dim3 blocks(DIVUP(boxes_num, kThreadsPerBlock),

--- a/paddle/phi/kernels/gpu/generate_proposals_kernel.cu
+++ b/paddle/phi/kernels/gpu/generate_proposals_kernel.cu
@@ -291,7 +291,11 @@ static void NMS(const phi::GPUContext &dev_ctx,
                 const T nms_threshold,
                 DenseTensor *keep_out,
                 bool pixel_offset = true) {
-  int boxes_num = proposals.dims()[0];
+  int64_t boxes_num = proposals.dims()[0];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(boxes_num, "boxes_num");
+
   const int col_blocks = DIVUP(boxes_num, kThreadsPerBlock);
   dim3 blocks(DIVUP(boxes_num, kThreadsPerBlock),
               DIVUP(boxes_num, kThreadsPerBlock));

--- a/paddle/phi/kernels/gpu/graph_reindex_kernel.cu
+++ b/paddle/phi/kernels/gpu/graph_reindex_kernel.cu
@@ -391,7 +391,11 @@ void GraphReindexKernel(const Context& dev_ctx,
 
   // Get reindex dst edge.
   // Add support for multi-type edges reindex.
-  int num_ac_count = count.dims()[0];
+  int64_t num_ac_count = count.dims()[0];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(num_ac_count, "num_ac_count");
+
   int num_edge_types = num_ac_count / bs;
   thrust::device_vector<int> unique_dst_reindex(bs);
   thrust::sequence(unique_dst_reindex.begin(), unique_dst_reindex.end());

--- a/paddle/phi/kernels/gpu/graph_reindex_kernel.cu
+++ b/paddle/phi/kernels/gpu/graph_reindex_kernel.cu
@@ -394,7 +394,6 @@ void GraphReindexKernel(const Context& dev_ctx,
   int64_t num_ac_count = count.dims()[0];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(num_ac_count, "num_ac_count");
 
   int num_edge_types = num_ac_count / bs;
   thrust::device_vector<int> unique_dst_reindex(bs);

--- a/paddle/phi/kernels/gpu/graph_sample_neighbors_kernel.cu
+++ b/paddle/phi/kernels/gpu/graph_sample_neighbors_kernel.cu
@@ -374,7 +374,6 @@ void GraphSampleNeighborsKernel(
   int64_t bs = x.dims()[0];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(bs, "bs");
 
   int64_t len_col_ptr = col_ptr.dims()[0];
 

--- a/paddle/phi/kernels/gpu/graph_sample_neighbors_kernel.cu
+++ b/paddle/phi/kernels/gpu/graph_sample_neighbors_kernel.cu
@@ -371,7 +371,11 @@ void GraphSampleNeighborsKernel(
   auto* row_data = row.data<T>();
   auto* col_ptr_data = col_ptr.data<T>();
   auto* x_data = x.data<T>();
-  int bs = x.dims()[0];
+  int64_t bs = x.dims()[0];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(bs, "bs");
+
   int64_t len_col_ptr = col_ptr.dims()[0];
 
   const thrust::device_ptr<const T> input(x_data);

--- a/paddle/phi/kernels/gpu/lookup_table_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/lookup_table_grad_kernel.cu
@@ -86,12 +86,10 @@ void LookupTableGradCUDAKernel(
   int64_t N = d_table_t->dims()[0];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(N, "N");
 
   int64_t D = d_table_t->dims()[1];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(D, "D");
 
   int K = ids_t->numel();
   const int64_t *ids = ids_t->data<int64_t>();

--- a/paddle/phi/kernels/gpu/lookup_table_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/lookup_table_grad_kernel.cu
@@ -91,7 +91,10 @@ void LookupTableGradCUDAKernel(
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
 
-  int K = ids_t->numel();
+  int64_t K = ids_t->numel();
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+
   const int64_t *ids = ids_t->data<int64_t>();
   const T *d_output = d_output_t->data<T>();
   T *d_table = dev_ctx.template Alloc<T>(d_table_t);

--- a/paddle/phi/kernels/gpu/lookup_table_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/lookup_table_grad_kernel.cu
@@ -83,8 +83,16 @@ void LookupTableGradCUDAKernel(
   auto d_output_t = &out_grad;
   auto d_table_t = w_grad;
 
-  int N = d_table_t->dims()[0];
-  int D = d_table_t->dims()[1];
+  int64_t N = d_table_t->dims()[0];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(N, "N");
+
+  int64_t D = d_table_t->dims()[1];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(D, "D");
+
   int K = ids_t->numel();
   const int64_t *ids = ids_t->data<int64_t>();
   const T *d_output = d_output_t->data<T>();

--- a/paddle/phi/kernels/gpu/psroi_pool_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/psroi_pool_grad_kernel.cu
@@ -117,10 +117,25 @@ void PsroiPoolGradKernel(const Context& dev_ctx,
                          int output_channels,
                          float spatial_scale,
                          DenseTensor* dx) {
-  int rois_num_t = rois.dims()[0];
-  int input_channels = x.dims()[1];
-  int height = x.dims()[2];
-  int width = x.dims()[3];
+  int64_t rois_num_t = rois.dims()[0];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(rois_num_t, "rois_num_t");
+
+  int64_t input_channels = x.dims()[1];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(input_channels, "input_channels");
+
+  int64_t height = x.dims()[2];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(height, "height");
+
+  int64_t width = x.dims()[3];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(width, "width");
 
   if (dx) {
     // set roi batch id

--- a/paddle/phi/kernels/gpu/psroi_pool_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/psroi_pool_grad_kernel.cu
@@ -120,22 +120,18 @@ void PsroiPoolGradKernel(const Context& dev_ctx,
   int64_t rois_num_t = rois.dims()[0];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(rois_num_t, "rois_num_t");
 
   int64_t input_channels = x.dims()[1];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(input_channels, "input_channels");
 
   int64_t height = x.dims()[2];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(height, "height");
 
   int64_t width = x.dims()[3];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(width, "width");
 
   if (dx) {
     // set roi batch id

--- a/paddle/phi/kernels/gpu/psroi_pool_kernel.cu
+++ b/paddle/phi/kernels/gpu/psroi_pool_kernel.cu
@@ -136,7 +136,6 @@ void PsroiPoolKernel(const Context& dev_ctx,
   int64_t rois_num_t = rois.dims()[0];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(rois_num_t, "rois_num_t");
 
   if (rois_num_t == 0) return;
   int rois_batch_size;

--- a/paddle/phi/kernels/gpu/psroi_pool_kernel.cu
+++ b/paddle/phi/kernels/gpu/psroi_pool_kernel.cu
@@ -133,7 +133,11 @@ void PsroiPoolKernel(const Context& dev_ctx,
           pooled_height,
           pooled_width));
 
-  int rois_num_t = rois.dims()[0];
+  int64_t rois_num_t = rois.dims()[0];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(rois_num_t, "rois_num_t");
+
   if (rois_num_t == 0) return;
   int rois_batch_size;
   DenseTensor rois_batch_id_list;

--- a/paddle/phi/kernels/gpu/psroi_pool_kernel.cu
+++ b/paddle/phi/kernels/gpu/psroi_pool_kernel.cu
@@ -213,7 +213,10 @@ void PsroiPoolKernel(const Context& dev_ctx,
        false,
        &rois_batch_id_list_gpu);
 
-  int output_size = out->numel();
+  int64_t output_size = out->numel();
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+
   int blocks = NumBlocks(output_size);
   int threads = kNumCUDAThreads;
 

--- a/paddle/phi/kernels/gpu/rnn_kernel.cu.cc
+++ b/paddle/phi/kernels/gpu/rnn_kernel.cu.cc
@@ -236,9 +236,20 @@ void RnnKernel(const Context &dev_ctx,
 
   auto handle = dev_ctx.cudnn_handle();
 
-  int seq_length = x.dims()[0];
-  int batch_size = x.dims()[1];
-  int input_size_local = x.dims()[2];
+  int64_t seq_length = x.dims()[0];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(seq_length, "seq_length");
+
+  int64_t batch_size = x.dims()[1];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(batch_size, "batch_size");
+
+  int64_t input_size_local = x.dims()[2];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(input_size_local, "input_size_local");
 
   size_t workspace_size;
   size_t reserve_size;

--- a/paddle/phi/kernels/gpu/rnn_kernel.cu.cc
+++ b/paddle/phi/kernels/gpu/rnn_kernel.cu.cc
@@ -239,17 +239,14 @@ void RnnKernel(const Context &dev_ctx,
   int64_t seq_length = x.dims()[0];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(seq_length, "seq_length");
 
   int64_t batch_size = x.dims()[1];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(batch_size, "batch_size");
 
   int64_t input_size_local = x.dims()[2];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(input_size_local, "input_size_local");
 
   size_t workspace_size;
   size_t reserve_size;

--- a/paddle/phi/kernels/gpu/roi_pool_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/roi_pool_grad_kernel.cu
@@ -104,7 +104,10 @@ void RoiPoolGradKernel(const Context& dev_ctx,
 
     auto gplace = dev_ctx.GetPlace();
     if (boxes_num) {
-      int boxes_batch_size = boxes_num->numel();
+      int64_t boxes_batch_size = boxes_num->numel();
+      // TODO(large-tensor): downstream functors may still use int; guard until
+      // upgraded.
+
       std::vector<int> boxes_num_list(boxes_batch_size);
       memory_utils::Copy(phi::CPUPlace(),
                          boxes_num_list.data(),

--- a/paddle/phi/kernels/gpu/roi_pool_kernel.cu
+++ b/paddle/phi/kernels/gpu/roi_pool_kernel.cu
@@ -138,7 +138,10 @@ void RoiPoolKernel(const Context& dev_ctx,
   auto gplace = dev_ctx.GetPlace();
 
   if (boxes_num) {
-    int boxes_batch_size = boxes_num->numel();
+    int64_t boxes_batch_size = boxes_num->numel();
+    // TODO(large-tensor): downstream functors may still use int; guard until
+    // upgraded.
+
     PADDLE_ENFORCE_EQ(
         boxes_batch_size,
         batch_size,

--- a/paddle/phi/kernels/gpu/row_conv_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/row_conv_grad_kernel.cu
@@ -279,7 +279,6 @@ void RowConvGradKernel(const Context &dev_ctx,
   int64_t timesteps = X->dims()[1];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(timesteps, "timesteps");
 
   if (is_tensor) {
     for (int i = 0; i < batch_size + 1; i++) {
@@ -295,7 +294,6 @@ void RowConvGradKernel(const Context &dev_ctx,
   int64_t future_context = Filter->dims()[0];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(future_context, "future_context");
 
   phi::MixVector<size_t> mixv_batch_indices(&batch_indices);
   size_t *idx = mixv_batch_indices.CUDAMutableData(dev_ctx.GetPlace());

--- a/paddle/phi/kernels/gpu/row_conv_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/row_conv_grad_kernel.cu
@@ -276,7 +276,11 @@ void RowConvGradKernel(const Context &dev_ctx,
 
   int input_dim = 0;
   phi::Vector<size_t> batch_indices(batch_size + 1);
-  int timesteps = X->dims()[1];
+  int64_t timesteps = X->dims()[1];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(timesteps, "timesteps");
+
   if (is_tensor) {
     for (int i = 0; i < batch_size + 1; i++) {
       batch_indices[i] = i * timesteps;
@@ -288,7 +292,11 @@ void RowConvGradKernel(const Context &dev_ctx,
   }
   // int input_dim = X->dims()[1];
   int num_sequence = batch_indices.size() - 1;
-  int future_context = Filter->dims()[0];
+  int64_t future_context = Filter->dims()[0];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(future_context, "future_context");
+
   phi::MixVector<size_t> mixv_batch_indices(&batch_indices);
   size_t *idx = mixv_batch_indices.CUDAMutableData(dev_ctx.GetPlace());
 

--- a/paddle/phi/kernels/gpu/row_conv_kernel.cu
+++ b/paddle/phi/kernels/gpu/row_conv_kernel.cu
@@ -120,7 +120,11 @@ void RowConvKernel(const Context &dev_ctx,
   }
   int input_dim = 0;
   phi::Vector<size_t> batch_indices(batch_size + 1);
-  int timesteps = X->dims()[1];
+  int64_t timesteps = X->dims()[1];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(timesteps, "timesteps");
+
   if (is_tensor) {
     for (int i = 0; i < batch_size + 1; i++) {
       batch_indices[i] = i * timesteps;
@@ -132,7 +136,11 @@ void RowConvKernel(const Context &dev_ctx,
   }
 
   int num_sequence = batch_indices.size() - 1;
-  int future_context = Filter->dims()[0];
+  int64_t future_context = Filter->dims()[0];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(future_context, "future_context");
+
   phi::MixVector<size_t> mix_vector(&batch_indices);
   size_t *idx = mix_vector.CUDAMutableData(dev_ctx.GetPlace());
   auto stream = dev_ctx.stream();

--- a/paddle/phi/kernels/gpu/row_conv_kernel.cu
+++ b/paddle/phi/kernels/gpu/row_conv_kernel.cu
@@ -123,7 +123,6 @@ void RowConvKernel(const Context &dev_ctx,
   int64_t timesteps = X->dims()[1];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(timesteps, "timesteps");
 
   if (is_tensor) {
     for (int i = 0; i < batch_size + 1; i++) {
@@ -139,7 +138,6 @@ void RowConvKernel(const Context &dev_ctx,
   int64_t future_context = Filter->dims()[0];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(future_context, "future_context");
 
   phi::MixVector<size_t> mix_vector(&batch_indices);
   size_t *idx = mix_vector.CUDAMutableData(dev_ctx.GetPlace());

--- a/paddle/phi/kernels/gpu/svd_kernel.cu
+++ b/paddle/phi/kernels/gpu/svd_kernel.cu
@@ -390,12 +390,10 @@ void SvdKernel(const Context& dev_ctx,
   int64_t m = dims[rank - 2];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(m, "m");
 
   int64_t n = dims[rank - 1];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(n, "n");
 
   auto* u_data = dev_ctx.template Alloc<T>(U);
   auto* vh_data = dev_ctx.template Alloc<T>(VH);

--- a/paddle/phi/kernels/gpu/svd_kernel.cu
+++ b/paddle/phi/kernels/gpu/svd_kernel.cu
@@ -387,8 +387,15 @@ void SvdKernel(const Context& dev_ctx,
     batch_count *= dims[i];
   }
   int rank = dims.size();
-  int m = dims[rank - 2];
-  int n = dims[rank - 1];
+  int64_t m = dims[rank - 2];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(m, "m");
+
+  int64_t n = dims[rank - 1];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(n, "n");
 
   auto* u_data = dev_ctx.template Alloc<T>(U);
   auto* vh_data = dev_ctx.template Alloc<T>(VH);

--- a/paddle/phi/kernels/gpu/top_p_sampling_kernel.cu
+++ b/paddle/phi/kernels/gpu/top_p_sampling_kernel.cu
@@ -1094,7 +1094,11 @@ void TopPSamplingKernel(const Context& dev_ctx,
   const auto* input = &x;
   // get the input dims
   const auto& in_dims = input->dims();
-  int p_num = ps.numel();
+  int64_t p_num = ps.numel();
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(p_num, "p_num");
+
   int bs = in_dims[0];
   int vocab_size = in_dims[1];
   T* out_ptr = dev_ctx.template Alloc<T>(out);

--- a/paddle/phi/kernels/gpu/top_p_sampling_kernel.cu
+++ b/paddle/phi/kernels/gpu/top_p_sampling_kernel.cu
@@ -1097,7 +1097,6 @@ void TopPSamplingKernel(const Context& dev_ctx,
   int64_t p_num = ps.numel();
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(p_num, "p_num");
 
   int bs = in_dims[0];
   int vocab_size = in_dims[1];

--- a/paddle/phi/kernels/gpu/weight_dequantize_kernel.cu
+++ b/paddle/phi/kernels/gpu/weight_dequantize_kernel.cu
@@ -381,12 +381,10 @@ void WeightDequantize(const Context& dev_ctx,
   int64_t n = scale.dims()[0];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(n, "n");
 
   int64_t k = x.dims()[1];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(k, "k");
 
   PADDLE_ENFORCE_EQ(
       (k % NUMPERTHREAD == 0),

--- a/paddle/phi/kernels/gpu/weight_dequantize_kernel.cu
+++ b/paddle/phi/kernels/gpu/weight_dequantize_kernel.cu
@@ -378,8 +378,16 @@ void WeightDequantize(const Context& dev_ctx,
                       const int32_t group_size,
                       DenseTensor* out) {
   using DataType = typename PDDataTypeTraits<T>::DataType;
-  int n = scale.dims()[0];
-  int k = x.dims()[1];
+  int64_t n = scale.dims()[0];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(n, "n");
+
+  int64_t k = x.dims()[1];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(k, "k");
+
   PADDLE_ENFORCE_EQ(
       (k % NUMPERTHREAD == 0),
       true,

--- a/paddle/phi/kernels/gpu/weight_only_linear_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/weight_only_linear_grad_kernel.cu
@@ -52,12 +52,10 @@ void WeightOnlyLinearGradKernel(const Context& dev_ctx,
   int64_t n = weight_scale.dims()[0];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(n, "n");
 
   int64_t k = weight.dims()[1];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(k, "k");
 
   dev_ctx.template Alloc<T>(x_grad);
   if (x_grad->numel() == 0 || out_grad.numel() == 0) {

--- a/paddle/phi/kernels/gpu/weight_only_linear_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/weight_only_linear_grad_kernel.cu
@@ -49,8 +49,16 @@ void WeightOnlyLinearGradKernel(const Context& dev_ctx,
       common::errors::InvalidArgument(
           "Currently weightonly linear grad only support per-channel mode. "));
 
-  int n = weight_scale.dims()[0];
-  int k = weight.dims()[1];
+  int64_t n = weight_scale.dims()[0];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(n, "n");
+
+  int64_t k = weight.dims()[1];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(k, "k");
+
   dev_ctx.template Alloc<T>(x_grad);
   if (x_grad->numel() == 0 || out_grad.numel() == 0) {
     Full<T, Context>(

--- a/paddle/phi/kernels/gpu/weighted_sample_neighbors_kernel.cu
+++ b/paddle/phi/kernels/gpu/weighted_sample_neighbors_kernel.cu
@@ -334,7 +334,6 @@ void WeightedSampleNeighborsKernel(const Context& dev_ctx,
   int64_t bs = x.dims()[0];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(bs, "bs");
 
   thread_local std::random_device rd;
   thread_local std::mt19937 gen(rd());

--- a/paddle/phi/kernels/gpu/weighted_sample_neighbors_kernel.cu
+++ b/paddle/phi/kernels/gpu/weighted_sample_neighbors_kernel.cu
@@ -331,7 +331,10 @@ void WeightedSampleNeighborsKernel(const Context& dev_ctx,
   auto* x_data = x.data<T>();
   auto* eids_data =
       (eids.get_ptr() == nullptr ? nullptr : eids.get_ptr()->data<T>());
-  int bs = x.dims()[0];
+  int64_t bs = x.dims()[0];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(bs, "bs");
 
   thread_local std::random_device rd;
   thread_local std::mt19937 gen(rd());

--- a/paddle/phi/kernels/gpu/yolo_box_post_kernel.cu
+++ b/paddle/phi/kernels/gpu/yolo_box_post_kernel.cu
@@ -408,7 +408,11 @@ void YoloBoxPostKernel(const Context& dev_ctx,
       downsample_ratio0, downsample_ratio1, downsample_ratio2};
   // clip_bbox and scale_x_y is not used now!
 
-  int batch = image_shape.dims()[0];
+  int64_t batch = image_shape.dims()[0];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(batch, "batch");
+
   TensorInfo* ts_info = new TensorInfo[batch * boxes_input.size()];
   for (int i = 0; i < batch * static_cast<int>(boxes_input.size()); i++) {
 #ifdef PADDLE_WITH_HIP

--- a/paddle/phi/kernels/gpu/yolo_box_post_kernel.cu
+++ b/paddle/phi/kernels/gpu/yolo_box_post_kernel.cu
@@ -411,7 +411,6 @@ void YoloBoxPostKernel(const Context& dev_ctx,
   int64_t batch = image_shape.dims()[0];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(batch, "batch");
 
   TensorInfo* ts_info = new TensorInfo[batch * boxes_input.size()];
   for (int i = 0; i < batch * static_cast<int>(boxes_input.size()); i++) {

--- a/paddle/phi/kernels/gpudnn/affine_grid_grad_kernel.cu
+++ b/paddle/phi/kernels/gpudnn/affine_grid_grad_kernel.cu
@@ -54,7 +54,6 @@ void AffineGridGradCudnnKernel(const Context& dev_ctx,
   int64_t n = output_grad.dims()[0];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(n, "n");
 
   auto& size_attr = outputShape.GetData();
   int h_size_data[4] = {0};

--- a/paddle/phi/kernels/gpudnn/affine_grid_grad_kernel.cu
+++ b/paddle/phi/kernels/gpudnn/affine_grid_grad_kernel.cu
@@ -51,7 +51,11 @@ void AffineGridGradCudnnKernel(const Context& dev_ctx,
   auto handle = dev_ctx.cudnn_handle();
   auto& theta_grad = input_grad;
 
-  int n = output_grad.dims()[0];
+  int64_t n = output_grad.dims()[0];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(n, "n");
+
   auto& size_attr = outputShape.GetData();
   int h_size_data[4] = {0};
   h_size_data[0] = n;

--- a/paddle/phi/kernels/gpudnn/affine_grid_kernel.cu
+++ b/paddle/phi/kernels/gpudnn/affine_grid_kernel.cu
@@ -45,7 +45,7 @@ void AffineGridCudnnKernel(const Context& dev_ctx,
   int64_t n = theta->dims()[0];
 
   auto& size_attr = outputShape.GetData();
-  int64_t h_size_data[4] = {0};
+  int h_size_data[4] = {0};
   h_size_data[0] = n;
   h_size_data[1] = size_attr[1];
   h_size_data[2] = size_attr[2];

--- a/paddle/phi/kernels/gpudnn/affine_grid_kernel.cu
+++ b/paddle/phi/kernels/gpudnn/affine_grid_kernel.cu
@@ -42,7 +42,11 @@ void AffineGridCudnnKernel(const Context& dev_ctx,
   auto handle = dev_ctx.cudnn_handle();
   auto* theta = &input;
   const T* theta_data = theta->data<T>();
-  int n = theta->dims()[0];
+  int64_t n = theta->dims()[0];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(n, "n");
+
   auto& size_attr = outputShape.GetData();
   int h_size_data[4] = {0};
   h_size_data[0] = n;

--- a/paddle/phi/kernels/gpudnn/affine_grid_kernel.cu
+++ b/paddle/phi/kernels/gpudnn/affine_grid_kernel.cu
@@ -43,12 +43,9 @@ void AffineGridCudnnKernel(const Context& dev_ctx,
   auto* theta = &input;
   const T* theta_data = theta->data<T>();
   int64_t n = theta->dims()[0];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(n, "n");
 
   auto& size_attr = outputShape.GetData();
-  int h_size_data[4] = {0};
+  int64_t h_size_data[4] = {0};
   h_size_data[0] = n;
   h_size_data[1] = size_attr[1];
   h_size_data[2] = size_attr[2];

--- a/paddle/phi/kernels/impl/lrn_kernel_impl.h
+++ b/paddle/phi/kernels/impl/lrn_kernel_impl.h
@@ -67,18 +67,7 @@ void LRNKernel(const Context& dev_ctx,
 
   // TODO(large-tensor): LRN GPU kernel implementation still uses int for
   // dimensions. Need to update GPU kernel to support dimensions > INT32_MAX.
-  PADDLE_ENFORCE_LE(
-      std::max({N, C, H, W}),
-      std::numeric_limits<int>::max(),
-      common::errors::InvalidArgument(
-          "One or more tensor dimensions (N=%ld, C=%ld, H=%ld, W=%ld) exceeds "
-          "the maximum value that int can represent (%d). LRN operation does "
-          "not support such large tensors yet.",
-          N,
-          C,
-          H,
-          W,
-          std::numeric_limits<int>::max()));
+  PADDLE_ENFORCE_LE_INT_MAX(std::max({N, C, H, W}), "std::max({N, C, H, W})");
 
   dev_ctx.template Alloc<T>(out);
 
@@ -175,18 +164,7 @@ void LRNGradKernel(const Context& dev_ctx,
 
   // TODO(large-tensor): LRN GPU kernel implementation still uses int for
   // dimensions. Need to update GPU kernel to support dimensions > INT32_MAX.
-  PADDLE_ENFORCE_LE(
-      std::max({N, C, H, W}),
-      std::numeric_limits<int>::max(),
-      common::errors::InvalidArgument(
-          "One or more tensor dimensions (N=%ld, C=%ld, H=%ld, W=%ld) exceeds "
-          "the maximum value that int can represent (%d). LRN operation does "
-          "not support such large tensors yet.",
-          N,
-          C,
-          H,
-          W,
-          std::numeric_limits<int>::max()));
+  PADDLE_ENFORCE_LE_INT_MAX(std::max({N, C, H, W}), "std::max({N, C, H, W})");
 
   LRNGradFunctor<Context, T> f;
   f(dev_ctx, x, out, mid, x_g, out_g, N, C, H, W, n, alpha, beta, data_layout);

--- a/paddle/phi/kernels/selected_rows/gpu/adam_kernel.cu
+++ b/paddle/phi/kernels/selected_rows/gpu/adam_kernel.cu
@@ -238,7 +238,11 @@ void AdamDenseParamSparseGradKernel(
 
   if (beta1_pow.place() == CPUPlace() && beta2_pow.place() == CPUPlace()) {
     int threads = 512;
-    int ndim = param.numel();
+    int64_t ndim = param.numel();
+    // TODO(large-tensor): downstream functors may still use int; guard until
+    // upgraded.
+    PADDLE_ENFORCE_LE_INT_MAX(ndim, "ndim");
+
     int blocks = (ndim + threads - 1) / threads;
 
     SparseAdamCUDAKernelREG<T, MPDType>

--- a/paddle/phi/kernels/selected_rows/gpu/adam_kernel.cu
+++ b/paddle/phi/kernels/selected_rows/gpu/adam_kernel.cu
@@ -241,7 +241,6 @@ void AdamDenseParamSparseGradKernel(
     int64_t ndim = param.numel();
     // TODO(large-tensor): downstream functors may still use int; guard until
     // upgraded.
-    PADDLE_ENFORCE_LE_INT_MAX(ndim, "ndim");
 
     int blocks = (ndim + threads - 1) / threads;
 

--- a/paddle/phi/kernels/selected_rows/gpu/adamw_kernel.cu
+++ b/paddle/phi/kernels/selected_rows/gpu/adamw_kernel.cu
@@ -259,7 +259,11 @@ void AdamwDenseParamSparseGradKernel(
 
   if (beta1_pow.place() == CPUPlace() && beta2_pow.place() == CPUPlace()) {
     int threads = 512;
-    int ndim = param.numel();
+    int64_t ndim = param.numel();
+    // TODO(large-tensor): downstream functors may still use int; guard until
+    // upgraded.
+    PADDLE_ENFORCE_LE_INT_MAX(ndim, "ndim");
+
     int blocks = (ndim + threads - 1) / threads;
 
     SparseAdamWCUDAKernelREG<T, MPDType>

--- a/paddle/phi/kernels/selected_rows/gpu/adamw_kernel.cu
+++ b/paddle/phi/kernels/selected_rows/gpu/adamw_kernel.cu
@@ -262,7 +262,6 @@ void AdamwDenseParamSparseGradKernel(
     int64_t ndim = param.numel();
     // TODO(large-tensor): downstream functors may still use int; guard until
     // upgraded.
-    PADDLE_ENFORCE_LE_INT_MAX(ndim, "ndim");
 
     int blocks = (ndim + threads - 1) / threads;
 

--- a/paddle/phi/kernels/selected_rows/gpu/lookup_table_grad_kernel.cu
+++ b/paddle/phi/kernels/selected_rows/gpu/lookup_table_grad_kernel.cu
@@ -86,12 +86,10 @@ void LookupTableGradCUDAKernel(
   int64_t N = d_table_t->dims()[0];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(N, "N");
 
   int64_t D = d_table_t->dims()[1];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-  PADDLE_ENFORCE_LE_INT_MAX(D, "D");
 
   int K = ids_t->numel();
   const int64_t *ids = ids_t->data<int64_t>();

--- a/paddle/phi/kernels/selected_rows/gpu/lookup_table_grad_kernel.cu
+++ b/paddle/phi/kernels/selected_rows/gpu/lookup_table_grad_kernel.cu
@@ -91,7 +91,10 @@ void LookupTableGradCUDAKernel(
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
 
-  int K = ids_t->numel();
+  int64_t K = ids_t->numel();
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+
   const int64_t *ids = ids_t->data<int64_t>();
   const T *d_output = d_output_t->data<T>();
   T *d_table = dev_ctx.template Alloc<T>(d_table_t);

--- a/paddle/phi/kernels/selected_rows/gpu/lookup_table_grad_kernel.cu
+++ b/paddle/phi/kernels/selected_rows/gpu/lookup_table_grad_kernel.cu
@@ -83,8 +83,16 @@ void LookupTableGradCUDAKernel(
   auto d_output_t = &out_grad;
   auto d_table_t = w_grad;
 
-  int N = d_table_t->dims()[0];
-  int D = d_table_t->dims()[1];
+  int64_t N = d_table_t->dims()[0];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(N, "N");
+
+  int64_t D = d_table_t->dims()[1];
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  PADDLE_ENFORCE_LE_INT_MAX(D, "D");
+
   int K = ids_t->numel();
   const int64_t *ids = ids_t->data<int64_t>();
   const T *d_output = d_output_t->data<T>();


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
https://github.com/PaddlePaddle/Paddle/pull/76107 使用的方法是检索代码->llm 修改代码->人工校对，目前发现这种方法存在两个弊端：
- 漏改情况较多，很多情况下只会改匹配到的部分，不会修改临近相关代码，而且会出现错误用法。
- 每一行都需要人工校对，因为llm生成的代码实际上是不能保证语法正确的，也不能保证语义一致。

由于cpu目录检索到的内容过多，漏改和错改属于普遍现象（LLM修改方案），因此本 PR 尝试了一种新的方案，使用 ast-grep 检索和替换代码，这种方法可以通过编写rule，保证语法和语义正确，同时可以大大提高复用性。

原本的方案中为了方便修改和review，采用了文件夹作为基本单位进行修改（因为同目录代码相似度相对较高），但是如果采用编写rule来修改的话，使用模式作为单位修改更利于review。

为了方便后续检索，本PR添加了PADDLE_ENFORCE_LE_INT_MAX宏。后续可以通过分析所有依赖PADDLE_ENFORCE_LE_INT_MAX限制变量的代码段，判断是否可以安全移除PADDLE_ENFORCE_LE_INT_MAX宏。

#### 修改内容
- 为了方便后续检索，本PR添加了PADDLE_ENFORCE_LE_INT_MAX宏。后续可以通过分析所有依赖PADDLE_ENFORCE_LE_INT_MAX限制变量的代码段，判断是否可以安全移除PADDLE_ENFORCE_LE_INT_MAX宏。
- https://github.com/PaddlePaddle/Paddle/pull/76313 引入了 ast-grep 工具，本PR在此基础上引入了 no-int32-type-dims rule。确保在使用dims等方法时必须定义为int64类型变量，目前可以强制 static_cast<int> 暂时跳过检查规避历史遗留问题。

#### TODO
- 添加规则限制使用 `std:vector<int64>`
- 移除 dims[$index] 这类的规则，减少可能的误检情况。



pcard-93269