### PR TITLE
Fix Extra VRAM Usage in PPTRT

### DIFF
--- a/python/paddle/tensorrt/export.py
+++ b/python/paddle/tensorrt/export.py
@@ -391,7 +391,7 @@ def convert_to_trt(program, trt_config, scope):
         )
 
         paddle.device.empty_cache()
-        
+
         # specify certain operators to be excluded from entering TensorRT
         if trt_config.disable_ops:
             forbid_op_lower_trt(program, trt_config.disable_ops)

--- a/python/paddle/tensorrt/export.py
+++ b/python/paddle/tensorrt/export.py
@@ -390,6 +390,8 @@ def convert_to_trt(program, trt_config, scope):
             scope=scope,
         )
 
+        paddle.device.empty_cache()
+        
         # specify certain operators to be excluded from entering TensorRT
         if trt_config.disable_ops:
             forbid_op_lower_trt(program, trt_config.disable_ops)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Improvements

### Description
<!-- Describe what you’ve done -->
By adding `empty_cache` after warm-up, the extra VRAM usage during PPTRT conversion was fixed, and subsequent VRAM usage is almost identical to that of the original TRT.
