### PR TITLE
[Compat] Add more constructors for compatible `at::Tensor`

### DIFF
--- a/paddle/fluid/pybind/torch_compat.h
+++ b/paddle/fluid/pybind/torch_compat.h
@@ -138,7 +138,7 @@ inline torch::IValue OperationInvoker::to_ivalue(py::handle obj) {
   } else if (py::isinstance<py::bool_>(obj)) {
     return torch::IValue(py::cast<bool>(obj));
   } else if (py::isinstance<py::int_>(obj)) {
-    return torch::IValue(py::cast<int>(obj));
+    return torch::IValue(py::cast<int64_t>(obj));
   } else if (py::isinstance<py::float_>(obj)) {
     return torch::IValue(py::cast<double>(obj));
   } else if (py::isinstance<py::str>(obj)) {

--- a/paddle/phi/api/include/compat/ATen/ATen.h
+++ b/paddle/phi/api/include/compat/ATen/ATen.h
@@ -17,6 +17,7 @@
 #include <ATen/Device.h>
 #include <ATen/Functions.h>
 #include <ATen/Tensor.h>
+#include <ATen/Utils.h>
 #include <c10/core/Device.h>
 #include <c10/core/DeviceType.h>
 #include <c10/core/MemoryFormat.h>

--- a/paddle/phi/api/include/compat/ATen/Utils.h
+++ b/paddle/phi/api/include/compat/ATen/Utils.h
@@ -14,7 +14,6 @@
 
 #pragma once
 
-#include <ATen/EmptyTensor.h>
 #include <c10/core/ScalarType.h>
 #include <c10/util/ArrayRef.h>
 #include <c10/util/Exception.h>

--- a/paddle/phi/api/include/compat/ATen/core/TensorBase.h
+++ b/paddle/phi/api/include/compat/ATen/core/TensorBase.h
@@ -38,8 +38,19 @@ class PADDLE_API TensorBase {
   TensorBase(TensorBase&&) noexcept = default;
   ~TensorBase() noexcept = default;
 
+#if defined(_MSC_VER)
+  TensorBase& operator=(const TensorBase& x) & {
+    tensor_ = x.tensor_;
+    return *this;
+  };
+  TensorBase& operator=(TensorBase&& x) & noexcept {
+    tensor_ = std::move(x.tensor_);
+    return *this;
+  }
+#else
   TensorBase& operator=(const TensorBase& x) & = default;
   TensorBase& operator=(TensorBase&& x) & noexcept = default;
+#endif
 
   TensorBase& operator=(const TensorBase&) && = delete;
   TensorBase& operator=(TensorBase&&) && noexcept = delete;
@@ -220,8 +231,9 @@ class PADDLE_API TensorBase {
   template <typename T, size_t N>
   TensorAccessor<T, N> accessor() && = delete;
 
-  PaddleTensor _PD_GetInner() const { return tensor_; }
-  PaddleTensor& _PD_GetInner() { return tensor_; }
+  const PaddleTensor& _PD_GetInner() const& { return tensor_; }
+  PaddleTensor& _PD_GetInner() & { return tensor_; }
+  PaddleTensor&& _PD_GetInner() && { return std::move(tensor_); }
 
  protected:
   PaddleTensor tensor_;

--- a/paddle/phi/api/include/compat/ATen/core/TensorBase.h
+++ b/paddle/phi/api/include/compat/ATen/core/TensorBase.h
@@ -42,7 +42,7 @@ class PADDLE_API TensorBase {
   TensorBase& operator=(const TensorBase& x) & {
     tensor_ = x.tensor_;
     return *this;
-  };
+  }
   TensorBase& operator=(TensorBase&& x) & noexcept {
     tensor_ = std::move(x.tensor_);
     return *this;

--- a/paddle/phi/api/include/compat/ATen/core/TensorBase.h
+++ b/paddle/phi/api/include/compat/ATen/core/TensorBase.h
@@ -34,6 +34,15 @@ class PADDLE_API TensorBase {
  public:
   TensorBase() = default;
   TensorBase(const PaddleTensor& tensor) : tensor_(tensor){};  // NOLINT
+  TensorBase(const TensorBase&) = default;
+  TensorBase(TensorBase&&) noexcept = default;
+  ~TensorBase() noexcept = default;
+
+  TensorBase& operator=(const TensorBase& x) & = default;
+  TensorBase& operator=(TensorBase&& x) & noexcept = default;
+
+  TensorBase& operator=(const TensorBase&) && = delete;
+  TensorBase& operator=(TensorBase&&) && noexcept = delete;
 
   void* data_ptr() const { return const_cast<void*>(tensor_.data()); }
   template <typename T>

--- a/paddle/phi/api/include/compat/ATen/core/TensorBody.h
+++ b/paddle/phi/api/include/compat/ATen/core/TensorBody.h
@@ -24,6 +24,8 @@ class Tensor : public TensorBase {
  public:
   Tensor() = default;
   Tensor(const PaddleTensor& tensor) : TensorBase(tensor){};  // NOLINT
+  Tensor(const Tensor& tensor) = default;
+  Tensor(Tensor&& tensor) = default;
 
   // Implicitly move-constructible from TensorBase, but must be explicit to
   // increase refcount
@@ -31,18 +33,32 @@ class Tensor : public TensorBase {
   /*implicit*/ Tensor(TensorBase&& base)                         // NOLINT
       : TensorBase(std::move(base)) {}
 
-  // TODO(dev): Implement assignment operators
-  // Tensor& operator=(const Tensor& x) & noexcept {
-  //   return operator=(static_cast<const TensorBase&>(x));
-  // }
-  // Tensor& operator=(Tensor&& x) & noexcept {
-  //   return operator=(static_cast<TensorBase&&>(x));
-  // }
+  Tensor& operator=(const PaddleTensor& x) & noexcept {
+    tensor_ = x;
+    return *this;
+  }
+  Tensor& operator=(const TensorBase& x) & noexcept {
+    tensor_ = x._PD_GetInner();
+    return *this;
+  }
+  Tensor& operator=(PaddleTensor&& x) & noexcept {
+    tensor_ = std::move(x);
+    return *this;
+  }
+  Tensor& operator=(TensorBase&& x) & noexcept {
+    tensor_ = std::move(x._PD_GetInner());
+    return *this;
+  }
 
+  Tensor& operator=(const Tensor& x) & noexcept {
+    return operator=(static_cast<const TensorBase&>(x));
+  }
+  Tensor& operator=(Tensor&& x) & noexcept {
+    return operator=(static_cast<TensorBase&&>(x));
+  }
   Tensor& operator=(const Scalar& v) && { return fill_(v); }
-  // TODO(dev): Implement assignment operators
-  // Tensor& operator=(const Tensor& rhs) && { return copy_(rhs); }
-  // Tensor& operator=(Tensor&& rhs) && { return copy_(rhs); }
+  Tensor& operator=(const Tensor& rhs) && { return copy_(rhs); }
+  Tensor& operator=(Tensor&& rhs) && { return copy_(rhs); }
 
   void* data_ptr() const { return const_cast<void*>(tensor_.data()); }
   template <typename T>

--- a/paddle/phi/api/include/compat/ATen/core/TensorBody.h
+++ b/paddle/phi/api/include/compat/ATen/core/TensorBody.h
@@ -38,7 +38,8 @@ class Tensor : public TensorBase {
     return *this;
   }
   Tensor& operator=(const TensorBase& x) & noexcept {
-    tensor_ = x._PD_GetInner();
+    const PaddleTensor& inner = x._PD_GetInner();
+    tensor_ = inner;
     return *this;
   }
   Tensor& operator=(PaddleTensor&& x) & noexcept {

--- a/paddle/phi/api/include/compat/ATen/core/TensorBody.h
+++ b/paddle/phi/api/include/compat/ATen/core/TensorBody.h
@@ -47,7 +47,7 @@ class Tensor : public TensorBase {
     return *this;
   }
   Tensor& operator=(TensorBase&& x) & noexcept {
-    tensor_ = std::move(x._PD_GetInner());
+    tensor_ = std::move(x)._PD_GetInner();
     return *this;
   }
 

--- a/paddle/phi/api/include/compat/ATen/core/TensorMethods.cpp
+++ b/paddle/phi/api/include/compat/ATen/core/TensorMethods.cpp
@@ -48,7 +48,7 @@ void check_type(const TensorBase& tensor,
   template <>                                                       \
   PADDLE_API T* TensorBase::mutable_data_ptr() const {              \
     check_type(*this, ScalarType::name, #name);                     \
-    return const_cast<PaddleTensor&>(tensor_).mutable_data<T>();    \
+    return const_cast<PaddleTensor&>(tensor_).data<T>();            \
   }                                                                 \
                                                                     \
   template <>                                                       \


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Improvements

### Description
<!-- Describe what you’ve done -->

补全 `at::Tensor` 构造函数接口，避免移动构造和拷贝构造触发默认的浅拷贝

<!-- PCard-66972 -->