### PR TITLE
[Typing] Bump mypy to v1.18.2 and cleanup scipy version in test dependencies

### DIFF
--- a/python/unittest_py/requirements.txt
+++ b/python/unittest_py/requirements.txt
@@ -6,9 +6,7 @@ hypothesis<6.145.0
 opencv-python>= 4.10.0.84
 visualdl==2.5.3
 paddle2onnx>=0.9.6; python_version < "3.12"
-scipy>=1.6, !=1.7.2, !=1.7.3 ; platform_system == "Windows"
-scipy == 1.10.1; python_version == "3.8"
-scipy > 1.13; python_version > "3.8"
+scipy > 1.13
 prettytable
 distro
 autograd==1.4
@@ -18,6 +16,6 @@ wandb>=0.17.2 ; python_version<"3.12"
 xlsxwriter==3.0.9
 xdoctest==1.3.0
 ubelt==1.3.3 # just for xdoctest
-mypy==1.17.1
+mypy==1.18.2
 soundfile
 apache-tvm-ffi==0.1.1


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

更新 mypy 到 v1.18.2

清理 test dependencies 里的 scipy 版本，因为不再支持 Python 3.8，直接 pin `scipy>1.13`

<!-- PCard-66972 -->