### PR TITLE
Fix bugs for savetensors load

### DIFF
--- a/python/paddle/framework/io.py
+++ b/python/paddle/framework/io.py
@@ -1243,7 +1243,11 @@ def load(path: str | BytesIO, **configs: Unpack[_LoadOptions]) -> Any:
                             safetensors.__version__ > "0.6.2"
                             and paddle.__version__ >= "3.2.0"
                         ):
-                            load_result = load_file(path, device='cuda')
+                            # NOTE(Ruibiao): load_file may cause segmentation fault in some case.
+                            f = safetensors.safe_open(path, framework="paddle")
+                            load_result = {}
+                            for k in f.keys():
+                                load_result[k] = f.get_tensor(k).cuda()
                         else:
                             load_result = load_file(
                                 path, device=_current_expected_place()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Execute Infrastructure


### PR Types
Bug fixes


### Description
<!-- Describe what you’ve done -->
```python
load_result = load_file(path, device='cuda')
```
paddle.load接口中这行代码存在2个bugs：
1. 传入'cuda'参数，`load_file`中默认使用gpu-0作为device，在非gpu-0进程中调用会出现上下文错误。由于在python端不方便获取`device_id`，本PR将其暂时改成加载为`cpu_tensor`，再通过`.cuda()`转换到gpu。
<img width="1404" height="648" alt="c563acf6285dfb3ada5638ef326290fd" src="https://github.com/user-attachments/assets/b22ad263-6820-4785-a1d4-89ab64ff46a1" />

2. 使用`load_file`加载`cpu_tensor`，触发`as_type`调用`cast`进行bf16到fp32转换的逻辑，该逻辑中会出segment fault错误。本PR暂时改为通过`safe_open`接口进行加载。
<img width="919" height="178" alt="image" src="https://github.com/user-attachments/assets/f69f51e1-91a5-4f10-904f-4c6413ce63b8" />

