### PR TITLE
[SOT][3.14] Fix `LOAD_FAST_BORROW` codegen and refactor fused instruction mappings

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/instruction_utils/instruction_pass.py
+++ b/python/paddle/jit/sot/opcode_translator/instruction_utils/instruction_pass.py
@@ -22,6 +22,7 @@ from paddle.jit.sot.utils import log, log_do
 
 from ...utils import InnerError
 from .instruction_utils import instrs_info
+from .opcode_info import TO_FUSED_INSTS
 from .stack_analyse import StackAnalyser
 
 if TYPE_CHECKING:
@@ -82,7 +83,7 @@ def find_loaded_once_local_vars(instrs: list[Instruction], code_options):
     """
     loaded_vars = {}
     for instr in instrs:
-        if instr.opname in ["LOAD_FAST", "LOAD_FAST_CHECK"]:
+        if instr.opname in ["LOAD_FAST", "LOAD_FAST_BORROW", "LOAD_FAST_CHECK"]:
             if instr.argval in loaded_vars:
                 loaded_vars[instr.argval] += 1
             else:
@@ -94,12 +95,12 @@ def find_loaded_once_local_vars(instrs: list[Instruction], code_options):
 
 def find_related_local_opcodes(instrs: list[Instruction], code_options):
     """
-    find out the opcode pairs consist with LOAD_FAST and STORE_FAST and LOAD_FAST_CHECK
+    find out the opcode pairs consist with LOAD_FAST and LOAD_FAST_BORROW and STORE_FAST and LOAD_FAST_CHECK
     """
     stack = []
     opcode_pairs = []
     for instr in instrs:
-        if instr.opname in ["LOAD_FAST", "LOAD_FAST_CHECK"]:
+        if instr.opname in ["LOAD_FAST", "LOAD_FAST_BORROW", "LOAD_FAST_CHECK"]:
             stack.append(instr)
         elif instr.opname == "STORE_FAST":
             if len(stack) > 0 and stack[-1] is not None:
@@ -174,7 +175,12 @@ def remove_load_store_pass(instrs: list[Instruction], code_options):
                     for instr in instrs:
                         if (
                             instr.opname
-                            in ("LOAD_FAST_CHECK", "LOAD_FAST", "STORE_FAST")
+                            in (
+                                "LOAD_FAST_CHECK",
+                                "LOAD_FAST",
+                                "LOAD_FAST_BORROW",
+                                "STORE_FAST",
+                            )
                             and instr.argval == b_name
                         ):
                             instr.argval = a_name
@@ -229,6 +235,7 @@ def remove_load_store_pass(instrs: list[Instruction], code_options):
                     not code_exist("STORE_FAST", b_name, code_range)
                     and not code_exist("LOAD_FAST_CHECK", b_name, code_range)
                     and not code_exist("LOAD_FAST", b_name, code_range)
+                    and not code_exist("LOAD_FAST_BORROW", b_name, code_range)
                     and not code_exist(
                         "LOAD_FAST_CHECK",
                         a_name,
@@ -236,6 +243,11 @@ def remove_load_store_pass(instrs: list[Instruction], code_options):
                     )
                     and not code_exist(
                         "LOAD_FAST", a_name, instrs[instrs.index(store_b) :]
+                    )
+                    and not code_exist(
+                        "LOAD_FAST_BORROW",
+                        a_name,
+                        instrs[instrs.index(store_b) :],
                     )
                 ):
                     last_store_a.argval = b_name
@@ -245,7 +257,12 @@ def remove_load_store_pass(instrs: list[Instruction], code_options):
                     for instr in instrs[last_store_idx:]:
                         if (
                             instr.opname
-                            in ("LOAD_FAST_CHECK", "LOAD_FAST", "STORE_FAST")
+                            in (
+                                "LOAD_FAST_CHECK",
+                                "LOAD_FAST",
+                                "LOAD_FAST_BORROW",
+                                "STORE_FAST",
+                            )
                             and instr.argval == a_name
                         ):
                             instr.argval = b_name
@@ -287,17 +304,12 @@ def fuse_double_super_instrs(instrs: list[Instruction], code_options):
     Fuse two consecutive LOAD_FAST or STORE_FAST instructions into one.
     """
     co_varnames = code_options['co_varnames']
-    TO_FUSE_INSTS: dict[tuple[str, str], str] = {
-        ("LOAD_FAST", "LOAD_FAST"): "LOAD_FAST_LOAD_FAST",
-        ("STORE_FAST", "STORE_FAST"): "STORE_FAST_STORE_FAST",
-        ("STORE_FAST", "LOAD_FAST"): "STORE_FAST_LOAD_FAST",
-    }
 
     def able_to_merge(idx: int):
         return (
             idx > 0
             and (instrs[idx - 1].opname, instrs[idx].opname)
-            in TO_FUSE_INSTS.keys()
+            in TO_FUSED_INSTS.keys()
             and not instrs[idx].is_jump_target
             and not instrs[idx - 1].is_jump_target
             and co_varnames.index(instrs[idx - 1].argval) < 16
@@ -306,7 +318,7 @@ def fuse_double_super_instrs(instrs: list[Instruction], code_options):
 
     def merge_two_op(prev_instr: Instruction, instr: Instruction):
         merge_key = (instrs[idx - 1].opname, instrs[idx].opname)
-        prev_instr.opname = TO_FUSE_INSTS[merge_key]
+        prev_instr.opname = TO_FUSED_INSTS[merge_key]
         prev_instr.opcode = dis.opmap[prev_instr.opname]
         prev_instr.is_generated = True
         prev_instr.argval = (prev_instr.argval, instr.argval)

--- a/python/paddle/jit/sot/opcode_translator/instruction_utils/instruction_pass.py
+++ b/python/paddle/jit/sot/opcode_translator/instruction_utils/instruction_pass.py
@@ -95,7 +95,7 @@ def find_loaded_once_local_vars(instrs: list[Instruction], code_options):
 
 def find_related_local_opcodes(instrs: list[Instruction], code_options):
     """
-    find out the opcode pairs consist with LOAD_FAST and LOAD_FAST_BORROW and STORE_FAST and LOAD_FAST_CHECK
+    Find opcode pairs consisting of LOAD_FAST, LOAD_FAST_BORROW, STORE_FAST, and LOAD_FAST_CHECK.
     """
     stack = []
     opcode_pairs = []

--- a/python/paddle/jit/sot/opcode_translator/instruction_utils/instruction_utils.py
+++ b/python/paddle/jit/sot/opcode_translator/instruction_utils/instruction_utils.py
@@ -435,12 +435,7 @@ def modify_vars(instructions: list[Instruction], code_options):
                     f"`{instrs.argval}` not in {namemap}"
                 )
                 instrs.arg = namemap.index(instrs.argval)
-        elif instrs.opname in [
-            'LOAD_FAST_LOAD_FAST',
-            'LOAD_FAST_BORROW_LOAD_FAST_BORROW',
-            'STORE_FAST_STORE_FAST',
-            'STORE_FAST_LOAD_FAST',
-        ]:
+        elif instrs.opname in FUSED_INSTS.keys():
             assert instrs.argval[0] in co_varnames, (
                 f"`{instrs.argval[0]}` not in {co_varnames}"
             )

--- a/python/paddle/jit/sot/opcode_translator/instruction_utils/instruction_utils.py
+++ b/python/paddle/jit/sot/opcode_translator/instruction_utils/instruction_utils.py
@@ -24,6 +24,7 @@ from ...utils import InnerError
 from .opcode_info import (
     ABS_JUMP,
     ALL_JUMP,
+    FUSED_INSTS,
     PYOPCODE_CACHE_SIZE,
     REL_BWD_JUMP,
     REL_JUMP,
@@ -118,16 +119,6 @@ def expand_super_instrs(instructions: list[Instruction]) -> list[Instruction]:
             is_generated=is_generated,
             jump_to=instr.jump_to,
         )
-
-    FUSED_INSTS: dict[str, tuple[str, str]] = {
-        "LOAD_FAST_LOAD_FAST": ("LOAD_FAST", "LOAD_FAST"),
-        "LOAD_FAST_BORROW_LOAD_FAST_BORROW": (
-            "LOAD_FAST_BORROW",
-            "LOAD_FAST_BORROW",
-        ),
-        "STORE_FAST_STORE_FAST": ("STORE_FAST", "STORE_FAST"),
-        "STORE_FAST_LOAD_FAST": ("STORE_FAST", "LOAD_FAST"),
-    }
 
     for instr in instructions:
         if instr.opname in FUSED_INSTS:
@@ -428,6 +419,7 @@ def modify_vars(instructions: list[Instruction], code_options):
     for instrs in instructions:
         if instrs.opname in [
             'LOAD_FAST',
+            'LOAD_FAST_BORROW',
             'LOAD_FAST_CHECK',
             'STORE_FAST',
             'DELETE_FAST',
@@ -445,6 +437,7 @@ def modify_vars(instructions: list[Instruction], code_options):
                 instrs.arg = namemap.index(instrs.argval)
         elif instrs.opname in [
             'LOAD_FAST_LOAD_FAST',
+            'LOAD_FAST_BORROW_LOAD_FAST_BORROW',
             'STORE_FAST_STORE_FAST',
             'STORE_FAST_LOAD_FAST',
         ]:

--- a/python/paddle/jit/sot/opcode_translator/instruction_utils/opcode_analysis.py
+++ b/python/paddle/jit/sot/opcode_translator/instruction_utils/opcode_analysis.py
@@ -49,6 +49,7 @@ def is_read_opcode(opname):
         "LOAD_NAME",
         "LOAD_GLOBAL",
         "LOAD_CLOSURE",
+        "LOAD_FAST_BORROW",
     ]:
         return True
     if opname in (

--- a/python/paddle/jit/sot/opcode_translator/instruction_utils/opcode_info.py
+++ b/python/paddle/jit/sot/opcode_translator/instruction_utils/opcode_info.py
@@ -153,3 +153,15 @@ def _get_binary_op_arg_map() -> dict[str, int]:
 
 
 BINARY_OP_ARG_MAP: dict[str, int] = _get_binary_op_arg_map()
+
+FUSED_INSTS: dict[str, tuple[str, str]] = {
+    "LOAD_FAST_LOAD_FAST": ("LOAD_FAST", "LOAD_FAST"),
+    "LOAD_FAST_BORROW_LOAD_FAST_BORROW": (
+        "LOAD_FAST_BORROW",
+        "LOAD_FAST_BORROW",
+    ),
+    "STORE_FAST_STORE_FAST": ("STORE_FAST", "STORE_FAST"),
+    "STORE_FAST_LOAD_FAST": ("STORE_FAST", "LOAD_FAST"),
+}
+
+TO_FUSED_INSTS = {v: k for k, v in FUSED_INSTS.items()}


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->

- 修复 `LOAD_FAST_BORROW` 的 codegen 部分
- `FUSED_INSTS` 和 `TO_FUSED_INSTS` 移动至 `opcode_info` 并改为 kv 转换，减少维护成本

新通过的单测

- `test_06_call_function.py`
- `test_11_jumps.py`
- `test_12_for_loop.py`
- `test_14_operators.py`
- `test_18_tensor_method.py`
- `test_22_generator.py`
- `test_analysis_inputs.py`
- `test_break_graph.py`
- `test_builtin_dispatch.py`
- `test_builtin_range.py`
- `test_builtin_zip.py`
- `test_constant_graph.py`
- `test_dataclass.py`
- `test_delete_fast.py`
- `test_dtype.py`
- `test_enumerate.py`
- `test_force_breakgraph_api.py`
- `test_functools.py`
- `test_inplace_api.py`
- `test_iter.py`
- `test_min_graph_size.py`
- `test_numpy_var_if.py`
- `test_numpy.py`
- `test_psdb.py`
- `test_resume_cache.py`
- `test_side_effects.py`
- `test_simulate_initialize.py`
- `test_sir_rollback.py`
- `test_sot_exception.py`
- `test_sot_tensor_array.py`
- `test_step_profiler.py`

剩余单测 15
