### PR TITLE
[Cherry-Pick][CINN] Fix bug of infer_symbol_shape for crop op (#75992)

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/group_merge/single_op_fallback_to_phi.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/group_merge/single_op_fallback_to_phi.cc
@@ -150,6 +150,7 @@ class FusionOpPattern : public pir::OpRewritePattern<cinn::dialect::FusionOp> {
         {paddle::dialect::AssignOut_Op::name(),
          &FusionOpPattern::AssignOutOpPattern},
         {paddle::dialect::CastOp::name(), &FusionOpPattern::CastOpPattern},
+        {cinn::dialect::ConcatOp::name(), &FusionOpPattern::ConcatOpPattern},
     };
     return handler_map;
   }

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.cc
@@ -830,7 +830,8 @@ bool CropOpInferSymbolicShape(pir::Operation *op,
 
   for (size_t i = 0; i < in_shape.size(); ++i) {
     if (in_shape[i].isa<int64_t>()) {
-      if (x_shape[i].Get<int64_t>() == 0) {  // x is 0-size
+      if (x_shape[i].isa<int64_t>() &&
+          x_shape[i].Get<int64_t>() == 0) {  // x is 0-size
         out_dims.push_back(symbol::DimExpr(x_shape[i]));
       } else if (in_shape[i].Get<int64_t>() == -1) {
         out_dims.push_back(symbol::DimExpr(x_shape[i] - offsets[i]));

--- a/test/ir/pir/cinn/inference/test_llama_postprocess.py
+++ b/test/ir/pir/cinn/inference/test_llama_postprocess.py
@@ -15,6 +15,8 @@ import sys
 import unittest
 from os.path import dirname
 
+import numpy as np
+
 import paddle
 import paddle.nn.functional as F
 from paddle import nn
@@ -93,8 +95,8 @@ class TestLlamaPostProcess(unittest.TestCase):
         self.input_ids = paddle.randint(0, 512, [1, 32], dtype="int64")
 
     def check_jit_kernel_info(self, static_fn):
-        utils.check_jit_kernel_number(static_fn, 5)
-        utils.check_jit_kernel_structure(static_fn, {utils.JIT_KERNEL_NAME: 5})
+        utils.check_jit_kernel_number(static_fn, 4)
+        utils.check_jit_kernel_structure(static_fn, {utils.JIT_KERNEL_NAME: 4})
 
     def eval(self, use_cinn):
         paddle.seed(2024)
@@ -114,11 +116,10 @@ class TestLlamaPostProcess(unittest.TestCase):
     def test_eval(self):
         dy_out = self.eval(use_cinn=False)
         cinn_out = self.eval(use_cinn=True)
-        # TODO(Aurelius84): fix the precision with inf
-        # for i in range(len(dy_out)):
-        #     np.testing.assert_allclose(
-        #         cinn_out[i].numpy(), dy_out[i].numpy(), atol=1e-6, rtol=1e-6
-        #     )
+        for i in range(len(dy_out)):
+            np.testing.assert_allclose(
+                cinn_out[i].numpy(), dy_out[i].numpy(), atol=1e-6, rtol=1e-6
+            )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
cherry-pick: https://github.com/PaddlePaddle/Paddle/pull/75992

修复 Crop 算子符号推导 Bug。