### PR TITLE
[PHI] Support direct indexing for `DenseTensor.dims(idx)`

### DIFF
--- a/paddle/phi/core/dense_tensor.h
+++ b/paddle/phi/core/dense_tensor.h
@@ -85,6 +85,46 @@ class PADDLE_API DenseTensor : public TensorBase,
   /// \return The dims of the tensor.
   const DDim& dims() const noexcept override { return meta_.dims; }
 
+  /// \brief Returns the size of the tensor along the specified dimension.
+  ///        Supports negative indices, which count from the last dimension.
+  /// \param dim The dimension index to retrieve. Must be in the range [0, ndim)
+  /// or [-ndim, -1]. \return The size of the tensor along the given dimension.
+  /// \throws phi::errors::OutOfRange if the tensor is empty or the index is out
+  /// of range.
+  const int64_t dims(int dim) const {
+    int ndim = meta_.dims.size();
+
+    // Ensure the tensor has at least one dimension
+    PADDLE_ENFORCE_GE(ndim,
+                      1,
+                      phi::errors::OutOfRange(
+                          "dims expects at least a 1-dimensional tensor"));
+
+    // Check if the index is within the valid range [-ndim, ndim)
+    PADDLE_ENFORCE_GE(
+        dim,
+        -ndim,
+        phi::errors::OutOfRange(
+            "dims: dimension index (%d) must be in range [-%d, %d)",
+            dim,
+            ndim,
+            ndim));
+    PADDLE_ENFORCE_LT(
+        dim,
+        ndim,
+        phi::errors::OutOfRange(
+            "dims: dimension index (%d) must be in range [-%d, %d)",
+            dim,
+            ndim,
+            ndim));
+
+    // Handle negative indices
+    if (dim < 0) {
+      dim += ndim;
+    }
+    return meta_.dims[dim];
+  }
+
   /// \brief Returns the stride of the tensor.
   /// \return The stride of the tensor.
   const DDim& strides() const noexcept { return meta_.strides; }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->

Pcard-75624

1. 支持直接通过`DenseTensor.dims(idx)`获取张量的某个维度大小(支持负数索引)，避免在开发phi算子时使用
`t.dims()[t.dims().size()-1]`这种复杂写法；
2. 添加了必要的的范围检查和单测

相关PR： <https://github.com/PaddlePaddle/Paddle/pull/76244>