### PR TITLE
[cherry-pick] fix bigtensor for infermeta

### DIFF
--- a/paddle/phi/infermeta/backward.cc
+++ b/paddle/phi/infermeta/backward.cc
@@ -740,10 +740,10 @@ void GruGradInferMeta(const MetaTensor& input,
                       MetaConfig config) {
   const auto& input_dims = input.dims();
   const auto& weight_dims = weight.dims();
-  int input_size = static_cast<int>(input_dims[1]);
-  int frame_size = static_cast<int>(weight_dims[0]);
-  int weight_height = static_cast<int>(weight_dims[0]);
-  int weight_width = static_cast<int>(weight_dims[1]);
+  int64_t input_size = input_dims[1];
+  int64_t frame_size = weight_dims[0];
+  int64_t weight_height = weight_dims[0];
+  int64_t weight_width = weight_dims[1];
   PADDLE_ENFORCE_EQ(
       input_size,
       frame_size * 3,
@@ -789,8 +789,8 @@ void GruGradInferMeta(const MetaTensor& input,
   }
   if (bias.initialized()) {
     const auto& bias_dims = bias.dims();
-    int bias_height = static_cast<int>(bias_dims[0]);
-    int bias_width = static_cast<int>(bias_dims[1]);
+    int64_t bias_height = bias_dims[0];
+    int64_t bias_width = bias_dims[1];
     PADDLE_ENFORCE_EQ(
         bias_height,
         1,
@@ -836,11 +836,10 @@ void GruUnitGradInferMeta(const MetaTensor& input,
   const auto& input_dims = input.dims();
   const auto& hidden_prev_dims = hidden_prev.dims();
   const auto& weight_dims = weight.dims();
-  // int batch_size = input_dims[0];
-  int input_size = static_cast<int>(input_dims[1]);
-  int frame_size = static_cast<int>(hidden_prev_dims[1]);
-  int weight_height = static_cast<int>(weight_dims[0]);
-  int weight_width = static_cast<int>(weight_dims[1]);
+  int64_t input_size = input_dims[1];
+  int64_t frame_size = hidden_prev_dims[1];
+  int64_t weight_height = weight_dims[0];
+  int64_t weight_width = weight_dims[1];
   if (config.is_runtime || input_size >= 0) {
     PADDLE_ENFORCE_EQ(
         input_size,
@@ -876,8 +875,8 @@ void GruUnitGradInferMeta(const MetaTensor& input,
           frame_size * 3));
   if (bias.initialized()) {
     const auto& bias_dims = bias.dims();
-    int bias_height = static_cast<int>(bias_dims[0]);
-    int bias_width = static_cast<int>(bias_dims[1]);
+    int64_t bias_height = bias_dims[0];
+    int64_t bias_width = bias_dims[1];
 
     PADDLE_ENFORCE_EQ(
         bias_height,
@@ -952,7 +951,7 @@ void InstanceNormGradInferMeta(const MetaTensor& x,
       common::errors::InvalidArgument(
           "The X@GRAD in InstanceNormGradInferMeta can't be nullptr."));
   const auto x_dims = x.dims();
-  const int C = static_cast<int>(x_dims[1]);
+  const int64_t C = x_dims[1];
   x_grad->set_dims(x_dims);
   x_grad->set_dtype(x.dtype());
   x_grad->set_layout(x.layout());
@@ -989,7 +988,7 @@ void InstanceNormDoubleGradInferMeta(const MetaTensor& x,
       common::errors::InvalidArgument(
           "The DX in InstanceNormDoubleGradInferMeta can't be nullptr."));
   const auto x_dims = x.dims();
-  const int C = static_cast<int>(x_dims[1]);
+  const int64_t C = x_dims[1];
   dx->set_dims(x_dims);
   dx->set_dtype(x.dtype());
   dx->set_layout(x.layout());

--- a/paddle/phi/infermeta/binary.cc
+++ b/paddle/phi/infermeta/binary.cc
@@ -712,12 +712,11 @@ void ConvInferMeta(const MetaTensor& input,
         (in_data_dims[i] < 0 || filter_dims[i + 2] < 0)) {
       output_shape.push_back(-1);
     } else {
-      const int dkernel =
-          static_cast<int>(dilations[i] * (filter_data_dims[i] - 1) + 1);
-      int output_size = static_cast<int>(
+      const int64_t dkernel = dilations[i] * (filter_data_dims[i] - 1) + 1;
+      int64_t output_size =
           (in_data_dims[i] + paddings[2 * i] + paddings[2 * i + 1] - dkernel) /
               strides[i] +
-          1);
+          1;
       output_shape.push_back(output_size);
     }
   }
@@ -1001,15 +1000,14 @@ void CorrelationInferMeta(const MetaTensor& input1,
                         "Input(Y) of CorrelationOp must be 4 dims."
                         "But received dims is %d.",
                         in2_dims.size()));
-  std::vector<int64_t> output_shape =
-      CorrelationOutputSize(static_cast<int>(in_dims[0]),
-                            static_cast<int>(in_dims[2]),
-                            static_cast<int>(in_dims[3]),
-                            stride1,
-                            stride2,
-                            kernel_size,
-                            pad_size,
-                            max_displacement);
+  std::vector<int64_t> output_shape = CorrelationOutputSize(in_dims[0],
+                                                            in_dims[2],
+                                                            in_dims[3],
+                                                            stride1,
+                                                            stride2,
+                                                            kernel_size,
+                                                            pad_size,
+                                                            max_displacement);
   out->set_dims(common::make_ddim(output_shape));
   out->set_dtype(input1.dtype());
 }
@@ -2153,9 +2151,7 @@ void GatherNdInferMeta(const MetaTensor& x,
   for (int i = 0; i < index_dims_size - 1; ++i) {
     result_dims.emplace_back(index_dims[i]);
   }
-  for (int i = static_cast<int>(index_dims[index_dims_size - 1]);
-       i < x_dims_size;
-       ++i) {
+  for (int64_t i = index_dims[index_dims_size - 1]; i < x_dims_size; ++i) {
     result_dims.emplace_back(x_dims[i]);
   }
 
@@ -2833,9 +2829,9 @@ void LUUnpackInferMeta(const MetaTensor& x,
                     common::errors::InvalidArgument(
                         "The rank of input must greater than 2."));
 
-  int m = static_cast<int>(x_dims[x_rank - 2]);
-  int n = static_cast<int>(x_dims[x_rank - 1]);
-  int min_mn = std::min(m, n);
+  int64_t m = x_dims[x_rank - 2];
+  int64_t n = x_dims[x_rank - 1];
+  int64_t min_mn = std::min(m, n);
   if (unpack_ludata) {
     auto ldims = x_dims;
     auto udims = x_dims;
@@ -3477,7 +3473,7 @@ void PullGpupsSparseInferMeta(const MetaTensor& w,
   std::vector<phi::DDim> outs_dims;
   outs_dims.resize(n_ids);
   for (size_t i = 0; i < n_ids; ++i) {
-    int embedding_size = size[i];
+    int64_t embedding_size = size[i];
     const auto ids_dims = ids[i]->dims();
     int ids_rank = ids_dims.size();
     PADDLE_ENFORCE_EQ(ids_dims[ids_rank - 1],
@@ -4009,7 +4005,7 @@ void StftInferMeta(const MetaTensor& x,
   const auto& x_dims = x.dims();
   const int x_rank = x_dims.size();
   const auto& window_dims = window.dims();
-  const int window_size = static_cast<int>(window_dims[0]);
+  const int64_t window_size = window_dims[0];
 
   PADDLE_ENFORCE_EQ(
       x_rank,
@@ -4033,8 +4029,8 @@ void StftInferMeta(const MetaTensor& x,
           n_fft,
           window_size));
 
-  int seq_length = static_cast<int>(x_dims[x_rank - 1]);
-  int n_frames = 1 + (seq_length - n_fft) / hop_length;
+  int64_t seq_length = x_dims[x_rank - 1];
+  int64_t n_frames = 1 + (seq_length - n_fft) / hop_length;
 
   PADDLE_ENFORCE_LE(n_fft,
                     seq_length,
@@ -4193,9 +4189,9 @@ void LstsqInferMeta(const MetaTensor& x,
   int x_rank = x_dims.size();
   int y_rank = y_dims.size();
 
-  int m = static_cast<int>(x_dims[x_rank - 2]);
-  int n = static_cast<int>(x_dims[x_rank - 1]);
-  int nrhs = static_cast<int>(y_dims[x_rank - 1]);
+  int64_t m = x_dims[x_rank - 2];
+  int64_t n = x_dims[x_rank - 1];
+  int64_t nrhs = y_dims[x_rank - 1];
 
   PADDLE_ENFORCE_GE(x_rank,
                     2,
@@ -4374,9 +4370,9 @@ void YoloBoxInferMeta(const MetaTensor& x,
                         "But received class_num (%s)",
                         class_num));
 
-  int box_num = 0;
+  int64_t box_num = 0;
   if ((dim_x[2] > 0 && dim_x[3] > 0) || config.is_runtime) {
-    box_num = static_cast<int>(dim_x[2] * dim_x[3] * anchor_num);
+    box_num = dim_x[2] * dim_x[3] * anchor_num;
   } else {
     box_num = -1;
   }
@@ -4682,8 +4678,8 @@ void WeightDequantizeInferMeta(const MetaTensor& x,
                           scale.dims()[0],
                           real_channel_shape));
   }
-  int n = static_cast<int>(x.dims()[1]);
-  int k = static_cast<int>(real_channel_shape);
+  int64_t n = x.dims()[1];
+  int64_t k = real_channel_shape;
   out->set_dims(common::make_ddim({n, k}));
   out->set_dtype(scale.dtype());
 }

--- a/paddle/phi/infermeta/spmd_rules/fused_rope.cc
+++ b/paddle/phi/infermeta/spmd_rules/fused_rope.cc
@@ -198,9 +198,9 @@ void infer_sin_cos(const DistMetaTensor& sin,
     // check sin, cos, position_ids's shape
     const int kBatchDimIndex = time_major ? 1 : 0;
     const int kSeqlenDimIndex = time_major ? 0 : 1;
-    int batch_size = q_shape[kBatchDimIndex];
-    int seq_len = q_shape[kSeqlenDimIndex];
-    int head_dim = q_shape[kHeadDimIndex];
+    int64_t batch_size = q_shape[kBatchDimIndex];
+    int64_t seq_len = q_shape[kSeqlenDimIndex];
+    int64_t head_dim = q_shape[kHeadDimIndex];
 
     int seq_len_dim_index = sin_shape.size() == 4 ? 1 : 0;
     int head_dim_index = sin_shape.size() == 4 ? 3 : 1;

--- a/paddle/phi/infermeta/ternary.cc
+++ b/paddle/phi/infermeta/ternary.cc
@@ -645,11 +645,11 @@ void FlashAttnInferMeta(const MetaTensor& q,
   softmax->set_dtype(q.dtype());
   softmax_lse->set_dtype(q.dtype());
   if (out_dims.size() == 4) {
-    auto round_multiple = [](int x) { return (x + 127) / 128 * 128; };
-    int batch_size = q.dims()[0];
-    int num_heads = q.dims()[2];
-    int seqlen_q_rounded = round_multiple(q.dims()[1]);
-    int seqlen_k_rounded = round_multiple(k.dims()[1]);
+    auto round_multiple = [](int64_t x) { return (x + 127) / 128 * 128; };
+    int64_t batch_size = q.dims()[0];
+    int64_t num_heads = q.dims()[2];
+    int64_t seqlen_q_rounded = round_multiple(q.dims()[1]);
+    int64_t seqlen_k_rounded = round_multiple(k.dims()[1]);
     if (softmax) {
       softmax->set_dims(
           {batch_size, num_heads, seqlen_q_rounded, seqlen_k_rounded});
@@ -659,11 +659,11 @@ void FlashAttnInferMeta(const MetaTensor& q,
     }
   }
   if (out_dims.size() == 3) {  // when use flash_attn_unpadded
-    auto round_multiple = [](int x) { return (x + 127) / 128 * 128; };
-    int batch_and_seq_size = q.dims()[0];
-    int num_heads = q.dims()[1];
-    int seqlen_q_rounded = round_multiple(batch_and_seq_size);
-    int seqlen_k_rounded = round_multiple(batch_and_seq_size);
+    auto round_multiple = [](int64_t x) { return (x + 127) / 128 * 128; };
+    int64_t batch_and_seq_size = q.dims()[0];
+    int64_t num_heads = q.dims()[1];
+    int64_t seqlen_q_rounded = round_multiple(batch_and_seq_size);
+    int64_t seqlen_k_rounded = round_multiple(batch_and_seq_size);
     if (softmax) {
       softmax->set_dims({num_heads, seqlen_q_rounded, seqlen_k_rounded});
     }
@@ -732,7 +732,9 @@ void CalcReducedAttnScoresInferMeta(const MetaTensor& q,
                      "calc_reduced_attn_scores must receive input q and "
                      "softmax_lse with consistent batch_size!"));
 
-  auto round_multiple = [](int x, int m) { return (x + m - 1) / m * m; };
+  auto round_multiple = [](int64_t x, int64_t m) {
+    return (x + m - 1) / m * m;
+  };
   PADDLE_ENFORCE(round_multiple(q.dims()[1], 128) == softmax_lse.dims()[2],
                  common::errors::InvalidArgument(
                      "calc_reduced_attn_scores must receive input q and "
@@ -748,9 +750,9 @@ void CalcReducedAttnScoresInferMeta(const MetaTensor& q,
                      "calc_reduced_attn_scores must receive input q and k "
                      "with consistent head_dim!"));
 
-  int batch_size = q.dims()[0];
-  int num_heads = q.dims()[2];
-  int seqlen_k = k.dims()[1];
+  int64_t batch_size = q.dims()[0];
+  int64_t num_heads = q.dims()[2];
+  int64_t seqlen_k = k.dims()[1];
 
   reduced_scores->set_dtype(phi::DataType::FLOAT32);
   reduced_scores->set_dims({batch_size, num_heads, 1, seqlen_k});
@@ -761,10 +763,10 @@ void FlashMaskV2InferMeta(const MetaTensor& q,
                           const MetaTensor& v,
                           MetaTensor* out,
                           MetaTensor* softmax_lse) {
-  const int batch_size = q.dims()[0];
-  const int seqlen_q = q.dims()[1];
-  const int num_heads = q.dims()[q.dims().size() - 2];
-  const int head_size_v = v.dims()[v.dims().size() - 1];
+  const int64_t batch_size = q.dims()[0];
+  const int64_t seqlen_q = q.dims()[1];
+  const int64_t num_heads = q.dims()[q.dims().size() - 2];
+  const int64_t head_size_v = v.dims()[v.dims().size() - 1];
   auto q_type = q.dtype();
   auto out_type =
       q_type == phi::DataType::FLOAT8_E4M3FN ? phi::DataType::BFLOAT16 : q_type;
@@ -782,10 +784,10 @@ void FlashAttnV3InferMeta(const MetaTensor& q,
                           const MetaTensor& v,
                           MetaTensor* out,
                           MetaTensor* softmax_lse) {
-  const int batch_size = q.dims()[0];
-  const int seqlen_q = q.dims()[1];
-  const int num_heads = q.dims()[q.dims().size() - 2];
-  const int head_size_v = v.dims()[v.dims().size() - 1];
+  const int64_t batch_size = q.dims()[0];
+  const int64_t seqlen_q = q.dims()[1];
+  const int64_t num_heads = q.dims()[q.dims().size() - 2];
+  const int64_t head_size_v = v.dims()[v.dims().size() - 1];
   auto q_type = q.dtype();
   auto out_type =
       q_type == phi::DataType::FLOAT8_E4M3FN ? phi::DataType::BFLOAT16 : q_type;
@@ -803,9 +805,9 @@ void FlashAttnV3VarlenInferMeta(const MetaTensor& q,
                                 const MetaTensor& v,
                                 MetaTensor* out,
                                 MetaTensor* softmax_lse) {
-  const int total_q = q.dims()[0];
-  const int num_heads = q.dims()[q.dims().size() - 2];
-  const int head_size_v = v.dims()[v.dims().size() - 1];
+  const int64_t total_q = q.dims()[0];
+  const int64_t num_heads = q.dims()[q.dims().size() - 2];
+  const int64_t head_size_v = v.dims()[v.dims().size() - 1];
   auto q_type = q.dtype();
   auto out_type =
       q_type == phi::DataType::FLOAT8_E4M3FN ? phi::DataType::BFLOAT16 : q_type;
@@ -1378,8 +1380,8 @@ void LayerNormInferMeta(const MetaTensor& x,
 
   // keep the axis size before normalization for shape of variance and mean
   auto before_norm_dims = slice_ddim(x_dim, 0, begin_norm_axis);
-  // int left = static_cast<int>(matrix_dim[0]);
-  int right = static_cast<int>(matrix_dim[1]);
+  // int64_t left = matrix_dim[0];
+  int64_t right = matrix_dim[1];
   if (scale) {
     PADDLE_ENFORCE_EQ(scale.dims().size(),
                       1,
@@ -2531,9 +2533,7 @@ void ScatterNdAddInferMeta(const MetaTensor& x,
       }
       r_updates_dims.emplace_back(index_dims[i]);
     }
-    for (int i = static_cast<int>(index_dims[index_dims_size - 1]);
-         i < ref_dims_size;
-         ++i) {
+    for (int64_t i = index_dims[index_dims_size - 1]; i < ref_dims_size; ++i) {
       if (ref_dims[i] == -1) {
         without_dynamic_shape = false;
       }
@@ -2676,7 +2676,7 @@ void SequenceConvInferMeta(const MetaTensor& x,
     int up_pad = std::max(0, -context_start);
     int down_pad = std::max(0, context_start + context_length - 1);
     int total_pad = up_pad + down_pad;
-    int input_width = static_cast<int>(in_dims[1]);
+    int64_t input_width = in_dims[1];
     bool start_equals_zero = context_start == 0;
     bool length_equals_one = context_length == 1;
     bool start_length = start_equals_zero && length_equals_one;
@@ -2749,11 +2749,11 @@ void SpectralNormInferMeta(const MetaTensor& weight,
           "Attr(power_iters) should be greater equal then 0, but received %d",
           power_iters));
 
-  int h = static_cast<int>(dim_weight[dim]);
-  int w = 1;
+  int64_t h = dim_weight[dim];
+  int64_t w = 1;
   for (int i = 0; i < rank_weight; i++) {
     if (i != dim) {
-      w *= static_cast<int>(dim_weight[i]);
+      w *= dim_weight[i];
     }
   }
   auto dim_u = u.dims();

--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -423,7 +423,7 @@ void AsComplexInferMeta(const MetaTensor& input, MetaTensor* output) {
           "Expected the rank of input(X) to be equal to or greater than 1."
           "But received rank of input(X) = %d",
           input_rank));
-  const int last_dim_size = static_cast<int>(in_dims[input_rank - 1]);
+  const int64_t last_dim_size = in_dims[input_rank - 1];
   PADDLE_ENFORCE_EQ(
       last_dim_size,
       2,
@@ -915,9 +915,8 @@ void DiagEmbedInferMeta(
                         dim1,
                         dim2));
 
-  int x_last_dim = x_dims[x_dims.size() - 1];
-  int new_dim_len =
-      (x_last_dim == -1) ? -1 : static_cast<int>(offset_ + x_last_dim);
+  int64_t x_last_dim = x_dims[x_dims.size() - 1];
+  int64_t new_dim_len = (x_last_dim == -1) ? -1 : offset_ + x_last_dim;
   auto sizes = common::vectorize(x_dims);
   sizes.pop_back();
   sizes.insert(sizes.begin() + std::min(dim1_, dim2_), new_dim_len);
@@ -1842,8 +1841,8 @@ void FoldInferMeta(const MetaTensor& x,
   int kernel_width = kernel_sizes[1];
   int dilation_height = dilations[0];
   int dilation_width = dilations[1];
-  int stride_height = strides[0];
-  int stride_width = strides[1];
+  int64_t stride_height = strides[0];
+  int64_t stride_width = strides[1];
 
   // check kernel_sizes
   PADDLE_ENFORCE_GT(kernel_height,
@@ -1910,8 +1909,7 @@ void FoldInferMeta(const MetaTensor& x,
   // batch_size
   out_dims.push_back(in_dims[0]);  // NOLINT
   // output_plane
-  int output_channels =
-      static_cast<int>(in_dims[1] / (kernel_width * kernel_height));
+  int64_t output_channels = in_dims[1] / (kernel_width * kernel_height);
   out_dims.push_back(output_channels);
 
   int blocks_height = (output_sizes[0] + 2 * paddings[0] -
@@ -2070,18 +2068,18 @@ void FrameInferMeta(const MetaTensor& x,
           "Attribute(axis) of FrameOp should 0 or -1, but got %s.", axis));
 
   std::vector<int64_t> output_shape;
-  int seq_length = 0;
-  int n_frames = 0;
+  int64_t seq_length = 0;
+  int64_t n_frames = 0;
 
   int start_axis = 0;
   int end_axis = 0;
 
   if (axis == 0) {
-    seq_length = static_cast<int>(x_dims[0]);
+    seq_length = x_dims[0];
     start_axis = 1;
     end_axis = x_rank - 1;
   } else {
-    seq_length = static_cast<int>(x_dims[x_rank - 1]);
+    seq_length = x_dims[x_rank - 1];
     start_axis = 0;
     end_axis = x_rank - 2;
   }
@@ -2675,9 +2673,9 @@ void LUInferMeta(const MetaTensor& x,
                         "The rank of input must greater than 2."));
   out->set_dims(x_dims);
   out->set_dtype(x.dtype());
-  int m = static_cast<int>(x_dims[x_rank - 1]);
-  int n = static_cast<int>(x_dims[x_rank - 2]);
-  int min_mn = std::min(m, n);
+  int64_t m = x_dims[x_rank - 1];
+  int64_t n = x_dims[x_rank - 2];
+  int64_t min_mn = std::min(m, n);
   auto dims_vec = common::vectorize(x_dims);
   PADDLE_ENFORCE_NOT_NULL(
       infos,
@@ -2713,8 +2711,8 @@ void MatrixRankInferMeta(const MetaTensor& x,
                         "The dims of input must be greater than 2."));
 
   if (hermitian && x.numel() != 0) {
-    int rows = static_cast<int>(dim_x[dim_x.size() - 2]);
-    int cols = static_cast<int>(dim_x[dim_x.size() - 1]);
+    int64_t rows = dim_x[dim_x.size() - 2];
+    int64_t cols = dim_x[dim_x.size() - 1];
     // if x is 0-size Tensor,ignore rows == cols check.
     PADDLE_ENFORCE_EQ(rows,
                       cols,
@@ -2798,7 +2796,7 @@ void MaxPoolWithIndexInferMeta(const MetaTensor& x,
     kernel_size_.resize(static_cast<size_t>(x_dims.size()) - 2);
     for (int i = 0; i < static_cast<int>(kernel_size_.size()); ++i) {
       paddings_[i] = 0;
-      kernel_size_[i] = static_cast<int>(x_dims[i + 2]);
+      kernel_size_[i] = x_dims[i + 2];
     }
   }
 
@@ -2833,12 +2831,11 @@ void MaxPoolWithIndexInferMeta(const MetaTensor& x,
       if ((!config.is_runtime) && (x_dims[i + 2] < 0)) {
         output_shape.push_back(x_dims[i + 2]);
       } else {
-        output_shape.push_back(
-            funcs::MaxPoolOutputSize(static_cast<int>(x_dims[i + 2]),
-                                     kernel_size_[i],
-                                     paddings_[i],
-                                     strides[i],
-                                     ceil_mode));
+        output_shape.push_back(funcs::MaxPoolOutputSize(x_dims[i + 2],
+                                                        kernel_size_[i],
+                                                        paddings_[i],
+                                                        strides[i],
+                                                        ceil_mode));
       }
     }
   }
@@ -3331,20 +3328,20 @@ void OverlapAddInferMeta(const MetaTensor& x,
           "Attribute(axis) of OverlapAddOp should 0 or -1, but got %s.", axis));
 
   std::vector<int64_t> output_shape;
-  int n_frames = 0;
-  int frame_length = 0;
-  int seq_length = 0;
+  int64_t n_frames = 0;
+  int64_t frame_length = 0;
+  int64_t seq_length = 0;
 
   int start_axis = 0;
   int end_axis = 0;
   if (axis == 0) {
-    n_frames = static_cast<int>(x_dims[0]);
-    frame_length = static_cast<int>(x_dims[1]);
+    n_frames = x_dims[0];
+    frame_length = x_dims[1];
     start_axis = 2;
     end_axis = x_rank - 1;
   } else {
-    n_frames = static_cast<int>(x_dims[x_rank - 1]);
-    frame_length = static_cast<int>(x_dims[x_rank - 2]);
+    n_frames = x_dims[x_rank - 1];
+    frame_length = x_dims[x_rank - 2];
     start_axis = 0;
     end_axis = x_rank - 3;
   }
@@ -3977,13 +3974,13 @@ void QrInferMeta(const MetaTensor& x,
       common::errors::InvalidArgument("the rank of input must greater than 2"));
   bool compute_q = false;
   bool reduced_mode = false;
-  int m = static_cast<int>(x_dims[x_rank - 2]);
-  int n = static_cast<int>(x_dims[x_rank - 1]);
-  int min_mn = std::min(m, n);
+  int64_t m = x_dims[x_rank - 2];
+  int64_t n = x_dims[x_rank - 1];
+  int64_t min_mn = std::min(m, n);
   std::tie(compute_q, reduced_mode) = phi::funcs::ParseQrMode(mode);
 
   if (compute_q) {
-    int k = reduced_mode ? min_mn : m;
+    int64_t k = reduced_mode ? min_mn : m;
     auto q_dims_vec = common::vectorize(x_dims);
     q_dims_vec[q_dims_vec.size() - 1] = k;
     q->set_dims(common::make_ddim(q_dims_vec));
@@ -3991,7 +3988,7 @@ void QrInferMeta(const MetaTensor& x,
     q->set_dims(common::make_ddim({0}));
   }
 
-  int k = reduced_mode ? min_mn : m;
+  int64_t k = reduced_mode ? min_mn : m;
   auto r_dims_vec = common::vectorize(x_dims);
   r_dims_vec[r_dims_vec.size() - 2] = k;
   r_dims_vec[r_dims_vec.size() - 1] = n;
@@ -4353,7 +4350,7 @@ void ReshapeInferMeta(const MetaTensor& x,
                       const IntArray& shape,
                       MetaTensor* out,
                       MetaConfig config) {
-  auto shape_data = shape.GetData();
+  std::vector<int64_t> shape_data = shape.GetData();
   PADDLE_ENFORCE_NOT_NULL(out,
                           common::errors::InvalidArgument(
                               "Output(Out) of ReshapeOp should not be null."));
@@ -4372,7 +4369,7 @@ void ReshapeInferMeta(const MetaTensor& x,
                 i,
                 in_dims.size(),
                 in_dims));
-        shape_data[i] = static_cast<int>(in_dims[static_cast<int>(i)]);
+        shape_data[i] = in_dims[static_cast<int>(i)];
       }
     }
     out->set_dims(common::make_ddim(shape_data));
@@ -5482,9 +5479,9 @@ void SvdInferMeta(const MetaTensor& x,
       in_dims.size(),
       2,
       common::errors::InvalidArgument("the rank of input must greater than 2"));
-  int m = static_cast<int>(in_dims[x_rank - 2]);
-  int n = static_cast<int>(in_dims[x_rank - 1]);
-  int k = std::min(m, n);
+  int64_t m = in_dims[x_rank - 2];
+  int64_t n = in_dims[x_rank - 1];
+  int64_t k = std::min(m, n);
   u->set_dims(!full_matrices ? UDDim(in_dims, k) : UDDim(in_dims, m));
   vh->set_dims(!full_matrices ? VHDDim(in_dims, k) : VHDDim(in_dims, n));
   s->set_dims(SDDim(in_dims, k));
@@ -6068,27 +6065,25 @@ void UnfoldInferMeta(const MetaTensor& x,
           dilations[0],
           dilations[1]));
 
-  std::vector<int> out_dims;
+  std::vector<int64_t> out_dims;
   out_dims.push_back(in_dims[0]);  // NOLINT
-  int output_channels =
-      in_dims[1] < 0
-          ? -1
-          : static_cast<int>(in_dims[1] * kernel_sizes[0] * kernel_sizes[1]);
+  int64_t output_channels =
+      in_dims[1] < 0 ? -1 : in_dims[1] * kernel_sizes[0] * kernel_sizes[1];
   out_dims.push_back(output_channels);
 
-  int output_height = phi::funcs::CalcOutputSize(static_cast<int>(in_dims[2]),
-                                                 kernel_sizes[0],
-                                                 dilations[0],
-                                                 paddings[0],
-                                                 paddings[2],
-                                                 strides[0]);
-  int output_width = phi::funcs::CalcOutputSize(static_cast<int>(in_dims[3]),
-                                                kernel_sizes[1],
-                                                dilations[1],
-                                                paddings[1],
-                                                paddings[3],
-                                                strides[1]);
-  int output_col_length = output_height * output_width;
+  int64_t output_height = phi::funcs::CalcOutputSize(in_dims[2],
+                                                     kernel_sizes[0],
+                                                     dilations[0],
+                                                     paddings[0],
+                                                     paddings[2],
+                                                     strides[0]);
+  int64_t output_width = phi::funcs::CalcOutputSize(in_dims[3],
+                                                    kernel_sizes[1],
+                                                    dilations[1],
+                                                    paddings[1],
+                                                    paddings[3],
+                                                    strides[1]);
+  int64_t output_col_length = output_height * output_width;
   if (config.is_runtime) {
     // only check output height and width in runtime
     PADDLE_ENFORCE_GT(

--- a/paddle/phi/kernels/funcs/unfold_functor.h
+++ b/paddle/phi/kernels/funcs/unfold_functor.h
@@ -18,11 +18,15 @@ namespace phi {
 namespace funcs {
 
 //////// CalcOutputSize Functor ///////
-template <typename T = int>
-inline T CalcOutputSize(
-    T input_size, T filter_size, T dilation, T padding1, T padding2, T stride) {
-  const T dkernel = dilation * (filter_size - 1) + 1;
-  T output_size = (input_size + padding1 + padding2 - dkernel) / stride + 1;
+inline int64_t CalcOutputSize(int64_t input_size,
+                              int64_t filter_size,
+                              int64_t dilation,
+                              int64_t padding1,
+                              int64_t padding2,
+                              int64_t stride) {
+  const int64_t dkernel = dilation * (filter_size - 1) + 1;
+  int64_t output_size =
+      (input_size + padding1 + padding2 - dkernel) / stride + 1;
   return input_size == -1 ? -1 : output_size;
 }
 

--- a/paddle/phi/kernels/impl/unfold_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/unfold_grad_kernel_impl.h
@@ -40,18 +40,18 @@ void UnfoldGradKernel(const Context& dev_ctx,
   const auto& x_dims = x_grad->dims();
   const int batch_size = static_cast<int>(x_dims[0]);
 
-  int out_height = phi::funcs::CalcOutputSize(static_cast<int>(x_dims[2]),
-                                              kernel_sizes[0],
-                                              dilations[0],
-                                              paddings[0],
-                                              paddings[2],
-                                              strides[0]);
-  int out_width = phi::funcs::CalcOutputSize(static_cast<int>(x_dims[3]),
-                                             kernel_sizes[1],
-                                             dilations[1],
-                                             paddings[1],
-                                             paddings[3],
-                                             strides[1]);
+  int64_t out_height = phi::funcs::CalcOutputSize(x_dims[2],
+                                                  kernel_sizes[0],
+                                                  dilations[0],
+                                                  paddings[0],
+                                                  paddings[2],
+                                                  strides[0]);
+  int64_t out_width = phi::funcs::CalcOutputSize(x_dims[3],
+                                                 kernel_sizes[1],
+                                                 dilations[1],
+                                                 paddings[1],
+                                                 paddings[3],
+                                                 strides[1]);
 
   DDim x_shape = common::make_ddim({x_dims[1], x_dims[2], x_dims[3]});
   DDim out_matrix_shape = common::make_ddim(

--- a/paddle/phi/kernels/impl/unfold_kernel_impl.h
+++ b/paddle/phi/kernels/impl/unfold_kernel_impl.h
@@ -40,18 +40,18 @@ void UnfoldKernel(const Context& dev_ctx,
   phi::funcs::Im2ColFunctor<phi::funcs::ColFormat::kCFO, Context, T> im2col;
   const auto& x_dims = x.dims();
 
-  int out_height = phi::funcs::CalcOutputSize(static_cast<int>(x_dims[2]),
-                                              kernel_sizes[0],
-                                              dilations[0],
-                                              paddings[0],
-                                              paddings[2],
-                                              strides[0]);
-  int out_width = phi::funcs::CalcOutputSize(static_cast<int>(x_dims[3]),
-                                             kernel_sizes[1],
-                                             dilations[1],
-                                             paddings[1],
-                                             paddings[3],
-                                             strides[1]);
+  int64_t out_height = phi::funcs::CalcOutputSize(x_dims[2],
+                                                  kernel_sizes[0],
+                                                  dilations[0],
+                                                  paddings[0],
+                                                  paddings[2],
+                                                  strides[0]);
+  int64_t out_width = phi::funcs::CalcOutputSize(x_dims[3],
+                                                 kernel_sizes[1],
+                                                 dilations[1],
+                                                 paddings[1],
+                                                 paddings[3],
+                                                 strides[1]);
 
   DDim x_shape = common::make_ddim({x_dims[1], x_dims[2], x_dims[3]});
   DDim out_matrix_shape = common::make_ddim(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

InferMeta中不该用int32的修改。 cp devPR:https://github.com/PaddlePaddle/Paddle/pull/76295

pcard-93269