### PR TITLE
[CINN] Avoid to produce `Sub` node when simplify expr

### DIFF
--- a/paddle/cinn/optim/simplify_util.cc
+++ b/paddle/cinn/optim/simplify_util.cc
@@ -298,7 +298,9 @@ ir::IndexExpr ConstructIndexExprByNodeType(const ir::IrNodeTy &ty,
     case ir::IrNodeTy::Add:
       return simplify_flag ? lhs + rhs : ir::Add::Make(lhs, rhs);
     case ir::IrNodeTy::Sub:
-      return simplify_flag ? lhs - rhs : ir::Sub::Make(lhs, rhs);
+      return simplify_flag
+                 ? lhs - rhs
+                 : ir::Add::Make(lhs, ir::Mul::Make(rhs, ir::IndexExpr(-1)));
     case ir::IrNodeTy::Mul:
       return simplify_flag ? lhs * rhs : ir::Mul::Make(lhs, rhs);
     case ir::IrNodeTy::Div:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

`ConstructIndexExprByNodeType` 里将对 `Sub` 的处理修改为生成 `ir::Add::Make(lhs, ir::Mul::Make(rhs, ir::IndexExpr(-1))`，避免后续遇到 `ir::Sub`

<!-- PCard-66972 -->