### PR TITLE
[Cherry-pick Fleety_12] [CodeStyle] Integrate `ast-grep` to `pre-commit` hooks (#76313)

### DIFF
--- a/.github/workflows/Codestyle-Check.yml
+++ b/.github/workflows/Codestyle-Check.yml
@@ -49,6 +49,12 @@ jobs:
         if: steps.check-bypass.outputs.can-skip != 'true'
         run: |
           pip install pre-commit==2.17.0 cpplint==1.6.0  clang-format==13.0.0
+          pip install ast-grep-cli==0.39.9 # This version should be consistent with the one in .pre-commit-config.yaml
+
+      - name: Run ast-grep unit tests
+        if: steps.check-bypass.outputs.can-skip != 'true'
+        run: |
+          ast-grep test
 
       - name: Check pre-commit
         if: steps.check-bypass.outputs.can-skip != 'true'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,10 @@ repos:
           (?x)^(
             test/dygraph_to_static/test_error.py
           )$
+  - repo: https://github.com/PFCCLab/ast-grep-pre-commit-mirror
+    rev: v0.39.9
+    hooks:
+      - id: ast-grep
   - repo: local
     hooks:
       - id: copyright_checker
@@ -158,7 +162,10 @@ repos:
           (?x)^(
             \.github/.+\.(yaml|yml)|
             \.pre-commit-config\.yaml|
-            \.yamlfmt
+            \.yamlfmt|
+            sgconfig\.yml|
+            ci/rules/.+\.yml|
+            ci/rule-tests/.+\.yml
           )
   # Others
   - repo: local

--- a/ci/check_approval.sh
+++ b/ci/check_approval.sh
@@ -330,19 +330,6 @@ if [ "${EMPTY_GRAD_OP_REGISTERED}" != "" ] && [ "${GIT_PT_ID}" != "" ]; then
     check_approval 1 phlrain XiaoguangHu01 kolinwei JiabinYang
 fi
 
-INVALID_UNITTEST_ASSERT_CHECK=`echo "$ALL_ADDED_LINES" | grep -zoE '\+\s+((assert\s+)|(self\.assert(True|Equal)\())(\s*\+\s*)?(np|numpy)\.(allclose|array_equal)[^+]*' || true`
-if [ "${INVALID_UNITTEST_ASSERT_CHECK}" != "" ] && [ "${PR_ID}" != "" ]; then
-    echo_line="It is recommended to use 'np.testing.assert_allclose' and 'np.testing.assert_array_equal' instead of 'self.assertTrue(np.allclose(...))' and 'self.assertTrue(np.array_equal(...))'.\nPlease modify the code below. If anything is unclear, please read the specification [ https://github.com/PaddlePaddle/community/blob/master/rfcs/CodeStyle/20220805_code_style_improvement_for_unittest.md#background ]. If it is a mismatch, please request SigureMo (Recommend) or zrr1999 or luotao1 review and approve.\nThe code that do not meet the specification are as follows:\n${INVALID_UNITTEST_ASSERT_CHECK}\n"
-    check_approval 1 SigureMo zrr1999 luotao1
-fi
-
-TEST_FILE_ADDED_LINES=$(git diff -U0 upstream/$BRANCH -- test |grep "^+")
-ENABLE_TO_STATIC_CHECK=`echo "$TEST_FILE_ADDED_LINES" | grep "enable_to_static(" || true`
-if [ "${ENABLE_TO_STATIC_CHECK}" != "" ] && [ "${PR_ID}" != "" ]; then
-    echo_line="You must have one RD (SigureMo, DrRyanHuang, zrr1999 or gouzil) approval for using 'paddle.jit.enable_to_static', we recommend using 'enable_to_static_guard' in the related test files.\n"
-    check_approval 1 SigureMo DrRyanHuang zrr1999 gouzil
-fi
-
 HAS_MODIFIED_DY2ST_TEST_FILES=$(git diff --name-only --diff-filter=ACMR upstream/$BRANCH | grep "test/dygraph_to_static/test_" || true)
 if [ "${HAS_MODIFIED_DY2ST_TEST_FILES}" != "" ] && [ "${PR_ID}" != "" ]; then
     error_lines=`python ${PADDLE_ROOT}/test/dygraph_to_static/check_approval.py ${HAS_MODIFIED_DY2ST_TEST_FILES}`

--- a/ci/rule-tests/__snapshots__/no-assert-with-numpy-testing-snapshot.yml
+++ b/ci/rule-tests/__snapshots__/no-assert-with-numpy-testing-snapshot.yml
@@ -1,0 +1,62 @@
+id: no-assert-with-numpy-testing
+snapshots:
+  assert np.allclose(a, b, rtol=1e-5):
+    labels:
+      - source: assert np.allclose(a, b, rtol=1e-5)
+        style: primary
+        start: 0
+        end: 35
+  assert np.array_equal(a, b, err_msg="Arrays are not equal"):
+    labels:
+      - source: assert np.array_equal(a, b, err_msg="Arrays are not equal")
+        style: primary
+        start: 0
+        end: 59
+  self.assertEqual(np.allclose(a, b), something):
+    labels:
+      - source: self.assertEqual(np.allclose(a, b), something)
+        style: primary
+        start: 0
+        end: 46
+  self.assertEqual(np.array_equal(a, b), True):
+    labels:
+      - source: self.assertEqual(np.array_equal(a, b), True)
+        style: primary
+        start: 0
+        end: 44
+  self.assertEqual(np.array_equal(a, b), True, err_msg="Arrays are not equal"):
+    labels:
+      - source: self.assertEqual(np.array_equal(a, b), True, err_msg="Arrays are not equal")
+        style: primary
+        start: 0
+        end: 76
+  self.assertEqual(something, np.allclose(a, b)):
+    labels:
+      - source: self.assertEqual(something, np.allclose(a, b))
+        style: primary
+        start: 0
+        end: 46
+  self.assertTrue(np.allclose(a, b)):
+    labels:
+      - source: self.assertTrue(np.allclose(a, b))
+        style: primary
+        start: 0
+        end: 34
+  self.assertTrue(np.allclose(a, b, rtol=1e-5, atol=1e-8)):
+    labels:
+      - source: self.assertTrue(np.allclose(a, b, rtol=1e-5, atol=1e-8))
+        style: primary
+        start: 0
+        end: 56
+  self.assertTrue(np.array_equal(a, b)):
+    labels:
+      - source: self.assertTrue(np.array_equal(a, b))
+        style: primary
+        start: 0
+        end: 37
+  self.assertTrue(np.array_equal(a, b), "Arrays are not equal"):
+    labels:
+      - source: self.assertTrue(np.array_equal(a, b), "Arrays are not equal")
+        style: primary
+        start: 0
+        end: 61

--- a/ci/rule-tests/__snapshots__/no-enable-to-static-snapshot.yml
+++ b/ci/rule-tests/__snapshots__/no-enable-to-static-snapshot.yml
@@ -1,0 +1,20 @@
+id: no-enable-to-static
+snapshots:
+  enable_to_static(True):
+    labels:
+      - source: enable_to_static(True)
+        style: primary
+        start: 0
+        end: 22
+  jit.enable_to_static(False):
+    labels:
+      - source: jit.enable_to_static(False)
+        style: primary
+        start: 0
+        end: 27
+  paddle.jit.enable_to_static(True):
+    labels:
+      - source: paddle.jit.enable_to_static(True)
+        style: primary
+        start: 0
+        end: 33

--- a/ci/rule-tests/no-assert-with-numpy-testing-test.yml
+++ b/ci/rule-tests/no-assert-with-numpy-testing-test.yml
@@ -1,0 +1,20 @@
+id: no-assert-with-numpy-testing
+valid:
+  - np.testing.assert_allclose(a, b)
+  - np.testing.assert_array_equal(a, b)
+  - np.testing.assert_allclose(a, b, rtol=1e-5, atol=1e-8)
+  - np.testing.assert_array_equal(a, b, err_msg="Arrays are not equal")
+  - assert paddle.allclose(a, b, rtol=1e-5)
+  - assert torch.array_equal(a, b)
+  - self.assertTrue(numpy)
+invalid:
+  - self.assertTrue(np.allclose(a, b))
+  - self.assertTrue(np.allclose(a, b, rtol=1e-5, atol=1e-8))
+  - self.assertTrue(np.array_equal(a, b))
+  - self.assertTrue(np.array_equal(a, b), "Arrays are not equal")
+  - self.assertEqual(something, np.allclose(a, b))
+  - self.assertEqual(np.allclose(a, b), something)
+  - self.assertEqual(np.array_equal(a, b), True)
+  - self.assertEqual(np.array_equal(a, b), True, err_msg="Arrays are not equal")
+  - assert np.allclose(a, b, rtol=1e-5)
+  - assert np.array_equal(a, b, err_msg="Arrays are not equal")

--- a/ci/rule-tests/no-enable-to-static-test.yml
+++ b/ci/rule-tests/no-enable-to-static-test.yml
@@ -1,0 +1,10 @@
+id: no-enable-to-static
+valid:
+  - |
+    with enable_to_static_guard(True):
+        # test code here
+  - enable_to_static_guard(False)
+invalid:
+  - paddle.jit.enable_to_static(True)
+  - jit.enable_to_static(False)
+  - enable_to_static(True)

--- a/ci/rules/no-assert-with-numpy-testing.yml
+++ b/ci/rules/no-assert-with-numpy-testing.yml
@@ -1,0 +1,23 @@
+id: no-assert-with-numpy-testing
+language: python
+severity: error
+message: |
+  It is recommended to use 'np.testing.assert_allclose' and 'np.testing.assert_array_equal'
+  instead of 'self.assertTrue(np.allclose(...))' and 'self.assertTrue(np.array_equal(...))'.
+  Please read the specification: https://github.com/PaddlePaddle/community/blob/master/rfcs/CodeStyle/20220805_code_style_improvement_for_unittest.md#background
+  If it is a false positive, please contact SigureMo (Recommend) or zrr1999 for more information.
+note: Use np.testing methods for more informative assertion messages
+files:
+  - test/**
+
+rule:
+  any:
+    - pattern: self.assertTrue($NP.$CHECK_EQ($$$ARGS) $$$_)
+    - pattern: self.assertEqual($ARG1, $NP.$CHECK_EQ($$$ARGS) $$$_)
+    - pattern: self.assertEqual($NP.$CHECK_EQ($$$ARGS), $ARG2 $$$_)
+    - pattern: assert $NP.$CHECK_EQ($$$ARGS)
+constraints:
+  NP:
+    regex: (np|numpy)
+  CHECK_EQ:
+    regex: (allclose|array_equal)

--- a/ci/rules/no-enable-to-static.yml
+++ b/ci/rules/no-enable-to-static.yml
@@ -1,0 +1,18 @@
+id: no-enable-to-static
+language: python
+severity: error
+message: |
+  Use `paddle.jit.enable_to_static` will caused some test run in dygraph mode. Recommended
+  to use `enable_to_static_guard` to avoid this problem.
+  If it is a false positive, please contact SigureMo (Recommend), DrRyanHuang or zrr1999 for more information.
+note: Use `enable_to_static_guard` to replace `paddle.jit.enable_to_static` in test files
+files:
+  - test/**
+
+rule:
+  any:
+    - pattern: $$$PREFIX.enable_to_static($$$ARGS)
+    - pattern: enable_to_static($$$ARGS)
+constraints:
+  PREFIX:
+    regex: (paddle\.jit|jit)

--- a/sgconfig.yml
+++ b/sgconfig.yml
@@ -1,0 +1,4 @@
+ruleDirs:
+  - ci/rules
+testConfigs:
+  - testDir: ci/rule-tests

--- a/test/legacy_test/test_full_like_op.py
+++ b/test/legacy_test/test_full_like_op.py
@@ -263,7 +263,7 @@ class TestFullKernelZeroSize(unittest.TestCase):
         shape = [0, 3]
         tensor = paddle.full(shape, value, dtype=dtype)
         expected = np.full(shape, value, dtype=dtype)
-        self.assertTrue(np.array_equal(tensor.numpy(), expected))
+        np.testing.assert_array_equal(tensor.numpy(), expected)
         paddle.enable_static()
 
     @unittest.skipIf(
@@ -277,7 +277,7 @@ class TestFullKernelZeroSize(unittest.TestCase):
         shape = [0, 3]
         tensor = paddle.full(shape, value, dtype=dtype)
         expected = np.full(shape, value, dtype=dtype)
-        self.assertTrue(np.array_equal(tensor.numpy(), expected))
+        np.testing.assert_array_equal(tensor.numpy(), expected)
         paddle.enable_static()
 
 
@@ -288,7 +288,7 @@ class TestFullLikeKernelZeroSize(unittest.TestCase):
         value = 10.0
         result = paddle.full_like(base_tensor, value, dtype="float32")
         expected = np.full_like(base_tensor.numpy(), value)
-        self.assertTrue(np.array_equal(result.numpy(), expected))
+        np.testing.assert_array_equal(result.numpy(), expected)
         paddle.enable_static()
 
     @unittest.skipIf(
@@ -302,7 +302,7 @@ class TestFullLikeKernelZeroSize(unittest.TestCase):
         value = 20.0
         result = paddle.full_like(base_tensor, value, dtype="float32")
         expected = np.full_like(base_tensor.numpy(), value)
-        self.assertTrue(np.array_equal(result.numpy(), expected))
+        np.testing.assert_array_equal(result.numpy(), expected)
         paddle.enable_static()
 
 

--- a/test/legacy_test/test_number_count_op.py
+++ b/test/legacy_test/test_number_count_op.py
@@ -69,8 +69,8 @@ class TestNumberCountAPI(unittest.TestCase):
             x = paddle.static.data('x', self.x.shape, dtype="int64")
             out = utils._number_count(x, self.upper_num)
             exe = paddle.static.Executor(self.place)
-            res = exe.run(feed={'x': self.x}, fetch_list=[out])
-            assert np.allclose(res, self.out)
+            (res,) = exe.run(feed={'x': self.x}, fetch_list=[out])
+            np.testing.assert_allclose(res, self.out)
 
     def test_api_dygraph(self):
         paddle.disable_static()

--- a/test/xpu/test_masked_select_op_xpu.py
+++ b/test/xpu/test_masked_select_op_xpu.py
@@ -110,12 +110,12 @@ class TestMaskedSelectAPI(unittest.TestCase):
 
         exe = paddle.static.Executor(place=paddle.XPUPlace(0))
 
-        res = exe.run(
+        (res,) = exe.run(
             paddle.static.default_main_program(),
             feed={"x": np_x, "mask": np_mask},
             fetch_list=[out],
         )
-        self.assertEqual(np.allclose(res, np_out), True)
+        np.testing.assert_allclose(res, np_out)
 
     def test_simulator_skip_run_mode(self):
         os.environ['XPUSIM_SKIP_RUN'] = '1'


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
devPR:https://github.com/PaddlePaddle/Paddle/pull/76313

> 添加 ast-grep 到 pre-commit hook 中，以实现通过 AST 匹配的方式达到更高的检测准确度
在 ast-grep 添加的 rule 只应当是不会有误检的 case，避免开发者遇到无法 commit 的问题，如果有误检的情况，则不可以加到相关 rules 里，仍然需要在 `ci/check_approval.sh` 里添加，这样可以通过 CI approval 机制达到局部豁免效果，当然后续可以考虑在 check approval 里使用 ast-grep 替代 grep

