### PR TITLE
[API Compatibility No.6] Sink bitwise_xor_ to cpp -part

### DIFF
--- a/paddle/phi/ops/yaml/python_api_info.yaml
+++ b/paddle/phi/ops/yaml/python_api_info.yaml
@@ -119,6 +119,11 @@
   args_alias :
     use_default_mapping : True
 
+- op : bitwise_xor_
+  name : [paddle.bitwise_xor_, paddle.Tensor.bitwise_xor_]
+  args_alias :
+    use_default_mapping : True
+
 - op : ceil
   name : [paddle.ceil, paddle.Tensor.ceil]
   args_alias :

--- a/python/paddle/_paddle_docs.py
+++ b/python/paddle/_paddle_docs.py
@@ -4237,6 +4237,41 @@ def bitwise_xor(
 )
 
 add_doc_and_signature(
+    "bitwise_xor_",
+    r"""
+    Inplace version of ``bitwise_xor`` API, the output Tensor will be inplaced with input ``x``.
+    Please refer to :ref:`api_paddle_bitwise_xor`.
+
+    Args:
+        x (Tensor): Input Tensor of ``bitwise_xor_``. It is a N-D Tensor of bool, uint8, int8, int16, int32, int64.
+        y (Tensor): Input Tensor of ``bitwise_xor_``. It is a N-D Tensor of bool, uint8, int8, int16, int32, int64.
+        name (str|None, optional): The default value is None. Normally there is no need for
+            user to set this property. For more information, please refer to :ref:`api_guide_Name`.
+
+    Returns:
+        Tensor: Result of ``bitwise_xor_``. It is the same Tensor as input ``x``.
+
+    Examples:
+        .. code-block:: python
+
+            >>> import paddle
+            >>> x = paddle.to_tensor([-5, -1, 1])
+            >>> y = paddle.to_tensor([4,  2, -3])
+            >>> x.bitwise_xor_(y)
+            >>> print(x)
+            Tensor(shape=[3], dtype=int64, place=Place(cpu), stop_gradient=True,
+            [-1, -3, -4])
+""",
+    """
+def bitwise_xor_(
+    x: Tensor,
+    y: Tensor,
+    name: str | None = None,
+) -> Tensor
+""",
+)
+
+add_doc_and_signature(
     "conj",
     r"""
     This function computes the conjugate of the Tensor elementwisely.

--- a/python/paddle/tensor/logic.py
+++ b/python/paddle/tensor/logic.py
@@ -25,6 +25,7 @@ from paddle._C_ops import (  # noqa: F401
     bitwise_and,
     bitwise_not,
     bitwise_xor,
+    bitwise_xor_,
     greater_than,
     isclose,
     logical_and,
@@ -1072,21 +1073,6 @@ def __rxor__(
         raise TypeError(
             f"unsupported operand type(s) for |: '{type(y).__name__}' and 'Tensor'"
         )
-
-
-@inplace_apis_in_dygraph_only
-def bitwise_xor_(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
-    r"""
-    Inplace version of ``bitwise_xor`` API, the output Tensor will be inplaced with input ``x``.
-    Please refer to :ref:`api_paddle_bitwise_xor`.
-    """
-    out_shape = broadcast_shape(x.shape, y.shape)
-    if out_shape != x.shape:
-        raise ValueError(
-            f"The shape of broadcast output {out_shape} is different from that of inplace tensor {x.shape} in the Inplace operation."
-        )
-    if in_dynamic_mode():
-        return _C_ops.bitwise_xor_(x, y)
 
 
 @inplace_apis_in_dygraph_only

--- a/test/legacy_test/test_api_compatibility.py
+++ b/test/legacy_test/test_api_compatibility.py
@@ -1193,5 +1193,64 @@ class TestBitwiseXorAPI_Compatibility(unittest.TestCase):
                 np.testing.assert_array_equal(out, ref_out)
 
 
+# Test bitwise_xor_ (inplace) compatibility
+class TestBitwiseXorInplaceAPI_Compatibility(unittest.TestCase):
+    def setUp(self):
+        np.random.seed(123)
+        paddle.enable_static()
+        self.shape = [5, 6]
+        self.dtype = 'int32'
+        self.init_data()
+
+    def init_data(self):
+        self.np_x = np.random.randint(0, 8, self.shape).astype(self.dtype)
+        self.np_y = np.random.randint(0, 8, self.shape).astype(self.dtype)
+
+    def test_dygraph_Compatibility(self):
+        paddle.disable_static()
+
+        # Position args (args)
+        x1 = paddle.to_tensor(self.np_x.copy())
+        y1 = paddle.to_tensor(self.np_y)
+        out1 = paddle.bitwise_xor_(x1, y1)
+
+        # Paddle keyword args (kwargs)
+        x2 = paddle.to_tensor(self.np_x.copy())
+        y2 = paddle.to_tensor(self.np_y)
+        out2 = paddle.bitwise_xor_(x=x2, y=y2)
+
+        # Torch keyword args
+        x3 = paddle.to_tensor(self.np_x.copy())
+        y3 = paddle.to_tensor(self.np_y)
+        out3 = paddle.bitwise_xor_(input=x3, other=y3)
+
+        # Tensor method - args
+        x4 = paddle.to_tensor(self.np_x.copy())
+        y4 = paddle.to_tensor(self.np_y)
+        out4 = x4.bitwise_xor_(y4)
+
+        # Tensor method - kwargs
+        x5 = paddle.to_tensor(self.np_x.copy())
+        y5 = paddle.to_tensor(self.np_y)
+        out5 = x5.bitwise_xor_(y=y5)
+
+        # Numpy reference output
+        ref_out = np.bitwise_xor(self.np_x, self.np_y)
+
+        # Verify all outputs
+        paddle_dygraph_out = [out1, out2, out3, out4, out5]
+        for out in paddle_dygraph_out:
+            np.testing.assert_array_equal(ref_out, out.numpy())
+
+        # Verify inplace modification
+        np.testing.assert_array_equal(ref_out, x1.numpy())
+        np.testing.assert_array_equal(ref_out, x2.numpy())
+        np.testing.assert_array_equal(ref_out, x3.numpy())
+        np.testing.assert_array_equal(ref_out, x4.numpy())
+        np.testing.assert_array_equal(ref_out, x5.numpy())
+
+        paddle.enable_static()
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### PR Category
User Experience

### PR Types
New Features

### Description
[任务](https://github.com/PaddlePaddle/Paddle/issues/76301#issue-3599435252)：No. 6 bitwise_xor_ , No.42 bitwise_xor

### 修改内容
1. 下沉 bitwise_xor_ 到 cpp
2. 支持参数别名:
   - `input` 作为 `x` 的别名
   - `other` 作为 `y` 的别名
3. 在 `test/legacy_test/test_inplace.py` 中添加参数别名测试用例
