### PR TITLE
[CINN] Add castOp before addOp by `AddCastToElementwiseAddPass`

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/add_cast_to_elementwise_add_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/add_cast_to_elementwise_add_pass.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/paddle/cinn/hlir/dialect/operator/transforms/add_cast_to_elementwise_add_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/add_cast_to_elementwise_add_pass.cc
@@ -1,0 +1,128 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/cinn/hlir/dialect/operator/transforms/add_cast_to_elementwise_add_pass.h"
+#include "paddle/cinn/hlir/dialect/operator/ir/cinn_op.h"
+#include "paddle/cinn/hlir/dialect/operator/ir/manual_op.h"
+#include "paddle/cinn/hlir/framework/pir/utils.h"
+#include "paddle/fluid/pir/dialect/operator/ir/op_type.h"
+#include "paddle/fluid/pir/dialect/operator/ir/pd_op.h"
+#include "paddle/pir/include/pass/pass.h"
+#include "paddle/pir/include/pattern_rewrite/frozen_rewrite_pattern_set.h"
+#include "paddle/pir/include/pattern_rewrite/pattern_applicator.h"
+#include "paddle/pir/include/pattern_rewrite/pattern_match.h"
+
+namespace cinn {
+namespace dialect {
+namespace ir {
+
+pir::Type GetOutputDtype(const pir::Type& x, const pir::Type& y) {
+  pir::IrContext* context = pir::IrContext::Instance();
+  // type promotion
+  if (x.isa<pir::Complex128Type>() || y.isa<pir::Complex128Type>()) {
+    return pir::Complex128Type::get(context);
+  }
+  if (x.isa<pir::Complex64Type>() || y.isa<pir::Complex64Type>()) {
+    return pir::Complex64Type::get(context);
+  }
+
+  if (x.isa<pir::IndexType>() || y.isa<pir::IndexType>() ||
+      x.isa<pir::Int64Type>() || y.isa<pir::Int64Type>() ||
+      x.isa<pir::Int32Type>() || y.isa<pir::Int32Type>() ||
+      x.isa<pir::Int16Type>() || y.isa<pir::Int16Type>() ||
+      x.isa<pir::Int8Type>() || y.isa<pir::Int8Type>() ||
+      x.isa<pir::UInt8Type>() || y.isa<pir::UInt8Type>() ||
+      x.isa<pir::BoolType>() || y.isa<pir::BoolType>()) {
+    PADDLE_THROW(::common::errors::InvalidType(
+        "Type promotion only support calculations between floating-point "
+        "numbers and between complex and real numbers. But got different "
+        "data type x: %s, y: %s.",
+        ::paddle::dialect::TransToPhiDataType(x),
+        ::paddle::dialect::TransToPhiDataType(y)));
+  }
+
+  if (x.isa<pir::Float64Type>() || y.isa<pir::Float64Type>()) {
+    return pir::Float64Type::get(context);
+  }
+  return pir::Float32Type::get(context);
+}
+
+template <typename OPTYPE>
+class AddCastToElementwiseAddPattern : public pir::OpRewritePattern<OPTYPE> {
+ public:
+  using pir::OpRewritePattern<OPTYPE>::OpRewritePattern;
+
+  bool MatchAndRewrite(OPTYPE op,
+                       pir::PatternRewriter& rewriter) const override {
+    const pir::Type& x_dtype = op->operand_source(0)
+                                   .type()
+                                   .template dyn_cast<pir::DenseTensorType>()
+                                   .dtype();
+    const pir::Type& y_dtype = op->operand_source(1)
+                                   .type()
+                                   .template dyn_cast<pir::DenseTensorType>()
+                                   .dtype();
+
+    if (x_dtype != y_dtype) {
+      pir::Type output_dtype = GetOutputDtype(x_dtype, y_dtype);
+
+      auto cast_op0 = rewriter.Build<paddle::dialect::CastOp>(
+          op->operand_source(0),
+          ::paddle::dialect::TransToPhiDataType(output_dtype));
+
+      auto cast_op1 = rewriter.Build<paddle::dialect::CastOp>(
+          op->operand_source(1),
+          ::paddle::dialect::TransToPhiDataType(output_dtype));
+
+      op->operand(0).set_source(cast_op0->result(0));
+      op->operand(1).set_source(cast_op1->result(0));
+
+      return true;
+    }
+    return false;
+  }
+};
+
+class AddCastToElementwiseAddPass : public pir::PatternRewritePass {
+ public:
+  AddCastToElementwiseAddPass()
+      : pir::PatternRewritePass("add_cast_to_elementwise_add_pass", 1) {}
+
+  pir::RewritePatternSet InitializePatterns(pir::IrContext* context) override {
+    pir::RewritePatternSet ps(context);
+    ps.Add<AddCastToElementwiseAddPattern<paddle::dialect::AddOp>>(context);
+    return ps;
+  }
+
+  bool CanApplyOn(pir::Operation* op) const override {
+    return op->num_regions() > 0 && op->isa<cinn::dialect::GroupOp>();
+  }
+};
+
+// NOTE: This is a temporary type promotion pass in the CINN frontend.
+// It is necessary because the `NeedTypePromotion` function in
+// `paddle/phi/common/type_promotion.h` explicitly disables automatic promotion
+// for fp16 and bf16 data types. This pass ensures type promotion for 'add'
+// operations with mixed-type operands, which the `NeedTypePromotion` function
+// blocks.
+//
+// This pass becomes obsolete and should be removed once the restriction on
+// fp16/bf16 promotion is lifted from the common type promotion logic.
+std::unique_ptr<pir::Pass> CreateAddCastToElementwiseAddPass() {
+  return std::make_unique<AddCastToElementwiseAddPass>();
+}
+
+}  // namespace ir
+}  // namespace dialect
+}  // namespace cinn

--- a/paddle/cinn/hlir/dialect/operator/transforms/add_cast_to_elementwise_add_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/add_cast_to_elementwise_add_pass.cc
@@ -27,6 +27,13 @@ namespace cinn {
 namespace dialect {
 namespace ir {
 
+auto is_integer_or_bool = [](const pir::Type& x) {
+  return x.isa<pir::IndexType>() || x.isa<pir::Int64Type>() ||
+         x.isa<pir::Int32Type>() || x.isa<pir::Int16Type>() ||
+         x.isa<pir::Int8Type>() || x.isa<pir::UInt8Type>() ||
+         x.isa<pir::BoolType>();
+};
+
 pir::Type GetOutputDtype(const pir::Type& x, const pir::Type& y) {
   pir::IrContext* context = pir::IrContext::Instance();
   // type promotion
@@ -37,13 +44,7 @@ pir::Type GetOutputDtype(const pir::Type& x, const pir::Type& y) {
     return pir::Complex64Type::get(context);
   }
 
-  if (x.isa<pir::IndexType>() || y.isa<pir::IndexType>() ||
-      x.isa<pir::Int64Type>() || y.isa<pir::Int64Type>() ||
-      x.isa<pir::Int32Type>() || y.isa<pir::Int32Type>() ||
-      x.isa<pir::Int16Type>() || y.isa<pir::Int16Type>() ||
-      x.isa<pir::Int8Type>() || y.isa<pir::Int8Type>() ||
-      x.isa<pir::UInt8Type>() || y.isa<pir::UInt8Type>() ||
-      x.isa<pir::BoolType>() || y.isa<pir::BoolType>()) {
+  if (is_integer_or_bool(x) || is_integer_or_bool(y)) {
     PADDLE_THROW(::common::errors::InvalidType(
         "Type promotion only support calculations between floating-point "
         "numbers and between complex and real numbers. But got different "

--- a/paddle/cinn/hlir/dialect/operator/transforms/add_cast_to_elementwise_add_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/add_cast_to_elementwise_add_pass.cc
@@ -27,13 +27,6 @@ namespace cinn {
 namespace dialect {
 namespace ir {
 
-auto is_integer_or_bool = [](const pir::Type& x) {
-  return x.isa<pir::IndexType>() || x.isa<pir::Int64Type>() ||
-         x.isa<pir::Int32Type>() || x.isa<pir::Int16Type>() ||
-         x.isa<pir::Int8Type>() || x.isa<pir::UInt8Type>() ||
-         x.isa<pir::BoolType>();
-};
-
 pir::Type GetOutputDtype(const pir::Type& x, const pir::Type& y) {
   pir::IrContext* context = pir::IrContext::Instance();
   // type promotion
@@ -43,6 +36,13 @@ pir::Type GetOutputDtype(const pir::Type& x, const pir::Type& y) {
   if (x.isa<pir::Complex64Type>() || y.isa<pir::Complex64Type>()) {
     return pir::Complex64Type::get(context);
   }
+
+  auto is_integer_or_bool = [](const pir::Type& x) {
+    return x.isa<pir::IndexType>() || x.isa<pir::Int64Type>() ||
+           x.isa<pir::Int32Type>() || x.isa<pir::Int16Type>() ||
+           x.isa<pir::Int8Type>() || x.isa<pir::UInt8Type>() ||
+           x.isa<pir::BoolType>();
+  };
 
   if (is_integer_or_bool(x) || is_integer_or_bool(y)) {
     PADDLE_THROW(::common::errors::InvalidType(

--- a/paddle/cinn/hlir/dialect/operator/transforms/add_cast_to_elementwise_add_pass.h
+++ b/paddle/cinn/hlir/dialect/operator/transforms/add_cast_to_elementwise_add_pass.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/paddle/cinn/hlir/dialect/operator/transforms/add_cast_to_elementwise_add_pass.h
+++ b/paddle/cinn/hlir/dialect/operator/transforms/add_cast_to_elementwise_add_pass.h
@@ -1,0 +1,29 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include "paddle/pir/include/pass/pass.h"
+#include "paddle/pir/include/pass/pass_registry.h"
+
+namespace cinn {
+namespace dialect {
+namespace ir {
+
+std::unique_ptr<pir::Pass> CreateAddCastToElementwiseAddPass();
+
+}  // namespace ir
+}  // namespace dialect
+}  // namespace cinn

--- a/paddle/cinn/hlir/dialect/operator/transforms/add_cinn_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/add_cinn_pass.cc
@@ -34,6 +34,7 @@
 #include "paddle/cinn/hlir/dialect/operator/ir/op_dialect.h"
 #include "paddle/cinn/hlir/dialect/operator/transforms/accuracy_check_pass.h"
 #include "paddle/cinn/hlir/dialect/operator/transforms/add_broadcast_to_elementwise_pass.h"
+#include "paddle/cinn/hlir/dialect/operator/transforms/add_cast_to_elementwise_add_pass.h"
 #include "paddle/cinn/hlir/dialect/operator/transforms/cinn_group_cluster_pass.h"
 #include "paddle/cinn/hlir/dialect/operator/transforms/conv2d_transpose_filter_pass.h"
 #include "paddle/cinn/hlir/dialect/operator/transforms/convert_fa_to_qkvmha_pass.h"
@@ -198,6 +199,7 @@ void ApplyGroupOpPass(::pir::Program* program,
 
   pass_manager->AddPass(
       cinn::dialect::ir::CreateAddBroadcastToElementwisePass());
+  pass_manager->AddPass(cinn::dialect::ir::CreateAddCastToElementwiseAddPass());
   pass_manager->AddPass(cinn::dialect::ir::CreateInsertBroadcastPass());
   pass_manager->AddPass(
       cinn::dialect::ir::CreateFuseShapeOpsIntoGenerateShapeOpPass());

--- a/test/dygraph_to_static/test_cast_pass.py
+++ b/test/dygraph_to_static/test_cast_pass.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ def func(x, y):
 
 class TestAddCastToElementwiseAddPass(Dy2StTestBase):
     # test AddCastToElementwiseAddPass
-    def test_bf16(self, dtype="float16"):
+    def _run(self, dtype):
         static_fn = paddle.jit.to_static(func)
         x = paddle.randn([200, 200])
         y = paddle.randn([200, 200], dtype=dtype)
@@ -40,8 +40,11 @@ class TestAddCastToElementwiseAddPass(Dy2StTestBase):
             static_fn(x, y).numpy(), x.numpy() + y.cast("float32").numpy()
         )
 
+    def test_bf16(self):
+        self._run(dtype="bfloat16")
+
     def test_fp16(self):
-        self.test_bf16("float16")
+        self._run(dtype="float16")
 
 
 if __name__ == '__main__':

--- a/test/dygraph_to_static/test_cast_pass.py
+++ b/test/dygraph_to_static/test_cast_pass.py
@@ -14,7 +14,12 @@
 
 import unittest
 
+import numpy as np
+
 import paddle
+
+SEED = 2025
+np.random.seed(SEED)
 
 
 def func(x, y):
@@ -23,8 +28,17 @@ def func(x, y):
 
 class TestAddCastToElementwiseAddPass(unittest.TestCase):
     # test AddCastToElementwiseAddPass
-    def test():
+    def test_bf16(self, dtype="float16"):
         static_fn = paddle.jit.to_static(func, full_graph=False, backend="CINN")
         x = paddle.randn([200, 200])
-        y = paddle.randn([200, 200], dtype="bfloat16")
-        out = static_fn(x, y)
+        y = paddle.randn([200, 200], dtype=dtype)
+        np.testing.assert_allclose(
+            static_fn(x, y).numpy(), x.numpy() + y.cast("float32").numpy()
+        )
+
+    def test_fp16(self):
+        self.test_bf16("float16")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/dygraph_to_static/test_cast_pass.py
+++ b/test/dygraph_to_static/test_cast_pass.py
@@ -15,21 +15,25 @@
 import unittest
 
 import numpy as np
+from dygraph_to_static_utils import (
+    Dy2StTestBase,
+)
 
 import paddle
 
 SEED = 2025
 np.random.seed(SEED)
+paddle.seed(SEED)
 
 
 def func(x, y):
     return x + y
 
 
-class TestAddCastToElementwiseAddPass(unittest.TestCase):
+class TestAddCastToElementwiseAddPass(Dy2StTestBase):
     # test AddCastToElementwiseAddPass
     def test_bf16(self, dtype="float16"):
-        static_fn = paddle.jit.to_static(func, full_graph=False, backend="CINN")
+        static_fn = paddle.jit.to_static(func)
         x = paddle.randn([200, 200])
         y = paddle.randn([200, 200], dtype=dtype)
         np.testing.assert_allclose(

--- a/test/ir/pir/test_cast_pass.py
+++ b/test/ir/pir/test_cast_pass.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import paddle
+
+
+def func(x, y):
+    return x + y
+
+
+class TestAddCastToElementwiseAddPass(unittest.TestCase):
+    # test AddCastToElementwiseAddPass
+    def test():
+        static_fn = paddle.jit.to_static(func, full_graph=False, backend="CINN")
+        x = paddle.randn([200, 200])
+        y = paddle.randn([200, 200], dtype="bfloat16")
+        out = static_fn(x, y)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
<!-- Pcard-92901 -->

运行 GPT OSS 20B 出现：

```
----------------------
Error Message Summary:
----------------------
InvalidArgumentError: The operands' types of the node [Add] don't match. 
Received types: float32 and bfloat16
  [Hint: Expected a.type() == b.type(), but received a.type():float32 != b.type():bfloat16.] 
(at /workspace/Paddle/paddle/cinn/ir/ir.cc:138)
```

打出IR图：

```
    (%544) = "cinn_op.fusion" [id:12442] () -> tensor<-1x32xf32> {
		...
        (%548) = "pd_op.add" [id:12441] (%543, %547) {stop_gradient:[false]} : (tensor<-1x32xf32>, tensor<-1x-1xf16>) -> tensor<-1x32xf32> ......
        () = "cf.yield" [id:12443] (%548) {} : (tensor<-1x32xf32>) ->  {  }
    } { ...... }
```

是这里的 `pd_op.add` 出现了问题，本PR添加 `AddCastToElementwiseAddPass` 在 add op 之前插入 cast op，保证类型一致

--

这个 PR 给 add 的两个输入都添加了 cast ，如下：

https://github.com/PaddlePaddle/Paddle/blob/f956a3bc2e422648f89bae9d6d4adb981162efa5/paddle/cinn/hlir/dialect/operator/transforms/add_cast_to_elementwise_add_pass.cc#L78-L93

不过不必担心 `CreateAddBroadcastToElementwisePass` 是 `ApplyGroupOpPass` 中的第一个Pass 
之后其中的不必要的 cast 将会被其他 pass 消除

https://github.com/PaddlePaddle/Paddle/blob/f956a3bc2e422648f89bae9d6d4adb981162efa5/paddle/cinn/hlir/dialect/operator/transforms/add_cinn_pass.cc#L195-L201


这个 Pass 处于 CINN 前端：

![](https://raw.githubusercontent.com/PaddlePaddle/community/refs/heads/master/pfcc/paddle-code-reading/CINN/img/cinn_arch.png)
