### PR TITLE
[Compat] Remove device parameter from Event class and update documentation

### DIFF
--- a/python/paddle/device/__init__.py
+++ b/python/paddle/device/__init__.py
@@ -1018,15 +1018,28 @@ class Event:
     A device event wrapper around StreamBase.
 
     Args:
-        device(str|paddle.CUDAPlace(n)|paddle.CustomPlace(n)|None): Which device the stream run on. If device is None, the device is the current device. Default: None.
-            It can be ``gpu``, ``gpu:x``, ``custom_device``, ``custom_device:x``, where ``custom_device`` is the name of CustomDevice,
-            where ``x`` is the index of the GPUs, XPUs. And it can be paddle.CUDAPlace(n) or paddle.CustomPlace(n).
         enable_timing (bool, optional): indicates if the event should measure time, default is False
         blocking (bool, optional): if True, ``wait`` will be blocking, default is False
         interprocess (bool): if True, the event can be shared between processes, default is False
 
     Returns:
         Event: The event.
+
+    Note:
+        The `device` parameter has been removed in the latest version. The event will always use the current device context.
+        Previously, you could specify the device like:
+        ```python
+        # Old usage (no longer supported)
+        e = paddle.device.Event(device="gpu:0")
+        ```
+        Now it will automatically use the current device:
+        ```python
+        # New usage
+        paddle.set_device("gpu:0")  # Set device first
+        e = paddle.device.Event()   # Will use gpu:0
+        ```
+
+        paddle.device.Event is equivalent to paddle.cuda.Event.
 
     Examples:
         .. code-block:: python
@@ -1035,10 +1048,16 @@ class Event:
             >>> import paddle
 
             >>> paddle.set_device('custom_cpu')
-            >>> e1 = paddle.device.Event()
-            >>> e2 = paddle.device.Event('custom_cpu')
-            >>> e3 = paddle.device.Event('custom_cpu:0')
-            >>> e4 = paddle.device.Event(paddle.CustomPlace('custom_cpu', 0))
+            >>> e1 = paddle.device.Event()  # Uses current device (custom_cpu)
+            >>>
+            >>> # Old usage (no longer supported):
+            >>> # e2 = paddle.device.Event('custom_cpu')
+            >>> # e3 = paddle.device.Event('custom_cpu:0')
+            >>> # e4 = paddle.device.Event(paddle.CustomPlace('custom_cpu', 0))
+            >>>
+            >>> # New equivalent usage:
+            >>> paddle.set_device('custom_cpu:0')
+            >>> e5 = paddle.device.Event()  # Uses custom_cpu:0
 
     '''
 
@@ -1048,17 +1067,11 @@ class Event:
 
     def __init__(
         self,
-        device: PlaceLike | None = None,
         enable_timing: bool = False,
         blocking: bool = False,
         interprocess: bool = False,
     ) -> None:
-        if device is None:
-            self.device = paddle.framework._current_expected_place_()
-        elif isinstance(device, str):
-            self.device = paddle.device._convert_to_place(device)
-        else:
-            self.device = device
+        self.device = paddle.framework._current_expected_place_()
 
         device_id = (
             self.device.get_device_id()
@@ -1340,7 +1353,7 @@ class Stream:
 
         '''
         if event is None:
-            event = Event(self.device)
+            event = Event()
         event.record(self)
         return event
 
@@ -1955,34 +1968,28 @@ class Device(str):
     _DEFAULT_DEVICE_STACK = []
     _SUPPORTED_TYPES = {"cpu", "gpu", "cuda", "xpu"}
 
-    def __new__(cls, type: str | int | None = None, index: int | None = None):
-        if isinstance(type, str):
-            t = type.lower()
-            if t not in cls._SUPPORTED_TYPES and ":" not in t:
-                raise ValueError(f"Unsupported device type: {t}")
-            if index is not None:
-                dev_type = t
-                dev_index = index if t != "cpu" else None
-            else:
-                if ":" in t:
-                    dev_type, idx = t.split(":")
-                    dev_type = dev_type.lower()
-                    if dev_type not in cls._SUPPORTED_TYPES:
-                        raise ValueError(f"Unsupported device type: {dev_type}")
-                    dev_index = int(idx)
-                else:
-                    dev_type = t
-                    dev_index = 0 if t != "cpu" else None
+    def __new__(
+        cls,
+        type: str | int | core.Place | None = None,
+        index: int | None = None,
+    ):
+        if index is not None:
+            type = str(type) + f":{index}"
 
-        elif isinstance(type, int):
-            dev_type = "cuda"
-            dev_index = type
+        place = device_to_place(type)
 
-        elif type is None and index is not None:
-            raise ValueError("Device type must be specified if index is given")
-
-        else:
-            raise TypeError(f"Unsupported type for Device: {type}")
+        if place.is_cpu_place():
+            dev_type = 'cpu'
+            dev_index = None
+        elif place.is_gpu_place():
+            dev_type = 'cuda'
+            dev_index = place.gpu_device_id()
+        elif place.is_xpu_place():
+            dev_type = 'xpu'
+            dev_index = place.gpu_device_id()
+        elif place.is_custom_device():
+            dev_index = place.get_device_id()
+            dev_type = place.get_device_type()
 
         s = f"{dev_type}:{dev_index}" if dev_type != "cpu" else "cpu"
         obj = str.__new__(cls, s)

--- a/python/paddle/device/__init__.py
+++ b/python/paddle/device/__init__.py
@@ -1968,28 +1968,34 @@ class Device(str):
     _DEFAULT_DEVICE_STACK = []
     _SUPPORTED_TYPES = {"cpu", "gpu", "cuda", "xpu"}
 
-    def __new__(
-        cls,
-        type: str | int | core.Place | None = None,
-        index: int | None = None,
-    ):
-        if index is not None:
-            type = str(type) + f":{index}"
+    def __new__(cls, type: str | int | None = None, index: int | None = None):
+        if isinstance(type, str):
+            t = type.lower()
+            if t not in cls._SUPPORTED_TYPES and ":" not in t:
+                raise ValueError(f"Unsupported device type: {t}")
+            if index is not None:
+                dev_type = t
+                dev_index = index if t != "cpu" else None
+            else:
+                if ":" in t:
+                    dev_type, idx = t.split(":")
+                    dev_type = dev_type.lower()
+                    if dev_type not in cls._SUPPORTED_TYPES:
+                        raise ValueError(f"Unsupported device type: {dev_type}")
+                    dev_index = int(idx)
+                else:
+                    dev_type = t
+                    dev_index = 0 if t != "cpu" else None
 
-        place = device_to_place(type)
+        elif isinstance(type, int):
+            dev_type = "cuda"
+            dev_index = type
 
-        if place.is_cpu_place():
-            dev_type = 'cpu'
-            dev_index = None
-        elif place.is_gpu_place():
-            dev_type = 'cuda'
-            dev_index = place.gpu_device_id()
-        elif place.is_xpu_place():
-            dev_type = 'xpu'
-            dev_index = place.gpu_device_id()
-        elif place.is_custom_device():
-            dev_index = place.get_device_id()
-            dev_type = place.get_device_type()
+        elif type is None and index is not None:
+            raise ValueError("Device type must be specified if index is given")
+
+        else:
+            raise TypeError(f"Unsupported type for Device: {type}")
 
     @property
     def type(self):

--- a/python/paddle/device/__init__.py
+++ b/python/paddle/device/__init__.py
@@ -1991,12 +1991,6 @@ class Device(str):
             dev_index = place.get_device_id()
             dev_type = place.get_device_type()
 
-        s = f"{dev_type}:{dev_index}" if dev_type != "cpu" else "cpu"
-        obj = str.__new__(cls, s)
-        obj._dev_type = dev_type
-        obj._index = dev_index
-        return obj
-
     @property
     def type(self):
         return self._dev_type

--- a/python/paddle/device/__init__.py
+++ b/python/paddle/device/__init__.py
@@ -1997,6 +1997,12 @@ class Device(str):
         else:
             raise TypeError(f"Unsupported type for Device: {type}")
 
+        s = f"{dev_type}:{dev_index}" if dev_type != "cpu" else "cpu"
+        obj = str.__new__(cls, s)
+        obj._dev_type = dev_type
+        obj._index = dev_index
+        return obj
+
     @property
     def type(self):
         return self._dev_type

--- a/test/compat/test_event_stream_apis.py
+++ b/test/compat/test_event_stream_apis.py
@@ -90,12 +90,10 @@ class TestEventStreamAPIs(unittest.TestCase):
         event1 = paddle.device.Event()
         self.assertIsInstance(event1, paddle.device.Event)
 
-        event2 = paddle.device.Event(device=device_str, enable_timing=True)
+        event2 = paddle.device.Event(enable_timing=True)
         self.assertIsInstance(event2, paddle.device.Event)
 
-        event3 = paddle.device.Event(
-            device=device_str, enable_timing=True, blocking=True
-        )
+        event3 = paddle.device.Event(enable_timing=True, blocking=True)
         self.assertIsInstance(event3, paddle.device.Event)
 
         # Test Stream creation with different parameters
@@ -159,12 +157,8 @@ class TestEventStreamAPIs(unittest.TestCase):
         # Test Event.elapsed_time()
         if hasattr(event1, 'event_base') and hasattr(event2, 'event_base'):
             # Create events with timing enabled
-            start_event = paddle.device.Event(
-                device=device_str, enable_timing=True
-            )
-            end_event = paddle.device.Event(
-                device=device_str, enable_timing=True
-            )
+            start_event = paddle.device.Event(enable_timing=True)
+            end_event = paddle.device.Event(enable_timing=True)
 
             # Record start event
             start_event.record()
@@ -243,7 +237,7 @@ class TestEventStreamAPIs(unittest.TestCase):
     def test_event_stream_error_handling(self):
         """Test Event and Stream error handling."""
         # Test with invalid device types
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             paddle.device.Event(device='invalid_device:0')
 
         with self.assertRaises(ValueError):
@@ -258,8 +252,8 @@ class TestEventStreamAPIs(unittest.TestCase):
             )
             paddle.device.set_device(device_str)
 
-            event1 = paddle.device.Event(device=device_str)
-            event2 = paddle.device.Event(device=device_str)
+            event1 = paddle.device.Event()
+            event2 = paddle.device.Event()
 
             # Should not raise exception even if events are not recorded
             try:
@@ -320,8 +314,8 @@ class TestEventStreamTimingFunctionality(unittest.TestCase):
         paddle.device.set_device(device_str)
 
         # Create events with timing enabled
-        start_event = paddle.device.Event(device=device_str, enable_timing=True)
-        end_event = paddle.device.Event(device=device_str, enable_timing=True)
+        start_event = paddle.device.Event(enable_timing=True)
+        end_event = paddle.device.Event(enable_timing=True)
 
         # Create a stream for work execution
         stream = paddle.device.Stream(device=device_str)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
## 变更描述
- 移除了`Event`类的`device`参数，现在会自动使用当前设备上下文
- 更新了相关文档字符串，清晰地描述了这一变更
- 添加了新旧用法对比示例

## 变更背景
之前`Event`类允许通过`device`参数指定设备，但这与`torch.cuda.Event`的参数不一致，我们需要保证`torch.cuda.Event`和`paddle.cuda.Event`的参数一致，并且`paddle.device.Event` 和`paddle.device.Event`一致。现在改为自动使用当前设备上下文，简化API并提高一致性。

## 主要变更
1. 从`Event.__init__()`中移除`device`参数
2. 更新类文档字符串，包含：
   - 变更说明
   - 新旧用法对比
   - 正确使用示例
3. 确保所有测试用例使用新的调用方式

## 影响范围
- 影响所有直接创建`Event`实例的代码
- 不影响`Stream.record_event()`等间接创建Event的方法

## 迁移指南
旧代码：
```python
e = paddle.device.Event(device="gpu:0")
```
新代码：

```Python
paddle.set_device("gpu:0")  # 先设置设备
e = paddle.device.Event()   # 再创建Event
```
card-67164