### PR TITLE
【Allocator】Tail alloc

### DIFF
--- a/paddle/phi/core/memory/allocation/virtual_memory_auto_growth_best_fit_allocator.cc
+++ b/paddle/phi/core/memory/allocation/virtual_memory_auto_growth_best_fit_allocator.cc
@@ -204,9 +204,11 @@ VirtualMemoryAutoGrowthBestFitAllocator::AllocateOrCompact(size_t size) {
 }
 
 void VirtualMemoryAutoGrowthBestFitAllocator::ExtendOrCompact(size_t size) {
-  void *ptr = nullptr;
+  void *alloc_ptr = nullptr;
+  size_t alloc_size = 0;
   if (FLAGS_dump_vmm_allocation_info) {
-    DumpInfo("===== Before ExtendOrCompact =====");
+    DumpInfo("===== Before ExtendOrCompact ===== request size: " +
+             std::to_string(size));
   }
 
   auto allocateptr = AllocateOrCompact(size).value_or(nullptr);
@@ -227,13 +229,14 @@ void VirtualMemoryAutoGrowthBestFitAllocator::ExtendOrCompact(size_t size) {
     return;
   }
 
-  ptr = allocateptr->ptr();
-  size = allocateptr->size();
+  alloc_ptr = allocateptr->ptr();
+  alloc_size = allocateptr->size();
   allocations_.push_back(std::move(allocateptr));  // hold allocation
 
   if (all_blocks_.empty()) {
-    all_blocks_.emplace_back(ptr, size, true);
-    free_blocks_.emplace(std::make_pair(size, ptr), all_blocks_.begin());
+    all_blocks_.emplace_back(alloc_ptr, alloc_size, true);
+    free_blocks_.emplace(std::make_pair(alloc_size, alloc_ptr),
+                         all_blocks_.begin());
     return;
   }
 
@@ -241,21 +244,24 @@ void VirtualMemoryAutoGrowthBestFitAllocator::ExtendOrCompact(size_t size) {
   auto block_it = all_blocks_.end();
   block_it--;
   if (block_it->is_free_ &&
-      reinterpret_cast<uint8_t *>(block_it->ptr_) + block_it->size_ == ptr) {
+      reinterpret_cast<uint8_t *>(block_it->ptr_) + block_it->size_ ==
+          alloc_ptr) {
     // merge with pre
     free_blocks_.erase(std::make_pair(block_it->size_, block_it->ptr_));
-    block_it->size_ += size;
+    block_it->size_ += alloc_size;
     free_blocks_.emplace(std::make_pair(block_it->size_, block_it->ptr_),
                          block_it);
   } else {
     // do not merge
-    all_blocks_.emplace_back(ptr, size, true);
+    all_blocks_.emplace_back(alloc_ptr, alloc_size, true);
     auto block_it = all_blocks_.end();
     block_it--;
-    free_blocks_.emplace(std::make_pair(size, ptr), block_it);
+    free_blocks_.emplace(std::make_pair(alloc_size, alloc_ptr), block_it);
   }
   if (FLAGS_dump_vmm_allocation_info) {
-    DumpInfo("===== After ExtendOrCompact =====");
+    DumpInfo("===== After ExtendOrCompact =====  request size: " +
+             std::to_string(size) +
+             " alloc size: " + std::to_string(alloc_size));
   }
 }
 

--- a/paddle/phi/core/memory/allocation/virtual_memory_auto_growth_best_fit_allocator.cc
+++ b/paddle/phi/core/memory/allocation/virtual_memory_auto_growth_best_fit_allocator.cc
@@ -152,35 +152,46 @@ void VirtualMemoryAutoGrowthBestFitAllocator::TryMergeBlock2Blocks(
 std::optional<AllocationPtr>
 VirtualMemoryAutoGrowthBestFitAllocator::AllocateOrCompact(size_t size) {
   AllocationPtr allocateptr = nullptr;
-  if (!FLAGS_native_compact) return underlying_allocator_->Allocate(size);
-  try {
-    allocateptr = std::move(underlying_allocator_->Allocate(size));
-  } catch (const paddle::memory::allocation::BadAlloc &e) {
-    VLOG(4) << "Do Memory Compact allocate size and compact " << size;
-    size_t compact_free_size = memory_compactor_->Compact(
-        all_blocks_, all_blocks_.front().ptr_, all_blocks_.back().ptr_);
-    if (compact_free_size < 0) throw;
-    VLOG(4) << "Memory Compacted Size: " << compact_free_size;
+  if (!FLAGS_native_compact) {
     auto free_block = std::prev(all_blocks_.end());
-    if (free_block->is_free_ && free_block->size_ < size) {
-      auto realloc_size = size - free_block->size_;
-      VLOG(4) << "Free block size {" << free_block->size_
-              << "} is smaller than allocate size {" << size
-              << "} after compact, re-alloc {" << realloc_size << "}";
-      try {
-        auto realloc_ptr =
-            underlying_allocator_->Allocate(size - free_block->size_);
-        VLOG(4) << "Re-alloc size {" << realloc_ptr->size() << "} success";
-        free_block->size_ += realloc_ptr->size();
-        allocations_.push_back(std::move(realloc_ptr));  // hold allocation
-      } catch (const paddle::memory::allocation::BadAlloc &e) {
-        VLOG(4) << "Re-alloc size {" << realloc_size << "} failed";
-        throw;
-      }
+    if (free_block->is_free_) {
+      assert(free_block->size_ < size);
+      auto remain_size = size - free_block->size_;
+      allocateptr = std::move(underlying_allocator_->Allocate(remain_size));
+    } else {
+      allocateptr = std::move(underlying_allocator_->Allocate(size));
     }
-    return std::nullopt;
+    return allocateptr;
+  } else {
+    try {
+      allocateptr = std::move(underlying_allocator_->Allocate(size));
+    } catch (const paddle::memory::allocation::BadAlloc &e) {
+      VLOG(4) << "Do Memory Compact allocate size and compact " << size;
+      size_t compact_free_size = memory_compactor_->Compact(
+          all_blocks_, all_blocks_.front().ptr_, all_blocks_.back().ptr_);
+      if (compact_free_size < 0) throw;
+      VLOG(4) << "Memory Compacted Size: " << compact_free_size;
+      auto free_block = std::prev(all_blocks_.end());
+      if (free_block->is_free_ && free_block->size_ < size) {
+        auto realloc_size = size - free_block->size_;
+        VLOG(4) << "Free block size {" << free_block->size_
+                << "} is smaller than allocate size {" << size
+                << "} after compact, re-alloc {" << realloc_size << "}";
+        try {
+          auto realloc_ptr =
+              underlying_allocator_->Allocate(size - free_block->size_);
+          VLOG(4) << "Re-alloc size {" << realloc_ptr->size() << "} success";
+          free_block->size_ += realloc_ptr->size();
+          allocations_.push_back(std::move(realloc_ptr));  // hold allocation
+        } catch (const paddle::memory::allocation::BadAlloc &e) {
+          VLOG(4) << "Re-alloc size {" << realloc_size << "} failed";
+          throw;
+        }
+      }
+      return std::nullopt;
+    }
+    return allocateptr;
   }
-  return allocateptr;
 }
 
 void VirtualMemoryAutoGrowthBestFitAllocator::ExtendOrCompact(size_t size) {

--- a/paddle/phi/core/memory/allocation/virtual_memory_auto_growth_best_fit_allocator.cc
+++ b/paddle/phi/core/memory/allocation/virtual_memory_auto_growth_best_fit_allocator.cc
@@ -152,46 +152,55 @@ void VirtualMemoryAutoGrowthBestFitAllocator::TryMergeBlock2Blocks(
 std::optional<AllocationPtr>
 VirtualMemoryAutoGrowthBestFitAllocator::AllocateOrCompact(size_t size) {
   AllocationPtr allocateptr = nullptr;
+  // Just Allocate, no compact.
   if (!FLAGS_native_compact) {
-    auto free_block = std::prev(all_blocks_.end());
-    if (free_block->is_free_) {
-      assert(free_block->size_ < size);
-      auto remain_size = size - free_block->size_;
-      allocateptr = std::move(underlying_allocator_->Allocate(remain_size));
+    if (all_blocks_.empty()) {
+      allocateptr = std::move(underlying_allocator_->Allocate(size));
     } else {
-      allocateptr = std::move(underlying_allocator_->Allocate(size));
-    }
-    return allocateptr;
-  } else {
-    try {
-      allocateptr = std::move(underlying_allocator_->Allocate(size));
-    } catch (const paddle::memory::allocation::BadAlloc &e) {
-      VLOG(4) << "Do Memory Compact allocate size and compact " << size;
-      size_t compact_free_size = memory_compactor_->Compact(
-          all_blocks_, all_blocks_.front().ptr_, all_blocks_.back().ptr_);
-      if (compact_free_size < 0) throw;
-      VLOG(4) << "Memory Compacted Size: " << compact_free_size;
       auto free_block = std::prev(all_blocks_.end());
-      if (free_block->is_free_ && free_block->size_ < size) {
-        auto realloc_size = size - free_block->size_;
-        VLOG(4) << "Free block size {" << free_block->size_
+      if (free_block->is_free_) {
+        assert(free_block->size_ < size);
+        auto remain_size = size - free_block->size_;
+        VLOG(1) << " Tail free block size {" << free_block->size_
                 << "} is smaller than allocate size {" << size
-                << "} after compact, re-alloc {" << realloc_size << "}";
-        try {
-          auto realloc_ptr =
-              underlying_allocator_->Allocate(size - free_block->size_);
-          VLOG(4) << "Re-alloc size {" << realloc_ptr->size() << "} success";
-          free_block->size_ += realloc_ptr->size();
-          allocations_.push_back(std::move(realloc_ptr));  // hold allocation
-        } catch (const paddle::memory::allocation::BadAlloc &e) {
-          VLOG(4) << "Re-alloc size {" << realloc_size << "} failed";
-          throw;
-        }
+                << "} after compact, re-alloc {" << remain_size << "}";
+        allocateptr = std::move(underlying_allocator_->Allocate(remain_size));
+      } else {
+        VLOG(1) << "Tail block is not free, just allocate {" << size << "}";
+        allocateptr = std::move(underlying_allocator_->Allocate(size));
       }
-      return std::nullopt;
     }
     return allocateptr;
   }
+  // Compact branch, try allocate and compact.
+  try {
+    allocateptr = std::move(underlying_allocator_->Allocate(size));
+  } catch (const paddle::memory::allocation::BadAlloc &e) {
+    VLOG(4) << "Do Memory Compact allocate size and compact " << size;
+    size_t compact_free_size = memory_compactor_->Compact(
+        all_blocks_, all_blocks_.front().ptr_, all_blocks_.back().ptr_);
+    if (compact_free_size < 0) throw;
+    VLOG(4) << "Memory Compacted Size: " << compact_free_size;
+    auto free_block = std::prev(all_blocks_.end());
+    if (free_block->is_free_ && free_block->size_ < size) {
+      auto realloc_size = size - free_block->size_;
+      VLOG(4) << "Free block size {" << free_block->size_
+              << "} is smaller than allocate size {" << size
+              << "} after compact, re-alloc {" << realloc_size << "}";
+      try {
+        auto realloc_ptr =
+            underlying_allocator_->Allocate(size - free_block->size_);
+        VLOG(4) << "Re-alloc size {" << realloc_ptr->size() << "} success";
+        free_block->size_ += realloc_ptr->size();
+        allocations_.push_back(std::move(realloc_ptr));  // hold allocation
+      } catch (const paddle::memory::allocation::BadAlloc &e) {
+        VLOG(4) << "Re-alloc size {" << realloc_size << "} failed";
+        throw;
+      }
+    }
+    return std::nullopt;
+  }
+  return allocateptr;
 }
 
 void VirtualMemoryAutoGrowthBestFitAllocator::ExtendOrCompact(size_t size) {

--- a/test/cpp/fluid/memory/CMakeLists.txt
+++ b/test/cpp/fluid/memory/CMakeLists.txt
@@ -79,10 +79,8 @@ cc_test(
   SRCS allocator_facade_abs_flags_test.cc
   DEPS phi common)
 
-cc_test(
-  vmm_allocator_tail_test
-  SRCS vmm_allocator_tail_test.cc
-  DEPS phi common)
+paddle_test(vmm_allocator_tail_test SRCS vmm_allocator_tail_test.cc DEPS phi
+            common)
 
 cc_test(
   allocator_facade_frac_flags_test

--- a/test/cpp/fluid/memory/CMakeLists.txt
+++ b/test/cpp/fluid/memory/CMakeLists.txt
@@ -83,8 +83,10 @@ if(WITH_GPU)
   if(WIN32)
     message(STATUS "Skip vmm_allocator_tail_test on Windows")
   else()
-    paddle_test(vmm_allocator_tail_test SRCS vmm_allocator_tail_test.cc DEPS
-                phi common)
+    nv_test(
+      vmm_allocator_tail_test
+      SRCS vmm_allocator_tail_test.cc
+      DEPS phi common)
   endif()
 endif()
 

--- a/test/cpp/fluid/memory/CMakeLists.txt
+++ b/test/cpp/fluid/memory/CMakeLists.txt
@@ -80,6 +80,11 @@ cc_test(
   DEPS phi common)
 
 cc_test(
+  vmm_allocator_tail_test
+  SRCS vmm_allocator_tail_test.cc
+  DEPS phi common)
+
+cc_test(
   allocator_facade_frac_flags_test
   SRCS allocator_facade_frac_flags_test.cc
   DEPS phi common)

--- a/test/cpp/fluid/memory/CMakeLists.txt
+++ b/test/cpp/fluid/memory/CMakeLists.txt
@@ -79,8 +79,14 @@ cc_test(
   SRCS allocator_facade_abs_flags_test.cc
   DEPS phi common)
 
-paddle_test(vmm_allocator_tail_test SRCS vmm_allocator_tail_test.cc DEPS phi
-            common)
+if(WITH_GPU)
+  if(WIN32)
+    message(STATUS "Skip vmm_allocator_tail_test on Windows")
+  else()
+    paddle_test(vmm_allocator_tail_test SRCS vmm_allocator_tail_test.cc DEPS
+                phi common)
+  endif()
+endif()
 
 cc_test(
   allocator_facade_frac_flags_test

--- a/test/cpp/fluid/memory/vmm_allocator_tail_test.cc
+++ b/test/cpp/fluid/memory/vmm_allocator_tail_test.cc
@@ -16,6 +16,7 @@
 #include "paddle/phi/core/memory/allocation/cuda_virtual_mem_allocator.h"
 #include "paddle/phi/core/memory/allocation/retry_allocator.h"
 #include "paddle/phi/core/memory/allocation/virtual_memory_auto_growth_best_fit_allocator.h"
+#include "paddle/phi/core/memory/memory.h"
 #include "paddle/phi/core/platform/device/gpu/gpu_info.h"
 
 #include "gtest/gtest.h"
@@ -30,8 +31,14 @@ TEST(VirtualMemoryAutoGrowthBestFitAllocator, TestAllocatorVisitor) {
       std::make_shared<VirtualMemoryAutoGrowthBestFitAllocator>(
           vmm_cuda_allocator, platform::GpuMinChunkSize(), phi::GPUPlace());
   size_t mb = (1 << 20);
-  vma_allocator->Allocate(1 * mb - 257);
-  vma_allocator->Allocate(2 * mb - 257);
+  auto allocation1 = vma_allocator->Allocate(10 * mb);
+  auto allocation2 = vma_allocator->Allocate(20 * mb);
+  auto allocation3 = vma_allocator->Allocate(30 * mb);
+  auto allocation4 = vma_allocator->Allocate(40 * mb);
+  allocation2.reset();
+  allocation4.reset();
+  auto allocation5 = vma_allocator->Allocate(50 * mb);
+  EXPECT_GT(DeviceMemoryStatCurrentValue("Reserved", 0), 110 * mb);
 }
 
 }  // namespace allocation

--- a/test/cpp/fluid/memory/vmm_allocator_tail_test.cc
+++ b/test/cpp/fluid/memory/vmm_allocator_tail_test.cc
@@ -18,7 +18,10 @@
 #include "paddle/phi/core/memory/allocation/virtual_memory_auto_growth_best_fit_allocator.h"
 #include "paddle/phi/core/memory/memory.h"
 #include "paddle/phi/core/platform/device/gpu/gpu_info.h"
-
+#ifdef PADDLE_WITH_CUDA
+#include <cuda.h>
+#include <cuda_runtime.h>
+#endif
 #include "gtest/gtest.h"
 namespace paddle {
 namespace memory {

--- a/test/cpp/fluid/memory/vmm_allocator_tail_test.cc
+++ b/test/cpp/fluid/memory/vmm_allocator_tail_test.cc
@@ -41,7 +41,7 @@ TEST(VirtualMemoryAutoGrowthBestFitAllocator, TestAllocatorVisitor) {
   allocation2.reset();
   allocation4.reset();
   auto allocation5 = vma_allocator->Allocate(50 * mb);
-  EXPECT_EQ(DeviceMemoryStatCurrentValue("Reserved", 0), 110 * mb);
+  EXPECT_EQ(DeviceMemoryStatCurrentValue("Reserved", 0), 112 * mb);
 }
 
 }  // namespace allocation

--- a/test/cpp/fluid/memory/vmm_allocator_tail_test.cc
+++ b/test/cpp/fluid/memory/vmm_allocator_tail_test.cc
@@ -1,0 +1,40 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/phi/core/memory/allocation/allocator.h"
+#include "paddle/phi/core/memory/allocation/cuda_virtual_mem_allocator.h"
+#include "paddle/phi/core/memory/allocation/retry_allocator.h"
+#include "paddle/phi/core/memory/allocation/virtual_memory_auto_growth_best_fit_allocator.h"
+#include "paddle/phi/core/memory/mem_visitor.h"
+#include "paddle/phi/core/platform/device/gpu/gpu_info.h"
+
+#include "gtest/gtest.h"
+namespace paddle {
+namespace memory {
+namespace allocation {
+
+TEST(VirtualMemoryAutoGrowthBestFitAllocator, TestAllocatorVisitor) {
+  auto vmm_cuda_allocator =
+      std::make_shared<CUDAVirtualMemAllocator>(phi::GPUPlace());
+  auto vma_allocator =
+      std::make_shared<VirtualMemoryAutoGrowthBestFitAllocator>(
+          vmm_cuda_allocator, platform::GpuMinChunkSize(), phi::GPUPlace());
+  size_t mb = (1 << 20);
+  vma_allocator->Allocate(1 * mb - 257);
+  vma_allocator->Allocate(2 * mb - 257);
+}
+
+}  // namespace allocation
+}  // namespace memory
+}  // namespace paddle

--- a/test/cpp/fluid/memory/vmm_allocator_tail_test.cc
+++ b/test/cpp/fluid/memory/vmm_allocator_tail_test.cc
@@ -22,12 +22,17 @@
 #include <cuda.h>
 #include <cuda_runtime.h>
 #endif
+#include "glog/logging.h"
 #include "gtest/gtest.h"
+
+PD_DECLARE_bool(dump_vmm_allocation_info);
 namespace paddle {
 namespace memory {
 namespace allocation {
 
 TEST(VirtualMemoryAutoGrowthBestFitAllocator, TestAllocatorVisitor) {
+  FLAGS_v = 4;
+  FLAGS_dump_vmm_allocation_info = true;
   auto vmm_cuda_allocator =
       std::make_shared<CUDAVirtualMemAllocator>(phi::GPUPlace());
   auto vma_allocator =
@@ -36,12 +41,13 @@ TEST(VirtualMemoryAutoGrowthBestFitAllocator, TestAllocatorVisitor) {
   size_t mb = (1 << 20);
   auto allocation1 = vma_allocator->Allocate(10 * mb);
   auto allocation2 = vma_allocator->Allocate(20 * mb);
+  auto allocation_tiny = vma_allocator->Allocate(2 * mb - 1);
   auto allocation3 = vma_allocator->Allocate(30 * mb);
   auto allocation4 = vma_allocator->Allocate(40 * mb);
   allocation2.reset();
   allocation4.reset();
   auto allocation5 = vma_allocator->Allocate(50 * mb);
-  EXPECT_EQ(DeviceMemoryStatCurrentValue("Reserved", 0), 112 * mb);
+  EXPECT_EQ(DeviceMemoryStatCurrentValue("Reserved", 0), 114 * mb);
 }
 
 }  // namespace allocation

--- a/test/cpp/fluid/memory/vmm_allocator_tail_test.cc
+++ b/test/cpp/fluid/memory/vmm_allocator_tail_test.cc
@@ -16,7 +16,6 @@
 #include "paddle/phi/core/memory/allocation/cuda_virtual_mem_allocator.h"
 #include "paddle/phi/core/memory/allocation/retry_allocator.h"
 #include "paddle/phi/core/memory/allocation/virtual_memory_auto_growth_best_fit_allocator.h"
-#include "paddle/phi/core/memory/mem_visitor.h"
 #include "paddle/phi/core/platform/device/gpu/gpu_info.h"
 
 #include "gtest/gtest.h"

--- a/test/cpp/fluid/memory/vmm_allocator_tail_test.cc
+++ b/test/cpp/fluid/memory/vmm_allocator_tail_test.cc
@@ -41,7 +41,7 @@ TEST(VirtualMemoryAutoGrowthBestFitAllocator, TestAllocatorVisitor) {
   allocation2.reset();
   allocation4.reset();
   auto allocation5 = vma_allocator->Allocate(50 * mb);
-  EXPECT_GT(DeviceMemoryStatCurrentValue("Reserved", 0), 110 * mb);
+  EXPECT_EQ(DeviceMemoryStatCurrentValue("Reserved", 0), 110 * mb);
 }
 
 }  // namespace allocation


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
本PR升级VMM allocator的拓展规则，当**尾部**存在空闲块，且需要拓展时，拓展 request_size - tail_free_block_size，并合并新拓展及尾部空闲块

Pcard-67164