### PR TITLE
[large tensor] Add no-int64-type-cuda-index-without-cast rule

### DIFF
--- a/ci/rule-tests/__snapshots__/no-int64-type-cuda-index-without-cast-snapshot.yml
+++ b/ci/rule-tests/__snapshots__/no-int64-type-cuda-index-without-cast-snapshot.yml
@@ -1,0 +1,16 @@
+id: no-int64-type-cuda-index-without-cast
+snapshots:
+  int64_t global_thread_idx = blockDim.x * blockIdx.x + threadIdx.x;:
+    fixed: int64_t global_thread_idx = static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(blockIdx.x) + static_cast<int64_t>(threadIdx.x);
+    labels:
+      - source: int64_t global_thread_idx = blockDim.x * blockIdx.x + threadIdx.x;
+        style: primary
+        start: 0
+        end: 66
+  int64_t row_id = blockIdx.y * gridDim.z + blockIdx.z;:
+    fixed: int64_t row_id = static_cast<int64_t>(blockIdx.y) * static_cast<int64_t>(gridDim.z) + static_cast<int64_t>(blockIdx.z);
+    labels:
+      - source: int64_t row_id = blockIdx.y * gridDim.z + blockIdx.z;
+        style: primary
+        start: 0
+        end: 53

--- a/ci/rule-tests/no-int64-type-cuda-index-without-cast.yml
+++ b/ci/rule-tests/no-int64-type-cuda-index-without-cast.yml
@@ -1,0 +1,7 @@
+id: no-int64-type-cuda-index-without-cast
+valid:
+  - int64_t global_thread_idx = static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(blockIdx.x) + static_cast<int64_t>(threadIdx.x);
+  - int row_id = blockIdx.y * gridDim.z + blockIdx.z;
+invalid:
+  - int64_t global_thread_idx = blockDim.x * blockIdx.x + threadIdx.x;
+  - int64_t row_id = blockIdx.y * gridDim.z + blockIdx.z;

--- a/ci/rules/no-int64-type-cuda-index-without-cast.yml
+++ b/ci/rules/no-int64-type-cuda-index-without-cast.yml
@@ -1,0 +1,38 @@
+id: no-int64-type-cuda-index-without-cast
+language: cpp
+files:
+  - paddle/phi/kernels/**
+ignores:
+  - paddle/phi/kernels/legacy/**
+  - paddle/phi/kernels/xpu/**
+  - paddle/phi/kernels/custom/**
+  - paddle/phi/kernels/sparse/**
+severity: warning
+message: Prefer int64_t for CUDA indexing (threadIdx/blockDim/blockIdx) to avoid overflow on large problems
+rule:
+  any:
+    # int/int32_t/auto x = <expr with threadIdx|blockDim|blockIdx>;
+    - all:
+        - pattern: $T $VAR = $RIGHT
+    # direct-initializer: T x(<RIGHT>);
+    - all:
+        - pattern: $T $VAR($RIGHT)
+constraints:
+  T:
+    regex: ^(int64_t)$
+  RIGHT:
+    all:
+      - regex: \b(threadIdx|blockDim|blockIdx.*){2,}\b
+      - not:
+          regex: "static_cast"
+rewriters:
+  - id: add-static-cast
+    rule:
+      pattern: $IDENT.$ATTR
+    fix: static_cast<int64_t>($IDENT.$ATTR)
+transform:
+  NEW_RIGHT:
+    rewrite:
+      rewriters: [add-static-cast]
+      source: $RIGHT
+fix: int64_t $VAR = $NEW_RIGHT;

--- a/ci/rules/no-int64-type-cuda-index-without-cast.yml
+++ b/ci/rules/no-int64-type-cuda-index-without-cast.yml
@@ -7,32 +7,37 @@ ignores:
   - paddle/phi/kernels/xpu/**
   - paddle/phi/kernels/custom/**
   - paddle/phi/kernels/sparse/**
-severity: warning
-message: Prefer int64_t for CUDA indexing (threadIdx/blockDim/blockIdx) to avoid overflow on large problems
+severity: error
+message: CUDA indexing calculation assigned to int64_t variable may overflow due to intermediate 32-bit arithmetic. If it is a false positive, please contact zrr1999 (Recommend), wanghuancoder for more information.
+note: Add static_cast<int64_t> to each CUDA built-in variable in the expression to prevent integer overflow during calculation.
 rule:
   any:
-    # int/int32_t/auto x = <expr with threadIdx|blockDim|blockIdx>;
+    # int64_t x = <expr with threadIdx|blockDim|blockIdx|gridDim>;
     - all:
-        - pattern: $T $VAR = $RIGHT
-    # direct-initializer: T x(<RIGHT>);
+        - pattern: $T $VAR = $EXPR
+    # int64_t x(<expr with threadIdx|blockDim|blockIdx|gridDim>);
     - all:
-        - pattern: $T $VAR($RIGHT)
+        - pattern: $T $VAR($EXPR)
 constraints:
   T:
     regex: ^(int64_t)$
-  RIGHT:
+  EXPR:
     all:
-      - regex: \b(threadIdx|blockDim|blockIdx.*){2,}\b
+      - regex: \b(threadIdx|blockIdx|blockDim|gridDim)\.(x|y|z|w)?\b
+      - kind: binary_expression
       - not:
-          regex: "static_cast"
+          regex: "static_cast<int64_t>"
 rewriters:
   - id: add-static-cast
     rule:
       pattern: $IDENT.$ATTR
+    constraints:
+      IDENT:
+        regex: ^(threadIdx|blockIdx|blockDim|gridDim)$
     fix: static_cast<int64_t>($IDENT.$ATTR)
 transform:
-  NEW_RIGHT:
+  NEW_EXPR:
     rewrite:
       rewriters: [add-static-cast]
-      source: $RIGHT
-fix: int64_t $VAR = $NEW_RIGHT;
+      source: $EXPR
+fix: int64_t $VAR = $NEW_EXPR;

--- a/paddle/phi/kernels/funcs/correlation_funcs.cu.h
+++ b/paddle/phi/kernels/funcs/correlation_funcs.cu.h
@@ -68,7 +68,10 @@ __forceinline__ __device__ T blockReduceSum(T val) {
 
 template <typename T>
 __global__ void set_zero(T *x, int64_t num) {
-  for (int64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < num;
+  for (int64_t i =
+           static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
+           static_cast<int64_t>(threadIdx.x);
+       i < num;
        i += blockDim.x * gridDim.x)
     x[i] = static_cast<T>(0);
 }

--- a/paddle/phi/kernels/funcs/cross_entropy.cu
+++ b/paddle/phi/kernels/funcs/cross_entropy.cu
@@ -54,8 +54,8 @@ __global__ void SoftCrossEntropyKernel(T* Y,
   int64_t tid = threadIdx.x;
   T val(0);
 
-  int64_t idx = blockIdx.x * class_num + tid;
-  int64_t end = blockIdx.x * class_num + class_num;
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * class_num + tid;
+  int64_t end = static_cast<int64_t>(blockIdx.x) * class_num + class_num;
   for (; idx < end; idx += blockDim.x) {
     val += phi::funcs::TolerableValue<T>()(phi::funcs::real_log(X[idx])) *
            label[idx];

--- a/paddle/phi/kernels/funcs/fake_dequantize_functor.cu
+++ b/paddle/phi/kernels/funcs/fake_dequantize_functor.cu
@@ -20,7 +20,9 @@ namespace funcs {
 template <typename T>
 __global__ void KeDequantize(
     const T* in, const T* scale, T max_range, int64_t num, T* out) {
-  int64_t idx = threadIdx.x + blockIdx.x * blockDim.x;
+  int64_t idx =
+      static_cast<int64_t>(threadIdx.x) +
+      static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x);
   for (int64_t i = idx; i < num; i += blockDim.x * gridDim.x) {
     out[i] = in[i] * scale[0] / max_range;
   }
@@ -69,7 +71,9 @@ __global__ void DequantizeOneScaleQuantAxisN(const T* in,
                                              const int n_scales,
                                              const int quant_stride,
                                              T* out) {
-  int64_t idx = blockDim.x * blockIdx.x + threadIdx.x;
+  int64_t idx =
+      static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(blockIdx.x) +
+      static_cast<int64_t>(threadIdx.x);
   for (int64_t i = idx; i < num; i += blockDim.x * gridDim.x) {
     T s = scale[(i / quant_stride) % n_scales];
     out[i] = in[i] * s / max_range;
@@ -85,7 +89,9 @@ __global__ void DequantizeTwoScale(const T* in,
                                    int n_scales,
                                    int quant_stride,
                                    T* out) {
-  int64_t idx = blockDim.x * blockIdx.x + threadIdx.x;
+  int64_t idx =
+      static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(blockIdx.x) +
+      static_cast<int64_t>(threadIdx.x);
   for (int64_t i = idx; i < num; i += blockDim.x * gridDim.x) {
     int scale_index = (i / quant_stride) % n_scales;
     T s = scale_one[scale_index] * scale_two[0];

--- a/paddle/phi/kernels/funcs/fake_quantize_functor.cu
+++ b/paddle/phi/kernels/funcs/fake_quantize_functor.cu
@@ -443,7 +443,9 @@ __global__ void ChannelClipAndQuantKernelQuantAxisN(const T *in,
                                                     const int nScale,
                                                     const int quant_stride,
                                                     T *out) {
-  int64_t idx = blockDim.x * blockIdx.x + threadIdx.x;
+  int64_t idx =
+      static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(blockIdx.x) +
+      static_cast<int64_t>(threadIdx.x);
   using ComputeDataType = typename QuantizeDataType<T>::type;
   ComputeDataType qmax_t = static_cast<ComputeDataType>(qmax);
   for (int64_t i = idx; i < n; i += blockDim.x * gridDim.x) {
@@ -536,7 +538,9 @@ __global__ void ChannelClipAndQuantDequantKernelQuantAxis0(const T *in,
                                                            const int64_t num,
                                                            const int cout,
                                                            T *out) {
-  int64_t idx = blockDim.x * blockIdx.x + threadIdx.x;
+  int64_t idx =
+      static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(blockIdx.x) +
+      static_cast<int64_t>(threadIdx.x);
   using ComputeDataType = typename QuantizeDataType<T>::type;
   ComputeDataType bin_cnt_t = static_cast<ComputeDataType>(bin_cnt);
 
@@ -571,7 +575,9 @@ __global__ void ChannelClipAndQuantDequantKernelQuantAxis1(const T *in,
                                                            const int64_t num,
                                                            const int64_t cout,
                                                            T *out) {
-  int64_t idx = blockDim.x * blockIdx.x + threadIdx.x;
+  int64_t idx =
+      static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(blockIdx.x) +
+      static_cast<int64_t>(threadIdx.x);
   using ComputeDataType = typename QuantizeDataType<T>::type;
   ComputeDataType bin_cnt_t = static_cast<ComputeDataType>(bin_cnt);
 

--- a/paddle/phi/kernels/funcs/gather_scatter_functor.cu
+++ b/paddle/phi/kernels/funcs/gather_scatter_functor.cu
@@ -73,7 +73,9 @@ class ReduceMin {
 static ReduceMin reduce_min;
 
 __global__ void CudaMemsetAsync(int* dest, int value, size_t size) {
-  int64_t tid = threadIdx.x + blockIdx.x * blockDim.x;
+  int64_t tid =
+      static_cast<int64_t>(threadIdx.x) +
+      static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x);
   if (tid * sizeof(int) >= size) return;
   dest[tid] = value;
 }
@@ -82,7 +84,9 @@ template <typename SrcT, typename DstT>
 __global__ void CastMemcpy(const SrcT* __restrict__ src,
                            DstT* __restrict__ dst,
                            int64_t size) {
-  int64_t tid = threadIdx.x + blockIdx.x * blockDim.x;
+  int64_t tid =
+      static_cast<int64_t>(threadIdx.x) +
+      static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x);
   if (tid >= size) return;
   dst[tid] = static_cast<DstT>(src[tid]);
 }
@@ -732,7 +736,9 @@ __global__ void ScatterInputGradGPUKernel(
   // no more than 18 int64_t, different from forward kernels
   // the backward kernel does not require src, so src_strides are not needed
   extern __shared__ int64_t smem_shape_strides[];
-  int64_t tid = threadIdx.x + blockIdx.x * blockDim.x;
+  int64_t tid =
+      static_cast<int64_t>(threadIdx.x) +
+      static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x);
 
   if (threadIdx.x < (2 * ndim)) {
     *(smem_shape_strides + threadIdx.x) = *(shape_strides + threadIdx.x);

--- a/paddle/phi/kernels/funcs/layer_norm_impl.cu.h
+++ b/paddle/phi/kernels/funcs/layer_norm_impl.cu.h
@@ -1222,7 +1222,8 @@ __global__ void LayerNormBackwardPartGradGammaBeta(const T *__restrict__ dout,
   }
   __syncthreads();
 
-  for (int64_t i1_block = blockIdx.y * BDIMY * VPTX; i1_block < n1;
+  for (int64_t i1_block = static_cast<int64_t>(blockIdx.y) * BDIMY * VPTX;
+       i1_block < n1;
        i1_block += VPTX_MUL_BDIMY * gridDim.y) {
     cuLoadAddStridedInputs<T, U, VPTX>(i1_block,
                                        thr_load_row_off,
@@ -1640,8 +1641,10 @@ __global__ void LayerNormBackwardGradientAll(
     int64_t feature_size,
     int64_t col_offset) {
   using ScaleBiasT = LayerNormScaleBiasT<T, U, ScaleBiasWithSameTypeX>;
-  int64_t beg_idx = threadIdx.x * feature_size + (blockIdx.x + col_offset);
-  int64_t end_idx = batch_size * feature_size + (blockIdx.x + col_offset);
+  int64_t beg_idx = static_cast<int64_t>(threadIdx.x) * feature_size +
+                    (static_cast<int64_t>(blockIdx.x) + col_offset);
+  int64_t end_idx = batch_size * feature_size +
+                    (static_cast<int64_t>(blockIdx.x) + col_offset);
   int64_t stride = BlockDim * feature_size;
 
   U d_scale_partial = static_cast<U>(0), d_bias_partial = static_cast<U>(0);
@@ -1696,8 +1699,10 @@ __global__ void LayerNormBackwardGradientScaleOrBias(
   using ScaleBiasT = LayerNormScaleBiasT<T, U, ScaleBiasWithSameTypeX>;
   using BlockReduce = cub::BlockReduce<U, BlockDim>;
   __shared__ typename BlockReduce::TempStorage temp_storage;
-  int64_t beg_idx = threadIdx.x * feature_size + blockIdx.x + col_offset;
-  int64_t end_idx = batch_size * feature_size + blockIdx.x + col_offset;
+  int64_t beg_idx = static_cast<int64_t>(threadIdx.x) * feature_size +
+                    static_cast<int64_t>(blockIdx.x) + col_offset;
+  int64_t end_idx =
+      batch_size * feature_size + static_cast<int64_t>(blockIdx.x) + col_offset;
   int64_t stride = BlockDim * feature_size;
   U d_scale_or_d_bias_partial = static_cast<U>(0);
 
@@ -1752,7 +1757,7 @@ __global__ void LayerNormBackwardPostProcessToCalculateDX(
 
   int64_t beg_idx = static_cast<int64_t>(blockIdx.x) * feature_size +
                     static_cast<int64_t>(threadIdx.x);
-  int64_t end_idx = (blockIdx.x + 1) * feature_size;
+  int64_t end_idx = (static_cast<int64_t>(blockIdx.x) + 1) * feature_size;
 
   U block_mean = mean[blockIdx.x];
   U block_var = var[blockIdx.x];
@@ -1803,7 +1808,7 @@ __global__ void LayerNormBackwardGradientOnlyDX(
 
   int64_t beg_idx = static_cast<int64_t>(blockIdx.x) * feature_size +
                     static_cast<int64_t>(threadIdx.x);
-  int64_t end_idx = (blockIdx.x + 1) * feature_size;
+  int64_t end_idx = (static_cast<int64_t>(blockIdx.x) + 1) * feature_size;
 
   U block_mean = mean[blockIdx.x], block_var = var[blockIdx.x];
   U d_x_mean_partial = static_cast<U>(0), d_x_var_partial = static_cast<U>(0);

--- a/paddle/phi/kernels/funcs/layer_norm_impl.cu.h
+++ b/paddle/phi/kernels/funcs/layer_norm_impl.cu.h
@@ -1750,7 +1750,8 @@ __global__ void LayerNormBackwardPostProcessToCalculateDX(
   __shared__ typename BlockReduce::TempStorage temp_storage;
   __shared__ U d_x_reduce_tmp[2];
 
-  int64_t beg_idx = blockIdx.x * feature_size + threadIdx.x;
+  int64_t beg_idx = static_cast<int64_t>(blockIdx.x) * feature_size +
+                    static_cast<int64_t>(threadIdx.x);
   int64_t end_idx = (blockIdx.x + 1) * feature_size;
 
   U block_mean = mean[blockIdx.x];
@@ -1800,7 +1801,8 @@ __global__ void LayerNormBackwardGradientOnlyDX(
   __shared__ typename BlockReduce::TempStorage temp_storage;
   __shared__ U d_x_reduce_tmp[2];
 
-  int64_t beg_idx = blockIdx.x * feature_size + threadIdx.x;
+  int64_t beg_idx = static_cast<int64_t>(blockIdx.x) * feature_size +
+                    static_cast<int64_t>(threadIdx.x);
   int64_t end_idx = (blockIdx.x + 1) * feature_size;
 
   U block_mean = mean[blockIdx.x], block_var = var[blockIdx.x];
@@ -1854,7 +1856,9 @@ __global__ void LayerNormBackwardWhenBatchSizeIsOne(
     const LayerNormScaleBiasT<T, U, ScaleBiasWithSameTypeX> *scale,
     float epsilon,
     int64_t feature_size) {
-  int64_t idx = threadIdx.x + blockIdx.x * blockDim.x;
+  int64_t idx =
+      static_cast<int64_t>(threadIdx.x) +
+      static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x);
   using ScaleBiasT = LayerNormScaleBiasT<T, U, ScaleBiasWithSameTypeX>;
   if (idx < feature_size) {
     auto var_val = static_cast<U>(rsqrt_(static_cast<float>(var[0]) + epsilon));

--- a/paddle/phi/kernels/funcs/scatter.cu.h
+++ b/paddle/phi/kernels/funcs/scatter.cu.h
@@ -67,7 +67,9 @@ __global__ void ScatterCUDAKernel(const T* params,
                                   size_t slice_size) {
   int64_t num = index_size * slice_size;
   int64_t block_size = blockDim.x;
-  int64_t i = (blockIdx.x * block_size + threadIdx.x) * VecSize;
+  int64_t i = (static_cast<int64_t>(blockIdx.x) * block_size +
+               static_cast<int64_t>(threadIdx.x)) *
+              VecSize;
   for (; i < num; i += gridDim.x * block_size * VecSize) {
     int64_t indices_i = i / slice_size;
     int64_t slice_i = i % slice_size;  // offset inside the slice

--- a/paddle/phi/kernels/funcs/strided_copy_kernel.cu.h
+++ b/paddle/phi/kernels/funcs/strided_copy_kernel.cu.h
@@ -40,7 +40,11 @@ __global__ void Contiguous2StridedCaseOneFunc(
     const int64_t x_max) {
   int64_t x = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   if (x < x_max) {
-    int64_t input_offset = (blockIdx.z * gridDim.y + blockIdx.y) * x_max + x;
+    int64_t input_offset =
+        (static_cast<int64_t>(blockIdx.z) * static_cast<int64_t>(gridDim.y) +
+         static_cast<int64_t>(blockIdx.y)) *
+            x_max +
+        x;
     int64_t output_offset = 0;
 
     int64_t reg_dims[6] = {
@@ -384,11 +388,17 @@ __global__ void Contiguous2StridedCaseZeroFunc(
     const T* input_data,
     T* output_data,
     phi::Array<int64_t, phi::DDim::kMaxRank + 1> output_stride) {
-  int64_t input_offset = (blockIdx.z * gridDim.y * gridDim.x +
-                          blockIdx.y * gridDim.x + blockIdx.x) *
-                             blockDim.z * blockDim.y * blockDim.x +
-                         threadIdx.z * blockDim.y * blockDim.x +
-                         threadIdx.y * blockDim.x + threadIdx.x;
+  int64_t input_offset =
+      (static_cast<int64_t>(blockIdx.z) * static_cast<int64_t>(gridDim.y) *
+           static_cast<int64_t>(gridDim.x) +
+       static_cast<int64_t>(blockIdx.y) * static_cast<int64_t>(gridDim.x) +
+       static_cast<int64_t>(blockIdx.x)) *
+          static_cast<int64_t>(blockDim.z) * static_cast<int64_t>(blockDim.y) *
+          static_cast<int64_t>(blockDim.x) +
+      static_cast<int64_t>(threadIdx.z) * static_cast<int64_t>(blockDim.y) *
+          static_cast<int64_t>(blockDim.x) +
+      static_cast<int64_t>(threadIdx.y) * static_cast<int64_t>(blockDim.x) +
+      static_cast<int64_t>(threadIdx.x);
   int64_t output_offset = 0;
 
   int64_t coordinate[6] = {threadIdx.x,
@@ -522,7 +532,10 @@ __global__ void Contiguous2StridedDefaultDiffDimFunc(
     Array<int64_t, phi::DDim::kMaxRank + 1> dims,
     const int64_t output_numel) {
   int MAX_LOAD_BYTES = VecSize * sizeof(T);
-  int64_t gid = (blockIdx.x * blockDim.x + threadIdx.x) * VecSize;
+  int64_t gid =
+      (static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
+       static_cast<int64_t>(threadIdx.x)) *
+      VecSize;
   T set_value[VecSize];
 #pragma unroll
   for (int i = 0; i < VecSize; i++) {
@@ -559,7 +572,10 @@ __global__ void Contiguous2StridedDefaultFunc(
     Array<int64_t, phi::DDim::kMaxRank + 1> dims,
     const int64_t output_numel) {
   int MAX_LOAD_BYTES = VecSize * sizeof(T);
-  int64_t gid = (blockIdx.x * blockDim.x + threadIdx.x) * VecSize;
+  int64_t gid =
+      (static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
+       static_cast<int64_t>(threadIdx.x)) *
+      VecSize;
 #pragma unroll
   for (int64_t i = gid; i < output_numel;
        i += blockDim.x * gridDim.x * VecSize) {
@@ -591,7 +607,10 @@ __global__ void Contiguous2StridedExpandDefaultFunc(
     const int64_t input_numel,
     const int64_t output_numel) {
   int MAX_LOAD_BYTES = VecSize * sizeof(T);
-  int64_t gid = (blockIdx.x * blockDim.x + threadIdx.x) * VecSize;
+  int64_t gid =
+      (static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
+       static_cast<int64_t>(threadIdx.x)) *
+      VecSize;
 #pragma unroll
   for (int64_t i = gid; i < output_numel;
        i += blockDim.x * gridDim.x * VecSize) {

--- a/paddle/phi/kernels/funcs/sync_batch_norm_utils.h
+++ b/paddle/phi/kernels/funcs/sync_batch_norm_utils.h
@@ -307,7 +307,10 @@ static __global__ void KeBNBackwardScaleBias2D(
 
     auto inv_var_i = inv_variance[i];
     auto mean_i = mean[i];
-    for (int64_t j = blockIdx.y * blockDim.y + threadIdx.y; j < inner_size;
+    for (int64_t j = static_cast<int64_t>(blockIdx.y) *
+                         static_cast<int64_t>(blockDim.y) +
+                     static_cast<int64_t>(threadIdx.y);
+         j < inner_size;
          j += gridDim.y * blockDim.y) {
       const int64_t id = layout == DataLayout::kNCHW
                              ? ((j / HxW) * C + i) * HxW + (j % HxW)

--- a/paddle/phi/kernels/funcs/vol2col.cu
+++ b/paddle/phi/kernels/funcs/vol2col.cu
@@ -50,7 +50,9 @@ __global__ void vol2col(int64_t num_kernels,
       num_kernels / output_detph / output_height / output_width;
   int64_t channels_col =
       input_channels * filter_depth * filter_height * filter_width;
-  for (int64_t index = blockIdx.x * blockDim.x + threadIdx.x;
+  for (int64_t index =
+           static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
+           static_cast<int64_t>(threadIdx.x);
        index < num_kernels;
        index += blockDim.x * gridDim.x) {
     int w_out = index % output_width;
@@ -247,7 +249,9 @@ __global__ void col2vol(int64_t num_kernels,
   const int d_filter_width = dilation_w * (filter_width - 1) + 1;
 
   int input_channels = num_kernels / depth / height / width;
-  for (int64_t index = blockIdx.x * blockDim.x + threadIdx.x;
+  for (int64_t index =
+           static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
+           static_cast<int64_t>(threadIdx.x);
        index < num_kernels;
        index += blockDim.x * gridDim.x) {
     T src_val = 0;

--- a/paddle/phi/kernels/fusion/gpu/block_attn.h
+++ b/paddle/phi/kernels/fusion/gpu/block_attn.h
@@ -2049,7 +2049,9 @@ __global__ void write_pre_cache_int8_to_cache(
   LoadT src_vec;
   LoadKVT cache_vec;
 
-  int64_t global_thread_idx = blockDim.x * blockIdx.x + threadIdx.x;
+  int64_t global_thread_idx =
+      static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(blockIdx.x) +
+      static_cast<int64_t>(threadIdx.x);
   const int hidden_size = pre_cache_length * head_size;
   const int cache_hidden_size = num_heads * hidden_size;
   const int offset = 2 * cache_hidden_size;
@@ -2136,7 +2138,9 @@ __global__ void write_pre_cache_to_cache(
   using LoadT = phi::AlignedVector<T, VecSize>;
   LoadT src_vec;
 
-  int64_t global_thread_idx = blockDim.x * blockIdx.x + threadIdx.x;
+  int64_t global_thread_idx =
+      static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(blockIdx.x) +
+      static_cast<int64_t>(threadIdx.x);
   const int hidden_size = pre_cache_length * head_size;
   const int cache_hidden_size = num_heads * hidden_size;
   const int offset = 2 * cache_hidden_size;
@@ -2566,7 +2570,9 @@ __global__ void VariableLengthRotaryKernel(
   LoadT src_vec;
   LoadEmbT cos_emb_vec;
   LoadEmbT sin_emb_vec;
-  int64_t global_thread_idx = blockDim.x * blockIdx.x + threadIdx.x;
+  int64_t global_thread_idx =
+      static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(blockIdx.x) +
+      static_cast<int64_t>(threadIdx.x);
   const int half_lastdim = last_dim / 2;
   const int hidden_size = num_head * last_dim;
   const int offset = 2 * hidden_size;
@@ -2626,7 +2632,9 @@ __global__ void NeoxVariableLengthRotaryKernel(
   LoadT right_vec;
   LoadEmbT cos_emb_vec;
   LoadEmbT sin_emb_vec;
-  int64_t global_thread_idx = blockDim.x * blockIdx.x + threadIdx.x;
+  int64_t global_thread_idx =
+      static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(blockIdx.x) +
+      static_cast<int64_t>(threadIdx.x);
   const int half_lastdim = last_dim / 2;
   const int hidden_size = num_head * half_lastdim;
   const int full_hidden_size = num_head * last_dim;
@@ -2746,7 +2754,9 @@ __global__ void GQAVariableLengthRotaryKernel(
   LoadT src_vec;
   LoadEmbT cos_emb_vec;
   LoadEmbT sin_emb_vec;
-  int64_t global_thread_idx = blockDim.x * blockIdx.x + threadIdx.x;
+  int64_t global_thread_idx =
+      static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(blockIdx.x) +
+      static_cast<int64_t>(threadIdx.x);
   const int half_lastdim = last_dim / 2;
   const int offset = (q_num_head + kv_num_head) * last_dim;
   for (int64_t linear_index = global_thread_idx * VecSize,
@@ -2806,7 +2816,9 @@ __global__ void GQANeoxVariableLengthRotaryKernel(
   LoadT right_vec;
   LoadEmbT cos_emb_vec;
   LoadEmbT sin_emb_vec;
-  int64_t global_thread_idx = blockDim.x * blockIdx.x + threadIdx.x;
+  int64_t global_thread_idx =
+      static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(blockIdx.x) +
+      static_cast<int64_t>(threadIdx.x);
   const int half_lastdim = last_dim / 2;
   const int offset = (q_num_head + kv_num_head) * half_lastdim;
   for (int64_t linear_index = global_thread_idx * VecSize,
@@ -2931,7 +2943,9 @@ __global__ void VariableLengthRotaryKernel(
   LoadScaleT out_scale_vec;
   LoadEmbT cos_emb_vec;
   LoadEmbT sin_emb_vec;
-  int64_t global_thread_idx = blockDim.x * blockIdx.x + threadIdx.x;
+  int64_t global_thread_idx =
+      static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(blockIdx.x) +
+      static_cast<int64_t>(threadIdx.x);
   const int half_lastdim = last_dim / 2;
   const int hidden_size = num_head * last_dim;
   const int offset = 3 * hidden_size;
@@ -3012,7 +3026,9 @@ __global__ void NeoxVariableLengthRotaryKernel(
   LoadScaleT right_out_scale_vec;
   LoadEmbT cos_emb_vec;
   LoadEmbT sin_emb_vec;
-  int64_t global_thread_idx = blockDim.x * blockIdx.x + threadIdx.x;
+  int64_t global_thread_idx =
+      static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(blockIdx.x) +
+      static_cast<int64_t>(threadIdx.x);
   const int half_lastdim = last_dim / 2;
   const int hidden_size = num_head * half_lastdim;
   const int full_hidden_size = num_head * last_dim;
@@ -3162,7 +3178,9 @@ __global__ void GQAVariableLengthRotaryKernel(
   LoadScaleT out_scale_vec;
   LoadEmbT cos_emb_vec;
   LoadEmbT sin_emb_vec;
-  int64_t global_thread_idx = blockDim.x * blockIdx.x + threadIdx.x;
+  int64_t global_thread_idx =
+      static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(blockIdx.x) +
+      static_cast<int64_t>(threadIdx.x);
   const int half_lastdim = last_dim / 2;
   const int offset = (q_num_head + 2 * kv_num_head) * last_dim;
   for (int64_t linear_index = global_thread_idx * VecSize,
@@ -3241,7 +3259,9 @@ __global__ void GQANeoxVariableLengthRotaryKernel(
   LoadScaleT right_out_scale_vec;
   LoadEmbT cos_emb_vec;
   LoadEmbT sin_emb_vec;
-  int64_t global_thread_idx = blockDim.x * blockIdx.x + threadIdx.x;
+  int64_t global_thread_idx =
+      static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(blockIdx.x) +
+      static_cast<int64_t>(threadIdx.x);
   const int half_lastdim = last_dim / 2;
   const int offset = (q_num_head + 2 * kv_num_head) * half_lastdim;
   for (int64_t linear_index = global_thread_idx * VecSize,
@@ -3385,7 +3405,9 @@ __global__ void VariableLengthRotaryKernel(
   LoadT bias_vec;
   LoadEmbT cos_emb_vec;
   LoadEmbT sin_emb_vec;
-  int64_t global_thread_idx = blockDim.x * blockIdx.x + threadIdx.x;
+  int64_t global_thread_idx =
+      static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(blockIdx.x) +
+      static_cast<int64_t>(threadIdx.x);
   const int half_lastdim = last_dim / 2;
   const int hidden_size = num_head * last_dim;
   const int offset = 3 * hidden_size;
@@ -3456,7 +3478,9 @@ __global__ void NeoxVariableLengthRotaryKernel(
   LoadT right_bias_vec;
   LoadEmbT cos_emb_vec;
   LoadEmbT sin_emb_vec;
-  int64_t global_thread_idx = blockDim.x * blockIdx.x + threadIdx.x;
+  int64_t global_thread_idx =
+      static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(blockIdx.x) +
+      static_cast<int64_t>(threadIdx.x);
   const int half_lastdim = last_dim / 2;
   const int hidden_size = num_head * half_lastdim;
   const int full_hidden_size = num_head * last_dim;
@@ -3591,7 +3615,9 @@ __global__ void GQAVariableLengthRotaryKernel(
   LoadT bias_vec;
   LoadEmbT cos_emb_vec;
   LoadEmbT sin_emb_vec;
-  int64_t global_thread_idx = blockDim.x * blockIdx.x + threadIdx.x;
+  int64_t global_thread_idx =
+      static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(blockIdx.x) +
+      static_cast<int64_t>(threadIdx.x);
   const int half_lastdim = last_dim / 2;
   const int offset = (q_num_head + 2 * kv_num_head) * last_dim;
   for (int64_t linear_index = global_thread_idx * VecSize,
@@ -3660,7 +3686,9 @@ __global__ void GQANeoxVariableLengthRotaryKernel(
   LoadT right_bias_vec;
   LoadEmbT cos_emb_vec;
   LoadEmbT sin_emb_vec;
-  int64_t global_thread_idx = blockDim.x * blockIdx.x + threadIdx.x;
+  int64_t global_thread_idx =
+      static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(blockIdx.x) +
+      static_cast<int64_t>(threadIdx.x);
   const int half_lastdim = last_dim / 2;
   const int offset = (q_num_head + 2 * kv_num_head) * half_lastdim;
   for (int64_t linear_index = global_thread_idx * VecSize,
@@ -3951,7 +3979,9 @@ __global__ void fusedQKV_transpose_split_kernel(T *q_buf,
                                                 const int q_head_num,
                                                 const int kv_head_num,
                                                 const int size_per_head) {
-  int64_t global_thread_idx = blockDim.x * blockIdx.x + threadIdx.x;
+  int64_t global_thread_idx =
+      static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(blockIdx.x) +
+      static_cast<int64_t>(threadIdx.x);
   using LoadT = phi::AlignedVector<T, VecSize>;
   LoadT src_vec;
 
@@ -4052,7 +4082,9 @@ __global__ void write_pre_cache_to_kv_buffer(
   const int32_t hidden_size = pre_cache_length * head_dim;
   const int32_t cache_hidden_size = num_head * hidden_size;
   const int32_t fused_hidden_size = 2 * cache_hidden_size;
-  int64_t global_thread_idx = blockDim.x * blockIdx.x + threadIdx.x;
+  int64_t global_thread_idx =
+      static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(blockIdx.x) +
+      static_cast<int64_t>(threadIdx.x);
   using LoadT = phi::AlignedVector<T, VecSize>;
   LoadT src_vec;
 
@@ -4108,7 +4140,9 @@ __global__ void fusedQKV_transpose_split_kernel(T *q_buf,
                                                 const int kv_head_num,
                                                 const int size_per_head) {
   const int fused_hidden_size = (q_head_num + 2 * kv_head_num) * size_per_head;
-  int64_t global_thread_idx = blockDim.x * blockIdx.x + threadIdx.x;
+  int64_t global_thread_idx =
+      static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(blockIdx.x) +
+      static_cast<int64_t>(threadIdx.x);
   using LoadT = phi::AlignedVector<T, VecSize>;
   LoadT src_vec;
 
@@ -4416,7 +4450,9 @@ __global__ void TransposeRemovingPadding(const T *input_data,
   // transpose and remove padding
   // [batch_size, num_head, max_len_this_time, head_dim] -> [token_num,
   // num_head, head_dim]
-  int64_t idx = blockDim.x * blockIdx.x + threadIdx.x;
+  int64_t idx =
+      static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(blockIdx.x) +
+      static_cast<int64_t>(threadIdx.x);
   const int dim_embed = num_head * head_dim;
   using LoadT = phi::AlignedVector<T, VecSize>;
   LoadT src_vec;

--- a/paddle/phi/kernels/fusion/gpu/block_attn.h
+++ b/paddle/phi/kernels/fusion/gpu/block_attn.h
@@ -4403,7 +4403,7 @@ __global__ void InitOutValueKernel(T *output_data,
                                    const T init_value) {
   const int tid = threadIdx.x;
   const int bid = blockIdx.x;
-  int64_t global_thread_idx = bid * blockDim.x + tid;
+  int64_t global_thread_idx = bid * static_cast<int64_t>(blockDim.x) + tid;
 
   for (int linear_index = global_thread_idx * VecSize,
            step = gridDim.x * blockDim.x * VecSize;

--- a/paddle/phi/kernels/fusion/gpu/block_multi_head_attention_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/block_multi_head_attention_kernel.cu
@@ -269,7 +269,10 @@ __global__ void DequantKernel(T* output,
                               const float* dequant_out_scale_data) {
   int64_t numel = m * n;
   int64_t stride = blockDim.x * gridDim.x * VecSize;
-  int64_t idx = (blockIdx.x * blockDim.x + threadIdx.x) * VecSize;
+  int64_t idx =
+      (static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
+       static_cast<int64_t>(threadIdx.x)) *
+      VecSize;
   int64_t col_id = idx % n;
 
   phi::AlignedVector<int32_t, VecSize> in_vec;

--- a/paddle/phi/kernels/fusion/gpu/block_multi_head_attention_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/block_multi_head_attention_kernel.cu
@@ -268,7 +268,8 @@ __global__ void DequantKernel(T* output,
                               const int64_t n,  // hidden
                               const float* dequant_out_scale_data) {
   int64_t numel = m * n;
-  int64_t stride = blockDim.x * gridDim.x * VecSize;
+  int64_t stride = static_cast<int64_t>(blockDim.x) *
+                   static_cast<int64_t>(gridDim.x) * VecSize;
   int64_t idx =
       (static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
        static_cast<int64_t>(threadIdx.x)) *

--- a/paddle/phi/kernels/fusion/gpu/fmha_ref.h
+++ b/paddle/phi/kernels/fusion/gpu/fmha_ref.h
@@ -79,7 +79,9 @@ __global__ void TransposeRemovingPadding(const T* input_data,
   // transpose and remove padding
   // [batch_size, num_head, seq_len, head_dim] -> [token_num, num_head,
   // head_dim]
-  int64_t idx = blockDim.x * blockIdx.x + threadIdx.x;
+  int64_t idx =
+      static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(blockIdx.x) +
+      static_cast<int64_t>(threadIdx.x);
   const int dim_embed = num_head * head_dim;
   using LoadT = phi::AlignedVector<T, VecSize>;
   LoadT src_vec;

--- a/paddle/phi/kernels/fusion/gpu/fused_multi_transformer_op.cu.h
+++ b/paddle/phi/kernels/fusion/gpu/fused_multi_transformer_op.cu.h
@@ -1804,7 +1804,10 @@ __global__ void gqa_write_cache_k_kernel(T *cache_k,
                                          const int64_t num_elems) {
   phi::AlignedVector<T, X_ELEMS> in_vec;
 
-  for (int64_t linear_idx = (blockIdx.x * blockDim.x + threadIdx.x) * X_ELEMS;
+  for (int64_t linear_idx = (static_cast<int64_t>(blockIdx.x) *
+                                 static_cast<int64_t>(blockDim.x) +
+                             static_cast<int64_t>(threadIdx.x)) *
+                            X_ELEMS;
        linear_idx < num_elems;
        linear_idx += blockDim.x * gridDim.x * X_ELEMS) {
     const int hidden_size = gqa_group_size * dim_head;
@@ -1841,7 +1844,10 @@ __global__ void gqa_write_cache_v_kernel(T *cache_v,
                                          const int64_t num_elems) {
   phi::AlignedVector<T, X_ELEMS> in_vec;
 
-  for (int64_t linear_idx = (blockIdx.x * blockDim.x + threadIdx.x) * X_ELEMS;
+  for (int64_t linear_idx = (static_cast<int64_t>(blockIdx.x) *
+                                 static_cast<int64_t>(blockDim.x) +
+                             static_cast<int64_t>(threadIdx.x)) *
+                            X_ELEMS;
        linear_idx < num_elems;
        linear_idx += blockDim.x * gridDim.x * X_ELEMS) {
     const int hidden_size = gqa_group_size * dim_head;
@@ -1935,7 +1941,9 @@ __global__ void fusedQKV_transpose_split_kernel(T *q_buf,
                                                 const int size_per_head) {
   const int32_t hidden_size = head_num * size_per_head;
   const int32_t fused_hidden_size = 3 * hidden_size;
-  int64_t global_thread_idx = blockDim.x * blockIdx.x + threadIdx.x;
+  int64_t global_thread_idx =
+      static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(blockIdx.x) +
+      static_cast<int64_t>(threadIdx.x);
   using LoadT = phi::AlignedVector<T, VecSize>;
   LoadT src_vec;
 
@@ -2023,7 +2031,9 @@ __global__ void add_fusedQKV_bias_transpose_split_kernel(
   const int32_t offset = batch_size * seq_len * head_num * size_per_head;
   const int32_t hidden_size = head_num * size_per_head;
   const int32_t fused_hidden_size = 3 * hidden_size;
-  int64_t global_thread_idx = blockDim.x * blockIdx.x + threadIdx.x;
+  int64_t global_thread_idx =
+      static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(blockIdx.x) +
+      static_cast<int64_t>(threadIdx.x);
   using LoadT = phi::AlignedVector<T, VecSize>;
   LoadT src_vec;
   LoadT bias_vec;
@@ -2156,7 +2166,9 @@ __global__ void gqa_fusedQKV_transpose_split_kernel(T *q_buf,
                                                     const int head_num,
                                                     const int size_per_head,
                                                     const int gqa_group_size) {
-  int64_t global_thread_idx = blockDim.x * blockIdx.x + threadIdx.x;
+  int64_t global_thread_idx =
+      static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(blockIdx.x) +
+      static_cast<int64_t>(threadIdx.x);
   using LoadT = phi::AlignedVector<T, VecSize>;
   LoadT src_vec;
 
@@ -2734,7 +2746,9 @@ __global__ void fused_transpose_split_kernel(
       batch_size * max_len_this_time * head_num * size_per_head;
   const int32_t hidden_size = head_num * size_per_head;
   const int32_t fused_hidden_size = 3 * hidden_size;
-  int64_t global_thread_idx = blockDim.x * blockIdx.x + threadIdx.x;
+  int64_t global_thread_idx =
+      static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(blockIdx.x) +
+      static_cast<int64_t>(threadIdx.x);
   using LoadT = phi::AlignedVector<T, VecSize>;
   LoadT src_vec;
   LoadT bias_vec;
@@ -2882,7 +2896,9 @@ __global__ void VariableLengthRotaryKernel(
   LoadT bias_vec;
   LoadEmbT cos_emb_vec;
   LoadEmbT sin_emb_vec;
-  int64_t global_thread_idx = blockDim.x * blockIdx.x + threadIdx.x;
+  int64_t global_thread_idx =
+      static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(blockIdx.x) +
+      static_cast<int64_t>(threadIdx.x);
   const int half_lastdim = last_dim / 2;
   const int hidden_size = num_head * last_dim;
   const int offset = 3 * hidden_size;
@@ -2997,7 +3013,9 @@ __global__ void GQAVariableLengthRotaryKernel(
   LoadT bias_vec;
   LoadEmbT cos_emb_vec;
   LoadEmbT sin_emb_vec;
-  int64_t global_thread_idx = blockDim.x * blockIdx.x + threadIdx.x;
+  int64_t global_thread_idx =
+      static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(blockIdx.x) +
+      static_cast<int64_t>(threadIdx.x);
   const int half_lastdim = last_dim / 2;
   // const int hidden_size = num_head * last_dim;
   const int offset = (num_head + 2 * gqa_group_size) * last_dim;

--- a/paddle/phi/kernels/fusion/gpu/fused_multi_transformer_op.cu.h
+++ b/paddle/phi/kernels/fusion/gpu/fused_multi_transformer_op.cu.h
@@ -2526,7 +2526,7 @@ __global__ void InitOutValueKernel(T *output_data,
                                    const T init_value) {
   const int tid = threadIdx.x;
   const int bid = blockIdx.x;
-  int64_t global_thread_idx = bid * blockDim.x + tid;
+  int64_t global_thread_idx = bid * static_cast<int64_t>(blockDim.x) + tid;
 
   for (int linear_index = global_thread_idx * VecSize,
            step = gridDim.x * blockDim.x * VecSize;

--- a/paddle/phi/kernels/fusion/gpu/fused_residual_dropout_bias.h
+++ b/paddle/phi/kernels/fusion/gpu/fused_residual_dropout_bias.h
@@ -228,7 +228,9 @@ __global__ void FusedResidualDropoutGrad(const T *dout,
                                          const T factor,
                                          const int64_t size,
                                          T *dx) {
-  int64_t idx = blockDim.x * blockIdx.x + threadIdx.x;
+  int64_t idx =
+      static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(blockIdx.x) +
+      static_cast<int64_t>(threadIdx.x);
 
   using LoadT = phi::AlignedVector<T, VecSize>;
   using StoreT = phi::AlignedVector<T, VecSize>;
@@ -278,8 +280,12 @@ __global__ void FusedResidualDropoutBias(
     const float *dequant_out_scale_data = nullptr,
     const float quant_next_in_scale = 1.0,
     const float residual_alpha = 1.0) {
-  int64_t col_id = blockDim.x * blockIdx.x + threadIdx.x;
-  int64_t row_id = blockIdx.y * gridDim.z + blockIdx.z;
+  int64_t col_id =
+      static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(blockIdx.x) +
+      static_cast<int64_t>(threadIdx.x);
+  int64_t row_id =
+      static_cast<int64_t>(blockIdx.y) * static_cast<int64_t>(gridDim.z) +
+      static_cast<int64_t>(blockIdx.z);
   if (row_id >= rows) {
     return;
   }

--- a/paddle/phi/kernels/gpu/adam_kernel.cu
+++ b/paddle/phi/kernels/gpu/adam_kernel.cu
@@ -53,7 +53,9 @@ __global__ void AdamKernelREG(MT beta1,
   MT beta1_pow = beta1_pow_;
   MT beta2_pow = beta2_pow_;
 
-  int64_t id = blockIdx.x * blockDim.x + threadIdx.x;
+  int64_t id =
+      static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
+      static_cast<int64_t>(threadIdx.x);
 
   for (; id < ndim; id += gridDim.x * blockDim.x) {
     MT p = master_param ? master_param[id] : static_cast<MT>(param[id]);
@@ -111,7 +113,9 @@ __global__ void AdamKernelMEM(MT beta1,
   MT beta1_pow = *beta1_pow_;
   MT beta2_pow = *beta2_pow_;
 
-  int64_t id = blockIdx.x * blockDim.x + threadIdx.x;
+  int64_t id =
+      static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
+      static_cast<int64_t>(threadIdx.x);
 
   for (; id < ndim; id += gridDim.x * blockDim.x) {
     MT p = master_param ? master_param[id] : static_cast<MT>(param[id]);

--- a/paddle/phi/kernels/gpu/adamw_kernel.cu
+++ b/paddle/phi/kernels/gpu/adamw_kernel.cu
@@ -84,7 +84,9 @@ __global__ void AdamWKernel(MT beta1,
                             BetaAccessor beta_accessor,
                             int64_t ndim,
                             bool amsgrad) {
-  int64_t id = blockIdx.x * blockDim.x + threadIdx.x;
+  int64_t id =
+      static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
+      static_cast<int64_t>(threadIdx.x);
   MT lr = *lr_ * lr_ratio;
   // Get beta powers
   MT beta1_pow = beta_accessor.GetBeta1();

--- a/paddle/phi/kernels/gpu/argsort_kernel.cu
+++ b/paddle/phi/kernels/gpu/argsort_kernel.cu
@@ -93,7 +93,8 @@ __global__ void merge_kernel(const T* A,
                              T* out,
                              IndType* out_ids,
                              bool descending) {
-  int64_t thread = blockDim.x * gridDim.x;
+  int64_t thread =
+      static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(gridDim.x);
   int64_t num_per_thread = (sizeA + sizeB + thread) / thread;
   for (int64_t offset = 0; offset < num_per_thread; offset++) {
     size_t idx = blockIdx.x * blockDim.x + threadIdx.x + offset * thread;

--- a/paddle/phi/kernels/gpu/batch_norm_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/batch_norm_grad_kernel.cu
@@ -284,7 +284,10 @@ static __global__ void BNBackward2DChannelLastStage1(
     BatchNormParamType<T> x_sum = static_cast<BatchNormParamType<T>>(0);
     BatchNormParamType<T> x_square_sum = static_cast<BatchNormParamType<T>>(0);
 
-    for (int64_t j = blockIdx.y * blockDim.y + threadIdx.y; j < inner_size;
+    for (int64_t j = static_cast<int64_t>(blockIdx.y) *
+                         static_cast<int64_t>(blockDim.y) +
+                     static_cast<int64_t>(threadIdx.y);
+         j < inner_size;
          j += inner_loop_stride) {
       const int64_t index = j * outer_size + i;
       BatchNormParamType<T> x_i = static_cast<BatchNormParamType<T>>(x[index]);
@@ -365,7 +368,10 @@ static __global__ void BNBackward2DChannelLastStage2(
     BatchNormParamType<T> inv_var_val =
         is_test ? 1.0 / sqrt(variances[i] + epsilon) : variances[i];
 
-    for (int64_t j = blockIdx.y * blockDim.y + threadIdx.y; j < inner_size;
+    for (int64_t j = static_cast<int64_t>(blockIdx.y) *
+                         static_cast<int64_t>(blockDim.y) +
+                     static_cast<int64_t>(threadIdx.y);
+         j < inner_size;
          j += inner_loop_stride) {
       const int64_t index = j * outer_size + i;
       BatchNormParamType<T> dy_i =
@@ -430,7 +436,10 @@ static __global__ void BNBackward2DChannelLastStage3(
     BatchNormParamType<T> dscale_val = dscales[i];
     BatchNormParamType<T> dbias_val = dbias[i];
 
-    for (int64_t j = blockIdx.y * blockDim.y + threadIdx.y; j < inner_size;
+    for (int64_t j = static_cast<int64_t>(blockIdx.y) *
+                         static_cast<int64_t>(blockDim.y) +
+                     static_cast<int64_t>(threadIdx.y);
+         j < inner_size;
          j += inner_loop_stride) {
       const int64_t index = j * outer_size + i;
       dx[index] = scale[i] * inv_var_val *

--- a/paddle/phi/kernels/gpu/batch_norm_kernel.cu
+++ b/paddle/phi/kernels/gpu/batch_norm_kernel.cu
@@ -247,7 +247,10 @@ static __global__ void BNForwardTraining2DChannelLastCompStat(
     BatchNormParamType<T> x_sum = static_cast<BatchNormParamType<T>>(0);
     BatchNormParamType<T> x_square_sum = static_cast<BatchNormParamType<T>>(0);
 
-    for (int64_t j = blockIdx.y * blockDim.y + threadIdx.y; j < inner_size;
+    for (int64_t j = static_cast<int64_t>(blockIdx.y) *
+                         static_cast<int64_t>(blockDim.y) +
+                     static_cast<int64_t>(threadIdx.y);
+         j < inner_size;
          j += inner_loop_stride) {
       const int64_t index = j * outer_size + i;
       BatchNormParamType<T> x_i = static_cast<BatchNormParamType<T>>(x[index]);
@@ -348,7 +351,10 @@ static __global__ void BNForwardTraining2DChannelLastWriteRes(
     BatchNormParamType<T> scale_val = scale[i];
     BatchNormParamType<T> bias_val = bias[i];
 
-    for (int64_t j = blockIdx.y * blockDim.y + threadIdx.y; j < inner_size;
+    for (int64_t j = static_cast<int64_t>(blockIdx.y) *
+                         static_cast<int64_t>(blockDim.y) +
+                     static_cast<int64_t>(threadIdx.y);
+         j < inner_size;
          j += inner_loop_stride) {
       const int64_t index = j * outer_size + i;
       BatchNormParamType<T> x_sub_mean =
@@ -394,7 +400,10 @@ static __global__ void BNForwardTraining2DCompStat(
     BatchNormParamType<T> x_sum = static_cast<BatchNormParamType<T>>(0);
     BatchNormParamType<T> x_square_sum = static_cast<BatchNormParamType<T>>(0);
 
-    for (int64_t j = blockIdx.x * blockDim.x + threadIdx.x; j < inner_size;
+    for (int64_t j = static_cast<int64_t>(blockIdx.x) *
+                         static_cast<int64_t>(blockDim.x) +
+                     static_cast<int64_t>(threadIdx.x);
+         j < inner_size;
          j += inner_loop_stride) {
       const int64_t index = (j / HxW * C + i) * HxW + j % HxW;
       BatchNormParamType<T> x_i = static_cast<BatchNormParamType<T>>(x[index]);
@@ -522,7 +531,10 @@ static __global__ void BNForwardTraining2DWriteRes(
     BatchNormParamType<T> scale_val = scale[i];
     BatchNormParamType<T> bias_val = bias[i];
 
-    for (int64_t j = blockIdx.x * blockDim.x + threadIdx.x; j < inner_size;
+    for (int64_t j = static_cast<int64_t>(blockIdx.x) *
+                         static_cast<int64_t>(blockDim.x) +
+                     static_cast<int64_t>(threadIdx.x);
+         j < inner_size;
          j += inner_loop_stride) {
       const int64_t index = (j / HxW * C + i) * HxW + j % HxW;
       BatchNormParamType<T> x_sub_mean =

--- a/paddle/phi/kernels/gpu/check_numerics_kernel.cu
+++ b/paddle/phi/kernels/gpu/check_numerics_kernel.cu
@@ -158,7 +158,9 @@ __global__ void FindNanInfAndBlockMaxMin(const T* value_ptr,
                                          MT* tensor_block_max_ptr,
                                          MT* tensor_block_min_ptr,
                                          MT* tensor_block_mean_ptr) {
-  int64_t i = threadIdx.x + blockIdx.x * blockDim.x;
+  int64_t i =
+      static_cast<int64_t>(threadIdx.x) +
+      static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x);
 
   int64_t num_nan = 0;
   int64_t num_inf = 0;

--- a/paddle/phi/kernels/gpu/contiguous_kernel.cu
+++ b/paddle/phi/kernels/gpu/contiguous_kernel.cu
@@ -48,9 +48,14 @@ __global__ void ContiguousCaseZeroFunc(
   int64_t input_offset = 0;
   int64_t grid_idx = static_cast<int64_t>(blockIdx.z) * gridDim.y * gridDim.x +
                      static_cast<int64_t>(blockIdx.y) * gridDim.x + blockIdx.x;
-  int64_t block_size = blockDim.z * (blockDim.y * blockDim.x);
-  int64_t block_idx = threadIdx.z * (blockDim.y * blockDim.x) +
-                      threadIdx.y * blockDim.x + threadIdx.x;
+  int64_t block_size =
+      static_cast<int64_t>(blockDim.z) *
+      (static_cast<int64_t>(blockDim.y) * static_cast<int64_t>(blockDim.x));
+  int64_t block_idx =
+      static_cast<int64_t>(threadIdx.z) * (static_cast<int64_t>(blockDim.y) *
+                                           static_cast<int64_t>(blockDim.x)) +
+      static_cast<int64_t>(threadIdx.y) * static_cast<int64_t>(blockDim.x) +
+      static_cast<int64_t>(threadIdx.x);
   int64_t output_offset = grid_idx * block_size + block_idx;
   int64_t coordinate[6] = {threadIdx.x,
                            threadIdx.y,

--- a/paddle/phi/kernels/gpu/cross_entropy_bwd_w_downcast.cu
+++ b/paddle/phi/kernels/gpu/cross_entropy_bwd_w_downcast.cu
@@ -145,11 +145,11 @@ __global__ void SoftmaxWithCrossEntropyGradHardLabelWarp(
 
   // Process multiple elements per thread using warp-level parallelism
   int64_t elements_per_thread =
-      (n * dim * d + gridDim.x * threads_per_block - 1) /
-      (gridDim.x * threads_per_block);
+      (n * dim * d + static_cast<int64_t>(gridDim.x) * threads_per_block - 1) /
+      (static_cast<int64_t>(gridDim.x) * threads_per_block);
 
   for (int e = 0; e < elements_per_thread; ++e) {
-    int64_t idx = tid + e * gridDim.x * threads_per_block;
+    int64_t idx = tid + e * static_cast<int64_t>(gridDim.x) * threads_per_block;
     if (idx >= n * dim * d) break;
 
     int64_t idx_n = idx / (d * dim);

--- a/paddle/phi/kernels/gpu/cross_entropy_bwd_w_downcast.cu
+++ b/paddle/phi/kernels/gpu/cross_entropy_bwd_w_downcast.cu
@@ -56,7 +56,9 @@ __global__ void SoftmaxWithCrossEntropyGradHardLabelVectorized(
   using VecT = typename phi::AlignedVector<LogitT, VEC_SIZE>;
   using SoftmaxVecT = typename phi::AlignedVector<T, VEC_SIZE>;
 
-  int64_t tid = blockIdx.x * blockDim.x + threadIdx.x;
+  int64_t tid =
+      static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
+      static_cast<int64_t>(threadIdx.x);
   int64_t vec_id = tid * VEC_SIZE;
 
   // Ensure we don't exceed bounds

--- a/paddle/phi/kernels/gpu/cross_entropy_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/cross_entropy_grad_kernel.cu
@@ -99,7 +99,9 @@ __global__ void SoftCrossEntropyGradientKernel(T* logit_grad,
                                                const int64_t n,
                                                const int64_t d,
                                                const int64_t remain) {
-  int64_t ids = blockIdx.x * blockDim.x + threadIdx.x;
+  int64_t ids =
+      static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
+      static_cast<int64_t>(threadIdx.x);
   if (ids < n * d) {
     int64_t idx_n = ids / d;
     int64_t idx_remain = ids % remain;
@@ -120,7 +122,9 @@ __global__ void SoftmaxWithCrossEntropyGradHardLabel(T* logits_grad,
                                                      const int64_t dim,
                                                      const int64_t d,
                                                      const int ignore_index) {
-  int64_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  int64_t idx =
+      static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
+      static_cast<int64_t>(threadIdx.x);
   int64_t idx_n = idx / (d * dim);
   int64_t idx_dim = (idx / d) % dim;
   int64_t idx_d = idx % d;

--- a/paddle/phi/kernels/gpu/cross_entropy_kernel.cu
+++ b/paddle/phi/kernels/gpu/cross_entropy_kernel.cu
@@ -215,7 +215,9 @@ __global__ void CrossEntropyExpHardLabel(T* loss,
                                          const int64_t dim,
                                          const int64_t d,
                                          const int ignore_idx) {
-  int64_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  int64_t idx =
+      static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
+      static_cast<int64_t>(threadIdx.x);
   int64_t idx_n = idx / (d * dim);
   int64_t idx_dim = (idx / d) % dim;
   int64_t idx_d = idx % d;

--- a/paddle/phi/kernels/gpu/cum_kernel.cu
+++ b/paddle/phi/kernels/gpu/cum_kernel.cu
@@ -43,7 +43,7 @@ __global__ void MatrixRowReverse(const T* matrix_data,
   for (int64_t bx = blockIdx.x; bx < grid_size; bx += gridDim.x) {
     for (int64_t block_offset = 0; block_offset < reverse_size;
          block_offset += item_per_block) {
-      int64_t reverse_offset = block_offset + threadIdx.x;
+      int64_t reverse_offset = block_offset + static_cast<int64_t>(threadIdx.x);
       int64_t src_offset = bx * reverse_size + reverse_offset;
       int64_t dst_offset =
           bx * reverse_size + (reverse_size - reverse_offset - 1);
@@ -69,8 +69,8 @@ __global__ void MatrixTranspose(T* odata,
   for (; block_i < wblocks * hblocks; block_i += gridDim.x) {
     int64_t block_y = block_i / wblocks;
     int64_t block_x = block_i % wblocks;
-    int64_t x = block_x * TILE_DIM + threadIdx.x;
-    int64_t y = block_y * TILE_DIM + threadIdx.y;
+    int64_t x = block_x * TILE_DIM + static_cast<int64_t>(threadIdx.x);
+    int64_t y = block_y * TILE_DIM + static_cast<int64_t>(threadIdx.y);
 
     for (int j = 0; j < TILE_DIM; j += BLOCK_ROWS) {
       if (x < width && (y + j) < height) {

--- a/paddle/phi/kernels/gpu/cum_maxmin_kernel.cu
+++ b/paddle/phi/kernels/gpu/cum_maxmin_kernel.cu
@@ -106,7 +106,7 @@ __global__ void KernelScanInnerWithIndices(const T1* x_data,
            static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.y);
        block_row < num_rows;
        block_row += blockDim.y * gridDim.x) {
-    int64_t row = block_row + threadIdx.y;
+    int64_t row = block_row + static_cast<int64_t>(threadIdx.y);
     const T1* row_self = x_data + row * row_size;
     T1* row_values = values_data + row * row_size;
     T2* row_indices = indices_data + row * row_size;
@@ -117,8 +117,9 @@ __global__ void KernelScanInnerWithIndices(const T1* x_data,
     for (int64_t block_col = 0; block_col < row_size;
          block_col += 2 * num_threads_x) {
       // Load data into shared memory (two values per thread).
-      int64_t col1 = block_col + threadIdx.x;
-      int64_t col2 = block_col + num_threads_x + threadIdx.x;
+      int64_t col1 = block_col + static_cast<int64_t>(threadIdx.x);
+      int64_t col2 =
+          block_col + num_threads_x + static_cast<int64_t>(threadIdx.x);
       if (row < num_rows) {
         if (col1 < row_size) {
           row_buf[threadIdx.x] = *reinterpret_cast<const T1*>(&row_self[col1]);

--- a/paddle/phi/kernels/gpu/cum_maxmin_kernel.cu
+++ b/paddle/phi/kernels/gpu/cum_maxmin_kernel.cu
@@ -102,7 +102,9 @@ __global__ void KernelScanInnerWithIndices(const T1* x_data,
   T1* row_buf = vbuf[threadIdx.y];
   T2* row_idx_buf = ibuf[threadIdx.y];
 
-  for (int64_t block_row = blockIdx.x * blockDim.y; block_row < num_rows;
+  for (int64_t block_row =
+           static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.y);
+       block_row < num_rows;
        block_row += blockDim.y * gridDim.x) {
     int64_t row = block_row + threadIdx.y;
     const T1* row_self = x_data + row * row_size;

--- a/paddle/phi/kernels/gpu/diag_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/diag_grad_kernel.cu
@@ -28,7 +28,10 @@ __global__ void ExtractDiagonalKernel(const T* dout,
                                       int64_t dx_length,
                                       const int64_t sumStride,
                                       const int64_t xStride) {
-  for (int64_t idx = blockIdx.x * blockDim.x + threadIdx.x; idx < dx_length;
+  for (int64_t idx =
+           static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
+           static_cast<int64_t>(threadIdx.x);
+       idx < dx_length;
        idx += gridDim.x * blockDim.x) {
     const int64_t outOffset = start + sumStride * idx;
     dx[xStride * idx] = dout[outOffset];
@@ -43,7 +46,10 @@ __global__ void PasteDiagonalKernel(const T* dout,
                                     int64_t size,
                                     const int64_t sumStride,
                                     const int64_t outStride) {
-  for (int64_t idx = blockIdx.x * blockDim.x + threadIdx.x; idx < size;
+  for (int64_t idx =
+           static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
+           static_cast<int64_t>(threadIdx.x);
+       idx < size;
        idx += gridDim.x * blockDim.x) {
     int64_t xOffset = start + sumStride * idx;
     dx[xOffset] = dout[outStride * idx];

--- a/paddle/phi/kernels/gpu/diag_kernel.cu
+++ b/paddle/phi/kernels/gpu/diag_kernel.cu
@@ -32,7 +32,10 @@ __global__ void ExtractDiagonalKernel(T* out,
                                       int64_t size,
                                       const int64_t sumStride,
                                       const int64_t outStride) {
-  for (int64_t idx = blockIdx.x * blockDim.x + threadIdx.x; idx < size;
+  for (int64_t idx =
+           static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
+           static_cast<int64_t>(threadIdx.x);
+       idx < size;
        idx += gridDim.x * blockDim.x) {
     const int64_t xOffset = start + sumStride * idx;
     out[outStride * idx] = x[xOffset];
@@ -47,7 +50,10 @@ __global__ void PasteDiagonalKernel(T* out,
                                     int64_t x_length,
                                     const int64_t sumStride,
                                     const int64_t xStride) {
-  for (int64_t idx = blockIdx.x * blockDim.x + threadIdx.x; idx < x_length;
+  for (int64_t idx =
+           static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
+           static_cast<int64_t>(threadIdx.x);
+       idx < x_length;
        idx += gridDim.x * blockDim.x) {
     const int64_t outOffset = start + sumStride * idx;
     out[outOffset] = x[xStride * idx];

--- a/paddle/phi/kernels/gpu/fill_diagonal_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/fill_diagonal_grad_kernel.cu
@@ -29,7 +29,8 @@ __global__ void fill_constant_kernel(const int64_t featuresize,
                                      int offset,
                                      T fillvar,
                                      int dims) {
-  for (int64_t idx = blockIdx.x * featuresize + threadIdx.x;
+  for (int64_t idx = static_cast<int64_t>(blockIdx.x) * featuresize +
+                     static_cast<int64_t>(threadIdx.x);
        idx * strides + offset < (blockIdx.x + 1) * featuresize;
        idx += blockDim.x) {
     // to check if the new position with offset is still in the same line;

--- a/paddle/phi/kernels/gpu/fill_diagonal_kernel.cu
+++ b/paddle/phi/kernels/gpu/fill_diagonal_kernel.cu
@@ -29,7 +29,8 @@ __global__ void fill_constant_kernel(const int64_t featuresize,
                                      int offset,
                                      T fillvar,
                                      int dims) {
-  for (int64_t idx = blockIdx.x * featuresize + threadIdx.x;
+  for (int64_t idx = static_cast<int64_t>(blockIdx.x) * featuresize +
+                     static_cast<int64_t>(threadIdx.x);
        idx * strides + offset < (blockIdx.x + 1) * featuresize;
        idx += blockDim.x) {
     // to check if the new position with offset is still in the same line;

--- a/paddle/phi/kernels/gpu/fused_token_prune_kernel.cu
+++ b/paddle/phi/kernels/gpu/fused_token_prune_kernel.cu
@@ -45,7 +45,9 @@ struct AttnMaskFunctor {
 
 __global__ void FillIndex(int64_t* indices, int num_raws, int num_cols) {
   int64_t num_threads = static_cast<int64_t>(num_raws) * num_cols;
-  int64_t tid = threadIdx.x + blockIdx.x * blockDim.x;
+  int64_t tid =
+      static_cast<int64_t>(threadIdx.x) +
+      static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x);
   int stride = blockDim.x * gridDim.x;
 
   for (; tid < num_threads; tid += stride) {
@@ -63,7 +65,9 @@ __global__ void TakeAlongAxis(const T* src,
                               int dst_num_cols,
                               int num_elements) {
   int64_t num_threads = static_cast<int64_t>(num_raws) * dst_num_cols;
-  int64_t tid = threadIdx.x + blockIdx.x * blockDim.x;
+  int64_t tid =
+      static_cast<int64_t>(threadIdx.x) +
+      static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x);
   int stride = blockDim.x * gridDim.x;
 
   for (; tid < num_threads; tid += stride) {

--- a/paddle/phi/kernels/gpu/graph_reindex_kernel.cu
+++ b/paddle/phi/kernels/gpu/graph_reindex_kernel.cu
@@ -279,7 +279,8 @@ __global__ void GetDstEdgeCUDAKernel(const int64_t num_rows,
   assert(blockDim.x == WARP_SIZE);
   assert(blockDim.y == BLOCK_WARPS);
 
-  int64_t out_row = blockIdx.x * TILE_SIZE + threadIdx.y;
+  int64_t out_row = static_cast<int64_t>(blockIdx.x) * TILE_SIZE +
+                    static_cast<int64_t>(threadIdx.y);
   const int64_t last_row =
       min(static_cast<int64_t>(blockIdx.x + 1) * TILE_SIZE, num_rows);
 

--- a/paddle/phi/kernels/gpu/graph_sample_neighbors_kernel.cu
+++ b/paddle/phi/kernels/gpu/graph_sample_neighbors_kernel.cu
@@ -73,7 +73,8 @@ __global__ void SampleKernel(const uint64_t rand_seed,
                              bool return_eids) {
   assert(blockDim.x == CTA_SIZE);
 
-  int64_t out_row = blockIdx.x * TILE_SIZE + threadIdx.y;
+  int64_t out_row = static_cast<int64_t>(blockIdx.x) * TILE_SIZE +
+                    static_cast<int64_t>(threadIdx.y);
   const int64_t last_row =
       min(static_cast<int64_t>(blockIdx.x + 1) * TILE_SIZE, num_nodes);
 #ifdef PADDLE_WITH_HIP
@@ -263,7 +264,8 @@ __global__ void GatherEdge(int k,
                            bool return_eids) {
   assert(blockDim.x == CTA_SIZE);
 
-  int64_t out_row = blockIdx.x * TILE_SIZE + threadIdx.y;
+  int64_t out_row = static_cast<int64_t>(blockIdx.x) * TILE_SIZE +
+                    static_cast<int64_t>(threadIdx.y);
   const int64_t last_row =
       min(static_cast<int64_t>(blockIdx.x + 1) * TILE_SIZE, num_rows);
 

--- a/paddle/phi/kernels/gpu/graph_send_ue_recv_funcs.h
+++ b/paddle/phi/kernels/gpu/graph_send_ue_recv_funcs.h
@@ -185,7 +185,8 @@ __global__ void ManipulateMeanGradCUDAKernelForMulX(const T* out_grad_data,
     int64_t tx =
         static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
         static_cast<int64_t>(threadIdx.x);
-    int64_t stride_x = blockDim.x * gridDim.x;
+    int64_t stride_x =
+        static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(gridDim.x);
 
     const T* out_grad_off = out_grad_data + src * l_len;
     const T* e_off = e_data + ty * r_len;
@@ -219,7 +220,8 @@ __global__ void ManipulateSumGradCUDAKernelForAddE(const T* out_grad_data,
     int64_t tx =
         static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
         static_cast<int64_t>(threadIdx.x);
-    int64_t stride_x = blockDim.x * gridDim.x;
+    int64_t stride_x =
+        static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(gridDim.x);
 
     T* e_grad_off = e_grad + ty * r_len;
     const T* out_grad_off = out_grad_data + dst * out_len;
@@ -255,7 +257,8 @@ __global__ void ManipulateSumGradCUDAKernelForMulE(const T* x_data,
     int64_t tx =
         static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
         static_cast<int64_t>(threadIdx.x);
-    int64_t stride_x = blockDim.x * gridDim.x;
+    int64_t stride_x =
+        static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(gridDim.x);
 
     const T* x_off = x_data + src * l_len;
     T* e_grad_off = e_grad + ty * r_len;
@@ -289,7 +292,8 @@ __global__ void ManipulateMeanGradCUDAKernelForAddE(const T* out_grad_data,
     int64_t tx =
         static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
         static_cast<int64_t>(threadIdx.x);
-    int64_t stride_x = blockDim.x * gridDim.x;
+    int64_t stride_x =
+        static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(gridDim.x);
 
     T* e_grad_off = e_grad + ty * r_len;
     const T* out_grad_off = out_grad_data + dst * out_len;
@@ -327,7 +331,8 @@ __global__ void ManipulateMeanGradCUDAKernelForMulE(const T* x_data,
     int64_t tx =
         static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
         static_cast<int64_t>(threadIdx.x);
-    int64_t stride_x = blockDim.x * gridDim.x;
+    int64_t stride_x =
+        static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(gridDim.x);
 
     const T* x_off = x_data + src * l_len;
     T* e_grad_off = e_grad + ty * r_len;
@@ -370,7 +375,8 @@ __global__ void ManipulateMinMaxGradCUDAKernelForAdd(const T* x_data,
     int64_t tx =
         static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
         static_cast<int64_t>(threadIdx.x);
-    int64_t stride_x = blockDim.x * gridDim.x;
+    int64_t stride_x =
+        static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(gridDim.x);
 
     const T* x_off = x_data + dst * x_len;
     const T* e_off = e_data + ty * e_len;
@@ -418,7 +424,8 @@ __global__ void ManipulateMinMaxGradCUDAKernelForMul(const T* x_data,
     int64_t tx =
         static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
         static_cast<int64_t>(threadIdx.x);
-    int64_t stride_x = blockDim.x * gridDim.x;
+    int64_t stride_x =
+        static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(gridDim.x);
 
     const T* x_off = x_data + dst * x_len;
     const T* e_off = e_data + ty * e_len;

--- a/paddle/phi/kernels/gpu/graph_send_ue_recv_funcs.h
+++ b/paddle/phi/kernels/gpu/graph_send_ue_recv_funcs.h
@@ -182,7 +182,9 @@ __global__ void ManipulateMeanGradCUDAKernelForMulX(const T* out_grad_data,
   while (ty < index_size) {
     IndexT src = src_indices[ty];
     IndexT dst = dst_indices[ty];
-    int64_t tx = blockIdx.x * blockDim.x + threadIdx.x;
+    int64_t tx =
+        static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
+        static_cast<int64_t>(threadIdx.x);
     int64_t stride_x = blockDim.x * gridDim.x;
 
     const T* out_grad_off = out_grad_data + src * l_len;
@@ -214,7 +216,9 @@ __global__ void ManipulateSumGradCUDAKernelForAddE(const T* out_grad_data,
 
   while (ty < index_size) {
     IndexT dst = dst_indices[ty];
-    int64_t tx = blockIdx.x * blockDim.x + threadIdx.x;
+    int64_t tx =
+        static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
+        static_cast<int64_t>(threadIdx.x);
     int64_t stride_x = blockDim.x * gridDim.x;
 
     T* e_grad_off = e_grad + ty * r_len;
@@ -248,7 +252,9 @@ __global__ void ManipulateSumGradCUDAKernelForMulE(const T* x_data,
   while (ty < index_size) {
     IndexT src = src_indices[ty];
     IndexT dst = dst_indices[ty];
-    int64_t tx = blockIdx.x * blockDim.x + threadIdx.x;
+    int64_t tx =
+        static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
+        static_cast<int64_t>(threadIdx.x);
     int64_t stride_x = blockDim.x * gridDim.x;
 
     const T* x_off = x_data + src * l_len;
@@ -280,7 +286,9 @@ __global__ void ManipulateMeanGradCUDAKernelForAddE(const T* out_grad_data,
 
   while (ty < index_size) {
     IndexT dst = dst_indices[ty];
-    int64_t tx = blockIdx.x * blockDim.x + threadIdx.x;
+    int64_t tx =
+        static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
+        static_cast<int64_t>(threadIdx.x);
     int64_t stride_x = blockDim.x * gridDim.x;
 
     T* e_grad_off = e_grad + ty * r_len;
@@ -316,7 +324,9 @@ __global__ void ManipulateMeanGradCUDAKernelForMulE(const T* x_data,
   while (ty < index_size) {
     IndexT src = src_indices[ty];
     IndexT dst = dst_indices[ty];
-    int64_t tx = blockIdx.x * blockDim.x + threadIdx.x;
+    int64_t tx =
+        static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
+        static_cast<int64_t>(threadIdx.x);
     int64_t stride_x = blockDim.x * gridDim.x;
 
     const T* x_off = x_data + src * l_len;
@@ -357,7 +367,9 @@ __global__ void ManipulateMinMaxGradCUDAKernelForAdd(const T* x_data,
   while (ty < index_size) {
     IndexT src = src_indices[ty];
     IndexT dst = dst_indices[ty];
-    int64_t tx = blockIdx.x * blockDim.x + threadIdx.x;
+    int64_t tx =
+        static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
+        static_cast<int64_t>(threadIdx.x);
     int64_t stride_x = blockDim.x * gridDim.x;
 
     const T* x_off = x_data + dst * x_len;
@@ -403,7 +415,9 @@ __global__ void ManipulateMinMaxGradCUDAKernelForMul(const T* x_data,
   while (ty < index_size) {
     IndexT src = src_indices[ty];
     IndexT dst = dst_indices[ty];
-    int64_t tx = blockIdx.x * blockDim.x + threadIdx.x;
+    int64_t tx =
+        static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
+        static_cast<int64_t>(threadIdx.x);
     int64_t stride_x = blockDim.x * gridDim.x;
 
     const T* x_off = x_data + dst * x_len;

--- a/paddle/phi/kernels/gpu/group_norm_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/group_norm_grad_kernel.cu
@@ -181,7 +181,10 @@ __global__ void GetScaleBiasGradientCUDAKernel(int64_t N,
                                                const AccT* db,
                                                T* d_scale,
                                                T* d_bias) {
-  for (int64_t c = blockIdx.x * blockDim.x + threadIdx.x; c < C;
+  for (int64_t c =
+           static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
+           static_cast<int64_t>(threadIdx.x);
+       c < C;
        c += gridDim.x * blockDim.x) {
     if (c < C) {
       const int G = group;

--- a/paddle/phi/kernels/gpu/group_norm_kernel.cu
+++ b/paddle/phi/kernels/gpu/group_norm_kernel.cu
@@ -223,7 +223,7 @@ __global__ void groupNormNDHWCSumSingerChannelKernel(
     return;
   }
   // The first activation loaded by that block.
-  int64_t dhwBegin = blockIdx.y * params.dhwPerBlock;
+  int64_t dhwBegin = static_cast<int64_t>(blockIdx.y) * params.dhwPerBlock;
   // The last activation loaded by that block.
   int64_t dhwEnd = min(dhwBegin + params.dhwPerBlock, params.dhw);
 
@@ -275,7 +275,7 @@ __global__ void groupNormNDHWCSumKernel(const GroupNormNDHWCParams<T> params) {
   }
   int32_t gj = ci / params.cPerGroup;
   int32_t cj = ci % params.cPerGroup;
-  int64_t dhwBegin = blockIdx.y * params.dhwPerBlock;
+  int64_t dhwBegin = static_cast<int64_t>(blockIdx.y) * params.dhwPerBlock;
   // The last activation loaded by that block.
   int64_t dhwEnd = min(dhwBegin + params.dhwPerBlock, params.dhw);
 
@@ -419,7 +419,8 @@ inline __device__ void GroupNormCompute(int64_t dhwBegin,
       phi::__2float<T>(*(reinterpret_cast<T const*>(params.beta) + ci));
   for (int64_t dhwi = dhwBegin; dhwi < dhwEnd; ++dhwi) {
     // The src/dst offset.
-    int64_t offset = blockIdx.z * params.dhwc + dhwi * params.c + ci;
+    int64_t offset =
+        static_cast<int64_t>(blockIdx.z) * params.dhwc + dhwi * params.c + ci;
     float src_data = phi::__2float<T>(params.srcX[offset]);
     if (params.srcR != nullptr) {
       auto gi = ci / params.cPerGroup;
@@ -461,7 +462,8 @@ inline __device__ void GroupNormCompute<phi::float16, 2>(
   // Iterate over the activations to compute the sums.
   for (int64_t dhwi = dhwBegin; dhwi < dhwEnd; ++dhwi) {
     // The src/dst offset.
-    int64_t offset = blockIdx.z * params.dhwc + dhwi * params.c + ci;
+    int64_t offset =
+        static_cast<int64_t>(blockIdx.z) * params.dhwc + dhwi * params.c + ci;
 
     // Fetch two channels per thread.
     __half2 h2 = *reinterpret_cast<__half2 const*>(&params.srcX[offset]);
@@ -516,7 +518,8 @@ inline __device__ void GroupNormCompute<__half, 2>(
   // Iterate over the activations to compute the sums.
   for (int64_t dhwi = dhwBegin; dhwi < dhwEnd; ++dhwi) {
     // The src/dst offset.
-    int64_t offset = blockIdx.z * params.dhwc + dhwi * params.c + ci;
+    int64_t offset =
+        static_cast<int64_t>(blockIdx.z) * params.dhwc + dhwi * params.c + ci;
 
     // Fetch two channels per thread.
     __half2 h2 = *reinterpret_cast<__half2 const*>(&params.srcX[offset]);
@@ -571,7 +574,8 @@ inline __device__ void GroupNormCompute<phi::bfloat16, 2>(
   // Iterate over the activations to compute the sums.
   for (int64_t dhwi = dhwBegin; dhwi < dhwEnd; ++dhwi) {
     // The src/dst offset.
-    int64_t offset = blockIdx.z * params.dhwc + dhwi * params.c + ci;
+    int64_t offset =
+        static_cast<int64_t>(blockIdx.z) * params.dhwc + dhwi * params.c + ci;
 
     // Fetch two channels per thread.
     __nv_bfloat162 h2 =
@@ -646,7 +650,7 @@ __global__ void groupNormNDHWCScaleKernel(
   float invStdDev = rsqrtf(var + params.eps);
 
   // The first activation loaded by that block.
-  int64_t dhwBegin = blockIdx.y * params.dhwPerBlock;
+  int64_t dhwBegin = static_cast<int64_t>(blockIdx.y) * params.dhwPerBlock;
   // The last activation loaded by that block.
   int64_t dhwEnd = min(dhwBegin + params.dhwPerBlock, params.dhw);
   GroupNormCompute<T, THREADS_PER_CHANNEL>(

--- a/paddle/phi/kernels/gpu/group_norm_utils.h
+++ b/paddle/phi/kernels/gpu/group_norm_utils.h
@@ -92,7 +92,7 @@ __device__ __forceinline__ void ThreadReduce(phi::Array<const T*, Num> arrs,
       y += blockDim.x;
     }
   }
-  int64_t remain = size % (VecSize * blockDim.x);
+  int64_t remain = size % (VecSize * static_cast<int64_t>(blockDim.x));
 
   T ins_x[VecSize];
   T ins_y[VecSize];

--- a/paddle/phi/kernels/gpu/instance_norm_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/instance_norm_grad_kernel.cu
@@ -34,7 +34,8 @@ static __global__ void GradComputeDX(const T *dy,
                                      const int C,
                                      const int64_t sample_size,
                                      T *dx) {
-  int64_t beg_idx = blockIdx.x * sample_size + threadIdx.x;
+  int64_t beg_idx = static_cast<int64_t>(blockIdx.x) * sample_size +
+                    static_cast<int64_t>(threadIdx.x);
   int64_t end_idx = (blockIdx.x + 1) * sample_size;
   int ncid = blockIdx.x;
   int c = ncid % C;
@@ -92,7 +93,8 @@ __global__ void DoubleGradComputeDX(const T *x,
                                     int64_t sample_size,
                                     const double epsilon,
                                     T *dx) {
-  int64_t beg_idx = blockIdx.x * sample_size + threadIdx.x;
+  int64_t beg_idx = static_cast<int64_t>(blockIdx.x) * sample_size +
+                    static_cast<int64_t>(threadIdx.x);
   int64_t end_idx = (blockIdx.x + 1) * sample_size;
   int ncid = blockIdx.x;
   int c = ncid % C;
@@ -192,7 +194,8 @@ __global__ void DoubleGradComputeDDY(const T *x,
                                      int64_t sample_size,
                                      const double epsilon,
                                      T *ddy) {
-  int64_t beg_idx = blockIdx.x * sample_size + threadIdx.x;
+  int64_t beg_idx = static_cast<int64_t>(blockIdx.x) * sample_size +
+                    static_cast<int64_t>(threadIdx.x);
   int64_t end_idx = (blockIdx.x + 1) * sample_size;
   int ncid = blockIdx.x;
   int c = ncid % C;
@@ -255,7 +258,8 @@ __global__ void DoubleGradComputeDScale(const T *x,
                                         int64_t sample_size,
                                         const double epsilon,
                                         AccT *dscale) {
-  int64_t beg_idx = blockIdx.x * sample_size + threadIdx.x;
+  int64_t beg_idx = static_cast<int64_t>(blockIdx.x) * sample_size +
+                    static_cast<int64_t>(threadIdx.x);
   int64_t end_idx = (blockIdx.x + 1) * sample_size;
   int ncid = blockIdx.x;
   int c = ncid % C;

--- a/paddle/phi/kernels/gpu/instance_norm_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/instance_norm_grad_kernel.cu
@@ -36,7 +36,7 @@ static __global__ void GradComputeDX(const T *dy,
                                      T *dx) {
   int64_t beg_idx = static_cast<int64_t>(blockIdx.x) * sample_size +
                     static_cast<int64_t>(threadIdx.x);
-  int64_t end_idx = (blockIdx.x + 1) * sample_size;
+  int64_t end_idx = (static_cast<int64_t>(blockIdx.x) + 1) * sample_size;
   int ncid = blockIdx.x;
   int c = ncid % C;
   BatchNormParamType<T> mean_val = mean[ncid];
@@ -95,7 +95,7 @@ __global__ void DoubleGradComputeDX(const T *x,
                                     T *dx) {
   int64_t beg_idx = static_cast<int64_t>(blockIdx.x) * sample_size +
                     static_cast<int64_t>(threadIdx.x);
-  int64_t end_idx = (blockIdx.x + 1) * sample_size;
+  int64_t end_idx = (static_cast<int64_t>(blockIdx.x) + 1) * sample_size;
   int ncid = blockIdx.x;
   int c = ncid % C;
 
@@ -196,7 +196,7 @@ __global__ void DoubleGradComputeDDY(const T *x,
                                      T *ddy) {
   int64_t beg_idx = static_cast<int64_t>(blockIdx.x) * sample_size +
                     static_cast<int64_t>(threadIdx.x);
-  int64_t end_idx = (blockIdx.x + 1) * sample_size;
+  int64_t end_idx = (static_cast<int64_t>(blockIdx.x) + 1) * sample_size;
   int ncid = blockIdx.x;
   int c = ncid % C;
   AccT mean_val = mean[ncid];
@@ -260,7 +260,7 @@ __global__ void DoubleGradComputeDScale(const T *x,
                                         AccT *dscale) {
   int64_t beg_idx = static_cast<int64_t>(blockIdx.x) * sample_size +
                     static_cast<int64_t>(threadIdx.x);
-  int64_t end_idx = (blockIdx.x + 1) * sample_size;
+  int64_t end_idx = (static_cast<int64_t>(blockIdx.x) + 1) * sample_size;
   int ncid = blockIdx.x;
   int c = ncid % C;
   AccT mean_val = mean[ncid];

--- a/paddle/phi/kernels/gpu/interpolate_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/interpolate_grad_kernel.cu
@@ -305,7 +305,7 @@ __global__ void KeBilinearInterpBwShareMemory(T* in,
 
     s_data[0][threadIdx.x] = static_cast<MT>(0);
     s_data[1][threadIdx.x] = static_cast<MT>(0);
-    int64_t remain = nthreads - (tid & (-blockDim.x));
+    int64_t remain = nthreads - (tid & (-static_cast<int64_t>(blockDim.x)));
     int64_t in_top_max_index =
         phi::funcs::BlockReduceMax(top_right_index, FINAL_MASK);
     int64_t in_bot_max_index =

--- a/paddle/phi/kernels/gpu/linspace_kernel.cu
+++ b/paddle/phi/kernels/gpu/linspace_kernel.cu
@@ -25,7 +25,9 @@ namespace phi {
 template <typename T, typename StepT>
 __global__ void LinspaceKernelInner(
     T start, T stop, StepT step, int64_t size, T* out) {
-  int64_t index = blockIdx.x * blockDim.x + threadIdx.x;
+  int64_t index =
+      static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
+      static_cast<int64_t>(threadIdx.x);
 
   for (; index < size; index += blockDim.x * gridDim.x) {
     if (index < size / 2) {
@@ -40,7 +42,9 @@ __global__ void LinspaceKernelInner(
 template <typename T>
 __global__ void LinspaceKernelInner(
     T start, T stop, T step, int64_t size, T* out) {
-  int64_t index = blockIdx.x * blockDim.x + threadIdx.x;
+  int64_t index =
+      static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
+      static_cast<int64_t>(threadIdx.x);
 
   for (; index < size; index += blockDim.x * gridDim.x) {
     if (index < size / 2) {

--- a/paddle/phi/kernels/gpu/logspace_kernel.cu
+++ b/paddle/phi/kernels/gpu/logspace_kernel.cu
@@ -31,7 +31,9 @@ __global__ void LogspaceKernelInner(
   MPType mt_stop = static_cast<MPType>(stop);
   MPType mt_base = static_cast<MPType>(base);
 
-  int64_t index = blockIdx.x * blockDim.x + threadIdx.x;
+  int64_t index =
+      static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
+      static_cast<int64_t>(threadIdx.x);
 
   for (; index < size; index += blockDim.x * gridDim.x) {
     if (index < size / 2) {

--- a/paddle/phi/kernels/gpu/nll_loss.h
+++ b/paddle/phi/kernels/gpu/nll_loss.h
@@ -143,7 +143,8 @@ __device__ void reduceNValuesInBlock(T* smem,
       threadVals[i] = threadIdx.x < numVals ? threadVals[i] : init;
     }
 
-    for (int64_t i = warpSize + threadIdx.x; i < numVals; i += warpSize) {
+    for (int64_t i = warpSize + static_cast<int64_t>(threadIdx.x); i < numVals;
+         i += warpSize) {
 #pragma unroll
       for (int64_t j = 0; j < N; ++j) {
         threadVals[j] = reduceOp(threadVals[j], smem[j * numVals + i]);
@@ -246,10 +247,10 @@ __global__ void GPUNLLLossForward2D_with_reduce(T* out_data,
   *out_data = 0;
   *total_weight_data = 0;
 
-  int64_t sample = blockIdx.x / blocks_per_sample;
+  int64_t sample = static_cast<int64_t>(blockIdx.x) / blocks_per_sample;
   int64_t toffset = sample * map_nelem;
   int64_t ioffset = sample * map_nelem * n_classes;
-  int64_t step = blockDim.x * blocks_per_sample;
+  int64_t step = static_cast<int64_t>(blockDim.x) * blocks_per_sample;
   for (i = (blockIdx.x % blocks_per_sample) * blockDim.x + threadIdx.x;
        i < map_nelem;
        i += step) {
@@ -370,8 +371,8 @@ __global__ void GPUNLLLossBackward2D_with_reduce(
   }
   int64_t i;
   const T norm = size_average ? (T)(1 / *total_weight_data) : (T)1;
-  int64_t sample = blockIdx.x / blocks_per_sample;
-  int64_t step = blockDim.x * blocks_per_sample;
+  int64_t sample = static_cast<int64_t>(blockIdx.x) / blocks_per_sample;
+  int64_t step = static_cast<int64_t>(blockDim.x) * blocks_per_sample;
   int64_t toffset = sample * map_nelem;
   int64_t ioffset = sample * map_nelem * n_classes;
   for (i = (blockIdx.x % blocks_per_sample) * blockDim.x + threadIdx.x;

--- a/paddle/phi/kernels/gpu/quantize_linear_kernel.cu
+++ b/paddle/phi/kernels/gpu/quantize_linear_kernel.cu
@@ -26,7 +26,9 @@ namespace phi {
 template <typename T>
 __global__ void KeDequantize(
     const T* in, const T* scale, T max_range, int64_t num, T* out) {
-  int64_t idx = threadIdx.x + blockIdx.x * blockDim.x;
+  int64_t idx =
+      static_cast<int64_t>(threadIdx.x) +
+      static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x);
   for (int64_t i = idx; i < num; i += blockDim.x * gridDim.x) {
     out[i] = in[i] * scale[0] / max_range;
   }
@@ -40,7 +42,9 @@ __global__ void DequantizeOneScaleQuantAxisN(const T* in,
                                              const int n_scales,
                                              const int quant_stride,
                                              T* out) {
-  int64_t idx = blockDim.x * blockIdx.x + threadIdx.x;
+  int64_t idx =
+      static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(blockIdx.x) +
+      static_cast<int64_t>(threadIdx.x);
   for (int64_t i = idx; i < num; i += blockDim.x * gridDim.x) {
     T s = scale[(i / quant_stride) % n_scales];
     out[i] = in[i] * s / max_range;

--- a/paddle/phi/kernels/gpu/repeat_interleave_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/repeat_interleave_grad_kernel.cu
@@ -42,7 +42,9 @@ __global__ void index_select_grad_cuda_kernel(const T* output_grad,
                                               int64_t stride,
                                               int64_t size,
                                               int64_t delta) {
-  int64_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  int64_t idx =
+      static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
+      static_cast<int64_t>(threadIdx.x);
   if (idx >= output_grad_numel) {
     return;
   }

--- a/paddle/phi/kernels/gpu/send_uv_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/send_uv_grad_kernel.cu
@@ -40,7 +40,9 @@ __global__ void GraphSendUVGradCUDAKernel(const T* out_grad,
   while (ty < index_size) {
     IndexT src = src_indices[ty];
     IndexT dst = dst_indices[ty];
-    int64_t tx = blockIdx.x * blockDim.x + threadIdx.x;
+    int64_t tx =
+        static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
+        static_cast<int64_t>(threadIdx.x);
     int64_t stride_x = blockDim.x * gridDim.x;
 
     const T* out_grad_off = out_grad + ty * slice_size;

--- a/paddle/phi/kernels/gpu/send_uv_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/send_uv_grad_kernel.cu
@@ -43,7 +43,8 @@ __global__ void GraphSendUVGradCUDAKernel(const T* out_grad,
     int64_t tx =
         static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
         static_cast<int64_t>(threadIdx.x);
-    int64_t stride_x = blockDim.x * gridDim.x;
+    int64_t stride_x =
+        static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(gridDim.x);
 
     const T* out_grad_off = out_grad + ty * slice_size;
     T* x_grad_off = x_grad + dst * slice_size;

--- a/paddle/phi/kernels/gpu/send_uv_kernel.cu
+++ b/paddle/phi/kernels/gpu/send_uv_kernel.cu
@@ -46,7 +46,9 @@ __global__ void GraphSendUVCUDAKernel(const T* x_data,
   while (ty < index_size) {
     IndexT src = src_indices[ty];
     IndexT dst = dst_indices[ty];
-    int64_t tx = blockIdx.x * blockDim.x + threadIdx.x;
+    int64_t tx =
+        static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
+        static_cast<int64_t>(threadIdx.x);
     int64_t stride_x = blockDim.x * gridDim.x;
 
     const T* x_off = x_data + src * x_len;

--- a/paddle/phi/kernels/gpu/send_uv_kernel.cu
+++ b/paddle/phi/kernels/gpu/send_uv_kernel.cu
@@ -49,7 +49,8 @@ __global__ void GraphSendUVCUDAKernel(const T* x_data,
     int64_t tx =
         static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
         static_cast<int64_t>(threadIdx.x);
-    int64_t stride_x = blockDim.x * gridDim.x;
+    int64_t stride_x =
+        static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(gridDim.x);
 
     const T* x_off = x_data + src * x_len;
     const T* y_off = y_data + dst * y_len;

--- a/paddle/phi/kernels/gpu/strided_copy_kernel.cu
+++ b/paddle/phi/kernels/gpu/strided_copy_kernel.cu
@@ -321,7 +321,9 @@ __global__ void StridedCopyDefaultFunc(
     phi::Array<int64_t, phi::DDim::kMaxRank + 1> output_stride,
     phi::Array<int64_t, phi::DDim::kMaxRank + 1> dims,
     const int64_t numel) {
-  int64_t gid = blockIdx.x * blockDim.x + threadIdx.x;
+  int64_t gid =
+      static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
+      static_cast<int64_t>(threadIdx.x);
 #pragma unroll
   for (int64_t i = gid; i < numel; i += blockDim.x * gridDim.x) {
     int64_t input_offset = 0;
@@ -383,11 +385,17 @@ __global__ void Strided2ContiguousCaseZeroFunc(
     phi::Array<int64_t, phi::DDim::kMaxRank + 1> input_stride,
     T* output_data) {
   int64_t input_offset = 0;
-  int64_t output_offset = (blockIdx.z * gridDim.y * gridDim.x +
-                           blockIdx.y * gridDim.x + blockIdx.x) *
-                              blockDim.z * blockDim.y * blockDim.x +
-                          threadIdx.z * blockDim.y * blockDim.x +
-                          threadIdx.y * blockDim.x + threadIdx.x;
+  int64_t output_offset =
+      (static_cast<int64_t>(blockIdx.z) * static_cast<int64_t>(gridDim.y) *
+           static_cast<int64_t>(gridDim.x) +
+       static_cast<int64_t>(blockIdx.y) * static_cast<int64_t>(gridDim.x) +
+       static_cast<int64_t>(blockIdx.x)) *
+          static_cast<int64_t>(blockDim.z) * static_cast<int64_t>(blockDim.y) *
+          static_cast<int64_t>(blockDim.x) +
+      static_cast<int64_t>(threadIdx.z) * static_cast<int64_t>(blockDim.y) *
+          static_cast<int64_t>(blockDim.x) +
+      static_cast<int64_t>(threadIdx.y) * static_cast<int64_t>(blockDim.x) +
+      static_cast<int64_t>(threadIdx.x);
   int64_t coordinate[6] = {threadIdx.x,
                            threadIdx.y,
                            threadIdx.z,
@@ -471,10 +479,16 @@ __global__ void Strided2ContiguousCaseOneFunc(
     T* out_data,
     phi::Array<int64_t, 6> dims,
     const int64_t x_max) {
-  int64_t x = blockIdx.x * blockDim.x + threadIdx.x;
+  int64_t x =
+      static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
+      static_cast<int64_t>(threadIdx.x);
   if (x < x_max) {
     int64_t input_offset = 0;
-    int64_t output_offset = (blockIdx.z * gridDim.y + blockIdx.y) * x_max + x;
+    int64_t output_offset =
+        (static_cast<int64_t>(blockIdx.z) * static_cast<int64_t>(gridDim.y) +
+         static_cast<int64_t>(blockIdx.y)) *
+            x_max +
+        x;
 
     int64_t reg_dims[6] = {
         dims[0], dims[1], dims[2], dims[3], dims[4], dims[5]};
@@ -658,7 +672,9 @@ __global__ void Strided2ContiguousDefaultFunc(
     T* output_data,
     Array<int64_t, phi::DDim::kMaxRank + 1> dims,
     const int64_t numel) {
-  int64_t gid = blockIdx.x * blockDim.x + threadIdx.x;
+  int64_t gid =
+      static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
+      static_cast<int64_t>(threadIdx.x);
 #pragma unroll
   for (int64_t i = gid; i < numel; i += blockDim.x * gridDim.x) {
     int64_t input_offset = 0;

--- a/paddle/phi/kernels/impl/renorm_impl.h
+++ b/paddle/phi/kernels/impl/renorm_impl.h
@@ -178,7 +178,9 @@ __global__ void RenormKernelFunc3(int64_t size,
                                   T* dim_value,
                                   float p,
                                   float max_norm) {
-  int64_t i = ((int64_t)blockIdx.x) * blockDim.x + threadIdx.x;
+  int64_t i =
+      static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
+      static_cast<int64_t>(threadIdx.x);
   if (i < size) {
     T temp = pow(dim_value[i], (T)(1.0 / p));
     dim_value[i] = 1.0;
@@ -193,7 +195,9 @@ __global__ void RenormKernelFunc4(const T* x_data,
                                   T* dim_value,
                                   int64_t dimension_each,
                                   int64_t dim_divisor) {
-  int64_t i = ((int64_t)blockIdx.x) * blockDim.x + threadIdx.x;
+  int64_t i = ((int64_t) static_cast<int64_t>(blockIdx.x)) *
+                  static_cast<int64_t>(blockDim.x) +
+              static_cast<int64_t>(threadIdx.x);
   auto dim_index = i / dim_divisor % dimension_each;
   if (i < size) {
     if (dim_value[dim_index] < 1.0)
@@ -208,7 +212,9 @@ __global__ void RenormElementwisePow(const T* x_data,
                                      T* pow_value,
                                      int64_t size,
                                      float p) {
-  int64_t i = ((int64_t)blockIdx.x) * blockDim.x + threadIdx.x;
+  int64_t i = ((int64_t) static_cast<int64_t>(blockIdx.x)) *
+                  static_cast<int64_t>(blockDim.x) +
+              static_cast<int64_t>(threadIdx.x);
   if (i < size) {
     pow_value[i] = pow(abs(x_data[i]), (T)p);
   }
@@ -223,7 +229,9 @@ __global__ void RenormGradKernelFunc1(const T* x_data,
                                       int64_t dimension_each,
                                       float p,
                                       int64_t dim_divisor) {
-  int64_t i = ((int64_t)blockIdx.x) * blockDim.x + threadIdx.x;
+  int64_t i = ((int64_t) static_cast<int64_t>(blockIdx.x)) *
+                  static_cast<int64_t>(blockDim.x) +
+              static_cast<int64_t>(threadIdx.x);
   auto dim_index = i / dim_divisor % dimension_each;
   if (i < size) {
     pow_value[i] = pow(abs(x_data[i]), (T)p);
@@ -243,7 +251,9 @@ __global__ void RenormGradKernelFunc2(const T* x_data,
                                       float p,
                                       float max_norm,
                                       int64_t dim_divisor) {
-  int64_t i = ((int64_t)blockIdx.x) * blockDim.x + threadIdx.x;
+  int64_t i = ((int64_t) static_cast<int64_t>(blockIdx.x)) *
+                  static_cast<int64_t>(blockDim.x) +
+              static_cast<int64_t>(threadIdx.x);
   auto dim_index = i / dim_divisor % dimension_each;
   if (i < dimension_each) {
     dim_power_sum[i] = 0;

--- a/paddle/phi/kernels/impl/renorm_impl.h
+++ b/paddle/phi/kernels/impl/renorm_impl.h
@@ -195,9 +195,9 @@ __global__ void RenormKernelFunc4(const T* x_data,
                                   T* dim_value,
                                   int64_t dimension_each,
                                   int64_t dim_divisor) {
-  int64_t i = ((int64_t) static_cast<int64_t>(blockIdx.x)) *
-                  static_cast<int64_t>(blockDim.x) +
-              static_cast<int64_t>(threadIdx.x);
+  int64_t i =
+      static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
+      static_cast<int64_t>(threadIdx.x);
   auto dim_index = i / dim_divisor % dimension_each;
   if (i < size) {
     if (dim_value[dim_index] < 1.0)
@@ -229,9 +229,9 @@ __global__ void RenormGradKernelFunc1(const T* x_data,
                                       int64_t dimension_each,
                                       float p,
                                       int64_t dim_divisor) {
-  int64_t i = ((int64_t) static_cast<int64_t>(blockIdx.x)) *
-                  static_cast<int64_t>(blockDim.x) +
-              static_cast<int64_t>(threadIdx.x);
+  int64_t i =
+      static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
+      static_cast<int64_t>(threadIdx.x);
   auto dim_index = i / dim_divisor % dimension_each;
   if (i < size) {
     pow_value[i] = pow(abs(x_data[i]), (T)p);
@@ -251,9 +251,9 @@ __global__ void RenormGradKernelFunc2(const T* x_data,
                                       float p,
                                       float max_norm,
                                       int64_t dim_divisor) {
-  int64_t i = ((int64_t) static_cast<int64_t>(blockIdx.x)) *
-                  static_cast<int64_t>(blockDim.x) +
-              static_cast<int64_t>(threadIdx.x);
+  int64_t i =
+      static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
+      static_cast<int64_t>(threadIdx.x);
   auto dim_index = i / dim_divisor % dimension_each;
   if (i < dimension_each) {
     dim_power_sum[i] = 0;

--- a/paddle/phi/kernels/primitive/datamover_primitives.h
+++ b/paddle/phi/kernels/primitive/datamover_primitives.h
@@ -249,7 +249,7 @@ __device__ __forceinline__ void ReadData(T* dst,
                                          const T* __restrict__ src,
                                          int64_t num) {
   if (IsBoundary) {  // blockDim.x * NX > num
-    int64_t thread_offset = threadIdx.x * NX;
+    int64_t thread_offset = static_cast<int64_t>(threadIdx.x) * NX;
 #pragma unroll
     for (int idx = 0; idx < NX; ++idx) {
       if (idx + thread_offset < num) {
@@ -259,7 +259,8 @@ __device__ __forceinline__ void ReadData(T* dst,
   } else {  // blockDim,x * NX < num
     constexpr int kVectorSize = (NX % 4 == 0) ? 4 : (NX % 2 == 0) ? 2 : 1;
     constexpr int kVectorsPerThread = NX / kVectorSize;
-    int64_t thread_offset = threadIdx.x * kVectorsPerThread;
+    int64_t thread_offset =
+        static_cast<int64_t>(threadIdx.x) * kVectorsPerThread;
 
     using VecType = details::VectorType<T, kVectorSize>;
     const VecType* vec_input = reinterpret_cast<const VecType*>(src);
@@ -557,7 +558,7 @@ __device__ __forceinline__ void WriteData(T* dst,
                                           T* __restrict__ src,
                                           int64_t num) {
   if (IsBoundary) {
-    int64_t thread_offset = threadIdx.x * NX;
+    int64_t thread_offset = static_cast<int64_t>(threadIdx.x) * NX;
 #pragma unroll
     for (int idx = 0; idx < NX; ++idx) {
       if ((thread_offset + idx) < num) {
@@ -569,7 +570,8 @@ __device__ __forceinline__ void WriteData(T* dst,
     constexpr int kVectorSize = (NX % 4 == 0) ? 4 : (NX % 2 == 0) ? 2 : 1;
     constexpr int kVectorsPerThread = NX / kVectorSize;
 
-    int64_t thread_offset = threadIdx.x * kVectorsPerThread;
+    int64_t thread_offset =
+        static_cast<int64_t>(threadIdx.x) * kVectorsPerThread;
     using VecType = details::VectorType<T, kVectorSize>;
     VecType* vec_dst = reinterpret_cast<VecType*>(dst);
     VecType vec_temp[kVectorsPerThread];
@@ -850,7 +852,7 @@ __device__ __forceinline__ void ReadDataBc(
 template <typename T, int NX, int NY>
 __device__ __forceinline__ void InitWithDataIndex(T* dst,
                                                   int64_t block_offset) {
-  int64_t thread_offset = block_offset + threadIdx.x * NX;
+  int64_t thread_offset = block_offset + static_cast<int64_t>(threadIdx.x) * NX;
 #pragma unroll
   for (int nx = 0; nx < NX; ++nx) {
     dst[nx] = static_cast<T>(thread_offset + nx);

--- a/sgconfig.yml
+++ b/sgconfig.yml
@@ -2,3 +2,5 @@ ruleDirs:
   - ci/rules
 testConfigs:
   - testDir: ci/rule-tests
+languageGlobs:
+  cpp: ['*.c', '*.cc', '*.cpp', '*.cu', '*.h', '*.cuh']


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
本PR在引入了 no-int64-type-cuda-index-without-cast rule。确保定义int64类型变量时，如果通过threadIdx,blockIdx等计算得到，必须保证使用了 static_cast<int64_t>，否则认为是有整数溢出风险。

目前检测到 177 个现有问题（0误检率），已全部修复。


有一个 int64_t i = ((int64_t) static_cast<int64_t>(blockIdx.x)) 没检查出来，下个PR修。

pcard-93269