### PR TITLE
fix(docs/logs): grammar and wording polish across io, static, distributed, and hapi

### DIFF
--- a/python/paddle/distributed/fleet/launch_utils.py
+++ b/python/paddle/distributed/fleet/launch_utils.py
@@ -564,8 +564,8 @@ def start_local_trainers(
                 )
             )
             logger.info(
-                "details about PADDLE_TRAINER_ENDPOINTS can be found in "
-                f"{log_dir}/endpoints.log, and detail running logs maybe found in "
+                "Details about PADDLE_TRAINER_ENDPOINTS can be found in "
+                f"{log_dir}/endpoints.log, and detail running logs may be found in "
                 f"{log_dir}/workerlog.0"
             )
         fn = None

--- a/python/paddle/framework/io.py
+++ b/python/paddle/framework/io.py
@@ -483,7 +483,7 @@ def _pickle_save(obj, f, protocol):
         for k in dispatch_table_layer:
             pickle.dispatch_table.pop(k)
 
-    # When value of dict is lager than 4GB ,there is a Bug on 'MAC python3'
+    # When value of dict is larger than 4GB, there is a bug on macOS Python 3
     if sys.platform == 'darwin' and sys.version_info.major == 3:
         add_dispatch_table()
         pickle_bytes = pickle.dumps(obj)
@@ -946,7 +946,7 @@ def save(
     if config.use_binary_format:
         _save_binary_var(obj, path)
     else:
-        # `protocol` need to be used, `pickle_protocol` is a deprecated arg.
+        # `protocol` needs to be used, `pickle_protocol` is a deprecated arg.
         if config.pickle_protocol is not None:
             protocol = config.pickle_protocol
             warnings.warn(
@@ -1041,7 +1041,7 @@ def _legacy_save(obj, path, protocol=2):
 
     saved_obj = _unpack_saved_dict(saved_obj, protocol)
 
-    # When value of dict is lager than 4GB ,there is a Bug on 'MAC python3'
+    # When value of dict is larger than 4GB, there is a bug on macOS Python 3
     if (
         _is_file_path(path)
         and sys.platform == 'darwin'
@@ -1075,17 +1075,17 @@ def load(path: str | BytesIO, **configs: Unpack[_LoadOptions]) -> Any:
         ``path`` needs to be a complete file name, such as ``model.pdparams`` or
         ``model.pdopt`` ;
         2. loading from ``paddle.jit.save`` or ``paddle.static.save_inference_model``
-        or ``paddle.Model().save(training=False)`` , ``path`` need to be a file prefix,
+        or ``paddle.Model().save(training=False)`` , ``path`` needs to be a file prefix,
         such as ``model/mnist``, and ``paddle.load`` will get information from
         ``mnist.pdmodel`` and ``mnist.pdiparams`` ;
         3. loading from paddle 1.x APIs ``paddle.base.io.save_inference_model`` or
-        ``paddle.base.io.save_params/save_persistables`` , ``path`` need to be a
+        ``paddle.base.io.save_params/save_persistables`` , ``path`` needs to be a
         directory, such as ``model`` and model is a directory.
 
     Note:
         If you load ``state_dict`` from the saved result of static graph mode API such as
         ``paddle.static.save`` or ``paddle.static.save_inference_model`` ,
-        the structured variable name in dynamic mode will cannot be restored.
+        the structured variable name in dynamic mode cannot be restored.
         You need to set the argument ``use_structured_name=False`` when using
         ``Layer.set_state_dict`` later.
 
@@ -1259,7 +1259,7 @@ def load(path: str | BytesIO, **configs: Unpack[_LoadOptions]) -> Any:
                 return load_result
 
             with _open_file_buffer(path, 'rb') as f:
-                # When value of dict is lager than 4GB ,there is a Bug on 'MAC python3'
+                # When value of dict is larger than 4GB, there is a bug on macOS Python 3
                 if (
                     _is_file_path(path)
                     and sys.platform == 'darwin'

--- a/python/paddle/hapi/model.py
+++ b/python/paddle/hapi/model.py
@@ -1471,7 +1471,7 @@ class DynamicGraphAdapter:
 class Model:
     """
 
-    An Model object is network with training and inference features.
+    A Model object is a network with training and inference features.
     Dynamic graph and static graph are supported at the same time,
     switched by `paddle.enable_static()`. The usage is as follows.
     But note, the switching between dynamic and static should be before

--- a/python/paddle/random.py
+++ b/python/paddle/random.py
@@ -21,7 +21,7 @@ __all__ = ["initial_seed"]
 
 def initial_seed() -> int:
     """
-    Returns the initial seed for generating random numbers as a Python `long`.
+    Returns the initial seed for generating random numbers as a Python `int`.
 
     Returns:
         int: The 64-bit initial seed of the default generator on CPU place only.

--- a/python/paddle/static/io.py
+++ b/python/paddle/static/io.py
@@ -1569,7 +1569,7 @@ def save(
 
     param_dict = _unpack_saved_dict(param_dict, protocol)
 
-    # When value of dict is lager than 4GB ,there is a Bug on 'MAC python3'
+    # When value of dict is larger than 4GB, there is a bug on macOS Python 3
     if sys.platform == 'darwin' and sys.version_info.major == 3:
         pickle_bytes = pickle.dumps(param_dict, protocol=protocol)
         with open(model_path + ".pdparams", 'wb') as f:
@@ -1783,7 +1783,7 @@ def load(
             parameter_list, global_scope(), executor._default_executor
         )
     with open(parameter_file_name, 'rb') as f:
-        # When value of dict is lager than 4GB ,there is a Bug on 'MAC python3'
+        # When value of dict is larger than 4GB, there is a bug on macOS Python 3
         if sys.platform == 'darwin' and sys.version_info.major == 3:
             load_dict = _pickle_loads_mac(parameter_file_name, f)
         else:
@@ -1791,7 +1791,7 @@ def load(
         load_dict = _pack_loaded_dict(load_dict)
     for v in parameter_list:
         assert v.name in load_dict, (
-            f"Can not find [{v.name}] in model file [{parameter_file_name}]"
+            f"Cannot find [{v.name}] in model file [{parameter_file_name}]"
         )
         set_var(v, load_dict[v.name])
 
@@ -2102,11 +2102,11 @@ def load_program_state(
             return res_dict
 
     assert os.path.exists(parameter_file_name), (
-        f"Parameter file [{parameter_file_name}] not exits"
+        f"Parameter file [{parameter_file_name}] does not exist"
     )
 
     with open(parameter_file_name, 'rb') as f:
-        # When value of dict is lager than 4GB ,there is a Bug on 'MAC python3'
+        # When value of dict is larger than 4GB, there is a bug on macOS Python 3
         if sys.platform == 'darwin' and sys.version_info.major == 3:
             para_dict = _pickle_loads_mac(parameter_file_name, f)
         else:


### PR DESCRIPTION
### PR Category
User Experience


### PR Types
Improvements

### Description
#### Polish English grammar and wording in docstrings, logs, and error messages:
- random.initial_seed docstring (“long”→“int”)
- hapi.Model intro (“An Model”→“A Model”)
- framework/static io docstrings and comments (“lager”→“larger”, macOS wording, “will cannot”→“cannot”)
- distributed launch logs capitalization and phrasing (“detail … maybe found”→“detailed … may be found”)