### PR TITLE
[CI] remove `pip install cmake==3.27.7`  in `.github/workflows/_Mac.yml`

### DIFF
--- a/.github/workflows/_Mac.yml
+++ b/.github/workflows/_Mac.yml
@@ -87,8 +87,6 @@ jobs:
           set -x
           cd ${work_dir}/Paddle
           source ~/.zshrc
-          python3.10 -m pip uninstall cmake -y || true
-          python3.10 -m pip install cmake==3.27.7
           bash -x ${work_dir}/Paddle/ci/run_setup.sh bdist_wheel ${parallel_number:-""}
           EXCODE=$?
           exit $EXCODE


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
删除 mac 流水线中显式安装特定版本 cmake 的逻辑，降低代理压力，之前设置是因为不支持 cmake4.0 ，且环境被修改为 4.0，现在没有这个问题

cc @SigureMo 