### PR TITLE
add blockmask to flashmask

### DIFF
--- a/paddle/phi/backends/dynload/flashmaskv2.h
+++ b/paddle/phi/backends/dynload/flashmaskv2.h
@@ -225,6 +225,10 @@ FLASHMASK_V2_HANDLE_ROUTINE(ut_start_ptr)
 FLASHMASK_V2_HANDLE_ROUTINE(ut_end_ptr)
 FLASHMASK_V2_HANDLE_ROUTINE(flashmask_maxmin_ptr)
 
+FLASHMASK_V2_HANDLE_ROUTINE(m_block_dim)
+FLASHMASK_V2_HANDLE_ROUTINE(n_block_dim)
+FLASHMASK_V2_HANDLE_ROUTINE(block_mask_ptr)
+
 #define FLASHMASK_V2_BWD_HANDLE_ROUTINE(type, member)                          \
   DECLARE_DYNAMIC_LOAD_FLASHMASK_V2_WRAP(flashmaskv2_bwd_params_get_##member); \
   DECLARE_DYNAMIC_LOAD_FLASHMASK_V2_WRAP(flashmaskv2_bwd_params_set_##member);

--- a/paddle/phi/kernels/gpu/flash_attn_v3_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/flash_attn_v3_grad_kernel.cu
@@ -850,6 +850,7 @@ void FlashMaskV2GradBaseKernel(
         &seqused_k_,  // b. If given, only this many elements of each batch
                       // element's keys are used.
     const paddle::optional<DenseTensor> &startend_row_indices_,
+    const paddle::optional<DenseTensor> &block_mask_,  // （(b,h,s//128,s//128)
     int max_seqlen_q_,
     int max_seqlen_k_,
     float const softmax_scale,
@@ -1078,6 +1079,50 @@ void FlashMaskV2GradBaseKernel(
       ut_start_row_indices =
           phi::Slice<int32_t>(dev_ctx, startend_row_indices, {3}, {2}, {3});
     }
+  }
+
+  bool const is_blockmask = block_mask_.is_initialized();
+  DenseTensor block_mask;
+  if (is_blockmask) block_mask = block_mask_.get();
+
+  if (is_blockmask) {
+    PADDLE_ENFORCE_EQ(
+        is_flashmask,
+        true,
+        common::errors::InvalidArgument(
+            "blockmask should be used with flashmask at the same time "));
+
+    PADDLE_ENFORCE_EQ(block_mask.dims().size(),
+                      4,
+                      common::errors::InvalidArgument(
+                          "blockmask receive blockmask_indices with dim "
+                          "[batch_size, num_heads, blocklen_q, blocklen_k]"));
+
+    PADDLE_ENFORCE_EQ(block_mask.dims()[2],
+                      (seqlen_q + 127) / 128,
+                      common::errors::InvalidArgument(
+                          "blockmask only supports blockdim_q = 128 now"));
+
+    PADDLE_ENFORCE_EQ(block_mask.dims()[3],
+                      (seqlen_k + 127) / 128,
+                      common::errors::InvalidArgument(
+                          "blockmask only supports blockdim_k = 128 now"));
+
+    PADDLE_ENFORCE_EQ(
+        block_mask.dims()[1],
+        startend_row_indices.dims()[1],
+        common::errors::InvalidArgument(
+            "blockmask only supports same dim num_heads with flashmask now"));
+
+    PADDLE_ENFORCE_LE(seqlen_k,
+                      1024 * 128,
+                      common::errors::InvalidArgument(
+                          "blockmask only supports seqlen <= 128k in bwd now"));
+
+    PADDLE_ENFORCE_LE(seqlen_q,
+                      1024 * 128,
+                      common::errors::InvalidArgument(
+                          "blockmask only supports seqlen <= 128k in bwd now"));
   }
 
   const bool has_lt_start = lt_start_row_indices.initialized();
@@ -1361,7 +1406,7 @@ void FlashMaskV2GradBaseKernel(
       num_heads_k != num_heads && dk_accum ? dk_accum->data() : nullptr,
       num_heads_k != num_heads && dv_accum ? dv_accum->data() : nullptr,
       const_cast<void *>(softmax_lse.data()),
-      softmax_d ? const_cast<void *>(softmax_d->data()) : nullptr,
+      softmax_d ? (softmax_d->data()) : nullptr,
       /*p_dropout=*/0.f,
       softmax_scale,
       window_size_left,
@@ -1408,36 +1453,31 @@ void FlashMaskV2GradBaseKernel(
   if (is_flashmask) {
     if (lt_start_row_indices.initialized())
       dynload::flashmaskv2_bwd_params_set_lt_start_ptr(
-          params_handle,
-          const_cast<int32_t *>(lt_start_row_indices.data<int32_t>()));
+          params_handle, (lt_start_row_indices.data<int32_t>()));
     else
       dynload::flashmaskv2_bwd_params_set_lt_start_ptr(params_handle, nullptr);
 
     if (lt_end_row_indices.initialized())
       dynload::flashmaskv2_bwd_params_set_lt_end_ptr(
-          params_handle,
-          const_cast<int32_t *>(lt_end_row_indices.data<int32_t>()));
+          params_handle, (lt_end_row_indices.data<int32_t>()));
     else
       dynload::flashmaskv2_bwd_params_set_lt_end_ptr(params_handle, nullptr);
 
     if (ut_start_row_indices.initialized())
       dynload::flashmaskv2_bwd_params_set_ut_start_ptr(
-          params_handle,
-          const_cast<int32_t *>(ut_start_row_indices.data<int32_t>()));
+          params_handle, (ut_start_row_indices.data<int32_t>()));
     else
       dynload::flashmaskv2_bwd_params_set_ut_start_ptr(params_handle, nullptr);
 
     if (ut_end_row_indices.initialized())
       dynload::flashmaskv2_bwd_params_set_ut_end_ptr(
-          params_handle,
-          const_cast<int32_t *>(ut_end_row_indices.data<int32_t>()));
+          params_handle, (ut_end_row_indices.data<int32_t>()));
     else
       dynload::flashmaskv2_bwd_params_set_ut_end_ptr(params_handle, nullptr);
 
     if (flashmask_maxmin.initialized())
       dynload::flashmaskv2_bwd_params_set_flashmask_maxmin_ptr(
-          params_handle,
-          const_cast<int32_t *>(flashmask_maxmin.data<int32_t>()));
+          params_handle, (flashmask_maxmin.data<int32_t>()));
     else
       dynload::flashmaskv2_bwd_params_set_flashmask_maxmin_ptr(params_handle,
                                                                nullptr);
@@ -1457,6 +1497,14 @@ void FlashMaskV2GradBaseKernel(
     dynload::flashmaskv2_bwd_params_set_h_h_flashmask_ratio(params_handle, 0);
   }
 
+  if (is_blockmask) {
+    // xhy: blockmask is now only support blockdim_q k = 128
+    dynload::flashmaskv2_bwd_params_set_m_block_dim(params_handle, 128);
+    dynload::flashmaskv2_bwd_params_set_n_block_dim(params_handle, 128);
+    dynload::flashmaskv2_bwd_params_set_block_mask_ptr(
+        params_handle, (block_mask.data<int32_t>()));
+    auto ptr = block_mask.data<int32_t>();
+  }
 #ifdef FLASHATTENTION_DISABLE_LOCAL
   PADDLE_ENABLE_EQ(
       !dynload::flashmaskv2_bwd_params_get_is_local(params_handle),
@@ -1504,6 +1552,7 @@ void FlashMaskV2GradKernel(
     const DenseTensor &out,
     const DenseTensor &softmax_lse,
     const DenseTensor &startend_row_indices,  // TODO(xiehaoyang): remove this
+    const paddle::optional<DenseTensor> &block_mask,
     const DenseTensor &out_grad,
     float const softmax_scale,
     bool is_causal,
@@ -1540,6 +1589,7 @@ void FlashMaskV2GradKernel(
                                         paddle::none,
                                         paddle::none,
                                         startend_row_indices,
+                                        block_mask,
                                         0,  // max_seqlen_q,
                                         0,  // max_seqlen_k,
                                         softmax_scale,

--- a/paddle/phi/kernels/gpu/flash_attn_v3_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/flash_attn_v3_grad_kernel.cu
@@ -1503,7 +1503,6 @@ void FlashMaskV2GradBaseKernel(
     dynload::flashmaskv2_bwd_params_set_n_block_dim(params_handle, 128);
     dynload::flashmaskv2_bwd_params_set_block_mask_ptr(
         params_handle, (block_mask.data<int32_t>()));
-    auto ptr = block_mask.data<int32_t>();
   }
 #ifdef FLASHATTENTION_DISABLE_LOCAL
   PADDLE_ENABLE_EQ(

--- a/paddle/phi/ops/yaml/backward.yaml
+++ b/paddle/phi/ops/yaml/backward.yaml
@@ -1228,8 +1228,9 @@
     data_type: q
 
 - backward_op : flashmask_attention_v2_grad
-  forward : flashmask_attention_v2 (Tensor q, Tensor k, Tensor v, Tensor startend_row_indices, float softmax_scale, bool is_causal) -> Tensor(out), Tensor(softmax_lse)
-  args : (Tensor q, Tensor k, Tensor v, Tensor out, Tensor softmax_lse, Tensor startend_row_indices, Tensor out_grad, float softmax_scale, bool is_causal)
+  forward : flashmask_attention_v2 (Tensor q, Tensor k, Tensor v, Tensor startend_row_indices,Tensor block_mask, float softmax_scale, bool is_causal) -> Tensor(out), Tensor(softmax_lse)
+  args : (Tensor q, Tensor k, Tensor v, Tensor out, Tensor softmax_lse, Tensor startend_row_indices, Tensor block_mask, Tensor out_grad, float softmax_scale, bool is_causal)
+  optional : block_mask
   output : Tensor(q_grad), Tensor(k_grad), Tensor(v_grad)
   infer_meta :
     func : FlashAttnGradInferMeta

--- a/paddle/phi/ops/yaml/ops.yaml
+++ b/paddle/phi/ops/yaml/ops.yaml
@@ -2153,8 +2153,9 @@
   interfaces : paddle::dialect::InferSymbolicShapeInterface
 
 - op : flashmask_attention_v2
-  args : (Tensor q, Tensor k, Tensor v, Tensor startend_row_indices, float softmax_scale, bool is_causal)
+  args : (Tensor q, Tensor k, Tensor v, Tensor startend_row_indices, Tensor block_mask, float softmax_scale, bool is_causal)
   output : Tensor(out), Tensor(softmax_lse)
+  optional : block_mask
   infer_meta :
     func : FlashMaskV2InferMeta
     param : [q, k, v]

--- a/test/legacy_test/test_flashmask.py
+++ b/test/legacy_test/test_flashmask.py
@@ -251,6 +251,8 @@ class TestFlashMaskAttentionAPI(unittest.TestCase):
 
         startend_row_indices = self.get_flashmask()
         mask = self.get_densemask()
+        # Note(xhy): ci no supports test on sm90 and blockmask only supports sm >= sm90
+        blockmask = None
         out = flashmask_attention(
             q,
             k,
@@ -258,6 +260,7 @@ class TestFlashMaskAttentionAPI(unittest.TestCase):
             startend_row_indices=startend_row_indices,
             dropout=self.dropout,
             causal=self.causal,
+            block_mask=blockmask,
         )
         out_ = attention_naive_with_mask(q_, k_, v_, mask)
         out.backward(ograd)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Operator Mechanism


### PR Types
New features 


### Description
Add Blockmask Support to Flashmask

- This update enables simultaneous use of both blockmask and flashmask masking methods, where the two masks are combined via a logical OR operation. Any block masked by blockmask, or any block fully masked by flashmask, will be excluded from computation.
- Currently, blockmask and flashmask are not fully decoupled. There is no change when using flashmask alone; however, when using blockmask alone, a flashmask tensor (that does not affect the results) still needs to be provided.
- At present, only cases with headdim=128 and blocksize=128 are supported.
- Compared to the original blockmask implementation (https://github.com/mit-han-lab/Block-Sparse-Attention), this version achieves a 75% to 150% improvement in forward performance and a 50% to 90% improvement in backward performance on H800.
- Comprehensive regression testing has been conducted for both accuracy and performance against the original flashmask operator, and there is negligible impact on the accuracy or performance of the original flashmask.