### PR TITLE
[CodeStyle] Use `itertools.product` reorganize deep nested loops (part2)

### DIFF
--- a/test/contrib/test_correlation.py
+++ b/test/contrib/test_correlation.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import itertools
 import unittest
 
 import numpy as np
@@ -53,27 +54,29 @@ def corr(
     D = 2 * d + 1
     output = np.zeros((B, D * D, H, W), dtype=np.float32)
 
-    for b in range(B):
-        for i in range(H):
-            for j in range(W):
-                for k in range(-d, d + 1):
-                    for l in range(-d, d + 1):
-                        x1_index = i + pad_size
-                        y1_index = j + pad_size
-                        x2_index = x1_index + k
-                        y2_index = y1_index + l
-                        output[b, l + d + D * (k + d), i, j] = np.mean(
-                            rinput1[
-                                b,
-                                x1_index : x1_index + K,
-                                y1_index : y1_index + K,
-                            ]
-                            * rinput2[
-                                b,
-                                x2_index : x2_index + K,
-                                y2_index : y2_index + K,
-                            ]
-                        )
+    for b, i, j, k, l in itertools.product(
+        range(B),
+        range(H),
+        range(W),
+        range(-d, d + 1),
+        range(-d, d + 1),
+    ):
+        x1_index = i + pad_size
+        y1_index = j + pad_size
+        x2_index = x1_index + k
+        y2_index = y1_index + l
+        output[b, l + d + D * (k + d), i, j] = np.mean(
+            rinput1[
+                b,
+                x1_index : x1_index + K,
+                y1_index : y1_index + K,
+            ]
+            * rinput2[
+                b,
+                x2_index : x2_index + K,
+                y2_index : y2_index + K,
+            ]
+        )
 
     return output
 

--- a/test/ir/inference/test_trt_convert_anchor_generator.py
+++ b/test/ir/inference/test_trt_convert_anchor_generator.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from __future__ import annotations
 
+import itertools
 import unittest
 from functools import partial
 from typing import Any
@@ -32,55 +33,62 @@ class TrtConvertAnchorGeneratorTest(TrtLayerAutoScanTest):
         def generate_input1(batch, attrs: list[dict[str, Any]]):
             return np.random.random([batch, 3, 64, 64]).astype(np.float32)
 
-        for batch in [1, 2, 4]:
-            for anchor_sizes in [[64.0, 128.0, 256.0, 512.0]]:
-                for aspect_ratios in [[0.5, 1, 2], [0.4, 1.2, 3]]:
-                    for variances in [
-                        [1.0, 1.0, 1.0, 1.0],
-                        [0.5, 1.0, 0.5, 1.0],
-                    ]:
-                        for stride in [[16.0, 16.0], [16.0, 32.0]]:
-                            for offset in [0.5, 0.8]:
-                                dics = [
-                                    {
-                                        "anchor_sizes": anchor_sizes,
-                                        "aspect_ratios": aspect_ratios,
-                                        "variances": variances,
-                                        "stride": stride,
-                                        "offset": offset,
-                                    }
-                                ]
+        for (
+            batch,
+            anchor_sizes,
+            aspect_ratios,
+            variances,
+            stride,
+            offset,
+        ) in itertools.product(
+            [1, 2, 4],
+            [[64.0, 128.0, 256.0, 512.0]],
+            [[0.5, 1, 2], [0.4, 1.2, 3]],
+            [
+                [1.0, 1.0, 1.0, 1.0],
+                [0.5, 1.0, 0.5, 1.0],
+            ],
+            [[16.0, 16.0], [16.0, 32.0]],
+            [0.5, 0.8],
+        ):
+            dics = [
+                {
+                    "anchor_sizes": anchor_sizes,
+                    "aspect_ratios": aspect_ratios,
+                    "variances": variances,
+                    "stride": stride,
+                    "offset": offset,
+                }
+            ]
 
-                                ops_config = [
-                                    {
-                                        "op_type": "anchor_generator",
-                                        "op_inputs": {"Input": ["input_data"]},
-                                        "op_outputs": {
-                                            "Anchors": ["output_anchors"],
-                                            "Variances": ["output_variances"],
-                                        },
-                                        "op_attrs": dics[0],
-                                    }
-                                ]
-                                ops = self.generate_op_config(ops_config)
+            ops_config = [
+                {
+                    "op_type": "anchor_generator",
+                    "op_inputs": {"Input": ["input_data"]},
+                    "op_outputs": {
+                        "Anchors": ["output_anchors"],
+                        "Variances": ["output_variances"],
+                    },
+                    "op_attrs": dics[0],
+                }
+            ]
+            ops = self.generate_op_config(ops_config)
 
-                                program_config = ProgramConfig(
-                                    ops=ops,
-                                    weights={},
-                                    inputs={
-                                        "input_data": TensorConfig(
-                                            data_gen=partial(
-                                                generate_input1, batch, dics
-                                            )
-                                        )
-                                    },
-                                    outputs=[
-                                        "output_anchors",
-                                        "output_variances",
-                                    ],
-                                )
+            program_config = ProgramConfig(
+                ops=ops,
+                weights={},
+                inputs={
+                    "input_data": TensorConfig(
+                        data_gen=partial(generate_input1, batch, dics)
+                    )
+                },
+                outputs=[
+                    "output_anchors",
+                    "output_variances",
+                ],
+            )
 
-                                yield program_config
+            yield program_config
 
     def generate_dynamic_shape(self, attrs):
         self.dynamic_shape.min_input_shape = {"input_data": [1, 3, 64, 64]}

--- a/test/ir/inference/test_trt_convert_deformable_conv.py
+++ b/test/ir/inference/test_trt_convert_deformable_conv.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import itertools
 import unittest
 from functools import partial
 from typing import Any
@@ -98,91 +99,94 @@ class TrtConvertDeformableConvTest(TrtLayerAutoScanTest):
             filter[0][0][0][0] = 8.8978638e-08
             return filter.astype(np.float32)
 
-        for batch in [
-            1,
-        ]:
-            for input_size in [[32, 32]]:
-                for kernel_sizes in [[3, 3]]:
-                    for strides in [[1, 1], [2, 2]]:
-                        for paddings in [[1, 1], [0, 2]]:
-                            for groups in [
-                                1,
-                            ]:
-                                for dilations in [[1, 1], [2, 2]]:
-                                    dics = [
-                                        {
-                                            "strides": strides,
-                                            "paddings": paddings,
-                                            "groups": groups,
-                                            "dilations": dilations,
-                                            "deformable_groups": 1,
-                                            "im2col_step": 1,
-                                        }
-                                    ]
+        for (
+            batch,
+            input_size,
+            kernel_sizes,
+            strides,
+            paddings,
+            groups,
+            dilations,
+        ) in itertools.product(
+            [1],
+            [[32, 32]],
+            [[3, 3]],
+            [[1, 1], [2, 2]],
+            [[1, 1], [0, 2]],
+            [1],
+            [[1, 1], [2, 2]],
+        ):
+            dics = [
+                {
+                    "strides": strides,
+                    "paddings": paddings,
+                    "groups": groups,
+                    "dilations": dilations,
+                    "deformable_groups": 1,
+                    "im2col_step": 1,
+                }
+            ]
+            ops_config = [
+                {
+                    "op_type": "deformable_conv",
+                    "op_inputs": {
+                        "Input": ["input_data"],
+                        "Offset": ["offset_data"],
+                        "Mask": ["mask_data"],
+                        "Filter": ["filter_data"],
+                    },
+                    "op_outputs": {"Output": ["output_data"]},
+                    "op_attrs": dics[0],
+                }
+            ]
+            ops = self.generate_op_config(ops_config)
 
-                                ops_config = [
-                                    {
-                                        "op_type": "deformable_conv",
-                                        "op_inputs": {
-                                            "Input": ["input_data"],
-                                            "Offset": ["offset_data"],
-                                            "Mask": ["mask_data"],
-                                            "Filter": ["filter_data"],
-                                        },
-                                        "op_outputs": {
-                                            "Output": ["output_data"]
-                                        },
-                                        "op_attrs": dics[0],
-                                    }
-                                ]
-                                ops = self.generate_op_config(ops_config)
+            program_config = ProgramConfig(
+                ops=ops,
+                weights={
+                    "filter_data": TensorConfig(
+                        data_gen=partial(
+                            generate_filter1,
+                            batch,
+                            input_size,
+                            kernel_sizes,
+                            dics,
+                        )
+                    )
+                },
+                inputs={
+                    "input_data": TensorConfig(
+                        data_gen=partial(
+                            generate_input1,
+                            batch,
+                            input_size,
+                            kernel_sizes,
+                            dics,
+                        )
+                    ),
+                    "offset_data": TensorConfig(
+                        data_gen=partial(
+                            generate_offset1,
+                            batch,
+                            input_size,
+                            kernel_sizes,
+                            dics,
+                        )
+                    ),
+                    "mask_data": TensorConfig(
+                        data_gen=partial(
+                            generate_mask1,
+                            batch,
+                            input_size,
+                            kernel_sizes,
+                            dics,
+                        )
+                    ),
+                },
+                outputs=["output_data"],
+            )
 
-                                program_config = ProgramConfig(
-                                    ops=ops,
-                                    weights={
-                                        "filter_data": TensorConfig(
-                                            data_gen=partial(
-                                                generate_filter1,
-                                                batch,
-                                                input_size,
-                                                kernel_sizes,
-                                                dics,
-                                            )
-                                        )
-                                    },
-                                    inputs={
-                                        "input_data": TensorConfig(
-                                            data_gen=partial(
-                                                generate_input1,
-                                                batch,
-                                                input_size,
-                                                kernel_sizes,
-                                                dics,
-                                            )
-                                        ),
-                                        "offset_data": TensorConfig(
-                                            data_gen=partial(
-                                                generate_offset1,
-                                                batch,
-                                                input_size,
-                                                kernel_sizes,
-                                                dics,
-                                            )
-                                        ),
-                                        "mask_data": TensorConfig(
-                                            data_gen=partial(
-                                                generate_mask1,
-                                                batch,
-                                                input_size,
-                                                kernel_sizes,
-                                                dics,
-                                            )
-                                        ),
-                                    },
-                                    outputs=["output_data"],
-                                )
-
-                                yield program_config
+            yield program_config
 
     def sample_predictor_configs(
         self, program_config

--- a/test/ir/inference/test_trt_convert_deformable_conv.py
+++ b/test/ir/inference/test_trt_convert_deformable_conv.py
@@ -114,7 +114,7 @@ class TrtConvertDeformableConvTest(TrtLayerAutoScanTest):
             [[1, 1], [2, 2]],
             [[1, 1], [0, 2]],
             [1],
-            [[1, 1], [2, 2]],
+            [[2, 2]],
         ):
             dics = [
                 {

--- a/test/ir/inference/test_trt_convert_emb_eltwise_layernorm.py
+++ b/test/ir/inference/test_trt_convert_emb_eltwise_layernorm.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import itertools
 import unittest
 from functools import partial
 
@@ -46,230 +47,182 @@ class TrtConvertEmbEltwiseLayernormTest1(TrtLayerAutoScanTest):
         def generate_weight4(size2):
             return np.random.randn(size2).astype(np.float32)
 
-        for input_size in [16, 128]:
-            for batch in [1, 2, 4]:
-                for size1 in [[8, 513, 768], [513, 768, 8], [768, 8, 513]]:
-                    size11 = size1[0]
-                    size12 = size1[1]
-                    size13 = size1[2]
-                    for size2 in [32, 768]:
-                        for norm_axis in [2]:
-                            for epsilon in [0.0001, 0.0005]:
-                                for axis1 in [0, -1]:
-                                    for axis2 in [0, -1]:
-                                        for type in [
-                                            "lookup_table",
-                                            "lookup_table_v2",
-                                        ]:
-                                            dics = [
-                                                {
-                                                    "is_sparse": False,
-                                                    "is_distributed": False,
-                                                    "padding_idx": -1,
-                                                    "is_test": True,
-                                                },
-                                                {
-                                                    "is_sparse": False,
-                                                    "is_distributed": False,
-                                                    "padding_idx": -1,
-                                                },
-                                                {"axis": axis1},
-                                                {"axis": axis2},
-                                                {
-                                                    "begin_norm_axis": norm_axis,
-                                                    "epsilon": epsilon,
-                                                },
-                                            ]
-                                            ops_config = [
-                                                {
-                                                    "op_type": type,
-                                                    "op_inputs": {
-                                                        "Ids": ["input_data1"],
-                                                        "W": [
-                                                            "embedding1_weight"
-                                                        ],
-                                                    },
-                                                    "op_outputs": {
-                                                        "Out": [
-                                                            "embedding1_output"
-                                                        ]
-                                                    },
-                                                    "op_attrs": (
-                                                        dics[0]
-                                                        if type
-                                                        == "lookup_table"
-                                                        else dics[1]
-                                                    ),
-                                                },
-                                                {
-                                                    "op_type": type,
-                                                    "op_inputs": {
-                                                        "Ids": ["input_data2"],
-                                                        "W": [
-                                                            "embedding2_weight"
-                                                        ],
-                                                    },
-                                                    "op_outputs": {
-                                                        "Out": [
-                                                            "embedding2_output"
-                                                        ]
-                                                    },
-                                                    "op_attrs": (
-                                                        dics[0]
-                                                        if type
-                                                        == "lookup_table"
-                                                        else dics[1]
-                                                    ),
-                                                },
-                                                {
-                                                    "op_type": type,
-                                                    "op_inputs": {
-                                                        "Ids": ["input_data3"],
-                                                        "W": [
-                                                            "embedding3_weight"
-                                                        ],
-                                                    },
-                                                    "op_outputs": {
-                                                        "Out": [
-                                                            "embedding3_output"
-                                                        ]
-                                                    },
-                                                    "op_attrs": (
-                                                        dics[0]
-                                                        if type
-                                                        == "lookup_table"
-                                                        else dics[1]
-                                                    ),
-                                                },
-                                                {
-                                                    "op_type": "elementwise_add",
-                                                    "op_inputs": {
-                                                        "X": [
-                                                            "embedding2_output"
-                                                        ],
-                                                        "Y": [
-                                                            "embedding3_output"
-                                                        ],
-                                                    },
-                                                    "op_outputs": {
-                                                        "Out": [
-                                                            "elementwise_add1_output"
-                                                        ]
-                                                    },
-                                                    "op_attrs": dics[2],
-                                                },
-                                                {
-                                                    "op_type": "elementwise_add",
-                                                    "op_inputs": {
-                                                        "X": [
-                                                            "elementwise_add1_output"
-                                                        ],
-                                                        "Y": [
-                                                            "embedding1_output"
-                                                        ],
-                                                    },
-                                                    "op_outputs": {
-                                                        "Out": [
-                                                            "elementwise_add2_output"
-                                                        ]
-                                                    },
-                                                    "op_attrs": dics[3],
-                                                },
-                                                {
-                                                    "op_type": "layer_norm",
-                                                    "op_inputs": {
-                                                        "X": [
-                                                            "elementwise_add2_output"
-                                                        ],
-                                                        "Bias": [
-                                                            "layer_norm_bias"
-                                                        ],
-                                                        "Scale": [
-                                                            "layer_norm_scale"
-                                                        ],
-                                                    },
-                                                    "op_outputs": {
-                                                        "Y": [
-                                                            "layer_norm_output1"
-                                                        ],
-                                                        "Mean": [
-                                                            "layer_norm_output2"
-                                                        ],
-                                                        "Variance": [
-                                                            "layer_norm_output3"
-                                                        ],
-                                                    },
-                                                    "op_attrs": dics[4],
-                                                },
-                                            ]
-                                            ops = self.generate_op_config(
-                                                ops_config
-                                            )
+        for (
+            input_size,
+            batch,
+            size1,
+            size2,
+            norm_axis,
+            epsilon,
+            axis1,
+            axis2,
+            type,
+        ) in itertools.product(
+            [16, 128],
+            [1, 2, 4],
+            [[8, 513, 768], [513, 768, 8], [768, 8, 513]],
+            [32, 768],
+            [2],
+            [0.0001, 0.0005],
+            [0, -1],
+            [0, -1],
+            ["lookup_table", "lookup_table_v2"],
+        ):
+            size11 = size1[0]
+            size12 = size1[1]
+            size13 = size1[2]
+            dics = [
+                {
+                    "is_sparse": False,
+                    "is_distributed": False,
+                    "padding_idx": -1,
+                    "is_test": True,
+                },
+                {
+                    "is_sparse": False,
+                    "is_distributed": False,
+                    "padding_idx": -1,
+                },
+                {"axis": axis1},
+                {"axis": axis2},
+                {
+                    "begin_norm_axis": norm_axis,
+                    "epsilon": epsilon,
+                },
+            ]
+            ops_config = [
+                {
+                    "op_type": type,
+                    "op_inputs": {
+                        "Ids": ["input_data1"],
+                        "W": ["embedding1_weight"],
+                    },
+                    "op_outputs": {"Out": ["embedding1_output"]},
+                    "op_attrs": (
+                        dics[0] if type == "lookup_table" else dics[1]
+                    ),
+                },
+                {
+                    "op_type": type,
+                    "op_inputs": {
+                        "Ids": ["input_data2"],
+                        "W": ["embedding2_weight"],
+                    },
+                    "op_outputs": {"Out": ["embedding2_output"]},
+                    "op_attrs": (
+                        dics[0] if type == "lookup_table" else dics[1]
+                    ),
+                },
+                {
+                    "op_type": type,
+                    "op_inputs": {
+                        "Ids": ["input_data3"],
+                        "W": ["embedding3_weight"],
+                    },
+                    "op_outputs": {"Out": ["embedding3_output"]},
+                    "op_attrs": (
+                        dics[0] if type == "lookup_table" else dics[1]
+                    ),
+                },
+                {
+                    "op_type": "elementwise_add",
+                    "op_inputs": {
+                        "X": ["embedding2_output"],
+                        "Y": ["embedding3_output"],
+                    },
+                    "op_outputs": {"Out": ["elementwise_add1_output"]},
+                    "op_attrs": dics[2],
+                },
+                {
+                    "op_type": "elementwise_add",
+                    "op_inputs": {
+                        "X": ["elementwise_add1_output"],
+                        "Y": ["embedding1_output"],
+                    },
+                    "op_outputs": {"Out": ["elementwise_add2_output"]},
+                    "op_attrs": dics[3],
+                },
+                {
+                    "op_type": "layer_norm",
+                    "op_inputs": {
+                        "X": ["elementwise_add2_output"],
+                        "Bias": ["layer_norm_bias"],
+                        "Scale": ["layer_norm_scale"],
+                    },
+                    "op_outputs": {
+                        "Y": ["layer_norm_output1"],
+                        "Mean": ["layer_norm_output2"],
+                        "Variance": ["layer_norm_output3"],
+                    },
+                    "op_attrs": dics[4],
+                },
+            ]
+            ops = self.generate_op_config(ops_config)
 
-                                            program_config = ProgramConfig(
-                                                ops=ops,
-                                                weights={
-                                                    "embedding1_weight": TensorConfig(
-                                                        data_gen=partial(
-                                                            generate_weight1,
-                                                            size11,
-                                                            size2,
-                                                        )
-                                                    ),
-                                                    "embedding2_weight": TensorConfig(
-                                                        data_gen=partial(
-                                                            generate_weight2,
-                                                            size12,
-                                                            size2,
-                                                        )
-                                                    ),
-                                                    "embedding3_weight": TensorConfig(
-                                                        data_gen=partial(
-                                                            generate_weight3,
-                                                            size13,
-                                                            size2,
-                                                        )
-                                                    ),
-                                                    "layer_norm_bias": TensorConfig(
-                                                        data_gen=partial(
-                                                            generate_weight4,
-                                                            size2,
-                                                        )
-                                                    ),
-                                                    "layer_norm_scale": TensorConfig(
-                                                        data_gen=partial(
-                                                            generate_weight4,
-                                                            size2,
-                                                        )
-                                                    ),
-                                                },
-                                                inputs={
-                                                    "input_data1": TensorConfig(
-                                                        data_gen=partial(
-                                                            generate_input,
-                                                            batch,
-                                                            input_size,
-                                                        )
-                                                    ),
-                                                    "input_data2": TensorConfig(
-                                                        data_gen=partial(
-                                                            generate_input,
-                                                            batch,
-                                                            input_size,
-                                                        )
-                                                    ),
-                                                    "input_data3": TensorConfig(
-                                                        data_gen=partial(
-                                                            generate_input,
-                                                            batch,
-                                                            input_size,
-                                                        )
-                                                    ),
-                                                },
-                                                outputs=["layer_norm_output1"],
-                                            )
+            program_config = ProgramConfig(
+                ops=ops,
+                weights={
+                    "embedding1_weight": TensorConfig(
+                        data_gen=partial(
+                            generate_weight1,
+                            size11,
+                            size2,
+                        )
+                    ),
+                    "embedding2_weight": TensorConfig(
+                        data_gen=partial(
+                            generate_weight2,
+                            size12,
+                            size2,
+                        )
+                    ),
+                    "embedding3_weight": TensorConfig(
+                        data_gen=partial(
+                            generate_weight3,
+                            size13,
+                            size2,
+                        )
+                    ),
+                    "layer_norm_bias": TensorConfig(
+                        data_gen=partial(
+                            generate_weight4,
+                            size2,
+                        )
+                    ),
+                    "layer_norm_scale": TensorConfig(
+                        data_gen=partial(
+                            generate_weight4,
+                            size2,
+                        )
+                    ),
+                },
+                inputs={
+                    "input_data1": TensorConfig(
+                        data_gen=partial(
+                            generate_input,
+                            batch,
+                            input_size,
+                        )
+                    ),
+                    "input_data2": TensorConfig(
+                        data_gen=partial(
+                            generate_input,
+                            batch,
+                            input_size,
+                        )
+                    ),
+                    "input_data3": TensorConfig(
+                        data_gen=partial(
+                            generate_input,
+                            batch,
+                            input_size,
+                        )
+                    ),
+                },
+                outputs=["layer_norm_output1"],
+            )
 
-                                            yield program_config
+            yield program_config
 
     def sample_predictor_configs(
         self, program_config

--- a/test/ir/pir/fused_pass/test_pir_fc_elementwise_layernorm_fuse_pass.py
+++ b/test/ir/pir/fused_pass/test_pir_fc_elementwise_layernorm_fuse_pass.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import itertools
 import unittest
 
 import numpy as np
@@ -36,79 +37,63 @@ class TestFcElementwiseLayerNormFusePattern(PassTest):
         return True
 
     def sample_program(self):
-        for x_shape in [[3, 2]]:
-            for w_shape in [[2, 3]]:
-                for y_shape in [[1, 3], [3]]:
-                    for bias_shape in [[3, 3]]:
-                        for with_relu in [True, False]:
-                            with paddle.pir_utils.IrGuard():
-                                start_prog = paddle.static.Program()
-                                main_prog = paddle.static.Program()
-                                with paddle.pir.core.program_guard(
-                                    main_prog, start_prog
-                                ):
-                                    x = paddle.static.data(
-                                        name='x', shape=x_shape, dtype='float32'
-                                    )
-                                    w = paddle.static.data(
-                                        name='w', shape=w_shape, dtype='float32'
-                                    )
-                                    y = paddle.static.data(
-                                        name='y', shape=y_shape, dtype='float32'
-                                    )
-                                    if with_relu:
-                                        relu_op = paddle.nn.ReLU()
-                                        fc_out = relu_op(
-                                            paddle.add(paddle.matmul(x, w), y)
-                                        )
-                                    else:
-                                        fc_out = paddle.add(
-                                            paddle.matmul(x, w), y
-                                        )
+        for (
+            x_shape,
+            w_shape,
+            y_shape,
+            bias_shape,
+            with_relu,
+        ) in itertools.product(
+            [[3, 2]], [[2, 3]], [[1, 3], [3]], [[3, 3]], [True, False]
+        ):
+            with paddle.pir_utils.IrGuard():
+                start_prog = paddle.static.Program()
+                main_prog = paddle.static.Program()
+                with paddle.pir.core.program_guard(main_prog, start_prog):
+                    x = paddle.static.data(
+                        name='x', shape=x_shape, dtype='float32'
+                    )
+                    w = paddle.static.data(
+                        name='w', shape=w_shape, dtype='float32'
+                    )
+                    y = paddle.static.data(
+                        name='y', shape=y_shape, dtype='float32'
+                    )
+                    if with_relu:
+                        relu_op = paddle.nn.ReLU()
+                        fc_out = relu_op(paddle.add(paddle.matmul(x, w), y))
+                    else:
+                        fc_out = paddle.add(paddle.matmul(x, w), y)
 
-                                    bias1 = paddle.static.data(
-                                        name='bias1',
-                                        shape=bias_shape,
-                                        dtype='float32',
-                                    )
+                    bias1 = paddle.static.data(
+                        name='bias1',
+                        shape=bias_shape,
+                        dtype='float32',
+                    )
 
-                                    add_out = paddle.add(fc_out, bias1)
-                                    layer_norm = paddle.nn.LayerNorm(
-                                        add_out.shape[-1:]
-                                    )
-                                    out = layer_norm(add_out)
-                                    out = paddle.assign(out)
-                                    self.pass_attr_list.append(
-                                        {'matmul_add_act_fuse_pass': {}}
-                                    )
-                                    self.pass_attr_list.append(
-                                        {
-                                            'fc_elementwise_layernorm_fuse_pass': {}
-                                        }
-                                    )
-                                    self.feeds = {
-                                        "x": np.random.random(x_shape).astype(
-                                            "float32"
-                                        ),
-                                        "w": np.random.random(w_shape).astype(
-                                            "float32"
-                                        ),
-                                        "y": np.random.random(y_shape).astype(
-                                            "float32"
-                                        ),
-                                        "bias1": np.random.random(
-                                            bias_shape
-                                        ).astype("float32"),
-                                    }
-                                    self.fetch_list = [out]
-                                    self.valid_op_map = {
-                                        "pd_op.add": 0,
-                                        "pd_op.relu": 0,
-                                        "pd_op.matmul": 0,
-                                        "pd_op.fused_fc_elementwise_layernorm": 1,
-                                    }
+                    add_out = paddle.add(fc_out, bias1)
+                    layer_norm = paddle.nn.LayerNorm(add_out.shape[-1:])
+                    out = layer_norm(add_out)
+                    out = paddle.assign(out)
+                    self.pass_attr_list.append({'matmul_add_act_fuse_pass': {}})
+                    self.pass_attr_list.append(
+                        {'fc_elementwise_layernorm_fuse_pass': {}}
+                    )
+                    self.feeds = {
+                        "x": np.random.random(x_shape).astype("float32"),
+                        "w": np.random.random(w_shape).astype("float32"),
+                        "y": np.random.random(y_shape).astype("float32"),
+                        "bias1": np.random.random(bias_shape).astype("float32"),
+                    }
+                    self.fetch_list = [out]
+                    self.valid_op_map = {
+                        "pd_op.add": 0,
+                        "pd_op.relu": 0,
+                        "pd_op.matmul": 0,
+                        "pd_op.fused_fc_elementwise_layernorm": 1,
+                    }
 
-                                    yield [main_prog, start_prog], False
+                    yield [main_prog, start_prog], False
 
     def setUp(self):
         if core.is_compiled_with_cuda():

--- a/test/ir/pir/fused_pass/test_pir_fused_rotary_position_embedding_pass.py
+++ b/test/ir/pir/fused_pass/test_pir_fused_rotary_position_embedding_pass.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import itertools
 import unittest
 
 import numpy as np
@@ -90,103 +91,95 @@ slice slice                    \                   squeeze       unsqueeze      
         return x3
 
     def sample_program(self):
-        for q_shape in [[2, 8, 2, 16]]:
-            for k_shape in [[2, 8, 2, 16]]:
-                for cos_shape in [[1, 8, 1, 16]]:
-                    for sin_shape in [[1, 8, 1, 16]]:
-                        for position_ids_shape in [[2, 8]]:
-                            with paddle.pir_utils.IrGuard():
-                                start_prog = paddle.static.Program()
-                                main_prog = paddle.static.Program()
-                                with paddle.pir.core.program_guard(
-                                    main_prog, start_prog
-                                ):
-                                    q = paddle.static.data(
-                                        name="q",
-                                        shape=q_shape,
-                                        dtype='float32',
-                                    )
-                                    k = paddle.static.data(
-                                        name="k",
-                                        shape=k_shape,
-                                        dtype='float32',
-                                    )
-                                    cos = paddle.static.data(
-                                        name="cos",
-                                        shape=cos_shape,
-                                        dtype='float32',
-                                    )
-                                    sin = paddle.static.data(
-                                        name="sin",
-                                        shape=sin_shape,
-                                        dtype='float32',
-                                    )
-                                    position_ids = paddle.static.data(
-                                        name="position_ids",
-                                        shape=position_ids_shape,
-                                        dtype='int64',
-                                    )
+        for (
+            q_shape,
+            k_shape,
+            cos_shape,
+            sin_shape,
+            position_ids_shape,
+        ) in itertools.product(
+            [[2, 8, 2, 16]],
+            [[2, 8, 2, 16]],
+            [[1, 8, 1, 16]],
+            [[1, 8, 1, 16]],
+            [[2, 8]],
+        ):
+            with paddle.pir_utils.IrGuard():
+                start_prog = paddle.static.Program()
+                main_prog = paddle.static.Program()
+                with paddle.pir.core.program_guard(main_prog, start_prog):
+                    q = paddle.static.data(
+                        name="q",
+                        shape=q_shape,
+                        dtype='float32',
+                    )
+                    k = paddle.static.data(
+                        name="k",
+                        shape=k_shape,
+                        dtype='float32',
+                    )
+                    cos = paddle.static.data(
+                        name="cos",
+                        shape=cos_shape,
+                        dtype='float32',
+                    )
+                    sin = paddle.static.data(
+                        name="sin",
+                        shape=sin_shape,
+                        dtype='float32',
+                    )
+                    position_ids = paddle.static.data(
+                        name="position_ids",
+                        shape=position_ids_shape,
+                        dtype='int64',
+                    )
 
-                                    cos = cos.squeeze(axis=[0, 2])
-                                    sin = sin.squeeze(axis=[0, 2])
-                                    cos = cos[position_ids].unsqueeze(2)
-                                    sin = sin[position_ids].unsqueeze(2)
+                    cos = cos.squeeze(axis=[0, 2])
+                    sin = sin.squeeze(axis=[0, 2])
+                    cos = cos[position_ids].unsqueeze(2)
+                    sin = sin[position_ids].unsqueeze(2)
 
-                                    q_embed = (q * cos) + (
-                                        self.rotate_half(q) * sin
-                                    )
-                                    k_embed = (k * cos) + (
-                                        self.rotate_half(k) * sin
-                                    )
+                    q_embed = (q * cos) + (self.rotate_half(q) * sin)
+                    k_embed = (k * cos) + (self.rotate_half(k) * sin)
 
-                                    out1 = paddle.assign(q_embed)
-                                    out2 = paddle.assign(k_embed)
+                    out1 = paddle.assign(q_embed)
+                    out2 = paddle.assign(k_embed)
 
-                                    position_ids_values = np.array(
-                                        [
-                                            [7, 5, 4, 6, 3, 1, 2, 0],
-                                            [3, 1, 4, 0, 7, 6, 5, 2],
-                                        ],
-                                        dtype='int64',
-                                    )
+                    position_ids_values = np.array(
+                        [
+                            [7, 5, 4, 6, 3, 1, 2, 0],
+                            [3, 1, 4, 0, 7, 6, 5, 2],
+                        ],
+                        dtype='int64',
+                    )
 
-                                    self.pass_attr_list = [
-                                        {
-                                            'fused_rotary_position_embedding_pass': {}
-                                        }
-                                    ]
+                    self.pass_attr_list = [
+                        {'fused_rotary_position_embedding_pass': {}}
+                    ]
 
-                                    self.feeds = {
-                                        "q": np.random.random(q_shape).astype(
-                                            "float32"
-                                        ),
-                                        "k": np.random.random(k_shape).astype(
-                                            "float32"
-                                        ),
-                                        "cos": np.random.random(
-                                            cos_shape
-                                        ).astype("float32"),
-                                        "sin": np.random.random(
-                                            sin_shape
-                                        ).astype("float32"),
-                                        "position_ids": np.broadcast_to(
-                                            np.arange(8, dtype='int64'), (2, 8)
-                                        ),
-                                    }
-                                    self.fetch_list = [out1, out2]
-                                    self.valid_op_map = {
-                                        "pd_op.squeeze": 0,
-                                        "pd_op.unsqueeze": 0,
-                                        "pd_op.concat": 0,
-                                        "pd_op.multiply": 0,
-                                        "pd_op.add": 0,
-                                        "pd_op.slice": 0,
-                                        "pd_op.scale": 0,
-                                        "builtin.combine": 0,
-                                        "pd_op.gather_nd": 0,
-                                        "pd_op.fused_rotary_position_embedding": 1,
-                                    }
-                                    yield [main_prog, start_prog], False
+                    self.feeds = {
+                        "q": np.random.random(q_shape).astype("float32"),
+                        "k": np.random.random(k_shape).astype("float32"),
+                        "cos": np.random.random(cos_shape).astype("float32"),
+                        "sin": np.random.random(sin_shape).astype("float32"),
+                        "position_ids": np.broadcast_to(
+                            np.arange(8, dtype='int64'), (2, 8)
+                        ),
+                    }
+                    self.fetch_list = [out1, out2]
+                    self.valid_op_map = {
+                        "pd_op.squeeze": 0,
+                        "pd_op.unsqueeze": 0,
+                        "pd_op.concat": 0,
+                        "pd_op.multiply": 0,
+                        "pd_op.add": 0,
+                        "pd_op.slice": 0,
+                        "pd_op.scale": 0,
+                        "builtin.combine": 0,
+                        "pd_op.gather_nd": 0,
+                        "pd_op.fused_rotary_position_embedding": 1,
+                    }
+                    yield [main_prog, start_prog], False
 
     def setUp(self):
         if core.is_compiled_with_cuda():

--- a/test/legacy_test/test_pairwise_distance.py
+++ b/test/legacy_test/test_pairwise_distance.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import itertools
 import unittest
 
 import numpy as np
@@ -114,93 +115,85 @@ class TestPairwiseDistance(unittest.TestCase):
         p_list = [-1, 0, 1, 2, np.inf, -np.inf]
         places = get_places()
         keeps = [False, True]
-        for place in places:
-            for shape in all_shape:
-                for dtype in dtypes:
-                    for p in p_list:
-                        for keepdim in keeps:
-                            x_np = np.random.random(shape).astype(dtype)
-                            y_np = np.random.random(shape).astype(dtype)
+        for place, shape, dtype, p, keepdim in itertools.product(
+            places, all_shape, dtypes, p_list, keeps
+        ):
+            x_np = np.random.random(shape).astype(dtype)
+            y_np = np.random.random(shape).astype(dtype)
 
-                            dygraph_ret = test_dygraph(
-                                place,
-                                x_np,
-                                y_np,
-                                p,
-                                epsilon=epsilon,
-                                keepdim=keepdim,
-                            )
-                            excepted_value = np_pairwise_distance(
-                                x_np, y_np, p, epsilon=epsilon, keepdim=keepdim
-                            )
+            dygraph_ret = test_dygraph(
+                place,
+                x_np,
+                y_np,
+                p,
+                epsilon=epsilon,
+                keepdim=keepdim,
+            )
+            excepted_value = np_pairwise_distance(
+                x_np, y_np, p, epsilon=epsilon, keepdim=keepdim
+            )
 
-                            self.assertEqual(
-                                dygraph_ret.shape, excepted_value.shape
-                            )
+            self.assertEqual(dygraph_ret.shape, excepted_value.shape)
 
-                            np.testing.assert_allclose(
-                                dygraph_ret, excepted_value, rtol=1e-05
-                            )
+            np.testing.assert_allclose(dygraph_ret, excepted_value, rtol=1e-05)
 
-                            dygraph_functional_ret = test_dygraph(
-                                place,
-                                x_np,
-                                y_np,
-                                p,
-                                epsilon=epsilon,
-                                keepdim=keepdim,
-                            )
+            dygraph_functional_ret = test_dygraph(
+                place,
+                x_np,
+                y_np,
+                p,
+                epsilon=epsilon,
+                keepdim=keepdim,
+            )
 
-                            self.assertEqual(
-                                dygraph_functional_ret.shape,
-                                excepted_value.shape,
-                            )
+            self.assertEqual(
+                dygraph_functional_ret.shape,
+                excepted_value.shape,
+            )
 
-                            np.testing.assert_allclose(
-                                dygraph_functional_ret,
-                                excepted_value,
-                                rtol=1e-05,
-                            )
+            np.testing.assert_allclose(
+                dygraph_functional_ret,
+                excepted_value,
+                rtol=1e-05,
+            )
 
-                            def dynamic_and_pir_mode_test():
-                                static_ret = test_static(
-                                    place,
-                                    x_np,
-                                    y_np,
-                                    p,
-                                    epsilon=epsilon,
-                                    keepdim=keepdim,
-                                )
+            def dynamic_and_pir_mode_test():
+                static_ret = test_static(
+                    place,
+                    x_np,
+                    y_np,
+                    p,
+                    epsilon=epsilon,
+                    keepdim=keepdim,
+                )
 
-                                self.assertEqual(
-                                    static_ret.shape, excepted_value.shape
-                                )
+                self.assertEqual(static_ret.shape, excepted_value.shape)
 
-                                np.testing.assert_allclose(
-                                    static_ret, excepted_value, rtol=1e-05
-                                )
+                np.testing.assert_allclose(
+                    static_ret, excepted_value, rtol=1e-05
+                )
 
-                                static_functional_ret = test_static(
-                                    place,
-                                    x_np,
-                                    y_np,
-                                    p,
-                                    epsilon=epsilon,
-                                    keepdim=keepdim,
-                                )
+                static_functional_ret = test_static(
+                    place,
+                    x_np,
+                    y_np,
+                    p,
+                    epsilon=epsilon,
+                    keepdim=keepdim,
+                )
 
-                                self.assertEqual(
-                                    static_functional_ret.shape,
-                                    excepted_value.shape,
-                                )
+                self.assertEqual(
+                    static_functional_ret.shape,
+                    excepted_value.shape,
+                )
 
-                                np.testing.assert_allclose(
-                                    static_functional_ret,
-                                    excepted_value,
-                                    rtol=1e-05,
-                                )
+                np.testing.assert_allclose(
+                    static_functional_ret,
+                    excepted_value,
+                    rtol=1e-05,
+                )
 
-                            dynamic_and_pir_mode_test()
+            dynamic_and_pir_mode_test()
 
     def test_pairwise_distance_broadcast_1(self):
         shape_x = [100, 100]

--- a/test/legacy_test/test_unpool_indices.py
+++ b/test/legacy_test/test_unpool_indices.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import itertools
 import unittest
 
 import numpy as np
@@ -49,12 +50,14 @@ def unpool1dmax_forward_naive(
     )
     out_lsize = output_size[0]
     out = np.zeros((s0, s1, out_lsize))
-    for nidx in range(s0):
-        for cidx in range(s1):
-            for l in range(s2):
-                index = indices[nidx, cidx, l]
-                lidx = index % out_lsize
-                out[nidx, cidx, lidx] = input[nidx, cidx, l]
+    for nidx, cidx, l in itertools.product(
+        range(s0),
+        range(s1),
+        range(s2),
+    ):
+        index = indices[nidx, cidx, l]
+        lidx = index % out_lsize
+        out[nidx, cidx, lidx] = input[nidx, cidx, l]
 
     return out
 
@@ -69,14 +72,16 @@ def unpool2dmax_forward_naive(
     out_hsize = output_size[0]
     out_wsize = output_size[1]
     out = np.zeros((s0, s1, out_hsize, out_wsize))
-    for nidx in range(s0):
-        for cidx in range(s1):
-            for h in range(s2):
-                for w in range(s3):
-                    index = indices[nidx, cidx, h, w]
-                    hidx = (index - index % out_wsize) // out_wsize
-                    widx = index % out_wsize
-                    out[nidx, cidx, hidx, widx] = input[nidx, cidx, h, w]
+    for nidx, cidx, h, w in itertools.product(
+        range(s0),
+        range(s1),
+        range(s2),
+        range(s3),
+    ):
+        index = indices[nidx, cidx, h, w]
+        hidx = (index - index % out_wsize) // out_wsize
+        widx = index % out_wsize
+        out[nidx, cidx, hidx, widx] = input[nidx, cidx, h, w]
 
     return out
 
@@ -92,22 +97,18 @@ def unpool3dmax_forward_naive(
     out_hsize = output_size[1]
     out_wsize = output_size[2]
     out = np.zeros((s0, s1, out_dsize, out_hsize, out_wsize))
-    for nidx in range(s0):
-        for cidx in range(s1):
-            for d in range(s2):
-                for h in range(s3):
-                    for w in range(s4):
-                        index = indices[nidx, cidx, d, h, w]
-                        didx = index // (out_wsize * out_hsize)
-                        hidx = (
-                            index - didx * out_hsize * out_wsize
-                        ) // out_wsize
-                        widx = (
-                            index - didx * out_hsize * out_wsize
-                        ) % out_wsize
-                        out[nidx, cidx, didx, hidx, widx] = input[
-                            nidx, cidx, d, h, w
-                        ]
+    for nidx, cidx, d, h, w in itertools.product(
+        range(s0),
+        range(s1),
+        range(s2),
+        range(s3),
+        range(s4),
+    ):
+        index = indices[nidx, cidx, d, h, w]
+        didx = index // (out_wsize * out_hsize)
+        hidx = (index - didx * out_hsize * out_wsize) // out_wsize
+        widx = (index - didx * out_hsize * out_wsize) % out_wsize
+        out[nidx, cidx, didx, hidx, widx] = input[nidx, cidx, d, h, w]
 
     return out
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

同 #61229，本 PR 清理 5 层及以上的嵌套循环，下个 PR 会添加相关的 ast-grep rule

<!-- PCard-66972 -->