### PR TITLE
Fix: FAILED when running pytest -q test/legacy_test/test_activation_op.py

### DIFF
--- a/test/legacy_test/test_activation_op.py
+++ b/test/legacy_test/test_activation_op.py
@@ -375,6 +375,8 @@ class Test_Expm1_Op_Int(unittest.TestCase):
 
 
 class TestParameter:
+    __test__ = False
+
     def test_out_name(self):
         with (
             static_guard(),


### PR DESCRIPTION
### PR Category
User Experience

### PR Types
Bug fixes


### Description
When running
```bash
pytest -q test/legacy_test/test_activation_op.py
```
the following failure will produce:

```text
=============================================== short test summary info ===============================================
FAILED test/legacy_test/test_activation_op.py::TestParameter::test_out_name - AttributeError: 'TestParameter' object has no attribute 'op_type'
FAILED test/legacy_test/test_activation_op.py::TestParameter::test_dygraph - AttributeError: 'TestParameter' object has no attribute 'op_type'
```

This is because pytest executes the class TestParameter as a test, however it's only a mixin with no `op_type`. Therefore, when running test on class TestTanh and class TestAtan, failure will be reported, though it doesn't effect the testing results of these two test class.

### Solution
Add `__test__ = False` to the class TestParameter to avoiding pytest collecting this mixin

### Changes
Before:
```python3
class TestParameter:

    def test_out_name(self):
        with (
            static_guard(),
            base.program_guard(base.Program()),
        ):
            np_x = np.array([0.1]).astype('float32').reshape((-1, 1))
            data = paddle.static.data(name="X", shape=[-1, 1], dtype="float32")
            out = eval(f"paddle.{self.op_type}(data, name='Y')")
            place = base.CPUPlace()
            exe = base.Executor(place)
            (result,) = exe.run(feed={"X": np_x}, fetch_list=[out])
            expected = eval(f"np.{self.op_type}(np_x)")
            np.testing.assert_allclose(result, expected, rtol=1e-05)

    def test_dygraph(self):
        with base.dygraph.guard():
            np_x = np.array([0.1])
            x = paddle.to_tensor(np_x)
            z = eval(f"paddle.{self.op_type}(x).numpy()")
            z_expected = eval(f"np.{self.op_type}(np_x)")
            np.testing.assert_allclose(z, z_expected, rtol=1e-05)
```
After:
```python3
class TestParameter:
    __test__ = False

    def test_out_name(self):
        with (
            static_guard(),
            base.program_guard(base.Program()),
        ):
            np_x = np.array([0.1]).astype('float32').reshape((-1, 1))
            data = paddle.static.data(name="X", shape=[-1, 1], dtype="float32")
            out = eval(f"paddle.{self.op_type}(data, name='Y')")
            place = base.CPUPlace()
            exe = base.Executor(place)
            (result,) = exe.run(feed={"X": np_x}, fetch_list=[out])
            expected = eval(f"np.{self.op_type}(np_x)")
            np.testing.assert_allclose(result, expected, rtol=1e-05)

    def test_dygraph(self):
        with base.dygraph.guard():
            np_x = np.array([0.1])
            x = paddle.to_tensor(np_x)
            z = eval(f"paddle.{self.op_type}(x).numpy()")
            z_expected = eval(f"np.{self.op_type}(np_x)")
            np.testing.assert_allclose(z, z_expected, rtol=1e-05)
```
