### PR TITLE
fix_PyObject_ToInt32 (#76419)

### DIFF
--- a/ci/dcu_test.sh
+++ b/ci/dcu_test.sh
@@ -23,6 +23,7 @@ function hybrid_paddlex() {
     unset HIP_VISIBLE_DEVICES
     git clone --depth=1000 https://gitee.com/paddlepaddle/PaddleX.git
     cd PaddleX
+    pip install --upgrade ruamel.yaml ruamel.yaml.clib
     pip install -e .[base]
     paddlex --install PaddleClas
     paddlex --install PaddleSeg

--- a/ci/dcu_test.sh
+++ b/ci/dcu_test.sh
@@ -23,7 +23,6 @@ function hybrid_paddlex() {
     unset HIP_VISIBLE_DEVICES
     git clone --depth=1000 https://gitee.com/paddlepaddle/PaddleX.git
     cd PaddleX
-    pip install --upgrade ruamel.yaml ruamel.yaml.clib
     pip install -e .[base]
     paddlex --install PaddleClas
     paddlex --install PaddleSeg


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
devPR:https://github.com/PaddlePaddle/Paddle/pull/76419
**问题描述：**
为了在PyObject_ToInt32函数中拦截超过int32的值，一开始在https://github.com/PaddlePaddle/Paddle/pull/76355 中将PyLong_AsLong替换成PyLong_AsLongLong，获取值后进行拦截判断。但是该实现在FD推理那边出现了异常拦截（由于没有环境，所以具体原因未知），所以进行了revert，还是使用PyLong_AsLong进行值转换，并增加PyErr_Occurred进行拦截。