### PR TITLE
[CINN] Add output for assign out && rename

### DIFF
--- a/paddle/common/flags.cc
+++ b/paddle/common/flags.cc
@@ -1146,7 +1146,7 @@ PHI_DEFINE_EXPORTED_string(deny_cinn_ops,
 
 /*
  * CINN related FLAG
- * Name: FLAGS_deny_cinn_ops
+ * Name: FLAGS_enable_cinn_compile_cache
  * Since Version: 3.0 Beta
  * Value Range: bool, default=true
  * Example: FLAGS_enable_cinn_compile_cache=true would reuse cached Kernel
@@ -1158,7 +1158,7 @@ PHI_DEFINE_EXPORTED_bool(
     "It controls whether to enable cinn compilation cache.");
 /*
  * CINN related FLAG
- * Name: FLAGS_deny_cinn_ops
+ * Name: FLAGS_cinn_compile_thread_num
  * Since Version: 3.0 Beta
  * Value Range: bool, default=-1
  * Example: FLAGS_cinn_compile_thread_num=8

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -3510,7 +3510,7 @@ def assign(x: TensorLike, output: paddle.Tensor | None = None) -> paddle.Tensor:
             if output is None:
                 output = _C_ops.assign(input)
             else:
-                _C_ops.assign_out_(input, output)
+                output = _C_ops.assign_out_(input, output)
         else:
             check_dtype(
                 input.dtype,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
<!-- Pcard-92901 -->

FastDeploy DeepseekV3 SOT转静 ✅，但是开启CINN❌，这一行会丢失 inplace 信息
```
output = paddle.assign(fmha_out_prefill + fmha_out_decode, output)
%152                        %134       +       %135,       %120
```
在组网期间，打出 `paddle.static.default_main_program()` 看，%152 这个输出丢失了，后面使用的是 %120

主要原因是目前 CINN Op 体系，没有传入 inplace 信息
后续会在 `GetJitKernelAttr` 部分给 `CINNKernelInfo` 添加 `inplace_map`

暂时可以通过 `export FLAGS_deny_cinn_ops="assign_out_"` 阻止 `pd_op.assign_out_` 走 CINN 来规避这个问题

----

调试时，可以通过这俩 Flag 关闭 CINN 多线程编译：
```
export FLAGS_enable_cinn_compile_cache=0
export FLAGS_cinn_compile_thread_num=1
```

报错内容：

```
E1119 10:50:13.956622 59721 multi_threading.cc:101] InvalidArgumentError: CudaAxisInfo is not valid. This check failed in block_dim() method.
  [Hint: Expected valid_ == true, but received valid_:0 != true:1.] (at ../paddle/cinn/ir/lowered_func.cc:699)
```

定位到时在死代码消除的地方，把其中一个分支弄没了:
```
I1119 10:56:46.273334 69953 schedule_block_dce.cc:162] 【BUG】Start EliminateDeadScheduleBlock{
  ScheduleBlock(root_888)
  {
    attrs(tile_method:TileFirstGeneralTactic)
    {
      thread_bind[blockIdx.x] for (i_j_fused, 0ll, (S36 * 2048ll))
      {
        ScheduleBlock(var_9)
        {
          i0_919, i1_626 = axis.bind((i_j_fused / 2048ll), (i_j_fused % 2048ll))
          read_buffers(_var_2[i0_919(0:S36), i1_626(0:2048ll)], _var[i0_919(0:S36)])
          write_buffers(_var_3[i0_919(0:S36), i1_626(0:2048ll)])
          {
            var_9[i0_919, i1_626] = (var_2[i0_919, i1_626] + var[(i1_626 / 128ll), i0_919, (i1_626 % 128ll)])
          }
        }
      }
    }
  }
}
I1119 10:56:46.273366 69953 schedule_block_dce.cc:146] Find dead schedule block: var_9 store: 0x4ef3d0e0 IsDeadStore(store) 1
I1119 10:56:46.273396 69953 schedule_block_dce.cc:165] 【BUG】End EliminateDeadScheduleBlock: {
  ScheduleBlock(root_888)
  {
    attrs(tile_method:TileFirstGeneralTactic)
    {

    }
  }
}
```

也就是这里：
```
void EliminateDeadScheduleBlock(Expr* e,
                                const std::vector<std::string>& output_names) {
  VLOG(6) << "Start EliminateDeadScheduleBlock" << *e;
  ScheduleBlockDCE eliminator(output_names);
  eliminator(e);
  VLOG(6) << "End EliminateDeadScheduleBlock: " << *e;
}
```