### PR TITLE
[SOT][3.14] fix `func_closure` lose、fix `CALL_FUNCTION_EX` kwargs_variable is `NullVariable`、add `MF.MF_HAS_ANNOTATE`、add `LOAD_COMMON_CONSTANT` opcode

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/instr_flag.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/instr_flag.py
@@ -32,7 +32,9 @@ class CONVERT_VALUE_FLAG:
     CV_ASCII = 3
 
 
+# https://github.com/python/cpython/blob/3.14/Include/internal/pycore_opcode_utils.h#L63-L68
 class MAKE_FUNCTION_FLAG:
+    MF_HAS_ANNOTATE = 0x10
     MF_HAS_CLOSURE = 0x08
     MF_HAS_ANNOTATION = 0x04
     MF_HAS_KWDEFAULTS = 0x02
@@ -57,3 +59,14 @@ class IntrinsicsUnaryFunctions(Enum):
     INTRINSIC_TYPEVARTUPLE = 9  # no support, PEP 695
     INTRINSIC_SUBSCRIPT_GENERIC = 10  # no support, PEP 695
     INTRINSIC_TYPEALIAS = 11  # no support, PEP 695
+
+
+# https://github.com/python/cpython/blob/3.14/Include/internal/pycore_opcode_utils.h#L70-L76
+# All are attributes of 'builtins'
+LOAD_COMMON_CONSTANT_FLAG = (
+    "AssertionError",
+    "NotImplementedError",
+    "tuple",
+    "all",
+    "any",
+)

--- a/python/paddle/jit/sot/opcode_translator/executor/pycode_generator.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/pycode_generator.py
@@ -813,6 +813,8 @@ class PyCodeGen:
         return self.add_instr("BINARY_OP", arg=BINARY_OP_ARG_MAP["NB_SUBSCR"])
 
     def gen_build_tuple(self, count):
+        if sys.version_info >= (3, 14) and count == 0:
+            return self.gen_load_const(())
         return self.add_instr("BUILD_TUPLE", arg=count, argval=count)
 
     def gen_build_list(self, count):

--- a/python/paddle/jit/sot/opcode_translator/instruction_utils/opcode_info.py
+++ b/python/paddle/jit/sot/opcode_translator/instruction_utils/opcode_info.py
@@ -29,7 +29,7 @@ UNCONDITIONAL_JUMP = {"JUMP_ABSOLUTE", "JUMP_FORWARD"}
 if sys.version_info >= (3, 11):
     UNCONDITIONAL_JUMP.add("JUMP_BACKWARD")
 RETURN = {"RETURN_VALUE"}
-if sys.version_info >= (3, 12):
+if (3, 12) <= sys.version_info < (3, 14):
     RETURN.add("RETURN_CONST")
 
 

--- a/test/sot/test_24_exceptions.py
+++ b/test/sot/test_24_exceptions.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import sys
 import unittest
 
 from test_case_base import (
@@ -961,9 +962,13 @@ class TestBuiltinFunctionRaiseExceptionGuard(TestCaseBase):
             0,
         )
         self.assert_results(foo_mod, 10)
+        if sys.version_info >= (3, 14):
+            zero_mod_msg = "division by zero"
+        else:
+            zero_mod_msg = "integer (.)*modulo by zero"
         self.assert_exceptions(
             ZeroDivisionError,
-            "integer (.)*modulo by zero",
+            zero_mod_msg,
             foo_mod,
             0,
         )


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->

新增字节码 `LOAD_COMMON_CONSTANT`, 在 `test_24_exceptions` 有测到（部分）就不加新单测了

通过的单测
- `test_10_build_unpack.py`
- `test_13_make_function.py`
- `test_15_slice.py`
- `test_17_paddle_layer.py`
- `test_19_closure.py`
- `test_23_super.py`
- `test_24_exceptions.py`
- `test_builtin_map.py`
- `test_capture_control_flow.py`
- `test_force_dynamic.py`
- `test_numpy_array.py`
- `test_sot_export.py`
- `test_sot_resnet.py`
- `test_sot_resnet50_backward.py`
- `test_str_format.py`

剩余单测 0