### PR TITLE
[large tensor] Improve no-int64-type-cuda-index-without-cast rule and fix some large tensor issue

### DIFF
--- a/ci/rule-tests/__snapshots__/no-int32-type-dims-snapshot.yml
+++ b/ci/rule-tests/__snapshots__/no-int32-type-dims-snapshot.yml
@@ -2,8 +2,8 @@ id: no-int32-type-dims
 snapshots:
   int class_num = prob->dims()[1];:
     fixed: |
-      int64_t class_num = prob->dims()[1];
       // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+      int64_t class_num = prob->dims()[1];
     labels:
       - source: int class_num = prob->dims()[1];
         style: primary
@@ -21,8 +21,8 @@ snapshots:
         end: 34
   int row_size = x.dims()[ndim - 1];:
     fixed: |
-      int64_t row_size = x.dims()[ndim - 1];
       // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+      int64_t row_size = x.dims()[ndim - 1];
     labels:
       - source: int row_size = x.dims()[ndim - 1];
         style: primary
@@ -30,8 +30,8 @@ snapshots:
         end: 34
   int32_t input_ids_num = input.numel();:
     fixed: |
-      int64_t input_ids_num = input.numel();
       // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+      int64_t input_ids_num = input.numel();
     labels:
       - source: int32_t input_ids_num = input.numel();
         style: primary

--- a/ci/rules/no-int32-type-dims.yml
+++ b/ci/rules/no-int32-type-dims.yml
@@ -29,8 +29,10 @@ constraints:
       # dims[...] / expr.dims()[...] / expr->dims()[...]
       - pattern: $E.dims[$INDEX]
       - pattern: $E.dims()[$INDEX]
+      - pattern: $E.dims($INDEX)
       - pattern: $E->dims[$INDEX]
       - pattern: $E->dims()[$INDEX]
+      - pattern: $E->dims($INDEX)
       # shape[...] / expr.shape()[...] / expr->shape()[...]
       - pattern: $E.shape[$INDEX]
       - pattern: $E.shape()[$INDEX]

--- a/ci/rules/no-int32-type-dims.yml
+++ b/ci/rules/no-int32-type-dims.yml
@@ -2,6 +2,7 @@ id: no-int32-type-dims
 language: cpp
 files:
   - paddle/phi/kernels/**
+  # - paddle/**
 ignores:
   - paddle/phi/kernels/legacy/**
   - paddle/phi/kernels/xpu/**
@@ -41,14 +42,12 @@ constraints:
       - pattern: $E->strides[$INDEX]
       - pattern: $E->strides()[$INDEX]
       # numel / numel()
-      - pattern: $E.numel
       - pattern: $E.numel()
-      - pattern: $E->numel()
       - pattern: $E->numel()
         # offset / offset()
         # unsafe
         # - pattern: $E.offset
         # - pattern: $E.offset()
 fix: |
-  int64_t $VAR = $RIGHT;
   // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  int64_t $VAR = $RIGHT;

--- a/ci/rules/no-int64-type-cuda-index-without-cast.yml
+++ b/ci/rules/no-int64-type-cuda-index-without-cast.yml
@@ -1,13 +1,7 @@
 id: no-int64-type-cuda-index-without-cast
 language: cpp
 files:
-  - paddle/phi/kernels/**
-  # - paddle/**
-ignores:
-  - paddle/phi/kernels/legacy/**
-  - paddle/phi/kernels/xpu/**
-  - paddle/phi/kernels/custom/**
-  - paddle/phi/kernels/sparse/**
+  - paddle/**
 severity: error
 message: CUDA indexing calculation assigned to int64_t variable may overflow due to intermediate 32-bit arithmetic. If it is a false positive, please contact zrr1999 (Recommend), wanghuancoder for more information.
 note: Add static_cast<int64_t> to each CUDA built-in variable in the expression to prevent integer overflow during calculation.

--- a/ci/rules/no-int64-type-cuda-index-without-cast.yml
+++ b/ci/rules/no-int64-type-cuda-index-without-cast.yml
@@ -2,6 +2,7 @@ id: no-int64-type-cuda-index-without-cast
 language: cpp
 files:
   - paddle/phi/kernels/**
+  # - paddle/**
 ignores:
   - paddle/phi/kernels/legacy/**
   - paddle/phi/kernels/xpu/**
@@ -12,21 +13,19 @@ message: CUDA indexing calculation assigned to int64_t variable may overflow due
 note: Add static_cast<int64_t> to each CUDA built-in variable in the expression to prevent integer overflow during calculation.
 rule:
   any:
-    # int64_t x = <expr with threadIdx|blockDim|blockIdx|gridDim>;
-    - all:
-        - pattern: $T $VAR = $EXPR
-    # int64_t x(<expr with threadIdx|blockDim|blockIdx|gridDim>);
-    - all:
-        - pattern: $T $VAR($EXPR)
+    - pattern: $T $VAR = $EXPR
 constraints:
   T:
-    regex: ^(int64_t)$
+    regex: ^(int64_t|size_t|IndexType)$
   EXPR:
-    all:
+    kind: binary_expression
+    any:
       - regex: \b(threadIdx|blockIdx|blockDim|gridDim)\.(x|y|z|w)?\b
-      - kind: binary_expression
-      - not:
-          regex: "static_cast<int64_t>"
+    # - regex: \b(THREAD_ID|BLOCK_NUM|BLOCK_ID)_(X|Y|Z|W)?\b
+    not:
+      any:
+        - regex: static_cast<(int64_t|size_t|IndexType)>
+        - regex: \[(threadIdx|blockIdx|blockDim|gridDim)\.(x|y|z|w)\]
 rewriters:
   - id: add-static-cast
     rule:
@@ -34,10 +33,10 @@ rewriters:
     constraints:
       IDENT:
         regex: ^(threadIdx|blockIdx|blockDim|gridDim)$
-    fix: static_cast<int64_t>($IDENT.$ATTR)
+    fix: static_cast<$T>($IDENT.$ATTR)
 transform:
   NEW_EXPR:
     rewrite:
       rewriters: [add-static-cast]
       source: $EXPR
-fix: int64_t $VAR = $NEW_EXPR;
+fix: $T $VAR = $NEW_EXPR;

--- a/paddle/fluid/framework/data_feed.cu
+++ b/paddle/fluid/framework/data_feed.cu
@@ -522,7 +522,9 @@ __global__ void GraphFillIdKernel(uint64_t *id_tensor,
   __shared__ int global_num;
   bool need_filter = false;
 
-  size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  size_t idx =
+      static_cast<size_t>(blockIdx.x) * static_cast<size_t>(blockDim.x) +
+      static_cast<size_t>(threadIdx.x);
   if (threadIdx.x == 0) {
     local_num = 0;
   }
@@ -578,7 +580,9 @@ __global__ void GraphFillIdKernel(uint64_t *id_tensor,
 }
 
 __global__ void GraphZeroIdKernel(uint64_t *id_tensor, int len) {
-  size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  size_t idx =
+      static_cast<size_t>(blockIdx.x) * static_cast<size_t>(blockDim.x) +
+      static_cast<size_t>(threadIdx.x);
   uint64_t zerokey = 0;
   if (idx < len) {
     int dst = idx * 2;

--- a/paddle/fluid/framework/fleet/heter_ps/hashtable_kernel.cu
+++ b/paddle/fluid/framework/fleet/heter_ps/hashtable_kernel.cu
@@ -245,7 +245,9 @@ __global__ void get_keys_kernel(Table* table,
   __shared__ uint64_t local_num;
   __shared__ uint64_t global_num;
 
-  size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  size_t idx =
+      static_cast<size_t>(blockIdx.x) * static_cast<size_t>(blockDim.x) +
+      static_cast<size_t>(threadIdx.x);
   if (threadIdx.x == 0) {
     local_num = 0;
   }
@@ -283,7 +285,9 @@ __global__ void get_key_values_kernel(Table* table,
   __shared__ uint64_t local_num;
   __shared__ uint64_t global_num;
 
-  size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  size_t idx =
+      static_cast<size_t>(blockIdx.x) * static_cast<size_t>(blockDim.x) +
+      static_cast<size_t>(threadIdx.x);
   if (threadIdx.x == 0) {
     local_num = 0;
   }

--- a/paddle/fluid/inference/tensorrt/plugin/group_norm_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/group_norm_op_plugin.cu
@@ -93,7 +93,7 @@ __global__ void groupNormNCHW32SumKernelQDQ(
   int32_t ci = blockIdx.x * params.cPerBlock + threadIdx.x * 2;
 
   // The first activation loaded by that block.
-  int64_t dhwBegin = blockIdx.y * params.dhwPerBlock;
+  int64_t dhwBegin = static_cast<int64_t>(blockIdx.y) * params.dhwPerBlock;
   // The last activation loaded by that block.
   int64_t dhwEnd = min(dhwBegin + params.dhwPerBlock, params.dhw);
 
@@ -235,7 +235,7 @@ __global__ void groupNormNCHW32ScaleKernelQDQ(
   float invStdDev = rsqrtf(var + params.eps);
 
   // The first activation loaded by that block.
-  int64_t dhwBegin = blockIdx.y * params.dhwPerBlock;
+  int64_t dhwBegin = static_cast<int64_t>(blockIdx.y) * params.dhwPerBlock;
   // The last activation loaded by that block.
   int64_t dhwEnd = min(dhwBegin + params.dhwPerBlock, params.dhw);
 

--- a/paddle/fluid/inference/tensorrt/plugin/preln_groupnorm_act_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/preln_groupnorm_act_op_plugin.cu
@@ -140,7 +140,7 @@ __global__ void prelnGroupNormNDHWCSumKernel(
   int32_t ci = blockIdx.x * params.cPerBlock + threadIdx.x * 2;
 
   // The first activation loaded by that block.
-  int64_t dhwBegin = blockIdx.y * params.dhwPerBlock;
+  int64_t dhwBegin = static_cast<int64_t>(blockIdx.y) * params.dhwPerBlock;
   // The last activation loaded by that block.
   int64_t dhwEnd = min(dhwBegin + params.dhwPerBlock, params.dhw);
 
@@ -309,7 +309,7 @@ __global__ void prelnGroupNormNDHWCScaleKernel(
   float invStdDev = rsqrtf(var + params.eps);
 
   // The first activation loaded by that block.
-  int64_t dhwBegin = blockIdx.y * params.dhwPerBlock;
+  int64_t dhwBegin = static_cast<int64_t>(blockIdx.y) * params.dhwPerBlock;
   // The last activation loaded by that block.
   int64_t dhwEnd = min(dhwBegin + params.dhwPerBlock, params.dhw);
 

--- a/paddle/fluid/inference/tensorrt/plugin/skip_groupnorm_act_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/skip_groupnorm_act_op_plugin.cu
@@ -151,7 +151,7 @@ __global__ void skipGroupNormNDHWCSumKernel(
   int32_t ci = blockIdx.x * params.cPerBlock + threadIdx.x * 2;
 
   // The first activation loaded by that block.
-  int64_t dhwBegin = blockIdx.y * params.dhwPerBlock;
+  int64_t dhwBegin = static_cast<int64_t>(blockIdx.y) * params.dhwPerBlock;
   // The last activation loaded by that block.
   int64_t dhwEnd = min(dhwBegin + params.dhwPerBlock, params.dhw);
 
@@ -321,7 +321,7 @@ __global__ void skipGroupNormNDHWCScaleKernel(
   float invStdDev = rsqrtf(var + params.eps);
 
   // The first activation loaded by that block.
-  int64_t dhwBegin = blockIdx.y * params.dhwPerBlock;
+  int64_t dhwBegin = static_cast<int64_t>(blockIdx.y) * params.dhwPerBlock;
   // The last activation loaded by that block.
   int64_t dhwEnd = min(dhwBegin + params.dhwPerBlock, params.dhw);
 

--- a/paddle/phi/kernels/cpu/eig.h
+++ b/paddle/phi/kernels/cpu/eig.h
@@ -348,8 +348,14 @@ void ComputeBackwardForComplexInput(const DenseTensor& L,
   // Vh: matrix with shape [m,m]
   // rhs: rhs with shape [m,k]
   // x_grad: out
-  int m = Vh.dims(-1);
-  int k = rhs.dims(-1);
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  int64_t m = Vh.dims(-1);
+
+  // TODO(large-tensor): downstream functors may still use int; guard until
+  // upgraded.
+  int64_t k = rhs.dims(-1);
+
   auto* matrix_data = Vh.data<T>();
   auto* rhs_data = rhs.data<T>();
 

--- a/paddle/phi/kernels/cpu/lrn_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/lrn_grad_kernel.cc
@@ -35,10 +35,10 @@ struct LRNGradFunctor<phi::CPUContext, T> {
                   const phi::DenseTensor& mid,
                   phi::DenseTensor* x_g,
                   const phi::DenseTensor& out_g,
-                  int N,
-                  int C,
-                  int H,
-                  int W,
+                  int64_t N,
+                  int64_t C,
+                  int64_t H,
+                  int64_t W,
                   int n,
                   T alpha,
                   T beta,
@@ -55,13 +55,13 @@ struct LRNGradFunctor<phi::CPUContext, T> {
 
     const int start = -(n - 1) / 2;
     const int end = start + n;
-    for (int m = 0; m < N; m++) {
-      for (int i = 0; i < C; i++) {
-        auto offsets = Eigen::array<int, 4>({{m, i, 0, 0}});
-        auto extents = Eigen::array<int, 4>({{1, 1, H, W}});
+    for (int64_t m = 0; m < N; m++) {
+      for (int64_t i = 0; i < C; i++) {
+        auto offsets = Eigen::array<int64_t, 4>({{m, i, 0, 0}});
+        auto extents = Eigen::array<int64_t, 4>({{1, 1, H, W}});
         if (data_layout == DataLayout::kNHWC) {
-          offsets = Eigen::array<int, 4>({{m, 0, 0, i}});
-          extents = Eigen::array<int, 4>({{1, H, W, 1}});
+          offsets = Eigen::array<int64_t, 4>({{m, 0, 0, i}});
+          extents = Eigen::array<int64_t, 4>({{1, H, W, 1}});
         }
 
         auto i_x = e_x.slice(offsets, extents);
@@ -71,15 +71,15 @@ struct LRNGradFunctor<phi::CPUContext, T> {
 
         i_x_g = i_mid.pow(-beta) * i_out_g;
         for (int c = start; c < end; c++) {
-          int ch = i + c;
+          int64_t ch = i + c;
           if (ch < 0 || ch >= C) {
             continue;
           }
 
           if (data_layout != DataLayout::kNHWC) {
-            offsets = Eigen::array<int, 4>({{m, ch, 0, 0}});
+            offsets = Eigen::array<int64_t, 4>({{m, ch, 0, 0}});
           } else {
-            offsets = Eigen::array<int, 4>({{m, 0, 0, ch}});
+            offsets = Eigen::array<int64_t, 4>({{m, 0, 0, ch}});
           }
           auto c_out = e_out.slice(offsets, extents);
           auto c_mid = e_mid.slice(offsets, extents);

--- a/paddle/phi/kernels/cpu/lrn_kernel.cc
+++ b/paddle/phi/kernels/cpu/lrn_kernel.cc
@@ -33,10 +33,10 @@ struct LRNFunctor<phi::CPUContext, T> {
                   const phi::DenseTensor& input,
                   phi::DenseTensor* out,
                   phi::DenseTensor* mid,
-                  int N,
-                  int C,
-                  int H,
-                  int W,
+                  int64_t N,
+                  int64_t C,
+                  int64_t H,
+                  int64_t W,
                   int n,
                   T k,
                   T alpha,
@@ -76,22 +76,22 @@ struct LRNFunctor<phi::CPUContext, T> {
     squared.Resize({1, C + n - 1, H, W});
     T* sdata = dev_ctx.Alloc<T>(&squared);
     std::memset(sdata, 0, sizeof(T) * squared.numel());
-    for (int i = 0; i < mid->numel(); ++i) {
+    for (int64_t i = 0; i < mid->numel(); ++i) {
       mdata[i] = k;
     }
-    int img_size = H * W;
-    int fea_size = C * img_size;
+    int64_t img_size = H * W;
+    int64_t fea_size = C * img_size;
     int pre_pad = (n - 1) / 2;
     // compute batches one by one
-    for (int i = 0; i < N; ++i) {
+    for (int64_t i = 0; i < N; ++i) {
       blas.VSQUARE(fea_size, idata + i * fea_size, sdata + pre_pad * img_size);
       // init the first channel of mid
       for (int c = 0; c < n; ++c) {
         blas.AXPY(img_size, alpha, sdata + c * img_size, mdata + i * fea_size);
       }
-      for (int c = 1; c < C; ++c) {
+      for (int64_t c = 1; c < C; ++c) {
         // copy previous scale
-        int mid_offset = i * fea_size + c * img_size;
+        int64_t mid_offset = i * fea_size + c * img_size;
         std::memcpy(mdata + mid_offset,
                     mdata + mid_offset - img_size,
                     img_size * sizeof(T));

--- a/paddle/phi/kernels/cpu/rnn_functor.h
+++ b/paddle/phi/kernels/cpu/rnn_functor.h
@@ -215,10 +215,10 @@ void AllocateReserveData(const Context& dev_ctx,
                          DenseTensor* hidden_data,
                          const DenseTensor* input) {
   int direction_num = is_bidirec ? 2 : 1;
-  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  // TODO(large-tensor): downstream functors may still use int
   int64_t time_step = input->dims()[0];
 
-  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  // TODO(large-tensor): downstream functors may still use int
   int64_t batch_size = input->dims()[1];
 
   int block_size = direction_num * time_step * batch_size * hidden_size;

--- a/paddle/phi/kernels/cpu/rnn_functor.h
+++ b/paddle/phi/kernels/cpu/rnn_functor.h
@@ -215,8 +215,12 @@ void AllocateReserveData(const Context& dev_ctx,
                          DenseTensor* hidden_data,
                          const DenseTensor* input) {
   int direction_num = is_bidirec ? 2 : 1;
-  int time_step = input->dims()[0];
-  int batch_size = input->dims()[1];
+  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  int64_t time_step = input->dims()[0];
+
+  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  int64_t batch_size = input->dims()[1];
+
   int block_size = direction_num * time_step * batch_size * hidden_size;
   int hidden_data_idx = (num_layers - 1);
   if (is_lstm(mode)) {

--- a/paddle/phi/kernels/cpu/tdm_child_kernel.cc
+++ b/paddle/phi/kernels/cpu/tdm_child_kernel.cc
@@ -37,8 +37,7 @@ void TDMChildInner(const Context &dev_ctx,
   int length = info_dims[1];
 
   int64_t input_ids_num = input.numel();
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   VLOG(4) << "TDM child op: input numel ->  " << input_ids_num;
 

--- a/paddle/phi/kernels/cpu/tdm_sampler_kernel.cc
+++ b/paddle/phi/kernels/cpu/tdm_sampler_kernel.cc
@@ -44,8 +44,7 @@ void TDMSamplerInner(const Context &dev_ctx,
                      phi::DenseTensor *mask) {
   // get dimension
   int64_t input_ids_num = input_tensor.numel();
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   VLOG(3) << "TDM: input ids nums: " << input_ids_num;
   auto layer_nums = neg_samples_num_list.size();

--- a/paddle/phi/kernels/funcs/cross_entropy.cu
+++ b/paddle/phi/kernels/funcs/cross_entropy.cu
@@ -123,12 +123,10 @@ void CrossEntropyFunctor<DeviceContext, T>::operator()(
   const T* prob_data = prob->data<T>();
 
   int64_t batch_size = prob->dims()[0];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   int64_t class_num = prob->dims()[1];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   constexpr int kMaxBlockDim = 512;
 

--- a/paddle/phi/kernels/funcs/cublaslt.h
+++ b/paddle/phi/kernels/funcs/cublaslt.h
@@ -249,9 +249,15 @@ void CublasLtMatmulFP8(const phi::GPUContext& dev_ctx,
                        const phi::DenseTensor& mat_b,
                        phi::DenseTensor* workspace,
                        phi::DenseTensor* out) {
-  int m = mat_a.dims()[0];
-  int k = mat_a.dims()[1];
-  int n = mat_b.dims()[1];
+  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  int64_t m = mat_a.dims()[0];
+
+  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  int64_t k = mat_a.dims()[1];
+
+  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  int64_t n = mat_b.dims()[1];
+
 
   // init data structure
   cublasStatus_t status;

--- a/paddle/phi/kernels/funcs/cublaslt.h
+++ b/paddle/phi/kernels/funcs/cublaslt.h
@@ -249,15 +249,14 @@ void CublasLtMatmulFP8(const phi::GPUContext& dev_ctx,
                        const phi::DenseTensor& mat_b,
                        phi::DenseTensor* workspace,
                        phi::DenseTensor* out) {
-  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  // TODO(large-tensor): downstream functors may still use int
   int64_t m = mat_a.dims()[0];
 
-  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  // TODO(large-tensor): downstream functors may still use int
   int64_t k = mat_a.dims()[1];
 
-  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  // TODO(large-tensor): downstream functors may still use int
   int64_t n = mat_b.dims()[1];
-
 
   // init data structure
   cublasStatus_t status;

--- a/paddle/phi/kernels/funcs/detection/bbox_util.cu.h
+++ b/paddle/phi/kernels/funcs/detection/bbox_util.cu.h
@@ -295,7 +295,9 @@ static void NMS(const phi::GPUContext &dev_ctx,
                 const T nms_threshold,
                 phi::DenseTensor *keep_out,
                 bool pixel_offset = true) {
-  int boxes_num = proposals.dims()[0];
+  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  int64_t boxes_num = proposals.dims()[0];
+
   const int col_blocks = DIVUP(boxes_num, kThreadsPerBlock);
   dim3 blocks(DIVUP(boxes_num, kThreadsPerBlock),
               DIVUP(boxes_num, kThreadsPerBlock));

--- a/paddle/phi/kernels/funcs/detection/bbox_util.cu.h
+++ b/paddle/phi/kernels/funcs/detection/bbox_util.cu.h
@@ -295,7 +295,7 @@ static void NMS(const phi::GPUContext &dev_ctx,
                 const T nms_threshold,
                 phi::DenseTensor *keep_out,
                 bool pixel_offset = true) {
-  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  // TODO(large-tensor): downstream functors may still use int
   int64_t boxes_num = proposals.dims()[0];
 
   const int col_blocks = DIVUP(boxes_num, kThreadsPerBlock);

--- a/paddle/phi/kernels/funcs/detection/bbox_util.h
+++ b/paddle/phi/kernels/funcs/detection/bbox_util.h
@@ -106,10 +106,10 @@ void BboxOverlaps(const phi::DenseTensor& r_boxes,
   auto r_boxes_et = phi::EigenTensor<T, 2>::From(r_boxes);
   auto c_boxes_et = phi::EigenTensor<T, 2>::From(c_boxes);
   auto overlaps_et = phi::EigenTensor<T, 2>::From(*overlaps);
-  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  // TODO(large-tensor): downstream functors may still use int
   int64_t r_num = r_boxes.dims()[0];
 
-  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  // TODO(large-tensor): downstream functors may still use int
   int64_t c_num = c_boxes.dims()[0];
 
   auto zero = static_cast<T>(0.0);
@@ -141,10 +141,10 @@ void BboxOverlaps(const phi::DenseTensor& r_boxes,
 template <typename T>
 void MaxIoU(const phi::DenseTensor& iou, phi::DenseTensor* max_iou) {
   const T* iou_data = iou.data<T>();
-  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  // TODO(large-tensor): downstream functors may still use int
   int64_t row = iou.dims()[0];
 
-  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  // TODO(large-tensor): downstream functors may still use int
   int64_t col = iou.dims()[1];
 
   T* max_iou_data = max_iou->data<T>();

--- a/paddle/phi/kernels/funcs/detection/bbox_util.h
+++ b/paddle/phi/kernels/funcs/detection/bbox_util.h
@@ -106,8 +106,12 @@ void BboxOverlaps(const phi::DenseTensor& r_boxes,
   auto r_boxes_et = phi::EigenTensor<T, 2>::From(r_boxes);
   auto c_boxes_et = phi::EigenTensor<T, 2>::From(c_boxes);
   auto overlaps_et = phi::EigenTensor<T, 2>::From(*overlaps);
-  int r_num = r_boxes.dims()[0];
-  int c_num = c_boxes.dims()[0];
+  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  int64_t r_num = r_boxes.dims()[0];
+
+  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  int64_t c_num = c_boxes.dims()[0];
+
   auto zero = static_cast<T>(0.0);
   T r_box_area, c_box_area, x_min, y_min, x_max, y_max, inter_w, inter_h,
       inter_area;
@@ -137,8 +141,12 @@ void BboxOverlaps(const phi::DenseTensor& r_boxes,
 template <typename T>
 void MaxIoU(const phi::DenseTensor& iou, phi::DenseTensor* max_iou) {
   const T* iou_data = iou.data<T>();
-  int row = iou.dims()[0];
-  int col = iou.dims()[1];
+  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  int64_t row = iou.dims()[0];
+
+  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  int64_t col = iou.dims()[1];
+
   T* max_iou_data = max_iou->data<T>();
   for (int i = 0; i < row; ++i) {
     const T* v = iou_data + i * col;

--- a/paddle/phi/kernels/funcs/diag_functor.h
+++ b/paddle/phi/kernels/funcs/diag_functor.h
@@ -113,7 +113,9 @@ DenseTensor BatchDiag(const Context& dev_ctx, const DenseTensor& x, int batch) {
     out_shape.push_back(x.dims()[i]);
   }
   out.Resize(common::make_ddim(out_shape));
-  int order = x.dims()[num_dims - 1];
+  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  int64_t order = x.dims()[num_dims - 1];
+
   int stride_out = order * order;
   int stride_in = order + 1;
   for (int64_t i = 0; i < batch; ++i) {

--- a/paddle/phi/kernels/funcs/diag_functor.h
+++ b/paddle/phi/kernels/funcs/diag_functor.h
@@ -113,7 +113,7 @@ DenseTensor BatchDiag(const Context& dev_ctx, const DenseTensor& x, int batch) {
     out_shape.push_back(x.dims()[i]);
   }
   out.Resize(common::make_ddim(out_shape));
-  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  // TODO(large-tensor): downstream functors may still use int
   int64_t order = x.dims()[num_dims - 1];
 
   int stride_out = order * order;

--- a/paddle/phi/kernels/funcs/elementwise/elementwise_op_function.h
+++ b/paddle/phi/kernels/funcs/elementwise/elementwise_op_function.h
@@ -792,8 +792,9 @@ static __global__ void FusedElemwiseAndActGradBroadcast1CUDAKernel(
     T *dy,
     T *d_intermediate) {
   __shared__ T sdata[BLOCK_Y][BLOCK_X];
-  size_t idx = threadIdx.x + BLOCK_X * blockIdx.x;
-  size_t width_stride = gridDim.x * BLOCK_X;
+  size_t idx = static_cast<size_t>(threadIdx.x) +
+               BLOCK_X * static_cast<size_t>(blockIdx.x);
+  size_t width_stride = static_cast<size_t>(gridDim.x) * BLOCK_X;
 
   size_t full_w = ROUNDUP(w, BLOCK_X);
 
@@ -874,7 +875,7 @@ static __global__ void FusedElemwiseAndActGradBroadcast1CUDAKernel(
       val += phi::backends::gpu::CudaShuffleXorSync(0xFFFFFFFF, val, i);
     }
 
-    size_t idx_j = j + threadIdx.y;
+    size_t idx_j = j + static_cast<size_t>(threadIdx.y);
     if (BcastY) {
       if (dy) {
         if (threadIdx.x == 0 && (idx_j < w)) dy[idx_j] = val;

--- a/paddle/phi/kernels/funcs/exclusive_scan.h
+++ b/paddle/phi/kernels/funcs/exclusive_scan.h
@@ -133,7 +133,7 @@ static __global__ void ExclusiveScanInnerDimCUDAKernel(
   size_t block_row = static_cast<size_t>(blockIdx.x * kThreadNumY);
   size_t block_row_stride = static_cast<size_t>(gridDim.x * kThreadNumY);
   for (; block_row < num_rows; block_row += block_row_stride) {
-    size_t row = block_row + threadIdx.y;
+    size_t row = block_row + static_cast<size_t>(threadIdx.y);
     T block_total = init;
 
     const T *row_x = x + row * row_size;
@@ -186,7 +186,7 @@ static __global__ void ExclusiveScanInnerDimCUDAKernel(
 
       for (size_t s = kThreadNumX, d = 1; s >= 1; s >>= 1, d <<= 1) {
         if (row < num_rows && threadIdx.x < s) {
-          size_t offset = (2 * threadIdx.x + 1) * d - 1;
+          size_t offset = (2 * static_cast<size_t>(threadIdx.x) + 1) * d - 1;
           row_buf[offset + d] = op(row_buf[offset], row_buf[offset + d]);
         }
         __syncthreads();
@@ -194,7 +194,7 @@ static __global__ void ExclusiveScanInnerDimCUDAKernel(
 
       for (size_t s = 2, d = kThreadNumX / 2; d >= 1; s <<= 1, d >>= 1) {
         if (row < num_rows && threadIdx.x < s - 1) {
-          size_t offset = 2 * (threadIdx.x + 1) * d - 1;
+          size_t offset = 2 * (static_cast<size_t>(threadIdx.x) + 1) * d - 1;
           row_buf[offset + d] = op(row_buf[offset], row_buf[offset + d]);
         }
         __syncthreads();

--- a/paddle/phi/kernels/funcs/im2col.cu
+++ b/paddle/phi/kernels/funcs/im2col.cu
@@ -44,9 +44,8 @@ __global__ void im2col(const T* data_im,
   int64_t input_channels = num_outs / col_height / col_width;
   int64_t channels_col = input_channels * filter_height * filter_width;
   const int64_t index =
-      static_cast<int64_t>(blockIdx.x * gridDim.y + blockIdx.y) *
-          static_cast<int64_t>(blockDim.x) +
-      static_cast<int64_t>(threadIdx.x);
+      (static_cast<int64_t>(blockIdx.x) * gridDim.y + blockIdx.y) * blockDim.x +
+      threadIdx.x;
   if (index < num_outs) {
     int64_t w_out = (data_layout != DataLayout::NHWC
                          ? index % col_width
@@ -133,9 +132,11 @@ class Im2ColFunctor<phi::funcs::ColFormat::kCFO, DeviceContext, T> {
 #ifdef WITH_NV_JETSON
     phi::backends::gpu::ChangeThreadNum(dev_ctx, &num_thread);
 #endif
-    int blocks = (num_outputs + num_thread - 1) / num_thread;
+    int64_t blocks = (num_outputs + num_thread - 1) / num_thread;
+    PADDLE_ENFORCE_LE_INT_MAX(blocks, "blocks");
+
     int block_x = 512;
-    int block_y = (blocks + 512 - 1) / 512;
+    int block_y = (static_cast<int>(blocks) + 512 - 1) / 512;
     dim3 threads(num_thread, 1);
     dim3 grid(block_x, block_y);
     im2col<T><<<grid, threads, 0, dev_ctx.stream()>>>(im.data<T>(),

--- a/paddle/phi/kernels/funcs/im2col.cu
+++ b/paddle/phi/kernels/funcs/im2col.cu
@@ -128,7 +128,7 @@ class Im2ColFunctor<phi::funcs::ColFormat::kCFO, DeviceContext, T> {
     int64_t col_width = col->dims()[4];
 
     int64_t num_outputs = im_channels * col_height * col_width;
-    int num_thread = 1024;
+    int num_thread = 512;
 #ifdef WITH_NV_JETSON
     phi::backends::gpu::ChangeThreadNum(dev_ctx, &num_thread);
 #endif
@@ -290,7 +290,7 @@ class Col2ImFunctor<phi::funcs::ColFormat::kCFO, DeviceContext, T> {
 
     int64_t num_kernels = im_channels * im_height * im_width;
 
-    int num_thread = 1024;
+    int num_thread = 512;
 #ifdef WITH_NV_JETSON
     phi::backends::gpu::ChangeThreadNum(dev_ctx, &num_thread);
 #endif

--- a/paddle/phi/kernels/funcs/im2col.cu
+++ b/paddle/phi/kernels/funcs/im2col.cu
@@ -116,11 +116,11 @@ class Im2ColFunctor<phi::funcs::ColFormat::kCFO, DeviceContext, T> {
                           "elements, but got %lld",
                           im.numel()));
 
-    int im_channels =
+    int64_t im_channels =
         (data_layout != DataLayout::NHWC ? im.dims()[0] : im.dims()[2]);
-    int im_height =
+    int64_t im_height =
         (data_layout != DataLayout::NHWC ? im.dims()[1] : im.dims()[0]);
-    int im_width =
+    int64_t im_width =
         (data_layout != DataLayout::NHWC ? im.dims()[2] : im.dims()[1]);
     int64_t filter_height = col->dims()[1];
     int64_t filter_width = col->dims()[2];
@@ -165,8 +165,8 @@ __global__ void col2im(int64_t n,
                        int64_t im_width,
                        int dilation_h,
                        int dilation_w,
-                       int64_t filter_height,
-                       int64_t filter_width,
+                       int filter_height,
+                       int filter_width,
                        int stride_height,
                        int stride_width,
                        int padding_height,
@@ -176,14 +176,15 @@ __global__ void col2im(int64_t n,
                        T* data_im,
                        const DataLayout data_layout) {
   const int64_t index =
-      static_cast<int64_t>(blockIdx.x * gridDim.y + blockIdx.y) *
-          static_cast<int64_t>(blockDim.x) +
-      static_cast<int64_t>(threadIdx.x);
+      (static_cast<int64_t>(blockIdx.x) * gridDim.y + blockIdx.y) * blockDim.x +
+      threadIdx.x;
 
-  const int64_t d_filter_height = dilation_h * (filter_height - 1) + 1;
-  const int64_t d_filter_width = dilation_w * (filter_width - 1) + 1;
+  // NOTE(zrr1999): dilation_x and filter_x are usually small
+  const int d_filter_height = dilation_h * (filter_height - 1) + 1;
+  const int d_filter_width = dilation_w * (filter_width - 1) + 1;
 
-  int64_t input_channels = n / im_height / im_width;
+  // NOTE(zrr1999): input_channels must be less than the range of int32
+  int input_channels = n / im_height / im_width;
 
   if (index < n) {
     T val = static_cast<T>(0);
@@ -194,8 +195,8 @@ __global__ void col2im(int64_t n,
                      ? (index / im_width) % im_height + padding_height
                      : (index / input_channels / im_width) % im_height +
                            padding_height);
-    int64_t c = (data_layout != DataLayout::NHWC ? index / im_width / im_height
-                                                 : index % input_channels);
+    int c = (data_layout != DataLayout::NHWC ? index / im_width / im_height
+                                             : index % input_channels);
 
     // compute the start and end of the output
     int64_t w_col_start =
@@ -206,8 +207,8 @@ __global__ void col2im(int64_t n,
     int64_t h_col_end = min(h / stride_height + 1, col_height);
 
     for (int64_t h_col = h_col_start; h_col < h_col_end; ++h_col) {
+      int64_t h_off = (h - h_col * stride_height);
       for (int64_t w_col = w_col_start; w_col < w_col_end; ++w_col) {
-        int64_t h_off = (h - h_col * stride_height);
         int64_t w_off = (w - w_col * stride_width);
         if (h_off % dilation_h == 0 && w_off % dilation_w == 0) {
           h_off /= dilation_h;
@@ -226,7 +227,6 @@ __global__ void col2im(int64_t n,
     data_im[index] = val;
   }
 }
-
 /*
  * im = [input_channels, input_height, input_width]
  * col =
@@ -255,16 +255,21 @@ class Col2ImFunctor<phi::funcs::ColFormat::kCFO, DeviceContext, T> {
                           "the dims of tensor 'col' is [%s].",
                           col.dims()));
 
-    int im_channels =
+    int64_t im_channels =
         (data_layout != DataLayout::NHWC ? im->dims()[0] : im->dims()[2]);
-    int im_height =
+    int64_t im_height =
         (data_layout != DataLayout::NHWC ? im->dims()[1] : im->dims()[0]);
-    int im_width =
+    int64_t im_width =
         (data_layout != DataLayout::NHWC ? im->dims()[2] : im->dims()[1]);
     int64_t filter_height = col.dims()[1];
     int64_t filter_width = col.dims()[2];
     int64_t col_height = col.dims()[3];
     int64_t col_width = col.dims()[4];
+
+    // NOTE(zrr1999): im_channels, filter_height, filter_width are usually small
+    PADDLE_ENFORCE_LE_INT_MAX(im_channels, "im_channels");
+    PADDLE_ENFORCE_LE_INT_MAX(filter_height, "filter_height");
+    PADDLE_ENFORCE_LE_INT_MAX(filter_width, "filter_width");
 
     PADDLE_ENFORCE_EQ(
         (im_height + padding[0] + padding[2] -
@@ -283,15 +288,17 @@ class Col2ImFunctor<phi::funcs::ColFormat::kCFO, DeviceContext, T> {
         common::errors::InvalidArgument("col_width and padding(padding_left, "
                                         "padding_right) are inconsistent."));
 
-    size_t num_kernels = im_channels * im_height * im_width;
+    int64_t num_kernels = im_channels * im_height * im_width;
 
     int num_thread = 1024;
 #ifdef WITH_NV_JETSON
     phi::backends::gpu::ChangeThreadNum(dev_ctx, &num_thread);
 #endif
-    size_t blocks = (num_kernels + num_thread - 1) / num_thread;
-    size_t block_x = 512;
-    size_t block_y = (blocks + 512 - 1) / 512;
+    int64_t blocks = (num_kernels + num_thread - 1) / num_thread;
+    PADDLE_ENFORCE_LE_INT_MAX(blocks, "blocks");
+
+    int block_x = 512;
+    int block_y = (static_cast<int>(blocks) + 512 - 1) / 512;
     dim3 threads(num_thread, 1);
     dim3 grid(block_x, block_y);
 

--- a/paddle/phi/kernels/funcs/im2col.cu
+++ b/paddle/phi/kernels/funcs/im2col.cu
@@ -26,45 +26,47 @@ namespace funcs {
 
 template <class T>
 __global__ void im2col(const T* data_im,
-                       int num_outs,
-                       int im_height,
-                       int im_width,
+                       int64_t num_outs,
+                       int64_t im_height,
+                       int64_t im_width,
                        int dilation_h,
                        int dilation_w,
-                       int filter_height,
-                       int filter_width,
+                       int64_t filter_height,
+                       int64_t filter_width,
                        int stride_height,
                        int stride_width,
                        int padding_height,
                        int padding_width,
-                       int col_height,
-                       int col_width,
+                       int64_t col_height,
+                       int64_t col_width,
                        T* data_col,
                        const DataLayout data_layout) {
-  int input_channels = num_outs / col_height / col_width;
-  int channels_col = input_channels * filter_height * filter_width;
-  const int index =
-      (blockIdx.x * gridDim.y + blockIdx.y) * blockDim.x + threadIdx.x;
+  int64_t input_channels = num_outs / col_height / col_width;
+  int64_t channels_col = input_channels * filter_height * filter_width;
+  const int64_t index =
+      static_cast<int64_t>(blockIdx.x * gridDim.y + blockIdx.y) *
+          static_cast<int64_t>(blockDim.x) +
+      static_cast<int64_t>(threadIdx.x);
   if (index < num_outs) {
-    int w_out = (data_layout != DataLayout::NHWC
-                     ? index % col_width
-                     : (index / input_channels) % col_width);
-    int h_out = (data_layout != DataLayout::NHWC
-                     ? (index / col_width) % col_height
-                     : (index / input_channels / col_width) % col_height);
-    int channel_in =
+    int64_t w_out = (data_layout != DataLayout::NHWC
+                         ? index % col_width
+                         : (index / input_channels) % col_width);
+    int64_t h_out = (data_layout != DataLayout::NHWC
+                         ? (index / col_width) % col_height
+                         : (index / input_channels / col_width) % col_height);
+    int64_t channel_in =
         (data_layout != DataLayout::NHWC ? index / col_width / col_height
                                          : index % input_channels);
-    int channel_out = channel_in * filter_height * filter_width;
-    int h_in = h_out * stride_height - padding_height;
-    int w_in = w_out * stride_width - padding_width;
+    int64_t channel_out = channel_in * filter_height * filter_width;
+    int64_t h_in = h_out * stride_height - padding_height;
+    int64_t w_in = w_out * stride_width - padding_width;
 
     data_col += (channel_out * col_height + h_out) * col_width + w_out;
-    for (int i = 0; i < filter_height; ++i) {
-      for (int j = 0; j < filter_width; ++j) {
-        int rIdx = h_in + i * dilation_h;
-        int cIdx = w_in + j * dilation_w;
-        int im_idx;
+    for (int64_t i = 0; i < filter_height; ++i) {
+      for (int64_t j = 0; j < filter_width; ++j) {
+        int64_t rIdx = h_in + i * dilation_h;
+        int64_t cIdx = w_in + j * dilation_w;
+        int64_t im_idx;
         if (data_layout != DataLayout::NHWC) {
           im_idx = (channel_in * im_height + rIdx) * im_width + cIdx;
         } else {
@@ -122,22 +124,11 @@ class Im2ColFunctor<phi::funcs::ColFormat::kCFO, DeviceContext, T> {
     int im_width =
         (data_layout != DataLayout::NHWC ? im.dims()[2] : im.dims()[1]);
     int64_t filter_height = col->dims()[1];
-    // TODO(large-tensor): downstream functors may still use int; guard until
-    // upgraded.
-
     int64_t filter_width = col->dims()[2];
-    // TODO(large-tensor): downstream functors may still use int; guard until
-    // upgraded.
-
     int64_t col_height = col->dims()[3];
-    // TODO(large-tensor): downstream functors may still use int; guard until
-    // upgraded.
-
     int64_t col_width = col->dims()[4];
-    // TODO(large-tensor): downstream functors may still use int; guard until
-    // upgraded.
 
-    int num_outputs = im_channels * col_height * col_width;
+    int64_t num_outputs = im_channels * col_height * col_width;
     int num_thread = 1024;
 #ifdef WITH_NV_JETSON
     phi::backends::gpu::ChangeThreadNum(dev_ctx, &num_thread);
@@ -167,58 +158,60 @@ class Im2ColFunctor<phi::funcs::ColFormat::kCFO, DeviceContext, T> {
 };
 
 template <class T>
-__global__ void col2im(int n,
+__global__ void col2im(int64_t n,
                        const T* data_col,
-                       int im_height,
-                       int im_width,
+                       int64_t im_height,
+                       int64_t im_width,
                        int dilation_h,
                        int dilation_w,
-                       int filter_height,
-                       int filter_width,
+                       int64_t filter_height,
+                       int64_t filter_width,
                        int stride_height,
                        int stride_width,
                        int padding_height,
                        int padding_width,
-                       int col_height,
-                       int col_width,
+                       int64_t col_height,
+                       int64_t col_width,
                        T* data_im,
                        const DataLayout data_layout) {
-  const int index =
-      (blockIdx.x * gridDim.y + blockIdx.y) * blockDim.x + threadIdx.x;
+  const int64_t index =
+      static_cast<int64_t>(blockIdx.x * gridDim.y + blockIdx.y) *
+          static_cast<int64_t>(blockDim.x) +
+      static_cast<int64_t>(threadIdx.x);
 
-  const int d_filter_height = dilation_h * (filter_height - 1) + 1;
-  const int d_filter_width = dilation_w * (filter_width - 1) + 1;
+  const int64_t d_filter_height = dilation_h * (filter_height - 1) + 1;
+  const int64_t d_filter_width = dilation_w * (filter_width - 1) + 1;
 
-  int input_channels = n / im_height / im_width;
+  int64_t input_channels = n / im_height / im_width;
 
   if (index < n) {
     T val = static_cast<T>(0);
-    int w = (data_layout != DataLayout::NHWC
-                 ? index % im_width + padding_width
-                 : (index / input_channels) % im_width + padding_width);
-    int h = (data_layout != DataLayout::NHWC
-                 ? (index / im_width) % im_height + padding_height
-                 : (index / input_channels / im_width) % im_height +
-                       padding_height);
-    int c = (data_layout != DataLayout::NHWC ? index / im_width / im_height
-                                             : index % input_channels);
+    int64_t w = (data_layout != DataLayout::NHWC
+                     ? index % im_width + padding_width
+                     : (index / input_channels) % im_width + padding_width);
+    int64_t h = (data_layout != DataLayout::NHWC
+                     ? (index / im_width) % im_height + padding_height
+                     : (index / input_channels / im_width) % im_height +
+                           padding_height);
+    int64_t c = (data_layout != DataLayout::NHWC ? index / im_width / im_height
+                                                 : index % input_channels);
 
     // compute the start and end of the output
-    int w_col_start =
+    int64_t w_col_start =
         (w < d_filter_width) ? 0 : (w - d_filter_width) / stride_width + 1;
-    int w_col_end = min(w / stride_width + 1, col_width);
-    int h_col_start =
+    int64_t w_col_end = min(w / stride_width + 1, col_width);
+    int64_t h_col_start =
         (h < d_filter_height) ? 0 : (h - d_filter_height) / stride_height + 1;
-    int h_col_end = min(h / stride_height + 1, col_height);
+    int64_t h_col_end = min(h / stride_height + 1, col_height);
 
-    for (int h_col = h_col_start; h_col < h_col_end; ++h_col) {
-      for (int w_col = w_col_start; w_col < w_col_end; ++w_col) {
-        int h_off = (h - h_col * stride_height);
-        int w_off = (w - w_col * stride_width);
+    for (int64_t h_col = h_col_start; h_col < h_col_end; ++h_col) {
+      for (int64_t w_col = w_col_start; w_col < w_col_end; ++w_col) {
+        int64_t h_off = (h - h_col * stride_height);
+        int64_t w_off = (w - w_col * stride_width);
         if (h_off % dilation_h == 0 && w_off % dilation_w == 0) {
           h_off /= dilation_h;
           w_off /= dilation_w;
-          int data_col_index =
+          int64_t data_col_index =
               (((c * filter_height + h_off) * filter_width + w_off) *
                    col_height +
                h_col) *
@@ -268,20 +261,9 @@ class Col2ImFunctor<phi::funcs::ColFormat::kCFO, DeviceContext, T> {
     int im_width =
         (data_layout != DataLayout::NHWC ? im->dims()[2] : im->dims()[1]);
     int64_t filter_height = col.dims()[1];
-    // TODO(large-tensor): downstream functors may still use int; guard until
-    // upgraded.
-
     int64_t filter_width = col.dims()[2];
-    // TODO(large-tensor): downstream functors may still use int; guard until
-    // upgraded.
-
     int64_t col_height = col.dims()[3];
-    // TODO(large-tensor): downstream functors may still use int; guard until
-    // upgraded.
-
     int64_t col_width = col.dims()[4];
-    // TODO(large-tensor): downstream functors may still use int; guard until
-    // upgraded.
 
     PADDLE_ENFORCE_EQ(
         (im_height + padding[0] + padding[2] -
@@ -362,33 +344,33 @@ template class PADDLE_API
 
 template <class T>
 __global__ void im2colOCF(const T* im_data,
-                          int im_channels,
-                          int im_height,
-                          int im_width,
-                          int filter_height,
-                          int filter_width,
+                          int64_t im_channels,
+                          int64_t im_height,
+                          int64_t im_width,
+                          int64_t filter_height,
+                          int64_t filter_width,
                           int stride_height,
                           int stride_width,
                           int padding_height,
                           int padding_width,
-                          int col_height,
-                          int col_width,
+                          int64_t col_height,
+                          int64_t col_width,
                           T* col_data) {
-  int swid = blockIdx.x;
-  int shid = blockIdx.y;
-  for (int channelid = threadIdx.z; channelid < im_channels;
+  int64_t swid = blockIdx.x;
+  int64_t shid = blockIdx.y;
+  for (int64_t channelid = threadIdx.z; channelid < im_channels;
        channelid += blockDim.z) {
-    for (int idy = threadIdx.y; idy < filter_height; idy += blockDim.y) {
-      for (int idx = threadIdx.x; idx < filter_width; idx += blockDim.x) {
-        int width_offset = idx + swid * stride_width - padding_width;
-        int height_offset = idy + shid * stride_height - padding_height;
-        int im_offset = width_offset + height_offset * im_width +
-                        channelid * im_height * im_width;
+    for (int64_t idy = threadIdx.y; idy < filter_height; idy += blockDim.y) {
+      for (int64_t idx = threadIdx.x; idx < filter_width; idx += blockDim.x) {
+        int64_t width_offset = idx + swid * stride_width - padding_width;
+        int64_t height_offset = idy + shid * stride_height - padding_height;
+        int64_t im_offset = width_offset + height_offset * im_width +
+                            channelid * im_height * im_width;
 
-        int col_offset = idx + idy * filter_width +
-                         channelid * filter_height * filter_width +
-                         (shid * col_width + swid) *
-                             (im_channels * filter_height * filter_width);
+        int64_t col_offset = idx + idy * filter_width +
+                             channelid * filter_height * filter_width +
+                             (shid * col_width + swid) *
+                                 (im_channels * filter_height * filter_width);
 
         col_data[col_offset] =
             (height_offset >= im_height || height_offset < 0 ||
@@ -429,32 +411,12 @@ class Im2ColFunctor<phi::funcs::ColFormat::kOCF, DeviceContext, T> {
                           col->dims()));
 
     int64_t im_channels = im.dims()[0];
-    // TODO(large-tensor): downstream functors may still use int; guard until
-    // upgraded.
-
     int64_t im_height = im.dims()[1];
-    // TODO(large-tensor): downstream functors may still use int; guard until
-    // upgraded.
-
     int64_t im_width = im.dims()[2];
-    // TODO(large-tensor): downstream functors may still use int; guard until
-    // upgraded.
-
     int64_t filter_height = col->dims()[3];
-    // TODO(large-tensor): downstream functors may still use int; guard until
-    // upgraded.
-
     int64_t filter_width = col->dims()[4];
-    // TODO(large-tensor): downstream functors may still use int; guard until
-    // upgraded.
-
     int64_t col_height = col->dims()[0];
-    // TODO(large-tensor): downstream functors may still use int; guard until
-    // upgraded.
-
     int64_t col_width = col->dims()[1];
-    // TODO(large-tensor): downstream functors may still use int; guard until
-    // upgraded.
 
     int block_dim_x = 0;
     int block_dim_y = 0;
@@ -495,33 +457,33 @@ class Im2ColFunctor<phi::funcs::ColFormat::kOCF, DeviceContext, T> {
 
 template <class T>
 __global__ void col2imOCF(const T* col_data,
-                          int im_channels,
-                          int im_height,
-                          int im_width,
-                          int filter_height,
-                          int filter_width,
+                          int64_t im_channels,
+                          int64_t im_height,
+                          int64_t im_width,
+                          int64_t filter_height,
+                          int64_t filter_width,
                           int stride_height,
                           int stride_width,
                           int padding_height,
                           int padding_width,
-                          int col_height,
-                          int col_width,
+                          int64_t col_height,
+                          int64_t col_width,
                           T* im_data) {
-  int swid = blockIdx.x;
-  int shid = blockIdx.y;
-  for (int channelid = threadIdx.z; channelid < im_channels;
+  int64_t swid = blockIdx.x;
+  int64_t shid = blockIdx.y;
+  for (int64_t channelid = threadIdx.z; channelid < im_channels;
        channelid += blockDim.z) {
-    for (int idy = threadIdx.y; idy < filter_height; idy += blockDim.y) {
-      for (int idx = threadIdx.x; idx < filter_width; idx += blockDim.x) {
-        int width_offset = idx + swid * stride_width - padding_width;
-        int height_offset = idy + shid * stride_height - padding_height;
-        int im_offset = width_offset + height_offset * im_width +
-                        channelid * im_height * im_width;
+    for (int64_t idy = threadIdx.y; idy < filter_height; idy += blockDim.y) {
+      for (int64_t idx = threadIdx.x; idx < filter_width; idx += blockDim.x) {
+        int64_t width_offset = idx + swid * stride_width - padding_width;
+        int64_t height_offset = idy + shid * stride_height - padding_height;
+        int64_t im_offset = width_offset + height_offset * im_width +
+                            channelid * im_height * im_width;
 
-        int col_offset = idx + idy * filter_width +
-                         channelid * filter_height * filter_width +
-                         (shid * col_width + swid) *
-                             (im_channels * filter_height * filter_width);
+        int64_t col_offset = idx + idy * filter_width +
+                             channelid * filter_height * filter_width +
+                             (shid * col_width + swid) *
+                                 (im_channels * filter_height * filter_width);
 
         if (height_offset >= 0 && height_offset < im_height &&
             width_offset >= 0 && width_offset < im_width) {
@@ -561,32 +523,12 @@ class Col2ImFunctor<phi::funcs::ColFormat::kOCF, DeviceContext, T> {
                           col.dims()));
 
     int64_t im_channels = im->dims()[0];
-    // TODO(large-tensor): downstream functors may still use int; guard until
-    // upgraded.
-
     int64_t im_height = im->dims()[1];
-    // TODO(large-tensor): downstream functors may still use int; guard until
-    // upgraded.
-
     int64_t im_width = im->dims()[2];
-    // TODO(large-tensor): downstream functors may still use int; guard until
-    // upgraded.
-
     int64_t filter_height = col.dims()[3];
-    // TODO(large-tensor): downstream functors may still use int; guard until
-    // upgraded.
-
     int64_t filter_width = col.dims()[4];
-    // TODO(large-tensor): downstream functors may still use int; guard until
-    // upgraded.
-
     int64_t col_height = col.dims()[0];
-    // TODO(large-tensor): downstream functors may still use int; guard until
-    // upgraded.
-
     int64_t col_width = col.dims()[1];
-    // TODO(large-tensor): downstream functors may still use int; guard until
-    // upgraded.
 
     PADDLE_ENFORCE_EQ(
         (im_height + padding[0] + padding[2] -

--- a/paddle/phi/kernels/funcs/im2col_cfo_cpu.h
+++ b/paddle/phi/kernels/funcs/im2col_cfo_cpu.h
@@ -38,10 +38,18 @@ inline void im2col_common(const phi::DenseTensor& im,
       (data_layout != DataLayout::kNHWC ? im.dims()[1] : im.dims()[0]);
   int im_width =
       (data_layout != DataLayout::kNHWC ? im.dims()[2] : im.dims()[1]);
-  int filter_height = col->dims()[1];
-  int filter_width = col->dims()[2];
-  int output_height = col->dims()[3];
-  int output_width = col->dims()[4];
+  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  int64_t filter_height = col->dims()[1];
+
+  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  int64_t filter_width = col->dims()[2];
+
+  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  int64_t output_height = col->dims()[3];
+
+  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  int64_t output_width = col->dims()[4];
+
   int channels_col = im_channels * filter_height * filter_width;
 
   // Convert dimensions to 64-bit to prevent overflow in arithmetic operations
@@ -101,10 +109,18 @@ inline void im2col_sh1sw1dh1dw1ph0pw0(
       (data_layout != DataLayout::kNHWC ? im.dims()[1] : im.dims()[0]);
   int im_width =
       (data_layout != DataLayout::kNHWC ? im.dims()[2] : im.dims()[1]);
-  int filter_height = col->dims()[1];
-  int filter_width = col->dims()[2];
-  int output_height = col->dims()[3];
-  int output_width = col->dims()[4];
+  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  int64_t filter_height = col->dims()[1];
+
+  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  int64_t filter_width = col->dims()[2];
+
+  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  int64_t output_height = col->dims()[3];
+
+  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  int64_t output_width = col->dims()[4];
+
 
   const T* im_data = im.data<T>();
   T* col_data = col->data<T>();
@@ -153,10 +169,18 @@ inline void im2col_sh1sw1dh1dw1ph1pw1(const phi::DenseTensor& im,
       (data_layout != DataLayout::kNHWC ? im.dims()[1] : im.dims()[0]);
   int im_width =
       (data_layout != DataLayout::kNHWC ? im.dims()[2] : im.dims()[1]);
-  int filter_height = col->dims()[1];
-  int filter_width = col->dims()[2];
-  int output_height = col->dims()[3];
-  int output_width = col->dims()[4];
+  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  int64_t filter_height = col->dims()[1];
+
+  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  int64_t filter_width = col->dims()[2];
+
+  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  int64_t output_height = col->dims()[3];
+
+  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  int64_t output_width = col->dims()[4];
+
 
   constexpr int plh = 1;
   constexpr int prh = 1;

--- a/paddle/phi/kernels/funcs/im2col_cfo_cpu.h
+++ b/paddle/phi/kernels/funcs/im2col_cfo_cpu.h
@@ -38,16 +38,16 @@ inline void im2col_common(const phi::DenseTensor& im,
       (data_layout != DataLayout::kNHWC ? im.dims()[1] : im.dims()[0]);
   int im_width =
       (data_layout != DataLayout::kNHWC ? im.dims()[2] : im.dims()[1]);
-  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  // TODO(large-tensor): downstream functors may still use int
   int64_t filter_height = col->dims()[1];
 
-  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  // TODO(large-tensor): downstream functors may still use int
   int64_t filter_width = col->dims()[2];
 
-  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  // TODO(large-tensor): downstream functors may still use int
   int64_t output_height = col->dims()[3];
 
-  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  // TODO(large-tensor): downstream functors may still use int
   int64_t output_width = col->dims()[4];
 
   int channels_col = im_channels * filter_height * filter_width;
@@ -109,18 +109,17 @@ inline void im2col_sh1sw1dh1dw1ph0pw0(
       (data_layout != DataLayout::kNHWC ? im.dims()[1] : im.dims()[0]);
   int im_width =
       (data_layout != DataLayout::kNHWC ? im.dims()[2] : im.dims()[1]);
-  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  // TODO(large-tensor): downstream functors may still use int
   int64_t filter_height = col->dims()[1];
 
-  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  // TODO(large-tensor): downstream functors may still use int
   int64_t filter_width = col->dims()[2];
 
-  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  // TODO(large-tensor): downstream functors may still use int
   int64_t output_height = col->dims()[3];
 
-  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  // TODO(large-tensor): downstream functors may still use int
   int64_t output_width = col->dims()[4];
-
 
   const T* im_data = im.data<T>();
   T* col_data = col->data<T>();
@@ -169,18 +168,17 @@ inline void im2col_sh1sw1dh1dw1ph1pw1(const phi::DenseTensor& im,
       (data_layout != DataLayout::kNHWC ? im.dims()[1] : im.dims()[0]);
   int im_width =
       (data_layout != DataLayout::kNHWC ? im.dims()[2] : im.dims()[1]);
-  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  // TODO(large-tensor): downstream functors may still use int
   int64_t filter_height = col->dims()[1];
 
-  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  // TODO(large-tensor): downstream functors may still use int
   int64_t filter_width = col->dims()[2];
 
-  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  // TODO(large-tensor): downstream functors may still use int
   int64_t output_height = col->dims()[3];
 
-  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  // TODO(large-tensor): downstream functors may still use int
   int64_t output_width = col->dims()[4];
-
 
   constexpr int plh = 1;
   constexpr int prh = 1;

--- a/paddle/phi/kernels/funcs/im2col_cfo_cpu.h
+++ b/paddle/phi/kernels/funcs/im2col_cfo_cpu.h
@@ -32,47 +32,33 @@ inline void im2col_common(const phi::DenseTensor& im,
                           const std::vector<int>& padding,
                           phi::DenseTensor* col,
                           const DataLayout data_layout = DataLayout::kNCHW) {
-  int im_channels =
+  int64_t im_channels =
       (data_layout != DataLayout::kNHWC ? im.dims()[0] : im.dims()[2]);
-  int im_height =
+  int64_t im_height =
       (data_layout != DataLayout::kNHWC ? im.dims()[1] : im.dims()[0]);
-  int im_width =
+  int64_t im_width =
       (data_layout != DataLayout::kNHWC ? im.dims()[2] : im.dims()[1]);
-  // TODO(large-tensor): downstream functors may still use int
   int64_t filter_height = col->dims()[1];
-
-  // TODO(large-tensor): downstream functors may still use int
   int64_t filter_width = col->dims()[2];
-
-  // TODO(large-tensor): downstream functors may still use int
   int64_t output_height = col->dims()[3];
-
-  // TODO(large-tensor): downstream functors may still use int
   int64_t output_width = col->dims()[4];
 
-  int channels_col = im_channels * filter_height * filter_width;
-
-  // Convert dimensions to 64-bit to prevent overflow in arithmetic operations
-  const int64_t im_channels64 = im_channels;
-  const int64_t im_height64 = im_height;
-  const int64_t im_width64 = im_width;
-  const int64_t output_height64 = output_height;
-  const int64_t output_width64 = output_width;
+  int64_t channels_col = im_channels * filter_height * filter_width;
 
   const T* im_data = im.data<T>();
   T* col_data = col->data<T>();
-  for (int c = 0; c < channels_col; ++c) {
-    int w_offset = c % filter_width;
-    int h_offset = (c / filter_width) % filter_height;
-    int c_im = c / (filter_width * filter_height);
-    for (int h = 0; h < output_height; ++h) {
-      int im_row_idx = h * stride[0] - padding[0] + h_offset * dilation[0];
-      for (int w = 0; w < output_width; ++w) {
-        int im_col_idx = w * stride[1] - padding[1] + w_offset * dilation[1];
+  for (int64_t c = 0; c < channels_col; ++c) {
+    int64_t w_offset = c % filter_width;
+    int64_t h_offset = (c / filter_width) % filter_height;
+    int64_t c_im = c / (filter_width * filter_height);
+    for (int64_t h = 0; h < output_height; ++h) {
+      int64_t im_row_idx = h * stride[0] - padding[0] + h_offset * dilation[0];
+      for (int64_t w = 0; w < output_width; ++w) {
+        int64_t im_col_idx =
+            w * stride[1] - padding[1] + w_offset * dilation[1];
 
         // Calculate col_idx using 64-bit arithmetic to prevent overflow
-        int64_t col_idx64 =
-            ((int64_t)c * output_height64 + h) * output_width64 + w;
+        int64_t col_idx64 = (c * output_height + h) * output_width + w;
 
         // Check bounds first to avoid buffer overflow in im_idx calculation
         if (im_row_idx < 0 || im_row_idx >= im_height || im_col_idx < 0 ||
@@ -81,12 +67,10 @@ inline void im2col_common(const phi::DenseTensor& im,
         } else {
           int64_t im_idx64;
           if (data_layout != DataLayout::kNHWC) {
-            im_idx64 = ((int64_t)c_im * im_height64 + im_row_idx) * im_width64 +
-                       im_col_idx;
+            im_idx64 = (c_im * im_height + im_row_idx) * im_width + im_col_idx;
           } else {
-            im_idx64 = ((int64_t)im_row_idx * im_width64 + im_col_idx) *
-                           im_channels64 +
-                       c_im;
+            im_idx64 =
+                (im_row_idx * im_width + im_col_idx) * im_channels + c_im;
           }
           *(col_data + col_idx64) = *(im_data + im_idx64);
         }
@@ -109,36 +93,29 @@ inline void im2col_sh1sw1dh1dw1ph0pw0(
       (data_layout != DataLayout::kNHWC ? im.dims()[1] : im.dims()[0]);
   int im_width =
       (data_layout != DataLayout::kNHWC ? im.dims()[2] : im.dims()[1]);
-  // TODO(large-tensor): downstream functors may still use int
   int64_t filter_height = col->dims()[1];
-
-  // TODO(large-tensor): downstream functors may still use int
   int64_t filter_width = col->dims()[2];
-
-  // TODO(large-tensor): downstream functors may still use int
   int64_t output_height = col->dims()[3];
-
-  // TODO(large-tensor): downstream functors may still use int
   int64_t output_width = col->dims()[4];
 
   const T* im_data = im.data<T>();
   T* col_data = col->data<T>();
-  int col_matrix_width = output_width * output_height;
-  int im_size = im_height * im_width;
+  int64_t col_matrix_width = output_width * output_height;
+  int64_t im_size = im_height * im_width;
   size_t copy_size = sizeof(T) * output_width;
   const T* im_data_oh = im_data;
   T* dst_data_oh = col_data;
-  for (int oh = 0; oh < output_height; ++oh) {
+  for (int64_t oh = 0; oh < output_height; ++oh) {
     const T* src_data_ic = im_data_oh;
     T* dst_data = dst_data_oh;
     for (int ic = 0; ic < im_channels; ++ic) {
       const T* src_data = src_data_ic;
-      for (int kh = 0; kh < filter_height; ++kh) {
-        for (int kw = 0; kw < filter_width; ++kw) {
+      for (int64_t kh = 0; kh < filter_height; ++kh) {
+        for (int64_t kw = 0; kw < filter_width; ++kw) {
           if (data_layout != DataLayout::kNHWC) {
             std::memcpy(dst_data, src_data + kw, copy_size);
           } else {
-            for (int kow = 0; kow < output_width; ++kow) {
+            for (int64_t kow = 0; kow < output_width; ++kow) {
               dst_data[kow] =
                   im_data[((oh + kh) * im_width + kw + kow) * im_channels + ic];
             }
@@ -168,16 +145,9 @@ inline void im2col_sh1sw1dh1dw1ph1pw1(const phi::DenseTensor& im,
       (data_layout != DataLayout::kNHWC ? im.dims()[1] : im.dims()[0]);
   int im_width =
       (data_layout != DataLayout::kNHWC ? im.dims()[2] : im.dims()[1]);
-  // TODO(large-tensor): downstream functors may still use int
   int64_t filter_height = col->dims()[1];
-
-  // TODO(large-tensor): downstream functors may still use int
   int64_t filter_width = col->dims()[2];
-
-  // TODO(large-tensor): downstream functors may still use int
   int64_t output_height = col->dims()[3];
-
-  // TODO(large-tensor): downstream functors may still use int
   int64_t output_width = col->dims()[4];
 
   constexpr int plh = 1;
@@ -187,10 +157,10 @@ inline void im2col_sh1sw1dh1dw1ph1pw1(const phi::DenseTensor& im,
 
   const T* im_data = im.data<T>();
   T* col_data = col->data<T>();
-  int im_size = im_height * im_width;
-  int col_matrix_width = output_width * output_height;
-  int col_block_fh = filter_width * col_matrix_width;  // fw*oh*ow
-  int col_block_ic = filter_height * col_block_fh;     // fh*fw*oh*ow
+  int64_t im_size = im_height * im_width;
+  int64_t col_matrix_width = output_width * output_height;
+  int64_t col_block_fh = filter_width * col_matrix_width;  // fw*oh*ow
+  int64_t col_block_ic = filter_height * col_block_fh;     // fh*fw*oh*ow
 
   // fill height padding
   {
@@ -201,7 +171,7 @@ inline void im2col_sh1sw1dh1dw1ph1pw1(const phi::DenseTensor& im,
     for (int ic = 0; ic < im_channels; ++ic) {
       T* dst_data_l = col_start_l;
       T* dst_data_r = col_start_r;
-      for (int kw = 0; kw < filter_width; ++kw) {
+      for (int64_t kw = 0; kw < filter_width; ++kw) {
         std::memset(dst_data_l, 0, copy_size);
         std::memset(dst_data_r, 0, copy_size);
         dst_data_l = dst_data_l + col_matrix_width;
@@ -218,9 +188,9 @@ inline void im2col_sh1sw1dh1dw1ph1pw1(const phi::DenseTensor& im,
     T* dst_data_ic = col_data;
     for (int ic = 0; ic < im_channels; ++ic) {
       T* dst_data_kh = dst_data_ic;
-      for (int kh = 0; kh < filter_height; ++kh) {
+      for (int64_t kh = 0; kh < filter_height; ++kh) {
         T* dst_data = dst_data_kh;
-        for (int oh = 0; oh < output_height; ++oh) {
+        for (int64_t oh = 0; oh < output_height; ++oh) {
           *dst_data = pad;
           dst_data = dst_data + output_width - 1;
           *dst_data = pad;
@@ -231,7 +201,7 @@ inline void im2col_sh1sw1dh1dw1ph1pw1(const phi::DenseTensor& im,
       dst_data_ic = dst_data_ic + col_block_ic;
     }
     // fill core
-    for (int oh = 0; oh < output_height; ++oh) {
+    for (int64_t oh = 0; oh < output_height; ++oh) {
       const T* im_data_start =
           im_data + (oh - plh > 0 ? oh - plh : 0) * im_width;
       T* dst_data = col_data + oh * output_width;

--- a/paddle/phi/kernels/funcs/inclusive_scan.h
+++ b/paddle/phi/kernels/funcs/inclusive_scan.h
@@ -136,7 +136,7 @@ static __global__ void InclusiveScanInnerDimCUDAKernel(
   size_t block_row = static_cast<size_t>(blockIdx.x * kThreadNumY);
   size_t block_row_stride = static_cast<size_t>(gridDim.x * kThreadNumY);
   for (; block_row < num_rows; block_row += block_row_stride) {
-    size_t row = block_row + threadIdx.y;
+    size_t row = block_row + static_cast<size_t>(threadIdx.y);
     T block_total = init;
 
     const T *row_x = x + row * row_size;
@@ -173,7 +173,7 @@ static __global__ void InclusiveScanInnerDimCUDAKernel(
 
       for (size_t s = kThreadNumX, d = 1; s >= 1; s >>= 1, d <<= 1) {
         if (row < num_rows && threadIdx.x < s) {
-          size_t offset = (2 * threadIdx.x + 1) * d - 1;
+          size_t offset = (2 * static_cast<size_t>(threadIdx.x) + 1) * d - 1;
           row_buf[offset + d] = op(row_buf[offset], row_buf[offset + d]);
         }
         __syncthreads();
@@ -181,7 +181,7 @@ static __global__ void InclusiveScanInnerDimCUDAKernel(
 
       for (size_t s = 2, d = kThreadNumX / 2; d >= 1; s <<= 1, d >>= 1) {
         if (row < num_rows && threadIdx.x < s - 1) {
-          size_t offset = 2 * (threadIdx.x + 1) * d - 1;
+          size_t offset = 2 * (static_cast<size_t>(threadIdx.x) + 1) * d - 1;
           row_buf[offset + d] = op(row_buf[offset], row_buf[offset + d]);
         }
         __syncthreads();

--- a/paddle/phi/kernels/funcs/math/cos_sim_functor.cu
+++ b/paddle/phi/kernels/funcs/math/cos_sim_functor.cu
@@ -30,7 +30,10 @@ __global__ void CosSimDyKernel(const T* x_norm,
                                T* dy) {
   int grid_size = blockDim.x * gridDim.x;
   T y_norm_data = y_norm[0];
-  for (size_t row_id = blockIdx.x * blockDim.x + threadIdx.x; row_id < rows;
+  for (size_t row_id =
+           static_cast<size_t>(blockIdx.x) * static_cast<size_t>(blockDim.x) +
+           static_cast<size_t>(threadIdx.x);
+       row_id < rows;
        row_id += grid_size) {
     T xy_norm_prod = x_norm[row_id] * y_norm_data;
     T dz_data = dz[row_id];

--- a/paddle/phi/kernels/funcs/sequence_padding.cu
+++ b/paddle/phi/kernels/funcs/sequence_padding.cu
@@ -34,7 +34,9 @@ __global__ void SequencePaddingKernel(T* dst,
   size_t seq_idx = blockIdx.y;
   size_t seq_len = seq_offsets[seq_idx + 1] - seq_offsets[seq_idx];
 
-  size_t step_idx = blockIdx.x * blockDim.y + threadIdx.y;
+  size_t step_idx =
+      static_cast<size_t>(blockIdx.x) * static_cast<size_t>(blockDim.y) +
+      static_cast<size_t>(threadIdx.y);
   size_t seq_data_offset = (seq_offsets[seq_idx] + step_idx) * step_width;
   size_t pad_data_offset = layout == kBatchLengthWidth
                                ? (seq_idx * pad_seq_len + step_idx) * step_width

--- a/paddle/phi/kernels/funcs/sequence_scale.cu
+++ b/paddle/phi/kernels/funcs/sequence_scale.cu
@@ -30,7 +30,7 @@ __global__ void SequenceScaleKernel(T* seq,
   for (size_t i = threadIdx.x;
        i < (lod[blockIdx.x + 1] - lod[blockIdx.x]) * seq_width;
        i += BlockSize) {
-    size_t idx = lod[blockIdx.x] * seq_width + i;
+    size_t idx = lod[static_cast<size_t>(blockIdx.x)] * seq_width + i;
     seq[idx] *= scales[blockIdx.x];
   }
 }

--- a/paddle/phi/kernels/funcs/top_k_function_cuda.h
+++ b/paddle/phi/kernels/funcs/top_k_function_cuda.h
@@ -875,7 +875,10 @@ __global__ void GatherKthValue(const T* input,
   void* shared_mem = static_cast<void*>(shared_mem_char);
 
   IndexType row =
-      blockIdx.z * gridDim.y * gridDim.x + blockIdx.y * gridDim.x + blockIdx.x;
+      static_cast<IndexType>(blockIdx.z) * static_cast<IndexType>(gridDim.y) *
+          static_cast<IndexType>(gridDim.x) +
+      static_cast<IndexType>(blockIdx.y) * static_cast<IndexType>(gridDim.x) +
+      static_cast<IndexType>(blockIdx.x);
   if (row >= num_rows) return;
   const T* cur_input = input + row * num_cols;
 

--- a/paddle/phi/kernels/funcs/vol2col.cu
+++ b/paddle/phi/kernels/funcs/vol2col.cu
@@ -183,7 +183,7 @@ void Vol2ColFunctor<DeviceContext, T>::operator()(
   int64_t num_outputs =
       input_channels * output_depth * output_height * output_width;
 
-  int max_threads = 1024;
+  int max_threads = 512;
 #ifdef WITH_NV_JETSON
   phi::backends::gpu::ChangeThreadNum(dev_ctx, &max_threads);
 #endif
@@ -397,7 +397,7 @@ void Col2VolFunctor<DeviceContext, T>::operator()(
   int64_t num_kernels =
       input_channels * input_depth * input_height * input_width;
 
-  int max_threads = 1024;
+  int max_threads = 512;
 #ifdef WITH_NV_JETSON
   phi::backends::gpu::ChangeThreadNum(dev_ctx, &max_threads);
 #endif

--- a/paddle/phi/kernels/funcs/vol2col.cu
+++ b/paddle/phi/kernels/funcs/vol2col.cu
@@ -138,28 +138,22 @@ void Vol2ColFunctor<DeviceContext, T>::operator()(
   int input_width =
       (data_layout != DataLayout::NHWC ? vol.dims()[3] : vol.dims()[2]);
   int64_t filter_depth = col->dims()[1];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   int64_t filter_height = col->dims()[2];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   int64_t filter_width = col->dims()[3];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   int64_t output_depth = col->dims()[4];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   int64_t output_height = col->dims()[5];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   int64_t output_width = col->dims()[6];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   bool paddings_size_is_6 = (paddings.size() == 6);
   int pad_d_forth = paddings_size_is_6 ? paddings[0] : paddings[0];
@@ -366,28 +360,22 @@ void Col2VolFunctor<DeviceContext, T>::operator()(
   int input_width =
       (data_layout != DataLayout::NHWC ? vol->dims()[3] : vol->dims()[2]);
   int64_t filter_depth = col.dims()[1];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   int64_t filter_height = col.dims()[2];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   int64_t filter_width = col.dims()[3];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   int64_t output_depth = col.dims()[4];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   int64_t output_height = col.dims()[5];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   int64_t output_width = col.dims()[6];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   bool paddings_size_is_6 = (paddings.size() == 6);
   int pad_d_forth = paddings_size_is_6 ? paddings[0] : paddings[0];

--- a/paddle/phi/kernels/funcs/vol2col.cu
+++ b/paddle/phi/kernels/funcs/vol2col.cu
@@ -26,24 +26,24 @@ namespace funcs {
 template <class T>
 __global__ void vol2col(int64_t num_kernels,
                         const T* data_vol,
-                        int depth,
-                        int height,
-                        int width,
+                        int64_t depth,
+                        int64_t height,
+                        int64_t width,
                         int dilation_d,
                         int dilation_h,
                         int dilation_w,
-                        int filter_depth,
-                        int filter_height,
-                        int filter_width,
+                        int64_t filter_depth,
+                        int64_t filter_height,
+                        int64_t filter_width,
                         int stride_depth,
                         int stride_height,
                         int stride_width,
                         int padding_depth,
                         int padding_height,
                         int padding_width,
-                        int output_detph,
-                        int output_height,
-                        int output_width,
+                        int64_t output_detph,
+                        int64_t output_height,
+                        int64_t output_width,
                         T* data_col,
                         const DataLayout data_layout) {
   int64_t input_channels =
@@ -55,26 +55,25 @@ __global__ void vol2col(int64_t num_kernels,
            static_cast<int64_t>(threadIdx.x);
        index < num_kernels;
        index += blockDim.x * gridDim.x) {
-    int w_out = index % output_width;
-    int h_out = (index / output_width) % output_height;
-    int d_out = (index / output_width / output_height) % output_detph;
-    int channel_in = index / output_width / output_height / output_detph;
-    int channel_out = channel_in * filter_depth * filter_height * filter_width;
-    int w_in = w_out * stride_width - padding_width;
-    int h_in = h_out * stride_height - padding_height;
-    int d_in = d_out * stride_depth - padding_depth;
+    int64_t w_out = index % output_width;
+    int64_t h_out = (index / output_width) % output_height;
+    int64_t d_out = (index / output_width / output_height) % output_detph;
+    int64_t channel_in = index / output_width / output_height / output_detph;
+    int64_t channel_out =
+        channel_in * filter_depth * filter_height * filter_width;
+    int64_t w_in = w_out * stride_width - padding_width;
+    int64_t h_in = h_out * stride_height - padding_height;
+    int64_t d_in = d_out * stride_depth - padding_depth;
 
-    data_col += ((static_cast<int64_t>(channel_out) * output_detph + d_out) *
-                     output_height +
-                 h_out) *
+    data_col += ((channel_out * output_detph + d_out) * output_height + h_out) *
                     output_width +
                 w_out;
-    for (int k = 0; k < filter_depth; ++k) {
-      for (int i = 0; i < filter_height; ++i) {
-        for (int j = 0; j < filter_width; ++j) {
-          int d = d_in + k * dilation_d;
-          int h = h_in + i * dilation_h;
-          int w = w_in + j * dilation_w;
+    for (int64_t k = 0; k < filter_depth; ++k) {
+      for (int64_t i = 0; i < filter_height; ++i) {
+        for (int64_t j = 0; j < filter_width; ++j) {
+          int64_t d = d_in + k * dilation_d;
+          int64_t h = h_in + i * dilation_h;
+          int64_t w = w_in + j * dilation_w;
           int64_t vol_idx;
           if (data_layout != DataLayout::NHWC) {
             vol_idx =
@@ -138,22 +137,11 @@ void Vol2ColFunctor<DeviceContext, T>::operator()(
   int input_width =
       (data_layout != DataLayout::NHWC ? vol.dims()[3] : vol.dims()[2]);
   int64_t filter_depth = col->dims()[1];
-  // TODO(large-tensor): downstream functors may still use int
-
   int64_t filter_height = col->dims()[2];
-  // TODO(large-tensor): downstream functors may still use int
-
   int64_t filter_width = col->dims()[3];
-  // TODO(large-tensor): downstream functors may still use int
-
   int64_t output_depth = col->dims()[4];
-  // TODO(large-tensor): downstream functors may still use int
-
   int64_t output_height = col->dims()[5];
-  // TODO(large-tensor): downstream functors may still use int
-
   int64_t output_width = col->dims()[6];
-  // TODO(large-tensor): downstream functors may still use int
 
   bool paddings_size_is_6 = (paddings.size() == 6);
   int pad_d_forth = paddings_size_is_6 ? paddings[0] : paddings[0];
@@ -235,73 +223,75 @@ void Vol2ColFunctor<DeviceContext, T>::operator()(
 template <class T>
 __global__ void col2vol(int64_t num_kernels,
                         const T* data_col,
-                        int depth,
-                        int height,
-                        int width,
+                        int64_t depth,
+                        int64_t height,
+                        int64_t width,
                         int dilation_d,
                         int dilation_h,
                         int dilation_w,
-                        int filter_depth,
-                        int filter_height,
-                        int filter_width,
+                        int64_t filter_depth,
+                        int64_t filter_height,
+                        int64_t filter_width,
                         int stride_depth,
                         int stride_height,
                         int stride_width,
                         int padding_depth,
                         int padding_height,
                         int padding_width,
-                        int output_detph,
-                        int output_height,
-                        int output_width,
+                        int64_t output_detph,
+                        int64_t output_height,
+                        int64_t output_width,
                         T* data_vol,
                         const DataLayout data_layout) {
-  const int d_filter_depth = dilation_d * (filter_depth - 1) + 1;
-  const int d_filter_height = dilation_h * (filter_height - 1) + 1;
-  const int d_filter_width = dilation_w * (filter_width - 1) + 1;
+  const int64_t d_filter_depth = dilation_d * (filter_depth - 1) + 1;
+  const int64_t d_filter_height = dilation_h * (filter_height - 1) + 1;
+  const int64_t d_filter_width = dilation_w * (filter_width - 1) + 1;
 
-  int input_channels = num_kernels / depth / height / width;
+  int64_t input_channels = num_kernels / depth / height / width;
   for (int64_t index =
            static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
            static_cast<int64_t>(threadIdx.x);
        index < num_kernels;
        index += blockDim.x * gridDim.x) {
     T src_val = 0;
-    int w = (data_layout != DataLayout::NHWC
-                 ? index % width + padding_width
-                 : (index / input_channels) % width + padding_width);
-    int h = (data_layout != DataLayout::NHWC
-                 ? (index / width) % height + padding_height
-                 : (index / input_channels / width) % height + padding_height);
-    int d = (data_layout != DataLayout::NHWC
-                 ? (index / width / height) % depth + padding_depth
-                 : index / input_channels / width / height + padding_depth);
-    int c = (data_layout != DataLayout::NHWC ? index / width / height / depth
-                                             : index % input_channels);
+    int64_t w = (data_layout != DataLayout::NHWC
+                     ? index % width + padding_width
+                     : (index / input_channels) % width + padding_width);
+    int64_t h =
+        (data_layout != DataLayout::NHWC
+             ? (index / width) % height + padding_height
+             : (index / input_channels / width) % height + padding_height);
+    int64_t d = (data_layout != DataLayout::NHWC
+                     ? (index / width / height) % depth + padding_depth
+                     : index / input_channels / width / height + padding_depth);
+    int64_t c =
+        (data_layout != DataLayout::NHWC ? index / width / height / depth
+                                         : index % input_channels);
 
     // compute the start and end of the output
-    int w_col_start =
+    int64_t w_col_start =
         (w < d_filter_width) ? 0 : (w - d_filter_width) / stride_width + 1;
-    int w_col_end = min(w / stride_width + 1, output_width);
-    int h_col_start =
+    int64_t w_col_end = min(w / stride_width + 1, output_width);
+    int64_t h_col_start =
         (h < d_filter_height) ? 0 : (h - d_filter_height) / stride_height + 1;
-    int h_col_end = min(h / stride_height + 1, output_height);
-    int d_col_start =
+    int64_t h_col_end = min(h / stride_height + 1, output_height);
+    int64_t d_col_start =
         (d < d_filter_depth) ? 0 : (d - d_filter_depth) / stride_depth + 1;
-    int d_col_end = min(d / stride_depth + 1, output_detph);
+    int64_t d_col_end = min(d / stride_depth + 1, output_detph);
 
-    for (int d_col = d_col_start; d_col < d_col_end; ++d_col) {
-      for (int h_col = h_col_start; h_col < h_col_end; ++h_col) {
-        for (int w_col = w_col_start; w_col < w_col_end; ++w_col) {
-          int d_off = (d - d_col * stride_depth);
-          int h_off = (h - h_col * stride_height);
-          int w_off = (w - w_col * stride_width);
+    for (int64_t d_col = d_col_start; d_col < d_col_end; ++d_col) {
+      for (int64_t h_col = h_col_start; h_col < h_col_end; ++h_col) {
+        for (int64_t w_col = w_col_start; w_col < w_col_end; ++w_col) {
+          int64_t d_off = (d - d_col * stride_depth);
+          int64_t h_off = (h - h_col * stride_height);
+          int64_t w_off = (w - w_col * stride_width);
           if (d_off % dilation_d == 0 && h_off % dilation_h == 0 &&
               w_off % dilation_w == 0) {
             d_off /= dilation_d;
             h_off /= dilation_h;
             w_off /= dilation_w;
 
-            int data_col_index =
+            int64_t data_col_index =
                 (((((c * filter_depth + d_off) * filter_height + h_off) *
                        filter_width +
                    w_off)));
@@ -360,22 +350,11 @@ void Col2VolFunctor<DeviceContext, T>::operator()(
   int input_width =
       (data_layout != DataLayout::NHWC ? vol->dims()[3] : vol->dims()[2]);
   int64_t filter_depth = col.dims()[1];
-  // TODO(large-tensor): downstream functors may still use int
-
   int64_t filter_height = col.dims()[2];
-  // TODO(large-tensor): downstream functors may still use int
-
   int64_t filter_width = col.dims()[3];
-  // TODO(large-tensor): downstream functors may still use int
-
   int64_t output_depth = col.dims()[4];
-  // TODO(large-tensor): downstream functors may still use int
-
   int64_t output_height = col.dims()[5];
-  // TODO(large-tensor): downstream functors may still use int
-
   int64_t output_width = col.dims()[6];
-  // TODO(large-tensor): downstream functors may still use int
 
   bool paddings_size_is_6 = (paddings.size() == 6);
   int pad_d_forth = paddings_size_is_6 ? paddings[0] : paddings[0];

--- a/paddle/phi/kernels/funcs/vol2col.cu
+++ b/paddle/phi/kernels/funcs/vol2col.cu
@@ -32,9 +32,9 @@ __global__ void vol2col(int64_t num_kernels,
                         int dilation_d,
                         int dilation_h,
                         int dilation_w,
-                        int64_t filter_depth,
-                        int64_t filter_height,
-                        int64_t filter_width,
+                        int filter_depth,
+                        int filter_height,
+                        int filter_width,
                         int stride_depth,
                         int stride_height,
                         int stride_width,
@@ -46,21 +46,17 @@ __global__ void vol2col(int64_t num_kernels,
                         int64_t output_width,
                         T* data_col,
                         const DataLayout data_layout) {
-  int64_t input_channels =
+  int input_channels =
       num_kernels / output_detph / output_height / output_width;
-  int64_t channels_col =
-      input_channels * filter_depth * filter_height * filter_width;
   for (int64_t index =
-           static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
-           static_cast<int64_t>(threadIdx.x);
+           static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
        index < num_kernels;
        index += blockDim.x * gridDim.x) {
     int64_t w_out = index % output_width;
     int64_t h_out = (index / output_width) % output_height;
     int64_t d_out = (index / output_width / output_height) % output_detph;
-    int64_t channel_in = index / output_width / output_height / output_detph;
-    int64_t channel_out =
-        channel_in * filter_depth * filter_height * filter_width;
+    int channel_in = index / output_width / output_height / output_detph;
+    int channel_out = channel_in * filter_depth * filter_height * filter_width;
     int64_t w_in = w_out * stride_width - padding_width;
     int64_t h_in = h_out * stride_height - padding_height;
     int64_t d_in = d_out * stride_depth - padding_depth;
@@ -68,22 +64,18 @@ __global__ void vol2col(int64_t num_kernels,
     data_col += ((channel_out * output_detph + d_out) * output_height + h_out) *
                     output_width +
                 w_out;
-    for (int64_t k = 0; k < filter_depth; ++k) {
-      for (int64_t i = 0; i < filter_height; ++i) {
-        for (int64_t j = 0; j < filter_width; ++j) {
-          int64_t d = d_in + k * dilation_d;
-          int64_t h = h_in + i * dilation_h;
+    for (int k = 0; k < filter_depth; ++k) {
+      int64_t d = d_in + k * dilation_d;
+      for (int i = 0; i < filter_height; ++i) {
+        int64_t h = h_in + i * dilation_h;
+        for (int j = 0; j < filter_width; ++j) {
           int64_t w = w_in + j * dilation_w;
           int64_t vol_idx;
           if (data_layout != DataLayout::NHWC) {
-            vol_idx =
-                ((static_cast<int64_t>(channel_in) * depth + d) * height + h) *
-                    width +
-                w;
+            vol_idx = ((channel_in * depth + d) * height + h) * width + w;
           } else {
-            vol_idx = ((static_cast<int64_t>(d) * height + h) * width + w) *
-                          input_channels +
-                      channel_in;
+            vol_idx =
+                ((d * height + h) * width + w) * input_channels + channel_in;
           }
           *data_col = (d >= 0 && d < depth && h >= 0 && h < height && w >= 0 &&
                        w < width)
@@ -128,13 +120,13 @@ void Vol2ColFunctor<DeviceContext, T>::operator()(
                         "The dimension of col should be 7, but received %d.",
                         col->dims().size()));
 
-  int input_channels =
+  int64_t input_channels =
       (data_layout != DataLayout::NHWC ? vol.dims()[0] : vol.dims()[3]);
-  int input_depth =
+  int64_t input_depth =
       (data_layout != DataLayout::NHWC ? vol.dims()[1] : vol.dims()[0]);
-  int input_height =
+  int64_t input_height =
       (data_layout != DataLayout::NHWC ? vol.dims()[2] : vol.dims()[1]);
-  int input_width =
+  int64_t input_width =
       (data_layout != DataLayout::NHWC ? vol.dims()[3] : vol.dims()[2]);
   int64_t filter_depth = col->dims()[1];
   int64_t filter_height = col->dims()[2];
@@ -142,6 +134,12 @@ void Vol2ColFunctor<DeviceContext, T>::operator()(
   int64_t output_depth = col->dims()[4];
   int64_t output_height = col->dims()[5];
   int64_t output_width = col->dims()[6];
+
+  // NOTE(zrr1999): im_channels, filter_height, filter_width, filter_depth are
+  // usually small
+  PADDLE_ENFORCE_LE_INT_MAX(
+      input_channels * filter_depth * filter_height * filter_width,
+      "input_channels*filter_depth*filter_height*filter_width");
 
   bool paddings_size_is_6 = (paddings.size() == 6);
   int pad_d_forth = paddings_size_is_6 ? paddings[0] : paddings[0];
@@ -341,13 +339,13 @@ void Col2VolFunctor<DeviceContext, T>::operator()(
                         "The dimension of col should be 7, but received %d.",
                         col.dims().size()));
 
-  int input_channels =
+  int64_t input_channels =
       (data_layout != DataLayout::NHWC ? vol->dims()[0] : vol->dims()[3]);
-  int input_depth =
+  int64_t input_depth =
       (data_layout != DataLayout::NHWC ? vol->dims()[1] : vol->dims()[0]);
-  int input_height =
+  int64_t input_height =
       (data_layout != DataLayout::NHWC ? vol->dims()[2] : vol->dims()[1]);
-  int input_width =
+  int64_t input_width =
       (data_layout != DataLayout::NHWC ? vol->dims()[3] : vol->dims()[2]);
   int64_t filter_depth = col.dims()[1];
   int64_t filter_height = col.dims()[2];
@@ -396,8 +394,8 @@ void Col2VolFunctor<DeviceContext, T>::operator()(
                         input_width_tmp,
                         output_width));
 
-  int64_t num_kernels = static_cast<int64_t>(input_channels) * input_depth *
-                        input_height * input_width;
+  int64_t num_kernels =
+      input_channels * input_depth * input_height * input_width;
 
   int max_threads = 1024;
 #ifdef WITH_NV_JETSON

--- a/paddle/phi/kernels/funcs/weight_dequant_functor.h
+++ b/paddle/phi/kernels/funcs/weight_dequant_functor.h
@@ -367,10 +367,10 @@ void WeightDequantize(const Context& dev_ctx,
                       DenseTensor* out) {
   using DataType = typename PDDataTypeTraits<T>::DataType;
 
-  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  // TODO(large-tensor): downstream functors may still use int
   int64_t n = scale.dims()[0];
 
-  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  // TODO(large-tensor): downstream functors may still use int
   int64_t k = x.dims()[1];
 
   dim3 block(512);

--- a/paddle/phi/kernels/funcs/weight_dequant_functor.h
+++ b/paddle/phi/kernels/funcs/weight_dequant_functor.h
@@ -367,8 +367,12 @@ void WeightDequantize(const Context& dev_ctx,
                       DenseTensor* out) {
   using DataType = typename PDDataTypeTraits<T>::DataType;
 
-  int n = scale.dims()[0];
-  int k = x.dims()[1];
+  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  int64_t n = scale.dims()[0];
+
+  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  int64_t k = x.dims()[1];
+
   dim3 block(512);
   dim3 grid(n / 32);
   auto stream = dev_ctx.stream();

--- a/paddle/phi/kernels/funcs/weight_only_gemv.cu
+++ b/paddle/phi/kernels/funcs/weight_only_gemv.cu
@@ -1358,16 +1358,13 @@ void WeightOnlyGemvKernel(const Context& dev_ctx,
   const T* weight_scale_data = weight_scale.data<T>();
   T* out_data = dev_ctx.template Alloc<T>(out);
   int64_t m = x.dims()[0];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   int64_t k = x.dims()[1];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   int64_t n = weight.dims()[0];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   WeightOnlyGemvWrapper<T>(dev_ctx,
                            x_data,

--- a/paddle/phi/kernels/fusion/cutlass/gemm_epilogue/gemm_epilogue_util.cu
+++ b/paddle/phi/kernels/fusion/cutlass/gemm_epilogue/gemm_epilogue_util.cu
@@ -54,8 +54,10 @@ __global__ void naive_gemm_epilogue_kernel(const T *input,
                                            float leaky_alpha,
                                            bool isVec_bias,
                                            OpType op_type) {
-  size_t j = threadIdx.x + blockIdx.x * blockDim.x;
-  size_t i = threadIdx.y + blockIdx.y * blockDim.y;
+  size_t j = static_cast<size_t>(threadIdx.x) +
+             static_cast<size_t>(blockIdx.x) * static_cast<size_t>(blockDim.x);
+  size_t i = static_cast<size_t>(threadIdx.y) +
+             static_cast<size_t>(blockIdx.y) * static_cast<size_t>(blockDim.y);
 
   if (i < M && j < N) {
     float accumulator = 0.;

--- a/paddle/phi/kernels/fusion/gpu/block_attn.h
+++ b/paddle/phi/kernels/fusion/gpu/block_attn.h
@@ -4329,8 +4329,12 @@ void GetDecoderTensor(const phi::GPUContext &dev_ctx,
   // qkv_out: [token_num, 2 * kv_num_head + q_num_head, dim_head] -> [bs, 1, 2 *
   // kv_num_head + q_num_head, dim_head] rope: [2, bsz, 1, seq_len, dim_head] ->
   // [2, bsz, 1, 1, dim_head]
-  int elem_nums = qkv_out_decoder->numel();
-  int qkv_out_nums = qkv_out.numel();
+  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  int64_t elem_nums = qkv_out_decoder->numel();
+
+  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  int64_t qkv_out_nums = qkv_out.numel();
+
   constexpr int PackSize = VEC_16B / sizeof(T);
   PADDLE_ENFORCE_EQ(
       dim_head % PackSize,

--- a/paddle/phi/kernels/fusion/gpu/block_attn.h
+++ b/paddle/phi/kernels/fusion/gpu/block_attn.h
@@ -4329,10 +4329,10 @@ void GetDecoderTensor(const phi::GPUContext &dev_ctx,
   // qkv_out: [token_num, 2 * kv_num_head + q_num_head, dim_head] -> [bs, 1, 2 *
   // kv_num_head + q_num_head, dim_head] rope: [2, bsz, 1, seq_len, dim_head] ->
   // [2, bsz, 1, 1, dim_head]
-  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  // TODO(large-tensor): downstream functors may still use int
   int64_t elem_nums = qkv_out_decoder->numel();
 
-  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  // TODO(large-tensor): downstream functors may still use int
   int64_t qkv_out_nums = qkv_out.numel();
 
   constexpr int PackSize = VEC_16B / sizeof(T);

--- a/paddle/phi/kernels/fusion/gpu/fused_stack_transpose_quant_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/fused_stack_transpose_quant_kernel.cu
@@ -36,8 +36,8 @@ __device__ void BlockLoad(ArrayT input_array,
       reinterpret_cast<const __nv_bfloat16*>(input_array.data[blockIdx.z]);
 
   for (size_t i = 0; i < 8; i++) {
-    size_t idx_m = block_y * 128 + threadIdx.y + i * 16;
-    size_t idx_k = block_x * 128 + threadIdx.x * 4;
+    size_t idx_m = block_y * 128 + static_cast<size_t>(threadIdx.y) + i * 16;
+    size_t idx_k = block_x * 128 + static_cast<size_t>(threadIdx.x) * 4;
     size_t idx = idx_m * K + idx_k;
 
     using LoadT = phi::kps::details::VectorType<__nv_bfloat16, 4>;
@@ -99,7 +99,7 @@ __global__ void __launch_bounds__(512)
                              size_t K,
                              FastDivMod K_div_128) {
   size_t block_y = K_div_128.Div(blockIdx.x);
-  size_t block_x = blockIdx.x - block_y * (K / 128);
+  size_t block_x = static_cast<size_t>(blockIdx.x) - block_y * (K / 128);
 
   // Load 128x128 elements from X
   __nv_bfloat16 x[8][4];
@@ -120,8 +120,8 @@ __global__ void __launch_bounds__(512)
   // Scale X and store to out
   for (uint32_t i = 0; i < 8; i++) {
     size_t idx_n = blockIdx.z;
-    size_t idx_m = block_y * 128 + threadIdx.y + i * 16;
-    size_t idx_k = block_x * 128 + threadIdx.x * 4;
+    size_t idx_m = block_y * 128 + static_cast<size_t>(threadIdx.y) + i * 16;
+    size_t idx_k = block_x * 128 + static_cast<size_t>(threadIdx.x) * 4;
     size_t idx = (idx_n * M + idx_m) * K + idx_k;
 
     using StoreT = phi::kps::details::VectorType<OutT, 4>;
@@ -144,7 +144,7 @@ __global__ void __launch_bounds__(512)
                                       size_t K,
                                       FastDivMod K_div_128) {
   size_t block_y = K_div_128.Div(blockIdx.x);
-  size_t block_x = blockIdx.x - block_y * (K / 128);
+  size_t block_x = static_cast<size_t>(blockIdx.x) - block_y * (K / 128);
 
   // Load 128x128 elements from X
   __nv_bfloat16 x[8][4];
@@ -177,8 +177,8 @@ __global__ void __launch_bounds__(512)
   // Store X back to out
   for (uint32_t i = 0; i < 8; i++) {
     size_t idx_n = blockIdx.z;
-    size_t idx_k = block_x * 128 + threadIdx.y + i * 16;
-    size_t idx_m = block_y * 128 + threadIdx.x * 4;
+    size_t idx_k = block_x * 128 + static_cast<size_t>(threadIdx.y) + i * 16;
+    size_t idx_m = block_y * 128 + static_cast<size_t>(threadIdx.x) * 4;
     size_t idx = (idx_n * K + idx_k) * M + idx_m;
 
     using StoreT = phi::kps::details::VectorType<OutT, 4>;

--- a/paddle/phi/kernels/fusion/gpu/fused_transpose_split_quant_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/fused_transpose_split_quant_kernel.cu
@@ -187,7 +187,7 @@ __global__ void __launch_bounds__(512)
 
   // 2. Get expert index and offset of the current block
   if (threadIdx.x == 0 && threadIdx.y == 0) {
-    size_t idx_m = blockIdx.x * size_t(128);
+    size_t idx_m = static_cast<size_t>(blockIdx.x) * size_t(128);
     size_t off_m = 0, next_off_m = 0;
     size_t expert_idx;
     for (expert_idx = 0; expert_idx < num_experts; expert_idx++) {

--- a/paddle/phi/kernels/fusion/gpu/fused_transpose_wlch_split_quant_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/fused_transpose_wlch_split_quant_kernel.cu
@@ -114,7 +114,7 @@ __global__ void __launch_bounds__(512)
       idx_y = PermuteHighIdx(
           block_off_x + threadIdx.y + i * 16, W_divmod, L, C_divmod);
     }
-    size_t idx_x = block_off_y + threadIdx.x * VecSize;
+    size_t idx_x = block_off_y + static_cast<size_t>(threadIdx.x) * VecSize;
     size_t idx = idx_y * H + idx_x;
     for (uint32_t j = 0; j < 4; j += VecSize) {
       if (idx_x + j * 32 < H) {
@@ -158,7 +158,8 @@ __global__ void __launch_bounds__(512)
     }
     float scale_out = 1.0f / col_scale[off];
     size_t idx_y = static_cast<size_t>(blockIdx.x) - expert_off / 128;
-    size_t idx_x = block_off_y + threadIdx.y * 32 + threadIdx.x;
+    size_t idx_x = block_off_y + static_cast<size_t>(threadIdx.y) * 32 +
+                   static_cast<size_t>(threadIdx.x);
     size_t idx = idx_y * H + idx_x;
     if (idx_x < H) {
       scale_ptrs[expert_idx][idx] = scale_out;
@@ -182,8 +183,8 @@ __global__ void __launch_bounds__(512)
   const size_t cur_tokens = tokens_per_expert[expert_idx];
   __nv_fp8_e4m3* out = out_ptrs[expert_idx];
   for (uint32_t i = 0; i < 8; i++) {
-    size_t idx_y = block_off_y + threadIdx.y + i * 16;
-    size_t idx_x = block_off_x + threadIdx.x * 4;
+    size_t idx_y = block_off_y + static_cast<size_t>(threadIdx.y) + i * 16;
+    size_t idx_x = block_off_x + static_cast<size_t>(threadIdx.x) * 4;
     size_t idx = idx_y * cur_tokens + (idx_x - expert_off);
     if (idx_y < H) {
       // Note: out is always 4x vectorizable.

--- a/paddle/phi/kernels/fusion/gpu/masked_multihead_attention_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/masked_multihead_attention_kernel.cu
@@ -1010,23 +1010,19 @@ void DispatchWithDtype(const Context &dev_ctx,
   const auto &x_dims = x.dims();
   int bsz = x_dims[0];
   int64_t cache_bsz = cache_kv.dims()[1];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   int64_t max_seq_len = cache_kv.dims()[3];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   int64_t dim_head = cache_kv.dims()[4];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   int timestep = max_seq_len;
   float inv_sqrt_dh = 1. / sqrt(dim_head);
 
   int64_t k_num_head = cache_kv.dims()[2];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   int v_num_head = k_num_head;
   // this num_head means query's head

--- a/paddle/phi/kernels/fusion/gpu/qkv_unpack_mha_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/qkv_unpack_mha_kernel.cu
@@ -462,29 +462,24 @@ void QKVDispatchWithDtype(const Context &dev_ctx,
   const auto &q_dims = q.dims();
   int bsz = q_dims[0];
   int64_t cache_bsz = q.dims()[0];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   int64_t max_seq_len = v.dims()[1];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   int64_t dim_head = v.dims()[3];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   int timestep = max_seq_len;
   float inv_sqrt_dh = 1. / sqrt(dim_head);
 
   int64_t k_num_head = k.dims()[2];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   int v_num_head = k_num_head;
   // this num_head means query's head
   int64_t num_head = q.dims()[2];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   QkvUnpackMhaParams<T> params;
 

--- a/paddle/phi/kernels/fusion/gpu/skip_layernorm_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/skip_layernorm_kernel.cu
@@ -43,8 +43,7 @@ void SkipLayerNormKernel(const Context &dev_ctx,
     num *= x.dims()[i];
   }
   int64_t hidden = x.dims()[2];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   phi::funcs::SkipLayerNormFunctor<T> skip_layer_norm_func;
 

--- a/paddle/phi/kernels/fusion/xpu/cross_attention_xpu_kernel.cc
+++ b/paddle/phi/kernels/fusion/xpu/cross_attention_xpu_kernel.cc
@@ -67,20 +67,22 @@ void CrossAttentionXPUKernelImpl(
   }
 
   int64_t batch = input_q.dims()[0];
-  // TODO(large-tensor): downstream functors may still use int
-
   int64_t max_q_len = input_q.dims()[1];
-  // TODO(large-tensor): downstream functors may still use int
-
   int64_t max_kv_len = input_kv.dims()[1];
-  // TODO(large-tensor): downstream functors may still use int
 
-  int max_seq_len = std::max(max_q_len, max_kv_len);
+  int64_t max_seq_len = std::max(max_q_len, max_kv_len);
   int qkv_shape = 0;  // B x L x H x D
   int hidden_dim = head_num * head_dim;
-  int q_mul_m = batch * max_q_len;
-  int kv_mul_m = batch * max_kv_len;
-  int loop_m[3] = {q_mul_m, kv_mul_m, kv_mul_m};
+  int64_t q_mul_m = batch * max_q_len;
+  int64_t kv_mul_m = batch * max_kv_len;
+
+  // TODO(large-tensor): XPU fc_fusion API not support int64
+  PADDLE_ENFORCE_LE_INT_MAX(q_mul_m, "q_mul_m");
+  PADDLE_ENFORCE_LE_INT_MAX(kv_mul_m, "kv_mul_m");
+
+  int loop_m[3] = {static_cast<int>(q_mul_m),
+                   static_cast<int>(kv_mul_m),
+                   static_cast<int>(kv_mul_m)};
   int n = hidden_dim;
   int k = hidden_dim;
   bool do_fc_qkv_fusion = false;

--- a/paddle/phi/kernels/fusion/xpu/cross_attention_xpu_kernel.cc
+++ b/paddle/phi/kernels/fusion/xpu/cross_attention_xpu_kernel.cc
@@ -76,7 +76,7 @@ void CrossAttentionXPUKernelImpl(
   int64_t q_mul_m = batch * max_q_len;
   int64_t kv_mul_m = batch * max_kv_len;
 
-  // TODO(large-tensor): XPU fc_fusion API not support int64
+  // NOTE(large-tensor): XPU fc_fusion API not support int64
   PADDLE_ENFORCE_LE_INT_MAX(q_mul_m, "q_mul_m");
   PADDLE_ENFORCE_LE_INT_MAX(kv_mul_m, "kv_mul_m");
 

--- a/paddle/phi/kernels/fusion/xpu/cross_attention_xpu_kernel.cc
+++ b/paddle/phi/kernels/fusion/xpu/cross_attention_xpu_kernel.cc
@@ -67,16 +67,13 @@ void CrossAttentionXPUKernelImpl(
   }
 
   int64_t batch = input_q.dims()[0];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   int64_t max_q_len = input_q.dims()[1];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   int64_t max_kv_len = input_kv.dims()[1];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   int max_seq_len = std::max(max_q_len, max_kv_len);
   int qkv_shape = 0;  // B x L x H x D

--- a/paddle/phi/kernels/fusion/xpu/embedding_with_eltwise_add_xpu_kernel.cc
+++ b/paddle/phi/kernels/fusion/xpu/embedding_with_eltwise_add_xpu_kernel.cc
@@ -21,14 +21,14 @@ namespace fusion {
 
 namespace {
 template <typename T>
-void FillSeqLod(int64_t batch_size,
+void FillSeqLod(int batch_size,
                 int max_seq_len,
                 const T* mask,
                 std::vector<int>* cpu_seq_lod) {
-  for (int64_t batch_idx = 0; batch_idx < batch_size; batch_idx++) {
+  for (int batch_idx = 0; batch_idx < batch_size; batch_idx++) {
     int cur_batch_seq_len = 0;
     for (int seq_idx = 0; seq_idx < max_seq_len; seq_idx++) {
-      int64_t mask_idx = batch_idx * max_seq_len + seq_idx;
+      int mask_idx = batch_idx * max_seq_len + seq_idx;
       if (mask[mask_idx] > 0) {
         cur_batch_seq_len++;
       } else {
@@ -40,14 +40,14 @@ void FillSeqLod(int64_t batch_size,
 }
 
 template <>
-void FillSeqLod<float>(int64_t batch_size,
+void FillSeqLod<float>(int batch_size,
                        int max_seq_len,
                        const float* mask,
                        std::vector<int>* cpu_seq_lod) {
-  for (int64_t batch_idx = 0; batch_idx < batch_size; batch_idx++) {
+  for (int batch_idx = 0; batch_idx < batch_size; batch_idx++) {
     int cur_batch_seq_len = 0;
     for (int seq_idx = 0; seq_idx < max_seq_len; seq_idx++) {
-      int64_t mask_idx = batch_idx * max_seq_len + seq_idx;
+      int mask_idx = batch_idx * max_seq_len + seq_idx;
       if (mask[mask_idx] > 1e-7) {
         cur_batch_seq_len++;
       } else {
@@ -108,6 +108,9 @@ void MultiEmbeddingKernel(const Context& dev_ctx,
   auto* mask_tensor = mask.get_ptr();
   if (mask_tensor != nullptr) {
     int64_t batch_size = mask_tensor->dims()[0];
+    // NOTE(large-tensor): XPU FillSeqLod API not support int64
+    PADDLE_ENFORCE_LE_INT_MAX(batch_size, "batch_size");
+
     auto pad_seq_len = mask_tensor->dims()[1];
     max_seq_len->Resize({1});
     dev_ctx.template HostAlloc<int>(max_seq_len)[0] = pad_seq_len;

--- a/paddle/phi/kernels/fusion/xpu/embedding_with_eltwise_add_xpu_kernel.cc
+++ b/paddle/phi/kernels/fusion/xpu/embedding_with_eltwise_add_xpu_kernel.cc
@@ -21,14 +21,14 @@ namespace fusion {
 
 namespace {
 template <typename T>
-void FillSeqLod(int batch_size,
+void FillSeqLod(int64_t batch_size,
                 int max_seq_len,
                 const T* mask,
                 std::vector<int>* cpu_seq_lod) {
-  for (int batch_idx = 0; batch_idx < batch_size; batch_idx++) {
+  for (int64_t batch_idx = 0; batch_idx < batch_size; batch_idx++) {
     int cur_batch_seq_len = 0;
     for (int seq_idx = 0; seq_idx < max_seq_len; seq_idx++) {
-      int mask_idx = batch_idx * max_seq_len + seq_idx;
+      int64_t mask_idx = batch_idx * max_seq_len + seq_idx;
       if (mask[mask_idx] > 0) {
         cur_batch_seq_len++;
       } else {
@@ -40,14 +40,14 @@ void FillSeqLod(int batch_size,
 }
 
 template <>
-void FillSeqLod<float>(int batch_size,
+void FillSeqLod<float>(int64_t batch_size,
                        int max_seq_len,
                        const float* mask,
                        std::vector<int>* cpu_seq_lod) {
-  for (int batch_idx = 0; batch_idx < batch_size; batch_idx++) {
+  for (int64_t batch_idx = 0; batch_idx < batch_size; batch_idx++) {
     int cur_batch_seq_len = 0;
     for (int seq_idx = 0; seq_idx < max_seq_len; seq_idx++) {
-      int mask_idx = batch_idx * max_seq_len + seq_idx;
+      int64_t mask_idx = batch_idx * max_seq_len + seq_idx;
       if (mask[mask_idx] > 1e-7) {
         cur_batch_seq_len++;
       } else {
@@ -108,9 +108,6 @@ void MultiEmbeddingKernel(const Context& dev_ctx,
   auto* mask_tensor = mask.get_ptr();
   if (mask_tensor != nullptr) {
     int64_t batch_size = mask_tensor->dims()[0];
-    // TODO(large-tensor): downstream functors may still use int; guard until
-    // upgraded.
-
     auto pad_seq_len = mask_tensor->dims()[1];
     max_seq_len->Resize({1});
     dev_ctx.template HostAlloc<int>(max_seq_len)[0] = pad_seq_len;

--- a/paddle/phi/kernels/fusion/xpu/fc_xpu_kernel.cc
+++ b/paddle/phi/kernels/fusion/xpu/fc_xpu_kernel.cc
@@ -55,7 +55,9 @@ void FcXPUKernelImpl(const Context& dev_ctx,
   int m = in_mat_dims[0];
   int k = in_mat_dims[1];
   int64_t n = w.dims()[0];
-  // TODO(large-tensor): downstream functors may still use int
+
+  // TODO(large-tensor): XPU fc_fusion API not support int64
+  PADDLE_ENFORCE_LE_INT_MAX(n, "n");
 
   auto* x_data = reinterpret_cast<const XPUTypeX*>(x.data<T_X>());
   const float* x_max_data =

--- a/paddle/phi/kernels/fusion/xpu/fc_xpu_kernel.cc
+++ b/paddle/phi/kernels/fusion/xpu/fc_xpu_kernel.cc
@@ -56,7 +56,7 @@ void FcXPUKernelImpl(const Context& dev_ctx,
   int k = in_mat_dims[1];
   int64_t n = w.dims()[0];
 
-  // TODO(large-tensor): XPU fc_fusion API not support int64
+  // NOTE(large-tensor): XPU fc_fusion API not support int64
   PADDLE_ENFORCE_LE_INT_MAX(n, "n");
 
   auto* x_data = reinterpret_cast<const XPUTypeX*>(x.data<T_X>());

--- a/paddle/phi/kernels/fusion/xpu/fc_xpu_kernel.cc
+++ b/paddle/phi/kernels/fusion/xpu/fc_xpu_kernel.cc
@@ -55,8 +55,7 @@ void FcXPUKernelImpl(const Context& dev_ctx,
   int m = in_mat_dims[0];
   int k = in_mat_dims[1];
   int64_t n = w.dims()[0];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   auto* x_data = reinterpret_cast<const XPUTypeX*>(x.data<T_X>());
   const float* x_max_data =

--- a/paddle/phi/kernels/fusion/xpu/fused_bias_act_kernel.cc
+++ b/paddle/phi/kernels/fusion/xpu/fused_bias_act_kernel.cc
@@ -47,10 +47,11 @@ static void ComputeImpl(const phi::XPUContext *xpu_ctx,
                         DenseTensor *out) {
   using XPUType = typename XPUTypeTrait<T>::Type;
   int64_t rows = x.dims()[0];
-  // TODO(large-tensor): downstream functors may still use int
-
   int64_t cols = x.dims()[1];
-  // TODO(large-tensor): downstream functors may still use int
+
+  // TODO(large-tensor): XPU broadcast_add API not support int64
+  PADDLE_ENFORCE_LE_INT_MAX(rows, "rows");
+  PADDLE_ENFORCE_LE_INT_MAX(cols, "cols");
 
   int r = 0;
   if (bias) {
@@ -59,7 +60,7 @@ static void ComputeImpl(const phi::XPUContext *xpu_ctx,
         reinterpret_cast<const XPUType *>(x.data<T>()),
         reinterpret_cast<const XPUType *>(bias.get().data<T>()),
         reinterpret_cast<XPUType *>(const_cast<T *>(x.data<T>())),
-        {rows, cols},
+        {static_cast<int>(rows), static_cast<int>(cols)},
         {1, cols});
     PADDLE_ENFORCE_EQ(
         r, 0, common::errors::Fatal("baidu::xpu::api::broadcast_add failed."));

--- a/paddle/phi/kernels/fusion/xpu/fused_bias_act_kernel.cc
+++ b/paddle/phi/kernels/fusion/xpu/fused_bias_act_kernel.cc
@@ -47,12 +47,10 @@ static void ComputeImpl(const phi::XPUContext *xpu_ctx,
                         DenseTensor *out) {
   using XPUType = typename XPUTypeTrait<T>::Type;
   int64_t rows = x.dims()[0];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   int64_t cols = x.dims()[1];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   int r = 0;
   if (bias) {

--- a/paddle/phi/kernels/fusion/xpu/multi_encoder_xpu_kernel.cc
+++ b/paddle/phi/kernels/fusion/xpu/multi_encoder_xpu_kernel.cc
@@ -74,8 +74,7 @@ void MultiEncoderXPUKernel(
   int64_t batch_size = x.dims()[0];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-
-  int seq_len = 1;
+  int64_t seq_len = 1;
   int head_dim;
   if (x.dims().size() == 2) {
     head_dim = x.dims()[1];

--- a/paddle/phi/kernels/fusion/xpu/multi_encoder_xpu_kernel.cc
+++ b/paddle/phi/kernels/fusion/xpu/multi_encoder_xpu_kernel.cc
@@ -72,8 +72,7 @@ void MultiEncoderXPUKernel(
                                     ? nullptr
                                     : max_seq_len.get_ptr()->data<int>();
   int64_t batch_size = x.dims()[0];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
   int64_t seq_len = 1;
   int head_dim;
   if (x.dims().size() == 2) {
@@ -177,8 +176,7 @@ void MultiEncoderXPUKernel(
   xpu::Activation_t qkv_act(static_cast<xpu::Activation_t::act_enum>(act_type));
 
   int64_t batch = x.dims()[0];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   // matmul_size * layer_num
   if (seq_lod_data) {

--- a/paddle/phi/kernels/fusion/xpu/multi_encoder_xpu_kernel.cc
+++ b/paddle/phi/kernels/fusion/xpu/multi_encoder_xpu_kernel.cc
@@ -72,7 +72,10 @@ void MultiEncoderXPUKernel(
                                     ? nullptr
                                     : max_seq_len.get_ptr()->data<int>();
   int64_t batch_size = x.dims()[0];
-  // TODO(large-tensor): downstream functors may still use int
+
+  // TODO(large-tensor): XPU multi_encoder API not support int64
+  PADDLE_ENFORCE_LE_INT_MAX(batch_size, "batch_size");
+
   int64_t seq_len = 1;
   int head_dim;
   if (x.dims().size() == 2) {
@@ -176,7 +179,9 @@ void MultiEncoderXPUKernel(
   xpu::Activation_t qkv_act(static_cast<xpu::Activation_t::act_enum>(act_type));
 
   int64_t batch = x.dims()[0];
-  // TODO(large-tensor): downstream functors may still use int
+
+  // TODO(large-tensor): XPU multi_encoder QKVAttnParam not support int64
+  PADDLE_ENFORCE_LE_INT_MAX(batch, "batch");
 
   // matmul_size * layer_num
   if (seq_lod_data) {
@@ -233,11 +238,12 @@ void MultiEncoderXPUKernel(
     std::vector<int> mask_shape(mask_dims.Get(),
                                 mask_dims.Get() + mask_dims.size());
     int64_t max_seq_len_value = x.dims()[1];
-    // TODO(large-tensor): downstream functors may still use int; guard until
-    // upgraded.
 
-    xpu::QKVAttnParam qkv_attn_param(batch,
-                                     max_seq_len_value,
+    // TODO(large-tensor): XPU QKVAttnParam not support int64
+    PADDLE_ENFORCE_LE_INT_MAX(max_seq_len_value, "max_seq_len_value");
+
+    xpu::QKVAttnParam qkv_attn_param(static_cast<int>(batch),
+                                     static_cast<int>(max_seq_len_value),
                                      head_num,
                                      size_per_head,
                                      mask_shape,
@@ -282,12 +288,13 @@ void MultiEncoderXPUKernel(
   } else {
     // When no mask input, like VIT, create LOD to act as vsl.
     int64_t max_seq_len_value = x.dims()[1];
-    // TODO(large-tensor): downstream functors may still use int; guard until
-    // upgraded.
+
+    // TODO(large-tensor): XPU QKVAttnParam not support int64
+    PADDLE_ENFORCE_LE_INT_MAX(max_seq_len_value, "max_seq_len_value");
 
     std::vector<int> lod;
-    for (int i = 0; i < batch + 1; i++) {
-      lod.push_back(i * max_seq_len_value);
+    for (int64_t i = 0; i < batch + 1; i++) {
+      lod.push_back(static_cast<int>(i * max_seq_len_value));
     }
     xpu::VectorParam<int> query_lod = {
         lod.data(), static_cast<int>(lod.size()), nullptr};

--- a/paddle/phi/kernels/fusion/xpu/multi_encoder_xpu_kernel.cc
+++ b/paddle/phi/kernels/fusion/xpu/multi_encoder_xpu_kernel.cc
@@ -290,7 +290,8 @@ void MultiEncoderXPUKernel(
     int64_t max_seq_len_value = x.dims()[1];
 
     // TODO(large-tensor): XPU QKVAttnParam not support int64
-    PADDLE_ENFORCE_LE_INT_MAX(max_seq_len_value, "max_seq_len_value");
+    PADDLE_ENFORCE_LE_INT_MAX(max_seq_len_value * batch,
+                              "max_seq_len_value*batch");
 
     std::vector<int> lod;
     for (int64_t i = 0; i < batch + 1; i++) {

--- a/paddle/phi/kernels/fusion/xpu/qkv_attention_xpu_kernel.cc
+++ b/paddle/phi/kernels/fusion/xpu/qkv_attention_xpu_kernel.cc
@@ -69,7 +69,7 @@ void QKVAttentionXPUKernelImpl(const Context& dev_ctx,
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
 
-  int qkv_shape = 0;  // B x L x H x D
+  int64_t qkv_shape = 0;  // B x L x H x D
   int hidden_dim = head_num * head_dim;
   // no mask input, construct a fake LOD to compute via vsl
   std::vector<int> lod;

--- a/paddle/phi/kernels/fusion/xpu/qkv_attention_xpu_kernel.cc
+++ b/paddle/phi/kernels/fusion/xpu/qkv_attention_xpu_kernel.cc
@@ -62,12 +62,10 @@ void QKVAttentionXPUKernelImpl(const Context& dev_ctx,
       reinterpret_cast<XPUTypeOut*>(dev_ctx.template Alloc<T_QKV>(qkv));
   float* tmp_mask = nullptr;
   int64_t batch = q.dims()[0];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   int64_t max_seq_len = q.dims()[1];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   int64_t qkv_shape = 0;  // B x L x H x D
   int hidden_dim = head_num * head_dim;

--- a/paddle/phi/kernels/fusion/xpu/qkv_attention_xpu_kernel.cc
+++ b/paddle/phi/kernels/fusion/xpu/qkv_attention_xpu_kernel.cc
@@ -65,8 +65,7 @@ void QKVAttentionXPUKernelImpl(const Context& dev_ctx,
   int64_t max_seq_len = q.dims()[1];
 
   // TODO(large-tensor): XPU qkv_attention API not support int64
-  PADDLE_ENFORCE_LE_INT_MAX(batch, "batch");
-  PADDLE_ENFORCE_LE_INT_MAX(max_seq_len, "max_seq_len");
+  PADDLE_ENFORCE_LE_INT_MAX(max_seq_len * batch, "max_seq_len*batch");
 
   int64_t qkv_shape = 0;  // B x L x H x D
   int hidden_dim = head_num * head_dim;

--- a/paddle/phi/kernels/fusion/xpu/qkv_attention_xpu_kernel.cc
+++ b/paddle/phi/kernels/fusion/xpu/qkv_attention_xpu_kernel.cc
@@ -62,17 +62,18 @@ void QKVAttentionXPUKernelImpl(const Context& dev_ctx,
       reinterpret_cast<XPUTypeOut*>(dev_ctx.template Alloc<T_QKV>(qkv));
   float* tmp_mask = nullptr;
   int64_t batch = q.dims()[0];
-  // TODO(large-tensor): downstream functors may still use int
-
   int64_t max_seq_len = q.dims()[1];
-  // TODO(large-tensor): downstream functors may still use int
+
+  // TODO(large-tensor): XPU qkv_attention API not support int64
+  PADDLE_ENFORCE_LE_INT_MAX(batch, "batch");
+  PADDLE_ENFORCE_LE_INT_MAX(max_seq_len, "max_seq_len");
 
   int64_t qkv_shape = 0;  // B x L x H x D
   int hidden_dim = head_num * head_dim;
   // no mask input, construct a fake LOD to compute via vsl
   std::vector<int> lod;
-  for (int i = 0; i < batch + 1; i++) {
-    lod.emplace_back(i * max_seq_len);
+  for (int64_t i = 0; i < batch + 1; i++) {
+    lod.emplace_back(static_cast<int>(i * max_seq_len));
   }
   xpu::VectorParam<int> query_lod = {
       lod.data(), static_cast<int>(lod.size()), nullptr};

--- a/paddle/phi/kernels/fusion/xpu/spatial_transformer_resblock_xpu_kernel.cc
+++ b/paddle/phi/kernels/fusion/xpu/spatial_transformer_resblock_xpu_kernel.cc
@@ -114,27 +114,28 @@ void SpatialTransformerResblockXPUKernel(
   // prepare conv params
   for (size_t i = 0; i < conv_filter.size(); i++) {
     int64_t xn = conv_filter[i]->dims()[0];
-    // TODO(large-tensor): downstream functors may still use int; guard until
-    // upgraded.
-
     int64_t nc = conv_filter[i]->dims()[1];
-    // TODO(large-tensor): downstream functors may still use int; guard until
-    // upgraded.
-
     int64_t nh = conv_filter[i]->dims()[2];
-    // TODO(large-tensor): downstream functors may still use int; guard until
-    // upgraded.
-
     int64_t nw = conv_filter[i]->dims()[3];
-    // TODO(large-tensor): downstream functors may still use int; guard until
-    // upgraded.
+
+    // TODO(large-tensor): XPU xftTensor not support int64
+    PADDLE_ENFORCE_LE_INT_MAX(xn, "xn");
+    PADDLE_ENFORCE_LE_INT_MAX(nc, "nc");
+    PADDLE_ENFORCE_LE_INT_MAX(nh, "nh");
+    PADDLE_ENFORCE_LE_INT_MAX(nw, "nw");
 
     xft_conv_weights_.emplace_back(
         const_cast<int16_t*>(
             reinterpret_cast<const int16_t*>(conv_filter[i]->data<int16_t>())),
         const_cast<float*>(conv_filter_max[i]->data<float>()),
-        xft::xftTensor<int16_t, 4>::dim_t{channel, xn, nh, nw});
-    kernel_dims_2d.emplace_back(std::vector<int>{xn, nc, nh, nw});
+        xft::xftTensor<int16_t, 4>::dim_t{channel,
+                                          static_cast<int>(xn),
+                                          static_cast<int>(nh),
+                                          static_cast<int>(nw)});
+    kernel_dims_2d.emplace_back(std::vector<int>{static_cast<int>(xn),
+                                                 static_cast<int>(nc),
+                                                 static_cast<int>(nh),
+                                                 static_cast<int>(nw)});
   }
 
   // prepare bias

--- a/paddle/phi/kernels/fusion/xpu/weight_only_linear_kernel_xpu.cc
+++ b/paddle/phi/kernels/fusion/xpu/weight_only_linear_kernel_xpu.cc
@@ -39,12 +39,11 @@ void WeightOnlyLinearXpuKernel(const Context& dev_ctx,
     case phi::DataType::FLOAT16: {
       using XPUType = typename XPUTypeTrait<phi::float16>::Type;
       int64_t n = weight.dims()[0];
-      // TODO(large-tensor): downstream functors may still use int; guard until
-      // upgraded.
-
       int64_t k = weight.dims()[1];
-      // TODO(large-tensor): downstream functors may still use int; guard until
-      // upgraded.
+
+      // TODO(large-tensor): XPU weight_only_linear API not support int64
+      PADDLE_ENFORCE_LE_INT_MAX(n, "n");
+      PADDLE_ENFORCE_LE_INT_MAX(k, "k");
 
       int m = x.numel() / k;
       DenseTensor max_value;

--- a/paddle/phi/kernels/gpu/apply_per_channel_scale_kernel.cu
+++ b/paddle/phi/kernels/gpu/apply_per_channel_scale_kernel.cu
@@ -155,14 +155,8 @@ void ApplyPerChannelScaleKernel(const Context& dev_ctx,
 #ifdef PADDLE_WITH_CUDA
   using DataType = typename PDDataTypeTraits<T>::DataType;
   int64_t rows = x.dims()[0];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
-
   int64_t cols = x.dims()[1];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
-
-  int elems = rows * cols;
+  int64_t elems = rows * cols;
   const T* x_data = x.data<T>();
   const T* scales_data = scales.data<T>();
   T* out_data = dev_ctx.template Alloc<T>(out);
@@ -191,6 +185,8 @@ void ApplyPerChannelScaleKernel(const Context& dev_ctx,
         reinterpret_cast<DataType*>(out_data),
         dev_ctx.stream());
   } else {
+    PADDLE_ENFORCE_LE_INT_MAX(rows, "rows");
+    PADDLE_ENFORCE_LE_INT_MAX(cols, "cols");
     apply_per_channel_scale_launcher<DataType, 16, float4>(
         reinterpret_cast<const DataType*>(x_data),
         reinterpret_cast<const DataType*>(scales_data),

--- a/paddle/phi/kernels/gpu/argsort_kernel.cu
+++ b/paddle/phi/kernels/gpu/argsort_kernel.cu
@@ -199,12 +199,7 @@ void ArgFullSort(const phi::GPUContext& dev_ctx,
                  const int64_t num_rows,
                  const int64_t num_cols,
                  const bool descending) {
-  PADDLE_ENFORCE_LE(num_cols,
-                    std::numeric_limits<int>::max(),
-                    ::common::errors::PreconditionNotMet(
-                        "The dimension being sorted should be less than "
-                        "2^31, but got %lld. Please check the input tensor. ",
-                        num_cols));
+  PADDLE_ENFORCE_LE_INT_MAX(num_cols, "num_cols");
 
   auto cu_stream = dev_ctx.stream();
   auto ComputeBlockSize = [](IndType col) {

--- a/paddle/phi/kernels/gpu/argsort_kernel.cu
+++ b/paddle/phi/kernels/gpu/argsort_kernel.cu
@@ -97,7 +97,9 @@ __global__ void merge_kernel(const T* A,
       static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(gridDim.x);
   int64_t num_per_thread = (sizeA + sizeB + thread) / thread;
   for (int64_t offset = 0; offset < num_per_thread; offset++) {
-    size_t idx = blockIdx.x * blockDim.x + threadIdx.x + offset * thread;
+    size_t idx =
+        static_cast<size_t>(blockIdx.x) * static_cast<size_t>(blockDim.x) +
+        static_cast<size_t>(threadIdx.x) + offset * thread;
     size_t total = sizeA + sizeB;
     if (idx >= total) return;
     size_t left = (idx > sizeB) ? idx - sizeB : 0;

--- a/paddle/phi/kernels/gpu/bernoulli_kernel.cu
+++ b/paddle/phi/kernels/gpu/bernoulli_kernel.cu
@@ -48,7 +48,8 @@ __global__ void bernoulli_cuda_kernel(
   hiprand_init(seed, thread_idx, offset, &state);
 #endif
 
-  size_t total_thread = gridDim.x * blockDim.x;
+  size_t total_thread =
+      static_cast<size_t>(gridDim.x) * static_cast<size_t>(blockDim.x);
   for (size_t i = 4 * thread_idx; i < size; i += total_thread * 4) {
     funcs::uniform_distribution<float> dist;
     float4 rand = dist(&state);

--- a/paddle/phi/kernels/gpu/c_concat_kernel.cu
+++ b/paddle/phi/kernels/gpu/c_concat_kernel.cu
@@ -94,10 +94,7 @@ void CConcatKernel(const Context& dev_ctx,
   auto out_dims = x->dims();
   out_dims[out_dims.size() - 1] *= nranks;
   int64_t rows_per_tensor = x->dims()[0];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
-
-  int offset = 0;
+  int64_t offset = 0;
   for (int i = 0; i < nranks; i++) {
     phi::DenseTensor temp = temp_out.Slice(offset, offset + rows_per_tensor);
     inputs.emplace_back(temp);

--- a/paddle/phi/kernels/gpu/cholesky_kernel.cu
+++ b/paddle/phi/kernels/gpu/cholesky_kernel.cu
@@ -177,8 +177,7 @@ void CholeskyKernel(const Context& dev_ctx,
     batch_count *= dims[i];
   }
   int64_t m = dims[dims.size() - 1];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   int64_t tensor_size = batch_count * static_cast<int64_t>(m) * m;
 

--- a/paddle/phi/kernels/gpu/class_center_sample_kernel.cu
+++ b/paddle/phi/kernels/gpu/class_center_sample_kernel.cu
@@ -334,8 +334,7 @@ void ClassCenterSampleKernel(const Context& dev_ctx,
   auto place = dev_ctx.GetPlace();
 
   int64_t batch_size = label.numel();
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   PADDLE_ENFORCE_LE(
       label.numel(),

--- a/paddle/phi/kernels/gpu/class_center_sample_kernel.cu
+++ b/paddle/phi/kernels/gpu/class_center_sample_kernel.cu
@@ -335,16 +335,7 @@ void ClassCenterSampleKernel(const Context& dev_ctx,
 
   int64_t batch_size = label.numel();
   // TODO(large-tensor): downstream functors may still use int
-
-  PADDLE_ENFORCE_LE(
-      label.numel(),
-      std::numeric_limits<int>::max(),
-      errors::InvalidArgument(
-          "The total number of elements for 'label' should be less than "
-          "%d, "
-          "but received %d",
-          std::numeric_limits<int>::max(),
-          label.numel()));
+  PADDLE_ENFORCE_LE_INT_MAX(label.numel(), "label.numel()");
   // Algorithm:
   // We first randomly generate a value in [0, num_classes) on each position
   // in a array(shape[num_classes]). Then, we mark the element as negative

--- a/paddle/phi/kernels/gpu/cross_entropy_bwd_w_downcast.cu
+++ b/paddle/phi/kernels/gpu/cross_entropy_bwd_w_downcast.cu
@@ -244,8 +244,7 @@ void CrossEntropyWithSoftmaxBwdWithDowncastGPUKernel(
   const int rank = logit_grad->dims().size();
   const int axis_v = phi::funcs::CanonicalAxis(axis, rank);
   int64_t axis_dim = logit_grad->dims()[axis_v];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   const int64_t n = phi::funcs::SizeToAxis(axis_v, logit_grad->dims());
   const int64_t d = phi::funcs::SizeFromAxis(axis_v, logit_grad->dims());

--- a/paddle/phi/kernels/gpu/cross_entropy_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/cross_entropy_grad_kernel.cu
@@ -165,8 +165,7 @@ void CrossEntropyWithSoftmaxGradGPUKernel(const GPUContext& dev_ctx,
   const int rank = logit_grad->dims().size();
   const int axis_v = phi::funcs::CanonicalAxis(axis, rank);
   int64_t axis_dim = logit_grad->dims()[axis_v];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   const int64_t n = phi::funcs::SizeToAxis(axis_v, logit_grad->dims());
   const int64_t d = phi::funcs::SizeFromAxis(axis_v, logit_grad->dims());

--- a/paddle/phi/kernels/gpu/cross_entropy_kernel.cu
+++ b/paddle/phi/kernels/gpu/cross_entropy_kernel.cu
@@ -1437,11 +1437,7 @@ void CrossEntropyWithSoftmaxKernel(const Context& dev_ctx,
   const int rank = logits.dims().size();
   const int64_t axis_v = phi::funcs::CanonicalAxis(axis, rank);
   const int64_t d = phi::funcs::SizeFromAxis<int64_t>(axis_v, logits.dims());
-  PADDLE_ENFORCE_LE(d,
-                    std::numeric_limits<int>::max(),
-                    common::errors::InvalidArgument(
-                        "(PreconditionNotMet) The num of"
-                        " the classes should be <= INT_MAX(2147483647)"));
+  PADDLE_ENFORCE_LE_INT_MAX(d, "d");
   if (softmax->numel() == 0) {
     // When soft_label is False, the axis column cannot be 0. Other dimensions
     // are the same, so the numel of softmax and loss are both 0.

--- a/paddle/phi/kernels/gpu/cudnn_lstm_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/cudnn_lstm_grad_kernel.cu
@@ -117,12 +117,10 @@ void CudnnLSTMGradKernel(
 
   int seq_length = input_dims[0];
   int64_t batch_size = x.dims()[1];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   int64_t input_size = x.dims()[2];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   size_t workspace_size;
   size_t reserve_size;

--- a/paddle/phi/kernels/gpu/cudnn_lstm_kernel.cu
+++ b/paddle/phi/kernels/gpu/cudnn_lstm_kernel.cu
@@ -201,16 +201,13 @@ void CudnnLSTMKernel(
   auto handle = dev_ctx.cudnn_handle();
 
   int64_t seq_length = x.dims()[0];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   int64_t batch_size = x.dims()[1];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   int64_t input_size = x.dims()[2];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   bool state_initialized = state_out->initialized() ? true : false;
 

--- a/paddle/phi/kernels/gpu/cum_maxmin_kernel.cu
+++ b/paddle/phi/kernels/gpu/cum_maxmin_kernel.cu
@@ -270,10 +270,7 @@ void ScanWithIndicesKernel(const Context& dev_ctx,
   if (axis == out_dims.size() - 1) {
     int ndim = x.dims().size();
     int64_t row_size = x.dims()[ndim - 1];
-    // TODO(large-tensor): downstream functors may still use int; guard until
-    // upgraded.
-
-    int num_rows = x.numel() / row_size;
+    int64_t num_rows = x.numel() / row_size;
 
     dim3 threads(16, 32);
     dim3 grid(std::min(

--- a/paddle/phi/kernels/gpu/dist_concat_kernel.cu
+++ b/paddle/phi/kernels/gpu/dist_concat_kernel.cu
@@ -56,10 +56,7 @@ void DistConcatKernel(const Context& dev_ctx,
   auto out_dims = x.dims();
   out_dims[out_dims.size() - 1] *= nranks;
   int64_t rows_per_tensor = x.dims()[0];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
-
-  int offset = 0;
+  int64_t offset = 0;
   for (int i = 0; i < nranks; i++) {
     DenseTensor temp =
         temp_out.Slice(static_cast<int64_t>(offset),

--- a/paddle/phi/kernels/gpu/flash_attn_v3_kernel.cu
+++ b/paddle/phi/kernels/gpu/flash_attn_v3_kernel.cu
@@ -216,10 +216,7 @@ void FlashAttnV3BaseKernel(
   int seqlen_q = !is_varlen_q ? sizes[1] : max_seqlen_q_;
   int total_q = !is_varlen_q ? batch_size * sizes[1] : sizes[0];
   int64_t num_heads = q.dims()[q.dims().size() - 2];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
-
-  int const head_size = q.dims()[q.dims().size() - 1];
+  int64_t const head_size = q.dims()[q.dims().size() - 1];
   int const head_size_v = v.dims()[v.dims().size() - 1];
   int const max_num_pages_per_seq = !paged_KV ? 0 : page_table.dims()[1];
   int const num_pages = !paged_KV ? 0 : k.dims()[0];
@@ -1382,10 +1379,7 @@ void FlashMaskV2BaseKernel(
   int seqlen_q = !is_varlen_q ? sizes[1] : max_seqlen_q_;
   int total_q = !is_varlen_q ? batch_size * sizes[1] : sizes[0];
   int64_t num_heads = q.dims()[q.dims().size() - 2];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
-
-  int const head_size = q.dims()[q.dims().size() - 1];
+  int64_t const head_size = q.dims()[q.dims().size() - 1];
   int const head_size_v = v.dims()[v.dims().size() - 1];
   int const max_num_pages_per_seq = !paged_KV ? 0 : page_table.dims()[1];
   int const num_pages = !paged_KV ? 0 : k.dims()[0];

--- a/paddle/phi/kernels/gpu/generate_proposals_kernel.cu
+++ b/paddle/phi/kernels/gpu/generate_proposals_kernel.cu
@@ -292,10 +292,7 @@ static void NMS(const phi::GPUContext &dev_ctx,
                 DenseTensor *keep_out,
                 bool pixel_offset = true) {
   int64_t boxes_num = proposals.dims()[0];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
-
-  const int col_blocks = DIVUP(boxes_num, kThreadsPerBlock);
+  const int64_t col_blocks = DIVUP(boxes_num, kThreadsPerBlock);
   dim3 blocks(DIVUP(boxes_num, kThreadsPerBlock),
               DIVUP(boxes_num, kThreadsPerBlock));
   dim3 threads(kThreadsPerBlock);
@@ -332,7 +329,7 @@ static void NMS(const phi::GPUContext &dev_ctx,
       ++num_to_keep;
       keep_vec.push_back(i);
       uint64_t *p = mask_host.data() + i * col_blocks;
-      for (int j = nblock; j < col_blocks; j++) {
+      for (int64_t j = nblock; j < col_blocks; j++) {
         remv[j] |= p[j];
       }
     }

--- a/paddle/phi/kernels/gpu/graph_reindex_kernel.cu
+++ b/paddle/phi/kernels/gpu/graph_reindex_kernel.cu
@@ -394,8 +394,7 @@ void GraphReindexKernel(const Context& dev_ctx,
   // Add support for multi-type edges reindex.
   int64_t num_ac_count = count.dims()[0];
   int64_t num_edge_types = num_ac_count / bs;
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
   thrust::device_vector<int> unique_dst_reindex(bs);
   thrust::sequence(unique_dst_reindex.begin(), unique_dst_reindex.end());
   reindex_dst->Resize({num_edges});

--- a/paddle/phi/kernels/gpu/graph_reindex_kernel.cu
+++ b/paddle/phi/kernels/gpu/graph_reindex_kernel.cu
@@ -393,10 +393,9 @@ void GraphReindexKernel(const Context& dev_ctx,
   // Get reindex dst edge.
   // Add support for multi-type edges reindex.
   int64_t num_ac_count = count.dims()[0];
+  int64_t num_edge_types = num_ac_count / bs;
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-
-  int num_edge_types = num_ac_count / bs;
   thrust::device_vector<int> unique_dst_reindex(bs);
   thrust::sequence(unique_dst_reindex.begin(), unique_dst_reindex.end());
   reindex_dst->Resize({num_edges});

--- a/paddle/phi/kernels/gpu/graph_sample_neighbors_kernel.cu
+++ b/paddle/phi/kernels/gpu/graph_sample_neighbors_kernel.cu
@@ -374,8 +374,7 @@ void GraphSampleNeighborsKernel(
   auto* col_ptr_data = col_ptr.data<T>();
   auto* x_data = x.data<T>();
   int64_t bs = x.dims()[0];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   int64_t len_col_ptr = col_ptr.dims()[0];
 

--- a/paddle/phi/kernels/gpu/interpolate_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/interpolate_grad_kernel.cu
@@ -130,10 +130,17 @@ __global__ void KeNearestNeighborInterpNCHWBw(T* in,
                                               const float ratio_h,
                                               const float ratio_w,
                                               const bool align_corners) {
-  IndexType out_img_idx = threadIdx.x + blockIdx.x * blockDim.x;
-  IndexType out_img_idy = threadIdx.y + blockIdx.y * blockDim.y;
-  IndexType nc_id = threadIdx.z + blockIdx.z * blockDim.z;
-  IndexType nc_stride = blockDim.z * gridDim.z;
+  IndexType out_img_idx =
+      static_cast<IndexType>(threadIdx.x) +
+      static_cast<IndexType>(blockIdx.x) * static_cast<IndexType>(blockDim.x);
+  IndexType out_img_idy =
+      static_cast<IndexType>(threadIdx.y) +
+      static_cast<IndexType>(blockIdx.y) * static_cast<IndexType>(blockDim.y);
+  IndexType nc_id =
+      static_cast<IndexType>(threadIdx.z) +
+      static_cast<IndexType>(blockIdx.z) * static_cast<IndexType>(blockDim.z);
+  IndexType nc_stride =
+      static_cast<IndexType>(blockDim.z) * static_cast<IndexType>(gridDim.z);
 
   // nearest_sampling by multiple read in_addr and write to out_addr
   IndexType in_img_idx =

--- a/paddle/phi/kernels/gpu/interpolate_kernel.cu
+++ b/paddle/phi/kernels/gpu/interpolate_kernel.cu
@@ -472,8 +472,11 @@ __global__ void KeBicubicInterpFw(const T* in,
                                   const bool align_corners,
                                   const DataLayout data_layout) {
   size_t nthreads = output_h * output_w;
-  size_t tid = blockIdx.x * blockDim.x + threadIdx.x;
-  size_t stride = blockDim.x * gridDim.x;
+  size_t tid =
+      static_cast<size_t>(blockIdx.x) * static_cast<size_t>(blockDim.x) +
+      static_cast<size_t>(threadIdx.x);
+  size_t stride =
+      static_cast<size_t>(blockDim.x) * static_cast<size_t>(gridDim.x);
   using MT = typename phi::dtype::MPTypeTrait<T>::Type;
 
   for (; tid < nthreads; tid += stride) {

--- a/paddle/phi/kernels/gpu/lookup_table_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/lookup_table_grad_kernel.cu
@@ -84,16 +84,13 @@ void LookupTableGradCUDAKernel(
   auto d_table_t = w_grad;
 
   int64_t N = d_table_t->dims()[0];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   int64_t D = d_table_t->dims()[1];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   int64_t K = ids_t->numel();
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   const int64_t *ids = ids_t->data<int64_t>();
   const T *d_output = d_output_t->data<T>();

--- a/paddle/phi/kernels/gpu/multinomial_kernel.cu
+++ b/paddle/phi/kernels/gpu/multinomial_kernel.cu
@@ -96,8 +96,11 @@ __global__ void sampleMultinomialWithReplacement(
     uint64_t offset) {
   // use binary search to get the selected category sample id.
   // let cumulative_probs_data[id-1] < rng_number < cumulative_probs_data[id].
-  size_t idx = gridDim.x * blockDim.x * blockIdx.y + blockDim.x * blockIdx.x +
-               threadIdx.x;
+  size_t idx =
+      static_cast<size_t>(gridDim.x) * static_cast<size_t>(blockDim.x) *
+          static_cast<size_t>(blockIdx.y) +
+      static_cast<size_t>(blockDim.x) * static_cast<size_t>(blockIdx.x) +
+      static_cast<size_t>(threadIdx.x);
 
 #if defined(__NVCC__)
   curandStatePhilox4_32_10_t state;

--- a/paddle/phi/kernels/gpu/psroi_pool_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/psroi_pool_grad_kernel.cu
@@ -118,20 +118,16 @@ void PsroiPoolGradKernel(const Context& dev_ctx,
                          float spatial_scale,
                          DenseTensor* dx) {
   int64_t rois_num_t = rois.dims()[0];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   int64_t input_channels = x.dims()[1];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   int64_t height = x.dims()[2];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   int64_t width = x.dims()[3];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   if (dx) {
     // set roi batch id

--- a/paddle/phi/kernels/gpu/rnn_kernel.cu.cc
+++ b/paddle/phi/kernels/gpu/rnn_kernel.cu.cc
@@ -237,16 +237,13 @@ void RnnKernel(const Context &dev_ctx,
   auto handle = dev_ctx.cudnn_handle();
 
   int64_t seq_length = x.dims()[0];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   int64_t batch_size = x.dims()[1];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   int64_t input_size_local = x.dims()[2];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   size_t workspace_size;
   size_t reserve_size;

--- a/paddle/phi/kernels/gpu/roi_pool_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/roi_pool_grad_kernel.cu
@@ -48,12 +48,11 @@ __global__ void GPURoiPoolBackward(const IndexType nthreads,
                                    const int pooled_width,
                                    int* box_batch_id_data,
                                    T* input_grad) {
-  IndexType index = static_cast<IndexType>(static_cast<IndexType>(blockIdx.x)) *
-                        static_cast<IndexType>(blockDim.x) +
-                    static_cast<IndexType>(threadIdx.x);
+  IndexType index =
+      static_cast<IndexType>(blockIdx.x) * static_cast<IndexType>(blockDim.x) +
+      static_cast<IndexType>(threadIdx.x);
   IndexType offset =
-      static_cast<IndexType>(static_cast<IndexType>(blockDim.x)) *
-      static_cast<IndexType>(gridDim.x);
+      static_cast<IndexType>(blockDim.x) * static_cast<IndexType>(gridDim.x);
   for (IndexType i = index; i < nthreads; i += offset) {
     IndexType pw = i % pooled_width;
     IndexType ph = (i / pooled_width) % pooled_height;

--- a/paddle/phi/kernels/gpu/roi_pool_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/roi_pool_grad_kernel.cu
@@ -48,9 +48,12 @@ __global__ void GPURoiPoolBackward(const IndexType nthreads,
                                    const int pooled_width,
                                    int* box_batch_id_data,
                                    T* input_grad) {
-  IndexType index =
-      static_cast<IndexType>(blockIdx.x) * blockDim.x + threadIdx.x;
-  IndexType offset = static_cast<IndexType>(blockDim.x) * gridDim.x;
+  IndexType index = static_cast<IndexType>(static_cast<IndexType>(blockIdx.x)) *
+                        static_cast<IndexType>(blockDim.x) +
+                    static_cast<IndexType>(threadIdx.x);
+  IndexType offset =
+      static_cast<IndexType>(static_cast<IndexType>(blockDim.x)) *
+      static_cast<IndexType>(gridDim.x);
   for (IndexType i = index; i < nthreads; i += offset) {
     IndexType pw = i % pooled_width;
     IndexType ph = (i / pooled_width) % pooled_height;

--- a/paddle/phi/kernels/gpu/roi_pool_kernel.cu
+++ b/paddle/phi/kernels/gpu/roi_pool_kernel.cu
@@ -45,9 +45,12 @@ __global__ void GPURoiPoolForward(const IndexType nthreads,
                                   int* box_batch_id_data,
                                   T* output_data,
                                   int64_t* arg_max_data) {
-  IndexType index =
-      static_cast<IndexType>(blockIdx.x) * blockDim.x + threadIdx.x;
-  IndexType offset = static_cast<IndexType>(blockDim.x) * gridDim.x;
+  IndexType index = static_cast<IndexType>(static_cast<IndexType>(blockIdx.x)) *
+                        static_cast<IndexType>(blockDim.x) +
+                    static_cast<IndexType>(threadIdx.x);
+  IndexType offset =
+      static_cast<IndexType>(static_cast<IndexType>(blockDim.x)) *
+      static_cast<IndexType>(gridDim.x);
   for (size_t i = index; i < nthreads; i += offset) {
     IndexType pw = i % pooled_width;
     IndexType ph = (i / pooled_width) % pooled_height;

--- a/paddle/phi/kernels/gpu/roi_pool_kernel.cu
+++ b/paddle/phi/kernels/gpu/roi_pool_kernel.cu
@@ -45,12 +45,11 @@ __global__ void GPURoiPoolForward(const IndexType nthreads,
                                   int* box_batch_id_data,
                                   T* output_data,
                                   int64_t* arg_max_data) {
-  IndexType index = static_cast<IndexType>(static_cast<IndexType>(blockIdx.x)) *
-                        static_cast<IndexType>(blockDim.x) +
-                    static_cast<IndexType>(threadIdx.x);
+  IndexType index =
+      static_cast<IndexType>(blockIdx.x) * static_cast<IndexType>(blockDim.x) +
+      static_cast<IndexType>(threadIdx.x);
   IndexType offset =
-      static_cast<IndexType>(static_cast<IndexType>(blockDim.x)) *
-      static_cast<IndexType>(gridDim.x);
+      static_cast<IndexType>(blockDim.x) * static_cast<IndexType>(gridDim.x);
   for (size_t i = index; i < nthreads; i += offset) {
     IndexType pw = i % pooled_width;
     IndexType ph = (i / pooled_width) % pooled_height;

--- a/paddle/phi/kernels/gpu/row_conv_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/row_conv_grad_kernel.cu
@@ -277,8 +277,7 @@ void RowConvGradKernel(const Context &dev_ctx,
   int input_dim = 0;
   phi::Vector<size_t> batch_indices(batch_size + 1);
   int64_t timesteps = X->dims()[1];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   if (is_tensor) {
     for (int i = 0; i < batch_size + 1; i++) {
@@ -292,8 +291,7 @@ void RowConvGradKernel(const Context &dev_ctx,
   // int input_dim = X->dims()[1];
   int num_sequence = batch_indices.size() - 1;
   int64_t future_context = Filter->dims()[0];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   phi::MixVector<size_t> mixv_batch_indices(&batch_indices);
   size_t *idx = mixv_batch_indices.CUDAMutableData(dev_ctx.GetPlace());

--- a/paddle/phi/kernels/gpu/row_conv_kernel.cu
+++ b/paddle/phi/kernels/gpu/row_conv_kernel.cu
@@ -121,8 +121,7 @@ void RowConvKernel(const Context &dev_ctx,
   int input_dim = 0;
   phi::Vector<size_t> batch_indices(batch_size + 1);
   int64_t timesteps = X->dims()[1];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   if (is_tensor) {
     for (int i = 0; i < batch_size + 1; i++) {
@@ -136,8 +135,7 @@ void RowConvKernel(const Context &dev_ctx,
 
   int num_sequence = batch_indices.size() - 1;
   int64_t future_context = Filter->dims()[0];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   phi::MixVector<size_t> mix_vector(&batch_indices);
   size_t *idx = mix_vector.CUDAMutableData(dev_ctx.GetPlace());

--- a/paddle/phi/kernels/gpu/svd_kernel.cu
+++ b/paddle/phi/kernels/gpu/svd_kernel.cu
@@ -388,12 +388,10 @@ void SvdKernel(const Context& dev_ctx,
   }
   int rank = dims.size();
   int64_t m = dims[rank - 2];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   int64_t n = dims[rank - 1];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   auto* u_data = dev_ctx.template Alloc<T>(U);
   auto* vh_data = dev_ctx.template Alloc<T>(VH);

--- a/paddle/phi/kernels/gpu/top_p_sampling_kernel.cu
+++ b/paddle/phi/kernels/gpu/top_p_sampling_kernel.cu
@@ -1096,8 +1096,7 @@ void TopPSamplingKernel(const Context& dev_ctx,
   const auto& in_dims = input->dims();
   int64_t p_num = ps.numel();
   int64_t bs = in_dims[0];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
   int vocab_size = in_dims[1];
   T* out_ptr = dev_ctx.template Alloc<T>(out);
   int64_t* ids_ptr = dev_ctx.template Alloc<int64_t>(ids);

--- a/paddle/phi/kernels/gpu/top_p_sampling_kernel.cu
+++ b/paddle/phi/kernels/gpu/top_p_sampling_kernel.cu
@@ -1095,10 +1095,9 @@ void TopPSamplingKernel(const Context& dev_ctx,
   // get the input dims
   const auto& in_dims = input->dims();
   int64_t p_num = ps.numel();
+  int64_t bs = in_dims[0];
   // TODO(large-tensor): downstream functors may still use int; guard until
   // upgraded.
-
-  int bs = in_dims[0];
   int vocab_size = in_dims[1];
   T* out_ptr = dev_ctx.template Alloc<T>(out);
   int64_t* ids_ptr = dev_ctx.template Alloc<int64_t>(ids);

--- a/paddle/phi/kernels/gpu/weight_dequantize_kernel.cu
+++ b/paddle/phi/kernels/gpu/weight_dequantize_kernel.cu
@@ -379,12 +379,10 @@ void WeightDequantize(const Context& dev_ctx,
                       DenseTensor* out) {
   using DataType = typename PDDataTypeTraits<T>::DataType;
   int64_t n = scale.dims()[0];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   int64_t k = x.dims()[1];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   PADDLE_ENFORCE_EQ(
       (k % NUMPERTHREAD == 0),

--- a/paddle/phi/kernels/gpu/weight_only_linear_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/weight_only_linear_grad_kernel.cu
@@ -50,12 +50,10 @@ void WeightOnlyLinearGradKernel(const Context& dev_ctx,
           "Currently weightonly linear grad only support per-channel mode. "));
 
   int64_t n = weight_scale.dims()[0];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   int64_t k = weight.dims()[1];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   dev_ctx.template Alloc<T>(x_grad);
   if (x_grad->numel() == 0 || out_grad.numel() == 0) {

--- a/paddle/phi/kernels/gpu/weighted_sample_neighbors_kernel.cu
+++ b/paddle/phi/kernels/gpu/weighted_sample_neighbors_kernel.cu
@@ -332,8 +332,7 @@ void WeightedSampleNeighborsKernel(const Context& dev_ctx,
   auto* eids_data =
       (eids.get_ptr() == nullptr ? nullptr : eids.get_ptr()->data<T>());
   int64_t bs = x.dims()[0];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   thread_local std::random_device rd;
   thread_local std::mt19937 gen(rd());

--- a/paddle/phi/kernels/gpu/yolo_box_post_kernel.cu
+++ b/paddle/phi/kernels/gpu/yolo_box_post_kernel.cu
@@ -409,8 +409,7 @@ void YoloBoxPostKernel(const Context& dev_ctx,
   // clip_bbox and scale_x_y is not used now!
 
   int64_t batch = image_shape.dims()[0];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   TensorInfo* ts_info = new TensorInfo[batch * boxes_input.size()];
   for (int i = 0; i < batch * static_cast<int>(boxes_input.size()); i++) {

--- a/paddle/phi/kernels/gpudnn/affine_grid_grad_kernel.cu
+++ b/paddle/phi/kernels/gpudnn/affine_grid_grad_kernel.cu
@@ -52,8 +52,7 @@ void AffineGridGradCudnnKernel(const Context& dev_ctx,
   auto& theta_grad = input_grad;
 
   int64_t n = output_grad.dims()[0];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
+  // TODO(large-tensor): downstream functors may still use int
 
   auto& size_attr = outputShape.GetData();
   int h_size_data[4] = {0};

--- a/paddle/phi/kernels/gpudnn/mha_cudnn_frontend.cu
+++ b/paddle/phi/kernels/gpudnn/mha_cudnn_frontend.cu
@@ -297,7 +297,9 @@ __global__ void cu_seqlens_to_actual_seqlens(size_t b,
                                              int32_t const *const kv_cu_seqlens,
                                              int32_t *q_seqlens,
                                              int32_t *kv_seqlens) {
-  size_t tid = blockIdx.x * blockDim.x + threadIdx.x;
+  size_t tid =
+      static_cast<size_t>(blockIdx.x) * static_cast<size_t>(blockDim.x) +
+      static_cast<size_t>(threadIdx.x);
   if (tid < b) {
     q_seqlens[tid] = q_cu_seqlens[tid + 1] - q_cu_seqlens[tid];
     kv_seqlens[tid] = kv_cu_seqlens[tid + 1] - kv_cu_seqlens[tid];

--- a/paddle/phi/kernels/gpudnn/softmax_gpudnn.h
+++ b/paddle/phi/kernels/gpudnn/softmax_gpudnn.h
@@ -1667,7 +1667,7 @@ __device__ __forceinline__ void WriteResults(int classes,
                                              Function<T, AccT, T> function) {
   IndexType offset = threadIdx.x;
 
-  IndexType last = classes % (VecSize * blockDim.x);
+  IndexType last = classes % (VecSize * static_cast<IndexType>(blockDim.x));
 
   for (; offset < classes - last; offset += blockDim.x * VecSize) {
     T tmpOutput[VecSize];
@@ -2018,7 +2018,9 @@ __global__ void SpatialSoftMaxForward(
   for (IndexType outer_index = blockIdx.x; outer_index < N;
        outer_index += gridDim.x) {
     const IndexType outer_offset = outer_index * outer_stride;
-    for (IndexType inner_index = blockIdx.y * blockDim.y + threadIdx.y;
+    for (IndexType inner_index = static_cast<IndexType>(blockIdx.y) *
+                                     static_cast<IndexType>(blockDim.y) +
+                                 static_cast<IndexType>(threadIdx.y);
          inner_index < D;
          inner_index += blockDim.y * gridDim.y) {
       const IndexType data_offset = outer_offset + inner_index;
@@ -2082,7 +2084,9 @@ __global__ void SpatialSoftMaxBackward(T* gradInput,
   for (IndexType outer_index = blockIdx.x; outer_index < N;
        outer_index += gridDim.x) {
     const IndexType outer_offset = outer_index * outer_stride;
-    for (IndexType inner_index = blockIdx.y * blockDim.y + threadIdx.y;
+    for (IndexType inner_index = static_cast<IndexType>(blockIdx.y) *
+                                     static_cast<IndexType>(blockDim.y) +
+                                 static_cast<IndexType>(threadIdx.y);
          inner_index < D;
          inner_index += blockDim.y * gridDim.y) {
       const IndexType data_offset = outer_offset + inner_index;
@@ -2136,7 +2140,9 @@ __global__ void softmax_warp_forward(T* dst,
   constexpr IndexType kWarpBatchSize = (next_power_of_two <= 128) ? 2 : 1;
 
   IndexType first_batch =
-      (blockDim.y * blockIdx.x + threadIdx.y) * kWarpBatchSize;
+      (static_cast<IndexType>(blockDim.y) * static_cast<IndexType>(blockIdx.x) +
+       static_cast<IndexType>(threadIdx.y)) *
+      kWarpBatchSize;
 
   // batch_size may not be a multiple of kWarpBatchSize. Determine how many
   // batches need to be computed within this warp.
@@ -2246,7 +2252,9 @@ __global__ void softmax_warp_backward(T* gradInput,
   constexpr IndexType kWarpBatchSize = (next_power_of_two <= 128) ? 2 : 1;
 
   IndexType first_batch =
-      (blockDim.y * blockIdx.x + threadIdx.y) * kWarpBatchSize;
+      (static_cast<IndexType>(blockDim.y) * static_cast<IndexType>(blockIdx.x) +
+       static_cast<IndexType>(threadIdx.y)) *
+      kWarpBatchSize;
 
   // batch_size may not be a multiple of kWarpBatchSize. Determine how many
   // batches need to be computed within this warp.
@@ -2255,7 +2263,7 @@ __global__ void softmax_warp_backward(T* gradInput,
 
   // There may be multiple batches per warp. Compute the thread’s index within
   // the batch.
-  IndexType local_idx = threadIdx.x % warp_size_t;
+  IndexType local_idx = static_cast<IndexType>(threadIdx.x) % warp_size_t;
 
   // The first element to be processed by the current thread.
   IndexType thread_offset = first_batch * stride + local_idx;

--- a/paddle/phi/kernels/gpudnn/softmax_gpudnn.h
+++ b/paddle/phi/kernels/gpudnn/softmax_gpudnn.h
@@ -445,7 +445,8 @@ __device__ __forceinline__ void ThreadVecWrite(T* out,
   }
 
   // the tail
-  for (IndexType offset = dim_size - last + threadIdx.x; offset < dim_size;
+  for (IndexType offset = dim_size - last + static_cast<IndexType>(threadIdx.x);
+       offset < dim_size;
        offset += blockDim.x) {
     out[offset] = functor(static_cast<AccT>(input[offset]));
   }

--- a/paddle/phi/kernels/impl/cross_entropy2_kernel_impl.h
+++ b/paddle/phi/kernels/impl/cross_entropy2_kernel_impl.h
@@ -50,7 +50,7 @@ void CrossEntropyOpKernel(const Context& dev_ctx,
     y_2d = phi::ReshapeToMatrix(*y, rank - 1);
   }
 
-  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  // TODO(large-tensor): downstream functors may still use int
   int64_t axis_dim = x.dims()[rank - 1];
 
   phi::funcs::CrossEntropyFunctor<Context, T>()(

--- a/paddle/phi/kernels/impl/cross_entropy2_kernel_impl.h
+++ b/paddle/phi/kernels/impl/cross_entropy2_kernel_impl.h
@@ -50,7 +50,9 @@ void CrossEntropyOpKernel(const Context& dev_ctx,
     y_2d = phi::ReshapeToMatrix(*y, rank - 1);
   }
 
-  int axis_dim = x.dims()[rank - 1];
+  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  int64_t axis_dim = x.dims()[rank - 1];
+
   phi::funcs::CrossEntropyFunctor<Context, T>()(
       dev_ctx, &y_2d, &x_2d, &labels_2d, soft_label, ignore_index, axis_dim);
 }

--- a/paddle/phi/kernels/impl/gru_unit_kernel_impl.h
+++ b/paddle/phi/kernels/impl/gru_unit_kernel_impl.h
@@ -67,8 +67,12 @@ void GRUUnitKernel(const Context& dev_ctx,
   dev_ctx.template Alloc<T>(reset_hidden_prev);
   dev_ctx.template Alloc<T>(hidden);
 
-  int batch_size = input_p->dims()[0];
-  int frame_size = hidden_prev_p->dims()[1];
+  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  int64_t batch_size = input_p->dims()[0];
+
+  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  int64_t frame_size = hidden_prev_p->dims()[1];
+
 
   auto x = phi::EigenMatrix<T>::From(input);
   auto h_p = phi::EigenMatrix<T>::From(hidden_prev);
@@ -212,8 +216,12 @@ void GRUUnitGradKernel(const Context& dev_ctx,
   auto d_r_h_p = phi::EigenMatrix<T>::From(reset_hidden_prev_grad);
   auto& place = *dev_ctx.eigen_device();
 
-  int batch_size = input.dims()[0];
-  int frame_size = hidden_prev.dims()[1];
+  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  int64_t batch_size = input.dims()[0];
+
+  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  int64_t frame_size = hidden_prev.dims()[1];
+
 
   Eigen::array<int, 2> extents{{batch_size, frame_size}};
   Eigen::array<int, 2> u_offsets{{0, 0}};

--- a/paddle/phi/kernels/impl/gru_unit_kernel_impl.h
+++ b/paddle/phi/kernels/impl/gru_unit_kernel_impl.h
@@ -67,10 +67,7 @@ void GRUUnitKernel(const Context& dev_ctx,
   dev_ctx.template Alloc<T>(reset_hidden_prev);
   dev_ctx.template Alloc<T>(hidden);
 
-  // TODO(large-tensor): downstream functors may still use int
   int64_t batch_size = input_p->dims()[0];
-
-  // TODO(large-tensor): downstream functors may still use int
   int64_t frame_size = hidden_prev_p->dims()[1];
 
   auto x = phi::EigenMatrix<T>::From(input);
@@ -84,8 +81,8 @@ void GRUUnitKernel(const Context& dev_ctx,
   if (bias) {
     auto b = phi::EigenMatrix<T>::From(bias.get());
     g.device(place) =
-        x + b.reshape(Eigen::array<int, 2>({{1, frame_size * 3}}))
-                .broadcast(Eigen::array<int, 2>({{batch_size, 1}}));
+        x + b.reshape(Eigen::array<int64_t, 2>({{1, frame_size * 3}}))
+                .broadcast(Eigen::array<int64_t, 2>({{batch_size, 1}}));
   } else {
     g.device(place) = x;
   }
@@ -109,15 +106,15 @@ void GRUUnitKernel(const Context& dev_ctx,
             frame_size * 3);
 
   // calculate activated gate
-  Eigen::array<int, 2> extents{{batch_size, frame_size}};
-  Eigen::array<int, 2> u_offsets{{0, 0}};
+  Eigen::array<int64_t, 2> extents{{batch_size, frame_size}};
+  Eigen::array<int64_t, 2> u_offsets{{0, 0}};
   ACT_COMPUTE(gate_activation,
               place,
               g.slice(u_offsets, extents),
               g.slice(u_offsets, extents),
               dev_ctx.GetPlace());
   auto u = g.slice(u_offsets, extents);  // update gate
-  Eigen::array<int, 2> r_offsets{{0, frame_size}};
+  Eigen::array<int64_t, 2> r_offsets{{0, frame_size}};
   ACT_COMPUTE(gate_activation,
               place,
               g.slice(r_offsets, extents),
@@ -139,7 +136,7 @@ void GRUUnitKernel(const Context& dev_ctx,
             gate_data + frame_size * 2,
             frame_size * 3);
 
-  Eigen::array<int, 2> c_offsets{{0, frame_size * 2}};
+  Eigen::array<int64_t, 2> c_offsets{{0, frame_size * 2}};
   ACT_COMPUTE(activation,
               place,
               g.slice(c_offsets, extents),
@@ -215,18 +212,15 @@ void GRUUnitGradKernel(const Context& dev_ctx,
   auto d_r_h_p = phi::EigenMatrix<T>::From(reset_hidden_prev_grad);
   auto& place = *dev_ctx.eigen_device();
 
-  // TODO(large-tensor): downstream functors may still use int
   int64_t batch_size = input.dims()[0];
-
-  // TODO(large-tensor): downstream functors may still use int
   int64_t frame_size = hidden_prev.dims()[1];
 
-  Eigen::array<int, 2> extents{{batch_size, frame_size}};
-  Eigen::array<int, 2> u_offsets{{0, 0}};
+  Eigen::array<int64_t, 2> extents{{batch_size, frame_size}};
+  Eigen::array<int64_t, 2> u_offsets{{0, 0}};
   auto u = g.slice(u_offsets, extents);  // update gate
-  Eigen::array<int, 2> r_offsets{{0, frame_size}};
+  Eigen::array<int64_t, 2> r_offsets{{0, frame_size}};
   auto r = g.slice(r_offsets, extents);  // reset gate
-  Eigen::array<int, 2> c_offsets{{0, frame_size * 2}};
+  Eigen::array<int64_t, 2> c_offsets{{0, frame_size * 2}};
   auto c = g.slice(c_offsets, extents);  // output candidate
 
   // backward for unactivated update gate
@@ -339,7 +333,7 @@ void GRUUnitGradKernel(const Context& dev_ctx,
   if (bias_grad) {
     dev_ctx.template Alloc<T>(bias_grad);
     auto d_b = phi::EigenVector<T>::Flatten(*bias_grad);
-    d_b.device(place) = d_g.sum(Eigen::array<int, 1>({{0}}));
+    d_b.device(place) = d_g.sum(Eigen::array<int64_t, 1>({{0}}));
   }
 }
 }  // namespace phi

--- a/paddle/phi/kernels/impl/gru_unit_kernel_impl.h
+++ b/paddle/phi/kernels/impl/gru_unit_kernel_impl.h
@@ -67,12 +67,11 @@ void GRUUnitKernel(const Context& dev_ctx,
   dev_ctx.template Alloc<T>(reset_hidden_prev);
   dev_ctx.template Alloc<T>(hidden);
 
-  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  // TODO(large-tensor): downstream functors may still use int
   int64_t batch_size = input_p->dims()[0];
 
-  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  // TODO(large-tensor): downstream functors may still use int
   int64_t frame_size = hidden_prev_p->dims()[1];
-
 
   auto x = phi::EigenMatrix<T>::From(input);
   auto h_p = phi::EigenMatrix<T>::From(hidden_prev);
@@ -216,12 +215,11 @@ void GRUUnitGradKernel(const Context& dev_ctx,
   auto d_r_h_p = phi::EigenMatrix<T>::From(reset_hidden_prev_grad);
   auto& place = *dev_ctx.eigen_device();
 
-  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  // TODO(large-tensor): downstream functors may still use int
   int64_t batch_size = input.dims()[0];
 
-  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  // TODO(large-tensor): downstream functors may still use int
   int64_t frame_size = hidden_prev.dims()[1];
-
 
   Eigen::array<int, 2> extents{{batch_size, frame_size}};
   Eigen::array<int, 2> u_offsets{{0, 0}};

--- a/paddle/phi/kernels/impl/gumbel_softmax_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/gumbel_softmax_grad_kernel_impl.h
@@ -45,18 +45,8 @@ void GumbelSoftmaxGradKernel(const Context& dev_ctx,
     return;
   }
 
-  // TODO(large-tensor): Softmax functor implementation still uses int for
-  // dimensions. Need to update Softmax functor to support dimensions >
-  // INT32_MAX.
-  PADDLE_ENFORCE_LE(
-      axis_dim,
-      std::numeric_limits<int>::max(),
-      common::errors::InvalidArgument(
-          "The axis dimension (%ld) exceeds the maximum value that int can "
-          "represent (%d). GumbelSoftmax gradient operation does not support "
-          "such large tensors yet.",
-          axis_dim,
-          std::numeric_limits<int>::max()));
+  // TODO(large-tensor): SoftmaxGradFunctor not support int64
+  PADDLE_ENFORCE_LE_INT_MAX(axis_dim, "axis_dim");
 
   const int size_to_axis = funcs::SizeToAxis(axis, dx->dims());
   const int size_from_axis = funcs::SizeFromAxis(axis, dx->dims());

--- a/paddle/phi/kernels/impl/gumbel_softmax_kernel_impl.h
+++ b/paddle/phi/kernels/impl/gumbel_softmax_kernel_impl.h
@@ -74,18 +74,8 @@ void GumbelSoftmaxKernelHelper(const Context& dev_ctx,
     return;
   }
 
-  // TODO(large-tensor): Softmax functor implementation still uses int for
-  // dimensions. Need to update Softmax functor to support dimensions >
-  // INT32_MAX.
-  PADDLE_ENFORCE_LE(
-      axis_dim,
-      std::numeric_limits<int>::max(),
-      common::errors::InvalidArgument(
-          "The axis dimension (%ld) exceeds the maximum value that int can "
-          "represent (%d). GumbelSoftmax operation does not support such "
-          "large tensors yet.",
-          axis_dim,
-          std::numeric_limits<int>::max()));
+  // TODO(large-tensor): SoftmaxFunctor not support int64
+  PADDLE_ENFORCE_LE_INT_MAX(axis_dim, "axis_dim");
 
   const int size_to_axis = funcs::SizeToAxis(axis, x.dims());
   const int size_from_axis = funcs::SizeFromAxis(axis, x.dims());

--- a/paddle/phi/kernels/impl/isclose_kernel_impl.h
+++ b/paddle/phi/kernels/impl/isclose_kernel_impl.h
@@ -129,9 +129,9 @@ __global__ void IscloseCUDAKernel(const T* in_data,
                                   bool equal_nan,
                                   IndexType num,
                                   bool* out_data) {
-  IndexType idx = static_cast<IndexType>(static_cast<IndexType>(blockIdx.x)) *
-                      static_cast<IndexType>(blockDim.x) +
-                  static_cast<IndexType>(threadIdx.x);
+  IndexType idx =
+      static_cast<IndexType>(blockIdx.x) * static_cast<IndexType>(blockDim.x) +
+      static_cast<IndexType>(threadIdx.x);
   bool val;
   using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
   for (IndexType i = idx; i < num; i += blockDim.x * gridDim.x) {

--- a/paddle/phi/kernels/impl/isclose_kernel_impl.h
+++ b/paddle/phi/kernels/impl/isclose_kernel_impl.h
@@ -129,7 +129,9 @@ __global__ void IscloseCUDAKernel(const T* in_data,
                                   bool equal_nan,
                                   IndexType num,
                                   bool* out_data) {
-  IndexType idx = static_cast<IndexType>(blockIdx.x) * blockDim.x + threadIdx.x;
+  IndexType idx = static_cast<IndexType>(static_cast<IndexType>(blockIdx.x)) *
+                      static_cast<IndexType>(blockDim.x) +
+                  static_cast<IndexType>(threadIdx.x);
   bool val;
   using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
   for (IndexType i = idx; i < num; i += blockDim.x * gridDim.x) {

--- a/paddle/phi/kernels/impl/isfinite_kernel_impl.h
+++ b/paddle/phi/kernels/impl/isfinite_kernel_impl.h
@@ -304,7 +304,9 @@ __global__ void IsfiniteCUDAKernel(
     typename std::enable_if<std::is_floating_point<T>::value &&
                             !std::is_same<T, phi::bfloat16>::value &&
                             !std::is_same<T, phi::float16>::value>::type* = 0) {
-  IndexType idx = threadIdx.x + blockIdx.x * blockDim.x;
+  IndexType idx =
+      static_cast<IndexType>(threadIdx.x) +
+      static_cast<IndexType>(blockIdx.x) * static_cast<IndexType>(blockDim.x);
   for (IndexType i = idx; i < num; i += blockDim.x * gridDim.x) {
     const T& a = in_data[i];
     out_data[i] = isfinite(a);
@@ -318,7 +320,9 @@ __global__ void IsfiniteCUDAKernel(
     bool* out_data,
     typename std::enable_if<std::is_same<T, phi::bfloat16>::value ||
                             std::is_same<T, phi::float16>::value>::type* = 0) {
-  IndexType idx = threadIdx.x + blockIdx.x * blockDim.x;
+  IndexType idx =
+      static_cast<IndexType>(threadIdx.x) +
+      static_cast<IndexType>(blockIdx.x) * static_cast<IndexType>(blockDim.x);
   for (IndexType i = idx; i < num; i += blockDim.x * gridDim.x) {
     const T& a = in_data[i];
     out_data[i] = isfinite(a);
@@ -331,7 +335,9 @@ __global__ void IsfiniteCUDAKernel(
     IndexType num,
     bool* out_data,
     typename std::enable_if<std::is_integral<T>::value>::type* = 0) {
-  IndexType idx = threadIdx.x + blockIdx.x * blockDim.x;
+  IndexType idx =
+      static_cast<IndexType>(threadIdx.x) +
+      static_cast<IndexType>(blockIdx.x) * static_cast<IndexType>(blockDim.x);
   for (IndexType i = idx; i < num; i += blockDim.x * gridDim.x) {
     out_data[i] = true;
   }
@@ -343,7 +349,9 @@ __global__ void IsfiniteCUDAKernel(
     IndexType num,
     bool* out_data,
     typename std::enable_if<is_complex64_or_complex128<T>::value>::type* = 0) {
-  IndexType idx = threadIdx.x + blockIdx.x * blockDim.x;
+  IndexType idx =
+      static_cast<IndexType>(threadIdx.x) +
+      static_cast<IndexType>(blockIdx.x) * static_cast<IndexType>(blockDim.x);
   for (IndexType i = idx; i < num; i += blockDim.x * gridDim.x) {
     const T& a = in_data[i];
     out_data[i] = isfinite(a.real) && isfinite(a.imag);
@@ -359,7 +367,9 @@ __global__ void IsnanCUDAKernel(
     typename std::enable_if<std::is_floating_point<T>::value &&
                             !std::is_same<T, phi::bfloat16>::value &&
                             !std::is_same<T, phi::float16>::value>::type* = 0) {
-  IndexType idx = threadIdx.x + blockIdx.x * blockDim.x;
+  IndexType idx =
+      static_cast<IndexType>(threadIdx.x) +
+      static_cast<IndexType>(blockIdx.x) * static_cast<IndexType>(blockDim.x);
   for (IndexType i = idx; i < num; i += blockDim.x * gridDim.x) {
     const T& a = in_data[i];
     out_data[i] = isnan(a);
@@ -373,7 +383,9 @@ __global__ void IsnanCUDAKernel(
     bool* out_data,
     typename std::enable_if<std::is_same<T, phi::bfloat16>::value ||
                             std::is_same<T, phi::float16>::value>::type* = 0) {
-  IndexType idx = threadIdx.x + blockIdx.x * blockDim.x;
+  IndexType idx =
+      static_cast<IndexType>(threadIdx.x) +
+      static_cast<IndexType>(blockIdx.x) * static_cast<IndexType>(blockDim.x);
   for (IndexType i = idx; i < num; i += blockDim.x * gridDim.x) {
     const T& a = in_data[i];
     out_data[i] = isnan(a);
@@ -386,7 +398,9 @@ __global__ void IsnanCUDAKernel(
     IndexType num,
     bool* out_data,
     typename std::enable_if<std::is_integral<T>::value>::type* = 0) {
-  IndexType idx = threadIdx.x + blockIdx.x * blockDim.x;
+  IndexType idx =
+      static_cast<IndexType>(threadIdx.x) +
+      static_cast<IndexType>(blockIdx.x) * static_cast<IndexType>(blockDim.x);
   for (IndexType i = idx; i < num; i += blockDim.x * gridDim.x) {
     out_data[i] = false;
   }
@@ -398,7 +412,9 @@ __global__ void IsnanCUDAKernel(
     IndexType num,
     bool* out_data,
     typename std::enable_if<is_complex64_or_complex128<T>::value>::type* = 0) {
-  IndexType idx = threadIdx.x + blockIdx.x * blockDim.x;
+  IndexType idx =
+      static_cast<IndexType>(threadIdx.x) +
+      static_cast<IndexType>(blockIdx.x) * static_cast<IndexType>(blockDim.x);
   for (IndexType i = idx; i < num; i += blockDim.x * gridDim.x) {
     const T& a = in_data[i];
     out_data[i] = isnan(a.real) || isnan(a.imag);
@@ -414,7 +430,9 @@ __global__ void IsinfCUDAKernel(
     typename std::enable_if<std::is_floating_point<T>::value &&
                             !std::is_same<T, phi::bfloat16>::value &&
                             !std::is_same<T, phi::float16>::value>::type* = 0) {
-  IndexType idx = threadIdx.x + blockIdx.x * blockDim.x;
+  IndexType idx =
+      static_cast<IndexType>(threadIdx.x) +
+      static_cast<IndexType>(blockIdx.x) * static_cast<IndexType>(blockDim.x);
   for (IndexType i = idx; i < num; i += blockDim.x * gridDim.x) {
     const T& a = in_data[i];
     out_data[i] = isinf(a);
@@ -428,7 +446,9 @@ __global__ void IsinfCUDAKernel(
     bool* out_data,
     typename std::enable_if<std::is_same<T, phi::bfloat16>::value ||
                             std::is_same<T, phi::float16>::value>::type* = 0) {
-  IndexType idx = threadIdx.x + blockIdx.x * blockDim.x;
+  IndexType idx =
+      static_cast<IndexType>(threadIdx.x) +
+      static_cast<IndexType>(blockIdx.x) * static_cast<IndexType>(blockDim.x);
   for (IndexType i = idx; i < num; i += blockDim.x * gridDim.x) {
     const T& a = in_data[i];
     out_data[i] = isinf(a);
@@ -441,7 +461,9 @@ __global__ void IsinfCUDAKernel(
     IndexType num,
     bool* out_data,
     typename std::enable_if<std::is_integral<T>::value>::type* = 0) {
-  IndexType idx = threadIdx.x + blockIdx.x * blockDim.x;
+  IndexType idx =
+      static_cast<IndexType>(threadIdx.x) +
+      static_cast<IndexType>(blockIdx.x) * static_cast<IndexType>(blockDim.x);
   for (IndexType i = idx; i < num; i += blockDim.x * gridDim.x) {
     out_data[i] = false;
   }
@@ -453,7 +475,9 @@ __global__ void IsinfCUDAKernel(
     IndexType num,
     bool* out_data,
     typename std::enable_if<is_complex64_or_complex128<T>::value>::type* = 0) {
-  IndexType idx = threadIdx.x + blockIdx.x * blockDim.x;
+  IndexType idx =
+      static_cast<IndexType>(threadIdx.x) +
+      static_cast<IndexType>(blockIdx.x) * static_cast<IndexType>(blockDim.x);
   for (IndexType i = idx; i < num; i += blockDim.x * gridDim.x) {
     const T& a = in_data[i];
     out_data[i] = isinf(a.real) || isinf(a.imag);

--- a/paddle/phi/kernels/impl/lrn_kernel_impl.h
+++ b/paddle/phi/kernels/impl/lrn_kernel_impl.h
@@ -29,10 +29,10 @@ struct LRNFunctor {
                   const phi::DenseTensor& input,
                   phi::DenseTensor* out,
                   phi::DenseTensor* mid,
-                  int N,
-                  int C,
-                  int H,
-                  int W,
+                  int64_t N,
+                  int64_t C,
+                  int64_t H,
+                  int64_t W,
                   int n,
                   T k,
                   T alpha,
@@ -64,10 +64,6 @@ void LRNKernel(const Context& dev_ctx,
   int64_t C = (data_layout != DataLayout::NHWC ? x_dims[1] : x_dims[3]);
   int64_t H = (data_layout != DataLayout::NHWC ? x_dims[2] : x_dims[1]);
   int64_t W = (data_layout != DataLayout::NHWC ? x_dims[3] : x_dims[2]);
-
-  // TODO(large-tensor): LRN GPU kernel implementation still uses int for
-  // dimensions. Need to update GPU kernel to support dimensions > INT32_MAX.
-  PADDLE_ENFORCE_LE_INT_MAX(std::max({N, C, H, W}), "std::max({N, C, H, W})");
 
   dev_ctx.template Alloc<T>(out);
 
@@ -161,10 +157,6 @@ void LRNGradKernel(const Context& dev_ctx,
   int64_t C = (data_layout != DataLayout::NHWC ? x_dims[1] : x_dims[3]);
   int64_t H = (data_layout != DataLayout::NHWC ? x_dims[2] : x_dims[1]);
   int64_t W = (data_layout != DataLayout::NHWC ? x_dims[3] : x_dims[2]);
-
-  // TODO(large-tensor): LRN GPU kernel implementation still uses int for
-  // dimensions. Need to update GPU kernel to support dimensions > INT32_MAX.
-  PADDLE_ENFORCE_LE_INT_MAX(std::max({N, C, H, W}), "std::max({N, C, H, W})");
 
   LRNGradFunctor<Context, T> f;
   f(dev_ctx, x, out, mid, x_g, out_g, N, C, H, W, n, alpha, beta, data_layout);

--- a/paddle/phi/kernels/impl/renorm_impl.h
+++ b/paddle/phi/kernels/impl/renorm_impl.h
@@ -212,9 +212,9 @@ __global__ void RenormElementwisePow(const T* x_data,
                                      T* pow_value,
                                      int64_t size,
                                      float p) {
-  int64_t i = ((int64_t) static_cast<int64_t>(blockIdx.x)) *
-                  static_cast<int64_t>(blockDim.x) +
-              static_cast<int64_t>(threadIdx.x);
+  int64_t i =
+      static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
+      static_cast<int64_t>(threadIdx.x);
   if (i < size) {
     pow_value[i] = pow(abs(x_data[i]), (T)p);
   }

--- a/paddle/phi/kernels/impl/unstack_kernel_impl.h
+++ b/paddle/phi/kernels/impl/unstack_kernel_impl.h
@@ -32,39 +32,27 @@ void UnStackKernel(const Context &dev_ctx,
   auto dx = outs;
   if (axis < 0) axis += dy->dims().size();
 
-  // TODO(large-tensor): downstream functors may still use int
   int64_t n = dy->dims()[axis];
 
   std::vector<T *> dx_datas(n);  // NOLINT
-  for (int i = 0; i < n; i++) {
+  for (int64_t i = 0; i < n; i++) {
     dx_datas[i] = dev_ctx.template Alloc<T>(dx[i]);
   }
   auto dy_data = dy->data<T>();
   if (dy->numel() == 0) {
-    for (int i = 0; i < n; i++) {
+    for (int64_t i = 0; i < n; i++) {
       dev_ctx.template Alloc<T>((outs)[i]);
       (outs)[i]->Resize((outs)[i]->dims());
     }
     return;
   }
-  int pre = 1;
+  int64_t pre = 1;
   for (int i = 0; i < axis; ++i) pre *= dy->dims()[i];
   int64_t total_num = dy->numel();
   int64_t post = total_num / (n * pre);
 
-  // TODO(large-tensor): StackGradFunctorForRange uses int for indexing, not
-  // int64_t
-  PADDLE_ENFORCE_LE(
-      total_num,
-      std::numeric_limits<int>::max(),
-      common::errors::InvalidArgument(
-          "The total number of elements in UnStack is %d, which exceeds the "
-          "maximum supported value %d. StackGradFunctorForRange uses int type "
-          "for indexing and does not support tensors with more than %d "
-          "elements.",
-          total_num,
-          std::numeric_limits<int>::max(),
-          std::numeric_limits<int>::max()));
+  // TODO(large-tensor): StackGradFunctorForRange not support int64
+  PADDLE_ENFORCE_LE_INT_MAX(total_num, "total_num");
 
 #if defined(__NVCC__) || defined(__HIPCC__)
   thrust::device_vector<T *> device_dx_vec(dx_datas);

--- a/paddle/phi/kernels/impl/unstack_kernel_impl.h
+++ b/paddle/phi/kernels/impl/unstack_kernel_impl.h
@@ -32,7 +32,7 @@ void UnStackKernel(const Context &dev_ctx,
   auto dx = outs;
   if (axis < 0) axis += dy->dims().size();
 
-  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  // TODO(large-tensor): downstream functors may still use int
   int64_t n = dy->dims()[axis];
 
   std::vector<T *> dx_datas(n);  // NOLINT

--- a/paddle/phi/kernels/impl/unstack_kernel_impl.h
+++ b/paddle/phi/kernels/impl/unstack_kernel_impl.h
@@ -32,7 +32,9 @@ void UnStackKernel(const Context &dev_ctx,
   auto dx = outs;
   if (axis < 0) axis += dy->dims().size();
 
-  int n = dy->dims()[axis];
+  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  int64_t n = dy->dims()[axis];
+
   std::vector<T *> dx_datas(n);  // NOLINT
   for (int i = 0; i < n; i++) {
     dx_datas[i] = dev_ctx.template Alloc<T>(dx[i]);

--- a/paddle/phi/kernels/impl/warpctc_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/warpctc_grad_kernel_impl.h
@@ -39,15 +39,18 @@ void WarpctcGradKernel(const Context& dev_ctx,
   dev_ctx.template Alloc<T>(logits_grad);
 
   if (logits_length.is_initialized()) {
-    // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+    // TODO(large-tensor): downstream functors may still use int; guard until
+    // upgraded.
     int64_t max_seq_length = warpctcgrad.dims()[0];
-      // Tmax
-    // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+    // Tmax
+    // TODO(large-tensor): downstream functors may still use int; guard until
+    // upgraded.
     int64_t num_sequences = warpctcgrad.dims()[1];
-       // B
-    // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+    // B
+    // TODO(large-tensor): downstream functors may still use int; guard until
+    // upgraded.
     int64_t seq_width = warpctcgrad.dims()[2];
-           // D
+    // D
 
     // B
     auto logits_len_e = EigenTensor<int64_t, 1>::From(*logits_length);

--- a/paddle/phi/kernels/impl/warpctc_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/warpctc_grad_kernel_impl.h
@@ -39,9 +39,15 @@ void WarpctcGradKernel(const Context& dev_ctx,
   dev_ctx.template Alloc<T>(logits_grad);
 
   if (logits_length.is_initialized()) {
-    int max_seq_length = warpctcgrad.dims()[0];  // Tmax
-    int num_sequences = warpctcgrad.dims()[1];   // B
-    int seq_width = warpctcgrad.dims()[2];       // D
+    // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+    int64_t max_seq_length = warpctcgrad.dims()[0];
+      // Tmax
+    // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+    int64_t num_sequences = warpctcgrad.dims()[1];
+       // B
+    // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+    int64_t seq_width = warpctcgrad.dims()[2];
+           // D
 
     // B
     auto logits_len_e = EigenTensor<int64_t, 1>::From(*logits_length);

--- a/paddle/phi/kernels/impl/warpctc_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/warpctc_grad_kernel_impl.h
@@ -39,18 +39,9 @@ void WarpctcGradKernel(const Context& dev_ctx,
   dev_ctx.template Alloc<T>(logits_grad);
 
   if (logits_length.is_initialized()) {
-    // TODO(large-tensor): downstream functors may still use int; guard until
-    // upgraded.
-    int64_t max_seq_length = warpctcgrad.dims()[0];
-    // Tmax
-    // TODO(large-tensor): downstream functors may still use int; guard until
-    // upgraded.
-    int64_t num_sequences = warpctcgrad.dims()[1];
-    // B
-    // TODO(large-tensor): downstream functors may still use int; guard until
-    // upgraded.
-    int64_t seq_width = warpctcgrad.dims()[2];
-    // D
+    int64_t max_seq_length = warpctcgrad.dims()[0];  // Tmax
+    int64_t num_sequences = warpctcgrad.dims()[1];   // B
+    int64_t seq_width = warpctcgrad.dims()[2];       // D
 
     // B
     auto logits_len_e = EigenTensor<int64_t, 1>::From(*logits_length);
@@ -61,8 +52,8 @@ void WarpctcGradKernel(const Context& dev_ctx,
 
     auto logits_grad_e = EigenTensor<T, 3>::From(*logits_grad);
 
-    Eigen::DSizes<int, 3> grad_shape(1, num_sequences, 1);
-    Eigen::DSizes<int, 3> bcast(max_seq_length, 1, seq_width);
+    Eigen::DSizes<int64_t, 3> grad_shape(1, num_sequences, 1);
+    Eigen::DSizes<int64_t, 3> bcast(max_seq_length, 1, seq_width);
     auto logits_g =
         warpctcgrad_e * loss_grad_e.reshape(grad_shape).broadcast(bcast).eval();
 

--- a/paddle/phi/kernels/impl/warprnnt_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/warprnnt_grad_kernel_impl.h
@@ -34,10 +34,18 @@ void WarprnntGradKernel(const Context& dev_ctx,
                         DenseTensor* input_grad) {
   dev_ctx.template Alloc<T>(input_grad);
 
-  int B = warprnntgrad.dims()[0];     // B
-  int Tmax = warprnntgrad.dims()[1];  // Tmax
-  int Umax = warprnntgrad.dims()[2];  // Umax
-  int D = warprnntgrad.dims()[3];     // D
+  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  int64_t B = warprnntgrad.dims()[0];
+       // B
+  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  int64_t Tmax = warprnntgrad.dims()[1];
+    // Tmax
+  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  int64_t Umax = warprnntgrad.dims()[2];
+    // Umax
+  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  int64_t D = warprnntgrad.dims()[3];
+       // D
 
   // (B,)
   auto loss_grad_e = EigenTensor<T, 1>::From(loss_grad);

--- a/paddle/phi/kernels/impl/warprnnt_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/warprnnt_grad_kernel_impl.h
@@ -34,18 +34,18 @@ void WarprnntGradKernel(const Context& dev_ctx,
                         DenseTensor* input_grad) {
   dev_ctx.template Alloc<T>(input_grad);
 
-  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  // TODO(large-tensor): downstream functors may still use int
   int64_t B = warprnntgrad.dims()[0];
-       // B
-  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  // B
+  // TODO(large-tensor): downstream functors may still use int
   int64_t Tmax = warprnntgrad.dims()[1];
-    // Tmax
-  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  // Tmax
+  // TODO(large-tensor): downstream functors may still use int
   int64_t Umax = warprnntgrad.dims()[2];
-    // Umax
-  // TODO(large-tensor): downstream functors may still use int; guard until upgraded.
+  // Umax
+  // TODO(large-tensor): downstream functors may still use int
   int64_t D = warprnntgrad.dims()[3];
-       // D
+  // D
 
   // (B,)
   auto loss_grad_e = EigenTensor<T, 1>::From(loss_grad);

--- a/paddle/phi/kernels/impl/warprnnt_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/warprnnt_grad_kernel_impl.h
@@ -34,18 +34,10 @@ void WarprnntGradKernel(const Context& dev_ctx,
                         DenseTensor* input_grad) {
   dev_ctx.template Alloc<T>(input_grad);
 
-  // TODO(large-tensor): downstream functors may still use int
   int64_t B = warprnntgrad.dims()[0];
-  // B
-  // TODO(large-tensor): downstream functors may still use int
   int64_t Tmax = warprnntgrad.dims()[1];
-  // Tmax
-  // TODO(large-tensor): downstream functors may still use int
   int64_t Umax = warprnntgrad.dims()[2];
-  // Umax
-  // TODO(large-tensor): downstream functors may still use int
   int64_t D = warprnntgrad.dims()[3];
-  // D
 
   // (B,)
   auto loss_grad_e = EigenTensor<T, 1>::From(loss_grad);
@@ -54,8 +46,8 @@ void WarprnntGradKernel(const Context& dev_ctx,
   auto warprnntgrad_e = EigenTensor<T, 4>::From(warprnntgrad);
   auto acts_grad_e = EigenTensor<T, 4>::From(*input_grad);
 
-  Eigen::DSizes<int, 4> grad_shape(B, 1, 1, 1);
-  Eigen::DSizes<int, 4> bcast(1, Tmax, Umax, D);
+  Eigen::DSizes<int64_t, 4> grad_shape(B, 1, 1, 1);
+  Eigen::DSizes<int64_t, 4> bcast(1, Tmax, Umax, D);
   auto acts_g =
       warprnntgrad_e * loss_grad_e.reshape(grad_shape).broadcast(bcast).eval();
 

--- a/paddle/phi/kernels/legacy/gpu/cal_aux_loss_kernel.cu
+++ b/paddle/phi/kernels/legacy/gpu/cal_aux_loss_kernel.cu
@@ -47,7 +47,9 @@ __global__ void cal_aux_loss_kernel(
   float seqlen_float_f = 0.f;
   if (dispatch_tokens_mask) {
     float local_seqlen_float_f = 0.f;
-    int64_t num_k = (dispatch_tokens_mask_len + blockDim.x - 1) / blockDim.x;
+    int64_t num_k =
+        (dispatch_tokens_mask_len + static_cast<int64_t>(blockDim.x) - 1) /
+        static_cast<int64_t>(blockDim.x);
     for (int64_t k = 0; k < num_k; ++k) {
       if (k * blockDim.x + threadIdx.x >= dispatch_tokens_mask_len) continue;
       bool mask = dispatch_tokens_mask[k * blockDim.x + threadIdx.x];
@@ -60,7 +62,8 @@ __global__ void cal_aux_loss_kernel(
     if (tokens_mask && row_gate_prob != dispatch_tokens_mask_len) {
       float sum_tokens_mask = 0.f;
       float local_sum_tokens_mask = 0.f;
-      int64_t num_k = (row_gate_prob + blockDim.x - 1) / blockDim.x;
+      int64_t num_k = (row_gate_prob + static_cast<int64_t>(blockDim.x) - 1) /
+                      static_cast<int64_t>(blockDim.x);
       for (int64_t k = 0; k < num_k; ++k) {
         if (k * blockDim.x + threadIdx.x >= row_gate_prob) continue;
         T mask = tokens_mask[k * blockDim.x + threadIdx.x];
@@ -77,7 +80,8 @@ __global__ void cal_aux_loss_kernel(
 
   } else if (tokens_mask) {
     float local_seqlen_float_f = 0.f;
-    int64_t num_k = (row_gate_prob + blockDim.x - 1) / blockDim.x;
+    int64_t num_k = (row_gate_prob + static_cast<int64_t>(blockDim.x) - 1) /
+                    static_cast<int64_t>(blockDim.x);
     for (int64_t k = 0; k < num_k; ++k) {
       if (k * blockDim.x + threadIdx.x >= row_gate_prob) continue;
       T mask = tokens_mask[k * blockDim.x + threadIdx.x];
@@ -100,7 +104,8 @@ __global__ void cal_aux_loss_kernel(
   __syncthreads();
   // 处理dispatch_mask
   if (col_dispatch_mask > 1) {
-    int64_t num_k = (row_dispatch_mask + blockDim.x - 1) / blockDim.x;
+    int64_t num_k = (row_dispatch_mask + static_cast<int64_t>(blockDim.x) - 1) /
+                    static_cast<int64_t>(blockDim.x);
 
     for (int64_t e = 0; e < col_dispatch_mask; e++) {
       int64_t local_sum_val = 0.f;
@@ -128,7 +133,8 @@ __global__ void cal_aux_loss_kernel(
 
   // 算me和l_aux
   float l_aux = 0.f;
-  int64_t num_k = (row_gate_prob + blockDim.x - 1) / blockDim.x;
+  int64_t num_k = (row_gate_prob + static_cast<int64_t>(blockDim.x) - 1) /
+                  static_cast<int64_t>(blockDim.x);
   for (int64_t e = 0; e < col_gate_prob; e++) {
     float local_sum_val = 0.f;
     for (int64_t k = 0; k < num_k; ++k) {

--- a/paddle/phi/kernels/legacy/gpu/fp8_quant_blockwise_kernel.cu
+++ b/paddle/phi/kernels/legacy/gpu/fp8_quant_blockwise_kernel.cu
@@ -371,8 +371,8 @@ __global__ void __launch_bounds__(512)
   // 1. Load 128x128 block of input.
   bf16x4_t x[8];
   for (uint32_t i = 0; i < 8; i++) {
-    size_t col_idx = block_offset_y + threadIdx.y + i * 16;
-    size_t row_idx = block_offset_x + threadIdx.x * 4;
+    size_t col_idx = block_offset_y + static_cast<size_t>(threadIdx.y) + i * 16;
+    size_t row_idx = block_offset_x + static_cast<size_t>(threadIdx.x) * 4;
     size_t idx = col_idx * rows + row_idx;
     x[i] = *reinterpret_cast<const bf16x4_t *>(input + idx);
   }
@@ -385,7 +385,8 @@ __global__ void __launch_bounds__(512)
     // 3. Write 1x128 scale.
     if (threadIdx.y < 4) {
       float scale_out = 1.0f / block_scale[threadIdx.y * 32 + threadIdx.x];
-      size_t col_idx = block_offset_y + threadIdx.y * 32 + threadIdx.x;
+      size_t col_idx = block_offset_y + static_cast<size_t>(threadIdx.y) * 32 +
+                       static_cast<size_t>(threadIdx.x);
       size_t row_idx = blockIdx.x;
       if constexpr (output_scale_transpose) {
         scale[row_idx * quanted_rows + col_idx] = scale_out;
@@ -396,8 +397,9 @@ __global__ void __launch_bounds__(512)
 
     // 4. Do quantization on X and write 128x128 output.
     for (uint32_t i = 0; i < 8; i++) {
-      size_t col_idx = block_offset_y + threadIdx.y + i * 16;
-      size_t row_idx = block_offset_x + threadIdx.x * 4;
+      size_t col_idx =
+          block_offset_y + static_cast<size_t>(threadIdx.y) + i * 16;
+      size_t row_idx = block_offset_x + static_cast<size_t>(threadIdx.x) * 4;
       size_t idx = col_idx * rows + row_idx;
       float scale_val = block_scale[i * 16 + threadIdx.y];
       fp8x4_t data;
@@ -418,7 +420,8 @@ __global__ void __launch_bounds__(512)
     if (threadIdx.y < 4) {
       float scale_out = 1.0f / block_scale[threadIdx.y * 32 + threadIdx.x];
       size_t col_idx = blockIdx.y;
-      size_t row_idx = block_offset_x + threadIdx.y * 32 + threadIdx.x;
+      size_t row_idx = block_offset_x + static_cast<size_t>(threadIdx.y) * 32 +
+                       static_cast<size_t>(threadIdx.x);
       if constexpr (output_scale_transpose) {
         scale_transposed[col_idx * quanted_cols + row_idx] = scale_out;
       } else {
@@ -439,8 +442,9 @@ __global__ void __launch_bounds__(512)
 
     // 8. Write 128x128 transposed output.
     for (uint32_t i = 0; i < 8; i++) {
-      size_t row_idx = block_offset_x + threadIdx.y + i * 16;
-      size_t col_idx = block_offset_y + threadIdx.x * 4;
+      size_t row_idx =
+          block_offset_x + static_cast<size_t>(threadIdx.y) + i * 16;
+      size_t col_idx = block_offset_y + static_cast<size_t>(threadIdx.x) * 4;
       size_t idx = row_idx * cols + col_idx;
       fp8x4_t data;
       for (uint32_t j = 0; j < 4; j++) {

--- a/paddle/phi/kernels/legacy/gpu/moe_combine_grad_kernel.cu
+++ b/paddle/phi/kernels/legacy/gpu/moe_combine_grad_kernel.cu
@@ -29,7 +29,10 @@ __global__ void combine_moe_bwd_kernel(const T* x,
                                        const int64_t seqlen,
                                        const int64_t hidden_size,
                                        const int64_t n) {
-  for (int64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n;
+  for (int64_t i =
+           static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
+           static_cast<int64_t>(threadIdx.x);
+       i < n;
        i += blockDim.x * gridDim.x) {
     int64_t row_i = i / hidden_size;
     int64_t slice_i = i - row_i * hidden_size;

--- a/paddle/phi/kernels/legacy/gpu/moe_combine_kernel.cu
+++ b/paddle/phi/kernels/legacy/gpu/moe_combine_kernel.cu
@@ -27,7 +27,10 @@ __global__ void combine_moe_kernel(const T* x,
                                    const int64_t seqlen,
                                    const int64_t hidden_size,
                                    const int64_t n) {
-  for (int64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n;
+  for (int64_t i =
+           static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
+           static_cast<int64_t>(threadIdx.x);
+       i < n;
        i += blockDim.x * gridDim.x) {
     int64_t row_i = i / hidden_size;
     int64_t slice_i = i - row_i * hidden_size;

--- a/paddle/phi/kernels/legacy/gpu/moe_fuse_bwd_op.h
+++ b/paddle/phi/kernels/legacy/gpu/moe_fuse_bwd_op.h
@@ -38,9 +38,13 @@ __global__ void gather_with_mask_permute_kernel(
   int* scatter_index_shared = reinterpret_cast<int*>(shared);
   float* combine_weights_shared =
       reinterpret_cast<float*>(shared + s_shared_num * k * sizeof(int));
-  int64_t shared_idx_begin = blockIdx.x * blockDim.x * vec_size;
+  int64_t shared_idx_begin = static_cast<int64_t>(blockIdx.x) *
+                             static_cast<int64_t>(blockDim.x) * vec_size;
 
-  for (int64_t idx = (blockIdx.x * blockDim.x + threadIdx.x) * vec_size;
+  for (int64_t idx = (static_cast<int64_t>(blockIdx.x) *
+                          static_cast<int64_t>(blockDim.x) +
+                      static_cast<int64_t>(threadIdx.x)) *
+                     vec_size;
        idx < N;
        idx += blockDim.x * gridDim.x * vec_size) {
     int64_t si = idx / dim;
@@ -106,9 +110,13 @@ __global__ void gather_with_mask_kernel(
   int* scatter_index_shared = reinterpret_cast<int*>(shared);
   float* combine_weights_shared =
       reinterpret_cast<float*>(shared + s_shared_num * k * sizeof(int));
-  int64_t shared_idx_begin = blockIdx.x * blockDim.x * vec_size;
+  int64_t shared_idx_begin = static_cast<int64_t>(blockIdx.x) *
+                             static_cast<int64_t>(blockDim.x) * vec_size;
 
-  for (int64_t idx = (blockIdx.x * blockDim.x + threadIdx.x) * vec_size;
+  for (int64_t idx = (static_cast<int64_t>(blockIdx.x) *
+                          static_cast<int64_t>(blockDim.x) +
+                      static_cast<int64_t>(threadIdx.x)) *
+                     vec_size;
        idx < N;
        idx += blockDim.x * gridDim.x * vec_size) {
     int64_t si = idx / dim;

--- a/paddle/phi/kernels/legacy/gpu/moe_gate_dispatch_and_quant_kernel.cu
+++ b/paddle/phi/kernels/legacy/gpu/moe_gate_dispatch_and_quant_kernel.cu
@@ -210,13 +210,15 @@ __global__ void initialize_moe_routing_kernel(
 
   __shared__ float scale[ThreadNum * VecSize / TileSize];
 
-  for (int64_t element_id = threadIdx.x * VecSize; element_id < cols;
+  for (int64_t element_id = static_cast<int64_t>(threadIdx.x) * VecSize;
+       element_id < cols;
        element_id += blockDim.x * VecSize) {
     // Each thread reads VecSize elements, totaling ThreadNum*VecSize elements
     // read Note: A single thread can compute at most one scale value
     phi::Load<__nv_bfloat16, VecSize>(&source_row_ptr[element_id], &src_vec);
 
-    int64_t local_scale_id = VecSize * threadIdx.x / TileSize;
+    int64_t local_scale_id =
+        VecSize * static_cast<int64_t>(threadIdx.x) / TileSize;
 
     ComputeScaleAndWrite<VecSize, Power2Scaling>(src_vec.val,
                                                  scale,

--- a/paddle/phi/kernels/selected_rows/gpu/adamw_kernel.cu
+++ b/paddle/phi/kernels/selected_rows/gpu/adamw_kernel.cu
@@ -260,13 +260,12 @@ void AdamwDenseParamSparseGradKernel(
   if (beta1_pow.place() == CPUPlace() && beta2_pow.place() == CPUPlace()) {
     int threads = 512;
     int64_t ndim = param.numel();
-    // TODO(large-tensor): downstream functors may still use int; guard until
-    // upgraded.
+    int64_t blocks = (ndim + threads - 1) / threads;
 
-    int blocks = (ndim + threads - 1) / threads;
-
+    // NOTE(large-tensor): Kernel launch requires int type for grid dimension
+    PADDLE_ENFORCE_LE_INT_MAX(blocks, "blocks");
     SparseAdamWCUDAKernelREG<T, MPDType>
-        <<<blocks, threads, 0, dev_ctx.stream()>>>(
+        <<<static_cast<int>(blocks), threads, 0, dev_ctx.stream()>>>(
             beta1_,
             beta2_,
             epsilon_,

--- a/paddle/phi/kernels/selected_rows/gpu/lookup_table_grad_kernel.cu
+++ b/paddle/phi/kernels/selected_rows/gpu/lookup_table_grad_kernel.cu
@@ -84,17 +84,8 @@ void LookupTableGradCUDAKernel(
   auto d_table_t = w_grad;
 
   int64_t N = d_table_t->dims()[0];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
-
   int64_t D = d_table_t->dims()[1];
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
-
   int64_t K = ids_t->numel();
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
-
   const int64_t *ids = ids_t->data<int64_t>();
   const T *d_output = d_output_t->data<T>();
   T *d_table = dev_ctx.template Alloc<T>(d_table_t);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
#### 规则变动
本PR主要优化了 no-int64-type-cuda-index-without-cast 规则。确保在int64类型的基础上，额外检测size_t、IndexType等。检测出来新错误 94 个（包含因为近期规则变动其他规则检测出来的存量问题），涉及51个文件，已全部修复。

目前发现一种threadIdx.x在索引值的误检情况（已通过黑名单的方式过滤掉）：
```
int64_t xxx=yyy[threadIdx.x]+1;
```

同时将 no-int64-type-cuda-index-without-cast 应用到全部文件上，额外出现 31个错误，已全部修复。

https://github.com/PaddlePaddle/Paddle/pull/76398/files 引入的7个新的问题（原规则无法检测到）也连带修复。

#### 手工修改
修复了大量前期工作的 TODO，梳理调用链路上的变量类型、函数签名等，逐步添加大 Tensor 支持，修改原则：
- int64 变量的简单运算不进行 cast，直接把赋值的变量类型更新到int64
- block 等地方使用 int64，先进行 PADDLE_ENFORCE_LE_INT_MAX 判断，再cast
- 结构体/函数签名，影响范围在局部的，更新到int64。影响范围过大的暂时添加TODO和PADDLE_ENFORCE_LE_INT_MAX
- col2im, vol2col 实现直接改为int64使用的寄存器资源过多，所以调低了thread上限

#### TODO
- static_cast<int>(x.dims()[0]) 需要检测
- 

pcard-93269