### PR TITLE
[Stride] Fix Index_Put 0Size Value && Rollback Expand view kernel

### DIFF
--- a/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
@@ -311,7 +311,6 @@ strided_compute_op_list = {
     "index_put",
     # others
     "matmul",
-    "expand",
 }
 
 strided_op_need_flags_check_list = {

--- a/paddle/phi/kernels/gpu/index_put_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_put_kernel.cu
@@ -130,6 +130,14 @@ void IndexPutKernel(const Context& dev_ctx,
       indices.empty(),
       false,
       common::errors::InvalidArgument("Indices cannot be empty."));
+
+  if (value.numel() == 0) {
+    if (!out->initialized()) {
+      phi::Copy(dev_ctx, x, dev_ctx.GetPlace(), false, out);
+    }
+    return;
+  }
+
   std::vector<DenseTensor> tmp_args;
   std::vector<const phi::DenseTensor*> int_indices_v =
       funcs::DealWithBoolIndices<T, Context>(dev_ctx, indices, &tmp_args);

--- a/paddle/phi/kernels/gpu/index_put_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_put_kernel.cu
@@ -131,13 +131,6 @@ void IndexPutKernel(const Context& dev_ctx,
       false,
       common::errors::InvalidArgument("Indices cannot be empty."));
 
-  if (value.numel() == 0) {
-    if (!out->initialized()) {
-      phi::Copy(dev_ctx, x, dev_ctx.GetPlace(), false, out);
-    }
-    return;
-  }
-
   std::vector<DenseTensor> tmp_args;
   std::vector<const phi::DenseTensor*> int_indices_v =
       funcs::DealWithBoolIndices<T, Context>(dev_ctx, indices, &tmp_args);

--- a/paddle/phi/kernels/gpu/index_put_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_put_kernel.cu
@@ -130,7 +130,6 @@ void IndexPutKernel(const Context& dev_ctx,
       indices.empty(),
       false,
       common::errors::InvalidArgument("Indices cannot be empty."));
-
   std::vector<DenseTensor> tmp_args;
   std::vector<const phi::DenseTensor*> int_indices_v =
       funcs::DealWithBoolIndices<T, Context>(dev_ctx, indices, &tmp_args);

--- a/paddle/phi/kernels/stride/expand_stride_kernel.cu
+++ b/paddle/phi/kernels/stride/expand_stride_kernel.cu
@@ -163,7 +163,7 @@ void ExpandStrideKernel(const Context& dev_ctx,
 
 }  // namespace phi
 
-PD_REGISTER_KERNEL(expand,
+PD_REGISTER_KERNEL(expand_stride,
                    GPU,
                    STRIDED,
                    phi::ExpandStrideKernel,

--- a/paddle/phi/kernels/stride/indexing_kernel.cu
+++ b/paddle/phi/kernels/stride/indexing_kernel.cu
@@ -99,6 +99,13 @@ void LaunchIndexPutKernel_V2(const Context& dev_ctx,
       false,
       common::errors::InvalidArgument("Indices cannot be empty."));
 
+  if (value.numel() == 0) {
+    if (!out->initialized()) {
+      phi::Copy(dev_ctx, x, dev_ctx.GetPlace(), false, out);
+    }
+    return;
+  }
+
   bool is_initialized = out->initialized();
   auto meta = x.meta();
   meta.dims = out->dims();

--- a/paddle/phi/kernels/stride/indexing_kernel.cu
+++ b/paddle/phi/kernels/stride/indexing_kernel.cu
@@ -99,13 +99,6 @@ void LaunchIndexPutKernel_V2(const Context& dev_ctx,
       false,
       common::errors::InvalidArgument("Indices cannot be empty."));
 
-  if (value.numel() == 0) {
-    if (!out->initialized()) {
-      phi::Copy(dev_ctx, x, dev_ctx.GetPlace(), false, out);
-    }
-    return;
-  }
-
   bool is_initialized = out->initialized();
   auto meta = x.meta();
   meta.dims = out->dims();
@@ -126,6 +119,13 @@ void LaunchIndexPutKernel_V2(const Context& dev_ctx,
 
   funcs::AdvancedIndex ad =
       funcs::AdvancedIndex<T, Context>(dev_ctx, *out, indices);
+  if (ad.empty_index) {
+    if (!out->initialized()) {
+      phi::Copy(dev_ctx, x, dev_ctx.GetPlace(), false, out);
+    }
+    return;
+  }
+
   if (!CheckIsDimsMatchBool(ad.src.dims(), value.dims())) {
     DenseTensor x_;
     DenseTensor value_;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-67164

1. 修复index为bool同时不含True情况下的index_put kernel分发路径错误
2. 回退expand view kernel到非view kernel，修复分布式不兼容产生的错误