### PR TITLE
[API Compatiblity] Support `paddle.linalg.solve`, `paddle.nn.functional.normalize`, `paddle.quantile`

### DIFF
--- a/python/paddle/_paddle_docs.py
+++ b/python/paddle/_paddle_docs.py
@@ -2201,7 +2201,7 @@ add_doc_and_signature(
 """,
     """
 def logical_and(
-    x: Tensor, y: Tensor, out: Tensor | None = None, name: str | None = None
+    x: Tensor, y: Tensor, name: str | None = None, *, out: Tensor | None = None
 ) -> Tensor
 """,
 )
@@ -2252,7 +2252,7 @@ add_doc_and_signature(
 """,
     """
 def logical_or(
-    x: Tensor, y: Tensor, out: Tensor | None = None, name: str | None = None
+    x: Tensor, y: Tensor, name: str | None = None, *, out: Tensor | None = None
 ) -> Tensor
 """,
 )
@@ -2298,7 +2298,7 @@ add_doc_and_signature(
 """,
     """
 def logical_not(
-    x: Tensor, out: Tensor | None = None, name: str | None = None
+    x: Tensor, name: str | None = None, *, out: Tensor | None = None
 ) -> Tensor
 """,
 )
@@ -2349,7 +2349,7 @@ add_doc_and_signature(
 """,
     """
 def logical_xor(
-    x: Tensor, y: Tensor, out: Tensor | None = None, name: str | None = None
+    x: Tensor, y: Tensor, name: str | None = None, *, out: Tensor | None = None
 ) -> Tensor
 """,
 )
@@ -2446,7 +2446,7 @@ add_doc_and_signature(
 """,
     """
 def tanh(
-    x: Tensor, *, out: Tensor | None = None, name: str | None = None,
+    x: Tensor, name: str | None = None, *, out: Tensor | None = None
 ) -> Tensor
 """,
 )
@@ -2486,7 +2486,7 @@ add_doc_and_signature(
 """,
     """
 def exp(
-    x: Tensor, *, out: Tensor | None = None, name: str | None = None
+    x: Tensor, name: str | None = None, *, out: Tensor | None = None
 ) -> Tensor
 """,
 )
@@ -2526,7 +2526,7 @@ add_doc_and_signature(
 """,
     """
 def expm1(
-    x: Tensor, *, out: Tensor | None = None, name: str | None = None
+    x: Tensor, name: str | None = None, *, out: Tensor | None = None
 ) -> Tensor
 """,
 )
@@ -2658,7 +2658,7 @@ add_doc_and_signature(
 """,
     """
 def round(
-    x: Tensor, decimals = 0, *, out: Tensor | None = None, name: str | None = None,
+    x: Tensor, decimals: int = 0, name: str | None = None, *, out: Tensor | None = None,
 ) -> Tensor
 """,
 )

--- a/python/paddle/nn/functional/norm.py
+++ b/python/paddle/nn/functional/norm.py
@@ -143,13 +143,13 @@ def normalize(
             'epsilon': epsilon,
         }
         helper = LayerHelper('p_norm', **locals())
-        ret = helper.create_variable_for_type_inference(dtype=x.dtype)
+        out = helper.create_variable_for_type_inference(dtype=x.dtype)
         helper.append_op(
-            type='p_norm', inputs={'X': x}, outputs={'Out': ret}, attrs=attrs
+            type='p_norm', inputs={'X': x}, outputs={'Out': out}, attrs=attrs
         )
-        eps = ret.block.create_var(dtype=ret.dtype)
-        eps = paddle.full(shape=[1], fill_value=epsilon, dtype=ret.dtype)
-        ret = paddle.divide(x, paddle.maximum(ret, eps), name=name)
+        eps = out.block.create_var(dtype=out.dtype)
+        eps = paddle.full(shape=[1], fill_value=epsilon, dtype=out.dtype)
+        out = paddle.divide(x, paddle.maximum(out, eps), name=name)
 
     if out is not None:
         paddle.assign(ret, out)

--- a/python/paddle/nn/functional/norm.py
+++ b/python/paddle/nn/functional/norm.py
@@ -122,13 +122,13 @@ def normalize(
 
     if in_dygraph_mode():
         eps = paddle.full(shape=[1], fill_value=epsilon, dtype=x.dtype)
-        out = _C_ops.p_norm(x, float(p), axis, epsilon, True, False)
-        output = x / _C_ops.maximum(out, eps)
+        output = _C_ops.p_norm(x, float(p), axis, epsilon, True, False)
+        output = x / _C_ops.maximum(output, eps)
 
     elif in_pir_mode():
         eps = paddle.full(shape=[1], fill_value=epsilon, dtype=x.dtype)
-        out = _C_ops.p_norm(x, float(p), axis, epsilon, True, False)
-        output = paddle.divide(x, _C_ops.maximum(out, eps), name=name)
+        output = _C_ops.p_norm(x, float(p), axis, epsilon, True, False)
+        output = paddle.divide(x, _C_ops.maximum(output, eps), name=name)
 
     else:
         check_type(p, 'p', (float, int), 'normalize')
@@ -148,16 +148,17 @@ def normalize(
             'epsilon': epsilon,
         }
         helper = LayerHelper('p_norm', **locals())
-        out = helper.create_variable_for_type_inference(dtype=x.dtype)
+        output = helper.create_variable_for_type_inference(dtype=x.dtype)
         helper.append_op(
-            type='p_norm', inputs={'X': x}, outputs={'Out': out}, attrs=attrs
+            type='p_norm', inputs={'X': x}, outputs={'Out': output}, attrs=attrs
         )
-        eps = out.block.create_var(dtype=out.dtype)
-        eps = paddle.full(shape=[1], fill_value=epsilon, dtype=out.dtype)
-        output = paddle.divide(x, paddle.maximum(out, eps), name=name)
+        eps = output.block.create_var(dtype=output.dtype)
+        eps = paddle.full(shape=[1], fill_value=epsilon, dtype=output.dtype)
+        output = paddle.divide(x, paddle.maximum(output, eps), name=name)
 
     if out is not None:
-        paddle.assign(output, output=out)
+        paddle.assign(output, out)
+        return out
     return output
 
 

--- a/python/paddle/nn/functional/norm.py
+++ b/python/paddle/nn/functional/norm.py
@@ -28,6 +28,7 @@ from paddle.base.framework import (
     in_pir_mode,
 )
 from paddle.utils.decorator_utils import (
+    ParamAliasDecorator,
     param_two_alias,
 )
 
@@ -49,12 +50,15 @@ if TYPE_CHECKING:
 __all__ = []
 
 
+@ParamAliasDecorator({"x": ["input"], "axis": ["dim"], "epsilon": ["eps"]})
 def normalize(
     x: Tensor,
     p: float = 2,
     axis: int = 1,
     epsilon: float = 1e-12,
     name: str | None = None,
+    *,
+    out: Tensor | None = None,
 ) -> Tensor:
     r"""
     Normalize ``x`` along dimension ``axis`` using :math:`L_p` norm. This layer computes
@@ -68,13 +72,21 @@ def normalize(
 
     where, :math:`\sum_i{\lvert x_i \rvert^p}` is calculated along the ``axis`` dimension.
 
+    .. note::
+        Alias Support: The parameter name ``input`` can be used as an alias for ``x``.
+        Alias Support: The parameter name ``dim`` can be used as an alias for ``axis``.
+        Alias Support: The parameter name ``eps`` can be used as an alias for ``epsilon``.
 
     Parameters:
         x (Tensor): The input tensor could be N-D tensor, and the input data type could be float32 or float64.
+            Alias: ``input``.
         p (float|int, optional): The exponent value in the norm formulation. Default: 2.
         axis (int, optional): The axis on which to apply normalization. If `axis < 0`, the dimension to normalization is `x.ndim + axis`. -1 is the last dimension.
+            Alias: ``dim``.
         epsilon (float, optional): Small float added to denominator to avoid dividing by zero. Default is 1e-12.
+            Alias: ``esp``.
         name (str|None, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
+        out (Tensor|None, optional): The output tensor. Default: None.
 
     Returns:
         Tensor, the output has the same shape and data type with ``x``.
@@ -111,12 +123,12 @@ def normalize(
     if in_dygraph_mode():
         eps = paddle.full(shape=[1], fill_value=epsilon, dtype=x.dtype)
         out = _C_ops.p_norm(x, float(p), axis, epsilon, True, False)
-        return x / _C_ops.maximum(out, eps)
+        output = x / _C_ops.maximum(out, eps)
 
     elif in_pir_mode():
         eps = paddle.full(shape=[1], fill_value=epsilon, dtype=x.dtype)
         out = _C_ops.p_norm(x, float(p), axis, epsilon, True, False)
-        return paddle.divide(x, _C_ops.maximum(out, eps), name=name)
+        output = paddle.divide(x, _C_ops.maximum(out, eps), name=name)
 
     else:
         check_type(p, 'p', (float, int), 'normalize')
@@ -142,7 +154,11 @@ def normalize(
         )
         eps = out.block.create_var(dtype=out.dtype)
         eps = paddle.full(shape=[1], fill_value=epsilon, dtype=out.dtype)
-        return paddle.divide(x, paddle.maximum(out, eps), name=name)
+        output = paddle.divide(x, paddle.maximum(out, eps), name=name)
+
+    if out is not None:
+        paddle.assign(output, output=out)
+    return output
 
 
 def batch_norm(

--- a/python/paddle/nn/functional/norm.py
+++ b/python/paddle/nn/functional/norm.py
@@ -72,11 +72,6 @@ def normalize(
 
     where, :math:`\sum_i{\lvert x_i \rvert^p}` is calculated along the ``axis`` dimension.
 
-    .. note::
-        Alias Support: The parameter name ``input`` can be used as an alias for ``x``.
-        Alias Support: The parameter name ``dim`` can be used as an alias for ``axis``.
-        Alias Support: The parameter name ``eps`` can be used as an alias for ``epsilon``.
-
     Parameters:
         x (Tensor): The input tensor could be N-D tensor, and the input data type could be float32 or float64.
             Alias: ``input``.
@@ -122,13 +117,13 @@ def normalize(
 
     if in_dygraph_mode():
         eps = paddle.full(shape=[1], fill_value=epsilon, dtype=x.dtype)
-        output = _C_ops.p_norm(x, float(p), axis, epsilon, True, False)
-        output = x / _C_ops.maximum(output, eps)
+        ret = _C_ops.p_norm(x, float(p), axis, epsilon, True, False)
+        ret = x / _C_ops.maximum(ret, eps)
 
     elif in_pir_mode():
         eps = paddle.full(shape=[1], fill_value=epsilon, dtype=x.dtype)
-        output = _C_ops.p_norm(x, float(p), axis, epsilon, True, False)
-        output = paddle.divide(x, _C_ops.maximum(output, eps), name=name)
+        ret = _C_ops.p_norm(x, float(p), axis, epsilon, True, False)
+        ret = paddle.divide(x, _C_ops.maximum(ret, eps), name=name)
 
     else:
         check_type(p, 'p', (float, int), 'normalize')
@@ -148,18 +143,18 @@ def normalize(
             'epsilon': epsilon,
         }
         helper = LayerHelper('p_norm', **locals())
-        output = helper.create_variable_for_type_inference(dtype=x.dtype)
+        ret = helper.create_variable_for_type_inference(dtype=x.dtype)
         helper.append_op(
-            type='p_norm', inputs={'X': x}, outputs={'Out': output}, attrs=attrs
+            type='p_norm', inputs={'X': x}, outputs={'Out': ret}, attrs=attrs
         )
-        eps = output.block.create_var(dtype=output.dtype)
-        eps = paddle.full(shape=[1], fill_value=epsilon, dtype=output.dtype)
-        output = paddle.divide(x, paddle.maximum(output, eps), name=name)
+        eps = ret.block.create_var(dtype=ret.dtype)
+        eps = paddle.full(shape=[1], fill_value=epsilon, dtype=ret.dtype)
+        ret = paddle.divide(x, paddle.maximum(ret, eps), name=name)
 
     if out is not None:
-        paddle.assign(output, out)
+        paddle.assign(ret, out)
         return out
-    return output
+    return ret
 
 
 def batch_norm(

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -4178,8 +4178,14 @@ def _transpose_last_2dim(x):
     return x
 
 
+@ParamAliasDecorator({"x": ["A"], "y": ["B"]})
 def solve(
-    x: Tensor, y: Tensor, left: bool = True, name: str | None = None
+    x: Tensor,
+    y: Tensor,
+    left: bool = True,
+    name: str | None = None,
+    *,
+    out: Tensor | None = None,
 ) -> Tensor:
     r"""
 
@@ -4197,14 +4203,19 @@ def solve(
 
     Specifically, this system of linear equations has one solution if and only if input 'X' is invertible.
 
+    .. note::
+        Alias Support: The parameter name ``A`` can be used as an alias for ``x``.
+        Alias Support: The parameter name ``B`` can be used as an alias for ``y``.
+
     Args:
         x (Tensor): A square matrix or a batch of square matrices. Its shape should be ``[*, M, M]``, where ``*`` is zero or
-            more batch dimensions. Its data type should be float32 or float64.
+            more batch dimensions. Its data type should be float32 or float64. Alias: ``A``.
         y (Tensor): A vector/matrix or a batch of vectors/matrices. Its shape should be ``[*, M, K]``, where ``*`` is zero or
-            more batch dimensions. Its data type should be float32 or float64.
+            more batch dimensions. Its data type should be float32 or float64. Alias: ``B``.
         left (bool, optional): Whether to solve the system :math:`X * Out = Y` or :math:`Out * X = Y`. Default: True.
         name (str|None, optional): Name for the operation (optional, default is None).
             For more information, please refer to :ref:`api_guide_Name`.
+        out (Tensor|None, optional): The output tensor. Default: None.
 
     Returns:
         Tensor: The solution of a square system of linear equations with a unique solution for input 'x' and 'y'.
@@ -4234,21 +4245,23 @@ def solve(
         y = _transpose_last_2dim(y)
 
     if in_dynamic_or_pir_mode():
-        out = _C_ops.solve(x, y)
+        output = _C_ops.solve(x, y)
     else:
         inputs = {"X": [x], "Y": [y]}
         helper = LayerHelper("solve", **locals())
         check_variable_and_dtype(x, 'x', ['float32', 'float64'], 'solve')
         check_variable_and_dtype(y, 'y', ['float32', 'float64'], 'solve')
-        out = helper.create_variable_for_type_inference(dtype=x.dtype)
+        output = helper.create_variable_for_type_inference(dtype=x.dtype)
 
         helper.append_op(
-            type="solve", inputs={"X": x, "Y": y}, outputs={"Out": out}
+            type="solve", inputs={"X": x, "Y": y}, outputs={"Out": output}
         )
 
     if not left:
-        out = _transpose_last_2dim(out)
-    return out
+        output = _transpose_last_2dim(output)
+    if out is not None:
+        paddle.assign(output, output=out)
+    return output
 
 
 def triangular_solve(

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -4248,10 +4248,10 @@ def solve(
         helper = LayerHelper("solve", **locals())
         check_variable_and_dtype(x, 'x', ['float32', 'float64'], 'solve')
         check_variable_and_dtype(y, 'y', ['float32', 'float64'], 'solve')
-        ret = helper.create_variable_for_type_inference(dtype=x.dtype)
+        out = helper.create_variable_for_type_inference(dtype=x.dtype)
 
         helper.append_op(
-            type="solve", inputs={"X": x, "Y": y}, outputs={"Out": ret}
+            type="solve", inputs={"X": x, "Y": y}, outputs={"Out": out}
         )
 
     if not left:

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -28,6 +28,7 @@ from paddle.tensor.math import broadcast_shape
 from paddle.utils.decorator_utils import (
     ParamAliasDecorator,
     VariableArgsDecorator,
+    param_two_alias,
     transpose_decorator,
 )
 from paddle.utils.inplace_utils import inplace_apis_in_dygraph_only
@@ -4178,7 +4179,7 @@ def _transpose_last_2dim(x):
     return x
 
 
-@ParamAliasDecorator({"x": ["A"], "y": ["B"]})
+@param_two_alias(["x", "A"], ["y", "B"])
 def solve(
     x: Tensor,
     y: Tensor,
@@ -4202,10 +4203,6 @@ def solve(
         Out = Y * X^-1
 
     Specifically, this system of linear equations has one solution if and only if input 'X' is invertible.
-
-    .. note::
-        Alias Support: The parameter name ``A`` can be used as an alias for ``x``.
-        Alias Support: The parameter name ``B`` can be used as an alias for ``y``.
 
     Args:
         x (Tensor): A square matrix or a batch of square matrices. Its shape should be ``[*, M, M]``, where ``*`` is zero or
@@ -4245,23 +4242,23 @@ def solve(
         y = _transpose_last_2dim(y)
 
     if in_dynamic_or_pir_mode():
-        output = _C_ops.solve(x, y)
+        ret = _C_ops.solve(x, y)
     else:
         inputs = {"X": [x], "Y": [y]}
         helper = LayerHelper("solve", **locals())
         check_variable_and_dtype(x, 'x', ['float32', 'float64'], 'solve')
         check_variable_and_dtype(y, 'y', ['float32', 'float64'], 'solve')
-        output = helper.create_variable_for_type_inference(dtype=x.dtype)
+        ret = helper.create_variable_for_type_inference(dtype=x.dtype)
 
         helper.append_op(
-            type="solve", inputs={"X": x, "Y": y}, outputs={"Out": output}
+            type="solve", inputs={"X": x, "Y": y}, outputs={"Out": ret}
         )
 
     if not left:
-        output = _transpose_last_2dim(output)
+        ret = _transpose_last_2dim(ret)
     if out is not None:
-        paddle.assign(output, output=out)
-    return output
+        paddle.assign(ret, out)
+    return ret
 
 
 def triangular_solve(

--- a/python/paddle/tensor/stat.py
+++ b/python/paddle/tensor/stat.py
@@ -881,12 +881,12 @@ def _compute_quantile(
 
     # TODO(chenjianye): replace the for-loop to directly take elements.
     for index in indices:
-        out = _compute_index(index)
+        output = _compute_index(index)
         if not keepdim:
-            out = paddle.squeeze(out, axis=axis)
+            output = paddle.squeeze(output, axis=axis)
         else:
-            out = out.reshape(out_shape)
-        outputs.append(out)
+            output = output.reshape(out_shape)
+        outputs.append(output)
 
     if len(outputs) > 1:
         outputs = paddle.stack(outputs, 0)
@@ -894,7 +894,8 @@ def _compute_quantile(
         outputs = outputs[0]
 
     if out is not None:
-        paddle.assign(outputs, output=out)
+        paddle.assign(outputs, out)
+        return out
     return outputs
 
 

--- a/python/paddle/tensor/stat.py
+++ b/python/paddle/tensor/stat.py
@@ -881,12 +881,12 @@ def _compute_quantile(
 
     # TODO(chenjianye): replace the for-loop to directly take elements.
     for index in indices:
-        output = _compute_index(index)
+        ret = _compute_index(index)
         if not keepdim:
-            output = paddle.squeeze(output, axis=axis)
+            ret = paddle.squeeze(ret, axis=axis)
         else:
-            output = output.reshape(out_shape)
-        outputs.append(output)
+            ret = ret.reshape(out_shape)
+        outputs.append(ret)
 
     if len(outputs) > 1:
         outputs = paddle.stack(outputs, 0)
@@ -913,10 +913,6 @@ def quantile(
     """
     Compute the quantile of the input along the specified axis.
     If any values in a reduced row are NaN, then the quantiles for that reduction will be NaN.
-
-    .. note::
-        Alias Support: The parameter name ``input`` can be used as an alias for ``x``.
-        Alias Support: The parameter name ``dim`` can be used as an alias for ``axis``.
 
     Args:
         x (Tensor): The input Tensor, it's data type can be float32, float64, int32, int64.

--- a/python/paddle/tensor/stat.py
+++ b/python/paddle/tensor/stat.py
@@ -717,6 +717,7 @@ def _compute_quantile(
     keepdim: bool = False,
     interpolation: _Interpolation = "linear",
     ignore_nan: bool = False,
+    out: Tensor | None = None,
 ) -> Tensor:
     """
     Compute the quantile of the input along the specified axis.
@@ -742,6 +743,7 @@ def _compute_quantile(
         ignore_nan: (bool, optional): Whether to ignore NaN of input Tensor.
             If ``ignore_nan`` is True, it will calculate nanquantile.
             Otherwise it will calculate quantile. Default is False.
+        out (Tensor|None, optional): The output tensor. Default: None.
 
     Returns:
         Tensor, results of quantile along ``axis`` of ``x``.
@@ -890,20 +892,30 @@ def _compute_quantile(
         outputs = paddle.stack(outputs, 0)
     else:
         outputs = outputs[0]
-    # return outputs.astype(x.dtype)
+
+    if out is not None:
+        paddle.assign(outputs, output=out)
     return outputs
 
 
+@param_two_alias(["x", "input"], ["axis", "dim"])
 def quantile(
     x: Tensor,
     q: float | Sequence[float] | Tensor,
     axis: int | list[int] | None = None,
     keepdim: bool = False,
     interpolation: _Interpolation = "linear",
+    name: str | None = None,
+    *,
+    out: Tensor | None = None,
 ) -> Tensor:
     """
     Compute the quantile of the input along the specified axis.
     If any values in a reduced row are NaN, then the quantiles for that reduction will be NaN.
+
+    .. note::
+        Alias Support: The parameter name ``input`` can be used as an alias for ``x``.
+        Alias Support: The parameter name ``dim`` can be used as an alias for ``axis``.
 
     Args:
         x (Tensor): The input Tensor, it's data type can be float32, float64, int32, int64.
@@ -925,6 +937,8 @@ def quantile(
             lower, midpoint and nearest. Default is linear.
         name (str, optional): Name for the operation (optional, default is None).
             For more information, please refer to :ref:`api_guide_Name`.
+        out (Tensor|None, optional): The output tensor. Default: None.
+
 
     Returns:
         Tensor, results of quantile along ``axis`` of ``x``.
@@ -975,6 +989,7 @@ def quantile(
         keepdim=keepdim,
         interpolation=interpolation,
         ignore_nan=False,
+        out=out,
     )
 
 

--- a/test/legacy_test/test_normalize.py
+++ b/test/legacy_test/test_normalize.py
@@ -135,6 +135,12 @@ class TestNormalizeAPI_Compatibility(unittest.TestCase):
             input=x, p=self.p, dim=self.axis, eps=self.epsilon
         )
         paddle_dygraph_out.append(out3)
+        # Key words args for out
+        out4 = paddle.zeros_like(x)
+        paddle.nn.functional.normalize(
+            x, self.p, self.axis, self.epsilon, out=out4
+        )
+        paddle_dygraph_out.append(out4)
         # Numpy reference output
         ref_out = self.np_x / np.maximum(
             np.linalg.norm(

--- a/test/legacy_test/test_normalize.py
+++ b/test/legacy_test/test_normalize.py
@@ -102,5 +102,92 @@ class TestNNFunctionalNormalize(unittest.TestCase):
             self.run_static(use_gpu=True)
 
 
+class TestNormalizeAPI_Compatibility(unittest.TestCase):
+    def setUp(self):
+        np.random.seed(2025)
+        self.places = ['cpu', get_device_place()]
+        self.shape = [2, 3, 4]
+        self.dtype = "float32"
+        self.init_data()
+
+    def init_data(self):
+        self.np_x = np.random.rand(*self.shape).astype(self.dtype)
+        self.p = 2
+        self.axis = 1
+        self.epsilon = 1e-12
+
+    def test_dygraph_Compatibility(self):
+        paddle.disable_static()
+        x = paddle.to_tensor(self.np_x)
+        paddle_dygraph_out = []
+        # Position args (args)
+        out1 = paddle.nn.functional.normalize(
+            x, self.p, self.axis, self.epsilon
+        )
+        paddle_dygraph_out.append(out1)
+        # Key words args (kwargs) for paddle
+        out2 = paddle.nn.functional.normalize(
+            x=x, p=self.p, axis=self.axis, epsilon=self.epsilon
+        )
+        paddle_dygraph_out.append(out2)
+        # Key words args for torch compatibility
+        out3 = paddle.nn.functional.normalize(
+            input=x, p=self.p, dim=self.axis, eps=self.epsilon
+        )
+        paddle_dygraph_out.append(out3)
+        # Numpy reference output
+        ref_out = self.np_x / np.maximum(
+            np.linalg.norm(
+                self.np_x, ord=self.p, axis=self.axis, keepdims=True
+            ),
+            self.epsilon,
+        )
+
+        for out in paddle_dygraph_out:
+            np.testing.assert_allclose(
+                ref_out, out.numpy(), rtol=1e-05, atol=1e-08
+            )
+        paddle.enable_static()
+
+    def test_static_Compatibility(self):
+        paddle.enable_static()
+        main = paddle.static.Program()
+        startup = paddle.static.Program()
+        with paddle.base.program_guard(main, startup):
+            x = paddle.static.data(name="x", shape=self.shape, dtype=self.dtype)
+            # Position args (args)
+            out1 = paddle.nn.functional.normalize(
+                x, self.p, self.axis, self.epsilon
+            )
+            # Key words args (kwargs) for paddle
+            out2 = paddle.nn.functional.normalize(
+                x=x, p=self.p, axis=self.axis, epsilon=self.epsilon
+            )
+            # Key words args for torch compatibility
+            out3 = paddle.nn.functional.normalize(
+                input=x, p=self.p, dim=self.axis, eps=self.epsilon
+            )
+            # Numpy reference output
+            ref_out = self.np_x / np.maximum(
+                np.linalg.norm(
+                    self.np_x, ord=self.p, axis=self.axis, keepdims=True
+                ),
+                self.epsilon,
+            )
+
+            fetch_list = [out1, out2, out3]
+            for place in self.places:
+                exe = paddle.base.Executor(place)
+                fetches = exe.run(
+                    main,
+                    feed={"x": self.np_x},
+                    fetch_list=fetch_list,
+                )
+                for out in fetches:
+                    np.testing.assert_allclose(
+                        out, ref_out, rtol=1e-05, atol=1e-08
+                    )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/legacy_test/test_quantile_and_nanquantile.py
+++ b/test/legacy_test/test_quantile_and_nanquantile.py
@@ -14,7 +14,7 @@
 import unittest
 
 import numpy as np
-from op_test import get_device, is_custom_device
+from op_test import get_device, get_device_place, is_custom_device
 
 import paddle
 
@@ -513,6 +513,112 @@ class TestQuantileRuntime(unittest.TestCase):
                     np.testing.assert_allclose(paddle_res, np_res, rtol=1e-05)
                     np.testing.assert_allclose(
                         paddle_res_fp64, np_res_fp64, rtol=1e-05
+                    )
+
+
+class TestQuantileAPI_Compatibility(unittest.TestCase):
+    def setUp(self):
+        np.random.seed(2025)
+        self.places = ['cpu', get_device_place()]
+        self.shape = [2, 3, 4]
+        self.dtype = "float32"
+        self.init_data()
+
+    def init_data(self):
+        self.np_x = np.random.rand(*self.shape).astype(self.dtype)
+        self.q = 0.5
+        self.axis = 1
+        self.keepdim = False
+        self.interpolation = "linear"
+
+    def test_dygraph_Compatibility(self):
+        paddle.disable_static()
+        x = paddle.to_tensor(self.np_x)
+        paddle_dygraph_out = []
+        # Position args (args)
+        out1 = paddle.quantile(
+            x, self.q, self.axis, self.keepdim, self.interpolation
+        )
+        paddle_dygraph_out.append(out1)
+        # Key words args (kwargs) for paddle
+        out2 = paddle.quantile(
+            x=x,
+            q=self.q,
+            axis=self.axis,
+            keepdim=self.keepdim,
+            interpolation=self.interpolation,
+        )
+        paddle_dygraph_out.append(out2)
+        # Key words args for torch compatibility
+        out3 = paddle.quantile(
+            input=x,
+            q=self.q,
+            dim=self.axis,
+            keepdim=self.keepdim,
+            interpolation=self.interpolation,
+        )
+        paddle_dygraph_out.append(out3)
+        # Numpy reference output
+        ref_out = np.quantile(
+            self.np_x,
+            self.q,
+            axis=self.axis,
+            keepdims=self.keepdim,
+            method=self.interpolation,
+        )
+
+        for out in paddle_dygraph_out:
+            np.testing.assert_allclose(
+                ref_out, out.numpy(), rtol=1e-05, atol=1e-08
+            )
+        paddle.enable_static()
+
+    def test_static_Compatibility(self):
+        paddle.enable_static()
+        main = paddle.static.Program()
+        startup = paddle.static.Program()
+        with paddle.base.program_guard(main, startup):
+            x = paddle.static.data(name="x", shape=self.shape, dtype=self.dtype)
+            # Position args (args)
+            out1 = paddle.quantile(
+                x, self.q, self.axis, self.keepdim, self.interpolation
+            )
+            # Key words args (kwargs) for paddle
+            out2 = paddle.quantile(
+                x=x,
+                q=self.q,
+                axis=self.axis,
+                keepdim=self.keepdim,
+                interpolation=self.interpolation,
+            )
+            # Key words args for torch compatibility
+            out3 = paddle.quantile(
+                input=x,
+                q=self.q,
+                dim=self.axis,
+                keepdim=self.keepdim,
+                interpolation=self.interpolation,
+            )
+            # Numpy reference output
+            ref_out = np.quantile(
+                self.np_x,
+                self.q,
+                axis=self.axis,
+                keepdims=self.keepdim,
+                method=self.interpolation,
+            )
+
+            fetch_list = [out1, out2, out3]
+            for place in self.places:
+                exe = paddle.base.Executor(place)
+                fetches = exe.run(
+                    main,
+                    feed={"x": self.np_x},
+                    fetch_list=fetch_list,
+                )
+                for out in fetches:
+                    np.testing.assert_allclose(
+                        out, ref_out, rtol=1e-05, atol=1e-08
                     )
 
 

--- a/test/legacy_test/test_quantile_and_nanquantile.py
+++ b/test/legacy_test/test_quantile_and_nanquantile.py
@@ -558,6 +558,12 @@ class TestQuantileAPI_Compatibility(unittest.TestCase):
             interpolation=self.interpolation,
         )
         paddle_dygraph_out.append(out3)
+        # Key words args for out
+        out4 = paddle.zeros_like(x)
+        out1 = paddle.quantile(
+            x, self.q, self.axis, self.keepdim, self.interpolation, out=out4
+        )
+        paddle_dygraph_out.append(out4)
         # Numpy reference output
         ref_out = np.quantile(
             self.np_x,

--- a/test/legacy_test/test_solve_op.py
+++ b/test/legacy_test/test_solve_op.py
@@ -961,6 +961,10 @@ class TestSolveAPI_Compatibility(unittest.TestCase):
         # Key words args for torch compatibility
         out3 = paddle.linalg.solve(A=A, B=B)
         paddle_dygraph_out.append(out3)
+        # Key words args for out
+        out4 = paddle.zeros_like(B)
+        paddle.linalg.solve(A, B, out=out4)
+        paddle_dygraph_out.append(out4)
         # Numpy reference output
         ref_out = np.linalg.solve(self.np_A, self.np_B)
 

--- a/test/legacy_test/test_solve_op.py
+++ b/test/legacy_test/test_solve_op.py
@@ -20,7 +20,7 @@ import numpy as np
 import paddle
 
 sys.path.append("..")
-from op_test import OpTest, get_places
+from op_test import OpTest, get_device_place, get_places
 
 from paddle import base
 
@@ -930,6 +930,78 @@ class TestSolveOpAPIZeroDimCase(unittest.TestCase):
 
             with self.assertRaises(ValueError):
                 run(place, x_shape=[10, 0, 0], y_shape=[10])
+
+
+class TestSolveAPI_Compatibility(unittest.TestCase):
+    def setUp(self):
+        np.random.seed(2025)
+        self.places = ['cpu', get_device_place()]
+        self.n = 4
+        self.shape_A = [self.n, self.n]
+        self.shape_B = [self.n, 1]
+        self.dtype = "float64"
+        self.init_data()
+
+    def init_data(self):
+        A = np.random.rand(*self.shape_A).astype(self.dtype)
+        self.np_A = np.dot(A, A.T) + np.eye(self.n)
+        self.np_B = np.random.rand(*self.shape_B).astype(self.dtype)
+
+    def test_dygraph_Compatibility(self):
+        paddle.disable_static()
+        A = paddle.to_tensor(self.np_A)
+        B = paddle.to_tensor(self.np_B)
+        paddle_dygraph_out = []
+        # Position args (args)
+        out1 = paddle.linalg.solve(A, B)
+        paddle_dygraph_out.append(out1)
+        # Key words args (kwargs) for paddle
+        out2 = paddle.linalg.solve(x=A, y=B)
+        paddle_dygraph_out.append(out2)
+        # Key words args for torch compatibility
+        out3 = paddle.linalg.solve(A=A, B=B)
+        paddle_dygraph_out.append(out3)
+        # Numpy reference output
+        ref_out = np.linalg.solve(self.np_A, self.np_B)
+
+        for out in paddle_dygraph_out:
+            np.testing.assert_allclose(
+                ref_out, out.numpy(), rtol=1e-05, atol=1e-08
+            )
+        paddle.enable_static()
+
+    def test_static_Compatibility(self):
+        paddle.enable_static()
+        main = paddle.static.Program()
+        startup = paddle.static.Program()
+        with paddle.base.program_guard(main, startup):
+            A = paddle.static.data(
+                name="A", shape=self.shape_A, dtype=self.dtype
+            )
+            B = paddle.static.data(
+                name="B", shape=self.shape_B, dtype=self.dtype
+            )
+            # Position args (args)
+            out1 = paddle.linalg.solve(A, B)
+            # Key words args (kwargs) for paddle
+            out2 = paddle.linalg.solve(x=A, y=B)
+            # Key words args for torch compatibility
+            out3 = paddle.linalg.solve(A=A, B=B)
+            # Numpy reference output
+            ref_out = np.linalg.solve(self.np_A, self.np_B)
+
+            fetch_list = [out1, out2, out3]
+            for place in self.places:
+                exe = paddle.base.Executor(place)
+                fetches = exe.run(
+                    main,
+                    feed={"A": self.np_A, "B": self.np_B},
+                    fetch_list=fetch_list,
+                )
+                for out in fetches:
+                    np.testing.assert_allclose(
+                        out, ref_out, rtol=1e-05, atol=1e-08
+                    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

New features

### Description
<!-- Describe what you’ve done -->
新增 `paddle.linalg.solve`, `paddle.nn.functional.normalize`, `paddle.quantile`等api的装饰器
修复了部分API参数顺序
<img width="1421" height="453" alt="943530eef8b5bf86d2c54fac5b829364" src="https://github.com/user-attachments/assets/54ee7e07-1994-4e4d-8dca-f09e8cd7ab62" />
<img width="1413" height="465" alt="6e9b1cd49cbc85a92303ebd1a496f596" src="https://github.com/user-attachments/assets/1d7f286d-3a2f-4b59-b244-1834876ada97" />
<img width="1411" height="555" alt="119f1c5b9dfa49973e57340163519353" src="https://github.com/user-attachments/assets/5181cb38-39db-483e-82b4-4ced1d41f9e0" />
