### PR TITLE
Fix numpy strict in add op test

### DIFF
--- a/test/legacy_test/test_add_op.py
+++ b/test/legacy_test/test_add_op.py
@@ -83,11 +83,19 @@ class TestPaddleAddBackward(unittest.TestCase):
         expected_y_grad = np.full(y_np.shape, 1.0 / N, dtype=np.float16)
 
         rtol, atol = 1e-3, 1e-3
+        actual_x_grad = x.grad.numpy()
         np.testing.assert_allclose(
-            x.grad.numpy(), expected_x_grad, rtol=rtol, atol=atol, strict=True
+            actual_x_grad, expected_x_grad, rtol=rtol, atol=atol
         )
+        assert actual_x_grad.dtype == expected_x_grad.dtype, (
+            f"x.grad dtype mismatch: expected {expected_x_grad.dtype}, got {actual_x_grad.dtype}"
+        )
+        actual_y_grad = y.grad.numpy()
         np.testing.assert_allclose(
-            y.grad.numpy(), expected_y_grad, rtol=rtol, atol=atol, strict=True
+            actual_y_grad, expected_y_grad, rtol=rtol, atol=atol
+        )
+        assert actual_y_grad.dtype == expected_y_grad.dtype, (
+            f"y.grad dtype mismatch: expected {expected_y_grad.dtype}, got {actual_y_grad.dtype}"
         )
 
     def test_backward_with_grad(self):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修复了 https://github.com/PaddlePaddle/Paddle/pull/76178 中对 numpy strict 参数的使用

pcard-93269
