### PR TITLE
[CINN] Sync EqualAllOpInferSymbolicShape with InferMeta

### DIFF
--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/binary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/binary_infer_sym.cc
@@ -790,17 +790,6 @@ bool EmbeddingOpInferSymbolicShape(
 
 bool EqualAllOpInferSymbolicShape(
     pir::Operation *op, pir::InferSymbolicShapeContext *infer_context) {
-  const auto &x_dims =
-      infer_context->GetShapeOrDataForValue(op->operand_source(0)).shape();
-  const auto &y_dims =
-      infer_context->GetShapeOrDataForValue(op->operand_source(1)).shape();
-
-  PADDLE_ENFORCE_GE(
-      x_dims.size(),
-      y_dims.size(),
-      common::errors::InvalidArgument(
-          "The size of dim_y should not be greater than dim_x's."));
-
   std::vector<symbol::DimExpr> out_dims =
       {};  // Adjust the dimensions as necessary
   infer_context->SetShapeOrDataForValue(

--- a/paddle/phi/infermeta/binary.cc
+++ b/paddle/phi/infermeta/binary.cc
@@ -521,8 +521,6 @@ void CompareInferMeta(const MetaTensor& x,
 void CompareAllInferMeta(const MetaTensor& x,
                          const MetaTensor& y,
                          MetaTensor* out) {
-  auto dim_x = x.dims();
-  auto dim_y = y.dims();
   out->share_lod(x);
   out->set_dims(common::make_ddim({}));
 }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
不小心看见了，修改一下
Changed in https://github.com/PaddlePaddle/Paddle/pull/76275/files#diff-b9b33ee5bf339762bbd32083387245de3a2c48cf8b9293da254ca0b752efb9cb
Sync EqualAllOpInferSymbolicShape with InferMeta