### PR TITLE
[Compat] Add missing inner place assign when parsing Device from string

### DIFF
--- a/paddle/phi/api/include/compat/c10/core/Device.cpp
+++ b/paddle/phi/api/include/compat/c10/core/Device.cpp
@@ -55,6 +55,7 @@ Device::Device(const std::string& device_string) : Device(Type::CPU) {
     std::string index_str = device_string.substr(colon_pos + 1);
     try {
       index = static_cast<DeviceIndex>(std::stoi(index_str));
+      inner_ = phi::Place(type, index);
     } catch (const std::invalid_argument&) {
       PADDLE_THROW(::common::errors::InvalidArgument(
           "Invalid device index: '%s' is not a number.", index_str));


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience

### PR Types
Others

### Description
<!-- Describe what you’ve done -->
fix Device.cpp
<img width="1571" height="202" alt="image" src="https://github.com/user-attachments/assets/48cd1993-a3c5-4b91-98d6-0049855d597f" />
修改未使用变量