### PR TITLE
4th-batch-82-信息提取不完整可能导致数据丢失

### DIFF
--- a/python/paddle/base/dygraph/math_op_patch.py
+++ b/python/paddle/base/dygraph/math_op_patch.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -179,6 +180,9 @@ def monkey_patch_math_tensor():
             return astype(tensor, 'uint8')
         elif self.is_complex():
             real = astype(self.real(), 'int8')
+            logging.warning(
+                "Casting complex values to real discards the imaginary part"
+            )
             return astype(real, 'uint8')
         else:
             return astype(self, 'uint8')


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
第四批-编号82（共1处)
当输入张量为复数类型（如 complex64 或 complex128）时，byte 方法仅提取其实部（self.real()），将其先转为 int8 再转为 uint8，而完全忽略了虚部。这导致输出张量仅保留了原张量的一半信息，造成数据丢失，且不符合用户对 byte() 应作用于“整个张量”的直观语义预期。

由于直接改起来影响过大，所以目前考虑和 torch和numpy 处理方式一样，添加一个警告。
