### PR TITLE
Replace np.asin with np.arcsin to support numpy1.x

### DIFF
--- a/test/legacy_test/test_activation_op.py
+++ b/test/legacy_test/test_activation_op.py
@@ -6366,7 +6366,7 @@ create_test_act_bf16_class(
 class TestActivationAPI_Compatibility(unittest.TestCase):
     ACTIVATION_CONFIGS = [
         ("paddle.abs", np.abs, {'min_val': -1.0, 'max_val': 1.0}),
-        ("paddle.asin", np.asin, {'min_val': -1.0, 'max_val': 1.0}),
+        ("paddle.asin", np.arcsin, {'min_val': -1.0, 'max_val': 1.0}),
         ("paddle.log2", np.log2, {'min_val': 0.0, 'max_val': 8.0}),
         ("paddle.exp", np.exp, {'min_val': -1.0, 'max_val': 1.0}),
         ("paddle.expm1", np.expm1, {'min_val': -1.0, 'max_val': 1.0}),


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Custom Device

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Replace np.asin with np.arcsin to support numpy1.x