### PR TITLE
[Custom Device] Skip FP64 grad check when FLAG_SKIP_FLOAT64 is on

### DIFF
--- a/test/legacy_test/op_test.py
+++ b/test/legacy_test/op_test.py
@@ -651,6 +651,8 @@ class OpTest(unittest.TestCase):
                 and not is_custom_device_op_test()
                 and not cls.check_prim
                 and not cls.check_prim_pir
+                and os.environ.get('FLAG_SKIP_FLOAT64', '').lower()
+                not in ['1', 'true', 'on']
             ):
                 raise AssertionError(
                     f"This test of {cls.op_type} op needs check_grad with fp64 precision."


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Custom Device

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
Skip FP64 grad check when FLAG_SKIP_FLOAT64 is on.