### PR TITLE
[CI] add H-Coverage workflow to `/rerun` support

### DIFF
--- a/.github/workflows/H-Coverage.yml
+++ b/.github/workflows/H-Coverage.yml
@@ -30,14 +30,14 @@ defaults:
 
 jobs:
   clone:
-    name: Coverage clone
+    name: H-Coverage clone
     uses: ./.github/workflows/_Clone-linux.yml
     with:
       workflow-name: 'coverage'
       clone_dir: Paddle-coverage
 
   build:
-    name: Coverage build
+    name: H-Coverage build
     needs: [clone]
     if: needs.clone.outputs.can-skip != 'true'
     runs-on:
@@ -211,7 +211,7 @@ jobs:
           docker rm ${{ env.container_name }}
 
   test:
-    name: Coverage test
+    name: H-Coverage test
     needs: [build]
     if: needs.build.outputs.can-skip != 'true'
     runs-on:

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -296,3 +296,23 @@ jobs:
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
           JOB_NAME: 'Slice / Check bypass / Check bypass'
+
+      - name: Rerun H-Coverage Build
+        if: ${{ contains(github.event.comment.body, 'h-ci') && contains(github.event.comment.body, 'build') }}
+        uses: ./.github/actions/rerun-workflow
+        with:
+          PR_ID: ${{ github.event.issue.number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          JOB_NAME: 'H-Coverage build'
+
+      - name: Rerun H-Coverage Test
+        if: ${{ contains(github.event.comment.body, 'h-ci') && contains(github.event.comment.body, 'test') }}
+        uses: ./.github/actions/rerun-workflow
+        with:
+          PR_ID: ${{ github.event.issue.number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          JOB_NAME: 'H-Coverage test'


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
add H-Coverage workflow to `/rerun` support