### PR TITLE
【CUDA Kernel No.59】Add declaration in group_norm_kernel.h -part

### DIFF
--- a/paddle/phi/kernels/group_norm_kernel.h
+++ b/paddle/phi/kernels/group_norm_kernel.h
@@ -38,6 +38,21 @@ void GroupNormKernel(const Context& dev_ctx,
                      DenseTensor* mean,
                      DenseTensor* variance);
 
+template <typename T, typename Context>
+void GroupNormNDHWCKernel(const Context& dev_ctx,
+                          const DenseTensor& x,
+                          const paddle::optional<DenseTensor>& residual,
+                          const paddle::optional<DenseTensor>& scale,
+                          const paddle::optional<DenseTensor>& bias,
+                          float epsilon,
+                          int groups,
+                          const std::string& data_layout_str,
+                          const std::string& activation,
+                          DenseTensor* y,
+                          DenseTensor* residual_out,
+                          DenseTensor* mean,
+                          DenseTensor* var);
+
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
 template <typename T, typename AccT = T>
 class GroupNormDirectCUDAFunctor {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Custom Device


### PR Types
Improvements


### Description
<!-- Describe what you’ve done -->
- Add `GroupNormNDHWCKernel` function declaration used in the PaddleCustomDevice repo

**Used AI Studio**
