### PR TITLE
[Stride] Support CPU Contiguous Kernel with DenseTensorIterator

### DIFF
--- a/paddle/phi/kernels/cpu/contiguous_kernel.cc
+++ b/paddle/phi/kernels/cpu/contiguous_kernel.cc
@@ -85,6 +85,11 @@ void ContiguousKernel(const Context& dev_ctx,
     return;
   }
 
+#if defined(_WIN32)
+  FallbackContiguous<T>(
+      input.dims(), input.strides(), numel, input_data, output_data);
+  return;
+#else
   if (IsComplexType(input.dtype())) {
     FallbackContiguous<T>(
         input.dims(), input.strides(), numel, input_data, output_data);
@@ -217,6 +222,7 @@ void ContiguousKernel(const Context& dev_ctx,
         input.dims(), input.strides(), numel, input_data, output_data);
 #endif
   }
+#endif
 }
 }  // namespace phi
 

--- a/paddle/phi/kernels/cpu/contiguous_kernel.cc
+++ b/paddle/phi/kernels/cpu/contiguous_kernel.cc
@@ -46,10 +46,8 @@ inline void FallbackContiguous(const DDim& input_dims,
                                const int64_t numel,
                                const T* input_data,
                                T* output_data) {
-  // Serial fallback path
   int rank = input_dims.size();
   auto dims = input_dims;
-
   for (int64_t i = 0; i < numel; i++) {
     int64_t input_offset = 0;
     int64_t index_tmp = i;
@@ -58,7 +56,6 @@ inline void FallbackContiguous(const DDim& input_dims,
       index_tmp = index_tmp / dims[dim];
       input_offset += mod * input_stride[dim];
     }
-
     output_data[i] = input_data[input_offset];
   }
 }
@@ -88,13 +85,13 @@ void ContiguousKernel(const Context& dev_ctx,
     return;
   }
 
+  if (IsComplexType(input.dtype())) {
+    FallbackContiguous<T>(
+        input.dims(), input.strides(), numel, input_data, output_data);
+    return;
+  }
+
   if (FastTransposeCopyValid(*out, input)) {
-    if (IsComplexType(input.dtype())) {
-      FallbackContiguous<T>(
-          input.dims(), input.strides(), numel, input_data, output_data);
-      return;
-    }
-    // Fast path for 2D transpose
     constexpr int64_t TRANS_NUMEL = 60;
     void* trans_buffer =
         malloc(phi::SizeOf(input.dtype()) * TRANS_NUMEL * TRANS_NUMEL);
@@ -141,7 +138,6 @@ void ContiguousKernel(const Context& dev_ctx,
     free(trans_buffer);
   } else {
 #if defined(PADDLE_WITH_OPENMP)
-    // OpenMP parallel path
     phi::DenseTensorIteratorConfig config;
     config.add_output(*out);
     config.add_const_input(input);
@@ -217,7 +213,6 @@ void ContiguousKernel(const Context& dev_ctx,
       }
     }
 #else
-    // Serial fallback path
     FallbackContiguous<T>(
         input.dims(), input.strides(), numel, input_data, output_data);
 #endif

--- a/paddle/phi/kernels/cpu/contiguous_kernel.cc
+++ b/paddle/phi/kernels/cpu/contiguous_kernel.cc
@@ -11,6 +11,7 @@ limitations under the License. */
 
 #include "paddle/phi/kernels/contiguous_kernel.h"
 
+#include <set>
 #include <vector>
 
 #include "paddle/phi/backends/cpu/cpu_context.h"
@@ -60,6 +61,60 @@ inline void FallbackContiguous(const DDim& input_dims,
   }
 }
 
+inline bool OnlyTransposed(const DDim& shape,
+                           const DDim& stride,
+                           const uint64_t& offset) {
+  if (offset != 0) {
+    return false;
+  }
+
+  DDim x_stride = stride;
+  DDim x_shape = shape;
+
+  std::set<int> visited_idx;
+  for (int i = 0; i < stride.size(); i++) {
+    int64_t max_num = 0;
+    int max_idx = -1;
+    for (int j = 0; j < stride.size(); j++) {
+      if (visited_idx.count(j)) {
+        continue;
+      }
+      if (stride[j] < 1) {
+        return false;
+      }
+      if (stride[j] > max_num) {
+        max_num = stride[j];
+        max_idx = j;
+      }
+    }
+    if (max_idx == -1) {
+      return false;
+    }
+    if (i != 0 && x_stride[i - 1] == max_num) {
+      return false;
+    }
+    visited_idx.insert(max_idx);
+    x_stride[i] = max_num;
+    x_shape[i] = shape[max_idx];
+  }
+
+  if (DenseTensorMeta::calc_strides(x_shape) == x_stride) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+inline bool FastContiguousJudge(const std::vector<int64_t>& coalesce_shape,
+                                const DenseTensor& input) {
+  if (coalesce_shape.size() > 3 || input.dims().size() == 0) return false;
+  auto x_meta = input.meta();
+  if (coalesce_shape.size() == 3 &&
+      !OnlyTransposed(x_meta.dims, x_meta.strides, x_meta.offset))
+    return false;
+  return true;
+}
+
 inline bool FastTransposeCopyValid(const DenseTensor& self,
                                    const DenseTensor& src) {
   constexpr int64_t MIN_NUMEL = 360;
@@ -85,17 +140,17 @@ void ContiguousKernel(const Context& dev_ctx,
     return;
   }
 
-#if defined(_WIN32)
-  FallbackContiguous<T>(
-      input.dims(), input.strides(), numel, input_data, output_data);
-  return;
-#else
   if (IsComplexType(input.dtype())) {
     FallbackContiguous<T>(
         input.dims(), input.strides(), numel, input_data, output_data);
     return;
   }
 
+#if defined(_WIN32)
+  FallbackContiguous<T>(
+      input.dims(), input.strides(), numel, input_data, output_data);
+  return;
+#else
   if (FastTransposeCopyValid(*out, input)) {
     constexpr int64_t TRANS_NUMEL = 60;
     void* trans_buffer =
@@ -148,8 +203,7 @@ void ContiguousKernel(const Context& dev_ctx,
     config.add_const_input(input);
     config.is_alloc_out_ = true;
     phi::DenseTensorIterator iter = config.build();
-
-    if (iter.shape().size() > 3 || input.dims().size() == 0) {
+    if (!FastContiguousJudge(iter.shape(), input)) {
       FallbackContiguous<T>(
           input.dims(), input.strides(), numel, input_data, output_data);
       return;

--- a/paddle/phi/kernels/cpu/contiguous_kernel.cc
+++ b/paddle/phi/kernels/cpu/contiguous_kernel.cc
@@ -198,6 +198,8 @@ void ContiguousKernel(const Context& dev_ctx,
             tmp_in_data += value * whole_stride[dim * iter.ntensors() + 1];
           }
 
+          auto step = dimiter.iter_for_step();
+
           for (int64_t i = 0; i < step[1]; i++) {
             for (int64_t j = 0; j < step[0]; j++) {
               const char* real_in_ptr = tmp_in_data + j * whole_stride[1];

--- a/paddle/phi/kernels/cpu/contiguous_kernel.cc
+++ b/paddle/phi/kernels/cpu/contiguous_kernel.cc
@@ -15,10 +15,61 @@ limitations under the License. */
 
 #include "paddle/phi/backends/cpu/cpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/funcs/dense_tensor_iterator.h"
 #include "paddle/phi/kernels/funcs/math_function.h"
 #include "paddle/phi/kernels/impl/transpose_grad_kernel_impl.h"
 
+#if defined(PADDLE_WITH_OPENMP)
+#include <omp.h>
+#endif
+
 namespace phi {
+
+inline int64_t DivUp(const int64_t& x, const int64_t& y) {
+  return (x + y - 1) / y;
+}
+
+inline void DealWithStride(const DenseTensorIterator& iter, int64_t* strides) {
+  for (int dim = 0; dim < iter.ndim(); dim++) {
+    for (int arg = 0; arg < iter.ntensors(); arg++) {
+      *strides++ = iter.strides(arg)[dim];
+    }
+  }
+  if (iter.ndim() < 2) {
+    std::fill_n(strides, (2 - iter.ndim()) * iter.ntensors(), 0);
+  }
+}
+
+template <typename T>
+inline void FallbackContiguous(const DDim& input_dims,
+                               const DDim& input_stride,
+                               const int64_t numel,
+                               const T* input_data,
+                               T* output_data) {
+  // Serial fallback path
+  int rank = input_dims.size();
+  auto dims = input_dims;
+
+  for (int64_t i = 0; i < numel; i++) {
+    int64_t input_offset = 0;
+    int64_t index_tmp = i;
+    for (int dim = rank - 1; dim >= 0; --dim) {
+      int64_t mod = index_tmp % dims[dim];
+      index_tmp = index_tmp / dims[dim];
+      input_offset += mod * input_stride[dim];
+    }
+
+    output_data[i] = input_data[input_offset];
+  }
+}
+
+inline bool FastTransposeCopyValid(const DenseTensor& self,
+                                   const DenseTensor& src) {
+  constexpr int64_t MIN_NUMEL = 360;
+  return src.numel() != 0 && src.dims().size() == 2 && src.strides()[0] == 1 &&
+         src.strides()[1] == src.dims()[0] &&
+         self.dims().size() == src.dims().size() && self.numel() >= MIN_NUMEL;
+}
 
 template <typename T, typename Context>
 void ContiguousKernel(const Context& dev_ctx,
@@ -31,21 +82,143 @@ void ContiguousKernel(const Context& dev_ctx,
 
   const T* input_data = input.data<T>();
   T* output_data = dev_ctx.template Alloc<T>(out);
-  int rank = input.dims().size();
-  auto dims = input.dims();
-  auto input_stride = input.strides();
   auto numel = input.numel();
 
-  for (int64_t i = 0; i < numel; i++) {
-    int64_t input_offset = 0;
-    int64_t index_tmp = i;
-    for (int dim = rank - 1; dim >= 0; --dim) {
-      int64_t mod = index_tmp % dims[dim];
-      index_tmp = index_tmp / dims[dim];
-      input_offset += mod * input_stride[dim];
+  if (numel == 0) {
+    return;
+  }
+
+  if (FastTransposeCopyValid(*out, input)) {
+    if (IsComplexType(input.dtype())) {
+      FallbackContiguous<T>(
+          input.dims(), input.strides(), numel, input_data, output_data);
+      return;
+    }
+    // Fast path for 2D transpose
+    constexpr int64_t TRANS_NUMEL = 60;
+    void* trans_buffer =
+        malloc(phi::SizeOf(input.dtype()) * TRANS_NUMEL * TRANS_NUMEL);
+
+    const T* tmp_src_ptr = input_data;
+    T* tmp_out_ptr = output_data;
+    T* tmp_buf_ptr = reinterpret_cast<T*>(trans_buffer);
+
+    int64_t dim0 = out->dims()[0];
+    int64_t dim1 = out->dims()[1];
+
+    for (int64_t d0 = 0; d0 < dim0; d0 += TRANS_NUMEL) {
+      for (int64_t d1 = 0; d1 < dim1; d1 += TRANS_NUMEL) {
+        const T* src_ptr_inter = tmp_src_ptr + d0 + d1 * dim0;
+        T* out_ptr_inter = tmp_out_ptr + d1 + d0 * dim1;
+
+        int nr = std::min(dim0 - d0, TRANS_NUMEL);
+        int nc = std::min(dim1 - d1, TRANS_NUMEL);
+
+        for (int c = 0; c < nc; c++) {
+          memcpy(tmp_buf_ptr + c * TRANS_NUMEL,
+                 src_ptr_inter + c * dim0,
+                 nr * sizeof(T));
+        }
+
+        int rc_max = std::max(nr, nc);
+        int rc_min = std::min(nr, nc);
+        for (int r = 0; r < rc_max; r++) {
+          int end = std::min(r, rc_min);
+          for (int c = 0; c < end; c++) {
+            T tmp = tmp_buf_ptr[r + TRANS_NUMEL * c];
+            tmp_buf_ptr[r + TRANS_NUMEL * c] = tmp_buf_ptr[r * TRANS_NUMEL + c];
+            tmp_buf_ptr[r * TRANS_NUMEL + c] = tmp;
+          }
+        }
+
+        for (int r = 0; r < nr; r++) {
+          memcpy(out_ptr_inter + r * dim1,
+                 tmp_buf_ptr + r * TRANS_NUMEL,
+                 nc * sizeof(T));
+        }
+      }
+    }
+    free(trans_buffer);
+  } else {
+#if defined(PADDLE_WITH_OPENMP)
+    // OpenMP parallel path
+    phi::DenseTensorIteratorConfig config;
+    config.add_output(*out);
+    config.add_const_input(input);
+    config.is_alloc_out_ = true;
+    phi::DenseTensorIterator iter = config.build();
+
+    if (iter.shape().size() > 2 || input.dims().size() == 0) {
+      FallbackContiguous<T>(
+          input.dims(), input.strides(), numel, input_data, output_data);
+      return;
     }
 
-    output_data[i] = input_data[input_offset];
+    std::vector<int64_t> tmp_strides(
+        iter.ntensors() * static_cast<size_t>(std::max(iter.ndim(), 2)));
+
+    DealWithStride(iter, tmp_strides.data());
+
+    std::vector<int64_t> out_stride(tmp_strides.begin() + iter.ntensors(),
+                                    tmp_strides.end());
+
+    const int64_t& iter_numel = iter.numel();
+    const char* in_ptr = reinterpret_cast<const char*>(input_data);
+    char* out_ptr = reinterpret_cast<char*>(output_data);
+    int64_t end = iter_numel;
+    int64_t begin = 0;
+    int64_t grain_size = 32768;
+
+    int64_t* whole_stride = tmp_strides.data();
+
+#pragma omp parallel
+    {
+      int64_t num_threads = omp_get_num_threads();
+
+      if (grain_size > 0) {
+        num_threads = std::min(num_threads, DivUp((end - begin), grain_size));
+      }
+
+      int64_t tid = omp_get_thread_num();
+      int64_t chunk_size = DivUp((end - begin), num_threads);
+      int64_t begin_tid = begin + tid * chunk_size;
+
+      if (begin_tid < end) {
+        int64_t range_start = begin_tid;
+        int64_t range_end = std::min(end, chunk_size + begin_tid);
+
+        auto dimiter = DimIter(iter.shape(), range_start, range_end);
+        while (!dimiter.iter_to_end()) {
+          const auto v_ndim = dimiter.values.size();
+          const char* tmp_in_data = in_ptr;
+          char* tmp_out_data = out_ptr;
+          for (size_t dim = 0; dim < v_ndim; dim++) {
+            int64_t value = dimiter.values[dim];
+            tmp_out_data += value * whole_stride[dim * iter.ntensors() + 0];
+            tmp_in_data += value * whole_stride[dim * iter.ntensors() + 1];
+          }
+
+          for (int64_t i = 0; i < step[1]; i++) {
+            for (int64_t j = 0; j < step[0]; j++) {
+              const char* real_in_ptr = tmp_in_data + j * whole_stride[1];
+              char* real_out_ptr = tmp_out_data + j * whole_stride[0];
+
+              *reinterpret_cast<T*>(real_out_ptr) =
+                  *reinterpret_cast<const T*>(real_in_ptr);
+            }
+            tmp_in_data = tmp_in_data + out_stride[1];
+            tmp_out_data = tmp_out_data + out_stride[0];
+          }
+
+          dimiter.iter_to_next(step);
+        }
+      }
+    }
+#else
+    // Serial fallback path
+    FallbackContiguous<T>(
+        input.dims(), input.strides(), numel, input_data, output_data);
+#endif
   }
 }
 }  // namespace phi

--- a/paddle/phi/kernels/cpu/contiguous_kernel.cc
+++ b/paddle/phi/kernels/cpu/contiguous_kernel.cc
@@ -149,7 +149,7 @@ void ContiguousKernel(const Context& dev_ctx,
     config.is_alloc_out_ = true;
     phi::DenseTensorIterator iter = config.build();
 
-    if (iter.shape().size() > 2 || input.dims().size() == 0) {
+    if (iter.shape().size() > 3 || input.dims().size() == 0) {
       FallbackContiguous<T>(
           input.dims(), input.strides(), numel, input_data, output_data);
       return;

--- a/paddle/phi/kernels/cpu/strided_copy_kernel.cc
+++ b/paddle/phi/kernels/cpu/strided_copy_kernel.cc
@@ -17,42 +17,15 @@ limitations under the License. */
 #include "paddle/phi/backends/context_pool.h"
 #include "paddle/phi/backends/cpu/cpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/contiguous_kernel.h"
 #include "paddle/phi/kernels/funcs/dense_tensor_iterator.h"
 #include "paddle/phi/kernels/funcs/math_function.h"
 #include "paddle/phi/kernels/impl/transpose_grad_kernel_impl.h"
-
-#if defined(PADDLE_WITH_OPENMP)
-#include <omp.h>
-#else
-#include "paddle/phi/kernels/contiguous_kernel.h"
-#endif
 
 COMMON_DECLARE_bool(use_stride_kernel);
 COMMON_DECLARE_bool(use_stride_compute_kernel);
 
 namespace phi {
-inline int64_t DivUp(const int64_t& x, const int64_t& y) {
-  return (x + y - 1) / y;
-}
-
-inline void DealWithStride(const DenseTensorIterator& iter, int64_t* strides) {
-  for (int dim = 0; dim < iter.ndim(); dim++) {
-    for (int arg = 0; arg < iter.ntensors(); arg++) {
-      *strides++ = iter.strides(arg)[dim];
-    }
-  }
-  if (iter.ndim() < 2) {
-    std::fill_n(strides, (2 - iter.ndim()) * iter.ntensors(), 0);
-  }
-}
-
-inline bool FastTransposeCopyValid(const DenseTensor& self,
-                                   const DenseTensor& src) {
-  constexpr int64_t MIN_NUMEL = 360;
-  return src.numel() != 0 && src.dims().size() == 2 && src.strides()[0] == 1 &&
-         src.strides()[1] == src.dims()[0] &&
-         self.dims().size() == src.dims().size() && self.numel() >= MIN_NUMEL;
-}
 
 template <typename T, typename Context>
 void StridedCopyKernel(const Context& dev_ctx,
@@ -100,160 +73,10 @@ void StridedCopyKernel(const Context& dev_ctx,
           dst_gpu_place, dst_ptr, src_cpu_place, input.data<T>(), size, stream);
 
     } else {
-      phi::DenseTensor src_cpu;
-      phi::DenseTensor cpu_input = input;
-      phi::DenseTensor* cpu_out = &src_cpu;
-      void* cpu_output_data;
-
-      phi::DenseTensorMeta cpu_meta = cpu_input.meta();
-      cpu_meta.strides = cpu_meta.calc_strides(cpu_meta.dims);
-      cpu_meta.offset = 0;
-      cpu_out->set_meta(cpu_meta);
-
-#if defined(PADDLE_WITH_OPENMP)
-      dev_ctx.HostAlloc(cpu_out, cpu_out->dtype());
-#endif
-      const void* cpu_input_data = cpu_input.data();
-      cpu_output_data =
-          malloc(phi::SizeOf(cpu_input.dtype()) * cpu_out->numel());
-
-      if (FastTransposeCopyValid(*cpu_out, cpu_input)) {
-        constexpr int64_t TRANS_NUMEL = 60;
-        void* trans_buffer =
-            malloc(phi::SizeOf(input.dtype()) * TRANS_NUMEL * TRANS_NUMEL);
-
-        const T* tmp_src_ptr = reinterpret_cast<const T*>(cpu_input_data);
-#if defined(PADDLE_WITH_OPENMP)
-        T* tmp_out_ptr = reinterpret_cast<T*>(cpu_output_data);
-#else
-        T* tmp_out_ptr = cpu_out->data<T>();
-#endif
-        T* tmp_buf_ptr = reinterpret_cast<T*>(trans_buffer);
-
-        int64_t dim0 = cpu_out->dims()[0];
-        int64_t dim1 = cpu_out->dims()[1];
-
-        for (int64_t d0 = 0; d0 < dim0; d0 += TRANS_NUMEL) {
-          for (int64_t d1 = 0; d1 < dim1; d1 += TRANS_NUMEL) {
-            const T* src_ptr_inter = tmp_src_ptr + d0 + d1 * dim0;
-            T* out_ptr_inter = tmp_out_ptr + d1 + d0 * dim1;
-
-            int nr = std::min(dim0 - d0, TRANS_NUMEL);
-            int nc = std::min(dim1 - d1, TRANS_NUMEL);
-
-            for (int c = 0; c < nc; c++) {
-              memcpy(tmp_buf_ptr + c * TRANS_NUMEL,
-                     src_ptr_inter + c * dim0,
-                     nr * sizeof(T));
-            }
-
-            int rc_max = std::max(nr, nc);
-            int rc_min = std::min(nr, nc);
-            for (int r = 0; r < rc_max; r++) {
-              int end = std::min(r, rc_min);
-              for (int c = 0; c < end; c++) {
-                T tmp = tmp_buf_ptr[r + TRANS_NUMEL * c];
-                tmp_buf_ptr[r + TRANS_NUMEL * c] =
-                    tmp_buf_ptr[r * TRANS_NUMEL + c];
-                tmp_buf_ptr[r * TRANS_NUMEL + c] = tmp;
-              }
-            }
-
-            for (int r = 0; r < nr; r++) {
-              memcpy(out_ptr_inter + r * dim1,
-                     tmp_buf_ptr + r * TRANS_NUMEL,
-                     nc * sizeof(T));
-            }
-          }
-        }
-        free(trans_buffer);
-      } else {
-#if defined(PADDLE_WITH_OPENMP)
-        phi::DenseTensorIteratorConfig config;
-        config.add_output(*cpu_out);
-        config.add_const_input(cpu_input);
-        config.is_alloc_out_ = true;
-        phi::DenseTensorIterator iter = config.build();
-
-        std::vector<int64_t> tmp_strides(
-            iter.ntensors() * static_cast<size_t>(std::max(iter.ndim(), 2)));
-
-        DealWithStride(iter, tmp_strides.data());
-
-        std::vector<int64_t> out_stride(tmp_strides.begin() + iter.ntensors(),
-                                        tmp_strides.end());
-
-        std::vector<int64_t> output_stride = iter.strides(0);
-        std::vector<int64_t> input_stride = iter.strides(1);
-
-        const int64_t& numel = iter.numel();
-
-        const char* in_ptr = reinterpret_cast<const char*>(cpu_input_data);
-        char* out_ptr = reinterpret_cast<char*>(cpu_output_data);
-
-        int64_t end = numel;
-        int64_t begin = 0;
-        int64_t grain_size = 32768;
-
-        int64_t* whole_stride = tmp_strides.data();
-
-#pragma omp parallel
-        {
-          int64_t num_threads = omp_get_num_threads();
-
-          if (grain_size > 0) {
-            num_threads =
-                std::min(num_threads, DivUp((end - begin), grain_size));
-          }
-
-          int64_t tid = omp_get_thread_num();
-          int64_t chunk_size = DivUp((end - begin), num_threads);
-          int64_t begin_tid = begin + tid * chunk_size;
-
-          if (begin_tid < end) {
-            int64_t range_start = begin_tid;
-            int64_t range_end = std::min(end, chunk_size + begin_tid);
-
-            auto dimiter = DimIter(iter.shape(), range_start, range_end);
-            while (!dimiter.iter_to_end()) {
-              const auto v_ndim = dimiter.values.size();
-              const char* tmp_in_data = in_ptr;
-              char* tmp_out_data = out_ptr;
-              for (size_t dim = 0; dim < v_ndim; dim++) {
-                int64_t value = dimiter.values[dim];
-                tmp_out_data += value * whole_stride[dim * iter.ntensors() + 0];
-                tmp_in_data += value * whole_stride[dim * iter.ntensors() + 1];
-              }
-
-              auto step = dimiter.iter_for_step();
-
-              for (int64_t i = 0; i < step[1]; i++) {
-                for (int64_t j = 0; j < step[0]; j++) {
-                  const char* real_in_ptr = tmp_in_data + j * whole_stride[1];
-                  char* real_out_ptr = tmp_out_data + j * whole_stride[0];
-
-                  *reinterpret_cast<T*>(real_out_ptr) =
-                      *reinterpret_cast<const T*>(real_in_ptr);
-                }
-                tmp_in_data = tmp_in_data + out_stride[1];
-                tmp_out_data = tmp_out_data + out_stride[0];
-              }
-
-              dimiter.iter_to_next(step);
-            }
-          }
-        }
-#else
-        phi::ContiguousKernel<T, Context>(dev_ctx, input, cpu_out);
-#endif
-      }
-#if defined(PADDLE_WITH_OPENMP)
-      auto* src_ptr = cpu_output_data;
-#else
-      auto* src_ptr = cpu_out->data<T>();
-#endif
-
-      auto size = phi::SizeOf(input.dtype()) * src_cpu.numel();
+      phi::DenseTensor cpu_out;
+      phi::ContiguousKernel<T, Context>(dev_ctx, input, &cpu_out);
+      auto* src_ptr = cpu_out.data<T>();
+      auto size = phi::SizeOf(input.dtype()) * cpu_out.numel();
       void* dst_ptr = gpu_dev_ctx->Alloc(
           &dst_gpu,
           dst_gpu.dtype(),
@@ -262,8 +85,6 @@ void StridedCopyKernel(const Context& dev_ctx,
 
       phi::memory_utils::Copy(
           dst_gpu_place, dst_ptr, src_cpu_place, src_ptr, size, stream);
-
-      free(cpu_output_data);
     }
     if (out != &dst_gpu) {
       PD_VISIT_ALL_TYPES(

--- a/paddle/phi/kernels/funcs/dense_tensor_iterator.cc
+++ b/paddle/phi/kernels/funcs/dense_tensor_iterator.cc
@@ -501,7 +501,7 @@ void DimIter::iter_to_next(const std::array<int64_t, 2>& step) {
 std::array<int64_t, 2> DimIter::iter_for_step() const {
   int64_t step0 = std::min(shape[0] - values[0], end - offset);
   int64_t step1 = 1;
-  if (step0 == shape[0] && !shape.empty()) {
+  if (step0 == shape[0] && !shape.empty() && shape.size() > 1) {
     step1 = std::min(shape[1] - values[1], (end - offset) / shape[0]);
   }
   return {step0, step1};


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
1. 将CPU Contiguous H2D加速逻辑从strided_copy.cc迁移至contiguous.cc，增加性能提升覆盖面
2. 注意目前CPU Contiguous加速逻辑适用于经DenseTensorIterator合并维度后dims.size() <= 2或只经过transpose的dims.size()=3的情况，并非全量覆盖

```python
x = paddle.randint(0, 255, shape=[263, 1080, 1920, 3]).astype(paddle.uint8)
transposed_x = x.transpose([0, 3, 1, 2])
x.contiguous() # 9810.336 ms -> 247.766 ms
```




pcard-67164