### PR TITLE
[CodeStyle] Enable docstring code format and start to use `pycon` as syntax highlight marker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ target-version = "py39"
 [tool.ruff.format]
 # Prevent change to double quotes by some users use ruff format
 quote-style = "preserve"
+docstring-code-format = true
 
 [tool.ruff.lint]
 select = [

--- a/python/paddle/device/__init__.py
+++ b/python/paddle/device/__init__.py
@@ -697,9 +697,11 @@ def get_default_device() -> paddle.device:
     Returns:
         str: The default device for PaddlePaddle.
     Example:
-        .. code-block:: python
-            import paddle
-            print(paddle.get_default_device())
+        .. code-block:: pycon
+
+            >>> import paddle
+
+            >>> print(paddle.get_default_device())
     """
     return paddle.device(get_device().replace("gpu", "cuda"))
 
@@ -1093,7 +1095,7 @@ class Event:
         ```python
         # New usage
         paddle.set_device("gpu:0")  # Set device first
-        e = paddle.device.Event()   # Will use gpu:0
+        e = paddle.device.Event()  # Will use gpu:0
         ```
 
         paddle.device.Event is equivalent to paddle.cuda.Event.

--- a/python/paddle/device/__init__.py
+++ b/python/paddle/device/__init__.py
@@ -697,7 +697,7 @@ def get_default_device() -> paddle.device:
     Returns:
         str: The default device for PaddlePaddle.
     Example:
-        .. code-block:: pycon
+        .. code-block:: python-console
 
             >>> import paddle
 

--- a/python/paddle/device/__init__.py
+++ b/python/paddle/device/__init__.py
@@ -697,7 +697,7 @@ def get_default_device() -> paddle.device:
     Returns:
         str: The default device for PaddlePaddle.
     Example:
-        .. code-block:: python-console
+        .. code-block:: pycon
 
             >>> import paddle
 

--- a/python/paddle/distributed/auto_parallel/intermediate/context_parallel.py
+++ b/python/paddle/distributed/auto_parallel/intermediate/context_parallel.py
@@ -40,74 +40,78 @@ class PrepareContextParallel(PlanBase):
         backend (string): select strategy for context parallel, now support 'p2p' and 'all2all'.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
-        >>> import paddle
-        >>> import paddle.distributed as dist
+            >>> import paddle
+            >>> import paddle.distributed as dist
 
-        >>> class SDPALayer(paddle.nn.Layer):
-        ...     def __init__(self):
-        ...         super().__init__()
-        ...
-        ...     def forward(self, q, k, v):
-        ...         return paddle.nn.functional.scaled_dot_product_attention(q, k, v)
-        >>>
-        >>> class AttentionLayer(paddle.nn.Layer):
-        ...     def __init__(self):
-        ...         super().__init__()
-        ...         self.hidden_size = 64
-        ...         self.num_key_value_heads = 10
-        ...         self.head_dim = 64
-        ...         self.sdpa = SDPALayer()
-        ...         self.q = paddle.nn.Linear(
-        ...             self.hidden_size,
-        ...             self.hidden_size,
-        ...             bias_attr=False,
-        ...         )
-        ...         self.k = paddle.nn.Linear(
-        ...             self.hidden_size,
-        ...             self.num_key_value_heads * self.head_dim,
-        ...             bias_attr=False,
-        ...         )
-        ...         self.v = paddle.nn.Linear(
-        ...             self.hidden_size,
-        ...             self.num_key_value_heads * self.head_dim,
-        ...             bias_attr=False,
-        ...         )
-        ...
-        ...     def forward(self, input):
-        ...         q = self.q(input)
-        ...         k = self.k(input)
-        ...         v = self.v(input)
-        ...         return self.sdpa(q, k, v)
-        >>>
-        >>> class LlamaLayer(paddle.nn.Layer):
-        ...     def __init__(self):
-        ...         super().__init__()
-        ...         self.attention = AttentionLayer()
-        ...
-        ...     def forward(self, input, label):
-        ...         return self.attention(input)
-        >>>
-        >>> class LlamaForCausalLayer(paddle.nn.Layer):
-        ...     def __init__(self):
-        ...         super().__init__()
-        ...         self.llama = LlamaLayer()
-        ...         self.weight = self.create_parameter(shape=[64, 1024])
-        ...         self.loss_func = paddle.nn.CrossEntropyLoss()
-        ...
-        ...     def forward(self, input, label):
-        ...         out = self.llama(input, label)
-        ...         logits = paddle.matmul(out, self.weight)
-        ...         loss = self.loss_func(logits, label)
-        ...         return logits
-        >>>
-        >>> # doctest: +REQUIRES(env:DISTRIBUTED)
-        >>> layer = LlamaForCausalLayer()
-        >>> mp_config = {
-        ...     'llama': dist.PrepareContextParallel('p2p'),
-        ...     'sdpa': dist.ContextParallel('p2p'),
-        ... }
+            >>> class SDPALayer(paddle.nn.Layer):
+            ...     def __init__(self):
+            ...         super().__init__()
+            ...
+            ...     def forward(self, q, k, v):
+            ...         return (
+            ...             paddle.nn.functional.scaled_dot_product_attention(
+            ...                 q, k, v
+            ...             )
+            ...         )
+            >>>
+            >>> class AttentionLayer(paddle.nn.Layer):
+            ...     def __init__(self):
+            ...         super().__init__()
+            ...         self.hidden_size = 64
+            ...         self.num_key_value_heads = 10
+            ...         self.head_dim = 64
+            ...         self.sdpa = SDPALayer()
+            ...         self.q = paddle.nn.Linear(
+            ...             self.hidden_size,
+            ...             self.hidden_size,
+            ...             bias_attr=False,
+            ...         )
+            ...         self.k = paddle.nn.Linear(
+            ...             self.hidden_size,
+            ...             self.num_key_value_heads * self.head_dim,
+            ...             bias_attr=False,
+            ...         )
+            ...         self.v = paddle.nn.Linear(
+            ...             self.hidden_size,
+            ...             self.num_key_value_heads * self.head_dim,
+            ...             bias_attr=False,
+            ...         )
+            ...
+            ...     def forward(self, input):
+            ...         q = self.q(input)
+            ...         k = self.k(input)
+            ...         v = self.v(input)
+            ...         return self.sdpa(q, k, v)
+            >>>
+            >>> class LlamaLayer(paddle.nn.Layer):
+            ...     def __init__(self):
+            ...         super().__init__()
+            ...         self.attention = AttentionLayer()
+            ...
+            ...     def forward(self, input, label):
+            ...         return self.attention(input)
+            >>>
+            >>> class LlamaForCausalLayer(paddle.nn.Layer):
+            ...     def __init__(self):
+            ...         super().__init__()
+            ...         self.llama = LlamaLayer()
+            ...         self.weight = self.create_parameter(shape=[64, 1024])
+            ...         self.loss_func = paddle.nn.CrossEntropyLoss()
+            ...
+            ...     def forward(self, input, label):
+            ...         out = self.llama(input, label)
+            ...         logits = paddle.matmul(out, self.weight)
+            ...         loss = self.loss_func(logits, label)
+            ...         return logits
+            >>>
+            >>> # doctest: +REQUIRES(env:DISTRIBUTED)
+            >>> layer = LlamaForCausalLayer()
+            >>> mp_config = {
+            ...     'llama': dist.PrepareContextParallel('p2p'),
+            ...     'sdpa': dist.ContextParallel('p2p'),
+            ... }
     """
 
     def __init__(self, backend: str = 'p2p') -> None:
@@ -245,7 +249,9 @@ class ContextParallel(PlanBase):
         ...         super().__init__()
         ...
         ...     def forward(self, q, k, v):
-        ...         return paddle.nn.functional.scaled_dot_product_attention(q, k, v)
+        ...         return paddle.nn.functional.scaled_dot_product_attention(
+        ...             q, k, v
+        ...         )
         >>>
         >>> class AttentionLayer(paddle.nn.Layer):
         ...     def __init__(self):

--- a/python/paddle/distributed/auto_parallel/intermediate/context_parallel.py
+++ b/python/paddle/distributed/auto_parallel/intermediate/context_parallel.py
@@ -40,7 +40,7 @@ class PrepareContextParallel(PlanBase):
         backend (string): select strategy for context parallel, now support 'p2p' and 'all2all'.
 
     Examples:
-        .. code-block:: python-console
+        .. code-block:: pycon
 
             >>> import paddle
             >>> import paddle.distributed as dist

--- a/python/paddle/distributed/auto_parallel/intermediate/context_parallel.py
+++ b/python/paddle/distributed/auto_parallel/intermediate/context_parallel.py
@@ -40,7 +40,7 @@ class PrepareContextParallel(PlanBase):
         backend (string): select strategy for context parallel, now support 'p2p' and 'all2all'.
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python-console
 
             >>> import paddle
             >>> import paddle.distributed as dist

--- a/python/paddle/distributed/auto_parallel/static/cost/op_runtime_cost.py
+++ b/python/paddle/distributed/auto_parallel/static/cost/op_runtime_cost.py
@@ -257,15 +257,21 @@ def measure_program_real_op_cost(
     Example
     -----------
     * Profiling a simple program from scratch:
-    >>> from paddle.distributed.auto_parallel.static.utils import measure_program_real_op_cost
-    >>> program = ... # build your own program object here.
+    >>> from paddle.distributed.auto_parallel.static.utils import (
+    ...     measure_program_real_op_cost,
+    ... )
+    >>> program = ...  # build your own program object here.
     >>> measure_program_real_op_cost(
     >>>     program, verbose_level=1
     >>> )
     * Profiling a program which is already embedded into an Executor or some other class instance:
     >>> import paddle
-    >>> from paddle.distributed.auto_parallel.static.utils import measure_program_real_op_cost
-    >>> place: str = paddle.device.get_device() # here we assume place = "cuda:x"
+    >>> from paddle.distributed.auto_parallel.static.utils import (
+    ...     measure_program_real_op_cost,
+    ... )
+    >>> place: str = (
+    ...     paddle.device.get_device()
+    ... )  # here we assume place = "cuda:x"
     >>> place = paddle.CUDAPlace(int(place.split(':')[1]))
     >>> # here "program" is an inner object that has already been built before
     >>> measure_program_real_op_cost(program, verbose_level=1)

--- a/python/paddle/distributed/fleet/utils/hybrid_parallel_inference.py
+++ b/python/paddle/distributed/fleet/utils/hybrid_parallel_inference.py
@@ -50,9 +50,15 @@ class HybridParallelInferenceHelper:
             >>> # while op pattern
             >>> with paddle.base.device_guard(f'{device}:all'):
             ...     # init global cond
-            ...     max_len = paddle.full(shape=[1], dtype="int64", fill_value=10)
-            ...     step_idx = paddle.full(shape=[1], dtype="int64", fill_value=0)
-            ...     cond_int = paddle.full(shape=[1], dtype="int64", fill_value=0, name="cond_int")
+            ...     max_len = paddle.full(
+            ...         shape=[1], dtype="int64", fill_value=10
+            ...     )
+            ...     step_idx = paddle.full(
+            ...         shape=[1], dtype="int64", fill_value=0
+            ...     )
+            ...     cond_int = paddle.full(
+            ...         shape=[1], dtype="int64", fill_value=0, name="cond_int"
+            ...     )
             ...     cond = layers.cast(step_idx < max_len, dtype="bool")
             ...     while_op = layers.While(cond, is_test=True)
 
@@ -62,22 +68,30 @@ class HybridParallelInferenceHelper:
             >>> with while_op.block():
             ...     with paddle.base.device_guard(f'{device}:all'):
             ...         # read data from global lod_tensor_array
-            ...         element_in_arr = paddle.tensor.array_read(array=arr, i=step_idx)
+            ...         element_in_arr = paddle.tensor.array_read(
+            ...             array=arr, i=step_idx
+            ...         )
             ...         # write placeholder data to global lod_tensor_array,
             ...         # it need for send_v2 of lod_tensor_array
             ...         paddle.increment(x=step_idx, value=1.0)
-            ...         paddle.tensor.array_write(element_in_arr, i=step_idx, array=arr)
+            ...         paddle.tensor.array_write(
+            ...             element_in_arr, i=step_idx, array=arr
+            ...         )
             ...     with paddle.base.device_guard(f'{device}:0'):
-            ...         pass # some code
+            ...         pass  # some code
             ...     with paddle.base.device_guard(f'{device}:1'):
-            ...         pass # some code
-            ...     with paddle.base.device_guard(f'{device}:{num_pp-1}'):
+            ...         pass  # some code
+            ...     with paddle.base.device_guard(f'{device}:{num_pp - 1}'):
             ...         # generate some data in while block and write to global lod_tensor_array
             ...         # that they are read in next while step.
             ...         # we will using send_v2 to send global lod_tensor_array to other pipeline and sync
-            ...         paddle.tensor.array_write(other_var, i=step_idx, array=arr)
+            ...         paddle.tensor.array_write(
+            ...             other_var, i=step_idx, array=arr
+            ...         )
             ...         # update cond and assign to cond_int, we will sync cond_int
-            ...         layers.assign(layers.cast(cond, dtype="int32"), cond_int)
+            ...         layers.assign(
+            ...             layers.cast(cond, dtype="int32"), cond_int
+            ...         )
             ...     with paddle.base.device_guard(f'{model._device}:all'):
             ...         # the code below must at end of while block and exists in device:all
             ...         layers.assign(layers.cast(cond_int, dtype='bool'), cond)

--- a/python/paddle/incubate/nn/functional/fused_transformer.py
+++ b/python/paddle/incubate/nn/functional/fused_transformer.py
@@ -552,9 +552,9 @@ def fused_multi_head_attention(
         >>> out = matmul(out, qkv_weight) + qkv_bias
         >>> out = transpose(out, perm=[2, 0, 3, 1, 4])
         >>> # extract q, k and v from out
-        >>> q = out[0:1,::] * (head_dim ** -0.5)
-        >>> k = out[1:2,::]
-        >>> v = out[2:3,::]
+        >>> q = out[0:1, ::] * (head_dim**-0.5)
+        >>> k = out[1:2, ::]
+        >>> v = out[2:3, ::]
         >>> out = matmul(q, k, transpose_y=True)
         >>> out = out + attn_mask
         >>> out = softmax(out)
@@ -1103,7 +1103,7 @@ def fused_multi_transformer(
         >>> q = out[0:1, ::]
         >>> k = out[1:2, ::]
         >>> v = out[2:3, ::]
-        >>> out = q * k^t
+        >>> out = q * k ^ t
         >>> out = attn_mask + out
         >>> out = softmax(out)
         >>> out = dropout(out)
@@ -1115,7 +1115,7 @@ def fused_multi_transformer(
         ... else:
         ...     out = layer_norm(x + dropout(out + bias))
 
-        >>> residual = out;
+        >>> residual = out
         >>> if pre_layer_norm:
         ...     out = ffn_layer_norm(out)
         >>> out = ffn1_linear(out)

--- a/python/paddle/incubate/nn/functional/fused_transformer.py
+++ b/python/paddle/incubate/nn/functional/fused_transformer.py
@@ -653,7 +653,7 @@ def fused_multi_head_attention(
             ...     None, None, None, None, 1e-5, qkv_bias,
             ...     linear_bias, None, attn_mask)
             >>> print(output.shape)
-            [2, 4, 128]
+            paddle.Size([2, 4, 128])
     """
 
     seed = None

--- a/python/paddle/incubate/optimizer/gradient_merge.py
+++ b/python/paddle/incubate/optimizer/gradient_merge.py
@@ -48,42 +48,60 @@ class GradientMergeOptimizer:
             the default value is `True`
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
-        >>> import paddle
-        >>> import numpy as np
-        >>> paddle.enable_static()
+            >>> import paddle
+            >>> import numpy as np
+            >>> paddle.enable_static()
 
-        >>> def gen_data(batch_size):
-        ...     return {"x": np.random.random(size=(batch_size, 32)).astype('float32'),
-        ...             "y": np.random.random(size=(batch_size, 1)).astype('int64')}
+            >>> def gen_data(batch_size):
+            ...     return {
+            ...         "x": np.random.random(size=(batch_size, 32)).astype(
+            ...             'float32'
+            ...         ),
+            ...         "y": np.random.random(size=(batch_size, 1)).astype(
+            ...             'int64'
+            ...         ),
+            ...     }
 
-        >>> def mlp(input_x, input_y, hid_dim=128, label_dim=2):
-        ...     fc_1 = paddle.static.nn.fc(x=input_x, size=hid_dim)
-        ...     prediction = paddle.static.nn.fc(x=[fc_1], size=label_dim, activation='softmax')
-        ...     cost = paddle.nn.functional.cross_entropy(
-        ...         input=prediction, label=input_y,
-        ...         reduction='none', use_softmax=False
-        ...     )
-        ...     sum_cost = paddle.mean(cost)
-        ...     return sum_cost, fc_1, prediction
+            >>> def mlp(input_x, input_y, hid_dim=128, label_dim=2):
+            ...     fc_1 = paddle.static.nn.fc(x=input_x, size=hid_dim)
+            ...     prediction = paddle.static.nn.fc(
+            ...         x=[fc_1], size=label_dim, activation='softmax'
+            ...     )
+            ...     cost = paddle.nn.functional.cross_entropy(
+            ...         input=prediction,
+            ...         label=input_y,
+            ...         reduction='none',
+            ...         use_softmax=False,
+            ...     )
+            ...     sum_cost = paddle.mean(cost)
+            ...     return sum_cost, fc_1, prediction
 
-        >>> input_x = paddle.static.data(name="x", shape=[-1,32], dtype='float32')
-        >>> input_y = paddle.static.data(name="y", shape=[-1,1], dtype='int64')
-        >>> cost, fc_1, pred = mlp(input_x, input_y)
-        >>> sgd = paddle.optimizer.Adam(learning_rate=0.01)
-        >>> sgd = paddle.incubate.optimizer.GradientMergeOptimizer(sgd, k_steps=4, avg=True)
-        >>> sgd.minimize(cost)
+            >>> input_x = paddle.static.data(
+            ...     name="x", shape=[-1, 32], dtype='float32'
+            ... )
+            >>> input_y = paddle.static.data(
+            ...     name="y", shape=[-1, 1], dtype='int64'
+            ... )
+            >>> cost, fc_1, pred = mlp(input_x, input_y)
+            >>> sgd = paddle.optimizer.Adam(learning_rate=0.01)
+            >>> sgd = paddle.incubate.optimizer.GradientMergeOptimizer(
+            ...     sgd, k_steps=4, avg=True
+            ... )
+            >>> sgd.minimize(cost)
 
-        >>> place = paddle.CPUPlace()
-        >>> exe = paddle.static.Executor(place)
-        >>> exe.run(paddle.static.default_startup_program())
+            >>> place = paddle.CPUPlace()
+            >>> exe = paddle.static.Executor(place)
+            >>> exe.run(paddle.static.default_startup_program())
 
-        >>> for i in range(10):
-        ...     cost_val = exe.run(feed=gen_data(32),
-        ...                program=paddle.static.default_main_program(),
-        ...                fetch_list=[cost.name])
-        ...     print("step=%d, cost=%f" % (i, cost_val[0]))
+            >>> for i in range(10):
+            ...     cost_val = exe.run(
+            ...         feed=gen_data(32),
+            ...         program=paddle.static.default_main_program(),
+            ...         fetch_list=[cost.name],
+            ...     )
+            ...     print("step=%d, cost=%f" % (i, cost_val[0]))
     """
 
     GRAD_MERGE_COND_NAME = "grad_merge_cond_name"

--- a/python/paddle/incubate/optimizer/gradient_merge.py
+++ b/python/paddle/incubate/optimizer/gradient_merge.py
@@ -48,7 +48,7 @@ class GradientMergeOptimizer:
             the default value is `True`
 
     Examples:
-        .. code-block:: python-console
+        .. code-block:: pycon
 
             >>> import paddle
             >>> import numpy as np

--- a/python/paddle/incubate/optimizer/gradient_merge.py
+++ b/python/paddle/incubate/optimizer/gradient_merge.py
@@ -48,7 +48,7 @@ class GradientMergeOptimizer:
             the default value is `True`
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python-console
 
             >>> import paddle
             >>> import numpy as np

--- a/python/paddle/nn/attention/sdpa.py
+++ b/python/paddle/nn/attention/sdpa.py
@@ -164,7 +164,10 @@ def sdpa_kernel(
         >>> print(out.shape)
         [2, 4, 8, 16]
         >>> # Example 3: Set priority order for multiple backends
-        >>> with sdpa_kernel([SDPBackend.MATH, SDPBackend.EFFICIENT_ATTENTION], set_priority=True):
+        >>> with sdpa_kernel(
+        ...     [SDPBackend.MATH, SDPBackend.EFFICIENT_ATTENTION],
+        ...     set_priority=True,
+        ... ):
         ...     out = scaled_dot_product_attention(query, key, value)
         >>> print(out.shape)
         [2, 4, 8, 16]

--- a/python/paddle/pir/math_op_patch.py
+++ b/python/paddle/pir/math_op_patch.py
@@ -604,18 +604,19 @@ def monkey_patch_value():
             Tensor, the number of elements for current Tensor
 
         Examples:
-            .. code-block:: python
+            .. code-block:: pycon
 
-            >>> import paddle
-            >>> paddle.enable_static()
-            >>> startup_prog = paddle.static.Program()
-            >>> main_prog = paddle.static.Program()
-            >>> with paddle.static.program_guard(startup_prog, main_prog):
-            ...     x = paddle.assign(np.random.rand(2, 3, 4).astype("float32"))
-            ...     (output_x,) = exe.run(main_program, fetch_list=[x.size])
-            ...     print(f"value's size is: {output_x}")
-            ...
-            value's size is: 24
+                >>> import paddle
+                >>> paddle.enable_static()
+                >>> startup_prog = paddle.static.Program()
+                >>> main_prog = paddle.static.Program()
+                >>> with paddle.static.program_guard(startup_prog, main_prog):
+                ...     x = paddle.assign(
+                ...         np.random.rand(2, 3, 4).astype("float32")
+                ...     )
+                ...     (output_x,) = exe.run(main_program, fetch_list=[x.size])
+                ...     print(f"value's size is: {output_x}")
+                value's size is: 24
         """
         return paddle.numel(self)
 

--- a/python/paddle/pir/math_op_patch.py
+++ b/python/paddle/pir/math_op_patch.py
@@ -604,7 +604,7 @@ def monkey_patch_value():
             Tensor, the number of elements for current Tensor
 
         Examples:
-            .. code-block:: python-console
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> paddle.enable_static()

--- a/python/paddle/pir/math_op_patch.py
+++ b/python/paddle/pir/math_op_patch.py
@@ -604,7 +604,7 @@ def monkey_patch_value():
             Tensor, the number of elements for current Tensor
 
         Examples:
-            .. code-block:: pycon
+            .. code-block:: python-console
 
                 >>> import paddle
                 >>> paddle.enable_static()

--- a/python/paddle/quantization/config.py
+++ b/python/paddle/quantization/config.py
@@ -220,12 +220,14 @@ class QuantConfig:
             weight(QuanterFactory | None): Quanter used for weights. Default is None.
 
         Examples:
-            .. code-block:: python
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> from paddle.nn import Linear
                 >>> from paddle.quantization import QuantConfig
-                >>> from paddle.quantization.quanters import FakeQuanterWithAbsMaxObserver
+                >>> from paddle.quantization.quanters import (
+                ...     FakeQuanterWithAbsMaxObserver,
+                ... )
 
                 >>> class Model(paddle.nn.Layer):
                 ...     def __init__(self):
@@ -234,7 +236,9 @@ class QuantConfig:
                 >>> model = Model()
                 >>> quanter = FakeQuanterWithAbsMaxObserver(moving_rate=0.9)
                 >>> q_config = QuantConfig(activation=None, weight=None)
-                >>> q_config.add_type_config([Linear], activation=quanter, weight=quanter)
+                >>> q_config.add_type_config(
+                ...     [Linear], activation=quanter, weight=quanter
+                ... )
                 >>> # doctest: +SKIP('random memory address')
                 >>> print(q_config)
                 Global config:
@@ -269,19 +273,23 @@ class QuantConfig:
             target(type[Layer]): The type of layers that will be converted to.
 
         Examples:
-            .. code-block:: python
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> from paddle.nn import Conv2D
                 >>> from paddle.quantization import QuantConfig
-                >>> from paddle.quantization.quanters import FakeQuanterWithAbsMaxObserver
+                >>> from paddle.quantization.quanters import (
+                ...     FakeQuanterWithAbsMaxObserver,
+                ... )
                 >>> quanter = FakeQuanterWithAbsMaxObserver(moving_rate=0.9)
                 >>> q_config = QuantConfig(activation=None, weight=None)
                 >>> class CustomizedQuantedConv2D(paddle.nn.Layer):
                 ...     def forward(self, x):
                 ...         pass
                 ...         # add some code for quantization simulation
-                >>> q_config.add_qat_layer_mapping(Conv2D, CustomizedQuantedConv2D)
+                >>> q_config.add_qat_layer_mapping(
+                ...     Conv2D, CustomizedQuantedConv2D
+                ... )
         """
         assert isinstance(source, type) and issubclass(
             source, paddle.nn.Layer

--- a/python/paddle/quantization/config.py
+++ b/python/paddle/quantization/config.py
@@ -220,7 +220,7 @@ class QuantConfig:
             weight(QuanterFactory | None): Quanter used for weights. Default is None.
 
         Examples:
-            .. code-block:: pycon
+            .. code-block:: python-console
 
                 >>> import paddle
                 >>> from paddle.nn import Linear
@@ -273,7 +273,7 @@ class QuantConfig:
             target(type[Layer]): The type of layers that will be converted to.
 
         Examples:
-            .. code-block:: pycon
+            .. code-block:: python-console
 
                 >>> import paddle
                 >>> from paddle.nn import Conv2D

--- a/python/paddle/quantization/config.py
+++ b/python/paddle/quantization/config.py
@@ -220,7 +220,7 @@ class QuantConfig:
             weight(QuanterFactory | None): Quanter used for weights. Default is None.
 
         Examples:
-            .. code-block:: python-console
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> from paddle.nn import Linear
@@ -273,7 +273,7 @@ class QuantConfig:
             target(type[Layer]): The type of layers that will be converted to.
 
         Examples:
-            .. code-block:: python-console
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> from paddle.nn import Conv2D

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -813,7 +813,11 @@ def shard_index(
     following formula:
     ::
 
-        v = v - shard_id * shard_size if shard_id * shard_size <= v < (shard_id+1) * shard_size else ignore_value
+        v = (
+            v - shard_id * shard_size
+            if shard_id * shard_size <= v < (shard_id + 1) * shard_size
+            else ignore_value
+        )
 
     That is, the value `v` is set to the new offset within the range represented by the shard `shard_id`
     if it in the range. Otherwise, we reset it to be `ignore_value`.

--- a/python/paddle/tensorrt/export.py
+++ b/python/paddle/tensorrt/export.py
@@ -144,17 +144,19 @@ class Input:
             tuple(numpy.ndarray, numpy.ndarray, numpy.ndarray): A tuple containing the generated input data for the minimum, optimal, and maximum shapes.
 
         Examples:
-            .. code-block:: python
+            .. code-block:: pycon
 
-            >>> from paddle.tensorrt.export import Input
-            >>> input_config = Input(
-            >>>     min_input_shape=(1,100),
-            >>>     optim_input_shape=(4,100),
-            >>>     max_input_shape=(8,100),
-            >>> )
-            >>> input.input_data_type='int64'
-            >>> input.input_range=(1,10)
-            >>> input_min_data, input_optim_data, input_max_data = input_config.generate_input_data()
+                >>> from paddle.tensorrt.export import Input
+                >>> input_config = Input(
+                >>>     min_input_shape=(1,100),
+                >>>     optim_input_shape=(4,100),
+                >>>     max_input_shape=(8,100),
+                >>> )
+                >>> input.input_data_type = 'int64'
+                >>> input.input_range = (1, 10)
+                >>> input_min_data, input_optim_data, input_max_data = (
+                ...     input_config.generate_input_data()
+                ... )
         """
         if self.warmup_data is not None:
             raise RuntimeError(
@@ -280,41 +282,42 @@ class TensorRTConfig:
             None
 
         Examples:
-            .. code-block:: python
-            >>> # example 1:
-            >>> from paddle.tensorrt.export import (
-            >>>    Input,
-            >>>    TensorRTConfig,
-            >>>    PrecisionMode,
-            >>> )
-            >>> input_config = Input(
-            >>>     min_input_shape=(1,100),
-            >>>     optim_input_shape=(4,100),
-            >>>     max_input_shape=(8,100),
-            >>> )
-            >>> input_config.input_data_type='int64'
-            >>> input_config.input_range=(1,10)
+            .. code-block:: pycon
 
-            >>> trt_config = TensorRTConfig(inputs=[input_config])
-            >>> trt_config.disable_ops = ["pd_op.dropout"]
-            >>> trt_config.precision_mode = PrecisionMode.FP16
-            >>> trt_config.ops_run_float = "pd_op.conv2d"
-            >>> trt_config.workspace_size = 1 << 32
+                >>> # example 1:
+                >>> from paddle.tensorrt.export import (
+                >>>    Input,
+                >>>    TensorRTConfig,
+                >>>    PrecisionMode,
+                >>> )
+                >>> input_config = Input(
+                >>>     min_input_shape=(1,100),
+                >>>     optim_input_shape=(4,100),
+                >>>     max_input_shape=(8,100),
+                >>> )
+                >>> input_config.input_data_type = 'int64'
+                >>> input_config.input_range = (1, 10)
 
-            >>> # example 2:
-            >>> from paddle.tensorrt.export import (
-            >>>     Input,
-            >>>     TensorRTConfig,
-            >>>     PrecisionMode,
-            >>> )
-            >>> input_config = Input(
-            >>>     warmup_data=(
-            >>>         np.random.rand(1,100).astype(np.float32),
-            >>>         np.random.rand(4,100).astype(np.float32),
-            >>>         np.random.rand(8,100).astype(np.float32),
-            >>>     )
-            >>> )
-            >>> trt_config = TensorRTConfig(inputs=[input_config])
+                >>> trt_config = TensorRTConfig(inputs=[input_config])
+                >>> trt_config.disable_ops = ["pd_op.dropout"]
+                >>> trt_config.precision_mode = PrecisionMode.FP16
+                >>> trt_config.ops_run_float = "pd_op.conv2d"
+                >>> trt_config.workspace_size = 1 << 32
+
+                >>> # example 2:
+                >>> from paddle.tensorrt.export import (
+                >>>     Input,
+                >>>     TensorRTConfig,
+                >>>     PrecisionMode,
+                >>> )
+                >>> input_config = Input(
+                >>>     warmup_data=(
+                >>>         np.random.rand(1,100).astype(np.float32),
+                >>>         np.random.rand(4,100).astype(np.float32),
+                >>>         np.random.rand(8,100).astype(np.float32),
+                >>>     )
+                >>> )
+                >>> trt_config = TensorRTConfig(inputs=[input_config])
         """
         # Checking Input Consistency
         has_input_data = [i.warmup_data is not None for i in inputs]

--- a/python/paddle/tensorrt/export.py
+++ b/python/paddle/tensorrt/export.py
@@ -144,7 +144,7 @@ class Input:
             tuple(numpy.ndarray, numpy.ndarray, numpy.ndarray): A tuple containing the generated input data for the minimum, optimal, and maximum shapes.
 
         Examples:
-            .. code-block:: python-console
+            .. code-block:: pycon
 
                 >>> from paddle.tensorrt.export import Input
                 >>> input_config = Input(
@@ -282,7 +282,7 @@ class TensorRTConfig:
             None
 
         Examples:
-            .. code-block:: python-console
+            .. code-block:: pycon
 
                 >>> # example 1:
                 >>> from paddle.tensorrt.export import (

--- a/python/paddle/tensorrt/export.py
+++ b/python/paddle/tensorrt/export.py
@@ -144,7 +144,7 @@ class Input:
             tuple(numpy.ndarray, numpy.ndarray, numpy.ndarray): A tuple containing the generated input data for the minimum, optimal, and maximum shapes.
 
         Examples:
-            .. code-block:: pycon
+            .. code-block:: python-console
 
                 >>> from paddle.tensorrt.export import Input
                 >>> input_config = Input(
@@ -282,7 +282,7 @@ class TensorRTConfig:
             None
 
         Examples:
-            .. code-block:: pycon
+            .. code-block:: python-console
 
                 >>> # example 1:
                 >>> from paddle.tensorrt.export import (

--- a/test/legacy_test/nets.py
+++ b/test/legacy_test/nets.py
@@ -104,18 +104,23 @@ def simple_img_conv_pool(
         Variable
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
-            import paddle.base as base
-            import paddle
-            paddle.enable_static()
-            img = paddle.static.data(name='img', shape=[100, 1, 28, 28], dtype='float32')
-            conv_pool = base.nets.simple_img_conv_pool(input=img,
-                                                        filter_size=5,
-                                                        num_filters=20,
-                                                        pool_size=2,
-                                                        pool_stride=2,
-                                                        act="relu")
+            >>> import paddle.base as base
+            >>> import paddle
+
+            >>> paddle.enable_static()
+            >>> img = paddle.static.data(
+            ...     name='img', shape=[100, 1, 28, 28], dtype='float32'
+            ... )
+            >>> conv_pool = base.nets.simple_img_conv_pool(
+            ...     input=img,
+            ...     filter_size=5,
+            ...     num_filters=20,
+            ...     pool_size=2,
+            ...     pool_stride=2,
+            ...     act="relu",
+            ... )
     """
     conv_out = paddle.static.nn.conv2d(
         input=input,
@@ -210,16 +215,21 @@ def img_conv_group(
 
             import paddle.base as base
             import paddle
+
             paddle.enable_static()
 
-            img = paddle.static.data(name='img', shape=[None, 1, 28, 28], dtype='float32')
-            conv_pool = base.nets.img_conv_group(input=img,
-                                                  conv_padding=1,
-                                                  conv_num_filter=[3, 3],
-                                                  conv_filter_size=3,
-                                                  conv_act="relu",
-                                                  pool_size=2,
-                                                  pool_stride=2)
+            img = paddle.static.data(
+                name='img', shape=[None, 1, 28, 28], dtype='float32'
+            )
+            conv_pool = base.nets.img_conv_group(
+                input=img,
+                conv_padding=1,
+                conv_num_filter=[3, 3],
+                conv_filter_size=3,
+                conv_act="relu",
+                pool_size=2,
+                pool_stride=2,
+            )
     """
     tmp = input
     assert isinstance(conv_num_filter, (list, tuple))
@@ -322,17 +332,24 @@ def sequence_conv_pool(
 
             import paddle.base as base
             import paddle
+
             paddle.enable_static()
-            input_dim = 100 #len(word_dict)
+            input_dim = 100  # len(word_dict)
             emb_dim = 128
             hid_dim = 512
-            data = paddle.static.data(name="words", shape=[None, 1], dtype="int64")
-            emb = paddle.static.nn.embedding(input=data, size=[input_dim, emb_dim], is_sparse=True)
-            seq_conv = base.nets.sequence_conv_pool(input=emb,
-                                                     num_filters=hid_dim,
-                                                     filter_size=3,
-                                                     act="tanh",
-                                                     pool_type="sqrt")
+            data = paddle.static.data(
+                name="words", shape=[None, 1], dtype="int64"
+            )
+            emb = paddle.static.nn.embedding(
+                input=data, size=[input_dim, emb_dim], is_sparse=True
+            )
+            seq_conv = base.nets.sequence_conv_pool(
+                input=emb,
+                num_filters=hid_dim,
+                filter_size=3,
+                act="tanh",
+                pool_type="sqrt",
+            )
     """
 
     check_variable_and_dtype(input, 'input', ['float32', 'float64'], 'input')
@@ -384,10 +401,12 @@ def glu(input, dim=-1):
 
             import paddle.base as base
             import paddle
+
             paddle.enable_static()
 
             data = paddle.static.data(
-                name="words", shape=[-1, 6, 3, 9], dtype="float32")
+                name="words", shape=[-1, 6, 3, 9], dtype="float32"
+            )
             # shape of output: [-1, 3, 3, 9]
             output = base.nets.glu(input=data, dim=1)
     """

--- a/test/legacy_test/nets.py
+++ b/test/legacy_test/nets.py
@@ -104,7 +104,7 @@ def simple_img_conv_pool(
         Variable
 
     Examples:
-        .. code-block:: python-console
+        .. code-block:: pycon
 
             >>> import paddle.base as base
             >>> import paddle

--- a/test/legacy_test/nets.py
+++ b/test/legacy_test/nets.py
@@ -104,7 +104,7 @@ def simple_img_conv_pool(
         Variable
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python-console
 
             >>> import paddle.base as base
             >>> import paddle

--- a/test/tools/test_sampcd_processor.py
+++ b/test/tools/test_sampcd_processor.py
@@ -212,7 +212,7 @@ class TestXdoctester(unittest.TestCase):
         docstring_input = """
             placeholder
 
-            .. code-block:: python
+            .. code-block:: pycon
                 :name: code-example-0
 
                 this is some blabla...
@@ -223,7 +223,7 @@ class TestXdoctester(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -232,7 +232,7 @@ class TestXdoctester(unittest.TestCase):
                     >>> print(1-1)
                     0
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-2
 
                     this is some blabla...
@@ -245,7 +245,7 @@ class TestXdoctester(unittest.TestCase):
         docstring_target = """
             placeholder
 
-            .. code-block:: python
+            .. code-block:: pycon
                 :name: code-example-0
 
                 this is some blabla...
@@ -256,7 +256,7 @@ class TestXdoctester(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -265,7 +265,7 @@ class TestXdoctester(unittest.TestCase):
                     >>> print(1-1)
                     0
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-2
 
                     this is some blabla...
@@ -306,7 +306,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -322,7 +322,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -339,7 +339,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -409,7 +409,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -423,7 +423,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -438,7 +438,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -517,7 +517,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -536,7 +536,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -555,7 +555,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -574,7 +574,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -592,7 +592,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -615,7 +615,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -713,7 +713,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -731,7 +731,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -749,7 +749,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -767,7 +767,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -784,7 +784,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -803,7 +803,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -822,7 +822,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -867,7 +867,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -887,7 +887,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -907,7 +907,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -921,7 +921,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -935,7 +935,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -949,7 +949,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -963,7 +963,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -977,7 +977,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -1142,7 +1142,7 @@ class TestGetTestResults(unittest.TestCase):
             'one_plus_one': """
             placeholder
 
-            .. code-block:: python
+            .. code-block:: pycon
                 :name: code-example-0
 
                 this is some blabla...
@@ -1153,7 +1153,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -1165,7 +1165,7 @@ class TestGetTestResults(unittest.TestCase):
             'one_minus_one': """
             placeholder
 
-            .. code-block:: python
+            .. code-block:: pycon
                 :name: code-example-0
 
                 this is some blabla...
@@ -1175,7 +1175,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -1230,7 +1230,7 @@ class TestGetTestResults(unittest.TestCase):
             'one_plus_one': """
             placeholder
 
-            .. code-block:: python
+            .. code-block:: pycon
                 :name: code-example-0
 
                 this is some blabla...
@@ -1241,7 +1241,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -1253,7 +1253,7 @@ class TestGetTestResults(unittest.TestCase):
             'one_minus_one': """
             placeholder
 
-            .. code-block:: python
+            .. code-block:: pycon
                 :name: code-example-0
 
                 this is some blabla...
@@ -1263,7 +1263,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -1318,7 +1318,7 @@ class TestGetTestResults(unittest.TestCase):
             'one_plus_one': """
             placeholder
 
-            .. code-block:: python
+            .. code-block:: pycon
                 :name: code-example-0
 
                 this is some blabla...
@@ -1329,7 +1329,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -1341,7 +1341,7 @@ class TestGetTestResults(unittest.TestCase):
             'one_minus_one': """
             placeholder
 
-            .. code-block:: python
+            .. code-block:: pycon
                 :name: code-example-0
 
                 this is some blabla...
@@ -1351,7 +1351,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -1406,7 +1406,7 @@ class TestGetTestResults(unittest.TestCase):
             'one_plus_one': """
             placeholder
 
-            .. code-block:: python
+            .. code-block:: pycon
                 :name: code-example-0
 
                 this is some blabla...
@@ -1417,7 +1417,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -1428,7 +1428,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-2
 
                     >>> print(1+2)
@@ -1439,7 +1439,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -1450,7 +1450,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-2
 
                     >>> print(1+1)
@@ -1541,7 +1541,7 @@ class TestGetTestResults(unittest.TestCase):
             'one_plus_one': """
             placeholder
 
-            .. code-block:: python
+            .. code-block:: pycon
                 :name: code-example-0
 
                 this is some blabla...
@@ -1552,7 +1552,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -1563,7 +1563,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-2
 
                     >>> print(1+2)
@@ -1574,7 +1574,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -1585,7 +1585,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-2
 
                     >>> print(1+1)
@@ -1622,7 +1622,7 @@ class TestGetTestResults(unittest.TestCase):
             'one_plus_one': """
             placeholder
 
-            .. code-block:: python
+            .. code-block:: pycon
                 :name: code-example-0
 
                 this is some blabla...
@@ -1633,7 +1633,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -1646,7 +1646,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-2
 
                     >>> print(1+2)
@@ -1657,7 +1657,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -1668,7 +1668,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-2
 
                     >>> print(1+1)
@@ -1727,7 +1727,7 @@ class TestGetTestResults(unittest.TestCase):
             'one_plus_one': """
             placeholder
 
-            .. code-block:: python
+            .. code-block:: pycon
                 :name: code-example-0
 
                 this is some blabla...
@@ -1822,7 +1822,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
 
                     >>> import numpy as np
                     >>> import paddle
@@ -1834,7 +1834,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
 
                     >>> import numpy as np
                     >>> import paddle
@@ -1868,7 +1868,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
 
                     >>> # doctest: +TIMEOUT(10)
                     >>> import time
@@ -1879,7 +1879,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
 
                     >>> # doctest: +TIMEOUT(10)
                     >>> import time
@@ -1890,7 +1890,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
 
                     >>> # doctest: +TIMEOUT(10)
                     >>> # doctest: +SKIP('skip')
@@ -1902,7 +1902,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
 
                     >>> # doctest: +SKIP('skip')
                     >>> # doctest: +TIMEOUT(10)
@@ -1914,7 +1914,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
 
                     >>> # doctest: +TIMEOUT(10)
                     >>> # doctest: +SKIP('skip')
@@ -1926,7 +1926,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
 
                     >>> # doctest: +SKIP('skip')
                     >>> # doctest: +TIMEOUT(10)
@@ -1938,13 +1938,13 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
 
                     >>> # doctest: +TIMEOUT(10)
                     >>> import time
                     >>> time.sleep(0.1)
 
-                .. code-block:: python
+                .. code-block:: pycon
 
                     >>> # doctest: +TIMEOUT(10)
                     >>> import time
@@ -2054,7 +2054,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
 
                     >>> import paddle.base
             """,
@@ -2063,7 +2063,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
 
                     >>> import paddle
                     >>> from paddle import fluid
@@ -2073,7 +2073,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
 
                     >>> # doctest: +SKIP('reason')
                     >>> import os
@@ -2083,7 +2083,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
 
                     >>> # doctest: +SKIP('reason')
                     >>> import os
@@ -2094,7 +2094,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
 
                     >>> # doctest: +SKIP('reason')
                     >>> import os
@@ -2107,7 +2107,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
 
                     >>> # doctest: +SKIP('reason')
                     >>> import os
@@ -2119,7 +2119,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
 
                     >>> # doctest: +SKIP
                     >>> import os
@@ -2130,7 +2130,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
 
                     >>> import os
                     >>> # doctest: +SKIP()
@@ -2141,7 +2141,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
 
                     >>> import os
                     >>> # doctest: +SKIP('reason')
@@ -2154,7 +2154,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
 
                     >>> # import paddle.base
                     >>> import os
@@ -2164,7 +2164,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
 
                     >>> import os # doctest: +SKIP
                     >>> import sys
@@ -2246,7 +2246,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
 
                     >>> import sys
                     >>> # required: GPU
@@ -2257,7 +2257,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
 
                     >>> import sys
                     >>> # requires: GPU
@@ -2268,7 +2268,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
 
                     >>> import sys
                     >>> # require   :   GPU
@@ -2279,7 +2279,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
 
                     >>> import sys
                     >>> # require: GPU, xpu
@@ -2290,7 +2290,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
 
                     >>> import sys
                     >>> #require:gpu
@@ -2301,7 +2301,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
 
                     >>> import sys
                     >>> #require:
@@ -2312,7 +2312,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
 
                     >>> import sys
                     >>> #require: xpu
@@ -2384,7 +2384,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -2405,7 +2405,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...

--- a/test/tools/test_sampcd_processor.py
+++ b/test/tools/test_sampcd_processor.py
@@ -212,7 +212,7 @@ class TestXdoctester(unittest.TestCase):
         docstring_input = """
             placeholder
 
-            .. code-block:: python-console
+            .. code-block:: pycon
                 :name: code-example-0
 
                 this is some blabla...
@@ -223,7 +223,7 @@ class TestXdoctester(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -232,7 +232,7 @@ class TestXdoctester(unittest.TestCase):
                     >>> print(1-1)
                     0
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-2
 
                     this is some blabla...
@@ -245,7 +245,7 @@ class TestXdoctester(unittest.TestCase):
         docstring_target = """
             placeholder
 
-            .. code-block:: python-console
+            .. code-block:: pycon
                 :name: code-example-0
 
                 this is some blabla...
@@ -256,7 +256,7 @@ class TestXdoctester(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -265,7 +265,7 @@ class TestXdoctester(unittest.TestCase):
                     >>> print(1-1)
                     0
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-2
 
                     this is some blabla...
@@ -306,7 +306,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -322,7 +322,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -339,7 +339,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -409,7 +409,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -423,7 +423,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -438,7 +438,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -517,7 +517,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -536,7 +536,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -555,7 +555,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -574,7 +574,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -592,7 +592,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -615,7 +615,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -713,7 +713,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -731,7 +731,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -749,7 +749,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -767,7 +767,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -784,7 +784,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -803,7 +803,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -822,7 +822,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -867,7 +867,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -887,7 +887,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -907,7 +907,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -921,7 +921,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -935,7 +935,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -949,7 +949,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -963,7 +963,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -977,7 +977,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -1142,7 +1142,7 @@ class TestGetTestResults(unittest.TestCase):
             'one_plus_one': """
             placeholder
 
-            .. code-block:: python-console
+            .. code-block:: pycon
                 :name: code-example-0
 
                 this is some blabla...
@@ -1153,7 +1153,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -1165,7 +1165,7 @@ class TestGetTestResults(unittest.TestCase):
             'one_minus_one': """
             placeholder
 
-            .. code-block:: python-console
+            .. code-block:: pycon
                 :name: code-example-0
 
                 this is some blabla...
@@ -1175,7 +1175,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -1230,7 +1230,7 @@ class TestGetTestResults(unittest.TestCase):
             'one_plus_one': """
             placeholder
 
-            .. code-block:: python-console
+            .. code-block:: pycon
                 :name: code-example-0
 
                 this is some blabla...
@@ -1241,7 +1241,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -1253,7 +1253,7 @@ class TestGetTestResults(unittest.TestCase):
             'one_minus_one': """
             placeholder
 
-            .. code-block:: python-console
+            .. code-block:: pycon
                 :name: code-example-0
 
                 this is some blabla...
@@ -1263,7 +1263,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -1318,7 +1318,7 @@ class TestGetTestResults(unittest.TestCase):
             'one_plus_one': """
             placeholder
 
-            .. code-block:: python-console
+            .. code-block:: pycon
                 :name: code-example-0
 
                 this is some blabla...
@@ -1329,7 +1329,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -1341,7 +1341,7 @@ class TestGetTestResults(unittest.TestCase):
             'one_minus_one': """
             placeholder
 
-            .. code-block:: python-console
+            .. code-block:: pycon
                 :name: code-example-0
 
                 this is some blabla...
@@ -1351,7 +1351,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -1406,7 +1406,7 @@ class TestGetTestResults(unittest.TestCase):
             'one_plus_one': """
             placeholder
 
-            .. code-block:: python-console
+            .. code-block:: pycon
                 :name: code-example-0
 
                 this is some blabla...
@@ -1417,7 +1417,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -1428,7 +1428,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-2
 
                     >>> print(1+2)
@@ -1439,7 +1439,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -1450,7 +1450,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-2
 
                     >>> print(1+1)
@@ -1541,7 +1541,7 @@ class TestGetTestResults(unittest.TestCase):
             'one_plus_one': """
             placeholder
 
-            .. code-block:: python-console
+            .. code-block:: pycon
                 :name: code-example-0
 
                 this is some blabla...
@@ -1552,7 +1552,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -1563,7 +1563,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-2
 
                     >>> print(1+2)
@@ -1574,7 +1574,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -1585,7 +1585,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-2
 
                     >>> print(1+1)
@@ -1622,7 +1622,7 @@ class TestGetTestResults(unittest.TestCase):
             'one_plus_one': """
             placeholder
 
-            .. code-block:: python-console
+            .. code-block:: pycon
                 :name: code-example-0
 
                 this is some blabla...
@@ -1633,7 +1633,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -1646,7 +1646,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-2
 
                     >>> print(1+2)
@@ -1657,7 +1657,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -1668,7 +1668,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-2
 
                     >>> print(1+1)
@@ -1727,7 +1727,7 @@ class TestGetTestResults(unittest.TestCase):
             'one_plus_one': """
             placeholder
 
-            .. code-block:: python-console
+            .. code-block:: pycon
                 :name: code-example-0
 
                 this is some blabla...
@@ -1822,7 +1822,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
 
                     >>> import numpy as np
                     >>> import paddle
@@ -1834,7 +1834,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
 
                     >>> import numpy as np
                     >>> import paddle
@@ -1868,7 +1868,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
 
                     >>> # doctest: +TIMEOUT(10)
                     >>> import time
@@ -1879,7 +1879,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
 
                     >>> # doctest: +TIMEOUT(10)
                     >>> import time
@@ -1890,7 +1890,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
 
                     >>> # doctest: +TIMEOUT(10)
                     >>> # doctest: +SKIP('skip')
@@ -1902,7 +1902,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
 
                     >>> # doctest: +SKIP('skip')
                     >>> # doctest: +TIMEOUT(10)
@@ -1914,7 +1914,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
 
                     >>> # doctest: +TIMEOUT(10)
                     >>> # doctest: +SKIP('skip')
@@ -1926,7 +1926,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
 
                     >>> # doctest: +SKIP('skip')
                     >>> # doctest: +TIMEOUT(10)
@@ -1938,13 +1938,13 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
 
                     >>> # doctest: +TIMEOUT(10)
                     >>> import time
                     >>> time.sleep(0.1)
 
-                .. code-block:: python-console
+                .. code-block:: pycon
 
                     >>> # doctest: +TIMEOUT(10)
                     >>> import time
@@ -2054,7 +2054,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
 
                     >>> import paddle.base
             """,
@@ -2063,7 +2063,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
 
                     >>> import paddle
                     >>> from paddle import fluid
@@ -2073,7 +2073,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
 
                     >>> # doctest: +SKIP('reason')
                     >>> import os
@@ -2083,7 +2083,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
 
                     >>> # doctest: +SKIP('reason')
                     >>> import os
@@ -2094,7 +2094,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
 
                     >>> # doctest: +SKIP('reason')
                     >>> import os
@@ -2107,7 +2107,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
 
                     >>> # doctest: +SKIP('reason')
                     >>> import os
@@ -2119,7 +2119,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
 
                     >>> # doctest: +SKIP
                     >>> import os
@@ -2130,7 +2130,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
 
                     >>> import os
                     >>> # doctest: +SKIP()
@@ -2141,7 +2141,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
 
                     >>> import os
                     >>> # doctest: +SKIP('reason')
@@ -2154,7 +2154,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
 
                     >>> # import paddle.base
                     >>> import os
@@ -2164,7 +2164,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
 
                     >>> import os # doctest: +SKIP
                     >>> import sys
@@ -2246,7 +2246,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
 
                     >>> import sys
                     >>> # required: GPU
@@ -2257,7 +2257,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
 
                     >>> import sys
                     >>> # requires: GPU
@@ -2268,7 +2268,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
 
                     >>> import sys
                     >>> # require   :   GPU
@@ -2279,7 +2279,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
 
                     >>> import sys
                     >>> # require: GPU, xpu
@@ -2290,7 +2290,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
 
                     >>> import sys
                     >>> #require:gpu
@@ -2301,7 +2301,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
 
                     >>> import sys
                     >>> #require:
@@ -2312,7 +2312,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
 
                     >>> import sys
                     >>> #require: xpu
@@ -2384,7 +2384,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -2405,7 +2405,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...

--- a/test/tools/test_sampcd_processor.py
+++ b/test/tools/test_sampcd_processor.py
@@ -212,7 +212,7 @@ class TestXdoctester(unittest.TestCase):
         docstring_input = """
             placeholder
 
-            .. code-block:: pycon
+            .. code-block:: python-console
                 :name: code-example-0
 
                 this is some blabla...
@@ -223,7 +223,7 @@ class TestXdoctester(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -232,7 +232,7 @@ class TestXdoctester(unittest.TestCase):
                     >>> print(1-1)
                     0
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-2
 
                     this is some blabla...
@@ -245,7 +245,7 @@ class TestXdoctester(unittest.TestCase):
         docstring_target = """
             placeholder
 
-            .. code-block:: pycon
+            .. code-block:: python-console
                 :name: code-example-0
 
                 this is some blabla...
@@ -256,7 +256,7 @@ class TestXdoctester(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -265,7 +265,7 @@ class TestXdoctester(unittest.TestCase):
                     >>> print(1-1)
                     0
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-2
 
                     this is some blabla...
@@ -306,7 +306,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -322,7 +322,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -339,7 +339,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -409,7 +409,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -423,7 +423,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -438,7 +438,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -517,7 +517,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -536,7 +536,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -555,7 +555,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -574,7 +574,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -592,7 +592,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -615,7 +615,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -713,7 +713,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -731,7 +731,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -749,7 +749,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -767,7 +767,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -784,7 +784,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -803,7 +803,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -822,7 +822,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -867,7 +867,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -887,7 +887,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -907,7 +907,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -921,7 +921,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -935,7 +935,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -949,7 +949,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -963,7 +963,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -977,7 +977,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -1142,7 +1142,7 @@ class TestGetTestResults(unittest.TestCase):
             'one_plus_one': """
             placeholder
 
-            .. code-block:: pycon
+            .. code-block:: python-console
                 :name: code-example-0
 
                 this is some blabla...
@@ -1153,7 +1153,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -1165,7 +1165,7 @@ class TestGetTestResults(unittest.TestCase):
             'one_minus_one': """
             placeholder
 
-            .. code-block:: pycon
+            .. code-block:: python-console
                 :name: code-example-0
 
                 this is some blabla...
@@ -1175,7 +1175,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -1230,7 +1230,7 @@ class TestGetTestResults(unittest.TestCase):
             'one_plus_one': """
             placeholder
 
-            .. code-block:: pycon
+            .. code-block:: python-console
                 :name: code-example-0
 
                 this is some blabla...
@@ -1241,7 +1241,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -1253,7 +1253,7 @@ class TestGetTestResults(unittest.TestCase):
             'one_minus_one': """
             placeholder
 
-            .. code-block:: pycon
+            .. code-block:: python-console
                 :name: code-example-0
 
                 this is some blabla...
@@ -1263,7 +1263,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -1318,7 +1318,7 @@ class TestGetTestResults(unittest.TestCase):
             'one_plus_one': """
             placeholder
 
-            .. code-block:: pycon
+            .. code-block:: python-console
                 :name: code-example-0
 
                 this is some blabla...
@@ -1329,7 +1329,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -1341,7 +1341,7 @@ class TestGetTestResults(unittest.TestCase):
             'one_minus_one': """
             placeholder
 
-            .. code-block:: pycon
+            .. code-block:: python-console
                 :name: code-example-0
 
                 this is some blabla...
@@ -1351,7 +1351,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -1406,7 +1406,7 @@ class TestGetTestResults(unittest.TestCase):
             'one_plus_one': """
             placeholder
 
-            .. code-block:: pycon
+            .. code-block:: python-console
                 :name: code-example-0
 
                 this is some blabla...
@@ -1417,7 +1417,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -1428,7 +1428,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-2
 
                     >>> print(1+2)
@@ -1439,7 +1439,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -1450,7 +1450,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-2
 
                     >>> print(1+1)
@@ -1541,7 +1541,7 @@ class TestGetTestResults(unittest.TestCase):
             'one_plus_one': """
             placeholder
 
-            .. code-block:: pycon
+            .. code-block:: python-console
                 :name: code-example-0
 
                 this is some blabla...
@@ -1552,7 +1552,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -1563,7 +1563,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-2
 
                     >>> print(1+2)
@@ -1574,7 +1574,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -1585,7 +1585,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-2
 
                     >>> print(1+1)
@@ -1622,7 +1622,7 @@ class TestGetTestResults(unittest.TestCase):
             'one_plus_one': """
             placeholder
 
-            .. code-block:: pycon
+            .. code-block:: python-console
                 :name: code-example-0
 
                 this is some blabla...
@@ -1633,7 +1633,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -1646,7 +1646,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-2
 
                     >>> print(1+2)
@@ -1657,7 +1657,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -1668,7 +1668,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-2
 
                     >>> print(1+1)
@@ -1727,7 +1727,7 @@ class TestGetTestResults(unittest.TestCase):
             'one_plus_one': """
             placeholder
 
-            .. code-block:: pycon
+            .. code-block:: python-console
                 :name: code-example-0
 
                 this is some blabla...
@@ -1822,7 +1822,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
 
                     >>> import numpy as np
                     >>> import paddle
@@ -1834,7 +1834,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
 
                     >>> import numpy as np
                     >>> import paddle
@@ -1868,7 +1868,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
 
                     >>> # doctest: +TIMEOUT(10)
                     >>> import time
@@ -1879,7 +1879,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
 
                     >>> # doctest: +TIMEOUT(10)
                     >>> import time
@@ -1890,7 +1890,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
 
                     >>> # doctest: +TIMEOUT(10)
                     >>> # doctest: +SKIP('skip')
@@ -1902,7 +1902,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
 
                     >>> # doctest: +SKIP('skip')
                     >>> # doctest: +TIMEOUT(10)
@@ -1914,7 +1914,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
 
                     >>> # doctest: +TIMEOUT(10)
                     >>> # doctest: +SKIP('skip')
@@ -1926,7 +1926,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
 
                     >>> # doctest: +SKIP('skip')
                     >>> # doctest: +TIMEOUT(10)
@@ -1938,13 +1938,13 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
 
                     >>> # doctest: +TIMEOUT(10)
                     >>> import time
                     >>> time.sleep(0.1)
 
-                .. code-block:: pycon
+                .. code-block:: python-console
 
                     >>> # doctest: +TIMEOUT(10)
                     >>> import time
@@ -2054,7 +2054,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
 
                     >>> import paddle.base
             """,
@@ -2063,7 +2063,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
 
                     >>> import paddle
                     >>> from paddle import fluid
@@ -2073,7 +2073,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
 
                     >>> # doctest: +SKIP('reason')
                     >>> import os
@@ -2083,7 +2083,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
 
                     >>> # doctest: +SKIP('reason')
                     >>> import os
@@ -2094,7 +2094,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
 
                     >>> # doctest: +SKIP('reason')
                     >>> import os
@@ -2107,7 +2107,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
 
                     >>> # doctest: +SKIP('reason')
                     >>> import os
@@ -2119,7 +2119,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
 
                     >>> # doctest: +SKIP
                     >>> import os
@@ -2130,7 +2130,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
 
                     >>> import os
                     >>> # doctest: +SKIP()
@@ -2141,7 +2141,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
 
                     >>> import os
                     >>> # doctest: +SKIP('reason')
@@ -2154,7 +2154,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
 
                     >>> # import paddle.base
                     >>> import os
@@ -2164,7 +2164,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
 
                     >>> import os # doctest: +SKIP
                     >>> import sys
@@ -2246,7 +2246,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
 
                     >>> import sys
                     >>> # required: GPU
@@ -2257,7 +2257,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
 
                     >>> import sys
                     >>> # requires: GPU
@@ -2268,7 +2268,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
 
                     >>> import sys
                     >>> # require   :   GPU
@@ -2279,7 +2279,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
 
                     >>> import sys
                     >>> # require: GPU, xpu
@@ -2290,7 +2290,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
 
                     >>> import sys
                     >>> #require:gpu
@@ -2301,7 +2301,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
 
                     >>> import sys
                     >>> #require:
@@ -2312,7 +2312,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
 
                     >>> import sys
                     >>> #require: xpu
@@ -2384,7 +2384,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -2405,7 +2405,7 @@ class TestGetTestResults(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...

--- a/test/tools/test_type_checking.py
+++ b/test/tools/test_type_checking.py
@@ -48,7 +48,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -60,7 +60,7 @@ class TestMypyChecker(unittest.TestCase):
             'multi': """
             placeholder
 
-            .. code-block:: python
+            .. code-block:: pycon
                 :name: code-example-0
 
                 this is some blabla...
@@ -71,7 +71,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -80,7 +80,7 @@ class TestMypyChecker(unittest.TestCase):
                     >>> print(1-1)
                     0
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-2
 
                     this is some blabla...
@@ -96,7 +96,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -114,7 +114,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -132,7 +132,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -150,7 +150,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -167,7 +167,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -186,7 +186,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -205,7 +205,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -250,7 +250,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -270,7 +270,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -290,7 +290,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -304,7 +304,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -318,7 +318,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -332,7 +332,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -346,7 +346,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -360,7 +360,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -385,7 +385,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -395,7 +395,7 @@ class TestMypyChecker(unittest.TestCase):
             'multi': """
             placeholder
 
-            .. code-block:: python
+            .. code-block:: pycon
                 :name: code-example-0
 
                 this is some blabla...
@@ -406,7 +406,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -416,7 +416,7 @@ class TestMypyChecker(unittest.TestCase):
                     >>> print(1-1)
                     0
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-2
 
                     this is some blabla...
@@ -439,7 +439,7 @@ class TestMypyChecker(unittest.TestCase):
             'multi': """
             placeholder
 
-            .. code-block:: python
+            .. code-block:: pycon
                 :name: code-example-0
 
                 this is some blabla...
@@ -450,7 +450,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -460,7 +460,7 @@ class TestMypyChecker(unittest.TestCase):
                     >>> print(1-1)
                     0
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-2
 
                     this is some blabla...
@@ -484,7 +484,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -495,7 +495,7 @@ class TestMypyChecker(unittest.TestCase):
             'multi': """
             placeholder
 
-            .. code-block:: python
+            .. code-block:: pycon
                 :name: code-example-0
 
                 this is some blabla...
@@ -506,7 +506,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -517,7 +517,7 @@ class TestMypyChecker(unittest.TestCase):
                     >>> print(1-1)
                     0
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-2
 
                     this is some blabla...
@@ -539,7 +539,7 @@ class TestMypyChecker(unittest.TestCase):
             'pass': """
             placeholder
 
-            .. code-block:: python
+            .. code-block:: pycon
                 :name: code-example-0
 
                 this is some blabla...
@@ -550,7 +550,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -562,7 +562,7 @@ class TestMypyChecker(unittest.TestCase):
                     >>> print(1-1)
                     0
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-2
 
                     this is some blabla...
@@ -585,7 +585,7 @@ class TestMypyChecker(unittest.TestCase):
             'fail': """
             placeholder
 
-            .. code-block:: python
+            .. code-block:: pycon
                 :name: code-example-0
 
                 this is some blabla...
@@ -596,7 +596,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -609,7 +609,7 @@ class TestMypyChecker(unittest.TestCase):
                     >>> print(1-1)
                     0
 
-                .. code-block:: python
+                .. code-block:: pycon
                     :name: code-example-2
 
                     this is some blabla...

--- a/test/tools/test_type_checking.py
+++ b/test/tools/test_type_checking.py
@@ -48,7 +48,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -60,7 +60,7 @@ class TestMypyChecker(unittest.TestCase):
             'multi': """
             placeholder
 
-            .. code-block:: pycon
+            .. code-block:: python-console
                 :name: code-example-0
 
                 this is some blabla...
@@ -71,7 +71,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -80,7 +80,7 @@ class TestMypyChecker(unittest.TestCase):
                     >>> print(1-1)
                     0
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-2
 
                     this is some blabla...
@@ -96,7 +96,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -114,7 +114,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -132,7 +132,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -150,7 +150,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -167,7 +167,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -186,7 +186,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -205,7 +205,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -250,7 +250,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -270,7 +270,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -290,7 +290,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -304,7 +304,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -318,7 +318,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -332,7 +332,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -346,7 +346,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -360,7 +360,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -385,7 +385,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -395,7 +395,7 @@ class TestMypyChecker(unittest.TestCase):
             'multi': """
             placeholder
 
-            .. code-block:: pycon
+            .. code-block:: python-console
                 :name: code-example-0
 
                 this is some blabla...
@@ -406,7 +406,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -416,7 +416,7 @@ class TestMypyChecker(unittest.TestCase):
                     >>> print(1-1)
                     0
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-2
 
                     this is some blabla...
@@ -439,7 +439,7 @@ class TestMypyChecker(unittest.TestCase):
             'multi': """
             placeholder
 
-            .. code-block:: pycon
+            .. code-block:: python-console
                 :name: code-example-0
 
                 this is some blabla...
@@ -450,7 +450,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -460,7 +460,7 @@ class TestMypyChecker(unittest.TestCase):
                     >>> print(1-1)
                     0
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-2
 
                     this is some blabla...
@@ -484,7 +484,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -495,7 +495,7 @@ class TestMypyChecker(unittest.TestCase):
             'multi': """
             placeholder
 
-            .. code-block:: pycon
+            .. code-block:: python-console
                 :name: code-example-0
 
                 this is some blabla...
@@ -506,7 +506,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -517,7 +517,7 @@ class TestMypyChecker(unittest.TestCase):
                     >>> print(1-1)
                     0
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-2
 
                     this is some blabla...
@@ -539,7 +539,7 @@ class TestMypyChecker(unittest.TestCase):
             'pass': """
             placeholder
 
-            .. code-block:: pycon
+            .. code-block:: python-console
                 :name: code-example-0
 
                 this is some blabla...
@@ -550,7 +550,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -562,7 +562,7 @@ class TestMypyChecker(unittest.TestCase):
                     >>> print(1-1)
                     0
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-2
 
                     this is some blabla...
@@ -585,7 +585,7 @@ class TestMypyChecker(unittest.TestCase):
             'fail': """
             placeholder
 
-            .. code-block:: pycon
+            .. code-block:: python-console
                 :name: code-example-0
 
                 this is some blabla...
@@ -596,7 +596,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-1
 
                     this is some blabla...
@@ -609,7 +609,7 @@ class TestMypyChecker(unittest.TestCase):
                     >>> print(1-1)
                     0
 
-                .. code-block:: pycon
+                .. code-block:: python-console
                     :name: code-example-2
 
                     this is some blabla...

--- a/test/tools/test_type_checking.py
+++ b/test/tools/test_type_checking.py
@@ -48,7 +48,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -60,7 +60,7 @@ class TestMypyChecker(unittest.TestCase):
             'multi': """
             placeholder
 
-            .. code-block:: python-console
+            .. code-block:: pycon
                 :name: code-example-0
 
                 this is some blabla...
@@ -71,7 +71,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -80,7 +80,7 @@ class TestMypyChecker(unittest.TestCase):
                     >>> print(1-1)
                     0
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-2
 
                     this is some blabla...
@@ -96,7 +96,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -114,7 +114,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -132,7 +132,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -150,7 +150,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -167,7 +167,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -186,7 +186,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -205,7 +205,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -250,7 +250,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -270,7 +270,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -290,7 +290,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -304,7 +304,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -318,7 +318,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -332,7 +332,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -346,7 +346,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -360,7 +360,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -385,7 +385,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -395,7 +395,7 @@ class TestMypyChecker(unittest.TestCase):
             'multi': """
             placeholder
 
-            .. code-block:: python-console
+            .. code-block:: pycon
                 :name: code-example-0
 
                 this is some blabla...
@@ -406,7 +406,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -416,7 +416,7 @@ class TestMypyChecker(unittest.TestCase):
                     >>> print(1-1)
                     0
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-2
 
                     this is some blabla...
@@ -439,7 +439,7 @@ class TestMypyChecker(unittest.TestCase):
             'multi': """
             placeholder
 
-            .. code-block:: python-console
+            .. code-block:: pycon
                 :name: code-example-0
 
                 this is some blabla...
@@ -450,7 +450,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -460,7 +460,7 @@ class TestMypyChecker(unittest.TestCase):
                     >>> print(1-1)
                     0
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-2
 
                     this is some blabla...
@@ -484,7 +484,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -495,7 +495,7 @@ class TestMypyChecker(unittest.TestCase):
             'multi': """
             placeholder
 
-            .. code-block:: python-console
+            .. code-block:: pycon
                 :name: code-example-0
 
                 this is some blabla...
@@ -506,7 +506,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -517,7 +517,7 @@ class TestMypyChecker(unittest.TestCase):
                     >>> print(1-1)
                     0
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-2
 
                     this is some blabla...
@@ -539,7 +539,7 @@ class TestMypyChecker(unittest.TestCase):
             'pass': """
             placeholder
 
-            .. code-block:: python-console
+            .. code-block:: pycon
                 :name: code-example-0
 
                 this is some blabla...
@@ -550,7 +550,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -562,7 +562,7 @@ class TestMypyChecker(unittest.TestCase):
                     >>> print(1-1)
                     0
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-2
 
                     this is some blabla...
@@ -585,7 +585,7 @@ class TestMypyChecker(unittest.TestCase):
             'fail': """
             placeholder
 
-            .. code-block:: python-console
+            .. code-block:: pycon
                 :name: code-example-0
 
                 this is some blabla...
@@ -596,7 +596,7 @@ class TestMypyChecker(unittest.TestCase):
 
             Examples:
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-1
 
                     this is some blabla...
@@ -609,7 +609,7 @@ class TestMypyChecker(unittest.TestCase):
                     >>> print(1-1)
                     0
 
-                .. code-block:: python-console
+                .. code-block:: pycon
                     :name: code-example-2
 
                     this is some blabla...

--- a/tools/sampcd_processor_readme.md
+++ b/tools/sampcd_processor_readme.md
@@ -121,7 +121,7 @@
 
 代码检查服从的样式，如 `google`, `freeform`。
 
-注意，Paddle 目前的代码块是在 `.. code-block:: python` 中，而 `doctest` 或 `xdoctest` 只关心是否有 PS1 (>>> ) 的包裹，`google` 样式则是只检查 `Examples:` 中的代码。这是目前主流的代码检查工具与 Paddle 不同的地方，所以，需要沿用 Paddle 目前的 `codeblock` 抽取过程。
+注意，Paddle 目前的代码块是在 `.. code-block:: pycon` 中，而 `doctest` 或 `xdoctest` 只关心是否有 PS1 (>>> ) 的包裹，`google` 样式则是只检查 `Examples:` 中的代码。这是目前主流的代码检查工具与 Paddle 不同的地方，所以，需要沿用 Paddle 目前的 `codeblock` 抽取过程。
 
 #### `target`
 
@@ -143,7 +143,7 @@
 
 - 为什么不能用 `style = google` `target = docstring` 的模式
 
-    因为，目前 Paddle 在 `Examples:` 之外的部分，也存在 `.. code-block:: python` 需要检查的代码。
+    因为，目前 Paddle 在 `Examples:` 之外的部分，也存在 `.. code-block:: pycon` 需要检查的代码。
 
 - 为什么不能用 `style = google` `target = codeblock` 的模式
 
@@ -159,7 +159,7 @@
 
 这里说明一下后续建议的示例代码书写格式。
 
-- 示例代码写在 `.. code-block:: python` 内部。
+- 示例代码写在 `.. code-block:: pycon` 内部。
 
 - 以 `>>> ` 表示代码开始，以 `... ` 表示代码的延续。
 
@@ -180,7 +180,7 @@ def something():
     """ Function summary ...
     Some description ...
 
-    .. code-block:: python
+    .. code-block:: pycon
         :name: code-example-0
 
         this is some blabla...
@@ -191,7 +191,7 @@ def something():
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
             :name: code-example-1
 
             this is some blabla...
@@ -204,9 +204,9 @@ def something():
     """
 ```
 
-错误的代码段，如， 没有正确使用 `.. code-block:: python`：
+错误的代码段，如， 没有正确使用 `.. code-block:: pycon`：
 
-``` python
+```python
 def something():
     """ Function summary ...
     Some description ...
@@ -217,7 +217,7 @@ def something():
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
             :name: code-example-1
 
             this is some blabla...
@@ -237,7 +237,7 @@ def something():
     """ Function summary ...
     Some description ...
 
-    .. code-block:: python
+    .. code-block:: pycon
         :name: code-example-0
 
         this is some blabla...
@@ -248,7 +248,7 @@ def something():
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
             :name: code-example-1
 
             this is some blabla...
@@ -269,7 +269,7 @@ def something():
     """ Function summary ...
     Some description ...
 
-    .. code-block:: python
+    .. code-block:: pycon
         :name: code-example-0
 
         this is some blabla...
@@ -280,7 +280,7 @@ def something():
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
             :name: code-example-1
 
             this is some blabla...

--- a/tools/sampcd_processor_readme.md
+++ b/tools/sampcd_processor_readme.md
@@ -121,7 +121,7 @@
 
 代码检查服从的样式，如 `google`, `freeform`。
 
-注意，Paddle 目前的代码块是在 `.. code-block:: pycon` 中，而 `doctest` 或 `xdoctest` 只关心是否有 PS1 (>>> ) 的包裹，`google` 样式则是只检查 `Examples:` 中的代码。这是目前主流的代码检查工具与 Paddle 不同的地方，所以，需要沿用 Paddle 目前的 `codeblock` 抽取过程。
+注意，Paddle 目前的代码块是在 `.. code-block:: python-console` 中，而 `doctest` 或 `xdoctest` 只关心是否有 PS1 (>>> ) 的包裹，`google` 样式则是只检查 `Examples:` 中的代码。这是目前主流的代码检查工具与 Paddle 不同的地方，所以，需要沿用 Paddle 目前的 `codeblock` 抽取过程。
 
 #### `target`
 
@@ -143,7 +143,7 @@
 
 - 为什么不能用 `style = google` `target = docstring` 的模式
 
-    因为，目前 Paddle 在 `Examples:` 之外的部分，也存在 `.. code-block:: pycon` 需要检查的代码。
+    因为，目前 Paddle 在 `Examples:` 之外的部分，也存在 `.. code-block:: python-console` 需要检查的代码。
 
 - 为什么不能用 `style = google` `target = codeblock` 的模式
 
@@ -159,7 +159,7 @@
 
 这里说明一下后续建议的示例代码书写格式。
 
-- 示例代码写在 `.. code-block:: pycon` 内部。
+- 示例代码写在 `.. code-block:: python-console` 内部。
 
 - 以 `>>> ` 表示代码开始，以 `... ` 表示代码的延续。
 
@@ -180,7 +180,7 @@ def something():
     """ Function summary ...
     Some description ...
 
-    .. code-block:: pycon
+    .. code-block:: python-console
         :name: code-example-0
 
         this is some blabla...
@@ -191,7 +191,7 @@ def something():
 
     Examples:
 
-        .. code-block:: pycon
+        .. code-block:: python-console
             :name: code-example-1
 
             this is some blabla...
@@ -204,7 +204,7 @@ def something():
     """
 ```
 
-错误的代码段，如， 没有正确使用 `.. code-block:: pycon`：
+错误的代码段，如， 没有正确使用 `.. code-block:: python-console`：
 
 ```python
 def something():
@@ -217,7 +217,7 @@ def something():
 
     Examples:
 
-        .. code-block:: pycon
+        .. code-block:: python-console
             :name: code-example-1
 
             this is some blabla...
@@ -237,7 +237,7 @@ def something():
     """ Function summary ...
     Some description ...
 
-    .. code-block:: pycon
+    .. code-block:: python-console
         :name: code-example-0
 
         this is some blabla...
@@ -248,7 +248,7 @@ def something():
 
     Examples:
 
-        .. code-block:: pycon
+        .. code-block:: python-console
             :name: code-example-1
 
             this is some blabla...
@@ -269,7 +269,7 @@ def something():
     """ Function summary ...
     Some description ...
 
-    .. code-block:: pycon
+    .. code-block:: python-console
         :name: code-example-0
 
         this is some blabla...
@@ -280,7 +280,7 @@ def something():
 
     Examples:
 
-        .. code-block:: pycon
+        .. code-block:: python-console
             :name: code-example-1
 
             this is some blabla...

--- a/tools/sampcd_processor_readme.md
+++ b/tools/sampcd_processor_readme.md
@@ -121,7 +121,7 @@
 
 代码检查服从的样式，如 `google`, `freeform`。
 
-注意，Paddle 目前的代码块是在 `.. code-block:: python-console` 中，而 `doctest` 或 `xdoctest` 只关心是否有 PS1 (>>> ) 的包裹，`google` 样式则是只检查 `Examples:` 中的代码。这是目前主流的代码检查工具与 Paddle 不同的地方，所以，需要沿用 Paddle 目前的 `codeblock` 抽取过程。
+注意，Paddle 目前的代码块是在 `.. code-block:: pycon` 中，而 `doctest` 或 `xdoctest` 只关心是否有 PS1 (>>> ) 的包裹，`google` 样式则是只检查 `Examples:` 中的代码。这是目前主流的代码检查工具与 Paddle 不同的地方，所以，需要沿用 Paddle 目前的 `codeblock` 抽取过程。
 
 #### `target`
 
@@ -143,7 +143,7 @@
 
 - 为什么不能用 `style = google` `target = docstring` 的模式
 
-    因为，目前 Paddle 在 `Examples:` 之外的部分，也存在 `.. code-block:: python-console` 需要检查的代码。
+    因为，目前 Paddle 在 `Examples:` 之外的部分，也存在 `.. code-block:: pycon` 需要检查的代码。
 
 - 为什么不能用 `style = google` `target = codeblock` 的模式
 
@@ -159,7 +159,7 @@
 
 这里说明一下后续建议的示例代码书写格式。
 
-- 示例代码写在 `.. code-block:: python-console` 内部。
+- 示例代码写在 `.. code-block:: pycon` 内部。
 
 - 以 `>>> ` 表示代码开始，以 `... ` 表示代码的延续。
 
@@ -180,7 +180,7 @@ def something():
     """ Function summary ...
     Some description ...
 
-    .. code-block:: python-console
+    .. code-block:: pycon
         :name: code-example-0
 
         this is some blabla...
@@ -191,7 +191,7 @@ def something():
 
     Examples:
 
-        .. code-block:: python-console
+        .. code-block:: pycon
             :name: code-example-1
 
             this is some blabla...
@@ -204,7 +204,7 @@ def something():
     """
 ```
 
-错误的代码段，如， 没有正确使用 `.. code-block:: python-console`：
+错误的代码段，如， 没有正确使用 `.. code-block:: pycon`：
 
 ```python
 def something():
@@ -217,7 +217,7 @@ def something():
 
     Examples:
 
-        .. code-block:: python-console
+        .. code-block:: pycon
             :name: code-example-1
 
             this is some blabla...
@@ -237,7 +237,7 @@ def something():
     """ Function summary ...
     Some description ...
 
-    .. code-block:: python-console
+    .. code-block:: pycon
         :name: code-example-0
 
         this is some blabla...
@@ -248,7 +248,7 @@ def something():
 
     Examples:
 
-        .. code-block:: python-console
+        .. code-block:: pycon
             :name: code-example-1
 
             this is some blabla...
@@ -269,7 +269,7 @@ def something():
     """ Function summary ...
     Some description ...
 
-    .. code-block:: python-console
+    .. code-block:: pycon
         :name: code-example-0
 
         this is some blabla...
@@ -280,7 +280,7 @@ def something():
 
     Examples:
 
-        .. code-block:: python-console
+        .. code-block:: pycon
             :name: code-example-1
 
             this is some blabla...

--- a/tools/sampcd_processor_utils.py
+++ b/tools/sampcd_processor_utils.py
@@ -226,13 +226,13 @@ class DocTester:
         style(str): `style` should be in {'google', 'freeform'}.
             `google`, codeblock in `Example(s):` section of docstring.
             `freeform`, all codeblocks in docstring wrapped with PS1(>>> ) and PS2(... ).
-            **CAUTION** no matter `.. code-block:: pycon` used or not,
+            **CAUTION** no matter `.. code-block:: python-console` used or not,
                 the docstring in PS1(>>> ) and PS2(... ) should be considered as codeblock.
         target(str): `target` should be in {'docstring', 'codeblock'}.
             `docstring`, the test target is a docstring with optional description, `Args:`, `Returns:`, `Examples:` and so on.
             `codeblock`, the codeblock extracted by `extract_code_blocks_from_docstr` from the docstring, and the pure codeblock is the docstring to test.
-                If we use `.. code-block:: pycon` wrapping the codeblock, the target should be `codeblock` instead of `docstring`.
-                Because the `doctest` and `xdoctest` do NOT care the `.. code-block:: pycon` directive.
+                If we use `.. code-block:: python-console` wrapping the codeblock, the target should be `codeblock` instead of `docstring`.
+                Because the `doctest` and `xdoctest` do NOT care the `.. code-block:: python-console` directive.
                 If the `style` is set to `google` and `target` is set to `codeblock`, we should implement/overwrite `ensemble_docstring` method,
                 where ensemble the codeblock into a docstring with a `Examples:` and some indents as least.
         directives(list[str]): `DocTester` hold the default directives, we can/should replace them with method `convert_directive`.
@@ -450,7 +450,7 @@ def extract_code_blocks_from_docstr(docstr, google_style=True):
 
     lastlineindex = len(docstr_list) - 1
 
-    cb_start_pat = re.compile(r"code-block::\s*(python|pycon)")
+    cb_start_pat = re.compile(r"code-block::\s*(python|python-console)")
     cb_param_pat = re.compile(r"^\s*:(\w+):\s*(\S*)\s*$")
 
     cb_info = {}

--- a/tools/sampcd_processor_utils.py
+++ b/tools/sampcd_processor_utils.py
@@ -226,13 +226,13 @@ class DocTester:
         style(str): `style` should be in {'google', 'freeform'}.
             `google`, codeblock in `Example(s):` section of docstring.
             `freeform`, all codeblocks in docstring wrapped with PS1(>>> ) and PS2(... ).
-            **CAUTION** no matter `.. code-block:: python-console` used or not,
+            **CAUTION** no matter `.. code-block:: pycon` used or not,
                 the docstring in PS1(>>> ) and PS2(... ) should be considered as codeblock.
         target(str): `target` should be in {'docstring', 'codeblock'}.
             `docstring`, the test target is a docstring with optional description, `Args:`, `Returns:`, `Examples:` and so on.
             `codeblock`, the codeblock extracted by `extract_code_blocks_from_docstr` from the docstring, and the pure codeblock is the docstring to test.
-                If we use `.. code-block:: python-console` wrapping the codeblock, the target should be `codeblock` instead of `docstring`.
-                Because the `doctest` and `xdoctest` do NOT care the `.. code-block:: python-console` directive.
+                If we use `.. code-block:: pycon` wrapping the codeblock, the target should be `codeblock` instead of `docstring`.
+                Because the `doctest` and `xdoctest` do NOT care the `.. code-block:: pycon` directive.
                 If the `style` is set to `google` and `target` is set to `codeblock`, we should implement/overwrite `ensemble_docstring` method,
                 where ensemble the codeblock into a docstring with a `Examples:` and some indents as least.
         directives(list[str]): `DocTester` hold the default directives, we can/should replace them with method `convert_directive`.

--- a/tools/sampcd_processor_utils.py
+++ b/tools/sampcd_processor_utils.py
@@ -450,7 +450,7 @@ def extract_code_blocks_from_docstr(docstr, google_style=True):
 
     lastlineindex = len(docstr_list) - 1
 
-    cb_start_pat = re.compile(r"code-block::\s*(python|python-console)")
+    cb_start_pat = re.compile(r"code-block::\s*(python|python-console|pycon)")
     cb_param_pat = re.compile(r"^\s*:(\w+):\s*(\S*)\s*$")
 
     cb_info = {}

--- a/tools/sampcd_processor_utils.py
+++ b/tools/sampcd_processor_utils.py
@@ -226,13 +226,13 @@ class DocTester:
         style(str): `style` should be in {'google', 'freeform'}.
             `google`, codeblock in `Example(s):` section of docstring.
             `freeform`, all codeblocks in docstring wrapped with PS1(>>> ) and PS2(... ).
-            **CAUTION** no matter `.. code-block:: python` used or not,
+            **CAUTION** no matter `.. code-block:: pycon` used or not,
                 the docstring in PS1(>>> ) and PS2(... ) should be considered as codeblock.
         target(str): `target` should be in {'docstring', 'codeblock'}.
             `docstring`, the test target is a docstring with optional description, `Args:`, `Returns:`, `Examples:` and so on.
             `codeblock`, the codeblock extracted by `extract_code_blocks_from_docstr` from the docstring, and the pure codeblock is the docstring to test.
-                If we use `.. code-block:: python` wrapping the codeblock, the target should be `codeblock` instead of `docstring`.
-                Because the `doctest` and `xdoctest` do NOT care the `.. code-block:: python` directive.
+                If we use `.. code-block:: pycon` wrapping the codeblock, the target should be `codeblock` instead of `docstring`.
+                Because the `doctest` and `xdoctest` do NOT care the `.. code-block:: pycon` directive.
                 If the `style` is set to `google` and `target` is set to `codeblock`, we should implement/overwrite `ensemble_docstring` method,
                 where ensemble the codeblock into a docstring with a `Examples:` and some indents as least.
         directives(list[str]): `DocTester` hold the default directives, we can/should replace them with method `convert_directive`.
@@ -450,7 +450,7 @@ def extract_code_blocks_from_docstr(docstr, google_style=True):
 
     lastlineindex = len(docstr_list) - 1
 
-    cb_start_pat = re.compile(r"code-block::\s*python")
+    cb_start_pat = re.compile(r"code-block::\s*(python|pycon)")
     cb_param_pat = re.compile(r"^\s*:(\w+):\s*(\S*)\s*$")
 
     cb_info = {}


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Docs

### Description
<!-- Describe what you’ve done -->

开启 ruff format 里的 `docstring-code-format` 选项，使 ruff 能够自动格式化部分 docstring 代码

```python
"""
这段可以格式化
.. code-block:: python

    import paddle
    # ...
"""

"""
这段可以格式化
.. code-block:: pycon

    >>> import paddle
    >>> # ...
"""

"""
这段可以格式化
.. code-block:: text

    import paddle
    # ...
"""

"""
这段可以格式化

import paddle
# ...
"""

"""
这段不可以格式化
.. code-block:: python

    >>> import paddle
    >>> # ...
"""
```

注意，我们常用的格式是不能格式化的，因为虽然写了语言是 `python`，但是实际上是 REPL 形式，即 `python-console`/`pycon`，故而无法格式化，但这也给我们渐进式修改带来了可能

关于错误使用 `python` 的问题，早在 #69135 已经有人指出，我们是时候修复一下了

关于使用 `python-console` 还是 `pycon`，鉴于 GitHub 上的使用率 `pycon`[^1][^2] 远高于 `python-console`[^3][^4]，因此使用 `pycon`

cc. @megemini @ooooo-create

<!-- PCard-66972 -->

[^1]: [Markdown `pycon`](https://github.com/search?q=%22%60%60%60pycon%22&type=code)
[^2]: [reStructureText `pycon`](https://github.com/search?q=%22code-block%3A%3A+pycon%22&type=code)
[^3]: [Markdown `python-console`](https://github.com/search?q=%22%60%60%60python-console%22&type=code)
[^4]: [reStructureText `python-console`](https://github.com/search?q=%22code-block%3A%3A+python-console%22&type=code)