### PR TITLE
【CUDA Kernel No.86】nonzero_kernel算子Kernel修复-part 

### DIFF
--- a/paddle/phi/kernels/nonzero_kernel.h
+++ b/paddle/phi/kernels/nonzero_kernel.h
@@ -23,4 +23,9 @@ void NonZeroKernel(const Context& dev_ctx,
                    const DenseTensor& condition,
                    DenseTensor* out);
 
+template <typename T, typename Context>
+void RestrictNonZeroKernel(const Context& dev_ctx,
+                           const DenseTensor& condition,
+                           const int64_t total_true_num,
+                           DenseTensor* out);
 }  // namespace phi


### PR DESCRIPTION
### PR Category
Custom Device

### PR Types
Improvements

### Description
Add missing declaration for RestrictNonZeroKernel in paddle/phi/kernels/nonzero_kernel.h. 