### PR TITLE
【CUDA Kernel No.84】multiclass_nms3_kernel算子Kernel修复-part

### DIFF
--- a/paddle/phi/kernels/multiclass_nms3_kernel.h
+++ b/paddle/phi/kernels/multiclass_nms3_kernel.h
@@ -49,5 +49,5 @@ void MultiClassNMSGPUKernel(const Context& dev_ctx,
                             DenseTensor* out,
                             DenseTensor* index,
                             DenseTensor* nms_rois_num);
-                            
+
 }  // namespace phi

--- a/paddle/phi/kernels/multiclass_nms3_kernel.h
+++ b/paddle/phi/kernels/multiclass_nms3_kernel.h
@@ -34,4 +34,20 @@ void MultiClassNMSKernel(const Context& dev_ctx,
                          DenseTensor* index,
                          DenseTensor* nms_rois_num);
 
+template <typename T, typename Context>
+void MultiClassNMSGPUKernel(const Context& dev_ctx,
+                            const DenseTensor& bboxes,
+                            const DenseTensor& scores,
+                            const paddle::optional<DenseTensor>& rois_num,
+                            float score_threshold,
+                            int nms_top_k,
+                            int keep_top_k,
+                            float nms_threshold,
+                            bool normalized,
+                            float nms_eta,
+                            int background_label,
+                            DenseTensor* out,
+                            DenseTensor* index,
+                            DenseTensor* nms_rois_num);
+                            
 }  // namespace phi


### PR DESCRIPTION
### PR Category
Custom Device

### PR Types
Improvements

### Description
This PR adds the missing function declaration for `MultiClassNMSGPUKernel` in `paddle/phi/kernels/multiclass_nms3_kernel.h`.