### PR TITLE
 fix kNHWC in onednn_reuse.h [fluid_ops]

### DIFF
--- a/paddle/phi/backends/onednn/onednn_reuse.h
+++ b/paddle/phi/backends/onednn/onednn_reuse.h
@@ -979,7 +979,7 @@ class BinaryOneDNNHandler : public OneDNNHandlerNoCachingT<T, dnnl::binary> {
                       src_y_tz.end());
       // For broadcasting for NHWC we need rotate extended shape
       if (OneDNNContext::tls().get_cur_paddle_data_layout() ==
-          DataLayout::kNHWC) {
+          DataLayout::NHWC) {
         std::rotate(dims1_ex.begin() + 1, dims1_ex.end() - 1, dims1_ex.end());
       }
       src1_md = src1_md.reshape(dims1_ex);
@@ -990,7 +990,7 @@ class BinaryOneDNNHandler : public OneDNNHandlerNoCachingT<T, dnnl::binary> {
                       src_x_tz.end());
       // For broadcasting for NHWC we need rotate extended shape
       if (OneDNNContext::tls().get_cur_paddle_data_layout() ==
-          DataLayout::kNHWC) {
+          DataLayout::NHWC) {
         std::rotate(dims0_ex.begin() + 1, dims0_ex.end() - 1, dims0_ex.end());
       }
       src0_md = src0_md.reshape(dims0_ex);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience

### PR Types
Others

### Description
<!-- Describe what you’ve done -->

在文件 onednn_reuse.h 中修改 DataLayout::kNHWC 
paddle/common/layout.h 中 kNHWC 为 NHWC, k前缀是fluid用法
<img width="783" height="155" alt="image" src="https://github.com/user-attachments/assets/3ae52b93-4f18-4a03-a1a8-a7b9c6164a7a" />
