### PR TITLE
fix all_to_all_kernel [fluid_ops]

### DIFF
--- a/paddle/phi/kernels/gpu/all_to_all_kernel.cu
+++ b/paddle/phi/kernels/gpu/all_to_all_kernel.cu
@@ -30,7 +30,6 @@ void AllToAllKernel(const Context& dev_ctx,
                     const DenseTensor& x,
                     DenseTensor* out) {
 #if defined(PADDLE_WITH_NCCL) || defined(PADDLE_WITH_RCCL)
-#if NCCL_VERSION_CODE >= 2703
   auto x_dims = x.dims();
   out->Resize(x_dims);
   dev_ctx.template Alloc<T>(out);
@@ -73,9 +72,6 @@ void AllToAllKernel(const Context& dev_ctx,
   }
   comm_ctx->GroupEnd();
 #else
-  PADDLE_THROW(common::errors::Unavailable("NCCL version >= 2.7.3 is needed."));
-#endif
-#else
   PADDLE_THROW(
       errors::PreconditionNotMet("PaddlePaddle should compile with GPU."));
 #endif
@@ -83,8 +79,6 @@ void AllToAllKernel(const Context& dev_ctx,
 
 }  // namespace phi
 
-#if (NCCL_VERSION_CODE >= 21000 && CUDA_VERSION >= 11000) || \
-    defined(PADDLE_WITH_HIP)
 PD_REGISTER_KERNEL(all_to_all,
                    GPU,
                    ALL_LAYOUT,
@@ -99,18 +93,3 @@ PD_REGISTER_KERNEL(all_to_all,
                    bool,
                    phi::bfloat16,
                    phi::float16) {}
-#else
-PD_REGISTER_KERNEL(all_to_all,
-                   GPU,
-                   ALL_LAYOUT,
-                   phi::AllToAllKernel,
-                   float,
-                   double,
-                   int,
-                   int8_t,
-                   uint8_t,
-                   int16_t,
-                   int64_t,
-                   bool,
-                   phi::float16) {}
-#endif


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience

### PR Types
Others

### Description
<!-- Describe what you’ve done -->
修改 all_to_all_kernel 中 NCCL 检查

NCCL 2.10 支持 CUDA 11.4，Paddle支持为 CUDA 11.7，修改不检查NCCL版本
https://docs.nvidia.com/deeplearning/nccl/release-notes/rel_2-10-3.html#rel_2-10-3
<img width="965" height="151" alt="image" src="https://github.com/user-attachments/assets/35832e47-8de6-48f2-b323-aa632e45d4ae" />
NCCL 2.7 支持 CUDA 11.0
https://docs.nvidia.com/deeplearning/nccl/release-notes/rel_2-7-3.html#rel_2-7-3
<img width="985" height="157" alt="image" src="https://github.com/user-attachments/assets/643b5e06-553b-4430-b41b-967aa37d64a8" />
