### PR TITLE
 fix nccl check in all_reduce_kernel.cu

### DIFF
--- a/paddle/phi/kernels/gpu/all_gather_kernel.cu
+++ b/paddle/phi/kernels/gpu/all_gather_kernel.cu
@@ -57,9 +57,6 @@ void AllGatherKernel(const Context& dev_ctx,
 
 }  // namespace phi
 
-// TODO(yuwentao01) the embedded macro definition will get an error under
-// windows, need to be solved in phi
-#if NCCL_VERSION_CODE >= 21000
 PD_REGISTER_KERNEL(all_gather,
                    GPU,
                    ALL_LAYOUT,
@@ -76,20 +73,3 @@ PD_REGISTER_KERNEL(all_gather,
                    phi::float16,
                    phi::complex64,
                    phi::complex128) {}
-#else
-PD_REGISTER_KERNEL(all_gather,
-                   GPU,
-                   ALL_LAYOUT,
-                   phi::AllGatherKernel,
-                   float,
-                   double,
-                   int,
-                   uint8_t,
-                   int8_t,
-                   int16_t,
-                   int64_t,
-                   bool,
-                   phi::float16,
-                   phi::complex64,
-                   phi::complex128) {}
-#endif

--- a/paddle/phi/kernels/gpu/all_reduce_kernel.cu
+++ b/paddle/phi/kernels/gpu/all_reduce_kernel.cu
@@ -82,7 +82,6 @@ void AllReduceKernel(const Context& dev_ctx,
 
 }  // namespace phi
 
-#if NCCL_VERSION_CODE >= 21000
 PD_REGISTER_KERNEL(all_reduce,
                    GPU,
                    ALL_LAYOUT,
@@ -97,18 +96,3 @@ PD_REGISTER_KERNEL(all_reduce,
                    int64_t,
                    phi::bfloat16,
                    phi::float16) {}
-#else
-PD_REGISTER_KERNEL(all_reduce,
-                   GPU,
-                   ALL_LAYOUT,
-                   phi::AllReduceKernel,
-                   float,
-                   double,
-                   int,
-                   bool,
-                   int8_t,
-                   uint8_t,
-                   int16_t,
-                   int64_t,
-                   phi::float16) {}
-#endif


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience

### PR Types
Others

### Description
<!-- Describe what you’ve done -->

修改 all_reduce_kernel 中 NCCL 检查
NCCL 2.10 支持 CUDA 11.4，Paddle支持为 CUDA 11.7，修改不检查NCCL版本
https://docs.nvidia.com/deeplearning/nccl/release-notes/rel_2-10-3.html#rel_2-10-3
<img width="965" height="151" alt="image" src="https://github.com/user-attachments/assets/35832e47-8de6-48f2-b323-aa632e45d4ae" />