### PR TITLE
[XPU]Remove xpu headers while packaging

### DIFF
--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -1507,7 +1507,10 @@ if '${WITH_GPU}' == 'ON' or '${WITH_ROCM}' == 'ON':
 
 
 if '${WITH_XPU}' == 'ON':
-    headers += list(find_files('*.h', '@PADDLE_BINARY_DIR@/third_party/xpu/src/extern_xpu/xpu', recursive=True)) # xdnn api headers
+    headers += [
+        h for h in find_files('*.h', '@PADDLE_BINARY_DIR@/third_party/xpu/src/extern_xpu/xpu', recursive=True)
+        if '/include/xpu/kernel/' not in h
+    ] # xdnn api headers
     headers += list(find_files('*.hpp', '@PADDLE_BINARY_DIR@/third_party/xpu/src/extern_xpu/xpu', recursive=True)) # xre headers with .hpp extension
 
 if (

--- a/setup.py
+++ b/setup.py
@@ -2248,13 +2248,15 @@ def get_headers():
         )
 
     if env_dict.get("WITH_XPU") == 'ON':
-        headers += list(
-            find_files(
+        headers += [
+            h
+            for h in find_files(
                 '*.h',
                 paddle_binary_dir + '/third_party/xpu/src/extern_xpu/xpu',
                 recursive=True,
             )
-        )  # xdnn api headers
+            if '/include/xpu/kernel/' not in h
+        ]  # xdnn api headers
         headers += list(
             find_files(
                 '*.hpp',


### PR DESCRIPTION
### PR Category
Custom Device

### PR Types
Security


### Description
This PR removes all xpu/kernel header files from the packaging process.

The XPU kernel headers contain low-level implementation details that are not intended to be exposed publicly.
To enhance privacy and prevent potential leakage of internal device-specific logic, these headers are now excluded during wheel packaging and installation.
